### PR TITLE
Email capture gate on portfolio calc + context on all calcs

### DIFF
--- a/app/api/email-capture/route.ts
+++ b/app/api/email-capture/route.ts
@@ -189,7 +189,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
   }
 
-  const { email, source, name } = body as { email?: string; source?: string; name?: string };
+  const { email, source, name, context } = body as { email?: string; source?: string; name?: string; context?: Record<string, unknown> };
   const utm = extractUtm(body as Record<string, unknown>);
 
   // Validate email properly
@@ -224,11 +224,12 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ success: true, message: 'Already subscribed' });
   }
 
-  // Save email to database
+  // Save email to database (with optional calculator/quiz context)
   const { error } = await supabase.from('email_captures').insert({
     email: sanitizedEmail,
     source: sanitizedSource,
     ...(sanitizedName ? { name: sanitizedName } : {}),
+    ...(context && typeof context === 'object' && Object.keys(context).length > 0 ? { context } : {}),
     ...utmForInsert(utm),
   });
 

--- a/app/portfolio-calculator/PortfolioCalculatorClient.tsx
+++ b/app/portfolio-calculator/PortfolioCalculatorClient.tsx
@@ -4,7 +4,8 @@ import { useState, useEffect, useMemo } from "react";
 import Link from "next/link";
 import Icon from "@/components/Icon";
 import { createClient } from "@/lib/supabase/client";
-import { trackClick, getAffiliateLink, AFFILIATE_REL } from "@/lib/tracking";
+import { trackClick, trackEvent, getAffiliateLink, AFFILIATE_REL } from "@/lib/tracking";
+import { getStoredUtm } from "@/components/UtmCapture";
 import type { Broker } from "@/lib/types";
 import LeadMagnet from "@/components/LeadMagnet";
 import AdvisorPrompt from "@/components/AdvisorPrompt";
@@ -27,6 +28,8 @@ export default function PortfolioCalculatorClient({ brokers, inline }: { brokers
   ]);
   const [currentBroker, setCurrentBroker] = useState("");
   const [showResults, setShowResults] = useState(false);
+  const [email, setEmail] = useState("");
+  const [emailCaptured, setEmailCaptured] = useState(false);
 
   const addHolding = () => {
     setHoldings([...holdings, {
@@ -44,6 +47,29 @@ export default function PortfolioCalculatorClient({ brokers, inline }: { brokers
   const removeHolding = (id: string) => {
     if (holdings.length === 1) return;
     setHoldings(holdings.filter(h => h.id !== id));
+  };
+
+  const handleEmailCapture = async () => {
+    if (!email.trim() || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) return;
+    await fetch("/api/email-capture", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email: email.trim(),
+        source: "portfolio-calculator",
+        name: "",
+        context: {
+          holdings: holdings.map(h => ({ market: h.market, trades_per_year: h.trades_per_year, avg_trade_size: h.avg_trade_size })),
+          current_broker: currentBroker || null,
+          cheapest_broker: results[0]?.broker.name || null,
+          annual_fees_cheapest: results[0]?.totalFees || null,
+          potential_savings: savings > 0 ? Math.round(savings) : 0,
+        },
+        ...getStoredUtm(),
+      }),
+    }).catch(() => {});
+    setEmailCaptured(true);
+    trackEvent("portfolio_calc_email", { email: email.trim() }, "/portfolio-calculator");
   };
 
   // Calculate fees for each broker
@@ -243,6 +269,23 @@ export default function PortfolioCalculatorClient({ brokers, inline }: { brokers
               </div>
             )}
 
+            {/* Email capture gate */}
+            {!emailCaptured && results.length > 5 && (
+              <div className="bg-slate-900 rounded-xl p-4 md:p-5 text-white mb-6">
+                <div className="flex items-start gap-3">
+                  <Icon name="mail" size={20} className="text-amber-400 shrink-0 mt-0.5" />
+                  <div className="flex-1">
+                    <p className="text-sm font-bold mb-1">See all {results.length} brokers ranked for your portfolio</p>
+                    <p className="text-xs text-slate-300 mb-3">Enter your email to unlock the full comparison + get a free personalised fee report.</p>
+                    <div className="flex gap-2">
+                      <input type="email" value={email} onChange={e => setEmail(e.target.value)} placeholder="your@email.com" className="flex-1 px-3 py-2 text-sm rounded-lg text-slate-900 border-0" />
+                      <button onClick={handleEmailCapture} className="px-4 py-2 bg-amber-500 text-white text-xs font-bold rounded-lg hover:bg-amber-600 shrink-0">Unlock Results</button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            )}
+
             {/* Results table */}
             <div className="bg-white border border-slate-200 rounded-xl overflow-hidden mb-6">
               <div className="grid grid-cols-12 bg-slate-50 text-xs font-semibold text-slate-600 px-3 md:px-4 py-2.5 border-b border-slate-200">
@@ -252,7 +295,7 @@ export default function PortfolioCalculatorClient({ brokers, inline }: { brokers
                 <span className="col-span-4 md:col-span-3 text-right hidden md:block">vs Current</span>
                 <span className="col-span-4 md:col-span-3 text-right" />
               </div>
-              {results.slice(0, 15).map((r, i) => {
+              {(emailCaptured ? results.slice(0, 15) : results.slice(0, 5)).map((r, i) => {
                 const isCurrent = r.broker.slug === currentBroker;
                 const diff = currentBroker ? currentBrokerFees - r.totalFees : 0;
                 return (

--- a/app/savings-calculator/SavingsCalculatorClient.tsx
+++ b/app/savings-calculator/SavingsCalculatorClient.tsx
@@ -68,7 +68,7 @@ export default function SavingsCalculatorClient({ accounts, inline }: { accounts
     await fetch("/api/email-capture", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ email: email.trim(), source: "savings-calculator", name: "", ...getStoredUtm() }),
+      body: JSON.stringify({ email: email.trim(), source: "savings-calculator", name: "", context: { balance, current_rate: currentRate, top_account: topAccount?.name, max_extra: maxExtra > 0 ? Math.round(maxExtra) : 0 }, ...getStoredUtm() }),
     }).catch(() => {});
     setEmailSubmitted(true);
     setEmailGated(false);

--- a/app/switching-calculator/SwitchingCalculatorClient.tsx
+++ b/app/switching-calculator/SwitchingCalculatorClient.tsx
@@ -77,7 +77,7 @@ export default function SwitchingCalculatorClient({ brokers, inline }: { brokers
   const handleEmailCapture = async () => {
     if (!email.trim()) return;
     await fetch("/api/email-capture", { method: "POST", headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ email: email.trim(), source: "switching_calculator", name: "", ...getStoredUtm() })
+      body: JSON.stringify({ email: email.trim(), source: "switching_calculator", name: "", context: { current_broker: currentBroker || null, trades_per_year: tradesPerYear, avg_trade_size: avgTradeSize, us_allocation_pct: usAllocation, potential_savings: savings > 0 ? Math.round(savings) : 0 }, ...getStoredUtm() })
     }).catch(() => {});
     setEmailCaptured(true);
   };

--- a/supabase/migrations/20260316_add_email_capture_context.sql
+++ b/supabase/migrations/20260316_add_email_capture_context.sql
@@ -1,0 +1,3 @@
+-- Add context column to email_captures for storing calculator/quiz inputs alongside the email
+-- This enables personalised nurture sequences based on what the user was calculating
+ALTER TABLE email_captures ADD COLUMN IF NOT EXISTS context JSONB;


### PR DESCRIPTION
## Summary
- Portfolio calculator now gates full results behind email capture (top 5 shown free, enter email to unlock all)
- All 3 calculators (savings, switching, portfolio) now pass their inputs as `context` JSONB alongside email captures — balance, trades/year, broker, potential savings etc.
- Email capture API updated to accept and store `context`
- Migration adds `context JSONB` column to `email_captures` table

This enables personalised nurture emails based on what the user was calculating (e.g. "You calculated $2,500 in savings — ready to switch?").

## Test plan
- [ ] Portfolio calculator shows top 5 results, email gate appears for full list
- [ ] Entering email unlocks all results
- [ ] Savings calculator email capture includes context (balance, rate, top account)
- [ ] Switching calculator email capture includes context (trades, broker, savings)
- [ ] Portfolio calculator email capture includes context (holdings, broker, fees)
- [ ] `email_captures.context` column exists after migration

https://claude.ai/code/session_01Kj25hcfBsqaR9f8GRPiWod