### PR TITLE
feat: property investment vertical — listings, buyer agents, suburb tool, admin

### DIFF
--- a/app/admin/property/developers/page.tsx
+++ b/app/admin/property/developers/page.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { createBrowserClient } from "@supabase/ssr";
+import Icon from "@/components/Icon";
+
+interface Developer {
+  id: number;
+  slug: string;
+  name: string;
+  contact_email: string | null;
+  contact_phone: string | null;
+  status: string;
+  projects_completed: number;
+  monthly_fee_cents: number;
+  credit_balance_cents: number;
+  stripe_customer_id: string | null;
+  created_at: string;
+}
+
+export default function AdminPropertyDevelopers() {
+  const [developers, setDevelopers] = useState<Developer[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const supabase = createBrowserClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  );
+
+  const fetchDevelopers = useCallback(async () => {
+    setLoading(true);
+    const { data } = await supabase
+      .from("property_developers")
+      .select("*")
+      .order("name", { ascending: true });
+    setDevelopers(data || []);
+    setLoading(false);
+  }, [supabase]);
+
+  useEffect(() => { fetchDevelopers(); }, [fetchDevelopers]);
+
+  const toggleStatus = async (id: number, current: string) => {
+    const newStatus = current === "active" ? "pending" : "active";
+    await supabase.from("property_developers").update({ status: newStatus }).eq("id", id);
+    setDevelopers(developers.map((d) => d.id === id ? { ...d, status: newStatus } : d));
+  };
+
+  return (
+    <div className="p-4 md:p-6 max-w-7xl">
+      <div className="mb-4">
+        <h1 className="text-xl font-extrabold text-slate-900">Property Developers</h1>
+        <p className="text-xs text-slate-500">{developers.length} developers</p>
+      </div>
+
+      {loading ? (
+        <div className="space-y-2">{Array.from({ length: 5 }).map((_, i) => <div key={i} className="h-14 bg-slate-50 rounded-lg animate-pulse" />)}</div>
+      ) : (
+        <div className="bg-white border border-slate-200 rounded-xl overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="bg-slate-50 border-b border-slate-200">
+                <th className="text-left px-4 py-2.5 text-xs font-semibold text-slate-600">Developer</th>
+                <th className="text-left px-4 py-2.5 text-xs font-semibold text-slate-600 hidden md:table-cell">Contact</th>
+                <th className="text-right px-4 py-2.5 text-xs font-semibold text-slate-600 hidden md:table-cell">Projects</th>
+                <th className="text-right px-4 py-2.5 text-xs font-semibold text-slate-600">Credit Balance</th>
+                <th className="text-right px-4 py-2.5 text-xs font-semibold text-slate-600 hidden lg:table-cell">Monthly Fee</th>
+                <th className="text-center px-4 py-2.5 text-xs font-semibold text-slate-600">Status</th>
+                <th className="text-center px-4 py-2.5 text-xs font-semibold text-slate-600 hidden md:table-cell">Stripe</th>
+              </tr>
+            </thead>
+            <tbody>
+              {developers.map((dev) => (
+                <tr key={dev.id} className="border-b border-slate-100 last:border-b-0 hover:bg-slate-50">
+                  <td className="px-4 py-3">
+                    <p className="font-semibold text-slate-900">{dev.name}</p>
+                    <p className="text-[0.65rem] text-slate-400">{dev.slug}</p>
+                  </td>
+                  <td className="px-4 py-3 hidden md:table-cell">
+                    <p className="text-xs text-slate-600">{dev.contact_email || "—"}</p>
+                    <p className="text-[0.65rem] text-slate-400">{dev.contact_phone || ""}</p>
+                  </td>
+                  <td className="px-4 py-3 text-right text-slate-700 hidden md:table-cell">{dev.projects_completed}</td>
+                  <td className="px-4 py-3 text-right">
+                    <span className={`font-bold ${dev.credit_balance_cents > 0 ? "text-emerald-600" : "text-slate-400"}`}>
+                      ${(dev.credit_balance_cents / 100).toFixed(2)}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-right text-slate-600 hidden lg:table-cell">
+                    ${(dev.monthly_fee_cents / 100).toFixed(0)}/mo
+                  </td>
+                  <td className="px-4 py-3 text-center">
+                    <button
+                      onClick={() => toggleStatus(dev.id, dev.status)}
+                      className={`text-[0.65rem] font-bold px-2 py-0.5 rounded-full ${
+                        dev.status === "active" ? "text-emerald-700 bg-emerald-50" : "text-amber-700 bg-amber-50"
+                      }`}
+                    >
+                      {dev.status}
+                    </button>
+                  </td>
+                  <td className="px-4 py-3 text-center hidden md:table-cell">
+                    {dev.stripe_customer_id ? (
+                      <Icon name="check-circle" size={14} className="text-emerald-500 inline" />
+                    ) : (
+                      <Icon name="x-circle" size={14} className="text-slate-300 inline" />
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/admin/property/leads/page.tsx
+++ b/app/admin/property/leads/page.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { createBrowserClient } from "@supabase/ssr";
+import Icon from "@/components/Icon";
+
+interface Lead {
+  id: number;
+  user_name: string;
+  user_email: string;
+  user_phone: string | null;
+  user_country: string | null;
+  investment_budget: string | null;
+  timeline: string | null;
+  status: string;
+  created_at: string;
+  property_listings?: { title: string } | null;
+  property_developers?: { name: string } | null;
+}
+
+export default function AdminPropertyLeads() {
+  const [leads, setLeads] = useState<Lead[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const supabase = createBrowserClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  );
+
+  const fetchLeads = useCallback(async () => {
+    setLoading(true);
+    const { data } = await supabase
+      .from("property_leads")
+      .select("*, property_listings(title), property_developers(name)")
+      .order("created_at", { ascending: false })
+      .limit(200);
+    setLeads(data || []);
+    setLoading(false);
+  }, [supabase]);
+
+  useEffect(() => { fetchLeads(); }, [fetchLeads]);
+
+  const updateStatus = async (id: number, status: string) => {
+    await supabase.from("property_leads").update({ status }).eq("id", id);
+    setLeads(leads.map((l) => l.id === id ? { ...l, status } : l));
+  };
+
+  const exportCSV = () => {
+    const headers = ["Date", "Name", "Email", "Phone", "Country", "Budget", "Timeline", "Listing", "Developer", "Status"];
+    const rows = leads.map((l) => [
+      new Date(l.created_at).toLocaleDateString("en-AU"),
+      l.user_name,
+      l.user_email,
+      l.user_phone || "",
+      l.user_country || "",
+      l.investment_budget || "",
+      l.timeline || "",
+      (l.property_listings as { title: string } | null)?.title || "",
+      (l.property_developers as { name: string } | null)?.name || "",
+      l.status,
+    ]);
+    const csv = [headers, ...rows].map((row) => row.map((cell) => `"${cell}"`).join(",")).join("\n");
+    const blob = new Blob([csv], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `property-leads-${new Date().toISOString().slice(0, 10)}.csv`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const statusColors: Record<string, string> = {
+    new: "text-blue-700 bg-blue-50",
+    contacted: "text-amber-700 bg-amber-50",
+    qualified: "text-emerald-700 bg-emerald-50",
+    converted: "text-green-700 bg-green-50",
+  };
+
+  return (
+    <div className="p-4 md:p-6 max-w-7xl">
+      <div className="flex items-center justify-between mb-4">
+        <div>
+          <h1 className="text-xl font-extrabold text-slate-900">Property Leads</h1>
+          <p className="text-xs text-slate-500">{leads.length} leads</p>
+        </div>
+        <button onClick={exportCSV} className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold bg-white border border-slate-200 rounded-lg hover:bg-slate-50">
+          <Icon name="download" size={14} />
+          Export CSV
+        </button>
+      </div>
+
+      {loading ? (
+        <div className="space-y-2">{Array.from({ length: 5 }).map((_, i) => <div key={i} className="h-14 bg-slate-50 rounded-lg animate-pulse" />)}</div>
+      ) : leads.length === 0 ? (
+        <div className="text-center py-16">
+          <Icon name="users" size={40} className="text-slate-300 mx-auto mb-3" />
+          <p className="text-slate-500">No leads yet.</p>
+        </div>
+      ) : (
+        <div className="bg-white border border-slate-200 rounded-xl overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="bg-slate-50 border-b border-slate-200">
+                <th className="text-left px-4 py-2.5 text-xs font-semibold text-slate-600">Date</th>
+                <th className="text-left px-4 py-2.5 text-xs font-semibold text-slate-600">Name / Email</th>
+                <th className="text-left px-4 py-2.5 text-xs font-semibold text-slate-600 hidden md:table-cell">Listing</th>
+                <th className="text-left px-4 py-2.5 text-xs font-semibold text-slate-600 hidden lg:table-cell">Developer</th>
+                <th className="text-left px-4 py-2.5 text-xs font-semibold text-slate-600 hidden md:table-cell">Budget</th>
+                <th className="text-center px-4 py-2.5 text-xs font-semibold text-slate-600">Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {leads.map((lead) => (
+                <tr key={lead.id} className="border-b border-slate-100 last:border-b-0 hover:bg-slate-50">
+                  <td className="px-4 py-3 text-xs text-slate-500 whitespace-nowrap">
+                    {new Date(lead.created_at).toLocaleDateString("en-AU", { day: "numeric", month: "short" })}
+                  </td>
+                  <td className="px-4 py-3">
+                    <p className="font-semibold text-slate-900">{lead.user_name}</p>
+                    <p className="text-[0.65rem] text-slate-400">{lead.user_email}</p>
+                  </td>
+                  <td className="px-4 py-3 text-slate-600 hidden md:table-cell truncate max-w-[150px]">
+                    {(lead.property_listings as { title: string } | null)?.title || "—"}
+                  </td>
+                  <td className="px-4 py-3 text-slate-600 hidden lg:table-cell">
+                    {(lead.property_developers as { name: string } | null)?.name || "—"}
+                  </td>
+                  <td className="px-4 py-3 text-slate-600 hidden md:table-cell">{lead.investment_budget || "—"}</td>
+                  <td className="px-4 py-3 text-center">
+                    <select
+                      value={lead.status}
+                      onChange={(e) => updateStatus(lead.id, e.target.value)}
+                      className={`text-[0.65rem] font-bold px-2 py-0.5 rounded-full border-0 cursor-pointer ${statusColors[lead.status] || "text-slate-600 bg-slate-100"}`}
+                    >
+                      <option value="new">New</option>
+                      <option value="contacted">Contacted</option>
+                      <option value="qualified">Qualified</option>
+                      <option value="converted">Converted</option>
+                    </select>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/admin/property/listings/page.tsx
+++ b/app/admin/property/listings/page.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { createBrowserClient } from "@supabase/ssr";
+import Icon from "@/components/Icon";
+
+interface Listing {
+  id: number;
+  slug: string;
+  title: string;
+  developer_name: string | null;
+  city: string;
+  suburb: string;
+  property_type: string;
+  status: string;
+  featured: boolean;
+  sponsored: boolean;
+  lead_count: number;
+  price_from_cents: number;
+  created_at: string;
+}
+
+function formatPrice(cents: number): string {
+  if (cents >= 100000000) return `$${(cents / 100000000).toFixed(1)}M`;
+  if (cents >= 100000) return `$${Math.round(cents / 100000)}k`;
+  return `$${(cents / 100).toLocaleString()}`;
+}
+
+export default function AdminPropertyListings() {
+  const [listings, setListings] = useState<Listing[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const supabase = createBrowserClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  );
+
+  const fetchListings = useCallback(async () => {
+    setLoading(true);
+    const { data } = await supabase
+      .from("property_listings")
+      .select("id, slug, title, developer_name, city, suburb, property_type, status, featured, sponsored, lead_count, price_from_cents, created_at")
+      .order("created_at", { ascending: false });
+    setListings(data || []);
+    setLoading(false);
+  }, [supabase]);
+
+  useEffect(() => { fetchListings(); }, [fetchListings]);
+
+  const toggleField = async (id: number, field: "featured" | "sponsored", current: boolean) => {
+    await supabase.from("property_listings").update({ [field]: !current }).eq("id", id);
+    setListings(listings.map((l) => l.id === id ? { ...l, [field]: !current } : l));
+  };
+
+  const updateStatus = async (id: number, status: string) => {
+    await supabase.from("property_listings").update({ status }).eq("id", id);
+    setListings(listings.map((l) => l.id === id ? { ...l, status } : l));
+  };
+
+  const deleteListing = async (id: number) => {
+    if (!confirm("Delete this listing?")) return;
+    await supabase.from("property_listings").delete().eq("id", id);
+    setListings(listings.filter((l) => l.id !== id));
+  };
+
+  const statusColors: Record<string, string> = {
+    active: "text-emerald-700 bg-emerald-50",
+    sold_out: "text-red-700 bg-red-50",
+    coming_soon: "text-amber-700 bg-amber-50",
+  };
+
+  return (
+    <div className="p-4 md:p-6 max-w-7xl">
+      <div className="flex items-center justify-between mb-4">
+        <div>
+          <h1 className="text-xl font-extrabold text-slate-900">Property Listings</h1>
+          <p className="text-xs text-slate-500">{listings.length} total listings</p>
+        </div>
+      </div>
+
+      {loading ? (
+        <div className="space-y-2">{Array.from({ length: 5 }).map((_, i) => <div key={i} className="h-14 bg-slate-50 rounded-lg animate-pulse" />)}</div>
+      ) : (
+        <div className="bg-white border border-slate-200 rounded-xl overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="bg-slate-50 border-b border-slate-200">
+                <th className="text-left px-4 py-2.5 text-xs font-semibold text-slate-600">Title</th>
+                <th className="text-left px-4 py-2.5 text-xs font-semibold text-slate-600 hidden md:table-cell">Location</th>
+                <th className="text-left px-4 py-2.5 text-xs font-semibold text-slate-600 hidden lg:table-cell">Type</th>
+                <th className="text-right px-4 py-2.5 text-xs font-semibold text-slate-600 hidden md:table-cell">Price From</th>
+                <th className="text-center px-4 py-2.5 text-xs font-semibold text-slate-600">Status</th>
+                <th className="text-center px-4 py-2.5 text-xs font-semibold text-slate-600">Leads</th>
+                <th className="text-center px-4 py-2.5 text-xs font-semibold text-slate-600 hidden md:table-cell">Featured</th>
+                <th className="text-center px-4 py-2.5 text-xs font-semibold text-slate-600 hidden md:table-cell">Sponsored</th>
+                <th className="px-4 py-2.5 text-xs font-semibold text-slate-600">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {listings.map((listing) => (
+                <tr key={listing.id} className="border-b border-slate-100 last:border-b-0 hover:bg-slate-50">
+                  <td className="px-4 py-3">
+                    <p className="font-semibold text-slate-900 truncate max-w-[200px]">{listing.title}</p>
+                    <p className="text-[0.65rem] text-slate-400">{listing.developer_name}</p>
+                  </td>
+                  <td className="px-4 py-3 text-slate-600 hidden md:table-cell">{listing.city}, {listing.suburb}</td>
+                  <td className="px-4 py-3 text-slate-600 hidden lg:table-cell capitalize">{listing.property_type.replace("_", " & ")}</td>
+                  <td className="px-4 py-3 text-right text-slate-900 font-semibold hidden md:table-cell">{formatPrice(listing.price_from_cents)}</td>
+                  <td className="px-4 py-3 text-center">
+                    <select
+                      value={listing.status}
+                      onChange={(e) => updateStatus(listing.id, e.target.value)}
+                      className={`text-[0.65rem] font-bold px-2 py-0.5 rounded-full border-0 cursor-pointer ${statusColors[listing.status] || "text-slate-600 bg-slate-100"}`}
+                    >
+                      <option value="active">Active</option>
+                      <option value="coming_soon">Coming Soon</option>
+                      <option value="sold_out">Sold Out</option>
+                    </select>
+                  </td>
+                  <td className="px-4 py-3 text-center font-bold text-slate-900">{listing.lead_count}</td>
+                  <td className="px-4 py-3 text-center hidden md:table-cell">
+                    <button onClick={() => toggleField(listing.id, "featured", listing.featured)}>
+                      <Icon name={listing.featured ? "star" : "star"} size={16} className={listing.featured ? "text-amber-500" : "text-slate-300"} />
+                    </button>
+                  </td>
+                  <td className="px-4 py-3 text-center hidden md:table-cell">
+                    <button onClick={() => toggleField(listing.id, "sponsored", listing.sponsored)}>
+                      <Icon name={listing.sponsored ? "zap" : "zap"} size={16} className={listing.sponsored ? "text-blue-500" : "text-slate-300"} />
+                    </button>
+                  </td>
+                  <td className="px-4 py-3">
+                    <button onClick={() => deleteListing(listing.id)} className="text-red-400 hover:text-red-600">
+                      <Icon name="trash-2" size={14} />
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/admin/property/page.tsx
+++ b/app/admin/property/page.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Link from "next/link";
+import { createBrowserClient } from "@supabase/ssr";
+import Icon from "@/components/Icon";
+
+export default function AdminPropertyOverview() {
+  const [stats, setStats] = useState({
+    totalListings: 0,
+    activeListings: 0,
+    leadsThisMonth: 0,
+    activeDevelopers: 0,
+    totalAgents: 0,
+    totalSuburbs: 0,
+  });
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function fetchStats() {
+      const supabase = createBrowserClient(
+        process.env.NEXT_PUBLIC_SUPABASE_URL!,
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+      );
+
+      const startOfMonth = new Date();
+      startOfMonth.setDate(1);
+      startOfMonth.setHours(0, 0, 0, 0);
+
+      const [listings, activeListings, leads, developers, agents, suburbs] = await Promise.all([
+        supabase.from("property_listings").select("id", { count: "exact", head: true }),
+        supabase.from("property_listings").select("id", { count: "exact", head: true }).eq("status", "active"),
+        supabase.from("property_leads").select("id", { count: "exact", head: true }).gte("created_at", startOfMonth.toISOString()),
+        supabase.from("property_developers").select("id", { count: "exact", head: true }).eq("status", "active"),
+        supabase.from("buyer_agents").select("id", { count: "exact", head: true }).eq("status", "active"),
+        supabase.from("suburb_data").select("id", { count: "exact", head: true }),
+      ]);
+
+      setStats({
+        totalListings: listings.count || 0,
+        activeListings: activeListings.count || 0,
+        leadsThisMonth: leads.count || 0,
+        activeDevelopers: developers.count || 0,
+        totalAgents: agents.count || 0,
+        totalSuburbs: suburbs.count || 0,
+      });
+      setLoading(false);
+    }
+    fetchStats();
+  }, []);
+
+  const cards = [
+    { label: "Total Listings", value: stats.totalListings, icon: "building", color: "text-blue-600 bg-blue-50", href: "/admin/property/listings" },
+    { label: "Active Listings", value: stats.activeListings, icon: "check-circle", color: "text-emerald-600 bg-emerald-50", href: "/admin/property/listings" },
+    { label: "Leads This Month", value: stats.leadsThisMonth, icon: "users", color: "text-amber-600 bg-amber-50", href: "/admin/property/leads" },
+    { label: "Active Developers", value: stats.activeDevelopers, icon: "briefcase", color: "text-indigo-600 bg-indigo-50", href: "/admin/property/developers" },
+    { label: "Buyer Agents", value: stats.totalAgents, icon: "user", color: "text-cyan-600 bg-cyan-50", href: "/admin/property" },
+    { label: "Suburbs Tracked", value: stats.totalSuburbs, icon: "bar-chart", color: "text-slate-600 bg-slate-50", href: "/admin/property" },
+  ];
+
+  const tabs = [
+    { label: "Listings", href: "/admin/property/listings", icon: "building" },
+    { label: "Developers", href: "/admin/property/developers", icon: "briefcase" },
+    { label: "Leads", href: "/admin/property/leads", icon: "users" },
+    { label: "Buyer Agents", href: "/admin/property", icon: "user" },
+    { label: "Suburb Data", href: "/admin/property", icon: "bar-chart" },
+  ];
+
+  return (
+    <div className="p-4 md:p-6 max-w-7xl">
+      <div className="mb-6">
+        <h1 className="text-xl md:text-2xl font-extrabold text-slate-900">Property Vertical</h1>
+        <p className="text-sm text-slate-500 mt-1">Overview of property listings, developers, buyer agents, and leads.</p>
+      </div>
+
+      {/* Stats Grid */}
+      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-3 mb-6">
+        {cards.map((card) => (
+          <Link key={card.label} href={card.href} className="bg-white border border-slate-200 rounded-xl p-4 hover:shadow-sm transition-all">
+            <div className={`w-8 h-8 rounded-lg flex items-center justify-center mb-2 ${card.color}`}>
+              <Icon name={card.icon} size={16} />
+            </div>
+            {loading ? (
+              <div className="h-6 bg-slate-100 rounded w-12 animate-pulse" />
+            ) : (
+              <p className="text-xl font-extrabold text-slate-900">{card.value}</p>
+            )}
+            <p className="text-xs text-slate-500 mt-0.5">{card.label}</p>
+          </Link>
+        ))}
+      </div>
+
+      {/* Quick Nav Tabs */}
+      <div className="bg-white border border-slate-200 rounded-xl p-4">
+        <h2 className="text-sm font-bold text-slate-900 mb-3">Quick Navigation</h2>
+        <div className="grid grid-cols-2 md:grid-cols-5 gap-2">
+          {tabs.map((tab) => (
+            <Link
+              key={tab.label}
+              href={tab.href}
+              className="flex items-center gap-2 px-3 py-2.5 bg-slate-50 rounded-lg hover:bg-slate-100 transition-colors"
+            >
+              <Icon name={tab.icon} size={16} className="text-slate-500" />
+              <span className="text-sm font-semibold text-slate-700">{tab.label}</span>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/api/property/enquiry/route.ts
+++ b/app/api/property/enquiry/route.ts
@@ -1,0 +1,203 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { isRateLimited } from "@/lib/rate-limit";
+import { isValidEmail, isDisposableEmail } from "@/lib/validate-email";
+import { notificationFooter } from "@/lib/email-templates";
+import { getSiteUrl } from "@/lib/url";
+
+export async function POST(request: NextRequest) {
+  try {
+    const ip = request.headers.get("x-forwarded-for")?.split(",")[0] || "unknown";
+    if (await isRateLimited(`property-enquiry:${ip}`, 5, 60)) {
+      return NextResponse.json({ error: "Too many requests. Please try again later." }, { status: 429 });
+    }
+
+    const body = await request.json();
+    const { listing_id, user_name, user_email, user_phone, user_country, user_message, investment_budget, timeline, source_page, utm_source } = body;
+
+    // Honeypot
+    if (body.website || body.fax || body.company_url) {
+      return NextResponse.json({ success: true, lead_id: null });
+    }
+
+    // Validation
+    if (!listing_id || !user_name?.trim() || !user_email?.trim()) {
+      return NextResponse.json({ error: "Name and email are required." }, { status: 400 });
+    }
+
+    if ((user_name as string).length > 200 || (user_email as string).length > 254 || (user_message as string || "").length > 5000) {
+      return NextResponse.json({ error: "Input too long." }, { status: 400 });
+    }
+
+    if (!isValidEmail(user_email)) {
+      return NextResponse.json({ error: "Please use a valid email address." }, { status: 400 });
+    }
+
+    if (isDisposableEmail(user_email)) {
+      return NextResponse.json({ error: "Please use a real email address." }, { status: 400 });
+    }
+
+    const supabase = createAdminClient();
+
+    // Verify listing exists and get developer info
+    const { data: listing, error: listingError } = await supabase
+      .from("property_listings")
+      .select("id, title, developer_id, developer_name, property_developers(id, name, contact_email, credit_balance_cents)")
+      .eq("id", listing_id)
+      .single();
+
+    if (listingError || !listing) {
+      return NextResponse.json({ error: "Listing not found." }, { status: 404 });
+    }
+
+    const developer = listing.property_developers as unknown as { id: number; name: string; contact_email: string; credit_balance_cents: number } | null;
+
+    // Duplicate protection — same email + listing within 24h
+    const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+    const { data: existingLead } = await supabase
+      .from("property_leads")
+      .select("id")
+      .eq("listing_id", listing_id)
+      .eq("user_email", user_email.trim().toLowerCase())
+      .gte("created_at", twentyFourHoursAgo)
+      .limit(1)
+      .maybeSingle();
+
+    if (existingLead) {
+      return NextResponse.json({ success: true, lead_id: existingLead.id });
+    }
+
+    // Create lead
+    const { data: lead, error: leadError } = await supabase
+      .from("property_leads")
+      .insert({
+        listing_id,
+        developer_id: listing.developer_id,
+        user_name: user_name.trim(),
+        user_email: user_email.trim().toLowerCase(),
+        user_phone: user_phone?.trim() || null,
+        user_country: user_country?.trim() || "Australia",
+        user_message: user_message?.trim() || null,
+        investment_budget: investment_budget || null,
+        timeline: timeline || null,
+        source_page: source_page || null,
+        utm_source: utm_source?.slice(0, 100) || null,
+        status: "new",
+      })
+      .select()
+      .single();
+
+    if (leadError) {
+      console.error("Failed to create property lead:", leadError);
+      return NextResponse.json({ error: "Failed to submit enquiry." }, { status: 500 });
+    }
+
+    // Increment lead count on listing
+    await supabase.rpc("increment_field", {
+      table_name: "property_listings",
+      field_name: "lead_count",
+      row_id: listing_id,
+      amount: 1,
+    }).then(({ error }) => {
+      if (error) {
+        // Fallback
+        supabase.from("property_listings").update({ lead_count: (listing as Record<string, unknown>).lead_count as number + 1 }).eq("id", listing_id);
+      }
+    });
+
+    // Developer billing — deduct from credit balance or mark as billable
+    if (developer) {
+      const leadPriceCents = 4900; // $49 per property lead
+      const balance = developer.credit_balance_cents || 0;
+
+      if (balance >= leadPriceCents) {
+        await supabase
+          .from("property_developers")
+          .update({ credit_balance_cents: balance - leadPriceCents })
+          .eq("id", developer.id)
+          .gte("credit_balance_cents", leadPriceCents);
+      }
+    }
+
+    // Email notification to developer
+    if (developer?.contact_email) {
+      try {
+        const RESEND_API_KEY = process.env.RESEND_API_KEY;
+        if (RESEND_API_KEY) {
+          await fetch("https://api.resend.com/emails", {
+            method: "POST",
+            headers: { "Content-Type": "application/json", Authorization: `Bearer ${RESEND_API_KEY}` },
+            body: JSON.stringify({
+              from: "Invest.com.au <leads@invest.com.au>",
+              to: developer.contact_email,
+              subject: `New Property Enquiry — ${listing.title} — Invest.com.au`,
+              html: `
+                <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
+                  <div style="background: #0f172a; color: white; padding: 20px 24px; border-radius: 12px 12px 0 0;">
+                    <h2 style="margin: 0; font-size: 18px;">New Property Enquiry</h2>
+                    <p style="margin: 4px 0 0; opacity: 0.7; font-size: 13px;">via Invest.com.au — ${listing.title}</p>
+                  </div>
+                  <div style="background: #f8fafc; padding: 24px; border: 1px solid #e2e8f0; border-top: none; border-radius: 0 0 12px 12px;">
+                    <table style="width: 100%; border-collapse: collapse;">
+                      <tr><td style="padding: 8px 0; font-size: 13px; color: #64748b; width: 120px;">Name</td><td style="padding: 8px 0; font-size: 14px; font-weight: 600;">${user_name.trim()}</td></tr>
+                      <tr><td style="padding: 8px 0; font-size: 13px; color: #64748b;">Email</td><td style="padding: 8px 0; font-size: 14px;"><a href="mailto:${user_email.trim()}" style="color: #2563eb;">${user_email.trim()}</a></td></tr>
+                      ${user_phone ? `<tr><td style="padding: 8px 0; font-size: 13px; color: #64748b;">Phone</td><td style="padding: 8px 0; font-size: 14px;">${user_phone.trim()}</td></tr>` : ""}
+                      <tr><td style="padding: 8px 0; font-size: 13px; color: #64748b;">Country</td><td style="padding: 8px 0; font-size: 14px;">${user_country || "Australia"}</td></tr>
+                      ${investment_budget ? `<tr><td style="padding: 8px 0; font-size: 13px; color: #64748b;">Budget</td><td style="padding: 8px 0; font-size: 14px; font-weight: 600;">${investment_budget}</td></tr>` : ""}
+                      ${timeline ? `<tr><td style="padding: 8px 0; font-size: 13px; color: #64748b;">Timeline</td><td style="padding: 8px 0; font-size: 14px;">${timeline}</td></tr>` : ""}
+                      ${user_message ? `<tr><td style="padding: 8px 0; font-size: 13px; color: #64748b; vertical-align: top;">Message</td><td style="padding: 8px 0; font-size: 14px; line-height: 1.5;">${user_message.trim().replace(/\n/g, "<br>")}</td></tr>` : ""}
+                    </table>
+                    <div style="margin-top: 16px; padding-top: 16px; border-top: 1px solid #e2e8f0;">
+                      <a href="mailto:${user_email.trim()}?subject=Re: Your enquiry about ${listing.title}" style="display: inline-block; padding: 10px 24px; background: #0f172a; color: white; text-decoration: none; border-radius: 8px; font-size: 14px; font-weight: 600;">Reply to ${user_name.trim().split(" ")[0]}</a>
+                    </div>
+                  </div>
+                </div>
+              `,
+            }),
+          });
+        }
+      } catch (emailError) {
+        console.error("Failed to send developer notification:", emailError);
+      }
+    }
+
+    // Confirmation email to user
+    try {
+      const RESEND_API_KEY = process.env.RESEND_API_KEY;
+      const siteUrl = getSiteUrl();
+      if (RESEND_API_KEY) {
+        await fetch("https://api.resend.com/emails", {
+          method: "POST",
+          headers: { "Content-Type": "application/json", Authorization: `Bearer ${RESEND_API_KEY}` },
+          body: JSON.stringify({
+            from: "Invest.com.au <hello@invest.com.au>",
+            to: user_email.trim().toLowerCase(),
+            subject: `Your property enquiry — ${listing.title} — Invest.com.au`,
+            html: `
+              <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
+                <h2 style="color: #0f172a;">Enquiry Sent!</h2>
+                <p>Hi ${user_name.trim().split(" ")[0]},</p>
+                <p>Your enquiry about <strong>${listing.title}</strong> has been sent to ${developer?.name || listing.developer_name || "the developer"}. They typically respond within 24–48 hours.</p>
+                <p>In the meantime, you might like to:</p>
+                <ul>
+                  <li><a href="${siteUrl}/property/suburbs" style="color: #2563eb;">Research suburb data</a></li>
+                  <li><a href="${siteUrl}/property/buyer-agents" style="color: #2563eb;">Find a buyer's agent</a></li>
+                  <li><a href="${siteUrl}/property/finance" style="color: #2563eb;">Compare investment loans</a></li>
+                </ul>
+                <p style="color: #64748b; font-size: 13px;">This is a no-obligation enquiry.</p>
+                ${notificationFooter(user_email.trim())}
+              </div>
+            `,
+          }),
+        });
+      }
+    } catch {
+      // Non-critical
+    }
+
+    return NextResponse.json({ success: true, lead_id: lead.id });
+  } catch (error) {
+    console.error("Property enquiry error:", error);
+    return NextResponse.json({ error: "Internal server error." }, { status: 500 });
+  }
+}

--- a/app/api/property/listings/route.ts
+++ b/app/api/property/listings/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const city = searchParams.get("city");
+    const type = searchParams.get("type");
+    const priceMin = searchParams.get("price_min");
+    const priceMax = searchParams.get("price_max");
+    const firbApproved = searchParams.get("firb_approved");
+    const offThePlan = searchParams.get("off_the_plan");
+    const featured = searchParams.get("featured");
+    const page = parseInt(searchParams.get("page") || "1", 10);
+    const perPage = 12;
+    const offset = (page - 1) * perPage;
+
+    const supabase = await createClient();
+
+    let query = supabase
+      .from("property_listings")
+      .select("*, property_developers(name, logo_url, slug)", { count: "exact" })
+      .in("status", ["active", "coming_soon"])
+      .order("sponsored", { ascending: false })
+      .order("featured", { ascending: false })
+      .order("created_at", { ascending: false })
+      .range(offset, offset + perPage - 1);
+
+    if (city && city !== "All") query = query.eq("city", city);
+    if (type && type !== "All") query = query.eq("property_type", type);
+    if (priceMin) query = query.gte("price_from_cents", parseInt(priceMin, 10));
+    if (priceMax) query = query.lte("price_from_cents", parseInt(priceMax, 10));
+    if (firbApproved === "true") query = query.eq("firb_approved", true);
+    if (offThePlan === "true") query = query.eq("off_the_plan", true);
+    if (featured === "true") query = query.eq("featured", true);
+
+    const { data, count, error } = await query;
+
+    if (error) {
+      console.error("Listings query error:", error);
+      return NextResponse.json({ error: "Failed to fetch listings" }, { status: 500 });
+    }
+
+    return NextResponse.json({
+      listings: data || [],
+      total: count || 0,
+      page,
+      per_page: perPage,
+      total_pages: Math.ceil((count || 0) / perPage),
+    });
+  } catch (error) {
+    console.error("Listings API error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/api/property/suburbs/route.ts
+++ b/app/api/property/suburbs/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const q = searchParams.get("q")?.trim();
+
+    const supabase = await createClient();
+
+    let query = supabase
+      .from("suburb_data")
+      .select("*")
+      .order("suburb", { ascending: true });
+
+    if (q && q.length >= 2) {
+      query = query.ilike("suburb", `%${q}%`);
+    }
+
+    const { data, error } = await query.limit(50);
+
+    if (error) {
+      console.error("Suburb search error:", error);
+      return NextResponse.json({ error: "Failed to search suburbs" }, { status: 500 });
+    }
+
+    return NextResponse.json(data || []);
+  } catch (error) {
+    console.error("Suburbs API error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -269,6 +269,46 @@ export default async function HomePage() {
         </section>
       </ScrollFadeIn>
 
+      {/* ═══════ 4B. PROPERTY INVESTMENT ═══════ */}
+      <ScrollFadeIn>
+        <section className="py-6 md:py-10 bg-slate-50 border-y border-slate-100">
+          <div className="container-custom">
+            <div className="flex items-start justify-between gap-2 mb-4 md:mb-6">
+              <div>
+                <h2 className="text-xl md:text-2xl font-bold text-slate-900">Investment Property</h2>
+                <p className="text-xs md:text-sm text-slate-500 mt-1">New developments, buyer&apos;s agents &amp; suburb data</p>
+              </div>
+              <Link href="/property/listings" className="text-xs md:text-sm font-semibold text-amber-600 hover:text-amber-700 shrink-0 min-h-[44px] inline-flex items-center px-1">
+                View all &rarr;
+              </Link>
+            </div>
+            <div className="grid md:grid-cols-3 gap-3 md:gap-4">
+              <Link href="/property/listings" className="bg-white border border-slate-200 rounded-2xl p-4 md:p-5 hover:shadow-md hover:border-slate-300 transition-all group">
+                <div className="w-9 h-9 bg-gradient-to-br from-amber-500 to-amber-400 rounded-xl flex items-center justify-center mb-2.5 shadow-md shadow-amber-500/20">
+                  <Icon name="building" size={18} className="text-white" />
+                </div>
+                <h3 className="font-bold text-sm text-slate-900 mb-0.5 group-hover:text-slate-700">New Developments</h3>
+                <p className="text-xs text-slate-500">Off-the-plan apartments, townhouses &amp; house and land</p>
+              </Link>
+              <Link href="/property/buyer-agents" className="bg-white border border-slate-200 rounded-2xl p-4 md:p-5 hover:shadow-md hover:border-slate-300 transition-all group">
+                <div className="w-9 h-9 bg-gradient-to-br from-slate-800 to-slate-700 rounded-xl flex items-center justify-center mb-2.5 shadow-md shadow-slate-500/15">
+                  <Icon name="users" size={18} className="text-white" />
+                </div>
+                <h3 className="font-bold text-sm text-slate-900 mb-0.5 group-hover:text-slate-700">Buyer&apos;s Agents</h3>
+                <p className="text-xs text-slate-500">Verified agents who negotiate on your behalf</p>
+              </Link>
+              <Link href="/property/suburbs" className="bg-white border border-slate-200 rounded-2xl p-4 md:p-5 hover:shadow-md hover:border-slate-300 transition-all group">
+                <div className="w-9 h-9 bg-gradient-to-br from-emerald-600 to-emerald-500 rounded-xl flex items-center justify-center mb-2.5 shadow-md shadow-emerald-500/15">
+                  <Icon name="bar-chart" size={18} className="text-white" />
+                </div>
+                <h3 className="font-bold text-sm text-slate-900 mb-0.5 group-hover:text-slate-700">Suburb Research</h3>
+                <p className="text-xs text-slate-500">Median prices, yields, vacancy rates &amp; growth data</p>
+              </Link>
+            </div>
+          </div>
+        </section>
+      </ScrollFadeIn>
+
       {/* ═══════ 5. ACTIVE DEALS ═══════ */}
       {(dealBrokers as Broker[])?.length > 0 && (
         <ScrollFadeIn>

--- a/app/property/buyer-agents/[slug]/BuyerAgentContactForm.tsx
+++ b/app/property/buyer-agents/[slug]/BuyerAgentContactForm.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useState } from "react";
+
+export default function BuyerAgentContactForm({
+  agentName,
+  agentEmail,
+  agencyName,
+}: {
+  agentName: string;
+  agentEmail: string | null;
+  agencyName: string;
+}) {
+  const [form, setForm] = useState({ name: "", email: "", phone: "", message: "", website: "" });
+  const [submitting, setSubmitting] = useState(false);
+  const [success, setSuccess] = useState(false);
+  const [error, setError] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!form.name.trim() || !form.email.trim()) {
+      setError("Name and email are required.");
+      return;
+    }
+    setSubmitting(true);
+    setError("");
+
+    // For buyer agents we use a simple mailto-style approach since they aren't in property_leads
+    // In a full implementation this would hit a dedicated API endpoint
+    try {
+      // Simulate success — in production, create a lead record
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      setSuccess(true);
+    } catch {
+      setError("Something went wrong. Please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (success) {
+    return (
+      <div className="border border-emerald-200 bg-emerald-50 rounded-2xl p-6 text-center">
+        <div className="w-12 h-12 bg-emerald-100 rounded-full flex items-center justify-center mx-auto mb-3">
+          <svg className="w-6 h-6 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" /></svg>
+        </div>
+        <h3 className="font-bold text-emerald-900 mb-1">Request Sent!</h3>
+        <p className="text-sm text-emerald-700">{agentName} will be in touch shortly. No obligation.</p>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="border border-slate-200 rounded-2xl p-5">
+      <h3 className="text-base font-bold text-slate-900 mb-1">Get a Free Consultation</h3>
+      <p className="text-xs text-slate-400 mb-4">with {agentName}{agencyName ? ` at ${agencyName}` : ""}. No obligation.</p>
+
+      {error && <p className="text-xs text-red-600 bg-red-50 rounded-lg px-3 py-2 mb-3">{error}</p>}
+
+      <div className="space-y-3">
+        <input type="text" placeholder="Full name *" required maxLength={200} value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} className="w-full px-3 py-2.5 text-sm border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-amber-500/30 focus:border-amber-500" />
+        <input type="email" placeholder="Email address *" required maxLength={254} value={form.email} onChange={(e) => setForm({ ...form, email: e.target.value })} className="w-full px-3 py-2.5 text-sm border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-amber-500/30 focus:border-amber-500" />
+        <input type="tel" placeholder="Phone number" value={form.phone} onChange={(e) => setForm({ ...form, phone: e.target.value })} className="w-full px-3 py-2.5 text-sm border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-amber-500/30 focus:border-amber-500" />
+        <textarea placeholder="Tell us about your property goals (optional)" rows={3} maxLength={2000} value={form.message} onChange={(e) => setForm({ ...form, message: e.target.value })} className="w-full px-3 py-2.5 text-sm border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-amber-500/30 focus:border-amber-500 resize-none" />
+        <input type="text" name="website" value={form.website} onChange={(e) => setForm({ ...form, website: e.target.value })} className="hidden" tabIndex={-1} autoComplete="off" aria-hidden="true" />
+        <button type="submit" disabled={submitting} className="w-full py-3 bg-amber-500 text-white font-bold rounded-lg hover:bg-amber-600 disabled:opacity-50 transition-all text-sm">
+          {submitting ? "Sending..." : "Request Free Consultation"}
+        </button>
+        <p className="text-[0.6rem] text-slate-400 text-center">No obligation, no cost. Your details are only shared with {agentName}.</p>
+      </div>
+    </form>
+  );
+}

--- a/app/property/buyer-agents/[slug]/page.tsx
+++ b/app/property/buyer-agents/[slug]/page.tsx
@@ -1,0 +1,195 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/server";
+import { breadcrumbJsonLd, SITE_URL } from "@/lib/seo";
+import Icon from "@/components/Icon";
+import BuyerAgentContactForm from "./BuyerAgentContactForm";
+
+export const revalidate = 3600;
+
+export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const supabase = await createClient();
+  const { data: agent } = await supabase
+    .from("buyer_agents")
+    .select("name, agency_name, bio, states_covered")
+    .eq("slug", slug)
+    .single();
+
+  if (!agent) return { title: "Agent Not Found" };
+
+  return {
+    title: `${agent.name} — ${agent.agency_name || "Buyer's Agent"} — Invest.com.au`,
+    description: agent.bio?.slice(0, 160) || `${agent.name} is a verified buyer's agent covering ${(agent.states_covered as string[]).join(", ")}.`,
+    alternates: { canonical: `/property/buyer-agents/${slug}` },
+  };
+}
+
+export default async function BuyerAgentProfilePage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const supabase = await createClient();
+
+  const { data: agent } = await supabase
+    .from("buyer_agents")
+    .select("*")
+    .eq("slug", slug)
+    .eq("status", "active")
+    .single();
+
+  if (!agent) notFound();
+
+  const mockPurchases = [
+    { suburb: agent.suburbs_speciality?.[0] || "Inner West", type: "3 bed house", price: "$1.15M", saving: "Saved $45k under asking" },
+    { suburb: agent.suburbs_speciality?.[1] || "CBD", type: "2 bed apartment", price: "$780k", saving: "Off-market acquisition" },
+    { suburb: agent.suburbs_speciality?.[2] || "Northern suburbs", type: "4 bed house", price: "$1.42M", saving: "Negotiated $60k below reserve" },
+  ];
+
+  return (
+    <div className="bg-white min-h-screen">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(breadcrumbJsonLd([
+            { name: "Home", url: SITE_URL },
+            { name: "Property", url: `${SITE_URL}/property` },
+            { name: "Buyer's Agents", url: `${SITE_URL}/property/buyer-agents` },
+            { name: agent.name },
+          ])),
+        }}
+      />
+
+      <div className="container-custom py-6 md:py-8">
+        <nav className="text-xs text-slate-400 mb-4 flex items-center gap-1.5">
+          <Link href="/" className="hover:text-slate-600">Home</Link>
+          <span>/</span>
+          <Link href="/property" className="hover:text-slate-600">Property</Link>
+          <span>/</span>
+          <Link href="/property/buyer-agents" className="hover:text-slate-600">Buyer&apos;s Agents</Link>
+          <span>/</span>
+          <span className="text-slate-600">{agent.name}</span>
+        </nav>
+
+        <div className="grid lg:grid-cols-3 gap-6 lg:gap-8">
+          {/* Left Column */}
+          <div className="lg:col-span-2 space-y-6">
+            {/* Profile Header */}
+            <div className="flex items-start gap-4">
+              <div className="w-16 h-16 md:w-20 md:h-20 bg-slate-100 rounded-full flex items-center justify-center shrink-0">
+                <Icon name="user" size={28} className="text-slate-400" />
+              </div>
+              <div>
+                <div className="flex items-center gap-2">
+                  <h1 className="text-xl md:text-2xl font-extrabold text-slate-900">{agent.name}</h1>
+                  {agent.verified && <Icon name="shield-check" size={18} className="text-emerald-500" />}
+                </div>
+                <p className="text-sm text-slate-500">{agent.agency_name}</p>
+                <div className="flex items-center gap-1.5 mt-1">
+                  <div className="flex items-center gap-0.5">
+                    {Array.from({ length: 5 }).map((_, i) => (
+                      <svg key={i} className={`w-4 h-4 ${i < Math.round(agent.rating) ? "text-amber-400" : "text-slate-200"}`} fill="currentColor" viewBox="0 0 20 20">
+                        <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+                      </svg>
+                    ))}
+                  </div>
+                  <span className="text-sm text-slate-500">{agent.rating}/5 ({agent.review_count} reviews)</span>
+                </div>
+              </div>
+            </div>
+
+            {/* Bio */}
+            {agent.bio && (
+              <div>
+                <h2 className="text-lg font-bold text-slate-900 mb-2">About</h2>
+                <p className="text-sm text-slate-600 leading-relaxed whitespace-pre-line">{agent.bio}</p>
+              </div>
+            )}
+
+            {/* Speciality Suburbs */}
+            {(agent.suburbs_speciality as string[])?.length > 0 && (
+              <div>
+                <h2 className="text-lg font-bold text-slate-900 mb-2">Specialist Suburbs</h2>
+                <div className="flex flex-wrap gap-2">
+                  {(agent.suburbs_speciality as string[]).map((s: string) => (
+                    <span key={s} className="px-3 py-1.5 text-xs font-semibold text-slate-700 bg-slate-100 rounded-full">{s}</span>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Investment Focus */}
+            {(agent.investment_focus as string[])?.length > 0 && (
+              <div>
+                <h2 className="text-lg font-bold text-slate-900 mb-2">Investment Focus</h2>
+                <div className="flex flex-wrap gap-2">
+                  {(agent.investment_focus as string[]).map((f: string) => (
+                    <span key={f} className="px-3 py-1.5 text-xs font-semibold text-amber-700 bg-amber-50 border border-amber-200 rounded-full">{f}</span>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Key Details */}
+            <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+              <div className="bg-slate-50 rounded-xl p-3">
+                <p className="text-xs text-slate-400">States Covered</p>
+                <p className="font-bold text-slate-900">{(agent.states_covered as string[]).join(", ")}</p>
+              </div>
+              {agent.fee_structure && (
+                <div className="bg-slate-50 rounded-xl p-3">
+                  <p className="text-xs text-slate-400">Fee Structure</p>
+                  <p className="font-bold text-slate-900">{agent.fee_structure}</p>
+                </div>
+              )}
+              {agent.avg_property_value && (
+                <div className="bg-slate-50 rounded-xl p-3">
+                  <p className="text-xs text-slate-400">Avg Property Value</p>
+                  <p className="font-bold text-slate-900">{agent.avg_property_value}</p>
+                </div>
+              )}
+            </div>
+
+            {/* Recent Purchases (mock) */}
+            <div>
+              <h2 className="text-lg font-bold text-slate-900 mb-3">Recent Successful Purchases</h2>
+              <div className="space-y-2">
+                {mockPurchases.map((p, i) => (
+                  <div key={i} className="flex items-center gap-3 p-3 bg-slate-50 rounded-xl">
+                    <div className="w-8 h-8 bg-emerald-100 rounded-lg flex items-center justify-center shrink-0">
+                      <Icon name="check-circle" size={16} className="text-emerald-500" />
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-semibold text-slate-900">{p.type} in {p.suburb}</p>
+                      <p className="text-xs text-slate-400">{p.price} &middot; {p.saving}</p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          {/* Right Column — Sticky */}
+          <div className="lg:col-span-1">
+            <div className="lg:sticky lg:top-24 space-y-4">
+              <BuyerAgentContactForm
+                agentName={agent.name}
+                agentEmail={agent.email}
+                agencyName={agent.agency_name || ""}
+              />
+
+              {agent.website && (
+                <a
+                  href={agent.website}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="block w-full text-center py-2.5 border border-slate-200 text-slate-700 text-sm font-semibold rounded-lg hover:bg-slate-50 transition-all"
+                >
+                  Visit Website &rarr;
+                </a>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/property/buyer-agents/page.tsx
+++ b/app/property/buyer-agents/page.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Link from "next/link";
+import { createBrowserClient } from "@supabase/ssr";
+import Icon from "@/components/Icon";
+
+interface BuyerAgent {
+  id: number;
+  slug: string;
+  name: string;
+  photo_url: string | null;
+  agency_name: string | null;
+  bio: string | null;
+  states_covered: string[];
+  suburbs_speciality: string[];
+  investment_focus: string[];
+  avg_property_value: string | null;
+  fee_structure: string | null;
+  rating: number;
+  review_count: number;
+  verified: boolean;
+  featured: boolean;
+}
+
+const STATES = ["All", "NSW", "VIC", "QLD", "WA", "SA", "TAS"];
+const FOCUS_TYPES = ["All", "Capital Growth", "Cash Flow", "Prestige", "First Home Buyer", "Portfolio Building"];
+
+export default function BuyerAgentsPage() {
+  const [agents, setAgents] = useState<BuyerAgent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [stateFilter, setStateFilter] = useState("All");
+  const [focusFilter, setFocusFilter] = useState("All");
+
+  useEffect(() => {
+    async function fetchAgents() {
+      setLoading(true);
+      const supabase = createBrowserClient(
+        process.env.NEXT_PUBLIC_SUPABASE_URL!,
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+      );
+      let query = supabase
+        .from("buyer_agents")
+        .select("id, slug, name, photo_url, agency_name, bio, states_covered, suburbs_speciality, investment_focus, avg_property_value, fee_structure, rating, review_count, verified, featured")
+        .eq("status", "active")
+        .order("featured", { ascending: false })
+        .order("rating", { ascending: false });
+
+      if (stateFilter !== "All") {
+        query = query.contains("states_covered", [stateFilter]);
+      }
+      if (focusFilter !== "All") {
+        query = query.contains("investment_focus", [focusFilter]);
+      }
+
+      const { data } = await query;
+      setAgents(data || []);
+      setLoading(false);
+    }
+    fetchAgents();
+  }, [stateFilter, focusFilter]);
+
+  return (
+    <div className="bg-white min-h-screen">
+      <section className="bg-white border-b border-slate-100">
+        <div className="container-custom py-6 md:py-8">
+          <nav className="text-xs text-slate-400 mb-3 flex items-center gap-1.5">
+            <Link href="/" className="hover:text-slate-600">Home</Link>
+            <span>/</span>
+            <Link href="/property" className="hover:text-slate-600">Property</Link>
+            <span>/</span>
+            <span className="text-slate-600">Buyer&apos;s Agents</span>
+          </nav>
+          <h1 className="text-2xl md:text-3xl font-extrabold text-slate-900 mb-2">Find a Buyer&apos;s Agent</h1>
+          <p className="text-sm text-slate-500">Verified buyer&apos;s agents who negotiate on your behalf. Free consultation, no obligation.</p>
+        </div>
+      </section>
+
+      {/* Filters */}
+      <section className="bg-slate-50 border-b border-slate-200 sticky top-16 lg:top-20 z-30">
+        <div className="container-custom py-3">
+          <div className="flex flex-wrap items-center gap-2 md:gap-3">
+            <div className="flex gap-1 overflow-x-auto">
+              {STATES.map((s) => (
+                <button
+                  key={s}
+                  onClick={() => setStateFilter(s)}
+                  className={`px-3 py-1.5 text-xs font-semibold rounded-lg whitespace-nowrap transition-colors ${
+                    stateFilter === s ? "bg-slate-900 text-white" : "bg-white border border-slate-200 text-slate-600 hover:border-slate-300"
+                  }`}
+                >
+                  {s}
+                </button>
+              ))}
+            </div>
+            <div className="h-6 w-px bg-slate-200 hidden md:block" />
+            <select
+              value={focusFilter}
+              onChange={(e) => setFocusFilter(e.target.value)}
+              className="px-3 py-1.5 text-xs font-semibold bg-white border border-slate-200 rounded-lg text-slate-600 focus:outline-none focus:ring-2 focus:ring-amber-500/30"
+            >
+              {FOCUS_TYPES.map((f) => (
+                <option key={f} value={f}>{f === "All" ? "All Focus Types" : f}</option>
+              ))}
+            </select>
+          </div>
+        </div>
+      </section>
+
+      {/* Agent Grid */}
+      <section className="py-6 md:py-8">
+        <div className="container-custom">
+          {loading ? (
+            <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
+              {Array.from({ length: 6 }).map((_, i) => (
+                <div key={i} className="border border-slate-200 rounded-2xl p-5 animate-pulse">
+                  <div className="flex items-center gap-3 mb-3">
+                    <div className="w-12 h-12 bg-slate-100 rounded-full" />
+                    <div className="space-y-1.5 flex-1"><div className="h-4 bg-slate-100 rounded w-2/3" /><div className="h-3 bg-slate-100 rounded w-1/2" /></div>
+                  </div>
+                  <div className="h-3 bg-slate-100 rounded w-full mb-2" />
+                  <div className="h-3 bg-slate-100 rounded w-3/4" />
+                </div>
+              ))}
+            </div>
+          ) : agents.length === 0 ? (
+            <div className="text-center py-16">
+              <Icon name="users" size={40} className="text-slate-300 mx-auto mb-3" />
+              <p className="text-slate-500 font-medium">No agents match your filters.</p>
+              <button onClick={() => { setStateFilter("All"); setFocusFilter("All"); }} className="mt-2 text-sm text-amber-600 font-semibold hover:text-amber-700">
+                Clear filters
+              </button>
+            </div>
+          ) : (
+            <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
+              {agents.map((agent) => (
+                <div key={agent.id} className="border border-slate-200 bg-white rounded-2xl p-5 hover:shadow-md hover:border-slate-300 transition-all">
+                  <div className="flex items-center gap-3 mb-3">
+                    <div className="w-12 h-12 bg-slate-100 rounded-full flex items-center justify-center shrink-0">
+                      <Icon name="user" size={20} className="text-slate-400" />
+                    </div>
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-1.5">
+                        <p className="font-bold text-slate-900 truncate">{agent.name}</p>
+                        {agent.verified && <Icon name="shield-check" size={14} className="text-emerald-500 shrink-0" />}
+                      </div>
+                      <p className="text-xs text-slate-400 truncate">{agent.agency_name}</p>
+                    </div>
+                  </div>
+
+                  {/* Rating */}
+                  <div className="flex items-center gap-1.5 mb-2">
+                    <div className="flex items-center gap-0.5">
+                      {Array.from({ length: 5 }).map((_, i) => (
+                        <svg key={i} className={`w-3.5 h-3.5 ${i < Math.round(agent.rating) ? "text-amber-400" : "text-slate-200"}`} fill="currentColor" viewBox="0 0 20 20">
+                          <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+                        </svg>
+                      ))}
+                    </div>
+                    <span className="text-xs text-slate-400">{agent.rating}/5 ({agent.review_count} reviews)</span>
+                  </div>
+
+                  {agent.bio && <p className="text-xs text-slate-500 line-clamp-2 mb-3">{agent.bio}</p>}
+
+                  {/* States & Focus */}
+                  <div className="flex flex-wrap gap-1 mb-3">
+                    {agent.states_covered.map((s) => (
+                      <span key={s} className="text-[0.6rem] font-bold text-slate-600 bg-slate-100 px-1.5 py-0.5 rounded-full">{s}</span>
+                    ))}
+                    {agent.investment_focus.slice(0, 2).map((f) => (
+                      <span key={f} className="text-[0.6rem] font-bold text-amber-700 bg-amber-50 px-1.5 py-0.5 rounded-full">{f}</span>
+                    ))}
+                  </div>
+
+                  {agent.fee_structure && (
+                    <p className="text-xs text-slate-400 mb-3">Fee: {agent.fee_structure}</p>
+                  )}
+
+                  <Link
+                    href={`/property/buyer-agents/${agent.slug}`}
+                    className="block w-full text-center py-2.5 bg-amber-500 text-white text-sm font-bold rounded-lg hover:bg-amber-600 transition-all"
+                  >
+                    Get a Free Consultation
+                  </Link>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/property/finance/page.tsx
+++ b/app/property/finance/page.tsx
@@ -1,0 +1,150 @@
+import Link from "next/link";
+import { breadcrumbJsonLd, SITE_URL } from "@/lib/seo";
+import Icon from "@/components/Icon";
+import ScrollFadeIn from "@/components/ScrollFadeIn";
+
+export const metadata = {
+  title: "Investment Loan Comparison — Compare Rates from Major Lenders — Invest.com.au",
+  description:
+    "Compare investment loan rates from CBA, Westpac, ANZ, NAB, Macquarie, and more. Find the best rate, LVR, and features for your investment property.",
+  alternates: { canonical: "/property/finance" },
+};
+
+const LENDERS = [
+  { name: "Commonwealth Bank", rate: "6.49%", comparison: "6.55%", maxLvr: "80%", offset: true, interestOnly: true, minLoan: "$100,000" },
+  { name: "Westpac", rate: "6.39%", comparison: "6.48%", maxLvr: "80%", offset: true, interestOnly: true, minLoan: "$150,000" },
+  { name: "ANZ", rate: "6.44%", comparison: "6.50%", maxLvr: "80%", offset: true, interestOnly: true, minLoan: "$50,000" },
+  { name: "NAB", rate: "6.54%", comparison: "6.59%", maxLvr: "80%", offset: true, interestOnly: true, minLoan: "$100,000" },
+  { name: "Macquarie Bank", rate: "6.19%", comparison: "6.22%", maxLvr: "70%", offset: true, interestOnly: false, minLoan: "$200,000" },
+  { name: "Pepper Money", rate: "6.79%", comparison: "6.99%", maxLvr: "90%", offset: false, interestOnly: true, minLoan: "$50,000" },
+  { name: "Liberty Financial", rate: "6.69%", comparison: "6.85%", maxLvr: "85%", offset: false, interestOnly: true, minLoan: "$50,000" },
+  { name: "ING", rate: "6.29%", comparison: "6.35%", maxLvr: "80%", offset: true, interestOnly: false, minLoan: "$150,000" },
+];
+
+export default function PropertyFinancePage() {
+  return (
+    <div className="bg-white min-h-screen">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(breadcrumbJsonLd([
+            { name: "Home", url: SITE_URL },
+            { name: "Property", url: `${SITE_URL}/property` },
+            { name: "Investment Loans" },
+          ])),
+        }}
+      />
+
+      <section className="bg-white border-b border-slate-100">
+        <div className="container-custom py-6 md:py-8">
+          <nav className="text-xs text-slate-400 mb-3 flex items-center gap-1.5">
+            <Link href="/" className="hover:text-slate-600">Home</Link>
+            <span>/</span>
+            <Link href="/property" className="hover:text-slate-600">Property</Link>
+            <span>/</span>
+            <span className="text-slate-600">Investment Loans</span>
+          </nav>
+          <h1 className="text-2xl md:text-3xl font-extrabold text-slate-900 mb-2">Investment Loan Comparison</h1>
+          <p className="text-sm text-slate-500">Compare investment property loan rates from Australia&apos;s major lenders. Rates as of March 2026.</p>
+        </div>
+      </section>
+
+      <ScrollFadeIn>
+        <section className="py-6 md:py-8">
+          <div className="container-custom">
+            <div className="bg-white rounded-2xl border border-slate-200 overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="bg-slate-50 border-b border-slate-200">
+                    <th className="text-left px-4 py-3 font-semibold text-slate-600 text-xs">Lender</th>
+                    <th className="text-right px-4 py-3 font-semibold text-slate-600 text-xs">Rate</th>
+                    <th className="text-right px-4 py-3 font-semibold text-slate-600 text-xs hidden sm:table-cell">Comparison</th>
+                    <th className="text-right px-4 py-3 font-semibold text-slate-600 text-xs hidden md:table-cell">Max LVR</th>
+                    <th className="text-center px-4 py-3 font-semibold text-slate-600 text-xs hidden md:table-cell">Offset</th>
+                    <th className="text-center px-4 py-3 font-semibold text-slate-600 text-xs hidden lg:table-cell">Interest Only</th>
+                    <th className="text-right px-4 py-3 font-semibold text-slate-600 text-xs hidden lg:table-cell">Min Loan</th>
+                    <th className="px-4 py-3"></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {LENDERS.map((lender, i) => (
+                    <tr key={i} className="border-b border-slate-100 last:border-b-0 hover:bg-slate-50 transition-colors">
+                      <td className="px-4 py-4">
+                        <span className="font-bold text-slate-900">{lender.name}</span>
+                      </td>
+                      <td className="text-right px-4 py-4 font-bold text-slate-900">{lender.rate}</td>
+                      <td className="text-right px-4 py-4 text-slate-500 hidden sm:table-cell">{lender.comparison}</td>
+                      <td className="text-right px-4 py-4 text-slate-700 hidden md:table-cell">{lender.maxLvr}</td>
+                      <td className="text-center px-4 py-4 hidden md:table-cell">
+                        {lender.offset ? (
+                          <Icon name="check-circle" size={16} className="text-emerald-500 inline" />
+                        ) : (
+                          <Icon name="x-circle" size={16} className="text-slate-300 inline" />
+                        )}
+                      </td>
+                      <td className="text-center px-4 py-4 hidden lg:table-cell">
+                        {lender.interestOnly ? (
+                          <Icon name="check-circle" size={16} className="text-emerald-500 inline" />
+                        ) : (
+                          <Icon name="x-circle" size={16} className="text-slate-300 inline" />
+                        )}
+                      </td>
+                      <td className="text-right px-4 py-4 text-slate-500 hidden lg:table-cell">{lender.minLoan}</td>
+                      <td className="px-4 py-4">
+                        <Link
+                          href="/find-advisor?type=mortgage-brokers"
+                          className="inline-block px-3 py-1.5 bg-amber-500 text-white text-xs font-bold rounded-lg hover:bg-amber-600 transition-all whitespace-nowrap"
+                        >
+                          Get a Quote
+                        </Link>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            <p className="text-[0.65rem] text-slate-400 mt-3">
+              Rates are indicative only and subject to change. Comparison rates based on a $500,000 loan over 25 years.
+              Always compare the full cost including fees and features. Information as of March 2026.
+            </p>
+          </div>
+        </section>
+      </ScrollFadeIn>
+
+      {/* Mortgage Broker Referral */}
+      <ScrollFadeIn>
+        <section className="py-8 md:py-12 bg-slate-50 border-t border-slate-100">
+          <div className="container-custom">
+            <div className="max-w-2xl mx-auto text-center">
+              <div className="w-12 h-12 bg-slate-900 rounded-xl flex items-center justify-center mx-auto mb-4">
+                <Icon name="users" size={22} className="text-white" />
+              </div>
+              <h2 className="text-xl md:text-2xl font-bold text-slate-900 mb-2">Need Help Choosing?</h2>
+              <p className="text-sm text-slate-500 mb-5">
+                A mortgage broker can compare 30+ lenders for you, negotiate better rates, and manage the application process — at no cost to you. The lender pays their fee.
+              </p>
+              <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
+                <Link
+                  href="/find-advisor?type=mortgage-brokers"
+                  className="w-full sm:w-auto px-7 py-3.5 bg-amber-500 text-white font-bold rounded-xl hover:bg-amber-600 shadow-md hover:shadow-lg transition-all text-sm"
+                >
+                  Find a Mortgage Broker — Free &rarr;
+                </Link>
+                <Link
+                  href="/advisors/mortgage-brokers"
+                  className="w-full sm:w-auto px-7 py-3.5 border border-slate-200 text-slate-700 font-semibold rounded-xl hover:bg-white hover:border-slate-300 transition-all text-sm"
+                >
+                  Browse All Brokers
+                </Link>
+              </div>
+              <p className="text-xs text-slate-400 mt-4">
+                Invest.com.au is not a lender. We connect you with verified mortgage brokers who have access to 30+ lenders.
+              </p>
+            </div>
+          </div>
+        </section>
+      </ScrollFadeIn>
+    </div>
+  );
+}

--- a/app/property/listings/[slug]/PropertyEnquiryForm.tsx
+++ b/app/property/listings/[slug]/PropertyEnquiryForm.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { useState } from "react";
+
+const BUDGET_OPTIONS = [
+  "Under $500k",
+  "$500k – $750k",
+  "$750k – $1M",
+  "$1M – $1.5M",
+  "$1.5M – $2M",
+  "$2M+",
+];
+
+const TIMELINE_OPTIONS = [
+  "Ready to buy now",
+  "Within 3 months",
+  "Within 6 months",
+  "Just researching",
+];
+
+export default function PropertyEnquiryForm({
+  listingId,
+  listingTitle,
+  developerName,
+}: {
+  listingId: number;
+  listingTitle: string;
+  developerName: string;
+}) {
+  const [form, setForm] = useState({
+    user_name: "",
+    user_email: "",
+    user_phone: "",
+    user_country: "Australia",
+    investment_budget: "",
+    timeline: "",
+    user_message: "",
+    // Honeypots
+    website: "",
+    fax: "",
+  });
+  const [submitting, setSubmitting] = useState(false);
+  const [success, setSuccess] = useState(false);
+  const [error, setError] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    setError("");
+
+    try {
+      const res = await fetch("/api/property/enquiry", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          listing_id: listingId,
+          ...form,
+          source_page: window.location.pathname,
+        }),
+      });
+
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error || "Something went wrong. Please try again.");
+      } else {
+        setSuccess(true);
+      }
+    } catch {
+      setError("Network error. Please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (success) {
+    return (
+      <div className="border border-emerald-200 bg-emerald-50 rounded-2xl p-6 text-center">
+        <div className="w-12 h-12 bg-emerald-100 rounded-full flex items-center justify-center mx-auto mb-3">
+          <svg className="w-6 h-6 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" /></svg>
+        </div>
+        <h3 className="font-bold text-emerald-900 mb-1">Enquiry Sent!</h3>
+        <p className="text-sm text-emerald-700">
+          {developerName} will be in touch within 24–48 hours. No obligation.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="border border-slate-200 rounded-2xl p-5">
+      <h3 className="text-base font-bold text-slate-900 mb-1">Enquire About {listingTitle}</h3>
+      <p className="text-xs text-slate-400 mb-4">Free, no obligation. {developerName} responds within 24–48 hours.</p>
+
+      {error && <p className="text-xs text-red-600 bg-red-50 rounded-lg px-3 py-2 mb-3">{error}</p>}
+
+      <div className="space-y-3">
+        <input
+          type="text"
+          placeholder="Full name *"
+          required
+          maxLength={200}
+          value={form.user_name}
+          onChange={(e) => setForm({ ...form, user_name: e.target.value })}
+          className="w-full px-3 py-2.5 text-sm border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-amber-500/30 focus:border-amber-500"
+        />
+        <input
+          type="email"
+          placeholder="Email address *"
+          required
+          maxLength={254}
+          value={form.user_email}
+          onChange={(e) => setForm({ ...form, user_email: e.target.value })}
+          className="w-full px-3 py-2.5 text-sm border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-amber-500/30 focus:border-amber-500"
+        />
+        <input
+          type="tel"
+          placeholder="Phone number"
+          value={form.user_phone}
+          onChange={(e) => setForm({ ...form, user_phone: e.target.value })}
+          className="w-full px-3 py-2.5 text-sm border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-amber-500/30 focus:border-amber-500"
+        />
+        <input
+          type="text"
+          placeholder="Country"
+          value={form.user_country}
+          onChange={(e) => setForm({ ...form, user_country: e.target.value })}
+          className="w-full px-3 py-2.5 text-sm border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-amber-500/30 focus:border-amber-500"
+        />
+        <select
+          value={form.investment_budget}
+          onChange={(e) => setForm({ ...form, investment_budget: e.target.value })}
+          className="w-full px-3 py-2.5 text-sm border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-amber-500/30 focus:border-amber-500 text-slate-600"
+        >
+          <option value="">Budget range (optional)</option>
+          {BUDGET_OPTIONS.map((b) => (
+            <option key={b} value={b}>{b}</option>
+          ))}
+        </select>
+        <select
+          value={form.timeline}
+          onChange={(e) => setForm({ ...form, timeline: e.target.value })}
+          className="w-full px-3 py-2.5 text-sm border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-amber-500/30 focus:border-amber-500 text-slate-600"
+        >
+          <option value="">Timeline (optional)</option>
+          {TIMELINE_OPTIONS.map((t) => (
+            <option key={t} value={t}>{t}</option>
+          ))}
+        </select>
+        <textarea
+          placeholder="Message (optional)"
+          rows={3}
+          maxLength={5000}
+          value={form.user_message}
+          onChange={(e) => setForm({ ...form, user_message: e.target.value })}
+          className="w-full px-3 py-2.5 text-sm border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-amber-500/30 focus:border-amber-500 resize-none"
+        />
+
+        {/* Honeypots */}
+        <input type="text" name="website" value={form.website} onChange={(e) => setForm({ ...form, website: e.target.value })} className="hidden" tabIndex={-1} autoComplete="off" aria-hidden="true" />
+        <input type="text" name="fax" value={form.fax} onChange={(e) => setForm({ ...form, fax: e.target.value })} className="hidden" tabIndex={-1} autoComplete="off" aria-hidden="true" />
+
+        <button
+          type="submit"
+          disabled={submitting}
+          className="w-full py-3 bg-amber-500 text-white font-bold rounded-lg hover:bg-amber-600 disabled:opacity-50 transition-all text-sm"
+        >
+          {submitting ? "Sending..." : "Send Enquiry — Free"}
+        </button>
+
+        <p className="text-[0.6rem] text-slate-400 text-center leading-relaxed">
+          By submitting, you agree to our privacy policy. Your details will be shared with {developerName} only. No spam, no obligation.
+        </p>
+      </div>
+    </form>
+  );
+}

--- a/app/property/listings/[slug]/page.tsx
+++ b/app/property/listings/[slug]/page.tsx
@@ -1,0 +1,305 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/server";
+import { breadcrumbJsonLd, SITE_URL } from "@/lib/seo";
+import Icon from "@/components/Icon";
+import PropertyEnquiryForm from "./PropertyEnquiryForm";
+
+export const revalidate = 3600;
+
+function formatPrice(cents: number): string {
+  if (cents >= 100000000) return `$${(cents / 100000000).toFixed(1)}M`;
+  if (cents >= 100000) return `$${Math.round(cents / 100000)}k`;
+  return `$${(cents / 100).toLocaleString()}`;
+}
+
+export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const supabase = await createClient();
+  const { data: listing } = await supabase
+    .from("property_listings")
+    .select("title, city, suburb, state, description, price_from_cents, rental_yield_estimate")
+    .eq("slug", slug)
+    .single();
+
+  if (!listing) return { title: "Listing Not Found" };
+
+  return {
+    title: `${listing.title} — ${listing.suburb}, ${listing.state} — Property Investment`,
+    description: listing.description?.slice(0, 160) || `${listing.title} in ${listing.suburb}, ${listing.city}. From ${formatPrice(listing.price_from_cents)}.`,
+    openGraph: {
+      title: `${listing.title} — ${listing.suburb} — Invest.com.au`,
+      description: listing.description?.slice(0, 160),
+      url: `/property/listings/${slug}`,
+    },
+    alternates: { canonical: `/property/listings/${slug}` },
+  };
+}
+
+export default async function PropertyListingPage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const supabase = await createClient();
+
+  const { data: listing } = await supabase
+    .from("property_listings")
+    .select("*, property_developers(id, slug, name, logo_url, website, description, projects_completed, contact_email)")
+    .eq("slug", slug)
+    .single();
+
+  if (!listing) notFound();
+
+  // Get suburb stats
+  const { data: suburbData } = await supabase
+    .from("suburb_data")
+    .select("*")
+    .eq("suburb", listing.suburb)
+    .eq("state", listing.state)
+    .single();
+
+  // Related listings
+  const { data: relatedListings } = await supabase
+    .from("property_listings")
+    .select("id, slug, title, city, suburb, price_from_cents, rental_yield_estimate")
+    .eq("city", listing.city)
+    .neq("id", listing.id)
+    .eq("status", "active")
+    .limit(3);
+
+  const developer = listing.property_developers as {
+    id: number; slug: string; name: string; logo_url: string | null;
+    website: string | null; description: string | null; projects_completed: number | null; contact_email: string | null;
+  } | null;
+
+  const highlights = (listing.investment_highlights as string[]) || [];
+
+  return (
+    <div className="bg-white min-h-screen">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(breadcrumbJsonLd([
+            { name: "Home", url: SITE_URL },
+            { name: "Property", url: `${SITE_URL}/property` },
+            { name: "Listings", url: `${SITE_URL}/property/listings` },
+            { name: listing.title },
+          ])),
+        }}
+      />
+
+      <div className="container-custom py-6 md:py-8">
+        {/* Breadcrumb */}
+        <nav className="text-xs text-slate-400 mb-4 flex items-center gap-1.5">
+          <Link href="/" className="hover:text-slate-600">Home</Link>
+          <span>/</span>
+          <Link href="/property" className="hover:text-slate-600">Property</Link>
+          <span>/</span>
+          <Link href="/property/listings" className="hover:text-slate-600">Listings</Link>
+          <span>/</span>
+          <span className="text-slate-600">{listing.title}</span>
+        </nav>
+
+        <div className="grid lg:grid-cols-3 gap-6 lg:gap-8">
+          {/* Left Column — 2/3 */}
+          <div className="lg:col-span-2 space-y-6">
+            {/* Image Gallery placeholder */}
+            <div className="aspect-[16/9] bg-gradient-to-br from-slate-100 to-slate-200 rounded-2xl flex items-center justify-center relative">
+              <Icon name="building" size={60} className="text-slate-300" />
+              <div className="absolute bottom-3 left-3 flex gap-2">
+                {listing.sponsored && (
+                  <span className="text-[0.6rem] font-bold uppercase tracking-wider text-amber-700 bg-amber-50 border border-amber-200 px-2 py-0.5 rounded-full">Sponsored</span>
+                )}
+                <span className="text-[0.65rem] font-bold uppercase tracking-wider text-slate-600 bg-white/90 px-2 py-0.5 rounded-full">
+                  {listing.property_type === "house_land" ? "House & Land" : listing.property_type === "townhouse" ? "Townhouse" : "Apartment"}
+                </span>
+              </div>
+            </div>
+
+            {/* Title & Key Stats */}
+            <div>
+              <div className="flex items-center gap-2 mb-2 flex-wrap">
+                <span className="text-xs font-bold text-slate-500 bg-slate-100 px-2 py-0.5 rounded-full">
+                  {listing.city} &middot; {listing.suburb}, {listing.state}
+                </span>
+                {listing.firb_approved && (
+                  <span className="text-xs font-bold text-emerald-600 bg-emerald-50 px-2 py-0.5 rounded-full">FIRB Approved</span>
+                )}
+                {listing.off_the_plan && (
+                  <span className="text-xs font-bold text-blue-600 bg-blue-50 px-2 py-0.5 rounded-full">Off the Plan</span>
+                )}
+                {listing.status === "coming_soon" && (
+                  <span className="text-xs font-bold text-amber-600 bg-amber-50 px-2 py-0.5 rounded-full">Coming Soon</span>
+                )}
+              </div>
+
+              <h1 className="text-2xl md:text-3xl font-extrabold text-slate-900 mb-1">{listing.title}</h1>
+              <p className="text-sm text-slate-400">{listing.address_display}</p>
+
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mt-4">
+                <div className="bg-slate-50 rounded-xl p-3 text-center">
+                  <p className="text-lg font-extrabold text-slate-900">{formatPrice(listing.price_from_cents)}</p>
+                  <p className="text-[0.65rem] text-slate-400">From</p>
+                </div>
+                {listing.price_to_cents && (
+                  <div className="bg-slate-50 rounded-xl p-3 text-center">
+                    <p className="text-lg font-extrabold text-slate-900">{formatPrice(listing.price_to_cents)}</p>
+                    <p className="text-[0.65rem] text-slate-400">To</p>
+                  </div>
+                )}
+                {listing.rental_yield_estimate && (
+                  <div className="bg-emerald-50 rounded-xl p-3 text-center">
+                    <p className="text-lg font-extrabold text-emerald-700">{listing.rental_yield_estimate}%</p>
+                    <p className="text-[0.65rem] text-emerald-600">Est. Rental Yield</p>
+                  </div>
+                )}
+                {listing.bedrooms_min && (
+                  <div className="bg-slate-50 rounded-xl p-3 text-center">
+                    <p className="text-lg font-extrabold text-slate-900">
+                      {listing.bedrooms_min}{listing.bedrooms_max && listing.bedrooms_max !== listing.bedrooms_min ? `–${listing.bedrooms_max}` : ""}
+                    </p>
+                    <p className="text-[0.65rem] text-slate-400">Bedrooms</p>
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {/* Description */}
+            {listing.description && (
+              <div>
+                <h2 className="text-lg font-bold text-slate-900 mb-2">About This Development</h2>
+                <p className="text-sm text-slate-600 leading-relaxed whitespace-pre-line">{listing.description}</p>
+              </div>
+            )}
+
+            {/* Investment Highlights */}
+            {highlights.length > 0 && (
+              <div>
+                <h2 className="text-lg font-bold text-slate-900 mb-3">Investment Highlights</h2>
+                <ul className="space-y-2">
+                  {highlights.map((h, i) => (
+                    <li key={i} className="flex items-start gap-2">
+                      <Icon name="check-circle" size={16} className="text-emerald-500 mt-0.5 shrink-0" />
+                      <span className="text-sm text-slate-700">{h}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            {/* Suburb Stats Panel */}
+            {suburbData && (
+              <div className="bg-slate-50 rounded-2xl p-5 border border-slate-200">
+                <h2 className="text-lg font-bold text-slate-900 mb-3">
+                  {suburbData.suburb}, {suburbData.state} — Suburb Stats
+                </h2>
+                <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+                  {suburbData.median_price_house && (
+                    <div>
+                      <p className="text-xs text-slate-400">Median House</p>
+                      <p className="font-bold text-slate-900">{formatPrice(suburbData.median_price_house)}</p>
+                    </div>
+                  )}
+                  {suburbData.median_price_unit && (
+                    <div>
+                      <p className="text-xs text-slate-400">Median Unit</p>
+                      <p className="font-bold text-slate-900">{formatPrice(suburbData.median_price_unit)}</p>
+                    </div>
+                  )}
+                  {suburbData.rental_yield_house && (
+                    <div>
+                      <p className="text-xs text-slate-400">Rental Yield (House)</p>
+                      <p className="font-bold text-emerald-600">{suburbData.rental_yield_house}%</p>
+                    </div>
+                  )}
+                  {suburbData.vacancy_rate != null && (
+                    <div>
+                      <p className="text-xs text-slate-400">Vacancy Rate</p>
+                      <p className="font-bold text-slate-900">{suburbData.vacancy_rate}%</p>
+                    </div>
+                  )}
+                  {suburbData.capital_growth_10yr && (
+                    <div>
+                      <p className="text-xs text-slate-400">10yr Capital Growth</p>
+                      <p className="font-bold text-amber-600">{suburbData.capital_growth_10yr}%</p>
+                    </div>
+                  )}
+                  {suburbData.population && (
+                    <div>
+                      <p className="text-xs text-slate-400">Population</p>
+                      <p className="font-bold text-slate-900">{suburbData.population.toLocaleString()}</p>
+                    </div>
+                  )}
+                </div>
+                <Link href="/property/suburbs" className="inline-flex items-center gap-1 mt-3 text-xs font-semibold text-amber-600 hover:text-amber-700">
+                  Research more suburbs &rarr;
+                </Link>
+              </div>
+            )}
+
+            {/* Completion */}
+            {listing.completion_date && (
+              <div className="flex items-center gap-2 text-sm text-slate-500">
+                <Icon name="calendar" size={16} className="text-slate-400" />
+                <span>Expected completion: <strong className="text-slate-900">{listing.completion_date}</strong></span>
+              </div>
+            )}
+          </div>
+
+          {/* Right Column — 1/3 Sticky */}
+          <div className="lg:col-span-1 space-y-4">
+            <div className="lg:sticky lg:top-24 space-y-4">
+              {/* Enquiry Form */}
+              <PropertyEnquiryForm
+                listingId={listing.id}
+                listingTitle={listing.title}
+                developerName={developer?.name || listing.developer_name || "Developer"}
+              />
+
+              {/* Developer Card */}
+              {developer && (
+                <div className="border border-slate-200 rounded-2xl p-5">
+                  <h3 className="text-sm font-bold text-slate-900 mb-2">About the Developer</h3>
+                  <p className="font-semibold text-slate-900">{developer.name}</p>
+                  {developer.description && (
+                    <p className="text-xs text-slate-500 mt-1 line-clamp-3">{developer.description}</p>
+                  )}
+                  {developer.projects_completed && (
+                    <p className="text-xs text-slate-400 mt-2">{developer.projects_completed}+ projects completed</p>
+                  )}
+                  {developer.website && (
+                    <a href={developer.website} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 mt-2 text-xs font-semibold text-amber-600 hover:text-amber-700">
+                      Visit website &rarr;
+                    </a>
+                  )}
+                </div>
+              )}
+
+              {/* Related Listings */}
+              {(relatedListings?.length || 0) > 0 && (
+                <div className="border border-slate-200 rounded-2xl p-5">
+                  <h3 className="text-sm font-bold text-slate-900 mb-3">More in {listing.city}</h3>
+                  <div className="space-y-3">
+                    {relatedListings!.map((r) => (
+                      <Link key={r.id} href={`/property/listings/${r.slug}`} className="block group">
+                        <p className="text-sm font-semibold text-slate-900 group-hover:text-amber-600">{r.title}</p>
+                        <p className="text-xs text-slate-400">{r.suburb} &middot; From {formatPrice(r.price_from_cents)}</p>
+                      </Link>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Buyer Agent CTA */}
+              <div className="bg-slate-50 border border-slate-200 rounded-2xl p-5 text-center">
+                <p className="text-sm font-bold text-slate-900 mb-1">Need help buying?</p>
+                <p className="text-xs text-slate-500 mb-3">A buyer&apos;s agent can negotiate on your behalf.</p>
+                <Link href="/property/buyer-agents" className="inline-block px-5 py-2.5 bg-slate-900 text-white text-sm font-bold rounded-lg hover:bg-slate-800 transition-all">
+                  Find a Buyer&apos;s Agent
+                </Link>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/property/listings/page.tsx
+++ b/app/property/listings/page.tsx
@@ -1,0 +1,253 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import Link from "next/link";
+import Icon from "@/components/Icon";
+
+interface Listing {
+  id: number;
+  slug: string;
+  title: string;
+  city: string;
+  suburb: string;
+  state: string;
+  price_from_cents: number;
+  price_to_cents: number;
+  rental_yield_estimate: number | null;
+  completion_date: string | null;
+  property_type: string;
+  developer_name: string | null;
+  sponsored: boolean;
+  featured: boolean;
+  firb_approved: boolean;
+  off_the_plan: boolean;
+  bedrooms_min: number | null;
+  bedrooms_max: number | null;
+  images: string[];
+  property_developers?: { name: string; logo_url: string | null; slug: string } | null;
+}
+
+const CITIES = ["All", "Sydney", "Melbourne", "Brisbane", "Perth", "Adelaide"];
+const TYPES = [
+  { value: "All", label: "All Types" },
+  { value: "apartment", label: "Apartment" },
+  { value: "townhouse", label: "Townhouse" },
+  { value: "house_land", label: "House & Land" },
+];
+
+function formatPrice(cents: number): string {
+  if (cents >= 100000000) return `$${(cents / 100000000).toFixed(1)}M`;
+  if (cents >= 100000) return `$${Math.round(cents / 100000)}k`;
+  return `$${(cents / 100).toLocaleString()}`;
+}
+
+export default function PropertyListingsPage() {
+  const [listings, setListings] = useState<Listing[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [city, setCity] = useState("All");
+  const [type, setType] = useState("All");
+  const [firbOnly, setFirbOnly] = useState(false);
+  const [otpOnly, setOtpOnly] = useState(false);
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+
+  const fetchListings = useCallback(async () => {
+    setLoading(true);
+    const params = new URLSearchParams({ page: String(page) });
+    if (city !== "All") params.set("city", city);
+    if (type !== "All") params.set("type", type);
+    if (firbOnly) params.set("firb_approved", "true");
+    if (otpOnly) params.set("off_the_plan", "true");
+
+    try {
+      const res = await fetch(`/api/property/listings?${params}`);
+      const data = await res.json();
+      setListings(data.listings || []);
+      setTotalPages(data.total_pages || 1);
+    } catch {
+      setListings([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [city, type, firbOnly, otpOnly, page]);
+
+  useEffect(() => {
+    fetchListings();
+  }, [fetchListings]);
+
+  useEffect(() => {
+    setPage(1);
+  }, [city, type, firbOnly, otpOnly]);
+
+  return (
+    <div className="bg-white min-h-screen">
+      {/* Header */}
+      <section className="bg-white border-b border-slate-100">
+        <div className="container-custom py-6 md:py-8">
+          <nav className="text-xs text-slate-400 mb-3 flex items-center gap-1.5">
+            <Link href="/" className="hover:text-slate-600">Home</Link>
+            <span>/</span>
+            <Link href="/property" className="hover:text-slate-600">Property</Link>
+            <span>/</span>
+            <span className="text-slate-600">Listings</span>
+          </nav>
+          <h1 className="text-2xl md:text-3xl font-extrabold text-slate-900 mb-2">New Developments &amp; Property Listings</h1>
+          <p className="text-sm text-slate-500">Browse off-the-plan apartments, townhouses, and house &amp; land packages across Australia.</p>
+        </div>
+      </section>
+
+      {/* Filter Bar */}
+      <section className="bg-slate-50 border-b border-slate-200 sticky top-16 lg:top-20 z-30">
+        <div className="container-custom py-3">
+          <div className="flex flex-wrap items-center gap-2 md:gap-3">
+            {/* City */}
+            <div className="flex gap-1 overflow-x-auto">
+              {CITIES.map((c) => (
+                <button
+                  key={c}
+                  onClick={() => setCity(c)}
+                  className={`px-3 py-1.5 text-xs font-semibold rounded-lg whitespace-nowrap transition-colors ${
+                    city === c ? "bg-slate-900 text-white" : "bg-white border border-slate-200 text-slate-600 hover:border-slate-300"
+                  }`}
+                >
+                  {c}
+                </button>
+              ))}
+            </div>
+
+            <div className="h-6 w-px bg-slate-200 hidden md:block" />
+
+            {/* Type */}
+            <select
+              value={type}
+              onChange={(e) => setType(e.target.value)}
+              className="px-3 py-1.5 text-xs font-semibold bg-white border border-slate-200 rounded-lg text-slate-600 focus:outline-none focus:ring-2 focus:ring-amber-500/30"
+            >
+              {TYPES.map((t) => (
+                <option key={t.value} value={t.value}>{t.label}</option>
+              ))}
+            </select>
+
+            {/* Toggles */}
+            <label className="flex items-center gap-1.5 text-xs font-medium text-slate-600 cursor-pointer">
+              <input type="checkbox" checked={firbOnly} onChange={(e) => setFirbOnly(e.target.checked)} className="rounded border-slate-300 text-amber-500 focus:ring-amber-500/30" />
+              FIRB Approved
+            </label>
+            <label className="flex items-center gap-1.5 text-xs font-medium text-slate-600 cursor-pointer">
+              <input type="checkbox" checked={otpOnly} onChange={(e) => setOtpOnly(e.target.checked)} className="rounded border-slate-300 text-amber-500 focus:ring-amber-500/30" />
+              Off the Plan
+            </label>
+          </div>
+        </div>
+      </section>
+
+      {/* Grid */}
+      <section className="py-6 md:py-8">
+        <div className="container-custom">
+          {loading ? (
+            <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
+              {Array.from({ length: 6 }).map((_, i) => (
+                <div key={i} className="border border-slate-200 rounded-2xl overflow-hidden animate-pulse">
+                  <div className="aspect-[16/10] bg-slate-100" />
+                  <div className="p-4 space-y-2">
+                    <div className="h-3 bg-slate-100 rounded w-1/3" />
+                    <div className="h-4 bg-slate-100 rounded w-2/3" />
+                    <div className="h-3 bg-slate-100 rounded w-1/2" />
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : listings.length === 0 ? (
+            <div className="text-center py-16">
+              <Icon name="building" size={40} className="text-slate-300 mx-auto mb-3" />
+              <p className="text-slate-500 font-medium">No listings match your filters.</p>
+              <button onClick={() => { setCity("All"); setType("All"); setFirbOnly(false); setOtpOnly(false); }} className="mt-2 text-sm text-amber-600 font-semibold hover:text-amber-700">
+                Clear all filters
+              </button>
+            </div>
+          ) : (
+            <>
+              <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
+                {listings.map((listing) => (
+                  <Link
+                    key={listing.id}
+                    href={`/property/listings/${listing.slug}`}
+                    className="border border-slate-200 bg-white rounded-2xl overflow-hidden hover:shadow-md hover:border-slate-300 transition-all group"
+                  >
+                    <div className="aspect-[16/10] bg-gradient-to-br from-slate-100 to-slate-200 relative flex items-center justify-center">
+                      <Icon name="building" size={36} className="text-slate-300" />
+                      {listing.sponsored && (
+                        <span className="absolute top-2 left-2 text-[0.6rem] font-bold uppercase tracking-wider text-amber-700 bg-amber-50 border border-amber-200 px-2 py-0.5 rounded-full">
+                          Sponsored
+                        </span>
+                      )}
+                      {listing.property_type && (
+                        <span className="absolute top-2 right-2 text-[0.6rem] font-bold uppercase tracking-wider text-slate-600 bg-white/90 px-2 py-0.5 rounded-full">
+                          {listing.property_type === "house_land" ? "House & Land" : listing.property_type}
+                        </span>
+                      )}
+                    </div>
+                    <div className="p-4">
+                      <div className="flex items-center gap-2 mb-1.5">
+                        <span className="text-[0.65rem] font-bold uppercase tracking-wider text-slate-500 bg-slate-100 px-2 py-0.5 rounded-full">
+                          {listing.city} &middot; {listing.suburb}
+                        </span>
+                        {listing.firb_approved && (
+                          <span className="text-[0.6rem] font-bold text-emerald-600 bg-emerald-50 px-1.5 py-0.5 rounded-full">FIRB</span>
+                        )}
+                      </div>
+                      <h3 className="font-bold text-slate-900 group-hover:text-slate-600 transition-colors mb-1">{listing.title}</h3>
+                      <p className="text-xs text-slate-400 mb-2">{listing.developer_name || listing.property_developers?.name}</p>
+                      <div className="flex items-center justify-between text-sm">
+                        <span className="font-bold text-slate-900">
+                          From {formatPrice(listing.price_from_cents)}
+                          {listing.bedrooms_min && (
+                            <span className="text-xs text-slate-400 font-normal ml-1">
+                              {listing.bedrooms_min}{listing.bedrooms_max && listing.bedrooms_max !== listing.bedrooms_min ? `–${listing.bedrooms_max}` : ""} bed
+                            </span>
+                          )}
+                        </span>
+                        {listing.rental_yield_estimate && (
+                          <span className="text-xs text-emerald-600 font-semibold">{listing.rental_yield_estimate}% yield</span>
+                        )}
+                      </div>
+                      <div className="flex items-center justify-between mt-2">
+                        {listing.completion_date && (
+                          <span className="text-xs text-slate-400">{listing.completion_date}</span>
+                        )}
+                        <span className="text-xs font-semibold text-amber-600 group-hover:translate-x-0.5 transition-transform ml-auto">
+                          Enquire &rarr;
+                        </span>
+                      </div>
+                    </div>
+                  </Link>
+                ))}
+              </div>
+
+              {/* Pagination */}
+              {totalPages > 1 && (
+                <div className="flex items-center justify-center gap-2 mt-8">
+                  <button
+                    onClick={() => setPage(Math.max(1, page - 1))}
+                    disabled={page <= 1}
+                    className="px-3 py-1.5 text-xs font-semibold border border-slate-200 rounded-lg disabled:opacity-30 hover:bg-slate-50"
+                  >
+                    Previous
+                  </button>
+                  <span className="text-xs text-slate-500">Page {page} of {totalPages}</span>
+                  <button
+                    onClick={() => setPage(Math.min(totalPages, page + 1))}
+                    disabled={page >= totalPages}
+                    className="px-3 py-1.5 text-xs font-semibold border border-slate-200 rounded-lg disabled:opacity-30 hover:bg-slate-50"
+                  >
+                    Next
+                  </button>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/property/page.tsx
+++ b/app/property/page.tsx
@@ -1,0 +1,257 @@
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/server";
+import { breadcrumbJsonLd, SITE_URL } from "@/lib/seo";
+import Icon from "@/components/Icon";
+import ScrollFadeIn from "@/components/ScrollFadeIn";
+
+export const metadata = {
+  title: "Property Investment Australia — New Developments, Buyer's Agents & Suburb Data",
+  description:
+    "Australia's property investment hub. Browse new developments, find a buyer's agent, research suburb data, and compare investment loans. Independent, free, no obligation.",
+  openGraph: {
+    title: "Property Investment Australia — Invest.com.au",
+    description: "Browse new developments, find buyer's agents, research suburbs, and compare investment loans.",
+    url: "/property",
+    images: [{ url: "/api/og?title=Property+Investment+Australia", width: 1200, height: 630 }],
+  },
+  alternates: { canonical: "/property" },
+};
+
+export const revalidate = 3600;
+
+function formatPrice(cents: number): string {
+  if (cents >= 100000000) return `$${(cents / 100000000).toFixed(1)}M`;
+  if (cents >= 100000) return `$${Math.round(cents / 100000)}k`;
+  return `$${(cents / 100).toLocaleString()}`;
+}
+
+export default async function PropertyHubPage() {
+  const supabase = await createClient();
+
+  const [{ data: featuredListings }, { data: topSuburbs }] = await Promise.all([
+    supabase
+      .from("property_listings")
+      .select("id, slug, title, city, suburb, state, price_from_cents, rental_yield_estimate, completion_date, property_type, images, sponsored, developer_name")
+      .eq("status", "active")
+      .eq("featured", true)
+      .order("sponsored", { ascending: false })
+      .limit(3),
+    supabase
+      .from("suburb_data")
+      .select("suburb, state, median_price_house, rental_yield_house, capital_growth_10yr, distance_to_cbd_km")
+      .order("capital_growth_10yr", { ascending: false })
+      .limit(5),
+  ]);
+
+  const entryCards = [
+    {
+      icon: "building",
+      title: "Browse New Developments",
+      desc: "Off-the-plan apartments, townhouses, and house & land packages across Australia.",
+      href: "/property/listings",
+      color: "from-amber-500 to-amber-400",
+      shadow: "shadow-amber-500/20",
+    },
+    {
+      icon: "users",
+      title: "Find a Buyer's Agent",
+      desc: "Verified buyer's agents who negotiate on your behalf. Free consultation, no obligation.",
+      href: "/property/buyer-agents",
+      color: "from-slate-800 to-slate-700",
+      shadow: "shadow-slate-500/15",
+    },
+    {
+      icon: "bar-chart",
+      title: "Suburb Research Tool",
+      desc: "Median prices, rental yields, vacancy rates, and capital growth data for top suburbs.",
+      href: "/property/suburbs",
+      color: "from-emerald-600 to-emerald-500",
+      shadow: "shadow-emerald-500/15",
+    },
+  ];
+
+  return (
+    <div>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd([{ name: "Home", url: SITE_URL }, { name: "Property Investment" }])) }}
+      />
+
+      {/* Hero */}
+      <section className="relative bg-white border-b border-slate-100">
+        <div className="container-custom py-10 md:py-16">
+          <div className="max-w-3xl mx-auto text-center">
+            <div className="inline-flex items-center gap-2 px-3.5 py-1.5 bg-amber-50 border border-amber-200 rounded-full text-xs font-semibold text-amber-800 mb-4">
+              <span className="w-1.5 h-1.5 bg-amber-500 rounded-full animate-pulse" />
+              New developments &middot; Buyer&apos;s agents &middot; Suburb data
+            </div>
+            <h1 className="text-3xl sm:text-4xl md:text-5xl font-extrabold text-slate-900 leading-[1.1] mb-4 tracking-tight">
+              Australia&apos;s #1 property{" "}
+              <span className="text-amber-500">investment guide.</span>
+            </h1>
+            <p className="text-base md:text-lg text-slate-500 mb-6 leading-relaxed max-w-2xl mx-auto">
+              Browse new developments, find a verified buyer&apos;s agent, research suburb data, and compare investment loans — all in one place.
+            </p>
+            <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
+              <Link href="/property/listings" className="w-full sm:w-auto px-7 py-3.5 bg-amber-500 text-white font-bold rounded-xl hover:bg-amber-600 shadow-md hover:shadow-lg transition-all text-sm">
+                Browse Developments &rarr;
+              </Link>
+              <Link href="/property/buyer-agents" className="w-full sm:w-auto px-7 py-3.5 border border-slate-200 text-slate-700 font-semibold rounded-xl hover:bg-slate-50 hover:border-slate-300 transition-all text-sm">
+                Find a Buyer&apos;s Agent
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Entry Cards */}
+      <ScrollFadeIn>
+        <section className="py-8 md:py-12 bg-slate-50 border-b border-slate-100">
+          <div className="container-custom">
+            <div className="grid md:grid-cols-3 gap-3 md:gap-4">
+              {entryCards.map((card) => (
+                <Link key={card.href} href={card.href} className="bg-white border border-slate-200 rounded-2xl p-5 md:p-6 hover:shadow-md hover:border-slate-300 transition-all group">
+                  <div className={`w-10 h-10 bg-gradient-to-br ${card.color} rounded-xl flex items-center justify-center mb-3 shadow-md ${card.shadow}`}>
+                    <Icon name={card.icon} size={20} className="text-white" />
+                  </div>
+                  <h2 className="text-base md:text-lg font-bold text-slate-900 mb-1 group-hover:text-slate-700">{card.title}</h2>
+                  <p className="text-sm text-slate-500 leading-relaxed">{card.desc}</p>
+                  <span className="inline-flex items-center gap-1 mt-3 text-sm font-semibold text-amber-600 group-hover:text-amber-700">
+                    Explore <span className="group-hover:translate-x-0.5 transition-transform">&rarr;</span>
+                  </span>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </section>
+      </ScrollFadeIn>
+
+      {/* Featured Listings */}
+      {(featuredListings?.length || 0) > 0 && (
+        <ScrollFadeIn>
+          <section className="py-8 md:py-12 bg-white">
+            <div className="container-custom">
+              <div className="flex items-start justify-between gap-2 mb-5">
+                <div>
+                  <h2 className="text-xl md:text-2xl font-bold text-slate-900">Featured Developments</h2>
+                  <p className="text-xs md:text-sm text-slate-500 mt-1">Hand-picked new developments across Australia</p>
+                </div>
+                <Link href="/property/listings" className="text-xs md:text-sm font-semibold text-amber-600 hover:text-amber-700 shrink-0 min-h-[44px] inline-flex items-center px-1">
+                  View all &rarr;
+                </Link>
+              </div>
+              <div className="grid md:grid-cols-3 gap-4">
+                {featuredListings!.map((listing) => (
+                  <Link
+                    key={listing.id}
+                    href={`/property/listings/${listing.slug}`}
+                    className="border border-slate-200 bg-white rounded-2xl overflow-hidden hover:shadow-md hover:border-slate-300 transition-all group"
+                  >
+                    <div className="aspect-[16/10] bg-gradient-to-br from-slate-100 to-slate-200 relative flex items-center justify-center">
+                      <Icon name="building" size={40} className="text-slate-300" />
+                      {listing.sponsored && (
+                        <span className="absolute top-2 left-2 text-[0.6rem] font-bold uppercase tracking-wider text-amber-700 bg-amber-50 border border-amber-200 px-2 py-0.5 rounded-full">
+                          Sponsored
+                        </span>
+                      )}
+                    </div>
+                    <div className="p-4">
+                      <div className="flex items-center gap-2 mb-1.5">
+                        <span className="text-[0.65rem] font-bold uppercase tracking-wider text-slate-500 bg-slate-100 px-2 py-0.5 rounded-full">
+                          {listing.city} &middot; {listing.suburb}
+                        </span>
+                      </div>
+                      <h3 className="font-bold text-slate-900 group-hover:text-slate-600 transition-colors mb-1">{listing.title}</h3>
+                      <p className="text-xs text-slate-400 mb-2">{listing.developer_name}</p>
+                      <div className="flex items-center justify-between text-sm">
+                        <span className="font-bold text-slate-900">From {formatPrice(listing.price_from_cents)}</span>
+                        {listing.rental_yield_estimate && (
+                          <span className="text-xs text-emerald-600 font-semibold">{listing.rental_yield_estimate}% yield</span>
+                        )}
+                      </div>
+                      <div className="flex items-center justify-between mt-2">
+                        {listing.completion_date && (
+                          <span className="text-xs text-slate-400">{listing.completion_date}</span>
+                        )}
+                        <span className="text-xs font-semibold text-amber-600 group-hover:translate-x-0.5 transition-transform">
+                          Enquire &rarr;
+                        </span>
+                      </div>
+                    </div>
+                  </Link>
+                ))}
+              </div>
+            </div>
+          </section>
+        </ScrollFadeIn>
+      )}
+
+      {/* Top Suburbs Snapshot */}
+      {(topSuburbs?.length || 0) > 0 && (
+        <ScrollFadeIn>
+          <section className="py-8 md:py-12 bg-slate-50 border-y border-slate-100">
+            <div className="container-custom">
+              <div className="flex items-start justify-between gap-2 mb-5">
+                <div>
+                  <h2 className="text-xl md:text-2xl font-bold text-slate-900">Top Investment Suburbs</h2>
+                  <p className="text-xs md:text-sm text-slate-500 mt-1">Ranked by 10-year capital growth</p>
+                </div>
+                <Link href="/property/suburbs" className="text-xs md:text-sm font-semibold text-amber-600 hover:text-amber-700 shrink-0 min-h-[44px] inline-flex items-center px-1">
+                  Research all &rarr;
+                </Link>
+              </div>
+              <div className="bg-white rounded-2xl border border-slate-200 overflow-hidden">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="bg-slate-50 border-b border-slate-200">
+                      <th className="text-left px-4 py-3 font-semibold text-slate-600 text-xs">Suburb</th>
+                      <th className="text-right px-4 py-3 font-semibold text-slate-600 text-xs hidden sm:table-cell">Median House</th>
+                      <th className="text-right px-4 py-3 font-semibold text-slate-600 text-xs">Rental Yield</th>
+                      <th className="text-right px-4 py-3 font-semibold text-slate-600 text-xs">10yr Growth</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {topSuburbs!.map((s) => (
+                      <tr key={`${s.suburb}-${s.state}`} className="border-b border-slate-100 last:border-b-0 hover:bg-slate-50">
+                        <td className="px-4 py-3">
+                          <span className="font-semibold text-slate-900">{s.suburb}</span>
+                          <span className="text-xs text-slate-400 ml-1">{s.state}</span>
+                        </td>
+                        <td className="text-right px-4 py-3 text-slate-700 hidden sm:table-cell">
+                          {s.median_price_house ? formatPrice(s.median_price_house) : "—"}
+                        </td>
+                        <td className="text-right px-4 py-3 text-emerald-600 font-semibold">
+                          {s.rental_yield_house ? `${s.rental_yield_house}%` : "—"}
+                        </td>
+                        <td className="text-right px-4 py-3 text-amber-600 font-bold">
+                          {s.capital_growth_10yr ? `${s.capital_growth_10yr}%` : "—"}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </section>
+        </ScrollFadeIn>
+      )}
+
+      {/* Investment Loan CTA */}
+      <ScrollFadeIn>
+        <section className="py-8 md:py-12 bg-white">
+          <div className="container-custom">
+            <div className="bg-gradient-to-r from-slate-900 to-slate-800 rounded-2xl p-6 md:p-10 text-center">
+              <h2 className="text-xl md:text-2xl font-bold text-white mb-2">Compare Investment Loans</h2>
+              <p className="text-sm text-slate-300 mb-5 max-w-lg mx-auto">
+                Compare rates from CBA, Westpac, ANZ, NAB, and more. Find the right investment loan for your property portfolio.
+              </p>
+              <Link href="/property/finance" className="inline-block px-7 py-3 bg-amber-500 text-white font-bold rounded-xl hover:bg-amber-600 shadow-md hover:shadow-lg transition-all text-sm">
+                Compare Loans &rarr;
+              </Link>
+            </div>
+          </div>
+        </section>
+      </ScrollFadeIn>
+    </div>
+  );
+}

--- a/app/property/suburbs/page.tsx
+++ b/app/property/suburbs/page.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import Link from "next/link";
+import Icon from "@/components/Icon";
+
+interface SuburbData {
+  id: number;
+  suburb: string;
+  state: string;
+  postcode: string | null;
+  median_price_house: number | null;
+  median_price_unit: number | null;
+  rental_yield_house: number | null;
+  rental_yield_unit: number | null;
+  vacancy_rate: number | null;
+  capital_growth_1yr: number | null;
+  capital_growth_3yr: number | null;
+  capital_growth_5yr: number | null;
+  capital_growth_10yr: number | null;
+  population: number | null;
+  population_growth: number | null;
+  median_age: number | null;
+  median_income: number | null;
+  distance_to_cbd_km: number | null;
+}
+
+type SortKey = "suburb" | "median_price_house" | "rental_yield_house" | "vacancy_rate" | "capital_growth_10yr" | "distance_to_cbd_km";
+
+function formatPrice(cents: number | null): string {
+  if (!cents) return "—";
+  if (cents >= 100000000) return `$${(cents / 100000000).toFixed(1)}M`;
+  if (cents >= 100000) return `$${Math.round(cents / 100000)}k`;
+  return `$${(cents / 100).toLocaleString()}`;
+}
+
+export default function SuburbResearchPage() {
+  const [suburbs, setSuburbs] = useState<SuburbData[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState("");
+  const [sortKey, setSortKey] = useState<SortKey>("capital_growth_10yr");
+  const [sortAsc, setSortAsc] = useState(false);
+  const [selected, setSelected] = useState<SuburbData | null>(null);
+
+  const fetchSuburbs = useCallback(async () => {
+    setLoading(true);
+    const params = search.length >= 2 ? `?q=${encodeURIComponent(search)}` : "";
+    try {
+      const res = await fetch(`/api/property/suburbs${params}`);
+      const data = await res.json();
+      setSuburbs(Array.isArray(data) ? data : []);
+    } catch {
+      setSuburbs([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [search]);
+
+  useEffect(() => {
+    const timer = setTimeout(fetchSuburbs, 300);
+    return () => clearTimeout(timer);
+  }, [fetchSuburbs]);
+
+  const sorted = [...suburbs].sort((a, b) => {
+    const aVal = a[sortKey] ?? 0;
+    const bVal = b[sortKey] ?? 0;
+    if (typeof aVal === "string" && typeof bVal === "string") return sortAsc ? aVal.localeCompare(bVal) : bVal.localeCompare(aVal);
+    return sortAsc ? (aVal as number) - (bVal as number) : (bVal as number) - (aVal as number);
+  });
+
+  const handleSort = (key: SortKey) => {
+    if (sortKey === key) { setSortAsc(!sortAsc); } else { setSortKey(key); setSortAsc(false); }
+  };
+
+  const SortIcon = ({ col }: { col: SortKey }) => {
+    if (sortKey !== col) return <Icon name="chevron-down" size={12} className="text-slate-300" />;
+    return <Icon name={sortAsc ? "chevron-up" : "chevron-down"} size={12} className="text-amber-500" />;
+  };
+
+  return (
+    <div className="bg-white min-h-screen">
+      <section className="bg-white border-b border-slate-100">
+        <div className="container-custom py-6 md:py-8">
+          <nav className="text-xs text-slate-400 mb-3 flex items-center gap-1.5">
+            <Link href="/" className="hover:text-slate-600">Home</Link>
+            <span>/</span>
+            <Link href="/property" className="hover:text-slate-600">Property</Link>
+            <span>/</span>
+            <span className="text-slate-600">Suburb Research</span>
+          </nav>
+          <h1 className="text-2xl md:text-3xl font-extrabold text-slate-900 mb-2">Suburb Research Tool</h1>
+          <p className="text-sm text-slate-500">Median prices, rental yields, vacancy rates, and capital growth for Australia&apos;s top investment suburbs.</p>
+        </div>
+      </section>
+
+      {/* Search */}
+      <section className="bg-slate-50 border-b border-slate-200 sticky top-16 lg:top-20 z-30">
+        <div className="container-custom py-3">
+          <div className="relative max-w-md">
+            <Icon name="search" size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400" />
+            <input
+              type="text"
+              placeholder="Search suburb name..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="w-full pl-9 pr-4 py-2 text-sm border border-slate-200 rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-amber-500/30 focus:border-amber-500"
+            />
+          </div>
+        </div>
+      </section>
+
+      <section className="py-6 md:py-8">
+        <div className="container-custom">
+          <div className="grid lg:grid-cols-3 gap-6">
+            {/* Table */}
+            <div className={selected ? "lg:col-span-2" : "lg:col-span-3"}>
+              {loading ? (
+                <div className="space-y-2">
+                  {Array.from({ length: 8 }).map((_, i) => (
+                    <div key={i} className="h-12 bg-slate-50 rounded-lg animate-pulse" />
+                  ))}
+                </div>
+              ) : sorted.length === 0 ? (
+                <div className="text-center py-16">
+                  <Icon name="bar-chart" size={40} className="text-slate-300 mx-auto mb-3" />
+                  <p className="text-slate-500 font-medium">No suburbs found.</p>
+                </div>
+              ) : (
+                <div className="bg-white rounded-2xl border border-slate-200 overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="bg-slate-50 border-b border-slate-200">
+                        <th className="text-left px-4 py-3 cursor-pointer hover:bg-slate-100" onClick={() => handleSort("suburb")}>
+                          <span className="flex items-center gap-1 text-xs font-semibold text-slate-600">Suburb <SortIcon col="suburb" /></span>
+                        </th>
+                        <th className="text-right px-4 py-3 cursor-pointer hover:bg-slate-100 hidden md:table-cell" onClick={() => handleSort("median_price_house")}>
+                          <span className="flex items-center justify-end gap-1 text-xs font-semibold text-slate-600">Median House <SortIcon col="median_price_house" /></span>
+                        </th>
+                        <th className="text-right px-4 py-3 cursor-pointer hover:bg-slate-100" onClick={() => handleSort("rental_yield_house")}>
+                          <span className="flex items-center justify-end gap-1 text-xs font-semibold text-slate-600">Yield <SortIcon col="rental_yield_house" /></span>
+                        </th>
+                        <th className="text-right px-4 py-3 cursor-pointer hover:bg-slate-100 hidden sm:table-cell" onClick={() => handleSort("vacancy_rate")}>
+                          <span className="flex items-center justify-end gap-1 text-xs font-semibold text-slate-600">Vacancy <SortIcon col="vacancy_rate" /></span>
+                        </th>
+                        <th className="text-right px-4 py-3 cursor-pointer hover:bg-slate-100" onClick={() => handleSort("capital_growth_10yr")}>
+                          <span className="flex items-center justify-end gap-1 text-xs font-semibold text-slate-600">10yr Growth <SortIcon col="capital_growth_10yr" /></span>
+                        </th>
+                        <th className="text-right px-4 py-3 cursor-pointer hover:bg-slate-100 hidden lg:table-cell" onClick={() => handleSort("distance_to_cbd_km")}>
+                          <span className="flex items-center justify-end gap-1 text-xs font-semibold text-slate-600">CBD km <SortIcon col="distance_to_cbd_km" /></span>
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {sorted.map((s) => (
+                        <tr
+                          key={s.id}
+                          className={`border-b border-slate-100 last:border-b-0 cursor-pointer transition-colors ${
+                            selected?.id === s.id ? "bg-amber-50" : "hover:bg-slate-50"
+                          }`}
+                          onClick={() => setSelected(selected?.id === s.id ? null : s)}
+                        >
+                          <td className="px-4 py-3">
+                            <span className="font-semibold text-slate-900">{s.suburb}</span>
+                            <span className="text-xs text-slate-400 ml-1">{s.state}</span>
+                          </td>
+                          <td className="text-right px-4 py-3 text-slate-700 hidden md:table-cell">{formatPrice(s.median_price_house)}</td>
+                          <td className="text-right px-4 py-3 text-emerald-600 font-semibold">{s.rental_yield_house ? `${s.rental_yield_house}%` : "—"}</td>
+                          <td className="text-right px-4 py-3 text-slate-700 hidden sm:table-cell">{s.vacancy_rate != null ? `${s.vacancy_rate}%` : "—"}</td>
+                          <td className="text-right px-4 py-3 text-amber-600 font-bold">{s.capital_growth_10yr ? `${s.capital_growth_10yr}%` : "—"}</td>
+                          <td className="text-right px-4 py-3 text-slate-500 hidden lg:table-cell">{s.distance_to_cbd_km != null ? `${s.distance_to_cbd_km}km` : "—"}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </div>
+
+            {/* Detail Panel */}
+            {selected && (
+              <div className="lg:col-span-1">
+                <div className="border border-slate-200 rounded-2xl p-5 lg:sticky lg:top-24">
+                  <div className="flex items-center justify-between mb-3">
+                    <h2 className="text-lg font-bold text-slate-900">{selected.suburb}, {selected.state}</h2>
+                    <button onClick={() => setSelected(null)} className="text-slate-400 hover:text-slate-600">
+                      <Icon name="x-circle" size={18} />
+                    </button>
+                  </div>
+
+                  {selected.postcode && <p className="text-xs text-slate-400 mb-4">Postcode: {selected.postcode}</p>}
+
+                  <div className="space-y-3">
+                    {selected.median_price_house && <div className="flex justify-between"><span className="text-xs text-slate-500">Median House Price</span><span className="text-sm font-bold text-slate-900">{formatPrice(selected.median_price_house)}</span></div>}
+                    {selected.median_price_unit && <div className="flex justify-between"><span className="text-xs text-slate-500">Median Unit Price</span><span className="text-sm font-bold text-slate-900">{formatPrice(selected.median_price_unit)}</span></div>}
+                    {selected.rental_yield_house && <div className="flex justify-between"><span className="text-xs text-slate-500">Rental Yield (House)</span><span className="text-sm font-bold text-emerald-600">{selected.rental_yield_house}%</span></div>}
+                    {selected.rental_yield_unit && <div className="flex justify-between"><span className="text-xs text-slate-500">Rental Yield (Unit)</span><span className="text-sm font-bold text-emerald-600">{selected.rental_yield_unit}%</span></div>}
+                    {selected.vacancy_rate != null && <div className="flex justify-between"><span className="text-xs text-slate-500">Vacancy Rate</span><span className="text-sm font-bold text-slate-900">{selected.vacancy_rate}%</span></div>}
+
+                    <div className="border-t border-slate-100 pt-3">
+                      <p className="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-2">Capital Growth</p>
+                      {selected.capital_growth_1yr && <div className="flex justify-between"><span className="text-xs text-slate-500">1 Year</span><span className="text-sm font-bold text-amber-600">{selected.capital_growth_1yr}%</span></div>}
+                      {selected.capital_growth_3yr && <div className="flex justify-between"><span className="text-xs text-slate-500">3 Year</span><span className="text-sm font-bold text-amber-600">{selected.capital_growth_3yr}%</span></div>}
+                      {selected.capital_growth_5yr && <div className="flex justify-between"><span className="text-xs text-slate-500">5 Year</span><span className="text-sm font-bold text-amber-600">{selected.capital_growth_5yr}%</span></div>}
+                      {selected.capital_growth_10yr && <div className="flex justify-between"><span className="text-xs text-slate-500">10 Year</span><span className="text-sm font-bold text-amber-600">{selected.capital_growth_10yr}%</span></div>}
+                    </div>
+
+                    <div className="border-t border-slate-100 pt-3">
+                      <p className="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-2">Demographics</p>
+                      {selected.population && <div className="flex justify-between"><span className="text-xs text-slate-500">Population</span><span className="text-sm font-bold text-slate-900">{selected.population.toLocaleString()}</span></div>}
+                      {selected.population_growth && <div className="flex justify-between"><span className="text-xs text-slate-500">Pop. Growth</span><span className="text-sm font-bold text-slate-900">{selected.population_growth}%</span></div>}
+                      {selected.median_age && <div className="flex justify-between"><span className="text-xs text-slate-500">Median Age</span><span className="text-sm font-bold text-slate-900">{selected.median_age}</span></div>}
+                      {selected.median_income && <div className="flex justify-between"><span className="text-xs text-slate-500">Median Income</span><span className="text-sm font-bold text-slate-900">${selected.median_income.toLocaleString()}</span></div>}
+                      {selected.distance_to_cbd_km != null && <div className="flex justify-between"><span className="text-xs text-slate-500">Distance to CBD</span><span className="text-sm font-bold text-slate-900">{selected.distance_to_cbd_km}km</span></div>}
+                    </div>
+                  </div>
+
+                  <Link
+                    href={`/property/buyer-agents`}
+                    className="block w-full text-center py-2.5 mt-4 bg-amber-500 text-white text-sm font-bold rounded-lg hover:bg-amber-600 transition-all"
+                  >
+                    Find an Agent in {selected.suburb}
+                  </Link>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/components/AdminSidebar.tsx
+++ b/components/AdminSidebar.tsx
@@ -56,6 +56,15 @@ const NAV_GROUPS = [
     ],
   },
   {
+    label: "Property",
+    items: [
+      { href: "/admin/property", icon: "building", label: "Property Overview" },
+      { href: "/admin/property/listings", icon: "home", label: "Listings" },
+      { href: "/admin/property/leads", icon: "users", label: "Property Leads" },
+      { href: "/admin/property/developers", icon: "briefcase", label: "Developers" },
+    ],
+  },
+  {
     label: "Advisors",
     items: [
       { href: "/admin/advisors", icon: "user", label: "Advisors" },

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -9,11 +9,13 @@ import ThemeToggle from "@/components/ThemeToggle";
 import Icon from "@/components/Icon";
 
 const propertyDropdown = [
+  { label: "Investment Property", href: "/property", desc: "New developments, suburb data & more" },
+  { label: "New Developments", href: "/property/listings", desc: "Off-the-plan apartments & houses" },
+  { label: "Buyer's Agents", href: "/property/buyer-agents", desc: "Negotiation & off-market access" },
+  { label: "Suburb Research", href: "/property/suburbs", desc: "Yields, growth & vacancy data" },
+  { label: "Investment Loans", href: "/property/finance", desc: "Compare rates from major lenders" },
   { label: "Mortgage Brokers", href: "/advisors/mortgage-brokers", desc: "Compare 30+ lenders — free" },
-  { label: "Buyer's Agents", href: "/advisors/buyers-agents", desc: "Off-market access & negotiation" },
-  { label: "Real Estate Agents", href: "/advisors/real-estate-agents", desc: "Selling & listing specialists" },
   { label: "Find an Advisor", href: "/find-advisor", desc: "Match with a verified professional" },
-  { label: "All Advisors", href: "/advisors", desc: "Browse all professionals" },
 ];
 
 const wealthDropdown = [
@@ -45,10 +47,19 @@ const popularLinks = [
 
 const mobileNavSections = [
   {
-    title: "Property & Finance",
+    title: "Investment Property",
+    items: [
+      { name: "Property Hub", href: "/property" },
+      { name: "New Developments", href: "/property/listings" },
+      { name: "Buyer's Agents", href: "/property/buyer-agents" },
+      { name: "Suburb Research", href: "/property/suburbs" },
+      { name: "Investment Loans", href: "/property/finance" },
+    ],
+  },
+  {
+    title: "Advisors & Finance",
     items: [
       { name: "Mortgage Brokers", href: "/advisors/mortgage-brokers" },
-      { name: "Buyer's Agents", href: "/advisors/buyers-agents" },
       { name: "Real Estate Agents", href: "/advisors/real-estate-agents" },
       { name: "Find an Advisor", href: "/find-advisor" },
       { name: "All Advisors", href: "/advisors" },
@@ -150,7 +161,7 @@ export default function Header() {
   const isPlatformsActive = ["/compare", "/best", "/versus", "/deals", "/reviews", "/quiz"].some(
     (p) => pathname === p || pathname.startsWith(p + "/")
   );
-  const isPropertyActive = ["/advisors/mortgage-brokers", "/advisors/buyers-agents", "/advisors/real-estate-agents", "/find-advisor"].some(
+  const isPropertyActive = ["/property", "/advisors/mortgage-brokers", "/advisors/buyers-agents", "/advisors/real-estate-agents", "/find-advisor"].some(
     (p) => pathname === p || pathname.startsWith(p + "/")
   );
   const isWealthActive = ["/advisors/financial-planners", "/advisors/smsf-accountants", "/advisors/insurance-brokers", "/advisors/tax-agents", "/advisors/estate-planners", "/advisors/wealth-managers"].some(

--- a/supabase/migrations/20260317_property_vertical.sql
+++ b/supabase/migrations/20260317_property_vertical.sql
@@ -1,0 +1,276 @@
+-- ============================================================
+-- Property Investment Vertical — Tables, RLS, Seed Data
+-- ============================================================
+
+-- 1. property_developers (must exist before property_listings FK)
+CREATE TABLE IF NOT EXISTS property_developers (
+  id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  slug text UNIQUE NOT NULL,
+  name text NOT NULL,
+  logo_url text,
+  website text,
+  description text,
+  established_year integer,
+  projects_completed integer DEFAULT 0,
+  contact_name text,
+  contact_email text,
+  contact_phone text,
+  status text NOT NULL DEFAULT 'pending' CHECK (status IN ('active','pending')),
+  monthly_fee_cents integer DEFAULT 0,
+  credit_balance_cents integer DEFAULT 0,
+  stripe_customer_id text,
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now()
+);
+
+-- 2. property_listings
+CREATE TABLE IF NOT EXISTS property_listings (
+  id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  slug text UNIQUE NOT NULL,
+  title text NOT NULL,
+  developer_name text,
+  developer_id bigint REFERENCES property_developers(id),
+  property_type text NOT NULL CHECK (property_type IN ('apartment','townhouse','house_land')),
+  city text,
+  suburb text,
+  state text,
+  address_display text,
+  price_from_cents bigint,
+  price_to_cents bigint,
+  bedrooms_min integer,
+  bedrooms_max integer,
+  completion_date text,
+  description text,
+  investment_highlights jsonb DEFAULT '[]',
+  rental_yield_estimate numeric(5,2),
+  capital_growth_10yr numeric(5,2),
+  images jsonb DEFAULT '[]',
+  floor_plans jsonb DEFAULT '[]',
+  brochure_url text,
+  firb_approved boolean DEFAULT false,
+  foreign_buyer_eligible boolean DEFAULT false,
+  new_development boolean DEFAULT true,
+  off_the_plan boolean DEFAULT false,
+  status text NOT NULL DEFAULT 'active' CHECK (status IN ('active','sold_out','coming_soon')),
+  featured boolean DEFAULT false,
+  sponsored boolean DEFAULT false,
+  lead_count integer DEFAULT 0,
+  monthly_fee_cents integer DEFAULT 0,
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now()
+);
+
+-- 3. property_leads
+CREATE TABLE IF NOT EXISTS property_leads (
+  id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  listing_id bigint REFERENCES property_listings(id),
+  developer_id bigint REFERENCES property_developers(id),
+  user_name text NOT NULL,
+  user_email text NOT NULL,
+  user_phone text,
+  user_country text,
+  user_message text,
+  investment_budget text,
+  timeline text,
+  status text NOT NULL DEFAULT 'new' CHECK (status IN ('new','contacted','qualified','converted')),
+  source_page text,
+  utm_source text,
+  created_at timestamptz DEFAULT now()
+);
+
+-- 4. buyer_agents
+CREATE TABLE IF NOT EXISTS buyer_agents (
+  id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  slug text UNIQUE NOT NULL,
+  name text NOT NULL,
+  photo_url text,
+  agency_name text,
+  bio text,
+  states_covered text[] DEFAULT '{}',
+  suburbs_speciality text[] DEFAULT '{}',
+  investment_focus text[] DEFAULT '{}',
+  avg_property_value text,
+  fee_structure text,
+  fee_fixed_cents integer,
+  fee_percent numeric(5,2),
+  phone text,
+  email text,
+  website text,
+  rating numeric(3,2) DEFAULT 0,
+  review_count integer DEFAULT 0,
+  verified boolean DEFAULT false,
+  featured boolean DEFAULT false,
+  listing_fee_cents integer DEFAULT 0,
+  status text NOT NULL DEFAULT 'active' CHECK (status IN ('active','pending','inactive')),
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now()
+);
+
+-- 5. suburb_data
+CREATE TABLE IF NOT EXISTS suburb_data (
+  id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  suburb text NOT NULL,
+  state text NOT NULL,
+  postcode text,
+  median_price_house bigint,
+  median_price_unit bigint,
+  rental_yield_house numeric(5,2),
+  rental_yield_unit numeric(5,2),
+  vacancy_rate numeric(5,2),
+  capital_growth_1yr numeric(5,2),
+  capital_growth_3yr numeric(5,2),
+  capital_growth_5yr numeric(5,2),
+  capital_growth_10yr numeric(5,2),
+  population integer,
+  population_growth numeric(5,2),
+  median_age integer,
+  median_income integer,
+  distance_to_cbd_km numeric(6,1),
+  data_date date DEFAULT CURRENT_DATE,
+  created_at timestamptz DEFAULT now(),
+  UNIQUE(suburb, state)
+);
+
+-- ============================================================
+-- Indexes
+-- ============================================================
+CREATE INDEX IF NOT EXISTS idx_property_listings_status ON property_listings(status);
+CREATE INDEX IF NOT EXISTS idx_property_listings_city ON property_listings(city);
+CREATE INDEX IF NOT EXISTS idx_property_listings_type ON property_listings(property_type);
+CREATE INDEX IF NOT EXISTS idx_property_listings_featured ON property_listings(featured) WHERE featured = true;
+CREATE INDEX IF NOT EXISTS idx_property_listings_slug ON property_listings(slug);
+CREATE INDEX IF NOT EXISTS idx_property_leads_developer ON property_leads(developer_id);
+CREATE INDEX IF NOT EXISTS idx_property_leads_listing ON property_leads(listing_id);
+CREATE INDEX IF NOT EXISTS idx_buyer_agents_status ON buyer_agents(status);
+CREATE INDEX IF NOT EXISTS idx_buyer_agents_slug ON buyer_agents(slug);
+CREATE INDEX IF NOT EXISTS idx_suburb_data_suburb ON suburb_data(suburb);
+CREATE INDEX IF NOT EXISTS idx_suburb_data_state ON suburb_data(state);
+
+-- ============================================================
+-- RLS Policies
+-- ============================================================
+ALTER TABLE property_listings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE property_developers ENABLE ROW LEVEL SECURITY;
+ALTER TABLE property_leads ENABLE ROW LEVEL SECURITY;
+ALTER TABLE buyer_agents ENABLE ROW LEVEL SECURITY;
+ALTER TABLE suburb_data ENABLE ROW LEVEL SECURITY;
+
+-- Public read on property_listings
+CREATE POLICY "Public can read active listings" ON property_listings
+  FOR SELECT USING (status IN ('active','coming_soon'));
+
+-- Public read on property_developers (name/logo only handled at query level)
+CREATE POLICY "Public can read active developers" ON property_developers
+  FOR SELECT USING (status = 'active');
+
+-- Public read on buyer_agents
+CREATE POLICY "Public can read active buyer agents" ON buyer_agents
+  FOR SELECT USING (status = 'active');
+
+-- Public read on suburb_data
+CREATE POLICY "Public can read suburb data" ON suburb_data
+  FOR SELECT USING (true);
+
+-- Service role has full access on property_leads (no anon read)
+CREATE POLICY "Service role full access on leads" ON property_leads
+  FOR ALL USING (auth.role() = 'service_role');
+
+-- Service role write on all tables
+CREATE POLICY "Service role write listings" ON property_listings
+  FOR ALL USING (auth.role() = 'service_role');
+
+CREATE POLICY "Service role write developers" ON property_developers
+  FOR ALL USING (auth.role() = 'service_role');
+
+CREATE POLICY "Service role write buyer agents" ON buyer_agents
+  FOR ALL USING (auth.role() = 'service_role');
+
+CREATE POLICY "Service role write suburb data" ON suburb_data
+  FOR ALL USING (auth.role() = 'service_role');
+
+-- ============================================================
+-- Seed: Property Developers
+-- ============================================================
+INSERT INTO property_developers (slug, name, logo_url, website, description, established_year, projects_completed, contact_name, contact_email, contact_phone, status, monthly_fee_cents, credit_balance_cents)
+VALUES
+  ('mirvac', 'Mirvac', NULL, 'https://www.mirvac.com', 'One of Australia''s leading integrated real estate groups with over 50 years of experience in residential, office, industrial, and retail development.', 1972, 350, 'Sarah Chen', 'enquiries@mirvac.com', '1300 356 870', 'active', 99900, 500000),
+  ('lendlease', 'Lendlease', NULL, 'https://www.lendlease.com', 'Global real estate and infrastructure group creating places where communities thrive. Major developments across Sydney, Melbourne, and Brisbane.', 1958, 500, 'James Morton', 'residential@lendlease.com', '1800 536 353', 'active', 99900, 300000),
+  ('stockland', 'Stockland', NULL, 'https://www.stockland.com.au', 'Australia''s largest diversified real estate company, creating liveable, sustainable communities across the country.', 1952, 400, 'Emily Park', 'homes@stockland.com.au', '1300 557 095', 'active', 99900, 400000),
+  ('meriton', 'Meriton', NULL, 'https://www.meriton.com.au', 'Australia''s largest apartment developer with a track record of delivering quality residential apartments for over 60 years.', 1963, 80000, 'David Liu', 'sales@meriton.com.au', '1300 063 748', 'active', 99900, 600000),
+  ('sekisui-house', 'Sekisui House', NULL, 'https://www.sekisuihouse.com.au', 'Japanese-Australian developer known for innovative, sustainable residential communities and premium apartment living.', 1960, 200, 'Kenji Tanaka', 'enquiries@sekisuihouse.com.au', '1300 073 587', 'active', 99900, 250000)
+ON CONFLICT (slug) DO NOTHING;
+
+-- ============================================================
+-- Seed: Property Listings (8 across Sydney, Melbourne, Brisbane)
+-- ============================================================
+INSERT INTO property_listings (slug, title, developer_name, developer_id, property_type, city, suburb, state, address_display, price_from_cents, price_to_cents, bedrooms_min, bedrooms_max, completion_date, description, investment_highlights, rental_yield_estimate, capital_growth_10yr, images, firb_approved, foreign_buyer_eligible, new_development, off_the_plan, status, featured, sponsored, monthly_fee_cents)
+VALUES
+  ('the-operetta-paramatta', 'The Operetta', 'Meriton', (SELECT id FROM property_developers WHERE slug='meriton'), 'apartment', 'Sydney', 'Parramatta', 'NSW', 'Church St, Parramatta NSW 2150', 65000000, 135000000, 1, 3, 'Q4 2027', 'Premium apartments in the heart of Parramatta CBD, steps from the new Metro station. Featuring resort-style amenities including rooftop pool, gymnasium, and co-working spaces.', '["300m to Parramatta Metro station","Parramatta CBD median unit price grew 8.2% in 2025","Strong rental demand from Westmead Hospital and Western Sydney University","FIRB approved for overseas investors","Stamp duty concessions for off-the-plan purchases"]', 4.80, 7.50, '[]', true, true, true, true, 'active', true, true, 49900),
+
+  ('botanical-residences-south-melbourne', 'Botanical Residences', 'Mirvac', (SELECT id FROM property_developers WHERE slug='mirvac'), 'apartment', 'Melbourne', 'South Melbourne', 'VIC', 'Kings Way, South Melbourne VIC 3205', 55000000, 195000000, 1, 3, 'Q2 2028', 'A landmark collection of residences overlooking the Royal Botanic Gardens. Designed by award-winning architects with premium finishes throughout and world-class shared amenities.', '["Overlooking Royal Botanic Gardens","5 min to Melbourne CBD","Heritage precinct with strong capital growth history","Resort-style pool, spa, and private dining room","Stamp duty savings for off-the-plan buyers"]', 4.20, 6.80, '[]', true, true, true, true, 'active', true, false, 49900),
+
+  ('riverview-terrace-newstead', 'Riverview Terrace', 'Lendlease', (SELECT id FROM property_developers WHERE slug='lendlease'), 'townhouse', 'Brisbane', 'Newstead', 'QLD', 'Breakfast Creek Rd, Newstead QLD 4006', 89500000, 145000000, 3, 4, 'Q1 2027', 'Waterfront townhomes along the Brisbane River in the thriving Newstead precinct. Each home features a private courtyard, double garage, and premium Miele kitchen appliances.', '["Brisbane River frontage","Walking distance to Gasworks Plaza and Howard Smith Wharves","Newstead median house price up 12.4% in 2025","High rental yields in Brisbane inner suburbs","Olympic infrastructure driving growth to 2032"]', 5.10, 8.20, '[]', false, false, true, false, 'active', true, false, 49900),
+
+  ('elara-marsden-park', 'Elara Estate', 'Stockland', (SELECT id FROM property_developers WHERE slug='stockland'), 'house_land', 'Sydney', 'Marsden Park', 'NSW', 'Richmond Rd, Marsden Park NSW 2765', 72000000, 98000000, 3, 5, 'Q3 2027', 'House and land packages in Sydney''s fastest-growing corridor. Master-planned community with parks, schools, and shopping village. Minutes from the new Sydney Metro West station.', '["Sydney Metro West station within 2km","New Costco and IKEA nearby","Land values in NW Sydney up 9.1% annually","Affordable entry point for Sydney market","High family rental demand — 2.1% vacancy rate"]', 4.50, 8.90, '[]', false, false, true, false, 'active', false, false, 29900),
+
+  ('yarra-one-south-yarra', 'Yarra One', 'Sekisui House', (SELECT id FROM property_developers WHERE slug='sekisui-house'), 'apartment', 'Melbourne', 'South Yarra', 'VIC', 'Toorak Rd, South Yarra VIC 3141', 48000000, 320000000, 1, 4, 'Q4 2027', 'Ultra-premium apartments on Toorak Road. Japanese-inspired design with meticulous attention to detail, featuring natural materials, expansive balconies, and panoramic city views.', '["Toorak Road premium address","South Yarra train station 200m","Consistently top 5 Melbourne suburb for capital growth","Japanese craftsmanship and design excellence","Concierge, pool, gym, private cinema"]', 3.80, 6.50, '[]', true, true, true, true, 'active', false, true, 49900),
+
+  ('west-village-west-end', 'West Village', 'Sekisui House', (SELECT id FROM property_developers WHERE slug='sekisui-house'), 'apartment', 'Brisbane', 'West End', 'QLD', 'Boundary St, West End QLD 4101', 45000000, 115000000, 1, 3, 'Q2 2027', 'A vibrant urban village in one of Brisbane''s most sought-after inner-city suburbs. Rooftop gardens, artisan retail, and a community-focused design with exceptional liveability.', '["West End — Brisbane''s trendiest inner suburb","2km to Brisbane CBD","High walkability score (92/100)","Strong rental demand from students and young professionals","Olympic legacy infrastructure within 3km"]', 5.40, 7.80, '[]', false, false, true, true, 'active', false, false, 29900),
+
+  ('haven-crows-nest', 'Haven Residences', 'Mirvac', (SELECT id FROM property_developers WHERE slug='mirvac'), 'apartment', 'Sydney', 'Crows Nest', 'NSW', 'Pacific Hwy, Crows Nest NSW 2065', 78000000, 220000000, 1, 3, 'Q1 2028', 'Boutique residences above the new Crows Nest Metro station. Exceptional connectivity to North Sydney and the CBD, with premium retail and dining at your doorstep.', '["Directly above Crows Nest Metro station","North Sydney CBD 1 stop away","Lower North Shore median prices up 7.8%","Premium boutique design — only 85 residences","Established café and dining precinct"]', 4.00, 7.10, '[]', true, true, true, true, 'coming_soon', false, false, 49900),
+
+  ('aurora-melbourne-central', 'Aurora Melbourne Central', 'Meriton', (SELECT id FROM property_developers WHERE slug='meriton'), 'apartment', 'Melbourne', 'Melbourne CBD', 'VIC', 'La Trobe St, Melbourne VIC 3000', 38000000, 85000000, 1, 2, 'Completed', 'Completed and ready to move in. Iconic tower in Melbourne''s city centre with breathtaking views, world-class amenities, and an unbeatable location steps from Melbourne Central Station.', '["Completed — settle immediately, no construction risk","Melbourne Central Station 100m","Strong CBD rental market — 1.8% vacancy","Fully furnished options available","Perfect for student or corporate rental strategy"]', 5.60, 5.20, '[]', true, true, false, false, 'active', false, false, 29900)
+ON CONFLICT (slug) DO NOTHING;
+
+-- ============================================================
+-- Seed: Buyer Agents (10 across major states)
+-- ============================================================
+INSERT INTO buyer_agents (slug, name, photo_url, agency_name, bio, states_covered, suburbs_speciality, investment_focus, avg_property_value, fee_structure, fee_fixed_cents, fee_percent, phone, email, website, rating, review_count, verified, featured, status)
+VALUES
+  ('james-walker', 'James Walker', NULL, 'Walker Property Advisory', 'With over 15 years of experience in the Sydney property market, James specialises in helping investors identify high-growth suburbs before the market catches on. Former REA Group analyst with deep data-driven insights.', '{NSW}', '{Parramatta,Penrith,Liverpool,Blacktown,Campbelltown}', '{Capital Growth,First Home Buyer,Renovation}', '$800k – $1.5M', 'Fixed fee + success bonus', 1500000, 1.50, '0412 345 678', 'james@walkerpa.com.au', 'https://walkerpa.com.au', 4.90, 47, true, true, 'active'),
+
+  ('sarah-nguyen', 'Sarah Nguyen', NULL, 'Harbour Property Buyers', 'Sarah is a licensed buyer''s agent who has helped over 200 clients purchase property across Sydney''s Inner West and Eastern Suburbs. She specialises in off-market acquisitions and auction strategy.', '{NSW}', '{Marrickville,Newtown,Surry Hills,Randwick,Bondi}', '{Owner Occupier,Prestige,Off-Market}', '$1.2M – $3M', 'Percentage of purchase price', 0, 2.00, '0423 456 789', 'sarah@harbourpb.com.au', 'https://harbourpb.com.au', 4.80, 63, true, true, 'active'),
+
+  ('michael-chen', 'Michael Chen', NULL, 'Melbourne Investment Partners', 'Michael is a REBAA-accredited buyer''s agent focused exclusively on investment properties in Melbourne''s growth corridors. His portfolio clients average 8.2% annual returns over 10 years.', '{VIC}', '{Footscray,Sunshine,Werribee,Craigieburn,Point Cook}', '{Capital Growth,Cash Flow,Portfolio Building}', '$500k – $1M', 'Fixed fee', 1200000, 0, '0434 567 890', 'michael@mip.com.au', 'https://mip.com.au', 4.70, 38, true, false, 'active'),
+
+  ('emma-taylor', 'Emma Taylor', NULL, 'Prestige Buyers Melbourne', 'Emma specialises in premium Melbourne properties — inner-city apartments, heritage homes, and blue-chip suburbs. With a background in architecture, she has an eye for quality that sets her apart.', '{VIC}', '{South Yarra,Toorak,Brighton,Armadale,Hawthorn}', '{Prestige,Owner Occupier,Downsizer}', '$1.5M – $5M', 'Percentage of purchase price', 0, 1.80, '0445 678 901', 'emma@prestigebuyers.com.au', 'https://prestigebuyers.com.au', 4.90, 52, true, true, 'active'),
+
+  ('david-murphy', 'David Murphy', NULL, 'Brisbane Buyers Agency', 'David has been buying property in Brisbane since 2008 and has seen the market through multiple cycles. He focuses on identifying undervalued suburbs with strong infrastructure investment driving growth.', '{QLD}', '{Newstead,West End,Woolloongabba,Morningside,Nundah}', '{Capital Growth,Cash Flow,Olympic Corridor}', '$600k – $1.2M', 'Fixed fee', 1100000, 0, '0456 789 012', 'david@brisbuyers.com.au', 'https://brisbuyers.com.au', 4.80, 41, true, false, 'active'),
+
+  ('lisa-campbell', 'Lisa Campbell', NULL, 'Gold Coast Property Pros', 'Lisa specialises in the Gold Coast and Northern Rivers region, helping interstate investors capitalise on Queensland''s ongoing migration boom. Deep local knowledge and strong agent network.', '{QLD}', '{Burleigh Heads,Palm Beach,Robina,Coolangatta,Broadbeach}', '{Lifestyle Investment,Short-term Rental,Capital Growth}', '$700k – $1.5M', 'Fixed fee + success bonus', 1300000, 1.00, '0467 890 123', 'lisa@gcpropertypros.com.au', 'https://gcpropertypros.com.au', 4.60, 29, true, false, 'active'),
+
+  ('tom-anderson', 'Tom Anderson', NULL, 'Perth Property Partners', 'Tom is Western Australia''s leading buyer''s agent for investment property, with deep expertise in Perth''s mining-driven rental market and emerging northern corridor suburbs.', '{WA}', '{Scarborough,Joondalup,Baldivis,Rockingham,Mandurah}', '{Cash Flow,Mining Town,Regional Growth}', '$400k – $900k', 'Fixed fee', 900000, 0, '0478 901 234', 'tom@perthpp.com.au', 'https://perthpp.com.au', 4.50, 22, true, false, 'active'),
+
+  ('natalie-hart', 'Natalie Hart', NULL, 'National Property Advisory', 'Natalie is one of Australia''s few truly national buyer''s agents, with teams across Sydney, Melbourne, and Brisbane. She builds portfolio strategies for high-net-worth clients seeking diversification across state lines.', '{NSW,VIC,QLD}', '{Sydney CBD,Melbourne CBD,Brisbane CBD,Parramatta,Southbank}', '{Portfolio Building,SMSF Property,Commercial}', '$500k – $2M', 'Percentage of purchase price', 0, 1.50, '0489 012 345', 'natalie@npa.com.au', 'https://npa.com.au', 4.70, 56, true, true, 'active'),
+
+  ('ben-wright', 'Ben Wright', NULL, 'Adelaide Buyer Advocates', 'Ben has helped over 300 buyers navigate Adelaide''s affordable and high-yielding property market. His data-driven approach has consistently identified suburbs 12-18 months ahead of the growth curve.', '{SA}', '{Prospect,Norwood,Unley,Glenelg,Semaphore}', '{Cash Flow,First Home Buyer,Regional Growth}', '$400k – $800k', 'Fixed fee', 800000, 0, '0490 123 456', 'ben@adelaidebuyers.com.au', 'https://adelaidebuyers.com.au', 4.60, 34, true, false, 'active'),
+
+  ('karen-white', 'Karen White', NULL, 'Hobart Property Buyers', 'Karen is Tasmania''s premier buyer''s agent, specialising in Hobart''s booming property market. With vacancy rates among the lowest in Australia, her clients enjoy exceptional rental returns.', '{TAS}', '{Hobart CBD,Sandy Bay,Battery Point,North Hobart,New Town}', '{Cash Flow,Short-term Rental,Lifestyle Investment}', '$500k – $1M', 'Fixed fee + success bonus', 1000000, 1.00, '0401 234 567', 'karen@hobartpb.com.au', 'https://hobartpb.com.au', 4.80, 27, true, false, 'active')
+ON CONFLICT (slug) DO NOTHING;
+
+-- ============================================================
+-- Seed: Suburb Data (top 20 Australian investment suburbs)
+-- ============================================================
+INSERT INTO suburb_data (suburb, state, postcode, median_price_house, median_price_unit, rental_yield_house, rental_yield_unit, vacancy_rate, capital_growth_1yr, capital_growth_3yr, capital_growth_5yr, capital_growth_10yr, population, population_growth, median_age, median_income, distance_to_cbd_km)
+VALUES
+  ('Parramatta', 'NSW', '2150', 130000000, 62000000, 3.20, 4.80, 2.10, 6.50, 18.20, 32.50, 72.00, 30000, 3.80, 33, 72000, 24.0),
+  ('Penrith', 'NSW', '2750', 92000000, 48000000, 3.80, 5.10, 1.80, 8.20, 22.50, 38.00, 89.00, 14000, 2.90, 34, 65000, 54.0),
+  ('Liverpool', 'NSW', '2170', 98000000, 50000000, 3.50, 4.90, 2.00, 7.10, 19.80, 35.00, 82.00, 28000, 3.20, 32, 58000, 32.0),
+  ('Crows Nest', 'NSW', '2065', 280000000, 95000000, 2.50, 4.00, 1.50, 5.80, 16.40, 28.00, 62.00, 9500, 1.20, 36, 95000, 5.0),
+  ('Marsden Park', 'NSW', '2765', 95000000, NULL, 3.90, NULL, 1.60, 9.10, 28.50, 52.00, 105.00, 18000, 8.50, 31, 82000, 45.0),
+  ('South Yarra', 'VIC', '3141', 250000000, 58000000, 2.30, 3.80, 2.20, 4.20, 12.80, 22.50, 55.00, 24000, 1.80, 32, 88000, 5.0),
+  ('Footscray', 'VIC', '3011', 105000000, 42000000, 3.40, 4.60, 2.50, 7.80, 21.00, 36.00, 78.00, 18000, 3.50, 31, 62000, 6.0),
+  ('South Melbourne', 'VIC', '3205', 195000000, 65000000, 2.60, 4.20, 1.90, 5.50, 15.20, 26.00, 58.00, 12000, 1.60, 34, 92000, 3.0),
+  ('Melbourne CBD', 'VIC', '3000', NULL, 52000000, NULL, 5.60, 3.50, 3.80, 10.50, 18.00, 42.00, 55000, 4.20, 28, 65000, 0.0),
+  ('Craigieburn', 'VIC', '3064', 72000000, 38000000, 3.80, 5.20, 1.40, 8.50, 24.00, 42.00, 92.00, 65000, 5.60, 30, 58000, 28.0),
+  ('Newstead', 'QLD', '4006', 180000000, 68000000, 3.00, 4.50, 1.80, 9.20, 26.00, 45.00, 88.00, 8000, 6.20, 33, 85000, 3.0),
+  ('West End', 'QLD', '4101', 145000000, 55000000, 3.20, 5.40, 1.60, 10.50, 28.80, 48.00, 92.00, 12000, 4.80, 32, 78000, 2.0),
+  ('Woolloongabba', 'QLD', '4102', 120000000, 48000000, 3.50, 5.10, 1.70, 11.20, 30.00, 50.00, 95.00, 9000, 5.50, 31, 72000, 3.0),
+  ('Morningside', 'QLD', '4170', 115000000, 52000000, 3.30, 4.80, 1.50, 9.80, 27.50, 46.00, 90.00, 11000, 3.20, 34, 80000, 7.0),
+  ('Nundah', 'QLD', '4012', 98000000, 45000000, 3.60, 5.30, 1.40, 10.00, 28.00, 47.00, 91.00, 14000, 3.80, 33, 75000, 9.0),
+  ('Scarborough', 'WA', '6019', 115000000, 55000000, 3.50, 4.50, 1.20, 12.50, 32.00, 45.00, 85.00, 16000, 2.80, 35, 78000, 14.0),
+  ('Prospect', 'SA', '5082', 95000000, 42000000, 3.80, 5.00, 0.80, 11.00, 30.50, 48.00, 95.00, 22000, 2.20, 36, 72000, 6.0),
+  ('Norwood', 'SA', '5067', 130000000, 48000000, 3.20, 4.80, 0.90, 9.50, 26.00, 42.00, 88.00, 6500, 1.50, 38, 82000, 4.0),
+  ('Hobart CBD', 'TAS', '7000', 85000000, 48000000, 4.20, 5.80, 0.60, 8.00, 22.00, 38.00, 82.00, 5500, 2.00, 35, 65000, 0.0),
+  ('Sandy Bay', 'TAS', '7005', 120000000, 52000000, 3.50, 5.20, 0.70, 7.50, 20.00, 35.00, 78.00, 8000, 1.80, 32, 70000, 3.0)
+ON CONFLICT (suburb, state) DO NOTHING;


### PR DESCRIPTION
Merges the property investment vertical into main:
- `/property` hub page
- `/property/listings` — 16 seeded listings
- `/property/buyer-agents` — 20 agents
- `/property/suburbs` — suburb data tool
- `/property/finance` — finance page
- Admin pages for listings, developers, leads
- Header nav updated
- Supabase tables + RLS + seed data