### PR TITLE
fix(audit): platform count, rating column, duplicate articles, font refs

### DIFF
--- a/app/invest/page.tsx
+++ b/app/invest/page.tsx
@@ -141,7 +141,7 @@ export default async function InvestHubPage() {
             <div className="grid grid-cols-2 gap-3">
               {[
                 { icon: "layers", label: "Marketplace", sub: "Browse businesses, mining, farmland & more for sale", href: "/invest/listings", iconBg: "bg-amber-500", border: "hover:border-amber-200 hover:bg-amber-50/60" },
-                { icon: "bar-chart-2", label: "Compare Platforms", sub: "73+ platforms compared by fees, features & ratings", href: "/compare", iconBg: "bg-slate-800", border: "hover:border-slate-300 hover:bg-slate-50" },
+                { icon: "bar-chart-2", label: "Compare Platforms", sub: "100+ platforms compared by fees &amp; features", href: "/compare", iconBg: "bg-slate-800", border: "hover:border-slate-300 hover:bg-slate-50" },
                 { icon: "user-check", label: "Browse Advisors", sub: "Licensed financial planners, SMSF accountants & more", href: "/advisors", iconBg: "bg-emerald-600", border: "hover:border-emerald-200 hover:bg-emerald-50/60" },
                 { icon: "globe", label: "Foreign Investors", sub: "FIRB rules, visa pathways & 12 country guides", href: "/foreign-investment", iconBg: "bg-violet-600", border: "hover:border-violet-200 hover:bg-violet-50/60" },
               ].map((card) => (
@@ -160,7 +160,7 @@ export default async function InvestHubPage() {
           <div className="mt-8 pt-6 border-t border-slate-100 grid grid-cols-2 md:grid-cols-4 gap-4 text-center">
             {[
               { value: "27", label: "Investment Verticals" },
-              { value: "73+", label: "Platforms Compared" },
+              { value: "100+", label: "Platforms Compared" },
               { value: "100+", label: "Active Listings" },
               { value: "Free", label: "No Hidden Fees" },
             ].map((s) => (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,7 +21,7 @@ import { PRIMARY_CTA_TEXT, PRIMARY_CTA_HREF, SECONDARY_CTA_TEXT, SECONDARY_CTA_H
 export const metadata = {
   title: "Compare Platforms, Browse Advisors & Explore Investments — Invest.com.au",
   description:
-    "Australia's independent investing hub. Compare 73+ trading platforms, browse licensed professionals, and explore investment opportunities — businesses for sale, mining, farmland, commercial property & more. Always free.",
+    "Australia's independent investing hub. Compare 100+ trading platforms, browse licensed professionals, and explore investment opportunities — businesses for sale, mining, farmland, commercial property & more. Always free.",
   openGraph: {
     title: "Compare Platforms, Browse Advisors & Explore Investments — Invest.com.au",
     description: "Australia's independent investing hub. Compare trading platforms, browse licensed professionals, and explore investment listings. Always free.",
@@ -534,8 +534,8 @@ export default async function HomePage() {
                   </Link>
                 ))}
               </div>
-              {/* Mobile articles */}
-              <div className="md:hidden">
+              {/* Mobile articles (aria-hidden to prevent duplicate screen reader content) */}
+              <div className="md:hidden" aria-hidden="true">
                 {(articles as Article[])[0] && (
                   <Link href={`/article/${(articles as Article[])[0].slug}`} className="block mb-3 rounded-xl overflow-hidden border border-slate-200 group">
                     {(articles as Article[])[0].cover_image_url && (

--- a/components/HomepageComparisonTable.tsx
+++ b/components/HomepageComparisonTable.tsx
@@ -172,12 +172,14 @@ export default function HomepageComparisonTable({
               <th scope="col" className="px-3 py-2 text-left font-semibold text-[0.69rem] uppercase tracking-wider text-slate-400"><JargonTooltip term="US Fee" /></th>
               <th scope="col" className="px-3 py-2 text-left font-semibold text-[0.69rem] uppercase tracking-wider text-slate-400 whitespace-nowrap"><JargonTooltip term="Intl. Fee" /></th>
               <th scope="col" className="px-3 py-2 text-center font-semibold text-[0.69rem] uppercase tracking-wider text-slate-400"><JargonTooltip term="CHESS" /></th>
+              {SHOW_RATINGS && (
               <th scope="col" className="px-3 py-2 text-center font-semibold text-[0.69rem] uppercase tracking-wider text-slate-400">
                 <span className="flex items-center gap-1 justify-center">
                   Rating
                   <Link href="/methodology" className="text-amber-500 hover:text-amber-700 transition-colors font-normal normal-case tracking-normal text-[0.6rem]" title="How we rate platforms">(how we rate)</Link>
                 </span>
               </th>
+              )}
               <th scope="col" className="px-3 py-2 pr-5 text-center font-semibold text-[0.69rem] uppercase tracking-wider text-slate-400 w-[155px]"></th>
             </tr>
           </thead>

--- a/components/SearchOverlay.tsx
+++ b/components/SearchOverlay.tsx
@@ -14,7 +14,7 @@ interface SearchItem {
 
 const SEARCH_INDEX: SearchItem[] = [
   // Platforms
-  { title: "Compare All Platforms", href: "/compare", category: "Platforms", description: "Side-by-side comparison of 73+ platforms" },
+  { title: "Compare All Platforms", href: "/compare", category: "Platforms", description: "Side-by-side comparison of 100+ platforms" },
   { title: "Share Trading", href: "/share-trading", category: "Platforms", description: "ASX & international share brokers" },
   { title: "Crypto Exchanges", href: "/crypto", category: "Platforms", description: "AUSTRAC-registered crypto platforms" },
   { title: "Super Funds", href: "/compare/super", category: "Platforms", description: "Compare fees & performance" },

--- a/components/layout/SiteFooter.tsx
+++ b/components/layout/SiteFooter.tsx
@@ -196,7 +196,7 @@ export function SiteFooter() {
           </div>
 
           <p className="text-xs text-slate-700 mt-4">
-            73+ platforms · verified advisors · Updated {updatedDate}
+            100+ platforms · licensed professionals · Updated {updatedDate}
           </p>
         </div>
       </div>


### PR DESCRIPTION
P0 — Platform count mismatch fixed:
- Meta description: 73+ → 100+ (matches actual DB count of 108)
- Footer: 73+ → 100+
- SearchOverlay: 73+ → 100+
- Invest hub: 73+ → 100+ in hero card and stats bar
- Also changed "verified advisors" → "licensed professionals" in footer

P0 — Rating column hidden when SHOW_RATINGS is false:
- Column header now gated behind SHOW_RATINGS
- Previously header showed "Rating (how we rate)" even when all rating values were hidden, creating empty column

P1 — Syfe logo added to database:
- Updated via Supabase SQL (logo_url set)

P1 — Duplicate article DOM rendering:
- Mobile article section now has aria-hidden="true"
- Screen readers skip the duplicate mobile version
- Both variants still render for CSS-based responsive display

P1 — Unloaded fonts (Gordita/Manrope):
- Not found in codebase — likely from browser extension or third-party service. No action needed.

https://claude.ai/code/session_01Pm4P3VYciJpVNYAdyJzsSn