### PR TITLE
fix: remove sticky thead from compare table to fix first row cutoff

### DIFF
--- a/app/compare/_components/CompareDesktopTable.tsx
+++ b/app/compare/_components/CompareDesktopTable.tsx
@@ -142,7 +142,7 @@ export default function CompareDesktopTable({
   return (
     <div key={`${activeFilter}-${searchQuery}`} className="hidden md:block overflow-x-auto tab-content-enter">
       <ScrollReveal key={`table-${activeFilter}-${searchQuery}-${sortCol}-${sortDir}`} animation="table-row-stagger" as="table" className="w-full border border-slate-200 rounded-lg compare-table">
-        <thead className="bg-slate-50 sticky top-12 md:top-16 z-10 shadow-sm">
+        <thead className="bg-slate-50 shadow-sm">
           <tr>
             <th scope="col" className="px-3 py-3 w-10"></th>
             <th scope="col" className="px-4 py-3 text-left font-semibold text-sm" aria-sort={sortCol === 'name' ? (sortDir === 1 ? 'ascending' : 'descending') : undefined}>


### PR DESCRIPTION
Root cause of the persistent first-row cutoff:

The thead had `sticky top-12 md:top-16 z-10` which made it stick at viewport top:64 (just below the site nav) when scrolled. The first broker row's top half was getting hidden behind the sticky header, creating the visual impression of a "cutoff" broker name.

Previous fixes addressed symptoms (border-collapse gap, editor's choice label position) but not the root cause.

Fix: removed sticky positioning entirely. Trade-off is losing sticky column headers when scrolled deep into the table, but most users compare 2-5 brokers from the top so the cost is small. Eliminates the cutoff bug completely.

If sticky headers are needed back later, the proper way is to use scroll-padding-top or extract column headers into a separate sticky bar outside the table.

https://claude.ai/code/session_01DyudU3Uo5eFGwXKQsYcbUw