### PR TITLE
feat: render investment_listings cards on hub pages + per-vertical count strip

### DIFF
--- a/app/invest/funds/page.tsx
+++ b/app/invest/funds/page.tsx
@@ -4,6 +4,7 @@ import { Suspense } from "react";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
 import { createAdminClient } from "@/lib/supabase/admin";
 import FundsDirectoryClient, { type FundListing } from "./FundsDirectoryClient";
+import VerticalMarketplaceListings from "@/components/marketplace/VerticalMarketplaceListings";
 
 export const revalidate = 600;
 
@@ -93,6 +94,20 @@ export default async function FundsPage() {
         <Suspense fallback={<div className="min-h-[60vh]" />}>
           <FundsDirectoryClient funds={funds} />
         </Suspense>
+
+        {/* Additional fund opportunities in the general marketplace
+            (investment_listings with vertical='funds'). Separate from
+            the fund_listings directory above — this surfaces
+            syndicated and SIV-tagged opportunities the editorial team
+            has curated. */}
+        <VerticalMarketplaceListings
+          vertical="funds"
+          accent="amber"
+          limit={6}
+          heading="More fund opportunities"
+          sub="Editorial-curated investment opportunities with vertical='funds' in our marketplace — syndicated, SIV-complying, and wholesale deal flow."
+          id="fund-marketplace"
+        />
       </div>
     </>
   );

--- a/app/invest/hydrogen/page.tsx
+++ b/app/invest/hydrogen/page.tsx
@@ -9,6 +9,7 @@ import {
 import AsxTickerCard from "@/components/commodities/AsxTickerCard";
 import EtfComparisonCard from "@/components/commodities/EtfComparisonCard";
 import GeneralAdviceWarning from "@/components/commodities/GeneralAdviceWarning";
+import VerticalMarketplaceListings from "@/components/marketplace/VerticalMarketplaceListings";
 import Icon from "@/components/Icon";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
 
@@ -459,6 +460,13 @@ export default async function HydrogenPage() {
           </div>
         </div>
       </section>
+
+      <VerticalMarketplaceListings
+        vertical="hydrogen"
+        accent="sky"
+        id="marketplace"
+        sub="Ten active hydrogen opportunities — ASX pure-plays, indirect majors, and project-equity deals. Register interest directly with the listing contact."
+      />
 
       <GeneralAdviceWarning sectorDisplayName={sector.display_name} />
     </div>

--- a/app/invest/listings/page.tsx
+++ b/app/invest/listings/page.tsx
@@ -65,6 +65,20 @@ async function fetchAllActiveListings(): Promise<InvestmentListing[]> {
 export default async function InvestListingsPage() {
   const listings = await fetchAllActiveListings();
 
+  // Per-vertical counts for the summary strip above the marketplace
+  // grid. Counts reflect the currently-active listings, computed
+  // once on the server to avoid loading the client with the raw
+  // aggregation.
+  const verticalCounts: Record<string, number> = {};
+  for (const l of listings) {
+    const v = l.vertical as string;
+    if (!v) continue;
+    verticalCounts[v] = (verticalCounts[v] || 0) + 1;
+  }
+  const sortedCounts = Object.entries(verticalCounts).sort(
+    ([, a], [, b]) => b - a,
+  );
+
   // Category tabs from invest-categories config
   const allCategories = getAllInvestCategories();
   const categoryTabs = allCategories.map((c) => ({
@@ -183,6 +197,33 @@ export default async function InvestListingsPage() {
             </details>
           </div>
         </div>
+
+        {/* Per-vertical count strip — live counts from the DB */}
+        {sortedCounts.length > 0 && (
+          <div className="container-custom max-w-6xl mb-4">
+            <div className="bg-white border border-slate-200 rounded-xl p-4">
+              <p className="text-[10px] font-bold uppercase tracking-wide text-slate-500 mb-3">
+                Active listings by vertical
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {sortedCounts.map(([slug, count]) => (
+                  <Link
+                    key={slug}
+                    href={`/invest/${slug}/listings`}
+                    className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-slate-50 hover:bg-amber-50 border border-slate-200 hover:border-amber-200 transition-colors text-xs"
+                  >
+                    <span className="font-semibold text-slate-700 capitalize">
+                      {slug.replace(/-/g, " ")}
+                    </span>
+                    <span className="font-extrabold text-amber-700 tabular-nums">
+                      {count}
+                    </span>
+                  </Link>
+                ))}
+              </div>
+            </div>
+          </div>
+        )}
 
         {/* Client component with filters + grid */}
         <InvestListingsClient

--- a/app/invest/mining/page.tsx
+++ b/app/invest/mining/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
 import Icon from "@/components/Icon";
 import SectionHeading from "@/components/SectionHeading";
+import VerticalMarketplaceListings from "@/components/marketplace/VerticalMarketplaceListings";
 
 export const revalidate = 3600;
 
@@ -347,6 +348,13 @@ export default function MiningPage() {
           </Link>
         </div>
       </section>
+
+      <VerticalMarketplaceListings
+        vertical="mining"
+        accent="amber"
+        id="marketplace"
+        sub="Active mining and critical-minerals opportunities in our marketplace — tenements, project equity and royalty streams. Register interest directly with the listing contact."
+      />
 
       {/* Foreign investor note */}
       <section className="py-10 md:py-12 bg-white border-t border-slate-100" id="foreign-investors">

--- a/app/invest/oil-gas/page.tsx
+++ b/app/invest/oil-gas/page.tsx
@@ -11,6 +11,7 @@ import {
 import AsxTickerCard from "@/components/commodities/AsxTickerCard";
 import EtfComparisonCard from "@/components/commodities/EtfComparisonCard";
 import GeneralAdviceWarning from "@/components/commodities/GeneralAdviceWarning";
+import VerticalMarketplaceListings from "@/components/marketplace/VerticalMarketplaceListings";
 import EnergyPriceWidget from "@/components/commodities/EnergyPriceWidget";
 import Icon from "@/components/Icon";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
@@ -527,6 +528,13 @@ export default async function OilGasPage() {
           </div>
         </div>
       </section>
+
+      <VerticalMarketplaceListings
+        vertical="oil-gas"
+        accent="amber"
+        id="marketplace"
+        sub="Twelve active oil &amp; gas opportunities — ASX majors, LNG royalties, refinery infrastructure and project equity. Register interest directly with the listing contact."
+      />
 
       {/* Research cross-link */}
       <section className="py-8 bg-slate-50 border-t border-slate-200">

--- a/app/invest/uranium/page.tsx
+++ b/app/invest/uranium/page.tsx
@@ -9,6 +9,7 @@ import {
 import AsxTickerCard from "@/components/commodities/AsxTickerCard";
 import EtfComparisonCard from "@/components/commodities/EtfComparisonCard";
 import GeneralAdviceWarning from "@/components/commodities/GeneralAdviceWarning";
+import VerticalMarketplaceListings from "@/components/marketplace/VerticalMarketplaceListings";
 import Icon from "@/components/Icon";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
 
@@ -462,6 +463,13 @@ export default async function UraniumPage() {
           </div>
         </div>
       </section>
+
+      <VerticalMarketplaceListings
+        vertical="uranium"
+        accent="yellow"
+        id="marketplace"
+        sub="Twelve active uranium opportunities — ASX producers and developers plus named project-equity deals. Register interest directly with the listing contact."
+      />
 
       <GeneralAdviceWarning sectorDisplayName={sector.display_name} />
     </div>

--- a/components/marketplace/EnquireButton.tsx
+++ b/components/marketplace/EnquireButton.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+import { useState } from "react";
+import Icon from "@/components/Icon";
+
+/**
+ * Inline enquire CTA for marketplace listing cards.
+ *
+ * POSTs to the existing /api/listings/enquire endpoint (which
+ * writes to listing_enquiries and sends the seller an email).
+ *
+ * Kept self-contained so it can drop into any listing card
+ * without plumbing a shared modal at the page level.
+ */
+
+interface Props {
+  listingId: number;
+  listingTitle: string;
+  /** Tailwind classes for the trigger button — should match host page accent */
+  buttonCls: string;
+}
+
+const INVESTOR_TYPES = [
+  { value: "domestic", label: "Australian resident" },
+  { value: "individual", label: "Individual" },
+  { value: "corporate", label: "Corporate" },
+  { value: "family_office", label: "Family office" },
+  { value: "foreign_individual", label: "Foreign individual" },
+  { value: "foreign_corporate", label: "Foreign corporate" },
+  { value: "visa_applicant", label: "SIV / visa applicant" },
+];
+
+export default function EnquireButton({
+  listingId,
+  listingTitle,
+  buttonCls,
+}: Props) {
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [phone, setPhone] = useState("");
+  const [investorType, setInvestorType] = useState("individual");
+  const [message, setMessage] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setSubmitting(true);
+    try {
+      const res = await fetch("/api/listings/enquire", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          listing_id: listingId,
+          user_name: name,
+          user_email: email,
+          user_phone: phone || undefined,
+          investor_type: investorType,
+          message: message || undefined,
+          source_page:
+            typeof window !== "undefined" ? window.location.pathname : null,
+        }),
+      });
+      const data = (await res.json()) as { success?: boolean; error?: string };
+      if (!data.success) {
+        setError(data.error || "Something went wrong. Please try again.");
+        setSubmitting(false);
+        return;
+      }
+      setSubmitted(true);
+    } catch {
+      setError("Network error. Please try again.");
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className={`inline-flex items-center gap-1.5 font-bold text-xs px-3 py-2 rounded-lg transition-colors ${buttonCls}`}
+      >
+        Enquire
+        <Icon name="arrow-right" size={12} />
+      </button>
+
+      {open && (
+        <div
+          className="fixed inset-0 z-50 bg-slate-900/60 flex items-center justify-center p-4"
+          onClick={() => !submitting && setOpen(false)}
+        >
+          <div
+            className="bg-white rounded-xl max-w-md w-full p-6 md:p-8"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {submitted ? (
+              <div>
+                <Icon
+                  name="check-circle"
+                  size={28}
+                  className="text-emerald-600 mb-3"
+                />
+                <h3 className="text-lg font-extrabold text-slate-900 mb-2">
+                  Thanks — enquiry sent
+                </h3>
+                <p className="text-sm text-slate-600 leading-relaxed mb-4">
+                  The listing contact will get in touch within 2 business days
+                  with the full information pack.
+                </p>
+                <p className="text-[11px] text-slate-500 mb-5">
+                  This is an information request, not an offer. Review the
+                  relevant PDS / IM and take personal financial advice before
+                  committing capital.
+                </p>
+                <button
+                  onClick={() => setOpen(false)}
+                  className={`w-full font-bold text-sm px-4 py-2.5 rounded-lg ${buttonCls}`}
+                >
+                  Close
+                </button>
+              </div>
+            ) : (
+              <form onSubmit={onSubmit} className="space-y-3">
+                <div>
+                  <h3 className="text-lg font-extrabold text-slate-900">
+                    Enquire
+                  </h3>
+                  <p className="text-xs text-slate-500 mt-0.5 line-clamp-2">
+                    About <strong>{listingTitle}</strong>
+                  </p>
+                </div>
+
+                <div>
+                  <label className="block text-[11px] font-bold uppercase tracking-wide text-slate-500 mb-1">
+                    Full name *
+                  </label>
+                  <input
+                    type="text"
+                    required
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    maxLength={120}
+                    className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-amber-400 focus:outline-none"
+                  />
+                </div>
+
+                <div>
+                  <label className="block text-[11px] font-bold uppercase tracking-wide text-slate-500 mb-1">
+                    Email *
+                  </label>
+                  <input
+                    type="email"
+                    required
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    maxLength={200}
+                    className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-amber-400 focus:outline-none"
+                  />
+                </div>
+
+                <div>
+                  <label className="block text-[11px] font-bold uppercase tracking-wide text-slate-500 mb-1">
+                    Phone
+                  </label>
+                  <input
+                    type="tel"
+                    value={phone}
+                    onChange={(e) => setPhone(e.target.value)}
+                    maxLength={40}
+                    className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-amber-400 focus:outline-none"
+                  />
+                </div>
+
+                <div>
+                  <label className="block text-[11px] font-bold uppercase tracking-wide text-slate-500 mb-1">
+                    Investor type
+                  </label>
+                  <select
+                    value={investorType}
+                    onChange={(e) => setInvestorType(e.target.value)}
+                    className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm bg-white"
+                  >
+                    {INVESTOR_TYPES.map((t) => (
+                      <option key={t.value} value={t.value}>
+                        {t.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <div>
+                  <label className="block text-[11px] font-bold uppercase tracking-wide text-slate-500 mb-1">
+                    Message (optional)
+                  </label>
+                  <textarea
+                    value={message}
+                    onChange={(e) => setMessage(e.target.value)}
+                    maxLength={2000}
+                    rows={3}
+                    className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-amber-400 focus:outline-none"
+                  />
+                </div>
+
+                {error && (
+                  <div
+                    role="alert"
+                    className="text-xs text-rose-700 bg-rose-50 border border-rose-200 rounded-lg p-3"
+                  >
+                    {error}
+                  </div>
+                )}
+
+                <div className="flex gap-2 pt-1">
+                  <button
+                    type="submit"
+                    disabled={submitting}
+                    className={`flex-1 font-bold text-sm px-4 py-2.5 rounded-lg disabled:bg-slate-400 ${buttonCls}`}
+                  >
+                    {submitting ? "Sending..." : "Send enquiry"}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setOpen(false)}
+                    className="text-sm font-semibold text-slate-600 hover:text-slate-800 px-3"
+                  >
+                    Cancel
+                  </button>
+                </div>
+
+                <p className="text-[10px] text-slate-500 leading-relaxed">
+                  Information request only — not an offer of a financial
+                  product. Review the relevant PDS / IM before investing.
+                </p>
+              </form>
+            )}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/components/marketplace/VerticalMarketplaceListings.tsx
+++ b/components/marketplace/VerticalMarketplaceListings.tsx
@@ -1,0 +1,307 @@
+import Link from "next/link";
+import { createAdminClient } from "@/lib/supabase/admin";
+import Icon from "@/components/Icon";
+import EnquireButton from "@/components/marketplace/EnquireButton";
+import { getListingVerticalLabel } from "@/lib/listing-verticals";
+
+/**
+ * Server component. Fetches active investment_listings for a
+ * given vertical and renders a card grid with an Enquire CTA.
+ *
+ * Designed to be dropped into any /invest/<vertical> hub page
+ * below the stocks / ETFs / ways-to-invest sections to surface
+ * the marketplace opportunities that live in investment_listings
+ * (12 oil-gas, 12 uranium, 10 hydrogen, etc.) but that the hubs
+ * previously linked out to instead of rendering inline.
+ */
+
+interface Listing {
+  id: number;
+  vertical: string;
+  title: string;
+  slug: string;
+  description: string | null;
+  price_display: string | null;
+  asking_price_cents: number | null;
+  location_state: string | null;
+  location_city: string | null;
+  industry: string | null;
+  sub_category: string | null;
+  key_metrics: Record<string, unknown> | null;
+  listing_type: string | null;
+  firb_eligible: boolean | null;
+  siv_complying: boolean | null;
+}
+
+interface Props {
+  vertical: string;
+  /** Max cards to render. Defaults to 6. */
+  limit?: number;
+  /** Override the section heading. */
+  heading?: string;
+  /** Override the subheading / lede. */
+  sub?: string;
+  /** Theme accent — matches the host page's brand colour. */
+  accent?: "amber" | "emerald" | "sky" | "yellow" | "slate";
+  /** Optional id for scroll-to links from tabs on the host page. */
+  id?: string;
+}
+
+const ACCENTS: Record<
+  NonNullable<Props["accent"]>,
+  { eyebrow: string; button: string }
+> = {
+  amber: {
+    eyebrow: "text-amber-600",
+    button: "bg-amber-500 hover:bg-amber-600 text-white",
+  },
+  yellow: {
+    eyebrow: "text-yellow-700",
+    button: "bg-yellow-600 hover:bg-yellow-700 text-white",
+  },
+  emerald: {
+    eyebrow: "text-emerald-600",
+    button: "bg-emerald-600 hover:bg-emerald-700 text-white",
+  },
+  sky: {
+    eyebrow: "text-sky-600",
+    button: "bg-sky-600 hover:bg-sky-700 text-white",
+  },
+  slate: {
+    eyebrow: "text-slate-700",
+    button: "bg-slate-900 hover:bg-slate-800 text-white",
+  },
+};
+
+async function fetchListings(
+  vertical: string,
+  limit: number,
+): Promise<Listing[]> {
+  try {
+    const supabase = createAdminClient();
+    const { data } = await supabase
+      .from("investment_listings")
+      .select(
+        "id, vertical, title, slug, description, price_display, asking_price_cents, location_state, location_city, industry, sub_category, key_metrics, listing_type, firb_eligible, siv_complying",
+      )
+      .eq("vertical", vertical)
+      .eq("status", "active")
+      .order("listing_type", { ascending: false, nullsFirst: false })
+      .order("created_at", { ascending: false })
+      .limit(limit);
+    return (data as Listing[] | null) || [];
+  } catch {
+    return [];
+  }
+}
+
+function formatCents(cents: number | null): string | null {
+  if (cents == null) return null;
+  const dollars = cents / 100;
+  if (dollars >= 1_000_000)
+    return `A$${(dollars / 1_000_000).toFixed(dollars >= 10_000_000 ? 0 : 1)}M`;
+  if (dollars >= 1_000) return `A$${(dollars / 1_000).toFixed(0)}K`;
+  return `A$${dollars.toFixed(0)}`;
+}
+
+export default async function VerticalMarketplaceListings({
+  vertical,
+  limit = 6,
+  heading,
+  sub,
+  accent = "amber",
+  id,
+}: Props) {
+  const listings = await fetchListings(vertical, limit);
+  if (listings.length === 0) return null;
+
+  const accentCls = ACCENTS[accent];
+  const label = getListingVerticalLabel(vertical);
+  const resolvedHeading =
+    heading ?? `${label} investment listings`;
+  const resolvedSub =
+    sub ??
+    `Active investment opportunities in our marketplace for this vertical. Register interest directly with the seller or the listing agent.`;
+
+  return (
+    <section
+      id={id}
+      className="py-10 md:py-12 bg-white border-t border-slate-100"
+    >
+      <div className="container-custom">
+        <div className="mb-6 max-w-3xl">
+          <p
+            className={`text-xs font-bold uppercase tracking-wider ${accentCls.eyebrow} mb-1`}
+          >
+            Marketplace
+          </p>
+          <h2 className="text-2xl md:text-3xl font-extrabold text-slate-900">
+            {resolvedHeading}
+          </h2>
+          <p className="text-sm text-slate-500 mt-1 leading-relaxed">
+            {resolvedSub}
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {listings.map((l) => (
+            <ListingCard key={l.id} listing={l} buttonCls={accentCls.button} />
+          ))}
+        </div>
+
+        <div className="mt-6 flex flex-wrap gap-4">
+          <Link
+            href={`/invest/${vertical}/listings`}
+            className={`inline-flex items-center gap-1.5 text-sm font-bold text-primary hover:underline`}
+          >
+            View all {label.toLowerCase()} listings
+            <Icon name="arrow-right" size={14} />
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ListingCard({
+  listing,
+  buttonCls,
+}: {
+  listing: Listing;
+  buttonCls: string;
+}) {
+  const price =
+    listing.price_display ?? formatCents(listing.asking_price_cents) ?? "POA";
+  const location = [listing.location_city, listing.location_state]
+    .filter(Boolean)
+    .join(", ");
+
+  // Pull up to 2 human-readable key_metrics pairs for the card.
+  const keyMetrics = extractKeyMetrics(listing.key_metrics);
+
+  return (
+    <article className="bg-white border border-slate-200 rounded-xl p-5 flex flex-col hover:shadow-md transition-shadow">
+      <div className="flex flex-wrap items-center gap-2 mb-2">
+        {listing.listing_type === "premium" && (
+          <span className="text-[10px] font-bold uppercase px-2 py-0.5 rounded-full bg-amber-500 text-white">
+            Premium
+          </span>
+        )}
+        {listing.listing_type === "featured" && (
+          <span className="text-[10px] font-bold uppercase px-2 py-0.5 rounded-full bg-amber-100 text-amber-800">
+            Featured
+          </span>
+        )}
+        {listing.siv_complying && (
+          <span className="text-[10px] font-bold uppercase px-2 py-0.5 rounded-full bg-emerald-100 text-emerald-800">
+            SIV
+          </span>
+        )}
+        {listing.firb_eligible && (
+          <span className="text-[10px] font-bold uppercase px-2 py-0.5 rounded-full bg-sky-100 text-sky-800">
+            FIRB
+          </span>
+        )}
+        {listing.sub_category && (
+          <span className="text-[10px] font-bold uppercase px-2 py-0.5 rounded-full bg-slate-100 text-slate-600">
+            {listing.sub_category}
+          </span>
+        )}
+      </div>
+
+      <h3 className="text-base font-extrabold text-slate-900 leading-tight mb-1 line-clamp-2">
+        {listing.title}
+      </h3>
+
+      {location && (
+        <p className="text-xs text-slate-500 inline-flex items-center gap-1 mb-2">
+          <Icon name="map-pin" size={11} />
+          {location}
+        </p>
+      )}
+
+      {listing.description && (
+        <p className="text-xs text-slate-600 leading-relaxed line-clamp-3 mb-3">
+          {listing.description}
+        </p>
+      )}
+
+      {keyMetrics.length > 0 && (
+        <dl className="grid grid-cols-2 gap-2 mb-4 text-xs">
+          {keyMetrics.map((m) => (
+            <div key={m.label} className="bg-slate-50 rounded-lg px-2.5 py-1.5">
+              <dt className="text-[10px] font-bold uppercase text-slate-500 truncate">
+                {m.label}
+              </dt>
+              <dd className="font-extrabold text-slate-900 truncate">
+                {m.value}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      )}
+
+      <div className="mt-auto flex items-center justify-between gap-3 pt-2 border-t border-slate-100">
+        <div>
+          <p className="text-[10px] font-bold uppercase text-slate-500">
+            Price
+          </p>
+          <p className="text-sm font-extrabold text-slate-900">{price}</p>
+        </div>
+        <EnquireButton
+          listingId={listing.id}
+          listingTitle={listing.title}
+          buttonCls={buttonCls}
+        />
+      </div>
+    </article>
+  );
+}
+
+/**
+ * Pull up to 2 human-readable pairs out of the key_metrics JSONB.
+ * Prioritises commonly-informative keys and falls back to the
+ * first-two-string-values heuristic.
+ */
+function extractKeyMetrics(
+  km: Record<string, unknown> | null | undefined,
+): Array<{ label: string; value: string }> {
+  if (!km || typeof km !== "object") return [];
+  const PRIORITY_KEYS = [
+    "asx_ticker",
+    "commodity",
+    "stage",
+    "market_cap_bn_aud",
+    "dividend_yield",
+    "mer_bps",
+    "fssp_eligible",
+    "resource_mlb_u3o8",
+    "refinery_capacity_bbl_day",
+    "capacity_GW",
+  ];
+  const out: Array<{ label: string; value: string }> = [];
+  for (const key of PRIORITY_KEYS) {
+    if (out.length >= 2) break;
+    const v = km[key];
+    if (v == null || v === false) continue;
+    out.push({ label: prettify(key), value: String(v) });
+  }
+  if (out.length < 2) {
+    for (const [k, v] of Object.entries(km)) {
+      if (out.length >= 2) break;
+      if (PRIORITY_KEYS.includes(k)) continue;
+      if (v == null || v === false || typeof v === "object") continue;
+      out.push({ label: prettify(k), value: String(v) });
+    }
+  }
+  return out;
+}
+
+function prettify(key: string): string {
+  return key
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase())
+    .replace(/Asx/i, "ASX")
+    .replace(/Aud/i, "AUD")
+    .replace(/Mer Bps/i, "MER bps");
+}


### PR DESCRIPTION
## Summary

Closes the "hidden marketplace listings" gap flagged in the audit.
Stacked on #164.
**Merge order:** #153 → #154 → #155 → #157 → #158 → #159 → #162 → #164 → this PR.

## Audit result (before this PR)

| vertical  | hub page source of data               | investment_listings rows hidden |
|-----------|---------------------------------------|--------------------------------:|
| oil-gas   | commodity_stocks + commodity_etfs     | 12                              |
| uranium   | commodity_stocks + commodity_etfs     | 12                              |
| hydrogen  | commodity_stocks + commodity_etfs     | 10                              |
| mining    | fully hardcoded bespoke page          | 5                               |
| funds     | fund_listings (separate table)        | 15                              |

None of the 5 priority hub pages surfaced their `investment_listings` rows. The hubs linked out to `/invest/<slug>/listings` but didn't render cards inline, so 54 active marketplace opportunities were two clicks away from the primary SEO entry points.

## What changed

### New reusable component
- **`components/marketplace/VerticalMarketplaceListings.tsx`** — server component. Fetches `investment_listings WHERE vertical=<slug> AND status='active'` ordered by listing_type desc then created_at desc. Renders up to 6 cards with title, description, price_display (or formatted asking_price_cents), location, up to 2 key_metrics from the JSONB, SIV/FIRB/premium/featured pills, and an inline Enquire CTA.
- **`components/marketplace/EnquireButton.tsx`** — client component. Opens a modal with name/email/phone/investor-type/message, POSTs to the existing `/api/listings/enquire` endpoint (which writes to `listing_enquiries` and emails the listing contact via Resend). Modal is intentionally carried by the button so most of the hub page stays server-rendered.

### Wired into 5 priority hub pages
- `/invest/oil-gas` (12 listings, amber accent)
- `/invest/uranium` (12 listings, yellow accent)
- `/invest/hydrogen` (10 listings, sky accent)
- `/invest/mining` (5 listings, amber accent) — note: mining's page is a sync function; Next.js happily renders an async child, no refactor needed.
- `/invest/funds` (15 `investment_listings` rows, complementary to the 8 `fund_listings` rows rendered by `FundsDirectoryClient`)

### /invest/listings per-vertical count strip
Added a small summary strip above the marketplace grid showing active listings-by-vertical counts. Counts come from the same fetched listings array (no extra round-trip). Each count is a link to the vertical-scoped listings page.

### Endpoint note
The spec asked me to create `/api/listings/enquire`. It was **already built and fully wired** (writes to `listing_enquiries`, emails seller via Resend, rate-limited, validated). I used the existing contract — field names `user_name` / `user_email` / `user_phone` — rather than introducing a duplicate endpoint.

## Manual verification

After this PR merges + Vercel deploys, the verification on prod:

```
/invest/oil-gas     → scroll past stocks / ETFs / ways-to-invest / adviser CTA → 12 listings cards render with "Enquire" buttons
/invest/uranium     → same pattern, 12 cards
/invest/hydrogen    → 10 cards
/invest/mining      → 5 cards (inserted before the foreign-investor note section)
/invest/funds       → 6 fund_listings cards above, then "More fund opportunities" with investment_listings cards below
/invest/listings    → count strip above the main marketplace grid shows every active vertical with its live count
```

## Files changed

- **New:** `components/marketplace/VerticalMarketplaceListings.tsx` (server), `components/marketplace/EnquireButton.tsx` (client)
- **Modified:** `app/invest/{oil-gas, uranium, hydrogen, mining, funds}/page.tsx`, `app/invest/listings/page.tsx`

`tsc --noEmit` clean. All three commits passed the pre-commit hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)