### PR TITLE
Hotfix 2 — generateStaticParams must use static Supabase client

### DIFF
--- a/app/brokers/full-service/[slug]/page.tsx
+++ b/app/brokers/full-service/[slug]/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
-import { createClient } from "@/lib/supabase/server";
+import { createStaticClient } from "@/lib/supabase/static";
 import type { Professional } from "@/lib/types";
 import {
   absoluteUrl,
@@ -17,10 +17,15 @@ import FullServiceBrokerEnquiryForm from "@/components/full-service-brokers/Full
 export const revalidate = 3600;
 
 export async function generateStaticParams() {
+  // Use the static client (anon key, no cookies). generateStaticParams
+  // runs at BUILD TIME with no request context, so the SSR createClient
+  // — which reads cookies() — throws "cookies was called outside a
+  // request scope" and fails the Vercel build. This was the cause of
+  // four failed production deploys.
   if (!process.env.NEXT_PUBLIC_SUPABASE_URL || !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY) {
     return [];
   }
-  const supabase = await createClient();
+  const supabase = createStaticClient();
   const { data } = await supabase
     .from("professionals")
     .select("slug")
@@ -35,7 +40,10 @@ export async function generateMetadata({
   params: Promise<{ slug: string }>;
 }): Promise<Metadata> {
   const { slug } = await params;
-  const supabase = await createClient();
+  // Static client — generateMetadata runs at build time for every slug
+  // returned by generateStaticParams above. No request context, no
+  // cookies. Same reason as the comment in generateStaticParams.
+  const supabase = createStaticClient();
   const { data } = await supabase
     .from("professionals")
     .select("name, bio, photo_url")
@@ -90,7 +98,12 @@ export default async function FullServiceBrokerDetailPage({
   params: Promise<{ slug: string }>;
 }) {
   const { slug } = await params;
-  const supabase = await createClient();
+  // Static client — this page is SSG (via generateStaticParams), so
+  // the body also runs at build time for each slug. Using the SSR
+  // createClient() here would fail build with "cookies was called
+  // outside a request scope". The firm data is public read-only so
+  // the anon key is the right level of access anyway.
+  const supabase = createStaticClient();
 
   const { data: firm } = await supabase
     .from("professionals")

--- a/next.config.ts
+++ b/next.config.ts
@@ -213,14 +213,30 @@ const nextConfig: NextConfig = {
   },
 };
 
-// withSentryConfig wraps the Next.js config for error tracking.
+// withSentryConfig wraps the Next.js config for error tracking + source
+// map upload. The upload step requires SENTRY_ORG, SENTRY_PROJECT AND
+// SENTRY_AUTH_TOKEN to be set in the build environment. If any is
+// missing, Sentry's CLI fails the build during the upload phase —
+// silently on local builds (silent: true) but loudly on Vercel where
+// CI=true flips the silent flag off.
+//
+// Until Sentry is fully configured in Vercel, make the wrap
+// conditional: skip it entirely when SENTRY_AUTH_TOKEN isn't set, so
+// the build ships as a plain Next.js app with no error tracking
+// instead of failing. Once the env vars are added in Vercel, the
+// wrap auto-re-engages on the next deploy with zero code changes.
+//
 // Using `as any` because Sentry v9 peer-deps target Next.js ≤15 types,
 // but the runtime integration works fine with Next.js 16.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export default withSentryConfig(nextConfig as any, {
-  org: process.env.SENTRY_ORG,
-  project: process.env.SENTRY_PROJECT,
-  silent: !process.env.CI,
-  widenClientFileUpload: true,
-  tunnelRoute: "/monitoring",
-}) as typeof nextConfig;
+const config: NextConfig = process.env.SENTRY_AUTH_TOKEN
+  ? (withSentryConfig(nextConfig as any, {
+      org: process.env.SENTRY_ORG,
+      project: process.env.SENTRY_PROJECT,
+      silent: !process.env.CI,
+      widenClientFileUpload: true,
+      tunnelRoute: "/monitoring",
+    }) as NextConfig)
+  : nextConfig;
+
+export default config;


### PR DESCRIPTION
## Second hotfix — real root cause of the Vercel build failures

PR #121 fixed the first two bugs (middleware.ts vs proxy.ts conflict, `node:crypto` in Edge Runtime) but production is still on Error because there was a **third** bug further down the build pipeline.

From the actual Vercel build log:

```
15:35:06  ✓ Compiled successfully in 9.0s
15:35:06  Running TypeScript ...
15:35:53  Collecting page data using 29 workers ...
15:35:55  Error: `cookies` was called outside a request scope.
15:35:55      at Object.k [as generateStaticParams]
15:35:56  Error: Failed to collect page data for /brokers/full-service/[slug]
15:35:56  Error: Command "npm run build" exited with 1
```

## Root cause

`app/brokers/full-service/[slug]/page.tsx` was calling `createClient()` from `lib/supabase/server.ts` inside **three** places that run at BUILD time, not request time:

1. `generateStaticParams` — enumerates slugs for SSG
2. `generateMetadata` — runs per slug during static generation
3. The default export (page body) — SSG-rendered for each slug

`lib/supabase/server.ts#createClient` eagerly calls `cookies()` from `next/headers` on line 10, which throws when called outside a request scope. This crashed the build during "Collecting page data".

## Fix

Switch all three to `createStaticClient()` from `lib/supabase/static.ts`, which uses the anon key with no cookie plumbing. This matches the pattern already used by `/broker/[slug]`, `/advisor/[slug]`, and other SSG pages in the repo. The firm data is public read-only so anon-key access is correct.

## Second change — defensive Sentry wrap

Also in this commit: made `withSentryConfig` conditional on `SENTRY_AUTH_TOKEN` being set. This was NOT the build failure (the cookies error killed the build first) but Sentry would have bitten next. On Vercel, `CI=true` flips the `silent` flag off, and the source map upload step fails without auth env vars configured.

The conditional wrap means: ship with no Sentry wrap at all today; re-engage Sentry automatically the moment `SENTRY_AUTH_TOKEN` + `SENTRY_ORG` + `SENTRY_PROJECT` are added to Vercel env with zero code changes.

## Verified locally

```
$ npm run build
exit 0
0 "Build error occurred" / "Failed to collect page data" lines
/brokers/full-service       (ƒ dynamic)
/brokers/full-service/[slug] (● SSG) ← now resolves cleanly
```

## After this merges

The full story will finally be:

- PR #117 (IA overhaul)           ✅ merged, deployed
- PR #118 (compliance + obs)      ✅ merged, **never deployed** (broke build)
- PR #119 (broker vertical)       ✅ merged, **never deployed** (broke build)
- PR #120 (cron auth + tests)     ✅ merged, **never deployed** (broke build)
- PR #121 (first hotfix)          ✅ merged, **still broken** (third bug)
- **This PR**                     → should finally deploy green

And then everything from PRs #118 through #121 lights up at once.

## Postmortem

Three bugs slipped into production across three PRs because **I never ran `npm run build` locally on any of them**. `tsc --noEmit` and `vitest run` both pass for all three, but:

- TypeScript check doesn't know about Next.js's middleware.ts vs proxy.ts conflict
- TypeScript check doesn't know which modules are allowed in Edge Runtime
- TypeScript check doesn't know that `generateStaticParams` runs outside a request scope

`npm run build` would have caught all three in 30 seconds each. Adding it to my pre-merge checklist for any PR that touches:
- `middleware.ts` / `proxy.ts`
- `lib/*-auth.ts` (imported across many routes)
- `generateStaticParams` / `generateMetadata`
- `next.config.ts`
- Anything imported by an Edge Runtime route

https://claude.ai/code/session_01DyudU3Uo5eFGwXKQsYcbUw