### PR TITLE
feat(hero): single CTA with universal intent picker modal

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,6 +15,7 @@ import { FeesFreshnessIndicator } from "@/components/FeesFreshnessIndicator";
 import { getMostRecentFeeCheck } from "@/lib/utils";
 import { ORGANIZATION_JSONLD, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
 import MobileStickyAdvisorCta from "@/components/MobileStickyAdvisorCta";
+import HeroIntentButton from "@/components/HeroIntentButton";
 import { PRIMARY_CTA_TEXT, PRIMARY_CTA_HREF, SECONDARY_CTA_TEXT, SECONDARY_CTA_HREF, SHOW_MATCH_LANGUAGE, SHOW_EDITORIAL_BADGES, SHOW_RATINGS, PLATFORM_COMPARE_HEADING, PLATFORM_COMPARE_SUBTEXT, FACTUAL_COMPARISON_DISCLAIMER } from "@/lib/compliance-config";
 
 export const metadata = {
@@ -168,46 +169,20 @@ export default async function HomePage() {
               Compare fees, browse directories, and explore investment options — built for Australians.
             </p>
 
-            {/* Intent router — 3 equal pathways */}
-            <p className="text-xs font-bold uppercase tracking-wider text-slate-400 mb-3">What are you looking for?</p>
-            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 max-w-2xl mx-auto mb-6">
-              <Link
-                href="/compare"
-                className="group flex flex-col items-center gap-2 p-4 bg-white border-2 border-slate-200 rounded-2xl hover:border-amber-400 hover:shadow-lg transition-all"
-              >
-                <div className="w-11 h-11 rounded-xl bg-amber-50 flex items-center justify-center group-hover:bg-amber-100 transition-colors">
-                  <Icon name="bar-chart-2" size={20} className="text-amber-600" />
-                </div>
-                <div className="text-center">
-                  <p className="text-sm font-bold text-slate-900 group-hover:text-amber-600 transition-colors">Compare Platforms</p>
-                  <p className="text-[0.65rem] text-slate-500 mt-0.5">{brokerCount}+ platforms &middot; fees &middot; features</p>
-                </div>
-              </Link>
-              <Link
-                href="/advisors"
-                className="group flex flex-col items-center gap-2 p-4 bg-white border-2 border-slate-200 rounded-2xl hover:border-amber-400 hover:shadow-lg transition-all"
-              >
-                <div className="w-11 h-11 rounded-xl bg-slate-100 flex items-center justify-center group-hover:bg-amber-50 transition-colors">
-                  <Icon name="users" size={20} className="text-slate-600 group-hover:text-amber-600" />
-                </div>
-                <div className="text-center">
-                  <p className="text-sm font-bold text-slate-900 group-hover:text-amber-600 transition-colors">Browse Professionals</p>
-                  <p className="text-[0.65rem] text-slate-500 mt-0.5">Planners &middot; brokers &middot; accountants</p>
-                </div>
-              </Link>
-              <Link
-                href="/invest"
-                className="group flex flex-col items-center gap-2 p-4 bg-white border-2 border-slate-200 rounded-2xl hover:border-amber-400 hover:shadow-lg transition-all"
-              >
-                <div className="w-11 h-11 rounded-xl bg-slate-100 flex items-center justify-center group-hover:bg-amber-50 transition-colors">
-                  <Icon name="layers" size={20} className="text-slate-600 group-hover:text-amber-600" />
-                </div>
-                <div className="text-center">
-                  <p className="text-sm font-bold text-slate-900 group-hover:text-amber-600 transition-colors">Explore Investments</p>
-                  <p className="text-[0.65rem] text-slate-500 mt-0.5">27 categories &middot; marketplace &middot; guides</p>
-                </div>
-              </Link>
+            {/* Single CTA → opens intent picker */}
+            <div className="mb-4">
+              <HeroIntentButton />
             </div>
+
+            {/* Fallback text links */}
+            <p className="text-sm text-slate-500 mb-6">
+              Or jump to:{" "}
+              <Link href="/compare" className="font-semibold text-slate-700 hover:text-amber-600 underline underline-offset-2 decoration-slate-300 hover:decoration-amber-400 transition-colors">platforms</Link>
+              {" · "}
+              <Link href="/advisors" className="font-semibold text-slate-700 hover:text-amber-600 underline underline-offset-2 decoration-slate-300 hover:decoration-amber-400 transition-colors">professionals</Link>
+              {" · "}
+              <Link href="/invest" className="font-semibold text-slate-700 hover:text-amber-600 underline underline-offset-2 decoration-slate-300 hover:decoration-amber-400 transition-colors">investments</Link>
+            </p>
 
             {/* Trust bar */}
             <div className="flex items-center justify-center flex-wrap gap-x-5 gap-y-1.5 text-sm font-semibold text-slate-600">

--- a/components/HeroIntentButton.tsx
+++ b/components/HeroIntentButton.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useState } from "react";
+import dynamic from "next/dynamic";
+import Icon from "@/components/Icon";
+
+const IntentPicker = dynamic(() => import("@/components/IntentPicker"), { ssr: false });
+
+export default function HeroIntentButton() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <button
+        onClick={() => setOpen(true)}
+        className="inline-flex items-center justify-center gap-2.5 px-10 py-4 bg-amber-500 hover:bg-amber-400 text-slate-900 font-extrabold text-base rounded-xl transition-all shadow-lg shadow-amber-500/25 hover:-translate-y-0.5 active:scale-[0.97] w-full sm:w-auto cursor-pointer"
+      >
+        What are you looking for?
+        <Icon name="arrow-right" size={18} />
+      </button>
+      <IntentPicker isOpen={open} onClose={() => setOpen(false)} />
+    </>
+  );
+}

--- a/components/IntentPicker.tsx
+++ b/components/IntentPicker.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import Link from "next/link";
+import Icon from "@/components/Icon";
+
+const SECTIONS = [
+  {
+    title: "Compare Platforms",
+    icon: "bar-chart-2",
+    items: [
+      { label: "Share Trading", href: "/compare?filter=shares", icon: "trending-up", desc: "ASX & international" },
+      { label: "Crypto Exchanges", href: "/compare?filter=crypto", icon: "bitcoin", desc: "AUSTRAC-registered" },
+      { label: "Super Funds", href: "/compare/super", icon: "shield", desc: "Fees & performance" },
+      { label: "Savings Accounts", href: "/compare?filter=savings", icon: "piggy-bank", desc: "High interest rates" },
+      { label: "ETFs", href: "/compare/etfs", icon: "layers", desc: "Index & thematic" },
+      { label: "CFD & Forex", href: "/compare?filter=cfd", icon: "repeat", desc: "Derivatives trading" },
+    ],
+  },
+  {
+    title: "Browse Professionals",
+    icon: "users",
+    items: [
+      { label: "Financial Planners", href: "/advisors/financial-planners", icon: "briefcase", desc: "Wealth & retirement" },
+      { label: "Mortgage Brokers", href: "/advisors/mortgage-brokers", icon: "home", desc: "Compare 30+ lenders" },
+      { label: "SMSF Accountants", href: "/advisors/smsf-accountants", icon: "calculator", desc: "Super specialists" },
+      { label: "Tax Agents", href: "/advisors/tax-agents", icon: "file-text", desc: "CGT & deductions" },
+      { label: "Buyer's Agents", href: "/advisors/buyers-agents", icon: "map-pin", desc: "Off-market access" },
+      { label: "Insurance Brokers", href: "/advisors/insurance-brokers", icon: "shield", desc: "Life & income" },
+    ],
+  },
+  {
+    title: "Explore Investments",
+    icon: "layers",
+    items: [
+      { label: "Businesses for Sale", href: "/invest/buy-business", icon: "briefcase", desc: "SME acquisitions" },
+      { label: "Mining & Resources", href: "/invest/mining", icon: "layers", desc: "Gold, lithium, copper" },
+      { label: "Farmland", href: "/invest/farmland", icon: "leaf", desc: "Cropping & pastoral" },
+      { label: "Commercial Property", href: "/invest/commercial-property", icon: "building", desc: "Office, industrial" },
+      { label: "Alternatives", href: "/invest/alternatives", icon: "gem", desc: "Wine, art, cars" },
+      { label: "All 27 Verticals", href: "/invest", icon: "compass", desc: "View everything" },
+    ],
+  },
+];
+
+export default function IntentPicker({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) {
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    },
+    [onClose]
+  );
+
+  useEffect(() => {
+    if (isOpen) {
+      document.addEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = "hidden";
+    }
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = "";
+    };
+  }, [isOpen, handleKeyDown]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-[200]" role="dialog" aria-modal="true" aria-label="What are you looking for?">
+      {/* Backdrop */}
+      <div className="absolute inset-0 bg-slate-900/50 backdrop-blur-sm" onClick={onClose} />
+
+      {/* Panel */}
+      <div className="relative max-w-2xl mx-auto mt-[5vh] sm:mt-[8vh] px-4">
+        <div className="bg-white rounded-2xl shadow-2xl border border-slate-200 overflow-hidden max-h-[85vh] overflow-y-auto">
+          {/* Header */}
+          <div className="sticky top-0 bg-white z-10 px-6 pt-5 pb-3 border-b border-slate-100 flex items-center justify-between">
+            <div>
+              <h2 className="text-lg font-extrabold text-slate-900">What are you looking for?</h2>
+              <p className="text-xs text-slate-500 mt-0.5">Choose a category to get started</p>
+            </div>
+            <button
+              onClick={onClose}
+              className="p-2 rounded-lg hover:bg-slate-100 transition-colors text-slate-400 hover:text-slate-600"
+              aria-label="Close"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
+            </button>
+          </div>
+
+          {/* Sections */}
+          <div className="p-5 space-y-6">
+            {SECTIONS.map((section) => (
+              <div key={section.title}>
+                <div className="flex items-center gap-2 mb-3">
+                  <Icon name={section.icon} size={16} className="text-amber-500" />
+                  <p className="text-xs font-bold uppercase tracking-wider text-amber-600">{section.title}</p>
+                </div>
+                <div className="grid grid-cols-2 sm:grid-cols-3 gap-2.5">
+                  {section.items.map((item) => (
+                    <Link
+                      key={item.href}
+                      href={item.href}
+                      onClick={onClose}
+                      className="group flex items-start gap-3 p-3 rounded-xl border border-slate-150 hover:border-amber-300 hover:bg-amber-50/40 transition-all"
+                    >
+                      <div className="w-8 h-8 rounded-lg bg-slate-100 group-hover:bg-amber-100 flex items-center justify-center shrink-0 transition-colors">
+                        <Icon name={item.icon} size={14} className="text-slate-500 group-hover:text-amber-600" />
+                      </div>
+                      <div className="min-w-0">
+                        <p className="text-sm font-semibold text-slate-900 group-hover:text-amber-700 leading-tight">{item.label}</p>
+                        <p className="text-[0.65rem] text-slate-400 leading-tight mt-0.5">{item.desc}</p>
+                      </div>
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Footer */}
+          <div className="px-6 py-4 border-t border-slate-100 bg-slate-50/50 text-center">
+            <p className="text-xs text-slate-500">
+              Or browse everything:{" "}
+              <Link href="/compare" onClick={onClose} className="font-semibold text-slate-700 hover:text-amber-600 underline underline-offset-2 decoration-slate-300">platforms</Link>
+              {" · "}
+              <Link href="/advisors" onClick={onClose} className="font-semibold text-slate-700 hover:text-amber-600 underline underline-offset-2 decoration-slate-300">professionals</Link>
+              {" · "}
+              <Link href="/invest" onClick={onClose} className="font-semibold text-slate-700 hover:text-amber-600 underline underline-offset-2 decoration-slate-300">investments</Link>
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Replaces the 3-card intent router with ONE amber button: "What are you looking for?" → opens a clean modal picker.

IntentPicker modal (new component):
- 3 grouped sections: Compare Platforms, Browse Professionals, Explore Investments
- 6 cards per section with icons and descriptions
- Compare: Shares, Crypto, Super, Savings, ETFs, CFD/Forex
- Professionals: Financial Planners, Mortgage Brokers, SMSF, Tax Agents, Buyer's Agents, Insurance Brokers
- Investments: Businesses, Mining, Farmland, Commercial Property, Alternatives, All 27 Verticals
- Keyboard accessible (Escape to close)
- "Or browse everything" footer with direct links
- Sticky header, scrollable content, responsive grid

HeroIntentButton (new component):
- Client component that manages modal state
- Dynamically imports IntentPicker (no SSR)
- Clean amber button with arrow icon

Why this is better:
- ONE clear action instead of 3 competing cards
- All 3 revenue streams accessible in 2 clicks max
- Compliant: pure navigation, no advice, no circumstances
- Mobile-friendly: modal vs 3 stacked cards

https://claude.ai/code/session_01Pm4P3VYciJpVNYAdyJzsSn