### PR TITLE
feat(security): B-09 — OTP gate for /api/listings/my-listings + drop anon SELECT on listing_enquiries [DO NOT MERGE without env var]

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -100,5 +100,12 @@ POSTBACK_SECRET=your_postback_secret_here
 VOTE_HASH_SALT=your_vote_hash_salt_here
 ADMIN_NOTIFICATION_EMAIL=admin@invest.com.au
 
+# Signs the `listing_owner_verified` cookie issued by
+# /api/listings/my-listings/verify after a successful OTP challenge
+# (B-09a). MUST be >=32 random bytes -- generate with `openssl rand -hex 32`.
+# On absence, the verify route fails closed (503) and my-listings stays
+# locked. Rotating invalidates all open listing-owner sessions (1h TTL).
+LISTING_OWNER_COOKIE_SECRET=your_listing_owner_cookie_secret_here
+
 # ── Logging (optional) ──────────────────────────────────
 # LOG_LEVEL=warn

--- a/__tests__/api/listings-my-listings-verify.test.ts
+++ b/__tests__/api/listings-my-listings-verify.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from "vitest";
+import { makeRequest } from "@/__tests__/helpers";
+
+const TEST_SECRET = "0123456789abcdef0123456789abcdef0123456789abcdef";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const mockAdminFrom = vi.fn();
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+
+const mockIsRateLimited = vi.fn().mockResolvedValue(false);
+vi.mock("@/lib/rate-limit", () => ({
+  isRateLimited: (...args: unknown[]) => mockIsRateLimited(...args),
+}));
+
+vi.mock("@/lib/validate-email", () => ({
+  isValidEmail: (e: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(e),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ error: vi.fn(), warn: vi.fn(), info: vi.fn() })),
+}));
+
+import { POST } from "@/app/api/listings/my-listings/verify/route";
+import {
+  LISTING_OWNER_COOKIE_NAME,
+  verifyListingOwnerCookie,
+} from "@/lib/listing-owner-cookie";
+
+const VALID_CODE = "123456";
+const FUTURE_EXPIRY = new Date(Date.now() + 5 * 60 * 1000).toISOString();
+
+function mockOtpRow(overrides: Partial<{
+  code: string;
+  expires_at: string;
+  used_at: string | null;
+  id: number;
+}> = {}) {
+  return {
+    id: overrides.id ?? 99,
+    code: overrides.code ?? VALID_CODE,
+    expires_at: overrides.expires_at ?? FUTURE_EXPIRY,
+    used_at: overrides.used_at ?? null,
+  };
+}
+
+function setupOtpQuery(otp: ReturnType<typeof mockOtpRow> | null) {
+  // First .from() call = SELECT, second = UPDATE.
+  let n = 0;
+  mockAdminFrom.mockImplementation(() => {
+    n++;
+    if (n === 1) {
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        is: vi.fn().mockReturnThis(),
+        order: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockReturnThis(),
+        maybeSingle: vi.fn().mockResolvedValue({ data: otp, error: null }),
+      };
+    }
+    return {
+      update: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockResolvedValue({ data: null, error: null }),
+    };
+  });
+}
+
+describe("POST /api/listings/my-listings/verify", () => {
+  let originalSecret: string | undefined;
+
+  beforeAll(() => {
+    originalSecret = process.env.LISTING_OWNER_COOKIE_SECRET;
+    process.env.LISTING_OWNER_COOKIE_SECRET = TEST_SECRET;
+  });
+
+  afterAll(() => {
+    if (originalSecret === undefined) {
+      delete process.env.LISTING_OWNER_COOKIE_SECRET;
+    } else {
+      process.env.LISTING_OWNER_COOKIE_SECRET = originalSecret;
+    }
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsRateLimited.mockResolvedValue(false);
+  });
+
+  it("returns 400 on invalid JSON", async () => {
+    const req = new (await import("next/server")).NextRequest(
+      "http://localhost/api/listings/my-listings/verify",
+      {
+        method: "POST",
+        body: "not-json",
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when email or code missing", async () => {
+    const req = makeRequest("/api/listings/my-listings/verify", {});
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when email is invalid", async () => {
+    const req = makeRequest("/api/listings/my-listings/verify", {
+      email: "not-an-email",
+      code: VALID_CODE,
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 429 on per-IP burst rate limit", async () => {
+    mockIsRateLimited.mockImplementation((key: string) =>
+      Promise.resolve(key.startsWith("my-listings-verify:")),
+    );
+    const req = makeRequest("/api/listings/my-listings/verify", {
+      email: "owner@example.com",
+      code: VALID_CODE,
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 429 on per-email rate limit", async () => {
+    mockIsRateLimited.mockImplementation((key: string) =>
+      Promise.resolve(key.startsWith("my-listings-verify-email:")),
+    );
+    const req = makeRequest("/api/listings/my-listings/verify", {
+      email: "owner@example.com",
+      code: VALID_CODE,
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 400 when no active OTP found", async () => {
+    setupOtpQuery(null);
+    const req = makeRequest("/api/listings/my-listings/verify", {
+      email: "owner@example.com",
+      code: VALID_CODE,
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/no active code/i);
+  });
+
+  it("returns 400 when OTP expired", async () => {
+    setupOtpQuery(
+      mockOtpRow({
+        expires_at: new Date(Date.now() - 1000).toISOString(),
+      }),
+    );
+    const req = makeRequest("/api/listings/my-listings/verify", {
+      email: "owner@example.com",
+      code: VALID_CODE,
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/expired/i);
+  });
+
+  it("returns 400 on incorrect code (timing-safe compare)", async () => {
+    setupOtpQuery(mockOtpRow({ code: VALID_CODE }));
+    const req = makeRequest("/api/listings/my-listings/verify", {
+      email: "owner@example.com",
+      code: "000000",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/incorrect code/i);
+  });
+
+  it("returns 400 on length-mismatched code (timing-safe compare)", async () => {
+    setupOtpQuery(mockOtpRow({ code: VALID_CODE }));
+    const req = makeRequest("/api/listings/my-listings/verify", {
+      email: "owner@example.com",
+      code: "12345", // 5 chars
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 200 + sets signed cookie on valid code", async () => {
+    setupOtpQuery(mockOtpRow({ code: VALID_CODE }));
+    const req = makeRequest("/api/listings/my-listings/verify", {
+      email: "owner@example.com",
+      code: VALID_CODE,
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const setCookie = res.headers.get("set-cookie") || "";
+    expect(setCookie).toContain(LISTING_OWNER_COOKIE_NAME);
+    expect(setCookie).toContain("HttpOnly");
+    expect(setCookie).toContain("SameSite=strict");
+    expect(setCookie).toContain("Path=/");
+
+    // Extract the cookie value and round-trip verify it.
+    const match = setCookie.match(
+      new RegExp(`${LISTING_OWNER_COOKIE_NAME}=([^;]+)`),
+    );
+    expect(match).not.toBeNull();
+    if (match) {
+      const verdict = verifyListingOwnerCookie(match[1], {
+        expectedEmail: "owner@example.com",
+      });
+      expect(verdict.ok).toBe(true);
+      if (verdict.ok) expect(verdict.email).toBe("owner@example.com");
+    }
+  });
+
+  it("normalises submitted email + code (trims) before checks", async () => {
+    setupOtpQuery(mockOtpRow({ code: VALID_CODE }));
+    const req = makeRequest("/api/listings/my-listings/verify", {
+      email: "  Owner@Example.COM  ",
+      code: ` ${VALID_CODE} `,
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const setCookie = res.headers.get("set-cookie") || "";
+    const match = setCookie.match(
+      new RegExp(`${LISTING_OWNER_COOKIE_NAME}=([^;]+)`),
+    );
+    if (match) {
+      const verdict = verifyListingOwnerCookie(match[1]);
+      if (verdict.ok) expect(verdict.email).toBe("owner@example.com");
+    }
+  });
+
+  it("returns 503 when cookie secret is missing (fails closed)", async () => {
+    const original = process.env.LISTING_OWNER_COOKIE_SECRET;
+    delete process.env.LISTING_OWNER_COOKIE_SECRET;
+    setupOtpQuery(mockOtpRow({ code: VALID_CODE }));
+    const req = makeRequest("/api/listings/my-listings/verify", {
+      email: "owner@example.com",
+      code: VALID_CODE,
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(503);
+    if (original !== undefined) {
+      process.env.LISTING_OWNER_COOKIE_SECRET = original;
+    } else {
+      process.env.LISTING_OWNER_COOKIE_SECRET = TEST_SECRET;
+    }
+    // Restore for subsequent tests.
+    process.env.LISTING_OWNER_COOKIE_SECRET = TEST_SECRET;
+  });
+});

--- a/__tests__/api/listings-my-listings.test.ts
+++ b/__tests__/api/listings-my-listings.test.ts
@@ -1,13 +1,13 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
+
+const TEST_SECRET = "0123456789abcdef0123456789abcdef0123456789abcdef";
 
 // ── Mocks ──────────────────────────────────────────────────────────────────────
 
-const mockServerFrom = vi.fn();
-vi.mock("@/lib/supabase/server", () => ({
-  createClient: vi.fn(() =>
-    Promise.resolve({ from: mockServerFrom })
-  ),
+const mockAdminFrom = vi.fn();
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
 }));
 
 vi.mock("@/lib/logger", () => ({
@@ -15,30 +15,79 @@ vi.mock("@/lib/logger", () => ({
 }));
 
 import { GET } from "@/app/api/listings/my-listings/route";
+import {
+  signListingOwnerCookie,
+  LISTING_OWNER_COOKIE_NAME,
+  LISTING_OWNER_COOKIE_MAX_AGE_S,
+} from "@/lib/listing-owner-cookie";
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
-function makeGet(email?: string): NextRequest {
+function makeGet(
+  email?: string,
+  options: { cookieValue?: string } = {},
+): NextRequest {
   const url = email
     ? `http://localhost/api/listings/my-listings?email=${encodeURIComponent(email)}`
     : "http://localhost/api/listings/my-listings";
-  return new NextRequest(url, { method: "GET" });
+  const headers: Record<string, string> = {};
+  if (options.cookieValue !== undefined) {
+    headers.cookie = `${LISTING_OWNER_COOKIE_NAME}=${options.cookieValue}`;
+  }
+  return new NextRequest(url, { method: "GET", headers });
 }
 
 const SAMPLE_LISTINGS = [
-  { id: 1, title: "Cafe for Sale", slug: "cafe-for-sale", vertical: "food", status: "active", asking_price_cents: 500000, price_display: "$500k", listing_type: "business", views: 10, enquiries: 2, created_at: "2026-01-01", expires_at: "2026-12-31" },
+  {
+    id: 1,
+    title: "Cafe for Sale",
+    slug: "cafe-for-sale",
+    vertical: "business",
+    status: "active",
+    asking_price_cents: 500000,
+    price_display: "$500k",
+    listing_type: "business",
+    views: 10,
+    enquiries: 2,
+    created_at: "2026-01-01",
+    expires_at: "2026-12-31",
+  },
 ];
 
 const SAMPLE_ENQUIRIES = [
-  { id: 10, listing_id: 1, user_name: "Bob", user_email: "bob@example.com", message: "Interested", created_at: "2026-01-02" },
+  {
+    id: 10,
+    listing_id: 1,
+    user_name: "Bob",
+    user_email: "bob@example.com",
+    message: "Interested",
+    created_at: "2026-01-02",
+  },
 ];
 
 // ── Tests ──────────────────────────────────────────────────────────────────────
 
-describe("GET /api/listings/my-listings", () => {
+describe("GET /api/listings/my-listings (B-09a OTP gate)", () => {
+  let originalSecret: string | undefined;
+
+  beforeAll(() => {
+    originalSecret = process.env.LISTING_OWNER_COOKIE_SECRET;
+    process.env.LISTING_OWNER_COOKIE_SECRET = TEST_SECRET;
+  });
+
+  afterAll(() => {
+    if (originalSecret === undefined) {
+      delete process.env.LISTING_OWNER_COOKIE_SECRET;
+    } else {
+      process.env.LISTING_OWNER_COOKIE_SECRET = originalSecret;
+    }
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
   });
+
+  // ── Input validation ────────────────────────────────────────────────────────
 
   it("returns 400 when email param is missing", async () => {
     const res = await GET(makeGet());
@@ -54,51 +103,100 @@ describe("GET /api/listings/my-listings", () => {
     expect(json.error).toMatch(/valid email/i);
   });
 
-  it("returns 500 when listings fetch fails", async () => {
-    const chain: Record<string, unknown> = {
-      select: vi.fn().mockReturnThis(),
-      ilike: vi.fn().mockReturnThis(),
-      order: vi.fn().mockResolvedValue({ data: null, error: { message: "db error" } }),
-    };
-    mockServerFrom.mockReturnValue(chain);
-    const res = await GET(makeGet("owner@example.com"));
-    expect(res.status).toBe(500);
-  });
+  // ── Cookie gate ─────────────────────────────────────────────────────────────
 
-  it("returns empty listings and enquiries when no listings found", async () => {
-    const chain: Record<string, unknown> = {
-      select: vi.fn().mockReturnThis(),
-      ilike: vi.fn().mockReturnThis(),
-      order: vi.fn().mockResolvedValue({ data: [], error: null }),
-    };
-    mockServerFrom.mockReturnValue(chain);
+  it("returns 401 when no cookie present", async () => {
     const res = await GET(makeGet("owner@example.com"));
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(401);
     const json = await res.json();
-    expect(json.listings).toEqual([]);
-    expect(json.enquiries).toEqual({});
+    expect(json.error).toMatch(/verification required/i);
+    expect(json.code).toBe("cookie_missing");
+    expect(json.next).toBe("/api/verify-otp/send");
   });
 
-  it("returns listings with enquiries grouped by listing_id", async () => {
+  it("returns 401 when cookie is malformed", async () => {
+    const res = await GET(
+      makeGet("owner@example.com", { cookieValue: "not-a-valid-cookie" }),
+    );
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json.code).toBe("cookie_malformed");
+  });
+
+  it("returns 401 when cookie has wrong (tampered) signature", async () => {
+    const valid = signListingOwnerCookie("owner@example.com");
+    // Flip a byte in the HMAC half.
+    const [payload, hmac] = valid.split(".");
+    const tamperedHmac =
+      hmac && hmac.length > 0
+        ? (hmac[0] === "A" ? "B" : "A") + hmac.slice(1)
+        : "AAAA";
+    const res = await GET(
+      makeGet("owner@example.com", {
+        cookieValue: `${payload}.${tamperedHmac}`,
+      }),
+    );
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json.code).toMatch(/cookie_(bad_signature|malformed)/);
+  });
+
+  it("returns 401 when cookie was issued for a different email", async () => {
+    // Cookie issued for victim@example.com but caller passes
+    // attacker@example.com — this is the central B-09 attack vector
+    // we must block. The signature is valid; the email mismatch is what
+    // catches it.
+    const cookieForVictim = signListingOwnerCookie("victim@example.com");
+    const res = await GET(
+      makeGet("attacker@example.com", { cookieValue: cookieForVictim }),
+    );
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json.code).toBe("cookie_email_mismatch");
+  });
+
+  it("returns 401 when cookie is expired", async () => {
+    // iat far in the past so exp is also in the past.
+    const expiredAt = Date.now() - (LISTING_OWNER_COOKIE_MAX_AGE_S + 60) * 1000;
+    const expiredCookie = signListingOwnerCookie(
+      "owner@example.com",
+      expiredAt,
+    );
+    const res = await GET(
+      makeGet("owner@example.com", { cookieValue: expiredCookie }),
+    );
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json.code).toBe("cookie_expired");
+  });
+
+  // ── Authorised path ────────────────────────────────────────────────────────
+
+  it("returns 200 with listings + enquiries when cookie is valid", async () => {
     let callCount = 0;
-    mockServerFrom.mockImplementation(() => {
+    mockAdminFrom.mockImplementation(() => {
       callCount++;
       if (callCount === 1) {
-        // listings query
         return {
           select: vi.fn().mockReturnThis(),
           ilike: vi.fn().mockReturnThis(),
-          order: vi.fn().mockResolvedValue({ data: SAMPLE_LISTINGS, error: null }),
+          order: vi
+            .fn()
+            .mockResolvedValue({ data: SAMPLE_LISTINGS, error: null }),
         };
       }
-      // enquiries query
       return {
         select: vi.fn().mockReturnThis(),
         in: vi.fn().mockReturnThis(),
-        order: vi.fn().mockResolvedValue({ data: SAMPLE_ENQUIRIES, error: null }),
+        order: vi
+          .fn()
+          .mockResolvedValue({ data: SAMPLE_ENQUIRIES, error: null }),
       };
     });
-    const res = await GET(makeGet("owner@example.com"));
+    const cookie = signListingOwnerCookie("owner@example.com");
+    const res = await GET(
+      makeGet("owner@example.com", { cookieValue: cookie }),
+    );
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.listings).toHaveLength(1);
@@ -106,43 +204,129 @@ describe("GET /api/listings/my-listings", () => {
     expect(json.enquiries["1"][0].user_name).toBe("Bob");
   });
 
+  it("returns empty arrays when valid cookie but no listings owned", async () => {
+    mockAdminFrom.mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      ilike: vi.fn().mockReturnThis(),
+      order: vi.fn().mockResolvedValue({ data: [], error: null }),
+    });
+    const cookie = signListingOwnerCookie("owner@example.com");
+    const res = await GET(
+      makeGet("owner@example.com", { cookieValue: cookie }),
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.listings).toEqual([]);
+    expect(json.enquiries).toEqual({});
+  });
+
+  it("normalises email case before matching cookie + querying", async () => {
+    let capturedEmail: string | undefined;
+    mockAdminFrom.mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      ilike: vi.fn((_col: string, val: string) => {
+        capturedEmail = val;
+        return {
+          order: vi.fn().mockResolvedValue({ data: [], error: null }),
+        };
+      }),
+    });
+    const cookie = signListingOwnerCookie("owner@example.com");
+    const res = await GET(
+      makeGet("Owner@Example.COM", { cookieValue: cookie }),
+    );
+    expect(res.status).toBe(200);
+    expect(capturedEmail).toBe("owner@example.com");
+  });
+
+  // ── DB error paths ─────────────────────────────────────────────────────────
+
+  it("returns 500 when listings fetch fails (cookie valid)", async () => {
+    mockAdminFrom.mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      ilike: vi.fn().mockReturnThis(),
+      order: vi
+        .fn()
+        .mockResolvedValue({ data: null, error: { message: "db error" } }),
+    });
+    const cookie = signListingOwnerCookie("owner@example.com");
+    const res = await GET(
+      makeGet("owner@example.com", { cookieValue: cookie }),
+    );
+    expect(res.status).toBe(500);
+  });
+
   it("returns listings without enquiries when enquiries fetch fails", async () => {
     let callCount = 0;
-    mockServerFrom.mockImplementation(() => {
+    mockAdminFrom.mockImplementation(() => {
       callCount++;
       if (callCount === 1) {
         return {
           select: vi.fn().mockReturnThis(),
           ilike: vi.fn().mockReturnThis(),
-          order: vi.fn().mockResolvedValue({ data: SAMPLE_LISTINGS, error: null }),
+          order: vi
+            .fn()
+            .mockResolvedValue({ data: SAMPLE_LISTINGS, error: null }),
         };
       }
       return {
         select: vi.fn().mockReturnThis(),
         in: vi.fn().mockReturnThis(),
-        order: vi.fn().mockResolvedValue({ data: null, error: { message: "enquiry error" } }),
+        order: vi
+          .fn()
+          .mockResolvedValue({ data: null, error: { message: "boom" } }),
       };
     });
-    const res = await GET(makeGet("owner@example.com"));
+    const cookie = signListingOwnerCookie("owner@example.com");
+    const res = await GET(
+      makeGet("owner@example.com", { cookieValue: cookie }),
+    );
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.listings).toHaveLength(1);
     expect(json.enquiries).toEqual({});
   });
 
-  it("normalises email to lowercase before querying", async () => {
-    let capturedEmail: string | undefined;
-    mockServerFrom.mockReturnValue({
+  // ── Refresh-window edge cases ──────────────────────────────────────────────
+
+  it("accepts a cookie whose exp is just inside the window", async () => {
+    // Issue with `now` ≈ now; exp will be `now + 1h`. Verify still valid.
+    mockAdminFrom.mockReturnValue({
       select: vi.fn().mockReturnThis(),
-      ilike: vi.fn((_, val: string) => { capturedEmail = val; return { order: vi.fn().mockResolvedValue({ data: [], error: null }) }; }),
+      ilike: vi.fn().mockReturnThis(),
+      order: vi.fn().mockResolvedValue({ data: [], error: null }),
     });
-    await GET(makeGet("Owner@Example.COM"));
-    expect(capturedEmail).toBe("owner@example.com");
+    const issuedAt = Date.now() - (LISTING_OWNER_COOKIE_MAX_AGE_S - 30) * 1000;
+    const cookie = signListingOwnerCookie("owner@example.com", issuedAt);
+    const res = await GET(
+      makeGet("owner@example.com", { cookieValue: cookie }),
+    );
+    expect(res.status).toBe(200);
   });
 
-  it("returns 500 on unexpected thrown error", async () => {
-    mockServerFrom.mockImplementation(() => { throw new Error("boom"); });
-    const res = await GET(makeGet("owner@example.com"));
+  it("rejects a cookie whose exp is exactly now (boundary expired)", async () => {
+    // iat = now - max_age, so exp = now. Verify uses `nowS >= payload.exp`,
+    // so this should fail closed.
+    const issuedAt = Date.now() - LISTING_OWNER_COOKIE_MAX_AGE_S * 1000;
+    const cookie = signListingOwnerCookie("owner@example.com", issuedAt);
+    const res = await GET(
+      makeGet("owner@example.com", { cookieValue: cookie }),
+    );
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json.code).toBe("cookie_expired");
+  });
+
+  // ── Misc ───────────────────────────────────────────────────────────────────
+
+  it("returns 500 on unexpected thrown error after cookie verifies", async () => {
+    mockAdminFrom.mockImplementation(() => {
+      throw new Error("boom");
+    });
+    const cookie = signListingOwnerCookie("owner@example.com");
+    const res = await GET(
+      makeGet("owner@example.com", { cookieValue: cookie }),
+    );
     expect(res.status).toBe(500);
   });
 });

--- a/__tests__/lib/listing-owner-cookie.test.ts
+++ b/__tests__/lib/listing-owner-cookie.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import {
+  signListingOwnerCookie,
+  verifyListingOwnerCookie,
+  LISTING_OWNER_COOKIE_NAME,
+  LISTING_OWNER_COOKIE_MAX_AGE_S,
+} from "@/lib/listing-owner-cookie";
+
+const TEST_SECRET = "0123456789abcdef0123456789abcdef0123456789abcdef"; // 48 chars
+
+describe("listing-owner-cookie", () => {
+  let originalSecret: string | undefined;
+
+  beforeAll(() => {
+    originalSecret = process.env.LISTING_OWNER_COOKIE_SECRET;
+    process.env.LISTING_OWNER_COOKIE_SECRET = TEST_SECRET;
+  });
+
+  afterAll(() => {
+    if (originalSecret === undefined) {
+      delete process.env.LISTING_OWNER_COOKIE_SECRET;
+    } else {
+      process.env.LISTING_OWNER_COOKIE_SECRET = originalSecret;
+    }
+  });
+
+  it("exposes a stable cookie name + 1h TTL", () => {
+    expect(LISTING_OWNER_COOKIE_NAME).toBe("listing_owner_verified");
+    expect(LISTING_OWNER_COOKIE_MAX_AGE_S).toBe(3600);
+  });
+
+  it("round-trips a signed cookie", () => {
+    const cookie = signListingOwnerCookie("owner@example.com");
+    const result = verifyListingOwnerCookie(cookie);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.email).toBe("owner@example.com");
+  });
+
+  it("normalises email to lowercase + trims whitespace", () => {
+    const cookie = signListingOwnerCookie("  Owner@Example.COM  ");
+    const result = verifyListingOwnerCookie(cookie);
+    if (result.ok) expect(result.email).toBe("owner@example.com");
+  });
+
+  it("rejects missing cookie", () => {
+    expect(verifyListingOwnerCookie(undefined)).toEqual({
+      ok: false,
+      reason: "missing",
+    });
+    expect(verifyListingOwnerCookie(null)).toEqual({
+      ok: false,
+      reason: "missing",
+    });
+    expect(verifyListingOwnerCookie("")).toEqual({
+      ok: false,
+      reason: "missing",
+    });
+  });
+
+  it("rejects malformed cookie (no dot)", () => {
+    expect(verifyListingOwnerCookie("garbage")).toEqual({
+      ok: false,
+      reason: "malformed",
+    });
+  });
+
+  it("rejects malformed cookie (extra dots)", () => {
+    expect(verifyListingOwnerCookie("a.b.c")).toEqual({
+      ok: false,
+      reason: "malformed",
+    });
+  });
+
+  it("rejects tampered HMAC", () => {
+    const cookie = signListingOwnerCookie("owner@example.com");
+    const [payload, hmac] = cookie.split(".");
+    const tamperedHmac =
+      hmac && hmac.length > 0
+        ? (hmac[0] === "A" ? "B" : "A") + hmac.slice(1)
+        : "AAAA";
+    const result = verifyListingOwnerCookie(`${payload}.${tamperedHmac}`);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(["bad_signature", "malformed"]).toContain(result.reason);
+    }
+  });
+
+  it("rejects tampered payload (HMAC won't match)", () => {
+    const cookie = signListingOwnerCookie("owner@example.com");
+    const [, hmac] = cookie.split(".");
+    const tamperedPayload = Buffer.from(
+      JSON.stringify({
+        email: "attacker@evil.com",
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      }),
+      "utf8",
+    )
+      .toString("base64")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+    const result = verifyListingOwnerCookie(`${tamperedPayload}.${hmac}`);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("bad_signature");
+  });
+
+  it("rejects expired cookie", () => {
+    const expiredAt = Date.now() - (LISTING_OWNER_COOKIE_MAX_AGE_S + 60) * 1000;
+    const cookie = signListingOwnerCookie("owner@example.com", expiredAt);
+    const result = verifyListingOwnerCookie(cookie);
+    expect(result).toEqual({ ok: false, reason: "expired" });
+  });
+
+  it("accepts cookie just inside the validity window", () => {
+    const issuedAt = Date.now() - (LISTING_OWNER_COOKIE_MAX_AGE_S - 30) * 1000;
+    const cookie = signListingOwnerCookie("owner@example.com", issuedAt);
+    const result = verifyListingOwnerCookie(cookie);
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects cookie at exact expiry boundary (>= exp is expired)", () => {
+    const issuedAt = Date.now() - LISTING_OWNER_COOKIE_MAX_AGE_S * 1000;
+    const cookie = signListingOwnerCookie("owner@example.com", issuedAt);
+    const result = verifyListingOwnerCookie(cookie);
+    expect(result).toEqual({ ok: false, reason: "expired" });
+  });
+
+  it("enforces expectedEmail when provided", () => {
+    const cookie = signListingOwnerCookie("victim@example.com");
+    const matchResult = verifyListingOwnerCookie(cookie, {
+      expectedEmail: "victim@example.com",
+    });
+    expect(matchResult.ok).toBe(true);
+
+    const mismatchResult = verifyListingOwnerCookie(cookie, {
+      expectedEmail: "attacker@example.com",
+    });
+    expect(mismatchResult).toEqual({ ok: false, reason: "email_mismatch" });
+  });
+
+  it("expectedEmail comparison is case-insensitive + trims", () => {
+    const cookie = signListingOwnerCookie("owner@example.com");
+    const result = verifyListingOwnerCookie(cookie, {
+      expectedEmail: "  Owner@Example.COM  ",
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("returns no_secret when env var missing", () => {
+    const original = process.env.LISTING_OWNER_COOKIE_SECRET;
+    delete process.env.LISTING_OWNER_COOKIE_SECRET;
+    const result = verifyListingOwnerCookie("anything.here");
+    expect(result).toEqual({ ok: false, reason: "no_secret" });
+    process.env.LISTING_OWNER_COOKIE_SECRET = original;
+  });
+
+  it("throws on sign when env var missing", () => {
+    const original = process.env.LISTING_OWNER_COOKIE_SECRET;
+    delete process.env.LISTING_OWNER_COOKIE_SECRET;
+    expect(() => signListingOwnerCookie("owner@example.com")).toThrow(
+      /LISTING_OWNER_COOKIE_SECRET/,
+    );
+    process.env.LISTING_OWNER_COOKIE_SECRET = original;
+  });
+
+  it("throws on sign when env var is too short", () => {
+    const original = process.env.LISTING_OWNER_COOKIE_SECRET;
+    process.env.LISTING_OWNER_COOKIE_SECRET = "tooshort";
+    expect(() => signListingOwnerCookie("owner@example.com")).toThrow(
+      /≥32 characters/,
+    );
+    if (original !== undefined) {
+      process.env.LISTING_OWNER_COOKIE_SECRET = original;
+    }
+  });
+
+  it("rejects cookie signed with a different secret", () => {
+    const original = process.env.LISTING_OWNER_COOKIE_SECRET;
+    process.env.LISTING_OWNER_COOKIE_SECRET =
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const cookie = signListingOwnerCookie("owner@example.com");
+    process.env.LISTING_OWNER_COOKIE_SECRET = TEST_SECRET;
+    const result = verifyListingOwnerCookie(cookie);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("bad_signature");
+    if (original !== undefined) {
+      process.env.LISTING_OWNER_COOKIE_SECRET = original;
+    }
+  });
+});

--- a/app/api/listings/my-listings/route.ts
+++ b/app/api/listings/my-listings/route.ts
@@ -1,11 +1,40 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import {
+  verifyListingOwnerCookie,
+  LISTING_OWNER_COOKIE_NAME,
+} from "@/lib/listing-owner-cookie";
 import { logger } from "@/lib/logger";
 
 const log = logger("listings:my-listings");
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
+export const runtime = "nodejs";
+
+/**
+ * GET /api/listings/my-listings?email=...
+ *
+ * Returns the listings + grouped enquiries for the listing owner
+ * identified by `email`. Authorisation is gated by the
+ * `listing_owner_verified` HMAC-signed cookie issued by
+ * /api/listings/my-listings/verify after the OTP challenge — see
+ * REMEDIATION_QUEUE.md B-09a.
+ *
+ * Status codes:
+ *   200 — verified; { listings, enquiries } returned
+ *   400 — missing or invalid email param
+ *   401 — no cookie / cookie does not match the requested email; the
+ *         response body includes a `next` field pointing at
+ *         /api/verify-otp/send so the frontend knows where to start
+ *         the OTP flow
+ *
+ * The DB queries run under `createAdminClient()` (service-role).
+ * After B-09b drops the "anon select enquiries" policy on
+ * `listing_enquiries`, the anon key cannot read enquiries at all, so
+ * service-role is the only path that returns rows. The cookie
+ * (validated above the query) is the actual ownership check.
+ */
 export async function GET(request: NextRequest) {
   try {
     const email = request.nextUrl.searchParams.get("email");
@@ -13,18 +42,35 @@ export async function GET(request: NextRequest) {
     if (!email || !EMAIL_REGEX.test(email.trim())) {
       return NextResponse.json(
         { error: "A valid email address is required." },
-        { status: 400 }
+        { status: 400 },
       );
     }
 
     const normalizedEmail = email.trim().toLowerCase();
-    const supabase = await createClient();
 
-    // Fetch listings for this email (case-insensitive via ilike)
+    const cookieValue = request.cookies.get(LISTING_OWNER_COOKIE_NAME)?.value;
+    const verdict = verifyListingOwnerCookie(cookieValue, {
+      expectedEmail: normalizedEmail,
+    });
+
+    if (!verdict.ok) {
+      return NextResponse.json(
+        {
+          error: "Email verification required.",
+          code: `cookie_${verdict.reason}`,
+          next: "/api/verify-otp/send",
+        },
+        { status: 401 },
+      );
+    }
+
+    const supabase = createAdminClient();
+
+    // Fetch listings for this email (case-insensitive via ilike).
     const { data: listings, error: listingsError } = await supabase
       .from("investment_listings")
       .select(
-        "id, title, slug, vertical, status, asking_price_cents, price_display, listing_type, views, enquiries, created_at, expires_at"
+        "id, title, slug, vertical, status, asking_price_cents, price_display, listing_type, views, enquiries, created_at, expires_at",
       )
       .ilike("contact_email", normalizedEmail)
       .order("created_at", { ascending: false });
@@ -33,7 +79,7 @@ export async function GET(request: NextRequest) {
       log.error("[my-listings] listings fetch error:", listingsError);
       return NextResponse.json(
         { error: "Failed to fetch listings." },
-        { status: 500 }
+        { status: 500 },
       );
     }
 
@@ -41,29 +87,27 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ listings: [], enquiries: {} });
     }
 
-    // Fetch enquiries for all listing IDs
+    // Fetch enquiries for all listing IDs.
     const listingIds = listings.map((l) => l.id);
     const { data: allEnquiries, error: enquiriesError } = await supabase
       .from("listing_enquiries")
-      .select(
-        "id, listing_id, user_name, user_email, message, created_at"
-      )
+      .select("id, listing_id, user_name, user_email, message, created_at")
       .in("listing_id", listingIds)
       .order("created_at", { ascending: false });
 
     if (enquiriesError) {
       log.error("[my-listings] enquiries fetch error:", enquiriesError);
-      // Return listings without enquiries rather than failing entirely
+      // Return listings without enquiries rather than failing entirely.
       return NextResponse.json({ listings, enquiries: {} });
     }
 
-    // Group enquiries by listing_id
+    // Group enquiries by listing_id.
     const enquiriesByListing: Record<number, typeof allEnquiries> = {};
     for (const enquiry of allEnquiries || []) {
       if (!enquiriesByListing[enquiry.listing_id]) {
         enquiriesByListing[enquiry.listing_id] = [];
       }
-      enquiriesByListing[enquiry.listing_id].push(enquiry);
+      enquiriesByListing[enquiry.listing_id]!.push(enquiry);
     }
 
     return NextResponse.json({
@@ -74,7 +118,7 @@ export async function GET(request: NextRequest) {
     log.error("[my-listings] unexpected error:", err);
     return NextResponse.json(
       { error: "An unexpected error occurred." },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/app/api/listings/my-listings/verify/route.ts
+++ b/app/api/listings/my-listings/verify/route.ts
@@ -1,0 +1,190 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { timingSafeEqual } from "crypto";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { isRateLimited } from "@/lib/rate-limit";
+import { isValidEmail } from "@/lib/validate-email";
+import {
+  signListingOwnerCookie,
+  LISTING_OWNER_COOKIE_NAME,
+  LISTING_OWNER_COOKIE_MAX_AGE_S,
+} from "@/lib/listing-owner-cookie";
+import { logger } from "@/lib/logger";
+
+export const runtime = "nodejs";
+
+const log = logger("api/listings/my-listings/verify");
+
+const Body = z.object({
+  email: z.string(),
+  code: z.string(),
+});
+
+/**
+ * POST /api/listings/my-listings/verify
+ *
+ * Verifies an OTP that was sent via /api/verify-otp/send for the
+ * listing-owner contact email, and on success issues a signed
+ * `listing_owner_verified` cookie (1h TTL) that
+ * /api/listings/my-listings reads to authorise the
+ * listings + enquiries lookup.
+ *
+ * This route mirrors the rate-limit + timing-safe check pattern of
+ * /api/verify-otp/verify but is purpose-specific so the OTP-verified
+ * cookie is only issued when the caller is intentionally completing
+ * the my-listings gate (B-09a). /api/verify-otp/verify itself stays
+ * generic — the find-advisor flow that uses it does not need (and
+ * should not get) a long-lived listing-owner cookie.
+ *
+ * Body: { email: string, code: string }
+ *
+ * Status codes:
+ *   200 — code valid, cookie set
+ *   400 — bad input or wrong/expired code
+ *   429 — rate-limited
+ *
+ * Layered rate limits (audit K-02 — defense-in-depth against brute force):
+ *   1. Per-IP burst cap:        3 attempts / 15 min
+ *   2. Per-IP cumulative cap:  10 attempts / 4 hr
+ *   3. Per-email cap:           5 attempts / 60 min
+ */
+export async function POST(request: NextRequest) {
+  const ip = (request.headers.get("x-forwarded-for") ?? "unknown")
+    .split(",")[0]
+    ?.trim() ?? "unknown";
+
+  if (await isRateLimited(`my-listings-verify:${ip}`, 3, 15)) {
+    return NextResponse.json(
+      {
+        error:
+          "Too many attempts. Please wait 15 minutes or request a new code.",
+      },
+      { status: 429 },
+    );
+  }
+  if (await isRateLimited(`my-listings-verify-cumulative:${ip}`, 10, 240)) {
+    return NextResponse.json(
+      {
+        error:
+          "Too many attempts from this network. Please try again in 4 hours.",
+      },
+      { status: 429 },
+    );
+  }
+
+  let raw: unknown;
+  try {
+    raw = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+  }
+  const parsed = Body.safeParse(raw);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+  }
+
+  const email = parsed.data.email.trim();
+  const code = parsed.data.code.trim();
+
+  if (!email || !isValidEmail(email)) {
+    return NextResponse.json(
+      { error: "Please enter a valid email address." },
+      { status: 400 },
+    );
+  }
+  if (!code) {
+    return NextResponse.json(
+      { error: "Code is required." },
+      { status: 400 },
+    );
+  }
+
+  const normalizedEmail = email.toLowerCase();
+
+  // Per-email cap (B-09a — most important layer because OTPs are
+  // scoped to email; an attacker rotating IPs would otherwise bypass
+  // per-IP limits).
+  if (
+    await isRateLimited(`my-listings-verify-email:${normalizedEmail}`, 5, 60)
+  ) {
+    return NextResponse.json(
+      { error: "Too many attempts. Please request a new code." },
+      { status: 429 },
+    );
+  }
+
+  const supabase = createAdminClient();
+
+  const { data: otp } = await supabase
+    .from("email_otps")
+    .select("id, code, expires_at, used_at")
+    .eq("email", normalizedEmail)
+    .is("used_at", null)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (!otp) {
+    return NextResponse.json(
+      { error: "No active code found. Please request a new one." },
+      { status: 400 },
+    );
+  }
+
+  if (new Date(otp.expires_at) < new Date()) {
+    return NextResponse.json(
+      { error: "Code has expired. Please request a new one." },
+      { status: 400 },
+    );
+  }
+
+  // Timing-safe OTP comparison to prevent timing attacks.
+  const submitted = Buffer.from(code);
+  const stored = Buffer.from(otp.code);
+  if (
+    submitted.length !== stored.length ||
+    !timingSafeEqual(submitted, stored)
+  ) {
+    return NextResponse.json(
+      { error: "Incorrect code. Please try again." },
+      { status: 400 },
+    );
+  }
+
+  // Mark used so the same code cannot be replayed.
+  await supabase
+    .from("email_otps")
+    .update({ used_at: new Date().toISOString() })
+    .eq("id", otp.id);
+
+  // Issue the signed listing-owner cookie.
+  let cookieValue: string;
+  try {
+    cookieValue = signListingOwnerCookie(normalizedEmail);
+  } catch (err) {
+    log.error("Failed to sign listing-owner cookie", {
+      email: normalizedEmail,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json(
+      {
+        error:
+          "Verification service is not configured. Please contact support.",
+      },
+      { status: 503 },
+    );
+  }
+
+  const response = NextResponse.json({ ok: true, verified: true });
+  response.cookies.set({
+    name: LISTING_OWNER_COOKIE_NAME,
+    value: cookieValue,
+    httpOnly: true,
+    sameSite: "strict",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: LISTING_OWNER_COOKIE_MAX_AGE_S,
+  });
+  log.info("listing-owner verified", { email: normalizedEmail });
+  return response;
+}

--- a/app/invest/my-listings/page.tsx
+++ b/app/invest/my-listings/page.tsx
@@ -61,27 +61,47 @@ function verticalToPath(vertical: string, slug: string): string {
   return pathMap[vertical] || `/invest/${vertical}/${slug}`;
 }
 
+type Stage = "email" | "code" | "results";
+
 export default function MyListingsPage() {
+  const [stage, setStage] = useState<Stage>("email");
   const [email, setEmail] = useState("");
-  const [submitted, setSubmitted] = useState(false);
-  const [loading, setLoading] = useState(false);
+  const [code, setCode] = useState("");
+  const [sendingCode, setSendingCode] = useState(false);
+  const [verifying, setVerifying] = useState(false);
+  const [loadingListings, setLoadingListings] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [listings, setListings] = useState<Listing[]>([]);
   const [enquiries, setEnquiries] = useState<Record<number, Enquiry[]>>({});
   const [expandedListing, setExpandedListing] = useState<number | null>(null);
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!email.trim()) return;
-
-    setLoading(true);
+  const resetToEmail = () => {
+    setStage("email");
+    setCode("");
     setError(null);
+    setListings([]);
+    setEnquiries({});
+    setExpandedListing(null);
+  };
 
+  const fetchListings = async (currentEmail: string) => {
+    setLoadingListings(true);
+    setError(null);
     try {
       const res = await fetch(
-        `/api/listings/my-listings?email=${encodeURIComponent(email.trim())}`
+        `/api/listings/my-listings?email=${encodeURIComponent(currentEmail)}`,
+        { credentials: "same-origin" },
       );
       const data = await res.json();
+
+      if (res.status === 401) {
+        // Cookie missing/expired/email-mismatch — bounce to OTP flow.
+        setStage("email");
+        setError(
+          "Verification expired. Please re-enter your email to receive a new code.",
+        );
+        return;
+      }
 
       if (!res.ok) {
         setError(data.error || "Something went wrong.");
@@ -90,11 +110,90 @@ export default function MyListingsPage() {
 
       setListings(data.listings || []);
       setEnquiries(data.enquiries || {});
-      setSubmitted(true);
+      setStage("results");
     } catch {
       setError("Failed to load listings. Please try again.");
     } finally {
-      setLoading(false);
+      setLoadingListings(false);
+    }
+  };
+
+  const handleSendCode = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!email.trim()) return;
+
+    setSendingCode(true);
+    setError(null);
+
+    try {
+      const res = await fetch("/api/verify-otp/send", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: email.trim() }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError(data.error || "Failed to send verification code.");
+        return;
+      }
+      setStage("code");
+    } catch {
+      setError("Network error. Please try again.");
+    } finally {
+      setSendingCode(false);
+    }
+  };
+
+  const handleVerifyCode = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = code.trim();
+    if (trimmed.length !== 6) {
+      setError("Please enter the 6-digit code from your email.");
+      return;
+    }
+
+    setVerifying(true);
+    setError(null);
+
+    try {
+      const res = await fetch("/api/listings/my-listings/verify", {
+        method: "POST",
+        credentials: "same-origin",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: email.trim(), code: trimmed }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError(data.error || "Incorrect code. Please try again.");
+        return;
+      }
+      // Cookie is now set; fetch the listings.
+      await fetchListings(email.trim());
+    } catch {
+      setError("Network error. Please try again.");
+    } finally {
+      setVerifying(false);
+    }
+  };
+
+  const handleResendCode = async () => {
+    setError(null);
+    setSendingCode(true);
+    try {
+      const res = await fetch("/api/verify-otp/send", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: email.trim() }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError(data.error || "Failed to resend the code.");
+        return;
+      }
+    } catch {
+      setError("Network error. Please try again.");
+    } finally {
+      setSendingCode(false);
     }
   };
 
@@ -111,16 +210,17 @@ export default function MyListingsPage() {
           </p>
         </div>
 
-        {/* Email lookup form */}
-        {!submitted && (
+        {/* Step 1: email */}
+        {stage === "email" && (
           <div className="bg-white rounded-xl border border-slate-200 p-6 md:p-8 max-w-lg">
             <h2 className="text-lg font-bold text-slate-900 mb-2">
               Find your listings
             </h2>
             <p className="text-sm text-slate-500 mb-6">
-              Enter the email you used to submit your listing.
+              Enter the email you used to submit your listing. We&apos;ll send
+              you a 6-digit code to verify it&apos;s you.
             </p>
-            <form onSubmit={handleSubmit} className="space-y-4">
+            <form onSubmit={handleSendCode} className="space-y-4">
               <div>
                 <label
                   htmlFor="email"
@@ -138,31 +238,90 @@ export default function MyListingsPage() {
                   className="w-full px-3 py-2 border border-slate-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                 />
               </div>
-              {error && (
-                <p className="text-sm text-red-600">{error}</p>
-              )}
+              {error && <p className="text-sm text-red-600">{error}</p>}
               <button
                 type="submit"
-                disabled={loading}
+                disabled={sendingCode}
                 className="w-full bg-blue-600 text-white font-semibold py-2.5 rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed text-sm"
               >
-                {loading ? "Looking up..." : "View my listings"}
+                {sendingCode ? "Sending code..." : "Send code"}
               </button>
             </form>
           </div>
         )}
 
-        {/* Results */}
-        {submitted && (
+        {/* Step 2: 6-digit code */}
+        {stage === "code" && (
+          <div className="bg-white rounded-xl border border-slate-200 p-6 md:p-8 max-w-lg">
+            <h2 className="text-lg font-bold text-slate-900 mb-2">
+              Enter the code
+            </h2>
+            <p className="text-sm text-slate-500 mb-6">
+              We sent a 6-digit code to{" "}
+              <strong className="text-slate-700">{email}</strong>. Enter it
+              below to view your listings.
+            </p>
+            <form onSubmit={handleVerifyCode} className="space-y-4">
+              <div>
+                <label
+                  htmlFor="code"
+                  className="block text-sm font-medium text-slate-700 mb-1"
+                >
+                  6-digit code
+                </label>
+                <input
+                  id="code"
+                  type="text"
+                  inputMode="numeric"
+                  autoComplete="one-time-code"
+                  pattern="[0-9]{6}"
+                  maxLength={6}
+                  required
+                  value={code}
+                  onChange={(e) =>
+                    setCode(e.target.value.replace(/[^0-9]/g, "").slice(0, 6))
+                  }
+                  placeholder="123456"
+                  className="w-full px-3 py-2 border border-slate-300 rounded-lg text-lg tracking-widest text-center font-mono focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                />
+              </div>
+              {error && <p className="text-sm text-red-600">{error}</p>}
+              <button
+                type="submit"
+                disabled={verifying || loadingListings}
+                className="w-full bg-blue-600 text-white font-semibold py-2.5 rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed text-sm"
+              >
+                {verifying || loadingListings
+                  ? "Verifying..."
+                  : "Verify and view listings"}
+              </button>
+              <div className="flex items-center justify-between text-xs text-slate-500">
+                <button
+                  type="button"
+                  onClick={resetToEmail}
+                  className="hover:text-slate-700 underline-offset-2 hover:underline"
+                >
+                  Use a different email
+                </button>
+                <button
+                  type="button"
+                  onClick={handleResendCode}
+                  disabled={sendingCode}
+                  className="hover:text-slate-700 underline-offset-2 hover:underline disabled:opacity-50"
+                >
+                  {sendingCode ? "Sending..." : "Resend code"}
+                </button>
+              </div>
+            </form>
+          </div>
+        )}
+
+        {/* Step 3: results */}
+        {stage === "results" && (
           <div>
             {/* Back / change email */}
             <button
-              onClick={() => {
-                setSubmitted(false);
-                setListings([]);
-                setEnquiries({});
-                setExpandedListing(null);
-              }}
+              onClick={resetToEmail}
               className="flex items-center gap-1 text-sm text-blue-600 hover:text-blue-800 mb-6"
             >
               <Icon name="arrow-left" size={14} />
@@ -234,27 +393,43 @@ export default function MyListingsPage() {
                         <p className="text-lg font-extrabold text-slate-900 mb-3">
                           {formatPrice(
                             listing.asking_price_cents,
-                            listing.price_display
+                            listing.price_display,
                           )}
                         </p>
 
                         {/* Stats row */}
                         <div className="flex flex-wrap gap-4 text-xs text-slate-500">
                           <span className="flex items-center gap-1">
-                            <Icon name="eye" size={13} className="text-slate-400" />
+                            <Icon
+                              name="eye"
+                              size={13}
+                              className="text-slate-400"
+                            />
                             {listing.views} views
                           </span>
                           <span className="flex items-center gap-1">
-                            <Icon name="mail" size={13} className="text-slate-400" />
+                            <Icon
+                              name="mail"
+                              size={13}
+                              className="text-slate-400"
+                            />
                             {listing.enquiries} enquiries
                           </span>
                           <span className="flex items-center gap-1">
-                            <Icon name="calendar" size={13} className="text-slate-400" />
+                            <Icon
+                              name="calendar"
+                              size={13}
+                              className="text-slate-400"
+                            />
                             Listed {formatDate(listing.created_at)}
                           </span>
                           {listing.expires_at && (
                             <span className="flex items-center gap-1">
-                              <Icon name="clock" size={13} className="text-slate-400" />
+                              <Icon
+                                name="clock"
+                                size={13}
+                                className="text-slate-400"
+                              />
                               Expires {formatDate(listing.expires_at)}
                             </span>
                           )}
@@ -266,7 +441,7 @@ export default function MyListingsPage() {
                             <Link
                               href={verticalToPath(
                                 listing.vertical,
-                                listing.slug
+                                listing.slug,
                               )}
                               className="text-sm text-blue-600 hover:text-blue-800 font-medium flex items-center gap-1"
                             >
@@ -278,7 +453,7 @@ export default function MyListingsPage() {
                             <button
                               onClick={() =>
                                 setExpandedListing(
-                                  isExpanded ? null : listing.id
+                                  isExpanded ? null : listing.id,
                                 )
                               }
                               className="text-sm text-slate-600 hover:text-slate-800 font-medium flex items-center gap-1"

--- a/lib/listing-owner-cookie.ts
+++ b/lib/listing-owner-cookie.ts
@@ -1,0 +1,186 @@
+/**
+ * Signed `listing_owner_verified` cookie issuance + verification.
+ *
+ * Once a listing owner proves possession of their listing's contact
+ * email by completing the OTP challenge at
+ * /api/listings/my-listings/verify, this module issues an HMAC-signed
+ * cookie that /api/listings/my-listings checks on every subsequent
+ * request. The cookie is HttpOnly + SameSite=Strict + Secure (in
+ * prod) and lasts 1 hour.
+ *
+ * Format: `<base64url(payload)>.<base64url(hmac)>`
+ *   payload: { email: string, iat: number, exp: number }
+ *   hmac:    HMAC-SHA-256(payload, LISTING_OWNER_COOKIE_SECRET)
+ *
+ * The cookie is opaque to clients — the value is the only thing that
+ * matters; we never trust client-supplied claims because everything
+ * is re-validated against the HMAC.
+ *
+ * Why a separate cookie from admin-mfa-cookie:
+ *   - Different secret rotation cadence + scope (anonymous listing
+ *     owners ≠ authenticated admins).
+ *   - Different TTL (1h vs 12h) — listing-owner sessions are short
+ *     because the email is the only auth factor; admin-mfa is layered
+ *     on top of an existing Supabase Auth session.
+ *   - Different blast radius if leaked: this cookie only unlocks one
+ *     listing owner's enquiries, admin cookie unlocks /admin/**.
+ *
+ * SECURITY: LISTING_OWNER_COOKIE_SECRET must be ≥32 random bytes.
+ * Rotate by setting a new secret + invalidating all sessions; owners
+ * will have to re-verify (1h is the worst case anyway). On secret
+ * absence, this module REFUSES to sign or verify rather than falling
+ * back to a default — silent fallback would hide misconfiguration in
+ * prod and silently undermine the B-09 gate.
+ *
+ * Audit ref: docs/audits/REMEDIATION_QUEUE.md B-09a (route + OTP gate
+ * for /api/listings/my-listings).
+ */
+
+import { createHmac, timingSafeEqual } from "crypto";
+
+export const LISTING_OWNER_COOKIE_NAME = "listing_owner_verified";
+export const LISTING_OWNER_COOKIE_MAX_AGE_S = 60 * 60; // 1 hour
+
+interface ListingOwnerCookiePayload {
+  email: string;
+  iat: number;
+  exp: number;
+}
+
+export type ListingOwnerVerifyResult =
+  | { ok: true; email: string }
+  | {
+      ok: false;
+      reason:
+        | "missing"
+        | "malformed"
+        | "bad_signature"
+        | "expired"
+        | "no_secret"
+        | "email_mismatch";
+    };
+
+function getSecret(): string {
+  const secret = process.env.LISTING_OWNER_COOKIE_SECRET;
+  if (!secret || secret.length < 32) {
+    throw new Error(
+      "LISTING_OWNER_COOKIE_SECRET must be set to ≥32 characters. " +
+        "Generate with: openssl rand -hex 32",
+    );
+  }
+  return secret;
+}
+
+function b64urlEncode(buf: Buffer): string {
+  return buf
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function b64urlDecode(s: string): Buffer {
+  const padded = s.replace(/-/g, "+").replace(/_/g, "/");
+  const padding = padded.length % 4 === 0 ? 0 : 4 - (padded.length % 4);
+  return Buffer.from(padded + "=".repeat(padding), "base64");
+}
+
+/**
+ * Build a signed cookie value for the given listing-owner email.
+ * Caller is responsible for setting the cookie on the response with
+ * HttpOnly + SameSite=Strict + Secure (prod) +
+ * Max-Age=LISTING_OWNER_COOKIE_MAX_AGE_S.
+ */
+export function signListingOwnerCookie(
+  email: string,
+  nowMs: number = Date.now(),
+): string {
+  const secret = getSecret();
+  const iat = Math.floor(nowMs / 1000);
+  const exp = iat + LISTING_OWNER_COOKIE_MAX_AGE_S;
+  const payload: ListingOwnerCookiePayload = {
+    email: email.toLowerCase().trim(),
+    iat,
+    exp,
+  };
+  const payloadB64 = b64urlEncode(Buffer.from(JSON.stringify(payload), "utf8"));
+  const hmac = createHmac("sha256", secret).update(payloadB64).digest();
+  const hmacB64 = b64urlEncode(hmac);
+  return `${payloadB64}.${hmacB64}`;
+}
+
+/**
+ * Verify a cookie value. Returns the verified email on success or a
+ * structured rejection reason. Uses constant-time HMAC compare so
+ * timing leaks don't tell an attacker which byte mismatched.
+ *
+ * If `expectedEmail` is provided, the verified payload email must
+ * match (after normalisation). This guards against a caller swapping
+ * the `email` query param while reusing a cookie issued for a
+ * different address.
+ */
+export function verifyListingOwnerCookie(
+  value: string | undefined | null,
+  options: { expectedEmail?: string; nowMs?: number } = {},
+): ListingOwnerVerifyResult {
+  const nowMs = options.nowMs ?? Date.now();
+  if (!value) return { ok: false, reason: "missing" };
+
+  let secret: string;
+  try {
+    secret = getSecret();
+  } catch {
+    return { ok: false, reason: "no_secret" };
+  }
+
+  const parts = value.split(".");
+  if (parts.length !== 2) return { ok: false, reason: "malformed" };
+  const [payloadB64, hmacB64] = parts;
+  if (!payloadB64 || !hmacB64) {
+    return { ok: false, reason: "malformed" };
+  }
+
+  // Recompute HMAC and constant-time compare.
+  const expected = createHmac("sha256", secret).update(payloadB64).digest();
+  let supplied: Buffer;
+  try {
+    supplied = b64urlDecode(hmacB64);
+  } catch {
+    return { ok: false, reason: "malformed" };
+  }
+  if (supplied.length !== expected.length) {
+    return { ok: false, reason: "bad_signature" };
+  }
+  if (!timingSafeEqual(expected, supplied)) {
+    return { ok: false, reason: "bad_signature" };
+  }
+
+  // Parse payload.
+  let payload: ListingOwnerCookiePayload;
+  try {
+    payload = JSON.parse(b64urlDecode(payloadB64).toString("utf8"));
+  } catch {
+    return { ok: false, reason: "malformed" };
+  }
+  if (
+    typeof payload?.email !== "string" ||
+    typeof payload?.iat !== "number" ||
+    typeof payload?.exp !== "number"
+  ) {
+    return { ok: false, reason: "malformed" };
+  }
+
+  const nowS = Math.floor(nowMs / 1000);
+  if (nowS >= payload.exp) {
+    return { ok: false, reason: "expired" };
+  }
+
+  if (
+    options.expectedEmail !== undefined &&
+    payload.email !== options.expectedEmail.toLowerCase().trim()
+  ) {
+    return { ok: false, reason: "email_mismatch" };
+  }
+
+  return { ok: true, email: payload.email };
+}

--- a/supabase/migrations/20260501_b09b_listing_enquiries_drop_anon_select.sql
+++ b/supabase/migrations/20260501_b09b_listing_enquiries_drop_anon_select.sql
@@ -1,0 +1,55 @@
+-- ============================================================================
+-- Migration: Drop "anon select enquiries" policy from listing_enquiries
+-- Date: 2026-05-01
+-- Audit ref: docs/audits/REMEDIATION_QUEUE.md B-09b
+-- Companion: app/api/listings/my-listings/route.ts (B-09a — refactored to
+--            use createAdminClient() behind an OTP-gated signed cookie)
+--
+-- History (B-04 → B-06 → B-09):
+--   - 20260601_rls_investment_listings.sql (B-04, option 2): preserved anon
+--     SELECT/INSERT to keep the public marketplace working while RLS was
+--     enabled. Tightened later by B-08 (20260602_investment_listings_tighten_rls.sql).
+--   - 20260601_rls_listing_enquiries.sql (B-06, first table): enabled RLS on
+--     listing_enquiries with an explicit `anon select enquiries` policy
+--     (USING true) to preserve the /api/listings/my-listings flow that, at
+--     the time, used the anon-key client to read enquiries by listing_id.
+--     That migration's own header comment flagged the policy as a known PII
+--     enumeration vector and pointed at B-09 as the cleanup item.
+--   - This migration (B-09b) drops the policy now that B-09a has refactored
+--     the route to use createAdminClient() behind an OTP-gated signed cookie.
+--     After this migration, the anon DB role cannot SELECT any row from
+--     listing_enquiries — the only path to enquiry PII is through the
+--     route, which requires a verified `listing_owner_verified` cookie.
+--
+-- Why: closes the PII enumeration vector that B-06 explicitly preserved.
+-- Anon callers (browser, public REST clients) can no longer read
+-- `listing_enquiries.user_name / user_email / user_phone / message` by
+-- guessing or scraping listing IDs. Service-role retains full access via
+-- the existing "service_role full access" policy, so admin diagnostics
+-- (app/api/listings/[id]/route.ts) and the refactored my-listings route
+-- continue to work.
+--
+-- Other callers verified non-affected (grep on 2026-05-01):
+--   - app/api/listings/enquire/route.ts — anon INSERT only (covered by the
+--     untouched "anon insert enquiry" policy).
+--   - app/api/listings/[id]/route.ts — service-role SELECT count.
+--   - app/api/listings/my-listings/route.ts — service-role after B-09a.
+--   - No anon UPDATE or DELETE caller exists.
+--
+-- Idempotent: DROP POLICY IF EXISTS is a no-op if the policy is already
+-- gone. Safe to re-run.
+--
+-- Rollback (DO NOT run unless B-09a is also reverted — re-creating the
+-- policy without the OTP gate would re-open the PII enumeration vector):
+--   CREATE POLICY "anon select enquiries"
+--     ON public.listing_enquiries
+--     FOR SELECT
+--     TO anon
+--     USING (true);
+-- ============================================================================
+
+BEGIN;
+
+DROP POLICY IF EXISTS "anon select enquiries" ON public.listing_enquiries;
+
+COMMIT;


### PR DESCRIPTION
## ⛔ Do not merge until env var is set in Vercel

This PR introduces a new env var:
- \`LISTING_OWNER_COOKIE_SECRET\` — ≥32 random bytes, generate with \`openssl rand -hex 32\`

If it's not set when this merges, \`/api/listings/my-listings/verify\` returns 503 and \`/invest/my-listings\` is locked. Documented in \`.env.local.example\`. Closest analog is \`ADMIN_MFA_COOKIE_SECRET\`.

**Founder action:** set the env var in Vercel for production + preview, then mark this PR ready and approve auto-merge.

## Summary
- **Closes a PII enumeration vector**: previously anyone could pass \`?email=victim@example.com\` to \`/api/listings/my-listings\` and harvest enquirer names + emails + messages.
- **B-09a** — route + OTP gate: requires HMAC-signed \`listing_owner_verified\` cookie (1h TTL) scoped to the requested email. Without it, returns 401 with \`next: /api/verify-otp/send\`. New \`/api/listings/my-listings/verify\` endpoint validates the OTP and sets the cookie.
- **B-09b** — RLS migration drops the legacy \`anon select enquiries\` policy. The route is now the only path to enquiry PII.
- Frontend (\`/invest/my-listings\`) is now a 3-step flow: email → OTP code → listings.

## Test plan
- [x] 44/44 tests passing (17 cookie helper + 12 verify route + 15 my-listings GET)
- [x] lint-staged passes
- [ ] env var \`LISTING_OWNER_COOKIE_SECRET\` set in Vercel
- [ ] CI green
- [ ] Manual smoke: send OTP → enter code → see listings (preview env)

🤖 Generated with [Claude Code](https://claude.com/claude-code)