### PR TITLE
feat(ops): Phase 2 n8n workflow #10 analytics_daily

### DIFF
--- a/docs/ops/n8n-phase2-analytics.md
+++ b/docs/ops/n8n-phase2-analytics.md
@@ -1,0 +1,128 @@
+# n8n Phase 2 — `analytics_daily` (workflow #10)
+
+## Purpose
+
+Roll up the previous day's rows from `agent_logs` into per-agent daily
+aggregates in `agent_analytics`. One row per `(agent_name, date)`, upserted
+idempotently so the job is safe to re-run.
+
+Each row captures:
+
+- `total_logs` / `error_count` / `warn_count` / `info_count`
+- `success_rate` — `(total_logs - error_count) / total_logs * 100`
+- `avg_runtime_ms` — mean of `metadata.runtime_ms` across logs with that field
+- `estimated_cost_usd` — `input_tokens * $3/M + output_tokens * $15/M`
+  (claude-opus-4-7 pricing)
+- `metadata.raw_log_ids` — the log IDs that fed the row, for traceability
+
+If `agent_logs` has no rows for the target day, the workflow still writes one
+sentinel row: `agent_name='system'`, `success_rate=100`,
+`metadata.note='no_logs_for_day'`. This keeps the heartbeat signal alive so a
+silent day is distinguishable from a failed workflow run.
+
+## Schedule + timezone
+
+- Cron: `0 0 6 * * *` (six-field: second minute hour dom month dow)
+- Timezone: `Australia/Sydney`
+- Fires daily at 06:00 Sydney — aggregates the previous Sydney day
+  (00:00 → 24:00 Sydney local time)
+
+The date-range node computes `startOfDay` / `endOfDay` as ISO strings with the
+correct Sydney UTC offset for that date (AEST +10 or AEDT +11), so DST
+transitions don't cause off-by-one-day bugs at the boundary.
+
+## Import instructions
+
+This workflow is held in source control and imported manually — we do not sync
+n8n workflows from git. To install:
+
+1. In the n8n UI (https://n8n-production-efab.up.railway.app), go to
+   **Workflows → Import from File**.
+2. Upload `infra/n8n/analytics_daily.json`.
+3. Open the workflow and replace the `[HARDCODE_SUPABASE_SERVICE_ROLE_KEY_HERE]`
+   placeholder in **four** locations:
+   - **Read agent_logs** node → `apikey` header
+   - **Read agent_logs** node → `Authorization` header (paste as
+     `Bearer <key>`)
+   - **Upsert to agent_analytics** node → `apikey` header
+   - **Upsert to agent_analytics** node → `Authorization` header (paste as
+     `Bearer <key>`)
+
+   The key is the Supabase **service role** key for project
+   `guggzyqceattncjwvgyc` (eu-west-1). It's in 1Password under
+   `Supabase / invest-com-au / service_role`.
+4. In the workflow **Settings** sidebar, confirm:
+   - **Timezone**: `Australia/Sydney`
+   - **Error workflow**: `agent_error_logger`
+5. Leave **Active** OFF until the smoke tests pass.
+
+## Smoke test plan
+
+### Test 1 — manual execution with real data
+
+1. Temporarily replace the **Schedule Trigger** node with a **Manual Trigger**
+   (same swap we did for `overseer_hourly`). Don't delete the schedule config
+   — just add a manual trigger and rewire the edge to `Compute Date Range`.
+2. Click **Execute workflow**.
+3. Expected flow:
+   - `Compute Date Range` emits one item with `startOfDay`, `endOfDay`,
+     `dateString` all pointing at yesterday (Sydney).
+   - `Read agent_logs` returns the logs from yesterday (should be ~1–5 rows
+     from `overseer_hourly`).
+   - `Compute Analytics` emits one row per distinct `agent_name`.
+   - `Upsert to agent_analytics` returns HTTP 201 with the inserted rows.
+4. Verify in Supabase:
+   ```sql
+   select agent_name, date, total_logs, error_count, success_rate,
+          estimated_cost_usd
+   from agent_analytics
+   where date = current_date - interval '1 day'
+   order by agent_name;
+   ```
+   Expect at least one row with `agent_name='overseer'` if overseer ran
+   yesterday.
+
+### Test 2 — empty-data path
+
+1. Pick a date with no `agent_logs` (e.g. before overseer was deployed).
+   Temporarily hardcode the `dateString` in `Compute Date Range` to that date
+   (and matching `startOfDay` / `endOfDay`).
+2. Execute the workflow.
+3. Expected: one row written with `agent_name='system'`, `success_rate=100`,
+   `metadata.note='no_logs_for_day'`.
+4. **Revert** the hardcoded date before continuing.
+
+### Test 3 — scheduled run
+
+1. Swap the Manual Trigger back out for the Schedule Trigger. Confirm the
+   cron expression is `0 0 6 * * *` (six fields).
+2. Click **Active** to enable.
+3. Wait until the next 06:00 Sydney.
+4. Check n8n **Executions** tab — should show one successful run at ~06:00.
+5. Check `agent_analytics` has a fresh row for the just-ended Sydney day.
+
+## Gotchas
+
+1. **Six-field cron, not five.** n8n v2.17+ uses
+   `second minute hour day-of-month month day-of-week`. The workflow JSON
+   declares `0 0 6 * * *`. A five-field expression will either be rejected or
+   silently interpreted with wrong field positions.
+2. **Hardcoded API keys.** This n8n instance does not expand
+   `{{ $env.VAR_NAME }}` inside HTTP Request node headers. Keys must be pasted
+   literally into the node config (same workaround as `overseer_hourly`). The
+   shipped JSON holds the placeholder `[HARDCODE_SUPABASE_SERVICE_ROLE_KEY_HERE]`
+   — never commit a real key to git; replace it only after import.
+3. **Upsert via `Prefer` header.** The `Upsert to agent_analytics` node relies
+   on `Prefer: resolution=merge-duplicates,return=representation` plus the
+   `UNIQUE(agent_name, date)` constraint to make re-runs idempotent. If the
+   unique index is dropped, the workflow will start inserting duplicates.
+4. **Cost pricing is model-specific.** The `Compute Analytics` node bakes in
+   claude-opus-4-7 pricing (`$3/M input`, `$15/M output`). If agents migrate
+   to a different model, update the constants `INPUT_PRICE` and `OUTPUT_PRICE`
+   in that node's JS before historical comparisons become meaningful.
+5. **Service-role bypasses RLS.** `agent_analytics` has RLS enabled; the
+   n8n writes succeed only because we use the service-role key. No end-user
+   session token will satisfy these policies — don't swap in the anon key.
+6. **Log volume cap.** `Read agent_logs` is capped at `limit=1000`. If a day
+   ever generates more than 1000 logs, the aggregates will be under-counted
+   silently. Add pagination before we ship more than a handful of agents.

--- a/infra/n8n/analytics_daily.json
+++ b/infra/n8n/analytics_daily.json
@@ -1,0 +1,231 @@
+{
+  "name": "analytics_daily",
+  "nodes": [
+    {
+      "parameters": {
+        "rule": {
+          "interval": [
+            {
+              "field": "cronExpression",
+              "expression": "0 0 6 * * *"
+            }
+          ]
+        }
+      },
+      "id": "b1a0d6e0-0001-4f00-a000-000000000001",
+      "name": "Schedule Trigger",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.2,
+      "position": [
+        240,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "mode": "runOnceForAllItems",
+        "language": "javaScript",
+        "jsCode": "const tz = 'Australia/Sydney';\nconst now = new Date();\n\nfunction getZonedYMD(date) {\n  const fmt = new Intl.DateTimeFormat('en-CA', {\n    timeZone: tz,\n    year: 'numeric', month: '2-digit', day: '2-digit'\n  });\n  const parts = fmt.formatToParts(date);\n  const obj = {};\n  for (const p of parts) { if (p.type !== 'literal') obj[p.type] = p.value; }\n  return `${obj.year}-${obj.month}-${obj.day}`;\n}\n\nfunction isoForSydneyMidnight(dateStr) {\n  // Figure out Sydney's UTC offset for that date (AEST +10 or AEDT +11)\n  const probe = new Date(`${dateStr}T12:00:00Z`);\n  const dtf = new Intl.DateTimeFormat('en-US', {\n    timeZone: tz,\n    timeZoneName: 'shortOffset'\n  });\n  const parts = dtf.formatToParts(probe);\n  const tzName = (parts.find(p => p.type === 'timeZoneName') || {}).value || 'GMT+10';\n  const m = tzName.match(/GMT([+-])(\\d{1,2})(?::?(\\d{2}))?/);\n  const sign = m ? m[1] : '+';\n  const hh = m ? String(parseInt(m[2], 10)).padStart(2, '0') : '10';\n  const mm = m && m[3] ? m[3] : '00';\n  return `${dateStr}T00:00:00${sign}${hh}:${mm}`;\n}\n\nconst todayStr = getZonedYMD(now);\nconst y = new Date(`${todayStr}T00:00:00Z`);\ny.setUTCDate(y.getUTCDate() - 1);\nconst yStr = `${y.getUTCFullYear()}-${String(y.getUTCMonth() + 1).padStart(2, '0')}-${String(y.getUTCDate()).padStart(2, '0')}`;\n\nconst startOfDay = isoForSydneyMidnight(yStr);\nconst endOfDay = isoForSydneyMidnight(todayStr);\n\nreturn [{ json: { startOfDay, endOfDay, dateString: yStr } }];\n"
+      },
+      "id": "b1a0d6e0-0002-4f00-a000-000000000002",
+      "name": "Compute Date Range",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        460,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "https://guggzyqceattncjwvgyc.supabase.co/rest/v1/agent_logs",
+        "sendQuery": true,
+        "queryParameters": {
+          "parameters": [
+            {
+              "name": "created_at",
+              "value": "=gte.{{ $json.startOfDay }}"
+            },
+            {
+              "name": "created_at",
+              "value": "=lt.{{ $json.endOfDay }}"
+            },
+            {
+              "name": "select",
+              "value": "id,agent_name,level,message,metadata,created_at"
+            },
+            {
+              "name": "limit",
+              "value": "1000"
+            },
+            {
+              "name": "order",
+              "value": "created_at.desc"
+            }
+          ]
+        },
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "apikey",
+              "value": "[HARDCODE_SUPABASE_SERVICE_ROLE_KEY_HERE]"
+            },
+            {
+              "name": "Authorization",
+              "value": "Bearer [HARDCODE_SUPABASE_SERVICE_ROLE_KEY_HERE]"
+            },
+            {
+              "name": "Accept",
+              "value": "application/json"
+            }
+          ]
+        },
+        "options": {
+          "response": {
+            "response": {
+              "responseFormat": "json"
+            }
+          },
+          "timeout": 30000
+        }
+      },
+      "id": "b1a0d6e0-0003-4f00-a000-000000000003",
+      "name": "Read agent_logs",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        680,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "mode": "runOnceForAllItems",
+        "language": "javaScript",
+        "jsCode": "const rawItems = $('Read agent_logs').all();\nconst logs = [];\nfor (const it of rawItems) {\n  const payload = it && it.json;\n  if (!payload) continue;\n  if (Array.isArray(payload)) {\n    for (const row of payload) if (row && typeof row === 'object') logs.push(row);\n  } else if (Array.isArray(payload.data)) {\n    for (const row of payload.data) if (row && typeof row === 'object') logs.push(row);\n  } else if (typeof payload === 'object') {\n    logs.push(payload);\n  }\n}\n\nconst dateString = $('Compute Date Range').first().json.dateString;\nconst nowIso = new Date().toISOString();\n\nif (logs.length === 0) {\n  return [{\n    json: {\n      agent_name: 'system',\n      date: dateString,\n      total_logs: 0,\n      error_count: 0,\n      warn_count: 0,\n      info_count: 0,\n      success_rate: 100,\n      avg_runtime_ms: null,\n      estimated_cost_usd: 0,\n      metadata: { note: 'no_logs_for_day', computed_at: nowIso }\n    }\n  }];\n}\n\n// claude-opus-4-7 pricing: $3/M input, $15/M output\nconst INPUT_PRICE = 0.000003;\nconst OUTPUT_PRICE = 0.000015;\n\nconst byAgent = new Map();\nfor (const log of logs) {\n  const name = (log && log.agent_name) ? String(log.agent_name) : 'unknown';\n  if (!byAgent.has(name)) byAgent.set(name, []);\n  byAgent.get(name).push(log);\n}\n\nconst rows = [];\nfor (const [agent_name, agentLogs] of byAgent) {\n  const total_logs = agentLogs.length;\n  let error_count = 0, warn_count = 0, info_count = 0;\n  let runtimeSum = 0, runtimeCount = 0;\n  let costSum = 0;\n  const raw_log_ids = [];\n\n  for (const log of agentLogs) {\n    const level = (log && typeof log.level === 'string') ? log.level.toLowerCase() : '';\n    if (level === 'error' || level === 'fatal') error_count++;\n    else if (level === 'warn') warn_count++;\n    else if (level === 'info') info_count++;\n\n    if (log && log.id !== undefined && log.id !== null) raw_log_ids.push(log.id);\n\n    const md = (log && log.metadata && typeof log.metadata === 'object') ? log.metadata : null;\n    if (md) {\n      if (typeof md.runtime_ms === 'number' && !Number.isNaN(md.runtime_ms)) {\n        runtimeSum += md.runtime_ms;\n        runtimeCount++;\n      }\n      const inTok = (typeof md.input_tokens === 'number' && !Number.isNaN(md.input_tokens)) ? md.input_tokens : 0;\n      const outTok = (typeof md.output_tokens === 'number' && !Number.isNaN(md.output_tokens)) ? md.output_tokens : 0;\n      costSum += inTok * INPUT_PRICE + outTok * OUTPUT_PRICE;\n    }\n  }\n\n  const success_rate = total_logs === 0 ? 100 : ((total_logs - error_count) / total_logs) * 100;\n  const avg_runtime_ms = runtimeCount > 0 ? runtimeSum / runtimeCount : null;\n\n  rows.push({\n    json: {\n      agent_name,\n      date: dateString,\n      total_logs,\n      error_count,\n      warn_count,\n      info_count,\n      success_rate,\n      avg_runtime_ms,\n      estimated_cost_usd: costSum,\n      metadata: { raw_log_ids, computed_at: nowIso }\n    }\n  });\n}\n\nreturn rows;\n"
+      },
+      "id": "b1a0d6e0-0004-4f00-a000-000000000004",
+      "name": "Compute Analytics",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        900,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://guggzyqceattncjwvgyc.supabase.co/rest/v1/agent_analytics",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify($input.all().map(i => i.json)) }}",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "apikey",
+              "value": "[HARDCODE_SUPABASE_SERVICE_ROLE_KEY_HERE]"
+            },
+            {
+              "name": "Authorization",
+              "value": "Bearer [HARDCODE_SUPABASE_SERVICE_ROLE_KEY_HERE]"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            },
+            {
+              "name": "Prefer",
+              "value": "resolution=merge-duplicates,return=representation"
+            }
+          ]
+        },
+        "options": {
+          "response": {
+            "response": {
+              "responseFormat": "json"
+            }
+          },
+          "timeout": 15000
+        }
+      },
+      "id": "b1a0d6e0-0005-4f00-a000-000000000005",
+      "name": "Upsert to agent_analytics",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1120,
+        300
+      ]
+    }
+  ],
+  "connections": {
+    "Schedule Trigger": {
+      "main": [
+        [
+          {
+            "node": "Compute Date Range",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Compute Date Range": {
+      "main": [
+        [
+          {
+            "node": "Read agent_logs",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Read agent_logs": {
+      "main": [
+        [
+          {
+            "node": "Compute Analytics",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Compute Analytics": {
+      "main": [
+        [
+          {
+            "node": "Upsert to agent_analytics",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "active": false,
+  "settings": {
+    "timezone": "Australia/Sydney",
+    "errorWorkflow": "agent_error_logger",
+    "executionOrder": "v1",
+    "saveExecutionProgress": true,
+    "saveDataSuccessExecution": "all",
+    "saveDataErrorExecution": "all"
+  },
+  "tags": [
+    {
+      "name": "analytics"
+    },
+    {
+      "name": "phase:2"
+    },
+    {
+      "name": "agent:10-analytics"
+    }
+  ]
+}

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -1551,6 +1551,54 @@ export type Database = {
           },
         ]
       }
+      agent_analytics: {
+        Row: {
+          agent_name: string
+          avg_runtime_ms: number | null
+          created_at: string | null
+          date: string
+          error_count: number
+          estimated_cost_usd: number | null
+          id: number
+          info_count: number
+          metadata: Json | null
+          success_rate: number
+          total_logs: number
+          updated_at: string | null
+          warn_count: number
+        }
+        Insert: {
+          agent_name: string
+          avg_runtime_ms?: number | null
+          created_at?: string | null
+          date: string
+          error_count?: number
+          estimated_cost_usd?: number | null
+          id?: number
+          info_count?: number
+          metadata?: Json | null
+          success_rate?: number
+          total_logs?: number
+          updated_at?: string | null
+          warn_count?: number
+        }
+        Update: {
+          agent_name?: string
+          avg_runtime_ms?: number | null
+          created_at?: string | null
+          date?: string
+          error_count?: number
+          estimated_cost_usd?: number | null
+          id?: number
+          info_count?: number
+          metadata?: Json | null
+          success_rate?: number
+          total_logs?: number
+          updated_at?: string | null
+          warn_count?: number
+        }
+        Relationships: []
+      }
       agent_logs: {
         Row: {
           agent_name: string
@@ -1629,6 +1677,7 @@ export type Database = {
           created_at: string
           error_message: string | null
           id: string
+          metadata: Json
           parent_task_id: string | null
           payload: Json
           priority: number
@@ -1645,6 +1694,7 @@ export type Database = {
           created_at?: string
           error_message?: string | null
           id?: string
+          metadata?: Json
           parent_task_id?: string | null
           payload?: Json
           priority?: number
@@ -1661,6 +1711,7 @@ export type Database = {
           created_at?: string
           error_message?: string | null
           id?: string
+          metadata?: Json
           parent_task_id?: string | null
           payload?: Json
           priority?: number
@@ -12761,3 +12812,4 @@ export const Constants = {
     Enums: {},
   },
 } as const
+

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -12812,4 +12812,3 @@ export const Constants = {
     Enums: {},
   },
 } as const
-

--- a/supabase/migrations/20260423124310_create_agent_analytics_table.sql
+++ b/supabase/migrations/20260423124310_create_agent_analytics_table.sql
@@ -1,0 +1,36 @@
+-- Create agent_analytics table for daily per-agent success rate tracking
+CREATE TABLE IF NOT EXISTS public.agent_analytics (
+  id BIGSERIAL PRIMARY KEY,
+  agent_name TEXT NOT NULL,
+  date DATE NOT NULL,
+  total_logs INTEGER NOT NULL DEFAULT 0,
+  error_count INTEGER NOT NULL DEFAULT 0,
+  warn_count INTEGER NOT NULL DEFAULT 0,
+  info_count INTEGER NOT NULL DEFAULT 0,
+  success_rate FLOAT NOT NULL DEFAULT 100.0,
+  avg_runtime_ms FLOAT,
+  estimated_cost_usd FLOAT,
+  metadata JSONB,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  UNIQUE(agent_name, date)
+);
+
+-- Create indexes for common queries
+CREATE INDEX IF NOT EXISTS idx_agent_analytics_agent_name ON public.agent_analytics(agent_name);
+CREATE INDEX IF NOT EXISTS idx_agent_analytics_date ON public.agent_analytics(date DESC);
+CREATE INDEX IF NOT EXISTS idx_agent_analytics_agent_date ON public.agent_analytics(agent_name, date DESC);
+
+-- Enable RLS
+ALTER TABLE public.agent_analytics ENABLE ROW LEVEL SECURITY;
+
+-- Create RLS policy: service role can do everything (n8n writes)
+DROP POLICY IF EXISTS "Service role can manage analytics" ON public.agent_analytics;
+CREATE POLICY "Service role can manage analytics" ON public.agent_analytics
+  FOR ALL
+  USING (true)
+  WITH CHECK (true);
+
+-- Grant permissions
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.agent_analytics TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.agent_analytics TO service_role;


### PR DESCRIPTION
## Summary

- Adds `infra/n8n/analytics_daily.json` — n8n workflow #10 (scheduled `0 0 6 * * *` Australia/Sydney) that rolls the previous day's `agent_logs` rows into per-agent aggregates in `agent_analytics`.
- Writes a sentinel `agent_name='system'` row on zero-log days so a quiet day is still distinguishable from a failed run.
- Idempotent via `Prefer: resolution=merge-duplicates` on the `UNIQUE(agent_name, date)` constraint. Date-range node respects Sydney UTC offset (AEST/AEDT) across DST.
- Adds `docs/ops/n8n-phase2-analytics.md` — import instructions, 4 service-role-key paste points, 3-part smoke plan, and gotchas (6-field cron, hardcoded keys, 1000-log cap, model-specific cost constants).

## Test plan

- [ ] Manual import to n8n, paste service-role key into the 4 header fields
- [ ] Smoke test 1: swap Schedule for Manual Trigger, execute, verify rows land in `agent_analytics` for yesterday
- [ ] Smoke test 2: force an empty-data day, verify the `agent_name='system'` sentinel row
- [ ] Smoke test 3: re-attach Schedule Trigger, activate, verify the next 06:00 Sydney run produces a fresh row
- [ ] Spot-check `estimated_cost_usd` against known token counts from `overseer_hourly` runs

Workflow ships `active: false` — no auto-deploy. User imports and activates manually after smoke tests pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QAX8NmTGM7XJ6vpL1YPaoY)_