### PR TITLE
fix(observability): cron dispatcher silent failures — restore cron_run_log (P0-1)

### DIFF
--- a/app/api/cron/_dispatch/[group]/route.ts
+++ b/app/api/cron/_dispatch/[group]/route.ts
@@ -129,7 +129,16 @@ export async function GET(
           .update({
             ended_at: new Date().toISOString(),
             duration_ms: durationMs,
-            status: handlerFailed ? "error" : "success",
+            // Status MUST be one of ('running','ok','error','partial')
+            // per the cron_run_log_status_check CHECK constraint
+            // (verified live 2026-04-26). The pre-fix dispatcher
+            // wrote 'success' here — the constraint silently rejected
+            // every UPDATE, which is the deepest layer of the
+            // 04-16 → 04-26 logging silence. 'ok' matches the value
+            // wrapCronHandler uses on the handler-side path so the
+            // observability dashboard groups both sources under one
+            // bucket.
+            status: handlerFailed ? "error" : "ok",
             error_message:
               errorMessage ?? (status >= 400 ? `HTTP ${status}` : null),
             stats: isPlainObject(body) ? body : null,

--- a/app/api/cron/_dispatch/[group]/route.ts
+++ b/app/api/cron/_dispatch/[group]/route.ts
@@ -45,12 +45,17 @@ export async function GET(
   const supabase = createAdminClient();
 
   const started = Date.now();
+  log.info("Dispatch start", { group, total: paths.length, origin });
+
   const results = await Promise.allSettled(
     paths.map(async (path) => {
       const t0 = Date.now();
       // Open a cron_run_log row before the call so a hanging handler
       // still shows up as "running" in the observability dashboard.
-      const { data: logRow } = await supabase
+      // We surface insert failures explicitly — silent failures here
+      // were the root cause of the 2026-04-16 → 2026-04-26 cron-log
+      // silence (P0-1).
+      const { data: logRow, error: insertErr } = await supabase
         .from("cron_run_log")
         .insert({
           name: path,
@@ -61,9 +66,19 @@ export async function GET(
         .select("id")
         .single();
 
+      if (insertErr) {
+        log.error("cron_run_log insert failed", {
+          path,
+          err: insertErr,
+          message: insertErr.message,
+          code: insertErr.code,
+        });
+      }
+
       let status = 0;
       let body: unknown = null;
       let errorMessage: string | null = null;
+      let fetchSucceeded = false;
       try {
         const res = await fetch(`${origin}${path}`, {
           method: "GET",
@@ -71,6 +86,7 @@ export async function GET(
           cache: "no-store",
         });
         status = res.status;
+        fetchSucceeded = true;
         try {
           body = await res.json();
         } catch {
@@ -78,38 +94,70 @@ export async function GET(
         }
       } catch (err) {
         errorMessage = err instanceof Error ? err.message : String(err);
+        log.error("loopback fetch threw", {
+          path,
+          err: err instanceof Error ? err : undefined,
+          message: errorMessage,
+        });
       }
       const durationMs = Date.now() - t0;
+
+      // A loopback fetch that throws (e.g., DNS / TLS / connection
+      // reset) leaves `status === 0`. Without this guard, the
+      // summary at the bottom treats `0 < 400` as success and
+      // dispatcher returns 200 even though every handler failed —
+      // which is exactly what masked the 10-day cron silence in
+      // 2026-04. Treat any non-fulfilled fetch as failure.
+      const handlerFailed = !fetchSucceeded || status >= 400;
+
+      if (handlerFailed) {
+        log.error("handler invocation failed", {
+          path,
+          status,
+          fetchSucceeded,
+          message: errorMessage ?? `HTTP ${status}`,
+          durationMs,
+        });
+      }
 
       // Close the row with the outcome. If the insert earlier failed
       // we silently drop the update — the dispatcher summary below is
       // still accurate.
       if (logRow) {
-        await supabase
+        const { error: updateErr } = await supabase
           .from("cron_run_log")
           .update({
             ended_at: new Date().toISOString(),
             duration_ms: durationMs,
-            status: errorMessage
-              ? "error"
-              : status < 400
-                ? "success"
-                : "error",
+            status: handlerFailed ? "error" : "success",
             error_message:
               errorMessage ?? (status >= 400 ? `HTTP ${status}` : null),
             stats: isPlainObject(body) ? body : null,
           })
           .eq("id", logRow.id);
+
+        if (updateErr) {
+          log.error("cron_run_log update failed", {
+            path,
+            logRowId: logRow.id,
+            err: updateErr,
+            message: updateErr.message,
+          });
+        }
       }
 
-      return { path, status, durationMs, body, errorMessage };
+      return { path, status, durationMs, body, errorMessage, handlerFailed };
     }),
   );
 
   const summary = results.map((r, i) => {
     const path = paths[i];
     if (r.status === "fulfilled") {
-      return { ok: r.value.status < 400, ...r.value };
+      // `handlerFailed` is the authoritative success/failure flag —
+      // it's true when the loopback fetch threw OR returned >=400.
+      // Pre-fix code used `status < 400` which incorrectly classified
+      // `status === 0` (fetch never returned) as success.
+      return { ok: !r.value.handlerFailed, ...r.value };
     }
     return {
       path,
@@ -120,12 +168,23 @@ export async function GET(
   });
 
   const failed = summary.filter((s) => !s.ok);
-  log.info("Dispatch complete", {
-    group,
-    total: summary.length,
-    failed: failed.length,
-    totalMs: Date.now() - started,
-  });
+  if (failed.length > 0) {
+    log.error("Dispatch complete with failures", {
+      group,
+      total: summary.length,
+      failed: failed.length,
+      totalMs: Date.now() - started,
+      // First 3 failed paths for triage; full set in summary response
+      failedPaths: failed.slice(0, 3).map((f) => f.path),
+    });
+  } else {
+    log.info("Dispatch complete", {
+      group,
+      total: summary.length,
+      failed: 0,
+      totalMs: Date.now() - started,
+    });
+  }
 
   return NextResponse.json(
     {


### PR DESCRIPTION
## TL;DR

\`cron_run_log\` has been silent for ~10 days while Vercel cron schedules fired every 5 min returning 200 OK. Root cause: a status-classification bug in the dispatcher made \`status === 0\` (thrown fetch) report as success, AND insert/update errors on \`cron_run_log\` were silently dropped. Fix surfaces the real errors via \`log.error\` (Sentry) and corrects the success/failure classification.

## Sprint context

- Sprint 1 of 8, PR #3 (after #223 pg_graphql, #224 queue updates)
- **P0-1** — single most-urgent operational gap per the 04-26 audit (§9.1)
- Audit ref: \`docs/audits/2026-04-26-comprehensive-audit.md\`
- Metric: M09 (cron success rate 7d) — restoring visibility
- Effort: 2h diagnose + 30 min patch

## Diagnosis evidence

| Check | Result |
|---|---|
| Vercel cron schedule firing? | ✅ \`/api/cron/_dispatch/*\` every 5 min, status 200 |
| 401s in cron auth? | ❌ Zero 401s in 3d (Vercel logs) |
| Service-role broken? | ❌ \`allocation_decisions\` + \`analytics_events\` still writing today |
| Direct service-role insert into \`cron_run_log\`? | ✅ Works (test row landed via Supabase MCP) |
| Handler routes invoked at all? | ❌ Zero handler-route logs in Vercel for 3d (only dispatcher paths) |
| RLS / FORCE RLS on \`cron_run_log\`? | RLS on, no policies, FORCE off (service-role bypasses) |

So: dispatcher → handler loopback fetches are failing silently, AND the dispatcher's success-classification bug (line 95: \`r.value.status < 400\`) made \`status === 0\` (init value when fetch throws) evaluate as "ok" → 200 OK → no alarm.

## Fix scope

**Behaviour-preserving where it works**, surfaces failures where it broke:

- INSERT error on \`cron_run_log\` → \`log.error\` (was: dropped).
- UPDATE error on \`cron_run_log\` → \`log.error\` (was: ignored entirely).
- Loopback fetch throw → \`log.error\` with the actual exception (was: only set local var).
- Per-handler failure → \`log.error\` with path/status/duration (was: silent).
- End-of-dispatch summary log → \`log.error\` when any handler failed, \`log.info\` otherwise (was: always \`log.info\`).
- Summary classification: \`ok = !handlerFailed\` (was: \`status < 400\` — broken for \`status === 0\`).
- Dispatcher now correctly returns \`207 Multi-Status\` when handlers fail (was: always 200).

## What this does NOT fix yet

The deeper architectural question — *why* loopback \`fetch(\`\${origin}\${path}\`)\` was failing in the first place — is deferred until restored logging tells us. Possible causes:
- Vercel intra-deployment fetch quirk
- DNS / TLS handshake issue on the public URL
- Auth header dropped under some deployment condition

Once Sentry surfaces the actual error, follow-up PR can either retry, switch to a direct-import dispatch model, or document the workaround.

## Test plan

- [ ] CI greens.
- [ ] After deploy, query \`SELECT max(started_at), count(*) FILTER (WHERE started_at > now() - interval '1 hour') FROM cron_run_log;\` — expect rows landing within 5-15 min.
- [ ] Sentry should show new \`loopback fetch threw\` / \`cron_run_log insert failed\` / \`handler invocation failed\` events — these reveal the underlying failure mode for the follow-up PR.
- [ ] Vercel logs for \`/api/cron/_dispatch/*\` should now return \`207 Multi-Status\` when handlers actually fail (the original intent).

## Follow-up: PR #6 — Sentry alert rule

Once this lands, the next PR adds a Sentry alert rule keyed on the new error events, so any future cron silence is caught within minutes instead of days.

Refs: #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>