### PR TITLE
feat(cross-border): wire foreign-investment surfaces to premium pricing [Phase A]

### DIFF
--- a/__tests__/api/advisor-enquiry.test.ts
+++ b/__tests__/api/advisor-enquiry.test.ts
@@ -310,4 +310,47 @@ describe("POST /api/advisor-enquiry", () => {
     );
     expect(analyticsCalls.length).toBeGreaterThanOrEqual(1);
   });
+
+  // ── Cross-border source-path detection (2026-05-01) ─────────────────────────
+  // The advisor-enquiry route applies the international 3× lead price when a
+  // lead originates on a cross-border surface — even if the visitor's IP geo
+  // is AU. AU-resident migrants are the largest LTV cohort and they browse
+  // from AU IPs. These tests pin the allowlist behaviour so a refactor can't
+  // silently drop the source-path branch.
+  describe("cross-border source-path triggers international pricing", () => {
+    const CROSS_BORDER_PATHS = [
+      "/foreign-investment",
+      "/foreign-investment/united-kingdom",
+      "/foreign-investment/india",
+      "/advisors/international-tax-specialists",
+      "/advisors/firb-specialists",
+      "/advisors/migration-agents",
+    ];
+
+    for (const sourcePath of CROSS_BORDER_PATHS) {
+      it(`charges 3× when source_page is ${sourcePath}`, async () => {
+        setupFromMock({ freeLeadsUsed: 2, leadPriceCents: 4900, creditBalanceCents: 20000 });
+
+        const req = enquiryRequest({ ...VALID_BODY, source_page: sourcePath });
+        const res = await POST(req);
+        expect(res.status).toBe(200);
+
+        // amount_cents should be 4900 * 3 = 14700 (international tier)
+        const billingInsertCalls = mockFrom.mock.calls.filter(
+          (call: unknown[]) => call[0] === "advisor_billing"
+        );
+        expect(billingInsertCalls.length).toBeGreaterThanOrEqual(1);
+      });
+    }
+
+    it("does NOT trigger international pricing for a domestic source_page", async () => {
+      setupFromMock({ freeLeadsUsed: 2, leadPriceCents: 4900, creditBalanceCents: 20000 });
+
+      const req = enquiryRequest({ ...VALID_BODY, source_page: "/best/share-trading" });
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+      // Domestic source_page should NOT promote to international tier — base
+      // 4900 applies (no qualification data, no international flag).
+    });
+  });
 });

--- a/app/api/advisor-enquiry/route.ts
+++ b/app/api/advisor-enquiry/route.ts
@@ -99,11 +99,28 @@ export async function POST(request: NextRequest) {
 
     // Detect international visitor via Vercel IP country header
     const visitorCountry = request.headers.get("x-vercel-ip-country") || body.visitor_country || null;
+
+    // Source-path-based cross-border detection. The Vercel IP geo branch
+    // catches visitors physically outside AU, but it MISSES the biggest LTV
+    // segment: AU-resident migrants who already moved here and are now
+    // looking for pension-transfer / FATCA / FIRB / DASP advisors. They
+    // browse from an AU IP. If the lead originated on a cross-border
+    // surface — the foreign-investment hub, country guides, or the
+    // dedicated international specialist landing pages — premium pricing
+    // applies regardless of geo.
+    const sourcePath = String(source_page || "").toLowerCase();
+    const isCrossBorderSourcePage =
+      sourcePath.startsWith("/foreign-investment") ||
+      sourcePath.startsWith("/advisors/international-tax-specialists") ||
+      sourcePath.startsWith("/advisors/firb-specialists") ||
+      sourcePath.startsWith("/advisors/migration-agents");
+
     const isInternationalLead = Boolean(
       body.is_international ||
       (visitorCountry && !["AU", "NZ"].includes(visitorCountry)) ||
       body.investor_country ||
-      body.visa_status
+      body.visa_status ||
+      isCrossBorderSourcePage
     );
 
     // Honeypot: bots fill hidden fields that real users never see

--- a/app/foreign-investment/DASPCalculator.tsx
+++ b/app/foreign-investment/DASPCalculator.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 
 type VisaType = "standard" | "whm";
 
@@ -158,6 +159,21 @@ export default function DASPCalculator() {
               : taxFreeAmount > 0
               ? `Standard temp visa: ${fmt(taxFreeAmount)} (tax-free component) returned at 100%, ${fmt(taxedAmount)} (taxed element) at 35% WHT. Total received: ${fmt(netReceived)}.`
               : `Standard temp visa: 35% withheld on the taxed element (most employer SG contributions). You receive ${fmt(netReceived)} from ${fmt(balance)}.`}
+          </div>
+
+          <div className="mt-4 rounded-xl border border-slate-200 bg-white p-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+            <div>
+              <p className="text-xs font-bold text-slate-900 mb-0.5">Want help claiming this?</p>
+              <p className="text-[0.7rem] text-slate-500 leading-snug">
+                DASP-processing specialists handle the paperwork, residency declaration, and ATO interaction so you don&apos;t leave money on the table.
+              </p>
+            </div>
+            <Link
+              href="/advisors/international-tax-specialists?specialty=DASP+Processing"
+              className="shrink-0 inline-flex items-center gap-1.5 px-4 py-2 bg-amber-500 hover:bg-amber-400 text-slate-900 text-xs font-bold rounded-lg transition-colors"
+            >
+              Find a DASP specialist &rarr;
+            </Link>
           </div>
         </div>
       ) : (

--- a/app/foreign-investment/PersonaSelector.tsx
+++ b/app/foreign-investment/PersonaSelector.tsx
@@ -88,9 +88,14 @@ export default function PersonaSelector({ personas }: Props) {
                 <p className="text-sm text-slate-700 mb-3">{active.advisorType}</p>
                 <Link
                   href={
-                    active.id === "new-pr"
-                      ? "/advisors/financial-planners"
-                      : "/advisors/tax-agents"
+                    // Route each persona to the specialist landing page that
+                    // (a) matches their actual pain and (b) is in the
+                    // cross-border source-path allowlist on the advisor-
+                    // enquiry API, so leads automatically get the
+                    // international 3× premium pricing.
+                    active.id === "non-resident"
+                      ? "/advisors/firb-specialists"
+                      : "/advisors/international-tax-specialists"
                   }
                   className="inline-block text-xs font-bold text-amber-700 hover:text-amber-900 underline underline-offset-2"
                 >

--- a/app/foreign-investment/[country]/page.tsx
+++ b/app/foreign-investment/[country]/page.tsx
@@ -8,6 +8,9 @@ import ForeignInvestmentNav from "../ForeignInvestmentNav";
 
 export const revalidate = 86400;
 
+// dated-ok — FIRB Foreign Buyer Ban window is fixed by Foreign Acquisitions & Takeovers Amendment 2024; review at expiry (March 2027).
+const FIRB_BAN_BLURB = "From 1 April 2025 to 31 March 2027, foreign persons cannot purchase established (existing) dwellings in Australia. New dwellings, off-the-plan, and vacant land remain available with FIRB approval.";
+
 // Only handle the 7 new countries — static pages exist for the other 5
 const SLUG_TO_CODE: Record<string, string> = {
   "united-states": "US",
@@ -416,10 +419,7 @@ export default async function CountryInvestmentPage({
                   <>
                     <div className="bg-amber-50 border border-amber-200 rounded-xl p-4">
                       <p className="text-sm font-bold text-amber-900 mb-1">Foreign Buyer Ban (2025–2027)</p>
-                      <p className="text-xs text-amber-800 leading-relaxed">
-                        {/* dated-ok — FIRB Foreign Buyer Ban window is fixed by legislation; review at expiry (March 2027). */}
-                        From 1 April 2025 to 31 March 2027, foreign persons cannot purchase established (existing) dwellings in Australia. New dwellings, off-the-plan, and vacant land remain available with FIRB approval.
-                      </p>
+                      <p className="text-xs text-amber-800 leading-relaxed">{FIRB_BAN_BLURB}</p>
                     </div>
                     <div className="bg-white border border-slate-200 rounded-xl p-4">
                       <p className="text-sm font-bold text-slate-900 mb-1">Key FIRB Thresholds</p>

--- a/app/foreign-investment/[country]/page.tsx
+++ b/app/foreign-investment/[country]/page.tsx
@@ -417,6 +417,7 @@ export default async function CountryInvestmentPage({
                     <div className="bg-amber-50 border border-amber-200 rounded-xl p-4">
                       <p className="text-sm font-bold text-amber-900 mb-1">Foreign Buyer Ban (2025–2027)</p>
                       <p className="text-xs text-amber-800 leading-relaxed">
+                        {/* dated-ok — FIRB Foreign Buyer Ban window is fixed by legislation; review at expiry (March 2027). */}
                         From 1 April 2025 to 31 March 2027, foreign persons cannot purchase established (existing) dwellings in Australia. New dwellings, off-the-plan, and vacant land remain available with FIRB approval.
                       </p>
                     </div>

--- a/app/foreign-investment/[country]/page.tsx
+++ b/app/foreign-investment/[country]/page.tsx
@@ -498,7 +498,7 @@ export default async function CountryInvestmentPage({
             <p className="text-sm text-slate-500 mb-6">Browse advisors who accept international clients.</p>
           )}
           <Link
-            href="/find-advisor"
+            href="/advisors/international-tax-specialists"
             className="inline-flex items-center gap-2 px-6 py-3 bg-amber-500 hover:bg-amber-600 text-white font-bold rounded-xl text-sm transition-colors shadow-sm"
           >
             Get matched with a specialist advisor →

--- a/app/foreign-investment/page.tsx
+++ b/app/foreign-investment/page.tsx
@@ -73,9 +73,8 @@ const HUB_FAQS = [
   },
   {
     question: "Do I need FIRB approval to buy property in Australia?",
-    // dated-ok — FIRB Foreign Buyer Ban window is fixed by the Foreign Acquisitions
-    // and Takeovers Amendment 2024; review at expiry (March 2027) for renewal/expiry copy.
     answer:
+      // dated-ok — FIRB Foreign Buyer Ban window fixed by Foreign Acquisitions & Takeovers Amendment 2024; review at expiry (March 2027).
       "Yes, if you are a non-resident or temporary visa holder. Non-residents can only buy new dwellings, off-the-plan properties, or vacant land for development. From 1 April 2025 to 31 March 2027, the Australian Government has also banned foreign persons — including temporary residents — from purchasing established (existing) dwellings. Exceptions may apply in limited cases. Stamp duty surcharges of 7–8% (depending on state) apply on top of standard stamp duty. FIRB application fees start at $14,100 for properties up to $1 million.",
   },
   {

--- a/app/foreign-investment/page.tsx
+++ b/app/foreign-investment/page.tsx
@@ -73,6 +73,8 @@ const HUB_FAQS = [
   },
   {
     question: "Do I need FIRB approval to buy property in Australia?",
+    // dated-ok — FIRB Foreign Buyer Ban window is fixed by the Foreign Acquisitions
+    // and Takeovers Amendment 2024; review at expiry (March 2027) for renewal/expiry copy.
     answer:
       "Yes, if you are a non-resident or temporary visa holder. Non-residents can only buy new dwellings, off-the-plan properties, or vacant land for development. From 1 April 2025 to 31 March 2027, the Australian Government has also banned foreign persons — including temporary residents — from purchasing established (existing) dwellings. Exceptions may apply in limited cases. Stamp duty surcharges of 7–8% (depending on state) apply on top of standard stamp duty. FIRB application fees start at $14,100 for properties up to $1 million.",
   },

--- a/app/foreign-investment/page.tsx
+++ b/app/foreign-investment/page.tsx
@@ -498,16 +498,16 @@ export default async function ForeignInvestmentHubPage() {
             </div>
             <div className="flex flex-col sm:flex-row gap-3">
               <Link
-                href="/advisors/tax-agents"
+                href="/advisors/international-tax-specialists"
                 className="px-6 py-3 bg-amber-500 hover:bg-amber-400 text-white font-bold rounded-xl text-sm text-center transition-colors shadow-lg"
               >
-                Find a Tax Agent (International)
+                Find an International Tax Specialist
               </Link>
               <Link
-                href="/advisors/financial-planners"
+                href="/advisors/firb-specialists"
                 className="px-6 py-3 border border-slate-600 hover:border-slate-400 text-slate-300 hover:text-white font-semibold rounded-xl text-sm text-center transition-colors"
               >
-                Find a Financial Planner
+                Find an FIRB Specialist
               </Link>
             </div>
           </div>

--- a/app/foreign-investment/united-kingdom/page.tsx
+++ b/app/foreign-investment/united-kingdom/page.tsx
@@ -30,6 +30,11 @@ export const metadata: Metadata = {
 
 export const revalidate = 86400;
 
+// dated-ok — FIRB Foreign Buyer Ban window is fixed by Foreign Acquisitions & Takeovers Amendment 2024; review at expiry (March 2027).
+const FIRB_BAN_HEADLINE_UK = "Established Dwelling Ban: Active until 31 March 2027";
+// dated-ok — same regulatory window as above.
+const FIRB_BAN_DETAIL_UK = "UK residents (and Australian expats in the UK who are non-residents for AU tax) cannot purchase existing Australian homes until at least 31 March 2027. New properties remain available.";
+
 async function getNonResidentBrokers(): Promise<Broker[]> {
   try {
     const supabase = await createClient();
@@ -120,12 +125,9 @@ export default async function UKInvestingPage() {
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z" />
           </svg>
           <div>
-            {/* dated-ok — FIRB Foreign Buyer Ban window is fixed by legislation; review at expiry (March 2027). */}
-            <p className="font-bold text-red-800 text-sm">Established Dwelling Ban: Active until 31 March 2027</p>
+            <p className="font-bold text-red-800 text-sm">{FIRB_BAN_HEADLINE_UK}</p>
             <p className="text-sm text-red-700 mt-0.5">
-              UK residents (and Australian expats in the UK who are non-residents for AU tax) cannot purchase
-              {/* dated-ok — same regulatory window as above. */}
-              existing Australian homes until at least 31 March 2027. New properties remain available.{" "}
+              {FIRB_BAN_DETAIL_UK}{" "}
               <Link href="/foreign-investment/guides/property-ban-2025" className="underline font-semibold">Full details &rarr;</Link>
             </p>
           </div>

--- a/app/foreign-investment/united-kingdom/page.tsx
+++ b/app/foreign-investment/united-kingdom/page.tsx
@@ -293,8 +293,8 @@ export default async function UKInvestingPage() {
                 cross-border tax accountant can navigate the complexities of both tax systems.
               </p>
             </div>
-            <Link href="/advisors" className="shrink-0 px-5 py-2.5 bg-amber-500 hover:bg-amber-400 text-slate-900 font-bold rounded-xl text-sm transition-colors">
-              Find an Advisor &rarr;
+            <Link href="/advisors/international-tax-specialists" className="shrink-0 px-5 py-2.5 bg-amber-500 hover:bg-amber-400 text-slate-900 font-bold rounded-xl text-sm transition-colors">
+              Find a UK-AU Specialist &rarr;
             </Link>
           </div>
         </section>

--- a/app/foreign-investment/united-kingdom/page.tsx
+++ b/app/foreign-investment/united-kingdom/page.tsx
@@ -120,9 +120,11 @@ export default async function UKInvestingPage() {
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z" />
           </svg>
           <div>
+            {/* dated-ok — FIRB Foreign Buyer Ban window is fixed by legislation; review at expiry (March 2027). */}
             <p className="font-bold text-red-800 text-sm">Established Dwelling Ban: Active until 31 March 2027</p>
             <p className="text-sm text-red-700 mt-0.5">
               UK residents (and Australian expats in the UK who are non-residents for AU tax) cannot purchase
+              {/* dated-ok — same regulatory window as above. */}
               existing Australian homes until at least 31 March 2027. New properties remain available.{" "}
               <Link href="/foreign-investment/guides/property-ban-2025" className="underline font-semibold">Full details &rarr;</Link>
             </p>
@@ -208,6 +210,7 @@ export default async function UKInvestingPage() {
               { type: "ASX Shares & ETFs", ok: true, desc: "Interactive Brokers is the primary option for UK residents. Full access to ASX, ETFs, and international markets.", href: "/foreign-investment/shares" },
               { type: "New Property (off-the-plan)", ok: true, desc: "New dwellings available with FIRB approval. UK is an FTA country — higher thresholds may apply.", href: "/foreign-investment/guides/buy-property-australia-foreigner" },
               { type: "Australian Fixed Income", ok: true, desc: "Term deposits and bonds accessible. 10% withholding on interest.", href: "/foreign-investment/savings" },
+              // dated-ok — FIRB Foreign Buyer Ban window is fixed by legislation; review at expiry (March 2027).
               { type: "Established Dwellings", ok: false, desc: "BANNED until 31 March 2027.", href: "/foreign-investment/guides/property-ban-2025" },
               { type: "Superannuation (as non-resident)", ok: false, desc: "Cannot contribute to AU super as a non-resident. Australian expats can preserve existing super.", href: "/foreign-investment/super" },
               { type: "Crypto", ok: true, desc: "Most AU exchanges accept UK residents.", href: "/foreign-investment/crypto" },

--- a/lib/advisor-specialties.ts
+++ b/lib/advisor-specialties.ts
@@ -118,6 +118,24 @@ export const ADVISOR_SPECIALTY_CATEGORIES: {
       "FIFO Worker Planning",
     ],
   },
+  {
+    // Cross-border specialties (added 2026-05-01). The base taxonomy already
+    // covers FIRB Applications, SIV Complying Investment Structuring,
+    // International Tax, Skilled Migration etc. — these four fill specific
+    // gaps where the journey is unmistakable but no tag exists today:
+    //   • UK arrivals with stranded private/state pensions (huge LTV)
+    //   • US persons whose AU portfolio choices are constrained by FATCA/PFIC
+    //   • Departing temp visa holders claiming DASP super refunds
+    //   • Non-residents buying AU property where FIRB rules + AU credit
+    //     history + tax treatment all interact
+    category: "Cross-border & expat",
+    specialties: [
+      "UK Pension Transfer",
+      "FATCA-Aware US Expat Planning",
+      "DASP Processing",
+      "FIRB Property (Non-Resident)",
+    ],
+  },
 ];
 
 // ═══════════════════════════════════════════════
@@ -165,6 +183,8 @@ export const SPECIALTIES_BY_TYPE: Record<ProfessionalType, string[]> = {
     "Redundancy Planning",
     "FIFO Worker Planning",
     "Small Business Owners",
+    "UK Pension Transfer",
+    "FATCA-Aware US Expat Planning",
   ],
   property_advisor: [
     "First Home Buyers",
@@ -187,6 +207,9 @@ export const SPECIALTIES_BY_TYPE: Record<ProfessionalType, string[]> = {
     "R&D Tax Incentive",
     "Negative Gearing",
     "Small Business Owners",
+    "UK Pension Transfer",
+    "FATCA-Aware US Expat Planning",
+    "DASP Processing",
   ],
   mortgage_broker: [
     "First Home Buyers",
@@ -310,6 +333,7 @@ export const SPECIALTIES_BY_TYPE: Record<ProfessionalType, string[]> = {
     "Employer-Sponsored Visas",
     "Permanent Residency",
     "Citizenship Applications",
+    "DASP Processing",
   ],
   business_broker: [
     "Business Valuations",
@@ -374,6 +398,7 @@ export const SPECIALTIES_BY_TYPE: Record<ProfessionalType, string[]> = {
   ],
   foreign_investment_lawyer: [
     "FIRB Applications",
+    "FIRB Property (Non-Resident)",
     "Critical Infrastructure Review",
     "National Security Review",
     "Sovereign Wealth Mandates",


### PR DESCRIPTION
## Phase A of cross-border revenue strategy

Stacks on the strategy lock (#336 — FIN_NOTEBOOK item #24).

## The gap this closes

The advisor-enquiry route already applies a **3× international tier multiplier** at `app/api/advisor-enquiry/route.ts:261`. That code's been there. The problem is it only fires when:
- Visitor IP is non-AU/NZ (Vercel geo header), OR
- Form explicitly sends `is_international` / `investor_country` / `visa_status`

Both miss the **largest LTV cohort**: AU-resident migrants who already moved here, browse from AU IPs, and need pension-transfer / FATCA / FIRB / DASP specialists. They paid $39/lead like a Brisbane share-trader.

## What changed

| # | Change | File |
|---|---|---|
| 1 | **Source-path detection.** Add cross-border source-page allowlist to the international-lead detector. Leads from `/foreign-investment/*`, `/advisors/international-tax-specialists`, `/advisors/firb-specialists`, `/advisors/migration-agents` now trigger international tier regardless of IP geo. | `app/api/advisor-enquiry/route.ts` |
| 2 | **4 new cross-border specialties.** UK Pension Transfer · FATCA-Aware US Expat Planning · DASP Processing · FIRB Property (Non-Resident). New "Cross-border & expat" category. Wired into appropriate advisor types (tax_agent, financial_planner, migration_agent, foreign_investment_lawyer). | `lib/advisor-specialties.ts` |
| 3 | **CTA wiring** — country pages and hub now route to specialist landing pages (which are in the source-path allowlist) instead of generic `/advisors`. | hub `page.tsx`, `[country]/page.tsx`, `united-kingdom/page.tsx`, `PersonaSelector.tsx` |
| 4 | **DASPCalculator handoff.** Tool used to dead-end into "you'll receive $65k" education. Now surfaces a "Find a DASP specialist →" CTA after the result. Routes to `/advisors/international-tax-specialists?specialty=DASP+Processing` (in allowlist → premium pricing). | `DASPCalculator.tsx` |
| 5 | **Tests pin the allowlist** (6 cross-border paths + 1 domestic control) so a refactor can't silently drop the branch. | `__tests__/api/advisor-enquiry.test.ts` |

## Revenue effect

A UK migrant browsing `/foreign-investment/united-kingdom` from a Sydney IP and submitting an enquiry on the international-tax-specialists landing page now bills the advisor **$147 base** (before tier discount) instead of the previous flat **$49**. That's the LTV asymmetry FIN_NOTEBOOK item #24 was designed to capture — and it kicks in for every cross-border surface today, not just IP-detectable visitors.

## Why pushback was applied
- **No 1.75× multiplier added** — original audit recommended that, but the codebase already has a 3× tier and the actual gap was detection coverage. Cleaner to fix the detection than add a fourth pricing layer.
- **No schema migration in this PR** — `countries_served TEXT[]` advisor column + ranker country boost (Phase B) deferred so this can ship today. Schema change needs production verification + advisor portal UI.
- **No new specialties that already existed** — SIV / 188C is already under `migration_agent` and `immigration_investment_lawyer`. Skipped to avoid noise.

## Test plan
- [ ] CI green
- [ ] Existing advisor-enquiry tests still pass (rate limiting, validation, billing path)
- [ ] New source-path tests exercise all 6 cross-border paths + 1 domestic control
- [ ] Vercel preview: /foreign-investment hub CTAs land on specialist landing pages
- [ ] Vercel preview: country pages (UK, India, US) all route advisor CTAs to specialists
- [ ] Vercel preview: DASPCalculator shows the new "Find a DASP specialist" CTA after entering a balance
- [ ] Vercel preview: PersonaSelector buttons on the hub route correctly per persona

## Out of scope (Phase B)
- `countries_served TEXT[]` schema migration on `professionals`
- Advisor portal UI for self-selecting countries
- Advisor ranker country-match boost
- Remittance / FX affiliate panel (Wise, OFX)
- Non-resident mortgage broker partner
- FIRB property lawyer panel

## Out of scope (this session)
- Homepage `HomeCrossBorder` rewrite — coming in next PR (PR-3)