### PR TITLE
feat(home): trust polish — enum fix, plain-English corridors, post-a-job section [Phase 4]

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import HomeHero from "@/components/HomeHero";
 import HomePillarsGrid from "@/components/HomePillarsGrid";
 import HomeListingsTeaser, { type HomeListing } from "@/components/HomeListingsTeaser";
 import HomeAdvisorsTeaser, { type HomeAdvisor } from "@/components/HomeAdvisorsTeaser";
+import HomePostAJob from "@/components/HomePostAJob";
 import HomeCompareDeepDive, { type CompareBroker } from "@/components/HomeCompareDeepDive";
 import HomeCrossBorder from "@/components/HomeCrossBorder";
 import HomeFridayBriefing from "@/components/HomeFridayBriefing";
@@ -214,6 +215,10 @@ export default async function HomePage() {
 
       <ScrollFadeIn>
         <HomeAdvisorsTeaser advisors={advisorList} totalCount={totalProfessionalCount} />
+      </ScrollFadeIn>
+
+      <ScrollFadeIn>
+        <HomePostAJob />
       </ScrollFadeIn>
 
       <ScrollFadeIn>

--- a/components/HomeAdvisorsTeaser.tsx
+++ b/components/HomeAdvisorsTeaser.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { DesignIcon } from "@/components/design/DesignIcon";
+import { PROFESSIONAL_TYPE_LABELS, type ProfessionalType } from "@/lib/types";
 
 export interface HomeAdvisor {
   slug: string;
@@ -20,16 +21,19 @@ export interface HomeAdvisor {
   verified: boolean | null;
 }
 
-const TYPE_LABEL: Record<string, string> = {
-  financial_planner: "Financial Planner",
-  mortgage_broker: "Mortgage Broker",
-  smsf_accountant: "SMSF Specialist",
-  tax_agent: "Tax Agent",
-  buyers_agent: "Buyer's Agent",
-  insurance_broker: "Insurance Broker",
-  estate_planner: "Estate Planner",
-  wealth_manager: "Wealth Manager",
-};
+// Look up a human label for any advisor type. Falls back to a Title-cased
+// version of the raw enum (e.g. "real_estate_agent" → "Real Estate Agent")
+// rather than letting the raw snake_case key leak into the UI when a new
+// type lands in the DB before PROFESSIONAL_TYPE_LABELS is updated.
+function formatAdvisorType(key: string): string {
+  if (key in PROFESSIONAL_TYPE_LABELS) {
+    return PROFESSIONAL_TYPE_LABELS[key as ProfessionalType];
+  }
+  return key
+    .split("_")
+    .map((w) => (w.length > 0 ? w[0]!.toUpperCase() + w.slice(1) : w))
+    .join(" ");
+}
 
 interface HomeAdvisorsTeaserProps {
   advisors: ReadonlyArray<HomeAdvisor>;
@@ -45,7 +49,7 @@ export default function HomeAdvisorsTeaser({ advisors, totalCount }: HomeAdvisor
     const entries = Array.from(counts.entries())
       .sort((a, b) => b[1] - a[1])
       .slice(0, 5);
-    return [{ key: "All", label: "All", n: totalCount }, ...entries.map(([k, n]) => ({ key: k, label: TYPE_LABEL[k] ?? k, n }))];
+    return [{ key: "All", label: "All", n: totalCount }, ...entries.map(([k, n]) => ({ key: k, label: formatAdvisorType(k), n }))];
   }, [advisors, totalCount]);
 
   const [filter, setFilter] = useState<string>("All");
@@ -179,7 +183,7 @@ export default function HomeAdvisorsTeaser({ advisors, totalCount }: HomeAdvisor
                     {a.verified && <DesignIcon name="shield-check" size={11} style={{ color: "var(--color-emerald-600)" }} />}
                   </div>
                   <div style={{ fontSize: 11, color: "var(--color-ink-500)", marginTop: 1 }}>
-                    {a.firm_name ?? (a.type ? TYPE_LABEL[a.type] ?? a.type : "Advisor")}
+                    {a.firm_name ?? (a.type ? formatAdvisorType(a.type) : "Advisor")}
                   </div>
                   <div style={{ fontSize: 10.5, color: "var(--color-ink-400)", marginTop: 1 }}>
                     {a.location_display ?? a.location_state ?? "Australia"}

--- a/components/HomeCrossBorder.tsx
+++ b/components/HomeCrossBorder.tsx
@@ -6,39 +6,39 @@ const CORRIDORS: ReadonlyArray<{
   code: string;
   title: string;
   tag: string;
-  lines: ReadonlyArray<string>;
+  blurb: string;
   advisers: number;
   href: string;
 }> = [
   {
     code: "GB",
-    title: "UK → AU",
+    title: "UK → Australia",
     tag: "Migrant",
-    lines: ["NHS / QROPS pension", "HMRC residency days"],
+    blurb: "Pension transfers, residency rules, and how to keep your UK tax sorted.",
     advisers: 34,
     href: "/foreign-investment/united-kingdom",
   },
   {
     code: "IN",
-    title: "India → AU",
+    title: "India → Australia",
     tag: "Migrant",
-    lines: ["NRI vs ROR status", "FEMA repatriation"],
+    blurb: "Resident-status rules, sending money out of India, and what changes when you arrive.",
     advisers: 37,
     href: "/foreign-investment/india",
   },
   {
     code: "CN",
-    title: "China → AU",
+    title: "China → Australia",
     tag: "Migrant",
-    lines: ["FX outflow ($50k)", "PRC property + AU tax"],
+    blurb: "Moving funds across the border, mainland property, and double-tax basics.",
     advisers: 24,
     href: "/foreign-investment/china",
   },
   {
     code: "US",
-    title: "US citizen in AU",
-    tag: "Dual / FATCA",
-    lines: ["FBAR + FATCA filing", "PFIC trap on AU ETFs"],
+    title: "US citizens in Australia",
+    tag: "Dual citizen",
+    blurb: "What the IRS still wants, plus the Australian funds you should and shouldn't own.",
     advisers: 28,
     href: "/foreign-investment/united-states",
   },
@@ -50,7 +50,7 @@ export default function HomeCrossBorder() {
       <div className="home-crossborder-header" style={{ display: "grid", gridTemplateColumns: "1.1fr 2fr", gap: 36, alignItems: "center", marginBottom: 18 }}>
         <div>
           <span className="iv2-mini" style={{ color: "var(--color-coral-600)" }}>
-            ● If your money has crossed a border
+            ● Cross-border · 8 country guides
           </span>
           <h2
             className="font-display"
@@ -63,10 +63,10 @@ export default function HomeCrossBorder() {
               textWrap: "balance",
             }}
           >
-            For visa holders, expats &amp; foreign investors.
+            Where are you investing from?
           </h2>
           <p style={{ fontSize: 12.5, color: "var(--color-ink-500)", margin: 0, maxWidth: 380, lineHeight: 1.5 }}>
-            Pick the situation that fits — we&apos;ll show you the right rules, advisors and deals.
+            For visa holders, expats &amp; foreign investors — we&apos;ll show you the right rules, advisors and deals.
           </p>
         </div>
         <div style={{ display: "flex", gap: 8, justifyContent: "flex-end", flexWrap: "wrap" }}>
@@ -105,24 +105,16 @@ export default function HomeCrossBorder() {
                 </div>
               </div>
             </div>
-            <ul style={{ listStyle: "none", padding: 0, margin: 0, display: "flex", flexDirection: "column", gap: 3 }}>
-              {p.lines.map((b) => (
-                <li
-                  key={b}
-                  style={{
-                    fontSize: 11,
-                    color: "var(--color-ink-500)",
-                    display: "flex",
-                    gap: 5,
-                    alignItems: "flex-start",
-                    lineHeight: 1.4,
-                  }}
-                >
-                  <span aria-hidden style={{ width: 3, height: 3, borderRadius: 99, background: "var(--color-coral-500)", marginTop: 5, flexShrink: 0 }} />
-                  {b}
-                </li>
-              ))}
-            </ul>
+            <p
+              style={{
+                fontSize: 11.5,
+                color: "var(--color-ink-500)",
+                margin: 0,
+                lineHeight: 1.45,
+              }}
+            >
+              {p.blurb}
+            </p>
             <div
               style={{
                 fontSize: 10,

--- a/components/HomePostAJob.tsx
+++ b/components/HomePostAJob.tsx
@@ -1,0 +1,147 @@
+import Link from "next/link";
+import { DesignIcon } from "@/components/design/DesignIcon";
+
+export default function HomePostAJob() {
+  return (
+    <section
+      style={{
+        background: "var(--color-sand-50)",
+        borderTop: "1px solid #e5e7eb",
+        borderBottom: "1px solid #e5e7eb",
+        padding: "52px 36px",
+      }}
+    >
+      <div style={{ maxWidth: 1080, margin: "0 auto" }}>
+        <div
+          className="home-postjob-grid"
+          style={{
+            display: "grid",
+            gridTemplateColumns: "1.2fr 1fr",
+            gap: 40,
+            alignItems: "center",
+          }}
+        >
+          <div>
+            <span className="iv2-mini" style={{ color: "var(--color-coral-600)" }}>
+              ● Reverse marketplace · always free
+            </span>
+            <h2
+              className="font-display"
+              style={{
+                fontSize: 30,
+                letterSpacing: "-.028em",
+                fontWeight: 800,
+                margin: "4px 0 0",
+                lineHeight: 1.05,
+                textWrap: "balance",
+              }}
+            >
+              Or describe what you need. They come to you.
+            </h2>
+            <p
+              style={{
+                fontSize: 15,
+                lineHeight: 1.55,
+                color: "var(--color-ink-600)",
+                margin: "14px 0 0",
+                maxWidth: 540,
+              }}
+            >
+              We send your brief to up to 5 verified advisors who specialise in your situation.
+              Average request gets 3&ndash;5 quotes within the first 24 hours. No obligation, free to post.
+            </p>
+
+            <div style={{ display: "flex", gap: 10, marginTop: 22, flexWrap: "wrap", alignItems: "center" }}>
+              <Link
+                href="/quotes/post"
+                className="iv2-cta"
+                style={{ fontSize: 14, padding: "12px 22px" }}
+              >
+                Post a job &mdash; free <DesignIcon name="arrow-right" size={13} strokeWidth={2.4} />
+              </Link>
+              <Link
+                href="/quotes/recent-wins"
+                className="iv2-cta-ghost"
+                style={{ fontSize: 13 }}
+              >
+                See recent jobs &amp; wins
+              </Link>
+            </div>
+          </div>
+
+          <ol
+            style={{
+              listStyle: "none",
+              padding: 0,
+              margin: 0,
+              display: "flex",
+              flexDirection: "column",
+              gap: 12,
+            }}
+          >
+            {(
+              [
+                ["1", "Describe what you need", "60 seconds. No email until you're ready to send."],
+                ["2", "We match advisors", "Up to 5 verified specialists relevant to your situation."],
+                ["3", "Quotes come back", "Most jobs hear back within a day. You pick — or pass."],
+              ] as const
+            ).map(([n, title, sub]) => (
+              <li
+                key={n}
+                style={{
+                  display: "flex",
+                  gap: 14,
+                  alignItems: "flex-start",
+                  padding: "14px 16px",
+                  background: "white",
+                  borderRadius: 12,
+                  border: "1px solid #e5e7eb",
+                  boxShadow: "0 1px 2px rgba(11,20,34,.04)",
+                }}
+              >
+                <span
+                  className="font-mono"
+                  style={{
+                    width: 26,
+                    height: 26,
+                    borderRadius: 99,
+                    background: "var(--color-coral-100)",
+                    color: "var(--color-coral-700)",
+                    fontWeight: 800,
+                    fontSize: 12,
+                    display: "inline-flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    flexShrink: 0,
+                  }}
+                  aria-hidden
+                >
+                  {n}
+                </span>
+                <div>
+                  <div style={{ fontSize: 13, fontWeight: 700, color: "var(--color-ink-900)" }}>
+                    {title}
+                  </div>
+                  <div
+                    style={{ fontSize: 12, color: "var(--color-ink-500)", marginTop: 2, lineHeight: 1.45 }}
+                  >
+                    {sub}
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ol>
+        </div>
+      </div>
+
+      <style>{`
+        @media (max-width: 900px) {
+          .home-postjob-grid {
+            grid-template-columns: 1fr !important;
+            gap: 24px !important;
+          }
+        }
+      `}</style>
+    </section>
+  );
+}


### PR DESCRIPTION
## Phase 4 of homepage v4 redesign

Built on top of Phases 1 ([#329](https://github.com/Funs7575/invest-com-au/pull/329) ✓ merged) and 3 ([#330](https://github.com/Funs7575/invest-com-au/pull/330) ✓ merged).

## What changed

| # | Change | File |
|---|---|---|
| 10 | Fix the raw enum leak — advisor type chips no longer render `real_estate_agent` / `debt_counsellor`. Use canonical `PROFESSIONAL_TYPE_LABELS` from `lib/types.ts` (covers all 30 types) with a defensive title-case fallback so this can't recur for new enum values | `HomeAdvisorsTeaser.tsx` |
| 11 | Rewrite international corridor cards in plain English. NHS / QROPS / HMRC / NRI / ROR / FEMA / FBAR / FATCA / PFIC are out — one tight blurb per corridor sells the click; the country page keeps all the depth | `HomeCrossBorder.tsx` |
| 16 | "Pick the situation that fits…" → **"Where are you investing from?"**. Moved the "visa holders, expats & foreign investors" framing to the body copy. Direct question reads stronger than a description | `HomeCrossBorder.tsx` |
| 14 | New `HomePostAJob` section between advisor preview and platform comparison. Surfaces the reverse-marketplace ("describe what you need, up to 5 verified advisors come back to you within 24h") — the structural moat Finder / Canstar can't replicate | `HomePostAJob.tsx` (new), `app/page.tsx` |

## Why

Three are bug-quality issues (raw enums, expert vocab on a discovery surface) and one is structural — Post-a-job was buried as a small CTA in another section's header. Reverse-marketplace is the strongest moat the platform has; it deserves real estate.

The 24h SLA on the new Post-a-job section is corroborated by existing copy on `/quotes` ("Average request gets 3–5 quotes within the first 24 hours") — not an aspirational promise.

## Pushback applied
- Did **not** simplify the advisor cards (#15) — fee/commission info is the strongest trust signal on the page; removing it would make the section read like Finder.
- Did **not** soften the SLA — checked existing UI, the 24h claim is already live elsewhere.

## Test plan

- [ ] Vercel preview advisor section: filter chips show "Real Estate Agent" / "Debt Counsellor" (not raw enums) when those types appear in the data
- [ ] Vercel preview corridor section: heading reads "Where are you investing from?"; cards show single-sentence blurbs in plain English (no QROPS / FEMA / FBAR / PFIC anywhere)
- [ ] Vercel preview: new "Or describe what you need…" Post-a-job section sits between advisor cards and platform comparison
- [ ] Post-a-job CTA routes to `/quotes/post`; secondary "See recent jobs & wins" routes to `/quotes/recent-wins`
- [ ] CI green
- [ ] Mobile: Post-a-job section stacks the 3-step list under the headline

## Out of scope (last phases)
- P2: four-ways grid restructure (visual heaviness, color rotation, "Post a job" replaces quiz card)
- P5: nav "Get Started" audit + sticky bottom banner metrics check
- P6: optional methodology relocation