### PR TITLE
feat(i): I-02 CI drift detection — fail build if database.types declares table without migration

### DIFF
--- a/.driftallowlist
+++ b/.driftallowlist
@@ -1,0 +1,134 @@
+# Database types drift allowlist (I-02 / A-07).
+#
+# Each entry is a table declared under `Database['public']['Tables']` in
+# `lib/database.types.ts` that has no `CREATE TABLE` statement in any
+# `supabase/migrations/*.sql` file.  This allowlist exists so the
+# `npm run audit:drift-types` CI gate can ship without first clearing the
+# 86-table historical drift backlog inventoried in
+# `docs/audits/drift-list.md` (generated 2026-04-30, refreshed 2026-05-01).
+#
+# As Stream A iterations (A-02 .. A-14, plus A-99 retirements) ship a
+# backfill migration for one of these tables, REMOVE the corresponding
+# entry from this file.  The gate emits a warning when an allowlist entry
+# is no longer drifted, so stale lines are surfaced on every CI run.
+#
+# Format: one table name per line.  Trailing `# comment` is ignored.
+# Whole-line `#` comments and blank lines are ignored.
+#
+# Categories follow the Stream A item map in docs/audits/drift-list.md.
+
+# A-04 (admin / audit)
+admin_audit_log
+
+# A-03 (advisor family)
+advisor_applications
+advisor_articles
+advisor_auth_tokens
+advisor_billing
+advisor_bookings
+advisor_booking_slots
+advisor_metrics_daily
+advisor_sessions
+advisor_specialties        # verify retirement before backfill
+advisor_verification_log
+
+# A-05 (affiliate / finance)
+affiliate_payout_reports
+affiliate_payout_variance
+conversion_events
+credit_packs
+finance_transactions
+subscriptions
+
+# A-06 (marketplace)
+allocation_decisions
+broker_accounts
+broker_activity_log
+broker_answers
+broker_data_changes
+broker_health_scores
+broker_packages
+broker_questions
+broker_review_invites
+broker_review_stats        # verify view vs table
+broker_wallets
+campaigns
+campaign_daily_stats
+campaign_events
+campaign_templates
+marketplace_invoices
+marketplace_placements
+sponsored_placement_bookings
+sponsored_placement_pricing
+wallet_transactions
+
+# A-07 (reference data)
+au_postcodes
+
+# A-08 (CRM / BD)
+bd_pipeline
+broker_outreach_log
+competitor_watch
+
+# A-09 (content tables)
+broker_transfer_guides
+content_calendar
+country_investment_profiles  # verify rename relationship to foreign_investment_dta
+fee_auto_rules
+fee_profiles
+fee_update_queue
+foreign_investment_rates     # verify whether folded into fi_* tables
+legal_documents
+regulatory_alerts
+switch_stories
+team_members
+
+# A-10 (consultations / courses)
+consultations
+consultation_bookings
+courses
+course_lessons
+course_progress
+course_purchases
+course_revenue
+
+# A-11 (ops / observability)
+cron_health_alerts
+posthog_events_mirror
+rate_limits
+webhook_delivery_queue
+
+# A-12 (email / lifecycle)
+investor_drip_log
+notification_preferences
+
+# A-13 (portfolio)
+portfolio_alerts
+portfolio_calculations     # verify usage; possibly retired
+portfolio_fee_snapshots
+portfolio_holdings         # verify; may be JSONB on user_portfolios
+user_portfolios
+
+# A-14 (Pro tier)
+pro_deals
+pro_deal_redemptions
+
+# A-02 (lead family / user data) — leftovers after main A-02 ship
+international_leads        # FK index exists but no CREATE TABLE — high priority
+lead_disputes
+user_reviews
+
+# A-99 (retirement / regenerate types — these tables look retired)
+article_moderation_log     # superseded by advisor_article_moderation_log
+content_products           # never shipped
+data_license_subscribers   # never shipped
+featured_plans             # superseded by sponsored_placement_*
+foreign_investment_flags   # renamed to foreign_investment_dta in 20260322 migration
+investor_journey_touchpoints  # superseded by attribution_touches
+sentiment_signals          # never shipped
+trading_performance_daily  # trading product never shipped
+trading_positions          # trading product never shipped
+trading_signals            # trading product never shipped
+
+# PostGIS extension-managed (out of scope — comes from CREATE EXTENSION postgis)
+spatial_ref_sys

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -391,6 +391,28 @@ jobs:
           GITHUB_BASE_REF: ${{ github.base_ref }}
         run: node scripts/check-rls-migrations.mjs
 
+  database-types-drift-gate:
+    name: Database types drift gate (lib/database.types.ts vs migrations)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: github.event_name == 'pull_request'
+    # Why this exists (I-02 / A-07): the audit found 91 tables declared in
+    # lib/database.types.ts that have no CREATE TABLE in supabase/migrations
+    # (docs/audits/drift-list.md, 2026-04-30).  Without a gate, that backlog
+    # silently re-grows every time a teammate adds a table via the Supabase
+    # dashboard but forgets to commit the matching migration — a fresh
+    # environment built from migrations alone would not match what the app
+    # expects.  This static-analysis check fails the build if the drift set
+    # grows; transitional drift is tolerated via .driftallowlist (one entry
+    # per drifted table, with a Stream A category comment).  As Stream A
+    # iterations land their backfill migrations, the corresponding allowlist
+    # entries are removed.  Skip token not required — this is static file
+    # analysis only.
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check database.types.ts has migrations for every public table
+        run: node scripts/check-database-types-drift.mjs
+
   lighthouse-cwv-gate:
     name: Lighthouse — Core Web Vitals gate (hard-fail)
     runs-on: ubuntu-latest

--- a/__tests__/scripts/check-database-types-drift.test.ts
+++ b/__tests__/scripts/check-database-types-drift.test.ts
@@ -1,0 +1,371 @@
+/**
+ * Tests for scripts/check-database-types-drift.mjs (I-02 / A-07).
+ *
+ * Exercises the exported helper functions directly so we can assert gate
+ * behaviour without spawning a child process.  The main() runner is not
+ * tested here — it's a thin wrapper around these helpers and its end-to-end
+ * behaviour is covered by the CI job itself on every PR.
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { join } from "node:path";
+
+const gatePath = join(process.cwd(), "scripts/check-database-types-drift.mjs");
+
+let extractTypesTables: (source: string) => string[];
+let extractMigrationTables: (sql: string) => string[];
+let parseAllowlist: (body: string) => Set<string>;
+let computeDrift: (
+  typesTables: string[],
+  migrationTables: string[],
+  allowed: Set<string>
+) => string[];
+let findStaleAllowlistEntries: (
+  allowed: Set<string>,
+  typesTables: string[],
+  migrationTables: string[]
+) => string[];
+
+beforeAll(async () => {
+  const mod = await import(gatePath);
+  extractTypesTables = mod.extractTypesTables;
+  extractMigrationTables = mod.extractMigrationTables;
+  parseAllowlist = mod.parseAllowlist;
+  computeDrift = mod.computeDrift;
+  findStaleAllowlistEntries = mod.findStaleAllowlistEntries;
+});
+
+// ---------------------------------------------------------------------------
+// extractTypesTables — parses the Supabase-generated database.types.ts shape
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds a minimal database.types.ts source skeleton with the requested
+ * table names declared inside `Database['public']['Tables']`.  Mirrors the
+ * exact indent + brace shape that `npx supabase gen types typescript` emits.
+ */
+function buildTypesSource(tableNames: string[], extra: { views?: string[] } = {}): string {
+  const tables = tableNames
+    .map(
+      (name) =>
+        `      ${name}: {\n` +
+        `        Row: {\n` +
+        `          id: number\n` +
+        `        }\n` +
+        `        Insert: {\n` +
+        `          id?: number\n` +
+        `        }\n` +
+        `        Update: {\n` +
+        `          id?: number\n` +
+        `        }\n` +
+        `        Relationships: []\n` +
+        `      }`
+    )
+    .join("\n");
+
+  const views = (extra.views ?? [])
+    .map(
+      (name) =>
+        `      ${name}: {\n` +
+        `        Row: {\n` +
+        `          id: number | null\n` +
+        `        }\n` +
+        `        Relationships: []\n` +
+        `      }`
+    )
+    .join("\n");
+
+  return [
+    "export type Database = {",
+    "  __InternalSupabase: {",
+    '    PostgrestVersion: "14.1"',
+    "  }",
+    "  public: {",
+    "    Tables: {",
+    tables,
+    "    }",
+    "    Views: {",
+    views,
+    "    }",
+    "    Functions: {}",
+    "    Enums: {}",
+    "    CompositeTypes: {}",
+    "  }",
+    "}",
+    "",
+  ].join("\n");
+}
+
+describe("extractTypesTables", () => {
+  it("extracts a single table from a minimal types source", () => {
+    const src = buildTypesSource(["foo"]);
+    expect(extractTypesTables(src)).toEqual(["foo"]);
+  });
+
+  it("extracts multiple tables in declaration order", () => {
+    const src = buildTypesSource(["alpha", "beta", "gamma"]);
+    expect(extractTypesTables(src)).toEqual(["alpha", "beta", "gamma"]);
+  });
+
+  it("does not pick up nested keys (Row, Insert, Update, Relationships)", () => {
+    const src = buildTypesSource(["only_top_level"]);
+    const out = extractTypesTables(src);
+    expect(out).toEqual(["only_top_level"]);
+    expect(out).not.toContain("Row");
+    expect(out).not.toContain("Insert");
+    expect(out).not.toContain("Update");
+    expect(out).not.toContain("Relationships");
+  });
+
+  it("does not pick up Views entries (sibling of Tables)", () => {
+    const src = buildTypesSource(["a_table"], { views: ["a_view"] });
+    expect(extractTypesTables(src)).toEqual(["a_table"]);
+  });
+
+  it("returns empty array when Tables block is empty", () => {
+    const src = buildTypesSource([]);
+    expect(extractTypesTables(src)).toEqual([]);
+  });
+
+  it("returns empty array on a malformed file with no public schema", () => {
+    const src = "export type Database = { foo: 1 }";
+    expect(extractTypesTables(src)).toEqual([]);
+  });
+
+  it("returns empty array on a malformed file missing Tables block", () => {
+    const src = [
+      "export type Database = {",
+      "  public: {",
+      "    Functions: {}",
+      "  }",
+      "}",
+      "",
+    ].join("\n");
+    expect(extractTypesTables(src)).toEqual([]);
+  });
+
+  it("deduplicates if the parser sees the same table twice", () => {
+    const src = buildTypesSource(["dup", "dup"]);
+    expect(extractTypesTables(src)).toEqual(["dup"]);
+  });
+
+  it("handles snake_case names with underscores and digits", () => {
+    const src = buildTypesSource(["table_1", "user_2fa_codes", "_slug_fix_log"]);
+    expect(extractTypesTables(src)).toEqual([
+      "table_1",
+      "user_2fa_codes",
+      "_slug_fix_log",
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractMigrationTables
+// ---------------------------------------------------------------------------
+
+describe("extractMigrationTables", () => {
+  it("returns table from a basic CREATE TABLE", () => {
+    expect(extractMigrationTables("CREATE TABLE foo (id uuid);")).toEqual(["foo"]);
+  });
+
+  it("handles CREATE TABLE IF NOT EXISTS", () => {
+    expect(extractMigrationTables("CREATE TABLE IF NOT EXISTS bar (id uuid);")).toEqual(["bar"]);
+  });
+
+  it("strips public. schema prefix", () => {
+    expect(extractMigrationTables("CREATE TABLE public.baz (id uuid);")).toEqual(["baz"]);
+  });
+
+  it("handles double-quoted table names", () => {
+    expect(extractMigrationTables('CREATE TABLE "quoted_table" (id uuid);')).toEqual([
+      "quoted_table",
+    ]);
+  });
+
+  it("returns multiple tables and dedupes", () => {
+    const sql = `
+      CREATE TABLE alpha (id uuid);
+      CREATE TABLE IF NOT EXISTS beta (id uuid);
+      CREATE TABLE public.alpha (id uuid); -- idempotent re-run
+    `;
+    expect(extractMigrationTables(sql).sort()).toEqual(["alpha", "beta"]);
+  });
+
+  it("is case-insensitive on the keyword", () => {
+    expect(extractMigrationTables("create table lower (id uuid);")).toEqual(["lower"]);
+  });
+
+  it("ignores ALTER TABLE / CREATE INDEX statements", () => {
+    const sql = `
+      ALTER TABLE foo ADD COLUMN bar text;
+      CREATE INDEX idx_foo ON foo (bar);
+    `;
+    expect(extractMigrationTables(sql)).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseAllowlist
+// ---------------------------------------------------------------------------
+
+describe("parseAllowlist", () => {
+  it("returns empty set for an empty body", () => {
+    expect(parseAllowlist("").size).toBe(0);
+  });
+
+  it("returns table names one per line", () => {
+    const body = "foo\nbar\nbaz\n";
+    const out = parseAllowlist(body);
+    expect(out.has("foo")).toBe(true);
+    expect(out.has("bar")).toBe(true);
+    expect(out.has("baz")).toBe(true);
+    expect(out.size).toBe(3);
+  });
+
+  it("ignores blank lines", () => {
+    const body = "foo\n\n\nbar\n";
+    expect(parseAllowlist(body).size).toBe(2);
+  });
+
+  it("ignores whole-line comments", () => {
+    const body = "# header comment\nfoo\n# another comment\nbar\n";
+    const out = parseAllowlist(body);
+    expect(out.size).toBe(2);
+    expect(out.has("foo")).toBe(true);
+    expect(out.has("bar")).toBe(true);
+  });
+
+  it("strips inline comments after the table name", () => {
+    const body = "foo  # A-04 backfill pending\nbar\n";
+    const out = parseAllowlist(body);
+    expect(out.has("foo")).toBe(true);
+    expect(out.has("bar")).toBe(true);
+  });
+
+  it("rejects entries that aren't valid table-name identifiers", () => {
+    const body = "valid_name\n123starts_with_digit\nhas spaces\n!bang\n";
+    const out = parseAllowlist(body);
+    expect(out.has("valid_name")).toBe(true);
+    expect(out.size).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeDrift
+// ---------------------------------------------------------------------------
+
+describe("computeDrift", () => {
+  it("returns empty when every types-table is in migrations (clean state)", () => {
+    expect(computeDrift(["a", "b", "c"], ["a", "b", "c"], new Set())).toEqual([]);
+  });
+
+  it("flags one drifted table", () => {
+    expect(computeDrift(["a", "b"], ["a"], new Set())).toEqual(["b"]);
+  });
+
+  it("flags multiple drifted tables", () => {
+    expect(computeDrift(["a", "b", "c", "d"], ["a"], new Set())).toEqual(["b", "c", "d"]);
+  });
+
+  it("respects the allowlist (allowed tables don't count as drift)", () => {
+    expect(computeDrift(["a", "b"], ["a"], new Set(["b"]))).toEqual([]);
+  });
+
+  it("preserves declaration order in the drift output", () => {
+    expect(computeDrift(["zeta", "alpha", "mu"], [], new Set())).toEqual([
+      "zeta",
+      "alpha",
+      "mu",
+    ]);
+  });
+
+  it("returns empty when types is empty", () => {
+    expect(computeDrift([], ["a"], new Set())).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findStaleAllowlistEntries
+// ---------------------------------------------------------------------------
+
+describe("findStaleAllowlistEntries", () => {
+  it("returns nothing when every allowlist entry is genuinely drifted", () => {
+    const allowed = new Set(["a", "b"]);
+    const types = ["a", "b", "c"];
+    const migrations = ["c"];
+    expect(findStaleAllowlistEntries(allowed, types, migrations)).toEqual([]);
+  });
+
+  it("flags an allowlist entry whose table now has a migration", () => {
+    const allowed = new Set(["a", "b"]);
+    const types = ["a", "b"];
+    const migrations = ["b"]; // b is no longer drifted
+    expect(findStaleAllowlistEntries(allowed, types, migrations)).toEqual(["b"]);
+  });
+
+  it("flags an allowlist entry whose table is no longer in types", () => {
+    const allowed = new Set(["retired_table", "a"]);
+    const types = ["a"];
+    const migrations: string[] = [];
+    expect(findStaleAllowlistEntries(allowed, types, migrations)).toEqual([
+      "retired_table",
+    ]);
+  });
+
+  it("returns sorted output for deterministic CI logs", () => {
+    const allowed = new Set(["zeta", "alpha", "mu"]);
+    const types: string[] = []; // all stale
+    const migrations: string[] = [];
+    expect(findStaleAllowlistEntries(allowed, types, [...migrations])).toEqual([
+      "alpha",
+      "mu",
+      "zeta",
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end scenarios
+// ---------------------------------------------------------------------------
+
+describe("integration: drift detection scenarios", () => {
+  it("clean state — every table has a migration", () => {
+    const types = extractTypesTables(buildTypesSource(["foo", "bar"]));
+    const mig = extractMigrationTables(
+      "CREATE TABLE foo (id uuid); CREATE TABLE bar (id uuid);"
+    );
+    expect(computeDrift(types, mig, new Set())).toEqual([]);
+  });
+
+  it("single drift — one table missing a migration", () => {
+    const types = extractTypesTables(buildTypesSource(["foo", "bar"]));
+    const mig = extractMigrationTables("CREATE TABLE foo (id uuid);");
+    expect(computeDrift(types, mig, new Set())).toEqual(["bar"]);
+  });
+
+  it("multiple drifts", () => {
+    const types = extractTypesTables(buildTypesSource(["foo", "bar", "baz", "qux"]));
+    const mig = extractMigrationTables("CREATE TABLE foo (id uuid);");
+    expect(computeDrift(types, mig, new Set())).toEqual(["bar", "baz", "qux"]);
+  });
+
+  it("allowlist exemption — drifted tables on allowlist pass", () => {
+    const types = extractTypesTables(buildTypesSource(["foo", "bar"]));
+    const mig = extractMigrationTables("CREATE TABLE foo (id uuid);");
+    const allowed = parseAllowlist("# transitional\nbar  # awaiting backfill\n");
+    expect(computeDrift(types, mig, allowed)).toEqual([]);
+  });
+
+  it("malformed types file — empty list, no false positives", () => {
+    const types = extractTypesTables("// not a Supabase types file");
+    const mig = extractMigrationTables("CREATE TABLE foo (id uuid);");
+    expect(computeDrift(types, mig, new Set())).toEqual([]);
+  });
+
+  it("partial allowlist — exempts only the listed table, others still drift", () => {
+    const types = extractTypesTables(buildTypesSource(["a", "b", "c"]));
+    const mig = extractMigrationTables("CREATE TABLE a (id uuid);");
+    const allowed = parseAllowlist("b\n");
+    expect(computeDrift(types, mig, allowed)).toEqual(["c"]);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "audit:stripe-idempotency": "node scripts/check-stripe-idempotency.mjs",
     "audit:stale-dated-stats": "node scripts/check-stale-dated-stats.mjs",
     "audit:rls-migrations": "node scripts/check-rls-migrations.mjs",
+    "audit:drift-types": "node scripts/check-database-types-drift.mjs",
     "audit:console-calls": "node scripts/check-console-calls.mjs",
     "audit:duplicate-functions": "node scripts/check-duplicate-functions.mjs",
     "audit:stale-branches": "node scripts/check-stale-branches.mjs",

--- a/scripts/check-database-types-drift.mjs
+++ b/scripts/check-database-types-drift.mjs
@@ -1,0 +1,308 @@
+#!/usr/bin/env node
+// @ts-check
+import { fileURLToPath } from "node:url";
+/**
+ * Database types drift gate (I-02 / A-07).
+ *
+ * Fails the build if `lib/database.types.ts` declares a table under
+ * `Database['public']['Tables']` that has no `CREATE TABLE` statement in any
+ * `supabase/migrations/*.sql` file.
+ *
+ * Why this matters: types are regenerated from the live Supabase schema, so a
+ * type-declared table that has no migration means a fresh environment built
+ * only from the migration tree would not match what the app's TypeScript
+ * expects.  That gap is how Stream A's 91-table backfill backlog
+ * (docs/audits/drift-list.md, generated 2026-04-30) accumulated in the first
+ * place — without a CI gate, drift silently re-grows the moment a teammate
+ * forgets to add a migration alongside a table they created in the dashboard.
+ *
+ * Usage:
+ *   npm run audit:drift-types               # local
+ *   node scripts/check-database-types-drift.mjs   # direct
+ *
+ * Escape hatch — the allowlist file `.driftallowlist` at repo root carries one
+ * table name per line.  Comments (`#`) and blank lines are ignored.  Each
+ * entry should have a brief justification on the same line in a `# …` comment
+ * so the file documents *why* the drift is tolerated.  The allowlist exists
+ * so this gate can ship without first clearing the historical 86-table drift
+ * backlog — it shrinks as Stream A items (A-02 .. A-14) ship.
+ *
+ * Parsing notes:
+ *  - We do NOT import from `lib/database.types.ts`; it uses TS type-level
+ *    features that aren't introspectable at runtime.  Instead we walk the
+ *    file as text and pick out the top-level table names inside the
+ *    `public: { Tables: { … } }` block by indent (6 spaces) and the trailing
+ *    `: {` token.  This mirrors the methodology in
+ *    `docs/audits/drift-list.md` §Methodology.
+ *  - Migration extraction reuses the same regex shape as
+ *    `scripts/check-rls-migrations.mjs` so the two gates agree on what
+ *    counts as a CREATE TABLE.
+ */
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+const TYPES_FILE = "lib/database.types.ts";
+const MIGRATIONS_DIR = "supabase/migrations";
+const ALLOWLIST_FILE = ".driftallowlist";
+
+// ---------------------------------------------------------------------------
+// Core logic — exported so unit tests can call directly
+// ---------------------------------------------------------------------------
+
+/**
+ * Extracts every table name declared under `Database['public']['Tables']`
+ * from a Supabase-generated database.types.ts source string.
+ *
+ * The parser is indent-aware:
+ *   export type Database = {            // col 0
+ *     public: {                         // col 2
+ *       Tables: {                       // col 4
+ *         <table_name>: {               // col 6  ← what we collect
+ *           Row: { … }                  // col 8
+ *           …
+ *         }
+ *       }
+ *       Views: { … }                    // col 4 (siblings of Tables)
+ *     }
+ *   }
+ *
+ * @param {string} source  full text of database.types.ts
+ * @returns {string[]}     table names in declaration order, deduplicated
+ */
+export function extractTypesTables(source) {
+  const lines = source.split("\n");
+  let inPublic = false;
+  let inTables = false;
+  /** @type {string[]} */
+  const names = [];
+  const seen = new Set();
+
+  for (const line of lines) {
+    if (!inPublic) {
+      // Top-level public schema opener.  The Supabase generator emits exactly
+      // `  public: {` with two leading spaces.
+      if (/^  public: \{$/.test(line)) {
+        inPublic = true;
+      }
+      continue;
+    }
+
+    if (!inTables) {
+      // Tables sub-block opens with four leading spaces.
+      if (/^    Tables: \{$/.test(line)) {
+        inTables = true;
+        continue;
+      }
+      // Closing the public block (col 2) ends our search entirely.
+      if (/^  \}$/.test(line)) {
+        break;
+      }
+      continue;
+    }
+
+    // Inside Tables.  The closing `    }` at column 4 ends the block.
+    if (/^    \}$/.test(line)) {
+      break;
+    }
+
+    // A table entry is exactly `      <name>: {` at column 6.  Any deeper
+    // indent is a nested `Row` / `Insert` / `Update` / `Relationships` key
+    // and must not be matched.
+    const m = /^      ([a-z_][a-z0-9_]*): \{$/.exec(line);
+    if (m && !seen.has(m[1])) {
+      seen.add(m[1]);
+      names.push(m[1]);
+    }
+  }
+
+  return names;
+}
+
+/**
+ * Extracts every CREATE TABLE target from a SQL string.  Strips an optional
+ * `public.` schema qualifier and lower-cases the result so casing differences
+ * across migrations don't produce phantom drift.
+ *
+ * @param {string} sql
+ * @returns {string[]}
+ */
+export function extractMigrationTables(sql) {
+  const re =
+    /CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(?:public\.)?"?([a-z_][a-z0-9_]*)"?/gi;
+  const names = new Set();
+  let m;
+  while ((m = re.exec(sql)) !== null) {
+    names.add(m[1].toLowerCase());
+  }
+  return [...names];
+}
+
+/**
+ * Parses a `.driftallowlist` file body.  Returns the set of allowed table
+ * names.  Inline comments after the table name are stripped:
+ *
+ *   admin_audit_log   # A-04 backfill pending
+ *   # whole-line comment
+ *   advisor_articles  # A-03 backfill pending
+ *
+ * @param {string} body
+ * @returns {Set<string>}
+ */
+export function parseAllowlist(body) {
+  const allowed = new Set();
+  for (const raw of body.split("\n")) {
+    const stripped = raw.replace(/#.*$/, "").trim();
+    if (!stripped) continue;
+    if (!/^[a-z_][a-z0-9_]*$/.test(stripped)) continue;
+    allowed.add(stripped);
+  }
+  return allowed;
+}
+
+/**
+ * Diffs the types-declared tables against the union of (migration-created
+ * tables) ∪ (allowlist).  Returns the names that are declared in types but
+ * neither created by a migration nor allow-listed.
+ *
+ * @param {string[]} typesTables
+ * @param {string[]} migrationTables
+ * @param {Set<string>} allowed
+ * @returns {string[]}
+ */
+export function computeDrift(typesTables, migrationTables, allowed) {
+  const migSet = new Set(migrationTables);
+  return typesTables.filter((t) => !migSet.has(t) && !allowed.has(t));
+}
+
+/**
+ * Returns allowlist entries that no longer correspond to a real drift.  These
+ * are stale lines that should be removed from the file once Stream A finishes
+ * the corresponding backfill.  We surface them as a warning (non-fatal) so
+ * the allowlist shrinks in lockstep with remediation.
+ *
+ * @param {Set<string>} allowed
+ * @param {string[]} typesTables
+ * @param {string[]} migrationTables
+ * @returns {string[]}
+ */
+export function findStaleAllowlistEntries(allowed, typesTables, migrationTables) {
+  const typesSet = new Set(typesTables);
+  const migSet = new Set(migrationTables);
+  const stale = [];
+  for (const name of allowed) {
+    // Allowlist entry is stale if either:
+    //   (a) the table no longer exists in types (likely retired), OR
+    //   (b) the table now has a migration (drift cleared).
+    if (!typesSet.has(name) || migSet.has(name)) {
+      stale.push(name);
+    }
+  }
+  return stale.sort();
+}
+
+// ---------------------------------------------------------------------------
+// Main runner
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const cwd = process.cwd();
+  const typesPath = path.join(cwd, TYPES_FILE);
+  const migrationsPath = path.join(cwd, MIGRATIONS_DIR);
+  const allowlistPath = path.join(cwd, ALLOWLIST_FILE);
+
+  let typesSource;
+  try {
+    typesSource = await fs.readFile(typesPath, "utf8");
+  } catch (err) {
+    console.error(`::error::Cannot read ${TYPES_FILE}: ${/** @type {Error} */ (err).message}`);
+    process.exit(1);
+  }
+
+  const typesTables = extractTypesTables(typesSource);
+  if (typesTables.length === 0) {
+    console.error(
+      `::error::No tables extracted from ${TYPES_FILE} — the parser may be out of sync with the file format.`
+    );
+    process.exit(1);
+  }
+
+  /** @type {string[]} */
+  let migrationFiles;
+  try {
+    const entries = await fs.readdir(migrationsPath);
+    migrationFiles = entries.filter((f) => f.endsWith(".sql")).sort();
+  } catch (err) {
+    console.error(
+      `::error::Cannot read ${MIGRATIONS_DIR}: ${/** @type {Error} */ (err).message}`
+    );
+    process.exit(1);
+  }
+
+  const migrationTables = new Set();
+  for (const file of migrationFiles) {
+    const sql = await fs.readFile(path.join(migrationsPath, file), "utf8");
+    for (const t of extractMigrationTables(sql)) {
+      migrationTables.add(t);
+    }
+  }
+
+  let allowed = new Set();
+  try {
+    const body = await fs.readFile(allowlistPath, "utf8");
+    allowed = parseAllowlist(body);
+  } catch {
+    // No allowlist file is fine — clean state.
+  }
+
+  const drift = computeDrift(typesTables, [...migrationTables], allowed);
+  const stale = findStaleAllowlistEntries(allowed, typesTables, [...migrationTables]);
+
+  console.log(
+    `Database types drift gate — ${typesTables.length} tables in types, ` +
+      `${migrationTables.size} tables in migrations, ${allowed.size} allow-listed.`
+  );
+
+  if (stale.length > 0) {
+    console.warn(
+      `::warning::${stale.length} allowlist entry(ies) appear stale (table is no longer drifted):`
+    );
+    for (const name of stale) {
+      console.warn(`  - ${name}`);
+    }
+    console.warn(`  → Remove from ${ALLOWLIST_FILE} to keep the allowlist honest.\n`);
+  }
+
+  if (drift.length === 0) {
+    console.log("Database types drift gate passed — no drifted tables.");
+    process.exit(0);
+  }
+
+  console.error(
+    `\n::error::Database types drift gate failed — ${drift.length} table(s) declared in ${TYPES_FILE} have no CREATE TABLE in ${MIGRATIONS_DIR}/:\n`
+  );
+  for (const name of drift) {
+    console.error(`  ✗  ${name}`);
+  }
+  console.error(
+    `\nFix options:\n` +
+      `  1. Add a forward-only migration that creates the table.  Mirror the\n` +
+      `     prod schema; include RLS policies (the rls-migrations gate will\n` +
+      `     check).  Example file: supabase/migrations/<YYYYMMDD>_${drift[0]}.sql\n` +
+      `  2. If the table is genuinely retired, remove it from\n` +
+      `     ${TYPES_FILE} (regenerate via \`npm run db:types\`).\n` +
+      `  3. If the drift is tolerated transitionally (e.g. waiting on a\n` +
+      `     Stream A iteration), add the table to ${ALLOWLIST_FILE} with a\n` +
+      `     justification comment.\n\n` +
+      `Background: docs/audits/drift-list.md classifies all known drift and\n` +
+      `tracks the Stream A backfill plan (A-02 .. A-14).\n`
+  );
+  process.exit(1);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err) => {
+    console.error("check-database-types-drift: unexpected error:", err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

New CI gate that prevents future schema drift from re-accumulating. Mirrors the structure of B-07's `rls-migrations-gate` (PR #286).

**Components:**
- `scripts/check-database-types-drift.mjs` — parses `lib/database.types.ts` as text (state-machine, no runtime import), greps `CREATE TABLE` from `supabase/migrations/*.sql`, diffs them. Exit 1 with remediation block on drift, exit 0 with stale-allowlist warning otherwise.
- `__tests__/scripts/check-database-types-drift.test.ts` — 38 vitest cases covering parser internals + 6 e2e scenarios.
- `.driftallowlist` — 86-entry seed reflecting current drift state, grouped by Stream A category. Shrinks as A-02..A-06 ship.
- `.github/workflows/ci.yml` — adds `database-types-drift-gate` job.
- `package.json` — adds `audit:drift-types` script.

**Local verification:**
- `node scripts/check-database-types-drift.mjs` → exit 0 (236 tables in types, 184 in migrations, 86 allow-listed)
- `npx tsc --noEmit` → clean
- `npx vitest run __tests__/scripts/check-database-types-drift.test.ts` → 38/38 pass

**Allowlist note:** Compared to `docs/audits/drift-list.md` (91 entries from 2026-04-30), 5 tables have moved out of drift since A-02 shipped (`lead_pricing`, `lead_pricing_log`, `profiles`, `quiz_leads`, `shared_shortlists`). With A-03 (PR #351) merged, another 5 will exit on next regen — current PR seeds at 86 to match the immediate state.

Reviewer worth checking: are `portfolio_calculations` / `portfolio_holdings` / `advisor_specialties` actually retirement candidates (A-99) rather than backfill?

## Test plan

- [ ] CI: new `database-types-drift-gate` job passes
- [ ] CI: full type-check + audit suite green
- [ ] Reviewer: skim allowlist for any table that should be retired instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)