### PR TITLE
feat(home): four-ways grid — Post-a-job replaces quiz, equal-weight treatment [Phase 2]

### DIFF
--- a/components/HomePillarsGrid.tsx
+++ b/components/HomePillarsGrid.tsx
@@ -16,64 +16,62 @@ export default function HomePillarsGrid({ listingCount, professionalCount, broke
     icon: string;
     accent: string;
     badge: string;
-    featured?: boolean;
   }> = [
     {
       title: "Compare platforms",
-      sub: "Brokers, super, crypto, savings, robo — fees side-by-side.",
+      sub: "Brokers, super, crypto, savings, robo — fees side-by-side, verified monthly.",
       cta: "Open comparisons",
       href: "/compare",
       icon: "trending-down",
-      accent: "#60a5fa",
+      accent: "#2563eb",
       badge: `${brokerCount} platforms`,
     },
     {
-      title: "Speak with an advisor",
-      sub: "ASIC-registered. Free quotes from verified pros.",
-      cta: "Find an advisor",
-      href: "/find-advisor",
+      title: "Find an advisor",
+      sub: "ASIC-registered. Browse 30+ specialties — planners, mortgage brokers, accountants.",
+      cta: "Browse advisors",
+      href: "/advisors",
       icon: "users",
       accent: "var(--color-coral-500)",
       badge: `${professionalCount.toLocaleString("en-AU")} advisors`,
-      featured: true,
+    },
+    {
+      title: "Post a job",
+      sub: "Describe what you need. Up to 5 verified advisors come back with quotes — free, no email needed to start.",
+      cta: "Post a job — free",
+      href: "/quotes/post",
+      icon: "megaphone",
+      accent: "#059669",
+      badge: "Quotes in 24h",
     },
     {
       title: "Browse listings",
-      sub: "Funds, businesses, farmland, mining, commercial property.",
+      sub: "Funds, businesses, farmland, mining, commercial property — vetted before they list.",
       cta: "Open marketplace",
       href: "/invest/listings",
       icon: "sparkles",
-      accent: "#fbbf24",
+      accent: "#d97706",
       badge: `${listingCount} live`,
-    },
-    {
-      title: "Take the 60-sec quiz",
-      sub: "Tell us your goal — we'll point you the right way.",
-      cta: "Start the quiz",
-      href: "/quiz",
-      icon: "compass",
-      accent: "#34d399",
-      badge: "60 seconds",
     },
   ];
 
   return (
-    <section style={{ padding: "44px 36px 48px", maxWidth: 1280, margin: "0 auto" }}>
-      <div style={{ marginBottom: 18 }}>
+    <section style={{ padding: "56px 36px 60px", maxWidth: 1280, margin: "0 auto" }}>
+      <div style={{ marginBottom: 24 }}>
         <span className="iv2-mini" style={{ color: "var(--color-coral-600)" }}>
-          ● Everything you can do here
+          ● Products · 4 ways to use invest.com.au
         </span>
         <h2
           className="font-display"
           style={{
-            fontSize: 30,
+            fontSize: 32,
             letterSpacing: "-.028em",
             fontWeight: 800,
-            margin: "4px 0 0",
+            margin: "6px 0 0",
             lineHeight: 1.05,
           }}
         >
-          Four ways to use invest.com.au.
+          Four products. One independent hub.
         </h2>
       </div>
 
@@ -86,57 +84,55 @@ export default function HomePillarsGrid({ listingCount, professionalCount, broke
             style={{
               display: "flex",
               flexDirection: "column",
-              background: p.featured ? "var(--color-ink-900)" : "white",
-              color: p.featured ? "white" : "var(--color-ink-900)",
-              border: p.featured ? `1.5px solid ${p.accent}` : "1px solid #e5e7eb",
-              borderTop: p.featured ? `1.5px solid ${p.accent}` : `3px solid ${p.accent}`,
+              background: "white",
+              color: "var(--color-ink-900)",
+              border: "1px solid #e5e7eb",
+              borderTop: `4px solid ${p.accent}`,
               borderRadius: 14,
-              padding: "26px 22px 22px",
+              padding: "30px 26px 26px",
               textDecoration: "none",
               position: "relative",
-              boxShadow: p.featured
-                ? `0 12px 32px color-mix(in oklch, ${p.accent} 20%, transparent)`
-                : "0 1px 0 rgba(0,0,0,.02)",
-              minHeight: 240,
+              boxShadow: "0 1px 2px rgba(11,20,34,.04)",
+              minHeight: 280,
             }}
           >
             <div
               aria-hidden
               style={{
-                width: 56,
-                height: 56,
-                borderRadius: 14,
-                background: `color-mix(in oklch, ${p.accent} ${p.featured ? 22 : 14}%, transparent)`,
+                width: 64,
+                height: 64,
+                borderRadius: 16,
+                background: `color-mix(in oklch, ${p.accent} 14%, transparent)`,
                 display: "flex",
                 alignItems: "center",
                 justifyContent: "center",
                 color: p.accent,
-                marginBottom: 16,
+                marginBottom: 20,
               }}
             >
-              <DesignIcon name={p.icon} size={28} strokeWidth={2.2} />
+              <DesignIcon name={p.icon} size={32} strokeWidth={2.2} />
             </div>
 
             <div
               className="font-display"
               style={{
-                fontSize: 21,
+                fontSize: 24,
                 fontWeight: 800,
-                lineHeight: 1.1,
-                letterSpacing: "-.022em",
-                marginBottom: 8,
+                lineHeight: 1.08,
+                letterSpacing: "-.024em",
+                marginBottom: 10,
                 textWrap: "balance",
-                color: p.featured ? "white" : "var(--color-ink-900)",
+                color: "var(--color-ink-900)",
               }}
             >
               {p.title}
             </div>
             <div
               style={{
-                fontSize: 13,
-                color: p.featured ? "rgba(255,255,255,.65)" : "var(--color-ink-500)",
-                lineHeight: 1.45,
-                marginBottom: 16,
+                fontSize: 13.5,
+                color: "var(--color-ink-500)",
+                lineHeight: 1.5,
+                marginBottom: 20,
                 flex: 1,
               }}
             >
@@ -159,9 +155,9 @@ export default function HomePillarsGrid({ listingCount, professionalCount, broke
                   color: p.accent,
                   textTransform: "uppercase",
                   letterSpacing: ".06em",
-                  background: `color-mix(in oklch, ${p.accent} ${p.featured ? 18 : 10}%, transparent)`,
-                  border: `1px solid color-mix(in oklch, ${p.accent} 30%, transparent)`,
-                  padding: "3px 8px",
+                  background: `color-mix(in oklch, ${p.accent} 10%, transparent)`,
+                  border: `1px solid color-mix(in oklch, ${p.accent} 28%, transparent)`,
+                  padding: "4px 9px",
                   borderRadius: 99,
                   whiteSpace: "nowrap",
                 }}
@@ -172,7 +168,7 @@ export default function HomePillarsGrid({ listingCount, professionalCount, broke
                 style={{
                   fontSize: 13,
                   fontWeight: 800,
-                  color: p.featured ? "white" : p.accent,
+                  color: p.accent,
                   display: "inline-flex",
                   alignItems: "center",
                   gap: 6,


### PR DESCRIPTION
## Phase 2 of homepage v4 redesign

Stacks on Phases 1 (#329 ✓), 3 (#330 ✓), 4 (#331).

## What changed

| # | Change | File |
|---|---|---|
| 6 | Replace "Take the 60-sec quiz" card with **"Post a job — free"**. Quiz is already the hero CTA — duplicating it as one of the four ways was redundant. Reverse-marketplace is the moat Finder/Canstar can't replicate; it deserves a top-level pillar slot | `HomePillarsGrid.tsx` |
| 7 | Equal-weight visual treatment. Drop the dark "featured" highlight on the advisor card — every card now has the same white bg + accent top-border, just rotating colours (blue / coral / emerald / amber). No card is the "favourite" | `HomePillarsGrid.tsx` |
| 7 | Heavier cards. Icon 56→64px, title 21→24pt, padding 26→30px, min-height 240→280px, more breathing room between blocks | `HomePillarsGrid.tsx` |
| 20 | Section header pattern: "Everything you can do here" → "Products · 4 ways to use invest.com.au" to match the rest of the page (`MARKETPLACE · 89 LIVE LISTINGS`, etc.). Headline tightened to "Four products. One independent hub." | `HomePillarsGrid.tsx` |
| — | Card title polish: "Speak with an advisor" → "Find an advisor" (less salesy). Advisor card now points to `/advisors` (browse) not `/find-advisor` (quiz funnel) — post-a-job is the matchmaking entry now | `HomePillarsGrid.tsx` |

## Why

The four-ways grid is the section that has to convert "I know I want to invest" into "I know which Invest.com.au product to use." That's a discovery decision, not a sales decision — so the section needs four equal-weight options that read as distinct products, not three options plus a marketing-styled funnel CTA.

## Pushback applied
- **Did not** ship real illustration / photography per card. That's a 1–2 week design lift requiring assets we don't have. Colour/typography/iconography differentiation gets ~80% of the visual weight at 0% of the asset cost; illustration is a v2 once the four-product framing is validated.

## Test plan

- [ ] Vercel preview: four cards with equal visual weight (no dark singled-out card)
- [ ] Top accent borders rotate colour: blue (compare) → coral (advisor) → emerald (post-a-job) → amber (listings)
- [ ] Third card reads "Post a job"; CTA "Post a job — free" routes to `/quotes/post`; badge reads "Quotes in 24h"
- [ ] No "Take the 60-sec quiz" card in this section (it's still the hero CTA)
- [ ] Section header reads "Products · 4 ways to use invest.com.au" / "Four products. One independent hub."
- [ ] Mobile: 4 → 2 → 1 column responsive collapse
- [ ] CI green

## Out of scope (last phases)
- P5: nav "Get Started" button audit + sticky bottom banner metrics check
- P6: optional methodology relocation