### PR TITLE
feat(e): E-02 batch 2 — convert 4 routes to Zod

### DIFF
--- a/app/api/account/claim-anonymous/route.ts
+++ b/app/api/account/claim-anonymous/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 import { createClient } from "@/lib/supabase/server";
 import { claimAnonymousSaves } from "@/lib/bookmarks";
 import { claimSessionQuizzes } from "@/lib/quiz-history";
@@ -7,6 +8,18 @@ import { logger } from "@/lib/logger";
 const log = logger("api:account:claim-anonymous");
 
 export const runtime = "nodejs";
+
+/**
+ * Body schema. `session_id` is the only field of interest; everything else
+ * is silently dropped. Top-level `.catch({})` mirrors the previous
+ * `.catch(() => ({}))` JSON-parse swallow so a malformed body still falls
+ * through to the existing "Missing session_id" 400 below.
+ */
+const ClaimAnonymousSchema = z
+  .object({
+    session_id: z.string().optional().catch(undefined),
+  })
+  .catch({});
 
 /**
  * POST /api/account/claim-anonymous
@@ -27,9 +40,9 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const body = await request.json().catch(() => ({}));
-  const sessionId =
-    typeof body.session_id === "string" ? body.session_id.slice(0, 100) : null;
+  const raw = await request.json().catch(() => ({}));
+  const parsed = ClaimAnonymousSchema.parse(raw);
+  const sessionId = parsed.session_id ? parsed.session_id.slice(0, 100) : null;
   if (!sessionId) {
     return NextResponse.json({ error: "Missing session_id" }, { status: 400 });
   }

--- a/app/api/notification-preferences/route.ts
+++ b/app/api/notification-preferences/route.ts
@@ -1,8 +1,32 @@
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 import { createClient } from "@/lib/supabase/server";
 import { logger } from "@/lib/logger";
 
 const log = logger("notifications");
+
+/**
+ * Body schema for POST. Every preference is an optional boolean —
+ * non-boolean values fall through to `undefined` per-field via
+ * `.optional().catch(undefined)`, mirroring the previous
+ * `typeof body[key] === "boolean" ? ... : drop` per-key filter (so a
+ * mixed body like `{ fee_alerts: "yes", weekly_digest: true }` keeps
+ * the valid key and drops only the bad one). The "no recognised keys
+ * → 400" gate below stays the gatekeeper.
+ *
+ * Top-level `.catch({})` mirrors the previous "non-object body → 400
+ * because zero allowed keys" path.
+ */
+const NotificationPreferencesSchema = z
+  .object({
+    fee_alerts: z.boolean().optional().catch(undefined),
+    weekly_digest: z.boolean().optional().catch(undefined),
+    deal_alerts: z.boolean().optional().catch(undefined),
+    campaign_updates: z.boolean().optional().catch(undefined),
+    marketing: z.boolean().optional().catch(undefined),
+  })
+  .passthrough()
+  .catch({});
 
 /**
  * GET /api/notification-preferences
@@ -58,23 +82,26 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Session expired. Please sign in again." }, { status: 401 });
   }
 
-  let body: Record<string, unknown>;
+  let raw: unknown;
   try {
-    body = await req.json();
+    raw = await req.json();
   } catch {
     return NextResponse.json(
       { error: "Some fields are invalid. Check and try again." },
       { status: 400 }
     );
   }
+  const parsed = NotificationPreferencesSchema.parse(raw);
 
-  // Only allow known preference keys
+  // Only allow known preference keys (booleans only — non-bool drops out
+  // because the schema marks each key `boolean | undefined`).
   const allowedKeys = ["fee_alerts", "weekly_digest", "deal_alerts", "campaign_updates", "marketing"] as const;
   const updates: Record<string, boolean> = {};
 
   for (const key of allowedKeys) {
-    if (typeof body[key] === "boolean") {
-      updates[key] = body[key] as boolean;
+    const value = parsed[key];
+    if (typeof value === "boolean") {
+      updates[key] = value;
     }
   }
 

--- a/app/api/privacy/request/route.ts
+++ b/app/api/privacy/request/route.ts
@@ -14,6 +14,7 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { logger } from "@/lib/logger";
 import { isValidEmail } from "@/lib/validate-email";
@@ -25,6 +26,22 @@ const log = logger("privacy-request");
 
 export const runtime = "nodejs";
 
+/**
+ * Body schema. Both fields are optional; the `type` enum catches unknown
+ * values to `undefined`, mirroring the previous
+ * `body.type === "export" || body.type === "delete" ? body.type : null`
+ * gate. The combined `if (!email || !isValidEmail(email) || !type)` 400
+ * below stays the gatekeeper. The top-level `.catch({})` keeps
+ * malformed-JSON bodies on the same 400 path the old
+ * `.catch(() => ({}))` produced.
+ */
+const PrivacyRequestSchema = z
+  .object({
+    email: z.string().optional().catch(undefined),
+    type: z.enum(["export", "delete"]).optional().catch(undefined),
+  })
+  .catch({});
+
 export async function POST(request: NextRequest) {
   // Strict rate limit — 3 requests per hour per IP. Privacy endpoints
   // are a prime abuse vector.
@@ -32,9 +49,10 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Too many requests" }, { status: 429 });
   }
 
-  const body = await request.json().catch(() => ({}));
-  const email = typeof body.email === "string" ? body.email.trim().toLowerCase() : null;
-  const type = body.type === "export" || body.type === "delete" ? body.type : null;
+  const raw = await request.json().catch(() => ({}));
+  const parsed = PrivacyRequestSchema.parse(raw);
+  const email = parsed.email ? parsed.email.trim().toLowerCase() : null;
+  const type = parsed.type ?? null;
 
   if (!email || !isValidEmail(email) || !type) {
     return NextResponse.json(

--- a/app/api/user-profile/route.ts
+++ b/app/api/user-profile/route.ts
@@ -1,5 +1,56 @@
 import { createClient } from "@/lib/supabase/server";
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+/**
+ * Body schema for PUT. Every field is optional and value-validating,
+ * matching the previous per-field `typeof === "string"` + enum
+ * `.includes()` guards. Invalid values fall through to `undefined`
+ * (so they're silently dropped) via the per-field
+ * `.optional().catch(undefined)` — preserving the route's "drop
+ * unrecognised values, reject only when zero allowed fields remain"
+ * contract end-to-end. The top-level `.catch({})` keeps malformed
+ * payloads on the same path the previous "no allowed fields → 400"
+ * gate produces.
+ */
+const INVESTING_EXPERIENCES = ["beginner", "intermediate", "advanced"] as const;
+const INVESTMENT_GOALS = ["growth", "income", "preservation", "speculation"] as const;
+const PORTFOLIO_SIZES = [
+  "under_10k",
+  "10k_50k",
+  "50k_200k",
+  "200k_500k",
+  "over_500k",
+] as const;
+const VALID_INTERESTS = [
+  "shares",
+  "etfs",
+  "crypto",
+  "super",
+  "property",
+  "savings",
+  "insurance",
+  "cfd_forex",
+] as const;
+const STATES = ["NSW", "VIC", "QLD", "WA", "SA", "TAS", "ACT", "NT"] as const;
+
+const UserProfileSchema = z
+  .object({
+    display_name: z.string().optional().catch(undefined),
+    avatar_url: z.string().optional().catch(undefined),
+    investing_experience: z
+      .enum(INVESTING_EXPERIENCES)
+      .optional()
+      .catch(undefined),
+    investment_goals: z.enum(INVESTMENT_GOALS).optional().catch(undefined),
+    portfolio_size: z.enum(PORTFOLIO_SIZES).optional().catch(undefined),
+    interested_in: z.array(z.unknown()).optional().catch(undefined),
+    preferred_broker: z.string().optional().catch(undefined),
+    state: z.enum(STATES).optional().catch(undefined),
+    onboarding_completed: z.boolean().optional().catch(undefined),
+  })
+  .passthrough()
+  .catch({});
 
 export async function GET() {
   try {
@@ -39,15 +90,16 @@ export async function PUT(req: NextRequest) {
     );
   }
 
-  let body: Record<string, unknown>;
+  let raw: unknown;
   try {
-    body = await req.json();
+    raw = await req.json();
   } catch {
     return NextResponse.json(
       { error: "Some fields are invalid. Check and try again." },
       { status: 400 }
     );
   }
+  const body = UserProfileSchema.parse(raw);
 
   // Validate fields
   const allowed: Record<string, unknown> = {};
@@ -58,23 +110,26 @@ export async function PUT(req: NextRequest) {
   if (typeof body.avatar_url === "string") {
     allowed.avatar_url = body.avatar_url.trim().slice(0, 500) || null;
   }
-  if (typeof body.investing_experience === "string" && ["beginner", "intermediate", "advanced"].includes(body.investing_experience)) {
+  if (body.investing_experience !== undefined) {
     allowed.investing_experience = body.investing_experience;
   }
-  if (typeof body.investment_goals === "string" && ["growth", "income", "preservation", "speculation"].includes(body.investment_goals)) {
+  if (body.investment_goals !== undefined) {
     allowed.investment_goals = body.investment_goals;
   }
-  if (typeof body.portfolio_size === "string" && ["under_10k", "10k_50k", "50k_200k", "200k_500k", "over_500k"].includes(body.portfolio_size)) {
+  if (body.portfolio_size !== undefined) {
     allowed.portfolio_size = body.portfolio_size;
   }
-  if (typeof body.interested_in === "object" && Array.isArray(body.interested_in)) {
-    const validInterests = ["shares", "etfs", "crypto", "super", "property", "savings", "insurance", "cfd_forex"];
-    allowed.interested_in = body.interested_in.filter((i: string) => validInterests.includes(i)).slice(0, 8);
+  if (Array.isArray(body.interested_in)) {
+    allowed.interested_in = (body.interested_in as unknown[])
+      .filter((i): i is (typeof VALID_INTERESTS)[number] =>
+        typeof i === "string" && (VALID_INTERESTS as readonly string[]).includes(i),
+      )
+      .slice(0, 8);
   }
   if (typeof body.preferred_broker === "string") {
     allowed.preferred_broker = body.preferred_broker.trim().slice(0, 100) || null;
   }
-  if (typeof body.state === "string" && ["NSW", "VIC", "QLD", "WA", "SA", "TAS", "ACT", "NT"].includes(body.state)) {
+  if (body.state !== undefined) {
     allowed.state = body.state;
   }
   if (typeof body.onboarding_completed === "boolean") {


### PR DESCRIPTION
## Summary
Second batch of E-02 (#315 was batch 1). Converts 4 more high-traffic POST/PUT/PATCH routes from per-field `typeof` casts to Zod schemas. Behaviour, status codes, error envelopes, and field-level error messages preserved bit-for-bit so existing integration tests cover the conversion without modification.

## Routes converted
- `app/api/user-profile/route.ts` — 15 tests still green; approach: inline; reason: route-specific "Some fields are invalid. Check and try again." 400 message + per-field "drop bad value, keep valid ones" contract needs per-field `.optional().catch(undefined)` rather than the helper's all-or-nothing 400
- `app/api/notification-preferences/route.ts` — 11 tests still green; approach: inline; same reason — route-specific 400 message + per-key drop-bad contract
- `app/api/privacy/request/route.ts` — 14 tests still green; approach: inline; reason: combined "Missing or invalid email / type" 400 message + existing `.catch(() => ({}))` JSON-swallow pattern make `withValidatedBody`'s "Invalid JSON body" envelope a behaviour change
- `app/api/account/claim-anonymous/route.ts` — 4 integration tests still green; approach: inline; reason: auth gate runs before JSON read; "Missing session_id" 400 is route-specific

## Pattern
Per-field `.optional().catch(undefined)` mirrors the previous `typeof body[k] === "string" ? ... : drop` contract. Top-level `.catch({})` preserves the malformed-body fallthrough path. `.passthrough()` retained on routes that forward extras (notification-preferences, user-profile).

## Still deferred for later batches
- `submit-lead`, `advisor-apply` (deferred since batch 1 — need behaviour-breaking test edits)
- `shortlist`, `claim-listing`, `unsubscribe`, `export-data` — each has its own quirk for batch 3 (claim-listing custom validate() with strict error-message ordering, export-data has no test file, shortlist/unsubscribe partial helper-envelope match)

## Test plan
- [x] 44 tests across 4 routes — all green (15 + 11 + 14 + 4)
- [x] `eslint --fix --max-warnings 0` clean on the 4 changed files
- [x] No response shapes / status codes / error messages changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)