### PR TITLE
feat: automation wave 2 — config, kill switches, bulk, charts, LLM scoring

### DIFF
--- a/__tests__/lib/article-quality-scoring.test.ts
+++ b/__tests__/lib/article-quality-scoring.test.ts
@@ -1,0 +1,271 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+// The library reads classifier_config for thresholds and writes to
+// article_quality_scores. Mock both supabase and the classifier-
+// config shim to keep tests hermetic.
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({
+    from: () => ({
+      insert: async () => ({ error: null }),
+    }),
+  }),
+}));
+
+vi.mock("@/lib/admin/classifier-config", () => ({
+  getThreshold: async (_c: string, name: string, def: number) => {
+    // Let each test override by setting a global.
+    const override = (globalThis as unknown as { __thresholds?: Record<string, number> })
+      .__thresholds;
+    return override?.[name] ?? def;
+  },
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+import {
+  scoreArticle,
+  resolveVerdict,
+  parseRubricJson,
+} from "@/lib/article-quality-scoring";
+
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+  delete process.env.ANTHROPIC_API_KEY;
+  delete process.env.OPENAI_API_KEY;
+  delete (globalThis as unknown as { __thresholds?: Record<string, number> }).__thresholds;
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  for (const k of Object.keys(process.env)) delete process.env[k];
+  Object.assign(process.env, ORIGINAL_ENV);
+});
+
+describe("resolveVerdict", () => {
+  it("auto_rejects when score is below reject_threshold", () => {
+    expect(resolveVerdict(30, 100, 80, 40, 60)).toBe("auto_reject");
+  });
+
+  it("escalates when compliance is below floor even with high score", () => {
+    expect(resolveVerdict(95, 50, 80, 40, 60)).toBe("escalate");
+  });
+
+  it("auto_approves when score >= approve_threshold and compliance is fine", () => {
+    expect(resolveVerdict(85, 90, 80, 40, 60)).toBe("auto_approve");
+  });
+
+  it("escalates between reject and approve thresholds", () => {
+    expect(resolveVerdict(60, 80, 80, 40, 60)).toBe("escalate");
+  });
+
+  it("treats exactly-approve_threshold as approve", () => {
+    expect(resolveVerdict(80, 80, 80, 40, 60)).toBe("auto_approve");
+  });
+
+  it("treats exactly-reject_threshold as escalate (not reject)", () => {
+    expect(resolveVerdict(40, 80, 80, 40, 60)).toBe("escalate");
+  });
+});
+
+describe("parseRubricJson", () => {
+  it("parses a strict JSON response", () => {
+    const r = parseRubricJson(
+      '{"rubric":{"clarity":90,"accuracy":80,"completeness":85,"compliance":95,"seo":70},"score":84,"feedback":"Good"}',
+    );
+    expect(r.rubric.clarity).toBe(90);
+    expect(r.score).toBe(84);
+    expect(r.feedback).toBe("Good");
+  });
+
+  it("strips a json markdown code fence", () => {
+    const r = parseRubricJson(
+      '```json\n{"rubric":{"clarity":80,"accuracy":80,"completeness":80,"compliance":80,"seo":80},"score":80,"feedback":"ok"}\n```',
+    );
+    expect(r.score).toBe(80);
+  });
+
+  it("clamps out-of-range values to [0, 100]", () => {
+    const r = parseRubricJson(
+      '{"rubric":{"clarity":150,"accuracy":-20,"completeness":85,"compliance":95,"seo":70},"score":84}',
+    );
+    expect(r.rubric.clarity).toBe(100);
+    expect(r.rubric.accuracy).toBe(0);
+  });
+
+  it("returns zeros on parse failure", () => {
+    const r = parseRubricJson("not json at all");
+    expect(r.rubric.clarity).toBe(0);
+    expect(r.score).toBe(0);
+    expect(r.feedback).toBe("parse_error");
+  });
+
+  it("averages the rubric when score is missing", () => {
+    const r = parseRubricJson(
+      '{"rubric":{"clarity":80,"accuracy":80,"completeness":80,"compliance":80,"seo":80}}',
+    );
+    expect(r.score).toBe(80);
+  });
+});
+
+describe("scoreArticle — stub provider", () => {
+  it("escalates when no LLM provider is configured", async () => {
+    const r = await scoreArticle({
+      articleId: 1,
+      articleSlug: "x",
+      title: "T",
+      content: "lorem ipsum",
+    });
+    expect(r.provider).toBe("stub");
+    expect(r.verdict).toBe("escalate");
+  });
+});
+
+describe("scoreArticle — claude provider", () => {
+  beforeEach(() => {
+    process.env.ANTHROPIC_API_KEY = "sk-ant-...";
+  });
+
+  it("auto_approves a high-scoring article", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          content: [
+            {
+              type: "text",
+              text: '{"rubric":{"clarity":90,"accuracy":85,"completeness":80,"compliance":95,"seo":75},"score":85,"feedback":"ok"}',
+            },
+          ],
+        }),
+      })),
+    );
+    const r = await scoreArticle({
+      articleId: 1,
+      articleSlug: "x",
+      title: "T",
+      content: "...",
+    });
+    expect(r.provider).toBe("claude");
+    expect(r.verdict).toBe("auto_approve");
+  });
+
+  it("escalates when compliance is below floor even with high aggregate", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          content: [
+            {
+              type: "text",
+              text: '{"rubric":{"clarity":95,"accuracy":95,"completeness":95,"compliance":40,"seo":95},"score":84,"feedback":"compliance issues"}',
+            },
+          ],
+        }),
+      })),
+    );
+    const r = await scoreArticle({
+      articleId: 2,
+      articleSlug: "x",
+      title: "T",
+      content: "...",
+    });
+    expect(r.verdict).toBe("escalate");
+    expect(r.rubric.compliance).toBe(40);
+  });
+
+  it("returns escalate verdict on HTTP error without crashing", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: false,
+        status: 500,
+        json: async () => ({}),
+      })),
+    );
+    const r = await scoreArticle({
+      articleId: 3,
+      articleSlug: "x",
+      title: "T",
+      content: "...",
+    });
+    expect(r.verdict).toBe("escalate");
+    expect(r.feedback).toContain("provider_error");
+  });
+
+  it("honours live-editable thresholds from classifier_config", async () => {
+    // Override approve_threshold to 70 so a score of 72 is auto_approve
+    (globalThis as unknown as { __thresholds?: Record<string, number> }).__thresholds = {
+      approve_threshold: 70,
+      reject_threshold: 30,
+      compliance_floor: 50,
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          content: [
+            {
+              type: "text",
+              text: '{"rubric":{"clarity":72,"accuracy":72,"completeness":72,"compliance":72,"seo":72},"score":72,"feedback":""}',
+            },
+          ],
+        }),
+      })),
+    );
+    const r = await scoreArticle({
+      articleId: 4,
+      articleSlug: "x",
+      title: "T",
+      content: "...",
+    });
+    expect(r.verdict).toBe("auto_approve");
+  });
+});
+
+describe("scoreArticle — openai provider", () => {
+  beforeEach(() => {
+    process.env.OPENAI_API_KEY = "sk-...";
+  });
+
+  it("parses a chat/completions response shape", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          choices: [
+            {
+              message: {
+                content:
+                  '{"rubric":{"clarity":30,"accuracy":30,"completeness":30,"compliance":30,"seo":30},"score":30,"feedback":"poor"}',
+              },
+            },
+          ],
+        }),
+      })),
+    );
+    const r = await scoreArticle({
+      articleId: 5,
+      articleSlug: "x",
+      title: "T",
+      content: "...",
+    });
+    expect(r.provider).toBe("openai");
+    expect(r.verdict).toBe("auto_reject"); // 30 < default reject_threshold 40
+  });
+});

--- a/__tests__/lib/classifier-config.test.ts
+++ b/__tests__/lib/classifier-config.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Build a configurable mock that lets each test control what the
+// "classifier_config" + "automation_kill_switches" tables return.
+let configRows: Array<{ classifier: string; threshold_name: string; value: number }> = [];
+let killSwitchRows: Array<{ feature: string; disabled: boolean }> = [];
+let queryCount = 0;
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({
+    from: (table: string) => ({
+      select: () => ({
+        eq: (_col: string, val: string) => {
+          queryCount++;
+          if (table === "classifier_config") {
+            return Promise.resolve({
+              data: configRows.filter((r) => r.classifier === val),
+              error: null,
+            });
+          }
+          return Promise.resolve({ data: [], error: null });
+        },
+        in: (_col: string, vals: string[]) => {
+          queryCount++;
+          if (table === "automation_kill_switches") {
+            return Promise.resolve({
+              data: killSwitchRows.filter((r) => vals.includes(r.feature)),
+              error: null,
+            });
+          }
+          return Promise.resolve({ data: [], error: null });
+        },
+      }),
+    }),
+  }),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+import {
+  getClassifierConfig,
+  getThreshold,
+  invalidateClassifierConfigCache,
+  isFeatureDisabled,
+  invalidateKillSwitchCache,
+} from "@/lib/admin/classifier-config";
+
+beforeEach(() => {
+  configRows = [];
+  killSwitchRows = [];
+  queryCount = 0;
+  invalidateClassifierConfigCache();
+  invalidateKillSwitchCache();
+});
+
+describe("getClassifierConfig", () => {
+  it("returns empty map when no rows match", async () => {
+    const cfg = await getClassifierConfig("text_moderation");
+    expect(cfg).toEqual({});
+  });
+
+  it("returns all thresholds for the classifier", async () => {
+    configRows = [
+      { classifier: "text_moderation", threshold_name: "min_spam_signals", value: 3 },
+      { classifier: "text_moderation", threshold_name: "max_link_density", value: 0.4 },
+      { classifier: "other", threshold_name: "foo", value: 99 },
+    ];
+    const cfg = await getClassifierConfig("text_moderation");
+    expect(cfg).toEqual({ min_spam_signals: 3, max_link_density: 0.4 });
+  });
+
+  it("caches results across calls", async () => {
+    configRows = [{ classifier: "x", threshold_name: "a", value: 1 }];
+    await getClassifierConfig("x");
+    await getClassifierConfig("x");
+    await getClassifierConfig("x");
+    expect(queryCount).toBe(1);
+  });
+
+  it("invalidateClassifierConfigCache forces a refetch", async () => {
+    configRows = [{ classifier: "x", threshold_name: "a", value: 1 }];
+    await getClassifierConfig("x");
+    invalidateClassifierConfigCache("x");
+    await getClassifierConfig("x");
+    expect(queryCount).toBe(2);
+  });
+});
+
+describe("getThreshold", () => {
+  it("returns the configured value when present", async () => {
+    configRows = [{ classifier: "foo", threshold_name: "warn", value: 7 }];
+    const v = await getThreshold("foo", "warn", 5);
+    expect(v).toBe(7);
+  });
+
+  it("falls back to the default when not configured", async () => {
+    const v = await getThreshold("foo", "warn", 5);
+    expect(v).toBe(5);
+  });
+
+  it("falls back to the default when value is NaN", async () => {
+    configRows = [{ classifier: "foo", threshold_name: "warn", value: Number.NaN }];
+    const v = await getThreshold("foo", "warn", 5);
+    expect(v).toBe(5);
+  });
+});
+
+describe("isFeatureDisabled", () => {
+  it("returns false when no kill switches are set", async () => {
+    expect(await isFeatureDisabled("text_moderation")).toBe(false);
+  });
+
+  it("returns true when the feature-specific kill switch is on", async () => {
+    killSwitchRows = [{ feature: "text_moderation", disabled: true }];
+    expect(await isFeatureDisabled("text_moderation")).toBe(true);
+  });
+
+  it("returns true when the global kill switch is on", async () => {
+    killSwitchRows = [{ feature: "global", disabled: true }];
+    expect(await isFeatureDisabled("any_feature")).toBe(true);
+  });
+
+  it("returns false when a feature's switch exists but is off", async () => {
+    killSwitchRows = [{ feature: "text_moderation", disabled: false }];
+    expect(await isFeatureDisabled("text_moderation")).toBe(false);
+  });
+});

--- a/__tests__/lib/photo-moderation.test.ts
+++ b/__tests__/lib/photo-moderation.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Photo moderation unit tests.
+ *
+ * The library writes to supabase for the audit log, so we mock the
+ * admin client to a no-op. We stub global fetch to simulate each
+ * provider's response shape.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+// Supabase admin client — mock so logModerationCheck is a no-op.
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({
+    from: () => ({
+      insert: async () => ({ error: null }),
+    }),
+  }),
+}));
+
+// Silence logger during tests.
+vi.mock("@/lib/logger", () => ({
+  logger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+import { moderatePhoto } from "@/lib/photo-moderation";
+
+const ORIGINAL_ENV = { ...process.env };
+
+function clearProviderEnv() {
+  delete process.env.CLOUDFLARE_IMAGES_TOKEN;
+  delete process.env.CLOUDFLARE_ACCOUNT_ID;
+  delete process.env.AWS_ACCESS_KEY_ID;
+  delete process.env.AWS_SECRET_ACCESS_KEY;
+  delete process.env.AWS_REGION;
+  delete process.env.REKOGNITION_PROXY_URL;
+}
+
+beforeEach(() => {
+  clearProviderEnv();
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  // Restore full env to avoid leaking between tests.
+  for (const k of Object.keys(process.env)) delete process.env[k];
+  Object.assign(process.env, ORIGINAL_ENV);
+});
+
+describe("moderatePhoto — stub provider (no env vars)", () => {
+  it("returns unknown verdict when no provider is configured", async () => {
+    const result = await moderatePhoto(
+      "https://example.com/photo.jpg",
+      "advisor_photo",
+      42,
+    );
+    expect(result.provider).toBe("stub");
+    expect(result.verdict).toBe("unknown");
+    expect(result.confidence).toBe(0);
+    expect(result.labels).toEqual({});
+  });
+
+  it("never throws on stub, regardless of input", async () => {
+    await expect(
+      moderatePhoto("", "listing_image", null),
+    ).resolves.toBeDefined();
+  });
+});
+
+describe("moderatePhoto — cloudflare provider", () => {
+  beforeEach(() => {
+    process.env.CLOUDFLARE_IMAGES_TOKEN = "https://worker.example.com/moderate";
+    process.env.CLOUDFLARE_ACCOUNT_ID = "acct-123";
+  });
+
+  it("returns clean when response has no explicit/suggestive flags", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          labels: { scenery: 0.1, person: 0.2 },
+          explicit: false,
+          suggestive: false,
+          confidence: 0.2,
+        }),
+      })),
+    );
+
+    const r = await moderatePhoto("https://ex/p.jpg", "advisor_photo");
+    expect(r.provider).toBe("cloudflare");
+    expect(r.verdict).toBe("clean");
+  });
+
+  it("returns rejected when explicit flag is true", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          labels: { explicit_nudity: 0.95 },
+          explicit: true,
+          suggestive: false,
+          confidence: 0.95,
+        }),
+      })),
+    );
+
+    const r = await moderatePhoto("https://ex/p.jpg", "listing_image");
+    expect(r.verdict).toBe("rejected");
+    expect(r.provider).toBe("cloudflare");
+  });
+
+  it("returns flagged when suggestive flag is true", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          labels: { suggestive: 0.6 },
+          explicit: false,
+          suggestive: true,
+          confidence: 0.6,
+        }),
+      })),
+    );
+
+    const r = await moderatePhoto("https://ex/p.jpg", "advisor_photo");
+    expect(r.verdict).toBe("flagged");
+  });
+
+  it("rejects when any label score exceeds 0.85", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          labels: { graphic_violence: 0.9 },
+          explicit: false,
+          suggestive: false,
+        }),
+      })),
+    );
+    const r = await moderatePhoto("https://ex/p.jpg", "broker_logo");
+    expect(r.verdict).toBe("rejected");
+  });
+
+  it("returns unknown verdict on HTTP error (no throw propagates)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: false,
+        status: 500,
+        json: async () => ({}),
+      })),
+    );
+    const r = await moderatePhoto("https://ex/p.jpg", "advisor_photo");
+    expect(r.verdict).toBe("unknown");
+    expect(r.labels.error).toBe(1);
+  });
+
+  it("returns unknown when fetch itself throws", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("network");
+      }),
+    );
+    const r = await moderatePhoto("https://ex/p.jpg", "advisor_photo");
+    expect(r.verdict).toBe("unknown");
+  });
+});
+
+describe("moderatePhoto — rekognition provider", () => {
+  beforeEach(() => {
+    process.env.AWS_ACCESS_KEY_ID = "AKIA...";
+    process.env.AWS_SECRET_ACCESS_KEY = "secret";
+    process.env.AWS_REGION = "ap-southeast-2";
+    process.env.REKOGNITION_PROXY_URL = "https://proxy.example.com/rekognition";
+  });
+
+  it("maps Rekognition labels to verdict=clean when all scores low", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          ModerationLabels: [
+            { Name: "Suggestive", Confidence: 20 },
+            { Name: "Tobacco", Confidence: 15 },
+          ],
+        }),
+      })),
+    );
+    const r = await moderatePhoto("https://ex/p.jpg", "advisor_photo");
+    expect(r.provider).toBe("rekognition");
+    expect(r.verdict).toBe("clean");
+    expect(r.labels.Suggestive).toBeCloseTo(0.2, 5);
+  });
+
+  it("flags when highest label > 0.5", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          ModerationLabels: [{ Name: "Suggestive", Confidence: 62 }],
+        }),
+      })),
+    );
+    const r = await moderatePhoto("https://ex/p.jpg", "listing_image");
+    expect(r.verdict).toBe("flagged");
+  });
+
+  it("rejects when highest label > 0.85", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          ModerationLabels: [{ Name: "ExplicitNudity", Confidence: 95 }],
+        }),
+      })),
+    );
+    const r = await moderatePhoto("https://ex/p.jpg", "advisor_photo");
+    expect(r.verdict).toBe("rejected");
+  });
+
+  it("returns unknown when REKOGNITION_PROXY_URL is missing", async () => {
+    delete process.env.REKOGNITION_PROXY_URL;
+    const r = await moderatePhoto("https://ex/p.jpg", "advisor_photo");
+    expect(r.verdict).toBe("unknown");
+    expect(r.provider).toBe("rekognition");
+  });
+});
+
+describe("moderatePhoto — provider selection priority", () => {
+  it("prefers cloudflare when both cloudflare and AWS env vars set", async () => {
+    process.env.CLOUDFLARE_IMAGES_TOKEN = "https://worker/moderate";
+    process.env.CLOUDFLARE_ACCOUNT_ID = "acct";
+    process.env.AWS_ACCESS_KEY_ID = "AKIA";
+    process.env.AWS_SECRET_ACCESS_KEY = "secret";
+    process.env.AWS_REGION = "ap-southeast-2";
+    process.env.REKOGNITION_PROXY_URL = "https://proxy";
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({ labels: {}, explicit: false, suggestive: false }),
+      })),
+    );
+
+    const r = await moderatePhoto("https://ex/p.jpg", "advisor_photo");
+    expect(r.provider).toBe("cloudflare");
+  });
+
+  it("falls through to stub if cloudflare partially configured", async () => {
+    process.env.CLOUDFLARE_IMAGES_TOKEN = "set";
+    // CLOUDFLARE_ACCOUNT_ID intentionally missing
+    const r = await moderatePhoto("https://ex/p.jpg", "advisor_photo");
+    expect(r.provider).toBe("stub");
+  });
+});

--- a/__tests__/lib/property-suburb-refresh.test.ts
+++ b/__tests__/lib/property-suburb-refresh.test.ts
@@ -1,0 +1,252 @@
+/**
+ * property-suburb-refresh unit tests.
+ *
+ * Uses an in-memory mock supabase that captures writes so we can
+ * assert on the diff + log row shape.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+let currentSuburb: Record<string, number | null> | null = null;
+let lastUpdate: Record<string, unknown> | null = null;
+let lastLog: Record<string, unknown> | null = null;
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({
+    from: (table: string) => ({
+      select: () => ({
+        eq: (_col: string, _val: string) => ({
+          maybeSingle: async () => ({ data: currentSuburb, error: null }),
+        }),
+      }),
+      update: (payload: Record<string, unknown>) => ({
+        eq: async () => {
+          lastUpdate = { table, payload };
+          return { error: null };
+        },
+      }),
+      insert: async (payload: Record<string, unknown>) => {
+        if (table === "property_suburb_refresh_log") lastLog = payload;
+        return { error: null };
+      },
+    }),
+  }),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+import { refreshSuburb } from "@/lib/property-suburb-refresh";
+
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+  currentSuburb = null;
+  lastUpdate = null;
+  lastLog = null;
+  vi.restoreAllMocks();
+  delete process.env.CORELOGIC_API_KEY;
+  delete process.env.CORELOGIC_API_URL;
+  delete process.env.SQM_RESEARCH_API_KEY;
+  delete process.env.SQM_RESEARCH_API_URL;
+});
+
+afterEach(() => {
+  for (const k of Object.keys(process.env)) delete process.env[k];
+  Object.assign(process.env, ORIGINAL_ENV);
+});
+
+describe("refreshSuburb — stub provider (no env vars)", () => {
+  it("returns empty diff and never touches suburb_data", async () => {
+    const r = await refreshSuburb("bondi-nsw-2026", "NSW");
+    expect(r.provider).toBe("stub");
+    expect(r.fieldsChanged).toEqual({});
+    expect(lastUpdate).toBeNull();
+    // Still logs an audit row so the cron looks healthy
+    expect(lastLog).not.toBeNull();
+    expect((lastLog as { provider: string }).provider).toBe("stub");
+  });
+});
+
+describe("refreshSuburb — corelogic happy path", () => {
+  beforeEach(() => {
+    process.env.CORELOGIC_API_KEY = "token-abc";
+  });
+
+  it("computes a diff of only changed fields and updates suburb_data", async () => {
+    currentSuburb = {
+      median_house_price: 100000000,
+      median_unit_price: 60000000,
+      rental_yield: 3.5,
+      vacancy_rate: 2.0,
+      capital_growth_10yr: 50,
+      sales_volume_12mo: 200,
+      median_rent_weekly: 750,
+    };
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          median_house: 110000000, // changed
+          median_unit: 60000000, // same
+          rental_yield: 3.8, // changed
+          vacancy_rate: 2.0, // same
+          capital_growth_10yr: null, // null — don't overwrite
+          sales_volume_12mo: 250,
+          median_rent_weekly: 800,
+        }),
+      })),
+    );
+
+    const r = await refreshSuburb("bondi-nsw-2026", "NSW");
+    expect(r.provider).toBe("corelogic");
+    expect(r.error).toBeUndefined();
+
+    // Only 4 of 7 fields actually changed
+    expect(Object.keys(r.fieldsChanged).sort()).toEqual([
+      "median_house_price",
+      "median_rent_weekly",
+      "rental_yield",
+      "sales_volume_12mo",
+    ]);
+    expect(r.fieldsChanged.median_house_price).toEqual([100000000, 110000000]);
+
+    // Update payload contains the same 4 fields (plus updated_at)
+    expect(lastUpdate).not.toBeNull();
+    const payload = (lastUpdate as { payload: Record<string, unknown> }).payload;
+    expect(payload.median_house_price).toBe(110000000);
+    expect(payload.rental_yield).toBe(3.8);
+    expect(payload.median_unit_price).toBeUndefined(); // unchanged → not in update
+    expect(payload.capital_growth_10yr).toBeUndefined(); // null → not overwritten
+    expect(payload.updated_at).toBeTruthy();
+  });
+
+  it("returns empty diff when nothing changed and skips update", async () => {
+    currentSuburb = {
+      median_house_price: 100000000,
+      median_unit_price: 60000000,
+      rental_yield: 3.5,
+      vacancy_rate: 2.0,
+      capital_growth_10yr: 50,
+      sales_volume_12mo: 200,
+      median_rent_weekly: 750,
+    };
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          median_house: 100000000,
+          median_unit: 60000000,
+          rental_yield: 3.5,
+          vacancy_rate: 2.0,
+          capital_growth_10yr: 50,
+          sales_volume_12mo: 200,
+          median_rent_weekly: 750,
+        }),
+      })),
+    );
+
+    const r = await refreshSuburb("bondi-nsw-2026", "NSW");
+    expect(r.fieldsChanged).toEqual({});
+    expect(lastUpdate).toBeNull();
+  });
+
+  it("never overwrites an existing value with null from provider", async () => {
+    currentSuburb = { median_house_price: 100000000 };
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({ median_house: null }),
+      })),
+    );
+
+    const r = await refreshSuburb("bondi-nsw-2026", "NSW");
+    expect(r.fieldsChanged).toEqual({});
+    expect(lastUpdate).toBeNull();
+  });
+
+  it("logs an error row when the provider fetch 500s", async () => {
+    currentSuburb = { median_house_price: 100000000 };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: false,
+        status: 502,
+        json: async () => ({}),
+      })),
+    );
+
+    const r = await refreshSuburb("bondi-nsw-2026", "NSW");
+    expect(r.error).toContain("corelogic HTTP 502");
+    expect(lastUpdate).toBeNull();
+    expect(lastLog).not.toBeNull();
+    const logRow = lastLog as { fields_changed: { __error?: string } };
+    expect(logRow.fields_changed.__error).toContain("corelogic HTTP 502");
+  });
+
+  it("handles a missing suburb row gracefully", async () => {
+    currentSuburb = null;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({ median_house: 100000000 }),
+      })),
+    );
+    const r = await refreshSuburb("ghost-vic-0000", "VIC");
+    expect(r.error).toBe("suburb row not found");
+    expect(r.fieldsChanged).toEqual({});
+  });
+});
+
+describe("refreshSuburb — sqm provider", () => {
+  beforeEach(() => {
+    process.env.SQM_RESEARCH_API_KEY = "sqm-token";
+  });
+
+  it("maps sqm response field names to the canonical schema", async () => {
+    currentSuburb = {
+      median_house_price: 80000000,
+      median_unit_price: null,
+      rental_yield: 4.0,
+      vacancy_rate: null,
+      capital_growth_10yr: null,
+      sales_volume_12mo: null,
+      median_rent_weekly: null,
+    };
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          median_house: 85000000,
+          yield: 4.3,
+          weekly_rent: 780,
+        }),
+      })),
+    );
+
+    const r = await refreshSuburb("st-kilda-vic-3182", "VIC");
+    expect(r.provider).toBe("sqm");
+    expect(r.fieldsChanged.median_house_price).toEqual([80000000, 85000000]);
+    expect(r.fieldsChanged.rental_yield).toEqual([4.0, 4.3]);
+    expect(r.fieldsChanged.median_rent_weekly).toEqual([null, 780]);
+  });
+});

--- a/app/admin/automation/audit-log/page.tsx
+++ b/app/admin/automation/audit-log/page.tsx
@@ -1,0 +1,137 @@
+import Link from "next/link";
+import AdminShell from "@/components/AdminShell";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+export const dynamic = "force-dynamic";
+
+interface AuditRow {
+  id: number;
+  admin_email: string;
+  feature: string;
+  action: string;
+  target_row_id: number | null;
+  target_verdict: string | null;
+  reason: string | null;
+  context: Record<string, unknown> | null;
+  created_at: string;
+}
+
+const ACTION_COLOUR: Record<string, string> = {
+  override: "bg-blue-100 text-blue-800",
+  trigger: "bg-slate-100 text-slate-700",
+  config: "bg-purple-100 text-purple-800",
+  bulk: "bg-amber-100 text-amber-800",
+  kill_switch: "bg-red-100 text-red-800",
+};
+
+/**
+ * Unified audit log page.
+ *
+ * One feed view over admin_action_log with simple filtering on
+ * feature + action + admin email. Defaults to the last 500 rows,
+ * most recent first. Admin-only via the AdminShell layout.
+ */
+export default async function AuditLogPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ feature?: string; action?: string; admin?: string }>;
+}) {
+  const params = await searchParams;
+  const admin = createAdminClient();
+  let query = admin
+    .from("admin_action_log")
+    .select("id, admin_email, feature, action, target_row_id, target_verdict, reason, context, created_at")
+    .order("created_at", { ascending: false })
+    .limit(500);
+
+  if (params.feature) query = query.eq("feature", params.feature);
+  if (params.action) query = query.eq("action", params.action);
+  if (params.admin) query = query.eq("admin_email", params.admin);
+
+  const { data } = await query;
+  const rows = (data || []) as AuditRow[];
+
+  return (
+    <AdminShell title="Admin action audit log" subtitle="Every classifier override, config change, bulk action and kill switch">
+      <div className="p-4 md:p-6 max-w-7xl">
+        <nav className="text-xs text-slate-500 mb-3">
+          <Link href="/admin/automation" className="hover:text-slate-900">
+            ← Automation dashboard
+          </Link>
+        </nav>
+
+        {/* Filters — plain links, no JS */}
+        <div className="flex flex-wrap items-center gap-2 mb-4">
+          <span className="text-xs text-slate-500">Filter:</span>
+          {["override", "trigger", "config", "bulk", "kill_switch"].map((a) => (
+            <Link
+              key={a}
+              href={`/admin/automation/audit-log?action=${a}`}
+              className={`text-[0.65rem] font-semibold px-2 py-1 rounded-full border ${
+                params.action === a
+                  ? "bg-slate-900 text-white border-slate-900"
+                  : "bg-white text-slate-700 border-slate-200 hover:bg-slate-50"
+              }`}
+            >
+              {a}
+            </Link>
+          ))}
+          {params.action || params.feature || params.admin ? (
+            <Link
+              href="/admin/automation/audit-log"
+              className="text-[0.65rem] font-semibold px-2 py-1 rounded-full text-slate-500 hover:text-slate-900"
+            >
+              clear
+            </Link>
+          ) : null}
+        </div>
+
+        <section className="bg-white border border-slate-200 rounded-xl overflow-hidden">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-[0.6rem] uppercase tracking-wider text-slate-500 border-b border-slate-100 bg-slate-50">
+                <th className="px-3 py-2 text-left font-semibold">When</th>
+                <th className="px-3 py-2 text-left font-semibold">Who</th>
+                <th className="px-3 py-2 text-left font-semibold">Feature</th>
+                <th className="px-3 py-2 text-left font-semibold">Action</th>
+                <th className="px-3 py-2 text-left font-semibold">Target</th>
+                <th className="px-3 py-2 text-left font-semibold">Reason</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.length === 0 && (
+                <tr>
+                  <td colSpan={6} className="px-4 py-8 text-center text-sm text-slate-500">
+                    No matching audit rows.
+                  </td>
+                </tr>
+              )}
+              {rows.map((r) => (
+                <tr key={r.id} className="border-b border-slate-100 last:border-0 hover:bg-slate-50/40">
+                  <td className="px-3 py-2 text-xs text-slate-600 whitespace-nowrap">
+                    {new Date(r.created_at).toLocaleString("en-AU")}
+                  </td>
+                  <td className="px-3 py-2 text-xs text-slate-800 truncate max-w-[18ch]">{r.admin_email}</td>
+                  <td className="px-3 py-2 text-xs font-mono text-slate-700">{r.feature}</td>
+                  <td className="px-3 py-2">
+                    <span className={`text-[0.6rem] font-semibold uppercase tracking-wider px-2 py-0.5 rounded ${ACTION_COLOUR[r.action] || "bg-slate-100 text-slate-700"}`}>
+                      {r.action}
+                    </span>
+                  </td>
+                  <td className="px-3 py-2 text-xs text-slate-700">
+                    {r.target_row_id ? `#${r.target_row_id}` : r.action === "bulk" ? `${(r.context as { row_count?: number } | null)?.row_count ?? "?"} rows` : "—"}
+                    {r.target_verdict && (
+                      <span className="ml-1 text-slate-500">→ {r.target_verdict}</span>
+                    )}
+                  </td>
+                  <td className="px-3 py-2 text-xs text-slate-600 truncate max-w-[40ch]">{r.reason || "—"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </section>
+        <p className="mt-3 text-[0.65rem] text-slate-500">Showing most recent 500. Older rows remain in the table.</p>
+      </div>
+    </AdminShell>
+  );
+}

--- a/app/admin/automation/config/ConfigEditor.tsx
+++ b/app/admin/automation/config/ConfigEditor.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { useState } from "react";
+
+interface ConfigRow {
+  id: number;
+  classifier: string;
+  threshold_name: string;
+  value: number;
+  min_value: number | null;
+  max_value: number | null;
+  description: string | null;
+  updated_by: string | null;
+  updated_at: string | null;
+}
+
+/**
+ * Table of classifier thresholds with inline editing. Each row has
+ * a numeric input + a Save button; Save POSTs to the config API and
+ * updates the local state on success.
+ *
+ * If initialRows is empty (fresh installation) the editor shows an
+ * explanation that classifiers will fall back to hardcoded defaults
+ * until a row is added.
+ */
+export default function ConfigEditor({ initialRows }: { initialRows: ConfigRow[] }) {
+  const [rows, setRows] = useState(initialRows);
+  const [draft, setDraft] = useState<Record<string, string>>({});
+  const [saving, setSaving] = useState<Record<string, boolean>>({});
+  const [error, setError] = useState<string | null>(null);
+  const [flash, setFlash] = useState<string | null>(null);
+
+  if (rows.length === 0) {
+    return (
+      <div className="bg-white border border-slate-200 rounded-xl p-6 text-center">
+        <p className="text-sm text-slate-600">
+          No thresholds configured yet — classifiers are running with
+          their hardcoded defaults. Insert rows into{" "}
+          <code className="bg-slate-100 px-1 rounded">classifier_config</code> to
+          override them at runtime.
+        </p>
+      </div>
+    );
+  }
+
+  async function save(row: ConfigRow) {
+    const key = `${row.classifier}:${row.threshold_name}`;
+    const draftValue = draft[key];
+    const value = draftValue !== undefined ? Number(draftValue) : row.value;
+    if (!Number.isFinite(value)) {
+      setError("Value must be a number");
+      return;
+    }
+    setError(null);
+    setFlash(null);
+    setSaving((s) => ({ ...s, [key]: true }));
+    try {
+      const res = await fetch("/api/admin/automation/config", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          classifier: row.classifier,
+          thresholdName: row.threshold_name,
+          value,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
+      setRows((rs) =>
+        rs.map((r) =>
+          r.id === row.id ? { ...r, value, updated_at: new Date().toISOString() } : r,
+        ),
+      );
+      setDraft((d) => {
+        const next = { ...d };
+        delete next[key];
+        return next;
+      });
+      setFlash(`${row.classifier}.${row.threshold_name} saved`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "save_failed");
+    } finally {
+      setSaving((s) => ({ ...s, [key]: false }));
+    }
+  }
+
+  // Group rows by classifier for readability.
+  const grouped = new Map<string, ConfigRow[]>();
+  for (const r of rows) {
+    if (!grouped.has(r.classifier)) grouped.set(r.classifier, []);
+    grouped.get(r.classifier)!.push(r);
+  }
+
+  return (
+    <div className="space-y-5">
+      {error && (
+        <div className="px-3 py-2 bg-red-50 border border-red-200 rounded text-xs text-red-800">
+          ⚠ {error}
+        </div>
+      )}
+      {flash && (
+        <div className="px-3 py-2 bg-emerald-50 border border-emerald-200 rounded text-xs text-emerald-800">
+          ✓ {flash}
+        </div>
+      )}
+
+      {[...grouped.entries()].map(([classifier, cls]) => (
+        <section key={classifier} className="bg-white border border-slate-200 rounded-xl overflow-hidden">
+          <header className="px-4 py-3 border-b border-slate-100 bg-slate-50">
+            <h3 className="text-sm font-bold text-slate-900">{classifier}</h3>
+          </header>
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-[0.6rem] uppercase tracking-wider text-slate-500 border-b border-slate-100">
+                <th className="px-4 py-2 text-left font-semibold">Threshold</th>
+                <th className="px-4 py-2 text-left font-semibold">Value</th>
+                <th className="px-4 py-2 text-left font-semibold">Bounds</th>
+                <th className="px-4 py-2 text-left font-semibold">Updated</th>
+                <th className="px-4 py-2 w-20"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {cls.map((row) => {
+                const key = `${row.classifier}:${row.threshold_name}`;
+                const isSaving = !!saving[key];
+                const draftValue = draft[key];
+                const hasDraft = draftValue !== undefined && Number(draftValue) !== row.value;
+                return (
+                  <tr key={row.id} className="border-b border-slate-100 last:border-0">
+                    <td className="px-4 py-2 text-slate-800">
+                      <div className="font-mono text-xs">{row.threshold_name}</div>
+                      {row.description && (
+                        <div className="text-[0.65rem] text-slate-500 mt-0.5">{row.description}</div>
+                      )}
+                    </td>
+                    <td className="px-4 py-2">
+                      <input
+                        type="number"
+                        step="any"
+                        defaultValue={row.value}
+                        onChange={(e) =>
+                          setDraft((d) => ({ ...d, [key]: e.target.value }))
+                        }
+                        className="w-24 px-2 py-1 border border-slate-300 rounded text-sm font-mono focus:ring-2 focus:ring-amber-400 focus:border-amber-400 outline-none"
+                      />
+                    </td>
+                    <td className="px-4 py-2 text-[0.65rem] text-slate-500 font-mono">
+                      {row.min_value ?? "—"} … {row.max_value ?? "—"}
+                    </td>
+                    <td className="px-4 py-2 text-[0.65rem] text-slate-500">
+                      {row.updated_at ? new Date(row.updated_at).toLocaleString("en-AU") : "—"}
+                      {row.updated_by && (
+                        <div className="truncate max-w-[12ch]">{row.updated_by}</div>
+                      )}
+                    </td>
+                    <td className="px-4 py-2">
+                      <button
+                        type="button"
+                        onClick={() => save(row)}
+                        disabled={!hasDraft || isSaving}
+                        className="px-3 py-1 text-xs font-semibold rounded bg-slate-900 text-white hover:bg-slate-800 disabled:bg-slate-300 disabled:cursor-not-allowed"
+                      >
+                        {isSaving ? "…" : "Save"}
+                      </button>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/app/admin/automation/config/page.tsx
+++ b/app/admin/automation/config/page.tsx
@@ -1,0 +1,50 @@
+import Link from "next/link";
+import AdminShell from "@/components/AdminShell";
+import { createAdminClient } from "@/lib/supabase/admin";
+import ConfigEditor from "./ConfigEditor";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Classifier threshold editor page.
+ *
+ * Reads every row from classifier_config server-side and hands it
+ * to a small client component for inline editing. Edits POST to
+ * /api/admin/automation/config which validates bounds and audits.
+ */
+export default async function AutomationConfigPage() {
+  const admin = createAdminClient();
+  const { data } = await admin
+    .from("classifier_config")
+    .select("id, classifier, threshold_name, value, min_value, max_value, description, updated_by, updated_at")
+    .order("classifier", { ascending: true })
+    .order("threshold_name", { ascending: true });
+
+  return (
+    <AdminShell
+      title="Classifier thresholds"
+      subtitle="Live-editable values. Writes take effect within 60s."
+    >
+      <div className="p-4 md:p-6 max-w-5xl">
+        <nav className="text-xs text-slate-500 mb-3">
+          <Link href="/admin/automation" className="hover:text-slate-900">
+            ← Automation dashboard
+          </Link>
+        </nav>
+        <div className="bg-amber-50 border border-amber-200 rounded-xl p-4 mb-5">
+          <h2 className="text-sm font-bold text-amber-900 mb-1">Caution</h2>
+          <p className="text-xs text-amber-800">
+            Thresholds control auto-approve / auto-reject decisions. A
+            value that looks reasonable but lowers the reject bar can
+            cause mass false-positive rejects. Use the{" "}
+            <Link href="/admin/automation/dry-run" className="underline">
+              dry-run tester
+            </Link>{" "}
+            before saving changes.
+          </p>
+        </div>
+        <ConfigEditor initialRows={data || []} />
+      </div>
+    </AdminShell>
+  );
+}

--- a/app/admin/automation/dry-run/DryRunForm.tsx
+++ b/app/admin/automation/dry-run/DryRunForm.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useState } from "react";
+
+const CLASSIFIERS = [
+  { value: "text_moderation", label: "Text moderation", sample: JSON.stringify({ text: "Great broker, fast execution", title: null, surface: "broker_review", authorId: "u1", authorVerified: true, authorPriorCount: 1, authorPriorRejections: 0 }, null, 2) },
+  { value: "listing_scam", label: "Listing scam", sample: JSON.stringify({ listing: { title: "High yield investment", description: "10% guaranteed monthly returns, send BTC for details.", contact_email: "noreply@example.com", price_cents: 1000000 } }, null, 2) },
+  { value: "advisor_application", label: "Advisor application", sample: JSON.stringify({ application: { full_name: "Jane Doe", firm: "ACME Advisory", afsl_number: "123456", abn: "12 345 678 901", specialties: ["retirement"] } }, null, 2) },
+  { value: "marketplace_campaign", label: "Marketplace campaign", sample: JSON.stringify({ title: "Premium SMSF advice", body: "Book a free consultation.", broker_trust_score: 0.8, budget_cents: 50000, prior_approved_campaigns: 2 }, null, 2) },
+];
+
+export default function DryRunForm() {
+  const [classifier, setClassifier] = useState(CLASSIFIERS[0].value);
+  const [input, setInput] = useState(CLASSIFIERS[0].sample);
+  const [result, setResult] = useState<unknown>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  async function run() {
+    setError(null);
+    setResult(null);
+    setBusy(true);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(input);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "json_parse_error");
+      setBusy(false);
+      return;
+    }
+    try {
+      const res = await fetch("/api/admin/automation/dry-run", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ classifier, input: parsed }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error || `HTTP ${res.status}`);
+      } else {
+        setResult(data.result);
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "fetch_failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function loadSample(c: string) {
+    const entry = CLASSIFIERS.find((x) => x.value === c);
+    setClassifier(c);
+    if (entry) setInput(entry.sample);
+    setResult(null);
+    setError(null);
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="bg-white border border-slate-200 rounded-xl p-4">
+        <label className="text-[0.65rem] font-semibold uppercase tracking-wider text-slate-500 block mb-1">
+          Classifier
+        </label>
+        <select
+          value={classifier}
+          onChange={(e) => loadSample(e.target.value)}
+          className="w-full px-3 py-2 border border-slate-300 rounded text-sm font-mono bg-white focus:ring-2 focus:ring-amber-400 focus:border-amber-400 outline-none"
+        >
+          {CLASSIFIERS.map((c) => (
+            <option key={c.value} value={c.value}>
+              {c.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="bg-white border border-slate-200 rounded-xl p-4">
+        <label className="text-[0.65rem] font-semibold uppercase tracking-wider text-slate-500 block mb-1">
+          Input JSON
+        </label>
+        <textarea
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          rows={14}
+          spellCheck={false}
+          className="w-full px-3 py-2 border border-slate-300 rounded text-xs font-mono focus:ring-2 focus:ring-amber-400 focus:border-amber-400 outline-none"
+        />
+        <div className="mt-3">
+          <button
+            type="button"
+            onClick={run}
+            disabled={busy}
+            className="px-4 py-2 text-sm font-semibold rounded bg-slate-900 text-white hover:bg-slate-800 disabled:opacity-50"
+          >
+            {busy ? "Running…" : "Run classifier"}
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="px-3 py-2 bg-red-50 border border-red-200 rounded text-xs text-red-800">
+          ⚠ {error}
+        </div>
+      )}
+
+      {result != null && (
+        <div className="bg-white border border-slate-200 rounded-xl p-4">
+          <h3 className="text-sm font-bold text-slate-900 mb-2">Result</h3>
+          <pre className="text-xs font-mono bg-slate-50 p-3 rounded border border-slate-100 overflow-x-auto">
+            {JSON.stringify(result, null, 2)}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/admin/automation/dry-run/page.tsx
+++ b/app/admin/automation/dry-run/page.tsx
@@ -1,0 +1,30 @@
+import Link from "next/link";
+import AdminShell from "@/components/AdminShell";
+import DryRunForm from "./DryRunForm";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Classifier dry-run tester.
+ *
+ * Admin can paste JSON input for any classifier and preview the
+ * verdict + signals without touching the DB. Used to tune thresholds
+ * and debug why a particular row got escalated.
+ */
+export default function DryRunPage() {
+  return (
+    <AdminShell
+      title="Classifier dry-run tester"
+      subtitle="Paste a JSON payload and preview the verdict without side effects"
+    >
+      <div className="p-4 md:p-6 max-w-4xl">
+        <nav className="text-xs text-slate-500 mb-3">
+          <Link href="/admin/automation" className="hover:text-slate-900">
+            ← Automation dashboard
+          </Link>
+        </nav>
+        <DryRunForm />
+      </div>
+    </AdminShell>
+  );
+}

--- a/app/admin/automation/kill-switch/KillSwitchControls.tsx
+++ b/app/admin/automation/kill-switch/KillSwitchControls.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useState } from "react";
+
+interface Row {
+  feature: string;
+  title: string;
+  description: string;
+  current: {
+    disabled: boolean;
+    reason: string | null;
+    disabled_by: string | null;
+    disabled_at: string | null;
+  };
+}
+
+export default function KillSwitchControls({ initialRows }: { initialRows: Row[] }) {
+  const [rows, setRows] = useState(initialRows);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+
+  async function toggle(row: Row) {
+    setError(null);
+    setBusy(row.feature);
+    const nextDisabled = !row.current.disabled;
+    let reason: string | null = null;
+    if (nextDisabled) {
+      reason = window.prompt(
+        `Reason for disabling ${row.title}? (Logged to audit.)`,
+        "",
+      );
+      if (reason == null) {
+        setBusy(null);
+        return; // user cancelled
+      }
+    }
+    try {
+      const res = await fetch("/api/admin/automation/kill-switch", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ feature: row.feature, disabled: nextDisabled, reason }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
+      setRows((rs) =>
+        rs.map((r) =>
+          r.feature === row.feature
+            ? {
+                ...r,
+                current: {
+                  disabled: nextDisabled,
+                  reason,
+                  disabled_by: nextDisabled ? "you" : null,
+                  disabled_at: nextDisabled ? new Date().toISOString() : null,
+                },
+              }
+            : r,
+        ),
+      );
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "toggle_failed");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      {error && (
+        <div className="px-3 py-2 bg-red-50 border border-red-200 rounded text-xs text-red-800">
+          ⚠ {error}
+        </div>
+      )}
+      {rows.map((row) => {
+        const disabled = row.current.disabled;
+        const isGlobal = row.feature === "global";
+        return (
+          <div
+            key={row.feature}
+            className={`flex items-start gap-4 p-4 rounded-xl border ${
+              isGlobal
+                ? disabled
+                  ? "border-red-400 bg-red-50"
+                  : "border-red-200 bg-white"
+                : disabled
+                  ? "border-amber-300 bg-amber-50"
+                  : "border-slate-200 bg-white"
+            }`}
+          >
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2">
+                <h3 className={`text-sm font-bold ${isGlobal ? "text-red-900" : "text-slate-900"}`}>
+                  {row.title}
+                </h3>
+                {disabled && (
+                  <span className="text-[0.6rem] font-bold uppercase tracking-wider px-2 py-0.5 rounded-full bg-amber-500 text-white">
+                    Disabled
+                  </span>
+                )}
+              </div>
+              <p className="text-xs text-slate-500 mt-1">{row.description}</p>
+              {disabled && row.current.reason && (
+                <p className="text-[0.65rem] text-amber-800 mt-2">
+                  Reason: {row.current.reason}
+                </p>
+              )}
+              {disabled && row.current.disabled_at && (
+                <p className="text-[0.6rem] text-slate-500 mt-0.5">
+                  Disabled {new Date(row.current.disabled_at).toLocaleString("en-AU")}{" "}
+                  by {row.current.disabled_by}
+                </p>
+              )}
+            </div>
+            <button
+              type="button"
+              onClick={() => toggle(row)}
+              disabled={busy === row.feature}
+              className={`text-xs font-semibold px-3 py-1.5 rounded border ${
+                disabled
+                  ? "bg-white border-slate-300 text-slate-700 hover:bg-slate-50"
+                  : "bg-slate-900 border-slate-900 text-white hover:bg-slate-800"
+              } disabled:opacity-50`}
+            >
+              {busy === row.feature ? "…" : disabled ? "Re-enable" : "Disable"}
+            </button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/admin/automation/kill-switch/page.tsx
+++ b/app/admin/automation/kill-switch/page.tsx
@@ -1,0 +1,62 @@
+import Link from "next/link";
+import AdminShell from "@/components/AdminShell";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { AUTOMATION_FEATURES, FEATURE_CONFIG } from "@/lib/admin/automation-metrics";
+import KillSwitchControls from "./KillSwitchControls";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Kill-switch admin page.
+ *
+ * Shows a toggle per automation feature (plus a "global" toggle at
+ * the top). Server-fetches the current state so the page renders
+ * without an extra client round-trip, then a client component
+ * handles the toggle interactions + POSTs.
+ */
+export default async function KillSwitchPage() {
+  const admin = createAdminClient();
+  const { data } = await admin
+    .from("automation_kill_switches")
+    .select("feature, disabled, reason, disabled_by, disabled_at")
+    .order("feature");
+
+  const byFeature = new Map((data || []).map((r) => [r.feature as string, r]));
+  const rows = [
+    { feature: "global", title: "GLOBAL — disable all automation", description: "Emergency: freezes every classifier and cron simultaneously. Use only if something is broken platform-wide." },
+    ...AUTOMATION_FEATURES.map((key) => ({
+      feature: key as string,
+      title: FEATURE_CONFIG[key].title,
+      description: FEATURE_CONFIG[key].description,
+    })),
+    { feature: "property_suburb_refresh", title: "Property suburb refresh", description: "Quarterly CoreLogic/SQM data refresh cron. Turn off if the paid data feed is erroring." },
+  ].map((r) => ({
+    ...r,
+    current: byFeature.get(r.feature) || { disabled: false, reason: null, disabled_by: null, disabled_at: null },
+  }));
+
+  return (
+    <AdminShell
+      title="Kill switches"
+      subtitle="Freeze classifiers and crons instantly without a deploy"
+    >
+      <div className="p-4 md:p-6 max-w-5xl">
+        <nav className="text-xs text-slate-500 mb-3">
+          <Link href="/admin/automation" className="hover:text-slate-900">
+            ← Automation dashboard
+          </Link>
+        </nav>
+        <div className="bg-red-50 border border-red-200 rounded-xl p-4 mb-5">
+          <h2 className="text-sm font-bold text-red-900 mb-1">Operator warning</h2>
+          <p className="text-xs text-red-800">
+            Flipping a kill switch stops the classifier from running on
+            new items. Pending items stay pending — they aren't
+            auto-rejected. The GLOBAL toggle stops every automation
+            feature at once and should only be used in emergencies.
+          </p>
+        </div>
+        <KillSwitchControls initialRows={rows} />
+      </div>
+    </AdminShell>
+  );
+}

--- a/app/admin/automation/listings/ListingsBulkTable.tsx
+++ b/app/admin/automation/listings/ListingsBulkTable.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import SignalsPopover from "@/components/admin/automation/SignalsPopover";
+import OverrideButton from "@/components/admin/automation/OverrideButton";
+import BulkActionToolbar from "@/components/admin/automation/BulkActionToolbar";
+
+interface ListingRow {
+  id: number;
+  title: string;
+  vertical: string;
+  status: string;
+  contact_email: string;
+  auto_classified_verdict: string | null;
+  auto_classified_risk_score: number | null;
+  auto_classified_reasons: string[] | null;
+  created_at: string;
+}
+
+/**
+ * Client component wrapping the listings table so we can have
+ * multi-select + bulk actions + CSV export on one page while the
+ * outer page stays a server component for data fetch + chart.
+ */
+export default function ListingsBulkTable({ initialRows }: { initialRows: ListingRow[] }) {
+  const [rows, setRows] = useState(initialRows);
+  const [selected, setSelected] = useState<Set<number>>(new Set());
+
+  const toggleOne = useCallback((id: number) => {
+    setSelected((s) => {
+      const next = new Set(s);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const toggleAll = useCallback(() => {
+    setSelected((s) => {
+      if (s.size === rows.length) return new Set();
+      return new Set(rows.map((r) => r.id));
+    });
+  }, [rows]);
+
+  const clearSelection = useCallback(() => setSelected(new Set()), []);
+
+  // Removes bulk-acted rows from the table so the UI matches server state
+  const onDone = useCallback(() => {
+    setRows((rs) => rs.filter((r) => !selected.has(r.id)));
+  }, [selected]);
+
+  const selectedIds = [...selected];
+
+  const csvRows = rows.map((r) => ({
+    id: r.id,
+    title: r.title,
+    vertical: r.vertical,
+    status: r.status,
+    contact_email: r.contact_email,
+    auto_classified_verdict: r.auto_classified_verdict,
+    auto_classified_risk_score: r.auto_classified_risk_score,
+    auto_classified_reasons: (r.auto_classified_reasons || []).join(";"),
+    created_at: r.created_at,
+  }));
+
+  return (
+    <>
+      <BulkActionToolbar
+        feature="listing_scam"
+        selectedIds={selectedIds}
+        onClearSelection={clearSelection}
+        onDone={onDone}
+        actions={[
+          { value: "active", label: "Approve → active" },
+          { value: "rejected", label: "Reject" },
+          { value: "pending", label: "Re-queue → pending" },
+        ]}
+        csvRows={csvRows}
+        csvFilename="listings.csv"
+      />
+
+      <section className="bg-white border border-slate-200 rounded-xl overflow-hidden">
+        <header className="px-4 py-3 border-b border-slate-100 bg-slate-50">
+          <h2 className="text-sm font-bold text-slate-900">Recent listings</h2>
+          <p className="text-xs text-slate-500">
+            Sorted by risk score descending. Tick rows to bulk-action.
+          </p>
+        </header>
+        <div className="overflow-x-auto">
+          <table className="w-full text-xs">
+            <thead className="bg-slate-50 border-b border-slate-100">
+              <tr>
+                <th className="px-3 py-2 w-6">
+                  <input
+                    type="checkbox"
+                    checked={selected.size === rows.length && rows.length > 0}
+                    onChange={toggleAll}
+                  />
+                </th>
+                <th className="px-4 py-2 text-left font-semibold text-slate-600">ID</th>
+                <th className="px-4 py-2 text-left font-semibold text-slate-600">Title</th>
+                <th className="px-4 py-2 text-left font-semibold text-slate-600">Vertical</th>
+                <th className="px-4 py-2 text-left font-semibold text-slate-600">Contact</th>
+                <th className="px-4 py-2 text-left font-semibold text-slate-600">Status</th>
+                <th className="px-4 py-2 text-left font-semibold text-slate-600">Verdict</th>
+                <th className="px-4 py-2 text-left font-semibold text-slate-600">Risk</th>
+                <th className="px-4 py-2 text-left font-semibold text-slate-600">Signals</th>
+                <th className="px-4 py-2 text-left font-semibold text-slate-600">Action</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100">
+              {[...rows]
+                .sort(
+                  (a, b) =>
+                    (b.auto_classified_risk_score || 0) - (a.auto_classified_risk_score || 0),
+                )
+                .map((r) => {
+                  const isSelected = selected.has(r.id);
+                  return (
+                    <tr
+                      key={r.id}
+                      className={`hover:bg-slate-50/50 ${isSelected ? "bg-amber-50/40" : ""}`}
+                    >
+                      <td className="px-3 py-2">
+                        <input
+                          type="checkbox"
+                          checked={isSelected}
+                          onChange={() => toggleOne(r.id)}
+                        />
+                      </td>
+                      <td className="px-4 py-2 font-mono text-slate-500">#{r.id}</td>
+                      <td className="px-4 py-2 text-slate-700 max-w-[200px] truncate" title={r.title}>
+                        {r.title}
+                      </td>
+                      <td className="px-4 py-2 text-slate-600">{r.vertical}</td>
+                      <td
+                        className="px-4 py-2 text-[0.65rem] text-slate-500 max-w-[180px] truncate"
+                        title={r.contact_email}
+                      >
+                        {r.contact_email}
+                      </td>
+                      <td className="px-4 py-2">
+                        <span
+                          className={`inline-block px-2 py-0.5 rounded text-[0.65rem] font-semibold ${
+                            r.status === "active"
+                              ? "bg-emerald-100 text-emerald-800"
+                              : r.status === "rejected"
+                                ? "bg-red-100 text-red-800"
+                                : "bg-slate-100 text-slate-600"
+                          }`}
+                        >
+                          {r.status}
+                        </span>
+                      </td>
+                      <td className="px-4 py-2 text-slate-600 text-[0.7rem]">
+                        {r.auto_classified_verdict || "—"}
+                      </td>
+                      <td className="px-4 py-2">
+                        {r.auto_classified_risk_score !== null ? (
+                          <div className="flex items-center gap-1">
+                            <div className="w-16 h-1.5 bg-slate-100 rounded overflow-hidden">
+                              <div
+                                className={`h-full ${
+                                  (r.auto_classified_risk_score || 0) > 70
+                                    ? "bg-red-500"
+                                    : (r.auto_classified_risk_score || 0) > 40
+                                      ? "bg-amber-500"
+                                      : "bg-emerald-500"
+                                }`}
+                                style={{ width: `${r.auto_classified_risk_score}%` }}
+                              />
+                            </div>
+                            <span className="text-[0.65rem] font-mono text-slate-600">
+                              {r.auto_classified_risk_score}
+                            </span>
+                          </div>
+                        ) : (
+                          "—"
+                        )}
+                      </td>
+                      <td className="px-4 py-2">
+                        <SignalsPopover reasons={r.auto_classified_reasons || null} />
+                      </td>
+                      <td className="px-4 py-2">
+                        {r.status === "pending" ? (
+                          <div className="flex gap-1">
+                            <OverrideButton
+                              feature="listing_scam"
+                              rowId={r.id}
+                              targetVerdict="active"
+                              label="Approve"
+                            />
+                            <OverrideButton
+                              feature="listing_scam"
+                              rowId={r.id}
+                              targetVerdict="rejected"
+                              label="Reject"
+                            />
+                          </div>
+                        ) : r.status === "active" ? (
+                          <OverrideButton
+                            feature="listing_scam"
+                            rowId={r.id}
+                            targetVerdict="rejected"
+                            label="→ Unpublish"
+                            requireReason
+                          />
+                        ) : (
+                          <OverrideButton
+                            feature="listing_scam"
+                            rowId={r.id}
+                            targetVerdict="active"
+                            label="→ Publish"
+                            requireReason
+                          />
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
+              {rows.length === 0 && (
+                <tr>
+                  <td colSpan={10} className="px-4 py-6 text-center text-slate-500">
+                    No listings
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/app/admin/automation/listings/page.tsx
+++ b/app/admin/automation/listings/page.tsx
@@ -1,93 +1,42 @@
 import { createAdminClient } from "@/lib/supabase/admin";
 import DrillDownShell from "@/components/admin/automation/DrillDownShell";
-import SignalsPopover from "@/components/admin/automation/SignalsPopover";
-import OverrideButton from "@/components/admin/automation/OverrideButton";
+import VerdictChart from "@/components/admin/automation/VerdictChart";
 import { getListingScamOverview } from "@/lib/admin/automation-metrics";
+import ListingsBulkTable from "./ListingsBulkTable";
 
 export const dynamic = "force-dynamic";
 
 export default async function ListingsDrillDown() {
   const supabase = createAdminClient();
-  const [overview, recentRes] = await Promise.all([
+  const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)
+    .toISOString()
+    .slice(0, 10);
+
+  const [overview, recentRes, chartRes] = await Promise.all([
     getListingScamOverview(),
     supabase
       .from("investment_listings")
-      .select("id, title, vertical, status, contact_email, auto_classified_verdict, auto_classified_risk_score, auto_classified_reasons, created_at")
+      .select(
+        "id, title, vertical, status, contact_email, auto_classified_verdict, auto_classified_risk_score, auto_classified_reasons, created_at",
+      )
       .order("created_at", { ascending: false })
       .limit(50),
+    supabase
+      .from("automation_verdict_daily")
+      .select("day, auto_acted, escalated, rejected, approved")
+      .eq("feature", "listing_scam")
+      .gte("day", thirtyDaysAgo)
+      .order("day", { ascending: true }),
   ]);
   const rows = recentRes.data || [];
+  const chartRows = chartRes.data || [];
 
   return (
     <DrillDownShell overview={overview}>
-      <section className="bg-white border border-slate-200 rounded-xl overflow-hidden">
-        <header className="px-4 py-3 border-b border-slate-100 bg-slate-50">
-          <h2 className="text-sm font-bold text-slate-900">Recent listings</h2>
-          <p className="text-xs text-slate-500">Sorted by risk score descending. High risk rows at the top need human review.</p>
-        </header>
-        <div className="overflow-x-auto">
-          <table className="w-full text-xs">
-            <thead className="bg-slate-50 border-b border-slate-100">
-              <tr>
-                <th className="px-4 py-2 text-left font-semibold text-slate-600">ID</th>
-                <th className="px-4 py-2 text-left font-semibold text-slate-600">Title</th>
-                <th className="px-4 py-2 text-left font-semibold text-slate-600">Vertical</th>
-                <th className="px-4 py-2 text-left font-semibold text-slate-600">Contact</th>
-                <th className="px-4 py-2 text-left font-semibold text-slate-600">Status</th>
-                <th className="px-4 py-2 text-left font-semibold text-slate-600">Verdict</th>
-                <th className="px-4 py-2 text-left font-semibold text-slate-600">Risk</th>
-                <th className="px-4 py-2 text-left font-semibold text-slate-600">Signals</th>
-                <th className="px-4 py-2 text-left font-semibold text-slate-600">Action</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-slate-100">
-              {rows.sort((a, b) => (b.auto_classified_risk_score || 0) - (a.auto_classified_risk_score || 0)).map((r) => (
-                <tr key={r.id} className="hover:bg-slate-50/50">
-                  <td className="px-4 py-2 font-mono text-slate-500">#{r.id}</td>
-                  <td className="px-4 py-2 text-slate-700 max-w-[200px] truncate" title={r.title}>{r.title}</td>
-                  <td className="px-4 py-2 text-slate-600">{r.vertical}</td>
-                  <td className="px-4 py-2 text-[0.65rem] text-slate-500 max-w-[180px] truncate" title={r.contact_email}>{r.contact_email}</td>
-                  <td className="px-4 py-2">
-                    <span className={`inline-block px-2 py-0.5 rounded text-[0.65rem] font-semibold ${r.status === "active" ? "bg-emerald-100 text-emerald-800" : r.status === "rejected" ? "bg-red-100 text-red-800" : "bg-slate-100 text-slate-600"}`}>{r.status}</span>
-                  </td>
-                  <td className="px-4 py-2 text-slate-600 text-[0.7rem]">{r.auto_classified_verdict || "—"}</td>
-                  <td className="px-4 py-2">
-                    {r.auto_classified_risk_score !== null ? (
-                      <div className="flex items-center gap-1">
-                        <div className="w-16 h-1.5 bg-slate-100 rounded overflow-hidden">
-                          <div
-                            className={`h-full ${(r.auto_classified_risk_score || 0) > 70 ? "bg-red-500" : (r.auto_classified_risk_score || 0) > 40 ? "bg-amber-500" : "bg-emerald-500"}`}
-                            style={{ width: `${r.auto_classified_risk_score}%` }}
-                          />
-                        </div>
-                        <span className="text-[0.65rem] font-mono text-slate-600">{r.auto_classified_risk_score}</span>
-                      </div>
-                    ) : "—"}
-                  </td>
-                  <td className="px-4 py-2">
-                    <SignalsPopover reasons={(r.auto_classified_reasons as string[] | null) || null} />
-                  </td>
-                  <td className="px-4 py-2">
-                    {r.status === "pending" ? (
-                      <div className="flex gap-1">
-                        <OverrideButton feature="listing_scam" rowId={r.id} targetVerdict="active" label="Approve" />
-                        <OverrideButton feature="listing_scam" rowId={r.id} targetVerdict="rejected" label="Reject" />
-                      </div>
-                    ) : r.status === "active" ? (
-                      <OverrideButton feature="listing_scam" rowId={r.id} targetVerdict="rejected" label="→ Unpublish" requireReason />
-                    ) : (
-                      <OverrideButton feature="listing_scam" rowId={r.id} targetVerdict="active" label="→ Publish" requireReason />
-                    )}
-                  </td>
-                </tr>
-              ))}
-              {rows.length === 0 && (
-                <tr><td colSpan={9} className="px-4 py-6 text-center text-slate-500">No listings</td></tr>
-              )}
-            </tbody>
-          </table>
-        </div>
-      </section>
+      <div className="mb-4">
+        <VerdictChart rows={chartRows} />
+      </div>
+      <ListingsBulkTable initialRows={rows} />
     </DrillDownShell>
   );
 }

--- a/app/admin/automation/page.tsx
+++ b/app/admin/automation/page.tsx
@@ -26,6 +26,22 @@ export default async function AdminAutomationPage() {
   return (
     <AdminShell title="Automation" subtitle="Classifier health + pending queues + manual controls">
       <div className="p-4 md:p-6 max-w-7xl">
+        {/* ── Global nav strip ── */}
+        <nav className="flex flex-wrap gap-2 mb-5 text-xs">
+          <Link href="/admin/automation/config" className="px-3 py-1.5 rounded-full bg-white border border-slate-200 hover:bg-slate-50 font-semibold text-slate-700">
+            ⚙ Thresholds
+          </Link>
+          <Link href="/admin/automation/kill-switch" className="px-3 py-1.5 rounded-full bg-white border border-slate-200 hover:bg-slate-50 font-semibold text-slate-700">
+            ⏸ Kill switches
+          </Link>
+          <Link href="/admin/automation/audit-log" className="px-3 py-1.5 rounded-full bg-white border border-slate-200 hover:bg-slate-50 font-semibold text-slate-700">
+            📜 Audit log
+          </Link>
+          <Link href="/admin/automation/dry-run" className="px-3 py-1.5 rounded-full bg-white border border-slate-200 hover:bg-slate-50 font-semibold text-slate-700">
+            🧪 Dry-run tester
+          </Link>
+        </nav>
+
         {/* ── Top summary bar ── */}
         <div className="grid grid-cols-4 gap-3 mb-6">
           <SummaryCard label="Healthy" value={healthCounts.green} dotClass="bg-emerald-500" />

--- a/app/api/admin/automation/bulk/route.ts
+++ b/app/api/admin/automation/bulk/route.ts
@@ -1,0 +1,197 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { getAdminEmails } from "@/lib/admin";
+import { logger } from "@/lib/logger";
+
+const log = logger("admin:automation:bulk");
+
+/**
+ * POST /api/admin/automation/bulk
+ *
+ * Bulk override endpoint for the drill-down pages. Lets an admin
+ * approve/reject many rows at once instead of clicking one row at a
+ * time. Every row acted on gets its admin_overridden_at + _by
+ * stamped, and a single summary row is written to admin_action_log
+ * with the list of target ids in `context.row_ids`.
+ *
+ * Body: {
+ *   feature:    'lead_disputes' | 'listing_scam' | 'text_moderation'
+ *             | 'advisor_applications' | 'broker_data_changes',
+ *   targetVerdict: feature-specific,
+ *   rowIds:        number[],
+ *   reason?:       string,
+ *   subSurface?:   'broker_review' | 'advisor_review' (text_moderation only)
+ * }
+ *
+ * Returns: { ok, updated, failed, errors: [...] }
+ *
+ * For safety:
+ *   - Max 500 rows per request (reject request otherwise)
+ *   - Money-movement features (lead_disputes) are NOT bulk-actionable
+ *     via this endpoint — those must go through per-row override so
+ *     the credit balance recalculation runs correctly
+ */
+const MAX_BULK_ROWS = 500;
+
+const BULK_ALLOWED_FEATURES = new Set([
+  "listing_scam",
+  "text_moderation",
+  "advisor_applications",
+  "broker_data_changes",
+  "marketplace_campaigns",
+]);
+
+type AdminClient = ReturnType<typeof createAdminClient>;
+
+export async function POST(request: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user || !user.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const adminEmails = getAdminEmails();
+  if (!adminEmails.includes(user.email.toLowerCase())) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const body = await request.json().catch(() => ({}));
+  const feature: string | null = typeof body.feature === "string" ? body.feature : null;
+  const targetVerdict: string | null =
+    typeof body.targetVerdict === "string" ? body.targetVerdict : null;
+  const rowIds: number[] = Array.isArray(body.rowIds)
+    ? body.rowIds.filter((v: unknown) => typeof v === "number")
+    : [];
+  const reason: string | null = typeof body.reason === "string" ? body.reason : null;
+  const subSurface: string | undefined =
+    typeof body.subSurface === "string" ? body.subSurface : undefined;
+
+  if (!feature || !targetVerdict || rowIds.length === 0) {
+    return NextResponse.json(
+      { error: "Missing feature / targetVerdict / rowIds" },
+      { status: 400 },
+    );
+  }
+  if (!BULK_ALLOWED_FEATURES.has(feature)) {
+    return NextResponse.json(
+      { error: `Feature ${feature} is not bulk-actionable (use single override)` },
+      { status: 400 },
+    );
+  }
+  if (rowIds.length > MAX_BULK_ROWS) {
+    return NextResponse.json(
+      { error: `Bulk request exceeds ${MAX_BULK_ROWS} rows` },
+      { status: 400 },
+    );
+  }
+
+  const admin = createAdminClient();
+  const nowIso = new Date().toISOString();
+  const auditPatch = {
+    admin_overridden_at: nowIso,
+    admin_overridden_by: user.email,
+  };
+
+  let updated = 0;
+  const errors: string[] = [];
+
+  try {
+    switch (feature) {
+      case "listing_scam":
+        updated = await bulkUpdate(admin, "investment_listings", rowIds, {
+          status: targetVerdict,
+          ...auditPatch,
+        });
+        break;
+      case "text_moderation": {
+        const table = subSurface === "advisor_review" ? "professional_reviews" : "user_reviews";
+        updated = await bulkUpdate(admin, table, rowIds, {
+          status: targetVerdict,
+          ...auditPatch,
+        });
+        break;
+      }
+      case "advisor_applications":
+        updated = await bulkUpdate(admin, "advisor_applications", rowIds, {
+          status: targetVerdict,
+          reviewed_at: nowIso,
+          reviewed_by: user.email,
+          ...auditPatch,
+        });
+        break;
+      case "broker_data_changes":
+        updated = await bulkUpdate(admin, "broker_data_changes", rowIds, {
+          auto_applied_at: nowIso,
+          ...auditPatch,
+        });
+        break;
+      case "marketplace_campaigns":
+        updated = await bulkUpdate(admin, "campaigns", rowIds, {
+          status: targetVerdict,
+          ...auditPatch,
+        });
+        break;
+    }
+  } catch (err) {
+    errors.push(err instanceof Error ? err.message : String(err));
+    log.error("Bulk override failed", { feature, err: errors[0] });
+  }
+
+  // Audit log — single row summarising the whole bulk action
+  await admin
+    .from("admin_action_log")
+    .insert({
+      admin_email: user.email,
+      feature,
+      action: "bulk",
+      target_row_id: null,
+      target_verdict: targetVerdict,
+      reason,
+      context: {
+        row_ids: rowIds,
+        row_count: rowIds.length,
+        sub_surface: subSurface,
+        updated,
+        errors,
+      },
+    })
+    .then(({ error }) => {
+      if (error) {
+        log.warn("admin_action_log insert failed", { error: error.message });
+      }
+    });
+
+  return NextResponse.json({
+    ok: errors.length === 0,
+    updated,
+    failed: rowIds.length - updated,
+    errors,
+  });
+}
+
+/**
+ * Do a batched update. Supabase JS has no built-in bulk update by
+ * id list so we just use .in('id', ...) which the PG engine expands
+ * into a single SQL UPDATE.
+ */
+async function bulkUpdate(
+  admin: AdminClient,
+  table: string,
+  rowIds: number[],
+  patch: Record<string, unknown>,
+): Promise<number> {
+  // Chunk into groups of 100 to keep the IN list small and predictable
+  let total = 0;
+  for (let i = 0; i < rowIds.length; i += 100) {
+    const chunk = rowIds.slice(i, i + 100);
+    const { error, count } = await admin
+      .from(table)
+      .update(patch, { count: "exact" })
+      .in("id", chunk);
+    if (error) throw new Error(`${table}: ${error.message}`);
+    total += count || chunk.length;
+  }
+  return total;
+}

--- a/app/api/admin/automation/config/route.ts
+++ b/app/api/admin/automation/config/route.ts
@@ -1,0 +1,146 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { getAdminEmails } from "@/lib/admin";
+import { logger } from "@/lib/logger";
+import { invalidateClassifierConfigCache } from "@/lib/admin/classifier-config";
+
+const log = logger("admin:automation:config");
+
+/**
+ * Classifier threshold editor endpoint.
+ *
+ *  GET  — returns every row from classifier_config for the UI.
+ *  POST — upserts a single threshold. Body: { classifier, thresholdName, value, reason? }
+ *
+ * Guardrails: if the target row has min_value/max_value set, writes
+ * outside those bounds are rejected. Every successful write is
+ * audited to admin_action_log with action='config'.
+ *
+ * After a write we invalidate the in-process config cache so the
+ * next classifier call picks up the new value immediately instead
+ * of waiting for the 60-second TTL.
+ */
+export async function GET(_request: NextRequest) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user || !user.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const adminEmails = getAdminEmails();
+  if (!adminEmails.includes(user.email.toLowerCase())) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const admin = createAdminClient();
+  const { data, error } = await admin
+    .from("classifier_config")
+    .select("id, classifier, threshold_name, value, min_value, max_value, description, updated_by, updated_at")
+    .order("classifier", { ascending: true })
+    .order("threshold_name", { ascending: true });
+
+  if (error) {
+    log.error("classifier_config fetch failed", { error: error.message });
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ rows: data || [] });
+}
+
+export async function POST(request: NextRequest) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user || !user.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const adminEmails = getAdminEmails();
+  if (!adminEmails.includes(user.email.toLowerCase())) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const body = await request.json().catch(() => ({}));
+  const classifier: string | null = typeof body.classifier === "string" ? body.classifier : null;
+  const thresholdName: string | null = typeof body.thresholdName === "string" ? body.thresholdName : null;
+  const value: number | null = typeof body.value === "number" && Number.isFinite(body.value) ? body.value : null;
+  const reason: string | null = typeof body.reason === "string" ? body.reason : null;
+  const description: string | null = typeof body.description === "string" ? body.description : null;
+  const minValue: number | null = typeof body.minValue === "number" ? body.minValue : null;
+  const maxValue: number | null = typeof body.maxValue === "number" ? body.maxValue : null;
+
+  if (!classifier || !thresholdName || value == null) {
+    return NextResponse.json(
+      { error: "Missing classifier / thresholdName / value" },
+      { status: 400 },
+    );
+  }
+
+  const admin = createAdminClient();
+
+  // Fetch existing row for bounds check. If it doesn't exist this is
+  // an insert — the body-provided minValue/maxValue become the new
+  // guardrails.
+  const { data: existing } = await admin
+    .from("classifier_config")
+    .select("id, min_value, max_value")
+    .eq("classifier", classifier)
+    .eq("threshold_name", thresholdName)
+    .maybeSingle();
+
+  const effectiveMin = existing?.min_value ?? minValue;
+  const effectiveMax = existing?.max_value ?? maxValue;
+  if (effectiveMin != null && value < Number(effectiveMin)) {
+    return NextResponse.json(
+      { error: `Value ${value} below configured minimum ${effectiveMin}` },
+      { status: 400 },
+    );
+  }
+  if (effectiveMax != null && value > Number(effectiveMax)) {
+    return NextResponse.json(
+      { error: `Value ${value} above configured maximum ${effectiveMax}` },
+      { status: 400 },
+    );
+  }
+
+  const { error: upsertErr } = await admin
+    .from("classifier_config")
+    .upsert(
+      {
+        classifier,
+        threshold_name: thresholdName,
+        value,
+        min_value: existing?.min_value ?? minValue,
+        max_value: existing?.max_value ?? maxValue,
+        description: existing ? undefined : description,
+        updated_by: user.email,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: "classifier,threshold_name" },
+    );
+
+  if (upsertErr) {
+    log.error("classifier_config upsert failed", { error: upsertErr.message });
+    return NextResponse.json({ error: upsertErr.message }, { status: 500 });
+  }
+
+  // Invalidate the process cache so the new value is live immediately.
+  invalidateClassifierConfigCache(classifier);
+
+  // Audit
+  await admin.from("admin_action_log").insert({
+    admin_email: user.email,
+    feature: classifier,
+    action: "config",
+    target_row_id: null,
+    target_verdict: null,
+    reason,
+    context: { threshold_name: thresholdName, value },
+  });
+
+  log.info("classifier_config updated", {
+    classifier,
+    thresholdName,
+    value,
+    adminEmail: user.email,
+  });
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/admin/automation/dry-run/route.ts
+++ b/app/api/admin/automation/dry-run/route.ts
@@ -1,0 +1,77 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { getAdminEmails } from "@/lib/admin";
+import { classifyText } from "@/lib/text-moderation";
+import { classifyListingForScam } from "@/lib/invest-listing-scam-classifier";
+import { classifyApplication } from "@/lib/advisor-application-classifier";
+import { classifyCampaign } from "@/lib/marketplace-campaign-classifier";
+
+/**
+ * POST /api/admin/automation/dry-run
+ *
+ * Admin-only endpoint that runs a classifier with given input and
+ * returns the verdict + signals WITHOUT writing anything to the DB
+ * or triggering any side effects. Used by the dashboard's
+ * classifier tester UI so admins can:
+ *
+ *   - Paste a review/listing/application and preview the verdict
+ *   - Tune thresholds and re-run to check the change took effect
+ *   - Debug why a particular row got escalated by seeing all signals
+ *
+ * Body: { classifier, input }
+ *
+ *   classifier: 'text_moderation' | 'listing_scam' | 'advisor_application' | 'marketplace_campaign'
+ *   input:      classifier-specific context object
+ *
+ * The classifiers themselves are pure — the work here is just
+ * dispatching and serialising the result. No side effects at all.
+ */
+export async function POST(request: NextRequest) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user || !user.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (!getAdminEmails().includes(user.email.toLowerCase())) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const body = await request.json().catch(() => ({}));
+  const classifier = typeof body.classifier === "string" ? body.classifier : null;
+  const input = body.input;
+
+  if (!classifier || !input || typeof input !== "object") {
+    return NextResponse.json({ error: "Missing classifier / input" }, { status: 400 });
+  }
+
+  try {
+    switch (classifier) {
+      case "text_moderation": {
+        const result = classifyText(input);
+        return NextResponse.json({ ok: true, result });
+      }
+      case "listing_scam": {
+        const result = classifyListingForScam(input);
+        return NextResponse.json({ ok: true, result });
+      }
+      case "advisor_application": {
+        const result = classifyApplication(input);
+        return NextResponse.json({ ok: true, result });
+      }
+      case "marketplace_campaign": {
+        const result = classifyCampaign(input);
+        return NextResponse.json({ ok: true, result });
+      }
+      default:
+        return NextResponse.json(
+          { error: `Unknown classifier: ${classifier}` },
+          { status: 400 },
+        );
+    }
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "classifier_threw" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/admin/automation/kill-switch/route.ts
+++ b/app/api/admin/automation/kill-switch/route.ts
@@ -1,0 +1,99 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { getAdminEmails } from "@/lib/admin";
+import { logger } from "@/lib/logger";
+import { invalidateKillSwitchCache } from "@/lib/admin/classifier-config";
+
+const log = logger("admin:automation:kill-switch");
+
+/**
+ * GET  — list every kill switch row (feature, disabled, reason, etc)
+ * POST — flip a feature on/off. Body: { feature, disabled, reason? }
+ *
+ *   feature='global' disables ALL automation features at once.
+ *   Per-feature rows (from AUTOMATION_FEATURES) disable a single
+ *   classifier/cron. Every classifier entry point calls
+ *   isFeatureDisabled() before running.
+ *
+ * After a write we invalidate the cache so the toggle takes effect
+ * on the next classifier call.
+ */
+
+export async function GET(_request: NextRequest) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user || !user.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (!getAdminEmails().includes(user.email.toLowerCase())) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const admin = createAdminClient();
+  const { data, error } = await admin
+    .from("automation_kill_switches")
+    .select("feature, disabled, reason, disabled_by, disabled_at")
+    .order("feature");
+
+  if (error) {
+    log.error("kill switch fetch failed", { error: error.message });
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  return NextResponse.json({ rows: data || [] });
+}
+
+export async function POST(request: NextRequest) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user || !user.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (!getAdminEmails().includes(user.email.toLowerCase())) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const body = await request.json().catch(() => ({}));
+  const feature: string | null = typeof body.feature === "string" ? body.feature : null;
+  const disabled: boolean =
+    typeof body.disabled === "boolean" ? body.disabled : false;
+  const reason: string | null = typeof body.reason === "string" ? body.reason : null;
+
+  if (!feature) {
+    return NextResponse.json({ error: "Missing feature" }, { status: 400 });
+  }
+
+  const admin = createAdminClient();
+  const nowIso = new Date().toISOString();
+  const { error: upsertErr } = await admin
+    .from("automation_kill_switches")
+    .upsert(
+      {
+        feature,
+        disabled,
+        reason,
+        disabled_by: disabled ? user.email : null,
+        disabled_at: disabled ? nowIso : null,
+      },
+      { onConflict: "feature" },
+    );
+
+  if (upsertErr) {
+    log.error("kill switch upsert failed", { error: upsertErr.message });
+    return NextResponse.json({ error: upsertErr.message }, { status: 500 });
+  }
+
+  invalidateKillSwitchCache();
+
+  await admin.from("admin_action_log").insert({
+    admin_email: user.email,
+    feature,
+    action: "kill_switch",
+    target_verdict: disabled ? "disabled" : "enabled",
+    reason,
+    context: { feature, disabled },
+  });
+
+  log.warn("Kill switch flipped", { feature, disabled, adminEmail: user.email });
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/cron/auto-resolve-disputes/route.ts
+++ b/app/api/cron/auto-resolve-disputes/route.ts
@@ -4,6 +4,7 @@ import { logger } from "@/lib/logger";
 import { requireCronAuth } from "@/lib/cron-auth";
 import { withCronRunLog } from "@/lib/cron-run-log";
 import { autoResolveDispute } from "@/lib/advisor-lead-dispute-resolver";
+import { isFeatureDisabled } from "@/lib/admin/classifier-config";
 
 const log = logger("cron:auto-resolve-disputes");
 
@@ -36,6 +37,15 @@ export async function GET(req: NextRequest) {
         escalated: 0,
         failed: 0,
       };
+
+      // Kill switch short-circuit — flip this from the admin dashboard
+      // to freeze auto-resolution without a redeploy.
+      if (await isFeatureDisabled("lead_disputes")) {
+        return {
+          response: NextResponse.json({ ok: true, skipped: "kill_switch_on", ...stats }),
+          stats: { ...stats, skipped: "kill_switch_on" as const },
+        };
+      }
 
       const supabase = createAdminClient();
       const { data: pending, error } = await supabase

--- a/app/api/cron/automation-verdict-rollup/route.ts
+++ b/app/api/cron/automation-verdict-rollup/route.ts
@@ -1,0 +1,232 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+import { requireCronAuth } from "@/lib/cron-auth";
+import { wrapCronHandler } from "@/lib/cron-run-log";
+
+const log = logger("cron:automation-verdict-rollup");
+
+export const runtime = "nodejs";
+export const maxDuration = 120;
+
+/**
+ * Hourly cron that aggregates classifier verdicts per feature into
+ * `automation_verdict_daily`. The admin dashboard's time-series
+ * charts read from this table instead of scanning raw
+ * lead_disputes / investment_listings / user_reviews on every page
+ * load.
+ *
+ * Strategy:
+ *   - Upsert today's row for every feature that produces verdicts
+ *   - Re-aggregate yesterday too (late-arriving updates)
+ *   - Past days are immutable — we don't touch them
+ *
+ * This is eventually-consistent with the raw tables, which is fine
+ * for a dashboard chart. Exact numbers are still available on the
+ * drill-down pages which query the raw tables directly.
+ */
+async function handler(req: NextRequest) {
+  const unauth = requireCronAuth(req);
+  if (unauth) return unauth;
+
+  const supabase = createAdminClient();
+  const today = new Date();
+  const yesterday = new Date(today.getTime() - 24 * 60 * 60 * 1000);
+
+  const days = [dayKey(yesterday), dayKey(today)];
+  const stats = { upserts: 0, failed: 0 };
+
+  for (const day of days) {
+    try {
+      const rows = await Promise.all([
+        rollupLeadDisputes(supabase, day),
+        rollupListings(supabase, day),
+        rollupTextModeration(supabase, day),
+        rollupApplications(supabase, day),
+        rollupBrokerChanges(supabase, day),
+        rollupCampaigns(supabase, day),
+      ]);
+      const flat = rows.flat();
+
+      for (const r of flat) {
+        const { error } = await supabase
+          .from("automation_verdict_daily")
+          .upsert(r, { onConflict: "feature,day" });
+        if (error) {
+          stats.failed++;
+          log.warn("verdict_daily upsert failed", { error: error.message, feature: r.feature });
+        } else {
+          stats.upserts++;
+        }
+      }
+    } catch (err) {
+      stats.failed++;
+      log.error("rollup day threw", {
+        day,
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  log.info("verdict rollup completed", stats);
+  return NextResponse.json({ ok: true, ...stats });
+}
+
+type Supa = ReturnType<typeof createAdminClient>;
+
+interface DailyRow {
+  feature: string;
+  day: string;
+  auto_acted: number;
+  escalated: number;
+  rejected: number;
+  approved: number;
+  refunded_cents: number;
+}
+
+function dayKey(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+function dayRange(day: string): { start: string; end: string } {
+  const start = new Date(`${day}T00:00:00Z`).toISOString();
+  const end = new Date(`${day}T23:59:59.999Z`).toISOString();
+  return { start, end };
+}
+
+async function rollupLeadDisputes(supabase: Supa, day: string): Promise<DailyRow[]> {
+  const { start, end } = dayRange(day);
+  const { data } = await supabase
+    .from("lead_disputes")
+    .select("auto_resolved_verdict, status, refunded_cents")
+    .gte("created_at", start)
+    .lte("created_at", end);
+  const rows = data || [];
+  return [
+    {
+      feature: "lead_disputes",
+      day,
+      auto_acted: rows.filter((r) => r.auto_resolved_verdict === "refund" || r.auto_resolved_verdict === "reject").length,
+      escalated: rows.filter((r) => r.auto_resolved_verdict === "escalate").length,
+      rejected: rows.filter((r) => r.status === "rejected").length,
+      approved: rows.filter((r) => r.status === "approved").length,
+      refunded_cents: rows.reduce((acc, r) => acc + ((r.refunded_cents as number | null) || 0), 0),
+    },
+  ];
+}
+
+async function rollupListings(supabase: Supa, day: string): Promise<DailyRow[]> {
+  const { start, end } = dayRange(day);
+  const { data } = await supabase
+    .from("investment_listings")
+    .select("auto_classified_verdict, status")
+    .gte("created_at", start)
+    .lte("created_at", end);
+  const rows = data || [];
+  return [
+    {
+      feature: "listing_scam",
+      day,
+      auto_acted: rows.filter((r) => r.auto_classified_verdict === "auto_approve" || r.auto_classified_verdict === "auto_reject").length,
+      escalated: rows.filter((r) => r.auto_classified_verdict === "escalate").length,
+      rejected: rows.filter((r) => r.auto_classified_verdict === "auto_reject").length,
+      approved: rows.filter((r) => r.auto_classified_verdict === "auto_approve").length,
+      refunded_cents: 0,
+    },
+  ];
+}
+
+async function rollupTextModeration(supabase: Supa, day: string): Promise<DailyRow[]> {
+  const { start, end } = dayRange(day);
+  const [broker, advisor] = await Promise.all([
+    supabase
+      .from("user_reviews")
+      .select("auto_moderated_verdict, status")
+      .gte("created_at", start)
+      .lte("created_at", end),
+    supabase
+      .from("professional_reviews")
+      .select("auto_moderated_verdict, status")
+      .gte("created_at", start)
+      .lte("created_at", end),
+  ]);
+  const rows = [...(broker.data || []), ...(advisor.data || [])];
+  return [
+    {
+      feature: "text_moderation",
+      day,
+      auto_acted: rows.filter((r) => r.auto_moderated_verdict === "auto_publish" || r.auto_moderated_verdict === "auto_reject").length,
+      escalated: rows.filter((r) => r.auto_moderated_verdict === "escalate").length,
+      rejected: rows.filter((r) => r.auto_moderated_verdict === "auto_reject").length,
+      approved: rows.filter((r) => r.auto_moderated_verdict === "auto_publish").length,
+      refunded_cents: 0,
+    },
+  ];
+}
+
+async function rollupApplications(supabase: Supa, day: string): Promise<DailyRow[]> {
+  const { start, end } = dayRange(day);
+  const { data } = await supabase
+    .from("advisor_applications")
+    .select("status, reviewed_by")
+    .gte("created_at", start)
+    .lte("created_at", end);
+  const rows = data || [];
+  const auto = rows.filter((r) => r.reviewed_by === "auto");
+  return [
+    {
+      feature: "advisor_applications",
+      day,
+      auto_acted: auto.length,
+      escalated: rows.filter((r) => r.status === "pending").length,
+      rejected: rows.filter((r) => r.status === "rejected").length,
+      approved: rows.filter((r) => r.status === "approved").length,
+      refunded_cents: 0,
+    },
+  ];
+}
+
+async function rollupBrokerChanges(supabase: Supa, day: string): Promise<DailyRow[]> {
+  const { start, end } = dayRange(day);
+  const { data } = await supabase
+    .from("broker_data_changes")
+    .select("auto_applied_tier, auto_applied_at")
+    .gte("created_at", start)
+    .lte("created_at", end);
+  const rows = data || [];
+  const applied = rows.filter((r) => r.auto_applied_at !== null);
+  return [
+    {
+      feature: "broker_data_changes",
+      day,
+      auto_acted: applied.filter((r) => r.auto_applied_tier !== "require_admin").length,
+      escalated: rows.filter((r) => r.auto_applied_tier === "require_admin" || r.auto_applied_tier === null).length,
+      rejected: 0,
+      approved: applied.length,
+      refunded_cents: 0,
+    },
+  ];
+}
+
+async function rollupCampaigns(supabase: Supa, day: string): Promise<DailyRow[]> {
+  const { start, end } = dayRange(day);
+  const { data } = await supabase
+    .from("campaigns")
+    .select("status")
+    .gte("created_at", start)
+    .lte("created_at", end);
+  const rows = data || [];
+  return [
+    {
+      feature: "marketplace_campaigns",
+      day,
+      auto_acted: rows.filter((r) => r.status === "active" || r.status === "rejected").length,
+      escalated: rows.filter((r) => r.status === "pending").length,
+      rejected: rows.filter((r) => r.status === "rejected").length,
+      approved: rows.filter((r) => r.status === "active").length,
+      refunded_cents: 0,
+    },
+  ];
+}
+
+export const GET = wrapCronHandler("automation-verdict-rollup", handler);

--- a/app/api/cron/property-suburb-refresh/route.ts
+++ b/app/api/cron/property-suburb-refresh/route.ts
@@ -1,0 +1,92 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+import { requireCronAuth } from "@/lib/cron-auth";
+import { wrapCronHandler } from "@/lib/cron-run-log";
+import { refreshSuburb } from "@/lib/property-suburb-refresh";
+import { isFeatureDisabled } from "@/lib/admin/classifier-config";
+
+const log = logger("cron:property-suburb-refresh");
+
+export const runtime = "nodejs";
+export const maxDuration = 300;
+
+/**
+ * Quarterly cron (runs 1st of every month early-morning AEST).
+ *
+ * Refreshes a batch of the oldest stale suburb records from
+ * whichever paid provider is configured. Because the CoreLogic /
+ * SQM contracts meter per-call, the cron intentionally only
+ * processes a small batch per run — the next run picks up the
+ * next-oldest batch, and the whole dataset cycles through every
+ * few weeks.
+ *
+ * When no provider is configured this cron does zero external
+ * calls and still logs a success row so the automation dashboard
+ * doesn't alert. The admin dashboard shows the "stub" provider
+ * in the per-suburb log, making the no-op state unambiguous.
+ */
+async function handler(req: NextRequest) {
+  const unauth = requireCronAuth(req);
+  if (unauth) return unauth;
+
+  // Kill switch short-circuit — lets an operator pause this cron
+  // instantly without a deploy if something is wrong upstream.
+  if (await isFeatureDisabled("property_suburb_refresh")) {
+    return NextResponse.json({ ok: true, skipped: "kill_switch_on" });
+  }
+
+  const supabase = createAdminClient();
+
+  // Pull oldest 25 by updated_at. If updated_at is null (first run)
+  // the coalesce makes sure those come first.
+  const { data: suburbs, error } = await supabase
+    .from("suburb_data")
+    .select("slug, state, updated_at")
+    .order("updated_at", { ascending: true, nullsFirst: true })
+    .limit(25);
+
+  if (error) {
+    log.error("Failed to fetch suburb batch", { error: error.message });
+    return NextResponse.json({ ok: false, error: "fetch_failed" }, { status: 500 });
+  }
+
+  const stats = {
+    scanned: suburbs?.length || 0,
+    updated: 0,
+    unchanged: 0,
+    failed: 0,
+    fields_changed_total: 0,
+  };
+
+  for (const row of suburbs || []) {
+    try {
+      const result = await refreshSuburb(row.slug as string, row.state as string);
+      if (result.error) {
+        stats.failed++;
+        continue;
+      }
+      const changedCount = Object.keys(result.fieldsChanged).length;
+      if (changedCount > 0) {
+        stats.updated++;
+        stats.fields_changed_total += changedCount;
+      } else {
+        stats.unchanged++;
+      }
+      // Pace at ~200ms between external calls to stay well under any
+      // per-second rate limit on CoreLogic/SQM.
+      await new Promise((r) => setTimeout(r, 200));
+    } catch (err) {
+      stats.failed++;
+      log.error("refreshSuburb threw", {
+        slug: row.slug,
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  log.info("property-suburb-refresh cron completed", stats);
+  return NextResponse.json({ ok: true, ...stats });
+}
+
+export const GET = wrapCronHandler("property-suburb-refresh", handler);

--- a/components/admin/automation/BulkActionToolbar.tsx
+++ b/components/admin/automation/BulkActionToolbar.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { useState, useCallback, useMemo } from "react";
+
+interface BulkActionOption {
+  value: string;
+  label: string;
+}
+
+interface Props {
+  feature: string;
+  subSurface?: string;
+  selectedIds: number[];
+  onClearSelection: () => void;
+  onDone: () => void;
+  /** Feature-specific target verdicts — dropdown options */
+  actions: BulkActionOption[];
+  /**
+   * CSV rows to export when the "Export CSV" button is clicked.
+   * Each row is a flat object; headers are inferred from the first row.
+   */
+  csvRows?: Array<Record<string, string | number | null>>;
+  csvFilename?: string;
+}
+
+/**
+ * Sticky bulk-action toolbar that appears when rows are selected
+ * on a drill-down page. Supports:
+ *
+ *   - Bulk approve / bulk reject with a confirmation prompt
+ *   - CSV export of the current page's rows (client-side download)
+ *
+ * The toolbar is intentionally dumb about the row rendering — the
+ * parent page keeps a Set<number> of selected ids and passes it in.
+ */
+export default function BulkActionToolbar({
+  feature,
+  subSurface,
+  selectedIds,
+  onClearSelection,
+  onDone,
+  actions,
+  csvRows,
+  csvFilename,
+}: Props) {
+  const [targetVerdict, setTargetVerdict] = useState(actions[0]?.value || "");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [flash, setFlash] = useState<string | null>(null);
+
+  const exportCsv = useCallback(() => {
+    if (!csvRows || csvRows.length === 0) return;
+    const headers = Object.keys(csvRows[0]);
+    const lines = [
+      headers.join(","),
+      ...csvRows.map((row) =>
+        headers
+          .map((h) => {
+            const v = row[h];
+            if (v == null) return "";
+            const s = String(v);
+            // Quote if contains comma, quote, or newline
+            if (/[,"\n]/.test(s)) return `"${s.replace(/"/g, '""')}"`;
+            return s;
+          })
+          .join(","),
+      ),
+    ];
+    const blob = new Blob([lines.join("\n")], { type: "text/csv;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = csvFilename || `${feature}-export.csv`;
+    link.click();
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
+  }, [csvRows, csvFilename, feature]);
+
+  const runBulk = useCallback(async () => {
+    setError(null);
+    setFlash(null);
+    if (selectedIds.length === 0) return;
+    const reason = window.prompt(
+      `Bulk ${targetVerdict} ${selectedIds.length} ${feature} rows. Reason (audit-logged):`,
+      "",
+    );
+    if (reason == null) return;
+    setBusy(true);
+    try {
+      const res = await fetch("/api/admin/automation/bulk", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          feature,
+          subSurface,
+          targetVerdict,
+          rowIds: selectedIds,
+          reason,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
+      setFlash(`${data.updated} rows updated${data.failed ? `, ${data.failed} failed` : ""}`);
+      onClearSelection();
+      onDone();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "bulk_failed");
+    } finally {
+      setBusy(false);
+    }
+  }, [feature, subSurface, targetVerdict, selectedIds, onClearSelection, onDone]);
+
+  const hasSelection = selectedIds.length > 0;
+
+  const selectionLabel = useMemo(
+    () => (hasSelection ? `${selectedIds.length} selected` : "None selected"),
+    [hasSelection, selectedIds.length],
+  );
+
+  return (
+    <div className="sticky top-2 z-20 bg-white border border-slate-200 rounded-xl shadow-sm p-3 mb-4 flex items-center gap-3 flex-wrap">
+      <div className="text-xs font-semibold text-slate-700">{selectionLabel}</div>
+
+      <div className="flex items-center gap-2">
+        <select
+          value={targetVerdict}
+          onChange={(e) => setTargetVerdict(e.target.value)}
+          className="px-2 py-1 border border-slate-300 rounded text-xs bg-white font-mono focus:outline-none focus:ring-2 focus:ring-amber-400"
+        >
+          {actions.map((a) => (
+            <option key={a.value} value={a.value}>
+              {a.label}
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          onClick={runBulk}
+          disabled={!hasSelection || busy}
+          className="px-3 py-1 text-xs font-semibold rounded bg-slate-900 text-white hover:bg-slate-800 disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          {busy ? "…" : "Apply"}
+        </button>
+        {hasSelection && (
+          <button
+            type="button"
+            onClick={onClearSelection}
+            className="px-2 py-1 text-[0.65rem] rounded text-slate-600 hover:bg-slate-100"
+          >
+            clear
+          </button>
+        )}
+      </div>
+
+      {csvRows && csvRows.length > 0 && (
+        <button
+          type="button"
+          onClick={exportCsv}
+          className="ml-auto px-3 py-1 text-xs font-semibold rounded bg-white border border-slate-300 text-slate-700 hover:bg-slate-50"
+        >
+          ↓ Export CSV ({csvRows.length})
+        </button>
+      )}
+
+      {error && <span className="text-[0.65rem] text-red-700">{error}</span>}
+      {flash && <span className="text-[0.65rem] text-emerald-700">{flash}</span>}
+    </div>
+  );
+}

--- a/components/admin/automation/VerdictChart.tsx
+++ b/components/admin/automation/VerdictChart.tsx
@@ -1,0 +1,161 @@
+/**
+ * Tiny server-rendered SVG chart for daily verdict counts.
+ *
+ * Renders an auto-acted vs escalated vs rejected stacked area
+ * chart for a single feature. No client JS — we don't need
+ * interactivity for a small static dashboard chart, and avoiding
+ * a chart lib keeps the bundle lean.
+ *
+ * Input is an array of rows from automation_verdict_daily. Rows
+ * are expected to be ordered by day ascending; the chart pads
+ * missing days with zeros internally.
+ */
+
+export interface VerdictDailyRow {
+  day: string; // ISO date
+  auto_acted: number;
+  escalated: number;
+  rejected: number;
+  approved: number;
+}
+
+interface Props {
+  rows: VerdictDailyRow[];
+  width?: number;
+  height?: number;
+  daysBack?: number;
+}
+
+const SERIES: Array<{
+  key: keyof Omit<VerdictDailyRow, "day">;
+  label: string;
+  color: string;
+}> = [
+  { key: "auto_acted", label: "Auto-acted", color: "#10b981" },
+  { key: "escalated", label: "Escalated", color: "#f59e0b" },
+  { key: "rejected", label: "Rejected", color: "#ef4444" },
+];
+
+export default function VerdictChart({
+  rows,
+  width = 640,
+  height = 180,
+  daysBack = 30,
+}: Props) {
+  // Build a dense array of the last N days so gaps show as zero.
+  const today = new Date();
+  const dense: VerdictDailyRow[] = [];
+  const rowByDay = new Map(rows.map((r) => [r.day, r]));
+  for (let i = daysBack - 1; i >= 0; i--) {
+    const d = new Date(today);
+    d.setUTCHours(0, 0, 0, 0);
+    d.setUTCDate(d.getUTCDate() - i);
+    const key = d.toISOString().slice(0, 10);
+    dense.push(
+      rowByDay.get(key) || {
+        day: key,
+        auto_acted: 0,
+        escalated: 0,
+        rejected: 0,
+        approved: 0,
+      },
+    );
+  }
+
+  const padL = 36;
+  const padR = 8;
+  const padT = 12;
+  const padB = 24;
+  const innerW = width - padL - padR;
+  const innerH = height - padT - padB;
+
+  const max = Math.max(
+    1,
+    ...dense.map((d) => d.auto_acted + d.escalated + d.rejected),
+  );
+
+  // Build stacked area paths
+  const xOf = (i: number) =>
+    dense.length > 1 ? padL + (i * innerW) / (dense.length - 1) : padL + innerW / 2;
+  const yOf = (v: number) => padT + innerH - (v / max) * innerH;
+
+  // For stacked series we accumulate bottom offsets per point.
+  const bottoms = dense.map(() => 0);
+  const seriesPaths: Array<{ color: string; label: string; d: string }> = [];
+
+  for (const s of SERIES) {
+    const topPoints: string[] = [];
+    const bottomPoints: string[] = [];
+    dense.forEach((row, i) => {
+      const bottom = bottoms[i];
+      const top = bottom + (row[s.key] as number);
+      topPoints.push(`${xOf(i)},${yOf(top)}`);
+      bottomPoints.push(`${xOf(i)},${yOf(bottom)}`);
+      bottoms[i] = top;
+    });
+    const d = `M ${topPoints.join(" L ")} L ${bottomPoints.reverse().join(" L ")} Z`;
+    seriesPaths.push({ color: s.color, label: s.label, d });
+  }
+
+  // Y axis ticks (0, max/2, max)
+  const ticks = [0, Math.round(max / 2), max];
+
+  return (
+    <figure className="bg-white border border-slate-200 rounded-xl overflow-hidden">
+      <figcaption className="px-4 py-3 border-b border-slate-100 bg-slate-50 flex items-center justify-between">
+        <h3 className="text-sm font-bold text-slate-900">Verdicts, last {daysBack} days</h3>
+        <div className="flex gap-3 text-[0.65rem]">
+          {SERIES.map((s) => (
+            <span key={s.key} className="inline-flex items-center gap-1">
+              <span
+                aria-hidden="true"
+                className="inline-block w-2.5 h-2.5 rounded-full"
+                style={{ background: s.color }}
+              />
+              <span className="text-slate-600">{s.label}</span>
+            </span>
+          ))}
+        </div>
+      </figcaption>
+      <div className="p-3">
+        <svg viewBox={`0 0 ${width} ${height}`} role="img" aria-label="Verdicts chart">
+          {/* grid */}
+          {ticks.map((t) => (
+            <g key={t}>
+              <line
+                x1={padL}
+                x2={width - padR}
+                y1={yOf(t)}
+                y2={yOf(t)}
+                stroke="#e2e8f0"
+                strokeDasharray="2 2"
+              />
+              <text
+                x={padL - 4}
+                y={yOf(t) + 3}
+                textAnchor="end"
+                fontSize="9"
+                fill="#64748b"
+              >
+                {t}
+              </text>
+            </g>
+          ))}
+
+          {/* stacked areas */}
+          {seriesPaths.map((s, i) => (
+            <path key={i} d={s.d} fill={s.color} fillOpacity={0.6} stroke={s.color} strokeWidth="1" />
+          ))}
+
+          {/* x-axis labels at the ends */}
+          <text x={padL} y={height - 6} fontSize="9" fill="#64748b">
+            {dense[0]?.day.slice(5)}
+          </text>
+          <text x={width - padR} y={height - 6} fontSize="9" fill="#64748b" textAnchor="end">
+            {dense[dense.length - 1]?.day.slice(5)}
+          </text>
+        </svg>
+      </div>
+    </figure>
+  );
+}

--- a/lib/admin/classifier-config.ts
+++ b/lib/admin/classifier-config.ts
@@ -1,0 +1,150 @@
+/**
+ * Classifier threshold config — read-side helpers.
+ *
+ * Every classifier that wants live-editable thresholds calls
+ * `getClassifierConfig("classifier_name")` at request time. The helper
+ * returns a { thresholdName → value } map pulled from the
+ * `classifier_config` table.
+ *
+ * If the table doesn't exist, is empty for that classifier, or the
+ * query fails for any reason, the helper returns an EMPTY map and the
+ * caller is expected to fall back to its hardcoded defaults. This
+ * guarantees a safe rollout: a misconfigured row NEVER causes a
+ * classifier to behave erratically, it just leaves the defaults in
+ * place until someone fixes the config.
+ *
+ * Results are cached in-process for 60 seconds so the classifier
+ * doesn't hit Supabase on every request. 60 seconds is short enough
+ * that a config change propagates quickly, long enough that a hot
+ * classifier doesn't hammer the DB.
+ */
+
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+
+const log = logger("classifier-config");
+
+// Module-level cache. Map<classifier, {cachedAt, values}>
+const cache = new Map<string, { cachedAt: number; values: Record<string, number> }>();
+const CACHE_TTL_MS = 60 * 1000;
+
+export async function getClassifierConfig(
+  classifier: string,
+): Promise<Record<string, number>> {
+  const now = Date.now();
+  const cached = cache.get(classifier);
+  if (cached && now - cached.cachedAt < CACHE_TTL_MS) {
+    return cached.values;
+  }
+
+  try {
+    const supabase = createAdminClient();
+    const { data, error } = await supabase
+      .from("classifier_config")
+      .select("threshold_name, value")
+      .eq("classifier", classifier);
+
+    if (error) {
+      log.warn("classifier_config fetch failed — falling back to defaults", {
+        classifier,
+        error: error.message,
+      });
+      cache.set(classifier, { cachedAt: now, values: {} });
+      return {};
+    }
+
+    const values: Record<string, number> = {};
+    for (const row of data || []) {
+      values[row.threshold_name] = Number(row.value);
+    }
+    cache.set(classifier, { cachedAt: now, values });
+    return values;
+  } catch (err) {
+    log.warn("classifier_config threw — falling back to defaults", {
+      classifier,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return {};
+  }
+}
+
+/**
+ * Read a single threshold with a hardcoded default.
+ *
+ *     const minSignals = await getThreshold("text_moderation", "min_spam_signals", 2);
+ *
+ * If the value in the DB is outside [min_value, max_value] bounds
+ * (checked at write time), the value was never written in the first
+ * place — there's no runtime guardrail here, just the write path.
+ */
+export async function getThreshold(
+  classifier: string,
+  thresholdName: string,
+  defaultValue: number,
+): Promise<number> {
+  const config = await getClassifierConfig(classifier);
+  const value = config[thresholdName];
+  return typeof value === "number" && !Number.isNaN(value) ? value : defaultValue;
+}
+
+/**
+ * Invalidate the cache for a classifier. Called by the admin
+ * /api/admin/automation/config POST handler after a write so the
+ * next classifier call picks up the new value immediately instead
+ * of waiting up to 60 seconds.
+ */
+export function invalidateClassifierConfigCache(classifier?: string): void {
+  if (classifier) {
+    cache.delete(classifier);
+  } else {
+    cache.clear();
+  }
+}
+
+// ─── Kill switches ─────────────────────────────────────────────────
+
+const killSwitchCache = new Map<string, { cachedAt: number; disabled: boolean }>();
+
+/**
+ * Check whether a classifier / cron feature is currently disabled.
+ * Every classifier entry point should call this and short-circuit
+ * if true so a kill switch actually takes effect immediately.
+ *
+ * Returns true if either the global kill switch OR the per-feature
+ * switch is on. Cached 30 seconds.
+ */
+export async function isFeatureDisabled(feature: string): Promise<boolean> {
+  const now = Date.now();
+
+  const cachedFeature = killSwitchCache.get(feature);
+  if (cachedFeature && now - cachedFeature.cachedAt < 30_000 && cachedFeature.disabled) {
+    return true;
+  }
+  const cachedGlobal = killSwitchCache.get("global");
+  if (cachedGlobal && now - cachedGlobal.cachedAt < 30_000 && cachedGlobal.disabled) {
+    return true;
+  }
+
+  try {
+    const supabase = createAdminClient();
+    const { data, error } = await supabase
+      .from("automation_kill_switches")
+      .select("feature, disabled")
+      .in("feature", [feature, "global"]);
+
+    if (error) return false; // fail-open: a DB error should not disable automation
+
+    let featureDisabled = false;
+    for (const row of data || []) {
+      killSwitchCache.set(row.feature, { cachedAt: now, disabled: row.disabled });
+      if (row.disabled) featureDisabled = true;
+    }
+    return featureDisabled;
+  } catch {
+    return false;
+  }
+}
+
+export function invalidateKillSwitchCache(): void {
+  killSwitchCache.clear();
+}

--- a/lib/article-quality-scoring.ts
+++ b/lib/article-quality-scoring.ts
@@ -1,0 +1,353 @@
+/**
+ * Article quality scoring — pluggable LLM adapter.
+ *
+ * Used by the advisor article pipeline to add a second, quality-
+ * oriented scoring pass on top of the existing deterministic
+ * text-moderation classifier. The deterministic classifier catches
+ * spam / policy violations; this one looks at rubric dimensions
+ * like clarity, accuracy, compliance, SEO health — things that
+ * require a language model to judge.
+ *
+ * Providers:
+ *
+ *   - claude   via ANTHROPIC_API_KEY
+ *   - openai   via OPENAI_API_KEY
+ *   - stub     no-op when neither is set — returns a permissive
+ *              verdict ("escalate") so nothing is auto-rejected
+ *              purely because the scoring budget isn't configured
+ *
+ * Verdicts:
+ *
+ *   - auto_approve   score ≥ approve_threshold + no hard fails
+ *   - auto_reject    score < reject_threshold OR hard fails present
+ *   - escalate       anything in between (queued for admin review)
+ *
+ * Every score is persisted to `article_quality_scores` regardless
+ * of verdict so we have a history per article that admins can
+ * inspect from the drill-down page.
+ */
+
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+import { getThreshold } from "@/lib/admin/classifier-config";
+
+const log = logger("article-quality-scoring");
+
+export type QualityProvider = "claude" | "openai" | "stub";
+export type QualityVerdict = "auto_approve" | "escalate" | "auto_reject";
+
+export interface QualityRubric {
+  clarity: number; // 0-100
+  accuracy: number;
+  completeness: number;
+  compliance: number;
+  seo: number;
+}
+
+export interface ArticleQualityScore {
+  provider: QualityProvider;
+  model: string | null;
+  score: number; // 0-100 aggregate
+  rubric: QualityRubric;
+  verdict: QualityVerdict;
+  feedback: string;
+}
+
+export interface ScoreArticleInput {
+  articleId: number | null;
+  articleSlug: string | null;
+  title: string;
+  content: string; // markdown or plain text
+}
+
+/**
+ * Score an article and persist the result. Thresholds:
+ *
+ *   - approve_threshold: aggregate ≥ this → auto_approve (default 80)
+ *   - reject_threshold:  aggregate < this → auto_reject  (default 40)
+ *   - compliance_floor:  compliance < this → force escalate (default 60)
+ *
+ * All three are live-editable from classifier_config under
+ * classifier='article_quality'.
+ *
+ * Never throws — a provider failure is logged and returns
+ * verdict='escalate' so humans can still review the article.
+ */
+export async function scoreArticle(
+  input: ScoreArticleInput,
+): Promise<ArticleQualityScore> {
+  const provider = selectProvider();
+  const [approveThreshold, rejectThreshold, complianceFloor] = await Promise.all([
+    getThreshold("article_quality", "approve_threshold", 80),
+    getThreshold("article_quality", "reject_threshold", 40),
+    getThreshold("article_quality", "compliance_floor", 60),
+  ]);
+
+  let result: ArticleQualityScore;
+  let useThresholds = true;
+  try {
+    if (provider === "claude") {
+      result = await runClaude(input);
+    } else if (provider === "openai") {
+      result = await runOpenAi(input);
+    } else {
+      // Stub: never run through the threshold policy — there's no
+      // real signal, forcing 'escalate' is the only safe outcome.
+      result = buildStubResult();
+      useThresholds = false;
+    }
+  } catch (err) {
+    log.warn("article quality provider threw — escalating", {
+      provider,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    result = {
+      provider,
+      model: null,
+      score: 0,
+      rubric: { clarity: 0, accuracy: 0, completeness: 0, compliance: 0, seo: 0 },
+      verdict: "escalate",
+      feedback: `provider_error: ${err instanceof Error ? err.message : String(err)}`,
+    };
+    // Provider errors must never auto-reject — the score is 0
+    // because the call failed, not because the article is bad.
+    useThresholds = false;
+  }
+
+  // Apply thresholds for real provider runs. Stub + provider-error
+  // paths keep 'escalate' so a broken upstream never silently turns
+  // into mass auto-rejections.
+  if (useThresholds) {
+    result.verdict = resolveVerdict(
+      result.score,
+      result.rubric.compliance,
+      approveThreshold,
+      rejectThreshold,
+      complianceFloor,
+    );
+  }
+
+  // Fire-and-forget audit log — don't block the caller.
+  persistScore(input, result).catch((err) =>
+    log.warn("article_quality_scores insert failed", {
+      err: err instanceof Error ? err.message : String(err),
+    }),
+  );
+
+  return result;
+}
+
+/**
+ * Pure verdict resolver — exported so tests can cover the policy
+ * decisions without having to stub a provider.
+ */
+export function resolveVerdict(
+  score: number,
+  compliance: number,
+  approveThreshold: number,
+  rejectThreshold: number,
+  complianceFloor: number,
+): QualityVerdict {
+  if (score < rejectThreshold) return "auto_reject";
+  if (compliance < complianceFloor) return "escalate";
+  if (score >= approveThreshold) return "auto_approve";
+  return "escalate";
+}
+
+function selectProvider(): QualityProvider {
+  if (process.env.ANTHROPIC_API_KEY) return "claude";
+  if (process.env.OPENAI_API_KEY) return "openai";
+  return "stub";
+}
+
+function buildStubResult(): ArticleQualityScore {
+  return {
+    provider: "stub",
+    model: null,
+    score: 0,
+    rubric: { clarity: 0, accuracy: 0, completeness: 0, compliance: 0, seo: 0 },
+    verdict: "escalate",
+    feedback: "No LLM provider configured — article escalated for human review.",
+  };
+}
+
+// ─── Shared prompt ────────────────────────────────────────────────
+
+const RUBRIC_INSTRUCTIONS = `You are scoring a financial article for an Australian investment
+comparison website. Score each dimension 0-100 and return STRICT JSON:
+
+{
+  "rubric": {
+    "clarity":       0-100,  // is the writing clear and well-structured?
+    "accuracy":      0-100,  // are facts and figures plausible?
+    "completeness":  0-100,  // does it cover the topic fully?
+    "compliance":    0-100,  // does it avoid personal advice, unsubstantiated
+                             // performance claims, and stay within general
+                             // information? (Australian FSG / corporations act)
+    "seo":           0-100   // headings, length, keyword use
+  },
+  "score": 0-100,            // weighted aggregate
+  "feedback": "1-3 sentences on what to fix"
+}
+
+Return ONLY the JSON. Do not wrap it in markdown. Do not add commentary.
+If the content is too short to judge, return rubric all zeros.`;
+
+// ─── Claude adapter ───────────────────────────────────────────────
+
+async function runClaude(input: ScoreArticleInput): Promise<ArticleQualityScore> {
+  const apiKey = process.env.ANTHROPIC_API_KEY!;
+  const model = process.env.ANTHROPIC_MODEL || "claude-haiku-4-5-20251001";
+
+  const res = await fetch("https://api.anthropic.com/v1/messages", {
+    method: "POST",
+    headers: {
+      "x-api-key": apiKey,
+      "anthropic-version": "2023-06-01",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      model,
+      max_tokens: 600,
+      messages: [
+        {
+          role: "user",
+          content: `${RUBRIC_INSTRUCTIONS}\n\n── ARTICLE ──\nTitle: ${input.title}\n\n${input.content.slice(0, 20000)}`,
+        },
+      ],
+    }),
+    signal: AbortSignal.timeout(30_000),
+  });
+
+  if (!res.ok) {
+    throw new Error(`claude HTTP ${res.status}`);
+  }
+  const body = (await res.json()) as {
+    content?: Array<{ type: string; text?: string }>;
+  };
+  const text = body.content?.find((c) => c.type === "text")?.text || "";
+  const parsed = parseRubricJson(text);
+
+  return {
+    provider: "claude",
+    model,
+    score: parsed.score,
+    rubric: parsed.rubric,
+    verdict: "escalate", // overridden by resolveVerdict
+    feedback: parsed.feedback,
+  };
+}
+
+// ─── OpenAI adapter ───────────────────────────────────────────────
+
+async function runOpenAi(input: ScoreArticleInput): Promise<ArticleQualityScore> {
+  const apiKey = process.env.OPENAI_API_KEY!;
+  const model = process.env.OPENAI_MODEL || "gpt-4o-mini";
+
+  const res = await fetch("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model,
+      response_format: { type: "json_object" },
+      messages: [
+        { role: "system", content: RUBRIC_INSTRUCTIONS },
+        {
+          role: "user",
+          content: `Title: ${input.title}\n\n${input.content.slice(0, 20000)}`,
+        },
+      ],
+    }),
+    signal: AbortSignal.timeout(30_000),
+  });
+
+  if (!res.ok) {
+    throw new Error(`openai HTTP ${res.status}`);
+  }
+  const body = (await res.json()) as {
+    choices?: Array<{ message?: { content?: string } }>;
+  };
+  const text = body.choices?.[0]?.message?.content || "";
+  const parsed = parseRubricJson(text);
+
+  return {
+    provider: "openai",
+    model,
+    score: parsed.score,
+    rubric: parsed.rubric,
+    verdict: "escalate",
+    feedback: parsed.feedback,
+  };
+}
+
+/**
+ * Parse the rubric JSON out of a model response. Handles both strict
+ * JSON replies and responses that accidentally include a markdown
+ * code fence. Never throws — returns a zero rubric on parse failure
+ * and lets the threshold logic take over.
+ */
+export function parseRubricJson(raw: string): {
+  rubric: QualityRubric;
+  score: number;
+  feedback: string;
+} {
+  const cleaned = raw.trim().replace(/^```(?:json)?\s*/i, "").replace(/```\s*$/i, "");
+  try {
+    const obj = JSON.parse(cleaned) as {
+      rubric?: Partial<QualityRubric>;
+      score?: number;
+      feedback?: string;
+    };
+    const rubric: QualityRubric = {
+      clarity: clamp(obj.rubric?.clarity),
+      accuracy: clamp(obj.rubric?.accuracy),
+      completeness: clamp(obj.rubric?.completeness),
+      compliance: clamp(obj.rubric?.compliance),
+      seo: clamp(obj.rubric?.seo),
+    };
+    const score = typeof obj.score === "number" ? clamp(obj.score) : avgRubric(rubric);
+    return {
+      rubric,
+      score,
+      feedback: (obj.feedback || "").slice(0, 500),
+    };
+  } catch {
+    return {
+      rubric: { clarity: 0, accuracy: 0, completeness: 0, compliance: 0, seo: 0 },
+      score: 0,
+      feedback: "parse_error",
+    };
+  }
+}
+
+function clamp(v: unknown): number {
+  const n = Number(v);
+  if (!Number.isFinite(n)) return 0;
+  return Math.max(0, Math.min(100, Math.round(n)));
+}
+
+function avgRubric(r: QualityRubric): number {
+  return Math.round((r.clarity + r.accuracy + r.completeness + r.compliance + r.seo) / 5);
+}
+
+// ─── Persistence ──────────────────────────────────────────────────
+
+async function persistScore(
+  input: ScoreArticleInput,
+  result: ArticleQualityScore,
+): Promise<void> {
+  const supabase = createAdminClient();
+  await supabase.from("article_quality_scores").insert({
+    article_id: input.articleId,
+    article_slug: input.articleSlug,
+    provider: result.provider,
+    model: result.model,
+    score: result.score,
+    rubric: result.rubric,
+    verdict: result.verdict,
+    feedback: result.feedback,
+  });
+}

--- a/lib/photo-moderation.ts
+++ b/lib/photo-moderation.ts
@@ -1,0 +1,235 @@
+/**
+ * Photo moderation — pluggable provider pattern.
+ *
+ * Covers advisor profile photos, listing images, broker logos — any
+ * user-uploaded image that goes on a public page. The check happens
+ * at upload time and the result is persisted to photo_moderation_log
+ * so the admin dashboard can see a history of checks even after the
+ * image is deleted.
+ *
+ * Providers:
+ *
+ *   - cloudflare   via Cloudflare Images API (explicit content check)
+ *                  activated by CLOUDFLARE_IMAGES_TOKEN +
+ *                  CLOUDFLARE_ACCOUNT_ID env vars
+ *
+ *   - rekognition  via AWS Rekognition DetectModerationLabels
+ *                  activated by AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY
+ *                  + AWS_REGION env vars
+ *
+ *   - stub         no-op — returns {verdict: 'unknown', provider: 'stub'}
+ *                  used when neither provider is configured so every
+ *                  upload still flows through the moderation path
+ *                  (and logs a row in photo_moderation_log) but never
+ *                  rejects on false positives. Admin reviews still
+ *                  happen as they do today.
+ *
+ * The caller always gets back a ModerationResult — the provider
+ * selection + failure handling is internal. This means integrating
+ * moderation into an upload path is a one-liner that's safe even
+ * when no provider is configured.
+ */
+
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+
+const log = logger("photo-moderation");
+
+export type PhotoVerdict = "clean" | "flagged" | "rejected" | "unknown";
+
+export interface PhotoModerationResult {
+  verdict: PhotoVerdict;
+  confidence: number; // 0-1
+  labels: Record<string, number>; // label → confidence
+  provider: "cloudflare" | "rekognition" | "stub";
+}
+
+export type PhotoTargetType = "advisor_photo" | "listing_image" | "broker_logo";
+
+/**
+ * Run photo moderation against whatever provider is configured.
+ *
+ *   photoUrl   — publicly accessible URL (the provider will fetch it)
+ *   targetType — used in the audit log only
+ *   targetId   — optional row id, logged for traceability
+ *
+ * Logs every check to photo_moderation_log regardless of verdict.
+ * Never throws — a provider failure is logged and returns verdict
+ * 'unknown' so the caller can decide whether to block the upload.
+ */
+export async function moderatePhoto(
+  photoUrl: string,
+  targetType: PhotoTargetType,
+  targetId: number | null = null,
+): Promise<PhotoModerationResult> {
+  const provider = selectProvider();
+
+  let result: PhotoModerationResult;
+  try {
+    if (provider === "cloudflare") {
+      result = await runCloudflare(photoUrl);
+    } else if (provider === "rekognition") {
+      result = await runRekognition(photoUrl);
+    } else {
+      result = {
+        verdict: "unknown",
+        confidence: 0,
+        labels: {},
+        provider: "stub",
+      };
+    }
+  } catch (err) {
+    log.warn("photo moderation provider threw — logging as unknown", {
+      provider,
+      photoUrl,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    result = {
+      verdict: "unknown",
+      confidence: 0,
+      labels: { error: 1 },
+      provider,
+    };
+  }
+
+  // Fire-and-forget audit log — don't block on the write
+  logModerationCheck(photoUrl, targetType, targetId, result).catch((err) =>
+    log.warn("photo_moderation_log insert failed", {
+      err: err instanceof Error ? err.message : String(err),
+    }),
+  );
+
+  return result;
+}
+
+function selectProvider(): "cloudflare" | "rekognition" | "stub" {
+  if (process.env.CLOUDFLARE_IMAGES_TOKEN && process.env.CLOUDFLARE_ACCOUNT_ID) {
+    return "cloudflare";
+  }
+  if (
+    process.env.AWS_ACCESS_KEY_ID &&
+    process.env.AWS_SECRET_ACCESS_KEY &&
+    process.env.AWS_REGION
+  ) {
+    return "rekognition";
+  }
+  return "stub";
+}
+
+// ─── Cloudflare Images adapter ───────────────────────────────────
+/**
+ * Cloudflare Images doesn't have a standalone "detect explicit content"
+ * endpoint, but it does expose a `requireSignedURLs` + variant pipeline.
+ * For v1 we use its adjacent "hash on upload + detect similar hashes
+ * in a known-bad allowlist" capability which you access via their
+ * Workers AI moderation model.
+ *
+ * This is the stub implementation expected to call Workers AI's
+ * image classifier. Operators running on Cloudflare will have a
+ * dedicated worker endpoint that wraps the model — set
+ * CLOUDFLARE_IMAGES_TOKEN to that worker's URL (not the account token).
+ */
+async function runCloudflare(photoUrl: string): Promise<PhotoModerationResult> {
+  const endpoint = process.env.CLOUDFLARE_IMAGES_TOKEN!;
+  const res = await fetch(endpoint, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ image_url: photoUrl }),
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!res.ok) {
+    throw new Error(`cloudflare HTTP ${res.status}`);
+  }
+  const body = (await res.json()) as {
+    labels?: Record<string, number>;
+    explicit?: boolean;
+    suggestive?: boolean;
+    confidence?: number;
+  };
+
+  const labels = body.labels || {};
+  const maxScore = Object.values(labels).reduce((max, v) => Math.max(max, v), 0);
+
+  let verdict: PhotoVerdict = "clean";
+  if (body.explicit || maxScore > 0.85) verdict = "rejected";
+  else if (body.suggestive || maxScore > 0.5) verdict = "flagged";
+
+  return {
+    verdict,
+    confidence: body.confidence ?? maxScore,
+    labels,
+    provider: "cloudflare",
+  };
+}
+
+// ─── AWS Rekognition adapter ─────────────────────────────────────
+/**
+ * DetectModerationLabels returns a list of moderation labels with
+ * confidence scores. We don't depend on the aws-sdk package to keep
+ * the bundle lean — just hit the HTTP endpoint with a SigV4 signed
+ * POST.
+ *
+ * For v1 this is implemented as a call to a minimal signing helper.
+ * If you want the full SDK integration, swap out this function's body.
+ */
+async function runRekognition(photoUrl: string): Promise<PhotoModerationResult> {
+  // V1: we expect operators running Rekognition to have deployed a
+  // thin proxy endpoint that handles SigV4 signing server-side and
+  // accepts { image_url } POST requests. Set AWS_REGION to that
+  // proxy's deployed region; the actual URL lives in
+  // REKOGNITION_PROXY_URL.
+  const endpoint = process.env.REKOGNITION_PROXY_URL;
+  if (!endpoint) {
+    throw new Error("REKOGNITION_PROXY_URL not set");
+  }
+
+  const res = await fetch(endpoint, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ image_url: photoUrl }),
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!res.ok) {
+    throw new Error(`rekognition HTTP ${res.status}`);
+  }
+  const body = (await res.json()) as {
+    ModerationLabels?: Array<{ Name: string; Confidence: number }>;
+  };
+
+  const labels: Record<string, number> = {};
+  let maxConfidence = 0;
+  for (const l of body.ModerationLabels || []) {
+    labels[l.Name] = l.Confidence / 100;
+    if (l.Confidence / 100 > maxConfidence) maxConfidence = l.Confidence / 100;
+  }
+
+  let verdict: PhotoVerdict = "clean";
+  if (maxConfidence > 0.85) verdict = "rejected";
+  else if (maxConfidence > 0.5) verdict = "flagged";
+
+  return {
+    verdict,
+    confidence: maxConfidence,
+    labels,
+    provider: "rekognition",
+  };
+}
+
+// ─── Audit logging ───────────────────────────────────────────────
+async function logModerationCheck(
+  photoUrl: string,
+  targetType: PhotoTargetType,
+  targetId: number | null,
+  result: PhotoModerationResult,
+): Promise<void> {
+  const supabase = createAdminClient();
+  await supabase.from("photo_moderation_log").insert({
+    photo_url: photoUrl,
+    target_type: targetType,
+    target_id: targetId,
+    provider: result.provider,
+    verdict: result.verdict,
+    confidence: result.confidence,
+    labels: result.labels,
+  });
+}

--- a/lib/property-suburb-refresh.ts
+++ b/lib/property-suburb-refresh.ts
@@ -1,0 +1,249 @@
+/**
+ * Property suburb auto-refresh — pluggable provider pattern.
+ *
+ * Suburb investment stats (median prices, yields, vacancy, capital
+ * growth) go stale. Without a provider we'd be serving the same
+ * numbers for years. This library ingests fresh stats from whichever
+ * paid data source is configured and writes a diff + audit row to
+ * `property_suburb_refresh_log` so admins can see what changed.
+ *
+ * Providers:
+ *
+ *   - corelogic  via CORELOGIC_API_KEY
+ *   - sqm        via SQM_RESEARCH_API_KEY
+ *   - stub       no-op when neither is configured — logs an entry
+ *                with empty fields_changed so the cron still runs
+ *                and the dashboard shows it as healthy
+ *
+ * Operational design:
+ *
+ *   - Upsert-style: pulls the latest numbers for each suburb and
+ *     writes changed fields back to `suburb_data`.
+ *   - Diff is computed in-memory and stored as
+ *     {field: [old, new]} JSON so admins can eyeball what changed.
+ *   - Fields never dropped — if the provider returns null we keep
+ *     the existing value (data loss is worse than staleness here).
+ *   - Rate limiting: the cron batches 25 suburbs per run with a
+ *     200ms pacer between calls. A fresh CoreLogic call is ~300ms.
+ */
+
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+
+const log = logger("property-suburb-refresh");
+
+export type SuburbProvider = "corelogic" | "sqm" | "stub";
+
+export interface SuburbRefreshData {
+  median_house_price: number | null;
+  median_unit_price: number | null;
+  rental_yield: number | null;
+  vacancy_rate: number | null;
+  capital_growth_10yr: number | null;
+  sales_volume_12mo: number | null;
+  median_rent_weekly: number | null;
+}
+
+export interface SuburbRefreshResult {
+  suburbSlug: string;
+  provider: SuburbProvider;
+  fieldsChanged: Record<string, [unknown, unknown]>;
+  error?: string;
+}
+
+/**
+ * Fetch the latest stats for a single suburb and merge them into
+ * `suburb_data`. Returns a diff object so the caller can log what
+ * changed.
+ *
+ * Safe to call on a suburb with no provider configured — in that
+ * case the function logs an empty refresh row and returns with
+ * fieldsChanged: {}.
+ */
+export async function refreshSuburb(
+  suburbSlug: string,
+  state: string,
+): Promise<SuburbRefreshResult> {
+  const provider = selectProvider();
+
+  let freshData: SuburbRefreshData | null = null;
+  let error: string | undefined;
+
+  try {
+    if (provider === "corelogic") {
+      freshData = await fetchFromCoreLogic(suburbSlug, state);
+    } else if (provider === "sqm") {
+      freshData = await fetchFromSqm(suburbSlug, state);
+    }
+  } catch (err) {
+    error = err instanceof Error ? err.message : String(err);
+    log.warn("suburb refresh provider threw", { suburbSlug, provider, error });
+  }
+
+  // No provider / fetch failed — log an empty refresh row and return.
+  if (!freshData) {
+    await logRefresh(suburbSlug, provider, {}, error);
+    return { suburbSlug, provider, fieldsChanged: {}, error };
+  }
+
+  // Load current row so we can compute diff.
+  const supabase = createAdminClient();
+  const { data: current, error: selectErr } = await supabase
+    .from("suburb_data")
+    .select(
+      "median_house_price, median_unit_price, rental_yield, vacancy_rate, capital_growth_10yr, sales_volume_12mo, median_rent_weekly",
+    )
+    .eq("slug", suburbSlug)
+    .maybeSingle();
+
+  if (selectErr || !current) {
+    const msg = selectErr?.message || "suburb row not found";
+    await logRefresh(suburbSlug, provider, {}, msg);
+    return { suburbSlug, provider, fieldsChanged: {}, error: msg };
+  }
+
+  // Diff + merge. Never overwrite with null (data loss avoidance).
+  const fieldsChanged: Record<string, [unknown, unknown]> = {};
+  const updates: Partial<SuburbRefreshData> = {};
+  for (const key of Object.keys(freshData) as (keyof SuburbRefreshData)[]) {
+    const newVal = freshData[key];
+    const oldVal = (current as Record<string, unknown>)[key];
+    if (newVal == null) continue;
+    if (newVal !== oldVal) {
+      fieldsChanged[key] = [oldVal, newVal];
+      (updates as Record<string, unknown>)[key] = newVal;
+    }
+  }
+
+  if (Object.keys(updates).length > 0) {
+    const { error: updErr } = await supabase
+      .from("suburb_data")
+      .update({ ...updates, updated_at: new Date().toISOString() })
+      .eq("slug", suburbSlug);
+    if (updErr) {
+      const msg = updErr.message;
+      await logRefresh(suburbSlug, provider, {}, msg);
+      return { suburbSlug, provider, fieldsChanged: {}, error: msg };
+    }
+  }
+
+  await logRefresh(suburbSlug, provider, fieldsChanged);
+  return { suburbSlug, provider, fieldsChanged };
+}
+
+function selectProvider(): SuburbProvider {
+  if (process.env.CORELOGIC_API_KEY) return "corelogic";
+  if (process.env.SQM_RESEARCH_API_KEY) return "sqm";
+  return "stub";
+}
+
+// ─── CoreLogic adapter ────────────────────────────────────────────
+/**
+ * CoreLogic's API is behind a partner agreement so there's no public
+ * JSON schema to link here. Operators with a contract get an endpoint
+ * URL + bearer token. For v1 we call a generic endpoint and expect a
+ * normalised JSON shape — operators bring their own proxy if the
+ * endpoint shape differs.
+ */
+async function fetchFromCoreLogic(
+  suburbSlug: string,
+  state: string,
+): Promise<SuburbRefreshData | null> {
+  const url =
+    process.env.CORELOGIC_API_URL ||
+    "https://api.corelogic.com.au/v1/suburbs/stats";
+  const token = process.env.CORELOGIC_API_KEY!;
+
+  const res = await fetch(
+    `${url}?slug=${encodeURIComponent(suburbSlug)}&state=${encodeURIComponent(state)}`,
+    {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(15_000),
+    },
+  );
+  if (!res.ok) throw new Error(`corelogic HTTP ${res.status}`);
+  const body = (await res.json()) as {
+    median_house?: number;
+    median_unit?: number;
+    rental_yield?: number;
+    vacancy_rate?: number;
+    capital_growth_10yr?: number;
+    sales_volume_12mo?: number;
+    median_rent_weekly?: number;
+  };
+
+  return {
+    median_house_price: normNumber(body.median_house),
+    median_unit_price: normNumber(body.median_unit),
+    rental_yield: normNumber(body.rental_yield),
+    vacancy_rate: normNumber(body.vacancy_rate),
+    capital_growth_10yr: normNumber(body.capital_growth_10yr),
+    sales_volume_12mo: normNumber(body.sales_volume_12mo),
+    median_rent_weekly: normNumber(body.median_rent_weekly),
+  };
+}
+
+// ─── SQM Research adapter ─────────────────────────────────────────
+async function fetchFromSqm(
+  suburbSlug: string,
+  state: string,
+): Promise<SuburbRefreshData | null> {
+  const url =
+    process.env.SQM_RESEARCH_API_URL ||
+    "https://sqmresearch.com.au/api/v1/suburb";
+  const token = process.env.SQM_RESEARCH_API_KEY!;
+
+  const res = await fetch(
+    `${url}?postcode_slug=${encodeURIComponent(suburbSlug)}&state=${encodeURIComponent(state)}`,
+    {
+      headers: { "X-API-Key": token },
+      signal: AbortSignal.timeout(15_000),
+    },
+  );
+  if (!res.ok) throw new Error(`sqm HTTP ${res.status}`);
+  const body = (await res.json()) as {
+    weekly_rent?: number;
+    yield?: number;
+    vacancy?: number;
+    median_house?: number;
+    median_unit?: number;
+    growth_10yr?: number;
+    volume?: number;
+  };
+
+  return {
+    median_house_price: normNumber(body.median_house),
+    median_unit_price: normNumber(body.median_unit),
+    rental_yield: normNumber(body.yield),
+    vacancy_rate: normNumber(body.vacancy),
+    capital_growth_10yr: normNumber(body.growth_10yr),
+    sales_volume_12mo: normNumber(body.volume),
+    median_rent_weekly: normNumber(body.weekly_rent),
+  };
+}
+
+function normNumber(v: unknown): number | null {
+  if (v == null) return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+async function logRefresh(
+  suburbSlug: string,
+  provider: SuburbProvider,
+  fieldsChanged: Record<string, [unknown, unknown]>,
+  error?: string,
+): Promise<void> {
+  try {
+    const supabase = createAdminClient();
+    await supabase.from("property_suburb_refresh_log").insert({
+      suburb_slug: suburbSlug,
+      provider,
+      fields_changed: error ? { ...fieldsChanged, __error: error } : fieldsChanged,
+    });
+  } catch (err) {
+    log.warn("property_suburb_refresh_log insert failed", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+  }
+}

--- a/supabase/migrations/20260413_automation_wave_2.sql
+++ b/supabase/migrations/20260413_automation_wave_2.sql
@@ -1,0 +1,163 @@
+-- Automation wave 2 schema.
+--
+-- Covers:
+--   1. classifier_config       — live-editable thresholds per classifier
+--   2. automation_kill_switches — system-wide / per-feature disable flag
+--   3. photo_moderation_log    — audit trail for every photo check
+--   4. article_quality_scores  — LLM scoring history per article
+--   5. property_suburb_refresh_log — audit + diff trail for the refresh cron
+--   6. admin_action_log        — unified audit for every admin override
+--   7. automation_verdict_daily — time-series aggregate table (hourly cron
+--                                  rollup so the dashboard chart doesn't
+--                                  scan raw tables on every page load)
+
+-- ── 1. classifier_config ──────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.classifier_config (
+  id              serial PRIMARY KEY,
+  classifier      text NOT NULL,
+  threshold_name  text NOT NULL,
+  value           numeric NOT NULL,
+  min_value       numeric,   -- guardrail: writes outside [min, max] are rejected
+  max_value       numeric,
+  description     text,
+  updated_by      text,
+  updated_at      timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (classifier, threshold_name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_classifier_config_classifier
+  ON public.classifier_config (classifier);
+
+ALTER TABLE public.classifier_config ENABLE ROW LEVEL SECURITY;
+
+COMMENT ON TABLE public.classifier_config IS
+  'Live-editable classifier thresholds. Each classifier reads from this table at request time and falls back to hardcoded defaults if no row is present.';
+
+-- ── 2. automation_kill_switches ───────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.automation_kill_switches (
+  feature      text PRIMARY KEY,   -- 'global' | feature key from FEATURE_CONFIG
+  disabled     boolean NOT NULL DEFAULT false,
+  reason       text,
+  disabled_by  text,
+  disabled_at  timestamptz
+);
+
+ALTER TABLE public.automation_kill_switches ENABLE ROW LEVEL SECURITY;
+
+COMMENT ON TABLE public.automation_kill_switches IS
+  'Kill switches for automation features. feature=global disables every classifier at once. Per-feature rows disable a single classifier. Checked by every classifier entry point.';
+
+-- ── 3. photo_moderation_log ───────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.photo_moderation_log (
+  id             bigserial PRIMARY KEY,
+  photo_url      text NOT NULL,
+  target_type    text NOT NULL,  -- 'advisor_photo' | 'listing_image' | 'broker_logo'
+  target_id      integer,
+  provider       text NOT NULL,  -- 'cloudflare' | 'rekognition' | 'stub'
+  verdict        text NOT NULL,  -- 'clean' | 'flagged' | 'rejected' | 'unknown'
+  confidence     numeric,
+  labels         jsonb,          -- provider-specific raw labels
+  checked_at     timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_photo_moderation_log_target
+  ON public.photo_moderation_log (target_type, target_id);
+
+CREATE INDEX IF NOT EXISTS idx_photo_moderation_log_recent
+  ON public.photo_moderation_log (checked_at DESC);
+
+ALTER TABLE public.photo_moderation_log ENABLE ROW LEVEL SECURITY;
+
+-- ── 4. article_quality_scores ─────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.article_quality_scores (
+  id             bigserial PRIMARY KEY,
+  article_id     integer,
+  article_slug   text,
+  provider       text NOT NULL,  -- 'claude' | 'openai' | 'stub'
+  model          text,
+  score          integer NOT NULL,  -- 0-100 aggregate
+  rubric         jsonb NOT NULL,    -- {clarity, accuracy, completeness, compliance, seo}
+  verdict        text NOT NULL,     -- 'auto_approve' | 'escalate' | 'auto_reject'
+  feedback       text,
+  checked_at     timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_article_quality_scores_article
+  ON public.article_quality_scores (article_id, checked_at DESC);
+
+ALTER TABLE public.article_quality_scores ENABLE ROW LEVEL SECURITY;
+
+-- ── 5. property_suburb_refresh_log ───────────────────────────────
+CREATE TABLE IF NOT EXISTS public.property_suburb_refresh_log (
+  id             bigserial PRIMARY KEY,
+  suburb_slug    text NOT NULL,
+  provider       text NOT NULL,  -- 'corelogic' | 'sqm' | 'stub'
+  fields_changed jsonb,           -- { median_price: [old, new], ... }
+  refreshed_at   timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_property_suburb_refresh_log_suburb
+  ON public.property_suburb_refresh_log (suburb_slug, refreshed_at DESC);
+
+ALTER TABLE public.property_suburb_refresh_log ENABLE ROW LEVEL SECURITY;
+
+-- ── 6. admin_action_log ───────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.admin_action_log (
+  id              bigserial PRIMARY KEY,
+  admin_email     text NOT NULL,
+  feature         text NOT NULL,   -- key from FEATURE_CONFIG
+  action          text NOT NULL,   -- 'override' | 'trigger' | 'config' | 'bulk' | 'kill_switch'
+  target_row_id   integer,
+  target_verdict  text,
+  reason          text,
+  context         jsonb,           -- freeform for bulk actions etc.
+  created_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_admin_action_log_admin
+  ON public.admin_action_log (admin_email, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_admin_action_log_feature
+  ON public.admin_action_log (feature, created_at DESC);
+
+ALTER TABLE public.admin_action_log ENABLE ROW LEVEL SECURITY;
+
+-- ── 7. automation_verdict_daily ──────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.automation_verdict_daily (
+  id             serial PRIMARY KEY,
+  feature        text NOT NULL,
+  day            date NOT NULL,
+  auto_acted     integer NOT NULL DEFAULT 0,
+  escalated      integer NOT NULL DEFAULT 0,
+  rejected       integer NOT NULL DEFAULT 0,
+  approved       integer NOT NULL DEFAULT 0,
+  refunded_cents bigint  NOT NULL DEFAULT 0,
+  UNIQUE (feature, day)
+);
+
+CREATE INDEX IF NOT EXISTS idx_automation_verdict_daily_feature_day
+  ON public.automation_verdict_daily (feature, day DESC);
+
+ALTER TABLE public.automation_verdict_daily ENABLE ROW LEVEL SECURITY;
+
+-- ── Constraints ──────────────────────────────────────────────────
+ALTER TABLE public.photo_moderation_log
+  DROP CONSTRAINT IF EXISTS photo_moderation_log_verdict_check;
+ALTER TABLE public.photo_moderation_log
+  ADD CONSTRAINT photo_moderation_log_verdict_check CHECK (
+    verdict = ANY (ARRAY['clean'::text, 'flagged'::text, 'rejected'::text, 'unknown'::text])
+  );
+
+ALTER TABLE public.article_quality_scores
+  DROP CONSTRAINT IF EXISTS article_quality_scores_verdict_check;
+ALTER TABLE public.article_quality_scores
+  ADD CONSTRAINT article_quality_scores_verdict_check CHECK (
+    verdict = ANY (ARRAY['auto_approve'::text, 'escalate'::text, 'auto_reject'::text])
+  );
+
+ALTER TABLE public.admin_action_log
+  DROP CONSTRAINT IF EXISTS admin_action_log_action_check;
+ALTER TABLE public.admin_action_log
+  ADD CONSTRAINT admin_action_log_action_check CHECK (
+    action = ANY (ARRAY['override'::text, 'trigger'::text, 'config'::text, 'bulk'::text, 'kill_switch'::text])
+  );

--- a/vercel.json
+++ b/vercel.json
@@ -151,6 +151,14 @@
     {
       "path": "/api/cron/verify-review-clients",
       "schedule": "0 4 * * *"
+    },
+    {
+      "path": "/api/cron/property-suburb-refresh",
+      "schedule": "0 3 1 * *"
+    },
+    {
+      "path": "/api/cron/automation-verdict-rollup",
+      "schedule": "15 * * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Wave 2 of the admin automation stack. Everything the wave 1 PR (#125) deferred, shipped with pluggable-provider-plus-safe-stub pattern so none of this breaks when the paid credentials aren't configured.

### Adapters
- **Photo moderation** (`lib/photo-moderation.ts`) — Cloudflare Workers AI / AWS Rekognition proxy / stub
- **Property suburb refresh** (`lib/property-suburb-refresh.ts`) — CoreLogic / SQM Research / stub, with quarterly `property-suburb-refresh` cron (batches oldest 25 per run, 200ms pacer, never overwrites with null)
- **LLM article quality scoring** (`lib/article-quality-scoring.ts`) — Claude / OpenAI / stub, rubric = clarity/accuracy/completeness/compliance/seo, thresholds live-editable from `classifier_config`, error paths and stub always escalate (never auto-reject)

### Admin dashboard extensions
- `/admin/automation/config` — classifier threshold editor with min/max guardrails
- `/admin/automation/kill-switch` — global + per-feature disable toggles
- `/admin/automation/audit-log` — unified feed over `admin_action_log` (override/trigger/config/bulk/kill_switch)
- `/admin/automation/dry-run` — paste JSON, preview classifier verdict, no side effects
- Listings drill-down now has multi-select bulk approve/reject, CSV export, and a 30-day stacked verdict chart

### API routes
- `POST /api/admin/automation/bulk` — bulk override (max 500 rows, money-mover features excluded, every action audited)
- `GET/POST /api/admin/automation/config` — classifier threshold CRUD with cache invalidation
- `GET/POST /api/admin/automation/kill-switch` — toggle features on/off
- `POST /api/admin/automation/dry-run` — classifier preview
- `/api/cron/property-suburb-refresh` — monthly
- `/api/cron/automation-verdict-rollup` — hourly, populates `automation_verdict_daily` for charts

### Integration
- `auto-resolve-disputes` cron short-circuits on kill switch
- `classifier_config` 60s TTL cache + invalidate-on-write
- Every config / kill-switch / bulk write logs to `admin_action_log`
- `isFeatureDisabled()` helper ready for every other classifier to drop in

### Schema (`supabase/migrations/20260413_automation_wave_2.sql` — already applied live)
- `classifier_config` — live thresholds + bounds
- `automation_kill_switches` — global + per-feature
- `photo_moderation_log` — every check audited
- `article_quality_scores` — scoring history per article
- `property_suburb_refresh_log` — field-level diff trail
- `admin_action_log` — unified audit
- `automation_verdict_daily` — time-series rollup

## Test plan

- [x] 49 new unit tests (photo-moderation, property-suburb-refresh, article-quality-scoring, classifier-config)
- [x] 905 / 905 total tests passing
- [x] `tsc --noEmit` clean
- [x] `npm run build` → Compiled successfully
- [ ] Smoke-test `/admin/automation/config` threshold write path in staging
- [ ] Smoke-test `/admin/automation/kill-switch` global toggle in staging
- [ ] Verify bulk action on listings drill-down against real rows
- [ ] Dry-run tester: try each of the 4 classifiers
- [ ] Manually trigger `/api/cron/automation-verdict-rollup` and confirm rows land in `automation_verdict_daily`

https://claude.ai/code/session_01DyudU3Uo5eFGwXKQsYcbUw