### PR TITLE
fix+feat: pre-launch critical bug fixes, stocks/ETFs/transfer pages, claims, sitemap, freshness cron

### DIFF
--- a/app/advisor/[slug]/page.tsx
+++ b/app/advisor/[slug]/page.tsx
@@ -4,9 +4,10 @@ import { createStaticClient } from "@/lib/supabase/static";
 import type { Professional } from "@/lib/types";
 import type { Metadata } from "next";
 import AdvisorProfileClient from "./AdvisorProfileClient";
-import { absoluteUrl, breadcrumbJsonLd, CURRENT_YEAR } from "@/lib/seo";
+import { absoluteUrl, breadcrumbJsonLd } from "@/lib/seo";
 import { PROFESSIONAL_TYPE_LABELS } from "@/lib/types";
 import ComplianceFooter from "@/components/ComplianceFooter";
+import ClaimListingButton from "@/components/claims/ClaimListingButton";
 
 export const revalidate = 1800;
 
@@ -205,6 +206,11 @@ export default async function AdvisorProfilePage({ params }: { params: Promise<{
         }) }} />
       )}
       <AdvisorProfileClient professional={pro as Professional} similar={similar} reviews={reviews} teamMembers={teamMembers} firm={firm} expertArticles={expertArticles} />
+      <ClaimListingButton
+        claimType="advisor"
+        targetSlug={pro.slug}
+        targetName={pro.name}
+      />
       <div className="container-custom pb-8">
         <ComplianceFooter />
       </div>

--- a/app/api/claim-listing/route.ts
+++ b/app/api/claim-listing/route.ts
@@ -1,0 +1,193 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { isRateLimited } from "@/lib/rate-limit";
+import { isValidEmail } from "@/lib/validate-email";
+import { logger } from "@/lib/logger";
+
+const log = logger("claim-listing");
+
+/**
+ * POST /api/claim-listing
+ *
+ * Captures a claim request from a broker or advisor profile page.
+ * Body:
+ *   {
+ *     claim_type: 'broker' | 'advisor' | 'listing',
+ *     target_slug: string,
+ *     full_name: string,
+ *     email: string,
+ *     company_role?: string,
+ *     phone?: string,
+ *     message?: string
+ *   }
+ */
+
+const ALLOWED_TYPES = ["broker", "advisor", "listing"] as const;
+type ClaimType = (typeof ALLOWED_TYPES)[number];
+
+interface Payload {
+  claim_type: ClaimType;
+  target_slug: string;
+  full_name: string;
+  email: string;
+  company_role: string | null;
+  phone: string | null;
+  message: string | null;
+}
+
+function validate(
+  body: Record<string, unknown>,
+): { ok: true; data: Payload } | { ok: false; error: string } {
+  const claim_type =
+    typeof body.claim_type === "string" ? body.claim_type : "";
+  const target_slug =
+    typeof body.target_slug === "string" ? body.target_slug.trim() : "";
+  const full_name =
+    typeof body.full_name === "string" ? body.full_name.trim() : "";
+  const email = typeof body.email === "string" ? body.email.trim() : "";
+
+  if (!ALLOWED_TYPES.includes(claim_type as ClaimType)) {
+    return { ok: false, error: "Invalid claim_type" };
+  }
+  if (!target_slug || target_slug.length > 200) {
+    return { ok: false, error: "Invalid target_slug" };
+  }
+  if (!full_name || full_name.length < 2 || full_name.length > 120) {
+    return { ok: false, error: "Invalid name" };
+  }
+  if (!isValidEmail(email)) {
+    return { ok: false, error: "Invalid email" };
+  }
+
+  const company_role =
+    typeof body.company_role === "string" && body.company_role.length <= 120
+      ? body.company_role.trim() || null
+      : null;
+  const phone =
+    typeof body.phone === "string" && body.phone.length <= 40
+      ? body.phone.trim() || null
+      : null;
+  const message =
+    typeof body.message === "string" && body.message.length <= 2000
+      ? body.message.trim() || null
+      : null;
+
+  return {
+    ok: true,
+    data: {
+      claim_type: claim_type as ClaimType,
+      target_slug,
+      full_name,
+      email,
+      company_role,
+      phone,
+      message,
+    },
+  };
+}
+
+export async function POST(req: NextRequest) {
+  const ip =
+    req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() || "unknown";
+  if (await isRateLimited(`claim-listing:${ip}`, 3, 10)) {
+    return NextResponse.json(
+      { success: false, error: "Too many requests" },
+      { status: 429 },
+    );
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await req.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json(
+      { success: false, error: "Invalid JSON" },
+      { status: 400 },
+    );
+  }
+
+  const v = validate(body);
+  if (!v.ok) {
+    return NextResponse.json(
+      { success: false, error: v.error },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const supabase = createAdminClient();
+    const { error } = await supabase.from("listing_claims").insert({
+      claim_type: v.data.claim_type,
+      target_slug: v.data.target_slug,
+      full_name: v.data.full_name,
+      email: v.data.email,
+      company_role: v.data.company_role,
+      phone: v.data.phone,
+      message: v.data.message,
+    });
+    if (error) {
+      log.error("insert_failed", { error: error.message });
+      return NextResponse.json(
+        { success: false, error: "Database error" },
+        { status: 500 },
+      );
+    }
+
+    // Fire-and-forget admin notification (no-op if Resend not configured)
+    void notifyAdmin(v.data).catch((err) =>
+      log.warn("admin_notify_failed", { err: String(err) }),
+    );
+
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    log.error("unexpected_error", { err: String(err) });
+    return NextResponse.json(
+      { success: false, error: "Unexpected error" },
+      { status: 500 },
+    );
+  }
+}
+
+async function notifyAdmin(claim: Payload): Promise<void> {
+  const key = process.env.RESEND_API_KEY;
+  const to = process.env.LEADS_NOTIFY_EMAIL;
+  if (!key || !to) return;
+
+  await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${key}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      from: "claims@invest.com.au",
+      to: [to],
+      subject: `New ${claim.claim_type} claim: ${claim.target_slug}`,
+      html: `
+        <h2>New ${claim.claim_type} profile claim</h2>
+        <p><strong>Target:</strong> ${escapeHtml(claim.target_slug)}</p>
+        <p><strong>Name:</strong> ${escapeHtml(claim.full_name)}</p>
+        <p><strong>Email:</strong> ${escapeHtml(claim.email)}</p>
+        ${claim.company_role ? `<p><strong>Role:</strong> ${escapeHtml(claim.company_role)}</p>` : ""}
+        ${claim.phone ? `<p><strong>Phone:</strong> ${escapeHtml(claim.phone)}</p>` : ""}
+        ${claim.message ? `<p><strong>Message:</strong><br>${escapeHtml(claim.message).replace(/\n/g, "<br>")}</p>` : ""}
+        <hr>
+        <p><small>Review in /admin/listing-claims.</small></p>
+      `,
+    }),
+  });
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(
+    /[&<>"']/g,
+    (ch) =>
+      ({
+        "&": "&amp;",
+        "<": "&lt;",
+        ">": "&gt;",
+        '"': "&quot;",
+        "'": "&#39;",
+      })[ch] || ch,
+  );
+}

--- a/app/api/cron/content-freshness/route.ts
+++ b/app/api/cron/content-freshness/route.ts
@@ -1,0 +1,119 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { requireCronAuth } from "@/lib/cron-auth";
+import { logger } from "@/lib/logger";
+
+const log = logger("cron-content-freshness");
+
+export const runtime = "nodejs";
+export const maxDuration = 60;
+export const dynamic = "force-dynamic";
+
+/**
+ * Cron: Content freshness checker
+ *
+ * Weekly. Finds published articles whose updated_at is older than
+ * six months, inserts each into content_calendar with
+ * priority='review_needed' (idempotent on article_id) so the
+ * editorial team has a ranked queue of freshness work.
+ *
+ * A digest email is fired via Resend if RESEND_API_KEY +
+ * LEADS_NOTIFY_EMAIL are configured. Otherwise the queue itself is
+ * the signal.
+ */
+
+const STALE_DAYS = 180;
+
+export async function GET(req: NextRequest) {
+  const unauth = requireCronAuth(req);
+  if (unauth) return unauth;
+
+  const supabase = createAdminClient();
+  const cutoff = new Date(
+    Date.now() - STALE_DAYS * 24 * 60 * 60 * 1000,
+  ).toISOString();
+
+  const { data: stale, error } = await supabase
+    .from("articles")
+    .select("id, slug, title, category, updated_at")
+    .eq("status", "published")
+    .lt("updated_at", cutoff)
+    .order("updated_at", { ascending: true })
+    .limit(200);
+
+  if (error) {
+    log.error("select_failed", { error: error.message });
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  const rows = stale ?? [];
+  let queued = 0;
+
+  for (const a of rows as Array<{
+    id: number;
+    slug: string;
+    title: string;
+    category: string | null;
+    updated_at: string | null;
+  }>) {
+    // Skip if there's already an open review task for this article.
+    const { data: existing } = await supabase
+      .from("content_calendar")
+      .select("id, status")
+      .eq("article_id", a.id)
+      .in("status", ["planned", "in_progress"])
+      .limit(1);
+    if (existing && existing.length > 0) continue;
+
+    const { error: insertErr } = await supabase.from("content_calendar").insert({
+      title: `[Refresh] ${a.title}`,
+      article_id: a.id,
+      category: a.category,
+      priority: "review_needed",
+      article_type: "refresh",
+      status: "planned",
+      notes: `Auto-queued by content-freshness cron. Last updated: ${a.updated_at}`,
+    });
+    if (!insertErr) queued++;
+  }
+
+  // Fire-and-forget digest email
+  if (queued > 0) {
+    void notifyAdmin(queued).catch((err) =>
+      log.warn("admin_notify_failed", { err: String(err) }),
+    );
+  }
+
+  log.info("freshness_run_complete", { stale: rows.length, queued });
+
+  return NextResponse.json({
+    ok: true,
+    stale_found: rows.length,
+    newly_queued: queued,
+  });
+}
+
+async function notifyAdmin(queued: number): Promise<void> {
+  const key = process.env.RESEND_API_KEY;
+  const to = process.env.LEADS_NOTIFY_EMAIL;
+  if (!key || !to) return;
+
+  await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${key}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      from: "cron@invest.com.au",
+      to: [to],
+      subject: `Content freshness — ${queued} articles queued for review`,
+      html: `
+        <h2>Content freshness digest</h2>
+        <p>${queued} articles older than ${STALE_DAYS} days have been
+        added to the content_calendar review queue.</p>
+        <p>Review in <a href="https://invest.com.au/admin/content-calendar">/admin/content-calendar</a>.</p>
+      `,
+    }),
+  });
+}

--- a/app/article/[slug]/page.tsx
+++ b/app/article/[slug]/page.tsx
@@ -8,6 +8,7 @@ import type { Article, Broker } from "@/lib/types";
 import { notFound } from "next/navigation";
 import { Suspense } from "react";
 import ArticleDetailClient from "./ArticleDetailClient";
+import ArticleBrokerTable from "@/components/ArticleBrokerTable";
 import IntlBrokersEnhanced from "@/components/IntlBrokersEnhanced";
 import ArticleSidebar from "@/components/ArticleSidebar";
 import SponsoredBrokerWidget from "@/components/SponsoredBrokerWidget";
@@ -337,6 +338,17 @@ export default async function ArticlePage({
               changelog={a.changelog ?? undefined}
               showMethodologyLink
             />
+
+            {/* Top-of-article broker compare — every article becomes an
+                affiliate revenue surface. Vertical comes from article
+                category; falls back to '*' for generic articles. */}
+            <div className="mt-6">
+              <ArticleBrokerTable
+                vertical={a.category ?? "*"}
+                maxBrokers={3}
+                heading="Top platforms for this topic"
+              />
+            </div>
           </div>
         </div>
       </section>

--- a/app/broker/[slug]/page.tsx
+++ b/app/broker/[slug]/page.tsx
@@ -21,6 +21,7 @@ import { scoreBrokerSimilarity } from "@/lib/internal-links";
 import QASection from "@/components/QASection";
 import AskQuestionForm from "@/components/AskQuestionForm";
 import ComplianceFooter from "@/components/ComplianceFooter";
+import ClaimListingButton from "@/components/claims/ClaimListingButton";
 
 export const revalidate = 3600; // ISR: revalidate every hour
 
@@ -334,6 +335,11 @@ async function BrokerQASection({ brokerSlug, brokerName, pageUrl }: { brokerSlug
         brokerName={brokerName}
         pageType="broker"
         pageSlug={brokerSlug}
+      />
+      <ClaimListingButton
+        claimType="broker"
+        targetSlug={brokerSlug}
+        targetName={brokerName}
       />
       <div className="container-custom pb-8">
         <ComplianceFooter />

--- a/app/how-to/transfer-from/[broker_slug]/page.tsx
+++ b/app/how-to/transfer-from/[broker_slug]/page.tsx
@@ -1,0 +1,379 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
+import { createAdminClient } from "@/lib/supabase/admin";
+import Icon from "@/components/Icon";
+
+export const revalidate = 3600;
+
+interface Step {
+  title?: string;
+  body?: string;
+  text?: string;
+  [key: string]: unknown;
+}
+
+interface GuideRow {
+  id: number;
+  broker_slug: string;
+  transfer_type: string | null;
+  steps: Step[] | null;
+  chess_transfer_fee: number | null;
+  supports_in_specie: boolean | null;
+  in_specie_notes: string | null;
+  special_requirements: string[] | null;
+  estimated_timeline_days: number | null;
+  exit_fees: string | null;
+  helpful_links: Array<{ label: string; url: string }> | null;
+}
+
+interface BrokerRow {
+  slug: string;
+  name: string;
+  logo_url: string | null;
+  rating: number | string | null;
+  tagline: string | null;
+  asx_fee: string | null;
+  chess_sponsored: boolean | null;
+  smsf_support: boolean | null;
+}
+
+async function fetchGuide(brokerSlug: string): Promise<GuideRow | null> {
+  try {
+    const supabase = createAdminClient();
+    const { data } = await supabase
+      .from("broker_transfer_guides")
+      .select("*")
+      .eq("broker_slug", brokerSlug)
+      .maybeSingle();
+    return (data as GuideRow | null) || null;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchBroker(slug: string): Promise<BrokerRow | null> {
+  try {
+    const supabase = createAdminClient();
+    const { data } = await supabase
+      .from("brokers")
+      .select("slug, name, logo_url, rating, tagline, asx_fee, chess_sponsored, smsf_support")
+      .eq("slug", slug)
+      .maybeSingle();
+    return (data as BrokerRow | null) || null;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchTopBrokers(excludeSlug: string): Promise<BrokerRow[]> {
+  try {
+    const supabase = createAdminClient();
+    const { data } = await supabase
+      .from("brokers")
+      .select("slug, name, logo_url, rating, tagline, asx_fee, chess_sponsored, smsf_support")
+      .eq("status", "active")
+      .eq("is_crypto", false)
+      .neq("slug", excludeSlug)
+      .order("rating", { ascending: false })
+      .limit(5);
+    return (data as BrokerRow[] | null) || [];
+  } catch {
+    return [];
+  }
+}
+
+export async function generateStaticParams() {
+  try {
+    const supabase = createAdminClient();
+    const { data } = await supabase
+      .from("broker_transfer_guides")
+      .select("broker_slug");
+    return (data || []).map((row: { broker_slug: string }) => ({
+      broker_slug: row.broker_slug,
+    }));
+  } catch {
+    return [];
+  }
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ broker_slug: string }>;
+}): Promise<Metadata> {
+  const { broker_slug } = await params;
+  const broker = await fetchBroker(broker_slug);
+  if (!broker) return { title: `How to transfer (${CURRENT_YEAR})` };
+  return {
+    title: `How to Transfer From ${broker.name} (${CURRENT_YEAR}) — Step-by-Step Guide`,
+    description: `Close your ${broker.name} account or transfer your ASX shares to another Australian broker. Step-by-step walkthrough, CHESS transfer fee, in-specie support and realistic timelines.`,
+    alternates: {
+      canonical: `${SITE_URL}/how-to/transfer-from/${broker_slug}`,
+    },
+  };
+}
+
+function formatFee(cents: number | null): string {
+  if (cents == null) return "Contact broker";
+  if (cents === 0) return "Free";
+  return (cents / 100).toLocaleString("en-AU", {
+    style: "currency",
+    currency: "AUD",
+    maximumFractionDigits: 0,
+  });
+}
+
+function formatRating(value: number | string | null): string {
+  if (value == null) return "—";
+  const num = typeof value === "string" ? parseFloat(value) : value;
+  if (!Number.isFinite(num)) return "—";
+  return `${num.toFixed(1)} / 5`;
+}
+
+export default async function TransferFromPage({
+  params,
+}: {
+  params: Promise<{ broker_slug: string }>;
+}) {
+  const { broker_slug } = await params;
+  const [guide, broker] = await Promise.all([
+    fetchGuide(broker_slug),
+    fetchBroker(broker_slug),
+  ]);
+  if (!guide || !broker) notFound();
+
+  const topBrokers = await fetchTopBrokers(broker_slug);
+
+  const breadcrumb = breadcrumbJsonLd([
+    { name: "Home", url: `${SITE_URL}/` },
+    { name: "How to", url: `${SITE_URL}/how-to` },
+    { name: "Transfer from", url: `${SITE_URL}/how-to/transfer-from` },
+    { name: broker.name },
+  ]);
+
+  const steps = Array.isArray(guide.steps) ? guide.steps : [];
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
+      />
+      <div className="bg-slate-50 min-h-screen">
+        <section className="bg-white border-b border-slate-200 py-8 md:py-10">
+          <div className="container-custom">
+            <nav
+              className="flex items-center gap-1.5 text-xs text-slate-500 mb-5"
+              aria-label="Breadcrumb"
+            >
+              <Link href="/" className="hover:text-slate-900">Home</Link>
+              <span className="text-slate-300">/</span>
+              <Link href="/how-to" className="hover:text-slate-900">How to</Link>
+              <span className="text-slate-300">/</span>
+              <Link
+                href="/how-to/transfer-from"
+                className="hover:text-slate-900"
+              >
+                Transfer from
+              </Link>
+              <span className="text-slate-300">/</span>
+              <span className="text-slate-900 font-medium">{broker.name}</span>
+            </nav>
+            <h1 className="text-2xl md:text-3xl lg:text-4xl font-extrabold text-slate-900 leading-tight">
+              How to transfer from {broker.name}
+            </h1>
+            <p className="text-sm md:text-base text-slate-600 leading-relaxed max-w-3xl mt-3">
+              Step-by-step guide to closing your {broker.name} account or
+              transferring ASX holdings to a better broker. Updated for {CURRENT_YEAR}.
+            </p>
+          </div>
+        </section>
+
+        <section className="py-8 md:py-10">
+          <div className="container-custom grid grid-cols-1 lg:grid-cols-3 gap-6">
+            {/* Main */}
+            <div className="lg:col-span-2 space-y-6">
+              <div className="bg-white border border-slate-200 rounded-xl p-6">
+                <h2 className="text-lg font-extrabold text-slate-900 mb-4">
+                  At-a-glance
+                </h2>
+                <dl className="grid grid-cols-2 md:grid-cols-4 gap-3">
+                  <Metric
+                    label="CHESS transfer fee"
+                    value={formatFee(guide.chess_transfer_fee)}
+                  />
+                  <Metric
+                    label="In-specie"
+                    value={guide.supports_in_specie ? "Supported" : "Not supported"}
+                  />
+                  <Metric
+                    label="Timeline"
+                    value={
+                      guide.estimated_timeline_days
+                        ? `${guide.estimated_timeline_days} days`
+                        : "Varies"
+                    }
+                  />
+                  <Metric
+                    label="Exit fees"
+                    value={guide.exit_fees ?? "None disclosed"}
+                  />
+                </dl>
+              </div>
+
+              {steps.length > 0 && (
+                <div className="bg-white border border-slate-200 rounded-xl p-6">
+                  <h2 className="text-lg font-extrabold text-slate-900 mb-4">
+                    Step by step
+                  </h2>
+                  <ol className="space-y-4">
+                    {steps.map((s, i) => (
+                      <li key={i} className="flex gap-3">
+                        <span className="shrink-0 w-7 h-7 rounded-full bg-amber-100 text-amber-800 text-xs font-extrabold flex items-center justify-center">
+                          {i + 1}
+                        </span>
+                        <div>
+                          {s.title && (
+                            <p className="font-bold text-slate-900 text-sm mb-1">
+                              {s.title}
+                            </p>
+                          )}
+                          <p className="text-sm text-slate-700 leading-relaxed whitespace-pre-line">
+                            {s.body ?? s.text ?? ""}
+                          </p>
+                        </div>
+                      </li>
+                    ))}
+                  </ol>
+                </div>
+              )}
+
+              {guide.supports_in_specie && guide.in_specie_notes && (
+                <div className="bg-white border border-slate-200 rounded-xl p-6">
+                  <h2 className="text-lg font-extrabold text-slate-900 mb-2">
+                    In-specie transfer notes
+                  </h2>
+                  <p className="text-sm text-slate-700 leading-relaxed whitespace-pre-line">
+                    {guide.in_specie_notes}
+                  </p>
+                </div>
+              )}
+
+              {guide.special_requirements &&
+                guide.special_requirements.length > 0 && (
+                  <div className="bg-amber-50 border border-amber-200 rounded-xl p-5">
+                    <h3 className="text-xs font-extrabold uppercase tracking-wide text-amber-800 mb-2">
+                      Special requirements
+                    </h3>
+                    <ul className="list-disc pl-5 text-sm text-amber-900 space-y-1">
+                      {guide.special_requirements.map((req, i) => (
+                        <li key={i}>{req}</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+
+              {guide.helpful_links && guide.helpful_links.length > 0 && (
+                <div className="bg-white border border-slate-200 rounded-xl p-6">
+                  <h2 className="text-lg font-extrabold text-slate-900 mb-3">
+                    Helpful links
+                  </h2>
+                  <ul className="space-y-2 text-sm">
+                    {guide.helpful_links.map((l, i) => (
+                      <li key={i}>
+                        <a
+                          href={l.url}
+                          target="_blank"
+                          rel="noreferrer noopener"
+                          className="text-amber-700 hover:underline inline-flex items-center gap-1"
+                        >
+                          {l.label}
+                          <Icon name="external-link" size={12} />
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
+
+            {/* Sidebar */}
+            <aside className="space-y-4">
+              <div className="bg-white border border-slate-200 rounded-xl p-5">
+                <h2 className="text-base font-extrabold text-slate-900 mb-3">
+                  Best brokers to switch to
+                </h2>
+                {topBrokers.length === 0 ? (
+                  <p className="text-sm text-slate-500">
+                    Compare alternatives.
+                  </p>
+                ) : (
+                  <ul className="space-y-3">
+                    {topBrokers.map((b) => (
+                      <li key={b.slug} className="border border-slate-100 rounded-lg p-3">
+                        <p className="font-bold text-sm text-slate-900">
+                          {b.name}
+                        </p>
+                        <p className="text-[11px] text-slate-500">
+                          Rating: {formatRating(b.rating)}
+                          {b.chess_sponsored ? " · CHESS" : ""}
+                          {b.smsf_support ? " · SMSF" : ""}
+                        </p>
+                        {b.asx_fee && (
+                          <p className="text-[11px] text-slate-600 mt-1">
+                            ASX fee: <strong>{b.asx_fee}</strong>
+                          </p>
+                        )}
+                        <Link
+                          href={`/broker/${b.slug}`}
+                          className="inline-flex items-center gap-1 text-xs font-bold text-amber-600 hover:underline mt-2"
+                        >
+                          Review
+                          <Icon name="arrow-right" size={12} />
+                        </Link>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+                <Link
+                  href="/compare?category=shares"
+                  className="mt-4 inline-flex items-center justify-center gap-2 w-full bg-amber-500 hover:bg-amber-600 text-white font-bold text-sm px-4 py-2.5 rounded-lg"
+                >
+                  Compare all brokers
+                  <Icon name="arrow-right" size={14} />
+                </Link>
+              </div>
+            </aside>
+          </div>
+        </section>
+
+        <section className="py-6 bg-white border-t border-slate-200">
+          <div className="container-custom max-w-3xl">
+            <p className="text-[11px] text-slate-500 leading-relaxed">
+              Transfer fees, in-specie support, and timelines are published by
+              {" "}{broker.name} and subject to change. Always confirm current
+              fees on the broker&rsquo;s official site before initiating. This
+              page is general information only, not personal financial product
+              advice.
+            </p>
+          </div>
+        </section>
+      </div>
+    </>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="border border-slate-200 rounded-lg p-3 bg-slate-50">
+      <dt className="text-[10px] font-bold uppercase text-slate-500 tracking-wide">
+        {label}
+      </dt>
+      <dd className="text-sm md:text-base font-extrabold text-slate-900 mt-0.5">
+        {value}
+      </dd>
+    </div>
+  );
+}

--- a/app/how-to/transfer-from/page.tsx
+++ b/app/how-to/transfer-from/page.tsx
@@ -1,0 +1,172 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
+import { createAdminClient } from "@/lib/supabase/admin";
+import Icon from "@/components/Icon";
+
+export const revalidate = 3600;
+
+export const metadata: Metadata = {
+  title: `How to Transfer From Your Current Broker (${CURRENT_YEAR}) — Step-by-Step Guides`,
+  description:
+    "Step-by-step guides for transferring shares, ETFs and cash out of every major Australian broker. Chess transfer fees, in-specie support, exit fees and realistic timelines.",
+  alternates: { canonical: `${SITE_URL}/how-to/transfer-from` },
+};
+
+interface GuideRow {
+  id: number;
+  broker_slug: string;
+  transfer_type: string | null;
+  chess_transfer_fee: number | null;
+  supports_in_specie: boolean | null;
+  estimated_timeline_days: number | null;
+}
+
+interface BrokerRow {
+  slug: string;
+  name: string;
+  logo_url: string | null;
+}
+
+async function fetchGuides(): Promise<GuideRow[]> {
+  try {
+    const supabase = createAdminClient();
+    const { data } = await supabase
+      .from("broker_transfer_guides")
+      .select(
+        "id, broker_slug, transfer_type, chess_transfer_fee, supports_in_specie, estimated_timeline_days",
+      )
+      .order("broker_slug", { ascending: true });
+    return (data as GuideRow[] | null) || [];
+  } catch {
+    return [];
+  }
+}
+
+async function fetchBrokers(slugs: string[]): Promise<Record<string, BrokerRow>> {
+  if (slugs.length === 0) return {};
+  try {
+    const supabase = createAdminClient();
+    const { data } = await supabase
+      .from("brokers")
+      .select("slug, name, logo_url")
+      .in("slug", slugs);
+    const map: Record<string, BrokerRow> = {};
+    for (const b of (data || []) as BrokerRow[]) map[b.slug] = b;
+    return map;
+  } catch {
+    return {};
+  }
+}
+
+function formatFee(cents: number | null): string {
+  if (cents == null) return "—";
+  if (cents === 0) return "Free";
+  return (cents / 100).toLocaleString("en-AU", {
+    style: "currency",
+    currency: "AUD",
+    maximumFractionDigits: 0,
+  });
+}
+
+export default async function TransferFromIndex() {
+  const guides = await fetchGuides();
+  const brokerMap = await fetchBrokers(guides.map((g) => g.broker_slug));
+
+  const breadcrumb = breadcrumbJsonLd([
+    { name: "Home", url: `${SITE_URL}/` },
+    { name: "How to", url: `${SITE_URL}/how-to` },
+    { name: "Transfer from" },
+  ]);
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
+      />
+      <div className="bg-white min-h-screen">
+        <section className="bg-slate-900 text-white py-10 md:py-14">
+          <div className="container-custom">
+            <nav
+              className="flex items-center gap-1.5 text-xs text-slate-400 mb-5"
+              aria-label="Breadcrumb"
+            >
+              <Link href="/" className="hover:text-white">Home</Link>
+              <span className="text-slate-600">/</span>
+              <Link href="/how-to" className="hover:text-white">How to</Link>
+              <span className="text-slate-600">/</span>
+              <span className="text-white font-medium">Transfer from</span>
+            </nav>
+            <h1 className="text-3xl md:text-4xl lg:text-5xl font-extrabold leading-tight mb-3 max-w-3xl">
+              Transfer your shares &amp; cash to a better broker
+            </h1>
+            <p className="text-base md:text-lg text-slate-300 leading-relaxed max-w-3xl">
+              Step-by-step guides for every major Australian broker — CHESS transfer fees, in-specie support, realistic timelines, and the paperwork you&rsquo;ll need.
+            </p>
+          </div>
+        </section>
+
+        <section className="py-10 bg-white">
+          <div className="container-custom max-w-5xl">
+            {guides.length === 0 ? (
+              <div className="py-20 text-center">
+                <p className="text-sm text-slate-500">
+                  No transfer guides published yet. Check back soon.
+                </p>
+              </div>
+            ) : (
+              <div className="overflow-x-auto rounded-xl border border-slate-200">
+                <table className="w-full text-sm">
+                  <thead className="bg-slate-50 border-b border-slate-200">
+                    <tr>
+                      <th className="text-left px-4 py-3 font-bold text-slate-700">From</th>
+                      <th className="text-left px-4 py-3 font-bold text-slate-700 hidden md:table-cell">CHESS transfer fee</th>
+                      <th className="text-left px-4 py-3 font-bold text-slate-700 hidden md:table-cell">In-specie</th>
+                      <th className="text-left px-4 py-3 font-bold text-slate-700 hidden lg:table-cell">Timeline</th>
+                      <th className="px-4 py-3"></th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-slate-100">
+                    {guides.map((g) => {
+                      const broker = brokerMap[g.broker_slug];
+                      return (
+                        <tr key={g.id} className="hover:bg-slate-50">
+                          <td className="px-4 py-3">
+                            <p className="font-bold text-slate-900">
+                              {broker?.name ?? g.broker_slug}
+                            </p>
+                          </td>
+                          <td className="px-4 py-3 text-slate-700 tabular-nums hidden md:table-cell">
+                            {formatFee(g.chess_transfer_fee)}
+                          </td>
+                          <td className="px-4 py-3 text-slate-700 hidden md:table-cell">
+                            {g.supports_in_specie ? "Yes" : "No"}
+                          </td>
+                          <td className="px-4 py-3 text-slate-700 hidden lg:table-cell">
+                            {g.estimated_timeline_days
+                              ? `${g.estimated_timeline_days} days`
+                              : "—"}
+                          </td>
+                          <td className="px-4 py-3 text-right whitespace-nowrap">
+                            <Link
+                              href={`/how-to/transfer-from/${g.broker_slug}`}
+                              className="text-amber-600 hover:underline text-xs font-bold inline-flex items-center gap-1"
+                            >
+                              View guide
+                              <Icon name="arrow-right" size={12} />
+                            </Link>
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        </section>
+      </div>
+    </>
+  );
+}

--- a/app/invest/[slug]/etfs/page.tsx
+++ b/app/invest/[slug]/etfs/page.tsx
@@ -1,0 +1,245 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
+import { createAdminClient } from "@/lib/supabase/admin";
+import Icon from "@/components/Icon";
+
+export const revalidate = 1800;
+
+interface EtfRow {
+  id: number;
+  ticker: string;
+  name: string;
+  issuer: string | null;
+  mer_pct: number | string | null;
+  underlying_exposure: string | null;
+  domicile: string | null;
+  distribution_frequency: string | null;
+  blurb: string | null;
+  display_order: number | null;
+  status: string | null;
+}
+
+interface SectorRow {
+  slug: string;
+  display_name: string;
+}
+
+async function fetchSector(slug: string): Promise<SectorRow | null> {
+  try {
+    const supabase = createAdminClient();
+    const { data } = await supabase
+      .from("commodity_sectors")
+      .select("slug, display_name")
+      .eq("slug", slug)
+      .eq("status", "active")
+      .maybeSingle();
+    return (data as SectorRow | null) || null;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchEtfs(sectorSlug: string): Promise<EtfRow[]> {
+  try {
+    const supabase = createAdminClient();
+    const { data } = await supabase
+      .from("commodity_etfs")
+      .select("*")
+      .eq("sector_slug", sectorSlug)
+      .eq("status", "active")
+      .order("display_order", { ascending: true });
+    return (data as EtfRow[] | null) || [];
+  } catch {
+    return [];
+  }
+}
+
+export async function generateStaticParams() {
+  try {
+    const supabase = createAdminClient();
+    const { data } = await supabase
+      .from("commodity_sectors")
+      .select("slug")
+      .eq("status", "active");
+    return (data || []).map((row: { slug: string }) => ({ slug: row.slug }));
+  } catch {
+    return [];
+  }
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const sector = await fetchSector(slug);
+  if (!sector) return { title: `Sector ETFs (${CURRENT_YEAR})` };
+  return {
+    title: `Best ${sector.display_name} ETFs in Australia (${CURRENT_YEAR})`,
+    description: `Compare ${sector.display_name.toLowerCase()} ETFs available on the ASX and via Australian brokers — MER, underlying exposure, domicile and distribution frequency.`,
+    alternates: { canonical: `${SITE_URL}/invest/${slug}/etfs` },
+    openGraph: {
+      title: `Best ${sector.display_name} ETFs in Australia (${CURRENT_YEAR})`,
+      url: `${SITE_URL}/invest/${slug}/etfs`,
+    },
+  };
+}
+
+function formatMer(value: number | string | null): string {
+  if (value == null) return "—";
+  const num = typeof value === "string" ? parseFloat(value) : value;
+  if (!Number.isFinite(num)) return "—";
+  return `${num.toFixed(2)}%`;
+}
+
+export default async function SectorEtfsPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const sector = await fetchSector(slug);
+  if (!sector) notFound();
+  const etfs = await fetchEtfs(slug);
+
+  const breadcrumb = breadcrumbJsonLd([
+    { name: "Home", url: `${SITE_URL}/` },
+    { name: "Invest", url: `${SITE_URL}/invest` },
+    { name: sector.display_name, url: `${SITE_URL}/invest/${slug}` },
+    { name: "ETFs" },
+  ]);
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
+      />
+      <div className="bg-white min-h-screen">
+        <section className="bg-slate-900 text-white py-10 md:py-12">
+          <div className="container-custom">
+            <nav
+              className="flex items-center gap-1.5 text-xs text-slate-400 mb-5"
+              aria-label="Breadcrumb"
+            >
+              <Link href="/" className="hover:text-white">Home</Link>
+              <span className="text-slate-600">/</span>
+              <Link href="/invest" className="hover:text-white">Invest</Link>
+              <span className="text-slate-600">/</span>
+              <Link href={`/invest/${slug}`} className="hover:text-white">
+                {sector.display_name}
+              </Link>
+              <span className="text-slate-600">/</span>
+              <span className="text-white font-medium">ETFs</span>
+            </nav>
+            <h1 className="text-2xl md:text-3xl lg:text-4xl font-extrabold leading-tight mb-3">
+              Best {sector.display_name} ETFs in Australia
+            </h1>
+            <p className="text-sm md:text-base text-slate-300 max-w-3xl leading-relaxed">
+              ETF wrappers give you diversified {sector.display_name.toLowerCase()} exposure in a single ticket. Compare MER, underlying index, domicile and distribution frequency across the ASX and Australian-accessible funds.
+            </p>
+          </div>
+        </section>
+
+        <section className="py-8 md:py-10 bg-white">
+          <div className="container-custom">
+            {etfs.length === 0 ? (
+              <div className="py-16 text-center">
+                <p className="text-sm text-slate-500">
+                  No {sector.display_name.toLowerCase()} ETFs listed yet. Check back soon.
+                </p>
+              </div>
+            ) : (
+              <div className="overflow-x-auto rounded-xl border border-slate-200">
+                <table className="w-full text-sm">
+                  <thead className="bg-slate-50 border-b border-slate-200">
+                    <tr>
+                      <th className="text-left px-4 py-3 font-bold text-slate-700">Ticker</th>
+                      <th className="text-left px-4 py-3 font-bold text-slate-700">Name</th>
+                      <th className="text-left px-4 py-3 font-bold text-slate-700 hidden md:table-cell">Issuer</th>
+                      <th className="text-left px-4 py-3 font-bold text-slate-700">MER</th>
+                      <th className="text-left px-4 py-3 font-bold text-slate-700 hidden lg:table-cell">Exposure</th>
+                      <th className="text-left px-4 py-3 font-bold text-slate-700 hidden xl:table-cell">Dom.</th>
+                      <th className="text-left px-4 py-3 font-bold text-slate-700 hidden xl:table-cell">Freq.</th>
+                      <th className="px-4 py-3"></th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-slate-100">
+                    {etfs.map((e) => (
+                      <tr key={e.id} className="hover:bg-slate-50">
+                        <td className="px-4 py-3 font-extrabold text-amber-700">
+                          {e.ticker}
+                        </td>
+                        <td className="px-4 py-3">
+                          <div className="font-bold text-slate-900">{e.name}</div>
+                          {e.blurb && (
+                            <p className="text-xs text-slate-500 mt-0.5 line-clamp-2 max-w-md">
+                              {e.blurb}
+                            </p>
+                          )}
+                        </td>
+                        <td className="px-4 py-3 text-slate-700 hidden md:table-cell">
+                          {e.issuer ?? "—"}
+                        </td>
+                        <td className="px-4 py-3 font-bold text-slate-900 tabular-nums">
+                          {formatMer(e.mer_pct)}
+                        </td>
+                        <td className="px-4 py-3 text-xs text-slate-600 hidden lg:table-cell line-clamp-2 max-w-xs">
+                          {e.underlying_exposure ?? "—"}
+                        </td>
+                        <td className="px-4 py-3 text-xs text-slate-600 hidden xl:table-cell">
+                          {e.domicile ?? "—"}
+                        </td>
+                        <td className="px-4 py-3 text-xs text-slate-600 hidden xl:table-cell">
+                          {e.distribution_frequency ?? "—"}
+                        </td>
+                        <td className="px-4 py-3 whitespace-nowrap text-right">
+                          <Link
+                            href="/compare?category=shares"
+                            className="inline-flex items-center gap-1 text-xs font-bold text-amber-600 hover:underline"
+                          >
+                            Buy via broker
+                            <Icon name="arrow-right" size={12} />
+                          </Link>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        </section>
+
+        <section className="py-10 bg-slate-50 border-y border-slate-200">
+          <div className="container-custom max-w-3xl text-center">
+            <h2 className="text-xl md:text-2xl font-extrabold text-slate-900 mb-2">
+              Prefer direct equity?
+            </h2>
+            <p className="text-sm text-slate-600 mb-5">
+              Compare individual ASX-listed {sector.display_name.toLowerCase()} companies side by side.
+            </p>
+            <Link
+              href={`/invest/${slug}/stocks`}
+              className="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-600 text-white font-bold text-sm px-5 py-2.5 rounded-lg"
+            >
+              View {sector.display_name} stocks
+              <Icon name="arrow-right" size={14} />
+            </Link>
+          </div>
+        </section>
+
+        <section className="py-8 bg-white">
+          <div className="container-custom max-w-3xl">
+            <p className="text-[11px] text-slate-500 leading-relaxed">
+              <strong>General information only.</strong> MER values are editorial snapshots sourced from each issuer&rsquo;s PDS. ETF prices and distributions move intraday — always check the current PDS before investing. This page is not personal financial product advice.
+            </p>
+          </div>
+        </section>
+      </div>
+    </>
+  );
+}

--- a/app/invest/[slug]/stocks/[ticker]/page.tsx
+++ b/app/invest/[slug]/stocks/[ticker]/page.tsx
@@ -1,0 +1,426 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
+import { createAdminClient } from "@/lib/supabase/admin";
+import Icon from "@/components/Icon";
+
+export const revalidate = 3600;
+
+interface StockRow {
+  id: number;
+  sector_slug: string;
+  ticker: string;
+  company_name: string;
+  market_cap_bucket: string | null;
+  dividend_yield_pct: number | string | null;
+  pe_ratio: number | string | null;
+  blurb: string | null;
+  primary_exposure: string | null;
+  included_in_indices: string[] | null;
+  foreign_ownership_risk: string | null;
+  last_reviewed_at: string | null;
+  status: string | null;
+}
+
+interface SectorRow {
+  slug: string;
+  display_name: string;
+}
+
+interface BrokerRow {
+  slug: string;
+  name: string;
+  logo_url: string | null;
+  asx_fee: string | null;
+  rating: number | string | null;
+  chess_sponsored: boolean | null;
+  tagline: string | null;
+  affiliate_url: string | null;
+}
+
+async function fetchStock(sectorSlug: string, ticker: string): Promise<StockRow | null> {
+  try {
+    const supabase = createAdminClient();
+    const { data } = await supabase
+      .from("commodity_stocks")
+      .select("*")
+      .eq("sector_slug", sectorSlug)
+      .ilike("ticker", ticker)
+      .eq("status", "active")
+      .maybeSingle();
+    return (data as StockRow | null) || null;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchSector(slug: string): Promise<SectorRow | null> {
+  try {
+    const supabase = createAdminClient();
+    const { data } = await supabase
+      .from("commodity_sectors")
+      .select("slug, display_name")
+      .eq("slug", slug)
+      .eq("status", "active")
+      .maybeSingle();
+    return (data as SectorRow | null) || null;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchRelated(sectorSlug: string, excludeTicker: string): Promise<StockRow[]> {
+  try {
+    const supabase = createAdminClient();
+    const { data } = await supabase
+      .from("commodity_stocks")
+      .select("id, sector_slug, ticker, company_name, market_cap_bucket, dividend_yield_pct, pe_ratio, blurb, primary_exposure, foreign_ownership_risk, last_reviewed_at, status, included_in_indices")
+      .eq("sector_slug", sectorSlug)
+      .eq("status", "active")
+      .neq("ticker", excludeTicker.toUpperCase())
+      .order("display_order", { ascending: true })
+      .limit(3);
+    return (data as StockRow[] | null) || [];
+  } catch {
+    return [];
+  }
+}
+
+async function fetchTopBrokers(): Promise<BrokerRow[]> {
+  try {
+    const supabase = createAdminClient();
+    const { data } = await supabase
+      .from("brokers")
+      .select("slug, name, logo_url, asx_fee, rating, chess_sponsored, tagline, affiliate_url")
+      .eq("status", "active")
+      .eq("is_crypto", false)
+      .order("rating", { ascending: false })
+      .limit(3);
+    return (data as BrokerRow[] | null) || [];
+  } catch {
+    return [];
+  }
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string; ticker: string }>;
+}): Promise<Metadata> {
+  const { slug, ticker } = await params;
+  const stock = await fetchStock(slug, ticker);
+  if (!stock) return { title: `ASX Stock (${CURRENT_YEAR})` };
+
+  return {
+    title: `${stock.ticker} — ${stock.company_name} (ASX) | Invest.com.au`,
+    description:
+      stock.blurb ||
+      `${stock.company_name} (ASX: ${stock.ticker}) — market cap, dividend yield and where to buy this Australian ${ticker.toUpperCase()} stock.`,
+    alternates: {
+      canonical: `${SITE_URL}/invest/${slug}/stocks/${stock.ticker.toLowerCase()}`,
+    },
+  };
+}
+
+const BUCKET_LABELS: Record<string, string> = {
+  mega: "Mega-cap (>A$50B)",
+  large: "Large-cap (A$5B – A$50B)",
+  mid: "Mid-cap (A$500M – A$5B)",
+  small: "Small-cap (A$100M – A$500M)",
+  spec: "Speculative (<A$100M)",
+};
+
+function formatPct(value: number | string | null): string {
+  if (value == null) return "—";
+  const num = typeof value === "string" ? parseFloat(value) : value;
+  if (!Number.isFinite(num)) return "—";
+  return `${num.toFixed(2)}%`;
+}
+
+function formatPe(value: number | string | null): string {
+  if (value == null) return "—";
+  const num = typeof value === "string" ? parseFloat(value) : value;
+  if (!Number.isFinite(num)) return "—";
+  return `${num.toFixed(1)}x`;
+}
+
+function formatRating(value: number | string | null): string {
+  if (value == null) return "—";
+  const num = typeof value === "string" ? parseFloat(value) : value;
+  if (!Number.isFinite(num)) return "—";
+  return `${num.toFixed(1)} / 5`;
+}
+
+export default async function StockDetailPage({
+  params,
+}: {
+  params: Promise<{ slug: string; ticker: string }>;
+}) {
+  const { slug, ticker } = await params;
+  const stock = await fetchStock(slug, ticker);
+  if (!stock) notFound();
+  const sector = await fetchSector(slug);
+  const [related, brokers] = await Promise.all([
+    fetchRelated(slug, stock.ticker),
+    fetchTopBrokers(),
+  ]);
+
+  const sectorName = sector?.display_name ?? slug;
+
+  const breadcrumb = breadcrumbJsonLd([
+    { name: "Home", url: `${SITE_URL}/` },
+    { name: "Invest", url: `${SITE_URL}/invest` },
+    { name: sectorName, url: `${SITE_URL}/invest/${slug}` },
+    { name: "Stocks", url: `${SITE_URL}/invest/${slug}/stocks` },
+    { name: stock.ticker },
+  ]);
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
+      />
+      <div className="bg-slate-50 min-h-screen">
+        <section className="bg-white border-b border-slate-200 py-8 md:py-10">
+          <div className="container-custom">
+            <nav
+              className="flex items-center gap-1.5 text-xs text-slate-500 mb-5"
+              aria-label="Breadcrumb"
+            >
+              <Link href="/" className="hover:text-slate-900">Home</Link>
+              <span className="text-slate-300">/</span>
+              <Link href="/invest" className="hover:text-slate-900">Invest</Link>
+              <span className="text-slate-300">/</span>
+              <Link href={`/invest/${slug}`} className="hover:text-slate-900">
+                {sectorName}
+              </Link>
+              <span className="text-slate-300">/</span>
+              <Link
+                href={`/invest/${slug}/stocks`}
+                className="hover:text-slate-900"
+              >
+                Stocks
+              </Link>
+              <span className="text-slate-300">/</span>
+              <span className="text-slate-900 font-medium">{stock.ticker}</span>
+            </nav>
+
+            <div className="flex items-baseline gap-3 mb-2">
+              <h1 className="text-3xl md:text-4xl font-extrabold text-amber-700 tabular-nums">
+                {stock.ticker}
+              </h1>
+              <span className="text-sm md:text-base text-slate-500">(ASX)</span>
+            </div>
+            <p className="text-xl md:text-2xl font-extrabold text-slate-900">
+              {stock.company_name}
+            </p>
+            {stock.blurb && (
+              <p className="text-sm md:text-base text-slate-600 leading-relaxed max-w-3xl mt-3">
+                {stock.blurb}
+              </p>
+            )}
+          </div>
+        </section>
+
+        <section className="py-8 md:py-10">
+          <div className="container-custom grid grid-cols-1 lg:grid-cols-3 gap-6">
+            {/* Main column */}
+            <div className="lg:col-span-2 space-y-6">
+              <div className="bg-white border border-slate-200 rounded-xl p-6">
+                <h2 className="text-lg font-extrabold text-slate-900 mb-4">
+                  Key metrics
+                </h2>
+                <dl className="grid grid-cols-2 md:grid-cols-4 gap-3">
+                  <Metric
+                    label="Market cap"
+                    value={
+                      stock.market_cap_bucket
+                        ? BUCKET_LABELS[stock.market_cap_bucket] ??
+                          stock.market_cap_bucket
+                        : "—"
+                    }
+                  />
+                  <Metric
+                    label="Dividend yield"
+                    value={formatPct(stock.dividend_yield_pct)}
+                  />
+                  <Metric label="P/E ratio" value={formatPe(stock.pe_ratio)} />
+                  <Metric
+                    label="Primary exposure"
+                    value={stock.primary_exposure ?? "—"}
+                  />
+                </dl>
+              </div>
+
+              {stock.included_in_indices &&
+                stock.included_in_indices.length > 0 && (
+                  <div className="bg-white border border-slate-200 rounded-xl p-6">
+                    <h2 className="text-lg font-extrabold text-slate-900 mb-3">
+                      Index inclusion
+                    </h2>
+                    <div className="flex flex-wrap gap-2">
+                      {stock.included_in_indices.map((idx) => (
+                        <span
+                          key={idx}
+                          className="text-[11px] font-bold px-2.5 py-0.5 rounded-full bg-slate-100 text-slate-700"
+                        >
+                          {idx}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+              {stock.foreign_ownership_risk && (
+                <div className="bg-amber-50 border border-amber-200 rounded-xl p-5">
+                  <h3 className="text-xs font-extrabold uppercase tracking-wide text-amber-800 mb-1">
+                    Foreign-ownership risk
+                  </h3>
+                  <p className="text-sm text-amber-900 leading-relaxed">
+                    {stock.foreign_ownership_risk}
+                  </p>
+                </div>
+              )}
+
+              <div className="bg-white border border-slate-200 rounded-xl p-5">
+                <p className="text-[11px] text-slate-500 leading-relaxed">
+                  <strong>General information only.</strong> Market figures are
+                  editorial snapshots
+                  {stock.last_reviewed_at
+                    ? ` (last reviewed ${new Date(
+                        stock.last_reviewed_at,
+                      ).toLocaleDateString("en-AU", {
+                        month: "short",
+                        year: "numeric",
+                      })})`
+                    : ""}{" "}
+                  and move intraday. Confirm current prices and dividends via
+                  your broker. Invest.com.au does not provide personal
+                  financial product advice — engage a licensed adviser before
+                  making investment decisions.
+                </p>
+              </div>
+            </div>
+
+            {/* Buy via these brokers sidebar */}
+            <aside className="space-y-4">
+              <div className="bg-white border border-slate-200 rounded-xl p-5">
+                <h2 className="text-base font-extrabold text-slate-900 mb-3">
+                  Buy {stock.ticker} via these brokers
+                </h2>
+                {brokers.length === 0 ? (
+                  <p className="text-sm text-slate-500">
+                    Compare brokers to buy this stock.
+                  </p>
+                ) : (
+                  <ul className="space-y-3">
+                    {brokers.map((b) => (
+                      <li
+                        key={b.slug}
+                        className="border border-slate-100 rounded-lg p-3"
+                      >
+                        <div className="flex items-start justify-between gap-3 mb-1">
+                          <div className="min-w-0 flex-1">
+                            <p className="font-bold text-sm text-slate-900 truncate">
+                              {b.name}
+                            </p>
+                            <p className="text-[11px] text-slate-500">
+                              Rating: {formatRating(b.rating)}
+                              {b.chess_sponsored ? " · CHESS" : ""}
+                            </p>
+                          </div>
+                          {b.asx_fee && (
+                            <span className="text-[11px] font-bold text-slate-700 whitespace-nowrap">
+                              {b.asx_fee}
+                            </span>
+                          )}
+                        </div>
+                        <Link
+                          href={`/broker/${b.slug}`}
+                          className="inline-flex items-center gap-1 text-xs font-bold text-amber-600 hover:underline"
+                        >
+                          View review
+                          <Icon name="arrow-right" size={12} />
+                        </Link>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+                <Link
+                  href="/compare?category=shares"
+                  className="mt-4 inline-flex items-center justify-center gap-2 w-full bg-amber-500 hover:bg-amber-600 text-white font-bold text-sm px-4 py-2.5 rounded-lg"
+                >
+                  Compare all ASX brokers
+                  <Icon name="arrow-right" size={14} />
+                </Link>
+              </div>
+
+              <div className="bg-white border border-slate-200 rounded-xl p-5">
+                <h3 className="text-sm font-extrabold text-slate-900 mb-2">
+                  Prefer diversified exposure?
+                </h3>
+                <p className="text-xs text-slate-600 mb-3">
+                  See {sectorName.toLowerCase()} sector ETFs for a single-ticket
+                  wrapper across multiple companies.
+                </p>
+                <Link
+                  href={`/invest/${slug}/etfs`}
+                  className="inline-flex items-center gap-1 text-sm font-bold text-amber-600 hover:underline"
+                >
+                  View {sectorName} ETFs
+                  <Icon name="arrow-right" size={12} />
+                </Link>
+              </div>
+            </aside>
+          </div>
+        </section>
+
+        {related.length > 0 && (
+          <section className="py-8 bg-white border-t border-slate-200">
+            <div className="container-custom">
+              <h2 className="text-xl md:text-2xl font-extrabold text-slate-900 mb-5">
+                Related {sectorName.toLowerCase()} stocks
+              </h2>
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                {related.map((r) => (
+                  <Link
+                    key={r.id}
+                    href={`/invest/${slug}/stocks/${r.ticker.toLowerCase()}`}
+                    className="block bg-slate-50 hover:bg-slate-100 border border-slate-200 rounded-xl p-5 transition-colors"
+                  >
+                    <span className="text-xs font-extrabold text-amber-700">
+                      {r.ticker}
+                    </span>
+                    <p className="text-sm font-bold text-slate-900 mt-1 line-clamp-1">
+                      {r.company_name}
+                    </p>
+                    {r.blurb && (
+                      <p className="text-xs text-slate-500 mt-2 line-clamp-2">
+                        {r.blurb}
+                      </p>
+                    )}
+                  </Link>
+                ))}
+              </div>
+            </div>
+          </section>
+        )}
+      </div>
+    </>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="border border-slate-200 rounded-lg p-3 bg-slate-50">
+      <dt className="text-[10px] font-bold uppercase text-slate-500 tracking-wide">
+        {label}
+      </dt>
+      <dd className="text-sm md:text-base font-extrabold text-slate-900 mt-0.5">
+        {value}
+      </dd>
+    </div>
+  );
+}

--- a/app/invest/[slug]/stocks/page.tsx
+++ b/app/invest/[slug]/stocks/page.tsx
@@ -1,0 +1,293 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
+import { createAdminClient } from "@/lib/supabase/admin";
+import Icon from "@/components/Icon";
+
+export const revalidate = 1800;
+
+interface StockRow {
+  id: number;
+  ticker: string;
+  company_name: string;
+  market_cap_bucket: string | null;
+  dividend_yield_pct: number | string | null;
+  pe_ratio: number | string | null;
+  blurb: string | null;
+  primary_exposure: string | null;
+  foreign_ownership_risk: string | null;
+  display_order: number | null;
+  status: string | null;
+}
+
+interface SectorRow {
+  slug: string;
+  display_name: string;
+  hero_description: string | null;
+}
+
+async function fetchSector(slug: string): Promise<SectorRow | null> {
+  try {
+    const supabase = createAdminClient();
+    const { data } = await supabase
+      .from("commodity_sectors")
+      .select("slug, display_name, hero_description")
+      .eq("slug", slug)
+      .eq("status", "active")
+      .maybeSingle();
+    return (data as SectorRow | null) || null;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchStocks(sectorSlug: string): Promise<StockRow[]> {
+  try {
+    const supabase = createAdminClient();
+    const { data } = await supabase
+      .from("commodity_stocks")
+      .select(
+        "id, ticker, company_name, market_cap_bucket, dividend_yield_pct, pe_ratio, blurb, primary_exposure, foreign_ownership_risk, display_order, status",
+      )
+      .eq("sector_slug", sectorSlug)
+      .eq("status", "active")
+      .order("display_order", { ascending: true });
+    return (data as StockRow[] | null) || [];
+  } catch {
+    return [];
+  }
+}
+
+export async function generateStaticParams() {
+  try {
+    const supabase = createAdminClient();
+    const { data } = await supabase
+      .from("commodity_sectors")
+      .select("slug")
+      .eq("status", "active");
+    return (data || []).map((row: { slug: string }) => ({ slug: row.slug }));
+  } catch {
+    return [];
+  }
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const sector = await fetchSector(slug);
+  if (!sector) {
+    return { title: `ASX Stocks (${CURRENT_YEAR})` };
+  }
+  return {
+    title: `ASX ${sector.display_name} Stocks (${CURRENT_YEAR}) — Compare Australian ${sector.display_name} Investment Opportunities`,
+    description: `Compare ASX-listed ${sector.display_name.toLowerCase()} stocks in Australia. Market cap, dividend yield, P/E ratio, and foreign-ownership risk flags for every active company on the register.`,
+    alternates: {
+      canonical: `${SITE_URL}/invest/${slug}/stocks`,
+    },
+    openGraph: {
+      title: `ASX ${sector.display_name} Stocks (${CURRENT_YEAR})`,
+      url: `${SITE_URL}/invest/${slug}/stocks`,
+    },
+  };
+}
+
+const BUCKET_LABELS: Record<string, string> = {
+  mega: "Mega-cap (>A$50B)",
+  large: "Large-cap (A$5B – A$50B)",
+  mid: "Mid-cap (A$500M – A$5B)",
+  small: "Small-cap (A$100M – A$500M)",
+  spec: "Speculative (<A$100M)",
+};
+
+function formatPct(value: number | string | null): string {
+  if (value == null) return "—";
+  const num = typeof value === "string" ? parseFloat(value) : value;
+  if (!Number.isFinite(num)) return "—";
+  return `${num.toFixed(2)}%`;
+}
+
+function formatPe(value: number | string | null): string {
+  if (value == null) return "—";
+  const num = typeof value === "string" ? parseFloat(value) : value;
+  if (!Number.isFinite(num)) return "—";
+  return `${num.toFixed(1)}x`;
+}
+
+export default async function SectorStocksPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const sector = await fetchSector(slug);
+  if (!sector) notFound();
+  const stocks = await fetchStocks(slug);
+
+  const breadcrumb = breadcrumbJsonLd([
+    { name: "Home", url: `${SITE_URL}/` },
+    { name: "Invest", url: `${SITE_URL}/invest` },
+    { name: sector.display_name, url: `${SITE_URL}/invest/${slug}` },
+    { name: "ASX Stocks" },
+  ]);
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
+      />
+      <div className="bg-white min-h-screen">
+        <section className="bg-slate-900 text-white py-10 md:py-12">
+          <div className="container-custom">
+            <nav
+              className="flex items-center gap-1.5 text-xs text-slate-400 mb-5"
+              aria-label="Breadcrumb"
+            >
+              <Link href="/" className="hover:text-white">Home</Link>
+              <span className="text-slate-600">/</span>
+              <Link href="/invest" className="hover:text-white">Invest</Link>
+              <span className="text-slate-600">/</span>
+              <Link href={`/invest/${slug}`} className="hover:text-white">
+                {sector.display_name}
+              </Link>
+              <span className="text-slate-600">/</span>
+              <span className="text-white font-medium">ASX Stocks</span>
+            </nav>
+            <h1 className="text-2xl md:text-3xl lg:text-4xl font-extrabold leading-tight mb-3">
+              ASX {sector.display_name} Stocks
+            </h1>
+            <p className="text-sm md:text-base text-slate-300 max-w-3xl leading-relaxed">
+              Editorially reviewed snapshots of every active ASX-listed {sector.display_name.toLowerCase()} company. Compare market cap, dividend yield, P/E ratio and foreign-ownership risk.
+            </p>
+          </div>
+        </section>
+
+        <section className="py-8 md:py-10 bg-white">
+          <div className="container-custom">
+            {stocks.length === 0 ? (
+              <div className="py-16 text-center">
+                <p className="text-sm text-slate-500">
+                  No active stocks in this sector yet. Check back soon.
+                </p>
+              </div>
+            ) : (
+              <div className="overflow-x-auto rounded-xl border border-slate-200">
+                <table className="w-full text-sm">
+                  <thead className="bg-slate-50 border-b border-slate-200">
+                    <tr>
+                      <th className="text-left px-4 py-3 font-bold text-slate-700">
+                        Ticker
+                      </th>
+                      <th className="text-left px-4 py-3 font-bold text-slate-700">
+                        Company
+                      </th>
+                      <th className="text-left px-4 py-3 font-bold text-slate-700 hidden md:table-cell">
+                        Market cap
+                      </th>
+                      <th className="text-left px-4 py-3 font-bold text-slate-700 hidden lg:table-cell">
+                        Yield
+                      </th>
+                      <th className="text-left px-4 py-3 font-bold text-slate-700 hidden lg:table-cell">
+                        P/E
+                      </th>
+                      <th className="text-left px-4 py-3 font-bold text-slate-700 hidden md:table-cell">
+                        FIRB
+                      </th>
+                      <th className="px-4 py-3"></th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-slate-100">
+                    {stocks.map((s) => (
+                      <tr key={s.id} className="hover:bg-slate-50">
+                        <td className="px-4 py-3 font-extrabold text-amber-700">
+                          {s.ticker}
+                        </td>
+                        <td className="px-4 py-3">
+                          <div className="font-bold text-slate-900">
+                            {s.company_name}
+                          </div>
+                          {s.blurb && (
+                            <p className="text-xs text-slate-500 mt-0.5 line-clamp-2 max-w-md">
+                              {s.blurb}
+                            </p>
+                          )}
+                        </td>
+                        <td className="px-4 py-3 text-slate-700 hidden md:table-cell">
+                          {s.market_cap_bucket
+                            ? BUCKET_LABELS[s.market_cap_bucket] ?? s.market_cap_bucket
+                            : "—"}
+                        </td>
+                        <td className="px-4 py-3 text-slate-700 font-semibold tabular-nums hidden lg:table-cell">
+                          {formatPct(s.dividend_yield_pct)}
+                        </td>
+                        <td className="px-4 py-3 text-slate-700 tabular-nums hidden lg:table-cell">
+                          {formatPe(s.pe_ratio)}
+                        </td>
+                        <td className="px-4 py-3 text-[11px] text-slate-600 hidden md:table-cell">
+                          {s.foreign_ownership_risk ?? "—"}
+                        </td>
+                        <td className="px-4 py-3 text-right whitespace-nowrap">
+                          <Link
+                            href={`/invest/${slug}/stocks/${s.ticker.toLowerCase()}`}
+                            className="text-amber-600 hover:underline text-xs font-bold inline-flex items-center gap-1"
+                          >
+                            View
+                            <Icon name="arrow-right" size={12} />
+                          </Link>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        </section>
+
+        <section className="py-10 bg-slate-50 border-y border-slate-200">
+          <div className="container-custom max-w-3xl text-center">
+            <h2 className="text-xl md:text-2xl font-extrabold text-slate-900 mb-2">
+              Need a broker to buy these stocks?
+            </h2>
+            <p className="text-sm text-slate-600 mb-5">
+              Compare ASX-accessible brokers side by side — fees, CHESS sponsorship, and market access compared transparently.
+            </p>
+            <div className="flex flex-wrap justify-center gap-3">
+              <Link
+                href="/compare?category=shares"
+                className="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-600 text-white font-bold text-sm px-5 py-2.5 rounded-lg"
+              >
+                Compare ASX brokers
+                <Icon name="arrow-right" size={14} />
+              </Link>
+              <Link
+                href={`/invest/${slug}/etfs`}
+                className="inline-flex items-center gap-2 bg-white hover:bg-slate-50 border border-slate-300 text-slate-900 font-bold text-sm px-5 py-2.5 rounded-lg"
+              >
+                Sector ETFs
+                <Icon name="arrow-right" size={14} />
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-8 bg-white">
+          <div className="container-custom max-w-3xl">
+            <p className="text-[11px] text-slate-500 leading-relaxed">
+              <strong>General information only.</strong> Market cap, yield and
+              P/E figures are editorial snapshots and move intraday. Always
+              confirm current figures via your broker or the ASX company
+              announcements platform. This page does not constitute personal
+              financial product advice — consult a licensed adviser before
+              investing.
+            </p>
+          </div>
+        </section>
+      </div>
+    </>
+  );
+}

--- a/app/invest/alternatives/listings/page.tsx
+++ b/app/invest/alternatives/listings/page.tsx
@@ -62,7 +62,13 @@ export default async function AlternativesListingsPage() {
         </div>
       )}
       <Suspense fallback={<div className="py-12 text-center text-slate-400">Loading listings...</div>}>
-        <InvestListingsClient listings={listings} categories={categoryTabs} initialCategory="alternatives" />
+        <InvestListingsClient
+          listings={listings}
+          categories={categoryTabs}
+          lockedCategory="alternatives"
+          pageTitle="Alternative Investment Investment Listings"
+          pageSubtitle="Browse Australian alternative investment opportunities — art, wine, collectibles and non-correlated assets."
+        />
       </Suspense>
     </>
   );

--- a/app/invest/buy-business/listings/page.tsx
+++ b/app/invest/buy-business/listings/page.tsx
@@ -52,7 +52,13 @@ export default async function BusinessListingsPage() {
         </div>
       )}
       <Suspense fallback={<div className="py-12 text-center text-slate-400">Loading listings...</div>}>
-        <InvestListingsClient listings={listings} categories={categoryTabs} initialCategory="buy-business" />
+        <InvestListingsClient
+          listings={listings}
+          categories={categoryTabs}
+          lockedCategory="buy-business"
+          pageTitle="Buy a Business Investment Listings"
+          pageSubtitle="Browse Australian businesses for sale — cafes, agencies, franchises, professional practices and e-commerce."
+        />
       </Suspense>
     </>
   );

--- a/app/invest/commercial-property/listings/page.tsx
+++ b/app/invest/commercial-property/listings/page.tsx
@@ -50,7 +50,13 @@ export default async function CommercialListingsPage() {
         </div>
       )}
       <Suspense fallback={<div className="py-12 text-center text-slate-400">Loading listings...</div>}>
-        <InvestListingsClient listings={listings} categories={categoryTabs} initialCategory="commercial-property" />
+        <InvestListingsClient
+          listings={listings}
+          categories={categoryTabs}
+          lockedCategory="commercial-property"
+          pageTitle="Commercial Property Investment Listings"
+          pageSubtitle="Browse Australian commercial property investment opportunities — office, industrial, retail, healthcare and childcare."
+        />
       </Suspense>
     </>
   );

--- a/app/invest/farmland/listings/page.tsx
+++ b/app/invest/farmland/listings/page.tsx
@@ -50,7 +50,13 @@ export default async function FarmlandListingsPage() {
         </div>
       )}
       <Suspense fallback={<div className="py-12 text-center text-slate-400">Loading listings...</div>}>
-        <InvestListingsClient listings={listings} categories={categoryTabs} initialCategory="farmland" />
+        <InvestListingsClient
+          listings={listings}
+          categories={categoryTabs}
+          lockedCategory="farmland"
+          pageTitle="Farmland & Agriculture Investment Listings"
+          pageSubtitle="Browse Australian farmland and agricultural investments — cropping, dairy, viticulture and horticulture across NSW, VIC, QLD, WA and SA."
+        />
       </Suspense>
     </>
   );

--- a/app/invest/franchise/listings/page.tsx
+++ b/app/invest/franchise/listings/page.tsx
@@ -50,7 +50,13 @@ export default async function FranchiseListingsPage() {
         </div>
       )}
       <Suspense fallback={<div className="py-12 text-center text-slate-400">Loading listings...</div>}>
-        <InvestListingsClient listings={listings} categories={categoryTabs} initialCategory="franchise" />
+        <InvestListingsClient
+          listings={listings}
+          categories={categoryTabs}
+          lockedCategory="franchise"
+          pageTitle="Franchise Investment Listings"
+          pageSubtitle="Browse Australian franchise opportunities — food, fitness, automotive and service businesses with proven models."
+        />
       </Suspense>
     </>
   );

--- a/app/invest/infrastructure/listings/page.tsx
+++ b/app/invest/infrastructure/listings/page.tsx
@@ -61,7 +61,13 @@ export default async function InfrastructureListingsPage() {
         </div>
       )}
       <Suspense fallback={<div className="py-12 text-center text-slate-400">Loading listings...</div>}>
-        <InvestListingsClient listings={listings} categories={categoryTabs} initialCategory="infrastructure" />
+        <InvestListingsClient
+          listings={listings}
+          categories={categoryTabs}
+          lockedCategory="infrastructure"
+          pageTitle="Infrastructure Investment Listings"
+          pageSubtitle="Browse Australian infrastructure investment opportunities — toll roads, airports, utilities and public-private partnerships."
+        />
       </Suspense>
     </>
   );

--- a/app/invest/mining/listings/page.tsx
+++ b/app/invest/mining/listings/page.tsx
@@ -50,7 +50,13 @@ export default async function MiningOpportunitiesPage() {
         </div>
       )}
       <Suspense fallback={<div className="py-12 text-center text-slate-400">Loading listings...</div>}>
-        <InvestListingsClient listings={listings} categories={categoryTabs} initialCategory="mining" />
+        <InvestListingsClient
+          listings={listings}
+          categories={categoryTabs}
+          lockedCategory="mining"
+          pageTitle="Mining Investment Listings"
+          pageSubtitle="Browse Australian mining investment opportunities — filter by commodity (lithium, gold, copper, iron ore, rare earths), project stage and state."
+        />
       </Suspense>
     </>
   );

--- a/app/invest/page.tsx
+++ b/app/invest/page.tsx
@@ -5,7 +5,6 @@ import {
   absoluteUrl,
   breadcrumbJsonLd,
   CURRENT_YEAR,
-  SITE_NAME,
 } from "@/lib/seo";
 import {
   getAllInvestCategories,
@@ -16,6 +15,7 @@ import {
   GENERAL_ADVICE_WARNING,
 } from "@/lib/compliance";
 import ScrollReveal from "@/components/ScrollReveal";
+import Icon from "@/components/Icon";
 
 export const revalidate = 3600;
 
@@ -231,6 +231,107 @@ export default async function InvestHubPage() {
               })}
             </div>
           </ScrollReveal>
+
+          {/* Energy & commodity sector hubs */}
+          <div className="mb-8 md:mb-12">
+            <h2 className="text-lg md:text-2xl font-bold mb-3 md:mb-4">
+              Energy &amp; commodity sector hubs
+            </h2>
+            <p className="text-xs md:text-sm text-slate-600 mb-4 md:mb-5 max-w-3xl">
+              ASX stocks, ETFs, and project-equity listings across the
+              commodities that move Australian markets.
+            </p>
+            <ScrollReveal animation="scroll-fade-in">
+              <div className="grid grid-cols-2 md:grid-cols-3 gap-3 md:gap-4">
+                {[
+                  {
+                    slug: "oil-gas",
+                    label: "Oil & Gas",
+                    description: "LNG, exploration, refineries and energy infrastructure",
+                    icon: "fuel",
+                    accentCard: "border-amber-200 hover:border-amber-400",
+                    accentBadge: "bg-amber-100 text-amber-700",
+                    accentHover: "group-hover:text-amber-700",
+                  },
+                  {
+                    slug: "uranium",
+                    label: "Uranium",
+                    description: "ASX uranium producers, explorers and sector ETFs",
+                    icon: "atom",
+                    accentCard: "border-yellow-200 hover:border-yellow-400",
+                    accentBadge: "bg-yellow-100 text-yellow-700",
+                    accentHover: "group-hover:text-yellow-700",
+                  },
+                  {
+                    slug: "hydrogen",
+                    label: "Hydrogen",
+                    description: "Green hydrogen, fuel cells and H2 infrastructure",
+                    icon: "droplets",
+                    accentCard: "border-sky-200 hover:border-sky-400",
+                    accentBadge: "bg-sky-100 text-sky-700",
+                    accentHover: "group-hover:text-sky-700",
+                  },
+                  {
+                    slug: "lithium",
+                    label: "Lithium",
+                    description: "Pilbara producers, downstream processing and battery metals",
+                    icon: "zap",
+                    accentCard: "border-emerald-200 hover:border-emerald-400",
+                    accentBadge: "bg-emerald-100 text-emerald-700",
+                    accentHover: "group-hover:text-emerald-700",
+                  },
+                  {
+                    slug: "gold",
+                    label: "Gold & Precious Metals",
+                    description: "Perth Mint, gold ETFs and ASX gold miners",
+                    icon: "coins",
+                    accentCard: "border-amber-200 hover:border-amber-400",
+                    accentBadge: "bg-amber-100 text-amber-700",
+                    accentHover: "group-hover:text-amber-700",
+                  },
+                  {
+                    slug: "mining",
+                    label: "Mining & Resources",
+                    description: "Iron ore, copper, rare earths and critical minerals",
+                    icon: "layers",
+                    accentCard: "border-slate-200 hover:border-slate-400",
+                    accentBadge: "bg-slate-100 text-slate-700",
+                    accentHover: "group-hover:text-slate-700",
+                  },
+                ].map((s) => {
+                  const count = verticalCounts[s.slug] || 0;
+                  return (
+                    <Link
+                      key={s.slug}
+                      href={`/invest/${s.slug}`}
+                      className={`group relative block rounded-xl border bg-white p-3 md:p-4 transition-all duration-200 hover:shadow-lg hover:scale-[1.01] ${s.accentCard}`}
+                    >
+                      <div className="flex items-start gap-2 mb-2">
+                        <span className={`shrink-0 p-1.5 rounded-lg ${s.accentBadge}`}>
+                          <Icon name={s.icon} size={18} className="" />
+                        </span>
+                        <div className="min-w-0 flex-1">
+                          <h3
+                            className={`font-bold text-sm md:text-base text-slate-900 transition-colors ${s.accentHover}`}
+                          >
+                            {s.label}
+                          </h3>
+                          <span className="text-[0.62rem] md:text-xs font-semibold text-slate-400">
+                            {count > 0
+                              ? `${count} ${count === 1 ? "listing" : "listings"} · Sector hub`
+                              : "Sector hub"}
+                          </span>
+                        </div>
+                      </div>
+                      <p className="text-[0.62rem] md:text-xs text-slate-500 leading-relaxed line-clamp-2">
+                        {s.description}
+                      </p>
+                    </Link>
+                  );
+                })}
+              </div>
+            </ScrollReveal>
+          </div>
 
           {/* Bottom CTA */}
           <div className="bg-slate-50 rounded-xl p-4 md:p-6 text-center">

--- a/app/invest/private-credit/listings/page.tsx
+++ b/app/invest/private-credit/listings/page.tsx
@@ -61,7 +61,13 @@ export default async function PrivateCreditListingsPage() {
         </div>
       )}
       <Suspense fallback={<div className="py-12 text-center text-slate-400">Loading listings...</div>}>
-        <InvestListingsClient listings={listings} categories={categoryTabs} initialCategory="private-credit" />
+        <InvestListingsClient
+          listings={listings}
+          categories={categoryTabs}
+          lockedCategory="private-credit"
+          pageTitle="Private Credit Investment Listings"
+          pageSubtitle="Browse Australian private credit investment opportunities — senior secured loans, mezzanine debt and structured credit."
+        />
       </Suspense>
     </>
   );

--- a/app/invest/renewable-energy/listings/page.tsx
+++ b/app/invest/renewable-energy/listings/page.tsx
@@ -50,7 +50,13 @@ export default async function EnergyProjectsPage() {
         </div>
       )}
       <Suspense fallback={<div className="py-12 text-center text-slate-400">Loading listings...</div>}>
-        <InvestListingsClient listings={listings} categories={categoryTabs} initialCategory="renewable-energy" />
+        <InvestListingsClient
+          listings={listings}
+          categories={categoryTabs}
+          lockedCategory="renewable-energy"
+          pageTitle="Renewable Energy Investment Listings"
+          pageSubtitle="Browse Australian renewable energy investment opportunities — solar, wind, battery storage and grid-scale projects."
+        />
       </Suspense>
     </>
   );

--- a/app/invest/startups/listings/page.tsx
+++ b/app/invest/startups/listings/page.tsx
@@ -50,7 +50,13 @@ export default async function StartupOpportunitiesPage() {
         </div>
       )}
       <Suspense fallback={<div className="py-12 text-center text-slate-400">Loading listings...</div>}>
-        <InvestListingsClient listings={listings} categories={categoryTabs} initialCategory="startups" />
+        <InvestListingsClient
+          listings={listings}
+          categories={categoryTabs}
+          lockedCategory="startups"
+          pageTitle="Startups & Tech Investment Listings"
+          pageSubtitle="Browse Australian startup investment opportunities — VC, angel rounds, SAFE notes and equity crowdfunding."
+        />
       </Suspense>
     </>
   );

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -174,6 +174,81 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     })),
   ];
 
+  // Dynamic /best-for/[slug] scenarios (from best_for_scenarios)
+  const { data: bestForScenarios } = supabase
+    ? await supabase
+        .from("best_for_scenarios")
+        .select("slug, updated_at")
+        .eq("status", "active")
+    : { data: null };
+  const bestForPages = [
+    { url: `${baseUrl}/best-for`, lastModified: new Date(), changeFrequency: "weekly" as const, priority: 0.85 },
+    ...(bestForScenarios || []).map((s: { slug: string; updated_at: string | null }) => ({
+      url: `${baseUrl}/best-for/${s.slug}`,
+      lastModified: s.updated_at ? new Date(s.updated_at) : new Date(),
+      changeFrequency: "weekly" as const,
+      priority: 0.75,
+    })),
+  ];
+
+  // Dynamic commodity sector stocks + ETFs pages
+  const { data: commoditySectors } = supabase
+    ? await supabase
+        .from("commodity_sectors")
+        .select("slug")
+        .eq("status", "active")
+    : { data: null };
+  const commodityPages = (commoditySectors || []).flatMap(
+    (s: { slug: string }) => [
+      {
+        url: `${baseUrl}/invest/${s.slug}/stocks`,
+        lastModified: new Date(),
+        changeFrequency: "weekly" as const,
+        priority: 0.7,
+      },
+      {
+        url: `${baseUrl}/invest/${s.slug}/etfs`,
+        lastModified: new Date(),
+        changeFrequency: "weekly" as const,
+        priority: 0.7,
+      },
+    ],
+  );
+
+  // Individual stock detail pages
+  const { data: commodityStocks } = supabase
+    ? await supabase
+        .from("commodity_stocks")
+        .select("sector_slug, ticker")
+        .eq("status", "active")
+    : { data: null };
+  const stockDetailPages = (commodityStocks || []).map(
+    (s: { sector_slug: string; ticker: string }) => ({
+      url: `${baseUrl}/invest/${s.sector_slug}/stocks/${s.ticker.toLowerCase()}`,
+      lastModified: new Date(),
+      changeFrequency: "weekly" as const,
+      priority: 0.6,
+    }),
+  );
+
+  // Broker transfer guides
+  const { data: transferGuides } = supabase
+    ? await supabase
+        .from("broker_transfer_guides")
+        .select("broker_slug, updated_at")
+    : { data: null };
+  const transferGuidePages = [
+    { url: `${baseUrl}/how-to/transfer-from`, lastModified: new Date(), changeFrequency: "weekly" as const, priority: 0.8 },
+    ...(transferGuides || []).map(
+      (g: { broker_slug: string; updated_at: string | null }) => ({
+        url: `${baseUrl}/how-to/transfer-from/${g.broker_slug}`,
+        lastModified: g.updated_at ? new Date(g.updated_at) : new Date(),
+        changeFrequency: "monthly" as const,
+        priority: 0.7,
+      }),
+    ),
+  ];
+
   // Dynamic team member pages (authors + reviewers)
   const { data: teamMembers } = supabase
     ? await supabase.from("team_members").select("slug, role, updated_at").eq("status", "active")
@@ -652,5 +727,5 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     priority: 0.6,
   }));
 
-  return [...staticPages, ...bestPages, ...costPages, ...brokerPages, ...articlePages, ...scenarioPages, ...authorPages, ...reviewerPages, ...alertPages, ...reportPages, ...versusPages, ...howToPages, ...expertArticlePages, ...advisorPages, ...advisorTypePages, ...advisorStatePages, ...advisorCityPages, ...advisorLocationPages, ...investingCityPages, ...glossaryPages, ...firmPages, ...propertyListingPages, ...suburbGuidePages, ...propertyHubPages, ...newHubPages, newsletterArchivePage, ...newsletterEditionPages, ...investStaticPages, ...investCategoryPages, ...investSubcategoryPages, ...investListingPages, ...stockbrokerFirmPages];
+  return [...staticPages, ...bestPages, ...bestForPages, ...commodityPages, ...stockDetailPages, ...transferGuidePages, ...costPages, ...brokerPages, ...articlePages, ...scenarioPages, ...authorPages, ...reviewerPages, ...alertPages, ...reportPages, ...versusPages, ...howToPages, ...expertArticlePages, ...advisorPages, ...advisorTypePages, ...advisorStatePages, ...advisorCityPages, ...advisorLocationPages, ...investingCityPages, ...glossaryPages, ...firmPages, ...propertyListingPages, ...suburbGuidePages, ...propertyHubPages, ...newHubPages, newsletterArchivePage, ...newsletterEditionPages, ...investStaticPages, ...investCategoryPages, ...investSubcategoryPages, ...investListingPages, ...stockbrokerFirmPages];
 }

--- a/components/ArticleBrokerTable.tsx
+++ b/components/ArticleBrokerTable.tsx
@@ -1,0 +1,177 @@
+import Link from "next/link";
+import { createAdminClient } from "@/lib/supabase/admin";
+import Icon from "@/components/Icon";
+
+/**
+ * ArticleBrokerTable
+ * ------------------
+ * Top-of-article compact broker compare table. Queries the brokers
+ * table server-side, filters by vertical, orders by rating, and
+ * renders the top N with affiliate CTAs.
+ *
+ * `vertical` is a free-form string that maps to the existing
+ * broker-categorisation columns — 'shares', 'crypto', 'cfd',
+ * 'savings', 'super', 'robo', or '*' for "any".
+ */
+
+interface Props {
+  vertical: string;
+  maxBrokers?: number;
+  /** Optional label replacing the default "Compare top brokers" heading */
+  heading?: string;
+}
+
+interface BrokerRow {
+  slug: string;
+  name: string;
+  logo_url: string | null;
+  rating: number | string | null;
+  asx_fee: string | null;
+  us_fee: string | null;
+  tagline: string | null;
+  chess_sponsored: boolean | null;
+  smsf_support: boolean | null;
+  platform_type: string | null;
+  is_crypto: boolean | null;
+  affiliate_url: string | null;
+  deal: boolean | null;
+  deal_text: string | null;
+}
+
+async function fetchBrokers(
+  vertical: string,
+  maxBrokers: number,
+): Promise<BrokerRow[]> {
+  try {
+    const supabase = createAdminClient();
+    let query = supabase
+      .from("brokers")
+      .select(
+        "slug, name, logo_url, rating, asx_fee, us_fee, tagline, chess_sponsored, smsf_support, platform_type, is_crypto, affiliate_url, deal, deal_text",
+      )
+      .eq("status", "active");
+
+    const v = vertical.toLowerCase();
+    if (v === "crypto") query = query.eq("is_crypto", true);
+    else if (v === "shares" || v === "etf" || v === "etfs") query = query.eq("is_crypto", false);
+    else if (v === "cfd") query = query.eq("platform_type", "cfd_forex");
+    else if (v === "savings") query = query.eq("platform_type", "savings_account");
+    else if (v === "super") query = query.eq("platform_type", "super_fund");
+    else if (v === "robo") query = query.eq("platform_type", "robo_advisor");
+    else if (v === "smsf") query = query.eq("smsf_support", true);
+    // default ('*' or unknown): no category filter
+
+    const { data } = await query
+      .order("rating", { ascending: false })
+      .limit(maxBrokers);
+    return (data as BrokerRow[] | null) || [];
+  } catch {
+    return [];
+  }
+}
+
+function formatRating(value: number | string | null): string {
+  if (value == null) return "—";
+  const num = typeof value === "string" ? parseFloat(value) : value;
+  if (!Number.isFinite(num)) return "—";
+  return num.toFixed(1);
+}
+
+function ratingStars(value: number | string | null): string {
+  const num =
+    value == null
+      ? 0
+      : typeof value === "string"
+        ? parseFloat(value)
+        : value;
+  if (!Number.isFinite(num)) return "";
+  const full = Math.round(num);
+  return "★".repeat(full) + "☆".repeat(Math.max(0, 5 - full));
+}
+
+export default async function ArticleBrokerTable({
+  vertical,
+  maxBrokers = 3,
+  heading,
+}: Props) {
+  const brokers = await fetchBrokers(vertical, maxBrokers);
+  if (brokers.length === 0) return null;
+
+  return (
+    <aside
+      aria-label="Recommended brokers"
+      className="my-8 bg-slate-50 border border-slate-200 rounded-xl overflow-hidden"
+    >
+      <header className="bg-slate-900 text-white px-4 py-3">
+        <p className="text-[10px] font-bold uppercase tracking-wide text-amber-400">
+          Editorial picks
+        </p>
+        <h3 className="text-sm md:text-base font-extrabold">
+          {heading ?? "Top platforms for this topic"}
+        </h3>
+      </header>
+      <ul className="divide-y divide-slate-200">
+        {brokers.map((b) => {
+          const cta = b.affiliate_url
+            ? { href: b.affiliate_url, label: "Visit site", external: true }
+            : { href: `/broker/${b.slug}`, label: "Read review", external: false };
+          return (
+            <li key={b.slug} className="flex items-center gap-4 px-4 py-3 bg-white">
+              <div className="w-10 h-10 rounded-lg bg-slate-100 shrink-0 flex items-center justify-center overflow-hidden">
+                {b.logo_url ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={b.logo_url}
+                    alt={b.name}
+                    className="max-w-full max-h-full"
+                  />
+                ) : (
+                  <Icon name="briefcase" size={18} className="text-slate-400" />
+                )}
+              </div>
+              <div className="flex-1 min-w-0">
+                <p className="font-bold text-sm text-slate-900 truncate">
+                  {b.name}
+                </p>
+                <p className="text-[11px] text-slate-500 truncate">
+                  {b.tagline ??
+                    [b.asx_fee && `ASX ${b.asx_fee}`, b.us_fee && `US ${b.us_fee}`]
+                      .filter(Boolean)
+                      .join(" · ")}
+                </p>
+                <p className="text-[11px] text-amber-600 font-semibold mt-0.5">
+                  <span aria-hidden="true" className="mr-1">
+                    {ratingStars(b.rating)}
+                  </span>
+                  {formatRating(b.rating)} / 5
+                  {b.chess_sponsored ? " · CHESS" : ""}
+                  {b.smsf_support ? " · SMSF" : ""}
+                </p>
+              </div>
+              <div className="shrink-0">
+                <Link
+                  href={cta.href}
+                  {...(cta.external
+                    ? { target: "_blank", rel: "sponsored nofollow noopener" }
+                    : {})}
+                  className="inline-flex items-center gap-1 bg-amber-500 hover:bg-amber-600 text-white font-bold text-xs px-3 py-2 rounded-lg transition-colors"
+                >
+                  {cta.label}
+                  <Icon name="arrow-right" size={12} />
+                </Link>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+      <footer className="px-4 py-2.5 bg-slate-50 border-t border-slate-200 text-[10px] text-slate-500">
+        Rankings are editorial, based on published fees, rating, and platform
+        features. Some links are affiliate links — see our{" "}
+        <Link href="/how-we-earn" className="underline">
+          how we earn
+        </Link>{" "}
+        page.
+      </footer>
+    </aside>
+  );
+}

--- a/components/InvestListingsClient.tsx
+++ b/components/InvestListingsClient.tsx
@@ -12,6 +12,23 @@ export interface InvestListingsClientProps {
   categories: { slug: string; label: string }[];
   initialCategory?: string;
   initialSubcategory?: string;
+  /**
+   * When set, the filter is locked to this category and the
+   * global category tab bar is hidden. Used on every
+   * /invest/[vertical]/listings page to prevent a ?category=
+   * URL param bleeding in from other pages and collapsing the
+   * result set to zero.
+   */
+  lockedCategory?: string;
+  /**
+   * Optional page title rendered above filters. Required on
+   * vertical listings pages per Phase 1D spec.
+   */
+  pageTitle?: string;
+  /**
+   * Optional page subtitle / lead paragraph.
+   */
+  pageSubtitle?: string;
 }
 
 // VERTICAL_TO_CATEGORY, FUND_SUB_TO_CATEGORY, and categoryForListing
@@ -61,13 +78,21 @@ export default function InvestListingsClient({
   categories,
   initialCategory,
   initialSubcategory,
+  lockedCategory,
+  pageTitle,
+  pageSubtitle,
 }: InvestListingsClientProps) {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
-  // Read filter state from URL search params (fall back to props)
-  const activeCategory = searchParams.get("category") ?? initialCategory ?? "all";
+  // When a vertical listings page passes lockedCategory, that
+  // value wins unconditionally — a ?category= URL param from
+  // another page must not bleed in. Otherwise fall back to the
+  // URL search param, then the initial prop, then 'all'.
+  const activeCategory = lockedCategory
+    ? lockedCategory
+    : (searchParams.get("category") ?? initialCategory ?? "all");
   const activeSubcategory = searchParams.get("sub") ?? initialSubcategory ?? "";
   const activeState = searchParams.get("state") ?? "";
   const activePriceIdx = Number(searchParams.get("price") ?? "0");
@@ -151,32 +176,52 @@ export default function InvestListingsClient({
 
   return (
     <div>
-      {/* ── Sticky category tab bar ── */}
-      <div className="sticky top-0 z-20 bg-white/95 backdrop-blur border-b border-slate-200">
-        <div className="container-custom overflow-x-auto scrollbar-hide">
-          <div className="flex gap-1.5 py-2.5 min-w-max">
-            {tabs.map((tab) => {
-              const isActive = tab.slug === activeCategory;
-              const colors = CATEGORY_COLORS[tab.slug] ?? CATEGORY_COLORS.all;
-              return (
-                <button
-                  key={tab.slug}
-                  onClick={() =>
-                    setParam({ category: tab.slug === "all" ? "" : tab.slug, sub: "" })
-                  }
-                  className={`whitespace-nowrap rounded-full px-3.5 py-1.5 text-xs font-semibold transition-all ${
-                    isActive
-                      ? `${colors.bg} ${colors.text} ring-1 ${colors.ring}`
-                      : "text-slate-500 hover:bg-slate-50 hover:text-slate-700"
-                  }`}
-                >
-                  {tab.label}
-                </button>
-              );
-            })}
+      {pageTitle && (
+        <div className="bg-white border-b border-slate-100 py-6 md:py-8">
+          <div className="container-custom">
+            <h1 className="text-2xl md:text-3xl lg:text-4xl font-extrabold text-slate-900 leading-tight">
+              {pageTitle}
+            </h1>
+            {pageSubtitle && (
+              <p className="text-sm md:text-base text-slate-600 leading-relaxed mt-2 max-w-3xl">
+                {pageSubtitle}
+              </p>
+            )}
           </div>
         </div>
-      </div>
+      )}
+
+      {/* ── Sticky category tab bar — ONLY on the global /invest/listings
+          marketplace. Hidden on every /invest/[vertical]/listings page
+          to prevent a ?category= URL param from the wrong vertical
+          filtering the result set down to zero. ── */}
+      {!lockedCategory && (
+        <div className="sticky top-0 z-20 bg-white/95 backdrop-blur border-b border-slate-200">
+          <div className="container-custom overflow-x-auto scrollbar-hide">
+            <div className="flex gap-1.5 py-2.5 min-w-max">
+              {tabs.map((tab) => {
+                const isActive = tab.slug === activeCategory;
+                const colors = CATEGORY_COLORS[tab.slug] ?? CATEGORY_COLORS.all;
+                return (
+                  <button
+                    key={tab.slug}
+                    onClick={() =>
+                      setParam({ category: tab.slug === "all" ? "" : tab.slug, sub: "" })
+                    }
+                    className={`whitespace-nowrap rounded-full px-3.5 py-1.5 text-xs font-semibold transition-all ${
+                      isActive
+                        ? `${colors.bg} ${colors.text} ring-1 ${colors.ring}`
+                        : "text-slate-500 hover:bg-slate-50 hover:text-slate-700"
+                    }`}
+                  >
+                    {tab.label}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      )}
 
       <div className="container-custom py-5 md:py-8">
         {/* ── Secondary filters row ── */}

--- a/components/claims/ClaimListingButton.tsx
+++ b/components/claims/ClaimListingButton.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { useState } from "react";
+import Icon from "@/components/Icon";
+
+interface Props {
+  claimType: "broker" | "advisor" | "listing";
+  targetSlug: string;
+  targetName: string;
+}
+
+/**
+ * "Are you [Name]? Claim this listing" CTA.
+ *
+ * Renders a prominent call-to-action at the bottom of broker and
+ * advisor profile pages. On click opens an inline form modal that
+ * posts to /api/claim-listing. Admin reviews the claim and grants
+ * ownership manually — this does not auto-approve.
+ */
+export default function ClaimListingButton({
+  claimType,
+  targetSlug,
+  targetName,
+}: Props) {
+  const [open, setOpen] = useState(false);
+  const [fullName, setFullName] = useState("");
+  const [email, setEmail] = useState("");
+  const [role, setRole] = useState("");
+  const [phone, setPhone] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setSubmitting(true);
+    try {
+      const res = await fetch("/api/claim-listing", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          claim_type: claimType,
+          target_slug: targetSlug,
+          full_name: fullName,
+          email,
+          company_role: role || undefined,
+          phone: phone || undefined,
+        }),
+      });
+      const data = (await res.json()) as { success?: boolean; error?: string };
+      if (!data.success) {
+        setError(data.error || "Something went wrong. Please try again.");
+        setSubmitting(false);
+        return;
+      }
+      setSubmitted(true);
+    } catch {
+      setError("Network error. Please try again.");
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <section className="py-10 bg-slate-50 border-t border-slate-200">
+      <div className="container-custom max-w-3xl">
+        <div className="bg-white border border-slate-200 rounded-xl p-6 md:p-8">
+          <div className="flex items-start gap-4">
+            <div className="w-10 h-10 rounded-xl bg-amber-50 flex items-center justify-center shrink-0">
+              <Icon name="shield-check" size={20} className="text-amber-600" />
+            </div>
+            <div className="flex-1 min-w-0">
+              <h2 className="text-lg md:text-xl font-extrabold text-slate-900 mb-1">
+                Are you {targetName}?
+              </h2>
+              <p className="text-sm text-slate-600 leading-relaxed mb-4">
+                Claim this profile to update your details, respond to
+                reviews, and connect with the investors searching for you on
+                Invest.com.au. We verify every claim before granting ownership.
+              </p>
+
+              {submitted ? (
+                <div className="bg-emerald-50 border border-emerald-200 rounded-lg p-4 text-sm text-emerald-900">
+                  <strong>Thanks — claim received.</strong> Our team will
+                  verify your identity and be in touch within 2 business days.
+                </div>
+              ) : !open ? (
+                <button
+                  onClick={() => setOpen(true)}
+                  className="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-600 text-white font-bold text-sm px-5 py-2.5 rounded-lg transition-colors"
+                >
+                  Claim this listing
+                  <Icon name="arrow-right" size={14} />
+                </button>
+              ) : (
+                <form onSubmit={onSubmit} className="space-y-3">
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                    <div>
+                      <label className="block text-[11px] font-bold uppercase tracking-wide text-slate-500 mb-1">
+                        Full name *
+                      </label>
+                      <input
+                        type="text"
+                        required
+                        value={fullName}
+                        onChange={(e) => setFullName(e.target.value)}
+                        maxLength={120}
+                        className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-amber-400 focus:outline-none"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-[11px] font-bold uppercase tracking-wide text-slate-500 mb-1">
+                        Email *
+                      </label>
+                      <input
+                        type="email"
+                        required
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                        maxLength={200}
+                        className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-amber-400 focus:outline-none"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-[11px] font-bold uppercase tracking-wide text-slate-500 mb-1">
+                        Role at {targetName}
+                      </label>
+                      <input
+                        type="text"
+                        value={role}
+                        onChange={(e) => setRole(e.target.value)}
+                        maxLength={120}
+                        placeholder="e.g. Head of Digital, CEO, Marketing"
+                        className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-amber-400 focus:outline-none"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-[11px] font-bold uppercase tracking-wide text-slate-500 mb-1">
+                        Phone
+                      </label>
+                      <input
+                        type="tel"
+                        value={phone}
+                        onChange={(e) => setPhone(e.target.value)}
+                        maxLength={40}
+                        className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-amber-400 focus:outline-none"
+                      />
+                    </div>
+                  </div>
+
+                  {error && (
+                    <div
+                      className="text-xs text-rose-700 bg-rose-50 border border-rose-200 rounded-lg p-3"
+                      role="alert"
+                    >
+                      {error}
+                    </div>
+                  )}
+
+                  <div className="flex gap-2">
+                    <button
+                      type="submit"
+                      disabled={submitting}
+                      className="bg-amber-500 hover:bg-amber-600 text-white font-bold text-sm px-5 py-2.5 rounded-lg disabled:bg-slate-400"
+                    >
+                      {submitting ? "Submitting..." : "Submit claim"}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setOpen(false)}
+                      className="text-sm font-semibold text-slate-600 hover:text-slate-800 px-3"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+
+                  <p className="text-[10px] text-slate-500 leading-relaxed">
+                    We&rsquo;ll verify your identity and match to the
+                    registered contact for this profile. Only the authorised
+                    representative can claim.
+                  </p>
+                </form>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/lib/cron-groups.ts
+++ b/lib/cron-groups.ts
@@ -95,7 +95,7 @@ export const CRON_GROUPS: Record<string, readonly string[]> = {
     "/api/cron/weekly-rate-update",
     "/api/cron/personalized-digest",
   ],
-  "weekly-mon-9": ["/api/cron/fee-digest"],
+  "weekly-mon-9": ["/api/cron/fee-digest", "/api/cron/content-freshness"],
   "weekly-mon-11": ["/api/cron/advisor-dormant-nudge"],
 
   "monthly-1-3": ["/api/cron/property-suburb-refresh"],

--- a/lib/listing-verticals.ts
+++ b/lib/listing-verticals.ts
@@ -1,0 +1,169 @@
+/**
+ * Canonical listing verticals — single source of truth.
+ *
+ * Every slug here matches:
+ *   - The route segment under /invest/<slug>/
+ *   - The investment_listings.vertical column value
+ *   - The lookup keys used by investment-listings-query, sitemap,
+ *     SubCategoryNav, navigation components and InvestListingsClient
+ *
+ * When adding a new vertical:
+ *   1. Insert a row into investment_verticals (or commodity_sectors
+ *      for commodity hubs) matching `slug` below.
+ *   2. Add the entry here with the same slug.
+ *   3. Create app/invest/<slug>/page.tsx following an existing hub
+ *      (oil-gas for commodity, buy-business for marketplace).
+ *   4. Run a slug-normalisation migration against investment_listings
+ *      if existing rows use a different casing/convention.
+ */
+
+export type ListingVerticalKind = "marketplace" | "commodity" | "fund" | "capital-markets";
+
+export interface ListingVertical {
+  /** Canonical slug — matches investment_listings.vertical and the route */
+  slug: string;
+  /** Display label used in nav, cards, breadcrumbs */
+  label: string;
+  /** Short one-liner for /invest grid card subtitle */
+  description: string;
+  /** Icon name passed to components/Icon */
+  icon: string;
+  /** Category for ordering / grouping on the hub page */
+  kind: ListingVerticalKind;
+  /** Sort order for the /invest grid and sitemap */
+  order: number;
+}
+
+export const LISTING_VERTICALS: readonly ListingVertical[] = [
+  {
+    slug: "buy-business",
+    label: "Buy a Business",
+    description: "Cafes, agencies, e-commerce, professional practices and more",
+    icon: "briefcase",
+    kind: "marketplace",
+    order: 10,
+  },
+  {
+    slug: "mining",
+    label: "Mining & Resources",
+    description: "Gold, lithium, copper, rare earths and critical minerals",
+    icon: "layers",
+    kind: "commodity",
+    order: 20,
+  },
+  {
+    slug: "oil-gas",
+    label: "Oil & Gas",
+    description:
+      "LNG, exploration, refineries and energy infrastructure",
+    icon: "fuel",
+    kind: "commodity",
+    order: 22,
+  },
+  {
+    slug: "uranium",
+    label: "Uranium",
+    description: "ASX uranium producers, explorers and sector ETFs",
+    icon: "atom",
+    kind: "commodity",
+    order: 24,
+  },
+  {
+    slug: "lithium",
+    label: "Lithium",
+    description: "Pilbara producers, downstream processing and battery metals",
+    icon: "zap",
+    kind: "commodity",
+    order: 26,
+  },
+  {
+    slug: "hydrogen",
+    label: "Hydrogen",
+    description:
+      "Green hydrogen, fuel cells and H2 infrastructure",
+    icon: "droplets",
+    kind: "commodity",
+    order: 28,
+  },
+  {
+    slug: "gold",
+    label: "Gold & Precious Metals",
+    description: "Perth Mint, gold ETFs and ASX gold miners",
+    icon: "coins",
+    kind: "commodity",
+    order: 30,
+  },
+  {
+    slug: "farmland",
+    label: "Farmland & Agriculture",
+    description: "Cropping, dairy, viticulture and horticulture across Australia",
+    icon: "leaf",
+    kind: "marketplace",
+    order: 40,
+  },
+  {
+    slug: "commercial-property",
+    label: "Commercial Property",
+    description: "Office, industrial, retail, medical and childcare",
+    icon: "building",
+    kind: "marketplace",
+    order: 50,
+  },
+  {
+    slug: "renewable-energy",
+    label: "Renewable Energy",
+    description: "Solar, wind, battery storage and grid-scale projects",
+    icon: "sun",
+    kind: "marketplace",
+    order: 55,
+  },
+  {
+    slug: "franchise",
+    label: "Franchise",
+    description: "Food, fitness, automotive and service franchise opportunities",
+    icon: "star",
+    kind: "marketplace",
+    order: 60,
+  },
+  {
+    slug: "startups",
+    label: "Startups & Tech",
+    description: "VC, angel investing, SAFE rounds and crowdfunding",
+    icon: "rocket",
+    kind: "capital-markets",
+    order: 70,
+  },
+  {
+    slug: "funds",
+    label: "Investment Funds",
+    description: "Managed, syndicated property, infrastructure and wholesale funds",
+    icon: "briefcase",
+    kind: "fund",
+    order: 80,
+  },
+  {
+    slug: "infrastructure",
+    label: "Infrastructure",
+    description: "Toll roads, airports, utilities and public-private partnerships",
+    icon: "layers",
+    kind: "capital-markets",
+    order: 90,
+  },
+];
+
+/** Canonical slugs only — useful for route static params + validation. */
+export const LISTING_VERTICAL_SLUGS: readonly string[] = LISTING_VERTICALS.map(
+  (v) => v.slug,
+);
+
+/** Fast lookup by slug. Returns undefined for unknown slugs. */
+export function getListingVertical(
+  slug: string,
+): ListingVertical | undefined {
+  return LISTING_VERTICALS.find((v) => v.slug === slug);
+}
+
+/** Label lookup — falls back to the raw slug if unknown. */
+export function getListingVerticalLabel(slug: string): string {
+  return getListingVertical(slug)?.label ?? slug;
+}

--- a/supabase/migrations/20260507_slug_normalisation.sql
+++ b/supabase/migrations/20260507_slug_normalisation.sql
@@ -1,0 +1,42 @@
+-- ============================================================
+-- Slug normalisation — align investment_listings.vertical with
+-- the route slugs used across /invest/[vertical].
+--
+-- Currently the table mixes underscore and hyphen conventions
+-- (e.g. 'commercial_property' vs route 'commercial-property'),
+-- plus singular/plural ('fund' vs route 'funds'). This mismatch
+-- is one of the root causes of vertical listing pages showing
+-- zero results.
+--
+-- After this migration, vertical values match the canonical
+-- slugs in lib/listing-verticals.ts.
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS _slug_fix_log (
+  id SERIAL,
+  note TEXT,
+  ts TIMESTAMPTZ DEFAULT NOW()
+);
+
+UPDATE public.investment_listings
+  SET vertical = 'commercial-property'
+  WHERE vertical = 'commercial_property';
+
+UPDATE public.investment_listings
+  SET vertical = 'buy-business'
+  WHERE vertical = 'business';
+
+UPDATE public.investment_listings
+  SET vertical = 'startups'
+  WHERE vertical = 'startup';
+
+UPDATE public.investment_listings
+  SET vertical = 'renewable-energy'
+  WHERE vertical = 'energy';
+
+UPDATE public.investment_listings
+  SET vertical = 'funds'
+  WHERE vertical = 'fund';
+
+INSERT INTO _slug_fix_log (note)
+  VALUES ('slug normalisation applied — 20260507');

--- a/supabase/migrations/20260508_listing_claims.sql
+++ b/supabase/migrations/20260508_listing_claims.sql
@@ -1,0 +1,25 @@
+-- ============================================================
+-- listing_claims — capture "claim this listing" requests from
+-- broker and advisor profile pages. Admin reviews the claim
+-- and confirms the claimant's identity / credentials before
+-- transferring ownership.
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS public.listing_claims (
+  id           SERIAL PRIMARY KEY,
+  claim_type   TEXT NOT NULL CHECK (claim_type IN ('broker', 'advisor', 'listing')),
+  target_slug  TEXT NOT NULL,
+  full_name    TEXT NOT NULL,
+  email        TEXT NOT NULL,
+  company_role TEXT,
+  phone        TEXT,
+  message      TEXT,
+  status       TEXT DEFAULT 'pending' CHECK (status IN ('pending','approved','rejected')),
+  admin_notes  TEXT,
+  created_at   TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_listing_claims_target
+  ON public.listing_claims (claim_type, target_slug);
+CREATE INDEX IF NOT EXISTS idx_listing_claims_status
+  ON public.listing_claims (status, created_at DESC);


### PR DESCRIPTION
## Summary

Focused pre-launch slice — prioritises the P1 listing bug and the highest-leverage Phase 4/5/7/10 work. Stacked on #157. **Merge order:** #153 → #154 → #155 → #157 → this PR.

This PR delivers a production-quality slice of the 11-phase pre-launch spec. What I **did not** do in this session is documented in the "Deferred work" section at the bottom — those items need external inputs (Stripe price IDs, Resend API key, content-volume work) or are substantial enough to warrant their own PR.

## Phases delivered

### ✅ Phase 1 — Critical bug fixes
- **1A Listing filter bug (root cause of 0 listings on every vertical page).** `components/InvestListingsClient.tsx` gets a new `lockedCategory` prop. When passed (by every vertical listing page), it wins unconditionally over `searchParams.get('category')` and the global category tab bar is hidden. This prevents a `?category=` URL param leaking in from `/invest/listings` and filtering the vertical page down to zero results. Marketplace route behaviour unchanged — it still reads from searchParams and defaults to `all`.
- **1B Slug normalisation.** Migration `20260507_slug_normalisation.sql` applied to prod. Rewrites 35 rows with the wrong convention. Verified post-migration: all 11 distinct vertical values now match canonical route slugs.
- **1C `lib/listing-verticals.ts`.** Single source of truth with 14 entries, typed `ListingVertical` interface, `getListingVertical()` and `getListingVerticalLabel()` helpers.
- **1D Page context.** Every vertical listings page now renders `H1="[Vertical] Investment Listings"` above the filters via the new `pageTitle` / `pageSubtitle` props. Breadcrumbs already correct.

### ✅ Phase 2 — /invest grid gap
- Oil & Gas, Uranium, Lithium, Hydrogen, Gold, Mining cards added to `/invest` as a new "Energy & commodity sector hubs" row. Nav + footer entries were delivered by PRs #153 / #155; this completes the grid gap specifically.

### ✅ Phase 3C — Listing claims
- `listing_claims` table created in prod (`20260508_listing_claims.sql`).
- `/api/claim-listing` endpoint with rate limiting + email validation + disposable-domain blocking.
- `<ClaimListingButton>` rendered at the bottom of `/broker/[slug]` and `/advisor/[slug]` with a progressive-disclosure form.

### ✅ Phase 4A / 4B / 4D — Hidden DB systems → live pages
- `/invest/[slug]/stocks` — index of all active commodity_stocks for that sector, full stocks compare table. `generateStaticParams` pulls every active sector.
- `/invest/[slug]/stocks/[ticker]` — individual stock detail page with "Buy via these brokers" sidebar, related stocks, foreign-ownership flags.
- `/invest/[slug]/etfs` — "Best [Sector] ETFs in Australia (2026)" page from commodity_etfs. Editorial-grade SEO targeting.
- `/how-to/transfer-from/` index + `/how-to/transfer-from/[broker_slug]` detail — pulls broker_transfer_guides, renders step-by-step instructions, pairs with "Best brokers to switch to" sidebar.

### ✅ Phase 4C — /best dynamic pages
- Already delivered in an earlier branch: `/best-for/` + `/best-for/[slug]` query `best_for_scenarios`. Verified present.

### ✅ Phase 5A — ArticleBrokerTable
- New server component `components/ArticleBrokerTable.tsx` queries brokers by vertical and renders the top N with affiliate CTAs.
- Injected into every `/article/[slug]` page below the AuthorByline. All ~266 published articles now carry an above-the-fold broker comparison.

### ✅ Phase 7D — Sitemap auto-regen
- `app/sitemap.ts` now dynamically includes: `/best-for`, every `best_for_scenarios.slug`, every `commodity_sectors.slug` (× `/stocks` + `/etfs`), every `commodity_stocks` ticker detail, every `broker_transfer_guides` entry, and the index.

### ✅ Phase 10A / 10B / 10D — Cron jobs
- **10A** `/api/cron/expire-deals` already live. Verified.
- **10B** New `/api/cron/content-freshness` — weekly scan for articles older than 180 days, queued to `content_calendar` with priority='review_needed'. Registered on the `weekly-mon-9` dispatcher group.
- **10D** `/api/cron/weekly-newsletter` already live. Verified.
- **10C** Sitemap ping on deploy — deferred (not wired to build pipeline; would need a Vercel build hook or post-deploy cron).

## Deferred work (explicit, with reasons)

Not a scope-cut because of laziness — these items either need external inputs or are substantial enough to warrant their own session.

- **Phase 3A Stripe on /advertise.** Requires real Stripe price IDs for the three tiers. Webhook handler scaffolding exists but I did not wire the Checkout Session endpoints without confirmed prices. Estimated: 4 hours once you have the IDs.
- **Phase 3B Newsletter Resend wiring.** `/api/newsletter/subscribe` already inserts to `newsletter_subscribers` — the gap is the Resend confirmation email. Estimated: 1 hour once `RESEND_API_KEY` is in Vercel.
- **Phase 3D Fund manager self-listing (/list-your-fund).** Form + Stripe $500 setup fee. Depends on Phase 3A Stripe wiring.
- **Phase 3E Admin affiliate performance dashboard.** Standalone admin page with aggregated queries + CSV export — probably a half-day of its own.
- **Phase 4E Buyer agents page.** `buyer_agents` data exists; directory page not yet built. ~2 hours.
- **Phase 5B Switch stories system.** Data model, /switch page, form, API. ~3 hours.
- **Phase 5C Exit intent modal.** UX decisions (trigger thresholds, mobile inactivity timing) plus session storage handling.
- **Phase 5D Glossary 185 new terms.** Content task — ~2,000-4,000 words of quality copy across 185 rows. Separate content PR.
- **Phase 6 — all email sequences (Resend).** 4 × 3-4 email sequences. ~1 day engineering + significant copywriting. Needs `RESEND_API_KEY`.
- **Phase 7A JSON-LD schema for every page type.** Roughly 7 schema functions + integration in 7 page types.
- **Phase 7B Internal linking engine.** Keyword mapping + article body rewriting.
- **Phase 7C 160 versus editorials seeding.** Content task — 160 × ~200-word entries.
- **Phase 8 AI concierge.** Full feature — Anthropic API route, chat drawer, conversation persistence. ~1 day.
- **Phase 9A Should-I-switch tool.** Multi-step wizard with broker-fee math. ~0.5 day.
- **Phase 9B /deals/pro page + admin.** ~2 hours.
- **Phase 11 Content seeding.** 150 articles + 160 versus + 239 suburbs + 3 switch stories + 5 pro deals. At realistic word counts, ~250,000 words of copy. Multiple dedicated content PRs.

## Verification

Database state (verified via Management API):
- `investment_listings.vertical` — every value matches `LISTING_VERTICALS`: `buy-business (10), commercial-property (5), farmland (6), franchise (5), funds (15), hydrogen (10), mining (5), oil-gas (12), renewable-energy (4), startups (5), uranium (12)`.
- `listing_claims` table created with 3-state `status` enum and FK-friendly nullable columns.
- Migrations applied: `20260507_slug_normalisation.sql`, `20260508_listing_claims.sql`.

Code state:
- `tsc --noEmit` clean.
- All 7 commits passed the project's pre-commit lint hook (one pre-existing unused-import and one unused-var warning fixed surgically along the way).

## Manual steps to activate deferred features
1. **`RESEND_API_KEY`** + **`LEADS_NOTIFY_EMAIL`** env vars in Vercel to activate: claim-listing admin notifications, content-freshness digest email, and all future email sequences. Leads are captured regardless.
2. **Stripe price IDs** for the 3 /advertise tiers (Editor's Pick $800/mo, Featured Partner $1,500/mo, Deal of the Month $2,000/mo) before Phase 3A can be implemented.
3. **Vercel build hook** if you want Phase 10C sitemap ping on every deploy.

## ASIC / compliance flags before launch
1. **New page types carry general-advice disclaimers but have NOT been reviewed by an AFSL-authorised counsel.** Broker stock-detail pages, ETF pages, and transfer-guide pages recommend products; disclaimers are prominent but legal sign-off is warranted before the hard-launch cycle.
2. **ArticleBrokerTable** injects affiliate CTAs into every article page. The "Some links are affiliate links — see our how we earn page" notice renders at the bottom of the widget. Confirm this satisfies your current advertiser-disclosure policy.
3. **Claim flow** currently trusts self-declaration of role. Admin should verify claimant identity before granting profile ownership — the `status='pending'` default is the gate; do not ship an auto-approve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)