### PR TITLE
refactor(f): F-03 consolidate formatCurrency re-implementations into lib/utils

### DIFF
--- a/app/api/cron/weekly-rate-update/route.ts
+++ b/app/api/cron/weekly-rate-update/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 import { notificationFooter } from "@/lib/email-templates";
 import { requireCronAuth } from "@/lib/cron-auth";
+import { formatCurrency } from "@/lib/utils";
 
 const log = logger("cron-weekly-rate-update");
 
@@ -41,15 +42,6 @@ const SOURCE_CONFIG: Record<
     path: "/portfolio-calculator",
   },
 };
-
-function formatCurrency(value: number): string {
-  return new Intl.NumberFormat("en-AU", {
-    style: "currency",
-    currency: "AUD",
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
-  }).format(value);
-}
 
 function buildPersonalLine(
   source: CalculatorSource,

--- a/app/costs/[slug]/page.tsx
+++ b/app/costs/[slug]/page.tsx
@@ -13,6 +13,7 @@ import {
   REVIEW_AUTHOR,
 } from "@/lib/seo";
 import { getAffiliateLink, AFFILIATE_REL } from "@/lib/tracking";
+import { formatCurrency } from "@/lib/utils";
 import AuthorByline from "@/components/AuthorByline";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
@@ -43,15 +44,6 @@ export async function generateMetadata({
     },
     alternates: { canonical: `/costs/${slug}` },
   };
-}
-
-function formatCurrency(n: number): string {
-  return n.toLocaleString("en-AU", {
-    style: "currency",
-    currency: "AUD",
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  });
 }
 
 export default async function CostScenarioPage({

--- a/app/debt-calculator/DebtCalculatorClient.tsx
+++ b/app/debt-calculator/DebtCalculatorClient.tsx
@@ -8,6 +8,7 @@ import AdvisorMatchCTA from "@/components/AdvisorMatchCTA";
 import { trackEvent, trackPageDuration } from "@/lib/tracking";
 import { getStoredUtm } from "@/components/UtmCapture";
 import { storeQualificationData } from "@/lib/qualification-store";
+import { formatCurrency } from "@/lib/utils";
 
 type DebtType = "credit_card" | "personal_loan" | "car_loan" | "hecs" | "other";
 
@@ -26,10 +27,6 @@ const DEBT_TYPE_LABELS: Record<DebtType, string> = {
   hecs: "HECS-HELP",
   other: "Other",
 };
-
-function formatCurrency(n: number): string {
-  return new Intl.NumberFormat("en-AU", { style: "currency", currency: "AUD", maximumFractionDigits: 0 }).format(n);
-}
 
 function formatMonths(months: number): string {
   const years = Math.floor(months / 12);

--- a/app/foreign-investment/WHTCalculator.tsx
+++ b/app/foreign-investment/WHTCalculator.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useMemo } from "react";
 import type { DTACountry } from "@/lib/foreign-investment-data";
+import { formatCurrency } from "@/lib/utils";
 
 interface Props {
   countries: DTACountry[];
@@ -43,9 +44,6 @@ export default function WHTCalculator({ countries, defaultRates }: Props) {
 
   const hasDTA = selectedCountry?.hasDTA ?? false;
   const noCountrySelected = !countryCode;
-
-  const formatCurrency = (n: number) =>
-    n.toLocaleString("en-AU", { style: "currency", currency: "AUD", maximumFractionDigits: 2 });
 
   return (
     <div className="bg-white rounded-2xl border border-slate-200 shadow-sm p-6">

--- a/app/property-yield-calculator/PropertyYieldCalculatorClient.tsx
+++ b/app/property-yield-calculator/PropertyYieldCalculatorClient.tsx
@@ -6,12 +6,9 @@ import Icon from "@/components/Icon";
 import SocialProofCounter from "@/components/SocialProofCounter";
 import { trackEvent, trackPageDuration } from "@/lib/tracking";
 import { getStoredUtm } from "@/components/UtmCapture";
+import { formatCurrency } from "@/lib/utils";
 
 /* ─── helpers ─── */
-
-function formatCurrency(n: number): string {
-  return new Intl.NumberFormat("en-AU", { style: "currency", currency: "AUD", maximumFractionDigits: 0 }).format(n);
-}
 
 function formatPercent(n: number): string {
   return n.toFixed(2) + "%";

--- a/app/retirement-calculator/RetirementCalculatorClient.tsx
+++ b/app/retirement-calculator/RetirementCalculatorClient.tsx
@@ -8,10 +8,7 @@ import { trackEvent, trackPageDuration } from "@/lib/tracking";
 import { getStoredUtm } from "@/components/UtmCapture";
 import { storeQualificationData } from "@/lib/qualification-store";
 import AdvisorMatchCTA from "@/components/AdvisorMatchCTA";
-
-function formatCurrency(n: number): string {
-  return new Intl.NumberFormat("en-AU", { style: "currency", currency: "AUD", maximumFractionDigits: 0 }).format(n);
-}
+import { formatCurrency } from "@/lib/utils";
 
 export default function RetirementCalculatorClient() {
   const [currentAge, setCurrentAge] = useState(35);

--- a/app/smsf-calculator/SMSFCalculatorClient.tsx
+++ b/app/smsf-calculator/SMSFCalculatorClient.tsx
@@ -6,12 +6,9 @@ import Icon from "@/components/Icon";
 import SocialProofCounter from "@/components/SocialProofCounter";
 import { trackEvent, trackPageDuration } from "@/lib/tracking";
 import { getStoredUtm } from "@/components/UtmCapture";
+import { formatCurrency } from "@/lib/utils";
 
 /* ── helpers ── */
-
-function formatCurrency(n: number): string {
-  return new Intl.NumberFormat("en-AU", { style: "currency", currency: "AUD", maximumFractionDigits: 0 }).format(n);
-}
 
 function smsfFixedCosts(): number {
   // Base SMSF running costs: audit ($1,500) + admin/accounting ($1,000)

--- a/app/super-contributions-calculator/SuperContributionsClient.tsx
+++ b/app/super-contributions-calculator/SuperContributionsClient.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useMemo } from "react";
 import Link from "next/link";
+import { formatCurrency } from "@/lib/utils";
 
 /* ── constants (FY2026) ── */
 
@@ -14,14 +15,6 @@ const SUPER_TAX_RATE = 0.15;
 const CARRY_FORWARD_BALANCE_THRESHOLD = 500_000;
 
 /* ── helpers ── */
-
-function formatCurrency(n: number): string {
-  return new Intl.NumberFormat("en-AU", {
-    style: "currency",
-    currency: "AUD",
-    maximumFractionDigits: 0,
-  }).format(n);
-}
 
 function formatPercent(n: number): string {
   return `${n.toFixed(1)}%`;


### PR DESCRIPTION
## Summary

Replaces 8 local `formatCurrency` re-implementations with `formatCurrency` from `@/lib/utils` (the SSOT).

**Visual delta to be aware of:** the canonical helper uses `minimumFractionDigits: 0`, so whole-dollar values render as `\$1,000` instead of `\$1,000.00`. This is the SSOT visual going forward — calculator UIs are the right place for this.

**Files converted (8):**
- `app/property-yield-calculator/PropertyYieldCalculatorClient.tsx`
- `app/super-contributions-calculator/SuperContributionsClient.tsx`
- `app/debt-calculator/DebtCalculatorClient.tsx`
- `app/retirement-calculator/RetirementCalculatorClient.tsx`
- `app/smsf-calculator/SMSFCalculatorClient.tsx`
- `app/foreign-investment/WHTCalculator.tsx`
- `app/api/cron/weekly-rate-update/route.ts`
- `app/costs/[slug]/page.tsx`

**Files skipped — behavioural divergence (5):**
- `app/admin/affiliate-links/page.tsx` — custom `\$Xk` suffix format
- `app/admin/analytics/AdminAnalyticsClient.tsx` — custom `\$Xk` suffix format
- `app/admin/marketplace/attribution/page.tsx` — cents input + `\$Xk` suffix
- `app/property/foreign-investment/CostCalculator.tsx` — custom `\$XM` millions suffix
- `app/property/foreign-investment/page.tsx` — custom `\$XM` millions suffix

Also untouched: `formatCurrencyExact` in `app/mortgage-calculator/MortgageCalculatorClient.tsx` (intentional always-2-decimals for mortgage payments — separate function, out of F-03 scope).

**Files dropped — lint-staged trap (2 → F-03-followup):**
- `app/mortgage-calculator/MortgageCalculatorClient.tsx` — pre-existing `react/no-unescaped-entities` warning (line 149)
- `app/savings-calculator/SavingsCalculatorClient.tsx` — pre-existing `react/no-unescaped-entities` warnings (lines 95, 168, 169, 273)

Both have viable, behaviour-equivalent replacements ready; just blocked by `--max-warnings 0` on unrelated warnings.

## Test plan

- [ ] CI: full type-check + audit suite green
- [ ] Visual: confirm whole-dollar values now render without trailing `.00` on the 8 calculator/pricing surfaces (intentional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)