### PR TITLE
feat(home): intent-driven hero quiz, visual pillars, compare filters + footer dedup

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,7 +9,6 @@ import HomeCrossBorder from "@/components/HomeCrossBorder";
 import HomeFridayBriefing from "@/components/HomeFridayBriefing";
 import HomeHowWeEarn from "@/components/HomeHowWeEarn";
 import ScrollFadeIn from "@/components/ScrollFadeIn";
-import ComplianceFooter from "@/components/ComplianceFooter";
 import MobileStickyAdvisorCta from "@/components/MobileStickyAdvisorCta";
 import { ORGANIZATION_JSONLD, SITE_URL } from "@/lib/seo";
 
@@ -52,7 +51,7 @@ export default async function HomePage() {
       .eq("status", "active")
       .order("promoted_placement", { ascending: false })
       .order("rating", { ascending: false })
-      .limit(20),
+      .limit(80),
     supabase
       .from("professionals")
       .select("id", { count: "exact", head: true })
@@ -79,7 +78,7 @@ export default async function HomePage() {
       .eq("status", "active")
       .order("listing_type", { ascending: false })
       .order("created_at", { ascending: false })
-      .limit(24),
+      .limit(80),
   ]);
 
   const brokerCount = brokers?.length || 0;
@@ -102,7 +101,41 @@ export default async function HomePage() {
   }));
 
   const advisorList: ReadonlyArray<HomeAdvisor> = (professionals ?? []) as HomeAdvisor[];
-  const listingList: ReadonlyArray<HomeListing> = (listings ?? []) as HomeListing[];
+
+  // Curate listings for the homepage teaser:
+  //   1. Prefer listings with at least one image (better hero unit)
+  //   2. Weight by paid tier: premium > featured > standard
+  //   3. Round-robin across verticals so the grid isn't dominated by one category
+  // Listings without images still appear after image-bearing ones if a vertical has none.
+  const rawListings = (listings ?? []) as HomeListing[];
+  const tierWeight: Record<string, number> = { premium: 3, featured: 2, standard: 1 };
+  const scored = rawListings
+    .map((l) => ({
+      l,
+      hasImg: !!(l.images && l.images.length > 0 && l.images[0]),
+      tier: tierWeight[l.listing_type ?? "standard"] ?? 0,
+    }))
+    .sort((a, b) => {
+      if (a.hasImg !== b.hasImg) return a.hasImg ? -1 : 1;
+      return b.tier - a.tier;
+    });
+
+  const perVerticalCap = 2;
+  const verticalCounts = new Map<string, number>();
+  const curated: HomeListing[] = [];
+  const overflow: HomeListing[] = [];
+  for (const { l } of scored) {
+    const used = verticalCounts.get(l.vertical) ?? 0;
+    if (used < perVerticalCap) {
+      curated.push(l);
+      verticalCounts.set(l.vertical, used + 1);
+    } else {
+      overflow.push(l);
+    }
+  }
+  // Final list: curated leads (image + diverse) followed by remaining inventory so the
+  // per-vertical tabs in HomeListingsTeaser still have plenty to filter through.
+  const listingList: ReadonlyArray<HomeListing> = [...curated, ...overflow].slice(0, 60);
 
   return (
     <div>
@@ -200,10 +233,6 @@ export default async function HomePage() {
       </ScrollFadeIn>
 
       <MobileStickyAdvisorCta />
-
-      <div className="container-custom pb-8 pt-6">
-        <ComplianceFooter />
-      </div>
     </div>
   );
 }

--- a/components/HeroQuizCard.tsx
+++ b/components/HeroQuizCard.tsx
@@ -4,13 +4,48 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { DesignIcon } from "@/components/design/DesignIcon";
 
-type AnswerId = "deals" | "advisor" | "compare" | "foreign";
+type AnswerId = "diy" | "marketplace" | "advisor" | "mix";
 
-const ANSWERS: ReadonlyArray<{ id: AnswerId; label: string; icon: string; accent: string; href: string }> = [
-  { id: "deals",   label: "I want to see deals beyond the ASX",      icon: "sparkles",      accent: "#fbbf24", href: "/quiz?seed=deals" },
-  { id: "advisor", label: "I need to talk to a licensed human",       icon: "users",         accent: "#34d399", href: "/quiz?seed=advisor" },
-  { id: "compare", label: "Compare brokers / super / savings",        icon: "trending-down", accent: "#60a5fa", href: "/quiz?seed=compare" },
-  { id: "foreign", label: "I'm on a visa or have foreign assets",     icon: "globe",         accent: "#f59e0b", href: "/quiz?seed=foreign" },
+const ANSWERS: ReadonlyArray<{
+  id: AnswerId;
+  label: string;
+  hint: string;
+  icon: string;
+  accent: string;
+  href: string;
+}> = [
+  {
+    id: "diy",
+    label: "Invest myself, on a platform",
+    hint: "Shares, ETFs, super, crypto — DIY",
+    icon: "trending-up",
+    accent: "#60a5fa",
+    href: "/quiz?seed=compare",
+  },
+  {
+    id: "marketplace",
+    label: "Browse private deals & listings",
+    hint: "Funds, businesses, farmland, mining, commercial",
+    icon: "sparkles",
+    accent: "#fbbf24",
+    href: "/quiz?seed=deals",
+  },
+  {
+    id: "advisor",
+    label: "Speak with a verified advisor",
+    hint: "Planner, accountant, broker — your situation",
+    icon: "users",
+    accent: "#34d399",
+    href: "/quiz?seed=advisor",
+  },
+  {
+    id: "mix",
+    label: "A mix of all of the above",
+    hint: "Show me the full picture",
+    icon: "compass",
+    accent: "var(--color-coral-400)",
+    href: "/quiz?seed=mix",
+  },
 ];
 
 export default function HeroQuizCard() {
@@ -43,24 +78,23 @@ export default function HeroQuizCard() {
         >
           <DesignIcon name="zap" size={11} /> Start here · 60 seconds
         </span>
-        <span style={{ marginLeft: "auto", fontSize: 11, color: "rgba(255,255,255,.5)" }}>Q 1 of 6</span>
       </div>
 
       <div
         className="font-display"
         style={{
-          fontSize: 22,
-          fontWeight: 700,
-          letterSpacing: "-.022em",
-          lineHeight: 1.15,
-          marginBottom: 14,
+          fontSize: 26,
+          fontWeight: 800,
+          letterSpacing: "-.024em",
+          lineHeight: 1.1,
+          marginBottom: 18,
           color: "white",
         }}
       >
-        What brings you here today?
+        How do you want to invest?
       </div>
 
-      <div role="radiogroup" aria-label="What brings you here today?" style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+      <div role="radiogroup" aria-label="How do you want to invest?" style={{ display: "flex", flexDirection: "column", gap: 8 }}>
         {ANSWERS.map((opt) => {
           const sel = pick === opt.id;
           return (
@@ -71,12 +105,12 @@ export default function HeroQuizCard() {
               aria-checked={sel}
               onClick={() => setPick(opt.id)}
               style={{
-                padding: "11px 12px",
-                borderRadius: 9,
+                padding: "14px 16px",
+                borderRadius: 12,
                 cursor: "pointer",
                 display: "flex",
                 alignItems: "center",
-                gap: 11,
+                gap: 14,
                 border: sel ? `1.5px solid ${opt.accent}` : "1px solid rgba(255,255,255,.1)",
                 background: sel
                   ? `color-mix(in oklch, ${opt.accent} 14%, transparent)`
@@ -84,14 +118,15 @@ export default function HeroQuizCard() {
                 textAlign: "left",
                 fontFamily: "inherit",
                 color: "white",
-                transition: "background .15s ease, border-color .15s ease",
+                transition: "background .15s ease, border-color .15s ease, transform .15s ease",
+                transform: sel ? "translateX(2px)" : "none",
               }}
             >
               <span
                 style={{
-                  width: 28,
-                  height: 28,
-                  borderRadius: 7,
+                  width: 44,
+                  height: 44,
+                  borderRadius: 10,
                   background: `color-mix(in oklch, ${opt.accent} 22%, transparent)`,
                   display: "inline-flex",
                   alignItems: "center",
@@ -101,13 +136,21 @@ export default function HeroQuizCard() {
                 }}
                 aria-hidden
               >
-                <DesignIcon name={opt.icon} size={13} strokeWidth={2.4} />
+                <DesignIcon name={opt.icon} size={22} strokeWidth={2.4} />
               </span>
-              <span style={{ fontSize: 13, fontWeight: 600 }}>{opt.label}</span>
+              <span style={{ display: "flex", flexDirection: "column", gap: 2, minWidth: 0, flex: 1 }}>
+                <span style={{ fontSize: 16, fontWeight: 800, color: "white", letterSpacing: "-.012em" }}>
+                  {opt.label}
+                </span>
+                <span style={{ fontSize: 12, color: "rgba(255,255,255,.55)", fontWeight: 500 }}>
+                  {opt.hint}
+                </span>
+              </span>
               <DesignIcon
                 name="arrow-right"
-                size={11}
-                style={{ marginLeft: "auto", color: sel ? opt.accent : "rgba(255,255,255,.3)" }}
+                size={14}
+                style={{ marginLeft: "auto", color: sel ? opt.accent : "rgba(255,255,255,.35)" }}
+                strokeWidth={2.4}
               />
             </button>
           );

--- a/components/HomeCompareDeepDive.tsx
+++ b/components/HomeCompareDeepDive.tsx
@@ -21,6 +21,16 @@ export interface CompareBroker {
   editors_pick: boolean | null;
 }
 
+const QUICK_FILTERS: ReadonlyArray<{ label: string; href: string }> = [
+  { label: "$0 brokerage", href: "/compare?category=shares" },
+  { label: "CHESS sponsored", href: "/compare?category=shares" },
+  { label: "Top-rated super", href: "/best/super-funds" },
+  { label: "Crypto · low fees", href: "/best/crypto-exchanges" },
+  { label: "Best HISA", href: "/best/savings-accounts" },
+  { label: "Robo · all-in fee", href: "/best/robo-advisors" },
+  { label: "Editor's picks", href: "/compare?sort=rating" },
+];
+
 const CAT_META: Record<string, { label: string; color: string; criterion: string; href: string; valueLabel: string }> = {
   share_broker:    { label: "Stock brokers",  color: "#60a5fa", criterion: "by total cost on $200/month DCA", href: "/share-trading", valueLabel: "Trade" },
   super_fund:      { label: "Super funds",    color: "#34d399", criterion: "by 10-yr balanced return net of fees", href: "/super",       valueLabel: "Fee" },
@@ -130,11 +140,54 @@ export default function HomeCompareDeepDive({ brokers }: HomeCompareDeepDiveProp
           })}
         </div>
 
+        <div
+          style={{
+            display: "flex",
+            gap: 6,
+            marginBottom: 14,
+            flexWrap: "wrap",
+            alignItems: "center",
+          }}
+        >
+          <span
+            className="font-mono"
+            style={{
+              fontSize: 9.5,
+              color: "rgba(255,255,255,.4)",
+              fontWeight: 700,
+              textTransform: "uppercase",
+              letterSpacing: ".08em",
+              marginRight: 4,
+            }}
+          >
+            Quick filters
+          </span>
+          {QUICK_FILTERS.map((f) => (
+            <Link
+              key={f.label}
+              href={f.href}
+              style={{
+                padding: "5px 10px",
+                fontSize: 11.5,
+                fontWeight: 600,
+                color: "rgba(255,255,255,.85)",
+                background: "rgba(255,255,255,.05)",
+                border: "1px solid rgba(255,255,255,.1)",
+                borderRadius: 99,
+                textDecoration: "none",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {f.label}
+            </Link>
+          ))}
+        </div>
+
         <div className="home-compare-grid" style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 12 }}>
           {featuredKeys.map((key) => {
             const meta = CAT_META[key];
             if (!meta) return null;
-            const rows = (groups.get(key) ?? []).slice(0, 3);
+            const rows = (groups.get(key) ?? []).slice(0, 4);
             if (rows.length === 0) return null;
             return (
               <div
@@ -219,6 +272,57 @@ export default function HomeCompareDeepDive({ brokers }: HomeCompareDeepDiveProp
               </div>
             );
           })}
+        </div>
+
+        <div
+          className="home-compare-end"
+          style={{
+            marginTop: 18,
+            padding: "14px 18px",
+            background: "rgba(255,255,255,.04)",
+            border: "1px solid rgba(255,255,255,.08)",
+            borderRadius: 12,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: 16,
+            flexWrap: "wrap",
+          }}
+        >
+          <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+            <span
+              className="font-mono"
+              style={{
+                fontSize: 9.5,
+                color: "rgba(255,255,255,.4)",
+                fontWeight: 700,
+                textTransform: "uppercase",
+                letterSpacing: ".08em",
+              }}
+            >
+              Not sure where to start?
+            </span>
+            <span style={{ fontSize: 13.5, fontWeight: 700, color: "white" }}>
+              Filter {brokers.length} platforms by your criteria — fees, features, regulator.
+            </span>
+          </div>
+          <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+            <Link href="/quiz" className="iv2-cta" style={{ fontSize: 12.5 }}>
+              60-second quiz <DesignIcon name="arrow-right" size={11} />
+            </Link>
+            <Link
+              href="/compare"
+              className="iv2-cta-ghost"
+              style={{
+                fontSize: 12.5,
+                color: "white",
+                borderColor: "rgba(255,255,255,.2)",
+                background: "transparent",
+              }}
+            >
+              Open full comparison
+            </Link>
+          </div>
         </div>
       </div>
 

--- a/components/HomeListingsTeaser.tsx
+++ b/components/HomeListingsTeaser.tsx
@@ -21,14 +21,17 @@ export interface HomeListing {
 }
 
 const VERTICAL_LABELS: Record<string, { label: string; color: string }> = {
-  mining:               { label: "Mining",     color: "#fbbf24" },
+  funds:                { label: "Funds",      color: "#60a5fa" },
+  "buy-business":       { label: "Business",   color: "#f87171" },
+  "commercial-property":{ label: "Commercial", color: "#a78bfa" },
   farmland:             { label: "Farmland",   color: "#84cc16" },
-  business:             { label: "Business",   color: "#f87171" },
-  commercial_property:  { label: "Commercial", color: "#a78bfa" },
-  energy:               { label: "Renewables", color: "#34d399" },
-  fund:                 { label: "Funds",      color: "#60a5fa" },
+  "renewable-energy":   { label: "Renewables", color: "#34d399" },
+  mining:               { label: "Mining",     color: "#fbbf24" },
   franchise:            { label: "Franchise",  color: "#db2777" },
-  startup:              { label: "Startup",    color: "#525252" },
+  startups:             { label: "Startups",   color: "#f59e0b" },
+  hydrogen:             { label: "Hydrogen",   color: "#06b6d4" },
+  uranium:              { label: "Uranium",    color: "#8b5cf6" },
+  "oil-gas":            { label: "Oil & Gas",  color: "#64748b" },
 };
 
 interface HomeListingsTeaserProps {

--- a/components/HomePillarsGrid.tsx
+++ b/components/HomePillarsGrid.tsx
@@ -9,56 +9,51 @@ interface PillarsProps {
 
 export default function HomePillarsGrid({ listingCount, professionalCount, brokerCount }: PillarsProps) {
   const pillars: ReadonlyArray<{
-    tag: string;
     title: string;
     sub: string;
     cta: string;
     href: string;
     icon: string;
     accent: string;
-    stats: ReadonlyArray<readonly [string, string]>;
+    badge: string;
     featured?: boolean;
   }> = [
     {
-      tag: "01",
-      title: `Browse ${listingCount} live listings`,
-      sub: "Mining · farmland · credit · renewables · off-plan · businesses.",
-      cta: "Open marketplace",
-      href: "/invest/listings",
-      icon: "sparkles",
-      accent: "#fbbf24",
-      stats: [[String(listingCount), "deals open"], ["$10k", "min from"]],
-    },
-    {
-      tag: "02 · NEW",
-      title: "Post a job — advisors come to you",
-      sub: "Describe your situation. Verified advisors quote. Free to post.",
-      cta: "Post your situation",
-      href: "/quotes/post",
-      icon: "megaphone",
-      accent: "var(--color-coral-500)",
-      stats: [["FREE", "to post"], ["4h", "avg response"]],
-      featured: true,
-    },
-    {
-      tag: "03",
-      title: "Find a verified advisor",
-      sub: "ASIC-registered. Filter by specialty, language, fee, location.",
-      cta: "Browse advisors",
-      href: "/advisors",
-      icon: "users",
-      accent: "#34d399",
-      stats: [[professionalCount.toLocaleString("en-AU"), "verified"], ["12+", "specialties"]],
-    },
-    {
-      tag: "04",
-      title: `Compare ${brokerCount} platforms`,
-      sub: "Brokers, super, savings, crypto, term deposits, mortgages, robo.",
+      title: "Compare platforms",
+      sub: "Brokers, super, crypto, savings, robo — fees side-by-side.",
       cta: "Open comparisons",
       href: "/compare",
       icon: "trending-down",
       accent: "#60a5fa",
-      stats: [[String(brokerCount), "platforms"], ["7", "categories"]],
+      badge: `${brokerCount} platforms`,
+    },
+    {
+      title: "Speak with an advisor",
+      sub: "ASIC-registered. Free quotes from verified pros.",
+      cta: "Find an advisor",
+      href: "/find-advisor",
+      icon: "users",
+      accent: "var(--color-coral-500)",
+      badge: `${professionalCount.toLocaleString("en-AU")} advisors`,
+      featured: true,
+    },
+    {
+      title: "Browse listings",
+      sub: "Funds, businesses, farmland, mining, commercial property.",
+      cta: "Open marketplace",
+      href: "/invest/listings",
+      icon: "sparkles",
+      accent: "#fbbf24",
+      badge: `${listingCount} live`,
+    },
+    {
+      title: "Take the 60-sec quiz",
+      sub: "Tell us your goal — we'll point you the right way.",
+      cta: "Start the quiz",
+      href: "/quiz",
+      icon: "compass",
+      accent: "#34d399",
+      badge: "60 seconds",
     },
   ];
 
@@ -82,7 +77,7 @@ export default function HomePillarsGrid({ listingCount, professionalCount, broke
         </h2>
       </div>
 
-      <div className="home-pillars-grid" style={{ display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: 12 }}>
+      <div className="home-pillars-grid" style={{ display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: 14 }}>
         {pillars.map((p) => (
           <Link
             key={p.href}
@@ -94,114 +89,98 @@ export default function HomePillarsGrid({ listingCount, professionalCount, broke
               background: p.featured ? "var(--color-ink-900)" : "white",
               color: p.featured ? "white" : "var(--color-ink-900)",
               border: p.featured ? `1.5px solid ${p.accent}` : "1px solid #e5e7eb",
-              borderTop: p.featured ? `1.5px solid ${p.accent}` : `2px solid ${p.accent}`,
-              borderRadius: 12,
-              padding: "18px 18px 16px",
+              borderTop: p.featured ? `1.5px solid ${p.accent}` : `3px solid ${p.accent}`,
+              borderRadius: 14,
+              padding: "26px 22px 22px",
               textDecoration: "none",
               position: "relative",
               boxShadow: p.featured
-                ? `0 8px 22px color-mix(in oklch, ${p.accent} 16%, transparent)`
+                ? `0 12px 32px color-mix(in oklch, ${p.accent} 20%, transparent)`
                 : "0 1px 0 rgba(0,0,0,.02)",
+              minHeight: 240,
             }}
           >
-            <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 10 }}>
-              <div
-                style={{
-                  width: 32,
-                  height: 32,
-                  borderRadius: 8,
-                  background: `color-mix(in oklch, ${p.accent} 18%, transparent)`,
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  color: p.accent,
-                }}
-                aria-hidden
-              >
-                <DesignIcon name={p.icon} size={15} strokeWidth={2.2} />
-              </div>
-              <span
-                style={{
-                  fontSize: 10,
-                  fontWeight: 800,
-                  color: p.accent,
-                  textTransform: "uppercase",
-                  letterSpacing: ".1em",
-                }}
-              >
-                {p.tag}
-              </span>
+            <div
+              aria-hidden
+              style={{
+                width: 56,
+                height: 56,
+                borderRadius: 14,
+                background: `color-mix(in oklch, ${p.accent} ${p.featured ? 22 : 14}%, transparent)`,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                color: p.accent,
+                marginBottom: 16,
+              }}
+            >
+              <DesignIcon name={p.icon} size={28} strokeWidth={2.2} />
             </div>
+
             <div
               className="font-display"
               style={{
-                fontSize: 16.5,
-                fontWeight: 700,
-                lineHeight: 1.18,
-                letterSpacing: "-.018em",
-                marginBottom: 6,
+                fontSize: 21,
+                fontWeight: 800,
+                lineHeight: 1.1,
+                letterSpacing: "-.022em",
+                marginBottom: 8,
                 textWrap: "balance",
+                color: p.featured ? "white" : "var(--color-ink-900)",
               }}
             >
               {p.title}
             </div>
             <div
               style={{
-                fontSize: 12,
+                fontSize: 13,
                 color: p.featured ? "rgba(255,255,255,.65)" : "var(--color-ink-500)",
                 lineHeight: 1.45,
-                marginBottom: 12,
+                marginBottom: 16,
                 flex: 1,
               }}
             >
               {p.sub}
             </div>
+
             <div
               style={{
                 display: "flex",
-                gap: 14,
-                marginBottom: 12,
-                paddingTop: 10,
-                borderTop: p.featured ? "1px solid rgba(255,255,255,.1)" : "1px solid #e5e7eb",
-              }}
-            >
-              {p.stats.map(([n, l]) => (
-                <div key={l}>
-                  <div
-                    className="font-mono"
-                    style={{
-                      fontSize: 14,
-                      fontWeight: 800,
-                      color: p.featured ? "white" : "var(--color-ink-900)",
-                      lineHeight: 1,
-                    }}
-                  >
-                    {n}
-                  </div>
-                  <div
-                    style={{
-                      fontSize: 9.5,
-                      color: p.featured ? "rgba(255,255,255,.5)" : "var(--color-ink-400)",
-                      marginTop: 3,
-                    }}
-                  >
-                    {l}
-                  </div>
-                </div>
-              ))}
-            </div>
-            <span
-              style={{
-                fontSize: 12.5,
-                fontWeight: 700,
-                color: p.accent,
-                display: "inline-flex",
                 alignItems: "center",
-                gap: 5,
+                justifyContent: "space-between",
+                gap: 8,
               }}
             >
-              {p.cta} <DesignIcon name="arrow-right" size={11} strokeWidth={2.6} />
-            </span>
+              <span
+                className="font-mono"
+                style={{
+                  fontSize: 11,
+                  fontWeight: 800,
+                  color: p.accent,
+                  textTransform: "uppercase",
+                  letterSpacing: ".06em",
+                  background: `color-mix(in oklch, ${p.accent} ${p.featured ? 18 : 10}%, transparent)`,
+                  border: `1px solid color-mix(in oklch, ${p.accent} 30%, transparent)`,
+                  padding: "3px 8px",
+                  borderRadius: 99,
+                  whiteSpace: "nowrap",
+                }}
+              >
+                {p.badge}
+              </span>
+              <span
+                style={{
+                  fontSize: 13,
+                  fontWeight: 800,
+                  color: p.featured ? "white" : p.accent,
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: 6,
+                }}
+              >
+                {p.cta} <DesignIcon name="arrow-right" size={14} strokeWidth={2.6} />
+              </span>
+            </div>
           </Link>
         ))}
       </div>

--- a/components/layout/SiteFooter.tsx
+++ b/components/layout/SiteFooter.tsx
@@ -17,7 +17,7 @@ export function SiteFooter() {
   });
 
   return (
-    <footer className="bg-slate-900 text-slate-300">
+    <footer className="bg-[var(--color-ink-900)] text-slate-300">
       {/* Main grid */}
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-12 pb-8">
         <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4 md:gap-8 mb-12">


### PR DESCRIPTION
## Summary

Six homepage surfaces revised after a deep-dive on revenue drivers (advisor leads = highest EV per visitor → promoted to featured pillar; affiliate clicks high-volume but volatile → kept as primary visual block).

- **HeroQuizCard**: intent-driven options (DIY / browse listings / advisor / mix), 44px icon tiles, 16px bold labels with hint lines. New heading: "How do you want to invest?".
- **HomePillarsGrid**: dropped 01–04 number tags and dual stats; 56px icon tiles, 21px/800-weight titles, single rounded badge stat. Reordered so the advisor CTA is featured (highest revenue per visitor at $39–$117/lead).
- **HomeCompareDeepDive**: 3 → 4 rows per category card, "Quick filters" chip row above the grid, closing CTA strip ("Not sure where to start? — 60-sec quiz / Open full comparison").
- **HomeListingsTeaser**: fixed `VERTICAL_LABELS` keys — DB stores kebab-case verticals (`buy-business`, `commercial-property`, `oil-gas`, `renewable-energy`, `startups`, `hydrogen`, `uranium`) which weren't in the map and were silently rendering raw vertical names.
- **app/page.tsx**: server-side curation of marketplace listings — prefer image-bearing rows, weight by paid tier (premium > featured > standard), round-robin across verticals so the teaser isn't dominated by hydrogen/oil-gas (which currently have zero images in the DB). Bumped broker query 20→80, listing query 24→80. Removed redundant `<ComplianceFooter />` since `SiteFooter` already shows the General Advice Warning — the previous duplication stacked two amber boxes.
- **SiteFooter**: `bg-slate-900` → `bg-[var(--color-ink-900)]` for visual continuity with the dark Compare and HowWeEarn sections directly above it.

## Test plan

- [ ] CI green
- [ ] Vercel preview: hero quiz answers route to `/quiz?seed={diy|deals|advisor|mix}` correctly
- [ ] Vercel preview: marketplace teaser shows mix of verticals with images (no hydrogen/oil-gas crowding)
- [ ] Vercel preview: only one General Advice Warning at page bottom (was two)
- [ ] Vercel preview: footer bg matches Compare/HowWeEarn sections seamlessly
- [ ] Vercel preview: Quick filter chips in Compare section navigate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)