### PR TITLE
8 UX/feature improvements: DASP calc, super contributions calc, compa…

### DIFF
--- a/app/best/[slug]/page.tsx
+++ b/app/best/[slug]/page.tsx
@@ -634,9 +634,14 @@ export default async function BestBrokerPage({
 
           {/* Cross-links to other best-for categories */}
           <div className="border-t border-slate-100 pt-5 md:pt-8">
-            <h3 className="text-base md:text-lg font-bold mb-3 md:mb-4">
-              More Investing Guides
-            </h3>
+            <div className="flex items-center justify-between mb-3 md:mb-4">
+              <h3 className="text-base md:text-lg font-bold">
+                More Investing Guides
+              </h3>
+              <Link href="/best" className="text-xs font-semibold text-amber-600 hover:text-amber-700 whitespace-nowrap">
+                View all categories &rarr;
+              </Link>
+            </div>
             <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
               {allCategories.slice(0, 6).map((otherCat) => (
                 <Link

--- a/app/broker/page.tsx
+++ b/app/broker/page.tsx
@@ -1,0 +1,9 @@
+import { redirect } from "next/navigation";
+
+/**
+ * /broker — no index page exists; redirect to the compare page
+ * which is the primary broker discovery experience.
+ */
+export default function BrokerIndexPage() {
+  redirect("/compare");
+}

--- a/app/compare/CompareNav.tsx
+++ b/app/compare/CompareNav.tsx
@@ -1,0 +1,41 @@
+import Link from "next/link";
+
+const NAV_ITEMS = [
+  { label: "All Platforms", href: "/compare", short: "All" },
+  { label: "ETFs", href: "/compare/etfs", short: "ETFs" },
+  { label: "Super Funds", href: "/compare/super", short: "Super" },
+  { label: "Insurance", href: "/compare/insurance", short: "Insurance" },
+];
+
+interface Props {
+  current: string; // matches href
+}
+
+export default function CompareNav({ current }: Props) {
+  return (
+    <div className="bg-white border-b border-slate-200 sticky top-0 z-10 shadow-sm">
+      <div className="container-custom">
+        <nav className="flex items-center gap-0.5 overflow-x-auto scrollbar-none" aria-label="Compare sections">
+          {NAV_ITEMS.map((item) => {
+            const active = item.href === current;
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                className={`shrink-0 px-3 py-3 text-xs font-semibold border-b-2 transition-colors whitespace-nowrap ${
+                  active
+                    ? "border-amber-500 text-amber-700"
+                    : "border-transparent text-slate-500 hover:text-slate-800 hover:border-slate-300"
+                }`}
+                aria-current={active ? "page" : undefined}
+              >
+                <span className="hidden sm:inline">{item.label}</span>
+                <span className="sm:hidden">{item.short}</span>
+              </Link>
+            );
+          })}
+        </nav>
+      </div>
+    </div>
+  );
+}

--- a/app/compare/etfs/page.tsx
+++ b/app/compare/etfs/page.tsx
@@ -1,5 +1,6 @@
 import { UPDATED_LABEL } from "@/lib/seo";
 import ETFCompareClient from "./ETFCompareClient";
+import CompareNav from "../CompareNav";
 
 export const metadata = {
   title: "Compare Australian ETFs — Fees, Returns & Holdings (2026)",
@@ -32,6 +33,7 @@ export default function ETFComparePage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
       />
+      <CompareNav current="/compare/etfs" />
       <ETFCompareClient />
     </>
   );

--- a/app/compare/insurance/page.tsx
+++ b/app/compare/insurance/page.tsx
@@ -1,5 +1,6 @@
 import { UPDATED_LABEL } from "@/lib/seo";
 import InsuranceCompareClient from "./InsuranceCompareClient";
+import CompareNav from "../CompareNav";
 
 export const metadata = {
   title: "Compare Insurance in Australia — Life, Income, Home (2026)",
@@ -79,6 +80,7 @@ export default function InsuranceComparePage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }}
       />
+      <CompareNav current="/compare/insurance" />
       <InsuranceCompareClient />
     </>
   );

--- a/app/compare/super/page.tsx
+++ b/app/compare/super/page.tsx
@@ -1,5 +1,6 @@
 import { UPDATED_LABEL } from "@/lib/seo";
 import SuperCompareClient from "./SuperCompareClient";
+import CompareNav from "../CompareNav";
 
 export const metadata = {
   title: "Compare Super Funds — Fees & Performance (2026)",
@@ -79,6 +80,7 @@ export default function SuperComparePage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }}
       />
+      <CompareNav current="/compare/super" />
       <SuperCompareClient />
     </>
   );

--- a/app/foreign-investment/DASPCalculator.tsx
+++ b/app/foreign-investment/DASPCalculator.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { useState } from "react";
+
+type VisaType = "standard" | "whm";
+
+const RATES = {
+  standard: { taxed: 35, untaxed: 65, taxFree: 0 },
+  whm: { taxed: 65, untaxed: 65, taxFree: 0 },
+};
+
+export default function DASPCalculator() {
+  const [visaType, setVisaType] = useState<VisaType>("standard");
+  const [totalBalance, setTotalBalance] = useState<string>("");
+  const [taxFreePercent, setTaxFreePercent] = useState<string>("0");
+
+  const balance = parseFloat(totalBalance.replace(/,/g, "")) || 0;
+  const taxFreeShare = Math.min(100, Math.max(0, parseFloat(taxFreePercent) || 0)) / 100;
+  const rates = RATES[visaType];
+
+  const taxFreeAmount = balance * taxFreeShare;
+  const taxedAmount = balance * (1 - taxFreeShare);
+
+  const whtOnTaxFree = 0;
+  const whtOnTaxed = taxedAmount * (rates.taxed / 100);
+  const totalWHT = whtOnTaxFree + whtOnTaxed;
+  const netReceived = balance - totalWHT;
+  const effectiveRate = balance > 0 ? (totalWHT / balance) * 100 : 0;
+
+  const fmt = (n: number) =>
+    n.toLocaleString("en-AU", { style: "currency", currency: "AUD", maximumFractionDigits: 0 });
+
+  return (
+    <div className="bg-white rounded-2xl border border-slate-200 shadow-sm p-6">
+      <p className="text-xs font-bold uppercase tracking-wider text-amber-600 mb-1">Interactive tool</p>
+      <h3 className="text-lg font-extrabold text-slate-900 mb-1">DASP withdrawal calculator</h3>
+      <p className="text-xs text-slate-500 mb-5 leading-relaxed">
+        Estimate how much you&apos;ll receive when you claim your superannuation through the
+        Departing Australia Superannuation Payment (DASP) scheme.
+      </p>
+
+      <div className="grid sm:grid-cols-2 gap-4 mb-5">
+        {/* Visa type */}
+        <div>
+          <label className="block text-xs font-bold text-slate-700 mb-1.5">Visa type</label>
+          <div className="grid grid-cols-2 gap-2">
+            {(["standard", "whm"] as VisaType[]).map((v) => (
+              <button
+                key={v}
+                onClick={() => setVisaType(v)}
+                className={`rounded-xl border-2 px-3 py-2.5 text-xs font-semibold transition-all text-left ${
+                  visaType === v
+                    ? "border-amber-500 bg-amber-50 text-amber-800"
+                    : "border-slate-200 bg-white text-slate-600 hover:border-slate-300"
+                }`}
+              >
+                {v === "standard" ? (
+                  <>
+                    <div className="font-extrabold mb-0.5">Standard temp visa</div>
+                    <div className="text-[0.65rem] opacity-80">457, 482, 485, student, etc.</div>
+                    <div className="text-[0.65rem] font-bold text-red-600 mt-1">35% WHT on taxed element</div>
+                  </>
+                ) : (
+                  <>
+                    <div className="font-extrabold mb-0.5">Working Holiday Maker</div>
+                    <div className="text-[0.65rem] opacity-80">Subclass 417 or 462</div>
+                    <div className="text-[0.65rem] font-bold text-red-700 mt-1">65% WHT on all elements</div>
+                  </>
+                )}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Super balance */}
+        <div className="space-y-3">
+          <div>
+            <label className="block text-xs font-bold text-slate-700 mb-1.5">Super balance (AUD)</label>
+            <div className="relative">
+              <span className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 text-sm font-medium">$</span>
+              <input
+                type="text"
+                inputMode="decimal"
+                value={totalBalance}
+                onChange={(e) => setTotalBalance(e.target.value.replace(/[^0-9.]/g, ""))}
+                placeholder="10,000"
+                className="w-full pl-7 pr-4 py-2.5 text-sm border border-slate-300 rounded-xl bg-white text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-amber-400/50 focus:border-amber-400 transition"
+              />
+            </div>
+          </div>
+          <div>
+            <label className="block text-xs font-bold text-slate-700 mb-1">
+              Tax-free component (%)
+              <span className="font-normal text-slate-400 ml-1">— after-tax contributions only</span>
+            </label>
+            <div className="relative">
+              <input
+                type="number"
+                min={0}
+                max={100}
+                value={taxFreePercent}
+                onChange={(e) => setTaxFreePercent(e.target.value)}
+                placeholder="0"
+                className="w-full pr-8 pl-3 py-2 text-sm border border-slate-300 rounded-xl bg-white text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-amber-400/50 focus:border-amber-400 transition"
+              />
+              <span className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 text-sm">%</span>
+            </div>
+            <p className="text-[0.6rem] text-slate-400 mt-1">Most super is 0% tax-free. Only non-concessional (after-tax) contributions are tax-free.</p>
+          </div>
+        </div>
+      </div>
+
+      {/* Result */}
+      {balance > 0 ? (
+        <div className="rounded-2xl bg-slate-50 border border-slate-200 p-5">
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-4">
+            <div className="text-center">
+              <p className="text-[0.65rem] font-bold text-slate-500 uppercase tracking-wide mb-0.5">Super balance</p>
+              <p className="text-base font-black text-slate-900">{fmt(balance)}</p>
+            </div>
+            <div className="text-center">
+              <p className="text-[0.65rem] font-bold text-slate-500 uppercase tracking-wide mb-0.5">WHT deducted</p>
+              <p className="text-base font-black text-red-700">−{fmt(totalWHT)}</p>
+            </div>
+            <div className="text-center">
+              <p className="text-[0.65rem] font-bold text-slate-500 uppercase tracking-wide mb-0.5">You receive</p>
+              <p className="text-base font-black text-green-700">{fmt(netReceived)}</p>
+            </div>
+            <div className="text-center">
+              <p className="text-[0.65rem] font-bold text-slate-500 uppercase tracking-wide mb-0.5">Effective rate</p>
+              <p className="text-base font-black text-slate-700">{effectiveRate.toFixed(1)}%</p>
+            </div>
+          </div>
+
+          {/* Breakdown bar */}
+          {balance > 0 && (
+            <div className="mb-3">
+              <div className="flex rounded-full overflow-hidden h-3">
+                <div
+                  className="bg-green-500 transition-all"
+                  style={{ width: `${(netReceived / balance) * 100}%` }}
+                />
+                <div
+                  className="bg-red-400 transition-all"
+                  style={{ width: `${(totalWHT / balance) * 100}%` }}
+                />
+              </div>
+              <div className="flex justify-between mt-1 text-[0.6rem] text-slate-500">
+                <span className="flex items-center gap-1"><span className="w-2 h-2 rounded-full bg-green-500 inline-block" />You receive ({(100 - effectiveRate).toFixed(0)}%)</span>
+                <span className="flex items-center gap-1"><span className="w-2 h-2 rounded-full bg-red-400 inline-block" />Tax withheld ({effectiveRate.toFixed(0)}%)</span>
+              </div>
+            </div>
+          )}
+
+          <div className="bg-amber-50 border border-amber-200 rounded-xl px-4 py-3 text-xs text-amber-800 leading-relaxed">
+            {visaType === "whm"
+              ? `Working Holiday Makers pay 65% DASP withholding on all components. On a ${fmt(balance)} balance, ${fmt(totalWHT)} is withheld and you receive ${fmt(netReceived)}.`
+              : taxFreeAmount > 0
+              ? `Standard temp visa: ${fmt(taxFreeAmount)} (tax-free component) returned at 100%, ${fmt(taxedAmount)} (taxed element) at 35% WHT. Total received: ${fmt(netReceived)}.`
+              : `Standard temp visa: 35% withheld on the taxed element (most employer SG contributions). You receive ${fmt(netReceived)} from ${fmt(balance)}.`}
+          </div>
+        </div>
+      ) : (
+        <div className="rounded-2xl bg-slate-50 border border-slate-200 px-5 py-6 text-center">
+          <p className="text-sm text-slate-400">Enter your super balance above to see your estimated DASP payout</p>
+        </div>
+      )}
+
+      <p className="mt-3 text-[0.65rem] text-slate-400 leading-relaxed">
+        Estimates only. Most super balances are 100% taxed element (concessional contributions and earnings). Tax-free component only arises from non-concessional (after-tax) contributions. Consult your super fund and a registered tax agent for exact figures.
+      </p>
+    </div>
+  );
+}

--- a/app/foreign-investment/cfd/page.tsx
+++ b/app/foreign-investment/cfd/page.tsx
@@ -7,6 +7,7 @@ import {
   FOREIGN_INVESTOR_GENERAL_DISCLAIMER,
 } from "@/lib/compliance";
 import ForeignInvestmentNav from "../ForeignInvestmentNav";
+import SectionHeading from "@/components/SectionHeading";
 
 export const metadata: Metadata = {
   title: "CFD & Forex Trading for Non-Residents in Australia — 2026 Guide — Invest.com.au",
@@ -84,16 +85,6 @@ const CFD_FAQS = [
     answer: "Almost certainly yes. Most countries tax their residents on worldwide income, including profits from CFD trading via Australian or offshore brokers. Even if Australia doesn't withhold tax automatically, your home country will likely require you to report and pay tax on CFD profits. Get advice from a tax professional in your home country.",
   },
 ];
-
-function SectionHeading({ eyebrow, title, sub }: { eyebrow: string; title: string; sub?: string }) {
-  return (
-    <div className="mb-6 md:mb-8">
-      <p className="text-xs font-bold uppercase tracking-wider text-amber-600 mb-1">{eyebrow}</p>
-      <h2 className="text-xl md:text-2xl font-extrabold text-slate-900">{title}</h2>
-      {sub && <p className="text-sm text-slate-500 mt-1 leading-relaxed">{sub}</p>}
-    </div>
-  );
-}
 
 const ASIC_LEVERAGE_LIMITS = [
   { market: "Major forex pairs", limit: "30:1", examples: "EUR/USD, GBP/USD, USD/JPY", color: "green" },

--- a/app/foreign-investment/crypto/page.tsx
+++ b/app/foreign-investment/crypto/page.tsx
@@ -5,6 +5,7 @@ import { breadcrumbJsonLd, SITE_URL } from "@/lib/seo";
 import { BROKER_NON_RESIDENT_NOTE, FOREIGN_INVESTOR_GENERAL_DISCLAIMER, CRYPTO_REGULATORY_NOTE } from "@/lib/compliance";
 import type { Broker } from "@/lib/types";
 import ForeignInvestmentNav from "../ForeignInvestmentNav";
+import SectionHeading from "@/components/SectionHeading";
 
 export const metadata: Metadata = {
   title: "Crypto for Non-Residents in Australia — AUSTRAC, KYC & Tax — 2026 Guide",
@@ -88,16 +89,6 @@ async function getBrokers(): Promise<Broker[]> {
   } catch {
     return [];
   }
-}
-
-function SectionHeading({ eyebrow, title, sub }: { eyebrow: string; title: string; sub?: string }) {
-  return (
-    <div className="mb-6 md:mb-8">
-      <p className="text-xs font-bold uppercase tracking-wider text-amber-600 mb-1">{eyebrow}</p>
-      <h2 className="text-xl md:text-2xl font-extrabold text-slate-900">{title}</h2>
-      {sub && <p className="text-sm text-slate-500 mt-1 leading-relaxed">{sub}</p>}
-    </div>
-  );
 }
 
 export default async function ForeignCryptoPage() {

--- a/app/foreign-investment/page.tsx
+++ b/app/foreign-investment/page.tsx
@@ -14,6 +14,7 @@ import PersonaSelector from "./PersonaSelector";
 import DTASearchTable from "./DTASearchTable";
 import ForeignInvestmentNav from "./ForeignInvestmentNav";
 import WHTCalculator from "./WHTCalculator";
+import SectionHeading from "@/components/SectionHeading";
 
 export const metadata: Metadata = {
   title: "Foreign Investment in Australia — Complete Guide 2026 — Invest.com.au",
@@ -80,16 +81,6 @@ const HUB_FAQS = [
       "Yes. Temporary visa holders physically living and working in Australia are treated as Australian tax residents and can invest like residents — open any brokerage, crypto exchange, or savings account. The key difference is at the end: when you leave, you can claim DASP (your super back), you may be taxed differently, and any property you bought as a primary residence must be sold on departure.",
   },
 ];
-
-function SectionHeading({ eyebrow, title, sub }: { eyebrow: string; title: string; sub?: string }) {
-  return (
-    <div className="mb-6 md:mb-8">
-      <p className="text-xs font-bold uppercase tracking-wider text-amber-600 mb-1">{eyebrow}</p>
-      <h2 className="text-xl md:text-2xl font-extrabold text-slate-900">{title}</h2>
-      {sub && <p className="text-sm text-slate-500 mt-1 leading-relaxed">{sub}</p>}
-    </div>
-  );
-}
 
 const participationColors: Record<string, string> = {
   yes: "bg-green-100 text-green-800",

--- a/app/foreign-investment/savings/page.tsx
+++ b/app/foreign-investment/savings/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import { breadcrumbJsonLd, SITE_URL } from "@/lib/seo";
 import { BROKER_NON_RESIDENT_NOTE, FOREIGN_INVESTOR_GENERAL_DISCLAIMER, WITHHOLDING_TAX_NOTE } from "@/lib/compliance";
 import ForeignInvestmentNav from "../ForeignInvestmentNav";
+import SectionHeading from "@/components/SectionHeading";
 
 export const metadata: Metadata = {
   title: "Savings Accounts for Non-Residents in Australia — 2026 Guide — Invest.com.au",
@@ -72,16 +73,6 @@ const SAVINGS_FAQS = [
     answer: "Possibly. Most countries tax their residents on worldwide income — including foreign interest income. Australia will not double-tax you (the 10% WHT is the final Australian tax), but you may owe tax in your home country on the gross interest. A foreign tax credit for the 10% Australian WHT may be available under a DTA.",
   },
 ];
-
-function SectionHeading({ eyebrow, title, sub }: { eyebrow: string; title: string; sub?: string }) {
-  return (
-    <div className="mb-6 md:mb-8">
-      <p className="text-xs font-bold uppercase tracking-wider text-amber-600 mb-1">{eyebrow}</p>
-      <h2 className="text-xl md:text-2xl font-extrabold text-slate-900">{title}</h2>
-      {sub && <p className="text-sm text-slate-500 mt-1 leading-relaxed">{sub}</p>}
-    </div>
-  );
-}
 
 export default function ForeignSavingsPage() {
   const breadcrumb = breadcrumbJsonLd([

--- a/app/foreign-investment/shares/page.tsx
+++ b/app/foreign-investment/shares/page.tsx
@@ -5,6 +5,7 @@ import { breadcrumbJsonLd, SITE_URL } from "@/lib/seo";
 import { BROKER_NON_RESIDENT_NOTE, FOREIGN_INVESTOR_GENERAL_DISCLAIMER, WITHHOLDING_TAX_NOTE } from "@/lib/compliance";
 import type { Broker } from "@/lib/types";
 import ForeignInvestmentNav from "../ForeignInvestmentNav";
+import SectionHeading from "@/components/SectionHeading";
 
 export const metadata: Metadata = {
   title: "Investing in Australian Shares as a Non-Resident — 2026 Guide — Invest.com.au",
@@ -92,16 +93,6 @@ async function getBrokers(): Promise<Broker[]> {
   } catch {
     return [];
   }
-}
-
-function SectionHeading({ eyebrow, title, sub }: { eyebrow: string; title: string; sub?: string }) {
-  return (
-    <div className="mb-6 md:mb-8">
-      <p className="text-xs font-bold uppercase tracking-wider text-amber-600 mb-1">{eyebrow}</p>
-      <h2 className="text-xl md:text-2xl font-extrabold text-slate-900">{title}</h2>
-      {sub && <p className="text-sm text-slate-500 mt-1 leading-relaxed">{sub}</p>}
-    </div>
-  );
 }
 
 export default async function ForeignSharesPage() {

--- a/app/foreign-investment/super/page.tsx
+++ b/app/foreign-investment/super/page.tsx
@@ -8,6 +8,8 @@ import {
 } from "@/lib/foreign-investment-data";
 import { DASP_WARNING, FOREIGN_INVESTOR_GENERAL_DISCLAIMER } from "@/lib/compliance";
 import ForeignInvestmentNav from "../ForeignInvestmentNav";
+import SectionHeading from "@/components/SectionHeading";
+import DASPCalculator from "../DASPCalculator";
 
 export const metadata: Metadata = {
   title: "Superannuation for Foreign Workers in Australia — DASP Guide 2026 — Invest.com.au",
@@ -31,16 +33,6 @@ export const metadata: Metadata = {
 };
 
 export const revalidate = 86400;
-
-function SectionHeading({ eyebrow, title, sub }: { eyebrow: string; title: string; sub?: string }) {
-  return (
-    <div className="mb-6 md:mb-8">
-      <p className="text-xs font-bold uppercase tracking-wider text-amber-600 mb-1">{eyebrow}</p>
-      <h2 className="text-xl md:text-2xl font-extrabold text-slate-900">{title}</h2>
-      {sub && <p className="text-sm text-slate-500 mt-1 leading-relaxed">{sub}</p>}
-    </div>
-  );
-}
 
 const SUPER_SECTIONS = [
   {
@@ -272,8 +264,15 @@ export default function ForeignSuperPage() {
         </div>
       </section>
 
-      {/* ── Detailed Sections ────────────────────────────────────────── */}
+      {/* ── DASP Calculator ──────────────────────────────────────────── */}
       <section className="py-12 md:py-16">
+        <div className="container-custom max-w-3xl">
+          <DASPCalculator />
+        </div>
+      </section>
+
+      {/* ── Detailed Sections ────────────────────────────────────────── */}
+      <section className="py-12 md:py-16 bg-slate-50">
         <div className="container-custom max-w-3xl">
           <SectionHeading
             eyebrow="Complete guide"

--- a/app/foreign-investment/tax/page.tsx
+++ b/app/foreign-investment/tax/page.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/lib/compliance";
 import DTASearchTable from "../DTASearchTable";
 import ForeignInvestmentNav from "../ForeignInvestmentNav";
+import SectionHeading from "@/components/SectionHeading";
 
 export const metadata: Metadata = {
   title: "Australian Tax for Non-Residents & Foreign Investors — 2026 Guide — Invest.com.au",
@@ -39,16 +40,6 @@ export const metadata: Metadata = {
 };
 
 export const revalidate = 86400;
-
-function SectionHeading({ eyebrow, title, sub }: { eyebrow: string; title: string; sub?: string }) {
-  return (
-    <div className="mb-6 md:mb-8">
-      <p className="text-xs font-bold uppercase tracking-wider text-amber-600 mb-1">{eyebrow}</p>
-      <h2 className="text-xl md:text-2xl font-extrabold text-slate-900">{title}</h2>
-      {sub && <p className="text-sm text-slate-500 mt-1 leading-relaxed">{sub}</p>}
-    </div>
-  );
-}
 
 const TAX_FAQS = [
   {

--- a/app/property/foreign-investment/page.tsx
+++ b/app/property/foreign-investment/page.tsx
@@ -12,6 +12,7 @@ import { FIRB_DISCLAIMER, FOREIGN_BUYER_STAMP_DUTY_WARNING } from "@/lib/complia
 import { breadcrumbJsonLd, SITE_URL } from "@/lib/seo";
 import CostCalculator from "./CostCalculator";
 import FaqAccordion from "./FaqAccordion";
+import SectionHeading from "@/components/SectionHeading";
 
 export const metadata: Metadata = {
   title: "Foreign Investment in Australian Property — FIRB Guide 2026 — Invest.com.au",
@@ -39,16 +40,6 @@ export const revalidate = 86400; // revalidate daily
 function formatCurrency(n: number) {
   if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(n % 1_000_000 === 0 ? 0 : 1)}M`;
   return `$${n.toLocaleString("en-AU")}`;
-}
-
-function SectionHeading({ eyebrow, title, sub }: { eyebrow: string; title: string; sub?: string }) {
-  return (
-    <div className="mb-6 md:mb-8">
-      <p className="text-xs font-bold uppercase tracking-wider text-amber-600 mb-1">{eyebrow}</p>
-      <h2 className="text-xl md:text-2xl font-extrabold text-slate-900">{title}</h2>
-      {sub && <p className="text-sm text-slate-500 mt-1 leading-relaxed">{sub}</p>}
-    </div>
-  );
 }
 
 export default function ForeignInvestmentPage() {

--- a/app/super-contributions-calculator/SuperContributionsClient.tsx
+++ b/app/super-contributions-calculator/SuperContributionsClient.tsx
@@ -1,0 +1,452 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import Link from "next/link";
+
+/* ── constants (FY2026) ── */
+
+const CONCESSIONAL_CAP = 30_000;
+const NON_CONCESSIONAL_CAP = 120_000;
+const BRING_FORWARD_CAP = 360_000;
+const DIV293_THRESHOLD = 250_000;
+const DIV293_EXTRA_RATE = 0.15; // extra 15% for high earners
+const SUPER_TAX_RATE = 0.15;
+const CARRY_FORWARD_BALANCE_THRESHOLD = 500_000;
+
+/* ── helpers ── */
+
+function formatCurrency(n: number): string {
+  return new Intl.NumberFormat("en-AU", {
+    style: "currency",
+    currency: "AUD",
+    maximumFractionDigits: 0,
+  }).format(n);
+}
+
+function formatPercent(n: number): string {
+  return `${n.toFixed(1)}%`;
+}
+
+/** Australian marginal income tax rate (FY2026, incl. 2% Medicare Levy) */
+function marginalRate(income: number): number {
+  if (income <= 18_200) return 0;
+  if (income <= 45_000) return 0.19 + 0.02;
+  if (income <= 120_000) return 0.325 + 0.02;
+  if (income <= 180_000) return 0.37 + 0.02;
+  return 0.45 + 0.02;
+}
+
+/* ── main component ── */
+
+export default function SuperContributionsClient() {
+  const [income, setIncome] = useState(90_000);
+  const [currentConcessional, setCurrentConcessional] = useState(12_000); // employer SG
+  const [extraConcessional, setExtraConcessional] = useState(5_000);
+  const [nonConcessional, setNonConcessional] = useState(0);
+  const [superBalance, setSuperBalance] = useState(150_000);
+  const [unusedCarryForward, setUnusedCarryForward] = useState(0);
+
+  const result = useMemo(() => {
+    const totalConcessional = currentConcessional + extraConcessional;
+    const isHighEarner = income >= DIV293_THRESHOLD;
+
+    // Concessional cap including carry-forward
+    const effectiveCap =
+      superBalance < CARRY_FORWARD_BALANCE_THRESHOLD
+        ? Math.min(CONCESSIONAL_CAP + unusedCarryForward, CONCESSIONAL_CAP * 6) // max 6 years
+        : CONCESSIONAL_CAP;
+
+    const concessionalExcess = Math.max(0, totalConcessional - effectiveCap);
+    const concessionalWithinCap = Math.min(totalConcessional, effectiveCap);
+
+    // Tax inside super on concessional contributions
+    const superTaxOnConcessional = concessionalWithinCap * SUPER_TAX_RATE;
+    const div293Tax = isHighEarner ? concessionalWithinCap * DIV293_EXTRA_RATE : 0;
+    const totalSuperTax = superTaxOnConcessional + div293Tax;
+    const effectiveSuperTaxRate = isHighEarner ? 0.3 : 0.15;
+
+    // Tax saving vs taking income at marginal rate
+    const marginal = marginalRate(income);
+    const taxSavingPerDollar = Math.max(0, marginal - effectiveSuperTaxRate);
+    const taxSavingOnExtra = extraConcessional * taxSavingPerDollar;
+
+    // Non-concessional: check cap
+    const ncCap = superBalance < CARRY_FORWARD_BALANCE_THRESHOLD ? BRING_FORWARD_CAP : NON_CONCESSIONAL_CAP;
+    const nonConcessionalExcess = Math.max(0, nonConcessional - ncCap);
+
+    // Net contribution landing in super (after 15% tax on concessional)
+    const netConcessionalInSuper = concessionalWithinCap - totalSuperTax;
+    const totalGoingIntoSuper = netConcessionalInSuper + nonConcessional;
+
+    return {
+      totalConcessional,
+      effectiveCap,
+      concessionalExcess,
+      concessionalWithinCap,
+      superTaxOnConcessional,
+      div293Tax,
+      totalSuperTax,
+      effectiveSuperTaxRate,
+      marginal,
+      taxSavingOnExtra,
+      taxSavingPerDollar,
+      nonConcessionalExcess,
+      ncCap,
+      netConcessionalInSuper,
+      totalGoingIntoSuper,
+      isHighEarner,
+    };
+  }, [
+    income,
+    currentConcessional,
+    extraConcessional,
+    nonConcessional,
+    superBalance,
+    unusedCarryForward,
+  ]);
+
+  const concessionalPct = Math.min(
+    100,
+    Math.round((result.totalConcessional / result.effectiveCap) * 100)
+  );
+
+  return (
+    <div className="py-10 md:py-16">
+      <div className="container-custom max-w-3xl">
+        {/* Header */}
+        <div className="mb-8">
+          <p className="text-xs font-bold uppercase tracking-wider text-amber-600 mb-1">
+            Free Calculator
+          </p>
+          <h1 className="text-2xl md:text-4xl font-extrabold text-slate-900 mb-2">
+            Super Contributions Calculator
+          </h1>
+          <p className="text-slate-500 text-sm md:text-base leading-relaxed">
+            See how much you can contribute to super, estimate the tax savings from salary sacrifice,
+            and check whether you&apos;re within your concessional and non-concessional caps for FY2026.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-5 gap-6 md:gap-8">
+          {/* ── Inputs ── */}
+          <div className="lg:col-span-2 space-y-5">
+            <div className="bg-white border border-slate-200 rounded-2xl p-5 space-y-5">
+              <h2 className="font-bold text-slate-900">Your Details</h2>
+
+              <div>
+                <label className="block text-xs font-semibold text-slate-600 mb-1">
+                  Annual income (before tax)
+                </label>
+                <div className="relative">
+                  <span className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 text-sm font-medium">$</span>
+                  <input
+                    type="number"
+                    min={0}
+                    step={1000}
+                    value={income}
+                    onChange={(e) => setIncome(Number(e.target.value))}
+                    className="w-full pl-7 pr-3 py-2 text-sm border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-amber-400"
+                  />
+                </div>
+                {income >= DIV293_THRESHOLD && (
+                  <p className="text-[0.68rem] text-orange-600 mt-1 font-medium">
+                    Division 293 applies — super contributions taxed at 30%
+                  </p>
+                )}
+              </div>
+
+              <div>
+                <label className="block text-xs font-semibold text-slate-600 mb-1">
+                  Employer SG contributions (annual)
+                  <span className="text-slate-400 font-normal ml-1">11.5% of salary</span>
+                </label>
+                <div className="relative">
+                  <span className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 text-sm font-medium">$</span>
+                  <input
+                    type="number"
+                    min={0}
+                    step={500}
+                    value={currentConcessional}
+                    onChange={(e) => setCurrentConcessional(Number(e.target.value))}
+                    className="w-full pl-7 pr-3 py-2 text-sm border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-amber-400"
+                  />
+                </div>
+              </div>
+
+              <div>
+                <label className="block text-xs font-semibold text-slate-600 mb-1">
+                  Extra concessional contributions
+                  <span className="text-slate-400 font-normal ml-1">salary sacrifice / personal deductible</span>
+                </label>
+                <div className="relative">
+                  <span className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 text-sm font-medium">$</span>
+                  <input
+                    type="number"
+                    min={0}
+                    step={500}
+                    value={extraConcessional}
+                    onChange={(e) => setExtraConcessional(Number(e.target.value))}
+                    className="w-full pl-7 pr-3 py-2 text-sm border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-amber-400"
+                  />
+                </div>
+              </div>
+
+              <div>
+                <label className="block text-xs font-semibold text-slate-600 mb-1">
+                  Non-concessional contributions
+                  <span className="text-slate-400 font-normal ml-1">after-tax money into super</span>
+                </label>
+                <div className="relative">
+                  <span className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 text-sm font-medium">$</span>
+                  <input
+                    type="number"
+                    min={0}
+                    step={1000}
+                    value={nonConcessional}
+                    onChange={(e) => setNonConcessional(Number(e.target.value))}
+                    className="w-full pl-7 pr-3 py-2 text-sm border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-amber-400"
+                  />
+                </div>
+              </div>
+
+              <div>
+                <label className="block text-xs font-semibold text-slate-600 mb-1">
+                  Current super balance
+                </label>
+                <div className="relative">
+                  <span className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 text-sm font-medium">$</span>
+                  <input
+                    type="number"
+                    min={0}
+                    step={5000}
+                    value={superBalance}
+                    onChange={(e) => setSuperBalance(Number(e.target.value))}
+                    className="w-full pl-7 pr-3 py-2 text-sm border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-amber-400"
+                  />
+                </div>
+                {superBalance < CARRY_FORWARD_BALANCE_THRESHOLD && (
+                  <p className="text-[0.68rem] text-emerald-600 mt-1 font-medium">
+                    Balance under $500k — carry-forward rules may apply
+                  </p>
+                )}
+              </div>
+
+              {superBalance < CARRY_FORWARD_BALANCE_THRESHOLD && (
+                <div>
+                  <label className="block text-xs font-semibold text-slate-600 mb-1">
+                    Unused concessional cap (last 5 yrs)
+                  </label>
+                  <div className="relative">
+                    <span className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 text-sm font-medium">$</span>
+                    <input
+                      type="number"
+                      min={0}
+                      step={1000}
+                      value={unusedCarryForward}
+                      onChange={(e) => setUnusedCarryForward(Number(e.target.value))}
+                      className="w-full pl-7 pr-3 py-2 text-sm border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-amber-400"
+                    />
+                  </div>
+                  <p className="text-[0.68rem] text-slate-400 mt-1">
+                    Find this on your ATO myGov account
+                  </p>
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* ── Results ── */}
+          <div className="lg:col-span-3 space-y-4">
+            {/* Concessional cap usage */}
+            <div className="bg-white border border-slate-200 rounded-2xl p-5">
+              <div className="flex items-start justify-between mb-3">
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                    Concessional Cap Usage
+                  </p>
+                  <p className="text-2xl font-extrabold text-slate-900">
+                    {formatCurrency(result.totalConcessional)}
+                    <span className="text-sm font-normal text-slate-400 ml-1">
+                      / {formatCurrency(result.effectiveCap)}
+                    </span>
+                  </p>
+                </div>
+                <span
+                  className={`text-xs font-bold px-2 py-1 rounded-full ${
+                    result.concessionalExcess > 0
+                      ? "bg-red-100 text-red-700"
+                      : concessionalPct >= 90
+                      ? "bg-amber-100 text-amber-700"
+                      : "bg-emerald-100 text-emerald-700"
+                  }`}
+                >
+                  {concessionalPct}% used
+                </span>
+              </div>
+
+              {/* Progress bar */}
+              <div className="h-2 bg-slate-100 rounded-full overflow-hidden mb-2">
+                <div
+                  className={`h-full rounded-full transition-all ${
+                    result.concessionalExcess > 0
+                      ? "bg-red-500"
+                      : concessionalPct >= 90
+                      ? "bg-amber-400"
+                      : "bg-emerald-500"
+                  }`}
+                  style={{ width: `${Math.min(100, concessionalPct)}%` }}
+                />
+              </div>
+
+              {result.concessionalExcess > 0 ? (
+                <p className="text-xs text-red-600 font-medium">
+                  {formatCurrency(result.concessionalExcess)} over the cap — excess will be included in your assessable income plus a 15% offset and interest charge.
+                </p>
+              ) : (
+                <p className="text-xs text-slate-500">
+                  {formatCurrency(result.effectiveCap - result.totalConcessional)} remaining cap available this FY
+                </p>
+              )}
+
+              {unusedCarryForward > 0 && superBalance < CARRY_FORWARD_BALANCE_THRESHOLD && (
+                <p className="text-xs text-emerald-600 mt-1 font-medium">
+                  Includes {formatCurrency(unusedCarryForward)} carry-forward cap
+                </p>
+              )}
+            </div>
+
+            {/* Tax saving */}
+            {extraConcessional > 0 && (
+              <div className="bg-emerald-50 border border-emerald-200 rounded-2xl p-5">
+                <p className="text-xs font-semibold uppercase tracking-wide text-emerald-700 mb-1">
+                  Tax Saving from Extra Contributions
+                </p>
+                <p className="text-2xl font-extrabold text-emerald-800">
+                  {formatCurrency(result.taxSavingOnExtra)}
+                </p>
+                <p className="text-xs text-emerald-700 mt-1">
+                  By contributing {formatCurrency(extraConcessional)} to super instead of taking it as income, you pay{" "}
+                  {formatPercent(result.effectiveSuperTaxRate * 100)} super tax instead of your{" "}
+                  {formatPercent(result.marginal * 100)} marginal rate —{" "}
+                  saving {formatPercent(result.taxSavingPerDollar * 100)} per dollar.
+                </p>
+              </div>
+            )}
+
+            {/* Contribution breakdown */}
+            <div className="bg-white border border-slate-200 rounded-2xl p-5">
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 mb-3">
+                Contribution Breakdown
+              </p>
+              <div className="space-y-2 text-sm">
+                <div className="flex justify-between">
+                  <span className="text-slate-600">Employer SG</span>
+                  <span className="font-semibold">{formatCurrency(currentConcessional)}</span>
+                </div>
+                {extraConcessional > 0 && (
+                  <div className="flex justify-between">
+                    <span className="text-slate-600">Extra concessional (salary sacrifice / deductible)</span>
+                    <span className="font-semibold">{formatCurrency(extraConcessional)}</span>
+                  </div>
+                )}
+                <div className="flex justify-between border-t border-slate-100 pt-2">
+                  <span className="text-slate-700 font-medium">Total concessional</span>
+                  <span className="font-bold">{formatCurrency(result.totalConcessional)}</span>
+                </div>
+                <div className="flex justify-between text-red-600">
+                  <span>Super tax (15%{result.isHighEarner ? " + 15% Div 293" : ""})</span>
+                  <span className="font-semibold">−{formatCurrency(result.totalSuperTax)}</span>
+                </div>
+                <div className="flex justify-between border-t border-slate-100 pt-2">
+                  <span className="text-slate-700 font-medium">Net concessional in super</span>
+                  <span className="font-bold">{formatCurrency(result.netConcessionalInSuper)}</span>
+                </div>
+                {nonConcessional > 0 && (
+                  <>
+                    <div className="flex justify-between">
+                      <span className="text-slate-600">Non-concessional</span>
+                      <span className="font-semibold">{formatCurrency(nonConcessional)}</span>
+                    </div>
+                    <div className="flex justify-between border-t border-slate-100 pt-2 text-base">
+                      <span className="font-bold text-slate-900">Total going into super</span>
+                      <span className="font-extrabold text-slate-900">{formatCurrency(result.totalGoingIntoSuper)}</span>
+                    </div>
+                  </>
+                )}
+              </div>
+            </div>
+
+            {/* Non-concessional warning */}
+            {result.nonConcessionalExcess > 0 && (
+              <div className="bg-red-50 border border-red-200 rounded-2xl p-4">
+                <p className="text-sm font-bold text-red-700 mb-1">Non-Concessional Cap Exceeded</p>
+                <p className="text-xs text-red-600">
+                  {formatCurrency(result.nonConcessionalExcess)} over the {formatCurrency(result.ncCap)} cap. Excess non-concessional contributions face a 47% tax rate. Consider withdrawing the excess before 30 June.
+                </p>
+              </div>
+            )}
+
+            {/* Rates table */}
+            <div className="bg-slate-50 border border-slate-200 rounded-2xl p-5">
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 mb-3">
+                FY2026 Contribution Limits
+              </p>
+              <div className="space-y-1.5 text-xs text-slate-600">
+                <div className="flex justify-between">
+                  <span>Concessional (CC) cap</span>
+                  <span className="font-semibold text-slate-800">$30,000</span>
+                </div>
+                <div className="flex justify-between">
+                  <span>Non-concessional (NCC) cap</span>
+                  <span className="font-semibold text-slate-800">$120,000</span>
+                </div>
+                <div className="flex justify-between">
+                  <span>Bring-forward NCC (3-year rule)</span>
+                  <span className="font-semibold text-slate-800">$360,000</span>
+                </div>
+                <div className="flex justify-between">
+                  <span>Super guarantee rate (SG)</span>
+                  <span className="font-semibold text-slate-800">11.5%</span>
+                </div>
+                <div className="flex justify-between">
+                  <span>Tax on concessional contributions</span>
+                  <span className="font-semibold text-slate-800">15%</span>
+                </div>
+                <div className="flex justify-between">
+                  <span>Division 293 threshold</span>
+                  <span className="font-semibold text-slate-800">$250,000</span>
+                </div>
+                <div className="flex justify-between">
+                  <span>Carry-forward balance limit</span>
+                  <span className="font-semibold text-slate-800">$500,000</span>
+                </div>
+              </div>
+            </div>
+
+            {/* CTA */}
+            <div className="bg-gradient-to-br from-amber-50 to-orange-50 border border-amber-200 rounded-2xl p-5">
+              <p className="text-sm font-bold text-slate-900 mb-1">
+                Want a personalised super strategy?
+              </p>
+              <p className="text-xs text-slate-600 mb-3">
+                A financial planner can model the tax impact of salary sacrifice, catch-up contributions and
+                transition to retirement strategies for your specific situation.
+              </p>
+              <Link
+                href="/advisors/financial-planners"
+                className="inline-block px-4 py-2 bg-amber-500 text-white text-xs font-bold rounded-lg hover:bg-amber-600 transition-colors"
+              >
+                Find a Financial Planner →
+              </Link>
+            </div>
+          </div>
+        </div>
+
+        {/* Disclaimer */}
+        <p className="text-[0.65rem] text-slate-400 mt-8 leading-relaxed">
+          This calculator provides general information only and does not constitute financial advice. Contribution caps and tax rates are for FY2026 and are subject to change. Speak with a qualified financial adviser before making contribution decisions. Always verify figures with the ATO or your fund.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/app/super-contributions-calculator/page.tsx
+++ b/app/super-contributions-calculator/page.tsx
@@ -1,0 +1,101 @@
+import type { Metadata } from "next";
+import { CURRENT_YEAR, SITE_NAME } from "@/lib/seo";
+import SuperContributionsClient from "./SuperContributionsClient";
+
+export const revalidate = 86400;
+
+export const metadata: Metadata = {
+  title: `Super Contributions Calculator — Concessional Caps & Tax Savings (${CURRENT_YEAR})`,
+  description:
+    "Calculate how much you can contribute to super in FY2026. See your concessional cap usage, tax savings from salary sacrifice, and whether carry-forward rules apply.",
+  alternates: { canonical: "/super-contributions-calculator" },
+  openGraph: {
+    title: `Super Contributions Calculator — Concessional Caps & Tax Savings | ${SITE_NAME}`,
+    description:
+      "Enter your income and employer contributions to see your remaining concessional cap, tax savings, and Division 293 liability for FY2026.",
+    images: [
+      {
+        url: "/api/og?title=Super+Contributions+Calculator&subtitle=Caps+%26+Tax+Savings+FY2026&type=default",
+        width: 1200,
+        height: 630,
+      },
+    ],
+  },
+  twitter: { card: "summary_large_image" as const },
+};
+
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  name: `Super Contributions Calculator — ${SITE_NAME}`,
+  description:
+    "Calculate your FY2026 concessional and non-concessional super contribution caps, tax savings from salary sacrifice, and Division 293 liability.",
+  url: "https://invest.com.au/super-contributions-calculator",
+  applicationCategory: "FinanceApplication",
+  operatingSystem: "Any",
+  offers: { "@type": "Offer", price: "0", priceCurrency: "AUD" },
+};
+
+const breadcrumbLd = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: [
+    { "@type": "ListItem", position: 1, name: "Home", item: "https://invest.com.au" },
+    {
+      "@type": "ListItem",
+      position: 2,
+      name: "Super Contributions Calculator",
+      item: "https://invest.com.au/super-contributions-calculator",
+    },
+  ],
+};
+
+const faqLd = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: [
+    {
+      "@type": "Question",
+      name: "What is the concessional super contribution cap for FY2026?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "The concessional (before-tax) contribution cap is $30,000 for FY2026. This includes employer super guarantee (SG) contributions and any salary sacrifice or personal deductible contributions you make.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "What is the non-concessional super contribution cap?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "The non-concessional (after-tax) contribution cap is $120,000 per year for FY2026. If eligible, you can use the bring-forward rule to contribute up to $360,000 over three years.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "What is Division 293 tax?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Division 293 is an additional 15% tax on concessional super contributions for individuals with income (including super contributions) exceeding $250,000. This brings the total super tax rate to 30% for high earners, rather than the standard 15%.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "Can I carry forward unused super contribution caps?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Yes, if your total super balance is below $500,000 on 30 June of the previous financial year, you can carry forward unused concessional cap amounts from the preceding five financial years and use them in a single year.",
+      },
+    },
+  ],
+};
+
+export default function SuperContributionsCalculatorPage() {
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }} />
+      <SuperContributionsClient />
+    </>
+  );
+}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -112,7 +112,7 @@ export default function Footer() {
                 <li><Link href="/compare?category=crypto" className="hover:text-white transition-colors inline-block py-0.5">Crypto Exchanges</Link></li>
                 <li><Link href="/compare/super" className="hover:text-white transition-colors inline-block py-0.5">Super Funds</Link></li>
                 <li><Link href="/best/robo-advisors" className="hover:text-white transition-colors inline-block py-0.5">Robo-Advisors</Link></li>
-                <li><Link href="/compare?filter=savings" className="hover:text-white transition-colors inline-block py-0.5">Savings Accounts</Link></li>
+                <li><Link href="/compare?category=savings" className="hover:text-white transition-colors inline-block py-0.5">Savings Accounts</Link></li>
                 <li><Link href="/versus" className="hover:text-white transition-colors inline-block py-0.5">Head-to-Head</Link></li>
                 <li><Link href="/deals" className="hover:text-white transition-colors inline-block py-0.5">Deals</Link></li>
               </ul>

--- a/components/SectionHeading.tsx
+++ b/components/SectionHeading.tsx
@@ -1,0 +1,15 @@
+interface Props {
+  eyebrow: string;
+  title: string;
+  sub?: string;
+}
+
+export default function SectionHeading({ eyebrow, title, sub }: Props) {
+  return (
+    <div className="mb-6 md:mb-8">
+      <p className="text-xs font-bold uppercase tracking-wider text-amber-600 mb-1">{eyebrow}</p>
+      <h2 className="text-xl md:text-2xl font-extrabold text-slate-900">{title}</h2>
+      {sub && <p className="text-sm text-slate-500 mt-1 leading-relaxed">{sub}</p>}
+    </div>
+  );
+}

--- a/components/VerticalBrokerTable.tsx
+++ b/components/VerticalBrokerTable.tsx
@@ -1,0 +1,305 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import Link from "next/link";
+import type { Broker } from "@/lib/types";
+import { getAffiliateLink, getBenefitCta, renderStars, AFFILIATE_REL } from "@/lib/tracking";
+import { isSponsored } from "@/lib/sponsorship";
+import BrokerCard from "@/components/BrokerCard";
+import BrokerLogo from "@/components/BrokerLogo";
+import ScrollReveal from "@/components/ScrollReveal";
+import SponsorBadge from "@/components/SponsorBadge";
+import JargonTooltip from "@/components/JargonTooltip";
+import CompactDisclaimerLine from "@/components/CompactDisclaimerLine";
+
+type ColumnDef = {
+  label: string;
+  jargon?: boolean;
+  render: (b: Broker) => React.ReactNode;
+  align?: "left" | "center";
+};
+
+function getColumns(slug: string): ColumnDef[] {
+  if (slug === "crypto") {
+    return [
+      { label: "Trading Fee", render: (b) => b.asx_fee || "Varies" },
+      { label: "Deposit", render: (b) => b.min_deposit || "Free" },
+      {
+        label: "AUSTRAC",
+        align: "center",
+        render: () => <span className="text-emerald-600 font-semibold">&#10003;</span>,
+      },
+      {
+        label: "Rating",
+        align: "center",
+        render: (b) => (
+          <>
+            <span className="text-amber">{renderStars(b.rating || 0)}</span>
+            <span className="text-sm text-slate-500 ml-1">{b.rating}</span>
+          </>
+        ),
+      },
+    ];
+  }
+
+  if (slug === "savings") {
+    return [
+      { label: "Interest Rate", render: (b) => b.asx_fee || "Varies" },
+      { label: "Min Deposit", render: (b) => b.min_deposit || "$0" },
+      {
+        label: "Gov. Guaranteed",
+        align: "center",
+        render: () => <span className="text-emerald-600 font-semibold">&#10003;</span>,
+      },
+      {
+        label: "Rating",
+        align: "center",
+        render: (b) => (
+          <>
+            <span className="text-amber">{renderStars(b.rating || 0)}</span>
+            <span className="text-sm text-slate-500 ml-1">{b.rating}</span>
+          </>
+        ),
+      },
+    ];
+  }
+
+  if (slug === "super") {
+    return [
+      { label: "Admin Fee", render: (b) => b.asx_fee || "Varies" },
+      {
+        label: "APRA Regulated",
+        align: "center",
+        render: () => <span className="text-emerald-600 font-semibold">&#10003;</span>,
+      },
+      {
+        label: "Insurance",
+        align: "center",
+        render: () => <span className="text-emerald-600 font-semibold">&#10003;</span>,
+      },
+      {
+        label: "Rating",
+        align: "center",
+        render: (b) => (
+          <>
+            <span className="text-amber">{renderStars(b.rating || 0)}</span>
+            <span className="text-sm text-slate-500 ml-1">{b.rating}</span>
+          </>
+        ),
+      },
+    ];
+  }
+
+  if (slug === "cfd") {
+    return [
+      { label: "Spread (EUR/USD)", render: (b) => b.asx_fee || "Varies" },
+      { label: "US Fee", render: (b) => b.us_fee || "N/A" },
+      {
+        label: "ASIC",
+        align: "center",
+        render: () => <span className="text-emerald-600 font-semibold">&#10003;</span>,
+      },
+      {
+        label: "Rating",
+        align: "center",
+        render: (b) => (
+          <>
+            <span className="text-amber">{renderStars(b.rating || 0)}</span>
+            <span className="text-sm text-slate-500 ml-1">{b.rating}</span>
+          </>
+        ),
+      },
+    ];
+  }
+
+  // Default: share-trading
+  return [
+    { label: "ASX Fee", jargon: true, render: (b) => b.asx_fee || "N/A" },
+    { label: "US Fee", jargon: true, render: (b) => b.us_fee || "N/A" },
+    {
+      label: "FX Rate",
+      jargon: true,
+      render: (b) => (b.fx_rate != null ? `${b.fx_rate}%` : "N/A"),
+    },
+    {
+      label: "CHESS",
+      jargon: true,
+      align: "center",
+      render: (b) => (
+        <span className={b.chess_sponsored ? "text-emerald-600 font-semibold" : "text-red-500"}>
+          {b.chess_sponsored ? "✓" : "✗"}
+        </span>
+      ),
+    },
+    {
+      label: "Rating",
+      align: "center",
+      render: (b) => (
+        <>
+          <span className="text-amber">{renderStars(b.rating || 0)}</span>
+          <span className="text-sm text-slate-500 ml-1">{b.rating}</span>
+        </>
+      ),
+    },
+  ];
+}
+
+interface Props {
+  brokers: Broker[];
+  slug: string;
+  color: { bg: string; border: string; text: string; accent: string; gradient: string };
+}
+
+export default function VerticalBrokerTable({ brokers, slug, color }: Props) {
+  const [query, setQuery] = useState("");
+  const columns = getColumns(slug);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return brokers;
+    return brokers.filter((b) => b.name.toLowerCase().includes(q));
+  }, [brokers, query]);
+
+  return (
+    <div>
+      {/* ─── Search ─── */}
+      <div className="mb-4">
+        <div className="relative max-w-xs">
+          <svg
+            className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M21 21l-4.35-4.35M17 11A6 6 0 1 1 5 11a6 6 0 0 1 12 0z"
+            />
+          </svg>
+          <input
+            type="search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search platforms…"
+            className="w-full pl-9 pr-3 py-2 text-sm border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-slate-300 bg-white"
+          />
+        </div>
+        {query && (
+          <p className="text-xs text-slate-500 mt-1.5">
+            {filtered.length === 0
+              ? "No platforms match your search"
+              : `${filtered.length} of ${brokers.length} platforms`}
+          </p>
+        )}
+      </div>
+
+      {/* Desktop table */}
+      <div className="hidden md:block overflow-x-auto mb-8">
+        <ScrollReveal
+          animation="table-row-stagger"
+          as="table"
+          className="w-full border border-slate-200 rounded-lg"
+        >
+          <thead className="bg-slate-50">
+            <tr>
+              <th className="px-4 py-3 text-left font-semibold text-sm">#</th>
+              <th className="px-4 py-3 text-left font-semibold text-sm">Platform</th>
+              {columns.map((col, i) => (
+                <th
+                  key={i}
+                  className={`px-4 py-3 font-semibold text-sm ${
+                    col.align === "center" ? "text-center" : "text-left"
+                  }`}
+                >
+                  {col.jargon ? <JargonTooltip term={col.label} /> : col.label}
+                </th>
+              ))}
+              <th className="px-4 py-3"></th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-200">
+            {filtered.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={3 + columns.length}
+                  className="px-4 py-8 text-center text-sm text-slate-400"
+                >
+                  No platforms match &ldquo;{query}&rdquo;
+                </td>
+              </tr>
+            ) : (
+              filtered.map((broker, i) => (
+                <tr
+                  key={broker.id}
+                  className={`hover:bg-slate-50 ${i === 0 && !query ? `${color.bg}/40` : ""}`}
+                >
+                  <td className="px-4 py-3 text-sm font-semibold text-slate-400">{i + 1}</td>
+                  <td className="px-4 py-3">
+                    <div className="flex items-center gap-2">
+                      <BrokerLogo broker={broker} size="sm" />
+                      <div>
+                        <div className="flex items-center gap-1.5 flex-wrap">
+                          <Link
+                            href={`/broker/${broker.slug}`}
+                            className="font-semibold text-brand hover:text-slate-900 transition-colors"
+                          >
+                            {broker.name}
+                          </Link>
+                          {isSponsored(broker) && <SponsorBadge broker={broker} />}
+                        </div>
+                        {i === 0 && !query && (
+                          <div className={`text-[0.69rem] font-extrabold ${color.text} uppercase tracking-wide`}>
+                            Top Pick
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  </td>
+                  {columns.map((col, ci) => (
+                    <td
+                      key={ci}
+                      className={`px-4 py-3 text-sm ${col.align === "center" ? "text-center" : ""}`}
+                    >
+                      {col.render(broker)}
+                    </td>
+                  ))}
+                  <td className="px-4 py-3 text-center">
+                    <a
+                      href={getAffiliateLink(broker)}
+                      target="_blank"
+                      rel={AFFILIATE_REL}
+                      className={`inline-block px-4 py-2 ${color.accent} text-white text-sm font-semibold rounded-lg hover:opacity-90 transition-colors`}
+                    >
+                      {getBenefitCta(broker, "compare")}
+                    </a>
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </ScrollReveal>
+      </div>
+
+      {/* Mobile cards */}
+      <div className="md:hidden space-y-2 mb-6">
+        {filtered.length === 0 ? (
+          <p className="text-sm text-slate-400 text-center py-6">
+            No platforms match &ldquo;{query}&rdquo;
+          </p>
+        ) : (
+          filtered.map((broker, i) => (
+            <BrokerCard
+              key={broker.id}
+              broker={broker}
+              badge={i === 0 && !query ? "Top Pick" : undefined}
+              context="compare"
+            />
+          ))
+        )}
+      </div>
+      <CompactDisclaimerLine />
+    </div>
+  );
+}

--- a/components/VerticalPillarPage.tsx
+++ b/components/VerticalPillarPage.tsx
@@ -25,168 +25,16 @@ import {
   AFCA_REFERENCE,
 } from "@/lib/compliance";
 import { isSponsored } from "@/lib/sponsorship";
-import BrokerCard from "@/components/BrokerCard";
 import BrokerLogo from "@/components/BrokerLogo";
 import CompactDisclaimerLine from "@/components/CompactDisclaimerLine";
 import ContextualLeadMagnet from "@/components/ContextualLeadMagnet";
-import ScrollReveal from "@/components/ScrollReveal";
 import OnThisPage from "@/components/OnThisPage";
 import SponsorBadge from "@/components/SponsorBadge";
-import JargonTooltip from "@/components/JargonTooltip";
 import Icon from "@/components/Icon";
 import { CATEGORY_COLORS } from "@/lib/internal-links";
 import PillarExitIntent from "@/components/PillarExitIntent";
 import PersonalizedRecommendations from "@/components/PersonalizedRecommendations";
-
-/* ─── Column config per vertical type ─── */
-
-type ColumnDef = {
-  label: string;
-  jargon?: boolean;
-  render: (b: Broker) => React.ReactNode;
-  align?: "left" | "center";
-};
-
-function getColumns(slug: string): ColumnDef[] {
-  if (slug === "crypto") {
-    return [
-      { label: "Trading Fee", render: (b) => b.asx_fee || "Varies" },
-      { label: "Deposit", render: (b) => b.min_deposit || "Free" },
-      {
-        label: "AUSTRAC",
-        align: "center",
-        render: () => (
-          <span className="text-emerald-600 font-semibold">&#10003;</span>
-        ),
-      },
-      {
-        label: "Rating",
-        align: "center",
-        render: (b) => (
-          <>
-            <span className="text-amber">{renderStars(b.rating || 0)}</span>
-            <span className="text-sm text-slate-500 ml-1">{b.rating}</span>
-          </>
-        ),
-      },
-    ];
-  }
-
-  if (slug === "savings") {
-    return [
-      { label: "Interest Rate", render: (b) => b.asx_fee || "Varies" },
-      { label: "Min Deposit", render: (b) => b.min_deposit || "$0" },
-      {
-        label: "Gov. Guaranteed",
-        align: "center",
-        render: () => (
-          <span className="text-emerald-600 font-semibold">&#10003;</span>
-        ),
-      },
-      {
-        label: "Rating",
-        align: "center",
-        render: (b) => (
-          <>
-            <span className="text-amber">{renderStars(b.rating || 0)}</span>
-            <span className="text-sm text-slate-500 ml-1">{b.rating}</span>
-          </>
-        ),
-      },
-    ];
-  }
-
-  if (slug === "super") {
-    return [
-      { label: "Admin Fee", render: (b) => b.asx_fee || "Varies" },
-      {
-        label: "APRA Regulated",
-        align: "center",
-        render: () => (
-          <span className="text-emerald-600 font-semibold">&#10003;</span>
-        ),
-      },
-      {
-        label: "Insurance",
-        align: "center",
-        render: () => (
-          <span className="text-emerald-600 font-semibold">&#10003;</span>
-        ),
-      },
-      {
-        label: "Rating",
-        align: "center",
-        render: (b) => (
-          <>
-            <span className="text-amber">{renderStars(b.rating || 0)}</span>
-            <span className="text-sm text-slate-500 ml-1">{b.rating}</span>
-          </>
-        ),
-      },
-    ];
-  }
-
-  if (slug === "cfd") {
-    return [
-      { label: "Spread (EUR/USD)", render: (b) => b.asx_fee || "Varies" },
-      { label: "US Fee", render: (b) => b.us_fee || "N/A" },
-      {
-        label: "ASIC",
-        align: "center",
-        render: () => (
-          <span className="text-emerald-600 font-semibold">&#10003;</span>
-        ),
-      },
-      {
-        label: "Rating",
-        align: "center",
-        render: (b) => (
-          <>
-            <span className="text-amber">{renderStars(b.rating || 0)}</span>
-            <span className="text-sm text-slate-500 ml-1">{b.rating}</span>
-          </>
-        ),
-      },
-    ];
-  }
-
-  // Default: share-trading
-  return [
-    { label: "ASX Fee", jargon: true, render: (b) => b.asx_fee || "N/A" },
-    { label: "US Fee", jargon: true, render: (b) => b.us_fee || "N/A" },
-    {
-      label: "FX Rate",
-      jargon: true,
-      render: (b) => (b.fx_rate != null ? `${b.fx_rate}%` : "N/A"),
-    },
-    {
-      label: "CHESS",
-      jargon: true,
-      align: "center",
-      render: (b) => (
-        <span
-          className={
-            b.chess_sponsored
-              ? "text-emerald-600 font-semibold"
-              : "text-red-500"
-          }
-        >
-          {b.chess_sponsored ? "✓" : "✗"}
-        </span>
-      ),
-    },
-    {
-      label: "Rating",
-      align: "center",
-      render: (b) => (
-        <>
-          <span className="text-amber">{renderStars(b.rating || 0)}</span>
-          <span className="text-sm text-slate-500 ml-1">{b.rating}</span>
-        </>
-      ),
-    },
-  ];
-}
+import VerticalBrokerTable from "@/components/VerticalBrokerTable";
 
 /* ─── Lead magnet segment mapping ─── */
 
@@ -229,7 +77,6 @@ export default function VerticalPillarPage({
 }: VerticalPillarPageProps) {
   const hasSponsored = brokers.some(isSponsored);
   const topPick = brokers[0] || null;
-  const columns = getColumns(config.slug);
   const dealBrokers = brokers.filter((b) => b.deal && b.deal_text).slice(0, 3);
   const hasDeals = dealBrokers.length > 0;
 
@@ -606,113 +453,11 @@ export default function VerticalPillarPage({
           >
             All Platforms ({brokers.length})
           </h2>
-
-          {/* Desktop table */}
-          <div className="hidden md:block overflow-x-auto mb-8">
-            <ScrollReveal
-              animation="table-row-stagger"
-              as="table"
-              className="w-full border border-slate-200 rounded-lg"
-            >
-              <thead className="bg-slate-50">
-                <tr>
-                  <th className="px-4 py-3 text-left font-semibold text-sm">
-                    #
-                  </th>
-                  <th className="px-4 py-3 text-left font-semibold text-sm">
-                    Platform
-                  </th>
-                  {columns.map((col, i) => (
-                    <th
-                      key={i}
-                      className={`px-4 py-3 font-semibold text-sm ${
-                        col.align === "center" ? "text-center" : "text-left"
-                      }`}
-                    >
-                      {col.jargon ? (
-                        <JargonTooltip term={col.label} />
-                      ) : (
-                        col.label
-                      )}
-                    </th>
-                  ))}
-                  <th className="px-4 py-3"></th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-slate-200">
-                {brokers.map((broker, i) => (
-                  <tr
-                    key={broker.id}
-                    className={`hover:bg-slate-50 ${
-                      i === 0 ? `${config.color.bg}/40` : ""
-                    }`}
-                  >
-                    <td className="px-4 py-3 text-sm font-semibold text-slate-400">
-                      {i + 1}
-                    </td>
-                    <td className="px-4 py-3">
-                      <div className="flex items-center gap-2">
-                        <BrokerLogo broker={broker} size="sm" />
-                        <div>
-                          <div className="flex items-center gap-1.5 flex-wrap">
-                            <Link
-                              href={`/broker/${broker.slug}`}
-                              className="font-semibold text-brand hover:text-slate-900 transition-colors"
-                            >
-                              {broker.name}
-                            </Link>
-                            {isSponsored(broker) && (
-                              <SponsorBadge broker={broker} />
-                            )}
-                          </div>
-                          {i === 0 && (
-                            <div
-                              className={`text-[0.69rem] font-extrabold ${config.color.text} uppercase tracking-wide`}
-                            >
-                              Top Pick
-                            </div>
-                          )}
-                        </div>
-                      </div>
-                    </td>
-                    {columns.map((col, ci) => (
-                      <td
-                        key={ci}
-                        className={`px-4 py-3 text-sm ${
-                          col.align === "center" ? "text-center" : ""
-                        }`}
-                      >
-                        {col.render(broker)}
-                      </td>
-                    ))}
-                    <td className="px-4 py-3 text-center">
-                      <a
-                        href={getAffiliateLink(broker)}
-                        target="_blank"
-                        rel={AFFILIATE_REL}
-                        className={`inline-block px-4 py-2 ${config.color.accent} text-white text-sm font-semibold rounded-lg hover:opacity-90 transition-colors`}
-                      >
-                        {getBenefitCta(broker, "compare")}
-                      </a>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </ScrollReveal>
-          </div>
-
-          {/* Mobile cards */}
-          <div className="md:hidden space-y-2 mb-6">
-            {brokers.map((broker, i) => (
-              <BrokerCard
-                key={broker.id}
-                broker={broker}
-                badge={i === 0 ? "Top Pick" : undefined}
-                context="compare"
-              />
-            ))}
-          </div>
-          <CompactDisclaimerLine />
+          <VerticalBrokerTable
+            brokers={brokers}
+            slug={config.slug}
+            color={config.color}
+          />
 
           {/* ─── Quick Tools ─── */}
           <div id="tools" className="mb-6 md:mb-10 scroll-mt-20">


### PR DESCRIPTION
…re nav, interactive broker search, SectionHeading refactor, broker redirect, /best back-link, footer fix

- Fix Footer savings link: ?filter=savings → ?category=savings
- Extract SectionHeading to shared component (removed 8 local duplicate definitions)
- Add DASPCalculator to /foreign-investment/super — visa-type toggle, balance input, colour-coded breakdown
- Add CompareNav sticky tab bar across /compare, /compare/etfs, /compare/super, /compare/insurance
- Add 'View all categories →' back-link to /best/[slug] pages
- Add /app/broker/page.tsx redirect to /compare (was 404)
- Extract broker table from VerticalPillarPage into VerticalBrokerTable client component with live name search filter
- Add /super-contributions-calculator page with FY2026 caps, carry-forward logic, Division 293 detection, and tax-saving display

https://claude.ai/code/session_01Sc4b8zVmRCqqYVZ8tf4JPD