### PR TITLE
chore(g): G-03 batch 3 — rollback headers on 10 partial-header migrations

### DIFF
--- a/supabase/migrations/010_logo_url_and_site_settings.sql
+++ b/supabase/migrations/010_logo_url_and_site_settings.sql
@@ -1,3 +1,58 @@
+-- ============================================================================
+-- Migration: 010_logo_url_and_site_settings.sql
+-- Purpose: Add `logo_url` column to brokers + create `site_settings`
+--          key/value table seeded with twelve `autopilot_*` toggle keys
+--          (defaults all 'true').
+-- Rollback: REVOKE policies, DISABLE RLS, DROP table, then DROP COLUMN
+--           on brokers.logo_url.
+-- Risk: high — `brokers.logo_url` is read on every broker card and
+--       comparison page; reverse drops every uploaded logo URL and
+--       blanks the broker comparison UI. `site_settings` controls the
+--       autopilot kill-switches actively read by 12 cron handlers — if
+--       any cron job runs against a missing site_settings table, those
+--       jobs short-circuit (the table-missing path falls back to the
+--       enabled default in code, but errors will spam logs). Snapshot
+--       both before any reverse migration.
+-- ============================================================================
+--
+-- Forward operations:
+--   1. ALTER TABLE brokers ADD COLUMN IF NOT EXISTS logo_url TEXT.
+--   2. CREATE TABLE IF NOT EXISTS site_settings
+--        (key TEXT PK, value TEXT NOT NULL DEFAULT '',
+--         updated_at TIMESTAMPTZ DEFAULT now()).
+--   3. INSERT 12 autopilot toggle rows (autopilot_enabled +
+--      autopilot_<job> for check-fees, expire-deals, marketplace-stats,
+--      quiz-follow-up, auto-publish, content-staleness,
+--      check-affiliate-links, low-balance-alerts, welcome-drip,
+--      weekly-newsletter, retry-webhooks) with value 'true',
+--      ON CONFLICT (key) DO NOTHING.
+--   4. ALTER TABLE site_settings ENABLE ROW LEVEL SECURITY.
+--   5. CREATE POLICY "Authenticated users can read site_settings"
+--        FOR SELECT TO authenticated USING (true).
+--   6. CREATE POLICY "Authenticated users can update site_settings"
+--        FOR UPDATE TO authenticated USING (true).
+--   7. CREATE POLICY "Authenticated users can insert site_settings"
+--        FOR INSERT TO authenticated WITH CHECK (true).
+--
+-- Rollback (in reverse order):
+--   7. DROP POLICY IF EXISTS "Authenticated users can insert site_settings"
+--        ON site_settings;
+--   6. DROP POLICY IF EXISTS "Authenticated users can update site_settings"
+--        ON site_settings;
+--   5. DROP POLICY IF EXISTS "Authenticated users can read site_settings"
+--        ON site_settings;
+--   4. ALTER TABLE site_settings DISABLE ROW LEVEL SECURITY;
+--   3. -- Seed inserts disappear with the table DROP at step 2; no
+--      -- separate inverse DELETE needed.
+--   2. DROP TABLE IF EXISTS site_settings;
+--      -- DESTRUCTIVE: removes every autopilot kill-switch override
+--      -- (operator-set 'false' values are lost; jobs revert to
+--      -- code-default 'enabled' on next run).
+--   1. ALTER TABLE brokers DROP COLUMN IF EXISTS logo_url;
+--      -- DESTRUCTIVE: drops every uploaded broker logo URL on
+--      -- populated rows. Snapshot first.
+-- ============================================================================
+
 -- Migration 010: Add logo_url to brokers and create site_settings table
 -- logo_url: stores the URL to each broker's actual logo image
 -- site_settings: key-value store for admin toggles (Autopilot, etc.)

--- a/supabase/migrations/20260309_content_tables.sql
+++ b/supabase/migrations/20260309_content_tables.sql
@@ -1,3 +1,65 @@
+-- ============================================================================
+-- Migration: 20260309_content_tables.sql
+-- Purpose: Migrate two very large content-as-code files into Supabase
+--          tables — `versus_editorials` (was versus-content.ts, 49K LOC)
+--          and `advisor_guide_content` (was advisor-guides.ts, 45K LOC).
+--          Both tables get RLS enabled with public-read policies and
+--          two indexes apiece for the lookup paths used by the
+--          comparison pages and advisor-guide pages.
+-- Rollback: DROP indexes, DROP policy, DISABLE RLS, DROP each table —
+--           in reverse order, advisor_guide_content first, then
+--           versus_editorials.
+-- Risk: high — DROP TABLE on populated tables permanently discards
+--       editorial content. The original .ts source files have since
+--       been deleted (the whole point of this migration was to move
+--       content out of the codebase), so there is no cheap revert to
+--       a pre-state. Operators MUST snapshot both tables to cold
+--       storage before any reverse migration; otherwise the comparison
+--       pages and advisor-guide pages will render empty.
+-- ============================================================================
+--
+-- Forward operations:
+--   1. CREATE TABLE IF NOT EXISTS versus_editorials (id SERIAL PK,
+--      slug UNIQUE, broker_a_slug, broker_b_slug, title,
+--      meta_description, intro, choose_a, choose_b, sections JSONB,
+--      verdict, faqs JSONB, created_at, updated_at).
+--   2. ALTER TABLE versus_editorials ENABLE ROW LEVEL SECURITY.
+--   3. CREATE POLICY "Public read versus editorials" FOR SELECT
+--        TO anon, authenticated USING (true).
+--   4. CREATE INDEX idx_versus_editorials_slug ON versus_editorials(slug).
+--   5. CREATE INDEX idx_versus_editorials_brokers
+--        ON versus_editorials(broker_a_slug, broker_b_slug).
+--   6. CREATE TABLE IF NOT EXISTS advisor_guide_content (id SERIAL PK,
+--      slug UNIQUE, advisor_type, title, meta_description, intro,
+--      sections JSONB, checklist JSONB, red_flags JSONB, faqs JSONB,
+--      cost_guide JSONB, created_at, updated_at).
+--   7. ALTER TABLE advisor_guide_content ENABLE ROW LEVEL SECURITY.
+--   8. CREATE POLICY "Public read advisor guides" FOR SELECT
+--        TO anon, authenticated USING (true).
+--   9. CREATE INDEX idx_advisor_guide_content_slug
+--        ON advisor_guide_content(slug).
+--  10. CREATE INDEX idx_advisor_guide_content_type
+--        ON advisor_guide_content(advisor_type).
+--
+-- Rollback (in reverse order):
+--  10. DROP INDEX IF EXISTS public.idx_advisor_guide_content_type;
+--   9. DROP INDEX IF EXISTS public.idx_advisor_guide_content_slug;
+--   8. DROP POLICY IF EXISTS "Public read advisor guides"
+--        ON advisor_guide_content;
+--   7. ALTER TABLE advisor_guide_content DISABLE ROW LEVEL SECURITY;
+--   6. DROP TABLE IF EXISTS advisor_guide_content;
+--      -- DESTRUCTIVE: discards every advisor-guide editorial row.
+--      -- Snapshot first.
+--   5. DROP INDEX IF EXISTS public.idx_versus_editorials_brokers;
+--   4. DROP INDEX IF EXISTS public.idx_versus_editorials_slug;
+--   3. DROP POLICY IF EXISTS "Public read versus editorials"
+--        ON versus_editorials;
+--   2. ALTER TABLE versus_editorials DISABLE ROW LEVEL SECURITY;
+--   1. DROP TABLE IF EXISTS versus_editorials;
+--      -- DESTRUCTIVE: discards every broker-vs-broker editorial row.
+--      -- Snapshot first.
+-- ============================================================================
+
 -- Migration: Move large content-as-code files to Supabase tables
 -- versus-content.ts (49K LOC) → versus_editorials
 -- advisor-guides.ts (45K LOC) → advisor_guide_content

--- a/supabase/migrations/20260316_create_leads_table.sql
+++ b/supabase/migrations/20260316_create_leads_table.sql
@@ -1,3 +1,36 @@
+-- ============================================================================
+-- Migration: 20260316_create_leads_table.sql
+-- Purpose: Create unified `leads` table used by /api/submit-lead for both
+--          advisor-quiz leads and platform-affiliate leads.
+-- Rollback: DROP the four indexes, then DROP the leads table.
+-- Risk: high — DROP TABLE permanently discards every captured lead row,
+--       which is the revenue-bearing payload of the entire quiz funnel.
+--       Operators MUST snapshot `leads` to cold storage before any
+--       reverse migration.
+-- ============================================================================
+--
+-- Forward operations:
+--   1. CREATE TABLE IF NOT EXISTS leads (id, lead_type, professional_id,
+--      broker_id, user_email, user_name, user_phone, user_location_state,
+--      user_intent, revenue_value_cents, source_page, utm_*, status,
+--      created_at, updated_at) with two CHECK constraints
+--      (lead_type IN ('advisor','platform'); status IN ('new','sent',
+--      'contacted','converted','lost','spam')).
+--   2. CREATE INDEX IF NOT EXISTS idx_leads_type ON leads(lead_type).
+--   3. CREATE INDEX IF NOT EXISTS idx_leads_email ON leads(user_email).
+--   4. CREATE INDEX IF NOT EXISTS idx_leads_status ON leads(status).
+--   5. CREATE INDEX IF NOT EXISTS idx_leads_created
+--                                  ON leads(created_at DESC).
+--
+-- Rollback (in reverse order):
+--   5. DROP INDEX IF EXISTS public.idx_leads_created;
+--   4. DROP INDEX IF EXISTS public.idx_leads_status;
+--   3. DROP INDEX IF EXISTS public.idx_leads_email;
+--   2. DROP INDEX IF EXISTS public.idx_leads_type;
+--   1. DROP TABLE IF EXISTS public.leads;
+--      -- DESTRUCTIVE: discards every captured lead. Snapshot first.
+-- ============================================================================
+
 -- Migration: Create unified leads table
 -- Used by /api/submit-lead for both advisor quiz and platform leads
 

--- a/supabase/migrations/20260318_seed_new_scenarios.sql
+++ b/supabase/migrations/20260318_seed_new_scenarios.sql
@@ -1,3 +1,38 @@
+-- ============================================================================
+-- Migration: 20260318_seed_new_scenarios.sql
+-- Purpose: Seed three new launch scenarios into the `scenarios` table —
+--          'First Home Buyer Investing' (slug 'first-home-buyer'),
+--          'Investing in Retirement' (slug 'retirees'), and
+--          'Ethical & ESG Investing' (slug 'esg-investing'). Each row
+--          has hero copy, problem/solution narrative, recommended
+--          brokers, and a considerations checklist.
+-- Rollback: DELETE the three rows by slug.
+-- Risk: medium — DELETE removes only the three seeded scenario rows
+--       (no FK from `scenarios` to consumer pages — the /scenarios/<slug>
+--       route just 404s on missing slugs). Editorial content is preserved
+--       in this migration body, so the rows can be re-seeded by re-running.
+--       Reverse impact: any operator edits to these three rows since the
+--       seed (title / sections / brokers) are lost — snapshot first if
+--       editorial has been touched.
+-- ============================================================================
+--
+-- Forward operations:
+--   1. INSERT INTO scenarios (title, slug, hero_title, icon, problem,
+--      solution, brokers, considerations) VALUES
+--        ('First Home Buyer Investing', 'first-home-buyer', ...),
+--        ('Investing in Retirement', 'retirees', ...),
+--        ('Ethical & ESG Investing', 'esg-investing', ...).
+--      (Note: this is a single multi-row INSERT, no ON CONFLICT clause —
+--      re-running will fail if any of the three slugs already exist on a
+--      UNIQUE constraint; treat as a one-shot seed.)
+--
+-- Rollback (in reverse order):
+--   1. DELETE FROM scenarios
+--        WHERE slug IN ('esg-investing', 'retirees', 'first-home-buyer');
+--      -- DESTRUCTIVE: discards any operator edits to these three
+--      -- scenario rows. Snapshot first.
+-- ============================================================================
+
 -- Seed three new high-value scenarios for launch
 -- Covers first home buyers, retirees, and ESG investors
 

--- a/supabase/migrations/20260318_seed_property_images.sql
+++ b/supabase/migrations/20260318_seed_property_images.sql
@@ -1,3 +1,58 @@
+-- ============================================================================
+-- Migration: 20260318_seed_property_images.sql
+-- Purpose: Seed `property_listings.images` (JSONB array of Unsplash URLs)
+--          for eight launch property listings. Each listing receives
+--          3-5 curated photo URLs covering exterior / interior /
+--          amenities / suburb context.
+-- Rollback: NULL out images on each of the eight slugs (resets to the
+--           pre-seed state for those rows).
+-- Risk: medium — reverse blanks the photo galleries on the eight seeded
+--       listings. If operators or admin tools have since UPDATEd the
+--       same `images` field with newer URLs (this migration uses
+--       UPDATE, not INSERT, so any later writes overwrite this seed),
+--       the reverse below will also clear those newer URLs. Inspect
+--       the live row state before running the rollback.
+-- ============================================================================
+--
+-- Forward operations:
+--   1. UPDATE property_listings SET images = '[<4 Unsplash URLs>]'
+--        WHERE slug = 'the-operetta-paramatta'.
+--   2. UPDATE property_listings SET images = '[<4 URLs>]'
+--        WHERE slug = 'botanical-residences-south-melbourne'.
+--   3. UPDATE property_listings SET images = '[<3 URLs>]'
+--        WHERE slug = 'riverview-terrace-newstead'.
+--   4. UPDATE property_listings SET images = '[<3 URLs>]'
+--        WHERE slug = 'elara-marsden-park'.
+--   5. UPDATE property_listings SET images = '[<4 URLs>]'
+--        WHERE slug = 'yarra-one-south-yarra'.
+--   6. UPDATE property_listings SET images = '[<3 URLs>]'
+--        WHERE slug = 'west-village-west-end'.
+--   7. UPDATE property_listings SET images = '[<3 URLs>]'
+--        WHERE slug = 'haven-crows-nest'.
+--   8. UPDATE property_listings SET images = '[<3 URLs>]'
+--        WHERE slug = 'aurora-melbourne-central'.
+--
+-- Rollback (in reverse order):
+--   8. UPDATE property_listings SET images = NULL
+--        WHERE slug = 'aurora-melbourne-central';
+--   7. UPDATE property_listings SET images = NULL
+--        WHERE slug = 'haven-crows-nest';
+--   6. UPDATE property_listings SET images = NULL
+--        WHERE slug = 'west-village-west-end';
+--   5. UPDATE property_listings SET images = NULL
+--        WHERE slug = 'yarra-one-south-yarra';
+--   4. UPDATE property_listings SET images = NULL
+--        WHERE slug = 'elara-marsden-park';
+--   3. UPDATE property_listings SET images = NULL
+--        WHERE slug = 'riverview-terrace-newstead';
+--   2. UPDATE property_listings SET images = NULL
+--        WHERE slug = 'botanical-residences-south-melbourne';
+--   1. UPDATE property_listings SET images = NULL
+--        WHERE slug = 'the-operetta-paramatta';
+--      -- DESTRUCTIVE: also clears any newer URLs that operators
+--      -- subsequently wrote to these rows.
+-- ============================================================================
+
 -- Seed property listing images with curated Unsplash photos
 -- Each listing gets 3-5 images: exterior, interior, amenities, suburb context
 

--- a/supabase/migrations/20260321_pre_launch_rls_fixes.sql
+++ b/supabase/migrations/20260321_pre_launch_rls_fixes.sql
@@ -1,3 +1,75 @@
+-- ============================================================================
+-- Migration: 20260321_pre_launch_rls_fixes.sql
+-- Purpose: Backfill ENABLE RLS + a service-role-only DENY-ALL policy on
+--          six tables from 003_broker_portal_features.sql that were
+--          shipped without RLS (broker_creatives, ab_tests,
+--          broker_notifications, support_tickets, support_messages,
+--          sponsor_invoices). Each table gets a single
+--          "Service role full access <table>" policy with
+--          USING (false), which the service-role client bypasses but
+--          all other roles are blocked from.
+-- Rollback: DROP each policy, then DISABLE ROW LEVEL SECURITY on each
+--           table.
+-- Risk: low — purely security-posture changes. Rolling back leaves
+--       these tables permission-checked at the role layer (service-role
+--       client still works) but exposes them through pg_graphql /
+--       authenticated role if those routes exist. The original state
+--       (RLS off) is what shipped through 003_broker_portal_features
+--       so reverse restores the same exposure pattern that existed
+--       before this migration. Idempotent forward pattern means
+--       re-running is also safe.
+-- ============================================================================
+--
+-- Forward operations:
+--   1. ALTER TABLE IF EXISTS broker_creatives
+--        ENABLE ROW LEVEL SECURITY.
+--   2. CREATE POLICY "Service role full access broker_creatives" ...
+--        USING (false), guarded by a NOT EXISTS check in DO $$ ... $$.
+--   3. ALTER TABLE IF EXISTS ab_tests ENABLE ROW LEVEL SECURITY.
+--   4. CREATE POLICY "Service role full access ab_tests" USING (false).
+--   5. ALTER TABLE IF EXISTS broker_notifications
+--        ENABLE ROW LEVEL SECURITY.
+--   6. CREATE POLICY "Service role full access broker_notifications"
+--        USING (false).
+--   7. ALTER TABLE IF EXISTS support_tickets
+--        ENABLE ROW LEVEL SECURITY.
+--   8. CREATE POLICY "Service role full access support_tickets"
+--        USING (false).
+--   9. ALTER TABLE IF EXISTS support_messages
+--        ENABLE ROW LEVEL SECURITY.
+--  10. CREATE POLICY "Service role full access support_messages"
+--        USING (false).
+--  11. ALTER TABLE IF EXISTS sponsor_invoices
+--        ENABLE ROW LEVEL SECURITY.
+--  12. CREATE POLICY "Service role full access sponsor_invoices"
+--        USING (false).
+--
+-- Rollback (in reverse order):
+--  12. DROP POLICY IF EXISTS "Service role full access sponsor_invoices"
+--        ON sponsor_invoices;
+--  11. ALTER TABLE IF EXISTS sponsor_invoices
+--        DISABLE ROW LEVEL SECURITY;
+--  10. DROP POLICY IF EXISTS "Service role full access support_messages"
+--        ON support_messages;
+--   9. ALTER TABLE IF EXISTS support_messages
+--        DISABLE ROW LEVEL SECURITY;
+--   8. DROP POLICY IF EXISTS "Service role full access support_tickets"
+--        ON support_tickets;
+--   7. ALTER TABLE IF EXISTS support_tickets
+--        DISABLE ROW LEVEL SECURITY;
+--   6. DROP POLICY IF EXISTS "Service role full access broker_notifications"
+--        ON broker_notifications;
+--   5. ALTER TABLE IF EXISTS broker_notifications
+--        DISABLE ROW LEVEL SECURITY;
+--   4. DROP POLICY IF EXISTS "Service role full access ab_tests"
+--        ON ab_tests;
+--   3. ALTER TABLE IF EXISTS ab_tests DISABLE ROW LEVEL SECURITY;
+--   2. DROP POLICY IF EXISTS "Service role full access broker_creatives"
+--        ON broker_creatives;
+--   1. ALTER TABLE IF EXISTS broker_creatives
+--        DISABLE ROW LEVEL SECURITY;
+-- ============================================================================
+
 -- Pre-launch: Enable RLS on tables missing it + add policies
 -- Tables from 003_broker_portal_features.sql that were missed
 

--- a/supabase/migrations/20260329_update_advisor_photos_portraits.sql
+++ b/supabase/migrations/20260329_update_advisor_photos_portraits.sql
@@ -1,3 +1,87 @@
+-- ============================================================================
+-- Migration: 20260329_update_advisor_photos_portraits.sql
+-- Purpose: Update `professionals.photo_url` to point at randomuser.me
+--          portrait photos for 54 seeded advisor profiles, replacing
+--          earlier placeholder URLs.
+-- Rollback: NULL out photo_url for the 54 advisor slugs touched
+--           (returns the rows to "no headshot" state). The original
+--           pre-seed URLs are not preserved by this migration so a
+--           true revert to the prior values requires a snapshot.
+-- Risk: medium — these are mock/seeded advisor rows used for the
+--       advisor directory UI. Reverse blanks every headshot, breaking
+--       portrait rendering on /find-advisor/* until reseeded. If
+--       operators have replaced any of these slugs with real-advisor
+--       photos since this migration ran, the reverse will also clear
+--       those production URLs — inspect live row state before reverse.
+-- ============================================================================
+--
+-- Forward operations:
+--   1-54. UPDATE professionals SET photo_url = '<randomuser.me URL>'
+--           WHERE slug = '<one of 54 city-prefixed advisor slugs>'.
+--           Slugs (in file order): james-wong-sydney,
+--           maria-papadopoulos-sydney, raj-patel-sydney,
+--           sophie-laurent-sydney, michael-oconnor-sydney,
+--           helen-tran-sydney, david-kowalski-sydney,
+--           anthony-nguyen-sydney, emma-richardson-sydney,
+--           daniel-stavros-sydney, fatima-hassan-sydney,
+--           margaret-campbell-sydney, chris-murphy-sydney,
+--           wei-chen-sydney, luke-thompson-sydney,
+--           olivia-martinez-melbourne, george-papadimitriou-melbourne,
+--           anita-desai-melbourne, tom-fitzgerald-melbourne,
+--           victoria-aldridge-melbourne, sam-ibrahim-melbourne,
+--           alexander-reid-melbourne, nina-volkov-melbourne,
+--           liam-chen-melbourne, jenny-le-melbourne,
+--           patricia-wright-melbourne, nick-constantine-melbourne,
+--           ben-walker-brisbane, karen-li-brisbane,
+--           josh-anderson-brisbane, rachel-green-brisbane,
+--           stuart-mackenzie-brisbane, tanya-russo-brisbane,
+--           hassan-ali-brisbane, diana-zhou-brisbane,
+--           andrew-mitchell-perth, lisa-tan-perth, ryan-kelly-perth,
+--           deepak-sharma-perth, jessica-harris-perth,
+--           peter-rossi-adelaide, sarah-campbell-adelaide,
+--           mark-katsaros-adelaide, catherine-singh-adelaide,
+--           robert-jenkins-canberra, elena-petrov-canberra,
+--           philip-chang-canberra, amanda-jones-hobart,
+--           nathan-williams-hobart, steve-hall-goldcoast,
+--           tina-nguyen-goldcoast, marco-santos-darwin,
+--           laura-smith-newcastle, bruce-taylor-wollongong,
+--           zac-miller-sunshinecoast.
+--
+-- Rollback (in reverse order):
+--   1. UPDATE professionals SET photo_url = NULL
+--        WHERE slug IN (
+--          'zac-miller-sunshinecoast', 'bruce-taylor-wollongong',
+--          'laura-smith-newcastle', 'marco-santos-darwin',
+--          'tina-nguyen-goldcoast', 'steve-hall-goldcoast',
+--          'nathan-williams-hobart', 'amanda-jones-hobart',
+--          'philip-chang-canberra', 'elena-petrov-canberra',
+--          'robert-jenkins-canberra', 'catherine-singh-adelaide',
+--          'mark-katsaros-adelaide', 'sarah-campbell-adelaide',
+--          'peter-rossi-adelaide', 'jessica-harris-perth',
+--          'deepak-sharma-perth', 'ryan-kelly-perth', 'lisa-tan-perth',
+--          'andrew-mitchell-perth', 'diana-zhou-brisbane',
+--          'hassan-ali-brisbane', 'tanya-russo-brisbane',
+--          'stuart-mackenzie-brisbane', 'rachel-green-brisbane',
+--          'josh-anderson-brisbane', 'karen-li-brisbane',
+--          'ben-walker-brisbane', 'nick-constantine-melbourne',
+--          'patricia-wright-melbourne', 'jenny-le-melbourne',
+--          'liam-chen-melbourne', 'nina-volkov-melbourne',
+--          'alexander-reid-melbourne', 'sam-ibrahim-melbourne',
+--          'victoria-aldridge-melbourne', 'tom-fitzgerald-melbourne',
+--          'anita-desai-melbourne', 'george-papadimitriou-melbourne',
+--          'olivia-martinez-melbourne', 'luke-thompson-sydney',
+--          'wei-chen-sydney', 'chris-murphy-sydney',
+--          'margaret-campbell-sydney', 'fatima-hassan-sydney',
+--          'daniel-stavros-sydney', 'emma-richardson-sydney',
+--          'anthony-nguyen-sydney', 'david-kowalski-sydney',
+--          'helen-tran-sydney', 'michael-oconnor-sydney',
+--          'sophie-laurent-sydney', 'raj-patel-sydney',
+--          'maria-papadopoulos-sydney', 'james-wong-sydney'
+--        );
+--      -- DESTRUCTIVE: blanks 54 advisor headshots; clears any
+--      -- operator-replaced URLs on those rows too.
+-- ============================================================================
+
 -- Migration: Update advisor photo URLs to realistic portrait photos
 -- Uses randomuser.me API portraits for professional-looking headshots
 -- Runs idempotently: updates all existing advisors by slug

--- a/supabase/migrations/20260423124310_create_agent_analytics_table.sql
+++ b/supabase/migrations/20260423124310_create_agent_analytics_table.sql
@@ -1,3 +1,47 @@
+-- ============================================================================
+-- Migration: 20260423124310_create_agent_analytics_table.sql
+-- Purpose: Create `agent_analytics` — a daily per-agent success-rate
+--          rollup table written by n8n cron jobs and read by the admin
+--          observability dashboard.
+-- Rollback: REVOKE grants, DROP policy, DISABLE RLS, DROP indexes,
+--           DROP table.
+-- Risk: medium — DROP TABLE discards historical agent-success-rate
+--       rollups. Source data in agent logs survives, so the rollups can
+--       be recomputed; but any time-series gap in the dashboard during
+--       reverse + recompute will be visible to operators.
+-- ============================================================================
+--
+-- Forward operations:
+--   1. CREATE TABLE IF NOT EXISTS public.agent_analytics
+--        (id BIGSERIAL PK, agent_name, date, total_logs, error_count,
+--         warn_count, info_count, success_rate, avg_runtime_ms,
+--         estimated_cost_usd, metadata, created_at, updated_at,
+--         UNIQUE(agent_name, date)).
+--   2. CREATE INDEX IF NOT EXISTS idx_agent_analytics_agent_name.
+--   3. CREATE INDEX IF NOT EXISTS idx_agent_analytics_date (date DESC).
+--   4. CREATE INDEX IF NOT EXISTS idx_agent_analytics_agent_date
+--                                  (agent_name, date DESC).
+--   5. ALTER TABLE public.agent_analytics ENABLE ROW LEVEL SECURITY.
+--   6. DROP POLICY IF EXISTS "Service role can manage analytics".
+--   7. CREATE POLICY "Service role can manage analytics" FOR ALL
+--        USING (true) WITH CHECK (true).
+--   8. GRANT SELECT, INSERT, UPDATE, DELETE ... TO authenticated.
+--   9. GRANT SELECT, INSERT, UPDATE, DELETE ... TO service_role.
+--
+-- Rollback (in reverse order):
+--   9. REVOKE ALL ON public.agent_analytics FROM service_role;
+--   8. REVOKE ALL ON public.agent_analytics FROM authenticated;
+--   7. DROP POLICY IF EXISTS "Service role can manage analytics"
+--        ON public.agent_analytics;
+--   6. -- (no inverse needed for the idempotent DROP POLICY guard.)
+--   5. ALTER TABLE public.agent_analytics DISABLE ROW LEVEL SECURITY;
+--   4. DROP INDEX IF EXISTS public.idx_agent_analytics_agent_date;
+--   3. DROP INDEX IF EXISTS public.idx_agent_analytics_date;
+--   2. DROP INDEX IF EXISTS public.idx_agent_analytics_agent_name;
+--   1. DROP TABLE IF EXISTS public.agent_analytics;
+--      -- DESTRUCTIVE: discards every daily rollup row.
+-- ============================================================================
+
 -- Create agent_analytics table for daily per-agent success rate tracking
 CREATE TABLE IF NOT EXISTS public.agent_analytics (
   id BIGSERIAL PRIMARY KEY,

--- a/supabase/migrations/20260423_newsletter_editions.sql
+++ b/supabase/migrations/20260423_newsletter_editions.sql
@@ -1,3 +1,38 @@
+-- ============================================================================
+-- Migration: 20260423_newsletter_editions.sql
+-- Purpose: Create `newsletter_editions` — archive of sent weekly digests
+--          referenced by /newsletter and /newsletter/[edition] but never
+--          previously created. Each row is one rendered digest.
+-- Rollback: DROP policy, DISABLE RLS, DROP index, DROP table, DROP
+--           comment-on-table comment.
+-- Risk: medium — DROP TABLE discards every archived edition (rendered
+--       HTML + counts). Source numbers (fee_changes, articles, deals)
+--       can be recomputed but the rendered HTML cannot. Snapshot before
+--       any reverse migration.
+-- ============================================================================
+--
+-- Forward operations:
+--   1. CREATE TABLE IF NOT EXISTS public.newsletter_editions
+--        (id bigserial PK, edition_date UNIQUE, subject, html_content,
+--         fee_changes_count, articles_count, deals_count, created_at).
+--   2. CREATE INDEX IF NOT EXISTS idx_newsletter_editions_date
+--                                  (edition_date DESC).
+--   3. ALTER TABLE public.newsletter_editions ENABLE ROW LEVEL SECURITY.
+--   4. CREATE POLICY "newsletter_editions_public_read" FOR SELECT
+--        USING (true).
+--   5. COMMENT ON TABLE public.newsletter_editions IS '...'.
+--
+-- Rollback (in reverse order):
+--   5. COMMENT ON TABLE public.newsletter_editions IS NULL;
+--   4. DROP POLICY IF EXISTS "newsletter_editions_public_read"
+--        ON public.newsletter_editions;
+--   3. ALTER TABLE public.newsletter_editions DISABLE ROW LEVEL SECURITY;
+--   2. DROP INDEX IF EXISTS public.idx_newsletter_editions_date;
+--   1. DROP TABLE IF EXISTS public.newsletter_editions;
+--      -- DESTRUCTIVE: discards rendered HTML for every archived
+--      -- edition. Snapshot first.
+-- ============================================================================
+
 -- Create the newsletter_editions table.
 --
 -- This table was referenced by the /newsletter archive page and

--- a/supabase/migrations/20260508_listing_claims.sql
+++ b/supabase/migrations/20260508_listing_claims.sql
@@ -1,3 +1,39 @@
+-- ============================================================================
+-- Migration: 20260508_listing_claims.sql
+-- Purpose: Create `listing_claims` — captures "claim this listing"
+--          requests from broker and advisor profile pages. Admin reviews
+--          the claim and confirms identity / credentials before
+--          transferring ownership.
+-- Rollback: DROP both indexes, then DROP the listing_claims table.
+-- Risk: high — DROP TABLE discards in-flight claim requests, which are
+--       directly tied to ownership transfer (operationally sensitive
+--       and may have legal implications). Snapshot before any reverse
+--       migration. NOTE: 20260601_rls_listing_claims.sql later adds RLS
+--       to this table; rolling THIS migration back without first
+--       rolling back the 20260601 RLS migration will leave dangling
+--       policies on a non-existent table.
+-- ============================================================================
+--
+-- Forward operations:
+--   1. CREATE TABLE IF NOT EXISTS public.listing_claims
+--        (id SERIAL PK, claim_type, target_slug, full_name, email,
+--         company_role, phone, message, status DEFAULT 'pending',
+--         admin_notes, created_at) with two CHECK constraints
+--        (claim_type IN ('broker','advisor','listing'); status IN
+--         ('pending','approved','rejected')).
+--   2. CREATE INDEX IF NOT EXISTS idx_listing_claims_target
+--        ON public.listing_claims (claim_type, target_slug).
+--   3. CREATE INDEX IF NOT EXISTS idx_listing_claims_status
+--        ON public.listing_claims (status, created_at DESC).
+--
+-- Rollback (in reverse order):
+--   3. DROP INDEX IF EXISTS public.idx_listing_claims_status;
+--   2. DROP INDEX IF EXISTS public.idx_listing_claims_target;
+--   1. DROP TABLE IF EXISTS public.listing_claims;
+--      -- DESTRUCTIVE: discards every captured claim. Roll back the
+--      -- later 20260601_rls_listing_claims migration first.
+-- ============================================================================
+
 -- ============================================================
 -- listing_claims — capture "claim this listing" requests from
 -- broker and advisor profile pages. Admin reviews the claim


### PR DESCRIPTION
## Summary
- Third batch of G-03. 10 more migrations get full rollback headers. All 511 added lines are SQL comments (header-only — no migration SQL changed).
- Confirmed no overlap with G-01/G-02 (#307), G-03 batch 1 (#311), G-03 batch 2 (#314), §5.2, §5.5.

## Migrations covered
- `010_logo_url_and_site_settings.sql` (high — DROP TABLE on operator-submitted brokers.logo_url)
- `20260309_content_tables.sql` (high — DROP TABLE on .ts-source-gone content)
- `20260316_create_leads_table.sql` (high — DROP TABLE on user-submitted leads; snapshot before reverse)
- `20260318_seed_new_scenarios.sql` (medium — re-seedable)
- `20260318_seed_property_images.sql` (medium — re-seedable)
- `20260321_pre_launch_rls_fixes.sql` (low — RLS toggles only)
- `20260329_update_advisor_photos_portraits.sql` (medium — UPDATE seeds, reversible to NULL)
- `20260423124310_create_agent_analytics_table.sql` (medium)
- `20260423_newsletter_editions.sql` (medium)
- `20260508_listing_claims.sql` (high — DROP TABLE on user-submitted claims)

Each high-risk header explicitly directs operators to snapshot before reverse.

## Risk distribution
1 low / 5 medium / 4 high. Higher-risk skew vs batches 1 and 2 because the cleanest low-risk candidates are now exhausted; remaining files involve user/operator-submitted content where forward DROPs are destructive.

## Test plan
- [x] `__tests__/lib/check-rls-migrations.test.ts` → 30/30 passing
- [x] Header-only changes; all 511 added lines are SQL comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)