### PR TITLE
Homepage redesign + lead pipeline optimizations

### DIFF
--- a/app/api/cron/post-enquiry-drip/route.ts
+++ b/app/api/cron/post-enquiry-drip/route.ts
@@ -350,5 +350,96 @@ export async function GET(req: Request) {
     }
   }
 
-  return NextResponse.json({ sent, checked: (leads || []).length });
+  // ═══════════════════════════════════════════════
+  // ADVISOR NUDGE: 3 days after lead creation, ask the advisor for an outcome update
+  // ═══════════════════════════════════════════════
+
+  const threeDaysAgo = new Date(Date.now() - 3 * 86400000).toISOString();
+  const tenDaysAgo = new Date(Date.now() - 10 * 86400000).toISOString();
+
+  const { data: nudgeLeads } = await supabase
+    .from("professional_leads")
+    .select("id, user_name, professional_id, created_at")
+    .eq("status", "new")
+    .is("advisor_nudge_sent_at", null)
+    .lte("created_at", threeDaysAgo)
+    .gte("created_at", tenDaysAgo)
+    .order("created_at", { ascending: true })
+    .limit(30);
+
+  // Fetch advisor details for nudge leads
+  const nudgeProIds = [...new Set((nudgeLeads || []).map(l => l.professional_id))];
+  const { data: nudgePros } = nudgeProIds.length > 0
+    ? await supabase.from("professionals").select("id, name, email").in("id", nudgeProIds)
+    : { data: [] };
+  const nudgeProMap = new Map((nudgePros || []).map(p => [p.id, p]));
+
+  let advisorNudgesSent = 0;
+
+  for (const lead of nudgeLeads || []) {
+    const advisor = nudgeProMap.get(lead.professional_id);
+    if (!advisor?.email) continue;
+
+    const userName = lead.user_name || "a potential client";
+    const createdDate = new Date(lead.created_at).toLocaleDateString("en-AU", {
+      day: "numeric",
+      month: "long",
+      year: "numeric",
+    });
+
+    const nudgeSubject = `Did you contact ${userName}? Update your lead status`;
+    const nudgeHtml = `
+      <div style="font-family:Arial,sans-serif;max-width:560px;margin:0 auto">
+        <h2 style="color:#0f172a;font-size:18px">Lead Status Update</h2>
+        <p style="color:#475569;font-size:14px;line-height:1.6">
+          Hi ${advisor.name || "there"},
+        </p>
+        <p style="color:#475569;font-size:14px;line-height:1.6">
+          You received an enquiry from <strong>${userName}</strong> on ${createdDate}.
+          Have you had a chance to follow up?
+        </p>
+        <p style="color:#475569;font-size:14px;line-height:1.6">
+          Please let us know the outcome so we can keep your lead pipeline accurate:
+        </p>
+        <div style="margin:20px 0;text-align:center">
+          <a href="${siteUrl}/advisor-portal?action=contacted&lead=${lead.id}" style="display:inline-block;padding:12px 20px;background:#7c3aed;color:white;border-radius:8px;text-decoration:none;font-size:14px;font-weight:600;margin:6px">
+            I contacted them
+          </a>
+          <a href="${siteUrl}/advisor-portal?action=converted&lead=${lead.id}" style="display:inline-block;padding:12px 20px;background:#16a34a;color:white;border-radius:8px;text-decoration:none;font-size:14px;font-weight:600;margin:6px">
+            Converted to client
+          </a>
+          <a href="${siteUrl}/advisor-portal?action=lost&lead=${lead.id}" style="display:inline-block;padding:12px 20px;background:#64748b;color:white;border-radius:8px;text-decoration:none;font-size:14px;font-weight:600;margin:6px">
+            Not interested
+          </a>
+        </div>
+        <p style="color:#94a3b8;font-size:12px;margin-top:20px">
+          Keeping your leads up to date helps us send you better-matched enquiries.
+        </p>
+        ${notificationFooter()}
+      </div>
+    `;
+
+    try {
+      await fetch("https://api.resend.com/emails", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${RESEND_API_KEY}` },
+        body: JSON.stringify({
+          from: "Invest.com.au <hello@invest.com.au>",
+          to: advisor.email,
+          subject: nudgeSubject,
+          html: nudgeHtml,
+        }),
+      });
+
+      await supabase.from("professional_leads").update({
+        advisor_nudge_sent_at: new Date().toISOString(),
+      }).eq("id", lead.id);
+
+      advisorNudgesSent++;
+    } catch (e) {
+      log.error("Advisor nudge email failed", { lead: lead.id, error: e instanceof Error ? e.message : String(e) });
+    }
+  }
+
+  return NextResponse.json({ sent, checked: (leads || []).length, advisor_nudges_sent: advisorNudgesSent });
 }

--- a/app/api/cron/weekly-rate-update/route.ts
+++ b/app/api/cron/weekly-rate-update/route.ts
@@ -1,0 +1,233 @@
+import { createAdminClient } from "@/lib/supabase/admin";
+import { NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
+import { notificationFooter } from "@/lib/email-templates";
+
+const log = logger("cron-weekly-rate-update");
+
+export const runtime = "edge";
+export const maxDuration = 30;
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://invest-com-au.vercel.app";
+
+const CALCULATOR_SOURCES = [
+  "savings-calculator",
+  "switching_calculator",
+  "portfolio-calculator",
+] as const;
+
+type CalculatorSource = (typeof CALCULATOR_SOURCES)[number];
+
+const SOURCE_CONFIG: Record<
+  CalculatorSource,
+  { headline: string; cta: string; path: string }
+> = {
+  "savings-calculator": {
+    headline: "Savings rates have moved — is your account still the best?",
+    cta: "Recalculate Your Savings",
+    path: "/savings-calculator",
+  },
+  switching_calculator: {
+    headline:
+      "Broker fees have been updated — are you still overpaying?",
+    cta: "Recalculate Switching Costs",
+    path: "/switching-calculator",
+  },
+  "portfolio-calculator": {
+    headline:
+      "Platform fees have changed — check your portfolio costs",
+    cta: "Recalculate Portfolio Fees",
+    path: "/portfolio-calculator",
+  },
+};
+
+function formatCurrency(value: number): string {
+  return new Intl.NumberFormat("en-AU", {
+    style: "currency",
+    currency: "AUD",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+function buildPersonalLine(
+  source: CalculatorSource,
+  context: Record<string, unknown> | null,
+): string {
+  if (!context) return "";
+
+  if (source === "savings-calculator" && typeof context.balance === "number") {
+    return `You previously checked your ${formatCurrency(context.balance)} balance — let's see if a better rate is available now.`;
+  }
+  if (
+    source === "switching_calculator" &&
+    typeof context.currentBroker === "string"
+  ) {
+    return `You were comparing costs from ${context.currentBroker} — fees may have shifted since then.`;
+  }
+  if (
+    source === "portfolio-calculator" &&
+    typeof context.portfolioValue === "number"
+  ) {
+    return `You checked costs on a ${formatCurrency(context.portfolioValue)} portfolio — updated fees could change the picture.`;
+  }
+  return "";
+}
+
+function buildEmailHtml(
+  firstName: string,
+  source: CalculatorSource,
+  context: Record<string, unknown> | null,
+  email: string,
+): string {
+  const config = SOURCE_CONFIG[source];
+  const personalLine = buildPersonalLine(source, context);
+
+  return `
+    <div style="font-family:Arial,sans-serif;max-width:560px;margin:0 auto">
+      <h2 style="color:#0f172a;font-size:18px">${config.headline}</h2>
+      <p style="color:#475569;font-size:14px;line-height:1.6">
+        Hi ${firstName},
+      </p>
+      ${
+        personalLine
+          ? `<p style="color:#475569;font-size:14px;line-height:1.6">${personalLine}</p>`
+          : ""
+      }
+      <p style="color:#475569;font-size:14px;line-height:1.6">
+        Rates and fees across Australian platforms are updated regularly.
+        Since your last visit, some numbers have changed — it's worth running your calculation again to make sure you're still getting the best deal.
+      </p>
+      <div style="text-align:center;margin:24px 0">
+        <a href="${SITE_URL}${config.path}" style="display:inline-block;padding:12px 32px;background:#0f172a;color:white;border-radius:10px;text-decoration:none;font-size:14px;font-weight:600">
+          ${config.cta} &rarr;
+        </a>
+      </div>
+      <hr style="border:none;border-top:1px solid #e2e8f0;margin:20px 0" />
+      <div style="background:#f8fafc;border-radius:8px;padding:16px;border:1px solid #e2e8f0">
+        <p style="font-size:13px;font-weight:700;color:#0f172a;margin:0 0 6px">Want personalised guidance?</p>
+        <p style="font-size:13px;color:#64748b;margin:0 0 10px">Talk to a verified financial advisor who can review your situation for free.</p>
+        <a href="${SITE_URL}/find-advisor" style="color:#7c3aed;font-size:13px;font-weight:600;text-decoration:none">
+          Talk to an Advisor &rarr;
+        </a>
+      </div>
+      ${notificationFooter(email)}
+    </div>
+  `;
+}
+
+export async function GET(req: Request) {
+  const authHeader = req.headers.get("authorization");
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const RESEND_API_KEY = process.env.RESEND_API_KEY;
+  if (!RESEND_API_KEY) {
+    return NextResponse.json({ error: "No RESEND_API_KEY" }, { status: 500 });
+  }
+
+  const supabase = createAdminClient();
+
+  const sevenDaysAgo = new Date(
+    Date.now() - 7 * 86400000,
+  ).toISOString();
+
+  // Fetch calculator email captures older than 7 days
+  const { data: captures, error: captureErr } = await supabase
+    .from("email_captures")
+    .select("id, email, name, source, context, created_at")
+    .in("source", [...CALCULATOR_SOURCES])
+    .lte("created_at", sevenDaysAgo)
+    .order("created_at", { ascending: true })
+    .limit(100);
+
+  if (captureErr) {
+    log.error("Failed to fetch email captures", { error: captureErr.message });
+    return NextResponse.json(
+      { error: "DB query failed" },
+      { status: 500 },
+    );
+  }
+
+  if (!captures || captures.length === 0) {
+    return NextResponse.json({ sent: 0, checked: 0, message: "No eligible captures" });
+  }
+
+  const captureIds = captures.map((c) => c.id);
+
+  // Check which have already been sent in the last 7 days
+  const { data: recentLogs } = await supabase
+    .from("weekly_rate_drip_log")
+    .select("email_capture_id")
+    .in("email_capture_id", captureIds)
+    .gte("sent_at", sevenDaysAgo);
+
+  const alreadySent = new Set(
+    (recentLogs || []).map((l) => l.email_capture_id),
+  );
+
+  let sent = 0;
+  let skipped = 0;
+
+  for (const capture of captures) {
+    if (alreadySent.has(capture.id)) {
+      skipped++;
+      continue;
+    }
+
+    const source = capture.source as CalculatorSource;
+    if (!SOURCE_CONFIG[source]) {
+      skipped++;
+      continue;
+    }
+
+    const firstName =
+      capture.name?.split(" ")[0] || "there";
+    const context = (capture.context as Record<string, unknown>) || null;
+
+    const subject = `${firstName}, rates have changed — check your numbers again`;
+    const html = buildEmailHtml(firstName, source, context, capture.email);
+
+    try {
+      const res = await fetch("https://api.resend.com/emails", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${RESEND_API_KEY}`,
+        },
+        body: JSON.stringify({
+          from: "Invest.com.au <hello@invest.com.au>",
+          to: capture.email,
+          subject,
+          html,
+        }),
+      });
+
+      if (res.ok) {
+        await supabase.from("weekly_rate_drip_log").insert({
+          email_capture_id: capture.id,
+          sent_at: new Date().toISOString(),
+        });
+        sent++;
+      } else {
+        log.error("Resend API error", {
+          captureId: capture.id,
+          status: res.status,
+        });
+      }
+    } catch (e) {
+      log.error("Weekly rate email failed", {
+        captureId: capture.id,
+        error: e instanceof Error ? e.message : String(e),
+      });
+    }
+  }
+
+  return NextResponse.json({
+    sent,
+    skipped,
+    checked: captures.length,
+    timestamp: new Date().toISOString(),
+  });
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -207,9 +207,9 @@ export default async function HomePage() {
         </div>
       </section>
 
-      {/* ═══════ 1b. SERVICE SELECTOR — "What do you need help with?" ═══════ */}
+      {/* ═══════ 1b. GUIDED CONCIERGE — "What's your goal?" ═══════ */}
       <ScrollFadeIn>
-        <section className="py-6 md:py-14 bg-slate-50 border-b border-slate-100">
+        <section className="py-6 md:py-12 bg-slate-50 border-b border-slate-100">
           <div className="container-custom">
             <HomepageServiceSelector />
           </div>
@@ -220,89 +220,6 @@ export default async function HomePage() {
       <AdvisorDirectory
         advisors={(featuredAdvisors as { slug: string; name: string; firm_name?: string; type: string; location_display?: string; location_state?: string; rating: number; review_count: number; photo_url?: string; specialties: string[]; verified?: boolean }[]) || []}
       />
-
-      {/* ═══════ 3. CROSS-SELLING JOURNEY — immediately after advisors ═══════ */}
-      <ScrollFadeIn>
-        <section className="py-3 md:py-10 bg-white">
-          <div className="container-custom">
-            <div className="bg-white border border-slate-200 rounded-xl p-4 md:p-6">
-              <h2 className="text-base md:text-xl font-bold text-slate-900 mb-1">Your financial journey doesn&apos;t stop at one step</h2>
-              <p className="text-xs md:text-sm text-slate-500 mb-4 md:mb-6">Most property buyers need multiple professionals. Here&apos;s the typical path:</p>
-              <div className="grid grid-cols-2 md:grid-cols-4 gap-2 md:gap-3">
-                {[
-                  { step: "1", label: "Mortgage Broker", desc: "Secure your home loan", href: "/advisors/mortgage-brokers", color: "bg-rose-50 border-rose-200 text-rose-700" },
-                  { step: "2", label: "Buyer's Agent", desc: "Find the right property", href: "/advisors/buyers-agents", color: "bg-teal-50 border-teal-200 text-teal-700" },
-                  { step: "3", label: "Insurance Broker", desc: "Protect your investment", href: "/advisors/insurance-brokers", color: "bg-sky-50 border-sky-200 text-sky-700" },
-                  { step: "4", label: "Tax Agent", desc: "Structure for efficiency", href: "/advisors/tax-agents", color: "bg-amber-50 border-amber-200 text-amber-700" },
-                ].map((item) => (
-                  <Link key={item.step} href={item.href} className={`relative border rounded-xl p-3 md:p-4 ${item.color} hover:shadow-md transition-all group`}>
-                    <span className="absolute -top-2 -left-2 w-6 h-6 bg-slate-900 text-white text-[0.6rem] font-bold rounded-full flex items-center justify-center shadow-sm">{item.step}</span>
-                    <p className="font-bold text-xs md:text-sm mt-1">{item.label}</p>
-                    <p className="text-[0.65rem] md:text-xs opacity-80 mt-0.5">{item.desc}</p>
-                  </Link>
-                ))}
-              </div>
-            </div>
-          </div>
-        </section>
-      </ScrollFadeIn>
-
-      {/* ═══════ 4. HIGH-VALUE VERTICALS — reinforces the journey steps ═══════ */}
-      <ScrollFadeIn>
-        <section className="py-3 md:py-10 bg-white">
-          <div className="container-custom">
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-3 md:gap-4">
-              <Link href="/advisors/mortgage-brokers" className="group bg-gradient-to-br from-rose-50 to-white border border-rose-200 rounded-xl p-4 md:p-5 hover:shadow-md hover:border-rose-300 transition-all">
-                <div className="flex items-center gap-3 mb-2">
-                  <div className="w-10 h-10 rounded-lg bg-rose-100 flex items-center justify-center shrink-0">
-                    <Icon name="landmark" size={20} className="text-rose-600" />
-                  </div>
-                  <div>
-                    <h3 className="text-sm md:text-base font-bold text-slate-900">Find a Mortgage Broker</h3>
-                    <p className="text-[0.65rem] md:text-xs text-slate-500">Free service — brokers are paid by lenders</p>
-                  </div>
-                </div>
-                <p className="text-xs text-slate-600 leading-relaxed">Compare rates from 30+ lenders. Our brokers help with home loans, refinancing, investment loans, and first home buyer grants.</p>
-                <span className="inline-flex items-center gap-1 mt-2 text-xs font-semibold text-rose-600 group-hover:text-rose-700">
-                  Browse mortgage brokers <span className="group-hover:translate-x-0.5 transition-transform">&rarr;</span>
-                </span>
-              </Link>
-
-              <Link href="/advisors/buyers-agents" className="group bg-gradient-to-br from-teal-50 to-white border border-teal-200 rounded-xl p-4 md:p-5 hover:shadow-md hover:border-teal-300 transition-all">
-                <div className="flex items-center gap-3 mb-2">
-                  <div className="w-10 h-10 rounded-lg bg-teal-100 flex items-center justify-center shrink-0">
-                    <Icon name="search" size={20} className="text-teal-600" />
-                  </div>
-                  <div>
-                    <h3 className="text-sm md:text-base font-bold text-slate-900">Find a Buyer&apos;s Agent</h3>
-                    <p className="text-[0.65rem] md:text-xs text-slate-500">Expert negotiation &amp; off-market access</p>
-                  </div>
-                </div>
-                <p className="text-xs text-slate-600 leading-relaxed">Independent buyer&apos;s advocates who work for you — not the seller. Property search, auction bidding, and due diligence.</p>
-                <span className="inline-flex items-center gap-1 mt-2 text-xs font-semibold text-teal-600 group-hover:text-teal-700">
-                  Browse buyer&apos;s agents <span className="group-hover:translate-x-0.5 transition-transform">&rarr;</span>
-                </span>
-              </Link>
-
-              <Link href="/advisors/insurance-brokers" className="group bg-gradient-to-br from-sky-50 to-white border border-sky-200 rounded-xl p-4 md:p-5 hover:shadow-md hover:border-sky-300 transition-all">
-                <div className="flex items-center gap-3 mb-2">
-                  <div className="w-10 h-10 rounded-lg bg-sky-100 flex items-center justify-center shrink-0">
-                    <Icon name="shield" size={20} className="text-sky-600" />
-                  </div>
-                  <div>
-                    <h3 className="text-sm md:text-base font-bold text-slate-900">Find an Insurance Broker</h3>
-                    <p className="text-[0.65rem] md:text-xs text-slate-500">Life, income protection &amp; business cover</p>
-                  </div>
-                </div>
-                <p className="text-xs text-slate-600 leading-relaxed">Compare policies from 10+ insurers. Is your super insurance enough? Our brokers find the gaps and fix them — free.</p>
-                <span className="inline-flex items-center gap-1 mt-2 text-xs font-semibold text-sky-600 group-hover:text-sky-700">
-                  Browse insurance brokers <span className="group-hover:translate-x-0.5 transition-transform">&rarr;</span>
-                </span>
-              </Link>
-            </div>
-          </div>
-        </section>
-      </ScrollFadeIn>
 
       {/* ═══════ 11. ARTICLES & GUIDES ═══════ */}
       {(articles as Article[])?.length > 0 && (

--- a/app/portfolio-calculator/PortfolioCalculatorClient.tsx
+++ b/app/portfolio-calculator/PortfolioCalculatorClient.tsx
@@ -10,6 +10,7 @@ import type { Broker } from "@/lib/types";
 import LeadMagnet from "@/components/LeadMagnet";
 import AdvisorPrompt from "@/components/AdvisorPrompt";
 import { storeQualificationData } from "@/lib/qualification-store";
+import AdvisorMatchCTA from "@/components/AdvisorMatchCTA";
 
 type Holding = {
   id: string;
@@ -346,6 +347,14 @@ export default function PortfolioCalculatorClient({ brokers, inline }: { brokers
                 <AdvisorPrompt context="tax" heading="Paying over $500/year in trading fees?" description="A tax agent can help you claim investment-related expenses as deductions, potentially saving more than the fees themselves." />
               </div>
             )}
+
+            <div className="mb-6">
+              <AdvisorMatchCTA
+                needKey="tax"
+                headline="Could you be claiming more on your investment fees?"
+                description="A tax agent can help you maximise deductions on brokerage, platform fees, and investment-related expenses."
+              />
+            </div>
 
             <LeadMagnet />
           </>

--- a/app/savings-calculator/SavingsCalculatorClient.tsx
+++ b/app/savings-calculator/SavingsCalculatorClient.tsx
@@ -7,6 +7,7 @@ import SocialProofCounter from "@/components/SocialProofCounter";
 import { trackEvent, trackClick, getAffiliateLink, AFFILIATE_REL, trackPageDuration } from "@/lib/tracking";
 import { getStoredUtm } from "@/components/UtmCapture";
 import { storeQualificationData } from "@/lib/qualification-store";
+import AdvisorMatchCTA from "@/components/AdvisorMatchCTA";
 
 type Account = {
   id: number; slug: string; name: string; platform_type: string;
@@ -259,6 +260,14 @@ export default function SavingsCalculatorClient({ accounts, inline }: { accounts
                 </Link>
               </div>
             )}
+            <div className="mb-6">
+              <AdvisorMatchCTA
+                needKey="planning"
+                headline="Want a personalised savings strategy?"
+                description="A financial planner can help you structure your savings across accounts, super, and investments to maximise returns and minimise tax."
+              />
+            </div>
+
             <div className="bg-white border border-slate-200 rounded-2xl p-5 md:p-8">
               <h2 className="text-lg font-bold text-slate-900 mb-3">Why Your Savings Rate Matters</h2>
               <p className="text-sm text-slate-600 leading-relaxed mb-4">

--- a/app/switching-calculator/SwitchingCalculatorClient.tsx
+++ b/app/switching-calculator/SwitchingCalculatorClient.tsx
@@ -9,6 +9,7 @@ import { getAffiliateLink, getBenefitCta, renderStars, AFFILIATE_REL, trackClick
 import { getStoredUtm } from "@/components/UtmCapture";
 import type { Broker } from "@/lib/types";
 import { storeQualificationData } from "@/lib/qualification-store";
+import AdvisorMatchCTA from "@/components/AdvisorMatchCTA";
 
 function parseFee(feeStr: string | null | undefined): { flat: number; pct: number } {
   if (!feeStr) return { flat: 0, pct: 0 };
@@ -239,6 +240,17 @@ export default function SwitchingCalculatorClient({ brokers, inline }: { brokers
                 </a>
               </div>
             )}
+          </div>
+        )}
+
+        {/* Advisor match CTA */}
+        {showResults && (
+          <div className="mt-6">
+            <AdvisorMatchCTA
+              needKey="planning"
+              headline="Need help optimising your investment setup?"
+              description="A financial planner can review your broker, portfolio structure, and tax position to make sure you're not leaving money on the table."
+            />
           </div>
         )}
 

--- a/components/HomepageServiceSelector.tsx
+++ b/components/HomepageServiceSelector.tsx
@@ -1,59 +1,154 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
 import Icon from "@/components/Icon";
 
-const services = [
-  { label: "Home Loan / Refinancing", desc: "Find the best mortgage rate for your situation", key: "mortgage", icon: "landmark", color: "bg-rose-50 text-rose-600" },
-  { label: "Buyers Agent", desc: "Help finding and negotiating property purchases", key: "buyers", icon: "search", color: "bg-teal-50 text-teal-600" },
-  { label: "Financial Planning", desc: "Retirement, wealth building, or investment strategy", key: "planning", icon: "trending-up", color: "bg-violet-50 text-violet-600" },
-  { label: "Insurance", desc: "Life, TPD, income protection, or business cover", key: "insurance", icon: "shield", color: "bg-sky-50 text-sky-600" },
-  { label: "SMSF Setup & Management", desc: "Set up or manage a self-managed super fund", key: "smsf", icon: "building", color: "bg-blue-50 text-blue-600" },
-  { label: "Tax Optimisation", desc: "Minimise tax on investments and capital gains", key: "tax", icon: "calculator", color: "bg-amber-50 text-amber-600" },
-  { label: "Wealth Management", desc: "Portfolio management for high-net-worth investors", key: "wealth", icon: "briefcase", color: "bg-indigo-50 text-indigo-600" },
-  { label: "Estate Planning", desc: "Protect your assets and plan for the future", key: "estate", icon: "file-text", color: "bg-slate-100 text-slate-600" },
-  { label: "Property Investment", desc: "Advice on buying investment property", key: "property", icon: "home", color: "bg-emerald-50 text-emerald-600" },
-  { label: "Real Estate Agent", desc: "Selling or listing your property", key: "realestate", icon: "map-pin", color: "bg-lime-50 text-lime-600" },
-  { label: "Crypto & Digital Assets", desc: "Crypto portfolio strategy and tax planning", key: "crypto", icon: "bitcoin", color: "bg-orange-50 text-orange-600" },
-  { label: "Aged Care", desc: "Navigate aged care options, costs, and subsidies", key: "agedcare", icon: "heart", color: "bg-pink-50 text-pink-600" },
-  { label: "Debt Help", desc: "Debt consolidation, budgeting, and financial recovery", key: "debt", icon: "credit-card", color: "bg-red-50 text-red-600" },
+/**
+ * Life-events concierge widget — progressive disclosure.
+ * Step 1: Pick a broad life event (4 options, not 13).
+ * Step 2: See the 2-3 relevant professionals for that event.
+ * Solves Hick's Law / choice paralysis on the homepage.
+ */
+
+interface Professional {
+  label: string;
+  desc: string;
+  needKey: string;
+  icon: string;
+  color: string;
+}
+
+interface LifeEvent {
+  key: string;
+  label: string;
+  subtitle: string;
+  icon: string;
+  color: string;
+  bgColor: string;
+  professionals: Professional[];
+}
+
+const LIFE_EVENTS: LifeEvent[] = [
+  {
+    key: "property",
+    label: "Buy Property",
+    subtitle: "Home loan, buyers agent, insurance",
+    icon: "home",
+    color: "text-rose-600",
+    bgColor: "bg-rose-50 border-rose-200 hover:border-rose-300",
+    professionals: [
+      { label: "Mortgage Broker", desc: "Compare rates from 30+ lenders — free, paid by lenders", needKey: "mortgage", icon: "landmark", color: "bg-rose-50 text-rose-600" },
+      { label: "Buyer's Agent", desc: "Independent negotiation, off-market access, due diligence", needKey: "buyers", icon: "search", color: "bg-teal-50 text-teal-600" },
+      { label: "Insurance Broker", desc: "Home, contents, life, and income protection cover", needKey: "insurance", icon: "shield", color: "bg-sky-50 text-sky-600" },
+    ],
+  },
+  {
+    key: "wealth",
+    label: "Grow Wealth",
+    subtitle: "Financial planning, tax, investing",
+    icon: "trending-up",
+    color: "text-violet-600",
+    bgColor: "bg-violet-50 border-violet-200 hover:border-violet-300",
+    professionals: [
+      { label: "Financial Planner", desc: "Retirement, super, wealth building — personalised strategy", needKey: "planning", icon: "trending-up", color: "bg-violet-50 text-violet-600" },
+      { label: "Tax Agent", desc: "Minimise tax on investments, capital gains, and deductions", needKey: "tax", icon: "calculator", color: "bg-amber-50 text-amber-600" },
+      { label: "Wealth Manager", desc: "Portfolio management for high-net-worth investors", needKey: "wealth", icon: "briefcase", color: "bg-indigo-50 text-indigo-600" },
+    ],
+  },
+  {
+    key: "protect",
+    label: "Protect What Matters",
+    subtitle: "Estate, insurance, aged care",
+    icon: "shield-check",
+    color: "text-emerald-600",
+    bgColor: "bg-emerald-50 border-emerald-200 hover:border-emerald-300",
+    professionals: [
+      { label: "Estate Planner", desc: "Wills, trusts, powers of attorney, succession planning", needKey: "estate", icon: "file-text", color: "bg-slate-100 text-slate-600" },
+      { label: "Insurance Broker", desc: "Life, income protection, business, and key person cover", needKey: "insurance", icon: "shield", color: "bg-sky-50 text-sky-600" },
+      { label: "Aged Care Advisor", desc: "Navigate costs, subsidies, and care options", needKey: "agedcare", icon: "heart", color: "bg-pink-50 text-pink-600" },
+    ],
+  },
+  {
+    key: "business",
+    label: "Business & Specialist",
+    subtitle: "SMSF, crypto, debt, property investment",
+    icon: "building",
+    color: "text-amber-600",
+    bgColor: "bg-amber-50 border-amber-200 hover:border-amber-300",
+    professionals: [
+      { label: "SMSF Accountant", desc: "Setup, compliance, audit, and investment strategy", needKey: "smsf", icon: "building", color: "bg-blue-50 text-blue-600" },
+      { label: "Property Advisor", desc: "Investment property strategy and portfolio building", needKey: "property", icon: "home", color: "bg-emerald-50 text-emerald-600" },
+      { label: "Crypto Advisor", desc: "Portfolio strategy, DeFi, and tax planning", needKey: "crypto", icon: "bitcoin", color: "bg-orange-50 text-orange-600" },
+    ],
+  },
 ];
 
 export default function HomepageServiceSelector() {
+  const [selected, setSelected] = useState<string | null>(null);
+
+  const activeEvent = LIFE_EVENTS.find((e) => e.key === selected);
+
   return (
     <div className="max-w-2xl mx-auto">
-      <h2 className="text-2xl md:text-3xl font-extrabold text-slate-900 mb-1">
-        What do you need help with?
+      <h2 className="text-xl md:text-2xl font-extrabold text-slate-900 mb-1 text-center">
+        What&apos;s your goal?
       </h2>
-      <p className="text-sm text-slate-500 mb-5">
-        We&apos;ll match you with the right type of professional.
+      <p className="text-sm text-slate-500 mb-5 text-center">
+        Pick a goal and we&apos;ll show you the right professionals.
       </p>
 
-      <div className="space-y-2">
-        {services.map((s) => (
-          <Link
-            key={s.key}
-            href={`/find-advisor?need=${s.key}`}
-            className="flex items-center gap-3 p-3 md:p-3.5 bg-white border border-slate-200 rounded-xl hover:border-violet-300 hover:shadow-sm transition-all group"
+      {/* Step 1: Life event cards */}
+      <div className="grid grid-cols-2 gap-2 md:gap-3">
+        {LIFE_EVENTS.map((event) => (
+          <button
+            key={event.key}
+            onClick={() => setSelected(selected === event.key ? null : event.key)}
+            className={`text-left border rounded-xl p-3 md:p-4 transition-all ${
+              selected === event.key
+                ? `${event.bgColor} ring-2 ring-offset-1 ring-slate-300 shadow-sm`
+                : "bg-white border-slate-200 hover:border-slate-300 hover:shadow-sm"
+            }`}
           >
-            <div className={`w-9 h-9 rounded-lg flex items-center justify-center shrink-0 ${s.color.split(" ")[0]}`}>
-              <Icon name={s.icon} size={18} className={s.color.split(" ")[1]} />
+            <div className="flex items-center gap-2 mb-1">
+              <Icon name={event.icon} size={18} className={selected === event.key ? event.color : "text-slate-400"} />
+              <span className="text-sm md:text-base font-bold text-slate-900">{event.label}</span>
             </div>
-            <div className="flex-1 min-w-0">
-              <span className="text-sm font-semibold text-slate-800 block">{s.label}</span>
-              <span className="text-[0.62rem] md:text-xs text-slate-500 block mt-0.5">{s.desc}</span>
-            </div>
-            <div className="w-5 h-5 rounded-full border-2 border-slate-200 shrink-0 group-hover:border-violet-300" />
-          </Link>
+            <p className="text-[0.65rem] md:text-xs text-slate-500 leading-snug">{event.subtitle}</p>
+          </button>
         ))}
       </div>
+
+      {/* Step 2: Reveal professionals (progressive disclosure) */}
+      {activeEvent && (
+        <div className="mt-4 space-y-2 animate-in fade-in slide-in-from-top-2 duration-200">
+          {activeEvent.professionals.map((pro) => (
+            <Link
+              key={pro.needKey}
+              href={`/find-advisor?need=${pro.needKey}`}
+              className="flex items-center gap-3 p-3 md:p-3.5 bg-white border border-slate-200 rounded-xl hover:border-violet-300 hover:shadow-sm transition-all group"
+            >
+              <div className={`w-9 h-9 rounded-lg flex items-center justify-center shrink-0 ${pro.color.split(" ")[0]}`}>
+                <Icon name={pro.icon} size={18} className={pro.color.split(" ")[1]} />
+              </div>
+              <div className="flex-1 min-w-0">
+                <span className="text-sm font-semibold text-slate-800 block">{pro.label}</span>
+                <span className="text-[0.62rem] md:text-xs text-slate-500 block mt-0.5">{pro.desc}</span>
+              </div>
+              <span className="text-xs font-semibold text-violet-600 shrink-0 group-hover:translate-x-0.5 transition-transform">
+                Match &rarr;
+              </span>
+            </Link>
+          ))}
+        </div>
+      )}
 
       <div className="text-center mt-5">
         <Link
           href="/find-advisor"
           className="inline-flex items-center gap-1.5 text-sm font-semibold text-violet-600 hover:text-violet-700 transition-colors"
         >
-          Not sure? Let us help you decide <span>&rarr;</span>
+          Not sure? Take the full quiz <span>&rarr;</span>
         </Link>
       </div>
     </div>

--- a/supabase/migrations/20260316_add_advisor_nudge_tracking.sql
+++ b/supabase/migrations/20260316_add_advisor_nudge_tracking.sql
@@ -1,0 +1,1 @@
+ALTER TABLE professional_leads ADD COLUMN IF NOT EXISTS advisor_nudge_sent_at TIMESTAMPTZ;

--- a/supabase/migrations/20260316_add_weekly_rate_drip_log.sql
+++ b/supabase/migrations/20260316_add_weekly_rate_drip_log.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS weekly_rate_drip_log (
+  id BIGSERIAL PRIMARY KEY,
+  email_capture_id BIGINT NOT NULL,
+  sent_at TIMESTAMPTZ DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_weekly_rate_drip_email ON weekly_rate_drip_log(email_capture_id);
+ALTER TABLE weekly_rate_drip_log ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
## Summary
- **Homepage life-events concierge**: Replace 13-service grid with progressive disclosure — 4 life events (Buy Property, Grow Wealth, Protect What Matters, Business & Specialist) that reveal 2-3 relevant professionals each. Solves Hick's Law / choice paralysis.
- **AdvisorMatchCTA on calculators**: Place "Get Matched Free" CTAs on savings, switching, and portfolio calculator result pages to convert calculator users into advisor leads
- **Cross-sell automation**: Day 14 dedicated cross-sell email in post-enquiry drip (e.g. mortgage lead gets buyers agent + insurance broker suggestions)
- **Advisor outcome nudge**: Day 3 email to advisors asking them to update lead status with one-click buttons (contacted/converted/not interested)
- **Weekly rate update cron**: Personalized weekly emails to calculator email captures with updated rates/fees
- **Advisor performance scoring**: Composite relevance sort (rating 35%, response speed 20%, reviews 15%, verified 15%, featured 10%, active 5%) + "Responds Fast" badges on profiles and directory cards
- **Email capture context**: Calculator inputs stored as JSONB alongside email captures for personalized nurture

## Test plan
- [ ] Homepage loads with 4 life-event cards, clicking reveals professionals with links to /find-advisor?need=X
- [ ] Calculator pages show AdvisorMatchCTA after results
- [ ] npm run build passes
- [ ] Post-enquiry drip includes cross-sell email at Day 14 and advisor nudge at Day 3
- [ ] Weekly rate update cron processes calculator email captures
- [ ] Advisor search returns results sorted by composite relevance score
- [ ] Run pending migrations on Supabase (advisor_nudge_tracking, weekly_rate_drip_log, email_capture_context)

https://claude.ai/code/session_01Kj25hcfBsqaR9f8GRPiWod