### PR TITLE
fix(tests): unblock CI on main — report-download + review-incentive

### DIFF
--- a/__tests__/api/review-incentive.test.ts
+++ b/__tests__/api/review-incentive.test.ts
@@ -73,19 +73,22 @@ function setupAdminMock(opts: {
 
   mockAdminFrom.mockImplementation((table: string) => {
     if (table === "incentive_reviews") {
+      // GET path: .select().eq() — awaited as { data: existingReviews[] }
+      // POST path: .select().eq().eq().maybeSingle() — { data: {id} | null }
+      const firstEqResult = {
+        eq: vi.fn(() => ({
+          maybeSingle: vi.fn().mockResolvedValue({
+            data: alreadyReviewed ? { id: "r1" } : null,
+          }),
+        })),
+        then: (resolve: (v: { data: { broker_slug: string }[] }) => void) =>
+          resolve({ data: existingReviews }),
+      };
       return {
-        select: vi.fn().mockReturnThis(),
-        eq: vi.fn().mockReturnThis(),
+        select: vi.fn(() => ({
+          eq: vi.fn(() => firstEqResult),
+        })),
         insert: vi.fn().mockResolvedValue({ error: insertReviewError }),
-        maybeSingle: vi.fn().mockResolvedValue({ data: alreadyReviewed ? { id: "r1" } : null }),
-        // first call for GET listing returns existingReviews array
-        ...(existingReviews.length >= 0 ? {
-          select: vi.fn(() => ({
-            eq: vi.fn().mockResolvedValue({ data: existingReviews }),
-            maybeSingle: vi.fn().mockResolvedValue({ data: alreadyReviewed ? { id: "r1" } : null }),
-          })),
-          insert: vi.fn().mockResolvedValue({ error: insertReviewError }),
-        } : {}),
       };
     }
     if (table === "brokers") {

--- a/app/api/report-download/route.ts
+++ b/app/api/report-download/route.ts
@@ -23,7 +23,8 @@ export async function POST(request: NextRequest) {
 
   try {
     const body = await request.json();
-    const { email } = body as { email: string };
+    const rawEmail = (body as { email?: unknown }).email;
+    const email = typeof rawEmail === "string" ? rawEmail.trim().toLowerCase() : "";
 
     if (!email || !email.includes("@") || email.length > 320) {
       return NextResponse.json(
@@ -32,7 +33,6 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Basic email format validation
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
     if (!emailRegex.test(email)) {
       return NextResponse.json(
@@ -48,7 +48,7 @@ export async function POST(request: NextRequest) {
       .from("email_captures")
       .upsert(
         {
-          email: email.toLowerCase().trim(),
+          email,
           source: "annual_report",
           captured_at: new Date().toISOString(),
         },


### PR DESCRIPTION
## Summary

CI on `main` was failing every PR's `Lint · Type-check · Test · Build` check — even doc-only PRs like #308. Two unrelated test failures, both fixed here.

### 1. `app/api/report-download/route.ts` — trim before validate

The email regex `/^[^\s@]+@[^\s@]+\.[^\s@]+$/` was applied to the raw request body. Input like `"  USER@EXAMPLE.COM  "` failed validation and returned 400, so the upsert was never invoked. The "lowercases and trims" test crashed on `upsertMock.mock.calls[0]` being `undefined`.

Fix: trim + lowercase the email up front, then validate, then store the already-canonical form. (Removed the redundant `.toLowerCase().trim()` in the upsert payload.)

### 2. `__tests__/api/review-incentive.test.ts` — mock chain matches route

The POST path in `app/api/review-incentive/route.ts:144` chains `.select().eq("user_id").eq("broker_slug").maybeSingle()`, but the mock made the first `.eq()` terminal — so the second `.eq()` was `undefined`.

Reshaped the `incentive_reviews` mock so `.eq()` returns a thenable:
- awaiting it (GET path) resolves to `{ data: existingReviews[] }`
- calling `.eq()` again (POST path) returns `{ maybeSingle: () => …{id} | null }`

## Verification

- `npx vitest run __tests__/api/review-incentive.test.ts __tests__/api/report-download.test.ts` → 30/30 pass
- `npx tsc --noEmit` → clean
- `npx eslint` on touched files → clean

## Test plan
- [ ] CI green on this PR (the actual proof — same job that failed on #308)
- [ ] Once merged, re-check CI on the 8 open PRs (#299, #300, #301, #302, #303, #306, #307, #308)


---
_Generated by [Claude Code](https://claude.ai/code/session_015AxjNcN2xVt7Q7RTj8fuCD)_