### PR TITLE
fix(ux): round 4 — mobile cards simplified, copy tightened, footer lighter

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -161,7 +161,7 @@ export default async function HomePage() {
 
             <h1 className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-extrabold text-slate-900 leading-[1.1] mb-4 tracking-tight">
               Compare platforms, professionals{" "}
-              <span className="text-amber-500">&amp; investment pathways</span>
+              <span className="text-amber-500">&amp; ways to invest</span>
             </h1>
 
             <p className="text-base md:text-lg text-slate-600 mb-8 leading-relaxed max-w-2xl mx-auto">
@@ -347,8 +347,7 @@ export default async function HomePage() {
         <div className="container-custom">
           <div className="max-w-3xl mx-auto text-center mb-8">
             <h2 className="text-xl md:text-2xl font-extrabold text-slate-900">
-              Know exactly what you need?{" "}
-              <span className="text-slate-500 font-semibold">Browse by category.</span>
+              Browse by category
             </h2>
           </div>
           <div className="grid grid-cols-2 md:grid-cols-5 gap-3 md:gap-4 max-w-5xl mx-auto">

--- a/components/HomepageComparisonTable.tsx
+++ b/components/HomepageComparisonTable.tsx
@@ -301,52 +301,26 @@ export default function HomepageComparisonTable({
             return cidMobile ? `${link}${link.includes("?") ? "&" : "?"}cid=${cidMobile}` : link;
           })();
           return (
-          <div key={broker.id} className="py-2.5 first:pt-1">
-            {/* Row 1: Rank + Icon + Name + CTA */}
-            <div className="flex items-center gap-2">
-              <div className="w-5 text-center shrink-0">
-                {SHOW_EDITORIAL_BADGES && isTopRatedMobile ? (
-                  <span className="text-amber-500 text-sm">🏆</span>
-                ) : (
-                  <span className="text-xs font-bold text-slate-400">{i + 1}</span>
-                )}
-              </div>
+          <div key={broker.id} className="py-3 first:pt-1">
+            <div className="flex items-center gap-2.5">
+              <span className="w-5 text-center text-xs font-bold text-slate-400 shrink-0">{i + 1}</span>
               <BrokerLogo broker={broker} size="sm" />
               <div className="flex-1 min-w-0">
-                <div className="flex items-center gap-1 flex-wrap">
-                  <a href={`/broker/${broker.slug}`} className="font-bold text-sm text-slate-900">
-                    {broker.name}
-                  </a>
-                  <PromoBadge broker={broker} />
-                  {isSponsored(broker) && <SponsorBadge broker={broker} />}
-                  {isCampaignMobile && !isSponsored(broker) && (
-                    <span className="text-[0.56rem] font-bold uppercase text-blue-700 bg-blue-50 px-1 py-px rounded">Sponsored</span>
-                  )}
-                  {SHOW_EDITORIAL_BADGES && !isSponsored(broker) && !isCampaignMobile && editorPicks[broker.slug] && (
-                    <span className="text-[0.56rem] font-bold uppercase text-amber-700 bg-amber-50 px-1 py-px rounded">
-                      {editorPicks[broker.slug]}
-                    </span>
-                  )}
+                <a href={`/broker/${broker.slug}`} className="font-bold text-sm text-slate-900 block truncate">{broker.name}</a>
+                <div className="flex items-center gap-2 mt-0.5 text-[0.7rem] text-slate-500">
+                  <span className="font-semibold text-slate-700">{broker.asx_fee || "N/A"} ASX</span>
+                  {broker.chess_sponsored && <span className="text-emerald-600 font-semibold">CHESS</span>}
+                  {(isSponsored(broker) || isCampaignMobile) && <span className="text-[0.56rem] font-bold uppercase text-blue-700 bg-blue-50 px-1 py-px rounded">Ad</span>}
                 </div>
               </div>
               <a
                 href={mobileLink}
                 target="_blank"
                 rel={AFFILIATE_REL}
-                className="shrink-0 px-3 py-1.5 min-h-[36px] inline-flex items-center bg-amber-500 text-white text-[0.65rem] font-bold rounded-lg active:scale-[0.97] transition-all"
+                className="shrink-0 px-3.5 py-2 min-h-[36px] inline-flex items-center bg-amber-500 text-slate-900 text-xs font-bold rounded-lg active:scale-[0.97] transition-all"
               >
                 Go →
               </a>
-            </div>
-            {/* Row 2: 2 key facts only — keep it scannable */}
-            <div className="flex items-center gap-2 mt-1 ml-[3.25rem] text-[0.7rem]">
-              <span className="text-slate-700 font-semibold">{broker.asx_fee || "N/A"} ASX</span>
-              {broker.chess_sponsored && (
-                <>
-                  <span className="text-slate-300">·</span>
-                  <span className="text-emerald-600 font-semibold">CHESS</span>
-                </>
-              )}
             </div>
           </div>
           );

--- a/components/layout/SiteFooter.tsx
+++ b/components/layout/SiteFooter.tsx
@@ -119,8 +119,8 @@ export function SiteFooter() {
         </div>
 
         {/* Compliance Section */}
-        <div className="border-t border-slate-800 pt-8 mb-8 space-y-4">
-          <h4 className="text-white font-semibold text-xs">Important Information</h4>
+        <div className="border-t border-slate-800 pt-5 mb-6 space-y-3">
+          <h4 className="text-slate-400 font-medium text-[0.65rem] uppercase tracking-wider">Important Information</h4>
 
           {/* General Information Disclaimer — always visible */}
           <div className="p-3 bg-slate-800/40 border border-amber-100/10 rounded-xl">


### PR DESCRIPTION
## Summary

UX polish round 4 — the final refinement pass.

### Mobile comparison cards radically simplified (Point 1)
Each broker card now shows ONLY: rank + logo + name + ASX fee + CHESS status + Go CTA. Removed all badges, ratings, editor picks, FX rates. One clean row per broker. Homepage preview teases the click.

### Copy tightened
- "investment pathways" → "ways to invest" (plain English)
- "Know exactly what you need? Browse by category." → "Browse by category"

### Footer lighter
- "Important Information" heading demoted to subtle uppercase label
- Reduced spacing throughout compliance section

https://claude.ai/code/session_01Pm4P3VYciJpVNYAdyJzsSn