### PR TITLE
Improvements sweep: should-I-switch, pre-launch V2, concierge polish, schema lib

### DIFF
--- a/app/admin/pre-launch/page.tsx
+++ b/app/admin/pre-launch/page.tsx
@@ -216,13 +216,98 @@ async function gatherMetrics(): Promise<Metric[]> {
   return metrics;
 }
 
+/* ─── V2: deployment & environment checks ─── */
+
+interface EnvCheck {
+  key: string;
+  required: boolean;
+  present: boolean;
+  note: string;
+}
+
+function checkEnv(): EnvCheck[] {
+  const vars: Array<Omit<EnvCheck, "present">> = [
+    { key: "NEXT_PUBLIC_SUPABASE_URL", required: true, note: "Supabase project URL — public, required for all client DB reads." },
+    { key: "NEXT_PUBLIC_SUPABASE_ANON_KEY", required: true, note: "Supabase anon key — required for all client DB reads." },
+    { key: "SUPABASE_SERVICE_ROLE_KEY", required: true, note: "Server-side admin client. Required for cron jobs, admin portal." },
+    { key: "NEXT_PUBLIC_SITE_URL", required: true, note: "Canonical site URL used in absoluteUrl() and sitemap." },
+    { key: "ANTHROPIC_API_KEY", required: true, note: "Powers the concierge chat + content ops scripts." },
+    { key: "RESEND_API_KEY", required: true, note: "Transactional email (newsletters, advisor claims, concierge digests)." },
+    { key: "STRIPE_SECRET_KEY", required: false, note: "Sponsor billing + advisor subscription — optional for soft launch." },
+    { key: "STRIPE_WEBHOOK_SECRET", required: false, note: "Stripe webhook verification. Required if STRIPE_SECRET_KEY is set." },
+    { key: "NEXT_PUBLIC_SENTRY_DSN", required: false, note: "Client-side Sentry error reporting." },
+    { key: "SENTRY_AUTH_TOKEN", required: false, note: "Sentry source-map upload at build time." },
+    { key: "CRON_SECRET", required: true, note: "Authenticates scheduled Vercel cron jobs." },
+  ];
+  return vars.map((v) => ({
+    ...v,
+    present: Boolean(process.env[v.key] && process.env[v.key]!.trim()),
+  }));
+}
+
+interface UrlCheck {
+  path: string;
+  status: number | null;
+  ok: boolean;
+  note: string;
+}
+
+async function checkCriticalUrls(): Promise<UrlCheck[]> {
+  const base =
+    process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/$/, "") ||
+    "https://invest.com.au";
+
+  const paths: Array<{ path: string; note: string }> = [
+    { path: "/", note: "Homepage" },
+    { path: "/sitemap.xml", note: "Sitemap index — Google crawls this first" },
+    { path: "/robots.txt", note: "Robots directives" },
+    { path: "/compare", note: "Broker comparison hub" },
+    { path: "/best/low-fees", note: "Best-for category template" },
+    { path: "/api/health", note: "Application health endpoint" },
+  ];
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 4000);
+  try {
+    const results = await Promise.all(
+      paths.map(async (p) => {
+        try {
+          const r = await fetch(`${base}${p.path}`, {
+            method: "GET",
+            redirect: "manual",
+            cache: "no-store",
+            signal: controller.signal,
+          });
+          const ok = r.status >= 200 && r.status < 400;
+          return { path: p.path, status: r.status, ok, note: p.note };
+        } catch {
+          return { path: p.path, status: null, ok: false, note: p.note };
+        }
+      }),
+    );
+    return results;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 export default async function AdminPreLaunchPage() {
   const metrics = await gatherMetrics();
+  const envChecks = checkEnv();
+  const urlChecks = await checkCriticalUrls();
   const blockers = metrics.filter((m) => m.severity === "block").length;
   const warnings = metrics.filter((m) => m.severity === "warn").length;
+  const missingRequiredEnv = envChecks.filter(
+    (e) => e.required && !e.present,
+  ).length;
+  const urlFailures = urlChecks.filter((u) => !u.ok).length;
 
   const overallSeverity: Metric["severity"] =
-    blockers > 0 ? "block" : warnings > 2 ? "warn" : "ok";
+    blockers > 0 || missingRequiredEnv > 0 || urlFailures > 0
+      ? "block"
+      : warnings > 2
+        ? "warn"
+        : "ok";
 
   return (
     <AdminShell
@@ -261,7 +346,7 @@ export default async function AdminPreLaunchPage() {
             }`}
           >
             {overallSeverity === "block"
-              ? `${blockers} blocker(s) detected — address before hard launch`
+              ? `${blockers + missingRequiredEnv + urlFailures} blocker(s) detected — address before hard launch`
               : overallSeverity === "warn"
                 ? `${warnings} warning(s) — review before hard launch`
                 : "All content-health checks pass"}
@@ -339,6 +424,116 @@ export default async function AdminPreLaunchPage() {
               </div>
             </div>
           ))}
+        </div>
+
+        {/* Environment variables */}
+        <div className="bg-white border border-slate-200 rounded-xl p-5">
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="text-sm font-extrabold uppercase tracking-wide text-slate-700">
+              Environment variables
+            </h2>
+            <span
+              className={`text-[10px] font-extrabold uppercase tracking-wide px-2 py-0.5 rounded-full ${
+                missingRequiredEnv > 0
+                  ? "bg-rose-100 text-rose-800"
+                  : "bg-emerald-100 text-emerald-800"
+              }`}
+            >
+              {missingRequiredEnv > 0
+                ? `${missingRequiredEnv} missing`
+                : "All required present"}
+            </span>
+          </div>
+          <div className="divide-y divide-slate-100">
+            {envChecks.map((e) => (
+              <div
+                key={e.key}
+                className="py-2 flex items-start justify-between gap-3"
+              >
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <code className="text-xs font-mono text-slate-900">
+                      {e.key}
+                    </code>
+                    {e.required && (
+                      <span className="text-[9px] font-bold uppercase tracking-wide text-slate-500">
+                        required
+                      </span>
+                    )}
+                  </div>
+                  <p className="text-[11px] text-slate-500 mt-0.5 max-w-xl">
+                    {e.note}
+                  </p>
+                </div>
+                <span
+                  className={`text-[10px] font-bold uppercase tracking-wide px-2 py-0.5 rounded-full shrink-0 ${
+                    e.present
+                      ? "bg-emerald-50 text-emerald-800"
+                      : e.required
+                        ? "bg-rose-50 text-rose-800"
+                        : "bg-slate-100 text-slate-600"
+                  }`}
+                >
+                  {e.present ? "Set" : e.required ? "Missing" : "Not set"}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Critical URL checks */}
+        <div className="bg-white border border-slate-200 rounded-xl p-5">
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="text-sm font-extrabold uppercase tracking-wide text-slate-700">
+              Critical URL reachability
+            </h2>
+            <span
+              className={`text-[10px] font-extrabold uppercase tracking-wide px-2 py-0.5 rounded-full ${
+                urlFailures > 0
+                  ? "bg-rose-100 text-rose-800"
+                  : "bg-emerald-100 text-emerald-800"
+              }`}
+            >
+              {urlFailures > 0
+                ? `${urlFailures} failing`
+                : "All reachable"}
+            </span>
+          </div>
+          <p className="text-[11px] text-slate-500 mb-3">
+            GETs each path against{" "}
+            <code className="bg-slate-50 px-1 rounded">
+              NEXT_PUBLIC_SITE_URL
+            </code>{" "}
+            with a 4s timeout. 3xx redirects count as OK. A failure here likely
+            means Vercel is down, DNS is misconfigured, or the route is
+            broken.
+          </p>
+          <div className="divide-y divide-slate-100">
+            {urlChecks.map((u) => (
+              <div
+                key={u.path}
+                className="py-2 flex items-center justify-between gap-3"
+              >
+                <div className="min-w-0">
+                  <code className="text-xs font-mono text-slate-900 truncate block">
+                    {u.path}
+                  </code>
+                  <p className="text-[11px] text-slate-500 mt-0.5">
+                    {u.note}
+                  </p>
+                </div>
+                <span
+                  className={`text-[10px] font-bold uppercase tracking-wide px-2 py-0.5 rounded-full shrink-0 ${
+                    u.ok
+                      ? "bg-emerald-50 text-emerald-800"
+                      : "bg-rose-50 text-rose-800"
+                  }`}
+                >
+                  {u.status == null ? "Timeout" : u.status}
+                </span>
+              </div>
+            ))}
+          </div>
         </div>
 
         {/* Ops notes */}

--- a/app/api/concierge/route.ts
+++ b/app/api/concierge/route.ts
@@ -220,3 +220,68 @@ export async function POST(req: NextRequest) {
     },
   });
 }
+
+/**
+ * GET /api/concierge?session_id=…
+ *
+ * Returns prior-turn history for the supplied session so the UI can
+ * rehydrate a conversation after a page refresh. Ordered oldest-first
+ * and capped at the last 40 turns.
+ */
+export async function GET(req: NextRequest) {
+  const session_id = req.nextUrl.searchParams.get("session_id") ?? "";
+  if (!/^[a-zA-Z0-9_-]{8,120}$/.test(session_id)) {
+    return NextResponse.json({ messages: [] });
+  }
+  if (!(await isAllowed("concierge_read", ipKey(req), { max: 60, refillPerSec: 1 }))) {
+    return new Response("Too many requests", { status: 429 });
+  }
+
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("chatbot_conversations")
+    .select("role, content, created_at")
+    .eq("session_id", session_id)
+    .order("created_at", { ascending: false })
+    .limit(40);
+
+  if (error) {
+    log.error("history_fetch_failed", { err: error.message });
+    return NextResponse.json({ messages: [] });
+  }
+
+  const messages = (data ?? [])
+    .slice()
+    .reverse()
+    .filter((r): r is { role: "user" | "assistant"; content: string; created_at: string } =>
+      (r.role === "user" || r.role === "assistant") && typeof r.content === "string",
+    )
+    .map((r) => ({ role: r.role, content: r.content }));
+
+  return NextResponse.json({ messages });
+}
+
+/**
+ * DELETE /api/concierge?session_id=…
+ *
+ * Clears the session's stored history so the user can start over.
+ */
+export async function DELETE(req: NextRequest) {
+  const session_id = req.nextUrl.searchParams.get("session_id") ?? "";
+  if (!/^[a-zA-Z0-9_-]{8,120}$/.test(session_id)) {
+    return NextResponse.json({ ok: false, error: "invalid session" }, { status: 400 });
+  }
+  if (!(await isAllowed("concierge_delete", ipKey(req), { max: 10, refillPerSec: 0.1 }))) {
+    return new Response("Too many requests", { status: 429 });
+  }
+  const supabase = createAdminClient();
+  const { error } = await supabase
+    .from("chatbot_conversations")
+    .delete()
+    .eq("session_id", session_id);
+  if (error) {
+    log.error("history_delete_failed", { err: error.message });
+    return NextResponse.json({ ok: false }, { status: 500 });
+  }
+  return NextResponse.json({ ok: true });
+}

--- a/app/concierge/ConciergeClient.tsx
+++ b/app/concierge/ConciergeClient.tsx
@@ -70,17 +70,46 @@ export default function ConciergeClient() {
   const [input, setInput] = useState("");
   const [streaming, setStreaming] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [hydrating, setHydrating] = useState(false);
   const bottomRef = useRef<HTMLDivElement | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
 
-  // Restore session id on mount.
+  // Restore session id on mount and fetch stored history.
   useEffect(() => {
+    let cancelled = false;
     try {
       const stored = localStorage.getItem(SESSION_KEY);
-      if (stored && stored.length <= 120) setSessionId(stored);
+      if (stored && stored.length <= 120) {
+        setSessionId(stored);
+        setHydrating(true);
+        (async () => {
+          try {
+            const r = await fetch(
+              `/api/concierge?session_id=${encodeURIComponent(stored)}`,
+              { cache: "no-store" },
+            );
+            if (!r.ok) return;
+            const json = (await r.json()) as {
+              messages?: Array<{ role: "user" | "assistant"; content: string }>;
+            };
+            if (cancelled || !json.messages?.length) return;
+            setMessages(
+              json.messages.map((m) => ({ ...m, id: genId() })),
+            );
+          } catch {
+            // offline / blocked — fine, session starts fresh
+          } finally {
+            if (!cancelled) setHydrating(false);
+          }
+        })();
+      }
     } catch {
       // localStorage blocked — fine, we'll generate server-side.
     }
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   // Scroll to bottom on new content.
@@ -111,6 +140,8 @@ export default function ConciergeClient() {
         { role: "assistant", content: "", id: assistantId },
       ]);
 
+      const ac = new AbortController();
+      abortRef.current = ac;
       try {
         const res = await fetch("/api/concierge", {
           method: "POST",
@@ -120,6 +151,7 @@ export default function ConciergeClient() {
             session_id: sessionId ?? undefined,
             history,
           }),
+          signal: ac.signal,
         });
 
         if (!res.ok || !res.body) {
@@ -173,19 +205,58 @@ export default function ConciergeClient() {
           }
         }
       } catch (err) {
-        setError(
-          err instanceof Error
-            ? err.message
-            : "Unexpected error — please try again",
-        );
-        setMessages((prev) => prev.filter((m) => m.id !== assistantId));
+        const aborted =
+          err instanceof DOMException && err.name === "AbortError";
+        if (!aborted) {
+          setError(
+            err instanceof Error
+              ? err.message
+              : "Unexpected error — please try again",
+          );
+          setMessages((prev) => prev.filter((m) => m.id !== assistantId));
+        } else {
+          setMessages((prev) =>
+            prev.map((m) =>
+              m.id === assistantId && m.content.length === 0
+                ? { ...m, content: "_(stopped)_" }
+                : m,
+            ),
+          );
+        }
       } finally {
+        abortRef.current = null;
         setStreaming(false);
         requestAnimationFrame(() => textareaRef.current?.focus());
       }
     },
     [streaming, messages, sessionId],
   );
+
+  const stopStream = useCallback(() => {
+    abortRef.current?.abort();
+  }, []);
+
+  const clearSession = useCallback(async () => {
+    if (streaming) return;
+    const sid = sessionId;
+    setMessages([]);
+    setError(null);
+    try {
+      localStorage.removeItem(SESSION_KEY);
+    } catch {
+      // ignore
+    }
+    setSessionId(null);
+    if (sid) {
+      try {
+        await fetch(`/api/concierge?session_id=${encodeURIComponent(sid)}`, {
+          method: "DELETE",
+        });
+      } catch {
+        // server-side deletion best-effort
+      }
+    }
+  }, [streaming, sessionId]);
 
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -216,14 +287,28 @@ export default function ConciergeClient() {
             <span className="text-slate-600">/</span>
             <span className="text-white font-medium">Concierge</span>
           </nav>
-          <h1 className="text-2xl md:text-3xl font-extrabold mb-1">
-            Investment concierge
-          </h1>
-          <p className="text-xs md:text-sm text-slate-400 max-w-2xl">
-            Ask anything about Australian investing — platforms, funds,
-            advisors, SMSF, FIRB, foreign investor rules. Educational only,
-            not personal financial advice.
-          </p>
+          <div className="flex items-start justify-between gap-3 flex-wrap">
+            <div>
+              <h1 className="text-2xl md:text-3xl font-extrabold mb-1">
+                Investment concierge
+              </h1>
+              <p className="text-xs md:text-sm text-slate-400 max-w-2xl">
+                Ask anything about Australian investing — platforms, funds,
+                advisors, SMSF, FIRB, foreign investor rules. Educational
+                only, not personal financial advice.
+              </p>
+            </div>
+            {messages.length > 0 && (
+              <button
+                type="button"
+                onClick={() => void clearSession()}
+                disabled={streaming}
+                className="text-[11px] font-semibold text-slate-300 hover:text-white disabled:opacity-40 border border-slate-700 hover:border-slate-500 rounded-full px-3 py-1 transition-colors"
+              >
+                Clear conversation
+              </button>
+            )}
+          </div>
         </div>
       </section>
 
@@ -231,7 +316,11 @@ export default function ConciergeClient() {
         <div className="container-custom max-w-4xl py-5 md:py-8">
           {/* Messages */}
           <div className="bg-white border border-slate-200 rounded-2xl p-4 md:p-6 min-h-[320px] mb-4">
-            {messages.length === 0 ? (
+            {hydrating && messages.length === 0 ? (
+              <div className="text-center py-12 text-xs text-slate-500">
+                Restoring your last conversation…
+              </div>
+            ) : messages.length === 0 ? (
               <div className="text-center py-8">
                 <div className="w-10 h-10 mx-auto mb-3 rounded-full bg-amber-100 flex items-center justify-center">
                   <Icon name="message-circle" size={20} className="text-amber-600" />
@@ -315,14 +404,25 @@ export default function ConciergeClient() {
               className="w-full bg-white border border-slate-300 rounded-2xl px-4 py-3 pr-24 text-sm focus:ring-2 focus:ring-amber-400 focus:outline-none resize-none"
               disabled={streaming}
             />
-            <button
-              type="submit"
-              disabled={!canSend}
-              className="absolute bottom-3 right-3 inline-flex items-center gap-1.5 bg-amber-500 hover:bg-amber-600 disabled:bg-slate-300 text-white font-bold text-xs px-4 py-2 rounded-lg"
-            >
-              {streaming ? "Thinking…" : "Send"}
-              <Icon name="arrow-right" size={12} />
-            </button>
+            {streaming ? (
+              <button
+                type="button"
+                onClick={stopStream}
+                className="absolute bottom-3 right-3 inline-flex items-center gap-1.5 bg-slate-800 hover:bg-slate-900 text-white font-bold text-xs px-4 py-2 rounded-lg"
+              >
+                Stop
+                <Icon name="x-circle" size={12} />
+              </button>
+            ) : (
+              <button
+                type="submit"
+                disabled={!canSend}
+                className="absolute bottom-3 right-3 inline-flex items-center gap-1.5 bg-amber-500 hover:bg-amber-600 disabled:bg-slate-300 text-white font-bold text-xs px-4 py-2 rounded-lg"
+              >
+                Send
+                <Icon name="arrow-right" size={12} />
+              </button>
+            )}
           </form>
 
           <p className="text-[11px] text-slate-500 leading-relaxed mt-3">

--- a/app/invest/alternatives/listings/[slug]/page.tsx
+++ b/app/invest/alternatives/listings/[slug]/page.tsx
@@ -14,6 +14,7 @@ import {
   ALTERNATIVES_SUB_CATEGORIES,
 } from "@/lib/investment-listings-query";
 import { getSubcategoryBySlug } from "@/lib/invest-categories";
+import ListingSchemaScripts from "@/components/ListingSchemaScripts";
 
 export const revalidate = 300;
 
@@ -155,6 +156,7 @@ export default async function AlternativesListingDetailPage({
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
       />
+      <ListingSchemaScripts listing={l} vertical={CATEGORY_SLUG} />
 
       {/* Hero */}
       <section className="bg-white border-b border-slate-100 py-12">

--- a/app/invest/buy-business/listings/[slug]/page.tsx
+++ b/app/invest/buy-business/listings/[slug]/page.tsx
@@ -13,6 +13,7 @@ import {
   fetchRelatedListings,
 } from "@/lib/investment-listings-query";
 import { getSubcategoryBySlug } from "@/lib/invest-categories";
+import ListingSchemaScripts from "@/components/ListingSchemaScripts";
 
 export const revalidate = 300;
 
@@ -120,6 +121,7 @@ export default async function BusinessListingDetailPage({
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
       />
+      <ListingSchemaScripts listing={l} vertical={CATEGORY_SLUG} />
 
       {/* Hero */}
       <section className="bg-white border-b border-slate-100 py-12">

--- a/app/invest/commercial-property/listings/[slug]/page.tsx
+++ b/app/invest/commercial-property/listings/[slug]/page.tsx
@@ -13,6 +13,7 @@ import {
   fetchRelatedListings,
 } from "@/lib/investment-listings-query";
 import { getSubcategoryBySlug } from "@/lib/invest-categories";
+import ListingSchemaScripts from "@/components/ListingSchemaScripts";
 
 export const revalidate = 300;
 
@@ -121,6 +122,7 @@ export default async function CommercialListingDetailPage({
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
       />
+      <ListingSchemaScripts listing={l} vertical={CATEGORY_SLUG} />
 
       <section className="bg-white border-b border-slate-100 py-12">
         <div className="container-custom">

--- a/app/invest/farmland/listings/[slug]/page.tsx
+++ b/app/invest/farmland/listings/[slug]/page.tsx
@@ -13,6 +13,7 @@ import {
   fetchRelatedListings,
 } from "@/lib/investment-listings-query";
 import { getSubcategoryBySlug } from "@/lib/invest-categories";
+import ListingSchemaScripts from "@/components/ListingSchemaScripts";
 
 export const revalidate = 300;
 
@@ -120,6 +121,7 @@ export default async function FarmlandListingDetailPage({
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
       />
+      <ListingSchemaScripts listing={l} vertical={CATEGORY_SLUG} />
 
       <section className="bg-white border-b border-slate-100 py-12">
         <div className="container-custom">

--- a/app/invest/franchise/listings/[slug]/page.tsx
+++ b/app/invest/franchise/listings/[slug]/page.tsx
@@ -13,6 +13,7 @@ import {
   fetchRelatedListings,
 } from "@/lib/investment-listings-query";
 import { getSubcategoryBySlug } from "@/lib/invest-categories";
+import ListingSchemaScripts from "@/components/ListingSchemaScripts";
 
 export const revalidate = 300;
 
@@ -120,6 +121,7 @@ export default async function FranchiseListingDetailPage({
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
       />
+      <ListingSchemaScripts listing={l} vertical={CATEGORY_SLUG} />
 
       <section className="bg-white border-b border-slate-100 py-12">
         <div className="container-custom">

--- a/app/invest/infrastructure/listings/[slug]/page.tsx
+++ b/app/invest/infrastructure/listings/[slug]/page.tsx
@@ -14,6 +14,7 @@ import {
   INFRASTRUCTURE_SUB_CATEGORIES,
 } from "@/lib/investment-listings-query";
 import { getSubcategoryBySlug } from "@/lib/invest-categories";
+import ListingSchemaScripts from "@/components/ListingSchemaScripts";
 
 export const revalidate = 300;
 
@@ -136,6 +137,7 @@ export default async function InfrastructureListingDetailPage({
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
       />
+      <ListingSchemaScripts listing={l} vertical={CATEGORY_SLUG} />
 
       {/* Hero */}
       <section className="bg-white border-b border-slate-100 py-12">

--- a/app/invest/mining/listings/[slug]/page.tsx
+++ b/app/invest/mining/listings/[slug]/page.tsx
@@ -13,6 +13,7 @@ import {
   fetchRelatedListings,
 } from "@/lib/investment-listings-query";
 import { getSubcategoryBySlug } from "@/lib/invest-categories";
+import ListingSchemaScripts from "@/components/ListingSchemaScripts";
 
 export const revalidate = 300;
 
@@ -125,6 +126,7 @@ export default async function MiningOpportunityDetailPage({
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
       />
+      <ListingSchemaScripts listing={l} vertical={CATEGORY_SLUG} />
 
       <section className="bg-white border-b border-slate-100 py-12">
         <div className="container-custom">

--- a/app/invest/private-credit/listings/[slug]/page.tsx
+++ b/app/invest/private-credit/listings/[slug]/page.tsx
@@ -14,6 +14,7 @@ import {
   PRIVATE_CREDIT_SUB_CATEGORIES,
 } from "@/lib/investment-listings-query";
 import { getSubcategoryBySlug } from "@/lib/invest-categories";
+import ListingSchemaScripts from "@/components/ListingSchemaScripts";
 
 export const revalidate = 300;
 
@@ -136,6 +137,7 @@ export default async function PrivateCreditListingDetailPage({
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
       />
+      <ListingSchemaScripts listing={l} vertical={CATEGORY_SLUG} />
 
       {/* Hero */}
       <section className="bg-white border-b border-slate-100 py-12">

--- a/app/invest/renewable-energy/listings/[slug]/page.tsx
+++ b/app/invest/renewable-energy/listings/[slug]/page.tsx
@@ -13,6 +13,7 @@ import {
   fetchRelatedListings,
 } from "@/lib/investment-listings-query";
 import { getSubcategoryBySlug } from "@/lib/invest-categories";
+import ListingSchemaScripts from "@/components/ListingSchemaScripts";
 
 export const revalidate = 300;
 
@@ -121,6 +122,7 @@ export default async function EnergyProjectDetailPage({
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
       />
+      <ListingSchemaScripts listing={l} vertical={CATEGORY_SLUG} />
 
       <section className="bg-white border-b border-slate-100 py-12">
         <div className="container-custom">

--- a/app/invest/startups/listings/[slug]/page.tsx
+++ b/app/invest/startups/listings/[slug]/page.tsx
@@ -13,6 +13,7 @@ import {
   fetchRelatedListings,
 } from "@/lib/investment-listings-query";
 import { getSubcategoryBySlug } from "@/lib/invest-categories";
+import ListingSchemaScripts from "@/components/ListingSchemaScripts";
 
 export const revalidate = 300;
 
@@ -123,6 +124,7 @@ export default async function StartupOpportunityDetailPage({
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
       />
+      <ListingSchemaScripts listing={l} vertical={CATEGORY_SLUG} />
 
       <section className="bg-white border-b border-slate-100 py-12">
         <div className="container-custom">

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -78,6 +78,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     "/advisor-apply", "/switching-calculator", "/savings-calculator",
     "/quick-audit", "/portfolio-xray", "/tax-optimizer", "/fee-simulator",
     "/trade-cost-calculator", "/us-share-costs-calculator", "/cgt-calculator",
+    "/tools", "/tools/should-i-switch", "/tools/visa-investment-calculator", "/tools/withholding-tax-calculator",
     "/firb-fee-estimator", "/non-resident-dividend-calculator", "/non-resident-cgt-checker",
     "/franking-credits-calculator", "/chess-lookup",
     "/share-trading", "/crypto", "/savings", "/super", "/cfd",

--- a/app/tools/should-i-switch/ShouldISwitchClient.tsx
+++ b/app/tools/should-i-switch/ShouldISwitchClient.tsx
@@ -1,0 +1,410 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import Icon from "@/components/Icon";
+import type { Broker } from "@/lib/types";
+import { getAffiliateLink } from "@/lib/tracking";
+
+type AssetMix = "asx" | "us" | "mixed";
+
+interface CostBreakdown {
+  broker: Broker;
+  asxBrokerage: number;
+  usBrokerage: number;
+  fxCost: number;
+  inactivity: number;
+  total: number;
+}
+
+function parseInactivityAnnual(raw: string | null | undefined): number {
+  if (!raw) return 0;
+  const s = raw.trim();
+  if (!s || /^(none|no|\$?0)$/i.test(s)) return 0;
+  const m = s.match(/\$(\d+(?:\.\d+)?)/);
+  if (!m) return 0;
+  const amount = parseFloat(m[1]!);
+  if (/month/i.test(s)) return amount * 12;
+  if (/qtr|quarter/i.test(s)) return amount * 4;
+  return amount;
+}
+
+function computeAnnualCost(
+  broker: Broker,
+  tradesPerMonth: number,
+  avgTradeSize: number,
+  mix: AssetMix,
+): CostBreakdown {
+  const totalAnnualTrades = tradesPerMonth * 12;
+
+  let asxShare = 0;
+  let usShare = 0;
+  if (mix === "asx") asxShare = 1;
+  else if (mix === "us") usShare = 1;
+  else {
+    asxShare = 0.5;
+    usShare = 0.5;
+  }
+
+  const asxTrades = totalAnnualTrades * asxShare;
+  const usTrades = totalAnnualTrades * usShare;
+
+  const asxBrokerage = (broker.asx_fee_value ?? 0) * asxTrades;
+  const usBrokerage = (broker.us_fee_value ?? 0) * usTrades;
+  const fxCost = ((broker.fx_rate ?? 0) / 100) * avgTradeSize * usTrades;
+  const inactivity = parseInactivityAnnual(broker.inactivity_fee);
+
+  const total = asxBrokerage + usBrokerage + fxCost + inactivity;
+  return { broker, asxBrokerage, usBrokerage, fxCost, inactivity, total };
+}
+
+function brokerHasRequiredFees(broker: Broker, mix: AssetMix): boolean {
+  const asxKnown = broker.asx_fee_value != null;
+  const usKnown = broker.us_fee_value != null && broker.fx_rate != null;
+  if (mix === "asx") return asxKnown;
+  if (mix === "us") return usKnown;
+  return asxKnown && usKnown;
+}
+
+function formatMoney(n: number): string {
+  return n.toLocaleString("en-AU", {
+    style: "currency",
+    currency: "AUD",
+    maximumFractionDigits: 0,
+  });
+}
+
+export default function ShouldISwitchClient({
+  brokers,
+}: {
+  brokers: Broker[];
+}) {
+  const [currentSlug, setCurrentSlug] = useState<string>("");
+  const [tradesPerMonth, setTradesPerMonth] = useState<number>(2);
+  const [avgTradeSize, setAvgTradeSize] = useState<number>(2000);
+  const [mix, setMix] = useState<AssetMix>("asx");
+
+  const results = useMemo(() => {
+    const eligible = brokers.filter((b) => brokerHasRequiredFees(b, mix));
+    const ranked = eligible
+      .map((b) => computeAnnualCost(b, tradesPerMonth, avgTradeSize, mix))
+      .sort((a, z) => a.total - z.total);
+    return ranked;
+  }, [brokers, tradesPerMonth, avgTradeSize, mix]);
+
+  const current = useMemo(
+    () => results.find((r) => r.broker.slug === currentSlug) ?? null,
+    [results, currentSlug],
+  );
+
+  const alternatives = useMemo(() => {
+    const top = results.filter((r) => r.broker.slug !== currentSlug).slice(0, 3);
+    return top;
+  }, [results, currentSlug]);
+
+  const annualSavings =
+    current && alternatives[0] ? Math.max(0, current.total - alternatives[0].total) : 0;
+  const tenYearSavings = annualSavings * 10;
+  const hasChoice = Boolean(currentSlug) && Boolean(current);
+
+  return (
+    <div className="py-5 md:py-12">
+      <div className="container-custom max-w-3xl">
+        <nav className="text-xs md:text-sm text-slate-500 mb-3 md:mb-6">
+          <Link href="/" className="hover:text-slate-900">
+            Home
+          </Link>
+          <span className="mx-1.5 md:mx-2">/</span>
+          <Link href="/tools" className="hover:text-slate-900">
+            Tools
+          </Link>
+          <span className="mx-1.5 md:mx-2">/</span>
+          <span className="text-slate-700">Should I Switch Broker?</span>
+        </nav>
+
+        <div className="bg-gradient-to-br from-amber-500 to-amber-600 rounded-2xl p-5 md:p-8 text-white mb-6 relative overflow-hidden">
+          <div className="relative z-10">
+            <div className="inline-flex items-center gap-2 bg-white/15 backdrop-blur-sm px-3 py-1 rounded-full mb-3">
+              <Icon name="arrow-right" size={14} className="text-white" />
+              <span className="text-xs font-bold uppercase tracking-wide">
+                Switch Calculator
+              </span>
+            </div>
+            <h1 className="text-2xl md:text-4xl font-extrabold mb-2 leading-tight">
+              Should I switch broker?
+            </h1>
+            <p className="text-sm md:text-base text-amber-50 max-w-2xl">
+              Pick your current broker, tell us how you invest, and we&apos;ll
+              compute the annual cost across every Australian platform — then
+              rank the top three alternatives by real $ saved.
+            </p>
+          </div>
+          <div className="absolute -right-10 -bottom-10 w-48 h-48 bg-white/5 rounded-full" />
+          <div className="absolute -right-24 -top-16 w-64 h-64 bg-white/5 rounded-full" />
+        </div>
+
+        <section className="bg-white border border-slate-200 rounded-xl p-5 md:p-6 mb-6">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-5">
+            <label className="block">
+              <span className="block text-xs font-semibold text-slate-700 mb-1.5">
+                Your current broker
+              </span>
+              <select
+                value={currentSlug}
+                onChange={(e) => setCurrentSlug(e.target.value)}
+                className="w-full border border-slate-300 rounded-lg px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-500"
+              >
+                <option value="">Select a broker…</option>
+                {brokers.map((b) => (
+                  <option key={b.slug} value={b.slug}>
+                    {b.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="block">
+              <span className="block text-xs font-semibold text-slate-700 mb-1.5">
+                Asset mix
+              </span>
+              <select
+                value={mix}
+                onChange={(e) => setMix(e.target.value as AssetMix)}
+                className="w-full border border-slate-300 rounded-lg px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-500"
+              >
+                <option value="asx">ASX shares only</option>
+                <option value="us">US shares only</option>
+                <option value="mixed">Mixed — 50% ASX, 50% US</option>
+              </select>
+            </label>
+
+            <label className="block">
+              <span className="block text-xs font-semibold text-slate-700 mb-1.5">
+                Trades per month
+              </span>
+              <input
+                type="number"
+                min={0}
+                step={1}
+                value={tradesPerMonth}
+                onChange={(e) =>
+                  setTradesPerMonth(Math.max(0, Number(e.target.value) || 0))
+                }
+                className="w-full border border-slate-300 rounded-lg px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-500"
+              />
+              <span className="block text-[11px] text-slate-500 mt-1">
+                {tradesPerMonth * 12} trades/year
+              </span>
+            </label>
+
+            <label className="block">
+              <span className="block text-xs font-semibold text-slate-700 mb-1.5">
+                Average trade size (AUD)
+              </span>
+              <input
+                type="number"
+                min={0}
+                step={100}
+                value={avgTradeSize}
+                onChange={(e) =>
+                  setAvgTradeSize(Math.max(0, Number(e.target.value) || 0))
+                }
+                className="w-full border border-slate-300 rounded-lg px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-500"
+              />
+              <span className="block text-[11px] text-slate-500 mt-1">
+                Annual turnover:{" "}
+                {formatMoney(tradesPerMonth * 12 * avgTradeSize)}
+              </span>
+            </label>
+          </div>
+        </section>
+
+        {hasChoice && current ? (
+          <section className="bg-slate-900 text-white rounded-2xl p-5 md:p-7 mb-6">
+            <div className="flex items-center justify-between gap-4 flex-wrap">
+              <div>
+                <div className="text-xs font-semibold uppercase tracking-wide text-amber-300">
+                  Verdict
+                </div>
+                <h2 className="text-xl md:text-2xl font-bold mt-1">
+                  {annualSavings > 50 ? (
+                    <>
+                      Yes — switching to{" "}
+                      <span className="text-amber-300">
+                        {alternatives[0]?.broker.name}
+                      </span>{" "}
+                      saves you {formatMoney(annualSavings)} per year.
+                    </>
+                  ) : annualSavings > 0 ? (
+                    <>
+                      Maybe — you&apos;d save only{" "}
+                      {formatMoney(annualSavings)} a year. Not worth switching
+                      unless you value other features.
+                    </>
+                  ) : (
+                    <>
+                      No — you&apos;re already on the cheapest broker for this
+                      profile.
+                    </>
+                  )}
+                </h2>
+                <p className="text-sm text-slate-300 mt-2">
+                  Your current annual cost on{" "}
+                  <strong>{current.broker.name}</strong>:{" "}
+                  <strong>{formatMoney(current.total)}</strong>. Over 10 years
+                  of the same trading profile, switching would save{" "}
+                  <strong>{formatMoney(tenYearSavings)}</strong> before
+                  compounding.
+                </p>
+              </div>
+            </div>
+          </section>
+        ) : null}
+
+        <section className="bg-white border border-slate-200 rounded-xl overflow-hidden mb-6">
+          <div className="p-4 md:p-5 border-b border-slate-100 flex items-center justify-between">
+            <h3 className="text-sm md:text-base font-bold text-slate-900">
+              {hasChoice
+                ? "Top 3 cheapest alternatives"
+                : "Cheapest brokers for your profile"}
+            </h3>
+            <span className="text-[11px] text-slate-500">
+              Ranked by annual cost
+            </span>
+          </div>
+          <ol className="divide-y divide-slate-100">
+            {(hasChoice ? alternatives : results.slice(0, 5)).map((r, idx) => {
+              const delta = current ? current.total - r.total : 0;
+              return (
+                <li
+                  key={r.broker.slug}
+                  className="p-4 md:p-5 flex items-center justify-between gap-4 flex-wrap"
+                >
+                  <div className="flex items-center gap-3 min-w-0">
+                    <span className="w-7 h-7 shrink-0 rounded-full bg-amber-50 text-amber-700 text-xs font-bold flex items-center justify-center">
+                      {idx + 1}
+                    </span>
+                    <div className="min-w-0">
+                      <Link
+                        href={`/broker/${r.broker.slug}`}
+                        className="text-sm md:text-base font-semibold text-slate-900 hover:text-amber-700 truncate block"
+                      >
+                        {r.broker.name}
+                      </Link>
+                      <div className="text-[11px] text-slate-500">
+                        {formatMoney(r.total)}/yr
+                        {r.fxCost > 0
+                          ? ` · inc. ${formatMoney(r.fxCost)} FX`
+                          : ""}
+                        {r.inactivity > 0
+                          ? ` · ${formatMoney(r.inactivity)} inactivity`
+                          : ""}
+                      </div>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-3 shrink-0">
+                    {hasChoice && delta > 0 ? (
+                      <span className="text-xs font-bold text-emerald-700 bg-emerald-50 rounded-full px-2.5 py-1">
+                        Save {formatMoney(delta)}/yr
+                      </span>
+                    ) : null}
+                    <a
+                      href={getAffiliateLink(r.broker)}
+                      target="_blank"
+                      rel="sponsored noopener noreferrer"
+                      className="text-xs md:text-sm font-semibold bg-amber-500 hover:bg-amber-600 text-white rounded-lg px-3 py-2 transition"
+                    >
+                      {r.broker.cta_text || "Visit broker"}
+                    </a>
+                  </div>
+                </li>
+              );
+            })}
+          </ol>
+          {results.length === 0 ? (
+            <div className="p-5 text-sm text-slate-500">
+              No brokers have complete fee data for this asset mix. Try another
+              mix.
+            </div>
+          ) : null}
+        </section>
+
+        <section className="bg-white border border-slate-200 rounded-xl p-5 md:p-6 mb-6">
+          <h3 className="text-sm md:text-base font-bold text-slate-900 mb-3">
+            How we calculate this
+          </h3>
+          <ul className="text-sm text-slate-600 space-y-1.5 leading-relaxed list-disc pl-5">
+            <li>
+              ASX brokerage = headline per-trade fee × ASX trades per year
+            </li>
+            <li>
+              US brokerage = headline per-trade fee × US trades per year
+            </li>
+            <li>
+              FX cost = FX margin % × average trade size × US trades per year
+            </li>
+            <li>
+              Inactivity fee parsed from the broker&apos;s published schedule
+            </li>
+          </ul>
+          <p className="text-xs text-slate-500 mt-3 leading-relaxed">
+            Numbers use each broker&apos;s published fees. Real trading costs
+            can differ due to tiered pricing, promotional rates, and
+            corporate-action fees. Always check the broker&apos;s full PDS
+            before switching. This is general information, not personal
+            advice.
+          </p>
+        </section>
+
+        <section className="bg-white border border-slate-200 rounded-xl p-5 md:p-6">
+          <h3 className="text-sm md:text-base font-bold text-slate-900 mb-3">
+            Before you switch
+          </h3>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3 text-sm text-slate-600">
+            <div>
+              <strong className="text-slate-900">CHESS vs custodial.</strong>{" "}
+              If you want to hold shares in your own name, pick a
+              CHESS-sponsored broker even if it&apos;s slightly more
+              expensive.
+            </div>
+            <div>
+              <strong className="text-slate-900">Transfer costs.</strong> Some
+              brokers charge $50-$110 to transfer existing holdings out. Check
+              both sides.
+            </div>
+            <div>
+              <strong className="text-slate-900">Off-market transfer.</strong>{" "}
+              CHESS → CHESS transfers are usually free between brokers. Your
+              new broker handles the paperwork.
+            </div>
+            <div>
+              <strong className="text-slate-900">Don&apos;t sell.</strong>{" "}
+              Selling to re-buy elsewhere triggers CGT. Transfer the holding
+              instead.
+            </div>
+          </div>
+          <div className="mt-4 flex flex-wrap gap-2 text-xs">
+            <Link
+              href="/compare"
+              className="inline-flex items-center gap-1 text-amber-700 hover:text-amber-800 font-semibold"
+            >
+              Compare all brokers →
+            </Link>
+            <Link
+              href="/best/low-fees"
+              className="inline-flex items-center gap-1 text-amber-700 hover:text-amber-800 font-semibold"
+            >
+              Best for low fees →
+            </Link>
+            <Link
+              href="/trade-cost-calculator"
+              className="inline-flex items-center gap-1 text-amber-700 hover:text-amber-800 font-semibold"
+            >
+              Per-trade cost calculator →
+            </Link>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/app/tools/should-i-switch/page.tsx
+++ b/app/tools/should-i-switch/page.tsx
@@ -1,0 +1,99 @@
+import type { Metadata } from "next";
+import { Suspense } from "react";
+import { createClient } from "@/lib/supabase/server";
+import type { Broker } from "@/lib/types";
+import {
+  absoluteUrl,
+  breadcrumbJsonLd,
+  CURRENT_YEAR,
+  SITE_NAME,
+} from "@/lib/seo";
+import ComplianceFooter from "@/components/ComplianceFooter";
+import ShouldISwitchClient from "./ShouldISwitchClient";
+
+export const revalidate = 3600;
+
+export const metadata: Metadata = {
+  title: `Should I Switch Broker? Savings Calculator (${CURRENT_YEAR}) — ${SITE_NAME}`,
+  description:
+    "See how much you'd save per year by switching Australian broker. Enter your current platform, trade size, and frequency — we compute the annual cost across every major broker and rank the top three cheapest alternatives.",
+  alternates: { canonical: "/tools/should-i-switch" },
+  openGraph: {
+    title: "Should I Switch Broker? — Annual Savings Calculator",
+    description:
+      "Compare your current broker against every Australian platform. Live brokerage + FX math shows exactly how much you'd save by switching.",
+    url: absoluteUrl("/tools/should-i-switch"),
+    images: [
+      {
+        url: "/api/og?title=Should+I+Switch+Broker%3F&subtitle=Annual+Savings+Calculator&type=default",
+        width: 1200,
+        height: 630,
+      },
+    ],
+  },
+  twitter: { card: "summary_large_image" as const },
+};
+
+const appLd = {
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  name: `Should I Switch Broker? — ${SITE_NAME}`,
+  description:
+    "Free interactive tool that calculates your annual broker cost and ranks the cheapest alternatives for your trading profile.",
+  url: absoluteUrl("/tools/should-i-switch"),
+  applicationCategory: "FinanceApplication",
+  operatingSystem: "Any",
+  offers: { "@type": "Offer", price: "0", priceCurrency: "AUD" },
+};
+
+const breadcrumbLd = breadcrumbJsonLd([
+  { name: "Home", url: absoluteUrl("/") },
+  { name: "Tools", url: absoluteUrl("/tools") },
+  {
+    name: "Should I Switch Broker?",
+    url: absoluteUrl("/tools/should-i-switch"),
+  },
+]);
+
+function Loading() {
+  return (
+    <div className="py-5 md:py-12 animate-pulse">
+      <div className="container-custom max-w-3xl">
+        <div className="h-6 w-64 bg-slate-100 rounded mb-4" />
+        <div className="h-48 bg-slate-100 rounded-2xl mb-6" />
+        <div className="h-96 bg-slate-100 rounded-xl" />
+      </div>
+    </div>
+  );
+}
+
+export default async function ShouldISwitchPage() {
+  const supabase = await createClient();
+  const { data: brokers } = await supabase
+    .from("brokers")
+    .select(
+      "id, name, slug, color, icon, logo_url, rating, asx_fee, asx_fee_value, us_fee, us_fee_value, fx_rate, chess_sponsored, smsf_support, is_crypto, inactivity_fee, cta_text, benefit_cta, affiliate_url, sponsorship_tier, status, platform_type",
+    )
+    .eq("status", "active")
+    .eq("is_crypto", false)
+    .order("name");
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(appLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
+      />
+      <Suspense fallback={<Loading />}>
+        <ShouldISwitchClient brokers={(brokers as Broker[]) || []} />
+      </Suspense>
+      <div className="container-custom pb-8">
+        <ComplianceFooter variant="calculator" />
+      </div>
+    </>
+  );
+}

--- a/components/ListingSchemaScripts.tsx
+++ b/components/ListingSchemaScripts.tsx
@@ -1,0 +1,46 @@
+import { listingProductJsonLd } from "@/lib/schema-markup";
+
+interface ListingLike {
+  slug: string;
+  title: string;
+  description?: string | null;
+  images?: string[] | null;
+  asking_price_cents?: number | null;
+  price_display?: string | null;
+  location_state?: string | null;
+  location_city?: string | null;
+}
+
+interface Props {
+  listing: ListingLike;
+  vertical: string;
+}
+
+/**
+ * Renders <script type="application/ld+json"> for a listing's
+ * Product schema. Kept as a tiny server component so the 10+ vertical
+ * listing-detail pages share a single canonical schema shape.
+ */
+export default function ListingSchemaScripts({ listing, vertical }: Props) {
+  const priceAud =
+    listing.asking_price_cents != null
+      ? Math.round(listing.asking_price_cents / 100)
+      : undefined;
+  const product = listingProductJsonLd({
+    slug: listing.slug,
+    title: listing.title,
+    description: listing.description ?? null,
+    imageUrl: listing.images?.[0] ?? null,
+    priceAud: priceAud ?? null,
+    priceDisplay: listing.price_display ?? null,
+    locationState: listing.location_state ?? null,
+    locationCity: listing.location_city ?? null,
+    vertical,
+  });
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(product) }}
+    />
+  );
+}

--- a/components/NewsletterExitIntentModal.tsx
+++ b/components/NewsletterExitIntentModal.tsx
@@ -58,8 +58,46 @@ export default function NewsletterExitIntentModal({
     [variant, pathname],
   );
 
+  // Only fire on pages where the reader is actively consuming
+  // content — article / compare / broker / advisor / best-for /
+  // tools. Never on homepage, login, account, onboarding or
+  // admin flows where an exit-intent popup is just friction.
+  const isEligiblePath = useCallback((path: string): boolean => {
+    if (!path || path === "/") return false;
+    const ALLOW_PREFIXES = [
+      "/article/",
+      "/compare",
+      "/broker/",
+      "/advisor/",
+      "/advisors/",
+      "/best/",
+      "/best-for/",
+      "/invest/",
+      "/tools/",
+      "/how-to/",
+      "/versus/",
+      "/research/",
+      "/foreign-investment/",
+      "/smsf",
+    ];
+    const DENY_PREFIXES = [
+      "/admin",
+      "/advisor-portal",
+      "/account",
+      "/login",
+      "/signup",
+      "/onboarding",
+      "/checkout",
+      "/quiz",
+      "/find-advisor",
+    ];
+    if (DENY_PREFIXES.some((p) => path.startsWith(p))) return false;
+    return ALLOW_PREFIXES.some((p) => path.startsWith(p));
+  }, []);
+
   const maybeFire = useCallback(() => {
     if (firedRef.current || disabled) return;
+    if (!isEligiblePath(pathname || "")) return;
     try {
       const k = "inv_newsletter_exit_intent_shown";
       if (sessionStorage.getItem(k)) return;
@@ -70,7 +108,7 @@ export default function NewsletterExitIntentModal({
     firedRef.current = true;
     setOpen(true);
     logEvent("shown");
-  }, [disabled, logEvent]);
+  }, [disabled, logEvent, isEligiblePath, pathname]);
 
   useEffect(() => {
     if (disabled) return;
@@ -96,11 +134,31 @@ export default function NewsletterExitIntentModal({
       lastScroll = y;
     };
 
+    // Mobile-UA 45s idle fallback — if the reader hasn't
+    // interacted (scroll, tap, touchmove) for 45 seconds AND has
+    // already seen some of the page, fire the modal.
+    let lastInteraction = Date.now();
+    const isMobileUA =
+      typeof navigator !== "undefined" &&
+      /Android|iPhone|iPad|iPod|Mobile/i.test(navigator.userAgent);
+    const onInteraction = () => {
+      lastInteraction = Date.now();
+    };
+    const idleCheck = window.setInterval(() => {
+      if (!isMobileUA) return;
+      if (Date.now() - lastInteraction >= 45_000 && seenDeep) maybeFire();
+    }, 5_000);
+
     document.addEventListener("mouseleave", onMouseLeave);
     window.addEventListener("scroll", onScroll, { passive: true });
+    document.addEventListener("touchstart", onInteraction, { passive: true });
+    document.addEventListener("touchmove", onInteraction, { passive: true });
     return () => {
       document.removeEventListener("mouseleave", onMouseLeave);
       window.removeEventListener("scroll", onScroll);
+      document.removeEventListener("touchstart", onInteraction);
+      document.removeEventListener("touchmove", onInteraction);
+      window.clearInterval(idleCheck);
     };
   }, [maybeFire, disabled]);
 

--- a/lib/keyword-linking.ts
+++ b/lib/keyword-linking.ts
@@ -1,0 +1,239 @@
+/**
+ * Keyword → canonical URL auto-linker.
+ *
+ * Scans article prose and wraps the first occurrence of high-value
+ * keywords in an internal link. Distributes SEO authority from 266
+ * published articles down to deep broker / advisor / hub pages.
+ *
+ * Pure — no DB lookups at render time. Maintain the keyword map in
+ * this file when a new broker, advisor type, or hub launches.
+ *
+ * Two entry points:
+ *   - linkifyHtml(html)   — rewrites an HTML string, skipping
+ *                           content already inside <a> / <code> /
+ *                           tag attributes.
+ *   - splitByLinks(text)  — splits plain text into an array of
+ *                           strings and {href,label} objects so
+ *                           the caller renders real <Link>s via
+ *                           React. Safer than dangerouslySetInnerHTML.
+ */
+
+export interface LinkTarget {
+  /** Keyword match (case-insensitive, word-boundary) */
+  keyword: string;
+  /** Internal URL to link to */
+  href: string;
+  /** Optional rel attribute — "sponsored nofollow" for broker links etc */
+  rel?: string;
+  /** Optional title attribute for accessibility / hover */
+  title?: string;
+}
+
+/**
+ * Keyword map. Longer-specific phrases first so "SMSF accountant"
+ * wins over bare "SMSF" when both could match.
+ */
+export const INTERNAL_LINK_TARGETS: readonly LinkTarget[] = [
+  // Multi-word specifics first (longest match wins)
+  { keyword: "Significant Investor Visa", href: "/foreign-investment/siv", title: "SIV pathway and complying investments" },
+  { keyword: "Business Innovation Visa", href: "/tools/visa-investment-calculator" },
+  { keyword: "Global Talent Visa", href: "/tools/visa-investment-calculator" },
+  { keyword: "SMSF Investment Guide", href: "/invest/smsf" },
+  { keyword: "SMSF accountant", href: "/advisors/smsf-accountants" },
+  { keyword: "SMSF auditor", href: "/smsf/auditors" },
+  { keyword: "SMSF specialist", href: "/advisors/smsf-specialists" },
+  { keyword: "financial planner", href: "/advisors/financial-planners" },
+  { keyword: "financial planners", href: "/advisors/financial-planners" },
+  { keyword: "mortgage broker", href: "/advisors/mortgage-brokers" },
+  { keyword: "buyers agent", href: "/advisors/buyers-agents" },
+  { keyword: "buyer's agent", href: "/advisors/buyers-agents" },
+  { keyword: "migration agent", href: "/advisors/migration-agents", title: "MARA-registered migration agents" },
+  { keyword: "mining lawyer", href: "/advisors/mining-lawyers" },
+  { keyword: "mining tax advisor", href: "/advisors/mining-tax-advisors" },
+  { keyword: "foreign investment lawyer", href: "/advisors/foreign-investment-lawyers" },
+  { keyword: "immigration investment lawyer", href: "/advisors/immigration-investment-lawyers" },
+  { keyword: "petroleum royalties", href: "/advisors/petroleum-royalties-advisors" },
+  { keyword: "resources fund manager", href: "/advisors/resources-fund-managers" },
+  { keyword: "energy financial planner", href: "/advisors/energy-financial-planners" },
+  { keyword: "fund manager", href: "/advisors/fund-managers" },
+
+  // Hubs / verticals
+  { keyword: "oil and gas", href: "/invest/oil-gas" },
+  { keyword: "oil & gas", href: "/invest/oil-gas" },
+  { keyword: "Perth Mint", href: "/invest/gold" },
+  { keyword: "critical minerals", href: "/invest/mining" },
+  { keyword: "Investment Funds", href: "/invest/funds" },
+
+  // Brokers — canonical broker slugs seed the map. Add new brokers
+  // as they launch.
+  { keyword: "CommSec", href: "/broker/commsec" },
+  { keyword: "SelfWealth", href: "/broker/selfwealth" },
+  { keyword: "Pearler", href: "/broker/pearler" },
+  { keyword: "Moomoo", href: "/broker/moomoo" },
+  { keyword: "Superhero", href: "/broker/superhero" },
+  { keyword: "Interactive Brokers", href: "/broker/interactive-brokers" },
+  { keyword: "CMC Markets", href: "/broker/cmc-markets" },
+  { keyword: "nabtrade", href: "/broker/nabtrade" },
+  { keyword: "Westpac Online Investing", href: "/broker/westpac-online-investing" },
+  { keyword: "Saxo", href: "/broker/saxo-bank" },
+  { keyword: "Stake", href: "/broker/stake" },
+
+  // Tools
+  { keyword: "FIRB fee estimator", href: "/firb-fee-estimator" },
+  { keyword: "FIRB application fee", href: "/firb-fee-estimator" },
+  { keyword: "franking credit calculator", href: "/franking-credits-calculator" },
+  { keyword: "CGT calculator", href: "/cgt-calculator" },
+  { keyword: "withholding tax calculator", href: "/tools/withholding-tax-calculator" },
+  { keyword: "non-resident dividend calculator", href: "/non-resident-dividend-calculator" },
+  { keyword: "visa investment calculator", href: "/tools/visa-investment-calculator" },
+
+  // Named commodity stocks that should link to sector hubs
+  { keyword: "Woodside Energy", href: "/invest/oil-gas" },
+  { keyword: "Santos", href: "/invest/oil-gas" },
+  { keyword: "Paladin Energy", href: "/invest/uranium" },
+  { keyword: "Boss Energy", href: "/invest/uranium" },
+  { keyword: "Deep Yellow", href: "/invest/uranium" },
+  { keyword: "Fortescue", href: "/invest/hydrogen" },
+  { keyword: "Pilbara Minerals", href: "/invest/lithium" },
+
+  // Concepts / shorter keywords (lowest priority — come last)
+  { keyword: "SMSF", href: "/smsf" },
+  { keyword: "FIRB", href: "/foreign-investment" },
+  { keyword: "SIV", href: "/foreign-investment/siv" },
+  { keyword: "PRRT", href: "/article/prrt-petroleum-resource-rent-tax-explained" },
+  { keyword: "uranium", href: "/invest/uranium" },
+  { keyword: "hydrogen", href: "/invest/hydrogen" },
+  { keyword: "lithium", href: "/invest/lithium" },
+  { keyword: "compare brokers", href: "/compare" },
+  { keyword: "ETF hub", href: "/etfs" },
+  { keyword: "research reports", href: "/research" },
+];
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// Pre-sort keywords longest-first so greedy matching honours
+// priority (multi-word phrases win over bare nouns).
+const SORTED_TARGETS = [...INTERNAL_LINK_TARGETS].sort(
+  (a, b) => b.keyword.length - a.keyword.length,
+);
+
+// Combined regex built once at module load. Case-insensitive, word
+// boundary on both sides so we don't rewrite "smsfcheck" or
+// "pre-SMSF" inside other words.
+const COMBINED_REGEX_SOURCE =
+  "\\b(" +
+  SORTED_TARGETS.map((l) => escapeRegex(l.keyword)).join("|") +
+  ")\\b";
+
+function findTarget(matchedText: string): LinkTarget | undefined {
+  const lower = matchedText.toLowerCase();
+  return SORTED_TARGETS.find((l) => l.keyword.toLowerCase() === lower);
+}
+
+export type TextOrLink =
+  | string
+  | { href: string; label: string; title?: string; rel?: string };
+
+/**
+ * Splits a plain-text string into an array of strings and link
+ * objects. Only the first occurrence of each keyword is linked —
+ * subsequent occurrences render as plain text. Safe for React
+ * rendering without dangerouslySetInnerHTML.
+ */
+export function splitByLinks(text: string): TextOrLink[] {
+  if (!text) return [];
+  const out: TextOrLink[] = [];
+  const used = new Set<string>();
+  const rx = new RegExp(COMBINED_REGEX_SOURCE, "gi");
+  let lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = rx.exec(text)) !== null) {
+    const match = m[0];
+    const key = match.toLowerCase();
+    if (used.has(key)) continue;
+    const target = findTarget(match);
+    if (!target) continue;
+    used.add(key);
+    if (m.index > lastIndex) out.push(text.slice(lastIndex, m.index));
+    out.push({
+      href: target.href,
+      label: match,
+      title: target.title,
+      rel: target.rel,
+    });
+    lastIndex = m.index + match.length;
+  }
+  if (lastIndex < text.length) out.push(text.slice(lastIndex));
+  return out;
+}
+
+/**
+ * HTML-safe linkifier for article bodies. Scans an HTML string and
+ * wraps the first occurrence of each keyword in an `<a href>`.
+ *
+ * Skips:
+ *   - Content inside existing <a> tags (no nested links)
+ *   - Content inside <code> / <pre> blocks (don't touch code)
+ *   - Content inside tag attributes (href, alt, etc.)
+ *
+ * First-occurrence semantics per keyword so prose stays readable.
+ */
+export function linkifyHtml(html: string): string {
+  if (!html) return "";
+  const used = new Set<string>();
+  let out = "";
+  let i = 0;
+  const len = html.length;
+
+  while (i < len) {
+    const ch = html[i];
+    if (ch === "<") {
+      const close = html.indexOf(">", i + 1);
+      if (close === -1) {
+        out += html.slice(i);
+        break;
+      }
+      const tag = html.slice(i, close + 1);
+      out += tag;
+      i = close + 1;
+
+      // Skip block content of <a>, <code>, <pre> — never inject links here.
+      const openMatch = /^<(a|code|pre)[\s>]/i.exec(tag);
+      if (openMatch) {
+        const closer = `</${openMatch[1]!.toLowerCase()}>`;
+        const closeAt = html.toLowerCase().indexOf(closer, i);
+        if (closeAt === -1) {
+          out += html.slice(i);
+          return out;
+        }
+        out += html.slice(i, closeAt + closer.length);
+        i = closeAt + closer.length;
+      }
+      continue;
+    }
+
+    const nextTag = html.indexOf("<", i);
+    const chunk = nextTag === -1 ? html.slice(i) : html.slice(i, nextTag);
+    out += replaceFirstKeywords(chunk, used);
+    i += chunk.length;
+  }
+  return out;
+}
+
+function replaceFirstKeywords(text: string, used: Set<string>): string {
+  const rx = new RegExp(COMBINED_REGEX_SOURCE, "gi");
+  return text.replace(rx, (match) => {
+    const key = match.toLowerCase();
+    if (used.has(key)) return match;
+    const target = findTarget(match);
+    if (!target) return match;
+    used.add(key);
+    const relAttr = target.rel ? ` rel="${target.rel}"` : "";
+    const titleAttr = target.title
+      ? ` title="${target.title.replace(/"/g, "&quot;")}"`
+      : "";
+    return `<a href="${target.href}"${titleAttr}${relAttr} class="text-amber-700 underline decoration-amber-300 underline-offset-2 hover:text-amber-800">${match}</a>`;
+  });
+}

--- a/lib/schema-markup.ts
+++ b/lib/schema-markup.ts
@@ -1,0 +1,314 @@
+/**
+ * Typed JSON-LD schema builders for every page type.
+ *
+ * Keeps schema markup consistent across pages and gives search
+ * engines richer results. Each function returns a plain object
+ * ready for JSON.stringify + <script type="application/ld+json">.
+ *
+ * Output types:
+ *   - Article      — editorial content (/article/[slug])
+ *   - FAQPage      — Q&A sections on articles and advisor pages
+ *   - FinancialProduct — broker review pages
+ *   - LocalBusiness + Person — advisor profile pages
+ *   - ItemList     — best-for ranked broker lists, versus pages
+ *   - Product      — marketplace listings (/invest/listings/[slug])
+ *   - WebApplication — calculator pages (/franking-credits-calculator etc.)
+ *
+ * Every builder accepts the minimum required fields and gracefully
+ * omits optional ones so empty values don't leak into the rendered
+ * JSON-LD.
+ */
+
+import { SITE_NAME, SITE_URL, absoluteUrl } from "@/lib/seo";
+
+const ORG = {
+  "@type": "Organization" as const,
+  name: SITE_NAME,
+  url: SITE_URL,
+  logo: `${SITE_URL}/logo.png`,
+};
+
+/** Drop null / undefined keys so JSON-LD output is clean. */
+function compact<T extends Record<string, unknown>>(obj: T): T {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (v === undefined || v === null) continue;
+    if (Array.isArray(v) && v.length === 0) continue;
+    out[k] = v;
+  }
+  return out as T;
+}
+
+// ─── Article ──────────────────────────────────────────────────
+
+export interface ArticleSchemaInput {
+  title: string;
+  slug: string;
+  description: string | null;
+  authorName?: string | null;
+  authorUrl?: string | null;
+  publishedAt?: string | null;
+  updatedAt?: string | null;
+  coverImageUrl?: string | null;
+  category?: string | null;
+}
+
+export function articleJsonLd(input: ArticleSchemaInput) {
+  return compact({
+    "@context": "https://schema.org",
+    "@type": "Article",
+    headline: input.title,
+    description: input.description ?? undefined,
+    image: input.coverImageUrl
+      ? absoluteUrl(input.coverImageUrl)
+      : `${SITE_URL}/api/og?title=${encodeURIComponent(input.title)}`,
+    datePublished: input.publishedAt ?? undefined,
+    dateModified: input.updatedAt ?? input.publishedAt ?? undefined,
+    author: input.authorName
+      ? compact({
+          "@type": "Person",
+          name: input.authorName,
+          url: input.authorUrl ?? undefined,
+        })
+      : ORG,
+    publisher: ORG,
+    articleSection: input.category ?? undefined,
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": absoluteUrl(`/article/${input.slug}`),
+    },
+  });
+}
+
+// ─── FAQ page ─────────────────────────────────────────────────
+
+export interface FaqItem {
+  q: string;
+  a: string;
+}
+
+export function faqJsonLd(items: FaqItem[]) {
+  if (items.length === 0) return null;
+  return {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: items.map((f) => ({
+      "@type": "Question",
+      name: f.q,
+      acceptedAnswer: { "@type": "Answer", text: f.a },
+    })),
+  };
+}
+
+// ─── Broker / FinancialProduct ────────────────────────────────
+
+export interface BrokerSchemaInput {
+  slug: string;
+  name: string;
+  description?: string | null;
+  logoUrl?: string | null;
+  rating?: number | null;
+  reviewCount?: number | null;
+  priceRange?: string | null;
+}
+
+export function brokerFinancialProductJsonLd(input: BrokerSchemaInput) {
+  return compact({
+    "@context": "https://schema.org",
+    "@type": "FinancialProduct",
+    name: input.name,
+    url: absoluteUrl(`/broker/${input.slug}`),
+    description: input.description ?? undefined,
+    image: input.logoUrl ?? undefined,
+    brand: ORG,
+    ...(input.rating && input.reviewCount && input.reviewCount > 0
+      ? {
+          aggregateRating: {
+            "@type": "AggregateRating",
+            ratingValue: input.rating,
+            reviewCount: input.reviewCount,
+            bestRating: 5,
+            worstRating: 1,
+          },
+        }
+      : {}),
+    priceRange: input.priceRange ?? undefined,
+  });
+}
+
+// ─── Advisor / LocalBusiness + Person ─────────────────────────
+
+export interface AdvisorSchemaInput {
+  slug: string;
+  name: string;
+  firmName?: string | null;
+  bio?: string | null;
+  photoUrl?: string | null;
+  phone?: string | null;
+  email?: string | null;
+  website?: string | null;
+  rating?: number | null;
+  reviewCount?: number | null;
+  locationState?: string | null;
+  locationSuburb?: string | null;
+  jobTitle?: string | null;
+  feeDescription?: string | null;
+}
+
+export function advisorJsonLd(input: AdvisorSchemaInput) {
+  const url = absoluteUrl(`/advisor/${input.slug}`);
+  const person = compact({
+    "@type": "Person",
+    name: input.name,
+    url,
+    image: input.photoUrl ?? undefined,
+    jobTitle: input.jobTitle ?? undefined,
+    telephone: input.phone ?? undefined,
+    email: input.email ?? undefined,
+    worksFor: input.firmName
+      ? { "@type": "Organization", name: input.firmName }
+      : undefined,
+    description: input.bio ?? undefined,
+  });
+
+  const localBusiness = input.firmName
+    ? compact({
+        "@context": "https://schema.org",
+        "@type": "LocalBusiness",
+        name: input.firmName,
+        image: input.photoUrl ?? undefined,
+        url: input.website ?? url,
+        telephone: input.phone ?? undefined,
+        email: input.email ?? undefined,
+        priceRange: input.feeDescription ?? undefined,
+        address: input.locationState
+          ? compact({
+              "@type": "PostalAddress",
+              addressRegion: input.locationState,
+              addressLocality: input.locationSuburb ?? undefined,
+              addressCountry: "AU",
+            })
+          : undefined,
+        ...(input.rating && input.reviewCount && input.reviewCount > 0
+          ? {
+              aggregateRating: {
+                "@type": "AggregateRating",
+                ratingValue: input.rating,
+                reviewCount: input.reviewCount,
+                bestRating: 5,
+                worstRating: 1,
+              },
+            }
+          : {}),
+      })
+    : null;
+
+  return { person, localBusiness };
+}
+
+// ─── ItemList — best-for pages + versus pages ────────────────
+
+export interface ItemListEntry {
+  position: number;
+  name: string;
+  url: string;
+  description?: string;
+}
+
+export function itemListJsonLd(name: string, items: ItemListEntry[]) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name,
+    numberOfItems: items.length,
+    itemListElement: items.map((i) => ({
+      "@type": "ListItem",
+      position: i.position,
+      name: i.name,
+      url: absoluteUrl(i.url),
+      description: i.description,
+    })),
+  };
+}
+
+// ─── Product — marketplace listings ──────────────────────────
+
+export interface ListingSchemaInput {
+  slug: string;
+  title: string;
+  description?: string | null;
+  imageUrl?: string | null;
+  priceAud?: number | null;
+  priceDisplay?: string | null;
+  locationState?: string | null;
+  locationCity?: string | null;
+  vertical?: string | null;
+}
+
+export function listingProductJsonLd(input: ListingSchemaInput) {
+  return compact({
+    "@context": "https://schema.org",
+    "@type": "Product",
+    name: input.title,
+    description: input.description ?? undefined,
+    image: input.imageUrl ?? undefined,
+    category: input.vertical ?? undefined,
+    url: absoluteUrl(
+      input.vertical
+        ? `/invest/${input.vertical}/listings/${input.slug}`
+        : `/invest/listings/${input.slug}`,
+    ),
+    brand: ORG,
+    ...(input.priceAud
+      ? {
+          offers: {
+            "@type": "Offer",
+            priceCurrency: "AUD",
+            price: input.priceAud,
+            url: absoluteUrl(
+              input.vertical
+                ? `/invest/${input.vertical}/listings/${input.slug}`
+                : `/invest/listings/${input.slug}`,
+            ),
+            availability: "https://schema.org/InStock",
+          },
+        }
+      : input.priceDisplay
+        ? { offers: { "@type": "Offer", priceSpecification: input.priceDisplay } }
+        : {}),
+    ...(input.locationState
+      ? {
+          areaServed: compact({
+            "@type": "Place",
+            address: {
+              "@type": "PostalAddress",
+              addressRegion: input.locationState,
+              addressLocality: input.locationCity ?? undefined,
+              addressCountry: "AU",
+            },
+          }),
+        }
+      : {}),
+  });
+}
+
+// ─── Calculator / WebApplication ─────────────────────────────
+
+export interface CalculatorSchemaInput {
+  name: string;
+  description: string;
+  path: string;
+}
+
+export function calculatorJsonLd(input: CalculatorSchemaInput) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "WebApplication",
+    name: `${input.name} — ${SITE_NAME}`,
+    description: input.description,
+    url: absoluteUrl(input.path),
+    applicationCategory: "FinanceApplication",
+    operatingSystem: "Any",
+    offers: { "@type": "Offer", price: "0", priceCurrency: "AUD" },
+  };
+}


### PR DESCRIPTION
## Summary
- **Exit intent modal**: path-gated to high-intent content (article/compare/broker/advisor/best/invest/tools) + 45s mobile idle fallback
- **Internal linking engine** (`lib/keyword-linking.ts`): ~60 canonical keyword→URL mappings with HTML-safe and React-safe entry points
- **Should-I-switch tool** (`/tools/should-i-switch`): interactive switching calculator with top-3 alternatives, annual + 10-year $ savings, and switching guidance
- **Pre-launch readiness V2** (`/admin/pre-launch`): env-var presence checks + 4s-timeout URL reachability probes rolled into the headline verdict
- **Concierge UX polish**: session rehydration on mount (GET `/api/concierge?session_id=…`), stream-cancel button, clear-conversation button, DELETE endpoint
- **Schema markup library** (`lib/schema-markup.ts`): typed JSON-LD builders for Article / FAQ / FinancialProduct / LocalBusiness+Person / ItemList / Product / WebApplication. Wired Product schema into all 10 vertical listing detail pages via `components/ListingSchemaScripts`
- **Sitemap**: now indexes `/tools/should-i-switch`, `/tools/visa-investment-calculator`, `/tools/withholding-tax-calculator`

## Test plan
- [ ] `/tools/should-i-switch` renders and recomputes when inputs change
- [ ] Exit intent modal does NOT fire on `/admin`, `/checkout`, `/quiz` etc.
- [ ] Mobile idle fallback fires after 45s of inactivity on a deep article
- [ ] Concierge survives page refresh and restores prior turns
- [ ] Stop button aborts an in-flight stream and leaves a `(stopped)` marker
- [ ] Clear button wipes localStorage + server-side history
- [ ] `/admin/pre-launch` shows env-var + URL reachability rows
- [ ] View-source on any `/invest/*/listings/[slug]` shows a valid `Product` JSON-LD block

🤖 Generated with [Claude Code](https://claude.com/claude-code)