### PR TITLE
feat: overhaul listing cards with hero images + premium design

### DIFF
--- a/components/InvestListingCard.tsx
+++ b/components/InvestListingCard.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import Image from "next/image";
 import type { InvestmentListing } from "@/lib/types";
 import { listingUrl } from "@/lib/listing-url";
 
@@ -12,6 +13,35 @@ function formatKeyMetricValue(value: string | number | boolean): string {
   return String(value);
 }
 
+/**
+ * Vertical → fallback gradient when listing has no images.
+ * Each category gets a distinct, warm gradient so cards still look polished.
+ */
+const VERTICAL_FALLBACK_GRADIENT: Record<string, string> = {
+  business: "from-blue-100 via-indigo-50 to-blue-50",
+  commercial_property: "from-slate-200 via-slate-100 to-slate-50",
+  energy: "from-emerald-100 via-emerald-50 to-green-50",
+  farmland: "from-green-100 via-lime-50 to-amber-50",
+  franchise: "from-purple-100 via-violet-50 to-pink-50",
+  fund: "from-violet-100 via-purple-50 to-indigo-50",
+  mining: "from-amber-100 via-yellow-50 to-orange-50",
+  startup: "from-indigo-100 via-blue-50 to-cyan-50",
+};
+
+/**
+ * Vertical → emoji icon for fallback when no images available.
+ */
+const VERTICAL_ICON: Record<string, string> = {
+  business: "🏢",
+  commercial_property: "🏬",
+  energy: "⚡",
+  farmland: "🌾",
+  franchise: "🍔",
+  fund: "📈",
+  mining: "⛏️",
+  startup: "🚀",
+};
+
 export default function InvestListingCard({
   listing,
   badge,
@@ -23,81 +53,141 @@ export default function InvestListingCard({
   const metricEntries = listing.key_metrics
     ? Object.entries(listing.key_metrics).slice(0, 3)
     : [];
+  const heroImage = listing.images?.[0];
+  const fallbackGradient = VERTICAL_FALLBACK_GRADIENT[listing.vertical] ?? "from-slate-100 to-slate-50";
+  const fallbackIcon = VERTICAL_ICON[listing.vertical] ?? "📊";
 
   return (
     <Link
       href={listingUrl(listing)}
-      className="group relative block rounded-xl border border-slate-200 bg-white transition-all duration-200 hover:shadow-lg hover:scale-[1.01]"
+      className="group relative block overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm hover:shadow-xl hover:border-slate-300 transition-all duration-300 hover:-translate-y-0.5"
     >
-      {/* Badge */}
-      {badge && (
-        <div className="px-3 pt-2.5 pb-0 text-[0.62rem] font-extrabold uppercase tracking-wide text-slate-700">
-          {badge}
-        </div>
-      )}
+      {/* Hero image / fallback */}
+      <div className="relative aspect-[16/10] overflow-hidden bg-slate-100">
+        {heroImage ? (
+          <Image
+            src={heroImage}
+            alt={listing.title}
+            fill
+            sizes="(max-width: 768px) 100vw, (max-width: 1280px) 50vw, 33vw"
+            className="object-cover transition-transform duration-500 group-hover:scale-105"
+            loading="lazy"
+          />
+        ) : (
+          <div className={`absolute inset-0 bg-gradient-to-br ${fallbackGradient} flex items-center justify-center`}>
+            <div className="text-6xl opacity-40 group-hover:scale-110 transition-transform duration-500">
+              {fallbackIcon}
+            </div>
+          </div>
+        )}
 
-      <div className="p-3">
-        {/* Row 1: Title + Price */}
-        <div className="flex items-start justify-between gap-2 mb-2">
-          <div className="min-w-0 flex-1">
-            <h3 className="font-bold text-sm text-slate-900 group-hover:text-slate-700 transition-colors truncate">
-              {listing.title}
-            </h3>
-            {location && (
-              <p className="text-[0.65rem] font-semibold text-slate-500 mt-0.5 truncate">
-                {location}
-              </p>
+        {/* Top-left badges (Featured / pick) */}
+        {(badge || listing.listing_type === "featured") && (
+          <div className="absolute top-3 left-3 flex flex-wrap gap-1.5">
+            {listing.listing_type === "featured" && (
+              <span className="bg-amber-500 text-slate-900 text-[0.62rem] font-extrabold uppercase tracking-wider px-2 py-1 rounded-md shadow-sm">
+                ★ Featured
+              </span>
+            )}
+            {badge && (
+              <span className="bg-white/95 backdrop-blur text-slate-800 text-[0.62rem] font-extrabold uppercase tracking-wider px-2 py-1 rounded-md shadow-sm">
+                {badge}
+              </span>
             )}
           </div>
-          {listing.price_display && (
-            <span className="shrink-0 text-sm font-bold text-slate-900">
-              {listing.price_display}
-            </span>
-          )}
-        </div>
+        )}
 
-        {/* Row 2: Industry + Sub-category + Compliance badges */}
-        <div className="flex flex-wrap items-center gap-1 mb-1.5">
-          {listing.industry && (
-            <span className="text-[0.6rem] px-1.5 py-0.5 bg-slate-50 rounded font-semibold text-slate-700">
-              {listing.industry}
-            </span>
-          )}
-          {listing.sub_category && (
-            <span className="text-[0.6rem] px-1.5 py-0.5 bg-slate-50 rounded font-semibold text-slate-700">
-              {listing.sub_category}
-            </span>
-          )}
-          {listing.firb_eligible && (
-            <span className="text-[0.6rem] px-1.5 py-0.5 bg-emerald-50 rounded font-bold text-emerald-700">
-              FIRB Eligible
-            </span>
-          )}
-          {listing.siv_complying && (
-            <span className="text-[0.6rem] px-1.5 py-0.5 bg-blue-50 rounded font-bold text-blue-700">
-              SIV Complying
-            </span>
-          )}
-        </div>
-
-        {/* Row 3: Key metrics */}
-        {metricEntries.length > 0 && (
-          <div className="flex flex-wrap items-center gap-1 mb-2">
-            {metricEntries.map(([key, value]) => (
-              <span
-                key={key}
-                className="text-[0.6rem] px-1.5 py-0.5 bg-slate-50 rounded font-semibold text-slate-600"
-              >
-                {key}: {formatKeyMetricValue(value)}
+        {/* Top-right compliance badges */}
+        {(listing.firb_eligible || listing.siv_complying) && (
+          <div className="absolute top-3 right-3 flex gap-1.5">
+            {listing.firb_eligible && (
+              <span className="bg-blue-600 text-white text-[0.6rem] font-extrabold uppercase tracking-wider px-2 py-1 rounded-md shadow-sm">
+                FIRB
               </span>
+            )}
+            {listing.siv_complying && (
+              <span className="bg-emerald-600 text-white text-[0.6rem] font-extrabold uppercase tracking-wider px-2 py-1 rounded-md shadow-sm">
+                SIV
+              </span>
+            )}
+          </div>
+        )}
+
+        {/* Bottom price overlay */}
+        {listing.price_display && (
+          <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent p-3">
+            <div className="text-white text-xs font-semibold opacity-80 uppercase tracking-wide">Asking</div>
+            <div className="text-white text-lg font-extrabold">{listing.price_display}</div>
+          </div>
+        )}
+      </div>
+
+      {/* Content */}
+      <div className="p-4">
+        {/* Title */}
+        <h3 className="font-bold text-base text-slate-900 group-hover:text-emerald-700 transition-colors line-clamp-2 mb-1.5 leading-snug">
+          {listing.title}
+        </h3>
+
+        {/* Location */}
+        {location && (
+          <p className="flex items-center gap-1 text-xs text-slate-500 mb-3">
+            <svg className="w-3 h-3 text-slate-400" fill="currentColor" viewBox="0 0 20 20">
+              <path fillRule="evenodd" d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z" clipRule="evenodd" />
+            </svg>
+            {location}
+          </p>
+        )}
+
+        {/* Industry / sub-category pills */}
+        {(listing.industry || listing.sub_category) && (
+          <div className="flex flex-wrap items-center gap-1 mb-3">
+            {listing.industry && (
+              <span className="text-[0.62rem] px-2 py-0.5 bg-slate-100 rounded-full font-semibold text-slate-600">
+                {listing.industry}
+              </span>
+            )}
+            {listing.sub_category && (
+              <span className="text-[0.62rem] px-2 py-0.5 bg-slate-100 rounded-full font-semibold text-slate-600 capitalize">
+                {listing.sub_category.replace(/_/g, " ")}
+              </span>
+            )}
+          </div>
+        )}
+
+        {/* Key metrics row */}
+        {metricEntries.length > 0 && (
+          <div className="grid grid-cols-3 gap-2 pt-3 mt-2 border-t border-slate-100">
+            {metricEntries.map(([key, value]) => (
+              <div key={key} className="text-center">
+                <div className="text-[0.6rem] text-slate-400 uppercase tracking-wide font-medium truncate">
+                  {key.replace(/_/g, " ")}
+                </div>
+                <div className="text-xs font-bold text-slate-900 truncate">
+                  {formatKeyMetricValue(value)}
+                </div>
+              </div>
             ))}
           </div>
         )}
 
-        {/* Row 4: CTA */}
-        <div className="flex items-center justify-end">
-          <span className="px-3 py-1.5 text-[0.69rem] font-bold rounded-lg bg-slate-900 text-white group-hover:bg-slate-800 transition-colors">
+        {/* CTA */}
+        <div className="flex items-center justify-between mt-4 pt-3 border-t border-slate-100">
+          <span className="text-[0.65rem] text-slate-400 font-medium">
+            {listing.images && listing.images.length > 0 && (
+              <>
+                <svg className="w-3 h-3 inline -mt-0.5 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                </svg>
+                {listing.images.length} {listing.images.length === 1 ? "photo" : "photos"}
+              </>
+            )}
+          </span>
+          <span className="inline-flex items-center gap-1 text-xs font-bold text-emerald-600 group-hover:text-emerald-700 group-hover:gap-2 transition-all">
             View Details
+            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M9 5l7 7-7 7" />
+            </svg>
           </span>
         </div>
       </div>

--- a/components/InvestListingsClient.tsx
+++ b/components/InvestListingsClient.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { useCallback, useMemo } from "react";
-import Link from "next/link";
 import { useRouter, useSearchParams, usePathname } from "next/navigation";
-import type { InvestmentListing, InvestListingVertical } from "@/lib/types";
-import { listingUrl, VERTICAL_TO_CATEGORY, FUND_SUB_TO_CATEGORY, categoryForListing } from "@/lib/listing-url";
+import type { InvestmentListing } from "@/lib/types";
+import { categoryForListing } from "@/lib/listing-url";
+import InvestListingCard from "@/components/InvestListingCard";
 
 // ─── Props ───────────────────────────────────────────────────────────
 export interface InvestListingsClientProps {
@@ -54,12 +54,6 @@ const SORT_OPTIONS: { value: SortKey; label: string }[] = [
   { value: "price-asc", label: "Price Low-High" },
   { value: "price-desc", label: "Price High-Low" },
 ];
-
-// ─── Helpers ─────────────────────────────────────────────────────────
-function formatLocation(state?: string, city?: string): string | null {
-  if (city && state) return `${city}, ${state}`;
-  return state || city || null;
-}
 
 // ─── Component ───────────────────────────────────────────────────────
 export default function InvestListingsClient({
@@ -272,69 +266,10 @@ export default function InvestListingsClient({
             </p>
           </div>
         ) : (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            {filtered.map((listing) => {
-              const location = formatLocation(listing.location_state, listing.location_city);
-              return (
-                <Link
-                  key={listing.id}
-                  href={listingUrl(listing)}
-                  className="group relative block rounded-xl border border-slate-200 bg-white transition-all duration-200 hover:shadow-lg hover:scale-[1.01]"
-                >
-                  <div className="p-4">
-                    {/* Title + Price */}
-                    <div className="flex items-start justify-between gap-2 mb-2">
-                      <h3 className="font-bold text-sm text-slate-900 group-hover:text-slate-700 transition-colors line-clamp-2 min-w-0 flex-1">
-                        {listing.title}
-                      </h3>
-                      {listing.price_display && (
-                        <span className="shrink-0 text-sm font-bold text-slate-900">
-                          {listing.price_display}
-                        </span>
-                      )}
-                    </div>
-
-                    {/* Location */}
-                    {location && (
-                      <p className="text-[0.65rem] font-semibold text-slate-500 mb-2 truncate">
-                        {location}
-                      </p>
-                    )}
-
-                    {/* Industry / Sub-category + Badges */}
-                    <div className="flex flex-wrap items-center gap-1 mb-3">
-                      {listing.industry && (
-                        <span className="text-[0.6rem] px-1.5 py-0.5 bg-slate-50 rounded font-semibold text-slate-700">
-                          {listing.industry}
-                        </span>
-                      )}
-                      {listing.sub_category && (
-                        <span className="text-[0.6rem] px-1.5 py-0.5 bg-slate-50 rounded font-semibold text-slate-700 capitalize">
-                          {listing.sub_category.replace(/_/g, " ")}
-                        </span>
-                      )}
-                      {listing.firb_eligible && (
-                        <span className="text-[0.6rem] px-1.5 py-0.5 bg-emerald-50 rounded font-bold text-emerald-700">
-                          FIRB
-                        </span>
-                      )}
-                      {listing.siv_complying && (
-                        <span className="text-[0.6rem] px-1.5 py-0.5 bg-blue-50 rounded font-bold text-blue-700">
-                          SIV
-                        </span>
-                      )}
-                    </div>
-
-                    {/* CTA */}
-                    <div className="flex items-center justify-end">
-                      <span className="px-3 py-1.5 text-[0.69rem] font-bold rounded-lg bg-slate-900 text-white group-hover:bg-slate-800 transition-colors">
-                        View Details
-                      </span>
-                    </div>
-                  </div>
-                </Link>
-              );
-            })}
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
+            {filtered.map((listing) => (
+              <InvestListingCard key={listing.id} listing={listing} />
+            ))}
           </div>
         )}
       </div>


### PR DESCRIPTION
The /invest/{category}/listings index pages had cramped, text-only cards with no visual appeal. Listings have an `images` field but the cards never displayed them.

Card overhaul:
- Hero image at top (16:10 aspect, lazy-loaded, scales on hover)
- Elegant fallback when no images: per-vertical gradient background
  + emoji icon (e.g. 🌾 for farmland, ⚡ for energy, 🚀 for startups)
- Featured badge overlay on top-left
- FIRB / SIV compliance badges on top-right
- Price overlay at bottom of image with gradient backdrop for legibility
- Rounded-2xl card with subtle shadow that lifts on hover
- Title now turns emerald green on hover for interactivity
- Location with proper map-pin icon
- Industry / sub-category as rounded pills
- Key metrics displayed in a 3-column grid below the description
- Photo count badge in footer if images exist
- "View Details →" CTA with animated arrow
- Subtle -translate-y-0.5 lift effect on hover

Code changes:
- Rewrote components/InvestListingCard.tsx (~85 lines → ~210 lines)
- Replaced 60+ lines of duplicated inline card JSX in InvestListingsClient.tsx with <InvestListingCard listing={listing} />
- Removed now-unused imports (Link, formatLocation, etc.) from InvestListingsClient
- Single source of truth for card design

Result:
- /invest/buy-business/listings now shows visual cards with hero images
- All other category listings pages get the same design (they all use the same InvestListingsClient component)
- Cards look premium even without images thanks to per-vertical fallback gradients

TypeScript: clean. Build: succeeds. Net: +25 lines (one component became the single source of truth, the other got 79 lines lighter).

https://claude.ai/code/session_01DyudU3Uo5eFGwXKQsYcbUw