### PR TITLE
fix: listing detail 404s + missing images

### DIFF
--- a/app/invest/[category]/listings/[subcategory]/page.tsx
+++ b/app/invest/[category]/listings/[subcategory]/page.tsx
@@ -18,6 +18,7 @@ import {
   GENERAL_ADVICE_WARNING,
 } from "@/lib/compliance";
 import InvestListingCard from "@/components/InvestListingCard";
+import { listingUrl } from "@/lib/listing-url";
 import ScrollReveal from "@/components/ScrollReveal";
 
 export const revalidate = 3600;
@@ -102,7 +103,7 @@ export default async function InvestSubcategoryListingsPage({
       "@type": "ListItem",
       position: i + 1,
       name: l.title,
-      url: absoluteUrl(`/invest/listing/${l.slug}`),
+      url: absoluteUrl(listingUrl(l)),
     })),
   };
 

--- a/app/invest/alternatives/listings/[slug]/page.tsx
+++ b/app/invest/alternatives/listings/[slug]/page.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from "next";
 import { createClient } from "@/lib/supabase/server";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
 import Icon from "@/components/Icon";
+import ListingImageGallery from "@/components/ListingImageGallery";
 import ListingCard, { type InvestmentListing } from "@/components/ListingCard";
 import ListingEnquiryForm from "@/components/ListingEnquiryForm";
 
@@ -135,6 +136,7 @@ export default async function AlternativesListingDetailPage({
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
             {/* Left: details */}
             <div className="lg:col-span-2 space-y-6">
+              <ListingImageGallery images={l.images} alt={l.title} />
               {/* Price card */}
               <div className="bg-white border border-slate-200 rounded-xl p-6">
                 <div className="flex flex-wrap items-center justify-between gap-4">

--- a/app/invest/buy-business/listings/[slug]/page.tsx
+++ b/app/invest/buy-business/listings/[slug]/page.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from "next";
 import { createClient } from "@/lib/supabase/server";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
 import Icon from "@/components/Icon";
+import ListingImageGallery from "@/components/ListingImageGallery";
 import ListingCard, { type InvestmentListing } from "@/components/ListingCard";
 import ListingEnquiryForm from "@/components/ListingEnquiryForm";
 
@@ -135,6 +136,7 @@ export default async function BusinessListingDetailPage({
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
             {/* Left: details */}
             <div className="lg:col-span-2 space-y-6">
+              <ListingImageGallery images={l.images} alt={l.title} />
               {/* Price card */}
               <div className="bg-white border border-slate-200 rounded-xl p-6">
                 <div className="flex flex-wrap items-center justify-between gap-4">

--- a/app/invest/commercial-property/listings/[slug]/page.tsx
+++ b/app/invest/commercial-property/listings/[slug]/page.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from "next";
 import { createClient } from "@/lib/supabase/server";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
 import Icon from "@/components/Icon";
+import ListingImageGallery from "@/components/ListingImageGallery";
 import ListingCard, { type InvestmentListing } from "@/components/ListingCard";
 import ListingEnquiryForm from "@/components/ListingEnquiryForm";
 
@@ -129,6 +130,7 @@ export default async function CommercialListingDetailPage({
         <div className="container-custom">
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
             <div className="lg:col-span-2 space-y-6">
+              <ListingImageGallery images={l.images} alt={l.title} />
               <div className="bg-white border border-slate-200 rounded-xl p-6">
                 <div className="flex flex-wrap items-center justify-between gap-4">
                   <div>

--- a/app/invest/farmland/listings/[slug]/page.tsx
+++ b/app/invest/farmland/listings/[slug]/page.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from "next";
 import { createClient } from "@/lib/supabase/server";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
 import Icon from "@/components/Icon";
+import ListingImageGallery from "@/components/ListingImageGallery";
 import ListingCard, { type InvestmentListing } from "@/components/ListingCard";
 import ListingEnquiryForm from "@/components/ListingEnquiryForm";
 
@@ -123,6 +124,7 @@ export default async function FarmlandListingDetailPage({
         <div className="container-custom">
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
             <div className="lg:col-span-2 space-y-6">
+              <ListingImageGallery images={l.images} alt={l.title} />
               <div className="bg-white border border-slate-200 rounded-xl p-6">
                 <div className="flex flex-wrap items-center justify-between gap-4">
                   <div>

--- a/app/invest/franchise/listings/[slug]/page.tsx
+++ b/app/invest/franchise/listings/[slug]/page.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from "next";
 import { createClient } from "@/lib/supabase/server";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
 import Icon from "@/components/Icon";
+import ListingImageGallery from "@/components/ListingImageGallery";
 import ListingCard, { type InvestmentListing } from "@/components/ListingCard";
 import ListingEnquiryForm from "@/components/ListingEnquiryForm";
 
@@ -125,6 +126,7 @@ export default async function FranchiseListingDetailPage({
         <div className="container-custom">
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
             <div className="lg:col-span-2 space-y-6">
+              <ListingImageGallery images={l.images} alt={l.title} />
               <div className="bg-white border border-slate-200 rounded-xl p-6">
                 <div className="flex flex-wrap items-center justify-between gap-4">
                   <div>

--- a/app/invest/infrastructure/listings/[slug]/page.tsx
+++ b/app/invest/infrastructure/listings/[slug]/page.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from "next";
 import { createClient } from "@/lib/supabase/server";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
 import Icon from "@/components/Icon";
+import ListingImageGallery from "@/components/ListingImageGallery";
 import ListingCard, { type InvestmentListing } from "@/components/ListingCard";
 import ListingEnquiryForm from "@/components/ListingEnquiryForm";
 
@@ -135,6 +136,7 @@ export default async function InfrastructureListingDetailPage({
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
             {/* Left: details */}
             <div className="lg:col-span-2 space-y-6">
+              <ListingImageGallery images={l.images} alt={l.title} />
               {/* Price card */}
               <div className="bg-white border border-slate-200 rounded-xl p-6">
                 <div className="flex flex-wrap items-center justify-between gap-4">

--- a/app/invest/listings/page.tsx
+++ b/app/invest/listings/page.tsx
@@ -14,6 +14,7 @@ import {
 import { getAllInvestCategories } from "@/lib/invest-categories";
 import type { InvestmentListing } from "@/lib/types";
 import InvestListingsClient from "@/components/InvestListingsClient";
+import { listingUrl } from "@/lib/listing-url";
 
 export const revalidate = 3600;
 
@@ -61,7 +62,7 @@ export default async function InvestListingsPage() {
       "@type": "ListItem",
       position: i + 1,
       name: l.title,
-      url: absoluteUrl(`/invest/listing/${l.slug}`),
+      url: absoluteUrl(listingUrl(l)),
     })),
   };
 

--- a/app/invest/mining/listings/[slug]/page.tsx
+++ b/app/invest/mining/listings/[slug]/page.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from "next";
 import { createClient } from "@/lib/supabase/server";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
 import Icon from "@/components/Icon";
+import ListingImageGallery from "@/components/ListingImageGallery";
 import ListingCard, { type InvestmentListing } from "@/components/ListingCard";
 import ListingEnquiryForm from "@/components/ListingEnquiryForm";
 
@@ -128,6 +129,7 @@ export default async function MiningOpportunityDetailPage({
         <div className="container-custom">
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
             <div className="lg:col-span-2 space-y-6">
+              <ListingImageGallery images={l.images} alt={l.title} />
               {/* Price */}
               <div className="bg-white border border-slate-200 rounded-xl p-6">
                 <div className="flex flex-wrap items-center justify-between gap-4">

--- a/app/invest/private-credit/listings/[slug]/page.tsx
+++ b/app/invest/private-credit/listings/[slug]/page.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from "next";
 import { createClient } from "@/lib/supabase/server";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
 import Icon from "@/components/Icon";
+import ListingImageGallery from "@/components/ListingImageGallery";
 import ListingCard, { type InvestmentListing } from "@/components/ListingCard";
 import ListingEnquiryForm from "@/components/ListingEnquiryForm";
 
@@ -135,6 +136,7 @@ export default async function PrivateCreditListingDetailPage({
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
             {/* Left: details */}
             <div className="lg:col-span-2 space-y-6">
+              <ListingImageGallery images={l.images} alt={l.title} />
               {/* Price card */}
               <div className="bg-white border border-slate-200 rounded-xl p-6">
                 <div className="flex flex-wrap items-center justify-between gap-4">

--- a/app/invest/renewable-energy/listings/[slug]/page.tsx
+++ b/app/invest/renewable-energy/listings/[slug]/page.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from "next";
 import { createClient } from "@/lib/supabase/server";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
 import Icon from "@/components/Icon";
+import ListingImageGallery from "@/components/ListingImageGallery";
 import ListingCard, { type InvestmentListing } from "@/components/ListingCard";
 import ListingEnquiryForm from "@/components/ListingEnquiryForm";
 
@@ -129,6 +130,7 @@ export default async function EnergyProjectDetailPage({
         <div className="container-custom">
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
             <div className="lg:col-span-2 space-y-6">
+              <ListingImageGallery images={l.images} alt={l.title} />
               <div className="bg-white border border-slate-200 rounded-xl p-6">
                 <div className="flex flex-wrap items-center justify-between gap-4">
                   <div>

--- a/app/invest/startups/listings/[slug]/page.tsx
+++ b/app/invest/startups/listings/[slug]/page.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from "next";
 import { createClient } from "@/lib/supabase/server";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
 import Icon from "@/components/Icon";
+import ListingImageGallery from "@/components/ListingImageGallery";
 import ListingCard, { type InvestmentListing } from "@/components/ListingCard";
 import ListingEnquiryForm from "@/components/ListingEnquiryForm";
 
@@ -131,6 +132,7 @@ export default async function StartupOpportunityDetailPage({
         <div className="container-custom">
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
             <div className="lg:col-span-2 space-y-6">
+              <ListingImageGallery images={l.images} alt={l.title} />
               <div className="bg-white border border-slate-200 rounded-xl p-6">
                 <div className="flex flex-wrap items-center justify-between gap-4">
                   <div>

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -5,6 +5,8 @@ import { getAllCostScenarioSlugs } from "@/lib/cost-scenarios";
 import { getAllCitySlugs } from "@/lib/cities";
 import { getAllGuideSlugs } from "@/lib/how-to-guides";
 import { getAllInvestCategorySlugs, getAllSubcategorySlugs } from "@/lib/invest-categories";
+import { listingUrl } from "@/lib/listing-url";
+import type { InvestListingVertical } from "@/lib/types";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://invest.com.au";
@@ -614,11 +616,11 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   // Individual investment listing detail pages
   const { data: investListings } = supabase
-    ? await supabase.from("investment_listings").select("slug, updated_at").eq("status", "active")
+    ? await supabase.from("investment_listings").select("slug, vertical, sub_category, updated_at").eq("status", "active")
     : { data: null };
 
   const investListingPages = (investListings || []).map((l) => ({
-    url: `${baseUrl}/invest/listing/${l.slug}`,
+    url: `${baseUrl}${listingUrl(l as { vertical: InvestListingVertical; sub_category?: string; slug: string })}`,
     lastModified: l.updated_at ? new Date(l.updated_at) : new Date(),
     changeFrequency: "weekly" as const,
     priority: 0.6,

--- a/components/InvestListingCard.tsx
+++ b/components/InvestListingCard.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import type { InvestmentListing } from "@/lib/types";
+import { listingUrl } from "@/lib/listing-url";
 
 function formatLocation(state?: string, city?: string): string | null {
   if (city && state) return `${city}, ${state}`;
@@ -25,7 +26,7 @@ export default function InvestListingCard({
 
   return (
     <Link
-      href={`/invest/listing/${listing.slug}`}
+      href={listingUrl(listing)}
       className="group relative block rounded-xl border border-slate-200 bg-white transition-all duration-200 hover:shadow-lg hover:scale-[1.01]"
     >
       {/* Badge */}

--- a/components/InvestListingsClient.tsx
+++ b/components/InvestListingsClient.tsx
@@ -4,6 +4,7 @@ import { useCallback, useMemo } from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams, usePathname } from "next/navigation";
 import type { InvestmentListing, InvestListingVertical } from "@/lib/types";
+import { listingUrl, VERTICAL_TO_CATEGORY, FUND_SUB_TO_CATEGORY, categoryForListing } from "@/lib/listing-url";
 
 // ─── Props ───────────────────────────────────────────────────────────
 export interface InvestListingsClientProps {
@@ -13,33 +14,9 @@ export interface InvestListingsClientProps {
   initialSubcategory?: string;
 }
 
-// ─── Vertical → category slug mapping ────────────────────────────────
-const VERTICAL_TO_CATEGORY: Record<InvestListingVertical, string> = {
-  business: "buy-business",
-  commercial_property: "commercial-property",
-  energy: "renewable-energy",
-  farmland: "farmland",
-  franchise: "franchise",
-  fund: "funds",
-  mining: "mining",
-  startup: "startups",
-};
-
-/** Fund sub-categories that belong to non-"funds" categories */
-const FUND_SUB_TO_CATEGORY: Record<string, string> = {
-  art: "alternatives",
-  wine: "alternatives",
-  private_credit: "private-credit",
-  infrastructure: "infrastructure",
-};
-
-function categoryForListing(listing: InvestmentListing): string {
-  if (listing.vertical === "fund" && listing.sub_category) {
-    const override = FUND_SUB_TO_CATEGORY[listing.sub_category];
-    if (override) return override;
-  }
-  return VERTICAL_TO_CATEGORY[listing.vertical] ?? "funds";
-}
+// VERTICAL_TO_CATEGORY, FUND_SUB_TO_CATEGORY, and categoryForListing
+// are imported from @/lib/listing-url so all link generation uses the
+// same canonical category mapping.
 
 // ─── Category colors (pill styling) ─────────────────────────────────
 const CATEGORY_COLORS: Record<string, { bg: string; text: string; ring: string }> = {
@@ -301,7 +278,7 @@ export default function InvestListingsClient({
               return (
                 <Link
                   key={listing.id}
-                  href={`/invest/listing/${listing.slug}`}
+                  href={listingUrl(listing)}
                   className="group relative block rounded-xl border border-slate-200 bg-white transition-all duration-200 hover:shadow-lg hover:scale-[1.01]"
                 >
                   <div className="p-4">

--- a/components/ListingImageGallery.tsx
+++ b/components/ListingImageGallery.tsx
@@ -1,0 +1,50 @@
+import Image from "next/image";
+
+interface ListingImageGalleryProps {
+  images?: string[] | null;
+  alt: string;
+}
+
+/**
+ * Image gallery for investment listing detail pages.
+ * Shows a hero image with up to 4 thumbnails.
+ * Renders nothing if there are no images.
+ */
+export default function ListingImageGallery({ images, alt }: ListingImageGalleryProps) {
+  if (!images || images.length === 0) return null;
+
+  const hero = images[0];
+  const thumbs = images.slice(1, 5);
+
+  return (
+    <div className="bg-white border border-slate-200 rounded-xl overflow-hidden">
+      {/* Hero image */}
+      <div className="relative aspect-[16/9] bg-slate-100">
+        <Image
+          src={hero}
+          alt={alt}
+          fill
+          className="object-cover"
+          priority
+          sizes="(max-width: 1024px) 100vw, 66vw"
+        />
+      </div>
+      {/* Thumbnails grid (only if there are more images) */}
+      {thumbs.length > 0 && (
+        <div className="grid grid-cols-4 gap-1 p-1">
+          {thumbs.map((img, i) => (
+            <div key={img + i} className="relative aspect-square bg-slate-100 rounded overflow-hidden">
+              <Image
+                src={img}
+                alt={`${alt} — image ${i + 2}`}
+                fill
+                className="object-cover"
+                sizes="(max-width: 1024px) 25vw, 16vw"
+              />
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lib/listing-url.ts
+++ b/lib/listing-url.ts
@@ -1,0 +1,55 @@
+import type { InvestmentListing, InvestListingVertical } from "@/lib/types";
+
+/**
+ * Maps each `vertical` value from the database to its corresponding
+ * URL category slug used in the /invest/{category}/listings/{slug} routes.
+ */
+export const VERTICAL_TO_CATEGORY: Record<InvestListingVertical, string> = {
+  business: "buy-business",
+  commercial_property: "commercial-property",
+  energy: "renewable-energy",
+  farmland: "farmland",
+  franchise: "franchise",
+  fund: "funds",
+  mining: "mining",
+  startup: "startups",
+};
+
+/**
+ * Some `fund` listings actually belong to a different category based on
+ * their `sub_category` value. For example, a fund with sub_category "art"
+ * is an "alternatives" category listing.
+ */
+export const FUND_SUB_TO_CATEGORY: Record<string, string> = {
+  art: "alternatives",
+  wine: "alternatives",
+  watches: "alternatives",
+  cars: "alternatives",
+  coins: "alternatives",
+  whisky: "alternatives",
+  private_credit: "private-credit",
+  infrastructure: "infrastructure",
+};
+
+/**
+ * Returns the canonical category slug for an investment listing.
+ * Used to construct correct URLs for listing detail pages.
+ */
+export function categoryForListing(listing: Pick<InvestmentListing, "vertical" | "sub_category">): string {
+  if (listing.vertical === "fund" && listing.sub_category) {
+    const override = FUND_SUB_TO_CATEGORY[listing.sub_category];
+    if (override) return override;
+  }
+  return VERTICAL_TO_CATEGORY[listing.vertical] ?? "funds";
+}
+
+/**
+ * Returns the canonical URL path for an investment listing detail page.
+ * Format: /invest/{category}/listings/{slug}
+ *
+ * Use this everywhere instead of hardcoded URL templates to ensure links
+ * always go to the correct category-specific route.
+ */
+export function listingUrl(listing: Pick<InvestmentListing, "vertical" | "sub_category" | "slug">): string {
+  return `/invest/${categoryForListing(listing)}/listings/${listing.slug}`;
+}


### PR DESCRIPTION
Two bugs causing listing detail pages to be broken:

Bug 1: 404 on /invest/listing/[slug]
The URL /invest/listing/macadamia-orchard-northern-rivers (and any listing detail link from the marketplace) was returning 404 because:
- The actual route is /invest/{category}/listings/[slug] (plural, with category prefix)
- 5 places in the codebase were hardcoded to generate the broken /invest/listing/[slug] URL pattern

Fixed by extracting a shared lib/listing-url.ts helper that maps each listing's vertical (and sub_category for fund overrides) to its canonical category URL, and using listingUrl(listing) everywhere links are generated:

- components/InvestListingCard.tsx (card link)
- components/InvestListingsClient.tsx (card link in unified marketplace)
- app/invest/listings/page.tsx (ItemList JSON-LD)
- app/invest/[category]/listings/[subcategory]/page.tsx (ItemList JSON-LD)
- app/sitemap.ts (dynamic sitemap entries)

The duplicate VERTICAL_TO_CATEGORY/categoryForListing definitions in InvestListingsClient have been removed and replaced with imports from the shared lib.

Bug 2: Detail pages don't render listing images
None of the 10 listing detail pages had any image rendering at all. Listings have an `images: string[]` field but it was never displayed — users only saw text content, never the actual property/business photos.

Fixed by adding a new <ListingImageGallery> component (hero image + up to 4 thumbnails) and adding it to all 10 detail pages:

- buy-business, commercial-property, farmland, franchise, mining, renewable-energy, startups, alternatives, private-credit, infrastructure

Uses next/image with proper sizes hints, fill layout, and priority loading on the hero image. Renders nothing if the listing has no images (graceful degradation).

Supabase storage hostname is already allowlisted in next.config.ts remotePatterns, so listing images will load correctly.

TypeScript: clean. Build: succeeds.

https://claude.ai/code/session_01DyudU3Uo5eFGwXKQsYcbUw