### PR TITLE
feat: full international investor infrastructure — quiz branching, ad…

### DIFF
--- a/app/advisor/[slug]/AdvisorProfileClient.tsx
+++ b/app/advisor/[slug]/AdvisorProfileClient.tsx
@@ -267,6 +267,21 @@ export default function AdvisorProfileClient({
                       Verified
                     </span>
                   )}
+                  {pro.accepts_international_clients && (
+                    <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-indigo-100 text-indigo-700 text-xs font-bold shrink-0">
+                      🌏 International Clients
+                    </span>
+                  )}
+                  {pro.firb_specialist && (
+                    <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-indigo-100 text-indigo-700 text-xs font-bold shrink-0">
+                      FIRB Specialist
+                    </span>
+                  )}
+                  {pro.international_tax_specialist && (
+                    <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-indigo-100 text-indigo-700 text-xs font-bold shrink-0">
+                      Cross-Border Tax
+                    </span>
+                  )}
                   {pro.accepting_new_clients === false && (
                     <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-red-100 text-red-600 text-xs font-bold shrink-0">
                       Not accepting clients
@@ -316,6 +331,12 @@ export default function AdvisorProfileClient({
                     <span className="flex items-center gap-1.5 text-sky-600 font-semibold">
                       <Icon name="clock" size={14} />
                       Responds within 24 hrs
+                    </span>
+                  )}
+                  {pro.languages && pro.languages.length > 0 && pro.languages.some(l => l.toLowerCase() !== "english") && (
+                    <span className="flex items-center gap-1.5 text-indigo-600 font-semibold">
+                      <Icon name="globe" size={14} />
+                      Speaks: {pro.languages.join(", ")}
                     </span>
                   )}
                 </div>

--- a/app/advisors/AdvisorsClient.tsx
+++ b/app/advisors/AdvisorsClient.tsx
@@ -203,6 +203,7 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
   const [firmFilter, setFirmFilter] = useState<string>("all");
   const [minRating, setMinRating] = useState<number>(0);
   const [verifiedOnly, setVerifiedOnly] = useState(false);
+  const [internationalOnly, setInternationalOnly] = useState(false);
   const [search, setSearch] = useState("");
   const [sortBy, setSortBy] = useState<SortKey>("rating");
   const [page, setPage] = useState(1);
@@ -384,6 +385,7 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
       if (firmFilter !== "all" && p.firm_name !== firmFilter) return false;
       if (minRating > 0 && (p.rating || 0) < minRating) return false;
       if (specialtyFilters.length > 0 && !specialtyFilters.every(sf => p.specialties.includes(sf))) return false;
+      if (internationalOnly && !p.accepts_international_clients && !p.firb_specialist && !p.international_tax_specialist) return false;
       if (search) {
         const q = search.toLowerCase();
         return p.name.toLowerCase().includes(q) || p.firm_name?.toLowerCase().includes(q) || p.specialties.some(s => s.toLowerCase().includes(q)) || p.location_display?.toLowerCase().includes(q) || p.location_suburb?.toLowerCase().includes(q);
@@ -411,7 +413,7 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
   const totalPages = Math.ceil(filtered.length / RESULTS_PER_PAGE);
   const paginatedResults = filtered.slice((page - 1) * RESULTS_PER_PAGE, page * RESULTS_PER_PAGE);
 
-  const activeFilterCount = [typeFilters.size > 0, stateFilter !== "all", specialtyFilters.length > 0, feeFilter !== "all", firmFilter !== "all", minRating > 0, verifiedOnly, isLocationActive].filter(Boolean).length;
+  const activeFilterCount = [typeFilters.size > 0, stateFilter !== "all", specialtyFilters.length > 0, feeFilter !== "all", firmFilter !== "all", minRating > 0, verifiedOnly, internationalOnly, isLocationActive].filter(Boolean).length;
 
   const contextParts: string[] = [];
   if (typeFilters.size > 0) {
@@ -441,7 +443,7 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
   const clearAll = () => {
     setTypeFilters(new Set()); setStateFilter("all"); setSpecialtyFilters([]); setFeeFilter("all");
     setFirmFilter("all"); setMinRating(0);
-    setVerifiedOnly(false); setSearch(""); setSortBy("rating");
+    setVerifiedOnly(false); setInternationalOnly(false); setSearch(""); setSortBy("rating");
     setLocationSearch(null); setUserLat(null); setUserLng(null); setRadius(25);
   };
 
@@ -593,6 +595,25 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
               </div>
             </div>
 
+            {/* International clients filter */}
+            <div className="border border-blue-200 bg-blue-50 rounded-xl px-4 py-3 flex items-center justify-between gap-3">
+              <div className="flex items-center gap-2">
+                <span className="text-base leading-none">🌏</span>
+                <div>
+                  <p className="text-xs font-bold text-blue-900">International clients</p>
+                  <p className="text-[0.65rem] text-blue-700">Show only advisors who accept overseas or expat clients (FIRB, cross-border tax, non-resident loans)</p>
+                </div>
+              </div>
+              <button
+                onClick={() => setInternationalOnly(!internationalOnly)}
+                className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full transition-colors duration-200 focus:outline-none ${internationalOnly ? "bg-blue-600" : "bg-slate-300"}`}
+                role="switch"
+                aria-checked={internationalOnly}
+              >
+                <span className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform duration-200 mt-0.5 ${internationalOnly ? "translate-x-4 ml-0.5" : "translate-x-0.5"}`} />
+              </button>
+            </div>
+
             {/* Specialties */}
             <div>
               <label className="text-xs font-bold text-slate-700 mb-2 block">Specialties {specialtyFilters.length > 0 && <span className="text-amber-600">({specialtyFilters.length} selected)</span>}</label>
@@ -662,6 +683,12 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
               <span className="inline-flex items-center gap-1 px-2.5 py-1 bg-slate-100 text-slate-700 text-[0.65rem] font-semibold rounded-full">
                 Verified
                 <button onClick={() => setVerifiedOnly(false)} className="hover:text-slate-900"><Icon name="x" size={12} /></button>
+              </span>
+            )}
+            {internationalOnly && (
+              <span className="inline-flex items-center gap-1 px-2.5 py-1 bg-blue-100 text-blue-700 text-[0.65rem] font-semibold rounded-full">
+                🌏 International clients
+                <button onClick={() => setInternationalOnly(false)} className="hover:text-blue-900"><Icon name="x" size={12} /></button>
               </span>
             )}
             <button onClick={clearAll} className="text-[0.62rem] text-slate-400 hover:text-slate-600 font-medium ml-1">Clear all</button>
@@ -797,6 +824,16 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
                         <span className="shrink-0 text-[0.56rem] md:text-[0.62rem] font-bold px-1.5 py-0.5 rounded-full bg-emerald-100 text-emerald-700 flex items-center gap-0.5">
                           <Icon name="zap" size={10} className="text-emerald-500" />
                           Fast
+                        </span>
+                      )}
+                      {pro.accepts_international_clients && (
+                        <span className="shrink-0 text-[0.56rem] md:text-[0.62rem] font-bold px-1.5 py-0.5 rounded-full bg-blue-100 text-blue-700">
+                          🌏 Intl
+                        </span>
+                      )}
+                      {pro.firb_specialist && (
+                        <span className="shrink-0 text-[0.56rem] md:text-[0.62rem] font-bold px-1.5 py-0.5 rounded-full bg-blue-100 text-blue-700">
+                          FIRB
                         </span>
                       )}
                     </div>

--- a/app/api/advisor-enquiry/route.ts
+++ b/app/api/advisor-enquiry/route.ts
@@ -93,6 +93,15 @@ export async function POST(request: NextRequest) {
     const body = await request.json();
     const { professional_id, user_name, user_email, user_phone, message, source_page } = body;
 
+    // Detect international visitor via Vercel IP country header
+    const visitorCountry = request.headers.get("x-vercel-ip-country") || body.visitor_country || null;
+    const isInternationalLead = Boolean(
+      body.is_international ||
+      (visitorCountry && !["AU", "NZ"].includes(visitorCountry)) ||
+      body.investor_country ||
+      body.visa_status
+    );
+
     // Honeypot: bots fill hidden fields that real users never see
     if (body.website || body.fax || body.company_url) {
       // Silent reject — return fake success so bots don't retry
@@ -209,8 +218,9 @@ export async function POST(request: NextRequest) {
     // Clamp 0-100
     score = Math.min(100, Math.max(0, score));
 
-    // Determine lead tier based on qualification data
-    const leadTier = hasQualificationData ? "qualified" : "standard";
+    // Determine lead tier based on qualification data and international status
+    // International leads are worth significantly more (foreign investors have higher transaction values)
+    const leadTier = isInternationalLead ? "international" : hasQualificationData ? "qualified" : "standard";
 
     // ── Auto-Billing (prepaid credit model) ──
     // First 2 leads are free (trial), then deduct from credit balance
@@ -241,9 +251,13 @@ export async function POST(request: NextRequest) {
     }
 
     const isFree = freeUsed < (categoryFreeLeads || freeTrialCount);
-    // Use qualified price when lead has qualification data
+    // Pricing tiers: international = 3x, qualified = 2x, standard = 1x
     const basePriceCents = advisor?.lead_price_cents || categoryPrice;
-    const priceCents = isFree ? 0 : (leadTier === "qualified" ? (categoryQualifiedPrice || basePriceCents * 2) : basePriceCents);
+    const priceCents = isFree ? 0 : (
+      leadTier === "international" ? basePriceCents * 3 :
+      leadTier === "qualified" ? (categoryQualifiedPrice || basePriceCents * 2) :
+      basePriceCents
+    );
     const balance = advisor?.credit_balance_cents || 0;
     const hasSufficientCredit = balance >= priceCents;
 
@@ -321,7 +335,9 @@ export async function POST(request: NextRequest) {
         if (RESEND_API_KEY) {
           // Build qualification data rows for the email
           const qualDataRows = hasQualificationData ? buildQualificationEmailRows(qualificationData) : "";
-          const tierBadge = leadTier === "qualified"
+          const tierBadge = leadTier === "international"
+            ? `<span style="display: inline-block; padding: 3px 10px; background: #dbeafe; color: #1e40af; border-radius: 20px; font-size: 11px; font-weight: 700; margin-left: 8px;">🌏 International Lead</span>`
+            : leadTier === "qualified"
             ? `<span style="display: inline-block; padding: 3px 10px; background: #dbeafe; color: #1e40af; border-radius: 20px; font-size: 11px; font-weight: 700; margin-left: 8px;">Qualified Lead</span>`
             : "";
 

--- a/app/api/advisor-lead/route.ts
+++ b/app/api/advisor-lead/route.ts
@@ -31,16 +31,25 @@ async function sendAdminNotification(
   phone: string,
   email: string,
   advisorType: string,
-  quizAnswers: Record<string, string>
+  quizAnswers: Record<string, string>,
+  intlContext?: { investorCountry?: string; visaStatus?: string; investorGoalIntl?: string }
 ): Promise<void> {
   const resendApiKey = process.env.RESEND_API_KEY;
   const adminEmail = process.env.ADMIN_NOTIFICATION_EMAIL || "leads@invest.com.au";
   if (!resendApiKey) return;
 
   const advisorLabel = ADVISOR_LABELS[advisorType] || "Financial Advisor";
+  const isIntl = Boolean(intlContext);
   const answersHtml = Object.entries(quizAnswers)
     .map(([k, v]) => `<tr><td style="padding:6px 12px;color:#64748b;font-size:13px;">${esc(k)}</td><td style="padding:6px 12px;font-weight:600;font-size:13px;">${esc(v)}</td></tr>`)
     .join("");
+
+  const intlHtml = isIntl && intlContext ? `
+    <tr style="background:#eff6ff;"><td colspan="2" style="padding:8px 12px;font-weight:700;font-size:12px;color:#1e40af;text-transform:uppercase;letter-spacing:0.5px;">🌏 International Lead</td></tr>
+    ${intlContext.investorCountry ? `<tr style="background:#eff6ff;"><td style="padding:6px 12px;color:#64748b;font-size:13px;">Country</td><td style="padding:6px 12px;font-weight:600;font-size:13px;">${esc(intlContext.investorCountry)}</td></tr>` : ""}
+    ${intlContext.visaStatus ? `<tr style="background:#eff6ff;"><td style="padding:6px 12px;color:#64748b;font-size:13px;">Visa Status</td><td style="padding:6px 12px;font-weight:600;font-size:13px;">${esc(intlContext.visaStatus)}</td></tr>` : ""}
+    ${intlContext.investorGoalIntl ? `<tr style="background:#eff6ff;"><td style="padding:6px 12px;color:#64748b;font-size:13px;">Goal</td><td style="padding:6px 12px;font-weight:600;font-size:13px;">${esc(intlContext.investorGoalIntl)}</td></tr>` : ""}
+  ` : "";
 
   const html = `
 <!DOCTYPE html>
@@ -48,9 +57,9 @@ async function sendAdminNotification(
 <head><meta charset="utf-8"></head>
 <body style="margin:0;padding:0;background:#f1f5f9;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
   <div style="max-width:520px;margin:0 auto;padding:24px 16px;">
-    <div style="background:linear-gradient(135deg,#d97706 0%,#b45309 100%);border-radius:12px 12px 0 0;padding:24px;text-align:center;">
-      <h1 style="color:#fff;font-size:20px;margin:0 0 4px;font-weight:800;">New Advisor Lead</h1>
-      <p style="color:#fde68a;font-size:13px;margin:0;">Invest.com.au — Unified Quiz</p>
+    <div style="background:linear-gradient(135deg,${isIntl ? "#1d4ed8 0%,#1e3a8a 100%" : "#d97706 0%,#b45309 100%"});border-radius:12px 12px 0 0;padding:24px;text-align:center;">
+      <h1 style="color:#fff;font-size:20px;margin:0 0 4px;font-weight:800;">${isIntl ? "🌏 International Advisor Lead" : "New Advisor Lead"}</h1>
+      <p style="color:${isIntl ? "#bfdbfe" : "#fde68a"};font-size:13px;margin:0;">Invest.com.au — Unified Quiz${isIntl ? " · International Track" : ""}</p>
     </div>
     <div style="background:#fff;padding:24px;border-radius:0 0 12px 12px;box-shadow:0 1px 3px rgba(0,0,0,.1);">
       <table style="width:100%;border-collapse:collapse;">
@@ -58,6 +67,7 @@ async function sendAdminNotification(
         <tr style="background:#f8fafc;"><td style="padding:8px 12px;color:#64748b;font-size:13px;">Phone</td><td style="padding:8px 12px;font-weight:700;font-size:14px;"><a href="tel:${esc(phone)}" style="color:#d97706;">${esc(phone)}</a></td></tr>
         <tr><td style="padding:8px 12px;color:#64748b;font-size:13px;">Email</td><td style="padding:8px 12px;font-weight:700;font-size:14px;"><a href="mailto:${esc(email)}" style="color:#d97706;">${esc(email)}</a></td></tr>
         <tr style="background:#f8fafc;"><td style="padding:8px 12px;color:#64748b;font-size:13px;">Advisor Type</td><td style="padding:8px 12px;font-weight:700;font-size:14px;">${esc(advisorLabel)}</td></tr>
+        ${intlHtml}
       </table>
       <h3 style="font-size:13px;color:#94a3b8;text-transform:uppercase;letter-spacing:0.5px;margin:20px 0 8px;">Quiz Answers</h3>
       <table style="width:100%;border-collapse:collapse;">${answersHtml}</table>
@@ -131,6 +141,10 @@ export async function POST(request: NextRequest) {
     advisor_type,
     quiz_answers,
     consent,
+    is_international,
+    investor_country,
+    visa_status,
+    investor_goal_intl,
   } = body as {
     name?: string;
     phone?: string;
@@ -138,14 +152,22 @@ export async function POST(request: NextRequest) {
     advisor_type?: string;
     quiz_answers?: Record<string, string>;
     consent?: boolean;
+    is_international?: boolean;
+    investor_country?: string;
+    visa_status?: string;
+    investor_goal_intl?: string;
   };
 
   // Validation
   if (!name || typeof name !== "string" || name.trim().length < 2) {
     return NextResponse.json({ error: "Full name is required" }, { status: 400 });
   }
-  if (!phone || !isValidAuPhone(phone as string)) {
+  // International users may have non-AU phone numbers — only validate AU format for domestic leads
+  if (!is_international && (!phone || !isValidAuPhone(phone as string))) {
     return NextResponse.json({ error: "Valid Australian phone number is required" }, { status: 400 });
+  }
+  if (is_international && (!phone || (phone as string).trim().length < 6)) {
+    return NextResponse.json({ error: "Phone number is required" }, { status: 400 });
   }
   if (!isValidEmail(email as string)) {
     return NextResponse.json({ error: "Valid email address is required" }, { status: 400 });
@@ -165,21 +187,29 @@ export async function POST(request: NextRequest) {
   const supabase = createAdminClient();
 
   const sanitizedName = name.trim().slice(0, 100);
-  const sanitizedPhone = phone.trim().slice(0, 30);
+  const sanitizedPhone = (phone || "").trim().slice(0, 30);
   const sanitizedEmail = (email as string).trim().toLowerCase().slice(0, 254);
   const sanitizedAdvisorType = (advisor_type || "not-sure").slice(0, 50);
   const sanitizedAnswers = quiz_answers && typeof quiz_answers === "object" ? quiz_answers : {};
+  const isIntl = Boolean(is_international);
 
   // Store lead in email_captures with rich context
   const { error } = await supabase.from("email_captures").insert({
     email: sanitizedEmail,
     name: sanitizedName,
-    source: "advisor-lead",
+    source: isIntl ? "advisor-lead-international" : "advisor-lead",
     context: {
       phone: sanitizedPhone,
       advisor_type: sanitizedAdvisorType,
       quiz_answers: sanitizedAnswers,
       lead_type: "advisor",
+      is_international: isIntl,
+      ...(isIntl && {
+        investor_country: (investor_country || "").slice(0, 50),
+        visa_status: (visa_status || "").slice(0, 50),
+        investor_goal_intl: (investor_goal_intl || "").slice(0, 50),
+        lead_tier: "international",
+      }),
     },
     ...utmForInsert(utm),
   });
@@ -194,7 +224,14 @@ export async function POST(request: NextRequest) {
 
   // Fire admin notification and Resend contact sync in parallel (non-blocking)
   Promise.all([
-    sendAdminNotification(sanitizedName, sanitizedPhone, sanitizedEmail, sanitizedAdvisorType, sanitizedAnswers),
+    sendAdminNotification(
+      sanitizedName, sanitizedPhone, sanitizedEmail, sanitizedAdvisorType, sanitizedAnswers,
+      isIntl ? {
+        investorCountry: (investor_country || "").slice(0, 50),
+        visaStatus: (visa_status || "").slice(0, 50),
+        investorGoalIntl: (investor_goal_intl || "").slice(0, 50),
+      } : undefined
+    ),
     syncToResendContacts(sanitizedEmail, sanitizedName),
   ]).catch((err) => log.error("Post-lead tasks failed", { error: String(err) }));
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import LayoutShell from "@/components/LayoutShell";
 import { ThemeProvider } from "@/components/ThemeProvider";
 import GoogleAnalytics from "@/components/GoogleAnalytics";
 import UtmCapture from "@/components/UtmCapture";
+import InternationalBannerServer from "@/components/InternationalBannerServer";
 
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import WebVitals from "@/components/WebVitals";
@@ -111,6 +112,7 @@ export default function RootLayout({
         <Suspense fallback={null}><UtmCapture /></Suspense>
 
         <ThemeProvider>
+          <InternationalBannerServer />
           <LayoutShell>{children}</LayoutShell>
         </ThemeProvider>
         <Suspense fallback={null}><WebVitals /></Suspense>

--- a/app/property/listings/[slug]/page.tsx
+++ b/app/property/listings/[slug]/page.tsx
@@ -7,6 +7,7 @@ import { OFF_THE_PLAN_WARNING, PROPERTY_DISCLAIMER_SHORT, PROPERTY_INDICATIVE_PR
 import Icon from "@/components/Icon";
 import PropertyEnquiryForm from "./PropertyEnquiryForm";
 import { getListingImages } from "@/lib/property-images";
+import FirbCostCalculatorInline from "@/components/FirbCostCalculatorInline";
 
 export const revalidate = 3600;
 
@@ -280,6 +281,14 @@ export default async function PropertyListingPage({ params }: { params: Promise<
                   </div>
                 </div>
               </div>
+            )}
+
+            {/* FIRB Cost Calculator — shown for FIRB-eligible or foreign-buyer-eligible properties */}
+            {(listing.firb_approved || listing.foreign_buyer_eligible || listing.off_the_plan || listing.new_development) && (
+              <FirbCostCalculatorInline
+                defaultPrice={Math.round(listing.price_from_cents / 100)}
+                defaultState={listing.state || "NSW"}
+              />
             )}
 
             {/* Description */}

--- a/app/quiz/_components/AdvisorResultsScreen.tsx
+++ b/app/quiz/_components/AdvisorResultsScreen.tsx
@@ -82,9 +82,13 @@ interface Props {
   quizAnswers: Record<string, string>;
   platformResults: PlatformResult[];
   onRestart: () => void;
+  isInternational?: boolean;
+  investorCountry?: string;
+  visaStatus?: string;
+  investorGoalIntl?: string;
 }
 
-export default function AdvisorResultsScreen({ advisorType, quizAnswers, platformResults, onRestart }: Props) {
+export default function AdvisorResultsScreen({ advisorType, quizAnswers, platformResults, onRestart, isInternational = false, investorCountry, visaStatus, investorGoalIntl }: Props) {
   // Step state
   const [step, setStep] = useState<FlowStep>("contact");
 
@@ -123,13 +127,18 @@ export default function AdvisorResultsScreen({ advisorType, quizAnswers, platfor
       return;
     }
     setContactError("");
-    trackEvent("advisor_contact_step_complete", { advisor_type: advisorType }, "/quiz");
-    setStep("location");
+    trackEvent("advisor_contact_step_complete", { advisor_type: advisorType, is_international: isInternational }, "/quiz");
+    // International users skip the location step — they don't have an AU state yet
+    if (isInternational) {
+      setStep("location"); // location step handles international mode inline
+    } else {
+      setStep("location");
+    }
   };
 
   /* ─── Step 2 → Step 3 ─── */
   const handleLocationNext = async () => {
-    if (!stateValue) {
+    if (!isInternational && !stateValue) {
       setLocationError("Please select your state or enter your postcode.");
       return;
     }
@@ -148,11 +157,15 @@ export default function AdvisorResultsScreen({ advisorType, quizAnswers, platfor
           email: email.trim(),
           advisor_type: advisorType,
           quiz_answers: quizAnswers,
-          state: stateValue,
+          state: stateValue || (isInternational ? "intl" : null),
           postcode: postcodeValue || null,
           suburb: suburbValue || null,
           budget: budgetValue || null,
           consent: true,
+          is_international: isInternational,
+          investor_country: investorCountry || null,
+          visa_status: visaStatus || null,
+          investor_goal_intl: investorGoalIntl || null,
         }),
       });
       trackEvent("advisor_lead_submit", { advisor_type: advisorType, state: stateValue }, "/quiz");
@@ -164,55 +177,72 @@ export default function AdvisorResultsScreen({ advisorType, quizAnswers, platfor
     try {
       const supabase = createClient();
       const dbType = TYPE_DB_MAP[advisorType];
-      let query = supabase
-        .from("professionals")
-        .select("id, slug, name, firm_name, type, photo_url, rating, review_count, location_display, location_state, specialties, fee_description, verified")
-        .eq("status", "active")
-        .eq("verified", true);
 
-      if (dbType) query = query.eq("type", dbType);
-      if (stateValue) query = query.eq("location_state", stateValue);
+      const mapAdvisor = (p: Record<string, unknown>): MatchedAdvisor => ({
+        id: p.id as number,
+        slug: p.slug as string,
+        name: p.name as string,
+        firm_name: (p.firm_name as string) ?? null,
+        type: p.type as string,
+        photo_url: (p.photo_url as string) ?? null,
+        rating: (p.rating as number) ?? 0,
+        review_count: (p.review_count as number) ?? 0,
+        location_display: (p.location_display as string) ?? null,
+        specialties: (p.specialties as string[]) ?? [],
+        fee_description: (p.fee_description as string) ?? null,
+        verified: (p.verified as boolean) ?? false,
+      });
 
-      const { data } = await query.order("rating", { ascending: false }).order("review_count", { ascending: false }).limit(5);
+      let matched: MatchedAdvisor[] = [];
 
-      const matched: MatchedAdvisor[] = (data || []).map((p) => ({
-        id: p.id,
-        slug: p.slug,
-        name: p.name,
-        firm_name: p.firm_name ?? null,
-        type: p.type,
-        photo_url: p.photo_url ?? null,
-        rating: p.rating ?? 0,
-        review_count: p.review_count ?? 0,
-        location_display: p.location_display ?? null,
-        specialties: p.specialties ?? [],
-        fee_description: p.fee_description ?? null,
-        verified: p.verified ?? false,
-      }));
+      if (isInternational) {
+        // For international investors: first try advisors with international flags
+        let intlQuery = supabase
+          .from("professionals")
+          .select("id, slug, name, firm_name, type, photo_url, rating, review_count, location_display, location_state, specialties, fee_description, verified, accepts_international_clients, international_tax_specialist, firb_specialist, languages")
+          .eq("status", "active")
+          .eq("verified", true)
+          .eq("accepts_international_clients", true);
+        if (dbType) intlQuery = intlQuery.eq("type", dbType);
+        const { data: intlData } = await intlQuery.order("rating", { ascending: false }).order("review_count", { ascending: false }).limit(5);
+        matched = (intlData || []).map(mapAdvisor);
 
-      // Fallback: try without state filter if empty
-      if (matched.length === 0 && stateValue) {
-        let fallbackQuery = supabase
+        // Fallback: search by international specialty keywords
+        if (matched.length < 3) {
+          const { data: specData } = await supabase
+            .from("professionals")
+            .select("id, slug, name, firm_name, type, photo_url, rating, review_count, location_display, location_state, specialties, fee_description, verified")
+            .eq("status", "active")
+            .eq("verified", true)
+            .contains("specialties", ["International Clients"])
+            .order("rating", { ascending: false })
+            .limit(5);
+          const specMapped = (specData || []).map(mapAdvisor);
+          const existingIds = new Set(matched.map(m => m.id));
+          matched.push(...specMapped.filter(m => !existingIds.has(m.id)));
+        }
+      } else {
+        let query = supabase
           .from("professionals")
           .select("id, slug, name, firm_name, type, photo_url, rating, review_count, location_display, location_state, specialties, fee_description, verified")
           .eq("status", "active")
           .eq("verified", true);
-        if (dbType) fallbackQuery = fallbackQuery.eq("type", dbType);
-        const { data: fallbackData } = await fallbackQuery.order("rating", { ascending: false }).limit(5);
-        matched.push(...(fallbackData || []).map((p) => ({
-          id: p.id,
-          slug: p.slug,
-          name: p.name,
-          firm_name: p.firm_name ?? null,
-          type: p.type,
-          photo_url: p.photo_url ?? null,
-          rating: p.rating ?? 0,
-          review_count: p.review_count ?? 0,
-          location_display: p.location_display ?? null,
-          specialties: p.specialties ?? [],
-          fee_description: p.fee_description ?? null,
-          verified: p.verified ?? false,
-        })));
+        if (dbType) query = query.eq("type", dbType);
+        if (stateValue) query = query.eq("location_state", stateValue);
+        const { data } = await query.order("rating", { ascending: false }).order("review_count", { ascending: false }).limit(5);
+        matched = (data || []).map(mapAdvisor);
+
+        // Fallback: try without state filter if empty
+        if (matched.length === 0 && stateValue) {
+          let fallbackQuery = supabase
+            .from("professionals")
+            .select("id, slug, name, firm_name, type, photo_url, rating, review_count, location_display, location_state, specialties, fee_description, verified")
+            .eq("status", "active")
+            .eq("verified", true);
+          if (dbType) fallbackQuery = fallbackQuery.eq("type", dbType);
+          const { data: fallbackData } = await fallbackQuery.order("rating", { ascending: false }).limit(5);
+          matched.push(...(fallbackData || []).map(mapAdvisor));
+        }
       }
 
       setAllMatches(matched);
@@ -342,10 +372,32 @@ export default function AdvisorResultsScreen({ advisorType, quizAnswers, platfor
     );
   }
 
+  const COUNTRY_LABELS: Record<string, string> = {
+    singapore: "Singapore", hong_kong: "Hong Kong", china: "China", india: "India",
+    uae: "UAE / Middle East", uk: "United Kingdom", usa: "United States",
+    malaysia: "Malaysia", new_zealand: "New Zealand", other: "your country",
+  };
+  const countryLabel = investorCountry ? (COUNTRY_LABELS[investorCountry] || "your country") : "overseas";
+
   /* ─── STEP: contact (default) ─── */
   return (
     <div className="pt-5 pb-8 md:py-12">
       <div className="container-custom max-w-2xl mx-auto">
+        {/* International context banner */}
+        {isInternational && (
+          <div className="bg-blue-50 border border-blue-200 rounded-xl px-4 py-3 mb-5 flex items-start gap-3">
+            <span className="text-xl leading-none mt-0.5">🌏</span>
+            <div>
+              <p className="text-sm font-semibold text-blue-900">
+                Matching you with international-specialist advisors
+              </p>
+              <p className="text-xs text-blue-700 mt-0.5">
+                We&apos;ll connect you with Australian advisors who specifically work with clients from {countryLabel} — including FIRB-accredited buyers agents, cross-border tax accountants, and non-resident mortgage brokers.
+              </p>
+            </div>
+          </div>
+        )}
+
         {/* Header */}
         <div className="text-center mb-5 md:mb-6 reveal-screen-in">
           <div className="w-14 h-14 md:w-16 md:h-16 bg-amber-100 rounded-full flex items-center justify-center mx-auto mb-3">
@@ -355,7 +407,9 @@ export default function AdvisorResultsScreen({ advisorType, quizAnswers, platfor
             You need a verified {advisorLabel}
           </h1>
           <p className="text-sm text-slate-500">
-            Based on your answers, professional advice is the right move.
+            {isInternational
+              ? `We'll match you with an Australian ${advisorLabel} who specialises in international clients.`
+              : "Based on your answers, professional advice is the right move."}
           </p>
         </div>
 

--- a/app/quiz/page.tsx
+++ b/app/quiz/page.tsx
@@ -15,11 +15,12 @@ import QuizEmailGate from "./_components/QuizEmailGate";
 import AdvisorResultsScreen from "./_components/AdvisorResultsScreen";
 
 /* ─── Types ─── */
-type QuestionId = "goal" | "mode" | "experience" | "complexity" | "amount" | "priority" | "advisor_type" | "property_sub";
-type QuizTrack = "diy" | "advisor";
+type QuestionId = "location" | "goal" | "mode" | "experience" | "complexity" | "amount" | "priority" | "advisor_type" | "property_sub" | "investor_country" | "visa_status" | "investor_goal_intl";
+type QuizTrack = "diy" | "advisor" | "international";
 type Phase = "questions" | "email-gate" | "analyzing" | "advisor-analyzing" | "diy-results" | "advisor-results";
 
 interface UnifiedAnswers {
+  location?: string;
   goal?: string;
   mode?: string;
   experience?: string;
@@ -28,6 +29,9 @@ interface UnifiedAnswers {
   priority?: string;
   advisor_type?: string;
   property_sub?: string;
+  investor_country?: string;
+  visa_status?: string;
+  investor_goal_intl?: string;
 }
 
 interface QuizWeight {
@@ -44,6 +48,47 @@ interface QuizWeight {
 
 /* ─── Unified question definitions ─── */
 const UNIFIED_QUESTIONS: Record<QuestionId, { text: string; options: { key: string; label: string; sub?: string; emoji?: string }[] }> = {
+  location: {
+    text: "Where are you based?",
+    options: [
+      { key: "australia",     label: "I live in Australia",              sub: "Australian resident or citizen",              emoji: "🇦🇺" },
+      { key: "international", label: "I'm outside Australia",            sub: "I'm based overseas and investing in Australia", emoji: "🌏" },
+      { key: "expat",         label: "Australian expat living abroad",   sub: "I'm an Aussie living overseas",               emoji: "✈️" },
+    ],
+  },
+  investor_country: {
+    text: "Which country are you based in?",
+    options: [
+      { key: "singapore",    label: "Singapore",     emoji: "🇸🇬" },
+      { key: "hong_kong",    label: "Hong Kong",     emoji: "🇭🇰" },
+      { key: "china",        label: "China",         emoji: "🇨🇳" },
+      { key: "india",        label: "India",         emoji: "🇮🇳" },
+      { key: "uae",          label: "UAE / Middle East", emoji: "🇦🇪" },
+      { key: "uk",           label: "United Kingdom", emoji: "🇬🇧" },
+      { key: "usa",          label: "United States", emoji: "🇺🇸" },
+      { key: "malaysia",     label: "Malaysia",      emoji: "🇲🇾" },
+      { key: "new_zealand",  label: "New Zealand",   emoji: "🇳🇿" },
+      { key: "other",        label: "Other country", emoji: "🌍" },
+    ],
+  },
+  visa_status: {
+    text: "What is your relationship with Australia?",
+    options: [
+      { key: "non_resident",    label: "Non-resident / no Australian ties", sub: "Never lived in Australia, no visa",                emoji: "🌐" },
+      { key: "temp_visa",       label: "Temporary visa holder",             sub: "457, 482, student, working holiday visa",         emoji: "📋" },
+      { key: "new_pr",          label: "New permanent resident",            sub: "Recently got PR, not yet a citizen",              emoji: "🏡" },
+      { key: "au_expat",        label: "Australian expat",                  sub: "Australian citizen or PR living abroad",          emoji: "✈️" },
+    ],
+  },
+  investor_goal_intl: {
+    text: "What are you looking to do in Australia?",
+    options: [
+      { key: "property",  label: "Buy property",            sub: "Residential or investment property",          emoji: "🏠" },
+      { key: "shares",    label: "Invest in ASX shares",    sub: "Stocks, ETFs, or managed funds",              emoji: "📈" },
+      { key: "savings",   label: "Park money in AUD",       sub: "High-interest savings or term deposits",      emoji: "💰" },
+      { key: "business",  label: "Set up a business",       sub: "Company registration, structuring",           emoji: "🏢" },
+    ],
+  },
   goal: {
     text: "What are you trying to do?",
     options: [
@@ -122,7 +167,12 @@ const UNIFIED_QUESTIONS: Record<QuestionId, { text: string; options: { key: stri
 };
 
 /* ─── Navigation logic ─── */
+function isInternational(a: UnifiedAnswers): boolean {
+  return a.location === "international" || a.location === "expat";
+}
+
 function resolveTrack(a: UnifiedAnswers): QuizTrack {
+  if (isInternational(a)) return "international";
   if (a.goal === "help" || a.goal === "home") return "advisor";
   if (a.mode === "help") return "advisor";
   if (a.property_sub === "physical") return "advisor";
@@ -131,7 +181,26 @@ function resolveTrack(a: UnifiedAnswers): QuizTrack {
 
 function getNextId(id: QuestionId, a: UnifiedAnswers): QuestionId | null {
   const track = resolveTrack(a);
+
+  // International track
+  if (track === "international") {
+    switch (id) {
+      case "location":      return "investor_country";
+      case "investor_country": return "visa_status";
+      case "visa_status":   return "investor_goal_intl";
+      case "investor_goal_intl": return "amount";
+      case "amount":        return "advisor_type";
+      case "advisor_type":  return null;
+      // These shouldn't be hit but handle defensively
+      case "goal": case "mode": case "experience": case "complexity":
+      case "priority": case "property_sub": return null;
+    }
+  }
+
+  // Domestic track
   switch (id) {
+    case "location":
+      return "goal";
     case "goal":
       return (a.goal === "help" || a.goal === "home") ? "complexity" : "mode";
     case "mode":
@@ -146,17 +215,31 @@ function getNextId(id: QuestionId, a: UnifiedAnswers): QuestionId | null {
       return a.goal === "property" ? "property_sub" : null;
     case "property_sub":
       return null;
+    // International-only questions that shouldn't appear on domestic track
+    case "investor_country":
+    case "visa_status":
+    case "investor_goal_intl":
+      return null;
   }
 }
 
 function getTotalSteps(a: UnifiedAnswers): number {
+  if (isInternational(a)) return 5; // location + country + visa + goal + amount + advisor_type
   const skipMode = a.goal === "help" || a.goal === "home";
   const hasPropertySub = a.goal === "property";
-  return (skipMode ? 4 : 5) + (hasPropertySub ? 1 : 0);
+  return 1 + (skipMode ? 4 : 5) + (hasPropertySub ? 1 : 0); // +1 for location
 }
 
 function inferAdvisorType(a: UnifiedAnswers): string {
   if (a.advisor_type && a.advisor_type !== "not-sure") return a.advisor_type;
+  // International track
+  if (isInternational(a)) {
+    if (a.investor_goal_intl === "property") return "buyers-agent";
+    if (a.investor_goal_intl === "shares") return "tax-agent";
+    if (a.investor_goal_intl === "savings" || a.investor_goal_intl === "business") return "financial-planner";
+    return "tax-agent";
+  }
+  // Domestic track
   if (a.property_sub === "physical") return "buyers-agent";
   if (a.goal === "home") return "mortgage-broker";
   if (a.goal === "property") return "buyers-agent";
@@ -259,7 +342,7 @@ function clearProgress() {
 
 export default function QuizPage() {
   const [phase, setPhase] = useState<Phase>("questions");
-  const [currentId, setCurrentId] = useState<QuestionId>("goal");
+  const [currentId, setCurrentId] = useState<QuestionId>("location");
   const [answers, setAnswers] = useState<UnifiedAnswers>({});
   const [history, setHistory] = useState<QuestionId[]>([]);
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
@@ -496,7 +579,7 @@ export default function QuizPage() {
   const handleRestart = () => {
     clearProgress();
     setPhase("questions");
-    setCurrentId("goal");
+    setCurrentId("location");
     setAnswers({});
     setHistory([]);
     setShowScoring(false);
@@ -592,6 +675,10 @@ export default function QuizPage() {
         quizAnswers={answers as Record<string, string>}
         platformResults={results}
         onRestart={handleRestart}
+        isInternational={isInternational(answers)}
+        investorCountry={answers.investor_country}
+        visaStatus={answers.visa_status}
+        investorGoalIntl={answers.investor_goal_intl}
       />
     );
   }

--- a/app/share-trading/page.tsx
+++ b/app/share-trading/page.tsx
@@ -6,6 +6,7 @@ import { absoluteUrl } from "@/lib/seo";
 import { boostFeaturedPartner } from "@/lib/sponsorship";
 import VerticalPillarPage from "@/components/VerticalPillarPage";
 import ForeignInvestorCallout from "@/components/ForeignInvestorCallout";
+import NonResidentFilterBanner from "@/components/NonResidentFilterBanner";
 
 const vertical = getVerticalBySlug("share-trading")!;
 
@@ -79,12 +80,19 @@ export default async function ShareTradingPage() {
     .order("views", { ascending: false })
     .limit(3);
 
+  const nonResidentCount = sorted.filter(b => b.accepts_non_residents === true).length;
+
   return (
     <>
       <ForeignInvestorCallout
         href="/foreign-investment/shares"
         verticalName="Australian shares"
         keyRule="30% WHT on unfranked dividends (reduced by DTA) · CGT exempt for non-residents on most listed shares · limited broker access without Australian address"
+      />
+      <NonResidentFilterBanner
+        total={sorted.length}
+        nonResidentCount={nonResidentCount}
+        vertical="shares"
       />
       <VerticalPillarPage
         config={vertical}

--- a/components/BrokerCard.tsx
+++ b/components/BrokerCard.tsx
@@ -141,6 +141,21 @@ export default memo(function BrokerCard({
           )}
         </div>
 
+        {/* Non-resident eligibility badge */}
+        {broker.accepts_non_residents === true && (
+          <div className="flex items-center gap-1 mb-1.5">
+            <span className="text-[0.6rem] px-1.5 py-0.5 bg-blue-50 rounded font-bold text-blue-700">🌏 Accepts non-residents</span>
+            {broker.foreign_investor_notes && (
+              <span className="text-[0.55rem] text-slate-400 truncate">{broker.foreign_investor_notes}</span>
+            )}
+          </div>
+        )}
+        {broker.accepts_non_residents === false && broker.accepts_temporary_residents === true && (
+          <div className="flex items-center gap-1 mb-1.5">
+            <span className="text-[0.6rem] px-1.5 py-0.5 bg-amber-50 rounded font-bold text-amber-700">Temp visa only</span>
+          </div>
+        )}
+
         {/* Row 3: Deal (if active and not expired) */}
         {broker.deal && broker.deal_text && (!broker.deal_expiry || new Date(broker.deal_expiry).getTime() > Date.now()) && (
           <div className="flex items-center gap-1.5 px-2 py-1 bg-amber-50 border border-amber-200/80 rounded-lg">

--- a/components/FirbCostCalculatorInline.tsx
+++ b/components/FirbCostCalculatorInline.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import Link from "next/link";
+import { STATE_SURCHARGES, getFirbFee } from "@/lib/firb-data";
+
+const STATE_CODES = ["NSW", "VIC", "QLD", "WA", "SA", "TAS", "ACT", "NT"] as const;
+type StateCode = typeof STATE_CODES[number];
+
+// Very rough stamp duty estimate for illustration (not legal advice)
+function estimateStampDuty(price: number, state: StateCode): number {
+  if (state === "NSW") {
+    if (price <= 16_000) return Math.max(price * 0.0125, 20);
+    if (price <= 35_000) return 200 + (price - 16_000) * 0.015;
+    if (price <= 100_000) return 485 + (price - 35_000) * 0.0175;
+    if (price <= 300_000) return 1_622 + (price - 100_000) * 0.035;
+    if (price <= 1_000_000) return 8_622 + (price - 300_000) * 0.045;
+    return 40_122 + (price - 1_000_000) * 0.055;
+  }
+  if (state === "VIC") {
+    if (price <= 25_000) return price * 0.014;
+    if (price <= 130_000) return 350 + (price - 25_000) * 0.024;
+    if (price <= 440_000) return 2_870 + (price - 130_000) * 0.06;
+    if (price <= 550_000) return 21_470 + (price - 440_000) * 0.06;
+    return 28_070 + (price - 550_000) * 0.065;
+  }
+  if (state === "QLD") {
+    if (price <= 5_000) return 0;
+    if (price <= 75_000) return (price - 5_000) * 0.015;
+    if (price <= 540_000) return 1_050 + (price - 75_000) * 0.035;
+    if (price <= 1_000_000) return 17_325 + (price - 540_000) * 0.045;
+    return 38_025 + (price - 1_000_000) * 0.0575;
+  }
+  // Generic 3.5% estimate for other states
+  return price * 0.035;
+}
+
+interface Props {
+  defaultPrice: number;
+  defaultState: string;
+}
+
+export default function FirbCostCalculatorInline({ defaultPrice, defaultState }: Props) {
+  const [price, setPrice] = useState(defaultPrice);
+  const [state, setState] = useState<StateCode>(
+    STATE_CODES.includes(defaultState as StateCode) ? (defaultState as StateCode) : "NSW"
+  );
+  const [expanded, setExpanded] = useState(false);
+
+  const calc = useMemo(() => {
+    const surchargeRow = STATE_SURCHARGES.find(s => s.stateCode === state);
+    const surchargePercent = surchargeRow?.surchargePercent ?? 7;
+    const baseStampDuty = estimateStampDuty(price, state);
+    const foreignSurcharge = price * (surchargePercent / 100);
+    const firbFee = getFirbFee(price);
+    const total = baseStampDuty + foreignSurcharge + firbFee;
+    return { baseStampDuty, foreignSurcharge, firbFee, total, surchargePercent };
+  }, [price, state]);
+
+  const fmt = (n: number) =>
+    n >= 1_000_000
+      ? `$${(n / 1_000_000).toFixed(2)}M`
+      : `$${Math.round(n).toLocaleString("en-AU")}`;
+
+  if (!expanded) {
+    return (
+      <div className="border border-blue-200 bg-blue-50 rounded-xl p-4">
+        <div className="flex items-start gap-3">
+          <span className="text-xl leading-none mt-0.5 shrink-0">🌏</span>
+          <div className="flex-1">
+            <p className="text-sm font-bold text-blue-900 mb-1">Foreign buyer? Calculate your full upfront cost</p>
+            <p className="text-xs text-blue-700 mb-3">
+              Includes FIRB application fee + foreign buyer stamp duty surcharge ({calc.surchargePercent}% in {state}) + standard stamp duty.
+              Total estimated: <span className="font-bold text-blue-900">{fmt(calc.total)}</span>
+            </p>
+            <button
+              onClick={() => setExpanded(true)}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-blue-600 text-white text-xs font-bold rounded-lg hover:bg-blue-700 transition-colors"
+            >
+              Show full cost breakdown →
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="border border-blue-200 bg-blue-50 rounded-xl p-4">
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2">
+          <span className="text-lg leading-none">🌏</span>
+          <h3 className="text-sm font-bold text-blue-900">Foreign Buyer Cost Calculator</h3>
+        </div>
+        <button onClick={() => setExpanded(false)} className="text-[0.65rem] text-blue-600 hover:text-blue-800 font-semibold">Collapse</button>
+      </div>
+
+      {/* Inputs */}
+      <div className="grid grid-cols-2 gap-3 mb-4">
+        <div>
+          <label className="block text-xs font-semibold text-blue-900 mb-1">Property Price (AUD)</label>
+          <input
+            type="number"
+            value={price}
+            onChange={e => setPrice(Math.max(0, Number(e.target.value)))}
+            step={50000}
+            className="w-full px-3 py-2 border border-blue-200 rounded-lg text-sm bg-white focus:outline-none focus:ring-2 focus:ring-blue-400/30"
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-semibold text-blue-900 mb-1">State</label>
+          <select
+            value={state}
+            onChange={e => setState(e.target.value as StateCode)}
+            className="w-full px-3 py-2 border border-blue-200 rounded-lg text-sm bg-white focus:outline-none focus:ring-2 focus:ring-blue-400/30"
+          >
+            {STATE_CODES.map(s => <option key={s} value={s}>{s}</option>)}
+          </select>
+        </div>
+      </div>
+
+      {/* Breakdown */}
+      <div className="bg-white rounded-lg border border-blue-200 overflow-hidden mb-4">
+        <div className="px-4 py-3 border-b border-blue-100 flex justify-between items-center">
+          <span className="text-xs text-slate-600">Standard stamp duty (est.)</span>
+          <span className="text-xs font-bold text-slate-900">{fmt(calc.baseStampDuty)}</span>
+        </div>
+        <div className="px-4 py-3 border-b border-blue-100 flex justify-between items-center bg-blue-50/50">
+          <span className="text-xs text-blue-700">Foreign buyer surcharge ({calc.surchargePercent}% in {state})</span>
+          <span className="text-xs font-bold text-blue-800">{fmt(calc.foreignSurcharge)}</span>
+        </div>
+        <div className="px-4 py-3 border-b border-blue-100 flex justify-between items-center">
+          <span className="text-xs text-slate-600">FIRB application fee</span>
+          <span className="text-xs font-bold text-slate-900">{fmt(calc.firbFee)}</span>
+        </div>
+        <div className="px-4 py-3 flex justify-between items-center bg-blue-600">
+          <span className="text-xs font-bold text-white">Total upfront (est.)</span>
+          <span className="text-base font-extrabold text-white">{fmt(calc.total)}</span>
+        </div>
+      </div>
+
+      <p className="text-[0.6rem] text-blue-700/70 mb-3">
+        Estimates only. Stamp duty calculated using simplified rates — get a conveyancer to confirm exact figures. FIRB fees current as at Jan 2026.
+        Temporary residents and Australian expats may have different thresholds.
+      </p>
+
+      <div className="flex items-center gap-2 flex-wrap">
+        <Link
+          href="/property/foreign-investment"
+          className="inline-flex items-center gap-1 px-3 py-1.5 bg-blue-600 text-white text-xs font-bold rounded-lg hover:bg-blue-700 transition-colors"
+        >
+          FIRB application guide →
+        </Link>
+        <Link
+          href="/advisors?type=buyers_agent&specialty=International+Clients"
+          className="inline-flex items-center gap-1 px-3 py-1.5 bg-white text-blue-700 border border-blue-200 text-xs font-bold rounded-lg hover:bg-blue-50 transition-colors"
+        >
+          Find a FIRB-specialist buyer&apos;s agent
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/components/InternationalBanner.tsx
+++ b/components/InternationalBanner.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Link from "next/link";
+import Icon from "@/components/Icon";
+
+const DISMISS_KEY = "intl-banner-dismissed-v1";
+
+// AU and NZ don't see the banner
+const DOMESTIC_COUNTRIES = new Set(["AU", "NZ"]);
+
+interface Props {
+  countryCode: string | null;
+}
+
+export default function InternationalBanner({ countryCode }: Props) {
+  const [dismissed, setDismissed] = useState(true); // start dismissed to avoid flash
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(DISMISS_KEY);
+      if (!stored) setDismissed(false);
+    } catch {
+      setDismissed(false);
+    }
+  }, []);
+
+  const handleDismiss = () => {
+    setDismissed(true);
+    try { localStorage.setItem(DISMISS_KEY, "1"); } catch { /* ignore */ }
+  };
+
+  if (!countryCode || DOMESTIC_COUNTRIES.has(countryCode) || dismissed) return null;
+
+  return (
+    <div className="bg-gradient-to-r from-indigo-600 to-blue-700 text-white text-sm">
+      <div className="container-custom max-w-7xl flex items-center justify-between gap-3 py-2.5 px-4">
+        <div className="flex items-center gap-2.5 min-w-0">
+          <span className="text-base leading-none shrink-0">🌏</span>
+          <p className="text-xs md:text-sm font-medium text-white/95 truncate">
+            <span className="hidden md:inline">Investing in Australia from overseas? </span>
+            <Link
+              href="/foreign-investment"
+              className="font-bold text-white underline underline-offset-2 hover:text-blue-100"
+            >
+              See our international investor guide
+            </Link>
+            <span className="hidden md:inline text-white/70"> — FIRB rules, broker eligibility, double tax agreements &amp; specialist advisors.</span>
+          </p>
+        </div>
+        <button
+          onClick={handleDismiss}
+          aria-label="Dismiss"
+          className="shrink-0 text-white/70 hover:text-white transition-colors"
+        >
+          <Icon name="x" size={16} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/InternationalBannerServer.tsx
+++ b/components/InternationalBannerServer.tsx
@@ -1,0 +1,9 @@
+import { headers } from "next/headers";
+import InternationalBanner from "./InternationalBanner";
+
+export default async function InternationalBannerServer() {
+  const hdrs = await headers();
+  // Vercel sets x-vercel-ip-country on all edge requests; falls back to null in dev
+  const countryCode = hdrs.get("x-vercel-ip-country");
+  return <InternationalBanner countryCode={countryCode} />;
+}

--- a/components/NonResidentFilterBanner.tsx
+++ b/components/NonResidentFilterBanner.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import Icon from "@/components/Icon";
+
+interface Props {
+  /** Total brokers shown on the page */
+  total: number;
+  /** How many accept non-residents */
+  nonResidentCount: number;
+  /** Vertical — so we can link to the right foreign-investment sub-page */
+  vertical?: "shares" | "crypto" | "savings" | "cfd";
+}
+
+const VERTICAL_LINKS: Record<string, string> = {
+  shares: "/foreign-investment/shares",
+  crypto: "/foreign-investment/crypto",
+  savings: "/foreign-investment/savings",
+  cfd: "/foreign-investment/shares",
+};
+
+export default function NonResidentFilterBanner({ total, nonResidentCount, vertical = "shares" }: Props) {
+  const [dismissed, setDismissed] = useState(false);
+  if (dismissed || nonResidentCount === 0) return null;
+
+  const href = VERTICAL_LINKS[vertical] || "/foreign-investment";
+
+  return (
+    <div className="bg-blue-50 border border-blue-200 rounded-xl p-4 mb-5 flex items-start gap-3">
+      <span className="text-xl leading-none mt-0.5 shrink-0">🌏</span>
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-bold text-blue-900 mb-1">
+          Based outside Australia? Only {nonResidentCount} of {total} platforms accept non-residents.
+        </p>
+        <p className="text-xs text-blue-700 mb-2">
+          Many Australian brokers require an Australian address or residential status. See our filtered guide showing only platforms that accept international applicants.
+        </p>
+        <Link
+          href={href}
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-blue-600 text-white text-xs font-bold rounded-lg hover:bg-blue-700 transition-colors"
+        >
+          <Icon name="filter" size={13} />
+          Show non-resident friendly platforms only →
+        </Link>
+      </div>
+      <button
+        onClick={() => setDismissed(true)}
+        aria-label="Dismiss"
+        className="text-blue-400 hover:text-blue-600 transition-colors shrink-0 mt-0.5"
+      >
+        <Icon name="x" size={16} />
+      </button>
+    </div>
+  );
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -112,6 +112,11 @@ export interface Broker {
   reviewed_at?: string;
   created_at: string;
   updated_at: string;
+  // International / non-resident eligibility
+  accepts_non_residents?: boolean | null;
+  accepts_temporary_residents?: boolean | null;
+  requires_australian_address?: boolean | null;
+  foreign_investor_notes?: string | null;
 }
 
 export interface Article {
@@ -1021,6 +1026,12 @@ export interface Professional {
   auto_paused_at?: string;
   auto_pause_reason?: string;
   pause_warning_sent_at?: string;
+  // International client fields
+  accepts_international_clients?: boolean;
+  international_tax_specialist?: boolean;
+  firb_specialist?: boolean;
+  migration_agent?: boolean;
+  migration_agent_marn?: string;
 }
 
 export interface ProfessionalLead {


### PR DESCRIPTION
…visor filtering, geolocation banner, lead pricing, FIRB calculator

- types.ts: add accepts_international_clients, firb_specialist, international_tax_specialist, migration_agent fields to Professional; add accepts_non_residents, accepts_temporary_residents, foreign_investor_notes to Broker
- Quiz: new location question as entry point (Australia / outside Australia / expat); international track branches into country → visa_status → investor_goal_intl → amount → advisor_type; inferAdvisorType handles international goals; AdvisorResultsScreen gets isInternational prop, shows context banner, queries international-specialist advisors first via accepts_international_clients flag and specialty matching
- Advisor directory: internationalOnly filter toggle (toggle switch in filter panel); active filter chip; filtering logic respects accepts_international_clients + firb_specialist + international_tax_specialist; advisor cards show 🌏 Intl and FIRB badges; profile page shows International Clients / FIRB Specialist / Cross-Border Tax badges and languages spoken
- IP geolocation: InternationalBannerServer reads x-vercel-ip-country header; InternationalBanner (dismissible client component) shown to non-AU/NZ visitors with link to /foreign-investment; injected in app/layout.tsx above LayoutShell
- Lead routing: advisor-enquiry route detects international leads via Vercel IP header + quiz flags; applies 3x price multiplier for international tier; email notification shows 🌏 badge; advisor-lead route accepts is_international, investor_country, visa_status, investor_goal_intl; stores as international tier in email_captures; relaxes AU phone validation for international users
- Broker pages: NonResidentFilterBanner component shows count of non-resident-friendly brokers and links to filtered guide; added to share-trading page; BrokerCard displays 🌏 Accepts non-residents badge and Temp visa only badge based on accepts_non_residents field
- FIRB calculator: FirbCostCalculatorInline component with collapsible UX — shows estimated stamp duty + foreign surcharge + FIRB fee broken down by state; uses STATE_SURCHARGES and getFirbFee from lib/firb-data.ts; injected on property listings for FIRB-approved, foreign-buyer-eligible, off-the-plan, and new-development listings

https://claude.ai/code/session_01Sc4b8zVmRCqqYVZ8tf4JPD