### PR TITLE
fix(seo): sitemap — filter articles by status='published' (P0-4)

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -146,9 +146,18 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     priority: 0.7,
   }));
 
-  // Dynamic article pages
+  // Dynamic article pages — only published. Without this filter,
+  // drafts (status='draft') and archived (status='archived') articles
+  // leak into the sitemap and get crawled by Google. Every other
+  // dynamic source on this file (brokers, professionals, scenarios,
+  // alerts, reports, advisor_articles) already filters by its
+  // status column; this query was the lone exception (P0-4 in
+  // docs/audits/2026-04-26-comprehensive-audit.md §8.1).
   const { data: articles } = supabase
-    ? await supabase.from("articles").select("slug, updated_at")
+    ? await supabase
+        .from("articles")
+        .select("slug, updated_at")
+        .eq("status", "published")
     : { data: null };
 
   const articlePages = (articles || []).map((a) => ({


### PR DESCRIPTION
## Summary

\`app/sitemap.ts:151\` was the only dynamic-source query in the file that didn't filter by status. Drafts and archived articles could leak into sitemap.xml and get crawled. One-line fix: add \`.eq('status', 'published')\`.

## Sprint context

- Sprint 1, PR #5
- **P0-4** (audit §8.1)
- Effort: 0.5h
- Metric: M11 (preventive)

## Verified zero regression

All 266 articles in DB are currently published (Supabase MCP query, 2026-04-26). Behaviourally identical today; correctness fix for the imminent Phase 2 editorial-pipeline (PR #207, \`editorial_publish_gate\`) that will start producing drafts.

## Test plan

- [ ] CI greens.
- [ ] After deploy, hit \`/sitemap.xml\` and confirm article count is unchanged (266 \`<url>\` entries under \`/article/\`).
- [ ] Insert a test article with \`status='draft'\`, regenerate sitemap (24h ISR or manual revalidate), confirm draft slug NOT present.

Refs: #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>