### PR TITLE
fix(o): O-03 — pin search_path on refresh_advisor_cohort_metrics() SECURITY DEFINER [audit remediation]

### DIFF
--- a/supabase/migrations/20260501_o03_refresh_advisor_cohort_metrics_search_path.sql
+++ b/supabase/migrations/20260501_o03_refresh_advisor_cohort_metrics_search_path.sql
@@ -1,0 +1,38 @@
+-- Date: 2026-05-01
+-- Audit ref: docs/audits/codebase-health-2026-04-24.md §O
+-- Queue item: O-03
+-- Why: refresh_advisor_cohort_metrics() is declared SECURITY DEFINER without a pinned
+--      search_path. An attacker who can create objects in a schema that appears before
+--      'public' in the caller's search_path could shadow built-ins or table names,
+--      causing the SECURITY DEFINER body to execute under elevated privilege using
+--      attacker-supplied objects. Pinning search_path = public, pg_catalog closes
+--      that injection vector.
+-- Idempotency: CREATE OR REPLACE FUNCTION is idempotent — re-running simply
+--              overwrites the function definition with identical content. No-op on
+--              subsequent applies.
+-- Rollback (restores pre-patch definition — removes SET search_path):
+--   CREATE OR REPLACE FUNCTION public.refresh_advisor_cohort_metrics()
+--    RETURNS void LANGUAGE plpgsql SECURITY DEFINER
+--   AS $function$
+--   BEGIN
+--     REFRESH MATERIALIZED VIEW public.advisor_cohort_metrics;
+--   END;
+--   $function$;
+--
+-- Callers verified: lib/job-queue.ts:161 (service-role RPC, admin context only).
+-- No anon-key callers; function is never exposed to unauthenticated paths.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.refresh_advisor_cohort_metrics()
+  RETURNS void
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path = public, pg_catalog
+AS $function$
+BEGIN
+  REFRESH MATERIALIZED VIEW public.advisor_cohort_metrics;
+END;
+$function$;
+
+COMMIT;


### PR DESCRIPTION
## Summary

Closes audit item O-03: `refresh_advisor_cohort_metrics()` was declared `SECURITY DEFINER` without a pinned `search_path`, leaving it vulnerable to search-path injection (CWE-89/CWE-20 for PostgreSQL SECURITY DEFINER functions).

**Fix:** adds `SET search_path = public, pg_catalog` to the function definition via an idempotent `CREATE OR REPLACE FUNCTION` migration.

## What changed

- `supabase/migrations/20260501_o03_refresh_advisor_cohort_metrics_search_path.sql` — patches the function in-place; `CREATE OR REPLACE` is a no-op on re-apply.

## Verified callers

- `lib/job-queue.ts:161` — service-role RPC, admin/cron context only. No anon-key paths reach this function.

## Rollback

Rollback SQL is in the migration header comment. One-line `CREATE OR REPLACE FUNCTION` restoring the pre-patch definition.

## Checklist

- [x] Migration is idempotent (`CREATE OR REPLACE FUNCTION`)
- [x] Rollback SQL in migration header
- [x] No anon-key callers — service-role only
- [x] Conventional Commits subject, scope `o`

Refs: #216
Audit: docs/audits/codebase-health-2026-04-24.md §O
Queue: O-03

---
_Generated by [Claude Code](https://claude.ai/code/session_014taNyAgVBfRnKYQ6wgtQ9Z)_