### PR TITLE
chore(ci): tighten auto-merge-label safety — deletion guard + LOC threshold

### DIFF
--- a/.github/workflows/scripts/auto-merge-label.js
+++ b/.github/workflows/scripts/auto-merge-label.js
@@ -365,6 +365,44 @@ async function run({ github, context, core }) {
     return;
   }
 
+  // 2a. Generalised deletion guard — added 2026-05-02 to extend the
+  // test-only guard above. Any tracked file removal is a meaningful
+  // signal: deleted route handlers, deleted migrations, deleted lib
+  // helpers, deleted seed scripts, deleted content. The SAFE allowlist
+  // patterns (page.tsx / seed scripts / content / docs / hub
+  // components / tests) all imply additions or modifications, not
+  // removals. A path-allowlist match on a deletion is a coincidence,
+  // not a safety guarantee. Force human review on any removal.
+  const removals = files.filter((f) => f.status === "removed");
+  if (removals.length > 0) {
+    core.info(
+      `file removals: ${removals.map((f) => f.filename).slice(0, 10).join(", ")}`,
+    );
+    await applyLabels({ github, context, number, decision: "review" });
+    return;
+  }
+
+  // 2b. LOC-threshold guard — added 2026-05-02. Even when every path
+  // matches the SAFE allowlist, a >1500-LOC PR is too large to be
+  // squash-merged unreviewed: a massive page.tsx refactor, a large
+  // seed script overhaul, or a wholesale content migration can break
+  // user-visible behaviour in ways the path classifier can't see. The
+  // 1500 floor is calibrated above typical loop-output sizes (most
+  // audit-loop test backfills land at 50–700 LOC; the largest
+  // observed in the queue is ~700 for a 29-test batch).
+  const totalAdditions = files.reduce(
+    (sum, f) => sum + (typeof f.additions === "number" ? f.additions : 0),
+    0,
+  );
+  const LARGE_PR_LOC_THRESHOLD = 1500;
+  if (totalAdditions > LARGE_PR_LOC_THRESHOLD) {
+    core.info(
+      `large PR: ${totalAdditions} additions across ${files.length} files (threshold ${LARGE_PR_LOC_THRESHOLD})`,
+    );
+    await applyLabels({ github, context, number, decision: "review" });
+    return;
+  }
+
   // 3. Allowlist check — every file must match a SAFE pattern.
   const unmatched = files.filter((f) => !isSafePath(f.filename));
   if (unmatched.length > 0) {


### PR DESCRIPTION
## Why

Founder confirmed today: PRs aren't manually reviewed in detail (they ask the assistant what to merge). The path-based classifier in \`auto-merge-label.js\` is therefore the only meaningful gate between loop-authored code and main. Two gaps leak through:

### Gap 1 — file deletions

Existing test-deletion guard only catches \`__tests__/**/*.test.ts\` removals. Other safe-path categories also imply additions/modifications only:

- \`app/**/page.tsx\` (deleted page = broken route)
- \`scripts/seed-*.ts\` (deleted seed = broken cron)
- \`content/**/*.md\`, \`docs/**/*.md\`
- \`components/Hub*.tsx\`

A path-allowlist match on a *removal* is a coincidence, not a safety guarantee.

### Gap 2 — large changes on safe paths

A 1500+ LOC change in \`app/**/page.tsx\` is technically SAFE-allowed but is beyond what ships unreviewed. The loop's typical output is 50–700 LOC (largest observed in queue is ~700 for a 29-test batch); 1500 is a comfortable headroom.

## Changes

Two new guards in the decision pipeline, sitting between the existing test-deletion guard and the allowlist check:

- **2a. Generalised deletion guard.** Any \`status === "removed"\` file → \`needs-human-review\`.
- **2b. LOC-threshold guard.** Total additions > 1500 → \`needs-human-review\`.

Both guards are **stricter** than current behaviour — they only push PRs from \`auto-merge-safe\` to \`needs-human-review\`, never the other direction. The workflow's other gates (CI green, 60-min quiet window, STOP comment) are unchanged.

## What this does NOT change

- Existing SAFE / BLOCKED pattern lists
- Existing first-of-pattern detection
- The 60-min quiet window
- The STOP comment escape hatch
- Auto-merge eligibility for routine adds-only PRs (test backfills, content updates, seed-script tweaks, etc.)

## Test plan

- [ ] PR that deletes a single tracked file (any path) → \`needs-human-review\`
- [ ] PR adding 1600+ lines of test code → \`needs-human-review\`
- [ ] PR adding 500 lines of test code → \`auto-merge-safe\` (unchanged)
- [ ] PR modifying \`app/page.tsx\` with no deletions and 200 additions → \`auto-merge-safe\` (unchanged)
- [ ] Syntax-checked locally with \`node -c\`

## Companion PRs in this batch

- #420 — Lighthouse CWV gate → advisory
- #419 — loop stops opening drafts
- #423 — Phase 1.5 conditional + Phase 2 stuck-detection guards