### PR TITLE
Advisor performance badges + relevance-weighted matching

### DIFF
--- a/app/advisor/[slug]/AdvisorProfileClient.tsx
+++ b/app/advisor/[slug]/AdvisorProfileClient.tsx
@@ -204,6 +204,18 @@ export default function AdvisorProfileClient({ professional: pro, similar, revie
                 {pro.firm_name && <div className="text-sm md:text-base text-slate-600 font-medium mb-1.5">{pro.firm_name}</div>}
                 <div className="flex items-center gap-2 md:gap-3 flex-wrap">
                   <span className="text-xs md:text-sm bg-violet-100 text-violet-700 px-2.5 py-1 rounded-lg font-semibold">{typeLabel}</span>
+                  {pro.avg_response_minutes != null && pro.avg_response_minutes <= 120 && (
+                    <span className="inline-flex items-center gap-1 text-[0.62rem] md:text-xs font-bold px-2 md:px-2.5 py-0.5 md:py-1 rounded-full bg-emerald-100 text-emerald-700">
+                      <Icon name="zap" size={12} className="text-emerald-500" />
+                      Responds Fast
+                    </span>
+                  )}
+                  {pro.avg_response_minutes != null && pro.avg_response_minutes > 120 && pro.avg_response_minutes <= 1440 && (
+                    <span className="inline-flex items-center gap-1 text-[0.62rem] md:text-xs font-bold px-2 md:px-2.5 py-0.5 md:py-1 rounded-full bg-sky-100 text-sky-700">
+                      <Icon name="clock" size={12} className="text-sky-500" />
+                      Responds within 24hrs
+                    </span>
+                  )}
                   {pro.location_display && (
                     <span className="inline-flex items-center gap-1 text-xs md:text-sm text-slate-500">
                       <Icon name="map-pin" size={14} className="text-slate-400" />

--- a/app/advisors/AdvisorsClient.tsx
+++ b/app/advisors/AdvisorsClient.tsx
@@ -723,6 +723,12 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
                           Featured
                         </span>
                       )}
+                      {pro.avg_response_minutes != null && pro.avg_response_minutes <= 120 && (
+                        <span className="shrink-0 text-[0.56rem] md:text-[0.62rem] font-bold px-1.5 py-0.5 rounded-full bg-emerald-100 text-emerald-700 flex items-center gap-0.5">
+                          <Icon name="zap" size={10} className="text-emerald-500" />
+                          Fast
+                        </span>
+                      )}
                     </div>
                     {pro.firm_name && (
                       <div className="text-[0.65rem] md:text-xs text-slate-500 truncate flex items-center gap-1.5">

--- a/app/api/advisor-search/route.ts
+++ b/app/api/advisor-search/route.ts
@@ -65,7 +65,7 @@ export async function GET(request: NextRequest) {
       // Standard Supabase query
       let query = supabase
         .from("professionals")
-        .select("id, slug, name, firm_name, type, specialties, location_state, location_suburb, location_display, location_postcode, photo_url, fee_structure, fee_description, hourly_rate_cents, flat_fee_cents, aum_percentage, initial_consultation_free, rating, review_count, verified, offer_text, offer_active, created_at", { count: "exact" })
+        .select("id, slug, name, firm_name, type, specialties, location_state, location_suburb, location_display, location_postcode, photo_url, fee_structure, fee_description, hourly_rate_cents, flat_fee_cents, aum_percentage, initial_consultation_free, rating, review_count, verified, offer_text, offer_active, created_at, avg_response_minutes, total_leads, featured_until, account_type", { count: "exact" })
         .eq("status", "active");
 
       if (type) query = query.eq("type", type);
@@ -78,17 +78,25 @@ export async function GET(request: NextRequest) {
         query = query.or(`name.ilike.${term},firm_name.ilike.${term},location_display.ilike.${term},location_suburb.ilike.${term}`);
       }
 
-      switch (sort) {
-        case "rating": query = query.order("rating", { ascending: false, nullsFirst: false }); break;
-        case "reviews": query = query.order("review_count", { ascending: false, nullsFirst: false }); break;
-        case "name": query = query.order("name", { ascending: true }); break;
-        case "newest": query = query.order("created_at", { ascending: false }); break;
-        case "fee_low": query = query.order("hourly_rate_cents", { ascending: true, nullsFirst: false }); break;
-        case "fee_high": query = query.order("hourly_rate_cents", { ascending: false, nullsFirst: false }); break;
-        default: query = query.order("rating", { ascending: false, nullsFirst: false });
-      }
+      // For "relevance" sort, fetch more and re-rank client-side with composite score.
+      // For all other sorts, use DB ordering.
+      const useRelevanceSort = sort === "relevance";
 
-      query = query.range(offset, offset + limit - 1);
+      if (!useRelevanceSort) {
+        switch (sort) {
+          case "rating": query = query.order("rating", { ascending: false, nullsFirst: false }); break;
+          case "reviews": query = query.order("review_count", { ascending: false, nullsFirst: false }); break;
+          case "name": query = query.order("name", { ascending: true }); break;
+          case "newest": query = query.order("created_at", { ascending: false }); break;
+          case "fee_low": query = query.order("hourly_rate_cents", { ascending: true, nullsFirst: false }); break;
+          case "fee_high": query = query.order("hourly_rate_cents", { ascending: false, nullsFirst: false }); break;
+          default: query = query.order("rating", { ascending: false, nullsFirst: false });
+        }
+        query = query.range(offset, offset + limit - 1);
+      } else {
+        // Fetch all matching, score and paginate in JS
+        query = query.order("rating", { ascending: false, nullsFirst: false });
+      }
 
       const { data, error, count } = await query;
       if (error) {
@@ -96,7 +104,48 @@ export async function GET(request: NextRequest) {
         return NextResponse.json({ error: "Search failed." }, { status: 500 });
       }
 
-      advisors = data ?? [];
+      if (useRelevanceSort && data) {
+        // Composite relevance scoring:
+        // - Rating weight: 35%
+        // - Review volume: 15%  (capped at 20 reviews = 1.0)
+        // - Response speed: 20% (< 2hrs = 1.0, < 12hrs = 0.7, < 24hrs = 0.4, else 0.1)
+        // - Verified: 15%
+        // - Featured: 10%
+        // - Has leads (active advisor): 5%
+        const scored = data.map((a: Record<string, unknown>) => {
+          const rating = (a.rating as number) || 0;
+          const reviews = (a.review_count as number) || 0;
+          const avgResp = a.avg_response_minutes as number | null;
+          const isVerified = a.verified as boolean;
+          const isFeatured = a.featured_until && new Date(a.featured_until as string) > new Date();
+          const hasLeads = ((a.total_leads as number) || 0) > 0;
+
+          const ratingScore = rating / 5;
+          const reviewScore = Math.min(reviews / 20, 1);
+          let responseScore = 0.1;
+          if (avgResp !== null && avgResp !== undefined) {
+            if (avgResp <= 120) responseScore = 1.0;
+            else if (avgResp <= 720) responseScore = 0.7;
+            else if (avgResp <= 1440) responseScore = 0.4;
+            else responseScore = 0.15;
+          }
+
+          const composite =
+            ratingScore * 0.35 +
+            reviewScore * 0.15 +
+            responseScore * 0.20 +
+            (isVerified ? 0.15 : 0) +
+            (isFeatured ? 0.10 : 0) +
+            (hasLeads ? 0.05 : 0);
+
+          return { ...a, _relevance: composite };
+        });
+
+        scored.sort((a: { _relevance: number }, b: { _relevance: number }) => b._relevance - a._relevance);
+        advisors = scored.slice(offset, offset + limit);
+      } else {
+        advisors = data ?? [];
+      }
       total = count ?? advisors.length;
     }
 

--- a/app/find-advisor/page.tsx
+++ b/app/find-advisor/page.tsx
@@ -252,6 +252,7 @@ interface MatchedAdvisor {
   offer_text?: string;
   offer_active?: boolean;
   initial_consultation_free?: boolean;
+  avg_response_minutes?: number | null;
 }
 
 function FindAdvisorResults({ selectedType, answers, getResultUrl, getResultLabel, onRestart }: {
@@ -270,7 +271,7 @@ function FindAdvisorResults({ selectedType, answers, getResultUrl, getResultLabe
     const params = new URLSearchParams({
       type: selectedType,
       limit: "6",
-      sort: "rating",
+      sort: "relevance",
       verified: "true",
     });
     if (answers.state && answers.state !== "other" && answers.state !== "any") {
@@ -360,6 +361,9 @@ function FindAdvisorResults({ selectedType, answers, getResultUrl, getResultLabe
                   <div className="flex items-center gap-2 mb-0.5">
                     {i === 0 && <span className="text-[0.56rem] font-bold px-1.5 py-0.5 bg-amber-100 text-amber-700 rounded">Top Match</span>}
                     {advisor.verified && <span className="text-[0.56rem] font-bold px-1.5 py-0.5 bg-blue-100 text-blue-700 rounded">Verified</span>}
+                    {advisor.avg_response_minutes != null && advisor.avg_response_minutes <= 120 && (
+                      <span className="text-[0.56rem] font-bold px-1.5 py-0.5 bg-emerald-100 text-emerald-700 rounded flex items-center gap-0.5"><Icon name="zap" size={9} />Fast</span>
+                    )}
                     {advisor.initial_consultation_free && <span className="text-[0.56rem] font-bold px-1.5 py-0.5 bg-emerald-100 text-emerald-700 rounded">Free Consult</span>}
                   </div>
                   <p className="text-sm font-bold text-slate-900 group-hover:text-violet-700 transition-colors truncate">{advisor.name}</p>


### PR DESCRIPTION
## Summary
- **Performance badges**: "Responds Fast" (green zap) shown on advisor profiles and directory cards for advisors with avg response under 2hrs. "Responds within 24hrs" (blue clock) on profiles for same-day responders.
- **Relevance-weighted search**: New composite scoring algorithm ranks advisors by rating (35%), response speed (20%), review volume (15%), verified status (15%), featured (10%), and lead activity (5%). Find-advisor wizard uses this by default.
- Better advisors now rank higher in match results → more leads → quality flywheel

## Test plan
- [ ] Advisor profile shows "Responds Fast" badge when avg_response_minutes <= 120
- [ ] Directory cards show green "Fast" badge for responsive advisors
- [ ] Find-advisor results show "Fast" badge inline with Verified/Free Consult
- [ ] `/api/advisor-search?sort=relevance` returns advisors ranked by composite score
- [ ] Find-advisor wizard uses relevance sort (not just rating)

https://claude.ai/code/session_01Kj25hcfBsqaR9f8GRPiWod