### PR TITLE
test(lib): 70 unit tests for libs shipped this session

### DIFF
--- a/__tests__/lib/fee-freshness.test.ts
+++ b/__tests__/lib/fee-freshness.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { computeFeeFreshness, FEE_STALE_DAYS } from "@/lib/fee-freshness";
+
+describe("computeFeeFreshness", () => {
+  const NOW = new Date("2026-04-19T12:00:00Z");
+
+  it("returns 'unknown' for null / undefined / empty input", () => {
+    expect(computeFeeFreshness(null, NOW).tier).toBe("unknown");
+    expect(computeFeeFreshness(undefined, NOW).tier).toBe("unknown");
+    expect(computeFeeFreshness("", NOW).tier).toBe("unknown");
+  });
+
+  it("returns 'unknown' for unparseable dates", () => {
+    expect(computeFeeFreshness("not-a-date", NOW).tier).toBe("unknown");
+  });
+
+  it("returns 'fresh' within the 30-day window", () => {
+    const r = computeFeeFreshness("2026-04-01T12:00:00Z", NOW);
+    expect(r.tier).toBe("fresh");
+    expect(r.ageDays).toBe(18);
+  });
+
+  it("returns 'fresh' exactly at 30 days", () => {
+    const r = computeFeeFreshness("2026-03-20T12:00:00Z", NOW);
+    expect(r.tier).toBe("fresh");
+    expect(r.ageDays).toBe(30);
+  });
+
+  it("returns 'current' between 30 and 90 days", () => {
+    const r = computeFeeFreshness("2026-03-01T12:00:00Z", NOW);
+    expect(r.tier).toBe("current");
+    expect(r.ageDays).toBe(49);
+  });
+
+  it("returns 'stale' past 90 days", () => {
+    const r = computeFeeFreshness("2026-01-01T12:00:00Z", NOW);
+    expect(r.tier).toBe("stale");
+    expect(r.ageDays).toBe(108);
+  });
+
+  it("uses 'Fees verified today' for the same-day case", () => {
+    expect(computeFeeFreshness(NOW.toISOString(), NOW).label).toBe(
+      "Fees verified today",
+    );
+  });
+
+  it("uses 'yesterday' for 1 day ago", () => {
+    expect(
+      computeFeeFreshness("2026-04-18T12:00:00Z", NOW).label,
+    ).toBe("Fees verified yesterday");
+  });
+
+  it("uses 'N days ago' label under 30 days", () => {
+    expect(
+      computeFeeFreshness("2026-04-10T12:00:00Z", NOW).label,
+    ).toBe("Fees verified 9 days ago");
+  });
+
+  it("switches to months after 30 days", () => {
+    expect(
+      computeFeeFreshness("2026-02-19T12:00:00Z", NOW).label,
+    ).toMatch(/^Fees verified \d+ months? ago$/);
+  });
+
+  it("never returns a negative ageDays (future dates)", () => {
+    const r = computeFeeFreshness("2027-01-01T12:00:00Z", NOW);
+    expect(r.ageDays).toBe(0);
+    expect(r.tier).toBe("fresh");
+  });
+
+  it("exposes a constant matching the stale threshold", () => {
+    expect(FEE_STALE_DAYS).toBe(90);
+  });
+
+  it("colour classes are deterministic per tier", () => {
+    expect(
+      computeFeeFreshness("2026-04-10T12:00:00Z", NOW).classes.dot,
+    ).toBe("bg-emerald-500");
+    expect(
+      computeFeeFreshness("2026-02-01T12:00:00Z", NOW).classes.dot,
+    ).toBe("bg-amber-500");
+    expect(
+      computeFeeFreshness("2025-11-01T12:00:00Z", NOW).classes.dot,
+    ).toBe("bg-rose-500");
+    expect(computeFeeFreshness(null, NOW).classes.dot).toBe("bg-rose-500");
+  });
+});

--- a/__tests__/lib/i18n-locales.test.ts
+++ b/__tests__/lib/i18n-locales.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+import {
+  LOCALES,
+  DEFAULT_LOCALE,
+  BCP47_TAG,
+  LOCALE_LABEL,
+  isLocale,
+  stripLocalePrefix,
+  localePath,
+} from "@/lib/i18n/locales";
+import { getForeignInvestmentDict } from "@/lib/i18n/dictionaries";
+
+describe("locale registry", () => {
+  it("has a default locale of en", () => {
+    expect(DEFAULT_LOCALE).toBe("en");
+  });
+
+  it("includes en + zh + ko and nothing else", () => {
+    expect([...LOCALES].sort()).toEqual(["en", "ko", "zh"]);
+  });
+
+  it("every locale has a BCP-47 tag and a UI label", () => {
+    for (const l of LOCALES) {
+      expect(BCP47_TAG[l]).toMatch(/^[a-z]{2}-[A-Z]{2}$/);
+      expect(LOCALE_LABEL[l]).toBeTruthy();
+    }
+  });
+
+  it("isLocale guards correctly", () => {
+    expect(isLocale("en")).toBe(true);
+    expect(isLocale("zh")).toBe(true);
+    expect(isLocale("fr")).toBe(false);
+    expect(isLocale("")).toBe(false);
+  });
+});
+
+describe("stripLocalePrefix", () => {
+  it("returns en for a non-prefixed path", () => {
+    expect(stripLocalePrefix("/foreign-investment")).toEqual({
+      locale: "en",
+      path: "/foreign-investment",
+    });
+  });
+
+  it("strips /zh and returns the residual path", () => {
+    expect(stripLocalePrefix("/zh/foreign-investment")).toEqual({
+      locale: "zh",
+      path: "/foreign-investment",
+    });
+  });
+
+  it("handles bare /zh as /", () => {
+    expect(stripLocalePrefix("/zh")).toEqual({ locale: "zh", path: "/" });
+  });
+
+  it("does not strip unrelated locales (fr, es)", () => {
+    expect(stripLocalePrefix("/fr/foo")).toEqual({
+      locale: "en",
+      path: "/fr/foo",
+    });
+  });
+});
+
+describe("localePath", () => {
+  it("leaves en unchanged", () => {
+    expect(localePath("/foreign-investment", "en")).toBe("/foreign-investment");
+  });
+
+  it("prefixes non-default locales", () => {
+    expect(localePath("/foreign-investment", "zh")).toBe("/zh/foreign-investment");
+    expect(localePath("/foreign-investment", "ko")).toBe("/ko/foreign-investment");
+  });
+
+  it("handles root path without leaving a dangling slash", () => {
+    expect(localePath("/", "zh")).toBe("/zh");
+  });
+});
+
+describe("foreign investment dictionary", () => {
+  it("exists for every registered locale", () => {
+    for (const l of LOCALES) {
+      const dict = getForeignInvestmentDict(l);
+      expect(dict).toBeDefined();
+      expect(dict.meta.title).toBeTruthy();
+    }
+  });
+
+  it("every locale has exactly 4 topic cards", () => {
+    for (const l of LOCALES) {
+      expect(getForeignInvestmentDict(l).topicCards).toHaveLength(4);
+    }
+  });
+
+  it("body arrays have at least 2 paragraphs in every locale", () => {
+    for (const l of LOCALES) {
+      const d = getForeignInvestmentDict(l);
+      expect(d.firb.body.length).toBeGreaterThanOrEqual(2);
+      expect(d.siv.body.length).toBeGreaterThanOrEqual(2);
+      expect(d.tax.body.length).toBeGreaterThanOrEqual(2);
+    }
+  });
+
+  it("localised topic cards link back to their own locale prefix", () => {
+    const zh = getForeignInvestmentDict("zh");
+    for (const card of zh.topicCards) {
+      expect(card.href).toMatch(/^\/zh\//);
+    }
+    const ko = getForeignInvestmentDict("ko");
+    for (const card of ko.topicCards) {
+      expect(card.href).toMatch(/^\/ko\//);
+    }
+  });
+});

--- a/__tests__/lib/keyword-linking.test.ts
+++ b/__tests__/lib/keyword-linking.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from "vitest";
+import {
+  INTERNAL_LINK_TARGETS,
+  linkifyHtml,
+  splitByLinks,
+} from "@/lib/keyword-linking";
+
+describe("INTERNAL_LINK_TARGETS", () => {
+  it("has no empty keywords or hrefs", () => {
+    for (const t of INTERNAL_LINK_TARGETS) {
+      expect(t.keyword.trim()).toBeTruthy();
+      expect(t.href).toMatch(/^\//);
+    }
+  });
+
+  it("has no duplicate (keyword, href) pairs", () => {
+    const seen = new Set<string>();
+    for (const t of INTERNAL_LINK_TARGETS) {
+      const k = `${t.keyword.toLowerCase()}::${t.href}`;
+      expect(seen.has(k)).toBe(false);
+      seen.add(k);
+    }
+  });
+});
+
+describe("splitByLinks", () => {
+  it("returns an empty array for empty input", () => {
+    expect(splitByLinks("")).toEqual([]);
+  });
+
+  it("returns plain text untouched when no keyword is present", () => {
+    const out = splitByLinks("Just some neutral copy about finance.");
+    expect(out).toHaveLength(1);
+    expect(out[0]).toBe("Just some neutral copy about finance.");
+  });
+
+  it("wraps the first occurrence of a known keyword", () => {
+    const out = splitByLinks("We recommend CommSec for beginners.");
+    expect(out).toEqual([
+      "We recommend ",
+      { href: "/broker/commsec", label: "CommSec", title: undefined, rel: undefined },
+      " for beginners.",
+    ]);
+  });
+
+  it("only links the first occurrence of a keyword", () => {
+    const out = splitByLinks("CommSec offers research. CommSec also sponsors CHESS.");
+    const links = out.filter(
+      (p): p is { href: string; label: string } =>
+        typeof p !== "string",
+    );
+    const commsecLinks = links.filter((l) => l.href === "/broker/commsec");
+    expect(commsecLinks).toHaveLength(1);
+  });
+
+  it("matches case-insensitively but preserves the original casing in the label", () => {
+    const out = splitByLinks("We use commSEC daily.");
+    const link = out.find((p) => typeof p !== "string");
+    expect(link).toBeDefined();
+    if (typeof link !== "string" && link) {
+      expect(link.label).toBe("commSEC");
+      expect(link.href).toBe("/broker/commsec");
+    }
+  });
+
+  it("prefers longer keywords over shorter ones that are substrings", () => {
+    // "SMSF accountant" should win over bare "SMSF" when both could match.
+    const out = splitByLinks("Find an SMSF accountant in Sydney.");
+    const link = out.find((p) => typeof p !== "string");
+    if (typeof link !== "string" && link) {
+      expect(link.label).toBe("SMSF accountant");
+      expect(link.href).toBe("/advisors/smsf-accountants");
+    }
+  });
+
+  it("respects word boundaries (won't match substrings of other words)", () => {
+    const out = splitByLinks("The commsecure vault is separate.");
+    // "commsec" is a keyword but "commsecure" should NOT match.
+    const links = out.filter((p) => typeof p !== "string");
+    expect(links).toHaveLength(0);
+  });
+});
+
+describe("linkifyHtml", () => {
+  it("returns an empty string for empty input", () => {
+    expect(linkifyHtml("")).toBe("");
+  });
+
+  it("wraps a matched keyword in <a>", () => {
+    const out = linkifyHtml("<p>We use CommSec daily.</p>");
+    expect(out).toContain('<a href="/broker/commsec"');
+    expect(out).toContain(">CommSec</a>");
+  });
+
+  it("does not rewrite text inside an existing <a>", () => {
+    const input =
+      '<p><a href="/external">CommSec is already linked</a>. CommSec again.</p>';
+    const out = linkifyHtml(input);
+    // The second CommSec (outside the <a>) should be linked; the first should not.
+    const newLinks = out.match(/href="\/broker\/commsec"/g) || [];
+    expect(newLinks).toHaveLength(1);
+    // Original external link is preserved.
+    expect(out).toContain('href="/external"');
+  });
+
+  it("skips <code> and <pre> blocks", () => {
+    const out = linkifyHtml(
+      "<pre>CommSec code example</pre><p>CommSec prose.</p>",
+    );
+    expect(out).toContain("<pre>CommSec code example</pre>");
+    // Prose outside the pre still gets linked once.
+    expect(out).toContain('<a href="/broker/commsec"');
+  });
+
+  it("only links first occurrence even across multiple chunks", () => {
+    const out = linkifyHtml(
+      "<p>CommSec first</p><p>CommSec second</p><p>CommSec third</p>",
+    );
+    const count = (out.match(/href="\/broker\/commsec"/g) || []).length;
+    expect(count).toBe(1);
+  });
+
+  it("is safe against malformed HTML (unclosed tag)", () => {
+    const out = linkifyHtml("<p>CommSec without closing");
+    expect(out).toContain("<p>");
+    expect(out.length).toBeGreaterThan(0);
+  });
+});

--- a/__tests__/lib/schema-markup.test.ts
+++ b/__tests__/lib/schema-markup.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect } from "vitest";
+import {
+  articleJsonLd,
+  faqJsonLd,
+  brokerFinancialProductJsonLd,
+  advisorJsonLd,
+  itemListJsonLd,
+  listingProductJsonLd,
+  calculatorJsonLd,
+} from "@/lib/schema-markup";
+
+describe("articleJsonLd", () => {
+  const base = {
+    title: "A guide to SMSFs",
+    slug: "guide-to-smsfs",
+    description: "A full guide",
+  };
+
+  it("emits the required @context / @type", () => {
+    const out = articleJsonLd(base);
+    expect(out["@context"]).toBe("https://schema.org");
+    expect(out["@type"]).toBe("Article");
+  });
+
+  it("falls back to the OG preview image when coverImageUrl is missing", () => {
+    const out = articleJsonLd(base);
+    expect(String(out.image)).toContain("/api/og");
+  });
+
+  it("uses the absolute coverImageUrl when provided", () => {
+    const out = articleJsonLd({
+      ...base,
+      coverImageUrl: "/covers/smsf.png",
+    });
+    expect(String(out.image)).toContain("/covers/smsf.png");
+  });
+
+  it("defaults dateModified to publishedAt when updatedAt is missing", () => {
+    const out = articleJsonLd({
+      ...base,
+      publishedAt: "2026-03-01",
+    });
+    expect(out.dateModified).toBe("2026-03-01");
+  });
+
+  it("falls back to the organisation author when authorName is absent", () => {
+    const out = articleJsonLd(base);
+    expect(
+      (out.author as { "@type": string })["@type"],
+    ).toBe("Organization");
+  });
+});
+
+describe("faqJsonLd", () => {
+  it("returns null for an empty array", () => {
+    expect(faqJsonLd([])).toBeNull();
+  });
+
+  it("builds a valid FAQPage for non-empty items", () => {
+    const out = faqJsonLd([
+      { q: "What is SMSF?", a: "Self-managed super fund." },
+    ]);
+    expect(out).toMatchObject({
+      "@type": "FAQPage",
+      mainEntity: [
+        {
+          "@type": "Question",
+          name: "What is SMSF?",
+          acceptedAnswer: { "@type": "Answer", text: "Self-managed super fund." },
+        },
+      ],
+    });
+  });
+});
+
+describe("brokerFinancialProductJsonLd", () => {
+  it("emits a URL and brand", () => {
+    const out = brokerFinancialProductJsonLd({ slug: "commsec", name: "CommSec" });
+    expect(out["@type"]).toBe("FinancialProduct");
+    expect(String(out.url)).toContain("/broker/commsec");
+    expect((out.brand as { "@type": string })["@type"]).toBe("Organization");
+  });
+
+  it("omits aggregateRating when review count is zero", () => {
+    const out = brokerFinancialProductJsonLd({
+      slug: "foo",
+      name: "Foo",
+      rating: 4.5,
+      reviewCount: 0,
+    });
+    expect(out.aggregateRating).toBeUndefined();
+  });
+
+  it("includes aggregateRating when review count > 0", () => {
+    const out = brokerFinancialProductJsonLd({
+      slug: "foo",
+      name: "Foo",
+      rating: 4.5,
+      reviewCount: 10,
+    });
+    expect(out.aggregateRating).toBeDefined();
+  });
+});
+
+describe("advisorJsonLd", () => {
+  it("returns person + localBusiness when firmName is set", () => {
+    const { person, localBusiness } = advisorJsonLd({
+      slug: "jane-doe",
+      name: "Jane Doe",
+      firmName: "Doe Advisers",
+    });
+    expect(person["@type"]).toBe("Person");
+    expect(localBusiness).not.toBeNull();
+    expect(localBusiness?.["@type"]).toBe("LocalBusiness");
+  });
+
+  it("returns person but null localBusiness when firmName is missing", () => {
+    const { person, localBusiness } = advisorJsonLd({
+      slug: "jane-doe",
+      name: "Jane Doe",
+    });
+    expect(person["@type"]).toBe("Person");
+    expect(localBusiness).toBeNull();
+  });
+});
+
+describe("itemListJsonLd", () => {
+  it("emits a numbered list with absolute URLs", () => {
+    const out = itemListJsonLd("Top brokers", [
+      { position: 1, name: "Stake", url: "/broker/stake" },
+      { position: 2, name: "CommSec", url: "/broker/commsec" },
+    ]);
+    expect(out.numberOfItems).toBe(2);
+    expect(String(out.itemListElement[0].url)).toContain("/broker/stake");
+  });
+});
+
+describe("listingProductJsonLd", () => {
+  it("emits an InStock offer when priceAud is set", () => {
+    const out = listingProductJsonLd({
+      slug: "acme",
+      title: "Acme fund",
+      priceAud: 250_000,
+    });
+    const offers = out.offers as { availability?: string; price?: number };
+    expect(offers.availability).toBe("https://schema.org/InStock");
+    expect(offers.price).toBe(250_000);
+  });
+
+  it("falls back to priceDisplay when priceAud is absent", () => {
+    const out = listingProductJsonLd({
+      slug: "acme",
+      title: "Acme fund",
+      priceDisplay: "From $50,000",
+    });
+    const offers = out.offers as { priceSpecification?: string };
+    expect(offers.priceSpecification).toBe("From $50,000");
+  });
+
+  it("omits offers entirely when neither price is set", () => {
+    const out = listingProductJsonLd({ slug: "acme", title: "Acme" });
+    expect(out.offers).toBeUndefined();
+  });
+
+  it("embeds areaServed when locationState is provided", () => {
+    const out = listingProductJsonLd({
+      slug: "acme",
+      title: "Acme",
+      locationState: "NSW",
+      locationCity: "Sydney",
+    });
+    expect(out.areaServed).toBeDefined();
+  });
+});
+
+describe("calculatorJsonLd", () => {
+  it("emits a free WebApplication in the FinanceApplication category", () => {
+    const out = calculatorJsonLd({
+      name: "FIRB fee estimator",
+      description: "Estimate your FIRB fee",
+      path: "/firb-fee-estimator",
+    });
+    expect(out["@type"]).toBe("WebApplication");
+    expect(out.applicationCategory).toBe("FinanceApplication");
+    expect((out.offers as { price: string }).price).toBe("0");
+  });
+});

--- a/__tests__/lib/versus-pairs.test.ts
+++ b/__tests__/lib/versus-pairs.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import {
+  generateVersusPairs,
+  getRelatedVersusPairs,
+} from "@/lib/versus-pairs";
+
+type Row = {
+  slug: string;
+  name: string;
+  rating: number | null;
+  platform_type:
+    | "share_broker"
+    | "cfd_forex"
+    | "crypto_exchange"
+    | "super_fund"
+    | "robo_advisor"
+    | "savings_account"
+    | "term_deposit"
+    | "property_platform"
+    | "research_tool";
+};
+
+const SHARE_BROKERS: Row[] = [
+  { slug: "stake", name: "Stake", rating: 4.5, platform_type: "share_broker" },
+  { slug: "commsec", name: "CommSec", rating: 3.5, platform_type: "share_broker" },
+  { slug: "moomoo", name: "Moomoo", rating: 4.3, platform_type: "share_broker" },
+];
+
+const CRYPTO: Row[] = [
+  { slug: "coinspot", name: "CoinSpot", rating: 4.2, platform_type: "crypto_exchange" },
+  { slug: "swyftx", name: "Swyftx", rating: 4.4, platform_type: "crypto_exchange" },
+];
+
+describe("generateVersusPairs", () => {
+  it("generates N*(N-1)/2 pairs per platform_type group", () => {
+    const pairs = generateVersusPairs([...SHARE_BROKERS, ...CRYPTO]);
+    // 3 share brokers → 3 pairs ; 2 crypto → 1 pair = 4 total
+    expect(pairs).toHaveLength(4);
+  });
+
+  it("never pairs across platform types", () => {
+    const pairs = generateVersusPairs([...SHARE_BROKERS, ...CRYPTO]);
+    for (const p of pairs) {
+      const [a, b] = p.slug.split("-vs-");
+      const rowA = [...SHARE_BROKERS, ...CRYPTO].find((r) => r.slug === a)!;
+      const rowB = [...SHARE_BROKERS, ...CRYPTO].find((r) => r.slug === b)!;
+      expect(rowA.platform_type).toBe(rowB.platform_type);
+    }
+  });
+
+  it("sorts slugs alphabetically in each pair", () => {
+    const pairs = generateVersusPairs(SHARE_BROKERS);
+    for (const p of pairs) {
+      const [a, b] = p.slug.split("-vs-");
+      expect([a, b]).toEqual([a, b].slice().sort());
+    }
+  });
+
+  it("ranks by rating product descending", () => {
+    const pairs = generateVersusPairs(SHARE_BROKERS);
+    for (let i = 1; i < pairs.length; i++) {
+      expect(pairs[i - 1].score).toBeGreaterThanOrEqual(pairs[i].score);
+    }
+  });
+
+  it("handles brokers with null rating as zero score", () => {
+    const pairs = generateVersusPairs([
+      ...SHARE_BROKERS,
+      {
+        slug: "unrated",
+        name: "Unrated",
+        rating: null,
+        platform_type: "share_broker",
+      },
+    ]);
+    const unratedPairs = pairs.filter((p) => p.slug.includes("unrated"));
+    for (const p of unratedPairs) {
+      expect(p.score).toBe(0);
+    }
+  });
+
+  it("returns an empty array for a single broker", () => {
+    expect(generateVersusPairs([SHARE_BROKERS[0]!])).toEqual([]);
+  });
+});
+
+describe("getRelatedVersusPairs", () => {
+  it("returns pairs that share a broker and platform_type", () => {
+    const all = generateVersusPairs(SHARE_BROKERS);
+    const stakeVsCommsec = all.find((p) => p.slug === "commsec-vs-stake")!;
+    const related = getRelatedVersusPairs(stakeVsCommsec, all, 10);
+
+    for (const r of related) {
+      const parts = r.slug.split("-vs-");
+      // Must share at least one of the two brokers in the input pair.
+      expect(parts.some((p) => p === "commsec" || p === "stake")).toBe(true);
+      expect(r.platform_type).toBe("share_broker");
+    }
+  });
+
+  it("never returns the input pair", () => {
+    const all = generateVersusPairs(SHARE_BROKERS);
+    const pair = all[0]!;
+    expect(getRelatedVersusPairs(pair, all, 10)).not.toContainEqual(pair);
+  });
+
+  it("respects the limit", () => {
+    const all = generateVersusPairs([...SHARE_BROKERS, ...CRYPTO]);
+    const p = all[0]!;
+    expect(getRelatedVersusPairs(p, all, 1).length).toBeLessThanOrEqual(1);
+  });
+});


### PR DESCRIPTION
Unit tests for `fee-freshness`, `versus-pairs`, `keyword-linking`, `schema-markup`, and `i18n/locales` — all of which shipped with zero coverage. 70 tests green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)