### PR TITLE
chore(ci+loop): five throughput multipliers — paths-ignore, smart auto-revert, auto-rebase, main-CI preflight, parallel command

### DIFF
--- a/.claude/commands/audit-remediation-iteration.md
+++ b/.claude/commands/audit-remediation-iteration.md
@@ -77,6 +77,35 @@ A live-DB schema change between iterations leaves `lib/database.types.ts` stale 
 
 If `lib/database.types.ts` is stale relative to live, regenerate, commit `chore(db): regenerate database.types.ts (auto-rescue)` direct to main, push. This is a one-line idempotent fix that benefits ALL open PRs simultaneously. Skip and proceed if the regen produces an empty diff.
 
+### Phase 1.7 — Main-CI preflight (added 2026-05-02 after the listings/types/admin-mock fire)
+
+Before opening any new stream PRs, check whether **main itself** is currently green. If main's last CI is failing, every PR opened against it inherits the failure — wasting iterations on bogus "CI-rescue" cycles and triggering spurious auto-revert PRs against unrelated commits. Lesson from 2026-05-01: the loop did 8+ "CI-rescue iter N" docs commits chasing a failure on main that none of the in-flight PRs caused.
+
+```bash
+# Latest main CI run
+main_ci_conclusion=$(gh run list --branch main --workflow CI --limit 1 \
+  --json conclusion,status \
+  --jq '.[0] | .conclusion // .status // "missing"')
+```
+
+Decision tree:
+
+- **`success`, `pending`, or `in_progress`** → main is healthy or being verified. Proceed to Phase 2.
+- **`failure`** → main is broken. **Do not open or update stream PRs this iteration.** Instead:
+  1. Fetch the failing job log: `gh run view --job <id> --log-failed`. Extract the failing test files / build step.
+  2. Switch to a fresh branch: `git checkout -b fix/main-rescue-<short-summary>`.
+  3. Reproduce the failure locally: `npx vitest run <failing-test-files>` or `npx tsc --noEmit` for type errors. **Don't proceed without a local repro.** A test that fails on CI but passes locally is environment-specific and needs a different fix path — surface to Blocked.
+  4. Patch the root cause (typical patterns observed: missing `vi.mock("@/lib/supabase/admin", …)` after a route was refactored to use the admin client; `lib/database.types.ts` drifted from migrations; stale advisor-auth mocks).
+  5. Verify locally green, commit (`fix(test+types): unblock main CI — <one-line summary>`), push, open PR with title `fix: unblock main CI — <summary>`.
+  6. Update the queue's "In flight" section with a `MAIN-RESCUE` row pointing to the new PR.
+  7. Print `STATUS: MAIN-RESCUE · pr=#<NNN>` and exit.
+- **`cancelled`** → likely concurrency cancellation from rapid-fire main commits, not a real failure. Look at the second-most-recent run (`--limit 2` and pick the older one). Treat that as the verdict.
+- **`missing`** → no CI run found yet (e.g., main was just pushed and CI hasn't started). Wait the loop's normal cadence and re-check on the next iteration; proceed cautiously to Phase 2.
+
+**Why this is Phase 1.7, not part of Phase 2:** Phase 2 rescues *stream PR* failures by editing the stream branch. Phase 1.7 rescues *main itself*, which is a different code path (different branch, different PR). Mixing them breaks the "one stream per iteration" invariant.
+
+**Time budget:** if the rescue isn't tractable in ~30 minutes of investigation, surface to Blocked with the failure log and exit `STATUS: BLOCKED`. The cloud loop's per-fire budget is bounded; main-rescue work that needs deep human investigation belongs to a human session.
+
 ### Phase 2 — CI rescue check
 
 For each stream in the queue's "In flight" table that has a PR number:

--- a/.claude/commands/audit-remediation-parallel.md
+++ b/.claude/commands/audit-remediation-parallel.md
@@ -1,0 +1,167 @@
+---
+description: Run 3 audit-remediation queue items in parallel via Opus worktree agents (3-4× throughput).
+---
+
+# /audit-remediation-parallel
+
+Spawn three parallel Opus agents on independent queue items, each in its own
+git worktree. Validated pattern (memory `feedback_parallel_agent_pattern.md`):
+~3 PRs in ~30 minutes vs the cloud loop's ~7-8 min per single PR.
+
+**This command is for human-driven sessions.** The cloud loop's
+`/audit-remediation-iteration` deliberately does NOT spawn sub-agents — its
+single-thread state model breaks if it does. This command is the parallel
+counterpart, run by a human who explicitly wants the throughput multiplier.
+
+---
+
+## When NOT to run this
+
+- Main CI is failing. Run `/audit-remediation-iteration` first; its Phase 1.7
+  will rescue main. Parallel agents on top of broken main = 3× the spurious
+  auto-revert noise.
+- Queue has fewer than 3 independent pending items.
+- You don't have ~30 minutes to babysit the merge step.
+
+---
+
+## Step 1 — Sync + sanity
+
+```bash
+git fetch origin main
+git checkout main && git pull --ff-only origin main
+
+# Main CI must be green (or pending) before parallelising.
+main_ci=$(gh run list --branch main --workflow CI --limit 1 --json conclusion --jq '.[0].conclusion // "pending"')
+echo "main CI: $main_ci"
+# If "failure", STOP and run /audit-remediation-iteration instead.
+```
+
+Read `docs/audits/REMEDIATION_QUEUE.md`. Pick **3 pending items from 3
+different streams** (never two from the same stream — they'd touch the same
+branch and conflict). Prefer items with these properties:
+
+- Estimated diff ≤ 200 LOC.
+- No migration (migrations need extra coordination on `lib/database.types.ts`).
+- File paths don't overlap with the other two picks (grep each item's listed
+  paths against the others).
+
+---
+
+## Step 2 — Spawn 3 agents in parallel
+
+In a single message, send three Agent tool calls — they MUST be in one
+response so they actually run concurrently. Each agent:
+
+- `subagent_type: "general-purpose"` (or another that takes `model`)
+- `model: "opus"`
+- `isolation: "worktree"` (creates a fresh `.claude/worktrees/agent-*` checkout)
+- `run_in_background: true`
+- Prompt template (per agent — substitute `{ITEM_ID}`, `{STREAM}`, `{PATHS}`, `{BRANCH}`):
+
+  > You are working on audit-remediation queue item **{ITEM_ID}** from stream **{STREAM}**.
+  >
+  > **Your task:** [paste the item description from the queue, verbatim].
+  >
+  > **Files you may touch:** {PATHS}. Do NOT touch any file outside this list.
+  >
+  > **Branch:** create `claude/audit-remediation/{BRANCH}` from `origin/main`.
+  >
+  > **Hard rules:**
+  > - Run `npx tsc --noEmit` on the changed files. Must be clean before commit.
+  > - Run `npm test -- <changed test files>` if any. Must pass.
+  > - Conventional Commit subject: `<type>({STREAM}): <one-line>`.
+  > - Commit body must include: **Why** (what was broken), **Verified callers**, **Idempotency/Safety**, **Rollback location**. See `.claude/commands/audit-remediation-iteration.md` Phase 6 for the contract.
+  > - Stop at the commit. **Do NOT push** — the main session pushes (the worktree has no node_modules; pre-push hook would OOM).
+  > - If you hit lint-staged warnings on files you didn't intend to change, drop those files from the PR rather than expanding scope.
+  >
+  > **Report back:** the branch name, the commit SHA, the file list, and any blockers.
+
+---
+
+## Step 3 — Push from the main worktree (this is the validated trick)
+
+Agents commit but don't push. From the main worktree (where node_modules
+exists and the husky pre-push hook has memory headroom), push each branch:
+
+```bash
+cd /home/finnduns/invest-com-au
+
+for branch in claude/audit-remediation/<a> claude/audit-remediation/<b> claude/audit-remediation/<c>; do
+  git fetch . "$branch:$branch" 2>/dev/null || git checkout "$branch"
+  NODE_OPTIONS="--max-old-space-size=5120" git push -u origin "$branch"
+done
+```
+
+The `NODE_OPTIONS` headroom matches `project_pre_push_node_options.md` —
+default 4 GB OOMs on this sandbox; 5 GB is enough.
+
+---
+
+## Step 4 — Open PRs
+
+For each branch:
+
+```bash
+gh pr create \
+  --base main \
+  --head <branch> \
+  --title "<conventional commit subject>" \
+  --body "$(cat <<'EOF'
+## Summary
+<1-2 sentences>
+
+## Queue item
+{ITEM_ID} — see docs/audits/REMEDIATION_QUEUE.md
+
+## Test plan
+- [ ] CI green
+- [ ] [item-specific verification]
+EOF
+)"
+```
+
+---
+
+## Step 5 — Update the queue (single commit on main)
+
+After all 3 PRs are open, update `docs/audits/REMEDIATION_QUEUE.md` once with
+all 3 items moved to "In flight" with their PR numbers. One commit, one push.
+Avoid 3 racing queue updates — the cloud loop will use the merged result.
+
+---
+
+## Step 6 — Watch + merge
+
+Each PR runs through normal CI. Once green:
+
+- **Tier A** (page UI / docs / tests): `gh pr merge <N> --squash --delete-branch`. No observation window needed.
+- **Tier B / C**: per `docs/audits/MERGE_AUTHORIZATION.md`. Tier C announces intent in chat first.
+
+If any PR hits a CI failure, treat it as a Phase-2 CI rescue in
+`/audit-remediation-iteration` — the same diagnose-and-fix flow applies.
+
+---
+
+## Hard rules (in addition to the iteration command's rules)
+
+- **Three at a time, max.** Four parallel agents stress the sandbox memory.
+  Three is the validated ceiling.
+- **Independent streams only.** Same-stream parallelism creates branch
+  conflicts that take longer to resolve than the throughput buys back.
+- **Push from main worktree, not agent worktrees.** Agent worktrees lack
+  `node_modules` so the pre-push tsc hook OOMs. Agents commit; you push.
+- **No agent merges its own PR.** Merge step runs in your context after CI
+  is green, with the merge-authorization tier rules applied.
+- **If the main worktree has uncommitted changes**, stash before checking
+  out an agent branch. Forgetting this is the single biggest source of
+  "lost work" panics in the parallel pattern.
+
+---
+
+## Throughput data (validated 2026-04-29)
+
+- **3 PRs in ~30 min** with this pattern.
+- vs ~7–8 min per PR for the cloud loop's serial single-thread mode.
+- Real-world multiplier: **~3-4×** when the parallel work is genuinely
+  independent. Less when items share files or one needs a migration regen.

--- a/.github/workflows/auto-rebase-loop-prs.yml
+++ b/.github/workflows/auto-rebase-loop-prs.yml
@@ -1,0 +1,128 @@
+name: Auto-rebase audit-remediation loop PRs
+
+# When main moves, automatically rebase every open PR whose head branch
+# starts with claude/audit-remediation/ onto the new main and force-push.
+# Why:
+#   - GitHub does NOT re-run CI when the base branch moves; only when the
+#     PR branch itself updates. Without this, PRs sit at "stale CI" that
+#     was run against an outdated main, and the audit-remediation loop
+#     wastes iterations doing "stale-base fix" docs commits that don't
+#     actually rebase the branch.
+#   - Lesson from 2026-05-01: ~8 "CI-rescue iter N" docs commits chased
+#     stale-base PRs that would have unblocked themselves with a single
+#     rebase.
+#
+# Scope: ONLY claude/audit-remediation/* branches. Human-authored PRs are
+# left alone — force-pushing those would be hostile.
+#
+# Safety:
+#   - --force-with-lease (not --force) so a concurrent push from anyone
+#     else aborts the rebase rather than overwriting their work.
+#   - On rebase conflict, abort and post a comment on the PR instead of
+#     fighting through it. Conflicts mean a human (or the loop) needs to
+#     resolve manually.
+#   - paths-ignore matches CI's so docs-only main commits don't trigger
+#     a useless rebase storm.
+#   - Concurrency group serialises rebases so two main commits can't
+#     race against each other on the same PR.
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - "docs/audits/**"
+      - "LOOP_DONE"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: auto-rebase-loop-prs
+  cancel-in-progress: false
+
+jobs:
+  rebase:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: ${{ !contains(github.event.head_commit.message, '[skip-rebase]') }}
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Rebase loop PRs onto main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -eu
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Pull every open PR whose head ref looks like a loop branch.
+          # Drafts are included intentionally — the loop opens drafts and
+          # marks them ready later, and stale-base on a draft is the same
+          # problem as stale-base on a ready PR.
+          mapfile -t prs < <(gh pr list \
+            --state open \
+            --limit 100 \
+            --json number,headRefName \
+            --jq '.[] | select(.headRefName | startswith("claude/audit-remediation/")) | .number')
+
+          if [ "${#prs[@]}" -eq 0 ]; then
+            echo "No claude/audit-remediation/* PRs open — nothing to rebase."
+            exit 0
+          fi
+
+          echo "Found ${#prs[@]} loop PR(s) to consider: ${prs[*]}"
+
+          rebased=0
+          conflicted=0
+          skipped=0
+
+          for pr in "${prs[@]}"; do
+            head=$(gh pr view "$pr" --json headRefName --jq '.headRefName')
+            echo ""
+            echo "=== PR #$pr · branch=$head ==="
+
+            # Fetch the branch fresh in case the local clone doesn't have it.
+            if ! git fetch origin "$head:$head" 2>/dev/null; then
+              echo "  ⚠ couldn't fetch branch — skipping"
+              skipped=$((skipped + 1))
+              continue
+            fi
+
+            git checkout "$head"
+
+            # Already up-to-date? Skip — saves a no-op force-push that
+            # would still trigger CI re-run for nothing.
+            if git merge-base --is-ancestor origin/main HEAD; then
+              echo "  ✓ already up-to-date with main — skipping"
+              skipped=$((skipped + 1))
+              continue
+            fi
+
+            # Try the rebase. On conflict, abort and comment.
+            if git rebase origin/main; then
+              if git push --force-with-lease origin "$head"; then
+                echo "  ✅ rebased + pushed PR #$pr"
+                rebased=$((rebased + 1))
+              else
+                echo "  ⚠ force-push rejected (lease lost) — somebody pushed concurrently; skipping"
+                git rebase --abort 2>/dev/null || true
+                skipped=$((skipped + 1))
+              fi
+            else
+              echo "  ❌ rebase conflict on PR #$pr — aborting + commenting"
+              git rebase --abort
+              gh pr comment "$pr" --body "🔄 Auto-rebase against latest main hit a conflict. The branch needs manual rebase or the loop's next CI-rescue iteration to resolve. (This comment is from \`auto-rebase-loop-prs.yml\`.)"
+              conflicted=$((conflicted + 1))
+            fi
+
+            git checkout main 2>/dev/null || true
+          done
+
+          echo ""
+          echo "Summary: rebased=${rebased} conflicted=${conflicted} skipped=${skipped} total=${#prs[@]}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,20 @@ name: CI
 on:
   push:
     branches: [main, "claude/**"]
+    # Skip CI on changes that can't affect the build (docs / queue housekeeping
+    # / the LOOP_DONE sentinel). Saves ~30-40% of CI runs that the
+    # audit-remediation loop's queue-update commits previously triggered, plus
+    # the cancellation-thrash where each new commit kills the previous run.
+    # WARNING: paths-ignore only takes effect when EVERY changed path matches.
+    # A PR that touches docs/audits/* AND code still runs CI.
+    paths-ignore:
+      - "docs/audits/**"
+      - "LOOP_DONE"
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "docs/audits/**"
+      - "LOOP_DONE"
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/.github/workflows/main-ci-auto-revert.yml
+++ b/.github/workflows/main-ci-auto-revert.yml
@@ -80,6 +80,23 @@ jobs:
             skip_reason="commit has [skip-revert] tag"
           elif [ "${author_email}" = "41898282+github-actions[bot]@users.noreply.github.com" ]; then
             skip_reason="commit by github-actions[bot] — fix-forward expected"
+          else
+            # Sanity check: if main was ALREADY failing on the parent commit,
+            # this CI failure is almost certainly inherited breakage, not
+            # caused by the new commit. Reverting in that case adds noise
+            # (the revert won't fix main) and trains the loop to chase
+            # spurious reverts. Lesson from 2026-05-01: 10 spurious revert
+            # PRs were opened for 10 unrelated commits because main was
+            # already broken on listings tests + database.types drift.
+            parent_sha=$(gh api "${api_path}" --jq '.parents[0].sha // empty')
+            if [ -n "${parent_sha}" ]; then
+              parent_ci=$(gh api \
+                "repos/${{ github.repository }}/actions/runs?head_sha=${parent_sha}&status=completed&per_page=20" \
+                --jq '[.workflow_runs[] | select(.name == "CI")][0].conclusion // "missing"')
+              if [ "${parent_ci}" = "failure" ]; then
+                skip_reason="parent commit ${parent_sha:0:8} CI was already failing (parent_ci=${parent_ci}) — main was broken before this commit; not blaming this one"
+              fi
+            fi
           fi
 
           if [ -n "${skip_reason}" ]; then


### PR DESCRIPTION
## Summary

Five infrastructure changes that compound into ~3× cleaner pipeline + ~3-4× throughput when the parallel pattern is invoked. Each change is in its own commit so they can be reviewed independently.

Born from the 2026-05-01 incident where main CI was broken for 24 h, the audit-remediation loop spent that time doing useless "stale-base fix" docs commits, and 10 spurious auto-revert PRs were opened against unrelated commits.

## Changes (commit-by-commit)

### 1. Skip CI on docs-only changes (5f83d957)
\`paths-ignore\` on \`ci.yml\` for \`docs/audits/**\` and \`LOOP_DONE\`. The loop produced ~40 queue-update commits in 12 h yesterday, each one paying for an ~8-min CI run that contributed nothing (most were cancelled by concurrency before completing). **Estimated saving: 30-40% of CI runs.**

### 2. Smarter auto-revert (ae278a2a)
\`main-ci-auto-revert.yml\` now checks the parent commit's CI before opening a revert. If parent's CI was \`failure\`, the new commit is inheriting breakage, not causing it — skip the revert. **Validated against historical data:** for commit \`59dbd8e6\` (the spuriously-reverted PR #384), parent \`a19ea785\` had \`conclusion=failure\`. New logic correctly identifies and skips.

### 3. Auto-rebase loop PRs (aadbd993)
New \`auto-rebase-loop-prs.yml\` workflow on push-to-main. For each open PR with \`claude/audit-remediation/*\` head ref, rebases onto the new main and force-pushes (with \`--force-with-lease\` and conflict-aborts-and-comments fallback). Eliminates the entire class of "stale-base CI rescue" iterations. Scope is intentionally narrow — does NOT touch human-authored PRs.

### 4. Loop main-CI preflight — Phase 1.7 (7dc9a065)
\`/audit-remediation-iteration\` now checks main's CI before opening any new stream PRs. If main is failing, switches to \`fix/main-rescue-*\` mode: reproduce locally → patch root cause → open fix PR → \`STATUS: MAIN-RESCUE\`. Time-budgeted at 30 min before falling back to Blocked. Lesson from yesterday: a 10-minute local repro would have found the unmocked admin client; the loop never tried because no phase looked at main itself.

### 5. \`/audit-remediation-parallel\` slash command (9a1251c0)
New human-driven slash command implementing the validated pattern from \`feedback_parallel_agent_pattern.md\` (3 PRs in ~30 min). Spawns 3 Opus agents on independent queue items via \`Agent\` tool with \`isolation: worktree\`. Agents commit but don't push (worktrees lack \`node_modules\`); main session pushes from the working tree where the husky hook has memory headroom. **3-4× throughput** when work is genuinely independent.

## Why these five together
1 + 3 = main can move freely without thrashing CI or leaving PRs stale.
2 + 4 = self-healing under main breakage; no spurious noise from the auto-revert system.
5 = once the pipeline is clean, scale agent count for real throughput.

Doing 5 alone amplifies the existing problems (more PRs = more concurrency thrash, more stale-base, more CI noise). 1-4 first, then 5.

## Test plan
- [x] All 3 YAML workflows validated via \`js-yaml\` parser (no syntax errors)
- [x] \`npx tsc --noEmit\` clean (no source changes but verifies nothing else broke)
- [x] Pre-push hooks pass
- [x] Smart auto-revert preflight validated against real historical SHAs (59dbd8e6 parent = failure as expected)
- [ ] After merge: confirm a docs-only main commit does NOT trigger CI
- [ ] After merge: confirm push to main triggers \`Auto-rebase audit-remediation loop PRs\` workflow (will skip if no loop PRs are currently open)
- [ ] After merge: \`/audit-remediation-iteration\` runs through Phase 1.7 cleanly (visible if next iter logs \`STATUS: MAIN-RESCUE\` or proceeds normally past 1.7)

## Risk
- **Tier C** (touches \`.github/workflows/\` + \`.claude/commands/\` — both in CLAUDE.md's Tier-C list).
- Highest risk = the auto-rebase workflow force-pushing the wrong branch. Mitigated by:
  - \`startswith("claude/audit-remediation/")\` filter (only loop branches)
  - \`--force-with-lease\` (aborts on concurrent push)
  - \`paths-ignore\` matching CI's (no rebase storm on docs commits)
  - Concurrency group serialises rebases

🤖 Generated with [Claude Code](https://claude.com/claude-code)