### PR TITLE
feat(invest): seed Unsplash hero image when listing has no DB images

### DIFF
--- a/components/InvestListingCard.tsx
+++ b/components/InvestListingCard.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import Image from "next/image";
 import type { InvestmentListing } from "@/lib/types";
 import { listingUrl } from "@/lib/listing-url";
+import { getListingHeroImage } from "@/lib/listing-vertical-images";
 import EnquireButton from "@/components/marketplace/EnquireButton";
 
 function formatLocation(state?: string, city?: string): string | null {
@@ -54,7 +55,9 @@ export default function InvestListingCard({
   const metricEntries = listing.key_metrics
     ? Object.entries(listing.key_metrics).slice(0, 3)
     : [];
-  const heroImage = listing.images?.[0];
+  const dbHeroImage = listing.images?.[0];
+  const heroImage = getListingHeroImage(listing.vertical, listing.id, listing.images);
+  const heroIsSeed = !dbHeroImage;
   const fallbackGradient = VERTICAL_FALLBACK_GRADIENT[listing.vertical] ?? "from-slate-100 to-slate-50";
   const fallbackIcon = VERTICAL_ICON[listing.vertical] ?? "📊";
 
@@ -63,17 +66,27 @@ export default function InvestListingCard({
       href={listingUrl(listing)}
       className="group relative block overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm hover:shadow-xl hover:border-slate-300 transition-all duration-300 hover:-translate-y-0.5"
     >
-      {/* Hero image / fallback */}
+      {/* Hero image — DB image when present, otherwise a deterministic
+          seed image from the listing's vertical. The gradient + emoji
+          path remains as a final guard if the seed pool is exhausted. */}
       <div className="relative aspect-[16/10] overflow-hidden bg-slate-100">
         {heroImage ? (
-          <Image
-            src={heroImage}
-            alt={listing.title}
-            fill
-            sizes="(max-width: 768px) 100vw, (max-width: 1280px) 50vw, 33vw"
-            className="object-cover transition-transform duration-500 group-hover:scale-105"
-            loading="lazy"
-          />
+          <>
+            <Image
+              src={heroImage}
+              alt={listing.title}
+              fill
+              sizes="(max-width: 768px) 100vw, (max-width: 1280px) 50vw, 33vw"
+              className="object-cover transition-transform duration-500 group-hover:scale-105"
+              loading="lazy"
+            />
+            {heroIsSeed && (
+              <div
+                aria-hidden
+                className={`absolute inset-0 bg-gradient-to-br ${fallbackGradient} opacity-30 mix-blend-multiply pointer-events-none`}
+              />
+            )}
+          </>
         ) : (
           <div className={`absolute inset-0 bg-gradient-to-br ${fallbackGradient} flex items-center justify-center`}>
             <div className="text-6xl opacity-40 group-hover:scale-110 transition-transform duration-500">

--- a/components/ListingCard.tsx
+++ b/components/ListingCard.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import Image from "next/image";
 import Icon from "@/components/Icon";
+import { getListingHeroImage } from "@/lib/listing-vertical-images";
 
 /**
  * Loose, tolerant type for ListingCard — accepts both the strict
@@ -202,21 +203,26 @@ export default function ListingCard({ listing }: ListingCardProps) {
 
   return (
     <div className="bg-white rounded-xl border border-slate-200 overflow-hidden shadow-sm hover:shadow-md transition-shadow flex flex-col">
-      {/* Image / Gradient placeholder */}
+      {/* Image — DB image when present, otherwise a deterministic seed
+          image keyed off the listing's vertical + id. The gradient + icon
+          path is preserved as a final guard. */}
       <Link href={detailPath} className="block relative aspect-[16/9] overflow-hidden">
-        {listing.images && listing.images.length > 0 ? (
-          <Image
-            src={listing.images[0]}
-            alt={listing.title}
-            fill
-            className="object-cover"
-            sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-          />
-        ) : (
-          <div className={`w-full h-full bg-gradient-to-br ${gradient} flex items-center justify-center`}>
-            <Icon name={VERTICAL_ICONS[listing.vertical] ?? "briefcase"} size={32} className="text-white/30" />
-          </div>
-        )}
+        {(() => {
+          const heroImage = getListingHeroImage(listing.vertical, listing.id, listing.images);
+          return heroImage ? (
+            <Image
+              src={heroImage}
+              alt={listing.title}
+              fill
+              className="object-cover"
+              sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+            />
+          ) : (
+            <div className={`w-full h-full bg-gradient-to-br ${gradient} flex items-center justify-center`}>
+              <Icon name={VERTICAL_ICONS[listing.vertical] ?? "briefcase"} size={32} className="text-white/30" />
+            </div>
+          );
+        })()}
         {/* Dark overlay for text legibility */}
         <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent" />
 

--- a/lib/listing-vertical-images.ts
+++ b/lib/listing-vertical-images.ts
@@ -1,0 +1,95 @@
+/**
+ * Curated Unsplash hero images per investment-listing vertical.
+ * Used as a fallback when the DB `images` column is empty so cards
+ * never render with just an emoji placeholder.
+ *
+ * The pool per vertical is intentionally small (4–6) so images repeat
+ * predictably; the choice is deterministic on the listing id so a given
+ * listing always shows the same image.
+ *
+ * Mirrors the pattern in `lib/property-images.ts`.
+ */
+
+const VERTICAL_IMAGES: Record<string, ReadonlyArray<string>> = {
+  business: [
+    "https://images.unsplash.com/photo-1497366216548-37526070297c?w=1200&h=675&q=80&auto=format&fit=crop",
+    "https://images.unsplash.com/photo-1556761175-5973dc0f32e7?w=1200&h=675&q=80&auto=format&fit=crop",
+    "https://images.unsplash.com/photo-1542744173-8e7e53415bb0?w=1200&h=675&q=80&auto=format&fit=crop",
+    "https://images.unsplash.com/photo-1521737604893-d14cc237f11d?w=1200&h=675&q=80&auto=format&fit=crop",
+    "https://images.unsplash.com/photo-1573164713988-8665fc963095?w=1200&h=675&q=80&auto=format&fit=crop",
+  ],
+  commercial_property: [
+    "https://images.unsplash.com/photo-1486406146926-c627a92ad1ab?w=1200&h=675&q=80&auto=format&fit=crop",
+    "https://images.unsplash.com/photo-1554435493-93422e8220c8?w=1200&h=675&q=80&auto=format&fit=crop",
+    "https://images.unsplash.com/photo-1577415124269-fc1140a69e91?w=1200&h=675&q=80&auto=format&fit=crop",
+    "https://images.unsplash.com/photo-1582407947304-fd86f028f716?w=1200&h=675&q=80&auto=format&fit=crop",
+    "https://images.unsplash.com/photo-1497366754035-f200968a6e72?w=1200&h=675&q=80&auto=format&fit=crop",
+  ],
+  energy: [
+    "https://images.unsplash.com/photo-1466611653911-95081537e5b7?w=1200&h=675&q=80&auto=format&fit=crop",
+    "https://images.unsplash.com/photo-1509391366360-2e959784a276?w=1200&h=675&q=80&auto=format&fit=crop",
+    "https://images.unsplash.com/photo-1497435334941-8c899ee9e8e9?w=1200&h=675&q=80&auto=format&fit=crop",
+    "https://images.unsplash.com/photo-1473341304170-971dccb5ac1e?w=1200&h=675&q=80&auto=format&fit=crop",
+    "https://images.unsplash.com/photo-1559302995-f1d7e5c2bba3?w=1200&h=675&q=80&auto=format&fit=crop",
+    "https://images.unsplash.com/photo-1497440001374-f26997328c1b?w=1200&h=675&q=80&auto=format&fit=crop",
+  ],
+  farmland: [
+    "https://images.unsplash.com/photo-1500382017468-9049fed747ef?w=1200&h=675&q=80&auto=format&fit=crop",
+    "https://images.unsplash.com/photo-1464226184884-fa280b87c399?w=1200&h=675&q=80&auto=format&fit=crop",
+    "https://images.unsplash.com/photo-1574943320219-553eb213f72d?w=1200&h=675&q=80&auto=format&fit=crop",
+    "https://images.unsplash.com/photo-1516570161787-2fd917215a3d?w=1200&h=675&q=80&auto=format&fit=crop",
+    "https://images.unsplash.com/photo-1500595046743-cd271d694d30?w=1200&h=675&q=80&auto=format&fit=crop",
+  ],
+  franchise: [
+    "https://images.unsplash.com/photo-1414235077428-338989a2e8c0?w=1200&h=675&q=80&auto=format&fit=crop",
+    "https://images.unsplash.com/photo-1552566626-52f8b828add9?w=1200&h=675&q=80&auto=format&fit=crop",
+    "https://images.unsplash.com/photo-1572202060038-ad048a23b32a?w=1200&h=675&q=80&auto=format&fit=crop",
+    "https://images.unsplash.com/photo-1555396273-367ea4eb4db5?w=1200&h=675&q=80&auto=format&fit=crop",
+    "https://images.unsplash.com/photo-1559339352-11d035aa65de?w=1200&h=675&q=80&auto=format&fit=crop",
+  ],
+  fund: [
+    "https://images.unsplash.com/photo-1611974789855-9c2a0a7236a3?w=1200&h=675&q=80&auto=format&fit=crop",
+    "https://images.unsplash.com/photo-1543286386-713bdd548da4?w=1200&h=675&q=80&auto=format&fit=crop",
+    "https://images.unsplash.com/photo-1554260570-9140fd3b7614?w=1200&h=675&q=80&auto=format&fit=crop",
+    "https://images.unsplash.com/photo-1551288049-bebda4e38f71?w=1200&h=675&q=80&auto=format&fit=crop",
+    "https://images.unsplash.com/photo-1611324586631-67dd2a36c8c8?w=1200&h=675&q=80&auto=format&fit=crop",
+  ],
+  mining: [
+    "https://images.unsplash.com/photo-1581094271901-8022df4466f9?w=1200&h=675&q=80&auto=format&fit=crop",
+    "https://images.unsplash.com/photo-1606613923022-ee4ce15a6d85?w=1200&h=675&q=80&auto=format&fit=crop",
+    "https://images.unsplash.com/photo-1518930259200-3e5b1f0d6b89?w=1200&h=675&q=80&auto=format&fit=crop",
+    "https://images.unsplash.com/photo-1518709268805-4e9042af9f23?w=1200&h=675&q=80&auto=format&fit=crop",
+    "https://images.unsplash.com/photo-1589939705384-5185137a7f0f?w=1200&h=675&q=80&auto=format&fit=crop",
+  ],
+  startup: [
+    "https://images.unsplash.com/photo-1556761175-b413da4baf72?w=1200&h=675&q=80&auto=format&fit=crop",
+    "https://images.unsplash.com/photo-1522071820081-009f0129c71c?w=1200&h=675&q=80&auto=format&fit=crop",
+    "https://images.unsplash.com/photo-1531545514256-b1400bc00f31?w=1200&h=675&q=80&auto=format&fit=crop",
+    "https://images.unsplash.com/photo-1517048676732-d65bc937f952?w=1200&h=675&q=80&auto=format&fit=crop",
+    "https://images.unsplash.com/photo-1559136555-9303baea8ebd?w=1200&h=675&q=80&auto=format&fit=crop",
+  ],
+};
+
+const GENERIC_FALLBACK_POOL: ReadonlyArray<string> = [
+  "https://images.unsplash.com/photo-1554260570-9140fd3b7614?w=1200&h=675&q=80&auto=format&fit=crop",
+  "https://images.unsplash.com/photo-1551288049-bebda4e38f71?w=1200&h=675&q=80&auto=format&fit=crop",
+  "https://images.unsplash.com/photo-1543286386-713bdd548da4?w=1200&h=675&q=80&auto=format&fit=crop",
+];
+
+/**
+ * Pick a deterministic seed image for a listing whose `images` array is empty.
+ * Returns the live DB image when present.
+ */
+export function getListingHeroImage(
+  vertical: string | null | undefined,
+  listingId: number | string,
+  dbImages: ReadonlyArray<string> | null | undefined,
+): string {
+  if (dbImages && dbImages.length > 0 && dbImages[0]) return dbImages[0];
+
+  const pool = (vertical && VERTICAL_IMAGES[vertical]) || GENERIC_FALLBACK_POOL;
+  const idNum = typeof listingId === "number" ? listingId : Number(listingId);
+  const safeIdx = Number.isFinite(idNum) && idNum >= 0 ? idNum : 0;
+  const fallback = pool[safeIdx % pool.length] ?? GENERIC_FALLBACK_POOL[0]!;
+  return fallback;
+}


### PR DESCRIPTION
## Summary
- The /invest marketplace and sub-category pages were rendering the 📊 emoji + vertical-icon-on-gradient placeholder when listings had no DB images — which was most of them. Cards looked broken next to rich metadata (FIRB badges, asking price, key metrics).
- Adds `lib/listing-vertical-images.ts` — curated Unsplash pool per vertical (business, commercial_property, energy, farmland, franchise, fund, mining, startup), 5–6 images each. Picker is deterministic on `listing.id` so a given listing always shows the same seed.
- Wires `getListingHeroImage()` into both card paths: `InvestListingCard` (marketplace + clients) and `components/ListingCard.tsx` (sub-category views). Gradient + icon branch preserved as final guard. On InvestListingCard, a soft 30% gradient overlay composites over the seed image so vertical color identity is retained.
- `next.config.ts` already allowlists `images.unsplash.com` in `remotePatterns` — no config change needed.

## Files
- `lib/listing-vertical-images.ts` (new)
- `components/InvestListingCard.tsx`
- `components/ListingCard.tsx`

## Test plan
- [x] `npm run type-check` clean
- [x] `npm run lint` clean
- [x] Dev: /invest renders 877 Unsplash hits, 0 emoji (was 0 / many before)
- [x] DB images still take priority — `getListingHeroImage` returns `dbImages[0]` if present

🤖 Generated with [Claude Code](https://claude.com/claude-code)