### PR TITLE
fix: update tests for security commit — CI should now pass

### DIFF
--- a/__tests__/api/advisor-enquiry.test.ts
+++ b/__tests__/api/advisor-enquiry.test.ts
@@ -6,7 +6,10 @@ import { makeRequest, createChainableBuilder } from "@/__tests__/helpers";
 const mockFrom = vi.fn();
 
 vi.mock("@/lib/supabase/server", () => ({
-  createClient: vi.fn(async () => ({ from: mockFrom })),
+  createClient: vi.fn(async () => ({
+    from: mockFrom,
+    rpc: vi.fn(() => Promise.resolve({ data: null, error: null })),
+  })),
 }));
 
 vi.mock("@/lib/rate-limit", () => ({
@@ -164,7 +167,7 @@ describe("POST /api/advisor-enquiry", () => {
     const res = await POST(req);
     expect(res.status).toBe(400);
     const json = await res.json();
-    expect(json.error).toContain("Invalid email");
+    expect(json.error).toContain("valid");
   });
 
   it("returns 404 when professional not found", async () => {


### PR DESCRIPTION
Fixes the 8 failing tests in `advisor-enquiry.test.ts` caused by the security commit:

- Added `rpc` mock to the supabase client mock (security commit introduced `supabase.rpc()` calls for atomic free lead counter increment)
- Updated email error message assertion to match new wording

https://claude.ai/code/session_01Sc4b8zVmRCqqYVZ8tf4JPD