### PR TITLE
chore(audit): scaffold continuous-loop remediation infrastructure

### DIFF
--- a/.claude/commands/audit-remediation-iteration.md
+++ b/.claude/commands/audit-remediation-iteration.md
@@ -1,0 +1,202 @@
+---
+description: Run one iteration of the audit-remediation loop (queue-driven; one mergeable chunk per run).
+---
+
+# /audit-remediation-iteration
+
+Execute exactly one iteration of the audit-remediation loop. The loop is
+queue-driven: this command reads `docs/audits/REMEDIATION_QUEUE.md`, picks the
+top non-blocked item per `docs/audits/REMEDIATION_DEFAULTS.md` priority order,
+does it, commits, pushes, updates the queue, and exits.
+
+**This command is idempotent at the iteration level.** A fresh-context session
+should be able to run it and produce coherent forward progress without prior
+conversation state.
+
+---
+
+## Inputs
+
+- `docs/audits/REMEDIATION_QUEUE.md` — work queue, status of each stream's PR.
+- `docs/audits/REMEDIATION_DEFAULTS.md` — branching, priority order, verification gates, stop conditions.
+- `docs/audits/codebase-health-2026-04-24.md` — original audit (PR #213).
+- Open issues #214 #215 #216 #217 #218 — P0 trackers.
+- `CLAUDE.md` — project conventions (Conventional Commits, RLS, admin.ts scope, `lib/logger`, etc.).
+- `CONTRIBUTING.md` — PR conventions.
+
+## Output of one iteration
+
+Exactly one of:
+
+1. **Forward progress:** one commit (or a small ordered series) on a stream branch, pushed, with the queue updated. Iteration prints `STATUS: PROGRESS · stream=<X> · item=<X-NN> · pr=#<NNN>`.
+2. **CI rescue:** if any in-flight stream's last CI was red, this iteration is dedicated to fixing that stream's PR. Prints `STATUS: CI-RESCUE · stream=<X> · pr=#<NNN>`.
+3. **Surfaced blocker:** an item turned out to need human input; queue's Blocked section gets a new entry; iteration commits no code. Prints `STATUS: BLOCKED · stream=<X> · item=<X-NN>`.
+4. **Nothing to do:** queue's In flight + Pending sections are empty (or fully blocked). Prints `STATUS: COMPLETE` if everything is Done, else `STATUS: ALL-BLOCKED`.
+
+---
+
+## Per-iteration contract
+
+Execute these phases in order. **Stop at the end of phase 7 — do not pick up a second item.**
+
+### Phase 0 — Lock
+
+```bash
+LOCK=.git/audit-remediation.lock
+if [ -f "$LOCK" ]; then
+  AGE_SECONDS=$(( $(date +%s) - $(stat -c %Y "$LOCK") ))
+  if [ "$AGE_SECONDS" -lt 5400 ]; then
+    echo "STATUS: LOCKED · another iteration is active (lock age ${AGE_SECONDS}s)"
+    exit 0
+  fi
+fi
+date -u +%FT%TZ > "$LOCK"
+trap 'rm -f "$LOCK"' EXIT
+```
+
+### Phase 1 — Sync
+
+```bash
+git fetch origin main
+git checkout main && git pull --ff-only origin main
+```
+
+Read `docs/audits/REMEDIATION_QUEUE.md` and `docs/audits/REMEDIATION_DEFAULTS.md` end-to-end. Do not skim — they encode all decisions.
+
+### Phase 2 — CI rescue check
+
+For each stream in the queue's "In flight" table that has a PR number:
+
+- `mcp__github__pull_request_read` with `method: get_status` (or equivalent) to fetch CI checks.
+- If any check is `failure` or `cancelled`: this iteration is a CI rescue for that stream.
+  - Switch to the stream branch (`git checkout <branch>`), pull latest.
+  - Diagnose the failure. Fix it. Run `npm run type-check`, `npm test -- <changed>`, `npm run lint -- <changed>` until green locally.
+  - Commit (Conventional Commit, scope = stream letter), push, update queue's "Last CI" cell to "fixing — see commit <sha>".
+  - Print `STATUS: CI-RESCUE · stream=<X> · pr=#<NNN>` and exit.
+
+If multiple streams have red CI, rescue the highest-priority one (per `REMEDIATION_DEFAULTS.md`).
+
+### Phase 3 — Pick the next item
+
+Walk `REMEDIATION_DEFAULTS.md`'s priority order. For each stream in order:
+
+- If the stream's queue section has a `pending` item, that's the candidate.
+- If the candidate is the very first item of that stream and the stream has no branch yet:
+  - Create branch from `main`: `git checkout -b claude/audit-remediation/<letter>-<slug>`.
+  - Make an initial empty commit (`git commit --allow-empty -m "chore(<stream-letter>): scaffold remediation stream"`).
+  - Push: `git push -u origin <branch>`.
+  - Open a draft PR via `mcp__github__create_pull_request` with title `chore(<stream-letter>): <stream title> [audit remediation]` and body referencing the audit + tracking issue.
+  - Update queue's In-flight table with branch + PR number.
+- Otherwise checkout the existing stream branch and pull.
+
+If no pending item exists in any stream, jump to Phase 7 with `STATUS: COMPLETE` (if all items are Done) or `STATUS: ALL-BLOCKED` (if some are Blocked).
+
+### Phase 4 — Verify before acting
+
+Apply the verification gate from `REMEDIATION_DEFAULTS.md` for the item's category:
+
+- **Deletion:** grep for symbol AND `export.*from.*<filename>` re-exports. If any match, mark item as `false-positive` in the queue's "Resolved as false positives" table, log to iteration log, exit phase 7 with `STATUS: PROGRESS` (queue housekeeping is real progress).
+- **Refactor (admin.ts → server.ts):** confirm route reads cookies / is in an authenticated layout. If not, surface to Blocked.
+- **New migration:** plan must include `IF NOT EXISTS`, rollback header, and `ENABLE ROW LEVEL SECURITY` if creating a table.
+- **New test:** plan must exercise the route handler's actual logic, not just import-and-truthy-assert.
+
+If verification rules out the item, surface a Blocked entry with the question for the user; print `STATUS: BLOCKED` and exit.
+
+### Phase 5 — Do the work
+
+Execute the item. Hard limits:
+
+- Diff cap: ≤ ~500 LOC excluding generated/data files. Larger work splits — break the queue item into sub-items in this iteration's update, do the first sub-item.
+- One stream branch per iteration. Never touch another stream's files.
+
+Local gates before commit (run all three):
+
+```bash
+npm run type-check
+npm test -- <changed test files only>
+npm run lint -- <changed files only>
+```
+
+If anything red:
+1. Try to fix. ≤ 2 fix attempts.
+2. If still red after 2 attempts, revert the iteration's working changes (`git checkout -- <files>`), surface to Blocked with the failure log, exit `STATUS: BLOCKED`.
+
+Every 10th iteration (count = `git log --oneline --grep="audit remediation iteration" | wc -l`), additionally run `npm run build`. If red, treat as above.
+
+### Phase 6 — Commit + push + PR update
+
+- Conventional Commits subject. Scope = stream letter. Body explains the why, references the queue item ID, references the audit section.
+- Trailer line: `Refs: #<tracking-issue>` (e.g., `Refs: #215` for stream B).
+- Do NOT include any AI-attribution trailer or "Co-authored-by" lines unless the project's existing `git log` already does so. Check first.
+- `git push origin <branch>` — retry up to 4× with exponential backoff on network errors only (per repo's git ops policy).
+- Update PR body via `mcp__github__update_pull_request` with the new progress checklist (mark item as done in PR body too).
+
+### Phase 7 — Update queue + exit
+
+In `docs/audits/REMEDIATION_QUEUE.md`:
+
+- Move completed item's row to the Done section, prepend a new line: `<ISO date> · <item-ID> · <one-line summary> · commit <sha> · pr #<NNN>`.
+- If the iteration broke a queue item into sub-items, replace the original row with the sub-items (status: pending, except the one just done which goes to Done).
+- Update the In flight table for the touched stream (PR number, last CI = "pending — pushed at <time>").
+- Append a single line to the Iteration log section.
+
+Print:
+
+```
+STATUS: PROGRESS
+Stream: <letter>
+Item: <item-ID>
+Branch: <branch>
+PR: #<NNN>
+Commit: <sha>
+Diff: +<additions> -<deletions> across <N> files
+Next item: <next-item-ID> (stream <letter>)
+Remaining: <count> pending · <count> blocked · <count> done
+```
+
+Exit. The lock file is removed via the trap.
+
+---
+
+## Hard rules
+
+- **Never** modify `docs/audits/codebase-health-2026-04-24.md` (audit is the immutable source).
+- **Never** force-push, reset --hard, or skip hooks.
+- **Never** apply migrations to prod or run anything that touches the live DB.
+- **Never** merge a PR. The user merges.
+- **Never** start work without first running phase 2 (CI rescue check). A red CI on an earlier stream blocks new work on that stream.
+- **Never** commit a red iteration. Revert and surface.
+- **Never** trust the audit's claims without the verification gate. The audit had at least one false positive (F-01).
+- **Always** keep iterations self-contained — one stream, one item (or one rescue, or one Blocked surface).
+
+## Useful one-liners (for diagnostic phases)
+
+```bash
+# Find tables in types.ts not in any migration:
+node -e "const t=require('./lib/database.types').Database.public.Tables; console.log(Object.keys(t).join('\n'))" | sort > /tmp/types-tables.txt
+grep -hE '^CREATE TABLE [a-zA-Z_.]+\b' supabase/migrations/*.sql | sed -E 's/.*CREATE TABLE (IF NOT EXISTS )?([a-zA-Z_.]+).*/\2/' | sort -u > /tmp/migration-tables.txt
+comm -23 /tmp/types-tables.txt /tmp/migration-tables.txt
+
+# Find migrations missing RLS enable:
+grep -L "ENABLE ROW LEVEL SECURITY" supabase/migrations/*.sql
+
+# Find admin.ts importers:
+grep -rn "from ['\"]@/lib/supabase/admin['\"]" --include="*.ts" --include="*.tsx" .
+
+# Find untested routes:
+comm -23 \
+  <(find app/api -name route.ts -o -name route.tsx | sort) \
+  <(find __tests__ -name "*.test.ts" | xargs grep -lE "app/api" 2>/dev/null | sort)
+
+# Find routes without Zod:
+grep -L "from ['\"]zod['\"]" $(find app/api -name route.ts)
+```
+
+---
+
+## When to STOP the loop entirely (`/loop` exits)
+
+The loop runner should stop when this command prints `STATUS: COMPLETE`. If
+the user wants the loop to also stop on `STATUS: ALL-BLOCKED`, configure the
+loop wrapper accordingly — but typically `ALL-BLOCKED` should pause for human
+input and resume after the queue is unblocked.

--- a/docs/audits/REMEDIATION_DEFAULTS.md
+++ b/docs/audits/REMEDIATION_DEFAULTS.md
@@ -1,0 +1,96 @@
+# Audit Remediation — Defaults
+
+Decisions baked into the loop. Override by editing this file or a queue item.
+The slash command `/audit-remediation-iteration` reads from here.
+
+Authored 2026-04-26 from the user's "use your defaults" go-ahead. Changes here
+take effect on the next iteration.
+
+## Branching
+
+- One draft PR per stream. Branch naming: `claude/audit-remediation/<letter>-<slug>`.
+- All branches forked from `main`, kept up to date by `git fetch origin main && git merge --no-edit origin/main` at the start of each iteration that touches the branch.
+- Setup PR (queue + slash command + defaults) lives on `claude/audit-codebase-health-8OCxZ` — that's the branch the harness assigned for this work.
+
+## Default decisions on the 5 open questions
+
+1. **PR strategy:** one draft PR per stream (9 PRs). Each iteration appends commits.
+2. **Branch naming:** `claude/audit-remediation/<letter>-<slug>` (see Streams below).
+3. **`admin.ts` in user paths (#216):** default is **refactor to `lib/supabase/server.ts` + add the missing RLS policy**. Surface to Blocked if (a) the route requires writing data the user shouldn't be able to mutate directly, or (b) RLS policy is non-obvious (e.g., affiliate revenue tables). Never silently leave service-role in a user path.
+4. **RLS for the 9 medium-risk tables (#215):** default policy is `owner_id = auth.uid()` for read/write, `service_role` for inserts, deny anon. If the table has no `owner_id`-shaped column, surface to Blocked. Always emit a `-- TODO: human review of policy semantics` comment in the migration.
+5. **CI gate:** before appending commits to an in-flight PR, the iteration runs `gh pr checks <number>` (or `mcp__github__pull_request_read` with checks). If CI is red, the iteration's job is to diagnose and fix that PR — not to start new work.
+
+## Verification gates (lessons from the audit)
+
+The audit had at least one false positive (the "dead components" — they're re-exported by `app/*/loading.tsx` and `app/*/error.tsx`, which the grep missed). **Trust the audit's directional claims, verify before destructive action.**
+
+Per-stream verification floor before any commit:
+
+- **Deletion:** `grep -rn "<symbol>" --include="*.ts" --include="*.tsx" .` plus the same with `export.*from.*<filename>` to catch re-exports. If anything matches, the item is a false positive — mark it RESOLVED-FALSE-POSITIVE in the queue.
+- **Refactor (admin.ts → server.ts):** confirm the calling route reads `req.cookies` or is in an authenticated layout; if not, surface to Blocked.
+- **New migration:** must be idempotent (`IF NOT EXISTS`), have a rollback header, and enable RLS if it creates a table.
+- **New test:** must actually exercise the route handler — not just import-and-assert-truthy. Reject on coverage of < 60% of the route's branches.
+
+## Per-iteration discipline
+
+- **Diff cap:** ≤ ~500 LOC per iteration (excluding generated files / pure data). Larger work splits across iterations.
+- **Always run before commit:**
+  ```bash
+  npm run type-check
+  npm test -- <changed test files only>
+  npm run lint -- <changed files only>
+  ```
+  If any red → fix or revert. Never commit a red iteration.
+- **Every 10th iteration:** also run `npm run build` to catch issues unit tests miss (route-manifest, ISR, server-component boundaries).
+- **No destructive git ops:** no `--force`, no `reset --hard`, no `clean -fd`. Migrations are forward-only per `CLAUDE.md`.
+- **No skipping hooks:** never `--no-verify`. If `lint-staged` rewrites files, restage and recommit.
+- **Conventional Commits** subject lines per `CONTRIBUTING.md` style (`fix(stream-d): add /api/submit-lead integration test`).
+
+## Streams
+
+| Letter | Branch | Title | Tracks issue |
+| --- | --- | --- | --- |
+| A | `claude/audit-remediation/a-drift-backfill` | DB schema drift backfill (231 tables) | #214 |
+| B | `claude/audit-remediation/b-rls-remediation` | RLS on 11 migrations | #215 |
+| C | `claude/audit-remediation/c-admin-scope-reset` | `admin.ts` scope reset | #216 |
+| D | `claude/audit-remediation/d-route-tests` | API route tests (critical 9 + backfill) | #217 |
+| E | `claude/audit-remediation/e-zod-rollout` | Zod validation rollout | #218 |
+| F | `claude/audit-remediation/f-hygiene` | Dead code, duplicate consolidation, SSOT | (no P0 issue; report §1 + §2) |
+| G | `claude/audit-remediation/g-migration-hygiene` | Idempotency + rollback headers | (report §5.2 + §5.4) |
+| H | `claude/audit-remediation/h-file-splits` | Files >1000 LOC | (report §3.2) |
+| I | `claude/audit-remediation/i-guardrails` | ESLint + CI guards (re-drift, RLS, admin.ts imports) | cross-cutting |
+
+## Priority order
+
+When choosing the next item, walk in this order and pick the first non-blocked one:
+
+1. **B (critical 2)** — `email_otps` and `leads` RLS — compliance gate.
+2. **D (critical 9)** — lead-capture + Stripe + signout integration tests — revenue gate.
+3. **B (other 9)** — remaining RLS migrations.
+4. **C** — `admin.ts` scope reset (mechanical refactors first; surface ambiguous to Blocked).
+5. **A** — drift backfill (4–5 tables per iteration).
+6. **E** — Zod rollout (top-20 first, then backfill).
+7. **G** — migration hygiene.
+8. **I** — guardrails (best after A/B/C land so the rules don't break in-flight work).
+9. **F** — hygiene cleanup.
+10. **H** — file splits (last; needs tests in place to be safe).
+
+## Concurrency + locking
+
+- Only one iteration may touch one branch at a time. Lock file: `.git/audit-remediation.lock` containing the iteration's start ISO timestamp. Stale locks (> 90 minutes old) are removed by the next iteration.
+- Iterations must complete on a single branch — never cross-commit between streams in one iteration.
+
+## Stop conditions
+
+- **Hard stop:** queue's `In flight` and `Blocked` sections are empty AND `Done` covers all original items. Iteration prints `STATUS: COMPLETE` and exits.
+- **Stream stuck:** if the same stream fails 3 iterations in a row (CI red after fix attempt), the stream is moved to Blocked with the failure log and the loop continues on other streams.
+- **Manual halt:** if the user pauses the loop, no cleanup is required — every iteration is a complete unit.
+
+## Stuff the loop will never do (ask the user instead)
+
+- Apply migrations to production (forward-only; user runs).
+- Run E2E against Stripe sandbox (no keys in repo).
+- Query the live DB for runtime data (row counts, last-read timestamps, partial-failure verification of §5.5).
+- Hit PostHog API for "is this route actually called in prod?" data — needed to safely act on the 135 suspected-dead routes.
+- Decide compliance copy beyond `lib/compliance.ts` SSOT.
+- Merge any PR.

--- a/docs/audits/REMEDIATION_QUEUE.md
+++ b/docs/audits/REMEDIATION_QUEUE.md
@@ -1,0 +1,177 @@
+# Audit Remediation — Queue
+
+Source of truth for `/audit-remediation-iteration`. Each iteration reads this
+file, picks the top non-blocked item per `REMEDIATION_DEFAULTS.md` priority
+order, does it, then updates this file before exiting.
+
+**Hand-edit this file to reorder, drop, or unblock items.** The loop will pick
+up your changes on its next run.
+
+Format conventions:
+
+- Items are stable IDs of the form `<stream-letter>-<NN>`.
+- Statuses: `pending` · `in-progress` · `done` · `blocked` · `false-positive`.
+- Each item has: ID · status · summary · est-iterations · notes (file paths, blockers, links).
+- "In flight" lists per-stream PR + branch + last CI status (updated each iteration).
+
+Audit source: `docs/audits/codebase-health-2026-04-24.md` (PR #213).
+
+---
+
+## In flight (per stream)
+
+_None yet — will be populated as the loop opens stream branches & PRs._
+
+| Stream | Branch | PR | Last CI | Items in flight |
+| --- | --- | --- | --- | --- |
+| A | _not started_ | — | — | — |
+| B | _not started_ | — | — | — |
+| C | _not started_ | — | — | — |
+| D | _not started_ | — | — | — |
+| E | _not started_ | — | — | — |
+| F | _not started_ | — | — | — |
+| G | _not started_ | — | — | — |
+| H | _not started_ | — | — | — |
+| I | _not started_ | — | — | — |
+
+---
+
+## Blocked — needs human input
+
+_None yet. Each entry below would have: stream, item ID, question, what the iteration tried, decision needed._
+
+---
+
+## Pending work
+
+### Stream B — RLS remediation (issue #215)
+
+Highest priority: critical 2 first.
+
+| ID | Status | Summary | Est. iterations | Notes |
+| --- | --- | --- | --- | --- |
+| B-01 | pending | RLS on `email_otps` (`supabase/migrations/20260316_email_otps.sql`) | 1 | Auth-sensitive; default policy: user reads only own row by `email`, service-role writes. |
+| B-02 | pending | RLS on `leads` (`supabase/migrations/20260316_create_leads_table.sql`) | 1 | PII; default policy: deny anon read, service-role write, admin role read. |
+| B-03 | pending | RLS on `sponsor_invoices` | 1 | Owner = sponsor user; default per `REMEDIATION_DEFAULTS.md` §4. |
+| B-04 | pending | RLS on `investment_listings` | 1 | Public-read likely intended; verify. |
+| B-05 | pending | RLS on `listing_claims` | 1 | Owner = claimant. |
+| B-06 | pending | RLS on remaining 6 medium-risk tables (one iteration each) | 6 | Enumerate from `grep -L "ENABLE ROW LEVEL SECURITY" supabase/migrations/*.sql` minus the 5 above. |
+| B-07 | pending | Add CI lint that fails any new `CREATE TABLE` migration without `ENABLE ROW LEVEL SECURITY` | 1 | Stream I overlap; coordinate. |
+
+### Stream D — Critical-path API tests (issue #217)
+
+| ID | Status | Summary | Est. iterations | Notes |
+| --- | --- | --- | --- | --- |
+| D-01 | pending | Integration test for `/api/submit-lead` | 1 | Pattern after existing `__tests__/api/*` files. Mock Supabase `admin` and outbound notifications. |
+| D-02 | pending | Integration test for `/api/quiz-lead` | 1 | |
+| D-03 | pending | Integration test for `/api/advisor-lead` | 1 | |
+| D-04 | pending | Integration test for `/api/advisor-apply` (root, not just `invite`) | 1 | |
+| D-05 | pending | Integration test for `/api/stripe/refund-subscription` | 1 | Mock `stripe` SDK + admin client. |
+| D-06 | pending | Integration test for `/api/stripe/cancel-subscription` | 1 | |
+| D-07 | pending | Integration test for `/api/stripe/create-portal` | 1 | |
+| D-08 | pending | Integration test for `/api/stripe/create-contract` | 1 | |
+| D-09 | pending | Integration test for `/api/auth/signout` | 1 | |
+| D-10 | pending | Add `vitest.config.mts` ratchet: API-route coverage floor | 1 | Compute current %, set ratchet just below. |
+| D-11 | pending | Backfill remaining 228 untested routes (chunked: ~5 per iteration, prioritised by traffic) | ~45 | Lowest priority within D; ongoing. |
+
+### Stream A — DB schema drift backfill (issue #214)
+
+| ID | Status | Summary | Est. iterations | Notes |
+| --- | --- | --- | --- | --- |
+| A-01 | pending | Reconciliation: produce precise list of drifted tables (compare `lib/database.types.ts` to `grep -E '^CREATE TABLE' supabase/migrations/*.sql`) | 1 | Output: `docs/audits/drift-list.md` with table → classification (app / Supabase-internal / PostGIS / retired). |
+| A-02 | pending | Backfill migrations for user-data table families (`leads_*`, `advisor_*`, `email_*`, `lead_*`) | ~8 | Idempotent + RLS-on; ~5 tables per iteration. |
+| A-03 | pending | Backfill migrations for revenue tables (`sponsor_*`, `subscription_*`, `affiliate_*`, `stripe_*`) | ~8 | |
+| A-04 | pending | Backfill migrations for content tables (`articles_*`, `guides_*`, `glossary_*`, `vertical_*`) | ~10 | |
+| A-05 | pending | Backfill migrations for ops/agent tables (`agent_*`, `platform_snapshots`, `ab_tests`) | ~6 | |
+| A-06 | pending | Backfill remaining miscellaneous tables | ~10 | |
+| A-07 | pending | Add CI check that fails build if `database.types.ts` declares a table not present in any migration | 1 | Stream I overlap. |
+
+### Stream C — `admin.ts` scope reset (issue #216)
+
+| ID | Status | Summary | Est. iterations | Notes |
+| --- | --- | --- | --- | --- |
+| C-01 | pending | Generate call graph: `grep -rn "from ['\"]@/lib/supabase/admin['\"]"` classified by route family | 1 | Output: `docs/audits/admin-callgraph.md`. |
+| C-02 | pending | Refactor `app/api/advisor-auth/*` admin imports to `server.ts` + add RLS where missing | ~3 | |
+| C-03 | pending | Refactor `app/api/advisor-apply/*` admin imports | ~2 | |
+| C-04 | pending | Refactor `app/api/affiliate/*` admin imports | ~2 | Likely several Blocked items here — surface to user. |
+| C-05 | pending | Refactor `app/account/notifications/page.tsx` + `components/ArticleBrokerTable.tsx` | 1 | |
+| C-06 | pending | Refactor `lib/*` modules currently importing admin (review per-module necessity) | ~3 | |
+| C-07 | pending | Update `CLAUDE.md` allowed-scope list with the documented exceptions surfaced during the refactor | 1 | |
+| C-08 | pending | Add ESLint rule restricting `lib/supabase/admin.ts` imports to allowed paths | 1 | Stream I overlap. |
+
+### Stream E — Zod validation rollout (issue #218)
+
+| ID | Status | Summary | Est. iterations | Notes |
+| --- | --- | --- | --- | --- |
+| E-01 | pending | Author `lib/validation/withValidatedBody.ts` helper + tests | 1 | Pattern: `withValidatedBody(schema, async (req, body) => {...})`. |
+| E-02 | pending | Convert top-20 highest-traffic routes to Zod (overlap with D-01..D-09) | ~5 | 4 routes per iteration. |
+| E-03 | pending | ESLint rule: flag new `await req.json()` without immediate `.parse()`/`.safeParse()` | 1 | Stream I. |
+| E-04 | pending | Backfill remaining ~206 routes (chunked: ~6 per iteration) | ~35 | Lowest priority within E; ongoing. |
+
+### Stream G — Migration hygiene
+
+| ID | Status | Summary | Est. iterations | Notes |
+| --- | --- | --- | --- | --- |
+| G-01 | pending | Idempotency: convert 10 non-idempotent migrations (per audit §5.2) to use `IF NOT EXISTS` / `CREATE OR REPLACE` | 1 | List in audit. Single iteration; comment-only or near-comment-only. |
+| G-02 | pending | Rollback headers: add to the 3 migrations missing headers entirely | 1 | `20260316_add_weekly_rate_drip_log.sql`, `20260316_add_advisor_nudge_tracking.sql`, `20260316_add_lead_outcome_tracking.sql`. |
+| G-03 | pending | Rollback headers: backfill explicit reverse-SQL on remaining 108 partial-header migrations | ~10 | ~10 migrations per iteration. |
+| G-04 | pending | Document the 8 partial-failure-marker migrations (audit §5.5) for user to verify in prod | 1 | Output to Blocked — needs DB access. |
+
+### Stream I — CI / lint guardrails
+
+Best done after A/B/C land so the rules don't break in-flight work.
+
+| ID | Status | Summary | Est. iterations | Notes |
+| --- | --- | --- | --- | --- |
+| I-01 | pending | CI: fail build if any `supabase/migrations/*.sql` adds a `CREATE TABLE` without `ENABLE ROW LEVEL SECURITY` | 1 | Pairs with B-07. |
+| I-02 | pending | CI: fail build if `lib/database.types.ts` declares a table not in any migration | 1 | Pairs with A-07. |
+| I-03 | pending | ESLint: restrict `lib/supabase/admin.ts` imports to allowed paths + `CLAUDE.md` exceptions | 1 | Pairs with C-08. |
+| I-04 | pending | ESLint: flag new `await req.json()` without an adjacent `.parse()`/`.safeParse()` | 1 | Pairs with E-03. |
+| I-05 | pending | CI: ratchet API-route test coverage floor (per D-10) | 1 | Pairs with D-10. |
+
+### Stream F — Hygiene (dead code, dupes, SSOT)
+
+| ID | Status | Summary | Est. iterations | Notes |
+| --- | --- | --- | --- | --- |
+| F-01 | false-positive | ~~Delete `components/RouteErrorBoundary.tsx` + `components/RouteLoadingSkeleton.tsx`~~ | — | **Audit was wrong.** Both are re-exported by 14 `app/*/loading.tsx` and `app/*/error.tsx` files (verified 2026-04-26). Keep. |
+| F-02 | pending | Add `formatDate` to `lib/utils.ts`; consolidate 8 local re-implementations | 1 | Per audit §2.1. |
+| F-03 | pending | Replace 13 `formatCurrency` re-implementations with `lib/utils.ts` import | 1 | |
+| F-04 | pending | Replace 5 `slugify` re-implementations with `lib/utils.ts` import | 1 | |
+| F-05 | pending | Replace 12 actionable `console.*` calls with `lib/logger.ts` | 1 | Per audit §2.2; top offender `app/advisor-portal/page.tsx`. |
+| F-06 | pending | Move 4 hardcoded compliance-copy strings to `lib/compliance.ts` (audit §2.2) | 1 | `BrokerCard.tsx`, `full-service-brokers/FullServiceBrokerCard.tsx`, `VerifiedBadge.tsx`, `AdminHelpPanel.tsx`. |
+| F-07 | pending | Migrate 42 hardcoded JSON-LD blocks to `lib/schema-markup.ts` helpers | ~6 | ~7 files per iteration. |
+| F-08 | pending | Extract shared `components/ui/Card` base, refactor 7 card components | ~3 | Lower priority — visual diffs need careful review. |
+
+### Stream H — File splits
+
+Only run after stream D has covered the file with tests; otherwise risk silent regression.
+
+| ID | Status | Summary | Est. iterations | Notes |
+| --- | --- | --- | --- | --- |
+| H-01 | pending | Split `app/api/stripe/webhook/route.ts` (1,197 LOC) — extract event handlers | ~3 | Highest leverage. Requires D-stream tests for stripe routes first. |
+| H-02 | pending | Split `lib/advisor-verification.ts` (1,075 LOC) — extract verification stages | ~3 | Second-highest. Requires test coverage. |
+| H-03 | pending | Split `app/advisor-portal/page.tsx` (2,761 LOC) into per-tab components | ~5 | Largest file. Pure-UI split; test via E2E. |
+| H-04 | pending | Split remaining 12 files in audit §3.2 (one or two per iteration) | ~10 | Lower priority. |
+
+---
+
+## Done
+
+_Empty. Items move here as iterations complete them — most recent at the top._
+
+---
+
+## Resolved as false positives
+
+| ID | Original claim | Why it's a FP | Verified |
+| --- | --- | --- | --- |
+| F-01 | "`RouteErrorBoundary` + `RouteLoadingSkeleton` are unimported" | Re-exported by 14 `app/*/loading.tsx` + `app/*/error.tsx` files via `export { default } from "@/components/Route*"` syntax — audit's grep didn't catch re-exports. | 2026-04-26 |
+
+---
+
+## Iteration log (most recent at top)
+
+### 2026-04-26 — setup
+- Created queue, defaults doc, slash command. No code changes.
+- Caught audit false positive (F-01); flagged for verification gate in `REMEDIATION_DEFAULTS.md`.
+- Status: ready for `/loop 30m /audit-remediation-iteration`.


### PR DESCRIPTION
Sets up the queue, defaults, and slash command for grinding through the audit (PR #213) as a continuous `/loop` on Claude Code.

## What this lands

- `docs/audits/REMEDIATION_QUEUE.md` — source of truth across iterations. 9 streams (A–I) seeded from the audit; ~225 work-items total. Hand-edit to reorder, drop, or unblock.
- `docs/audits/REMEDIATION_DEFAULTS.md` — documented defaults for the 5 open design questions (PR strategy, branching, `admin.ts` refactor target, RLS policy default, CI gate). Override by editing.
- `.claude/commands/audit-remediation-iteration.md` — the slash command. Strict per-iteration contract: lock → sync → CI rescue → pick → verify → do → commit/push/PR → update queue. Hard rules: never force-push, never apply prod migrations, never merge, always verify before destructive action.

## How to start the loop

```
/loop 30m /audit-remediation-iteration
```

The loop exits when the slash command prints `STATUS: COMPLETE`. Pauses on `STATUS: ALL-BLOCKED` (queue's Blocked section needs your input).

## Priority order

Compliance + revenue gates first:

1. **B-critical 2** — RLS on `email_otps` + `leads` (Tracks #215)
2. **D-critical 9** — integration tests for lead-capture, Stripe, signout (Tracks #217)
3. B-other-9 → C → A → E → G → I → F → H

## Caught one audit false positive while seeding

`RouteErrorBoundary` + `RouteLoadingSkeleton` were flagged as "unimported" in the audit. They're not — they're re-exported by 14 `app/*/loading.tsx` and `app/*/error.tsx` files via `export { default } from "@/components/Route*"` syntax that the audit's grep didn't catch. Marked as `F-01` false-positive in the queue, and used the lesson to bake "verify before destructive action" into the slash command's phase 4.

## What changes when you merge this

Nothing in code. Pure infrastructure. The first real iteration of the loop is what starts producing diffs against streams A–I.

Refs: #213 #214 #215 #216 #217 #218

---
_Generated by [Claude Code](https://claude.ai/code/session_01SvGLDUByAim3RSHHK8zz9x)_