### PR TITLE
fix(cron): loop back through production alias, not unique-deploy URL

### DIFF
--- a/app/api/cron/dispatch/[group]/route.ts
+++ b/app/api/cron/dispatch/[group]/route.ts
@@ -49,17 +49,26 @@ export async function GET(
     );
   }
 
-  const origin = new URL(req.url).origin;
-  // Build the Authorization header from CRON_SECRET directly rather than
-  // forwarding `req.headers.get("authorization")`. The 11:20 UTC post-fix
-  // run showed every loopback fetch returning HTTP 401 even though the
-  // inbound dispatcher request was authenticated — strong signal that
-  // either the inbound header isn't surviving the round-trip or Vercel
-  // strips Authorization on internal HTTPS loopbacks. Sourcing the secret
-  // from the env on the way out removes both possibilities. The inbound
-  // request is still validated by `requireCronAuth(req)` above, so this
-  // doesn't relax the dispatcher's auth — it only ensures the loopback
-  // header is canonical.
+  // Loop back through the production alias, NOT `req.url`'s origin.
+  //
+  // Vercel cron fires against the unique deployment URL
+  // (`invest-com-XXXX-finns-projects-…vercel.app`), which has Vercel's
+  // Deployment Protection enabled — that layer returns an HTML 401
+  // "Authentication Required" page BEFORE proxy.ts runs, so loopback
+  // fetches never reach the route handler. Curl confirms: unique URL →
+  // HTML 401 (Vercel auth wall), production alias → JSON 401 from
+  // proxy.ts. Vercel automatically populates VERCEL_PROJECT_PRODUCTION_URL
+  // with the protection-free production alias, so we use that.
+  //
+  // Falls back to `req.url`'s origin for local `npm run dev` where the
+  // env var is unset.
+  const origin = process.env.VERCEL_PROJECT_PRODUCTION_URL
+    ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
+    : new URL(req.url).origin;
+  // Build Authorization from CRON_SECRET directly so the outbound header
+  // is canonical regardless of header-rewrite/strip behaviour on the
+  // round-trip. The inbound request is still validated by
+  // `requireCronAuth(req)` above.
   const auth = process.env.CRON_SECRET
     ? `Bearer ${process.env.CRON_SECRET}`
     : "";


### PR DESCRIPTION
## Summary

Third and final layer of the cron-blackout fix. After #270 (route registration) and #272 (outbound auth canonicalisation), inner-cron loopback fetches still recorded \`HTTP 401\`. The cause:

\`\`\`bash
$ curl -s -o /dev/null -w '%{http_code}\n' https://invest-com-7l8mkxoie-finns-projects-2deaa68c.vercel.app/api/cron/heartbeat
401   # HTML "Authentication Required" page from Vercel Deployment Protection

$ curl -s -o /dev/null -w '%{http_code}\n' https://invest-com-au.vercel.app/api/cron/heartbeat
401   # JSON {"error":"Unauthorized"} from proxy.ts (correct: no Bearer)
\`\`\`

Vercel cron fires against the unique deployment URL (\`invest-com-XXXX-finns-projects-…vercel.app\`), so \`new URL(req.url).origin\` in the dispatcher resolves to that protected URL. Every loopback fetch gets stopped at Vercel's auth wall *before* proxy.ts validates the Bearer.

## Fix

Read \`VERCEL_PROJECT_PRODUCTION_URL\` (Vercel auto-sets it to the protection-free production alias) and prefix \`https://\`. Falls back to \`req.url\`'s origin for local \`npm run dev\`.

\`\`\`ts
const origin = process.env.VERCEL_PROJECT_PRODUCTION_URL
  ? \`https://\${process.env.VERCEL_PROJECT_PRODUCTION_URL}\`
  : new URL(req.url).origin;
\`\`\`

## Verification after deploy

- Within 5 min: \`cron_run_log\` rows from inner crons switch from \`status='error'\` / \`error_message='HTTP 401'\` to \`status='ok'\`
- New \`triggered_by='cron'\` rows from \`wrapCronHandler\` appear alongside \`triggered_by='dispatcher'\`
- \`/api/cron/heartbeat\` appears in Vercel runtime logs

## Test plan
- [ ] Vercel deploy succeeds
- [ ] \`SELECT count(*) FROM cron_run_log WHERE status='ok' AND triggered_by='cron' AND started_at > now() - interval '5 minutes'\` ≥ 1
- [ ] No regression on existing per-handler tests

Cron blackout fix layers:
- #270: route registration (underscore-prefix Next.js private folder)
- #272: outbound auth header canonicalisation
- **#this PR**: outbound URL targets the public production alias