### PR TITLE
feat: smart matching — dedup, rematch, persistence

### DIFF
--- a/app/advisor/[slug]/AdvisorProfileClient.tsx
+++ b/app/advisor/[slug]/AdvisorProfileClient.tsx
@@ -85,7 +85,7 @@ function BioSection({ name, bio }: { name: string; bio: string }) {
         {bio}
       </p>
       {isLong && !expanded && (
-        <button onClick={() => setExpanded(true)} className="md:hidden text-sm font-semibold text-violet-600 hover:text-violet-800 mt-2">
+        <button onClick={() => setExpanded(true)} className="md:hidden text-sm font-semibold text-amber-600 hover:text-amber-800 mt-2">
           Read more
         </button>
       )}
@@ -177,7 +177,7 @@ export default function AdvisorProfileClient({ professional: pro, similar, revie
         {/* Profile header — premium hero card */}
         <div className="relative bg-white border border-slate-200 rounded-2xl overflow-hidden mb-4 md:mb-6 shadow-sm">
           {/* Gradient banner */}
-          <div className="h-24 md:h-32 bg-gradient-to-br from-violet-600 via-violet-500 to-indigo-500 relative">
+          <div className="h-24 md:h-32 bg-gradient-to-br from-amber-600 via-amber-500 to-indigo-500 relative">
             <div className="absolute inset-0 bg-[radial-gradient(circle_at_70%_20%,rgba(255,255,255,0.15),transparent_60%)]" />
             <div className="absolute inset-0 bg-[radial-gradient(circle_at_20%_80%,rgba(255,255,255,0.1),transparent_50%)]" />
           </div>
@@ -187,7 +187,7 @@ export default function AdvisorProfileClient({ professional: pro, similar, revie
               {pro.photo_url ? (
                 <Image src={pro.photo_url} alt={pro.name} width={160} height={160} className="w-24 h-24 md:w-36 md:h-36 rounded-2xl object-cover shrink-0 ring-4 ring-white shadow-lg" />
               ) : (
-                <div className="w-24 h-24 md:w-36 md:h-36 rounded-2xl bg-gradient-to-br from-violet-100 to-violet-50 flex items-center justify-center text-2xl md:text-4xl font-bold text-violet-600 shrink-0 ring-4 ring-white shadow-lg">
+                <div className="w-24 h-24 md:w-36 md:h-36 rounded-2xl bg-gradient-to-br from-amber-100 to-amber-50 flex items-center justify-center text-2xl md:text-4xl font-bold text-amber-600 shrink-0 ring-4 ring-white shadow-lg">
                   {pro.name.split(" ").map((n) => n[0]).join("")}
                 </div>
               )}
@@ -203,7 +203,7 @@ export default function AdvisorProfileClient({ professional: pro, similar, revie
                 </div>
                 {pro.firm_name && <div className="text-sm md:text-base text-slate-600 font-medium mb-1.5">{pro.firm_name}</div>}
                 <div className="flex items-center gap-2 md:gap-3 flex-wrap">
-                  <span className="text-xs md:text-sm bg-violet-100 text-violet-700 px-2.5 py-1 rounded-lg font-semibold">{typeLabel}</span>
+                  <span className="text-xs md:text-sm bg-amber-100 text-amber-700 px-2.5 py-1 rounded-lg font-semibold">{typeLabel}</span>
                   {pro.avg_response_minutes != null && pro.avg_response_minutes <= 120 && (
                     <span className="inline-flex items-center gap-1 text-[0.62rem] md:text-xs font-bold px-2 md:px-2.5 py-0.5 md:py-1 rounded-full bg-emerald-100 text-emerald-700">
                       <Icon name="zap" size={12} className="text-emerald-500" />
@@ -231,7 +231,7 @@ export default function AdvisorProfileClient({ professional: pro, similar, revie
                 </div>
                 {/* Inline CTA row — desktop only */}
                 <div className="hidden md:flex items-center gap-3 mt-4">
-                  <a href="#enquiry" className="px-6 py-2.5 bg-violet-600 text-white text-sm font-bold rounded-lg hover:bg-violet-700 transition-colors shadow-sm">
+                  <a href="#enquiry" className="px-6 py-2.5 bg-amber-600 text-white text-sm font-bold rounded-lg hover:bg-amber-700 transition-colors shadow-sm">
                     Request Free Consultation
                   </a>
                   {pro.booking_link && (
@@ -311,7 +311,7 @@ export default function AdvisorProfileClient({ professional: pro, similar, revie
         {/* Quick facts grid — elevated */}
         <div className="grid grid-cols-2 md:grid-cols-4 gap-2.5 md:gap-4 mb-5 md:mb-8">
           {[
-            { label: "Type", value: typeLabel, icon: "briefcase", bg: "bg-violet-50", border: "border-violet-200", iconColor: "text-violet-500" },
+            { label: "Type", value: typeLabel, icon: "briefcase", bg: "bg-amber-50", border: "border-amber-200", iconColor: "text-amber-500" },
             { label: "Location", value: pro.location_display || "Australia", icon: "map-pin", bg: "bg-blue-50", border: "border-blue-200", iconColor: "text-blue-500" },
             { label: "Fees", value: pro.fee_description || "Contact for pricing", icon: "coins", bg: "bg-amber-50", border: "border-amber-200", iconColor: "text-amber-500" },
             { label: "Licence", value: pro.afsl_number || pro.registration_number || "Verified", icon: "shield-check", bg: "bg-emerald-50", border: "border-emerald-200", iconColor: "text-emerald-500" },
@@ -422,15 +422,15 @@ export default function AdvisorProfileClient({ professional: pro, similar, revie
 
         {/* Special Offer */}
         {pro.offer_active && pro.offer_text && (
-          <div className="bg-gradient-to-r from-violet-50 to-violet-100/50 border border-violet-200 rounded-xl p-4 md:p-5 mb-4 md:mb-6">
+          <div className="bg-gradient-to-r from-amber-50 to-amber-100/50 border border-amber-200 rounded-xl p-4 md:p-5 mb-4 md:mb-6">
             <div className="flex items-start gap-3">
-              <div className="w-9 h-9 rounded-full bg-violet-200 flex items-center justify-center shrink-0">
-                <Icon name="tag" size={18} className="text-violet-600" />
+              <div className="w-9 h-9 rounded-full bg-amber-200 flex items-center justify-center shrink-0">
+                <Icon name="tag" size={18} className="text-amber-600" />
               </div>
               <div className="flex-1 min-w-0">
-                <p className="text-[0.58rem] font-bold uppercase tracking-wider text-violet-500 mb-0.5">Special Offer</p>
-                <p className="text-sm md:text-base font-bold text-violet-900">{pro.offer_text}</p>
-                {pro.offer_terms && <p className="text-[0.62rem] md:text-xs text-violet-600 mt-1">{pro.offer_terms}</p>}
+                <p className="text-[0.58rem] font-bold uppercase tracking-wider text-amber-500 mb-0.5">Special Offer</p>
+                <p className="text-sm md:text-base font-bold text-amber-900">{pro.offer_text}</p>
+                {pro.offer_terms && <p className="text-[0.62rem] md:text-xs text-amber-600 mt-1">{pro.offer_terms}</p>}
               </div>
             </div>
           </div>
@@ -495,8 +495,8 @@ export default function AdvisorProfileClient({ professional: pro, similar, revie
         {pro.specialties.length > 0 && (
           <div className="bg-white border border-slate-200 rounded-xl p-5 md:p-6 mb-5 md:mb-8 shadow-sm">
             <div className="flex items-center gap-2.5 mb-3">
-              <div className="w-8 h-8 rounded-lg bg-violet-50 flex items-center justify-center">
-                <Icon name="target" size={16} className="text-violet-500" />
+              <div className="w-8 h-8 rounded-lg bg-amber-50 flex items-center justify-center">
+                <Icon name="target" size={16} className="text-amber-500" />
               </div>
               <h2 className="text-base md:text-lg font-bold text-slate-900">Specialties</h2>
             </div>
@@ -521,7 +521,7 @@ export default function AdvisorProfileClient({ professional: pro, similar, revie
               )}
               {(pro.qualifications)?.map((q) => (
                 <div key={q} className="flex items-center gap-2 text-xs md:text-sm text-slate-700">
-                  <Icon name="award" size={14} className="text-violet-500 shrink-0" />
+                  <Icon name="award" size={14} className="text-amber-500 shrink-0" />
                   <span>{q}</span>
                 </div>
               ))}
@@ -591,7 +591,7 @@ export default function AdvisorProfileClient({ professional: pro, similar, revie
         {(pro.meeting_types)?.length ? (
           <div className="flex flex-wrap gap-2 mb-4 md:mb-6">
             {(pro.meeting_types!).map((mt) => (
-              <span key={mt} className="inline-flex items-center gap-1.5 text-xs font-medium px-2.5 py-1 rounded-full bg-violet-50 text-violet-700 border border-violet-200">
+              <span key={mt} className="inline-flex items-center gap-1.5 text-xs font-medium px-2.5 py-1 rounded-full bg-amber-50 text-amber-700 border border-amber-200">
                 <Icon name={mt === "video" ? "video" : mt === "phone" ? "phone" : "map-pin"} size={12} />
                 {mt === "in-person" ? "In-Person" : mt === "video" ? "Video Call" : mt === "phone" ? "Phone" : mt}
               </span>
@@ -606,9 +606,9 @@ export default function AdvisorProfileClient({ professional: pro, similar, revie
 
         {/* Ideal Client */}
         {pro.ideal_client && (
-          <div className="bg-violet-50 border border-violet-200 rounded-xl p-4 md:p-5 mb-4 md:mb-6">
-            <h2 className="text-sm md:text-base font-bold text-violet-900 mb-1.5">Who I Work With</h2>
-            <p className="text-xs md:text-sm text-violet-700 leading-relaxed">{pro.ideal_client!}</p>
+          <div className="bg-amber-50 border border-amber-200 rounded-xl p-4 md:p-5 mb-4 md:mb-6">
+            <h2 className="text-sm md:text-base font-bold text-amber-900 mb-1.5">Who I Work With</h2>
+            <p className="text-xs md:text-sm text-amber-700 leading-relaxed">{pro.ideal_client!}</p>
           </div>
         )}
 
@@ -634,7 +634,7 @@ export default function AdvisorProfileClient({ professional: pro, similar, revie
             <h2 className="text-sm md:text-base font-bold text-slate-900 mb-3">Client Testimonials</h2>
             <div className="space-y-3">
               {(pro.testimonials!).map((t, i) => (
-                <blockquote key={i} className="border-l-2 border-violet-300 pl-3">
+                <blockquote key={i} className="border-l-2 border-amber-300 pl-3">
                   <p className="text-xs md:text-sm text-slate-600 italic leading-relaxed">&ldquo;{t.quote}&rdquo;</p>
                   <footer className="text-xs text-slate-400 mt-1">— {t.author}{t.date ? `, ${t.date}` : ""}</footer>
                 </blockquote>
@@ -685,7 +685,7 @@ export default function AdvisorProfileClient({ professional: pro, similar, revie
                 <div className="flex items-start gap-2"><span className="text-emerald-400 font-bold mt-0.5">3</span><span>They&apos;ll contact you to arrange a consultation</span></div>
                 <div className="flex items-start gap-2"><span className="text-emerald-400 font-bold mt-0.5">4</span><span>No obligation — you decide if it&apos;s a good fit</span></div>
               </div>
-              <Link href="/advisors" className="inline-block mt-5 text-sm font-semibold text-violet-300 hover:text-violet-200 transition-colors">
+              <Link href="/advisors" className="inline-block mt-5 text-sm font-semibold text-amber-300 hover:text-amber-200 transition-colors">
                 Browse more advisors →
               </Link>
             </div>
@@ -709,7 +709,7 @@ export default function AdvisorProfileClient({ professional: pro, similar, revie
                       onChange={(e) => setName(e.target.value)}
                       onBlur={() => setTouched(p => ({ ...p, name: true }))}
                       placeholder="Full name"
-                      className={`w-full px-3.5 py-3 text-sm bg-white/10 border rounded-lg text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-violet-500/50 focus:border-violet-400 ${nameError ? "border-red-400" : "border-white/20"}`}
+                      className={`w-full px-3.5 py-3 text-sm bg-white/10 border rounded-lg text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-amber-500/50 focus:border-amber-400 ${nameError ? "border-red-400" : "border-white/20"}`}
                     />
                     {nameError && <p className="text-[0.62rem] text-red-400 mt-0.5">{nameError}</p>}
                   </div>
@@ -721,7 +721,7 @@ export default function AdvisorProfileClient({ professional: pro, similar, revie
                       onChange={(e) => setEmail(e.target.value)}
                       onBlur={() => setTouched(p => ({ ...p, email: true }))}
                       placeholder="your@email.com"
-                      className={`w-full px-3.5 py-3 text-sm bg-white/10 border rounded-lg text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-violet-500/50 focus:border-violet-400 ${emailError ? "border-red-400" : "border-white/20"}`}
+                      className={`w-full px-3.5 py-3 text-sm bg-white/10 border rounded-lg text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-amber-500/50 focus:border-amber-400 ${emailError ? "border-red-400" : "border-white/20"}`}
                     />
                     {emailError && <p className="text-[0.62rem] text-red-400 mt-0.5">{emailError}</p>}
                   </div>
@@ -733,7 +733,7 @@ export default function AdvisorProfileClient({ professional: pro, similar, revie
                     value={phone}
                     onChange={(e) => setPhone(e.target.value)}
                     placeholder="04XX XXX XXX"
-                    className="w-full px-3.5 py-3 text-sm bg-white/10 border border-white/20 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-violet-500/50 focus:border-violet-400"
+                    className="w-full px-3.5 py-3 text-sm bg-white/10 border border-white/20 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-amber-500/50 focus:border-amber-400"
                   />
                 </div>
                 <div>
@@ -743,7 +743,7 @@ export default function AdvisorProfileClient({ professional: pro, similar, revie
                     onChange={(e) => setMessage(e.target.value)}
                     placeholder="Brief description of your situation..."
                     rows={3}
-                    className="w-full px-3.5 py-3 text-sm bg-white/10 border border-white/20 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-violet-500/50 focus:border-violet-400 resize-vertical"
+                    className="w-full px-3.5 py-3 text-sm bg-white/10 border border-white/20 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-amber-500/50 focus:border-amber-400 resize-vertical"
                   />
                 </div>
                 {formError && <p className="text-xs text-red-400 font-medium">{formError}</p>}
@@ -751,7 +751,7 @@ export default function AdvisorProfileClient({ professional: pro, similar, revie
                 <button
                   onClick={handleSubmit}
                   disabled={!name.trim() || !email.trim() || formState === "submitting"}
-                  className="w-full py-3.5 bg-violet-600 text-white font-bold text-sm rounded-lg hover:bg-violet-500 disabled:opacity-50 disabled:cursor-not-allowed transition-all active:scale-[0.98] shadow-lg shadow-violet-600/25"
+                  className="w-full py-3.5 bg-amber-600 text-white font-bold text-sm rounded-lg hover:bg-amber-500 disabled:opacity-50 disabled:cursor-not-allowed transition-all active:scale-[0.98] shadow-lg shadow-amber-600/25"
                 >
                   {formState === "submitting" ? "Sending..." : `Send Enquiry to ${pro.name.split(" ")[0]}`}
                 </button>
@@ -858,17 +858,17 @@ export default function AdvisorProfileClient({ professional: pro, similar, revie
                 <a
                   key={article.id}
                   href={`/expert/${article.slug}`}
-                  className="block bg-white border border-slate-200 rounded-xl p-3.5 hover:shadow-md hover:border-violet-200 transition-all group"
+                  className="block bg-white border border-slate-200 rounded-xl p-3.5 hover:shadow-md hover:border-amber-200 transition-all group"
                 >
                   <div className="flex items-start justify-between gap-3">
                     <div className="flex-1 min-w-0">
-                      <h3 className="text-sm font-bold text-slate-900 group-hover:text-violet-700 transition-colors line-clamp-2">{article.title}</h3>
+                      <h3 className="text-sm font-bold text-slate-900 group-hover:text-amber-700 transition-colors line-clamp-2">{article.title}</h3>
                       {article.excerpt && (
                         <p className="text-xs text-slate-500 mt-1 line-clamp-2">{article.excerpt}</p>
                       )}
                       <div className="flex items-center gap-2 mt-2">
                         {article.category && (
-                          <span className="text-[0.58rem] font-semibold text-violet-600 bg-violet-50 px-1.5 py-0.5 rounded">{article.category}</span>
+                          <span className="text-[0.58rem] font-semibold text-amber-600 bg-amber-50 px-1.5 py-0.5 rounded">{article.category}</span>
                         )}
                         {article.reading_time_mins && (
                           <span className="text-[0.58rem] text-slate-400">{article.reading_time_mins} min read</span>
@@ -878,7 +878,7 @@ export default function AdvisorProfileClient({ professional: pro, similar, revie
                         )}
                       </div>
                     </div>
-                    <span className="text-violet-500 group-hover:translate-x-0.5 transition-transform mt-1">
+                    <span className="text-amber-500 group-hover:translate-x-0.5 transition-transform mt-1">
                       <Icon name="arrow-right" size={16} />
                     </span>
                   </div>
@@ -972,12 +972,12 @@ export default function AdvisorProfileClient({ professional: pro, similar, revie
                   body: JSON.stringify({ event_type: "booking_click", page: `/advisor/${pro.slug}`, metadata: { advisor: pro.slug, source: "sticky_mobile" } }),
                 }).catch(() => {});
               }}
-              className="flex-1 py-3 bg-violet-600 text-white font-bold rounded-xl text-sm text-center"
+              className="flex-1 py-3 bg-amber-600 text-white font-bold rounded-xl text-sm text-center"
             >
               Book Free Call
             </a>
           ) : (
-            <a href="#enquiry" className="flex-1 py-3 bg-violet-600 text-white font-bold rounded-xl text-sm text-center">
+            <a href="#enquiry" className="flex-1 py-3 bg-amber-600 text-white font-bold rounded-xl text-sm text-center">
               Request Free Consultation
             </a>
           )}
@@ -998,7 +998,7 @@ export default function AdvisorProfileClient({ professional: pro, similar, revie
             {pro.verified && <span className="text-[0.56rem] font-bold px-1.5 py-0.5 rounded-full bg-blue-100 text-blue-700">Verified</span>}
             <span className="text-xs text-slate-500">{pro.firm_name}</span>
           </div>
-          <a href="#enquiry" className="px-6 py-2.5 bg-violet-600 text-white text-sm font-bold rounded-lg hover:bg-violet-700 transition-colors">
+          <a href="#enquiry" className="px-6 py-2.5 bg-amber-600 text-white text-sm font-bold rounded-lg hover:bg-amber-700 transition-colors">
             Request Free Consultation
           </a>
         </div>
@@ -1010,7 +1010,7 @@ export default function AdvisorProfileClient({ professional: pro, similar, revie
             <p className="text-xs font-bold text-slate-900 truncate">{pro.name}</p>
             <p className="text-[0.6rem] text-slate-500 truncate">{pro.fee_description || "Free consultation"}</p>
           </div>
-          <a href="#enquiry" className="shrink-0 px-5 py-2.5 bg-violet-600 text-white text-xs font-bold rounded-lg hover:bg-violet-700 transition-colors">
+          <a href="#enquiry" className="shrink-0 px-5 py-2.5 bg-amber-600 text-white text-xs font-bold rounded-lg hover:bg-amber-700 transition-colors">
             Enquire Free
           </a>
         </div>

--- a/app/advisor/[slug]/AdvisorProfileClient.tsx
+++ b/app/advisor/[slug]/AdvisorProfileClient.tsx
@@ -104,6 +104,23 @@ export default function AdvisorProfileClient({ professional: pro, similar, revie
   const [message, setMessage] = useState("");
   const [touched, setTouched] = useState<Record<string, boolean>>({});
 
+  // Detect if user was already matched with this advisor via the quiz
+  const [alreadyMatched, setAlreadyMatched] = useState(false);
+  useEffect(() => {
+    try {
+      const raw = sessionStorage.getItem("invest_quiz_match");
+      if (raw) {
+        const data = JSON.parse(raw);
+        if (data.matchedAdvisors?.some((a: { slug: string }) => a.slug === pro.slug)) {
+          setAlreadyMatched(true);
+          // Pre-fill form with saved quiz data
+          if (data.quizData?.firstName) setName(data.quizData.firstName);
+          if (data.quizData?.email) setEmail(data.quizData.email);
+        }
+      }
+    } catch {}
+  }, [pro.slug]);
+
   // Review form state
   const [reviewFormOpen, setReviewFormOpen] = useState(false);
   const [reviewState, setReviewState] = useState<"idle" | "success">("idle");
@@ -666,9 +683,25 @@ export default function AdvisorProfileClient({ professional: pro, similar, revie
           <BookingWidget advisorSlug={pro.slug} advisorName={pro.name} />
         </div>
 
+        {/* Already matched banner */}
+        {alreadyMatched && formState !== "success" && (
+          <div className="bg-amber-50 border border-amber-200 rounded-xl p-4 mb-4 md:mb-6 flex items-start gap-3">
+            <div className="w-8 h-8 rounded-full bg-amber-100 flex items-center justify-center shrink-0 mt-0.5">
+              <Icon name="check-circle" size={16} className="text-amber-600" />
+            </div>
+            <div>
+              <p className="text-sm font-bold text-amber-900">You&apos;ve been matched with {pro.name}</p>
+              <p className="text-xs text-amber-700 mt-0.5">
+                {pro.name} has already been notified of your enquiry via the advisor quiz. They&apos;ll reach out to you within 24 hours.
+                If you&apos;d like to add more details, use the form below.
+              </p>
+            </div>
+          </div>
+        )}
+
         {/* Enquiry form — premium card */}
         <div id="enquiry" className="bg-gradient-to-br from-slate-900 to-slate-800 rounded-2xl p-5 md:p-8 mb-5 md:mb-8 scroll-mt-20 shadow-lg text-white relative overflow-hidden">
-          <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(139,92,246,0.15),transparent_60%)]" />
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(245,158,11,0.15),transparent_60%)]" />
           <div className="relative">
           {formState === "success" ? (
             <div className="text-center py-6">

--- a/app/advisors/AdvisorsClient.tsx
+++ b/app/advisors/AdvisorsClient.tsx
@@ -104,7 +104,7 @@ function LocationSearch({ onSelect, selected }: { onSelect: (p: PostcodeResult |
           onChange={e => { setQuery(e.target.value); search(e.target.value); }}
           onFocus={() => results.length > 0 && setOpen(true)}
           placeholder="Suburb or postcode..."
-          className="w-full pl-8 pr-8 py-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-violet-500/30"
+          className="w-full pl-8 pr-8 py-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-amber-500/30"
         />
         {selected && (
           <button onClick={() => { setQuery(""); onSelect(null); setResults([]); }} className="absolute right-2.5 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-600">
@@ -118,7 +118,7 @@ function LocationSearch({ onSelect, selected }: { onSelect: (p: PostcodeResult |
             <button
               key={p.postcode}
               onClick={() => { onSelect(p); setQuery(`${p.locality}, ${p.state}`); setOpen(false); }}
-              className="w-full text-left px-3 py-2 hover:bg-violet-50 text-sm text-slate-700 flex items-center justify-between"
+              className="w-full text-left px-3 py-2 hover:bg-amber-50 text-sm text-slate-700 flex items-center justify-between"
             >
               <span>{p.locality}, {p.state}</span>
               <span className="text-xs text-slate-400">{p.postcode}</span>
@@ -148,7 +148,7 @@ function UseMyLocation({ onLocate }: { onLocate: (lat: number, lng: number) => v
           { enableHighAccuracy: false, timeout: 10000 }
         );
       }}
-      className="flex items-center gap-1 text-[0.65rem] font-semibold text-violet-600 hover:text-violet-800 transition-colors"
+      className="flex items-center gap-1 text-[0.65rem] font-semibold text-amber-600 hover:text-amber-800 transition-colors"
     >
       <Icon name="navigation" size={12} />
       {loading ? "Locating..." : "Use my location"}
@@ -407,16 +407,16 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
           <span className="text-slate-700">{activeTypeLabel || "Find an Advisor"}</span>
         </nav>
 
-        <div className="bg-gradient-to-br from-violet-50 to-slate-50 border border-violet-100 rounded-2xl p-4 md:p-8 mb-4 md:mb-6">
+        <div className="bg-gradient-to-br from-amber-50 to-slate-50 border border-amber-100 rounded-2xl p-4 md:p-8 mb-4 md:mb-6">
           <h1 className="text-xl md:text-4xl font-extrabold mb-1.5 md:mb-3 text-slate-900">{dynamicTitle}</h1>
           <p className="text-xs md:text-base text-slate-500 mb-3 md:mb-5">
             <span className="md:hidden">{dynamicDescription.slice(0, 60)}...</span>
             <span className="hidden md:inline">{dynamicDescription}</span>
           </p>
           <div className="flex items-center gap-3 md:gap-6 text-[0.62rem] md:text-xs text-slate-500">
-            <span className="flex items-center gap-1.5"><span className="w-2 h-2 bg-violet-500 rounded-full" /><span className="font-semibold text-slate-700">{professionals.length}</span> advisors</span>
-            <span className="flex items-center gap-1.5"><Icon name="shield" size={14} className="text-violet-400" />ASIC verified</span>
-            <span className="flex items-center gap-1.5"><Icon name="clock" size={14} className="text-violet-400" />Free consultation</span>
+            <span className="flex items-center gap-1.5"><span className="w-2 h-2 bg-amber-500 rounded-full" /><span className="font-semibold text-slate-700">{professionals.length}</span> advisors</span>
+            <span className="flex items-center gap-1.5"><Icon name="shield" size={14} className="text-amber-400" />ASIC verified</span>
+            <span className="flex items-center gap-1.5"><Icon name="clock" size={14} className="text-amber-400" />Free consultation</span>
           </div>
         </div>
 
@@ -424,15 +424,15 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
         <div className="flex gap-2 mb-3 md:mb-4">
           <div className="relative flex-1">
             <Icon name="search" size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400" />
-            <input type="text" placeholder="Search name, firm, specialty, suburb..." value={search} onChange={e => setSearch(e.target.value)} className="w-full pl-9 pr-4 py-2.5 md:py-3 text-sm border border-slate-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-violet-500/30 focus:border-violet-400 transition-all" />
+            <input type="text" placeholder="Search name, firm, specialty, suburb..." value={search} onChange={e => setSearch(e.target.value)} className="w-full pl-9 pr-4 py-2.5 md:py-3 text-sm border border-slate-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-amber-500/30 focus:border-amber-400 transition-all" />
             {search && <button onClick={() => setSearch("")} className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-600"><Icon name="x" size={16} /></button>}
           </div>
-          <button onClick={() => setFiltersOpen(!filtersOpen)} className={`flex items-center gap-1.5 px-3 md:px-4 py-2.5 border rounded-xl text-sm font-semibold transition-all shrink-0 ${filtersOpen || activeFilterCount > 0 ? "bg-violet-50 border-violet-300 text-violet-700" : "bg-white border-slate-200 text-slate-600 hover:bg-slate-50"}`}>
+          <button onClick={() => setFiltersOpen(!filtersOpen)} className={`flex items-center gap-1.5 px-3 md:px-4 py-2.5 border rounded-xl text-sm font-semibold transition-all shrink-0 ${filtersOpen || activeFilterCount > 0 ? "bg-amber-50 border-amber-300 text-amber-700" : "bg-white border-slate-200 text-slate-600 hover:bg-slate-50"}`}>
             <Icon name="sliders" size={16} />
             <span className="hidden md:inline">Filters</span>
-            {activeFilterCount > 0 && <span className="w-5 h-5 bg-violet-600 text-white text-[0.6rem] font-bold rounded-full flex items-center justify-center">{activeFilterCount}</span>}
+            {activeFilterCount > 0 && <span className="w-5 h-5 bg-amber-600 text-white text-[0.6rem] font-bold rounded-full flex items-center justify-center">{activeFilterCount}</span>}
           </button>
-          <select value={sortBy} onChange={e => setSortBy(e.target.value as SortKey)} className="hidden md:block px-3 py-2.5 border border-slate-200 rounded-xl text-sm text-slate-600 bg-white focus:outline-none focus:ring-2 focus:ring-violet-500/30">
+          <select value={sortBy} onChange={e => setSortBy(e.target.value as SortKey)} className="hidden md:block px-3 py-2.5 border border-slate-200 rounded-xl text-sm text-slate-600 bg-white focus:outline-none focus:ring-2 focus:ring-amber-500/30">
             {SORT_OPTIONS.map(o => <option key={o.key} value={o.key}>{o.label}</option>)}
           </select>
         </div>
@@ -443,7 +443,7 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
             {/* Location / Near me */}
             <div>
               <label className="text-xs font-bold text-slate-700 mb-2 block flex items-center gap-1.5">
-                <Icon name="map-pin" size={13} className="text-violet-500" />
+                <Icon name="map-pin" size={13} className="text-amber-500" />
                 Location
               </label>
               <div className="grid grid-cols-1 md:grid-cols-3 gap-2">
@@ -451,7 +451,7 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
                   <LocationSearch selected={locationSearch} onSelect={(p) => { setLocationSearch(p); if (!p) { setUserLat(null); setUserLng(null); } }} />
                 </div>
                 <div className="flex items-center gap-2">
-                  <select value={radius} onChange={e => setRadius(Number(e.target.value))} className="flex-1 px-3 py-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-violet-500/30" disabled={!isLocationActive}>
+                  <select value={radius} onChange={e => setRadius(Number(e.target.value))} className="flex-1 px-3 py-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-amber-500/30" disabled={!isLocationActive}>
                     {RADIUS_OPTIONS.map(r => <option key={r.value} value={r.value}>{r.label}</option>)}
                   </select>
                   <UseMyLocation onLocate={(lat, lng) => { setUserLat(lat); setUserLng(lng); setSortBy("distance"); setLocationSearch({ postcode: "", locality: "My location", state: "", latitude: lat, longitude: lng }); }} />
@@ -464,10 +464,10 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
               <label className="text-xs font-bold text-slate-700 mb-2 block">Advisor Type</label>
               <div className="flex flex-wrap gap-1.5">
                 {TYPE_FILTERS.map(f => (
-                  <button key={f.key} onClick={() => toggleType(f.key)} className={`flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold rounded-lg transition-all ${(f.key === "all" ? typeFilters.size === 0 : typeFilters.has(f.key as ProfessionalType)) ? "bg-violet-600 text-white shadow-sm" : "bg-slate-50 text-slate-600 hover:bg-slate-100 border border-slate-200"}`}>
-                    <Icon name={f.icon} size={13} className={(f.key === "all" ? typeFilters.size === 0 : typeFilters.has(f.key as ProfessionalType)) ? "text-violet-200" : "text-slate-400"} />
+                  <button key={f.key} onClick={() => toggleType(f.key)} className={`flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold rounded-lg transition-all ${(f.key === "all" ? typeFilters.size === 0 : typeFilters.has(f.key as ProfessionalType)) ? "bg-amber-600 text-white shadow-sm" : "bg-slate-50 text-slate-600 hover:bg-slate-100 border border-slate-200"}`}>
+                    <Icon name={f.icon} size={13} className={(f.key === "all" ? typeFilters.size === 0 : typeFilters.has(f.key as ProfessionalType)) ? "text-amber-200" : "text-slate-400"} />
                     {f.label}
-                    {typeCounts[f.key] ? <span className={(f.key === "all" ? typeFilters.size === 0 : typeFilters.has(f.key as ProfessionalType)) ? "text-violet-200" : "text-slate-400"}>({typeCounts[f.key]})</span> : null}
+                    {typeCounts[f.key] ? <span className={(f.key === "all" ? typeFilters.size === 0 : typeFilters.has(f.key as ProfessionalType)) ? "text-amber-200" : "text-slate-400"}>({typeCounts[f.key]})</span> : null}
                   </button>
                 ))}
               </div>
@@ -476,14 +476,14 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
             <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-3">
               <div>
                 <label className="text-xs font-bold text-slate-700 mb-1.5 block">State</label>
-                <select value={stateFilter} onChange={e => setStateFilter(e.target.value)} className="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-violet-500/30" disabled={isLocationActive}>
+                <select value={stateFilter} onChange={e => setStateFilter(e.target.value)} className="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-amber-500/30" disabled={isLocationActive}>
                   <option value="all">All States</option>
                   {AU_STATES.map(s => <option key={s} value={s}>{s}</option>)}
                 </select>
               </div>
               <div>
                 <label className="text-xs font-bold text-slate-700 mb-1.5 block">Fee Structure</label>
-                <select value={feeFilter} onChange={e => setFeeFilter(e.target.value)} className="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-violet-500/30">
+                <select value={feeFilter} onChange={e => setFeeFilter(e.target.value)} className="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-amber-500/30">
                   <option value="all">Any</option>
                   <option value="fee-for-service">Fee for Service</option>
                   <option value="commission">Commission</option>
@@ -493,14 +493,14 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
               </div>
               <div>
                 <label className="text-xs font-bold text-slate-700 mb-1.5 block">Advisory Firm</label>
-                <select value={firmFilter} onChange={e => setFirmFilter(e.target.value)} className="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-violet-500/30">
+                <select value={firmFilter} onChange={e => setFirmFilter(e.target.value)} className="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-amber-500/30">
                   <option value="all">All Firms</option>
                   {allFirmNames.map(f => <option key={f} value={f}>{f}</option>)}
                 </select>
               </div>
               <div>
                 <label className="text-xs font-bold text-slate-700 mb-1.5 block">Min Rating</label>
-                <select value={minRating} onChange={e => setMinRating(Number(e.target.value))} className="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-violet-500/30">
+                <select value={minRating} onChange={e => setMinRating(Number(e.target.value))} className="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-amber-500/30">
                   <option value={0}>Any</option>
                   <option value={4.5}>4.5+ ★</option>
                   <option value={4.0}>4.0+ ★</option>
@@ -510,13 +510,13 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
               </div>
               <div>
                 <label className="text-xs font-bold text-slate-700 mb-1.5 block">Sort By</label>
-                <select value={sortBy} onChange={e => setSortBy(e.target.value as SortKey)} className="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-violet-500/30">
+                <select value={sortBy} onChange={e => setSortBy(e.target.value as SortKey)} className="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-amber-500/30">
                   {SORT_OPTIONS.map(o => <option key={o.key} value={o.key}>{o.label}</option>)}
                 </select>
               </div>
               <div className="flex items-end">
                 <label className="flex items-center gap-2 cursor-pointer py-2">
-                  <input type="checkbox" checked={verifiedOnly} onChange={() => setVerifiedOnly(!verifiedOnly)} className="w-4 h-4 rounded border-slate-300 text-violet-600 focus:ring-violet-500" />
+                  <input type="checkbox" checked={verifiedOnly} onChange={() => setVerifiedOnly(!verifiedOnly)} className="w-4 h-4 rounded border-slate-300 text-amber-600 focus:ring-amber-500" />
                   <span className="text-xs font-semibold text-slate-700">Verified only</span>
                 </label>
               </div>
@@ -524,17 +524,17 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
 
             {/* Specialties */}
             <div>
-              <label className="text-xs font-bold text-slate-700 mb-2 block">Specialties {specialtyFilters.length > 0 && <span className="text-violet-600">({specialtyFilters.length} selected)</span>}</label>
+              <label className="text-xs font-bold text-slate-700 mb-2 block">Specialties {specialtyFilters.length > 0 && <span className="text-amber-600">({specialtyFilters.length} selected)</span>}</label>
               <div className="flex flex-wrap gap-1.5 max-h-28 overflow-y-auto">
                 {allSpecialties.map(s => (
-                  <button key={s} onClick={() => toggleSpecialty(s)} className={`px-2.5 py-1 text-[0.65rem] font-medium rounded-full transition-all ${specialtyFilters.includes(s) ? "bg-violet-100 text-violet-700 border border-violet-300" : "bg-slate-50 text-slate-500 border border-slate-200 hover:bg-slate-100"}`}>{s}</button>
+                  <button key={s} onClick={() => toggleSpecialty(s)} className={`px-2.5 py-1 text-[0.65rem] font-medium rounded-full transition-all ${specialtyFilters.includes(s) ? "bg-amber-100 text-amber-700 border border-amber-300" : "bg-slate-50 text-slate-500 border border-slate-200 hover:bg-slate-100"}`}>{s}</button>
                 ))}
               </div>
             </div>
 
             <div className="flex items-center justify-between pt-2 border-t border-slate-100">
               <button onClick={clearAll} className="text-xs text-slate-500 hover:text-slate-700 font-medium">Clear all filters</button>
-              <button onClick={() => setFiltersOpen(false)} className="px-4 py-2 bg-violet-600 text-white text-xs font-bold rounded-lg hover:bg-violet-700 transition-colors">
+              <button onClick={() => setFiltersOpen(false)} className="px-4 py-2 bg-amber-600 text-white text-xs font-bold rounded-lg hover:bg-amber-700 transition-colors">
                 {nearbyLoading ? "Searching..." : `Show ${filtered.length} result${filtered.length !== 1 ? "s" : ""}`}
               </button>
             </div>
@@ -545,16 +545,16 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
         {activeFilterCount > 0 && !filtersOpen && (
           <div className="flex flex-wrap items-center gap-1.5 mb-3">
             {isLocationActive && locationSearch && (
-              <span className="inline-flex items-center gap-1 px-2.5 py-1 bg-violet-100 text-violet-700 text-[0.65rem] font-semibold rounded-full">
+              <span className="inline-flex items-center gap-1 px-2.5 py-1 bg-amber-100 text-amber-700 text-[0.65rem] font-semibold rounded-full">
                 <Icon name="map-pin" size={11} />
                 {radius > 0 ? `${radius}km from ` : "Near "}{locationSearch.locality}
-                <button onClick={() => { setLocationSearch(null); setUserLat(null); setUserLng(null); }} className="hover:text-violet-900"><Icon name="x" size={12} /></button>
+                <button onClick={() => { setLocationSearch(null); setUserLat(null); setUserLng(null); }} className="hover:text-amber-900"><Icon name="x" size={12} /></button>
               </span>
             )}
             {Array.from(typeFilters).map(t => (
-              <span key={t} className="inline-flex items-center gap-1 px-2.5 py-1 bg-violet-100 text-violet-700 text-[0.65rem] font-semibold rounded-full">
+              <span key={t} className="inline-flex items-center gap-1 px-2.5 py-1 bg-amber-100 text-amber-700 text-[0.65rem] font-semibold rounded-full">
                 {TYPE_FILTERS.find(f => f.key === t)?.label}
-                <button onClick={() => toggleType(t)} className="hover:text-violet-900"><Icon name="x" size={12} /></button>
+                <button onClick={() => toggleType(t)} className="hover:text-amber-900"><Icon name="x" size={12} /></button>
               </span>
             ))}
             {stateFilter !== "all" && (
@@ -619,7 +619,7 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
             <button
               onClick={() => { /* handled by clearing firm filter */ setFirmFilter("all"); }}
               className={`px-4 py-2 text-sm font-semibold rounded-lg transition-all ${
-                firmFilter === "all" ? "bg-violet-600 text-white shadow-sm" : "bg-slate-100 text-slate-600 hover:bg-slate-200"
+                firmFilter === "all" ? "bg-amber-600 text-white shadow-sm" : "bg-slate-100 text-slate-600 hover:bg-slate-200"
               }`}
             >
               All Advisors ({professionals.length})
@@ -629,14 +629,14 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
                 key={firm.id}
                 onClick={() => setFirmFilter(firm.name)}
                 className={`px-3 py-2 text-sm font-medium rounded-lg transition-all flex items-center gap-1.5 ${
-                  firmFilter === firm.name ? "bg-violet-600 text-white shadow-sm" : "bg-slate-100 text-slate-600 hover:bg-slate-200"
+                  firmFilter === firm.name ? "bg-amber-600 text-white shadow-sm" : "bg-slate-100 text-slate-600 hover:bg-slate-200"
                 }`}
               >
-                <span className="w-5 h-5 rounded bg-violet-100 flex items-center justify-center text-[0.5rem] font-bold text-violet-600 shrink-0">
+                <span className="w-5 h-5 rounded bg-amber-100 flex items-center justify-center text-[0.5rem] font-bold text-amber-600 shrink-0">
                   {firm.name.split(/\s+/).slice(0, 2).map((w: string) => w[0]).join("").toUpperCase()}
                 </span>
                 {firm.name}
-                <span className={`text-xs ${firmFilter === firm.name ? "text-violet-200" : "text-slate-400"}`}>({firmMemberCounts[firm.id] || 0})</span>
+                <span className={`text-xs ${firmFilter === firm.name ? "text-amber-200" : "text-slate-400"}`}>({firmMemberCounts[firm.id] || 0})</span>
               </button>
             ))}
           </div>
@@ -647,13 +647,13 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
           const selectedFirm = firms.find((f: AdvisorFirm) => f.name === firmFilter);
           if (!selectedFirm) return null;
           return (
-            <div className="bg-white border border-violet-200 rounded-xl p-4 md:p-5 mb-4 flex flex-col md:flex-row gap-4">
+            <div className="bg-white border border-amber-200 rounded-xl p-4 md:p-5 mb-4 flex flex-col md:flex-row gap-4">
               <div className="flex items-start gap-3 flex-1 min-w-0">
-                <div className="w-14 h-14 rounded-xl bg-gradient-to-br from-violet-100 to-violet-50 border border-violet-200 flex items-center justify-center shrink-0">
+                <div className="w-14 h-14 rounded-xl bg-gradient-to-br from-amber-100 to-amber-50 border border-amber-200 flex items-center justify-center shrink-0">
                   {selectedFirm.logo_url ? (
                     <Image src={selectedFirm.logo_url} alt={selectedFirm.name} width={56} height={56} className="w-full h-full object-contain rounded-xl" />
                   ) : (
-                    <span className="text-lg font-bold text-violet-600">
+                    <span className="text-lg font-bold text-amber-600">
                       {selectedFirm.name.split(/\s+/).slice(0, 2).map((w: string) => w[0]).join("").toUpperCase()}
                     </span>
                   )}
@@ -662,14 +662,14 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
                   <h3 className="text-base font-bold text-slate-900">{selectedFirm.name}</h3>
                   <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 mt-0.5 text-xs text-slate-500">
                     {selectedFirm.location_display && <span className="flex items-center gap-1"><Icon name="map-pin" size={11} className="text-slate-400" />{selectedFirm.location_display}</span>}
-                    {selectedFirm.afsl_number && <span className="flex items-center gap-1"><Icon name="shield" size={11} className="text-violet-400" />AFSL {selectedFirm.afsl_number}</span>}
+                    {selectedFirm.afsl_number && <span className="flex items-center gap-1"><Icon name="shield" size={11} className="text-amber-400" />AFSL {selectedFirm.afsl_number}</span>}
                     <span className="flex items-center gap-1"><Icon name="users" size={11} className="text-blue-400" />{firmMemberCounts[selectedFirm.id] || 0} advisors</span>
                   </div>
                   {selectedFirm.bio && <p className="text-xs text-slate-500 mt-1.5 line-clamp-2">{selectedFirm.bio}</p>}
                 </div>
               </div>
               <div className="flex items-center gap-2 shrink-0">
-                <Link href={`/firm/${selectedFirm.slug}`} className="px-4 py-2 bg-violet-600 text-white text-xs font-bold rounded-lg hover:bg-violet-700 transition-colors">
+                <Link href={`/firm/${selectedFirm.slug}`} className="px-4 py-2 bg-amber-600 text-white text-xs font-bold rounded-lg hover:bg-amber-700 transition-colors">
                   View Firm Profile →
                 </Link>
               </div>
@@ -696,14 +696,14 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
         ) : paginatedResults.length > 0 ? (
           <div className="space-y-2.5 md:space-y-3">
             {paginatedResults.map(pro => (
-              <Link key={pro.id} href={`/advisor/${pro.slug}`} className={`block bg-white border rounded-xl p-3.5 md:p-5 hover:shadow-lg hover:-translate-y-0.5 transition-all duration-200 ${pro.featured_until && new Date(pro.featured_until) > new Date() ? "border-amber-300 ring-1 ring-amber-100 hover:border-amber-400" : "border-slate-200 hover:border-violet-200"}`}>
+              <Link key={pro.id} href={`/advisor/${pro.slug}`} className={`block bg-white border rounded-xl p-3.5 md:p-5 hover:shadow-lg hover:-translate-y-0.5 transition-all duration-200 ${pro.featured_until && new Date(pro.featured_until) > new Date() ? "border-amber-300 ring-1 ring-amber-100 hover:border-amber-400" : "border-slate-200 hover:border-amber-200"}`}>
                 <div className="flex gap-3 md:gap-4">
                   {pro.photo_url ? (
-                    <div className="w-12 h-12 md:w-16 md:h-16 rounded-xl overflow-hidden shrink-0 ring-2 ring-violet-100">
+                    <div className="w-12 h-12 md:w-16 md:h-16 rounded-xl overflow-hidden shrink-0 ring-2 ring-amber-100">
                       <img src={pro.photo_url} alt={pro.name} className="w-full h-full object-cover" />
                     </div>
                   ) : (
-                    <div className="w-12 h-12 md:w-16 md:h-16 rounded-xl bg-gradient-to-br from-violet-100 to-slate-100 flex items-center justify-center text-sm md:text-lg font-bold text-violet-600 shrink-0">
+                    <div className="w-12 h-12 md:w-16 md:h-16 rounded-xl bg-gradient-to-br from-amber-100 to-slate-100 flex items-center justify-center text-sm md:text-lg font-bold text-amber-600 shrink-0">
                       {pro.name.split(" ").map(n => n[0]).join("")}
                     </div>
                   )}
@@ -711,7 +711,7 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
                     <div className="flex items-center gap-2 mb-0.5">
                       <span className="font-bold text-sm md:text-base text-slate-900 truncate">{pro.name}</span>
                       {pro.verified && (
-                        <span className="shrink-0 text-[0.56rem] md:text-[0.62rem] font-bold px-1.5 py-0.5 rounded-full bg-violet-100 text-violet-700 flex items-center gap-0.5">
+                        <span className="shrink-0 text-[0.56rem] md:text-[0.62rem] font-bold px-1.5 py-0.5 rounded-full bg-amber-100 text-amber-700 flex items-center gap-0.5">
                           <svg className="w-2.5 h-2.5" fill="currentColor" viewBox="0 0 20 20"><path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" /></svg>
                           Verified
                         </span>
@@ -736,7 +736,7 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
                       </div>
                     )}
                     <div className="flex items-center gap-2 mt-1 flex-wrap">
-                      <span className="text-[0.62rem] md:text-xs text-violet-600 bg-violet-50 px-2 py-0.5 rounded-full font-medium">{PROFESSIONAL_TYPE_LABELS[pro.type]}</span>
+                      <span className="text-[0.62rem] md:text-xs text-amber-600 bg-amber-50 px-2 py-0.5 rounded-full font-medium">{PROFESSIONAL_TYPE_LABELS[pro.type]}</span>
                       {pro.account_type === "firm_member" ? (
                         <span className="text-[0.56rem] md:text-[0.62rem] font-semibold text-blue-600 bg-blue-50 px-1.5 py-0.5 rounded-full flex items-center gap-0.5">
                           <Icon name="users" size={10} className="text-blue-400" />Firm
@@ -795,9 +795,9 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
                       </div>
                     )}
                     {pro.offer_active && pro.offer_text && (
-                      <div className="mt-2 bg-violet-50 border border-violet-100 rounded-lg px-2.5 py-1.5 flex items-center gap-1.5">
-                        <Icon name="tag" size={11} className="text-violet-500 shrink-0" />
-                        <span className="text-[0.58rem] md:text-[0.62rem] font-bold text-violet-700 truncate">{pro.offer_text}</span>
+                      <div className="mt-2 bg-amber-50 border border-amber-100 rounded-lg px-2.5 py-1.5 flex items-center gap-1.5">
+                        <Icon name="tag" size={11} className="text-amber-500 shrink-0" />
+                        <span className="text-[0.58rem] md:text-[0.62rem] font-bold text-amber-700 truncate">{pro.offer_text}</span>
                       </div>
                     )}
                   </div>
@@ -813,7 +813,7 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
             <p className="text-xs text-slate-400 mb-3">
               {isLocationActive ? `No advisors within ${radius}km. Try a larger radius.` : search ? `No results for "${search}".` : "Try adjusting your filters."}
             </p>
-            <button onClick={clearAll} className="text-xs text-violet-600 font-semibold hover:text-violet-800">Clear all filters</button>
+            <button onClick={clearAll} className="text-xs text-amber-600 font-semibold hover:text-amber-800">Clear all filters</button>
           </div>
         )}
 
@@ -827,7 +827,7 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
               else if (page <= 4) pn = i + 1;
               else if (page >= totalPages - 3) pn = totalPages - 6 + i;
               else pn = page - 3 + i;
-              return <button key={pn} onClick={() => setPage(pn)} className={`w-9 h-9 text-xs font-semibold rounded-lg transition-all ${page === pn ? "bg-violet-600 text-white" : "border border-slate-200 text-slate-600 hover:bg-slate-50"}`}>{pn}</button>;
+              return <button key={pn} onClick={() => setPage(pn)} className={`w-9 h-9 text-xs font-semibold rounded-lg transition-all ${page === pn ? "bg-amber-600 text-white" : "border border-slate-200 text-slate-600 hover:bg-slate-50"}`}>{pn}</button>;
             })}
             <button onClick={() => setPage(p => Math.min(totalPages, p + 1))} disabled={page === totalPages} className="px-3 py-2 text-xs font-semibold border border-slate-200 rounded-lg hover:bg-slate-50 disabled:opacity-40 disabled:cursor-not-allowed">Next {"\u2192"}</button>
           </div>
@@ -851,7 +851,7 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
               <h2 className="text-lg md:text-xl font-extrabold text-slate-900 mb-2">Cost Guide</h2>
               <p className="text-sm text-slate-600 leading-relaxed">{editorial.costGuide}</p>
             </div>
-            <div className="bg-gradient-to-br from-violet-50 to-white border border-violet-200/60 rounded-xl p-4 md:p-6">
+            <div className="bg-gradient-to-br from-amber-50 to-white border border-amber-200/60 rounded-xl p-4 md:p-6">
               <h2 className="text-lg md:text-xl font-extrabold text-slate-900 mb-2">Industry Insight</h2>
               <p className="text-sm text-slate-600 leading-relaxed">{editorial.industryInsight}</p>
             </div>

--- a/app/api/submit-lead/route.ts
+++ b/app/api/submit-lead/route.ts
@@ -35,7 +35,6 @@ function resolveAdvisorTypes(need: string, context?: string[]): string[] {
 
   const types = new Set(baseTypes);
 
-  // Add more specific types based on context selections
   for (const c of context) {
     if (c === "first_home" || c === "refinance") types.add("mortgage_broker");
     if (c === "investment") { types.add("mortgage_broker"); types.add("property_advisor"); }
@@ -52,6 +51,10 @@ function resolveAdvisorTypes(need: string, context?: string[]): string[] {
   return [...types];
 }
 
+/* ─── Common select fields for matching queries ─── */
+
+const MATCH_SELECT = "id, slug, name, firm_name, type, photo_url, rating, review_count, location_display, location_state, specialties, fee_description, verified, bio, email";
+
 /**
  * POST /api/submit-lead
  *
@@ -60,6 +63,10 @@ function resolveAdvisorTypes(need: string, context?: string[]): string[] {
  *   2. Location (user's state)
  *   3. Rating & reviews (highest first)
  *   4. Round-robin fairness (skip advisors who got a lead in the last 24h)
+ *   5. Exclusion list (skip advisors the user was already matched with)
+ *
+ * Supports `exclude_advisor_ids` to avoid re-matching the same advisor.
+ * Supports `rematch: true` to request a different advisor (skips lead creation emails on rematch).
  *
  * Returns matched advisor profile for immediate display.
  */
@@ -81,6 +88,8 @@ export async function POST(request: NextRequest) {
     professional_id,
     broker_slug,
     source_page,
+    exclude_advisor_ids,
+    rematch,
   } = body as {
     lead_type?: string;
     user_email?: string;
@@ -91,6 +100,8 @@ export async function POST(request: NextRequest) {
     professional_id?: number;
     broker_slug?: string;
     source_page?: string;
+    exclude_advisor_ids?: number[];
+    rematch?: boolean;
   };
 
   if (!lead_type || !["advisor", "platform"].includes(lead_type)) {
@@ -110,6 +121,7 @@ export async function POST(request: NextRequest) {
 
   const utm = extractUtm(body);
   const supabase = createAdminClient();
+  const normalizedEmail = (user_email as string).toLowerCase().trim();
 
   // ─── Platform leads (unchanged) ───
   if (lead_type === "platform") {
@@ -128,7 +140,7 @@ export async function POST(request: NextRequest) {
       .insert({
         lead_type,
         broker_id,
-        user_email: (user_email as string).toLowerCase().trim(),
+        user_email: normalizedEmail,
         user_name: typeof user_name === "string" ? user_name.trim() : null,
         user_phone: typeof user_phone === "string" ? user_phone.trim() : null,
         source_page: typeof source_page === "string" ? source_page : null,
@@ -155,71 +167,124 @@ export async function POST(request: NextRequest) {
   const advisorTypes = resolveAdvisorTypes(need, context);
   const userState = typeof user_location_state === "string" ? user_location_state : null;
 
+  // Build exclusion list: client-provided + any advisors this email was matched with in last 7 days
+  const excludeIds = new Set<number>(Array.isArray(exclude_advisor_ids) ? exclude_advisor_ids : []);
+
+  // Look up recent matches for this email to prevent cross-system duplicates
+  const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+  const { data: recentLeads } = await supabase
+    .from("leads")
+    .select("professional_id")
+    .eq("user_email", normalizedEmail)
+    .eq("lead_type", "advisor")
+    .gte("created_at", sevenDaysAgo)
+    .not("professional_id", "is", null);
+
+  if (recentLeads) {
+    for (const rl of recentLeads) {
+      if (rl.professional_id) excludeIds.add(rl.professional_id as number);
+    }
+  }
+
+  // Also check professional_leads (direct enquiry system) for cross-system dedup
+  const { data: recentEnquiries } = await supabase
+    .from("professional_leads")
+    .select("professional_id")
+    .eq("user_email", normalizedEmail)
+    .gte("created_at", sevenDaysAgo);
+
+  if (recentEnquiries) {
+    for (const re of recentEnquiries) {
+      if (re.professional_id) excludeIds.add(re.professional_id as number);
+    }
+  }
+
+  const excludeArray = [...excludeIds];
+
   // 24h ago for round-robin fairness
   const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
 
-  // Try matching: same state, no recent lead, best rated
+  // Helper: build match query with exclusion
+  function buildMatchQuery(opts: { state?: string; roundRobin?: boolean; anyType?: boolean }) {
+    let query = supabase
+      .from("professionals")
+      .select(MATCH_SELECT)
+      .eq("status", "active")
+      .eq("verified", true);
+
+    if (opts.state) query = query.eq("location_state", opts.state);
+    if (!opts.anyType) query = query.in("type", advisorTypes);
+    if (opts.roundRobin) query = query.or(`last_lead_date.is.null,last_lead_date.lt.${oneDayAgo}`);
+    if (excludeArray.length > 0) {
+      // Exclude already-matched advisors
+      for (const id of excludeArray) {
+        query = query.neq("id", id);
+      }
+    }
+
+    return query
+      .order("rating", { ascending: false })
+      .order("review_count", { ascending: false })
+      .limit(1);
+  }
+
+  // Try matching with 4-level fallback
   let matchedAdvisor: Record<string, unknown> | null = null;
 
-  // Attempt 1: Same state + not recently matched
+  // Attempt 1: Same state + round-robin + exclusion
   if (userState) {
-    const { data } = await supabase
-      .from("professionals")
-      .select("id, slug, name, firm_name, type, photo_url, rating, review_count, location_display, location_state, specialties, fee_description, verified, bio, email")
-      .eq("status", "active")
-      .eq("verified", true)
-      .eq("location_state", userState)
-      .in("type", advisorTypes)
-      .or(`last_lead_date.is.null,last_lead_date.lt.${oneDayAgo}`)
-      .order("rating", { ascending: false })
-      .order("review_count", { ascending: false })
-      .limit(1);
-
+    const { data } = await buildMatchQuery({ state: userState, roundRobin: true });
     if (data && data.length > 0) matchedAdvisor = data[0];
   }
 
-  // Attempt 2: Same state, any advisor (ignore round-robin)
+  // Attempt 2: Same state + exclusion (ignore round-robin)
   if (!matchedAdvisor && userState) {
-    const { data } = await supabase
-      .from("professionals")
-      .select("id, slug, name, firm_name, type, photo_url, rating, review_count, location_display, location_state, specialties, fee_description, verified, bio, email")
-      .eq("status", "active")
-      .eq("verified", true)
-      .eq("location_state", userState)
-      .in("type", advisorTypes)
-      .order("rating", { ascending: false })
-      .order("review_count", { ascending: false })
-      .limit(1);
-
+    const { data } = await buildMatchQuery({ state: userState });
     if (data && data.length > 0) matchedAdvisor = data[0];
   }
 
-  // Attempt 3: Any state, best available
+  // Attempt 3: Any state + exclusion
   if (!matchedAdvisor) {
-    const { data } = await supabase
-      .from("professionals")
-      .select("id, slug, name, firm_name, type, photo_url, rating, review_count, location_display, location_state, specialties, fee_description, verified, bio, email")
-      .eq("status", "active")
-      .eq("verified", true)
-      .in("type", advisorTypes)
-      .order("rating", { ascending: false })
-      .order("review_count", { ascending: false })
-      .limit(1);
-
+    const { data } = await buildMatchQuery({});
     if (data && data.length > 0) matchedAdvisor = data[0];
   }
 
-  // Attempt 4: Absolute fallback — any advisor
+  // Attempt 4: Any advisor + exclusion (any type)
   if (!matchedAdvisor) {
+    const { data } = await buildMatchQuery({ anyType: true });
+    if (data && data.length > 0) matchedAdvisor = data[0];
+  }
+
+  // Attempt 5: Absolute fallback — if all advisors excluded, tell user
+  if (!matchedAdvisor && excludeArray.length > 0) {
+    // Try without exclusions to see if there are ANY advisors
     const { data } = await supabase
       .from("professionals")
-      .select("id, slug, name, firm_name, type, photo_url, rating, review_count, location_display, location_state, specialties, fee_description, verified, bio, email")
+      .select(MATCH_SELECT)
       .eq("status", "active")
       .eq("verified", true)
       .order("rating", { ascending: false })
       .limit(1);
 
-    if (data && data.length > 0) matchedAdvisor = data[0];
+    if (!data || data.length === 0) {
+      // No advisors at all
+      return NextResponse.json({
+        success: true,
+        lead_id: null,
+        matched: null,
+        no_more_matches: true,
+        message: "We've matched you with all available advisors in this category. Browse our full directory for more options.",
+      });
+    }
+
+    // All advisors already matched — return signal to frontend
+    return NextResponse.json({
+      success: true,
+      lead_id: null,
+      matched: null,
+      no_more_matches: true,
+      message: "You've been matched with all available advisors for your criteria. Browse our full directory for more options.",
+    });
   }
 
   const matchedId = matchedAdvisor ? (matchedAdvisor.id as number) : null;
@@ -246,7 +311,7 @@ export async function POST(request: NextRequest) {
     .insert({
       lead_type,
       professional_id: resolvedProfessionalId,
-      user_email: (user_email as string).toLowerCase().trim(),
+      user_email: normalizedEmail,
       user_name: typeof user_name === "string" ? user_name.trim() : null,
       user_phone: typeof user_phone === "string" ? user_phone.trim() : null,
       user_location_state: userState,
@@ -273,9 +338,9 @@ export async function POST(request: NextRequest) {
       .insert({
         professional_id: resolvedProfessionalId,
         user_name: typeof user_name === "string" ? user_name.trim() : null,
-        user_email: (user_email as string).toLowerCase().trim(),
+        user_email: normalizedEmail,
         user_phone: typeof user_phone === "string" ? user_phone.trim() : null,
-        message: `Auto-matched via quiz. Need: ${need}. Context: ${(context || []).join(", ")}. Budget: ${user_intent?.budget || "not specified"}.`,
+        message: `Auto-matched via quiz${rematch ? " (rematch)" : ""}. Need: ${need}. Context: ${(context || []).join(", ")}. Budget: ${user_intent?.budget || "not specified"}.`,
         source_page: typeof source_page === "string" ? source_page : null,
         utm_source: (utm as UtmParams).utm_source ?? null,
         utm_medium: (utm as UtmParams).utm_medium ?? null,
@@ -293,27 +358,28 @@ export async function POST(request: NextRequest) {
   }
 
   // Send email notifications (non-blocking)
+  // On rematch, notify the new advisor but don't re-send the user confirmation
   if (matchedAdvisor && matchedAdvisor.email) {
-    // Notify the advisor
     sendNewLeadNotification(
       matchedAdvisor.email as string,
       matchedAdvisor.name as string,
       typeof user_name === "string" ? user_name.trim() : "A potential client",
-      (user_email as string).toLowerCase().trim(),
+      normalizedEmail,
       typeof user_phone === "string" ? user_phone.trim() : null,
       userState,
       need,
       context,
     ).catch(() => null);
 
-    // Confirm to the user
-    sendLeadConfirmationToUser(
-      (user_email as string).toLowerCase().trim(),
-      typeof user_name === "string" ? user_name.trim() : "there",
-      matchedAdvisor.name as string,
-      matchedAdvisor.type as string,
-      (matchedAdvisor.firm_name as string) || null,
-    ).catch(() => null);
+    if (!rematch) {
+      sendLeadConfirmationToUser(
+        normalizedEmail,
+        typeof user_name === "string" ? user_name.trim() : "there",
+        matchedAdvisor.name as string,
+        matchedAdvisor.type as string,
+        (matchedAdvisor.firm_name as string) || null,
+      ).catch(() => null);
+    }
   }
 
   log.info("Lead submitted with match", {
@@ -321,6 +387,8 @@ export async function POST(request: NextRequest) {
     matched_advisor_id: matchedId,
     advisor_types: advisorTypes,
     state: userState,
+    rematch: !!rematch,
+    excluded: excludeArray.length,
   });
 
   return NextResponse.json({
@@ -328,6 +396,7 @@ export async function POST(request: NextRequest) {
     lead_id: lead?.id,
     matched: matchedAdvisor
       ? {
+          id: matchedAdvisor.id,
           slug: matchedAdvisor.slug,
           name: matchedAdvisor.name,
           firm_name: matchedAdvisor.firm_name || null,
@@ -341,5 +410,6 @@ export async function POST(request: NextRequest) {
           verified: matchedAdvisor.verified || false,
         }
       : null,
+    no_more_matches: false,
   });
 }

--- a/app/broker/[slug]/BrokerReviewClient.tsx
+++ b/app/broker/[slug]/BrokerReviewClient.tsx
@@ -130,7 +130,7 @@ function formatFieldName(name: string): string {
 
 const CATEGORY_COLORS: Record<string, string> = {
   tax: "bg-purple-100 text-purple-700",
-  beginners: "bg-blue-100 text-blue-700",
+  beginners: "bg-amber-100 text-amber-700",
   smsf: "bg-emerald-100 text-emerald-700",
   strategy: "bg-amber-100 text-amber-700",
   news: "bg-red-100 text-red-700",
@@ -296,7 +296,7 @@ export default function BrokerReviewClient({
                 <span className="text-amber-400 text-sm">{renderStars(b.rating || 0)}</span>
                 <span className="text-sm font-bold text-slate-700">{b.rating}/5</span>
                 {b.chess_sponsored && (
-                  <span className="px-2 py-0.5 bg-blue-100 text-blue-700 text-xs font-semibold rounded-full">CHESS</span>
+                  <span className="px-2 py-0.5 bg-amber-100 text-amber-700 text-xs font-semibold rounded-full">CHESS</span>
                 )}
                 {b.deal && (
                   <span className="px-2 py-0.5 bg-amber-100 text-amber-700 text-xs font-semibold rounded-full">Deal Active</span>
@@ -407,15 +407,15 @@ export default function BrokerReviewClient({
         )}
 
         {/* Who Is This Best For? */}
-        <div id="best-for" className="bg-blue-50 border border-blue-200 rounded-xl p-4 md:p-6 mb-6 md:mb-8 scroll-mt-20">
+        <div id="best-for" className="bg-amber-50 border border-amber-200 rounded-xl p-4 md:p-6 mb-6 md:mb-8 scroll-mt-20">
           <div className="flex items-center gap-2 mb-3">
-            <Icon name="target" size={20} className="text-blue-700 shrink-0" />
+            <Icon name="target" size={20} className="text-amber-700 shrink-0" />
             <h2 className="text-base md:text-lg font-extrabold text-slate-900">Who Is {b.name} Best For?</h2>
           </div>
           <ul className="space-y-2">
             {bestFor.map((item, i) => (
               <li key={i} className="flex items-start gap-2 text-sm text-slate-700">
-                <span className="text-blue-600 font-bold mt-0.5">✓</span>
+                <span className="text-amber-600 font-bold mt-0.5">✓</span>
                 <span>{item}</span>
               </li>
             ))}
@@ -513,7 +513,7 @@ export default function BrokerReviewClient({
         <div className="grid grid-cols-2 md:grid-cols-4 gap-2 md:gap-3 mb-6 md:mb-8">
           {[
             { label: "ASX Fee", value: b.asx_fee || "N/A", sub: b.asx_fee_value != null && b.asx_fee_value === 0 ? "Free" : undefined, accent: "border-t-emerald-500" },
-            { label: "US Fee", value: b.us_fee || "N/A", sub: b.platform_type === "crypto_exchange" ? "N/A" : undefined, accent: "border-t-blue-500" },
+            { label: "US Fee", value: b.us_fee || "N/A", sub: b.platform_type === "crypto_exchange" ? "N/A" : undefined, accent: "border-t-amber-500" },
             { label: "FX Rate", value: b.fx_rate != null ? `${b.fx_rate}%` : "N/A", accent: "border-t-amber-500" },
             { label: "Safety", value: b.chess_sponsored ? "CHESS" : b.platform_type === "crypto_exchange" ? "AUSTRAC" : "Custodian", accent: "border-t-violet-500" },
           ].map((stat, i) => (
@@ -803,11 +803,11 @@ export default function BrokerReviewClient({
             )}
 
             {b.platform_type === "super_fund" && (
-              <div className="bg-blue-50 border border-blue-200 rounded-lg p-3">
-                <h3 className="font-semibold text-blue-800 mb-1 text-xs flex items-center gap-1.5">
+              <div className="bg-amber-50 border border-amber-200 rounded-lg p-3">
+                <h3 className="font-semibold text-amber-800 mb-1 text-xs flex items-center gap-1.5">
                   <span>🏛️</span> Super Fund Switching Warning — ASIC RG 183
                 </h3>
-                <p className="text-xs text-blue-700 leading-relaxed">{SUPER_WARNING}</p>
+                <p className="text-xs text-amber-700 leading-relaxed">{SUPER_WARNING}</p>
               </div>
             )}
 
@@ -873,7 +873,7 @@ export default function BrokerReviewClient({
                 {feeHistory.map((c) => (
                   <div key={c.id} className="flex items-start gap-3 bg-white border border-slate-200 rounded-lg px-4 py-3">
                     <span className={`text-[10px] font-bold uppercase px-1.5 py-0.5 rounded mt-0.5 ${
-                      c.change_type === 'update' ? 'bg-blue-50 text-blue-700' :
+                      c.change_type === 'update' ? 'bg-amber-50 text-amber-700' :
                       c.change_type === 'add' ? 'bg-emerald-50 text-emerald-700' :
                       'bg-red-50 text-red-700'
                     }`}>
@@ -889,7 +889,7 @@ export default function BrokerReviewClient({
                             <div className="text-xs text-slate-500 mt-0.5 flex items-center gap-1">
                               <span className="line-through text-red-400 truncate max-w-[180px]">{c.old_value || '\u2014'}</span>
                               <span className="text-slate-300">{'\u2192'}</span>
-                              <span className="text-blue-700 font-medium truncate max-w-[180px]">{c.new_value || '\u2014'}</span>
+                              <span className="text-amber-700 font-medium truncate max-w-[180px]">{c.new_value || '\u2014'}</span>
                             </div>
                           )}
                           {c.change_type === 'add' && <p className="text-xs text-emerald-700 mt-0.5">{c.new_value}</p>}

--- a/app/compare/_components/CompareFooter.tsx
+++ b/app/compare/_components/CompareFooter.tsx
@@ -138,10 +138,10 @@ export default function CompareFooter({ sorted, brokers, activeFilter }: Props) 
           </Link>
         </div>
         <div className="bg-white border border-slate-200 rounded-xl p-3 md:p-6 flex flex-col items-start gap-1.5 md:gap-0">
-          <Icon name="calculator" size={18} className="text-violet-600 shrink-0 md:mb-2" />
+          <Icon name="calculator" size={18} className="text-amber-600 shrink-0 md:mb-2" />
           <h2 className="text-xs md:text-lg font-bold text-slate-900">Fee Calculator</h2>
           <p className="text-[0.58rem] md:text-xs text-slate-500 md:mb-4 hidden md:block">See exact fees for your portfolio at every broker.</p>
-          <Link href="/portfolio-calculator" className="mt-auto px-3 md:px-5 py-1.5 md:py-2.5 bg-violet-600 text-white text-[0.65rem] md:text-sm font-bold rounded-lg hover:bg-violet-700 transition-colors">
+          <Link href="/portfolio-calculator" className="mt-auto px-3 md:px-5 py-1.5 md:py-2.5 bg-amber-600 text-white text-[0.65rem] md:text-sm font-bold rounded-lg hover:bg-amber-700 transition-colors">
             Calculate →
           </Link>
         </div>

--- a/app/deals/page.tsx
+++ b/app/deals/page.tsx
@@ -120,12 +120,12 @@ export default async function DealsPage() {
               <div className="flex items-center justify-between mb-4">
                 <div>
                   <h2 className="text-base md:text-lg font-bold text-slate-900 flex items-center gap-2">
-                    <Icon name="users" size={18} className="text-violet-500" />
+                    <Icon name="users" size={18} className="text-amber-500" />
                     Verified Financial Advisors
                   </h2>
                   <p className="text-[0.65rem] md:text-xs text-slate-500 mt-0.5">Send a free enquiry to a verified professional — exclusive, no obligation</p>
                 </div>
-                <Link href="/advisors" className="text-xs font-semibold text-violet-600 hover:text-violet-800 transition-colors hidden md:flex items-center gap-1">
+                <Link href="/advisors" className="text-xs font-semibold text-amber-600 hover:text-amber-800 transition-colors hidden md:flex items-center gap-1">
                   Browse all advisors &rarr;
                 </Link>
               </div>
@@ -136,7 +136,7 @@ export default async function DealsPage() {
                     <Link
                       key={advisor.slug}
                       href={`/advisor/${advisor.slug}`}
-                      className="flex items-start gap-3 p-3.5 bg-white border border-violet-100 rounded-xl hover:border-violet-300 hover:shadow-md transition-all group"
+                      className="flex items-start gap-3 p-3.5 bg-white border border-amber-100 rounded-xl hover:border-amber-300 hover:shadow-md transition-all group"
                     >
                       <Image
                         src={advisor.photo_url || `https://ui-avatars.com/api/?name=${encodeURIComponent(advisor.name)}&size=80&background=7c3aed&color=fff`}
@@ -146,9 +146,9 @@ export default async function DealsPage() {
                         className="rounded-full shrink-0"
                       />
                       <div className="flex-1 min-w-0">
-                        <p className="text-sm font-bold text-slate-900 group-hover:text-violet-700 transition-colors">{advisor.name}</p>
+                        <p className="text-sm font-bold text-slate-900 group-hover:text-amber-700 transition-colors">{advisor.name}</p>
                         <p className="text-[0.65rem] text-slate-500">{advisor.firm_name}</p>
-                        <p className="text-[0.6rem] text-violet-600 font-medium mt-0.5">{typeLabel} &middot; {advisor.location_display}</p>
+                        <p className="text-[0.6rem] text-amber-600 font-medium mt-0.5">{typeLabel} &middot; {advisor.location_display}</p>
                         <div className="flex items-center gap-1.5 mt-1">
                           <span className="text-[0.62rem] text-amber-600 font-bold">{advisor.rating}/5</span>
                           <span className="text-[0.58rem] text-slate-400">({advisor.review_count} reviews)</span>
@@ -159,8 +159,8 @@ export default async function DealsPage() {
                 })}
               </div>
               <div className="text-center mt-3">
-                <Link href="/find-advisor" className="inline-flex items-center gap-1.5 px-5 py-2.5 bg-violet-600 text-white text-xs font-bold rounded-lg hover:bg-violet-700 transition-colors">
-                  <Icon name="search" size={14} className="text-violet-200" />
+                <Link href="/find-advisor" className="inline-flex items-center gap-1.5 px-5 py-2.5 bg-amber-600 text-white text-xs font-bold rounded-lg hover:bg-amber-700 transition-colors">
+                  <Icon name="search" size={14} className="text-amber-200" />
                   Find Your Advisor
                 </Link>
               </div>

--- a/app/find-advisor/page.tsx
+++ b/app/find-advisor/page.tsx
@@ -17,6 +17,7 @@ import { trackEvent } from "@/lib/tracking";
 type Intent = "buy_property" | "grow_wealth" | "protect_assets" | "business_tax";
 
 interface MatchedAdvisor {
+  id: number;
   slug: string;
   name: string;
   firm_name: string | null;
@@ -42,12 +43,45 @@ interface QuizState {
   consent: boolean;
 }
 
+// ─── Session persistence helpers ─────────────────────────────────────────────
+
+const STORAGE_KEY = "invest_quiz_match";
+
+interface PersistedMatch {
+  matchedAdvisors: MatchedAdvisor[];
+  excludeIds: number[];
+  quizData: { intent: string; context: string[]; state: string; budget: string; firstName: string; email: string };
+  timestamp: number;
+}
+
+function saveMatchToStorage(data: PersistedMatch) {
+  try { sessionStorage.setItem(STORAGE_KEY, JSON.stringify(data)); } catch {}
+}
+
+function loadMatchFromStorage(): PersistedMatch | null {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const data = JSON.parse(raw) as PersistedMatch;
+    // Expire after 1 hour
+    if (Date.now() - data.timestamp > 60 * 60 * 1000) {
+      sessionStorage.removeItem(STORAGE_KEY);
+      return null;
+    }
+    return data;
+  } catch { return null; }
+}
+
+function clearMatchStorage() {
+  try { sessionStorage.removeItem(STORAGE_KEY); } catch {}
+}
+
 // ─── Step 1 data ──────────────────────────────────────────────────────────────
 
 const INTENT_OPTIONS = [
   {
     id: "buy_property" as Intent,
-    emoji: "🏠",
+    emoji: "\u{1F3E0}",
     title: "Buy Property",
     desc: "Purchase a home or investment property",
     baseClass: "from-rose-50 to-orange-50 border-rose-200 hover:border-rose-400 hover:shadow-rose-100",
@@ -55,7 +89,7 @@ const INTENT_OPTIONS = [
   },
   {
     id: "grow_wealth" as Intent,
-    emoji: "📈",
+    emoji: "\u{1F4C8}",
     title: "Grow Wealth",
     desc: "Build long-term financial security",
     baseClass: "from-emerald-50 to-teal-50 border-emerald-200 hover:border-emerald-400 hover:shadow-emerald-100",
@@ -63,7 +97,7 @@ const INTENT_OPTIONS = [
   },
   {
     id: "protect_assets" as Intent,
-    emoji: "🛡️",
+    emoji: "\u{1F6E1}\uFE0F",
     title: "Protect Assets",
     desc: "Insurance, estate planning & succession",
     baseClass: "from-blue-50 to-indigo-50 border-blue-200 hover:border-blue-400 hover:shadow-blue-100",
@@ -71,7 +105,7 @@ const INTENT_OPTIONS = [
   },
   {
     id: "business_tax" as Intent,
-    emoji: "📊",
+    emoji: "\u{1F4CA}",
     title: "Business / Tax",
     desc: "SMSF setup, tax strategy & debt",
     baseClass: "from-violet-50 to-purple-50 border-violet-200 hover:border-violet-400 hover:shadow-violet-100",
@@ -103,7 +137,7 @@ const CONTEXT_CONFIG: Record<
     type: "radio",
     options: [
       { id: "getting_started", label: "Just getting started (under $10k saved)" },
-      { id: "have_savings", label: "I have savings but no investing plan ($10k–$100k)" },
+      { id: "have_savings", label: "I have savings but no investing plan ($10k\u2013$100k)" },
       { id: "optimize", label: "I have investments and want to optimise ($100k+)" },
       { id: "retirement", label: "I'm approaching retirement and need a strategy" },
     ],
@@ -121,7 +155,7 @@ const CONTEXT_CONFIG: Record<
     ],
   },
   business_tax: {
-    title: "What's your situation?",
+    title: "What\u2019s your situation?",
     subtitle: "Choose the option that best describes you",
     type: "radio",
     options: [
@@ -137,7 +171,7 @@ const CONTEXT_CONFIG: Record<
 // ─── Step 3 select options ────────────────────────────────────────────────────
 
 const STATES = [
-  { value: "", label: "Select your state or territory…", disabled: true },
+  { value: "", label: "Select your state or territory\u2026", disabled: true },
   { value: "NSW", label: "New South Wales" },
   { value: "VIC", label: "Victoria" },
   { value: "QLD", label: "Queensland" },
@@ -149,11 +183,11 @@ const STATES = [
 ];
 
 const BUDGETS = [
-  { value: "", label: "Select a range (optional)…" },
-  { value: "under_100k", label: "Under $100k — just getting started" },
-  { value: "100k_500k", label: "$100k – $500k — building wealth" },
-  { value: "500k_2m", label: "$500k – $2M — established investor" },
-  { value: "over_2m", label: "$2M+ — high net worth" },
+  { value: "", label: "Select a range (optional)\u2026" },
+  { value: "under_100k", label: "Under $100k \u2014 just getting started" },
+  { value: "100k_500k", label: "$100k \u2013 $500k \u2014 building wealth" },
+  { value: "500k_2m", label: "$500k \u2013 $2M \u2014 established investor" },
+  { value: "over_2m", label: "$2M+ \u2014 high net worth" },
   { value: "prefer_not_say", label: "Prefer not to say" },
 ];
 
@@ -208,11 +242,37 @@ function FindAdvisorQuiz() {
       }
     }
   }, [needParam, appliedNeed]);
+
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [submitted, setSubmitted] = useState(false);
-  const [matchedAdvisor, setMatchedAdvisor] = useState<MatchedAdvisor | null>(null);
+  const [matchedAdvisors, setMatchedAdvisors] = useState<MatchedAdvisor[]>([]);
+  const [excludeIds, setExcludeIds] = useState<number[]>([]);
+  const [noMoreMatches, setNoMoreMatches] = useState(false);
+  const [rematching, setRematching] = useState(false);
+
+  // Restore persisted match on mount
+  useEffect(() => {
+    const saved = loadMatchFromStorage();
+    if (saved && saved.matchedAdvisors.length > 0) {
+      setMatchedAdvisors(saved.matchedAdvisors);
+      setExcludeIds(saved.excludeIds);
+      setSubmitted(true);
+      setQuiz(prev => ({
+        ...prev,
+        step: 5,
+        intent: (saved.quizData.intent as Intent) || prev.intent,
+        context: saved.quizData.context || prev.context,
+        state: saved.quizData.state || prev.state,
+        budget: saved.quizData.budget || prev.budget,
+        firstName: saved.quizData.firstName || prev.firstName,
+        email: saved.quizData.email || prev.email,
+      }));
+    }
+  }, []);
+
+  const currentMatch = matchedAdvisors.length > 0 ? matchedAdvisors[matchedAdvisors.length - 1] : null;
 
   const update = useCallback((updates: Partial<QuizState>) => {
     setQuiz((prev) => ({ ...prev, ...updates }));
@@ -220,7 +280,9 @@ function FindAdvisorQuiz() {
 
   const restart = () => {
     setQuiz({ step: 1, intent: null, context: [], state: "", budget: "", firstName: "", email: "", phone: "", consent: false });
-    setErrors({}); setSubmitError(null); setSubmitted(false); setMatchedAdvisor(null);
+    setErrors({}); setSubmitError(null); setSubmitted(false);
+    setMatchedAdvisors([]); setExcludeIds([]); setNoMoreMatches(false);
+    clearMatchStorage();
   };
 
   const handleIntent = (intent: Intent) => {
@@ -251,6 +313,31 @@ function FindAdvisorQuiz() {
     update({ step: 4 });
   };
 
+  const submitMatch = async (isRematch: boolean = false) => {
+    const res = await fetch("/api/submit-lead", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        lead_type: "advisor",
+        user_email: quiz.email.trim(),
+        user_name: quiz.firstName.trim(),
+        user_phone: quiz.phone.trim() || undefined,
+        user_location_state: quiz.state,
+        user_intent: {
+          need: intentToNeed(quiz.intent!),
+          context: quiz.context,
+          budget: quiz.budget,
+        },
+        source_page: "/find-advisor",
+        exclude_advisor_ids: isRematch ? excludeIds : [],
+        rematch: isRematch,
+      }),
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error || "Something went wrong.");
+    return data;
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     const errs: Record<string, string> = {};
@@ -264,33 +351,72 @@ function FindAdvisorQuiz() {
     setErrors({});
 
     try {
-      const res = await fetch("/api/submit-lead", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          lead_type: "advisor",
-          user_email: quiz.email.trim(),
-          user_name: quiz.firstName.trim(),
-          user_phone: quiz.phone.trim() || undefined,
-          user_location_state: quiz.state,
-          user_intent: {
-            need: intentToNeed(quiz.intent!),
+      const data = await submitMatch(false);
+      if (data.matched) {
+        const advisor = data.matched as MatchedAdvisor;
+        setMatchedAdvisors([advisor]);
+        setExcludeIds([advisor.id]);
+        // Persist to sessionStorage
+        saveMatchToStorage({
+          matchedAdvisors: [advisor],
+          excludeIds: [advisor.id],
+          quizData: {
+            intent: quiz.intent || "",
             context: quiz.context,
+            state: quiz.state,
             budget: quiz.budget,
+            firstName: quiz.firstName,
+            email: quiz.email,
           },
-          source_page: "/find-advisor",
-        }),
-      });
-      const data = await res.json();
-      if (!res.ok) { setSubmitError(data.error || "Something went wrong."); return; }
-      if (data.matched) setMatchedAdvisor(data.matched);
+          timestamp: Date.now(),
+        });
+      }
       setSubmitted(true);
       update({ step: 5 });
       trackEvent("find_advisor_complete", { intent: quiz.intent, matched: !!data.matched }, "/find-advisor");
-    } catch {
-      setSubmitError("Network error. Please try again.");
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : "Network error. Please try again.");
     } finally {
       setSubmitting(false);
+    }
+  };
+
+  const handleRematch = async () => {
+    setRematching(true);
+    setSubmitError(null);
+
+    try {
+      const data = await submitMatch(true);
+
+      if (data.no_more_matches) {
+        setNoMoreMatches(true);
+        trackEvent("find_advisor_no_more_matches", { intent: quiz.intent, matched_count: matchedAdvisors.length }, "/find-advisor");
+      } else if (data.matched) {
+        const advisor = data.matched as MatchedAdvisor;
+        const newAdvisors = [...matchedAdvisors, advisor];
+        const newExclude = [...excludeIds, advisor.id];
+        setMatchedAdvisors(newAdvisors);
+        setExcludeIds(newExclude);
+        // Update persistence
+        saveMatchToStorage({
+          matchedAdvisors: newAdvisors,
+          excludeIds: newExclude,
+          quizData: {
+            intent: quiz.intent || "",
+            context: quiz.context,
+            state: quiz.state,
+            budget: quiz.budget,
+            firstName: quiz.firstName,
+            email: quiz.email,
+          },
+          timestamp: Date.now(),
+        });
+        trackEvent("find_advisor_rematch", { intent: quiz.intent, new_advisor: advisor.slug, match_number: newAdvisors.length }, "/find-advisor");
+      }
+    } catch {
+      setSubmitError("Couldn't find another match. Please try again.");
+    } finally {
+      setRematching(false);
     }
   };
 
@@ -365,8 +491,13 @@ function FindAdvisorQuiz() {
           <MatchConfirmation
             userEmail={quiz.email}
             userFirstName={quiz.firstName}
-            matchedAdvisor={matchedAdvisor}
+            currentMatch={currentMatch}
+            allMatches={matchedAdvisors}
+            onRematch={handleRematch}
+            rematching={rematching}
+            noMoreMatches={noMoreMatches}
             onRestart={restart}
+            submitError={submitError}
           />
         )}
 
@@ -421,7 +552,7 @@ function Step1({ onSelect }: { onSelect: (intent: Intent) => void }) {
       </div>
 
       <div className="mt-8 pt-6 border-t border-slate-100 flex flex-wrap items-center justify-center gap-x-5 gap-y-2 text-xs text-slate-500">
-        {["ASIC-verified professionals", "100% free to use", "No spam — ever"].map((t) => (
+        {["ASIC-verified professionals", "100% free to use", "No spam \u2014 ever"].map((t) => (
           <span key={t} className="flex items-center gap-1.5">
             <svg className="w-3.5 h-3.5 text-emerald-500" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
               <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
@@ -486,9 +617,9 @@ function Step2({
       )}
 
       <div className="flex gap-3 mt-8">
-        <Button variant="ghost" onClick={onBack}>← Back</Button>
+        <Button variant="ghost" onClick={onBack}>&larr; Back</Button>
         <Button variant="primary" onClick={onNext} disabled={selections.length === 0} className="flex-1">
-          Continue →
+          Continue &rarr;
         </Button>
       </div>
     </Card>
@@ -538,9 +669,9 @@ function Step3({
       </div>
 
       <div className="flex gap-3 mt-8">
-        <Button variant="ghost" onClick={onBack}>← Back</Button>
+        <Button variant="ghost" onClick={onBack}>&larr; Back</Button>
         <Button variant="primary" onClick={onNext} disabled={!stateValue} className="flex-1">
-          Continue →
+          Continue &rarr;
         </Button>
       </div>
     </Card>
@@ -616,9 +747,9 @@ function Step4({
         </div>
 
         <div className="flex gap-3 pt-2">
-          <Button type="button" variant="ghost" onClick={onBack} disabled={submitting}>← Back</Button>
+          <Button type="button" variant="ghost" onClick={onBack} disabled={submitting}>&larr; Back</Button>
           <Button type="submit" variant="primary" loading={submitting} disabled={submitting} className="flex-1">
-            {submitting ? "Finding your match…" : "Get Matched Free →"}
+            {submitting ? "Finding your match\u2026" : "Get Matched Free \u2192"}
           </Button>
         </div>
       </form>
@@ -632,8 +763,9 @@ function typeLabel(type: string): string {
   return type.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
-function MatchConfirmation({ userEmail, userFirstName, matchedAdvisor, onRestart }: {
-  userEmail: string; userFirstName: string; matchedAdvisor: MatchedAdvisor | null; onRestart: () => void;
+function MatchConfirmation({ userEmail, userFirstName, currentMatch, allMatches, onRematch, rematching, noMoreMatches, onRestart, submitError }: {
+  userEmail: string; userFirstName: string; currentMatch: MatchedAdvisor | null; allMatches: MatchedAdvisor[];
+  onRematch: () => void; rematching: boolean; noMoreMatches: boolean; onRestart: () => void; submitError: string | null;
 }) {
   return (
     <div className="space-y-5 animate-in fade-in slide-in-from-bottom-4 duration-500">
@@ -645,17 +777,22 @@ function MatchConfirmation({ userEmail, userFirstName, matchedAdvisor, onRestart
           </svg>
         </div>
         <h1 className="text-2xl md:text-3xl font-extrabold text-slate-900 mb-1">
-          {matchedAdvisor ? "You've been matched!" : "Request Received!"}
+          {currentMatch ? "You\u2019ve been matched!" : "Request Received!"}
         </h1>
         <p className="text-sm text-slate-500">
-          {matchedAdvisor
-            ? `Great news ${userFirstName} — we found the perfect advisor for you`
+          {currentMatch
+            ? `Great news ${userFirstName} \u2014 we found the perfect advisor for you`
             : "We'll match you with a verified professional shortly"}
         </p>
+        {allMatches.length > 1 && (
+          <p className="text-xs text-amber-600 font-semibold mt-1">
+            Match {allMatches.length} of {allMatches.length}{noMoreMatches ? " (all available)" : ""}
+          </p>
+        )}
       </div>
 
       {/* Matched advisor card */}
-      {matchedAdvisor && (
+      {currentMatch && (
         <div className="relative overflow-hidden rounded-2xl border-2 border-amber-200 bg-gradient-to-br from-amber-50/80 via-white to-white shadow-lg">
           {/* Match quality bar */}
           <div className="bg-gradient-to-r from-amber-500 to-amber-400 px-4 py-2.5 flex items-center justify-between">
@@ -663,7 +800,7 @@ function MatchConfirmation({ userEmail, userFirstName, matchedAdvisor, onRestart
               <Icon name="zap" size={14} className="text-white" />
               <span className="text-xs font-bold tracking-wide uppercase">Your Matched Advisor</span>
             </div>
-            {matchedAdvisor.verified && (
+            {currentMatch.verified && (
               <div className="flex items-center gap-1 bg-white/20 backdrop-blur-sm rounded-full px-2.5 py-0.5">
                 <Icon name="shield-check" size={12} className="text-white" />
                 <span className="text-[0.65rem] font-semibold text-white">ASIC Verified</span>
@@ -676,8 +813,8 @@ function MatchConfirmation({ userEmail, userFirstName, matchedAdvisor, onRestart
             <div className="flex items-start gap-4 mb-5">
               <div className="relative shrink-0">
                 <Image
-                  src={matchedAdvisor.photo_url || `https://ui-avatars.com/api/?name=${encodeURIComponent(matchedAdvisor.name)}&size=160&background=f59e0b&color=fff&bold=true`}
-                  alt={matchedAdvisor.name}
+                  src={currentMatch.photo_url || `https://ui-avatars.com/api/?name=${encodeURIComponent(currentMatch.name)}&size=160&background=f59e0b&color=fff&bold=true`}
+                  alt={currentMatch.name}
                   width={72}
                   height={72}
                   className="rounded-xl object-cover w-16 h-16 md:w-[72px] md:h-[72px] ring-2 ring-amber-200"
@@ -687,19 +824,19 @@ function MatchConfirmation({ userEmail, userFirstName, matchedAdvisor, onRestart
                 </div>
               </div>
               <div className="flex-1 min-w-0">
-                <h2 className="text-lg md:text-xl font-extrabold text-slate-900 leading-tight">{matchedAdvisor.name}</h2>
-                <p className="text-sm font-semibold text-amber-600 mt-0.5">{typeLabel(matchedAdvisor.type)}</p>
-                {matchedAdvisor.firm_name && (
-                  <p className="text-xs text-slate-500 mt-0.5">{matchedAdvisor.firm_name}</p>
+                <h2 className="text-lg md:text-xl font-extrabold text-slate-900 leading-tight">{currentMatch.name}</h2>
+                <p className="text-sm font-semibold text-amber-600 mt-0.5">{typeLabel(currentMatch.type)}</p>
+                {currentMatch.firm_name && (
+                  <p className="text-xs text-slate-500 mt-0.5">{currentMatch.firm_name}</p>
                 )}
                 <div className="flex items-center gap-3 mt-2">
-                  {matchedAdvisor.rating > 0 && (
+                  {currentMatch.rating > 0 && (
                     <div className="flex items-center gap-1">
                       <div className="flex">
                         {Array.from({ length: 5 }).map((_, i) => (
                           <svg
                             key={i}
-                            className={`w-3.5 h-3.5 ${i < Math.round(matchedAdvisor.rating) ? "text-amber-400" : "text-slate-200"}`}
+                            className={`w-3.5 h-3.5 ${i < Math.round(currentMatch.rating) ? "text-amber-400" : "text-slate-200"}`}
                             fill="currentColor"
                             viewBox="0 0 20 20"
                           >
@@ -707,14 +844,14 @@ function MatchConfirmation({ userEmail, userFirstName, matchedAdvisor, onRestart
                           </svg>
                         ))}
                       </div>
-                      <span className="text-xs font-bold text-slate-700">{matchedAdvisor.rating}</span>
-                      <span className="text-xs text-slate-400">({matchedAdvisor.review_count})</span>
+                      <span className="text-xs font-bold text-slate-700">{currentMatch.rating}</span>
+                      <span className="text-xs text-slate-400">({currentMatch.review_count})</span>
                     </div>
                   )}
-                  {matchedAdvisor.location_display && (
+                  {currentMatch.location_display && (
                     <span className="text-xs text-slate-500 flex items-center gap-1">
                       <Icon name="map-pin" size={11} className="text-slate-400" />
-                      {matchedAdvisor.location_display}
+                      {currentMatch.location_display}
                     </span>
                   )}
                 </div>
@@ -722,11 +859,11 @@ function MatchConfirmation({ userEmail, userFirstName, matchedAdvisor, onRestart
             </div>
 
             {/* Specialties */}
-            {matchedAdvisor.specialties?.length > 0 && (
+            {currentMatch.specialties?.length > 0 && (
               <div className="mb-4">
                 <p className="text-[0.65rem] font-semibold text-slate-400 uppercase tracking-wider mb-2">Specialties</p>
                 <div className="flex flex-wrap gap-1.5">
-                  {matchedAdvisor.specialties.slice(0, 5).map((spec) => (
+                  {currentMatch.specialties.slice(0, 5).map((spec) => (
                     <span key={spec} className="text-xs bg-amber-50 text-amber-700 border border-amber-200 px-2.5 py-1 rounded-lg font-medium">
                       {spec}
                     </span>
@@ -736,22 +873,88 @@ function MatchConfirmation({ userEmail, userFirstName, matchedAdvisor, onRestart
             )}
 
             {/* Fee info */}
-            {matchedAdvisor.fee_description && (
+            {currentMatch.fee_description && (
               <div className="bg-slate-50 rounded-xl p-3 mb-4 flex items-start gap-2">
                 <Icon name="coins" size={14} className="text-slate-400 shrink-0 mt-0.5" />
-                <p className="text-xs text-slate-600 leading-relaxed">{matchedAdvisor.fee_description}</p>
+                <p className="text-xs text-slate-600 leading-relaxed">{currentMatch.fee_description}</p>
               </div>
             )}
 
             {/* CTA */}
             <Link
-              href={`/advisor/${matchedAdvisor.slug}`}
+              href={`/advisor/${currentMatch.slug}`}
               className="flex items-center justify-center gap-2 w-full py-3 bg-amber-500 hover:bg-amber-600 text-white font-bold rounded-xl transition-all shadow-sm hover:shadow-md text-sm"
             >
               View Full Profile
               <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" /></svg>
             </Link>
           </div>
+        </div>
+      )}
+
+      {/* Previously matched advisors */}
+      {allMatches.length > 1 && (
+        <div>
+          <p className="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-2">Previous Matches</p>
+          <div className="space-y-2">
+            {allMatches.slice(0, -1).reverse().map((advisor) => (
+              <Link
+                key={advisor.id}
+                href={`/advisor/${advisor.slug}`}
+                className="flex items-center gap-3 p-3 bg-slate-50 border border-slate-200 rounded-xl hover:bg-slate-100 transition-colors"
+              >
+                <Image
+                  src={advisor.photo_url || `https://ui-avatars.com/api/?name=${encodeURIComponent(advisor.name)}&size=80&background=f59e0b&color=fff&bold=true`}
+                  alt={advisor.name}
+                  width={40}
+                  height={40}
+                  className="rounded-lg object-cover w-10 h-10 shrink-0"
+                />
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-bold text-slate-800 truncate">{advisor.name}</p>
+                  <p className="text-xs text-slate-500">{typeLabel(advisor.type)}{advisor.location_display ? ` \u2022 ${advisor.location_display}` : ""}</p>
+                </div>
+                <div className="flex items-center gap-1 text-xs text-amber-500 font-semibold shrink-0">
+                  <span>{advisor.rating}</span>
+                  <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 20 20"><path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" /></svg>
+                </div>
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Rematch button */}
+      {currentMatch && !noMoreMatches && (
+        <button
+          onClick={onRematch}
+          disabled={rematching}
+          className="w-full py-3 border-2 border-dashed border-slate-300 rounded-xl text-sm font-semibold text-slate-600 hover:border-amber-400 hover:text-amber-700 hover:bg-amber-50/50 transition-all disabled:opacity-50"
+        >
+          {rematching ? (
+            <span className="flex items-center justify-center gap-2">
+              <svg className="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24"><circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" /><path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" /></svg>
+              Finding another advisor...
+            </span>
+          ) : (
+            <span className="flex items-center justify-center gap-2">
+              <Icon name="refresh-cw" size={14} />
+              Match me with a different advisor
+            </span>
+          )}
+        </button>
+      )}
+
+      {noMoreMatches && (
+        <div className="bg-amber-50 border border-amber-200 rounded-xl p-4 text-center">
+          <p className="text-sm font-semibold text-amber-800 mb-1">You&apos;ve seen all available matches</p>
+          <p className="text-xs text-amber-600">We&apos;ve matched you with every advisor available for your criteria. Browse our full directory for more options.</p>
+        </div>
+      )}
+
+      {submitError && (
+        <div className="p-3 bg-red-50 border border-red-200 rounded-xl text-sm text-red-700 text-center">
+          {submitError}
         </div>
       )}
 
@@ -762,16 +965,16 @@ function MatchConfirmation({ userEmail, userFirstName, matchedAdvisor, onRestart
           What happens next, {userFirstName}:
         </h3>
         <ol className="space-y-3">
-          {(matchedAdvisor
+          {(currentMatch
             ? [
-                `${matchedAdvisor.name} has been notified of your enquiry`,
+                `${currentMatch.name} has been notified of your enquiry`,
                 `They'll reach out to you at ${userEmail} within 24 hours`,
-                "You'll book a free initial consultation — no obligation",
+                "You'll book a free initial consultation \u2014 no obligation",
               ]
             : [
                 "We'll find the best-matched advisor for your situation",
                 `They'll reach out to you at ${userEmail} within 24 hours`,
-                "You'll book a free initial consultation — no obligation",
+                "You'll book a free initial consultation \u2014 no obligation",
               ]
           ).map((step, i) => (
             <li key={i} className="flex items-start gap-3">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -228,12 +228,7 @@ export default async function HomePage() {
         </section>
       </ScrollFadeIn>
 
-      {/* ═══════ 3. ADVISOR DIRECTORY ═══════ */}
-      <AdvisorDirectory
-        advisors={(featuredAdvisors as { slug: string; name: string; firm_name?: string; type: string; location_display?: string; location_state?: string; rating: number; review_count: number; photo_url?: string; specialties: string[]; verified?: boolean }[]) || []}
-      />
-
-      {/* ═══════ 4. TOP PLATFORMS ═══════ */}
+      {/* ═══════ 3. TOP PLATFORMS ═══════ */}
       <ScrollFadeIn>
         <section className="py-6 sm:py-10 md:py-16 bg-white">
           <div className="container-custom">
@@ -268,6 +263,11 @@ export default async function HomePage() {
           </div>
         </section>
       </ScrollFadeIn>
+
+      {/* ═══════ 4. ADVISOR DIRECTORY ═══════ */}
+      <AdvisorDirectory
+        advisors={(featuredAdvisors as { slug: string; name: string; firm_name?: string; type: string; location_display?: string; location_state?: string; rating: number; review_count: number; photo_url?: string; specialties: string[]; verified?: boolean }[]) || []}
+      />
 
       {/* ═══════ 5. ACTIVE DEALS ═══════ */}
       {(dealBrokers as Broker[])?.length > 0 && (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -39,7 +39,7 @@ export const metadata = {
 const bestForCards = [
   { icon: "sprout", title: "Best for Beginners", description: "Low fees, simple platforms, educational resources", href: "/best/beginners", color: "bg-amber-50 border-amber-200 text-amber-800" },
   { icon: "globe", title: "Best for US Shares", description: "Low FX fees and $0 US brokerage compared", href: "/best/us-shares", color: "bg-slate-50 border-slate-200 text-slate-800" },
-  { icon: "cpu", title: "Best Robo-Advisors", description: "Automated investing with Stockspot, Raiz & more", href: "/best/robo-advisors", color: "bg-violet-50 border-violet-200 text-violet-800" },
+  { icon: "cpu", title: "Best Robo-Advisors", description: "Automated investing with Stockspot, Raiz & more", href: "/best/robo-advisors", color: "bg-amber-50 border-amber-200 text-amber-800" },
   { icon: "building", title: "Compare Super Funds", description: "Compare fees, performance & insurance across funds", href: "/compare/super", color: "bg-emerald-50 border-emerald-200 text-emerald-800" },
   { icon: "coins", title: "Lowest Fees", description: "$0 brokerage and verified low-cost options", href: "/best/low-fees", color: "bg-amber-50 border-amber-200 text-amber-800" },
   { icon: "bitcoin", title: "Best Crypto Exchanges", description: "AUSTRAC-registered exchanges with AUD deposits", href: "/best/crypto", color: "bg-orange-50 border-orange-200 text-orange-800" },

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -228,7 +228,12 @@ export default async function HomePage() {
         </section>
       </ScrollFadeIn>
 
-      {/* ═══════ 3. TOP PLATFORMS ═══════ */}
+      {/* ═══════ 3. ADVISOR DIRECTORY ═══════ */}
+      <AdvisorDirectory
+        advisors={(featuredAdvisors as { slug: string; name: string; firm_name?: string; type: string; location_display?: string; location_state?: string; rating: number; review_count: number; photo_url?: string; specialties: string[]; verified?: boolean }[]) || []}
+      />
+
+      {/* ═══════ 4. TOP PLATFORMS ═══════ */}
       <ScrollFadeIn>
         <section className="py-6 sm:py-10 md:py-16 bg-white">
           <div className="container-custom">
@@ -263,11 +268,6 @@ export default async function HomePage() {
           </div>
         </section>
       </ScrollFadeIn>
-
-      {/* ═══════ 4. ADVISOR DIRECTORY ═══════ */}
-      <AdvisorDirectory
-        advisors={(featuredAdvisors as { slug: string; name: string; firm_name?: string; type: string; location_display?: string; location_state?: string; rating: number; review_count: number; photo_url?: string; specialties: string[]; verified?: boolean }[]) || []}
-      />
 
       {/* ═══════ 5. ACTIVE DEALS ═══════ */}
       {(dealBrokers as Broker[])?.length > 0 && (

--- a/app/savings-calculator/SavingsCalculatorClient.tsx
+++ b/app/savings-calculator/SavingsCalculatorClient.tsx
@@ -90,10 +90,10 @@ export default function SavingsCalculatorClient({ accounts, inline }: { accounts
   return (
     <div className="py-0">
       {/* Hero */}
-      {!inline && <div className="bg-gradient-to-br from-blue-600 via-blue-700 to-indigo-800 text-white py-8 md:py-14 px-4">
+      {!inline && <div className="bg-gradient-to-br from-amber-500 via-amber-600 to-amber-800 text-white py-8 md:py-14 px-4">
         <div className="container-custom max-w-3xl text-center">
           <h1 className="text-xl md:text-3xl font-extrabold mb-2">Are you earning enough on your savings?</h1>
-          <p className="text-sm md:text-base text-blue-100">Enter your balance and current rate — we'll show you exactly how much more you could earn.</p>
+          <p className="text-sm md:text-base text-amber-100">Enter your balance and current rate — we'll show you exactly how much more you could earn.</p>
           <div className="mt-3"><SocialProofCounter variant="badge" /></div>
         </div>
       </div>}
@@ -110,12 +110,12 @@ export default function SavingsCalculatorClient({ accounts, inline }: { accounts
                   type="number"
                   value={balance}
                   onChange={e => setBalance(Math.max(0, parseInt(e.target.value) || 0))}
-                  className="w-full pl-8 pr-4 py-3 text-lg font-bold border border-slate-200 rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-400 outline-none"
+                  className="w-full pl-8 pr-4 py-3 text-lg font-bold border border-slate-200 rounded-lg focus:ring-2 focus:ring-amber-500/20 focus:border-amber-400 outline-none"
                 />
               </div>
               <div className="flex gap-1.5 mt-2">
                 {[5000, 10000, 25000, 50000, 100000].map(v => (
-                  <button key={v} onClick={() => setBalance(v)} className={`text-[0.56rem] px-2 py-1 rounded-full font-semibold transition-all ${balance === v ? "bg-blue-600 text-white" : "bg-slate-100 text-slate-600 hover:bg-slate-200"}`}>
+                  <button key={v} onClick={() => setBalance(v)} className={`text-[0.56rem] px-2 py-1 rounded-full font-semibold transition-all ${balance === v ? "bg-amber-500 text-white" : "bg-slate-100 text-slate-600 hover:bg-slate-200"}`}>
                     {v >= 1000 ? `$${v / 1000}k` : `$${v}`}
                   </button>
                 ))}
@@ -129,13 +129,13 @@ export default function SavingsCalculatorClient({ accounts, inline }: { accounts
                   step="0.1"
                   value={currentRate}
                   onChange={e => setCurrentRate(Math.max(0, Math.min(10, parseFloat(e.target.value) || 0)))}
-                  className="w-full pr-8 pl-4 py-3 text-lg font-bold border border-slate-200 rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-400 outline-none"
+                  className="w-full pr-8 pl-4 py-3 text-lg font-bold border border-slate-200 rounded-lg focus:ring-2 focus:ring-amber-500/20 focus:border-amber-400 outline-none"
                 />
                 <span className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 font-semibold">%</span>
               </div>
               <div className="flex gap-1.5 mt-2">
                 {[0, 0.5, 1.0, 2.0, 3.0, 4.0].map(v => (
-                  <button key={v} onClick={() => setCurrentRate(v)} className={`text-[0.56rem] px-2 py-1 rounded-full font-semibold transition-all ${currentRate === v ? "bg-blue-600 text-white" : "bg-slate-100 text-slate-600 hover:bg-slate-200"}`}>
+                  <button key={v} onClick={() => setCurrentRate(v)} className={`text-[0.56rem] px-2 py-1 rounded-full font-semibold transition-all ${currentRate === v ? "bg-amber-500 text-white" : "bg-slate-100 text-slate-600 hover:bg-slate-200"}`}>
                     {v}%
                   </button>
                 ))}
@@ -144,7 +144,7 @@ export default function SavingsCalculatorClient({ accounts, inline }: { accounts
           </div>
           <button
             onClick={handleCalculate}
-            className="w-full mt-5 px-6 py-3.5 bg-blue-600 text-white text-base font-bold rounded-xl hover:bg-blue-700 transition-all shadow-lg hover:shadow-xl"
+            className="w-full mt-5 px-6 py-3.5 bg-amber-500 text-white text-base font-bold rounded-xl hover:bg-amber-600 transition-all shadow-lg hover:shadow-xl"
           >
             Calculate My Savings →
           </button>
@@ -219,7 +219,7 @@ export default function SavingsCalculatorClient({ accounts, inline }: { accounts
                       target="_blank"
                       rel={AFFILIATE_REL}
                       onClick={() => trackClick(account.slug, account.name, "savings-calc", "/savings-calculator", "savings")}
-                      className="hidden md:inline-block px-3 py-1.5 bg-blue-600 text-white text-xs font-bold rounded-lg hover:bg-blue-700 transition-all"
+                      className="hidden md:inline-block px-3 py-1.5 bg-amber-500 text-white text-xs font-bold rounded-lg hover:bg-amber-600 transition-all"
                     >
                       Visit →
                     </a>
@@ -234,7 +234,7 @@ export default function SavingsCalculatorClient({ accounts, inline }: { accounts
                   <p className="text-xs text-slate-500 mb-3">Enter your email to unlock the full comparison</p>
                   <div className="flex gap-2 max-w-xs mx-auto">
                     <input type="email" value={email} onChange={e => setEmail(e.target.value)} placeholder="your@email.com" className="flex-1 px-3 py-2 text-sm border border-slate-200 rounded-lg" />
-                    <button onClick={handleEmailSubmit} className="px-4 py-2 bg-blue-600 text-white text-sm font-bold rounded-lg hover:bg-blue-700">Unlock</button>
+                    <button onClick={handleEmailSubmit} className="px-4 py-2 bg-amber-500 text-white text-sm font-bold rounded-lg hover:bg-amber-600">Unlock</button>
                   </div>
                 </div>
               )}

--- a/app/smsf-calculator/SMSFCalculatorClient.tsx
+++ b/app/smsf-calculator/SMSFCalculatorClient.tsx
@@ -155,10 +155,10 @@ export default function SMSFCalculatorClient() {
   return (
     <div className="py-0">
       {/* Hero */}
-      <div className="bg-gradient-to-br from-blue-600 via-blue-700 to-blue-800 text-white py-8 md:py-14 px-4">
+      <div className="bg-gradient-to-br from-amber-500 via-amber-600 to-amber-800 text-white py-8 md:py-14 px-4">
         <div className="container-custom max-w-3xl text-center">
           <h1 className="text-xl md:text-3xl font-extrabold mb-2">Is a Self-Managed Super Fund right for you?</h1>
-          <p className="text-sm md:text-base text-blue-100">Enter your super details below — we&apos;ll compare your current fund against running an SMSF.</p>
+          <p className="text-sm md:text-base text-amber-100">Enter your super details below — we&apos;ll compare your current fund against running an SMSF.</p>
           <div className="mt-3"><SocialProofCounter variant="badge" /></div>
         </div>
       </div>
@@ -176,12 +176,12 @@ export default function SMSFCalculatorClient() {
                   type="number"
                   value={balance}
                   onChange={e => setBalance(Math.max(0, parseInt(e.target.value) || 0))}
-                  className="w-full pl-8 pr-4 py-3 text-lg font-bold border border-slate-200 rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-400 outline-none"
+                  className="w-full pl-8 pr-4 py-3 text-lg font-bold border border-slate-200 rounded-lg focus:ring-2 focus:ring-amber-500/20 focus:border-amber-400 outline-none"
                 />
               </div>
               <div className="flex gap-1.5 mt-2">
                 {[100_000, 200_000, 300_000, 500_000, 1_000_000].map(v => (
-                  <button key={v} onClick={() => setBalance(v)} className={`text-[0.56rem] px-2 py-1 rounded-full font-semibold transition-all ${balance === v ? "bg-blue-600 text-white" : "bg-slate-100 text-slate-600 hover:bg-slate-200"}`}>
+                  <button key={v} onClick={() => setBalance(v)} className={`text-[0.56rem] px-2 py-1 rounded-full font-semibold transition-all ${balance === v ? "bg-amber-500 text-white" : "bg-slate-100 text-slate-600 hover:bg-slate-200"}`}>
                     {v >= 1_000_000 ? `$${v / 1_000_000}M` : `$${v / 1000}k`}
                   </button>
                 ))}
@@ -197,7 +197,7 @@ export default function SMSFCalculatorClient() {
                   type="number"
                   value={annualContribution}
                   onChange={e => setAnnualContribution(Math.max(0, parseInt(e.target.value) || 0))}
-                  className="w-full pl-8 pr-4 py-3 text-lg font-bold border border-slate-200 rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-400 outline-none"
+                  className="w-full pl-8 pr-4 py-3 text-lg font-bold border border-slate-200 rounded-lg focus:ring-2 focus:ring-amber-500/20 focus:border-amber-400 outline-none"
                 />
               </div>
               <p className="text-[0.6rem] text-slate-400 mt-1">Concessional cap $30,000/yr (2024-25)</p>
@@ -212,13 +212,13 @@ export default function SMSFCalculatorClient() {
                   step="0.1"
                   value={currentFeePercent}
                   onChange={e => setCurrentFeePercent(Math.max(0, Math.min(5, parseFloat(e.target.value) || 0)))}
-                  className="w-full pr-8 pl-4 py-3 text-lg font-bold border border-slate-200 rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-400 outline-none"
+                  className="w-full pr-8 pl-4 py-3 text-lg font-bold border border-slate-200 rounded-lg focus:ring-2 focus:ring-amber-500/20 focus:border-amber-400 outline-none"
                 />
                 <span className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 font-semibold">%</span>
               </div>
               <div className="flex gap-1.5 mt-2">
                 {[0.5, 0.8, 1.0, 1.2, 1.5, 2.0].map(v => (
-                  <button key={v} onClick={() => setCurrentFeePercent(v)} className={`text-[0.56rem] px-2 py-1 rounded-full font-semibold transition-all ${currentFeePercent === v ? "bg-blue-600 text-white" : "bg-slate-100 text-slate-600 hover:bg-slate-200"}`}>
+                  <button key={v} onClick={() => setCurrentFeePercent(v)} className={`text-[0.56rem] px-2 py-1 rounded-full font-semibold transition-all ${currentFeePercent === v ? "bg-amber-500 text-white" : "bg-slate-100 text-slate-600 hover:bg-slate-200"}`}>
                     {v}%
                   </button>
                 ))}
@@ -234,13 +234,13 @@ export default function SMSFCalculatorClient() {
                   step="0.5"
                   value={expectedReturn}
                   onChange={e => setExpectedReturn(Math.max(0, Math.min(15, parseFloat(e.target.value) || 0)))}
-                  className="w-full pr-8 pl-4 py-3 text-lg font-bold border border-slate-200 rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-400 outline-none"
+                  className="w-full pr-8 pl-4 py-3 text-lg font-bold border border-slate-200 rounded-lg focus:ring-2 focus:ring-amber-500/20 focus:border-amber-400 outline-none"
                 />
                 <span className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 font-semibold">%</span>
               </div>
               <div className="flex gap-1.5 mt-2">
                 {[5, 6, 7, 8, 9, 10].map(v => (
-                  <button key={v} onClick={() => setExpectedReturn(v)} className={`text-[0.56rem] px-2 py-1 rounded-full font-semibold transition-all ${expectedReturn === v ? "bg-blue-600 text-white" : "bg-slate-100 text-slate-600 hover:bg-slate-200"}`}>
+                  <button key={v} onClick={() => setExpectedReturn(v)} className={`text-[0.56rem] px-2 py-1 rounded-full font-semibold transition-all ${expectedReturn === v ? "bg-amber-500 text-white" : "bg-slate-100 text-slate-600 hover:bg-slate-200"}`}>
                     {v}%
                   </button>
                 ))}
@@ -255,13 +255,13 @@ export default function SMSFCalculatorClient() {
                   type="number"
                   value={yearsToRetirement}
                   onChange={e => setYearsToRetirement(Math.max(1, Math.min(50, parseInt(e.target.value) || 0)))}
-                  className="w-full pl-4 pr-12 py-3 text-lg font-bold border border-slate-200 rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-400 outline-none"
+                  className="w-full pl-4 pr-12 py-3 text-lg font-bold border border-slate-200 rounded-lg focus:ring-2 focus:ring-amber-500/20 focus:border-amber-400 outline-none"
                 />
                 <span className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 font-semibold">years</span>
               </div>
               <div className="flex gap-1.5 mt-2">
                 {[5, 10, 15, 20, 25, 30].map(v => (
-                  <button key={v} onClick={() => setYearsToRetirement(v)} className={`text-[0.56rem] px-2 py-1 rounded-full font-semibold transition-all ${yearsToRetirement === v ? "bg-blue-600 text-white" : "bg-slate-100 text-slate-600 hover:bg-slate-200"}`}>
+                  <button key={v} onClick={() => setYearsToRetirement(v)} className={`text-[0.56rem] px-2 py-1 rounded-full font-semibold transition-all ${yearsToRetirement === v ? "bg-amber-500 text-white" : "bg-slate-100 text-slate-600 hover:bg-slate-200"}`}>
                     {v}yr
                   </button>
                 ))}
@@ -271,7 +271,7 @@ export default function SMSFCalculatorClient() {
 
           <button
             onClick={handleCalculate}
-            className="w-full mt-5 px-6 py-3.5 bg-blue-600 text-white text-base font-bold rounded-xl hover:bg-blue-700 transition-all shadow-lg hover:shadow-xl"
+            className="w-full mt-5 px-6 py-3.5 bg-amber-500 text-white text-base font-bold rounded-xl hover:bg-amber-600 transition-all shadow-lg hover:shadow-xl"
           >
             Compare SMSF vs Current Fund →
           </button>

--- a/app/switching-calculator/SwitchingCalculatorClient.tsx
+++ b/app/switching-calculator/SwitchingCalculatorClient.tsx
@@ -271,10 +271,10 @@ export default function SwitchingCalculatorClient({ brokers, inline }: { brokers
           <p>Our switching calculator uses real fee data from {brokers.length} Australian platforms, updated daily. It accounts for ASX brokerage, US share fees, FX conversion rates, and inactivity charges to show your true annual cost.</p>
           <h3 className="text-base font-bold text-slate-900">How to switch brokers</h3>
           <p>Switching is easier than most people think. For CHESS-sponsored brokers, your HIN (Holder Identification Number) transfers directly — your shares stay in your name throughout. The process typically takes 3-5 business days. Read our <Link href="/switch" className="text-violet-600 hover:underline">complete switching guide</Link> for step-by-step instructions.</p>
-          <div className="bg-blue-50 border border-blue-200 rounded-xl p-4 mt-4">
-            <p className="text-sm font-bold text-blue-800 mb-1">Also check your savings rate</p>
-            <p className="text-xs text-blue-600">Most Australians earn 0.01% on their cash while top accounts offer 5%+. On $50k, that's $2,750/year difference.</p>
-            <Link href="/savings-calculator" className="inline-block mt-2 text-xs font-bold text-blue-700 hover:underline">Try the Savings Calculator →</Link>
+          <div className="bg-amber-50 border border-amber-200 rounded-xl p-4 mt-4">
+            <p className="text-sm font-bold text-amber-800 mb-1">Also check your savings rate</p>
+            <p className="text-xs text-amber-600">Most Australians earn 0.01% on their cash while top accounts offer 5%+. On $50k, that's $2,750/year difference.</p>
+            <Link href="/savings-calculator" className="inline-block mt-2 text-xs font-bold text-amber-700 hover:underline">Try the Savings Calculator →</Link>
           </div>
         </div>
       </div>

--- a/components/BookingWidget.tsx
+++ b/components/BookingWidget.tsx
@@ -122,15 +122,15 @@ export default function BookingWidget({ advisorSlug, advisorName }: { advisorSlu
     // External booking link (Calendly, Cal.com, etc.)
     if (bookingLink) {
       return (
-        <div className="bg-gradient-to-br from-violet-50 to-indigo-50 border border-violet-200 rounded-xl overflow-hidden">
+        <div className="bg-gradient-to-br from-amber-50 to-orange-50 border border-amber-200 rounded-xl overflow-hidden">
           <div className="p-4 md:p-5">
             <div className="flex items-center gap-2 mb-2">
-              <div className="w-8 h-8 bg-violet-100 rounded-lg flex items-center justify-center">
-                <Icon name="calendar" size={18} className="text-violet-600" />
+              <div className="w-8 h-8 bg-amber-100 rounded-lg flex items-center justify-center">
+                <Icon name="calendar" size={18} className="text-amber-600" />
               </div>
               <div>
-                <h3 className="text-sm font-bold text-violet-900">Book a Free Consultation</h3>
-                <p className="text-[0.6rem] text-violet-600">30-minute video or phone call</p>
+                <h3 className="text-sm font-bold text-amber-900">Book a Free Consultation</h3>
+                <p className="text-[0.6rem] text-amber-600">30-minute video or phone call</p>
               </div>
             </div>
             {bookingIntro && <p className="text-xs text-slate-600 mb-3">{bookingIntro}</p>}
@@ -150,12 +150,12 @@ export default function BookingWidget({ advisorSlug, advisorName }: { advisorSlu
                   }),
                 }).catch(() => {});
               }}
-              className="block w-full text-center px-4 py-3 bg-violet-600 text-white font-bold rounded-xl hover:bg-violet-700 transition-all text-sm shadow-sm hover:shadow-md"
+              className="block w-full text-center px-4 py-3 bg-amber-500 text-white font-bold rounded-xl hover:bg-amber-600 transition-all text-sm shadow-sm hover:shadow-md"
             >
-              Choose a Time →
+              Choose a Time &rarr;
             </a>
-            <p className="text-[0.5rem] text-violet-400 text-center mt-2">
-              {bookingLink.includes("calendly") ? "Powered by Calendly" : bookingLink.includes("cal.com") ? "Powered by Cal.com" : "Opens booking calendar"} · No obligation · Free initial consultation
+            <p className="text-[0.5rem] text-amber-400 text-center mt-2">
+              {bookingLink.includes("calendly") ? "Powered by Calendly" : bookingLink.includes("cal.com") ? "Powered by Cal.com" : "Opens booking calendar"} &middot; No obligation &middot; Free initial consultation
             </p>
           </div>
         </div>

--- a/components/HomepageComparisonTable.tsx
+++ b/components/HomepageComparisonTable.tsx
@@ -186,9 +186,9 @@ export default function HomepageComparisonTable({
                 key={broker.id}
                 className={`group hover:bg-slate-50/80 transition-colors ${
                   isCampaignWinner
-                    ? "bg-blue-50/30 border-l-2 border-l-blue-400"
+                    ? "bg-amber-50/30 border-l-2 border-l-amber-400"
                     : isSponsored(broker)
-                    ? "bg-blue-50/30 border-l-2 border-l-blue-400"
+                    ? "bg-amber-50/30 border-l-2 border-l-amber-400"
                     : isTopRated
                     ? "bg-amber-50/40 border-l-2 border-l-amber-400"
                     : editorPicks[broker.slug]

--- a/lib/how-to-guides.ts
+++ b/lib/how-to-guides.ts
@@ -1041,7 +1041,7 @@ For REIT and ETF investors, monitor your portfolio allocation and rebalance if p
       { heading: "Switch via MyGov (Easiest Method)", body: "The simplest way to switch super is through your MyGov account linked to the ATO. Log in, go to Super, select 'Transfer super', choose the fund to transfer from and to, and submit. The transfer typically takes 3-5 business days. You can also use the new fund's rollover form. Make sure you only consolidate into one fund to avoid paying multiple sets of fees." },
     ],
     relatedBrokerFilter: (b) => b.platform_type === "super_fund",
-    relatedBestPages: [{ label: "Best Super Funds", href: "/best/super-funds" }, { label: "Super Fund Comparison", href: "/compare?category=super" }],
+    relatedBestPages: [{ label: "Best Super Funds", href: "/best/super-funds" }, { label: "Super Fund Comparison", href: "/compare/super" }],
     faqs: [
       { question: "Can I lose money by switching super funds?", answer: "You could lose insurance cover if you don't arrange new cover before cancelling. Investment-wise, switching doesn't trigger CGT as super is a tax-sheltered environment." },
       { question: "Should I consolidate multiple super accounts?", answer: "Generally yes — multiple accounts mean multiple sets of fees and insurance premiums. Consolidate into the best-performing, lowest-fee fund. Exception: keep separate accounts if one has grandfathered insurance terms." },

--- a/lib/verticals.ts
+++ b/lib/verticals.ts
@@ -318,7 +318,7 @@ const VERTICALS: VerticalConfig[] = [
       { label: "SMSF", href: "/best/smsf", description: "Self-managed super fund platforms with low admin costs and flexibility" },
     ],
     tools: [
-      { label: "Compare Super Funds", href: "/compare?category=super", icon: "bar-chart" },
+      { label: "Compare Super Funds", href: "/compare/super", icon: "bar-chart" },
       { label: "Find Your Match", href: "/quiz", icon: "target" },
       { label: "Fee Impact Calculator", href: "/fee-impact", icon: "calculator" },
     ],


### PR DESCRIPTION
## Summary
- Quiz auto-match excludes advisors already matched (7-day dedup window)
- Cross-system dedup: checks both `leads` and `professional_leads` tables
- "Match me with a different advisor" button on confirmation
- Match persisted to sessionStorage (survives refresh)
- Advisor profile shows "already matched" banner when user visits from quiz
- BookingWidget violet→amber brand colors

https://claude.ai/code/session_01Sc4b8zVmRCqqYVZ8tf4JPD