### PR TITLE
chore(f): replace 9 console.* calls with lib/logger.ts (F-05)

### DIFF
--- a/app/admin/compliance/page.tsx
+++ b/app/admin/compliance/page.tsx
@@ -9,6 +9,9 @@ import {
   COMPANY_ACN,
   COMPANY_ABN,
 } from "@/lib/compliance";
+import { logger } from "@/lib/logger";
+
+const log = logger("admin-compliance");
 
 /* ─── Types ─── */
 
@@ -779,7 +782,7 @@ export default function CompliancePage() {
       });
 
     } catch (err) {
-      console.error("Compliance check error:", err);
+      log.error("compliance check failed", { err: err instanceof Error ? err.message : String(err) });
     }
 
     setChecks(results);

--- a/app/advisor-portal/BillingTab.tsx
+++ b/app/advisor-portal/BillingTab.tsx
@@ -3,6 +3,9 @@
 import { useState, useEffect } from "react";
 import Icon from "@/components/Icon";
 import type { Advisor, Stats, CategoryPricing, BillingRecord, ViewType } from "./types";
+import { logger } from "@/lib/logger";
+
+const log = logger("advisor-portal-billing");
 
 type TopupRecord = { id: number; amount_cents: number; status: string; created_at: string };
 
@@ -72,7 +75,7 @@ export default function BillingTab({ advisor, stats, categoryPricing, billing, o
                   else alert(data.error || "Failed to create checkout session. Please try again.");
                 } catch (err) {
                   alert("Something went wrong. Please check you're logged in and try again.");
-                  console.error("Topup error:", err);
+                  log.error("topup checkout failed", { err: err instanceof Error ? err.message : String(err) });
                 }
               }}
               className={`w-full py-2.5 rounded-lg text-sm font-bold transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-violet-500 focus-visible:ring-offset-2 ${
@@ -120,7 +123,7 @@ export default function BillingTab({ advisor, stats, categoryPricing, billing, o
                   else alert(data.error || "Failed to create checkout session. Please try again.");
                 } catch (err) {
                   alert("Something went wrong. Please check you're logged in and try again.");
-                  console.error("Featured topup error:", err);
+                  log.error("featured topup checkout failed", { err: err instanceof Error ? err.message : String(err) });
                 }
               }}
               className="w-full py-2 rounded-lg text-sm font-bold bg-amber-500 text-white hover:bg-amber-600 transition-all"

--- a/app/advisor-portal/LeadsTab.tsx
+++ b/app/advisor-portal/LeadsTab.tsx
@@ -3,6 +3,9 @@
 import Icon from "@/components/Icon";
 import LeadScoreBadge from "@/components/LeadScoreBadge";
 import type { Advisor, Stats, Lead, CategoryPricing, DisputeModal } from "./types";
+import { logger } from "@/lib/logger";
+
+const log = logger("advisor-portal-leads");
 
 type LeadStatusFilter = "all" | "new" | "contacted" | "converted" | "lost";
 
@@ -114,7 +117,7 @@ export default function LeadsTab({
                   else alert(data.error || "Failed to create checkout session. Please try again.");
                 } catch (err) {
                   alert("Something went wrong. Please check you&apos;re logged in and try again.");
-                  console.error("Topup error:", err);
+                  log.error("topup checkout failed", { err: err instanceof Error ? err.message : String(err) });
                 }
               }}
               className={`relative flex flex-col items-center p-2.5 rounded-lg border text-center transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-violet-500 focus-visible:ring-offset-2 ${

--- a/app/invest/[slug]/page.tsx
+++ b/app/invest/[slug]/page.tsx
@@ -5,6 +5,9 @@ import { createClient } from "@/lib/supabase/server";
 import { breadcrumbJsonLd, absoluteUrl, SITE_URL, SITE_NAME, CURRENT_YEAR } from "@/lib/seo";
 import Icon from "@/components/Icon";
 import SectionHeading from "@/components/SectionHeading";
+import { logger } from "@/lib/logger";
+
+const log = logger("invest-vertical-slug");
 
 export const revalidate = 3600;
 
@@ -47,7 +50,7 @@ export async function generateMetadata({
     .maybeSingle();
 
   if (error) {
-    console.error("[invest/[slug]] metadata query failed", error.message);
+    log.error("metadata query failed", { err: error.message, slug });
     return { title: "Investment Vertical" };
   }
 

--- a/components/ErrorBoundary.tsx
+++ b/components/ErrorBoundary.tsx
@@ -1,5 +1,8 @@
 "use client";
 import { Component, type ReactNode } from "react";
+import { logger } from "@/lib/logger";
+
+const log = logger("error-boundary");
 
 interface Props { children: ReactNode; fallback?: ReactNode; section?: string }
 interface State { hasError: boolean; error?: Error }
@@ -20,7 +23,7 @@ export default class ErrorBoundary extends Component<Props, State> {
     if (w?.Sentry) {
       w.Sentry.captureException(error);
     }
-    console.error(`[ErrorBoundary${this.props.section ? ` - ${this.props.section}` : ""}]`, error);
+    log.error("boundary caught error", { section: this.props.section ?? null, err: error });
   }
 
   override render() {

--- a/components/PushNotificationPrompt.tsx
+++ b/components/PushNotificationPrompt.tsx
@@ -2,6 +2,9 @@
 
 import { useState, useEffect, useCallback } from "react";
 import Icon from "@/components/Icon";
+import { logger } from "@/lib/logger";
+
+const log = logger("push-notification-prompt");
 
 const TOPICS = [
   { id: "fee_changes", label: "Fee Changes", desc: "When a broker changes their fees" },
@@ -104,7 +107,7 @@ export default function PushNotificationPrompt() {
       localStorage.setItem(LS_SUBSCRIBED_KEY, "1");
       setStep("done");
     } catch (err) {
-      console.error("Push subscribe error:", err);
+      log.error("push subscribe failed", { err: err instanceof Error ? err.message : String(err) });
       setError("Something went wrong. Please try again.");
     } finally {
       setLoading(false);

--- a/components/ServiceWorkerRegistrar.tsx
+++ b/components/ServiceWorkerRegistrar.tsx
@@ -1,6 +1,9 @@
 "use client";
 
 import { useEffect } from "react";
+import { logger } from "@/lib/logger";
+
+const log = logger("service-worker-registrar");
 
 /**
  * Registers the service worker. Mount once in the root layout.
@@ -26,7 +29,7 @@ export default function ServiceWorkerRegistrar() {
         .register("/sw.js", { scope: "/" })
         .catch((err) => {
           // Non-fatal — worse case we serve the site without offline support
-          console.warn("service worker registration failed", err);
+          log.warn("service worker registration failed", { err: err instanceof Error ? err.message : String(err) });
         });
     };
     if (document.readyState === "complete") register();

--- a/components/SwitchStoryForm.tsx
+++ b/components/SwitchStoryForm.tsx
@@ -5,6 +5,9 @@ import Link from "next/link";
 import StarRatingInput from "./StarRatingInput";
 import { createClient } from "@/lib/supabase/client";
 import { trackEvent } from "@/lib/tracking";
+import { logger } from "@/lib/logger";
+
+const log = logger("switch-story-form");
 
 interface BrokerOption {
   slug: string;
@@ -58,7 +61,7 @@ export default function SwitchStoryForm({
           // Without the broker list the form is unusable (both dropdowns
           // are empty). Surface an explicit error so the user knows to
           // retry instead of staring at a blank form.
-          console.error("[SwitchStoryForm] broker list load failed", error.message);
+          log.error("broker list load failed", { err: error.message });
           setErrorMsg("Couldn't load broker list. Please refresh and try again.");
           return;
         }

--- a/components/WebVitals.tsx
+++ b/components/WebVitals.tsx
@@ -1,6 +1,9 @@
 "use client";
 
 import { useReportWebVitals } from "next/web-vitals";
+import { logger } from "@/lib/logger";
+
+const log = logger("web-vitals");
 
 /**
  * Reports Core Web Vitals (CLS, LCP, INP, FCP, TTFB) to analytics.
@@ -14,10 +17,13 @@ export default function WebVitals() {
   useReportWebVitals((metric) => {
     const { name, value, id, rating } = metric;
 
-    // Log in development for debugging
+    // Log in development for debugging (logger filters debug-level out in prod)
     if (process.env.NODE_ENV === "development") {
-       
-      console.log(`[Web Vital] ${name}: ${Math.round(value * 100) / 100} (${rating})`);
+      log.debug(`${name}: ${Math.round(value * 100) / 100} (${rating})`, {
+        metric: name,
+        value: Math.round(value * 100) / 100,
+        rating,
+      });
     }
 
     // Send to Google Analytics if gtag is available


### PR DESCRIPTION
## Summary
Migrates 9 of 12 actionable `console.*` calls to structured logging via `lib/logger.ts`, per CLAUDE.md "Single sources of truth — Structured logging: lib/logger.ts (never console.*)".

## Why
Audit `docs/audits/codebase-health-2026-04-24.md` §2.2 — application code shouldn't use raw `console` for logging. Logger gives consistent shape (module name, level, structured context) that downstream tools (Sentry, Vercel logs) can parse.

## Files migrated
- app/admin/compliance/page.tsx → admin-compliance (error)
- app/advisor-portal/BillingTab.tsx → advisor-portal-billing (error x2)
- app/advisor-portal/LeadsTab.tsx → advisor-portal-leads (error)
- app/invest/[slug]/page.tsx → invest-vertical-slug (error)
- components/ErrorBoundary.tsx → error-boundary (error)
- components/PushNotificationPrompt.tsx → push-notification-prompt (error)
- components/ServiceWorkerRegistrar.tsx → service-worker-registrar (warn)
- components/SwitchStoryForm.tsx → switch-story-form (error)
- components/WebVitals.tsx → web-vitals (debug)

## Out-of-scope (separate PR)
3 files in the original audit list have **pre-existing** eslint warnings (`react-hooks/immutability`, `set-state-in-effect`, `no-unused-vars`) that lint-staged refuses even though F-05's diff doesn't introduce them:
- app/admin/marketplace/campaigns/page.tsx
- app/fee-impact/FeeImpactClient.tsx
- app/portfolio/PortfolioClient.tsx

These will be cleaned up in a follow-up PR (F-05a) that fixes the pre-existing warnings then completes the console→logger migration. Filed in this PR description so it doesn't get lost.

## Console call left in place (intentional)
`app/api-docs/page.tsx:439` — inside a `<CodeBlock>`, example API code shown to docs readers, not runtime logging.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint <changed files> --max-warnings 0` clean
- [x] Pre-push hook passed
- [ ] CI green

Tier A — housekeeping conformance, no behavioral change.

Refs: REMEDIATION_QUEUE.md F-05

🤖 Generated with [Claude Code](https://claude.com/claude-code)