### PR TITLE
chore(diag): cron dispatcher entry-write diagnostic (P0-1 final layer)

### DIFF
--- a/app/api/cron/_dispatch/[group]/route.ts
+++ b/app/api/cron/_dispatch/[group]/route.ts
@@ -47,6 +47,38 @@ export async function GET(
   const started = Date.now();
   log.info("Dispatch start", { group, total: paths.length, origin });
 
+  // ─────────────────────────────────────────────────────────────
+  // Diagnostic write at function entry to definitively prove the
+  // dispatcher route handler is executing. Without this, we can't
+  // distinguish between "Vercel served a cached 200 without
+  // running the route" and "route ran but its writes silently
+  // failed". Distinct `name` + `triggered_by` so it doesn't
+  // pollute real cron-health dashboards. Awaited (not
+  // fire-and-forget) so we can capture the error if it fails.
+  //
+  // Once the cron silence is conclusively diagnosed (Sprint 1
+  // close-out), this entry-write is removed in a follow-up PR.
+  // Tracked as cleanup in queue stream L.
+  // ─────────────────────────────────────────────────────────────
+  const { error: diagErr } = await supabase
+    .from("cron_run_log")
+    .insert({
+      name: `_diagnostic:${group}`,
+      started_at: new Date().toISOString(),
+      status: "ok",
+      duration_ms: 0,
+      triggered_by: "dispatcher",
+      stats: { commit: process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 7) || "local", origin, paths_count: paths.length },
+    });
+  if (diagErr) {
+    log.error("DIAGNOSTIC_ENTRY_INSERT_FAILED", {
+      group,
+      err: diagErr,
+      message: diagErr.message,
+      code: diagErr.code,
+    });
+  }
+
   const results = await Promise.allSettled(
     paths.map(async (path) => {
       const t0 = Date.now();


### PR DESCRIPTION
## Summary

Adds a single AWAITED INSERT at the top of \`app/api/cron/_dispatch/[group]/route.ts\` GET handler. This is the final diagnostic to close P0-1.

## Why

Two remaining hypotheses for cron silence after 5 attempted fixes:

**A.** Vercel serves a cached 200 without invoking the route handler at all → diagnostic write WON'T land + nothing in Sentry.

**B.** Handler runs but supabase writes silently fail for some reason → diagnostic write WON'T land + \`DIAGNOSTIC_ENTRY_INSERT_FAILED\` will fire to Sentry with the actual error.

Either result is unambiguous and tells us what to fix.

## Plan

- [ ] Merge → deploy → wait for next every-5m cron fire (~5min)
- [ ] Query \`cron_run_log WHERE name='_diagnostic:every-5m'\` — if rows land, dispatcher IS executing
- [ ] If no rows AND no Sentry events → hypothesis A (Vercel caching). Action: add \`Cache-Control: no-store, no-cache\` header + \`export const revalidate = 0\` and re-deploy
- [ ] If no rows BUT Sentry events fire → hypothesis B (silent supabase failure). Action: read the error and ship the real fix
- [ ] Cleanup PR removes the diagnostic once answer is in

## Sprint context

- Sprint 1 final layer of P0-1
- Audit ref: §9.1
- Effort: 5 min
- Cleanup: separate follow-up PR

Refs: #221, #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>