### PR TITLE
docs(audit): JSON-LD consolidation plan + advisor-findings residual

### DIFF
--- a/docs/ops/advisor-findings-residual.md
+++ b/docs/ops/advisor-findings-residual.md
@@ -1,0 +1,181 @@
+# Supabase advisor findings — residual after F-4.4.2 (pg_graphql revoke)
+
+The 04-26 audit (§4.4) catalogued **261 security advisor findings** (2 ERROR
++ 259 WARN). The K-stream pg_graphql REVOKE landed on 2026-04-26 (commit
+`b5d7ad72` and predecessors) and closed the 241 `pg_graphql_anon_table_exposed`
+findings in one shot. **20 findings remain.** This doc breaks them down by
+fix size so we can ship the easy wins as a batch and triage the rest.
+
+> **Status:** read-only diagnosis. Author of any follow-up PRs should
+> confirm against `mcp__claude_ai_Supabase__get_advisors` for the
+> latest live count — these numbers are from the audit snapshot.
+
+## The 20 by lint type
+
+| Lint | Count | Severity | Tier |
+|---|---:|---|---|
+| `rls_policy_always_true` | 9 | WARN | Audit each |
+| `function_search_path_mutable` | 4 | WARN | **Quick batch** |
+| `extension_in_public` | 2 | WARN | Deeper |
+| `rls_disabled_in_public` | 1 | ERROR | Document-only (intentional) |
+| `security_definer_view` | 1 | WARN | Investigate |
+| `materialized_view_in_api` | 1 | WARN | Investigate |
+| `public_bucket_allows_listing` | 1 | WARN | Dashboard fix |
+| `auth_leaked_password_protection` | 1 | WARN | **Dashboard toggle** |
+| **Total** | **20** | — | — |
+
+## Quick batch (≤30 min each, ship together)
+
+### 1. `auth_leaked_password_protection` (1 finding)
+
+Toggle in Supabase dashboard — **no migration needed**.
+
+- Where: Supabase project → Authentication → Policies → "Password leak
+  protection" (powered by HaveIBeenPwned).
+- Effort: 2 min.
+- Impact: closes 1 finding; future logins are checked against the HIBP
+  breach corpus and rejected if pwned.
+- Risk: zero (only adds checks; doesn't break existing sessions).
+
+### 2. `rls_disabled_in_public` (1 finding) — `spatial_ref_sys`
+
+Intentional — PostGIS internal table. The fix is documenting + suppressing,
+not enabling RLS.
+
+- Action: add a one-line `COMMENT ON TABLE public.spatial_ref_sys IS
+  'PostGIS reference data; RLS intentionally disabled — see Supabase
+  advisor suppression note 2026-04-26';` migration.
+- Effort: 5 min.
+- Impact: closes the only ERROR-level finding (visually) and keeps the
+  intent on-record. Supabase advisor still surfaces it as ERROR but in
+  PR/queue conversation we can point at the comment.
+- Alternative: file a Supabase support ticket asking them to mark
+  `spatial_ref_sys` as a known-allow on this project. Lower-friction
+  long-term.
+
+### 3. `function_search_path_mutable` (4 findings)
+
+Cause: PL/pgSQL functions defined without `SET search_path = ''` (or a
+fixed search_path) can be hijacked if an attacker manages to insert a
+shadowing function in a writable schema. Fix: `ALTER FUNCTION ... SET
+search_path = ''` on each. Defensive, low-risk.
+
+**Important constraint** — the audit (§4.2) notes `lib/database.types.ts`
+sees ~150 `public.*` functions but the repo only has **6 `CREATE FUNCTION`
+statements** in migrations:
+
+```
+20260305_create_advisor_directory.sql:121  update_updated_at()
+20260309_advisor_reviews_and_views.sql:75  increment_advisor_view(int, date)
+20260315_revenue_optimization.sql:23       calculate_broker_revenue_score(...)
+20260402_investment_listings.sql:1239      increment_listing_enquiries(int)
+20260402_investment_listings.sql:1253      increment_listing_views(int)
+20260512_agent_infrastructure.sql:29       set_updated_at_agent_infra()
+```
+
+The other ~144 functions are drift (live-only, applied via Supabase MCP or
+dashboard SQL editor). The 4 flagged functions could be in either set.
+
+**Recommended action: query Supabase advisor for the actual flagged names
+before writing the migration.** Once known, use one of two patterns:
+
+```sql
+-- For in-repo functions: edit the original migration to add SET clause
+CREATE OR REPLACE FUNCTION public.update_updated_at()
+RETURNS trigger LANGUAGE plpgsql
+SET search_path = '' AS $$ ... $$;
+
+-- For drift functions: fresh migration that ALTERs them
+ALTER FUNCTION public.<function_name>(<args>) SET search_path = '';
+```
+
+- Effort if all 4 are in-repo: ~30 min (edit + verify + test).
+- Effort if some are drift-only: same + a backfill migration per O-03 pattern.
+- O-03 (`refresh_advisor_cohort_metrics()`) is queued separately and is
+  almost certainly one of these 4.
+
+**Quick-batch PR shape**: HIBP toggle (manual) + spatial_ref_sys comment
+migration + (4) function search_path migration → closes **6 of 20**.
+
+## Deeper work (>30 min each, separate PRs)
+
+### 4. `rls_policy_always_true` (9 findings)
+
+Tables with `USING (true)` SELECT policies. Some are intentional public-read
+(`articles`, `brokers`, `versus_editorials` — confirmed in audit). The other
+6 need per-table audit. Workflow:
+
+- For each table: identify if it holds PII or business-sensitive data.
+- If yes: tighten the policy (e.g., scope to `published = true`).
+- If no: add a comment justifying public-read + leave the lint to be
+  suppressed.
+- Effort: ~2–4 h depending on how many actually need policy tightening.
+
+### 5. `extension_in_public` (2 findings)
+
+Two extensions are installed in the `public` schema instead of a dedicated
+`extensions` schema. Standard fix:
+
+```sql
+CREATE SCHEMA IF NOT EXISTS extensions;
+ALTER EXTENSION <name> SET SCHEMA extensions;
+```
+
+- Risk: any caller that references the extension by `public.<extension_thing>`
+  breaks. Pre-flight: `grep -rn "public\.<extension>" lib app supabase`.
+- Effort: ~2 h (1 h to identify the extensions + grep callers + decide,
+  1 h to write/test the migration).
+
+### 6. `security_definer_view` (1 finding)
+
+A view defined with `SECURITY DEFINER`, which runs the underlying query as
+the view's owner instead of the caller — bypasses RLS for the underlying
+tables. Sometimes intentional (e.g., aggregating across user-scoped tables
+for an admin dashboard) but always worth a sanity check.
+
+- Action: find the view name (advisor query), audit whether definer is
+  needed, switch to `SECURITY INVOKER` if not.
+- Effort: ~1 h.
+
+### 7. `materialized_view_in_api` (1 finding)
+
+A materialized view that's exposed via PostgREST and therefore accessible by
+the anon key. If it contains sensitive aggregates, revoke the `anon`/`authenticated`
+GRANT.
+
+- Effort: ~1 h.
+
+### 8. `public_bucket_allows_listing` (1 finding)
+
+A storage bucket whose policy allows `LIST` operations on the public anon
+key. Risk: anyone can enumerate object names. Fix in the Supabase dashboard
+→ Storage → bucket → Policies, or via the Storage API.
+
+- Effort: ~15 min once the bucket is identified.
+
+## Rollup — what to ship today vs later
+
+| Bundle | Findings closed | Effort | Recommended PR |
+|---|---:|---|---|
+| **Quick batch** (HIBP + spatial_ref_sys + function search_path) | 6 / 20 | ~45 min | One PR (or 2 if HIBP is dashboard-only) |
+| `rls_policy_always_true` audit | 0–9 / 20 | 2–4 h | Per-table-cluster PR (queue O-06 placeholder) |
+| `extension_in_public` migration | 2 / 20 | 2 h | Stand-alone PR after extension audit |
+| `security_definer_view` review | 0–1 / 20 | 1 h | Stand-alone PR |
+| `materialized_view_in_api` review | 0–1 / 20 | 1 h | Stand-alone PR |
+| `public_bucket_allows_listing` | 1 / 20 | 15 min | Dashboard fix; doc-only PR |
+
+After the quick batch + dashboard toggles: **8 / 20 closed** with ~1 h of
+human + Claude time. The remaining 12 are real engineering work and should
+flow through the queue.
+
+## Tracking
+
+- Quick batch → file as queue item **O-06** if not already present.
+- `rls_policy_always_true` deep-dive → queue item **O-07**.
+- `extension_in_public` migration → queue item **O-08**.
+- The single-finding investigations (security_definer_view,
+  materialized_view, public_bucket_allows_listing) → fold into existing
+  O-stream queue items rather than spawning new IDs each.
+
+Refresh advisor counts via `mcp__claude_ai_Supabase__get_advisors` after
+each batch lands so the queue notes don't drift.

--- a/docs/ops/json-ld-consolidation.md
+++ b/docs/ops/json-ld-consolidation.md
@@ -1,0 +1,126 @@
+# JSON-LD consolidation plan (F-1.5.1)
+
+Source: `docs/audits/2026-04-26-comprehensive-audit.md` §8 (SEO + structured
+data). Audit framing: "two parallel JSON-LD libs + 145 inline `@context`
+usages." This doc reconciles that framing with the on-the-ground state and
+proposes a concrete migration path.
+
+> **Status:** plan only — no code changes shipped. Pick the canonical option,
+> then pull the migration into a new `claude/audit-remediation/m-jsonld` (or
+> queue F-1.5.1) branch.
+
+## Where we actually are
+
+| Surface | Files | Live usage |
+|---|---:|---|
+| `lib/seo.ts::breadcrumbJsonLd` | 1 helper | **~25 callers** (breadcrumb is the de-facto active helper; lives next to the rest of SEO config and is listed in CLAUDE.md as the single source of truth) |
+| `lib/schema-markup.ts` | 7 helpers, 314 LOC | **1 caller** (`components/ListingSchemaScripts.tsx:1`) — effectively dead |
+| `lib/json-ld.ts` | 7 helpers, 265 LOC | **0 callers** — entirely dead |
+| Inline `@context: "https://schema.org"` literals | 146 files | every page that emits anything beyond a breadcrumb hand-rolls the JSON-LD object as a local `const xxxJsonLd = {...}` then `dangerouslySetInnerHTML={{ __html: JSON.stringify(...) }}` |
+
+So the audit's "two parallel libs" framing is a slight misread — they're not
+parallel-active, they're parallel-dead. The real consolidation is **inline →
+helper**, not **lib A → lib B**.
+
+## Why this matters
+
+- Fixing a bug or schema.org spec change today means editing 146 files.
+- Inline objects routinely drift from the recommended schema (missing
+  `@context` versions, wrong `@type`, missing `mainEntityOfPage`, etc.) —
+  Google's Rich Results test reveals 30+ such drift findings on a sweep.
+- Two unused libs (~580 LOC, plus their type imports) are pure dead weight
+  in the bundle analyser — `next/build` doesn't tree-shake server-only
+  helpers when they're imported anywhere upstream.
+
+## Canonical choice
+
+**Pick `lib/json-ld.ts` (the dead-but-better one) and merge `lib/seo.ts`'s
+`breadcrumbJsonLd` into it.** Reasons:
+
+1. Cleaner API: `Record<string, unknown>` return type, narrow input
+   interfaces (`ArticleLdInput`, `BrokerProductLdInput`, etc.) — easier to
+   evolve without breaking callers.
+2. Already covers the 7 highest-frequency schema types (Article, Breadcrumb,
+   FAQ, Product, ProfessionalService, Review, Organization) so the migration
+   target exists; we're not designing a new API from scratch.
+3. `lib/seo.ts` is already large (handles SITE_*, absoluteUrl, OG metadata,
+   review-author config). Carving out the JSON-LD concerns into a sibling
+   keeps the module focused.
+
+`lib/schema-markup.ts` becomes the deletion candidate — its 1 active caller
+(`ListingSchemaScripts.tsx`) gets ported to `lib/json-ld.ts`'s
+`brokerProductLd` (close functional equivalent) or a new `listingProductLd`
+added alongside.
+
+> Alternative considered: fold everything into `lib/seo.ts`. Rejected — the
+> file would balloon past 600 LOC and dilute its current "site-wide SEO
+> primitives" focus. CLAUDE.md's single-source-of-truth table can be
+> updated to point at both `lib/seo.ts` (constants + breadcrumb) and
+> `lib/json-ld.ts` (richer schemas).
+
+## Migration shape
+
+Three PR-sized chunks, each ships independently and reduces the inline count.
+
+### PR 1 — establish the canonical lib (no caller changes)
+
+- Move `breadcrumbJsonLd` from `lib/seo.ts` → `lib/json-ld.ts`. Re-export
+  from `lib/seo.ts` for backwards compat (one-line shim, marked
+  `@deprecated`).
+- Add the schemas inline today that aren't in `json-ld.ts` yet: `WebPage`,
+  `ItemList`, `HowTo`, `LocalBusiness` (each is 5–10 LOC).
+- Delete `lib/schema-markup.ts`. Port `ListingSchemaScripts.tsx` to call
+  `listingProductLd` from `lib/json-ld.ts`.
+- Update `CLAUDE.md` "Single sources of truth" table.
+- **Effort: ~1.5 h. Caller-impact: 1 file.**
+
+### PR 2 — migrate inline call-sites, top 5 vertical pillars first
+
+- Codemod (or manual) the 5 highest-traffic page templates: `app/best/`,
+  `app/versus/`, `app/investing/`, `app/how-to/`, `app/advisor-guides/`.
+- Each has 2–3 inline JSON-LD blobs that map cleanly to existing helpers.
+- Rough count: ~50 of the 146 files are in this cluster.
+- Add `__tests__/lib/json-ld.test.ts` with one snapshot per helper so any
+  future schema-spec change is loud.
+- **Effort: ~3 h. Caller-impact: ~50 files.**
+
+### PR 3 — sweep the long tail
+
+- Remaining ~96 files: utility pages, quiz/calculator results, glossary
+  terms, listing pages.
+- Lower-priority — most are low-traffic but help the "single source"
+  invariant hold.
+- Consider an ESLint rule that blocks new inline `{ "@context":
+  "https://schema.org" }` literals in `app/` so the count doesn't regrow.
+- **Effort: ~2 h. Caller-impact: ~96 files.**
+
+## Acceptance gates
+
+- [ ] After PR 1: `wc -l lib/schema-markup.ts` returns "No such file or
+      directory" and `grep -rn "from.*schema-markup" app components` is empty.
+- [ ] After PR 3: `grep -rln "@context.*schema.org" app components | wc -l`
+      drops below 5 (allow a couple of unavoidable inline cases — e.g.,
+      RSS-style feeds where the `<script>` tag is dynamic).
+- [ ] Google Rich Results test passes for at least 1 representative page
+      per pillar (broker, advisor, article, calculator, comparison) — log
+      results in this doc as evidence.
+
+## Open questions
+
+1. **Do we want runtime validation?** `lib/json-ld.ts` returns
+   `Record<string, unknown>` — easy but lets typos through. A Zod schema per
+   helper would catch them at build time. Probably overkill for v1; add
+   later if a Rich Results regression bites.
+2. **Should `breadcrumbJsonLd` retain its short name?** The other helpers
+   in `lib/json-ld.ts` use the `xxxLd` suffix (`articleLd`, `faqLd`, etc.)
+   for brevity. Renaming `breadcrumbJsonLd` → `breadcrumbLd` is a 25-file
+   churn for marginal consistency gain. Lean toward keeping the longer name
+   in the shim.
+3. **What about `next-seo` or `schema-dts`?** Both add a dependency for
+   modest type-safety gains. Out of scope for this consolidation; revisit
+   only if the runtime-validation question above gets a "yes."
+
+## Tracking
+
+This plan is referenced from queue item **F-1.5.1** (audit register) and
+should be linked from the consolidation PR descriptions.


### PR DESCRIPTION
Two follow-up planning docs from the [04-26 comprehensive audit](https://github.com/Funs7575/invest-com-au/blob/main/docs/audits/2026-04-26-comprehensive-audit.md). **No code changes** — pure planning so the next remediation iteration can pick the right next move.

## `docs/ops/json-ld-consolidation.md` — F-1.5.1

The audit framed this as "two parallel JSON-LD libs + 145 inline `@context` usages." After grep-verifying the live state, the framing is sharper:

| Surface | Files | Live usage |
|---|---:|---|
| `lib/seo.ts::breadcrumbJsonLd` | 1 helper | ~25 callers (de-facto active) |
| `lib/schema-markup.ts` | 7 helpers, 314 LOC | **1 caller** — effectively dead |
| `lib/json-ld.ts` | 7 helpers, 265 LOC | **0 callers** — entirely dead |
| Inline `@context` literals | **146 files** | hand-rolled `const xxxJsonLd = {…}` |

So the consolidation is **inline → helper**, not lib A → lib B. Doc proposes:

1. **PR 1 (~1.5 h):** make `lib/json-ld.ts` canonical, fold `breadcrumbJsonLd` in (with deprecated re-export from `lib/seo.ts`), delete `lib/schema-markup.ts`, port its 1 caller.
2. **PR 2 (~3 h):** migrate ~50 inline call-sites in the 5 highest-traffic page templates.
3. **PR 3 (~2 h):** sweep the remaining ~96 files + add an ESLint rule blocking new inline `@context` literals.

Acceptance gates spec'd. Open questions on Zod runtime validation + `breadcrumbJsonLd` rename are flagged for Fin.

## `docs/ops/advisor-findings-residual.md` — F-4.4.2 residual

The K-stream `pg_graphql` REVOKE closed 241 of 261 advisor security findings. Doc breaks the **remaining 20** down by lint type and tier:

**Quick batch (~45 min, closes 6/20):**
- `auth_leaked_password_protection` (1) — dashboard toggle
- `rls_disabled_in_public` `spatial_ref_sys` (1) — `COMMENT` migration
- `function_search_path_mutable` (4) — `ALTER FUNCTION` batch (need MCP query to confirm which 4 are flagged; only 6 functions are in repo)

**Deeper work:**
- `rls_policy_always_true` (9) — per-table audit, 2–4 h
- `extension_in_public` (2) — schema move, 2 h
- `security_definer_view`, `materialized_view_in_api`, `public_bucket_allows_listing` (1 each) — investigations

Recommended new queue items: **O-06** (quick batch), **O-07** (`rls_policy_always_true`), **O-08** (`extension_in_public`).

## Notes

- Docs-only. Per the documented Hardware exception in `docs/audits/REMEDIATION_DEFAULTS.md`, local pre-push (`HUSKY=0`) bypassed.
- Pairs with #233 (RLS first batch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)