### PR TITLE
feat(seo): richer schema + boost editorial backfill cron

### DIFF
--- a/app/api/cron/versus-editorial-backfill/route.ts
+++ b/app/api/cron/versus-editorial-backfill/route.ts
@@ -8,7 +8,7 @@ import type { PlatformType } from "@/lib/types";
 
 const log = logger("cron:versus-editorial-backfill");
 
-export const maxDuration = 60;
+export const maxDuration = 300;
 
 /**
  * AI-generated versus editorial backfill.
@@ -18,14 +18,15 @@ export const maxDuration = 60;
  * the result. Idempotent — skips pairs that already have editorial so
  * re-running burns no tokens.
  *
- * Runs N pairs per invocation (default 5, override with ?max=N) so the
- * cron stays well under its 60s budget and token costs are predictable.
- * Daily runs would complete the backfill of 400 pairs in ~80 days; a
- * one-off manual trigger with ?max=40 batches it through faster.
+ * Runs N pairs per invocation (default 20, override with ?max=N). At
+ * ~1500 output tokens per editorial that's ~30k tokens/day — well
+ * under the Sonnet cost floor. With the default quota the backfill of
+ * 400 pairs finishes in ~3 weeks instead of ~3 months. The 300s
+ * maxDuration gives room for ~80 pairs per manual ?max burst.
  */
 
 const MODEL = "claude-sonnet-4-20250514";
-const DEFAULT_MAX_PAIRS = 5;
+const DEFAULT_MAX_PAIRS = 20;
 
 interface BrokerRow {
   id: number;
@@ -70,7 +71,7 @@ export async function GET(req: NextRequest) {
 
   const max = Math.max(
     1,
-    Math.min(40, Number(req.nextUrl.searchParams.get("max") ?? DEFAULT_MAX_PAIRS)),
+    Math.min(80, Number(req.nextUrl.searchParams.get("max") ?? DEFAULT_MAX_PAIRS)),
   );
 
   const supabase = createAdminClient();
@@ -151,11 +152,20 @@ export async function GET(req: NextRequest) {
     }
   }
 
+  const remaining = pairs.length - existingSlugs.size - generated;
+  log.info("backfill_run_complete", {
+    generated,
+    failed,
+    remaining,
+    totalPairs: pairs.length,
+    alreadyDone: existingSlugs.size + generated,
+  });
   return NextResponse.json({
     ok: true,
     generated,
     failed,
-    remaining: pairs.length - existingSlugs.size - generated,
+    remaining,
+    totalPairs: pairs.length,
   });
 }
 

--- a/app/best/[slug]/page.tsx
+++ b/app/best/[slug]/page.tsx
@@ -149,6 +149,12 @@ export default async function BestBrokerPage({
     },
   };
 
+  // Rich ItemList: each entry embeds a FinancialProduct with
+  // name/url/description so Google has enough context to render a
+  // richer SERP tile than a bare ListItem. AggregateRating is
+  // deliberately NOT included here — Google's structured-data policy
+  // forbids fabricated review counts, and the per-broker pages
+  // already carry real aggregateRating when user reviews exist.
   const itemListJsonLd = {
     "@context": "https://schema.org",
     "@type": "ItemList",
@@ -157,8 +163,13 @@ export default async function BestBrokerPage({
     itemListElement: filtered.slice(0, 10).map((b, i) => ({
       "@type": "ListItem",
       position: i + 1,
-      name: b.name,
       url: absoluteUrl(`/broker/${b.slug}`),
+      item: {
+        "@type": "FinancialProduct",
+        name: b.name,
+        url: absoluteUrl(`/broker/${b.slug}`),
+        description: b.tagline || `${b.name} — Australian investing platform`,
+      },
     })),
   };
 

--- a/app/broker/[slug]/page.tsx
+++ b/app/broker/[slug]/page.tsx
@@ -170,8 +170,13 @@ export default async function BrokerPage({ params }: { params: Promise<{ slug: s
     { name: b.name },
   ]);
 
-  // AggregateRating JSON-LD for user reviews (star ratings in Google results)
-  // Uses SoftwareApplication type to distinguish user ratings from editorial review on FinancialProduct
+  // AggregateRating + individual Reviews JSON-LD for user reviews.
+  // SoftwareApplication type keeps this entity distinct from the
+  // editorial FinancialProduct review — Google honours both and shows
+  // star-rating rich results on SERP when ≥1 user review exists.
+  // We nest the top 5 most-recent approved reviews as individual
+  // Review items so rich snippets can display review excerpts.
+  const topUserReviews = ((userReviews ?? []) as UserReview[]).slice(0, 5);
   const aggregateRatingLd = reviewStats && reviewStats.review_count > 0 && reviewStats.average_rating != null ? {
     "@context": "https://schema.org",
     "@type": "SoftwareApplication",
@@ -185,6 +190,25 @@ export default async function BrokerPage({ params }: { params: Promise<{ slug: s
       worstRating: 1,
       ratingCount: reviewStats.review_count,
     },
+    ...(topUserReviews.length > 0
+      ? {
+          review: topUserReviews.map((r) => ({
+            "@type": "Review",
+            author: { "@type": "Person", name: r.display_name || "Anonymous" },
+            datePublished: r.created_at
+              ? new Date(r.created_at).toISOString().split("T")[0]
+              : undefined,
+            name: r.title || `${b.name} review`,
+            reviewBody: (r.body || "").slice(0, 500),
+            reviewRating: {
+              "@type": "Rating",
+              ratingValue: r.rating,
+              bestRating: 5,
+              worstRating: 1,
+            },
+          })),
+        }
+      : {}),
   } : null;
 
   // Dates for visible byline (must match structured data)


### PR DESCRIPTION
## Summary

Two SEO compounders, zero blockers:

### 1. Richer Review schema on /broker/[slug]
- Nest top 5 user reviews as individual \`Review\` items inside the SoftwareApplication AggregateRating block → SERP can render review excerpts beside the star rating
- No-op on pages without user reviews

### 2. Richer ItemList on /best/[slug]
- Each ListItem now embeds a \`FinancialProduct\` item (name, description, URL) → Google has richer entity context for "best of" SERP tiles
- Deliberately skips aggregateRating at the list level (Google forbids fabricated review counts; the per-broker page carries the real one)

### 3. Editorial-backfill cron throughput
- Default quota 5 → **20** pairs per daily run (Sonnet ~30k output tokens = well under cost floor)
- \`maxDuration\` 60s → 300s so a manual \`?max=80\` burst fits
- Logs remaining pair count for observability
- Result: 400-pair backfill finishes in ~3 weeks instead of ~3 months. Currently 81 → targeting full coverage.

## Test plan
- [x] \`tsc --noEmit\` clean
- [x] \`eslint --max-warnings 0\` clean on all 3 files
- [ ] Next daily-5 run writes up to 20 new editorials
- [ ] Google Rich Results Test on a broker page with user reviews still validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)