### PR TITLE
feat: firm team management — invite acceptance, profile editing, role…

### DIFF
--- a/app/advisor-apply/page.tsx
+++ b/app/advisor-apply/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect, Suspense } from "react";
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
 import Icon from "@/components/Icon";
 import { PROFESSIONAL_TYPE_LABELS } from "@/lib/types";
 
@@ -41,7 +42,22 @@ function resizeImage(file: File): Promise<Blob> {
   });
 }
 
-export default function AdvisorApplyPage() {
+type InviteContext = {
+  email: string;
+  name: string | null;
+  firmName: string | null;
+  firmId: number;
+  role: string;
+};
+
+function AdvisorApplyInner() {
+  const searchParams = useSearchParams();
+  const inviteToken = searchParams.get("invite");
+
+  const [inviteContext, setInviteContext] = useState<InviteContext | null>(null);
+  const [inviteError, setInviteError] = useState("");
+  const [inviteLoading, setInviteLoading] = useState(!!inviteToken);
+
   const [accountType, setAccountType] = useState<"individual" | "firm">("individual");
   const [form, setForm] = useState({
     name: "", firm_name: "", email: "", phone: "", type: "financial_planner",
@@ -59,6 +75,31 @@ export default function AdvisorApplyPage() {
   const [photoError, setPhotoError] = useState("");
   const [photoUploading, setPhotoUploading] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Load invite context if token present
+  useEffect(() => {
+    if (!inviteToken) return;
+    setInviteLoading(true);
+    fetch(`/api/advisor-apply/invite?token=${inviteToken}`)
+      .then(async (res) => {
+        if (!res.ok) {
+          const d = await res.json();
+          setInviteError(d.error || "Invalid invitation");
+          return;
+        }
+        const data: InviteContext = await res.json();
+        setInviteContext(data);
+        // Pre-fill email and name from invitation
+        setForm(f => ({
+          ...f,
+          email: data.email || f.email,
+          name: data.name || f.name,
+        }));
+        setAccountType("firm");
+      })
+      .catch(() => setInviteError("Failed to load invitation. Please try again."))
+      .finally(() => setInviteLoading(false));
+  }, [inviteToken]);
 
   const handlePhotoSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -120,13 +161,17 @@ export default function AdvisorApplyPage() {
       setErrorMsg("Name, email, and advisor type are required.");
       return;
     }
-    if (accountType === "firm" && !form.firm_name) {
+    if (accountType === "firm" && !inviteToken && !form.firm_name) {
       setErrorMsg("Firm name is required for firm applications.");
       return;
     }
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
     if (!emailRegex.test(form.email)) {
       setErrorMsg("Please enter a valid email address.");
+      return;
+    }
+    if (inviteContext && form.email.toLowerCase() !== inviteContext.email.toLowerCase()) {
+      setErrorMsg(`This invitation was sent to ${inviteContext.email}. Please use that email address.`);
       return;
     }
     if (!photoFile) {
@@ -136,7 +181,6 @@ export default function AdvisorApplyPage() {
     setStatus("submitting");
     setErrorMsg("");
     try {
-      // Upload photo first
       const photoUrl = await uploadPhoto();
       if (!photoUrl) {
         setErrorMsg("Photo upload failed. Please try again.");
@@ -144,10 +188,19 @@ export default function AdvisorApplyPage() {
         return;
       }
 
+      const payload: Record<string, unknown> = {
+        ...form,
+        account_type: accountType,
+        photo_url: photoUrl,
+      };
+      if (inviteToken) {
+        payload.invite_token = inviteToken;
+      }
+
       const res = await fetch("/api/advisor-apply", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ ...form, account_type: accountType, photo_url: photoUrl }),
+        body: JSON.stringify(payload),
       });
       if (res.ok) {
         setStatus("success");
@@ -162,6 +215,32 @@ export default function AdvisorApplyPage() {
     }
   };
 
+  // Loading state while looking up invite
+  if (inviteLoading) {
+    return (
+      <div className="py-20 text-center">
+        <div className="w-8 h-8 border-2 border-slate-300 border-t-violet-600 rounded-full animate-spin mx-auto mb-3" />
+        <p className="text-sm text-slate-500">Loading invitation...</p>
+      </div>
+    );
+  }
+
+  // Invalid invite token
+  if (inviteToken && inviteError) {
+    return (
+      <div className="py-12 md:py-20">
+        <div className="container-custom max-w-lg text-center">
+          <div className="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center mx-auto mb-4">
+            <Icon name="x" size={32} className="text-red-600" />
+          </div>
+          <h1 className="text-2xl font-extrabold text-slate-900 mb-2">Invitation Problem</h1>
+          <p className="text-slate-500 mb-6">{inviteError}</p>
+          <Link href="/advisor-apply" className="text-sm text-violet-600 hover:text-violet-700 font-semibold">Apply without an invitation →</Link>
+        </div>
+      </div>
+    );
+  }
+
   if (status === "success") {
     return (
       <div className="py-12 md:py-20">
@@ -170,12 +249,19 @@ export default function AdvisorApplyPage() {
             <Icon name="check" size={32} className="text-emerald-600" />
           </div>
           <h1 className="text-2xl font-extrabold text-slate-900 mb-2">Application Submitted!</h1>
-          <p className="text-slate-500 mb-6">We&apos;ll review your credentials and get back to you within 48 hours. Check your email for confirmation.</p>
+          <p className="text-slate-500 mb-6">
+            {inviteContext
+              ? `Your application to join ${inviteContext.firmName} has been submitted. We'll review your credentials and get back to you within 48 hours.`
+              : "We'll review your credentials and get back to you within 48 hours. Check your email for confirmation."
+            }
+          </p>
           <Link href="/advisors" className="text-sm text-amber-600 hover:text-amber-700 font-semibold">&larr; Back to Advisor Directory</Link>
         </div>
       </div>
     );
   }
+
+  const isInviteFlow = !!inviteContext;
 
   return (
     <div className="py-5 md:py-12">
@@ -188,13 +274,31 @@ export default function AdvisorApplyPage() {
           <span className="text-slate-700">Apply</span>
         </nav>
 
+        {/* Invite banner */}
+        {isInviteFlow && (
+          <div className="bg-violet-50 border border-violet-200 rounded-xl p-4 mb-5 flex items-center gap-3">
+            <div className="w-10 h-10 bg-violet-100 rounded-full flex items-center justify-center shrink-0">
+              <Icon name="users" size={18} className="text-violet-600" />
+            </div>
+            <div>
+              <p className="text-sm font-bold text-violet-900">You&apos;ve been invited to join {inviteContext.firmName}</p>
+              <p className="text-xs text-violet-600 mt-0.5">Complete your profile below to accept the invitation and join the team.</p>
+            </div>
+          </div>
+        )}
+
         {/* Hero */}
         <div className="bg-gradient-to-br from-violet-600 to-violet-800 rounded-2xl p-5 md:p-8 mb-6 md:mb-8 text-white relative overflow-hidden">
           <div className="absolute inset-0 bg-[radial-gradient(circle_at_bottom_left,rgba(255,255,255,0.1),transparent_60%)]" />
           <div className="relative">
-            <h1 className="text-xl md:text-3xl font-extrabold mb-2">Get Listed on Invest.com.au</h1>
+            <h1 className="text-xl md:text-3xl font-extrabold mb-2">
+              {isInviteFlow ? `Join ${inviteContext.firmName}` : "Get Listed on Invest.com.au"}
+            </h1>
             <p className="text-sm md:text-base text-violet-200 mb-4 leading-relaxed max-w-lg">
-              Join our advisor directory and connect with Australian investors looking for professional advice.
+              {isInviteFlow
+                ? `Complete your profile to join the ${inviteContext.firmName} team on Invest.com.au.`
+                : "Join our advisor directory and connect with Australian investors looking for professional advice."
+              }
             </p>
             <div className="grid grid-cols-3 gap-2 md:gap-3">
               {[
@@ -214,26 +318,28 @@ export default function AdvisorApplyPage() {
 
         <div className="bg-white border border-slate-200 rounded-xl p-5 md:p-6">
           <div className="space-y-4">
-            {/* Account Type Selector */}
-            <div>
-              <label className="block text-xs font-semibold text-slate-600 mb-2">I&apos;m applying as *</label>
-              <div className="grid grid-cols-2 gap-3">
-                <button type="button" onClick={() => setAccountType("individual")} className={`p-3 rounded-lg border-2 text-left transition-all ${accountType === "individual" ? "border-slate-900 bg-slate-50" : "border-slate-200 hover:border-slate-300"}`}>
-                  <div className="flex items-center gap-2 mb-1">
-                    <Icon name="user" size={16} className={accountType === "individual" ? "text-slate-900" : "text-slate-400"} />
-                    <span className="text-sm font-bold text-slate-900">Individual Advisor</span>
-                  </div>
-                  <p className="text-[0.62rem] text-slate-500">Solo practitioner or authorised rep</p>
-                </button>
-                <button type="button" onClick={() => setAccountType("firm")} className={`p-3 rounded-lg border-2 text-left transition-all ${accountType === "firm" ? "border-slate-900 bg-slate-50" : "border-slate-200 hover:border-slate-300"}`}>
-                  <div className="flex items-center gap-2 mb-1">
-                    <Icon name="building" size={16} className={accountType === "firm" ? "text-slate-900" : "text-slate-400"} />
-                    <span className="text-sm font-bold text-slate-900">Firm / Brokerage</span>
-                  </div>
-                  <p className="text-[0.62rem] text-slate-500">Register your firm & invite team members</p>
-                </button>
+            {/* Account Type Selector — hidden in invite flow */}
+            {!isInviteFlow && (
+              <div>
+                <label className="block text-xs font-semibold text-slate-600 mb-2">I&apos;m applying as *</label>
+                <div className="grid grid-cols-2 gap-3">
+                  <button type="button" onClick={() => setAccountType("individual")} className={`p-3 rounded-lg border-2 text-left transition-all ${accountType === "individual" ? "border-slate-900 bg-slate-50" : "border-slate-200 hover:border-slate-300"}`}>
+                    <div className="flex items-center gap-2 mb-1">
+                      <Icon name="user" size={16} className={accountType === "individual" ? "text-slate-900" : "text-slate-400"} />
+                      <span className="text-sm font-bold text-slate-900">Individual Advisor</span>
+                    </div>
+                    <p className="text-[0.62rem] text-slate-500">Solo practitioner or authorised rep</p>
+                  </button>
+                  <button type="button" onClick={() => setAccountType("firm")} className={`p-3 rounded-lg border-2 text-left transition-all ${accountType === "firm" ? "border-slate-900 bg-slate-50" : "border-slate-200 hover:border-slate-300"}`}>
+                    <div className="flex items-center gap-2 mb-1">
+                      <Icon name="building" size={16} className={accountType === "firm" ? "text-slate-900" : "text-slate-400"} />
+                      <span className="text-sm font-bold text-slate-900">Firm / Brokerage</span>
+                    </div>
+                    <p className="text-[0.62rem] text-slate-500">Register your firm & invite team members</p>
+                  </button>
+                </div>
               </div>
-            </div>
+            )}
 
             {/* Photo Upload */}
             <div>
@@ -305,14 +411,22 @@ export default function AdvisorApplyPage() {
                 <label className="block text-xs font-semibold text-slate-600 mb-1">{accountType === "firm" ? "Your Full Name *" : "Full Name *"}</label>
                 <input value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} className="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm" placeholder="Sarah Chen" />
               </div>
-              <div>
-                <label className="block text-xs font-semibold text-slate-600 mb-1">{accountType === "firm" ? "Firm Name *" : "Firm Name"}</label>
-                <input value={form.firm_name} onChange={(e) => setForm({ ...form, firm_name: e.target.value })} className="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm" placeholder="Chen Advisory" />
-              </div>
+              {!isInviteFlow && (
+                <div>
+                  <label className="block text-xs font-semibold text-slate-600 mb-1">{accountType === "firm" ? "Firm Name *" : "Firm Name"}</label>
+                  <input value={form.firm_name} onChange={(e) => setForm({ ...form, firm_name: e.target.value })} className="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm" placeholder="Chen Advisory" />
+                </div>
+              )}
+              {isInviteFlow && (
+                <div>
+                  <label className="block text-xs font-semibold text-slate-600 mb-1">Firm</label>
+                  <input value={inviteContext.firmName || ""} disabled className="w-full px-3 py-2 border border-slate-100 bg-slate-50 rounded-lg text-sm text-slate-500 cursor-not-allowed" />
+                </div>
+              )}
             </div>
 
-            {/* Firm-specific fields */}
-            {accountType === "firm" && (
+            {/* Firm-specific fields — only for new firm applications, not invite flow */}
+            {accountType === "firm" && !isInviteFlow && (
               <div className="grid grid-cols-2 gap-3">
                 <div>
                   <label className="block text-xs font-semibold text-slate-600 mb-1">ABN</label>
@@ -328,7 +442,15 @@ export default function AdvisorApplyPage() {
             <div className="grid grid-cols-2 gap-3">
               <div>
                 <label className="block text-xs font-semibold text-slate-600 mb-1">Email *</label>
-                <input type="email" value={form.email} onChange={(e) => setForm({ ...form, email: e.target.value })} className="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm" placeholder="sarah@example.com" />
+                <input
+                  type="email"
+                  value={form.email}
+                  onChange={(e) => setForm({ ...form, email: e.target.value })}
+                  disabled={isInviteFlow}
+                  className={`w-full px-3 py-2 border border-slate-200 rounded-lg text-sm ${isInviteFlow ? "bg-slate-50 text-slate-500 cursor-not-allowed" : ""}`}
+                  placeholder="sarah@example.com"
+                />
+                {isInviteFlow && <p className="text-[0.56rem] text-slate-400 mt-0.5">Email is fixed by your invitation.</p>}
               </div>
               <div>
                 <label className="block text-xs font-semibold text-slate-600 mb-1">Phone</label>
@@ -379,7 +501,7 @@ export default function AdvisorApplyPage() {
               <textarea value={form.bio} onChange={(e) => setForm({ ...form, bio: e.target.value })} rows={3} className="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm" placeholder="Tell investors about your experience and approach..." />
             </div>
 
-            {accountType !== "firm" ? (
+            {accountType !== "firm" || isInviteFlow ? (
               <div className="grid grid-cols-2 gap-3">
                 <div>
                   <label className="block text-xs font-semibold text-slate-600 mb-1">Website</label>
@@ -404,7 +526,7 @@ export default function AdvisorApplyPage() {
               disabled={status === "submitting" || !form.termsAccepted}
               className="w-full py-3 bg-slate-900 text-white font-bold rounded-lg text-sm hover:bg-slate-800 disabled:opacity-50 transition-colors"
             >
-              {status === "submitting" ? (photoUploading ? "Uploading photo..." : "Submitting...") : "Submit Application"}
+              {status === "submitting" ? (photoUploading ? "Uploading photo..." : "Submitting...") : isInviteFlow ? "Accept Invitation & Apply" : "Submit Application"}
             </button>
           </div>
 
@@ -436,5 +558,17 @@ export default function AdvisorApplyPage() {
         </p>
       </div>
     </div>
+  );
+}
+
+export default function AdvisorApplyPage() {
+  return (
+    <Suspense fallback={
+      <div className="py-20 text-center">
+        <div className="w-8 h-8 border-2 border-slate-300 border-t-violet-600 rounded-full animate-spin mx-auto mb-3" />
+      </div>
+    }>
+      <AdvisorApplyInner />
+    </Suspense>
   );
 }

--- a/app/advisor-portal/page.tsx
+++ b/app/advisor-portal/page.tsx
@@ -19,8 +19,26 @@ type Advisor = {
   featured_until?: string;
 };
 
-type FirmMember = { id: number; name: string; slug: string; email?: string; type: string; photo_url?: string; verified?: boolean; status?: string; created_at: string };
+type FirmMember = { id: number; name: string; slug: string; email?: string; type: string; photo_url?: string; verified?: boolean; status?: string; created_at: string; role?: string; is_firm_admin?: boolean };
 type FirmInvite = { id: number; email: string; name?: string; status: string; created_at: string; expires_at: string };
+
+type FirmDetails = {
+  id: number; name: string; slug: string; abn?: string; acn?: string; afsl_number?: string;
+  website?: string; phone?: string; email?: string; logo_url?: string; bio?: string;
+  location_state?: string; location_suburb?: string; max_seats: number; status: string;
+};
+
+type FirmAnalyticsMember = FirmMember & {
+  leads30d: number; totalLeads: number; views30d: number;
+  totalBilledCents: number; convertedLeads: number; conversionRate: string;
+  credit_balance_cents?: number;
+};
+
+type FirmAnalyticsSummary = {
+  totalMembers: number; totalLeads: number; totalLeads30d: number; totalViews30d: number;
+  totalConverted: number; conversionRate: string; totalBilledCents: number;
+  totalCreditCents: number; avgRating: string | null;
+};
 
 type Lead = {
   id: number; user_name: string; user_email: string; user_phone?: string;
@@ -60,6 +78,17 @@ export default function AdvisorPortalPage() {
   const [inviteEmail, setInviteEmail] = useState("");
   const [inviteName, setInviteName] = useState("");
   const [inviteStatus, setInviteStatus] = useState<"idle" | "sending" | "sent" | "error">("idle");
+  const [firmDetails, setFirmDetails] = useState<FirmDetails | null>(null);
+  const [firmMemberCount, setFirmMemberCount] = useState(0);
+  const [firmAnalytics, setFirmAnalytics] = useState<{ members: FirmAnalyticsMember[]; summary: FirmAnalyticsSummary | null } | null>(null);
+  const [firmTab, setFirmTab] = useState<"members" | "analytics" | "settings">("members");
+  const [editingFirm, setEditingFirm] = useState<Partial<FirmDetails> | null>(null);
+  const [savingFirm, setSavingFirm] = useState(false);
+  const [firmSaved, setFirmSaved] = useState(false);
+  const [seatRequestSeats, setSeatRequestSeats] = useState("");
+  const [seatRequestReason, setSeatRequestReason] = useState("");
+  const [seatRequestStatus, setSeatRequestStatus] = useState<"idle" | "sending" | "sent" | "error">("idle");
+  const [inviteActionStatus, setInviteActionStatus] = useState<Record<number, "idle" | "loading" | "done" | "error">>({});
   const [viewsByDay, setViewsByDay] = useState<ViewDay[]>([]);
   const [billing, setBilling] = useState<BillingRecord[]>([]);
   const [reviews, setReviews] = useState<Review[]>([]);
@@ -108,11 +137,30 @@ export default function AdvisorPortalPage() {
 
   const loadFirmData = useCallback(async () => {
     try {
-      const res = await fetch("/api/advisor-auth/firm/invite");
-      if (res.ok) {
-        const data = await res.json();
+      const [inviteRes, firmRes] = await Promise.all([
+        fetch("/api/advisor-auth/firm/invite"),
+        fetch("/api/advisor-auth/firm"),
+      ]);
+      if (inviteRes.ok) {
+        const data = await inviteRes.json();
         setFirmMembers(data.members || []);
         setFirmInvites(data.invitations || []);
+      }
+      if (firmRes.ok) {
+        const data = await firmRes.json();
+        setFirmDetails(data.firm || null);
+        setFirmMemberCount(data.memberCount || 0);
+        setEditingFirm(data.firm || null);
+      }
+    } catch { /* ignore */ }
+  }, []);
+
+  const loadFirmAnalytics = useCallback(async () => {
+    try {
+      const res = await fetch("/api/advisor-auth/firm/analytics");
+      if (res.ok) {
+        const data = await res.json();
+        setFirmAnalytics(data);
       }
     } catch { /* ignore */ }
   }, []);
@@ -419,7 +467,7 @@ export default function AdvisorPortalPage() {
             <button
               key={item.key}
               type="button"
-              onClick={() => { setView(item.key as typeof view); if (item.key === "team") loadFirmData(); }}
+              onClick={() => { setView(item.key as typeof view); if (item.key === "team") { loadFirmData(); } }}
               className={`flex items-center gap-1.5 px-3 py-3 text-sm font-medium border-b-2 transition-colors whitespace-nowrap focus:outline-none focus-visible:ring-2 focus-visible:ring-violet-500 focus-visible:ring-inset ${
                 view === item.key
                   ? "border-slate-900 text-slate-900"
@@ -1420,71 +1468,458 @@ export default function AdvisorPortalPage() {
         {/* ─── TEAM (firm admins only) ─── */}
         {view === "team" && isFirmAdmin && (
           <div>
-            <h2 className="text-lg font-bold text-slate-900 mb-1">Team Management</h2>
-            <p className="text-sm text-slate-500 mb-6">Invite advisors to join your firm on Invest.com.au. Each member gets their own verified profile.</p>
-
-            {/* Invite form */}
-            <div className="bg-white border border-slate-200 rounded-xl p-5 mb-6">
-              <h3 className="text-sm font-bold text-slate-900 mb-3">Invite a Team Member</h3>
-              <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
-                <input value={inviteName} onChange={(e) => setInviteName(e.target.value)} placeholder="Name (optional)" className="px-3 py-2 border border-slate-200 rounded-lg text-sm" />
-                <input type="email" value={inviteEmail} onChange={(e) => setInviteEmail(e.target.value)} placeholder="Email address *" className="px-3 py-2 border border-slate-200 rounded-lg text-sm" />
-                <button onClick={sendInvite} disabled={inviteStatus === "sending" || !inviteEmail.trim()} className="px-4 py-2 bg-slate-900 text-white font-semibold rounded-lg text-sm hover:bg-slate-800 disabled:opacity-50 transition-colors">
-                  {inviteStatus === "sending" ? "Sending..." : inviteStatus === "sent" ? "Sent!" : "Send Invite"}
-                </button>
+            <div className="flex items-center justify-between mb-4">
+              <div>
+                <h2 className="text-lg font-bold text-slate-900">{firmDetails?.name || "Team"}</h2>
+                <p className="text-xs text-slate-500 mt-0.5">{firmMemberCount} of {firmDetails?.max_seats || 10} seats used</p>
               </div>
-              {inviteStatus === "error" && <p className="text-xs text-red-600 mt-2">Failed to send invite. Please try again.</p>}
+              {/* Seat bar */}
+              <div className="flex items-center gap-2">
+                <div className="w-24 h-1.5 bg-slate-100 rounded-full overflow-hidden">
+                  <div className="h-full bg-violet-500 rounded-full" style={{ width: `${Math.min((firmMemberCount / (firmDetails?.max_seats || 10)) * 100, 100)}%` }} />
+                </div>
+                <span className="text-[0.62rem] text-slate-400">{firmMemberCount}/{firmDetails?.max_seats || 10}</span>
+              </div>
             </div>
 
-            {/* Current members */}
-            <div className="bg-white border border-slate-200 rounded-xl p-5 mb-6">
-              <h3 className="text-sm font-bold text-slate-900 mb-3">Team Members ({firmMembers.length})</h3>
-              {firmMembers.length === 0 ? (
-                <p className="text-sm text-slate-400">No team members yet. Invite your first advisor above.</p>
-              ) : (
-                <div className="divide-y divide-slate-100">
-                  {firmMembers.map((m) => (
-                    <div key={m.id} className="py-3 flex items-center justify-between">
-                      <div className="flex items-center gap-3">
-                        {m.photo_url ? (
-                          <img src={m.photo_url} alt="" className="w-8 h-8 rounded-full object-cover" />
-                        ) : (
-                          <div className="w-8 h-8 bg-violet-100 rounded-full flex items-center justify-center text-xs font-bold text-violet-600">{m.name?.[0]}</div>
-                        )}
+            {/* Sub-tabs */}
+            <div className="flex gap-1 mb-5 bg-slate-100 p-1 rounded-lg w-fit">
+              {(["members", "analytics", "settings"] as const).map((t) => (
+                <button key={t} onClick={() => { setFirmTab(t); if (t === "analytics" && !firmAnalytics) loadFirmAnalytics(); }}
+                  className={`px-3 py-1.5 text-xs font-semibold rounded-md transition-all ${firmTab === t ? "bg-white text-slate-900 shadow-sm" : "text-slate-500 hover:text-slate-700"}`}>
+                  {t === "members" ? "Members & Invites" : t === "analytics" ? "Analytics" : "Firm Settings"}
+                </button>
+              ))}
+            </div>
+
+            {/* ── MEMBERS TAB ── */}
+            {firmTab === "members" && (
+              <>
+                {/* Invite form */}
+                <div className="bg-white border border-slate-200 rounded-xl p-5 mb-5">
+                  <h3 className="text-sm font-bold text-slate-900 mb-3">Invite a Team Member</h3>
+                  {firmMemberCount >= (firmDetails?.max_seats || 10) ? (
+                    <div className="bg-amber-50 border border-amber-200 rounded-lg p-3 text-xs text-amber-700">
+                      <strong>Seat limit reached.</strong> You&apos;ve used all {firmDetails?.max_seats} seats. Go to <button onClick={() => setFirmTab("settings")} className="underline font-semibold">Firm Settings</button> to request more seats.
+                    </div>
+                  ) : (
+                    <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+                      <input value={inviteName} onChange={(e) => setInviteName(e.target.value)} placeholder="Name (optional)" className="px-3 py-2 border border-slate-200 rounded-lg text-sm" />
+                      <input type="email" value={inviteEmail} onChange={(e) => setInviteEmail(e.target.value)} placeholder="Email address *" className="px-3 py-2 border border-slate-200 rounded-lg text-sm" />
+                      <button onClick={sendInvite} disabled={inviteStatus === "sending" || !inviteEmail.trim()} className="px-4 py-2 bg-slate-900 text-white font-semibold rounded-lg text-sm hover:bg-slate-800 disabled:opacity-50 transition-colors">
+                        {inviteStatus === "sending" ? "Sending..." : inviteStatus === "sent" ? "Sent!" : "Send Invite"}
+                      </button>
+                    </div>
+                  )}
+                  {inviteStatus === "error" && <p className="text-xs text-red-600 mt-2">Failed to send invite. Please try again.</p>}
+                </div>
+
+                {/* Current members */}
+                <div className="bg-white border border-slate-200 rounded-xl p-5 mb-5">
+                  <h3 className="text-sm font-bold text-slate-900 mb-3">Team Members ({firmMembers.length})</h3>
+                  {firmMembers.length === 0 ? (
+                    <p className="text-sm text-slate-400">No team members yet. Invite your first advisor above.</p>
+                  ) : (
+                    <div className="divide-y divide-slate-100">
+                      {firmMembers.map((m) => (
+                        <div key={m.id} className="py-3 flex items-center justify-between gap-3">
+                          <div className="flex items-center gap-3 min-w-0">
+                            {m.photo_url ? (
+                              <img src={m.photo_url} alt="" className="w-9 h-9 rounded-full object-cover shrink-0" />
+                            ) : (
+                              <div className="w-9 h-9 bg-violet-100 rounded-full flex items-center justify-center text-xs font-bold text-violet-600 shrink-0">{m.name?.[0]}</div>
+                            )}
+                            <div className="min-w-0">
+                              <div className="text-sm font-semibold text-slate-900 flex items-center gap-1.5">
+                                {m.name}
+                                {m.id === advisor?.id && <span className="text-[0.5rem] bg-violet-100 text-violet-700 px-1 py-0.5 rounded font-bold uppercase">You</span>}
+                              </div>
+                              <div className="text-[0.62rem] text-slate-500 truncate">{m.email} · {PROFESSIONAL_TYPE_LABELS[m.type as keyof typeof PROFESSIONAL_TYPE_LABELS] || m.type}</div>
+                            </div>
+                          </div>
+                          <div className="flex items-center gap-2 shrink-0">
+                            {m.verified && <span className="text-[0.56rem] bg-emerald-50 text-emerald-700 px-1.5 py-0.5 rounded font-semibold hidden md:inline">Verified</span>}
+                            {/* Role selector */}
+                            <select
+                              value={m.role || (m.is_firm_admin ? "owner" : "member")}
+                              disabled={m.id === advisor?.id}
+                              onChange={async (e) => {
+                                const newRole = e.target.value;
+                                const res = await fetch("/api/advisor-auth/firm/member", {
+                                  method: "PATCH",
+                                  headers: { "Content-Type": "application/json" },
+                                  body: JSON.stringify({ memberId: m.id, role: newRole }),
+                                });
+                                if (res.ok) {
+                                  setFirmMembers(prev => prev.map(fm => fm.id === m.id ? { ...fm, role: newRole, is_firm_admin: newRole !== "member" } : fm));
+                                } else {
+                                  const d = await res.json();
+                                  alert(d.error || "Failed to update role");
+                                }
+                              }}
+                              className="text-[0.62rem] border border-slate-200 rounded px-1.5 py-1 bg-white disabled:opacity-50 disabled:cursor-not-allowed"
+                            >
+                              <option value="owner">Owner</option>
+                              <option value="manager">Manager</option>
+                              <option value="member">Member</option>
+                            </select>
+                            <span className={`text-[0.56rem] px-1.5 py-0.5 rounded font-semibold ${m.status === "active" ? "bg-emerald-50 text-emerald-700" : "bg-amber-50 text-amber-700"}`}>{m.status}</span>
+                            {m.id !== advisor?.id && (
+                              <button
+                                onClick={async () => {
+                                  if (!confirm(`Remove ${m.name} from the firm? Their individual profile will remain active.`)) return;
+                                  const res = await fetch(`/api/advisor-auth/firm/member?memberId=${m.id}`, { method: "DELETE" });
+                                  if (res.ok) {
+                                    setFirmMembers(prev => prev.filter(fm => fm.id !== m.id));
+                                    setFirmMemberCount(c => c - 1);
+                                  } else {
+                                    const d = await res.json();
+                                    alert(d.error || "Failed to remove member");
+                                  }
+                                }}
+                                className="text-[0.56rem] text-red-500 hover:text-red-700 border border-red-200 px-1.5 py-0.5 rounded hover:bg-red-50 transition-colors"
+                              >
+                                Remove
+                              </button>
+                            )}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+
+                {/* Invitations */}
+                {firmInvites.length > 0 && (
+                  <div className="bg-white border border-slate-200 rounded-xl p-5">
+                    <h3 className="text-sm font-bold text-slate-900 mb-3">Invitations</h3>
+                    <div className="divide-y divide-slate-100">
+                      {firmInvites.map((inv) => (
+                        <div key={inv.id} className="py-3 flex items-center justify-between gap-3">
+                          <div className="min-w-0">
+                            <div className="text-sm font-medium text-slate-900">{inv.name || inv.email}</div>
+                            {inv.name && <div className="text-[0.62rem] text-slate-500">{inv.email}</div>}
+                            <div className="text-[0.56rem] text-slate-400 mt-0.5">
+                              Sent {new Date(inv.created_at).toLocaleDateString("en-AU", { day: "numeric", month: "short" })} ·{" "}
+                              {inv.status === "pending" ? `Expires ${new Date(inv.expires_at).toLocaleDateString("en-AU", { day: "numeric", month: "short" })}` : `Status: ${inv.status}`}
+                            </div>
+                          </div>
+                          <div className="flex items-center gap-2 shrink-0">
+                            <span className={`text-[0.56rem] px-1.5 py-0.5 rounded font-semibold ${
+                              inv.status === "pending" ? "bg-amber-50 text-amber-700" :
+                              inv.status === "accepted" ? "bg-emerald-50 text-emerald-700" :
+                              inv.status === "revoked" ? "bg-red-50 text-red-600" :
+                              "bg-slate-100 text-slate-500"
+                            }`}>{inv.status}</span>
+                            {(inv.status === "pending" || inv.status === "expired") && (
+                              <button
+                                disabled={inviteActionStatus[inv.id] === "loading"}
+                                onClick={async () => {
+                                  setInviteActionStatus(prev => ({ ...prev, [inv.id]: "loading" }));
+                                  const res = await fetch("/api/advisor-auth/firm/invite", {
+                                    method: "PATCH",
+                                    headers: { "Content-Type": "application/json" },
+                                    body: JSON.stringify({ inviteId: inv.id, action: "resend" }),
+                                  });
+                                  if (res.ok) {
+                                    setInviteActionStatus(prev => ({ ...prev, [inv.id]: "done" }));
+                                    setTimeout(() => setInviteActionStatus(prev => ({ ...prev, [inv.id]: "idle" })), 3000);
+                                    loadFirmData();
+                                  } else {
+                                    const d = await res.json();
+                                    alert(d.error || "Failed to resend");
+                                    setInviteActionStatus(prev => ({ ...prev, [inv.id]: "error" }));
+                                  }
+                                }}
+                                className="text-[0.56rem] text-blue-600 border border-blue-200 px-1.5 py-0.5 rounded hover:bg-blue-50 transition-colors disabled:opacity-50"
+                              >
+                                {inviteActionStatus[inv.id] === "loading" ? "…" : inviteActionStatus[inv.id] === "done" ? "Sent!" : "Resend"}
+                              </button>
+                            )}
+                            {inv.status === "pending" && (
+                              <button
+                                disabled={inviteActionStatus[inv.id] === "loading"}
+                                onClick={async () => {
+                                  if (!confirm("Revoke this invitation?")) return;
+                                  setInviteActionStatus(prev => ({ ...prev, [inv.id]: "loading" }));
+                                  const res = await fetch("/api/advisor-auth/firm/invite", {
+                                    method: "PATCH",
+                                    headers: { "Content-Type": "application/json" },
+                                    body: JSON.stringify({ inviteId: inv.id, action: "revoke" }),
+                                  });
+                                  if (res.ok) {
+                                    loadFirmData();
+                                  } else {
+                                    const d = await res.json();
+                                    alert(d.error || "Failed to revoke");
+                                    setInviteActionStatus(prev => ({ ...prev, [inv.id]: "error" }));
+                                  }
+                                }}
+                                className="text-[0.56rem] text-red-500 border border-red-200 px-1.5 py-0.5 rounded hover:bg-red-50 transition-colors disabled:opacity-50"
+                              >
+                                Revoke
+                              </button>
+                            )}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </>
+            )}
+
+            {/* ── ANALYTICS TAB ── */}
+            {firmTab === "analytics" && (
+              <>
+                {!firmAnalytics ? (
+                  <div className="flex items-center justify-center py-12">
+                    <div className="w-6 h-6 border-2 border-slate-200 border-t-violet-600 rounded-full animate-spin" />
+                  </div>
+                ) : (
+                  <>
+                    {firmAnalytics.summary && (
+                      <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-5">
+                        {[
+                          { label: "Total Views (30d)", value: firmAnalytics.summary.totalViews30d, icon: "eye", color: "text-blue-600", bg: "bg-blue-50" },
+                          { label: "Enquiries (30d)", value: firmAnalytics.summary.totalLeads30d, icon: "inbox", color: "text-violet-600", bg: "bg-violet-50" },
+                          { label: "Conversion Rate", value: firmAnalytics.summary.conversionRate, icon: "target", color: "text-emerald-600", bg: "bg-emerald-50" },
+                          { label: "Total Credits", value: `$${((firmAnalytics.summary.totalCreditCents || 0) / 100).toFixed(0)}`, icon: "credit-card", color: "text-amber-600", bg: "bg-amber-50" },
+                        ].map((s, i) => (
+                          <div key={i} className="bg-white border border-slate-200 rounded-xl p-4">
+                            <div className={`w-8 h-8 ${s.bg} rounded-lg flex items-center justify-center mb-2`}>
+                              <Icon name={s.icon} size={16} className={s.color} />
+                            </div>
+                            <p className="text-lg font-bold text-slate-900">{typeof s.value === "number" ? s.value.toLocaleString() : s.value}</p>
+                            <p className="text-xs text-slate-500">{s.label}</p>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+
+                    <div className="bg-white border border-slate-200 rounded-xl overflow-hidden">
+                      <div className="px-4 py-3 border-b border-slate-100">
+                        <h3 className="text-sm font-bold text-slate-900">Performance by Member</h3>
+                      </div>
+                      <div className="overflow-x-auto">
+                        <table className="w-full text-left text-xs">
+                          <thead>
+                            <tr className="bg-slate-50 text-[0.62rem] font-semibold text-slate-500 uppercase tracking-wider">
+                              <th className="px-4 py-2">Advisor</th>
+                              <th className="px-4 py-2 text-right">Views (30d)</th>
+                              <th className="px-4 py-2 text-right">Leads (30d)</th>
+                              <th className="px-4 py-2 text-right">Converted</th>
+                              <th className="px-4 py-2 text-right">Credits</th>
+                              <th className="px-4 py-2 text-right">Total Billed</th>
+                            </tr>
+                          </thead>
+                          <tbody className="divide-y divide-slate-100">
+                            {firmAnalytics.members.map((m) => (
+                              <tr key={m.id} className="hover:bg-slate-50 transition-colors">
+                                <td className="px-4 py-2.5">
+                                  <div className="flex items-center gap-2">
+                                    {m.photo_url ? (
+                                      <img src={m.photo_url} alt="" className="w-6 h-6 rounded-full object-cover shrink-0" />
+                                    ) : (
+                                      <div className="w-6 h-6 bg-violet-100 rounded-full flex items-center justify-center text-[0.56rem] font-bold text-violet-600 shrink-0">{m.name?.[0]}</div>
+                                    )}
+                                    <div>
+                                      <div className="font-semibold text-slate-900 text-xs">{m.name}</div>
+                                      <div className="text-[0.56rem] text-slate-400">{m.role || "member"}</div>
+                                    </div>
+                                  </div>
+                                </td>
+                                <td className="px-4 py-2.5 text-right font-medium text-slate-700">{m.views30d}</td>
+                                <td className="px-4 py-2.5 text-right font-medium text-slate-700">{m.leads30d}</td>
+                                <td className="px-4 py-2.5 text-right">
+                                  <span className={`text-[0.56rem] font-semibold ${m.convertedLeads > 0 ? "text-emerald-600" : "text-slate-400"}`}>{m.convertedLeads} ({m.conversionRate})</span>
+                                </td>
+                                <td className="px-4 py-2.5 text-right text-slate-600">${((m.credit_balance_cents || 0) / 100).toFixed(0)}</td>
+                                <td className="px-4 py-2.5 text-right text-slate-600">${((m.totalBilledCents || 0) / 100).toFixed(0)}</td>
+                              </tr>
+                            ))}
+                          </tbody>
+                          {firmAnalytics.summary && (
+                            <tfoot>
+                              <tr className="bg-slate-50 font-bold text-xs border-t border-slate-200">
+                                <td className="px-4 py-2.5 text-slate-700">Total ({firmAnalytics.summary.totalMembers} members)</td>
+                                <td className="px-4 py-2.5 text-right text-slate-700">{firmAnalytics.summary.totalViews30d}</td>
+                                <td className="px-4 py-2.5 text-right text-slate-700">{firmAnalytics.summary.totalLeads30d}</td>
+                                <td className="px-4 py-2.5 text-right text-emerald-700">{firmAnalytics.summary.totalConverted} ({firmAnalytics.summary.conversionRate})</td>
+                                <td className="px-4 py-2.5 text-right text-slate-700">${((firmAnalytics.summary.totalCreditCents || 0) / 100).toFixed(0)}</td>
+                                <td className="px-4 py-2.5 text-right text-slate-700">${((firmAnalytics.summary.totalBilledCents || 0) / 100).toFixed(0)}</td>
+                              </tr>
+                            </tfoot>
+                          )}
+                        </table>
+                      </div>
+                    </div>
+                  </>
+                )}
+              </>
+            )}
+
+            {/* ── SETTINGS TAB ── */}
+            {firmTab === "settings" && editingFirm && (
+              <>
+                <div className="bg-white border border-slate-200 rounded-xl p-5 mb-5">
+                  <h3 className="text-sm font-bold text-slate-900 mb-4">Firm Profile</h3>
+                  <div className="space-y-4">
+                    <div>
+                      <label className="block text-xs font-semibold text-slate-600 mb-1">Firm Name</label>
+                      <input
+                        value={editingFirm.name || ""}
+                        onChange={(e) => setEditingFirm(f => ({ ...f, name: e.target.value }))}
+                        className="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm"
+                        placeholder="e.g. Chen Advisory Group"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-xs font-semibold text-slate-600 mb-1">About the Firm</label>
+                      <textarea
+                        value={editingFirm.bio || ""}
+                        onChange={(e) => setEditingFirm(f => ({ ...f, bio: e.target.value }))}
+                        rows={4}
+                        className="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm"
+                        placeholder="Describe your firm and its approach..."
+                      />
+                    </div>
+                    <div className="grid grid-cols-2 gap-3">
+                      <div>
+                        <label className="block text-xs font-semibold text-slate-600 mb-1">Website</label>
+                        <input value={editingFirm.website || ""} onChange={(e) => setEditingFirm(f => ({ ...f, website: e.target.value }))} className="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm" placeholder="https://..." />
+                      </div>
+                      <div>
+                        <label className="block text-xs font-semibold text-slate-600 mb-1">Phone</label>
+                        <input value={editingFirm.phone || ""} onChange={(e) => setEditingFirm(f => ({ ...f, phone: e.target.value }))} className="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm" placeholder="02 XXXX XXXX" />
+                      </div>
+                    </div>
+                    <div className="grid grid-cols-2 gap-3">
+                      <div>
+                        <label className="block text-xs font-semibold text-slate-600 mb-1">Email</label>
+                        <input type="email" value={editingFirm.email || ""} onChange={(e) => setEditingFirm(f => ({ ...f, email: e.target.value }))} className="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm" placeholder="info@firm.com.au" />
+                      </div>
+                      <div>
+                        <label className="block text-xs font-semibold text-slate-600 mb-1">ABN</label>
+                        <input value={editingFirm.abn || ""} onChange={(e) => setEditingFirm(f => ({ ...f, abn: e.target.value }))} className="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm" placeholder="XX XXX XXX XXX" />
+                      </div>
+                    </div>
+                    <div className="grid grid-cols-2 gap-3">
+                      <div>
+                        <label className="block text-xs font-semibold text-slate-600 mb-1">AFSL Number</label>
+                        <input value={editingFirm.afsl_number || ""} onChange={(e) => setEditingFirm(f => ({ ...f, afsl_number: e.target.value }))} className="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm" placeholder="e.g. 234567" />
+                      </div>
+                      <div>
+                        <label className="block text-xs font-semibold text-slate-600 mb-1">State</label>
+                        <select value={editingFirm.location_state || ""} onChange={(e) => setEditingFirm(f => ({ ...f, location_state: e.target.value }))} className="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm">
+                          <option value="">Select...</option>
+                          {["NSW","VIC","QLD","WA","SA","TAS","ACT","NT"].map(s => <option key={s} value={s}>{s}</option>)}
+                        </select>
+                      </div>
+                    </div>
+                    <div>
+                      <label className="block text-xs font-semibold text-slate-600 mb-1">Suburb</label>
+                      <input value={editingFirm.location_suburb || ""} onChange={(e) => setEditingFirm(f => ({ ...f, location_suburb: e.target.value }))} className="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm" placeholder="Sydney CBD" />
+                    </div>
+                    <div className="flex items-center gap-3 pt-2">
+                      <button
+                        onClick={async () => {
+                          setSavingFirm(true);
+                          try {
+                            const res = await fetch("/api/advisor-auth/firm", {
+                              method: "PATCH",
+                              headers: { "Content-Type": "application/json" },
+                              body: JSON.stringify(editingFirm),
+                            });
+                            if (res.ok) {
+                              const data = await res.json();
+                              setFirmDetails(data.firm);
+                              setEditingFirm(data.firm);
+                              setFirmSaved(true);
+                              setTimeout(() => setFirmSaved(false), 3000);
+                            } else {
+                              const d = await res.json();
+                              alert(d.error || "Failed to save");
+                            }
+                          } finally { setSavingFirm(false); }
+                        }}
+                        disabled={savingFirm}
+                        className="px-5 py-2.5 bg-slate-900 text-white font-semibold rounded-lg text-sm hover:bg-slate-800 disabled:opacity-50 transition-colors"
+                      >
+                        {savingFirm ? "Saving..." : "Save Changes"}
+                      </button>
+                      {firmSaved && <span className="text-sm text-emerald-600 font-medium">Saved!</span>}
+                    </div>
+                  </div>
+                </div>
+
+                {/* Seat upgrade */}
+                <div className="bg-white border border-slate-200 rounded-xl p-5">
+                  <div className="flex items-start justify-between mb-3">
+                    <div>
+                      <h3 className="text-sm font-bold text-slate-900">Seat Limit</h3>
+                      <p className="text-xs text-slate-500 mt-0.5">Currently {firmMemberCount} of {firmDetails?.max_seats || 10} seats used.</p>
+                    </div>
+                    <span className={`text-xs font-bold px-2 py-1 rounded-full ${firmMemberCount >= (firmDetails?.max_seats || 10) ? "bg-red-100 text-red-700" : "bg-emerald-50 text-emerald-700"}`}>
+                      {firmDetails?.max_seats || 10} seats
+                    </span>
+                  </div>
+
+                  {seatRequestStatus === "sent" ? (
+                    <div className="bg-emerald-50 border border-emerald-200 rounded-lg p-3 text-sm text-emerald-700">
+                      Request sent! Our team will review and update your seat limit within 1 business day.
+                    </div>
+                  ) : (
+                    <div className="space-y-3">
+                      <div className="grid grid-cols-2 gap-3">
                         <div>
-                          <div className="text-sm font-semibold text-slate-900">{m.name}</div>
-                          <div className="text-[0.62rem] text-slate-500">{m.email} · {PROFESSIONAL_TYPE_LABELS[m.type as keyof typeof PROFESSIONAL_TYPE_LABELS] || m.type}</div>
+                          <label className="block text-xs font-semibold text-slate-600 mb-1">Requested Seats</label>
+                          <input
+                            type="number"
+                            value={seatRequestSeats}
+                            onChange={(e) => setSeatRequestSeats(e.target.value)}
+                            min={(firmDetails?.max_seats || 10) + 1}
+                            max={200}
+                            className="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm"
+                            placeholder={`More than ${firmDetails?.max_seats || 10}`}
+                          />
+                        </div>
+                        <div>
+                          <label className="block text-xs font-semibold text-slate-600 mb-1">Reason (optional)</label>
+                          <input
+                            value={seatRequestReason}
+                            onChange={(e) => setSeatRequestReason(e.target.value)}
+                            className="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm"
+                            placeholder="Growing team, new office..."
+                          />
                         </div>
                       </div>
-                      <div className="flex items-center gap-2">
-                        {m.verified && <span className="text-[0.56rem] bg-emerald-50 text-emerald-700 px-1.5 py-0.5 rounded font-semibold">Verified</span>}
-                        <span className={`text-[0.56rem] px-1.5 py-0.5 rounded font-semibold ${m.status === "active" ? "bg-emerald-50 text-emerald-700" : "bg-amber-50 text-amber-700"}`}>{m.status}</span>
-                      </div>
+                      <button
+                        disabled={seatRequestStatus === "sending" || !seatRequestSeats}
+                        onClick={async () => {
+                          setSeatRequestStatus("sending");
+                          const res = await fetch("/api/advisor-auth/firm/seat-request", {
+                            method: "POST",
+                            headers: { "Content-Type": "application/json" },
+                            body: JSON.stringify({ requestedSeats: parseInt(seatRequestSeats), reason: seatRequestReason }),
+                          });
+                          if (res.ok) {
+                            setSeatRequestStatus("sent");
+                          } else {
+                            const d = await res.json();
+                            alert(d.error || "Failed to submit request");
+                            setSeatRequestStatus("error");
+                          }
+                        }}
+                        className="px-4 py-2 bg-violet-600 text-white font-semibold rounded-lg text-sm hover:bg-violet-700 disabled:opacity-50 transition-colors"
+                      >
+                        {seatRequestStatus === "sending" ? "Sending..." : "Request More Seats"}
+                      </button>
+                      <p className="text-[0.6rem] text-slate-400">Our team will review your request and update your seat limit within 1 business day. There&apos;s no charge for seat upgrades.</p>
                     </div>
-                  ))}
+                  )}
                 </div>
-              )}
-            </div>
-
-            {/* Pending invitations */}
-            {firmInvites.length > 0 && (
-              <div className="bg-white border border-slate-200 rounded-xl p-5">
-                <h3 className="text-sm font-bold text-slate-900 mb-3">Pending Invitations</h3>
-                <div className="divide-y divide-slate-100">
-                  {firmInvites.map((inv) => (
-                    <div key={inv.id} className="py-3 flex items-center justify-between">
-                      <div>
-                        <div className="text-sm font-medium text-slate-900">{inv.name || inv.email}</div>
-                        {inv.name && <div className="text-[0.62rem] text-slate-500">{inv.email}</div>}
-                      </div>
-                      <div className="flex items-center gap-2">
-                        <span className={`text-[0.56rem] px-1.5 py-0.5 rounded font-semibold ${inv.status === "pending" ? "bg-amber-50 text-amber-700" : inv.status === "accepted" ? "bg-emerald-50 text-emerald-700" : "bg-slate-100 text-slate-500"}`}>{inv.status}</span>
-                        <span className="text-[0.56rem] text-slate-400">Expires {new Date(inv.expires_at).toLocaleDateString()}</span>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </div>
+              </>
             )}
           </div>
         )}

--- a/app/api/advisor-apply/invite/route.ts
+++ b/app/api/advisor-apply/invite/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+// Public endpoint: look up an invite token to pre-fill the apply form
+export async function GET(request: NextRequest) {
+  const token = request.nextUrl.searchParams.get("token");
+  if (!token) return NextResponse.json({ error: "Token required" }, { status: 400 });
+
+  const supabase = createAdminClient();
+
+  const { data: invite } = await supabase
+    .from("advisor_firm_invitations")
+    .select("id, email, name, status, expires_at, role, firm_id, advisor_firms(name)")
+    .eq("token", token)
+    .single();
+
+  if (!invite) return NextResponse.json({ error: "Invalid invitation" }, { status: 404 });
+  if (invite.status !== "pending") return NextResponse.json({ error: "This invitation has already been used or revoked." }, { status: 410 });
+  if (new Date(invite.expires_at) < new Date()) {
+    // Mark expired
+    await supabase.from("advisor_firm_invitations").update({ status: "expired" }).eq("id", invite.id);
+    return NextResponse.json({ error: "This invitation has expired. Please ask your firm admin to resend it." }, { status: 410 });
+  }
+
+  const firm = invite.advisor_firms as unknown as { name: string } | null;
+
+  return NextResponse.json({
+    email: invite.email,
+    name: invite.name || null,
+    firmName: firm?.name || null,
+    firmId: invite.firm_id,
+    role: invite.role || "member",
+  });
+}

--- a/app/api/advisor-apply/route.ts
+++ b/app/api/advisor-apply/route.ts
@@ -11,13 +11,31 @@ export async function POST(request: NextRequest) {
     }
 
     const body = await request.json();
-    const { name, firm_name, email, phone, type, afsl_number, registration_number, location_state, location_suburb, specialties, bio, website, fee_description, account_type, abn, photo_url, pitch_message, years_experience, client_types, languages } = body;
+    const { name, firm_name, email, phone, type, afsl_number, registration_number, location_state, location_suburb, specialties, bio, website, fee_description, account_type, abn, photo_url, pitch_message, years_experience, client_types, languages, invite_token } = body;
 
     if (!name?.trim() || !email?.trim() || !type) {
       return NextResponse.json({ error: "Name, email, and advisor type are required." }, { status: 400 });
     }
 
     const supabase = await createClient();
+
+    // Validate invite token if provided
+    let inviteData: { id: number; firm_id: number; role: string } | null = null;
+    if (invite_token) {
+      const { data: invite } = await supabase
+        .from("advisor_firm_invitations")
+        .select("id, firm_id, role, email, status, expires_at")
+        .eq("token", invite_token)
+        .single();
+
+      if (!invite || invite.status !== "pending" || new Date(invite.expires_at) < new Date()) {
+        return NextResponse.json({ error: "Invalid or expired invitation token." }, { status: 400 });
+      }
+      if (invite.email.toLowerCase() !== email.toLowerCase().trim()) {
+        return NextResponse.json({ error: "This invitation was sent to a different email address." }, { status: 400 });
+      }
+      inviteData = { id: invite.id, firm_id: invite.firm_id, role: invite.role };
+    }
 
     // Check if email already registered
     const { data: existing } = await supabase
@@ -56,7 +74,7 @@ export async function POST(request: NextRequest) {
       bio: bio?.trim() || null,
       website: website?.trim() || null,
       fee_description: fee_description?.trim() || null,
-      account_type: account_type || null,
+      account_type: inviteData ? "firm" : (account_type || null),
       abn: abn?.trim() || null,
       photo_url: photo_url?.trim() || null,
       referral_source: body.referral_source?.trim()?.slice(0, 200) || null,
@@ -64,6 +82,7 @@ export async function POST(request: NextRequest) {
       years_experience: years_experience ? parseInt(String(years_experience)) || null : null,
       client_types: client_types?.trim()?.slice(0, 500) || null,
       languages: languages?.trim()?.slice(0, 200) || null,
+      firm_id: inviteData?.firm_id || null,
     });
 
     if (error) {
@@ -71,8 +90,15 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Failed to submit application." }, { status: 500 });
     }
 
+    // Mark invitation as accepted if token was used
+    if (inviteData) {
+      await supabase.from("advisor_firm_invitations")
+        .update({ status: "accepted", accepted_at: new Date().toISOString() })
+        .eq("id", inviteData.id);
+    }
+
     // Send confirmation email and admin notification
-    sendApplicationConfirmation(email.toLowerCase().trim(), name.trim(), account_type || 'individual').catch((err) => console.error("[advisor-apply] confirmation email failed:", err));
+    sendApplicationConfirmation(email.toLowerCase().trim(), name.trim(), inviteData ? 'firm' : (account_type || 'individual')).catch((err) => console.error("[advisor-apply] confirmation email failed:", err));
     sendAdminNotification(
       `New advisor application: ${name.trim()}`,
       `<strong>${name.trim()}</strong> (${account_type === 'firm' ? 'Firm' : 'Individual'}) applied as ${type}.<br/>Email: ${email}<br/>Firm: ${firm_name || 'N/A'}<br/><a href="https://invest.com.au/admin/advisors" style="color:#2563eb">Review in Admin →</a>`

--- a/app/api/advisor-auth/firm/analytics/route.ts
+++ b/app/api/advisor-auth/firm/analytics/route.ts
@@ -1,0 +1,112 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+export async function GET(request: NextRequest) {
+  try {
+    const sessionToken = request.cookies.get("advisor_session")?.value;
+    if (!sessionToken) return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+
+    const supabase = await createClient();
+    const { data: session } = await supabase
+      .from("advisor_sessions")
+      .select("professional_id, expires_at")
+      .eq("session_token", sessionToken)
+      .single();
+
+    if (!session || new Date(session.expires_at) < new Date()) {
+      return NextResponse.json({ error: "Session expired" }, { status: 401 });
+    }
+
+    const { data: advisor } = await supabase
+      .from("professionals")
+      .select("id, firm_id, is_firm_admin")
+      .eq("id", session.professional_id)
+      .single();
+
+    if (!advisor?.firm_id) {
+      return NextResponse.json({ error: "Not in a firm" }, { status: 403 });
+    }
+
+    const adminSupabase = createAdminClient();
+
+    // Get all members in the firm
+    const { data: members } = await adminSupabase
+      .from("professionals")
+      .select("id, name, slug, photo_url, type, status, verified, credit_balance_cents, free_leads_used, lead_price_cents, rating, review_count")
+      .eq("firm_id", advisor.firm_id)
+      .order("created_at", { ascending: true });
+
+    if (!members || members.length === 0) {
+      return NextResponse.json({ members: [], summary: null });
+    }
+
+    const memberIds = members.map(m => m.id);
+    const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+
+    // Aggregate leads across all members
+    const { data: allLeads } = await adminSupabase
+      .from("professional_leads")
+      .select("id, professional_id, status, bill_amount_cents, billed, created_at")
+      .in("professional_id", memberIds);
+
+    const leads = allLeads || [];
+    const leads30d = leads.filter(l => l.created_at >= thirtyDaysAgo);
+
+    // Aggregate profile views across all members
+    const { data: allViews } = await adminSupabase
+      .from("professional_views")
+      .select("professional_id, view_date, view_count")
+      .in("professional_id", memberIds)
+      .gte("view_date", thirtyDaysAgo.split("T")[0]);
+
+    const totalViews30d = (allViews || []).reduce((sum, v) => sum + (v.view_count || 0), 0);
+
+    // Per-member stats
+    const memberStats = members.map(m => {
+      const mLeads = leads.filter(l => l.professional_id === m.id);
+      const mLeads30d = mLeads.filter(l => l.created_at >= thirtyDaysAgo);
+      const mViews30d = (allViews || []).filter(v => v.professional_id === m.id).reduce((sum, v) => sum + (v.view_count || 0), 0);
+      const totalBilledCents = mLeads.filter(l => l.billed).reduce((sum, l) => sum + (l.bill_amount_cents || 0), 0);
+      const convertedLeads = mLeads.filter(l => l.status === "converted").length;
+
+      return {
+        ...m,
+        leads30d: mLeads30d.length,
+        totalLeads: mLeads.length,
+        views30d: mViews30d,
+        totalBilledCents,
+        convertedLeads,
+        conversionRate: mLeads.length > 0 ? ((convertedLeads / mLeads.length) * 100).toFixed(1) + "%" : "0%",
+      };
+    });
+
+    // Firm summary
+    const totalLeads = leads.length;
+    const totalLeads30d = leads30d.length;
+    const totalConverted = leads.filter(l => l.status === "converted").length;
+    const totalBilledCents = leads.filter(l => l.billed).reduce((sum, l) => sum + (l.bill_amount_cents || 0), 0);
+    const totalCreditCents = members.reduce((sum, m) => sum + (m.credit_balance_cents || 0), 0);
+    const avgRating = members.filter(m => (m.review_count || 0) > 0 && m.rating).length > 0
+      ? (members.filter(m => m.rating).reduce((sum, m) => sum + Number(m.rating), 0) / members.filter(m => m.rating).length).toFixed(1)
+      : null;
+
+    return NextResponse.json({
+      members: memberStats,
+      summary: {
+        totalMembers: members.length,
+        totalLeads,
+        totalLeads30d,
+        totalViews30d,
+        totalConverted,
+        conversionRate: totalLeads > 0 ? ((totalConverted / totalLeads) * 100).toFixed(1) + "%" : "0%",
+        totalBilledCents,
+        totalCreditCents,
+        avgRating,
+      },
+    });
+  } catch (error) {
+    console.error("[firm/analytics] error:", error);
+    return NextResponse.json({ error: "Internal error" }, { status: 500 });
+  }
+}

--- a/app/api/advisor-auth/firm/invite/route.ts
+++ b/app/api/advisor-auth/firm/invite/route.ts
@@ -157,3 +157,92 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: "Internal error" }, { status: 500 });
   }
 }
+
+// PATCH — revoke or resend an invitation
+export async function PATCH(request: NextRequest) {
+  try {
+    const sessionToken = request.cookies.get("advisor_session")?.value;
+    if (!sessionToken) return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+
+    const supabase = await createClient();
+
+    const { data: session } = await supabase
+      .from("advisor_sessions")
+      .select("professional_id, expires_at")
+      .eq("session_token", sessionToken)
+      .single();
+
+    if (!session || new Date(session.expires_at) < new Date()) {
+      return NextResponse.json({ error: "Session expired" }, { status: 401 });
+    }
+
+    const { data: advisor } = await supabase
+      .from("professionals")
+      .select("id, name, firm_id, is_firm_admin")
+      .eq("id", session.professional_id)
+      .single();
+
+    if (!advisor?.is_firm_admin || !advisor.firm_id) {
+      return NextResponse.json({ error: "Only firm admins can manage invitations" }, { status: 403 });
+    }
+
+    const body = await request.json();
+    const { inviteId, action } = body;
+
+    if (!inviteId || !["revoke", "resend"].includes(action)) {
+      return NextResponse.json({ error: "inviteId and action (revoke|resend) required" }, { status: 400 });
+    }
+
+    // Verify the invite belongs to this firm
+    const { data: invite } = await supabase
+      .from("advisor_firm_invitations")
+      .select("id, email, name, status, firm_id")
+      .eq("id", inviteId)
+      .eq("firm_id", advisor.firm_id)
+      .single();
+
+    if (!invite) return NextResponse.json({ error: "Invitation not found" }, { status: 404 });
+
+    if (action === "revoke") {
+      if (invite.status !== "pending") {
+        return NextResponse.json({ error: "Only pending invitations can be revoked" }, { status: 400 });
+      }
+      await supabase.from("advisor_firm_invitations").update({ status: "revoked" }).eq("id", inviteId);
+      return NextResponse.json({ success: true });
+    }
+
+    // resend — create a fresh token and update the invitation
+    if (invite.status !== "pending" && invite.status !== "expired") {
+      return NextResponse.json({ error: "Only pending or expired invitations can be resent" }, { status: 400 });
+    }
+
+    const { data: firm } = await supabase
+      .from("advisor_firms")
+      .select("name, max_seats, status")
+      .eq("id", advisor.firm_id)
+      .single();
+
+    if (!firm || firm.status !== "active") {
+      return NextResponse.json({ error: "Firm not active" }, { status: 400 });
+    }
+
+    const newToken = randomBytes(32).toString("hex");
+    const newExpiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+
+    await supabase
+      .from("advisor_firm_invitations")
+      .update({ token: newToken, status: "pending", expires_at: newExpiresAt })
+      .eq("id", inviteId);
+
+    const siteUrl = getSiteUrl(request.headers.get("host"));
+    const acceptUrl = `${siteUrl}/advisor-apply?invite=${newToken}`;
+    sendFirmInvitation(invite.email, invite.name || undefined, firm.name, advisor.name, acceptUrl).catch((err) =>
+      console.error("[firm-invite] resend email failed:", err)
+    );
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("[firm-invite] patch error:", error);
+    return NextResponse.json({ error: "Internal error" }, { status: 500 });
+  }
+}

--- a/app/api/advisor-auth/firm/member/route.ts
+++ b/app/api/advisor-auth/firm/member/route.ts
@@ -1,0 +1,130 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+async function getFirmAdmin(request: NextRequest) {
+  const sessionToken = request.cookies.get("advisor_session")?.value;
+  if (!sessionToken) return null;
+
+  const supabase = await createClient();
+  const { data: session } = await supabase
+    .from("advisor_sessions")
+    .select("professional_id, expires_at")
+    .eq("session_token", sessionToken)
+    .single();
+
+  if (!session || new Date(session.expires_at) < new Date()) return null;
+
+  const { data: advisor } = await supabase
+    .from("professionals")
+    .select("id, name, firm_id, is_firm_admin")
+    .eq("id", session.professional_id)
+    .single();
+
+  if (!advisor?.is_firm_admin || !advisor.firm_id) return null;
+  return advisor;
+}
+
+// PATCH — update member role
+export async function PATCH(request: NextRequest) {
+  const admin = await getFirmAdmin(request);
+  if (!admin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  let body: { memberId: number; role: string; is_firm_admin?: boolean };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+  }
+
+  const { memberId, role, is_firm_admin } = body;
+  if (!memberId || !role) return NextResponse.json({ error: "memberId and role required" }, { status: 400 });
+
+  const validRoles = ["owner", "manager", "member"];
+  if (!validRoles.includes(role)) return NextResponse.json({ error: "Invalid role" }, { status: 400 });
+
+  const supabase = createAdminClient();
+
+  // Ensure the member is in the same firm
+  const { data: member } = await supabase
+    .from("professionals")
+    .select("id, is_firm_admin")
+    .eq("id", memberId)
+    .eq("firm_id", admin.firm_id)
+    .single();
+
+  if (!member) return NextResponse.json({ error: "Member not found in your firm" }, { status: 404 });
+
+  // Cannot change own role to non-admin unless someone else is owner
+  if (memberId === admin.id && role !== "owner") {
+    // Check if there's another owner
+    const { count: ownerCount } = await supabase
+      .from("professionals")
+      .select("id", { count: "exact", head: true })
+      .eq("firm_id", admin.firm_id)
+      .eq("is_firm_admin", true)
+      .neq("id", admin.id);
+    if (!ownerCount || ownerCount === 0) {
+      return NextResponse.json({ error: "Cannot remove your own admin role — assign another owner first" }, { status: 400 });
+    }
+  }
+
+  const updates: Record<string, unknown> = { role };
+  // Promote/demote firm admin based on role
+  if (is_firm_admin !== undefined) {
+    updates.is_firm_admin = is_firm_admin;
+  } else {
+    updates.is_firm_admin = role === "owner" || role === "manager";
+  }
+
+  const { error } = await supabase
+    .from("professionals")
+    .update(updates)
+    .eq("id", memberId);
+
+  if (error) {
+    console.error("[firm/member] role update failed:", error);
+    return NextResponse.json({ error: "Failed to update role" }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}
+
+// DELETE — remove a team member from the firm
+export async function DELETE(request: NextRequest) {
+  const admin = await getFirmAdmin(request);
+  if (!admin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const memberId = Number(request.nextUrl.searchParams.get("memberId"));
+  if (!memberId) return NextResponse.json({ error: "memberId required" }, { status: 400 });
+
+  // Cannot remove yourself
+  if (memberId === admin.id) {
+    return NextResponse.json({ error: "You cannot remove yourself from the firm" }, { status: 400 });
+  }
+
+  const supabase = createAdminClient();
+
+  // Ensure the member is in the same firm
+  const { data: member } = await supabase
+    .from("professionals")
+    .select("id, name")
+    .eq("id", memberId)
+    .eq("firm_id", admin.firm_id)
+    .single();
+
+  if (!member) return NextResponse.json({ error: "Member not found in your firm" }, { status: 404 });
+
+  // Detach from firm (don't delete the professional record)
+  const { error } = await supabase
+    .from("professionals")
+    .update({ firm_id: null, is_firm_admin: false, account_type: "individual", role: null })
+    .eq("id", memberId);
+
+  if (error) {
+    console.error("[firm/member] remove failed:", error);
+    return NextResponse.json({ error: "Failed to remove member" }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/app/api/advisor-auth/firm/route.ts
+++ b/app/api/advisor-auth/firm/route.ts
@@ -1,0 +1,100 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+async function getAdvisorFromSession(request: NextRequest) {
+  const sessionToken = request.cookies.get("advisor_session")?.value;
+  if (!sessionToken) return null;
+
+  const supabase = await createClient();
+  const { data: session } = await supabase
+    .from("advisor_sessions")
+    .select("professional_id, expires_at")
+    .eq("session_token", sessionToken)
+    .single();
+
+  if (!session || new Date(session.expires_at) < new Date()) return null;
+
+  const { data: advisor } = await supabase
+    .from("professionals")
+    .select("id, name, firm_id, is_firm_admin, role")
+    .eq("id", session.professional_id)
+    .single();
+
+  return advisor;
+}
+
+// GET — fetch firm details (any firm member can view)
+export async function GET(request: NextRequest) {
+  const advisor = await getAdvisorFromSession(request);
+  if (!advisor?.firm_id) return NextResponse.json({ error: "Not authenticated or not in a firm" }, { status: 401 });
+
+  const supabase = createAdminClient();
+  const { data: firm, error } = await supabase
+    .from("advisor_firms")
+    .select("*")
+    .eq("id", advisor.firm_id)
+    .single();
+
+  if (error || !firm) return NextResponse.json({ error: "Firm not found" }, { status: 404 });
+
+  // Get member count for seat info
+  const { count: memberCount } = await supabase
+    .from("professionals")
+    .select("id", { count: "exact", head: true })
+    .eq("firm_id", advisor.firm_id);
+
+  return NextResponse.json({ firm, memberCount: memberCount || 0 });
+}
+
+// PATCH — update firm details (firm admins only)
+export async function PATCH(request: NextRequest) {
+  const advisor = await getAdvisorFromSession(request);
+  if (!advisor?.is_firm_admin || !advisor.firm_id) {
+    return NextResponse.json({ error: "Only firm admins can update firm details" }, { status: 403 });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+  }
+
+  // Allowlist editable fields
+  const allowed = ["name", "bio", "website", "phone", "email", "location_state", "location_suburb", "abn", "acn", "afsl_number", "logo_url"];
+  const updates: Record<string, unknown> = {};
+  for (const key of allowed) {
+    if (key in body) {
+      updates[key] = typeof body[key] === "string" ? (body[key] as string).trim() || null : body[key];
+    }
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return NextResponse.json({ error: "No valid fields to update" }, { status: 400 });
+  }
+
+  // Recompute location_display if location fields changed
+  if ("location_suburb" in updates || "location_state" in updates) {
+    const supabase = createAdminClient();
+    const { data: current } = await supabase.from("advisor_firms").select("location_suburb, location_state").eq("id", advisor.firm_id).single();
+    const suburb = ("location_suburb" in updates ? updates.location_suburb : current?.location_suburb) as string | null;
+    const state = ("location_state" in updates ? updates.location_state : current?.location_state) as string | null;
+    updates.location_display = [suburb, state].filter(Boolean).join(", ") || null;
+  }
+
+  const supabase = createAdminClient();
+  const { data: firm, error } = await supabase
+    .from("advisor_firms")
+    .update(updates)
+    .eq("id", advisor.firm_id)
+    .select()
+    .single();
+
+  if (error) {
+    console.error("[firm] update failed:", error);
+    return NextResponse.json({ error: "Failed to update firm" }, { status: 500 });
+  }
+
+  return NextResponse.json({ firm });
+}

--- a/app/api/advisor-auth/firm/seat-request/route.ts
+++ b/app/api/advisor-auth/firm/seat-request/route.ts
@@ -1,0 +1,84 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { sendAdminNotification } from "@/lib/advisor-emails";
+
+export async function POST(request: NextRequest) {
+  try {
+    const sessionToken = request.cookies.get("advisor_session")?.value;
+    if (!sessionToken) return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+
+    const supabase = await createClient();
+    const { data: session } = await supabase
+      .from("advisor_sessions")
+      .select("professional_id, expires_at")
+      .eq("session_token", sessionToken)
+      .single();
+
+    if (!session || new Date(session.expires_at) < new Date()) {
+      return NextResponse.json({ error: "Session expired" }, { status: 401 });
+    }
+
+    const { data: advisor } = await supabase
+      .from("professionals")
+      .select("id, name, email, firm_id, is_firm_admin")
+      .eq("id", session.professional_id)
+      .single();
+
+    if (!advisor?.is_firm_admin || !advisor.firm_id) {
+      return NextResponse.json({ error: "Only firm admins can request seat upgrades" }, { status: 403 });
+    }
+
+    const { data: firm } = await supabase
+      .from("advisor_firms")
+      .select("name, max_seats")
+      .eq("id", advisor.firm_id)
+      .single();
+
+    if (!firm) return NextResponse.json({ error: "Firm not found" }, { status: 404 });
+
+    const body = await request.json();
+    const { requestedSeats, reason } = body;
+
+    const parsedSeats = parseInt(String(requestedSeats));
+    if (!parsedSeats || parsedSeats <= firm.max_seats || parsedSeats > 200) {
+      return NextResponse.json({ error: `Requested seats must be more than current limit (${firm.max_seats}) and up to 200` }, { status: 400 });
+    }
+
+    const adminSupabase = createAdminClient();
+
+    // Check for recent pending request
+    const { data: recentRequest } = await adminSupabase
+      .from("firm_seat_requests")
+      .select("id")
+      .eq("firm_id", advisor.firm_id)
+      .eq("status", "pending")
+      .single();
+
+    if (recentRequest) {
+      return NextResponse.json({ error: "You already have a pending seat upgrade request" }, { status: 409 });
+    }
+
+    await adminSupabase.from("firm_seat_requests").insert({
+      firm_id: advisor.firm_id,
+      requested_by: advisor.id,
+      current_seats: firm.max_seats,
+      requested_seats: parsedSeats,
+      reason: reason?.trim()?.slice(0, 500) || null,
+    });
+
+    // Notify admin
+    sendAdminNotification(
+      `Seat upgrade request: ${firm.name}`,
+      `<strong>${advisor.name}</strong> from <strong>${firm.name}</strong> has requested a seat upgrade.<br/>
+      Current: ${firm.max_seats} seats → Requested: ${parsedSeats} seats<br/>
+      ${reason ? `Reason: ${reason}` : "No reason provided"}<br/>
+      <a href="https://invest.com.au/admin/advisors" style="color:#2563eb">Review in Admin →</a>`
+    ).catch((err) => console.error("[seat-request] admin notification failed:", err));
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("[seat-request] error:", error);
+    return NextResponse.json({ error: "Internal error" }, { status: 500 });
+  }
+}

--- a/supabase/migrations/20260326_firm_roles_and_seat_requests.sql
+++ b/supabase/migrations/20260326_firm_roles_and_seat_requests.sql
@@ -1,0 +1,34 @@
+-- Migration: Firm roles and seat upgrade requests
+-- Adds role column to professionals and a seat upgrade request table
+
+-- 1. Add role column to professionals (owner/manager/member)
+ALTER TABLE professionals ADD COLUMN IF NOT EXISTS role TEXT DEFAULT 'member'
+  CHECK (role IN ('owner', 'manager', 'member'));
+
+-- Set existing firm admins to owner role
+UPDATE professionals SET role = 'owner' WHERE is_firm_admin = true AND firm_id IS NOT NULL;
+UPDATE professionals SET role = 'member' WHERE firm_id IS NOT NULL AND is_firm_admin = false;
+
+CREATE INDEX IF NOT EXISTS idx_professionals_role ON professionals(role) WHERE firm_id IS NOT NULL;
+
+-- 2. Create firm_seat_requests table for seat upgrade requests
+CREATE TABLE IF NOT EXISTS firm_seat_requests (
+  id SERIAL PRIMARY KEY,
+  firm_id INTEGER NOT NULL REFERENCES advisor_firms(id) ON DELETE CASCADE,
+  requested_by INTEGER NOT NULL REFERENCES professionals(id),
+  current_seats INTEGER NOT NULL,
+  requested_seats INTEGER NOT NULL,
+  reason TEXT,
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'approved', 'rejected')),
+  admin_notes TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  reviewed_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_seat_requests_firm ON firm_seat_requests(firm_id);
+CREATE INDEX IF NOT EXISTS idx_seat_requests_status ON firm_seat_requests(status);
+ALTER TABLE firm_seat_requests ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Service role full access seat_requests" ON firm_seat_requests FOR ALL USING (auth.role() = 'service_role');
+
+-- 3. Add firm_id lookup index to advisor_firm_invitations for the invite token lookup
+CREATE INDEX IF NOT EXISTS idx_firm_invitations_email ON advisor_firm_invitations(email);


### PR DESCRIPTION
…s, analytics, seat upgrades

- Invite acceptance: /advisor-apply?invite=token now looks up the invitation, pre-fills email/name/firm, locks the email field, and links the applicant to the firm on submission (advisor-apply/invite API + updated apply page + route)

- Firm profile editing: new GET/PATCH /api/advisor-auth/firm lets firm admins update name, bio, website, phone, email, ABN, AFSL, location

- Team member removal: DELETE /api/advisor-auth/firm/member detaches a member from the firm without deleting their profile; confirm dialog in UI

- Role management: PATCH /api/advisor-auth/firm/member supports owner/manager/ member roles; DB migration adds role column to professionals; existing admins migrated to owner role

- Firm-level analytics: /api/advisor-auth/firm/analytics aggregates views, leads, conversions, and credit balances across all firm members with a per-member table in the new Analytics sub-tab

- Resend/revoke invitations: PATCH /api/advisor-auth/firm/invite with action=resend|revoke; UI shows Resend + Revoke buttons per invitation, resend resets the token and expiry then re-sends the email

- Seat upgrade flow: /api/advisor-auth/firm/seat-request creates a request record and notifies admin; UI in Firm Settings tab with seat bar and form; new firm_seat_requests table in migration

https://claude.ai/code/session_01Sc4b8zVmRCqqYVZ8tf4JPD