### PR TITLE
feat(home): plain-English rewrite + 4-tile breadth

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,24 +17,24 @@ import { ORGANIZATION_JSONLD, SITE_URL } from "@/lib/seo";
 export const metadata = {
   title: {
     absolute:
-      "Compare Platforms, Browse Listings, Find Experts — Invest.com.au",
+      "Compare Investing Platforms, Browse Investments for Sale, Find Experts — Invest.com.au",
   },
   description:
-    "One place to compare platforms, browse investment listings, find experts, or get matched to the right next step. Independent. ASIC-registered. General information only.",
+    "Compare brokers, crypto, super and savings. Browse Australian investments for sale — businesses, farmland, mining, property. Find a verified expert, or get matched in 60 seconds. Independent. ASIC-registered. General information only.",
   openGraph: {
     title:
-      "Compare Platforms, Browse Listings, Find Experts — Invest.com.au",
+      "Compare Investing Platforms, Browse Investments for Sale, Find Experts — Invest.com.au",
     description:
-      "Compare platforms, browse listings, find experts, or get matched in 60 seconds.",
+      "Compare platforms, browse Australian investments for sale, find experts, or get matched in 60 seconds.",
     url: "/",
     images: [{ url: "/api/og", width: 1200, height: 630 }],
   },
   twitter: {
     card: "summary_large_image" as const,
     title:
-      "Compare Platforms, Browse Listings, Find Experts — Invest.com.au",
+      "Compare Investing Platforms, Browse Investments for Sale, Find Experts — Invest.com.au",
     description:
-      "Compare platforms, browse listings, find experts, or get matched in 60 seconds.",
+      "Compare platforms, browse Australian investments for sale, find experts, or get matched in 60 seconds.",
   },
   alternates: { canonical: "/" },
 };
@@ -172,7 +172,7 @@ export default async function HomePage() {
             "@context": "https://schema.org",
             ...ORGANIZATION_JSONLD,
             description:
-              "One place to compare platforms, browse investment listings, find experts, or get matched to the right next step. Independent. ASIC-registered. General information only.",
+              "Compare brokers, crypto, super and savings. Browse Australian investments for sale — businesses, farmland, mining, property. Find a verified expert, or get matched in 60 seconds. Independent. ASIC-registered. General information only.",
           }),
         }}
       />
@@ -193,10 +193,10 @@ export default async function HomePage() {
               },
               {
                 "@type": "Question",
-                name: "Where can I browse Australian investment opportunities?",
+                name: "Where can I browse Australian investments for sale?",
                 acceptedAnswer: {
                   "@type": "Answer",
-                  text: `Browse the marketplace at ${SITE_URL}/invest — businesses for sale, mining, farmland, commercial property, renewable energy projects and selected investment listings. Listings are not recommendations; always perform due diligence.`,
+                  text: `Browse the marketplace at ${SITE_URL}/invest — businesses for sale, mining, farmland, commercial property, renewable energy projects, franchises, IPOs and more. These are real opportunities listed by owners and operators, not recommendations; always perform due diligence.`,
                 },
               },
               {
@@ -212,7 +212,7 @@ export default async function HomePage() {
                 name: "What does Get matched do?",
                 acceptedAnswer: {
                   "@type": "Answer",
-                  text: `Get matched is a short prompt-based flow at ${SITE_URL}/quiz that routes you to the right next step — comparison, listing, expert directory or matched enquiry — based on your situation. No email needed.`,
+                  text: `Get matched is a short 4-question flow at ${SITE_URL}/quiz that routes you to the right next step — a platform to compare, an opportunity to browse, an expert to contact, or a guide to read — based on your situation. 60 seconds. No email needed.`,
                 },
               },
             ],
@@ -238,10 +238,6 @@ export default async function HomePage() {
       </ScrollFadeIn>
 
       <ScrollFadeIn>
-        <HomeHowWeEarn />
-      </ScrollFadeIn>
-
-      <ScrollFadeIn>
         <HomeCompareDeepDive brokers={compareBrokers} />
       </ScrollFadeIn>
 
@@ -263,6 +259,10 @@ export default async function HomePage() {
 
       <ScrollFadeIn>
         <HomeFridayBriefing />
+      </ScrollFadeIn>
+
+      <ScrollFadeIn>
+        <HomeHowWeEarn />
       </ScrollFadeIn>
 
       <MobileBottomNav />

--- a/components/HomeHero.tsx
+++ b/components/HomeHero.tsx
@@ -68,8 +68,8 @@ export default function HomeHero() {
             textWrap: "balance",
           }}
         >
-          Australia&apos;s front door for{" "}
-          <span style={{ color: "var(--color-coral-400)" }}>investment decisions.</span>
+          Compare investing platforms, see what&apos;s for sale, or find an expert &mdash;{" "}
+          <span style={{ color: "var(--color-coral-400)" }}>all in one place.</span>
         </h1>
 
         <p
@@ -81,8 +81,9 @@ export default function HomeHero() {
             margin: "20px 0 0",
           }}
         >
-          One place to compare platforms, browse investment listings, find experts, or get matched
-          to the right next step &mdash; without the financial jargon.
+          Compare brokers, crypto exchanges, super funds and savings accounts. Browse real
+          Australian investment opportunities &mdash; businesses, farmland, mining, property.
+          Find a verified expert. Or answer 4 questions to get matched. No jargon, no email.
         </p>
 
         <div
@@ -125,7 +126,7 @@ export default function HomeHero() {
               gap: 8,
             }}
           >
-            Browse manually <DesignIcon name="arrow-right" size={14} strokeWidth={2.4} />
+            Skip the quiz <DesignIcon name="arrow-right" size={14} strokeWidth={2.4} />
           </Link>
         </div>
 

--- a/components/HomePathfinder.tsx
+++ b/components/HomePathfinder.tsx
@@ -49,7 +49,7 @@ export default function HomePathfinder() {
             }}
           >
             Answer a few quick questions and we&apos;ll show the best next step &mdash; compare
-            platforms, browse listings, find an expert, or post a request.
+            platforms, browse investments for sale, find an expert, or post a request.
           </p>
           <p
             style={{

--- a/components/HomeRouteCards.tsx
+++ b/components/HomeRouteCards.tsx
@@ -29,6 +29,20 @@ interface RouteCardsProps {
 
 type RouteKind = "compare" | "browse" | "find" | "matched";
 
+interface RouteConfig {
+  kind: RouteKind;
+  audienceEyebrow: string;
+  title: string;
+  subtitle: string;
+  categories: ReadonlyArray<string>;
+  cta: string;
+  href: string;
+  icon: string;
+  accent: string;
+  badge: string;
+  featured?: boolean;
+}
+
 export default function HomeRouteCards({
   brokerCount,
   listingCount,
@@ -37,56 +51,70 @@ export default function HomeRouteCards({
   topListings,
   topAdvisors,
 }: RouteCardsProps) {
-  const routes: ReadonlyArray<{
-    kind: RouteKind;
-    title: string;
-    cta: string;
-    href: string;
-    icon: string;
-    accent: string;
-    audience: string;
-    badge: string;
-    featured?: boolean;
-  }> = [
+  const routes: ReadonlyArray<RouteConfig> = [
     {
       kind: "compare",
-      title: "Compare platforms",
-      cta: "Compare",
+      audienceEyebrow: "If you know what you want",
+      title: "Compare investing platforms",
+      subtitle: "Side-by-side fees, features and ratings.",
+      categories: ["Share brokers", "Crypto", "Robo", "Super", "Savings", "CFDs", "ETFs"],
+      cta: "Compare now",
       href: "/compare",
       icon: "trending-down",
       accent: "#2563eb",
-      audience: "If you know what you want",
-      badge: `${brokerCount || 0} platforms`,
+      badge: `9 categories · ${brokerCount.toLocaleString("en-AU")}+ platforms`,
     },
     {
       kind: "browse",
-      title: "Browse listings",
-      cta: "Browse",
+      audienceEyebrow: "If you want real opportunities",
+      title: "Browse investments for sale",
+      subtitle: "Real Australian businesses, projects and assets — listed by owners and operators.",
+      categories: [
+        "Businesses",
+        "Farmland",
+        "Mining",
+        "Commercial property",
+        "Franchises",
+        "Renewables",
+        "IPOs",
+      ],
+      cta: "Browse opportunities",
       href: "/invest",
       icon: "map-pin",
       accent: "#059669",
-      audience: "If you want real opportunities",
-      badge: `${listingCount || 0} listed`,
+      badge: `28 categories · ${listingCount.toLocaleString("en-AU")} live`,
     },
     {
       kind: "find",
-      title: "Find an expert",
-      cta: "Find",
+      audienceEyebrow: "If you need a pro",
+      title: "Find an Australian expert",
+      subtitle: "Verified advisers and specialists — by region, fee and specialty.",
+      categories: [
+        "Financial advisers",
+        "SMSF accountants",
+        "Mortgage brokers",
+        "Buyer's agents",
+        "Tax agents",
+        "FIRB",
+        "Cross-border",
+      ],
+      cta: "Find an expert",
       href: "/advisors",
       icon: "users",
       accent: "#7c3aed",
-      audience: "If you need a pro",
-      badge: `${professionalCount.toLocaleString("en-AU")} verified`,
+      badge: `9 specialties · ${professionalCount.toLocaleString("en-AU")} verified`,
     },
     {
       kind: "matched",
-      title: "Get matched",
-      cta: "Get matched",
+      audienceEyebrow: "If you're not sure where to start",
+      title: "Match me to the right step",
+      subtitle: "4 quick questions. We route you to the platform, opportunity, expert or guide that fits.",
+      categories: [],
+      cta: "Start the 4-question quiz",
       href: "/quiz",
       icon: "sparkles",
       accent: "#f25822",
-      audience: "If you're not sure where to start",
-      badge: "Free · no email",
+      badge: "60 seconds · Free · No email",
       featured: true,
     },
   ];
@@ -283,11 +311,12 @@ export default function HomeRouteCards({
             letterSpacing: "-.028em",
             fontWeight: 800,
             margin: "6px 0 0",
-            lineHeight: 1.05,
+            lineHeight: 1.1,
             textWrap: "balance",
+            maxWidth: 820,
           }}
         >
-          Compare. Browse. Find. Get matched.
+          Whichever way you want to invest in Australia, we cover it.
         </h2>
       </div>
 
@@ -307,7 +336,7 @@ export default function HomeRouteCards({
               borderRadius: 16,
               overflow: "hidden",
               textDecoration: "none",
-              minHeight: 360,
+              minHeight: 420,
               boxShadow: r.featured
                 ? `0 14px 36px color-mix(in oklch, ${r.accent} 28%, transparent)`
                 : "0 1px 2px rgba(11,20,34,.04)",
@@ -357,20 +386,81 @@ export default function HomeRouteCards({
               <DesignIcon name={r.icon} size={40} strokeWidth={2.2} />
             </div>
 
-            <div style={{ padding: "22px 22px 22px", display: "flex", flexDirection: "column", flex: 1 }}>
+            <div style={{ padding: "18px 20px 22px", display: "flex", flexDirection: "column", flex: 1 }}>
+              <div
+                className="font-mono"
+                style={{
+                  fontSize: 10,
+                  fontWeight: 800,
+                  textTransform: "uppercase",
+                  letterSpacing: ".07em",
+                  color: r.featured ? "rgba(255,255,255,.62)" : r.accent,
+                  marginBottom: 8,
+                }}
+              >
+                {r.audienceEyebrow}
+              </div>
+
               <div
                 className="font-display"
                 style={{
-                  fontSize: 21,
+                  fontSize: 20,
                   fontWeight: 800,
-                  lineHeight: 1.1,
-                  letterSpacing: "-.022em",
-                  marginBottom: 12,
+                  lineHeight: 1.12,
+                  letterSpacing: "-.02em",
+                  marginBottom: 6,
                   color: r.featured ? "white" : "var(--color-ink-900)",
                 }}
               >
                 {r.title}
               </div>
+
+              <div
+                style={{
+                  fontSize: 13,
+                  lineHeight: 1.4,
+                  color: r.featured ? "rgba(255,255,255,.72)" : "var(--color-ink-600)",
+                  marginBottom: 12,
+                }}
+              >
+                {r.subtitle}
+              </div>
+
+              {r.categories.length > 0 && (
+                <div
+                  className="route-cat-strip"
+                  style={{
+                    display: "flex",
+                    flexWrap: "wrap",
+                    gap: 4,
+                    marginBottom: 14,
+                  }}
+                >
+                  {r.categories.map((c, i) => (
+                    <span
+                      key={c}
+                      data-idx={i}
+                      className="route-cat-chip"
+                      style={{
+                        fontSize: 10.5,
+                        fontWeight: 700,
+                        padding: "2px 7px",
+                        borderRadius: 99,
+                        background: r.featured
+                          ? "rgba(255,255,255,.08)"
+                          : `color-mix(in oklch, ${r.accent} 7%, white)`,
+                        color: r.featured ? "rgba(255,255,255,.78)" : "var(--color-ink-700)",
+                        border: r.featured
+                          ? "1px solid rgba(255,255,255,.14)"
+                          : `1px solid color-mix(in oklch, ${r.accent} 18%, transparent)`,
+                        whiteSpace: "nowrap",
+                      }}
+                    >
+                      {c}
+                    </span>
+                  ))}
+                </div>
+              )}
 
               {renderPreview(r.kind, !!r.featured)}
 
@@ -398,18 +488,6 @@ export default function HomeRouteCards({
               </div>
 
               <div style={{ flex: 1 }} />
-
-              <div
-                style={{
-                  fontSize: 12,
-                  color: r.featured ? "rgba(255,255,255,.62)" : "var(--color-ink-500)",
-                  marginBottom: 14,
-                  lineHeight: 1.4,
-                  fontStyle: "italic",
-                }}
-              >
-                {r.audience}
-              </div>
 
               <div
                 style={{
@@ -465,11 +543,13 @@ export default function HomeRouteCards({
           <span aria-hidden>·</span>
           <span>{brokerCount.toLocaleString("en-AU")} platforms tracked</span>
           <span aria-hidden>·</span>
-          <span>{listingCount.toLocaleString("en-AU")} live listings</span>
+          <span>{listingCount.toLocaleString("en-AU")} live opportunities</span>
           <span aria-hidden>·</span>
           <span>{professionalCount.toLocaleString("en-AU")} verified experts</span>
           <span aria-hidden>·</span>
-          <span>ASIC-registered</span>
+          <span style={{ color: "var(--color-ink-700)", fontWeight: 800 }}>
+            Free for users — we earn from listings, not from clicks
+          </span>
         </div>
         <Link
           href="/methodology"
@@ -495,6 +575,9 @@ export default function HomeRouteCards({
         }
         @media (max-width: 640px) {
           .home-routes-grid { grid-template-columns: 1fr !important; }
+          .route-cat-chip[data-idx="4"],
+          .route-cat-chip[data-idx="5"],
+          .route-cat-chip[data-idx="6"] { display: none; }
         }
         @keyframes routePulse {
           0%, 100% { opacity: 0.35; transform: scale(0.85); }

--- a/components/layout/Navigation.tsx
+++ b/components/layout/Navigation.tsx
@@ -273,7 +273,7 @@ const mobileSections = [
     ],
   },
   {
-    title: "Browse listings",
+    title: "Investments for sale",
     items: [
       { name: "Investment Marketplace", href: "/invest" },
       { name: "Investment Funds", href: "/invest/funds" },


### PR DESCRIPTION
## Summary
- Hero + 4-tile redesign on the homepage. User testing failed on cold-reader comprehension: hero was metaphorical ("Australia's front door for investment decisions"), the section H2 was four verbs without objects ("Compare. Browse. Find. Get matched."), and the word "listings" hid the most differentiated content (businesses for sale, farmland, mining, property, renewables).
- Each tile now leads with an audience eyebrow ("If you know what you want"), shows a category chip strip — Share brokers · Crypto · Robo · Super · Savings · CFDs · ETFs (compare); Businesses · Farmland · Mining · Commercial property · Franchises · Renewables · IPOs (browse); Financial advisers · SMSF · Mortgage · Buyer's agents · Tax · FIRB · Cross-border (find) — and composes the badge as breadth × depth ("9 categories · N+ platforms").
- Tile 4 (Get matched) now reads as a tool, not a directory: title "Match me to the right step", CTA "Start the 4-question quiz", badge "60 seconds · Free · No email".
- Sitewide cleanup of "Browse listings" → "Investments for sale" / "Browse investments for sale" in nav, page metadata, FAQ JSON-LD, HomePathfinder copy.
- HomeHowWeEarn moved below HomeFridayBriefing so the trust note closes the page.

## Files changed
- `app/page.tsx` — metadata, FAQ JSON-LD, section ordering
- `components/HomeHero.tsx` — H1, subhead, secondary CTA
- `components/HomeRouteCards.tsx` — 4-tile redesign (subtitle + chip strip + audience eyebrow + composed badge + new H2 + tile 4 as tool + footer trust line + mobile chip truncation)
- `components/HomePathfinder.tsx` — copy fix (kill "browse listings")
- `components/layout/Navigation.tsx` — mega-menu rename

## Test plan
- [x] `npm run type-check` clean
- [x] `npm run lint` clean on all 5 changed files
- [x] Dev server: homepage renders, 8 new strings present, 0 hits on the 5 retired strings ("Compare. Browse. Find. Get matched.", "Browse listings", "Browse manually", "investment listings", "Australia's front door")
- [x] Section order verified in DOM: HomeRouteCards trust line → HomeFridayBriefing → HomeHowWeEarn
- [ ] Visual smoke on Vercel preview (desktop + mobile)
- [ ] Confirm chip strip truncates to 4 chips on mobile breakpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)