### PR TITLE
fix(tests): import afterEach in broker-portal-deals.test.ts

### DIFF
--- a/__tests__/api/broker-portal-deals.test.ts
+++ b/__tests__/api/broker-portal-deals.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { NextRequest } from "next/server";
 
 // ── Mocks ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- One-line fix: `__tests__/api/broker-portal-deals.test.ts:161` uses `afterEach` but the vitest import on line 1 omits it
- Unblocks pre-push hook for non-loop sessions (per `project_test_typescript_drift` memory, main has known TS drift in test files; this clears one)

## Test plan
- [x] `npm test -- __tests__/api/broker-portal-deals.test.ts` — was already passing at runtime (vitest auto-globals); only the type check was failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)