### PR TITLE
fix(security): revoke pg_graphql anon — closes 241 advisor findings (P0 / Sprint 1 #1)

### DIFF
--- a/supabase/migrations/20260426_revoke_pg_graphql_anon.sql
+++ b/supabase/migrations/20260426_revoke_pg_graphql_anon.sql
@@ -1,0 +1,49 @@
+-- ============================================================
+-- Revoke pg_graphql anonymous + authenticated access
+--
+-- Closes 241 of 261 Supabase security-advisor findings
+-- (`pg_graphql_anon_table_exposed`) in a single statement.
+--
+-- Rationale: the repository does not use the GraphQL endpoint at
+-- /graphql/v1. Verified 2026-04-26 by:
+--     grep -rn "/graphql/v1\|pg_graphql\|graphql_public" \
+--          app/ components/ lib/ --include="*.ts" --include="*.tsx"
+-- → zero matches.
+--
+-- All client traffic uses PostgREST via the Supabase JS SDK
+-- (`.from('table').select(...)`). Removing GraphQL anon access
+-- shrinks the attack surface to PostgREST + RLS, which is what
+-- our security model assumes.
+--
+-- Rollback (do not include in this migration — operator step
+-- only if a future feature needs GraphQL):
+--     GRANT USAGE ON SCHEMA graphql_public TO anon, authenticated;
+--     GRANT USAGE ON SCHEMA graphql        TO anon, authenticated;
+--     GRANT EXECUTE ON FUNCTION graphql_public.graphql(text, text, jsonb, text)
+--         TO anon, authenticated;
+--
+-- Audit reference: docs/audits/2026-04-26-comprehensive-audit.md
+-- §4.4.2 ("F-4.4.2 P1 — Revoke pg_graphql anon access").
+-- Maps to metric M07 (Supabase advisor findings — security).
+-- ============================================================
+
+-- Belt-and-braces: revoke from both schemas pg_graphql installs
+-- (`graphql_public` is the user-facing wrapper; `graphql` holds
+-- the internal resolver).
+REVOKE USAGE ON SCHEMA graphql_public FROM anon, authenticated;
+REVOKE USAGE ON SCHEMA graphql        FROM anon, authenticated;
+
+-- Revoke the wrapper function explicitly. The signature is the
+-- standard one shipped by pg_graphql; if it ever changes, this
+-- statement becomes a no-op (REVOKE on a non-existent function
+-- raises NOTICE only when explicitly named, so we wrap in DO).
+DO $$
+BEGIN
+  EXECUTE 'REVOKE EXECUTE ON FUNCTION graphql_public.graphql(text, text, jsonb, text) FROM anon, authenticated';
+EXCEPTION
+  WHEN undefined_function THEN
+    RAISE NOTICE 'graphql_public.graphql(...) not present — skipping (extension may have been removed already)';
+END $$;
+
+-- Service role retains access (no REVOKE on service_role above).
+-- Postgres superuser (`postgres`) is unaffected.


### PR DESCRIPTION
## Summary

Single-statement migration that revokes \`pg_graphql\` access from the \`anon\` and \`authenticated\` roles. Closes **241 of 261** Supabase security-advisor findings (\`pg_graphql_anon_table_exposed\`) in one shot — the highest-leverage hour in the entire 4-month plan per the comprehensive audit.

The repo does not use the GraphQL endpoint at \`/graphql/v1\`. All client traffic goes through PostgREST via the Supabase JS SDK.

**Verified zero callers** (2026-04-26):
\`\`\`
$ grep -rn "/graphql/v1\|pg_graphql\|graphql_public" app/ components/ lib/ --include="*.ts" --include="*.tsx"
ZERO MATCHES
\`\`\`

## Sprint context

- **Audit reference**: \`docs/audits/2026-04-26-comprehensive-audit.md\` §4.4.2
- **Sprint**: 1 of 8 (Sprint 1, PR #1 of ~8)
- **P-level**: P1 (highest-leverage single hour — user-flagged)
- **Metric movement**: M07 (Supabase security advisors): **261 → ~20** ⬇️
- **Effort**: ~1h

## Test plan

- [ ] Migration applies cleanly on a fresh staging branch (CI: \`db:diff\`).
- [ ] After apply, re-query \`mcp__claude_ai_Supabase__get_advisors\` (security) — expect 241 \`pg_graphql_anon_table_exposed\` findings to disappear.
- [ ] Smoke-test public pages (homepage, \`/compare\`, \`/quiz\`, \`/article/{slug}\`) — should be unaffected (PostgREST path).
- [ ] Smoke-test logged-in admin pages — should be unaffected (service-role retained).

## Rollback

If a future feature needs GraphQL, run (manually):

\`\`\`sql
GRANT USAGE ON SCHEMA graphql_public TO anon, authenticated;
GRANT USAGE ON SCHEMA graphql        TO anon, authenticated;
GRANT EXECUTE ON FUNCTION graphql_public.graphql(text, text, jsonb, text)
    TO anon, authenticated;
\`\`\`

Refs: #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>