### PR TITLE
Deploy: Homepage service selector + qualified lead pipeline

### DIFF
--- a/app/admin/pricing/page.tsx
+++ b/app/admin/pricing/page.tsx
@@ -7,6 +7,8 @@ interface PricingRow {
   id: number;
   advisor_type: string;
   price_cents: number;
+  qualified_price_cents: number | null;
+  exclusive_price_cents: number | null;
   min_price_cents: number;
   max_price_cents: number;
   free_trial_leads: number;
@@ -81,6 +83,8 @@ export default function AdminPricingPage() {
     setEditRow(row.advisor_type);
     setEditValues({
       price_cents: row.price_cents,
+      qualified_price_cents: row.qualified_price_cents ?? row.price_cents * 2,
+      exclusive_price_cents: row.exclusive_price_cents ?? row.price_cents * 3,
       min_price_cents: row.min_price_cents,
       max_price_cents: row.max_price_cents,
       free_trial_leads: row.free_trial_leads,
@@ -92,7 +96,7 @@ export default function AdminPricingPage() {
     setSaving(row.advisor_type);
     setMessage(null);
 
-    const updates: Record<string, number> = {};
+    const updates: Record<string, number | null> = {};
     const logEntries: { advisor_type: string; field_changed: string; old_value: string; new_value: string; changed_by: string }[] = [];
 
     if (editValues.price_cents !== undefined && editValues.price_cents !== row.price_cents) {
@@ -114,6 +118,14 @@ export default function AdminPricingPage() {
     if (editValues.featured_monthly_cents !== undefined && editValues.featured_monthly_cents !== row.featured_monthly_cents) {
       updates.featured_monthly_cents = editValues.featured_monthly_cents;
       logEntries.push({ advisor_type: row.advisor_type, field_changed: "featured_monthly_cents", old_value: String(row.featured_monthly_cents), new_value: String(editValues.featured_monthly_cents), changed_by: "admin" });
+    }
+    if (editValues.qualified_price_cents !== undefined && editValues.qualified_price_cents !== row.qualified_price_cents) {
+      updates.qualified_price_cents = editValues.qualified_price_cents;
+      logEntries.push({ advisor_type: row.advisor_type, field_changed: "qualified_price_cents", old_value: String(row.qualified_price_cents || 0), new_value: String(editValues.qualified_price_cents), changed_by: "admin" });
+    }
+    if (editValues.exclusive_price_cents !== undefined && editValues.exclusive_price_cents !== row.exclusive_price_cents) {
+      updates.exclusive_price_cents = editValues.exclusive_price_cents;
+      logEntries.push({ advisor_type: row.advisor_type, field_changed: "exclusive_price_cents", old_value: String(row.exclusive_price_cents || 0), new_value: String(editValues.exclusive_price_cents), changed_by: "admin" });
     }
 
     if (Object.keys(updates).length === 0) {
@@ -196,7 +208,9 @@ export default function AdminPricingPage() {
             <thead>
               <tr className="bg-slate-50 border-b border-slate-200">
                 <th className="text-left px-4 py-3 font-semibold text-slate-700">Vertical</th>
-                <th className="text-center px-3 py-3 font-semibold text-slate-700">Lead Price</th>
+                <th className="text-center px-3 py-3 font-semibold text-slate-700">Standard</th>
+                <th className="text-center px-3 py-3 font-semibold text-blue-700">Qualified</th>
+                <th className="text-center px-3 py-3 font-semibold text-violet-700 hidden md:table-cell">Exclusive</th>
                 <th className="text-center px-3 py-3 font-semibold text-slate-700 hidden md:table-cell">Min</th>
                 <th className="text-center px-3 py-3 font-semibold text-slate-700 hidden md:table-cell">Max</th>
                 <th className="text-center px-3 py-3 font-semibold text-slate-700">Free Leads</th>
@@ -233,6 +247,36 @@ export default function AdminPricingPage() {
                         </div>
                       ) : (
                         <span className="font-bold text-slate-900 text-base">{formatCents(row.price_cents)}</span>
+                      )}
+                    </td>
+                    <td className="px-3 py-3 text-center">
+                      {isEditing ? (
+                        <div className="flex items-center justify-center gap-1">
+                          <span className="text-slate-400">$</span>
+                          <input
+                            type="number"
+                            className="w-16 px-2 py-1 border border-blue-300 rounded text-center text-sm font-bold"
+                            value={centsToInput(editValues.qualified_price_cents || 0)}
+                            onChange={(e) => setEditValues({ ...editValues, qualified_price_cents: inputToCents(e.target.value) })}
+                          />
+                        </div>
+                      ) : (
+                        <span className="font-bold text-blue-700 text-base">{formatCents(row.qualified_price_cents || row.price_cents * 2)}</span>
+                      )}
+                    </td>
+                    <td className="px-3 py-3 text-center hidden md:table-cell">
+                      {isEditing ? (
+                        <div className="flex items-center justify-center gap-1">
+                          <span className="text-slate-400">$</span>
+                          <input
+                            type="number"
+                            className="w-16 px-2 py-1 border border-violet-300 rounded text-center text-sm font-bold"
+                            value={centsToInput(editValues.exclusive_price_cents || 0)}
+                            onChange={(e) => setEditValues({ ...editValues, exclusive_price_cents: inputToCents(e.target.value) })}
+                          />
+                        </div>
+                      ) : (
+                        <span className="font-bold text-violet-700 text-base">{formatCents(row.exclusive_price_cents || row.price_cents * 3)}</span>
                       )}
                     </td>
                     <td className="px-3 py-3 text-center hidden md:table-cell">

--- a/app/advisor/[slug]/AdvisorProfileClient.tsx
+++ b/app/advisor/[slug]/AdvisorProfileClient.tsx
@@ -11,6 +11,7 @@ import AdvisorReviewForm from "@/components/AdvisorReviewForm";
 import { getStoredUtm } from "@/components/UtmCapture";
 import { trackEvent } from "@/lib/tracking";
 import { getVerificationConfig, getVerificationLinks } from "@/lib/advisor-verification";
+import { getQualificationData } from "@/lib/qualification-store";
 
 const TYPE_TO_PLATFORMS: Record<string, { label: string; href: string }[]> = {
   smsf_accountant: [
@@ -146,6 +147,7 @@ export default function AdvisorProfileClient({ professional: pro, similar, revie
           pages_visited: typeof window !== 'undefined' ? parseInt(sessionStorage.getItem('pages_visited') || '1') : 1,
           quiz_completed: typeof window !== 'undefined' ? !!sessionStorage.getItem('quiz_completed') : false,
           calculator_used: typeof window !== 'undefined' ? !!sessionStorage.getItem('calculator_used') : false,
+          qualification_data: getQualificationData(),
           ...getStoredUtm(),
         }),
       });

--- a/app/advisors/[type]/[state]/page.tsx
+++ b/app/advisors/[type]/[state]/page.tsx
@@ -22,7 +22,6 @@ const SLUG_TO_TYPE: Record<string, ProfessionalType> = {
   "aged-care-advisors": "aged_care_advisor",
   "crypto-advisors": "crypto_advisor",
   "debt-counsellors": "debt_counsellor",
-  "real-estate-agents": "real_estate_agent",
 };
 
 const STATE_NAMES: Record<string, string> = {

--- a/app/advisors/[type]/page.tsx
+++ b/app/advisors/[type]/page.tsx
@@ -22,7 +22,6 @@ const SLUG_TO_TYPE: Record<string, ProfessionalType> = {
   "aged-care-advisors": "aged_care_advisor",
   "crypto-advisors": "crypto_advisor",
   "debt-counsellors": "debt_counsellor",
-  "real-estate-agents": "real_estate_agent",
 };
 
 const TYPE_DESCRIPTIONS: Record<string, string> = {
@@ -39,7 +38,6 @@ const TYPE_DESCRIPTIONS: Record<string, string> = {
   "aged-care-advisors": "Find aged care advisors who specialise in residential aged care, home care packages, means testing, and retirement transitions.",
   "crypto-advisors": "Compare crypto and digital asset advisors for portfolio construction, tax planning, and DeFi strategy in Australia.",
   "debt-counsellors": "Find accredited debt counsellors for debt consolidation, hardship applications, budgeting, and financial recovery.",
-  "real-estate-agents": "Find licensed real estate agents for property sales, purchases, leasing, and property management across Australia.",
 };
 
 const TYPE_FAQS: Record<string, { q: string; a: string }[]> = {

--- a/app/api/advisor-enquiry/route.ts
+++ b/app/api/advisor-enquiry/route.ts
@@ -4,6 +4,82 @@ import { isRateLimited } from "@/lib/rate-limit";
 import { notificationFooter } from "@/lib/email-templates";
 import { getSiteUrl } from "@/lib/url";
 
+// Format qualification data as HTML table rows for the advisor notification email
+function buildQualificationEmailRows(qd: { source: string; data: Record<string, unknown> }): string {
+  const data = qd.data;
+  if (!data || Object.keys(data).length === 0) return "";
+
+  const LABEL_MAP: Record<string, string> = {
+    advisor_type: "Service Needed",
+    need: "Category",
+    amount: "Value Range",
+    urgency: "Urgency",
+    state: "Location",
+    balance: "Savings Balance",
+    current_rate: "Current Rate",
+    income: "Income",
+    deposit: "Deposit",
+    borrowing_amount: "Borrowing Amount",
+    target_suburb: "Target Area",
+    current_broker: "Current Broker",
+    trades_per_year: "Trades/Year",
+    avg_trade_size: "Avg Trade Size",
+    us_allocation_pct: "US Allocation",
+    potential_savings: "Potential Savings",
+    cheapest_broker: "Best-Fit Platform",
+    top_match: "Quiz Top Match",
+    results_count: "Results Count",
+    max_extra_interest: "Extra Interest Potential",
+    top_account: "Top Account",
+    annual_fees: "Annual Fees",
+  };
+
+  const VALUE_MAP: Record<string, Record<string, string>> = {
+    amount: { small: "Under $50,000", medium: "$50k – $200k", large: "$200k – $500k", whale: "Over $500,000", unsure: "Not sure yet" },
+    urgency: { urgent: "This week", soon: "Within a month", exploring: "Just exploring" },
+    state: { NSW: "New South Wales", VIC: "Victoria", QLD: "Queensland", WA: "Western Australia", SA: "South Australia", other: "TAS/ACT/NT", any: "Remote/Online" },
+  };
+
+  const formatValue = (key: string, val: unknown): string => {
+    if (val === null || val === undefined) return "—";
+    // Check mapped values
+    if (VALUE_MAP[key] && typeof val === "string" && VALUE_MAP[key][val]) return VALUE_MAP[key][val];
+    // Format currency-like numbers
+    if (typeof val === "number") {
+      if (key.includes("balance") || key.includes("income") || key.includes("deposit") || key.includes("borrowing") || key.includes("savings") || key.includes("fees") || key.includes("trade_size") || key.includes("interest")) {
+        return `$${val.toLocaleString("en-AU")}`;
+      }
+      if (key.includes("rate") || key.includes("pct") || key.includes("allocation")) return `${val}%`;
+      return String(val);
+    }
+    if (Array.isArray(val)) return val.join(", ");
+    return String(val);
+  };
+
+  // Filter out internal/unneeded fields
+  const skipKeys = new Set(["captured_at", "question_labels", "answers", "holdings"]);
+  const rows = Object.entries(data)
+    .filter(([k, v]) => !skipKeys.has(k) && v !== null && v !== undefined)
+    .map(([k, v]) => {
+      const label = LABEL_MAP[k] || k.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+      return `<tr><td style="padding: 6px 0; font-size: 13px; color: #64748b; width: 120px;">${label}</td><td style="padding: 6px 0; font-size: 14px; font-weight: 600;">${formatValue(k, v)}</td></tr>`;
+    })
+    .join("");
+
+  if (!rows) return "";
+
+  const sourceLabel = qd.source.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+
+  return `
+    <div style="margin-top: 16px; padding-top: 16px; border-top: 1px solid #e2e8f0;">
+      <p style="margin: 0 0 8px; font-size: 12px; font-weight: 700; color: #1e40af; text-transform: uppercase; letter-spacing: 0.5px;">Qualification Data (via ${sourceLabel})</p>
+      <table style="width: 100%; border-collapse: collapse; background: #eff6ff; border-radius: 8px; padding: 8px;">
+        ${rows}
+      </table>
+    </div>
+  `;
+}
+
 export async function POST(request: NextRequest) {
   try {
     // Rate limiting (DB-backed, survives serverless cold starts)
@@ -99,8 +175,23 @@ export async function POST(request: NextRequest) {
     if (body.quiz_completed) { score += 20; signals.quiz_completed = true; }
     if (body.calculator_used) { score += 15; signals.calculator_used = true; }
 
+    // Qualification data from quiz/calculator (structured data, not just booleans)
+    const qualificationData = body.qualification_data || null;
+    const hasQualificationData = qualificationData && qualificationData.source && qualificationData.data && Object.keys(qualificationData.data).length > 0;
+    if (hasQualificationData) {
+      score += 25;
+      signals.qualification = {
+        source: qualificationData.source,
+        data: qualificationData.data,
+        captured_at: qualificationData.captured_at,
+      };
+    }
+
     // Clamp 0-100
     score = Math.min(100, Math.max(0, score));
+
+    // Determine lead tier based on qualification data
+    const leadTier = hasQualificationData ? "qualified" : "standard";
 
     // ── Auto-Billing (prepaid credit model) ──
     // First 2 leads are free (trial), then deduct from credit balance
@@ -115,28 +206,34 @@ export async function POST(request: NextRequest) {
 
     // Get category default price if advisor has no custom price
     let categoryPrice = 4900; // ultimate fallback
+    let categoryQualifiedPrice = 9800; // fallback: 2x standard
     let categoryFreeLeads = 2;
     if (!advisor?.lead_price_cents) {
       const { data: catPricing } = await supabase
         .from("lead_pricing")
-        .select("price_cents, free_trial_leads")
+        .select("price_cents, qualified_price_cents, free_trial_leads")
         .eq("advisor_type", pro.type)
         .single();
       if (catPricing) {
         categoryPrice = catPricing.price_cents;
+        categoryQualifiedPrice = catPricing.qualified_price_cents || catPricing.price_cents * 2;
         categoryFreeLeads = catPricing.free_trial_leads;
       }
     }
 
     const isFree = freeUsed < (categoryFreeLeads || freeTrialCount);
-    const priceCents = isFree ? 0 : (advisor?.lead_price_cents || categoryPrice);
+    // Use qualified price when lead has qualification data
+    const basePriceCents = advisor?.lead_price_cents || categoryPrice;
+    const priceCents = isFree ? 0 : (leadTier === "qualified" ? (categoryQualifiedPrice || basePriceCents * 2) : basePriceCents);
     const balance = advisor?.credit_balance_cents || 0;
     const hasSufficientCredit = balance >= priceCents;
 
-    // Update lead with quality score and billing
+    // Update lead with quality score, billing, and qualification data
     await supabase.from("professional_leads").update({
       quality_score: score,
       quality_signals: signals,
+      qualification_data: hasQualificationData ? qualificationData : null,
+      lead_tier: leadTier,
       billed: !isFree && hasSufficientCredit,
       bill_amount_cents: isFree ? 0 : priceCents,
     }).eq("id", lead.id);
@@ -178,6 +275,12 @@ export async function POST(request: NextRequest) {
         const RESEND_API_KEY = process.env.RESEND_API_KEY;
         const siteUrl = getSiteUrl();
         if (RESEND_API_KEY) {
+          // Build qualification data rows for the email
+          const qualDataRows = hasQualificationData ? buildQualificationEmailRows(qualificationData) : "";
+          const tierBadge = leadTier === "qualified"
+            ? `<span style="display: inline-block; padding: 3px 10px; background: #dbeafe; color: #1e40af; border-radius: 20px; font-size: 11px; font-weight: 700; margin-left: 8px;">Qualified Lead</span>`
+            : "";
+
           await fetch("https://api.resend.com/emails", {
             method: "POST",
             headers: {
@@ -187,20 +290,21 @@ export async function POST(request: NextRequest) {
             body: JSON.stringify({
               from: "Invest.com.au <leads@invest.com.au>",
               to: pro.email,
-              subject: `New Enquiry from ${user_name.trim()} — Invest.com.au`,
+              subject: `${leadTier === "qualified" ? "⭐ Qualified Lead" : "New Enquiry"} from ${user_name.trim()} — Invest.com.au`,
               html: `
                 <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
                   <div style="background: #0f172a; color: white; padding: 20px 24px; border-radius: 12px 12px 0 0;">
-                    <h2 style="margin: 0; font-size: 18px;">New Consultation Request</h2>
-                    <p style="margin: 4px 0 0; opacity: 0.7; font-size: 13px;">via Invest.com.au</p>
+                    <h2 style="margin: 0; font-size: 18px;">New Consultation Request${tierBadge}</h2>
+                    <p style="margin: 4px 0 0; opacity: 0.7; font-size: 13px;">via Invest.com.au · Quality Score: ${score}/100</p>
                   </div>
                   <div style="background: #f8fafc; padding: 24px; border: 1px solid #e2e8f0; border-top: none; border-radius: 0 0 12px 12px;">
                     <table style="width: 100%; border-collapse: collapse;">
-                      <tr><td style="padding: 8px 0; font-size: 13px; color: #64748b; width: 100px;">Name</td><td style="padding: 8px 0; font-size: 14px; font-weight: 600;">${user_name.trim()}</td></tr>
+                      <tr><td style="padding: 8px 0; font-size: 13px; color: #64748b; width: 120px;">Name</td><td style="padding: 8px 0; font-size: 14px; font-weight: 600;">${user_name.trim()}</td></tr>
                       <tr><td style="padding: 8px 0; font-size: 13px; color: #64748b;">Email</td><td style="padding: 8px 0; font-size: 14px;"><a href="mailto:${user_email.trim()}" style="color: #2563eb;">${user_email.trim()}</a></td></tr>
                       ${user_phone ? `<tr><td style="padding: 8px 0; font-size: 13px; color: #64748b;">Phone</td><td style="padding: 8px 0; font-size: 14px;"><a href="tel:${user_phone.trim()}" style="color: #2563eb;">${user_phone.trim()}</a></td></tr>` : ""}
                       ${message ? `<tr><td style="padding: 8px 0; font-size: 13px; color: #64748b; vertical-align: top;">Message</td><td style="padding: 8px 0; font-size: 14px; line-height: 1.5;">${message.trim().replace(/\n/g, "<br>")}</td></tr>` : ""}
                     </table>
+                    ${qualDataRows}
                     <div style="margin-top: 16px; padding-top: 16px; border-top: 1px solid #e2e8f0;">
                       <a href="mailto:${user_email.trim()}?subject=Re: Your enquiry on Invest.com.au" style="display: inline-block; padding: 10px 24px; background: #0f172a; color: white; text-decoration: none; border-radius: 8px; font-size: 14px; font-weight: 600;">Reply to ${user_name.trim().split(" ")[0]}</a>
                       <a href="${siteUrl}/advisor-portal" style="display: inline-block; margin-left: 8px; padding: 10px 24px; background: #f1f5f9; color: #334155; text-decoration: none; border-radius: 8px; font-size: 14px; font-weight: 600;">View in Dashboard</a>
@@ -264,9 +368,11 @@ export async function POST(request: NextRequest) {
             professional_id,
             advisor_type: pro.type,
             quality_score: score,
+            lead_tier: leadTier,
             is_free_lead: isFree,
             has_phone: !!user_phone?.trim(),
             has_message: !!message?.trim(),
+            has_qualification_data: hasQualificationData,
           },
         },
       ]);

--- a/app/find-advisor/page.tsx
+++ b/app/find-advisor/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useMemo } from "react";
+import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import Image from "next/image";
 import Icon from "@/components/Icon";
@@ -98,9 +99,23 @@ const ADVISOR_TIPS: Record<string, string[]> = {
 };
 
 export default function FindAdvisorPage() {
-  const [step, setStep] = useState(0);
-  const [answers, setAnswers] = useState<Record<string, string>>({});
-  const [selectedType, setSelectedType] = useState<ProfessionalType | null>(null);
+  const searchParams = useSearchParams();
+  const needParam = searchParams.get("need");
+
+  // Check if the need param matches a valid option key
+  const prefilledNeed = useMemo(() => {
+    if (!needParam) return null;
+    const match = STEPS[0].options.find((o) => o.key === needParam);
+    return match && "type" in match ? { key: match.key, type: (match as { type: ProfessionalType }).type } : null;
+  }, [needParam]);
+
+  const [step, setStep] = useState(prefilledNeed ? 1 : 0);
+  const [answers, setAnswers] = useState<Record<string, string>>(
+    prefilledNeed ? { need: prefilledNeed.key } : {}
+  );
+  const [selectedType, setSelectedType] = useState<ProfessionalType | null>(
+    prefilledNeed ? prefilledNeed.type : null
+  );
   const [fade, setFade] = useState(false);
 
   const transition = useCallback((newStep: number) => {

--- a/app/find-advisor/page.tsx
+++ b/app/find-advisor/page.tsx
@@ -28,7 +28,6 @@ const STEPS = [
       { label: "Crypto & Digital Assets", desc: "Crypto portfolio strategy and tax planning", key: "crypto", type: "crypto_advisor" as ProfessionalType, icon: "bitcoin", color: "bg-orange-50 border-orange-200" },
       { label: "Aged Care", desc: "Navigate aged care options, costs, and subsidies", key: "agedcare", type: "aged_care_advisor" as ProfessionalType, icon: "heart", color: "bg-pink-50 border-pink-200" },
       { label: "Debt Help", desc: "Debt consolidation, budgeting, and financial recovery", key: "debt", type: "debt_counsellor" as ProfessionalType, icon: "credit-card", color: "bg-red-50 border-red-200" },
-      { label: "Real Estate Agent", desc: "Selling, buying, or leasing residential or commercial property", key: "realestate", type: "real_estate_agent" as ProfessionalType, icon: "map", color: "bg-cyan-50 border-cyan-200" },
     ],
   },
   {
@@ -77,7 +76,6 @@ const TYPE_SLUG_MAP: Record<ProfessionalType, string> = {
   real_estate_agent: "real-estate-agents", wealth_manager: "wealth-managers",
   aged_care_advisor: "aged-care-advisors",
   crypto_advisor: "crypto-advisors", debt_counsellor: "debt-counsellors",
-  real_estate_agent: "real-estate-agents",
 };
 const STATE_SLUG_MAP: Record<string, string> = { NSW: "nsw", VIC: "vic", QLD: "qld", WA: "wa", SA: "sa" };
 
@@ -95,7 +93,6 @@ const ADVISOR_TIPS: Record<string, string[]> = {
   aged_care_advisor: ["Ask about experience with Centrelink and DVA means testing", "They should explain RAD vs DAP options clearly", "Look for Aged Care Steps or similar specialist accreditation"],
   crypto_advisor: ["Must hold an AFSL to provide crypto investment advice", "Ask how they track cost bases across exchanges and wallets", "Check they understand DeFi, staking, and airdrop tax treatment"],
   debt_counsellor: ["Free counselling is available through the National Debt Helpline (1800 007 007)", "Be wary of 'debt management' companies that charge upfront fees", "Ask about all options including hardship provisions and debt agreements"],
-  real_estate_agent: ["Must hold a state-based real estate licence — verify with your state's Fair Trading", "Ask about their average days on market and clearance rates", "Check recent sales in your area to gauge their local expertise"],
 };
 
 export default function FindAdvisorPage() {

--- a/app/find-advisor/page.tsx
+++ b/app/find-advisor/page.tsx
@@ -8,6 +8,7 @@ import Icon from "@/components/Icon";
 import type { ProfessionalType } from "@/lib/types";
 import { PROFESSIONAL_TYPE_LABELS } from "@/lib/types";
 import { trackEvent } from "@/lib/tracking";
+import { storeQualificationData } from "@/lib/qualification-store";
 
 const STEPS = [
   {
@@ -289,6 +290,15 @@ function FindAdvisorResults({ selectedType, answers, getResultUrl, getResultLabe
       urgency: answers.urgency,
       state: answers.state,
     }, "/find-advisor");
+
+    // Store qualification data for lead enrichment
+    storeQualificationData("find_advisor", {
+      advisor_type: selectedType,
+      need: answers.need,
+      amount: answers.amount,
+      urgency: answers.urgency,
+      state: answers.state,
+    });
   }, [selectedType, answers]);
 
   const tips = selectedType && ADVISOR_TIPS[selectedType] ? ADVISOR_TIPS[selectedType] : [];

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,6 +13,7 @@ import Icon from "@/components/Icon";
 import BrokerLogo from "@/components/BrokerLogo";
 import { AFFILIATE_REL } from "@/lib/tracking";
 import HeroLeadCapture from "@/components/HeroLeadCapture";
+import HomepageServiceSelector from "@/components/HomepageServiceSelector";
 import AdvisorDirectory from "@/components/AdvisorDirectory";
 import { FeesFreshnessIndicator } from "@/components/FeesFreshnessIndicator";
 import { getMostRecentFeeCheck } from "@/lib/utils";
@@ -205,6 +206,15 @@ export default async function HomePage() {
           </div>
         </div>
       </section>
+
+      {/* ═══════ 1b. SERVICE SELECTOR — "What do you need help with?" ═══════ */}
+      <ScrollFadeIn>
+        <section className="py-6 md:py-14 bg-slate-50 border-b border-slate-100">
+          <div className="container-custom">
+            <HomepageServiceSelector />
+          </div>
+        </section>
+      </ScrollFadeIn>
 
       {/* ═══════ 2. ADVISOR DIRECTORY — Tabbed ═══════ */}
       <AdvisorDirectory

--- a/app/portfolio-calculator/PortfolioCalculatorClient.tsx
+++ b/app/portfolio-calculator/PortfolioCalculatorClient.tsx
@@ -8,6 +8,7 @@ import { trackClick, getAffiliateLink, AFFILIATE_REL } from "@/lib/tracking";
 import type { Broker } from "@/lib/types";
 import LeadMagnet from "@/components/LeadMagnet";
 import AdvisorPrompt from "@/components/AdvisorPrompt";
+import { storeQualificationData } from "@/lib/qualification-store";
 
 type Holding = {
   id: string;
@@ -211,7 +212,16 @@ export default function PortfolioCalculatorClient({ brokers, inline }: { brokers
           </div>
 
           <button
-            onClick={() => setShowResults(true)}
+            onClick={() => {
+              setShowResults(true);
+              storeQualificationData("portfolio_calculator", {
+                holdings: holdings.map(h => ({ market: h.market, trades_per_year: h.trades_per_year, avg_trade_size: h.avg_trade_size })),
+                current_broker: currentBroker || null,
+                cheapest_broker: results[0]?.broker.name || null,
+                annual_fees: results[0]?.totalFees || null,
+                potential_savings: savings > 0 ? savings : null,
+              });
+            }}
             className="mt-4 w-full md:w-auto px-6 py-3 bg-slate-900 text-white font-bold rounded-lg text-sm hover:bg-slate-800 transition-colors"
           >
             Calculate My Fees →

--- a/app/quiz/page.tsx
+++ b/app/quiz/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useMemo, useRef } from "react";
 import { createClient } from "@/lib/supabase/client";
 import type { Broker } from "@/lib/types";
 import { trackEvent } from "@/lib/tracking";
+import { storeQualificationData } from "@/lib/qualification-store";
 import { getPlacementWinners, type PlacementWinner } from "@/lib/sponsorship";
 import { scoreQuizResults, type WeightKey, type QuizWeights } from "@/lib/quiz-scoring";
 
@@ -445,6 +446,14 @@ export default function QuizPage() {
           results: topResults,
           completedAt: new Date().toISOString(),
         }));
+
+        // Store qualification data for lead enrichment
+        storeQualificationData("quiz", {
+          answers,
+          top_match: results[0]?.slug || null,
+          results_count: results.length,
+          question_labels: questions.map(q => q.question_text),
+        });
       } catch { /* quota exceeded */ }
     }
   }, [step, questions.length, brokers.length, results, answers]);

--- a/app/savings-calculator/SavingsCalculatorClient.tsx
+++ b/app/savings-calculator/SavingsCalculatorClient.tsx
@@ -6,6 +6,7 @@ import Icon from "@/components/Icon";
 import SocialProofCounter from "@/components/SocialProofCounter";
 import { trackEvent, trackClick, getAffiliateLink, AFFILIATE_REL, trackPageDuration } from "@/lib/tracking";
 import { getStoredUtm } from "@/components/UtmCapture";
+import { storeQualificationData } from "@/lib/qualification-store";
 
 type Account = {
   id: number; slug: string; name: string; platform_type: string;
@@ -48,6 +49,12 @@ export default function SavingsCalculatorClient({ accounts, inline }: { accounts
 
   const handleCalculate = () => {
     setShowResults(true);
+    storeQualificationData("savings_calculator", {
+      balance,
+      current_rate: currentRate,
+      max_extra_interest: maxExtra,
+      top_account: topAccount?.name || null,
+    });
     trackEvent("savings_calc_result", {
       balance,
       current_rate: currentRate,

--- a/app/switching-calculator/SwitchingCalculatorClient.tsx
+++ b/app/switching-calculator/SwitchingCalculatorClient.tsx
@@ -8,6 +8,7 @@ import SocialProofCounter from "@/components/SocialProofCounter";
 import { getAffiliateLink, getBenefitCta, renderStars, AFFILIATE_REL, trackClick, trackPageDuration } from "@/lib/tracking";
 import { getStoredUtm } from "@/components/UtmCapture";
 import type { Broker } from "@/lib/types";
+import { storeQualificationData } from "@/lib/qualification-store";
 
 function parseFee(feeStr: string | null | undefined): { flat: number; pct: number } {
   if (!feeStr) return { flat: 0, pct: 0 };
@@ -59,6 +60,14 @@ export default function SwitchingCalculatorClient({ brokers, inline }: { brokers
 
   const handleCalculate = () => {
     setShowResults(true);
+    storeQualificationData("switching_calculator", {
+      current_broker: currentBroker || null,
+      trades_per_year: tradesPerYear,
+      avg_trade_size: avgTradeSize,
+      us_allocation_pct: usAllocation,
+      potential_savings: savings > 0 ? Math.round(savings) : null,
+      cheapest_broker: cheapest?.broker.name || null,
+    });
     // Track
     fetch("/api/track-event", { method: "POST", headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ event_type: "switching_calc_result", page: "/switching-calculator", metadata: { current: currentBroker, trades: tradesPerYear, avg_size: avgTradeSize, us_pct: usAllocation, savings: Math.round(savings) } })

--- a/components/AdvisorMatchCTA.tsx
+++ b/components/AdvisorMatchCTA.tsx
@@ -1,0 +1,51 @@
+import Link from "next/link";
+import Icon from "@/components/Icon";
+
+interface AdvisorMatchCTAProps {
+  /** The wizard need key to pre-fill (e.g. "mortgage", "tax", "planning") */
+  needKey: string;
+  /** Headline shown above the CTA */
+  headline: string;
+  /** Supporting description */
+  description: string;
+}
+
+const NEED_KEY_TO_ICON: Record<string, string> = {
+  mortgage: "landmark",
+  buyers: "search",
+  planning: "trending-up",
+  insurance: "shield",
+  smsf: "building",
+  tax: "calculator",
+  wealth: "briefcase",
+  estate: "file-text",
+  property: "home",
+  realestate: "map-pin",
+  crypto: "bitcoin",
+  agedcare: "heart",
+  debt: "credit-card",
+};
+
+export default function AdvisorMatchCTA({ needKey, headline, description }: AdvisorMatchCTAProps) {
+  const icon = NEED_KEY_TO_ICON[needKey] || "users";
+
+  return (
+    <div className="bg-gradient-to-br from-violet-50 to-slate-50 border border-violet-200/60 rounded-xl p-4 md:p-5">
+      <div className="flex items-start gap-3">
+        <div className="w-10 h-10 rounded-full bg-violet-100 flex items-center justify-center shrink-0">
+          <Icon name={icon} size={18} className="text-violet-600" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <h3 className="text-sm md:text-base font-bold text-slate-900 mb-0.5">{headline}</h3>
+          <p className="text-xs md:text-sm text-slate-500 mb-3 leading-relaxed">{description}</p>
+          <Link
+            href={`/find-advisor?need=${needKey}`}
+            className="inline-flex items-center gap-1.5 px-4 py-2 bg-violet-600 text-white text-xs font-bold rounded-lg hover:bg-violet-700 transition-colors"
+          >
+            Get Matched Free <span>&rarr;</span>
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/HomepageServiceSelector.tsx
+++ b/components/HomepageServiceSelector.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import Link from "next/link";
+import Icon from "@/components/Icon";
+
+const services = [
+  { label: "Home Loan / Refinancing", desc: "Find the best mortgage rate for your situation", key: "mortgage", icon: "landmark", color: "bg-rose-50 text-rose-600" },
+  { label: "Buyers Agent", desc: "Help finding and negotiating property purchases", key: "buyers", icon: "search", color: "bg-teal-50 text-teal-600" },
+  { label: "Financial Planning", desc: "Retirement, wealth building, or investment strategy", key: "planning", icon: "trending-up", color: "bg-violet-50 text-violet-600" },
+  { label: "Insurance", desc: "Life, TPD, income protection, or business cover", key: "insurance", icon: "shield", color: "bg-sky-50 text-sky-600" },
+  { label: "SMSF Setup & Management", desc: "Set up or manage a self-managed super fund", key: "smsf", icon: "building", color: "bg-blue-50 text-blue-600" },
+  { label: "Tax Optimisation", desc: "Minimise tax on investments and capital gains", key: "tax", icon: "calculator", color: "bg-amber-50 text-amber-600" },
+  { label: "Wealth Management", desc: "Portfolio management for high-net-worth investors", key: "wealth", icon: "briefcase", color: "bg-indigo-50 text-indigo-600" },
+  { label: "Estate Planning", desc: "Protect your assets and plan for the future", key: "estate", icon: "file-text", color: "bg-slate-100 text-slate-600" },
+  { label: "Property Investment", desc: "Advice on buying investment property", key: "property", icon: "home", color: "bg-emerald-50 text-emerald-600" },
+  { label: "Real Estate Agent", desc: "Selling or listing your property", key: "realestate", icon: "map-pin", color: "bg-lime-50 text-lime-600" },
+  { label: "Crypto & Digital Assets", desc: "Crypto portfolio strategy and tax planning", key: "crypto", icon: "bitcoin", color: "bg-orange-50 text-orange-600" },
+  { label: "Aged Care", desc: "Navigate aged care options, costs, and subsidies", key: "agedcare", icon: "heart", color: "bg-pink-50 text-pink-600" },
+  { label: "Debt Help", desc: "Debt consolidation, budgeting, and financial recovery", key: "debt", icon: "credit-card", color: "bg-red-50 text-red-600" },
+];
+
+export default function HomepageServiceSelector() {
+  return (
+    <div className="max-w-2xl mx-auto">
+      <h2 className="text-2xl md:text-3xl font-extrabold text-slate-900 mb-1">
+        What do you need help with?
+      </h2>
+      <p className="text-sm text-slate-500 mb-5">
+        We&apos;ll match you with the right type of professional.
+      </p>
+
+      <div className="space-y-2">
+        {services.map((s) => (
+          <Link
+            key={s.key}
+            href={`/find-advisor?need=${s.key}`}
+            className="flex items-center gap-3 p-3 md:p-3.5 bg-white border border-slate-200 rounded-xl hover:border-violet-300 hover:shadow-sm transition-all group"
+          >
+            <div className={`w-9 h-9 rounded-lg flex items-center justify-center shrink-0 ${s.color.split(" ")[0]}`}>
+              <Icon name={s.icon} size={18} className={s.color.split(" ")[1]} />
+            </div>
+            <div className="flex-1 min-w-0">
+              <span className="text-sm font-semibold text-slate-800 block">{s.label}</span>
+              <span className="text-[0.62rem] md:text-xs text-slate-500 block mt-0.5">{s.desc}</span>
+            </div>
+            <div className="w-5 h-5 rounded-full border-2 border-slate-200 shrink-0 group-hover:border-violet-300" />
+          </Link>
+        ))}
+      </div>
+
+      <div className="text-center mt-5">
+        <Link
+          href="/find-advisor"
+          className="inline-flex items-center gap-1.5 text-sm font-semibold text-violet-600 hover:text-violet-700 transition-colors"
+        >
+          Not sure? Let us help you decide <span>&rarr;</span>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/lib/advisor-specialties.ts
+++ b/lib/advisor-specialties.ts
@@ -261,20 +261,6 @@ export const SPECIALTIES_BY_TYPE: Record<ProfessionalType, string[]> = {
     "Credit Repair",
     "Budget Coaching",
   ],
-  real_estate_agent: [
-    "Residential Sales",
-    "Residential Leasing",
-    "Commercial Sales",
-    "Commercial Leasing",
-    "Property Management",
-    "Auction Specialist",
-    "Off-the-Plan Sales",
-    "Rural & Regional",
-    "Prestige Property",
-    "First Home Buyers",
-    "Investment Property",
-    "Development Sites",
-  ],
 };
 
 // ═══════════════════════════════════════════════

--- a/lib/qualification-store.ts
+++ b/lib/qualification-store.ts
@@ -1,0 +1,46 @@
+/**
+ * Stores qualification data (quiz answers, calculator inputs) in sessionStorage
+ * so it can be attached to advisor enquiry leads for better lead quality scoring.
+ */
+
+export interface QualificationData {
+  source: string; // e.g. "find_advisor", "mortgage_calculator", "quiz", "savings_calculator"
+  data: Record<string, unknown>;
+  captured_at: string; // ISO timestamp
+}
+
+const STORAGE_KEY = "qualification_data";
+
+export function storeQualificationData(source: string, data: Record<string, unknown>): void {
+  if (typeof window === "undefined") return;
+  try {
+    const payload: QualificationData = {
+      source,
+      data,
+      captured_at: new Date().toISOString(),
+    };
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+  } catch {
+    // sessionStorage may be unavailable (private browsing, storage full)
+  }
+}
+
+export function getQualificationData(): QualificationData | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    return JSON.parse(raw) as QualificationData;
+  } catch {
+    return null;
+  }
+}
+
+export function clearQualificationData(): void {
+  if (typeof window === "undefined") return;
+  try {
+    sessionStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // ignore
+  }
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1046,7 +1046,6 @@ export const PROFESSIONAL_TYPE_LABELS: Record<ProfessionalType, string> = {
   aged_care_advisor: "Aged Care Advisor",
   crypto_advisor: "Crypto Advisor",
   debt_counsellor: "Debt Counsellor",
-  real_estate_agent: "Real Estate Agent",
 };
 
 export const PROFESSIONAL_TYPE_ICONS: Record<ProfessionalType, string> = {
@@ -1063,7 +1062,6 @@ export const PROFESSIONAL_TYPE_ICONS: Record<ProfessionalType, string> = {
   aged_care_advisor: "heart",
   crypto_advisor: "bitcoin",
   debt_counsellor: "credit-card",
-  real_estate_agent: "map",
 };
 
 export const AU_STATES = ["NSW", "VIC", "QLD", "WA", "SA", "TAS", "ACT", "NT"] as const;

--- a/supabase/migrations/20260316_add_qualified_lead_pricing.sql
+++ b/supabase/migrations/20260316_add_qualified_lead_pricing.sql
@@ -1,0 +1,31 @@
+-- ═══════════════════════════════════════════════
+-- Add tiered lead pricing (standard / qualified / exclusive)
+-- and qualification data storage on professional_leads
+-- ═══════════════════════════════════════════════
+
+-- Add qualified and exclusive pricing tiers to lead_pricing
+ALTER TABLE lead_pricing
+  ADD COLUMN IF NOT EXISTS qualified_price_cents INTEGER,
+  ADD COLUMN IF NOT EXISTS exclusive_price_cents INTEGER;
+
+-- Set defaults: qualified = 2x standard, exclusive = 3x standard
+UPDATE lead_pricing SET
+  qualified_price_cents = price_cents * 2,
+  exclusive_price_cents = price_cents * 3
+WHERE qualified_price_cents IS NULL;
+
+-- Add qualification data and lead tier to professional_leads
+ALTER TABLE professional_leads
+  ADD COLUMN IF NOT EXISTS qualification_data JSONB,
+  ADD COLUMN IF NOT EXISTS lead_tier TEXT DEFAULT 'standard';
+
+-- Add quality_score and quality_signals if they don't exist yet
+-- (these are used in code but may not have a migration)
+ALTER TABLE professional_leads
+  ADD COLUMN IF NOT EXISTS quality_score INTEGER,
+  ADD COLUMN IF NOT EXISTS quality_signals JSONB,
+  ADD COLUMN IF NOT EXISTS bill_amount_cents INTEGER;
+
+-- Index for filtering leads by tier (useful for reporting)
+CREATE INDEX IF NOT EXISTS idx_leads_tier ON professional_leads(lead_tier);
+CREATE INDEX IF NOT EXISTS idx_leads_quality_score ON professional_leads(quality_score DESC);


### PR DESCRIPTION
## Summary
- **Homepage service selector**: Added "What do you need help with?" section showing all 13 advisor categories, each linking to the find-advisor wizard
- **Qualified lead pipeline**: Quiz/calculator inputs now persist in sessionStorage and flow through to advisor leads with enriched notification emails
- **Tiered lead pricing**: Qualified leads (with calculator/quiz data) can be priced higher than standard leads, with admin UI for managing all 3 tiers

## Test plan
- [ ] Homepage shows the new service selector section
- [ ] Clicking a service category navigates to `/find-advisor?need={key}` with Step 1 pre-filled
- [ ] Completing a calculator stores qualification data in sessionStorage
- [ ] Submitting an advisor enquiry after using a calculator includes qualification data in the lead
- [ ] Advisor notification email shows qualification data table for qualified leads
- [ ] Admin pricing page shows qualified/exclusive price columns
- [ ] Database migration adds new columns to lead_pricing and professional_leads tables

https://claude.ai/code/session_01Kj25hcfBsqaR9f8GRPiWod