### PR TITLE
fix(vercel): consolidate 62 crons into 39 via dispatcher route

### DIFF
--- a/app/api/cron/_dispatch/[group]/route.ts
+++ b/app/api/cron/_dispatch/[group]/route.ts
@@ -1,0 +1,96 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireCronAuth } from "@/lib/cron-auth";
+import { CRON_GROUPS } from "@/lib/cron-groups";
+import { logger } from "@/lib/logger";
+
+const log = logger("cron-dispatch");
+
+export const runtime = "nodejs";
+export const maxDuration = 300;
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/cron/_dispatch/[group]
+ *
+ * Fan-out dispatcher. Vercel triggers this per schedule in vercel.json;
+ * the group slug maps to one or more individual handler paths in
+ * CRON_GROUPS. Each handler is invoked over the loopback with the
+ * original Authorization header so the per-handler CRON_SECRET check
+ * still guards the real work.
+ *
+ * Existence rationale: Vercel's 40-cron-per-project cap. We have 62
+ * handlers; this file collapses them to 39 schedule entries with zero
+ * behavioural change to any handler.
+ */
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ group: string }> },
+) {
+  const unauth = requireCronAuth(req);
+  if (unauth) return unauth;
+
+  const { group } = await params;
+  const paths = CRON_GROUPS[group];
+  if (!paths) {
+    log.warn("Unknown cron group", { group });
+    return NextResponse.json(
+      { error: `Unknown cron group: ${group}` },
+      { status: 404 },
+    );
+  }
+
+  const origin = new URL(req.url).origin;
+  const auth = req.headers.get("authorization") ?? "";
+
+  const started = Date.now();
+  const results = await Promise.allSettled(
+    paths.map(async (path) => {
+      const t0 = Date.now();
+      const res = await fetch(`${origin}${path}`, {
+        method: "GET",
+        headers: { Authorization: auth },
+        cache: "no-store",
+      });
+      const durationMs = Date.now() - t0;
+      let body: unknown = null;
+      try {
+        body = await res.json();
+      } catch {
+        // handler returned non-JSON; ignore body, status is what we log
+      }
+      return { path, status: res.status, durationMs, body };
+    }),
+  );
+
+  const summary = results.map((r, i) => {
+    const path = paths[i];
+    if (r.status === "fulfilled") {
+      return { ok: r.value.status < 400, ...r.value };
+    }
+    return {
+      path,
+      ok: false,
+      error:
+        r.reason instanceof Error ? r.reason.message : String(r.reason),
+    };
+  });
+
+  const failed = summary.filter((s) => !s.ok);
+  log.info("Dispatch complete", {
+    group,
+    total: summary.length,
+    failed: failed.length,
+    totalMs: Date.now() - started,
+  });
+
+  return NextResponse.json(
+    {
+      ok: failed.length === 0,
+      group,
+      total: summary.length,
+      failed: failed.length,
+      results: summary,
+    },
+    { status: failed.length === 0 ? 200 : 207 },
+  );
+}

--- a/lib/cron-groups.ts
+++ b/lib/cron-groups.ts
@@ -1,0 +1,110 @@
+/**
+ * Cron dispatcher groups.
+ *
+ * Vercel's per-project cron limit is 40. We have 62 individual handlers, so
+ * vercel.json triggers a dispatcher route (/api/cron/_dispatch/[group]) once
+ * per unique cron schedule, and the dispatcher fans out to every handler that
+ * shares that schedule.
+ *
+ * Each group key maps directly to a cron schedule via vercel.json:
+ *   - hourly-N        : minute N of every hour (e.g. hourly-0 = "0 * * * *")
+ *   - daily-H         : every day at hour H (e.g. daily-4 = "0 4 * * *")
+ *   - daily-H-M       : every day at H:M (e.g. daily-9-30 = "30 9 * * *")
+ *   - weekly-<day>-H  : every week on <day> at hour H
+ *   - monthly-D-H     : every month on day D at hour H
+ *   - every-Nm        : every N minutes (step form in the minute field)
+ *   - every-Nh        : every N hours (step form in the hour field)
+ *
+ * The handler paths below are called internally via fetch() so each handler
+ * keeps its own runtime directive (edge/nodejs), maxDuration, and existing
+ * CRON_SECRET auth check — no refactoring required. To revert to direct
+ * per-handler cron entries, copy the arrays below back into vercel.json.
+ */
+export const CRON_GROUPS: Record<string, readonly string[]> = {
+  "hourly-0": ["/api/cron/auto-resolve-disputes"],
+  "hourly-5": ["/api/cron/broker-snapshot"],
+  "hourly-15": ["/api/cron/automation-verdict-rollup"],
+  "hourly-20": ["/api/cron/cron-freshness"],
+  "hourly-30": ["/api/cron/embeddings-refresh"],
+
+  "every-5m": ["/api/cron/job-queue-worker"],
+  "every-10m": ["/api/cron/confirm-lead-notify"],
+  "every-15m": ["/api/cron/retry-webhooks", "/api/cron/slo-monitor"],
+  "every-6h": ["/api/admin/run-migration"],
+
+  "daily-0": ["/api/cron/auto-publish"],
+  "daily-1": ["/api/cron/cleanup"],
+  "daily-1-30": ["/api/cron/warehouse-rollup"],
+  "daily-2": [
+    "/api/cron/lead-quality-weights",
+    "/api/cron/low-balance-alerts",
+    "/api/cron/refresh-revenue-view",
+    "/api/cron/gdpr-retention-purge",
+  ],
+  "daily-3": [
+    "/api/cron/referral-payouts",
+    "/api/cron/data-integrity-audit",
+  ],
+  "daily-4": [
+    "/api/cron/email-bounce-sweep",
+    "/api/cron/marketplace-stats",
+    "/api/cron/verify-review-clients",
+    "/api/cron/ab-auto-promote",
+    "/api/cron/revenue-reconciliation",
+  ],
+  "daily-5": [
+    "/api/cron/expire-deals",
+    "/api/cron/advisor-quality",
+    "/api/cron/review-sentiment-refresh",
+  ],
+  "daily-6": ["/api/cron/check-fees", "/api/cron/tmd-audit"],
+  "daily-7": [
+    "/api/cron/portfolio-alerts",
+    "/api/cron/price-drop-alerts",
+  ],
+  "daily-8": ["/api/cron/complaints-sla"],
+  "daily-9": [
+    "/api/cron/investor-drip",
+    "/api/cron/advisor-nudge",
+    "/api/cron/subscription-dunning",
+  ],
+  "daily-9-30": ["/api/cron/enforce-lead-sla"],
+  "daily-10": [
+    "/api/cron/advisor-profile-gate-drip",
+    "/api/cron/welcome-drip",
+    "/api/cron/advisor-onboarding",
+    "/api/cron/abandoned-quiz-drip",
+  ],
+  "daily-11": [
+    "/api/cron/advisor-dunning",
+    "/api/cron/post-enquiry-drip",
+  ],
+  "daily-12": ["/api/cron/abandoned-form-drip"],
+  "daily-15": ["/api/cron/web-vitals-rollup"],
+  "daily-16": ["/api/cron/attribution-rollup"],
+  "daily-23": ["/api/cron/quiz-follow-up"],
+
+  "weekly-sun-0": ["/api/cron/rotate-featured-advisors"],
+  "weekly-mon-3": [
+    "/api/cron/afsl-expiry-monitor",
+    "/api/cron/content-staleness",
+  ],
+  "weekly-mon-7": ["/api/cron/check-affiliate-links"],
+  "weekly-mon-8": [
+    "/api/cron/weekly-newsletter",
+    "/api/cron/weekly-rate-update",
+    "/api/cron/personalized-digest",
+  ],
+  "weekly-mon-9": ["/api/cron/fee-digest"],
+  "weekly-mon-11": ["/api/cron/advisor-dormant-nudge"],
+
+  "monthly-1-3": ["/api/cron/property-suburb-refresh"],
+  "monthly-1-6": ["/api/cron/monthly-affiliate-report"],
+  "monthly-1-8": ["/api/cron/portfolio-monitor"],
+  "monthly-1-9": [
+    "/api/cron/monthly-advisor-reports",
+    "/api/cron/annual-review-reminder",
+  ],
+  "monthly-1-10": ["/api/cron/winback-drip"],
+  "monthly-2-3": ["/api/cron/month-end-close"],
+};

--- a/vercel.json
+++ b/vercel.json
@@ -1,252 +1,47 @@
 {
   "crons": [
-    {
-      "path": "/api/cron/auto-resolve-disputes",
-      "schedule": "0 * * * *"
-    },
-    {
-      "path": "/api/cron/enforce-lead-sla",
-      "schedule": "30 9 * * *"
-    },
-    {
-      "path": "/api/cron/advisor-profile-gate-drip",
-      "schedule": "0 10 * * *"
-    },
-    {
-      "path": "/api/cron/advisor-dunning",
-      "schedule": "0 11 * * *"
-    },
-    {
-      "path": "/api/cron/afsl-expiry-monitor",
-      "schedule": "0 3 * * 1"
-    },
-    {
-      "path": "/api/cron/email-bounce-sweep",
-      "schedule": "0 4 * * *"
-    },
-    {
-      "path": "/api/cron/monthly-advisor-reports",
-      "schedule": "0 9 1 * *"
-    },
-    {
-      "path": "/api/cron/lead-quality-weights",
-      "schedule": "0 2 * * *"
-    },
-    {
-      "path": "/api/cron/investor-drip",
-      "schedule": "0 9 * * *"
-    },
-    {
-      "path": "/api/cron/check-fees",
-      "schedule": "0 6 * * *"
-    },
-    {
-      "path": "/api/cron/expire-deals",
-      "schedule": "0 5 * * *"
-    },
-    {
-      "path": "/api/cron/welcome-drip",
-      "schedule": "0 10 * * *"
-    },
-    {
-      "path": "/api/cron/quiz-follow-up",
-      "schedule": "0 23 * * *"
-    },
-    {
-      "path": "/api/cron/weekly-newsletter",
-      "schedule": "0 8 * * 1"
-    },
-    {
-      "path": "/api/cron/check-affiliate-links",
-      "schedule": "0 7 * * 1"
-    },
-    {
-      "path": "/api/cron/auto-publish",
-      "schedule": "0 0 * * *"
-    },
-    {
-      "path": "/api/cron/content-staleness",
-      "schedule": "0 3 * * 1"
-    },
-    {
-      "path": "/api/cron/marketplace-stats",
-      "schedule": "0 4 * * *"
-    },
-    {
-      "path": "/api/cron/low-balance-alerts",
-      "schedule": "0 2 * * *"
-    },
-    {
-      "path": "/api/cron/retry-webhooks",
-      "schedule": "*/15 * * * *"
-    },
-    {
-      "path": "/api/cron/cleanup",
-      "schedule": "0 1 * * *"
-    },
-    {
-      "path": "/api/cron/advisor-onboarding",
-      "schedule": "0 10 * * *"
-    },
-    {
-      "path": "/api/cron/advisor-quality",
-      "schedule": "0 5 * * *"
-    },
-    {
-      "path": "/api/cron/post-enquiry-drip",
-      "schedule": "0 11 * * *"
-    },
-    {
-      "path": "/api/cron/annual-review-reminder",
-      "schedule": "0 9 1 * *"
-    },
-    {
-      "path": "/api/cron/portfolio-alerts",
-      "schedule": "0 7 * * *"
-    },
-    {
-      "path": "/api/cron/portfolio-monitor",
-      "schedule": "0 8 1 * *"
-    },
-    {
-      "path": "/api/cron/rotate-featured-advisors",
-      "schedule": "0 0 * * 0"
-    },
-    {
-      "path": "/api/cron/refresh-revenue-view",
-      "schedule": "0 2 * * *"
-    },
-    {
-      "path": "/api/cron/advisor-nudge",
-      "schedule": "0 9 * * *"
-    },
-    {
-      "path": "/api/cron/weekly-rate-update",
-      "schedule": "0 8 * * 1"
-    },
-    {
-      "path": "/api/cron/confirm-lead-notify",
-      "schedule": "*/10 * * * *"
-    },
-    {
-      "path": "/api/admin/run-migration",
-      "schedule": "0 */6 * * *"
-    },
-    {
-      "path": "/api/cron/monthly-affiliate-report",
-      "schedule": "0 6 1 * *"
-    },
-    {
-      "path": "/api/cron/fee-digest",
-      "schedule": "0 9 * * 1"
-    },
-    {
-      "path": "/api/cron/personalized-digest",
-      "schedule": "0 8 * * 1"
-    },
-    {
-      "path": "/api/cron/price-drop-alerts",
-      "schedule": "0 7 * * *"
-    },
-    {
-      "path": "/api/cron/verify-review-clients",
-      "schedule": "0 4 * * *"
-    },
-    {
-      "path": "/api/cron/property-suburb-refresh",
-      "schedule": "0 3 1 * *"
-    },
-    {
-      "path": "/api/cron/automation-verdict-rollup",
-      "schedule": "15 * * * *"
-    },
-    {
-      "path": "/api/cron/ab-auto-promote",
-      "schedule": "0 4 * * *"
-    },
-    {
-      "path": "/api/cron/abandoned-quiz-drip",
-      "schedule": "0 10 * * *"
-    },
-    {
-      "path": "/api/cron/advisor-dormant-nudge",
-      "schedule": "0 11 * * 1"
-    },
-    {
-      "path": "/api/cron/winback-drip",
-      "schedule": "0 10 1 * *"
-    },
-    {
-      "path": "/api/cron/referral-payouts",
-      "schedule": "0 3 * * *"
-    },
-    {
-      "path": "/api/cron/embeddings-refresh",
-      "schedule": "30 * * * *"
-    },
-    {
-      "path": "/api/cron/review-sentiment-refresh",
-      "schedule": "0 5 * * *"
-    },
-    {
-      "path": "/api/cron/abandoned-form-drip",
-      "schedule": "0 12 * * *"
-    },
-    {
-      "path": "/api/cron/slo-monitor",
-      "schedule": "*/15 * * * *"
-    },
-    {
-      "path": "/api/cron/gdpr-retention-purge",
-      "schedule": "0 2 * * *"
-    },
-    {
-      "path": "/api/cron/job-queue-worker",
-      "schedule": "*/5 * * * *"
-    },
-    {
-      "path": "/api/cron/warehouse-rollup",
-      "schedule": "30 1 * * *"
-    },
-    {
-      "path": "/api/cron/data-integrity-audit",
-      "schedule": "0 3 * * *"
-    },
-    {
-      "path": "/api/cron/subscription-dunning",
-      "schedule": "0 9 * * *"
-    },
-    {
-      "path": "/api/cron/month-end-close",
-      "schedule": "0 3 2 * *"
-    },
-    {
-      "path": "/api/cron/revenue-reconciliation",
-      "schedule": "0 4 * * *"
-    },
-    {
-      "path": "/api/cron/complaints-sla",
-      "schedule": "0 8 * * *"
-    },
-    {
-      "path": "/api/cron/cron-freshness",
-      "schedule": "20 * * * *"
-    },
-    {
-      "path": "/api/cron/tmd-audit",
-      "schedule": "0 6 * * *"
-    },
-    {
-      "path": "/api/cron/broker-snapshot",
-      "schedule": "5 * * * *"
-    },
-    {
-      "path": "/api/cron/web-vitals-rollup",
-      "schedule": "0 15 * * *"
-    },
-    {
-      "path": "/api/cron/attribution-rollup",
-      "schedule": "0 16 * * *"
-    }
+    { "path": "/api/cron/_dispatch/every-5m", "schedule": "*/5 * * * *" },
+    { "path": "/api/cron/_dispatch/every-10m", "schedule": "*/10 * * * *" },
+    { "path": "/api/cron/_dispatch/every-15m", "schedule": "*/15 * * * *" },
+    { "path": "/api/cron/_dispatch/every-6h", "schedule": "0 */6 * * *" },
+
+    { "path": "/api/cron/_dispatch/hourly-0", "schedule": "0 * * * *" },
+    { "path": "/api/cron/_dispatch/hourly-5", "schedule": "5 * * * *" },
+    { "path": "/api/cron/_dispatch/hourly-15", "schedule": "15 * * * *" },
+    { "path": "/api/cron/_dispatch/hourly-20", "schedule": "20 * * * *" },
+    { "path": "/api/cron/_dispatch/hourly-30", "schedule": "30 * * * *" },
+
+    { "path": "/api/cron/_dispatch/daily-0", "schedule": "0 0 * * *" },
+    { "path": "/api/cron/_dispatch/daily-1", "schedule": "0 1 * * *" },
+    { "path": "/api/cron/_dispatch/daily-1-30", "schedule": "30 1 * * *" },
+    { "path": "/api/cron/_dispatch/daily-2", "schedule": "0 2 * * *" },
+    { "path": "/api/cron/_dispatch/daily-3", "schedule": "0 3 * * *" },
+    { "path": "/api/cron/_dispatch/daily-4", "schedule": "0 4 * * *" },
+    { "path": "/api/cron/_dispatch/daily-5", "schedule": "0 5 * * *" },
+    { "path": "/api/cron/_dispatch/daily-6", "schedule": "0 6 * * *" },
+    { "path": "/api/cron/_dispatch/daily-7", "schedule": "0 7 * * *" },
+    { "path": "/api/cron/_dispatch/daily-8", "schedule": "0 8 * * *" },
+    { "path": "/api/cron/_dispatch/daily-9", "schedule": "0 9 * * *" },
+    { "path": "/api/cron/_dispatch/daily-9-30", "schedule": "30 9 * * *" },
+    { "path": "/api/cron/_dispatch/daily-10", "schedule": "0 10 * * *" },
+    { "path": "/api/cron/_dispatch/daily-11", "schedule": "0 11 * * *" },
+    { "path": "/api/cron/_dispatch/daily-12", "schedule": "0 12 * * *" },
+    { "path": "/api/cron/_dispatch/daily-15", "schedule": "0 15 * * *" },
+    { "path": "/api/cron/_dispatch/daily-16", "schedule": "0 16 * * *" },
+    { "path": "/api/cron/_dispatch/daily-23", "schedule": "0 23 * * *" },
+
+    { "path": "/api/cron/_dispatch/weekly-sun-0", "schedule": "0 0 * * 0" },
+    { "path": "/api/cron/_dispatch/weekly-mon-3", "schedule": "0 3 * * 1" },
+    { "path": "/api/cron/_dispatch/weekly-mon-7", "schedule": "0 7 * * 1" },
+    { "path": "/api/cron/_dispatch/weekly-mon-8", "schedule": "0 8 * * 1" },
+    { "path": "/api/cron/_dispatch/weekly-mon-9", "schedule": "0 9 * * 1" },
+    { "path": "/api/cron/_dispatch/weekly-mon-11", "schedule": "0 11 * * 1" },
+
+    { "path": "/api/cron/_dispatch/monthly-1-3", "schedule": "0 3 1 * *" },
+    { "path": "/api/cron/_dispatch/monthly-1-6", "schedule": "0 6 1 * *" },
+    { "path": "/api/cron/_dispatch/monthly-1-8", "schedule": "0 8 1 * *" },
+    { "path": "/api/cron/_dispatch/monthly-1-9", "schedule": "0 9 1 * *" },
+    { "path": "/api/cron/_dispatch/monthly-1-10", "schedule": "0 10 1 * *" },
+    { "path": "/api/cron/_dispatch/monthly-2-3", "schedule": "0 3 2 * *" }
   ]
 }


### PR DESCRIPTION
Vercel's per-project cron cap is 40. The project had grown to 62 individual cron entries in vercel.json, which made every Pro deploy fail at config validation before any build step ran.

This commit introduces a fan-out dispatcher so the total number of cron schedule entries drops under the cap without refactoring any of the existing handlers:

- app/api/cron/_dispatch/[group]/route.ts — receives the cron hit, authenticates via requireCronAuth() (the existing CRON_SECRET pattern shared across every /api/cron handler), then fans out to each handler path for that group in parallel via Promise.allSettled. Calls are over the loopback with the original Authorization header forwarded through, so each downstream handler keeps its own runtime directive (edge/nodejs), maxDuration, and auth contract. Returns 200 on all-success or 207 if any downstream failed; per- handler status, duration, and body are included in the response for observability.

- lib/cron-groups.ts — static mapping from group slug to the handler paths that share each schedule. Group slug convention encodes the schedule (e.g. daily-4 = "0 4 * * *", weekly-mon-8 = "0 8 * * 1", every-5m = "*/5 * * * *") so the vercel.json entry and the group key are human-matchable.

- vercel.json — 62 entries collapsed to 39 (one per unique schedule). Zero behavioural change: every handler still runs at its original time; they're just invoked indirectly through the dispatcher.

Reversibility: dropping this is a one-file revert of vercel.json back to per-handler entries, plus deletion of the two new files. The underlying handlers are untouched, so nothing about the actual cron work changes.

Verified:
- 39 unique schedule entries confirmed (under the 40 cap).
- All 62 handler paths referenced by cron-groups.ts resolve to existing route.ts files on disk.
- npx tsc --noEmit: clean.