### PR TITLE
feat: wave 7 — trust + ops maturity

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,61 @@
+# Dependabot config — weekly scheduled PRs for dependency upgrades.
+#
+# Scope:
+#   - Production npm deps (grouped by minor/patch so we don't
+#     drown in PR noise)
+#   - Security-only updates fire immediately regardless of day
+#   - GitHub Actions pinned versions
+#
+# Assignment: all PRs are labelled and land on @finn so one person
+# owns the weekly green-ness of the dependency tree.
+
+version: 2
+updates:
+  # ── npm ──
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Australia/Sydney
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - automated
+    groups:
+      prod-patch:
+        dependency-type: production
+        update-types:
+          - patch
+      prod-minor:
+        dependency-type: production
+        update-types:
+          - minor
+      dev-patch-minor:
+        dependency-type: development
+        update-types:
+          - patch
+          - minor
+    # Security advisories bypass the weekly schedule and open
+    # immediately. There is no way to "group" these — one PR per
+    # advisory is the safe default.
+    ignore:
+      # Next.js major versions need a manual migration pass
+      - dependency-name: next
+        update-types: ["version-update:semver-major"]
+      - dependency-name: react
+        update-types: ["version-update:semver-major"]
+      - dependency-name: react-dom
+        update-types: ["version-update:semver-major"]
+
+  # ── GitHub Actions ──
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 3
+    labels:
+      - dependencies
+      - github-actions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,33 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  dependency-scan:
+    name: Dependency vulnerabilities
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+      - name: npm audit (high + critical only)
+        run: |
+          # Fails the job if there are any HIGH or CRITICAL
+          # vulnerabilities. Moderate + low are surfaced for
+          # review but do not block the merge.
+          npm audit --audit-level=high --production
+
+      - name: Dependency review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+          # allow-licenses: keeps the copyleft-safety check in
+          # one place so the review fails if someone adds a GPL
+          # dep to what's otherwise MIT/Apache/BSD.
+          allow-licenses: MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, CC0-1.0, CC-BY-4.0, 0BSD, Unlicense, BlueOak-1.0.0
+
   e2e:
     name: End-to-end (Playwright)
     runs-on: ubuntu-latest

--- a/__tests__/lib/api-schemas.test.ts
+++ b/__tests__/lib/api-schemas.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from "vitest";
+import {
+  FormEventRequest,
+  AttributionTouchRequest,
+  SearchResponse,
+  PrivacyRequestInput,
+  BulkActionRequest,
+  BulkActionResponse,
+  assertContract,
+} from "@/lib/api-schemas";
+
+describe("FormEventRequest", () => {
+  it("accepts a valid event", () => {
+    const r = FormEventRequest.safeParse({
+      session_id: "s123",
+      form_name: "quiz",
+      step: "q1",
+      event: "view",
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("rejects an unknown form_name", () => {
+    const r = FormEventRequest.safeParse({
+      session_id: "s123",
+      form_name: "other",
+      step: "q1",
+      event: "view",
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects an unknown event", () => {
+    const r = FormEventRequest.safeParse({
+      session_id: "s123",
+      form_name: "quiz",
+      step: "q1",
+      event: "ghost",
+    });
+    expect(r.success).toBe(false);
+  });
+});
+
+describe("AttributionTouchRequest", () => {
+  it("accepts a view event", () => {
+    const r = AttributionTouchRequest.safeParse({
+      session_id: "s1",
+      event: "view",
+      page_path: "/compare",
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("rejects missing session_id", () => {
+    const r = AttributionTouchRequest.safeParse({ event: "view" });
+    expect(r.success).toBe(false);
+  });
+});
+
+describe("SearchResponse", () => {
+  it("accepts an empty result set", () => {
+    const r = SearchResponse.safeParse({ hits: [] });
+    expect(r.success).toBe(true);
+  });
+
+  it("requires type/id/title/excerpt/score on each hit", () => {
+    const r = SearchResponse.safeParse({
+      hits: [
+        {
+          type: "article",
+          id: "how-to",
+          title: "How to",
+          excerpt: "An article",
+          score: 0.9,
+        },
+      ],
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("rejects a hit with score out of range", () => {
+    const r = SearchResponse.safeParse({
+      hits: [
+        { type: "article", id: "x", title: "x", excerpt: "x", score: 1.5 },
+      ],
+    });
+    expect(r.success).toBe(false);
+  });
+});
+
+describe("PrivacyRequestInput", () => {
+  it("accepts a well-formed request", () => {
+    const r = PrivacyRequestInput.safeParse({
+      email: "alex@example.com",
+      type: "export",
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("rejects an invalid email", () => {
+    const r = PrivacyRequestInput.safeParse({
+      email: "not-an-email",
+      type: "export",
+    });
+    expect(r.success).toBe(false);
+  });
+});
+
+describe("BulkActionRequest", () => {
+  it("caps rowIds at 500", () => {
+    const r = BulkActionRequest.safeParse({
+      feature: "listing_scam",
+      targetVerdict: "rejected",
+      rowIds: new Array(600).fill(0).map((_, i) => i + 1),
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("accepts a valid payload", () => {
+    const r = BulkActionRequest.safeParse({
+      feature: "listing_scam",
+      targetVerdict: "rejected",
+      rowIds: [1, 2, 3],
+    });
+    expect(r.success).toBe(true);
+  });
+});
+
+describe("BulkActionResponse", () => {
+  it("accepts a normal response", () => {
+    const r = BulkActionResponse.safeParse({
+      ok: true,
+      updated: 3,
+      failed: 0,
+      errors: [],
+    });
+    expect(r.success).toBe(true);
+  });
+});
+
+describe("assertContract", () => {
+  it("returns the parsed data on success", () => {
+    const body = { hits: [] };
+    const data = assertContract(SearchResponse, body);
+    expect(data.hits).toEqual([]);
+  });
+
+  it("throws with a helpful message on failure", () => {
+    expect(() =>
+      assertContract(SearchResponse, { hits: [{ type: "nope" }] }),
+    ).toThrow(/Contract mismatch/);
+  });
+});

--- a/__tests__/lib/feature-flags.test.ts
+++ b/__tests__/lib/feature-flags.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from "vitest";
+import { evaluateFlag, rolloutHash } from "@/lib/feature-flags";
+
+function row(overrides: Partial<Parameters<typeof evaluateFlag>[0] & object> = {}) {
+  return {
+    flag_key: "test",
+    enabled: true,
+    rollout_pct: 100,
+    allowlist: [] as string[],
+    denylist: [] as string[],
+    segments: [] as string[],
+    ...overrides,
+  };
+}
+
+describe("rolloutHash", () => {
+  it("is stable for the same input", () => {
+    expect(rolloutHash("flag", "user@example.com")).toBe(
+      rolloutHash("flag", "user@example.com"),
+    );
+  });
+
+  it("is in [0, 99]", () => {
+    const h = rolloutHash("flag", "user@example.com");
+    expect(h).toBeGreaterThanOrEqual(0);
+    expect(h).toBeLessThan(100);
+  });
+
+  it("differs per flag for the same user", () => {
+    const a = rolloutHash("flag-a", "user@example.com");
+    const b = rolloutHash("flag-b", "user@example.com");
+    // They MIGHT collide by chance, but with two different
+    // flag keys it's improbable. If this flakes, tighten.
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("evaluateFlag — simple on/off", () => {
+  it("returns false for null row", () => {
+    expect(evaluateFlag(null, {})).toBe(false);
+  });
+
+  it("returns false when enabled is false", () => {
+    expect(evaluateFlag(row({ enabled: false }), {})).toBe(false);
+  });
+
+  it("returns true when enabled + 100% rollout", () => {
+    expect(evaluateFlag(row(), {})).toBe(true);
+  });
+});
+
+describe("evaluateFlag — deny/allow lists", () => {
+  it("denylist wins over allowlist", () => {
+    expect(
+      evaluateFlag(
+        row({ denylist: ["u@x.com"], allowlist: ["u@x.com"] }),
+        { userKey: "u@x.com" },
+      ),
+    ).toBe(false);
+  });
+
+  it("allowlist overrides disabled flag", () => {
+    expect(
+      evaluateFlag(
+        row({ enabled: false, allowlist: ["u@x.com"] }),
+        { userKey: "u@x.com" },
+      ),
+    ).toBe(true);
+  });
+
+  it("allowlist overrides 0% rollout", () => {
+    expect(
+      evaluateFlag(
+        row({ rollout_pct: 0, allowlist: ["u@x.com"] }),
+        { userKey: "u@x.com" },
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("evaluateFlag — segment targeting", () => {
+  it("empty segments means everyone", () => {
+    expect(evaluateFlag(row(), { segment: "advisor" })).toBe(true);
+    expect(evaluateFlag(row(), { segment: "user" })).toBe(true);
+  });
+
+  it("denies when caller segment is not in list", () => {
+    expect(
+      evaluateFlag(row({ segments: ["admin"] }), { segment: "advisor" }),
+    ).toBe(false);
+  });
+
+  it("allows when caller segment matches", () => {
+    expect(
+      evaluateFlag(row({ segments: ["admin", "advisor"] }), { segment: "advisor" }),
+    ).toBe(true);
+  });
+
+  it("denies when segments is set and no caller segment given", () => {
+    expect(evaluateFlag(row({ segments: ["admin"] }), {})).toBe(false);
+  });
+});
+
+describe("evaluateFlag — percentage rollout", () => {
+  it("0% rollout → false", () => {
+    expect(
+      evaluateFlag(row({ rollout_pct: 0 }), { userKey: "u@x.com" }),
+    ).toBe(false);
+  });
+
+  it("100% rollout → true", () => {
+    expect(
+      evaluateFlag(row({ rollout_pct: 100 }), { userKey: "u@x.com" }),
+    ).toBe(true);
+  });
+
+  it("partial rollout is deterministic per user key", () => {
+    const r = row({ flag_key: "partial", rollout_pct: 50 });
+    const first = evaluateFlag(r, { userKey: "u@x.com" });
+    const second = evaluateFlag(r, { userKey: "u@x.com" });
+    expect(first).toBe(second);
+  });
+
+  it("partial rollout gives roughly the right proportion", () => {
+    // 100 deterministic keys, 30% rollout. Expect ~30 to be true.
+    let trueCount = 0;
+    for (let i = 0; i < 100; i++) {
+      if (
+        evaluateFlag(row({ flag_key: "spread", rollout_pct: 30 }), {
+          userKey: `user-${i}@x.com`,
+        })
+      )
+        trueCount++;
+    }
+    expect(trueCount).toBeGreaterThan(10);
+    expect(trueCount).toBeLessThan(60);
+  });
+});

--- a/__tests__/lib/slo.test.ts
+++ b/__tests__/lib/slo.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { evaluateSlo } from "@/lib/slo";
+
+function def(overrides: Partial<Parameters<typeof evaluateSlo>[0]> = {}) {
+  return {
+    name: "test",
+    service: "cron",
+    metric: "success_rate",
+    target: 0.99,
+    comparator: ">=" as const,
+    window_minutes: 60,
+    ...overrides,
+  };
+}
+
+describe("evaluateSlo — success_rate >= 0.99", () => {
+  it("within target → no breach", () => {
+    const r = evaluateSlo(def(), { value: 0.995 });
+    expect(r.breached).toBe(false);
+    expect(r.reason).toBe("within_target");
+  });
+
+  it("slightly below target → warn", () => {
+    const r = evaluateSlo(def(), { value: 0.96 });
+    expect(r.breached).toBe(true);
+    expect(r.severity).toBe("warn");
+  });
+
+  it("way below target → page", () => {
+    const r = evaluateSlo(def(), { value: 0.4 });
+    expect(r.breached).toBe(true);
+    expect(r.severity).toBe("page");
+  });
+});
+
+describe("evaluateSlo — other comparators", () => {
+  it("< target for queue age", () => {
+    const r = evaluateSlo(
+      def({ metric: "queue_age", target: 15, comparator: "<" }),
+      { value: 20 },
+    );
+    expect(r.breached).toBe(true);
+  });
+
+  it("<= passes when equal", () => {
+    const r = evaluateSlo(
+      def({ metric: "latency", target: 1000, comparator: "<=" }),
+      { value: 1000 },
+    );
+    expect(r.breached).toBe(false);
+  });
+
+  it("> passes when strictly greater", () => {
+    const r = evaluateSlo(
+      def({ metric: "ok_count", target: 5, comparator: ">" }),
+      { value: 6 },
+    );
+    expect(r.breached).toBe(false);
+  });
+
+  it("> fails when equal", () => {
+    const r = evaluateSlo(
+      def({ metric: "ok_count", target: 5, comparator: ">" }),
+      { value: 5 },
+    );
+    expect(r.breached).toBe(true);
+  });
+});
+
+describe("evaluateSlo — severity tier", () => {
+  it("page when gap >= 50%", () => {
+    const r = evaluateSlo(
+      def({ target: 100, comparator: ">=" }),
+      { value: 40 },
+    );
+    // (100 - 40) / 100 = 0.6 → page
+    expect(r.severity).toBe("page");
+  });
+
+  it("warn when gap < 50%", () => {
+    const r = evaluateSlo(
+      def({ target: 100, comparator: ">=" }),
+      { value: 70 },
+    );
+    // (100 - 70) / 100 = 0.3 → warn
+    expect(r.severity).toBe("warn");
+  });
+});

--- a/app/admin/automation/db-health/page.tsx
+++ b/app/admin/automation/db-health/page.tsx
@@ -1,0 +1,169 @@
+import Link from "next/link";
+import AdminShell from "@/components/AdminShell";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Database health dashboard.
+ *
+ * Three panels, all powered by pg_stat_statements + pg_stat_activity
+ * (wrapped in SQL views created by the wave 7 migration):
+ *
+ *   1. Slow queries — top 50 by mean execution time
+ *   2. Connection pool — current connection count per state
+ *   3. Retention rules — last run + rows affected
+ *
+ * Read-only. Every query is bounded to protect the dashboard from
+ * runaway rows.
+ */
+export default async function DbHealthPage() {
+  const admin = createAdminClient();
+
+  const [slowRes, poolRes, retentionRes] = await Promise.all([
+    admin
+      .from("slow_query_snapshot")
+      .select("*")
+      .order("mean_exec_time", { ascending: false })
+      .limit(50),
+    admin.from("connection_pool_snapshot").select("*"),
+    admin.from("retention_rules").select("*").order("table_name"),
+  ]);
+
+  const slow = slowRes.data || [];
+  const pool = poolRes.data || [];
+  const retention = retentionRes.data || [];
+
+  return (
+    <AdminShell title="Database health" subtitle="Slow queries, connection pool, retention">
+      <div className="p-4 md:p-6 max-w-6xl">
+        <nav className="text-xs text-slate-500 mb-3">
+          <Link href="/admin/automation" className="hover:text-slate-900">
+            ← Automation dashboard
+          </Link>
+        </nav>
+
+        {/* ── Connection pool ── */}
+        <section className="bg-white border border-slate-200 rounded-xl overflow-hidden mb-5">
+          <header className="px-4 py-3 border-b border-slate-100 bg-slate-50">
+            <h2 className="text-sm font-bold text-slate-900">Connection pool</h2>
+            <p className="text-[0.65rem] text-slate-500">Alert at 85% of Supabase pool cap</p>
+          </header>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-3 p-4">
+            {pool.length === 0 && (
+              <div className="col-span-full text-xs text-slate-500 text-center py-4">
+                No connection data — is pg_stat_activity available?
+              </div>
+            )}
+            {pool.map((row) => (
+              <div key={(row.state as string) || "null"} className="border border-slate-200 rounded p-3">
+                <div className="text-[0.6rem] uppercase tracking-wider text-slate-500">
+                  {(row.state as string) || "unknown"}
+                </div>
+                <div className="text-xl font-bold text-slate-900 mt-1">
+                  {(row.connection_count as number) || 0}
+                </div>
+                <div className="text-[0.65rem] text-slate-500">
+                  max age: {Math.round((row.max_age_seconds as number) || 0)}s
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* ── Slow queries ── */}
+        <section className="bg-white border border-slate-200 rounded-xl overflow-hidden mb-5">
+          <header className="px-4 py-3 border-b border-slate-100 bg-slate-50">
+            <h2 className="text-sm font-bold text-slate-900">Slow queries</h2>
+            <p className="text-[0.65rem] text-slate-500">Top 50 by mean execution time (ms)</p>
+          </header>
+          <div className="overflow-x-auto">
+            <table className="w-full text-xs">
+              <thead className="bg-slate-50 border-b border-slate-100">
+                <tr>
+                  <th className="px-3 py-2 text-left font-semibold text-slate-600">Query</th>
+                  <th className="px-3 py-2 text-right font-semibold text-slate-600">Calls</th>
+                  <th className="px-3 py-2 text-right font-semibold text-slate-600">Mean ms</th>
+                  <th className="px-3 py-2 text-right font-semibold text-slate-600">Max ms</th>
+                  <th className="px-3 py-2 text-right font-semibold text-slate-600">Rows</th>
+                </tr>
+              </thead>
+              <tbody>
+                {slow.length === 0 && (
+                  <tr>
+                    <td colSpan={5} className="px-3 py-6 text-center text-slate-500">
+                      No slow queries. All mean exec times below 50ms.
+                    </td>
+                  </tr>
+                )}
+                {slow.map((q) => (
+                  <tr key={(q.queryid as string | number).toString()} className="border-b border-slate-100 last:border-0">
+                    <td className="px-3 py-2 font-mono text-[0.65rem] text-slate-700 max-w-[40ch] truncate" title={q.query_sample as string}>
+                      {q.query_sample as string}
+                    </td>
+                    <td className="px-3 py-2 text-right font-mono text-slate-700">
+                      {((q.calls as number) || 0).toLocaleString("en-AU")}
+                    </td>
+                    <td className="px-3 py-2 text-right font-mono text-slate-700">
+                      {Math.round((q.mean_exec_time as number) || 0)}
+                    </td>
+                    <td className="px-3 py-2 text-right font-mono text-slate-700">
+                      {Math.round((q.max_exec_time as number) || 0)}
+                    </td>
+                    <td className="px-3 py-2 text-right font-mono text-slate-700">
+                      {((q.rows as number) || 0).toLocaleString("en-AU")}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* ── Retention rules ── */}
+        <section className="bg-white border border-slate-200 rounded-xl overflow-hidden">
+          <header className="px-4 py-3 border-b border-slate-100 bg-slate-50">
+            <h2 className="text-sm font-bold text-slate-900">Retention rules</h2>
+            <p className="text-[0.65rem] text-slate-500">GDPR + Privacy Act data trimming policy</p>
+          </header>
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-[0.6rem] uppercase tracking-wider text-slate-500 border-b border-slate-100">
+                <th className="px-4 py-2 text-left font-semibold">Table</th>
+                <th className="px-4 py-2 text-left font-semibold">Strategy</th>
+                <th className="px-4 py-2 text-right font-semibold">Keep days</th>
+                <th className="px-4 py-2 text-left font-semibold">Last run</th>
+                <th className="px-4 py-2 text-right font-semibold">Last affected</th>
+              </tr>
+            </thead>
+            <tbody>
+              {retention.map((r) => (
+                <tr key={r.id as number} className="border-b border-slate-100 last:border-0">
+                  <td className="px-4 py-2 font-mono text-xs text-slate-700">{r.table_name as string}</td>
+                  <td className="px-4 py-2 text-xs">
+                    <span className={`px-2 py-0.5 rounded text-[0.6rem] font-semibold ${r.strategy === "delete" ? "bg-red-100 text-red-800" : "bg-amber-100 text-amber-800"}`}>
+                      {r.strategy as string}
+                    </span>
+                  </td>
+                  <td className="px-4 py-2 text-right font-mono text-xs text-slate-700">
+                    {(r.keep_days as number).toLocaleString("en-AU")}
+                  </td>
+                  <td className="px-4 py-2 text-[0.65rem] text-slate-500">
+                    {r.last_run_at
+                      ? new Date(r.last_run_at as string).toLocaleString("en-AU")
+                      : "never"}
+                  </td>
+                  <td className="px-4 py-2 text-right font-mono text-xs text-slate-700">
+                    {r.last_rows_affected != null
+                      ? (r.last_rows_affected as number).toLocaleString("en-AU")
+                      : "—"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </section>
+      </div>
+    </AdminShell>
+  );
+}

--- a/app/admin/automation/page.tsx
+++ b/app/admin/automation/page.tsx
@@ -43,6 +43,12 @@ export default async function AdminAutomationPage() {
           <Link href="/admin/automation/attribution" className="px-3 py-1.5 rounded-full bg-white border border-slate-200 hover:bg-slate-50 font-semibold text-slate-700">
             📊 Attribution
           </Link>
+          <Link href="/admin/automation/forms" className="px-3 py-1.5 rounded-full bg-white border border-slate-200 hover:bg-slate-50 font-semibold text-slate-700">
+            📝 Form funnels
+          </Link>
+          <Link href="/admin/automation/db-health" className="px-3 py-1.5 rounded-full bg-white border border-slate-200 hover:bg-slate-50 font-semibold text-slate-700">
+            🗄 DB health
+          </Link>
         </nav>
 
         {/* ── Top summary bar ── */}

--- a/app/api/admin/automation/flags/route.ts
+++ b/app/api/admin/automation/flags/route.ts
@@ -1,0 +1,135 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { requireAdmin } from "@/lib/require-admin";
+import { invalidateFlagCache } from "@/lib/feature-flags";
+import { logger } from "@/lib/logger";
+
+const log = logger("admin:automation:flags");
+
+/**
+ * Feature flag CRUD.
+ *
+ *   GET    — list every flag with its current state
+ *   POST   — create or upsert a flag
+ *   PATCH  — partial update by flag_key (enabled, rollout_pct,
+ *            allowlist, denylist, segments)
+ *
+ * Every mutation:
+ *   - stamps updated_by + updated_at on the row
+ *   - invalidates the in-process evaluator cache so the change
+ *     is visible within 30s across all workers
+ *   - logs an admin_action_log row for the audit trail
+ */
+
+export async function GET() {
+  const guard = await requireAdmin();
+  if (!guard.ok) return guard.response;
+
+  const admin = createAdminClient();
+  const { data, error } = await admin
+    .from("feature_flags")
+    .select("*")
+    .order("flag_key");
+  if (error) {
+    log.error("feature_flags fetch failed", { error: error.message });
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  return NextResponse.json({ rows: data || [] });
+}
+
+export async function POST(request: NextRequest) {
+  const guard = await requireAdmin();
+  if (!guard.ok) return guard.response;
+
+  const body = await request.json().catch(() => ({}));
+  const flagKey = typeof body.flag_key === "string" ? body.flag_key : null;
+  if (!flagKey) {
+    return NextResponse.json({ error: "Missing flag_key" }, { status: 400 });
+  }
+
+  const admin = createAdminClient();
+  const payload = {
+    flag_key: flagKey,
+    description: typeof body.description === "string" ? body.description : null,
+    enabled: typeof body.enabled === "boolean" ? body.enabled : false,
+    rollout_pct: clampPct(body.rollout_pct),
+    allowlist: Array.isArray(body.allowlist)
+      ? body.allowlist.filter((s: unknown): s is string => typeof s === "string")
+      : [],
+    denylist: Array.isArray(body.denylist)
+      ? body.denylist.filter((s: unknown): s is string => typeof s === "string")
+      : [],
+    segments: Array.isArray(body.segments)
+      ? body.segments.filter((s: unknown): s is string => typeof s === "string")
+      : [],
+    updated_by: guard.email,
+    updated_at: new Date().toISOString(),
+  };
+
+  const { error } = await admin
+    .from("feature_flags")
+    .upsert(payload, { onConflict: "flag_key" });
+  if (error) {
+    log.error("feature_flags upsert failed", { error: error.message });
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  invalidateFlagCache(flagKey);
+  await admin.from("admin_action_log").insert({
+    admin_email: guard.email,
+    feature: `flag:${flagKey}`,
+    action: "config",
+    reason: typeof body.reason === "string" ? body.reason : null,
+    context: payload as unknown as Record<string, unknown>,
+  });
+
+  return NextResponse.json({ ok: true });
+}
+
+export async function PATCH(request: NextRequest) {
+  const guard = await requireAdmin();
+  if (!guard.ok) return guard.response;
+
+  const body = await request.json().catch(() => ({}));
+  const flagKey = typeof body.flag_key === "string" ? body.flag_key : null;
+  if (!flagKey) {
+    return NextResponse.json({ error: "Missing flag_key" }, { status: 400 });
+  }
+
+  const patch: Record<string, unknown> = {
+    updated_by: guard.email,
+    updated_at: new Date().toISOString(),
+  };
+  if (typeof body.enabled === "boolean") patch.enabled = body.enabled;
+  if (body.rollout_pct != null) patch.rollout_pct = clampPct(body.rollout_pct);
+  if (Array.isArray(body.allowlist)) patch.allowlist = body.allowlist;
+  if (Array.isArray(body.denylist)) patch.denylist = body.denylist;
+  if (Array.isArray(body.segments)) patch.segments = body.segments;
+
+  const admin = createAdminClient();
+  const { error } = await admin
+    .from("feature_flags")
+    .update(patch)
+    .eq("flag_key", flagKey);
+  if (error) {
+    log.error("feature_flags patch failed", { error: error.message });
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  invalidateFlagCache(flagKey);
+  await admin.from("admin_action_log").insert({
+    admin_email: guard.email,
+    feature: `flag:${flagKey}`,
+    action: "config",
+    reason: typeof body.reason === "string" ? body.reason : null,
+    context: patch,
+  });
+
+  return NextResponse.json({ ok: true });
+}
+
+function clampPct(value: unknown): number {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return 0;
+  return Math.max(0, Math.min(100, Math.round(n)));
+}

--- a/app/api/admin/reports/afsl-monthly/route.ts
+++ b/app/api/admin/reports/afsl-monthly/route.ts
@@ -1,0 +1,201 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { requireAdmin } from "@/lib/require-admin";
+
+export const runtime = "nodejs";
+
+/**
+ * GET /api/admin/reports/afsl-monthly?month=YYYY-MM
+ *
+ * Generates a compliance-ready summary of financial + moderation
+ * activity for an AFSL audit. Default month is the previous month.
+ *
+ * The JSON body is what the monthly report needs — admins open it
+ * in the browser, paste to a template doc, sign, and file. We
+ * don't generate a PDF server-side because that pulls in headless
+ * Chromium, which is a lot of weight for a monthly export.
+ *
+ * Covers:
+ *   1. Financial audit — refunds, credit adjustments, disputes
+ *      resolved, total refunded cents, top 10 reason strings
+ *   2. AFSL verification — advisor applications verified vs.
+ *      escalated by the ASIC register lookup
+ *   3. Photo moderation — checks, rejections, flags
+ *   4. Text moderation — reviews auto-published / auto-rejected /
+ *      escalated
+ *   5. Kill switches — any flag that was flipped during the month
+ *   6. SLO incidents — severity breakdown + resolution count
+ *
+ * One-shot report: no DB writes, purely aggregation.
+ */
+export async function GET(request: NextRequest) {
+  const guard = await requireAdmin();
+  if (!guard.ok) return guard.response;
+
+  const admin = createAdminClient();
+  const monthParam = request.nextUrl.searchParams.get("month");
+  const { start, end, label } = resolveMonth(monthParam);
+
+  const startIso = start.toISOString();
+  const endIso = end.toISOString();
+
+  const [
+    financial,
+    advisorApps,
+    photoMod,
+    textModBroker,
+    textModAdvisor,
+    killSwitchLog,
+    sloIncidents,
+    disputeRows,
+  ] = await Promise.all([
+    admin
+      .from("financial_audit_log")
+      .select("action, amount_cents, reason")
+      .gte("created_at", startIso)
+      .lt("created_at", endIso),
+    admin
+      .from("advisor_applications")
+      .select("status, reviewed_by, verification_result")
+      .gte("created_at", startIso)
+      .lt("created_at", endIso),
+    admin
+      .from("photo_moderation_log")
+      .select("verdict")
+      .gte("checked_at", startIso)
+      .lt("checked_at", endIso),
+    admin
+      .from("user_reviews")
+      .select("auto_moderated_verdict")
+      .gte("created_at", startIso)
+      .lt("created_at", endIso),
+    admin
+      .from("professional_reviews")
+      .select("auto_moderated_verdict")
+      .gte("created_at", startIso)
+      .lt("created_at", endIso),
+    admin
+      .from("admin_action_log")
+      .select("feature, action, target_verdict, reason, admin_email, created_at")
+      .eq("action", "kill_switch")
+      .gte("created_at", startIso)
+      .lt("created_at", endIso),
+    admin
+      .from("slo_incidents")
+      .select("severity, slo_name, started_at, resolved_at")
+      .gte("started_at", startIso)
+      .lt("started_at", endIso),
+    admin
+      .from("lead_disputes")
+      .select("status, refunded_cents, auto_resolved_verdict")
+      .gte("created_at", startIso)
+      .lt("created_at", endIso),
+  ]);
+
+  const financialRows = financial.data || [];
+  const advisorAppsRows = advisorApps.data || [];
+  const photoRows = photoMod.data || [];
+  const textBrokerRows = textModBroker.data || [];
+  const textAdvisorRows = textModAdvisor.data || [];
+  const killRows = killSwitchLog.data || [];
+  const sloRows = sloIncidents.data || [];
+  const disputesRows = disputeRows.data || [];
+
+  const totalRefundedCents = financialRows
+    .filter((r) => r.action === "refund")
+    .reduce((s, r) => s + ((r.amount_cents as number | null) || 0), 0);
+
+  const report = {
+    report_type: "afsl_monthly",
+    month_label: label,
+    period: { start: startIso, end: endIso },
+    generated_at: new Date().toISOString(),
+    generated_by: guard.email,
+    financial_audit: {
+      total_rows: financialRows.length,
+      by_action: tallyField(financialRows, "action"),
+      total_refunded_cents: totalRefundedCents,
+      total_refunded_aud: (totalRefundedCents / 100).toFixed(2),
+    },
+    advisor_verification: {
+      total: advisorAppsRows.length,
+      by_status: tallyField(advisorAppsRows, "status"),
+      auto_reviewed: advisorAppsRows.filter((r) => r.reviewed_by === "auto").length,
+    },
+    photo_moderation: {
+      total_checks: photoRows.length,
+      by_verdict: tallyField(photoRows, "verdict"),
+    },
+    text_moderation: {
+      user_reviews: {
+        total: textBrokerRows.length,
+        by_verdict: tallyField(textBrokerRows, "auto_moderated_verdict"),
+      },
+      professional_reviews: {
+        total: textAdvisorRows.length,
+        by_verdict: tallyField(textAdvisorRows, "auto_moderated_verdict"),
+      },
+    },
+    lead_disputes: {
+      total: disputesRows.length,
+      by_status: tallyField(disputesRows, "status"),
+      by_auto_verdict: tallyField(disputesRows, "auto_resolved_verdict"),
+      total_refunded_cents: disputesRows.reduce(
+        (s, r) => s + ((r.refunded_cents as number | null) || 0),
+        0,
+      ),
+    },
+    kill_switches_flipped: killRows.map((r) => ({
+      feature: r.feature,
+      verdict: r.target_verdict,
+      admin: r.admin_email,
+      reason: r.reason,
+      when: r.created_at,
+    })),
+    slo_incidents: {
+      total: sloRows.length,
+      by_severity: tallyField(sloRows, "severity"),
+      unresolved: sloRows.filter((r) => !r.resolved_at).length,
+    },
+  };
+
+  return NextResponse.json(report, {
+    headers: {
+      "Content-Type": "application/json",
+      "Content-Disposition": `attachment; filename="afsl-monthly-${label}.json"`,
+    },
+  });
+}
+
+function tallyField(
+  rows: Array<Record<string, unknown>>,
+  field: string,
+): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const row of rows) {
+    const key = (row[field] as string) || "null";
+    out[key] = (out[key] || 0) + 1;
+  }
+  return out;
+}
+
+function resolveMonth(param: string | null): { start: Date; end: Date; label: string } {
+  const now = new Date();
+  let year: number;
+  let month: number;
+  if (param && /^\d{4}-\d{2}$/.test(param)) {
+    const [y, m] = param.split("-").map(Number);
+    year = y;
+    month = m - 1;
+  } else {
+    // Default to last month
+    const d = new Date(now);
+    d.setUTCMonth(d.getUTCMonth() - 1);
+    year = d.getUTCFullYear();
+    month = d.getUTCMonth();
+  }
+  const start = new Date(Date.UTC(year, month, 1));
+  const end = new Date(Date.UTC(year, month + 1, 1));
+  const label = `${year}-${String(month + 1).padStart(2, "0")}`;
+  return { start, end, label };
+}

--- a/app/api/cron/gdpr-retention-purge/route.ts
+++ b/app/api/cron/gdpr-retention-purge/route.ts
@@ -1,0 +1,112 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+import { requireCronAuth } from "@/lib/cron-auth";
+import { wrapCronHandler } from "@/lib/cron-run-log";
+import { isFeatureDisabled } from "@/lib/admin/classifier-config";
+
+const log = logger("cron:gdpr-retention-purge");
+
+export const runtime = "nodejs";
+export const maxDuration = 300;
+
+/**
+ * Daily cron that enforces data retention policies.
+ *
+ * For each enabled row in `retention_rules`:
+ *   - If strategy = 'delete': hard-delete rows older than keep_days
+ *   - If strategy = 'anonymise': null out email_column on rows
+ *     older than keep_days
+ *
+ * Idempotent — re-running after a successful purge is a no-op
+ * because the already-purged rows no longer match the date cut-off.
+ *
+ * Safety: every run stamps last_run_at + last_rows_affected on the
+ * rule so admins can see what happened. Each rule has its own try
+ * block so one broken rule doesn't stop the rest. Failures go to
+ * Sentry via the structured logger.
+ */
+async function handler(req: NextRequest) {
+  const unauth = requireCronAuth(req);
+  if (unauth) return unauth;
+
+  if (await isFeatureDisabled("gdpr_retention_purge")) {
+    return NextResponse.json({ ok: true, skipped: "kill_switch_on" });
+  }
+
+  const supabase = createAdminClient();
+  const { data: rules, error } = await supabase
+    .from("retention_rules")
+    .select("*")
+    .eq("enabled", true);
+
+  if (error) {
+    log.error("Failed to fetch retention_rules", { error: error.message });
+    return NextResponse.json({ ok: false, error: "fetch_failed" }, { status: 500 });
+  }
+
+  const stats = { rules: rules?.length || 0, deleted: 0, anonymised: 0, failed: 0 };
+  const now = new Date();
+
+  for (const rule of rules || []) {
+    try {
+      const cutoff = new Date(
+        now.getTime() - (rule.keep_days as number) * 24 * 60 * 60 * 1000,
+      ).toISOString();
+      const tsCol = rule.timestamp_column as string;
+      const table = rule.table_name as string;
+
+      if (rule.strategy === "delete") {
+        const { count, error: delErr } = await supabase
+          .from(table)
+          .delete({ count: "exact" })
+          .lt(tsCol, cutoff);
+        if (delErr) throw new Error(delErr.message);
+        stats.deleted += count || 0;
+        await supabase
+          .from("retention_rules")
+          .update({
+            last_run_at: now.toISOString(),
+            last_rows_affected: count || 0,
+          })
+          .eq("id", rule.id);
+      } else if (rule.strategy === "anonymise") {
+        const emailCol = rule.email_column as string | null;
+        if (!emailCol) {
+          log.warn("anonymise rule without email_column — skipping", {
+            table,
+            id: rule.id,
+          });
+          continue;
+        }
+        const placeholder = `anonymised-${rule.id}@privacy.invest.com.au`;
+        const { count, error: updErr } = await supabase
+          .from(table)
+          .update({ [emailCol]: placeholder }, { count: "exact" })
+          .lt(tsCol, cutoff)
+          .neq(emailCol, placeholder);
+        if (updErr) throw new Error(updErr.message);
+        stats.anonymised += count || 0;
+        await supabase
+          .from("retention_rules")
+          .update({
+            last_run_at: now.toISOString(),
+            last_rows_affected: count || 0,
+          })
+          .eq("id", rule.id);
+      }
+    } catch (err) {
+      stats.failed++;
+      log.error("retention rule failed", {
+        id: rule.id,
+        table: rule.table_name,
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  log.info("gdpr retention purge completed", stats);
+  return NextResponse.json({ ok: true, ...stats });
+}
+
+export const GET = wrapCronHandler("gdpr-retention-purge", handler);

--- a/app/api/cron/slo-monitor/route.ts
+++ b/app/api/cron/slo-monitor/route.ts
@@ -1,0 +1,165 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+import { requireCronAuth } from "@/lib/cron-auth";
+import { wrapCronHandler } from "@/lib/cron-run-log";
+import {
+  evaluateSlo,
+  openIncident,
+  resolveIncident,
+  type SloDefinition,
+} from "@/lib/slo";
+
+const log = logger("cron:slo-monitor");
+
+export const runtime = "nodejs";
+export const maxDuration = 120;
+
+/**
+ * Every 15 minutes — reads each enabled SLO, measures the relevant
+ * signal, and opens/resolves incidents accordingly.
+ *
+ * Supported metric types (in evaluation_source):
+ *
+ *   1. cron success_rate
+ *      source: { type: "cron", name: "<cron-name>" }
+ *      Reads the last `window_minutes` of cron_run_log rows for
+ *      that cron and computes (ok rows / total rows).
+ *
+ *   2. cron freshness (minutes since last ok)
+ *      source: { type: "cron_freshness", name: "<cron-name>" }
+ *      Reads the most recent cron_run_log ok row and returns
+ *      minutes since it ran.
+ *
+ *   3. queue age
+ *      source: { type: "queue_age", table: "job_queue", column: "scheduled_at", status_column: "status", status_value: "ready" }
+ *      Reads the oldest ready row and returns minutes old.
+ *
+ *   4. slo_incidents open count (recursive, useful for alerting
+ *      on the monitor itself)
+ *      source: { type: "open_incidents" }
+ */
+async function handler(req: NextRequest) {
+  const unauth = requireCronAuth(req);
+  if (unauth) return unauth;
+
+  const supabase = createAdminClient();
+  const stats = { evaluated: 0, breached: 0, resolved: 0, failed: 0 };
+
+  const { data: definitions, error } = await supabase
+    .from("slo_definitions")
+    .select("*")
+    .eq("enabled", true);
+
+  if (error) {
+    log.error("Failed to load SLO definitions", { error: error.message });
+    return NextResponse.json({ ok: false, error: "fetch_failed" }, { status: 500 });
+  }
+
+  for (const def of definitions || []) {
+    stats.evaluated++;
+    try {
+      const definition: SloDefinition = {
+        name: def.name as string,
+        service: def.service as string,
+        metric: def.metric as string,
+        target: Number(def.target),
+        comparator: def.comparator as SloDefinition["comparator"],
+        window_minutes: (def.window_minutes as number) || 60,
+      };
+
+      const measurement = await measureSlo(supabase, definition, (def.evaluation_source || {}) as Record<string, unknown>);
+      if (measurement == null) {
+        stats.failed++;
+        continue;
+      }
+
+      const result = evaluateSlo(definition, measurement);
+      if (result.breached) {
+        await openIncident(definition, measurement, result);
+        stats.breached++;
+      } else {
+        await resolveIncident(definition.name);
+        stats.resolved++;
+      }
+    } catch (err) {
+      stats.failed++;
+      log.error("slo evaluation threw", {
+        name: def.name,
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  log.info("slo monitor completed", stats);
+  return NextResponse.json({ ok: true, ...stats });
+}
+
+type AdminClient = ReturnType<typeof createAdminClient>;
+
+async function measureSlo(
+  supabase: AdminClient,
+  def: SloDefinition,
+  source: Record<string, unknown>,
+): Promise<{ value: number; context?: Record<string, unknown> } | null> {
+  const type = source.type as string | undefined;
+  const windowStart = new Date(Date.now() - def.window_minutes * 60 * 1000).toISOString();
+
+  switch (type) {
+    case "cron": {
+      const name = source.name as string;
+      const { data } = await supabase
+        .from("cron_run_log")
+        .select("status")
+        .eq("name", name)
+        .gte("started_at", windowStart);
+      const rows = data || [];
+      if (rows.length === 0) return { value: 1, context: { note: "no runs in window" } };
+      const ok = rows.filter((r) => r.status === "ok").length;
+      return { value: ok / rows.length, context: { total: rows.length, ok } };
+    }
+    case "cron_freshness": {
+      const name = source.name as string;
+      const { data } = await supabase
+        .from("cron_run_log")
+        .select("started_at")
+        .eq("name", name)
+        .eq("status", "ok")
+        .order("started_at", { ascending: false })
+        .limit(1)
+        .maybeSingle();
+      if (!data) return { value: Infinity, context: { note: "no ok run ever" } };
+      const minutes = (Date.now() - new Date(data.started_at as string).getTime()) / (60 * 1000);
+      return { value: minutes };
+    }
+    case "queue_age": {
+      const table = source.table as string;
+      const tsCol = (source.column as string) || "scheduled_at";
+      const statusCol = (source.status_column as string) || "status";
+      const statusVal = (source.status_value as string) || "ready";
+      const { data } = await supabase
+        .from(table)
+        .select(tsCol)
+        .eq(statusCol, statusVal)
+        .order(tsCol, { ascending: true })
+        .limit(1)
+        .maybeSingle();
+      if (!data) return { value: 0 };
+      const row = data as unknown as Record<string, unknown>;
+      const ts = new Date(row[tsCol] as string).getTime();
+      return { value: (Date.now() - ts) / (60 * 1000) };
+    }
+    case "open_incidents": {
+      const { count } = await supabase
+        .from("slo_incidents")
+        .select("id", { count: "exact", head: true })
+        .eq("status", "open");
+      return { value: count || 0 };
+    }
+    default:
+      log.warn("unknown slo source type", { type, name: def.name });
+      return null;
+  }
+}
+
+export const GET = wrapCronHandler("slo-monitor", handler);

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -1,0 +1,57 @@
+# Runbooks
+
+Playbooks for the on-call engineer. One markdown file per alert or
+critical service. When you get paged, open the runbook with the
+matching name in the alert title and follow the steps.
+
+## Naming convention
+
+```
+docs/runbooks/<service>-<problem>.md
+```
+
+Every runbook MUST have these sections (the template helps):
+
+1. **What just fired** — one sentence describing the alert
+2. **Impact** — who sees what when this is broken
+3. **Diagnosis** — ordered steps to identify the root cause
+4. **Mitigations** — the fastest way to stop the bleeding,
+   even if the root cause is unclear
+5. **Rollback** — how to undo if a deploy caused the incident
+6. **Recovery** — how to restore full service once mitigated
+7. **Post-incident** — what to write up, what to schedule, who
+   to notify
+
+## Current runbooks
+
+- [`cron-stuck.md`](./cron-stuck.md) — a scheduled job hasn't
+  run or hasn't completed successfully within its expected window
+- [`stripe-webhook-stuck.md`](./stripe-webhook-stuck.md) —
+  Stripe events aren't being processed (`processing` rows piling
+  up in `stripe_webhook_events`)
+- [`resend-rate-limited.md`](./resend-rate-limited.md) — Resend
+  is returning 429s and drip / transactional emails are failing
+- [`supabase-slow.md`](./supabase-slow.md) — database latency
+  p95 above SLO and admin pages are timing out
+- [`slo-breach.md`](./slo-breach.md) — the SLO monitor opened
+  a new incident; use this as a starting point then branch to
+  the service-specific runbook
+
+## Template
+
+Copy `TEMPLATE.md` when adding a new runbook:
+
+```bash
+cp docs/runbooks/TEMPLATE.md docs/runbooks/my-service-issue.md
+```
+
+## Principles
+
+- **Mitigate first, diagnose second** — stop the bleeding
+  before you understand everything
+- **Kill switches are a mitigation, not a fix** — flipping one
+  buys you time, it doesn't close the ticket
+- **Annotate what you tried** — add a note to the incident row
+  (`slo_incidents.notes`) so post-incident review has the data
+- **Escalate early** — if you're 15 minutes in with no
+  progress, page the next person in the rotation

--- a/docs/runbooks/TEMPLATE.md
+++ b/docs/runbooks/TEMPLATE.md
@@ -1,0 +1,59 @@
+# <Runbook title>
+
+## What just fired
+
+One sentence. The user-visible symptom, not the mechanism.
+
+## Impact
+
+- Who: which user segment is affected
+- What they see: the specific broken experience
+- Revenue/compliance impact: any $/regulatory exposure
+
+## Diagnosis
+
+Ordered checks. Each one should be a one-liner you can run.
+
+1. `git log -5 --oneline main` — was there a recent deploy?
+2. Open `/admin/automation` — which feature tile is red?
+3. `select * from cron_run_log where name = 'X' order by started_at desc limit 5` — are recent runs ok?
+4. ...
+
+## Mitigations
+
+Fastest way to stop the bleeding, even if diagnosis is incomplete.
+
+- Flip the kill switch: `/admin/automation/kill-switch` → toggle `<feature>`
+- Increase the rate limit for `<endpoint>` in `rate_limit_buckets`
+- Roll back the most recent deploy (see below)
+
+## Rollback
+
+```bash
+# Find the last known good deploy
+git log --oneline main
+# Revert
+git revert <sha>
+git push origin main
+# OR via Vercel CLI
+vercel rollback
+```
+
+## Recovery
+
+Once mitigated, restore full service:
+
+1. Remove kill switch / rate limit override
+2. Backfill any work that was skipped (see the specific cron
+   docs for idempotency guarantees)
+3. Verify in the admin dashboard
+
+## Post-incident
+
+- Update `slo_incidents.notes` with a short timeline
+- Mark `slo_incidents.resolved_at`
+- Schedule a post-mortem if:
+  - Customer-visible impact > 10 minutes
+  - Revenue impact > $1k
+  - Any compliance-affecting event
+- File a follow-up ticket for any underlying cause the fix didn't address

--- a/docs/runbooks/cron-stuck.md
+++ b/docs/runbooks/cron-stuck.md
@@ -1,0 +1,67 @@
+# Cron stuck
+
+## What just fired
+
+A scheduled cron job hasn't successfully run inside its expected
+window. Usually fires from SLO name `cron_<name>_freshness` or the
+admin automation dashboard shows a red tile.
+
+## Impact
+
+Depends on the cron:
+
+- `auto-resolve-disputes` — new disputes pile up in the pending
+  queue, advisors wait longer for refunds (revenue trust)
+- `lead-quality-weights` — the ranker is running on yesterday's
+  model. Low direct impact for a day.
+- `property-suburb-refresh` — suburb data is stale. Low impact.
+- `abandoned-form-drip` — recovery emails don't send. One day
+  late is fine, multi-day is recoverable.
+- `embeddings-refresh` — semantic search results use the last
+  indexed version. Low impact short term.
+- `slo-monitor` — **self-silencing** — if this is stuck, no
+  other alerts will fire. High priority.
+
+## Diagnosis
+
+1. Open `/admin/automation` — find the red tile.
+2. Click the cron name → drill-down shows `last_run`,
+   `status`, `error_message`, and per-run stats.
+3. If `status = running` older than 5 minutes → the run is
+   hanging. Check Vercel cron logs for that invocation.
+4. If `status = error` with a stack trace → read the error,
+   decide whether it's code or data.
+5. If `last_run` is > 2× cadence old but no error row → Vercel
+   didn't dispatch the cron. Check `vercel.json` schedule and
+   the Vercel dashboard cron list.
+
+## Mitigations
+
+- **Manual trigger from the dashboard**: click the "Run now" button
+  on the drill-down. This fires the cron with the `x-admin-manual`
+  header so the run is tagged separately from scheduled runs.
+- **Kill switch**: if the cron is failing on bad data, flip the
+  matching feature kill switch at `/admin/automation/kill-switch`
+  so new work is skipped while you investigate.
+- **Raise max duration**: if the cron is timing out (Vercel logs
+  show 5xx), bump `maxDuration` in the route file and redeploy.
+
+## Rollback
+
+If a recent deploy caused it, `vercel rollback` to the last
+successful deploy. Confirm the cron rows in `cron_run_log` return
+to `status = ok` within one cadence.
+
+## Recovery
+
+- Remove the kill switch
+- Run the cron manually once to confirm it's recovering
+- Monitor the admin dashboard for one more cadence cycle
+- Resolve the SLO incident at `/admin/automation/slo` (or via
+  SQL) so on-call isn't paged twice
+
+## Post-incident
+
+Timeline and fix notes in `slo_incidents.notes`. If the root
+cause was a schema change that broke a query, file a ticket to
+add a migration test that catches the same pattern.

--- a/docs/runbooks/resend-rate-limited.md
+++ b/docs/runbooks/resend-rate-limited.md
@@ -1,0 +1,55 @@
+# Resend rate-limited
+
+## What just fired
+
+Resend is returning 429s and outbound email isn't sending. This
+usually shows up as:
+
+- Drip crons logging `resend send failed` in Sentry
+- Privacy verification links not reaching users
+- Stripe welcome emails missing
+
+## Impact
+
+No critical outbound email is delivered. User-visible workflows
+(password reset, privacy verify) are broken. Medium-severe —
+users can still browse the site but lose trust.
+
+## Diagnosis
+
+1. Check Resend dashboard — hit the status page + account-level
+   sending limits
+2. `select count(*) from cron_run_log where name ilike '%drip%' and status = 'error' and started_at > now() - interval '1 hour';`
+3. Any recent spike in outbound volume (e.g. a broadcast cron
+   firing at the same time as the usual drips)?
+
+## Mitigations
+
+- **Slow everything down**: enable the `email_throttle` feature
+  flag (Wave 7) to reduce drip fan-out to 10% rollout while you
+  investigate
+- **Kill switch drips**: flip `abandoned_form_drip`, `winback_drip`,
+  `advisor_dormant_nudge` at `/admin/automation/kill-switch` —
+  these are non-critical and can resume tomorrow
+- **Leave transactional emails on**: Stripe webhook, privacy
+  verify, and password reset should stay enabled. If they're also
+  429'ing, escalate to Resend support
+
+## Rollback
+
+No deploy usually — this is an upstream / quota issue. If a
+recent change added a new drip or email volume, revert that PR.
+
+## Recovery
+
+- Once Resend recovers, un-flip the kill switches in the reverse
+  order (most important first)
+- Back-fill is unnecessary for the one-dose drips — users who
+  didn't get the 2-day abandoned-quiz email will see the 7-day
+  one instead
+
+## Post-incident
+
+- Note the peak 429 rate in the incident log
+- Consider whether to raise the Resend tier or spread the drip
+  cron schedules to avoid bursts at the top of the hour

--- a/docs/runbooks/stripe-webhook-stuck.md
+++ b/docs/runbooks/stripe-webhook-stuck.md
@@ -1,0 +1,76 @@
+# Stripe webhook stuck
+
+## What just fired
+
+Stripe webhook events are piling up in the `processing` state in
+`stripe_webhook_events`. Either the handler is failing, Stripe is
+retrying a bad event, or the idempotency loop has a bug.
+
+## Impact
+
+Live. Advisor credit top-ups may be missing, Pro welcome emails
+undelivered, dispute refunds in limbo. Revenue-critical.
+
+## Diagnosis
+
+```sql
+-- Rows stuck in 'processing' older than 5 minutes
+SELECT event_id, event_type, started_at, status
+FROM stripe_webhook_events
+WHERE status = 'processing' AND started_at < now() - interval '5 minutes'
+ORDER BY started_at ASC
+LIMIT 20;
+
+-- Most recent errors
+SELECT event_id, event_type, started_at
+FROM stripe_webhook_events
+WHERE status = 'error'
+ORDER BY started_at DESC
+LIMIT 20;
+```
+
+Then:
+
+1. Check Sentry for the webhook handler — look for recent
+   uncaught errors tagged `stripe-webhook`.
+2. Open Stripe dashboard → Webhooks → the endpoint → see the
+   failed delivery queue. Compare event IDs against the rows.
+3. If one specific event is poisoning the queue, note the
+   event_id and skip it explicitly.
+
+## Mitigations
+
+- **Re-drive stale rows**: the handler already re-takes any
+  processing row older than 5 minutes on Stripe's retry. If
+  Stripe stopped retrying, you can nudge it from the Stripe
+  dashboard → "Resend" on the event.
+- **Skip a poison event**: mark the row as error so the rest of
+  the queue proceeds.
+  ```sql
+  UPDATE stripe_webhook_events
+  SET status = 'error', completed_at = now()
+  WHERE event_id = '<evt_id>';
+  ```
+- **Never** delete rows from `stripe_webhook_events` — the PK
+  uniqueness is what keeps idempotency working.
+
+## Rollback
+
+If a recent deploy broke the webhook handler, `vercel rollback`.
+The handler is append-only so rolling back is safe.
+
+## Recovery
+
+- Stripe will retry the failed events automatically for up to
+  3 days (standard exponential backoff)
+- For anything outside that window, re-drive from the Stripe
+  dashboard
+- Run the monthly AFSL report to confirm refunds landed
+
+## Post-incident
+
+- Timeline in `slo_incidents.notes`
+- If the root cause was a schema mismatch, add a test that
+  constructs the specific event type with a fixture
+- If the idempotency loop was at fault, update the test in
+  `__tests__/api/stripe-webhook.test.ts`

--- a/lib/api-schemas.ts
+++ b/lib/api-schemas.ts
@@ -1,0 +1,141 @@
+/**
+ * Shared API request/response schemas.
+ *
+ * Every public API route that returns structured data should
+ * export its response shape here and assert it with
+ * `assertResponse(schema, json)`. The contract test then runs
+ * the assertion against a live (or Playwright-mocked) response
+ * and fails the build if a backend change breaks the frontend
+ * contract.
+ *
+ * Why zod + a central file instead of per-route schemas:
+ *   - Single source of truth, greppable
+ *   - Lets us generate a JSON schema bundle for partners /
+ *     OpenAPI-like docs later
+ *   - Easy to import into the E2E test suite
+ */
+
+import { z } from "zod";
+
+// ─── Primitive building blocks ────────────────────────────────────
+
+export const OkResponse = z.object({
+  ok: z.literal(true),
+});
+
+export const ErrorResponse = z.object({
+  error: z.string(),
+});
+
+// ─── /api/form-event ───────────────────────────────────────────────
+
+export const FormEventRequest = z.object({
+  session_id: z.string().min(1).max(100),
+  user_key: z.string().optional().nullable(),
+  form_name: z.enum([
+    "quiz",
+    "advisor_enquiry",
+    "advisor_signup",
+    "advisor_apply",
+    "broker_apply",
+    "lead_form",
+  ]),
+  step: z.string().min(1).max(100),
+  step_index: z.number().int().nonnegative().optional().nullable(),
+  event: z.enum(["view", "interact", "complete", "abandon"]),
+  meta: z.record(z.string(), z.unknown()).optional().nullable(),
+});
+
+export const FormEventResponse = OkResponse;
+
+// ─── /api/attribution/touch ────────────────────────────────────────
+
+export const AttributionTouchRequest = z.object({
+  session_id: z.string().min(1).max(100),
+  user_key: z.string().optional().nullable(),
+  event: z.enum(["view", "click", "signup", "lead", "conversion"]),
+  source: z.string().optional().nullable(),
+  medium: z.string().optional().nullable(),
+  campaign: z.string().optional().nullable(),
+  landing_path: z.string().optional().nullable(),
+  page_path: z.string().optional().nullable(),
+  vertical: z.string().optional().nullable(),
+  value_cents: z.number().int().optional().nullable(),
+});
+
+// ─── /api/search-semantic ──────────────────────────────────────────
+
+export const SearchHit = z.object({
+  type: z.enum(["article", "broker", "advisor", "qa", "scenario"]),
+  id: z.string(),
+  title: z.string(),
+  excerpt: z.string(),
+  score: z.number().min(0).max(1),
+});
+
+export const SearchResponse = z.object({
+  hits: z.array(SearchHit),
+  provider: z.string().optional(),
+  degraded: z.boolean().optional(),
+  error: z.string().optional(),
+});
+
+// ─── /api/privacy/request ──────────────────────────────────────────
+
+export const PrivacyRequestInput = z.object({
+  email: z.string().email(),
+  type: z.enum(["export", "delete"]),
+});
+
+export const PrivacyRequestResponse = z.object({
+  ok: z.literal(true),
+  message: z.string(),
+});
+
+// ─── /api/admin/automation/bulk ────────────────────────────────────
+
+export const BulkActionRequest = z.object({
+  feature: z.enum([
+    "listing_scam",
+    "text_moderation",
+    "advisor_applications",
+    "broker_data_changes",
+    "marketplace_campaigns",
+  ]),
+  targetVerdict: z.string().min(1),
+  rowIds: z.array(z.number().int()).min(1).max(500),
+  reason: z.string().optional().nullable(),
+  subSurface: z.enum(["broker_review", "advisor_review"]).optional(),
+});
+
+export const BulkActionResponse = z.object({
+  ok: z.boolean(),
+  updated: z.number().int().nonnegative(),
+  failed: z.number().int().nonnegative(),
+  errors: z.array(z.string()),
+});
+
+// ─── Helper: assert a response matches a schema ────────────────────
+
+/**
+ * Validates a parsed JSON body against a zod schema. Throws if it
+ * doesn't match so a contract test can see the exact diff.
+ *
+ * Usage in Playwright / unit tests:
+ *
+ *     const body = await response.json();
+ *     assertContract(SearchResponse, body);
+ */
+export function assertContract<T extends z.ZodTypeAny>(
+  schema: T,
+  value: unknown,
+): z.infer<T> {
+  const result = schema.safeParse(value);
+  if (!result.success) {
+    const msg = result.error.issues
+      .map((i) => `${i.path.join(".") || "<root>"}: ${i.message}`)
+      .join("\n");
+    throw new Error(`Contract mismatch:\n${msg}`);
+  }
+  return result.data;
+}

--- a/lib/feature-flags.ts
+++ b/lib/feature-flags.ts
@@ -1,0 +1,152 @@
+/**
+ * Feature flag evaluator.
+ *
+ * Strictly more powerful than the existing `isFeatureDisabled`
+ * kill switches: a flag can be partially on (percentage rollout),
+ * targeted at specific users/segments (allowlist / denylist), or
+ * fully on.
+ *
+ * Kill switches stay for the existing automation features — those
+ * are strict on/off emergency handles. New features start here
+ * and can be ramped gradually.
+ *
+ * API:
+ *
+ *     const enabled = await isFlagEnabled("new_search_ui", {
+ *       userKey: user.email,
+ *       segment: "admin",
+ *     });
+ *     if (enabled) { ... }
+ *
+ * The evaluator caches rows in-process for 30 seconds so flipping
+ * a flag in the admin UI propagates within one cron cycle.
+ */
+
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+
+const log = logger("feature-flags");
+
+export interface FlagContext {
+  userKey?: string | null;
+  segment?: "advisor" | "broker" | "admin" | "user" | null;
+}
+
+interface FlagRow {
+  flag_key: string;
+  enabled: boolean;
+  rollout_pct: number;
+  allowlist: string[];
+  denylist: string[];
+  segments: string[];
+}
+
+const CACHE_TTL_MS = 30_000;
+const cache = new Map<string, { row: FlagRow | null; at: number }>();
+
+/**
+ * Stable hash of (flagKey, userKey) → 0..99. Used for percentage
+ * rollout. The key is hashed together so different flags get
+ * different sticky assignments for the same user — otherwise a
+ * 10% rollout would always pick the same people for every flag.
+ */
+export function rolloutHash(flagKey: string, userKey: string): number {
+  const input = `${flagKey}::${userKey}`;
+  // FNV-1a — deterministic, dep-free
+  let h = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return (h >>> 0) % 100;
+}
+
+/**
+ * Pure evaluation given a pre-loaded row. Exported so tests can
+ * cover every case without mocking Supabase.
+ */
+export function evaluateFlag(
+  row: FlagRow | null | undefined,
+  context: FlagContext,
+): boolean {
+  if (!row) return false;
+
+  const key = context.userKey || "";
+
+  // 1. Denylist wins absolutely
+  if (key && row.denylist.includes(key)) return false;
+
+  // 2. Allowlist is next — a listed key is always on regardless
+  //    of rollout_pct / enabled
+  if (key && row.allowlist.includes(key)) return true;
+
+  // 3. Master switch
+  if (!row.enabled) return false;
+
+  // 4. Segment targeting — if segments is set, the caller's
+  //    segment must match at least one entry. Empty segments
+  //    means "applies to everyone".
+  if (row.segments.length > 0) {
+    if (!context.segment) return false;
+    if (!row.segments.includes(context.segment)) return false;
+  }
+
+  // 5. Percentage rollout
+  if (row.rollout_pct >= 100) return true;
+  if (row.rollout_pct <= 0) return false;
+  if (!key) {
+    // No stable key → flip a coin per call. That's fine for
+    // anonymous read-through feature flags.
+    return Math.random() * 100 < row.rollout_pct;
+  }
+  return rolloutHash(row.flag_key, key) < row.rollout_pct;
+}
+
+/**
+ * Read a flag row from the DB, with 30-second in-process cache.
+ * Fail-open: DB errors return null → evaluateFlag() returns false.
+ */
+export async function loadFlag(flagKey: string): Promise<FlagRow | null> {
+  const now = Date.now();
+  const cached = cache.get(flagKey);
+  if (cached && now - cached.at < CACHE_TTL_MS) return cached.row;
+
+  try {
+    const supabase = createAdminClient();
+    const { data, error } = await supabase
+      .from("feature_flags")
+      .select("flag_key, enabled, rollout_pct, allowlist, denylist, segments")
+      .eq("flag_key", flagKey)
+      .maybeSingle();
+    if (error) {
+      log.warn("feature_flags fetch failed", {
+        flag: flagKey,
+        error: error.message,
+      });
+      cache.set(flagKey, { row: null, at: now });
+      return null;
+    }
+    const row = (data as FlagRow | null) || null;
+    cache.set(flagKey, { row, at: now });
+    return row;
+  } catch (err) {
+    log.warn("feature_flags threw", {
+      flag: flagKey,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}
+
+export async function isFlagEnabled(
+  flagKey: string,
+  context: FlagContext = {},
+): Promise<boolean> {
+  const row = await loadFlag(flagKey);
+  return evaluateFlag(row, context);
+}
+
+export function invalidateFlagCache(flagKey?: string): void {
+  if (flagKey) cache.delete(flagKey);
+  else cache.clear();
+}

--- a/lib/slo.ts
+++ b/lib/slo.ts
@@ -1,0 +1,238 @@
+/**
+ * SLO evaluator + alert helpers.
+ *
+ * Pure decision functions that take a measured value and an SLO
+ * definition, decide whether it's breached, and (if so) open an
+ * incident row. The `slo-monitor` cron is the only caller — it
+ * walks every enabled row in `slo_definitions`, runs the matching
+ * measurement, then calls `evaluateSlo`.
+ *
+ * Alert routing:
+ *   - `warn` incidents → Slack webhook
+ *   - `page` incidents → Slack + PagerDuty webhook
+ *
+ * Both webhook URLs come from env vars. If they're unset we still
+ * open the incident row, just without an external notification —
+ * so adding the webhook later is zero-code.
+ */
+
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+
+const log = logger("slo");
+
+export type SloComparator = ">=" | "<=" | "<" | ">";
+
+export interface SloDefinition {
+  name: string;
+  service: string;
+  metric: string;
+  target: number;
+  comparator: SloComparator;
+  window_minutes: number;
+}
+
+export interface SloMeasurement {
+  value: number;
+  context?: Record<string, unknown>;
+}
+
+export interface SloEvaluation {
+  breached: boolean;
+  severity: "warn" | "page";
+  reason: string;
+}
+
+/**
+ * Pure evaluation — given a measurement + an SLO definition,
+ * decide whether the SLO is in breach and at what severity.
+ *
+ * Rules:
+ *   - If the comparator check fails → breach
+ *   - Severity = 'page' if the breach is ≥50% off target
+ *     (e.g. 99% target, measured 49% = page; measured 95% = warn)
+ *   - Otherwise severity = 'warn'
+ *
+ * Kept pure so the unit tests can cover every case without a
+ * DB stub.
+ */
+export function evaluateSlo(
+  definition: SloDefinition,
+  measurement: SloMeasurement,
+): SloEvaluation {
+  const { target, comparator } = definition;
+  const value = measurement.value;
+  let breached: boolean;
+  switch (comparator) {
+    case ">=":
+      breached = !(value >= target);
+      break;
+    case ">":
+      breached = !(value > target);
+      break;
+    case "<=":
+      breached = !(value <= target);
+      break;
+    case "<":
+      breached = !(value < target);
+      break;
+  }
+  if (!breached) {
+    return { breached: false, severity: "warn", reason: "within_target" };
+  }
+
+  // Page if the breach is >= 50% off target
+  const gap = Math.abs(value - target) / Math.max(Math.abs(target), 1);
+  const severity: "warn" | "page" = gap >= 0.5 ? "page" : "warn";
+  return {
+    breached: true,
+    severity,
+    reason: `measured ${value} ${comparator} ${target} failed (gap ${(gap * 100).toFixed(0)}%)`,
+  };
+}
+
+/**
+ * Open a new slo_incidents row for a breach. Fire-and-forget
+ * notification on success. Safe to call multiple times — the
+ * cron dedupes by only opening if there isn't already an `open`
+ * row for the same SLO name.
+ */
+export async function openIncident(
+  definition: SloDefinition,
+  measurement: SloMeasurement,
+  evaluation: SloEvaluation,
+): Promise<void> {
+  if (!evaluation.breached) return;
+
+  const supabase = createAdminClient();
+  // Dedupe — don't open a new incident if one is already open
+  const { data: existing } = await supabase
+    .from("slo_incidents")
+    .select("id")
+    .eq("slo_name", definition.name)
+    .eq("status", "open")
+    .limit(1);
+  if (existing && existing.length > 0) return;
+
+  const { error } = await supabase.from("slo_incidents").insert({
+    slo_name: definition.name,
+    service: definition.service,
+    severity: evaluation.severity,
+    measured_value: measurement.value,
+    target_value: definition.target,
+    comparator: definition.comparator,
+    notes: evaluation.reason,
+    context: measurement.context || null,
+  });
+  if (error) {
+    log.warn("slo_incidents insert failed", { error: error.message });
+    return;
+  }
+
+  // Route to Slack (always) + PagerDuty (page only)
+  notifySlack(definition, evaluation, measurement).catch((err) =>
+    log.warn("slo slack notification failed", {
+      err: err instanceof Error ? err.message : String(err),
+    }),
+  );
+  if (evaluation.severity === "page") {
+    notifyPagerDuty(definition, evaluation, measurement).catch((err) =>
+      log.warn("slo pagerduty notification failed", {
+        err: err instanceof Error ? err.message : String(err),
+      }),
+    );
+  }
+}
+
+async function notifySlack(
+  def: SloDefinition,
+  evaluation: SloEvaluation,
+  measurement: SloMeasurement,
+): Promise<void> {
+  const url = process.env.SLACK_ALERT_WEBHOOK_URL;
+  if (!url) return;
+  const emoji = evaluation.severity === "page" ? ":rotating_light:" : ":warning:";
+  const body = {
+    text: `${emoji} SLO breach: *${def.name}*`,
+    attachments: [
+      {
+        color: evaluation.severity === "page" ? "#dc2626" : "#f59e0b",
+        fields: [
+          { title: "Service", value: def.service, short: true },
+          { title: "Metric", value: def.metric, short: true },
+          { title: "Target", value: `${def.comparator} ${def.target}`, short: true },
+          { title: "Measured", value: String(measurement.value), short: true },
+          { title: "Reason", value: evaluation.reason, short: false },
+        ],
+      },
+    ],
+  };
+  await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(8_000),
+  });
+}
+
+async function notifyPagerDuty(
+  def: SloDefinition,
+  evaluation: SloEvaluation,
+  measurement: SloMeasurement,
+): Promise<void> {
+  const routingKey = process.env.PAGERDUTY_ROUTING_KEY;
+  if (!routingKey) return;
+  const body = {
+    routing_key: routingKey,
+    event_action: "trigger",
+    dedup_key: `slo:${def.name}`,
+    payload: {
+      summary: `SLO breach: ${def.name}`,
+      severity: "error",
+      source: "invest-com-au",
+      component: def.service,
+      custom_details: {
+        metric: def.metric,
+        target: def.target,
+        measured: measurement.value,
+        reason: evaluation.reason,
+        ...(measurement.context || {}),
+      },
+    },
+  };
+  await fetch("https://events.pagerduty.com/v2/enqueue", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(8_000),
+  });
+}
+
+/**
+ * Resolve any open incident whose name matches the given SLO.
+ * Called by the monitor cron after an evaluation comes back
+ * clean so recoveries auto-close.
+ */
+export async function resolveIncident(sloName: string): Promise<void> {
+  const supabase = createAdminClient();
+  await supabase
+    .from("slo_incidents")
+    .update({ status: "resolved", resolved_at: new Date().toISOString() })
+    .eq("slo_name", sloName)
+    .eq("status", "open");
+
+  // Also send PagerDuty resolve event so the incident auto-closes
+  const routingKey = process.env.PAGERDUTY_ROUTING_KEY;
+  if (routingKey) {
+    await fetch("https://events.pagerduty.com/v2/enqueue", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        routing_key: routingKey,
+        event_action: "resolve",
+        dedup_key: `slo:${sloName}`,
+      }),
+      signal: AbortSignal.timeout(8_000),
+    }).catch(() => undefined);
+  }
+}

--- a/supabase/migrations/20260415_wave_7_trust_ops.sql
+++ b/supabase/migrations/20260415_wave_7_trust_ops.sql
@@ -1,0 +1,165 @@
+-- Wave 7 schema — trust + ops maturity foundations.
+--
+-- Tables introduced:
+--   1. feature_flags           — percentage + segment rollout beyond
+--                                on/off kill switches
+--   2. slo_definitions         — per-service SLO targets + thresholds
+--   3. slo_incidents           — automatic incident creation when a
+--                                threshold is breached
+--   4. retention_rules         — GDPR / Privacy Act data retention
+--                                policy per table/column
+--
+-- Every table RLS-enabled and service-role only.
+
+-- ── 1. feature_flags ───────────────────────────────────────────────
+-- Richer than automation_kill_switches: supports a percentage
+-- rollout, a list of user segments (e.g. "advisor", "broker",
+-- "admin"), and a list of explicit allowlist/denylist keys (email,
+-- id, etc). Evaluated in order:
+--
+--   1. denylist — if the caller's key is in denylist → false
+--   2. allowlist — if the caller's key is in allowlist → true
+--   3. segment match → enabled for that segment
+--   4. percentage rollout via stable hash(key) mod 100 < rollout_pct
+--
+-- A row with rollout_pct = 0 and empty lists is "off". Rolling to
+-- 100 is the same as the existing kill-switch "enabled" state —
+-- so feature_flags is a strict superset.
+CREATE TABLE IF NOT EXISTS public.feature_flags (
+  id              bigserial PRIMARY KEY,
+  flag_key        text NOT NULL UNIQUE,
+  description     text,
+  enabled         boolean NOT NULL DEFAULT false,
+  rollout_pct     integer NOT NULL DEFAULT 0,
+  allowlist       text[] NOT NULL DEFAULT '{}',
+  denylist        text[] NOT NULL DEFAULT '{}',
+  segments        text[] NOT NULL DEFAULT '{}',   -- 'advisor' | 'broker' | 'admin' | 'user'
+  updated_by      text,
+  updated_at      timestamptz NOT NULL DEFAULT now(),
+  created_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_feature_flags_key
+  ON public.feature_flags (flag_key);
+
+ALTER TABLE public.feature_flags ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE public.feature_flags
+  DROP CONSTRAINT IF EXISTS feature_flags_rollout_pct_check;
+ALTER TABLE public.feature_flags
+  ADD CONSTRAINT feature_flags_rollout_pct_check CHECK (
+    rollout_pct >= 0 AND rollout_pct <= 100
+  );
+
+COMMENT ON TABLE public.feature_flags IS
+  'Percentage + segment feature flags. Supersedes automation_kill_switches for new features; existing kill switches remain for legacy compat.';
+
+-- ── 2. slo_definitions ─────────────────────────────────────────────
+-- One row per SLO we track. The monitoring cron reads this table,
+-- queries the relevant metric (cron_run_log duration, HTTP error
+-- rate, queue age etc), and writes a row to slo_incidents if the
+-- target is breached.
+CREATE TABLE IF NOT EXISTS public.slo_definitions (
+  id                bigserial PRIMARY KEY,
+  name              text NOT NULL UNIQUE,
+  service           text NOT NULL,       -- 'cron' | 'api' | 'webhook' | 'ingest'
+  metric            text NOT NULL,       -- 'success_rate' | 'p95_latency_ms' | 'queue_age_minutes' | 'error_rate'
+  target            numeric NOT NULL,    -- e.g. 0.99 for 99% success
+  comparator        text NOT NULL,       -- '>=' | '<=' | '<' | '>'
+  window_minutes    integer NOT NULL DEFAULT 60,
+  evaluation_source jsonb,               -- freeform hint for the evaluator cron (e.g. {cron: "auto-resolve-disputes"})
+  enabled           boolean NOT NULL DEFAULT true,
+  created_at        timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.slo_definitions ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE public.slo_definitions
+  DROP CONSTRAINT IF EXISTS slo_definitions_comparator_check;
+ALTER TABLE public.slo_definitions
+  ADD CONSTRAINT slo_definitions_comparator_check CHECK (
+    comparator = ANY (ARRAY['>='::text, '<='::text, '<'::text, '>'::text])
+  );
+
+-- ── 3. slo_incidents ───────────────────────────────────────────────
+-- Every SLO breach produces one row. Status machine:
+--   open → acknowledged → resolved
+--
+-- Includes the raw measurement so on-call can see what tripped
+-- without re-running the query.
+CREATE TABLE IF NOT EXISTS public.slo_incidents (
+  id               bigserial PRIMARY KEY,
+  slo_name         text NOT NULL,
+  service          text NOT NULL,
+  severity         text NOT NULL,       -- 'warn' | 'page'
+  measured_value   numeric,
+  target_value     numeric,
+  comparator       text,
+  started_at       timestamptz NOT NULL DEFAULT now(),
+  acknowledged_at  timestamptz,
+  acknowledged_by  text,
+  resolved_at      timestamptz,
+  status           text NOT NULL DEFAULT 'open',
+  notes            text,
+  context          jsonb
+);
+
+CREATE INDEX IF NOT EXISTS idx_slo_incidents_open
+  ON public.slo_incidents (status, started_at DESC)
+  WHERE status = 'open';
+CREATE INDEX IF NOT EXISTS idx_slo_incidents_slo
+  ON public.slo_incidents (slo_name, started_at DESC);
+
+ALTER TABLE public.slo_incidents ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE public.slo_incidents
+  DROP CONSTRAINT IF EXISTS slo_incidents_severity_check;
+ALTER TABLE public.slo_incidents
+  ADD CONSTRAINT slo_incidents_severity_check CHECK (
+    severity = ANY (ARRAY['warn'::text, 'page'::text])
+  );
+
+ALTER TABLE public.slo_incidents
+  DROP CONSTRAINT IF EXISTS slo_incidents_status_check;
+ALTER TABLE public.slo_incidents
+  ADD CONSTRAINT slo_incidents_status_check CHECK (
+    status = ANY (ARRAY['open'::text, 'acknowledged'::text, 'resolved'::text])
+  );
+
+-- ── 4. retention_rules ─────────────────────────────────────────────
+-- Privacy Act 1988 (Cth) + GDPR require that personal data is kept
+-- no longer than necessary. This table lists the retention policy
+-- per data surface. The `gdpr-retention-purge` cron reads this
+-- table and runs the appropriate DELETE / ANONYMISE per rule.
+CREATE TABLE IF NOT EXISTS public.retention_rules (
+  id              bigserial PRIMARY KEY,
+  table_name      text NOT NULL,
+  keep_days       integer NOT NULL,     -- data older than this may be purged
+  strategy        text NOT NULL,        -- 'delete' | 'anonymise'
+  email_column    text,                 -- null = not keyed by email
+  timestamp_column text NOT NULL,       -- e.g. 'created_at' | 'captured_at'
+  description     text,
+  last_run_at     timestamptz,
+  last_rows_affected integer,
+  enabled         boolean NOT NULL DEFAULT true,
+  UNIQUE (table_name, timestamp_column)
+);
+
+ALTER TABLE public.retention_rules ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE public.retention_rules
+  DROP CONSTRAINT IF EXISTS retention_rules_strategy_check;
+ALTER TABLE public.retention_rules
+  ADD CONSTRAINT retention_rules_strategy_check CHECK (
+    strategy = ANY (ARRAY['delete'::text, 'anonymise'::text])
+  );
+
+-- Seed a conservative default policy
+INSERT INTO public.retention_rules (table_name, keep_days, strategy, email_column, timestamp_column, description)
+VALUES
+  ('form_events', 180, 'delete', NULL, 'created_at', 'Form funnel events — 6 month retention'),
+  ('attribution_touches', 180, 'delete', NULL, 'created_at', 'Attribution beacons — 6 month retention'),
+  ('analytics_events', 365, 'delete', NULL, 'created_at', 'Generic analytics — 12 month retention'),
+  ('affiliate_clicks', 730, 'delete', NULL, 'clicked_at', 'Affiliate clicks — 24 month retention for conversion attribution'),
+  ('email_captures', 730, 'anonymise', 'email', 'captured_at', 'Email captures — 24 months then anonymise')
+ON CONFLICT (table_name, timestamp_column) DO NOTHING;

--- a/vercel.json
+++ b/vercel.json
@@ -191,6 +191,14 @@
     {
       "path": "/api/cron/abandoned-form-drip",
       "schedule": "0 12 * * *"
+    },
+    {
+      "path": "/api/cron/slo-monitor",
+      "schedule": "*/15 * * * *"
+    },
+    {
+      "path": "/api/cron/gdpr-retention-purge",
+      "schedule": "0 2 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Wave 7 — Platform trust + ops maturity

Seven items from the Wave 6 audit's "Tier 3 foundations" list.

### Dependency + supply-chain
- `npm audit --audit-level=high` in CI — PR fails on high/critical vulns
- `actions/dependency-review-action` with license allowlist
- `.github/dependabot.yml` — weekly grouped PRs + advisory bypass

### SLOs + alerts
- `lib/slo.ts` pure evaluator (severity tier from gap %) + Slack + PagerDuty routing with auto-resolve
- `/api/cron/slo-monitor` — 15-min cron supporting 4 measurement types (cron success rate, cron freshness, queue age, open incidents)
- `slo_definitions` / `slo_incidents` tables

### GDPR automation
- `/api/cron/gdpr-retention-purge` — daily, reads `retention_rules` and deletes/anonymises per policy
- Seeded with conservative defaults covering form_events, attribution_touches, analytics_events, affiliate_clicks, email_captures

### AFSL monthly report
- `GET /api/admin/reports/afsl-monthly?month=YYYY-MM` — JSON bundle covering financial audit, AFSL verifications, photo mod, text mod, disputes, kill switches, SLO incidents

### Runbooks
- `docs/runbooks/` with README, TEMPLATE, and concrete playbooks for cron-stuck, stripe-webhook-stuck, resend-rate-limited
- "Mitigate first, diagnose second" principle baked in

### Feature flags (supersedes kill switches for new features)
- `lib/feature-flags.ts` pure evaluator — stable rolloutHash, deny>allow>enabled>segment>percentage precedence, 30s cache, fail-open
- `/api/admin/automation/flags` GET/POST/PATCH under `requireAdmin`, audit-logged

### Contract testing
- `lib/api-schemas.ts` — zod schemas for form-event, attribution-touch, search-semantic, privacy-request, bulk-action
- `assertContract()` helper for Playwright + unit tests

### DB health
- `pg_stat_statements` extension enabled
- `slow_query_snapshot` + `connection_pool_snapshot` SQL views
- `/admin/automation/db-health` panel: slow queries + pool state + retention rules status

## Test plan
- [x] **41 new unit tests** (SLO, feature flags, api-schemas)
- [x] **1448 / 1448** total passing
- [x] `tsc --noEmit` clean
- [x] `npm run build` → Compiled successfully
- [ ] Seed `slo_definitions` via admin in staging, verify `slo-monitor` writes incidents
- [ ] Set `SLACK_ALERT_WEBHOOK_URL` / `PAGERDUTY_ROUTING_KEY` and fire a test breach
- [ ] Run `/api/admin/reports/afsl-monthly?month=2026-03` for a real month
- [ ] Insert a test `feature_flags` row, verify a partial rollout evaluation

https://claude.ai/code/session_01DyudU3Uo5eFGwXKQsYcbUw