### PR TITLE
test(advisor-auth): cover /session, /verify, /profile routes

### DIFF
--- a/__tests__/api/advisor-auth-profile.test.ts
+++ b/__tests__/api/advisor-auth-profile.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { createChainableBuilder } from "@/__tests__/helpers";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const mockGetUser = vi.fn();
+const mockServerFrom = vi.fn();
+const mockAdminFrom = vi.fn();
+const supabaseCalls: Record<string, { method: string; args: unknown[] }[]> = {};
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({
+    auth: { getUser: mockGetUser },
+    from: mockServerFrom,
+  })),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({ from: mockAdminFrom }),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  isRateLimited: vi.fn(() => Promise.resolve(false)),
+}));
+
+import { PATCH } from "@/app/api/advisor-auth/profile/route";
+import { isRateLimited } from "@/lib/rate-limit";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function makePatch(
+  body: Record<string, unknown>,
+  cookie?: string,
+): NextRequest {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (cookie) headers.cookie = `advisor_session=${cookie}`;
+  return new NextRequest("http://localhost/api/advisor-auth/profile", {
+    method: "PATCH",
+    body: JSON.stringify(body),
+    headers,
+  });
+}
+
+function resetCalls() {
+  for (const k of Object.keys(supabaseCalls)) delete supabaseCalls[k];
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("PATCH /api/advisor-auth/profile", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetCalls();
+    mockServerFrom.mockReset();
+    mockAdminFrom.mockReset();
+    mockServerFrom.mockImplementation((table: string) =>
+      createChainableBuilder(table, supabaseCalls),
+    );
+    mockAdminFrom.mockImplementation((table: string) =>
+      createChainableBuilder(table, supabaseCalls),
+    );
+    (isRateLimited as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+  });
+
+  it("returns 429 when rate limited", async () => {
+    (isRateLimited as ReturnType<typeof vi.fn>).mockResolvedValueOnce(true);
+    const res = await PATCH(makePatch({ bio: "hi" }));
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 401 when no auth user and no legacy session", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    const res = await PATCH(makePatch({ bio: "hi" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("updates allowed fields when authed via supabase", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "u-1", email: "a@b.com" } },
+    });
+    mockAdminFrom.mockImplementation((table: string) => {
+      const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "professionals") {
+        b.maybeSingle = vi.fn(() =>
+          Promise.resolve({ data: { id: 99 }, error: null }),
+        );
+      }
+      return b;
+    });
+
+    const res = await PATCH(
+      makePatch({
+        bio: "New bio",
+        website: "https://example.com",
+        // Disallowed field — should be silently dropped
+        verified: true,
+        rating: 5,
+      }),
+    );
+    expect(res.status).toBe(200);
+
+    // Server client (createClient) is what runs the update
+    const proCalls = supabaseCalls.professionals || [];
+    const updateCall = proCalls.find((c) => c.method === "update");
+    expect(updateCall).toBeDefined();
+    const args = updateCall?.args[0] as Record<string, unknown>;
+    expect(args.bio).toBe("New bio");
+    expect(args.website).toBe("https://example.com");
+    // Disallowed fields must NOT leak into the update
+    expect(args.verified).toBeUndefined();
+    expect(args.rating).toBeUndefined();
+    expect(typeof args.updated_at).toBe("string");
+  });
+
+  it("returns 500 when the update query errors", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "u-2", email: "a@b.com" } },
+    });
+    mockAdminFrom.mockImplementation((table: string) => {
+      const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "professionals") {
+        b.maybeSingle = vi.fn(() =>
+          Promise.resolve({ data: { id: 99 }, error: null }),
+        );
+      }
+      return b;
+    });
+    mockServerFrom.mockImplementation((table: string) => {
+      const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "professionals") {
+        // Override the awaited update result
+        b.eq = vi.fn(() =>
+          Promise.resolve({ data: null, error: { message: "db error" } }),
+        );
+      }
+      return b;
+    });
+
+    const res = await PATCH(makePatch({ bio: "hi" }));
+    expect(res.status).toBe(500);
+  });
+
+  it("authenticates via legacy session cookie when supabase user is absent", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    const futureExpiry = new Date(Date.now() + 86400 * 1000).toISOString();
+    mockAdminFrom.mockImplementation((table: string) => {
+      const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "advisor_sessions") {
+        b.single = vi.fn(() =>
+          Promise.resolve({
+            data: { professional_id: 88, expires_at: futureExpiry },
+            error: null,
+          }),
+        );
+      }
+      return b;
+    });
+
+    const res = await PATCH(
+      makePatch({ bio: "from legacy" }, "legacy-cookie"),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 401 when legacy session is expired", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    const pastExpiry = new Date(Date.now() - 1000).toISOString();
+    mockAdminFrom.mockImplementation((table: string) => {
+      const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "advisor_sessions") {
+        b.single = vi.fn(() =>
+          Promise.resolve({
+            data: { professional_id: 88, expires_at: pastExpiry },
+            error: null,
+          }),
+        );
+      }
+      return b;
+    });
+
+    const res = await PATCH(makePatch({ bio: "x" }, "stale-cookie"));
+    expect(res.status).toBe(401);
+  });
+});

--- a/__tests__/api/advisor-auth-session.test.ts
+++ b/__tests__/api/advisor-auth-session.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { createChainableBuilder } from "@/__tests__/helpers";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const mockGetUser = vi.fn();
+const mockSignOut = vi.fn(() => Promise.resolve({ error: null }));
+const mockServerFrom = vi.fn();
+const mockAdminFrom = vi.fn();
+const supabaseCalls: Record<string, { method: string; args: unknown[] }[]> = {};
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({
+    auth: { getUser: mockGetUser, signOut: mockSignOut },
+    from: mockServerFrom,
+  })),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({ from: mockAdminFrom }),
+}));
+
+import { GET, DELETE } from "@/app/api/advisor-auth/session/route";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function reqWithCookie(cookie?: string): NextRequest {
+  const headers: Record<string, string> = {};
+  if (cookie) headers.cookie = `advisor_session=${cookie}`;
+  return new NextRequest("http://localhost/api/advisor-auth/session", {
+    method: "GET",
+    headers,
+  });
+}
+
+function deleteReqWithCookie(cookie?: string): NextRequest {
+  const headers: Record<string, string> = {};
+  if (cookie) headers.cookie = `advisor_session=${cookie}`;
+  return new NextRequest("http://localhost/api/advisor-auth/session", {
+    method: "DELETE",
+    headers,
+  });
+}
+
+const ADVISOR = {
+  id: 7,
+  name: "Test Advisor",
+  slug: "test-advisor",
+  email: "advisor@test.com",
+  status: "active",
+  auth_user_id: null,
+};
+
+function resetCalls() {
+  for (const k of Object.keys(supabaseCalls)) delete supabaseCalls[k];
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("GET /api/advisor-auth/session", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetCalls();
+    mockServerFrom.mockReset();
+    mockAdminFrom.mockReset();
+    mockServerFrom.mockImplementation((table: string) =>
+      createChainableBuilder(table, supabaseCalls),
+    );
+    mockAdminFrom.mockImplementation((table: string) =>
+      createChainableBuilder(table, supabaseCalls),
+    );
+  });
+
+  it("returns 401 when no auth user and no legacy cookie", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    const res = await GET(reqWithCookie());
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json.error).toBe("Not authenticated");
+  });
+
+  it("returns advisor with authMethod=supabase when supabase user is linked", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "u-123", email: "advisor@test.com" } },
+    });
+    mockAdminFrom.mockImplementation((table: string) => {
+      const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "professionals") {
+        b.maybeSingle = vi.fn(() =>
+          Promise.resolve({
+            data: { ...ADVISOR, auth_user_id: "u-123" },
+            error: null,
+          }),
+        );
+      }
+      return b;
+    });
+
+    const res = await GET(reqWithCookie());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.authMethod).toBe("supabase");
+    expect(json.advisor.id).toBe(7);
+  });
+
+  it("links auth_user_id when not yet set on advisor row", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "u-456", email: "advisor@test.com" } },
+    });
+    mockAdminFrom.mockImplementation((table: string) => {
+      const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "professionals") {
+        b.maybeSingle = vi.fn(() =>
+          Promise.resolve({
+            data: { ...ADVISOR, auth_user_id: null },
+            error: null,
+          }),
+        );
+      }
+      return b;
+    });
+
+    const res = await GET(reqWithCookie());
+    expect(res.status).toBe(200);
+    // Should have called update on professionals to backfill auth_user_id
+    const proCalls = supabaseCalls.professionals || [];
+    const updateCall = proCalls.find((c) => c.method === "update");
+    expect(updateCall).toBeDefined();
+    const updateArgs = updateCall?.args[0] as Record<string, unknown>;
+    expect(updateArgs.auth_user_id).toBe("u-456");
+  });
+
+  it("returns advisor with authMethod=legacy for valid legacy session", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    const futureExpiry = new Date(Date.now() + 86400 * 1000).toISOString();
+    mockAdminFrom.mockImplementation((table: string) => {
+      const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "advisor_sessions") {
+        b.single = vi.fn(() =>
+          Promise.resolve({
+            data: { professional_id: 7, expires_at: futureExpiry },
+            error: null,
+          }),
+        );
+      }
+      if (table === "professionals") {
+        b.single = vi.fn(() => Promise.resolve({ data: ADVISOR, error: null }));
+      }
+      return b;
+    });
+
+    const res = await GET(reqWithCookie("legacy-token"));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.authMethod).toBe("legacy");
+  });
+
+  it("returns 401 and clears cookie when legacy session is expired", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    const pastExpiry = new Date(Date.now() - 86400 * 1000).toISOString();
+    mockAdminFrom.mockImplementation((table: string) => {
+      const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "advisor_sessions") {
+        b.single = vi.fn(() =>
+          Promise.resolve({
+            data: { professional_id: 7, expires_at: pastExpiry },
+            error: null,
+          }),
+        );
+      }
+      return b;
+    });
+
+    const res = await GET(reqWithCookie("legacy-stale"));
+    expect(res.status).toBe(401);
+    // Cookie should be cleared via Set-Cookie with empty/expiry
+    const setCookie = res.headers.get("set-cookie") || "";
+    expect(setCookie).toContain("advisor_session=");
+  });
+});
+
+describe("DELETE /api/advisor-auth/session", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetCalls();
+    mockServerFrom.mockReset();
+    mockAdminFrom.mockReset();
+    mockServerFrom.mockImplementation((table: string) =>
+      createChainableBuilder(table, supabaseCalls),
+    );
+    mockAdminFrom.mockImplementation((table: string) =>
+      createChainableBuilder(table, supabaseCalls),
+    );
+  });
+
+  it("signs out and clears cookie even with no legacy session", async () => {
+    const res = await DELETE(deleteReqWithCookie());
+    expect(res.status).toBe(200);
+    expect(mockSignOut).toHaveBeenCalled();
+  });
+
+  it("deletes legacy session row when cookie is present", async () => {
+    const res = await DELETE(deleteReqWithCookie("legacy-token"));
+    expect(res.status).toBe(200);
+    const sessCalls = supabaseCalls.advisor_sessions || [];
+    expect(sessCalls.some((c) => c.method === "delete")).toBe(true);
+  });
+
+  it("still returns success when supabase signOut throws", async () => {
+    mockSignOut.mockRejectedValueOnce(new Error("network blip"));
+    const res = await DELETE(deleteReqWithCookie("legacy-token"));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.success).toBe(true);
+  });
+});

--- a/__tests__/api/advisor-auth-verify.test.ts
+++ b/__tests__/api/advisor-auth-verify.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { createChainableBuilder } from "@/__tests__/helpers";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const mockFrom = vi.fn();
+const supabaseCalls: Record<string, { method: string; args: unknown[] }[]> = {};
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({ from: mockFrom })),
+}));
+
+import { POST } from "@/app/api/advisor-auth/verify/route";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function makeReq(body: Record<string, unknown>): NextRequest {
+  return new NextRequest("http://localhost/api/advisor-auth/verify", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function resetCalls() {
+  for (const k of Object.keys(supabaseCalls)) delete supabaseCalls[k];
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("POST /api/advisor-auth/verify", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetCalls();
+    mockFrom.mockReset();
+    mockFrom.mockImplementation((table: string) =>
+      createChainableBuilder(table, supabaseCalls),
+    );
+  });
+
+  it("returns 400 when token is missing", async () => {
+    const res = await POST(makeReq({}));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe("Token required");
+  });
+
+  it("returns 401 when token is not found", async () => {
+    mockFrom.mockImplementation((table: string) => {
+      const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "advisor_auth_tokens") {
+        b.single = vi.fn(() => Promise.resolve({ data: null, error: null }));
+      }
+      return b;
+    });
+
+    const res = await POST(makeReq({ token: "nope" }));
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe("Invalid or expired link");
+  });
+
+  it("returns 401 when token has already been used", async () => {
+    mockFrom.mockImplementation((table: string) => {
+      const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "advisor_auth_tokens") {
+        b.single = vi.fn(() =>
+          Promise.resolve({
+            data: {
+              id: "tok-1",
+              professional_id: 5,
+              expires_at: new Date(Date.now() + 60_000).toISOString(),
+              used_at: new Date(Date.now() - 1000).toISOString(),
+            },
+            error: null,
+          }),
+        );
+      }
+      return b;
+    });
+
+    const res = await POST(makeReq({ token: "used" }));
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe("This link has already been used");
+  });
+
+  it("returns 401 when token is expired", async () => {
+    mockFrom.mockImplementation((table: string) => {
+      const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "advisor_auth_tokens") {
+        b.single = vi.fn(() =>
+          Promise.resolve({
+            data: {
+              id: "tok-2",
+              professional_id: 5,
+              expires_at: new Date(Date.now() - 60_000).toISOString(),
+              used_at: null,
+            },
+            error: null,
+          }),
+        );
+      }
+      return b;
+    });
+
+    const res = await POST(makeReq({ token: "expired" }));
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe(
+      "This link has expired. Please request a new one.",
+    );
+  });
+
+  it("verifies a valid token, marks used, creates session, sets cookie", async () => {
+    mockFrom.mockImplementation((table: string) => {
+      const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "advisor_auth_tokens") {
+        b.single = vi.fn(() =>
+          Promise.resolve({
+            data: {
+              id: "tok-3",
+              professional_id: 11,
+              expires_at: new Date(Date.now() + 60_000).toISOString(),
+              used_at: null,
+            },
+            error: null,
+          }),
+        );
+      }
+      if (table === "professionals") {
+        b.single = vi.fn(() =>
+          Promise.resolve({
+            data: {
+              id: 11,
+              name: "Verified Advisor",
+              slug: "verified-advisor",
+              firm_name: "VA Co",
+              email: "verified@advisor.test",
+              photo_url: null,
+            },
+            error: null,
+          }),
+        );
+      }
+      return b;
+    });
+
+    const res = await POST(makeReq({ token: "valid" }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.success).toBe(true);
+    expect(json.advisor.id).toBe(11);
+
+    // Token marked used
+    const tokenCalls = supabaseCalls.advisor_auth_tokens || [];
+    expect(tokenCalls.some((c) => c.method === "update")).toBe(true);
+
+    // Session row inserted
+    const sessionCalls = supabaseCalls.advisor_sessions || [];
+    const insertCall = sessionCalls.find((c) => c.method === "insert");
+    expect(insertCall).toBeDefined();
+    const insertArgs = insertCall?.args[0] as Record<string, unknown>;
+    expect(insertArgs.professional_id).toBe(11);
+    expect(typeof insertArgs.session_token).toBe("string");
+    expect((insertArgs.session_token as string).length).toBeGreaterThan(32);
+
+    // advisor_session cookie set
+    const setCookie = res.headers.get("set-cookie") || "";
+    expect(setCookie).toContain("advisor_session=");
+    expect(setCookie.toLowerCase()).toContain("httponly");
+    expect(setCookie.toLowerCase()).toContain("samesite=lax");
+  });
+
+  it("returns 500 when an unexpected error is thrown", async () => {
+    mockFrom.mockImplementation(() => {
+      throw new Error("DB connection lost");
+    });
+
+    const res = await POST(makeReq({ token: "boom" }));
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe("Failed");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds **20 new test cases** across three previously-untested advisor-auth routes.
- `__tests__/api/advisor-auth-session.test.ts` (8) — GET unauth / Supabase-auth / legacy-auth, auth_user_id linking on first login, expired-legacy 401 with cookie clear; DELETE happy / legacy-delete / signOut-throws-but-still-200.
- `__tests__/api/advisor-auth-verify.test.ts` (6) — missing-token 400, invalid / used / expired token 401s, valid-token happy path (token marked used, session inserted, httpOnly+SameSite cookie set), thrown-error 500.
- `__tests__/api/advisor-auth-profile.test.ts` (6) — rate-limit 429, unauth 401, allow-list update (with `verified`/`rating` leaks blocked), update-error 500, legacy-cookie auth happy + expired-legacy 401.

The `/login` route already had `__tests__/api/advisor-auth.test.ts`; this PR fills out the remaining advisor-auth surface area.

## Test plan

- [x] `npm test -- __tests__/api/advisor-auth-*.test.ts` — 20/20 passing
- [x] `npx eslint <new files> --max-warnings 0` — clean
- [ ] CI gates green
- [ ] Auto-merge once approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)