### PR TITLE
refactor(f): F-04 slugify consolidation — first wave (1 of 11; 10 follow-ups)

### DIFF
--- a/app/api/admin/content/generate-draft/route.ts
+++ b/app/api/admin/content/generate-draft/route.ts
@@ -1,5 +1,6 @@
 import { createAdminClient } from "@/lib/supabase/admin";
 import { NextRequest, NextResponse } from "next/server";
+import { slugify } from "@/lib/utils";
 
 export const runtime = "edge";
 export const maxDuration = 120;
@@ -197,10 +198,7 @@ OUTPUT FORMAT (return valid JSON):
     }
 
     // Create the draft article
-    const slug = item.title
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, "-")
-      .replace(/^-|-$/g, "");
+    const slug = slugify(item.title);
 
     const { data: article, error: insertErr } = await supabase
       .from("articles")


### PR DESCRIPTION
## Summary

Replaces inline `toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "")` in `app/api/admin/content/generate-draft/route.ts` with `slugify(title)` from `@/lib/utils`. Behavioural-equivalence verified across plain ASCII, diacritics, underscores, leading/trailing punctuation, multiple consecutive separators.

**Files dropped (lint-staged trap → F-04-followup):**

10 files had viable, behaviour-preserving slugify replacements implemented and tsc-clean, but were reverted because husky `lint-staged --max-warnings 0` would fail on warnings unrelated to this change:

| File | Pre-existing warning |
|------|---|
| `app/admin/quarterly-reports/page.tsx` | `react-hooks/set-state-in-effect` |
| `app/admin/regulatory-alerts/page.tsx` | `react-hooks/set-state-in-effect` |
| `app/admin/team-members/page.tsx` | `react-hooks/exhaustive-deps` |
| `app/admin/consultations/page.tsx` | `react-hooks/immutability` |
| `app/admin/courses/page.tsx` | `react-hooks/immutability` |
| `app/admin/courses/[slug]/page.tsx` | `react-hooks/immutability` + `react-hooks/exhaustive-deps` |
| `app/api/advisor-articles/route.ts` | 2× `invest/no-unvalidated-req-json` |
| `app/api/advisor-signup/route.ts` | `invest/no-unvalidated-req-json` |
| `app/api/community/threads/route.ts` | `invest/no-unvalidated-req-json` |
| `app/api/marketplace/register/route.ts` | `invest/no-unvalidated-req-json` |

For each: replace local `slugify` / `generateSlug` / `autoSlug` with `import { slugify } from "@/lib/utils"`; for `advisor-articles` and `community/threads`, append `.slice(0, 80)` at call site to preserve length truncation.

**Files intentionally NOT replaced (behavioural divergence — would change stored slugs / URLs):**

- `app/api/quotes/route.ts` — local impl preserves leading/trailing hyphens
- `app/api/admin/advisor-applications/route.ts` — composite slug; suburb component intentionally has no separator (`stkilda` not `st-kilda`)
- `app/admin/advisors/page.tsx` — line 83 sanitiser preserves leading/trailing hyphens; line 123 `autoSlug` strips internal hyphens
- `app/admin/marketplace/placements/page.tsx` — input filter, not a slugifier
- `app/broker-portal/register/page.tsx` — real-time char allowlist filter
- `app/api/privacy/verify/route.ts` — filename sanitiser using `_` not `-`

## Test plan

- [ ] CI: full type-check + audit suite green
- [ ] Manual: regenerated AI-draft slugs are byte-identical to prior outputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)