### PR TITLE
feat(advisors): conveyancer + property_lawyer professional types

### DIFF
--- a/__tests__/lib/advisor-specialties.test.ts
+++ b/__tests__/lib/advisor-specialties.test.ts
@@ -49,6 +49,23 @@ describe("SPECIALTIES_BY_TYPE", () => {
     expect(SPECIALTIES_BY_TYPE.financial_planner.length).toBeGreaterThan(0);
   });
 
+  it("includes property-thread completion types (conveyancer, property_lawyer)", () => {
+    expect(SPECIALTIES_BY_TYPE.conveyancer.length).toBeGreaterThan(0);
+    expect(SPECIALTIES_BY_TYPE.property_lawyer.length).toBeGreaterThan(0);
+    // Conveyancer specialties should reference settlement work
+    expect(
+      SPECIALTIES_BY_TYPE.conveyancer.some((s) =>
+        /settle|contract|stamp duty|pexa/i.test(s),
+      ),
+    ).toBe(true);
+    // Property lawyer specialties should reference disputes / SMSF / off-the-plan
+    expect(
+      SPECIALTIES_BY_TYPE.property_lawyer.some((s) =>
+        /dispute|smsf|off-the-plan|litigation|strata/i.test(s),
+      ),
+    ).toBe(true);
+  });
+
   it("every type's specialty list is non-empty", () => {
     for (const [type, specialties] of Object.entries(SPECIALTIES_BY_TYPE)) {
       expect(

--- a/app/advisors/[type]/page.tsx
+++ b/app/advisors/[type]/page.tsx
@@ -44,6 +44,9 @@ const SLUG_TO_TYPE: Record<string, ProfessionalType> = {
   "smsf-specialists": "smsf_specialist",
   "immigration-investment-lawyers": "immigration_investment_lawyer",
   "fund-managers": "fund_manager",
+  // Property-thread completion (20260501)
+  "conveyancers": "conveyancer",
+  "property-lawyers": "property_lawyer",
 };
 
 const TYPE_DESCRIPTIONS: Record<string, string> = {
@@ -75,6 +78,8 @@ const TYPE_DESCRIPTIONS: Record<string, string> = {
   "smsf-specialists": "Find AFSL-authorised SMSF specialists — setup, investment strategy, LRBA property structuring, pension-phase transition, and death benefit nominations.",
   "immigration-investment-lawyers": "Find specialist lawyers for Significant Investor Visa (SIV), Business Innovation Visa, and SIV-complying investment structuring. Experienced with FIRB coordination and sophisticated-investor certification.",
   "fund-managers": "Browse AFSL-licensed Australian fund managers — wholesale, retail-registered, managed investment schemes, private credit, and alternative mandates.",
+  "conveyancers": "Find licensed Australian conveyancers for residential and off-the-plan property settlement. PEXA-accredited specialists handling contracts, stamp duty, and title transfer across NSW, VIC, QLD, WA, SA, TAS, ACT and NT.",
+  "property-lawyers": "Find specialist Australian property lawyers for off-the-plan disputes, strata matters, SMSF property structuring, and property litigation. Practising-certificate-verified solicitors across every state.",
 };
 
 const TYPE_FAQS: Record<string, { q: string; a: string }[]> = {
@@ -217,6 +222,16 @@ const TYPE_FAQS: Record<string, { q: string; a: string }[]> = {
     { q: "What's the difference between wholesale and retail fund managers?", a: "Retail funds are available to everyday investors and must issue a Product Disclosure Statement (PDS). Wholesale funds are restricted to sophisticated/professional investors (typically $2.5M net assets or $250K gross income certification) and issue an Information Memorandum instead of a PDS." },
     { q: "How do fund manager fees work?", a: "Management fee: typically 0.5–1.5% p.a. of AUM. Performance fee: 15–20% over a benchmark or absolute hurdle, often with a high-water mark. Some funds charge entry/exit fees or buy-sell spreads. Always review the PDS/IM fee schedule and compare on the total cost of ownership." },
     { q: "How do I verify a fund manager is legitimate?", a: "Check their AFSL number on the ASIC register — it should cover managed investment schemes and/or wholesale dealing. Review the fund's PDS or IM. For retail funds, check ASIC's MoneySmart tool. Past performance must be disclosed in standard format." },
+  ],
+  "conveyancers": [
+    { q: "What's the difference between a conveyancer and a property lawyer?", a: "A conveyancer is licensed specifically to handle property settlements: contract review, title searches, PEXA e-settlement, and stamp duty. A property lawyer is an admitted solicitor who can also handle disputes, off-the-plan complications, and litigation. Conveyancers are typically cheaper for straightforward residential purchases; property lawyers are preferred for complex titles or where a dispute is possible." },
+    { q: "How much does a conveyancer cost in Australia?", a: "Standard residential settlement fees range $800–$2,200 depending on state and complexity. NSW and VIC sit in the $1,200–$1,800 range. Off-the-plan settlements often cost more ($1,500–$3,000) because contracts are longer and there are more compliance touchpoints. Search and government fees ($300–$700) are charged on top." },
+    { q: "Do I need a conveyancer in Queensland?", a: "Queensland is the only state where conveyancing is restricted to admitted solicitors — there is no separate conveyancer licence. So in QLD you'll engage a property lawyer for what other states would call conveyancing. Fees are similar to interstate conveyancers for straightforward purchases." },
+  ],
+  "property-lawyers": [
+    { q: "When do I need a property lawyer instead of a conveyancer?", a: "Use a property lawyer for off-the-plan disputes (sunset clauses, defects, developer insolvency), strata or owners-corporation issues, SMSF property structuring (LRBA, in-specie transfers), commercial conveyancing, or any matter where a contract dispute is reasonably possible. The legal cover is broader than a conveyancer's licence allows." },
+    { q: "How much does a property lawyer cost?", a: "Straightforward residential conveyancing handled by a solicitor: $1,200–$2,500. Off-the-plan disputes or strata litigation: $5,000–$25,000+ depending on scope. SMSF property structuring with LRBA setup: $3,500–$7,500. Hourly rates: $400–$700 at boutique firms, $700–$1,000+ at top-tier. All legal fees attract GST." },
+    { q: "What is the sunset clause issue with off-the-plan?", a: "Sunset clauses let either party rescind an off-the-plan contract if the development isn't completed by a specified date — historically used by developers to cancel and re-sell at a higher price after the market rose. NSW and VIC have legislated to restrict developer-initiated rescissions; a property lawyer should review every off-the-plan contract for the current rules in your state." },
   ],
 };
 
@@ -500,6 +515,26 @@ const TYPE_EDITORIAL: Record<string, { howToChoose: string[]; costGuide: string;
     ],
     costGuide: "Retail managed funds: 0.3–1.5% p.a. management fee, some with performance fees. Wholesale funds: 1.0–2.0% management + 15–20% performance over hurdle. Private credit funds: 0.85–1.25% management + 10–15% performance. Private equity: 1.75–2.25% + 20% carry over 8% preferred return.",
     industryInsight: "The Australian managed-funds industry manages ~$4.3 trillion. Post-RG 97 fee disclosure, retail investors can compare total-cost-of-ownership more directly than ever. Wholesale mandates remain the fastest-growing segment, particularly in private credit and infrastructure.",
+  },
+  "conveyancers": {
+    howToChoose: [
+      "Verify their state-issued conveyancer licence on Fair Trading (NSW, VIC, SA, WA, TAS, ACT, NT) — in QLD use a solicitor",
+      "Confirm PEXA accreditation — paper settlements are now the exception, not the rule",
+      "Ask for a fixed-fee quote upfront covering search, settlement, and PEXA fees separately from disbursements",
+      "Check responsiveness — settlement is time-sensitive and 24-hour reply windows matter at exchange and settlement",
+    ],
+    costGuide: "Standard residential settlement: $800–$2,200 (search and gov fees $300–$700 extra). Off-the-plan: $1,500–$3,000. Combined contract review + settlement packages: $1,500–$2,800. Hourly rates rarely apply — most conveyancers quote fixed fees.",
+    industryInsight: "PEXA e-settlement now covers >95% of property transactions across the eastern states. The shift has reduced settlement risk and time-on-the-day delays but raised the bar on conveyancer technology and cyber-fraud awareness — title-fraud insurance is increasingly expected.",
+  },
+  "property-lawyers": {
+    howToChoose: [
+      "Verify a current practising certificate with the relevant state Law Society",
+      "Match expertise to your situation — off-the-plan, strata, SMSF property, and commercial are different sub-specialties",
+      "Ask about recent matters: a property lawyer who has actually run sunset-clause litigation is materially different from one who has only drafted settlements",
+      "For SMSF property, confirm they coordinate with your accountant and SMSF specialist on the LRBA structuring",
+    ],
+    costGuide: "Residential conveyancing by a solicitor: $1,200–$2,500. Off-the-plan disputes or strata litigation: $5,000–$25,000+. SMSF property + LRBA setup: $3,500–$7,500 one-off. Commercial conveyancing: $3,000–$10,000. Hourly rates: $400–$700 (boutique), $700–$1,000+ (top-tier).",
+    industryInsight: "NSW and VIC have tightened sunset-clause rules to limit developer-initiated rescissions, and SMSF LRBA scrutiny by the ATO has increased materially since 2024. Property law as a stand-alone solicitor specialty is growing — generalist 'commercial + property' practices are giving way to dedicated property litigators.",
   },
 };
 

--- a/app/property/page.tsx
+++ b/app/property/page.tsx
@@ -475,6 +475,80 @@ export default async function PropertyHubPage() {
         </ScrollFadeIn>
       )}
 
+      {/* ── Buying a property? Team CTA ───────────── */}
+      <ScrollFadeIn>
+        <section className="py-8 md:py-14 bg-white">
+          <div className="container-custom">
+            <div className="flex items-end justify-between gap-2 mb-6">
+              <div>
+                <p className="text-xs font-bold text-amber-600 uppercase tracking-wider mb-1">Your Property Team</p>
+                <h2 className="text-xl md:text-3xl font-extrabold text-slate-900">Buying a property? Line up your team.</h2>
+                <p className="text-sm text-slate-500 mt-1">A full property purchase usually involves four professionals. Free, no-obligation introductions.</p>
+              </div>
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+              {[
+                {
+                  icon: "landmark",
+                  iconBg: "bg-blue-600",
+                  border: "hover:border-blue-200 hover:bg-blue-50/40",
+                  label: "Mortgage Broker",
+                  copy: "Compare 30+ lenders for the right investment loan structure and rate.",
+                  href: "/advisors/mortgage-brokers",
+                  cta: "Find a broker",
+                  ctaCls: "text-blue-700",
+                },
+                {
+                  icon: "search",
+                  iconBg: "bg-amber-500",
+                  border: "hover:border-amber-200 hover:bg-amber-50/40",
+                  label: "Buyer's Agent",
+                  copy: "Source, evaluate, and negotiate — including off-market opportunities.",
+                  href: "/advisors/buyers-agents",
+                  cta: "Find an agent",
+                  ctaCls: "text-amber-600",
+                },
+                {
+                  icon: "file-signature",
+                  iconBg: "bg-emerald-600",
+                  border: "hover:border-emerald-200 hover:bg-emerald-50/40",
+                  label: "Conveyancer",
+                  copy: "Settlement, contract review, PEXA e-settlement, and stamp duty.",
+                  href: "/advisors/conveyancers",
+                  cta: "Find a conveyancer",
+                  ctaCls: "text-emerald-700",
+                },
+                {
+                  icon: "gavel",
+                  iconBg: "bg-slate-800",
+                  border: "hover:border-slate-300 hover:bg-slate-50",
+                  label: "Property Lawyer",
+                  copy: "Off-the-plan disputes, strata, SMSF property structuring, litigation.",
+                  href: "/advisors/property-lawyers",
+                  cta: "Find a lawyer",
+                  ctaCls: "text-slate-700",
+                },
+              ].map((card) => (
+                <Link
+                  key={card.href}
+                  href={card.href}
+                  className={`bg-white border border-slate-200 rounded-2xl p-5 transition-all group flex flex-col ${card.border}`}
+                >
+                  <div className={`w-10 h-10 ${card.iconBg} rounded-xl flex items-center justify-center mb-4 shadow-sm`}>
+                    <Icon name={card.icon} size={20} className="text-white" />
+                  </div>
+                  <h3 className="text-sm font-bold text-slate-900 mb-1">{card.label}</h3>
+                  <p className="text-xs text-slate-500 leading-relaxed mb-4 flex-1">{card.copy}</p>
+                  <span className={`text-xs font-bold ${card.ctaCls} group-hover:underline flex items-center gap-1`}>
+                    {card.cta} <span className="group-hover:translate-x-0.5 transition-transform">&rarr;</span>
+                  </span>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </section>
+      </ScrollFadeIn>
+
       {/* ── Buyer's Agent CTA ─────────────────────── */}
       <ScrollFadeIn>
         <section className="py-8 md:py-12 bg-slate-50 border-y border-slate-100">

--- a/lib/advisor-application-classifier.ts
+++ b/lib/advisor-application-classifier.ts
@@ -103,6 +103,8 @@ const ABN_REQUIRED: readonly string[] = [
   "aged_care_advisor",
   "crypto_advisor",
   "debt_counsellor",
+  "conveyancer",
+  "property_lawyer",
 ];
 
 // ─── Top-level classifier ─────────────────────────────────────────────

--- a/lib/advisor-opt-ins.ts
+++ b/lib/advisor-opt-ins.ts
@@ -75,6 +75,8 @@ const VALID_ADVISOR_TYPES = new Set([
   "smsf_specialist",
   "immigration_investment_lawyer",
   "fund_manager",
+  "conveyancer",
+  "property_lawyer",
 ]);
 
 export async function processAdvisorOptIns(args: ProcessOptInsArgs): Promise<ProcessOptInsResult> {

--- a/lib/advisor-specialties.ts
+++ b/lib/advisor-specialties.ts
@@ -445,6 +445,25 @@ export const SPECIALTIES_BY_TYPE: Record<ProfessionalType, string[]> = {
     "Custody & Administration",
     "Performance Attribution",
   ],
+  conveyancer: [
+    "Residential Settlement",
+    "Off-the-Plan Settlement",
+    "Contract Review",
+    "PEXA E-Settlement",
+    "Stamp Duty & Concessions",
+    "First Home Buyers",
+    "Title Searches",
+  ],
+  property_lawyer: [
+    "Off-the-Plan Disputes",
+    "Strata & Owners Corporation",
+    "SMSF Property Structuring",
+    "Property Litigation",
+    "Easements & Caveats",
+    "Adverse Possession",
+    "Commercial Conveyancing",
+    "Lease Disputes",
+  ],
 };
 
 // ═══════════════════════════════════════════════

--- a/lib/advisor-verification.ts
+++ b/lib/advisor-verification.ts
@@ -1000,6 +1000,77 @@ export const VERIFICATION_CONFIGS: Record<ProfessionalType, VerificationConfig> 
     cpd: "Ongoing fund-manager training as required under RG 104 / RG 133",
     disclosure: "Fund managers must operate under a valid AFSL. Verify the fund''s PDS (retail) or Information Memorandum (wholesale), and confirm the AFSL covers the specific activities being offered. Past performance is not an indicator of future returns.",
   },
+
+  // ─── Property-thread completion (20260501) ────────────────────
+  // Conveyancers and property lawyers complete the property purchase
+  // advisor team alongside mortgage_broker + buyers_agent. Conveyancers
+  // are licensed under state-based conveyancing or fair-trading
+  // legislation (NSW: Conveyancers Licensing Act; QLD: only solicitors
+  // can convey, no separate conveyancer licence). Property lawyers hold
+  // a state Legal Practising Certificate.
+
+  conveyancer: {
+    type: "conveyancer",
+    label: "Conveyancer",
+    primaryLicence: {
+      code: "Conveyancer Licence",
+      name: "State Conveyancer Licence",
+      regulator: "State Fair Trading / Consumer Affairs",
+      regulatorShort: "Fair Trading",
+      // State-specific in practice — defaults to NSW Fair Trading
+      // licence search; getVerificationLinks layers the matching
+      // STATE_FAIR_TRADING_URLS entry on top when a state is supplied.
+      verifyUrl: "https://verify.licence.nsw.gov.au/",
+      verifyLabel: "Verify with State Fair Trading",
+      mandatory: true,
+      field: "registration_number",
+      description: "Conveyancers must hold a state-based licence to handle property settlements. NSW, VIC, SA, WA, TAS, ACT and NT licence conveyancers separately from solicitors. In QLD only admitted lawyers can conduct conveyancing.",
+    },
+    additionalLicences: [],
+    qualifications: [
+      "State-issued conveyancer licence (NSW, VIC, SA, WA, TAS, ACT, NT) or admitted lawyer (QLD)",
+      "Advanced Diploma of Conveyancing or equivalent in licensing states",
+      "PEXA-accredited for electronic settlement (now mandatory for most transactions)",
+    ],
+    associations: [
+      { name: "Australian Institute of Conveyancers", acronym: "AIC", url: "https://www.aicnational.com.au" },
+      { name: "State Law Society / Bar Association", acronym: "Law Society", url: "https://www.lawsociety.com.au/" },
+    ],
+    insurance: "Professional Indemnity Insurance — mandatory under state licensing conditions, typically minimum $2M per claim",
+    edr: "Complaints handled by state Fair Trading / Consumer Affairs and the Australian Institute of Conveyancers",
+    cpd: "State-based CPD — typically 10 hours per year",
+    disclosure: "Conveyancers are licensed under state-based legislation, not federal ASIC regulation. Licensing varies materially: NSW issues a Conveyancers Licence; QLD restricts conveyancing to admitted solicitors. Always verify the licence on your state's Fair Trading register before engaging.",
+  },
+
+  property_lawyer: {
+    type: "property_lawyer",
+    label: "Property Lawyer",
+    primaryLicence: {
+      code: "LPC",
+      name: "Legal Practising Certificate",
+      regulator: "State Law Society / Legal Services Commission",
+      regulatorShort: "Law Society",
+      verifyUrl: "https://www.lawcouncil.asn.au",
+      verifyLabel: "Verify on state Law Society register",
+      mandatory: true,
+      field: "registration_number",
+      description: "Property lawyers must hold a current practising certificate in their admitted jurisdiction — issued by the relevant state Law Society to admitted legal practitioners.",
+    },
+    additionalLicences: [],
+    qualifications: [
+      "Admitted to practice in at least one Australian state or territory",
+      "Current practising certificate with state Law Society",
+      "Substantive experience in residential and commercial property transactions, off-the-plan disputes, strata, and SMSF property structuring",
+    ],
+    associations: [
+      { name: "Law Council of Australia — Property Law Committee", acronym: "LCA", url: "https://www.lawcouncil.asn.au" },
+      { name: "State Law Society / Bar Association", acronym: "Law Society", url: "https://www.lawsociety.com.au/" },
+    ],
+    insurance: "Professional Indemnity Insurance — mandatory under state legal profession acts",
+    edr: "Complaints handled by the relevant state Legal Services Commissioner",
+    cpd: "10 CPD units per year as required by state Law Society",
+    disclosure: "Property lawyers must hold a current practising certificate in their admitted jurisdiction. Use a property lawyer (rather than a conveyancer) for off-the-plan disputes, contract negotiations, SMSF property structuring, or any matter likely to require litigation. Legal fees attract GST.",
+  },
 };
 
 // ═══════════════════════════════════════════════════════════════════
@@ -1060,8 +1131,8 @@ export function getVerificationLinks(type: ProfessionalType, state?: string): {
     }
   }
 
-  // State-based register for buyers agents / property types
-  if ((type === "buyers_agent" || type === "property_advisor" || type === "real_estate_agent") && state && STATE_FAIR_TRADING_URLS[state]) {
+  // State-based register for buyers agents / property types / conveyancers
+  if ((type === "buyers_agent" || type === "property_advisor" || type === "real_estate_agent" || type === "conveyancer") && state && STATE_FAIR_TRADING_URLS[state]) {
     const ft = STATE_FAIR_TRADING_URLS[state];
     links.push({
       label: `Verify on ${ft.name}`,

--- a/lib/api-schemas.ts
+++ b/lib/api-schemas.ts
@@ -125,7 +125,7 @@ export const QUOTE_ADVISOR_TYPES = [
   "smsf_accountant", "financial_planner", "property_advisor", "tax_agent",
   "mortgage_broker", "estate_planner", "insurance_broker", "buyers_agent",
   "wealth_manager", "aged_care_advisor", "crypto_advisor", "business_broker",
-  "migration_agent",
+  "migration_agent", "conveyancer", "property_lawyer",
 ] as const;
 
 export const QUOTE_AU_STATES = [

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -978,7 +978,13 @@ export type ProfessionalType =
   | 'smsf_auditor'
   | 'smsf_specialist'
   | 'immigration_investment_lawyer'
-  | 'fund_manager';
+  | 'fund_manager'
+  // New in 20260501 — property-thread completion.
+  // Conveyancers handle settlement; property lawyers handle disputes,
+  // off-the-plan, and SMSF property work. See
+  // supabase/migrations/20260501_add_property_advisor_types.sql.
+  | 'conveyancer'
+  | 'property_lawyer';
 
 export interface Professional {
   id: number;
@@ -1152,6 +1158,8 @@ export const PROFESSIONAL_TYPE_LABELS: Record<ProfessionalType, string> = {
   smsf_specialist: "SMSF Specialist",
   immigration_investment_lawyer: "Immigration Investment Lawyer",
   fund_manager: "Fund Manager",
+  conveyancer: "Conveyancer",
+  property_lawyer: "Property Lawyer",
 };
 
 export const PROFESSIONAL_TYPE_ICONS: Record<ProfessionalType, string> = {
@@ -1186,6 +1194,8 @@ export const PROFESSIONAL_TYPE_ICONS: Record<ProfessionalType, string> = {
   smsf_specialist: "building",
   immigration_investment_lawyer: "plane",
   fund_manager: "briefcase",
+  conveyancer: "file-signature",
+  property_lawyer: "gavel",
 };
 
 export const AU_STATES = ["NSW", "VIC", "QLD", "WA", "SA", "TAS", "ACT", "NT"] as const;

--- a/supabase/migrations/20260501_add_property_advisor_types.sql
+++ b/supabase/migrations/20260501_add_property_advisor_types.sql
@@ -1,0 +1,145 @@
+-- ============================================================================
+-- Migration: 20260501_add_property_advisor_types.sql
+-- Date:      2026-05-01
+-- Purpose:   Add 'conveyancer' and 'property_lawyer' to the
+--            professionals.type CHECK constraint and seed corresponding
+--            lead_pricing rows. Completes the property-purchase advisor
+--            thread (mortgage_broker → buyers_agent → conveyancer →
+--            property_lawyer) so /property can recommend a complete team
+--            and /advisors/conveyancers + /advisors/property-lawyers
+--            become real listing pages.
+-- ----------------------------------------------------------------------------
+-- Storage model:
+--   `professionals.type` is a TEXT column with a CHECK constraint named
+--   `professionals_type_check` (NOT a Postgres ENUM — see
+--   20260305_create_advisor_directory.sql line 96 and the historical
+--   widenings in 20260309_add_new_advisor_types.sql,
+--   20260315_add_real_estate_agent.sql, 20260413_stockbroker_firms.sql,
+--   20260428_advisor_directory_extensions.sql,
+--   20260429_oil_gas_expansion.sql, 20260501_uranium_expansion.sql, and
+--   20260506_revenue_expansion.sql).
+--
+--   The CHECK is widened forward-only by DROP CONSTRAINT IF EXISTS +
+--   ADD CONSTRAINT — the same drop+add pattern used by every previous
+--   widening since the table was created. A widening never invalidates
+--   existing rows, so this is safe to apply with traffic.
+-- ----------------------------------------------------------------------------
+-- Idempotency:
+--   * DROP CONSTRAINT IF EXISTS — safe to re-run.
+--   * ADD CONSTRAINT — recreates the same constraint name with the
+--     superset of values; deterministic on every run.
+--   * lead_pricing INSERT … ON CONFLICT (advisor_type) DO NOTHING.
+-- ----------------------------------------------------------------------------
+-- Rollback (operator-driven, not automatic):
+--   Forward-only in production. To rollback you must:
+--     1. UPDATE public.professionals
+--          SET type = 'property_advisor'
+--          WHERE type IN ('conveyancer','property_lawyer');
+--        -- or DELETE the rows; the CHECK won't recreate while any
+--        -- row uses the values you're trying to drop.
+--     2. DELETE FROM public.lead_pricing
+--          WHERE advisor_type IN ('conveyancer','property_lawyer');
+--     3. ALTER TABLE public.professionals
+--          DROP CONSTRAINT IF EXISTS professionals_type_check;
+--     4. Recreate the prior constraint by copying the ARRAY[...] from
+--        20260506_revenue_expansion.sql lines 26-59 (that is the most
+--        recent constraint that did NOT include conveyancer or
+--        property_lawyer).
+--
+--   N.B. The advisor opt-in / opt-in fan-out tables (listing_advisor_opt_ins,
+--   public_job_advisor_types) use TEXT advisor_type columns with NO CHECK
+--   constraint, so this migration is the only DB-level place the new
+--   values need to be allowed. The application-level allowlist in
+--   lib/advisor-opt-ins.ts (VALID_ADVISOR_TYPES) is updated alongside
+--   this migration.
+-- ----------------------------------------------------------------------------
+-- Risk: low — additive widening only; reverse path is operator-driven.
+-- ============================================================================
+
+BEGIN;
+
+-- 1. Widen the CHECK constraint with the two new types.
+ALTER TABLE public.professionals
+  DROP CONSTRAINT IF EXISTS professionals_type_check;
+
+ALTER TABLE public.professionals
+  ADD CONSTRAINT professionals_type_check CHECK (
+    type = ANY (ARRAY[
+      'smsf_accountant',
+      'financial_planner',
+      'property_advisor',
+      'tax_agent',
+      'mortgage_broker',
+      'estate_planner',
+      'insurance_broker',
+      'buyers_agent',
+      'wealth_manager',
+      'aged_care_advisor',
+      'crypto_advisor',
+      'debt_counsellor',
+      'real_estate_agent',
+      'mining_lawyer',
+      'mining_tax_advisor',
+      'migration_agent',
+      'business_broker',
+      'commercial_lawyer',
+      'rural_property_agent',
+      'commercial_property_agent',
+      'energy_consultant',
+      'stockbroker_firm',
+      'private_wealth_manager',
+      'energy_financial_planner',
+      'resources_fund_manager',
+      'foreign_investment_lawyer',
+      'petroleum_royalties_advisor',
+      'smsf_auditor',
+      'smsf_specialist',
+      'immigration_investment_lawyer',
+      'fund_manager',
+      -- New in 20260501 — property-thread completion:
+      'conveyancer',
+      'property_lawyer'
+    ]::text[])
+  );
+
+-- 2. Seed lead_pricing rows so the lead-pricing helper has a row when
+--    the first advisor of these types onboards. Mirrors the seed pattern
+--    used by 20260315_add_real_estate_agent.sql and the wave-N expansions.
+--
+--    Pricing rationale:
+--      * conveyancer — high lead volume, moderate transaction value.
+--        Comparable to mortgage_broker / buyers_agent intent. $39 lead
+--        (with $29 floor / $69 ceiling), $179/month feature.
+--      * property_lawyer — lower volume but higher value (disputes,
+--        SMSF property, off-the-plan). Closer to commercial_lawyer
+--        pricing. $59 lead ($39/$99), $199/month feature.
+INSERT INTO public.lead_pricing (
+  advisor_type,
+  price_cents,
+  description,
+  min_price_cents,
+  max_price_cents,
+  free_trial_leads,
+  featured_monthly_cents
+) VALUES
+  (
+    'conveyancer',
+    3900,
+    'Conveyancers — settlement, contract review, PEXA e-settlement, and stamp duty for residential and off-the-plan property purchases.',
+    2900,
+    6900,
+    2,
+    17900
+  ),
+  (
+    'property_lawyer',
+    5900,
+    'Property lawyers — off-the-plan disputes, strata, SMSF property structuring, commercial conveyancing, and property litigation.',
+    3900,
+    9900,
+    2,
+    19900
+  )
+ON CONFLICT (advisor_type) DO NOTHING;
+
+COMMIT;


### PR DESCRIPTION
## Why

Completes the property-purchase thread. Today `/property` dead-ends after `mortgage_broker` + `buyers_agent`. Conveyancers handle settlement; property lawyers handle disputes, off-the-plan, and SMSF property. Adds both as `ProfessionalType` values, populates the `/advisors/[type]` SEO routes, and ships a \"Buying a property?\" team widget on `/property`.

## Tier C — schema migration

`supabase/migrations/20260501_add_property_advisor_types.sql`:

- DROP+ADD widening on `professionals_type_check` (`professionals.type` is a TEXT column with a CHECK constraint, **not** a Postgres enum — confirmed by reading prior migrations)
- Idempotent (`ON CONFLICT DO NOTHING` on inserts; CHECK rebuild is conditional)
- Seeds `lead_pricing` rows: \$39 conveyancer / \$59 property_lawyer — **required** to avoid a 500 on first advisor of these types (matches the pattern in `20260315_add_real_estate_agent.sql` and the wave-N expansions)

## Files (10)

Exhaustive switches updated for TS strict + `noUncheckedIndexedAccess`:
- `lib/types.ts` — union + `PROFESSIONAL_TYPE_LABELS` + `PROFESSIONAL_TYPE_ICONS`
- `lib/advisor-verification.ts` — `VERIFICATION_CONFIGS` entries; conveyancer added to state-register layering condition
- `lib/advisor-specialties.ts` — `SPECIALTIES_BY_TYPE` entries
- `lib/advisor-opt-ins.ts` — `VALID_ADVISOR_TYPES`
- `lib/advisor-application-classifier.ts` — `ABN_REQUIRED` (no AFSL needed)
- `lib/api-schemas.ts` — `QUOTE_ADVISOR_TYPES` for `/quotes/post`

Routes + content:
- `app/advisors/[type]/page.tsx` — slug → type for `conveyancers` + `property-lawyers`, plus `TYPE_DESCRIPTIONS` / `TYPE_FAQS` / `TYPE_EDITORIAL`
- `app/property/page.tsx` — \"Buying a property? Line up your team.\" widget after Top Suburbs

Test:
- `__tests__/lib/advisor-specialties.test.ts` — non-empty specialty arrays for both new types

## Test plan

- [ ] Apply migration in staging — verify CHECK constraint rebuilt + `lead_pricing` rows present
- [ ] Visit `/advisors/conveyancers` and `/advisors/property-lawyers` — both render with editorial
- [ ] Visit `/property` — verify team widget after Top Suburbs
- [ ] `npm run type-check` clean (exhaustive switches)
- [ ] Lead pricing query returns rows for both types