### PR TITLE
fix(ux): hero copy, section reorder, trust strip, footer softening

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -160,12 +160,12 @@ export default async function HomePage() {
             </div>
 
             <h1 className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-extrabold text-slate-900 leading-[1.1] mb-4 tracking-tight">
-              Australia&apos;s comparison and directory hub{" "}
-              <span className="text-amber-500">for investors</span>
+              Compare platforms, professionals{" "}
+              <span className="text-amber-500">&amp; investment pathways</span>
             </h1>
 
             <p className="text-base md:text-lg text-slate-600 mb-8 leading-relaxed max-w-2xl mx-auto">
-              Compare platforms, browse professionals, and explore investment options — always free, always independent.
+              Compare fees, browse directories, and explore investment options in one place.
             </p>
 
             {/* Primary CTA */}
@@ -238,18 +238,18 @@ export default async function HomePage() {
         <div className="container-custom">
           <div className="flex items-center justify-center flex-wrap gap-x-6 gap-y-2 text-xs font-medium">
             <span className="flex items-center gap-1.5">
-              <Icon name="shield-check" size={14} className="text-amber-400" />
-              Independent comparison platform
+              <Icon name="bar-chart-2" size={14} className="text-amber-400" />
+              Compare factual platform data
             </span>
             <span className="text-slate-600 hidden sm:block" aria-hidden="true">|</span>
             <span className="flex items-center gap-1.5">
-              <Icon name="link" size={14} className="text-amber-400" />
-              Public-register-linked directories
+              <Icon name="users" size={14} className="text-amber-400" />
+              Browse professional directories
             </span>
             <span className="text-slate-600 hidden sm:block" aria-hidden="true">|</span>
             <span className="flex items-center gap-1.5">
-              <Icon name="eye" size={14} className="text-amber-400" />
-              Editorially separate from promotions
+              <Icon name="book-open" size={14} className="text-amber-400" />
+              Educational tools for Australian investors
             </span>
           </div>
         </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -415,58 +415,7 @@ export default async function HomePage() {
         </div>
       </section>
 
-      {/* ═══════ 3B. INVESTMENT MARKETPLACE ═══════ */}
-      <ScrollFadeIn>
-        <section className="py-10 md:py-14 bg-slate-50 border-b border-slate-100">
-          <div className="container-custom">
-            <div className="flex items-start justify-between gap-2 mb-6">
-              <div>
-                <p className="text-xs font-semibold text-amber-600 uppercase tracking-wide mb-1">Investment Marketplace</p>
-                <h2 className="text-xl md:text-2xl font-extrabold text-slate-900">Explore Investment Categories</h2>
-                <p className="text-sm text-slate-600 mt-1">Enquire about real assets across these categories — businesses, mining, farmland, property and more.</p>
-              </div>
-              <Link href="/invest/listings" className="text-xs md:text-sm font-semibold text-amber-600 hover:text-amber-700 shrink-0 min-h-[44px] inline-flex items-center px-1">
-                View All &rarr;
-              </Link>
-            </div>
-            <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
-              {[
-                { title: "Businesses for Sale", icon: "briefcase", href: "/invest/buy-business/listings", color: "bg-slate-800" },
-                { title: "Mining & Resources", icon: "layers", href: "/invest/mining/opportunities", color: "bg-amber-600" },
-                { title: "Farmland & Agriculture", icon: "leaf", href: "/invest/farmland/listings", color: "bg-green-600" },
-                { title: "Commercial Property", icon: "building", href: "/invest/commercial-property/listings", color: "bg-blue-600" },
-                { title: "Franchise", icon: "star", href: "/invest/franchise/listings", color: "bg-purple-600" },
-                { title: "Renewable Energy", icon: "zap", href: "/invest/renewable-energy/projects", color: "bg-teal-600" },
-                { title: "Private Credit", icon: "credit-card", href: "/invest/private-credit/listings", color: "bg-indigo-600" },
-                { title: "Alternatives", icon: "gem", href: "/invest/alternatives/listings", color: "bg-rose-600" },
-              ].map((cat) => (
-                <Link
-                  key={cat.href}
-                  href={cat.href}
-                  className="group bg-white border border-slate-200 rounded-xl p-4 hover:border-amber-200 hover:shadow-md transition-all text-center"
-                >
-                  <div className={`w-10 h-10 ${cat.color} rounded-xl flex items-center justify-center mx-auto mb-3 shadow-sm`}>
-                    <Icon name={cat.icon} size={18} className="text-white" />
-                  </div>
-                  <p className="text-sm font-bold text-slate-900 group-hover:text-amber-600 transition-colors">{cat.title}</p>
-                  <p className="text-xs text-amber-600 font-semibold mt-1">Browse &rarr;</p>
-                </Link>
-              ))}
-            </div>
-            <div className="text-center mt-6">
-              <Link
-                href="/invest/listings"
-                className="inline-flex items-center gap-2 px-6 py-3 bg-slate-900 hover:bg-slate-800 text-white font-bold text-sm rounded-xl transition-all"
-              >
-                <Icon name="layers" size={15} />
-                View All {listingCount || 55}+ Investment Listings &rarr;
-              </Link>
-            </div>
-          </div>
-        </section>
-      </ScrollFadeIn>
-
-      {/* ═══════ 7. TOOLS & CALCULATORS ═══════ */}
+      {/* ═══════ 6. TOOLS & CALCULATORS ═══════ */}
       <ScrollFadeIn>
         <section className="py-6 md:py-10 bg-white border-t border-slate-100">
           <div className="container-custom">
@@ -499,26 +448,7 @@ export default async function HomePage() {
         </section>
       </ScrollFadeIn>
 
-      {/* ═══════ 8. ADVISOR DIRECTORY ═══════ */}
-      <div className="text-center mb-6 pt-6 bg-slate-50">
-        <p className="text-xs text-slate-500 max-w-lg mx-auto">
-          Browse directory listings and public register details. Always verify provider suitability for your own circumstances.
-        </p>
-      </div>
-      <AdvisorDirectory />
-
-      {/* ═══════ 9. EMAIL CAPTURE ═══════ */}
-      <ScrollFadeIn>
-        <section className="py-6 md:py-10 bg-white border-t border-slate-100">
-          <div className="container-custom">
-            <div className="max-w-xl mx-auto">
-              <LeadMagnet />
-            </div>
-          </div>
-        </section>
-      </ScrollFadeIn>
-
-      {/* ═══════ 10. ARTICLES & GUIDES ═══════ */}
+      {/* ═══════ 7. ARTICLES & GUIDES ═══════ */}
       {(articles as Article[])?.length > 0 && (
         <ScrollFadeIn>
           <section className="py-6 md:py-10 bg-slate-50 border-t border-slate-200">
@@ -593,6 +523,76 @@ export default async function HomePage() {
           </section>
         </ScrollFadeIn>
       )}
+
+      {/* ═══════ 8. INVESTMENT MARKETPLACE ═══════ */}
+      <ScrollFadeIn>
+        <section className="py-10 md:py-14 bg-slate-50 border-b border-slate-100">
+          <div className="container-custom">
+            <div className="flex items-center justify-between mb-6">
+              <div>
+                <p className="text-xs font-semibold text-amber-600 uppercase tracking-wide mb-1">Investment Marketplace</p>
+                <h2 className="text-xl md:text-2xl font-extrabold text-slate-900">Explore Investment Categories</h2>
+                <p className="text-sm text-slate-600 mt-1">Enquire about real assets across these categories.</p>
+              </div>
+              <Link href="/invest/listings" className="text-sm font-semibold text-amber-600 hover:text-amber-700 shrink-0">
+                View all categories →
+              </Link>
+            </div>
+            <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
+              {[
+                { title: "Businesses for Sale", icon: "briefcase", href: "/invest/buy-business/listings", color: "bg-slate-800" },
+                { title: "Mining & Resources", icon: "layers", href: "/invest/mining/opportunities", color: "bg-amber-600" },
+                { title: "Farmland & Agriculture", icon: "leaf", href: "/invest/farmland/listings", color: "bg-green-600" },
+                { title: "Commercial Property", icon: "building", href: "/invest/commercial-property/listings", color: "bg-blue-600" },
+                { title: "Franchise", icon: "star", href: "/invest/franchise/listings", color: "bg-purple-600" },
+                { title: "Renewable Energy", icon: "zap", href: "/invest/renewable-energy/projects", color: "bg-teal-600" },
+                { title: "Private Credit", icon: "credit-card", href: "/invest/private-credit/listings", color: "bg-indigo-600" },
+                { title: "Alternatives", icon: "gem", href: "/invest/alternatives/listings", color: "bg-rose-600" },
+              ].map((cat) => (
+                <Link
+                  key={cat.href}
+                  href={cat.href}
+                  className="group bg-white border border-slate-200 rounded-xl p-4 hover:border-amber-200 hover:shadow-md transition-all text-center"
+                >
+                  <div className={`w-10 h-10 ${cat.color} rounded-xl flex items-center justify-center mx-auto mb-3 shadow-sm`}>
+                    <Icon name={cat.icon} size={18} className="text-white" />
+                  </div>
+                  <p className="text-sm font-bold text-slate-900 group-hover:text-amber-600 transition-colors">{cat.title}</p>
+                  <p className="text-xs text-amber-600 font-semibold mt-1">Browse &rarr;</p>
+                </Link>
+              ))}
+            </div>
+            <div className="text-center mt-6">
+              <Link
+                href="/invest/listings"
+                className="inline-flex items-center gap-2 px-6 py-3 bg-slate-900 hover:bg-slate-800 text-white font-bold text-sm rounded-xl transition-all"
+              >
+                <Icon name="layers" size={15} />
+                View All {listingCount || 55}+ Investment Listings &rarr;
+              </Link>
+            </div>
+          </div>
+        </section>
+      </ScrollFadeIn>
+
+      {/* ═══════ 9. ADVISOR DIRECTORY ═══════ */}
+      <div className="text-center mb-6 pt-6 bg-slate-50">
+        <p className="text-xs text-slate-500 max-w-lg mx-auto">
+          Browse directory listings and public register details. Always verify provider suitability for your own circumstances.
+        </p>
+      </div>
+      <AdvisorDirectory />
+
+      {/* ═══════ 10. EMAIL CAPTURE ═══════ */}
+      <ScrollFadeIn>
+        <section className="py-6 md:py-10 bg-white border-t border-slate-100">
+          <div className="container-custom">
+            <div className="max-w-xl mx-auto">
+              <LeadMagnet />
+            </div>
+          </div>
+        </section>
+      </ScrollFadeIn>
 
       {/* ═══════ MOBILE STICKY CTA (item 68) ═══════ */}
       <MobileStickyAdvisorCta />

--- a/components/layout/SiteFooter.tsx
+++ b/components/layout/SiteFooter.tsx
@@ -159,19 +159,19 @@ export function SiteFooter() {
         </div>
 
         {/* Compliance Section */}
-        <div className="border-t border-slate-800 pt-8 mb-8 space-y-5">
-          <h4 className="text-white font-bold text-sm">Important Information</h4>
+        <div className="border-t border-slate-800 pt-8 mb-8 space-y-4">
+          <h4 className="text-white font-semibold text-xs">Important Information</h4>
 
           {/* General Information Disclaimer — always visible */}
-          <div className="p-4 bg-slate-800/60 border border-slate-700 rounded-xl">
+          <div className="p-3 bg-slate-800/40 border border-amber-100/10 rounded-xl">
             <div className="flex items-start gap-2.5">
-              <svg className="w-4 h-4 text-amber-400 shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <svg className="w-3.5 h-3.5 text-amber-400 shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
               </svg>
               <div>
-                <p className="text-xs font-bold text-amber-400 mb-1.5">General Information Only</p>
-                <p className="text-xs text-slate-400 leading-relaxed">{GENERAL_ADVICE_WARNING}</p>
-                <p className="text-xs text-slate-400 leading-relaxed mt-2">
+                <p className="text-[0.7rem] font-bold text-amber-400 mb-1">General Information Only</p>
+                <p className="text-[0.7rem] text-slate-400 leading-relaxed">{GENERAL_ADVICE_WARNING}</p>
+                <p className="text-[0.7rem] text-slate-400 leading-relaxed mt-1.5">
                   Invest.com.au is a factual comparison and directory service. We do not assess suitability.
                   We do not provide personal financial advice. We do not recommend one provider as suitable
                   for a particular user. Users should review provider documents (PDS, TMD, FSG) and seek
@@ -195,7 +195,7 @@ export function SiteFooter() {
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
                   </svg>
                 </summary>
-                <p className="text-xs text-slate-500 leading-relaxed pt-2 pb-1">{item.content}</p>
+                <p className="text-[0.7rem] text-slate-500 leading-relaxed pt-2 pb-1">{item.content}</p>
               </details>
             ))}
           </div>


### PR DESCRIPTION
## Summary

UX feedback round 2 — hero copy, section reorder, trust strip, footer softening.

- Hero: "Compare platforms, professionals & investment pathways"
- Subheadline: one clean sentence
- Trust strip: factual/directory/educational framing
- Section reorder: Compare → Categories → Tools → Learn → Marketplace → Advisors
- Category CTA: "View all categories →" prominent alongside heading
- Footer: smaller text, lighter warning box, less mobile weight

https://claude.ai/code/session_01Pm4P3VYciJpVNYAdyJzsSn