### PR TITLE
legal: fix 10-point audit — FSG, developer terms, ACL carve-out, AFSL always visible

### DIFF
--- a/app/advertiser-terms/page.tsx
+++ b/app/advertiser-terms/page.tsx
@@ -131,7 +131,7 @@ export default function AdvertiserTermsPage() {
               <p className="text-sm text-slate-600">
                 For advertising enquiries or questions about this Agreement, contact us at{" "}
                 <a href="mailto:advertise@invest.com.au" className="text-slate-700 underline hover:text-slate-900">advertise@invest.com.au</a>{" "}
-                or write to: {COMPANY_LEGAL_NAME}, PO Box 123, Melbourne VIC 3000.
+                or email: partners@invest.com.au.
               </p>
             </section>
           </div>

--- a/app/advisor-terms/page.tsx
+++ b/app/advisor-terms/page.tsx
@@ -128,7 +128,7 @@ export default function AdvisorTermsPage() {
               <p className="text-sm text-slate-600">
                 For questions about this Agreement, contact us at{" "}
                 <a href="mailto:legal@invest.com.au" className="text-slate-700 underline hover:text-slate-900">legal@invest.com.au</a>{" "}
-                or write to: {COMPANY_LEGAL_NAME}, PO Box 123, Melbourne VIC 3000.
+                or email: partners@invest.com.au.
               </p>
             </section>
           </div>

--- a/app/broker-terms/page.tsx
+++ b/app/broker-terms/page.tsx
@@ -112,7 +112,7 @@ export default function BrokerTermsPage() {
               <p>
                 For questions about this Agreement, contact us at{" "}
                 <a href="mailto:partnerships@invest.com.au" className="text-slate-700 underline hover:text-slate-900">partnerships@invest.com.au</a>{" "}
-                or write to: {COMPANY_LEGAL_NAME}, PO Box 123, Melbourne VIC 3000.
+                or email: partners@invest.com.au.
               </p>
             </S>
           </div>

--- a/app/developer-terms/page.tsx
+++ b/app/developer-terms/page.tsx
@@ -1,0 +1,316 @@
+import Link from "next/link";
+import { absoluteUrl, breadcrumbJsonLd, SITE_NAME } from "@/lib/seo";
+import {
+  COMPANY_LEGAL_NAME,
+  COMPANY_ACN,
+  COMPANY_ABN,
+} from "@/lib/compliance";
+
+export const metadata = {
+  title: "Developer & Buyer's Agent Listing Terms — Invest.com.au",
+  description:
+    "Terms and conditions for property developers and buyer's agents listed on the Invest.com.au property vertical.",
+  alternates: { canonical: "/developer-terms" },
+  robots: { index: true, follow: true },
+};
+
+const EFFECTIVE_DATE = "18 March 2026";
+const VERSION = "1.0";
+
+export default function DeveloperTermsPage() {
+  const breadcrumbs = breadcrumbJsonLd([
+    { name: "Home", url: absoluteUrl("/") },
+    { name: "Developer & Agent Listing Terms" },
+  ]);
+
+  const S = ({ n, title, children }: { n: number; title: string; children: React.ReactNode }) => (
+    <section className="bg-slate-50 border border-slate-200 rounded-xl p-5 md:p-6">
+      <h2 className="text-base md:text-lg font-bold text-slate-900 mb-2">{n}. {title}</h2>
+      <div className="text-sm text-slate-600 leading-relaxed space-y-2">{children}</div>
+    </section>
+  );
+
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbs) }} />
+      <div className="py-5 md:py-12">
+        <div className="container-custom max-w-3xl">
+          <div className="text-sm text-slate-500 mb-6">
+            <Link href="/" className="hover:text-slate-900">Home</Link>
+            <span className="mx-2">/</span>
+            <span className="text-slate-700">Developer & Agent Listing Terms</span>
+          </div>
+
+          <h1 className="text-2xl md:text-4xl font-extrabold mb-2">
+            Developer &amp; Buyer&apos;s Agent Listing Terms
+          </h1>
+          <p className="text-xs text-slate-400 mb-2">Version {VERSION} — Effective {EFFECTIVE_DATE}</p>
+          <p className="text-xs text-slate-400 mb-8">
+            {COMPANY_LEGAL_NAME} (ACN {COMPANY_ACN}, ABN {COMPANY_ABN})
+          </p>
+
+          <div className="bg-amber-50 border border-amber-200 rounded-xl p-4 mb-6">
+            <p className="text-xs text-amber-700">
+              This agreement governs your participation as a property developer or buyer&apos;s agent
+              on {SITE_NAME}. By submitting a listing or profile, you agree to these terms. These
+              terms are separate from the{" "}
+              <Link href="/advisor-terms" className="underline hover:text-amber-900">Advisor Services Agreement</Link>,
+              which governs financial professionals (financial advisers, mortgage brokers, accountants).
+            </p>
+          </div>
+
+          <div className="space-y-6">
+            <S n={1} title="Parties">
+              <p>
+                This agreement is between {COMPANY_LEGAL_NAME} (&quot;we&quot;, &quot;us&quot;,
+                &quot;Platform&quot;) and the property developer or buyer&apos;s agent
+                (&quot;you&quot;, &quot;Developer&quot;, &quot;Agent&quot;) who lists
+                on the {SITE_NAME} property vertical.
+              </p>
+            </S>
+
+            <S n={2} title="Nature of Service">
+              <p>
+                {SITE_NAME} is an information and comparison platform, not a real estate
+                agent or mortgage broker. We do not hold a real estate agent&apos;s licence
+                in any Australian state or territory. We provide:
+              </p>
+              <ul className="list-disc pl-5 space-y-1">
+                <li>A listing directory for new property developments and off-the-plan sales</li>
+                <li>A directory of buyer&apos;s agents for referral by consumers</li>
+                <li>Lead generation services (consumer enquiry forms)</li>
+                <li>Suburb research data and general property information</li>
+              </ul>
+              <p>
+                We do not act as your agent, represent buyers on your behalf, or participate
+                in any property transaction.
+              </p>
+            </S>
+
+            <S n={3} title="Developer Listing Requirements">
+              <p>
+                To list a property development on {SITE_NAME}, you must:
+              </p>
+              <ul className="list-disc pl-5 space-y-1">
+                <li>
+                  Be a licensed property developer or authorised sales representative
+                  in the relevant Australian state or territory.
+                </li>
+                <li>
+                  Provide accurate and complete information about each development,
+                  including indicative pricing, property type, completion date, and
+                  FIRB approval status where applicable.
+                </li>
+                <li>
+                  Immediately notify us of any material changes to listed information,
+                  including price changes, settlement delays, or project cancellations.
+                </li>
+                <li>
+                  Ensure that any off-the-plan sales comply with applicable state laws,
+                  including mandatory cooling-off periods and disclosure statement
+                  requirements.
+                </li>
+                <li>
+                  Not list developments that are not genuinely for sale or that have
+                  not received necessary planning approvals.
+                </li>
+              </ul>
+            </S>
+
+            <S n={4} title="Buyer's Agent Listing Requirements">
+              <p>
+                To list as a buyer&apos;s agent on {SITE_NAME}, you must:
+              </p>
+              <ul className="list-disc pl-5 space-y-1">
+                <li>
+                  Hold a valid real estate agent&apos;s licence (or buyer&apos;s agent
+                  licence where available) in each state or territory in which you
+                  operate. You must provide your licence number and it will be displayed
+                  on your profile.
+                </li>
+                <li>
+                  Have professional indemnity insurance appropriate to your business
+                  activities.
+                </li>
+                <li>
+                  Provide accurate information about your fee structure, areas of
+                  specialisation, and investment focus.
+                </li>
+                <li>
+                  Comply with all applicable state-based real estate legislation,
+                  including the Property and Stock Agents Act 2002 (NSW), Estate
+                  Agents Act 1980 (VIC), Property Occupations Act 2014 (QLD),
+                  and equivalent legislation in other states.
+                </li>
+              </ul>
+            </S>
+
+            <S n={5} title="Lead Handling &amp; Privacy">
+              <p>
+                Consumer enquiry leads delivered to you via {SITE_NAME} must be
+                handled in accordance with:
+              </p>
+              <ul className="list-disc pl-5 space-y-1">
+                <li>
+                  The <strong>Privacy Act 1988 (Cth)</strong> and the Australian Privacy
+                  Principles — you must have a privacy policy that covers how you handle
+                  personal information received from us.
+                </li>
+                <li>
+                  The <strong>Spam Act 2003 (Cth)</strong> — you may only contact leads
+                  for the purpose of the enquiry they submitted. You must not add leads
+                  to marketing lists without separate express consent.
+                </li>
+                <li>
+                  Leads must only be used to respond to the specific enquiry submitted.
+                  Sharing, selling, or licensing lead data to any third party is strictly
+                  prohibited.
+                </li>
+                <li>
+                  You must respond to leads within 2 business days. Persistent
+                  non-response may result in suspension from the platform.
+                </li>
+              </ul>
+            </S>
+
+            <S n={6} title="Fees &amp; Billing">
+              <p>
+                Listing fees, lead fees, and any promotional placement fees will be
+                set out in a separate fee schedule agreed between you and {SITE_NAME}.
+                We reserve the right to vary our fee schedule on 30 days&apos; written
+                notice. Fees are exclusive of GST unless otherwise stated.
+              </p>
+              <p>
+                <strong>No AFSL required for fees:</strong> Lead fees paid to us are
+                commercial referral fees between businesses and do not constitute
+                conflicted remuneration under the Future of Financial Advice (FOFA)
+                reforms, as we are not a financial services provider.
+              </p>
+            </S>
+
+            <S n={7} title="Content Standards">
+              <p>
+                All listing content, profile information, and marketing material you
+                provide must:
+              </p>
+              <ul className="list-disc pl-5 space-y-1">
+                <li>
+                  Be accurate and not misleading or deceptive under the Australian
+                  Consumer Law (ACL), including sections 18 and 29 of the Competition
+                  and Consumer Act 2010 (Cth).
+                </li>
+                <li>
+                  Comply with the Australian Competition and Consumer Commission (ACCC)
+                  guidelines on property advertising.
+                </li>
+                <li>
+                  Not make unsupported claims about investment returns, capital growth,
+                  or rental yields without appropriate qualification and data sources.
+                </li>
+                <li>
+                  Include all material information required by applicable state disclosure
+                  laws (e.g. vendor disclosure statements, off-the-plan contract
+                  requirements).
+                </li>
+              </ul>
+              <p>
+                We reserve the right to edit, remove, or reject any listing content
+                that does not meet these standards, without liability.
+              </p>
+            </S>
+
+            <S n={8} title="Sponsored Listings">
+              <p>
+                Sponsored or &quot;Featured&quot; placements are disclosed to consumers
+                as paid placements. Sponsored status does not affect the independent
+                editorial assessment of any listing. We will not remove or alter our
+                disclaimer disclosures as a condition of any commercial arrangement.
+              </p>
+            </S>
+
+            <S n={9} title="Warranties">
+              <p>You warrant and represent that:</p>
+              <ul className="list-disc pl-5 space-y-1">
+                <li>You hold all licences, registrations, and authorisations required to conduct your business.</li>
+                <li>All information you provide to us is accurate, complete, and not misleading.</li>
+                <li>You have the legal right to list the properties or services you advertise on our platform.</li>
+                <li>You will comply with all applicable Australian laws and regulations.</li>
+              </ul>
+            </S>
+
+            <S n={10} title="Indemnity">
+              <p>
+                You indemnify {COMPANY_LEGAL_NAME} against any claims, losses, damages,
+                costs (including legal costs on a solicitor-client basis), and expenses
+                arising from or in connection with:
+              </p>
+              <ul className="list-disc pl-5 space-y-1">
+                <li>Any breach of these Terms by you</li>
+                <li>Any inaccurate, misleading, or unlawful listing content you provide</li>
+                <li>Any claim by a consumer arising from your handling of a lead</li>
+                <li>Any breach of privacy or spam laws in connection with lead data</li>
+              </ul>
+            </S>
+
+            <S n={11} title="Termination">
+              <p>
+                Either party may terminate this agreement on 14 days&apos; written notice.
+                We may suspend or immediately terminate your listing if you:
+              </p>
+              <ul className="list-disc pl-5 space-y-1">
+                <li>Breach any of these Terms</li>
+                <li>Have your real estate licence suspended or cancelled</li>
+                <li>Engage in misleading or deceptive conduct</li>
+                <li>Receive repeated consumer complaints substantiated by us</li>
+              </ul>
+              <p>
+                Upon termination, your listing will be removed from the site. Lead data
+                already delivered to you remains subject to the obligations in Section 5.
+              </p>
+            </S>
+
+            <S n={12} title="Limitation of Liability">
+              <p>
+                To the maximum extent permitted by law, our liability to you is limited
+                to the fees paid to us in the 3 months preceding the claim. We are not
+                liable for any indirect, consequential, or special loss.
+              </p>
+              <p>
+                Nothing in this agreement excludes liability that cannot be excluded
+                under the Australian Consumer Law.
+              </p>
+            </S>
+
+            <S n={13} title="Governing Law &amp; Disputes">
+              <p>
+                This agreement is governed by the laws of the State of Victoria,
+                Australia. Any dispute must first be referred to good faith negotiation.
+                If unresolved within 30 days, either party may seek resolution through
+                the courts of Victoria.
+              </p>
+            </S>
+
+            <S n={14} title="Contact">
+              <p>
+                Questions about these terms or your listing? Email us at{" "}
+                <a href="mailto:partners@invest.com.au" className="underline hover:text-slate-900">
+                  partners@invest.com.au
+                </a>
+                .
+              </p>
+              <p className="text-xs text-slate-500">
+                {COMPANY_LEGAL_NAME} · ACN {COMPANY_ACN} · ABN {COMPANY_ABN}
+              </p>
+            </S>
+          </div>
+
+          <div className="mt-10 flex flex-wrap gap-4 text-sm text-slate-500 justify-center">
+            <Link href="/terms" className="underline hover:text-slate-700">Consumer Terms of Use</Link>
+            <Link href="/advisor-terms" className="underline hover:text-slate-700">Advisor Services Agreement</Link>
+            <Link href="/privacy" className="underline hover:text-slate-700">Privacy Policy</Link>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/fsg/page.tsx
+++ b/app/fsg/page.tsx
@@ -1,0 +1,191 @@
+import Link from "next/link";
+import {
+  COMPANY_LEGAL_NAME,
+  COMPANY_ACN,
+  COMPANY_ABN,
+  AFSL_STATUS_DISCLOSURE,
+  FSG_NOTE,
+} from "@/lib/compliance";
+
+export const metadata = {
+  title: "Financial Services Guide — Invest.com.au",
+  description:
+    "Why Invest.com.au does not issue a Financial Services Guide, and what this means for you as a user of our information service.",
+  alternates: { canonical: "/fsg" },
+};
+
+export default function FSGPage() {
+  return (
+    <div className="py-5 md:py-12">
+      <div className="container-custom max-w-3xl">
+        <div className="text-sm text-slate-500 mb-6">
+          <Link href="/" className="hover:text-slate-900">Home</Link>
+          <span className="mx-2">/</span>
+          <span className="text-slate-700">Financial Services Guide</span>
+        </div>
+
+        <h1 className="text-2xl md:text-4xl font-extrabold mb-2">
+          Financial Services Guide
+        </h1>
+        <p className="text-xs text-slate-400 mb-8">Last updated: 18 March 2026</p>
+
+        {/* Key callout */}
+        <div className="bg-amber-50 border border-amber-200 rounded-xl p-5 mb-8">
+          <div className="flex items-start gap-2">
+            <svg className="w-5 h-5 text-amber-500 shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            <div>
+              <p className="text-sm font-bold text-amber-800 mb-1">We do not issue a Financial Services Guide</p>
+              <p className="text-sm text-amber-700 leading-relaxed">
+                {COMPANY_LEGAL_NAME} (ACN {COMPANY_ACN}) does not hold an Australian
+                Financial Services Licence (AFSL) and does not provide personal financial
+                advice. We are an information and comparison service. Under the Corporations
+                Act 2001, we are not required to issue an FSG.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="space-y-6 text-sm text-slate-600 leading-relaxed">
+
+          <section>
+            <h2 className="text-lg font-bold text-slate-900 mb-2">What is a Financial Services Guide?</h2>
+            <p>
+              A Financial Services Guide (FSG) is a document that Australian Financial
+              Services Licence (AFSL) holders are required to give to retail clients
+              before providing financial services. An FSG describes:
+            </p>
+            <ul className="list-disc pl-5 mt-2 space-y-1">
+              <li>What financial services the licensee provides</li>
+              <li>How the licensee is remunerated</li>
+              <li>The licensee&apos;s dispute resolution process</li>
+              <li>How to contact the licensee</li>
+            </ul>
+            <p className="mt-2">
+              The obligation to provide an FSG arises under section 941A of the
+              Corporations Act 2001 (Cth) and applies to holders of an AFSL.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-bold text-slate-900 mb-2">Why We Don&apos;t Issue One</h2>
+            <p>
+              {AFSL_STATUS_DISCLOSURE}
+            </p>
+            <p className="mt-2">
+              Because we do not hold an AFSL, we are not required to issue an FSG to
+              users. Our site operates as a general information and comparison service.
+              We do not:
+            </p>
+            <ul className="list-disc pl-5 mt-2 space-y-1">
+              <li>Provide personal financial advice tailored to your individual circumstances</li>
+              <li>Issue, arrange, or deal in financial products</li>
+              <li>Operate as a licensed mortgage broker or credit representative</li>
+              <li>Hold client money or assets</li>
+            </ul>
+            <p className="mt-2">
+              Our advisor matching tool and quiz match users with professionals based on
+              their general preferences. This is a referral service, not personal
+              financial advice. The matched advisors are independent professionals who
+              hold their own AFSL or operate under an AFSL.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-bold text-slate-900 mb-2">What You Should Request From Providers</h2>
+            <p>{FSG_NOTE}</p>
+            <p className="mt-2">
+              When engaging with any financial adviser, mortgage broker, or financial
+              product provider introduced through this site, you should:
+            </p>
+            <ul className="list-disc pl-5 mt-2 space-y-1">
+              <li>
+                <strong>Request their FSG</strong> — which details their services,
+                fees, and how they are remunerated
+              </li>
+              <li>
+                <strong>Request a Statement of Advice (SOA)</strong> if they provide
+                you with personal financial advice
+              </li>
+              <li>
+                <strong>Verify their AFSL</strong> — check the ASIC Professional
+                Registers at{" "}
+                <a
+                  href="https://moneysmart.gov.au/financial-advice/financial-advisers-register"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline hover:text-slate-900"
+                >
+                  moneysmart.gov.au
+                </a>
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-bold text-slate-900 mb-2">How We Are Remunerated</h2>
+            <p>
+              We earn revenue through affiliate commissions from financial platforms,
+              per-enquiry referral fees from listed advisors and property developers,
+              and display advertising. We disclose our commercial relationships on every
+              page of the site and in our{" "}
+              <Link href="/how-we-earn" className="underline hover:text-slate-900">
+                How We Earn
+              </Link>{" "}
+              page. Commercial arrangements do not influence our independent editorial
+              ratings or reviews.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-bold text-slate-900 mb-2">Complaints &amp; Disputes</h2>
+            <p>
+              If you have a concern about how we have handled your information or enquiry,
+              contact us at{" "}
+              <a href="mailto:hello@invest.com.au" className="underline hover:text-slate-900">
+                hello@invest.com.au
+              </a>
+              . We aim to respond within 5 business days.
+            </p>
+            <p className="mt-2">
+              If you have a complaint about a financial product, service, or advice
+              provided by a licensed professional you found through this site, contact
+              that provider directly. If unresolved, you can lodge a complaint with the{" "}
+              <a
+                href="https://www.afca.org.au"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline hover:text-slate-900"
+              >
+                Australian Financial Complaints Authority (AFCA)
+              </a>{" "}
+              at 1800 931 678 or afca.org.au.
+            </p>
+            <p className="mt-2">
+              See our <Link href="/complaints" className="underline hover:text-slate-900">Complaints page</Link> for full details.
+            </p>
+          </section>
+
+          <section className="bg-slate-50 border border-slate-200 rounded-xl p-5">
+            <h2 className="text-base font-bold text-slate-900 mb-2">Company Details</h2>
+            <p>{COMPANY_LEGAL_NAME}</p>
+            <p>ACN {COMPANY_ACN} · ABN {COMPANY_ABN}</p>
+            <p>
+              Email:{" "}
+              <a href="mailto:hello@invest.com.au" className="underline hover:text-slate-900">
+                hello@invest.com.au
+              </a>
+            </p>
+            <div className="mt-3 pt-3 border-t border-slate-200 flex flex-wrap gap-3 text-xs">
+              <Link href="/terms" className="underline hover:text-slate-900">Terms of Use</Link>
+              <Link href="/privacy" className="underline hover:text-slate-900">Privacy Policy</Link>
+              <Link href="/how-we-earn" className="underline hover:text-slate-900">How We Earn</Link>
+              <Link href="/complaints" className="underline hover:text-slate-900">Complaints</Link>
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -13,7 +13,7 @@ export default function PrivacyPage() {
       <div className="container-custom max-w-3xl">
         <h1 className="text-3xl font-extrabold mb-2">Privacy Policy</h1>
         <p className="text-sm text-slate-500 mb-8">
-          Version 1.1 — Last updated: 18 March 2026
+          Version 1.2 — Last updated: 18 March 2026
         </p>
 
         <div className="prose prose-slate max-w-none text-sm leading-relaxed space-y-6">
@@ -45,7 +45,7 @@ export default function PrivacyPage() {
                 PDF).
               </li>
               <li>
-                <strong>Name, email, and phone number</strong> — when you submit
+                <strong>Name, email, phone number, country of residence, investment budget, and purchase timeline</strong> — when you submit
                 an enquiry form (e.g. property enquiry, buyer&apos;s agent
                 contact, advisor matching). This data is shared with the
                 specific provider you enquired about.
@@ -97,10 +97,12 @@ export default function PrivacyPage() {
               </li>
               <li>
                 <strong>Property enquiries:</strong> If you submit an enquiry about a
-                property listing or buyer&apos;s agent, your name, email, phone (if
-                provided), budget, timeline, and message are shared with the relevant
-                developer or agent. Your details are shared only with the provider you
-                enquired about.
+                property listing, your name, email, phone (if provided), country of
+                residence, investment budget, purchase timeline, and message are shared
+                with the specific property developer for that listing. If you contact a
+                buyer&apos;s agent, your details are shared with that agent only.
+                Your details are shared only with the provider you enquired about and
+                are not sold or passed to other parties.
               </li>
               <li>
                 To improve our website, content, and user experience through
@@ -201,11 +203,60 @@ export default function PrivacyPage() {
                 affiliate link, the partner may set their own cookies. We do not
                 share your email or personal data with affiliate partners.
               </li>
+              <li>
+                <strong>Advisors and financial professionals</strong> — when you
+                submit an advisor enquiry, your contact details are shared with
+                the specific advisor you selected.
+              </li>
+              <li>
+                <strong>Property developers and buyer&apos;s agents</strong> — when
+                you submit a property enquiry, your contact details are shared
+                with the specific developer or agent you enquired about. We
+                require all listed parties to handle your data in accordance with
+                applicable privacy laws.
+              </li>
             </ul>
           </section>
 
           <section>
-            <h2 className="text-lg font-bold mb-2">7. Data Security</h2>
+            <h2 className="text-lg font-bold mb-2">
+              7. User-Generated Content (Reviews &amp; Articles)
+            </h2>
+            <p className="text-slate-600 mb-2">
+              Our site allows users to submit reviews of advisors and financial
+              platforms, and allows verified advisors to publish articles.
+            </p>
+            <ul className="list-disc pl-5 text-slate-600 space-y-1">
+              <li>
+                <strong>Reviews:</strong> If you submit a review, your display
+                name (or &quot;Anonymous&quot; if you choose) and the content of
+                your review may be published publicly. We store your email
+                address to verify the review and for moderation purposes — it
+                is not published.
+              </li>
+              <li>
+                <strong>Advisor articles:</strong> Articles published by advisors
+                include the advisor&apos;s name and firm. We retain authorship
+                records for editorial purposes.
+              </li>
+              <li>
+                <strong>Moderation:</strong> We reserve the right to moderate,
+                edit, or remove user-submitted content that violates our content
+                standards or applicable law.
+              </li>
+              <li>
+                <strong>Deletion requests:</strong> You may request removal of
+                your review by contacting{" "}
+                <a href="mailto:privacy@invest.com.au" className="underline">
+                  privacy@invest.com.au
+                </a>
+                .
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-bold mb-2">8. Data Security</h2>
             <p className="text-slate-600">
               We take reasonable steps to protect your personal information from
               misuse, interference, loss, and unauthorised access. Email
@@ -218,7 +269,7 @@ export default function PrivacyPage() {
 
           <section>
             <h2 className="text-lg font-bold mb-2">
-              8. Your Rights Under the Privacy Act
+              9. Your Rights Under the Privacy Act
             </h2>
             <p className="text-slate-600 mb-2">
               Under the Australian Privacy Act 1988, you have the right to:
@@ -255,7 +306,7 @@ export default function PrivacyPage() {
 
           <section>
             <h2 className="text-lg font-bold mb-2">
-              9. Email Communications (Spam Act 2003)
+              10. Email Communications (Spam Act 2003)
             </h2>
             <p className="text-slate-600">
               All commercial electronic messages sent by Invest.com.au comply
@@ -270,7 +321,7 @@ export default function PrivacyPage() {
 
           <section>
             <h2 className="text-lg font-bold mb-2">
-              10. Changes to This Policy
+              11. Changes to This Policy
             </h2>
             <p className="text-slate-600">
               We may update this Privacy Policy from time to time. Any changes
@@ -281,7 +332,7 @@ export default function PrivacyPage() {
           </section>
 
           <section>
-            <h2 className="text-lg font-bold mb-2">11. Contact Us</h2>
+            <h2 className="text-lg font-bold mb-2">12. Contact Us</h2>
             <p className="text-slate-600">
               If you have any questions about this Privacy Policy, or wish to
               make a complaint about how we have handled your personal

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -20,6 +20,13 @@ export default function TermsPage() {
     { name: "Terms of Use" },
   ]);
 
+  const S = ({ n, title, children }: { n: number; title: string; children: React.ReactNode }) => (
+    <section className="bg-slate-50 border border-slate-200 rounded-xl p-6">
+      <h2 className="text-lg font-bold mb-2">{n}. {title}</h2>
+      <div className="text-sm text-slate-600 leading-relaxed space-y-2">{children}</div>
+    </section>
+  );
+
   return (
     <>
       <script
@@ -29,142 +36,172 @@ export default function TermsPage() {
       <div className="py-5 md:py-12">
         <div className="container-custom">
           <div className="max-w-3xl mx-auto">
-            {/* Breadcrumb */}
             <div className="text-sm text-slate-500 mb-6">
-              <Link href="/" className="hover:text-brand">
-                Home
-              </Link>
+              <Link href="/" className="hover:text-brand">Home</Link>
               <span className="mx-2">/</span>
               <span className="text-brand">Terms of Use</span>
             </div>
 
             <h1 className="text-2xl md:text-4xl font-extrabold mb-2">Terms of Use</h1>
-            <p className="text-xs text-slate-400 mb-8">Version 1.0 — Last updated 10 March 2026</p>
+            <p className="text-xs text-slate-400 mb-8">Version 1.1 — Last updated 18 March 2026</p>
 
             <div className="space-y-6">
-              {/* 1. Scope of Service */}
-              <section className="bg-slate-50 border border-slate-200 rounded-xl p-6">
-                <h2 className="text-lg font-bold mb-2">1. Scope of Service</h2>
-                <p className="text-sm text-slate-600 leading-relaxed">
+              <S n={1} title="Scope of Service">
+                <p>
                   {COMPANY_LEGAL_NAME} (ACN {COMPANY_ACN}, ABN {COMPANY_ABN}),
                   trading as {SITE_NAME}, is an information service that provides
                   comparisons, reviews, and educational content about Australian
-                  investment platforms. We are not a financial product issuer,
-                  credit provider, or financial adviser.
+                  investment platforms, financial advisors, and property investment.
+                  We are not a financial product issuer, credit provider, financial
+                  adviser, mortgage broker, or real estate agent.
                 </p>
-              </section>
+              </S>
 
-              {/* 2. General Advice Warning */}
-              <section className="bg-slate-50 border border-slate-200 rounded-xl p-6">
-                <h2 className="text-lg font-bold mb-2">
-                  2. General Advice Warning
-                </h2>
-                <p className="text-sm text-slate-600 leading-relaxed">
-                  {GENERAL_ADVICE_WARNING}
+              <S n={2} title="General Advice Warning">
+                <p>{GENERAL_ADVICE_WARNING}</p>
+              </S>
+
+              <S n={3} title="Accuracy &amp; Completeness">
+                <p>
+                  While we strive to keep all information accurate and up to date, we
+                  cannot guarantee the completeness or accuracy of information on this
+                  site. Suburb data, property prices, loan rates, and platform fee data
+                  are indicative only and subject to change. Always verify information
+                  with the product issuer, developer, or lender before making a
+                  decision.
                 </p>
-              </section>
+              </S>
 
-              {/* 3. Accuracy & Completeness */}
-              <section className="bg-slate-50 border border-slate-200 rounded-xl p-6">
-                <h2 className="text-lg font-bold mb-2">
-                  3. Accuracy &amp; Completeness
-                </h2>
-                <p className="text-sm text-slate-600 leading-relaxed">
-                  While we strive to keep all information accurate and up to
-                  date, we cannot guarantee the completeness or accuracy of
-                  information on this site. Fee data is verified periodically
-                  &mdash; see our{" "}
-                  <Link
-                    href="/about"
-                    className="text-slate-700 hover:text-slate-900 underline"
-                  >
-                    verification process
-                  </Link>
-                  . Always verify information with the product issuer before
-                  making a decision.
-                </p>
-              </section>
+              <S n={4} title="Affiliate Relationships">
+                <p>{ADVERTISER_DISCLOSURE}</p>
+              </S>
 
-              {/* 4. Affiliate Relationships */}
-              <section className="bg-slate-50 border border-slate-200 rounded-xl p-6">
-                <h2 className="text-lg font-bold mb-2">
-                  4. Affiliate Relationships
-                </h2>
-                <p className="text-sm text-slate-600 leading-relaxed">
-                  {ADVERTISER_DISCLOSURE}
-                </p>
-              </section>
-
-              {/* 5. Limitation of Liability */}
-              <section className="bg-slate-50 border border-slate-200 rounded-xl p-6">
-                <h2 className="text-lg font-bold mb-2">
-                  5. Limitation of Liability
-                </h2>
-                <p className="text-sm text-slate-600 leading-relaxed">
+              <S n={5} title="Limitation of Liability">
+                <p>
                   To the maximum extent permitted by law, {SITE_NAME} and its
                   contributors shall not be liable for any loss or damage arising
                   from your use of this site or reliance on information contained
-                  herein.
+                  herein, including investment losses, property transaction losses,
+                  or decisions made based on comparison data, suburb statistics,
+                  or advisor referrals.
                 </p>
-              </section>
+                <p className="text-xs text-slate-500 border-l-2 border-amber-300 pl-3 mt-2">
+                  <strong>Australian Consumer Law:</strong> Nothing in these Terms
+                  excludes, restricts, or modifies any right or remedy, or any
+                  guarantee, warranty, or other term or condition, implied or imposed
+                  by the Australian Consumer Law (Schedule 2 to the Competition and
+                  Consumer Act 2010 (Cth)) that cannot lawfully be excluded or
+                  limited. Our liability for a failure to comply with a consumer
+                  guarantee under the Australian Consumer Law is limited, to the
+                  extent permitted by law, to re-supplying the services or paying
+                  the cost of having the services re-supplied.
+                </p>
+              </S>
 
-              {/* 6. User Responsibilities */}
-              <section className="bg-slate-50 border border-slate-200 rounded-xl p-6">
-                <h2 className="text-lg font-bold mb-2">
-                  6. User Responsibilities
-                </h2>
-                <p className="text-sm text-slate-600 mb-2 leading-relaxed">
-                  By using this site, you agree to:
-                </p>
-                <ul className="list-disc pl-5 text-sm text-slate-600 space-y-1 leading-relaxed">
+              <S n={6} title="User Responsibilities">
+                <p>By using this site, you agree to:</p>
+                <ul className="list-disc pl-5 space-y-1">
                   <li>Use the site for lawful purposes only.</li>
                   <li>
-                    Not scrape, reproduce, or redistribute content without
-                    written permission.
+                    Not scrape, reproduce, or redistribute content without written
+                    permission.
                   </li>
                   <li>
-                    Verify information independently with the product issuer
-                    before making financial decisions.
+                    Verify information independently with the product issuer before
+                    making financial decisions.
                   </li>
                 </ul>
-              </section>
+              </S>
 
-              {/* 7. Intellectual Property */}
-              <section className="bg-slate-50 border border-slate-200 rounded-xl p-6">
-                <h2 className="text-lg font-bold mb-2">
-                  7. Intellectual Property
-                </h2>
-                <p className="text-sm text-slate-600 leading-relaxed">
-                  All content, design, and branding on this site is owned by{" "}
-                  {SITE_NAME}. You may not reproduce, distribute, or create
-                  derivative works from any material on this site without our
-                  prior written consent.
+              <S n={7} title="User-Generated Content">
+                <p>
+                  This site allows users to submit reviews of financial advisors
+                  and platforms, and allows verified advisors to publish articles
+                  (&quot;User Content&quot;). By submitting User Content, you:
                 </p>
-              </section>
-
-              {/* 8. Governing Law */}
-              <section className="bg-slate-50 border border-slate-200 rounded-xl p-6">
-                <h2 className="text-lg font-bold mb-2">8. Governing Law</h2>
-                <p className="text-sm text-slate-600 leading-relaxed">
-                  These terms are governed by the laws of Australia.
+                <ul className="list-disc pl-5 space-y-1">
+                  <li>
+                    <strong>Grant us a licence</strong> to publish, display, edit,
+                    and remove your User Content for the purposes of operating and
+                    improving the site.
+                  </li>
+                  <li>
+                    <strong>Warrant</strong> that your User Content is truthful,
+                    based on genuine experience, not defamatory, and does not
+                    infringe any third-party rights (including intellectual property
+                    rights).
+                  </li>
+                  <li>
+                    <strong>Acknowledge</strong> that we may moderate, edit, or
+                    remove User Content at our discretion, including content that
+                    is misleading, offensive, or in breach of these Terms.
+                  </li>
+                  <li>
+                    <strong>Understand</strong> that reviews must reflect a genuine
+                    experience with the reviewed advisor or platform, and that
+                    submitting false or incentivised reviews may constitute misleading
+                    conduct under the Australian Consumer Law.
+                  </li>
+                </ul>
+                <p>
+                  We do not endorse or take responsibility for User Content and
+                  accept no liability for any errors or omissions in reviews or
+                  advisor-published articles.
                 </p>
-              </section>
+              </S>
 
-              {/* 9. Changes to Terms */}
-              <section className="bg-slate-50 border border-slate-200 rounded-xl p-6">
-                <h2 className="text-lg font-bold mb-2">
-                  9. Changes to Terms
-                </h2>
-                <p className="text-sm text-slate-600 leading-relaxed">
-                  We may update these terms from time to time. Continued use of
-                  the site constitutes acceptance of any changes.
+              <S n={8} title="Intellectual Property">
+                <p>
+                  All original content, design, and branding on this site is owned
+                  by {SITE_NAME}. You may not reproduce, distribute, or create
+                  derivative works from any material on this site without our prior
+                  written consent. User Content remains the property of the
+                  submitting user, subject to the licence granted in Section 7.
                 </p>
-              </section>
+              </S>
 
-              {/* 10. Contact */}
-              <section className="bg-slate-50 border border-slate-200 rounded-xl p-6">
-                <h2 className="text-lg font-bold mb-2">10. Contact</h2>
-                <p className="text-sm text-slate-600 leading-relaxed">
+              <S n={9} title="Governing Law &amp; Dispute Resolution">
+                <p>
+                  These Terms are governed by the laws of the State of Victoria,
+                  Australia. You agree to submit to the non-exclusive jurisdiction
+                  of the courts of Victoria.
+                </p>
+                <p>
+                  <strong>Dispute resolution:</strong> Before commencing legal
+                  proceedings, you agree to contact us at{" "}
+                  <a href="mailto:hello@invest.com.au" className="underline hover:text-slate-900">
+                    hello@invest.com.au
+                  </a>{" "}
+                  to attempt to resolve the dispute in good faith. If the dispute
+                  cannot be resolved within 30 days, either party may seek
+                  resolution through the courts of Victoria.
+                </p>
+                <p>
+                  If you are a consumer with a complaint about a financial product
+                  recommended or compared on this site, you may also contact the
+                  Australian Financial Complaints Authority (AFCA) at{" "}
+                  <a href="https://www.afca.org.au" target="_blank" rel="noopener noreferrer" className="underline hover:text-slate-900">
+                    afca.org.au
+                  </a>{" "}
+                  or 1800 931 678. See our{" "}
+                  <Link href="/complaints" className="underline hover:text-slate-900">
+                    Complaints &amp; AFCA page
+                  </Link>
+                  .
+                </p>
+              </S>
+
+              <S n={10} title="Changes to Terms">
+                <p>
+                  We may update these terms from time to time. Any material changes
+                  will be posted on this page with an updated &quot;Last
+                  updated&quot; date. Continued use of the site after changes
+                  constitutes acceptance of the updated Terms.
+                </p>
+              </S>
+
+              <S n={11} title="Contact">
+                <p>
                   Questions about these terms? Email us at{" "}
                   <a
                     href="mailto:hello@invest.com.au"
@@ -174,10 +211,12 @@ export default function TermsPage() {
                   </a>
                   .
                 </p>
-              </section>
+                <p className="text-xs text-slate-500">
+                  {COMPANY_LEGAL_NAME} · ACN {COMPANY_ACN} · ABN {COMPANY_ABN}
+                </p>
+              </S>
             </div>
 
-            {/* Privacy Policy Link */}
             <div className="mt-10 text-center">
               <Link
                 href="/privacy"

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -9,7 +9,6 @@ const sections = [
   { title: "Financial Services Guide", content: FSG_NOTE },
   { title: "Crypto Warning", content: CRYPTO_WARNING },
   { title: "Regulatory Note", content: REGULATORY_NOTE },
-  { title: "AFSL Status", content: AFSL_STATUS_DISCLOSURE },
 ];
 
 export default function Footer() {
@@ -37,11 +36,21 @@ export default function Footer() {
                   <p className="text-[0.62rem] md:text-[0.69rem] text-slate-500 leading-relaxed mt-1.5">
                     Consider your objectives, financial situation and needs before acting. See our{" "}
                     <Link href="/terms" className="underline hover:text-slate-700">Terms of Use</Link>,{" "}
-                    <Link href="/privacy" className="underline hover:text-slate-700">Privacy Policy</Link>, and{" "}
-                    <Link href="/how-we-earn" className="underline hover:text-slate-700">How We Earn</Link>.
+                    <Link href="/privacy" className="underline hover:text-slate-700">Privacy Policy</Link>,{" "}
+                    <Link href="/how-we-earn" className="underline hover:text-slate-700">How We Earn</Link>, and{" "}
+                    <Link href="/fsg" className="underline hover:text-slate-700">FSG</Link>.
                   </p>
                 </div>
               </div>
+            </div>
+
+            {/* AFSL Status — always visible per ASIC requirements */}
+            <div className="border-t border-slate-200 py-2 md:py-3">
+              <p className="text-[0.62rem] md:text-xs font-semibold text-slate-500 mb-0.5">AFSL &amp; Licensing Status</p>
+              <p className="text-[0.62rem] md:text-xs text-slate-500 leading-relaxed">
+                {AFSL_STATUS_DISCLOSURE}{" "}
+                <Link href="/fsg" className="underline hover:text-slate-700">Financial Services Guide →</Link>
+              </p>
             </div>
 
             {sections.map((section, i) => (
@@ -143,7 +152,9 @@ export default function Footer() {
                 <li><Link href="/privacy" className="hover:text-white transition-colors inline-block py-0.5">Privacy</Link></li>
                 <li><Link href="/methodology" className="hover:text-white transition-colors inline-block py-0.5">Methodology</Link></li>
                 <li><Link href="/terms" className="hover:text-white transition-colors inline-block py-0.5">Terms</Link></li>
+                <li><Link href="/fsg" className="hover:text-white transition-colors inline-block py-0.5">FSG</Link></li>
                 <li><Link href="/advisor-terms" className="hover:text-white transition-colors inline-block py-0.5">Advisor Terms</Link></li>
+                <li><Link href="/developer-terms" className="hover:text-white transition-colors inline-block py-0.5">Developer Terms</Link></li>
                 <li><Link href="/broker-terms" className="hover:text-white transition-colors inline-block py-0.5">Advertiser Terms</Link></li>
                 <li><Link href="/complaints" className="hover:text-white transition-colors inline-block py-0.5">Complaints & AFCA</Link></li>
                 <li><Link href="/contact" className="hover:text-white transition-colors inline-block py-0.5">Contact</Link></li>


### PR DESCRIPTION
## Summary
- Privacy Policy v1.2: country/budget/timeline data types, UGC section, property developer disclosure
- Terms of Use v1.1: ACL carve-out, UGC licence/warranty section, governing law = Victoria, dispute resolution
- New /fsg page explaining why no FSG is issued
- Footer: AFSL status always visible (not behind toggle), FSG link added
- New /developer-terms: 14-section agreement for property developers and buyer agents
- Placeholder PO Box removed from all 3 B2B agreements