### PR TITLE
feat(a): A-03 batch 1 — backfill 5 revenue table migrations (idempotent + RLS)

### DIFF
--- a/supabase/migrations/20260603130000_a03_backfill_revenue_affiliate_payout_reports.sql
+++ b/supabase/migrations/20260603130000_a03_backfill_revenue_affiliate_payout_reports.sql
@@ -1,0 +1,130 @@
+-- ============================================================================
+-- Migration: Backfill public.affiliate_payout_reports (A-03 batch 1)
+-- Date:      2026-05-01 (queued under 20260603 to sort after A-02 batch 1)
+-- Audit ref: docs/audits/drift-list.md (A-05 affiliate / finance family,
+--            shipped via the A-03 revenue iteration grouping)
+-- Queue item: docs/audits/REMEDIATION_QUEUE.md A-03
+--
+-- Purpose
+--   `affiliate_payout_reports` is declared in `lib/database.types.ts`
+--   (line 1504) but the migration tree never CREATEs the table. It stores
+--   per-broker, per-period payout reports uploaded from affiliate networks
+--   (Awin / Impact / etc.) — the "what the network reported" side of the
+--   reconciliation against our own click/conversion tracking.
+--
+--   Used by 1 call site:
+--     - app/api/cron/affiliate-payout-recon/route.ts  (read for variance calc)
+--
+--   Writes happen via the admin client during the cron's reconciliation pass
+--   (the route itself only reads here; uploads land via the admin upload
+--   route which uses the service-role client).
+--
+-- Why it matters
+--   Revenue forensics — without the report ledger, the variance cron has
+--   nothing to compare tracked clicks against, and broker payout disputes
+--   lose their authoritative "what the network told us" record. Bringing it
+--   into the migration tree means a clean rebuild matches prod.
+--
+-- Schema source of truth
+--   Live DB (verified 2026-05-01 via information_schema.columns) +
+--   lib/database.types.ts → Database['public']['Tables']['affiliate_payout_reports'].
+--   - id                       bigint      PK   nextval('affiliate_payout_reports_id_seq')
+--   - broker_slug              text        NOT NULL
+--   - period_start             date        NOT NULL
+--   - period_end               date        NOT NULL
+--   - reported_clicks          integer     NOT NULL DEFAULT 0
+--   - reported_conversions     integer     NOT NULL DEFAULT 0
+--   - reported_revenue_cents   bigint      NOT NULL DEFAULT 0
+--   - currency                 text        NOT NULL DEFAULT 'AUD'
+--   - source                   text        NULLABLE  (e.g. 'awin', 'impact')
+--   - raw_payload              jsonb       NULLABLE  (full network response)
+--   - uploaded_by              text        NULLABLE  (admin email)
+--   - uploaded_at              timestamptz NOT NULL DEFAULT now()
+--
+--   UNIQUE (broker_slug, period_start, period_end) — one report per
+--   broker per reporting window, observed in live DB.
+--
+-- Divergence from types
+--   - Types declare `reported_revenue_cents: number`; live DB is `bigint`
+--     (cents at scale fit). Migration uses `bigint` — trust live DB.
+--   - Types declare `id: number`; live DB is `bigint` with sequence default.
+--     Migration uses `bigserial` (idiomatic for nextval-backed bigint PK).
+--   - Types declare `currency: string` with no nullability hint at runtime;
+--     live DB has NOT NULL DEFAULT 'AUD'. Migration matches live DB.
+--
+-- RLS policy chosen — service-role-only (deny anon + authenticated by default)
+--   - service_role: explicit FOR ALL allow.
+--   - anon + authenticated: NO policy — RLS denies all access by default.
+--
+--   Justification: revenue ledger. The single app reader is a Vercel cron
+--   that runs under the service-role client (`app/api/cron/affiliate-payout-recon`).
+--   Uploads happen via admin tooling. There is no user-facing read path —
+--   broker payout figures are commercially sensitive (per-network rates,
+--   raw payloads can include partner-specific identifiers) and must never
+--   leak to anon/authenticated. Pattern matches `lead_pricing_log` and
+--   `admin_audit_log`: append-only / admin-only revenue surfaces stay
+--   server-side. Revenue tables are exempted from the RLS isolation gate
+--   (no user_id column to isolate on).
+--
+-- Idempotency
+--   - The body uses `if not exists` on the table — no-op when it exists.
+--   - CREATE UNIQUE INDEX IF NOT EXISTS on the natural key.
+--   - CREATE INDEX IF NOT EXISTS on the broker/period DESC lookup pattern.
+--   - DROP POLICY IF EXISTS + CREATE POLICY for every policy.
+--
+-- Risk: low
+--   - Forward-only schema add; no data shaping.
+--   - All callers already use service-role; no behavioural change.
+--   - FK target for `affiliate_payout_variance.report_id` is created here
+--     so the next migration in this batch can attach safely.
+--
+-- Rollback
+--   BEGIN;
+--     DROP POLICY IF EXISTS "service_role full access" ON public.affiliate_payout_reports;
+--     DROP INDEX IF EXISTS idx_affiliate_payout_reports_slug_period;
+--     DROP INDEX IF EXISTS affiliate_payout_reports_broker_period_uniq;
+--     ALTER TABLE public.affiliate_payout_reports DISABLE ROW LEVEL SECURITY;
+--     -- DROP TABLE public.affiliate_payout_reports;  -- destructive; clean rebuild only
+--   COMMIT;
+-- ============================================================================
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.affiliate_payout_reports (
+  id                       bigserial   NOT NULL,
+  broker_slug              text        NOT NULL,
+  period_start             date        NOT NULL,
+  period_end               date        NOT NULL,
+  reported_clicks          integer     NOT NULL DEFAULT 0,
+  reported_conversions     integer     NOT NULL DEFAULT 0,
+  reported_revenue_cents   bigint      NOT NULL DEFAULT 0,
+  currency                 text        NOT NULL DEFAULT 'AUD',
+  source                   text,
+  raw_payload              jsonb,
+  uploaded_by              text,
+  uploaded_at              timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT affiliate_payout_reports_pkey PRIMARY KEY (id)
+);
+
+-- Natural key: one upload per broker per reporting window.
+CREATE UNIQUE INDEX IF NOT EXISTS affiliate_payout_reports_broker_period_uniq
+  ON public.affiliate_payout_reports (broker_slug, period_start, period_end);
+
+-- Lookup pattern: latest report per broker (admin dashboard + recon cron).
+CREATE INDEX IF NOT EXISTS idx_affiliate_payout_reports_slug_period
+  ON public.affiliate_payout_reports (broker_slug, period_end DESC);
+
+ALTER TABLE public.affiliate_payout_reports ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.affiliate_payout_reports FORCE  ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "service_role full access" ON public.affiliate_payout_reports;
+CREATE POLICY "service_role full access"
+  ON public.affiliate_payout_reports
+  FOR ALL TO service_role
+  USING (true) WITH CHECK (true);
+
+-- No anon/authenticated policies — revenue ledger; all readers and writers
+-- are server-side service-role (cron + admin upload). Mirrors the
+-- admin_audit_log pattern.
+
+COMMIT;

--- a/supabase/migrations/20260603130001_a03_backfill_revenue_affiliate_payout_variance.sql
+++ b/supabase/migrations/20260603130001_a03_backfill_revenue_affiliate_payout_variance.sql
@@ -1,0 +1,130 @@
+-- ============================================================================
+-- Migration: Backfill public.affiliate_payout_variance (A-03 batch 1)
+-- Date:      2026-05-01 (queued under 20260603 to sort after A-02 batch 1)
+-- Audit ref: docs/audits/drift-list.md (A-05 affiliate / finance family,
+--            shipped via the A-03 revenue iteration grouping)
+-- Queue item: docs/audits/REMEDIATION_QUEUE.md A-03
+--
+-- Purpose
+--   `affiliate_payout_variance` is declared in `lib/database.types.ts`
+--   (line 1549) but the migration tree never CREATEs the table. It stores
+--   the per-broker reconciliation result from comparing
+--   `affiliate_payout_reports` (network-reported clicks/revenue) against
+--   our own first-party click/conversion tracking, with a `flagged`
+--   boolean for follow-up.
+--
+--   Used by 2 call sites:
+--     - app/api/cron/affiliate-payout-recon/route.ts  (read recent + insert)
+--
+--   Inserted from the recon cron once per (broker, period) pair after each
+--   variance calculation pass.
+--
+-- Why it matters
+--   Revenue forensics — variance rows are the audit trail behind every
+--   "broker is under-reporting" investigation. Without it, payout
+--   discrepancies have no historical record.
+--
+-- Schema source of truth
+--   Live DB (verified 2026-05-01 via information_schema.columns) +
+--   lib/database.types.ts → Database['public']['Tables']['affiliate_payout_variance'].
+--   - id                  bigint      PK   nextval('affiliate_payout_variance_id_seq')
+--   - report_id           bigint      NULLABLE  FK -> affiliate_payout_reports(id) ON DELETE CASCADE
+--   - broker_slug         text        NOT NULL
+--   - period_start        date        NOT NULL
+--   - period_end          date        NOT NULL
+--   - tracked_clicks      integer     NOT NULL
+--   - reported_clicks     integer     NOT NULL
+--   - click_delta         integer     NOT NULL  (tracked - reported)
+--   - click_delta_pct     numeric     NULLABLE
+--   - revenue_cents       bigint      NOT NULL
+--   - flagged             boolean     NOT NULL DEFAULT false
+--   - computed_at         timestamptz NOT NULL DEFAULT now()
+--
+-- Divergence from types
+--   - Types declare `revenue_cents: number`; live DB is `bigint`. Migration
+--     uses `bigint` — trust live DB. (Cents-at-scale rationale.)
+--   - Types declare `click_delta_pct: number | null`; live DB is `numeric`
+--     (no precision/scale specified). Migration uses `numeric` — trust
+--     live DB.
+--
+-- FK behaviour (verified live)
+--   `report_id REFERENCES affiliate_payout_reports(id) ON DELETE CASCADE`.
+--   If a report row is deleted (e.g. re-upload), its derived variance
+--   rows go with it — sensible because variance is a pure function of the
+--   report.
+--
+-- RLS policy chosen — service-role-only (deny anon + authenticated by default)
+--   - service_role: explicit FOR ALL allow.
+--   - anon + authenticated: NO policy — RLS denies all access by default.
+--
+--   Justification: same as `affiliate_payout_reports` — revenue forensics,
+--   server-side only, no user-facing read path. Pattern matches
+--   `admin_audit_log`.
+--
+-- Idempotency
+--   - The body uses `if not exists` on the table — no-op when it exists.
+--   - CREATE INDEX IF NOT EXISTS for the FK and the partial-index lookup.
+--   - DROP POLICY IF EXISTS + CREATE POLICY for every policy.
+--
+-- Risk: low
+--   - Forward-only schema add; no data shaping.
+--   - FK depends on `affiliate_payout_reports`, which is created in the
+--     migration immediately preceding this one (20260603130000_…).
+--   - All callers already use service-role; no behavioural change.
+--
+-- Rollback
+--   BEGIN;
+--     DROP POLICY IF EXISTS "service_role full access" ON public.affiliate_payout_variance;
+--     DROP INDEX IF EXISTS idx_payout_variance_flagged;
+--     DROP INDEX IF EXISTS idx_affiliate_payout_variance_report_id;
+--     ALTER TABLE public.affiliate_payout_variance DISABLE ROW LEVEL SECURITY;
+--     -- DROP TABLE public.affiliate_payout_variance;  -- destructive; clean rebuild only
+--   COMMIT;
+-- ============================================================================
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.affiliate_payout_variance (
+  id                  bigserial   NOT NULL,
+  report_id           bigint,
+  broker_slug         text        NOT NULL,
+  period_start        date        NOT NULL,
+  period_end          date        NOT NULL,
+  tracked_clicks      integer     NOT NULL,
+  reported_clicks     integer     NOT NULL,
+  click_delta         integer     NOT NULL,
+  click_delta_pct     numeric,
+  revenue_cents       bigint      NOT NULL,
+  flagged             boolean     NOT NULL DEFAULT false,
+  computed_at         timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT affiliate_payout_variance_pkey PRIMARY KEY (id),
+  CONSTRAINT affiliate_payout_variance_report_id_fkey
+    FOREIGN KEY (report_id)
+    REFERENCES public.affiliate_payout_reports(id)
+    ON DELETE CASCADE
+);
+
+-- FK index — speeds variance lookups by report and avoids the missing-FK-index
+-- advisory captured in 20260426_add_missing_fk_indexes.sql for sibling tables.
+CREATE INDEX IF NOT EXISTS idx_affiliate_payout_variance_report_id
+  ON public.affiliate_payout_variance (report_id);
+
+-- Partial index on flagged rows — recon dashboards page through "still
+-- needs follow-up" rows in computed_at DESC order.
+CREATE INDEX IF NOT EXISTS idx_payout_variance_flagged
+  ON public.affiliate_payout_variance (computed_at DESC)
+  WHERE flagged = true;
+
+ALTER TABLE public.affiliate_payout_variance ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.affiliate_payout_variance FORCE  ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "service_role full access" ON public.affiliate_payout_variance;
+CREATE POLICY "service_role full access"
+  ON public.affiliate_payout_variance
+  FOR ALL TO service_role
+  USING (true) WITH CHECK (true);
+
+-- No anon/authenticated policies — revenue ledger; all readers and writers
+-- are server-side service-role. Mirrors `affiliate_payout_reports`.
+
+COMMIT;

--- a/supabase/migrations/20260603130002_a03_backfill_revenue_sponsored_placement_pricing.sql
+++ b/supabase/migrations/20260603130002_a03_backfill_revenue_sponsored_placement_pricing.sql
@@ -1,0 +1,139 @@
+-- ============================================================================
+-- Migration: Backfill public.sponsored_placement_pricing (A-03 batch 1)
+-- Date:      2026-05-01 (queued under 20260603 to sort after A-02 batch 1)
+-- Audit ref: docs/audits/drift-list.md (A-06 marketplace family,
+--            shipped via the A-03 revenue iteration grouping)
+-- Queue item: docs/audits/REMEDIATION_QUEUE.md A-03
+--
+-- Purpose
+--   `sponsored_placement_pricing` is declared in `lib/database.types.ts`
+--   (line 10659) but the migration tree never CREATEs the table. It is
+--   the rate card for sponsored placement slots — one row per (tier,
+--   duration_days) combination, with the price in cents, the Stripe
+--   price_id for checkout, and a max-concurrent slot count for capacity.
+--
+--   Used by 2 call sites:
+--     - app/advertise/featured-placement/page.tsx     (public read of the rate card)
+--     - app/api/advertise/create-checkout/route.ts    (read price for Stripe checkout)
+--
+-- Why it matters
+--   Revenue surface — drives the `/advertise/featured-placement` page and
+--   the Stripe Checkout creation flow. Pricing is shown publicly on the
+--   marketing page, but writes are admin-only.
+--
+-- Schema source of truth
+--   Live DB (verified 2026-05-01 via information_schema.columns) +
+--   lib/database.types.ts → Database['public']['Tables']['sponsored_placement_pricing'].
+--   - id                bigint      PK   nextval('sponsored_placement_pricing_id_seq')
+--   - tier              text        NOT NULL  CHECK (tier IN ('featured_partner','editors_pick','deal_of_month'))
+--   - duration_days     integer     NOT NULL  CHECK (duration_days > 0)
+--   - amount_cents      bigint      NOT NULL  CHECK (amount_cents > 0)
+--   - currency          text        NOT NULL DEFAULT 'AUD'
+--   - stripe_price_id   text        NULLABLE
+--   - max_concurrent    integer     NOT NULL DEFAULT 3
+--   - description       text        NULLABLE
+--   - active            boolean     NOT NULL DEFAULT true
+--   - sort_order        integer     NOT NULL DEFAULT 0
+--   - created_at        timestamptz NOT NULL DEFAULT now()
+--
+--   UNIQUE (tier, duration_days) — one price per (tier, duration) pair.
+--
+-- Divergence from types
+--   - Types declare `amount_cents: number`; live DB is `bigint`. Migration
+--     uses `bigint` — trust live DB.
+--   - Live DB has CHECK constraints on `tier`, `duration_days > 0`,
+--     `amount_cents > 0` not visible in the type. Migration ports them
+--     verbatim from live.
+--
+-- RLS policy chosen — read-public-config / write-admin
+--   - service_role: explicit FOR ALL allow.
+--   - authenticated: SELECT permitted (active rows only — see policy below).
+--   - anon: SELECT permitted (active rows only).
+--   - INSERT/UPDATE/DELETE: NOT granted to anon/authenticated. Rate card
+--     edits flow through admin tooling using the service-role client.
+--
+--   Justification: this is a rate card, not PII. The marketing page
+--   (`/advertise/featured-placement`) renders prices to anonymous visitors
+--   via the user-cookie Supabase client. Same pattern as `lead_pricing`
+--   in A-02 batch 1 — public-read of pricing config is the existing
+--   behaviour, and granting read here means we don't need to refactor the
+--   marketing page to use the admin client just to fetch list prices.
+--   The `WHERE active = true` in the SELECT policy keeps draft/retired
+--   tiers internal-only (admin tooling reads via service-role and sees
+--   everything).
+--
+-- Idempotency
+--   - The body uses `if not exists` on the table — no-op when it exists.
+--   - DROP POLICY IF EXISTS + CREATE POLICY for every policy.
+--   - The CHECK constraints are inlined in the table definition so they
+--     attach atomically with the create; no separate ADD CONSTRAINT step
+--     to guard.
+--
+-- Risk: low
+--   - Forward-only schema add; no data shaping.
+--   - Public read of active rows mirrors today's behaviour (the
+--     marketing page already reads the table via the user-cookie client).
+--   - No write paths exposed to anon/authenticated.
+--
+-- Flagged ambiguity
+--   - `stripe_price_id` is left nullable here to match live DB and types,
+--     but a row with no `stripe_price_id` cannot drive Stripe Checkout.
+--     The create-checkout route should defensively skip such rows; not in
+--     scope for this backfill.
+--
+-- Rollback
+--   BEGIN;
+--     DROP POLICY IF EXISTS "service_role full access"  ON public.sponsored_placement_pricing;
+--     DROP POLICY IF EXISTS "public read active pricing" ON public.sponsored_placement_pricing;
+--     ALTER TABLE public.sponsored_placement_pricing DISABLE ROW LEVEL SECURITY;
+--     -- DROP TABLE public.sponsored_placement_pricing;  -- destructive; clean rebuild only
+--   COMMIT;
+-- ============================================================================
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.sponsored_placement_pricing (
+  id                bigserial   NOT NULL,
+  tier              text        NOT NULL,
+  duration_days     integer     NOT NULL,
+  amount_cents      bigint      NOT NULL,
+  currency          text        NOT NULL DEFAULT 'AUD',
+  stripe_price_id   text,
+  max_concurrent    integer     NOT NULL DEFAULT 3,
+  description       text,
+  active            boolean     NOT NULL DEFAULT true,
+  sort_order        integer     NOT NULL DEFAULT 0,
+  created_at        timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT sponsored_placement_pricing_pkey PRIMARY KEY (id),
+  CONSTRAINT sponsored_placement_pricing_tier_check
+    CHECK (tier IN ('featured_partner', 'editors_pick', 'deal_of_month')),
+  CONSTRAINT sponsored_placement_pricing_duration_days_check
+    CHECK (duration_days > 0),
+  CONSTRAINT sponsored_placement_pricing_amount_cents_check
+    CHECK (amount_cents > 0),
+  CONSTRAINT sponsored_placement_pricing_tier_duration_days_key
+    UNIQUE (tier, duration_days)
+);
+
+ALTER TABLE public.sponsored_placement_pricing ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.sponsored_placement_pricing FORCE  ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "service_role full access" ON public.sponsored_placement_pricing;
+CREATE POLICY "service_role full access"
+  ON public.sponsored_placement_pricing
+  FOR ALL TO service_role
+  USING (true) WITH CHECK (true);
+
+-- Public read of active rate card — same pattern as lead_pricing (A-02
+-- batch 1). The marketing page renders prices to anonymous visitors;
+-- writes go through admin/service-role only.
+DROP POLICY IF EXISTS "public read active pricing" ON public.sponsored_placement_pricing;
+CREATE POLICY "public read active pricing"
+  ON public.sponsored_placement_pricing
+  FOR SELECT TO anon, authenticated
+  USING (active = true);
+
+-- No anon/authenticated INSERT/UPDATE/DELETE: rate card edits flow through
+-- admin tooling using the service-role client.
+
+COMMIT;

--- a/supabase/migrations/20260603130003_a03_backfill_revenue_sponsored_placement_bookings.sql
+++ b/supabase/migrations/20260603130003_a03_backfill_revenue_sponsored_placement_bookings.sql
@@ -1,0 +1,195 @@
+-- ============================================================================
+-- Migration: Backfill public.sponsored_placement_bookings (A-03 batch 1)
+-- Date:      2026-05-01 (queued under 20260603 to sort after A-02 batch 1)
+-- Audit ref: docs/audits/drift-list.md (A-06 marketplace family,
+--            shipped via the A-03 revenue iteration grouping)
+-- Queue item: docs/audits/REMEDIATION_QUEUE.md A-03
+--
+-- Purpose
+--   `sponsored_placement_bookings` is declared in `lib/database.types.ts`
+--   (line 10585) but the migration tree never CREATEs the table. It is
+--   the booking ledger for sponsored placement slots — one row per paid
+--   slot reservation, with the broker, tier, time window, Stripe payment
+--   identifiers, and lifecycle timestamps (applied_at, cleared_at).
+--
+--   Used by 6 call sites:
+--     - app/admin/sponsored-queue/page.tsx                          (admin: read)
+--     - app/api/advertise/create-checkout/route.ts                  (insert pre-checkout row)
+--     - app/api/cron/sponsored-renewal-reminder/route.ts            (read + update)
+--     - app/api/cron/sponsored-placement-apply/route.ts             (read + update lifecycle)
+--     - app/broker-portal/sponsored-slots/page.tsx                  (broker: read own)
+--     - lib/stripe-webhook/handlers/checkout-session-completed.ts   (read + update on payment)
+--
+-- Why it matters
+--   Revenue ledger — every paid sponsored slot has a row here. Drives the
+--   admin sponsored queue, the broker-portal "your slots" view, the renewal
+--   reminder cron, and the lifecycle cron that flips status from
+--   scheduled -> active -> ended. Stripe webhook flow finalises the row
+--   after checkout completes.
+--
+-- Schema source of truth
+--   Live DB (verified 2026-05-01 via information_schema.columns) +
+--   lib/database.types.ts → Database['public']['Tables']['sponsored_placement_bookings'].
+--   - id                         bigint      PK   nextval('sponsored_placement_bookings_id_seq')
+--   - broker_slug                text        NOT NULL
+--   - tier                       text        NOT NULL  CHECK IN ('featured_partner','editors_pick','deal_of_month')
+--   - starts_at                  timestamptz NOT NULL
+--   - ends_at                    timestamptz NOT NULL  (CHECK ends_at > starts_at)
+--   - amount_cents               bigint      NULLABLE  (paid amount captured post-checkout)
+--   - currency                   text        NOT NULL DEFAULT 'AUD'
+--   - invoice_ref                text        NULLABLE
+--   - notes                      text        NULLABLE
+--   - status                     text        NOT NULL DEFAULT 'scheduled'
+--                                            CHECK IN ('scheduled','active','ended','cancelled')
+--   - created_by                 text        NULLABLE  (admin email or broker session)
+--   - created_at                 timestamptz NOT NULL DEFAULT now()
+--   - applied_at                 timestamptz NULLABLE  (when status flipped to active)
+--   - cleared_at                 timestamptz NULLABLE  (when status flipped to ended)
+--   - broker_id                  bigint      NULLABLE  FK -> brokers(id) ON DELETE SET NULL
+--   - stripe_session_id          text        NULLABLE  (UNIQUE when set)
+--   - stripe_payment_intent_id   text        NULLABLE
+--   - stripe_invoice_url         text        NULLABLE
+--   - renewal_reminder_sent_at   timestamptz NULLABLE
+--
+-- Divergence from types
+--   - Types declare `amount_cents: number | null`; live DB is `bigint`.
+--     Migration uses `bigint`.
+--   - Types declare `broker_id: number | null`; live DB is `bigint` with
+--     FK to `brokers(id)` (numeric type bigint in `brokers`). Migration
+--     mirrors live.
+--   - Live DB has CHECK constraints (`status_check`, `tier_check`, and
+--     the unnamed `ends_at > starts_at` check) not visible in the type.
+--     Migration ports them verbatim.
+--   - Live DB has a partial UNIQUE INDEX on `stripe_session_id WHERE NOT NULL`
+--     (`idx_sponsored_bookings_session_uniq`) plus three lookup indexes:
+--     `idx_sponsored_bookings_active`, `idx_sponsored_bookings_reminder_due`,
+--     `idx_sponsored_bookings_window`. Migration ports them.
+--
+-- FK behaviour (verified live)
+--   `broker_id REFERENCES brokers(id) ON DELETE SET NULL`. If a broker
+--   directory row is deleted (rare; brokers usually soft-delete), the
+--   booking history survives with broker_id nulled — `broker_slug` remains
+--   as the immutable historical reference.
+--
+-- RLS policy chosen — service-role-only (deny anon + authenticated by default)
+--   - service_role: explicit FOR ALL allow.
+--   - anon + authenticated: NO policy — RLS denies all access by default.
+--
+--   Justification: revenue ledger with payment identifiers (Stripe
+--   session/payment-intent/invoice URL). Every reader is server-side:
+--     - admin pages run server-side and use the service-role/admin client.
+--     - broker-portal "your slots" view (`app/broker-portal/sponsored-slots/page.tsx`)
+--       is a server component that uses the admin client and filters by
+--       the authenticated broker's session before returning rows. RLS does
+--       not need to enforce broker-isolation here because the page never
+--       reaches Supabase from the user-cookie client; the broker session
+--       boundary is enforced in app code first.
+--     - crons and the Stripe webhook all run service-role.
+--   Granting authenticated read would expose every broker's revenue and
+--   Stripe identifiers to every other authenticated user — strict deny is
+--   correct. Pattern matches `marketplace_invoices` / `wallet_transactions`
+--   ownership model elsewhere in the tree.
+--
+-- Idempotency
+--   - The body uses `if not exists` on the table — no-op when it exists.
+--   - CREATE INDEX IF NOT EXISTS for FK and lookup indexes.
+--   - CREATE UNIQUE INDEX IF NOT EXISTS for the partial Stripe-session uniqueness.
+--   - DROP POLICY IF EXISTS + CREATE POLICY for every policy.
+--
+-- Risk: low
+--   - Forward-only schema add; no data shaping.
+--   - All callers already use admin/service-role; deny-anon does not
+--     change behaviour.
+--   - FK depends on `brokers` (created by the marketplace migrations
+--     long predating this batch).
+--
+-- Rollback
+--   BEGIN;
+--     DROP POLICY IF EXISTS "service_role full access" ON public.sponsored_placement_bookings;
+--     DROP INDEX IF EXISTS idx_sponsored_placement_bookings_broker_id;
+--     DROP INDEX IF EXISTS idx_sponsored_bookings_window;
+--     DROP INDEX IF EXISTS idx_sponsored_bookings_reminder_due;
+--     DROP INDEX IF EXISTS idx_sponsored_bookings_active;
+--     DROP INDEX IF EXISTS idx_sponsored_bookings_session_uniq;
+--     ALTER TABLE public.sponsored_placement_bookings DISABLE ROW LEVEL SECURITY;
+--     -- DROP TABLE public.sponsored_placement_bookings;  -- destructive; clean rebuild only
+--   COMMIT;
+-- ============================================================================
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.sponsored_placement_bookings (
+  id                         bigserial   NOT NULL,
+  broker_slug                text        NOT NULL,
+  tier                       text        NOT NULL,
+  starts_at                  timestamptz NOT NULL,
+  ends_at                    timestamptz NOT NULL,
+  amount_cents               bigint,
+  currency                   text        NOT NULL DEFAULT 'AUD',
+  invoice_ref                text,
+  notes                      text,
+  status                     text        NOT NULL DEFAULT 'scheduled',
+  created_by                 text,
+  created_at                 timestamptz NOT NULL DEFAULT now(),
+  applied_at                 timestamptz,
+  cleared_at                 timestamptz,
+  broker_id                  bigint,
+  stripe_session_id          text,
+  stripe_payment_intent_id   text,
+  stripe_invoice_url         text,
+  renewal_reminder_sent_at   timestamptz,
+  CONSTRAINT sponsored_placement_bookings_pkey PRIMARY KEY (id),
+  CONSTRAINT sponsored_placement_bookings_tier_check
+    CHECK (tier IN ('featured_partner', 'editors_pick', 'deal_of_month')),
+  CONSTRAINT sponsored_placement_bookings_status_check
+    CHECK (status IN ('scheduled', 'active', 'ended', 'cancelled')),
+  CONSTRAINT sponsored_placement_bookings_check
+    CHECK (ends_at > starts_at),
+  CONSTRAINT sponsored_placement_bookings_broker_id_fkey
+    FOREIGN KEY (broker_id)
+    REFERENCES public.brokers(id)
+    ON DELETE SET NULL
+);
+
+-- FK index — broker_id lookups (admin sponsored queue groups by broker).
+CREATE INDEX IF NOT EXISTS idx_sponsored_placement_bookings_broker_id
+  ON public.sponsored_placement_bookings (broker_id);
+
+-- Lifecycle scan — the apply cron picks up scheduled+active rows ordered
+-- by starts_at to flip status.
+CREATE INDEX IF NOT EXISTS idx_sponsored_bookings_active
+  ON public.sponsored_placement_bookings (status, starts_at)
+  WHERE status IN ('scheduled', 'active');
+
+-- Renewal reminder cron — find active rows whose ends_at is approaching
+-- and that haven't been reminded yet.
+CREATE INDEX IF NOT EXISTS idx_sponsored_bookings_reminder_due
+  ON public.sponsored_placement_bookings (ends_at)
+  WHERE status = 'active' AND renewal_reminder_sent_at IS NULL;
+
+-- Window overlap checks — concurrent-slot capacity validation in the
+-- create-checkout route.
+CREATE INDEX IF NOT EXISTS idx_sponsored_bookings_window
+  ON public.sponsored_placement_bookings (starts_at, ends_at);
+
+-- Stripe session idempotency — webhook handler upserts by session_id; the
+-- partial unique index prevents duplicate finalisation if Stripe retries.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_sponsored_bookings_session_uniq
+  ON public.sponsored_placement_bookings (stripe_session_id)
+  WHERE stripe_session_id IS NOT NULL;
+
+ALTER TABLE public.sponsored_placement_bookings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.sponsored_placement_bookings FORCE  ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "service_role full access" ON public.sponsored_placement_bookings;
+CREATE POLICY "service_role full access"
+  ON public.sponsored_placement_bookings
+  FOR ALL TO service_role
+  USING (true) WITH CHECK (true);
+
+-- No anon/authenticated policies — revenue ledger with payment
+-- identifiers. Broker-portal access is already gated server-side by the
+-- broker session and uses the admin client; granting authenticated read
+-- here would leak every broker's Stripe identifiers across tenants.
+
+COMMIT;

--- a/supabase/migrations/20260603130004_a03_backfill_revenue_subscriptions.sql
+++ b/supabase/migrations/20260603130004_a03_backfill_revenue_subscriptions.sql
@@ -1,0 +1,185 @@
+-- ============================================================================
+-- Migration: Backfill public.subscriptions (A-03 batch 1)
+-- Date:      2026-05-01 (queued under 20260603 to sort after A-02 batch 1)
+-- Audit ref: docs/audits/drift-list.md (A-05 affiliate / finance family,
+--            shipped via the A-03 revenue iteration grouping)
+-- Queue item: docs/audits/REMEDIATION_QUEUE.md A-03
+--
+-- Purpose
+--   `subscriptions` is declared in `lib/database.types.ts` (line 10770) but
+--   the migration tree never CREATEs the table. It is the Stripe-backed
+--   user subscription ledger — one row per (auth.users, stripe_subscription),
+--   tracking Stripe lifecycle (status, current_period_*, cancel_at_period_end,
+--   pause/grace fields) and dunning state.
+--
+--   Used by 14+ call sites — selected:
+--     - app/admin/pro-subscribers/page.tsx                                 (admin: read + update)
+--     - app/admin/funnel/page.tsx                                          (admin: count active)
+--     - app/api/cron/subscription-dunning/route.ts                         (read + update dunning)
+--     - app/api/stripe/cancel-subscription/route.ts                        (read + update cancel flag)
+--     - app/api/stripe/refund-subscription/route.ts                        (read on refund)
+--     - app/api/stripe/create-checkout/route.ts                            (read existing customer)
+--     - app/api/course/purchase/route.ts                                   (read entitlement)
+--     - app/api/consultation/book/route.ts                                 (read entitlement)
+--     - app/api/fee-profile/route.ts                                       (read entitlement)
+--     - app/api/review-incentive/route.ts                                  (read entitlement)
+--     - lib/hooks/useSubscription.ts                                       (browser: read own)
+--     - lib/server/get-subscription.ts                                     (server: read by user_id)
+--     - lib/stripe-webhook/lib/upsert-subscription.ts                      (webhook: upsert)
+--     - lib/stripe-webhook/handlers/customer-subscription-paused.ts        (webhook: update)
+--     - lib/stripe-webhook/handlers/invoice.ts                             (webhook: update)
+--
+-- Why it matters
+--   Direct revenue + entitlement source of truth — gates every Pro feature
+--   (course access, fee-profile downloads, review incentives, consultation
+--   booking, etc.). Without this in the migration tree a clean rebuild
+--   loses the entitlement check entirely. RLS-critical: per-user data with
+--   Stripe identifiers and dunning state.
+--
+-- Schema source of truth
+--   Live DB (verified 2026-05-01 via information_schema.columns +
+--   pg_attribute.attidentity) + lib/database.types.ts →
+--   Database['public']['Tables']['subscriptions'].
+--   - id                       bigint      PK   GENERATED ALWAYS AS IDENTITY
+--   - user_id                  uuid        NOT NULL  FK -> auth.users(id) ON DELETE CASCADE
+--   - stripe_subscription_id   text        NOT NULL  UNIQUE
+--   - stripe_customer_id       text        NOT NULL
+--   - status                   text        NOT NULL DEFAULT 'incomplete'
+--                                          CHECK IN ('active','trialing','past_due','canceled',
+--                                                    'incomplete','incomplete_expired','unpaid','paused')
+--   - price_id                 text        NULLABLE
+--   - plan_interval            text        NULLABLE  CHECK IN ('month','year')
+--   - current_period_start     timestamptz NULLABLE
+--   - current_period_end       timestamptz NULLABLE
+--   - cancel_at_period_end     boolean     NULLABLE DEFAULT false
+--   - canceled_at              timestamptz NULLABLE
+--   - created_at               timestamptz NULLABLE DEFAULT now()
+--   - updated_at               timestamptz NULLABLE DEFAULT now()
+--   - grace_period_until       timestamptz NULLABLE
+--   - paused_at                timestamptz NULLABLE
+--   - pause_reason             text        NULLABLE
+--   - dunning_attempt_count    integer     NULLABLE DEFAULT 0
+--   - last_dunning_email_at    timestamptz NULLABLE
+--
+-- Divergence from types
+--   - Types declare `id?: never` on Insert/Update; live DB confirms this is
+--     `GENERATED ALWAYS AS IDENTITY` (not bigserial). The two are subtly
+--     different: GENERATED ALWAYS rejects manual id assignment outright.
+--     Migration uses `GENERATED ALWAYS AS IDENTITY` — trust live DB.
+--   - Live DB has CHECK constraints on `status` and `plan_interval` not
+--     visible in the type. Migration ports them verbatim.
+--   - The type lists `cancel_at_period_end: boolean | null` with no default
+--     visible; live DB has DEFAULT false. Migration matches live DB.
+--   - The type has no FK target on `user_id`; live DB has
+--     FK -> auth.users(id) ON DELETE CASCADE. Migration matches live DB.
+--
+-- RLS policy chosen — owner-isolation (user reads own row only)
+--   - service_role: explicit FOR ALL allow (cron, webhooks, admin tooling).
+--   - authenticated: SELECT permitted WHERE user_id = auth.uid() — owner-only.
+--   - anon: NO policy — RLS denies.
+--   - INSERT/UPDATE/DELETE: NOT granted to anon/authenticated. All writes
+--     flow through Stripe webhook handlers (`lib/stripe-webhook/lib/upsert-subscription.ts`,
+--     `customer-subscription-paused.ts`, `invoice.ts`) and admin tooling,
+--     all of which use the service-role client. The user-cookie hook
+--     (`lib/hooks/useSubscription.ts`) and the cancel/refund routes only
+--     read; cancellation actually flips Stripe-side first and the change
+--     mirrors back via webhook.
+--
+--   Justification: this is the user's billing relationship — they have a
+--   right to read their own subscription state (the Pro account page and
+--   the `useSubscription` hook depend on it from the user-cookie client).
+--   Cross-user reads would leak Stripe identifiers and dunning history
+--   between tenants. Pattern matches the `profiles` owner-isolation policy
+--   shipped in A-02 batch 1.
+--
+-- Idempotency
+--   - The body uses `if not exists` on the table — no-op when it exists.
+--   - CREATE INDEX IF NOT EXISTS on `user_id` (FK lookup; matches live DB).
+--   - The UNIQUE constraint on `stripe_subscription_id` is inlined in the
+--     table definition so it attaches atomically.
+--   - DROP POLICY IF EXISTS + CREATE POLICY for every policy.
+--
+-- Risk: low-medium
+--   - Forward-only schema add; no data shaping.
+--   - Owner-isolation policy is additive against today's behaviour: the
+--     `useSubscription` hook already reads via the user-cookie client and
+--     filters by `eq('user_id', user.id)` in code; RLS just enforces what
+--     code already does.
+--   - One ambiguity to flag: a couple of admin/AI-chat routes (e.g.
+--     `app/api/admin/ai-chat/route.ts`) reference `email` and `cancelled_at`
+--     columns that exist neither in types nor in live DB. That looks like
+--     a pre-existing bug in admin tooling — out of scope for this backfill,
+--     but logged here so the next person doesn't chase it as a schema gap.
+--
+-- Rollback
+--   BEGIN;
+--     DROP POLICY IF EXISTS "service_role full access" ON public.subscriptions;
+--     DROP POLICY IF EXISTS "owner read own subscription" ON public.subscriptions;
+--     DROP INDEX IF EXISTS idx_subscriptions_user_id;
+--     ALTER TABLE public.subscriptions DISABLE ROW LEVEL SECURITY;
+--     -- DROP TABLE public.subscriptions;  -- destructive; clean rebuild only
+--   COMMIT;
+-- ============================================================================
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.subscriptions (
+  id                       bigint      GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  user_id                  uuid        NOT NULL,
+  stripe_subscription_id   text        NOT NULL,
+  stripe_customer_id       text        NOT NULL,
+  status                   text        NOT NULL DEFAULT 'incomplete',
+  price_id                 text,
+  plan_interval            text,
+  current_period_start     timestamptz,
+  current_period_end       timestamptz,
+  cancel_at_period_end     boolean              DEFAULT false,
+  canceled_at              timestamptz,
+  created_at               timestamptz          DEFAULT now(),
+  updated_at               timestamptz          DEFAULT now(),
+  grace_period_until       timestamptz,
+  paused_at                timestamptz,
+  pause_reason             text,
+  dunning_attempt_count    integer              DEFAULT 0,
+  last_dunning_email_at    timestamptz,
+  CONSTRAINT subscriptions_stripe_subscription_id_key UNIQUE (stripe_subscription_id),
+  CONSTRAINT subscriptions_status_check
+    CHECK (status IN ('active', 'trialing', 'past_due', 'canceled',
+                      'incomplete', 'incomplete_expired', 'unpaid', 'paused')),
+  CONSTRAINT subscriptions_plan_interval_check
+    CHECK (plan_interval IS NULL OR plan_interval IN ('month', 'year')),
+  CONSTRAINT subscriptions_user_id_fkey
+    FOREIGN KEY (user_id)
+    REFERENCES auth.users(id)
+    ON DELETE CASCADE
+);
+
+-- FK lookup — every read on the user-cookie client filters by user_id;
+-- matches the index already present in live DB.
+CREATE INDEX IF NOT EXISTS idx_subscriptions_user_id
+  ON public.subscriptions (user_id);
+
+ALTER TABLE public.subscriptions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.subscriptions FORCE  ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "service_role full access" ON public.subscriptions;
+CREATE POLICY "service_role full access"
+  ON public.subscriptions
+  FOR ALL TO service_role
+  USING (true) WITH CHECK (true);
+
+-- Owner-isolation read — the Pro account page and `useSubscription` hook
+-- read the current user's own subscription via the user-cookie client.
+-- Cross-user reads are forbidden (would leak Stripe identifiers).
+DROP POLICY IF EXISTS "owner read own subscription" ON public.subscriptions;
+CREATE POLICY "owner read own subscription"
+  ON public.subscriptions
+  FOR SELECT TO authenticated
+  USING (user_id = auth.uid());
+
+-- No INSERT/UPDATE/DELETE policies for anon/authenticated: subscription
+-- state mutations all flow through Stripe webhook handlers using the
+-- service-role client. User-initiated cancellations call Stripe first and
+-- the resulting state mirrors back via webhook.
+
+COMMIT;


### PR DESCRIPTION
## Summary

Stream A backfill — 5 revenue tables (`affiliate_payout_reports`, `affiliate_payout_variance`, `sponsored_placement_pricing`, `sponsored_placement_bookings`, `subscriptions`) get `CREATE TABLE IF NOT EXISTS` migrations with RLS-on, mirroring the A-02 batch 1 (#322) pattern exactly.

All tables verified against live DB (project `guggzyqceattncjwvgyc`); column-type divergences resolved in favour of live (live uses `bigint` where `database.types.ts` says `number`; `subscriptions.id` is `GENERATED ALWAYS AS IDENTITY`).

RLS posture:
- 4 of 5 tables: service-role only (revenue tables never read by anon)
- `sponsored_placement_pricing`: read-public (active=true) / write-admin — mirrors `lead_pricing` from A-02; consumed by the public marketing rate-card page

Out-of-band finding logged in the `subscriptions` migration header: `app/api/admin/ai-chat/route.ts` references `subscriptions.email` and `subscriptions.cancelled_at` which exist in neither types nor live DB — pre-existing bug, not a schema gap.

## Test plan

- [ ] CI: rls-migrations-gate passes (5 new CREATE TABLE statements, all RLS-enabled)
- [ ] CI: full type-check + audit suite green
- [ ] Manual: confirm the 5 migrations are no-ops in live (idempotent — `IF NOT EXISTS`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)