### PR TITLE
feat(home): move methodology section above the inventory [Phase 6]

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -208,6 +208,15 @@ export default async function HomePage() {
         />
       </ScrollFadeIn>
 
+      {/* Methodology section ("Zero of our revenue is a commission") moved
+          here between the four-ways grid and the marketplace teaser so the
+          trust signal lands BEFORE the visitor enters the inventory. By
+          the time they're scanning marketplace cards or platform fees,
+          they already know how the site is paid for. */}
+      <ScrollFadeIn>
+        <HomeHowWeEarn />
+      </ScrollFadeIn>
+
       <ScrollFadeIn>
         <HomeListingsTeaser listings={listingList} totalCount={totalListingCount} />
       </ScrollFadeIn>
@@ -226,10 +235,6 @@ export default async function HomePage() {
 
       <ScrollFadeIn>
         <HomeFridayBriefing />
-      </ScrollFadeIn>
-
-      <ScrollFadeIn>
-        <HomeHowWeEarn />
       </ScrollFadeIn>
 
       <MobileStickyAdvisorCta />


### PR DESCRIPTION
## Phase 6 of homepage v4 redesign — final structural change

Stacks on Phases 1 (#329 ✓), 3 (#330 ✓), 2 (#332), 4 (#331), 5 (#333). After this lands, the v4 redesign is complete.

## What changed

Single move: `HomeHowWeEarn` (the methodology section — "Zero of our revenue is a commission", 64 / 24 / 9 / 3% revenue-mix breakdown) goes from the bottom of the homepage to between `HomePillarsGrid` (four-ways) and `HomeListingsTeaser` (marketplace).

```diff
  <HomePillarsGrid />
+ <HomeHowWeEarn />            ← moved here
  <HomeListingsTeaser />
  <HomeAdvisorsTeaser />
  <HomeCompareDeepDive />
  <HomeCrossBorder />
  <HomeFridayBriefing />
- <HomeHowWeEarn />            ← was here
  <MobileStickyAdvisorCta />
```

## Why

The methodology section is the single strongest competitive differentiator on the homepage — Finder and Canstar are commission-funded, we're not. Burying it between the Friday Briefing and the mobile sticky was leaving leverage on the table. The new position puts the trust signal exactly between "here are the four products" and "here is the inventory" — by the time the visitor is scanning marketplace cards or platform fees, they already understand how the site is paid for.

## Pushback applied

The user's feedback note suggested **"above the international section"** as the new position. I went with **after the four-ways** instead, because the international section is itself a low-priority surface for the median Australian visitor — putting methodology above it would still leave it below five higher-traffic sections. After-four-ways is the highest-leverage placement that doesn't disrupt the marketing-funnel order.

## Test plan

- [ ] Vercel preview: methodology section now appears immediately after the four-ways grid (before marketplace, advisors, compare, cross-border, Friday Briefing)
- [ ] Section content unchanged (64% / 24% / 9% / 3% breakdown still renders, no copy edits)
- [ ] No methodology section at the bottom of the page (it moved, didn't duplicate)
- [ ] Mobile + desktop scroll order matches expectation
- [ ] CI green

## Out of scope
This is the final phase of the v4 redesign. Items intentionally not addressed:
- #15 advisor card density (kept fee/commission info per pushback — strongest trust signal)
- #19 footer density (defensible as power-user surface area)
- #21–25 in user feedback (already correct, "don't touch" items)