### PR TITLE
fix(ci): repair YAML validity in visual-regression + main-ci-auto-revert

### DIFF
--- a/.github/workflows/main-ci-auto-revert.yml
+++ b/.github/workflows/main-ci-auto-revert.yml
@@ -124,28 +124,38 @@ jobs:
         run: |
           set -eu
           short_sha=$(echo "${SHA}" | cut -c1-8)
+          # Body via temp file (heredoc-with-tabs would lose Markdown bullets;
+          # writing to a file keeps the body readable and avoids the
+          # YAML-block-scalar dedent issue that would otherwise break the
+          # workflow file when --body's content de-indents to column 0).
+          body_file=$(mktemp)
+          cat >"${body_file}" <<BODY_EOF
+          ## Auto-revert
+
+          The CI run on main for commit \`${short_sha}\` failed:
+
+          - **Failing commit:** ${SHA}
+          - **Subject:** ${SUBJECT}
+          - **CI run:** ${RUN_URL}
+
+          This PR reverts that commit so main is green again. Review the failure
+          above before merging — if the failure was a flake or unrelated to the
+          diff, close this PR and comment \`STOP\` on the original commit's run
+          to prevent future auto-reverts of the same SHA.
+
+          To prevent auto-revert in future, add \`[skip-revert]\` to the commit
+          message subject.
+
+          Layer 4 safeguard from \`docs/audits/MERGE_AUTHORIZATION.md\`.
+          BODY_EOF
+          # Strip the 10-space indent that the YAML block requires.
+          sed -i 's/^          //' "${body_file}"
           gh pr create \
             --base main \
             --head "${BRANCH}" \
             --draft \
             --title "revert: ${SUBJECT}" \
-            --body "## Auto-revert
-
-The CI run on main for commit \`${short_sha}\` failed:
-
-- **Failing commit:** ${SHA}
-- **Subject:** ${SUBJECT}
-- **CI run:** ${RUN_URL}
-
-This PR reverts that commit so main is green again. Review the failure
-above before merging — if the failure was a flake or unrelated to the
-diff, close this PR and comment \`STOP\` on the original commit's run
-to prevent future auto-reverts of the same SHA.
-
-To prevent auto-revert in future, add \`[skip-revert]\` to the commit
-message subject.
-
-Layer 4 safeguard from \`docs/audits/MERGE_AUTHORIZATION.md\`."
+            --body-file "${body_file}"
 
       - name: Comment on failing commit
         if: ${{ steps.inspect.outputs.skip == '' }}

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -75,7 +75,6 @@ jobs:
     if: false
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    needs: ci
 
     env:
       NEXT_PUBLIC_SUPABASE_URL: https://placeholder.supabase.co


### PR DESCRIPTION
## Summary

Two GitHub Actions workflows have been failing on every push to `main` since 2026-04-29 with phantom failure records (zero jobs scheduled, instant fail). Tracked down today after the 14-PR audit-remediation batch landed and made the noise visible.

### `main-ci-auto-revert.yml`

`gh pr create --body "..."` was using a multiline shell string where body lines dedent to column 0 inside the YAML `run: |` block. YAML's literal-block scalar treats those lines as ending the block, then tries to parse `**Failing commit:**` as a structural node — `*Failing` looks like an alias reference and the parser dies.

Fix: write the body via a heredoc into a tempfile (indented at the YAML block level, then sed-stripped) and pass via `gh pr create --body-file`.

### `visual-regression.yml`

Job `chromatic` declared `needs: ci`, but `ci` is a job in `ci.yml`, not in this workflow. Cross-workflow `needs:` is not valid syntax. Even with the job's `if: false` guard, the parser still validates `needs:` before scheduling, so the whole workflow rejects.

Fix: drop `needs: ci`. When this workflow gets enabled (after the Chromatic account/token setup at the top of the file), it can pull artifacts via `workflow_run` or a separate orchestration.

## Why now

Both bugs landed late April. They were silent — phantom failures don't gate anything — until the audit loop's CI-noise sweep flagged them today.

## Rollback

`git revert <merge-sha>` and force a re-push to main. Both workflows return to their previous (silent-fail) state. No data loss; the auto-revert workflow has never successfully run.

## Test plan
- [ ] CI green on this PR
- [ ] After merge: next push to main produces no new failure records on either workflow
- [ ] After merge: `gh api repos/Funs7575/invest-com-au/actions/workflows` shows both workflows with state=active and no validation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)