### PR TITLE
fix(invest/listings): unify category filter, kill taxonomy fork

### DIFF
--- a/__tests__/lib/listing-url.test.ts
+++ b/__tests__/lib/listing-url.test.ts
@@ -21,8 +21,11 @@ describe("categoryForListing", () => {
     ["farmland", "farmland"],
     ["franchise", "franchise"],
     ["fund", "funds"],
+    ["hydrogen", "hydrogen"],
     ["mining", "mining"],
+    ["oil_gas", "oil-gas"],
     ["startup", "startups"],
+    ["uranium", "uranium"],
   ])("maps vertical %s to slug %s", (vertical, slug) => {
     expect(categoryForListing({ vertical, sub_category: undefined })).toBe(slug);
   });

--- a/__tests__/lib/taxonomy-consistency.test.ts
+++ b/__tests__/lib/taxonomy-consistency.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import {
+  VERTICAL_TO_CATEGORY,
+  FUND_SUB_TO_CATEGORY,
+} from "@/lib/listing-url";
+import {
+  getAllInvestCategories,
+  getAllInvestCategorySlugs,
+} from "@/lib/invest-categories";
+
+/**
+ * These tests guard against the taxonomy fork that caused the
+ * 2026-04-26 listing-filter UX bug: the badge bar rendered DB-vertical
+ * counts (uranium / oil_gas / hydrogen) that the pill row could not
+ * filter by, because invest-categories.ts had no entry for them.
+ *
+ * Concretely, every value in VERTICAL_TO_CATEGORY (and every value in
+ * FUND_SUB_TO_CATEGORY) MUST resolve to a real category slug declared
+ * in invest-categories.ts — otherwise the filter UI drops listings on
+ * the floor.
+ */
+describe("taxonomy consistency: listing-url ↔ invest-categories", () => {
+  const slugs = new Set(getAllInvestCategorySlugs());
+
+  it.each(Object.entries(VERTICAL_TO_CATEGORY))(
+    "DB vertical %s → category slug %s exists in invest-categories.ts",
+    (_vertical, categorySlug) => {
+      expect(slugs.has(categorySlug)).toBe(true);
+    },
+  );
+
+  it.each(Object.entries(FUND_SUB_TO_CATEGORY))(
+    "fund sub_category %s → category slug %s exists in invest-categories.ts",
+    (_sub, categorySlug) => {
+      expect(slugs.has(categorySlug)).toBe(true);
+    },
+  );
+
+  it("every category dbVertical value is a known InvestListingVertical", () => {
+    const known = new Set(Object.keys(VERTICAL_TO_CATEGORY));
+    for (const cat of getAllInvestCategories()) {
+      for (const v of cat.dbVerticals) {
+        expect(known.has(v)).toBe(true);
+      }
+    }
+  });
+
+  it("every commodity vertical with a dedicated category is mapped", () => {
+    // Uranium / oil-gas / hydrogen are the three categories the
+    // 2026-04-26 audit found missing from the pill row. Lock them in
+    // so a future refactor can't silently drop them again.
+    const required = ["uranium", "oil-gas", "hydrogen"];
+    for (const slug of required) {
+      expect(slugs.has(slug)).toBe(true);
+      // …and at least one DB vertical must route to that slug.
+      const matchingVerticals = Object.entries(VERTICAL_TO_CATEGORY)
+        .filter(([, cat]) => cat === slug)
+        .map(([v]) => v);
+      expect(matchingVerticals.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/app/invest/listings/page.tsx
+++ b/app/invest/listings/page.tsx
@@ -15,7 +15,7 @@ import { getAllInvestCategories } from "@/lib/invest-categories";
 import type { InvestmentListing } from "@/lib/types";
 import { logger } from "@/lib/logger";
 import InvestListingsClient from "@/components/InvestListingsClient";
-import { listingUrl } from "@/lib/listing-url";
+import { categoryForListing, listingUrl } from "@/lib/listing-url";
 
 const log = logger("invest-listings-all");
 
@@ -65,25 +65,24 @@ async function fetchAllActiveListings(): Promise<InvestmentListing[]> {
 export default async function InvestListingsPage() {
   const listings = await fetchAllActiveListings();
 
-  // Per-vertical counts for the summary strip above the marketplace
-  // grid. Counts reflect the currently-active listings, computed
-  // once on the server to avoid loading the client with the raw
-  // aggregation.
-  const verticalCounts: Record<string, number> = {};
+  // ── Single source of truth for the category filter ──
+  // Counts are computed using `categoryForListing()` — the same
+  // mapping the active filter uses — so what users see on the tab
+  // matches what the grid shows when they click. This deliberately
+  // replaces the prior dual UI (DB-vertical badge bar + hard-coded
+  // pill row) which produced inconsistent counts and missing
+  // categories. Categories with zero listings remain visible so the
+  // taxonomy stays stable across loads (dimmed in the UI).
+  const categoryCounts: Record<string, number> = {};
   for (const l of listings) {
-    const v = l.vertical as string;
-    if (!v) continue;
-    verticalCounts[v] = (verticalCounts[v] || 0) + 1;
+    const cat = categoryForListing(l);
+    categoryCounts[cat] = (categoryCounts[cat] ?? 0) + 1;
   }
-  const sortedCounts = Object.entries(verticalCounts).sort(
-    ([, a], [, b]) => b - a,
-  );
-
-  // Category tabs from invest-categories config
   const allCategories = getAllInvestCategories();
   const categoryTabs = allCategories.map((c) => ({
     slug: c.slug,
     label: c.label,
+    count: categoryCounts[c.slug] ?? 0,
   }));
 
   // ── JSON-LD: ItemList ──
@@ -198,34 +197,12 @@ export default async function InvestListingsPage() {
           </div>
         </div>
 
-        {/* Per-vertical count strip — live counts from the DB */}
-        {sortedCounts.length > 0 && (
-          <div className="container-custom max-w-6xl mb-4">
-            <div className="bg-white border border-slate-200 rounded-xl p-4">
-              <p className="text-[10px] font-bold uppercase tracking-wide text-slate-500 mb-3">
-                Active listings by vertical
-              </p>
-              <div className="flex flex-wrap gap-2">
-                {sortedCounts.map(([slug, count]) => (
-                  <Link
-                    key={slug}
-                    href={`/invest/${slug}/listings`}
-                    className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-slate-50 hover:bg-amber-50 border border-slate-200 hover:border-amber-200 transition-colors text-xs"
-                  >
-                    <span className="font-semibold text-slate-700 capitalize">
-                      {slug.replace(/-/g, " ")}
-                    </span>
-                    <span className="font-extrabold text-amber-700 tabular-nums">
-                      {count}
-                    </span>
-                  </Link>
-                ))}
-              </div>
-            </div>
-          </div>
-        )}
-
-        {/* Client component with filters + grid */}
+        {/* Single unified category filter + grid. The previous
+            "Active Listings by Vertical" summary strip lived here and
+            was removed in 2026-04 — it duplicated the tab bar with a
+            different (DB-vertical) taxonomy and confused users. The
+            tab bar inside InvestListingsClient now serves both roles:
+            navigation and live counts. */}
         <InvestListingsClient
           listings={listings}
           categories={categoryTabs}

--- a/components/InvestListingCard.tsx
+++ b/components/InvestListingCard.tsx
@@ -82,7 +82,11 @@ export default function InvestListingCard({
           </div>
         )}
 
-        {/* Top-left badges (Featured / pick) */}
+        {/* Top-left badges — Featured (gold) is the only attention-grabbing
+            badge on the image. Compliance status (FIRB / SIV) was previously
+            rendered as competing top-right overlays; it now sits inline in
+            the card body as neutral text so the image hero isn't visually
+            crowded. See visual-hierarchy fix in the 2026-04-26 audit. */}
         {(badge || listing.listing_type === "featured") && (
           <div className="absolute top-3 left-3 flex flex-wrap gap-1.5">
             {listing.listing_type === "featured" && (
@@ -93,22 +97,6 @@ export default function InvestListingCard({
             {badge && (
               <span className="bg-white/95 backdrop-blur text-slate-800 text-[0.62rem] font-extrabold uppercase tracking-wider px-2 py-1 rounded-md shadow-sm">
                 {badge}
-              </span>
-            )}
-          </div>
-        )}
-
-        {/* Top-right compliance badges */}
-        {(listing.firb_eligible || listing.siv_complying) && (
-          <div className="absolute top-3 right-3 flex gap-1.5">
-            {listing.firb_eligible && (
-              <span className="bg-blue-600 text-white text-[0.6rem] font-extrabold uppercase tracking-wider px-2 py-1 rounded-md shadow-sm">
-                FIRB
-              </span>
-            )}
-            {listing.siv_complying && (
-              <span className="bg-emerald-600 text-white text-[0.6rem] font-extrabold uppercase tracking-wider px-2 py-1 rounded-md shadow-sm">
-                SIV
               </span>
             )}
           </div>
@@ -140,8 +128,15 @@ export default function InvestListingCard({
           </p>
         )}
 
-        {/* Industry / sub-category pills */}
-        {(listing.industry || listing.sub_category) && (
+        {/* Industry / sub-category pills + neutral compliance indicators.
+            FIRB / SIV were previously gold-blue/emerald top-right overlays
+            competing with Featured for attention; rendered inline here as
+            small neutral text-icons they communicate the same info without
+            disturbing the image hero or stealing focus from Featured. */}
+        {(listing.industry ||
+          listing.sub_category ||
+          listing.firb_eligible ||
+          listing.siv_complying) && (
           <div className="flex flex-wrap items-center gap-1 mb-3">
             {listing.industry && (
               <span className="text-[0.62rem] px-2 py-0.5 bg-slate-100 rounded-full font-semibold text-slate-600">
@@ -151,6 +146,22 @@ export default function InvestListingCard({
             {listing.sub_category && (
               <span className="text-[0.62rem] px-2 py-0.5 bg-slate-100 rounded-full font-semibold text-slate-600 capitalize">
                 {listing.sub_category.replace(/_/g, " ")}
+              </span>
+            )}
+            {listing.firb_eligible && (
+              <span
+                className="inline-flex items-center gap-0.5 text-[0.62rem] px-2 py-0.5 bg-slate-50 border border-slate-200 rounded-full font-semibold text-slate-600"
+                title="Foreign Investment Review Board eligible"
+              >
+                <span aria-hidden="true">✓</span> FIRB-eligible
+              </span>
+            )}
+            {listing.siv_complying && (
+              <span
+                className="inline-flex items-center gap-0.5 text-[0.62rem] px-2 py-0.5 bg-slate-50 border border-slate-200 rounded-full font-semibold text-slate-600"
+                title="Significant Investor Visa compliant"
+              >
+                <span aria-hidden="true">✓</span> SIV-complying
               </span>
             )}
           </div>

--- a/components/InvestListingsClient.tsx
+++ b/components/InvestListingsClient.tsx
@@ -7,9 +7,17 @@ import { categoryForListing } from "@/lib/listing-url";
 import InvestListingCard from "@/components/InvestListingCard";
 
 // ─── Props ───────────────────────────────────────────────────────────
+export interface CategoryTab {
+  slug: string;
+  label: string;
+  /** Optional pre-computed listing count for this category. When provided,
+   *  shown inline on the tab. Pass 0 (or omit) to suppress the count chip. */
+  count?: number;
+}
+
 export interface InvestListingsClientProps {
   listings: InvestmentListing[];
-  categories: { slug: string; label: string }[];
+  categories: CategoryTab[];
   initialCategory?: string;
   initialSubcategory?: string;
   /**
@@ -32,6 +40,9 @@ export interface InvestListingsClientProps {
 }
 
 // ─── Category colors (pill styling) ─────────────────────────────────
+// Keyed by canonical category slug. New verticals (uranium, oil-gas,
+// hydrogen) added here MUST also be reflected in lib/invest-categories.ts
+// and lib/listing-url.ts to keep the taxonomy aligned.
 const CATEGORY_COLORS: Record<
   string,
   { bg: string; text: string; ring: string }
@@ -39,6 +50,9 @@ const CATEGORY_COLORS: Record<
   all: { bg: "bg-slate-100", text: "text-slate-700", ring: "ring-slate-300" },
   "buy-business": { bg: "bg-blue-100", text: "text-blue-700", ring: "ring-blue-300" },
   mining: { bg: "bg-amber-100", text: "text-amber-700", ring: "ring-amber-300" },
+  uranium: { bg: "bg-yellow-100", text: "text-yellow-800", ring: "ring-yellow-300" },
+  "oil-gas": { bg: "bg-stone-200", text: "text-stone-800", ring: "ring-stone-400" },
+  hydrogen: { bg: "bg-sky-100", text: "text-sky-700", ring: "ring-sky-300" },
   farmland: { bg: "bg-green-100", text: "text-green-700", ring: "ring-green-300" },
   "commercial-property": { bg: "bg-slate-100", text: "text-slate-700", ring: "ring-slate-400" },
   franchise: { bg: "bg-purple-100", text: "text-purple-700", ring: "ring-purple-300" },
@@ -267,11 +281,27 @@ export default function InvestListingsClient({
     });
   }
 
-  // All category tabs (prepend "All")
-  const tabs = useMemo(
-    () => [{ slug: "all", label: "All" }, ...categories],
-    [categories],
-  );
+  // All category tabs (prepend "All"). When counts are provided, the
+  // "All" tab shows the total of every category's listings — i.e. the
+  // unfiltered universe — so users can see at a glance how broad the
+  // page is before narrowing down.
+  const tabs = useMemo<CategoryTab[]>(() => {
+    const allCount = categories.reduce(
+      (sum, c) => sum + (c.count ?? 0),
+      0,
+    );
+    return [
+      { slug: "all", label: "All", count: allCount > 0 ? allCount : undefined },
+      ...categories,
+    ];
+  }, [categories]);
+
+  // When a category is active, surface its label in the sub-category
+  // header so users always know what bucket they're narrowing within.
+  const activeCategoryLabel = useMemo(() => {
+    if (activeCategory === "all") return "";
+    return prettyCategory(activeCategory, categories);
+  }, [activeCategory, categories]);
 
   return (
     <div>
@@ -290,33 +320,64 @@ export default function InvestListingsClient({
         </div>
       )}
 
-      {/* ── Sticky category tab bar — global page only ── */}
+      {/* ── Sticky category filter — single source of truth ──
+           Replaces the previous "Active Listings by Vertical" badge
+           bar + duplicate pill row. Each tab shows the live count
+           inline so users can see at a glance which categories have
+           listings before they click. The active tab is highlighted
+           with the category's own colour theme + ring; inactive tabs
+           with zero listings are dimmed but kept visible so the
+           taxonomy stays consistent across loads. */}
       {!lockedCategory && (
-        <div className="sticky top-0 z-20 bg-white/95 backdrop-blur border-b border-slate-200">
+        <nav
+          aria-label="Filter listings by category"
+          className="sticky top-0 z-20 bg-white/95 backdrop-blur border-b border-slate-200"
+        >
           <div className="container-custom overflow-x-auto scrollbar-hide">
-            <div className="flex gap-1.5 py-2.5 min-w-max">
+            <div
+              role="tablist"
+              className="flex gap-1.5 py-2.5 min-w-max"
+            >
               {tabs.map((tab) => {
                 const isActive = tab.slug === activeCategory;
                 const colors = CATEGORY_COLORS[tab.slug] ?? CATEGORY_COLORS.all;
+                const hasCount = typeof tab.count === "number";
+                const isEmpty = hasCount && tab.count === 0;
                 return (
                   <button
                     key={tab.slug}
+                    role="tab"
+                    aria-selected={isActive}
                     onClick={() =>
                       setParam({ category: tab.slug === "all" ? "" : tab.slug, sub: "" })
                     }
-                    className={`whitespace-nowrap rounded-full px-3.5 py-1.5 text-xs font-semibold transition-all ${
+                    className={`whitespace-nowrap inline-flex items-center gap-1.5 rounded-full px-3.5 py-1.5 text-xs font-semibold transition-all ${
                       isActive
-                        ? `${colors.bg} ${colors.text} ring-1 ${colors.ring}`
-                        : "text-slate-500 hover:bg-slate-50 hover:text-slate-700"
+                        ? `${colors.bg} ${colors.text} ring-2 ${colors.ring} shadow-sm`
+                        : isEmpty
+                          ? "text-slate-300 hover:bg-slate-50"
+                          : "text-slate-500 hover:bg-slate-50 hover:text-slate-700"
                     }`}
                   >
-                    {tab.label}
+                    <span>{tab.label}</span>
+                    {hasCount && tab.count! > 0 && (
+                      <span
+                        className={`tabular-nums text-[10px] font-extrabold rounded-full px-1.5 py-0.5 ${
+                          isActive
+                            ? "bg-white/70"
+                            : "bg-slate-100 text-slate-600"
+                        }`}
+                        aria-label={`${tab.count} listings`}
+                      >
+                        {tab.count}
+                      </span>
+                    )}
                   </button>
                 );
               })}
             </div>
           </div>
-        </div>
+        </nav>
       )}
 
       {/* ── Sticky filter toolbar — visible as user scrolls. ──
@@ -453,11 +514,13 @@ export default function InvestListingsClient({
       <div className="container-custom py-5 md:py-8">
         {/* Sub-category pills — only meaningful when a single category
             is selected. Collapsed into a compact chip row with a
-            visible label so readers know what the pills narrow. */}
+            visible label so readers know what the pills narrow. The
+            header surfaces the active category name so users always
+            know which bucket they're refining. */}
         {subCategories.length > 0 && (
           <div className="mb-5">
             <p className="text-[11px] font-semibold uppercase tracking-wide text-slate-500 mb-1.5">
-              Narrow by type
+              Narrow {activeCategoryLabel ? `${activeCategoryLabel} ` : ""}by type
             </p>
             <div className="flex flex-wrap gap-1.5">
               {subCategories.map((sub) => {

--- a/docs/audits/2026-04-26-filter-ux-inconsistency.md
+++ b/docs/audits/2026-04-26-filter-ux-inconsistency.md
@@ -1,0 +1,60 @@
+# Filter UX inconsistency audit — 2026-04-26
+
+Status: **P1 fix landed for `/invest/listings`.** Other affected pages are documented as follow-ups below.
+
+## What broke
+
+`/invest/listings?category=farmland` rendered two filter UIs reading from two different sources:
+
+- **"Active Listings by Vertical" badge bar** — live aggregation of `investment_listings.vertical` (DB column). Showed 11 verticals with counts including Uranium (12), Oil Gas (12), Hydrogen (10).
+- **Pill row** — hard-coded `getAllInvestCategories()` from `lib/invest-categories.ts`. Showed 12 categories including "Alternatives / Private Credit / Infrastructure" (which had zero listings in the badge bar).
+
+Result:
+- ~34 listings (uranium + oil_gas + hydrogen) appeared in the badge bar but could not be reached via the pill row.
+- Three pill-row categories (alternatives / private-credit / infrastructure) had no live counts in the badge bar.
+- Users clicking the badge bar were sent to `/invest/{slug}/listings` deep-links that 404 for the three commodity verticals.
+
+## Root cause
+
+A taxonomy fork: `lib/listing-url.ts::VERTICAL_TO_CATEGORY` had no mapping for `uranium / oil_gas / hydrogen`, so listings carrying those `vertical` values fell through to the default and never matched any pill-row category. `invest-categories.ts` likewise had no top-level entries for them — uranium existed only as a sub-category of mining.
+
+## What was fixed in this PR
+
+- **Single source of truth**: `lib/invest-categories.ts` is now the canonical category list for filter UIs. Three new top-level entries added: `uranium`, `oil-gas`, `hydrogen`, each with full SEO metadata, sub-categories, sections, and FAQs.
+- **Type alignment**: `InvestListingVertical` (in `lib/types.ts`) gained `'uranium' | 'oil_gas' | 'hydrogen'` so DB values match the type.
+- **Mapping completed**: `VERTICAL_TO_CATEGORY` in `lib/listing-url.ts` maps the three new verticals to their canonical slugs.
+- **Unified filter UI**: the `/invest/listings` page now renders one filter — the tab bar inside `InvestListingsClient`. The redundant "Active Listings by Vertical" badge bar was removed. The tab bar now shows live counts inline, applies each category's colour theme, and dims categories with zero listings (so the taxonomy stays stable across loads).
+- **Header context**: the sub-category strip now reads "Narrow Farmland by type" (etc.) instead of the bare "Narrow by type".
+- **Card visual hierarchy**: FIRB and SIV badges moved from competing top-right overlays on the image to neutral inline text-pills in the card body. Featured (gold) is now the only attention-grabbing badge on the image hero.
+- **Taxonomy regression guard**: new `__tests__/lib/taxonomy-consistency.test.ts` fails loudly if a future refactor adds a `VERTICAL_TO_CATEGORY` mapping without a matching `invest-categories.ts` entry, or drops uranium/oil-gas/hydrogen.
+
+## Follow-ups (not in this PR)
+
+The same anti-pattern (filter UI rendering from a hard-coded list separate from data) exists on these pages, but the user impact is lower because each page's filter is internally consistent — there's no taxonomy fork between two competing UIs on the same page. Recommend separate atomic PRs:
+
+| Page | Source | Notes |
+|---|---|---|
+| `/advisors`, `/advisors/[type]` | `PROFESSIONAL_TYPE_LABELS` in `lib/types.ts` (24 hard-coded types) | `app/advisors/AdvisorsClient.tsx:24-33` |
+| `/articles`, `/articles/[category]` | `CATEGORY_COLORS` + `CATEGORY_LABELS` hard-coded in `app/articles/page.tsx:31-61` | 13 hard-coded entries |
+| `/glossary` | DB query for categories, but `CATEGORY_ICONS` map hard-coded | `app/glossary/page.tsx:56-68` |
+| `/property/listings` | Hard-coded `PROPERTY_TYPES` (3 entries) | `app/property/listings/page.tsx:46-50` |
+| Header / Footer / SearchOverlay / Navigation | Each maintains its own Uranium / Oil Gas / Hydrogen link list | Not a filter bug — but represents the same taxonomy duplication. Consider migrating to `LISTING_VERTICALS` from `lib/listing-verticals.ts`. |
+
+`/invest/page.tsx`, `/invest/[slug]/listings`, `/invest/buy-business/listings` (etc.) all read from the same `getAllInvestCategories()` source as `/invest/listings`, so they benefit from the same fix without separate edits.
+
+## CLAUDE.md note
+
+`CLAUDE.md` line 51 claims `lib/verticals.ts` is the single source of truth for "vertical config (pillar pages, categories)." That's only true for **pillar pages** (broker / financial-product hubs: share-trading, crypto, super, etc.), not for **investment marketplace categories**. Three modules co-exist and shouldn't be conflated:
+
+- `lib/verticals.ts` — 9 broker/pillar verticals
+- `lib/listing-verticals.ts` — 14 listing/marketplace verticals (slugs + nav metadata)
+- `lib/invest-categories.ts` — 14 listing categories (filter UI source + landing-page SEO content)
+
+Worth a follow-up CLAUDE.md edit to make the distinction explicit.
+
+## SEO impact
+
+- No URL changes. All existing `/invest/{category}/listings` and `/invest/{category}` paths continue to work.
+- New canonical pages: `/invest/uranium`, `/invest/oil-gas`, `/invest/hydrogen` already existed as hub pages and remain unchanged.
+- New JSON-LD: each new category in `invest-categories.ts` ships with title, h1, metaDescription, intro, sections, faqs — picked up by existing landing-page templates.
+- `revalidate = 3600` preserved on `/invest/listings`.

--- a/lib/invest-categories.ts
+++ b/lib/invest-categories.ts
@@ -301,6 +301,237 @@ const categories: InvestCategory[] = [
     ],
   },
 
+  // ─── Uranium ───
+  {
+    slug: "uranium",
+    label: "Uranium",
+    dbVerticals: ["uranium"],
+    color: {
+      bg: "bg-yellow-50",
+      border: "border-yellow-200",
+      text: "text-yellow-800",
+      accent: "bg-yellow-600",
+      gradient: "from-yellow-50 to-white",
+    },
+    icon: "atom",
+    title: `Uranium Investment Opportunities in Australia (${yr})`,
+    h1: "Uranium Investment Opportunities in Australia",
+    metaDescription: `Invest in Australian uranium — ASX producers, ISR projects, sector ETFs and exploration plays. ${upd}.`,
+    intro: `Australia holds the world's largest uranium reserves and supplies roughly 10% of global production. With small modular reactors and the global nuclear renaissance lifting long-term demand, ASX-listed uranium plays span from established producers to advanced explorers.`,
+    sections: [
+      {
+        heading: "Why Invest in Uranium Now",
+        body: "Uranium spot prices have re-rated significantly since 2022 as utilities re-contract for the next decade and emerging nuclear demand from data centres and SMRs adds new structural buyers. Australian deposits — particularly in South Australia and the Northern Territory — offer Tier-1 grade with established regulatory pathways.",
+      },
+      {
+        heading: "Ways to Get Uranium Exposure",
+        body: "Direct project equity (ISR producers, advanced explorers), ASX-listed producers and developers, physical-uranium trusts, and broad nuclear-energy ETFs. Royalty streams over producing operations offer passive yield with reduced operational risk.",
+      },
+    ],
+    faqs: [
+      {
+        question: "Where can uranium be mined in Australia?",
+        answer: "South Australia (Olympic Dam, Beverley, Four Mile, Honeymoon) and the Northern Territory permit uranium mining. Western Australia lifted its ban in 2024. NSW, Victoria, and Queensland maintain state moratoriums. Federal export oversight applies to all production.",
+      },
+      {
+        question: "What's the cheapest way to get uranium exposure?",
+        answer: "ASX-listed uranium ETFs and major producers (BHP, Paladin Energy, Boss Energy) provide liquid exposure for any size investment. Physical-uranium trusts (like SPUT and Yellow Cake) track the metal directly. Direct project equity typically requires $250K+ minimum cheques.",
+      },
+      {
+        question: "Are uranium investments ESG-compliant?",
+        answer: "The EU Taxonomy classified nuclear as a transitional sustainable activity in 2022, and most major ESG frameworks now recognise uranium's role in clean baseload generation. Many institutional ESG funds are reversing previous uranium exclusions on energy-transition grounds.",
+      },
+    ],
+    subcategories: [
+      {
+        slug: "producers",
+        label: "Producers",
+        dbValue: "producer",
+        title: `ASX Uranium Producers — Investment Listings (${yr})`,
+        h1: "ASX Uranium Producers",
+        metaDescription: `Browse listings of producing Australian uranium operations and ASX-listed uranium producers. ${upd}.`,
+        intro: "Active uranium producers offer near-term cash flow leverage to spot prices, with operating mines in SA and NT ramping production into a tightening market.",
+        faqs: [
+          { question: "Who are Australia's main uranium producers?", answer: "BHP (Olympic Dam), Boss Energy (Honeymoon), and Heathgate Resources (Beverley) operate producing mines. Paladin Energy restarted Langer Heinrich in Namibia and is advancing Australian assets." },
+        ],
+      },
+      {
+        slug: "explorers",
+        label: "Explorers & Developers",
+        dbValue: "explorer",
+        title: `Australian Uranium Explorers & Developers (${yr})`,
+        h1: "Australian Uranium Explorers & Developers",
+        metaDescription: `Investment opportunities across Australian uranium explorers and pre-production developers. ${upd}.`,
+        intro: "Pre-production uranium plays offer leverage to a sustained spot recovery — definitive feasibility studies, permitting milestones, and offtake announcements typically catalyse re-rates.",
+        faqs: [
+          { question: "What's the risk of investing in uranium explorers?", answer: "Pre-revenue explorers carry high binary risk: dilution at unfavourable prices, permitting delays, and discovery risk. Diversification across 4-6 names or a thematic ETF reduces single-name exposure." },
+        ],
+      },
+      {
+        slug: "etfs",
+        label: "Sector ETFs",
+        dbValue: "etf",
+        title: `Australian Uranium ETFs and Index Products (${yr})`,
+        h1: "Australian Uranium & Nuclear-Energy ETFs",
+        metaDescription: `Browse uranium and nuclear-energy ETFs available to Australian investors. ${upd}.`,
+        intro: "ETFs spread single-name risk across producers, developers, and physical uranium — a sensible entry point for most retail investors.",
+        faqs: [
+          { question: "Which uranium ETFs are available in Australia?", answer: "URNM (Sprott Uranium Miners), URA (Global X), and Betashares' nuclear-energy products are available via local brokers and CHESS-sponsored access." },
+        ],
+      },
+    ],
+  },
+
+  // ─── Oil & Gas ───
+  {
+    slug: "oil-gas",
+    label: "Oil & Gas",
+    dbVerticals: ["oil_gas"],
+    color: {
+      bg: "bg-stone-50",
+      border: "border-stone-200",
+      text: "text-stone-700",
+      accent: "bg-stone-700",
+      gradient: "from-stone-50 to-white",
+    },
+    icon: "fuel",
+    title: `Oil & Gas Investment Opportunities in Australia (${yr})`,
+    h1: "Oil & Gas Investment Opportunities in Australia",
+    metaDescription: `Invest in Australian oil & gas — LNG, exploration, refineries, midstream infrastructure and royalties. ${upd}.`,
+    intro: `Australia is one of the world's largest LNG exporters, with significant offshore and onshore gas plays across the North West Shelf, Browse Basin, Bass Strait, and Cooper Basin. Investment opportunities range from explorer equity to producing royalty streams and infrastructure stakes.`,
+    sections: [
+      {
+        heading: "Australian Oil & Gas at a Glance",
+        body: "LNG remains the highest-value Australian gas export, with major projects on the North West Shelf, Gorgon, Wheatstone, Ichthys, and Prelude FLNG. Domestic gas demand is structurally tight on the east coast, supporting prices for new conventional and unconventional supply.",
+      },
+      {
+        heading: "Investment Pathways",
+        body: "Direct working interests in producing or developing fields, ASX-listed E&P equities (Woodside, Santos, Beach Energy), midstream infrastructure investments (pipelines, processing), and royalty/production-payment structures. Each carries different risk-return profiles.",
+      },
+    ],
+    faqs: [
+      {
+        question: "Is oil & gas a good investment in 2026?",
+        answer: "Demand is more durable than headlines suggest — global oil consumption is still growing, gas underwrites grid reliability as renewables scale, and underinvestment since 2014 has tightened global supply. Energy-transition risk is real but priced into producer multiples.",
+      },
+      {
+        question: "How can I invest in Australian LNG?",
+        answer: "Liquid public exposure via Woodside Energy (WDS) and Santos (STO) on the ASX. Working-interest stakes in projects typically require institutional-scale cheques. Specialist energy funds offer diversified private-market exposure.",
+      },
+      {
+        question: "What's a royalty stream in oil & gas?",
+        answer: "A royalty entitles the holder to a percentage of revenue from a producing field, paid before operating costs and capex. Royalties offer leveraged exposure to commodity prices with no operational risk — but face depletion as reserves are produced.",
+      },
+    ],
+    subcategories: [
+      {
+        slug: "lng",
+        label: "LNG",
+        dbValue: "lng",
+        title: `Australian LNG Investments (${yr})`,
+        h1: "Australian LNG Project Investments",
+        metaDescription: `Investment opportunities across Australian LNG projects — North West Shelf, Gorgon, Ichthys, Prelude. ${upd}.`,
+        intro: "Australia hosts seven operating LNG export plants with combined capacity of ~88 Mtpa — second only to the United States.",
+        faqs: [
+          { question: "Who operates Australian LNG projects?", answer: "Woodside, Chevron, Shell, Inpex, ConocoPhillips, and Santos operate the seven major LNG plants. Stakes are typically held via long-term JV agreements." },
+        ],
+      },
+      {
+        slug: "exploration",
+        label: "Exploration & Development",
+        dbValue: "exploration",
+        title: `Australian Oil & Gas Exploration Listings (${yr})`,
+        h1: "Australian Oil & Gas Exploration & Development",
+        metaDescription: `Investment opportunities in Australian oil & gas exploration permits and field developments. ${upd}.`,
+        intro: "Exploration and appraisal plays offer high-leverage exposure to discovery and development outcomes — with commensurate binary risk.",
+        faqs: [
+          { question: "Where are the most active exploration regions?", answer: "Beetaloo, Cooper, Bowen-Surat, Browse, Carnarvon, and Bonaparte basins remain the most actively explored, with new acreage releases periodically through the offshore acreage round." },
+        ],
+      },
+      {
+        slug: "midstream",
+        label: "Midstream & Infrastructure",
+        dbValue: "midstream",
+        title: `Australian Oil & Gas Infrastructure Investments (${yr})`,
+        h1: "Australian Oil & Gas Midstream & Infrastructure",
+        metaDescription: `Pipelines, processing and storage infrastructure investment opportunities across Australia. ${upd}.`,
+        intro: "Midstream infrastructure offers stable, regulated-style cashflows — tolling on volumes rather than commodity-price exposure.",
+        faqs: [
+          { question: "How do midstream returns compare to E&P?", answer: "Midstream typically targets 8-12% IRRs with much lower volatility than upstream E&P. Returns are driven by throughput contracts and tariff escalators rather than oil price." },
+        ],
+      },
+    ],
+  },
+
+  // ─── Hydrogen ───
+  {
+    slug: "hydrogen",
+    label: "Hydrogen",
+    dbVerticals: ["hydrogen"],
+    color: {
+      bg: "bg-sky-50",
+      border: "border-sky-200",
+      text: "text-sky-700",
+      accent: "bg-sky-600",
+      gradient: "from-sky-50 to-white",
+    },
+    icon: "droplets",
+    title: `Hydrogen Investment Opportunities in Australia (${yr})`,
+    h1: "Hydrogen Investment Opportunities in Australia",
+    metaDescription: `Invest in Australian hydrogen — green H2, fuel cells, production hubs and export-scale projects. ${upd}.`,
+    intro: `Australia's hydrogen industry is scaling fast, backed by federal Hydrogen Headstart funding and state strategies in QLD, WA, and SA. Opportunities span large-scale green hydrogen export hubs, regional production-and-distribution projects, fuel-cell technology, and pure-play ASX equities.`,
+    sections: [
+      {
+        heading: "Why Hydrogen Matters",
+        body: "Hydrogen is the only zero-emission energy carrier capable of decarbonising heavy industry, long-haul freight, and seasonal energy storage. Australia has the renewable resources, deep-water ports, and trade relationships to become a top-3 hydrogen exporter by 2035.",
+      },
+      {
+        heading: "Investment Stages",
+        body: "Most hydrogen projects are still pre-FID. Investors can participate via early-stage project equity (highest risk/return), ASX-listed pure-plays and integrated energy companies, electrolyser technology vendors, or sector-specific funds.",
+      },
+    ],
+    faqs: [
+      {
+        question: "What is green hydrogen?",
+        answer: "Green hydrogen is produced by electrolysing water using renewable electricity — splitting H2O into H2 and O2 with zero direct emissions. It's distinguished from grey hydrogen (from fossil gas without capture) and blue hydrogen (with carbon capture).",
+      },
+      {
+        question: "Which Australian hydrogen projects are most advanced?",
+        answer: "CQ-H2 (Stanwell), Murchison Hydrogen Renewables, H2-Hub Gladstone, Western Green Energy Hub, and Hunter Valley Hydrogen Hub are at FEED or near FID. Hydrogen Headstart Round 1 selected two projects for $4B in production credits.",
+      },
+      {
+        question: "What returns are achievable in hydrogen?",
+        answer: "Early-stage project equity targets 15-25% IRRs but carries development and offtake risk. Late-stage infrastructure stakes are more institutional, targeting 8-12% IRRs with 20-30 year offtake contracts.",
+      },
+    ],
+    subcategories: [
+      {
+        slug: "production",
+        label: "Production & Hubs",
+        dbValue: "production",
+        title: `Australian Hydrogen Production Projects (${yr})`,
+        h1: "Australian Hydrogen Production & Hub Investments",
+        metaDescription: `Investment opportunities in Australian green hydrogen production projects and export hubs. ${upd}.`,
+        intro: "Australia's hydrogen production projects are scaling from pilot to gigawatt-scale, with export-focused hubs targeting Asian markets.",
+        faqs: [
+          { question: "How big are Australia's hydrogen ambitions?", answer: "Australia targets 30+ Mtpa of hydrogen production by 2050, equivalent to a top-3 global position. Federal and state programs combined have committed over $7B in support funding." },
+        ],
+      },
+      {
+        slug: "fuel-cells",
+        label: "Fuel Cells & Technology",
+        dbValue: "fuel_cell",
+        title: `Hydrogen Fuel Cell & Technology Investments (${yr})`,
+        h1: "Hydrogen Fuel Cell & Technology Investments",
+        metaDescription: `ASX and private hydrogen technology companies — fuel cells, electrolysers, storage. ${upd}.`,
+        intro: "Hardware suppliers — electrolysers, fuel cells, compression and storage — capture value across all production projects.",
+        faqs: [
+          { question: "Are there ASX-listed hydrogen technology companies?", answer: "Yes — Hazer Group, Province Resources, Pure Hydrogen Corporation and others trade on the ASX. Specialist ETFs offer diversified exposure to global hydrogen-economy names." },
+        ],
+      },
+    ],
+  },
+
   // ─── Farmland ───
   {
     slug: "farmland",

--- a/lib/listing-url.ts
+++ b/lib/listing-url.ts
@@ -11,8 +11,11 @@ export const VERTICAL_TO_CATEGORY: Record<InvestListingVertical, string> = {
   farmland: "farmland",
   franchise: "franchise",
   fund: "funds",
+  hydrogen: "hydrogen",
   mining: "mining",
+  oil_gas: "oil-gas",
   startup: "startups",
+  uranium: "uranium",
 };
 
 /**

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1317,8 +1317,11 @@ export type InvestListingVertical =
   | 'farmland'
   | 'franchise'
   | 'fund'
+  | 'hydrogen'
   | 'mining'
-  | 'startup';
+  | 'oil_gas'
+  | 'startup'
+  | 'uranium';
 
 export interface InvestmentListing {
   id: number;


### PR DESCRIPTION
## Summary

`/invest/listings` rendered two filter UIs from two different sources and missed ~34 live listings.

- **Badge bar** — live DB aggregation of `investment_listings.vertical`. Showed Uranium (12), Oil Gas (12), Hydrogen (10).
- **Pill row** — hard-coded `getAllInvestCategories()` from `lib/invest-categories.ts`. Could not filter to those three because there were no entries and no `VERTICAL_TO_CATEGORY` mappings. Conversely, it showed Alternatives / Private Credit / Infrastructure with zero live counts.

This PR makes `lib/invest-categories.ts` the single source of truth and replaces the dual UI with one unified, count-aware filter.

## What changed

- **Taxonomy aligned**: 3 new top-level categories (`uranium`, `oil-gas`, `hydrogen`) with full SEO copy, sub-categories, sections, FAQs in `lib/invest-categories.ts`.
- **Type alignment**: `InvestListingVertical` extended; `VERTICAL_TO_CATEGORY` updated.
- **Counts on the server**: `categoryForListing()` is the single mapping — same one the active filter uses — so what the tab badge shows matches what the grid renders.
- **Unified filter**: tab bar now shows inline counts, applies each category's colour theme, dims zero-count categories, ARIA `tablist` semantics. Old "Active Listings by Vertical" badge bar removed.
- **Header context**: "Narrow by type" → "Narrow Farmland by type" when a category is active.
- **Card visual hierarchy**: FIRB / SIV moved from competing top-right overlays to neutral inline text-pills in the card body; Featured (gold) keeps the only attention-grabbing slot on the image hero.
- **Regression guard**: `__tests__/lib/taxonomy-consistency.test.ts` fails if a future refactor adds a `VERTICAL_TO_CATEGORY` value with no matching `invest-categories.ts` entry, or drops the three commodity categories.
- **Audit doc**: `docs/audits/2026-04-26-filter-ux-inconsistency.md` covers root cause, fix, follow-up pages, and the CLAUDE.md correction (`lib/verticals.ts` is *not* the SOT for listing categories — three modules co-exist and shouldn't be conflated).

## Follow-ups (separate PRs, documented in the audit)

Same hard-coded-list anti-pattern, lower priority because each is internally consistent on its own page:
- `/advisors` + `/advisors/[type]` — `PROFESSIONAL_TYPE_LABELS`
- `/articles` + `/articles/[category]` — `CATEGORY_COLORS` / `CATEGORY_LABELS`
- `/glossary` — hard-coded `CATEGORY_ICONS`
- `/property/listings` — `PROPERTY_TYPES`
- Header / Footer / SearchOverlay / Navigation — duplicated Uranium / Oil Gas / Hydrogen link lists; migrate to `LISTING_VERTICALS` from `lib/listing-verticals.ts`.

## SEO

- No URL changes. Existing `/invest/{category}/listings` and `/invest/{category}` paths preserved.
- New canonical category content (uranium / oil-gas / hydrogen) ships with full title / h1 / metaDescription / intro / sections / faqs picked up by the existing landing-page templates.
- `revalidate = 3600` preserved on `/invest/listings`.

## Test plan

- [x] `npm run type-check` — clean
- [x] `npm test -- listing-url taxonomy-consistency invest-categories` — 55/55 pass
- [x] `npm test -- listing-verticals invest-listing-scam-classifier investment-listings-query` — 46/46 pass (no regressions)
- [x] eslint clean on all changed files
- [ ] Vercel preview: verify `/invest/listings` shows single filter bar with counts, click Uranium filters to those listings, "Narrow Farmland by type" header appears on `?category=farmland`, FIRB/SIV badges inline in card body
- [ ] Vercel preview: verify `/invest/buy-business/listings` (locked-category page) still hides the global tab bar
- [ ] Vercel preview: verify `/invest/farmland/listings/{slug}` detail pages still work (URL mapping unchanged)

https://claude.ai/code/session_01HrS7uGqJnKTb8esGXBqHQH

---
_Generated by [Claude Code](https://claude.ai/code/session_01HrS7uGqJnKTb8esGXBqHQH)_