### PR TITLE
test(advisor-auth): cover /firm, /firm/member, /firm/seat-request

### DIFF
--- a/__tests__/api/advisor-auth-firm-member.test.ts
+++ b/__tests__/api/advisor-auth-firm-member.test.ts
@@ -1,0 +1,311 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { createChainableBuilder } from "@/__tests__/helpers";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const mockServerFrom = vi.fn();
+const mockAdminFrom = vi.fn();
+const supabaseCalls: Record<string, { method: string; args: unknown[] }[]> = {};
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({ from: mockServerFrom })),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({ from: mockAdminFrom }),
+}));
+
+import { PATCH, DELETE } from "@/app/api/advisor-auth/firm/member/route";
+
+function makePatch(body: unknown, cookie?: string): NextRequest {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (cookie) headers.cookie = `advisor_session=${cookie}`;
+  return new NextRequest("http://localhost/api/advisor-auth/firm/member", {
+    method: "PATCH",
+    body: typeof body === "string" ? body : JSON.stringify(body),
+    headers,
+  });
+}
+
+function makeDelete(memberId: number | string, cookie?: string): NextRequest {
+  const headers: Record<string, string> = {};
+  if (cookie) headers.cookie = `advisor_session=${cookie}`;
+  return new NextRequest(
+    `http://localhost/api/advisor-auth/firm/member?memberId=${memberId}`,
+    {
+      method: "DELETE",
+      headers,
+    },
+  );
+}
+
+function withFirmAdmin(adminId = 42, firmId = 7) {
+  mockServerFrom.mockImplementation((table: string) => {
+    const b = createChainableBuilder(table, supabaseCalls);
+    if (table === "advisor_sessions") {
+      b.single = vi.fn(() =>
+        Promise.resolve({
+          data: {
+            professional_id: adminId,
+            expires_at: new Date(Date.now() + 86400 * 1000).toISOString(),
+          },
+          error: null,
+        }),
+      );
+    }
+    if (table === "professionals") {
+      b.single = vi.fn(() =>
+        Promise.resolve({
+          data: {
+            id: adminId,
+            name: "Admin",
+            firm_id: firmId,
+            is_firm_admin: true,
+          },
+          error: null,
+        }),
+      );
+    }
+    return b;
+  });
+}
+
+function resetCalls() {
+  for (const k of Object.keys(supabaseCalls)) delete supabaseCalls[k];
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("PATCH /api/advisor-auth/firm/member", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetCalls();
+    mockServerFrom.mockReset();
+    mockAdminFrom.mockReset();
+    mockServerFrom.mockImplementation((table: string) =>
+      createChainableBuilder(table, supabaseCalls),
+    );
+    mockAdminFrom.mockImplementation((table: string) =>
+      createChainableBuilder(table, supabaseCalls),
+    );
+  });
+
+  it("returns 403 when no session cookie", async () => {
+    const res = await PATCH(makePatch({ memberId: 1, role: "manager" }));
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 for invalid JSON", async () => {
+    withFirmAdmin();
+    const res = await PATCH(makePatch("{not-json", "valid"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when memberId or role missing", async () => {
+    withFirmAdmin();
+    const res = await PATCH(makePatch({ memberId: 1 }, "valid"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for invalid role", async () => {
+    withFirmAdmin();
+    const res = await PATCH(
+      makePatch({ memberId: 1, role: "bogus" }, "valid"),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when member not in same firm", async () => {
+    withFirmAdmin();
+    mockAdminFrom.mockImplementation((table: string) => {
+      const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "professionals") {
+        b.single = vi.fn(() =>
+          Promise.resolve({ data: null, error: null }),
+        );
+      }
+      return b;
+    });
+    const res = await PATCH(
+      makePatch({ memberId: 99, role: "manager" }, "valid"),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("blocks self-demotion when no other owner exists", async () => {
+    withFirmAdmin();
+    mockAdminFrom.mockImplementation((table: string) => {
+      const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "professionals") {
+        b.single = vi.fn(() =>
+          Promise.resolve({
+            data: { id: 42, is_firm_admin: true },
+            error: null,
+          }),
+        );
+        // count of other owners — return 0 via thenable
+        b.neq = vi.fn(() => {
+          supabaseCalls[table]?.push({ method: "neq", args: [] });
+          return Object.assign(b, {
+            then: (cb: (v: unknown) => void) => {
+              cb({ count: 0, data: null, error: null });
+              return Promise.resolve();
+            },
+          });
+        });
+      }
+      return b;
+    });
+
+    const res = await PATCH(
+      makePatch({ memberId: 42, role: "member" }, "valid"),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/another owner first/);
+  });
+
+  it("updates a member's role and is_firm_admin auto-derived", async () => {
+    withFirmAdmin();
+    mockAdminFrom.mockImplementation((table: string) => {
+      const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "professionals") {
+        b.single = vi.fn(() =>
+          Promise.resolve({
+            data: { id: 99, is_firm_admin: false },
+            error: null,
+          }),
+        );
+        // The update awaits .eq() directly
+        b.eq = vi.fn(() => {
+          supabaseCalls[table]?.push({ method: "eq", args: [] });
+          return Object.assign(b, {
+            then: (cb: (v: unknown) => void) => {
+              cb({ data: null, error: null });
+              return Promise.resolve();
+            },
+          });
+        });
+      }
+      return b;
+    });
+
+    const res = await PATCH(
+      makePatch({ memberId: 99, role: "manager" }, "valid"),
+    );
+    expect(res.status).toBe(200);
+
+    const proCalls = supabaseCalls.professionals || [];
+    const updateCall = proCalls.find((c) => c.method === "update");
+    expect(updateCall).toBeDefined();
+    const updateArgs = updateCall?.args[0] as Record<string, unknown>;
+    expect(updateArgs.role).toBe("manager");
+    expect(updateArgs.is_firm_admin).toBe(true);
+  });
+
+  it("respects explicit is_firm_admin=false", async () => {
+    withFirmAdmin();
+    mockAdminFrom.mockImplementation((table: string) => {
+      const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "professionals") {
+        b.single = vi.fn(() =>
+          Promise.resolve({
+            data: { id: 99, is_firm_admin: true },
+            error: null,
+          }),
+        );
+      }
+      return b;
+    });
+
+    await PATCH(
+      makePatch(
+        { memberId: 99, role: "manager", is_firm_admin: false },
+        "valid",
+      ),
+    );
+
+    const proCalls = supabaseCalls.professionals || [];
+    const updateArgs = proCalls.find((c) => c.method === "update")
+      ?.args[0] as Record<string, unknown>;
+    expect(updateArgs.is_firm_admin).toBe(false);
+  });
+});
+
+describe("DELETE /api/advisor-auth/firm/member", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetCalls();
+    mockServerFrom.mockReset();
+    mockAdminFrom.mockReset();
+    mockServerFrom.mockImplementation((table: string) =>
+      createChainableBuilder(table, supabaseCalls),
+    );
+    mockAdminFrom.mockImplementation((table: string) =>
+      createChainableBuilder(table, supabaseCalls),
+    );
+  });
+
+  it("returns 403 when no session", async () => {
+    const res = await DELETE(makeDelete(99));
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 when memberId missing", async () => {
+    withFirmAdmin();
+    const res = await DELETE(makeDelete("", "valid"));
+    expect(res.status).toBe(400);
+  });
+
+  it("blocks removing self", async () => {
+    withFirmAdmin(42);
+    const res = await DELETE(makeDelete(42, "valid"));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/cannot remove yourself/);
+  });
+
+  it("returns 404 when member not in firm", async () => {
+    withFirmAdmin();
+    mockAdminFrom.mockImplementation((table: string) => {
+      const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "professionals") {
+        b.single = vi.fn(() =>
+          Promise.resolve({ data: null, error: null }),
+        );
+      }
+      return b;
+    });
+    const res = await DELETE(makeDelete(99, "valid"));
+    expect(res.status).toBe(404);
+  });
+
+  it("detaches member from firm without deleting the row", async () => {
+    withFirmAdmin();
+    mockAdminFrom.mockImplementation((table: string) => {
+      const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "professionals") {
+        b.single = vi.fn(() =>
+          Promise.resolve({
+            data: { id: 99, name: "Bob" },
+            error: null,
+          }),
+        );
+      }
+      return b;
+    });
+
+    const res = await DELETE(makeDelete(99, "valid"));
+    expect(res.status).toBe(200);
+
+    const proCalls = supabaseCalls.professionals || [];
+    const updateCall = proCalls.find((c) => c.method === "update");
+    expect(updateCall).toBeDefined();
+    const updateArgs = updateCall?.args[0] as Record<string, unknown>;
+    expect(updateArgs.firm_id).toBe(null);
+    expect(updateArgs.is_firm_admin).toBe(false);
+    expect(updateArgs.account_type).toBe("individual");
+    expect(updateArgs.role).toBe(null);
+  });
+});

--- a/__tests__/api/advisor-auth-firm-seat-request.test.ts
+++ b/__tests__/api/advisor-auth-firm-seat-request.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { createChainableBuilder } from "@/__tests__/helpers";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const mockServerFrom = vi.fn();
+const mockAdminFrom = vi.fn();
+const mockSendAdminNotification = vi.fn(() => Promise.resolve());
+const supabaseCalls: Record<string, { method: string; args: unknown[] }[]> = {};
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({ from: mockServerFrom })),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({ from: mockAdminFrom }),
+}));
+
+vi.mock("@/lib/advisor-emails", () => ({
+  sendAdminNotification: (...args: unknown[]) =>
+    mockSendAdminNotification(...args),
+}));
+
+import { POST } from "@/app/api/advisor-auth/firm/seat-request/route";
+
+function makePost(body: unknown, cookie?: string): NextRequest {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (cookie) headers.cookie = `advisor_session=${cookie}`;
+  return new NextRequest(
+    "http://localhost/api/advisor-auth/firm/seat-request",
+    {
+      method: "POST",
+      body: typeof body === "string" ? body : JSON.stringify(body),
+      headers,
+    },
+  );
+}
+
+function withSession(opts: {
+  expired?: boolean;
+  advisor?: Record<string, unknown> | null;
+  firm?: Record<string, unknown> | null;
+} = {}) {
+  const expiresAt = opts.expired
+    ? new Date(Date.now() - 86400 * 1000).toISOString()
+    : new Date(Date.now() + 86400 * 1000).toISOString();
+
+  mockServerFrom.mockImplementation((table: string) => {
+    const b = createChainableBuilder(table, supabaseCalls);
+    if (table === "advisor_sessions") {
+      b.single = vi.fn(() =>
+        Promise.resolve({
+          data: { professional_id: 42, expires_at: expiresAt },
+          error: null,
+        }),
+      );
+    }
+    if (table === "professionals") {
+      b.single = vi.fn(() =>
+        Promise.resolve({
+          data:
+            opts.advisor === undefined
+              ? {
+                  id: 42,
+                  name: "Admin",
+                  email: "admin@firm.test",
+                  firm_id: 7,
+                  is_firm_admin: true,
+                }
+              : opts.advisor,
+          error: null,
+        }),
+      );
+    }
+    if (table === "advisor_firms") {
+      b.single = vi.fn(() =>
+        Promise.resolve({
+          data:
+            opts.firm === undefined
+              ? { name: "Test Firm", max_seats: 5 }
+              : opts.firm,
+          error: null,
+        }),
+      );
+    }
+    return b;
+  });
+}
+
+function resetCalls() {
+  for (const k of Object.keys(supabaseCalls)) delete supabaseCalls[k];
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("POST /api/advisor-auth/firm/seat-request", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetCalls();
+    mockServerFrom.mockReset();
+    mockAdminFrom.mockReset();
+    mockServerFrom.mockImplementation((table: string) =>
+      createChainableBuilder(table, supabaseCalls),
+    );
+    mockAdminFrom.mockImplementation((table: string) =>
+      createChainableBuilder(table, supabaseCalls),
+    );
+  });
+
+  it("returns 401 when no cookie", async () => {
+    const res = await POST(makePost({ requestedSeats: 10 }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when session is expired", async () => {
+    withSession({ expired: true });
+    const res = await POST(makePost({ requestedSeats: 10 }, "valid"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when not a firm admin", async () => {
+    withSession({
+      advisor: {
+        id: 42,
+        name: "Member",
+        email: "m@firm.test",
+        firm_id: 7,
+        is_firm_admin: false,
+      },
+    });
+    const res = await POST(makePost({ requestedSeats: 10 }, "valid"));
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 404 when firm not found", async () => {
+    withSession({ firm: null });
+    const res = await POST(makePost({ requestedSeats: 10 }, "valid"));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 when requestedSeats is at-or-below current", async () => {
+    withSession();
+    const res = await POST(
+      makePost({ requestedSeats: 5 }, "valid"),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when requestedSeats > 200", async () => {
+    withSession();
+    const res = await POST(
+      makePost({ requestedSeats: 250 }, "valid"),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 409 when a pending request already exists", async () => {
+    withSession();
+    mockAdminFrom.mockImplementation((table: string) => {
+      const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "firm_seat_requests") {
+        b.single = vi.fn(() =>
+          Promise.resolve({ data: { id: 99 }, error: null }),
+        );
+      }
+      return b;
+    });
+    const res = await POST(makePost({ requestedSeats: 10 }, "valid"));
+    expect(res.status).toBe(409);
+  });
+
+  it("creates seat request and notifies admin on success", async () => {
+    withSession();
+    mockAdminFrom.mockImplementation((table: string) => {
+      const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "firm_seat_requests") {
+        b.single = vi.fn(() =>
+          Promise.resolve({ data: null, error: null }),
+        );
+      }
+      return b;
+    });
+
+    const res = await POST(
+      makePost(
+        { requestedSeats: 12, reason: "Hiring two new advisors" },
+        "valid",
+      ),
+    );
+    expect(res.status).toBe(200);
+
+    const seatCalls = supabaseCalls.firm_seat_requests || [];
+    const insertCall = seatCalls.find((c) => c.method === "insert");
+    expect(insertCall).toBeDefined();
+    const insertArgs = insertCall?.args[0] as Record<string, unknown>;
+    expect(insertArgs.firm_id).toBe(7);
+    expect(insertArgs.requested_seats).toBe(12);
+    expect(insertArgs.current_seats).toBe(5);
+    expect(insertArgs.reason).toBe("Hiring two new advisors");
+
+    expect(mockSendAdminNotification).toHaveBeenCalled();
+  });
+
+  it("returns 500 on unexpected error", async () => {
+    mockServerFrom.mockImplementation(() => {
+      throw new Error("DB exploded");
+    });
+    const res = await POST(makePost({ requestedSeats: 10 }, "valid"));
+    expect(res.status).toBe(500);
+  });
+});

--- a/__tests__/api/advisor-auth-firm.test.ts
+++ b/__tests__/api/advisor-auth-firm.test.ts
@@ -1,0 +1,293 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { createChainableBuilder } from "@/__tests__/helpers";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const mockServerFrom = vi.fn();
+const mockAdminFrom = vi.fn();
+const supabaseCalls: Record<string, { method: string; args: unknown[] }[]> = {};
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({ from: mockServerFrom })),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({ from: mockAdminFrom }),
+}));
+
+import { GET, PATCH } from "@/app/api/advisor-auth/firm/route";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function makeGet(cookie?: string): NextRequest {
+  const headers: Record<string, string> = {};
+  if (cookie) headers.cookie = `advisor_session=${cookie}`;
+  return new NextRequest("http://localhost/api/advisor-auth/firm", {
+    method: "GET",
+    headers,
+  });
+}
+
+function makePatch(body: unknown, cookie?: string): NextRequest {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (cookie) headers.cookie = `advisor_session=${cookie}`;
+  return new NextRequest("http://localhost/api/advisor-auth/firm", {
+    method: "PATCH",
+    body: typeof body === "string" ? body : JSON.stringify(body),
+    headers,
+  });
+}
+
+function withSessionAndAdvisor(opts: {
+  expired?: boolean;
+  advisor?: Record<string, unknown> | null;
+} = {}) {
+  const expiresAt = opts.expired
+    ? new Date(Date.now() - 86400 * 1000).toISOString()
+    : new Date(Date.now() + 86400 * 1000).toISOString();
+  mockServerFrom.mockImplementation((table: string) => {
+    const b = createChainableBuilder(table, supabaseCalls);
+    if (table === "advisor_sessions") {
+      b.single = vi.fn(() =>
+        Promise.resolve({
+          data: { professional_id: 42, expires_at: expiresAt },
+          error: null,
+        }),
+      );
+    }
+    if (table === "professionals") {
+      b.single = vi.fn(() =>
+        Promise.resolve({
+          data:
+            opts.advisor === undefined
+              ? {
+                  id: 42,
+                  name: "Admin",
+                  firm_id: 7,
+                  is_firm_admin: true,
+                  role: "owner",
+                }
+              : opts.advisor,
+          error: null,
+        }),
+      );
+    }
+    return b;
+  });
+}
+
+function resetCalls() {
+  for (const k of Object.keys(supabaseCalls)) delete supabaseCalls[k];
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("GET /api/advisor-auth/firm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetCalls();
+    mockServerFrom.mockReset();
+    mockAdminFrom.mockReset();
+    mockServerFrom.mockImplementation((table: string) =>
+      createChainableBuilder(table, supabaseCalls),
+    );
+    mockAdminFrom.mockImplementation((table: string) =>
+      createChainableBuilder(table, supabaseCalls),
+    );
+  });
+
+  it("returns 401 when no cookie", async () => {
+    const res = await GET(makeGet());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when advisor has no firm_id", async () => {
+    withSessionAndAdvisor({
+      advisor: { id: 42, name: "Indie", firm_id: null },
+    });
+    const res = await GET(makeGet("valid"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when firm row not found", async () => {
+    withSessionAndAdvisor();
+    mockAdminFrom.mockImplementation((table: string) => {
+      const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "advisor_firms") {
+        b.single = vi.fn(() =>
+          Promise.resolve({ data: null, error: { code: "PGRST116" } }),
+        );
+      }
+      return b;
+    });
+    const res = await GET(makeGet("valid"));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns firm and memberCount on success", async () => {
+    withSessionAndAdvisor();
+    mockAdminFrom.mockImplementation((table: string) => {
+      const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "advisor_firms") {
+        b.single = vi.fn(() =>
+          Promise.resolve({
+            data: { id: 7, name: "Test Firm" },
+            error: null,
+          }),
+        );
+      }
+      if (table === "professionals") {
+        // The count query awaits eq() directly; provide a thenable count
+        b.eq = vi.fn(() => {
+          supabaseCalls[table]?.push({ method: "eq", args: [] });
+          return Object.assign(b, {
+            then: (cb: (v: unknown) => void) => {
+              cb({ count: 4, data: null, error: null });
+              return Promise.resolve();
+            },
+          });
+        });
+      }
+      return b;
+    });
+
+    const res = await GET(makeGet("valid"));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.firm.id).toBe(7);
+    expect(json.memberCount).toBe(4);
+  });
+});
+
+describe("PATCH /api/advisor-auth/firm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetCalls();
+    mockServerFrom.mockReset();
+    mockAdminFrom.mockReset();
+    mockServerFrom.mockImplementation((table: string) =>
+      createChainableBuilder(table, supabaseCalls),
+    );
+    mockAdminFrom.mockImplementation((table: string) =>
+      createChainableBuilder(table, supabaseCalls),
+    );
+  });
+
+  it("returns 403 when not a firm admin", async () => {
+    withSessionAndAdvisor({
+      advisor: {
+        id: 42,
+        name: "Member",
+        firm_id: 7,
+        is_firm_admin: false,
+      },
+    });
+    const res = await PATCH(makePatch({ name: "X" }, "valid"));
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 403 when not in a firm", async () => {
+    withSessionAndAdvisor({
+      advisor: {
+        id: 42,
+        name: "Indie",
+        firm_id: null,
+        is_firm_admin: true,
+      },
+    });
+    const res = await PATCH(makePatch({ name: "X" }, "valid"));
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    withSessionAndAdvisor();
+    const res = await PATCH(makePatch("{not-json", "valid"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when no allowed fields are provided", async () => {
+    withSessionAndAdvisor();
+    const res = await PATCH(
+      makePatch({ verified: true, rating: 5 }, "valid"),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("updates allowlisted fields and returns the updated firm", async () => {
+    withSessionAndAdvisor();
+    mockAdminFrom.mockImplementation((table: string) => {
+      const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "advisor_firms") {
+        b.single = vi.fn(() =>
+          Promise.resolve({
+            data: { id: 7, name: "New Name", website: "https://new.test" },
+            error: null,
+          }),
+        );
+      }
+      return b;
+    });
+
+    const res = await PATCH(
+      makePatch(
+        {
+          name: "New Name",
+          website: "https://new.test",
+          // disallowed
+          verified: true,
+        },
+        "valid",
+      ),
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.firm.name).toBe("New Name");
+
+    const firmCalls = supabaseCalls.advisor_firms || [];
+    const updateCall = firmCalls.find((c) => c.method === "update");
+    expect(updateCall).toBeDefined();
+    const updateArgs = updateCall?.args[0] as Record<string, unknown>;
+    expect(updateArgs.name).toBe("New Name");
+    expect(updateArgs.website).toBe("https://new.test");
+    expect(updateArgs.verified).toBeUndefined();
+  });
+
+  it("recomputes location_display when location fields change", async () => {
+    withSessionAndAdvisor();
+    let firmCallCount = 0;
+    mockAdminFrom.mockImplementation((table: string) => {
+      const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "advisor_firms") {
+        b.single = vi.fn(() => {
+          firmCallCount++;
+          if (firmCallCount === 1) {
+            // current state lookup
+            return Promise.resolve({
+              data: { location_suburb: "Bondi", location_state: "NSW" },
+              error: null,
+            });
+          }
+          // returned firm after update
+          return Promise.resolve({
+            data: { id: 7, location_display: "Manly, NSW" },
+            error: null,
+          });
+        });
+      }
+      return b;
+    });
+
+    const res = await PATCH(
+      makePatch({ location_suburb: "Manly" }, "valid"),
+    );
+    expect(res.status).toBe(200);
+
+    const firmCalls = supabaseCalls.advisor_firms || [];
+    const updateCall = firmCalls.find((c) => c.method === "update");
+    const updateArgs = updateCall?.args[0] as Record<string, unknown>;
+    expect(updateArgs.location_display).toBe("Manly, NSW");
+  });
+});


### PR DESCRIPTION
## Summary

Adds **32 new test cases** across three more advisor-auth firm sub-routes.

- `advisor-auth-firm` (10) — GET: 401 no cookie / no firm_id, 404 firm-not-found, happy with memberCount; PATCH: 403 non-admin / not-in-firm, 400 invalid JSON / no allowed fields, allowlist update with disallowed fields dropped, location_display recompute when suburb/state changes.
- `advisor-auth-firm-member` (13) — PATCH: 403 no session, 400 invalid JSON / missing fields / invalid role, 404 cross-firm, 400 self-demotion-without-other-owner, happy role + auto-derived is_firm_admin, explicit is_firm_admin override; DELETE: 403 no session, 400 missing memberId / self-removal, 404 cross-firm, happy detach without deleting the row.
- `advisor-auth-firm-seat-request` (9) — 401 no cookie / expired, 403 non-admin, 404 firm not found, 400 invalid seat count (≤current or >200), 409 existing pending request, happy insert + admin notification, 500 on unexpected error.

After this PR, advisor-auth coverage spans 14 of 15 sub-routes. Remaining: `/firm/invite` and `/firm/analytics`.

## Test plan

- [x] `npm test -- __tests__/api/advisor-auth-firm*.test.ts` — 32/32
- [x] `npx eslint --max-warnings 0` — clean
- [ ] CI gates green
- [ ] Auto-merge once approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)