### PR TITLE
fix: pre-launch audit — admin clients, seed guard, env docs

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -19,6 +19,10 @@ RESEND_API_KEY=re_your_resend_api_key_here
 # ── Cron / Internal ───────────────────────────────────────
 CRON_SECRET=your_cron_secret_here
 INTERNAL_API_KEY=your_internal_api_key_here
+# Used by /api/revalidate to purge ISR cache on demand
+REVALIDATE_SECRET=your_revalidate_secret_here
+# Used by /api/partner/leads for partner API access
+PARTNER_API_KEY=your_partner_api_key_here
 
 # ── Admin ─────────────────────────────────────────────────
 # Comma-separated list of emails allowed to access /admin

--- a/app/api/admin/bd-pipeline/route.ts
+++ b/app/api/admin/bd-pipeline/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
 import { ADMIN_EMAILS } from "@/lib/admin";
 
 async function requireAdmin() {
@@ -25,7 +26,7 @@ export async function GET() {
     const admin = await requireAdmin();
     if (!admin) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-    const supabase = await createClient();
+    const supabase = createAdminClient();
     const { data } = await supabase
       .from("bd_pipeline")
       .select("*")
@@ -41,7 +42,7 @@ export async function POST(request: NextRequest) {
   const admin = await requireAdmin();
   if (!admin) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  const supabase = await createClient();
+  const supabase = createAdminClient();
   const body = await request.json();
   const { id, ...fields } = body;
 
@@ -78,7 +79,7 @@ export async function DELETE(request: NextRequest) {
   const admin = await requireAdmin();
   if (!admin) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  const supabase = await createClient();
+  const supabase = createAdminClient();
   const { id } = await request.json();
   if (!id) return NextResponse.json({ error: "id required" }, { status: 400 });
   await supabase.from("bd_pipeline").delete().eq("id", id);

--- a/app/api/admin/fee-queue/route.ts
+++ b/app/api/admin/fee-queue/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
 import { ADMIN_EMAILS } from "@/lib/admin";
 
 async function requireAdmin() {
@@ -25,7 +26,7 @@ export async function GET() {
     const admin = await requireAdmin();
     if (!admin) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-    const supabase = await createClient();
+    const supabase = createAdminClient();
     const { data } = await supabase
       .from("fee_update_queue")
       .select("*")
@@ -42,7 +43,7 @@ export async function POST(request: NextRequest) {
   const admin = await requireAdmin();
   if (!admin) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  const supabase = await createClient();
+  const supabase = createAdminClient();
   const { id, action } = await request.json();
 
   if (!id || !action) return NextResponse.json({ error: "id and action required" }, { status: 400 });

--- a/app/api/questions/moderate/route.ts
+++ b/app/api/questions/moderate/route.ts
@@ -134,7 +134,7 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "Action must be 'approve' or 'reject'" }, { status: 400 });
     }
 
-    const supabase = await createClient();
+    const supabase = createAdminClient();
     const table = type === "question" ? "broker_questions" : "broker_answers";
     const newStatus = action === "approve" ? "approved" : "rejected";
 

--- a/app/api/seed/route.ts
+++ b/app/api/seed/route.ts
@@ -8,6 +8,11 @@ const log = logger("seed");
 const ADMIN_DOMAIN = "@invest.com.au";
 
 export async function POST() {
+  // Block in production
+  if (process.env.NODE_ENV === "production") {
+    return NextResponse.json({ error: "Not available in production" }, { status: 403 });
+  }
+
   try {
     const supabase = await createClient();
 


### PR DESCRIPTION
Fixes from the comprehensive launch readiness audit.

**High severity (would break in prod):**
- Document `REVALIDATE_SECRET` and `PARTNER_API_KEY` in `.env.local.example` — these were required by API routes but undocumented, causing silent failures if not set in Vercel

**Medium severity (silent failures for admins):**
- `admin/bd-pipeline`: switch DB ops from `createClient` → `createAdminClient` (auth check still uses server client for `getUser()`)
- `admin/fee-queue`: same pattern
- `questions/moderate`: use `createAdminClient` for the UPDATE at line 137 that was using the anon client
- `seed`: add `NODE_ENV === production` guard — returns 403 in prod even with valid admin credentials

https://claude.ai/code/session_01Sc4b8zVmRCqqYVZ8tf4JPD