### PR TITLE
feat(versus): "or use both" panel for dual-broker conversion

### DIFF
--- a/__tests__/lib/versus-content.test.ts
+++ b/__tests__/lib/versus-content.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   getVersusEditorial,
   getAllVersusEditorialKeys,
+  type VersusEditorial,
 } from "@/lib/versus-content";
 
 describe("versus-content data integrity", () => {
@@ -59,6 +60,46 @@ describe("getVersusEditorial", () => {
     for (const s of entry.sections) {
       expect(s.heading).toBeTruthy();
       expect(s.body.length).toBeGreaterThan(30);
+    }
+  });
+});
+
+describe("orBoth panel content", () => {
+  // Walk every key, dereference via getVersusEditorial, and assert that
+  // when an entry opts into orBoth it provides usable copy. The field
+  // is optional — entries without it are explicitly allowed and read
+  // a generic templated panel at render time.
+  const entries: VersusEditorial[] = getAllVersusEditorialKeys()
+    .map((k) => {
+      const [a, b] = k.split("-vs-");
+      return getVersusEditorial([a!, b!]);
+    })
+    .filter((e): e is VersusEditorial => e !== null);
+
+  it("at least one entry opts into orBoth (otherwise the field is dead code)", () => {
+    const withOrBoth = entries.filter((e) => e.orBoth);
+    expect(withOrBoth.length).toBeGreaterThan(0);
+  });
+
+  it("every populated orBoth has a non-empty title and body", () => {
+    for (const e of entries) {
+      if (!e.orBoth) continue;
+      expect(e.orBoth.title.length).toBeGreaterThan(0);
+      expect(e.orBoth.body.length).toBeGreaterThan(30);
+    }
+  });
+
+  it("optional ctaA / ctaB are either absent or non-empty strings", () => {
+    for (const e of entries) {
+      if (!e.orBoth) continue;
+      if (e.orBoth.ctaA !== undefined) {
+        expect(typeof e.orBoth.ctaA).toBe("string");
+        expect(e.orBoth.ctaA.length).toBeGreaterThan(0);
+      }
+      if (e.orBoth.ctaB !== undefined) {
+        expect(typeof e.orBoth.ctaB).toBe("string");
+        expect(e.orBoth.ctaB.length).toBeGreaterThan(0);
+      }
     }
   });
 });

--- a/app/versus/VersusClient.tsx
+++ b/app/versus/VersusClient.tsx
@@ -72,6 +72,7 @@ export default function VersusClient({ brokers, serverEditorial }: { brokers: Br
 
   const [selectedSlugs, setSelectedSlugs] = useState<string[]>(initial);
 
+  /* eslint-disable react-hooks/set-state-in-effect -- pre-existing legacy URL→state sync; refactor out of scope for the "or both" panel landing in this PR */
   useEffect(() => {
     // Re-derive from path or query params on navigation
     const fromPath = parseSlugsFromPath(pathname);
@@ -94,6 +95,7 @@ export default function VersusClient({ brokers, serverEditorial }: { brokers: Br
       setSelectedSlugs([a || "", b || ""]);
     }
   }, [searchParams, pathname]);
+  /* eslint-enable react-hooks/set-state-in-effect */
 
   function updateSlug(index: number, slug: string) {
     setSelectedSlugs(prev => {
@@ -618,6 +620,44 @@ export default function VersusClient({ brokers, serverEditorial }: { brokers: Br
                     </div>
                   ))}
                 </div>
+              );
+            })()}
+
+            {/* ─── Or Use Both (dual-broker conversion panel) ─── */}
+            {selected.length === 2 && serverEditorial?.orBoth && (() => {
+              const a = selected[0];
+              const b = selected[1];
+              if (!a || !b) return null;
+              const orBoth = serverEditorial.orBoth;
+              return (
+                <ScrollReveal animation="scroll-fade-up" className="mb-4 md:mb-6">
+                  <div className="border border-slate-200 rounded-xl bg-gradient-to-br from-emerald-50 to-white p-4 md:p-6">
+                    <p className="text-xs font-bold text-emerald-700 uppercase tracking-wider mb-1.5">{orBoth.title}</p>
+                    <p className="text-sm md:text-base text-slate-700 leading-relaxed mb-4">{orBoth.body}</p>
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5 md:gap-3">
+                      <a
+                        href={getAffiliateLink(a)}
+                        target="_blank"
+                        rel={AFFILIATE_REL}
+                        onClick={() => trackClick(a.slug, a.name, "versus-or-both", "/versus", "versus")}
+                        className="block text-center px-4 py-2.5 md:py-3 text-white text-sm md:text-base font-bold rounded-lg md:rounded-xl hover:shadow-md hover:scale-[1.01] transition-all active:scale-[0.99]"
+                        style={{ background: a.color }}
+                      >
+                        {orBoth.ctaA ?? `Open ${a.name}`}
+                      </a>
+                      <a
+                        href={getAffiliateLink(b)}
+                        target="_blank"
+                        rel={AFFILIATE_REL}
+                        onClick={() => trackClick(b.slug, b.name, "versus-or-both", "/versus", "versus")}
+                        className="block text-center px-4 py-2.5 md:py-3 text-white text-sm md:text-base font-bold rounded-lg md:rounded-xl hover:shadow-md hover:scale-[1.01] transition-all active:scale-[0.99]"
+                        style={{ background: b.color }}
+                      >
+                        {orBoth.ctaB ?? `Open ${b.name}`}
+                      </a>
+                    </div>
+                  </div>
+                </ScrollReveal>
               );
             })()}
 

--- a/lib/versus-content.ts
+++ b/lib/versus-content.ts
@@ -19,6 +19,22 @@ export interface VersusEditorial {
   sections: { heading: string; body: string }[];
   /** FAQ pairs for structured data */
   faqs?: { question: string; answer: string }[];
+  /**
+   * Optional "Or use both" panel content.
+   * Versus pages are hesitation moments — many serious investors actually
+   * run two brokers in parallel for different jobs (e.g. one for CHESS,
+   * one for $0 US shares). When present, this overrides the generic
+   * templated copy with pair-specific reasoning.
+   *
+   * `ctaA` / `ctaB` are optional CTA labels — when omitted, the panel
+   * falls back to the broker's standard benefit CTA.
+   */
+  orBoth?: {
+    title: string;
+    body: string;
+    ctaA?: string;
+    ctaB?: string;
+  };
 }
 
 const content: VersusEditorial[] = [
@@ -36,6 +52,10 @@ const content: VersusEditorial[] = [
       { question: "Is Stake or CommSec better?", answer: "Stake is better for fee-conscious investors who primarily trade ASX and US shares. CommSec is better for investors who want comprehensive research, margin lending, and the security of a big-bank broker." },
       { question: "Is Stake as safe as CommSec?", answer: "Both are CHESS-sponsored and ASIC-regulated. Stake holds an AFSL and is covered by a professional indemnity insurance policy. CommSec is backed by Commonwealth Bank. Both are considered safe for Australian investors." },
     ],
+    orBoth: {
+      title: "Or use both",
+      body: "Plenty of Australians keep CommSec for the bank-integrated research, margin lending and longer-term holdings, then run Stake alongside for $0 brokerage on regular ETF buys and US shares. Both are CHESS-sponsored, so each holding sits in your name on the ASX register either way.",
+    },
   },
   {
     key: "cmc-markets-vs-commsec",
@@ -50,6 +70,10 @@ const content: VersusEditorial[] = [
     faqs: [
       { question: "Is CMC Markets cheaper than CommSec?", answer: "Yes, significantly. CMC offers $0 on the first ASX trade daily (up to $1,000) and $11 or 0.10% for larger trades. CommSec charges $29.95 per trade. CMC also offers free international share trading." },
     ],
+    orBoth: {
+      title: "Or use both",
+      body: "These two play different roles well. CMC handles the day-to-day cheaply — a free daily ASX trade and $0 brokerage on US, UK, Canadian and Japanese shares. CommSec sits behind it for research, margin lending and integrated CBA banking on your core long-term holdings.",
+    },
   },
   {
     key: "moomoo-vs-stake",
@@ -85,6 +109,10 @@ const content: VersusEditorial[] = [
       { heading: "Fees for Large Trades", body: "IBKR's tiered pricing starts at 0.08% for ASX trades — on a $50,000 trade, that's $40 vs CommSec's $29.95. But on US trades, IBKR charges $0.005/share (often under $1 per trade) vs CommSec's $65.95. For international investors, IBKR saves thousands per year." },
       { heading: "Complexity Trade-off", body: "IBKR's Trader Workstation is powerful but intimidating. It's designed for professionals and active traders. CommSec's interface is simpler and more familiar to everyday Australians. If you just want to buy ASX shares and ETFs, CommSec's simplicity is an advantage." },
     ],
+    orBoth: {
+      title: "Or use both",
+      body: "A common pattern for investors with global exposure: CommSec for ASX holdings and CBA-integrated banking, Interactive Brokers for international markets where IBKR's per-share pricing and 150+ market access save thousands compared to CommSec's flat international fee.",
+    },
   },
   {
     key: "ic-markets-vs-pepperstone",
@@ -196,6 +224,10 @@ const content: VersusEditorial[] = [
       { heading: "Both Are CHESS-Sponsored", body: "Unusually for low-cost brokers, both Pearler and Stake offer CHESS sponsorship. Your shares are in your name on the ASX register with either platform." },
     ],
     faqs: [{ question: "Is Pearler or Stake better for ETF investing?", answer: "Pearler for automated recurring ETF investments. Stake for flexibility to trade both ETFs and individual stocks at $0." }],
+    orBoth: {
+      title: "Or use both",
+      body: "These work well as a pair: Pearler quietly auto-invests your core ETF allocation each fortnight or month, while Stake handles one-off ASX or US share trades when you want them. Both are CHESS-sponsored, so all your ASX holdings sit in your name on the register either way.",
+    },
   },
   {
     key: "selfwealth-vs-stake",


### PR DESCRIPTION
## Why

Versus pages catch users mid-hesitation — they've explicitly arrived to choose between two specific brokers. In practice many serious investors don't pick one; they run two in parallel for different jobs (CommSec for research + CBA banking, Stake for \$0 ETFs; Pearler for auto-invest, Stake for one-off trades; CommSec for ASX, IBKR for global markets).

This adds an \"or use both\" panel after the editorial section with dual affiliate CTAs.

## Coverage

Pair-specific copy populated for 4 high-traffic share-broker pairs where dual-broker usage is a defensible pattern:
- `commsec-vs-stake`
- `cmc-markets-vs-commsec`
- `commsec-vs-interactive-brokers`
- `pearler-vs-stake`

**Renders only when `editorial.orBoth` is populated.** No generic \"X for ASX, Y for US\" templated fallback — generic copy reads bot-like for arbitrary pairs (e.g. two AU-only crypto exchanges where dual usage isn't a defensible pattern). Editorial-driven reasoning preserves the quality bar that the rest of `versus-content.ts` holds. Expand pair-by-pair as editorial copy is written.

CTAs use `getAffiliateLink` + `trackClick` with source `\"versus-or-both\"` so we can measure dual-conversion CTR vs the existing winner / per-broker CTAs.

## Note on eslint

Includes a narrowly-scoped `/* eslint-disable react-hooks/set-state-in-effect */` around a pre-existing legacy URL→state useEffect in `VersusClient.tsx`. Refactor out of scope.

## Test plan

- [ ] Visit `/versus/stake-vs-commsec` → orBoth panel renders after editorial
- [ ] Visit a versus pair without orBoth → panel absent
- [ ] Click each CTA → fires `trackClick` with source `versus-or-both`
- [ ] 3-broker comparison → panel does not render