### PR TITLE
fix(home): swap Friday Briefing/HowWeEarn order, footer dark continuous

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -239,11 +239,11 @@ export default async function HomePage() {
       </ScrollFadeIn>
 
       <ScrollFadeIn>
-        <HomeHowWeEarn />
+        <HomeFridayBriefing />
       </ScrollFadeIn>
 
       <ScrollFadeIn>
-        <HomeFridayBriefing />
+        <HomeHowWeEarn />
       </ScrollFadeIn>
 
       <MobileBottomNav />

--- a/components/layout/SiteFooter.tsx
+++ b/components/layout/SiteFooter.tsx
@@ -17,7 +17,10 @@ export function SiteFooter() {
   });
 
   return (
-    <footer className="bg-[var(--color-ink-900)] text-slate-300">
+    <footer
+      className="text-slate-300"
+      style={{ background: "var(--color-ink-900)" }}
+    >
       {/* Main grid */}
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-12 pb-8">
         <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4 md:gap-8 mb-12">


### PR DESCRIPTION
## Summary
- Swaps the order of `HomeFridayBriefing` and `HomeHowWeEarn` so the dark "How invest.com.au earns" section comes last
- Makes the footer background explicit inline `var(--color-ink-900)` so it renders identically to HomeHowWeEarn
- Net effect: the dark how-we-earn section flows seamlessly into the dark footer as one continuous block

## Test plan
- [x] Type-check clean
- [ ] Preview: Friday Briefing → How invest.com.au earns → Footer (no visible seam between the last two)

🤖 Generated with [Claude Code](https://claude.com/claude-code)