### PR TITLE
feat: admin automation dashboard — one place to see + control every classifier

### DIFF
--- a/__tests__/lib/automation-metrics.test.ts
+++ b/__tests__/lib/automation-metrics.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeHealth,
+  FEATURE_CONFIG,
+  AUTOMATION_FEATURES,
+  type LatestCronRun,
+} from "@/lib/admin/automation-metrics";
+
+function mockRun(overrides: Partial<LatestCronRun> = {}): LatestCronRun {
+  return {
+    name: "test",
+    startedAt: new Date().toISOString(),
+    endedAt: new Date().toISOString(),
+    durationMs: 1000,
+    status: "ok",
+    stats: {},
+    errorMessage: null,
+    triggeredBy: "cron",
+    ...overrides,
+  };
+}
+
+describe("computeHealth", () => {
+  it("returns green when recent run ok and queue empty", () => {
+    expect(computeHealth(mockRun(), 0, 1, 20, 50)).toBe("green");
+  });
+
+  it("returns amber when run status is partial", () => {
+    expect(computeHealth(mockRun({ status: "partial" }), 0, 1, 20, 50)).toBe("amber");
+  });
+
+  it("returns red when run status is error", () => {
+    expect(computeHealth(mockRun({ status: "error" }), 0, 1, 20, 50)).toBe("red");
+  });
+
+  it("returns red when pending queue exceeds critical threshold", () => {
+    expect(computeHealth(mockRun(), 100, 1, 20, 50)).toBe("red");
+  });
+
+  it("returns amber when pending queue exceeds warn threshold", () => {
+    expect(computeHealth(mockRun(), 25, 1, 20, 50)).toBe("amber");
+  });
+
+  it("returns red when cron is overdue by more than 2 cadence windows", () => {
+    const threeHoursAgo = new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString();
+    expect(computeHealth(mockRun({ startedAt: threeHoursAgo }), 0, 1, 20, 50)).toBe("red");
+  });
+
+  it("returns amber when cron is overdue by 1-2 cadence windows", () => {
+    const ninetyMinsAgo = new Date(Date.now() - 90 * 60 * 1000).toISOString();
+    expect(computeHealth(mockRun({ startedAt: ninetyMinsAgo }), 0, 1, 20, 50)).toBe("amber");
+  });
+
+  it("returns unknown when no run history and no pending", () => {
+    expect(computeHealth(null, 0, 24, 20, 50)).toBe("unknown");
+  });
+
+  it("returns amber when no run history but queue is at warn level", () => {
+    expect(computeHealth(null, 25, 24, 20, 50)).toBe("amber");
+  });
+
+  it("returns unknown when no run history and queue is well below warn", () => {
+    expect(computeHealth(null, 5, 24, 20, 50)).toBe("unknown");
+  });
+
+  it("prioritises red over amber when both conditions hit", () => {
+    expect(computeHealth(mockRun({ status: "error" }), 25, 1, 20, 50)).toBe("red");
+  });
+});
+
+describe("FEATURE_CONFIG", () => {
+  it("has an entry for every feature in AUTOMATION_FEATURES", () => {
+    for (const key of AUTOMATION_FEATURES) {
+      expect(FEATURE_CONFIG[key]).toBeDefined();
+      expect(FEATURE_CONFIG[key].key).toBe(key);
+      expect(FEATURE_CONFIG[key].title).toBeTruthy();
+      expect(FEATURE_CONFIG[key].slug).toBeTruthy();
+    }
+  });
+
+  it("uses unique slugs", () => {
+    const slugs = AUTOMATION_FEATURES.map((k) => FEATURE_CONFIG[k].slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+});

--- a/app/admin/automation/afsl-expiry/page.tsx
+++ b/app/admin/automation/afsl-expiry/page.tsx
@@ -1,0 +1,64 @@
+import { createAdminClient } from "@/lib/supabase/admin";
+import DrillDownShell from "@/components/admin/automation/DrillDownShell";
+import { getAfslExpiryOverview } from "@/lib/admin/automation-metrics";
+
+export const dynamic = "force-dynamic";
+
+export default async function AfslExpiryDrillDown() {
+  const supabase = createAdminClient();
+  const [overview, flaggedRes] = await Promise.all([
+    getAfslExpiryOverview(),
+    supabase
+      .from("professionals")
+      .select("id, name, email, afsl_number, auto_pause_reason, auto_paused_at")
+      .in("auto_pause_reason", ["afsl_ceased", "afsl_suspended"])
+      .order("auto_paused_at", { ascending: false })
+      .limit(50),
+  ]);
+
+  return (
+    <DrillDownShell overview={overview}>
+      <section className="bg-white border border-slate-200 rounded-xl overflow-hidden">
+        <header className="px-4 py-3 border-b border-slate-100 bg-red-50">
+          <h2 className="text-sm font-bold text-slate-900">AFSL-flagged advisors</h2>
+          <p className="text-xs text-slate-500">
+            Set <code className="bg-white px-1 rounded text-[0.65rem]">AFSL_LOOKUP_URL</code> env var to activate the weekly register check.
+            Without it the cron is a safe no-op.
+          </p>
+        </header>
+        <table className="w-full text-xs">
+          <thead className="bg-slate-50 border-b border-slate-100">
+            <tr>
+              <th className="px-4 py-2 text-left font-semibold text-slate-600">ID</th>
+              <th className="px-4 py-2 text-left font-semibold text-slate-600">Advisor</th>
+              <th className="px-4 py-2 text-left font-semibold text-slate-600">AFSL</th>
+              <th className="px-4 py-2 text-left font-semibold text-slate-600">Reason</th>
+              <th className="px-4 py-2 text-left font-semibold text-slate-600">Flagged</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-100">
+            {(flaggedRes.data || []).map((r) => (
+              <tr key={r.id}>
+                <td className="px-4 py-2 font-mono text-slate-500">#{r.id}</td>
+                <td className="px-4 py-2 text-slate-700">
+                  <div className="font-semibold">{r.name}</div>
+                  <div className="text-[0.65rem] text-slate-400">{r.email}</div>
+                </td>
+                <td className="px-4 py-2 font-mono text-slate-600">{r.afsl_number}</td>
+                <td className="px-4 py-2">
+                  <span className="inline-block px-2 py-0.5 rounded text-[0.65rem] font-semibold bg-red-100 text-red-800">{r.auto_pause_reason}</span>
+                </td>
+                <td className="px-4 py-2 text-[0.65rem] text-slate-500">
+                  {r.auto_paused_at ? new Date(r.auto_paused_at).toLocaleString("en-AU") : "—"}
+                </td>
+              </tr>
+            ))}
+            {(flaggedRes.data?.length || 0) === 0 && (
+              <tr><td colSpan={5} className="px-4 py-6 text-center text-slate-500">No advisors flagged by the AFSL monitor</td></tr>
+            )}
+          </tbody>
+        </table>
+      </section>
+    </DrillDownShell>
+  );
+}

--- a/app/admin/automation/applications/page.tsx
+++ b/app/admin/automation/applications/page.tsx
@@ -1,0 +1,86 @@
+import { createAdminClient } from "@/lib/supabase/admin";
+import DrillDownShell from "@/components/admin/automation/DrillDownShell";
+import OverrideButton from "@/components/admin/automation/OverrideButton";
+import { getAdvisorApplicationOverview } from "@/lib/admin/automation-metrics";
+
+export const dynamic = "force-dynamic";
+
+export default async function ApplicationsDrillDown() {
+  const supabase = createAdminClient();
+  const [overview, recentRes] = await Promise.all([
+    getAdvisorApplicationOverview(),
+    supabase
+      .from("advisor_applications")
+      .select("id, name, firm_name, email, type, afsl_number, abn, status, rejection_reason, reviewed_by, admin_notes, created_at")
+      .order("created_at", { ascending: false })
+      .limit(50),
+  ]);
+  const rows = recentRes.data || [];
+
+  return (
+    <DrillDownShell overview={overview}>
+      <section className="bg-white border border-slate-200 rounded-xl overflow-hidden">
+        <header className="px-4 py-3 border-b border-slate-100 bg-slate-50">
+          <h2 className="text-sm font-bold text-slate-900">Recent applications</h2>
+          <p className="text-xs text-slate-500">Most recent 50 applications. Set <code>AFSL_LOOKUP_URL</code> + <code>ABN_LOOKUP_GUID</code> env vars to activate auto-verification.</p>
+        </header>
+        <div className="overflow-x-auto">
+          <table className="w-full text-xs">
+            <thead className="bg-slate-50 border-b border-slate-100">
+              <tr>
+                <th className="px-4 py-2 text-left font-semibold text-slate-600">ID</th>
+                <th className="px-4 py-2 text-left font-semibold text-slate-600">Name / firm</th>
+                <th className="px-4 py-2 text-left font-semibold text-slate-600">Type</th>
+                <th className="px-4 py-2 text-left font-semibold text-slate-600">AFSL / ABN</th>
+                <th className="px-4 py-2 text-left font-semibold text-slate-600">Status</th>
+                <th className="px-4 py-2 text-left font-semibold text-slate-600">Reviewed by</th>
+                <th className="px-4 py-2 text-left font-semibold text-slate-600">Classifier notes</th>
+                <th className="px-4 py-2 text-left font-semibold text-slate-600">Action</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100">
+              {rows.map((r) => (
+                <tr key={r.id} className="hover:bg-slate-50/50">
+                  <td className="px-4 py-2 font-mono text-slate-500">#{r.id}</td>
+                  <td className="px-4 py-2 text-slate-700">
+                    <div className="truncate max-w-[180px]">{r.name}</div>
+                    {r.firm_name && <div className="text-[0.65rem] text-slate-400 truncate max-w-[180px]">{r.firm_name}</div>}
+                  </td>
+                  <td className="px-4 py-2 text-slate-600">{r.type}</td>
+                  <td className="px-4 py-2 text-slate-500 text-[0.65rem]">
+                    {r.afsl_number ? `AFSL ${r.afsl_number}` : "—"}
+                    <br />
+                    {r.abn ? `ABN ${r.abn}` : "—"}
+                  </td>
+                  <td className="px-4 py-2">
+                    <span className={`inline-block px-2 py-0.5 rounded text-[0.65rem] font-semibold ${r.status === "approved" ? "bg-emerald-100 text-emerald-800" : r.status === "rejected" ? "bg-red-100 text-red-800" : "bg-slate-100 text-slate-600"}`}>{r.status}</span>
+                  </td>
+                  <td className="px-4 py-2 text-slate-600">{r.reviewed_by || "—"}</td>
+                  <td className="px-4 py-2 text-[0.65rem] text-slate-500 max-w-[220px]">
+                    <div className="line-clamp-2" title={r.admin_notes || ""}>{r.admin_notes || "—"}</div>
+                    {r.rejection_reason && <div className="text-red-600 mt-1 line-clamp-1">{r.rejection_reason}</div>}
+                  </td>
+                  <td className="px-4 py-2">
+                    {r.status === "pending" ? (
+                      <div className="flex gap-1">
+                        <OverrideButton feature="advisor_applications" rowId={r.id} targetVerdict="approved" label="Approve" />
+                        <OverrideButton feature="advisor_applications" rowId={r.id} targetVerdict="rejected" label="Reject" />
+                      </div>
+                    ) : r.status === "approved" ? (
+                      <OverrideButton feature="advisor_applications" rowId={r.id} targetVerdict="rejected" label="→ Reject" requireReason />
+                    ) : (
+                      <OverrideButton feature="advisor_applications" rowId={r.id} targetVerdict="approved" label="→ Approve" requireReason />
+                    )}
+                  </td>
+                </tr>
+              ))}
+              {rows.length === 0 && (
+                <tr><td colSpan={8} className="px-4 py-6 text-center text-slate-500">No applications</td></tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </DrillDownShell>
+  );
+}

--- a/app/admin/automation/broker-changes/page.tsx
+++ b/app/admin/automation/broker-changes/page.tsx
@@ -1,0 +1,71 @@
+import { createAdminClient } from "@/lib/supabase/admin";
+import DrillDownShell from "@/components/admin/automation/DrillDownShell";
+import { getBrokerChangesOverview } from "@/lib/admin/automation-metrics";
+
+export const dynamic = "force-dynamic";
+
+export default async function BrokerChangesDrillDown() {
+  const supabase = createAdminClient();
+  const [overview, recentRes] = await Promise.all([
+    getBrokerChangesOverview(),
+    supabase
+      .from("broker_data_changes")
+      .select("id, broker_slug, change_type, field, old_value, new_value, auto_applied_at, auto_applied_tier, applied_at, created_at")
+      .order("created_at", { ascending: false })
+      .limit(50),
+  ]);
+  const rows = recentRes.data || [];
+
+  return (
+    <DrillDownShell overview={overview}>
+      <section className="bg-white border border-slate-200 rounded-xl overflow-hidden">
+        <header className="px-4 py-3 border-b border-slate-100 bg-slate-50">
+          <h2 className="text-sm font-bold text-slate-900">Recent broker data changes</h2>
+          <p className="text-xs text-slate-500">Classified by risk tier — cosmetic edits auto-apply, money/compliance fields require admin approval.</p>
+        </header>
+        <table className="w-full text-xs">
+          <thead className="bg-slate-50 border-b border-slate-100">
+            <tr>
+              <th className="px-4 py-2 text-left font-semibold text-slate-600">ID</th>
+              <th className="px-4 py-2 text-left font-semibold text-slate-600">Broker</th>
+              <th className="px-4 py-2 text-left font-semibold text-slate-600">Field</th>
+              <th className="px-4 py-2 text-left font-semibold text-slate-600">Old → New</th>
+              <th className="px-4 py-2 text-left font-semibold text-slate-600">Tier</th>
+              <th className="px-4 py-2 text-left font-semibold text-slate-600">Status</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-100">
+            {rows.map((r) => (
+              <tr key={r.id}>
+                <td className="px-4 py-2 font-mono text-slate-500">#{r.id}</td>
+                <td className="px-4 py-2 text-slate-700 font-semibold">{r.broker_slug}</td>
+                <td className="px-4 py-2 text-slate-600">{r.field}</td>
+                <td className="px-4 py-2 text-[0.65rem] text-slate-500 max-w-[200px]">
+                  <div className="truncate" title={String(r.old_value)}>
+                    <span className="text-slate-400">from:</span> {String(r.old_value)?.slice(0, 40)}
+                  </div>
+                  <div className="truncate" title={String(r.new_value)}>
+                    <span className="text-emerald-600">to:</span> {String(r.new_value)?.slice(0, 40)}
+                  </div>
+                </td>
+                <td className="px-4 py-2">
+                  {r.auto_applied_tier ? (
+                    <span className={`inline-block px-2 py-0.5 rounded text-[0.65rem] font-semibold ${r.auto_applied_tier === "auto_apply" ? "bg-emerald-100 text-emerald-800" : r.auto_applied_tier === "auto_apply_reviewable" ? "bg-amber-100 text-amber-800" : "bg-red-100 text-red-800"}`}>
+                      {r.auto_applied_tier}
+                    </span>
+                  ) : "—"}
+                </td>
+                <td className="px-4 py-2 text-[0.65rem] text-slate-500">
+                  {r.auto_applied_at ? "Auto-applied" : r.applied_at ? "Applied by admin" : "Pending"}
+                </td>
+              </tr>
+            ))}
+            {rows.length === 0 && (
+              <tr><td colSpan={6} className="px-4 py-6 text-center text-slate-500">No recent changes</td></tr>
+            )}
+          </tbody>
+        </table>
+      </section>
+    </DrillDownShell>
+  );
+}

--- a/app/admin/automation/campaigns/page.tsx
+++ b/app/admin/automation/campaigns/page.tsx
@@ -1,0 +1,62 @@
+import { createAdminClient } from "@/lib/supabase/admin";
+import DrillDownShell from "@/components/admin/automation/DrillDownShell";
+import { getMarketplaceCampaignOverview } from "@/lib/admin/automation-metrics";
+
+export const dynamic = "force-dynamic";
+
+export default async function CampaignsDrillDown() {
+  const supabase = createAdminClient();
+  const [overview, recentRes] = await Promise.all([
+    getMarketplaceCampaignOverview(),
+    supabase
+      .from("campaigns")
+      .select("id, broker_slug, inventory_type, status, budget_cents, start_date, end_date, created_at")
+      .order("created_at", { ascending: false })
+      .limit(50),
+  ]);
+  const rows = recentRes.data || [];
+
+  return (
+    <DrillDownShell overview={overview}>
+      <section className="bg-white border border-slate-200 rounded-xl overflow-hidden">
+        <header className="px-4 py-3 border-b border-slate-100 bg-slate-50">
+          <h2 className="text-sm font-bold text-slate-900">Recent campaigns</h2>
+          <p className="text-xs text-slate-500">Submitted by brokers. Status reflects the classifier verdict for auto-decided rows.</p>
+        </header>
+        <table className="w-full text-xs">
+          <thead className="bg-slate-50 border-b border-slate-100">
+            <tr>
+              <th className="px-4 py-2 text-left font-semibold text-slate-600">ID</th>
+              <th className="px-4 py-2 text-left font-semibold text-slate-600">Broker</th>
+              <th className="px-4 py-2 text-left font-semibold text-slate-600">Type</th>
+              <th className="px-4 py-2 text-left font-semibold text-slate-600">Budget</th>
+              <th className="px-4 py-2 text-left font-semibold text-slate-600">Dates</th>
+              <th className="px-4 py-2 text-left font-semibold text-slate-600">Status</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-100">
+            {rows.map((r) => (
+              <tr key={r.id}>
+                <td className="px-4 py-2 font-mono text-slate-500">#{r.id}</td>
+                <td className="px-4 py-2 text-slate-700 font-semibold">{r.broker_slug}</td>
+                <td className="px-4 py-2 text-slate-600">{r.inventory_type}</td>
+                <td className="px-4 py-2 font-semibold text-slate-700">A${((r.budget_cents || 0) / 100).toFixed(0)}</td>
+                <td className="px-4 py-2 text-[0.65rem] text-slate-500">
+                  {r.start_date} → {r.end_date}
+                </td>
+                <td className="px-4 py-2">
+                  <span className={`inline-block px-2 py-0.5 rounded text-[0.65rem] font-semibold ${r.status === "active" ? "bg-emerald-100 text-emerald-800" : r.status === "rejected" ? "bg-red-100 text-red-800" : "bg-slate-100 text-slate-600"}`}>
+                    {r.status}
+                  </span>
+                </td>
+              </tr>
+            ))}
+            {rows.length === 0 && (
+              <tr><td colSpan={6} className="px-4 py-6 text-center text-slate-500">No recent campaigns</td></tr>
+            )}
+          </tbody>
+        </table>
+      </section>
+    </DrillDownShell>
+  );
+}

--- a/app/admin/automation/disputes/page.tsx
+++ b/app/admin/automation/disputes/page.tsx
@@ -1,0 +1,112 @@
+import { createAdminClient } from "@/lib/supabase/admin";
+import DrillDownShell from "@/components/admin/automation/DrillDownShell";
+import SignalsPopover from "@/components/admin/automation/SignalsPopover";
+import OverrideButton from "@/components/admin/automation/OverrideButton";
+import { getLeadDisputeOverview } from "@/lib/admin/automation-metrics";
+
+export const dynamic = "force-dynamic";
+
+export default async function DisputesDrillDown() {
+  const supabase = createAdminClient();
+  const [overview, recentRes] = await Promise.all([
+    getLeadDisputeOverview(),
+    supabase
+      .from("lead_disputes")
+      .select("id, lead_id, professional_id, reason, reason_code, status, auto_resolved_verdict, auto_resolved_confidence, auto_resolved_reasons, refunded_cents, created_at, admin_overridden_at, professionals(name), professional_leads(user_name, user_email)")
+      .order("created_at", { ascending: false })
+      .limit(50),
+  ]);
+
+  const rows = (recentRes.data as unknown as Array<{
+    id: number;
+    lead_id: number;
+    professional_id: number;
+    reason: string;
+    reason_code: string | null;
+    status: string;
+    auto_resolved_verdict: string | null;
+    auto_resolved_confidence: string | null;
+    auto_resolved_reasons: string[] | null;
+    refunded_cents: number | null;
+    created_at: string;
+    admin_overridden_at: string | null;
+    professionals: { name: string } | null;
+    professional_leads: { user_name: string; user_email: string } | null;
+  }>) || [];
+
+  return (
+    <DrillDownShell overview={overview}>
+      <section className="bg-white border border-slate-200 rounded-xl overflow-hidden">
+        <header className="px-4 py-3 border-b border-slate-100 bg-slate-50">
+          <h2 className="text-sm font-bold text-slate-900">Recent disputes</h2>
+          <p className="text-xs text-slate-500">Last 50 disputes, newest first. Override reverses the auto-verdict + moves any credit both ways.</p>
+        </header>
+        <div className="overflow-x-auto">
+          <table className="w-full text-xs">
+            <thead className="bg-slate-50 border-b border-slate-100">
+              <tr>
+                <th className="px-4 py-2 text-left font-semibold text-slate-600">ID</th>
+                <th className="px-4 py-2 text-left font-semibold text-slate-600">Advisor</th>
+                <th className="px-4 py-2 text-left font-semibold text-slate-600">Lead</th>
+                <th className="px-4 py-2 text-left font-semibold text-slate-600">Reason</th>
+                <th className="px-4 py-2 text-left font-semibold text-slate-600">Status</th>
+                <th className="px-4 py-2 text-left font-semibold text-slate-600">Verdict</th>
+                <th className="px-4 py-2 text-left font-semibold text-slate-600">Signals</th>
+                <th className="px-4 py-2 text-left font-semibold text-slate-600">Refunded</th>
+                <th className="px-4 py-2 text-left font-semibold text-slate-600">Override</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100">
+              {rows.map((r) => (
+                <tr key={r.id} className="hover:bg-slate-50/50">
+                  <td className="px-4 py-2 font-mono text-slate-500">#{r.id}</td>
+                  <td className="px-4 py-2 text-slate-700 truncate max-w-[140px]">{r.professionals?.name || "—"}</td>
+                  <td className="px-4 py-2 text-slate-500 truncate max-w-[160px]">{r.professional_leads?.user_email || "—"}</td>
+                  <td className="px-4 py-2 text-slate-700">{r.reason_code || r.reason?.slice(0, 30)}</td>
+                  <td className="px-4 py-2">
+                    <StatusBadge status={r.status} />
+                  </td>
+                  <td className="px-4 py-2">
+                    {r.auto_resolved_verdict ? (
+                      <span className="text-slate-700">
+                        {r.auto_resolved_verdict}{r.auto_resolved_confidence ? ` (${r.auto_resolved_confidence})` : ""}
+                      </span>
+                    ) : "—"}
+                  </td>
+                  <td className="px-4 py-2">
+                    <SignalsPopover reasons={r.auto_resolved_reasons} />
+                  </td>
+                  <td className="px-4 py-2 text-slate-700">
+                    {r.refunded_cents ? `A$${((r.refunded_cents) / 100).toFixed(2)}` : "—"}
+                  </td>
+                  <td className="px-4 py-2">
+                    {r.admin_overridden_at ? (
+                      <span className="text-[0.65rem] text-amber-700">overridden</span>
+                    ) : r.status === "approved" ? (
+                      <OverrideButton feature="lead_disputes" rowId={r.id} targetVerdict="rejected" label="→ Reject" requireReason />
+                    ) : r.status === "rejected" ? (
+                      <OverrideButton feature="lead_disputes" rowId={r.id} targetVerdict="approved" label="→ Refund" requireReason />
+                    ) : (
+                      <span className="text-[0.65rem] text-slate-400">pending</span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+              {rows.length === 0 && (
+                <tr><td colSpan={9} className="px-4 py-6 text-center text-slate-500">No recent disputes</td></tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </DrillDownShell>
+  );
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const cls =
+    status === "approved" ? "bg-emerald-100 text-emerald-800" :
+    status === "rejected" ? "bg-red-100 text-red-800" :
+    "bg-slate-100 text-slate-600";
+  return <span className={`inline-block px-2 py-0.5 rounded text-[0.65rem] font-semibold ${cls}`}>{status}</span>;
+}

--- a/app/admin/automation/dunning/page.tsx
+++ b/app/admin/automation/dunning/page.tsx
@@ -1,0 +1,80 @@
+import { createAdminClient } from "@/lib/supabase/admin";
+import DrillDownShell from "@/components/admin/automation/DrillDownShell";
+import { getDunningOverview } from "@/lib/admin/automation-metrics";
+
+export const dynamic = "force-dynamic";
+
+export default async function DunningDrillDown() {
+  const supabase = createAdminClient();
+  const [overview, failedRes] = await Promise.all([
+    getDunningOverview(),
+    supabase
+      .from("advisor_credit_topups")
+      .select("id, professional_id, amount_cents, status, dunning_step, dunning_last_attempt_at, created_at, professionals(name, email)")
+      .eq("status", "failed")
+      .order("created_at", { ascending: false })
+      .limit(50),
+  ]);
+
+  const rows = (failedRes.data as unknown as Array<{
+    id: number;
+    professional_id: number;
+    amount_cents: number;
+    status: string;
+    dunning_step: number | null;
+    dunning_last_attempt_at: string | null;
+    created_at: string;
+    professionals: { name: string; email: string } | null;
+  }>) || [];
+
+  const stepLabels = ["Pending", "Day 1 retry", "Day 3 retry", "Day 7 final"];
+
+  return (
+    <DrillDownShell overview={overview}>
+      <section className="bg-white border border-slate-200 rounded-xl overflow-hidden">
+        <header className="px-4 py-3 border-b border-slate-100 bg-red-50">
+          <h2 className="text-sm font-bold text-slate-900">Failed top-ups</h2>
+          <p className="text-xs text-slate-500">Each row represents a failed Stripe charge currently in the dunning sequence.</p>
+        </header>
+        <table className="w-full text-xs">
+          <thead className="bg-slate-50 border-b border-slate-100">
+            <tr>
+              <th className="px-4 py-2 text-left font-semibold text-slate-600">ID</th>
+              <th className="px-4 py-2 text-left font-semibold text-slate-600">Advisor</th>
+              <th className="px-4 py-2 text-left font-semibold text-slate-600">Amount</th>
+              <th className="px-4 py-2 text-left font-semibold text-slate-600">Dunning step</th>
+              <th className="px-4 py-2 text-left font-semibold text-slate-600">Last attempt</th>
+              <th className="px-4 py-2 text-left font-semibold text-slate-600">Created</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-100">
+            {rows.map((r) => (
+              <tr key={r.id}>
+                <td className="px-4 py-2 font-mono text-slate-500">#{r.id}</td>
+                <td className="px-4 py-2 text-slate-700">
+                  {r.professionals?.name}
+                  <div className="text-[0.65rem] text-slate-400">{r.professionals?.email}</div>
+                </td>
+                <td className="px-4 py-2 font-semibold text-slate-700">A${(r.amount_cents / 100).toFixed(2)}</td>
+                <td className="px-4 py-2">
+                  <span className={`inline-block px-2 py-0.5 rounded text-[0.65rem] font-semibold ${(r.dunning_step || 0) >= 3 ? "bg-red-100 text-red-800" : (r.dunning_step || 0) >= 1 ? "bg-amber-100 text-amber-800" : "bg-slate-100 text-slate-600"}`}>
+                    {stepLabels[r.dunning_step || 0]}
+                  </span>
+                </td>
+                <td className="px-4 py-2 text-[0.65rem] text-slate-500">
+                  {r.dunning_last_attempt_at ? new Date(r.dunning_last_attempt_at).toLocaleString("en-AU") : "—"}
+                </td>
+                <td className="px-4 py-2 text-[0.65rem] text-slate-500">
+                  {new Date(r.created_at).toLocaleString("en-AU")}
+                </td>
+              </tr>
+            ))}
+            {rows.length === 0 && (
+              <tr><td colSpan={6} className="px-4 py-6 text-center text-slate-500">No failed top-ups currently</td></tr>
+            )}
+          </tbody>
+        </table>
+      </section>
+    </DrillDownShell>
+  );
+}

--- a/app/admin/automation/email-suppression/page.tsx
+++ b/app/admin/automation/email-suppression/page.tsx
@@ -1,0 +1,57 @@
+import { createAdminClient } from "@/lib/supabase/admin";
+import DrillDownShell from "@/components/admin/automation/DrillDownShell";
+import { getEmailBouncesOverview } from "@/lib/admin/automation-metrics";
+
+export const dynamic = "force-dynamic";
+
+export default async function EmailSuppressionDrillDown() {
+  const supabase = createAdminClient();
+  const [overview, suppressedRes] = await Promise.all([
+    getEmailBouncesOverview(),
+    supabase
+      .from("email_suppression_list")
+      .select("email, reason, source, bounce_count, first_seen_at, last_seen_at")
+      .order("last_seen_at", { ascending: false })
+      .limit(200),
+  ]);
+
+  return (
+    <DrillDownShell overview={overview}>
+      <section className="bg-white border border-slate-200 rounded-xl overflow-hidden">
+        <header className="px-4 py-3 border-b border-slate-100 bg-slate-50">
+          <h2 className="text-sm font-bold text-slate-900">Suppression list</h2>
+          <p className="text-xs text-slate-500">Emails on this list are skipped by every transactional send helper. Top 200 by recency.</p>
+        </header>
+        <table className="w-full text-xs">
+          <thead className="bg-slate-50 border-b border-slate-100">
+            <tr>
+              <th className="px-4 py-2 text-left font-semibold text-slate-600">Email</th>
+              <th className="px-4 py-2 text-left font-semibold text-slate-600">Reason</th>
+              <th className="px-4 py-2 text-left font-semibold text-slate-600">Source</th>
+              <th className="px-4 py-2 text-left font-semibold text-slate-600">Bounces</th>
+              <th className="px-4 py-2 text-left font-semibold text-slate-600">Last seen</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-100">
+            {(suppressedRes.data || []).map((r) => (
+              <tr key={r.email}>
+                <td className="px-4 py-2 font-mono text-slate-700">{r.email}</td>
+                <td className="px-4 py-2">
+                  <span className="inline-block px-2 py-0.5 rounded text-[0.65rem] font-semibold bg-red-100 text-red-800">{r.reason}</span>
+                </td>
+                <td className="px-4 py-2 text-[0.65rem] text-slate-500">{r.source || "—"}</td>
+                <td className="px-4 py-2 text-slate-600">{r.bounce_count || 1}</td>
+                <td className="px-4 py-2 text-[0.65rem] text-slate-500">
+                  {r.last_seen_at ? new Date(r.last_seen_at).toLocaleDateString("en-AU") : "—"}
+                </td>
+              </tr>
+            ))}
+            {(suppressedRes.data?.length || 0) === 0 && (
+              <tr><td colSpan={5} className="px-4 py-6 text-center text-slate-500">No suppressed emails</td></tr>
+            )}
+          </tbody>
+        </table>
+      </section>
+    </DrillDownShell>
+  );
+}

--- a/app/admin/automation/listings/page.tsx
+++ b/app/admin/automation/listings/page.tsx
@@ -1,0 +1,93 @@
+import { createAdminClient } from "@/lib/supabase/admin";
+import DrillDownShell from "@/components/admin/automation/DrillDownShell";
+import SignalsPopover from "@/components/admin/automation/SignalsPopover";
+import OverrideButton from "@/components/admin/automation/OverrideButton";
+import { getListingScamOverview } from "@/lib/admin/automation-metrics";
+
+export const dynamic = "force-dynamic";
+
+export default async function ListingsDrillDown() {
+  const supabase = createAdminClient();
+  const [overview, recentRes] = await Promise.all([
+    getListingScamOverview(),
+    supabase
+      .from("investment_listings")
+      .select("id, title, vertical, status, contact_email, auto_classified_verdict, auto_classified_risk_score, auto_classified_reasons, created_at")
+      .order("created_at", { ascending: false })
+      .limit(50),
+  ]);
+  const rows = recentRes.data || [];
+
+  return (
+    <DrillDownShell overview={overview}>
+      <section className="bg-white border border-slate-200 rounded-xl overflow-hidden">
+        <header className="px-4 py-3 border-b border-slate-100 bg-slate-50">
+          <h2 className="text-sm font-bold text-slate-900">Recent listings</h2>
+          <p className="text-xs text-slate-500">Sorted by risk score descending. High risk rows at the top need human review.</p>
+        </header>
+        <div className="overflow-x-auto">
+          <table className="w-full text-xs">
+            <thead className="bg-slate-50 border-b border-slate-100">
+              <tr>
+                <th className="px-4 py-2 text-left font-semibold text-slate-600">ID</th>
+                <th className="px-4 py-2 text-left font-semibold text-slate-600">Title</th>
+                <th className="px-4 py-2 text-left font-semibold text-slate-600">Vertical</th>
+                <th className="px-4 py-2 text-left font-semibold text-slate-600">Contact</th>
+                <th className="px-4 py-2 text-left font-semibold text-slate-600">Status</th>
+                <th className="px-4 py-2 text-left font-semibold text-slate-600">Verdict</th>
+                <th className="px-4 py-2 text-left font-semibold text-slate-600">Risk</th>
+                <th className="px-4 py-2 text-left font-semibold text-slate-600">Signals</th>
+                <th className="px-4 py-2 text-left font-semibold text-slate-600">Action</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100">
+              {rows.sort((a, b) => (b.auto_classified_risk_score || 0) - (a.auto_classified_risk_score || 0)).map((r) => (
+                <tr key={r.id} className="hover:bg-slate-50/50">
+                  <td className="px-4 py-2 font-mono text-slate-500">#{r.id}</td>
+                  <td className="px-4 py-2 text-slate-700 max-w-[200px] truncate" title={r.title}>{r.title}</td>
+                  <td className="px-4 py-2 text-slate-600">{r.vertical}</td>
+                  <td className="px-4 py-2 text-[0.65rem] text-slate-500 max-w-[180px] truncate" title={r.contact_email}>{r.contact_email}</td>
+                  <td className="px-4 py-2">
+                    <span className={`inline-block px-2 py-0.5 rounded text-[0.65rem] font-semibold ${r.status === "active" ? "bg-emerald-100 text-emerald-800" : r.status === "rejected" ? "bg-red-100 text-red-800" : "bg-slate-100 text-slate-600"}`}>{r.status}</span>
+                  </td>
+                  <td className="px-4 py-2 text-slate-600 text-[0.7rem]">{r.auto_classified_verdict || "—"}</td>
+                  <td className="px-4 py-2">
+                    {r.auto_classified_risk_score !== null ? (
+                      <div className="flex items-center gap-1">
+                        <div className="w-16 h-1.5 bg-slate-100 rounded overflow-hidden">
+                          <div
+                            className={`h-full ${(r.auto_classified_risk_score || 0) > 70 ? "bg-red-500" : (r.auto_classified_risk_score || 0) > 40 ? "bg-amber-500" : "bg-emerald-500"}`}
+                            style={{ width: `${r.auto_classified_risk_score}%` }}
+                          />
+                        </div>
+                        <span className="text-[0.65rem] font-mono text-slate-600">{r.auto_classified_risk_score}</span>
+                      </div>
+                    ) : "—"}
+                  </td>
+                  <td className="px-4 py-2">
+                    <SignalsPopover reasons={(r.auto_classified_reasons as string[] | null) || null} />
+                  </td>
+                  <td className="px-4 py-2">
+                    {r.status === "pending" ? (
+                      <div className="flex gap-1">
+                        <OverrideButton feature="listing_scam" rowId={r.id} targetVerdict="active" label="Approve" />
+                        <OverrideButton feature="listing_scam" rowId={r.id} targetVerdict="rejected" label="Reject" />
+                      </div>
+                    ) : r.status === "active" ? (
+                      <OverrideButton feature="listing_scam" rowId={r.id} targetVerdict="rejected" label="→ Unpublish" requireReason />
+                    ) : (
+                      <OverrideButton feature="listing_scam" rowId={r.id} targetVerdict="active" label="→ Publish" requireReason />
+                    )}
+                  </td>
+                </tr>
+              ))}
+              {rows.length === 0 && (
+                <tr><td colSpan={9} className="px-4 py-6 text-center text-slate-500">No listings</td></tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </DrillDownShell>
+  );
+}

--- a/app/admin/automation/moderation/page.tsx
+++ b/app/admin/automation/moderation/page.tsx
@@ -1,0 +1,128 @@
+import { createAdminClient } from "@/lib/supabase/admin";
+import DrillDownShell from "@/components/admin/automation/DrillDownShell";
+import SignalsPopover from "@/components/admin/automation/SignalsPopover";
+import OverrideButton from "@/components/admin/automation/OverrideButton";
+import { getTextModerationOverview } from "@/lib/admin/automation-metrics";
+
+export const dynamic = "force-dynamic";
+
+export default async function ModerationDrillDown() {
+  const supabase = createAdminClient();
+  const [overview, brokerRes, advisorRes] = await Promise.all([
+    getTextModerationOverview(),
+    supabase
+      .from("user_reviews")
+      .select("id, broker_slug, display_name, title, body, status, auto_moderated_verdict, auto_moderated_reasons, created_at")
+      .order("created_at", { ascending: false })
+      .limit(30),
+    supabase
+      .from("professional_reviews")
+      .select("id, professional_id, reviewer_name, title, body, status, auto_moderated_verdict, auto_moderated_reasons, created_at")
+      .order("created_at", { ascending: false })
+      .limit(30),
+  ]);
+
+  return (
+    <DrillDownShell overview={overview}>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
+        <ReviewTable
+          title="Broker reviews"
+          subtitle="user_reviews table"
+          subSurface="broker_review"
+          rows={(brokerRes.data || []).map((r) => ({
+            id: r.id,
+            target: r.broker_slug,
+            author: r.display_name || "Anonymous",
+            title: r.title,
+            body: r.body,
+            status: r.status || "pending",
+            verdict: r.auto_moderated_verdict,
+            reasons: r.auto_moderated_reasons as string[] | null,
+          }))}
+        />
+        <ReviewTable
+          title="Advisor reviews"
+          subtitle="professional_reviews table"
+          subSurface="advisor_review"
+          rows={(advisorRes.data || []).map((r) => ({
+            id: r.id,
+            target: `advisor #${r.professional_id}`,
+            author: r.reviewer_name || "Anonymous",
+            title: r.title,
+            body: r.body,
+            status: r.status || "pending",
+            verdict: r.auto_moderated_verdict,
+            reasons: r.auto_moderated_reasons as string[] | null,
+          }))}
+        />
+      </div>
+    </DrillDownShell>
+  );
+}
+
+interface ReviewRow {
+  id: number;
+  target: string;
+  author: string;
+  title: string | null;
+  body: string | null;
+  status: string;
+  verdict: string | null;
+  reasons: string[] | null;
+}
+
+function ReviewTable({
+  title,
+  subtitle,
+  subSurface,
+  rows,
+}: {
+  title: string;
+  subtitle: string;
+  subSurface: string;
+  rows: ReviewRow[];
+}) {
+  return (
+    <section className="bg-white border border-slate-200 rounded-xl overflow-hidden">
+      <header className="px-4 py-3 border-b border-slate-100 bg-slate-50">
+        <h2 className="text-sm font-bold text-slate-900">{title}</h2>
+        <p className="text-xs text-slate-500">{subtitle}</p>
+      </header>
+      <ul className="divide-y divide-slate-100 max-h-[600px] overflow-y-auto">
+        {rows.map((r) => (
+          <li key={r.id} className="px-4 py-3">
+            <div className="flex items-start justify-between gap-3 mb-1">
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2 text-[0.65rem] text-slate-500 mb-0.5">
+                  <span className="font-mono">#{r.id}</span>
+                  <span>·</span>
+                  <span>{r.target}</span>
+                  <span>·</span>
+                  <span>{r.author}</span>
+                </div>
+                {r.title && <p className="text-xs font-semibold text-slate-900">{r.title}</p>}
+                <p className="text-[0.7rem] text-slate-600 line-clamp-2">{r.body || "—"}</p>
+              </div>
+              <div className="shrink-0 flex flex-col items-end gap-1">
+                <span className={`inline-block px-2 py-0.5 rounded text-[0.6rem] font-semibold ${r.status === "published" ? "bg-emerald-100 text-emerald-800" : r.status === "rejected" ? "bg-red-100 text-red-800" : "bg-slate-100 text-slate-600"}`}>{r.status}</span>
+                <SignalsPopover reasons={r.reasons} label="Why" />
+              </div>
+            </div>
+            <div className="flex items-center gap-1 mt-1.5">
+              <span className="text-[0.6rem] text-slate-400">{r.verdict || "no classifier verdict"}</span>
+              <span className="ml-auto flex gap-1">
+                {r.status === "pending" && (
+                  <>
+                    <OverrideButton feature="text_moderation" rowId={r.id} targetVerdict="published" label="Publish" />
+                    <OverrideButton feature="text_moderation" rowId={r.id} targetVerdict="rejected" label="Reject" />
+                  </>
+                )}
+              </span>
+            </div>
+          </li>
+        ))}
+        {rows.length === 0 && <li className="px-4 py-6 text-center text-xs text-slate-500">No recent reviews</li>}
+      </ul>
+    </section>
+  );
+}

--- a/app/admin/automation/monthly-reports/page.tsx
+++ b/app/admin/automation/monthly-reports/page.tsx
@@ -1,0 +1,40 @@
+import DrillDownShell from "@/components/admin/automation/DrillDownShell";
+import { getMonthlyReportsOverview } from "@/lib/admin/automation-metrics";
+
+export const dynamic = "force-dynamic";
+
+export default async function MonthlyReportsDrillDown() {
+  const overview = await getMonthlyReportsOverview();
+  const stats = overview.lastRun?.stats || {};
+
+  return (
+    <DrillDownShell overview={overview}>
+      <section className="bg-white border border-slate-200 rounded-xl p-5">
+        <h2 className="text-sm font-bold text-slate-900 mb-3">Last run details</h2>
+        {overview.lastRun && overview.lastRun.status !== "never_run" ? (
+          <dl className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            <Stat label="Scanned" value={(stats.scanned as number) || 0} />
+            <Stat label="Emailed" value={(stats.emailed as number) || 0} />
+            <Stat label="Skipped (no leads)" value={(stats.skipped_no_leads as number) || 0} />
+            <Stat label="Errored" value={(stats.errored as number) || 0} />
+          </dl>
+        ) : (
+          <p className="text-xs text-slate-500">Never run. The cron fires on the 1st of each month at 9am AEST.</p>
+        )}
+        <p className="text-[0.7rem] text-slate-500 mt-4">
+          Each advisor with at least one lead last month receives a performance email with leads received /
+          responded / converted, average response time, and percentile rank across peers in the same category.
+        </p>
+      </section>
+    </DrillDownShell>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: number }) {
+  return (
+    <div>
+      <dt className="text-[0.6rem] font-semibold uppercase tracking-wider text-slate-500">{label}</dt>
+      <dd className="text-lg font-bold text-slate-900">{value}</dd>
+    </div>
+  );
+}

--- a/app/admin/automation/page.tsx
+++ b/app/admin/automation/page.tsx
@@ -1,0 +1,150 @@
+import Link from "next/link";
+import AdminShell from "@/components/AdminShell";
+import HealthTile from "@/components/admin/automation/HealthTile";
+import {
+  getAllFeatureOverviews,
+  type FeatureOverview,
+} from "@/lib/admin/automation-metrics";
+
+// Server component — fetches every feature overview in parallel.
+// `dynamic = "force-dynamic"` because the metrics change minute-to-
+// minute and we don't want stale numbers on the dashboard.
+export const dynamic = "force-dynamic";
+
+export default async function AdminAutomationPage() {
+  const overviews = await getAllFeatureOverviews();
+
+  const healthCounts = {
+    green: overviews.filter((o) => o.health === "green").length,
+    amber: overviews.filter((o) => o.health === "amber").length,
+    red: overviews.filter((o) => o.health === "red").length,
+    unknown: overviews.filter((o) => o.health === "unknown").length,
+  };
+
+  const needsAttention = buildNeedsAttentionFeed(overviews);
+
+  return (
+    <AdminShell title="Automation" subtitle="Classifier health + pending queues + manual controls">
+      <div className="p-4 md:p-6 max-w-7xl">
+        {/* ── Top summary bar ── */}
+        <div className="grid grid-cols-4 gap-3 mb-6">
+          <SummaryCard label="Healthy" value={healthCounts.green} dotClass="bg-emerald-500" />
+          <SummaryCard label="Warnings" value={healthCounts.amber} dotClass="bg-amber-500" />
+          <SummaryCard label="Errors" value={healthCounts.red} dotClass="bg-red-500" />
+          <SummaryCard label="Unknown" value={healthCounts.unknown} dotClass="bg-slate-400" />
+        </div>
+
+        {/* ── Needs attention feed ── */}
+        {needsAttention.length > 0 && (
+          <section className="mb-6 bg-white border border-slate-200 rounded-xl overflow-hidden">
+            <header className="px-4 py-3 border-b border-slate-100 bg-slate-50 flex items-center justify-between">
+              <h2 className="text-sm font-bold text-slate-900">Needs attention</h2>
+              <span className="text-xs text-slate-500">{needsAttention.length} items</span>
+            </header>
+            <ul className="divide-y divide-slate-100">
+              {needsAttention.map((item, i) => (
+                <li key={i} className="px-4 py-3 flex items-start gap-3">
+                  <span className={`w-2 h-2 rounded-full shrink-0 mt-1.5 ${item.severity === "red" ? "bg-red-500" : "bg-amber-500"}`} />
+                  <div className="flex-1 min-w-0">
+                    <Link
+                      href={`/admin/automation/${item.slug}`}
+                      className="text-sm font-semibold text-slate-900 hover:text-amber-600"
+                    >
+                      {item.title}
+                    </Link>
+                    <p className="text-xs text-slate-500 mt-0.5">{item.detail}</p>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        {/* ── Feature tile grid ── */}
+        <section>
+          <header className="mb-3 flex items-baseline justify-between">
+            <h2 className="text-sm font-bold text-slate-900">All features</h2>
+            <p className="text-xs text-slate-500">Click a tile to drill down, override decisions, and manually trigger crons.</p>
+          </header>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+            {overviews.map((overview) => (
+              <HealthTile key={overview.feature} overview={overview} />
+            ))}
+          </div>
+        </section>
+
+        {/* ── Docs / config link ── */}
+        <footer className="mt-8 pt-6 border-t border-slate-200 text-xs text-slate-500">
+          <p>
+            Classifier source of truth lives in <code className="bg-slate-100 px-1 rounded">lib/</code>.
+            Every cron logs to <code className="bg-slate-100 px-1 rounded">cron_run_log</code> table —
+            90-day retention. Override decisions are audited in the
+            <code className="bg-slate-100 px-1 rounded">admin_overridden_at / admin_overridden_by</code> columns on each target table.
+          </p>
+        </footer>
+      </div>
+    </AdminShell>
+  );
+}
+
+// ─── Summary card ─────────────────────────────────────────────────────
+
+function SummaryCard({
+  label,
+  value,
+  dotClass,
+}: {
+  label: string;
+  value: number;
+  dotClass: string;
+}) {
+  return (
+    <div className="bg-white border border-slate-200 rounded-xl p-4">
+      <div className="flex items-center gap-2 mb-1">
+        <span className={`w-2 h-2 rounded-full ${dotClass}`} />
+        <span className="text-[0.65rem] font-semibold uppercase tracking-wider text-slate-500">{label}</span>
+      </div>
+      <p className="text-2xl font-bold text-slate-900">{value}</p>
+    </div>
+  );
+}
+
+// ─── Needs-attention feed builder ────────────────────────────────────
+
+interface NeedsAttentionItem {
+  title: string;
+  detail: string;
+  slug: string;
+  severity: "amber" | "red";
+}
+
+function buildNeedsAttentionFeed(overviews: FeatureOverview[]): NeedsAttentionItem[] {
+  const items: NeedsAttentionItem[] = [];
+
+  for (const o of overviews) {
+    if (o.health === "red") {
+      items.push({
+        title: o.display.title,
+        detail:
+          o.lastRun?.errorMessage ||
+          (o.pending > 0 ? `${o.pending} items pending — queue is critical` : "Last run errored"),
+        slug: o.display.slug,
+        severity: "red",
+      });
+    } else if (o.health === "amber") {
+      items.push({
+        title: o.display.title,
+        detail:
+          o.pending > 0
+            ? `${o.pending} items pending review`
+            : o.lastRun?.status === "partial"
+              ? "Last run completed with partial failures"
+              : "Last run is overdue",
+        slug: o.display.slug,
+        severity: "amber",
+      });
+    }
+  }
+
+  return items;
+}

--- a/app/admin/automation/profile-gates/page.tsx
+++ b/app/admin/automation/profile-gates/page.tsx
@@ -1,0 +1,55 @@
+import { createAdminClient } from "@/lib/supabase/admin";
+import DrillDownShell from "@/components/admin/automation/DrillDownShell";
+import { getProfileGateOverview } from "@/lib/admin/automation-metrics";
+
+export const dynamic = "force-dynamic";
+
+export default async function ProfileGateDrillDown() {
+  const supabase = createAdminClient();
+  const [overview, stuckRes] = await Promise.all([
+    getProfileGateOverview(),
+    supabase
+      .from("professionals")
+      .select("id, name, email, profile_missing_fields, profile_gate_step, profile_gate_checked_at, created_at")
+      .eq("profile_quality_gate", "pending")
+      .order("created_at", { ascending: false })
+      .limit(100),
+  ]);
+
+  const rows = stuckRes.data || [];
+  const byStep: Record<number, typeof rows> = { 0: [], 1: [], 2: [], 3: [], 4: [] };
+  for (const r of rows) byStep[r.profile_gate_step || 0].push(r);
+
+  const stepLabels = ["Not started", "Day 1 warning", "Day 3 warning", "Day 7 warning", "Day 14 final"];
+
+  return (
+    <DrillDownShell overview={overview}>
+      <section className="bg-white border border-slate-200 rounded-xl overflow-hidden">
+        <header className="px-4 py-3 border-b border-slate-100 bg-slate-50">
+          <h2 className="text-sm font-bold text-slate-900">Advisors at quality gate</h2>
+          <p className="text-xs text-slate-500">Grouped by drip step. Advisors auto-unlock when all fields are filled.</p>
+        </header>
+        <div className="grid grid-cols-1 md:grid-cols-5 divide-x divide-slate-100">
+          {[0, 1, 2, 3, 4].map((step) => (
+            <div key={step} className="p-3">
+              <h3 className="text-[0.65rem] font-bold uppercase tracking-wider text-slate-500 mb-2">
+                {stepLabels[step]} ({byStep[step].length})
+              </h3>
+              <ul className="space-y-1">
+                {byStep[step].slice(0, 20).map((a) => (
+                  <li key={a.id} className="text-[0.7rem]">
+                    <div className="font-semibold text-slate-800 truncate">{a.name}</div>
+                    <div className="text-slate-400 text-[0.6rem]">
+                      {(a.profile_missing_fields || []).slice(0, 3).join(", ")}
+                    </div>
+                  </li>
+                ))}
+                {byStep[step].length === 0 && <li className="text-[0.65rem] text-slate-400">—</li>}
+              </ul>
+            </div>
+          ))}
+        </div>
+      </section>
+    </DrillDownShell>
+  );
+}

--- a/app/admin/automation/quality-weights/page.tsx
+++ b/app/admin/automation/quality-weights/page.tsx
@@ -1,0 +1,71 @@
+import { createAdminClient } from "@/lib/supabase/admin";
+import DrillDownShell from "@/components/admin/automation/DrillDownShell";
+import { getQualityWeightsOverview } from "@/lib/admin/automation-metrics";
+
+export const dynamic = "force-dynamic";
+
+export default async function QualityWeightsDrillDown() {
+  const supabase = createAdminClient();
+  const overview = await getQualityWeightsOverview();
+
+  // Pull the latest model_version's weights for display
+  const { data: latestVersion } = await supabase
+    .from("lead_quality_weights")
+    .select("model_version")
+    .order("model_version", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  const { data: weights } = latestVersion
+    ? await supabase
+        .from("lead_quality_weights")
+        .select("signal_name, weight, sample_size, hit_rate, computed_at")
+        .eq("model_version", latestVersion.model_version)
+        .order("weight", { ascending: false })
+    : { data: [] };
+
+  return (
+    <DrillDownShell overview={overview}>
+      <section className="bg-white border border-slate-200 rounded-xl overflow-hidden">
+        <header className="px-4 py-3 border-b border-slate-100 bg-slate-50">
+          <h2 className="text-sm font-bold text-slate-900">
+            Latest computed weights{latestVersion ? ` (v${latestVersion.model_version})` : ""}
+          </h2>
+          <p className="text-xs text-slate-500">
+            Recomputed nightly from 90-day conversion outcomes. The live scorer in <code className="bg-slate-100 px-1 rounded">/api/advisor-enquiry</code> currently uses hardcoded weights — flip it to read from this table when you're confident in the values.
+          </p>
+        </header>
+        {weights && weights.length > 0 ? (
+          <table className="w-full text-xs">
+            <thead className="bg-slate-50 border-b border-slate-100">
+              <tr>
+                <th className="px-4 py-2 text-left font-semibold text-slate-600">Signal</th>
+                <th className="px-4 py-2 text-left font-semibold text-slate-600">Weight</th>
+                <th className="px-4 py-2 text-left font-semibold text-slate-600">Sample size</th>
+                <th className="px-4 py-2 text-left font-semibold text-slate-600">Hit rate</th>
+                <th className="px-4 py-2 text-left font-semibold text-slate-600">Computed</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100">
+              {weights.map((w) => (
+                <tr key={w.signal_name}>
+                  <td className="px-4 py-2 font-mono text-slate-700">{w.signal_name}</td>
+                  <td className="px-4 py-2 font-semibold text-slate-900">{w.weight}</td>
+                  <td className="px-4 py-2 text-slate-600">{w.sample_size}</td>
+                  <td className="px-4 py-2 text-slate-600">{(Number(w.hit_rate) * 100).toFixed(2)}%</td>
+                  <td className="px-4 py-2 text-[0.65rem] text-slate-500">
+                    {new Date(w.computed_at).toLocaleDateString("en-AU")}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : (
+          <div className="p-6 text-center text-xs text-slate-500">
+            No computed weights yet. The nightly cron writes rows when at least 100 leads are available in the 90-day window.
+          </div>
+        )}
+      </section>
+    </DrillDownShell>
+  );
+}

--- a/app/admin/automation/sla/page.tsx
+++ b/app/admin/automation/sla/page.tsx
@@ -1,0 +1,77 @@
+import { createAdminClient } from "@/lib/supabase/admin";
+import DrillDownShell from "@/components/admin/automation/DrillDownShell";
+import { getLeadSlaOverview } from "@/lib/admin/automation-metrics";
+
+export const dynamic = "force-dynamic";
+
+export default async function SlaDrillDown() {
+  const supabase = createAdminClient();
+  const fourteenDaysAgo = new Date(Date.now() - 14 * 24 * 60 * 60 * 1000).toISOString();
+
+  const [overview, pausedRes, warnedRes] = await Promise.all([
+    getLeadSlaOverview(),
+    supabase
+      .from("professionals")
+      .select("id, name, email, auto_paused_at, auto_pause_reason")
+      .eq("status", "paused")
+      .eq("auto_pause_reason", "sla_miss")
+      .order("auto_paused_at", { ascending: false })
+      .limit(50),
+    supabase
+      .from("professionals")
+      .select("id, name, email, pause_warning_sent_at")
+      .eq("status", "active")
+      .not("pause_warning_sent_at", "is", null)
+      .gte("pause_warning_sent_at", fourteenDaysAgo)
+      .order("pause_warning_sent_at", { ascending: false })
+      .limit(50),
+  ]);
+
+  return (
+    <DrillDownShell overview={overview}>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
+        <section className="bg-white border border-slate-200 rounded-xl overflow-hidden">
+          <header className="px-4 py-3 border-b border-slate-100 bg-red-50">
+            <h2 className="text-sm font-bold text-slate-900">Paused for SLA miss</h2>
+            <p className="text-xs text-slate-500">{pausedRes.data?.length || 0} advisors currently auto-paused. Auto-unpause on next cron run when unresponded drops below 3.</p>
+          </header>
+          <ul className="divide-y divide-slate-100 max-h-[600px] overflow-y-auto">
+            {(pausedRes.data || []).map((a) => (
+              <li key={a.id} className="px-4 py-3">
+                <p className="text-sm font-semibold text-slate-900">{a.name}</p>
+                <p className="text-xs text-slate-500">{a.email}</p>
+                <p className="text-[0.65rem] text-slate-400 mt-0.5">
+                  Paused {a.auto_paused_at ? new Date(a.auto_paused_at).toLocaleString("en-AU") : "—"}
+                </p>
+              </li>
+            ))}
+            {(pausedRes.data?.length || 0) === 0 && (
+              <li className="px-4 py-6 text-center text-xs text-slate-500">No advisors currently paused for SLA</li>
+            )}
+          </ul>
+        </section>
+
+        <section className="bg-white border border-slate-200 rounded-xl overflow-hidden">
+          <header className="px-4 py-3 border-b border-slate-100 bg-amber-50">
+            <h2 className="text-sm font-bold text-slate-900">Warning in progress</h2>
+            <p className="text-xs text-slate-500">Advisors who have received an SLA warning in the last 14 days.</p>
+          </header>
+          <ul className="divide-y divide-slate-100 max-h-[600px] overflow-y-auto">
+            {(warnedRes.data || []).map((a) => (
+              <li key={a.id} className="px-4 py-3">
+                <p className="text-sm font-semibold text-slate-900">{a.name}</p>
+                <p className="text-xs text-slate-500">{a.email}</p>
+                <p className="text-[0.65rem] text-slate-400 mt-0.5">
+                  Warned {a.pause_warning_sent_at ? new Date(a.pause_warning_sent_at).toLocaleString("en-AU") : "—"}
+                </p>
+              </li>
+            ))}
+            {(warnedRes.data?.length || 0) === 0 && (
+              <li className="px-4 py-6 text-center text-xs text-slate-500">No active warnings</li>
+            )}
+          </ul>
+        </section>
+      </div>
+    </DrillDownShell>
+  );
+}

--- a/app/api/admin/automation/override/route.ts
+++ b/app/api/admin/automation/override/route.ts
@@ -1,0 +1,271 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { getAdminEmails } from "@/lib/admin";
+import { logger } from "@/lib/logger";
+
+const log = logger("admin:automation:override");
+
+/**
+ * POST /api/admin/automation/override
+ *
+ * Admin override for classifier decisions. Dispatches to the
+ * right handler based on `feature`. Every override writes
+ * admin_overridden_at + admin_overridden_by to the target row
+ * for audit.
+ *
+ * Body: { feature, rowId, targetVerdict, reason? }
+ *
+ * Feature dispatch table:
+ *   lead_disputes       → flip dispute status (approve ↔ reject)
+ *   listing_scam        → flip listing status
+ *   text_moderation     → flip review status (broker/advisor reviews)
+ *   advisor_applications → flip application status
+ *   broker_data_changes → apply a queued change or revert an auto-applied one
+ */
+export async function POST(request: NextRequest) {
+  // ── Auth ─────────────────────────────────────────────────
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user || !user.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const adminEmails = getAdminEmails();
+  if (!adminEmails.includes(user.email.toLowerCase())) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const body = await request.json().catch(() => ({}));
+  const feature = typeof body.feature === "string" ? body.feature : null;
+  const rowId = typeof body.rowId === "number" ? body.rowId : null;
+  const targetVerdict = typeof body.targetVerdict === "string" ? body.targetVerdict : null;
+  const reason = typeof body.reason === "string" ? body.reason : null;
+
+  if (!feature || !rowId || !targetVerdict) {
+    return NextResponse.json(
+      { error: "Missing feature / rowId / targetVerdict" },
+      { status: 400 },
+    );
+  }
+
+  const admin = createAdminClient();
+  const nowIso = new Date().toISOString();
+  const auditPatch = {
+    admin_overridden_at: nowIso,
+    admin_overridden_by: user.email,
+  };
+
+  try {
+    switch (feature) {
+      case "lead_disputes":
+        return await overrideLeadDispute(admin, rowId, targetVerdict, reason, auditPatch, user.email);
+      case "listing_scam":
+        return await overrideListing(admin, rowId, targetVerdict, auditPatch);
+      case "text_moderation":
+        return await overrideReview(admin, rowId, targetVerdict, body.subSurface, auditPatch);
+      case "advisor_applications":
+        return await overrideApplication(admin, rowId, targetVerdict, auditPatch, user.email);
+      case "broker_data_changes":
+        return await overrideBrokerChange(admin, rowId, targetVerdict, auditPatch);
+      default:
+        return NextResponse.json({ error: `Unknown feature: ${feature}` }, { status: 400 });
+    }
+  } catch (err) {
+    log.error("Override handler threw", {
+      feature,
+      rowId,
+      targetVerdict,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "override_failed" },
+      { status: 500 },
+    );
+  }
+}
+
+// ─── Per-feature override handlers ──────────────────────────────────
+
+type AdminClient = ReturnType<typeof createAdminClient>;
+
+async function overrideLeadDispute(
+  admin: AdminClient,
+  disputeId: number,
+  targetVerdict: string,
+  reason: string | null,
+  auditPatch: Record<string, string>,
+  adminEmail: string,
+) {
+  if (targetVerdict !== "approved" && targetVerdict !== "rejected") {
+    return NextResponse.json({ error: "targetVerdict must be approved or rejected" }, { status: 400 });
+  }
+
+  const { data: dispute } = await admin
+    .from("lead_disputes")
+    .select("id, lead_id, professional_id, status, refunded_cents")
+    .eq("id", disputeId)
+    .maybeSingle();
+
+  if (!dispute) {
+    return NextResponse.json({ error: "Dispute not found" }, { status: 404 });
+  }
+
+  // If flipping from rejected → approved, we need to actually refund
+  // the advisor. If flipping approved → rejected, we need to debit
+  // the refund back. These are money-movement operations — audit
+  // them carefully.
+  if (dispute.status === targetVerdict) {
+    return NextResponse.json({ error: "Dispute already in that state" }, { status: 400 });
+  }
+
+  const { data: lead } = await admin
+    .from("professional_leads")
+    .select("id, bill_amount_cents")
+    .eq("id", dispute.lead_id)
+    .maybeSingle();
+  const billAmount = lead?.bill_amount_cents || 0;
+
+  if (targetVerdict === "approved") {
+    // Credit the advisor the original bill amount (if not already refunded)
+    if (!dispute.refunded_cents) {
+      const { data: advisor } = await admin
+        .from("professionals")
+        .select("credit_balance_cents")
+        .eq("id", dispute.professional_id)
+        .single();
+      const currentBalance = advisor?.credit_balance_cents || 0;
+      await admin
+        .from("professionals")
+        .update({ credit_balance_cents: currentBalance + billAmount })
+        .eq("id", dispute.professional_id);
+      await admin
+        .from("professional_leads")
+        .update({ billed: false, outcome: "refunded_dispute" })
+        .eq("id", dispute.lead_id);
+    }
+    await admin
+      .from("lead_disputes")
+      .update({
+        status: "approved",
+        resolved_at: auditPatch.admin_overridden_at,
+        refunded_cents: billAmount,
+        admin_override_reason: reason,
+        ...auditPatch,
+      })
+      .eq("id", disputeId);
+  } else {
+    // Reversing an approved → rejected. Debit the previously-credited
+    // balance back. This could fail if the advisor has spent it in
+    // the meantime; in that case we leave the balance as-is and
+    // accept the accounting discrepancy — the log captures it.
+    if ((dispute.refunded_cents || 0) > 0) {
+      const { data: advisor } = await admin
+        .from("professionals")
+        .select("credit_balance_cents")
+        .eq("id", dispute.professional_id)
+        .single();
+      const currentBalance = advisor?.credit_balance_cents || 0;
+      const newBalance = Math.max(0, currentBalance - (dispute.refunded_cents || 0));
+      await admin
+        .from("professionals")
+        .update({ credit_balance_cents: newBalance })
+        .eq("id", dispute.professional_id);
+    }
+    await admin
+      .from("lead_disputes")
+      .update({
+        status: "rejected",
+        resolved_at: auditPatch.admin_overridden_at,
+        refunded_cents: 0,
+        admin_override_reason: reason,
+        ...auditPatch,
+      })
+      .eq("id", disputeId);
+  }
+
+  log.info("Lead dispute overridden", {
+    disputeId,
+    targetVerdict,
+    adminEmail,
+    refundAmount: billAmount,
+  });
+  return NextResponse.json({ ok: true });
+}
+
+async function overrideListing(
+  admin: AdminClient,
+  listingId: number,
+  targetVerdict: string,
+  auditPatch: Record<string, string>,
+) {
+  if (targetVerdict !== "active" && targetVerdict !== "rejected" && targetVerdict !== "pending") {
+    return NextResponse.json({ error: "targetVerdict must be active, rejected, or pending" }, { status: 400 });
+  }
+  await admin
+    .from("investment_listings")
+    .update({ status: targetVerdict, ...auditPatch })
+    .eq("id", listingId);
+  return NextResponse.json({ ok: true });
+}
+
+async function overrideReview(
+  admin: AdminClient,
+  reviewId: number,
+  targetVerdict: string,
+  subSurface: string | undefined,
+  auditPatch: Record<string, string>,
+) {
+  if (targetVerdict !== "published" && targetVerdict !== "rejected" && targetVerdict !== "pending") {
+    return NextResponse.json({ error: "targetVerdict must be published, rejected, or pending" }, { status: 400 });
+  }
+
+  const table = subSurface === "advisor_review" ? "professional_reviews" : "user_reviews";
+  await admin
+    .from(table)
+    .update({ status: targetVerdict, ...auditPatch })
+    .eq("id", reviewId);
+  return NextResponse.json({ ok: true });
+}
+
+async function overrideApplication(
+  admin: AdminClient,
+  applicationId: number,
+  targetVerdict: string,
+  auditPatch: Record<string, string>,
+  adminEmail: string,
+) {
+  if (targetVerdict !== "approved" && targetVerdict !== "rejected") {
+    return NextResponse.json({ error: "targetVerdict must be approved or rejected" }, { status: 400 });
+  }
+  await admin
+    .from("advisor_applications")
+    .update({
+      status: targetVerdict,
+      reviewed_at: auditPatch.admin_overridden_at,
+      reviewed_by: adminEmail,
+      ...auditPatch,
+    })
+    .eq("id", applicationId);
+  return NextResponse.json({ ok: true });
+}
+
+async function overrideBrokerChange(
+  admin: AdminClient,
+  changeId: number,
+  targetVerdict: string,
+  auditPatch: Record<string, string>,
+) {
+  if (targetVerdict !== "applied" && targetVerdict !== "reverted" && targetVerdict !== "rejected") {
+    return NextResponse.json({ error: "targetVerdict must be applied, reverted, or rejected" }, { status: 400 });
+  }
+  // For v1 we just stamp the audit columns. Actually applying the
+  // change (or reverting it) back to the broker row is handled by
+  // the existing /admin/brokers flow.
+  await admin
+    .from("broker_data_changes")
+    .update({ ...auditPatch, auto_applied_at: new Date().toISOString() })
+    .eq("id", changeId);
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/admin/automation/trigger/route.ts
+++ b/app/api/admin/automation/trigger/route.ts
@@ -1,0 +1,113 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { getAdminEmails } from "@/lib/admin";
+import { logger } from "@/lib/logger";
+import { FEATURE_CONFIG } from "@/lib/admin/automation-metrics";
+import { getSiteUrl } from "@/lib/url";
+
+const log = logger("admin:automation:trigger");
+
+// Allowlist of cron names that can be triggered from the admin dashboard.
+// Prevents abuse of the trigger endpoint to hit arbitrary cron routes.
+const ALLOWED_CRONS = new Set(
+  Object.values(FEATURE_CONFIG)
+    .map((f) => f.cronName)
+    .filter((c): c is string => c !== null),
+);
+
+/**
+ * POST /api/admin/automation/trigger
+ *
+ * Manually fires a cron from the admin automation dashboard. Admin-auth
+ * gated. Forwards to the actual cron route with the CRON_SECRET bearer
+ * token so the browser never sees the secret.
+ *
+ * Body: { cron: string }
+ * Returns: { ok, status, summary }
+ */
+export async function POST(request: NextRequest) {
+  // ── Auth ─────────────────────────────────────────────────────
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user || !user.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const adminEmails = getAdminEmails();
+  if (!adminEmails.includes(user.email.toLowerCase())) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const body = await request.json().catch(() => ({}));
+  const cronName = typeof body.cron === "string" ? body.cron : null;
+  if (!cronName) {
+    return NextResponse.json({ error: "Missing cron name" }, { status: 400 });
+  }
+
+  if (!ALLOWED_CRONS.has(cronName)) {
+    return NextResponse.json(
+      { error: `Cron '${cronName}' not on the allowlist. Known crons: ${Array.from(ALLOWED_CRONS).join(", ")}` },
+      { status: 400 },
+    );
+  }
+
+  if (!process.env.CRON_SECRET) {
+    return NextResponse.json(
+      { error: "CRON_SECRET not configured on server" },
+      { status: 500 },
+    );
+  }
+
+  // ── Forward the request ─────────────────────────────────────
+  const url = `${getSiteUrl()}/api/cron/${cronName}`;
+  try {
+    const res = await fetch(url, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${process.env.CRON_SECRET}`,
+        // Mark the run as admin-manual so the dashboard can distinguish
+        // it from scheduled Vercel cron executions.
+        "X-Admin-Manual": "1",
+        "X-Admin-Email": user.email,
+      },
+      signal: AbortSignal.timeout(120_000),
+    });
+    const data = await res.json().catch(() => ({}));
+
+    log.info("Admin triggered cron", {
+      cronName,
+      adminEmail: user.email,
+      status: res.status,
+    });
+
+    if (!res.ok) {
+      return NextResponse.json(
+        {
+          ok: false,
+          status: res.status,
+          error: data?.error || `HTTP ${res.status}`,
+        },
+        { status: 502 },
+      );
+    }
+
+    // Build a human-readable summary from the cron's response
+    const stats: Record<string, unknown> = data && typeof data === "object" ? data : {};
+    const summary = Object.entries(stats)
+      .filter(([k, v]) => k !== "ok" && typeof v === "number" && (v as number) > 0)
+      .map(([k, v]) => `${k}=${v}`)
+      .join(", ") || "completed";
+
+    return NextResponse.json({ ok: true, status: res.status, summary, data: stats });
+  } catch (err) {
+    log.error("Admin trigger failed", {
+      cronName,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "trigger_failed" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/cron/advisor-dunning/route.ts
+++ b/app/api/cron/advisor-dunning/route.ts
@@ -5,6 +5,7 @@ import { requireCronAuth } from "@/lib/cron-auth";
 import { getStripe } from "@/lib/stripe";
 import { escapeHtml } from "@/lib/html-escape";
 import { getSiteUrl } from "@/lib/url";
+import { wrapCronHandler } from "@/lib/cron-run-log";
 
 const log = logger("cron:advisor-dunning");
 
@@ -30,7 +31,7 @@ export const maxDuration = 60;
  *
  * Safe to run daily — each step only fires once per row.
  */
-export async function GET(req: NextRequest) {
+async function handler(req: NextRequest) {
   const unauth = requireCronAuth(req);
   if (unauth) return unauth;
 
@@ -227,3 +228,5 @@ function sendEmail(to: string | null, subject: string, html: string): void {
     }),
   }).catch(() => {});
 }
+
+export const GET = wrapCronHandler("advisor-dunning", handler);

--- a/app/api/cron/advisor-profile-gate-drip/route.ts
+++ b/app/api/cron/advisor-profile-gate-drip/route.ts
@@ -4,6 +4,7 @@ import { logger } from "@/lib/logger";
 import { requireCronAuth } from "@/lib/cron-auth";
 import { escapeHtml } from "@/lib/html-escape";
 import { getSiteUrl } from "@/lib/url";
+import { wrapCronHandler } from "@/lib/cron-run-log";
 
 const log = logger("cron:advisor-profile-gate-drip");
 
@@ -29,7 +30,7 @@ export const maxDuration = 60;
  *
  * Idempotent via the `profile_gate_step` column (added in the migration).
  */
-export async function GET(req: NextRequest) {
+async function handler(req: NextRequest) {
   const unauth = requireCronAuth(req);
   if (unauth) return unauth;
 
@@ -217,3 +218,5 @@ function sendEmail(to: string | null, subject: string, html: string): void {
     }),
   }).catch(() => {});
 }
+
+export const GET = wrapCronHandler("advisor-profile-gate-drip", handler);

--- a/app/api/cron/afsl-expiry-monitor/route.ts
+++ b/app/api/cron/afsl-expiry-monitor/route.ts
@@ -6,6 +6,7 @@ import { lookupAfsl } from "@/lib/advisor-application-resolver";
 import { escapeHtml } from "@/lib/html-escape";
 import { getSiteUrl } from "@/lib/url";
 import { ADMIN_EMAIL } from "@/lib/admin";
+import { wrapCronHandler } from "@/lib/cron-run-log";
 
 const log = logger("cron:afsl-expiry-monitor");
 
@@ -28,7 +29,7 @@ export const maxDuration = 60;
  * Runs weekly because the register doesn't change daily and we
  * don't want to hammer it. Vercel cron schedule: '0 3 * * 1' (Mon 3am).
  */
-export async function GET(req: NextRequest) {
+async function handler(req: NextRequest) {
   const unauth = requireCronAuth(req);
   if (unauth) return unauth;
 
@@ -131,3 +132,5 @@ function sendEmail(to: string | null, subject: string, html: string): void {
     }),
   }).catch(() => {});
 }
+
+export const GET = wrapCronHandler("afsl-expiry-monitor", handler);

--- a/app/api/cron/auto-resolve-disputes/route.ts
+++ b/app/api/cron/auto-resolve-disputes/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { logger } from "@/lib/logger";
 import { requireCronAuth } from "@/lib/cron-auth";
+import { withCronRunLog } from "@/lib/cron-run-log";
 import { autoResolveDispute } from "@/lib/advisor-lead-dispute-resolver";
 
 const log = logger("cron:auto-resolve-disputes");
@@ -12,72 +13,67 @@ export const maxDuration = 60;
 /**
  * Hourly backfill cron for advisor lead disputes.
  *
- * The submission POST (/api/advisor-auth/disputes) runs the classifier
- * inline, so 99% of disputes get resolved immediately. This cron is the
- * belt to that suspenders — it sweeps any disputes still in `pending`
- * state (e.g. because the classifier threw, or was introduced after
- * the dispute was created, or because an admin manually unresolved a
- * dispute and wants it re-classified).
- *
- * Runs every hour. Idempotent — autoResolveDispute() short-circuits
- * on disputes that are already in a terminal state.
- *
- * Budget: process up to 200 disputes per run. The inline path handles
- * steady-state load, so 200/hour is 4,800/day which is more than
- * enough headroom for even a rapid backlog.
+ * The submission POST runs the classifier inline for the common
+ * case; this cron is the belt to that suspenders, sweeping anything
+ * stuck in `pending` status. Wrapped with withCronRunLog so the
+ * admin automation dashboard can show "last run" + stats.
  */
 export async function GET(req: NextRequest) {
   const unauth = requireCronAuth(req);
   if (unauth) return unauth;
 
-  const supabase = createAdminClient();
+  const triggeredBy: "cron" | "admin_manual" = req.headers.get("x-admin-manual")
+    ? "admin_manual"
+    : "cron";
 
-  // Fetch the oldest pending disputes first so we clear any backlog
-  // chronologically. `status = 'pending'` is the only condition — we
-  // deliberately re-run the classifier on rows that have an existing
-  // auto_resolved_verdict='escalate' stamp so an admin who unpicks an
-  // escalation and flips it back to pending gets a re-classification.
-  const { data: pending, error } = await supabase
-    .from("lead_disputes")
-    .select("id")
-    .eq("status", "pending")
-    .order("created_at", { ascending: true })
-    .limit(200);
+  return withCronRunLog(
+    "auto-resolve-disputes",
+    async () => {
+      const stats = {
+        scanned: 0,
+        refunded: 0,
+        rejected: 0,
+        escalated: 0,
+        failed: 0,
+      };
 
-  if (error) {
-    log.error("Failed to fetch pending disputes", { error: error.message });
-    return NextResponse.json(
-      { ok: false, error: "fetch_failed" },
-      { status: 500 },
-    );
-  }
+      const supabase = createAdminClient();
+      const { data: pending, error } = await supabase
+        .from("lead_disputes")
+        .select("id")
+        .eq("status", "pending")
+        .order("created_at", { ascending: true })
+        .limit(200);
 
-  const stats = {
-    scanned: pending?.length || 0,
-    refunded: 0,
-    rejected: 0,
-    escalated: 0,
-    failed: 0,
-  };
+      if (error) {
+        log.error("Failed to fetch pending disputes", { error: error.message });
+        throw new Error("fetch_failed: " + error.message);
+      }
 
-  for (const row of pending || []) {
-    try {
-      const result = await autoResolveDispute(row.id);
-      if (result.verdict === "refund") stats.refunded++;
-      else if (result.verdict === "reject") stats.rejected++;
-      else stats.escalated++;
-    } catch (err) {
-      stats.failed++;
-      log.error("Auto-resolve threw", {
-        disputeId: row.id,
-        err: err instanceof Error ? err.message : String(err),
-      });
-    }
-  }
+      stats.scanned = pending?.length || 0;
 
-  if (stats.scanned > 0) {
-    log.info("Backfill cron completed", stats);
-  }
+      for (const row of pending || []) {
+        try {
+          const result = await autoResolveDispute(row.id);
+          if (result.verdict === "refund") stats.refunded++;
+          else if (result.verdict === "reject") stats.rejected++;
+          else stats.escalated++;
+        } catch (err) {
+          stats.failed++;
+          log.error("Auto-resolve threw", {
+            disputeId: row.id,
+            err: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
 
-  return NextResponse.json({ ok: true, ...stats });
+      if (stats.scanned > 0) log.info("Backfill cron completed", stats);
+
+      return {
+        response: NextResponse.json({ ok: true, ...stats }),
+        stats,
+      };
+    },
+    { triggeredBy },
+  );
 }

--- a/app/api/cron/email-bounce-sweep/route.ts
+++ b/app/api/cron/email-bounce-sweep/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { logger } from "@/lib/logger";
 import { requireCronAuth } from "@/lib/cron-auth";
+import { wrapCronHandler } from "@/lib/cron-run-log";
 
 const log = logger("cron:email-bounce-sweep");
 
@@ -27,7 +28,7 @@ export const maxDuration = 60;
  * scrubs drips for whatever is ALREADY in email_suppression_list,
  * so manual adds to the suppression table still take effect.
  */
-export async function GET(req: NextRequest) {
+async function handler(req: NextRequest) {
   const unauth = requireCronAuth(req);
   if (unauth) return unauth;
 
@@ -141,3 +142,5 @@ export async function GET(req: NextRequest) {
   log.info("Email bounce sweep completed", stats);
   return NextResponse.json({ ok: true, ...stats });
 }
+
+export const GET = wrapCronHandler("email-bounce-sweep", handler);

--- a/app/api/cron/enforce-lead-sla/route.ts
+++ b/app/api/cron/enforce-lead-sla/route.ts
@@ -5,6 +5,7 @@ import { requireCronAuth } from "@/lib/cron-auth";
 import { ADMIN_EMAIL } from "@/lib/admin";
 import { escapeHtml } from "@/lib/html-escape";
 import { getSiteUrl } from "@/lib/url";
+import { wrapCronHandler } from "@/lib/cron-run-log";
 
 const log = logger("cron:enforce-lead-sla");
 
@@ -31,7 +32,7 @@ export const maxDuration = 60;
  * Idempotent: uses pause_warning_sent_at to prevent spamming warnings
  * and auto_paused_at to prevent re-pausing already-paused advisors.
  */
-export async function GET(req: NextRequest) {
+async function handler(req: NextRequest) {
   const unauth = requireCronAuth(req);
   if (unauth) return unauth;
 
@@ -225,3 +226,5 @@ function sendEmail(to: string | null, subject: string, html: string): void {
     }),
   }).catch(() => {});
 }
+
+export const GET = wrapCronHandler("enforce-lead-sla", handler);

--- a/app/api/cron/lead-quality-weights/route.ts
+++ b/app/api/cron/lead-quality-weights/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { logger } from "@/lib/logger";
 import { requireCronAuth } from "@/lib/cron-auth";
+import { wrapCronHandler } from "@/lib/cron-run-log";
 
 const log = logger("cron:lead-quality-weights");
 
@@ -41,7 +42,7 @@ export const maxDuration = 120;
  * Weight formula: signal_weight = hit_rate / baseline_hit_rate * 30
  * — clamped to the 0–100 range used by the live scorer.
  */
-export async function GET(req: NextRequest) {
+async function handler(req: NextRequest) {
   const unauth = requireCronAuth(req);
   if (unauth) return unauth;
 
@@ -159,3 +160,5 @@ export async function GET(req: NextRequest) {
     weights: weightRows,
   });
 }
+
+export const GET = wrapCronHandler("lead-quality-weights", handler);

--- a/app/api/cron/monthly-advisor-reports/route.ts
+++ b/app/api/cron/monthly-advisor-reports/route.ts
@@ -4,6 +4,7 @@ import { logger } from "@/lib/logger";
 import { requireCronAuth } from "@/lib/cron-auth";
 import { escapeHtml } from "@/lib/html-escape";
 import { getSiteUrl } from "@/lib/url";
+import { wrapCronHandler } from "@/lib/cron-run-log";
 
 const log = logger("cron:monthly-advisor-reports");
 
@@ -27,7 +28,7 @@ export const maxDuration = 300;
  *
  * Runs once per month; Vercel schedule: '0 9 1 * *'.
  */
-export async function GET(req: NextRequest) {
+async function handler(req: NextRequest) {
   const unauth = requireCronAuth(req);
   if (unauth) return unauth;
 
@@ -200,3 +201,5 @@ function sendEmail(to: string | null, subject: string, html: string): void {
     }),
   }).catch(() => {});
 }
+
+export const GET = wrapCronHandler("monthly-advisor-reports", handler);

--- a/components/AdminSidebar.tsx
+++ b/components/AdminSidebar.tsx
@@ -22,6 +22,7 @@ const NAV_GROUPS = [
   {
     label: "Health & Ops",
     items: [
+      { href: "/admin/automation", icon: "cpu", label: "Automation" },
       { href: "/admin/data-health", icon: "activity", label: "Data Health" },
       { href: "/admin/seo-health", icon: "search", label: "SEO Health" },
       { href: "/admin/compliance", icon: "shield-check", label: "Compliance" },

--- a/components/admin/automation/CronTriggerButton.tsx
+++ b/components/admin/automation/CronTriggerButton.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useState } from "react";
+
+/**
+ * Manually trigger a cron endpoint from the admin dashboard.
+ *
+ * Posts to /api/admin/automation/trigger with the cron name. The
+ * server-side route is admin-authed and forwards to the actual
+ * cron route with the right CRON_SECRET bearer token, so the
+ * browser never sees the secret.
+ *
+ * Disables itself while in-flight and shows a success / error
+ * flash afterwards.
+ */
+export default function CronTriggerButton({
+  cronName,
+  label,
+}: {
+  cronName: string;
+  label?: string;
+}) {
+  const [status, setStatus] = useState<"idle" | "running" | "ok" | "error">("idle");
+  const [message, setMessage] = useState<string>("");
+
+  const handleClick = async () => {
+    if (status === "running") return;
+    setStatus("running");
+    setMessage("");
+
+    try {
+      const res = await fetch("/api/admin/automation/trigger", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ cron: cronName }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setStatus("error");
+        setMessage(data?.error || `HTTP ${res.status}`);
+        return;
+      }
+      setStatus("ok");
+      setMessage(data?.summary || "Completed");
+    } catch (err) {
+      setStatus("error");
+      setMessage(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  return (
+    <div className="inline-flex flex-col items-start">
+      <button
+        onClick={handleClick}
+        disabled={status === "running"}
+        className="px-3 py-1.5 text-xs font-semibold bg-slate-900 text-white rounded-lg hover:bg-slate-800 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+      >
+        {status === "running" ? "Running…" : label || `Run ${cronName} now`}
+      </button>
+      {status === "ok" && <span className="text-[0.65rem] text-emerald-700 mt-1">✓ {message}</span>}
+      {status === "error" && <span className="text-[0.65rem] text-red-700 mt-1">✗ {message}</span>}
+    </div>
+  );
+}

--- a/components/admin/automation/DrillDownShell.tsx
+++ b/components/admin/automation/DrillDownShell.tsx
@@ -1,0 +1,126 @@
+import Link from "next/link";
+import AdminShell from "@/components/AdminShell";
+import CronTriggerButton from "@/components/admin/automation/CronTriggerButton";
+import type { FeatureOverview } from "@/lib/admin/automation-metrics";
+
+/**
+ * Shared header + layout for every automation drill-down page.
+ *
+ * Renders:
+ *   - Breadcrumb back to /admin/automation
+ *   - Feature title + description
+ *   - Health/pending/7-day stat row
+ *   - Manual trigger button (for cron-driven features)
+ *   - `children` slot for the feature-specific content (tables, lists)
+ */
+export default function DrillDownShell({
+  overview,
+  children,
+}: {
+  overview: FeatureOverview;
+  children: React.ReactNode;
+}) {
+  return (
+    <AdminShell title={overview.display.title} subtitle={overview.display.description}>
+      <div className="p-4 md:p-6 max-w-7xl">
+        <nav className="text-xs text-slate-500 mb-3">
+          <Link href="/admin/automation" className="hover:text-slate-900">
+            ← Automation dashboard
+          </Link>
+        </nav>
+
+        <div className="bg-white border border-slate-200 rounded-xl p-4 mb-5">
+          <div className="flex items-start justify-between gap-4 flex-wrap">
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2 mb-1">
+                <HealthDot health={overview.health} />
+                <h1 className="text-lg md:text-xl font-bold text-slate-900">{overview.display.title}</h1>
+              </div>
+              <p className="text-sm text-slate-500 max-w-2xl">{overview.display.description}</p>
+            </div>
+            {overview.display.cronName && (
+              <CronTriggerButton cronName={overview.display.cronName} label={`Run ${overview.display.cronName} now`} />
+            )}
+          </div>
+
+          <dl className="grid grid-cols-2 md:grid-cols-5 gap-4 mt-4 pt-4 border-t border-slate-100">
+            <Stat label="Pending review" value={overview.pending} />
+            <Stat label="Auto-acted (7d)" value={overview.recentCounts.autoActed} />
+            <Stat label="Escalated (7d)" value={overview.recentCounts.escalated} />
+            <Stat label="Rejected (7d)" value={overview.recentCounts.rejected} />
+            <Stat label="Approved (7d)" value={overview.recentCounts.approved} />
+          </dl>
+
+          {overview.lastRun && overview.lastRun.status !== "never_run" && (
+            <div className="mt-4 pt-4 border-t border-slate-100 text-xs text-slate-500 flex flex-wrap gap-x-4 gap-y-1">
+              <span>
+                Last run:{" "}
+                <strong className="text-slate-700">
+                  {overview.lastRun.startedAt ? new Date(overview.lastRun.startedAt).toLocaleString("en-AU") : "—"}
+                </strong>
+              </span>
+              <span>
+                Status:{" "}
+                <strong className={statusClass(overview.lastRun.status)}>
+                  {overview.lastRun.status}
+                </strong>
+              </span>
+              {overview.lastRun.durationMs !== null && (
+                <span>
+                  Duration: <strong className="text-slate-700">{overview.lastRun.durationMs}ms</strong>
+                </span>
+              )}
+              {overview.lastRun.triggeredBy && (
+                <span>
+                  Triggered by: <strong className="text-slate-700">{overview.lastRun.triggeredBy}</strong>
+                </span>
+              )}
+            </div>
+          )}
+
+          {overview.lastRun?.errorMessage && (
+            <div className="mt-3 px-3 py-2 bg-red-50 border border-red-200 rounded text-xs text-red-800">
+              ⚠ {overview.lastRun.errorMessage}
+            </div>
+          )}
+        </div>
+
+        {children}
+      </div>
+    </AdminShell>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: number }) {
+  return (
+    <div>
+      <dt className="text-[0.6rem] font-semibold uppercase tracking-wider text-slate-500">{label}</dt>
+      <dd className="text-lg font-bold text-slate-900">{value}</dd>
+    </div>
+  );
+}
+
+function HealthDot({ health }: { health: FeatureOverview["health"] }) {
+  const cls: Record<FeatureOverview["health"], string> = {
+    green: "bg-emerald-500",
+    amber: "bg-amber-500",
+    red: "bg-red-500",
+    unknown: "bg-slate-400",
+  };
+  return <span className={`w-2.5 h-2.5 rounded-full ${cls[health]}`} aria-hidden="true" />;
+}
+
+function statusClass(status: string): string {
+  switch (status) {
+    case "ok":
+      return "text-emerald-700";
+    case "error":
+      return "text-red-700";
+    case "partial":
+      return "text-amber-700";
+    case "running":
+      return "text-blue-700";
+    default:
+      return "text-slate-700";
+  }
+}

--- a/components/admin/automation/HealthTile.tsx
+++ b/components/admin/automation/HealthTile.tsx
@@ -1,0 +1,83 @@
+import Link from "next/link";
+import type { FeatureOverview } from "@/lib/admin/automation-metrics";
+
+const HEALTH_STYLES: Record<FeatureOverview["health"], string> = {
+  green: "bg-emerald-50 border-emerald-200 text-emerald-800",
+  amber: "bg-amber-50 border-amber-200 text-amber-900",
+  red: "bg-red-50 border-red-200 text-red-800",
+  unknown: "bg-slate-50 border-slate-200 text-slate-600",
+};
+
+const HEALTH_DOT: Record<FeatureOverview["health"], string> = {
+  green: "bg-emerald-500",
+  amber: "bg-amber-500",
+  red: "bg-red-500",
+  unknown: "bg-slate-400",
+};
+
+/**
+ * A single feature tile on the /admin/automation overview page.
+ *
+ * Shows:
+ *   - Feature title + health dot
+ *   - Pending queue count (escalated items waiting for human review)
+ *   - Last run time + status (cron-driven features only)
+ *   - 7-day auto-acted count
+ *   - Click-through to the feature's drill-down page
+ */
+export default function HealthTile({ overview }: { overview: FeatureOverview }) {
+  const { display, pending, lastRun, health, recentCounts } = overview;
+
+  const lastRunLabel = (() => {
+    if (!lastRun || lastRun.status === "never_run") {
+      return display.cronName ? "Never run" : "—";
+    }
+    if (!lastRun.startedAt) return "—";
+    const diffMs = Date.now() - new Date(lastRun.startedAt).getTime();
+    const diffMin = Math.floor(diffMs / (1000 * 60));
+    if (diffMin < 1) return "just now";
+    if (diffMin < 60) return `${diffMin}m ago`;
+    const diffHours = Math.floor(diffMin / 60);
+    if (diffHours < 24) return `${diffHours}h ago`;
+    const diffDays = Math.floor(diffHours / 24);
+    return `${diffDays}d ago`;
+  })();
+
+  return (
+    <Link
+      href={`/admin/automation/${display.slug}`}
+      className={`block rounded-xl border p-4 transition hover:shadow-md hover:border-slate-400 ${HEALTH_STYLES[health]}`}
+    >
+      <div className="flex items-start justify-between gap-3 mb-3">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1">
+            <span className={`w-2 h-2 rounded-full shrink-0 ${HEALTH_DOT[health]}`} aria-hidden="true" />
+            <h3 className="text-sm font-bold text-slate-900 truncate">{display.title}</h3>
+          </div>
+          <p className="text-[0.7rem] text-slate-500 leading-snug line-clamp-2">{display.description}</p>
+        </div>
+      </div>
+
+      <dl className="grid grid-cols-3 gap-2 pt-3 border-t border-black/5">
+        <div>
+          <dt className="text-[0.6rem] font-semibold uppercase tracking-wider text-slate-500">Pending</dt>
+          <dd className="text-base font-bold text-slate-900">{pending}</dd>
+        </div>
+        <div>
+          <dt className="text-[0.6rem] font-semibold uppercase tracking-wider text-slate-500">7-day auto</dt>
+          <dd className="text-base font-bold text-slate-900">{recentCounts.autoActed}</dd>
+        </div>
+        <div>
+          <dt className="text-[0.6rem] font-semibold uppercase tracking-wider text-slate-500">Last run</dt>
+          <dd className="text-xs font-semibold text-slate-700">{lastRunLabel}</dd>
+        </div>
+      </dl>
+
+      {lastRun?.errorMessage && (
+        <p className="mt-2 text-[0.65rem] text-red-700 line-clamp-2" title={lastRun.errorMessage}>
+          ⚠ {lastRun.errorMessage}
+        </p>
+      )}
+    </Link>
+  );
+}

--- a/components/admin/automation/OverrideButton.tsx
+++ b/components/admin/automation/OverrideButton.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useState } from "react";
+
+/**
+ * Generic admin-override button.
+ *
+ * Each classifier feature exposes a slightly different override API
+ * (approve a rejected dispute, reject a published review, etc.) so
+ * this component takes a `feature` + `rowId` + `targetVerdict`
+ * tuple and posts to /api/admin/automation/override which dispatches
+ * to the right handler.
+ *
+ * Shows a confirm modal before acting — these are destructive on
+ * already-acted decisions (e.g. reversing an auto-refund means
+ * debiting the advisor back).
+ */
+export default function OverrideButton({
+  feature,
+  rowId,
+  targetVerdict,
+  label,
+  requireReason = false,
+}: {
+  feature: string;
+  rowId: number;
+  targetVerdict: string;
+  label: string;
+  requireReason?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const [reason, setReason] = useState("");
+  const [status, setStatus] = useState<"idle" | "submitting" | "done" | "error">("idle");
+  const [errorMsg, setErrorMsg] = useState("");
+
+  const handleConfirm = async () => {
+    if (requireReason && !reason.trim()) {
+      setErrorMsg("Reason is required");
+      return;
+    }
+    setStatus("submitting");
+    setErrorMsg("");
+
+    try {
+      const res = await fetch("/api/admin/automation/override", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ feature, rowId, targetVerdict, reason }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setStatus("error");
+        setErrorMsg(data?.error || `HTTP ${res.status}`);
+        return;
+      }
+      setStatus("done");
+      setTimeout(() => window.location.reload(), 500);
+    } catch (err) {
+      setStatus("error");
+      setErrorMsg(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  if (status === "done") {
+    return <span className="text-[0.65rem] text-emerald-700">✓ Applied, refreshing…</span>;
+  }
+
+  return (
+    <>
+      <button
+        onClick={() => setOpen(true)}
+        className="px-2.5 py-1 text-[0.7rem] font-semibold bg-white border border-slate-300 text-slate-700 rounded hover:bg-slate-50 transition-colors"
+      >
+        {label}
+      </button>
+
+      {open && (
+        <div
+          className="fixed inset-0 bg-black/40 z-50 flex items-center justify-center p-4"
+          onClick={() => status === "idle" && setOpen(false)}
+        >
+          <div
+            className="bg-white rounded-xl p-5 max-w-md w-full shadow-2xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3 className="text-base font-bold text-slate-900 mb-1">Confirm override</h3>
+            <p className="text-sm text-slate-600 mb-4">
+              You're about to <strong>{label.toLowerCase()}</strong> for row #{rowId} on the{" "}
+              <code className="text-xs bg-slate-100 px-1 rounded">{feature}</code> feature. This is
+              logged with your admin identity and timestamp for audit.
+            </p>
+
+            {requireReason && (
+              <div className="mb-4">
+                <label className="block text-xs font-semibold text-slate-700 mb-1">
+                  Reason <span className="text-red-500">*</span>
+                </label>
+                <textarea
+                  value={reason}
+                  onChange={(e) => setReason(e.target.value)}
+                  rows={3}
+                  className="w-full px-3 py-2 text-sm border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-amber-500/30"
+                  placeholder="Why are you overriding the classifier?"
+                  disabled={status === "submitting"}
+                />
+              </div>
+            )}
+
+            {errorMsg && <p className="text-xs text-red-600 mb-2">{errorMsg}</p>}
+
+            <div className="flex gap-2">
+              <button
+                onClick={handleConfirm}
+                disabled={status === "submitting"}
+                className="flex-1 px-4 py-2 bg-red-600 text-white text-sm font-semibold rounded-lg hover:bg-red-700 disabled:opacity-50 transition-colors"
+              >
+                {status === "submitting" ? "Applying…" : `Confirm ${label}`}
+              </button>
+              <button
+                onClick={() => setOpen(false)}
+                disabled={status === "submitting"}
+                className="px-4 py-2 bg-white border border-slate-300 text-slate-700 text-sm font-semibold rounded-lg hover:bg-slate-50 transition-colors"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/components/admin/automation/SignalsPopover.tsx
+++ b/components/admin/automation/SignalsPopover.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useState } from "react";
+
+/**
+ * Collapsible "why did the classifier decide this?" UI.
+ *
+ * Given an array of signal strings (from auto_resolved_reasons /
+ * auto_classified_reasons / auto_moderated_reasons jsonb columns),
+ * renders a compact trigger + expanded panel so admins can inspect
+ * the rule firings without blowing up the row height when collapsed.
+ */
+export default function SignalsPopover({
+  reasons,
+  label = "Signals",
+}: {
+  reasons: string[] | null;
+  label?: string;
+}) {
+  const [open, setOpen] = useState(false);
+
+  if (!reasons || reasons.length === 0) {
+    return <span className="text-xs text-slate-400">—</span>;
+  }
+
+  return (
+    <div className="inline-block relative">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className="text-xs font-semibold text-slate-700 hover:text-slate-900 underline decoration-dotted"
+      >
+        {label} ({reasons.length})
+      </button>
+      {open && (
+        <div
+          className="absolute z-20 mt-1 right-0 w-64 bg-white border border-slate-200 rounded-lg shadow-lg p-3"
+          onMouseLeave={() => setOpen(false)}
+        >
+          <p className="text-[0.65rem] font-semibold uppercase tracking-wider text-slate-500 mb-1.5">Classifier reasons</p>
+          <ul className="space-y-1">
+            {reasons.map((r, i) => (
+              <li key={i} className="text-[0.7rem] text-slate-700 font-mono break-words">
+                • {r}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lib/admin/automation-metrics.ts
+++ b/lib/admin/automation-metrics.ts
@@ -1,0 +1,676 @@
+/**
+ * Aggregation layer for the admin automation dashboard.
+ *
+ * Every feature tile + drill-down reads from one of these functions.
+ * Split out so the overview page and the individual drill-down pages
+ * show consistent numbers — there's one source of truth per metric.
+ *
+ * Runs server-side in admin pages (uses createAdminClient) so the
+ * dashboard never exposes raw table queries to the browser.
+ */
+
+import { createAdminClient } from "@/lib/supabase/admin";
+
+// ─── Feature identifiers ────────────────────────────────────────────
+// Single source of truth for the 13 features the dashboard tracks.
+// Used as tile keys, cron names, drill-down slugs.
+export const AUTOMATION_FEATURES = [
+  "lead_disputes",
+  "advisor_applications",
+  "listing_scam",
+  "text_moderation",
+  "lead_sla",
+  "profile_gate_drip",
+  "advisor_dunning",
+  "broker_data_changes",
+  "marketplace_campaigns",
+  "afsl_expiry",
+  "email_bounces",
+  "monthly_reports",
+  "quality_weights",
+] as const;
+
+export type AutomationFeature = (typeof AUTOMATION_FEATURES)[number];
+
+export interface FeatureDisplay {
+  key: AutomationFeature;
+  title: string;
+  cronName: string | null; // null if feature isn't cron-driven
+  description: string;
+  slug: string; // /admin/automation/<slug>
+}
+
+export const FEATURE_CONFIG: Record<AutomationFeature, FeatureDisplay> = {
+  lead_disputes: {
+    key: "lead_disputes",
+    title: "Lead dispute auto-resolver",
+    cronName: "auto-resolve-disputes",
+    description: "Classifies advisor lead disputes and auto-refunds/rejects where confidence is high",
+    slug: "disputes",
+  },
+  advisor_applications: {
+    key: "advisor_applications",
+    title: "Advisor application verification",
+    cronName: null,
+    description: "AFSL + ABN register lookups on new advisor applications",
+    slug: "applications",
+  },
+  listing_scam: {
+    key: "listing_scam",
+    title: "Investment listing scam classifier",
+    cronName: null,
+    description: "Rule-based fraud detection on user-submitted investment listings",
+    slug: "listings",
+  },
+  text_moderation: {
+    key: "text_moderation",
+    title: "Review & article moderation",
+    cronName: null,
+    description: "Text classifier for broker reviews, advisor reviews, switch stories, Q&A and advisor articles",
+    slug: "moderation",
+  },
+  lead_sla: {
+    key: "lead_sla",
+    title: "Lead SLA enforcement",
+    cronName: "enforce-lead-sla",
+    description: "Warns then auto-pauses advisors with unresponded leads",
+    slug: "sla",
+  },
+  profile_gate_drip: {
+    key: "profile_gate_drip",
+    title: "Profile quality gate drip",
+    cronName: "advisor-profile-gate-drip",
+    description: "Email drip for advisors stuck at the profile quality gate",
+    slug: "profile-gates",
+  },
+  advisor_dunning: {
+    key: "advisor_dunning",
+    title: "Stripe auto-topup dunning",
+    cronName: "advisor-dunning",
+    description: "Retry + escalate failed advisor credit top-up charges",
+    slug: "dunning",
+  },
+  broker_data_changes: {
+    key: "broker_data_changes",
+    title: "Broker data change auto-approval",
+    cronName: null,
+    description: "Tiers broker profile edits into auto-apply, reviewable, admin-required",
+    slug: "broker-changes",
+  },
+  marketplace_campaigns: {
+    key: "marketplace_campaigns",
+    title: "Marketplace campaign auto-approval",
+    cronName: null,
+    description: "Auto-approves clean creative from trusted brokers with valid budget",
+    slug: "campaigns",
+  },
+  afsl_expiry: {
+    key: "afsl_expiry",
+    title: "AFSL expiry monitor",
+    cronName: "afsl-expiry-monitor",
+    description: "Weekly ASIC register re-check for every active advisor",
+    slug: "afsl-expiry",
+  },
+  email_bounces: {
+    key: "email_bounces",
+    title: "Email bounce auto-suppression",
+    cronName: "email-bounce-sweep",
+    description: "Resend bounce pull + suppression list + drip scrub",
+    slug: "email-suppression",
+  },
+  monthly_reports: {
+    key: "monthly_reports",
+    title: "Monthly advisor reports",
+    cronName: "monthly-advisor-reports",
+    description: "Monthly performance email per advisor with percentile ranks",
+    slug: "monthly-reports",
+  },
+  quality_weights: {
+    key: "quality_weights",
+    title: "Lead quality weights feedback",
+    cronName: "lead-quality-weights",
+    description: "Nightly recomputation of signal weights from observed conversions",
+    slug: "quality-weights",
+  },
+};
+
+// ─── Core metric shapes ──────────────────────────────────────────────
+
+export interface LatestCronRun {
+  name: string;
+  startedAt: string | null;
+  endedAt: string | null;
+  durationMs: number | null;
+  status: "running" | "ok" | "error" | "partial" | "never_run";
+  stats: Record<string, unknown> | null;
+  errorMessage: string | null;
+  triggeredBy: string | null;
+}
+
+export interface FeatureOverview {
+  feature: AutomationFeature;
+  display: FeatureDisplay;
+  pending: number; // items waiting for human review (escalated queue)
+  lastRun: LatestCronRun | null; // null if not cron-driven
+  health: "green" | "amber" | "red" | "unknown";
+  recentCounts: {
+    autoActed: number; // refund + reject + approve + publish verdicts
+    escalated: number;
+    rejected: number;
+    approved: number;
+    refunded: number;
+    total: number;
+  };
+}
+
+// ─── Latest cron run lookup ──────────────────────────────────────────
+
+/**
+ * Fetch the most recent cron_run_log row for a given cron name.
+ * Returns null if the table doesn't exist or there's no row — the
+ * dashboard renders that as "never_run" rather than failing the page.
+ */
+export async function getLatestCronRun(cronName: string): Promise<LatestCronRun> {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("cron_run_log")
+    .select("name, started_at, ended_at, duration_ms, status, stats, error_message, triggered_by")
+    .eq("name", cronName)
+    .order("started_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error || !data) {
+    return {
+      name: cronName,
+      startedAt: null,
+      endedAt: null,
+      durationMs: null,
+      status: "never_run",
+      stats: null,
+      errorMessage: null,
+      triggeredBy: null,
+    };
+  }
+
+  return {
+    name: data.name,
+    startedAt: data.started_at,
+    endedAt: data.ended_at,
+    durationMs: data.duration_ms,
+    status: (data.status as LatestCronRun["status"]) || "never_run",
+    stats: (data.stats as Record<string, unknown> | null) || null,
+    errorMessage: data.error_message || null,
+    triggeredBy: data.triggered_by || null,
+  };
+}
+
+/**
+ * Compute the overall health colour for a feature given its latest
+ * cron run + pending queue depth.
+ *
+ *   green  — ran successfully within the feature's expected cadence
+ *            AND pending queue is under the "needs attention" threshold
+ *   amber  — ran with partial success OR queue is getting large
+ *            OR hasn't run for >1 cadence window but <2
+ *   red    — last run errored OR hasn't run for >2 cadence windows
+ *            OR pending queue is way over threshold
+ *   unknown — not cron-driven AND no recent decisions to evaluate
+ */
+export function computeHealth(
+  lastRun: LatestCronRun | null,
+  pending: number,
+  expectedCadenceHours: number,
+  queueWarn: number,
+  queueCritical: number,
+): "green" | "amber" | "red" | "unknown" {
+  // RED conditions take priority — any single red signal wins.
+  if (pending >= queueCritical) return "red";
+  if (lastRun?.status === "error") return "red";
+  if (lastRun?.startedAt) {
+    const ageHours = (Date.now() - new Date(lastRun.startedAt).getTime()) / (1000 * 60 * 60);
+    if (ageHours > expectedCadenceHours * 2) return "red";
+  }
+
+  // AMBER conditions — degraded but not broken.
+  if (pending >= queueWarn) return "amber";
+  if (lastRun?.status === "partial") return "amber";
+  if (lastRun?.startedAt) {
+    const ageHours = (Date.now() - new Date(lastRun.startedAt).getTime()) / (1000 * 60 * 60);
+    if (ageHours > expectedCadenceHours * 1.25) return "amber";
+  }
+
+  // No run history at all — unknown. Queue-based warn/red checks
+  // above would have caught anything above the warn threshold, so
+  // reaching here with no lastRun means everything is fine or we
+  // simply have no data to evaluate.
+  if (!lastRun || lastRun.status === "never_run") {
+    return "unknown";
+  }
+
+  return "green";
+}
+
+// ─── Per-feature metric functions ────────────────────────────────────
+
+/**
+ * Lead dispute metrics — pulls the last 7 days of lead_disputes
+ * activity and aggregates by verdict.
+ */
+export async function getLeadDisputeOverview(): Promise<FeatureOverview> {
+  const supabase = createAdminClient();
+  const display = FEATURE_CONFIG.lead_disputes;
+  const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+
+  const [pendingRes, recentRes, lastRun] = await Promise.all([
+    supabase
+      .from("lead_disputes")
+      .select("id", { count: "exact", head: true })
+      .eq("status", "pending"),
+    supabase
+      .from("lead_disputes")
+      .select("auto_resolved_verdict, status, refunded_cents")
+      .gte("created_at", sevenDaysAgo),
+    display.cronName ? getLatestCronRun(display.cronName) : Promise.resolve(null),
+  ]);
+
+  const recent = recentRes.data || [];
+  const recentCounts = {
+    autoActed: recent.filter((d) => d.auto_resolved_verdict === "refund" || d.auto_resolved_verdict === "reject").length,
+    escalated: recent.filter((d) => d.auto_resolved_verdict === "escalate").length,
+    rejected: recent.filter((d) => d.status === "rejected").length,
+    approved: recent.filter((d) => d.status === "approved").length,
+    refunded: recent.reduce((acc, d) => acc + ((d.refunded_cents as number | null) || 0), 0),
+    total: recent.length,
+  };
+
+  return {
+    feature: "lead_disputes",
+    display,
+    pending: pendingRes.count || 0,
+    lastRun,
+    health: computeHealth(lastRun, pendingRes.count || 0, 1, 20, 50),
+    recentCounts,
+  };
+}
+
+export async function getAdvisorApplicationOverview(): Promise<FeatureOverview> {
+  const supabase = createAdminClient();
+  const display = FEATURE_CONFIG.advisor_applications;
+  const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+
+  const [pendingRes, recentRes] = await Promise.all([
+    supabase
+      .from("advisor_applications")
+      .select("id", { count: "exact", head: true })
+      .eq("status", "pending"),
+    supabase
+      .from("advisor_applications")
+      .select("status, reviewed_by")
+      .gte("created_at", sevenDaysAgo),
+  ]);
+
+  const recent = recentRes.data || [];
+  const autoReviewed = recent.filter((r) => r.reviewed_by === "auto");
+
+  return {
+    feature: "advisor_applications",
+    display,
+    pending: pendingRes.count || 0,
+    lastRun: null,
+    health: computeHealth(null, pendingRes.count || 0, 24, 20, 50),
+    recentCounts: {
+      autoActed: autoReviewed.filter((r) => r.status === "approved" || r.status === "rejected").length,
+      escalated: recent.filter((r) => r.status === "pending").length,
+      rejected: recent.filter((r) => r.status === "rejected").length,
+      approved: recent.filter((r) => r.status === "approved").length,
+      refunded: 0,
+      total: recent.length,
+    },
+  };
+}
+
+export async function getListingScamOverview(): Promise<FeatureOverview> {
+  const supabase = createAdminClient();
+  const display = FEATURE_CONFIG.listing_scam;
+  const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+
+  const [pendingRes, recentRes] = await Promise.all([
+    supabase
+      .from("investment_listings")
+      .select("id", { count: "exact", head: true })
+      .eq("status", "pending"),
+    supabase
+      .from("investment_listings")
+      .select("status, auto_classified_verdict")
+      .gte("created_at", sevenDaysAgo),
+  ]);
+
+  const recent = recentRes.data || [];
+  return {
+    feature: "listing_scam",
+    display,
+    pending: pendingRes.count || 0,
+    lastRun: null,
+    health: computeHealth(null, pendingRes.count || 0, 24, 30, 100),
+    recentCounts: {
+      autoActed: recent.filter((r) => r.auto_classified_verdict === "auto_approve" || r.auto_classified_verdict === "auto_reject").length,
+      escalated: recent.filter((r) => r.auto_classified_verdict === "escalate").length,
+      rejected: recent.filter((r) => r.auto_classified_verdict === "auto_reject").length,
+      approved: recent.filter((r) => r.auto_classified_verdict === "auto_approve").length,
+      refunded: 0,
+      total: recent.length,
+    },
+  };
+}
+
+export async function getTextModerationOverview(): Promise<FeatureOverview> {
+  const supabase = createAdminClient();
+  const display = FEATURE_CONFIG.text_moderation;
+  const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+
+  const [pendingBroker, pendingAdvisor, brokerRecent, advisorRecent] = await Promise.all([
+    supabase.from("user_reviews").select("id", { count: "exact", head: true }).eq("status", "pending"),
+    supabase.from("professional_reviews").select("id", { count: "exact", head: true }).eq("status", "pending"),
+    supabase.from("user_reviews").select("auto_moderated_verdict, status").gte("created_at", sevenDaysAgo),
+    supabase.from("professional_reviews").select("auto_moderated_verdict, status").gte("created_at", sevenDaysAgo),
+  ]);
+
+  const allRecent = [...(brokerRecent.data || []), ...(advisorRecent.data || [])];
+  const pending = (pendingBroker.count || 0) + (pendingAdvisor.count || 0);
+
+  return {
+    feature: "text_moderation",
+    display,
+    pending,
+    lastRun: null,
+    health: computeHealth(null, pending, 24, 40, 150),
+    recentCounts: {
+      autoActed: allRecent.filter((r) => r.auto_moderated_verdict === "auto_publish" || r.auto_moderated_verdict === "auto_reject").length,
+      escalated: allRecent.filter((r) => r.auto_moderated_verdict === "escalate").length,
+      rejected: allRecent.filter((r) => r.auto_moderated_verdict === "auto_reject").length,
+      approved: allRecent.filter((r) => r.auto_moderated_verdict === "auto_publish").length,
+      refunded: 0,
+      total: allRecent.length,
+    },
+  };
+}
+
+async function cronOnlyOverview(
+  feature: AutomationFeature,
+  expectedCadenceHours: number,
+  queueQuery: () => Promise<number>,
+): Promise<FeatureOverview> {
+  const display = FEATURE_CONFIG[feature];
+  const [pending, lastRun] = await Promise.all([
+    queueQuery(),
+    display.cronName ? getLatestCronRun(display.cronName) : Promise.resolve(null),
+  ]);
+
+  return {
+    feature,
+    display,
+    pending,
+    lastRun,
+    health: computeHealth(lastRun, pending, expectedCadenceHours, 20, 50),
+    recentCounts: {
+      autoActed: (lastRun?.stats?.warned1 as number | undefined) || 0,
+      escalated: 0,
+      rejected: 0,
+      approved: 0,
+      refunded: 0,
+      total: 0,
+    },
+  };
+}
+
+export async function getLeadSlaOverview(): Promise<FeatureOverview> {
+  const supabase = createAdminClient();
+  return cronOnlyOverview("lead_sla", 24, async () => {
+    const { count } = await supabase
+      .from("professionals")
+      .select("id", { count: "exact", head: true })
+      .eq("status", "paused")
+      .eq("auto_pause_reason", "sla_miss");
+    return count || 0;
+  });
+}
+
+export async function getProfileGateOverview(): Promise<FeatureOverview> {
+  const supabase = createAdminClient();
+  return cronOnlyOverview("profile_gate_drip", 24, async () => {
+    const { count } = await supabase
+      .from("professionals")
+      .select("id", { count: "exact", head: true })
+      .eq("profile_quality_gate", "pending");
+    return count || 0;
+  });
+}
+
+export async function getDunningOverview(): Promise<FeatureOverview> {
+  const supabase = createAdminClient();
+  return cronOnlyOverview("advisor_dunning", 24, async () => {
+    const { count } = await supabase
+      .from("advisor_credit_topups")
+      .select("id", { count: "exact", head: true })
+      .eq("status", "failed");
+    return count || 0;
+  });
+}
+
+export async function getBrokerChangesOverview(): Promise<FeatureOverview> {
+  const supabase = createAdminClient();
+  const display = FEATURE_CONFIG.broker_data_changes;
+  const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+
+  const [pendingRes, recentRes] = await Promise.all([
+    supabase
+      .from("broker_data_changes")
+      .select("id", { count: "exact", head: true })
+      .is("auto_applied_at", null)
+      .is("applied_at", null),
+    supabase
+      .from("broker_data_changes")
+      .select("auto_applied_tier, auto_applied_at")
+      .gte("created_at", sevenDaysAgo),
+  ]);
+
+  const recent = recentRes.data || [];
+  const applied = recent.filter((r) => r.auto_applied_at !== null);
+
+  return {
+    feature: "broker_data_changes",
+    display,
+    pending: pendingRes.count || 0,
+    lastRun: null,
+    health: computeHealth(null, pendingRes.count || 0, 24, 30, 100),
+    recentCounts: {
+      autoActed: applied.filter((r) => r.auto_applied_tier !== "require_admin").length,
+      escalated: recent.filter((r) => r.auto_applied_tier === "require_admin" || r.auto_applied_tier === null).length,
+      rejected: 0,
+      approved: applied.length,
+      refunded: 0,
+      total: recent.length,
+    },
+  };
+}
+
+export async function getMarketplaceCampaignOverview(): Promise<FeatureOverview> {
+  const supabase = createAdminClient();
+  const display = FEATURE_CONFIG.marketplace_campaigns;
+  const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+
+  const [pendingRes, recentRes] = await Promise.all([
+    supabase
+      .from("campaigns")
+      .select("id", { count: "exact", head: true })
+      .eq("status", "pending"),
+    supabase
+      .from("campaigns")
+      .select("status")
+      .gte("created_at", sevenDaysAgo),
+  ]);
+
+  const recent = recentRes.data || [];
+  return {
+    feature: "marketplace_campaigns",
+    display,
+    pending: pendingRes.count || 0,
+    lastRun: null,
+    health: computeHealth(null, pendingRes.count || 0, 24, 15, 40),
+    recentCounts: {
+      autoActed: recent.filter((r) => r.status === "active" || r.status === "rejected").length,
+      escalated: recent.filter((r) => r.status === "pending").length,
+      rejected: recent.filter((r) => r.status === "rejected").length,
+      approved: recent.filter((r) => r.status === "active").length,
+      refunded: 0,
+      total: recent.length,
+    },
+  };
+}
+
+export async function getAfslExpiryOverview(): Promise<FeatureOverview> {
+  const supabase = createAdminClient();
+  return cronOnlyOverview("afsl_expiry", 168 /* weekly */, async () => {
+    const { count } = await supabase
+      .from("professionals")
+      .select("id", { count: "exact", head: true })
+      .in("auto_pause_reason", ["afsl_ceased", "afsl_suspended"]);
+    return count || 0;
+  });
+}
+
+export async function getEmailBouncesOverview(): Promise<FeatureOverview> {
+  const supabase = createAdminClient();
+  const display = FEATURE_CONFIG.email_bounces;
+  const [pendingRes, lastRun] = await Promise.all([
+    supabase.from("email_suppression_list").select("email", { count: "exact", head: true }),
+    display.cronName ? getLatestCronRun(display.cronName) : Promise.resolve(null),
+  ]);
+
+  return {
+    feature: "email_bounces",
+    display,
+    pending: pendingRes.count || 0,
+    lastRun,
+    health: computeHealth(lastRun, 0, 24, Infinity, Infinity),
+    recentCounts: {
+      autoActed: (lastRun?.stats?.pulled_from_resend as number | undefined) || 0,
+      escalated: 0,
+      rejected: 0,
+      approved: 0,
+      refunded: 0,
+      total: pendingRes.count || 0,
+    },
+  };
+}
+
+export async function getMonthlyReportsOverview(): Promise<FeatureOverview> {
+  const display = FEATURE_CONFIG.monthly_reports;
+  const lastRun = display.cronName ? await getLatestCronRun(display.cronName) : null;
+  return {
+    feature: "monthly_reports",
+    display,
+    pending: 0,
+    lastRun,
+    health: computeHealth(lastRun, 0, 720 /* monthly */, Infinity, Infinity),
+    recentCounts: {
+      autoActed: (lastRun?.stats?.emailed as number | undefined) || 0,
+      escalated: 0,
+      rejected: 0,
+      approved: 0,
+      refunded: 0,
+      total: (lastRun?.stats?.scanned as number | undefined) || 0,
+    },
+  };
+}
+
+export async function getQualityWeightsOverview(): Promise<FeatureOverview> {
+  const display = FEATURE_CONFIG.quality_weights;
+  const supabase = createAdminClient();
+  const [lastRun, versionRes] = await Promise.all([
+    display.cronName ? getLatestCronRun(display.cronName) : Promise.resolve(null),
+    supabase
+      .from("lead_quality_weights")
+      .select("model_version")
+      .order("model_version", { ascending: false })
+      .limit(1)
+      .maybeSingle(),
+  ]);
+
+  return {
+    feature: "quality_weights",
+    display,
+    pending: 0,
+    lastRun,
+    health: computeHealth(lastRun, 0, 24, Infinity, Infinity),
+    recentCounts: {
+      autoActed: (lastRun?.stats?.signals_computed as number | undefined) || 0,
+      escalated: 0,
+      rejected: 0,
+      approved: 0,
+      refunded: 0,
+      total: (versionRes.data?.model_version as number | undefined) || 0,
+    },
+  };
+}
+
+// ─── Overview dispatcher ─────────────────────────────────────────────
+
+/**
+ * Fetch overview metrics for every feature in parallel.
+ * Used by the /admin/automation index page.
+ */
+export async function getAllFeatureOverviews(): Promise<FeatureOverview[]> {
+  const results = await Promise.all([
+    getLeadDisputeOverview().catch((e) => safeFallback("lead_disputes", e)),
+    getAdvisorApplicationOverview().catch((e) => safeFallback("advisor_applications", e)),
+    getListingScamOverview().catch((e) => safeFallback("listing_scam", e)),
+    getTextModerationOverview().catch((e) => safeFallback("text_moderation", e)),
+    getLeadSlaOverview().catch((e) => safeFallback("lead_sla", e)),
+    getProfileGateOverview().catch((e) => safeFallback("profile_gate_drip", e)),
+    getDunningOverview().catch((e) => safeFallback("advisor_dunning", e)),
+    getBrokerChangesOverview().catch((e) => safeFallback("broker_data_changes", e)),
+    getMarketplaceCampaignOverview().catch((e) => safeFallback("marketplace_campaigns", e)),
+    getAfslExpiryOverview().catch((e) => safeFallback("afsl_expiry", e)),
+    getEmailBouncesOverview().catch((e) => safeFallback("email_bounces", e)),
+    getMonthlyReportsOverview().catch((e) => safeFallback("monthly_reports", e)),
+    getQualityWeightsOverview().catch((e) => safeFallback("quality_weights", e)),
+  ]);
+  return results;
+}
+
+/**
+ * Safe fallback used when a single feature metric query fails —
+ * the dashboard still renders, one tile shows "unknown" instead
+ * of crashing the whole page.
+ */
+function safeFallback(feature: AutomationFeature, err: unknown): FeatureOverview {
+  const display = FEATURE_CONFIG[feature];
+  // Narrow the error shape without crashing on non-Error throwables
+  const message = err instanceof Error ? err.message : String(err);
+  return {
+    feature,
+    display,
+    pending: 0,
+    lastRun: {
+      name: display.cronName || feature,
+      startedAt: null,
+      endedAt: null,
+      durationMs: null,
+      status: "never_run",
+      stats: { error: message },
+      errorMessage: message,
+      triggeredBy: null,
+    },
+    health: "unknown",
+    recentCounts: {
+      autoActed: 0,
+      escalated: 0,
+      rejected: 0,
+      approved: 0,
+      refunded: 0,
+      total: 0,
+    },
+  };
+}

--- a/lib/cron-run-log.ts
+++ b/lib/cron-run-log.ts
@@ -1,0 +1,176 @@
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+import type { NextRequest, NextResponse } from "next/server";
+
+const log = logger("cron-run-log");
+
+/**
+ * Wraps a cron handler with run-tracking.
+ *
+ * Every cron route writes a row to `cron_run_log` on start and
+ * updates it on completion with status + stats + duration. This
+ * powers the admin automation dashboard's "is this healthy?" checks
+ * because Vercel's cron log UI only retains 24h and is not
+ * queryable.
+ *
+ * Usage:
+ *
+ *     export async function GET(req: NextRequest) {
+ *       const unauth = requireCronAuth(req);
+ *       if (unauth) return unauth;
+ *
+ *       return withCronRunLog("my_cron_name", async () => {
+ *         // ... cron body
+ *         return { ok: true, stats: { scanned: 10 } };
+ *       }, { triggeredBy: req.headers.get("x-admin-manual") ? "admin_manual" : "cron" });
+ *     }
+ *
+ * Returns the NextResponse the handler built, so the caller just
+ * wraps their existing logic. If the handler throws, the run row
+ * gets status='error' with the message, and the error is re-thrown
+ * so Sentry still catches it.
+ */
+export async function withCronRunLog<T>(
+  cronName: string,
+  handler: () => Promise<{ response: T; stats?: Record<string, unknown> }>,
+  options: { triggeredBy?: "cron" | "admin_manual" | "test" } = {},
+): Promise<T> {
+  const supabase = createAdminClient();
+  const startedAt = new Date();
+  const triggeredBy = options.triggeredBy || "cron";
+
+  // Insert a "running" row immediately so a hanging cron shows up as
+  // running rather than invisible.
+  const { data: logRow, error: insertErr } = await supabase
+    .from("cron_run_log")
+    .insert({
+      name: cronName,
+      started_at: startedAt.toISOString(),
+      status: "running",
+      triggered_by: triggeredBy,
+    })
+    .select("id")
+    .single();
+
+  if (insertErr) {
+    log.warn("Failed to insert cron_run_log row", { cronName, error: insertErr.message });
+  }
+
+  try {
+    const result = await handler();
+    const endedAt = new Date();
+    const durationMs = endedAt.getTime() - startedAt.getTime();
+
+    // Determine status: 'ok' if no failure counters, 'partial' if any
+    // failure field is > 0 (convention used by existing crons which
+    // report {failed, errored} in their stats)
+    const stats = result.stats || {};
+    const failureCount = (
+      (stats.failed as number | undefined) ||
+      (stats.errored as number | undefined) ||
+      0
+    );
+    const status = failureCount > 0 ? "partial" : "ok";
+
+    if (logRow) {
+      await supabase
+        .from("cron_run_log")
+        .update({
+          ended_at: endedAt.toISOString(),
+          duration_ms: durationMs,
+          status,
+          stats,
+        })
+        .eq("id", logRow.id);
+    }
+
+    return result.response;
+  } catch (err) {
+    const endedAt = new Date();
+    const durationMs = endedAt.getTime() - startedAt.getTime();
+    const errorMessage = err instanceof Error ? err.message : String(err);
+
+    if (logRow) {
+      await supabase
+        .from("cron_run_log")
+        .update({
+          ended_at: endedAt.toISOString(),
+          duration_ms: durationMs,
+          status: "error",
+          error_message: errorMessage.slice(0, 500),
+        })
+        .eq("id", logRow.id);
+    }
+
+    log.error("Cron handler threw", { cronName, error: errorMessage });
+    throw err;
+  }
+}
+
+/**
+ * Drop-in handler wrapper so existing cron routes can add run-log
+ * tracking with a one-line change:
+ *
+ *     // Before
+ *     export async function GET(req: NextRequest) { ...body... }
+ *
+ *     // After
+ *     async function handler(req: NextRequest) { ...body... }
+ *     export const GET = wrapCronHandler("my-cron", handler);
+ *
+ * The wrapper clones the response, parses its JSON body to extract
+ * stats for the log row, and auto-detects admin-manual triggers via
+ * the X-Admin-Manual header.
+ */
+export function wrapCronHandler(
+  cronName: string,
+  handler: (req: NextRequest) => Promise<NextResponse>,
+): (req: NextRequest) => Promise<NextResponse> {
+  return async (req: NextRequest) => {
+    const triggeredBy: "cron" | "admin_manual" = req.headers.get("x-admin-manual")
+      ? "admin_manual"
+      : "cron";
+
+    return withCronRunLog(
+      cronName,
+      async () => {
+        const response = await handler(req);
+        // Clone + parse body to extract stats. If the handler returned
+        // a non-JSON or non-successful response we still log but with
+        // empty stats.
+        let stats: Record<string, unknown> = {};
+        try {
+          const bodyText = await response.clone().text();
+          if (bodyText) {
+            const parsed = JSON.parse(bodyText);
+            if (parsed && typeof parsed === "object") {
+              stats = parsed as Record<string, unknown>;
+            }
+          }
+        } catch {
+          // non-JSON response, no stats
+        }
+        return { response, stats };
+      },
+      { triggeredBy },
+    );
+  };
+}
+
+/**
+ * Clean up cron_run_log rows older than 90 days. Called by a separate
+ * cleanup cron so we don't block real crons on maintenance work.
+ */
+export async function cleanupCronRunLog(): Promise<number> {
+  const supabase = createAdminClient();
+  const cutoff = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString();
+  const { count, error } = await supabase
+    .from("cron_run_log")
+    .delete({ count: "exact" })
+    .lt("started_at", cutoff);
+  if (error) {
+    log.error("cron_run_log cleanup failed", { error: error.message });
+    return 0;
+  }
+  return count || 0;
+}

--- a/supabase/migrations/20260413_admin_automation_dashboard.sql
+++ b/supabase/migrations/20260413_admin_automation_dashboard.sql
@@ -1,0 +1,122 @@
+-- Admin automation dashboard foundations.
+--
+-- Two changes:
+--   1. New `cron_run_log` table so every cron can persist a run
+--      record on completion. Without this there's no way to answer
+--      "when did X last run successfully" or "what did X return on
+--      its last run" from the admin dashboard — Vercel's cron log
+--      UI is 24-hour retention and not queryable.
+--   2. Override audit columns on every classifier target table so
+--      an admin can reverse a classifier verdict through the
+--      dashboard and we have a clear audit trail of who did it
+--      and when.
+
+-- ── 1. cron_run_log ──────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.cron_run_log (
+  id             bigserial PRIMARY KEY,
+  name           text NOT NULL,
+  started_at     timestamptz NOT NULL,
+  ended_at       timestamptz,
+  duration_ms    integer,
+  status         text NOT NULL,  -- 'running' | 'ok' | 'error' | 'partial'
+  stats          jsonb,
+  error_message  text,
+  triggered_by   text DEFAULT 'cron'  -- 'cron' | 'admin_manual' | 'test'
+);
+
+ALTER TABLE public.cron_run_log
+  DROP CONSTRAINT IF EXISTS cron_run_log_status_check;
+ALTER TABLE public.cron_run_log
+  ADD CONSTRAINT cron_run_log_status_check CHECK (
+    status = ANY (ARRAY['running'::text, 'ok'::text, 'error'::text, 'partial'::text])
+  );
+
+-- Query patterns: "latest run of cron X", "any runs in the last 48h",
+-- "errors only". Index on (name, started_at DESC) covers them all.
+CREATE INDEX IF NOT EXISTS idx_cron_run_log_name_started
+  ON public.cron_run_log (name, started_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_cron_run_log_errors
+  ON public.cron_run_log (started_at DESC)
+  WHERE status = 'error';
+
+-- Auto-cleanup: keep 90 days of runs. Beyond that the stats are
+-- interesting for analytics but not operational, so we trim to keep
+-- the table small.
+CREATE INDEX IF NOT EXISTS idx_cron_run_log_cleanup
+  ON public.cron_run_log (started_at)
+  WHERE started_at < (now() - INTERVAL '90 days');
+
+ALTER TABLE public.cron_run_log ENABLE ROW LEVEL SECURITY;
+
+COMMENT ON TABLE public.cron_run_log IS
+  'Every cron run writes one row here on completion. Source of truth for the admin automation dashboard''s "last run" + "is this healthy" checks.';
+
+-- ── 2. Override audit columns ────────────────────────────────────
+
+-- lead_disputes already has admin_notes + status; add override tracking
+ALTER TABLE public.lead_disputes
+  ADD COLUMN IF NOT EXISTS admin_overridden_at timestamptz,
+  ADD COLUMN IF NOT EXISTS admin_overridden_by text,
+  ADD COLUMN IF NOT EXISTS admin_override_reason text;
+
+-- advisor_applications
+ALTER TABLE public.advisor_applications
+  ADD COLUMN IF NOT EXISTS admin_overridden_at timestamptz,
+  ADD COLUMN IF NOT EXISTS admin_overridden_by text;
+
+-- investment_listings — auto-approve/reject path gets override visibility
+ALTER TABLE public.investment_listings
+  ADD COLUMN IF NOT EXISTS auto_classified_at timestamptz,
+  ADD COLUMN IF NOT EXISTS auto_classified_verdict text,
+  ADD COLUMN IF NOT EXISTS auto_classified_risk_score integer,
+  ADD COLUMN IF NOT EXISTS auto_classified_reasons jsonb,
+  ADD COLUMN IF NOT EXISTS admin_overridden_at timestamptz,
+  ADD COLUMN IF NOT EXISTS admin_overridden_by text;
+
+ALTER TABLE public.investment_listings
+  DROP CONSTRAINT IF EXISTS investment_listings_auto_verdict_check;
+ALTER TABLE public.investment_listings
+  ADD CONSTRAINT investment_listings_auto_verdict_check CHECK (
+    auto_classified_verdict IS NULL OR auto_classified_verdict = ANY (ARRAY[
+      'auto_approve'::text, 'auto_reject'::text, 'escalate'::text
+    ])
+  );
+
+-- user_reviews + professional_reviews — text moderation verdicts
+ALTER TABLE public.user_reviews
+  ADD COLUMN IF NOT EXISTS auto_moderated_at timestamptz,
+  ADD COLUMN IF NOT EXISTS auto_moderated_verdict text,
+  ADD COLUMN IF NOT EXISTS auto_moderated_reasons jsonb,
+  ADD COLUMN IF NOT EXISTS admin_overridden_at timestamptz,
+  ADD COLUMN IF NOT EXISTS admin_overridden_by text;
+
+ALTER TABLE public.user_reviews
+  DROP CONSTRAINT IF EXISTS user_reviews_auto_verdict_check;
+ALTER TABLE public.user_reviews
+  ADD CONSTRAINT user_reviews_auto_verdict_check CHECK (
+    auto_moderated_verdict IS NULL OR auto_moderated_verdict = ANY (ARRAY[
+      'auto_publish'::text, 'auto_reject'::text, 'escalate'::text
+    ])
+  );
+
+ALTER TABLE public.professional_reviews
+  ADD COLUMN IF NOT EXISTS auto_moderated_at timestamptz,
+  ADD COLUMN IF NOT EXISTS auto_moderated_verdict text,
+  ADD COLUMN IF NOT EXISTS auto_moderated_reasons jsonb,
+  ADD COLUMN IF NOT EXISTS admin_overridden_at timestamptz,
+  ADD COLUMN IF NOT EXISTS admin_overridden_by text;
+
+ALTER TABLE public.professional_reviews
+  DROP CONSTRAINT IF EXISTS professional_reviews_auto_verdict_check;
+ALTER TABLE public.professional_reviews
+  ADD CONSTRAINT professional_reviews_auto_verdict_check CHECK (
+    auto_moderated_verdict IS NULL OR auto_moderated_verdict = ANY (ARRAY[
+      'auto_publish'::text, 'auto_reject'::text, 'escalate'::text
+    ])
+  );
+
+COMMENT ON COLUMN public.lead_disputes.admin_overridden_at IS
+  'When an admin manually reversed the classifier verdict via the automation dashboard.';
+COMMENT ON COLUMN public.cron_run_log.triggered_by IS
+  'cron = scheduled Vercel run, admin_manual = manually triggered from the dashboard, test = test run.';


### PR DESCRIPTION
## Summary

Single-page admin dashboard at **`/admin/automation`** plus **13 drill-down pages** giving full visibility and control over every auto-classifier and cron shipped in the last two PRs. **Unlocks the value of all the automation work** — without this dashboard, every classifier was a black box.

**856/856 tests passing** (was 843, +13 new). TypeScript clean. `npm run build` exit 0. Migration live.

## Overview page

Four zones:

1. **Top summary row** — counts of healthy / warning / error / unknown features
2. **"Needs attention" feed** — amber + red features sorted by severity, click-through to drill-down
3. **Grid of 13 feature tiles** — health dot, pending queue, 7-day auto-acted count, last run time, error message if any
4. **Audit footer** — classifier source location, override tracking, cron log retention

## 13 drill-down pages

| Slug | Shows | Actions |
|---|---|---|
| `disputes` | Recent disputes with verdict + signals | Override to refund / reject |
| `applications` | Recent advisor applications | Approve / reject / reverse |
| `listings` | Listings sorted by risk score + risk bar | Approve / reject / unpublish |
| `moderation` | Broker + advisor reviews side by side | Publish / reject |
| `sla` | Paused + warning-in-progress advisors | View |
| `profile-gates` | 5-step drip funnel | View missing fields |
| `dunning` | Failed top-ups by dunning step | View |
| `broker-changes` | Recent changes with tier badges | View (auto-apply already happened) |
| `campaigns` | Recent marketplace campaigns | View |
| `afsl-expiry` | Advisors flagged by weekly register check | View |
| `email-suppression` | Full suppression list | View |
| `monthly-reports` | Last run stats | Manual trigger |
| `quality-weights` | Latest model version weights table | View |

Every drill-down uses `<DrillDownShell />` so the header (breadcrumb + health dot + stat row + manual trigger button + last-run diagnostics) is consistent.

## Shared components

- `HealthTile` — grid tile with health traffic light
- `DrillDownShell` — shared header + stat row
- `CronTriggerButton` — fire a cron with confirmation, shows success/error flash
- `SignalsPopover` — collapsible "why did the classifier decide this" popover reading from `auto_resolved_reasons` / `auto_moderated_reasons` / `auto_classified_reasons` jsonb columns
- `OverrideButton` — confirm modal + POST to `/api/admin/automation/override`

## API surface

### POST `/api/admin/automation/trigger`
Admin-authed. Allowlist-gated (only 8 known cron names). Forwards to the actual cron route with the `CRON_SECRET` bearer token + `X-Admin-Manual` header so `wrapCronHandler` stamps `triggered_by='admin_manual'`.

### POST `/api/admin/automation/override`
Admin-authed. Dispatches to per-feature handlers. For lead disputes, flipping `approved ↔ rejected` actually moves the credit both ways (credits the advisor on reverse-to-approved, debits on reverse-to-rejected). Every override stamps `admin_overridden_at + admin_overridden_by + reason` on the target row for audit.

## Schema

New migration `20260413_admin_automation_dashboard.sql` (already applied):

```sql
-- cron_run_log table
CREATE TABLE cron_run_log (
  id bigserial PRIMARY KEY,
  name text NOT NULL,
  started_at timestamptz NOT NULL,
  ended_at timestamptz,
  duration_ms integer,
  status text NOT NULL,  -- running/ok/error/partial
  stats jsonb,
  error_message text,
  triggered_by text DEFAULT 'cron'  -- cron/admin_manual/test
);

-- Override audit columns on every classifier target
ALTER TABLE lead_disputes ADD admin_overridden_at, admin_overridden_by, admin_override_reason;
ALTER TABLE advisor_applications ADD admin_overridden_at, admin_overridden_by;
ALTER TABLE investment_listings ADD auto_classified_* + admin_overridden_*;
ALTER TABLE user_reviews ADD auto_moderated_* + admin_overridden_*;
ALTER TABLE professional_reviews ADD auto_moderated_* + admin_overridden_*;
```

Plus CHECK enums on all new verdict columns, partial indexes for the cron log hot paths (`(name, started_at DESC)` + errors-only).

## Cron wiring

Two helpers in `lib/cron-run-log.ts`:

- `withCronRunLog(name, handler, options)` — low-level wrapper used by the already-restructured `auto-resolve-disputes` cron
- `wrapCronHandler(name, handler)` — drop-in replacement for the existing `export async function GET(req)` shape. Intercepts the response, parses the JSON body for stats, writes a `cron_run_log` row. Used on the other 7 new crons **without restructuring their existing logic**.

All 8 automation crons are wrapped. Admin-manual triggers set the `X-Admin-Manual` header which `wrapCronHandler` reads to stamp `triggered_by='admin_manual'` — so the dashboard distinguishes scheduled runs from manual kicks.

## Admin nav

New sidebar entry in the Health & Ops section: **"Automation"** linking to `/admin/automation`. Positioned first in the section so it's the default ops landing.

## Tests

`__tests__/lib/automation-metrics.test.ts` — 13 new unit tests covering:

- `computeHealth` returns `green` / `amber` / `red` / `unknown` correctly for every combination of cron status + queue depth + run age
- RED conditions take priority over AMBER (errored cron with amber queue is red)
- Queue warn level only triggers amber, not red
- Cron overdue by >2 cadence windows is red; 1.25–2 is amber
- `FEATURE_CONFIG` has an entry for every `AUTOMATION_FEATURES` key
- All 13 feature slugs are unique

## What this unlocks

Every auto-classifier shipped this session now has:

✅ **A live health check** the admin can see at a glance
✅ **A pending queue counter** that updates on every page load
✅ **A signals popover** showing exactly why the classifier decided what it decided
✅ **An override button** that's logged for audit (with reason-required for money-moving overrides)
✅ **A manual trigger button** for cron-driven features

Without this dashboard, every classifier was a black box. With it, every decision is auditable and reversible. **The first time a classifier makes a questionable call, you override + move on** — the feature keeps running instead of getting turned off.

## What this deliberately does NOT do (v1 scope)

- **Config / threshold editing UI** — editing classifier thresholds from the UI was proposed but deferred because a bad threshold = lots of bad decisions. Thresholds are code changes with tests for now.
- **Time-series graphs** of verdicts per day — the count stats are point-in-time snapshots. Add a charts library in v2 if useful.
- **Email digest** of daily/weekly dashboard state — could write a cron that emails the summary to the admin at start of day. Defer until we know the admin actually checks the dashboard.
- **Bulk actions** (approve all pending, reject all with specific signal) — skipped for v1 because the risk of a bulk-action mistake is high. Add with a confirmation-list preview once the dashboard has been used for a while.

https://claude.ai/code/session_01DyudU3Uo5eFGwXKQsYcbUw