### PR TITLE
fix(ux): homepage restructure, choice paralysis, compliance badges, footer accordions

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -170,29 +170,26 @@ export default async function HomePage() {
               Compare {brokerCount}+ platforms. Browse licensed professionals. Explore investment opportunities — businesses, mining, farmland, property &amp; more.
             </p>
 
-            {/* Three CTAs */}
-            <div className="flex flex-col sm:flex-row items-center justify-center gap-3 mb-6">
+            {/* Primary CTA */}
+            <div className="mb-5">
               <Link
                 href="/compare"
-                className="w-full sm:w-auto inline-flex items-center justify-center gap-2 px-7 py-3.5 bg-amber-500 hover:bg-amber-400 text-slate-900 font-extrabold text-sm rounded-xl transition-all shadow-lg shadow-amber-500/25 hover:-translate-y-0.5"
+                className="inline-flex items-center justify-center gap-2.5 px-10 py-4 bg-amber-500 hover:bg-amber-400 text-slate-900 font-extrabold text-base rounded-xl transition-all shadow-lg shadow-amber-500/25 hover:-translate-y-0.5 w-full sm:w-auto"
               >
                 Compare Platforms
-                <Icon name="arrow-right" size={16} />
-              </Link>
-              <Link
-                href="/advisors"
-                className="w-full sm:w-auto inline-flex items-center justify-center gap-2 px-7 py-3.5 border-2 border-slate-200 text-slate-700 font-bold text-sm rounded-xl hover:border-slate-300 hover:bg-slate-50 transition-all"
-              >
-                Browse Directories
-              </Link>
-              <Link
-                href="/invest/listings"
-                className="w-full sm:w-auto inline-flex items-center justify-center gap-2 px-7 py-3.5 bg-slate-900 hover:bg-slate-800 text-white font-bold text-sm rounded-xl transition-all"
-              >
-                <Icon name="layers" size={15} />
-                Explore Marketplace
+                <Icon name="arrow-right" size={18} />
               </Link>
             </div>
+
+            {/* Secondary links */}
+            <p className="text-sm text-slate-500 mb-6">
+              Or browse{" "}
+              <Link href="/advisors" className="font-semibold text-slate-700 hover:text-amber-600 underline underline-offset-2 decoration-slate-300 hover:decoration-amber-400 transition-colors">directories</Link>
+              {" · "}
+              <Link href="/invest/listings" className="font-semibold text-slate-700 hover:text-amber-600 underline underline-offset-2 decoration-slate-300 hover:decoration-amber-400 transition-colors">marketplace</Link>
+              {" · "}
+              <Link href="/invest" className="font-semibold text-slate-700 hover:text-amber-600 underline underline-offset-2 decoration-slate-300 hover:decoration-amber-400 transition-colors">investment guides</Link>
+            </p>
 
             {/* Trust bar */}
             <div className="flex items-center justify-center flex-wrap gap-x-5 gap-y-1.5 text-sm font-semibold text-slate-600">
@@ -257,7 +254,7 @@ export default async function HomePage() {
                     className="shrink-0 flex items-center gap-2 bg-slate-50 hover:bg-slate-100 border border-slate-200 hover:border-amber-400/60 rounded-lg px-3 py-2 transition-all group"
                   >
                     <span className="text-[0.55rem] font-bold uppercase tracking-wider bg-amber-500 text-white px-1.5 py-0.5 rounded-full shrink-0">
-                      Verified Promo
+                      Promotion
                     </span>
                     <BrokerLogo broker={broker} size="xs" />
                     <span className="text-xs font-semibold text-slate-700 group-hover:text-slate-900 whitespace-nowrap max-w-[180px] truncate">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,8 +7,6 @@ import type { Article } from "@/lib/types";
 import HomepageComparisonTable from "@/components/HomepageComparisonTable";
 import ScrollFadeIn from "@/components/ScrollFadeIn";
 import LeadMagnet from "@/components/LeadMagnet";
-import DealCard from "@/components/DealCard";
-import CompactDisclaimerLine from "@/components/CompactDisclaimerLine";
 import Icon from "@/components/Icon";
 import BrokerLogo from "@/components/BrokerLogo";
 import { AFFILIATE_REL } from "@/lib/tracking";
@@ -162,12 +160,12 @@ export default async function HomePage() {
             </div>
 
             <h1 className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-extrabold text-slate-900 leading-[1.1] mb-4 tracking-tight">
-              Australia&apos;s independent{" "}
-              <span className="text-amber-500">investing hub</span>
+              Australia&apos;s comparison and directory hub{" "}
+              <span className="text-amber-500">for investors</span>
             </h1>
 
             <p className="text-base md:text-lg text-slate-600 mb-8 leading-relaxed max-w-2xl mx-auto">
-              Compare {brokerCount}+ platforms. Browse licensed professionals. Explore investment opportunities — businesses, mining, farmland, property &amp; more.
+              Compare platforms, browse professionals, and explore investment options — always free, always independent.
             </p>
 
             {/* Primary CTA */}
@@ -234,6 +232,28 @@ export default async function HomePage() {
         </div>
       </section>
 
+
+      {/* ═══════ TRUST STRIP ═══════ */}
+      <section className="bg-slate-900 text-white py-3">
+        <div className="container-custom">
+          <div className="flex items-center justify-center flex-wrap gap-x-6 gap-y-2 text-xs font-medium">
+            <span className="flex items-center gap-1.5">
+              <Icon name="shield-check" size={14} className="text-amber-400" />
+              Independent comparison platform
+            </span>
+            <span className="text-slate-600 hidden sm:block" aria-hidden="true">|</span>
+            <span className="flex items-center gap-1.5">
+              <Icon name="link" size={14} className="text-amber-400" />
+              Public-register-linked directories
+            </span>
+            <span className="text-slate-600 hidden sm:block" aria-hidden="true">|</span>
+            <span className="flex items-center gap-1.5">
+              <Icon name="eye" size={14} className="text-amber-400" />
+              Editorially separate from promotions
+            </span>
+          </div>
+        </div>
+      </section>
 
       {/* ═══════ 1E. MONEY ROW — top affiliate promos ═══════ */}
       {dealBrokers.length > 0 && (
@@ -402,8 +422,8 @@ export default async function HomePage() {
             <div className="flex items-start justify-between gap-2 mb-6">
               <div>
                 <p className="text-xs font-semibold text-amber-600 uppercase tracking-wide mb-1">Investment Marketplace</p>
-                <h2 className="text-xl md:text-2xl font-extrabold text-slate-900">Browse Investment Opportunities</h2>
-                <p className="text-sm text-slate-600 mt-1">Enquire about real assets — businesses for sale, mining projects, farmland, commercial property &amp; more.</p>
+                <h2 className="text-xl md:text-2xl font-extrabold text-slate-900">Explore Investment Categories</h2>
+                <p className="text-sm text-slate-600 mt-1">Enquire about real assets across these categories — businesses, mining, farmland, property and more.</p>
               </div>
               <Link href="/invest/listings" className="text-xs md:text-sm font-semibold text-amber-600 hover:text-amber-700 shrink-0 min-h-[44px] inline-flex items-center px-1">
                 View All &rarr;
@@ -446,71 +466,62 @@ export default async function HomePage() {
         </section>
       </ScrollFadeIn>
 
-      {/* ═══════ 4. CURRENT PLATFORM DEALS ═══════ */}
-      {(dealBrokers as Broker[])?.length >= 3 && (
-        <ScrollFadeIn>
-          <section className="py-6 md:py-10 bg-gradient-to-b from-amber-50/60 to-white border-y border-amber-100">
-            <div className="container-custom">
-              <div className="flex items-start justify-between gap-2 mb-4 md:mb-6">
-                <div>
-                  <h2 className="text-lg md:text-2xl font-bold text-slate-900">Current Platform Deals</h2>
-                  <p className="text-xs md:text-sm text-slate-600 mt-0.5">Verified promotions from Australian trading platforms — {updatedMonth}</p>
-                </div>
-                <Link href="/deals" className="text-xs md:text-sm font-semibold text-amber-600 hover:text-amber-700 shrink-0 min-h-[44px] inline-flex items-center px-1">
-                  View All &rarr;
-                </Link>
+      {/* ═══════ 7. TOOLS & CALCULATORS ═══════ */}
+      <ScrollFadeIn>
+        <section className="py-6 md:py-10 bg-white border-t border-slate-100">
+          <div className="container-custom">
+            <div className="flex items-center justify-between mb-4 md:mb-6">
+              <div>
+                <p className="text-xs text-amber-600 uppercase tracking-widest font-bold mb-1">Free tools</p>
+                <h2 className="text-xl md:text-2xl font-bold text-slate-900">Investing Tools &amp; Calculators</h2>
               </div>
-              <div className="hidden md:grid md:grid-cols-2 lg:grid-cols-3 gap-4">
-                {(dealBrokers as Broker[]).map((broker) => (
-                  <DealCard key={broker.id} broker={broker} />
-                ))}
-              </div>
-              <div className="md:hidden space-y-2">
-                {(dealBrokers as Broker[]).map((broker) => {
-                  const expiryDate = broker.deal_expiry ? new Date(broker.deal_expiry) : null;
-                  const daysLeft = expiryDate ? Math.max(0, Math.ceil((expiryDate.getTime() - Date.now()) / 86400000)) : null;
-                  const isUrgent = daysLeft !== null && daysLeft <= 7;
-                  const affiliateLink = `/go/${broker.slug}`;
-                  return (
-                    <div key={broker.id} className="border border-slate-200 rounded-xl p-3 bg-white">
-                      <div className="flex items-center gap-2 mb-2">
-                        <BrokerLogo broker={broker} size="sm" />
-                        <div className="flex-1 min-w-0">
-                          <span className="font-bold text-sm text-slate-900 truncate block">{broker.name}</span>
-                          <span className="text-xs text-slate-400">{broker.rating}/5</span>
-                        </div>
-                        <a href={affiliateLink} target="_blank" rel={AFFILIATE_REL} className="shrink-0 px-3 py-1.5 min-h-[44px] flex items-center bg-amber-500 text-white text-xs font-bold rounded-lg active:scale-[0.98] transition-all">
-                          Claim &rarr;
-                        </a>
-                      </div>
-                      <div className="bg-amber-50 rounded-lg px-2.5 py-2 flex items-start gap-1.5">
-                        <Icon name="flame" size={12} className="text-amber-500 shrink-0 mt-0.5" />
-                        <p className="text-xs text-slate-700 font-medium leading-snug line-clamp-2 flex-1">{broker.deal_text}</p>
-                        {isUrgent && daysLeft !== null && (
-                          <span className="shrink-0 text-xs font-bold px-1.5 py-0.5 rounded-full bg-red-100 text-red-600 animate-pulse whitespace-nowrap">
-                            {daysLeft}d left
-                          </span>
-                        )}
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-              <div className="mt-3 md:mt-4">
-                <CompactDisclaimerLine />
-              </div>
+              <Link href="/calculators" className="text-xs md:text-sm font-semibold text-slate-500 hover:text-amber-600 transition-colors shrink-0">
+                View All Calculators &rarr;
+              </Link>
             </div>
-          </section>
-        </ScrollFadeIn>
-      )}
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-2 md:gap-3">
+              {[
+                { href: "/portfolio-calculator", icon: "calculator", color: "from-amber-500 to-amber-400", shadow: "shadow-amber-500/20", title: "Portfolio Calculator", desc: "See exact fees at every platform" },
+                { href: "/switching-calculator", icon: "arrow-right-left", color: "from-slate-700 to-slate-600", shadow: "shadow-slate-500/15", title: "Switching Calculator", desc: "How much are you overpaying?" },
+                { href: "/savings-calculator", icon: "piggy-bank", color: "from-amber-600 to-amber-500", shadow: "shadow-amber-500/20", title: "Savings Calculator", desc: "Are you earning enough?" },
+                { href: "/mortgage-calculator", icon: "home", color: "from-slate-700 to-slate-600", shadow: "shadow-slate-500/15", title: "Borrowing Power", desc: "How much can you borrow?" },
+              ].map((tool) => (
+                <Link key={tool.href} href={tool.href} className="bg-white border border-slate-200 rounded-xl p-3 md:p-5 hover:shadow-md hover:border-slate-300 transition-all group">
+                  <div className={`w-8 h-8 md:w-10 md:h-10 bg-gradient-to-br ${tool.color} rounded-xl flex items-center justify-center mb-2 md:mb-3 shadow-md ${tool.shadow}`}>
+                    <Icon name={tool.icon} size={18} className="text-white" />
+                  </div>
+                  <h3 className="text-xs md:text-sm font-bold text-slate-900 mb-0.5 group-hover:text-slate-700">{tool.title}</h3>
+                  <p className="text-xs text-slate-600">{tool.desc}</p>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </section>
+      </ScrollFadeIn>
 
-      {/* ═══════ 5. ADVISOR DIRECTORY ═══════ */}
+      {/* ═══════ 8. ADVISOR DIRECTORY ═══════ */}
+      <div className="text-center mb-6 pt-6 bg-slate-50">
+        <p className="text-xs text-slate-500 max-w-lg mx-auto">
+          Browse directory listings and public register details. Always verify provider suitability for your own circumstances.
+        </p>
+      </div>
       <AdvisorDirectory />
 
-      {/* ═══════ 6. ARTICLES & GUIDES ═══════ */}
+      {/* ═══════ 9. EMAIL CAPTURE ═══════ */}
+      <ScrollFadeIn>
+        <section className="py-6 md:py-10 bg-white border-t border-slate-100">
+          <div className="container-custom">
+            <div className="max-w-xl mx-auto">
+              <LeadMagnet />
+            </div>
+          </div>
+        </section>
+      </ScrollFadeIn>
+
+      {/* ═══════ 10. ARTICLES & GUIDES ═══════ */}
       {(articles as Article[])?.length > 0 && (
         <ScrollFadeIn>
-          <section className="py-6 md:py-10 bg-white">
+          <section className="py-6 md:py-10 bg-slate-50 border-t border-slate-200">
             <div className="container-custom">
               <div className="flex items-start justify-between gap-2 mb-4 md:mb-6">
                 <div>
@@ -582,50 +593,6 @@ export default async function HomePage() {
           </section>
         </ScrollFadeIn>
       )}
-
-      {/* ═══════ 8. TOOLS & CALCULATORS ═══════ */}
-      <ScrollFadeIn>
-        <section className="py-6 md:py-10 bg-slate-50 border-t border-slate-100">
-          <div className="container-custom">
-            <div className="flex items-center justify-between mb-4 md:mb-6">
-              <div>
-                <p className="text-xs text-amber-600 uppercase tracking-widest font-bold mb-1">Free tools</p>
-                <h2 className="text-xl md:text-2xl font-bold text-slate-900">Investing Tools &amp; Calculators</h2>
-              </div>
-              <Link href="/calculators" className="text-xs md:text-sm font-semibold text-slate-500 hover:text-amber-600 transition-colors shrink-0">
-                View All Calculators &rarr;
-              </Link>
-            </div>
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-2 md:gap-3">
-              {[
-                { href: "/portfolio-calculator", icon: "calculator", color: "from-amber-500 to-amber-400", shadow: "shadow-amber-500/20", title: "Portfolio Calculator", desc: "See exact fees at every platform" },
-                { href: "/switching-calculator", icon: "arrow-right-left", color: "from-slate-700 to-slate-600", shadow: "shadow-slate-500/15", title: "Switching Calculator", desc: "How much are you overpaying?" },
-                { href: "/savings-calculator", icon: "piggy-bank", color: "from-amber-600 to-amber-500", shadow: "shadow-amber-500/20", title: "Savings Calculator", desc: "Are you earning enough?" },
-                { href: "/mortgage-calculator", icon: "home", color: "from-slate-700 to-slate-600", shadow: "shadow-slate-500/15", title: "Borrowing Power", desc: "How much can you borrow?" },
-              ].map((tool) => (
-                <Link key={tool.href} href={tool.href} className="bg-white border border-slate-200 rounded-xl p-3 md:p-5 hover:shadow-md hover:border-slate-300 transition-all group">
-                  <div className={`w-8 h-8 md:w-10 md:h-10 bg-gradient-to-br ${tool.color} rounded-xl flex items-center justify-center mb-2 md:mb-3 shadow-md ${tool.shadow}`}>
-                    <Icon name={tool.icon} size={18} className="text-white" />
-                  </div>
-                  <h3 className="text-xs md:text-sm font-bold text-slate-900 mb-0.5 group-hover:text-slate-700">{tool.title}</h3>
-                  <p className="text-xs text-slate-600">{tool.desc}</p>
-                </Link>
-              ))}
-            </div>
-          </div>
-        </section>
-      </ScrollFadeIn>
-
-      {/* ═══════ 9. EMAIL CAPTURE ═══════ */}
-      <ScrollFadeIn>
-        <section className="py-6 md:py-10 bg-white border-t border-slate-100">
-          <div className="container-custom">
-            <div className="max-w-xl mx-auto">
-              <LeadMagnet />
-            </div>
-          </div>
-        </section>
-      </ScrollFadeIn>
 
       {/* ═══════ MOBILE STICKY CTA (item 68) ═══════ */}
       <MobileStickyAdvisorCta />

--- a/components/HomepageComparisonTable.tsx
+++ b/components/HomepageComparisonTable.tsx
@@ -14,6 +14,7 @@ import { sortWithSponsorship, isSponsored, getPlacementWinners, type PlacementWi
 import { filterByFrequencyCap } from "@/lib/marketplace/frequency-cap";
 import JargonTooltip from "@/components/JargonTooltip";
 import ShortlistButton from "@/components/ShortlistButton";
+import { SHOW_RATINGS, SHOW_EDITORIAL_BADGES } from "@/lib/compliance-config";
 
 // Homepage shows focused categories only — niche tabs live on /compare
 const TAB_OPTIONS = ["All Platforms", "Share Trading", "Super Funds", "Robo-Advisors", "Savings", "Crypto Exchanges"] as const;
@@ -205,7 +206,7 @@ export default function HomepageComparisonTable({
                 }`}
               >
                 <td className="sticky left-0 z-10 bg-inherit pl-5 pr-2 py-2.5 text-xs text-slate-400 font-medium">
-                  {isTopRated ? (
+                  {SHOW_EDITORIAL_BADGES && isTopRated ? (
                     <span className="text-amber-500 text-sm" title="Top Rated">🏆</span>
                   ) : (
                     i + 1
@@ -228,7 +229,7 @@ export default function HomepageComparisonTable({
                           <span className="text-[0.62rem] font-bold px-1.5 py-0.5 bg-blue-50 text-blue-600 rounded-full uppercase tracking-wide">Sponsored</span>
                         )}
                       </div>
-                      {!isSponsored(broker) && !isCampaignWinner && editorPicks[broker.slug] && (
+                      {SHOW_EDITORIAL_BADGES && !isSponsored(broker) && !isCampaignWinner && editorPicks[broker.slug] && (
                         <div className={`text-[0.65rem] font-bold uppercase tracking-wide px-1.5 py-0.5 rounded-full ${
                           editorPicks[broker.slug] === "Editor\u2019s Choice"
                             ? "bg-amber-100 text-amber-700 border border-amber-200"
@@ -259,12 +260,14 @@ export default function HomepageComparisonTable({
                     {broker.chess_sponsored ? "\u2713 Yes" : "\u2717 No"}
                   </span>
                 </td>
+                {SHOW_RATINGS && (
                 <td className="px-3 py-2.5 text-center">
                   <div className="flex items-center justify-center gap-1">
                     <span className="text-amber text-xs">{renderStars(broker.rating || 0)}</span>
                     <span className="text-xs font-semibold text-slate-600">{broker.rating}</span>
                   </div>
                 </td>
+                )}
                 <td className="px-3 py-2.5 pr-5 text-center">
                   <div className="flex flex-col items-center gap-0.5">
                     <a
@@ -302,7 +305,7 @@ export default function HomepageComparisonTable({
             {/* Row 1: Rank + Icon + Name + CTA */}
             <div className="flex items-center gap-2">
               <div className="w-5 text-center shrink-0">
-                {isTopRatedMobile ? (
+                {SHOW_EDITORIAL_BADGES && isTopRatedMobile ? (
                   <span className="text-amber-500 text-sm">🏆</span>
                 ) : (
                   <span className="text-xs font-bold text-slate-400">{i + 1}</span>
@@ -337,8 +340,8 @@ export default function HomepageComparisonTable({
             </div>
             {/* Row 2: Rating + key metrics inline */}
             <div className="flex items-center gap-2 mt-1 ml-[3.25rem] text-[0.7rem]">
-              <span className="text-amber">{renderStars(broker.rating || 0)}</span>
-              <span className="text-slate-500 font-medium">{broker.rating}</span>
+              {SHOW_RATINGS && <><span className="text-amber">{renderStars(broker.rating || 0)}</span>
+              <span className="text-slate-500 font-medium">{broker.rating}</span></>}
               <span className="text-slate-300">·</span>
               <span className="text-slate-600"><span className="font-semibold">{broker.asx_fee || "N/A"}</span> ASX</span>
               {broker.fx_rate != null && (

--- a/components/MobileStickyAdvisorCta.tsx
+++ b/components/MobileStickyAdvisorCta.tsx
@@ -28,15 +28,15 @@ export default function MobileStickyAdvisorCta() {
     <div className="md:hidden fixed bottom-0 left-0 right-0 z-50 pb-safe">
       <div className="bg-white border-t border-slate-200 shadow-[0_-4px_20px_rgba(0,0,0,0.10)] px-4 py-3 flex items-center gap-3">
         <div className="flex-1 min-w-0">
-          <p className="text-xs font-bold text-slate-900 leading-tight">Find the right advisor</p>
-          <p className="text-[0.65rem] text-slate-500">Free &middot; no obligation &middot; 60 seconds</p>
+          <p className="text-xs font-bold text-slate-900 leading-tight">Need help?</p>
+          <p className="text-[0.65rem] text-slate-500">Compare platforms &middot; browse directories &middot; explore listings</p>
         </div>
         <Link
-          href="/find-advisor"
+          href="/compare"
           onClick={() => setDismissed(true)}
-          className="shrink-0 px-4 py-2.5 min-h-[44px] flex items-center bg-amber-500 hover:bg-amber-600 text-white text-xs font-bold rounded-xl transition-colors"
+          className="shrink-0 px-4 py-2.5 min-h-[44px] flex items-center bg-amber-500 hover:bg-amber-600 text-slate-900 text-xs font-bold rounded-xl transition-colors"
         >
-          Find My Advisor — Free &rarr;
+          Compare Platforms &rarr;
         </Link>
         <button
           onClick={() => setDismissed(true)}

--- a/components/QuizPromptBar.tsx
+++ b/components/QuizPromptBar.tsx
@@ -88,10 +88,10 @@ export default function QuizPromptBar() {
               </Link>
             )}
             <Link
-              href="/quiz"
+              href="/compare"
               className="flex-1 text-center py-2.5 bg-amber-500 text-white text-[0.75rem] font-bold rounded-lg hover:bg-amber-600 active:bg-amber-700 active:scale-[0.98] transition-all min-h-[40px] flex items-center justify-center gap-1.5"
             >
-              Find My Match →
+              Compare Platforms →
             </Link>
           </div>
         </div>
@@ -104,16 +104,16 @@ export default function QuizPromptBar() {
             <p className="text-sm text-slate-600">
               Need help?{" "}
               <strong className="text-slate-900">
-                Find your platform or advisor
+                Compare platforms and browse directories
               </strong>{" "}
-              in 60 seconds.
+              — free, no obligation.
             </p>
             <div className="flex items-center gap-2 shrink-0">
               <Link
-                href="/quiz"
+                href="/compare"
                 className="px-5 py-2.5 bg-amber-500 text-white text-sm font-bold rounded-lg hover:bg-amber-600 active:bg-amber-700 active:scale-[0.97] transition-all"
               >
-                Find My Match &rarr;
+                Compare Platforms &rarr;
               </Link>
               <button
                 onClick={handleDesktopDismiss}

--- a/components/layout/SiteFooter.tsx
+++ b/components/layout/SiteFooter.tsx
@@ -23,10 +23,13 @@ export function SiteFooter() {
     <footer className="bg-slate-900 text-slate-300">
       {/* Main grid */}
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-12 pb-8">
-        <div className="grid grid-cols-2 md:grid-cols-5 gap-8 mb-12">
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-5 gap-4 md:gap-8 mb-12">
           {/* Column 0 — Invest */}
-          <div>
-            <h3 className="text-white font-bold text-sm mb-4">Invest</h3>
+          <details className="group" open>
+            <summary className="flex items-center justify-between cursor-pointer md:cursor-default list-none">
+              <h3 className="text-white font-bold text-sm">Invest</h3>
+              <svg className="w-4 h-4 text-slate-500 group-open:rotate-180 transition-transform md:hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" /></svg>
+            </summary>
             <ul className="space-y-2.5 text-sm">
               {[
                 { label: "All Verticals", href: "/invest" },
@@ -47,11 +50,14 @@ export function SiteFooter() {
                 </li>
               ))}
             </ul>
-          </div>
+          </details>
 
           {/* Column 1 — Platforms */}
-          <div>
-            <h3 className="text-white font-bold text-sm mb-4">Platforms</h3>
+          <details className="group" open>
+            <summary className="flex items-center justify-between cursor-pointer md:cursor-default list-none">
+              <h3 className="text-white font-bold text-sm">Platforms</h3>
+              <svg className="w-4 h-4 text-slate-500 group-open:rotate-180 transition-transform md:hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" /></svg>
+            </summary>
             <ul className="space-y-2.5 text-sm">
               {[
                 { label: "Compare All", href: "/compare" },
@@ -71,11 +77,14 @@ export function SiteFooter() {
                 </li>
               ))}
             </ul>
-          </div>
+          </details>
 
           {/* Column 2 — Advisors */}
-          <div>
-            <h3 className="text-white font-bold text-sm mb-4">Advisors</h3>
+          <details className="group" open>
+            <summary className="flex items-center justify-between cursor-pointer md:cursor-default list-none">
+              <h3 className="text-white font-bold text-sm">Advisors</h3>
+              <svg className="w-4 h-4 text-slate-500 group-open:rotate-180 transition-transform md:hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" /></svg>
+            </summary>
             <ul className="space-y-2.5 text-sm">
               {[
                 { label: "Find an Advisor", href: "/find-advisor" },
@@ -94,11 +103,14 @@ export function SiteFooter() {
                 </li>
               ))}
             </ul>
-          </div>
+          </details>
 
           {/* Column 3 — Learn */}
-          <div>
-            <h3 className="text-white font-bold text-sm mb-4">Learn</h3>
+          <details className="group" open>
+            <summary className="flex items-center justify-between cursor-pointer md:cursor-default list-none">
+              <h3 className="text-white font-bold text-sm">Learn</h3>
+              <svg className="w-4 h-4 text-slate-500 group-open:rotate-180 transition-transform md:hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" /></svg>
+            </summary>
             <ul className="space-y-2.5 text-sm">
               {[
                 { label: "All Articles", href: "/articles" },
@@ -117,11 +129,14 @@ export function SiteFooter() {
                 </li>
               ))}
             </ul>
-          </div>
+          </details>
 
           {/* Column 4 — Company */}
-          <div>
-            <h3 className="text-white font-bold text-sm mb-4">Company</h3>
+          <details className="group" open>
+            <summary className="flex items-center justify-between cursor-pointer md:cursor-default list-none">
+              <h3 className="text-white font-bold text-sm">Company</h3>
+              <svg className="w-4 h-4 text-slate-500 group-open:rotate-180 transition-transform md:hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" /></svg>
+            </summary>
             <ul className="space-y-2.5 text-sm">
               {[
                 { label: "About Us", href: "/about" },
@@ -140,7 +155,7 @@ export function SiteFooter() {
                 </li>
               ))}
             </ul>
-          </div>
+          </details>
         </div>
 
         {/* Compliance Section */}


### PR DESCRIPTION
## Summary

Major UX overhaul based on detailed feedback — choice paralysis fix, homepage restructure, compliance badges, footer accordions, and sticky bar fixes.

### Homepage Restructure
- **Hero sharpened**: "Australia's comparison and directory hub for investors"
- **1 primary CTA** instead of 3 stacked buttons (eliminates mobile choice paralysis)
- **New dark trust strip**: Independent platform | Public-register directories | Editorially separate
- **Section reorder**: Hero → Trust → Deals → Compare → Categories → Marketplace → Tools → Professionals → Email → Articles
- **"Current Platform Deals" section removed** (redundant with Money Row deal strip)
- **"Browse Investment Opportunities" → "Explore Investment Categories"**
- **Trust note added above professionals section**

### Compliance Badges Fixed
- Trophy icons, "Editor's Choice", "Lowest Fees" badges on HomepageComparisonTable now gated behind `SHOW_EDITORIAL_BADGES`
- Star ratings gated behind `SHOW_RATINGS` (desktop + mobile views)
- "Verified Promo" → "Promotion" on deal strip

### Mobile Sticky Bar
- "Find the right advisor" → "Need help?"
- "Find My Advisor — Free" → "Compare Platforms"
- Removed quiz/match language

### Quiz Prompt Bar
- "Find My Match" → "Compare Platforms"
- Links to /compare instead of /quiz

### Footer
- All 5 columns converted to collapsible `<details>` accordions on mobile
- Chevron icons, default open, user-collapsible
- Much tighter on mobile screens

https://claude.ai/code/session_01Pm4P3VYciJpVNYAdyJzsSn