### PR TITLE
fix(test): C-02 CI fallout from #327 — vi.hoisted + requireAdvisorSession mocks (unblocks 11 PRs)

### DIFF
--- a/__tests__/api/advisor-auth-data.test.ts
+++ b/__tests__/api/advisor-auth-data.test.ts
@@ -9,6 +9,18 @@ const mockServerFrom = vi.fn();
 const mockAdminFrom = vi.fn();
 const supabaseCalls: Record<string, { method: string; args: unknown[] }[]> = {};
 
+// vi.hoisted() — the requireAdvisorSession helper mock factory below is
+// hoisted above this declaration block, so the fn it captures must be hoisted
+// too to avoid TDZ errors. See __tests__/lib/require-advisor-session.test.ts
+// for the same pattern.
+const { mockRequireAdvisorSession } = vi.hoisted(() => ({
+  mockRequireAdvisorSession: vi.fn(),
+}));
+
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: mockRequireAdvisorSession,
+}));
+
 vi.mock("@/lib/supabase/server", () => ({
   createClient: vi.fn(async () => ({
     auth: { getUser: mockGetUser },
@@ -37,6 +49,7 @@ function makePatch(body: unknown): NextRequest {
 }
 
 function authedAdvisor(advisorId = 42) {
+  mockRequireAdvisorSession.mockResolvedValue(advisorId);
   mockGetUser.mockResolvedValue({
     data: { user: { id: "u-1", email: "advisor@test.com" } },
   });
@@ -69,9 +82,12 @@ describe("GET /api/advisor-auth/data", () => {
     mockAdminFrom.mockImplementation((table: string) =>
       createChainableBuilder(table, supabaseCalls),
     );
+    // Default to authenticated; auth-failure tests override with null below.
+    mockRequireAdvisorSession.mockResolvedValue(42);
   });
 
   it("returns 401 when not authenticated", async () => {
+    mockRequireAdvisorSession.mockResolvedValueOnce(null);
     mockGetUser.mockResolvedValue({ data: { user: null } });
     const res = await GET(makeGet());
     expect(res.status).toBe(401);
@@ -84,6 +100,9 @@ describe("GET /api/advisor-auth/data", () => {
     const recent = new Date(Date.now() - 5 * 86400000).toISOString();
     const old = new Date(Date.now() - 60 * 86400000).toISOString();
 
+    // NOTE: Post-C-02, the route uses admin client for professional_leads,
+    // advisor_billing, advisor_profile_views, and professional_reviews. These
+    // had previously been on mockServerFrom — moved to mockAdminFrom below.
     mockAdminFrom.mockImplementation((table: string) => {
       const b = createChainableBuilder(table, supabaseCalls);
       if (table === "professionals") {
@@ -124,11 +143,6 @@ describe("GET /api/advisor-auth/data", () => {
           });
         });
       }
-      return b;
-    });
-
-    mockServerFrom.mockImplementation((table: string) => {
-      const b = createChainableBuilder(table, supabaseCalls);
       if (table === "professional_leads") {
         // Both queries (limit + count). Override the terminal limit to
         // return rows; the count query returns array via order/.then.
@@ -224,9 +238,12 @@ describe("PATCH /api/advisor-auth/data", () => {
     mockAdminFrom.mockImplementation((table: string) =>
       createChainableBuilder(table, supabaseCalls),
     );
+    // Default to authenticated; auth-failure tests override with null below.
+    mockRequireAdvisorSession.mockResolvedValue(42);
   });
 
   it("returns 401 when not authenticated", async () => {
+    mockRequireAdvisorSession.mockResolvedValueOnce(null);
     mockGetUser.mockResolvedValue({ data: { user: null } });
     const res = await PATCH(makePatch({ leadId: 1, status: "contacted" }));
     expect(res.status).toBe(401);
@@ -240,7 +257,8 @@ describe("PATCH /api/advisor-auth/data", () => {
 
   it("returns 404 when lead doesn't belong to advisor", async () => {
     authedAdvisor();
-    mockServerFrom.mockImplementation((table: string) => {
+    // Post-C-02: route uses admin client for professional_leads.
+    mockAdminFrom.mockImplementation((table: string) => {
       const b = createChainableBuilder(table, supabaseCalls);
       if (table === "professional_leads") {
         b.single = vi.fn(() => Promise.resolve({ data: null, error: null }));
@@ -254,7 +272,8 @@ describe("PATCH /api/advisor-auth/data", () => {
   it("stamps contacted_at, responded_at, and computes response_time_minutes", async () => {
     authedAdvisor();
     const created = new Date(Date.now() - 10 * 60 * 1000).toISOString();
-    mockServerFrom.mockImplementation((table: string) => {
+    // Post-C-02: route uses admin client for professional_leads.
+    mockAdminFrom.mockImplementation((table: string) => {
       const b = createChainableBuilder(table, supabaseCalls);
       if (table === "professional_leads") {
         b.single = vi.fn(() =>
@@ -285,7 +304,8 @@ describe("PATCH /api/advisor-auth/data", () => {
 
   it("stamps converted_at and outcome=won when status=converted", async () => {
     authedAdvisor();
-    mockServerFrom.mockImplementation((table: string) => {
+    // Post-C-02: route uses admin client for professional_leads.
+    mockAdminFrom.mockImplementation((table: string) => {
       const b = createChainableBuilder(table, supabaseCalls);
       if (table === "professional_leads") {
         b.single = vi.fn(() =>
@@ -310,7 +330,8 @@ describe("PATCH /api/advisor-auth/data", () => {
 
   it("stamps outcome=lost on lost / rejected status", async () => {
     authedAdvisor();
-    mockServerFrom.mockImplementation((table: string) => {
+    // Post-C-02: route uses admin client for professional_leads.
+    mockAdminFrom.mockImplementation((table: string) => {
       const b = createChainableBuilder(table, supabaseCalls);
       if (table === "professional_leads") {
         b.single = vi.fn(() =>
@@ -333,7 +354,8 @@ describe("PATCH /api/advisor-auth/data", () => {
 
   it("persists notes when provided", async () => {
     authedAdvisor();
-    mockServerFrom.mockImplementation((table: string) => {
+    // Post-C-02: route uses admin client for professional_leads.
+    mockAdminFrom.mockImplementation((table: string) => {
       const b = createChainableBuilder(table, supabaseCalls);
       if (table === "professional_leads") {
         b.single = vi.fn(() =>

--- a/__tests__/api/advisor-auth-disputes.test.ts
+++ b/__tests__/api/advisor-auth-disputes.test.ts
@@ -11,6 +11,16 @@ const mockAutoResolve = vi.fn((..._args: unknown[]) => undefined as unknown);
 const mockNotifyAdmin = vi.fn((..._args: unknown[]) => Promise.resolve());
 const supabaseCalls: Record<string, { method: string; args: unknown[] }[]> = {};
 
+// vi.hoisted() — vi.mock factories are hoisted; the captured fn must be too.
+// Post-C-02 the route delegates auth to requireAdvisorSession (helper).
+const { mockRequireAdvisorSession } = vi.hoisted(() => ({
+  mockRequireAdvisorSession: vi.fn(),
+}));
+
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: mockRequireAdvisorSession,
+}));
+
 vi.mock("@/lib/supabase/server", () => ({
   createClient: vi.fn(async () => ({
     auth: { getUser: mockGetUser },
@@ -51,6 +61,8 @@ function makeGet(): NextRequest {
 }
 
 function authedAdvisor(advisorId = 42) {
+  // Post-C-02: helper is mocked; mockGetUser kept for any non-helper paths.
+  mockRequireAdvisorSession.mockResolvedValue(advisorId);
   mockGetUser.mockResolvedValue({
     data: { user: { id: "u-1", email: "advisor@test.com" } },
   });
@@ -91,10 +103,11 @@ function setupServerFromForPost(opts: {
   // `from(table)` creates a fresh builder, but we want the counter to span
   // them so the route's two distinct `.from('lead_disputes')` calls (lookup +
   // insert) get different rows back.
+  // Post-C-02: route uses admin client for all queries here.
   let leadCallCount = 0;
   let disputeCallCount = 0;
 
-  mockServerFrom.mockImplementation((table: string) => {
+  mockAdminFrom.mockImplementation((table: string) => {
     const b = createChainableBuilder(table, supabaseCalls);
     if (table === "professional_leads") {
       b.single = vi.fn(() => {
@@ -173,6 +186,8 @@ describe("POST /api/advisor-auth/disputes", () => {
     mockAdminFrom.mockImplementation((table: string) =>
       createChainableBuilder(table, supabaseCalls),
     );
+    // Default: not authenticated. authedAdvisor() flips this to 42.
+    mockRequireAdvisorSession.mockResolvedValue(null);
     (isRateLimited as ReturnType<typeof vi.fn>).mockResolvedValue(false);
     mockAutoResolve.mockResolvedValue({
       verdict: "refund",
@@ -188,6 +203,7 @@ describe("POST /api/advisor-auth/disputes", () => {
   });
 
   it("returns 401 when not authenticated", async () => {
+    // Helper default (null) already simulates unauthenticated.
     mockGetUser.mockResolvedValue({ data: { user: null } });
     const res = await POST(makePost({ leadId: 1, reason: "spam" }));
     expect(res.status).toBe(401);
@@ -326,6 +342,8 @@ describe("GET /api/advisor-auth/disputes", () => {
     mockAdminFrom.mockImplementation((table: string) =>
       createChainableBuilder(table, supabaseCalls),
     );
+    // Default: not authenticated. authedAdvisor() flips this to 42.
+    mockRequireAdvisorSession.mockResolvedValue(null);
   });
 
   it("returns 401 when not authenticated", async () => {
@@ -336,7 +354,8 @@ describe("GET /api/advisor-auth/disputes", () => {
 
   it("returns disputes array for the advisor", async () => {
     authedAdvisor();
-    mockServerFrom.mockImplementation((table: string) => {
+    // Post-C-02: route uses admin client for lead_disputes.
+    mockAdminFrom.mockImplementation((table: string) => {
       const b = createChainableBuilder(table, supabaseCalls);
       if (table === "lead_disputes") {
         b.order = vi.fn(() =>
@@ -360,7 +379,8 @@ describe("GET /api/advisor-auth/disputes", () => {
 
   it("returns empty array when no disputes exist", async () => {
     authedAdvisor();
-    mockServerFrom.mockImplementation((table: string) => {
+    // Post-C-02: route uses admin client for lead_disputes.
+    mockAdminFrom.mockImplementation((table: string) => {
       const b = createChainableBuilder(table, supabaseCalls);
       if (table === "lead_disputes") {
         b.order = vi.fn(() =>

--- a/__tests__/api/advisor-auth-firm-analytics.test.ts
+++ b/__tests__/api/advisor-auth-firm-analytics.test.ts
@@ -8,6 +8,16 @@ const mockServerFrom = vi.fn();
 const mockAdminFrom = vi.fn();
 const supabaseCalls: Record<string, { method: string; args: unknown[] }[]> = {};
 
+// vi.hoisted() — vi.mock factories are hoisted; the captured fn must be too.
+// Post-C-02 the route delegates auth to requireAdvisorSession (helper).
+const { mockRequireAdvisorSession } = vi.hoisted(() => ({
+  mockRequireAdvisorSession: vi.fn(),
+}));
+
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: mockRequireAdvisorSession,
+}));
+
 vi.mock("@/lib/supabase/server", () => ({
   createClient: vi.fn(async () => ({ from: mockServerFrom })),
 }));
@@ -34,19 +44,15 @@ function withSession(opts: {
   expired?: boolean;
   advisor?: Record<string, unknown> | null;
 } = {}) {
-  const expiresAt = opts.expired
-    ? new Date(Date.now() - 86400 * 1000).toISOString()
-    : new Date(Date.now() + 86400 * 1000).toISOString();
-  mockServerFrom.mockImplementation((table: string) => {
+  // Post-C-02: helper handles auth (cookie + expiry); set null for expired.
+  if (opts.expired) {
+    mockRequireAdvisorSession.mockResolvedValue(null);
+  } else {
+    mockRequireAdvisorSession.mockResolvedValue(42);
+  }
+  // Route uses admin client for the firm-membership lookup.
+  mockAdminFrom.mockImplementation((table: string) => {
     const b = createChainableBuilder(table, supabaseCalls);
-    if (table === "advisor_sessions") {
-      b.single = vi.fn(() =>
-        Promise.resolve({
-          data: { professional_id: 42, expires_at: expiresAt },
-          error: null,
-        }),
-      );
-    }
     if (table === "professionals") {
       b.single = vi.fn(() =>
         Promise.resolve({
@@ -80,6 +86,9 @@ describe("GET /api/advisor-auth/firm/analytics", () => {
     mockAdminFrom.mockImplementation((table: string) =>
       createChainableBuilder(table, supabaseCalls),
     );
+    // Default: not authenticated. Tests that need auth call withSession()
+    // (or explicitly mockResolvedValue(42)) below.
+    mockRequireAdvisorSession.mockResolvedValue(null);
   });
 
   it("returns 401 when no cookie", async () => {
@@ -101,9 +110,17 @@ describe("GET /api/advisor-auth/firm/analytics", () => {
 
   it("returns empty members + null summary when firm has no members", async () => {
     withSession();
+    // Override admin mock for both the membership check (single) and the
+    // firm-members listing (order). Post-C-02 both go via admin.
     mockAdminFrom.mockImplementation((table: string) => {
       const b = createChainableBuilder(table, supabaseCalls);
       if (table === "professionals") {
+        b.single = vi.fn(() =>
+          Promise.resolve({
+            data: { id: 42, firm_id: 7, is_firm_admin: true },
+            error: null,
+          }),
+        );
         b.order = vi.fn(() =>
           Promise.resolve({ data: [], error: null }),
         );
@@ -122,9 +139,17 @@ describe("GET /api/advisor-auth/firm/analytics", () => {
     withSession();
     const recent = new Date(Date.now() - 5 * 86400000).toISOString();
     const old = new Date(Date.now() - 60 * 86400000).toISOString();
+    // Override admin mock for membership check (single) + members listing
+    // (order). Post-C-02 both go via admin.
     mockAdminFrom.mockImplementation((table: string) => {
       const b = createChainableBuilder(table, supabaseCalls);
       if (table === "professionals") {
+        b.single = vi.fn(() =>
+          Promise.resolve({
+            data: { id: 42, firm_id: 7, is_firm_admin: true },
+            error: null,
+          }),
+        );
         b.order = vi.fn(() =>
           Promise.resolve({
             data: [
@@ -220,7 +245,10 @@ describe("GET /api/advisor-auth/firm/analytics", () => {
   });
 
   it("returns 500 on unexpected error", async () => {
-    mockServerFrom.mockImplementation(() => {
+    // Post-C-02: route uses admin client, and auth happens in helper before
+    // any DB query. Throw from admin to trigger the route's catch block.
+    mockRequireAdvisorSession.mockResolvedValue(42);
+    mockAdminFrom.mockImplementation(() => {
       throw new Error("DB unavailable");
     });
     const res = await GET(makeGet("valid"));

--- a/__tests__/api/advisor-auth-firm-invite.test.ts
+++ b/__tests__/api/advisor-auth-firm-invite.test.ts
@@ -10,8 +10,27 @@ const mockSendFirmInvitation = vi.fn((..._args: unknown[]) =>
 );
 const supabaseCalls: Record<string, { method: string; args: unknown[] }[]> = {};
 
+// vi.hoisted() — vi.mock() factories are hoisted, so the captured fns must
+// be hoisted too. Post-C-02 the route uses requireAdvisorSession (helper) +
+// admin client throughout; this test now mocks both with mockServerFrom
+// aliased to admin for shared data setups (smaller diff).
+const { mockRequireAdvisorSession } = vi.hoisted(() => ({
+  mockRequireAdvisorSession: vi.fn(),
+}));
+
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: mockRequireAdvisorSession,
+}));
+
 vi.mock("@/lib/supabase/server", () => ({
   createClient: vi.fn(async () => ({ from: mockServerFrom })),
+}));
+
+// Post-C-02 the route uses createAdminClient() for all queries. Aliasing to
+// the existing mockServerFrom keeps the existing per-test data-setup bodies
+// working without renaming every reference.
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({ from: mockServerFrom }),
 }));
 
 vi.mock("@/lib/url", () => ({
@@ -53,21 +72,18 @@ function withFirmAdmin(opts: {
   firm?: Record<string, unknown> | null;
   memberCount?: number;
 } = {}) {
-  const expiresAt = opts.expired
-    ? new Date(Date.now() - 86400 * 1000).toISOString()
-    : new Date(Date.now() + 86400 * 1000).toISOString();
+  // Post-C-02: requireAdvisorSession helper is mocked. An "expired" session
+  // is now expressed as helper-returns-null (the helper itself does the
+  // expires_at check on the cookie row).
+  if (opts.expired) {
+    mockRequireAdvisorSession.mockResolvedValue(null);
+  } else {
+    mockRequireAdvisorSession.mockResolvedValue(42);
+  }
   let proCallCount = 0;
 
   mockServerFrom.mockImplementation((table: string) => {
     const b = createChainableBuilder(table, supabaseCalls);
-    if (table === "advisor_sessions") {
-      b.single = vi.fn(() =>
-        Promise.resolve({
-          data: { professional_id: 42, expires_at: expiresAt },
-          error: null,
-        }),
-      );
-    }
     if (table === "professionals") {
       proCallCount++;
       const isFirstCall = proCallCount === 1;
@@ -135,21 +151,27 @@ describe("POST /api/advisor-auth/firm/invite", () => {
     mockServerFrom.mockImplementation((table: string) =>
       createChainableBuilder(table, supabaseCalls),
     );
+    // Default: not authenticated. Tests that need auth call withFirmAdmin()
+    // (or explicitly mockResolvedValue(42)) below.
+    mockRequireAdvisorSession.mockResolvedValue(null);
   });
 
-  it("returns 401 with no cookie", async () => {
+  it("returns 403 when not authenticated (no cookie)", async () => {
+    // Post-C-02: route folds unauthenticated and "not a firm admin" into the
+    // same 403 path. The previous 401 was an artifact of the inlined auth
+    // logic which is now in the requireAdvisorSession helper.
     const res = await POST(
       makeReq("POST", { email: "new@firm.test" }),
     );
-    expect(res.status).toBe(401);
+    expect(res.status).toBe(403);
   });
 
-  it("returns 401 when session expired", async () => {
+  it("returns 403 when session expired", async () => {
     withFirmAdmin({ expired: true });
     const res = await POST(
       makeReq("POST", { email: "new@firm.test" }, "valid"),
     );
-    expect(res.status).toBe(401);
+    expect(res.status).toBe(403);
   });
 
   it("returns 403 when not a firm admin", async () => {
@@ -294,11 +316,16 @@ describe("GET /api/advisor-auth/firm/invite", () => {
     mockServerFrom.mockImplementation((table: string) =>
       createChainableBuilder(table, supabaseCalls),
     );
+    // Default: not authenticated. Tests that need auth call withFirmAdmin()
+    // (or explicitly mockResolvedValue(42)) below.
+    mockRequireAdvisorSession.mockResolvedValue(null);
   });
 
-  it("returns 401 with no cookie", async () => {
+  it("returns 403 when not authenticated (no cookie)", async () => {
+    // Post-C-02: route returns 403 from the firm-admin gate for both
+    // unauthenticated and non-firm-admin users.
     const res = await GET(makeReq("GET", null));
-    expect(res.status).toBe(401);
+    expect(res.status).toBe(403);
   });
 
   it("returns 403 when not a firm admin", async () => {
@@ -362,12 +389,17 @@ describe("PATCH /api/advisor-auth/firm/invite", () => {
     mockServerFrom.mockImplementation((table: string) =>
       createChainableBuilder(table, supabaseCalls),
     );
+    // Default: not authenticated. Tests that need auth call withFirmAdmin()
+    // (or explicitly mockResolvedValue(42)) below.
+    mockRequireAdvisorSession.mockResolvedValue(null);
   });
 
   function withInviteRow(opts: {
     inviteStatus?: string;
     found?: boolean;
   } = {}) {
+    // Post-C-02: helper handles auth before route does any DB work.
+    mockRequireAdvisorSession.mockResolvedValue(42);
     let proCount = 0;
     mockServerFrom.mockImplementation((table: string) => {
       const b = createChainableBuilder(table, supabaseCalls);
@@ -428,11 +460,13 @@ describe("PATCH /api/advisor-auth/firm/invite", () => {
     });
   }
 
-  it("returns 401 with no cookie", async () => {
+  it("returns 403 when not authenticated (no cookie)", async () => {
+    // Post-C-02: route returns 403 from the firm-admin gate for both
+    // unauthenticated and non-firm-admin users.
     const res = await PATCH(
       makeReq("PATCH", { inviteId: 5, action: "revoke" }),
     );
-    expect(res.status).toBe(401);
+    expect(res.status).toBe(403);
   });
 
   it("returns 400 for invalid action", async () => {

--- a/__tests__/api/advisor-auth-firm-member.test.ts
+++ b/__tests__/api/advisor-auth-firm-member.test.ts
@@ -8,6 +8,16 @@ const mockServerFrom = vi.fn();
 const mockAdminFrom = vi.fn();
 const supabaseCalls: Record<string, { method: string; args: unknown[] }[]> = {};
 
+// vi.hoisted() — vi.mock factories are hoisted; the captured fn must be too.
+// Post-C-02 the route delegates auth to requireAdvisorSession (helper).
+const { mockRequireAdvisorSession } = vi.hoisted(() => ({
+  mockRequireAdvisorSession: vi.fn(),
+}));
+
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: mockRequireAdvisorSession,
+}));
+
 vi.mock("@/lib/supabase/server", () => ({
   createClient: vi.fn(async () => ({ from: mockServerFrom })),
 }));
@@ -43,19 +53,10 @@ function makeDelete(memberId: number | string, cookie?: string): NextRequest {
 }
 
 function withFirmAdmin(adminId = 42, firmId = 7) {
-  mockServerFrom.mockImplementation((table: string) => {
+  // Post-C-02: helper handles auth; admin client handles professionals lookup.
+  mockRequireAdvisorSession.mockResolvedValue(adminId);
+  mockAdminFrom.mockImplementation((table: string) => {
     const b = createChainableBuilder(table, supabaseCalls);
-    if (table === "advisor_sessions") {
-      b.single = vi.fn(() =>
-        Promise.resolve({
-          data: {
-            professional_id: adminId,
-            expires_at: new Date(Date.now() + 86400 * 1000).toISOString(),
-          },
-          error: null,
-        }),
-      );
-    }
     if (table === "professionals") {
       b.single = vi.fn(() =>
         Promise.resolve({
@@ -91,6 +92,8 @@ describe("PATCH /api/advisor-auth/firm/member", () => {
     mockAdminFrom.mockImplementation((table: string) =>
       createChainableBuilder(table, supabaseCalls),
     );
+    // Default: not authenticated. withFirmAdmin() flips this to 42.
+    mockRequireAdvisorSession.mockResolvedValue(null);
   });
 
   it("returns 403 when no session cookie", async () => {
@@ -120,12 +123,22 @@ describe("PATCH /api/advisor-auth/firm/member", () => {
 
   it("returns 404 when member not in same firm", async () => {
     withFirmAdmin();
+    // Two single() calls on professionals: 1st = firm admin (getFirmAdmin),
+    // 2nd = member-in-firm check. We want the member check to return null.
+    let proCallCount = 0;
     mockAdminFrom.mockImplementation((table: string) => {
       const b = createChainableBuilder(table, supabaseCalls);
       if (table === "professionals") {
-        b.single = vi.fn(() =>
-          Promise.resolve({ data: null, error: null }),
-        );
+        b.single = vi.fn(() => {
+          proCallCount++;
+          if (proCallCount === 1) {
+            return Promise.resolve({
+              data: { id: 42, name: "Admin", firm_id: 7, is_firm_admin: true },
+              error: null,
+            });
+          }
+          return Promise.resolve({ data: null, error: null });
+        });
       }
       return b;
     });
@@ -137,12 +150,14 @@ describe("PATCH /api/advisor-auth/firm/member", () => {
 
   it("blocks self-demotion when no other owner exists", async () => {
     withFirmAdmin();
+    // Two single() calls on professionals: getFirmAdmin then member check.
+    // For self-demotion both target id 42, so both can return the same row.
     mockAdminFrom.mockImplementation((table: string) => {
       const b = createChainableBuilder(table, supabaseCalls);
       if (table === "professionals") {
         b.single = vi.fn(() =>
           Promise.resolve({
-            data: { id: 42, is_firm_admin: true },
+            data: { id: 42, name: "Admin", firm_id: 7, is_firm_admin: true },
             error: null,
           }),
         );
@@ -169,15 +184,24 @@ describe("PATCH /api/advisor-auth/firm/member", () => {
 
   it("updates a member's role and is_firm_admin auto-derived", async () => {
     withFirmAdmin();
+    // Two single() calls: getFirmAdmin (admin id=42) then member check (id=99).
+    let proCallCount = 0;
     mockAdminFrom.mockImplementation((table: string) => {
       const b = createChainableBuilder(table, supabaseCalls);
       if (table === "professionals") {
-        b.single = vi.fn(() =>
-          Promise.resolve({
+        b.single = vi.fn(() => {
+          proCallCount++;
+          if (proCallCount === 1) {
+            return Promise.resolve({
+              data: { id: 42, name: "Admin", firm_id: 7, is_firm_admin: true },
+              error: null,
+            });
+          }
+          return Promise.resolve({
             data: { id: 99, is_firm_admin: false },
             error: null,
-          }),
-        );
+          });
+        });
         // The update awaits .eq() directly
         b.eq = vi.fn(() => {
           supabaseCalls[table]?.push({ method: "eq", args: [] });
@@ -207,15 +231,23 @@ describe("PATCH /api/advisor-auth/firm/member", () => {
 
   it("respects explicit is_firm_admin=false", async () => {
     withFirmAdmin();
+    let proCallCount = 0;
     mockAdminFrom.mockImplementation((table: string) => {
       const b = createChainableBuilder(table, supabaseCalls);
       if (table === "professionals") {
-        b.single = vi.fn(() =>
-          Promise.resolve({
+        b.single = vi.fn(() => {
+          proCallCount++;
+          if (proCallCount === 1) {
+            return Promise.resolve({
+              data: { id: 42, name: "Admin", firm_id: 7, is_firm_admin: true },
+              error: null,
+            });
+          }
+          return Promise.resolve({
             data: { id: 99, is_firm_admin: true },
             error: null,
-          }),
-        );
+          });
+        });
       }
       return b;
     });
@@ -246,6 +278,8 @@ describe("DELETE /api/advisor-auth/firm/member", () => {
     mockAdminFrom.mockImplementation((table: string) =>
       createChainableBuilder(table, supabaseCalls),
     );
+    // Default: not authenticated. withFirmAdmin() flips this to 42.
+    mockRequireAdvisorSession.mockResolvedValue(null);
   });
 
   it("returns 403 when no session", async () => {
@@ -268,12 +302,20 @@ describe("DELETE /api/advisor-auth/firm/member", () => {
 
   it("returns 404 when member not in firm", async () => {
     withFirmAdmin();
+    let proCallCount = 0;
     mockAdminFrom.mockImplementation((table: string) => {
       const b = createChainableBuilder(table, supabaseCalls);
       if (table === "professionals") {
-        b.single = vi.fn(() =>
-          Promise.resolve({ data: null, error: null }),
-        );
+        b.single = vi.fn(() => {
+          proCallCount++;
+          if (proCallCount === 1) {
+            return Promise.resolve({
+              data: { id: 42, name: "Admin", firm_id: 7, is_firm_admin: true },
+              error: null,
+            });
+          }
+          return Promise.resolve({ data: null, error: null });
+        });
       }
       return b;
     });
@@ -283,15 +325,23 @@ describe("DELETE /api/advisor-auth/firm/member", () => {
 
   it("detaches member from firm without deleting the row", async () => {
     withFirmAdmin();
+    let proCallCount = 0;
     mockAdminFrom.mockImplementation((table: string) => {
       const b = createChainableBuilder(table, supabaseCalls);
       if (table === "professionals") {
-        b.single = vi.fn(() =>
-          Promise.resolve({
+        b.single = vi.fn(() => {
+          proCallCount++;
+          if (proCallCount === 1) {
+            return Promise.resolve({
+              data: { id: 42, name: "Admin", firm_id: 7, is_firm_admin: true },
+              error: null,
+            });
+          }
+          return Promise.resolve({
             data: { id: 99, name: "Bob" },
             error: null,
-          }),
-        );
+          });
+        });
       }
       return b;
     });

--- a/__tests__/api/advisor-auth-firm-seat-request.test.ts
+++ b/__tests__/api/advisor-auth-firm-seat-request.test.ts
@@ -11,6 +11,16 @@ const mockSendAdminNotification = vi.fn((..._args: unknown[]) =>
 );
 const supabaseCalls: Record<string, { method: string; args: unknown[] }[]> = {};
 
+// vi.hoisted() — vi.mock factories are hoisted; the captured fn must be too.
+// Post-C-02 the route delegates auth to requireAdvisorSession (helper).
+const { mockRequireAdvisorSession } = vi.hoisted(() => ({
+  mockRequireAdvisorSession: vi.fn(),
+}));
+
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: mockRequireAdvisorSession,
+}));
+
 vi.mock("@/lib/supabase/server", () => ({
   createClient: vi.fn(async () => ({ from: mockServerFrom })),
 }));
@@ -46,20 +56,15 @@ function withSession(opts: {
   advisor?: Record<string, unknown> | null;
   firm?: Record<string, unknown> | null;
 } = {}) {
-  const expiresAt = opts.expired
-    ? new Date(Date.now() - 86400 * 1000).toISOString()
-    : new Date(Date.now() + 86400 * 1000).toISOString();
+  // Post-C-02: helper handles auth; admin client handles DB lookups.
+  if (opts.expired) {
+    mockRequireAdvisorSession.mockResolvedValue(null);
+  } else {
+    mockRequireAdvisorSession.mockResolvedValue(42);
+  }
 
-  mockServerFrom.mockImplementation((table: string) => {
+  mockAdminFrom.mockImplementation((table: string) => {
     const b = createChainableBuilder(table, supabaseCalls);
-    if (table === "advisor_sessions") {
-      b.single = vi.fn(() =>
-        Promise.resolve({
-          data: { professional_id: 42, expires_at: expiresAt },
-          error: null,
-        }),
-      );
-    }
     if (table === "professionals") {
       b.single = vi.fn(() =>
         Promise.resolve({
@@ -110,6 +115,8 @@ describe("POST /api/advisor-auth/firm/seat-request", () => {
     mockAdminFrom.mockImplementation((table: string) =>
       createChainableBuilder(table, supabaseCalls),
     );
+    // Default: not authenticated. withSession() flips this to 42.
+    mockRequireAdvisorSession.mockResolvedValue(null);
   });
 
   it("returns 401 when no cookie", async () => {
@@ -161,8 +168,32 @@ describe("POST /api/advisor-auth/firm/seat-request", () => {
 
   it("returns 409 when a pending request already exists", async () => {
     withSession();
+    // Combine professionals/advisor_firms (from withSession) with the
+    // firm_seat_requests override.
     mockAdminFrom.mockImplementation((table: string) => {
       const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "professionals") {
+        b.single = vi.fn(() =>
+          Promise.resolve({
+            data: {
+              id: 42,
+              name: "Admin",
+              email: "admin@firm.test",
+              firm_id: 7,
+              is_firm_admin: true,
+            },
+            error: null,
+          }),
+        );
+      }
+      if (table === "advisor_firms") {
+        b.single = vi.fn(() =>
+          Promise.resolve({
+            data: { name: "Test Firm", max_seats: 5 },
+            error: null,
+          }),
+        );
+      }
       if (table === "firm_seat_requests") {
         b.single = vi.fn(() =>
           Promise.resolve({ data: { id: 99 }, error: null }),
@@ -176,8 +207,32 @@ describe("POST /api/advisor-auth/firm/seat-request", () => {
 
   it("creates seat request and notifies admin on success", async () => {
     withSession();
+    // Combine professionals/advisor_firms (from withSession) with the
+    // firm_seat_requests override.
     mockAdminFrom.mockImplementation((table: string) => {
       const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "professionals") {
+        b.single = vi.fn(() =>
+          Promise.resolve({
+            data: {
+              id: 42,
+              name: "Admin",
+              email: "admin@firm.test",
+              firm_id: 7,
+              is_firm_admin: true,
+            },
+            error: null,
+          }),
+        );
+      }
+      if (table === "advisor_firms") {
+        b.single = vi.fn(() =>
+          Promise.resolve({
+            data: { name: "Test Firm", max_seats: 5 },
+            error: null,
+          }),
+        );
+      }
       if (table === "firm_seat_requests") {
         b.single = vi.fn(() =>
           Promise.resolve({ data: null, error: null }),
@@ -207,7 +262,10 @@ describe("POST /api/advisor-auth/firm/seat-request", () => {
   });
 
   it("returns 500 on unexpected error", async () => {
-    mockServerFrom.mockImplementation(() => {
+    // Post-C-02: route uses admin client; auth happens in helper before
+    // any DB query. Throw from admin to trigger the route's catch block.
+    mockRequireAdvisorSession.mockResolvedValue(42);
+    mockAdminFrom.mockImplementation(() => {
       throw new Error("DB exploded");
     });
     const res = await POST(makePost({ requestedSeats: 10 }, "valid"));

--- a/__tests__/api/advisor-auth-firm.test.ts
+++ b/__tests__/api/advisor-auth-firm.test.ts
@@ -8,6 +8,16 @@ const mockServerFrom = vi.fn();
 const mockAdminFrom = vi.fn();
 const supabaseCalls: Record<string, { method: string; args: unknown[] }[]> = {};
 
+// vi.hoisted() — vi.mock factories are hoisted; the captured fn must be too.
+// Post-C-02 the route delegates auth to requireAdvisorSession (helper).
+const { mockRequireAdvisorSession } = vi.hoisted(() => ({
+  mockRequireAdvisorSession: vi.fn(),
+}));
+
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: mockRequireAdvisorSession,
+}));
+
 vi.mock("@/lib/supabase/server", () => ({
   createClient: vi.fn(async () => ({ from: mockServerFrom })),
 }));
@@ -45,19 +55,15 @@ function withSessionAndAdvisor(opts: {
   expired?: boolean;
   advisor?: Record<string, unknown> | null;
 } = {}) {
-  const expiresAt = opts.expired
-    ? new Date(Date.now() - 86400 * 1000).toISOString()
-    : new Date(Date.now() + 86400 * 1000).toISOString();
-  mockServerFrom.mockImplementation((table: string) => {
+  // Post-C-02: helper handles auth (cookie + expiry); admin client handles
+  // the professionals lookup.
+  if (opts.expired) {
+    mockRequireAdvisorSession.mockResolvedValue(null);
+  } else {
+    mockRequireAdvisorSession.mockResolvedValue(42);
+  }
+  mockAdminFrom.mockImplementation((table: string) => {
     const b = createChainableBuilder(table, supabaseCalls);
-    if (table === "advisor_sessions") {
-      b.single = vi.fn(() =>
-        Promise.resolve({
-          data: { professional_id: 42, expires_at: expiresAt },
-          error: null,
-        }),
-      );
-    }
     if (table === "professionals") {
       b.single = vi.fn(() =>
         Promise.resolve({
@@ -97,6 +103,8 @@ describe("GET /api/advisor-auth/firm", () => {
     mockAdminFrom.mockImplementation((table: string) =>
       createChainableBuilder(table, supabaseCalls),
     );
+    // Default: not authenticated. withSessionAndAdvisor() flips this to 42.
+    mockRequireAdvisorSession.mockResolvedValue(null);
   });
 
   it("returns 401 when no cookie", async () => {
@@ -114,8 +122,23 @@ describe("GET /api/advisor-auth/firm", () => {
 
   it("returns 404 when firm row not found", async () => {
     withSessionAndAdvisor();
+    // Combine professionals (from withSessionAndAdvisor) with advisor_firms.
     mockAdminFrom.mockImplementation((table: string) => {
       const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "professionals") {
+        b.single = vi.fn(() =>
+          Promise.resolve({
+            data: {
+              id: 42,
+              name: "Admin",
+              firm_id: 7,
+              is_firm_admin: true,
+              role: "owner",
+            },
+            error: null,
+          }),
+        );
+      }
       if (table === "advisor_firms") {
         b.single = vi.fn(() =>
           Promise.resolve({ data: null, error: { code: "PGRST116" } }),
@@ -129,6 +152,8 @@ describe("GET /api/advisor-auth/firm", () => {
 
   it("returns firm and memberCount on success", async () => {
     withSessionAndAdvisor();
+    // Combine professionals (from withSessionAndAdvisor) + advisor_firms +
+    // member-count thenable on professionals.
     mockAdminFrom.mockImplementation((table: string) => {
       const b = createChainableBuilder(table, supabaseCalls);
       if (table === "advisor_firms") {
@@ -140,6 +165,18 @@ describe("GET /api/advisor-auth/firm", () => {
         );
       }
       if (table === "professionals") {
+        b.single = vi.fn(() =>
+          Promise.resolve({
+            data: {
+              id: 42,
+              name: "Admin",
+              firm_id: 7,
+              is_firm_admin: true,
+              role: "owner",
+            },
+            error: null,
+          }),
+        );
         // The count query awaits eq() directly; provide a thenable count
         b.eq = vi.fn(() => {
           supabaseCalls[table]?.push({ method: "eq", args: [] });
@@ -174,6 +211,8 @@ describe("PATCH /api/advisor-auth/firm", () => {
     mockAdminFrom.mockImplementation((table: string) =>
       createChainableBuilder(table, supabaseCalls),
     );
+    // Default: not authenticated. withSessionAndAdvisor() flips this to 42.
+    mockRequireAdvisorSession.mockResolvedValue(null);
   });
 
   it("returns 403 when not a firm admin", async () => {
@@ -218,8 +257,23 @@ describe("PATCH /api/advisor-auth/firm", () => {
 
   it("updates allowlisted fields and returns the updated firm", async () => {
     withSessionAndAdvisor();
+    // Combine professionals (firm-admin check) with advisor_firms.
     mockAdminFrom.mockImplementation((table: string) => {
       const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "professionals") {
+        b.single = vi.fn(() =>
+          Promise.resolve({
+            data: {
+              id: 42,
+              name: "Admin",
+              firm_id: 7,
+              is_firm_admin: true,
+              role: "owner",
+            },
+            error: null,
+          }),
+        );
+      }
       if (table === "advisor_firms") {
         b.single = vi.fn(() =>
           Promise.resolve({
@@ -258,8 +312,23 @@ describe("PATCH /api/advisor-auth/firm", () => {
   it("recomputes location_display when location fields change", async () => {
     withSessionAndAdvisor();
     let firmCallCount = 0;
+    // Combine professionals (firm-admin check) with advisor_firms call counter.
     mockAdminFrom.mockImplementation((table: string) => {
       const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "professionals") {
+        b.single = vi.fn(() =>
+          Promise.resolve({
+            data: {
+              id: 42,
+              name: "Admin",
+              firm_id: 7,
+              is_firm_admin: true,
+              role: "owner",
+            },
+            error: null,
+          }),
+        );
+      }
       if (table === "advisor_firms") {
         b.single = vi.fn(() => {
           firmCallCount++;

--- a/__tests__/api/advisor-auth-payment.test.ts
+++ b/__tests__/api/advisor-auth-payment.test.ts
@@ -7,6 +7,16 @@ import { createChainableBuilder } from "@/__tests__/helpers";
 const mockAdminFrom = vi.fn();
 const supabaseCalls: Record<string, { method: string; args: unknown[] }[]> = {};
 
+// vi.hoisted() — vi.mock factories are hoisted; the captured fn must be too.
+// Post-C-02 the route delegates auth to requireAdvisorSession (helper).
+const { mockRequireAdvisorSession } = vi.hoisted(() => ({
+  mockRequireAdvisorSession: vi.fn(),
+}));
+
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: mockRequireAdvisorSession,
+}));
+
 vi.mock("@/lib/supabase/admin", () => ({
   createAdminClient: () => ({ from: mockAdminFrom }),
 }));
@@ -48,19 +58,10 @@ function withSessionAndAdvisor(
   professionalId = 42,
   advisorOverrides: Record<string, unknown> = {},
 ) {
+  // Post-C-02: helper handles auth.
+  mockRequireAdvisorSession.mockResolvedValue(professionalId);
   mockAdminFrom.mockImplementation((table: string) => {
     const b = createChainableBuilder(table, supabaseCalls);
-    if (table === "advisor_sessions") {
-      b.single = vi.fn(() =>
-        Promise.resolve({
-          data: {
-            professional_id: professionalId,
-            expires_at: new Date(Date.now() + 86400 * 1000).toISOString(),
-          },
-          error: null,
-        }),
-      );
-    }
     if (table === "professionals") {
       b.single = vi.fn(() =>
         Promise.resolve({
@@ -100,6 +101,8 @@ describe("POST /api/advisor-auth/payment", () => {
     mockAdminFrom.mockImplementation((table: string) =>
       createChainableBuilder(table, supabaseCalls),
     );
+    // Default: not authenticated. withSessionAndAdvisor() flips this to 42.
+    mockRequireAdvisorSession.mockResolvedValue(null);
     mockCustomerCreate.mockResolvedValue({ id: "cus_new" });
     mockCheckoutCreate.mockResolvedValue({
       id: "cs_payment_001",
@@ -115,14 +118,7 @@ describe("POST /api/advisor-auth/payment", () => {
   });
 
   it("returns 401 when session is invalid/expired", async () => {
-    mockAdminFrom.mockImplementation((table: string) => {
-      const b = createChainableBuilder(table, supabaseCalls);
-      if (table === "advisor_sessions") {
-        b.single = vi.fn(() => Promise.resolve({ data: null, error: null }));
-      }
-      return b;
-    });
-
+    // Helper default (null) already simulates unauthenticated/expired.
     const res = await POST(
       makePost({ advisor_id: 42, credit_pack: "starter" }, "stale-token"),
     );
@@ -130,31 +126,17 @@ describe("POST /api/advisor-auth/payment", () => {
   });
 
   it("returns 400 for invalid JSON body", async () => {
-    mockAdminFrom.mockImplementation((table: string) => {
-      const b = createChainableBuilder(table, supabaseCalls);
-      if (table === "advisor_sessions") {
-        b.single = vi.fn(() =>
-          Promise.resolve({
-            data: {
-              professional_id: 42,
-              expires_at: new Date(Date.now() + 86400 * 1000).toISOString(),
-            },
-            error: null,
-          }),
-        );
-      }
-      return b;
-    });
-
+    // Helper handles auth; route then JSON-parses the body.
+    mockRequireAdvisorSession.mockResolvedValue(42);
     const res = await POST(makePost("{not-json", "valid-token"));
     expect(res.status).toBe(400);
   });
 
-  it("returns 400 when advisor_id is missing", async () => {
-    withSessionAndAdvisor();
-    const res = await POST(makePost({ credit_pack: "starter" }, "valid"));
-    expect(res.status).toBe(400);
-  });
+  // Post-C-02: route ignores body.advisor_id and uses the session-scoped
+  // advisorId from requireAdvisorSession() for both auth and DB scoping. The
+  // previous "advisor_id missing" / "advisor_id doesn't match session"
+  // tests no longer apply — body.advisor_id is unused. The session is the
+  // single source of truth for which advisor is paying.
 
   it("returns 400 when credit_pack is invalid", async () => {
     withSessionAndAdvisor();
@@ -164,28 +146,11 @@ describe("POST /api/advisor-auth/payment", () => {
     expect(res.status).toBe(400);
   });
 
-  it("returns 403 when advisor_id doesn't match session", async () => {
-    withSessionAndAdvisor(42);
-    const res = await POST(
-      makePost({ advisor_id: 99, credit_pack: "starter" }, "valid"),
-    );
-    expect(res.status).toBe(403);
-  });
-
   it("returns 404 when advisor row not found", async () => {
+    // Helper handles auth; admin lookup returns null for the advisor row.
+    mockRequireAdvisorSession.mockResolvedValue(42);
     mockAdminFrom.mockImplementation((table: string) => {
       const b = createChainableBuilder(table, supabaseCalls);
-      if (table === "advisor_sessions") {
-        b.single = vi.fn(() =>
-          Promise.resolve({
-            data: {
-              professional_id: 42,
-              expires_at: new Date(Date.now() + 86400 * 1000).toISOString(),
-            },
-            error: null,
-          }),
-        );
-      }
       if (table === "professionals") {
         b.single = vi.fn(() =>
           Promise.resolve({ data: null, error: null }),
@@ -250,6 +215,8 @@ describe("POST /api/advisor-auth/payment", () => {
   });
 
   it("returns 500 on unexpected error", async () => {
+    // Helper handles auth; throw from admin client to trigger catch.
+    mockRequireAdvisorSession.mockResolvedValue(42);
     mockAdminFrom.mockImplementation(() => {
       throw new Error("DB unreachable");
     });

--- a/__tests__/api/advisor-auth-profile.test.ts
+++ b/__tests__/api/advisor-auth-profile.test.ts
@@ -9,6 +9,16 @@ const mockServerFrom = vi.fn();
 const mockAdminFrom = vi.fn();
 const supabaseCalls: Record<string, { method: string; args: unknown[] }[]> = {};
 
+// vi.hoisted() — vi.mock factories are hoisted; the captured fn must be too.
+// Post-C-02 the route delegates auth to requireAdvisorSession (helper).
+const { mockRequireAdvisorSession } = vi.hoisted(() => ({
+  mockRequireAdvisorSession: vi.fn(),
+}));
+
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: mockRequireAdvisorSession,
+}));
+
 vi.mock("@/lib/supabase/server", () => ({
   createClient: vi.fn(async () => ({
     auth: { getUser: mockGetUser },
@@ -62,6 +72,8 @@ describe("PATCH /api/advisor-auth/profile", () => {
     mockAdminFrom.mockImplementation((table: string) =>
       createChainableBuilder(table, supabaseCalls),
     );
+    // Default: not authenticated. Tests flip this per-case below.
+    mockRequireAdvisorSession.mockResolvedValue(null);
     (isRateLimited as ReturnType<typeof vi.fn>).mockResolvedValue(false);
   });
 
@@ -78,17 +90,10 @@ describe("PATCH /api/advisor-auth/profile", () => {
   });
 
   it("updates allowed fields when authed via supabase", async () => {
+    // Helper handles auth.
+    mockRequireAdvisorSession.mockResolvedValue(99);
     mockGetUser.mockResolvedValue({
       data: { user: { id: "u-1", email: "a@b.com" } },
-    });
-    mockAdminFrom.mockImplementation((table: string) => {
-      const b = createChainableBuilder(table, supabaseCalls);
-      if (table === "professionals") {
-        b.maybeSingle = vi.fn(() =>
-          Promise.resolve({ data: { id: 99 }, error: null }),
-        );
-      }
-      return b;
     });
 
     const res = await PATCH(
@@ -102,7 +107,7 @@ describe("PATCH /api/advisor-auth/profile", () => {
     );
     expect(res.status).toBe(200);
 
-    // Server client (createClient) is what runs the update
+    // Post-C-02: route uses admin client for the update.
     const proCalls = supabaseCalls.professionals || [];
     const updateCall = proCalls.find((c) => c.method === "update");
     expect(updateCall).toBeDefined();
@@ -116,22 +121,15 @@ describe("PATCH /api/advisor-auth/profile", () => {
   });
 
   it("returns 500 when the update query errors", async () => {
+    mockRequireAdvisorSession.mockResolvedValue(99);
     mockGetUser.mockResolvedValue({
       data: { user: { id: "u-2", email: "a@b.com" } },
     });
+    // Post-C-02: route uses admin client for the update; awaited eq() returns
+    // {data, error} — return an error to trigger the 500.
     mockAdminFrom.mockImplementation((table: string) => {
       const b = createChainableBuilder(table, supabaseCalls);
       if (table === "professionals") {
-        b.maybeSingle = vi.fn(() =>
-          Promise.resolve({ data: { id: 99 }, error: null }),
-        );
-      }
-      return b;
-    });
-    mockServerFrom.mockImplementation((table: string) => {
-      const b = createChainableBuilder(table, supabaseCalls);
-      if (table === "professionals") {
-        // Override the awaited update result
         b.eq = vi.fn(() =>
           Promise.resolve({ data: null, error: { message: "db error" } }),
         );
@@ -144,20 +142,10 @@ describe("PATCH /api/advisor-auth/profile", () => {
   });
 
   it("authenticates via legacy session cookie when supabase user is absent", async () => {
+    // Helper translates the cookie into an advisorId; cookie path is now
+    // entirely an internal helper concern.
+    mockRequireAdvisorSession.mockResolvedValue(88);
     mockGetUser.mockResolvedValue({ data: { user: null } });
-    const futureExpiry = new Date(Date.now() + 86400 * 1000).toISOString();
-    mockAdminFrom.mockImplementation((table: string) => {
-      const b = createChainableBuilder(table, supabaseCalls);
-      if (table === "advisor_sessions") {
-        b.single = vi.fn(() =>
-          Promise.resolve({
-            data: { professional_id: 88, expires_at: futureExpiry },
-            error: null,
-          }),
-        );
-      }
-      return b;
-    });
 
     const res = await PATCH(
       makePatch({ bio: "from legacy" }, "legacy-cookie"),
@@ -166,20 +154,9 @@ describe("PATCH /api/advisor-auth/profile", () => {
   });
 
   it("returns 401 when legacy session is expired", async () => {
+    // Helper returns null for an expired cookie session.
+    mockRequireAdvisorSession.mockResolvedValue(null);
     mockGetUser.mockResolvedValue({ data: { user: null } });
-    const pastExpiry = new Date(Date.now() - 1000).toISOString();
-    mockAdminFrom.mockImplementation((table: string) => {
-      const b = createChainableBuilder(table, supabaseCalls);
-      if (table === "advisor_sessions") {
-        b.single = vi.fn(() =>
-          Promise.resolve({
-            data: { professional_id: 88, expires_at: pastExpiry },
-            error: null,
-          }),
-        );
-      }
-      return b;
-    });
 
     const res = await PATCH(makePatch({ bio: "x" }, "stale-cookie"));
     expect(res.status).toBe(401);

--- a/__tests__/api/advisor-auth-tier-upgrade.test.ts
+++ b/__tests__/api/advisor-auth-tier-upgrade.test.ts
@@ -14,6 +14,16 @@ const mockEnqueueJob = vi.fn((..._args: unknown[]) => Promise.resolve());
 const mockCheckoutCreate = vi.fn();
 const supabaseCalls: Record<string, { method: string; args: unknown[] }[]> = {};
 
+// vi.hoisted() — vi.mock factories are hoisted; the captured fn must be too.
+// Post-C-02 the route delegates auth to requireAdvisorSession (helper).
+const { mockRequireAdvisorSession } = vi.hoisted(() => ({
+  mockRequireAdvisorSession: vi.fn(),
+}));
+
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: mockRequireAdvisorSession,
+}));
+
 vi.mock("next/headers", () => ({
   cookies: vi.fn(async () => ({ get: mockCookieStoreGet })),
 }));
@@ -62,25 +72,20 @@ function withCookieAndSession(
   expiresAt = new Date(Date.now() + 86400 * 1000).toISOString(),
   hasCookie = true,
 ) {
+  // Post-C-02: helper handles cookie + expiry + lookup. The cookie store
+  // mock is kept for parity with old setup but unused by the route now.
   if (hasCookie) {
     mockCookieStoreGet.mockReturnValue({ value: "session-token" });
   } else {
     mockCookieStoreGet.mockReturnValue(undefined);
   }
-  mockServerFrom.mockImplementation((table: string) => {
-    const b = createChainableBuilder(table, supabaseCalls);
-    if (table === "advisor_sessions") {
-      b.maybeSingle = vi.fn(() =>
-        Promise.resolve({
-          data: professionalId
-            ? { professional_id: professionalId, expires_at: expiresAt }
-            : null,
-          error: null,
-        }),
-      );
-    }
-    return b;
-  });
+  // Helper returns advisorId on a valid live session, null otherwise.
+  const isExpired = new Date(expiresAt) < new Date();
+  if (!hasCookie || !professionalId || isExpired) {
+    mockRequireAdvisorSession.mockResolvedValue(null);
+  } else {
+    mockRequireAdvisorSession.mockResolvedValue(professionalId);
+  }
 }
 
 function withAdvisorTier(currentTier: string) {
@@ -122,6 +127,8 @@ describe("POST /api/advisor-auth/tier-upgrade", () => {
     mockAdminFrom.mockImplementation((table: string) =>
       createChainableBuilder(table, supabaseCalls),
     );
+    // Default: not authenticated. withCookieAndSession() flips this.
+    mockRequireAdvisorSession.mockResolvedValue(null);
     mockCheckoutCreate.mockResolvedValue({
       id: "cs_tier_001",
       url: "https://checkout.stripe.com/c/cs_tier_001",
@@ -135,13 +142,16 @@ describe("POST /api/advisor-auth/tier-upgrade", () => {
   });
 
   it("returns 401 when session is expired", async () => {
+    // Post-C-02: helper handles cookie expiry and returns null. Route emits
+    // a single "Not authenticated" error (the previous "Session expired"
+    // string lived in the inlined session-expiry branch in the route).
     withCookieAndSession(
       42,
       new Date(Date.now() - 86400 * 1000).toISOString(),
     );
     const res = await POST(makePost({ target_tier: "growth" }));
     expect(res.status).toBe(401);
-    expect((await res.json()).error).toBe("Session expired");
+    expect((await res.json()).error).toBe("Not authenticated");
   });
 
   it("returns 401 when session lookup returns null", async () => {

--- a/__tests__/lib/require-advisor-session.test.ts
+++ b/__tests__/lib/require-advisor-session.test.ts
@@ -4,9 +4,14 @@ import type { NextRequest } from "next/server";
 
 // ── module mocks ──────────────────────────────────────────────────────────────
 
-const mockGetUser = vi.fn();
-const mockMaybeSingle = vi.fn();
-const mockSingle = vi.fn();
+// vi.hoisted() — vi.mock() is hoisted to the top of the file by Vitest, so
+// these mock fns must be hoisted too or the factory below will hit a TDZ
+// ReferenceError when it dereferences them.
+const { mockGetUser, mockMaybeSingle, mockSingle } = vi.hoisted(() => ({
+  mockGetUser: vi.fn(),
+  mockMaybeSingle: vi.fn(),
+  mockSingle: vi.fn(),
+}));
 
 vi.mock("@/lib/supabase/server", () => ({
   createClient: vi.fn().mockResolvedValue({


### PR DESCRIPTION
## ⚠️ Hot-fix — main CI is red

PR #327 (C-02 advisor-auth helper) merged ~3h ago. Routes work in prod, but the test mocks weren't updated for the new auth path → ~100 cascading test failures across 14 files. **Main CI has been red since.** All open PRs (mine + the cloud loop's) are inheriting the failure.

This PR is test-only. **No app code, no route handlers, no helper changes.**

## What changed
1. \`__tests__/lib/require-advisor-session.test.ts\` — wrap mock vars in \`vi.hoisted()\` so the hoisted \`vi.mock\` factories can reference them. (\`Cannot access mockSingle before initialization\` → fixed.)
2. **10 advisor-auth-\* test files** — add top-level \`vi.mock("@/lib/require-advisor-session")\` with \`vi.hoisted\`, control return value per test.
3. **3 assertion updates** for legitimate route-behaviour changes from #327:
   - \`firm/invite\` + \`firm/member\`: 401+403 folded into 403
   - \`tier-upgrade\`: error string changed
   - \`payment\`: route now session-scoped (2 obsolete body-validation tests dropped)

## Skipped (already green): \`advisor-auth-notifications\`, \`request-review\`, \`topup\`, \`verify-review\`.

## Test plan
- [x] All 11 modified files: 114/114 passing
- [x] All 15 advisor-auth-* files together: 156/156 passing
- [x] Helper test alone: 7/7 passing
- [ ] CI green

## Unblocks
PRs #347, #348 (DRAFT), #349, #359, #360, #361, #366, #367, #368, #369, #377 — all currently failing on the same job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)