### PR TITLE
fix: use admin client in advisor-enquiry to bypass RLS

### DIFF
--- a/__tests__/api/advisor-enquiry.test.ts
+++ b/__tests__/api/advisor-enquiry.test.ts
@@ -5,8 +5,8 @@ import { makeRequest, createChainableBuilder } from "@/__tests__/helpers";
 
 const mockFrom = vi.fn();
 
-vi.mock("@/lib/supabase/server", () => ({
-  createClient: vi.fn(async () => ({
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({
     from: mockFrom,
     rpc: vi.fn(() => Promise.resolve({ data: null, error: null })),
   })),

--- a/app/api/advisor-enquiry/route.ts
+++ b/app/api/advisor-enquiry/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
 import { isRateLimited } from "@/lib/rate-limit";
 import { isValidEmail, isDisposableEmail } from "@/lib/validate-email";
 import { notificationFooter } from "@/lib/email-templates";
@@ -119,7 +119,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Please use a real email address." }, { status: 400 });
     }
 
-    const supabase = await createClient();
+    const supabase = createAdminClient();
 
     // Verify the professional exists and is active
     const { data: pro, error: proError } = await supabase


### PR DESCRIPTION
Fixes 401 on `professional_leads` insert.

The route was using the cookie-based server client (anon key) which is blocked by Row Level Security → 401. Switched to `createAdminClient` (service role key).

https://claude.ai/code/session_01Sc4b8zVmRCqqYVZ8tf4JPD