### PR TITLE
refactor(f): F-06 move compliance copy strings to lib/compliance.ts SSOT

### DIFF
--- a/components/BrokerCard.tsx
+++ b/components/BrokerCard.tsx
@@ -3,6 +3,7 @@
 import { memo } from "react";
 import type { Broker } from "@/lib/types";
 import { trackClick, getAffiliateLink, getBenefitCta, renderStars, AFFILIATE_REL } from "@/lib/tracking";
+import { AFFILIATE_AD_TOOLTIP } from "@/lib/compliance";
 import SponsorBadge from "@/components/SponsorBadge";
 import Icon from "@/components/Icon";
 import ShortlistButton from "@/components/ShortlistButton";
@@ -72,7 +73,7 @@ export default memo(function BrokerCard({
                 {broker.name}
               </a>
               {broker.affiliate_url && !isSponsoredBroker && (
-                <span title="We may earn a commission if you visit this platform" className="text-[0.6rem] font-semibold px-1 py-0.5 bg-slate-100 text-slate-400 rounded uppercase tracking-wide shrink-0">Ad</span>
+                <span title={AFFILIATE_AD_TOOLTIP} className="text-[0.6rem] font-semibold px-1 py-0.5 bg-slate-100 text-slate-400 rounded uppercase tracking-wide shrink-0">Ad</span>
               )}
             </div>
             <div className="flex items-center gap-1.5">

--- a/components/VerifiedBadge.tsx
+++ b/components/VerifiedBadge.tsx
@@ -1,4 +1,9 @@
 import Icon from "@/components/Icon";
+import {
+  ABN_VERIFIED_NOTE,
+  AFSL_VERIFIED_NOTE,
+  SEEDED_PROFILE_NOTE,
+} from "@/lib/compliance";
 
 /**
  * Verified badge — renders up to three pill labels that document
@@ -60,7 +65,9 @@ export default function VerifiedBadge({
   if (hasAbn) {
     pills.push({
       label: "ABN Verified",
-      title: abn ? `ABN ${abn} confirmed on the ABR.` : "ABN confirmed on the ABR.",
+      title: abn
+        ? ABN_VERIFIED_NOTE.replace("ABN", `ABN ${abn}`)
+        : ABN_VERIFIED_NOTE,
       cls: "bg-emerald-100 text-emerald-800 border-emerald-200",
       icon: "check-circle",
     });
@@ -69,8 +76,8 @@ export default function VerifiedBadge({
     pills.push({
       label: "AFSL Current",
       title: afsl
-        ? `AFSL ${afsl} confirmed current on the ASIC Professional Registers.`
-        : "AFSL confirmed current on the ASIC Professional Registers.",
+        ? AFSL_VERIFIED_NOTE.replace("AFSL", `AFSL ${afsl}`)
+        : AFSL_VERIFIED_NOTE,
       cls: "bg-sky-100 text-sky-800 border-sky-200",
       icon: "shield-check",
     });
@@ -78,8 +85,7 @@ export default function VerifiedBadge({
   if (isSeeded && showSeeded) {
     pills.push({
       label: "Seeded",
-      title:
-        "This profile was seeded by the editorial team and has not yet been independently verified against ABR / ASIC.",
+      title: SEEDED_PROFILE_NOTE,
       cls: "bg-slate-100 text-slate-700 border-slate-200",
       icon: "info",
     });

--- a/components/full-service-brokers/FullServiceBrokerEnquiryForm.tsx
+++ b/components/full-service-brokers/FullServiceBrokerEnquiryForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { FULL_SERVICE_ENQUIRY_DISCLAIMER } from "@/lib/compliance";
 
 interface Props {
   professionalId: number;
@@ -203,9 +204,7 @@ export default function FullServiceBrokerEnquiryForm({
       </button>
 
       <p className="text-[0.65rem] text-slate-500 text-center leading-relaxed">
-        General information only — not personal financial advice. {firmName} is
-        responsible for any advice they give you and operates under their own
-        AFSL.
+        {FULL_SERVICE_ENQUIRY_DISCLAIMER.replace("{firmName}", firmName)}
       </p>
     </form>
   );

--- a/lib/compliance.ts
+++ b/lib/compliance.ts
@@ -60,6 +60,41 @@ export const COURSE_AFFILIATE_DISCLOSURE =
   "This course contains links to broker platforms. We may earn a commission if you sign up through these links. " +
   "This does not affect our educational content.";
 
+/** Tooltip on the inline "Ad" pill next to a broker name on cards / tables */
+export const AFFILIATE_AD_TOOLTIP =
+  "We may earn a commission if you visit this platform";
+
+/**
+ * Verified-badge tooltip explaining that an ABN was confirmed against the ABR.
+ * Components may prepend the actual ABN ("ABN 12 345 678 901 confirmed on the ABR.")
+ * when one is available; this is the canonical fallback when no ABN is on file.
+ */
+export const ABN_VERIFIED_NOTE = "ABN confirmed on the ABR.";
+
+/**
+ * Verified-badge tooltip explaining that an AFSL was confirmed against the
+ * ASIC Professional Registers. Components may prepend the AFSL number
+ * ("AFSL 123456 confirmed current on the ASIC Professional Registers.") when
+ * one is available; this is the canonical fallback when no number is on file.
+ */
+export const AFSL_VERIFIED_NOTE =
+  "AFSL confirmed current on the ASIC Professional Registers.";
+
+/**
+ * Verified-badge tooltip shown on the admin-only "Seeded" pill — clarifies
+ * that the profile has not yet been independently verified.
+ */
+export const SEEDED_PROFILE_NOTE =
+  "This profile was seeded by the editorial team and has not yet been independently verified against ABR / ASIC.";
+
+/**
+ * Disclaimer printed beneath a full-service-broker enquiry form.
+ * The literal `{firmName}` token MUST be replaced with the firm's display
+ * name at render time (e.g. via `.replace("{firmName}", firmName)`).
+ */
+export const FULL_SERVICE_ENQUIRY_DISCLAIMER =
+  "General information only — not personal financial advice. {firmName} is responsible for any advice they give you and operates under their own AFSL.";
+
 // ═══════════════════════════════════════════════════════════════════
 // AUSTRALIAN-SPECIFIC COMPLIANCE (ASIC / AFSL / AFCA / RG 234/256)
 // ═══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Moves 5 hardcoded compliance copy strings into `lib/compliance.ts` (the SSOT) and updates 3 components to import them. **Wording is byte-identical** to prior inline copy — no compliance rewrite, no re-review needed.

| New export | Used in | Purpose |
|---|---|---|
| `AFFILIATE_AD_TOOLTIP` | `BrokerCard.tsx` | Tooltip on inline "Ad" pill |
| `ABN_VERIFIED_NOTE` | `VerifiedBadge.tsx` | ABR-confirmed fallback when no ABN on file |
| `AFSL_VERIFIED_NOTE` | `VerifiedBadge.tsx` | ASIC Pro Registers fallback when no AFSL on file |
| `SEEDED_PROFILE_NOTE` | `VerifiedBadge.tsx` | Admin-only "Seeded" pill explanation |
| `FULL_SERVICE_ENQUIRY_DISCLAIMER` | `FullServiceBrokerEnquiryForm.tsx` | Full-service-broker enquiry disclaimer (with `{firmName}` token) |

**Scope deviations from audit:**
- Audit listed `FullServiceBrokerCard.tsx`; the actual hardcoded disclaimer lives in `FullServiceBrokerEnquiryForm.tsx`. Updated.
- Audit listed `AdminHelpPanel.tsx` (4th file). Deferred to F-06-followup — needs separate sweep.

## Test plan

- [ ] CI: full type-check + audit suite green
- [ ] Manual: visual diff on the affected components (tooltips, badge, disclaimer block) — all should render byte-identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)