### PR TITLE
feat: nav polish — /super canonical, advertise CTA, related-verticals strip

### DIFF
--- a/app/advertise/page.tsx
+++ b/app/advertise/page.tsx
@@ -224,6 +224,24 @@ export default function AdvertisePage() {
               </div>
             ))}
           </div>
+          <div className="mt-10 text-center">
+            <Link
+              href="/advertise/packages"
+              className="inline-flex items-center gap-2 px-8 py-3 bg-slate-900 text-white font-bold text-sm rounded-lg hover:bg-slate-800 transition-colors"
+            >
+              Configure &amp; book a package
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+              </svg>
+            </Link>
+            <p className="text-xs text-slate-500 mt-3">
+              Self-serve checkout with duration discounts — or{" "}
+              <a href="mailto:partners@invest.com.au" className="underline hover:text-slate-900 transition-colors">
+                contact sales
+              </a>
+              .
+            </p>
+          </div>
         </div>
       </section>
 

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -115,7 +115,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     "/property/finance",
     // Additional public pages
     "/tools", "/rates", "/properties", "/pro", "/jobs",
-    "/advertise", "/advertise/featured-placement", "/advertiser-terms", "/accessibility",
+    "/advertise", "/advertise/packages", "/advertise/featured-placement", "/advertiser-terms", "/accessibility",
     "/fsg", "/legal", "/developer-terms", "/consultations",
     "/courses", "/reports", "/portfolio", "/portfolio-calculator",
     "/advisor-signup",

--- a/components/VerticalPillarPage.tsx
+++ b/components/VerticalPillarPage.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import type { Broker, Article } from "@/lib/types";
 import type { VerticalConfig } from "@/lib/verticals";
+import { getRelatedVerticals } from "@/lib/verticals";
 import {
   absoluteUrl,
   breadcrumbJsonLd,
@@ -158,6 +159,7 @@ export default function VerticalPillarPage({
             ...(advisors.length > 0 ? [{ id: "expert-advisors", label: "Advisors" }] : []),
             ...(expertArticles.length > 0 ? [{ id: "expert-insights", label: "Expert Insights" }] : []),
             ...(config.faqs.length > 0 ? [{ id: "faq", label: "FAQ" }] : []),
+            { id: "other-categories", label: "Other Categories" },
             ...(relatedArticles.length > 0
               ? [{ id: "related-articles", label: "Articles" }]
               : []),
@@ -538,6 +540,7 @@ export default function VerticalPillarPage({
                         href={`/advisor/${advisor.slug}`}
                         className="flex items-center gap-3 p-3 bg-white border border-violet-100 rounded-xl hover:border-violet-300 hover:shadow-md transition-all group"
                       >
+                        {/* eslint-disable-next-line @next/next/no-img-element */}
                         <img
                           src={advisor.photo_url || `https://ui-avatars.com/api/?name=${encodeURIComponent(advisor.name)}&size=80&background=7c3aed&color=fff`}
                           alt={advisor.name}
@@ -601,8 +604,9 @@ export default function VerticalPillarPage({
               <h2 className="text-xl md:text-2xl font-extrabold text-slate-900 mb-4">Expert Insights</h2>
               <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
                 {expertArticles.map((article: ExpertArticle) => (
-                  <a key={article.id} href={`/expert/${article.slug}`} className="bg-white border border-slate-200 rounded-xl p-4 hover:shadow-md hover:border-slate-300 transition-all group">
+                  <Link key={article.id} href={`/expert/${article.slug}`} className="bg-white border border-slate-200 rounded-xl p-4 hover:shadow-md hover:border-slate-300 transition-all group">
                     <div className="flex items-center gap-2 mb-2.5">
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
                       <img
                         src={article.author_photo_url || `https://ui-avatars.com/api/?name=${encodeURIComponent(article.author_name || 'Expert')}&background=7c3aed&color=fff&size=40`}
                         alt={article.author_name || 'Expert'}
@@ -618,11 +622,11 @@ export default function VerticalPillarPage({
                     {article.category && (
                       <span className="inline-block mt-2 px-2 py-0.5 bg-violet-50 text-violet-600 text-[0.58rem] font-medium rounded-full">{article.category}</span>
                     )}
-                  </a>
+                  </Link>
                 ))}
               </div>
               <div className="mt-3 text-center">
-                <a href="/expert" className="text-xs font-bold text-violet-600 hover:text-violet-800 transition-colors">View all expert articles &rarr;</a>
+                <Link href="/expert" className="text-xs font-bold text-violet-600 hover:text-violet-800 transition-colors">View all expert articles &rarr;</Link>
               </div>
             </section>
           )}
@@ -650,6 +654,31 @@ export default function VerticalPillarPage({
               </div>
             </div>
           )}
+
+          {/* ─── Other Categories (cross-sell to sibling pillars) ─── */}
+          <div id="other-categories" className="mb-6 md:mb-10 scroll-mt-20">
+            <h2 className="text-lg md:text-xl font-bold mb-3">
+              Compare Other Categories
+            </h2>
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-2 md:gap-3">
+              {getRelatedVerticals(config.slug).map((rv) => (
+                <Link
+                  key={rv.slug}
+                  href={`/${rv.slug}`}
+                  className="block p-3 border border-slate-200 rounded-xl hover:border-slate-400 hover:bg-slate-50/50 transition-all group"
+                >
+                  <span className="text-sm font-semibold text-slate-800 group-hover:text-slate-900">
+                    {rv.label}
+                  </span>
+                  {rv.tagline && (
+                    <p className="text-[0.6rem] md:text-xs text-slate-500 mt-0.5">
+                      {rv.tagline}
+                    </p>
+                  )}
+                </Link>
+              ))}
+            </div>
+          </div>
 
           {/* ─── Related Articles ─── */}
           {relatedArticles.length > 0 && (

--- a/components/layout/Navigation.tsx
+++ b/components/layout/Navigation.tsx
@@ -18,7 +18,7 @@ const platformsMenu = {
   byCategory: [
     { label: "Share Trading", href: "/share-trading", desc: "ASX & international shares" },
     { label: "ETFs", href: "/compare/etfs", desc: "Diversified index investing" },
-    { label: "Super Funds", href: "/compare/super", desc: "Compare fees & performance" },
+    { label: "Super Funds", href: "/super", desc: "Compare fees & performance" },
     { label: "Savings Accounts", href: "/savings", desc: "High interest & at-call accounts" },
     { label: "Robo-Advisors", href: "/robo-advisors", desc: "Automated portfolio management" },
     { label: "Term Deposits", href: "/term-deposits", desc: "Government-guaranteed fixed rates" },
@@ -251,7 +251,7 @@ const mobileSections = [
       { name: "Share Trading", href: "/share-trading" },
       { name: "ETFs", href: "/compare/etfs" },
       { name: "Crypto Exchanges", href: "/crypto" },
-      { name: "Super Funds", href: "/compare/super" },
+      { name: "Super Funds", href: "/super" },
       { name: "Savings Accounts", href: "/savings" },
       { name: "CFD & Forex", href: "/cfd" },
       { name: "Non-Resident Brokers", href: "/compare/non-residents" },

--- a/components/layout/SiteFooter.tsx
+++ b/components/layout/SiteFooter.tsx
@@ -27,7 +27,7 @@ export function SiteFooter() {
             { label: "Share Trading", href: "/share-trading" },
             { label: "ETFs", href: "/compare/etfs" },
             { label: "Crypto", href: "/crypto" },
-            { label: "Super Funds", href: "/compare/super" },
+            { label: "Super Funds", href: "/super" },
             { label: "Savings Accounts", href: "/savings" },
             { label: "Current Deals", href: "/deals" },
             { label: "Broker vs Broker", href: "/versus" },

--- a/lib/verticals.ts
+++ b/lib/verticals.ts
@@ -628,4 +628,39 @@ export function getAllVerticalSlugs(): string[] {
   return VERTICALS.map((v) => v.slug);
 }
 
+const PILLAR_SHORT_LABELS: Record<string, string> = {
+  "share-trading": "Share Trading",
+  crypto: "Crypto",
+  savings: "Savings",
+  super: "Super",
+  cfd: "CFD & Forex",
+  "term-deposits": "Term Deposits",
+  "robo-advisors": "Robo-Advisors",
+  "property-platforms": "Property Platforms",
+  "research-tools": "Research Tools",
+};
+
+export interface RelatedVertical {
+  slug: string;
+  label: string;
+  tagline: string;
+}
+
+/**
+ * Sibling pillars for cross-sell strips. Excludes the current vertical.
+ * Tagline is the first stat ("20+ Platforms Compared" style) when available.
+ */
+export function getRelatedVerticals(currentSlug: string): RelatedVertical[] {
+  return VERTICALS.filter((v) => v.slug !== currentSlug).map((v) => {
+    const firstStat = v.stats[0];
+    return {
+      slug: v.slug,
+      label: PILLAR_SHORT_LABELS[v.slug] ?? v.slug,
+      tagline: firstStat
+        ? `${firstStat.value} ${firstStat.label.toLowerCase()}`
+        : "",
+    };
+  });
+}
+
 export { VERTICALS };


### PR DESCRIPTION
## Summary

Nav + UX audit follow-up. Tightens discoverability around the vertical pillar pages and the self-serve sponsorship flow.

- **Footer + nav now link Super Funds → /super**, matching the other four pillars (/share-trading, /crypto, /savings, /cfd). Was /compare/super, which dropped users on the comparison table instead of the content hub. Three call sites updated (footer, desktop mega-menu, mobile menu).
- **/advertise/packages added to sitemap.ts** — it was reachable from the footer but not indexed.
- **/advertise → /advertise/packages CTA** under the Sponsorship Packages section. Previously prospects landed on the /advertise static copy with no path to self-serve checkout.
- **"Compare Other Categories" strip** on every pillar page — new `getRelatedVerticals` helper in `lib/verticals.ts` emits siblings with a quick stat tagline; rendered as a 4-column grid below the FAQ. Compounds internal linking across the 9 pillars.
- Incidental: converted two pre-existing `<a href="/expert/…">` to `<Link>` so the file lints under `max-warnings 0`. Two pre-existing `<img>` warnings silenced with targeted eslint-disable comments (proper `next/image` conversion needs remote-domain config — out of scope).

## Notes

Audit also flagged "no admin surface for crons" — that was wrong. `/admin/automation/cron-health` already has full per-cron observability (last-run, success rate, stale status). No change needed there.

Audit item about stale sponsorship tier prices on `/advertise` ($1,500 / $800 / $2,000) vs the self-serve page ($2,000 / $500 / $300) is unresolved — flagging for a follow-up PR since reconciling pricing needs a product decision, not code.

## Test plan

- [ ] `/share-trading`, `/crypto`, `/savings`, `/super`, `/cfd` all render and show the "Compare Other Categories" strip with 8 sibling pillars
- [ ] Click "Super Funds" in desktop mega-menu → lands on /super (pillar), not /compare/super
- [ ] Click "Super Funds" in mobile menu → same
- [ ] Click "Super Funds" in footer → same
- [ ] /advertise → "Configure & book a package" button → lands on /advertise/packages
- [ ] sitemap.xml includes /advertise/packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)