### PR TITLE
fix(home): UX polish — Get matched naming, Post a request rename, copy

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -191,10 +191,10 @@ export default async function HomePage() {
               },
               {
                 "@type": "Question",
-                name: "What is the 60-second pathfinder?",
+                name: "What does Get matched do?",
                 acceptedAnswer: {
                   "@type": "Answer",
-                  text: `A short prompt-based tool at ${SITE_URL}/quiz that routes you to the right next step — comparison, listing, expert directory or matched enquiry — based on your situation. No email needed.`,
+                  text: `Get matched is a short prompt-based flow at ${SITE_URL}/quiz that routes you to the right next step — comparison, listing, expert directory or matched enquiry — based on your situation. No email needed.`,
                 },
               },
             ],

--- a/components/HomeAdvisorsTeaser.tsx
+++ b/components/HomeAdvisorsTeaser.tsx
@@ -75,16 +75,15 @@ export default function HomeAdvisorsTeaser({ advisors, totalCount }: HomeAdvisor
           >
             Find the right expert before you commit.
           </h2>
-          <p style={{ fontSize: 13, color: "var(--color-ink-500)", margin: "6px 0 0", maxWidth: 560, lineHeight: 1.5 }}>
-            Browse specialists by what they help with, where they operate and how they can support
-            your next decision.
+          <p style={{ fontSize: 13, color: "var(--color-ink-500)", margin: "6px 0 0", maxWidth: 620, lineHeight: 1.5 }}>
+            Browse experts yourself, or get matched if you&apos;re not sure who you need.
           </p>
         </div>
         <div style={{ display: "flex", gap: 8 }}>
           <Link href="/advisors" className="iv2-cta-ghost" style={{ fontSize: 12.5 }}>
             Browse all {totalCount.toLocaleString("en-AU")}
           </Link>
-          <Link href="/quotes/post" className="iv2-cta" style={{ fontSize: 12.5 }}>
+          <Link href="/quiz" className="iv2-cta" style={{ fontSize: 12.5 }}>
             Get matched
           </Link>
         </div>

--- a/components/HomeCompareDeepDive.tsx
+++ b/components/HomeCompareDeepDive.tsx
@@ -94,8 +94,9 @@ export default function HomeCompareDeepDive({ brokers }: HomeCompareDeepDiveProp
             >
               Key platform fees, features and trade-offs in one place.
             </h2>
-            <p style={{ fontSize: 13, color: "var(--color-ink-500)", margin: "6px 0 0", maxWidth: 560, lineHeight: 1.5 }}>
-              A homepage preview &mdash; jump into a category for the full comparison.
+            <p style={{ fontSize: 13, color: "var(--color-ink-500)", margin: "6px 0 0", maxWidth: 620, lineHeight: 1.5 }}>
+              Start with a simple preview, then open the full comparison when you want to filter by
+              fees, features, account type or provider.
             </p>
           </div>
           <Link href="/compare" className="iv2-cta" style={{ fontSize: 12.5 }}>
@@ -257,7 +258,7 @@ export default function HomeCompareDeepDive({ brokers }: HomeCompareDeepDiveProp
           </div>
           <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
             <Link href="/quiz" className="iv2-cta" style={{ fontSize: 12.5 }}>
-              60-second quiz <DesignIcon name="arrow-right" size={11} />
+              Get matched in 60s <DesignIcon name="arrow-right" size={11} />
             </Link>
             <Link
               href="/compare"

--- a/components/HomeHero.tsx
+++ b/components/HomeHero.tsx
@@ -95,7 +95,7 @@ export default function HomeHero() {
           }}
         >
           <Link
-            href="#routes"
+            href="/quiz"
             className="iv2-cta"
             style={{
               fontSize: 16,
@@ -107,10 +107,10 @@ export default function HomeHero() {
               boxShadow: "0 8px 24px rgba(242,88,34,.32)",
             }}
           >
-            Choose a route <DesignIcon name="arrow-right" size={16} strokeWidth={2.6} />
+            Get matched in 60 seconds <DesignIcon name="arrow-right" size={16} strokeWidth={2.6} />
           </Link>
           <Link
-            href="/quiz"
+            href="#routes"
             style={{
               fontSize: 14,
               fontWeight: 700,
@@ -125,7 +125,7 @@ export default function HomeHero() {
               gap: 8,
             }}
           >
-            Use the 60-second pathfinder <DesignIcon name="arrow-right" size={14} strokeWidth={2.4} />
+            Browse manually <DesignIcon name="arrow-right" size={14} strokeWidth={2.4} />
           </Link>
         </div>
 

--- a/components/HomeListingsTeaser.tsx
+++ b/components/HomeListingsTeaser.tsx
@@ -66,9 +66,9 @@ export default function HomeListingsTeaser({ listings, totalCount }: HomeListing
             >
               Australian investment opportunities, shown clearly.
             </h2>
-            <p style={{ fontSize: 13, color: "var(--color-ink-500)", margin: "6px 0 0", maxWidth: 560, lineHeight: 1.5 }}>
-              Listings are not recommendations. Always perform due diligence and seek professional
-              advice where required.
+            <p style={{ fontSize: 13, color: "var(--color-ink-500)", margin: "6px 0 0", maxWidth: 620, lineHeight: 1.5 }}>
+              Browse selected property, business and private-market opportunities with clear
+              location, category and next-step details.
             </p>
           </div>
           <Link href="/invest" className="iv2-cta-ghost" style={{ fontSize: 12.5 }}>

--- a/components/HomePathfinder.tsx
+++ b/components/HomePathfinder.tsx
@@ -23,7 +23,7 @@ export default function HomePathfinder() {
       >
         <div>
           <span className="iv2-mini" style={{ color: "var(--color-coral-600)" }}>
-            ● 60-second pathfinder
+            ● Get matched · 60-second flow
           </span>
           <h2
             className="font-display"
@@ -37,7 +37,7 @@ export default function HomePathfinder() {
               textWrap: "balance",
             }}
           >
-            Use the 60-second pathfinder.
+            Not sure where to start? Get matched.
           </h2>
           <p
             style={{
@@ -48,8 +48,8 @@ export default function HomePathfinder() {
               maxWidth: 540,
             }}
           >
-            Answer a few prompts and get routed to the right next step: comparison, expert,
-            listing, matched enquiry or learning guide.
+            Answer a few prompts and we&apos;ll route you to the right next step: comparison,
+            expert, listing or matched enquiry. (Pathfinder, internally.)
           </p>
           <ul
             style={{
@@ -81,7 +81,7 @@ export default function HomePathfinder() {
             className="iv2-cta"
             style={{ fontSize: 14, padding: "12px 22px", borderRadius: 11 }}
           >
-            Start the pathfinder <DesignIcon name="arrow-right" size={13} strokeWidth={2.6} />
+            Get matched in 60 seconds <DesignIcon name="arrow-right" size={13} strokeWidth={2.6} />
           </Link>
         </div>
 

--- a/components/HomePostAJob.tsx
+++ b/components/HomePostAJob.tsx
@@ -23,7 +23,7 @@ export default function HomePostAJob() {
         >
           <div>
             <span className="iv2-mini" style={{ color: "var(--color-coral-600)" }}>
-              ● Get matched · free
+              ● Post a request · free
             </span>
             <h2
               className="font-display"
@@ -36,7 +36,7 @@ export default function HomePostAJob() {
                 textWrap: "balance",
               }}
             >
-              Tell us what you need.
+              Post a request.
             </h2>
             <p
               style={{
@@ -47,8 +47,8 @@ export default function HomePostAJob() {
                 maxWidth: 560,
               }}
             >
-              Describe your situation once and we&apos;ll route you towards relevant specialists,
-              comparisons, listings or next steps. Most matched enquiries hear back within a day.
+              Describe what you need and have specialists come to you with proposals — like
+              Airtasker for investing decisions. Most requests hear back within a day.
             </p>
 
             <div style={{ display: "flex", gap: 10, marginTop: 22, flexWrap: "wrap", alignItems: "center" }}>
@@ -57,14 +57,14 @@ export default function HomePostAJob() {
                 className="iv2-cta"
                 style={{ fontSize: 14, padding: "12px 22px" }}
               >
-                Get matched <DesignIcon name="arrow-right" size={13} strokeWidth={2.4} />
+                Post a request <DesignIcon name="arrow-right" size={13} strokeWidth={2.4} />
               </Link>
               <Link
                 href="/quotes/recent-wins"
                 className="iv2-cta-ghost"
                 style={{ fontSize: 13 }}
               >
-                See recent matches
+                See recent requests
               </Link>
             </div>
           </div>
@@ -81,9 +81,9 @@ export default function HomePostAJob() {
           >
             {(
               [
-                ["1", "Describe your need", "60 seconds. No email until you're ready to send."],
-                ["2", "We route you", "To relevant specialists, comparisons or listings — whatever fits."],
-                ["3", "Compare options", "You pick. Introductions only — we don't decide for you."],
+                ["1", "Describe your need", "A short brief. No email until you're ready to send."],
+                ["2", "Specialists respond", "Relevant pros come to you with quotes or proposals."],
+                ["3", "You pick", "Compare responses on your terms. Introductions only."],
               ] as const
             ).map(([n, title, sub]) => (
               <li

--- a/components/HomeRouteCards.tsx
+++ b/components/HomeRouteCards.tsx
@@ -30,7 +30,7 @@ export default function HomeRouteCards({
   }> = [
     {
       title: "Compare platforms",
-      copy: "Choose brokers, investing apps, super options, crypto platforms and savings tools by key fees, features and trade-offs.",
+      copy: "Brokers, super, crypto and savings — sorted by key fees and features.",
       cta: "Compare platforms",
       href: "/compare",
       micro: "Lowest-friction starting point",
@@ -40,7 +40,7 @@ export default function HomeRouteCards({
     },
     {
       title: "Browse opportunities",
-      copy: "Explore Australian property, businesses, farmland, resources, private credit and selected investment listings.",
+      copy: "Property, businesses, farmland and private-market listings, shown clearly.",
       cta: "Browse listings",
       href: "/invest",
       micro: "Marketplace route",
@@ -50,7 +50,7 @@ export default function HomeRouteCards({
     },
     {
       title: "Find an expert",
-      copy: "Compare specialists across property, lending, financial advice, tax, SMSF and cross-border investment support.",
+      copy: "Property, lending, advice, tax, SMSF and cross-border specialists.",
       cta: "Find an expert",
       href: "/advisors",
       micro: "Human help route",
@@ -60,11 +60,11 @@ export default function HomeRouteCards({
     },
     {
       title: "Get matched",
-      copy: "Tell us what you need and we'll route you towards relevant specialists, comparisons, listings or next steps.",
-      cta: "Get matched",
-      href: "/quotes/post",
+      copy: "Answer a few prompts. We route you to the right next step.",
+      cta: "Get matched in 60s",
+      href: "/quiz",
       micro: "Best if you're unsure",
-      badge: "Free · 24h",
+      badge: "60-sec flow · free",
       icon: "compass",
       accent: "#059669",
       featured: true,

--- a/components/MobileBottomNav.tsx
+++ b/components/MobileBottomNav.tsx
@@ -5,10 +5,9 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 
 // Sticky mobile bottom navigation — four tabs that mirror the homepage
-// route cards: Compare / Listings / Experts / Pathfinder. Replaces the
-// previous single-CTA MobileStickyAdvisorCta. Per v5 spec we don't
-// overload mobile with long menus — these four cover the dominant retail
-// intents.
+// route cards: Compare / Listings / Experts / Get matched. The fourth
+// tab points at /quiz (the guided matching flow); "Pathfinder" stays as
+// internal/explanatory language only.
 const TABS: ReadonlyArray<{ label: string; href: string; icon: React.ReactNode; matchPrefix: string }> = [
   {
     label: "Compare",
@@ -46,7 +45,7 @@ const TABS: ReadonlyArray<{ label: string; href: string; icon: React.ReactNode; 
     ),
   },
   {
-    label: "Pathfinder",
+    label: "Get matched",
     href: "/quiz",
     matchPrefix: "/quiz",
     icon: (
@@ -66,8 +65,8 @@ export default function MobileBottomNav() {
 
   // Avoid SSR/CSR mismatch: don't render the bar until after hydration so
   // pathname-based "active tab" highlighting reflects the real route.
-  // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional initial mount-only state set
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional initial mount-only state set
     setMounted(true);
   }, []);
 

--- a/components/layout/Navigation.tsx
+++ b/components/layout/Navigation.tsx
@@ -42,7 +42,7 @@ const platformsMenu = {
     { label: "Compare All Platforms", href: "/compare" },
     { label: "Broker vs Broker", href: "/versus" },
     { label: "Current Deals", href: "/deals" },
-    ...(SHOW_MATCH_LANGUAGE ? [{ label: "Platform Quiz (60s)", href: "/quiz" }] : []),
+    ...(SHOW_MATCH_LANGUAGE ? [{ label: "Get matched (60s)", href: "/quiz" }] : []),
     { label: "Fee Calculator", href: "/calculators" },
   ],
 };
@@ -727,7 +727,7 @@ export function Navigation() {
             </button>
             <AccountButton />
             <Link
-              href="/quotes/post"
+              href="/quiz"
               className="bg-amber-500 hover:bg-amber-600 active:bg-amber-700 text-slate-900 px-4 py-2.5 rounded-xl font-bold text-sm transition-all shadow-sm hover:shadow-md active:scale-[0.97] inline-flex items-center gap-2 cursor-pointer"
             >
               Get matched
@@ -749,7 +749,7 @@ export function Navigation() {
               </svg>
             </button>
             <Link
-              href="/quotes/post"
+              href="/quiz"
               className="bg-amber-500 text-slate-900 px-4 py-2 rounded-lg text-xs font-bold transition-all hover:bg-amber-600 min-h-11 inline-flex items-center cursor-pointer"
             >
               Get matched


### PR DESCRIPTION
## Summary

Aligns the homepage on a single canonical naming model:

- **"Get matched"** = the public-facing name for the guided quiz/matching flow (`/quiz`). Header CTA, hero primary CTA, route card #4, advisors teaser, compare section, mobile bottom nav, FAQ JSON-LD all point here.
- **"Post a request"** = the Airtasker-style request flow (`/quotes/post`). HomePostAJob renamed from "Tell us what you need" + "Get matched" CTA to "Post a request" headline + CTA. The two flows no longer share a label.
- **"Pathfinder"** demoted to internal/explanatory language only — section retitled "Not sure where to start? Get matched."; mobile nav 4th tab relabelled "Get matched"; header tools menu entry relabelled "Get matched (60s)".
- **Hero secondary CTA** changed from "Use the 60-second pathfinder" to "Browse manually" (anchor → #routes).
- **Visible "Quiz" wording** removed from compare section ("60-second quiz" → "Get matched in 60s") and FAQ JSON-LD.

Section copy:

- **Compare**: "Start with a simple preview, then open the full comparison when you want to filter by fees, features, account type or provider."
- **Listings**: "Browse selected property, business and private-market opportunities with clear location, category and next-step details."
- **Experts bridge line**: "Browse experts yourself, or get matched if you're not sure who you need."
- **Route cards**: copy shortened across all four for mobile scanning.

## What's preserved
- Hero headline ("Australia's front door for investment decisions.")
- Four routes (Compare, Browse, Find expert, Get matched)
- Compare above Listings ordering
- Listings premium visual treatment
- Search bar + Popular starting points
- All routes, data flows, matching logic, listings, expert cards, comparison data

## Test plan
- [x] Standalone `npm run type-check` clean
- [x] Selective ESLint clean on changed files
- [x] Local Next.js compile succeeded (26.8min on this sandbox; CI build will validate)
- [ ] Vercel preview: hero shows new CTAs, route card 4 says "Get matched in 60s" + links to /quiz, mobile sticky nav 4th tab says "Get matched"
- [ ] Post-a-request section shows "Post a request" headline + CTA (not "Get matched")

Pre-push hook bypassed with `--no-verify` because tsc kept hanging in the husky subprocess context on this sandbox; standalone tsc + the file-level lint pass are clean. CLAUDE.md documents this as the supported bypass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)