### PR TITLE
feat(home): real-preview route cards + Tools nav + revenue band lifted

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -111,6 +111,17 @@ export default async function HomePage() {
 
   const advisorList: ReadonlyArray<HomeAdvisor> = (professionals ?? []) as HomeAdvisor[];
 
+  // Live route-card preview slices — feed real data into the four cards on
+  // the homepage so each one shows what's inside instead of just an icon.
+  const topBrokersForCards = compareBrokers
+    .slice(0, 6)
+    .map((b) => ({ name: b.name, asx_fee: b.asx_fee }));
+
+  const topAdvisorsForCards = advisorList
+    .filter((a) => a.photo_url)
+    .slice(0, 5)
+    .map((a) => ({ name: a.name, photo_url: a.photo_url ?? null }));
+
   // Curate listings for the homepage teaser:
   //   1. Prefer listings with at least one image (better hero unit)
   //   2. Weight by paid tier: premium > featured > standard
@@ -142,6 +153,15 @@ export default async function HomePage() {
     }
   }
   const listingList: ReadonlyArray<HomeListing> = [...curated, ...overflow].slice(0, 60);
+
+  const topListingsForCards = listingList
+    .filter((l) => l.images && l.images.length > 0 && l.images[0])
+    .slice(0, 3)
+    .map((l) => ({
+      id: l.id,
+      title: l.title,
+      image: (l.images && l.images[0]) ? l.images[0] : null,
+    }));
 
   return (
     <div>
@@ -207,11 +227,18 @@ export default async function HomePage() {
           listingCount={totalListingCount}
           professionalCount={totalProfessionalCount}
           brokerCount={brokerCount}
+          topBrokers={topBrokersForCards}
+          topListings={topListingsForCards}
+          topAdvisors={topAdvisorsForCards}
         />
       </ScrollFadeIn>
 
       <ScrollFadeIn>
         <HomePathfinder />
+      </ScrollFadeIn>
+
+      <ScrollFadeIn>
+        <HomeHowWeEarn />
       </ScrollFadeIn>
 
       <ScrollFadeIn>
@@ -236,10 +263,6 @@ export default async function HomePage() {
 
       <ScrollFadeIn>
         <HomeFridayBriefing />
-      </ScrollFadeIn>
-
-      <ScrollFadeIn>
-        <HomeHowWeEarn />
       </ScrollFadeIn>
 
       <MobileBottomNav />

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -121,6 +121,45 @@ const advisorsMegaMenu: { title: string; items: { label: string; href: string; d
   },
 ];
 
+const toolsMegaMenu: { title: string; items: { label: string; href: string; desc: string }[] }[] = [
+  {
+    title: "Calculators",
+    items: [
+      { label: "Franking Credits", href: "/dividends/calculator", desc: "Calculate ASX dividend franking" },
+      { label: "Negative Gearing", href: "/negative-gearing", desc: "Property tax-loss modelling" },
+      { label: "Lump-Sum Investing", href: "/lump-sum-investing", desc: "Lump-sum vs DCA, modelled" },
+      { label: "All Calculators", href: "/calculators", desc: "Browse 20+ financial calculators" },
+    ],
+  },
+  {
+    title: "SMSF",
+    items: [
+      { label: "SMSF Setup", href: "/smsf/setup", desc: "Step-by-step setup guide" },
+      { label: "SMSF Crypto", href: "/smsf/crypto", desc: "Holding crypto in super" },
+      { label: "SMSF Property", href: "/smsf/property", desc: "Property in your SMSF" },
+      { label: "SMSF Cost Calculator", href: "/smsf-calculator", desc: "Setup + ongoing cost estimate" },
+    ],
+  },
+  {
+    title: "Business",
+    items: [
+      { label: "Sell a Business", href: "/sell-business", desc: "Valuation, broker, CGT" },
+      { label: "Business Valuation", href: "/sell-business/valuation", desc: "Free valuation tool" },
+      { label: "Visa & Migration", href: "/visa-investment", desc: "Investor & business visas" },
+      { label: "Dividend Hub", href: "/dividends", desc: "Franking, ASX yield & ETFs" },
+    ],
+  },
+  {
+    title: "Grants & Programs",
+    items: [
+      { label: "Grants Hub", href: "/grants", desc: "All Australian business grants" },
+      { label: "R&D Tax Incentive", href: "/grants/rd-tax-incentive", desc: "Up to 43.5% refundable" },
+      { label: "EMDG Export Grant", href: "/grants/emdg", desc: "Export market development" },
+      { label: "Industry Growth Program", href: "/grants/industry-growth-program", desc: "Up to $50M co-investment" },
+    ],
+  },
+];
+
 const platformsDropdown = [
   { label: "Compare Platforms", href: "/compare", desc: "Side-by-side comparison tool" },
   { label: `Best Platforms ${CURRENT_YEAR}`, href: "/best", desc: "Top picks by category" },
@@ -453,6 +492,88 @@ function AdvisorsMegaDropdown({ isActive }: { isActive: boolean }) {
   );
 }
 
+/**
+ * Tools mega dropdown — surfaces calculators, SMSF, business and grants
+ * tools that previously only existed in the mobile drawer. Mirrors the
+ * Invest / Advisors mega dropdown structure: four columns + a Learn rail.
+ */
+function ToolsMegaDropdown({ isActive }: { isActive: boolean }) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const timeout = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const enter = () => { clearTimeout(timeout.current); setOpen(true); };
+  const leave = () => { timeout.current = setTimeout(() => setOpen(false), 150); };
+
+  useEffect(() => {
+    return () => clearTimeout(timeout.current);
+  }, []);
+
+  return (
+    <div ref={ref} className="relative" onMouseEnter={enter} onMouseLeave={leave}>
+      <button
+        onClick={() => setOpen(!open)}
+        className={`px-4 py-2 text-slate-600 hover:text-slate-900 hover:bg-slate-50 font-bold rounded-lg transition-colors flex items-center gap-1 text-sm focus:outline-none focus:ring-2 focus:ring-blue-700/40 ${
+          isActive ? "text-slate-900 bg-slate-50" : ""
+        }`}
+        aria-haspopup="true"
+        aria-expanded={open}
+      >
+        Tools
+        <Icon name="chevron-down" size={14} className={`text-slate-400 transition-transform ${open ? "rotate-180" : ""}`} aria-hidden="true" />
+      </button>
+      {open && (
+        <div className="absolute top-full left-1/2 -translate-x-1/2 pt-2 z-50">
+          <div className="bg-white rounded-xl border border-slate-200 shadow-xl p-5 flex gap-6" style={{ width: "860px" }}>
+            {toolsMegaMenu.map((col) => (
+              <div key={col.title} className="flex-1 min-w-0">
+                <p className="text-[0.65rem] font-extrabold uppercase tracking-wider text-amber-500 mb-2 px-2">{col.title}</p>
+                <div className="space-y-0.5">
+                  {col.items.map((item) => (
+                    <Link
+                      key={item.href}
+                      href={item.href}
+                      onClick={() => setOpen(false)}
+                      className="block px-2 py-1.5 rounded-lg hover:bg-slate-50 transition-colors group"
+                    >
+                      <div className="text-sm font-bold text-slate-900 group-hover:text-amber-600 transition-colors">{item.label}</div>
+                      <div className="text-[0.68rem] text-slate-400 leading-tight">{item.desc}</div>
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            ))}
+            <div className="border-l border-slate-100 pl-5 flex flex-col justify-between" style={{ minWidth: "140px" }}>
+              <div>
+                <p className="text-[0.65rem] font-extrabold uppercase tracking-wider text-amber-500 mb-2">Learn</p>
+                <Link href="/learn" onClick={() => setOpen(false)} className="block text-sm font-bold text-slate-900 hover:text-amber-600 py-1 transition-colors">
+                  Learn to Invest
+                </Link>
+                <Link href="/articles" onClick={() => setOpen(false)} className="block text-sm font-bold text-slate-900 hover:text-amber-600 py-1 transition-colors">
+                  Articles &amp; Guides
+                </Link>
+                <Link href="/how-to" onClick={() => setOpen(false)} className="block text-sm font-bold text-slate-900 hover:text-amber-600 py-1 transition-colors">
+                  How-To Guides
+                </Link>
+                <Link href="/glossary" onClick={() => setOpen(false)} className="block text-sm font-bold text-slate-900 hover:text-amber-600 py-1 transition-colors">
+                  Glossary
+                </Link>
+              </div>
+              <Link
+                href="/calculators"
+                onClick={() => setOpen(false)}
+                className="mt-3 flex items-center gap-1.5 bg-amber-500 hover:bg-amber-400 text-slate-900 font-bold text-xs px-3 py-2 rounded-lg transition-colors"
+              >
+                All tools <Icon name="arrow-right" size={12} aria-hidden="true" />
+              </Link>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
 function DesktopDropdown({
   label,
   items,
@@ -532,6 +653,21 @@ export default function Header() {
     pathname.startsWith("/for-advisors");
   const isForeignActive = pathname === "/foreign-investment" || pathname.startsWith("/foreign-investment/");
   const isInvestActive = pathname === "/invest" || pathname.startsWith("/invest/");
+  const isToolsActive = [
+    "/calculators",
+    "/dividends",
+    "/negative-gearing",
+    "/lump-sum-investing",
+    "/smsf",
+    "/smsf-calculator",
+    "/sell-business",
+    "/visa-investment",
+    "/grants",
+    "/learn",
+    "/articles",
+    "/how-to",
+    "/glossary",
+  ].some((p) => pathname === p || pathname.startsWith(p + "/"));
 
   return (
     <header className="bg-white/95 backdrop-blur-md border-b border-slate-200 sticky top-0 z-50 shadow-[0_2px_20px_rgb(0,0,0,0.02)] transition-all duration-300">
@@ -551,6 +687,7 @@ export default function Header() {
             <AdvisorsMegaDropdown isActive={isAdvisorsActive} />
             <div className="h-6 w-px bg-slate-200 mx-2" />
             <DesktopDropdown label="Compare Platforms" items={platformsDropdown} isActive={isPlatformsActive} />
+            <ToolsMegaDropdown isActive={isToolsActive} />
             <div className="h-6 w-px bg-slate-200 mx-2" />
             <DesktopDropdown label="Investing from Abroad" items={foreignDropdown} isActive={isForeignActive} />
           </nav>

--- a/components/HomeRouteCards.tsx
+++ b/components/HomeRouteCards.tsx
@@ -1,70 +1,271 @@
 import Link from "next/link";
+import Image from "next/image";
 import { DesignIcon } from "@/components/design/DesignIcon";
+
+type PreviewBroker = {
+  name: string;
+  asx_fee: string | null;
+};
+
+type PreviewListing = {
+  id: number | string;
+  title: string;
+  image: string | null;
+};
+
+type PreviewAdvisor = {
+  name: string;
+  photo_url: string | null;
+};
 
 interface RouteCardsProps {
   brokerCount: number;
   listingCount: number;
   professionalCount: number;
+  topBrokers: ReadonlyArray<PreviewBroker>;
+  topListings: ReadonlyArray<PreviewListing>;
+  topAdvisors: ReadonlyArray<PreviewAdvisor>;
 }
+
+type RouteKind = "compare" | "browse" | "find" | "matched";
 
 export default function HomeRouteCards({
   brokerCount,
   listingCount,
   professionalCount,
+  topBrokers,
+  topListings,
+  topAdvisors,
 }: RouteCardsProps) {
   const routes: ReadonlyArray<{
+    kind: RouteKind;
     title: string;
     cta: string;
     href: string;
     icon: string;
     accent: string;
-    examples: string;
     audience: string;
     badge: string;
     featured?: boolean;
   }> = [
     {
+      kind: "compare",
       title: "Compare platforms",
       cta: "Compare",
       href: "/compare",
       icon: "trending-down",
       accent: "#2563eb",
-      examples: "Brokers · Super · Crypto · Savings",
       audience: "If you know what you want",
       badge: `${brokerCount || 0} platforms`,
     },
     {
+      kind: "browse",
       title: "Browse listings",
       cta: "Browse",
       href: "/invest",
       icon: "map-pin",
       accent: "#059669",
-      examples: "Property · Businesses · Farmland · Funds",
       audience: "If you want real opportunities",
       badge: `${listingCount || 0} listed`,
     },
     {
+      kind: "find",
       title: "Find an expert",
       cta: "Find",
       href: "/advisors",
       icon: "users",
       accent: "#7c3aed",
-      examples: "Advisers · Mortgage · Tax · SMSF",
       audience: "If you need a pro",
       badge: `${professionalCount.toLocaleString("en-AU")} verified`,
     },
     {
+      kind: "matched",
       title: "Get matched",
       cta: "Get matched",
       href: "/quiz",
       icon: "sparkles",
       accent: "#f25822",
-      examples: "60 seconds · 4 quick questions",
       audience: "If you're not sure where to start",
       badge: "Free · no email",
       featured: true,
     },
   ];
+
+  const previewBrokers = topBrokers.slice(0, 3);
+  const previewListings = topListings.filter((l) => l.image).slice(0, 3);
+  const previewAdvisors = topAdvisors.filter((a) => a.photo_url).slice(0, 5);
+
+  function renderPreview(kind: RouteKind, featured: boolean) {
+    if (kind === "compare") {
+      if (previewBrokers.length === 0) return null;
+      return (
+        <div style={{ display: "flex", flexDirection: "column", gap: 4, marginBottom: 14 }}>
+          {previewBrokers.map((b) => (
+            <div
+              key={b.name}
+              className="font-mono"
+              style={{
+                fontSize: 11,
+                display: "flex",
+                justifyContent: "space-between",
+                gap: 8,
+                color: "var(--color-ink-700)",
+                background: "color-mix(in oklch, #2563eb 4%, white)",
+                border: "1px solid color-mix(in oklch, #2563eb 12%, transparent)",
+                borderRadius: 6,
+                padding: "5px 8px",
+              }}
+            >
+              <span style={{ fontWeight: 700, color: "var(--color-ink-900)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                {b.name}
+              </span>
+              <span style={{ color: "#2563eb", fontWeight: 800, flexShrink: 0 }}>
+                {b.asx_fee ?? "—"}
+              </span>
+            </div>
+          ))}
+        </div>
+      );
+    }
+
+    if (kind === "browse") {
+      if (previewListings.length === 0) return null;
+      return (
+        <div style={{ display: "flex", gap: 6, marginBottom: 14 }}>
+          {previewListings.map((l) => (
+            <div
+              key={l.id}
+              aria-hidden
+              style={{
+                position: "relative",
+                width: 64,
+                height: 48,
+                borderRadius: 6,
+                overflow: "hidden",
+                border: "1px solid color-mix(in oklch, #059669 18%, transparent)",
+                background: "color-mix(in oklch, #059669 6%, white)",
+                flexShrink: 0,
+              }}
+            >
+              {l.image ? (
+                <Image
+                  src={l.image}
+                  alt=""
+                  fill
+                  sizes="64px"
+                  style={{ objectFit: "cover" }}
+                  unoptimized
+                />
+              ) : null}
+            </div>
+          ))}
+        </div>
+      );
+    }
+
+    if (kind === "find") {
+      if (previewAdvisors.length === 0) return null;
+      const overflow = Math.max(0, professionalCount - previewAdvisors.length);
+      return (
+        <div style={{ display: "flex", alignItems: "center", marginBottom: 14 }}>
+          <div style={{ display: "flex" }}>
+            {previewAdvisors.map((a, i) => (
+              <div
+                key={a.name + i}
+                aria-hidden
+                style={{
+                  position: "relative",
+                  width: 32,
+                  height: 32,
+                  borderRadius: 99,
+                  overflow: "hidden",
+                  border: "2px solid white",
+                  marginLeft: i === 0 ? 0 : -8,
+                  background: "color-mix(in oklch, #7c3aed 14%, white)",
+                  zIndex: previewAdvisors.length - i,
+                  flexShrink: 0,
+                }}
+              >
+                {a.photo_url ? (
+                  <Image
+                    src={a.photo_url}
+                    alt=""
+                    fill
+                    sizes="32px"
+                    style={{ objectFit: "cover" }}
+                    unoptimized
+                  />
+                ) : null}
+              </div>
+            ))}
+          </div>
+          {overflow > 0 && (
+            <span
+              className="font-mono"
+              style={{
+                fontSize: 11,
+                fontWeight: 800,
+                color: "#7c3aed",
+                background: "color-mix(in oklch, #7c3aed 10%, white)",
+                border: "1px solid color-mix(in oklch, #7c3aed 24%, transparent)",
+                padding: "3px 8px",
+                borderRadius: 99,
+                marginLeft: 8,
+              }}
+            >
+              +{overflow.toLocaleString("en-AU")} more
+            </span>
+          )}
+        </div>
+      );
+    }
+
+    if (kind === "matched") {
+      return (
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 10,
+            marginBottom: 14,
+          }}
+        >
+          <div style={{ display: "flex", gap: 6 }}>
+            {[0, 1, 2, 3].map((i) => (
+              <span
+                key={i}
+                aria-hidden
+                className="route-pulse-dot"
+                style={{
+                  width: 10,
+                  height: 10,
+                  borderRadius: 99,
+                  background: featured ? "rgba(255,255,255,.95)" : "currentColor",
+                  display: "inline-block",
+                  animationDelay: `${i * 0.18}s`,
+                }}
+              />
+            ))}
+          </div>
+          <span
+            className="font-mono"
+            style={{
+              fontSize: 11,
+              fontWeight: 700,
+              color: featured ? "rgba(255,255,255,.78)" : "var(--color-ink-600)",
+              letterSpacing: ".01em",
+            }}
+          >
+            4 quick questions
+          </span>
+        </div>
+      );
+    }
+
+    return null;
+  }
+
+  const totalCovered = brokerCount + listingCount + professionalCount;
 
   return (
     <section
@@ -106,7 +307,7 @@ export default function HomeRouteCards({
               borderRadius: 16,
               overflow: "hidden",
               textDecoration: "none",
-              minHeight: 320,
+              minHeight: 360,
               boxShadow: r.featured
                 ? `0 14px 36px color-mix(in oklch, ${r.accent} 28%, transparent)`
                 : "0 1px 2px rgba(11,20,34,.04)",
@@ -164,26 +365,14 @@ export default function HomeRouteCards({
                   fontWeight: 800,
                   lineHeight: 1.1,
                   letterSpacing: "-.022em",
-                  marginBottom: 8,
+                  marginBottom: 12,
                   color: r.featured ? "white" : "var(--color-ink-900)",
                 }}
               >
                 {r.title}
               </div>
 
-              <div
-                className="font-mono"
-                style={{
-                  fontSize: 11.5,
-                  fontWeight: 700,
-                  color: r.featured ? "rgba(255,255,255,.78)" : "var(--color-ink-600)",
-                  letterSpacing: ".01em",
-                  marginBottom: 14,
-                  lineHeight: 1.45,
-                }}
-              >
-                {r.examples}
-              </div>
+              {renderPreview(r.kind, !!r.featured)}
 
               <div style={{ marginBottom: 14 }}>
                 <span
@@ -244,12 +433,78 @@ export default function HomeRouteCards({
         ))}
       </div>
 
+      <div
+        style={{
+          marginTop: 18,
+          padding: "12px 18px",
+          background: "var(--color-sand-50)",
+          border: "1px solid #e5e7eb",
+          borderRadius: 10,
+          display: "flex",
+          flexWrap: "wrap",
+          gap: "10px 18px",
+          alignItems: "center",
+          justifyContent: "space-between",
+        }}
+      >
+        <div
+          className="font-mono"
+          style={{
+            fontSize: 11.5,
+            fontWeight: 700,
+            color: "var(--color-ink-500)",
+            letterSpacing: ".02em",
+            display: "flex",
+            flexWrap: "wrap",
+            gap: "4px 14px",
+            alignItems: "center",
+          }}
+        >
+          <span aria-hidden style={{ width: 6, height: 6, borderRadius: 99, background: "#10b981", display: "inline-block" }} />
+          <span>Updated weekly</span>
+          <span aria-hidden>·</span>
+          <span>{brokerCount.toLocaleString("en-AU")} platforms tracked</span>
+          <span aria-hidden>·</span>
+          <span>{listingCount.toLocaleString("en-AU")} live listings</span>
+          <span aria-hidden>·</span>
+          <span>{professionalCount.toLocaleString("en-AU")} verified experts</span>
+          <span aria-hidden>·</span>
+          <span>ASIC-registered</span>
+        </div>
+        <Link
+          href="/methodology"
+          className="font-mono"
+          style={{
+            fontSize: 11.5,
+            fontWeight: 800,
+            color: "var(--color-ink-700)",
+            textDecoration: "none",
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 4,
+            whiteSpace: "nowrap",
+          }}
+        >
+          How we rank ({totalCovered.toLocaleString("en-AU")} entries) <DesignIcon name="arrow-right" size={11} strokeWidth={2.4} />
+        </Link>
+      </div>
+
       <style>{`
         @media (max-width: 1024px) {
           .home-routes-grid { grid-template-columns: repeat(2, 1fr) !important; }
         }
         @media (max-width: 640px) {
           .home-routes-grid { grid-template-columns: 1fr !important; }
+        }
+        @keyframes routePulse {
+          0%, 100% { opacity: 0.35; transform: scale(0.85); }
+          50% { opacity: 1; transform: scale(1); }
+        }
+        .route-pulse-dot {
+          animation: routePulse 1.4s ease-in-out infinite;
+        }
+        @media (prefers-reduced-motion: reduce) {
+          .route-pulse-dot { animation: none; opacity: 0.85; }
         }
       `}</style>
     </section>


### PR DESCRIPTION
## Summary

This is the second commit from the original v6 PR (#384) which got auto-merged before this work landed. Reopening as its own PR since #384 is closed.

**Three changes:**

1. **Real-preview route cards** — each card now shows what's inside, not just an icon:
   - Compare → 3 mini fee rows pulled from the live brokers table (real platform names + asx_fee strings)
   - Browse → 3 listing thumbnails using the actual curated images
   - Find an expert → 5 overlapping verified-advisor avatar photos with a "+N more" pill from live total
   - Get matched → 4 staggered-pulse progress dots (CSS keyframes; \`prefers-reduced-motion\` respected) + "4 quick questions" caption

   Below the grid: a thin research strip — *Updated weekly · {N} platforms · {M} listings · {K} verified experts · ASIC-registered* + methodology link.

2. **Tools mega dropdown** added to desktop nav. Surfaces 16 utilities that previously only existed in the mobile drawer: Calculators / SMSF / Business / Grants & Programs columns + a Learn rail (Articles, How-To, Glossary) with an "All tools" CTA.

3. **HomeHowWeEarn lifted** above HomeCompareDeepDive — the revenue/incentive transparency band now runs *before* the first commercial comparison surface, instead of being buried at the bottom.

## Depends on

PR #392 (\`fix(test+types)\` rescue) — until that lands on main, the listings tests in this PR's CI will fail. Once #392 is in main and this is rebased, CI should go green.

## Test plan

- [x] Type-check passes locally
- [x] Lint passes locally
- [x] Dev-server smoke test (curl + grep'd for new audience tags, "Updated weekly" strip, route-pulse-dot CSS, Tools nav presence)
- [ ] Vercel preview renders cleanly
- [ ] CI green after #392 merges and this rebases

🤖 Generated with [Claude Code](https://claude.com/claude-code)