### PR TITLE
fix(ux): convert ALL 20 listing + detail page heroes to white

### DIFF
--- a/app/invest/alternatives/listings/AlternativesListingsClient.tsx
+++ b/app/invest/alternatives/listings/AlternativesListingsClient.tsx
@@ -74,21 +74,21 @@ export default function AlternativesListingsClient({ listings }: Props) {
   return (
     <div>
       {/* Hero */}
-      <section className="bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 text-white py-12 md:py-16">
+      <section className="bg-white border-b border-slate-100 py-12 md:py-16">
         <div className="container-custom">
-          <nav className="flex items-center gap-1.5 text-xs text-slate-400 mb-6" aria-label="Breadcrumb">
-            <Link href="/" className="hover:text-white transition-colors">Home</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <Link href="/invest" className="hover:text-white transition-colors">Invest</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <Link href="/invest/alternatives" className="hover:text-white transition-colors">Alternative Investments</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <span className="text-slate-300">Listings</span>
+          <nav className="flex items-center gap-1.5 text-xs text-slate-500 mb-6" aria-label="Breadcrumb">
+            <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <Link href="/invest" className="hover:text-slate-900 transition-colors">Invest</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <Link href="/invest/alternatives" className="hover:text-slate-900 transition-colors">Alternative Investments</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <span className="text-slate-900 font-medium">Listings</span>
           </nav>
-          <h1 className="text-3xl md:text-4xl font-extrabold mb-3">
+          <h1 className="text-3xl md:text-4xl font-extrabold mb-3 text-slate-900">
             Alternative Investments in Australia
           </h1>
-          <p className="text-slate-300 text-base max-w-2xl">
+          <p className="text-slate-600 text-base max-w-2xl">
             {listings.length > 0
               ? `${listings.length} active listing${listings.length !== 1 ? "s" : ""} — wine, art, classic cars, watches and more`
               : "Browse alternative investment opportunities across Australia"}

--- a/app/invest/alternatives/listings/[slug]/page.tsx
+++ b/app/invest/alternatives/listings/[slug]/page.tsx
@@ -90,16 +90,16 @@ export default async function AlternativesListingDetailPage({
       />
 
       {/* Hero */}
-      <section className="bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 text-white py-12">
+      <section className="bg-white border-b border-slate-100 py-12">
         <div className="container-custom">
-          <nav className="flex items-center gap-1.5 text-xs text-slate-400 mb-4" aria-label="Breadcrumb">
-            <Link href="/" className="hover:text-white transition-colors">Home</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <Link href="/invest" className="hover:text-white transition-colors">Invest</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <Link href="/invest/alternatives/listings" className="hover:text-white transition-colors">Alternative Investments</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <span className="text-slate-300 truncate max-w-[160px]">{l.title}</span>
+          <nav className="flex items-center gap-1.5 text-xs text-slate-500 mb-4" aria-label="Breadcrumb">
+            <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <Link href="/invest" className="hover:text-slate-900 transition-colors">Invest</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <Link href="/invest/alternatives/listings" className="hover:text-slate-900 transition-colors">Alternative Investments</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <span className="text-slate-900 font-medium truncate max-w-[160px]">{l.title}</span>
           </nav>
 
           <div className="flex flex-wrap gap-2 mb-3">
@@ -119,9 +119,9 @@ export default async function AlternativesListingDetailPage({
             )}
           </div>
 
-          <h1 className="text-2xl md:text-3xl font-extrabold mb-2">{l.title}</h1>
+          <h1 className="text-2xl md:text-3xl font-extrabold mb-2 text-slate-900">{l.title}</h1>
           {location && (
-            <div className="flex items-center gap-1.5 text-slate-300 text-sm">
+            <div className="flex items-center gap-1.5 text-slate-600 text-sm">
               <Icon name="map-pin" size={14} />
               {location}
             </div>

--- a/app/invest/buy-business/listings/BusinessListingsClient.tsx
+++ b/app/invest/buy-business/listings/BusinessListingsClient.tsx
@@ -78,21 +78,21 @@ export default function BusinessListingsClient({ listings }: Props) {
   return (
     <div>
       {/* Hero */}
-      <section className="bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 text-white py-12 md:py-16">
+      <section className="bg-white border-b border-slate-100 py-12 md:py-16">
         <div className="container-custom">
-          <nav className="flex items-center gap-1.5 text-xs text-slate-400 mb-6" aria-label="Breadcrumb">
-            <Link href="/" className="hover:text-white transition-colors">Home</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <Link href="/invest" className="hover:text-white transition-colors">Invest</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <Link href="/invest/buy-business" className="hover:text-white transition-colors">Buy a Business</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <span className="text-slate-300">Listings</span>
+          <nav className="flex items-center gap-1.5 text-xs text-slate-500 mb-6" aria-label="Breadcrumb">
+            <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <Link href="/invest" className="hover:text-slate-900 transition-colors">Invest</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <Link href="/invest/buy-business" className="hover:text-slate-900 transition-colors">Buy a Business</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <span className="text-slate-900 font-medium">Listings</span>
           </nav>
-          <h1 className="text-3xl md:text-4xl font-extrabold mb-3">
+          <h1 className="text-3xl md:text-4xl font-extrabold mb-3 text-slate-900">
             Businesses for Sale in Australia
           </h1>
-          <p className="text-slate-300 text-base max-w-2xl">
+          <p className="text-slate-600 text-base max-w-2xl">
             {listings.length > 0
               ? `${listings.length} active listing${listings.length !== 1 ? "s" : ""} across Australia`
               : "Browse businesses for sale across Australia"}

--- a/app/invest/buy-business/listings/[slug]/page.tsx
+++ b/app/invest/buy-business/listings/[slug]/page.tsx
@@ -90,16 +90,16 @@ export default async function BusinessListingDetailPage({
       />
 
       {/* Hero */}
-      <section className="bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 text-white py-12">
+      <section className="bg-white border-b border-slate-100 py-12">
         <div className="container-custom">
-          <nav className="flex items-center gap-1.5 text-xs text-slate-400 mb-4" aria-label="Breadcrumb">
-            <Link href="/" className="hover:text-white transition-colors">Home</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <Link href="/invest" className="hover:text-white transition-colors">Invest</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <Link href="/invest/buy-business/listings" className="hover:text-white transition-colors">Businesses for Sale</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <span className="text-slate-300 truncate max-w-[160px]">{l.title}</span>
+          <nav className="flex items-center gap-1.5 text-xs text-slate-500 mb-4" aria-label="Breadcrumb">
+            <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <Link href="/invest" className="hover:text-slate-900 transition-colors">Invest</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <Link href="/invest/buy-business/listings" className="hover:text-slate-900 transition-colors">Businesses for Sale</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <span className="text-slate-900 font-medium truncate max-w-[160px]">{l.title}</span>
           </nav>
 
           <div className="flex flex-wrap gap-2 mb-3">
@@ -119,9 +119,9 @@ export default async function BusinessListingDetailPage({
             )}
           </div>
 
-          <h1 className="text-2xl md:text-3xl font-extrabold mb-2">{l.title}</h1>
+          <h1 className="text-2xl md:text-3xl font-extrabold mb-2 text-slate-900">{l.title}</h1>
           {location && (
-            <div className="flex items-center gap-1.5 text-slate-300 text-sm">
+            <div className="flex items-center gap-1.5 text-slate-600 text-sm">
               <Icon name="map-pin" size={14} />
               {location}
             </div>

--- a/app/invest/commercial-property/listings/CommercialListingsClient.tsx
+++ b/app/invest/commercial-property/listings/CommercialListingsClient.tsx
@@ -62,19 +62,19 @@ export default function CommercialListingsClient({ listings }: Props) {
 
   return (
     <div>
-      <section className="bg-gradient-to-br from-blue-900 via-slate-900 to-slate-900 text-white py-12 md:py-16">
+      <section className="bg-white border-b border-slate-100 py-12 md:py-16">
         <div className="container-custom">
-          <nav className="flex items-center gap-1.5 text-xs text-slate-400 mb-6" aria-label="Breadcrumb">
-            <Link href="/" className="hover:text-white transition-colors">Home</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <Link href="/invest" className="hover:text-white transition-colors">Invest</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <Link href="/invest/commercial-property" className="hover:text-white transition-colors">Commercial Property</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <span className="text-slate-300">Listings</span>
+          <nav className="flex items-center gap-1.5 text-xs text-slate-500 mb-6" aria-label="Breadcrumb">
+            <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <Link href="/invest" className="hover:text-slate-900 transition-colors">Invest</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <Link href="/invest/commercial-property" className="hover:text-slate-900 transition-colors">Commercial Property</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <span className="text-slate-900 font-medium">Listings</span>
           </nav>
-          <h1 className="text-3xl md:text-4xl font-extrabold mb-3">Commercial Property for Sale</h1>
-          <p className="text-slate-300 text-base max-w-2xl">
+          <h1 className="text-3xl md:text-4xl font-extrabold mb-3 text-slate-900">Commercial Property for Sale</h1>
+          <p className="text-slate-600 text-base max-w-2xl">
             {listings.length > 0
               ? `${listings.length} active listing${listings.length !== 1 ? "s" : ""} — office, industrial, retail, and hotel assets across Australia`
               : "Commercial properties for sale across Australia with yield data and direct enquiry"}

--- a/app/invest/commercial-property/listings/[slug]/page.tsx
+++ b/app/invest/commercial-property/listings/[slug]/page.tsx
@@ -86,14 +86,14 @@ export default async function CommercialListingDetailPage({
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
       />
 
-      <section className="bg-gradient-to-br from-blue-900 via-slate-900 to-slate-900 text-white py-12">
+      <section className="bg-white border-b border-slate-100 py-12">
         <div className="container-custom">
-          <nav className="flex items-center gap-1.5 text-xs text-slate-400 mb-4" aria-label="Breadcrumb">
-            <Link href="/" className="hover:text-white transition-colors">Home</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <Link href="/invest/commercial-property/listings" className="hover:text-white transition-colors">Commercial Properties</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <span className="text-slate-300 truncate max-w-[160px]">{l.title}</span>
+          <nav className="flex items-center gap-1.5 text-xs text-slate-500 mb-4" aria-label="Breadcrumb">
+            <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <Link href="/invest/commercial-property/listings" className="hover:text-slate-900 transition-colors">Commercial Properties</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <span className="text-slate-900 font-medium truncate max-w-[160px]">{l.title}</span>
           </nav>
 
           <div className="flex flex-wrap gap-2 mb-3">
@@ -115,9 +115,9 @@ export default async function CommercialListingDetailPage({
             )}
           </div>
 
-          <h1 className="text-2xl md:text-3xl font-extrabold mb-2">{l.title}</h1>
+          <h1 className="text-2xl md:text-3xl font-extrabold mb-2 text-slate-900">{l.title}</h1>
           {location && (
-            <div className="flex items-center gap-1.5 text-slate-300 text-sm">
+            <div className="flex items-center gap-1.5 text-slate-600 text-sm">
               <Icon name="map-pin" size={14} />
               {location}
             </div>

--- a/app/invest/farmland/listings/FarmlandListingsClient.tsx
+++ b/app/invest/farmland/listings/FarmlandListingsClient.tsx
@@ -70,19 +70,19 @@ export default function FarmlandListingsClient({ listings }: Props) {
 
   return (
     <div>
-      <section className="bg-gradient-to-br from-green-900 via-slate-900 to-slate-900 text-white py-12 md:py-16">
+      <section className="bg-white border-b border-slate-100 py-12 md:py-16">
         <div className="container-custom">
-          <nav className="flex items-center gap-1.5 text-xs text-slate-400 mb-6" aria-label="Breadcrumb">
-            <Link href="/" className="hover:text-white transition-colors">Home</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <Link href="/invest" className="hover:text-white transition-colors">Invest</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <Link href="/invest/farmland" className="hover:text-white transition-colors">Farmland</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <span className="text-slate-300">Listings</span>
+          <nav className="flex items-center gap-1.5 text-xs text-slate-500 mb-6" aria-label="Breadcrumb">
+            <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <Link href="/invest" className="hover:text-slate-900 transition-colors">Invest</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <Link href="/invest/farmland" className="hover:text-slate-900 transition-colors">Farmland</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <span className="text-slate-900 font-medium">Listings</span>
           </nav>
-          <h1 className="text-3xl md:text-4xl font-extrabold mb-3">Farmland & Agricultural Properties for Sale</h1>
-          <p className="text-slate-300 text-base max-w-2xl">
+          <h1 className="text-3xl md:text-4xl font-extrabold mb-3 text-slate-900">Farmland & Agricultural Properties for Sale</h1>
+          <p className="text-slate-600 text-base max-w-2xl">
             {listings.length > 0
               ? `${listings.length} active listing${listings.length !== 1 ? "s" : ""} — FIRB-eligible properties highlighted`
               : "Agricultural land for sale across Australia with FIRB guidance for foreign buyers"}

--- a/app/invest/farmland/listings/[slug]/page.tsx
+++ b/app/invest/farmland/listings/[slug]/page.tsx
@@ -85,14 +85,14 @@ export default async function FarmlandListingDetailPage({
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
       />
 
-      <section className="bg-gradient-to-br from-green-900 via-slate-900 to-slate-900 text-white py-12">
+      <section className="bg-white border-b border-slate-100 py-12">
         <div className="container-custom">
-          <nav className="flex items-center gap-1.5 text-xs text-slate-400 mb-4" aria-label="Breadcrumb">
-            <Link href="/" className="hover:text-white transition-colors">Home</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <Link href="/invest/farmland/listings" className="hover:text-white transition-colors">Farmland Listings</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <span className="text-slate-300 truncate max-w-[160px]">{l.title}</span>
+          <nav className="flex items-center gap-1.5 text-xs text-slate-500 mb-4" aria-label="Breadcrumb">
+            <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <Link href="/invest/farmland/listings" className="hover:text-slate-900 transition-colors">Farmland Listings</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <span className="text-slate-900 font-medium truncate max-w-[160px]">{l.title}</span>
           </nav>
 
           <div className="flex flex-wrap gap-2 mb-3">
@@ -109,9 +109,9 @@ export default async function FarmlandListingDetailPage({
             )}
           </div>
 
-          <h1 className="text-2xl md:text-3xl font-extrabold mb-2">{l.title}</h1>
+          <h1 className="text-2xl md:text-3xl font-extrabold mb-2 text-slate-900">{l.title}</h1>
           {location && (
-            <div className="flex items-center gap-1.5 text-slate-300 text-sm">
+            <div className="flex items-center gap-1.5 text-slate-600 text-sm">
               <Icon name="map-pin" size={14} />
               {location}
             </div>

--- a/app/invest/franchise/listings/FranchiseListingsClient.tsx
+++ b/app/invest/franchise/listings/FranchiseListingsClient.tsx
@@ -62,19 +62,19 @@ export default function FranchiseListingsClient({ listings }: Props) {
 
   return (
     <div>
-      <section className="bg-gradient-to-br from-purple-900 via-slate-900 to-slate-900 text-white py-12 md:py-16">
+      <section className="bg-white border-b border-slate-100 py-12 md:py-16">
         <div className="container-custom">
-          <nav className="flex items-center gap-1.5 text-xs text-slate-400 mb-6" aria-label="Breadcrumb">
-            <Link href="/" className="hover:text-white transition-colors">Home</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <Link href="/invest" className="hover:text-white transition-colors">Invest</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <Link href="/invest/franchise" className="hover:text-white transition-colors">Franchise</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <span className="text-slate-300">Listings</span>
+          <nav className="flex items-center gap-1.5 text-xs text-slate-500 mb-6" aria-label="Breadcrumb">
+            <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <Link href="/invest" className="hover:text-slate-900 transition-colors">Invest</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <Link href="/invest/franchise" className="hover:text-slate-900 transition-colors">Franchise</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <span className="text-slate-900 font-medium">Listings</span>
           </nav>
-          <h1 className="text-3xl md:text-4xl font-extrabold mb-3">Franchise Opportunities in Australia</h1>
-          <p className="text-slate-300 text-base max-w-2xl">
+          <h1 className="text-3xl md:text-4xl font-extrabold mb-3 text-slate-900">Franchise Opportunities in Australia</h1>
+          <p className="text-slate-600 text-base max-w-2xl">
             {listings.length > 0
               ? `${listings.length} available territor${listings.length !== 1 ? "ies" : "y"} across Australia`
               : "Available franchise territories across food, fitness, cleaning, automotive, retail, and education"}

--- a/app/invest/franchise/listings/[slug]/page.tsx
+++ b/app/invest/franchise/listings/[slug]/page.tsx
@@ -85,14 +85,14 @@ export default async function FranchiseListingDetailPage({
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
       />
 
-      <section className="bg-gradient-to-br from-purple-900 via-slate-900 to-slate-900 text-white py-12">
+      <section className="bg-white border-b border-slate-100 py-12">
         <div className="container-custom">
-          <nav className="flex items-center gap-1.5 text-xs text-slate-400 mb-4" aria-label="Breadcrumb">
-            <Link href="/" className="hover:text-white transition-colors">Home</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <Link href="/invest/franchise/listings" className="hover:text-white transition-colors">Franchise Listings</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <span className="text-slate-300 truncate max-w-[160px]">{l.title}</span>
+          <nav className="flex items-center gap-1.5 text-xs text-slate-500 mb-4" aria-label="Breadcrumb">
+            <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <Link href="/invest/franchise/listings" className="hover:text-slate-900 transition-colors">Franchise Listings</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <span className="text-slate-900 font-medium truncate max-w-[160px]">{l.title}</span>
           </nav>
 
           <div className="flex flex-wrap gap-2 mb-3">
@@ -111,9 +111,9 @@ export default async function FranchiseListingDetailPage({
             )}
           </div>
 
-          <h1 className="text-2xl md:text-3xl font-extrabold mb-2">{l.title}</h1>
+          <h1 className="text-2xl md:text-3xl font-extrabold mb-2 text-slate-900">{l.title}</h1>
           {location && (
-            <div className="flex items-center gap-1.5 text-slate-300 text-sm">
+            <div className="flex items-center gap-1.5 text-slate-600 text-sm">
               <Icon name="map-pin" size={14} />
               {location}
             </div>

--- a/app/invest/infrastructure/listings/InfrastructureListingsClient.tsx
+++ b/app/invest/infrastructure/listings/InfrastructureListingsClient.tsx
@@ -79,21 +79,21 @@ export default function InfrastructureListingsClient({ listings }: Props) {
   return (
     <div>
       {/* Hero */}
-      <section className="bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 text-white py-12 md:py-16">
+      <section className="bg-white border-b border-slate-100 py-12 md:py-16">
         <div className="container-custom">
-          <nav className="flex items-center gap-1.5 text-xs text-slate-400 mb-6" aria-label="Breadcrumb">
-            <Link href="/" className="hover:text-white transition-colors">Home</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <Link href="/invest" className="hover:text-white transition-colors">Invest</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <Link href="/invest/infrastructure" className="hover:text-white transition-colors">Infrastructure</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <span className="text-slate-300">Listings</span>
+          <nav className="flex items-center gap-1.5 text-xs text-slate-500 mb-6" aria-label="Breadcrumb">
+            <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <Link href="/invest" className="hover:text-slate-900 transition-colors">Invest</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <Link href="/invest/infrastructure" className="hover:text-slate-900 transition-colors">Infrastructure</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <span className="text-slate-900 font-medium">Listings</span>
           </nav>
-          <h1 className="text-3xl md:text-4xl font-extrabold mb-3">
+          <h1 className="text-3xl md:text-4xl font-extrabold mb-3 text-slate-900">
             Infrastructure Investments in Australia
           </h1>
-          <p className="text-slate-300 text-base max-w-2xl">
+          <p className="text-slate-600 text-base max-w-2xl">
             {listings.length > 0
               ? `${listings.length} active listing${listings.length !== 1 ? "s" : ""} — toll roads, energy, airports, ports and utilities`
               : "Browse infrastructure investment opportunities across Australia"}

--- a/app/invest/infrastructure/listings/[slug]/page.tsx
+++ b/app/invest/infrastructure/listings/[slug]/page.tsx
@@ -90,16 +90,16 @@ export default async function InfrastructureListingDetailPage({
       />
 
       {/* Hero */}
-      <section className="bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 text-white py-12">
+      <section className="bg-white border-b border-slate-100 py-12">
         <div className="container-custom">
-          <nav className="flex items-center gap-1.5 text-xs text-slate-400 mb-4" aria-label="Breadcrumb">
-            <Link href="/" className="hover:text-white transition-colors">Home</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <Link href="/invest" className="hover:text-white transition-colors">Invest</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <Link href="/invest/infrastructure/listings" className="hover:text-white transition-colors">Infrastructure</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <span className="text-slate-300 truncate max-w-[160px]">{l.title}</span>
+          <nav className="flex items-center gap-1.5 text-xs text-slate-500 mb-4" aria-label="Breadcrumb">
+            <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <Link href="/invest" className="hover:text-slate-900 transition-colors">Invest</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <Link href="/invest/infrastructure/listings" className="hover:text-slate-900 transition-colors">Infrastructure</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <span className="text-slate-900 font-medium truncate max-w-[160px]">{l.title}</span>
           </nav>
 
           <div className="flex flex-wrap gap-2 mb-3">
@@ -119,9 +119,9 @@ export default async function InfrastructureListingDetailPage({
             )}
           </div>
 
-          <h1 className="text-2xl md:text-3xl font-extrabold mb-2">{l.title}</h1>
+          <h1 className="text-2xl md:text-3xl font-extrabold mb-2 text-slate-900">{l.title}</h1>
           {location && (
-            <div className="flex items-center gap-1.5 text-slate-300 text-sm">
+            <div className="flex items-center gap-1.5 text-slate-600 text-sm">
               <Icon name="map-pin" size={14} />
               {location}
             </div>

--- a/app/invest/mining/opportunities/MiningListingsClient.tsx
+++ b/app/invest/mining/opportunities/MiningListingsClient.tsx
@@ -65,19 +65,19 @@ export default function MiningListingsClient({ listings }: Props) {
 
   return (
     <div>
-      <section className="bg-gradient-to-br from-amber-900 via-slate-900 to-slate-900 text-white py-12 md:py-16">
+      <section className="bg-white border-b border-slate-100 py-12 md:py-16">
         <div className="container-custom">
-          <nav className="flex items-center gap-1.5 text-xs text-slate-400 mb-6" aria-label="Breadcrumb">
-            <Link href="/" className="hover:text-white transition-colors">Home</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <Link href="/invest" className="hover:text-white transition-colors">Invest</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <Link href="/invest/mining" className="hover:text-white transition-colors">Mining</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <span className="text-slate-300">Opportunities</span>
+          <nav className="flex items-center gap-1.5 text-xs text-slate-500 mb-6" aria-label="Breadcrumb">
+            <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <Link href="/invest" className="hover:text-slate-900 transition-colors">Invest</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <Link href="/invest/mining" className="hover:text-slate-900 transition-colors">Mining</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <span className="text-slate-900 font-medium">Opportunities</span>
           </nav>
-          <h1 className="text-3xl md:text-4xl font-extrabold mb-3">Mining Investment Opportunities</h1>
-          <p className="text-slate-300 text-base max-w-2xl">
+          <h1 className="text-3xl md:text-4xl font-extrabold mb-3 text-slate-900">Mining Investment Opportunities</h1>
+          <p className="text-slate-600 text-base max-w-2xl">
             {listings.length > 0
               ? `${listings.length} active mining opportunit${listings.length !== 1 ? "ies" : "y"} across Australia`
               : "Direct project investments in Australian mining and resources"}

--- a/app/invest/mining/opportunities/[slug]/page.tsx
+++ b/app/invest/mining/opportunities/[slug]/page.tsx
@@ -85,14 +85,14 @@ export default async function MiningOpportunityDetailPage({
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
       />
 
-      <section className="bg-gradient-to-br from-amber-900 via-slate-900 to-slate-900 text-white py-12">
+      <section className="bg-white border-b border-slate-100 py-12">
         <div className="container-custom">
-          <nav className="flex items-center gap-1.5 text-xs text-slate-400 mb-4" aria-label="Breadcrumb">
-            <Link href="/" className="hover:text-white transition-colors">Home</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <Link href="/invest/mining/opportunities" className="hover:text-white transition-colors">Mining Opportunities</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <span className="text-slate-300 truncate max-w-[160px]">{l.title}</span>
+          <nav className="flex items-center gap-1.5 text-xs text-slate-500 mb-4" aria-label="Breadcrumb">
+            <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <Link href="/invest/mining/opportunities" className="hover:text-slate-900 transition-colors">Mining Opportunities</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <span className="text-slate-900 font-medium truncate max-w-[160px]">{l.title}</span>
           </nav>
 
           <div className="flex flex-wrap gap-2 mb-3">
@@ -114,9 +114,9 @@ export default async function MiningOpportunityDetailPage({
             )}
           </div>
 
-          <h1 className="text-2xl md:text-3xl font-extrabold mb-2">{l.title}</h1>
+          <h1 className="text-2xl md:text-3xl font-extrabold mb-2 text-slate-900">{l.title}</h1>
           {location && (
-            <div className="flex items-center gap-1.5 text-slate-300 text-sm">
+            <div className="flex items-center gap-1.5 text-slate-600 text-sm">
               <Icon name="map-pin" size={14} />
               {location}
             </div>

--- a/app/invest/private-credit/listings/PrivateCreditListingsClient.tsx
+++ b/app/invest/private-credit/listings/PrivateCreditListingsClient.tsx
@@ -75,21 +75,21 @@ export default function PrivateCreditListingsClient({ listings }: Props) {
   return (
     <div>
       {/* Hero */}
-      <section className="bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 text-white py-12 md:py-16">
+      <section className="bg-white border-b border-slate-100 py-12 md:py-16">
         <div className="container-custom">
-          <nav className="flex items-center gap-1.5 text-xs text-slate-400 mb-6" aria-label="Breadcrumb">
-            <Link href="/" className="hover:text-white transition-colors">Home</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <Link href="/invest" className="hover:text-white transition-colors">Invest</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <Link href="/invest/private-credit" className="hover:text-white transition-colors">Private Credit</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <span className="text-slate-300">Listings</span>
+          <nav className="flex items-center gap-1.5 text-xs text-slate-500 mb-6" aria-label="Breadcrumb">
+            <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <Link href="/invest" className="hover:text-slate-900 transition-colors">Invest</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <Link href="/invest/private-credit" className="hover:text-slate-900 transition-colors">Private Credit</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <span className="text-slate-900 font-medium">Listings</span>
           </nav>
-          <h1 className="text-3xl md:text-4xl font-extrabold mb-3">
+          <h1 className="text-3xl md:text-4xl font-extrabold mb-3 text-slate-900">
             Private Credit Funds in Australia
           </h1>
-          <p className="text-slate-300 text-base max-w-2xl">
+          <p className="text-slate-600 text-base max-w-2xl">
             {listings.length > 0
               ? `${listings.length} active listing${listings.length !== 1 ? "s" : ""} — senior secured, mezzanine, P2P and real estate debt`
               : "Browse private credit investment opportunities across Australia"}

--- a/app/invest/private-credit/listings/[slug]/page.tsx
+++ b/app/invest/private-credit/listings/[slug]/page.tsx
@@ -90,16 +90,16 @@ export default async function PrivateCreditListingDetailPage({
       />
 
       {/* Hero */}
-      <section className="bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 text-white py-12">
+      <section className="bg-white border-b border-slate-100 py-12">
         <div className="container-custom">
-          <nav className="flex items-center gap-1.5 text-xs text-slate-400 mb-4" aria-label="Breadcrumb">
-            <Link href="/" className="hover:text-white transition-colors">Home</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <Link href="/invest" className="hover:text-white transition-colors">Invest</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <Link href="/invest/private-credit/listings" className="hover:text-white transition-colors">Private Credit</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <span className="text-slate-300 truncate max-w-[160px]">{l.title}</span>
+          <nav className="flex items-center gap-1.5 text-xs text-slate-500 mb-4" aria-label="Breadcrumb">
+            <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <Link href="/invest" className="hover:text-slate-900 transition-colors">Invest</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <Link href="/invest/private-credit/listings" className="hover:text-slate-900 transition-colors">Private Credit</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <span className="text-slate-900 font-medium truncate max-w-[160px]">{l.title}</span>
           </nav>
 
           <div className="flex flex-wrap gap-2 mb-3">
@@ -119,9 +119,9 @@ export default async function PrivateCreditListingDetailPage({
             )}
           </div>
 
-          <h1 className="text-2xl md:text-3xl font-extrabold mb-2">{l.title}</h1>
+          <h1 className="text-2xl md:text-3xl font-extrabold mb-2 text-slate-900">{l.title}</h1>
           {location && (
-            <div className="flex items-center gap-1.5 text-slate-300 text-sm">
+            <div className="flex items-center gap-1.5 text-slate-600 text-sm">
               <Icon name="map-pin" size={14} />
               {location}
             </div>

--- a/app/invest/renewable-energy/projects/EnergyListingsClient.tsx
+++ b/app/invest/renewable-energy/projects/EnergyListingsClient.tsx
@@ -62,19 +62,19 @@ export default function EnergyListingsClient({ listings }: Props) {
 
   return (
     <div>
-      <section className="bg-gradient-to-br from-teal-900 via-slate-900 to-slate-900 text-white py-12 md:py-16">
+      <section className="bg-white border-b border-slate-100 py-12 md:py-16">
         <div className="container-custom">
-          <nav className="flex items-center gap-1.5 text-xs text-slate-400 mb-6" aria-label="Breadcrumb">
-            <Link href="/" className="hover:text-white transition-colors">Home</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <Link href="/invest" className="hover:text-white transition-colors">Invest</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <Link href="/invest/renewable-energy" className="hover:text-white transition-colors">Renewable Energy</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <span className="text-slate-300">Projects</span>
+          <nav className="flex items-center gap-1.5 text-xs text-slate-500 mb-6" aria-label="Breadcrumb">
+            <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <Link href="/invest" className="hover:text-slate-900 transition-colors">Invest</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <Link href="/invest/renewable-energy" className="hover:text-slate-900 transition-colors">Renewable Energy</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <span className="text-slate-900 font-medium">Projects</span>
           </nav>
-          <h1 className="text-3xl md:text-4xl font-extrabold mb-3">Renewable Energy Projects Seeking Investment</h1>
-          <p className="text-slate-300 text-base max-w-2xl">
+          <h1 className="text-3xl md:text-4xl font-extrabold mb-3 text-slate-900">Renewable Energy Projects Seeking Investment</h1>
+          <p className="text-slate-600 text-base max-w-2xl">
             {listings.length > 0
               ? `${listings.length} active project${listings.length !== 1 ? "s" : ""} — solar, wind, battery, and hydrogen`
               : "Direct co-investment opportunities in Australian renewable energy projects"}

--- a/app/invest/renewable-energy/projects/[slug]/page.tsx
+++ b/app/invest/renewable-energy/projects/[slug]/page.tsx
@@ -86,14 +86,14 @@ export default async function EnergyProjectDetailPage({
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
       />
 
-      <section className="bg-gradient-to-br from-teal-900 via-slate-900 to-slate-900 text-white py-12">
+      <section className="bg-white border-b border-slate-100 py-12">
         <div className="container-custom">
-          <nav className="flex items-center gap-1.5 text-xs text-slate-400 mb-4" aria-label="Breadcrumb">
-            <Link href="/" className="hover:text-white transition-colors">Home</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <Link href="/invest/renewable-energy/projects" className="hover:text-white transition-colors">Energy Projects</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <span className="text-slate-300 truncate max-w-[160px]">{l.title}</span>
+          <nav className="flex items-center gap-1.5 text-xs text-slate-500 mb-4" aria-label="Breadcrumb">
+            <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <Link href="/invest/renewable-energy/projects" className="hover:text-slate-900 transition-colors">Energy Projects</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <span className="text-slate-900 font-medium truncate max-w-[160px]">{l.title}</span>
           </nav>
 
           <div className="flex flex-wrap gap-2 mb-3">
@@ -115,9 +115,9 @@ export default async function EnergyProjectDetailPage({
             )}
           </div>
 
-          <h1 className="text-2xl md:text-3xl font-extrabold mb-2">{l.title}</h1>
+          <h1 className="text-2xl md:text-3xl font-extrabold mb-2 text-slate-900">{l.title}</h1>
           {location && (
-            <div className="flex items-center gap-1.5 text-slate-300 text-sm">
+            <div className="flex items-center gap-1.5 text-slate-600 text-sm">
               <Icon name="map-pin" size={14} />
               {location}
             </div>

--- a/app/invest/startups/opportunities/StartupListingsClient.tsx
+++ b/app/invest/startups/opportunities/StartupListingsClient.tsx
@@ -67,19 +67,19 @@ export default function StartupListingsClient({ listings }: Props) {
 
   return (
     <div>
-      <section className="bg-gradient-to-br from-rose-900 via-slate-900 to-slate-900 text-white py-12 md:py-16">
+      <section className="bg-white border-b border-slate-100 py-12 md:py-16">
         <div className="container-custom">
-          <nav className="flex items-center gap-1.5 text-xs text-slate-400 mb-6" aria-label="Breadcrumb">
-            <Link href="/" className="hover:text-white transition-colors">Home</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <Link href="/invest" className="hover:text-white transition-colors">Invest</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <Link href="/invest/startups" className="hover:text-white transition-colors">Startups</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <span className="text-slate-300">Opportunities</span>
+          <nav className="flex items-center gap-1.5 text-xs text-slate-500 mb-6" aria-label="Breadcrumb">
+            <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <Link href="/invest" className="hover:text-slate-900 transition-colors">Invest</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <Link href="/invest/startups" className="hover:text-slate-900 transition-colors">Startups</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <span className="text-slate-900 font-medium">Opportunities</span>
           </nav>
-          <h1 className="text-3xl md:text-4xl font-extrabold mb-3">Startup Investment Opportunities</h1>
-          <p className="text-slate-300 text-base max-w-2xl">
+          <h1 className="text-3xl md:text-4xl font-extrabold mb-3 text-slate-900">Startup Investment Opportunities</h1>
+          <p className="text-slate-600 text-base max-w-2xl">
             {listings.length > 0
               ? `${listings.length} Australian startup${listings.length !== 1 ? "s" : ""} raising capital`
               : "Australian startups and growth companies raising capital from investors"}

--- a/app/invest/startups/opportunities/[slug]/page.tsx
+++ b/app/invest/startups/opportunities/[slug]/page.tsx
@@ -88,14 +88,14 @@ export default async function StartupOpportunityDetailPage({
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
       />
 
-      <section className="bg-gradient-to-br from-rose-900 via-slate-900 to-slate-900 text-white py-12">
+      <section className="bg-white border-b border-slate-100 py-12">
         <div className="container-custom">
-          <nav className="flex items-center gap-1.5 text-xs text-slate-400 mb-4" aria-label="Breadcrumb">
-            <Link href="/" className="hover:text-white transition-colors">Home</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <Link href="/invest/startups/opportunities" className="hover:text-white transition-colors">Startup Opportunities</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-600" />
-            <span className="text-slate-300 truncate max-w-[160px]">{l.title}</span>
+          <nav className="flex items-center gap-1.5 text-xs text-slate-500 mb-4" aria-label="Breadcrumb">
+            <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <Link href="/invest/startups/opportunities" className="hover:text-slate-900 transition-colors">Startup Opportunities</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <span className="text-slate-900 font-medium truncate max-w-[160px]">{l.title}</span>
           </nav>
 
           <div className="flex flex-wrap gap-2 mb-3">
@@ -117,9 +117,9 @@ export default async function StartupOpportunityDetailPage({
             )}
           </div>
 
-          <h1 className="text-2xl md:text-3xl font-extrabold mb-2">{l.title}</h1>
+          <h1 className="text-2xl md:text-3xl font-extrabold mb-2 text-slate-900">{l.title}</h1>
           {location && (
-            <div className="flex items-center gap-1.5 text-slate-300 text-sm">
+            <div className="flex items-center gap-1.5 text-slate-600 text-sm">
               <Icon name="map-pin" size={14} />
               {location}
             </div>


### PR DESCRIPTION
Converted every remaining dark gradient hero across the entire invest section — all listing client components AND detail pages.

10 listing client components:
- BusinessListingsClient, CommercialListingsClient, FarmlandListingsClient
- FranchiseListingsClient, MiningListingsClient, EnergyListingsClient
- StartupListingsClient, AlternativesListingsClient
- InfrastructureListingsClient, PrivateCreditListingsClient

10 detail pages ([slug]/page.tsx):
- buy-business, commercial-property, farmland, franchise, mining
- renewable-energy, startups, alternatives, infrastructure, private-credit

Changes per file:
- Dark gradient → bg-white border-b border-slate-100
- Breadcrumbs: white text → slate-500/900
- H1: added text-slate-900
- Subtitles: text-slate-300 → text-slate-600

Zero dark gradient heroes remaining anywhere in /app/invest/.

https://claude.ai/code/session_01Pm4P3VYciJpVNYAdyJzsSn