### PR TITLE
feat(e): add lib/validation/withValidatedBody.ts helper + tests (E-01)

### DIFF
--- a/__tests__/lib/validation/withValidatedBody.test.ts
+++ b/__tests__/lib/validation/withValidatedBody.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+import {
+  withValidatedBody,
+  VALIDATION_ERROR_CODE,
+} from "@/lib/validation/withValidatedBody";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function makePost(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/test-route", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+}
+
+const Schema = z.object({
+  email: z.string().email(),
+  age: z.number().int().nonnegative(),
+});
+
+type SchemaBody = z.infer<typeof Schema>;
+
+// ── Behavioural tests ─────────────────────────────────────────────────────────
+
+describe("withValidatedBody — happy path", () => {
+  it("invokes the handler with the parsed body and returns its response", async () => {
+    const handler = vi.fn(async (_req: NextRequest, body: SchemaBody) =>
+      NextResponse.json({ ok: true, echoed: body }),
+    );
+    const route = withValidatedBody(Schema, handler);
+
+    const res = await route(makePost({ email: "a@b.com", age: 30 }));
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    const [, parsed] = handler.mock.calls[0]!;
+    expect(parsed).toEqual({ email: "a@b.com", age: 30 });
+
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { ok: boolean; echoed: SchemaBody };
+    expect(json.ok).toBe(true);
+    expect(json.echoed).toEqual({ email: "a@b.com", age: 30 });
+  });
+
+  it("supports a synchronous handler that returns a NextResponse directly", async () => {
+    const handler = vi.fn((_req: NextRequest, _body: SchemaBody) =>
+      NextResponse.json({ ok: true }),
+    );
+    const route = withValidatedBody(Schema, handler);
+
+    const res = await route(makePost({ email: "a@b.com", age: 1 }));
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("withValidatedBody — invalid JSON", () => {
+  it("returns 400 { error: 'Invalid JSON body' } and does not invoke the handler", async () => {
+    const handler = vi.fn();
+    const route = withValidatedBody(Schema, handler);
+
+    const res = await route(makePost("not-valid-json"));
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { error: string };
+    expect(json).toEqual({ error: "Invalid JSON body" });
+  });
+
+  it("treats an empty body as invalid JSON", async () => {
+    const handler = vi.fn();
+    const route = withValidatedBody(Schema, handler);
+
+    const res = await route(makePost(""));
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { error: string };
+    expect(json.error).toBe("Invalid JSON body");
+  });
+});
+
+describe("withValidatedBody — schema validation failure", () => {
+  it("returns 400 with the first issue surfaced + code + raw issues", async () => {
+    const handler = vi.fn();
+    const route = withValidatedBody(Schema, handler);
+
+    // age is missing entirely + email is invalid; we expect the first issue
+    // (Zod walks the schema fields in declaration order: email first).
+    const res = await route(makePost({ email: "not-an-email" }));
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as {
+      error: string;
+      code: string;
+      issues: Array<{ path: (string | number)[]; message: string }>;
+    };
+
+    expect(json.code).toBe(VALIDATION_ERROR_CODE);
+    expect(json.code).toBe("validation_error");
+    expect(Array.isArray(json.issues)).toBe(true);
+    expect(json.issues.length).toBeGreaterThan(0);
+
+    // First issue is on `email`; the surfaced error string includes the path.
+    expect(json.error).toMatch(/email/);
+    expect(json.issues[0]!.path).toEqual(["email"]);
+  });
+
+  it("includes ALL issues, not just the first", async () => {
+    const handler = vi.fn();
+    const route = withValidatedBody(Schema, handler);
+
+    const res = await route(makePost({ email: "not-an-email", age: -5 }));
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as {
+      issues: Array<{ path: (string | number)[] }>;
+    };
+    // both `email` (invalid format) and `age` (must be >= 0) must surface
+    const paths = json.issues.map((i) => i.path.join("."));
+    expect(paths).toContain("email");
+    expect(paths).toContain("age");
+  });
+
+  it("surfaces a top-level error when schema rejects the root value", async () => {
+    const RootArray = z.array(z.number());
+    const handler = vi.fn();
+    const route = withValidatedBody(RootArray, handler);
+
+    const res = await route(makePost({ not: "an array" }));
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as {
+      error: string;
+      code: string;
+      issues: unknown[];
+    };
+    expect(json.code).toBe(VALIDATION_ERROR_CODE);
+    expect(typeof json.error).toBe("string");
+    expect(json.error.length).toBeGreaterThan(0);
+  });
+});
+
+describe("withValidatedBody — handler errors", () => {
+  it("re-throws when the handler rejects (does not silently swallow)", async () => {
+    const boom = new Error("kaboom");
+    const handler = vi.fn(async (_req: NextRequest, _body: SchemaBody) => {
+      throw boom;
+    });
+    const route = withValidatedBody(Schema, handler);
+
+    await expect(
+      route(makePost({ email: "a@b.com", age: 1 })),
+    ).rejects.toBe(boom);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-throws synchronous handler errors", async () => {
+    const boom = new Error("sync-kaboom");
+    const handler = vi.fn((_req: NextRequest, _body: SchemaBody): NextResponse => {
+      throw boom;
+    });
+    const route = withValidatedBody(Schema, handler);
+
+    await expect(
+      route(makePost({ email: "a@b.com", age: 1 })),
+    ).rejects.toBe(boom);
+  });
+});
+
+// ── Type-level test ───────────────────────────────────────────────────────────
+// Locks the ergonomics: handlers receive `body: z.infer<typeof schema>` —
+// no manual cast at the callsite, no `unknown`. If the wrapper's generic
+// regresses, this block fails to type-check (and CI's tsc step catches it).
+
+describe("withValidatedBody — type ergonomics", () => {
+  it("infers the handler body parameter as z.infer<typeof schema>", () => {
+    const ShapedSchema = z.object({
+      email: z.string().email(),
+      plan: z.enum(["free", "pro"]),
+      seats: z.number().int().positive(),
+      meta: z.record(z.string(), z.unknown()).optional(),
+    });
+
+    type Inferred = z.infer<typeof ShapedSchema>;
+
+    const route = withValidatedBody(ShapedSchema, async (_req, body) => {
+      // Compile-time assertion: every field on `body` must be exactly the
+      // shape declared above, with no extra `unknown`/`any` widening.
+      const _email: string = body.email;
+      const _plan: "free" | "pro" = body.plan;
+      const _seats: number = body.seats;
+      const _meta: Record<string, unknown> | undefined = body.meta;
+
+      // Strong identity check — the inferred type must match the schema's
+      // output exactly. A regression that widens `body` to `unknown`
+      // breaks this assignment.
+      const _identity: Inferred = body;
+
+      // Touch the locals so eslint `no-unused-vars` doesn't complain at
+      // runtime; the assertions above are what the test really cares about.
+      void _email;
+      void _plan;
+      void _seats;
+      void _meta;
+      void _identity;
+
+      return NextResponse.json({ ok: true });
+    });
+
+    expect(typeof route).toBe("function");
+  });
+});

--- a/lib/validation/withValidatedBody.ts
+++ b/lib/validation/withValidatedBody.ts
@@ -1,0 +1,115 @@
+/**
+ * `withValidatedBody` — request-body Zod validation wrapper for API routes.
+ *
+ * Author a route handler that takes a *parsed*, *typed* body and let the
+ * wrapper deal with JSON-parse errors, schema validation, and the 400
+ * response envelope. Lets every callsite drop ~10 lines of try/catch +
+ * field guards.
+ *
+ * Usage:
+ *
+ *   import { z } from "zod";
+ *   import { withValidatedBody } from "@/lib/validation/withValidatedBody";
+ *
+ *   const Body = z.object({
+ *     email: z.string().email(),
+ *     plan: z.enum(["free", "pro"]),
+ *   });
+ *
+ *   export const POST = withValidatedBody(Body, async (req, body) => {
+ *     // body is fully typed: { email: string; plan: "free" | "pro" }
+ *     return NextResponse.json({ ok: true });
+ *   });
+ *
+ * Response shape on failure (matches the established error envelope across
+ * `app/api/*` routes — single `{ error }` field with status 400 — extended
+ * with a stable `code` discriminator and the raw Zod issues array so client
+ * code can render field-level errors when it wants to):
+ *
+ *   - Invalid JSON body  →  400 { error: "Invalid JSON body" }
+ *   - Schema mismatch    →  400 {
+ *       error: "<first human-readable issue>",
+ *       code: "validation_error",
+ *       issues: ZodIssue[],
+ *     }
+ *
+ * The helper deliberately does **not** log. Logging is the route's job
+ * (and several routes already log JSON-parse failures with their own
+ * scoped `logger("<route>")`). Keeping the wrapper transparent means it
+ * composes with edge runtime, node runtime, cron auth wrappers, and so on
+ * without surprising side-effects.
+ *
+ * Handler errors are *not* swallowed — if the handler throws, the wrapper
+ * re-throws so Sentry / Next's default error boundary still fire. This is
+ * the same contract the un-wrapped routes have today.
+ */
+
+import type { NextRequest, NextResponse } from "next/server";
+import { NextResponse as NextResponseImpl } from "next/server";
+import type { z } from "zod";
+
+/** Stable error code for schema-validation 400s. */
+export const VALIDATION_ERROR_CODE = "validation_error" as const;
+
+export interface ValidationErrorBody {
+  error: string;
+  code: typeof VALIDATION_ERROR_CODE;
+  issues: z.core.$ZodIssue[];
+}
+
+export interface InvalidJsonBody {
+  error: "Invalid JSON body";
+}
+
+/**
+ * Wraps a route handler so it receives a parsed, schema-validated body.
+ *
+ * - The schema is constrained to `z.ZodType` so `z.infer<typeof schema>`
+ *   resolves to the schema's exact output type — the handler's `body`
+ *   parameter is fully typed without the caller having to specify a
+ *   generic explicitly.
+ * - Falls through to a 400 with a stable error envelope on JSON-parse
+ *   failure or schema mismatch; never invokes the handler in those cases.
+ */
+export function withValidatedBody<Schema extends z.ZodType>(
+  schema: Schema,
+  handler: (
+    req: NextRequest,
+    body: z.infer<Schema>,
+  ) => Promise<NextResponse> | NextResponse,
+): (req: NextRequest) => Promise<NextResponse> {
+  return async function validatedRoute(req: NextRequest): Promise<NextResponse> {
+    let raw: unknown;
+    try {
+      raw = await req.json();
+    } catch {
+      return NextResponseImpl.json<InvalidJsonBody>(
+        { error: "Invalid JSON body" },
+        { status: 400 },
+      );
+    }
+
+    const parsed = schema.safeParse(raw);
+    if (!parsed.success) {
+      const issues = parsed.error.issues;
+      // Surface the first issue as the human-readable summary. Clients that
+      // want field-level rendering use the `issues` array directly.
+      const firstIssue = issues[0];
+      const path = firstIssue?.path?.join(".") ?? "";
+      const message = firstIssue?.message ?? "Invalid request body";
+      const error = path ? `${path}: ${message}` : message;
+      return NextResponseImpl.json<ValidationErrorBody>(
+        {
+          error,
+          code: VALIDATION_ERROR_CODE,
+          issues,
+        },
+        { status: 400 },
+      );
+    }
+
+    // `parsed.data` is `z.infer<Schema>`; the handler's `body` parameter
+    // type is preserved end-to-end without a cast.
+    return handler(req, parsed.data);
+  };
+}


### PR DESCRIPTION
## Summary
Adds `lib/validation/withValidatedBody.ts` — a typed Zod-validation wrapper for Next.js route handlers. Foundation for E-02 (rolling Zod across the top-20 highest-traffic routes).

Pattern: `withValidatedBody(schema, async (req, body) => { ... })`
- Body is fully typed as `z.infer<typeof schema>`
- Invalid JSON → 400 `{ error: "Invalid JSON body" }`
- Schema failure → 400 with first issue surfaced + structured `issues` array
- Handler errors propagate (not swallowed)

## Why
Audit `docs/audits/codebase-health-2026-04-24.md` §X — Zod adoption is currently per-route ad-hoc. A standard wrapper makes the next 20 route migrations consistent, enforces "validate at the boundary" by type, and lets ESLint/TS catch routes that forget to validate.

## What ships
- `lib/validation/withValidatedBody.ts` — the helper
- `__tests__/lib/validation/withValidatedBody.test.ts` — coverage including type-level expectations
- Response shape matches the existing `app/api/quotes/route.ts` validation path (no new error envelope)

## Out-of-scope
This PR does NOT migrate any existing route — that's E-02, separate scope. Two easy first-migration candidates identified for next session: `app/api/submit-lead/route.ts` and `app/api/cohort-stats/route.ts` (both have inline `await req.json()` then ad-hoc shape checks).

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] All new tests pass
- [x] Pre-push hook passed cleanly
- [ ] CI green

Tier A/B border — new lib + tests, no existing code touched.

Refs: REMEDIATION_QUEUE.md E-01

🤖 Generated with [Claude Code](https://claude.com/claude-code)