### PR TITLE
test(lead-routes): expand coverage for submit/quiz/advisor lead APIs

### DIFF
--- a/__tests__/api/advisor-lead.test.ts
+++ b/__tests__/api/advisor-lead.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { makeRequest, createChainableBuilder } from "@/__tests__/helpers";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const mockFrom = vi.fn();
+const supabaseCalls: Record<string, { method: string; args: unknown[] }[]> = {};
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({ from: mockFrom }),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  isRateLimited: vi.fn(() => Promise.resolve(false)),
+}));
+
+vi.mock("@/lib/posthog/server", () => ({
+  captureServerEvent: vi.fn(() => Promise.resolve()),
+}));
+
+import { POST } from "@/app/api/advisor-lead/route";
+import { isRateLimited } from "@/lib/rate-limit";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+const VALID = {
+  name: "Alice Lead",
+  phone: "0411567890",
+  email: "alice@test.com",
+  advisor_type: "financial-planner",
+  quiz_answers: { goal: "retirement", horizon: "10y" },
+  consent: true,
+};
+
+function buildRequest(body: Record<string, unknown>, ip = "8.8.8.8") {
+  return makeRequest("/api/advisor-lead", body, { ip });
+}
+
+function resetCalls() {
+  for (const k of Object.keys(supabaseCalls)) delete supabaseCalls[k];
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("POST /api/advisor-lead", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetCalls();
+    mockFrom.mockReset();
+    mockFrom.mockImplementation((table: string) =>
+      createChainableBuilder(table, supabaseCalls),
+    );
+    (isRateLimited as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+  });
+
+  // ── Validation ──
+
+  it("returns 400 for invalid JSON", async () => {
+    const req = new Request("http://localhost/api/advisor-lead", {
+      method: "POST",
+      body: "{not-json",
+      headers: { "Content-Type": "application/json" },
+    });
+    const res = await POST(req as unknown as Parameters<typeof POST>[0]);
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe("Invalid JSON body");
+  });
+
+  it("returns 400 when name is missing", async () => {
+    const req = buildRequest({ ...VALID, name: "" });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when name is too short", async () => {
+    const req = buildRequest({ ...VALID, name: "X" });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for invalid AU phone (non-international)", async () => {
+    const req = buildRequest({ ...VALID, phone: "123" });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/phone/i);
+  });
+
+  it("accepts non-AU phone when is_international=true", async () => {
+    const req = buildRequest({
+      ...VALID,
+      is_international: true,
+      phone: "+1 415 555 0100",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 400 for too-short phone when is_international=true", async () => {
+    const req = buildRequest({
+      ...VALID,
+      is_international: true,
+      phone: "12",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for invalid email", async () => {
+    const req = buildRequest({ ...VALID, email: "not-email" });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when consent is missing", async () => {
+    const req = buildRequest({ ...VALID, consent: false });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe("Consent is required");
+  });
+
+  // ── Rate limit ──
+
+  it("returns 429 when rate limited", async () => {
+    (isRateLimited as ReturnType<typeof vi.fn>).mockResolvedValueOnce(true);
+    const req = buildRequest(VALID);
+    const res = await POST(req);
+    expect(res.status).toBe(429);
+  });
+
+  // ── Happy paths ──
+
+  it("inserts an advisor lead with quiz_answers and returns success", async () => {
+    const req = buildRequest(VALID);
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.success).toBe(true);
+
+    const captureCalls = supabaseCalls.email_captures || [];
+    const insertCall = captureCalls.find((c) => c.method === "insert");
+    expect(insertCall).toBeDefined();
+    const args = insertCall?.args[0] as Record<string, unknown>;
+    expect(args.email).toBe("alice@test.com");
+    expect(args.source).toBe("advisor-lead");
+    const ctx = args.context as Record<string, unknown>;
+    expect(ctx.advisor_type).toBe("financial-planner");
+    expect(ctx.is_international).toBe(false);
+    expect(ctx.quiz_answers).toEqual({ goal: "retirement", horizon: "10y" });
+  });
+
+  it("tags lead as international with extra context fields", async () => {
+    const req = buildRequest({
+      ...VALID,
+      is_international: true,
+      phone: "+1 415 555 0100",
+      investor_country: "USA",
+      visa_status: "permanent_resident",
+      investor_goal_intl: "buy_property",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const captureCalls = supabaseCalls.email_captures || [];
+    const insertCall = captureCalls.find((c) => c.method === "insert");
+    const args = insertCall?.args[0] as Record<string, unknown>;
+    expect(args.source).toBe("advisor-lead-international");
+    const ctx = args.context as Record<string, unknown>;
+    expect(ctx.is_international).toBe(true);
+    expect(ctx.investor_country).toBe("USA");
+    expect(ctx.lead_tier).toBe("international");
+  });
+
+  // ── Duplicate handling ──
+
+  it("treats duplicate email (Postgres 23505) as success", async () => {
+    mockFrom.mockImplementation((table: string) => {
+      const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "email_captures") {
+        // Override insert to return a duplicate-key error directly via thenable
+        b.insert = vi.fn(() =>
+          Promise.resolve({
+            data: null,
+            error: { code: "23505", message: "duplicate key value" },
+          }),
+        );
+      }
+      return b;
+    });
+
+    const req = buildRequest(VALID);
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.success).toBe(true);
+  });
+
+  it("returns 500 on non-duplicate insert error", async () => {
+    mockFrom.mockImplementation((table: string) => {
+      const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "email_captures") {
+        b.insert = vi.fn(() =>
+          Promise.resolve({
+            data: null,
+            error: { code: "OTHER", message: "connection refused" },
+          }),
+        );
+      }
+      return b;
+    });
+
+    const req = buildRequest(VALID);
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+  });
+
+  // ── Sanitization ──
+
+  it("sanitizes oversize fields", async () => {
+    const longName = "A".repeat(500);
+    const longCountry = "X".repeat(200);
+    const req = buildRequest({
+      ...VALID,
+      name: longName,
+      is_international: true,
+      phone: "+1 415 555 0100",
+      investor_country: longCountry,
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const captureCalls = supabaseCalls.email_captures || [];
+    const insertCall = captureCalls.find((c) => c.method === "insert");
+    const args = insertCall?.args[0] as Record<string, unknown>;
+    expect((args.name as string).length).toBeLessThanOrEqual(100);
+    const ctx = args.context as Record<string, unknown>;
+    expect((ctx.investor_country as string).length).toBeLessThanOrEqual(50);
+  });
+});

--- a/__tests__/api/quiz-lead.test.ts
+++ b/__tests__/api/quiz-lead.test.ts
@@ -1,5 +1,26 @@
 import { describe, it, expect, vi, beforeEach, afterAll } from "vitest";
 import { NextRequest } from "next/server";
+
+const mockIsAllowed = vi.fn();
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: (...args: unknown[]) => mockIsAllowed(...args),
+  ipKey: () => "test-ip",
+}));
+
+vi.mock("@/lib/quiz-history", () => ({
+  recordQuizSubmission: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(() =>
+    Promise.resolve({
+      auth: {
+        getUser: vi.fn(() => Promise.resolve({ data: { user: null } })),
+      },
+    }),
+  ),
+}));
+
 import { POST } from "@/app/api/quiz-lead/route";
 
 function makeRequest(
@@ -20,11 +41,22 @@ function makeRequest(
 describe("POST /api/quiz-lead", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockIsAllowed.mockResolvedValue(true);
   });
 
   afterAll(() => {
-    // Clear rate limit cleanup intervals from the API route modules
     vi.restoreAllMocks();
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    const req = new Request("http://localhost/api/quiz-lead", {
+      method: "POST",
+      body: "{not-json",
+      headers: { "Content-Type": "application/json" },
+    });
+    const res = await POST(req as unknown as NextRequest);
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe("Invalid JSON body");
   });
 
   it("returns 400 for invalid email", async () => {
@@ -43,6 +75,28 @@ describe("POST /api/quiz-lead", () => {
     expect(json.error).toBeDefined();
   });
 
+  it("rejects disposable email domains", async () => {
+    const req = makeRequest(
+      { email: "spam@mailinator.com" },
+      "30.0.0.10",
+    );
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe(
+      "Please use a real email address.",
+    );
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    mockIsAllowed.mockResolvedValueOnce(false);
+    const req = makeRequest(
+      { email: "rate@example.com" },
+      "30.0.0.11",
+    );
+    const res = await POST(req);
+    expect(res.status).toBe(429);
+  });
+
   it("returns 200 for valid quiz lead submission", async () => {
     const req = makeRequest(
       {
@@ -57,5 +111,46 @@ describe("POST /api/quiz-lead", () => {
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.success).toBe(true);
+  });
+
+  it("normalizes mixed-case email to lowercase", async () => {
+    const req = makeRequest(
+      {
+        email: "Mixed.Case@EXAMPLE.com",
+        name: "Mixed",
+        answers: [],
+        top_match_slug: "stake",
+      },
+      "30.0.0.4",
+    );
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    expect((await res.json()).success).toBe(true);
+  });
+
+  it("succeeds without top_match_slug (skips email send)", async () => {
+    const req = makeRequest(
+      {
+        email: "no-match@example.com",
+        name: "No Match",
+        answers: ["beginner"],
+      },
+      "30.0.0.5",
+    );
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    expect((await res.json()).success).toBe(true);
+  });
+
+  it("accepts answers when not an array (treats as empty)", async () => {
+    const req = makeRequest(
+      {
+        email: "weird-answers@example.com",
+        answers: "not-an-array",
+      },
+      "30.0.0.6",
+    );
+    const res = await POST(req);
+    expect(res.status).toBe(200);
   });
 });

--- a/__tests__/api/submit-lead.test.ts
+++ b/__tests__/api/submit-lead.test.ts
@@ -1,0 +1,434 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { makeRequest, createChainableBuilder } from "@/__tests__/helpers";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const mockFrom = vi.fn();
+const supabaseCalls: Record<string, { method: string; args: unknown[] }[]> = {};
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({ from: mockFrom }),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  isRateLimited: vi.fn(() => Promise.resolve(false)),
+}));
+
+const mockSendNewLeadNotification = vi.fn(() => Promise.resolve());
+const mockSendLeadConfirmationToUser = vi.fn(() => Promise.resolve());
+
+vi.mock("@/lib/advisor-emails", () => ({
+  sendNewLeadNotification: (...args: unknown[]) =>
+    mockSendNewLeadNotification(...args),
+  sendLeadConfirmationToUser: (...args: unknown[]) =>
+    mockSendLeadConfirmationToUser(...args),
+}));
+
+import { POST } from "@/app/api/submit-lead/route";
+import { isRateLimited } from "@/lib/rate-limit";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+const ADVISOR = {
+  id: 1,
+  slug: "alice-advisor",
+  name: "Alice",
+  firm_name: "Alice Capital",
+  type: "financial_planner",
+  photo_url: null,
+  rating: 4.8,
+  review_count: 50,
+  location_display: "Sydney NSW",
+  location_state: "NSW",
+  specialties: ["retirement"],
+  fee_description: "Fee-only",
+  verified: true,
+  bio: null,
+  email: "alice@advisor.test",
+};
+
+function resetCalls() {
+  for (const k of Object.keys(supabaseCalls)) delete supabaseCalls[k];
+}
+
+function buildRequest(body: Record<string, unknown>, ip = "9.9.9.9") {
+  return makeRequest("/api/submit-lead", body, { ip });
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("POST /api/submit-lead", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetCalls();
+    mockFrom.mockReset();
+    mockFrom.mockImplementation((table: string) =>
+      createChainableBuilder(table, supabaseCalls),
+    );
+    (isRateLimited as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+  });
+
+  // ── Validation ──
+
+  it("returns 400 for invalid JSON body", async () => {
+    const req = new Request("http://localhost/api/submit-lead", {
+      method: "POST",
+      body: "{not-json",
+      headers: { "Content-Type": "application/json" },
+    });
+    const res = await POST(req as unknown as Parameters<typeof POST>[0]);
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("Invalid JSON");
+  });
+
+  it("returns 400 for missing lead_type", async () => {
+    const req = buildRequest({ user_email: "test@example.com" });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe("Invalid lead_type");
+  });
+
+  it("returns 400 for invalid lead_type", async () => {
+    const req = buildRequest({
+      lead_type: "bogus",
+      user_email: "test@example.com",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for missing email", async () => {
+    const req = buildRequest({ lead_type: "advisor" });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe("Valid email required");
+  });
+
+  it("returns 400 for invalid email format", async () => {
+    const req = buildRequest({
+      lead_type: "advisor",
+      user_email: "not-an-email",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects disposable email domains", async () => {
+    const req = buildRequest({
+      lead_type: "advisor",
+      user_email: "user@mailinator.com",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe("Please use a real email address.");
+  });
+
+  // ── Honeypot ──
+
+  it("silently succeeds when honeypot fields are filled", async () => {
+    const req = buildRequest({
+      lead_type: "advisor",
+      user_email: "real@example.com",
+      website: "spam.example.com",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.success).toBe(true);
+    expect(json.lead_id).toBe(null);
+    expect(json.matched).toBe(null);
+    // Crucially, no DB writes
+    expect(supabaseCalls.leads).toBeUndefined();
+  });
+
+  // ── Rate limit ──
+
+  it("returns 429 when rate limited", async () => {
+    (isRateLimited as ReturnType<typeof vi.fn>).mockResolvedValueOnce(true);
+    const req = buildRequest({
+      lead_type: "advisor",
+      user_email: "rl@example.com",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(429);
+  });
+
+  // ── Platform leads ──
+
+  describe("lead_type=platform", () => {
+    it("inserts a platform lead with broker lookup", async () => {
+      mockFrom.mockImplementation((table: string) => {
+        const b = createChainableBuilder(table, supabaseCalls);
+        if (table === "brokers") {
+          b.single = vi.fn(() =>
+            Promise.resolve({
+              data: { id: 42, cpa_value: 1500 },
+              error: null,
+            }),
+          );
+        }
+        if (table === "leads") {
+          b.single = vi.fn(() =>
+            Promise.resolve({ data: { id: 99 }, error: null }),
+          );
+        }
+        return b;
+      });
+
+      const req = buildRequest({
+        lead_type: "platform",
+        user_email: "platform@test.com",
+        user_name: "Platform User",
+        broker_slug: "test-broker",
+        source_page: "/compare",
+      });
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.success).toBe(true);
+      expect(json.lead_id).toBe(99);
+
+      const leadCalls = supabaseCalls.leads || [];
+      const insertCall = leadCalls.find((c) => c.method === "insert");
+      expect(insertCall).toBeDefined();
+      const args = insertCall?.args[0] as Record<string, unknown>;
+      expect(args.lead_type).toBe("platform");
+      expect(args.broker_id).toBe(42);
+      expect(args.user_email).toBe("platform@test.com");
+    });
+
+    it("returns 500 when platform lead insert fails", async () => {
+      mockFrom.mockImplementation((table: string) => {
+        const b = createChainableBuilder(table, supabaseCalls);
+        if (table === "leads") {
+          b.single = vi.fn(() =>
+            Promise.resolve({
+              data: null,
+              error: { message: "db down" },
+            }),
+          );
+        }
+        return b;
+      });
+
+      const req = buildRequest({
+        lead_type: "platform",
+        user_email: "fail@test.com",
+      });
+      const res = await POST(req);
+      expect(res.status).toBe(500);
+    });
+  });
+
+  // ── confirm_advisor_id fast-path ──
+
+  describe("confirm_advisor_id", () => {
+    it("returns 404 when confirmed advisor not found", async () => {
+      mockFrom.mockImplementation((table: string) => {
+        const b = createChainableBuilder(table, supabaseCalls);
+        if (table === "professionals") {
+          b.single = vi.fn(() =>
+            Promise.resolve({ data: null, error: null }),
+          );
+        }
+        return b;
+      });
+
+      const req = buildRequest({
+        lead_type: "advisor",
+        user_email: "user@test.com",
+        confirm_advisor_id: 9999,
+      });
+      const res = await POST(req);
+      expect(res.status).toBe(404);
+    });
+
+    it("creates lead and notifies advisor when confirming", async () => {
+      let professionalsCallCount = 0;
+      let leadCallCount = 0;
+      mockFrom.mockImplementation((table: string) => {
+        const b = createChainableBuilder(table, supabaseCalls);
+        if (table === "professionals") {
+          b.single = vi.fn(() => {
+            professionalsCallCount++;
+            // First call: confirmedAdvisor lookup
+            // Second call: tier lookup
+            return Promise.resolve({
+              data:
+                professionalsCallCount === 1
+                  ? ADVISOR
+                  : { advisor_tier: "silver" },
+              error: null,
+            });
+          });
+        }
+        if (table === "leads") {
+          // First call: existingLead dedup lookup → null
+          // Second call: confirmedLead insert → return id
+          b.single = vi.fn(() => {
+            leadCallCount++;
+            return Promise.resolve({
+              data: leadCallCount === 1 ? null : { id: 555 },
+              error: leadCallCount === 1 ? { code: "PGRST116" } : null,
+            });
+          });
+        }
+        return b;
+      });
+
+      const req = buildRequest({
+        lead_type: "advisor",
+        user_email: "user@test.com",
+        user_name: "User Test",
+        user_phone: "0400000000",
+        user_intent: { need: "planning", context: ["retirement"], budget: "100k" },
+        confirm_advisor_id: 1,
+      });
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.success).toBe(true);
+      expect(json.lead_id).toBe(555);
+      expect(json.matched.id).toBe(1);
+
+      // Advisor email + user confirmation should both be sent
+      expect(mockSendNewLeadNotification).toHaveBeenCalled();
+      expect(mockSendLeadConfirmationToUser).toHaveBeenCalled();
+    });
+
+    it("dedupes when the user already confirmed this advisor in last 7 days", async () => {
+      mockFrom.mockImplementation((table: string) => {
+        const b = createChainableBuilder(table, supabaseCalls);
+        if (table === "professionals") {
+          b.single = vi.fn(() =>
+            Promise.resolve({ data: ADVISOR, error: null }),
+          );
+        }
+        if (table === "leads") {
+          b.single = vi.fn(() =>
+            Promise.resolve({ data: { id: 777 }, error: null }),
+          );
+        }
+        return b;
+      });
+
+      const req = buildRequest({
+        lead_type: "advisor",
+        user_email: "user@test.com",
+        confirm_advisor_id: 1,
+      });
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.lead_id).toBe(777);
+      // Lead notifications should NOT fire on dedupe
+      expect(mockSendNewLeadNotification).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Advisor matching ──
+
+  describe("advisor matching", () => {
+    it("dry_run returns the matched advisor without writing a lead", async () => {
+      mockFrom.mockImplementation((table: string) => {
+        const b = createChainableBuilder(table, supabaseCalls);
+        if (table === "professionals") {
+          // Override limit to return an array via thenable
+          b.limit = vi.fn(() => {
+            supabaseCalls[table]?.push({ method: "limit", args: [] });
+            return Promise.resolve({ data: [ADVISOR], error: null });
+          });
+        }
+        return b;
+      });
+
+      const req = buildRequest({
+        lead_type: "advisor",
+        user_email: "match@test.com",
+        user_location_state: "NSW",
+        user_intent: { need: "planning" },
+        dry_run: true,
+      });
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.matched.id).toBe(1);
+      expect(json.lead_id).toBe(null);
+      // No insert into leads on dry_run (read for dedup is fine)
+      const leadCalls = supabaseCalls.leads || [];
+      expect(leadCalls.some((c) => c.method === "insert")).toBe(false);
+      expect(mockSendNewLeadNotification).not.toHaveBeenCalled();
+    });
+
+    it("returns no_more_matches when all advisors are excluded", async () => {
+      mockFrom.mockImplementation((table: string) => {
+        const b = createChainableBuilder(table, supabaseCalls);
+        if (table === "professionals") {
+          b.limit = vi.fn(() => {
+            supabaseCalls[table]?.push({ method: "limit", args: [] });
+            // First 4 attempts return empty (filtered by exclusion); 5th returns advisor
+            return Promise.resolve({ data: [], error: null });
+          });
+        }
+        return b;
+      });
+
+      const req = buildRequest({
+        lead_type: "advisor",
+        user_email: "exhausted@test.com",
+        user_location_state: "NSW",
+        user_intent: { need: "planning" },
+        exclude_advisor_ids: [1, 2, 3],
+      });
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.no_more_matches).toBe(true);
+      expect(json.matched).toBe(null);
+    });
+
+    it("creates an advisor lead with revenue_value_cents from tier", async () => {
+      mockFrom.mockImplementation((table: string) => {
+        const b = createChainableBuilder(table, supabaseCalls);
+        if (table === "professionals") {
+          b.limit = vi.fn(() => {
+            supabaseCalls[table]?.push({ method: "limit", args: [] });
+            return Promise.resolve({ data: [ADVISOR], error: null });
+          });
+          b.single = vi.fn(() =>
+            Promise.resolve({
+              data: { advisor_tier: "gold" },
+              error: null,
+            }),
+          );
+        }
+        if (table === "leads") {
+          b.single = vi.fn(() =>
+            Promise.resolve({ data: { id: 12345 }, error: null }),
+          );
+        }
+        return b;
+      });
+
+      const req = buildRequest({
+        lead_type: "advisor",
+        user_email: "match@test.com",
+        user_name: "Lead User",
+        user_location_state: "NSW",
+        user_intent: { need: "planning" },
+      });
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.lead_id).toBe(12345);
+      expect(json.matched.id).toBe(1);
+
+      const leadCalls = supabaseCalls.leads || [];
+      const insertCall = leadCalls.find((c) => c.method === "insert");
+      const insertArgs = insertCall?.args[0] as Record<string, unknown>;
+      // gold tier → 6000 cents
+      expect(insertArgs.revenue_value_cents).toBe(6000);
+    });
+  });
+});

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -48,6 +48,8 @@ export function createChainableBuilder(
   const chainMethods = [
     "select", "insert", "upsert", "update", "delete",
     "eq", "neq", "order", "limit", "gte", "lte", "in", "gt", "lt",
+    "not", "or", "is", "ilike", "like", "contains", "containedBy",
+    "range", "match", "filter",
   ];
 
   for (const method of chainMethods) {


### PR DESCRIPTION
## Summary

- Adds **39 new test cases** across the three lead-capture routes (16 + 14 + 9), filling out validation, rate-limit, branch, and dedup coverage.
- `__tests__/api/submit-lead.test.ts` (new, 16 cases) — JSON / lead_type / email / honeypot / rate-limit gates, platform-lead branch, `confirm_advisor_id` fast-path (404, happy, dedup), matching flow (`dry_run`, `no_more_matches`, tier-based `revenue_value_cents`).
- `__tests__/api/advisor-lead.test.ts` (new, 14 cases) — name / phone / email / consent validation, AU vs international phone branches, rate-limit, happy + international paths, duplicate-key tolerance, insert-error 500, oversize-field sanitisation.
- `__tests__/api/quiz-lead.test.ts` (3 → 9 cases) — adds invalid-JSON, disposable-email, rate-limit, mixed-case email, missing top_match, non-array answers, with proper mocks for `rate-limit-db`, `quiz-history`, and `supabase/server`.
- `__tests__/helpers.ts` — extends the shared chainable mock builder with the remaining PostgREST chain methods (`not`, `or`, `is`, `ilike`, etc.) so tests exercising filters like `.not("col", "is", null)` work without per-test overrides.

## Test plan

- [x] `npm test` — 3330 passing across 209 files (no regressions from helpers change)
- [x] `npx eslint <new files> --max-warnings 0` — clean
- [ ] CI gates green
- [ ] Auto-merge once approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)