### PR TITLE
feat(quiz): bundle results — thread cards above leaderboard

### DIFF
--- a/__tests__/components/ThreadCardsStrip.test.tsx
+++ b/__tests__/components/ThreadCardsStrip.test.tsx
@@ -1,0 +1,140 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "./setup";
+import ThreadCardsStrip, {
+  selectThreadCards,
+  type ThreadAnswers,
+} from "@/app/quiz/_components/ThreadCardsStrip";
+
+describe("selectThreadCards", () => {
+  it("returns zero cards for a minimal non-DIY simple-small profile", () => {
+    const cards = selectThreadCards({
+      goal: "grow",
+      mode: "help", // not diy/unsure
+      complexity: "simple",
+      amount: "small",
+      priority: "fees",
+    });
+    expect(cards).toHaveLength(0);
+  });
+
+  it("includes 'super' card when goal is super", () => {
+    const cards = selectThreadCards({ goal: "super" });
+    expect(cards.some((c) => c.key === "super")).toBe(true);
+  });
+
+  it("includes 'super' card on a high amount even for non-retirement goal", () => {
+    const cards = selectThreadCards({ goal: "grow", amount: "whale" });
+    expect(cards.some((c) => c.key === "super")).toBe(true);
+  });
+
+  it("includes 'savings' card when mode is diy", () => {
+    const cards = selectThreadCards({ mode: "diy" });
+    expect(cards.some((c) => c.key === "savings")).toBe(true);
+  });
+
+  it("includes 'savings' card on meaningful amount even when mode is help", () => {
+    const cards = selectThreadCards({ mode: "help", amount: "medium" });
+    expect(cards.some((c) => c.key === "savings")).toBe(true);
+  });
+
+  it("includes 'tax' card when complexity is complex", () => {
+    const cards = selectThreadCards({ complexity: "complex" });
+    const tax = cards.find((c) => c.key === "tax");
+    expect(tax).toBeDefined();
+    expect(tax?.heading).toBe("Get tax help");
+    expect(tax?.href).toBe("/advisors/tax-agents");
+  });
+
+  it("re-frames 'tax' card as SMSF help when goal is super", () => {
+    const cards = selectThreadCards({ goal: "super" });
+    const tax = cards.find((c) => c.key === "tax");
+    expect(tax).toBeDefined();
+    expect(tax?.heading).toBe("Get SMSF help");
+    expect(tax?.href).toBe("/advisors/smsf-accountants");
+  });
+
+  it("includes 'advisor' card when mode is unsure", () => {
+    const cards = selectThreadCards({ mode: "unsure" });
+    expect(cards.some((c) => c.key === "advisor")).toBe(true);
+  });
+
+  it("does not include 'advisor' card when mode is diy", () => {
+    const cards = selectThreadCards({ mode: "diy", goal: "grow" });
+    expect(cards.some((c) => c.key === "advisor")).toBe(false);
+  });
+
+  it("caps the strip at 4 cards", () => {
+    // Pile on every condition we can simultaneously
+    const cards = selectThreadCards({
+      goal: "super", // super + tax(SMSF)
+      mode: "unsure", // advisor
+      complexity: "complex", // tax (already added)
+      amount: "whale", // super (already added)
+      priority: "safety", // super (already added)
+    });
+    expect(cards.length).toBeLessThanOrEqual(4);
+  });
+
+  it("never includes a 'broker' card (delegated to leaderboard below)", () => {
+    const cards = selectThreadCards({
+      goal: "super",
+      mode: "diy",
+      complexity: "complex",
+      amount: "whale",
+    });
+    expect(cards.some((c) => c.key === "broker")).toBe(false);
+  });
+});
+
+describe("ThreadCardsStrip", () => {
+  it("renders nothing when no cards qualify", () => {
+    const answers: ThreadAnswers = {
+      goal: "grow",
+      mode: "help",
+      complexity: "simple",
+      amount: "small",
+      priority: "fees",
+    };
+    const { container } = render(<ThreadCardsStrip answers={answers} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the section heading and at least one card when conditions match", () => {
+    render(<ThreadCardsStrip answers={{ goal: "super" }} />);
+    expect(screen.getByText("Your investing stack")).toBeInTheDocument();
+    expect(
+      screen.getByText("A great setup is more than just a broker"),
+    ).toBeInTheDocument();
+    // Super card should be present
+    expect(screen.getByText("Sort your super")).toBeInTheDocument();
+  });
+
+  it("renders SMSF copy variant for goal=super", () => {
+    render(<ThreadCardsStrip answers={{ goal: "super" }} />);
+    expect(screen.getByText("Get SMSF help")).toBeInTheDocument();
+  });
+
+  it("renders tax copy variant when complexity is complex", () => {
+    render(<ThreadCardsStrip answers={{ complexity: "complex" }} />);
+    expect(screen.getByText("Get tax help")).toBeInTheDocument();
+  });
+
+  it("renders the advisor card for mode=unsure", () => {
+    render(<ThreadCardsStrip answers={{ mode: "unsure" }} />);
+    expect(screen.getByText("Talk to an advisor")).toBeInTheDocument();
+  });
+
+  it("links each card to the expected route", () => {
+    render(
+      <ThreadCardsStrip
+        answers={{ mode: "diy", complexity: "complex", goal: "crypto" }}
+      />,
+    );
+    // savings
+    const savings = screen.getByText("See savings rates").closest("a");
+    expect(savings).toHaveAttribute("href", "/savings");
+    // tax (non-SMSF variant since goal=crypto)
+    const tax = screen.getByText("Find an accountant").closest("a");
+    expect(tax).toHaveAttribute("href", "/advisors/tax-agents");
+  });
+});

--- a/app/quiz/_components/QuizResultsScreen.tsx
+++ b/app/quiz/_components/QuizResultsScreen.tsx
@@ -12,6 +12,7 @@ import QuizTopMatch from "./QuizTopMatch";
 import QuizComparisonTable from "./QuizComparisonTable";
 import QuizRunnerUps from "./QuizRunnerUps";
 import QuizResultsFooter from "./QuizResultsFooter";
+import ThreadCardsStrip, { type ThreadAnswers } from "./ThreadCardsStrip";
 
 interface ScoredResult {
   slug: string;
@@ -22,6 +23,7 @@ interface ScoredResult {
 interface Props {
   results: ScoredResult[];
   answers: string[];
+  unifiedAnswers: ThreadAnswers;
   hasCryptoResult: boolean;
   emailGate: boolean;
   gateEmail: string;
@@ -41,6 +43,7 @@ interface Props {
 export default function QuizResultsScreen({
   results,
   answers,
+  unifiedAnswers,
   hasCryptoResult,
   emailGate,
   gateEmail,
@@ -96,6 +99,7 @@ export default function QuizResultsScreen({
           {/* Confetti burst + emoji */}
           <div className="relative h-14 md:h-20 mb-1 md:mb-2" aria-hidden="true">
             <div className="confetti-container confetti-active">
+              {/* eslint-disable react-hooks/purity -- decorative confetti, deliberate randomness on each render */}
               {Array.from({ length: 24 }).map((_, i) => (
                 <span key={i} className="confetti-particle" style={{
                   '--confetti-x': `${-60 + Math.random() * 120}px`,
@@ -106,6 +110,7 @@ export default function QuizResultsScreen({
                   left: `${8 + (i / 24) * 84}%`,
                 } as React.CSSProperties} />
               ))}
+              {/* eslint-enable react-hooks/purity */}
             </div>
             <div className="absolute inset-0 flex items-center justify-center">
               <Icon name="trophy" size={36} className="celebrate-emoji text-amber-500 md:hidden" />
@@ -164,6 +169,11 @@ export default function QuizResultsScreen({
             </div>
           </>
         )}
+
+        {/* Your investing stack — multi-thread bundle cards conditional on quiz answers.
+            Renders above the leaderboard so users see investing as broker + super + savings + tax,
+            not just "pick a broker". Returns null when no thread matches the user's answers. */}
+        <ThreadCardsStrip answers={unifiedAnswers} />
 
         {/* Top Match */}
         {topMatch?.broker && (

--- a/app/quiz/_components/ThreadCardsStrip.tsx
+++ b/app/quiz/_components/ThreadCardsStrip.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import Link from "next/link";
+import Icon from "@/components/Icon";
+import { trackEvent } from "@/lib/tracking";
+
+/**
+ * Subset of UnifiedAnswers from app/quiz/page.tsx that drives thread visibility.
+ * Kept narrow on purpose — anything else is irrelevant to bundle suggestions.
+ */
+export interface ThreadAnswers {
+  goal?: string;
+  mode?: string;
+  complexity?: string;
+  amount?: string;
+  priority?: string;
+}
+
+interface ThreadCard {
+  key: string;
+  iconName: string;
+  heading: string;
+  copy: string;
+  ctaLabel: string;
+  href: string;
+}
+
+/**
+ * Decide which thread cards to surface for a quiz-taker on the DIY results screen.
+ *
+ * Rules (kept conservative — 2 to 4 cards max so the strip never feels noisy):
+ *  • Sort your super — goal=='super' OR priority=='safety' OR amount in {large, whale}
+ *  • Park your cash buffer — mode=='diy' OR amount in {medium, large, whale}
+ *  • Get tax help — complexity=='complex' OR goal in {super, crypto, property}
+ *  • Talk to an advisor — mode=='unsure' (DIY users still on the fence)
+ *
+ * "Pick your broker" is intentionally omitted — the leaderboard rendered immediately
+ * below this strip already does that job.
+ */
+export function selectThreadCards(answers: ThreadAnswers): ThreadCard[] {
+  const cards: ThreadCard[] = [];
+
+  const isHighAmount = answers.amount === "large" || answers.amount === "whale";
+  const isMeaningfulAmount = answers.amount === "medium" || isHighAmount;
+
+  // Sort your super
+  if (answers.goal === "super" || answers.priority === "safety" || isHighAmount) {
+    cards.push({
+      key: "super",
+      iconName: "landmark",
+      heading: "Sort your super",
+      copy: "Compare top-performing super funds — most Aussies leave thousands on the table here.",
+      ctaLabel: "Compare super funds",
+      href: "/super",
+    });
+  }
+
+  // Park your cash buffer
+  if (answers.mode === "diy" || isMeaningfulAmount) {
+    cards.push({
+      key: "savings",
+      iconName: "piggy-bank",
+      heading: "Park your cash buffer",
+      copy: "Keep your emergency fund earning interest. High-rate savings accounts compared.",
+      ctaLabel: "See savings rates",
+      href: "/savings",
+    });
+  }
+
+  // Get tax help
+  if (
+    answers.complexity === "complex" ||
+    answers.goal === "super" ||
+    answers.goal === "crypto" ||
+    answers.goal === "property"
+  ) {
+    const isSmsf = answers.goal === "super";
+    cards.push({
+      key: "tax",
+      iconName: "calculator",
+      heading: isSmsf ? "Get SMSF help" : "Get tax help",
+      copy: isSmsf
+        ? "SMSF setup, compliance and audits need a specialist accountant."
+        : "A tax specialist can save more than their fee on crypto, property or complex returns.",
+      ctaLabel: "Find an accountant",
+      href: isSmsf ? "/advisors/smsf-accountants" : "/advisors/tax-agents",
+    });
+  }
+
+  // Talk to an advisor — only for DIY users who said they're unsure
+  if (answers.mode === "unsure") {
+    cards.push({
+      key: "advisor",
+      iconName: "users",
+      heading: "Talk to an advisor",
+      copy: "Not sure where to start? A 30-minute chat with a planner can clarify your next move.",
+      ctaLabel: "Find an advisor",
+      href: "/find-advisor",
+    });
+  }
+
+  // Cap at 4 — anything more is noise. Order above is intentional (super > savings > tax > advisor).
+  return cards.slice(0, 4);
+}
+
+interface Props {
+  answers: ThreadAnswers;
+}
+
+export default function ThreadCardsStrip({ answers }: Props) {
+  const cards = selectThreadCards(answers);
+
+  // Render nothing if no cards qualify — avoid empty section.
+  if (cards.length === 0) return null;
+
+  return (
+    <section
+      aria-labelledby="quiz-bundle-heading"
+      className="mb-4 md:mb-6 result-card-in result-card-in-delay-2"
+    >
+      <div className="text-center mb-3 md:mb-4">
+        <p className="text-[0.58rem] md:text-[0.62rem] font-bold uppercase tracking-wider text-emerald-600 mb-1">
+          Your investing stack
+        </p>
+        <h2
+          id="quiz-bundle-heading"
+          className="text-base md:text-xl font-extrabold text-slate-900"
+        >
+          A great setup is more than just a broker
+        </h2>
+        <p className="text-[0.69rem] md:text-sm text-slate-500 mt-1">
+          Based on your answers, here&apos;s what else is worth a look.
+        </p>
+      </div>
+
+      <div
+        className={`grid gap-2.5 md:gap-3 ${
+          cards.length === 1
+            ? "grid-cols-1"
+            : cards.length === 2
+              ? "grid-cols-1 sm:grid-cols-2"
+              : "grid-cols-1 sm:grid-cols-2"
+        }`}
+      >
+        {cards.map((card) => (
+          <Link
+            key={card.key}
+            href={card.href}
+            onClick={() =>
+              trackEvent("quiz_thread_card_click", { thread: card.key }, "/quiz")
+            }
+            className="group flex items-start gap-3 p-3 md:p-4 bg-white border border-slate-200 rounded-xl hover:border-emerald-300 hover:shadow-sm transition-all active:scale-[0.99]"
+          >
+            <div className="w-9 h-9 md:w-10 md:h-10 rounded-lg bg-emerald-50 flex items-center justify-center shrink-0 group-hover:bg-emerald-100 transition-colors">
+              <Icon
+                name={card.iconName}
+                size={18}
+                className="text-emerald-600"
+              />
+            </div>
+            <div className="flex-1 min-w-0">
+              <h3 className="text-sm md:text-base font-bold text-slate-900 mb-0.5">
+                {card.heading}
+              </h3>
+              <p className="text-[0.69rem] md:text-xs text-slate-500 leading-relaxed mb-1.5">
+                {card.copy}
+              </p>
+              <span className="text-[0.65rem] md:text-xs font-semibold text-emerald-700 group-hover:text-emerald-800">
+                {card.ctaLabel} <span aria-hidden="true">→</span>
+              </span>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/app/quiz/page.tsx
+++ b/app/quiz/page.tsx
@@ -720,6 +720,7 @@ export default function QuizPage() {
       <QuizResultsScreen
         results={results}
         answers={scoringAnswers}
+        unifiedAnswers={answers}
         hasCryptoResult={hasCryptoResult}
         emailGate={false}
         gateEmail=""


### PR DESCRIPTION
## Why

Quiz currently outputs a single ranked broker list. Reframes the result as a multi-thread investing stack — \"Your investing stack\" section above the leaderboard with 3-4 cards (sort super / park cash / tax help / advisor) conditionally rendered from the user's actual answers. Multiplies affiliate paths from the highest-intent surface on the site.

## Card visibility logic

- **Sort your super** → `goal=='super'` OR `priority=='safety'` OR `amount in {large, whale}` → /super
- **Park your cash buffer** → `mode=='diy'` OR `amount in {medium, large, whale}` → /savings
- **Get tax/SMSF help** → `complexity=='complex'` OR `goal in {super, crypto, property}` → /advisors/tax-agents (or smsf-accountants when goal=super)
- **Talk to an advisor** → `mode=='unsure'` → /find-advisor

Hard cap of 4 cards. Returns null if zero match (simple-small profiles see original results untouched).

## Judgment calls

- **DIY track only.** Strip is intentionally skipped on the advisor track — that funnel already has a dedicated contact → match flow; bundle cards above it would muddy higher intent.
- **No \"Pick your broker\" card.** Redundant with the leaderboard ~30px below.
- Click tracking via existing `trackEvent('quiz_thread_card_click')`.

## Test plan

- [ ] Take quiz with goal=super → expect Sort-your-super + Get-SMSF-help
- [ ] Take quiz with mode=advisor → no strip, AdvisorResultsScreen unchanged
- [ ] Verify email gate, share buttons, top-match confetti still work
- [ ] Spot-check card click events fire