### PR TITLE
feat(listings): comprehensive filter upgrade — search, sort, vertical…

### DIFF
--- a/components/UnifiedListingsClient.tsx
+++ b/components/UnifiedListingsClient.tsx
@@ -6,6 +6,8 @@ import { useRouter, useSearchParams } from "next/navigation";
 import ListingCard, { type InvestmentListing } from "@/components/ListingCard";
 import Icon from "@/components/Icon";
 
+// ─── Vertical definitions ────────────────────────────────────────────────────
+
 const VERTICALS = [
   { value: "all", label: "All Categories", icon: "layers" },
   { value: "business", label: "Businesses", icon: "briefcase" },
@@ -21,6 +23,8 @@ const VERTICALS = [
   { value: "infrastructure", label: "Infrastructure", icon: "git-branch" },
 ];
 
+// ─── Shared filters ──────────────────────────────────────────────────────────
+
 const STATES = ["All", "NSW", "VIC", "QLD", "WA", "SA", "TAS", "ACT", "NT"];
 
 const PRICE_RANGES = [
@@ -32,6 +36,125 @@ const PRICE_RANGES = [
   { value: "over_20m", label: "$20M+" },
 ];
 
+const SORT_OPTIONS = [
+  { value: "featured", label: "Featured First" },
+  { value: "newest", label: "Newest First" },
+  { value: "price_asc", label: "Price: Low → High" },
+  { value: "price_desc", label: "Price: High → Low" },
+];
+
+// ─── Vertical-specific secondary filters ─────────────────────────────────────
+
+const SECONDARY_FILTERS: Record<string, { key: string; label: string; options: { value: string; label: string }[] }> = {
+  business: {
+    key: "industry",
+    label: "Industry",
+    options: [
+      { value: "all", label: "All Industries" },
+      { value: "Hospitality", label: "Hospitality" },
+      { value: "Retail", label: "Retail" },
+      { value: "Professional Services", label: "Professional Services" },
+      { value: "Services", label: "Services" },
+      { value: "Healthcare", label: "Healthcare" },
+      { value: "Education & Childcare", label: "Education" },
+      { value: "Trade Services", label: "Trade Services" },
+      { value: "Transport & Logistics", label: "Transport" },
+    ],
+  },
+  mining: {
+    key: "sub_category",
+    label: "Commodity",
+    options: [
+      { value: "all", label: "All Commodities" },
+      { value: "Gold", label: "Gold" },
+      { value: "Lithium", label: "Lithium" },
+      { value: "Copper", label: "Copper" },
+      { value: "Iron Ore", label: "Iron Ore" },
+      { value: "Rare Earths", label: "Rare Earths" },
+      { value: "Silver", label: "Silver" },
+      { value: "Nickel", label: "Nickel" },
+    ],
+  },
+  farmland: {
+    key: "sub_category",
+    label: "Type",
+    options: [
+      { value: "all", label: "All Types" },
+      { value: "Cropping", label: "Cropping" },
+      { value: "Pastoral", label: "Pastoral / Beef" },
+      { value: "Dairy", label: "Dairy" },
+      { value: "Viticulture", label: "Viticulture / Wine" },
+      { value: "Horticulture", label: "Horticulture" },
+      { value: "Mixed", label: "Mixed Farming" },
+    ],
+  },
+  commercial_property: {
+    key: "sub_category",
+    label: "Asset Class",
+    options: [
+      { value: "all", label: "All Classes" },
+      { value: "Office", label: "Office" },
+      { value: "Industrial", label: "Industrial" },
+      { value: "Retail", label: "Retail" },
+      { value: "Hotel", label: "Hotel" },
+      { value: "Childcare", label: "Childcare" },
+      { value: "Medical", label: "Medical" },
+    ],
+  },
+  franchise: {
+    key: "industry",
+    label: "Industry",
+    options: [
+      { value: "all", label: "All Industries" },
+      { value: "Food & Beverage", label: "Food & Beverage" },
+      { value: "Fitness", label: "Fitness" },
+      { value: "Home Services", label: "Home Services" },
+      { value: "Automotive", label: "Automotive" },
+      { value: "Education", label: "Education" },
+    ],
+  },
+  energy: {
+    key: "sub_category",
+    label: "Technology",
+    options: [
+      { value: "all", label: "All Technologies" },
+      { value: "Solar", label: "Solar" },
+      { value: "Wind", label: "Wind" },
+      { value: "Battery", label: "Battery Storage" },
+      { value: "Hydrogen", label: "Hydrogen" },
+      { value: "Hydro", label: "Hydro" },
+    ],
+  },
+  startup: {
+    key: "industry",
+    label: "Sector",
+    options: [
+      { value: "all", label: "All Sectors" },
+      { value: "Fintech", label: "Fintech" },
+      { value: "Healthtech", label: "Healthtech" },
+      { value: "Proptech", label: "Proptech" },
+      { value: "Cleantech", label: "Cleantech" },
+      { value: "Agtech", label: "Agtech" },
+      { value: "Edtech", label: "Edtech" },
+    ],
+  },
+  alternatives: {
+    key: "sub_category",
+    label: "Category",
+    options: [
+      { value: "all", label: "All Categories" },
+      { value: "Wine", label: "Wine" },
+      { value: "Art", label: "Art" },
+      { value: "Cars", label: "Classic Cars" },
+      { value: "Watches", label: "Watches" },
+      { value: "Coins", label: "Coins" },
+      { value: "Whisky", label: "Whisky" },
+    ],
+  },
+};
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
 export default function UnifiedListingsClient({ listings }: { listings: InvestmentListing[] }) {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -39,7 +162,11 @@ export default function UnifiedListingsClient({ listings }: { listings: Investme
   const activeVertical = searchParams.get("vertical") || "all";
   const activeState = searchParams.get("state") || "All";
   const activePrice = searchParams.get("price") || "all";
+  const activeSort = searchParams.get("sort") || "featured";
+  const activeSecondary = searchParams.get("secondary") || "all";
   const firbOnly = searchParams.get("firb") === "true";
+  const sivOnly = searchParams.get("siv") === "true";
+  const searchQuery = searchParams.get("q") || "";
 
   function setParam(key: string, value: string) {
     const params = new URLSearchParams(searchParams.toString());
@@ -51,21 +178,54 @@ export default function UnifiedListingsClient({ listings }: { listings: Investme
     router.push(`/invest/listings${params.toString() ? `?${params.toString()}` : ""}`, { scroll: false });
   }
 
-  function toggleFirb() {
+  function setVertical(value: string) {
+    const params = new URLSearchParams();
+    if (value !== "all") params.set("vertical", value);
+    // Reset secondary filter when changing vertical
+    router.push(`/invest/listings${params.toString() ? `?${params.toString()}` : ""}`, { scroll: false });
+  }
+
+  function toggleBool(key: string, current: boolean) {
     const params = new URLSearchParams(searchParams.toString());
-    if (firbOnly) {
-      params.delete("firb");
-    } else {
-      params.set("firb", "true");
-    }
+    if (current) params.delete(key);
+    else params.set(key, "true");
     router.push(`/invest/listings?${params.toString()}`, { scroll: false });
   }
 
+  function clearAll() {
+    router.push("/invest/listings", { scroll: false });
+  }
+
+  // Active filter count (excluding vertical and sort)
+  const activeFilterCount = [
+    activeState !== "All",
+    activePrice !== "all",
+    activeSecondary !== "all",
+    firbOnly,
+    sivOnly,
+    searchQuery.length > 0,
+  ].filter(Boolean).length;
+
+  // Secondary filter config for current vertical
+  const secondaryFilter = SECONDARY_FILTERS[activeVertical] || null;
+
+  // ─── Filter + Sort ─────────────────────────────────────────────────────────
+
   const filtered = useMemo(() => {
-    return listings.filter((l) => {
+    let result = listings.filter((l) => {
       if (activeVertical !== "all" && l.vertical !== activeVertical) return false;
       if (activeState !== "All" && l.location_state !== activeState) return false;
       if (firbOnly && !l.firb_eligible) return false;
+      if (sivOnly && !l.siv_complying) return false;
+
+      // Secondary filter (industry or sub_category)
+      if (activeSecondary !== "all" && secondaryFilter) {
+        const field = secondaryFilter.key as keyof InvestmentListing;
+        const val = l[field] as string | null;
+        if (!val || !val.toLowerCase().includes(activeSecondary.toLowerCase())) return false;
+      }
+
+      // Price range
       if (activePrice !== "all") {
         const price = l.asking_price_cents ?? 0;
         switch (activePrice) {
@@ -76,11 +236,39 @@ export default function UnifiedListingsClient({ listings }: { listings: Investme
           case "over_20m": if (price < 2000000000) return false; break;
         }
       }
+
+      // Keyword search
+      if (searchQuery) {
+        const q = searchQuery.toLowerCase();
+        const haystack = `${l.title} ${l.description || ""} ${l.industry || ""} ${l.sub_category || ""} ${l.location_city || ""} ${l.location_state || ""}`.toLowerCase();
+        if (!haystack.includes(q)) return false;
+      }
+
       return true;
     });
-  }, [listings, activeVertical, activeState, activePrice, firbOnly]);
 
-  // Count per vertical for pills
+    // Sort
+    switch (activeSort) {
+      case "newest":
+        result.sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
+        break;
+      case "price_asc":
+        result.sort((a, b) => (a.asking_price_cents ?? 0) - (b.asking_price_cents ?? 0));
+        break;
+      case "price_desc":
+        result.sort((a, b) => (b.asking_price_cents ?? 0) - (a.asking_price_cents ?? 0));
+        break;
+      default: // featured
+        result.sort((a, b) => {
+          const typeOrder: Record<string, number> = { premium: 3, featured: 2, standard: 1 };
+          return (typeOrder[b.listing_type] || 0) - (typeOrder[a.listing_type] || 0);
+        });
+    }
+
+    return result;
+  }, [listings, activeVertical, activeState, activePrice, activeSort, activeSecondary, firbOnly, sivOnly, searchQuery, secondaryFilter]);
+
+  // Count per vertical
   const verticalCounts = useMemo(() => {
     const counts: Record<string, number> = { all: listings.length };
     for (const l of listings) {
@@ -89,7 +277,19 @@ export default function UnifiedListingsClient({ listings }: { listings: Investme
     return counts;
   }, [listings]);
 
+  // Count per state (for current vertical)
+  const stateCounts = useMemo(() => {
+    const base = activeVertical === "all" ? listings : listings.filter((l) => l.vertical === activeVertical);
+    const counts: Record<string, number> = { All: base.length };
+    for (const l of base) {
+      if (l.location_state) counts[l.location_state] = (counts[l.location_state] || 0) + 1;
+    }
+    return counts;
+  }, [listings, activeVertical]);
+
   const activeLabel = VERTICALS.find((v) => v.value === activeVertical)?.label || "All";
+
+  // ─── Render ────────────────────────────────────────────────────────────────
 
   return (
     <div>
@@ -129,7 +329,7 @@ export default function UnifiedListingsClient({ listings }: { listings: Investme
               return (
                 <button
                   key={v.value}
-                  onClick={() => setParam("vertical", v.value)}
+                  onClick={() => setVertical(v.value)}
                   className={`shrink-0 flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-semibold transition-all ${
                     isActive
                       ? "bg-amber-500 text-slate-900 shadow-sm"
@@ -151,46 +351,93 @@ export default function UnifiedListingsClient({ listings }: { listings: Investme
         </div>
       </section>
 
-      {/* Filters */}
+      {/* Filters bar */}
       <section className="bg-white border-b border-slate-200 py-3 sticky top-[68px] z-10 shadow-sm">
         <div className="container-custom">
-          <div className="flex items-center gap-3 flex-wrap">
-            {/* State filter */}
-            <div className="flex items-center gap-1.5">
-              <Icon name="map-pin" size={14} className="text-slate-400" />
-              <select
-                value={activeState}
-                onChange={(e) => setParam("state", e.target.value)}
-                className="text-sm border border-slate-200 rounded-lg px-3 py-1.5 bg-white text-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400"
-              >
-                {STATES.map((s) => (
-                  <option key={s} value={s}>{s === "All" ? "All States" : s}</option>
-                ))}
-              </select>
+          <div className="flex items-center gap-2.5 flex-wrap">
+            {/* Search */}
+            <div className="relative flex-1 min-w-[160px] max-w-[280px]">
+              <Icon name="search" size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400" />
+              <input
+                type="text"
+                value={searchQuery}
+                onChange={(e) => setParam("q", e.target.value)}
+                placeholder="Search listings..."
+                className="w-full pl-9 pr-3 py-1.5 text-sm border border-slate-200 rounded-lg bg-white text-slate-700 placeholder:text-slate-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400"
+              />
             </div>
 
-            {/* Price filter */}
+            {/* State */}
+            <select
+              value={activeState}
+              onChange={(e) => setParam("state", e.target.value)}
+              className="text-sm border border-slate-200 rounded-lg px-2.5 py-1.5 bg-white text-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400"
+            >
+              {STATES.map((s) => (
+                <option key={s} value={s}>
+                  {s === "All" ? "All States" : s}{stateCounts[s] ? ` (${stateCounts[s]})` : ""}
+                </option>
+              ))}
+            </select>
+
+            {/* Secondary filter (vertical-specific) */}
+            {secondaryFilter && (
+              <select
+                value={activeSecondary}
+                onChange={(e) => setParam("secondary", e.target.value)}
+                className="text-sm border border-slate-200 rounded-lg px-2.5 py-1.5 bg-white text-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400"
+              >
+                {secondaryFilter.options.map((o) => (
+                  <option key={o.value} value={o.value}>{o.label}</option>
+                ))}
+              </select>
+            )}
+
+            {/* Price */}
             <select
               value={activePrice}
               onChange={(e) => setParam("price", e.target.value)}
-              className="text-sm border border-slate-200 rounded-lg px-3 py-1.5 bg-white text-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400"
+              className="text-sm border border-slate-200 rounded-lg px-2.5 py-1.5 bg-white text-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400"
             >
               {PRICE_RANGES.map((p) => (
                 <option key={p.value} value={p.value}>{p.label}</option>
               ))}
             </select>
 
+            {/* Sort */}
+            <select
+              value={activeSort}
+              onChange={(e) => setParam("sort", e.target.value)}
+              className="text-sm border border-slate-200 rounded-lg px-2.5 py-1.5 bg-white text-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400"
+            >
+              {SORT_OPTIONS.map((s) => (
+                <option key={s.value} value={s.value}>{s.label}</option>
+              ))}
+            </select>
+
             {/* FIRB toggle */}
             <button
-              onClick={toggleFirb}
-              className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold border transition-all ${
+              onClick={() => toggleBool("firb", firbOnly)}
+              className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-semibold border transition-all ${
                 firbOnly
                   ? "bg-blue-50 text-blue-700 border-blue-200"
                   : "bg-white text-slate-500 border-slate-200 hover:border-slate-300"
               }`}
             >
               <Icon name="globe" size={13} />
-              FIRB Eligible
+              FIRB
+            </button>
+
+            {/* SIV toggle */}
+            <button
+              onClick={() => toggleBool("siv", sivOnly)}
+              className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-semibold border transition-all ${
+                sivOnly
+                  ? "bg-purple-50 text-purple-700 border-purple-200"
+                  : "bg-white text-slate-500 border-slate-200 hover:border-slate-300"
+              }`}
+            >
+              SIV
             </button>
 
             {/* Result count */}
@@ -198,6 +445,46 @@ export default function UnifiedListingsClient({ listings }: { listings: Investme
               {filtered.length} result{filtered.length !== 1 ? "s" : ""}
             </span>
           </div>
+
+          {/* Active filter summary */}
+          {activeFilterCount > 0 && (
+            <div className="flex items-center gap-2 mt-2 flex-wrap">
+              <span className="text-xs text-slate-400">Active filters:</span>
+              {activeState !== "All" && (
+                <button onClick={() => setParam("state", "All")} className="inline-flex items-center gap-1 px-2 py-0.5 bg-slate-100 text-slate-600 rounded-full text-xs hover:bg-slate-200 transition-colors">
+                  {activeState} <span className="text-slate-400">&times;</span>
+                </button>
+              )}
+              {activePrice !== "all" && (
+                <button onClick={() => setParam("price", "all")} className="inline-flex items-center gap-1 px-2 py-0.5 bg-slate-100 text-slate-600 rounded-full text-xs hover:bg-slate-200 transition-colors">
+                  {PRICE_RANGES.find((p) => p.value === activePrice)?.label} <span className="text-slate-400">&times;</span>
+                </button>
+              )}
+              {activeSecondary !== "all" && secondaryFilter && (
+                <button onClick={() => setParam("secondary", "all")} className="inline-flex items-center gap-1 px-2 py-0.5 bg-slate-100 text-slate-600 rounded-full text-xs hover:bg-slate-200 transition-colors">
+                  {secondaryFilter.options.find((o) => o.value === activeSecondary)?.label} <span className="text-slate-400">&times;</span>
+                </button>
+              )}
+              {firbOnly && (
+                <button onClick={() => toggleBool("firb", true)} className="inline-flex items-center gap-1 px-2 py-0.5 bg-blue-50 text-blue-600 rounded-full text-xs hover:bg-blue-100 transition-colors">
+                  FIRB Eligible <span className="text-blue-400">&times;</span>
+                </button>
+              )}
+              {sivOnly && (
+                <button onClick={() => toggleBool("siv", true)} className="inline-flex items-center gap-1 px-2 py-0.5 bg-purple-50 text-purple-600 rounded-full text-xs hover:bg-purple-100 transition-colors">
+                  SIV Complying <span className="text-purple-400">&times;</span>
+                </button>
+              )}
+              {searchQuery && (
+                <button onClick={() => setParam("q", "")} className="inline-flex items-center gap-1 px-2 py-0.5 bg-slate-100 text-slate-600 rounded-full text-xs hover:bg-slate-200 transition-colors">
+                  &ldquo;{searchQuery}&rdquo; <span className="text-slate-400">&times;</span>
+                </button>
+              )}
+              <button onClick={clearAll} className="text-xs text-amber-600 font-semibold hover:text-amber-700 ml-1">
+                Clear all
+              </button>
+            </div>
+          )}
         </div>
       </section>
 
@@ -216,9 +503,11 @@ export default function UnifiedListingsClient({ listings }: { listings: Investme
                 <Icon name="search" size={24} className="text-slate-400" />
               </div>
               <h3 className="text-lg font-bold text-slate-900 mb-2">No listings found</h3>
-              <p className="text-slate-500 text-sm mb-6">Try adjusting your filters, or check back soon as new listings are added regularly.</p>
+              <p className="text-slate-500 text-sm mb-6 max-w-md mx-auto">
+                Try adjusting your filters or search term. New listings are added regularly.
+              </p>
               <button
-                onClick={() => router.push("/invest/listings")}
+                onClick={clearAll}
                 className="px-5 py-2.5 bg-amber-500 text-slate-900 text-sm font-bold rounded-xl hover:bg-amber-400 transition-colors"
               >
                 Clear all filters
@@ -234,13 +523,59 @@ export default function UnifiedListingsClient({ listings }: { listings: Investme
         </div>
       </section>
 
+      {/* Save search / email alert */}
+      <section className="py-8 bg-white border-t border-slate-100">
+        <div className="container-custom">
+          <div className="max-w-lg mx-auto bg-amber-50 border border-amber-100 rounded-xl p-5 text-center">
+            <Icon name="bell" size={20} className="text-amber-500 mx-auto mb-2" />
+            <h3 className="text-sm font-bold text-slate-900 mb-1">Get notified about new listings</h3>
+            <p className="text-xs text-slate-500 mb-3">
+              {activeVertical !== "all"
+                ? `We'll email you when new ${activeLabel.toLowerCase()} listings are added.`
+                : "We'll email you when new investment listings are added."}
+            </p>
+            <form
+              onSubmit={(e) => {
+                e.preventDefault();
+                const form = e.target as HTMLFormElement;
+                const email = (form.elements.namedItem("alert_email") as HTMLInputElement)?.value;
+                if (email) {
+                  fetch("/api/email-capture", {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ email, source: `listing-alert-${activeVertical}` }),
+                  });
+                  form.reset();
+                  alert("You'll be notified when new listings are added.");
+                }
+              }}
+              className="flex gap-2 max-w-sm mx-auto"
+            >
+              <input
+                name="alert_email"
+                type="email"
+                placeholder="you@email.com"
+                required
+                className="flex-1 px-3 py-2 text-sm border border-amber-200 rounded-lg bg-white text-slate-700 placeholder:text-slate-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400"
+              />
+              <button
+                type="submit"
+                className="px-4 py-2 bg-amber-500 text-slate-900 text-sm font-bold rounded-lg hover:bg-amber-400 transition-colors shrink-0"
+              >
+                Notify me
+              </button>
+            </form>
+          </div>
+        </div>
+      </section>
+
       {/* List CTA */}
       <section className="py-10 bg-white border-t border-slate-100">
         <div className="container-custom">
           <div className="max-w-2xl mx-auto bg-white border border-slate-200 rounded-xl p-6 text-center">
             <h2 className="text-lg font-extrabold text-slate-900 mb-2">List Your Investment Opportunity</h2>
             <p className="text-sm text-slate-500 mb-4">
-              Advisors, brokers, and fund managers can list investment opportunities directly on Invest.com.au and reach qualified investors.
+              Advisors, brokers, and fund managers can list investment opportunities directly on Invest.com.au and reach investors.
             </p>
             <Link
               href="/invest/list"


### PR DESCRIPTION
…-specific filters, alerts

Keyword search:
- Text search across title, description, industry, sub_category, city, state
- Search icon inline with input field
- Clears via active filter summary

Sort options:
- Featured First (default — premium/featured listings top)
- Newest First
- Price: Low → High
- Price: High → Low

Vertical-specific secondary filters:
- Business: Industry (Hospitality, Retail, Services, Healthcare, etc.)
- Mining: Commodity (Gold, Lithium, Copper, Iron Ore, Rare Earths, etc.)
- Farmland: Type (Cropping, Pastoral, Dairy, Viticulture, etc.)
- Commercial Property: Asset Class (Office, Industrial, Retail, Hotel, etc.)
- Franchise: Industry (Food, Fitness, Home Services, etc.)
- Energy: Technology (Solar, Wind, Battery, Hydrogen, etc.)
- Startups: Sector (Fintech, Healthtech, Proptech, etc.)
- Alternatives: Category (Wine, Art, Cars, Watches, etc.)
- Filter appears/disappears based on selected vertical

SIV toggle:
- Purple toggle button alongside FIRB toggle
- Filters for Significant Investor Visa-complying listings

Active filter summary bar:
- Shows all active filters as removable pills
- Individual × to clear each filter
- "Clear all" link to reset everything
- Only appears when filters are active

Result counts on state filter:
- Each state option shows count: "NSW (12)"
- Counts update based on selected vertical

Save search / email alerts:
- "Get notified about new listings" section
- Email capture form that sends to /api/email-capture
- Source tracking includes vertical: listing-alert-{vertical}
- Contextual copy based on active vertical

https://claude.ai/code/session_01Pm4P3VYciJpVNYAdyJzsSn