### PR TITLE
fix(security): sanitise newsletter html_content render (P0-2)

### DIFF
--- a/app/newsletter/[edition]/page.tsx
+++ b/app/newsletter/[edition]/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import { absoluteUrl, breadcrumbJsonLd, SITE_NAME, ORGANIZATION_JSONLD } from "@/lib/seo";
+import { sanitizeHtml } from "@/lib/sanitize-html";
 
 export const revalidate = 86400;
 
@@ -176,11 +177,23 @@ export default async function NewsletterEditionPage({
           </div>
         </div>
 
-        {/* Rendered HTML content */}
+        {/* Rendered HTML content.
+            Sanitised via lib/sanitize-html.ts before render. The newsletter
+            html_content column is admin-authored today, but defence-in-depth
+            matters here for two reasons:
+              1. A compromised admin account becomes stored XSS hitting every
+                 newsletter reader (large blast radius — full email list).
+              2. Future advertiser-submission features (sponsored newsletter
+                 sections) will write to the same column.
+            P0-2 in docs/audits/2026-04-26-comprehensive-audit.md §7.7.
+            Follow-up F-7.7.3 (queue K-stream) replaces the regex
+            sanitiser with isomorphic-dompurify for stronger guarantees. */}
         <div className="border border-slate-200 rounded-2xl bg-white overflow-hidden shadow-sm">
           <div
             className="newsletter-html-content"
-            dangerouslySetInnerHTML={{ __html: editionData.html_content }}
+            dangerouslySetInnerHTML={{
+              __html: sanitizeHtml(editionData.html_content),
+            }}
           />
         </div>
 


### PR DESCRIPTION
## Summary

Pipe DB-stored newsletter \`html_content\` through the existing \`sanitizeHtml()\` helper before \`dangerouslySetInnerHTML\` renders it. Closes the audit's P0-2 stored-XSS vector.

## Sprint context

- Sprint 1, PR #7
- **P0-2** (audit §7.7)
- Effort: 30 min (existing helper made it trivial; audit estimated 4h)
- Metric: M07

## Why P0 even though it's admin-authored today

Two amplifying factors:

1. **Blast radius** — newsletter goes to every subscriber. A single compromised admin account becomes stored XSS in every reader's browser at edition publish.
2. **Imminent expansion** — sponsored-newsletter-sections per the marketplace roadmap will let advertisers write to the same column. Locking sanitisation now means adding that surface doesn't require a security review.

## Known follow-up

\`lib/sanitize-html.ts\` is regex-based — its own header comment admits "Not a replacement for DOMPurify". Misses mutation XSS / namespaced SVG / mismatched-quote bypasses. Audit's **F-7.7.3 (P1, K-stream)** tracks the swap to \`isomorphic-dompurify\` (~12KB) for production-grade sanitisation. This PR closes the immediate "no sanitiser at all" P0; the deeper upgrade is queued separately.

## Test plan

- [ ] CI greens.
- [ ] Existing newsletter editions (6 in DB) render visually unchanged.
- [ ] Test payload: insert edition with \`html_content\` containing \`<script>alert(1)</script>\` + \`<img src=x onerror=alert(1)>\` + \`<a href="javascript:alert(1)">click</a>\` — all three should be stripped/neutralised.

Refs: #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>