### PR TITLE
fix: compare table — collapse borders to remove gap above first row

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -597,9 +597,9 @@ body {
 .scroll-check-stagger.is-visible > *:nth-child(5) { animation-delay: 0.5s; }
 .scroll-check-stagger.is-visible > *:nth-child(6) { animation-delay: 0.6s; }
 
-/* ── Compare table: ensure first row clears sticky header ── */
-.compare-table tbody tr:first-child > td {
-  padding-top: 1rem;
+/* ── Compare table: collapse borders to prevent gaps between thead/tbody ── */
+.compare-table {
+  border-collapse: collapse;
 }
 
 /* ── Table row stagger ─────────────────────────────── */


### PR DESCRIPTION
The previous fix added padding-top to the first row, but the real issue was the table's default border-collapse: separate causing visible spacing between thead and tbody.

- Removed the padding-top first-row hack
- Added border-collapse: collapse to .compare-table

This eliminates the empty white area between the column headers and the first broker row that was visually "covering" the editor's choice slot.

https://claude.ai/code/session_01DyudU3Uo5eFGwXKQsYcbUw