### PR TITLE
feat: add 5 missing hub sub-pages — ETF bonds/international/sectors, …

### DIFF
--- a/app/etfs/bonds/page.tsx
+++ b/app/etfs/bonds/page.tsx
@@ -1,0 +1,462 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR, UPDATED_LABEL } from "@/lib/seo";
+import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
+import SectionHeading from "@/components/SectionHeading";
+
+export const revalidate = 86400;
+
+export const metadata: Metadata = {
+  title: `Best Bond ETFs Australia (${CURRENT_YEAR}) — Fixed Income ETFs Compared`,
+  description: `Compare the best Australian bond and fixed income ETFs: VAF, IAF, BOND, CRED, FLOT and more. Government bonds, corporate bonds, and cash ETFs analysed by yield, duration, and credit quality. ${UPDATED_LABEL}.`,
+  openGraph: {
+    title: `Best Bond ETFs Australia (${CURRENT_YEAR}) — Fixed Income ETF Guide`,
+    description: "Complete guide to bond and fixed income ETFs in Australia. Compare government bonds, corporate bonds, and inflation-linked ETFs.",
+    url: `${SITE_URL}/etfs/bonds`,
+  },
+  twitter: { card: "summary_large_image" },
+  alternates: { canonical: `${SITE_URL}/etfs/bonds` },
+};
+
+const BOND_ETFS = [
+  {
+    ticker: "VAF",
+    name: "Vanguard Australian Fixed Interest ETF",
+    provider: "Vanguard",
+    index: "Bloomberg AusBond Composite 0+ Yr Index",
+    mer: "0.20%",
+    aum: "$3.8B",
+    yield: "~4.1%",
+    duration: "~6.5 years",
+    creditQuality: "AAA / Government",
+    type: "Australian Bonds (Broad)",
+    pros: [
+      "Broad diversification across government and semi-government bonds",
+      "Largest Australian bond ETF — excellent liquidity",
+      "Low credit risk — mostly AAA-rated government bonds",
+      "Natural portfolio hedge against equity market downturns",
+    ],
+    cons: [
+      "Interest rate sensitive — rises in rates reduce unit price",
+      "Lower yield than corporate bond ETFs",
+      "Returns are lower than equities over the long run",
+    ],
+    verdict: "The core building block for fixed income exposure in an Australian portfolio. Reliable, liquid, and low-risk.",
+  },
+  {
+    ticker: "IAF",
+    name: "iShares Core Composite Bond ETF",
+    provider: "BlackRock iShares",
+    index: "Bloomberg AusBond Composite 0+ Yr Index",
+    mer: "0.15%",
+    aum: "$2.1B",
+    yield: "~4.1%",
+    duration: "~6.5 years",
+    creditQuality: "AAA / Government",
+    type: "Australian Bonds (Broad)",
+    pros: [
+      "Slightly cheaper MER than VAF",
+      "Same index as VAF — near-identical performance",
+      "BlackRock's institutional-grade management",
+      "Strong liquidity and AUM",
+    ],
+    cons: [
+      "Similar interest rate sensitivity to VAF",
+      "Returns are income-focused, not capital growth",
+    ],
+    verdict: "The cheapest way to access broad Australian bond market exposure. Essentially interchangeable with VAF.",
+  },
+  {
+    ticker: "BOND",
+    name: "PIMCO Australian Short-Term Bond ETF",
+    provider: "PIMCO",
+    index: "Actively managed",
+    mer: "0.49%",
+    aum: "$620M",
+    yield: "~4.6%",
+    duration: "~1.5 years",
+    creditQuality: "Investment Grade",
+    type: "Short-Duration Active",
+    pros: [
+      "Short duration means lower interest rate risk",
+      "Active management by PIMCO — a global bond specialist",
+      "Higher yield than passive broad-market funds",
+      "Less price volatility than long-duration bond ETFs",
+    ],
+    cons: [
+      "Higher MER for an active fund",
+      "Active risk — manager can underperform",
+      "Less transparent holdings than passive index ETFs",
+    ],
+    verdict: "Good choice for investors wanting income with low interest rate risk. The PIMCO brand adds credibility for active bond management.",
+  },
+  {
+    ticker: "CRED",
+    name: "BetaShares Australian Investment Grade Corporate Bond ETF",
+    provider: "Betashares",
+    index: "Solactive Australian Investment Grade Corporate Bond Select Index",
+    mer: "0.25%",
+    aum: "$480M",
+    yield: "~4.8%",
+    duration: "~4.5 years",
+    creditQuality: "BBB to AAA (Corporate)",
+    type: "Corporate Bonds",
+    pros: [
+      "Higher yield than government bond ETFs",
+      "Investment-grade only — avoids junk bonds",
+      "Diversified across Australian corporate issuers",
+      "Good for income-focused portfolios",
+    ],
+    cons: [
+      "Higher credit risk than government bond ETFs",
+      "Corporate bonds correlate more with equities in stress periods",
+      "Smaller AUM than VAF/IAF means wider spreads",
+    ],
+    verdict: "For investors seeking higher income than government bonds can offer while maintaining investment-grade credit quality.",
+  },
+  {
+    ticker: "FLOT",
+    name: "VanEck Australian Floating Rate ETF",
+    provider: "VanEck",
+    index: "Bloomberg AusBond Credit FRN 0+ Yr Index",
+    mer: "0.22%",
+    aum: "$890M",
+    yield: "~5.0%",
+    duration: "~0.2 years",
+    creditQuality: "Investment Grade (floating rate notes)",
+    type: "Floating Rate Notes",
+    pros: [
+      "Minimal interest rate sensitivity — floats with the RBA cash rate",
+      "Yields rise when rates rise (unlike fixed-rate bonds)",
+      "Low price volatility",
+      "Attractive in rising or high rate environments",
+    ],
+    cons: [
+      "Yields fall when rates fall — the flip side of floating rate",
+      "Less diversification benefit vs equities than traditional bonds",
+      "Niche product — best understood as a cash-plus return",
+    ],
+    verdict: "An excellent option in a high or rising interest rate environment. Protects against rate risk that affects standard bond ETFs.",
+  },
+];
+
+const SECTIONS = [
+  {
+    heading: "Why hold bonds in your portfolio?",
+    body: `Bond ETFs serve a fundamentally different purpose to share ETFs. Rather than seeking capital growth, bonds provide income, stability, and — crucially — protection when equity markets fall.
+
+**The core role of bonds:**
+During severe equity market drawdowns (GFC 2008-09, COVID crash March 2020), high-quality government bond ETFs typically rise or hold steady while share prices fall sharply. This is the 'flight to safety' effect: when investors panic, they sell shares and buy government bonds, pushing bond prices up. For a balanced portfolio, this negative correlation reduces volatility and can improve risk-adjusted returns.
+
+**How bond ETFs work:**
+When you buy a bond ETF, you're buying a fund that holds a portfolio of individual bonds. Each bond pays a fixed interest rate (coupon) and returns the principal at maturity. The ETF pools hundreds of bonds with different maturities and reinvests as bonds mature, maintaining a consistent average duration.
+
+Bond ETF prices move inversely with interest rates. When rates rise, existing bond prices fall (newer bonds pay more, making existing ones less attractive). When rates fall, bond prices rise. This is why bond ETFs suffered in 2022-23 when the RBA raised rates aggressively.
+
+**Bond ETFs vs term deposits:**
+Many Australian investors choose term deposits instead of bond ETFs. Key differences:
+- Term deposits are fixed-term (you're locked in). Bond ETFs are liquid (sell anytime on ASX).
+- Term deposits are government-guaranteed up to $250K per institution. Bond ETFs are not (though government bond ETFs hold actual government bonds, which carry similar implicit security).
+- Bond ETFs provide more diversification. Term deposits provide certainty of return.
+- For portfolios above $500K, bond ETFs are typically more tax-efficient than multiple term deposits.`,
+  },
+  {
+    heading: "Duration: the most important number in bond investing",
+    body: `Duration measures a bond ETF's sensitivity to interest rate changes. Specifically, it approximates the percentage change in price for each 1% change in interest rates.
+
+**Practical example:**
+VAF has a duration of approximately 6.5 years. If interest rates rise by 1%, VAF's price falls by approximately 6.5%. If rates fall by 1%, VAF's price rises by approximately 6.5%.
+
+**Duration and your portfolio strategy:**
+- **Short duration (0–2 years):** Low interest rate sensitivity. Suitable for investors nervous about rate movements. Lower yield but more stable price. Examples: FLOT, BOND.
+- **Medium duration (3–5 years):** Balanced approach. Moderate rate sensitivity, moderate yield.
+- **Long duration (7+ years):** High interest rate sensitivity but highest yield and most defensive benefit during equity crashes. Examples: VGB (government bonds to 10+ years).
+
+**The 2022–23 lesson:**
+Australian bond ETFs suffered meaningful losses in 2022-23 as the RBA raised the cash rate from 0.10% to 4.35%. VAF fell approximately 8–10% in price during this period. Investors who understood duration weren't surprised — the maths worked exactly as expected. Short-duration ETFs like FLOT outperformed dramatically during this period.
+
+**Matching duration to your time horizon:**
+If you need to access funds in 2 years, a long-duration bond ETF creates unnecessary risk. Match the approximate duration of your bond ETF to your investment time horizon.`,
+  },
+  {
+    heading: "Government bonds vs corporate bonds — which is better?",
+    body: `The choice between government and corporate bond ETFs is a classic risk-return trade-off.
+
+**Government bond ETFs (VAF, IAF, VGB):**
+- Issued by the Australian federal and state governments
+- Effectively zero credit risk — the Australian government has never defaulted
+- Lower yields than corporate bonds
+- Provide the strongest portfolio diversification benefit against equities
+- Best choice for genuine defensive allocation
+
+**Corporate bond ETFs (CRED, IHCB):**
+- Issued by Australian and international companies
+- Higher yields compensate for credit risk (risk of default)
+- Investment-grade corporate bonds (BBB to AAA) have low but non-zero default risk
+- Correlate more with equities during market stress — reducing the diversification benefit
+- Appropriate for income-focused portfolios where yield is the priority
+
+**High-yield bonds (caution):**
+High-yield (junk) bond ETFs offer the highest yields but correlate almost perfectly with equities during market downturns — providing essentially no diversification benefit. Most Australian investors are better served by investment-grade bonds for their fixed income allocation and equities for growth.
+
+**The practical recommendation:**
+For most Australian investors, a simple split between VAF or IAF (broad Australian bonds) and a corporate bond ETF like CRED provides a good balance of yield and defensiveness. Aim for 60-70% government/semi-government and 30-40% corporate bonds within your fixed income allocation.`,
+  },
+];
+
+const FAQS = [
+  {
+    question: "Are bond ETFs safe?",
+    answer: "Government bond ETFs like VAF and IAF are among the safest investments available — they hold bonds backed by the Australian government, which has never defaulted. However, 'safe' doesn't mean 'no risk.' Bond prices fall when interest rates rise. If you hold VAF for 10 years, you'll almost certainly earn a positive return. If you need to sell after rates have just spiked, you may sell at a loss. Short-duration bond ETFs like FLOT carry significantly less interest rate risk.",
+  },
+  {
+    question: "What is the typical yield on Australian bond ETFs?",
+    answer: `In 2026, Australian government bond ETFs yield approximately 4.0–4.5% per annum (reflecting the RBA cash rate environment). Corporate bond ETFs yield 4.5–5.5%. Floating rate ETFs like FLOT yield close to the RBA cash rate plus a small spread. These yields fluctuate as interest rates change — when rates rise, new bonds pay more, so the effective yield on bond ETFs increases over time as the portfolio is refreshed.`,
+  },
+  {
+    question: "Should I hold bonds inside or outside super?",
+    answer: "Bond income is taxed at your marginal rate outside super, or at 15% (or 0% in pension phase) inside super. For most working Australians in the 32.5%+ tax bracket, holding bond ETFs inside super (via a platform or SMSF) is significantly more tax-efficient than outside super. This is the opposite of the recommendation for franked equities, which are more tax-efficient outside super for many investors.",
+  },
+  {
+    question: "How do bond ETFs pay income?",
+    answer: "Bond ETFs distribute income (interest payments from the underlying bonds) typically monthly or quarterly. Unlike equity ETFs which pay dividends with franking credits, bond distributions are unfranked interest income taxed at your full marginal rate. This is why bonds are often described as 'less tax-efficient' than Australian equity ETFs for investors outside super.",
+  },
+  {
+    question: "What percentage of my portfolio should be in bonds?",
+    answer: "Traditional guidance suggests holding your age as a percentage in bonds (e.g. 40% bonds at age 40). Modern approaches are more nuanced — a 40-year-old with a high risk tolerance and long investment horizon might hold only 10–20% in bonds. Key factors: your time horizon, income stability, tolerance for portfolio volatility, and whether you need regular income from investments. Speak with a financial adviser for personalised asset allocation advice.",
+  },
+  {
+    question: "How did bond ETFs perform during COVID and the rate rises?",
+    answer: "During the COVID crash (Feb-March 2020), VAF rose approximately 2-3% as investors fled to safety — demonstrating the defensive benefit of government bonds. During the 2022-23 rate hiking cycle, VAF fell approximately 8-10% as rates rose sharply from 0.10% to 4.35%. Short-duration ETFs like FLOT held up much better. This illustrates that the defensive value of bonds is most apparent during equity market crashes, but they carry real interest rate risk when central banks tighten.",
+  },
+];
+
+export default function BondETFsPage() {
+  const breadcrumb = breadcrumbJsonLd([
+    { name: "Home", url: SITE_URL },
+    { name: "ETFs", url: `${SITE_URL}/etfs` },
+    { name: "Bond & Fixed Income ETFs" },
+  ]);
+
+  const faqSchema = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: FAQS.map((f) => ({
+      "@type": "Question",
+      name: f.question,
+      acceptedAnswer: { "@type": "Answer", text: f.answer },
+    })),
+  };
+
+  return (
+    <div className="bg-white min-h-screen">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+
+      {/* Hero */}
+      <section className="bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 text-white py-10 md:py-14">
+        <div className="container-custom">
+          <nav className="text-xs text-slate-400 mb-5 flex items-center gap-1.5 flex-wrap">
+            <Link href="/" className="hover:text-slate-200">Home</Link>
+            <span>/</span>
+            <Link href="/etfs" className="hover:text-slate-200">ETFs</Link>
+            <span>/</span>
+            <span className="text-slate-300">Bond & Fixed Income ETFs</span>
+          </nav>
+          <div className="max-w-3xl">
+            <div className="inline-flex items-center gap-2 px-3 py-1 bg-slate-500/20 border border-slate-500/30 rounded-full text-xs font-semibold text-slate-300 mb-4">
+              <span className="w-1.5 h-1.5 bg-slate-400 rounded-full" />
+              Fixed Income · {UPDATED_LABEL}
+            </div>
+            <h1 className="text-2xl sm:text-3xl md:text-4xl font-extrabold leading-[1.1] mb-3 tracking-tight">
+              Best Bond ETFs Australia{" "}
+              <span className="text-amber-400">({CURRENT_YEAR})</span>
+            </h1>
+            <p className="text-sm md:text-base text-slate-300 leading-relaxed max-w-2xl">
+              Compare the best Australian bond and fixed income ETFs — government bonds, corporate bonds,
+              floating rate notes, and short-duration options. Yield, duration, credit quality, and MER analysed independently.
+            </p>
+            <div className="flex flex-wrap gap-3 mt-5">
+              <Link href="/etfs" className="px-4 py-2 bg-white/10 hover:bg-white/20 text-white text-xs font-semibold rounded-lg transition-colors border border-white/20">
+                ← All ETF Categories
+              </Link>
+              <Link href="/etfs/dividends" className="px-4 py-2 bg-white/10 hover:bg-white/20 text-white text-xs font-semibold rounded-lg transition-colors border border-white/20">
+                Dividend ETFs →
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Callouts */}
+      <section className="py-8 bg-slate-50 border-b border-slate-200">
+        <div className="container-custom">
+          <div className="grid sm:grid-cols-3 gap-4">
+            <div className="bg-white rounded-2xl border border-slate-200 p-5">
+              <p className="text-xs font-bold text-slate-600 uppercase tracking-wide mb-1">RBA Cash Rate (2026)</p>
+              <p className="text-xl font-black text-slate-900">~4.10%</p>
+              <p className="text-xs text-slate-600 mt-1">Sets the floor for short-duration bond yields. Government bond ETFs yield 4–4.5%.</p>
+            </div>
+            <div className="bg-white rounded-2xl border border-amber-200 p-5">
+              <p className="text-xs font-bold text-amber-800 uppercase tracking-wide mb-1">VAF Duration</p>
+              <p className="text-xl font-black text-amber-700">~6.5 years</p>
+              <p className="text-xs text-slate-600 mt-1">A 1% rate rise reduces VAF price by ~6.5%. Duration is the key number for bond ETF investors.</p>
+            </div>
+            <div className="bg-white rounded-2xl border border-slate-200 p-5">
+              <p className="text-xs font-bold text-slate-600 uppercase tracking-wide mb-1">Lowest MER</p>
+              <p className="text-xl font-black text-slate-900">0.15% (IAF)</p>
+              <p className="text-xs text-slate-600 mt-1">iShares Core Composite Bond ETF — the cheapest broad Australian bond exposure.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ETF Comparison Cards */}
+      <section className="py-10 md:py-14">
+        <div className="container-custom">
+          <SectionHeading
+            eyebrow="Bond ETF Comparison"
+            title="Australian Bond & Fixed Income ETFs"
+            sub="Key metrics and independent analysis for the most popular Australian bond ETFs."
+          />
+          <div className="mt-8 space-y-6">
+            {BOND_ETFS.map((etf) => (
+              <div key={etf.ticker} className="bg-white border border-slate-200 rounded-2xl p-6 hover:shadow-md transition-shadow">
+                <div className="flex flex-wrap items-start justify-between gap-4 mb-4">
+                  <div>
+                    <div className="flex items-center gap-3 mb-1">
+                      <span className="font-mono text-lg font-black text-slate-900 bg-slate-100 px-3 py-1 rounded-lg">{etf.ticker}</span>
+                      <span className="text-xs bg-amber-100 text-amber-800 px-2 py-1 rounded font-semibold">{etf.type}</span>
+                    </div>
+                    <p className="text-sm font-semibold text-slate-700">{etf.name}</p>
+                    <p className="text-xs text-slate-500">{etf.provider} · {etf.index}</p>
+                  </div>
+                  <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 text-center">
+                    {[
+                      { label: "MER", value: etf.mer },
+                      { label: "AUM", value: etf.aum },
+                      { label: "Yield", value: etf.yield },
+                      { label: "Duration", value: etf.duration },
+                    ].map((m) => (
+                      <div key={m.label} className="bg-slate-50 rounded-xl p-2.5">
+                        <p className="text-xs text-slate-500 mb-0.5">{m.label}</p>
+                        <p className="text-sm font-bold text-slate-900">{m.value}</p>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+                <div className="grid sm:grid-cols-2 gap-4 mb-4">
+                  <div>
+                    <p className="text-xs font-bold text-green-700 mb-1.5">Pros</p>
+                    <ul className="space-y-1">
+                      {etf.pros.map((p) => (
+                        <li key={p} className="text-xs text-slate-600 flex items-start gap-1.5">
+                          <span className="text-green-500 mt-0.5 shrink-0">✓</span>{p}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                  <div>
+                    <p className="text-xs font-bold text-red-700 mb-1.5">Cons</p>
+                    <ul className="space-y-1">
+                      {etf.cons.map((c) => (
+                        <li key={c} className="text-xs text-slate-600 flex items-start gap-1.5">
+                          <span className="text-red-400 mt-0.5 shrink-0">✗</span>{c}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                </div>
+                <div className="bg-amber-50 border border-amber-200 rounded-xl p-3">
+                  <p className="text-xs font-bold text-amber-800 mb-1">Our Take</p>
+                  <p className="text-xs text-slate-700 leading-relaxed">{etf.verdict}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Editorial */}
+      <section className="py-10 bg-slate-50">
+        <div className="container-custom max-w-3xl">
+          <SectionHeading eyebrow="Bond ETF Guide" title="Everything You Need to Know About Bond ETFs" />
+          <div className="mt-8 space-y-10">
+            {SECTIONS.map((sec) => (
+              <div key={sec.heading}>
+                <h2 className="text-lg font-extrabold text-slate-900 mb-3">{sec.heading}</h2>
+                <div className="prose prose-sm max-w-none text-slate-600 leading-relaxed">
+                  {sec.body.split("\n\n").map((para, i) => (
+                    <p key={i} className="mb-3 last:mb-0 whitespace-pre-line">{para}</p>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* FAQs */}
+      <section className="py-10 md:py-12">
+        <div className="container-custom max-w-2xl">
+          <SectionHeading eyebrow="FAQ" title="Bond ETF Questions Answered" />
+          <div className="mt-6 divide-y divide-slate-200">
+            {FAQS.map((faq) => (
+              <details key={faq.question} className="py-4 group">
+                <summary className="text-sm font-semibold text-slate-900 cursor-pointer list-none flex items-center justify-between gap-2">
+                  {faq.question}
+                  <span className="text-slate-400 group-open:rotate-180 transition-transform shrink-0">▾</span>
+                </summary>
+                <p className="mt-3 text-sm text-slate-600 leading-relaxed">{faq.answer}</p>
+              </details>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Related */}
+      <section className="py-10 bg-slate-50 border-t border-slate-200">
+        <div className="container-custom">
+          <SectionHeading eyebrow="Related ETFs" title="Explore Other ETF Categories" />
+          <div className="mt-6 grid sm:grid-cols-3 gap-4">
+            {[
+              { title: "ASX 200 ETFs", href: "/etfs/asx-200", icon: "🇦🇺", desc: "VAS, A200, STW, IOZ" },
+              { title: "Dividend ETFs", href: "/etfs/dividends", icon: "💰", desc: "VHY, HVST, SYI, ZYAU" },
+              { title: "US Market ETFs", href: "/etfs/us-exposure", icon: "🇺🇸", desc: "IVV, NDQ, QUS, VTS" },
+            ].map((cat) => (
+              <Link key={cat.href} href={cat.href} className="group bg-white border border-slate-200 rounded-xl p-5 hover:border-amber-300 hover:shadow-sm transition-all">
+                <div className="text-2xl mb-2">{cat.icon}</div>
+                <p className="text-sm font-bold text-slate-900 group-hover:text-amber-700 mb-1">{cat.title}</p>
+                <p className="text-xs text-slate-500 font-mono">{cat.desc}</p>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-12 bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 text-white">
+        <div className="container-custom text-center max-w-xl">
+          <h2 className="text-xl font-extrabold mb-3">Ready to add bonds to your portfolio?</h2>
+          <p className="text-sm text-slate-300 mb-6">
+            Compare brokers that offer ASX-listed bond ETFs with low brokerage and no platform fees.
+          </p>
+          <div className="flex flex-col sm:flex-row gap-3 justify-center">
+            <Link href="/best/etfs" className="px-6 py-3 bg-amber-500 hover:bg-amber-400 text-black font-bold text-sm rounded-xl transition-colors">
+              Best ETF Brokers →
+            </Link>
+            <Link href="/etfs" className="px-6 py-3 bg-white/10 hover:bg-white/20 border border-white/20 text-white font-semibold text-sm rounded-xl transition-colors">
+              All ETF Categories →
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <section className="py-6 bg-slate-100 border-t border-slate-200">
+        <div className="container-custom max-w-3xl">
+          <p className="text-xs text-slate-500 leading-relaxed">{GENERAL_ADVICE_WARNING}</p>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/etfs/international/page.tsx
+++ b/app/etfs/international/page.tsx
@@ -1,0 +1,440 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR, UPDATED_LABEL } from "@/lib/seo";
+import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
+import SectionHeading from "@/components/SectionHeading";
+
+export const revalidate = 86400;
+
+export const metadata: Metadata = {
+  title: `Best International ETFs Australia (${CURRENT_YEAR}) — VGS, IWLD, VEU, FEMX Compared`,
+  description: `Compare the best international ETFs available in Australia: VGS, IWLD, VEU, FEMX, VDHG and more. Developed markets, emerging markets, and all-world ETFs analysed by MER, coverage, and performance. ${UPDATED_LABEL}.`,
+  openGraph: {
+    title: `Best International ETFs Australia (${CURRENT_YEAR})`,
+    description: "Complete guide to international ETFs in Australia. Compare global developed markets, emerging markets, and all-world ETFs.",
+    url: `${SITE_URL}/etfs/international`,
+  },
+  twitter: { card: "summary_large_image" },
+  alternates: { canonical: `${SITE_URL}/etfs/international` },
+};
+
+const INTERNATIONAL_ETFS = [
+  {
+    ticker: "VGS",
+    name: "Vanguard MSCI Index International Shares ETF",
+    provider: "Vanguard",
+    index: "MSCI World ex-Australia Index",
+    mer: "0.18%",
+    aum: "$8.2B",
+    yield: "~1.6%",
+    countries: "23 developed markets",
+    holdings: "~1,500 companies",
+    currency: "Unhedged (AUD)",
+    pros: [
+      "Largest international ETF in Australia by AUM",
+      "Covers 23 developed markets — US, Europe, Japan, Canada",
+      "Excellent liquidity and tight spreads",
+      "Low MER for broad developed market exposure",
+      "Quarterly distributions with some franking from NZ shares",
+    ],
+    cons: [
+      "No emerging markets exposure (China, India, Brazil)",
+      "Heavily US-weighted (~70%) — significant concentration",
+      "Currency risk — unhedged AUD/USD and AUD/EUR exposure",
+    ],
+    verdict: "The default choice for international developed market exposure. Simple, cheap, liquid. Best paired with VAS for a core two-ETF portfolio.",
+  },
+  {
+    ticker: "IWLD",
+    name: "iShares Core MSCI World All Cap ETF",
+    provider: "BlackRock iShares",
+    index: "MSCI World Investable Market Index",
+    mer: "0.09%",
+    aum: "$3.1B",
+    yield: "~1.5%",
+    countries: "23 developed markets",
+    holdings: "~3,900 companies",
+    currency: "Unhedged (AUD)",
+    pros: [
+      "Cheapest broad international ETF — only 0.09% MER",
+      "Broader than VGS — includes small-cap international stocks",
+      "~3,900 holdings for deep diversification",
+      "BlackRock institutional-grade management",
+    ],
+    cons: [
+      "No emerging markets",
+      "Similar US concentration to VGS",
+      "Smaller AUM than VGS means slightly wider spreads",
+    ],
+    verdict: "The cheapest way to access global developed markets. The broader coverage (small caps included) is a meaningful advantage over VGS at a lower cost.",
+  },
+  {
+    ticker: "VEU",
+    name: "Vanguard All-World ex-US Shares ETF",
+    provider: "Vanguard",
+    index: "FTSE All-World ex US Index",
+    mer: "0.20%",
+    aum: "$1.8B",
+    yield: "~2.8%",
+    countries: "45+ markets (ex-US)",
+    holdings: "~3,800 companies",
+    currency: "Unhedged (AUD)",
+    pros: [
+      "Excludes US — perfect complement to IVV or NDQ for US exposure",
+      "Includes both developed AND emerging markets (ex-US)",
+      "Higher dividend yield than US-heavy ETFs",
+      "Broad geographic diversification across 45+ countries",
+    ],
+    cons: [
+      "Less liquid than VGS on ASX",
+      "More complex to combine with US ETFs for total portfolio",
+      "Higher MER than IWLD",
+    ],
+    verdict: "Best used alongside a dedicated US ETF (IVV or NDQ) for investors who want to control their US vs rest-of-world allocation precisely.",
+  },
+  {
+    ticker: "FEMX",
+    name: "Fidelity Global Emerging Markets ETF",
+    provider: "Fidelity",
+    index: "Actively managed (Emerging Markets)",
+    mer: "0.50%",
+    aum: "$410M",
+    yield: "~1.8%",
+    countries: "24 emerging markets",
+    holdings: "~90 companies",
+    currency: "Unhedged (AUD)",
+    pros: [
+      "Dedicated emerging markets exposure — China, India, Taiwan, Brazil",
+      "Active management seeks to avoid state-owned enterprises and governance risks",
+      "Concentrated portfolio of quality emerging market companies",
+      "Fidelity's deep emerging markets research capability",
+    ],
+    cons: [
+      "Higher MER for active management",
+      "Concentrated — only ~90 holdings vs 1,000+ for passive EM funds",
+      "Active risk — manager can underperform the benchmark",
+      "Emerging markets are inherently more volatile",
+    ],
+    verdict: "For investors wanting emerging market exposure without taking on all the governance and state-ownership risks of passive EM indices. The active quality filter has merit.",
+  },
+  {
+    ticker: "VGAD",
+    name: "Vanguard MSCI Index International Shares (Hedged) ETF",
+    provider: "Vanguard",
+    index: "MSCI World ex-Australia Index (AUD Hedged)",
+    mer: "0.21%",
+    aum: "$1.4B",
+    yield: "~1.8%",
+    countries: "23 developed markets",
+    holdings: "~1,500 companies",
+    currency: "AUD Hedged",
+    pros: [
+      "Same index as VGS but currency-hedged",
+      "Eliminates AUD/foreign currency exchange rate risk",
+      "Returns purely reflect international company performance",
+      "Useful for investors expecting AUD to strengthen",
+    ],
+    cons: [
+      "Hedging costs reduce returns when AUD weakens",
+      "Slightly higher MER than VGS for the hedge",
+      "Hedging adds complexity and counterparty risk",
+    ],
+    verdict: "Choose VGAD over VGS if you're concerned about AUD strengthening (which would hurt unhedged returns). Most long-term investors are better off unhedged (VGS).",
+  },
+];
+
+const SECTIONS = [
+  {
+    heading: "Why invest internationally? The case for global diversification",
+    body: `The Australian share market represents less than 2% of global equity market capitalisation. Investing only in Australian shares means concentrating 100% of your equity risk in a market dominated by four banks and two mining companies. International diversification is not optional — it's essential.
+
+**What you get with international ETFs:**
+- Exposure to the world's leading technology companies (Apple, Microsoft, Nvidia, Alphabet) — all of which list in the US, not Australia
+- Access to healthcare innovation leaders (Novo Nordisk, Eli Lilly, UnitedHealth)
+- Exposure to Japanese, European, and Korean industrial giants
+- Participation in emerging market growth stories (India, Southeast Asia, Brazil)
+
+**The Australia-only portfolio problem:**
+An ASX-200 portfolio has approximately 30% in banks and financials, 20% in resources and mining, and relatively little in technology, healthcare, and consumer discretionary. This sector imbalance means Australian-only investors missed the extraordinary tech-driven returns of the 2010s entirely.
+
+**VAS + VGS: the two-ETF core portfolio:**
+The most commonly recommended starting portfolio for Australian investors is a combination of VAS (Australian shares) and VGS (international developed markets). A 40% VAS / 60% VGS split gives you broad Australian diversification plus developed market global exposure in a simple, low-cost structure. Both pay quarterly distributions, both are among the largest ETFs on the ASX, and together they cover approximately 1,800 companies across 24 countries.`,
+  },
+  {
+    heading: "Developed markets vs emerging markets — what's the difference?",
+    body: `International ETFs broadly split into two categories: developed markets and emerging markets.
+
+**Developed markets (VGS, IWLD):**
+- Includes the US, UK, Japan, Germany, France, Canada, Australia (excluded in 'ex-Australia' versions), South Korea, Switzerland
+- Stable regulatory environments, strong property rights, liquid markets
+- Lower growth potential but lower volatility
+- US typically accounts for 60–70% of developed market indices
+
+**Emerging markets (FEMX, Vanguard VGE):**
+- Includes China, India, Brazil, Taiwan, South Korea (in some indices), South Africa, Indonesia
+- Higher long-term growth potential, but higher volatility and risk
+- Political risk, currency risk, and governance concerns are real
+- China currently accounts for 25–30% of most passive EM indices — a significant concentration
+
+**Should you add emerging markets?**
+For most Australian investors, a 10–15% emerging markets allocation (alongside developed markets) is reasonable. Emerging markets ETFs have underperformed developed markets significantly over the past decade, largely due to China's regulatory crackdowns and tech sector restrictions. However, India's growth trajectory and Southeast Asia's demographics make the case for some EM exposure.
+
+**A practical allocation:**
+60% ASX equities (VAS) + 30% International developed (VGS or IWLD) + 10% Emerging markets (FEMX or VGE) covers the major equity markets efficiently in three holdings.`,
+  },
+  {
+    heading: "Currency risk and hedging — should you hedge?",
+    body: `When you buy an unhedged international ETF like VGS, your returns are affected by both:
+1. The performance of the underlying international shares
+2. Changes in the AUD vs the basket of foreign currencies
+
+**When AUD weakens:** Your unhedged international ETF returns increase in AUD terms — the foreign shares are worth more in Australian dollars.
+
+**When AUD strengthens:** Your unhedged international ETF returns decrease — the foreign shares are worth less in Australian dollars.
+
+**Why most long-term investors don't hedge:**
+Currency movements are largely unpredictable over any given year. Over decades, the AUD has been relatively stable against major currencies, oscillating within a range. Long-term investors who hedge are effectively making a currency bet rather than avoiding risk.
+
+More importantly, an unhedged international ETF provides a natural hedge against Australian economic weakness — which tends to cause AUD to weaken and unhedged international returns to rise. During the GFC, the AUD fell from 0.98 USD to 0.60 USD, boosting unhedged returns for Australians precisely when the domestic economy was stressed.
+
+**When hedging makes sense:**
+If you're investing with a 2–3 year time horizon, or believe AUD is about to strengthen materially, a hedged ETF like VGAD provides certainty of return in AUD terms. For super funds with short-term liability matching requirements, hedged international exposure may be appropriate.`,
+  },
+];
+
+const FAQS = [
+  {
+    question: "What is the best international ETF for Australian investors?",
+    answer: "For most Australians, IWLD (iShares Core MSCI World All Cap) offers the best combination of low cost (0.09% MER), broad diversification (3,900+ companies), and liquidity. VGS (Vanguard MSCI World) is the most popular choice by AUM and is equally excellent — slightly fewer holdings but backed by Vanguard's trusted brand. Either works well as the international pillar of a core portfolio.",
+  },
+  {
+    question: "Should I use VGS or IWLD?",
+    answer: "IWLD is cheaper (0.09% vs 0.18% MER) and broader (includes international small caps). VGS is larger by AUM ($8.2B vs $3.1B) with potentially tighter bid-ask spreads. For large portfolios, the cost difference compounds meaningfully — IWLD saves $900/year per $1M invested vs VGS. For most investors, the practical difference is small. Choose based on your platform's brokerage and which ETF has tighter spreads when you're trading.",
+  },
+  {
+    question: "Do international ETFs pay dividends?",
+    answer: "Yes, but the distributions differ from Australian equity ETFs. International ETFs pay distributions from dividends received from foreign companies, but these are unfranked (no franking credits, as the underlying companies don't pay Australian corporate tax). Distribution yields are typically 1.5–3% for international equity ETFs — lower than Australian equity ETFs which benefit from franking credits.",
+  },
+  {
+    question: "Are international ETFs affected by foreign withholding tax?",
+    answer: "Yes. Many countries withhold tax on dividends before they're paid to foreign investors (e.g. the US withholds 30%, reduced to 15% under the Australia-US tax treaty). Australian-domiciled ETFs like VGS have this tax withheld at the fund level before distributions are paid. You don't receive a separate withholding tax credit — it's already built into the lower distribution yield of international ETFs.",
+  },
+  {
+    question: "What is the best way to get emerging markets exposure?",
+    answer: "FEMX (Fidelity) takes an active approach filtering for quality, which has merit in markets with governance risks. Vanguard Emerging Markets (VGE) provides cheaper passive exposure to a broader set of emerging markets companies including large China positions. For most investors, a 10-15% EM allocation using either approach is reasonable. Avoid making emerging markets a large part of your portfolio given the higher volatility and political risk.",
+  },
+  {
+    question: "How do international ETFs fit into an Australian portfolio?",
+    answer: "The most common approach is a core two-ETF portfolio: VAS (Australian shares, 30-40%) + VGS or IWLD (international developed markets, 60-70%). This gives you ~300 Australian companies and ~1,500 international companies in two holdings. More sophisticated portfolios add emerging markets (VGE or FEMX), international small caps, or sector-specific international exposure. Keep it simple — the two-ETF core is hard to beat for most investors.",
+  },
+];
+
+export default function InternationalETFsPage() {
+  const breadcrumb = breadcrumbJsonLd([
+    { name: "Home", url: SITE_URL },
+    { name: "ETFs", url: `${SITE_URL}/etfs` },
+    { name: "International ETFs" },
+  ]);
+
+  const faqSchema = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: FAQS.map((f) => ({
+      "@type": "Question",
+      name: f.question,
+      acceptedAnswer: { "@type": "Answer", text: f.answer },
+    })),
+  };
+
+  return (
+    <div className="bg-white min-h-screen">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+
+      {/* Hero */}
+      <section className="bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 text-white py-10 md:py-14">
+        <div className="container-custom">
+          <nav className="text-xs text-slate-400 mb-5 flex items-center gap-1.5 flex-wrap">
+            <Link href="/" className="hover:text-slate-200">Home</Link>
+            <span>/</span>
+            <Link href="/etfs" className="hover:text-slate-200">ETFs</Link>
+            <span>/</span>
+            <span className="text-slate-300">International ETFs</span>
+          </nav>
+          <div className="max-w-3xl">
+            <div className="inline-flex items-center gap-2 px-3 py-1 bg-purple-500/20 border border-purple-500/30 rounded-full text-xs font-semibold text-purple-300 mb-4">
+              <span className="w-1.5 h-1.5 bg-purple-400 rounded-full" />
+              Global Diversification · {UPDATED_LABEL}
+            </div>
+            <h1 className="text-2xl sm:text-3xl md:text-4xl font-extrabold leading-[1.1] mb-3 tracking-tight">
+              Best International ETFs Australia{" "}
+              <span className="text-amber-400">({CURRENT_YEAR})</span>
+            </h1>
+            <p className="text-sm md:text-base text-slate-300 leading-relaxed max-w-2xl">
+              Compare the best international ETFs available in Australia — developed markets, emerging markets,
+              and all-world funds. VGS, IWLD, VEU, FEMX and more, analysed by MER, coverage, currency exposure, and performance.
+            </p>
+            <div className="flex flex-wrap gap-3 mt-5">
+              <Link href="/etfs/asx-200" className="px-4 py-2 bg-amber-500 hover:bg-amber-400 text-black text-xs font-bold rounded-lg transition-colors">
+                Pair with ASX 200 ETFs →
+              </Link>
+              <Link href="/etfs" className="px-4 py-2 bg-white/10 hover:bg-white/20 text-white text-xs font-semibold rounded-lg transition-colors border border-white/20">
+                ← All ETF Categories
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Callouts */}
+      <section className="py-8 bg-slate-50 border-b border-slate-200">
+        <div className="container-custom">
+          <div className="grid sm:grid-cols-3 gap-4">
+            <div className="bg-white rounded-2xl border border-purple-200 p-5">
+              <p className="text-xs font-bold text-purple-700 uppercase tracking-wide mb-1">Australia = Global Market</p>
+              <p className="text-xl font-black text-purple-700">&lt;2%</p>
+              <p className="text-xs text-slate-600 mt-1">Australia represents under 2% of global equity market cap. International ETFs give you access to the other 98%.</p>
+            </div>
+            <div className="bg-white rounded-2xl border border-amber-200 p-5">
+              <p className="text-xs font-bold text-amber-800 uppercase tracking-wide mb-1">Cheapest International ETF</p>
+              <p className="text-xl font-black text-amber-700">0.09% (IWLD)</p>
+              <p className="text-xs text-slate-600 mt-1">iShares Core MSCI World All Cap ETF — 3,900+ global companies for just $90/year per $100K invested.</p>
+            </div>
+            <div className="bg-white rounded-2xl border border-slate-200 p-5">
+              <p className="text-xs font-bold text-slate-600 uppercase tracking-wide mb-1">VGS AUM</p>
+              <p className="text-xl font-black text-slate-900">$8.2B</p>
+              <p className="text-xs text-slate-600 mt-1">The most popular international ETF in Australia by assets under management, reflecting deep investor trust.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ETF Cards */}
+      <section className="py-10 md:py-14">
+        <div className="container-custom">
+          <SectionHeading
+            eyebrow="International ETF Comparison"
+            title="Global ETFs Available in Australia"
+            sub="Developed markets, emerging markets, and currency-hedged options — independently analysed."
+          />
+          <div className="mt-8 space-y-6">
+            {INTERNATIONAL_ETFS.map((etf) => (
+              <div key={etf.ticker} className="bg-white border border-slate-200 rounded-2xl p-6 hover:shadow-md transition-shadow">
+                <div className="flex flex-wrap items-start justify-between gap-4 mb-4">
+                  <div>
+                    <div className="flex items-center gap-3 mb-1">
+                      <span className="font-mono text-lg font-black text-slate-900 bg-slate-100 px-3 py-1 rounded-lg">{etf.ticker}</span>
+                      <span className="text-xs bg-purple-100 text-purple-800 px-2 py-1 rounded font-semibold">{etf.currency}</span>
+                    </div>
+                    <p className="text-sm font-semibold text-slate-700">{etf.name}</p>
+                    <p className="text-xs text-slate-500">{etf.provider} · {etf.index}</p>
+                  </div>
+                  <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 text-center">
+                    {[
+                      { label: "MER", value: etf.mer },
+                      { label: "AUM", value: etf.aum },
+                      { label: "Yield", value: etf.yield },
+                      { label: "Countries", value: etf.countries.split(" ")[0] + " " + etf.countries.split(" ")[1] },
+                    ].map((m) => (
+                      <div key={m.label} className="bg-slate-50 rounded-xl p-2.5">
+                        <p className="text-xs text-slate-500 mb-0.5">{m.label}</p>
+                        <p className="text-sm font-bold text-slate-900">{m.value}</p>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+                <div className="grid sm:grid-cols-2 gap-4 mb-4">
+                  <div>
+                    <p className="text-xs font-bold text-green-700 mb-1.5">Pros</p>
+                    <ul className="space-y-1">
+                      {etf.pros.map((p) => (
+                        <li key={p} className="text-xs text-slate-600 flex items-start gap-1.5">
+                          <span className="text-green-500 mt-0.5 shrink-0">✓</span>{p}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                  <div>
+                    <p className="text-xs font-bold text-red-700 mb-1.5">Cons</p>
+                    <ul className="space-y-1">
+                      {etf.cons.map((c) => (
+                        <li key={c} className="text-xs text-slate-600 flex items-start gap-1.5">
+                          <span className="text-red-400 mt-0.5 shrink-0">✗</span>{c}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                </div>
+                <div className="bg-amber-50 border border-amber-200 rounded-xl p-3">
+                  <p className="text-xs font-bold text-amber-800 mb-1">Our Take</p>
+                  <p className="text-xs text-slate-700 leading-relaxed">{etf.verdict}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Editorial */}
+      <section className="py-10 bg-slate-50">
+        <div className="container-custom max-w-3xl">
+          <SectionHeading eyebrow="International Investing Guide" title="Global Diversification for Australian Investors" />
+          <div className="mt-8 space-y-10">
+            {SECTIONS.map((sec) => (
+              <div key={sec.heading}>
+                <h2 className="text-lg font-extrabold text-slate-900 mb-3">{sec.heading}</h2>
+                <div className="prose prose-sm max-w-none text-slate-600 leading-relaxed">
+                  {sec.body.split("\n\n").map((para, i) => (
+                    <p key={i} className="mb-3 last:mb-0 whitespace-pre-line">{para}</p>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* FAQs */}
+      <section className="py-10 md:py-12">
+        <div className="container-custom max-w-2xl">
+          <SectionHeading eyebrow="FAQ" title="International ETF Questions Answered" />
+          <div className="mt-6 divide-y divide-slate-200">
+            {FAQS.map((faq) => (
+              <details key={faq.question} className="py-4 group">
+                <summary className="text-sm font-semibold text-slate-900 cursor-pointer list-none flex items-center justify-between gap-2">
+                  {faq.question}
+                  <span className="text-slate-400 group-open:rotate-180 transition-transform shrink-0">▾</span>
+                </summary>
+                <p className="mt-3 text-sm text-slate-600 leading-relaxed">{faq.answer}</p>
+              </details>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-12 bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 text-white">
+        <div className="container-custom text-center max-w-xl">
+          <h2 className="text-xl font-extrabold mb-3">Ready to invest globally?</h2>
+          <p className="text-sm text-slate-300 mb-6">
+            Compare brokers that offer ASX-listed international ETFs with low brokerage and no platform fees.
+          </p>
+          <div className="flex flex-col sm:flex-row gap-3 justify-center">
+            <Link href="/best/etfs" className="px-6 py-3 bg-amber-500 hover:bg-amber-400 text-black font-bold text-sm rounded-xl transition-colors">
+              Best ETF Brokers →
+            </Link>
+            <Link href="/etfs/vs/vgs-vs-iwld" className="px-6 py-3 bg-white/10 hover:bg-white/20 border border-white/20 text-white font-semibold text-sm rounded-xl transition-colors">
+              VGS vs IWLD →
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <section className="py-6 bg-slate-100 border-t border-slate-200">
+        <div className="container-custom max-w-3xl">
+          <p className="text-xs text-slate-500 leading-relaxed">{GENERAL_ADVICE_WARNING}</p>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/etfs/sectors/page.tsx
+++ b/app/etfs/sectors/page.tsx
@@ -1,0 +1,472 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR, UPDATED_LABEL } from "@/lib/seo";
+import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
+import SectionHeading from "@/components/SectionHeading";
+
+export const revalidate = 86400;
+
+export const metadata: Metadata = {
+  title: `Best Sector ETFs Australia (${CURRENT_YEAR}) — Technology, Healthcare, Resources & More`,
+  description: `Compare the best sector ETFs in Australia: HACK (cybersecurity), DRUG (healthcare), NDQ (tech), OZR (resources), QFN (financials) and more. Targeted sector exposure analysed by MER, performance, and risk. ${UPDATED_LABEL}.`,
+  openGraph: {
+    title: `Best Sector ETFs Australia (${CURRENT_YEAR})`,
+    description: "Complete guide to Australian sector ETFs. Target technology, healthcare, resources, financials and more with a single ETF.",
+    url: `${SITE_URL}/etfs/sectors`,
+  },
+  twitter: { card: "summary_large_image" },
+  alternates: { canonical: `${SITE_URL}/etfs/sectors` },
+};
+
+const SECTOR_ETFS = [
+  {
+    ticker: "NDQ",
+    name: "BetaShares NASDAQ 100 ETF",
+    provider: "Betashares",
+    sector: "Technology / Growth",
+    index: "NASDAQ 100 Index",
+    mer: "0.48%",
+    aum: "$5.8B",
+    yield: "~0.5%",
+    topHoldings: "Apple, Microsoft, Nvidia, Amazon, Meta",
+    icon: "💻",
+    pros: [
+      "Australia's largest sector ETF — excellent liquidity",
+      "Access to the world's leading technology companies",
+      "NASDAQ 100 has significantly outperformed S&P 500 over 10 years",
+      "Single entry point to US mega-cap tech",
+    ],
+    cons: [
+      "Concentrated in tech — sector risk in downturns",
+      "Higher MER than broad market ETFs",
+      "Currency risk (unhedged USD exposure)",
+      "Not true 'tech-only' — includes Amazon, Tesla in NASDAQ 100",
+    ],
+    verdict: "The most popular way for Australians to access US technology leaders. Use as a growth satellite to a core VAS + VGS portfolio — not a replacement for broad market exposure.",
+  },
+  {
+    ticker: "HACK",
+    name: "BetaShares Global Cybersecurity ETF",
+    provider: "Betashares",
+    sector: "Cybersecurity",
+    index: "Nasdaq CTA Cybersecurity Index",
+    mer: "0.67%",
+    aum: "$910M",
+    yield: "~0.3%",
+    topHoldings: "Palo Alto Networks, CrowdStrike, Fortinet, Zscaler, Okta",
+    icon: "🔐",
+    pros: [
+      "Dedicated exposure to the fast-growing cybersecurity sector",
+      "Structural tailwind — cybersecurity spending grows regardless of economic cycle",
+      "Diversified across 40+ global cybersecurity companies",
+      "Sector is relatively non-cyclical — governments and businesses must spend regardless",
+    ],
+    cons: [
+      "High MER for a thematic ETF",
+      "Concentrated sector — high single-sector risk",
+      "Individual companies can be disrupted by faster rivals",
+      "Smaller AUM than NDQ — wider spreads possible",
+    ],
+    verdict: "A solid thematic ETF for investors who want targeted cybersecurity exposure. The structural case for cybersecurity spending growth is compelling — but keep sector ETFs to 5-10% of your portfolio.",
+  },
+  {
+    ticker: "DRUG",
+    name: "BetaShares Global Healthcare ETF (Currency Hedged)",
+    provider: "Betashares",
+    sector: "Healthcare / Biotech",
+    index: "Nasdaq Global ex-Australia Healthcare Hedged AUD Index",
+    mer: "0.57%",
+    aum: "$280M",
+    yield: "~0.8%",
+    topHoldings: "UnitedHealth, Eli Lilly, AbbVie, Johnson & Johnson, Novo Nordisk",
+    icon: "💊",
+    pros: [
+      "Defensive sector — healthcare demand is non-cyclical",
+      "Exposure to global pharmaceutical and biotech giants",
+      "Currency-hedged — removes AUD/USD exchange rate risk",
+      "Ageing population demographics support long-term demand",
+    ],
+    cons: [
+      "Drug approval risk — clinical trial failures affect individual companies",
+      "High regulatory and political risk (drug pricing policy)",
+      "Higher MER for hedged thematic exposure",
+      "Hedging costs erode returns when AUD weakens",
+    ],
+    verdict: "Healthcare is genuinely defensive — a 5-10% allocation makes sense for investors approaching retirement or wanting a defensive tilt. The hedging is a reasonable choice for healthcare given AUD volatility.",
+  },
+  {
+    ticker: "OZR",
+    name: "SPDR S&P/ASX 200 Resources ETF",
+    provider: "State Street SPDR",
+    sector: "Australian Resources",
+    index: "S&P/ASX 200 Resources Index",
+    mer: "0.34%",
+    aum: "$590M",
+    yield: "~3.5%",
+    topHoldings: "BHP, RIO, Fortescue, South32, Mineral Resources",
+    icon: "⛏️",
+    pros: [
+      "Pure Australian resources exposure — BHP, RIO, and more",
+      "Inflation hedge — resources companies benefit from rising commodity prices",
+      "Strong dividend yields from major miners",
+      "High franking credits from ASX-listed resources companies",
+    ],
+    cons: [
+      "Highly cyclical — commodity price dependent",
+      "BHP/RIO dominate — some concentration in 2-3 companies",
+      "Commodity markets can be extremely volatile",
+      "Overlaps significantly with any ASX 200 ETF holding",
+    ],
+    verdict: "Useful as a tactical overweight to resources if you have a view on commodity prices, but most ASX 200 ETFs already give you 20%+ in resources. Adds concentration risk if combined with VAS.",
+  },
+  {
+    ticker: "QFN",
+    name: "BetaShares Australian Financials Sector ETF",
+    provider: "Betashares",
+    sector: "Australian Financials",
+    index: "Solactive Australia Financials Select Index",
+    mer: "0.34%",
+    aum: "$155M",
+    yield: "~4.8%",
+    topHoldings: "CBA, NAB, Westpac, ANZ, Macquarie",
+    icon: "🏦",
+    pros: [
+      "Direct exposure to Australia's four major banks",
+      "High dividend yield with strong franking credits",
+      "Banks benefit from higher interest rate environments",
+      "Well-regulated, systemically important companies",
+    ],
+    cons: [
+      "Concentration risk — four banks dominate",
+      "Rate-sensitive — bank margins compress in low-rate environments",
+      "Overlaps almost entirely with any ASX 200 ETF",
+      "Australian banks have limited international growth",
+    ],
+    verdict: "The ASX 200 already gives you 30%+ in financials — adding QFN on top creates heavy bank concentration. Only appropriate as a tactical bet on Australian bank outperformance.",
+  },
+  {
+    ticker: "ETHI",
+    name: "BetaShares Global Sustainability Leaders ETF",
+    provider: "Betashares",
+    sector: "ESG / Ethical",
+    index: "Nasdaq Future Global Sustainability Leaders Index",
+    mer: "0.59%",
+    aum: "$2.1B",
+    yield: "~0.7%",
+    topHoldings: "Apple, Microsoft, Nvidia, ASML, Visa",
+    icon: "🌱",
+    pros: [
+      "Excludes fossil fuels, weapons, tobacco, gambling",
+      "Strong 10-year performance — ESG leaders include quality tech companies",
+      "One of Australia's largest ESG ETFs with excellent liquidity",
+      "Aligns investment with ethical values",
+    ],
+    cons: [
+      "Higher MER than non-ESG alternatives",
+      "Still heavily US and tech-weighted",
+      "ESG screening excludes some legitimate industries",
+      "ESG ratings are not standardised and can be inconsistent",
+    ],
+    verdict: "Australia's most popular ethical ETF — and it has performed well because ESG-leaders overlap heavily with quality technology companies. A legitimate alternative to VGS for investors with ethical investing priorities.",
+  },
+];
+
+const SECTIONS = [
+  {
+    heading: "Should you use sector ETFs?",
+    body: `Sector ETFs let you express conviction about specific industries or themes — but they require discipline in sizing and selection.
+
+**When sector ETFs make sense:**
+- You have a specific view on an industry's long-term growth that differs from the market's view
+- You want to complement a broad market ETF with targeted exposure
+- You want a defensive tilt (healthcare, utilities) or growth tilt (technology) relative to the broad market
+- You're implementing a values-based investment approach (ESG, avoidance of specific sectors)
+
+**When to be cautious:**
+Sector ETFs are inherently more volatile than broad market ETFs. A sector can underperform for years even if the fundamental thesis is correct. Technology ETFs that performed spectacularly in 2020-21 fell 30-50% in 2022 as rate expectations changed. Resources ETFs are heavily correlated with commodity cycles that can last years.
+
+**Portfolio sizing guidance:**
+Most financial planners suggest capping satellite positions (sector ETFs, individual stocks) at 10-20% of your equity portfolio. Your core broad market ETFs (VAS, VGS or IWLD) should represent 80-90%.
+
+**The overlap problem:**
+Many sector ETFs heavily overlap with existing holdings. If you already hold VAS (which is ~30% financials), adding QFN (100% financials) dramatically overweights banks in your total portfolio. Check the underlying holdings of your broad ETFs before adding sector exposure.`,
+  },
+  {
+    heading: "Technology ETFs — the growth story",
+    body: `Technology sector ETFs have been the standout performers of the past 15 years. The NASDAQ 100 (tracked by NDQ) has returned approximately 15-18% per year over the past decade — significantly beating the S&P 500 and ASX 200.
+
+**Why tech has outperformed:**
+- Software has near-zero marginal cost of production — extraordinary profit margins
+- Platform businesses (Apple App Store, Microsoft Azure, Google Search) create durable competitive moats
+- Secular growth in digital advertising, cloud computing, and AI investment
+- US tech giants have become essential infrastructure for global businesses
+
+**The risks:**
+- Tech valuations are highly sensitive to interest rates — higher rates reduce the present value of future earnings, which tech companies typically generate further in the future
+- Regulatory risk — antitrust action, data privacy regulation, and AI governance could impair tech giants' business models
+- Concentration risk — 5 companies (Apple, Microsoft, Nvidia, Alphabet, Amazon) represent 40%+ of the NASDAQ 100
+- Disruption risk — today's tech giants can be disrupted by the next wave of innovation
+
+**The practical approach:**
+A 10-15% allocation to NDQ (or ETHI for ethical investors) alongside VGS and VAS is reasonable for investors seeking above-market technology exposure. NDQ already has significant overlap with VGS (which is ~70% US and ~25-30% tech) — manage the total tech weighting carefully.`,
+  },
+  {
+    heading: "Thematic ETFs — structural trends or expensive bets?",
+    body: `Beyond traditional sector ETFs, thematic ETFs target specific trends: cybersecurity (HACK), clean energy, robotics and AI, ageing populations, and more. The question is whether thematic ETFs represent genuine structural opportunities or expensive speculation.
+
+**The case for thematic ETFs:**
+Certain secular trends do drive above-market returns for extended periods. Cybersecurity is a good example — enterprise and government spending on cybersecurity has grown regardless of economic cycles because the cost of a breach far exceeds the cost of prevention. HACK has delivered reasonable risk-adjusted returns by focusing on a genuine structural need.
+
+**The risks of thematic ETFs:**
+- By the time a theme is obvious enough to launch an ETF around it, the opportunity may already be priced in
+- Many thematic ETFs launch at the top of hype cycles (blockchain, cannabis, etc.)
+- Higher MERs — most thematic ETFs charge 0.50-0.75%
+- Narrower investment universes mean individual company risk is higher
+- Some themes underperform for years before (if ever) delivering on their promise
+
+**Evaluation checklist for thematic ETFs:**
+1. Is this a genuine structural trend, or a current market narrative?
+2. Are the companies in this ETF actually pure-plays, or is it a loose thematic grouping?
+3. What is the MER vs the return premium you're expecting?
+4. Is the AUM large enough for good liquidity? (Aim for $200M+)
+5. Does this overlap significantly with your existing broad market ETFs?`,
+  },
+];
+
+const FAQS = [
+  {
+    question: "What is the best technology ETF in Australia?",
+    answer: "NDQ (BetaShares NASDAQ 100) is the most popular tech-focused ETF in Australia with $5.8B AUM and excellent liquidity. It tracks the NASDAQ 100 index — the 100 largest non-financial companies on the NASDAQ, which is heavily technology-weighted. For pure cybersecurity exposure, HACK is the leading option. For ethical/ESG investors wanting tech exposure, ETHI is a strong alternative. All have higher MERs than broad market ETFs (0.48-0.67%), which is the price of sector specialisation.",
+  },
+  {
+    question: "Are sector ETFs risky?",
+    answer: "Sector ETFs are inherently more volatile than broad market ETFs because they lack diversification across sectors. A resources ETF (OZR) is heavily correlated with commodity prices; a technology ETF (NDQ) is sensitive to interest rate changes and tech sentiment. This doesn't make them bad investments — it means they should be sized appropriately (5-15% of your portfolio) and used to complement a broad market core, not replace it.",
+  },
+  {
+    question: "What is ETHI and how does it work?",
+    answer: "ETHI (BetaShares Global Sustainability Leaders ETF) invests in global companies that are leaders in sustainability and ESG (environmental, social, governance) practices, while excluding companies involved in fossil fuels, weapons, tobacco, gambling, and other controversial activities. In practice, the ETF is heavily weighted toward US technology companies (Apple, Microsoft, Nvidia) which score well on ESG metrics. It has performed comparably to VGS over 5-10 years while excluding industries many investors wish to avoid.",
+  },
+  {
+    question: "Can I use sector ETFs to reduce overlap in my portfolio?",
+    answer: "Sometimes, but often sector ETFs increase rather than reduce overlap. For example, if you hold VAS (30% financials) and add QFN (100% financials), you dramatically overweight Australian banks. A more effective use of sector ETFs is to fill genuine gaps — e.g. adding HACK for cybersecurity exposure that VGS provides very little of, or adding OZR to overweight resources if you have conviction on commodity prices. Always check the underlying holdings of your existing ETFs before adding sector exposure.",
+  },
+  {
+    question: "What is the minimum portfolio size for sector ETFs to make sense?",
+    answer: "There's no hard minimum, but sector ETFs generally make more sense as portfolio size increases. On a $20,000 portfolio, the added brokerage cost of holding multiple ETFs (including sector positions) may not be worthwhile. On a $200,000+ portfolio, a 10% allocation to a thematic like HACK or DRUG becomes a $20,000 position that's worth managing separately. For smaller portfolios, a single all-in-one ETF (like VDHG) may be a simpler alternative.",
+  },
+  {
+    question: "How do sector ETFs fit in a retirement or SMSF portfolio?",
+    answer: "For retirement portfolios, defensive sector ETFs (healthcare/DRUG, infrastructure, utilities) can provide stable income and reduced volatility. Growth sector ETFs (NDQ, HACK) are appropriate in the growth phase but should be reduced as you approach retirement. SMSF investors have full flexibility to hold sector ETFs alongside broad market exposure, property, and other assets. The key is maintaining an overall allocation consistent with your investment strategy — sector ETFs should complement, not dominate, a retirement portfolio.",
+  },
+];
+
+export default function SectorETFsPage() {
+  const breadcrumb = breadcrumbJsonLd([
+    { name: "Home", url: SITE_URL },
+    { name: "ETFs", url: `${SITE_URL}/etfs` },
+    { name: "Sector ETFs" },
+  ]);
+
+  const faqSchema = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: FAQS.map((f) => ({
+      "@type": "Question",
+      name: f.question,
+      acceptedAnswer: { "@type": "Answer", text: f.answer },
+    })),
+  };
+
+  return (
+    <div className="bg-white min-h-screen">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+
+      {/* Hero */}
+      <section className="bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 text-white py-10 md:py-14">
+        <div className="container-custom">
+          <nav className="text-xs text-slate-400 mb-5 flex items-center gap-1.5 flex-wrap">
+            <Link href="/" className="hover:text-slate-200">Home</Link>
+            <span>/</span>
+            <Link href="/etfs" className="hover:text-slate-200">ETFs</Link>
+            <span>/</span>
+            <span className="text-slate-300">Sector ETFs</span>
+          </nav>
+          <div className="max-w-3xl">
+            <div className="inline-flex items-center gap-2 px-3 py-1 bg-rose-500/20 border border-rose-500/30 rounded-full text-xs font-semibold text-rose-300 mb-4">
+              <span className="w-1.5 h-1.5 bg-rose-400 rounded-full" />
+              Sector & Thematic ETFs · {UPDATED_LABEL}
+            </div>
+            <h1 className="text-2xl sm:text-3xl md:text-4xl font-extrabold leading-[1.1] mb-3 tracking-tight">
+              Best Sector ETFs Australia{" "}
+              <span className="text-amber-400">({CURRENT_YEAR})</span>
+            </h1>
+            <p className="text-sm md:text-base text-slate-300 leading-relaxed max-w-2xl">
+              Compare sector and thematic ETFs in Australia — technology, cybersecurity, healthcare, resources,
+              financials, and ESG. Targeted exposure analysed by MER, performance, and how they fit in a broader portfolio.
+            </p>
+            <div className="flex flex-wrap gap-3 mt-5">
+              <Link href="/etfs" className="px-4 py-2 bg-white/10 hover:bg-white/20 text-white text-xs font-semibold rounded-lg transition-colors border border-white/20">
+                ← All ETF Categories
+              </Link>
+              <Link href="/etfs/us-exposure" className="px-4 py-2 bg-white/10 hover:bg-white/20 text-white text-xs font-semibold rounded-lg transition-colors border border-white/20">
+                US Market ETFs →
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Callouts */}
+      <section className="py-8 bg-slate-50 border-b border-slate-200">
+        <div className="container-custom">
+          <div className="grid sm:grid-cols-3 gap-4">
+            <div className="bg-white rounded-2xl border border-rose-200 p-5">
+              <p className="text-xs font-bold text-rose-700 uppercase tracking-wide mb-1">NDQ — Australia&apos;s Largest Sector ETF</p>
+              <p className="text-xl font-black text-rose-700">$5.8B AUM</p>
+              <p className="text-xs text-slate-600 mt-1">The NASDAQ 100 ETF is the dominant sector play — Apple, Microsoft, Nvidia in one ASX-listed fund.</p>
+            </div>
+            <div className="bg-white rounded-2xl border border-amber-200 p-5">
+              <p className="text-xs font-bold text-amber-800 uppercase tracking-wide mb-1">Typical Sector ETF MER</p>
+              <p className="text-xl font-black text-amber-700">0.35–0.70%</p>
+              <p className="text-xs text-slate-600 mt-1">Sector ETFs cost 2–5x more than broad market ETFs — worth it only if the targeted exposure delivers a return premium.</p>
+            </div>
+            <div className="bg-white rounded-2xl border border-slate-200 p-5">
+              <p className="text-xs font-bold text-slate-600 uppercase tracking-wide mb-1">Recommended Satellite Allocation</p>
+              <p className="text-xl font-black text-slate-900">5–15%</p>
+              <p className="text-xs text-slate-600 mt-1">Sector ETFs should complement — not replace — your broad market core (VAS + VGS or IWLD).</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ETF Cards */}
+      <section className="py-10 md:py-14">
+        <div className="container-custom">
+          <SectionHeading
+            eyebrow="Sector ETF Comparison"
+            title="Australian Sector & Thematic ETFs"
+            sub="Independent analysis of the most popular sector and thematic ETFs available on the ASX."
+          />
+          <div className="mt-8 space-y-6">
+            {SECTOR_ETFS.map((etf) => (
+              <div key={etf.ticker} className="bg-white border border-slate-200 rounded-2xl p-6 hover:shadow-md transition-shadow">
+                <div className="flex flex-wrap items-start justify-between gap-4 mb-4">
+                  <div>
+                    <div className="flex items-center gap-3 mb-1">
+                      <span className="text-2xl">{etf.icon}</span>
+                      <span className="font-mono text-lg font-black text-slate-900 bg-slate-100 px-3 py-1 rounded-lg">{etf.ticker}</span>
+                      <span className="text-xs bg-rose-100 text-rose-800 px-2 py-1 rounded font-semibold">{etf.sector}</span>
+                    </div>
+                    <p className="text-sm font-semibold text-slate-700">{etf.name}</p>
+                    <p className="text-xs text-slate-500">{etf.provider} · {etf.index}</p>
+                    <p className="text-xs text-slate-400 mt-1">Top holdings: {etf.topHoldings}</p>
+                  </div>
+                  <div className="grid grid-cols-3 gap-3 text-center">
+                    {[
+                      { label: "MER", value: etf.mer },
+                      { label: "AUM", value: etf.aum },
+                      { label: "Yield", value: etf.yield },
+                    ].map((m) => (
+                      <div key={m.label} className="bg-slate-50 rounded-xl p-2.5">
+                        <p className="text-xs text-slate-500 mb-0.5">{m.label}</p>
+                        <p className="text-sm font-bold text-slate-900">{m.value}</p>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+                <div className="grid sm:grid-cols-2 gap-4 mb-4">
+                  <div>
+                    <p className="text-xs font-bold text-green-700 mb-1.5">Pros</p>
+                    <ul className="space-y-1">
+                      {etf.pros.map((p) => (
+                        <li key={p} className="text-xs text-slate-600 flex items-start gap-1.5">
+                          <span className="text-green-500 mt-0.5 shrink-0">✓</span>{p}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                  <div>
+                    <p className="text-xs font-bold text-red-700 mb-1.5">Cons</p>
+                    <ul className="space-y-1">
+                      {etf.cons.map((c) => (
+                        <li key={c} className="text-xs text-slate-600 flex items-start gap-1.5">
+                          <span className="text-red-400 mt-0.5 shrink-0">✗</span>{c}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                </div>
+                <div className="bg-amber-50 border border-amber-200 rounded-xl p-3">
+                  <p className="text-xs font-bold text-amber-800 mb-1">Our Take</p>
+                  <p className="text-xs text-slate-700 leading-relaxed">{etf.verdict}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Editorial */}
+      <section className="py-10 bg-slate-50">
+        <div className="container-custom max-w-3xl">
+          <SectionHeading eyebrow="Sector ETF Guide" title="How to Use Sector ETFs Effectively" />
+          <div className="mt-8 space-y-10">
+            {SECTIONS.map((sec) => (
+              <div key={sec.heading}>
+                <h2 className="text-lg font-extrabold text-slate-900 mb-3">{sec.heading}</h2>
+                <div className="prose prose-sm max-w-none text-slate-600 leading-relaxed">
+                  {sec.body.split("\n\n").map((para, i) => (
+                    <p key={i} className="mb-3 last:mb-0 whitespace-pre-line">{para}</p>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* FAQs */}
+      <section className="py-10 md:py-12">
+        <div className="container-custom max-w-2xl">
+          <SectionHeading eyebrow="FAQ" title="Sector ETF Questions Answered" />
+          <div className="mt-6 divide-y divide-slate-200">
+            {FAQS.map((faq) => (
+              <details key={faq.question} className="py-4 group">
+                <summary className="text-sm font-semibold text-slate-900 cursor-pointer list-none flex items-center justify-between gap-2">
+                  {faq.question}
+                  <span className="text-slate-400 group-open:rotate-180 transition-transform shrink-0">▾</span>
+                </summary>
+                <p className="mt-3 text-sm text-slate-600 leading-relaxed">{faq.answer}</p>
+              </details>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-12 bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 text-white">
+        <div className="container-custom text-center max-w-xl">
+          <h2 className="text-xl font-extrabold mb-3">Ready to add sector exposure to your portfolio?</h2>
+          <p className="text-sm text-slate-300 mb-6">
+            Compare brokers that offer ASX-listed sector ETFs with low brokerage.
+          </p>
+          <div className="flex flex-col sm:flex-row gap-3 justify-center">
+            <Link href="/best/etfs" className="px-6 py-3 bg-amber-500 hover:bg-amber-400 text-black font-bold text-sm rounded-xl transition-colors">
+              Best ETF Brokers →
+            </Link>
+            <Link href="/etfs" className="px-6 py-3 bg-white/10 hover:bg-white/20 border border-white/20 text-white font-semibold text-sm rounded-xl transition-colors">
+              All ETF Categories →
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <section className="py-6 bg-slate-100 border-t border-slate-200">
+        <div className="container-custom max-w-3xl">
+          <p className="text-xs text-slate-500 leading-relaxed">{GENERAL_ADVICE_WARNING}</p>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/insurance/tpd/page.tsx
+++ b/app/insurance/tpd/page.tsx
@@ -1,0 +1,418 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR, UPDATED_LABEL } from "@/lib/seo";
+import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
+import SectionHeading from "@/components/SectionHeading";
+
+export const revalidate = 86400;
+
+export const metadata: Metadata = {
+  title: `TPD Insurance Australia (${CURRENT_YEAR}) — Total & Permanent Disability Guide`,
+  description: `Complete guide to TPD (Total and Permanent Disability) insurance in Australia: own occupation vs any occupation definitions, inside super vs outside, typical payouts, and how to choose cover. ${UPDATED_LABEL}.`,
+  openGraph: {
+    title: `TPD Insurance Australia (${CURRENT_YEAR}) — Total & Permanent Disability Guide`,
+    description: "Everything you need to know about TPD insurance in Australia — definitions, super vs outside, costs, and who needs it.",
+    url: `${SITE_URL}/insurance/tpd`,
+  },
+  twitter: { card: "summary_large_image" },
+  alternates: { canonical: `${SITE_URL}/insurance/tpd` },
+};
+
+const SECTIONS = [
+  {
+    heading: "What is TPD insurance and who needs it?",
+    body: `Total and Permanent Disability (TPD) insurance pays you a lump sum if you become permanently unable to work due to illness or injury. Unlike income protection — which pays a monthly benefit during disability — TPD is a one-time payment designed to cover major life expenses, adapt your home or vehicle, repay debt, and fund ongoing care.
+
+**Who needs TPD insurance?**
+TPD is most valuable for people who:
+- Have a mortgage or significant debt that a total disability would make unserviceable
+- Have dependants who rely on their income
+- Are in a physically demanding occupation where disability risk is higher
+- Have no significant financial assets to self-insure against a total disability
+- Are under 60 and still building wealth
+
+TPD is less critical for:
+- Retirees with substantial super or assets
+- People whose mortgages are largely paid off
+- People with very high income protection cover that includes permanent disability benefits
+
+**How much TPD cover do you need?**
+A basic calculation: Outstanding mortgage + outstanding debts + 3-5 years of living expenses + estimated ongoing care costs. For a 40-year-old with a $600,000 mortgage and $200,000 in other debts, $1-1.5 million in TPD cover may be appropriate. Super funds often provide default TPD cover of $200,000-$500,000 — this is typically far below what most Australians actually need.
+
+**The Disability Gap:**
+ASIC research shows the majority of Australians with TPD insurance are significantly underinsured — often holding 20-30% of the cover they actually need. This is partly because most TPD cover is default cover inside super, where amounts are not individually tailored.`,
+  },
+  {
+    heading: "Own occupation vs any occupation — the critical difference",
+    body: `The single most important decision in TPD insurance is the definition of disability. There are two main definitions:
+
+**Own occupation TPD:**
+Pays if you are permanently unable to perform your specific occupation. A surgeon who loses a hand, a pilot who develops a vision problem, or a tradesperson with a serious back injury could all claim under own occupation TPD — even if they could theoretically do some other form of work.
+
+- More generous definition — more likely to pay at claim time
+- Can only be held outside super (since July 2014 tax law changes)
+- Higher premiums than any occupation
+
+**Any occupation TPD:**
+Pays only if you are permanently unable to perform any work suited to your education, training, or experience. This is a much higher bar — a surgeon who loses a hand might not qualify if they could theoretically work as a medical consultant or administrator.
+
+- More restrictive definition — lower premium but harder to claim
+- Can be held inside or outside super
+- Most default super fund TPD is 'any occupation'
+
+**The 2014 super tax change:**
+From July 2014, TPD insurance held inside super must use the 'any occupation' definition (or a more restrictive 'activities of daily living' definition). Own occupation TPD must now be held outside super. This means most Australians' default super fund TPD is the less protective 'any occupation' definition.
+
+**Our recommendation:**
+For professionals, tradespeople, and anyone with a specialised occupation, own occupation TPD held outside super provides materially better protection. The premium difference is typically 20-40% more than any occupation — worth it for the dramatically better claim outcome in most disability scenarios.`,
+  },
+  {
+    heading: "TPD inside super vs outside super",
+    body: `Most Australians receive some default TPD cover inside their super fund. Understanding the trade-offs between inside and outside super is critical for TPD insurance decisions.
+
+**TPD inside super:**
+
+Advantages:
+- Premiums paid from pre-tax super contributions — reduces the effective premium cost
+- No out-of-pocket cost (premiums come from your super balance, not your bank account)
+- Default cover is automatic and doesn't require health underwriting in many cases
+
+Disadvantages:
+- Must use 'any occupation' definition (more restrictive, harder to claim)
+- Super fund can have restrictive investment mandates and limited claims support
+- Condition of release rules apply — you must meet a super fund condition of release to access the money (typically 'permanent incapacity', assessed by the trustee)
+- Erosion of super balance if premiums are not offset by super contributions
+- Can't be 'own occupation' definition (since July 2014)
+
+**TPD outside super:**
+
+Advantages:
+- Own occupation definition available — better claim outcome
+- Direct ownership — you deal directly with the insurer, not through super trustee
+- Payment is direct — no super fund trustee approval required
+- No super preservation rules — you access the lump sum directly at claim time
+
+Disadvantages:
+- Premiums paid from after-tax income (not tax-deductible for individuals)
+- Higher out-of-pocket cost vs inside super
+
+**The hybrid approach:**
+Many financial advisers recommend holding some TPD inside super (using pre-tax dollars for a basic amount) and additional TPD outside super with an own occupation definition. For example: $500,000 inside super (any occupation, funded by super contributions) + $500,000 outside super (own occupation, after-tax premiums) gives a $1M total coverage with the better definition on the outside-super portion.`,
+  },
+  {
+    heading: "How a TPD claim works",
+    body: `Understanding the claims process before you need it avoids the compounding stress of a disability event. TPD claims are more complex than life insurance claims because you're alive and must prove total and permanent disability — not a straightforward event like death.
+
+**Step 1 — Notify your insurer:**
+Contact your insurer or super fund trustee as soon as it becomes clear your disability is likely to be permanent. Don't wait until you're certain — start the process early. The insurer will provide a claims kit.
+
+**Step 2 — Medical evidence:**
+You'll need detailed medical evidence from your treating doctors, specialists, and possibly independent medical examiners chosen by the insurer. Expect multiple medical reports, functional capacity assessments, and occupational assessments. This process typically takes 3-12 months.
+
+**Step 3 — Occupational evidence:**
+For 'any occupation' definitions, the insurer will also assess your education, training, and experience to determine what jobs you could potentially perform. This is where many claims are disputed — the insurer may argue you could theoretically do some form of sedentary work.
+
+**Step 4 — Trustee decision (for super fund TPD):**
+If held inside super, the trustee (super fund) must be satisfied you meet the definition before releasing the benefit. The super fund's trustee acts as an intermediary — which can add complexity and delay.
+
+**Step 5 — Appeal process:**
+If your claim is denied, you can appeal internally (to the insurer or trustee), then to the Australian Financial Complaints Authority (AFCA), and ultimately to court. Having an insurance broker or specialist lawyer at claim time significantly improves outcomes for disputed claims.
+
+**Getting help:**
+TPD claims are the most litigated area of insurance. Consider engaging an insurance specialist broker before you need to claim — they can advocate on your behalf and know the insurer's claims process from the inside. Specialist insurance lawyers work on a no-win, no-fee basis for disputed TPD claims.`,
+  },
+];
+
+const TPD_COSTS = [
+  { profile: "35-year-old male, office worker, $500K cover, any occupation, inside super", monthlyPremium: "$35–$65/month" },
+  { profile: "35-year-old male, tradesperson, $500K cover, any occupation, inside super", monthlyPremium: "$70–$120/month" },
+  { profile: "35-year-old female, office worker, $500K cover, own occupation, outside super", monthlyPremium: "$45–$80/month" },
+  { profile: "40-year-old male, professional, $1M cover, own occupation, outside super", monthlyPremium: "$140–$220/month" },
+  { profile: "45-year-old, office worker, $500K cover, any occupation, inside super", monthlyPremium: "$90–$150/month" },
+];
+
+const FAQS = [
+  {
+    question: "How much does TPD insurance cost in Australia?",
+    answer: "TPD premiums vary significantly by age, occupation, health, sum insured, and definition (own vs any occupation). A rough guide: a 35-year-old office worker holding $500,000 TPD inside super with an any occupation definition typically pays $35-65/month. Own occupation definitions and outside super holding cost more. A 40-year-old professional seeking $1M in own occupation TPD outside super might pay $140-220/month. The only accurate way to know your premium is to get a personalised quote.",
+  },
+  {
+    question: "Is TPD insurance tax-deductible?",
+    answer: "TPD premiums held outside super are generally NOT tax-deductible for individuals. TPD premiums held inside super are deductible to the super fund — which is why inside-super TPD is effectively paid with pre-tax money (a cost advantage). Income protection premiums outside super ARE tax-deductible — a key difference between the two products.",
+  },
+  {
+    question: "What happens to my TPD insurance if I leave my super fund?",
+    answer: "If you leave your super fund, your default TPD cover typically ceases. When you join a new employer and super fund, you may receive new default cover — but you may be assessed at your current age and health, and the cover amount may differ. Any pre-existing conditions you've developed since joining the old fund may be excluded. If you leave employment, check your cover situation immediately — this is a common gap.",
+  },
+  {
+    question: "Can I hold TPD and income protection at the same time?",
+    answer: "Yes — in fact, most financial advisers recommend holding both. They serve different purposes: income protection pays a monthly benefit while you're unable to work (and you may recover); TPD pays a lump sum only if your disability is total and permanent. Income protection provides cash flow during recovery; TPD provides a capital sum if you'll never work again. Together they address both short-medium term disability and permanent disability.",
+  },
+  {
+    question: "What is the difference between TPD and trauma insurance?",
+    answer: "TPD pays if you are permanently unable to work. Trauma insurance pays a lump sum if you are diagnosed with a specified serious illness (cancer, heart attack, stroke, etc.) — regardless of whether you can still work. A cancer patient who continues to work while undergoing treatment could claim trauma insurance but not TPD. They target different events, which is why some advisers recommend holding both.",
+  },
+  {
+    question: "What is the tax treatment of a TPD payout?",
+    answer: "TPD benefits received inside super are treated as super fund payments and have complex tax treatment depending on your age, preservation age, and how the benefit is paid. Generally, a TPD payment to someone under preservation age (currently 60) from inside super may include a taxable component taxed at 20% (plus Medicare levy) and a tax-free component. TPD benefits outside super are generally tax-free. This is one reason some advisers prefer outside-super TPD for large sum insured amounts — but you should get specific tax advice for your situation.",
+  },
+];
+
+export default function TPDInsurancePage() {
+  const breadcrumb = breadcrumbJsonLd([
+    { name: "Home", url: SITE_URL },
+    { name: "Insurance", url: `${SITE_URL}/insurance` },
+    { name: "TPD Insurance" },
+  ]);
+
+  const faqSchema = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: FAQS.map((f) => ({
+      "@type": "Question",
+      name: f.question,
+      acceptedAnswer: { "@type": "Answer", text: f.answer },
+    })),
+  };
+
+  return (
+    <div className="bg-white min-h-screen">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+
+      {/* Hero */}
+      <section className="bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 text-white py-10 md:py-14">
+        <div className="container-custom">
+          <nav className="text-xs text-slate-400 mb-5 flex items-center gap-1.5 flex-wrap">
+            <Link href="/" className="hover:text-slate-200">Home</Link>
+            <span>/</span>
+            <Link href="/insurance" className="hover:text-slate-200">Insurance</Link>
+            <span>/</span>
+            <span className="text-slate-300">TPD Insurance</span>
+          </nav>
+          <div className="max-w-3xl">
+            <div className="inline-flex items-center gap-2 px-3 py-1 bg-purple-500/20 border border-purple-500/30 rounded-full text-xs font-semibold text-purple-300 mb-4">
+              <span className="w-1.5 h-1.5 bg-purple-400 rounded-full" />
+              TPD Insurance · {UPDATED_LABEL}
+            </div>
+            <h1 className="text-2xl sm:text-3xl md:text-4xl font-extrabold leading-[1.1] mb-3 tracking-tight">
+              TPD Insurance Australia{" "}
+              <span className="text-amber-400">({CURRENT_YEAR})</span>
+            </h1>
+            <p className="text-sm md:text-base text-slate-300 leading-relaxed max-w-2xl">
+              Total and Permanent Disability (TPD) insurance pays a lump sum if you&apos;re permanently unable to work.
+              Understand own vs any occupation definitions, inside vs outside super, and how much cover you actually need.
+            </p>
+            <div className="flex flex-wrap gap-3 mt-5">
+              <Link href="/quiz" className="px-4 py-2 bg-amber-500 hover:bg-amber-400 text-black text-xs font-bold rounded-lg transition-colors">
+                Find an Insurance Adviser →
+              </Link>
+              <Link href="/insurance" className="px-4 py-2 bg-white/10 hover:bg-white/20 text-white text-xs font-semibold rounded-lg transition-colors border border-white/20">
+                ← All Insurance Types
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Callouts */}
+      <section className="py-8 bg-slate-50 border-b border-slate-200">
+        <div className="container-custom">
+          <div className="grid sm:grid-cols-3 gap-4">
+            <div className="bg-white rounded-2xl border border-purple-200 p-5">
+              <p className="text-xs font-bold text-purple-700 uppercase tracking-wide mb-1">Common Default Super Cover</p>
+              <p className="text-xl font-black text-purple-700">$200K–$500K</p>
+              <p className="text-xs text-slate-600 mt-1">Default TPD inside super is often far below what Australians actually need. Most are significantly underinsured.</p>
+            </div>
+            <div className="bg-white rounded-2xl border border-amber-200 p-5">
+              <p className="text-xs font-bold text-amber-800 uppercase tracking-wide mb-1">Own vs Any Occupation</p>
+              <p className="text-xl font-black text-amber-700">Critical choice</p>
+              <p className="text-xs text-slate-600 mt-1">&apos;Own occupation&apos; is far more likely to pay at claim time. Only available outside super. Worth the premium difference.</p>
+            </div>
+            <div className="bg-white rounded-2xl border border-slate-200 p-5">
+              <p className="text-xs font-bold text-slate-600 uppercase tracking-wide mb-1">Tax Treatment Outside Super</p>
+              <p className="text-xl font-black text-slate-900">Tax-free payout</p>
+              <p className="text-xs text-slate-600 mt-1">TPD benefits paid directly from outside-super policies are generally received tax-free. Inside-super payouts have complex tax treatment.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Own vs Any Comparison */}
+      <section className="py-10 md:py-12">
+        <div className="container-custom">
+          <SectionHeading
+            eyebrow="Key Decision"
+            title="Own Occupation vs Any Occupation"
+            sub="The most important choice in TPD insurance — understand the difference before you buy."
+          />
+          <div className="mt-8 grid sm:grid-cols-2 gap-6">
+            <div className="bg-green-50 border border-green-200 rounded-2xl p-6">
+              <div className="flex items-center gap-2 mb-3">
+                <span className="w-2.5 h-2.5 bg-green-500 rounded-full" />
+                <h3 className="text-base font-bold text-green-900">Own Occupation (Recommended)</h3>
+              </div>
+              <p className="text-xs text-slate-700 leading-relaxed mb-4">
+                Pays if you can no longer perform <strong>your specific occupation</strong>. A surgeon, pilot, or
+                tradesperson who can&apos;t do their job — even if they could theoretically do other work — can claim.
+              </p>
+              <ul className="space-y-2">
+                {[
+                  "More likely to pay at claim time",
+                  "Accounts for your specific training and skills",
+                  "Better protection for professionals and tradespeople",
+                  "Payout is generally tax-free",
+                ].map((p) => (
+                  <li key={p} className="flex items-start gap-2 text-xs text-slate-700">
+                    <span className="text-green-600 font-bold mt-0.5 shrink-0">✓</span>{p}
+                  </li>
+                ))}
+              </ul>
+              <div className="mt-4 pt-4 border-t border-green-200">
+                <p className="text-xs text-green-800 font-semibold">Must be held outside super · Higher premiums</p>
+              </div>
+            </div>
+            <div className="bg-amber-50 border border-amber-200 rounded-2xl p-6">
+              <div className="flex items-center gap-2 mb-3">
+                <span className="w-2.5 h-2.5 bg-amber-500 rounded-full" />
+                <h3 className="text-base font-bold text-amber-900">Any Occupation (Default in Super)</h3>
+              </div>
+              <p className="text-xs text-slate-700 leading-relaxed mb-4">
+                Pays only if you can no longer perform <strong>any occupation</strong> suited to your education,
+                training, or experience. A much higher threshold — and the default definition in most super funds.
+              </p>
+              <ul className="space-y-2">
+                {[
+                  "Lower premiums — can be funded from super",
+                  "Suitable for general workforce roles",
+                  "Can be held inside or outside super",
+                  "Default cover in most super funds",
+                ].map((p) => (
+                  <li key={p} className="flex items-start gap-2 text-xs text-slate-700">
+                    <span className="text-amber-600 font-bold mt-0.5 shrink-0">→</span>{p}
+                  </li>
+                ))}
+              </ul>
+              <div className="mt-4 pt-4 border-t border-amber-200">
+                <p className="text-xs text-amber-800 font-semibold">Higher claim bar · Insurer can dispute more easily</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Cost Table */}
+      <section className="py-10 bg-slate-50">
+        <div className="container-custom">
+          <SectionHeading
+            eyebrow="Premium Guide"
+            title="Indicative TPD Insurance Costs"
+            sub="Monthly premiums vary significantly by age, occupation, definition, and health. These are indicative ranges only — get personalised quotes."
+          />
+          <div className="mt-6 overflow-x-auto">
+            <table className="w-full text-sm border-collapse">
+              <thead>
+                <tr className="bg-slate-800 text-white">
+                  <th className="text-left py-3 px-4 text-xs font-bold">Profile</th>
+                  <th className="text-center py-3 px-4 text-xs font-bold">Indicative Monthly Premium</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-200">
+                {TPD_COSTS.map((row) => (
+                  <tr key={row.profile} className="bg-white hover:bg-slate-50 transition-colors">
+                    <td className="py-3 px-4 text-xs text-slate-700">{row.profile}</td>
+                    <td className="py-3 px-4 text-xs font-bold text-slate-900 text-center">{row.monthlyPremium}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <p className="text-xs text-slate-400 mt-2">Indicative only. Actual premiums depend on health history, smoker status, and individual underwriting. See a financial adviser for a personalised quote.</p>
+          </div>
+        </div>
+      </section>
+
+      {/* Editorial Sections */}
+      <section className="py-10 md:py-12">
+        <div className="container-custom max-w-3xl">
+          <SectionHeading eyebrow="TPD Insurance Guide" title="Everything You Need to Know About TPD" />
+          <div className="mt-8 space-y-10">
+            {SECTIONS.map((sec) => (
+              <div key={sec.heading}>
+                <h2 className="text-lg font-extrabold text-slate-900 mb-3">{sec.heading}</h2>
+                <div className="prose prose-sm max-w-none text-slate-600 leading-relaxed">
+                  {sec.body.split("\n\n").map((para, i) => (
+                    <p key={i} className="mb-3 last:mb-0 whitespace-pre-line">{para}</p>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* FAQs */}
+      <section className="py-10 md:py-12 bg-slate-50">
+        <div className="container-custom max-w-2xl">
+          <SectionHeading eyebrow="FAQ" title="TPD Insurance Questions Answered" />
+          <div className="mt-6 divide-y divide-slate-200">
+            {FAQS.map((faq) => (
+              <details key={faq.question} className="py-4 group">
+                <summary className="text-sm font-semibold text-slate-900 cursor-pointer list-none flex items-center justify-between gap-2">
+                  {faq.question}
+                  <span className="text-slate-400 group-open:rotate-180 transition-transform shrink-0">▾</span>
+                </summary>
+                <p className="mt-3 text-sm text-slate-600 leading-relaxed">{faq.answer}</p>
+              </details>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Related Insurance */}
+      <section className="py-10 border-t border-slate-200">
+        <div className="container-custom">
+          <SectionHeading eyebrow="Related Insurance" title="Other Types of Personal Insurance" />
+          <div className="mt-6 grid sm:grid-cols-2 lg:grid-cols-4 gap-4">
+            {[
+              { title: "Life Insurance", href: "/insurance/life", icon: "🛡️", desc: "Lump sum for your family" },
+              { title: "Income Protection", href: "/insurance/income-protection", icon: "💼", desc: "70% of income while unable to work" },
+              { title: "Trauma Insurance", href: "/insurance/trauma", icon: "❤️", desc: "Serious illness lump sum" },
+              { title: "Health Insurance", href: "/insurance/health", icon: "🏥", desc: "Private hospital and extras" },
+            ].map((ins) => (
+              <Link key={ins.href} href={ins.href} className="group bg-white border border-slate-200 rounded-xl p-5 hover:border-amber-300 hover:shadow-sm transition-all">
+                <div className="text-2xl mb-2">{ins.icon}</div>
+                <p className="text-sm font-bold text-slate-900 group-hover:text-amber-700 mb-1">{ins.title}</p>
+                <p className="text-xs text-slate-500">{ins.desc}</p>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-12 bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 text-white">
+        <div className="container-custom text-center max-w-xl">
+          <h2 className="text-xl font-extrabold mb-3">Get personalised TPD insurance advice</h2>
+          <p className="text-sm text-slate-300 mb-6">
+            TPD insurance is complex — own vs any occupation, inside vs outside super, and the right sum insured all matter.
+            An insurance specialist can structure your cover correctly.
+          </p>
+          <div className="flex flex-col sm:flex-row gap-3 justify-center">
+            <Link href="/quiz" className="px-6 py-3 bg-amber-500 hover:bg-amber-400 text-black font-bold text-sm rounded-xl transition-colors">
+              Find an Insurance Adviser →
+            </Link>
+            <Link href="/insurance" className="px-6 py-3 bg-white/10 hover:bg-white/20 border border-white/20 text-white font-semibold text-sm rounded-xl transition-colors">
+              All Insurance Types →
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <section className="py-6 bg-slate-100 border-t border-slate-200">
+        <div className="container-custom max-w-3xl">
+          <p className="text-xs text-slate-500 leading-relaxed">{GENERAL_ADVICE_WARNING}</p>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/insurance/trauma/page.tsx
+++ b/app/insurance/trauma/page.tsx
@@ -1,0 +1,383 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR, UPDATED_LABEL } from "@/lib/seo";
+import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
+import SectionHeading from "@/components/SectionHeading";
+
+export const revalidate = 86400;
+
+export const metadata: Metadata = {
+  title: `Trauma Insurance Australia (${CURRENT_YEAR}) — Critical Illness Cover Guide`,
+  description: `Complete guide to trauma insurance (critical illness cover) in Australia: what conditions are covered, how much you need, costs, and how it differs from life insurance and TPD. ${UPDATED_LABEL}.`,
+  openGraph: {
+    title: `Trauma Insurance Australia (${CURRENT_YEAR}) — Critical Illness Cover`,
+    description: "Everything about trauma insurance in Australia — covered conditions, costs, and whether you need it alongside life insurance and income protection.",
+    url: `${SITE_URL}/insurance/trauma`,
+  },
+  twitter: { card: "summary_large_image" },
+  alternates: { canonical: `${SITE_URL}/insurance/trauma` },
+};
+
+const COVERED_CONDITIONS = [
+  { category: "Cancer", conditions: "Most invasive cancers (not early-stage or non-invasive in most policies)", common: true },
+  { category: "Heart Attack", conditions: "Myocardial infarction meeting specified severity criteria", common: true },
+  { category: "Stroke", conditions: "Neurological deficit lasting 24+ hours in most policies", common: true },
+  { category: "Coronary Bypass Surgery", conditions: "Surgery to correct blockage or narrowing of coronary arteries", common: true },
+  { category: "Kidney Failure", conditions: "Chronic, irreversible failure of both kidneys requiring dialysis or transplant", common: true },
+  { category: "Major Organ Transplant", conditions: "Heart, lung, liver, kidney, or pancreas transplant", common: true },
+  { category: "Blindness", conditions: "Permanent, irreversible loss of sight in both eyes", common: false },
+  { category: "Deafness", conditions: "Permanent, irreversible loss of hearing in both ears", common: false },
+  { category: "Paraplegia / Quadriplegia", conditions: "Permanent paralysis of limbs", common: false },
+  { category: "Severe Burns", conditions: "Burns covering specified percentage of body surface area", common: false },
+  { category: "Alzheimer's Disease", conditions: "Confirmed diagnosis resulting in significant functional impairment", common: false },
+  { category: "Parkinson's Disease", conditions: "Confirmed, unequivocal diagnosis with permanent symptoms", common: false },
+];
+
+const SECTIONS = [
+  {
+    heading: "What is trauma insurance and how does it work?",
+    body: `Trauma insurance (also called critical illness cover or living insurance) pays a lump sum if you're diagnosed with a specified serious medical condition. Unlike income protection — which pays a monthly benefit when you can't work — trauma insurance pays regardless of whether you can work or not.
+
+The defining feature of trauma insurance is that it pays on diagnosis of a covered condition, not on inability to work. A cancer patient who continues working part-time through chemotherapy cannot claim income protection (they're earning income) and cannot claim TPD (they're not permanently disabled) — but they can claim trauma insurance.
+
+**How the money is typically used:**
+- Repaying mortgage or other debts to reduce financial pressure during recovery
+- Funding expensive experimental or private medical treatment not covered by Medicare or private health insurance
+- Allowing a spouse or partner to stop working to provide care
+- Modifying home or vehicle for recovery needs
+- Funding rehabilitation, physiotherapy, and ongoing care
+- Creating financial breathing room to recover without financial stress accelerating health problems
+
+**The psychological value:**
+Research on cancer recovery outcomes consistently shows that financial stress during serious illness negatively affects recovery. A trauma insurance payout removes the financial anxiety from a health crisis — allowing you to focus on recovery rather than bills.
+
+**Who should consider trauma insurance:**
+Trauma insurance is particularly valuable for:
+- Dual-income households where either partner's income is essential
+- Self-employed people without employer sick leave or income continuity
+- People with a family history of cancer, heart disease, or stroke
+- Parents of young children who want to ensure financial security during serious illness
+- Professionals whose income would collapse without them working (e.g. business owners)`,
+  },
+  {
+    heading: "Trauma insurance vs life insurance vs TPD vs income protection",
+    body: `Many Australians confuse trauma insurance with their other personal insurance — and the overlapping names don't help. Here's how each product works and what it covers:
+
+**Life insurance** pays your beneficiaries a lump sum when you die. It does nothing for you while you're alive. Critical for protecting your family after your death.
+
+**TPD insurance** pays you a lump sum if you become permanently and totally disabled — unable to work ever again. It does not pay for partial disability, serious illness that you recover from, or cancer where you survive and could return to work.
+
+**Income protection** pays 70% of your income monthly while you are unable to work. It doesn't pay if you're working through illness, and stops when you return to work or when your benefit period ends.
+
+**Trauma insurance** pays a lump sum upon diagnosis of a specified serious condition — regardless of whether you can still work, and regardless of whether you recover.
+
+**The critical gap trauma fills:**
+Consider a 45-year-old who is diagnosed with early-stage breast cancer. She undergoes surgery and 6 months of chemotherapy, then makes a full recovery and returns to work.
+- Life insurance: no payout — she didn't die
+- TPD: no payout — she eventually returned to work
+- Income protection: pays 70% of her income for the period she can't work (valuable but limited)
+- Trauma insurance: pays a lump sum on cancer diagnosis — immediately, without waiting
+
+The lump sum can pay off the mortgage, fund private treatment, allow her partner to stop working to be supportive, and eliminate financial pressure during the most stressful months of her life.
+
+**Do you need all four?**
+Most financial advisers prioritise: 1) income protection, 2) life insurance (if you have dependants), 3) TPD, 4) trauma insurance. Trauma is often treated as an 'if budget allows' addition to a comprehensive insurance plan — but for people with family history of cancer or heart disease, it's a first-tier priority.`,
+  },
+  {
+    heading: "What trauma insurance does NOT cover — the fine print",
+    body: `Understanding the exclusions and definitional requirements in trauma insurance is essential before you buy.
+
+**Common exclusions and limitations:**
+
+**Survival period:** Most trauma policies require you to survive for 14-30 days after the diagnosis. If you are diagnosed with cancer and die within 14 days, the trauma policy typically does not pay — the life insurance would instead. This is standard across the industry.
+
+**Severity thresholds:** Not all diagnoses of a covered condition automatically trigger a claim. Many policies require the condition to reach a specified severity:
+- Heart attack: must cause documented cardiac enzyme elevation and ECG changes — minor cardiac events may not qualify
+- Cancer: most policies exclude early-stage, non-invasive cancers, ductal carcinoma in situ (DCIS), early-stage prostate cancer, and skin cancers other than melanoma
+- Stroke: must cause neurological deficit lasting at least 24 hours in many policies
+
+**Pre-existing conditions:** Conditions you had before taking out the policy are typically excluded or subject to loadings. Health underwriting at application determines what pre-existing conditions are excluded.
+
+**Definition variations between insurers:** Trauma definitions vary significantly between insurers. The same diagnosis might trigger a claim with one insurer and be denied by another. This is why using an insurance broker to select a policy with quality definitions — not just the cheapest premium — is critical.
+
+**Trauma reinsurance:** Some policies offer 'buy-back' options that allow you to reinstate the life insurance component after a trauma claim. This is worth paying for if you can afford it.
+
+**Our recommendation:** When comparing trauma policies, ask for the Product Disclosure Statement (PDS) and look specifically at the definitions for cancer, heart attack, and stroke — the three most common claims. Don't choose purely on premium.`,
+  },
+  {
+    heading: "How much trauma insurance do you need?",
+    body: `Unlike life insurance (which is often calculated as 10x income) or income protection (which replaces your income), trauma insurance serves a specific purpose: providing financial buffer during serious illness recovery.
+
+**A practical calculation:**
+1. **Mortgage payoff amount:** The biggest use of a trauma payout is often eliminating mortgage stress. Consider: if you were diagnosed with cancer tomorrow, how much would it change your situation to have no mortgage repayments?
+
+2. **Private treatment costs:** Experimental cancer treatments, private oncologists, and specialists not fully covered by private health insurance can cost $50,000-$200,000+. The PBS covers many cancer drugs — but not all, and not always the latest targeted therapies.
+
+3. **Income replacement gap:** If income protection covers 70% of your income, the 30% gap plus lifestyle costs during recovery adds up. For 6-12 months of recovery, this can be $30,000-$80,000 depending on income.
+
+4. **Family support costs:** A partner who stops working to support you during recovery represents lost income. For 6 months on an average salary, this is $40,000-$60,000.
+
+**Typical recommendation:**
+Most insurance advisers suggest trauma cover of 6-12 months of gross income, or the mortgage balance — whichever is higher. For a 40-year-old earning $120,000 with a $500,000 mortgage, $500,000-$750,000 in trauma cover is a reasonable target. The actual right amount depends on your specific situation.
+
+**Partial trauma cover:**
+Some insurers offer 'partial trauma' or 'severity-based' payments — paying 25% of the sum insured for less severe diagnoses (e.g. early-stage cancer before invasive treatment). This allows lower premiums while still providing some benefit for less severe events.`,
+  },
+];
+
+const COSTS_TABLE = [
+  { profile: "35-year-old female, non-smoker, $250K cover", monthlyPremium: "$55–$90/month" },
+  { profile: "35-year-old male, non-smoker, $250K cover", monthlyPremium: "$70–$110/month" },
+  { profile: "40-year-old female, non-smoker, $500K cover", monthlyPremium: "$150–$230/month" },
+  { profile: "40-year-old male, non-smoker, $500K cover", monthlyPremium: "$180–$280/month" },
+  { profile: "45-year-old, smoker, $250K cover", monthlyPremium: "$200–$350/month" },
+];
+
+const FAQS = [
+  {
+    question: "Is trauma insurance worth it?",
+    answer: "Trauma insurance is worth considering if: you have a family history of cancer, heart disease, or stroke; you're self-employed without employer sick leave; you have a mortgage and dependants; or you couldn't maintain your lifestyle on income protection payments alone. The statistics support its value — 1 in 2 Australians will be diagnosed with cancer in their lifetime, and heart disease is the leading cause of death. Trauma insurance provides a meaningful financial buffer during the most stressful health events. Whether it's worth the premium depends on your personal circumstances and budget.",
+  },
+  {
+    question: "Can I hold trauma insurance inside super?",
+    answer: "No. Since 2014, the ATO has restricted super funds to only holding insurance that is aligned with standard superannuation conditions of release (death, TPD, terminal illness, retirement). Because trauma insurance pays on diagnosis of a condition (not a super condition of release), it cannot be held inside super. All trauma insurance must be held outside super, with premiums paid from after-tax income.",
+  },
+  {
+    question: "Are trauma insurance premiums tax-deductible?",
+    answer: "No. Trauma insurance premiums are not tax-deductible for individuals — unlike income protection premiums held outside super, which are tax-deductible. This means trauma insurance has a higher after-tax cost than income protection. This is one reason income protection is generally prioritised as the more cost-effective first insurance priority for most working Australians.",
+  },
+  {
+    question: "Is a trauma payout taxed?",
+    answer: "Generally, trauma insurance payouts are received tax-free as a lump sum. There is no income tax on trauma insurance benefits paid to individuals holding policies outside super. This tax-free treatment makes the effective value of a trauma payout higher than the face value — a $300,000 trauma payout is received in full, unlike income protection payments which are taxed as income.",
+  },
+  {
+    question: "Does private health insurance replace the need for trauma insurance?",
+    answer: "No — they're complementary, not interchangeable. Private health insurance covers hospital costs and some treatment costs. Trauma insurance provides cash to cover: the income you lose during recovery, the private or experimental treatments private health insurance doesn't cover, the lifestyle costs of recovery, and the option to pay off debt to reduce financial pressure. Even with excellent private health insurance, a serious illness diagnosis creates significant financial impacts beyond medical bills that trauma insurance addresses.",
+  },
+  {
+    question: "What is stepped vs level premiums for trauma insurance?",
+    answer: "Stepped premiums start cheaper and increase with age each year (sometimes significantly after 50). Level premiums are higher initially but relatively stable over time. For trauma insurance, which is typically held until age 65 or until mortgage payoff, level premiums often save money for people who take out cover in their late 30s or 40s. The crossover point (where level becomes cheaper than stepped in cumulative premiums paid) is typically around age 45-50. Discuss with an insurance adviser which structure suits your plan.",
+  },
+];
+
+export default function TraumaInsurancePage() {
+  const breadcrumb = breadcrumbJsonLd([
+    { name: "Home", url: SITE_URL },
+    { name: "Insurance", url: `${SITE_URL}/insurance` },
+    { name: "Trauma Insurance" },
+  ]);
+
+  const faqSchema = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: FAQS.map((f) => ({
+      "@type": "Question",
+      name: f.question,
+      acceptedAnswer: { "@type": "Answer", text: f.answer },
+    })),
+  };
+
+  return (
+    <div className="bg-white min-h-screen">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+
+      {/* Hero */}
+      <section className="bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 text-white py-10 md:py-14">
+        <div className="container-custom">
+          <nav className="text-xs text-slate-400 mb-5 flex items-center gap-1.5 flex-wrap">
+            <Link href="/" className="hover:text-slate-200">Home</Link>
+            <span>/</span>
+            <Link href="/insurance" className="hover:text-slate-200">Insurance</Link>
+            <span>/</span>
+            <span className="text-slate-300">Trauma Insurance</span>
+          </nav>
+          <div className="max-w-3xl">
+            <div className="inline-flex items-center gap-2 px-3 py-1 bg-rose-500/20 border border-rose-500/30 rounded-full text-xs font-semibold text-rose-300 mb-4">
+              <span className="w-1.5 h-1.5 bg-rose-400 rounded-full" />
+              Critical Illness Cover · {UPDATED_LABEL}
+            </div>
+            <h1 className="text-2xl sm:text-3xl md:text-4xl font-extrabold leading-[1.1] mb-3 tracking-tight">
+              Trauma Insurance Australia{" "}
+              <span className="text-amber-400">({CURRENT_YEAR})</span>
+            </h1>
+            <p className="text-sm md:text-base text-slate-300 leading-relaxed max-w-2xl">
+              Trauma insurance pays a lump sum if you&apos;re diagnosed with cancer, heart attack, stroke, or 60+
+              other serious conditions — regardless of whether you can still work. Independent guide to critical
+              illness cover in Australia.
+            </p>
+            <div className="flex flex-wrap gap-3 mt-5">
+              <Link href="/quiz" className="px-4 py-2 bg-amber-500 hover:bg-amber-400 text-black text-xs font-bold rounded-lg transition-colors">
+                Find an Insurance Adviser →
+              </Link>
+              <Link href="/insurance" className="px-4 py-2 bg-white/10 hover:bg-white/20 text-white text-xs font-semibold rounded-lg transition-colors border border-white/20">
+                ← All Insurance Types
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Callouts */}
+      <section className="py-8 bg-slate-50 border-b border-slate-200">
+        <div className="container-custom">
+          <div className="grid sm:grid-cols-3 gap-4">
+            <div className="bg-white rounded-2xl border border-rose-200 p-5">
+              <p className="text-xs font-bold text-rose-700 uppercase tracking-wide mb-1">Cancer Lifetime Risk</p>
+              <p className="text-xl font-black text-rose-700">1 in 2</p>
+              <p className="text-xs text-slate-600 mt-1">Half of all Australians will be diagnosed with cancer in their lifetime. Trauma insurance pays on diagnosis.</p>
+            </div>
+            <div className="bg-white rounded-2xl border border-amber-200 p-5">
+              <p className="text-xs font-bold text-amber-800 uppercase tracking-wide mb-1">Conditions Covered</p>
+              <p className="text-xl font-black text-amber-700">60+</p>
+              <p className="text-xs text-slate-600 mt-1">Most trauma policies cover 60 or more specified serious conditions. Cancer, heart attack, and stroke are the most common claims.</p>
+            </div>
+            <div className="bg-white rounded-2xl border border-slate-200 p-5">
+              <p className="text-xs font-bold text-slate-600 uppercase tracking-wide mb-1">Tax on Payout</p>
+              <p className="text-xl font-black text-slate-900">Tax-free</p>
+              <p className="text-xs text-slate-600 mt-1">Trauma insurance payouts to individuals are generally received completely tax-free as a lump sum.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Covered Conditions */}
+      <section className="py-10 md:py-12">
+        <div className="container-custom">
+          <SectionHeading
+            eyebrow="Covered Conditions"
+            title="What Trauma Insurance Covers"
+            sub="Most trauma policies cover 60+ conditions. These are the most common — always check your specific policy PDS."
+          />
+          <div className="mt-6 grid sm:grid-cols-2 gap-3">
+            {COVERED_CONDITIONS.map((c) => (
+              <div key={c.category} className={`flex items-start gap-3 p-4 rounded-xl border ${c.common ? "bg-white border-slate-200" : "bg-slate-50 border-slate-100"}`}>
+                <span className={`mt-0.5 shrink-0 text-sm ${c.common ? "text-green-500" : "text-slate-400"}`}>
+                  {c.common ? "✓" : "○"}
+                </span>
+                <div>
+                  <p className="text-xs font-bold text-slate-900">{c.category}</p>
+                  <p className="text-xs text-slate-500 mt-0.5">{c.conditions}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+          <p className="text-xs text-slate-400 mt-4">✓ = very commonly covered · ○ = covered in most but check definitions carefully. Always read the PDS.</p>
+        </div>
+      </section>
+
+      {/* Premium Cost Table */}
+      <section className="py-10 bg-slate-50">
+        <div className="container-custom">
+          <SectionHeading
+            eyebrow="Premium Guide"
+            title="Indicative Trauma Insurance Costs"
+            sub="Premiums vary by age, sex, smoker status, and cover amount. These are indicative ranges — get personalised quotes."
+          />
+          <div className="mt-6 overflow-x-auto">
+            <table className="w-full text-sm border-collapse">
+              <thead>
+                <tr className="bg-slate-800 text-white">
+                  <th className="text-left py-3 px-4 text-xs font-bold">Profile</th>
+                  <th className="text-center py-3 px-4 text-xs font-bold">Indicative Monthly Premium</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-200">
+                {COSTS_TABLE.map((row) => (
+                  <tr key={row.profile} className="bg-white hover:bg-slate-50 transition-colors">
+                    <td className="py-3 px-4 text-xs text-slate-700">{row.profile}</td>
+                    <td className="py-3 px-4 text-xs font-bold text-slate-900 text-center">{row.monthlyPremium}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <p className="text-xs text-slate-400 mt-2">Indicative only. Actual premiums depend on health history and individual underwriting. Trauma premiums are not tax-deductible.</p>
+          </div>
+        </div>
+      </section>
+
+      {/* Editorial Sections */}
+      <section className="py-10 md:py-12">
+        <div className="container-custom max-w-3xl">
+          <SectionHeading eyebrow="Trauma Insurance Guide" title="Everything You Need to Know" />
+          <div className="mt-8 space-y-10">
+            {SECTIONS.map((sec) => (
+              <div key={sec.heading}>
+                <h2 className="text-lg font-extrabold text-slate-900 mb-3">{sec.heading}</h2>
+                <div className="prose prose-sm max-w-none text-slate-600 leading-relaxed">
+                  {sec.body.split("\n\n").map((para, i) => (
+                    <p key={i} className="mb-3 last:mb-0 whitespace-pre-line">{para}</p>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* FAQs */}
+      <section className="py-10 md:py-12 bg-slate-50">
+        <div className="container-custom max-w-2xl">
+          <SectionHeading eyebrow="FAQ" title="Trauma Insurance Questions Answered" />
+          <div className="mt-6 divide-y divide-slate-200">
+            {FAQS.map((faq) => (
+              <details key={faq.question} className="py-4 group">
+                <summary className="text-sm font-semibold text-slate-900 cursor-pointer list-none flex items-center justify-between gap-2">
+                  {faq.question}
+                  <span className="text-slate-400 group-open:rotate-180 transition-transform shrink-0">▾</span>
+                </summary>
+                <p className="mt-3 text-sm text-slate-600 leading-relaxed">{faq.answer}</p>
+              </details>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Related Insurance */}
+      <section className="py-10 border-t border-slate-200">
+        <div className="container-custom">
+          <SectionHeading eyebrow="Related Insurance" title="Other Types of Personal Insurance" />
+          <div className="mt-6 grid sm:grid-cols-2 lg:grid-cols-4 gap-4">
+            {[
+              { title: "Life Insurance", href: "/insurance/life", icon: "🛡️", desc: "Lump sum for your family" },
+              { title: "Income Protection", href: "/insurance/income-protection", icon: "💼", desc: "70% of income while unable to work" },
+              { title: "TPD Insurance", href: "/insurance/tpd", icon: "⚕️", desc: "Permanently unable to work payout" },
+              { title: "Health Insurance", href: "/insurance/health", icon: "🏥", desc: "Private hospital and extras" },
+            ].map((ins) => (
+              <Link key={ins.href} href={ins.href} className="group bg-white border border-slate-200 rounded-xl p-5 hover:border-amber-300 hover:shadow-sm transition-all">
+                <div className="text-2xl mb-2">{ins.icon}</div>
+                <p className="text-sm font-bold text-slate-900 group-hover:text-amber-700 mb-1">{ins.title}</p>
+                <p className="text-xs text-slate-500">{ins.desc}</p>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-12 bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 text-white">
+        <div className="container-custom text-center max-w-xl">
+          <h2 className="text-xl font-extrabold mb-3">Get personalised trauma insurance advice</h2>
+          <p className="text-sm text-slate-300 mb-6">
+            Definition quality varies significantly between trauma policies. An insurance specialist can identify
+            the right cover for your situation and health history.
+          </p>
+          <div className="flex flex-col sm:flex-row gap-3 justify-center">
+            <Link href="/quiz" className="px-6 py-3 bg-amber-500 hover:bg-amber-400 text-black font-bold text-sm rounded-xl transition-colors">
+              Find an Insurance Adviser →
+            </Link>
+            <Link href="/insurance" className="px-6 py-3 bg-white/10 hover:bg-white/20 border border-white/20 text-white font-semibold text-sm rounded-xl transition-colors">
+              All Insurance Types →
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <section className="py-6 bg-slate-100 border-t border-slate-200">
+        <div className="container-custom max-w-3xl">
+          <p className="text-xs text-slate-500 leading-relaxed">{GENERAL_ADVICE_WARNING}</p>
+        </div>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
…insurance TPD/trauma

Fills all broken navigation links identified in audit:
- /etfs/bonds — Bond & fixed income ETFs (VAF, IAF, BOND, CRED, FLOT) with duration explainer, govt vs corporate guide, 6 FAQs
- /etfs/international — International ETFs (VGS, IWLD, VEU, FEMX, VGAD) with developed vs emerging markets, currency hedging guide, 6 FAQs
- /etfs/sectors — Sector/thematic ETFs (NDQ, HACK, DRUG, OZR, QFN, ETHI) with sizing guide, thematic evaluation framework, 6 FAQs
- /insurance/tpd — TPD insurance guide with own vs any occupation comparison table, cost table, claims process walkthrough, 6 FAQs
- /insurance/trauma — Trauma/critical illness insurance with 60+ covered conditions, cost table, comparison vs life/TPD/income protection, 6 FAQs

All pages follow existing hub pattern: hero, callouts, content cards, editorial sections, FAQ schema, disclaimer, related links, CTA.

https://claude.ai/code/session_01Sc4b8zVmRCqqYVZ8tf4JPD