### PR TITLE
Activate internal linking + broker review collection + AI versus editorials

### DIFF
--- a/app/api/broker-review-invite/route.ts
+++ b/app/api/broker-review-invite/route.ts
@@ -1,0 +1,167 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+/**
+ * GET /api/broker-review-invite?token=…
+ *
+ * Resolves an invite token into the broker summary needed to render
+ * the /review/broker/[token] form. Marks the invite as `opened` the
+ * first time it's hit (for funnel measurement). Does NOT expose the
+ * invite email to the client — the form submits it server-side.
+ */
+export async function GET(req: NextRequest) {
+  const token = req.nextUrl.searchParams.get("token") ?? "";
+  if (!/^[0-9a-f-]{36}$/i.test(token)) {
+    return NextResponse.json({ error: "Invalid token" }, { status: 400 });
+  }
+
+  const supabase = createAdminClient();
+  const { data: invite, error } = await supabase
+    .from("broker_review_invites")
+    .select("id, broker_slug, broker_id, status, expires_at, email")
+    .eq("token", token)
+    .maybeSingle();
+
+  if (error || !invite) {
+    return NextResponse.json(
+      { error: "Invite not found or expired" },
+      { status: 404 },
+    );
+  }
+
+  if (invite.status === "completed") {
+    return NextResponse.json(
+      { error: "This review has already been submitted." },
+      { status: 409 },
+    );
+  }
+
+  if (new Date(invite.expires_at).getTime() < Date.now()) {
+    await supabase
+      .from("broker_review_invites")
+      .update({ status: "expired" })
+      .eq("id", invite.id);
+    return NextResponse.json({ error: "Invite expired" }, { status: 410 });
+  }
+
+  const { data: broker } = await supabase
+    .from("brokers")
+    .select("id, name, slug, logo_url, rating")
+    .eq("slug", invite.broker_slug)
+    .maybeSingle();
+
+  if (!broker) {
+    return NextResponse.json({ error: "Broker not found" }, { status: 404 });
+  }
+
+  // Flip to `opened` on first resolve
+  if (invite.status === "sent") {
+    await supabase
+      .from("broker_review_invites")
+      .update({ status: "opened", opened_at: new Date().toISOString() })
+      .eq("id", invite.id);
+  }
+
+  return NextResponse.json({
+    invite: { token, broker_slug: invite.broker_slug },
+    broker: {
+      id: broker.id,
+      name: broker.name,
+      slug: broker.slug,
+      logo_url: broker.logo_url,
+      rating: broker.rating,
+    },
+  });
+}
+
+/**
+ * POST /api/broker-review-invite
+ *
+ * Submits a review backed by an invite token. The server-side flow:
+ *   1. Validate the token and fetch the pinned (email, broker_slug)
+ *   2. Insert a row into user_reviews with status='auto_verified' and
+ *      the invite-pinned email — bypasses the email-verify step since
+ *      the token itself proves ownership of the email.
+ *   3. Mark the invite completed + linked to the review
+ *
+ * The existing /api/user-review endpoint is preserved for organic
+ * submissions (visitors writing reviews without an invite); this
+ * endpoint is for the short-path invite flow.
+ */
+export async function POST(req: NextRequest) {
+  let body: Record<string, unknown>;
+  try {
+    body = (await req.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const token = typeof body.token === "string" ? body.token : "";
+  const rating = Number(body.rating);
+  const reviewBody = typeof body.body === "string" ? body.body.trim() : "";
+  const title = typeof body.title === "string" ? body.title.trim() : "";
+  const display_name = typeof body.display_name === "string" ? body.display_name.trim() : "";
+  const fees_rating = Number(body.fees_rating);
+  const platform_rating = Number(body.platform_rating);
+  const support_rating = Number(body.support_rating);
+  const reliability_rating = Number(body.reliability_rating);
+  const experience_months = Number(body.experience_months);
+
+  if (!/^[0-9a-f-]{36}$/i.test(token)) {
+    return NextResponse.json({ error: "Invalid token" }, { status: 400 });
+  }
+  if (!(rating >= 1 && rating <= 5)) {
+    return NextResponse.json({ error: "Rating must be 1-5" }, { status: 400 });
+  }
+  if (reviewBody.length < 50 || reviewBody.length > 4000) {
+    return NextResponse.json({ error: "Review body must be 50-4000 characters" }, { status: 400 });
+  }
+
+  const supabase = createAdminClient();
+  const { data: invite } = await supabase
+    .from("broker_review_invites")
+    .select("id, email, broker_slug, broker_id, status")
+    .eq("token", token)
+    .maybeSingle();
+
+  if (!invite) return NextResponse.json({ error: "Invite not found" }, { status: 404 });
+  if (invite.status === "completed") {
+    return NextResponse.json({ error: "Already submitted" }, { status: 409 });
+  }
+
+  const { data: review, error: insertErr } = await supabase
+    .from("user_reviews")
+    .insert({
+      broker_id: invite.broker_id,
+      broker_slug: invite.broker_slug,
+      display_name: display_name || "Anonymous",
+      email: invite.email,
+      rating: Math.round(rating),
+      title: title || null,
+      body: reviewBody,
+      fees_rating: Number.isFinite(fees_rating) ? Math.round(fees_rating) : null,
+      platform_rating: Number.isFinite(platform_rating) ? Math.round(platform_rating) : null,
+      support_rating: Number.isFinite(support_rating) ? Math.round(support_rating) : null,
+      reliability_rating: Number.isFinite(reliability_rating) ? Math.round(reliability_rating) : null,
+      experience_months: Number.isFinite(experience_months) ? Math.round(experience_months) : null,
+      status: "pending_moderation",
+      verified_at: new Date().toISOString(),
+    })
+    .select("id")
+    .single();
+
+  if (insertErr || !review) {
+    return NextResponse.json({ error: "Insert failed" }, { status: 500 });
+  }
+
+  await supabase
+    .from("broker_review_invites")
+    .update({
+      status: "completed",
+      completed_at: new Date().toISOString(),
+      user_review_id: review.id,
+    })
+    .eq("id", invite.id);
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/cron/broker-review-invites/route.ts
+++ b/app/api/cron/broker-review-invites/route.ts
@@ -1,0 +1,220 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { sendEmail } from "@/lib/resend";
+import { logger } from "@/lib/logger";
+import { requireCronAuth } from "@/lib/cron-auth";
+import { SITE_URL } from "@/lib/seo";
+
+const log = logger("cron:broker-review-invites");
+
+export const maxDuration = 60;
+
+/**
+ * Broker review-invite cron.
+ *
+ * Converts affiliate clicks into review-requests. Flow:
+ *
+ *   1. Find affiliate_clicks from 7-30 days ago with a session_id
+ *   2. Join to email_captures to resolve an email for that session
+ *   3. Skip suppressed / unsubscribed emails
+ *   4. Skip any (email, broker_slug) we've already invited in last 90 days
+ *   5. Create a broker_review_invites row + token
+ *   6. Send a Resend email with the magic link /review/broker/{token}
+ *
+ * Runs daily at 10:00 AEST. Max 50 invites per run to stay well under
+ * Resend and cron timeouts — the natural cadence of clicks won't
+ * exceed this at current volumes.
+ */
+
+const MAX_INVITES_PER_RUN = 50;
+const CLICK_MIN_AGE_DAYS = 7;
+const CLICK_MAX_AGE_DAYS = 30;
+const DEDUP_WINDOW_DAYS = 90;
+
+export async function GET(req: NextRequest) {
+  const unauth = requireCronAuth(req);
+  if (unauth) return unauth;
+
+  const supabase = createAdminClient();
+  const now = Date.now();
+  const minAge = new Date(
+    now - CLICK_MIN_AGE_DAYS * 24 * 60 * 60 * 1000,
+  ).toISOString();
+  const maxAge = new Date(
+    now - CLICK_MAX_AGE_DAYS * 24 * 60 * 60 * 1000,
+  ).toISOString();
+  const dedupCutoff = new Date(
+    now - DEDUP_WINDOW_DAYS * 24 * 60 * 60 * 1000,
+  ).toISOString();
+
+  // Pull eligible affiliate clicks with session_id in the target window.
+  const { data: clicks, error: clickErr } = await supabase
+    .from("affiliate_clicks")
+    .select("broker_id, broker_slug, broker_name, session_id, clicked_at")
+    .gte("clicked_at", maxAge)
+    .lte("clicked_at", minAge)
+    .not("session_id", "is", null)
+    .order("clicked_at", { ascending: false })
+    .limit(500);
+
+  if (clickErr || !clicks || clicks.length === 0) {
+    return NextResponse.json({ ok: true, sent: 0, reason: "no eligible clicks" });
+  }
+
+  // Resolve session_id → email via email_captures
+  const sessionIds = Array.from(
+    new Set(clicks.map((c) => c.session_id).filter(Boolean)),
+  );
+  const { data: captures } = await supabase
+    .from("email_captures")
+    .select("email, session_id, unsubscribed, status")
+    .in("session_id", sessionIds as string[])
+    .eq("unsubscribed", false)
+    .neq("status", "suppressed");
+
+  const sessionToEmail = new Map<string, string>();
+  for (const cap of captures ?? []) {
+    if (cap.session_id && cap.email && !sessionToEmail.has(cap.session_id)) {
+      sessionToEmail.set(cap.session_id, cap.email);
+    }
+  }
+
+  if (sessionToEmail.size === 0) {
+    return NextResponse.json({
+      ok: true,
+      sent: 0,
+      reason: "no captured emails match these sessions",
+    });
+  }
+
+  // Build unique (email, broker_slug) candidate set — newest click wins
+  const candidates = new Map<
+    string,
+    { email: string; broker_slug: string; broker_id: number | null; broker_name: string }
+  >();
+  for (const c of clicks) {
+    const email = c.session_id ? sessionToEmail.get(c.session_id) : null;
+    if (!email) continue;
+    const key = `${email}|${c.broker_slug}`;
+    if (!candidates.has(key)) {
+      candidates.set(key, {
+        email,
+        broker_slug: c.broker_slug,
+        broker_id: c.broker_id ?? null,
+        broker_name: c.broker_name ?? c.broker_slug,
+      });
+    }
+  }
+
+  // Suppress candidates already invited for this broker in the last 90 days
+  const emails = Array.from(new Set([...candidates.values()].map((c) => c.email)));
+  const { data: priorInvites } = await supabase
+    .from("broker_review_invites")
+    .select("email, broker_slug")
+    .in("email", emails)
+    .gte("sent_at", dedupCutoff);
+  const suppressedKeys = new Set(
+    (priorInvites ?? []).map((p) => `${p.email}|${p.broker_slug}`),
+  );
+
+  // Suppress emails on the suppression list
+  const { data: suppressed } = await supabase
+    .from("email_suppression_list")
+    .select("email")
+    .in("email", emails);
+  const suppressedEmails = new Set(
+    (suppressed ?? []).map((s) => s.email as string),
+  );
+
+  const toSend = [...candidates.values()]
+    .filter((c) => !suppressedKeys.has(`${c.email}|${c.broker_slug}`))
+    .filter((c) => !suppressedEmails.has(c.email))
+    .slice(0, MAX_INVITES_PER_RUN);
+
+  let sent = 0;
+  let failed = 0;
+
+  for (const c of toSend) {
+    // Create the invite row first — the token is what the email links to
+    const { data: invite, error: insertErr } = await supabase
+      .from("broker_review_invites")
+      .insert({
+        email: c.email,
+        broker_slug: c.broker_slug,
+        broker_id: c.broker_id,
+      })
+      .select("token")
+      .single();
+
+    if (insertErr || !invite) {
+      log.error("invite_insert_failed", {
+        email: c.email,
+        broker: c.broker_slug,
+        err: insertErr?.message,
+      });
+      failed++;
+      continue;
+    }
+
+    const reviewUrl = `${SITE_URL}/review/broker/${invite.token}`;
+    const unsubUrl = `${SITE_URL}/api/unsubscribe?email=${encodeURIComponent(c.email)}`;
+    const html = renderInviteEmail({
+      brokerName: c.broker_name,
+      brokerSlug: c.broker_slug,
+      reviewUrl,
+      unsubUrl,
+    });
+
+    const result = await sendEmail({
+      to: c.email,
+      subject: `How was your experience with ${c.broker_name}?`,
+      html,
+    });
+
+    if (result.ok) {
+      sent++;
+    } else {
+      failed++;
+      log.warn("send_failed", {
+        email: c.email,
+        broker: c.broker_slug,
+        err: result.error,
+      });
+    }
+  }
+
+  return NextResponse.json({ ok: true, sent, failed, candidates: toSend.length });
+}
+
+function renderInviteEmail(opts: {
+  brokerName: string;
+  brokerSlug: string;
+  reviewUrl: string;
+  unsubUrl: string;
+}): string {
+  return `<!DOCTYPE html>
+<html>
+  <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #f8fafc; padding: 24px;">
+    <div style="max-width: 560px; margin: 0 auto; background: white; border-radius: 12px; padding: 28px; border: 1px solid #e2e8f0;">
+      <p style="font-size: 13px; color: #64748b; margin: 0 0 8px;">invest.com.au</p>
+      <h1 style="font-size: 20px; color: #0f172a; margin: 0 0 12px;">How did it go with ${opts.brokerName}?</h1>
+      <p style="font-size: 14px; line-height: 1.55; color: #334155; margin: 0 0 16px;">
+        You recently visited <strong>${opts.brokerName}</strong> through our comparison.
+        A quick honest review helps other Australians choose — it takes under two minutes.
+      </p>
+      <p style="margin: 0 0 24px;">
+        <a href="${opts.reviewUrl}"
+           style="display: inline-block; background: #f59e0b; color: white; font-weight: 700; text-decoration: none; padding: 12px 22px; border-radius: 10px; font-size: 14px;">
+          Leave a review
+        </a>
+      </p>
+      <p style="font-size: 12px; color: #64748b; line-height: 1.5; margin: 0 0 6px;">
+        This is a personalised magic link — no login required. Reviews are moderated before publishing and your email is never shared.
+      </p>
+      <p style="font-size: 11px; color: #94a3b8; margin-top: 20px; border-top: 1px solid #e2e8f0; padding-top: 14px;">
+        Not interested? <a href="${opts.unsubUrl}" style="color: #94a3b8;">Unsubscribe</a>.
+      </p>
+    </div>
+  </body>
+</html>`;
+}

--- a/app/api/cron/versus-editorial-backfill/route.ts
+++ b/app/api/cron/versus-editorial-backfill/route.ts
@@ -1,0 +1,255 @@
+import { NextRequest, NextResponse } from "next/server";
+import Anthropic from "@anthropic-ai/sdk";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+import { requireCronAuth } from "@/lib/cron-auth";
+import { generateVersusPairs } from "@/lib/versus-pairs";
+import type { PlatformType } from "@/lib/types";
+
+const log = logger("cron:versus-editorial-backfill");
+
+export const maxDuration = 60;
+
+/**
+ * AI-generated versus editorial backfill.
+ *
+ * For every within-platform-type broker pair that lacks a row in
+ * versus_editorials, call Claude once with a strict prompt and insert
+ * the result. Idempotent — skips pairs that already have editorial so
+ * re-running burns no tokens.
+ *
+ * Runs N pairs per invocation (default 5, override with ?max=N) so the
+ * cron stays well under its 60s budget and token costs are predictable.
+ * Daily runs would complete the backfill of 400 pairs in ~80 days; a
+ * one-off manual trigger with ?max=40 batches it through faster.
+ */
+
+const MODEL = "claude-sonnet-4-20250514";
+const DEFAULT_MAX_PAIRS = 5;
+
+interface BrokerRow {
+  id: number;
+  slug: string;
+  name: string;
+  rating: number | null;
+  platform_type: PlatformType;
+  asx_fee: string | null;
+  asx_fee_value: number | null;
+  us_fee: string | null;
+  us_fee_value: number | null;
+  fx_rate: number | null;
+  chess_sponsored: boolean | null;
+  smsf_support: boolean | null;
+  min_deposit: string | null;
+  markets: string[] | null;
+  tagline: string | null;
+}
+
+interface GeneratedEditorial {
+  title: string;
+  meta_description: string;
+  intro: string;
+  choose_a: string;
+  choose_b: string;
+  sections: { heading: string; body: string }[];
+  verdict: string;
+  faqs: { question: string; answer: string }[];
+}
+
+export async function GET(req: NextRequest) {
+  const unauth = requireCronAuth(req);
+  if (unauth) return unauth;
+
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json(
+      { ok: false, error: "ANTHROPIC_API_KEY missing" },
+      { status: 503 },
+    );
+  }
+
+  const max = Math.max(
+    1,
+    Math.min(40, Number(req.nextUrl.searchParams.get("max") ?? DEFAULT_MAX_PAIRS)),
+  );
+
+  const supabase = createAdminClient();
+
+  const { data: brokers, error: brokersErr } = await supabase
+    .from("brokers")
+    .select(
+      "id, slug, name, rating, platform_type, asx_fee, asx_fee_value, us_fee, us_fee_value, fx_rate, chess_sponsored, smsf_support, min_deposit, markets, tagline",
+    )
+    .eq("status", "active");
+
+  if (brokersErr || !brokers) {
+    return NextResponse.json({ ok: false, error: "broker fetch failed" }, { status: 500 });
+  }
+
+  const bySlug = new Map<string, BrokerRow>();
+  for (const b of brokers as BrokerRow[]) bySlug.set(b.slug, b);
+
+  const pairs = generateVersusPairs(
+    (brokers as BrokerRow[]).map((b) => ({
+      slug: b.slug,
+      name: b.name,
+      rating: b.rating,
+      platform_type: b.platform_type,
+    })),
+  );
+
+  const { data: existing } = await supabase
+    .from("versus_editorials")
+    .select("slug");
+  const existingSlugs = new Set((existing ?? []).map((r) => r.slug));
+
+  const missing = pairs.filter((p) => !existingSlugs.has(p.slug)).slice(0, max);
+
+  if (missing.length === 0) {
+    return NextResponse.json({ ok: true, generated: 0, reason: "all pairs have editorial" });
+  }
+
+  const client = new Anthropic({ apiKey });
+  let generated = 0;
+  let failed = 0;
+
+  for (const pair of missing) {
+    const [slugA, slugB] = pair.slug.split("-vs-");
+    const a = bySlug.get(slugA!);
+    const b = bySlug.get(slugB!);
+    if (!a || !b) continue;
+
+    try {
+      const editorial = await generateEditorial(client, a, b);
+      const { error: insertErr } = await supabase
+        .from("versus_editorials")
+        .insert({
+          slug: pair.slug,
+          broker_a_slug: a.slug,
+          broker_b_slug: b.slug,
+          title: editorial.title,
+          meta_description: editorial.meta_description,
+          intro: editorial.intro,
+          choose_a: editorial.choose_a,
+          choose_b: editorial.choose_b,
+          sections: editorial.sections,
+          verdict: editorial.verdict,
+          faqs: editorial.faqs,
+        });
+      if (insertErr) {
+        log.error("insert_failed", { pair: pair.slug, err: insertErr.message });
+        failed++;
+      } else {
+        generated++;
+      }
+    } catch (err) {
+      failed++;
+      log.error("generation_failed", {
+        pair: pair.slug,
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return NextResponse.json({
+    ok: true,
+    generated,
+    failed,
+    remaining: pairs.length - existingSlugs.size - generated,
+  });
+}
+
+async function generateEditorial(
+  client: Anthropic,
+  a: BrokerRow,
+  b: BrokerRow,
+): Promise<GeneratedEditorial> {
+  const platformLabel = a.platform_type === b.platform_type ? a.platform_type : "platform";
+
+  const prompt = `You are writing a short, honest comparison for Australian investors.
+Output STRICT JSON matching this schema:
+{
+  "title": "string (<70 chars, format: 'A vs B: Side-by-Side Comparison')",
+  "meta_description": "string (120-160 chars, factual, no hype)",
+  "intro": "string (2-3 sentences TL;DR, state the main difference)",
+  "choose_a": "string (1 sentence completing 'Choose A if...')",
+  "choose_b": "string (1 sentence completing 'Choose B if...')",
+  "sections": [
+    { "heading": "Fees head-to-head", "body": "2-3 sentences comparing specific fee numbers" },
+    { "heading": "Platform & features", "body": "2-3 sentences comparing practical differences" },
+    { "heading": "Who should pick which", "body": "2-3 sentences on fit by investor type" }
+  ],
+  "verdict": "string (2 sentences, neutral editorial verdict)",
+  "faqs": [
+    { "question": "string", "answer": "string (2-3 sentences)" },
+    { "question": "string", "answer": "string (2-3 sentences)" }
+  ]
+}
+
+Rules:
+- Factual, not marketing. Do not say either is "best".
+- Cite specific numbers from the data below wherever you can.
+- Include "This is general information, not personal financial advice" language only in FAQ answers where it's genuinely relevant.
+- Australian English. No emojis. No em-dashes.
+- Return JSON only. No prose before or after.
+
+A = ${a.name}:
+  rating=${a.rating ?? "n/a"}
+  platform_type=${a.platform_type}
+  asx_fee=${a.asx_fee ?? "n/a"} (${a.asx_fee_value ?? "n/a"} per trade)
+  us_fee=${a.us_fee ?? "n/a"} (${a.us_fee_value ?? "n/a"} per trade)
+  fx_rate=${a.fx_rate ?? "n/a"}%
+  chess_sponsored=${a.chess_sponsored ?? "n/a"}
+  smsf_support=${a.smsf_support ?? "n/a"}
+  min_deposit=${a.min_deposit ?? "n/a"}
+  markets=${(a.markets ?? []).join(", ") || "n/a"}
+  tagline=${a.tagline ?? ""}
+
+B = ${b.name}:
+  rating=${b.rating ?? "n/a"}
+  platform_type=${b.platform_type}
+  asx_fee=${b.asx_fee ?? "n/a"} (${b.asx_fee_value ?? "n/a"} per trade)
+  us_fee=${b.us_fee ?? "n/a"} (${b.us_fee_value ?? "n/a"} per trade)
+  fx_rate=${b.fx_rate ?? "n/a"}%
+  chess_sponsored=${b.chess_sponsored ?? "n/a"}
+  smsf_support=${b.smsf_support ?? "n/a"}
+  min_deposit=${b.min_deposit ?? "n/a"}
+  markets=${(b.markets ?? []).join(", ") || "n/a"}
+  tagline=${b.tagline ?? ""}
+
+${platformLabel === "platform" ? "" : `Context: both are Australian ${platformLabel} platforms.`}
+`;
+
+  const response = await client.messages.create({
+    model: MODEL,
+    max_tokens: 1500,
+    messages: [{ role: "user", content: prompt }],
+  });
+
+  const text =
+    response.content.find((c) => c.type === "text")?.text?.trim() ?? "";
+  const jsonText = extractJson(text);
+  const parsed = JSON.parse(jsonText) as GeneratedEditorial;
+  validateEditorial(parsed);
+  return parsed;
+}
+
+/** Strip optional markdown fences so `json ... ` round-trips cleanly. */
+function extractJson(text: string): string {
+  const fenced = text.match(/```json\s*([\s\S]*?)```/);
+  if (fenced) return fenced[1]!.trim();
+  const first = text.indexOf("{");
+  const last = text.lastIndexOf("}");
+  if (first >= 0 && last > first) return text.slice(first, last + 1);
+  return text;
+}
+
+function validateEditorial(e: GeneratedEditorial): void {
+  if (!e.title || e.title.length > 120) throw new Error("bad title");
+  if (!e.intro || e.intro.length < 40) throw new Error("bad intro");
+  if (!e.choose_a || !e.choose_b) throw new Error("missing choose_a/b");
+  if (!Array.isArray(e.sections) || e.sections.length < 2)
+    throw new Error("sections must have 2+ entries");
+  if (!Array.isArray(e.faqs) || e.faqs.length < 2)
+    throw new Error("faqs must have 2+ entries");
+}

--- a/app/article/[slug]/page.tsx
+++ b/app/article/[slug]/page.tsx
@@ -23,6 +23,7 @@ import ArticleComments from "@/components/ArticleComments";
 import Icon from "@/components/Icon";
 import AdSlot from "@/components/AdSlot";
 import AdvisorPrompt from "@/components/AdvisorPrompt";
+import LinkifiedText from "@/components/LinkifiedText";
 
 export const revalidate = 3600; // ISR: revalidate every hour
 
@@ -410,9 +411,10 @@ export default async function ArticlePage({
                     <h2 className="text-2xl font-bold mb-4">
                       {a.sections[0].heading}
                     </h2>
-                    <div className="max-w-none text-slate-700 leading-relaxed whitespace-pre-line">
-                      {a.sections[0].body}
-                    </div>
+                    <LinkifiedText
+                      text={a.sections[0].body}
+                      skipHrefs={[`/article/${a.slug}`]}
+                    />
                   </section>
 
                   {/* Inject enhanced tools */}
@@ -438,9 +440,10 @@ export default async function ArticlePage({
                         <h2 className="text-2xl font-bold mb-4">
                           {section.heading}
                         </h2>
-                        <div className="max-w-none text-slate-700 leading-relaxed whitespace-pre-line">
-                          {section.body}
-                        </div>
+                        <LinkifiedText
+                          text={section.body}
+                          skipHrefs={[`/article/${a.slug}`]}
+                        />
                       </section>
                     )
                   )}
@@ -489,9 +492,10 @@ export default async function ArticlePage({
                           <h2 className="text-2xl font-bold mb-4">
                             {section.heading}
                           </h2>
-                          <div className="max-w-none text-slate-700 leading-relaxed whitespace-pre-line">
-                            {section.body}
-                          </div>
+                          <LinkifiedText
+                            text={section.body}
+                            skipHrefs={[`/article/${a.slug}`]}
+                          />
                         </section>
                         {/* In-content ad after 2nd section (only if 4+ sections for density) */}
                         {i === 1 && a.sections!.length >= 4 && (

--- a/app/review/broker/[token]/BrokerReviewInviteClient.tsx
+++ b/app/review/broker/[token]/BrokerReviewInviteClient.tsx
@@ -1,0 +1,386 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import Image from "next/image";
+
+interface BrokerInfo {
+  id: number;
+  name: string;
+  slug: string;
+  logo_url: string | null;
+  rating: number | null;
+}
+
+function StarRating({
+  value,
+  onChange,
+  label,
+  required = false,
+}: {
+  value: number;
+  onChange: (v: number) => void;
+  label: string;
+  required?: boolean;
+}) {
+  const [hover, setHover] = useState(0);
+  return (
+    <div>
+      <p className="text-xs font-semibold text-slate-600 mb-1">
+        {label}
+        {required && " *"}
+      </p>
+      <div className="flex gap-1">
+        {[1, 2, 3, 4, 5].map((star) => (
+          <button
+            key={star}
+            type="button"
+            onClick={() => onChange(star)}
+            onMouseEnter={() => setHover(star)}
+            onMouseLeave={() => setHover(0)}
+            className="text-2xl focus:outline-none transition-transform hover:scale-110"
+            aria-label={`${star} star${star === 1 ? "" : "s"}`}
+          >
+            <span
+              className={
+                (hover || value) >= star ? "text-amber-400" : "text-slate-200"
+              }
+            >
+              ★
+            </span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default function BrokerReviewInviteClient({ token }: { token: string }) {
+  const [broker, setBroker] = useState<BrokerInfo | null>(null);
+  const [loadError, setLoadError] = useState("");
+  const [loading, setLoading] = useState(true);
+
+  const [rating, setRating] = useState(0);
+  const [feesRating, setFeesRating] = useState(0);
+  const [platformRating, setPlatformRating] = useState(0);
+  const [supportRating, setSupportRating] = useState(0);
+  const [reliabilityRating, setReliabilityRating] = useState(0);
+  const [title, setTitle] = useState("");
+  const [body, setBody] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [experienceMonths, setExperienceMonths] = useState<number | "">("");
+
+  const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [submitError, setSubmitError] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(
+          `/api/broker-review-invite?token=${encodeURIComponent(token)}`,
+          { cache: "no-store" },
+        );
+        const data = (await res.json()) as {
+          broker?: BrokerInfo;
+          error?: string;
+        };
+        if (cancelled) return;
+        if (res.ok && data.broker) setBroker(data.broker);
+        else setLoadError(data.error ?? "Invalid or expired review link.");
+      } catch {
+        if (!cancelled) setLoadError("Failed to load — please try again.");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitError("");
+    if (!rating) return setSubmitError("Please give an overall rating.");
+    if (body.trim().length < 50)
+      return setSubmitError("Review must be at least 50 characters.");
+
+    setSubmitting(true);
+    try {
+      const res = await fetch("/api/broker-review-invite", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          token,
+          rating,
+          fees_rating: feesRating || null,
+          platform_rating: platformRating || null,
+          support_rating: supportRating || null,
+          reliability_rating: reliabilityRating || null,
+          experience_months:
+            typeof experienceMonths === "number" ? experienceMonths : null,
+          title: title.trim() || null,
+          body: body.trim(),
+          display_name: displayName.trim() || null,
+        }),
+      });
+      const data = (await res.json()) as { ok?: boolean; error?: string };
+      if (res.ok && data.ok) setSubmitted(true);
+      else setSubmitError(data.error ?? "Failed to submit. Please try again.");
+    } catch {
+      setSubmitError("Network error. Please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-slate-50 flex items-center justify-center">
+        <div className="w-8 h-8 border-2 border-slate-300 border-t-slate-900 rounded-full animate-spin" />
+      </div>
+    );
+  }
+
+  if (loadError || !broker) {
+    return (
+      <div className="min-h-screen bg-slate-50 flex items-center justify-center p-4">
+        <div className="text-center max-w-sm">
+          <h1 className="text-lg font-bold text-slate-900 mb-2">
+            Review link unavailable
+          </h1>
+          <p className="text-sm text-slate-500 mb-4">
+            {loadError ?? "This review link is invalid or has expired."}
+          </p>
+          <Link
+            href="/compare"
+            className="text-sm text-amber-700 hover:text-amber-800 font-medium"
+          >
+            Browse brokers →
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  if (submitted) {
+    return (
+      <div className="min-h-screen bg-gradient-to-b from-emerald-50 to-white flex items-center justify-center p-4">
+        <div className="text-center max-w-sm">
+          <div className="w-16 h-16 bg-emerald-100 rounded-full flex items-center justify-center mx-auto mb-4">
+            <svg
+              className="w-8 h-8 text-emerald-600"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2.5}
+                d="M5 13l4 4L19 7"
+              />
+            </svg>
+          </div>
+          <h1 className="text-2xl font-extrabold text-slate-900 mb-2">
+            Thanks for sharing!
+          </h1>
+          <p className="text-sm text-slate-600 mb-1">
+            Your review will be moderated before publishing — usually within 24
+            hours.
+          </p>
+          <Link
+            href={`/broker/${broker.slug}`}
+            className="inline-block mt-4 px-6 py-2.5 bg-slate-900 text-white font-semibold rounded-lg text-sm hover:bg-slate-800 transition-colors"
+          >
+            View {broker.name}
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-slate-50 to-white py-10">
+      <div className="max-w-lg mx-auto px-4">
+        <div className="text-center mb-6">
+          <Link
+            href="/"
+            className="text-sm font-bold text-slate-900 hover:text-slate-700"
+          >
+            Invest.com.au
+          </Link>
+          <p className="text-xs text-slate-400 mt-0.5">Broker Review</p>
+        </div>
+
+        <div className="bg-white border border-slate-200 rounded-2xl p-4 mb-6 flex items-center gap-4">
+          {broker.logo_url ? (
+            <Image
+              src={broker.logo_url}
+              alt={broker.name}
+              width={56}
+              height={56}
+              className="rounded-xl object-contain w-14 h-14 bg-white shrink-0"
+            />
+          ) : (
+            <div className="w-14 h-14 rounded-xl bg-amber-100 text-amber-700 font-bold flex items-center justify-center shrink-0">
+              {broker.name[0]}
+            </div>
+          )}
+          <div className="flex-1 min-w-0">
+            <p className="font-bold text-slate-900 truncate">{broker.name}</p>
+            <p className="text-xs text-slate-500">Share your experience</p>
+          </div>
+          {broker.rating ? (
+            <div className="text-right shrink-0">
+              <p className="text-sm font-bold text-slate-900">
+                {broker.rating}
+              </p>
+              <p className="text-[0.6rem] text-slate-400">editor rating</p>
+            </div>
+          ) : null}
+        </div>
+
+        <div className="bg-white border border-slate-200 rounded-2xl p-6">
+          <h1 className="text-lg font-extrabold text-slate-900 mb-1">
+            Leave a review
+          </h1>
+          <p className="text-xs text-slate-500 mb-5">
+            Helps other Australians choose. Honest reviews only — moderated
+            before publishing.
+          </p>
+
+          <form onSubmit={handleSubmit} className="space-y-5">
+            <StarRating
+              value={rating}
+              onChange={setRating}
+              label="Overall rating"
+              required
+            />
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 bg-slate-50 rounded-xl p-4">
+              <StarRating
+                value={feesRating}
+                onChange={setFeesRating}
+                label="Fees"
+              />
+              <StarRating
+                value={platformRating}
+                onChange={setPlatformRating}
+                label="Platform"
+              />
+              <StarRating
+                value={supportRating}
+                onChange={setSupportRating}
+                label="Support"
+              />
+              <StarRating
+                value={reliabilityRating}
+                onChange={setReliabilityRating}
+                label="Reliability"
+              />
+            </div>
+
+            <div>
+              <label className="block text-xs font-semibold text-slate-600 mb-1">
+                Review title{" "}
+                <span className="text-slate-400 font-normal">(optional)</span>
+              </label>
+              <input
+                type="text"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                maxLength={100}
+                placeholder="Summarise your experience in one line"
+                className="w-full px-3 py-2.5 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-amber-500"
+              />
+            </div>
+
+            <div>
+              <label className="block text-xs font-semibold text-slate-600 mb-1">
+                Your review *
+              </label>
+              <textarea
+                value={body}
+                onChange={(e) => setBody(e.target.value)}
+                rows={5}
+                maxLength={4000}
+                placeholder="What did they do well? What could be better? Fees, support, platform — anything useful to other readers."
+                className="w-full px-3 py-2.5 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-amber-500 resize-none"
+              />
+              <p
+                className={`text-[0.6rem] mt-0.5 ${body.trim().length < 50 ? "text-slate-400" : "text-emerald-600"}`}
+              >
+                {body.trim().length} / 50 characters minimum
+              </p>
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div>
+                <label className="block text-xs font-semibold text-slate-600 mb-1">
+                  Display name{" "}
+                  <span className="text-slate-400 font-normal">
+                    (or leave blank for Anonymous)
+                  </span>
+                </label>
+                <input
+                  type="text"
+                  value={displayName}
+                  onChange={(e) => setDisplayName(e.target.value)}
+                  maxLength={80}
+                  placeholder="Jane D."
+                  className="w-full px-3 py-2.5 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-amber-500"
+                />
+              </div>
+              <div>
+                <label className="block text-xs font-semibold text-slate-600 mb-1">
+                  Months using{" "}
+                  <span className="text-slate-400 font-normal">(optional)</span>
+                </label>
+                <input
+                  type="number"
+                  min={0}
+                  max={600}
+                  value={experienceMonths}
+                  onChange={(e) =>
+                    setExperienceMonths(
+                      e.target.value === "" ? "" : Number(e.target.value),
+                    )
+                  }
+                  placeholder="6"
+                  className="w-full px-3 py-2.5 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-amber-500"
+                />
+              </div>
+            </div>
+
+            {submitError && (
+              <div
+                role="alert"
+                className="bg-red-50 border border-red-200 rounded-lg px-3 py-2 text-sm text-red-700"
+              >
+                {submitError}
+              </div>
+            )}
+
+            <button
+              type="submit"
+              disabled={submitting}
+              className="w-full py-3 bg-amber-500 hover:bg-amber-600 text-white font-bold rounded-xl text-sm transition-colors disabled:opacity-60"
+            >
+              {submitting ? "Submitting…" : "Submit review"}
+            </button>
+
+            <p className="text-center text-[0.65rem] text-slate-400">
+              Your email stays private. Reviews that look fake are removed.{" "}
+              <Link href="/privacy" className="underline hover:text-slate-600">
+                Privacy policy
+              </Link>
+            </p>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/review/broker/[token]/page.tsx
+++ b/app/review/broker/[token]/page.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from "next";
+import BrokerReviewInviteClient from "./BrokerReviewInviteClient";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Leave a review — invest.com.au",
+  robots: { index: false, follow: false },
+};
+
+export default async function BrokerReviewInvitePage({
+  params,
+}: {
+  params: Promise<{ token: string }>;
+}) {
+  const { token } = await params;
+  return <BrokerReviewInviteClient token={token} />;
+}

--- a/components/LinkifiedText.tsx
+++ b/components/LinkifiedText.tsx
@@ -1,0 +1,51 @@
+import Link from "next/link";
+import { splitByLinks } from "@/lib/keyword-linking";
+
+interface Props {
+  text: string;
+  /**
+   * Slugs to skip auto-linking — pass the current page's slug and any
+   * primary target slugs so we don't self-link an article to itself or
+   * link "CommSec" on the CommSec review page.
+   */
+  skipHrefs?: string[];
+  /** Tailwind classes for the wrapper — kept transparent by default. */
+  className?: string;
+}
+
+/**
+ * Renders prose with first-occurrence internal links wrapped as real
+ * <Link>s. Keeps the whitespace-pre-line flow of plain text so pasted
+ * copy still breaks on newlines.
+ *
+ * Safer than dangerouslySetInnerHTML — the keyword-linking engine
+ * returns an array of `string | {href,label}` nodes that React renders
+ * natively.
+ */
+export default function LinkifiedText({ text, skipHrefs, className }: Props) {
+  if (!text) return null;
+  const skip = new Set(skipHrefs ?? []);
+  const parts = splitByLinks(text);
+
+  return (
+    <div
+      className={`max-w-none text-slate-700 leading-relaxed whitespace-pre-line ${className ?? ""}`}
+    >
+      {parts.map((p, i) => {
+        if (typeof p === "string") return <span key={i}>{p}</span>;
+        if (skip.has(p.href)) return <span key={i}>{p.label}</span>;
+        return (
+          <Link
+            key={i}
+            href={p.href}
+            title={p.title}
+            rel={p.rel}
+            className="text-amber-700 underline decoration-amber-300 underline-offset-2 hover:text-amber-800"
+          >
+            {p.label}
+          </Link>
+        );
+      })}
+    </div>
+  );
+}

--- a/lib/cron-groups.ts
+++ b/lib/cron-groups.ts
@@ -51,11 +51,13 @@ export const CRON_GROUPS: Record<string, readonly string[]> = {
     "/api/cron/verify-review-clients",
     "/api/cron/ab-auto-promote",
     "/api/cron/revenue-reconciliation",
+    "/api/cron/broker-review-invites",
   ],
   "daily-5": [
     "/api/cron/expire-deals",
     "/api/cron/advisor-quality",
     "/api/cron/review-sentiment-refresh",
+    "/api/cron/versus-editorial-backfill",
   ],
   "daily-6": ["/api/cron/check-fees", "/api/cron/tmd-audit"],
   "daily-7": [


### PR DESCRIPTION
## Summary
- **Internal linking activated**: \`components/LinkifiedText\` wraps article sections and auto-links canonical destinations (brokers, advisors, tools, hubs) on first occurrence across every article
- **Broker review collection flow**: migration + invite cron + magic-link page. Affiliate click → 7 days later → email invite → one-click review form → moderation queue → aggregate rating feeds the existing Google star schema
- **AI-generated versus editorials**: backfill cron generates TL;DR + choose-A/B + 3 sections + FAQs for every pair missing editorial. Idempotent, 5 pairs/run default, \`?max=40\` for batch runs

## Test plan
- [ ] Open any article and confirm terms like \"CommSec\", \"SMSF\", \"financial planner\" auto-link
- [ ] Self-link suppression: the article's own slug is never linked to itself
- [ ] Visit \`/review/broker/<fresh-token>\` after manually inserting an invite row — form pre-fills broker
- [ ] Submit flow marks invite completed + inserts pending_moderation user_reviews row
- [ ] Call \`/api/cron/versus-editorial-backfill?max=1\` with the cron secret → new row appears in \`versus_editorials\`
- [ ] The versus page for that pair now shows TL;DR + choose A/B + sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)