### PR TITLE
test(d): D-11 batches 24b+25 — route tests backfill (110 tests, 10 files) [audit remediation]

### DIFF
--- a/__tests__/api/advisor-auction-public-bids.test.ts
+++ b/__tests__/api/advisor-auction-public-bids.test.ts
@@ -1,0 +1,347 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockGetUser = vi.fn();
+const mockAdminFrom = vi.fn();
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(() => Promise.resolve({ auth: { getUser: () => mockGetUser() } })),
+}));
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+vi.mock("@/lib/rate-limit", () => ({ isRateLimited: vi.fn(() => false) }));
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import { isRateLimited } from "@/lib/rate-limit";
+
+function makeGetReq(ip = "1.2.3.4") {
+  return new NextRequest("http://localhost/api/advisor-auction/public-bids", {
+    method: "GET",
+    headers: { "x-forwarded-for": ip },
+  });
+}
+
+function makeDeleteReq(bidId?: number, reason?: string, ip = "1.2.3.4") {
+  const url = new URL("http://localhost/api/advisor-auction/public-bids");
+  if (bidId !== undefined) url.searchParams.set("bid_id", String(bidId));
+  if (reason) url.searchParams.set("reason", reason);
+  return new NextRequest(url.toString(), {
+    method: "DELETE",
+    headers: { "x-forwarded-for": ip },
+  });
+}
+
+const sampleBids = [
+  {
+    id: 1,
+    bid_amount: 200,
+    status: "active",
+    created_at: new Date().toISOString(),
+    advisor_auctions: {
+      id: 10,
+      slug: "find-financial-planner",
+      job_title: "Need a financial planner",
+      budget_band: "5k_10k",
+      location: "Sydney",
+      status: "open",
+      ends_at: new Date(Date.now() + 86400_000).toISOString(),
+      winning_bid_id: null,
+      source: "public_job",
+    },
+  },
+];
+
+describe("GET /api/advisor-auction/public-bids", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(isRateLimited).mockResolvedValue(false);
+    mockGetUser.mockResolvedValue({ data: { user: { email: "advisor@example.com" } } });
+  });
+
+  it("returns 429 when rate limited", async () => {
+    vi.mocked(isRateLimited).mockResolvedValue(true);
+    const { GET } = await import("@/app/api/advisor-auction/public-bids/route");
+    const res = await GET(makeGetReq());
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    const { GET } = await import("@/app/api/advisor-auction/public-bids/route");
+    const res = await GET(makeGetReq());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when advisor not found", async () => {
+    mockAdminFrom.mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: null }),
+    });
+    const { GET } = await import("@/app/api/advisor-auction/public-bids/route");
+    const res = await GET(makeGetReq());
+    expect(res.status).toBe(404);
+  });
+
+  it("returns bids array on success", async () => {
+    const advisorChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: { id: 1 } }),
+    };
+    const bidsChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue({ data: sampleBids, error: null }),
+    };
+    mockAdminFrom
+      .mockReturnValueOnce(advisorChain)
+      .mockReturnValueOnce(bidsChain);
+
+    const { GET } = await import("@/app/api/advisor-auction/public-bids/route");
+    const res = await GET(makeGetReq());
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(body.bids)).toBe(true);
+    expect((body.bids as unknown[]).length).toBe(1);
+  });
+
+  it("returns empty array when advisor has no bids", async () => {
+    const advisorChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: { id: 2 } }),
+    };
+    const bidsChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue({ data: [], error: null }),
+    };
+    mockAdminFrom
+      .mockReturnValueOnce(advisorChain)
+      .mockReturnValueOnce(bidsChain);
+
+    const { GET } = await import("@/app/api/advisor-auction/public-bids/route");
+    const res = await GET(makeGetReq());
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(res.status).toBe(200);
+    expect(body.bids).toEqual([]);
+  });
+
+  it("returns 500 on DB error fetching bids", async () => {
+    const advisorChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: { id: 1 } }),
+    };
+    const bidsChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue({ data: null, error: { message: "DB failure" } }),
+    };
+    mockAdminFrom
+      .mockReturnValueOnce(advisorChain)
+      .mockReturnValueOnce(bidsChain);
+
+    const { GET } = await import("@/app/api/advisor-auction/public-bids/route");
+    const res = await GET(makeGetReq());
+    expect(res.status).toBe(500);
+  });
+});
+
+describe("DELETE /api/advisor-auction/public-bids", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(isRateLimited).mockResolvedValue(false);
+    mockGetUser.mockResolvedValue({ data: { user: { email: "advisor@example.com" } } });
+  });
+
+  it("returns 429 when rate limited", async () => {
+    vi.mocked(isRateLimited).mockResolvedValue(true);
+    const { DELETE } = await import("@/app/api/advisor-auction/public-bids/route");
+    const res = await DELETE(makeDeleteReq(1));
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    const { DELETE } = await import("@/app/api/advisor-auction/public-bids/route");
+    const res = await DELETE(makeDeleteReq(1));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when bid_id is missing", async () => {
+    const { DELETE } = await import("@/app/api/advisor-auction/public-bids/route");
+    const res = await DELETE(makeDeleteReq(undefined));
+    expect(res.status).toBe(400);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.error).toMatch(/bid_id/i);
+  });
+
+  it("returns 404 when advisor not found", async () => {
+    mockAdminFrom.mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: null }),
+    });
+    const { DELETE } = await import("@/app/api/advisor-auction/public-bids/route");
+    const res = await DELETE(makeDeleteReq(5));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 when bid not found for this advisor", async () => {
+    const advisorChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: { id: 1 } }),
+    };
+    const bidChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: null }),
+    };
+    mockAdminFrom
+      .mockReturnValueOnce(advisorChain)
+      .mockReturnValueOnce(bidChain);
+
+    const { DELETE } = await import("@/app/api/advisor-auction/public-bids/route");
+    const res = await DELETE(makeDeleteReq(99));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 when bid is not on a public job", async () => {
+    const advisorChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: { id: 1 } }),
+    };
+    const bid = { id: 5, status: "active", auction_id: 10, advisor_auctions: { source: "sponsored", status: "open" } };
+    const bidChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: bid }),
+    };
+    mockAdminFrom
+      .mockReturnValueOnce(advisorChain)
+      .mockReturnValueOnce(bidChain);
+
+    const { DELETE } = await import("@/app/api/advisor-auction/public-bids/route");
+    const res = await DELETE(makeDeleteReq(5));
+    expect(res.status).toBe(400);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.error).toMatch(/public quote/i);
+  });
+
+  it("returns 400 when bid is not active (already won)", async () => {
+    const advisorChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: { id: 1 } }),
+    };
+    const bid = { id: 5, status: "won", auction_id: 10, advisor_auctions: { source: "public_job", status: "closed" } };
+    const bidChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: bid }),
+    };
+    mockAdminFrom
+      .mockReturnValueOnce(advisorChain)
+      .mockReturnValueOnce(bidChain);
+
+    const { DELETE } = await import("@/app/api/advisor-auction/public-bids/route");
+    const res = await DELETE(makeDeleteReq(5));
+    expect(res.status).toBe(400);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.error).toMatch(/active bids/i);
+  });
+
+  it("returns 400 when auction is no longer open", async () => {
+    const advisorChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: { id: 1 } }),
+    };
+    const bid = { id: 5, status: "active", auction_id: 10, advisor_auctions: { source: "public_job", status: "closed" } };
+    const bidChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: bid }),
+    };
+    mockAdminFrom
+      .mockReturnValueOnce(advisorChain)
+      .mockReturnValueOnce(bidChain);
+
+    const { DELETE } = await import("@/app/api/advisor-auction/public-bids/route");
+    const res = await DELETE(makeDeleteReq(5));
+    expect(res.status).toBe(400);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.error).toMatch(/no longer open/i);
+  });
+
+  it("retracts bid successfully", async () => {
+    const advisorChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: { id: 1 } }),
+    };
+    const bid = { id: 5, status: "active", auction_id: 10, advisor_auctions: { source: "public_job", status: "open" } };
+    const bidChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: bid }),
+    };
+    const updateChain = {
+      update: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockResolvedValue({ error: null }),
+    };
+    mockAdminFrom
+      .mockReturnValueOnce(advisorChain)
+      .mockReturnValueOnce(bidChain)
+      .mockReturnValueOnce(updateChain);
+
+    const { DELETE } = await import("@/app/api/advisor-auction/public-bids/route");
+    const res = await DELETE(makeDeleteReq(5, "schedule_conflict"));
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(updateChain.update).toHaveBeenCalledWith({ status: "retracted", retract_reason: "schedule_conflict" });
+  });
+
+  it("uses null retract_reason for invalid reason values", async () => {
+    const advisorChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: { id: 1 } }),
+    };
+    const bid = { id: 5, status: "active", auction_id: 10, advisor_auctions: { source: "public_job", status: "open" } };
+    const bidChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: bid }),
+    };
+    const updateChain = {
+      update: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockResolvedValue({ error: null }),
+    };
+    mockAdminFrom
+      .mockReturnValueOnce(advisorChain)
+      .mockReturnValueOnce(bidChain)
+      .mockReturnValueOnce(updateChain);
+
+    const { DELETE } = await import("@/app/api/advisor-auction/public-bids/route");
+    const res = await DELETE(makeDeleteReq(5, "not_a_valid_reason"));
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(res.status).toBe(200);
+    expect(updateChain.update).toHaveBeenCalledWith({ status: "retracted", retract_reason: null });
+  });
+});

--- a/__tests__/api/advisor-portal-marketplace-analytics.test.ts
+++ b/__tests__/api/advisor-portal-marketplace-analytics.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockGetUser = vi.fn();
+const mockAdminFrom = vi.fn();
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(() => Promise.resolve({ auth: { getUser: () => mockGetUser() } })),
+}));
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+vi.mock("@/lib/rate-limit", () => ({ isRateLimited: vi.fn(() => false) }));
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import { isRateLimited } from "@/lib/rate-limit";
+
+function makeReq(ip = "1.2.3.4") {
+  return new NextRequest("http://localhost/api/advisor-portal/marketplace-analytics", {
+    headers: { "x-forwarded-for": ip },
+  });
+}
+
+function mockChain(data: unknown, error: unknown = null) {
+  return {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    gte: vi.fn().mockReturnThis(),
+    neq: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockResolvedValue({ data, error }),
+    maybeSingle: vi.fn().mockResolvedValue({ data, error }),
+  };
+}
+
+describe("GET /api/advisor-portal/marketplace-analytics", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(isRateLimited).mockResolvedValue(false);
+    mockGetUser.mockResolvedValue({ data: { user: { email: "advisor@example.com" } } });
+  });
+
+  it("returns 429 when rate limited", async () => {
+    vi.mocked(isRateLimited).mockResolvedValue(true);
+    const { GET } = await import("@/app/api/advisor-portal/marketplace-analytics/route");
+    const res = await GET(makeReq());
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    const { GET } = await import("@/app/api/advisor-portal/marketplace-analytics/route");
+    const res = await GET(makeReq());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when advisor not found", async () => {
+    const advChain = mockChain(null);
+    const bidsChain = mockChain([]);
+    mockAdminFrom
+      .mockReturnValueOnce(advChain)
+      .mockReturnValue(bidsChain);
+
+    const { GET } = await import("@/app/api/advisor-portal/marketplace-analytics/route");
+    const res = await GET(makeReq());
+    expect(res.status).toBe(404);
+  });
+
+  it("calculates win rate correctly", async () => {
+    const advisor = { id: 1, type: "financial_planner" };
+    const since = new Date(Date.now() - 30 * 86400_000).toISOString();
+    const myBids = [
+      { id: 1, bid_amount: 100, status: "won", created_at: new Date().toISOString(), auction_id: 10, retract_reason: null, advisor_auctions: { id: 10, created_at: new Date(Date.now() - 3600_000).toISOString(), advisor_types: ["financial_planner"] } },
+      { id: 2, bid_amount: 200, status: "lost", created_at: new Date().toISOString(), auction_id: 11, retract_reason: null, advisor_auctions: { id: 11, created_at: new Date(Date.now() - 7200_000).toISOString(), advisor_types: ["financial_planner"] } },
+      { id: 3, bid_amount: 150, status: "lost", created_at: new Date().toISOString(), auction_id: 12, retract_reason: null, advisor_auctions: { id: 12, created_at: new Date(Date.now() - 1800_000).toISOString(), advisor_types: ["financial_planner"] } },
+      { id: 4, bid_amount: 180, status: "retracted", created_at: new Date().toISOString(), auction_id: 13, retract_reason: "schedule_conflict", advisor_auctions: { id: 13, created_at: new Date(Date.now() - 900_000).toISOString(), advisor_types: ["financial_planner"] } },
+    ];
+
+    const advChain = { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis(), maybeSingle: vi.fn().mockResolvedValue({ data: advisor }) };
+    const bidsChain = { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis(), gte: vi.fn().mockResolvedValue({ data: myBids }) };
+    const catChain = { select: vi.fn().mockReturnThis(), gte: vi.fn().mockReturnThis(), neq: vi.fn().mockReturnThis(), limit: vi.fn().mockResolvedValue({ data: [] }) };
+
+    mockAdminFrom
+      .mockReturnValueOnce(advChain)
+      .mockReturnValueOnce(bidsChain)
+      .mockReturnValueOnce(catChain);
+
+    const { GET } = await import("@/app/api/advisor-portal/marketplace-analytics/route");
+    const res = await GET(makeReq());
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(res.status).toBe(200);
+    expect(body.total_bids).toBe(4);
+    expect(body.wins).toBe(1);
+    expect(body.lost).toBe(2);
+    expect(body.retracted).toBe(1);
+    expect(body.win_rate_pct).toBe(25); // 1/4 = 25%
+    expect(body.window_days).toBe(30);
+  });
+
+  it("returns zero win rate and null median when no bids", async () => {
+    const advisor = { id: 1, type: "financial_planner" };
+
+    const advChain = { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis(), maybeSingle: vi.fn().mockResolvedValue({ data: advisor }) };
+    const bidsChain = { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis(), gte: vi.fn().mockResolvedValue({ data: [] }) };
+    const catChain = { select: vi.fn().mockReturnThis(), gte: vi.fn().mockReturnThis(), neq: vi.fn().mockReturnThis(), limit: vi.fn().mockResolvedValue({ data: [] }) };
+
+    mockAdminFrom
+      .mockReturnValueOnce(advChain)
+      .mockReturnValueOnce(bidsChain)
+      .mockReturnValueOnce(catChain);
+
+    const { GET } = await import("@/app/api/advisor-portal/marketplace-analytics/route");
+    const res = await GET(makeReq());
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(res.status).toBe(200);
+    expect(body.win_rate_pct).toBe(0);
+    expect(body.median_response_hours).toBeNull();
+    expect(body.total_bids).toBe(0);
+  });
+
+  it("filters bids by advisor type", async () => {
+    const advisor = { id: 1, type: "tax_agent" };
+    // One bid on a "tax_agent" auction, one on a "financial_planner" auction
+    const bids = [
+      { id: 1, bid_amount: 100, status: "won", created_at: new Date().toISOString(), auction_id: 10, retract_reason: null, advisor_auctions: { id: 10, created_at: new Date().toISOString(), advisor_types: ["tax_agent"] } },
+      { id: 2, bid_amount: 200, status: "lost", created_at: new Date().toISOString(), auction_id: 11, retract_reason: null, advisor_auctions: { id: 11, created_at: new Date().toISOString(), advisor_types: ["financial_planner"] } },
+    ];
+
+    const advChain = { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis(), maybeSingle: vi.fn().mockResolvedValue({ data: advisor }) };
+    const bidsChain = { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis(), gte: vi.fn().mockResolvedValue({ data: bids }) };
+    const catChain = { select: vi.fn().mockReturnThis(), gte: vi.fn().mockReturnThis(), neq: vi.fn().mockReturnThis(), limit: vi.fn().mockResolvedValue({ data: [] }) };
+
+    mockAdminFrom
+      .mockReturnValueOnce(advChain)
+      .mockReturnValueOnce(bidsChain)
+      .mockReturnValueOnce(catChain);
+
+    const { GET } = await import("@/app/api/advisor-portal/marketplace-analytics/route");
+    const res = await GET(makeReq());
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(res.status).toBe(200);
+    // Only 1 bid (tax_agent) should count
+    expect(body.total_bids).toBe(1);
+    expect(body.wins).toBe(1);
+    expect(body.win_rate_pct).toBe(100);
+  });
+
+  it("computes category benchmark win rate from public_job bids", async () => {
+    const advisor = { id: 1, type: "financial_planner" };
+
+    const advChain = { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis(), maybeSingle: vi.fn().mockResolvedValue({ data: advisor }) };
+    const bidsChain = { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis(), gte: vi.fn().mockResolvedValue({ data: [] }) };
+    const catBids = [
+      { status: "won", advisor_auctions: { source: "public_job", advisor_types: ["financial_planner"] } },
+      { status: "won", advisor_auctions: { source: "public_job", advisor_types: ["financial_planner"] } },
+      { status: "lost", advisor_auctions: { source: "public_job", advisor_types: ["financial_planner"] } },
+      { status: "won", advisor_auctions: { source: "sponsored", advisor_types: ["financial_planner"] } }, // excluded
+    ];
+    const catChain = { select: vi.fn().mockReturnThis(), gte: vi.fn().mockReturnThis(), neq: vi.fn().mockReturnThis(), limit: vi.fn().mockResolvedValue({ data: catBids }) };
+
+    mockAdminFrom
+      .mockReturnValueOnce(advChain)
+      .mockReturnValueOnce(bidsChain)
+      .mockReturnValueOnce(catChain);
+
+    const { GET } = await import("@/app/api/advisor-portal/marketplace-analytics/route");
+    const res = await GET(makeReq());
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(res.status).toBe(200);
+    // 2 wins out of 3 public_job bids = 67%
+    expect(body.category_avg_win_rate_pct).toBe(67);
+  });
+
+  it("returns 500 on unexpected error", async () => {
+    mockAdminFrom.mockImplementation(() => { throw new Error("DB crash"); });
+
+    const { GET } = await import("@/app/api/advisor-portal/marketplace-analytics/route");
+    const res = await GET(makeReq());
+    expect(res.status).toBe(500);
+  });
+});

--- a/__tests__/api/advisor-portal-marketplace-settings.test.ts
+++ b/__tests__/api/advisor-portal-marketplace-settings.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockGetUser = vi.fn();
+const mockAdminFrom = vi.fn();
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(() => Promise.resolve({ auth: { getUser: () => mockGetUser() } })),
+}));
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+vi.mock("@/lib/rate-limit", () => ({ isRateLimited: vi.fn(() => false) }));
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import { isRateLimited } from "@/lib/rate-limit";
+
+function makeReq(method = "GET", body?: unknown, ip = "1.2.3.4") {
+  return new NextRequest("http://localhost/api/advisor-portal/marketplace-settings", {
+    method,
+    headers: { "content-type": "application/json", "x-forwarded-for": ip },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+}
+
+function makeProChain(pro: unknown) {
+  return {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn().mockResolvedValue({ data: pro }),
+  };
+}
+
+function makeUpdateChain(error: unknown = null) {
+  return {
+    update: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockResolvedValue({ error }),
+  };
+}
+
+describe("GET /api/advisor-portal/marketplace-settings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(isRateLimited).mockResolvedValue(false);
+    mockGetUser.mockResolvedValue({ data: { user: { email: "adv@example.com" } } });
+  });
+
+  it("returns 429 when rate limited", async () => {
+    vi.mocked(isRateLimited).mockResolvedValue(true);
+    const { GET } = await import("@/app/api/advisor-portal/marketplace-settings/route");
+    const res = await GET(makeReq("GET"));
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    const { GET } = await import("@/app/api/advisor-portal/marketplace-settings/route");
+    const res = await GET(makeReq("GET"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when advisor not found", async () => {
+    mockAdminFrom.mockReturnValue(makeProChain(null));
+    const { GET } = await import("@/app/api/advisor-portal/marketplace-settings/route");
+    const res = await GET(makeReq("GET"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns current settings", async () => {
+    const pro = {
+      id: 1,
+      accepts_new_clients: false,
+      bid_templates: [{ id: "t1", label: "My template", body: "Hello, I am..." }],
+      alert_preferences: { advisor_types: ["financial_planner"], states: ["NSW"], budget_bands: ["5k_10k"] },
+    };
+    mockAdminFrom.mockReturnValue(makeProChain(pro));
+
+    const { GET } = await import("@/app/api/advisor-portal/marketplace-settings/route");
+    const res = await GET(makeReq("GET"));
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(res.status).toBe(200);
+    expect(body.accepts_new_clients).toBe(false);
+    expect(body.bid_templates).toHaveLength(1);
+    expect(body.alert_preferences).toEqual({ advisor_types: ["financial_planner"], states: ["NSW"], budget_bands: ["5k_10k"] });
+  });
+
+  it("returns defaults when DB fields are null", async () => {
+    const pro = { id: 1, accepts_new_clients: null, bid_templates: null, alert_preferences: null };
+    mockAdminFrom.mockReturnValue(makeProChain(pro));
+
+    const { GET } = await import("@/app/api/advisor-portal/marketplace-settings/route");
+    const res = await GET(makeReq("GET"));
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(res.status).toBe(200);
+    expect(body.accepts_new_clients).toBe(true);
+    expect(body.bid_templates).toEqual([]);
+    expect(body.alert_preferences).toEqual({ advisor_types: [], states: [], budget_bands: [] });
+  });
+
+  it("returns 500 on unexpected error", async () => {
+    mockAdminFrom.mockImplementation(() => { throw new Error("crash"); });
+    const { GET } = await import("@/app/api/advisor-portal/marketplace-settings/route");
+    const res = await GET(makeReq("GET"));
+    expect(res.status).toBe(500);
+  });
+});
+
+describe("PATCH /api/advisor-portal/marketplace-settings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(isRateLimited).mockResolvedValue(false);
+    mockGetUser.mockResolvedValue({ data: { user: { email: "adv@example.com" } } });
+  });
+
+  it("returns 429 when rate limited", async () => {
+    vi.mocked(isRateLimited).mockResolvedValue(true);
+    const { PATCH } = await import("@/app/api/advisor-portal/marketplace-settings/route");
+    const res = await PATCH(makeReq("PATCH", { accepts_new_clients: true }));
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    const { PATCH } = await import("@/app/api/advisor-portal/marketplace-settings/route");
+    const res = await PATCH(makeReq("PATCH", { accepts_new_clients: true }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 on invalid JSON", async () => {
+    const pro = { id: 1, accepts_new_clients: true, bid_templates: [], alert_preferences: null };
+    mockAdminFrom.mockReturnValue(makeProChain(pro));
+    const req = new NextRequest("http://localhost/api/advisor-portal/marketplace-settings", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: "not-json",
+    });
+    const { PATCH } = await import("@/app/api/advisor-portal/marketplace-settings/route");
+    const res = await PATCH(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when nothing to update (empty body)", async () => {
+    const pro = { id: 1, accepts_new_clients: true, bid_templates: [], alert_preferences: null };
+    mockAdminFrom.mockReturnValue(makeProChain(pro));
+    const { PATCH } = await import("@/app/api/advisor-portal/marketplace-settings/route");
+    const res = await PATCH(makeReq("PATCH", {}));
+    expect(res.status).toBe(400);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.error).toMatch(/nothing to update/i);
+  });
+
+  it("updates accepts_new_clients successfully", async () => {
+    const pro = { id: 5, accepts_new_clients: true, bid_templates: [], alert_preferences: null };
+    const proChain = makeProChain(pro);
+    const updateChain = makeUpdateChain(null);
+    mockAdminFrom
+      .mockReturnValueOnce(proChain)
+      .mockReturnValueOnce(updateChain);
+
+    const { PATCH } = await import("@/app/api/advisor-portal/marketplace-settings/route");
+    const res = await PATCH(makeReq("PATCH", { accepts_new_clients: false }));
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(updateChain.update).toHaveBeenCalledWith({ accepts_new_clients: false });
+  });
+
+  it("rejects bid_templates with >5 items", async () => {
+    const pro = { id: 1, accepts_new_clients: true, bid_templates: [], alert_preferences: null };
+    mockAdminFrom.mockReturnValue(makeProChain(pro));
+    const templates = Array.from({ length: 6 }, (_, i) => ({ id: `t${i}`, label: `T${i}`, body: "body" }));
+
+    const { PATCH } = await import("@/app/api/advisor-portal/marketplace-settings/route");
+    const res = await PATCH(makeReq("PATCH", { bid_templates: templates }));
+    expect(res.status).toBe(400);
+  });
+
+  it("updates valid alert_preferences", async () => {
+    const pro = { id: 5, accepts_new_clients: true, bid_templates: [], alert_preferences: null };
+    const proChain = makeProChain(pro);
+    const updateChain = makeUpdateChain(null);
+    mockAdminFrom
+      .mockReturnValueOnce(proChain)
+      .mockReturnValueOnce(updateChain);
+
+    const prefs = { advisor_types: ["financial_planner", "tax_agent"] as const, states: ["NSW", "VIC"] as const, budget_bands: ["5k_10k"] as const };
+    const { PATCH } = await import("@/app/api/advisor-portal/marketplace-settings/route");
+    const res = await PATCH(makeReq("PATCH", { alert_preferences: prefs }));
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+  });
+
+  it("rejects invalid advisor_type in alert_preferences", async () => {
+    const pro = { id: 1, accepts_new_clients: true, bid_templates: [], alert_preferences: null };
+    mockAdminFrom.mockReturnValue(makeProChain(pro));
+
+    const { PATCH } = await import("@/app/api/advisor-portal/marketplace-settings/route");
+    const res = await PATCH(makeReq("PATCH", { alert_preferences: { advisor_types: ["invalid_type"], states: [], budget_bands: [] } }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 500 on DB update error", async () => {
+    const pro = { id: 5, accepts_new_clients: true, bid_templates: [], alert_preferences: null };
+    const proChain = makeProChain(pro);
+    const updateChain = makeUpdateChain({ message: "update failed" });
+    mockAdminFrom
+      .mockReturnValueOnce(proChain)
+      .mockReturnValueOnce(updateChain);
+
+    const { PATCH } = await import("@/app/api/advisor-portal/marketplace-settings/route");
+    const res = await PATCH(makeReq("PATCH", { accepts_new_clients: false }));
+    expect(res.status).toBe(500);
+  });
+});

--- a/__tests__/api/broker-portal-deals.test.ts
+++ b/__tests__/api/broker-portal-deals.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const mockGetUser = vi.fn();
+const mockAdminFrom = vi.fn();
+const mockGetAdminEmails = vi.fn(() => ["admin@invest.com.au"]);
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+
+vi.mock("@/lib/admin", () => ({
+  getAdminEmails: () => mockGetAdminEmails(),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn() })),
+}));
+
+// broker-portal/deals uses createServerClient from @supabase/ssr directly
+vi.mock("@supabase/ssr", () => ({
+  createServerClient: vi.fn(() => ({
+    auth: { getUser: () => mockGetUser() },
+  })),
+}));
+
+import { GET, PUT } from "@/app/api/broker-portal/deals/route";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+const USER = { id: "user-123" };
+const BROKER_ACCOUNT = { id: "acct-1", broker_slug: "commsec", status: "active" };
+
+function makeGet(cookie = "auth-cookie=tok"): NextRequest {
+  return new NextRequest("http://localhost/api/broker-portal/deals", {
+    method: "GET",
+    headers: { cookie },
+  });
+}
+
+function makePut(body: unknown, cookie = "auth-cookie=tok"): NextRequest {
+  return new NextRequest("http://localhost/api/broker-portal/deals", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json", cookie },
+    body: JSON.stringify(body),
+  });
+}
+
+function setupAdminMock(opts: {
+  account?: typeof BROKER_ACCOUNT | null;
+  broker?: Record<string, unknown> | null;
+  updateError?: { message: string } | null;
+} = {}) {
+  const { account = BROKER_ACCOUNT, broker = {}, updateError = null } = opts;
+
+  mockAdminFrom.mockImplementation((table: string) => {
+    if (table === "broker_accounts") {
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        maybeSingle: vi.fn().mockResolvedValue({ data: account }),
+      };
+    }
+    if (table === "brokers") {
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: broker }),
+        update: vi.fn().mockReturnThis(),
+      };
+    }
+    return {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      update: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: null }),
+    };
+  });
+
+  // For PUT the update chain ends with .eq() returning an error or not
+  if (updateError !== null) {
+    mockAdminFrom.mockImplementation((table: string) => {
+      if (table === "broker_accounts") {
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          maybeSingle: vi.fn().mockResolvedValue({ data: account }),
+        };
+      }
+      if (table === "brokers") {
+        return {
+          update: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({ error: updateError }),
+          })),
+        };
+      }
+      return {};
+    });
+  }
+}
+
+// ── GET tests ──────────────────────────────────────────────────────────────────
+
+describe("GET /api/broker-portal/deals", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 401 when user is not authenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    const res = await GET(makeGet());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when no active broker account found", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: USER } });
+    setupAdminMock({ account: null });
+    const res = await GET(makeGet());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns deal fields for authenticated broker", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: USER } });
+    setupAdminMock({
+      broker: {
+        deal: true,
+        deal_text: "$0 brokerage first month",
+        deal_expiry: "2026-06-30",
+        deal_terms: "New accounts only",
+        deal_category: "no_brokerage",
+        deal_verified_date: "2026-04-01T00:00:00Z",
+      },
+    });
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.deal).toBe(true);
+    expect(body.deal_text).toBe("$0 brokerage first month");
+    expect(body.deal_expiry).toBe("2026-06-30");
+  });
+
+  it("returns defaults when broker has no active deal", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: USER } });
+    setupAdminMock({ broker: { deal: null, deal_text: null } });
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.deal).toBe(false);
+    expect(body.deal_text).toBe("");
+  });
+});
+
+// ── PUT tests ─────────────────────────────────────────────────────────────────
+
+describe("PUT /api/broker-portal/deals", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true }));
+  });
+
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    const res = await PUT(makePut({ deal_enabled: true, deal_text: "Offer" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when deal_enabled=true but deal_text is empty", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: USER } });
+    setupAdminMock();
+    const res = await PUT(makePut({ deal_enabled: true, deal_text: "" }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/deal text is required/i);
+  });
+
+  it("returns 400 when deal_text exceeds 200 characters", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: USER } });
+    setupAdminMock();
+    const res = await PUT(makePut({ deal_enabled: true, deal_text: "a".repeat(201) }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/200 characters/i);
+  });
+
+  it("returns 400 when deal_terms exceeds 500 characters", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: USER } });
+    setupAdminMock();
+    const res = await PUT(makePut({ deal_enabled: true, deal_text: "Good deal", deal_terms: "t".repeat(501) }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/500 characters/i);
+  });
+
+  it("returns 400 when deal_expiry is in the past", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: USER } });
+    setupAdminMock();
+    const res = await PUT(
+      makePut({ deal_enabled: true, deal_text: "Offer", deal_expiry: "2020-01-01" }),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/future/i);
+  });
+
+  it("successfully updates deal and returns success=true", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: USER } });
+    mockAdminFrom.mockImplementation((table: string) => {
+      if (table === "broker_accounts") {
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          maybeSingle: vi.fn().mockResolvedValue({ data: BROKER_ACCOUNT }),
+        };
+      }
+      if (table === "brokers") {
+        return {
+          update: vi.fn(() => ({ eq: vi.fn().mockResolvedValue({ error: null }) })),
+        };
+      }
+      return {};
+    });
+    const futureExpiry = new Date(Date.now() + 30 * 86400000).toISOString().split("T")[0];
+    const res = await PUT(
+      makePut({ deal_enabled: true, deal_text: "Great offer", deal_expiry: futureExpiry }),
+    );
+    expect(res.status).toBe(200);
+    expect((await res.json()).success).toBe(true);
+  });
+
+  it("returns 500 when DB update fails", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: USER } });
+    setupAdminMock({ updateError: { message: "DB down" } });
+    const res = await PUT(makePut({ deal_enabled: true, deal_text: "Offer" }));
+    expect(res.status).toBe(500);
+  });
+
+  it("disabling deal sets deal=false and clears text fields", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: USER } });
+    const updateMock = vi.fn(() => ({ eq: vi.fn().mockResolvedValue({ error: null }) }));
+    mockAdminFrom.mockImplementation((table: string) => {
+      if (table === "broker_accounts") {
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          maybeSingle: vi.fn().mockResolvedValue({ data: BROKER_ACCOUNT }),
+        };
+      }
+      if (table === "brokers") {
+        return { update: updateMock };
+      }
+      return {};
+    });
+    const res = await PUT(makePut({ deal_enabled: false }));
+    expect(res.status).toBe(200);
+    const [[updateData]] = updateMock.mock.calls;
+    expect((updateData as Record<string, unknown>).deal).toBe(false);
+    expect((updateData as Record<string, unknown>).deal_text).toBeNull();
+  });
+});

--- a/__tests__/api/broker-portal-invoices-pdf.test.ts
+++ b/__tests__/api/broker-portal-invoices-pdf.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockGetUser = vi.fn();
+const mockAdminFrom = vi.fn();
+
+vi.mock("@supabase/ssr", () => ({
+  createServerClient: vi.fn(() => ({
+    auth: { getUser: () => mockGetUser() },
+  })),
+}));
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+vi.mock("@/lib/utils", () => ({
+  formatDate: vi.fn((iso: string) => new Date(iso).toLocaleDateString("en-AU")),
+}));
+
+function makeReq(id: string) {
+  return new NextRequest(`http://localhost/api/broker-portal/invoices/${id}/pdf`);
+}
+
+function makeParams(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+const baseInvoice = {
+  id: 42,
+  invoice_number: "INV-2026-042",
+  status: "paid",
+  amount_cents: 11000,
+  subtotal_cents: 10000,
+  tax_cents: 1000,
+  description: "Marketplace ad spend",
+  broker_slug: "commsec",
+  broker_company_name: "CommSec Pty Ltd",
+  broker_email: "billing@commsec.com.au",
+  broker_abn: "48 123 123 124",
+  line_items: null,
+  currency: "AUD",
+  created_at: new Date().toISOString(),
+  paid_at: new Date().toISOString(),
+};
+
+describe("GET /api/broker-portal/invoices/[id]/pdf", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUser.mockResolvedValue({ data: { user: { id: "user-1", email: "broker@example.com" } } });
+  });
+
+  it("returns 400 for non-numeric invoice ID", async () => {
+    const { GET } = await import("@/app/api/broker-portal/invoices/[id]/pdf/route");
+    const res = await GET(makeReq("abc"), makeParams("abc"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    const { GET } = await import("@/app/api/broker-portal/invoices/[id]/pdf/route");
+    const res = await GET(makeReq("42"), makeParams("42"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when no active broker account", async () => {
+    mockAdminFrom.mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: null }),
+    });
+
+    const { GET } = await import("@/app/api/broker-portal/invoices/[id]/pdf/route");
+    const res = await GET(makeReq("42"), makeParams("42"));
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 404 when invoice not found for this broker", async () => {
+    const accountChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: { broker_slug: "commsec" } }),
+    };
+    const invoiceChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+    };
+    mockAdminFrom
+      .mockReturnValueOnce(accountChain)
+      .mockReturnValueOnce(invoiceChain);
+
+    const { GET } = await import("@/app/api/broker-portal/invoices/[id]/pdf/route");
+    const res = await GET(makeReq("42"), makeParams("42"));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns HTML with Content-Type text/html", async () => {
+    const accountChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: { broker_slug: "commsec" } }),
+    };
+    const invoiceChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: baseInvoice, error: null }),
+    };
+    mockAdminFrom
+      .mockReturnValueOnce(accountChain)
+      .mockReturnValueOnce(invoiceChain);
+
+    const { GET } = await import("@/app/api/broker-portal/invoices/[id]/pdf/route");
+    const res = await GET(makeReq("42"), makeParams("42"));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("text/html");
+  });
+
+  it("sets Content-Disposition with invoice number in filename", async () => {
+    const accountChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: { broker_slug: "commsec" } }),
+    };
+    const invoiceChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: baseInvoice, error: null }),
+    };
+    mockAdminFrom
+      .mockReturnValueOnce(accountChain)
+      .mockReturnValueOnce(invoiceChain);
+
+    const { GET } = await import("@/app/api/broker-portal/invoices/[id]/pdf/route");
+    const res = await GET(makeReq("42"), makeParams("42"));
+    const disposition = res.headers.get("Content-Disposition") ?? "";
+    expect(disposition).toContain("INV-2026-042");
+    expect(disposition).toContain("inline");
+  });
+
+  it("includes status label PAID in HTML body", async () => {
+    const accountChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: { broker_slug: "commsec" } }),
+    };
+    const invoiceChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: baseInvoice, error: null }),
+    };
+    mockAdminFrom
+      .mockReturnValueOnce(accountChain)
+      .mockReturnValueOnce(invoiceChain);
+
+    const { GET } = await import("@/app/api/broker-portal/invoices/[id]/pdf/route");
+    const res = await GET(makeReq("42"), makeParams("42"));
+    const html = await res.text();
+    expect(html).toContain("PAID");
+  });
+
+  it("renders PENDING status label for unpaid invoices", async () => {
+    const pendingInvoice = { ...baseInvoice, status: "pending", paid_at: null };
+    const accountChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: { broker_slug: "commsec" } }),
+    };
+    const invoiceChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: pendingInvoice, error: null }),
+    };
+    mockAdminFrom
+      .mockReturnValueOnce(accountChain)
+      .mockReturnValueOnce(invoiceChain);
+
+    const { GET } = await import("@/app/api/broker-portal/invoices/[id]/pdf/route");
+    const res = await GET(makeReq("42"), makeParams("42"));
+    const html = await res.text();
+    expect(html).toContain("PENDING");
+  });
+
+  it("uses line_items JSON when present", async () => {
+    const invoiceWithItems = {
+      ...baseInvoice,
+      line_items: JSON.stringify([
+        { description: "Lead delivery — March 2026", amount_cents: 5000, quantity: 2 },
+        { description: "Platform fee", amount_cents: 1000, quantity: 1 },
+      ]),
+    };
+    const accountChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: { broker_slug: "commsec" } }),
+    };
+    const invoiceChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: invoiceWithItems, error: null }),
+    };
+    mockAdminFrom
+      .mockReturnValueOnce(accountChain)
+      .mockReturnValueOnce(invoiceChain);
+
+    const { GET } = await import("@/app/api/broker-portal/invoices/[id]/pdf/route");
+    const res = await GET(makeReq("42"), makeParams("42"));
+    const html = await res.text();
+    expect(html).toContain("Lead delivery");
+    expect(html).toContain("Platform fee");
+  });
+
+  it("falls back to single description line when line_items is null", async () => {
+    const invoiceNoItems = { ...baseInvoice, line_items: null, description: "Monthly ad spend" };
+    const accountChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: { broker_slug: "commsec" } }),
+    };
+    const invoiceChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: invoiceNoItems, error: null }),
+    };
+    mockAdminFrom
+      .mockReturnValueOnce(accountChain)
+      .mockReturnValueOnce(invoiceChain);
+
+    const { GET } = await import("@/app/api/broker-portal/invoices/[id]/pdf/route");
+    const res = await GET(makeReq("42"), makeParams("42"));
+    const html = await res.text();
+    expect(html).toContain("Monthly ad spend");
+  });
+
+  it("escapes XSS in invoice fields", async () => {
+    const xssInvoice = { ...baseInvoice, broker_company_name: '<script>alert("xss")</script>' };
+    const accountChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: { broker_slug: "commsec" } }),
+    };
+    const invoiceChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: xssInvoice, error: null }),
+    };
+    mockAdminFrom
+      .mockReturnValueOnce(accountChain)
+      .mockReturnValueOnce(invoiceChain);
+
+    const { GET } = await import("@/app/api/broker-portal/invoices/[id]/pdf/route");
+    const res = await GET(makeReq("42"), makeParams("42"));
+    const html = await res.text();
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
+});

--- a/__tests__/api/report-download.test.ts
+++ b/__tests__/api/report-download.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const mockIsAllowed = vi.fn();
+const mockIpKey = vi.fn((req: NextRequest) => req.headers.get("x-forwarded-for") ?? "unknown");
+
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: (...args: unknown[]) => mockIsAllowed(...args),
+  ipKey: (req: NextRequest) => mockIpKey(req),
+}));
+
+const mockFrom = vi.fn();
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn() })),
+}));
+
+import { POST } from "@/app/api/report-download/route";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function makePost(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/report-download", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-forwarded-for": "1.2.3.4",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function setupUpsertMock(error: unknown = null) {
+  mockFrom.mockReturnValue({
+    upsert: vi.fn().mockResolvedValue({ error }),
+  });
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("POST /api/report-download", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowed.mockResolvedValue(true);
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockIsAllowed.mockResolvedValue(false);
+    const res = await POST(makePost({ email: "user@example.com" }));
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 400 when email is missing", async () => {
+    const res = await POST(makePost({}));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/valid email/i);
+  });
+
+  it("returns 400 for email without @ symbol", async () => {
+    const res = await POST(makePost({ email: "notanemail" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for email exceeding 320 chars", async () => {
+    const longEmail = "a".repeat(310) + "@x.com";
+    const res = await POST(makePost({ email: longEmail }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for malformed email format", async () => {
+    const res = await POST(makePost({ email: "bad@" }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/invalid email/i);
+  });
+
+  it("returns 200 for valid email and upserts to email_captures", async () => {
+    setupUpsertMock();
+    const res = await POST(makePost({ email: "user@example.com" }));
+    expect(res.status).toBe(200);
+    expect((await res.json()).success).toBe(true);
+    expect(mockFrom).toHaveBeenCalledWith("email_captures");
+  });
+
+  it("lowercases and trims the email before upsert", async () => {
+    const upsertMock = vi.fn().mockResolvedValue({ error: null });
+    mockFrom.mockReturnValue({ upsert: upsertMock });
+
+    await POST(makePost({ email: "  USER@EXAMPLE.COM  " }));
+
+    const [upsertArg] = upsertMock.mock.calls[0];
+    expect(upsertArg.email).toBe("user@example.com");
+  });
+
+  it("sets source to annual_report", async () => {
+    const upsertMock = vi.fn().mockResolvedValue({ error: null });
+    mockFrom.mockReturnValue({ upsert: upsertMock });
+
+    await POST(makePost({ email: "user@example.com" }));
+
+    const [upsertArg] = upsertMock.mock.calls[0];
+    expect(upsertArg.source).toBe("annual_report");
+  });
+
+  it("returns 200 even when DB upsert errors (good UX over perfect persistence)", async () => {
+    setupUpsertMock({ message: "unique constraint" });
+    const res = await POST(makePost({ email: "user@example.com" }));
+    expect(res.status).toBe(200);
+    expect((await res.json()).success).toBe(true);
+  });
+
+  it("returns 400 for completely invalid JSON body", async () => {
+    const req = new NextRequest("http://localhost/api/report-download", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-forwarded-for": "1.2.3.4" },
+      body: "not-json",
+    });
+    mockIsAllowed.mockResolvedValue(true);
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("passes correct rate-limit params to isAllowed", async () => {
+    setupUpsertMock();
+    await POST(makePost({ email: "user@example.com" }));
+    expect(mockIsAllowed).toHaveBeenCalledWith(
+      "report_download_post",
+      expect.any(String),
+      expect.objectContaining({ max: 10 }),
+    );
+  });
+});

--- a/__tests__/api/review-incentive.test.ts
+++ b/__tests__/api/review-incentive.test.ts
@@ -1,0 +1,274 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const mockIsAllowed = vi.fn();
+const mockIpKey = vi.fn((req: NextRequest) => req.headers.get("x-forwarded-for") ?? "127.0.0.1");
+
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: (...args: unknown[]) => mockIsAllowed(...args),
+  ipKey: (req: NextRequest) => mockIpKey(req),
+}));
+
+const mockGetUser = vi.fn();
+const mockAdminFrom = vi.fn();
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(() =>
+    Promise.resolve({ auth: { getUser: () => mockGetUser() } }),
+  ),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn() })),
+}));
+
+import { GET, POST } from "@/app/api/review-incentive/route";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+const USER = { id: "user-abc" };
+
+function makePost(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/review-incentive", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "x-forwarded-for": "1.2.3.4" },
+    body: JSON.stringify(body),
+  });
+}
+
+const LONG_BODY = "a".repeat(100);
+const VALID_POST_BODY = {
+  broker_slug: "commsec",
+  rating: 4,
+  title: "Great platform",
+  body: LONG_BODY,
+  pros: ["Low fees"],
+  cons: [],
+};
+
+function setupAdminMock(opts: {
+  existingReviews?: { broker_slug: string }[];
+  brokers?: { slug: string; name: string }[];
+  subscription?: { status: string; id?: string; current_period_end?: string } | null;
+  brokerExists?: boolean;
+  alreadyReviewed?: boolean;
+  insertReviewError?: { message: string } | null;
+  insertSubError?: { message: string } | null;
+} = {}) {
+  const {
+    existingReviews = [],
+    brokers = [{ slug: "commsec", name: "CommSec" }],
+    subscription = null,
+    brokerExists = true,
+    alreadyReviewed = false,
+    insertReviewError = null,
+    insertSubError = null,
+  } = opts;
+
+  mockAdminFrom.mockImplementation((table: string) => {
+    if (table === "incentive_reviews") {
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        insert: vi.fn().mockResolvedValue({ error: insertReviewError }),
+        maybeSingle: vi.fn().mockResolvedValue({ data: alreadyReviewed ? { id: "r1" } : null }),
+        // first call for GET listing returns existingReviews array
+        ...(existingReviews.length >= 0 ? {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({ data: existingReviews }),
+            maybeSingle: vi.fn().mockResolvedValue({ data: alreadyReviewed ? { id: "r1" } : null }),
+          })),
+          insert: vi.fn().mockResolvedValue({ error: insertReviewError }),
+        } : {}),
+      };
+    }
+    if (table === "brokers") {
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        order: vi.fn().mockResolvedValue({ data: brokers }),
+        maybeSingle: vi.fn().mockResolvedValue({ data: brokerExists ? { slug: "commsec", name: "CommSec" } : null }),
+      };
+    }
+    if (table === "subscriptions") {
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        in: vi.fn().mockReturnThis(),
+        maybeSingle: vi.fn().mockResolvedValue({ data: subscription }),
+        insert: vi.fn().mockResolvedValue({ error: insertSubError }),
+        update: vi.fn().mockReturnThis(),
+      };
+    }
+    return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis() };
+  });
+}
+
+// ── GET tests ──────────────────────────────────────────────────────────────────
+
+describe("GET /api/review-incentive", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
+  it("returns eligible=true with brokers when user has no reviews", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: USER } });
+    setupAdminMock({ existingReviews: [], brokers: [{ slug: "commsec", name: "CommSec" }] });
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.eligible).toBe(true);
+    expect(body.reward).toBe("1 month Pro");
+  });
+
+  it("has_pro is false when no active subscription", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: USER } });
+    setupAdminMock({ subscription: null });
+    const res = await GET();
+    expect((await res.json()).has_pro).toBe(false);
+  });
+
+  it("has_pro is true when active subscription exists", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: USER } });
+    setupAdminMock({ subscription: { status: "active" } });
+    const res = await GET();
+    expect((await res.json()).has_pro).toBe(true);
+  });
+});
+
+// ── POST tests ─────────────────────────────────────────────────────────────────
+
+describe("POST /api/review-incentive", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowed.mockResolvedValue(true);
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockIsAllowed.mockResolvedValue(false);
+    mockGetUser.mockResolvedValue({ data: { user: USER } });
+    const res = await POST(makePost(VALID_POST_BODY));
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    const res = await POST(makePost(VALID_POST_BODY));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for invalid JSON", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: USER } });
+    const req = new NextRequest("http://localhost/api/review-incentive", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-forwarded-for": "1.2.3.4" },
+      body: "not-json",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for invalid broker_slug (uppercase)", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: USER } });
+    const res = await POST(makePost({ ...VALID_POST_BODY, broker_slug: "CommSec" }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/invalid broker slug/i);
+  });
+
+  it("returns 400 for rating < 1", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: USER } });
+    const res = await POST(makePost({ ...VALID_POST_BODY, rating: 0 }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/rating/i);
+  });
+
+  it("returns 400 for non-integer rating (e.g. 3.5)", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: USER } });
+    const res = await POST(makePost({ ...VALID_POST_BODY, rating: 3.5 }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when title is too short (< 5 chars)", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: USER } });
+    const res = await POST(makePost({ ...VALID_POST_BODY, title: "Hi" }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/title/i);
+  });
+
+  it("returns 400 when body is under 100 chars", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: USER } });
+    const res = await POST(makePost({ ...VALID_POST_BODY, body: "short" }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/100 characters/i);
+  });
+
+  it("returns 400 when body exceeds 5000 chars", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: USER } });
+    const res = await POST(makePost({ ...VALID_POST_BODY, body: "a".repeat(5001) }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/5000/i);
+  });
+
+  it("returns 404 when broker not found or inactive", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: USER } });
+    setupAdminMock({ brokerExists: false });
+    const res = await POST(makePost(VALID_POST_BODY));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 409 when user already reviewed this broker", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: USER } });
+    setupAdminMock({ alreadyReviewed: true });
+    const res = await POST(makePost(VALID_POST_BODY));
+    expect(res.status).toBe(409);
+  });
+
+  it("returns 500 on review insert error", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: USER } });
+    setupAdminMock({ insertReviewError: { message: "insert failed" } });
+    const res = await POST(makePost(VALID_POST_BODY));
+    expect(res.status).toBe(500);
+  });
+
+  it("grants new Pro subscription when user has none", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: USER } });
+    setupAdminMock({ subscription: null });
+    const res = await POST(makePost(VALID_POST_BODY));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.pro_granted).toBe(true);
+  });
+
+  it("extends existing subscription by 1 month", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: USER } });
+    setupAdminMock({
+      subscription: {
+        id: "sub-1",
+        status: "active",
+        current_period_end: new Date(Date.now() + 86400000 * 15).toISOString(),
+      },
+    });
+    const res = await POST(makePost(VALID_POST_BODY));
+    expect(res.status).toBe(200);
+    expect((await res.json()).pro_granted).toBe(true);
+  });
+
+  it("does not fail if Pro grant fails — review still returns 200", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: USER } });
+    setupAdminMock({ subscription: null, insertSubError: { message: "sub insert failed" } });
+    const res = await POST(makePost(VALID_POST_BODY));
+    expect(res.status).toBe(200);
+    expect((await res.json()).pro_granted).toBe(false);
+  });
+});

--- a/__tests__/api/reviews-verify-client.test.ts
+++ b/__tests__/api/reviews-verify-client.test.ts
@@ -1,0 +1,299 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockGetUser = vi.fn();
+const mockAdminFrom = vi.fn();
+const mockIsAllowed = vi.fn();
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(() => Promise.resolve({ auth: { getUser: () => mockGetUser() } })),
+}));
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: (...args: unknown[]) => mockIsAllowed(...args),
+  ipKey: vi.fn((req: NextRequest) => req.headers.get("x-forwarded-for") ?? "unknown"),
+}));
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+vi.mock("@/lib/admin", () => ({
+  ADMIN_EMAILS: ["admin@invest.com.au"],
+}));
+
+function makeReq(body: unknown) {
+  return new NextRequest("http://localhost/api/reviews/verify-client", {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-forwarded-for": "1.2.3.4" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/reviews/verify-client", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowed.mockResolvedValue(true);
+    mockGetUser.mockResolvedValue({
+      data: { user: { email: "admin@invest.com.au" } },
+      error: null,
+    });
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockIsAllowed.mockResolvedValue(false);
+    const { POST } = await import("@/app/api/reviews/verify-client/route");
+    const res = await POST(makeReq({ review_id: 1, review_type: "broker" }));
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+    const { POST } = await import("@/app/api/reviews/verify-client/route");
+    const res = await POST(makeReq({ review_id: 1, review_type: "broker" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 for non-admin user", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { email: "regular@example.com" } }, error: null });
+    const { POST } = await import("@/app/api/reviews/verify-client/route");
+    const res = await POST(makeReq({ review_id: 1, review_type: "broker" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 on invalid JSON body", async () => {
+    const req = new NextRequest("http://localhost/api/reviews/verify-client", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "not-json",
+    });
+    const { POST } = await import("@/app/api/reviews/verify-client/route");
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when review_id or review_type missing", async () => {
+    const { POST } = await import("@/app/api/reviews/verify-client/route");
+    const res = await POST(makeReq({ review_id: 1 }));
+    expect(res.status).toBe(400);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.error).toMatch(/required/i);
+  });
+
+  it("returns 400 for invalid review_type", async () => {
+    const { POST } = await import("@/app/api/reviews/verify-client/route");
+    const res = await POST(makeReq({ review_id: 1, review_type: "company" }));
+    expect(res.status).toBe(400);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.error).toMatch(/broker.*advisor/i);
+  });
+
+  // ── Broker review path ──
+
+  it("returns 404 when broker review not found", async () => {
+    mockAdminFrom.mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: null, error: { message: "not found" } }),
+    });
+    const { POST } = await import("@/app/api/reviews/verify-client/route");
+    const res = await POST(makeReq({ review_id: 99, review_type: "broker" }));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns already_verified when broker review is already verified", async () => {
+    mockAdminFrom.mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({
+        data: { id: 1, email: "user@example.com", broker_slug: "commsec", broker_id: 2, is_verified_client: true },
+        error: null,
+      }),
+    });
+    const { POST } = await import("@/app/api/reviews/verify-client/route");
+    const res = await POST(makeReq({ review_id: 1, review_type: "broker" }));
+    const body = await res.json() as Record<string, unknown>;
+    expect(res.status).toBe(200);
+    expect(body.already_verified).toBe(true);
+  });
+
+  it("verifies broker review via signup_match", async () => {
+    const reviewChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({
+        data: { id: 1, email: "customer@example.com", broker_slug: "commsec", broker_id: 2, is_verified_client: false },
+        error: null,
+      }),
+    };
+    const signupChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue({ data: [{ id: 10 }] }),
+    };
+    const updateChain = {
+      update: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockResolvedValue({ error: null }),
+    };
+    mockAdminFrom
+      .mockReturnValueOnce(reviewChain)
+      .mockReturnValueOnce(signupChain)
+      .mockReturnValueOnce(updateChain);
+
+    const { POST } = await import("@/app/api/reviews/verify-client/route");
+    const res = await POST(makeReq({ review_id: 1, review_type: "broker" }));
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(res.status).toBe(200);
+    expect(body.verified).toBe(true);
+    expect(body.verified_via).toBe("signup_match");
+  });
+
+  it("returns verified=false when no broker signup match", async () => {
+    const reviewChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({
+        data: { id: 1, email: "customer@example.com", broker_slug: "commsec", broker_id: 2, is_verified_client: false },
+        error: null,
+      }),
+    };
+    const signupChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue({ data: [] }),
+    };
+    mockAdminFrom
+      .mockReturnValueOnce(reviewChain)
+      .mockReturnValueOnce(signupChain);
+
+    const { POST } = await import("@/app/api/reviews/verify-client/route");
+    const res = await POST(makeReq({ review_id: 1, review_type: "broker" }));
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(res.status).toBe(200);
+    expect(body.verified).toBe(false);
+  });
+
+  it("returns 500 when broker review update fails", async () => {
+    const reviewChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({
+        data: { id: 1, email: "customer@example.com", broker_slug: "commsec", broker_id: 2, is_verified_client: false },
+        error: null,
+      }),
+    };
+    const signupChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue({ data: [{ id: 10 }] }),
+    };
+    const updateChain = {
+      update: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockResolvedValue({ error: { message: "update failed" } }),
+    };
+    mockAdminFrom
+      .mockReturnValueOnce(reviewChain)
+      .mockReturnValueOnce(signupChain)
+      .mockReturnValueOnce(updateChain);
+
+    const { POST } = await import("@/app/api/reviews/verify-client/route");
+    const res = await POST(makeReq({ review_id: 1, review_type: "broker" }));
+    expect(res.status).toBe(500);
+  });
+
+  // ── Advisor review path ──
+
+  it("returns 404 when advisor review not found", async () => {
+    mockAdminFrom.mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: null, error: { message: "not found" } }),
+    });
+    const { POST } = await import("@/app/api/reviews/verify-client/route");
+    const res = await POST(makeReq({ review_id: 99, review_type: "advisor" }));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns already_verified for advisor review already verified", async () => {
+    mockAdminFrom.mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({
+        data: { id: 1, reviewer_email: "user@example.com", professional_id: 5, is_verified_client: true },
+        error: null,
+      }),
+    });
+    const { POST } = await import("@/app/api/reviews/verify-client/route");
+    const res = await POST(makeReq({ review_id: 1, review_type: "advisor" }));
+    const body = await res.json() as Record<string, unknown>;
+    expect(res.status).toBe(200);
+    expect(body.already_verified).toBe(true);
+  });
+
+  it("verifies advisor review via enquiry_match", async () => {
+    const reviewChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({
+        data: { id: 1, reviewer_email: "client@example.com", professional_id: 5, is_verified_client: false },
+        error: null,
+      }),
+    };
+    const leadChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue({ data: [{ id: 20 }] }),
+    };
+    const updateChain = {
+      update: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockResolvedValue({ error: null }),
+    };
+    mockAdminFrom
+      .mockReturnValueOnce(reviewChain)
+      .mockReturnValueOnce(leadChain)
+      .mockReturnValueOnce(updateChain);
+
+    const { POST } = await import("@/app/api/reviews/verify-client/route");
+    const res = await POST(makeReq({ review_id: 1, review_type: "advisor" }));
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(res.status).toBe(200);
+    expect(body.verified).toBe(true);
+    expect(body.verified_via).toBe("enquiry_match");
+  });
+
+  it("returns verified=false when no advisor lead match", async () => {
+    const reviewChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({
+        data: { id: 1, reviewer_email: "client@example.com", professional_id: 5, is_verified_client: false },
+        error: null,
+      }),
+    };
+    const leadChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue({ data: [] }),
+    };
+    mockAdminFrom
+      .mockReturnValueOnce(reviewChain)
+      .mockReturnValueOnce(leadChain);
+
+    const { POST } = await import("@/app/api/reviews/verify-client/route");
+    const res = await POST(makeReq({ review_id: 1, review_type: "advisor" }));
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(res.status).toBe(200);
+    expect(body.verified).toBe(false);
+  });
+
+  it("returns 500 on unexpected throw", async () => {
+    mockAdminFrom.mockImplementation(() => { throw new Error("crash"); });
+    const { POST } = await import("@/app/api/reviews/verify-client/route");
+    const res = await POST(makeReq({ review_id: 1, review_type: "broker" }));
+    expect(res.status).toBe(500);
+  });
+});

--- a/__tests__/api/sync-shortlist.test.ts
+++ b/__tests__/api/sync-shortlist.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const mockIsRateLimited = vi.fn();
+vi.mock("@/lib/rate-limit", () => ({
+  isRateLimited: (...args: unknown[]) => mockIsRateLimited(...args),
+}));
+
+const mockGetUser = vi.fn();
+const mockFrom = vi.fn();
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(() =>
+    Promise.resolve({
+      auth: { getUser: () => mockGetUser() },
+      from: mockFrom,
+    }),
+  ),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn() })),
+}));
+
+import { GET, POST } from "@/app/api/sync-shortlist/route";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+const USER = { id: "user-123" };
+
+function makeGet(): NextRequest {
+  return new NextRequest("http://localhost/api/sync-shortlist", { method: "GET" });
+}
+
+function makePost(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/sync-shortlist", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function setupShortlistMock(opts: {
+  slugs?: { broker_slug: string; added_at: string }[];
+  selectError?: { message: string } | null;
+  deleteError?: { message: string } | null;
+  insertError?: { message: string } | null;
+} = {}) {
+  const { slugs = [], selectError = null, deleteError = null, insertError = null } = opts;
+
+  mockFrom.mockImplementation(() => ({
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    order: vi.fn().mockResolvedValue({ data: slugs, error: selectError }),
+    delete: vi.fn().mockReturnThis(),
+    insert: vi.fn().mockResolvedValue({ error: insertError }),
+    // delete returns a thenable when chained with eq
+    ...(deleteError !== undefined ? {
+      delete: vi.fn(() => ({
+        eq: vi.fn().mockResolvedValue({ error: deleteError }),
+      })),
+    } : {}),
+  }));
+}
+
+// ── GET tests ──────────────────────────────────────────────────────────────────
+
+describe("GET /api/sync-shortlist", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsRateLimited.mockResolvedValue(false);
+  });
+
+  it("returns 401 when user is not authenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    const res = await GET();
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toMatch(/not authenticated/i);
+  });
+
+  it("returns empty slugs array when shortlist is empty", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: USER } });
+    setupShortlistMock({ slugs: [] });
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect((await res.json()).slugs).toEqual([]);
+  });
+
+  it("returns slugs from the shortlist", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: USER } });
+    setupShortlistMock({
+      slugs: [
+        { broker_slug: "commsec", added_at: "2026-01-01T00:00:00Z" },
+        { broker_slug: "cmc-markets", added_at: "2026-01-02T00:00:00Z" },
+      ],
+    });
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect((await res.json()).slugs).toEqual(["commsec", "cmc-markets"]);
+  });
+
+  it("returns 500 on DB fetch error", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: USER } });
+    setupShortlistMock({ selectError: { message: "connection timeout" } });
+    const res = await GET();
+    expect(res.status).toBe(500);
+  });
+});
+
+// ── POST tests ─────────────────────────────────────────────────────────────────
+
+describe("POST /api/sync-shortlist", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsRateLimited.mockResolvedValue(false);
+  });
+
+  it("returns 401 when user is not authenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    const res = await POST(makePost({ slugs: ["commsec"] }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 429 when rate limit exceeded", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: USER } });
+    mockIsRateLimited.mockResolvedValue(true);
+    const res = await POST(makePost({ slugs: ["commsec"] }));
+    expect(res.status).toBe(429);
+  });
+
+  it("replaces entire shortlist and returns slugs", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: USER } });
+    mockFrom.mockReturnValue({
+      delete: vi.fn(() => ({ eq: vi.fn().mockResolvedValue({ error: null }) })),
+      insert: vi.fn().mockResolvedValue({ error: null }),
+    });
+    const res = await POST(makePost({ slugs: ["commsec", "cmc-markets"] }));
+    expect(res.status).toBe(200);
+    expect((await res.json()).slugs).toEqual(["commsec", "cmc-markets"]);
+  });
+
+  it("clears shortlist when empty slugs array provided", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: USER } });
+    mockFrom.mockReturnValue({
+      delete: vi.fn(() => ({ eq: vi.fn().mockResolvedValue({ error: null }) })),
+      insert: vi.fn().mockResolvedValue({ error: null }),
+    });
+    const res = await POST(makePost({ slugs: [] }));
+    expect(res.status).toBe(200);
+    expect((await res.json()).slugs).toEqual([]);
+  });
+
+  it("caps slugs at MAX_SHORTLIST (8)", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: USER } });
+    mockFrom.mockReturnValue({
+      delete: vi.fn(() => ({ eq: vi.fn().mockResolvedValue({ error: null }) })),
+      insert: vi.fn().mockResolvedValue({ error: null }),
+    });
+    const tooMany = Array.from({ length: 12 }, (_, i) => `broker-${i}`);
+    const res = await POST(makePost({ slugs: tooMany }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.slugs.length).toBeLessThanOrEqual(8);
+  });
+
+  it("filters out non-string slugs", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: USER } });
+    mockFrom.mockReturnValue({
+      delete: vi.fn(() => ({ eq: vi.fn().mockResolvedValue({ error: null }) })),
+      insert: vi.fn().mockResolvedValue({ error: null }),
+    });
+    const res = await POST(makePost({ slugs: ["commsec", 123, null, "", "valid"] }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.slugs).toEqual(["commsec", "valid"]);
+  });
+
+  it("treats non-array slugs as empty list", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: USER } });
+    mockFrom.mockReturnValue({
+      delete: vi.fn(() => ({ eq: vi.fn().mockResolvedValue({ error: null }) })),
+      insert: vi.fn().mockResolvedValue({ error: null }),
+    });
+    const res = await POST(makePost({ slugs: "commsec" }));
+    expect(res.status).toBe(200);
+    expect((await res.json()).slugs).toEqual([]);
+  });
+
+  it("returns 500 on delete error", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: USER } });
+    mockFrom.mockReturnValue({
+      delete: vi.fn(() => ({ eq: vi.fn().mockResolvedValue({ error: { message: "delete failed" } }) })),
+    });
+    const res = await POST(makePost({ slugs: ["commsec"] }));
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 500 on insert error", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: USER } });
+    mockFrom.mockReturnValue({
+      delete: vi.fn(() => ({ eq: vi.fn().mockResolvedValue({ error: null }) })),
+      insert: vi.fn().mockResolvedValue({ error: { message: "insert failed" } }),
+    });
+    const res = await POST(makePost({ slugs: ["commsec"] }));
+    expect(res.status).toBe(500);
+  });
+});

--- a/__tests__/api/tax-optimizer.test.ts
+++ b/__tests__/api/tax-optimizer.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const mockIsAllowed = vi.fn();
+const mockIpKey = vi.fn((req: NextRequest) => req.headers.get("x-forwarded-for") ?? "127.0.0.1");
+
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: (...args: unknown[]) => mockIsAllowed(...args),
+  ipKey: (req: NextRequest) => mockIpKey(req),
+}));
+
+vi.mock("@/lib/ticker-sectors", () => ({
+  lookupTicker: vi.fn(() => ({ dividend_yield_est: 0.04 })),
+  isFrankedDividend: vi.fn(() => false),
+  estimatedFrankingRate: vi.fn(() => 0),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn() })),
+}));
+
+import { POST } from "@/app/api/tax-optimizer/route";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function makePost(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/tax-optimizer", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "x-forwarded-for": "1.2.3.4" },
+    body: JSON.stringify(body),
+  });
+}
+
+const TODAY = new Date();
+function daysAgo(n: number): string {
+  const d = new Date(TODAY);
+  d.setDate(d.getDate() - n);
+  return d.toISOString().split("T")[0];
+}
+
+const GAIN_HOLDING = {
+  ticker: "CBA",
+  name: "Commonwealth Bank",
+  buy_date: daysAgo(400), // >365 → CGT discount eligible
+  buy_price: 80,
+  current_price: 120,
+  quantity: 10,
+};
+
+const LOSS_HOLDING = {
+  ticker: "XYZ",
+  name: "XYZ Corp",
+  buy_date: daysAgo(200),
+  buy_price: 50,
+  current_price: 30,
+  quantity: 5,
+};
+
+const NEAR_DISCOUNT_HOLDING = {
+  ticker: "BHP",
+  name: "BHP Group",
+  buy_date: daysAgo(300), // 66 days to CGT discount
+  buy_price: 40,
+  current_price: 55,
+  quantity: 20,
+};
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("POST /api/tax-optimizer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowed.mockResolvedValue(true);
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockIsAllowed.mockResolvedValue(false);
+    const res = await POST(makePost({ income_bracket: "45k-120k", holdings: [GAIN_HOLDING] }));
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 400 when income_bracket is missing", async () => {
+    const res = await POST(makePost({ holdings: [GAIN_HOLDING] }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/income bracket/i);
+  });
+
+  it("returns 400 when holdings array is empty", async () => {
+    const res = await POST(makePost({ income_bracket: "45k-120k", holdings: [] }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when holdings is missing entirely", async () => {
+    const res = await POST(makePost({ income_bracket: "45k-120k" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 200 with correct CGT for gain holding held >365 days (50% discount)", async () => {
+    const res = await POST(makePost({ income_bracket: "45k-120k", holdings: [GAIN_HOLDING] }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.income_bracket).toBe("45k-120k");
+    expect(body.marginal_rate).toBe(0.325);
+    // gain = (120-80)*10 = 400. With discount: 400*0.5*0.325 = 65
+    const holding = body.holdings[0];
+    expect(holding.cgt_discount_eligible).toBe(true);
+    expect(holding.unrealised_gain).toBe(400);
+    expect(holding.estimated_cgt).toBeCloseTo(65, 0);
+  });
+
+  it("returns estimated_cgt without 50% discount for holdings < 365 days", async () => {
+    const recentHolding = { ...GAIN_HOLDING, buy_date: daysAgo(100) };
+    const res = await POST(makePost({ income_bracket: "45k-120k", holdings: [recentHolding] }));
+    const body = await res.json();
+    const holding = body.holdings[0];
+    expect(holding.cgt_discount_eligible).toBe(false);
+    // gain = 400. Without discount: 400 * 0.325 = 130
+    expect(holding.estimated_cgt).toBeCloseTo(130, 0);
+  });
+
+  it("identifies tax-loss harvesting candidates", async () => {
+    const res = await POST(
+      makePost({ income_bracket: "45k-120k", holdings: [GAIN_HOLDING, LOSS_HOLDING] }),
+    );
+    const body = await res.json();
+    expect(body.tax_loss_candidates.length).toBeGreaterThan(0);
+    const candidate = body.tax_loss_candidates[0];
+    expect(candidate.ticker).toBe("XYZ");
+    expect(candidate.loss_amount).toBeGreaterThan(0);
+    expect(candidate.wash_sale_warning).toBe(true);
+  });
+
+  it("produces CGT discount alert for holding within 90 days of discount", async () => {
+    const res = await POST(
+      makePost({ income_bracket: "45k-120k", holdings: [NEAR_DISCOUNT_HOLDING] }),
+    );
+    const body = await res.json();
+    expect(body.cgt_discount_alerts.length).toBeGreaterThan(0);
+    expect(body.cgt_discount_alerts[0].ticker).toBe("BHP");
+    expect(body.cgt_discount_alerts[0].days_remaining).toBeGreaterThan(0);
+    expect(body.cgt_discount_alerts[0].days_remaining).toBeLessThanOrEqual(90);
+  });
+
+  it("returns cgt_summary with total_gains and net_gain", async () => {
+    const res = await POST(
+      makePost({ income_bracket: "45k-120k", holdings: [GAIN_HOLDING, LOSS_HOLDING] }),
+    );
+    const body = await res.json();
+    expect(body.cgt_summary).toMatchObject({
+      total_gains: expect.any(Number),
+      total_losses: expect.any(Number),
+      net_gain: expect.any(Number),
+    });
+    expect(body.cgt_summary.total_losses).toBeGreaterThan(0);
+  });
+
+  it("uses 0.325 as default marginal_rate for unrecognised bracket", async () => {
+    const res = await POST(makePost({ income_bracket: "unknown-bracket", holdings: [GAIN_HOLDING] }));
+    expect(res.status).toBe(200);
+    expect((await res.json()).marginal_rate).toBe(0.325);
+  });
+
+  it("returns top_moves array capped at 3", async () => {
+    const res = await POST(
+      makePost({
+        income_bracket: "45k-120k",
+        holdings: [GAIN_HOLDING, LOSS_HOLDING, NEAR_DISCOUNT_HOLDING],
+      }),
+    );
+    const body = await res.json();
+    expect(body.top_moves.length).toBeLessThanOrEqual(3);
+  });
+
+  it("returns 500 on unexpected throw", async () => {
+    mockIsAllowed.mockRejectedValue(new Error("rate limit DB down"));
+    const res = await POST(makePost({ income_bracket: "45k-120k", holdings: [GAIN_HOLDING] }));
+    expect(res.status).toBe(500);
+  });
+});

--- a/docs/audits/REMEDIATION_QUEUE.md
+++ b/docs/audits/REMEDIATION_QUEUE.md
@@ -25,29 +25,29 @@ _None yet — will be populated as the loop opens stream branches & PRs._
 | Stream | Branch | PR | Last CI | Items in flight |
 | --- | --- | --- | --- | --- |
 | A | _not started_ | — | — | — |
-| B | `claude/audit-remediation/b-07-rls-migration-lint` | #286 (draft) | pending — pushed 2026-04-28T22:35Z | PR #220 merged (B-01..B-06 done/blocked/FP). B-07 done (`0097159`) — CI gate: new CREATE TABLE migrations must include ENABLE ROW LEVEL SECURITY. |
+| B | ✓ merged | #286 ✓ merged 2026-04-29 | ✅ green | PR #220 merged (B-01..B-06 done/blocked/FP). B-07 done (`0097159`) — CI gate: new CREATE TABLE migrations must include ENABLE ROW LEVEL SECURITY. B-08/B-09 pending. |
 | C | _not started_ | — | — | — |
-| D | `claude/audit-remediation/d-route-tests` | #285 | pending — pushed 2026-04-29T23:35Z | D-01 done (commit `7269510`) · D-02 done (commit `ebf2250`) · D-03 done (commit `0177aa1`) · D-04 done (commit `bea95b1`) · D-05 done (commit `e49375d`) · D-06 done (commit `c0cd3ee`) · D-07 done (commit `33230fb`) · D-08 done (commit `311df3f`) · D-09 done (commit `8e2d35d`) · D-10 done (commit `4e702c1`) · D-11 batch 1 done (commit `90c7c5b`) · D-11 batch 2 done (commit `387bcb4`) · D-11 batch 3 done (commit `db0df8d`) · D-11 batch 4 done (commit `c49e3aa`) · CI-rescue merged main (commit `9282178`) · D-11 batch 5 done (commit `6c7637f`) · D-11 batch 6 done (commit `f7e1a1c`) · D-11 batch 7 done (commit `f183cba`) · D-11 batch 8 done (commit `f336fc7`) · D-11 batch 9 done (commit `2c78f24`) · D-11 batch 10 done (commit `73c8aa1`) · D-11 batch 11 done (commit `3fab2c1`) · D-11 batch 12 done (commit `856026c`) · D-11 batch 12c done (commit `cc77b65`) · D-11 batch 13 done (commit `9dae465`) · D-11 batch 14 done (commit `c64ca614`) · D-11 batch 15 done (commit `01b685f`) · D-11 batch 16 done (commit `6536d77`) · D-11 batch 17 done (commit `bbca74d`) · D-11 batch 17b done (commit `251f745`) · **Also: PR #287 (`d-11-batch-15`) parallel coverage — batch 15: quiz/data+csp-report+complaints/intake+advisor-dashboard+course/purchase (`5c4df09`); batch 16: advisor-articles+community/posts/[id]+advisor-search/postcodes+v1/api-keys+marketplace/webhook (`ebdb3f4`) — 110 complementary tests, merges independently** · D-11 batch 18 done (commit `2694124`) · D-11 batch 18b done (commit `6a89600`→`701cf83`) · D-11 batch 19 done (commit `b93f1647`) · D-11 batch 19b done (commit `49e0ad5`) · D-11 batch 20 done (commit `2f72b7a`) · D-11 batch 21 done (commit `eec7429`) · D-11 batch 21b done (commit `d460cb5`→`32e3069`) · D-11 batch 22 done (commit `951a295`) · D-11 batch 22b done (commit `4b5e73b`) · D-11 batch 23 done (commit `575143b`) · D-11 batch 23b done (commit `a6574f1c`) |
-| E | _not started_ | — | — | — |
-| F | _not started_ | — | — | — |
+| D | `claude/audit-remediation/d-route-tests-2` | #285 ✓ merged 2026-04-29 (batches 1–23b); new PR TBD | ✅ green on #285 | D-01..D-10 done. D-11 batches 1–23b done via PR #285 (merged 2026-04-29). **D-11 batch 24 in progress on new branch** (push/send · webhooks/broker-signup · webhooks/resend · sync-shortlist · report-download). ~96 routes remain untested. |
+| E | ✓ merged | #295 ✓ merged 2026-04-29 | ✅ green | E-01 done — `lib/validation/withValidatedBody.ts` helper + 17 tests. E-02..E-04 pending. |
+| F | ✓ merged | #293 #294 ✓ merged 2026-04-29 | ✅ green | F-02 done (formatDate consolidated, 10 callsites). F-05 done (9 console.* → logger). F-05a (3 remaining files) pending. |
 | G | _not started_ | — | — | — |
 | H | _not started_ | — | — | — |
-| I | `claude/audit-remediation/i-new-04-main-ci-auto-revert` | #278 (draft) | pending — pushed 2026-04-28T16:14Z | I-NEW-01 done via #277 (`00ef2790`); I-NEW-02 hotfix `5b7937dc`; I-NEW-03 hotfix `4b050ed9`; I-NEW-05 race-fix `55d077bf`; **first real metrics snapshot landed 2026-04-28T16:12Z (grade F 0.0899 — Supabase secrets need to be set in GH Actions for non-zero on M04/M07/M08/M09/M10/M11/M12)**; I-NEW-04 in flight (auto-revert workflow `b42233fb`) |
-| J | `claude/audit-remediation/j-stripe-webhook` | #288 (draft) | pending — pushed 2026-04-29T22:30Z | J-01a..J-01e (route.ts 1197 → 165 LOC) · J-01d-ext (commit `bb1d56f6`) · J-03 (commit `b8e7189`) · J-05 (commit `d68852e`) · J-06 (commit `eedf582`) · J-08 (commit `e99aedc`) · J-09 (commit `e99aedc`) · J-10 (commit `e99aedc`) — all handlers complete (14 registered). Stream complete pending PR merge. |
-| K | `claude/audit-remediation/k-security-hardening` | #222 | pending — pushed 2026-04-27T05:35Z | K-01..K-08 done; K-09 false-positive; K-10..K-15 done — **stream complete** |
-| L | `claude/audit-remediation/l-observability` | #289 (draft) | pending — pushed 2026-04-30T00:10Z | L-06 done (commit `12183619`) — 8 SLOs seeded. L-07 done (commit `824366e`) — email alert sink (OPS_ALERT_EMAIL pattern) + 25 tests. L-08 in progress. |
-| M | `claude/audit-remediation/m-01b-cover-image-backfill` | #283 (draft) | pending — pushed 2026-04-28T21:25Z | M-01b in flight (commit `19a0d7e6`) — per-article OG cover override + backfill script. |
-| N | `claude/audit-remediation/n-ux-perf` | #242 | pending — pushed 2026-04-27T13:30Z | N-01+N-02 done (`2ec6f89`) · N-03a done (`36e3f6d`) · N-03b done (`97bb9b00`) · N-03c done (`b29f443`) · N-04 FP · N-05 FP · N-06 blocked · N-07 batch 1 done (`2e5d8a4`) · N-07 batch 2 done (`91d0d42`) · N-08 done (`315d3b7`) · N-09 done (`3b43bf8`) · N-10 done (`0c33d71`) · N-11 done (`c2b769e`) — **stream complete** (N-06 blocked) |
+| I | ✓ merged | #278 ✓ merged 2026-04-28 | ✅ green | I-NEW-01..I-NEW-05 done. I-NEW-04 auto-revert workflow (`b42233fb`) — **stream complete**. |
+| J | ✓ merged | #288 ✓ merged 2026-04-29 | ✅ green | J-01a..J-01e (route.ts 1197 → 165 LOC) · all 14 handlers registered — **stream complete**. |
+| K | ✓ merged | #222 ✓ merged 2026-04-28 | ✅ green | K-01..K-15 done (K-09 FP) — **stream complete**. |
+| L | new branch TBD | #289 ✓ merged 2026-04-29 | ✅ green | L-06 done (8 SLOs). L-07 done (email alert sink + 25 tests). **L-08 pending** (PostHog events — advisor_selected, checkout_started, subscription_active, etc.). |
+| M | ✓ merged | #283 ✓ merged 2026-04-28 | ✅ green | M-01b done (per-article OG cover override + backfill script). M-02 pending. |
+| N | ✓ merged | #242 ✓ merged 2026-04-28 | ✅ green | N-01..N-11 done (N-04/N-05 FP, N-06 blocked) — **stream complete**. |
 | O | `claude/audit-remediation/o-rls-no-policy` | merged via #235/#237/#239 | last pushed 2026-04-26 | O-01 iter1 done (`user_notifications`/`user_quiz_history`/`user_bookmarks`) · iter2 done `8e638bd` (`article_comments`/`article_reactions`) · iter3 done `c9c8fcd` (admin/audit cluster) · iter4 done `e965eb7` (14 observability/admin tables). ~34 tables remain for iter5+. |
 | P | _not started_ | — | — | — |
 | Q | _not started_ | — | — | — |
-| R | _not started_ | — | — | — |
+| R | ✓ merged | #290 ✓ merged 2026-04-29 | ✅ green | R-01 done — marketplace allocation algorithm + CPC billing tests (738 LOC). |
 | S | _not started_ | — | — | — |
-| V | `claude/audit-remediation/v-polish-extras` | #252 | pending — pushed 2026-04-27T22:47Z (V-NEW-01: stale-dated-stats CI gate + 33 tests) | V-NEW-04 done (`5aadce3`) · CI-rescue `e37633c` · V-NEW-01 done (`a99c5db0`) · V-NEW-02 blocked (no compliance factual-filter) · V-NEW-03 done (`84bde1f`) |
-| V (V-NEW-06) | `claude/audit-remediation/v-new-06-ai-cost-caps` | #258 | pending — pushed 2026-04-27 | V-NEW-06 done (commit `a7bd736`) |
-| V (V-NEW-07) | `claude/audit-remediation/v-new-07-admin-mfa-enforced` | #256 | pending — test-fix pushed 2026-04-27T18:45Z | V-NEW-07a done (cookie helper + verify route + 22 tests) · V-NEW-07b done (`698bbae`) · test-fix `0561944` |
-| X | `claude/audit-remediation/x-admin-backlog` | #257 | pending — pushed 2026-04-27T18:23Z (X-01 decision matrix) | X-01 done — per-file decision matrix at `docs/audits/x-admin-backlog-decision-matrix.md`; X-02..X-09 parallel-eligible with W |
-| Y | `claude/audit-remediation/y-registry-nav` | #253 | pending — pushed 2026-04-27T19:25Z | Y-05 done (commit `fb9dec3`) · Y-08 done (commit `8bb1d4d`) |
+| V | ✓ merged | #252 ✓ merged 2026-04-28 | ✅ green | V-NEW-01/03/04 done. V-NEW-02 blocked (compliance factual-filter). |
+| V (V-NEW-06) | ✓ merged | #258 ✓ merged 2026-04-28 | ✅ green | V-NEW-06 done — AI cost caps + per-user-per-day budget. |
+| V (V-NEW-07) | ✓ merged | #256 ✓ merged 2026-04-28 | ✅ green | V-NEW-07a+07b done — admin MFA cookie gate + step-up UI. |
+| X | ✓ merged | #257 ✓ merged 2026-04-28 | ✅ green | X-01 done — decision matrix. X-02..X-09 pending. |
+| Y | ✓ merged | #253 ✓ merged 2026-04-28 | ✅ green | Y-05 done (DatedStatBadge + lib/dated-stats.ts). Y-08 done (dated-strings CI gate). Y-01..Y-04/Y-06/Y-07 pending. |
 
 ---
 
@@ -237,7 +237,7 @@ Highest priority: critical 2 first.
 
 | ID | Status | Summary | Est. iterations | Notes |
 | --- | --- | --- | --- | --- |
-| E-01 | pending | Author `lib/validation/withValidatedBody.ts` helper + tests | 1 | Pattern: `withValidatedBody(schema, async (req, body) => {...})`. |
+| E-01 | done | Author `lib/validation/withValidatedBody.ts` helper + tests | 1 | Done in commit `5d36e52` (PR #295, merged 2026-04-29). Pattern: `withValidatedBody(schema, async (req, body) => {...})`. |
 | E-02 | pending | Convert top-20 highest-traffic routes to Zod (overlap with D-01..D-09) | ~5 | 4 routes per iteration. |
 | E-03 | pending | ESLint rule: flag new `await req.json()` without immediate `.parse()`/`.safeParse()` | 1 | Stream I. |
 | E-04 | pending | Backfill remaining ~206 routes (chunked: ~6 per iteration) | ~35 | Lowest priority within E; ongoing. |


### PR DESCRIPTION
## Stream D — Critical-path API tests (D-11 batches 24b + 25)

Audit remediation stream D. Tracking: issue #221. Queue: `docs/audits/REMEDIATION_QUEUE.md` → Stream D.

Continuation branch after PR #285 (batches 1–23b) was merged. Non-overlapping with PR #297 (push/send, webhooks/*, property/*).

---

## Batch 24b — Routes tested (53 tests, 5 files)

### `sync-shortlist` GET + POST — 12 tests
User broker shortlist sync (authenticated). GET: auth 401, empty list, slug array returned, DB error 500. POST: auth 401, rate limit 429, full replace success, clear on empty slugs, MAX_SHORTLIST=8 cap, non-string slug filter, non-array treated as empty, delete error 500, insert error 500.

### `report-download` POST — 10 tests
Annual report email capture with rate limiting. Covers: rate limit 429, missing email 400, missing @ 400, email >320 chars 400, bad format regex 400, valid email 200, email lowercased+trimmed before upsert, source set to `annual_report`, upsert error still returns 200 (good UX), invalid JSON body 400.

### `review-incentive` GET + POST — 16 tests
Review incentive eligibility + submission. GET: auth 401, eligible=true with unreviewed brokers, has_pro=false when no subscription, has_pro=true with active subscription. POST: rate limit 429, auth 401, invalid JSON 400, broker_slug regex validation, rating 1–5 integer validation, title 5–200 chars, body 100–5000 chars, broker not found 404, already reviewed 409, insert error 500, Pro granted on new user, extends existing subscription, Pro grant failure is non-fatal.

### `tax-optimizer` POST — 10 tests
Australian CGT calculator with tax-loss harvesting. Covers: rate limit 429, missing income_bracket/holdings 400, empty holdings 400, CGT with 50% discount (held >365 days), CGT without discount (<365 days), tax-loss harvesting candidates, CGT discount alerts (within 90 days), cgt_summary shape, default marginal_rate for unknown bracket, unexpected throw → 500.

### `broker-portal/deals` GET + PUT — 9 tests
Broker self-service deal management. GET: auth 401, no active account 401, deal fields returned, defaults when no deal. PUT: auth 401, text-required 400, deal_text >200 chars 400, deal_terms >500 chars 400, past expiry date 400, success 200, DB update error 500, disabled deal clears all text fields.

---

## Batch 25 — Routes tested (57 tests, 5 files)

### `advisor-portal/marketplace-analytics` GET — 7 tests
Analytics for advisor bid win/loss rates + category benchmark. Covers: rate-limit 429, auth 401, advisor 404, win-rate calculation (1/4 = 25%), zero-bids defaults (win_rate=0, median_response_hours=null), type-filter (bids on other-type auctions excluded), category benchmark from public_job bids only, 500 on crash.

### `advisor-portal/marketplace-settings` GET + PATCH — 13 tests
Advisor marketplace settings (accepts_new_clients, bid_templates, alert_preferences). GET: rate-limit, auth 401, advisor 401, current settings, null DB fields default, 500. PATCH: rate-limit, auth 401, invalid JSON, empty body 400, accepts_new_clients update, >5 bid_templates 400, valid alert_preferences, invalid advisor_type enum 400, DB error 500.

### `advisor-auction/public-bids` GET + DELETE — 14 tests
Advisor's bids on public quote requests. GET: rate-limit, auth 401, advisor 404, bids array returned, empty array, DB error 500. DELETE: rate-limit, auth 401, missing bid_id 400, advisor 404, bid 404, non-public-job 400, non-active bid 400, auction not open 400, success (reason stored), invalid reason → null.

### `broker-portal/invoices/[id]/pdf` GET — 10 tests
Invoice HTML PDF generation. Covers: non-numeric ID 400, auth 401, no broker account 403, invoice not found 404, HTML 200, Content-Type text/html, Content-Disposition with invoice number, PAID label, PENDING label, JSON line items rendered, description fallback, XSS escaping in company name.

### `reviews/verify-client` POST — 15 tests
Admin-only client verification for broker and advisor reviews. Covers: rate-limit 429, auth 401, non-admin 401, invalid JSON 400, missing fields 400, invalid review_type 400; broker path: not found 404, already_verified short-circuit, signup_match → verified+verified_via, no match → verified=false, update error 500; advisor path: not found 404, already_verified, lead_match → enquiry_match, no lead match, unexpected throw 500.

---

## State

~76 routes remain untested. Continuing on this branch in subsequent batches.

Refs: REMEDIATION_QUEUE.md D-11

https://claude.ai/code/session_01TzzcdW5xEbAzPFcFD88Naa