### PR TITLE
feat(home): strip filters, lighten platform comparison [Phase 3]

### DIFF
--- a/components/HomeCompareDeepDive.tsx
+++ b/components/HomeCompareDeepDive.tsx
@@ -21,23 +21,13 @@ export interface CompareBroker {
   editors_pick: boolean | null;
 }
 
-const QUICK_FILTERS: ReadonlyArray<{ label: string; href: string }> = [
-  { label: "$0 brokerage", href: "/compare?category=shares" },
-  { label: "CHESS sponsored", href: "/compare?category=shares" },
-  { label: "Top-rated super", href: "/best/super-funds" },
-  { label: "Crypto · low fees", href: "/best/crypto-exchanges" },
-  { label: "Best HISA", href: "/best/savings-accounts" },
-  { label: "Robo · all-in fee", href: "/best/robo-advisors" },
-  { label: "Editor's picks", href: "/compare?sort=rating" },
-];
-
 const CAT_META: Record<string, { label: string; color: string; criterion: string; href: string; valueLabel: string }> = {
-  share_broker:    { label: "Stock brokers",  color: "#60a5fa", criterion: "by total cost on $200/month DCA", href: "/share-trading", valueLabel: "Trade" },
-  super_fund:      { label: "Super funds",    color: "#34d399", criterion: "by 10-yr balanced return net of fees", href: "/super",       valueLabel: "Fee" },
-  savings_account: { label: "Savings",        color: "#fbbf24", criterion: "by max bonus rate (conditions met)",   href: "/savings",     valueLabel: "Rate" },
-  crypto_exchange: { label: "Crypto",         color: "#a78bfa", criterion: "by maker/taker fee on AUD pairs",      href: "/crypto",      valueLabel: "Fee" },
-  term_deposit:    { label: "Term deposits",  color: "#f59e0b", criterion: "by 12-month rate at $50k",             href: "/term-deposits", valueLabel: "Rate" },
-  robo_advisor:    { label: "Robo / managed", color: "#94a3b8", criterion: "by all-in fee on $50k portfolio",      href: "/robo-advisors", valueLabel: "Fee" },
+  share_broker:    { label: "Stock brokers",  color: "#2563eb", criterion: "by total cost on $200/month DCA", href: "/share-trading", valueLabel: "Trade" },
+  super_fund:      { label: "Super funds",    color: "#059669", criterion: "by 10-yr balanced return net of fees", href: "/super",       valueLabel: "Fee" },
+  savings_account: { label: "Savings",        color: "#d97706", criterion: "by max bonus rate (conditions met)",   href: "/savings",     valueLabel: "Rate" },
+  crypto_exchange: { label: "Crypto",         color: "#7c3aed", criterion: "by maker/taker fee on AUD pairs",      href: "/crypto",      valueLabel: "Fee" },
+  term_deposit:    { label: "Term deposits",  color: "#ea580c", criterion: "by 12-month rate at $50k",             href: "/term-deposits", valueLabel: "Rate" },
+  robo_advisor:    { label: "Robo / managed", color: "#475569", criterion: "by all-in fee on $50k portfolio",      href: "/robo-advisors", valueLabel: "Fee" },
 };
 
 interface HomeCompareDeepDiveProps {
@@ -79,18 +69,16 @@ export default function HomeCompareDeepDive({ brokers }: HomeCompareDeepDiveProp
     <section
       style={{
         padding: "52px 36px",
-        background: "var(--color-ink-900)",
-        color: "white",
+        background: "white",
+        color: "var(--color-ink-900)",
+        borderTop: "1px solid #e5e7eb",
         position: "relative",
-        overflow: "hidden",
       }}
     >
-      <div aria-hidden className="iv2-dotgrid" style={{ position: "absolute", inset: 0, opacity: 0.4, pointerEvents: "none" }} />
-
       <div style={{ position: "relative", maxWidth: 1280, margin: "0 auto" }}>
-        <div style={{ display: "flex", alignItems: "flex-end", justifyContent: "space-between", marginBottom: 18, gap: 16, flexWrap: "wrap" }}>
+        <div style={{ display: "flex", alignItems: "flex-end", justifyContent: "space-between", marginBottom: 22, gap: 16, flexWrap: "wrap" }}>
           <div>
-            <span className="iv2-mini" style={{ color: "var(--color-coral-300)" }}>
+            <span className="iv2-mini" style={{ color: "var(--color-coral-600)" }}>
               ● Compare · {brokers.length} platforms · verified monthly
             </span>
             <h2
@@ -101,7 +89,6 @@ export default function HomeCompareDeepDive({ brokers }: HomeCompareDeepDiveProp
                 fontWeight: 800,
                 margin: "4px 0 0",
                 lineHeight: 1.05,
-                color: "white",
               }}
             >
               Every fee. Seven categories. One source.
@@ -112,7 +99,7 @@ export default function HomeCompareDeepDive({ brokers }: HomeCompareDeepDiveProp
           </Link>
         </div>
 
-        <div style={{ display: "flex", gap: 6, marginBottom: 14, flexWrap: "wrap", borderBottom: "1px solid rgba(255,255,255,.1)" }}>
+        <div style={{ display: "flex", gap: 6, marginBottom: 18, flexWrap: "wrap", borderBottom: "1px solid #e5e7eb" }}>
           {tabs.map((t) => {
             const active = activeTab === t.key;
             return (
@@ -127,60 +114,17 @@ export default function HomeCompareDeepDive({ brokers }: HomeCompareDeepDiveProp
                   cursor: "pointer",
                   border: "none",
                   background: "none",
-                  color: active ? "white" : "rgba(255,255,255,.5)",
-                  borderBottom: active ? "2px solid var(--color-coral-400)" : "2px solid transparent",
+                  color: active ? "var(--color-ink-900)" : "var(--color-ink-400)",
+                  borderBottom: active ? "2px solid var(--color-coral-500)" : "2px solid transparent",
                   marginBottom: -1,
                   fontFamily: "inherit",
                 }}
               >
                 {t.label}
-                <span style={{ fontSize: 10.5, color: "rgba(255,255,255,.4)", fontWeight: 500, marginLeft: 3 }}>{t.n}</span>
+                <span style={{ fontSize: 10.5, color: "var(--color-ink-400)", fontWeight: 500, marginLeft: 4 }}>{t.n}</span>
               </button>
             );
           })}
-        </div>
-
-        <div
-          style={{
-            display: "flex",
-            gap: 6,
-            marginBottom: 14,
-            flexWrap: "wrap",
-            alignItems: "center",
-          }}
-        >
-          <span
-            className="font-mono"
-            style={{
-              fontSize: 9.5,
-              color: "rgba(255,255,255,.4)",
-              fontWeight: 700,
-              textTransform: "uppercase",
-              letterSpacing: ".08em",
-              marginRight: 4,
-            }}
-          >
-            Quick filters
-          </span>
-          {QUICK_FILTERS.map((f) => (
-            <Link
-              key={f.label}
-              href={f.href}
-              style={{
-                padding: "5px 10px",
-                fontSize: 11.5,
-                fontWeight: 600,
-                color: "rgba(255,255,255,.85)",
-                background: "rgba(255,255,255,.05)",
-                border: "1px solid rgba(255,255,255,.1)",
-                borderRadius: 99,
-                textDecoration: "none",
-                whiteSpace: "nowrap",
-              }}
-            >
-              {f.label}
-            </Link>
-          ))}
         </div>
 
         <div className="home-compare-grid" style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 12 }}>
@@ -193,20 +137,21 @@ export default function HomeCompareDeepDive({ brokers }: HomeCompareDeepDiveProp
               <div
                 key={key}
                 style={{
-                  background: "rgba(255,255,255,.04)",
-                  border: "1px solid rgba(255,255,255,.08)",
+                  background: "white",
+                  border: "1px solid #e5e7eb",
                   borderRadius: 12,
                   overflow: "hidden",
                   display: "flex",
                   flexDirection: "column",
+                  boxShadow: "0 1px 2px rgba(11,20,34,.04)",
                 }}
               >
-                <div style={{ padding: "12px 14px", borderBottom: "1px solid rgba(255,255,255,.08)" }}>
+                <div style={{ padding: "12px 14px", borderBottom: "1px solid #f1f5f9" }}>
                   <div style={{ display: "flex", alignItems: "center", gap: 7, marginBottom: 3 }}>
                     <span aria-hidden style={{ width: 7, height: 7, borderRadius: 99, background: meta.color }} />
-                    <span style={{ fontSize: 13, fontWeight: 700, color: "white" }}>{meta.label}</span>
+                    <span style={{ fontSize: 13, fontWeight: 700, color: "var(--color-ink-900)" }}>{meta.label}</span>
                   </div>
-                  <div style={{ fontSize: 10.5, color: "rgba(255,255,255,.5)" }}>Ranked {meta.criterion}</div>
+                  <div style={{ fontSize: 10.5, color: "var(--color-ink-500)" }}>Ranked {meta.criterion}</div>
                 </div>
                 {rows.map((row, j) => {
                   const isPromoted = !!row.promoted_placement || row.sponsorship_tier === "featured_partner" || row.sponsorship_tier === "deal_of_month";
@@ -228,28 +173,28 @@ export default function HomeCompareDeepDive({ brokers }: HomeCompareDeepDiveProp
                         gridTemplateColumns: "22px 26px 1fr auto auto",
                         gap: 9,
                         alignItems: "center",
-                        borderBottom: j < rows.length - 1 ? "1px solid rgba(255,255,255,.06)" : "none",
-                        background: isPromoted ? "rgba(242,88,34,.08)" : "transparent",
+                        borderBottom: j < rows.length - 1 ? "1px solid #f1f5f9" : "none",
+                        background: isPromoted ? "rgba(242,88,34,.06)" : "transparent",
                       }}
                     >
-                      <span className="font-mono" style={{ fontSize: 9.5, color: "rgba(255,255,255,.4)", fontWeight: 700 }}>
+                      <span className="font-mono" style={{ fontSize: 9.5, color: "var(--color-ink-400)", fontWeight: 700 }}>
                         0{j + 1}
                       </span>
                       <Logo name={initials} bg={row.color ?? "var(--color-ink-700)"} size={24} />
                       <div style={{ minWidth: 0 }}>
-                        <div style={{ fontSize: 12.5, fontWeight: 700, color: "white", display: "flex", alignItems: "center", gap: 5 }}>
+                        <div style={{ fontSize: 12.5, fontWeight: 700, color: "var(--color-ink-900)", display: "flex", alignItems: "center", gap: 5 }}>
                           <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{row.name}</span>
                           {isPromoted ? <SponsorChip kind="promoted" /> : isEditor ? <SponsorChip kind="editor" /> : null}
                         </div>
-                        <div className="font-mono tnum" style={{ fontSize: 10.5, color: "rgba(255,255,255,.55)", marginTop: 1 }}>
+                        <div className="font-mono tnum" style={{ fontSize: 10.5, color: "var(--color-ink-500)", marginTop: 1 }}>
                           {meta.valueLabel} {value}
                         </div>
                       </div>
-                      <span style={{ fontSize: 12, fontWeight: 700, color: "white", display: "inline-flex", alignItems: "center", gap: 3, whiteSpace: "nowrap" }}>
-                        <span style={{ color: "#fbbf24", fontSize: 11 }} aria-hidden>★</span>
+                      <span style={{ fontSize: 12, fontWeight: 700, color: "var(--color-ink-900)", display: "inline-flex", alignItems: "center", gap: 3, whiteSpace: "nowrap" }}>
+                        <span style={{ color: "#f59e0b", fontSize: 11 }} aria-hidden>★</span>
                         <span className="font-mono">{row.rating ? row.rating.toFixed(1) : "—"}</span>
                       </span>
-                      <DesignIcon name="arrow-right" size={10} style={{ color: "rgba(255,255,255,.4)" }} />
+                      <DesignIcon name="arrow-right" size={10} style={{ color: "var(--color-ink-400)" }} />
                     </div>
                   );
                 })}
@@ -262,7 +207,7 @@ export default function HomeCompareDeepDive({ brokers }: HomeCompareDeepDiveProp
                     color: meta.color,
                     background: "transparent",
                     border: "none",
-                    borderTop: "1px solid rgba(255,255,255,.06)",
+                    borderTop: "1px solid #f1f5f9",
                     textAlign: "center",
                     textDecoration: "none",
                   }}
@@ -279,8 +224,8 @@ export default function HomeCompareDeepDive({ brokers }: HomeCompareDeepDiveProp
           style={{
             marginTop: 18,
             padding: "14px 18px",
-            background: "rgba(255,255,255,.04)",
-            border: "1px solid rgba(255,255,255,.08)",
+            background: "var(--color-sand-50)",
+            border: "1px solid #e5e7eb",
             borderRadius: 12,
             display: "flex",
             alignItems: "center",
@@ -294,7 +239,7 @@ export default function HomeCompareDeepDive({ brokers }: HomeCompareDeepDiveProp
               className="font-mono"
               style={{
                 fontSize: 9.5,
-                color: "rgba(255,255,255,.4)",
+                color: "var(--color-ink-400)",
                 fontWeight: 700,
                 textTransform: "uppercase",
                 letterSpacing: ".08em",
@@ -302,7 +247,7 @@ export default function HomeCompareDeepDive({ brokers }: HomeCompareDeepDiveProp
             >
               Not sure where to start?
             </span>
-            <span style={{ fontSize: 13.5, fontWeight: 700, color: "white" }}>
+            <span style={{ fontSize: 13.5, fontWeight: 700, color: "var(--color-ink-900)" }}>
               Filter {brokers.length} platforms by your criteria — fees, features, regulator.
             </span>
           </div>
@@ -313,12 +258,7 @@ export default function HomeCompareDeepDive({ brokers }: HomeCompareDeepDiveProp
             <Link
               href="/compare"
               className="iv2-cta-ghost"
-              style={{
-                fontSize: 12.5,
-                color: "white",
-                borderColor: "rgba(255,255,255,.2)",
-                background: "transparent",
-              }}
+              style={{ fontSize: 12.5 }}
             >
               Open full comparison
             </Link>

--- a/components/HomeListingsTeaser.tsx
+++ b/components/HomeListingsTeaser.tsx
@@ -1,6 +1,3 @@
-"use client";
-
-import { useState, useMemo } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { DesignIcon } from "@/components/design/DesignIcon";
@@ -40,19 +37,7 @@ interface HomeListingsTeaserProps {
 }
 
 export default function HomeListingsTeaser({ listings, totalCount }: HomeListingsTeaserProps) {
-  const tabs = useMemo(() => {
-    const counts = new Map<string, number>();
-    for (const l of listings) {
-      counts.set(l.vertical, (counts.get(l.vertical) ?? 0) + 1);
-    }
-    const entries = Array.from(counts.entries())
-      .sort((a, b) => b[1] - a[1])
-      .slice(0, 8);
-    return [{ key: "All", label: "All", n: totalCount }, ...entries.map(([k, n]) => ({ key: k, label: VERTICAL_LABELS[k]?.label ?? k, n }))];
-  }, [listings, totalCount]);
-
-  const [activeTab, setActiveTab] = useState<string>("All");
-  const visible = activeTab === "All" ? listings.slice(0, 6) : listings.filter((l) => l.vertical === activeTab).slice(0, 6);
+  const visible = listings.slice(0, 6);
 
   return (
     <section
@@ -63,7 +48,7 @@ export default function HomeListingsTeaser({ listings, totalCount }: HomeListing
       }}
     >
       <div style={{ maxWidth: 1280, margin: "0 auto" }}>
-        <div style={{ display: "flex", alignItems: "flex-end", justifyContent: "space-between", marginBottom: 18, gap: 16, flexWrap: "wrap" }}>
+        <div style={{ display: "flex", alignItems: "flex-end", justifyContent: "space-between", marginBottom: 22, gap: 16, flexWrap: "wrap" }}>
           <div>
             <span className="iv2-mini" style={{ color: "var(--color-coral-600)" }}>
               ● The Marketplace · {totalCount} live listings
@@ -86,81 +71,10 @@ export default function HomeListingsTeaser({ listings, totalCount }: HomeListing
           </Link>
         </div>
 
-        <div
-          style={{
-            display: "flex",
-            alignItems: "center",
-            gap: 6,
-            marginBottom: 14,
-            borderBottom: "1px solid #e5e7eb",
-            flexWrap: "wrap",
-          }}
-        >
-          {tabs.map((t) => {
-            const active = activeTab === t.key;
-            return (
-              <button
-                key={t.key}
-                type="button"
-                onClick={() => setActiveTab(t.key)}
-                style={{
-                  padding: "9px 12px",
-                  fontSize: 12.5,
-                  fontWeight: 600,
-                  cursor: "pointer",
-                  border: "none",
-                  background: "none",
-                  color: active ? "var(--color-ink-900)" : "var(--color-ink-400)",
-                  borderBottom: active ? "2px solid var(--color-coral-500)" : "2px solid transparent",
-                  marginBottom: -1,
-                  fontFamily: "inherit",
-                }}
-              >
-                {t.label}
-                <span style={{ fontSize: 10.5, color: "var(--color-ink-400)", fontWeight: 500, marginLeft: 4 }}>{t.n}</span>
-              </button>
-            );
-          })}
-          <Link
-            href="/invest/listings"
-            className="home-listings-facets"
-            style={{
-              marginLeft: "auto",
-              display: "flex",
-              gap: 6,
-              alignItems: "center",
-              paddingBottom: 6,
-              textDecoration: "none",
-            }}
-            aria-label="Filter listings (full filters on browse page)"
-          >
-            {["$ Min", "Yield", "Term", "Status"].map((f) => (
-              <span
-                key={f}
-                style={{
-                  padding: "5px 10px",
-                  borderRadius: 99,
-                  fontSize: 11,
-                  fontWeight: 600,
-                  border: "1px solid #e5e7eb",
-                  background: "white",
-                  color: "var(--color-ink-500)",
-                  display: "inline-flex",
-                  alignItems: "center",
-                  gap: 4,
-                }}
-              >
-                {f}
-                <DesignIcon name="chevron-down" size={9} />
-              </span>
-            ))}
-          </Link>
-        </div>
-
         <div className="home-listings-grid" style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 12 }}>
           {visible.length === 0 && (
             <div style={{ gridColumn: "1 / -1", padding: "36px 18px", textAlign: "center", color: "var(--color-ink-400)", fontSize: 13 }}>
-              No listings in this category yet — <Link href="/invest/listings" style={{ color: "var(--color-coral-600)", fontWeight: 700 }}>browse all</Link>.
+              No listings yet — <Link href="/invest/listings" style={{ color: "var(--color-coral-600)", fontWeight: 700 }}>browse all</Link>.
             </div>
           )}
           {visible.map((l) => {
@@ -264,9 +178,6 @@ export default function HomeListingsTeaser({ listings, totalCount }: HomeListing
       <style>{`
         @media (max-width: 1024px) {
           .home-listings-grid { grid-template-columns: repeat(2, 1fr) !important; }
-        }
-        @media (max-width: 768px) {
-          .home-listings-facets { display: none !important; }
         }
         @media (max-width: 640px) {
           .home-listings-grid { grid-template-columns: 1fr !important; }


### PR DESCRIPTION
## Phase 3 of homepage v4 redesign

Independent of Phase 1 ([#329](https://github.com/Funs7575/invest-com-au/pull/329)). Both can land in either order.

## What changed

| # | Change | File |
|---|---|---|
| 8 | Drop the marketplace filter chip row (8 vertical tabs + 4 sub-filter chips = 13 controls) — show 6 listing cards + section-header "Browse all N →" only | `HomeListingsTeaser.tsx` |
| — | HomeListingsTeaser becomes a server component (no interactivity left) — small bundle win | `HomeListingsTeaser.tsx` |
| 9 | Drop the platform comparison QUICK_FILTERS chip row (CHESS / HISA / Robo · all-in fee / Editor's picks) — expert vocabulary on a homepage | `HomeCompareDeepDive.tsx` |
| 11 | Convert platform comparison section from dark (`var(--color-ink-900)`) to light (white) — methodology becomes the only deep-dark band | `HomeCompareDeepDive.tsx` |

## Why

Filtering on a homepage is a power-user task on a discovery surface — those controls belong on `/marketplace` and `/compare`. A first-time visitor sees 13 chips on the marketplace section and 7 quick-filter chips on the comparison section before they've even read what the page does.

Visual weight should match conversion priority. The platform comparison section was a full dark-mode block taking up roughly a third of the homepage height — heavier than the marketplace and advisor sections above it. It's volume traffic, not high-LTV. Lightening it lets the methodology section ("Zero of our revenue is a commission") be the only deep-dark band below the hero, where it carries real differentiation.

## Test plan

- [ ] Vercel preview marketplace section shows just 6 cards + "Browse all N →" header link — no vertical tabs, no `$ Min · Yield · Term · Status` chips
- [ ] Vercel preview platform comparison section is white/light (not dark) — text contrast looks correct on all rows
- [ ] Platform comparison still shows category tabs (Stock brokers / Super funds / Crypto / etc.) — those are intentional
- [ ] No QUICK_FILTERS chip row on the comparison section
- [ ] Promoted/featured rows still highlighted (now amber on white instead of amber on dark)
- [ ] CI green
- [ ] Mobile rendering — both sections stack cleanly with the new simpler layouts

## Out of scope (next phases)
- P2: four-ways grid restructure ("Post a job" replaces quiz card; equal-weight visual treatment)
- P4: trust polish (advisor card simplification, plain-English corridor cards, dedicated post-a-job section, raw-enum fix)
- P5: nav + sticky banner audit
- P6: optional methodology relocation