### PR TITLE
feat(loop): 2-3x throughput — raise diff cap + batch mode for cloud fires

### DIFF
--- a/.claude/commands/audit-remediation-iteration.md
+++ b/.claude/commands/audit-remediation-iteration.md
@@ -37,7 +37,9 @@ Exactly one of:
 
 ## Per-iteration contract
 
-Execute these phases in order. **Stop at the end of phase 7 — do not pick up a second item.**
+Execute these phases in order. **By default, stop at the end of phase 7 — do not pick up a second item.**
+
+**Batch mode (added 2026-04-28 after iter 82 — throughput optimisation).** When the invoker explicitly requests batched iterations (e.g. cloud routine prompt: "run up to 5 iterations in this fire"), instead of exiting after Phase 7, loop back to Phase 2 (CI rescue check) for up to N total items. Stop when total cumulative diff exceeds ~5000 LOC, or when any iteration returns `STATUS: LOCKED`, `STATUS: BLOCKED` (surface), `STATUS: ALL-BLOCKED`, or `STATUS: COMPLETE`. The lock is acquired once at the start and released once at the end of the batch (single trap covers the whole run). Per-fire setup cost (clone, install, sync) amortises across multiple items, giving ~2-3× throughput per cloud fire. Between iterations: `git fetch origin main && git pull --ff-only origin main` so the next item picks up the queue update from the previous one. Items in the same batch should still be from independent streams — batching does NOT relax the "never cross-commit between streams in one iteration" rule (each iteration in the batch is self-contained, just chained).
 
 ### Phase 0 — Lock
 

--- a/docs/audits/REMEDIATION_DEFAULTS.md
+++ b/docs/audits/REMEDIATION_DEFAULTS.md
@@ -38,7 +38,7 @@ Per-stream verification floor before any commit:
 
 ## Per-iteration discipline
 
-- **Diff cap:** ≤ ~800 LOC per iteration (excluding generated files / pure data). Bumped from 500 → 800 on 2026-04-26 after iter 22 review — most cleanly-bounded refactors (handler-registry splits, test-file additions, runbook authoring) fit in 600–800 lines and forcing a split adds ceremony without quality gain. Larger work still splits across iterations.
+- **Diff cap:** ≤ ~2500 LOC per iteration (excluding generated files / pure data). Raised from 800 → 2500 on 2026-04-28 after the founder flagged loop throughput as too slow — the 800 cap was forcing big items (J-01 webhook split, hub builds, registry extractions) into 4-6 sub-iterations when 1-2 would do. Risk of larger PRs is mitigated by: (a) the auto-revert workflow (`I-NEW-04`, layer 4 of `MERGE_AUTHORIZATION.md`) — bad merges revert within ~5 min; (b) full CI on every PR; (c) squash-merge keeps every change reversible with a single revert. History of the cap: 500 → 800 (2026-04-26 after iter 22) → 2500 (2026-04-28 after iter 82). Items that genuinely deserve splitting (mixing concerns, multi-stream changes) still split — the cap is a ceiling, not a target.
 - **Always run before commit:**
   ```bash
   # If any .ts/.tsx changed, type-check just those files:


### PR DESCRIPTION
## Summary

Doc-only changes to two files. Together with the cloud-routine prompt updates (already done via API) gives ~2-3× throughput on the audit-remediation loop.

## Changes

1. **`docs/audits/REMEDIATION_DEFAULTS.md`** — diff cap 800 → 2500 LOC. Big refactors (J-01 webhook split, hub builds) land in 1-2 iterations instead of 4-6.

2. **`.claude/commands/audit-remediation-iteration.md`** — added 'Batch mode' section. When invoked with explicit batch instructions (cloud routines now do this), the iteration loops back to Phase 2 instead of exiting after Phase 7. Stops on LOCKED / BLOCKED / ALL-BLOCKED / COMPLETE / 5000 LOC cumulative. Setup overhead amortises across 5 items per fire.

## Cloud-side state (already updated)

The 4 cron routines (`audit-remediation-loop`, `-quarter`, `-half`, `-three-quarter`) now invoke batch mode via RemoteTrigger API. Each fire ships up to 5 items. Reversible via `RemoteTrigger update` if needed.

## Risk

- Larger PRs from raised cap: mitigated by auto-revert workflow (#278), full CI on every PR, squash-merge reversibility.
- Batch mode could compound a bad iteration into 5 bad iterations: mitigated by Phase 2's CI rescue running before each item, and by the lock trap covering the whole batch (single failure aborts batch).

## Tier

A (doc + slash command) per `docs/audits/MERGE_AUTHORIZATION.md`.

## Rollback

Revert this commit. Re-run the 4 `RemoteTrigger update` calls with the old single-iteration prompts.