### PR TITLE
feat(home): v6 — reviewer-led naming + visual route cards

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,8 +2,6 @@ import { createClient } from "@/lib/supabase/server";
 import type { Broker } from "@/lib/types";
 import HomeHero from "@/components/HomeHero";
 import HomeRouteCards from "@/components/HomeRouteCards";
-import HomeSearchBar from "@/components/HomeSearchBar";
-import HomePopularStarts from "@/components/HomePopularStarts";
 import HomePathfinder from "@/components/HomePathfinder";
 import HomeListingsTeaser, { type HomeListing } from "@/components/HomeListingsTeaser";
 import HomeAdvisorsTeaser, { type HomeAdvisor } from "@/components/HomeAdvisorsTeaser";
@@ -19,24 +17,24 @@ import { ORGANIZATION_JSONLD, SITE_URL } from "@/lib/seo";
 export const metadata = {
   title: {
     absolute:
-      "Compare Platforms, Browse Opportunities, Find Experts — Invest.com.au",
+      "Compare Platforms, Browse Listings, Find Experts — Invest.com.au",
   },
   description:
-    "Australia's front door for investment decisions. Compare platforms, browse opportunities, find experts or get matched to the right next step. Independent. ASIC-registered. General information only.",
+    "One place to compare platforms, browse investment listings, find experts, or get matched to the right next step. Independent. ASIC-registered. General information only.",
   openGraph: {
     title:
-      "Compare Platforms, Browse Opportunities, Find Experts — Invest.com.au",
+      "Compare Platforms, Browse Listings, Find Experts — Invest.com.au",
     description:
-      "Australia's front door for investment decisions. Compare, browse, find or get matched.",
+      "Compare platforms, browse listings, find experts, or get matched in 60 seconds.",
     url: "/",
     images: [{ url: "/api/og", width: 1200, height: 630 }],
   },
   twitter: {
     card: "summary_large_image" as const,
     title:
-      "Compare Platforms, Browse Opportunities, Find Experts — Invest.com.au",
+      "Compare Platforms, Browse Listings, Find Experts — Invest.com.au",
     description:
-      "Australia's front door for investment decisions. Compare, browse, find or get matched.",
+      "Compare platforms, browse listings, find experts, or get matched in 60 seconds.",
   },
   alternates: { canonical: "/" },
 };
@@ -154,7 +152,7 @@ export default async function HomePage() {
             "@context": "https://schema.org",
             ...ORGANIZATION_JSONLD,
             description:
-              "Australia's front door for investment decisions. Compare platforms, browse opportunities, find experts or get matched. Independent. ASIC-registered. General information only.",
+              "One place to compare platforms, browse investment listings, find experts, or get matched to the right next step. Independent. ASIC-registered. General information only.",
           }),
         }}
       />
@@ -212,11 +210,9 @@ export default async function HomePage() {
         />
       </ScrollFadeIn>
 
-      <HomeSearchBar />
-
-      <HomePopularStarts />
-
-      <HomePathfinder />
+      <ScrollFadeIn>
+        <HomePathfinder />
+      </ScrollFadeIn>
 
       <ScrollFadeIn>
         <HomeCompareDeepDive brokers={compareBrokers} />

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -563,7 +563,7 @@ export default function Header() {
               href="/quiz"
               className="bg-amber-500 hover:bg-amber-600 text-white px-5 py-2.5 rounded-lg font-bold transition-all shadow-sm hover:shadow-md flex items-center gap-2 text-sm"
             >
-              Start Free Match
+              Get matched
               <Icon name="arrow-right" size={16} />
             </Link>
           </div>
@@ -623,22 +623,22 @@ export default function Header() {
                 onClick={() => setMenuOpen(false)}
                 className="block w-full py-3 min-h-11 text-center text-sm font-extrabold text-white bg-amber-500 rounded-xl hover:bg-amber-600 transition-colors"
               >
-                Start Free Match
+                Get matched
               </Link>
               <div className="flex gap-2">
                 <Link
-                  href="/find-advisor"
+                  href="/advisors"
                   onClick={() => setMenuOpen(false)}
                   className="flex-1 py-2.5 min-h-11 flex items-center justify-center text-xs font-bold text-center text-slate-700 bg-slate-50 border border-slate-200 rounded-lg hover:bg-slate-100 transition-colors"
                 >
-                  Find Advisor
+                  Find an expert
                 </Link>
                 <Link
                   href="/compare"
                   onClick={() => setMenuOpen(false)}
                   className="flex-1 py-2.5 min-h-11 flex items-center justify-center text-xs font-bold text-center text-slate-700 bg-slate-50 border border-slate-200 rounded-lg hover:bg-slate-100 transition-colors"
                 >
-                  Compare Platforms
+                  Compare platforms
                 </Link>
               </div>
             </div>

--- a/components/HomeHero.tsx
+++ b/components/HomeHero.tsx
@@ -81,8 +81,8 @@ export default function HomeHero() {
             margin: "20px 0 0",
           }}
         >
-          Compare platforms, browse opportunities, find experts or get matched to the right next
-          step &mdash; without getting lost in financial jargon.
+          One place to compare platforms, browse investment listings, find experts, or get matched
+          to the right next step &mdash; without the financial jargon.
         </p>
 
         <div

--- a/components/HomePathfinder.tsx
+++ b/components/HomePathfinder.tsx
@@ -48,8 +48,18 @@ export default function HomePathfinder() {
               maxWidth: 540,
             }}
           >
-            Answer a few prompts and we&apos;ll route you to the right next step: comparison,
-            expert, listing or matched enquiry. (Pathfinder, internally.)
+            Answer a few quick questions and we&apos;ll show the best next step &mdash; compare
+            platforms, browse listings, find an expert, or post a request.
+          </p>
+          <p
+            style={{
+              fontSize: 12.5,
+              color: "var(--color-ink-500)",
+              fontStyle: "italic",
+              margin: "10px 0 0",
+            }}
+          >
+            Best if you&apos;re not sure where to start.
           </p>
           <ul
             style={{

--- a/components/HomePostAJob.tsx
+++ b/components/HomePostAJob.tsx
@@ -47,8 +47,18 @@ export default function HomePostAJob() {
                 maxWidth: 560,
               }}
             >
-              Describe what you need and have specialists come to you with proposals — like
+              Describe what you need and have specialists come to you with proposals &mdash; like
               Airtasker for investing decisions. Most requests hear back within a day.
+            </p>
+            <p
+              style={{
+                fontSize: 13,
+                color: "var(--color-ink-500)",
+                fontStyle: "italic",
+                margin: "10px 0 0",
+              }}
+            >
+              Best if you want specialists to come back with options.
             </p>
 
             <div style={{ display: "flex", gap: 10, marginTop: 22, flexWrap: "wrap", alignItems: "center" }}>

--- a/components/HomeRouteCards.tsx
+++ b/components/HomeRouteCards.tsx
@@ -7,11 +7,6 @@ interface RouteCardsProps {
   professionalCount: number;
 }
 
-// Four route cards — the primary navigational decision below the hero.
-// Replaces the previous v4 HomePillarsGrid. Cards are equal-weight in size
-// and breathing room, but "Get matched" gets a subtle dark-card treatment
-// because per the v5 spec it's the recommended path for users who don't
-// know which other route to pick (the moat product).
 export default function HomeRouteCards({
   brokerCount,
   listingCount,
@@ -19,54 +14,54 @@ export default function HomeRouteCards({
 }: RouteCardsProps) {
   const routes: ReadonlyArray<{
     title: string;
-    copy: string;
     cta: string;
     href: string;
-    micro: string;
-    badge: string;
     icon: string;
     accent: string;
+    examples: string;
+    audience: string;
+    badge: string;
     featured?: boolean;
   }> = [
     {
       title: "Compare platforms",
-      copy: "Brokers, super, crypto and savings — sorted by key fees and features.",
-      cta: "Compare platforms",
+      cta: "Compare",
       href: "/compare",
-      micro: "Lowest-friction starting point",
-      badge: `${brokerCount || 0} platforms`,
       icon: "trending-down",
       accent: "#2563eb",
+      examples: "Brokers · Super · Crypto · Savings",
+      audience: "If you know what you want",
+      badge: `${brokerCount || 0} platforms`,
     },
     {
-      title: "Browse opportunities",
-      copy: "Property, businesses, farmland and private-market listings, shown clearly.",
-      cta: "Browse listings",
+      title: "Browse listings",
+      cta: "Browse",
       href: "/invest",
-      micro: "Marketplace route",
+      icon: "map-pin",
+      accent: "#059669",
+      examples: "Property · Businesses · Farmland · Funds",
+      audience: "If you want real opportunities",
       badge: `${listingCount || 0} listed`,
-      icon: "sparkles",
-      accent: "#d97706",
     },
     {
       title: "Find an expert",
-      copy: "Property, lending, advice, tax, SMSF and cross-border specialists.",
-      cta: "Find an expert",
+      cta: "Find",
       href: "/advisors",
-      micro: "Human help route",
-      badge: `${professionalCount.toLocaleString("en-AU")} verified`,
       icon: "users",
-      accent: "var(--color-coral-500)",
+      accent: "#7c3aed",
+      examples: "Advisers · Mortgage · Tax · SMSF",
+      audience: "If you need a pro",
+      badge: `${professionalCount.toLocaleString("en-AU")} verified`,
     },
     {
       title: "Get matched",
-      copy: "Answer a few prompts. We route you to the right next step.",
-      cta: "Get matched in 60s",
+      cta: "Get matched",
       href: "/quiz",
-      micro: "Best if you're unsure",
-      badge: "60-sec flow · free",
-      icon: "compass",
-      accent: "#059669",
+      icon: "sparkles",
+      accent: "#f25822",
+      examples: "60 seconds · 4 quick questions",
+      audience: "If you're not sure where to start",
+      badge: "Free · no email",
       featured: true,
     },
   ];
@@ -102,101 +97,147 @@ export default function HomeRouteCards({
             href={r.href}
             className="iv2-card-hover"
             style={{
+              position: "relative",
               display: "flex",
               flexDirection: "column",
               background: r.featured ? "var(--color-ink-900)" : "white",
               color: r.featured ? "white" : "var(--color-ink-900)",
               border: r.featured ? `1.5px solid ${r.accent}` : "1px solid #e5e7eb",
-              borderTop: r.featured ? `1.5px solid ${r.accent}` : `4px solid ${r.accent}`,
-              borderRadius: 14,
-              padding: "30px 26px 26px",
+              borderRadius: 16,
+              overflow: "hidden",
               textDecoration: "none",
-              minHeight: 280,
+              minHeight: 320,
               boxShadow: r.featured
-                ? `0 12px 32px color-mix(in oklch, ${r.accent} 22%, transparent)`
+                ? `0 14px 36px color-mix(in oklch, ${r.accent} 28%, transparent)`
                 : "0 1px 2px rgba(11,20,34,.04)",
+              transform: r.featured ? "translateY(-4px)" : undefined,
             }}
           >
+            {r.featured && (
+              <span
+                aria-hidden
+                style={{
+                  position: "absolute",
+                  top: 12,
+                  right: 12,
+                  zIndex: 2,
+                  fontSize: 10.5,
+                  fontWeight: 800,
+                  textTransform: "uppercase",
+                  letterSpacing: ".06em",
+                  background: "white",
+                  color: r.accent,
+                  padding: "4px 10px",
+                  borderRadius: 99,
+                  boxShadow: "0 2px 6px rgba(0,0,0,.18)",
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: 4,
+                }}
+              >
+                <DesignIcon name="star" size={11} strokeWidth={2.4} fill="currentColor" /> Start here
+              </span>
+            )}
+
             <div
               aria-hidden
               style={{
-                width: 64,
-                height: 64,
-                borderRadius: 16,
+                height: 88,
                 background: r.featured
-                  ? `color-mix(in oklch, ${r.accent} 22%, transparent)`
-                  : `color-mix(in oklch, ${r.accent} 14%, transparent)`,
+                  ? `linear-gradient(135deg, ${r.accent} 0%, color-mix(in oklch, ${r.accent} 70%, #ec4899) 100%)`
+                  : `color-mix(in oklch, ${r.accent} 12%, white)`,
                 display: "flex",
                 alignItems: "center",
                 justifyContent: "center",
-                color: r.accent,
-                marginBottom: 18,
+                color: r.featured ? "white" : r.accent,
+                borderBottom: r.featured ? "none" : `1px solid color-mix(in oklch, ${r.accent} 18%, transparent)`,
               }}
             >
-              <DesignIcon name={r.icon} size={32} strokeWidth={2.2} />
+              <DesignIcon name={r.icon} size={40} strokeWidth={2.2} />
             </div>
 
-            <div
-              className="font-display"
-              style={{
-                fontSize: 22,
-                fontWeight: 800,
-                lineHeight: 1.1,
-                letterSpacing: "-.022em",
-                marginBottom: 10,
-                color: r.featured ? "white" : "var(--color-ink-900)",
-              }}
-            >
-              {r.title}
-            </div>
-            <div
-              style={{
-                fontSize: 13,
-                color: r.featured ? "rgba(255,255,255,.72)" : "var(--color-ink-500)",
-                lineHeight: 1.5,
-                marginBottom: 16,
-                flex: 1,
-              }}
-            >
-              {r.copy}
-            </div>
-
-            <div style={{ marginBottom: 14 }}>
-              <span
-                className="font-mono"
+            <div style={{ padding: "22px 22px 22px", display: "flex", flexDirection: "column", flex: 1 }}>
+              <div
+                className="font-display"
                 style={{
-                  fontSize: 10.5,
+                  fontSize: 21,
                   fontWeight: 800,
-                  color: r.accent,
-                  textTransform: "uppercase",
-                  letterSpacing: ".06em",
-                  background: `color-mix(in oklch, ${r.accent} ${r.featured ? 18 : 10}%, transparent)`,
-                  border: `1px solid color-mix(in oklch, ${r.accent} 30%, transparent)`,
-                  padding: "3px 8px",
-                  borderRadius: 99,
+                  lineHeight: 1.1,
+                  letterSpacing: "-.022em",
+                  marginBottom: 8,
+                  color: r.featured ? "white" : "var(--color-ink-900)",
                 }}
               >
-                {r.badge}
-              </span>
-            </div>
+                {r.title}
+              </div>
 
-            <div
-              style={{
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "space-between",
-                gap: 8,
-                paddingTop: 12,
-                borderTop: r.featured ? "1px solid rgba(255,255,255,.08)" : "1px solid #f1f5f9",
-              }}
-            >
-              <div>
-                <div style={{ fontSize: 13, fontWeight: 800, color: r.featured ? "white" : r.accent, display: "inline-flex", alignItems: "center", gap: 6 }}>
-                  {r.cta} <DesignIcon name="arrow-right" size={13} strokeWidth={2.6} />
-                </div>
-                <div style={{ fontSize: 10.5, color: r.featured ? "rgba(255,255,255,.5)" : "var(--color-ink-400)", marginTop: 2 }}>
-                  {r.micro}
-                </div>
+              <div
+                className="font-mono"
+                style={{
+                  fontSize: 11.5,
+                  fontWeight: 700,
+                  color: r.featured ? "rgba(255,255,255,.78)" : "var(--color-ink-600)",
+                  letterSpacing: ".01em",
+                  marginBottom: 14,
+                  lineHeight: 1.45,
+                }}
+              >
+                {r.examples}
+              </div>
+
+              <div style={{ marginBottom: 14 }}>
+                <span
+                  className="font-mono"
+                  style={{
+                    fontSize: 10,
+                    fontWeight: 800,
+                    color: r.featured ? "white" : r.accent,
+                    textTransform: "uppercase",
+                    letterSpacing: ".07em",
+                    background: r.featured
+                      ? "rgba(255,255,255,.12)"
+                      : `color-mix(in oklch, ${r.accent} 10%, transparent)`,
+                    border: r.featured
+                      ? "1px solid rgba(255,255,255,.18)"
+                      : `1px solid color-mix(in oklch, ${r.accent} 28%, transparent)`,
+                    padding: "3px 9px",
+                    borderRadius: 99,
+                  }}
+                >
+                  {r.badge}
+                </span>
+              </div>
+
+              <div style={{ flex: 1 }} />
+
+              <div
+                style={{
+                  fontSize: 12,
+                  color: r.featured ? "rgba(255,255,255,.62)" : "var(--color-ink-500)",
+                  marginBottom: 14,
+                  lineHeight: 1.4,
+                  fontStyle: "italic",
+                }}
+              >
+                {r.audience}
+              </div>
+
+              <div
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  gap: 6,
+                  fontSize: 13,
+                  fontWeight: 800,
+                  padding: "10px 14px",
+                  borderRadius: 10,
+                  background: r.featured ? r.accent : "transparent",
+                  color: r.featured ? "white" : r.accent,
+                  border: r.featured ? `1.5px solid ${r.accent}` : `1.5px solid color-mix(in oklch, ${r.accent} 30%, transparent)`,
+                }}
+              >
+                {r.cta} <DesignIcon name="arrow-right" size={13} strokeWidth={2.6} />
               </div>
             </div>
           </Link>


### PR DESCRIPTION
## Summary

Acts on the external homepage UX review (2026-05-01). Two goals:

1. **Naming hygiene** — collapse five overlapping verbs (Quiz / Pathfinder / Find Advisor / Get matched / Post a request) into one canonical mental model.
2. **Make the four route cards scannable in <1s** — Gen-Z brain shortcut: each card pattern-matches via a distinct color block + icon + concrete example list + audience tag.

The friend-feedback that triggered the review (\"too much info, switches off\") is also addressed by dropping two redundant routing surfaces (`HomeSearchBar`, `HomePopularStarts`) that stacked above the cards.

## Canonical vocabulary (now used everywhere user-facing)

| What it does | Name |
|---|---|
| Guided routing flow (the quiz) | **Get matched** |
| Self-serve fee/feature comparison | **Compare platforms** |
| Marketplace of opportunities | **Browse listings** |
| Directory of professionals | **Find an expert** |
| Airtasker-style brief flow | **Post a request** |

## Visual changes

**Route cards (`HomeRouteCards.tsx`):**
- Full-width 88px colored header strip per card with a 40px icon centered
  - Blue · Compare platforms (trending-down icon)
  - Green · Browse listings (map-pin icon)
  - Purple · Find an expert (users icon)
  - Warm gradient · Get matched (sparkles icon, plus a floating ★ Start here badge)
- New \"examples\" row inside each card with concrete dot-separated noun list (\"Brokers · Super · Crypto · Savings\")
- New italic \"audience tag\" at the bottom (\"If you know what you want\", \"If you're not sure where to start\", etc.)
- Get matched card is lifted -4px, uses a filled brand-color CTA button (others use outline) and casts a deeper colored shadow

**Hero (`HomeHero.tsx`):**
- Subhead rewritten to verb list: *\"One place to compare platforms, browse investment listings, find experts, or get matched to the right next step — without the financial jargon.\"*

**Header (`Header.tsx`):**
- Desktop top-right CTA: \"Start Free Match\" → **\"Get matched\"**
- Mobile drawer: \"Start Free Match\" → **\"Get matched\"**, \"Find Advisor\" → **\"Find an expert\"** (now points to `/advisors` rather than the legacy `/find-advisor` page), case-corrected \"Compare platforms\"

**Sub-sections:**
- `HomePathfinder.tsx`: removed user-facing \"(Pathfinder, internally.)\" leak; new copy \"Answer a few quick questions and we'll show the best next step — compare platforms, browse listings, find an expert, or post a request.\" Added italic tag *\"Best if you're not sure where to start.\"*
- `HomePostAJob.tsx`: added italic tag *\"Best if you want specialists to come back with options.\"* so the user sees how it differs from the quiz

## Page order (per reviewer)

1. Hero
2. Four route cards
3. Get matched teaser (HomePathfinder)
4. Compare platforms preview
5. Listings teaser
6. Experts teaser
7. Post a request
8. Cross-border
9. Friday Briefing (newsletter)
10. How we earn (disclosure / methodology)

Removed from homepage in this PR: `HomeSearchBar`, `HomePopularStarts`. Reasoning: they're two additional routing surfaces stacked on top of the four cards, exactly the \"too many decisions above the fold\" problem the friend reaction surfaced. Components still exist; trivial to add back if conversion data argues for them.

## Test plan
- [ ] Verify `/` renders without errors in Vercel preview
- [ ] Confirm \"Get matched\" is the only top-right CTA (no duplicate \"Start Free Match\")
- [ ] Confirm \"Pathfinder\" word does not appear anywhere visible to a logged-out user
- [ ] Spot-check the four cards on desktop, tablet (2×2), and mobile (1×1 stack)
- [ ] Confirm Get matched card shows the ★ Start here badge and uses the gradient header
- [ ] Confirm sticky bottom mobile nav still highlights the active route
- [ ] Confirm metadata description in page source matches new tagline (no \"opportunities\" leak)
- [ ] Run a friend test: cold visitor scans the page in 5s — can they articulate \"what is this site\"?

🤖 Generated with [Claude Code](https://claude.com/claude-code)