### PR TITLE
fix(api): surface OTP send failures instead of swallowing them

### DIFF
--- a/__tests__/api/verify-otp-send.test.ts
+++ b/__tests__/api/verify-otp-send.test.ts
@@ -22,6 +22,15 @@ vi.mock("@/lib/supabase/admin", () => ({
   createAdminClient: () => ({ from: mockFrom }),
 }));
 
+vi.mock("@/lib/logger", () => ({
+  logger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
 vi.stubGlobal("fetch", mockFetch);
 
 // ── Import after mocks ────────────────────────────────────────────────────────
@@ -55,21 +64,27 @@ function makeChain() {
 
 describe("POST /api/verify-otp/send", () => {
   let savedKey: string | undefined;
+  let savedEnv: string | undefined;
 
   beforeEach(() => {
     vi.clearAllMocks();
     savedKey = process.env.RESEND_API_KEY;
+    savedEnv = process.env.NODE_ENV;
     delete process.env.RESEND_API_KEY;
+    // Default to dev-mode behavior so existing test cases keep working.
+    vi.stubEnv("NODE_ENV", "test");
     mockIsRateLimited.mockResolvedValue(false);
     mockIsValidEmail.mockReturnValue(true);
     mockIsDisposableEmail.mockReturnValue(false);
     mockFrom.mockReturnValue(makeChain());
-    mockFetch.mockResolvedValue({ ok: true });
+    mockFetch.mockResolvedValue({ ok: true, text: async () => "" });
   });
 
   afterEach(() => {
     if (savedKey !== undefined) process.env.RESEND_API_KEY = savedKey;
     else delete process.env.RESEND_API_KEY;
+    vi.unstubAllEnvs();
+    if (savedEnv !== undefined) vi.stubEnv("NODE_ENV", savedEnv);
   });
 
   it("returns 429 when rate limited", async () => {
@@ -159,9 +174,44 @@ describe("POST /api/verify-otp/send", () => {
     );
   });
 
-  it("returns 200 { success: true } on success", async () => {
+  it("returns 200 with devSkipped flag in dev when key absent", async () => {
+    const res = await POST(makePost({ email: "a@b.com" }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true, devSkipped: true });
+  });
+
+  it("returns 200 { success: true } on successful send", async () => {
+    process.env.RESEND_API_KEY = "re_test_key";
+    mockFetch.mockResolvedValueOnce({ ok: true, text: async () => "" });
     const res = await POST(makePost({ email: "a@b.com" }));
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ success: true });
+  });
+
+  it("returns 503 in production when RESEND_API_KEY is missing", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const res = await POST(makePost({ email: "a@b.com" }));
+    expect(res.status).toBe(503);
+    expect(await res.json()).toMatchObject({ error: expect.stringContaining("not configured") });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("returns 502 when Resend responds non-OK", async () => {
+    process.env.RESEND_API_KEY = "re_test_key";
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 422,
+      text: async () => '{"name":"validation_error","message":"domain not verified"}',
+    });
+    const res = await POST(makePost({ email: "a@b.com" }));
+    expect(res.status).toBe(502);
+    expect(await res.json()).toMatchObject({ error: expect.stringContaining("couldn't send") });
+  });
+
+  it("returns 502 when Resend fetch throws", async () => {
+    process.env.RESEND_API_KEY = "re_test_key";
+    mockFetch.mockRejectedValueOnce(new Error("network down"));
+    const res = await POST(makePost({ email: "a@b.com" }));
+    expect(res.status).toBe(502);
   });
 });

--- a/app/api/verify-otp/send/route.ts
+++ b/app/api/verify-otp/send/route.ts
@@ -1,14 +1,26 @@
 import { createAdminClient } from "@/lib/supabase/admin";
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 import { isValidEmail, isDisposableEmail } from "@/lib/validate-email";
 import { isRateLimited } from "@/lib/rate-limit";
+import { logger } from "@/lib/logger";
 
 export const runtime = "edge";
 
+const log = logger("api/verify-otp/send");
+
+const Body = z.object({ email: z.string() });
+
 /**
  * POST /api/verify-otp/send
- * Generates a 6-digit OTP and emails it to the provided address.
+ * Generates a 6-digit OTP and emails it via Resend.
  * Rate-limited to 5 sends per IP per 10 minutes.
+ *
+ * Failure semantics: if the email cannot be sent (missing API key, Resend
+ * outage, non-2xx response), we return 502 in production so the UI surfaces
+ * a real error instead of silently advancing to the "enter code" step. In
+ * development, a missing key is tolerated (warned) so local flows work
+ * without Resend credentials.
  */
 export async function POST(request: NextRequest) {
   const ip = (request.headers.get("x-forwarded-for") ?? "unknown").split(",")[0].trim();
@@ -16,12 +28,17 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Too many requests. Please wait a moment." }, { status: 429 });
   }
 
-  let email: string;
+  let raw: unknown;
   try {
-    ({ email } = await request.json());
+    raw = await request.json();
   } catch {
     return NextResponse.json({ error: "Invalid request" }, { status: 400 });
   }
+  const parsed = Body.safeParse(raw);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+  }
+  const { email } = parsed.data;
 
   if (!isValidEmail(email)) {
     return NextResponse.json({ error: "Please enter a valid email address." }, { status: 400 });
@@ -48,10 +65,22 @@ export async function POST(request: NextRequest) {
 
   await supabase.from("email_otps").insert({ email: normalizedEmail, code, expires_at: expiresAt });
 
-  // Send email via Resend
   const key = process.env.RESEND_API_KEY;
-  if (key) {
-    await fetch("https://api.resend.com/emails", {
+  if (!key) {
+    if (process.env.NODE_ENV === "production") {
+      log.error("RESEND_API_KEY missing — verification email not sent", { email: normalizedEmail });
+      return NextResponse.json(
+        { error: "Email service is not configured. Please contact support." },
+        { status: 503 },
+      );
+    }
+    log.warn("RESEND_API_KEY missing — skipping send (dev mode)", { email: normalizedEmail });
+    return NextResponse.json({ success: true, devSkipped: true });
+  }
+
+  let resendRes: Response;
+  try {
+    resendRes = await fetch("https://api.resend.com/emails", {
       method: "POST",
       headers: { "Content-Type": "application/json", Authorization: `Bearer ${key}` },
       body: JSON.stringify({
@@ -71,8 +100,30 @@ export async function POST(request: NextRequest) {
           </div>
         </div>`,
       }),
-    }).catch(() => null);
+    });
+  } catch (err) {
+    log.error("Resend request threw", { err, email: normalizedEmail });
+    return NextResponse.json(
+      { error: "We couldn't send the verification email. Please try again." },
+      { status: 502 },
+    );
   }
 
+  if (!resendRes.ok) {
+    // Pull the error body for diagnostics — Resend returns JSON like
+    // { statusCode, name, message } on 4xx (e.g. unverified domain).
+    const body = await resendRes.text().catch(() => "<unreadable>");
+    log.error("Resend returned non-OK", {
+      status: resendRes.status,
+      body: body.slice(0, 500),
+      email: normalizedEmail,
+    });
+    return NextResponse.json(
+      { error: "We couldn't send the verification email. Please try again." },
+      { status: 502 },
+    );
+  }
+
+  log.info("OTP email sent", { email: normalizedEmail });
   return NextResponse.json({ success: true });
 }


### PR DESCRIPTION
## Why

You hit "no verification email arrived" on the find-advisor (quiz) flow. Investigation showed nothing was wiped or regressed by recent merges — the flow has always been silently failure-tolerant:

- `app/api/verify-otp/send/route.ts` returned `{ success: true }` when `RESEND_API_KEY` was missing.
- The Resend `fetch()` had a `.catch(() => null)` that swallowed network errors and 4xx/5xx responses (e.g. unverified sender domain).
- No `logger.*` calls anywhere in the route, so production failures left no trace in Sentry or Vercel logs.

End result: the UI advanced to the "Enter the 6-digit code" step even when no email had been attempted.

## What changed

`app/api/verify-otp/send/route.ts`
- Missing `RESEND_API_KEY` in **production** → `503` + `logger.error` (Sentry alerts).
- Missing key in **dev** → `200 { success: true, devSkipped: true }` + `logger.warn` (local flows keep working).
- Resend non-2xx → `502`, response body captured (truncated to 500 chars) and logged.
- Resend `fetch()` throw → `502`, error logged.
- Successful send → `logger.info` breadcrumb.
- Body parser tightened to a Zod schema (clears the `invest/no-unvalidated-req-json` lint warning).

`__tests__/api/verify-otp-send.test.ts`
- Mocked `@/lib/logger` (no Sentry side-effects in tests).
- Switched env mutation to `vi.stubEnv` (TS strict-friendly).
- 4 new tests: prod-missing-key 503, Resend non-OK 502, Resend throw 502, dev success shape.

15/15 tests passing, `npm run type-check` clean, ESLint clean (`--max-warnings 0`).

## Likely production diagnosis

Once this ships, your next test will produce one of three log events that pinpoints the root cause:
1. `RESEND_API_KEY missing` → env var not set on this Vercel environment.
2. `Resend returned non-OK` with body → almost certainly `hello@invest.com.au` domain not verified in Resend, or rate/quota.
3. `Resend request threw` → network/edge-runtime issue.

## Test plan

- [ ] Deploy preview, hit find-advisor flow, submit email
- [ ] Confirm Sentry/Vercel logs surface the failure (or success info breadcrumb)
- [ ] If 503 in prod, confirm UI shows the "Email service is not configured" toast instead of silently advancing
- [ ] Once Resend is correctly configured, verify a real email arrives and the flow completes

---
_Generated by [Claude Code](https://claude.ai/code/session_01LuYVYEsKKFjPgf42FfXZzX)_