### PR TITLE
feat(seo): site-wide default opengraph-image + twitter-image (P0-6)

### DIFF
--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,0 +1,144 @@
+import { ImageResponse } from "next/og";
+import { SITE_NAME, SITE_DESCRIPTION } from "@/lib/seo";
+
+/**
+ * Site-wide default OpenGraph image.
+ *
+ * Next.js App Router convention: a top-level `app/opengraph-image.tsx`
+ * is auto-served at `/opengraph-image.png` and propagated to every
+ * route's <meta property="og:image"> unless a child segment
+ * explicitly overrides it (via its own `opengraph-image.tsx` file
+ * or `metadata.openGraph.images`).
+ *
+ * Why this exists: per the 2026-04-26 audit (§8.6, P0-6), pages that
+ * defined their own `openGraph` block without `images` lost the
+ * layout-level `/api/og` fallback and shipped favicon-tier social
+ * cards. Adding the file-system convention here means EVERY page
+ * gets a proper card by default — even pages that didn't realise
+ * they needed to opt in.
+ *
+ * Renders Edge-side; cached by Next.js + Vercel CDN.
+ */
+
+export const runtime = "edge";
+export const alt = `${SITE_NAME} — Compare Australian Investing Platforms`;
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default async function Image() {
+  const brandBg = "#0f172a";
+  const green = "#15803d";
+  const amber = "#f59e0b";
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          padding: "60px 80px",
+          backgroundColor: brandBg,
+          color: "white",
+          fontFamily: "system-ui, sans-serif",
+        }}
+      >
+        {/* Brand accent bar */}
+        <div
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            right: 0,
+            height: "8px",
+            background: `linear-gradient(to right, ${green}, ${amber})`,
+            display: "flex",
+          }}
+        />
+
+        {/* Logo / wordmark */}
+        <div
+          style={{
+            fontSize: 36,
+            fontWeight: 700,
+            letterSpacing: "-0.02em",
+            marginBottom: 28,
+            opacity: 0.85,
+            display: "flex",
+            alignItems: "center",
+            gap: 12,
+          }}
+        >
+          <span
+            style={{
+              display: "inline-flex",
+              width: 44,
+              height: 44,
+              borderRadius: 10,
+              background: `linear-gradient(135deg, ${green}, ${amber})`,
+              alignItems: "center",
+              justifyContent: "center",
+              fontSize: 24,
+              fontWeight: 800,
+            }}
+          >
+            $
+          </span>
+          {SITE_NAME}
+        </div>
+
+        {/* Headline */}
+        <div
+          style={{
+            fontSize: 76,
+            fontWeight: 800,
+            letterSpacing: "-0.03em",
+            lineHeight: 1.05,
+            marginBottom: 24,
+            display: "flex",
+          }}
+        >
+          Compare Platforms.
+          <br />
+          Find Advisors.
+        </div>
+
+        {/* Subhead */}
+        <div
+          style={{
+            fontSize: 28,
+            fontWeight: 400,
+            opacity: 0.78,
+            lineHeight: 1.3,
+            maxWidth: "85%",
+            display: "flex",
+          }}
+        >
+          {SITE_DESCRIPTION}
+        </div>
+
+        {/* Footer URL */}
+        <div
+          style={{
+            position: "absolute",
+            bottom: 40,
+            left: 80,
+            right: 80,
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            fontSize: 22,
+            fontWeight: 600,
+            opacity: 0.65,
+          }}
+        >
+          <span>invest.com.au</span>
+          <span style={{ color: amber }}>Independent · Verified · 2026</span>
+        </div>
+      </div>
+    ),
+    { ...size },
+  );
+}

--- a/app/twitter-image.tsx
+++ b/app/twitter-image.tsx
@@ -1,0 +1,12 @@
+/**
+ * Site-wide default Twitter card image.
+ *
+ * Re-uses the OpenGraph image generator so Twitter and other social
+ * platforms render identical cards. Twitter's `summary_large_image`
+ * card is 1200×630, same as OpenGraph, so a single asset works.
+ *
+ * Per the 2026-04-26 audit (§8.6, P0-6): without `app/twitter-image.tsx`,
+ * Twitter falls back to favicon-tier cards on any page that doesn't
+ * explicitly set `twitter.images` in its metadata.
+ */
+export { default, alt, size, contentType, runtime } from "./opengraph-image";

--- a/app/twitter-image.tsx
+++ b/app/twitter-image.tsx
@@ -1,12 +1,31 @@
+import OpenGraphImage from "./opengraph-image";
+
 /**
  * Site-wide default Twitter card image.
  *
  * Re-uses the OpenGraph image generator so Twitter and other social
  * platforms render identical cards. Twitter's `summary_large_image`
- * card is 1200×630, same as OpenGraph, so a single asset works.
+ * card is 1200×630, same as OpenGraph, so a single rendered asset
+ * works.
  *
- * Per the 2026-04-26 audit (§8.6, P0-6): without `app/twitter-image.tsx`,
- * Twitter falls back to favicon-tier cards on any page that doesn't
+ * NOTE on the export shape: Next.js 16 / Turbopack requires the
+ * route-segment config (`runtime`, `alt`, `size`, `contentType`) to
+ * be statically parseable in EACH file — re-exporting via
+ * `export { runtime } from "./opengraph-image"` fails the build with
+ * "Next.js can't recognize the exported `runtime` field". So we
+ * redeclare each metadata constant inline (cheap — strings + a tiny
+ * object) and only delegate the actual `Image()` rendering function.
+ *
+ * Per the 2026-04-26 audit (§8.6, P0-6): without this file, Twitter
+ * falls back to favicon-tier cards on any page that doesn't
  * explicitly set `twitter.images` in its metadata.
  */
-export { default, alt, size, contentType, runtime } from "./opengraph-image";
+
+export const runtime = "edge";
+export const alt = "Invest.com.au — Compare Australian Investing Platforms";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default async function TwitterImage() {
+  return OpenGraphImage();
+}


### PR DESCRIPTION
## Summary

Add \`app/opengraph-image.tsx\` and \`app/twitter-image.tsx\` so every page gets a branded social card by default — even those that defined their own \`metadata.openGraph\` block without an \`images\` field (and therefore lost the layout's \`/api/og\` fallback).

## Sprint context

- Sprint 1, PR #6
- **P0-6** (audit §8.6)
- Effort: 2h
- Metric: M12 (OG image coverage — site-wide default)

## What's different from \`/api/og\`?

\`/api/og\` (already exists) is the **dynamic** generator — used by article and broker pages with \`?title=...&type=article\` for per-page customisation. This PR adds the Next.js **file-system convention** (\`app/opengraph-image.tsx\`) which serves as the **static** site-wide default. Pages that don't override openGraph in their metadata automatically inherit this image at \`/opengraph-image.png\`.

## Brand

- 1200×630 (matches OG + Twitter \`summary_large_image\`)
- Dark navy background (\`#0f172a\`)
- Green→amber gradient accent bar (matches site brand)
- \`$\` icon + \`Invest.com.au\` wordmark
- Headline: "Compare Platforms. Find Advisors."
- Subhead: \`SITE_DESCRIPTION\` from \`lib/seo.ts\`
- Footer: \`invest.com.au\` + "Independent · Verified · 2026"

## Test plan

- [ ] CI greens.
- [ ] After deploy, GET \`https://invest-com-au.vercel.app/opengraph-image.png\` → expect 200 + the generated PNG.
- [ ] Run any static page (e.g. \`/glossary\`, \`/about\`) through https://www.opengraph.xyz/ → verify the new card appears.
- [ ] Twitter card validator (https://cards-dev.twitter.com/validator) against a page without custom \`twitter.images\` → expect the new card.

Refs: #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>