### PR TITLE
chore(db): repo-parity migration for 4 missing FK indexes (already live via MCP)

### DIFF
--- a/supabase/migrations/20260426_add_missing_fk_indexes.sql
+++ b/supabase/migrations/20260426_add_missing_fk_indexes.sql
@@ -1,0 +1,46 @@
+-- ============================================================
+-- Add 4 missing foreign-key indexes (audit F-4.5.4 / P2)
+--
+-- Source: 04-26 audit §4.5 (Supabase performance advisor —
+-- `unindexed_foreign_keys` lint, 4 findings).
+--
+-- Repo-side parity for the 4 indexes the founder applied LIVE on
+-- 2026-04-26 via Supabase MCP (migration name on the live DB:
+-- `add_missing_fk_indexes_2026_04_26`). This file ensures the
+-- supabase/migrations/ source-of-truth catches up to live so:
+--
+--   1. Fresh dev environments rebuild correctly from migrations.
+--   2. CI's pending stream-A drift reconciliation doesn't re-flag
+--      these tables as drifted.
+--   3. Any future rollback-from-source has the index definitions.
+--
+-- Idempotent (`IF NOT EXISTS`). Safe to re-apply on the live DB —
+-- will be a no-op since the indexes already exist with these exact
+-- names (verified via pg_indexes query 2026-04-26).
+--
+-- Performance impact: each index speeds up FK joins + cascading
+-- delete checks; together they close all 4
+-- `unindexed_foreign_keys` advisor findings.
+--
+-- Rollback (operator-only):
+--   DROP INDEX IF EXISTS public.idx_affiliate_payout_variance_report_id;
+--   DROP INDEX IF EXISTS public.idx_broker_review_invites_user_review_id;
+--   DROP INDEX IF EXISTS public.idx_international_leads_professional_lead_id;
+--   DROP INDEX IF EXISTS public.idx_sponsored_placement_bookings_broker_id;
+-- ============================================================
+
+-- 1. affiliate_payout_variance.report_id → affiliate_payout_reports
+CREATE INDEX IF NOT EXISTS idx_affiliate_payout_variance_report_id
+  ON public.affiliate_payout_variance USING btree (report_id);
+
+-- 2. broker_review_invites.user_review_id → user_reviews
+CREATE INDEX IF NOT EXISTS idx_broker_review_invites_user_review_id
+  ON public.broker_review_invites USING btree (user_review_id);
+
+-- 3. international_leads.professional_lead_id → professional_leads
+CREATE INDEX IF NOT EXISTS idx_international_leads_professional_lead_id
+  ON public.international_leads USING btree (professional_lead_id);
+
+-- 4. sponsored_placement_bookings.broker_id → brokers
+CREATE INDEX IF NOT EXISTS idx_sponsored_placement_bookings_broker_id
+  ON public.sponsored_placement_bookings USING btree (broker_id);


### PR DESCRIPTION
## Summary

Repo-side migration mirroring the 4 FK indexes the founder applied live via Supabase MCP on 2026-04-26 (live migration name: \`add_missing_fk_indexes_2026_04_26\`). Catches the \`supabase/migrations/\` source-of-truth up to production.

## Sprint context

- Sprint 1 — repo-parity for founder's parallel MCP work
- Audit ref: §4.5 (F-4.5.4)
- Effort: 0.25h
- Metric: M08

## Why

1. Fresh dev / staging environments rebuild correctly.
2. Stream-A's drift reconciliation doesn't re-flag these tables as drifted.
3. Operator rollback has authoritative SQL.

## Indexes (all close \`unindexed_foreign_keys\` advisor findings)

| Table | Column | FK target | Index name |
|---|---|---|---|
| affiliate_payout_variance | report_id | affiliate_payout_reports | idx_affiliate_payout_variance_report_id |
| broker_review_invites | user_review_id | user_reviews | idx_broker_review_invites_user_review_id |
| international_leads | professional_lead_id | professional_leads | idx_international_leads_professional_lead_id |
| sponsored_placement_bookings | broker_id | brokers | idx_sponsored_placement_bookings_broker_id |

## Idempotency

\`CREATE INDEX IF NOT EXISTS\` on each — safe to re-apply on live (no-op since they already exist with these exact names; verified via \`pg_indexes\` query 2026-04-26).

## Test plan

- [ ] CI greens (migration linter, if any).
- [ ] On a throwaway Supabase branch (or staging), apply the file → expect 4 \`CREATE INDEX\` statements, each a no-op if the index exists.
- [ ] Re-run \`mcp__claude_ai_Supabase__get_advisors\` (performance) → expect the 4 \`unindexed_foreign_keys\` findings to be gone.

Refs: #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>