### PR TITLE
chore(quality): /review + /simplify cleanup for revenue-expansion hubs

### DIFF
--- a/app/dividends/calculator/FrankingCalculatorClient.tsx
+++ b/app/dividends/calculator/FrankingCalculatorClient.tsx
@@ -3,6 +3,7 @@
 import { useState, useMemo } from "react";
 import Link from "next/link";
 import Icon from "@/components/Icon";
+import { formatAUD } from "@/lib/currency";
 
 const TAX_RATES: Array<{ id: string; label: string; rate: number; isSmsf?: boolean; pension?: boolean }> = [
   { id: "0",        label: "0% — under threshold",   rate: 0 },
@@ -16,10 +17,6 @@ const TAX_RATES: Array<{ id: string; label: string; rate: number; isSmsf?: boole
 
 const CORPORATE_RATE = 0.30;
 
-function formatAUD(n: number): string {
-  return new Intl.NumberFormat("en-AU", { style: "currency", currency: "AUD", maximumFractionDigits: 2 }).format(n);
-}
-
 export default function FrankingCalculatorClient() {
   const [dividend, setDividend] = useState<number>(1_000);
   const [frankingPct, setFrankingPct] = useState<number>(100);
@@ -31,9 +28,8 @@ export default function FrankingCalculatorClient() {
     const frankingCredit = frankedPortion * (CORPORATE_RATE / (1 - CORPORATE_RATE));
     const grossedUp = dividend + frankingCredit;
     const taxOnGrossedUp = grossedUp * tr.rate;
-    const netTaxAfterOffset = taxOnGrossedUp - frankingCredit;
-    const refundOrTax = netTaxAfterOffset; // negative = refund
-    const netIncome = dividend - Math.max(0, refundOrTax) + Math.max(0, -refundOrTax);
+    const refundOrTax = taxOnGrossedUp - frankingCredit; // negative = refund
+    const netIncome = dividend - refundOrTax;
     return {
       tr,
       frankingCredit,
@@ -92,29 +88,29 @@ export default function FrankingCalculatorClient() {
           <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
             <div>
               <p className="text-[10px] uppercase tracking-wider font-extrabold text-slate-400">Franking credit</p>
-              <p className="text-lg md:text-xl font-extrabold mt-1">{formatAUD(calc.frankingCredit)}</p>
+              <p className="text-lg md:text-xl font-extrabold mt-1">{formatAUD(calc.frankingCredit, 2)}</p>
             </div>
             <div>
               <p className="text-[10px] uppercase tracking-wider font-extrabold text-slate-400">Grossed-up dividend</p>
-              <p className="text-lg md:text-xl font-extrabold mt-1">{formatAUD(calc.grossedUp)}</p>
+              <p className="text-lg md:text-xl font-extrabold mt-1">{formatAUD(calc.grossedUp, 2)}</p>
             </div>
             <div>
               <p className="text-[10px] uppercase tracking-wider font-extrabold text-slate-400">Tax on grossed-up</p>
-              <p className="text-lg md:text-xl font-extrabold mt-1">{formatAUD(calc.taxOnGrossedUp)}</p>
+              <p className="text-lg md:text-xl font-extrabold mt-1">{formatAUD(calc.taxOnGrossedUp, 2)}</p>
             </div>
             <div>
               <p className="text-[10px] uppercase tracking-wider font-extrabold" style={{ color: isRefund ? "#34D399" : "#F87171" }}>
                 {isRefund ? "Refund" : "Net tax"}
               </p>
               <p className="text-lg md:text-xl font-extrabold mt-1" style={{ color: isRefund ? "#34D399" : "#F87171" }}>
-                {formatAUD(Math.abs(calc.refundOrTax))}
+                {formatAUD(Math.abs(calc.refundOrTax), 2)}
               </p>
             </div>
           </div>
 
           <div className="mt-5 pt-5 border-t border-white/10">
             <p className="text-[10px] uppercase tracking-wider font-extrabold text-amber-400">Net after-tax income from this dividend</p>
-            <p className="text-3xl md:text-4xl font-extrabold mt-1" style={{ color: "#EAB308" }}>{formatAUD(calc.netIncome)}</p>
+            <p className="text-3xl md:text-4xl font-extrabold mt-1" style={{ color: "#EAB308" }}>{formatAUD(calc.netIncome, 2)}</p>
           </div>
         </div>
 
@@ -122,7 +118,7 @@ export default function FrankingCalculatorClient() {
         <div className="rounded-xl border border-slate-200 bg-slate-50 p-5">
           {calc.tr.pension ? (
             <p className="text-sm text-slate-700 leading-relaxed">
-              <strong className="text-emerald-700">SMSF pension phase:</strong> you receive <strong>{formatAUD(calc.frankingCredit)}</strong> as a cash refund from the ATO — even though the fund pays no tax. This is one of the most powerful SMSF tax benefits available to Australian retail investors. <Link href="/smsf" className="text-amber-700 hover:underline font-bold">Explore SMSF →</Link>
+              <strong className="text-emerald-700">SMSF pension phase:</strong> you receive <strong>{formatAUD(calc.frankingCredit, 2)}</strong> as a cash refund from the ATO — even though the fund pays no tax. This is one of the most powerful SMSF tax benefits available to Australian retail investors. <Link href="/smsf" className="text-amber-700 hover:underline font-bold">Explore SMSF →</Link>
             </p>
           ) : calc.tr.isSmsf ? (
             <p className="text-sm text-slate-700 leading-relaxed">

--- a/app/grants/eligibility-quiz/EligibilityQuizClient.tsx
+++ b/app/grants/eligibility-quiz/EligibilityQuizClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import Icon from "@/components/Icon";
 import HubLeadForm from "@/components/leads/HubLeadForm";
 
@@ -146,6 +146,7 @@ export default function EligibilityQuizClient() {
   const [step, setStep] = useState(0);
   const [answers, setAnswers] = useState<Answers>({});
   const [done, setDone] = useState(false);
+  const results = useMemo(() => (done ? evaluate(answers) : []), [done, answers]);
 
   function answer(q: Q, value: string) {
     const next = { ...answers, [q.id]: value };
@@ -164,7 +165,6 @@ export default function EligibilityQuizClient() {
   }
 
   if (done) {
-    const results = evaluate(answers);
     return (
       <div className="space-y-6">
         <div className="rounded-2xl border border-slate-200 bg-white p-6 md:p-8 shadow-sm">

--- a/app/lump-sum-investing/calculator/LumpSumCalculatorClient.tsx
+++ b/app/lump-sum-investing/calculator/LumpSumCalculatorClient.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useMemo } from "react";
 import HubLeadForm from "@/components/leads/HubLeadForm";
+import { formatAUD } from "@/lib/currency";
 
 const TAX_OPTIONS = [
   { id: "none",   label: "No tax (super pension)",  rate: 0 },
@@ -10,10 +11,6 @@ const TAX_OPTIONS = [
   { id: "37",     label: "37% marginal",            rate: 0.37 },
   { id: "45",     label: "45% marginal",            rate: 0.45 },
 ];
-
-function formatAUD(n: number): string {
-  return new Intl.NumberFormat("en-AU", { style: "currency", currency: "AUD", maximumFractionDigits: 0 }).format(n);
-}
 
 function project(initial: number, monthly: number, annualRate: number, years: number, taxRate: number) {
   const months = years * 12;

--- a/app/negative-gearing/calculator/NegativeGearingCalculatorClient.tsx
+++ b/app/negative-gearing/calculator/NegativeGearingCalculatorClient.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useMemo } from "react";
 import HubLeadForm from "@/components/leads/HubLeadForm";
+import { formatAUD } from "@/lib/currency";
 
 const TAX_RATES = [
   { label: "0% — under threshold", rate: 0 },
@@ -10,10 +11,6 @@ const TAX_RATES = [
   { label: "37%", rate: 0.37 },
   { label: "45%", rate: 0.45 },
 ];
-
-function formatAUD(n: number): string {
-  return new Intl.NumberFormat("en-AU", { style: "currency", currency: "AUD", maximumFractionDigits: 0 }).format(n);
-}
 
 export default function NegativeGearingCalculatorClient() {
   const [propertyValue, setPropertyValue] = useState<number>(850_000);
@@ -108,7 +105,7 @@ export default function NegativeGearingCalculatorClient() {
         </div>
 
         <p className="text-[11px] text-slate-500 leading-relaxed">
-          Estimate only. Excludes CGT on sale, vacancy, rate rises, and depreciation. Capital-growth assumptions are notoriously optimistic — model conservatively.
+          Estimate only. The 10-year projection assumes constant interest rates, costs, and tax bracket — none of which hold across a real holding period. Excludes CGT on sale, vacancy, rate rises and depreciation. Capital-growth assumptions are notoriously optimistic; model conservatively and stress-test against the next rate cycle.
         </p>
       </div>
 

--- a/app/sell-business/valuation/ValuationClient.tsx
+++ b/app/sell-business/valuation/ValuationClient.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useMemo } from "react";
 import HubLeadForm from "@/components/leads/HubLeadForm";
+import { formatAUD } from "@/lib/currency";
 
 type Industry = "retail" | "hospitality" | "professional" | "tech" | "manufacturing" | "trades" | "healthcare" | "other";
 
@@ -17,10 +18,6 @@ const INDUSTRIES: Array<{ id: Industry; label: string; ebitdaMin: number; ebitda
 ];
 
 type Method = "ebitda" | "revenue" | "asset";
-
-function formatAUD(n: number): string {
-  return new Intl.NumberFormat("en-AU", { style: "currency", currency: "AUD", maximumFractionDigits: 0 }).format(n);
-}
 
 export default function ValuationClient() {
   const [industry, setIndustry] = useState<Industry>("professional");

--- a/components/RdTaxCalculator.tsx
+++ b/components/RdTaxCalculator.tsx
@@ -3,6 +3,7 @@
 import { useState, useMemo } from "react";
 import Icon from "@/components/Icon";
 import HubLeadForm from "@/components/leads/HubLeadForm";
+import { formatAUD } from "@/lib/currency";
 
 const SMALL_CO_OFFSET = 0.435;   // refundable, < $20M turnover
 const LARGE_CO_OFFSET = 0.385;   // non-refundable, > $20M turnover (simplified)
@@ -18,14 +19,6 @@ const ELIGIBLE_ACTIVITIES: Array<{ id: string; label: string; eligible: boolean 
   { id: "content",       label: "Content writing or SEO",                              eligible: false },
   { id: "compliance",    label: "Regulatory compliance testing",                       eligible: false },
 ];
-
-function formatAUD(n: number): string {
-  return new Intl.NumberFormat("en-AU", {
-    style: "currency",
-    currency: "AUD",
-    maximumFractionDigits: 0,
-  }).format(n);
-}
 
 export default function RdTaxCalculator() {
   const [turnover, setTurnover] = useState<number>(2_000_000);

--- a/components/leads/HubLeadForm.tsx
+++ b/components/leads/HubLeadForm.tsx
@@ -2,6 +2,7 @@
 
 import { useState, type FormEvent, type ReactNode } from "react";
 import Icon from "@/components/Icon";
+import { isValidEmailClient, isDisposableEmail } from "@/lib/validate-email";
 
 type Intent = {
   need: string;
@@ -15,7 +16,11 @@ interface HubLeadFormProps {
   source: string;
   ctaLabel?: string;
   ctaIntro?: ReactNode;
-  /** Optional extra fields to capture (eg. company, dev_spend). Stored as part of source_page metadata. */
+  /**
+   * Optional domain-specific fields appended to source_page so they
+   * survive into lead routing (`source_page` is one of the columns
+   * the matching engine sees).
+   */
   extraFields?: Array<{ name: string; label: string; type?: "text" | "number"; required?: boolean }>;
   /** Show state selector. Defaults to true. */
   showState?: boolean;
@@ -40,7 +45,6 @@ export default function HubLeadForm({
   async function onSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
     setError(null);
-    setSubmitting(true);
 
     const fd = new FormData(e.currentTarget);
     const email = String(fd.get("email") || "").trim();
@@ -48,11 +52,26 @@ export default function HubLeadForm({
     const phone = String(fd.get("phone") || "").trim();
     const state = String(fd.get("state") || "").trim();
 
-    const extras: Record<string, string> = {};
+    if (!isValidEmailClient(email)) {
+      setError("Please enter a valid email address.");
+      return;
+    }
+    if (isDisposableEmail(email)) {
+      setError("Please use a real email address — disposable inboxes aren't supported.");
+      return;
+    }
+
+    setSubmitting(true);
+
+    // Domain-specific extras get appended to source_page so the
+    // server's matcher and analytics can see them without a schema
+    // change. Server route ignores anything else in the body.
+    const extras: string[] = [];
     for (const f of extraFields) {
       const v = String(fd.get(f.name) || "").trim();
-      if (v) extras[f.name] = v;
+      if (v) extras.push(`${f.name}=${v}`);
     }
+    const sourcePage = extras.length ? `${source}|${extras.join("|")}` : source;
 
     try {
       const res = await fetch("/api/submit-lead", {
@@ -65,11 +84,8 @@ export default function HubLeadForm({
           user_phone: phone || undefined,
           user_location_state: state || undefined,
           user_intent: intent,
-          source_page: source,
-          // honeypot field — bots will fill this; humans won't see it
+          source_page: sourcePage,
           website: String(fd.get("website") || ""),
-          // Capture extras as additional context
-          ...(Object.keys(extras).length ? { extra_metadata: extras } : {}),
         }),
       });
       const json = await res.json();

--- a/lib/currency.ts
+++ b/lib/currency.ts
@@ -84,6 +84,20 @@ export function formatCurrency(
 }
 
 /**
+ * Format a whole-dollar AUD amount. Convenience wrapper for the common
+ * case of "I have a number in dollars (not cents) and want the standard
+ * en-AU currency string". Default fraction digits = 0 (most calculators
+ * round to whole dollars in their UI).
+ */
+export function formatAUD(dollars: number, fractionDigits = 0): string {
+  return new Intl.NumberFormat("en-AU", {
+    style: "currency",
+    currency: "AUD",
+    maximumFractionDigits: fractionDigits,
+  }).format(dollars);
+}
+
+/**
  * Abbreviate large currency amounts — useful for tight mobile UIs.
  *
  *   $1,234      → $1.2k

--- a/scripts/seed-revenue-expansion.ts
+++ b/scripts/seed-revenue-expansion.ts
@@ -47,23 +47,15 @@ const LEAD_PRICING_ROWS: Array<{
 ];
 
 async function seedLeadPricing() {
-  let inserted = 0;
-  let skipped = 0;
-  for (const row of LEAD_PRICING_ROWS) {
-    const { data: existing } = await supabase
-      .from("lead_pricing")
-      .select("advisor_type")
-      .eq("advisor_type", row.advisor_type)
-      .maybeSingle();
-    if (existing) { skipped++; continue; }
-    const { error } = await supabase.from("lead_pricing").insert(row);
-    if (error) {
-      console.error(`  ! ${row.advisor_type}: ${error.message}`);
-      continue;
-    }
-    inserted++;
+  // Single bulk upsert is one round trip vs N×2 for the loop variant.
+  const { error, count } = await supabase
+    .from("lead_pricing")
+    .upsert(LEAD_PRICING_ROWS, { onConflict: "advisor_type", ignoreDuplicates: true, count: "exact" });
+  if (error) {
+    console.error(`  ! lead_pricing upsert: ${error.message}`);
+    return;
   }
-  console.log(`lead_pricing: ${inserted} inserted, ${skipped} already present`);
+  console.log(`lead_pricing: ${count ?? "?"} rows reconciled (existing rows untouched)`);
 }
 
 /* ─── Articles ───────────────────────────────────────────────────── */
@@ -390,42 +382,32 @@ const ARTICLES: ArticleSeed[] = [
 ];
 
 async function seedArticles() {
-  let inserted = 0;
-  let skipped = 0;
-  let errors = 0;
   const now = new Date().toISOString();
-  for (const a of ARTICLES) {
-    const { data: existing } = await supabase
-      .from("articles")
-      .select("slug")
-      .eq("slug", a.slug)
-      .maybeSingle();
-    if (existing) { skipped++; continue; }
-    const { error } = await supabase.from("articles").insert({
-      slug: a.slug,
-      title: a.title,
-      category: a.category,
-      tags: a.tags,
-      excerpt: a.excerpt,
-      read_time: a.read_time,
-      sections: a.sections,
-      author_name: AUTHOR_NAME,
-      status: "published",
-      evergreen: true,
-      content_type: a.content_type || "guide",
-      related_brokers: [],
-      published_at: now,
-      created_at: now,
-      updated_at: now,
-    });
-    if (error) {
-      console.error(`  ! ${a.slug}: ${error.message}`);
-      errors++;
-      continue;
-    }
-    inserted++;
+  const rows = ARTICLES.map((a) => ({
+    slug: a.slug,
+    title: a.title,
+    category: a.category,
+    tags: a.tags,
+    excerpt: a.excerpt,
+    read_time: a.read_time,
+    sections: a.sections,
+    author_name: AUTHOR_NAME,
+    status: "published",
+    evergreen: true,
+    content_type: a.content_type || "guide",
+    related_brokers: [],
+    published_at: now,
+    created_at: now,
+    updated_at: now,
+  }));
+  const { error, count } = await supabase
+    .from("articles")
+    .upsert(rows, { onConflict: "slug", ignoreDuplicates: true, count: "exact" });
+  if (error) {
+    console.error(`  ! articles upsert: ${error.message}`);
+    return;
   }
-  console.log(`articles: ${inserted} inserted, ${skipped} already present, ${errors} errors`);
+  console.log(`articles: ${count ?? "?"} rows reconciled (existing slugs untouched)`);
 }
 
 async function main() {


### PR DESCRIPTION
## Summary

Eight new revenue-expansion content hubs plus seed data — all static, build-clean, lead-capturing into the existing `/api/submit-lead` flow.

- **/grants** — R&D Tax Incentive, EMDG, Industry Growth Program, NSW MVP Ventures + a 5-question eligibility quiz and an embeddable refundable-offset calculator.
- **/smsf** — Five sub-pages added (setup, crypto, property, investment-strategy, checklist). `app/smsf/page.tsx` only had a sub-page nav-card section *appended* before the GAW footer — no restructure.
- **/sell-business** — Hub, EBITDA / revenue / asset-based valuation calculator, 12-month exit-readiness checklist.
- **/visa-investment** — Post-SIV (closed 31 July 2024) pathways: National Innovation Visa 858, 482/186, state nomination, 188C transition.
- **/dividends** — Hub, franking-credits explainer with worked examples & DTA reference, calculator covering personal and SMSF (incl. pension-phase) outcomes.
- **/negative-gearing** — Hub with metro worked example, gearing comparison, SMSF clarification + 10-year cash-flow calculator.
- **/lump-sum-investing** — Hub, redundancy guide, inheritance guide, compound-growth calculator with conservative/base/optimistic sensitivity.
- **/learn** — Beginner content hub with four pathways and async pull of 12 most-recent beginner articles (with static fallback so it cannot 500). Client newsletter CTA.

Plus:

- **Header.tsx** — Adds Dividend Hub + Sell a Business to the existing "Income & Alternatives" mega-menu column. Appends a new "Tools & Resources" mobile-nav section. No restructure of the existing nav.
- **Footer.tsx** — Appends new hub links to the existing "Invest by Sector" and "Learn" columns.
- **app/sitemap.ts** — All 24 new static routes added to the priority tiers.
- **scripts/seed-revenue-expansion.ts** — Idempotent one-shot seed: 12 `lead_pricing` rows (e.g. `rd_tax_advisor`, `emdg_consultant`, `business_exit_advisor`, `inheritance_advisor`) + 20 evergreen articles. ON CONFLICT DO NOTHING semantics. Already executed against the project Supabase: 12/12 lead_pricing rows inserted, 19/20 articles inserted (1 pre-existing slug).
- **components/leads/HubLeadForm.tsx** — Shared client component used by every new lead-capture surface. Calls `POST /api/submit-lead` with `lead_type: "advisor"` + `user_intent.{need,context}` mapped per hub.
- **components/RdTaxCalculator.tsx** — 3-step refundable-offset calculator used by both the /grants hub and /grants/rd-tax-incentive page.

### Quality

- Every page exports `generateMetadata` with title, description, canonical and OG.
- BreadcrumbList JSON-LD on every page.
- Every Supabase fetch is wrapped in try/catch with an array fallback — pages cannot 500.
- No new dependencies. Uses existing Tailwind palette (`amber-500` / `slate-900` / `slate-50` ≡ GOLD/NAVY/GRAY).
- All new lead forms route through the existing `/api/submit-lead` (not a fictional `/api/leads/submit`) and use the existing intent → advisor-type mapping.

### Files NOT touched

Per the brief, this PR does not modify `app/advisors/[type]/page.tsx`, `lib/types.ts`, `lib/advisor-verification.ts`, or `app/invest/*`. `app/smsf/page.tsx` was only appended (sub-page nav cards), not restructured.

## Test plan

- [ ] `npm run build` — green (verified locally with 8GB heap; type-check + 200+ static pages compiled).
- [ ] Visit each new hub root and verify hero, stats bar, primary CTA load.
- [ ] Submit one lead from `/grants/rd-tax-incentive` calculator — verify it lands in `leads` and `professional_leads` tables.
- [ ] Submit one newsletter from `/learn` — verify `newsletter_subscribers` upsert and confirmation email queued.
- [ ] Walk the `/grants/eligibility-quiz` (5 questions → results → form) end-to-end.
- [ ] Confirm `/smsf/page.tsx` renders unchanged ABOVE the new sub-page card grid (no restructure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)