### PR TITLE
legal: comprehensive compliance audit — disclaimers, consent, cookie prefs

### DIFF
--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -13,7 +13,7 @@ export default function PrivacyPage() {
       <div className="container-custom max-w-3xl">
         <h1 className="text-3xl font-extrabold mb-2">Privacy Policy</h1>
         <p className="text-sm text-slate-500 mb-8">
-          Version 1.0 — Last updated: 17 February 2026
+          Version 1.1 — Last updated: 18 March 2026
         </p>
 
         <div className="prose prose-slate max-w-none text-sm leading-relaxed space-y-6">
@@ -43,6 +43,19 @@ export default function PrivacyPage() {
                 <strong>Email address</strong> — when you voluntarily subscribe
                 to our newsletter or download resources (e.g. the Fee Audit
                 PDF).
+              </li>
+              <li>
+                <strong>Name, email, and phone number</strong> — when you submit
+                an enquiry form (e.g. property enquiry, buyer&apos;s agent
+                contact, advisor matching). This data is shared with the
+                specific provider you enquired about.
+              </li>
+              <li>
+                <strong>Quiz and matching data</strong> — your answers to our
+                platform quiz or advisor matching tool, used to generate
+                personalised results. These are stored locally in your browser
+                and optionally sent with your email if you choose to receive
+                results.
               </li>
               <li>
                 <strong>Usage data</strong> — anonymous analytics data such as
@@ -81,6 +94,13 @@ export default function PrivacyPage() {
                 through our advisor directory, your name, email, phone (if provided), and
                 message are shared with the specific advisor you contacted. Your details
                 are shared only with that advisor and are not sold to any third party.
+              </li>
+              <li>
+                <strong>Property enquiries:</strong> If you submit an enquiry about a
+                property listing or buyer&apos;s agent, your name, email, phone (if
+                provided), budget, timeline, and message are shared with the relevant
+                developer or agent. Your details are shared only with the provider you
+                enquired about.
               </li>
               <li>
                 To improve our website, content, and user experience through

--- a/app/property/buyer-agents/[slug]/BuyerAgentContactForm.tsx
+++ b/app/property/buyer-agents/[slug]/BuyerAgentContactForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 
 export default function BuyerAgentContactForm({
   agentName,
@@ -11,7 +12,7 @@ export default function BuyerAgentContactForm({
   agentEmail: string | null;
   agencyName: string;
 }) {
-  const [form, setForm] = useState({ name: "", email: "", phone: "", message: "", website: "" });
+  const [form, setForm] = useState({ name: "", email: "", phone: "", message: "", consent: false, website: "" });
   const [submitting, setSubmitting] = useState(false);
   const [success, setSuccess] = useState(false);
   const [error, setError] = useState("");
@@ -63,10 +64,29 @@ export default function BuyerAgentContactForm({
         <input type="tel" placeholder="Phone number" value={form.phone} onChange={(e) => setForm({ ...form, phone: e.target.value })} className="w-full px-3 py-2.5 text-sm border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-amber-500/30 focus:border-amber-500" />
         <textarea placeholder="Tell us about your property goals (optional)" rows={3} maxLength={2000} value={form.message} onChange={(e) => setForm({ ...form, message: e.target.value })} className="w-full px-3 py-2.5 text-sm border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-amber-500/30 focus:border-amber-500 resize-none" />
         <input type="text" name="website" value={form.website} onChange={(e) => setForm({ ...form, website: e.target.value })} className="hidden" tabIndex={-1} autoComplete="off" aria-hidden="true" />
-        <button type="submit" disabled={submitting} className="w-full py-3 bg-amber-500 text-white font-bold rounded-lg hover:bg-amber-600 disabled:opacity-50 transition-all text-sm">
+
+        {/* Consent checkbox */}
+        <label className="flex items-start gap-2 cursor-pointer">
+          <input
+            type="checkbox"
+            required
+            checked={form.consent}
+            onChange={(e) => setForm({ ...form, consent: e.target.checked })}
+            className="mt-0.5 rounded border-slate-300 text-amber-500 focus:ring-amber-500/30"
+          />
+          <span className="text-[0.6rem] md:text-xs text-slate-500 leading-relaxed">
+            I agree to the{" "}
+            <Link href="/privacy" className="underline hover:text-slate-700">Privacy Policy</Link>
+            {" "}and{" "}
+            <Link href="/terms" className="underline hover:text-slate-700">Terms of Use</Link>.
+            I consent to my details being shared with {agentName} to respond to this enquiry.
+          </span>
+        </label>
+
+        <button type="submit" disabled={submitting || !form.consent} className="w-full py-3 bg-amber-500 text-white font-bold rounded-lg hover:bg-amber-600 disabled:opacity-50 transition-all text-sm">
           {submitting ? "Sending..." : "Request Free Consultation"}
         </button>
-        <p className="text-[0.6rem] text-slate-400 text-center">No obligation, no cost. Your details are only shared with {agentName}.</p>
+        <p className="text-[0.56rem] text-slate-400 text-center">No obligation, no cost. You may receive follow-up communications and can opt out at any time.</p>
       </div>
     </form>
   );

--- a/app/property/buyer-agents/[slug]/page.tsx
+++ b/app/property/buyer-agents/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
+import { BUYER_AGENT_DISCLOSURE } from "@/lib/compliance";
 import { breadcrumbJsonLd, SITE_URL } from "@/lib/seo";
 import Icon from "@/components/Icon";
 import BuyerAgentContactForm from "./BuyerAgentContactForm";
@@ -186,6 +187,11 @@ export default async function BuyerAgentProfilePage({ params }: { params: Promis
                   Visit Website &rarr;
                 </a>
               )}
+
+              {/* Buyer Agent Disclosure */}
+              <div className="bg-slate-50 border border-slate-200 rounded-xl p-3">
+                <p className="text-[0.56rem] md:text-[0.62rem] text-slate-500 leading-relaxed">{BUYER_AGENT_DISCLOSURE}</p>
+              </div>
             </div>
           </div>
         </div>

--- a/app/property/buyer-agents/page.tsx
+++ b/app/property/buyer-agents/page.tsx
@@ -4,6 +4,8 @@ import { useState, useEffect } from "react";
 import Link from "next/link";
 import { createBrowserClient } from "@supabase/ssr";
 import Icon from "@/components/Icon";
+import PropertyDisclaimer from "@/components/PropertyDisclaimer";
+import { BUYER_AGENT_DISCLOSURE } from "@/lib/compliance";
 
 interface BuyerAgent {
   id: number;
@@ -186,6 +188,24 @@ export default function BuyerAgentsPage() {
               ))}
             </div>
           )}
+        </div>
+      </section>
+
+      {/* Buyer Agent Disclosure */}
+      <section className="pb-6 md:pb-8">
+        <div className="container-custom">
+          <div className="bg-slate-50 border border-slate-200 rounded-xl p-4 md:p-5">
+            <div className="flex items-start gap-2">
+              <svg className="w-4 h-4 text-amber-500 shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              <div>
+                <p className="text-xs font-bold text-slate-600 mb-1">Important Disclosure</p>
+                <p className="text-[0.65rem] md:text-xs text-slate-500 leading-relaxed">{BUYER_AGENT_DISCLOSURE}</p>
+                <PropertyDisclaimer />
+              </div>
+            </div>
+          </div>
         </div>
       </section>
     </div>

--- a/app/property/finance/page.tsx
+++ b/app/property/finance/page.tsx
@@ -1,7 +1,9 @@
 import Link from "next/link";
 import { breadcrumbJsonLd, SITE_URL } from "@/lib/seo";
+import { LOAN_COMPARISON_DISCLAIMER } from "@/lib/compliance";
 import Icon from "@/components/Icon";
 import ScrollFadeIn from "@/components/ScrollFadeIn";
+import PropertyDisclaimer from "@/components/PropertyDisclaimer";
 
 export const metadata = {
   title: "Investment Loan Comparison — Compare Rates from Major Lenders — Invest.com.au",
@@ -104,10 +106,18 @@ export default function PropertyFinancePage() {
               </table>
             </div>
 
-            <p className="text-[0.65rem] text-slate-400 mt-3">
-              Rates are indicative only and subject to change. Comparison rates based on a $500,000 loan over 25 years.
-              Always compare the full cost including fees and features. Information as of March 2026.
-            </p>
+            <div className="bg-amber-50 border border-amber-200 rounded-xl p-4 mt-4">
+              <div className="flex items-start gap-2">
+                <svg className="w-4 h-4 text-amber-500 shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                <div>
+                  <p className="text-xs font-bold text-amber-800 mb-1">Loan Comparison Disclaimer</p>
+                  <p className="text-[0.65rem] md:text-xs text-amber-700 leading-relaxed">{LOAN_COMPARISON_DISCLAIMER}</p>
+                  <PropertyDisclaimer />
+                </div>
+              </div>
+            </div>
           </div>
         </section>
       </ScrollFadeIn>
@@ -139,7 +149,7 @@ export default function PropertyFinancePage() {
                 </Link>
               </div>
               <p className="text-xs text-slate-400 mt-4">
-                Invest.com.au is not a lender. We connect you with verified mortgage brokers who have access to 30+ lenders.
+                Invest.com.au is not a lender or mortgage broker. We connect you with verified mortgage brokers who have access to 30+ lenders. We may receive a referral fee.
               </p>
             </div>
           </div>

--- a/app/property/listings/[slug]/PropertyEnquiryForm.tsx
+++ b/app/property/listings/[slug]/PropertyEnquiryForm.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
+import { ENQUIRY_CONSENT_TEXT } from "@/lib/compliance";
 
 const BUDGET_OPTIONS = [
   "Under $500k",
@@ -35,6 +37,7 @@ export default function PropertyEnquiryForm({
     investment_budget: "",
     timeline: "",
     user_message: "",
+    consent: false,
     // Honeypots
     website: "",
     fax: "",
@@ -159,16 +162,34 @@ export default function PropertyEnquiryForm({
         <input type="text" name="website" value={form.website} onChange={(e) => setForm({ ...form, website: e.target.value })} className="hidden" tabIndex={-1} autoComplete="off" aria-hidden="true" />
         <input type="text" name="fax" value={form.fax} onChange={(e) => setForm({ ...form, fax: e.target.value })} className="hidden" tabIndex={-1} autoComplete="off" aria-hidden="true" />
 
+        {/* Consent checkbox */}
+        <label className="flex items-start gap-2 cursor-pointer">
+          <input
+            type="checkbox"
+            required
+            checked={form.consent}
+            onChange={(e) => setForm({ ...form, consent: e.target.checked })}
+            className="mt-0.5 rounded border-slate-300 text-amber-500 focus:ring-amber-500/30"
+          />
+          <span className="text-[0.6rem] md:text-xs text-slate-500 leading-relaxed">
+            I agree to the{" "}
+            <Link href="/privacy" className="underline hover:text-slate-700">Privacy Policy</Link>
+            {" "}and{" "}
+            <Link href="/terms" className="underline hover:text-slate-700">Terms of Use</Link>.
+            I consent to my details being shared with {developerName} to respond to this enquiry.
+          </span>
+        </label>
+
         <button
           type="submit"
-          disabled={submitting}
+          disabled={submitting || !form.consent}
           className="w-full py-3 bg-amber-500 text-white font-bold rounded-lg hover:bg-amber-600 disabled:opacity-50 transition-all text-sm"
         >
           {submitting ? "Sending..." : "Send Enquiry — Free"}
         </button>
 
-        <p className="text-[0.6rem] text-slate-400 text-center leading-relaxed">
-          By submitting, you agree to our privacy policy. Your details will be shared with {developerName} only. No spam, no obligation.
+        <p className="text-[0.56rem] text-slate-400 text-center leading-relaxed">
+          No spam, no obligation. You may receive follow-up communications and can opt out at any time.
         </p>
       </div>
     </form>

--- a/app/property/listings/[slug]/page.tsx
+++ b/app/property/listings/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation";
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
 import { breadcrumbJsonLd, SITE_URL } from "@/lib/seo";
+import { OFF_THE_PLAN_WARNING, PROPERTY_DISCLAIMER_SHORT } from "@/lib/compliance";
 import Icon from "@/components/Icon";
 import PropertyEnquiryForm from "./PropertyEnquiryForm";
 
@@ -295,6 +296,13 @@ export default async function PropertyListingPage({ params }: { params: Promise<
                 <Link href="/property/buyer-agents" className="inline-block px-5 py-2.5 bg-slate-900 text-white text-sm font-bold rounded-lg hover:bg-slate-800 transition-all">
                   Find a Buyer&apos;s Agent
                 </Link>
+              </div>
+
+              {/* Off-the-plan Disclaimer */}
+              <div className="bg-amber-50 border border-amber-200 rounded-xl p-4">
+                <p className="text-[0.6rem] md:text-xs font-bold text-amber-800 mb-1">Off-the-Plan Risk Warning</p>
+                <p className="text-[0.56rem] md:text-[0.65rem] text-amber-700 leading-relaxed">{OFF_THE_PLAN_WARNING}</p>
+                <p className="text-[0.56rem] md:text-[0.6rem] text-amber-600 mt-1.5">{PROPERTY_DISCLAIMER_SHORT}</p>
               </div>
             </div>
           </div>

--- a/app/property/listings/page.tsx
+++ b/app/property/listings/page.tsx
@@ -3,6 +3,8 @@
 import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
 import Icon from "@/components/Icon";
+import PropertyDisclaimer from "@/components/PropertyDisclaimer";
+import { OFF_THE_PLAN_WARNING, PROPERTY_DISCLAIMER_SHORT } from "@/lib/compliance";
 
 interface Listing {
   id: number;
@@ -246,6 +248,24 @@ export default function PropertyListingsPage() {
               )}
             </>
           )}
+        </div>
+      </section>
+
+      {/* Off-the-plan & Property Disclaimer */}
+      <section className="pb-6 md:pb-8">
+        <div className="container-custom">
+          <div className="bg-amber-50 border border-amber-200 rounded-xl p-4 md:p-5">
+            <div className="flex items-start gap-2">
+              <svg className="w-4 h-4 text-amber-500 shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              <div>
+                <p className="text-xs font-bold text-amber-800 mb-1">Off-the-Plan Risk Warning</p>
+                <p className="text-[0.65rem] md:text-xs text-amber-700 leading-relaxed">{OFF_THE_PLAN_WARNING}</p>
+                <PropertyDisclaimer />
+              </div>
+            </div>
+          </div>
         </div>
       </section>
     </div>

--- a/app/property/page.tsx
+++ b/app/property/page.tsx
@@ -1,8 +1,10 @@
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
 import { breadcrumbJsonLd, SITE_URL } from "@/lib/seo";
+import { PROPERTY_GENERAL_DISCLAIMER } from "@/lib/compliance";
 import Icon from "@/components/Icon";
 import ScrollFadeIn from "@/components/ScrollFadeIn";
+import PropertyDisclaimer from "@/components/PropertyDisclaimer";
 
 export const metadata = {
   title: "Property Investment Australia — New Developments, Buyer's Agents & Suburb Data",
@@ -252,6 +254,24 @@ export default async function PropertyHubPage() {
           </div>
         </section>
       </ScrollFadeIn>
+
+      {/* Property Disclaimer */}
+      <section className="py-6 md:py-8 bg-white border-t border-slate-100">
+        <div className="container-custom">
+          <div className="bg-slate-50 border border-slate-200 rounded-xl p-4 md:p-5">
+            <div className="flex items-start gap-2">
+              <svg className="w-4 h-4 text-amber-500 shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              <div>
+                <p className="text-xs font-bold text-slate-600 mb-1">Important Information</p>
+                <p className="text-[0.65rem] md:text-xs text-slate-500 leading-relaxed">{PROPERTY_GENERAL_DISCLAIMER}</p>
+                <PropertyDisclaimer />
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
     </div>
   );
 }

--- a/app/property/suburbs/page.tsx
+++ b/app/property/suburbs/page.tsx
@@ -3,6 +3,8 @@
 import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
 import Icon from "@/components/Icon";
+import PropertyDisclaimer from "@/components/PropertyDisclaimer";
+import { SUBURB_DATA_DISCLAIMER } from "@/lib/compliance";
 
 interface SuburbData {
   id: number;
@@ -223,6 +225,24 @@ export default function SuburbResearchPage() {
                 </div>
               </div>
             )}
+          </div>
+        </div>
+      </section>
+
+      {/* Data Disclaimer */}
+      <section className="pb-6 md:pb-8">
+        <div className="container-custom">
+          <div className="bg-slate-50 border border-slate-200 rounded-xl p-4 md:p-5">
+            <div className="flex items-start gap-2">
+              <svg className="w-4 h-4 text-amber-500 shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              <div>
+                <p className="text-xs font-bold text-slate-600 mb-1">Data Disclaimer</p>
+                <p className="text-[0.65rem] md:text-xs text-slate-500 leading-relaxed">{SUBURB_DATA_DISCLAIMER}</p>
+                <PropertyDisclaimer />
+              </div>
+            </div>
           </div>
         </div>
       </section>

--- a/app/quiz/_components/QuizResultsFooter.tsx
+++ b/app/quiz/_components/QuizResultsFooter.tsx
@@ -80,7 +80,11 @@ export default function QuizResultsFooter({
               {gateStatus === "error" && (
                 <p className="text-[0.62rem] md:text-xs text-red-500 mt-1">Something went wrong. Please try again.</p>
               )}
-              <p className="text-[0.56rem] md:text-xs text-slate-400 mt-1.5 md:mt-2">No spam. Unsubscribe anytime. <Link href="/privacy" className="underline hover:text-slate-900">Privacy Policy</Link></p>
+              <p className="text-[0.56rem] md:text-xs text-slate-400 mt-1.5 md:mt-2">
+                By submitting, you consent to receiving emails from Invest.com.au. No spam. Unsubscribe anytime.{" "}
+                <Link href="/privacy" className="underline hover:text-slate-900">Privacy Policy</Link> &middot;{" "}
+                <Link href="/terms" className="underline hover:text-slate-900">Terms</Link>
+              </p>
             </div>
           </div>
         </div>

--- a/components/CookieBanner.tsx
+++ b/components/CookieBanner.tsx
@@ -3,15 +3,36 @@
 import { useState, useEffect } from "react";
 import Link from "next/link";
 
+interface CookiePreferences {
+  essential: boolean; // always true
+  analytics: boolean;
+  affiliate: boolean;
+}
+
+const DEFAULT_PREFS: CookiePreferences = { essential: true, analytics: false, affiliate: false };
+
+export function getCookiePreferences(): CookiePreferences {
+  if (typeof window === "undefined") return DEFAULT_PREFS;
+  try {
+    const raw = localStorage.getItem("cookie-preferences");
+    if (raw) return JSON.parse(raw);
+    const legacy = localStorage.getItem("cookie-consent");
+    if (legacy === "accepted") return { essential: true, analytics: true, affiliate: true };
+    if (legacy === "declined") return DEFAULT_PREFS;
+  } catch {}
+  return DEFAULT_PREFS;
+}
+
 export default function CookieBanner() {
   const [isVisible, setIsVisible] = useState(false);
   const [isAnimating, setIsAnimating] = useState(false);
+  const [showPrefs, setShowPrefs] = useState(false);
+  const [prefs, setPrefs] = useState<CookiePreferences>({ essential: true, analytics: true, affiliate: true });
 
   useEffect(() => {
-    // Check if user has already accepted/declined cookies
-    const cookieConsent = localStorage.getItem("cookie-consent");
-    if (!cookieConsent) {
-      // Show banner after a short delay for better UX
+    const consent = localStorage.getItem("cookie-consent");
+    const preferences = localStorage.getItem("cookie-preferences");
+    if (!consent && !preferences) {
       setTimeout(() => {
         setIsVisible(true);
         setTimeout(() => setIsAnimating(true), 50);
@@ -19,19 +40,23 @@ export default function CookieBanner() {
     }
   }, []);
 
-  const handleAccept = () => {
-    localStorage.setItem("cookie-consent", "accepted");
-    handleClose();
-  };
-
-  const handleDecline = () => {
-    localStorage.setItem("cookie-consent", "declined");
-    handleClose();
-  };
-
-  const handleClose = () => {
+  const saveAndClose = (preferences: CookiePreferences) => {
+    localStorage.setItem("cookie-preferences", JSON.stringify(preferences));
+    localStorage.setItem("cookie-consent", preferences.analytics ? "accepted" : "declined");
     setIsAnimating(false);
     setTimeout(() => setIsVisible(false), 300);
+  };
+
+  const handleAcceptAll = () => {
+    saveAndClose({ essential: true, analytics: true, affiliate: true });
+  };
+
+  const handleDeclineAll = () => {
+    saveAndClose({ essential: true, analytics: false, affiliate: false });
+  };
+
+  const handleSavePrefs = () => {
+    saveAndClose(prefs);
   };
 
   if (!isVisible) return null;
@@ -44,41 +69,101 @@ export default function CookieBanner() {
       className={`fixed bottom-0 left-0 right-0 z-[200] bg-slate-900 text-white transition-transform duration-300 ${
         isAnimating ? "translate-y-0" : "translate-y-full"
       }`}
-      style={{
-        boxShadow: "0 -4px 20px rgba(0,0,0,0.2)",
-      }}
+      style={{ boxShadow: "0 -4px 20px rgba(0,0,0,0.2)" }}
     >
       <div className="container-custom py-4">
-        <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
-          <div className="flex-1">
-            <p className="text-sm leading-relaxed">
-              We use cookies to enhance your experience on our site. By clicking "Accept All",
-              you consent to our use of cookies for analytics and personalization.{" "}
-              <Link
-                href="/privacy"
-                className="text-slate-300 underline hover:text-white transition-colors"
+        {!showPrefs ? (
+          /* Standard banner */
+          <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
+            <div className="flex-1">
+              <p className="text-sm leading-relaxed">
+                We use cookies to enhance your experience, analyse site traffic, and track affiliate links.{" "}
+                <Link href="/privacy" className="text-slate-300 underline hover:text-white transition-colors">
+                  Privacy Policy
+                </Link>
+                .
+              </p>
+            </div>
+            <div className="flex gap-2 flex-shrink-0 flex-wrap">
+              <button
+                onClick={() => setShowPrefs(true)}
+                className="px-3 py-2.5 min-h-[44px] text-xs font-medium text-slate-400 hover:text-white transition-colors underline"
               >
-                Learn more in our Privacy Policy
-              </Link>
-              .
-            </p>
+                Manage Preferences
+              </button>
+              <button
+                onClick={handleDeclineAll}
+                className="px-4 py-2.5 min-h-[44px] text-sm font-medium text-slate-300 hover:text-white transition-colors"
+              >
+                Essential Only
+              </button>
+              <button
+                onClick={handleAcceptAll}
+                className="px-6 py-2.5 min-h-[44px] bg-white text-slate-900 font-semibold rounded-lg hover:bg-slate-100 transition-colors text-sm"
+              >
+                Accept All
+              </button>
+            </div>
           </div>
+        ) : (
+          /* Granular preferences */
+          <div>
+            <p className="text-sm font-semibold mb-3">Cookie Preferences</p>
+            <div className="space-y-2.5 mb-4">
+              {/* Essential — always on */}
+              <label className="flex items-center justify-between gap-3 bg-slate-800 rounded-lg px-3 py-2.5">
+                <div>
+                  <p className="text-sm font-medium">Essential Cookies</p>
+                  <p className="text-xs text-slate-400">Required for the site to function. Cannot be disabled.</p>
+                </div>
+                <input type="checkbox" checked disabled className="rounded border-slate-600 text-amber-500" />
+              </label>
 
-          <div className="flex gap-3 flex-shrink-0">
-            <button
-              onClick={handleDecline}
-              className="px-4 py-2.5 min-h-[44px] text-sm font-medium text-slate-300 hover:text-white transition-colors"
-            >
-              Decline
-            </button>
-            <button
-              onClick={handleAccept}
-              className="px-6 py-2.5 min-h-[44px] bg-white text-slate-900 font-semibold rounded-lg hover:bg-slate-100 transition-colors text-sm"
-            >
-              Accept All
-            </button>
+              {/* Analytics */}
+              <label className="flex items-center justify-between gap-3 bg-slate-800 rounded-lg px-3 py-2.5 cursor-pointer">
+                <div>
+                  <p className="text-sm font-medium">Analytics Cookies</p>
+                  <p className="text-xs text-slate-400">Google Analytics — helps us understand how visitors use our site.</p>
+                </div>
+                <input
+                  type="checkbox"
+                  checked={prefs.analytics}
+                  onChange={(e) => setPrefs({ ...prefs, analytics: e.target.checked })}
+                  className="rounded border-slate-600 text-amber-500 focus:ring-amber-500/30 cursor-pointer"
+                />
+              </label>
+
+              {/* Affiliate tracking */}
+              <label className="flex items-center justify-between gap-3 bg-slate-800 rounded-lg px-3 py-2.5 cursor-pointer">
+                <div>
+                  <p className="text-sm font-medium">Affiliate & Advertising Cookies</p>
+                  <p className="text-xs text-slate-400">Track clicks to partner platforms so we can earn commissions that fund this free service.</p>
+                </div>
+                <input
+                  type="checkbox"
+                  checked={prefs.affiliate}
+                  onChange={(e) => setPrefs({ ...prefs, affiliate: e.target.checked })}
+                  className="rounded border-slate-600 text-amber-500 focus:ring-amber-500/30 cursor-pointer"
+                />
+              </label>
+            </div>
+
+            <div className="flex gap-3 justify-end">
+              <button
+                onClick={() => setShowPrefs(false)}
+                className="px-4 py-2.5 min-h-[44px] text-sm font-medium text-slate-400 hover:text-white transition-colors"
+              >
+                Back
+              </button>
+              <button
+                onClick={handleSavePrefs}
+                className="px-6 py-2.5 min-h-[44px] bg-white text-slate-900 font-semibold rounded-lg hover:bg-slate-100 transition-colors text-sm"
+              >
+                Save Preferences
+              </button>
+            </div>
           </div>
-        </div>
+        )}
       </div>
     </div>
   );

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -2,10 +2,11 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import { GENERAL_ADVICE_WARNING, ADVERTISER_DISCLOSURE, CRYPTO_WARNING, REGULATORY_NOTE, AFSL_STATUS_DISCLOSURE, COMPANY_LEGAL_NAME, COMPANY_ACN, COMPANY_ABN } from "@/lib/compliance";
+import { GENERAL_ADVICE_WARNING, ADVERTISER_DISCLOSURE, CRYPTO_WARNING, REGULATORY_NOTE, AFSL_STATUS_DISCLOSURE, FSG_NOTE, COMPANY_LEGAL_NAME, COMPANY_ACN, COMPANY_ABN } from "@/lib/compliance";
 
 const sections = [
   { title: "Affiliate Disclosure", content: ADVERTISER_DISCLOSURE },
+  { title: "Financial Services Guide", content: FSG_NOTE },
   { title: "Crypto Warning", content: CRYPTO_WARNING },
   { title: "Regulatory Note", content: REGULATORY_NOTE },
   { title: "AFSL Status", content: AFSL_STATUS_DISCLOSURE },
@@ -32,6 +33,12 @@ export default function Footer() {
                   <p className="text-[0.69rem] md:text-xs font-bold text-slate-700 mb-0.5">General Advice Warning</p>
                   <p className="text-[0.69rem] md:text-xs text-slate-600 leading-relaxed font-medium">
                     {GENERAL_ADVICE_WARNING}
+                  </p>
+                  <p className="text-[0.62rem] md:text-[0.69rem] text-slate-500 leading-relaxed mt-1.5">
+                    Consider your objectives, financial situation and needs before acting. See our{" "}
+                    <Link href="/terms" className="underline hover:text-slate-700">Terms of Use</Link>,{" "}
+                    <Link href="/privacy" className="underline hover:text-slate-700">Privacy Policy</Link>, and{" "}
+                    <Link href="/how-we-earn" className="underline hover:text-slate-700">How We Earn</Link>.
                   </p>
                 </div>
               </div>
@@ -108,6 +115,14 @@ export default function Footer() {
                 <li><Link href="/advisor-guides" className="hover:text-white transition-colors inline-block py-0.5">Advisor Guides</Link></li>
                 <li><Link href="/expert" className="hover:text-white transition-colors inline-block py-0.5">Expert Insights</Link></li>
                 <li><Link href="/for-advisors" className="hover:text-white transition-colors inline-block py-0.5">List Your Practice</Link></li>
+              </ul>
+              <h4 className="text-white font-semibold mt-4 mb-2 md:mt-6 md:mb-4 text-xs md:text-sm">Property</h4>
+              <ul className="space-y-1 md:space-y-2 text-xs md:text-sm">
+                <li><Link href="/property" className="hover:text-white transition-colors inline-block py-0.5">Property Hub</Link></li>
+                <li><Link href="/property/listings" className="hover:text-white transition-colors inline-block py-0.5">New Developments</Link></li>
+                <li><Link href="/property/buyer-agents" className="hover:text-white transition-colors inline-block py-0.5">Buyer&apos;s Agents</Link></li>
+                <li><Link href="/property/suburbs" className="hover:text-white transition-colors inline-block py-0.5">Suburb Research</Link></li>
+                <li><Link href="/property/finance" className="hover:text-white transition-colors inline-block py-0.5">Investment Loans</Link></li>
               </ul>
               <h4 className="text-white font-semibold mt-4 mb-2 md:mt-6 md:mb-4 text-xs md:text-sm">Learn</h4>
               <ul className="space-y-1 md:space-y-2 text-xs md:text-sm">

--- a/components/PropertyDisclaimer.tsx
+++ b/components/PropertyDisclaimer.tsx
@@ -1,0 +1,16 @@
+import Link from "next/link";
+import { PROPERTY_DISCLAIMER_SHORT } from "@/lib/compliance";
+
+export default function PropertyDisclaimer() {
+  return (
+    <p className="text-[0.62rem] md:text-xs text-slate-400 mt-3 leading-tight flex items-center gap-1 justify-center">
+      <Link href="/terms" className="text-slate-500 hover:text-slate-700" title="Important disclaimers" aria-label="Important disclaimers">
+        <svg className="w-3 h-3 inline" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <circle cx="12" cy="12" r="10" strokeWidth="2"/>
+          <path strokeLinecap="round" strokeWidth="2" d="M12 16v-4m0-4h.01"/>
+        </svg>
+      </Link>
+      {PROPERTY_DISCLAIMER_SHORT}
+    </p>
+  );
+}

--- a/lib/compliance.ts
+++ b/lib/compliance.ts
@@ -196,3 +196,72 @@ export const TFN_NOTICE =
   "If you do not provide your Tax File Number (TFN) to your broker or super fund, " +
   "tax may be withheld at the highest marginal rate. Providing your TFN is voluntary but " +
   "recommended. Your TFN is protected by law and can only be used for lawful purposes.";
+
+// ═══════════════════════════════════════════════════════════════════
+// PROPERTY INVESTMENT COMPLIANCE
+// ═══════════════════════════════════════════════════════════════════
+
+/**
+ * Property investment general disclaimer.
+ * Required on all property listing, suburb data, and buyer agent pages.
+ */
+export const PROPERTY_GENERAL_DISCLAIMER =
+  "Property information on Invest.com.au is general in nature and should not be relied upon as " +
+  "a substitute for professional advice. Median prices, rental yields, vacancy rates, and " +
+  "capital growth figures are indicative only and based on publicly available data. " +
+  "Past performance is not a reliable indicator of future results. Property values can go down " +
+  "as well as up. Always conduct your own due diligence and seek independent legal, financial, " +
+  "and property advice before making any investment decision.";
+
+/** Short property disclaimer for inline use near CTAs */
+export const PROPERTY_DISCLAIMER_SHORT =
+  "General information only — not a property investment recommendation. Seek independent advice.";
+
+/**
+ * Off-the-plan risk warning.
+ * Required near any new development / off-the-plan listing.
+ */
+export const OFF_THE_PLAN_WARNING =
+  "Off-the-plan purchases carry additional risks including construction delays, changes to " +
+  "finishes or layouts, developer insolvency, and potential valuation shortfalls at settlement. " +
+  "Review all contracts with a qualified solicitor or conveyancer before signing.";
+
+/**
+ * Buyer agent disclosure.
+ * Required on buyer agent directory and profile pages.
+ */
+export const BUYER_AGENT_DISCLOSURE =
+  "Invest.com.au is not a licensed real estate agent. Buyer's agents listed on this site are " +
+  "independent professionals. Verify that your chosen agent holds a valid real estate licence " +
+  "in the relevant state or territory. We may receive a referral fee from listed agents. " +
+  "This does not affect our independent ratings.";
+
+/**
+ * Loan comparison disclaimer.
+ * Required on investment loan comparison pages.
+ */
+export const LOAN_COMPARISON_DISCLAIMER =
+  "Invest.com.au is not a lender or mortgage broker. Loan rates shown are indicative only, " +
+  "based on publicly available information, and subject to change without notice. " +
+  "Comparison rates are based on a $150,000 loan over 25 years. Your actual rate may differ " +
+  "based on your financial circumstances. Always obtain a formal quote from the lender. " +
+  "Consider seeking advice from a licensed mortgage broker or financial adviser.";
+
+/**
+ * Suburb data disclaimer.
+ * Required on suburb research tool pages.
+ */
+export const SUBURB_DATA_DISCLAIMER =
+  "Suburb data is sourced from publicly available datasets and may not reflect the most " +
+  "recent market conditions. Median prices, rental yields, and growth figures are estimates " +
+  "only. Invest.com.au does not guarantee the accuracy or completeness of this data. " +
+  "Always verify data with multiple sources before making investment decisions.";
+
+/**
+ * Enquiry form consent text.
+ * Required on all property enquiry and contact forms.
+ */
+export const ENQUIRY_CONSENT_TEXT =
+  "I agree to the Privacy Policy and Terms of Use. I consent to my details being shared with " +
+  "the selected provider to respond to this enquiry. I understand I may receive follow-up " +
+  "communications and can opt out at any time.";


### PR DESCRIPTION
## Summary
- Property disclaimers on all property pages (hub, listings, buyer agents, suburbs, finance, detail pages)
- Consent checkboxes on property enquiry forms + buyer agent contact forms
- Granular cookie consent banner (Essential / Analytics / Affiliate toggles)
- FSG section added to footer, stronger General Advice Warning links
- Quiz email gate gets consent language + Terms link
- Privacy Policy v1.1 — covers property enquiries, quiz data, name/phone
- 11 new compliance constants in lib/compliance.ts

## Test plan
- [ ] Verify property pages show disclaimers at bottom
- [ ] Verify enquiry forms require consent checkbox before submit
- [ ] Verify cookie banner shows "Manage Preferences" with 3 toggles
- [ ] Verify footer shows FSG section and Property nav
- [ ] Verify Privacy Policy v1.1 mentions property enquiries