### PR TITLE
feat: single-source sponsorship tiers + align /advertise prices

### DIFF
--- a/__tests__/lib/sponsorship-tiers.test.ts
+++ b/__tests__/lib/sponsorship-tiers.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import {
+  SELF_SERVE_TIERS,
+  SELF_SERVE_TIER_PRICES_CENTS,
+  SELF_SERVE_DURATIONS,
+  SELF_SERVE_DURATION_DISCOUNTS,
+  VALID_SELF_SERVE_DURATIONS,
+  calculateCheckoutCents,
+  getSelfServeTier,
+} from "@/lib/sponsorship-tiers";
+
+describe("SELF_SERVE_TIERS", () => {
+  it("declares the three canonical tier ids", () => {
+    expect(SELF_SERVE_TIERS.map((t) => t.id).sort()).toEqual([
+      "category_sponsor",
+      "deal_of_month",
+      "featured_partner",
+    ]);
+  });
+
+  it("exposes prices in cents that match dollar basePrice × 100", () => {
+    for (const t of SELF_SERVE_TIERS) {
+      expect(SELF_SERVE_TIER_PRICES_CENTS[t.id]).toBe(t.basePrice * 100);
+    }
+  });
+
+  it("has exactly one tier flagged as highlight/most-popular", () => {
+    expect(SELF_SERVE_TIERS.filter((t) => t.highlight)).toHaveLength(1);
+  });
+
+  it("every tier has a non-empty feature list", () => {
+    for (const t of SELF_SERVE_TIERS) {
+      expect(t.includes.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("SELF_SERVE_DURATIONS", () => {
+  it("exposes the four canonical durations (1/3/6/12 months)", () => {
+    expect(VALID_SELF_SERVE_DURATIONS).toEqual([1, 3, 6, 12]);
+  });
+
+  it("1-month duration has zero discount; longer durations do not", () => {
+    const one = SELF_SERVE_DURATIONS.find((d) => d.months === 1);
+    const twelve = SELF_SERVE_DURATIONS.find((d) => d.months === 12);
+    expect(one?.discount).toBe(0);
+    expect(twelve?.discount).toBeGreaterThan(0);
+  });
+
+  it("discount map matches the declared durations", () => {
+    for (const d of SELF_SERVE_DURATIONS) {
+      expect(SELF_SERVE_DURATION_DISCOUNTS[d.months]).toBe(d.discount);
+    }
+  });
+});
+
+describe("calculateCheckoutCents", () => {
+  it("returns monthly × months in cents for a 1-month purchase (no discount)", () => {
+    // Featured Partner is $2000/mo → 1 month = 200000 cents
+    expect(calculateCheckoutCents("featured_partner", 1)).toBe(200000);
+  });
+
+  it("applies the 10% discount at 3 months", () => {
+    // $2000 × 3 × 0.9 = $5400 → 540000 cents
+    expect(calculateCheckoutCents("featured_partner", 3)).toBe(540000);
+  });
+
+  it("applies the 30% discount at 12 months", () => {
+    // $2000 × 12 × 0.7 = $16800 → 1680000 cents
+    expect(calculateCheckoutCents("featured_partner", 12)).toBe(1680000);
+  });
+
+  it("computes category_sponsor correctly at the $500 base rate", () => {
+    // $500 × 6 × 0.8 = $2400 → 240000 cents
+    expect(calculateCheckoutCents("category_sponsor", 6)).toBe(240000);
+  });
+
+  it("computes deal_of_month correctly at the $300 base rate", () => {
+    // $300 × 1 × 1.0 = $300 → 30000 cents
+    expect(calculateCheckoutCents("deal_of_month", 1)).toBe(30000);
+  });
+
+  it("returns 0 for an unknown tier", () => {
+    // @ts-expect-error — testing runtime fallthrough
+    expect(calculateCheckoutCents("bogus_tier", 1)).toBe(0);
+  });
+
+  it("returns 0 for an unsupported duration", () => {
+    expect(calculateCheckoutCents("featured_partner", 2)).toBe(0);
+  });
+});
+
+describe("getSelfServeTier", () => {
+  it("looks up a tier by id", () => {
+    expect(getSelfServeTier("featured_partner")?.name).toBe("Featured Partner");
+  });
+
+  it("returns undefined for an unknown id", () => {
+    expect(getSelfServeTier("nope")).toBeUndefined();
+  });
+});

--- a/app/advertise/packages/PackagesClient.tsx
+++ b/app/advertise/packages/PackagesClient.tsx
@@ -1,27 +1,16 @@
 "use client";
 
 import { useState, useMemo } from "react";
+import {
+  SELF_SERVE_TIERS,
+  SELF_SERVE_DURATIONS,
+  type SelfServeTierId,
+} from "@/lib/sponsorship-tiers";
 
-type Tier = "featured_partner" | "category_sponsor" | "deal_of_month";
+type Tier = SelfServeTierId;
 
-interface TierConfig {
-  id: Tier;
-  name: string;
-  basePrice: number;
-}
-
-const TIERS: TierConfig[] = [
-  { id: "featured_partner", name: "Featured Partner", basePrice: 2000 },
-  { id: "category_sponsor", name: "Category Sponsor", basePrice: 500 },
-  { id: "deal_of_month", name: "Deal of the Month", basePrice: 300 },
-];
-
-const DURATIONS = [
-  { months: 1, label: "1 month", discount: 0 },
-  { months: 3, label: "3 months", discount: 0.1 },
-  { months: 6, label: "6 months", discount: 0.2 },
-  { months: 12, label: "12 months", discount: 0.3 },
-];
+const TIERS = SELF_SERVE_TIERS;
+const DURATIONS = SELF_SERVE_DURATIONS;
 
 const CATEGORIES = [
   { slug: "beginners", label: "Best for Beginners" },

--- a/app/advertise/page.tsx
+++ b/app/advertise/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import type { Metadata } from "next";
+import { SELF_SERVE_TIERS } from "@/lib/sponsorship-tiers";
 
 export const revalidate = 86400;
 
@@ -69,46 +70,18 @@ const PLACEMENTS = [
   },
 ];
 
-const TIERS = [
-  {
-    name: "Featured Partner",
-    price: "$1,500",
-    period: "/month",
-    features: [
-      "Top position across all pages",
-      "\"Featured Partner\" badge",
-      "Priority in quiz results",
-      "Dedicated account manager",
-      "Monthly performance reports",
-    ],
-    highlight: true,
-  },
-  {
-    name: "Editor's Pick",
-    price: "$800",
-    period: "/month",
-    features: [
-      "Promoted position in listings",
-      "\"Editor's Pick\" badge",
-      "Enhanced broker profile",
-      "Quarterly performance reports",
-    ],
-    highlight: false,
-  },
-  {
-    name: "Deal of the Month",
-    price: "$2,000",
-    period: "/month",
-    features: [
-      "Featured deal banner sitewide",
-      "\"Deal of the Month\" badge",
-      "Homepage deal carousel",
-      "Email newsletter inclusion",
-      "Social media promotion",
-    ],
-    highlight: false,
-  },
-];
+/**
+ * Tier copy mirrors the self-serve catalogue so prices on the marketing
+ * page never drift from what `/advertise/packages` actually charges.
+ * Edit prices/features in `lib/sponsorship-tiers.ts`, not here.
+ */
+const TIERS = SELF_SERVE_TIERS.map((t) => ({
+  name: t.name,
+  price: `$${t.basePrice.toLocaleString("en-AU")}`,
+  period: "/month",
+  features: t.includes,
+  highlight: !!t.highlight,
+}));
 
 export default function AdvertisePage() {
   return (

--- a/app/api/advertise/checkout/route.ts
+++ b/app/api/advertise/checkout/route.ts
@@ -9,11 +9,12 @@ import {
   SELF_SERVE_TIERS,
   VALID_SELF_SERVE_DURATIONS,
   SELF_SERVE_DURATION_DISCOUNTS,
+  type SelfServeTierId,
 } from "@/lib/sponsorship-tiers";
 
 const log = logger("advertise-checkout");
 
-const TIER_PRICES = SELF_SERVE_TIER_PRICES_CENTS;
+const TIER_PRICES: Record<SelfServeTierId, number> = SELF_SERVE_TIER_PRICES_CENTS;
 
 const TIER_LABELS: Record<string, string> = Object.fromEntries(
   SELF_SERVE_TIERS.map((t) => [
@@ -26,13 +27,17 @@ const VALID_DURATIONS = VALID_SELF_SERVE_DURATIONS;
 
 const DURATION_DISCOUNTS = SELF_SERVE_DURATION_DISCOUNTS;
 
+function isSelfServeTierId(v: unknown): v is SelfServeTierId {
+  return typeof v === "string" && v in TIER_PRICES;
+}
+
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
     const { tier, category_slug, duration_months, company_name, contact_email } = body;
 
     // Validate tier
-    if (!tier || !TIER_PRICES[tier]) {
+    if (!isSelfServeTierId(tier)) {
       return NextResponse.json(
         { error: "Invalid sponsorship tier." },
         { status: 400 }

--- a/app/api/advertise/checkout/route.ts
+++ b/app/api/advertise/checkout/route.ts
@@ -4,29 +4,27 @@ import { NextRequest, NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 import { getSiteUrl } from "@/lib/url";
 import { isValidEmail } from "@/lib/validate-email";
+import {
+  SELF_SERVE_TIER_PRICES_CENTS,
+  SELF_SERVE_TIERS,
+  VALID_SELF_SERVE_DURATIONS,
+  SELF_SERVE_DURATION_DISCOUNTS,
+} from "@/lib/sponsorship-tiers";
 
 const log = logger("advertise-checkout");
 
-const TIER_PRICES: Record<string, number> = {
-  featured_partner: 2000_00, // cents
-  category_sponsor: 500_00,
-  deal_of_month: 300_00,
-};
+const TIER_PRICES = SELF_SERVE_TIER_PRICES_CENTS;
 
-const TIER_LABELS: Record<string, string> = {
-  featured_partner: "Featured Partner Sponsorship",
-  category_sponsor: "Category Sponsor",
-  deal_of_month: "Deal of the Month",
-};
+const TIER_LABELS: Record<string, string> = Object.fromEntries(
+  SELF_SERVE_TIERS.map((t) => [
+    t.id,
+    t.id === "featured_partner" ? "Featured Partner Sponsorship" : t.name,
+  ]),
+);
 
-const VALID_DURATIONS = [1, 3, 6, 12];
+const VALID_DURATIONS = VALID_SELF_SERVE_DURATIONS;
 
-const DURATION_DISCOUNTS: Record<number, number> = {
-  1: 0,
-  3: 0.1,
-  6: 0.2,
-  12: 0.3,
-};
+const DURATION_DISCOUNTS = SELF_SERVE_DURATION_DISCOUNTS;
 
 export async function POST(request: NextRequest) {
   try {

--- a/lib/sponsorship-tiers.ts
+++ b/lib/sponsorship-tiers.ts
@@ -1,0 +1,125 @@
+/**
+ * Self-serve sponsorship tier catalogue — single source of truth.
+ *
+ * These are the tiers that `/advertise/packages` sells and that
+ * `/api/advertise/checkout` charges via Stripe. The `/advertise`
+ * marketing landing page reads from here too so prices don't drift.
+ *
+ * DO NOT confuse with `lib/sponsorship.ts` `TIER_PRICING` — that
+ * governs a separate legacy ranking system (featured_partner /
+ * editors_pick / deal_of_month) used for placement scoring. This
+ * file is about self-serve ad purchase.
+ */
+
+export type SelfServeTierId =
+  | "featured_partner"
+  | "category_sponsor"
+  | "deal_of_month";
+
+export interface SelfServeTier {
+  id: SelfServeTierId;
+  name: string;
+  /** Monthly price in AUD dollars (not cents). */
+  basePrice: number;
+  description: string;
+  /** Rough impressions estimate shown on marketing copy. */
+  impressions: string;
+  /** Whether this tier gets the "Most Popular" highlight. */
+  highlight?: boolean;
+  /** Bullet-point feature list. */
+  includes: string[];
+}
+
+export const SELF_SERVE_TIERS: SelfServeTier[] = [
+  {
+    id: "featured_partner",
+    name: "Featured Partner",
+    basePrice: 2000,
+    description:
+      "Maximum visibility across the entire site. Your brand appears first on compare pages, quiz results, and category listings with a Featured Partner badge.",
+    impressions: "~80,000/mo",
+    highlight: true,
+    includes: [
+      "Top position across all placements",
+      "Featured Partner badge sitewide",
+      "Priority in quiz results",
+      "Dedicated account manager",
+      "Monthly performance reports",
+    ],
+  },
+  {
+    id: "category_sponsor",
+    name: "Category Sponsor",
+    basePrice: 500,
+    description:
+      "Own a single category vertical (e.g. Best for Beginners, CHESS-Sponsored). Your brand appears as the sponsored pick on one category page with a Sponsor badge.",
+    impressions: "~8,000/mo per category",
+    includes: [
+      "Top position on one category page",
+      "Category Sponsor badge",
+      "Category-level analytics",
+      "Choose your category during checkout",
+    ],
+  },
+  {
+    id: "deal_of_month",
+    name: "Deal of the Month",
+    basePrice: 300,
+    description:
+      "Promote a time-bound offer in the Current Deals carousel and email newsletter. Best for sign-up bonuses or limited-time rate boosts.",
+    impressions: "~20,000/mo",
+    includes: [
+      "Deals carousel placement",
+      "Deal of the Month badge",
+      "Newsletter inclusion",
+      "Social media mention",
+    ],
+  },
+];
+
+/** Monthly prices in cents — the shape Stripe and the checkout route want. */
+export const SELF_SERVE_TIER_PRICES_CENTS: Record<SelfServeTierId, number> =
+  Object.fromEntries(
+    SELF_SERVE_TIERS.map((t) => [t.id, t.basePrice * 100]),
+  ) as Record<SelfServeTierId, number>;
+
+export interface SelfServeDuration {
+  months: number;
+  label: string;
+  /** Fractional discount, e.g. 0.1 = 10% off. */
+  discount: number;
+}
+
+export const SELF_SERVE_DURATIONS: SelfServeDuration[] = [
+  { months: 1, label: "1 month", discount: 0 },
+  { months: 3, label: "3 months", discount: 0.1 },
+  { months: 6, label: "6 months", discount: 0.2 },
+  { months: 12, label: "12 months", discount: 0.3 },
+];
+
+export const VALID_SELF_SERVE_DURATIONS = SELF_SERVE_DURATIONS.map(
+  (d) => d.months,
+);
+
+export const SELF_SERVE_DURATION_DISCOUNTS: Record<number, number> =
+  Object.fromEntries(
+    SELF_SERVE_DURATIONS.map((d) => [d.months, d.discount]),
+  );
+
+/**
+ * Total checkout amount in cents for a tier + duration. Returns 0 for
+ * an unknown tier/duration so callers can fall through to validation.
+ */
+export function calculateCheckoutCents(
+  tierId: SelfServeTierId,
+  months: number,
+): number {
+  const monthlyCents = SELF_SERVE_TIER_PRICES_CENTS[tierId];
+  const discount = SELF_SERVE_DURATION_DISCOUNTS[months];
+  if (monthlyCents == null || discount == null) return 0;
+  return Math.round(monthlyCents * months * (1 - discount));
+}
+
+export function getSelfServeTier(id: string): SelfServeTier | undefined {
+  return SELF_SERVE_TIERS.find((t) => t.id === id);
+}


### PR DESCRIPTION
## Summary

Fixes the pricing trust issue surfaced by the Wave A nav audit: `/advertise` marketed three tiers at \$1,500 / \$800 / \$2,000 (Featured Partner / Editor's Pick / Deal of the Month) while `/advertise/packages` actually charged **different tiers** at **different prices** (\$2,000 / \$500 / \$300 for Featured Partner / Category Sponsor / Deal of the Month). Linking the two pages in Wave A made the discrepancy visible.

- New `lib/sponsorship-tiers.ts` = canonical self-serve tier catalogue (tier ids, dollar `basePrice`, feature bullets, impressions copy, duration discounts, `calculateCheckoutCents` helper).
- `/advertise` marketing now renders tier cards from `SELF_SERVE_TIERS` — matches what the checkout charges.
- `PackagesClient` + `/api/advertise/checkout` both read from the shared catalogue.
- `lib/sponsorship.ts` `TIER_PRICING` **intentionally untouched** — it governs a separate legacy placement-ranking system with different tier ids (documented in the new file header).
- 16 unit tests cover tier shape, cents↔dollars consistency, discount ladder (10% / 20% / 30%), and invalid-input fallthrough.

## Pricing decision (flag for review)

I made the `/advertise/packages` prices canonical because that's the page that actually takes Stripe payments — marketing copy must match the checkout, not the other way round. If the \$1,500 / \$800 / \$2,000 prices on the old `/advertise` page were the real intended prices, swap the `basePrice` values in `lib/sponsorship-tiers.ts` (and the corresponding checkout prices) in a follow-up. But that means changing what Stripe currently charges, so it's a product call.

## Test plan

- [ ] `/advertise` renders the three tiers at \$2,000 / \$500 / \$300 with the right feature bullets
- [ ] `/advertise/packages` still works end-to-end (tier pick → duration pick → Stripe checkout)
- [ ] Existing Stripe sessions keep working (no tier id changes, just constant extraction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)