### PR TITLE
fix(seo): redirect commodity pillar /listings → canonical subcategory listings

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -158,6 +158,32 @@ const nextConfig: NextConfig = {
         destination: "/invest/:category/listings/:subcategory",
         permanent: true,
       },
+      // ── Commodity pillar pages → canonical subcategory listings ──
+      // /invest/uranium, /invest/gold, /invest/lithium etc. are SEO/education
+      // pillar pages; the marketplace listings live under the parent category
+      // (mining or renewable-energy) as `/listings/<commodity>` subpaths. Users
+      // who land on the pillar and try /listings naturally hit a 404 — redirect
+      // them to the canonical listings location. 308 so search engines update.
+      {
+        source: "/invest/uranium/listings",
+        destination: "/invest/mining/listings/uranium",
+        permanent: true,
+      },
+      {
+        source: "/invest/gold/listings",
+        destination: "/invest/mining/listings/gold",
+        permanent: true,
+      },
+      {
+        source: "/invest/lithium/listings",
+        destination: "/invest/mining/listings/lithium",
+        permanent: true,
+      },
+      {
+        source: "/invest/hydrogen/listings",
+        destination: "/invest/renewable-energy/listings/hydrogen",
+        permanent: true,
+      },
       // ── /invest/listing/[slug] catch-all (deleted route) ──
       // Old inbound links from before the listings system cleanup used
       // a flat `/invest/listing/[slug]` URL that no longer exists.


### PR DESCRIPTION
## Summary

- `/invest/uranium/listings` was 404ing — fix it (and 3 sibling commodity URLs that have the same problem)
- Adds 4 permanent redirects in `next.config.ts` to canonical listings URLs
- Zero behaviour change for working URLs; pure 404 → canonical fix

## What was happening

The `/invest/<commodity>` pages (uranium, gold, lithium, hydrogen) are SEO/education pillar pages sourced from `lib/commodities.ts` sector data. The marketplace listings for these commodities actually live under their parent category:

| Pillar URL (kept) | Listings — was 404 | Listings — now redirects to |
|---|---|---|
| `/invest/uranium` | `/invest/uranium/listings` ❌ | `/invest/mining/listings/uranium` ✅ |
| `/invest/gold` | `/invest/gold/listings` ❌ | `/invest/mining/listings/gold` ✅ |
| `/invest/lithium` | `/invest/lithium/listings` ❌ | `/invest/mining/listings/lithium` ✅ |
| `/invest/hydrogen` | `/invest/hydrogen/listings` ❌ | `/invest/renewable-energy/listings/hydrogen` ✅ |

Users land on the pillar page, look for listings, hit a 404. Same root cause as the existing `/invest/:category/opportunities` and `/mining/opportunities/:slug` redirects already in the same file.

## Test plan

- [ ] Preview deploy: visit `/invest/uranium/listings` → should 308 to `/invest/mining/listings/uranium` and render the uranium subcategory listings page
- [ ] Same check for `/invest/gold/listings`, `/invest/lithium/listings`, `/invest/hydrogen/listings`
- [ ] Existing pillar URLs (`/invest/uranium`, etc.) still load unchanged
- [ ] Existing canonical URLs (`/invest/mining/listings/uranium`, etc.) still load unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)