### PR TITLE
feat: sponsored columns, content_freshness_log, newsletter + stock/ETF route verification

### DIFF
--- a/app/api/cron/content-freshness/route.ts
+++ b/app/api/cron/content-freshness/route.ts
@@ -74,7 +74,16 @@ export async function GET(req: NextRequest) {
       status: "planned",
       notes: `Auto-queued by content-freshness cron. Last updated: ${a.updated_at}`,
     });
-    if (!insertErr) queued++;
+    if (!insertErr) {
+      queued++;
+      // Audit-trail log — separate from the active work queue above.
+      // Unresolved rows here indicate freshness work not yet completed.
+      await supabase.from("content_freshness_log").insert({
+        article_id: a.id,
+        reason: `Published article older than ${STALE_DAYS} days (last updated ${a.updated_at ?? "unknown"})`,
+        resolved: false,
+      });
+    }
   }
 
   // Fire-and-forget digest email

--- a/supabase/migrations/20260509_sponsored_columns_and_freshness_log.sql
+++ b/supabase/migrations/20260509_sponsored_columns_and_freshness_log.sql
@@ -1,0 +1,44 @@
+-- ============================================================
+-- Pre-launch round 2:
+--   * Add sponsored / sponsored_tier / sponsored_until to brokers
+--     (in addition to the existing sponsorship_tier / sponsorship_end
+--     columns, which stay in place for backwards compatibility).
+--   * Create content_freshness_log for audit-trail separate from
+--     the content_calendar queue.
+-- ============================================================
+
+-- ────────────────────────────────────────────────────────────
+-- brokers sponsored columns (per master spec Phase 3A schema)
+-- ────────────────────────────────────────────────────────────
+ALTER TABLE public.brokers
+  ADD COLUMN IF NOT EXISTS sponsored BOOLEAN DEFAULT false;
+
+ALTER TABLE public.brokers
+  ADD COLUMN IF NOT EXISTS sponsored_tier TEXT;
+
+ALTER TABLE public.brokers
+  ADD COLUMN IF NOT EXISTS sponsored_until TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS idx_brokers_sponsored
+  ON public.brokers (sponsored, sponsored_until)
+  WHERE sponsored = true;
+
+-- ────────────────────────────────────────────────────────────
+-- content_freshness_log — audit trail of freshness flags.
+-- The content-freshness cron queues refresh work in
+-- content_calendar. This table stores the historical record of
+-- every flag, separate from the active work queue.
+-- ────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.content_freshness_log (
+  id          SERIAL PRIMARY KEY,
+  article_id  INTEGER REFERENCES public.articles(id) ON DELETE CASCADE,
+  flagged_at  TIMESTAMPTZ DEFAULT NOW(),
+  reason      TEXT,
+  resolved    BOOLEAN DEFAULT false
+);
+
+CREATE INDEX IF NOT EXISTS idx_content_freshness_log_article
+  ON public.content_freshness_log (article_id);
+CREATE INDEX IF NOT EXISTS idx_content_freshness_log_unresolved
+  ON public.content_freshness_log (flagged_at DESC)
+  WHERE resolved = false;


### PR DESCRIPTION
## Summary

Second pre-launch slice — completing the 6 items from the latest prompt. Stacked on #158. **Merge order:** #153 → #154 → #155 → #157 → #158 → this PR.

## Items addressed

### 1 + 2 + 6 — Stock / ETF pages + sitemap (previously delivered in #158, verified here)

Per the latest prompt asking for `app/invest/[vertical]/stocks/page.tsx`, `[ticker]` detail, and `/etfs/page.tsx`:

These were built in #158 under the existing `[slug]` dynamic segment (not `[vertical]`) because `app/invest/[slug]/` already exists in the codebase and Next.js disallows two different dynamic-segment names (`[slug]` vs `[vertical]`) at the same folder level. The routes resolve the same URLs: `/invest/uranium/stocks`, `/invest/oil-gas/etfs`, `/invest/gold/stocks/nst`, etc.

Verified in this PR:
- `app/invest/[slug]/stocks/page.tsx` — 293 lines, `generateStaticParams` over active commodity_sectors, renders stocks table with ticker / company / market cap / dividend yield / P/E / FIRB risk.
- `app/invest/[slug]/stocks/[ticker]/page.tsx` — 426 lines, full stock profile with "Buy via these brokers" sidebar.
- `app/invest/[slug]/etfs/page.tsx` — 245 lines, ticker / name / issuer / MER / underlying exposure / distribution frequency.
- `app/sitemap.ts` already contains `stockDetailPages`, `commodityPages` (×2 per sector for stocks + etfs), and the sector-level routes — 5 references verified by grep.

### 3 — Sponsored columns on brokers ✅

New in this PR. Migration `20260509_sponsored_columns_and_freshness_log.sql`:

```sql
ALTER TABLE public.brokers ADD COLUMN IF NOT EXISTS sponsored BOOLEAN DEFAULT false;
ALTER TABLE public.brokers ADD COLUMN IF NOT EXISTS sponsored_tier TEXT;
ALTER TABLE public.brokers ADD COLUMN IF NOT EXISTS sponsored_until TIMESTAMPTZ;
CREATE INDEX IF NOT EXISTS idx_brokers_sponsored
  ON public.brokers (sponsored, sponsored_until)
  WHERE sponsored = true;
```

Verified in prod:
```
sponsored        | boolean                  | false
sponsored_tier   | text                     | null
sponsored_until  | timestamp with time zone | null
```

Note: the older `sponsorship_tier` (text) and `sponsorship_end` (date) columns are kept alongside — renaming them would have broken existing code reading those columns.

### 4 — Newsletter subscribe wiring ✅

Verified. The `/api/newsletter/subscribe` endpoint already exists and correctly:
- Rate-limits (5/hour per IP)
- Validates email (including disposable-domain blocking)
- Inserts to `newsletter_subscribers` with email, source, status, subscribed_at, UTM attribution
- Enqueues a double-opt-in confirmation job

Tested with a real insert against production `newsletter_subscribers` — the row was written correctly (id returned), then cleaned up. End-to-end wiring confirmed.

The `source` column spec: per existing table shape, source is free text and the endpoint accepts `{ email, name?, preference?, source? }` body shape. No schema change needed.

### 5 — content_freshness_log table ✅

New in this PR. Same migration:

```sql
CREATE TABLE IF NOT EXISTS public.content_freshness_log (
  id          SERIAL PRIMARY KEY,
  article_id  INTEGER REFERENCES public.articles(id) ON DELETE CASCADE,
  flagged_at  TIMESTAMPTZ DEFAULT NOW(),
  reason      TEXT,
  resolved    BOOLEAN DEFAULT false
);
```

Also wired the existing weekly content-freshness cron (`app/api/cron/content-freshness/route.ts`) to write an audit row to `content_freshness_log` on each newly-queued refresh. `content_calendar` remains the active work queue; `content_freshness_log` is the historical audit trail.

Verified in prod: table exists with all 5 columns.

## Verification output

```
brokers.sponsored columns:
  sponsored        boolean                   DEFAULT false
  sponsored_tier   text                      DEFAULT null
  sponsored_until  timestamp with time zone  DEFAULT null

content_freshness_log columns:
  id          integer
  article_id  integer
  flagged_at  timestamp with time zone
  reason      text
  resolved    boolean

newsletter_subscribers live insert test:
  inserted id=1 with source='prelaunch-verification' → cleaned up.

stocks/etfs pages present:
  app/invest/[slug]/stocks/page.tsx          (293 lines)
  app/invest/[slug]/stocks/[ticker]/page.tsx (426 lines)
  app/invest/[slug]/etfs/page.tsx            (245 lines)

sitemap dynamic route references:
  5 matches on stockDetailPages / commodityPages / stocks|etfs template strings.
```

`tsc --noEmit` clean on the changed files.

## Manual step

The Stripe webhook in a future PR will write to the new `sponsored` / `sponsored_tier` / `sponsored_until` columns. When that PR lands, the admin dashboard queries should filter `WHERE sponsored = true AND (sponsored_until IS NULL OR sponsored_until > NOW())` to respect expiry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)