### PR TITLE
test(stripe-webhook): expand idempotency, ordering, and checkout-flow coverage

### DIFF
--- a/__tests__/api/stripe-webhook.test.ts
+++ b/__tests__/api/stripe-webhook.test.ts
@@ -82,6 +82,12 @@ vi.mock("@/lib/advisor-billing", () => ({
     mockHandleInvoicePaymentFailed(...args),
 }));
 
+// Mock wallet (dynamically imported in charge.refunded handler)
+const mockDebitWallet = vi.fn();
+vi.mock("@/lib/marketplace/wallet", () => ({
+  debitWallet: (...args: unknown[]) => mockDebitWallet(...args),
+}));
+
 // Mock Sentry (imported transitively via logger)
 vi.mock("@sentry/nextjs", () => ({
   captureMessage: vi.fn(),
@@ -615,6 +621,545 @@ describe("POST /api/stripe/webhook", () => {
 
       const json = await res.json();
       expect(json.error).toBe("Webhook handler failed");
+    });
+  });
+
+  // ── Missing STRIPE_WEBHOOK_SECRET ──
+
+  describe("missing webhook secret", () => {
+    it("returns 500 when STRIPE_WEBHOOK_SECRET is not configured", async () => {
+      delete process.env.STRIPE_WEBHOOK_SECRET;
+      const req = makeWebhookRequest('{"type":"test"}');
+      const res = await POST(req);
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.error).toBe("Webhook not configured");
+    });
+  });
+
+  // ── Idempotency ──
+
+  describe("idempotency", () => {
+    it("returns duplicate:true when event already processed (status=done)", async () => {
+      const event = fakeStripeEvent("invoice.paid", {
+        id: "in_dup_001",
+        customer: "cus_dup",
+        payment_intent: "pi_dup",
+        metadata: { type: "advisor_lead" },
+      });
+      mockConstructEvent.mockReturnValue(event);
+
+      mockFrom.mockImplementation((table: string) => {
+        const builder = createChainableBuilder(table);
+        if (table === "stripe_webhook_events") {
+          builder.insert = vi.fn(() =>
+            Promise.resolve({
+              data: null,
+              error: { code: "23505", message: "duplicate key value" },
+            }),
+          );
+          builder.maybeSingle = vi.fn(() =>
+            Promise.resolve({
+              data: { status: "done", started_at: new Date().toISOString() },
+              error: null,
+            }),
+          );
+        }
+        return builder;
+      });
+
+      const req = makeWebhookRequest(JSON.stringify(event));
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.duplicate).toBe(true);
+      // Handler should NOT have run
+      expect(mockHandleInvoicePaid).not.toHaveBeenCalled();
+    });
+
+    it("returns inflight:true when another worker is currently processing the event", async () => {
+      const event = fakeStripeEvent("invoice.paid", {
+        id: "in_inflight_001",
+        customer: "cus_inflight",
+        payment_intent: "pi_inflight",
+        metadata: { type: "advisor_lead" },
+      });
+      mockConstructEvent.mockReturnValue(event);
+
+      const oneMinuteAgo = new Date(Date.now() - 60 * 1000).toISOString();
+      mockFrom.mockImplementation((table: string) => {
+        const builder = createChainableBuilder(table);
+        if (table === "stripe_webhook_events") {
+          builder.insert = vi.fn(() =>
+            Promise.resolve({
+              data: null,
+              error: { code: "23505", message: "duplicate key value" },
+            }),
+          );
+          builder.maybeSingle = vi.fn(() =>
+            Promise.resolve({
+              data: { status: "processing", started_at: oneMinuteAgo },
+              error: null,
+            }),
+          );
+        }
+        return builder;
+      });
+
+      const req = makeWebhookRequest(JSON.stringify(event));
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.inflight).toBe(true);
+      expect(mockHandleInvoicePaid).not.toHaveBeenCalled();
+    });
+
+    it("re-takes a stale processing row and runs the handler", async () => {
+      const event = fakeStripeEvent("invoice.paid", {
+        id: "in_stale_001",
+        customer: "cus_stale",
+        payment_intent: "pi_stale",
+        metadata: { type: "advisor_lead" },
+      });
+      mockConstructEvent.mockReturnValue(event);
+
+      const tenMinutesAgo = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+      mockFrom.mockImplementation((table: string) => {
+        const builder = createChainableBuilder(table);
+        if (table === "stripe_webhook_events") {
+          builder.insert = vi.fn(() =>
+            Promise.resolve({
+              data: null,
+              error: { code: "23505", message: "duplicate key value" },
+            }),
+          );
+          builder.maybeSingle = vi.fn(() =>
+            Promise.resolve({
+              data: { status: "processing", started_at: tenMinutesAgo },
+              error: null,
+            }),
+          );
+        }
+        return builder;
+      });
+
+      const req = makeWebhookRequest(JSON.stringify(event));
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+      // Handler ran
+      expect(mockHandleInvoicePaid).toHaveBeenCalledWith(
+        "in_stale_001",
+        "pi_stale",
+      );
+    });
+  });
+
+  // ── Out-of-order subscription event protection ──
+
+  describe("out-of-order subscription updates", () => {
+    it("skips upsert when incoming event is older than stored updated_at", async () => {
+      const oldStart = Math.floor(new Date("2026-01-01").getTime() / 1000);
+      const event = fakeStripeEvent("customer.subscription.updated", {
+        id: "sub_ooo_001",
+        customer: "cus_ooo",
+        status: "active",
+        items: {
+          data: [{ price: { id: "p1", recurring: { interval: "month" } } }],
+        },
+        current_period_start: oldStart,
+        current_period_end: oldStart + 30 * 86400,
+        cancel_at_period_end: false,
+        canceled_at: null,
+      });
+      mockConstructEvent.mockReturnValue(event);
+
+      const futureUpdatedAt = "2030-01-01T00:00:00.000Z";
+
+      mockFrom.mockImplementation((table: string) => {
+        const builder = createChainableBuilder(table);
+        if (table === "profiles") {
+          builder.single = vi.fn(() =>
+            Promise.resolve({ data: { id: "user-uuid-ooo" }, error: null }),
+          );
+        }
+        if (table === "subscriptions") {
+          builder.maybeSingle = vi.fn(() =>
+            Promise.resolve({
+              data: { updated_at: futureUpdatedAt, status: "canceled" },
+              error: null,
+            }),
+          );
+        }
+        return builder;
+      });
+
+      const req = makeWebhookRequest(JSON.stringify(event));
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+
+      const subCalls = supabaseCalls["subscriptions"] || [];
+      expect(subCalls.some((c) => c.method === "upsert")).toBe(false);
+    });
+  });
+
+  // ── invoice.payment_failed (subscription customer email) ──
+
+  describe("invoice.payment_failed (non-advisor subscription)", () => {
+    it("sends a payment-failed email to the subscriber", async () => {
+      process.env.RESEND_API_KEY = "re_test_key";
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(new Response("{}", { status: 200 }));
+
+      const event = fakeStripeEvent("invoice.payment_failed", {
+        id: "in_sub_fail_email",
+        customer: "cus_sub_fail_email",
+        amount_due: 8900,
+        metadata: {},
+      });
+      mockConstructEvent.mockReturnValue(event);
+      mockCustomerRetrieve.mockResolvedValue({
+        id: "cus_sub_fail_email",
+        email: "user@test.com",
+      });
+
+      mockFrom.mockImplementation((table: string) => {
+        const builder = createChainableBuilder(table);
+        if (table === "profiles") {
+          builder.maybeSingle = vi.fn(() =>
+            Promise.resolve({ data: { id: "user-uuid-sub" }, error: null }),
+          );
+        }
+        return builder;
+      });
+
+      const req = makeWebhookRequest(JSON.stringify(event));
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+
+      const resendCalls = fetchSpy.mock.calls.filter(
+        ([url]) => typeof url === "string" && url.includes("resend.com"),
+      );
+      expect(resendCalls.length).toBeGreaterThanOrEqual(1);
+
+      fetchSpy.mockRestore();
+      delete process.env.RESEND_API_KEY;
+    });
+  });
+
+  // ── checkout.session.completed: advisor_credit_topup ──
+
+  describe("checkout.session.completed (advisor_credit_topup)", () => {
+    it("credits advisor balance and marks topup completed", async () => {
+      const event = fakeStripeEvent("checkout.session.completed", {
+        id: "cs_topup_1",
+        mode: "payment",
+        payment_intent: "pi_topup_1",
+        amount_total: 50000,
+        customer_email: "advisor@test.com",
+        customer_details: { email: "advisor@test.com" },
+        metadata: {
+          type: "advisor_credit_topup",
+          professional_id: "42",
+          topup_id: "100",
+          per_lead_cents: "5000",
+        },
+      });
+      mockConstructEvent.mockReturnValue(event);
+
+      mockFrom.mockImplementation((table: string) => {
+        const builder = createChainableBuilder(table);
+        if (table === "advisor_credit_topups") {
+          builder.single = vi.fn(() =>
+            Promise.resolve({ data: { status: "pending" }, error: null }),
+          );
+        }
+        if (table === "professionals") {
+          builder.single = vi.fn(() =>
+            Promise.resolve({
+              data: {
+                credit_balance_cents: 10000,
+                lifetime_credit_cents: 20000,
+              },
+              error: null,
+            }),
+          );
+          builder.maybeSingle = vi.fn(() =>
+            Promise.resolve({
+              data: { email: "advisor@test.com", name: "Test Advisor" },
+              error: null,
+            }),
+          );
+        }
+        return builder;
+      });
+
+      const req = makeWebhookRequest(JSON.stringify(event));
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+
+      expect(mockFrom).toHaveBeenCalledWith("advisor_credit_topups");
+      expect(mockFrom).toHaveBeenCalledWith("professionals");
+      const proCalls = supabaseCalls["professionals"] || [];
+      expect(proCalls.some((c) => c.method === "update")).toBe(true);
+      const topupCalls = supabaseCalls["advisor_credit_topups"] || [];
+      expect(topupCalls.some((c) => c.method === "update")).toBe(true);
+    });
+
+    it("skips crediting when topup is already completed (idempotent)", async () => {
+      const event = fakeStripeEvent("checkout.session.completed", {
+        id: "cs_topup_dup",
+        mode: "payment",
+        payment_intent: "pi_topup_dup",
+        amount_total: 50000,
+        customer_email: "advisor@test.com",
+        metadata: {
+          type: "advisor_credit_topup",
+          professional_id: "42",
+          topup_id: "100",
+        },
+      });
+      mockConstructEvent.mockReturnValue(event);
+
+      mockFrom.mockImplementation((table: string) => {
+        const builder = createChainableBuilder(table);
+        if (table === "advisor_credit_topups") {
+          builder.single = vi.fn(() =>
+            Promise.resolve({ data: { status: "completed" }, error: null }),
+          );
+        }
+        return builder;
+      });
+
+      const req = makeWebhookRequest(JSON.stringify(event));
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+
+      const proCalls = supabaseCalls["professionals"] || [];
+      expect(proCalls.some((c) => c.method === "update")).toBe(false);
+    });
+  });
+
+  // ── checkout.session.completed: advisor_featured ──
+
+  describe("checkout.session.completed (advisor_featured)", () => {
+    it("activates featured listing for 30 days", async () => {
+      const event = fakeStripeEvent("checkout.session.completed", {
+        id: "cs_featured_1",
+        mode: "payment",
+        amount_total: 9900,
+        customer_email: "advisor@test.com",
+        metadata: {
+          type: "advisor_featured",
+          professional_id: "77",
+        },
+      });
+      mockConstructEvent.mockReturnValue(event);
+
+      mockFrom.mockImplementation((table: string) => {
+        const builder = createChainableBuilder(table);
+        if (table === "professionals") {
+          builder.maybeSingle = vi.fn(() =>
+            Promise.resolve({
+              data: {
+                email: "advisor@test.com",
+                name: "Test Advisor",
+                slug: "test-advisor",
+              },
+              error: null,
+            }),
+          );
+        }
+        return builder;
+      });
+
+      const req = makeWebhookRequest(JSON.stringify(event));
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+
+      const proCalls = supabaseCalls["professionals"] || [];
+      const updateCall = proCalls.find((c) => c.method === "update");
+      expect(updateCall).toBeDefined();
+      const updateArgs = updateCall?.args[0] as
+        | { featured_until?: string }
+        | undefined;
+      expect(typeof updateArgs?.featured_until).toBe("string");
+    });
+  });
+
+  // ── checkout.session.completed: listing_payment ──
+
+  describe("checkout.session.completed (listing_payment)", () => {
+    it("activates listing with expiry from plan duration", async () => {
+      const event = fakeStripeEvent("checkout.session.completed", {
+        id: "cs_listing_1",
+        mode: "payment",
+        amount_total: 19900,
+        customer_email: "seller@test.com",
+        metadata: {
+          type: "listing_payment",
+          listing_id: "55",
+          plan_id: "3",
+          contact_email: "seller@test.com",
+        },
+      });
+      mockConstructEvent.mockReturnValue(event);
+
+      mockFrom.mockImplementation((table: string) => {
+        const builder = createChainableBuilder(table);
+        if (table === "listing_plans") {
+          builder.single = vi.fn(() =>
+            Promise.resolve({
+              data: {
+                plan_name: "Premium",
+                features: { listing_duration_days: 90 },
+              },
+              error: null,
+            }),
+          );
+        }
+        if (table === "investment_listings") {
+          builder.single = vi.fn(() =>
+            Promise.resolve({
+              data: { title: "My Listing", slug: "my-listing" },
+              error: null,
+            }),
+          );
+        }
+        return builder;
+      });
+
+      const req = makeWebhookRequest(JSON.stringify(event));
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+
+      const listingCalls = supabaseCalls["investment_listings"] || [];
+      const updateCall = listingCalls.find((c) => c.method === "update");
+      expect(updateCall).toBeDefined();
+      const updateArgs = updateCall?.args[0] as
+        | { status?: string; expires_at?: string }
+        | undefined;
+      expect(updateArgs?.status).toBe("active");
+      expect(typeof updateArgs?.expires_at).toBe("string");
+    });
+  });
+
+  // ── checkout.session.completed: sponsored_placement ──
+
+  describe("checkout.session.completed (sponsored_placement)", () => {
+    it("creates a scheduled booking when metadata is complete", async () => {
+      const event = fakeStripeEvent("checkout.session.completed", {
+        id: "cs_sponsored_ok",
+        mode: "payment",
+        payment_status: "paid",
+        amount_total: 100000,
+        currency: "aud",
+        customer_email: "broker@test.com",
+        invoice: null,
+        metadata: {
+          kind: "sponsored_placement",
+          broker_id: "11",
+          broker_slug: "test-broker",
+          broker_name: "Test Broker",
+          tier: "homepage_hero",
+          starts_at: "2026-05-01T00:00:00.000Z",
+          ends_at: "2026-05-31T00:00:00.000Z",
+          duration_days: "30",
+          contact_email: "broker@test.com",
+          contact_name: "Test Contact",
+        },
+      });
+      mockConstructEvent.mockReturnValue(event);
+
+      mockFrom.mockImplementation((table: string) => {
+        const builder = createChainableBuilder(table);
+        if (table === "sponsored_placement_bookings") {
+          builder.maybeSingle = vi.fn(() =>
+            Promise.resolve({ data: null, error: null }),
+          );
+          builder.insert = vi.fn(() => Promise.resolve({ error: null }));
+        }
+        return builder;
+      });
+
+      const req = makeWebhookRequest(JSON.stringify(event));
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+
+      const bookCalls = supabaseCalls["sponsored_placement_bookings"] || [];
+      expect(bookCalls.some((c) => c.method === "select")).toBe(true);
+    });
+
+    it("alerts admin when sponsored_placement metadata is incomplete", async () => {
+      process.env.RESEND_API_KEY = "re_test_key";
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(new Response("{}", { status: 200 }));
+
+      const event = fakeStripeEvent("checkout.session.completed", {
+        id: "cs_sponsored_bad",
+        mode: "payment",
+        payment_status: "paid",
+        amount_total: 50000,
+        customer_email: "broker@test.com",
+        metadata: {
+          kind: "sponsored_placement",
+        },
+      });
+      mockConstructEvent.mockReturnValue(event);
+
+      const req = makeWebhookRequest(JSON.stringify(event));
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+
+      const bookCalls = supabaseCalls["sponsored_placement_bookings"] || [];
+      expect(bookCalls.some((c) => c.method === "insert")).toBe(false);
+
+      const resendCalls = fetchSpy.mock.calls.filter(
+        ([url]) => typeof url === "string" && url.includes("resend.com"),
+      );
+      expect(resendCalls.length).toBeGreaterThanOrEqual(1);
+
+      fetchSpy.mockRestore();
+      delete process.env.RESEND_API_KEY;
+    });
+  });
+
+  // ── charge.refunded: consultation booking ──
+
+  describe("charge.refunded (consultation)", () => {
+    it("marks consultation booking refunded", async () => {
+      const event = fakeStripeEvent("charge.refunded", {
+        id: "ch_refund_consult",
+        payment_intent: "pi_refund_consult",
+        amount_refunded: 19900,
+      });
+      mockConstructEvent.mockReturnValue(event);
+
+      mockFrom.mockImplementation((table: string) => {
+        const builder = createChainableBuilder(table);
+        if (table === "consultation_bookings") {
+          builder.maybeSingle = vi.fn(() =>
+            Promise.resolve({
+              data: { id: 7, user_id: "user-uuid", consultation_id: 5 },
+              error: null,
+            }),
+          );
+        }
+        return builder;
+      });
+
+      const req = makeWebhookRequest(JSON.stringify(event));
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+
+      const bookingCalls = supabaseCalls["consultation_bookings"] || [];
+      const updateCall = bookingCalls.find((c) => c.method === "update");
+      expect(updateCall).toBeDefined();
+      const updateArgs = updateCall?.args[0] as
+        | { status?: string; refunded_at?: string }
+        | undefined;
+      expect(updateArgs?.status).toBe("refunded");
     });
   });
 });


### PR DESCRIPTION
## Summary

- Adds 13 test cases to `__tests__/api/stripe-webhook.test.ts`, lifting the file from 16 → 29 tests.
- Targets previously-untested branches in `app/api/stripe/webhook/route.ts`: missing webhook secret, idempotency state machine (duplicate/in-flight/stale-retake), out-of-order subscription protection, subscriber payment-failed email, advisor_credit_topup, advisor_featured, listing_payment, sponsored_placement (happy path + incomplete-metadata admin alert), and consultation-booking refund.
- No source changes — pure additive tests against existing handler behaviour.

## Test plan

- [x] `npm test -- __tests__/api/stripe-webhook.test.ts` → 29/29 passing
- [x] `npx eslint __tests__/api/stripe-webhook.test.ts --max-warnings 0` → clean
- [x] `npm run type-check` → exit 0
- [ ] CI gates green
- [ ] Auto-merge once approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)