### PR TITLE
fix(tests): resolve accumulated TypeScript errors in __tests__/api

### DIFF
--- a/__tests__/api/analytics-dashboard.test.ts
+++ b/__tests__/api/analytics-dashboard.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { NextRequest } from "next/server";
 
 // ── Mocks ──────────────────────────────────────────────────────────────────────
@@ -28,8 +28,12 @@ function makeAuthedGet(): NextRequest {
   return makeGet({ Authorization: `Bearer ${CRON_SECRET}` });
 }
 
-/** Count builder — used for all the `.select("id", { count, head }).gte().eq()` calls. */
-function makeCountBuilder(count: number, error: unknown = null) {
+/** Count builder — used for all the `.select("id", { count, head }).gte().eq()` calls.
+ * Currently unused (the thenable variant below covers all chain shapes); kept for
+ * future tests that need a non-thenable builder. Underscore-prefixed to satisfy
+ * the no-unused-vars rule without deleting (low risk, possible future use).
+ */
+function _makeCountBuilder(count: number, error: unknown = null) {
   return {
     select: vi.fn().mockReturnThis(),
     gte: vi.fn().mockReturnThis(),

--- a/__tests__/api/community-posts-id.test.ts
+++ b/__tests__/api/community-posts-id.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
+import { createChainableBuilder } from "@/__tests__/helpers";
 
 // ── Mocks ──────────────────────────────────────────────────────────────────────
 

--- a/__tests__/api/cron-ab-auto-promote.test.ts
+++ b/__tests__/api/cron-ab-auto-promote.test.ts
@@ -15,7 +15,9 @@ vi.mock("@/lib/cron-auth", () => ({
   requireCronAuth: vi.fn(() => null),
 }));
 
-const mockIsFeatureDisabled = vi.fn(() => Promise.resolve(false));
+const mockIsFeatureDisabled = vi.fn<(...args: unknown[]) => Promise<boolean>>(() =>
+  Promise.resolve(false),
+);
 vi.mock("@/lib/admin/classifier-config", () => ({
   isFeatureDisabled: (...args: unknown[]) => mockIsFeatureDisabled(...args),
 }));

--- a/__tests__/api/cron-abandoned-form-drip.test.ts
+++ b/__tests__/api/cron-abandoned-form-drip.test.ts
@@ -20,7 +20,7 @@ vi.mock("@/lib/cron-auth", () => ({
   requireCronAuth: vi.fn(() => null),
 }));
 
-const mockIsFeatureDisabled = vi.fn(async () => false);
+const mockIsFeatureDisabled = vi.fn<(...args: unknown[]) => Promise<boolean>>(async () => false);
 vi.mock("@/lib/admin/classifier-config", () => ({
   isFeatureDisabled: (...args: unknown[]) => mockIsFeatureDisabled(...args),
 }));

--- a/__tests__/api/cron-abandoned-quiz-drip.test.ts
+++ b/__tests__/api/cron-abandoned-quiz-drip.test.ts
@@ -20,13 +20,15 @@ vi.mock("@/lib/cron-auth", () => ({
   requireCronAuth: vi.fn(() => null),
 }));
 
-const mockIsFeatureDisabled = vi.fn(async () => false);
+const mockIsFeatureDisabled = vi.fn<(...args: unknown[]) => Promise<boolean>>(async () => false);
 vi.mock("@/lib/admin/classifier-config", () => ({
   isFeatureDisabled: (...args: unknown[]) => mockIsFeatureDisabled(...args),
 }));
 
-const mockBuildEmailToUserIdMap = vi.fn(async () => new Map<string, string>());
-const mockNotifyUser = vi.fn(async () => false);
+const mockBuildEmailToUserIdMap = vi.fn<(...args: unknown[]) => Promise<Map<string, string>>>(
+  async () => new Map<string, string>(),
+);
+const mockNotifyUser = vi.fn<(...args: unknown[]) => Promise<boolean>>(async () => false);
 vi.mock("@/lib/notifications", () => ({
   buildEmailToUserIdMap: (...args: unknown[]) => mockBuildEmailToUserIdMap(...args),
   notifyUser: (...args: unknown[]) => mockNotifyUser(...args),

--- a/__tests__/api/cron-account-deletion-reminder.test.ts
+++ b/__tests__/api/cron-account-deletion-reminder.test.ts
@@ -20,8 +20,16 @@ vi.mock("@/lib/cron-auth", () => ({
   requireCronAuth: vi.fn(() => null),
 }));
 
-// sendEmail mock — controls whether the email send succeeds
-const mockSendEmail = vi.fn(async () => ({ ok: true }));
+// sendEmail mock — controls whether the email send succeeds.
+// Typed with the real return shape `{ ok: boolean; error?: string }` so
+// callers can `mockResolvedValueOnce({ ok: false, error: "..." })` without TS
+// narrowing the return to `{ ok: true }`. The args list is `unknown[]` so the
+// mock can be invoked from the spread-args wrapper below without TS demanding
+// a literal tuple.
+type SendEmailResult = { ok: boolean; error?: string };
+const mockSendEmail = vi.fn<(...args: unknown[]) => Promise<SendEmailResult>>(
+  async () => ({ ok: true }),
+);
 vi.mock("@/lib/resend", () => ({
   sendEmail: (...args: unknown[]) => mockSendEmail(...args),
 }));
@@ -172,7 +180,8 @@ describe("GET /api/cron/account-deletion-reminder", () => {
     dbQueue.push({ data: [PENDING_ROWS[0]], error: null });
     dbQueue.push({ error: null });
     await GET(makeReq());
-    const subject = mockSendEmail.mock.calls[0]?.[0]?.subject as string;
+    const firstCallArg = mockSendEmail.mock.calls[0]?.[0] as { subject: string } | undefined;
+    const subject = firstCallArg?.subject ?? "";
     expect(subject).toMatch(/Final reminder/i);
     expect(subject).toMatch(/day/i);
   });

--- a/__tests__/api/cron-advisor-dormant-nudge.test.ts
+++ b/__tests__/api/cron-advisor-dormant-nudge.test.ts
@@ -20,7 +20,7 @@ vi.mock("@/lib/cron-auth", () => ({
   requireCronAuth: vi.fn(() => null),
 }));
 
-const mockIsFeatureDisabled = vi.fn(async () => false);
+const mockIsFeatureDisabled = vi.fn<(...args: unknown[]) => Promise<boolean>>(async () => false);
 vi.mock("@/lib/admin/classifier-config", () => ({
   isFeatureDisabled: (...args: unknown[]) => mockIsFeatureDisabled(...args),
 }));

--- a/__tests__/api/cron-advisor-onboarding.test.ts
+++ b/__tests__/api/cron-advisor-onboarding.test.ts
@@ -14,7 +14,12 @@ vi.mock("@/lib/email-templates", () => ({
   notificationFooter: vi.fn(() => "<footer>unsubscribe</footer>"),
 }));
 
-const mockFetch = vi.fn(() => Promise.resolve(new Response("ok", { status: 200 })));
+// Typed with the real fetch signature so `mock.calls[i]` is `[input, init?]`,
+// not `[]`. Otherwise `calls[0][1]` fails noUncheckedIndexedAccess on a `[]`
+// tuple (length-0 has no index 1).
+const mockFetch = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
+  () => Promise.resolve(new Response("ok", { status: 200 })),
+);
 vi.stubGlobal("fetch", mockFetch);
 
 // DB queue consumed per from() call

--- a/__tests__/api/cron-confirm-lead-notify.test.ts
+++ b/__tests__/api/cron-confirm-lead-notify.test.ts
@@ -11,7 +11,9 @@ vi.mock("@/lib/cron-auth", () => ({
   requireCronAuth: vi.fn(() => null),
 }));
 
-const mockSendLeadNotification = vi.fn(() => Promise.resolve());
+const mockSendLeadNotification = vi.fn<(...args: unknown[]) => Promise<unknown>>(() =>
+  Promise.resolve(),
+);
 vi.mock("@/lib/advisor-emails", () => ({
   sendNewLeadNotification: (...args: unknown[]) => mockSendLeadNotification(...args),
 }));

--- a/__tests__/api/cron-data-export-monitor.test.ts
+++ b/__tests__/api/cron-data-export-monitor.test.ts
@@ -20,7 +20,14 @@ vi.mock("@/lib/cron-auth", () => ({
   requireCronAuth: vi.fn(() => null),
 }));
 
-const mockSendEmail = vi.fn(async () => ({ ok: true }));
+// sendEmail mock — typed with the real `{ ok: boolean; error?: string }` shape
+// (otherwise TS narrows to `{ ok: true }` and `{ ok: false, error: ... }`
+// becomes an "unknown property" error). `unknown[]` args make the mock callable
+// from the spread-args wrapper below.
+type SendEmailResult = { ok: boolean; error?: string };
+const mockSendEmail = vi.fn<(...args: unknown[]) => Promise<SendEmailResult>>(
+  async () => ({ ok: true }),
+);
 vi.mock("@/lib/resend", () => ({
   sendEmail: (...args: unknown[]) => mockSendEmail(...args),
 }));
@@ -138,7 +145,8 @@ describe("GET /api/cron/data-export-monitor", () => {
     const res = await GET(makeReq());
     const body = await res.json();
     expect(body.ok).toBe(true);
-    expect(mockSendEmail.mock.calls[0]?.[0]?.to).toBe("fallback@example.com");
+    const firstArg = mockSendEmail.mock.calls[0]?.[0] as { to: string } | undefined;
+    expect(firstArg?.to).toBe("fallback@example.com");
   });
 
   it("happy path — reminder-only rows: sends one email with correct subject", async () => {
@@ -151,9 +159,9 @@ describe("GET /api/cron/data-export-monitor", () => {
     expect(body.stale_count).toBe(1);
     expect(body.urgent_count).toBe(0);
     expect(mockSendEmail).toHaveBeenCalledTimes(1);
-    const call = mockSendEmail.mock.calls[0]?.[0] as { to: string; subject: string };
-    expect(call.to).toBe("admin@invest.com.au");
-    expect(call.subject).not.toMatch(/URGENT/i);
+    const call = mockSendEmail.mock.calls[0]?.[0] as { to: string; subject: string } | undefined;
+    expect(call?.to).toBe("admin@invest.com.au");
+    expect(call?.subject).not.toMatch(/URGENT/i);
   });
 
   it("happy path — urgent rows: subject contains URGENT and correct counts", async () => {
@@ -165,8 +173,8 @@ describe("GET /api/cron/data-export-monitor", () => {
     expect(body.ok).toBe(true);
     expect(body.stale_count).toBe(2);
     expect(body.urgent_count).toBe(1);
-    const subject = (mockSendEmail.mock.calls[0]?.[0] as { subject: string }).subject;
-    expect(subject).toMatch(/URGENT/i);
+    const callArg = mockSendEmail.mock.calls[0]?.[0] as { subject: string } | undefined;
+    expect(callArg?.subject).toMatch(/URGENT/i);
   });
 
   it("returns ok=false when sendEmail fails", async () => {

--- a/__tests__/api/developer-leads.test.ts
+++ b/__tests__/api/developer-leads.test.ts
@@ -60,7 +60,10 @@ function makePost(body: unknown, headers: Record<string, string> = {}): NextRequ
   });
 }
 
-function makeInsertChain(result = { error: null }) {
+// Default result is { error: null }, but a test passes `{ error: { message } }`
+// to simulate DB failure, so the param is widened to `error: PostgrestError-ish | null`.
+type InsertResult = { error: { message: string } | null };
+function makeInsertChain(result: InsertResult = { error: null }) {
   const c: Record<string, unknown> = {};
   c.insert = vi.fn().mockResolvedValue(result);
   return c;

--- a/__tests__/api/fee-alerts.test.ts
+++ b/__tests__/api/fee-alerts.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { NextRequest } from "next/server";
 
 // ── Mocks ──────────────────────────────────────────────────────────────────────

--- a/__tests__/api/partner-status.test.ts
+++ b/__tests__/api/partner-status.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { NextRequest } from "next/server";
 
 // ── Mocks ──────────────────────────────────────────────────────────────────────

--- a/__tests__/api/verify-professional.test.ts
+++ b/__tests__/api/verify-professional.test.ts
@@ -10,14 +10,20 @@ vi.mock("@/lib/rate-limit-db", () => ({
 }));
 
 const mockVerifyAbn = vi.fn();
-const mockNormaliseAbn = vi.fn((s: string) => s.replace(/\s/g, ""));
+// Args typed `unknown[]` so the spread-args wrapper below can call this without
+// TS demanding an exact tuple match. Implementation casts to string at call time.
+const mockNormaliseAbn = vi.fn<(...args: unknown[]) => string>((...args) =>
+  String(args[0] ?? "").replace(/\s/g, ""),
+);
 vi.mock("@/lib/verify-abn", () => ({
   verifyAbn: (...args: unknown[]) => mockVerifyAbn(...args),
   normaliseAbn: (...args: unknown[]) => mockNormaliseAbn(...args),
 }));
 
 const mockVerifyAfsl = vi.fn();
-const mockNormaliseAfsl = vi.fn((s: string) => s.replace(/\s/g, ""));
+const mockNormaliseAfsl = vi.fn<(...args: unknown[]) => string>((...args) =>
+  String(args[0] ?? "").replace(/\s/g, ""),
+);
 vi.mock("@/lib/verify-afsl", () => ({
   verifyAfsl: (...args: unknown[]) => mockVerifyAfsl(...args),
   normaliseAfsl: (...args: unknown[]) => mockNormaliseAfsl(...args),
@@ -48,7 +54,22 @@ function makePost(body: unknown, authToken?: string): NextRequest {
   });
 }
 
-const PROFESSIONAL = {
+// Typed explicitly so individual tests can override `abn`/`afsl_number` to null
+// (some scenarios pass null values into setupAdminMocks).
+type ProfessionalRow = {
+  id: number;
+  slug: string;
+  name: string;
+  email: string;
+  type: string;
+  abn: string | null;
+  afsl_number: string | null;
+  verified: boolean;
+  verification_method: string | null;
+  health_status: string;
+};
+
+const PROFESSIONAL: ProfessionalRow = {
   id: 42,
   slug: "jane-advisor",
   name: "Jane Advisor",
@@ -62,7 +83,7 @@ const PROFESSIONAL = {
 };
 
 function setupAdminMocks(
-  proData: typeof PROFESSIONAL | null = PROFESSIONAL,
+  proData: ProfessionalRow | null = PROFESSIONAL,
   updateError: Error | null = null
 ) {
   mockAdminFrom.mockImplementation((table: string) => {


### PR DESCRIPTION
## Summary

`tsc --noEmit` had accumulated **34 errors** in `__tests__/api/*.test.ts` files, all in code that had drifted out of sync with TS strict + `noUncheckedIndexedAccess`. The husky pre-push hook runs `tsc --noEmit` against the whole tree, so any session with husky locally couldn't push until this was fixed. The cloud loop was bypassing the hook with `HUSKY=0`, but interactive sessions had no escape — this was the throughput ceiling for the team.

This PR brings `tsc --noEmit` back to clean (**0 errors**) so the hook passes.

## Why CI didn't catch it

CI runs `npm run build`, which invokes Next.js's bundled tsc with a different inclusion set (it appears to skip or differently process the `__tests__/` tree). The pre-push hook runs `npx tsc --noEmit`, which uses the project's full `tsconfig.json` and includes everything. **This is itself a separate audit item** — CI and the hook should run the same check, otherwise drift like this will accumulate again. Recommend a follow-up to add `npm run type-check` to CI as a hard gate.

## Categories fixed (14 files)

- **Missing `afterEach` import** (3 files): `analytics-dashboard`, `fee-alerts`, `partner-status`. Tests called `afterEach(...)` but only imported `beforeEach`. One-line import fix.
- **Missing `createChainableBuilder` import** (1 file): `community-posts-id`. Helper exists at `__tests__/helpers.ts:40` but wasn't imported.
- **Spread argument tuple errors** (8 files, ~11 call sites): `vi.fn(async () => false)` infers a fixed-arity signature, so the surrounding `(...args: unknown[]) => mock(...args)` wrapper failed TS2556 ("A spread argument must either have a tuple type or be passed to a rest parameter"). Fixed by typing each mock with `vi.fn<(...args: unknown[]) => Promise<X>>(impl)` so it accepts any args.
- **Mock return-type narrowing** (`cron-account-deletion-reminder`, `cron-data-export-monitor`): `vi.fn(async () => ({ ok: true }))` narrowed the return to literal `{ ok: true }`, so `mockResolvedValueOnce({ ok: false, error: "..." })` failed TS2353. Widened to the real `{ ok: boolean; error?: string }` shape from `lib/resend.ts`.
- **Tuple length-0 element access on `mock.calls`** (`cron-advisor-onboarding`, `cron-data-export-monitor`, `cron-account-deletion-reminder`): `mockFetch` was typed `() => Promise<Response>`, so `mock.calls[i]` was an empty tuple `[]` and `[1]` failed TS2493. Typed `mockFetch` with the real fetch signature `(input, init?) => Promise<Response>`. For send-email mocks, cast call args via `as { ... } | undefined` rather than through the unknown layer.
- **Type assignability** (`developer-leads`, `verify-professional`): `makeInsertChain` default `{ error: null }` got narrowed to `{ error: null }`, rejecting `{ error: { message: "constraint violation" } }`. Widened the param. `PROFESSIONAL` fixture inferred `abn: string`, but a test overrides with `abn: null` — added explicit `ProfessionalRow` type.

Plus one drive-by lint fix: renamed unused `makeCountBuilder` -> `_makeCountBuilder` in `analytics-dashboard.test.ts` (lint-staged ran on staged files and surfaced the pre-existing unused-var warning).

## Constraints respected

- Tests-only — zero changes to production code (`app/`, `lib/` proper, `components/`, `proxy.ts`).
- No `as any` anywhere.
- No `tsconfig.json` widening.
- No `--no-verify` on push (the hook **passed cleanly**, which was the point).

## Test plan

- [x] `npx tsc --noEmit` exits 0 (verified locally — was 34 errors, now 0).
- [x] Husky pre-push hook passes (verified — branch pushed without `--no-verify`).
- [x] All 14 changed test files still pass: `npm test -- <14 files>` -> **116/116 passing**.
- [ ] CI green on this PR.

## Follow-up audit item

CI should run the same `tsc --noEmit` the pre-push hook runs (or vice versa). Right now they diverge silently — that's how 34 errors accumulated without anyone noticing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)