### PR TITLE
fix: Vercel build — cookie-free Supabase client for generateStaticParams

### DIFF
--- a/app/advisor/[slug]/page.tsx
+++ b/app/advisor/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
+import { createStaticClient } from "@/lib/supabase/static";
 import type { Professional } from "@/lib/types";
 import type { Metadata } from "next";
 import AdvisorProfileClient from "./AdvisorProfileClient";
@@ -12,7 +13,7 @@ export async function generateStaticParams() {
   if (!process.env.NEXT_PUBLIC_SUPABASE_URL || !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY) {
     return [];
   }
-  const supabase = await createClient();
+  const supabase = createStaticClient();
   const { data } = await supabase.from("professionals").select("slug").eq("status", "active");
   return (data || []).map((p) => ({ slug: p.slug }));
 }

--- a/app/article/[slug]/page.tsx
+++ b/app/article/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import { createClient } from "@/lib/supabase/server";
+import { createStaticClient } from "@/lib/supabase/static";
 import Link from "next/link";
 import Image from "next/image";
 import type { Article, Broker, TeamMember } from "@/lib/types";
@@ -25,7 +26,7 @@ export async function generateStaticParams() {
   if (!process.env.NEXT_PUBLIC_SUPABASE_URL || !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY) {
     return [];
   }
-  const supabase = await createClient();
+  const supabase = createStaticClient();
   const { data } = await supabase.from("articles").select("slug").eq("status", "published").limit(200);
   return (data || []).map((a) => ({ slug: a.slug }));
 }

--- a/app/broker/[slug]/page.tsx
+++ b/app/broker/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from "react";
 import { createClient } from "@/lib/supabase/server";
+import { createStaticClient } from "@/lib/supabase/static";
 import type { Broker, TeamMember, UserReview, BrokerReviewStats, SwitchStory, BrokerQuestion, BrokerAnswer } from "@/lib/types";
 import { notFound } from "next/navigation";
 import BrokerReviewClient from "./BrokerReviewClient";
@@ -23,7 +24,7 @@ export async function generateStaticParams() {
   if (!process.env.NEXT_PUBLIC_SUPABASE_URL || !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY) {
     return [];
   }
-  const supabase = await createClient();
+  const supabase = createStaticClient();
   const { data } = await supabase.from("brokers").select("slug").eq("status", "active");
   return (data || []).map((b) => ({ slug: b.slug }));
 }

--- a/app/newsletter/[edition]/page.tsx
+++ b/app/newsletter/[edition]/page.tsx
@@ -1,4 +1,5 @@
 import { createClient } from "@/lib/supabase/server";
+import { createStaticClient } from "@/lib/supabase/static";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
@@ -10,7 +11,7 @@ export async function generateStaticParams() {
   if (!process.env.NEXT_PUBLIC_SUPABASE_URL || !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY) {
     return [];
   }
-  const supabase = await createClient();
+  const supabase = createStaticClient();
   const { data } = await supabase
     .from("newsletter_editions")
     .select("edition_date");

--- a/app/newsletter/[edition]/page.tsx
+++ b/app/newsletter/[edition]/page.tsx
@@ -7,6 +7,9 @@ import { absoluteUrl, breadcrumbJsonLd, SITE_NAME, ORGANIZATION_JSONLD } from "@
 export const revalidate = 86400;
 
 export async function generateStaticParams() {
+  if (!process.env.NEXT_PUBLIC_SUPABASE_URL || !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY) {
+    return [];
+  }
   const supabase = await createClient();
   const { data } = await supabase
     .from("newsletter_editions")

--- a/app/property/suburbs/[slug]/page.tsx
+++ b/app/property/suburbs/[slug]/page.tsx
@@ -46,6 +46,9 @@ function advisorStateSlug(state: string): string {
 /* ─── generateStaticParams ─── */
 
 export async function generateStaticParams() {
+  if (!process.env.NEXT_PUBLIC_SUPABASE_URL || !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY) {
+    return [];
+  }
   const supabase = await createClient();
   const { data } = await supabase
     .from("suburb_data")

--- a/app/property/suburbs/[slug]/page.tsx
+++ b/app/property/suburbs/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
+import { createStaticClient } from "@/lib/supabase/static";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
 import { SUBURB_DATA_DISCLAIMER } from "@/lib/compliance";
 import Icon from "@/components/Icon";
@@ -49,7 +50,7 @@ export async function generateStaticParams() {
   if (!process.env.NEXT_PUBLIC_SUPABASE_URL || !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY) {
     return [];
   }
-  const supabase = await createClient();
+  const supabase = createStaticClient();
   const { data } = await supabase
     .from("suburb_data")
     .select("slug")

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -503,10 +503,9 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   }));
 
   // Dynamic suburb guide pages
-  const { data: suburbSlugs } = await supabase
-    .from("suburb_data")
-    .select("slug")
-    .not("slug", "is", null);
+  const { data: suburbSlugs } = supabase
+    ? await supabase.from("suburb_data").select("slug").not("slug", "is", null)
+    : { data: null };
 
   const suburbGuidePages = (suburbSlugs || []).map((s) => ({
     url: `${baseUrl}/property/suburbs/${s.slug}`,
@@ -563,9 +562,9 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   ].map((p) => ({ ...p, lastModified: new Date(), changeFrequency: "weekly" as const }));
 
   // Newsletter archive & edition pages
-  const { data: newsletterEditions } = await supabase
-    .from("newsletter_editions")
-    .select("edition_date, created_at");
+  const { data: newsletterEditions } = supabase
+    ? await supabase.from("newsletter_editions").select("edition_date, created_at")
+    : { data: null };
 
   const newsletterArchivePage = {
     url: `${baseUrl}/newsletter`,

--- a/lib/supabase/static.ts
+++ b/lib/supabase/static.ts
@@ -1,0 +1,15 @@
+import { createClient } from '@supabase/supabase-js'
+
+/**
+ * Cookie-free Supabase client for use in generateStaticParams and other
+ * build-time contexts where cookies() is not available.
+ * Uses the public anon key — safe for read-only queries (slug lists, etc.).
+ */
+export function createStaticClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  if (!url || !anonKey) {
+    throw new Error("Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY environment variable");
+  }
+  return createClient(url, anonKey);
+}


### PR DESCRIPTION
## Summary

Every Vercel deployment has been failing since `generateStaticParams` was added across 5 pages. **This PR fixes the root cause and should unblock all deployments.**

### The problem

`generateStaticParams` runs at build time, outside a request scope. The server Supabase client (`lib/supabase/server.ts`) calls `cookies()` internally, which throws:

> `cookies` was called outside a request scope

This broke builds for `/article/[slug]`, `/broker/[slug]`, `/advisor/[slug]`, `/newsletter/[edition]`, and `/property/suburbs/[slug]`.

### The fix

- **New `lib/supabase/static.ts`** — a cookie-free Supabase client using the public anon key directly via `@supabase/supabase-js`. Safe for read-only slug queries at build time.
- **Switched all 5 `generateStaticParams`** to use `createStaticClient()` instead of `createClient()`.
- **Added env var guards** for `suburb_data` and `newsletter_editions` queries in `sitemap.ts` (missed by previous PRs).

### Files changed (7)

| File | Change |
|------|--------|
| `lib/supabase/static.ts` | New cookie-free client for build-time use |
| `app/article/[slug]/page.tsx` | Use `createStaticClient()` in generateStaticParams |
| `app/broker/[slug]/page.tsx` | Same |
| `app/advisor/[slug]/page.tsx` | Same |
| `app/newsletter/[edition]/page.tsx` | Same + env var guard |
| `app/property/suburbs/[slug]/page.tsx` | Same + env var guard |
| `app/sitemap.ts` | Guard suburb_data + newsletter_editions queries |

## Test plan

- [ ] Verify Vercel deployment succeeds (this has been failing on every deploy)
- [ ] Confirm static pages pre-render correctly for brokers, articles, advisors
- [ ] Spot-check `/broker/stake`, `/article/*`, `/advisor/*` load correctly

https://claude.ai/code/session_01DyudU3Uo5eFGwXKQsYcbUw