### PR TITLE
fix(deps): regenerate package-lock.json for @axe-core/playwright

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "stripe": "^17.7.0"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.10.0",
         "@next/bundle-analyzer": "^16.2.3",
         "@playwright/test": "^1.50.0",
         "@tailwindcss/postcss": "^4.2.2",
@@ -108,6 +109,19 @@
       "version": "10.4.3",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.2.tgz",
+      "integrity": "sha512-iP6hfNl9G0j/SEUSo8M7D80RbcDo9KRAAfDP4IT5OHB+Wm6zUHIrm8Y51BKI+Oyqduvipf9u1hcRy57zCBKzWQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.3"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -3346,7 +3360,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.11.1",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.3.tgz",
+      "integrity": "sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==",
       "dev": true,
       "license": "MPL-2.0",
       "engines": {


### PR DESCRIPTION
Unblocks CI — every run since #170 failed at `npm ci` because package-lock.json wasn't regenerated after adding @axe-core/playwright.