### PR TITLE
test(advisor-auth): cover /topup, /notifications, /request-review

### DIFF
--- a/__tests__/api/advisor-auth-notifications.test.ts
+++ b/__tests__/api/advisor-auth-notifications.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { createChainableBuilder } from "@/__tests__/helpers";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const mockGetUser = vi.fn();
+const mockServerFrom = vi.fn();
+const mockAdminFrom = vi.fn();
+const supabaseCalls: Record<string, { method: string; args: unknown[] }[]> = {};
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({
+    auth: { getUser: mockGetUser },
+    from: mockServerFrom,
+  })),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({ from: mockAdminFrom }),
+}));
+
+import { GET, PATCH } from "@/app/api/advisor-auth/notifications/route";
+
+function makeGet(): NextRequest {
+  return new NextRequest("http://localhost/api/advisor-auth/notifications", {
+    method: "GET",
+  });
+}
+
+function makePatch(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/advisor-auth/notifications", {
+    method: "PATCH",
+    body: typeof body === "string" ? body : JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function authedAdvisor() {
+  mockGetUser.mockResolvedValue({
+    data: { user: { id: "u-1", email: "advisor@test.com" } },
+  });
+}
+
+function resetCalls() {
+  for (const k of Object.keys(supabaseCalls)) delete supabaseCalls[k];
+}
+
+describe("GET /api/advisor-auth/notifications", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetCalls();
+    mockServerFrom.mockReset();
+    mockAdminFrom.mockReset();
+    mockServerFrom.mockImplementation((table: string) =>
+      createChainableBuilder(table, supabaseCalls),
+    );
+    mockAdminFrom.mockImplementation((table: string) =>
+      createChainableBuilder(table, supabaseCalls),
+    );
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    const res = await GET(makeGet());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns DEFAULT_PREFS when advisor has no saved preferences", async () => {
+    authedAdvisor();
+    mockAdminFrom.mockImplementation((table: string) => {
+      const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "professionals") {
+        b.maybeSingle = vi.fn(() =>
+          Promise.resolve({ data: { id: 42 }, error: null }),
+        );
+        b.single = vi.fn(() =>
+          Promise.resolve({
+            data: { email_preferences: null },
+            error: null,
+          }),
+        );
+      }
+      return b;
+    });
+
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.prefs).toEqual({
+      new_lead: true,
+      weekly_summary: true,
+      billing_alerts: true,
+      review_new: false,
+    });
+  });
+
+  it("merges saved preferences with defaults", async () => {
+    authedAdvisor();
+    mockAdminFrom.mockImplementation((table: string) => {
+      const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "professionals") {
+        b.maybeSingle = vi.fn(() =>
+          Promise.resolve({ data: { id: 42 }, error: null }),
+        );
+        b.single = vi.fn(() =>
+          Promise.resolve({
+            data: {
+              email_preferences: {
+                new_lead: false,
+                review_new: true,
+              },
+            },
+            error: null,
+          }),
+        );
+      }
+      return b;
+    });
+
+    const res = await GET(makeGet());
+    const json = await res.json();
+    // saved overrides
+    expect(json.prefs.new_lead).toBe(false);
+    expect(json.prefs.review_new).toBe(true);
+    // defaults preserved for unspecified keys
+    expect(json.prefs.weekly_summary).toBe(true);
+    expect(json.prefs.billing_alerts).toBe(true);
+  });
+});
+
+describe("PATCH /api/advisor-auth/notifications", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetCalls();
+    mockServerFrom.mockReset();
+    mockAdminFrom.mockReset();
+    mockServerFrom.mockImplementation((table: string) =>
+      createChainableBuilder(table, supabaseCalls),
+    );
+    mockAdminFrom.mockImplementation((table: string) =>
+      createChainableBuilder(table, supabaseCalls),
+    );
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    const res = await PATCH(makePatch({ prefs: { new_lead: true } }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when prefs are missing", async () => {
+    authedAdvisor();
+    mockAdminFrom.mockImplementation((table: string) => {
+      const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "professionals") {
+        b.maybeSingle = vi.fn(() =>
+          Promise.resolve({ data: { id: 42 }, error: null }),
+        );
+      }
+      return b;
+    });
+    const res = await PATCH(makePatch({}));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when prefs is not an object", async () => {
+    authedAdvisor();
+    mockAdminFrom.mockImplementation((table: string) => {
+      const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "professionals") {
+        b.maybeSingle = vi.fn(() =>
+          Promise.resolve({ data: { id: 42 }, error: null }),
+        );
+      }
+      return b;
+    });
+    const res = await PATCH(makePatch({ prefs: "yes" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("coerces all preference fields to booleans", async () => {
+    authedAdvisor();
+    mockAdminFrom.mockImplementation((table: string) => {
+      const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "professionals") {
+        b.maybeSingle = vi.fn(() =>
+          Promise.resolve({ data: { id: 42 }, error: null }),
+        );
+      }
+      return b;
+    });
+
+    const res = await PATCH(
+      makePatch({
+        prefs: {
+          new_lead: 1,
+          weekly_summary: 0,
+          billing_alerts: "yes",
+          review_new: null,
+        },
+      }),
+    );
+    expect(res.status).toBe(200);
+
+    const proCalls = supabaseCalls.professionals || [];
+    const updateCall = proCalls.find((c) => c.method === "update");
+    expect(updateCall).toBeDefined();
+    const updateArgs = updateCall?.args[0] as Record<string, unknown>;
+    const prefs = updateArgs.email_preferences as Record<string, unknown>;
+    expect(prefs.new_lead).toBe(true);
+    expect(prefs.weekly_summary).toBe(false);
+    expect(prefs.billing_alerts).toBe(true);
+    expect(prefs.review_new).toBe(false);
+  });
+
+  it("returns success with warning when column is missing", async () => {
+    authedAdvisor();
+    mockAdminFrom.mockImplementation((table: string) => {
+      const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "professionals") {
+        b.maybeSingle = vi.fn(() =>
+          Promise.resolve({ data: { id: 42 }, error: null }),
+        );
+        // Override the awaited update result via .eq() terminal
+        b.eq = vi.fn(() =>
+          Promise.resolve({
+            data: null,
+            error: { message: "column does not exist" },
+          }),
+        );
+      }
+      return b;
+    });
+
+    const res = await PATCH(
+      makePatch({ prefs: { new_lead: true } }),
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.success).toBe(true);
+    expect(json.warning).toMatch(/in memory only/);
+  });
+});

--- a/__tests__/api/advisor-auth-request-review.test.ts
+++ b/__tests__/api/advisor-auth-request-review.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { createChainableBuilder } from "@/__tests__/helpers";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const mockGetUser = vi.fn();
+const mockServerFrom = vi.fn();
+const mockAdminFrom = vi.fn();
+const mockSendReviewRequest = vi.fn();
+const supabaseCalls: Record<string, { method: string; args: unknown[] }[]> = {};
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({
+    auth: { getUser: mockGetUser },
+    from: mockServerFrom,
+  })),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({ from: mockAdminFrom }),
+}));
+
+vi.mock("@/lib/advisor-emails", () => ({
+  sendReviewRequest: (...args: unknown[]) => mockSendReviewRequest(...args),
+}));
+
+import { POST } from "@/app/api/advisor-auth/request-review/route";
+
+function makePost(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/advisor-auth/request-review", {
+    method: "POST",
+    body: typeof body === "string" ? body : JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function authedAdvisor(advisorId = 42) {
+  mockGetUser.mockResolvedValue({
+    data: { user: { id: "u-1", email: "advisor@test.com" } },
+  });
+  mockAdminFrom.mockImplementation((table: string) => {
+    const b = createChainableBuilder(table, supabaseCalls);
+    if (table === "professionals") {
+      b.maybeSingle = vi.fn(() =>
+        Promise.resolve({ data: { id: advisorId }, error: null }),
+      );
+    }
+    return b;
+  });
+}
+
+function resetCalls() {
+  for (const k of Object.keys(supabaseCalls)) delete supabaseCalls[k];
+}
+
+describe("POST /api/advisor-auth/request-review", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetCalls();
+    mockServerFrom.mockReset();
+    mockAdminFrom.mockReset();
+    mockServerFrom.mockImplementation((table: string) =>
+      createChainableBuilder(table, supabaseCalls),
+    );
+    mockAdminFrom.mockImplementation((table: string) =>
+      createChainableBuilder(table, supabaseCalls),
+    );
+    mockSendReviewRequest.mockResolvedValue(true);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    const res = await POST(makePost({ leadId: 1 }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when leadId is missing", async () => {
+    authedAdvisor();
+    const res = await POST(makePost({}));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when leadId is not a number", async () => {
+    authedAdvisor();
+    const res = await POST(makePost({ leadId: "not-a-number" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when lead is not found", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "u-1", email: "advisor@test.com" } },
+    });
+    mockAdminFrom.mockImplementation((table: string) => {
+      const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "professionals") {
+        b.maybeSingle = vi.fn(() =>
+          Promise.resolve({ data: { id: 42 }, error: null }),
+        );
+      }
+      if (table === "professional_leads") {
+        b.single = vi.fn(() =>
+          Promise.resolve({ data: null, error: null }),
+        );
+      }
+      return b;
+    });
+    const res = await POST(makePost({ leadId: 99 }));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 when lead is not converted", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "u-1", email: "advisor@test.com" } },
+    });
+    mockAdminFrom.mockImplementation((table: string) => {
+      const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "professionals") {
+        b.maybeSingle = vi.fn(() =>
+          Promise.resolve({ data: { id: 42 }, error: null }),
+        );
+      }
+      if (table === "professional_leads") {
+        b.single = vi.fn(() =>
+          Promise.resolve({
+            data: {
+              id: 5,
+              user_name: "Lead",
+              user_email: "lead@test.com",
+              status: "new",
+              review_requested_at: null,
+            },
+            error: null,
+          }),
+        );
+      }
+      return b;
+    });
+    const res = await POST(makePost({ leadId: 5 }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/converted/);
+  });
+
+  it("returns 409 when review already requested", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "u-1", email: "advisor@test.com" } },
+    });
+    mockAdminFrom.mockImplementation((table: string) => {
+      const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "professionals") {
+        b.maybeSingle = vi.fn(() =>
+          Promise.resolve({ data: { id: 42 }, error: null }),
+        );
+      }
+      if (table === "professional_leads") {
+        b.single = vi.fn(() =>
+          Promise.resolve({
+            data: {
+              id: 5,
+              user_name: "Lead",
+              user_email: "lead@test.com",
+              status: "converted",
+              review_requested_at: "2026-04-01",
+            },
+            error: null,
+          }),
+        );
+      }
+      return b;
+    });
+    const res = await POST(makePost({ leadId: 5 }));
+    expect(res.status).toBe(409);
+  });
+
+  it("sends email and stamps review_requested_at on success", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "u-1", email: "advisor@test.com" } },
+    });
+    mockAdminFrom.mockImplementation((table: string) => {
+      const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "professionals") {
+        b.maybeSingle = vi.fn(() =>
+          Promise.resolve({ data: { id: 42 }, error: null }),
+        );
+        b.single = vi.fn(() =>
+          Promise.resolve({
+            data: { name: "Advisor", slug: "advisor" },
+            error: null,
+          }),
+        );
+      }
+      if (table === "professional_leads") {
+        b.single = vi.fn(() =>
+          Promise.resolve({
+            data: {
+              id: 5,
+              user_name: "Lead User",
+              user_email: "lead@test.com",
+              status: "converted",
+              review_requested_at: null,
+            },
+            error: null,
+          }),
+        );
+      }
+      return b;
+    });
+
+    const res = await POST(makePost({ leadId: 5 }));
+    expect(res.status).toBe(200);
+    expect(mockSendReviewRequest).toHaveBeenCalledWith(
+      "lead@test.com",
+      "Lead User",
+      "Advisor",
+      "advisor",
+    );
+    const leadCalls = supabaseCalls.professional_leads || [];
+    const updateCall = leadCalls.find((c) => c.method === "update");
+    expect(updateCall).toBeDefined();
+    const updateArgs = updateCall?.args[0] as Record<string, unknown>;
+    expect(typeof updateArgs.review_requested_at).toBe("string");
+  });
+
+  it("returns 500 when sendReviewRequest fails", async () => {
+    mockSendReviewRequest.mockResolvedValue(false);
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "u-1", email: "advisor@test.com" } },
+    });
+    mockAdminFrom.mockImplementation((table: string) => {
+      const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "professionals") {
+        b.maybeSingle = vi.fn(() =>
+          Promise.resolve({ data: { id: 42 }, error: null }),
+        );
+        b.single = vi.fn(() =>
+          Promise.resolve({
+            data: { name: "Advisor", slug: "advisor" },
+            error: null,
+          }),
+        );
+      }
+      if (table === "professional_leads") {
+        b.single = vi.fn(() =>
+          Promise.resolve({
+            data: {
+              id: 5,
+              user_name: "Lead",
+              user_email: "lead@test.com",
+              status: "converted",
+              review_requested_at: null,
+            },
+            error: null,
+          }),
+        );
+      }
+      return b;
+    });
+
+    const res = await POST(makePost({ leadId: 5 }));
+    expect(res.status).toBe(500);
+  });
+});

--- a/__tests__/api/advisor-auth-topup.test.ts
+++ b/__tests__/api/advisor-auth-topup.test.ts
@@ -1,0 +1,426 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { createChainableBuilder } from "@/__tests__/helpers";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const mockGetUser = vi.fn();
+const mockServerFrom = vi.fn();
+const mockAdminFrom = vi.fn();
+const supabaseCalls: Record<string, { method: string; args: unknown[] }[]> = {};
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({
+    auth: { getUser: mockGetUser },
+    from: mockServerFrom,
+  })),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({ from: mockAdminFrom }),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  isRateLimited: vi.fn(() => Promise.resolve(false)),
+}));
+
+vi.mock("@/lib/url", () => ({
+  getSiteUrl: () => "https://invest.com.au",
+}));
+
+vi.mock("@/lib/advisor-billing", () => ({
+  DEFAULT_TOPUP_CENTS: 20000,
+}));
+
+const mockCustomerCreate = vi.fn();
+const mockCheckoutCreate = vi.fn();
+let throwOnGetStripe = false;
+vi.mock("@/lib/stripe", () => ({
+  getStripe: () => {
+    if (throwOnGetStripe) throw new Error("Stripe not configured");
+    return {
+      customers: { create: mockCustomerCreate },
+      checkout: { sessions: { create: mockCheckoutCreate } },
+    };
+  },
+}));
+
+import { POST, GET } from "@/app/api/advisor-auth/topup/route";
+import { isRateLimited } from "@/lib/rate-limit";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function makePost(body: Record<string, unknown>, cookie?: string): NextRequest {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (cookie) headers.cookie = `advisor_session=${cookie}`;
+  return new NextRequest("http://localhost/api/advisor-auth/topup", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers,
+  });
+}
+
+function makeGet(cookie?: string): NextRequest {
+  const headers: Record<string, string> = {};
+  if (cookie) headers.cookie = `advisor_session=${cookie}`;
+  return new NextRequest("http://localhost/api/advisor-auth/topup", {
+    method: "GET",
+    headers,
+  });
+}
+
+function authedAdvisor(advisorId = 42) {
+  mockGetUser.mockResolvedValue({
+    data: { user: { id: "u-1", email: "advisor@test.com" } },
+  });
+  mockAdminFrom.mockImplementation((table: string) => {
+    const b = createChainableBuilder(table, supabaseCalls);
+    if (table === "professionals") {
+      b.maybeSingle = vi.fn(() =>
+        Promise.resolve({ data: { id: advisorId }, error: null }),
+      );
+    }
+    return b;
+  });
+}
+
+function resetCalls() {
+  for (const k of Object.keys(supabaseCalls)) delete supabaseCalls[k];
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("POST /api/advisor-auth/topup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetCalls();
+    throwOnGetStripe = false;
+    mockServerFrom.mockReset();
+    mockAdminFrom.mockReset();
+    mockServerFrom.mockImplementation((table: string) =>
+      createChainableBuilder(table, supabaseCalls),
+    );
+    mockAdminFrom.mockImplementation((table: string) =>
+      createChainableBuilder(table, supabaseCalls),
+    );
+    (isRateLimited as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+    mockCustomerCreate.mockResolvedValue({ id: "cus_new_001" });
+    mockCheckoutCreate.mockResolvedValue({
+      id: "cs_test_001",
+      url: "https://checkout.stripe.com/c/cs_test_001",
+    });
+  });
+
+  it("returns 429 when rate limited", async () => {
+    (isRateLimited as ReturnType<typeof vi.fn>).mockResolvedValueOnce(true);
+    const res = await POST(makePost({}));
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    const res = await POST(makePost({}));
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects amount < $50", async () => {
+    authedAdvisor();
+    const res = await POST(makePost({ amount_cents: 100 }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/between \$50 and \$2,000/);
+  });
+
+  it("rejects amount > $2000", async () => {
+    authedAdvisor();
+    const res = await POST(makePost({ amount_cents: 300000 }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when professional not found", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "u-1", email: "advisor@test.com" } },
+    });
+    mockAdminFrom.mockImplementation((table: string) => {
+      const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "professionals") {
+        // First .maybeSingle() returns the advisor id (auth path)
+        b.maybeSingle = vi.fn(() =>
+          Promise.resolve({ data: { id: 42 }, error: null }),
+        );
+        // .single() (the pro-lookup) returns null
+        b.single = vi.fn(() =>
+          Promise.resolve({ data: null, error: null }),
+        );
+      }
+      return b;
+    });
+
+    const res = await POST(makePost({}));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 503 when Stripe is not configured", async () => {
+    throwOnGetStripe = true;
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "u-1", email: "advisor@test.com" } },
+    });
+    mockAdminFrom.mockImplementation((table: string) => {
+      const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "professionals") {
+        b.maybeSingle = vi.fn(() =>
+          Promise.resolve({ data: { id: 42 }, error: null }),
+        );
+        b.single = vi.fn(() =>
+          Promise.resolve({
+            data: {
+              id: 42,
+              name: "Advisor",
+              email: "advisor@test.com",
+              stripe_customer_id: "cus_existing",
+            },
+            error: null,
+          }),
+        );
+      }
+      return b;
+    });
+
+    const res = await POST(makePost({}));
+    expect(res.status).toBe(503);
+  });
+
+  it("uses pack pricing when pack_slug=growth", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "u-1", email: "advisor@test.com" } },
+    });
+    mockAdminFrom.mockImplementation((table: string) => {
+      const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "professionals") {
+        b.maybeSingle = vi.fn(() =>
+          Promise.resolve({ data: { id: 42 }, error: null }),
+        );
+        b.single = vi.fn(() =>
+          Promise.resolve({
+            data: {
+              id: 42,
+              name: "Advisor",
+              email: "advisor@test.com",
+              stripe_customer_id: "cus_existing",
+            },
+            error: null,
+          }),
+        );
+      }
+      if (table === "advisor_credit_topups") {
+        b.single = vi.fn(() =>
+          Promise.resolve({ data: { id: 555 }, error: null }),
+        );
+      }
+      return b;
+    });
+
+    const res = await POST(makePost({ pack_slug: "growth" }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.url).toBe("https://checkout.stripe.com/c/cs_test_001");
+
+    const callArg = mockCheckoutCreate.mock.calls[0][0];
+    expect(callArg.line_items[0].price_data.unit_amount).toBe(44900);
+    expect(callArg.metadata.type).toBe("advisor_credit_topup");
+    expect(callArg.metadata.pack_slug).toBe("growth");
+    expect(callArg.metadata.pack_leads).toBe("12");
+  });
+
+  it("creates a Stripe customer when stripe_customer_id is missing", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "u-1", email: "advisor@test.com" } },
+    });
+    mockAdminFrom.mockImplementation((table: string) => {
+      const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "professionals") {
+        b.maybeSingle = vi.fn(() =>
+          Promise.resolve({ data: { id: 42 }, error: null }),
+        );
+        b.single = vi.fn(() =>
+          Promise.resolve({
+            data: {
+              id: 42,
+              name: "Advisor",
+              email: "advisor@test.com",
+              stripe_customer_id: null,
+            },
+            error: null,
+          }),
+        );
+      }
+      if (table === "advisor_credit_topups") {
+        b.single = vi.fn(() =>
+          Promise.resolve({ data: { id: 555 }, error: null }),
+        );
+      }
+      return b;
+    });
+
+    const res = await POST(makePost({ amount_cents: 50000 }));
+    expect(res.status).toBe(200);
+    expect(mockCustomerCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: "advisor@test.com",
+        name: "Advisor",
+      }),
+    );
+    const callArg = mockCheckoutCreate.mock.calls[0][0];
+    expect(callArg.customer).toBe("cus_new_001");
+  });
+
+  it("uses 'advisor_featured' type for featured_monthly pack", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "u-1", email: "advisor@test.com" } },
+    });
+    mockAdminFrom.mockImplementation((table: string) => {
+      const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "professionals") {
+        b.maybeSingle = vi.fn(() =>
+          Promise.resolve({ data: { id: 42 }, error: null }),
+        );
+        b.single = vi.fn(() =>
+          Promise.resolve({
+            data: {
+              id: 42,
+              name: "Advisor",
+              email: "advisor@test.com",
+              stripe_customer_id: "cus_existing",
+            },
+            error: null,
+          }),
+        );
+      }
+      if (table === "advisor_credit_topups") {
+        b.single = vi.fn(() =>
+          Promise.resolve({ data: { id: 555 }, error: null }),
+        );
+      }
+      return b;
+    });
+
+    const res = await POST(makePost({ pack_slug: "featured_monthly" }));
+    expect(res.status).toBe(200);
+    const callArg = mockCheckoutCreate.mock.calls[0][0];
+    expect(callArg.metadata.type).toBe("advisor_featured");
+    expect(callArg.line_items[0].price_data.unit_amount).toBe(14900);
+  });
+});
+
+describe("GET /api/advisor-auth/topup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetCalls();
+    mockServerFrom.mockReset();
+    mockAdminFrom.mockReset();
+    mockServerFrom.mockImplementation((table: string) =>
+      createChainableBuilder(table, supabaseCalls),
+    );
+    mockAdminFrom.mockImplementation((table: string) =>
+      createChainableBuilder(table, supabaseCalls),
+    );
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    const res = await GET(makeGet());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns balance and topup history with derived free_leads_remaining", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "u-1", email: "advisor@test.com" } },
+    });
+    mockAdminFrom.mockImplementation((table: string) => {
+      const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "professionals") {
+        let callCount = 0;
+        b.maybeSingle = vi.fn(() => {
+          callCount++;
+          // First call: auth lookup
+          if (callCount === 1) {
+            return Promise.resolve({ data: { id: 42 }, error: null });
+          }
+          return Promise.resolve({ data: null, error: null });
+        });
+        b.single = vi.fn(() =>
+          Promise.resolve({
+            data: {
+              credit_balance_cents: 50000,
+              lifetime_credit_cents: 100000,
+              lifetime_lead_spend_cents: 49000,
+              free_leads_used: 1,
+              lead_price_cents: 4900,
+            },
+            error: null,
+          }),
+        );
+      }
+      if (table === "advisor_credit_topups") {
+        // Make limit return an array directly (final terminal)
+        b.limit = vi.fn(() => {
+          supabaseCalls[table]?.push({ method: "limit", args: [] });
+          return Promise.resolve({
+            data: [
+              {
+                id: 1,
+                amount_cents: 50000,
+                status: "completed",
+                created_at: "2026-01-01",
+              },
+            ],
+            error: null,
+          });
+        });
+      }
+      return b;
+    });
+
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.balance_cents).toBe(50000);
+    expect(json.lifetime_credit_cents).toBe(100000);
+    expect(json.free_leads_used).toBe(1);
+    expect(json.free_leads_remaining).toBe(1);
+    expect(json.lead_price_cents).toBe(4900);
+    expect(json.topups).toHaveLength(1);
+  });
+
+  it("falls back to defaults when professional row is missing", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "u-1", email: "advisor@test.com" } },
+    });
+    mockAdminFrom.mockImplementation((table: string) => {
+      const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "professionals") {
+        b.maybeSingle = vi.fn(() =>
+          Promise.resolve({ data: { id: 42 }, error: null }),
+        );
+        b.single = vi.fn(() =>
+          Promise.resolve({ data: null, error: null }),
+        );
+      }
+      if (table === "advisor_credit_topups") {
+        b.limit = vi.fn(() =>
+          Promise.resolve({ data: [], error: null }),
+        );
+      }
+      return b;
+    });
+
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.balance_cents).toBe(0);
+    expect(json.free_leads_remaining).toBe(2);
+    expect(json.lead_price_cents).toBe(4900);
+    expect(json.topups).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds **28 new test cases** across three more advisor-auth sub-routes.
- `advisor-auth-topup` (12) — POST rate-limit, unauth, \$50/\$2000 bounds, missing pro 404, Stripe-not-configured 503, pack pricing (growth), customer creation when `stripe_customer_id` is null, `featured_monthly` → `advisor_featured` type. GET unauth + balance + `free_leads_remaining` derivation + missing-pro defaults.
- `advisor-auth-notifications` (8) — GET unauth, default prefs, saved-overrides-default; PATCH unauth, missing/non-object prefs, boolean coercion, column-missing graceful fallback.
- `advisor-auth-request-review` (8) — unauth, missing/non-numeric `leadId`, lead-not-found 404, not-converted 400, already-requested 409, happy path (calls `sendReviewRequest`, stamps `review_requested_at`), email-failure 500.

After this, advisor-auth coverage spans 7 of 12 sub-routes (login, session, verify, profile, topup, notifications, request-review). Remaining untested: data, disputes, firm/*, payment, tier-upgrade.

## Test plan

- [x] `npm test -- __tests__/api/advisor-auth-{topup,notifications,request-review}.test.ts` — 28/28
- [x] `npx eslint <new files> --max-warnings 0` — clean
- [ ] CI gates green
- [ ] Auto-merge once approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)