### PR TITLE
chore(g): G-03 batch 4 — rollback headers on 10 partial-header migrations

### DIFF
--- a/supabase/migrations/001_initial.sql
+++ b/supabase/migrations/001_initial.sql
@@ -1,3 +1,68 @@
+-- ============================================================================
+-- Migration: 001_initial.sql
+-- Purpose: Bootstrap the original schema — six core tables (brokers,
+--          articles, scenarios, affiliate_clicks, quiz_weights,
+--          site_settings), enable RLS on all six, install six public-read
+--          / public-insert RLS policies, and create five performance
+--          indexes (broker slug/status, article slug, scenario slug,
+--          affiliate_clicks broker_id).
+-- Rollback: DROP every object created — five indexes, six policies, six
+--          tables (all CASCADE because downstream migrations FK into
+--          brokers and add columns/policies on top of every table here).
+-- Risk: high (irreversible) — these tables hold every broker, article,
+--       scenario, affiliate-click, quiz-weight, and site-setting row in
+--       the application. CASCADE drops cascade into ~100 downstream
+--       migrations' tables, indexes, FKs, and triggers. Operator MUST
+--       take a full database snapshot (`pg_dump` or Supabase backup)
+--       before reverting; the migration cannot recreate the row data.
+-- ============================================================================
+--
+-- Forward operations:
+--   1. CREATE TABLE brokers (id, name, slug, color, ...).
+--   2. CREATE TABLE articles (id, title, slug, excerpt, ...).
+--   3. CREATE TABLE scenarios (id, title, slug, hero_title, ...).
+--   4. CREATE TABLE affiliate_clicks (id, broker_id FK→brokers, ...).
+--   5. CREATE TABLE quiz_weights (id, broker_id FK→brokers, ...).
+--   6. CREATE TABLE site_settings (id, key, value, ...).
+--   7. ALTER TABLE ... ENABLE ROW LEVEL SECURITY on all six tables.
+--   8. CREATE POLICY "Public read for active brokers" ON brokers.
+--   9. CREATE POLICY "Public read articles" ON articles.
+--  10. CREATE POLICY "Public read scenarios" ON scenarios.
+--  11. CREATE POLICY "Insert clicks" ON affiliate_clicks.
+--  12. CREATE POLICY "Public read quiz weights" ON quiz_weights.
+--  13. CREATE POLICY "Public read settings" ON site_settings.
+--  14. CREATE INDEX idx_brokers_slug, idx_brokers_status,
+--      idx_articles_slug, idx_scenarios_slug,
+--      idx_affiliate_clicks_broker_id.
+--
+-- Rollback (in reverse order):
+--   -- Pre-step (operator): take a full pg_dump / Supabase snapshot. Every
+--   -- broker, article, scenario, click, quiz weight, and site setting
+--   -- will be lost; downstream migrations that FK into brokers (campaigns,
+--   -- user_reviews, switch_stories, broker_questions, etc.) will also
+--   -- be dropped via CASCADE.
+--  14. DROP INDEX IF EXISTS idx_affiliate_clicks_broker_id;
+--      DROP INDEX IF EXISTS idx_scenarios_slug;
+--      DROP INDEX IF EXISTS idx_articles_slug;
+--      DROP INDEX IF EXISTS idx_brokers_status;
+--      DROP INDEX IF EXISTS idx_brokers_slug;
+--  13. DROP POLICY IF EXISTS "Public read settings" ON site_settings;
+--  12. DROP POLICY IF EXISTS "Public read quiz weights" ON quiz_weights;
+--  11. DROP POLICY IF EXISTS "Insert clicks" ON affiliate_clicks;
+--  10. DROP POLICY IF EXISTS "Public read scenarios" ON scenarios;
+--   9. DROP POLICY IF EXISTS "Public read articles" ON articles;
+--   8. DROP POLICY IF EXISTS "Public read for active brokers" ON brokers;
+--   7. (RLS toggles drop with the tables.)
+--   6. DROP TABLE IF EXISTS site_settings CASCADE;
+--   5. DROP TABLE IF EXISTS quiz_weights CASCADE;
+--   4. DROP TABLE IF EXISTS affiliate_clicks CASCADE;
+--   3. DROP TABLE IF EXISTS scenarios CASCADE;
+--   2. DROP TABLE IF EXISTS articles CASCADE;
+--   1. DROP TABLE IF EXISTS brokers CASCADE;
+--      -- DESTRUCTIVE: collapses the entire application schema. Restore
+--      -- from snapshot is the only recovery path.
+-- ============================================================================
+
 -- Create brokers table
 CREATE TABLE brokers (
   id BIGSERIAL PRIMARY KEY,

--- a/supabase/migrations/002_schema_additions.sql
+++ b/supabase/migrations/002_schema_additions.sql
@@ -1,3 +1,81 @@
+-- ============================================================================
+-- Migration: 002_schema_additions.sql
+-- Purpose: Phase-0 feature-parity additions — add affiliate_clicks.layer
+--          and brokers.benefit_cta columns; create quiz_questions,
+--          calculator_config, email_captures tables (with RLS + 3 policies
+--          + 4 indexes); seed quiz_questions (4 rows), calculator_config
+--          (5 rows), and site_settings defaults (10 keys).
+-- Rollback: Drop the 3 new tables (CASCADE — quiz/calculator/email infra
+--          downstream FKs into them); drop the 4 new indexes; drop the 2
+--          added columns; remove the 10 seeded site_settings keys.
+-- Risk: high — quiz_questions / calculator_config / email_captures hold
+--       live user-facing config and email-capture leads. Reverse drops
+--       lose the email_captures rows (operator-collected lead data).
+--       brokers.benefit_cta and affiliate_clicks.layer are referenced by
+--       app code; dropping them will fail at runtime until shipped code
+--       reverts.
+-- ============================================================================
+--
+-- Forward operations:
+--   1. ALTER TABLE affiliate_clicks ADD COLUMN IF NOT EXISTS layer TEXT.
+--   2. ALTER TABLE brokers ADD COLUMN IF NOT EXISTS benefit_cta TEXT.
+--   3. CREATE TABLE IF NOT EXISTS quiz_questions (id, order_index,
+--      question_text, options jsonb, active, ...).
+--   4. CREATE TABLE IF NOT EXISTS calculator_config (id, calc_type
+--      UNIQUE, config jsonb, ...).
+--   5. CREATE TABLE IF NOT EXISTS email_captures (id, email, source,
+--      captured_at).
+--   6. ALTER TABLE ... ENABLE ROW LEVEL SECURITY on all 3 new tables.
+--   7. CREATE POLICY "Public read quiz questions" ON quiz_questions
+--      (active = TRUE).
+--   8. CREATE POLICY "Public read calculator config" ON calculator_config.
+--   9. CREATE POLICY "Insert email captures" ON email_captures.
+--  10. CREATE INDEX IF NOT EXISTS idx_quiz_questions_order,
+--      idx_calculator_config_type, idx_email_captures_source,
+--      idx_affiliate_clicks_layer.
+--  11. INSERT 4 rows into quiz_questions.
+--  12. INSERT 5 rows into calculator_config.
+--  13. INSERT 10 site_settings keys ON CONFLICT (key) DO NOTHING.
+--
+-- Rollback (in reverse order):
+--   -- Pre-step (operator): export email_captures rows externally — they
+--   -- represent collected user emails and are NOT recoverable from the
+--   -- migration body.
+--  13. DELETE FROM site_settings WHERE key IN (
+--        'site_title', 'meta_description', 'abn', 'email',
+--        'social_proof_visitors', 'social_proof_rating',
+--        'social_proof_independence', 'hero_headline',
+--        'hero_subtitle', 'media_logos'
+--      );
+--  12. DELETE FROM calculator_config
+--      WHERE calc_type IN ('franking', 'switching', 'fx', 'cgt', 'chess');
+--  11. DELETE FROM quiz_questions
+--      WHERE question_text IN (
+--        'What is your main investing goal?',
+--        'How experienced are you with investing?',
+--        'How much are you looking to invest?',
+--        'What matters most to you?'
+--      );
+--  10. DROP INDEX IF EXISTS idx_affiliate_clicks_layer;
+--      DROP INDEX IF EXISTS idx_email_captures_source;
+--      DROP INDEX IF EXISTS idx_calculator_config_type;
+--      DROP INDEX IF EXISTS idx_quiz_questions_order;
+--   9. DROP POLICY IF EXISTS "Insert email captures" ON email_captures;
+--   8. DROP POLICY IF EXISTS "Public read calculator config"
+--        ON calculator_config;
+--   7. DROP POLICY IF EXISTS "Public read quiz questions"
+--        ON quiz_questions;
+--   6. (RLS toggles drop with the tables.)
+--   5. DROP TABLE IF EXISTS email_captures CASCADE;
+--      -- DESTRUCTIVE: drops user-submitted email leads.
+--   4. DROP TABLE IF EXISTS calculator_config CASCADE;
+--   3. DROP TABLE IF EXISTS quiz_questions CASCADE;
+--   2. ALTER TABLE brokers DROP COLUMN IF EXISTS benefit_cta;
+--      -- App code reads brokers.benefit_cta — revert ship-side first.
+--   1. ALTER TABLE affiliate_clicks DROP COLUMN IF EXISTS layer;
+--      -- App code writes affiliate_clicks.layer — revert ship-side first.
+-- ============================================================================
+
 -- Phase 0: Schema additions for feature parity
 
 -- Add layer column to affiliate_clicks for tracking click source context

--- a/supabase/migrations/20260305_create_advisor_directory.sql
+++ b/supabase/migrations/20260305_create_advisor_directory.sql
@@ -1,3 +1,85 @@
+-- ============================================================================
+-- Migration: 20260305_create_advisor_directory.sql
+-- Purpose: Create the advisor directory foundation — `professionals` core
+--          advisor-profile table (5 indexes, 2 policies), `professional_leads`
+--          enquiry table (3 indexes, 2 policies, FK to professionals), enable
+--          RLS on both, install the shared `update_updated_at()` trigger
+--          function and bind it to both tables.
+-- Rollback: DROP both tables CASCADE (every advisor profile + every enquiry
+--          row is destroyed); DROP the 4 RLS policies (drop with tables);
+--          DROP the 2 triggers (drop with tables); DROP the shared
+--          `update_updated_at()` function only if no other table relies
+--          on it (downstream migrations REUSE this function — DO NOT
+--          DROP it during partial revert).
+-- Risk: high — `professionals` is the source of truth for the advisor
+--       directory and is FK'd by ~15 downstream tables (advisor_articles,
+--       advisor_bookings, advisor_applications, professional_reviews,
+--       advisor_firm_invitations, advisor_credit_balance, …). CASCADE
+--       collapses all of them. `professional_leads` rows represent
+--       paying-billed lead enquiries (lead_value, billed flag) — losing
+--       them loses revenue ledger data.
+-- ============================================================================
+--
+-- Forward operations:
+--   1. CREATE TABLE IF NOT EXISTS professionals (id, slug, name, type
+--      CHECK (6 enum values), specialties jsonb, location_*, afsl_number,
+--      acn, abn, registration_number, bio, photo_url, website, phone,
+--      email, fee_structure, fee_description, rating, review_count,
+--      verified, status CHECK ('active','inactive','pending'),
+--      onboarded_at, created_at, updated_at).
+--   2. CREATE INDEX IF NOT EXISTS idx_professionals_type,
+--      _state, _status, _slug, _type_state.
+--   3. CREATE TABLE IF NOT EXISTS professional_leads (id,
+--      professional_id FK→professionals, user_name, user_email,
+--      user_phone, message, source_page, utm_*, status CHECK
+--      ('new','sent','contacted','converted','lost','spam'),
+--      lead_value, billed, created_at, updated_at).
+--   4. CREATE INDEX IF NOT EXISTS idx_leads_professional, _status, _created.
+--   5. ALTER TABLE professionals / professional_leads ENABLE ROW LEVEL SECURITY.
+--   6. CREATE POLICY "Public can view active professionals" ON professionals.
+--   7. CREATE POLICY "Anyone can submit leads" ON professional_leads.
+--   8. CREATE POLICY "Admins full access professionals" ON professionals.
+--   9. CREATE POLICY "Admins full access leads" ON professional_leads.
+--  10. CREATE OR REPLACE FUNCTION update_updated_at() — shared trigger fn
+--      that downstream migrations also reuse.
+--  11. CREATE TRIGGER professionals_updated_at BEFORE UPDATE … EXECUTE
+--      FUNCTION update_updated_at().
+--  12. CREATE TRIGGER professional_leads_updated_at BEFORE UPDATE … EXECUTE
+--      FUNCTION update_updated_at().
+--
+-- Rollback (in reverse order):
+--   -- Pre-step (operator): snapshot professionals + professional_leads
+--   -- (lead_value + billed columns are revenue ledger data). Verify no
+--   -- downstream migrations depend on update_updated_at() before dropping.
+--  12. DROP TRIGGER IF EXISTS professional_leads_updated_at
+--        ON professional_leads;
+--  11. DROP TRIGGER IF EXISTS professionals_updated_at ON professionals;
+--  10. -- DO NOT DROP update_updated_at() — many downstream tables
+--      -- (advisor_firms, advisor_articles, advisor_bookings, …) reuse
+--      -- this trigger function. Only drop on a full schema teardown.
+--      -- Full-teardown step: DROP FUNCTION IF EXISTS update_updated_at();
+--   9. DROP POLICY IF EXISTS "Admins full access leads" ON professional_leads;
+--   8. DROP POLICY IF EXISTS "Admins full access professionals"
+--        ON professionals;
+--   7. DROP POLICY IF EXISTS "Anyone can submit leads" ON professional_leads;
+--   6. DROP POLICY IF EXISTS "Public can view active professionals"
+--        ON professionals;
+--   5. (RLS toggles drop with the tables.)
+--   4. DROP INDEX IF EXISTS idx_leads_created;
+--      DROP INDEX IF EXISTS idx_leads_status;
+--      DROP INDEX IF EXISTS idx_leads_professional;
+--   3. DROP TABLE IF EXISTS professional_leads CASCADE;
+--      -- DESTRUCTIVE: drops billed-lead history (revenue ledger).
+--   2. DROP INDEX IF EXISTS idx_professionals_type_state;
+--      DROP INDEX IF EXISTS idx_professionals_slug;
+--      DROP INDEX IF EXISTS idx_professionals_status;
+--      DROP INDEX IF EXISTS idx_professionals_state;
+--      DROP INDEX IF EXISTS idx_professionals_type;
+--   1. DROP TABLE IF EXISTS professionals CASCADE;
+--      -- DESTRUCTIVE: collapses the entire advisor directory and ~15
+--      -- downstream advisor_* tables via FK CASCADE.
+-- ============================================================================
+
 -- Migration: Create advisor directory tables
 -- Run in Supabase Dashboard > SQL Editor
 

--- a/supabase/migrations/20260309_security_and_performance_fixes.sql
+++ b/supabase/migrations/20260309_security_and_performance_fixes.sql
@@ -1,12 +1,124 @@
 -- ============================================================================
--- Migration: Security & Performance Fixes
--- Date: 2026-03-09
+-- Migration: 20260309_security_and_performance_fixes.sql
+-- Purpose: Security + performance hardening — replace ~10 overly permissive
+--          INSERT policies with validation predicates (email_captures,
+--          quiz_leads, analytics_events, affiliate_clicks, switch_stories,
+--          user_reviews, shared_shortlists, professional_leads,
+--          professional_reviews, advisor_profile_views, investor_drip_log);
+--          add ~22 missing FK / lookup indexes (idx_affiliate_clicks_broker,
+--          idx_analytics_events_*, idx_user_reviews_*, idx_switch_stories_*,
+--          idx_broker_questions_page, idx_articles_*, idx_broker_data_changes_*,
+--          idx_email_captures_email, idx_quiz_leads_email, plus conditional
+--          indexes on advisor_*, course_*, marketplace_*, portfolio_*
+--          tables); set search_path = public on 4 utility functions
+--          (cleanup_old_analytics, cleanup_rate_limits, update_updated_at,
+--          increment_advisor_view); drop 3 unused indexes
+--          (idx_email_captures_status, idx_portfolios_email,
+--          idx_analytics_events_created, idx_analytics_events_event_type,
+--          idx_fee_snapshots_portfolio).
+-- Rollback: Per-section reverse — recreate the loose `WITH CHECK (true)`
+--          policies, drop the added indexes, recreate the dropped indexes,
+--          revert search_path on the 4 functions. The full reverse is a
+--          NET DEGRADATION of the database (loosens RLS, removes
+--          performance indexes) and SHOULD ONLY BE USED to undo a bad
+--          deploy — never as a routine operation.
+-- Risk: high — reverse weakens RLS validation (allows empty/invalid
+--       INSERTs the new policies block), removes FK indexes (sequential
+--       scans on JOIN-heavy queries), and re-introduces mutable
+--       search_path (security advisory). Single transaction (BEGIN/COMMIT)
+--       so partial failure rolls back cleanly forward; the reverse must
+--       likewise be wrapped in BEGIN/COMMIT.
+-- ============================================================================
 --
--- Addresses:
---   1. RLS policies with overly permissive WITH CHECK (true)
---   2. Missing indexes on foreign keys and frequently queried columns
---   3. Mutable search_path on functions
---   4. Unused index cleanup
+-- Forward operations (top-level only — see body for the full ~30 ops):
+--   1. BEGIN.
+--   2. SECTION 1 (RLS): for each of email_captures, quiz_leads,
+--      analytics_events, affiliate_clicks, switch_stories, user_reviews,
+--      shared_shortlists, professional_leads, professional_reviews,
+--      advisor_profile_views, investor_drip_log: DROP all known loose
+--      INSERT policies (`WITH CHECK (true)`), CREATE replacement INSERT
+--      policy with validation predicate (email non-empty, broker_slug
+--      non-empty, rating in 1..5, etc.). Conditional via DO blocks for
+--      tables that may not exist yet.
+--   3. SECTION 2 (indexes): CREATE INDEX IF NOT EXISTS for ~22 FK /
+--      lookup columns; conditional CREATE for advisor_*, course_*,
+--      marketplace_*, portfolio_* tables.
+--   4. SECTION 3 (search_path): DO blocks ALTER FUNCTION ... SET
+--      search_path = public on cleanup_old_analytics, cleanup_rate_limits,
+--      update_updated_at, increment_advisor_view (each conditional on
+--      pg_proc presence).
+--   5. SECTION 4 (cleanup): DROP INDEX IF EXISTS idx_email_captures_status,
+--      idx_portfolios_email; (idx_analytics_events_created /
+--      idx_analytics_events_event_type / idx_fee_snapshots_portfolio
+--      dropped in body as duplicate-index cleanup).
+--   6. COMMIT.
+--
+-- Rollback (in reverse order):
+--   -- WARNING: this reverse intentionally re-loosens RLS and removes
+--   -- performance indexes. Only run as part of a full deploy revert,
+--   -- never as a routine "undo".
+--   6. BEGIN;
+--   5. -- Re-create the dropped "unused" indexes if a downstream
+--      -- migration ever recreates them (otherwise leave dropped):
+--      CREATE INDEX IF NOT EXISTS idx_email_captures_status
+--        ON email_captures(status);
+--      CREATE INDEX IF NOT EXISTS idx_portfolios_email
+--        ON user_portfolios(email);
+--      CREATE INDEX IF NOT EXISTS idx_analytics_events_created
+--        ON analytics_events(created_at);
+--      CREATE INDEX IF NOT EXISTS idx_analytics_events_event_type
+--        ON analytics_events(event_type);
+--      CREATE INDEX IF NOT EXISTS idx_fee_snapshots_portfolio
+--        ON portfolio_fee_snapshots(portfolio_id);
+--   4. -- Revert search_path on the 4 utility functions:
+--      ALTER FUNCTION cleanup_old_analytics() RESET search_path;
+--      ALTER FUNCTION cleanup_rate_limits() RESET search_path;
+--      ALTER FUNCTION update_updated_at() RESET search_path;
+--      ALTER FUNCTION increment_advisor_view(integer, date) RESET search_path;
+--   3. -- Drop the ~22 indexes added by SECTION 2 (sample — drop all
+--      -- idx_* names introduced in this migration's body):
+--      DROP INDEX IF EXISTS idx_investor_drip_log_email;
+--      DROP INDEX IF EXISTS idx_advisor_auth_tokens_advisor;
+--      DROP INDEX IF EXISTS idx_advisor_sessions_advisor;
+--      DROP INDEX IF EXISTS idx_advisor_billing_advisor;
+--      DROP INDEX IF EXISTS idx_advisor_bookings_user;
+--      DROP INDEX IF EXISTS idx_advisor_bookings_advisor;
+--      DROP INDEX IF EXISTS idx_advisor_applications_user;
+--      DROP INDEX IF EXISTS idx_portfolio_alerts_portfolio;
+--      DROP INDEX IF EXISTS idx_portfolio_fee_snapshots_portfolio;
+--      DROP INDEX IF EXISTS idx_portfolio_holdings_portfolio;
+--      DROP INDEX IF EXISTS idx_marketplace_campaigns_broker;
+--      DROP INDEX IF EXISTS idx_course_progress_user;
+--      DROP INDEX IF EXISTS idx_course_purchases_user;
+--      DROP INDEX IF EXISTS idx_quiz_leads_email;
+--      DROP INDEX IF EXISTS idx_email_captures_email;
+--      DROP INDEX IF EXISTS idx_broker_data_changes_changed_at;
+--      DROP INDEX IF EXISTS idx_broker_data_changes_broker;
+--      DROP INDEX IF EXISTS idx_advisor_articles_professional;
+--      DROP INDEX IF EXISTS idx_articles_category;
+--      DROP INDEX IF EXISTS idx_articles_status;
+--      DROP INDEX IF EXISTS idx_broker_answers_question;
+--      DROP INDEX IF EXISTS idx_broker_questions_page;
+--      DROP INDEX IF EXISTS idx_switch_stories_source_broker;
+--      DROP INDEX IF EXISTS idx_switch_stories_broker_slug;
+--      DROP INDEX IF EXISTS idx_user_reviews_email;
+--      DROP INDEX IF EXISTS idx_user_reviews_broker_id;
+--      DROP INDEX IF EXISTS idx_analytics_events_created_at;
+--      DROP INDEX IF EXISTS idx_analytics_events_event_type;
+--      DROP INDEX IF EXISTS idx_analytics_events_page;
+--      DROP INDEX IF EXISTS idx_affiliate_clicks_broker;
+--   2. -- Re-create loose INSERT policies (NET DEGRADATION — only do this
+--      -- to revert a bad deploy). Pattern per table:
+--      DROP POLICY IF EXISTS "<validated policy name>" ON <table>;
+--      CREATE POLICY "<original loose name>" ON <table>
+--        FOR INSERT WITH CHECK (true);
+--      -- Apply to email_captures, quiz_leads, analytics_events,
+--      -- affiliate_clicks, switch_stories, user_reviews,
+--      -- shared_shortlists, professional_leads, professional_reviews,
+--      -- advisor_profile_views, investor_drip_log.
+--      -- Original policy names varied per table — check git history
+--      -- pre-2026-03-09 for the exact name strings.
+--   1. COMMIT;
 -- ============================================================================
 
 BEGIN;

--- a/supabase/migrations/20260309_seed_mock_advisors.sql
+++ b/supabase/migrations/20260309_seed_mock_advisors.sql
@@ -1,3 +1,78 @@
+-- ============================================================================
+-- Migration: 20260309_seed_mock_advisors.sql
+-- Purpose: Seed 55 realistic mock advisor profiles into `professionals`
+--          across 12 advisor types and major AU cities (Sydney, Melbourne,
+--          Brisbane, Perth, Adelaide, Canberra, Hobart, Gold Coast, Darwin,
+--          Newcastle, Wollongong, Sunshine Coast). Single INSERT … ON
+--          CONFLICT (slug) DO NOTHING.
+-- Rollback: DELETE the 55 mock advisor rows by slug, but ONLY after
+--          confirming no FK-referencing rows exist (advisor_articles,
+--          advisor_bookings, advisor_applications, professional_leads,
+--          professional_reviews) — otherwise the DELETE fails on FK
+--          violation. The forward INSERT is re-runnable (idempotent).
+-- Risk: medium — reverse fails if any production user has booked,
+--       reviewed, or messaged one of the 55 mock advisors. Operator must
+--       cascade-clean those FK rows or accept the seeded advisors stay
+--       in the directory.
+-- ============================================================================
+--
+-- Forward operations:
+--   1. INSERT INTO professionals (slug, name, firm_name, type,
+--        specialties, location_state, location_suburb, location_display,
+--        afsl_number, abn, registration_number, bio, photo_url, website,
+--        phone, email, fee_structure, fee_description, rating,
+--        review_count, verified, status, onboarded_at, profile_complete)
+--      VALUES (... 55 rows ...)
+--      ON CONFLICT (slug) DO NOTHING.
+--
+-- Rollback (in reverse order):
+--   -- Pre-step (operator): delete or reassign FK-dependent rows in
+--   -- advisor_articles, advisor_bookings, advisor_applications,
+--   -- professional_leads, professional_reviews that reference any of
+--   -- the 55 mock advisor IDs. Otherwise the DELETE will fail with
+--   -- foreign_key_violation.
+--   1. DELETE FROM professionals
+--      WHERE slug IN (
+--        -- Sydney
+--        'james-wong-sydney', 'maria-papadopoulos-sydney',
+--        'raj-patel-sydney', 'sophie-laurent-sydney',
+--        'michael-oconnor-sydney', 'helen-tran-sydney',
+--        'david-kowalski-sydney', 'anthony-nguyen-sydney',
+--        'emma-richardson-sydney', 'daniel-stavros-sydney',
+--        'fatima-hassan-sydney', 'margaret-campbell-sydney',
+--        'chris-murphy-sydney', 'wei-chen-sydney',
+--        'luke-thompson-sydney',
+--        -- Melbourne
+--        'olivia-martinez-melbourne', 'george-papadimitriou-melbourne',
+--        'anita-desai-melbourne', 'tom-fitzgerald-melbourne',
+--        'victoria-aldridge-melbourne', 'sam-ibrahim-melbourne',
+--        'alexander-reid-melbourne', 'nina-volkov-melbourne',
+--        'liam-chen-melbourne', 'jenny-le-melbourne',
+--        'patricia-wright-melbourne', 'nick-constantine-melbourne',
+--        -- Brisbane
+--        'ben-walker-brisbane', 'karen-li-brisbane',
+--        'josh-anderson-brisbane', 'rachel-green-brisbane',
+--        'stuart-mackenzie-brisbane', 'tanya-russo-brisbane',
+--        'hassan-ali-brisbane', 'diana-zhou-brisbane',
+--        -- Perth
+--        'andrew-mitchell-perth', 'lisa-tan-perth',
+--        'ryan-kelly-perth', 'deepak-sharma-perth',
+--        'jessica-harris-perth',
+--        -- Adelaide
+--        'peter-rossi-adelaide', 'sarah-campbell-adelaide',
+--        'mark-katsaros-adelaide', 'catherine-singh-adelaide',
+--        -- Canberra / Hobart / GC / Darwin / regional
+--        'robert-jenkins-canberra', 'elena-petrov-canberra',
+--        'philip-chang-canberra', 'amanda-jones-hobart',
+--        'nathan-williams-hobart', 'steve-hall-goldcoast',
+--        'tina-nguyen-goldcoast', 'marco-santos-darwin',
+--        'laura-smith-newcastle', 'bruce-taylor-wollongong',
+--        'zac-miller-sunshinecoast'
+--      );
+--      -- Will fail with foreign_key_violation if downstream FKs reference
+--      -- any of these rows. See pre-step.
+-- ============================================================================
+
 -- Migration: Seed 55 realistic mock advisor accounts
 -- Covers all 12 advisor types across all major Australian cities
 -- Idempotent: uses ON CONFLICT (slug) DO NOTHING

--- a/supabase/migrations/20260310_admin_login_attempts.sql
+++ b/supabase/migrations/20260310_admin_login_attempts.sql
@@ -1,3 +1,40 @@
+-- ============================================================================
+-- Migration: 20260310_admin_login_attempts.sql
+-- Purpose: Create the `admin_login_attempts` rate-limiting table (ip_hash
+--          PK, count, reset_at), one index on reset_at for cleanup, and
+--          enable RLS with NO policies (deny-all to anon/authenticated;
+--          service_role bypasses RLS automatically). Replaces an
+--          in-process Map that lost state across serverless invocations.
+-- Rollback: DROP the index, DROP the table CASCADE. Live admin
+--          rate-limit counters are wiped — operators get one fresh
+--          window of brute-force allowance immediately after revert.
+-- Risk: medium — admin login endpoints (`/api/admin/login` etc.) write
+--       to this table on every attempt; dropping it produces runtime
+--       errors until shipped admin auth code reverts to its in-memory
+--       fallback, AND any in-flight brute-force protection state is
+--       lost (briefly elevated risk window).
+-- ============================================================================
+--
+-- Forward operations:
+--   1. CREATE TABLE IF NOT EXISTS admin_login_attempts
+--        (ip_hash TEXT PRIMARY KEY, count INT NOT NULL DEFAULT 1,
+--         reset_at TIMESTAMPTZ NOT NULL).
+--   2. CREATE INDEX idx_admin_login_attempts_reset_at
+--        ON admin_login_attempts (reset_at).
+--   3. ALTER TABLE admin_login_attempts ENABLE ROW LEVEL SECURITY.
+--      -- No policies — deny all anon/authenticated; only service_role
+--      -- (used by /api/admin/login server route) reads/writes.
+--
+-- Rollback (in reverse order):
+--   -- Pre-step (operator): confirm shipped `/api/admin/login` no longer
+--   -- reads/writes admin_login_attempts (or revert that code first),
+--   -- otherwise the route 500s on every attempt.
+--   3. (RLS toggle drops with the table.)
+--   2. DROP INDEX IF EXISTS idx_admin_login_attempts_reset_at;
+--   1. DROP TABLE IF EXISTS admin_login_attempts CASCADE;
+--      -- Brief elevated risk window: in-flight rate-limit counters lost.
+-- ============================================================================
+
 -- Admin login rate limiting table (replaces in-memory Map)
 CREATE TABLE IF NOT EXISTS admin_login_attempts (
   ip_hash TEXT PRIMARY KEY,

--- a/supabase/migrations/20260310_advisor_firms_and_invitations.sql
+++ b/supabase/migrations/20260310_advisor_firms_and_invitations.sql
@@ -1,3 +1,96 @@
+-- ============================================================================
+-- Migration: 20260310_advisor_firms_and_invitations.sql
+-- Purpose: Add the firm-level account model — `advisor_firms` table
+--          (slug, abn, acn, afsl_number, status CHECK, admin_professional_id
+--          FK→professionals, max_seats), `advisor_firm_invitations` table
+--          (firm_id FK→advisor_firms ON DELETE CASCADE, email, token UNIQUE,
+--          role, status, expires_at), 4 indexes, RLS + 3 policies; add 3
+--          columns to advisor_applications (account_type CHECK, abn,
+--          firm_id FK), 3 columns to professionals (firm_id FK,
+--          is_firm_admin, account_type CHECK), 1 conditional FK index on
+--          professionals(firm_id); install update_updated_at trigger on
+--          advisor_firms.
+-- Rollback: DROP the trigger, DROP the index on professionals(firm_id),
+--          ALTER TABLE professionals DROP COLUMN ... (3 cols), ALTER TABLE
+--          advisor_applications DROP COLUMN ... (3 cols), DROP TABLE
+--          advisor_firm_invitations CASCADE (token table — losing rows
+--          invalidates pending invitation links), DROP TABLE advisor_firms
+--          CASCADE (loses every firm record).
+-- Risk: high — `advisor_firms` rows are operator-onboarded billing
+--       entities; reverse loses the firm registry. `advisor_firm_invitations`
+--       holds outstanding invite tokens — losing them invalidates pending
+--       advisor invites. The dropped FK columns on professionals /
+--       advisor_applications cascade-orphan firm membership data.
+-- ============================================================================
+--
+-- Forward operations:
+--   1. CREATE TABLE IF NOT EXISTS advisor_firms (id, name, slug UNIQUE,
+--      abn, acn, afsl_number, website, phone, email, logo_url, location_*,
+--      bio, status CHECK ('active','inactive','pending','suspended'),
+--      admin_professional_id FK→professionals, max_seats DEFAULT 10,
+--      created_at, updated_at).
+--   2. CREATE INDEX IF NOT EXISTS idx_advisor_firms_status, _slug.
+--   3. ALTER TABLE advisor_firms ENABLE ROW LEVEL SECURITY.
+--   4. CREATE POLICY "Public can read active firms" ON advisor_firms.
+--   5. CREATE POLICY "Service role full access firms" ON advisor_firms.
+--   6. CREATE TABLE IF NOT EXISTS advisor_firm_invitations (id, firm_id
+--      FK→advisor_firms ON DELETE CASCADE, email, name, invited_by
+--      FK→professionals, token UNIQUE, role DEFAULT 'member', status
+--      CHECK ('pending','accepted','expired','revoked'), accepted_at,
+--      expires_at DEFAULT (NOW() + INTERVAL '7 days'), created_at).
+--   7. CREATE INDEX IF NOT EXISTS idx_firm_invitations_token, _firm.
+--   8. ALTER TABLE advisor_firm_invitations ENABLE ROW LEVEL SECURITY.
+--   9. CREATE POLICY "Service role full access invitations"
+--      ON advisor_firm_invitations.
+--  10. ALTER TABLE advisor_applications ADD COLUMN IF NOT EXISTS
+--      account_type TEXT DEFAULT 'individual' CHECK (...), abn TEXT,
+--      firm_id INTEGER REFERENCES advisor_firms(id).
+--  11. ALTER TABLE professionals ADD COLUMN IF NOT EXISTS firm_id INTEGER
+--      REFERENCES advisor_firms(id), is_firm_admin BOOLEAN DEFAULT false,
+--      account_type TEXT DEFAULT 'individual' CHECK (...).
+--  12. CREATE INDEX IF NOT EXISTS idx_professionals_firm
+--      ON professionals(firm_id) WHERE firm_id IS NOT NULL.
+--  13. CREATE TRIGGER update_advisor_firms_updated_at BEFORE UPDATE …
+--      EXECUTE FUNCTION update_updated_at().
+--
+-- Rollback (in reverse order):
+--   -- Pre-step (operator): export advisor_firms + advisor_firm_invitations
+--   -- (firm registry + outstanding invite tokens are not recoverable
+--   -- from the migration body). Communicate to firm admins that pending
+--   -- invitation links will become invalid.
+--  13. DROP TRIGGER IF EXISTS update_advisor_firms_updated_at
+--        ON advisor_firms;
+--  12. DROP INDEX IF EXISTS idx_professionals_firm;
+--  11. ALTER TABLE professionals
+--        DROP COLUMN IF EXISTS account_type,
+--        DROP COLUMN IF EXISTS is_firm_admin,
+--        DROP COLUMN IF EXISTS firm_id;
+--      -- App code reads professionals.firm_id / is_firm_admin — revert
+--      -- ship-side first.
+--  10. ALTER TABLE advisor_applications
+--        DROP COLUMN IF EXISTS firm_id,
+--        DROP COLUMN IF EXISTS abn,
+--        DROP COLUMN IF EXISTS account_type;
+--   9. DROP POLICY IF EXISTS "Service role full access invitations"
+--        ON advisor_firm_invitations;
+--   8. (RLS toggle drops with the table.)
+--   7. DROP INDEX IF EXISTS idx_firm_invitations_firm;
+--      DROP INDEX IF EXISTS idx_firm_invitations_token;
+--   6. DROP TABLE IF EXISTS advisor_firm_invitations CASCADE;
+--      -- DESTRUCTIVE: outstanding invite tokens invalidated.
+--   5. DROP POLICY IF EXISTS "Service role full access firms"
+--        ON advisor_firms;
+--   4. DROP POLICY IF EXISTS "Public can read active firms" ON advisor_firms;
+--   3. (RLS toggle drops with the table.)
+--   2. DROP INDEX IF EXISTS idx_advisor_firms_slug;
+--      DROP INDEX IF EXISTS idx_advisor_firms_status;
+--   1. DROP TABLE IF EXISTS advisor_firms CASCADE;
+--      -- DESTRUCTIVE: drops every firm registry row plus dependent
+--      -- advisor_applications.firm_id / professionals.firm_id values
+--      -- (already nulled in step 10/11; CASCADE noop here unless 10/11
+--      -- skipped).
+-- ============================================================================
+
 -- Migration: Advisor Firms & Invitations
 -- Adds firm accounts, team invitations, and links professionals to firms
 

--- a/supabase/migrations/20260310_content_architecture.sql
+++ b/supabase/migrations/20260310_content_architecture.sql
@@ -1,3 +1,92 @@
+-- ============================================================================
+-- Migration: 20260310_content_architecture.sql
+-- Purpose: Content-architecture enhancement — add 2 columns to articles
+--          (content_type, related_advisor_types text[]); add 6 columns to
+--          advisor_articles (word_count, related_broker_slugs text[],
+--          related_advisor_types text[], featured, read_time,
+--          moderation_score); create article_guidelines table (unique key,
+--          title, description, active, sort_order) with RLS + 1 policy;
+--          seed 8 article_guidelines rows; create
+--          advisor_article_moderation_log table (article_id FK→
+--          advisor_articles ON DELETE CASCADE) with RLS + service-role-only
+--          policy + 1 index; add 3 performance indexes
+--          (idx_articles_content_type, idx_advisor_articles_featured,
+--          idx_advisor_articles_status).
+-- Rollback: DROP the 3 perf indexes; DROP advisor_article_moderation_log
+--          CASCADE (loses moderation audit trail); DROP article_guidelines
+--          CASCADE (loses 8 seeded guidelines + any operator-added rows);
+--          ALTER TABLE advisor_articles DROP COLUMN ... (6 cols); ALTER
+--          TABLE articles DROP COLUMN ... (2 cols).
+-- Risk: high — `advisor_article_moderation_log` is an audit trail (every
+--       moderation action by reviewer); reverse loses compliance evidence.
+--       Dropped columns on articles / advisor_articles are referenced by
+--       app code — runtime errors until shipped code reverts.
+-- ============================================================================
+--
+-- Forward operations:
+--   1. ALTER TABLE articles ADD COLUMN IF NOT EXISTS content_type text
+--      DEFAULT 'editorial', related_advisor_types text[] DEFAULT '{}'.
+--   2. ALTER TABLE advisor_articles ADD COLUMN IF NOT EXISTS word_count
+--      integer DEFAULT 0, related_broker_slugs text[] DEFAULT '{}',
+--      related_advisor_types text[] DEFAULT '{}', featured boolean
+--      DEFAULT false, read_time integer DEFAULT 0, moderation_score
+--      integer DEFAULT 0.
+--   3. CREATE TABLE IF NOT EXISTS article_guidelines (id IDENTITY, key
+--      UNIQUE, title, description, active DEFAULT true, sort_order,
+--      created_at).
+--   4. ALTER TABLE article_guidelines ENABLE ROW LEVEL SECURITY.
+--   5. CREATE POLICY "Public read guidelines" ON article_guidelines.
+--   6. INSERT INTO article_guidelines (key, ...) VALUES (8 rows)
+--      ON CONFLICT (key) DO NOTHING.
+--   7. CREATE TABLE IF NOT EXISTS advisor_article_moderation_log (id
+--      IDENTITY, article_id FK→advisor_articles ON DELETE CASCADE,
+--      action, old_status, new_status, performed_by, notes, created_at).
+--   8. ALTER TABLE advisor_article_moderation_log ENABLE ROW LEVEL SECURITY.
+--   9. CREATE POLICY "Service role only mod log"
+--      ON advisor_article_moderation_log FOR ALL USING (false).
+--  10. CREATE INDEX IF NOT EXISTS idx_advisor_article_mod_log_article.
+--  11. CREATE INDEX IF NOT EXISTS idx_articles_content_type,
+--      idx_advisor_articles_featured (partial: WHERE featured = true),
+--      idx_advisor_articles_status.
+--
+-- Rollback (in reverse order):
+--   -- Pre-step (operator): export advisor_article_moderation_log
+--   -- (compliance audit trail) and any operator-added article_guidelines
+--   -- rows beyond the 8 seeded keys.
+--  11. DROP INDEX IF EXISTS idx_advisor_articles_status;
+--      DROP INDEX IF EXISTS idx_advisor_articles_featured;
+--      DROP INDEX IF EXISTS idx_articles_content_type;
+--  10. DROP INDEX IF EXISTS idx_advisor_article_mod_log_article;
+--   9. DROP POLICY IF EXISTS "Service role only mod log"
+--        ON advisor_article_moderation_log;
+--   8. (RLS toggle drops with the table.)
+--   7. DROP TABLE IF EXISTS advisor_article_moderation_log CASCADE;
+--      -- DESTRUCTIVE: drops moderation audit trail (compliance evidence).
+--   6. DELETE FROM article_guidelines
+--      WHERE key IN (
+--        'min_words', 'no_product_promo', 'australian_focus',
+--        'disclaimers', 'original_content', 'factual_accuracy',
+--        'professional_tone', 'no_guarantees'
+--      );
+--   5. DROP POLICY IF EXISTS "Public read guidelines" ON article_guidelines;
+--   4. (RLS toggle drops with the table.)
+--   3. DROP TABLE IF EXISTS article_guidelines CASCADE;
+--      -- Drops any operator-added guidelines beyond the 8 seeded keys.
+--   2. ALTER TABLE advisor_articles
+--        DROP COLUMN IF EXISTS moderation_score,
+--        DROP COLUMN IF EXISTS read_time,
+--        DROP COLUMN IF EXISTS featured,
+--        DROP COLUMN IF EXISTS related_advisor_types,
+--        DROP COLUMN IF EXISTS related_broker_slugs,
+--        DROP COLUMN IF EXISTS word_count;
+--      -- App code reads these columns; revert ship-side first.
+--   1. ALTER TABLE articles
+--        DROP COLUMN IF EXISTS related_advisor_types,
+--        DROP COLUMN IF EXISTS content_type;
+--      -- articles.content_type drives editorial-vs-how-to filtering;
+--      -- revert ship-side first.
+-- ============================================================================
+
 -- Content architecture enhancement: content_type, guidelines, moderation
 
 -- 1. Add content_type to articles for filtering editorial vs how-to vs news

--- a/supabase/migrations/20260310_fix_advisor_photos.sql
+++ b/supabase/migrations/20260310_fix_advisor_photos.sql
@@ -1,3 +1,53 @@
+-- ============================================================================
+-- Migration: 20260310_fix_advisor_photos.sql
+-- Purpose: Backfill `professionals.photo_url` for advisors with NULL
+--          photo_url — Part 1 sets a per-slug ui-avatars.com URL for ~55
+--          known advisor slugs (brand colour #7c3aed); Part 2 catch-all
+--          generates a name-derived ui-avatars URL for any remaining
+--          advisor with NULL photo_url. Both UPDATEs gated on
+--          `WHERE photo_url IS NULL` so the migration is idempotent.
+-- Rollback: NOT cleanly reversible — the forward UPDATE overwrites NULL
+--          values; the reverse cannot distinguish "this value was set by
+--          this migration" from "this value was set by a later operator
+--          edit / 20260309_create_advisor_photos_storage upload". A
+--          best-effort reverse sets ui-avatars.com URLs back to NULL,
+--          but this also wipes any operator changes pointing at
+--          ui-avatars.com (rare but possible).
+-- Risk: high (irreversible) — pure data backfill; the original NULL
+--       state is not preserved. Operator MUST snapshot
+--       professionals.photo_url before reverting. The advisor directory
+--       UI falls back to a placeholder when photo_url is NULL, so the
+--       reverse degrades the visual experience but does not break
+--       functionality.
+-- ============================================================================
+--
+-- Forward operations:
+--   1. UPDATE professionals SET photo_url = CASE slug WHEN '<slug>' THEN
+--      '<ui-avatars.com URL>' … (55 slugs) ELSE photo_url END
+--      WHERE photo_url IS NULL.
+--   2. UPDATE professionals SET photo_url =
+--        'https://ui-avatars.com/api/?name=' ||
+--        REPLACE(name, ' ', '+') || '&background=7c3aed&color=fff&size=200&bold=true'
+--      WHERE photo_url IS NULL.
+--
+-- Rollback (in reverse order):
+--   -- Pre-step (operator): snapshot
+--   --   SELECT id, slug, photo_url FROM professionals;
+--   -- Reverse cannot distinguish migration-set URLs from operator-set
+--   -- URLs. The simplest best-effort reverse is to NULL every
+--   -- ui-avatars.com URL — accept that any operator edits that point
+--   -- to ui-avatars.com (rare) will also be wiped.
+--   2. -- Best-effort reverse for the catch-all (Part 2):
+--      UPDATE professionals SET photo_url = NULL
+--      WHERE photo_url LIKE 'https://ui-avatars.com/api/%'
+--        AND photo_url LIKE '%&background=7c3aed&color=fff&size=200&bold=true';
+--   1. -- The per-slug UPDATE in Part 1 is subsumed by the reverse in
+--      -- step 2 (all 55 slugs use the same ui-avatars.com pattern).
+--      -- No additional action needed.
+--      -- DESTRUCTIVE: any operator-set ui-avatars.com URL on any advisor
+--      -- is also wiped. Restore from snapshot to undo collateral damage.
+-- ============================================================================
+
 -- Migration: Set branded photo_url for all advisors with NULL photo_url
 -- Uses ui-avatars.com with invest.com.au brand purple (#7c3aed)
 -- Idempotent: only updates rows where photo_url IS NULL

--- a/supabase/migrations/20260310_fix_performance_advisories.sql
+++ b/supabase/migrations/20260310_fix_performance_advisories.sql
@@ -1,3 +1,97 @@
+-- ============================================================================
+-- Migration: 20260310_fix_performance_advisories.sql
+-- Purpose: Fix Supabase performance-advisor warnings — (1) wrap
+--          `current_setting('request.jwt.claims', …)` in `(select …)` for
+--          per-query (not per-row) evaluation on 2 RLS UPDATE policies
+--          (`Update own portfolio alerts` on portfolio_alerts, `Update own
+--          portfolio` on user_portfolios); (2) drop 3 duplicate indexes
+--          (idx_analytics_events_created, idx_analytics_events_event_type,
+--          idx_fee_snapshots_portfolio); (3) add 9 missing FK indexes
+--          (idx_professional_leads_professional_id,
+--          idx_professional_reviews_professional_id,
+--          idx_advisor_applications_professional_id,
+--          idx_advisor_articles_professional_id,
+--          idx_advisor_bookings_professional_id,
+--          idx_affiliate_clicks_broker_id, idx_articles_author_id,
+--          idx_campaign_events_campaign_id, idx_campaigns_placement_id).
+-- Rollback: Recreate the 3 dropped duplicate indexes; drop the 9 added
+--          FK indexes; revert the 2 UPDATE policies to the original
+--          unwrapped `current_setting(...)` predicate. Reverse is a NET
+--          DEGRADATION (re-introduces the per-row evaluation perf issue
+--          and removes FK indexes); only run as part of a full deploy
+--          revert.
+-- Risk: medium — reverse re-introduces the perf-advisor warnings the
+--       Supabase advisor flagged (sequential scans on JOINs, slow per-row
+--       JWT lookup). Functionally identical to forward, just slower.
+--       The 2 RLS predicates change semantically as well: `(select
+--       current_setting(...))` is evaluated once per query; the unwrapped
+--       form is evaluated once per row. Reverse is safe but wasteful.
+-- ============================================================================
+--
+-- Forward operations:
+--   1. DROP POLICY IF EXISTS "Update own portfolio alerts"
+--        ON public.portfolio_alerts;
+--      CREATE POLICY "Update own portfolio alerts"
+--        ON public.portfolio_alerts FOR UPDATE
+--        USING (portfolio_id IN (SELECT id FROM public.user_portfolios
+--          WHERE email = (select current_setting(
+--            'request.jwt.claims', true)::json->>'email')))
+--        WITH CHECK (portfolio_id IS NOT NULL).
+--   2. DROP POLICY IF EXISTS "Update own portfolio"
+--        ON public.user_portfolios;
+--      CREATE POLICY "Update own portfolio" ON public.user_portfolios
+--        FOR UPDATE
+--        USING (email = (select current_setting(
+--          'request.jwt.claims', true)::json->>'email'))
+--        WITH CHECK (email IS NOT NULL AND length(TRIM(BOTH FROM email)) > 0).
+--   3. DROP INDEX IF EXISTS public.idx_analytics_events_created;
+--      DROP INDEX IF EXISTS public.idx_analytics_events_event_type;
+--      DROP INDEX IF EXISTS public.idx_fee_snapshots_portfolio.
+--   4. CREATE INDEX IF NOT EXISTS idx_professional_leads_professional_id,
+--      idx_professional_reviews_professional_id,
+--      idx_advisor_applications_professional_id,
+--      idx_advisor_articles_professional_id,
+--      idx_advisor_bookings_professional_id,
+--      idx_affiliate_clicks_broker_id, idx_articles_author_id,
+--      idx_campaign_events_campaign_id, idx_campaigns_placement_id.
+--
+-- Rollback (in reverse order):
+--   -- WARNING: reverse re-introduces the per-row JWT lookup perf issue
+--   -- and removes FK indexes. Only run as part of a full deploy revert.
+--   4. DROP INDEX IF EXISTS public.idx_campaigns_placement_id;
+--      DROP INDEX IF EXISTS public.idx_campaign_events_campaign_id;
+--      DROP INDEX IF EXISTS public.idx_articles_author_id;
+--      DROP INDEX IF EXISTS public.idx_affiliate_clicks_broker_id;
+--      DROP INDEX IF EXISTS public.idx_advisor_bookings_professional_id;
+--      DROP INDEX IF EXISTS public.idx_advisor_articles_professional_id;
+--      DROP INDEX IF EXISTS public.idx_advisor_applications_professional_id;
+--      DROP INDEX IF EXISTS public.idx_professional_reviews_professional_id;
+--      DROP INDEX IF EXISTS public.idx_professional_leads_professional_id;
+--   3. -- Re-create the dropped duplicate indexes only if a downstream
+--      -- migration has not already replaced them with equivalents:
+--      CREATE INDEX IF NOT EXISTS idx_fee_snapshots_portfolio
+--        ON public.portfolio_fee_snapshots(portfolio_id);
+--      CREATE INDEX IF NOT EXISTS idx_analytics_events_event_type
+--        ON public.analytics_events(event_type);
+--      CREATE INDEX IF NOT EXISTS idx_analytics_events_created
+--        ON public.analytics_events(created_at);
+--   2. DROP POLICY IF EXISTS "Update own portfolio" ON public.user_portfolios;
+--      CREATE POLICY "Update own portfolio" ON public.user_portfolios
+--        FOR UPDATE
+--        USING (email = current_setting(
+--          'request.jwt.claims', true)::json->>'email')
+--        WITH CHECK (email IS NOT NULL
+--          AND length(TRIM(BOTH FROM email)) > 0);
+--   1. DROP POLICY IF EXISTS "Update own portfolio alerts"
+--        ON public.portfolio_alerts;
+--      CREATE POLICY "Update own portfolio alerts"
+--        ON public.portfolio_alerts FOR UPDATE
+--        USING (portfolio_id IN (SELECT id FROM public.user_portfolios
+--          WHERE email = current_setting(
+--            'request.jwt.claims', true)::json->>'email'))
+--        WITH CHECK (portfolio_id IS NOT NULL);
+-- ============================================================================
+
 -- Fix Supabase performance advisories
 
 -- 1. Fix RLS initplan: wrap current_setting in (select ...) for per-query eval


### PR DESCRIPTION
## Summary

Continuation of G-03 (PRs #311, #314, #316). Adds rollback headers to the next 10 chronologically-ordered partial-header migrations. Format mirrors prior batches exactly — boxed `=` border, `Migration:`/`Purpose:`/`Rollback:`/`Risk:` keys, numbered forward + reverse-order operation lists, `IF EXISTS` on every DROP for idempotency.

10 migrations covered (chronological):
1. `001_initial.sql` (high — irreversible without snapshot)
2. `002_schema_additions.sql` (high — destroys email_captures rows on rollback)
3. `20260305_create_advisor_directory.sql` (high — CASCADE collapses ~15 advisor_* tables)
4. `20260309_security_and_performance_fixes.sql` (high — multi-section policy/index/search_path; reverse is net degradation)
5. `20260309_seed_mock_advisors.sql` (medium — re-seedable, fails on FK refs)
6. `20260310_admin_login_attempts.sql` (medium)
7. `20260310_advisor_firms_and_invitations.sql` (high — invalidates pending invite tokens)
8. `20260310_content_architecture.sql` (high — drops moderation audit trail)
9. `20260310_fix_advisor_photos.sql` (high — irreversible data backfill, documented best-effort reverse)
10. `20260310_fix_performance_advisories.sql` (medium)

Risk distribution: 7 high / 3 medium. Skewed higher than prior batches because cleanest candidates are now exhausted; remaining migrations are foundational schema and large hardening sweeps. All risks documented inline.

## Test plan

- [ ] CI: rls-migrations-gate green (no semantic changes, comment-only)
- [ ] CI: full suite green
- [ ] Reviewer: confirm header format matches PR #311 / #314 / #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)