### PR TITLE
test(advisor-auth): cover /payment and /tier-upgrade routes

### DIFF
--- a/__tests__/api/advisor-auth-payment.test.ts
+++ b/__tests__/api/advisor-auth-payment.test.ts
@@ -1,0 +1,261 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { createChainableBuilder } from "@/__tests__/helpers";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const mockAdminFrom = vi.fn();
+const supabaseCalls: Record<string, { method: string; args: unknown[] }[]> = {};
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({ from: mockAdminFrom }),
+}));
+
+vi.mock("@/lib/url", () => ({
+  getSiteUrl: () => "https://invest.com.au",
+}));
+
+const mockCustomerCreate = vi.fn();
+const mockCheckoutCreate = vi.fn();
+let throwOnGetStripe = false;
+vi.mock("@/lib/stripe", () => ({
+  getStripe: () => {
+    if (throwOnGetStripe) throw new Error("Stripe not configured");
+    return {
+      customers: { create: mockCustomerCreate },
+      checkout: { sessions: { create: mockCheckoutCreate } },
+    };
+  },
+}));
+
+import { POST } from "@/app/api/advisor-auth/payment/route";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function makePost(body: unknown, cookie?: string): NextRequest {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (cookie) headers.cookie = `advisor_session=${cookie}`;
+  return new NextRequest("http://localhost/api/advisor-auth/payment", {
+    method: "POST",
+    body: typeof body === "string" ? body : JSON.stringify(body),
+    headers,
+  });
+}
+
+function withSessionAndAdvisor(
+  professionalId = 42,
+  advisorOverrides: Record<string, unknown> = {},
+) {
+  mockAdminFrom.mockImplementation((table: string) => {
+    const b = createChainableBuilder(table, supabaseCalls);
+    if (table === "advisor_sessions") {
+      b.single = vi.fn(() =>
+        Promise.resolve({
+          data: {
+            professional_id: professionalId,
+            expires_at: new Date(Date.now() + 86400 * 1000).toISOString(),
+          },
+          error: null,
+        }),
+      );
+    }
+    if (table === "professionals") {
+      b.single = vi.fn(() =>
+        Promise.resolve({
+          data: {
+            id: professionalId,
+            name: "Advisor",
+            email: "advisor@test.com",
+            stripe_customer_id: "cus_existing",
+            status: "active",
+            ...advisorOverrides,
+          },
+          error: null,
+        }),
+      );
+    }
+    if (table === "advisor_credit_topups") {
+      b.single = vi.fn(() =>
+        Promise.resolve({ data: { id: 99 }, error: null }),
+      );
+    }
+    return b;
+  });
+}
+
+function resetCalls() {
+  for (const k of Object.keys(supabaseCalls)) delete supabaseCalls[k];
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("POST /api/advisor-auth/payment", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetCalls();
+    throwOnGetStripe = false;
+    mockAdminFrom.mockReset();
+    mockAdminFrom.mockImplementation((table: string) =>
+      createChainableBuilder(table, supabaseCalls),
+    );
+    mockCustomerCreate.mockResolvedValue({ id: "cus_new" });
+    mockCheckoutCreate.mockResolvedValue({
+      id: "cs_payment_001",
+      url: "https://checkout.stripe.com/c/cs_payment_001",
+    });
+  });
+
+  it("returns 401 when no session cookie", async () => {
+    const res = await POST(
+      makePost({ advisor_id: 42, credit_pack: "starter" }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when session is invalid/expired", async () => {
+    mockAdminFrom.mockImplementation((table: string) => {
+      const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "advisor_sessions") {
+        b.single = vi.fn(() => Promise.resolve({ data: null, error: null }));
+      }
+      return b;
+    });
+
+    const res = await POST(
+      makePost({ advisor_id: 42, credit_pack: "starter" }, "stale-token"),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    mockAdminFrom.mockImplementation((table: string) => {
+      const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "advisor_sessions") {
+        b.single = vi.fn(() =>
+          Promise.resolve({
+            data: {
+              professional_id: 42,
+              expires_at: new Date(Date.now() + 86400 * 1000).toISOString(),
+            },
+            error: null,
+          }),
+        );
+      }
+      return b;
+    });
+
+    const res = await POST(makePost("{not-json", "valid-token"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when advisor_id is missing", async () => {
+    withSessionAndAdvisor();
+    const res = await POST(makePost({ credit_pack: "starter" }, "valid"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when credit_pack is invalid", async () => {
+    withSessionAndAdvisor();
+    const res = await POST(
+      makePost({ advisor_id: 42, credit_pack: "bogus" }, "valid"),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 403 when advisor_id doesn't match session", async () => {
+    withSessionAndAdvisor(42);
+    const res = await POST(
+      makePost({ advisor_id: 99, credit_pack: "starter" }, "valid"),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 404 when advisor row not found", async () => {
+    mockAdminFrom.mockImplementation((table: string) => {
+      const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "advisor_sessions") {
+        b.single = vi.fn(() =>
+          Promise.resolve({
+            data: {
+              professional_id: 42,
+              expires_at: new Date(Date.now() + 86400 * 1000).toISOString(),
+            },
+            error: null,
+          }),
+        );
+      }
+      if (table === "professionals") {
+        b.single = vi.fn(() =>
+          Promise.resolve({ data: null, error: null }),
+        );
+      }
+      return b;
+    });
+
+    const res = await POST(
+      makePost({ advisor_id: 42, credit_pack: "starter" }, "valid"),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when advisor account is suspended", async () => {
+    withSessionAndAdvisor(42, { status: "suspended" });
+    const res = await POST(
+      makePost({ advisor_id: 42, credit_pack: "starter" }, "valid"),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 503 when Stripe is not configured", async () => {
+    throwOnGetStripe = true;
+    withSessionAndAdvisor();
+    const res = await POST(
+      makePost({ advisor_id: 42, credit_pack: "starter" }, "valid"),
+    );
+    expect(res.status).toBe(503);
+  });
+
+  it("creates a checkout session for starter pack", async () => {
+    withSessionAndAdvisor();
+    const res = await POST(
+      makePost({ advisor_id: 42, credit_pack: "starter" }, "valid"),
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.url).toBe("https://checkout.stripe.com/c/cs_payment_001");
+
+    const callArg = mockCheckoutCreate.mock.calls[0][0];
+    expect(callArg.line_items[0].price_data.unit_amount).toBe(19900);
+    expect(callArg.metadata.type).toBe("advisor_credit_topup");
+    expect(callArg.metadata.credits).toBe("5");
+  });
+
+  it("creates a Stripe customer when stripe_customer_id is null", async () => {
+    withSessionAndAdvisor(42, { stripe_customer_id: null });
+    const res = await POST(
+      makePost({ advisor_id: 42, credit_pack: "scale" }, "valid"),
+    );
+    expect(res.status).toBe(200);
+    expect(mockCustomerCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: "advisor@test.com",
+        name: "Advisor",
+      }),
+    );
+    const callArg = mockCheckoutCreate.mock.calls[0][0];
+    expect(callArg.customer).toBe("cus_new");
+    expect(callArg.line_items[0].price_data.unit_amount).toBe(79900);
+  });
+
+  it("returns 500 on unexpected error", async () => {
+    mockAdminFrom.mockImplementation(() => {
+      throw new Error("DB unreachable");
+    });
+    const res = await POST(
+      makePost({ advisor_id: 42, credit_pack: "starter" }, "valid"),
+    );
+    expect(res.status).toBe(500);
+  });
+});

--- a/__tests__/api/advisor-auth-tier-upgrade.test.ts
+++ b/__tests__/api/advisor-auth-tier-upgrade.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { createChainableBuilder } from "@/__tests__/helpers";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const mockServerFrom = vi.fn();
+const mockAdminFrom = vi.fn();
+const mockCookieStoreGet = vi.fn();
+const mockRecordFinancialAudit = vi.fn(() => Promise.resolve());
+const mockEnqueueJob = vi.fn(() => Promise.resolve());
+const mockCheckoutCreate = vi.fn();
+const supabaseCalls: Record<string, { method: string; args: unknown[] }[]> = {};
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(async () => ({ get: mockCookieStoreGet })),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({ from: mockServerFrom })),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({ from: mockAdminFrom }),
+}));
+
+vi.mock("@/lib/financial-audit", () => ({
+  recordFinancialAudit: (...args: unknown[]) =>
+    mockRecordFinancialAudit(...args),
+}));
+
+vi.mock("@/lib/job-queue", () => ({
+  enqueueJob: (...args: unknown[]) => mockEnqueueJob(...args),
+}));
+
+vi.mock("@/lib/url", () => ({
+  getSiteUrl: () => "https://invest.com.au",
+}));
+
+vi.mock("@/lib/stripe", () => ({
+  getStripe: () => ({
+    checkout: { sessions: { create: mockCheckoutCreate } },
+  }),
+}));
+
+import { POST } from "@/app/api/advisor-auth/tier-upgrade/route";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function makePost(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/advisor-auth/tier-upgrade", {
+    method: "POST",
+    body: typeof body === "string" ? body : JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function withCookieAndSession(
+  professionalId: number | null = 42,
+  expiresAt = new Date(Date.now() + 86400 * 1000).toISOString(),
+  hasCookie = true,
+) {
+  if (hasCookie) {
+    mockCookieStoreGet.mockReturnValue({ value: "session-token" });
+  } else {
+    mockCookieStoreGet.mockReturnValue(undefined);
+  }
+  mockServerFrom.mockImplementation((table: string) => {
+    const b = createChainableBuilder(table, supabaseCalls);
+    if (table === "advisor_sessions") {
+      b.maybeSingle = vi.fn(() =>
+        Promise.resolve({
+          data: professionalId
+            ? { professional_id: professionalId, expires_at: expiresAt }
+            : null,
+          error: null,
+        }),
+      );
+    }
+    return b;
+  });
+}
+
+function withAdvisorTier(currentTier: string) {
+  mockAdminFrom.mockImplementation((table: string) => {
+    const b = createChainableBuilder(table, supabaseCalls);
+    if (table === "professionals") {
+      b.maybeSingle = vi.fn(() =>
+        Promise.resolve({
+          data: {
+            id: 42,
+            email: "advisor@test.com",
+            name: "Advisor",
+            advisor_tier: currentTier,
+          },
+          error: null,
+        }),
+      );
+    }
+    return b;
+  });
+}
+
+function resetCalls() {
+  for (const k of Object.keys(supabaseCalls)) delete supabaseCalls[k];
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("POST /api/advisor-auth/tier-upgrade", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetCalls();
+    delete process.env.STRIPE_SECRET_KEY;
+    mockServerFrom.mockReset();
+    mockAdminFrom.mockReset();
+    mockServerFrom.mockImplementation((table: string) =>
+      createChainableBuilder(table, supabaseCalls),
+    );
+    mockAdminFrom.mockImplementation((table: string) =>
+      createChainableBuilder(table, supabaseCalls),
+    );
+    mockCheckoutCreate.mockResolvedValue({
+      id: "cs_tier_001",
+      url: "https://checkout.stripe.com/c/cs_tier_001",
+    });
+  });
+
+  it("returns 401 when no session cookie", async () => {
+    withCookieAndSession(42, undefined, false);
+    const res = await POST(makePost({ target_tier: "growth" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when session is expired", async () => {
+    withCookieAndSession(
+      42,
+      new Date(Date.now() - 86400 * 1000).toISOString(),
+    );
+    const res = await POST(makePost({ target_tier: "growth" }));
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe("Session expired");
+  });
+
+  it("returns 401 when session lookup returns null", async () => {
+    withCookieAndSession(null);
+    const res = await POST(makePost({ target_tier: "growth" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when target_tier is missing", async () => {
+    withCookieAndSession();
+    const res = await POST(makePost({}));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe("Missing target_tier");
+  });
+
+  it("returns 400 for unknown tier id", async () => {
+    withCookieAndSession();
+    const res = await POST(makePost({ target_tier: "platinum" }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe("Unknown tier");
+  });
+
+  it("returns 404 when advisor row missing", async () => {
+    withCookieAndSession();
+    mockAdminFrom.mockImplementation((table: string) => {
+      const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "professionals") {
+        b.maybeSingle = vi.fn(() =>
+          Promise.resolve({ data: null, error: null }),
+        );
+      }
+      return b;
+    });
+    const res = await POST(makePost({ target_tier: "growth" }));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 200 no-op when current tier matches target", async () => {
+    withCookieAndSession();
+    withAdvisorTier("growth");
+    const res = await POST(makePost({ target_tier: "growth" }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.message).toBe("Already on this tier");
+  });
+
+  it("downgrades immediately, audits, and enqueues confirmation email", async () => {
+    withCookieAndSession();
+    withAdvisorTier("pro");
+    const res = await POST(
+      makePost({ target_tier: "growth", billing: "monthly" }),
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.action).toBe("downgraded");
+    expect(json.tier).toBe("growth");
+
+    // Direct stamp on professionals
+    const proCalls = supabaseCalls.professionals || [];
+    const updateCall = proCalls.find((c) => c.method === "update");
+    expect(updateCall).toBeDefined();
+    const updateArgs = updateCall?.args[0] as Record<string, unknown>;
+    expect(updateArgs.advisor_tier).toBe("growth");
+    expect(updateArgs.tier_change_reason).toBe("self_service_downgrade");
+
+    expect(mockRecordFinancialAudit).toHaveBeenCalled();
+    expect(mockEnqueueJob).toHaveBeenCalledWith(
+      "send_email",
+      expect.objectContaining({ to: "advisor@test.com" }),
+    );
+  });
+
+  it("returns placeholder URL when Stripe is not configured (upgrade)", async () => {
+    withCookieAndSession();
+    withAdvisorTier("free");
+    const res = await POST(makePost({ target_tier: "growth" }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.action).toBe("stripe_not_configured");
+    expect(json.checkout_url).toContain("/upgrade/thanks?tier=growth");
+    expect(mockCheckoutCreate).not.toHaveBeenCalled();
+  });
+
+  it("creates Stripe subscription checkout for upgrades", async () => {
+    process.env.STRIPE_SECRET_KEY = "sk_test_xxx";
+    withCookieAndSession();
+    withAdvisorTier("free");
+    const res = await POST(
+      makePost({ target_tier: "pro", billing: "annual" }),
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.action).toBe("upgrade_checkout");
+    expect(json.checkout_url).toBe("https://checkout.stripe.com/c/cs_tier_001");
+
+    const callArg = mockCheckoutCreate.mock.calls[0][0];
+    expect(callArg.mode).toBe("subscription");
+    // Pro annual = 143000 per advisor-tiers.ts
+    expect(callArg.line_items[0].price_data.unit_amount).toBe(143000);
+    expect(callArg.line_items[0].price_data.recurring.interval).toBe("year");
+    expect(callArg.metadata.type).toBe("advisor_tier_upgrade");
+    expect(callArg.metadata.from_tier).toBe("free");
+    expect(callArg.metadata.to_tier).toBe("pro");
+  });
+
+  it("returns 500 when stripe checkout creation throws", async () => {
+    process.env.STRIPE_SECRET_KEY = "sk_test_xxx";
+    withCookieAndSession();
+    withAdvisorTier("free");
+    mockCheckoutCreate.mockRejectedValueOnce(new Error("Stripe API down"));
+    const res = await POST(makePost({ target_tier: "growth" }));
+    expect(res.status).toBe(500);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds **23 new test cases** across two more advisor-auth sub-routes.
- `advisor-auth-payment` (12) — 401 no cookie / expired session, 400 bad JSON / missing fields, 403 advisor_id mismatch / suspended, 404 missing advisor, 503 Stripe-not-configured, happy paths for starter pack + customer creation when `stripe_customer_id` is null, 500 on unexpected error.
- `advisor-auth-tier-upgrade` (11) — 401 no cookie / null or expired session, 400 missing / unknown target_tier, 404 missing advisor, 200 no-op when current==target, full downgrade path (direct stamp + financial audit + email job), Stripe-not-configured placeholder URL for upgrades, full upgrade Stripe checkout with annual recurring + metadata, 500 on Stripe API failure.

After this PR, advisor-auth coverage spans 9 of 12 sub-routes. Remaining untested: data, disputes, firm/* (analytics, invite, member, seat-request).

## Test plan

- [x] `npm test -- __tests__/api/advisor-auth-{payment,tier-upgrade}.test.ts` — 23/23
- [x] `npx eslint <new files> --max-warnings 0` — clean
- [ ] CI gates green
- [ ] Auto-merge once approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)