### PR TITLE
feat(invest): images on ticker cards + sub-category seeds + detail-page hero

### DIFF
--- a/app/invest/alternatives/listings/[slug]/page.tsx
+++ b/app/invest/alternatives/listings/[slug]/page.tsx
@@ -204,7 +204,7 @@ export default async function AlternativesListingDetailPage({
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
             {/* Left: details */}
             <div className="lg:col-span-2 space-y-6">
-              <ListingImageGallery images={l.images} alt={l.title} />
+              <ListingImageGallery images={l.images} alt={l.title} vertical={l.vertical} listingId={l.id} subCategory={l.sub_category} />
               {/* Price card */}
               <div className="bg-white border border-slate-200 rounded-xl p-6">
                 <div className="flex flex-wrap items-center justify-between gap-4">

--- a/app/invest/buy-business/listings/[slug]/page.tsx
+++ b/app/invest/buy-business/listings/[slug]/page.tsx
@@ -169,7 +169,7 @@ export default async function BusinessListingDetailPage({
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
             {/* Left: details */}
             <div className="lg:col-span-2 space-y-6">
-              <ListingImageGallery images={l.images} alt={l.title} />
+              <ListingImageGallery images={l.images} alt={l.title} vertical={l.vertical} listingId={l.id} subCategory={l.sub_category} />
               {/* Price card */}
               <div className="bg-white border border-slate-200 rounded-xl p-6">
                 <div className="flex flex-wrap items-center justify-between gap-4">

--- a/app/invest/commercial-property/listings/[slug]/page.tsx
+++ b/app/invest/commercial-property/listings/[slug]/page.tsx
@@ -167,7 +167,7 @@ export default async function CommercialListingDetailPage({
         <div className="container-custom">
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
             <div className="lg:col-span-2 space-y-6">
-              <ListingImageGallery images={l.images} alt={l.title} />
+              <ListingImageGallery images={l.images} alt={l.title} vertical={l.vertical} listingId={l.id} subCategory={l.sub_category} />
               <div className="bg-white border border-slate-200 rounded-xl p-6">
                 <div className="flex flex-wrap items-center justify-between gap-4">
                   <div>

--- a/app/invest/farmland/listings/[slug]/page.tsx
+++ b/app/invest/farmland/listings/[slug]/page.tsx
@@ -161,7 +161,7 @@ export default async function FarmlandListingDetailPage({
         <div className="container-custom">
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
             <div className="lg:col-span-2 space-y-6">
-              <ListingImageGallery images={l.images} alt={l.title} />
+              <ListingImageGallery images={l.images} alt={l.title} vertical={l.vertical} listingId={l.id} subCategory={l.sub_category} />
               <div className="bg-white border border-slate-200 rounded-xl p-6">
                 <div className="flex flex-wrap items-center justify-between gap-4">
                   <div>

--- a/app/invest/franchise/listings/[slug]/page.tsx
+++ b/app/invest/franchise/listings/[slug]/page.tsx
@@ -163,7 +163,7 @@ export default async function FranchiseListingDetailPage({
         <div className="container-custom">
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
             <div className="lg:col-span-2 space-y-6">
-              <ListingImageGallery images={l.images} alt={l.title} />
+              <ListingImageGallery images={l.images} alt={l.title} vertical={l.vertical} listingId={l.id} subCategory={l.sub_category} />
               <div className="bg-white border border-slate-200 rounded-xl p-6">
                 <div className="flex flex-wrap items-center justify-between gap-4">
                   <div>

--- a/app/invest/infrastructure/listings/[slug]/page.tsx
+++ b/app/invest/infrastructure/listings/[slug]/page.tsx
@@ -185,7 +185,7 @@ export default async function InfrastructureListingDetailPage({
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
             {/* Left: details */}
             <div className="lg:col-span-2 space-y-6">
-              <ListingImageGallery images={l.images} alt={l.title} />
+              <ListingImageGallery images={l.images} alt={l.title} vertical={l.vertical} listingId={l.id} subCategory={l.sub_category} />
               {/* Price card */}
               <div className="bg-white border border-slate-200 rounded-xl p-6">
                 <div className="flex flex-wrap items-center justify-between gap-4">

--- a/app/invest/mining/listings/[slug]/page.tsx
+++ b/app/invest/mining/listings/[slug]/page.tsx
@@ -171,7 +171,7 @@ export default async function MiningOpportunityDetailPage({
         <div className="container-custom">
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
             <div className="lg:col-span-2 space-y-6">
-              <ListingImageGallery images={l.images} alt={l.title} />
+              <ListingImageGallery images={l.images} alt={l.title} vertical={l.vertical} listingId={l.id} subCategory={l.sub_category} />
               {/* Price */}
               <div className="bg-white border border-slate-200 rounded-xl p-6">
                 <div className="flex flex-wrap items-center justify-between gap-4">

--- a/app/invest/private-credit/listings/[slug]/page.tsx
+++ b/app/invest/private-credit/listings/[slug]/page.tsx
@@ -185,7 +185,7 @@ export default async function PrivateCreditListingDetailPage({
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
             {/* Left: details */}
             <div className="lg:col-span-2 space-y-6">
-              <ListingImageGallery images={l.images} alt={l.title} />
+              <ListingImageGallery images={l.images} alt={l.title} vertical={l.vertical} listingId={l.id} subCategory={l.sub_category} />
               {/* Price card */}
               <div className="bg-white border border-slate-200 rounded-xl p-6">
                 <div className="flex flex-wrap items-center justify-between gap-4">

--- a/app/invest/renewable-energy/listings/[slug]/page.tsx
+++ b/app/invest/renewable-energy/listings/[slug]/page.tsx
@@ -167,7 +167,7 @@ export default async function EnergyProjectDetailPage({
         <div className="container-custom">
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
             <div className="lg:col-span-2 space-y-6">
-              <ListingImageGallery images={l.images} alt={l.title} />
+              <ListingImageGallery images={l.images} alt={l.title} vertical={l.vertical} listingId={l.id} subCategory={l.sub_category} />
               <div className="bg-white border border-slate-200 rounded-xl p-6">
                 <div className="flex flex-wrap items-center justify-between gap-4">
                   <div>

--- a/app/invest/startups/listings/[slug]/page.tsx
+++ b/app/invest/startups/listings/[slug]/page.tsx
@@ -169,7 +169,7 @@ export default async function StartupOpportunityDetailPage({
         <div className="container-custom">
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
             <div className="lg:col-span-2 space-y-6">
-              <ListingImageGallery images={l.images} alt={l.title} />
+              <ListingImageGallery images={l.images} alt={l.title} vertical={l.vertical} listingId={l.id} subCategory={l.sub_category} />
               <div className="bg-white border border-slate-200 rounded-xl p-6">
                 <div className="flex flex-wrap items-center justify-between gap-4">
                   <div>

--- a/components/InvestListingCard.tsx
+++ b/components/InvestListingCard.tsx
@@ -56,7 +56,16 @@ export default function InvestListingCard({
     ? Object.entries(listing.key_metrics).slice(0, 3)
     : [];
   const dbHeroImage = listing.images?.[0];
-  const heroImage = getListingHeroImage(listing.vertical, listing.id, listing.images);
+  const commodityKey =
+    listing.sub_category ??
+    (listing.key_metrics?.commodity as string | undefined) ??
+    null;
+  const heroImage = getListingHeroImage(
+    listing.vertical,
+    listing.id,
+    listing.images,
+    commodityKey,
+  );
   const heroIsSeed = !dbHeroImage;
   const fallbackGradient = VERTICAL_FALLBACK_GRADIENT[listing.vertical] ?? "from-slate-100 to-slate-50";
   const fallbackIcon = VERTICAL_ICON[listing.vertical] ?? "📊";

--- a/components/ListingCard.tsx
+++ b/components/ListingCard.tsx
@@ -208,7 +208,16 @@ export default function ListingCard({ listing }: ListingCardProps) {
           path is preserved as a final guard. */}
       <Link href={detailPath} className="block relative aspect-[16/9] overflow-hidden">
         {(() => {
-          const heroImage = getListingHeroImage(listing.vertical, listing.id, listing.images);
+          const commodityKey =
+            listing.sub_category ??
+            (listing.key_metrics?.commodity as string | undefined) ??
+            null;
+          const heroImage = getListingHeroImage(
+            listing.vertical,
+            listing.id,
+            listing.images,
+            commodityKey,
+          );
           return heroImage ? (
             <Image
               src={heroImage}

--- a/components/ListingImageGallery.tsx
+++ b/components/ListingImageGallery.tsx
@@ -1,20 +1,42 @@
 import Image from "next/image";
+import { getListingHeroImage } from "@/lib/listing-vertical-images";
 
 interface ListingImageGalleryProps {
   images?: string[] | null;
   alt: string;
+  /** Vertical of the listing — used to pick a seed hero when `images` is empty. */
+  vertical?: string | null;
+  /** Stable id (DB id or slug) — keeps the seed deterministic per listing. */
+  listingId?: number | string;
+  /** sub_category / commodity for finer-grained image selection. */
+  subCategory?: string | null;
 }
 
 /**
  * Image gallery for investment listing detail pages.
  * Shows a hero image with up to 4 thumbnails.
- * Renders nothing if there are no images.
+ * When the DB has no images, falls back to a single seed hero
+ * (no thumbnails) keyed on vertical + sub_category + id.
  */
-export default function ListingImageGallery({ images, alt }: ListingImageGalleryProps) {
-  if (!images || images.length === 0) return null;
+export default function ListingImageGallery({
+  images,
+  alt,
+  vertical,
+  listingId,
+  subCategory,
+}: ListingImageGalleryProps) {
+  const dbImages = images && images.length > 0 ? images : null;
+  const hasDbImages = !!dbImages;
 
-  const hero = images[0];
-  const thumbs = images.slice(1, 5);
+  const hero = hasDbImages
+    ? dbImages[0]
+    : listingId !== undefined
+      ? getListingHeroImage(vertical, listingId, null, subCategory)
+      : null;
+
+  if (!hero) return null;
+
+  const thumbs = hasDbImages ? dbImages.slice(1, 5) : [];
 
   return (
     <div className="bg-white border border-slate-200 rounded-xl overflow-hidden">
@@ -29,7 +51,7 @@ export default function ListingImageGallery({ images, alt }: ListingImageGallery
           sizes="(max-width: 1024px) 100vw, 66vw"
         />
       </div>
-      {/* Thumbnails grid (only if there are more images) */}
+      {/* Thumbnails grid (only when DB has multiple images) */}
       {thumbs.length > 0 && (
         <div className="grid grid-cols-4 gap-1 p-1">
           {thumbs.map((img, i) => (

--- a/components/commodities/AsxTickerCard.tsx
+++ b/components/commodities/AsxTickerCard.tsx
@@ -1,4 +1,6 @@
+import Image from "next/image";
 import type { CommodityStock } from "@/lib/commodities";
+import { getSectorThumbImage } from "@/lib/listing-vertical-images";
 
 interface Props {
   stock: CommodityStock;
@@ -35,23 +37,43 @@ export default function AsxTickerCard({ stock }: Props) {
     ? EXPOSURE_LABEL[stock.primary_exposure]
     : null;
 
+  const thumb = getSectorThumbImage(stock.sector_slug, stock.ticker);
+
   return (
-    <article className="border border-slate-200 rounded-xl bg-white p-4 hover:shadow-md transition-shadow">
-      <header className="flex items-baseline justify-between gap-2 mb-2">
-        <div>
-          <h3 className="text-base font-extrabold text-slate-900 leading-tight">
+    <article className="border border-slate-200 rounded-xl bg-white overflow-hidden hover:shadow-md transition-shadow flex flex-col">
+      {/* Sector-themed thumbnail. Deterministic on ticker so each card
+          shows a stable image. Aspect ratio is shorter than the listing
+          card's 16:10 because ticker cards are denser. */}
+      <div className="relative aspect-[16/7] bg-slate-100">
+        <Image
+          src={thumb}
+          alt=""
+          fill
+          sizes="(max-width: 768px) 100vw, (max-width: 1280px) 50vw, 33vw"
+          className="object-cover"
+          loading="lazy"
+        />
+        <div className="absolute inset-0 bg-gradient-to-t from-black/30 via-transparent to-transparent" />
+        <div className="absolute top-2 right-2">
+          {bucket && (
+            <span
+              className={`text-[10px] font-bold uppercase px-2 py-0.5 rounded-full shrink-0 shadow-sm ${bucket.className}`}
+            >
+              {bucket.label}
+            </span>
+          )}
+        </div>
+        <div className="absolute bottom-2 left-3 right-3 text-white">
+          <h3 className="text-base font-extrabold leading-tight drop-shadow">
             {stock.ticker}
           </h3>
-          <p className="text-xs text-slate-600 mt-0.5">{stock.company_name}</p>
+          <p className="text-[11px] opacity-95 leading-snug line-clamp-1 drop-shadow">
+            {stock.company_name}
+          </p>
         </div>
-        {bucket && (
-          <span
-            className={`text-[10px] font-bold uppercase px-2 py-0.5 rounded-full shrink-0 ${bucket.className}`}
-          >
-            {bucket.label}
-          </span>
-        )}
-      </header>
+      </div>
+
+      <div className="p-4 flex-1 flex flex-col">
 
       {stock.blurb && (
         <p className="text-xs text-slate-700 leading-snug mb-3">
@@ -92,6 +114,7 @@ export default function AsxTickerCard({ stock }: Props) {
         Past performance is not a reliable indicator of future performance.
         Consider your personal circumstances.
       </p>
+      </div>
     </article>
   );
 }

--- a/lib/listing-vertical-images.ts
+++ b/lib/listing-vertical-images.ts
@@ -10,6 +10,78 @@
  * Mirrors the pattern in `lib/property-images.ts`.
  */
 
+/**
+ * Sub-category / commodity overrides for verticals where the parent
+ * pool is too generic. Looked up first via `(vertical, subCategory)`;
+ * falls back to the parent vertical pool if no override exists.
+ *
+ * Keys are normalised to lowercase + underscores so callers can pass
+ * either listing.sub_category, listing.key_metrics.commodity, or a
+ * URL slug ("oil-gas" → "oil_gas") interchangeably.
+ */
+const VERTICAL_SUBCATEGORY_IMAGES: Record<
+  string,
+  Record<string, ReadonlyArray<string>>
+> = {
+  energy: {
+    hydrogen: [
+      "https://images.unsplash.com/photo-1623227866882-c005c26dfe41?w=1200&h=675&q=80&auto=format&fit=crop",
+      "https://images.unsplash.com/photo-1497440001374-f26997328c1b?w=1200&h=675&q=80&auto=format&fit=crop",
+      "https://images.unsplash.com/photo-1592833167001-55b39c8e9e2c?w=1200&h=675&q=80&auto=format&fit=crop",
+      "https://images.unsplash.com/photo-1581094271901-8022df4466f9?w=1200&h=675&q=80&auto=format&fit=crop",
+    ],
+    solar: [
+      "https://images.unsplash.com/photo-1509391366360-2e959784a276?w=1200&h=675&q=80&auto=format&fit=crop",
+      "https://images.unsplash.com/photo-1559302995-f1d7e5c2bba3?w=1200&h=675&q=80&auto=format&fit=crop",
+      "https://images.unsplash.com/photo-1466611653911-95081537e5b7?w=1200&h=675&q=80&auto=format&fit=crop",
+      "https://images.unsplash.com/photo-1497440001374-f26997328c1b?w=1200&h=675&q=80&auto=format&fit=crop",
+    ],
+    wind: [
+      "https://images.unsplash.com/photo-1466611653911-95081537e5b7?w=1200&h=675&q=80&auto=format&fit=crop",
+      "https://images.unsplash.com/photo-1473341304170-971dccb5ac1e?w=1200&h=675&q=80&auto=format&fit=crop",
+      "https://images.unsplash.com/photo-1532601224476-15c79f2f7a51?w=1200&h=675&q=80&auto=format&fit=crop",
+      "https://images.unsplash.com/photo-1497435334941-8c899ee9e8e9?w=1200&h=675&q=80&auto=format&fit=crop",
+    ],
+    oil_gas: [
+      "https://images.unsplash.com/photo-1518709268805-4e9042af9f23?w=1200&h=675&q=80&auto=format&fit=crop",
+      "https://images.unsplash.com/photo-1495615080073-6b89c9839ce0?w=1200&h=675&q=80&auto=format&fit=crop",
+      "https://images.unsplash.com/photo-1557804506-669a67965ba0?w=1200&h=675&q=80&auto=format&fit=crop",
+    ],
+  },
+  mining: {
+    lithium: [
+      "https://images.unsplash.com/photo-1518709268805-4e9042af9f23?w=1200&h=675&q=80&auto=format&fit=crop",
+      "https://images.unsplash.com/photo-1581094271901-8022df4466f9?w=1200&h=675&q=80&auto=format&fit=crop",
+      "https://images.unsplash.com/photo-1606613923022-ee4ce15a6d85?w=1200&h=675&q=80&auto=format&fit=crop",
+      "https://images.unsplash.com/photo-1518930259200-3e5b1f0d6b89?w=1200&h=675&q=80&auto=format&fit=crop",
+    ],
+    uranium: [
+      "https://images.unsplash.com/photo-1518709268805-4e9042af9f23?w=1200&h=675&q=80&auto=format&fit=crop",
+      "https://images.unsplash.com/photo-1559757175-5700dde675bc?w=1200&h=675&q=80&auto=format&fit=crop",
+      "https://images.unsplash.com/photo-1606613923022-ee4ce15a6d85?w=1200&h=675&q=80&auto=format&fit=crop",
+    ],
+    gold: [
+      "https://images.unsplash.com/photo-1610375461246-83df859d849d?w=1200&h=675&q=80&auto=format&fit=crop",
+      "https://images.unsplash.com/photo-1589939705384-5185137a7f0f?w=1200&h=675&q=80&auto=format&fit=crop",
+      "https://images.unsplash.com/photo-1605792657660-596af9009e82?w=1200&h=675&q=80&auto=format&fit=crop",
+    ],
+    iron_ore: [
+      "https://images.unsplash.com/photo-1581094271901-8022df4466f9?w=1200&h=675&q=80&auto=format&fit=crop",
+      "https://images.unsplash.com/photo-1518709268805-4e9042af9f23?w=1200&h=675&q=80&auto=format&fit=crop",
+      "https://images.unsplash.com/photo-1606613923022-ee4ce15a6d85?w=1200&h=675&q=80&auto=format&fit=crop",
+    ],
+    copper: [
+      "https://images.unsplash.com/photo-1518709268805-4e9042af9f23?w=1200&h=675&q=80&auto=format&fit=crop",
+      "https://images.unsplash.com/photo-1606613923022-ee4ce15a6d85?w=1200&h=675&q=80&auto=format&fit=crop",
+    ],
+  },
+};
+
+function normaliseSubKey(s: string | null | undefined): string | null {
+  if (!s) return null;
+  return s.toLowerCase().replace(/-/g, "_").replace(/\s+/g, "_");
+}
+
 const VERTICAL_IMAGES: Record<string, ReadonlyArray<string>> = {
   business: [
     "https://images.unsplash.com/photo-1497366216548-37526070297c?w=1200&h=675&q=80&auto=format&fit=crop",
@@ -79,17 +151,59 @@ const GENERIC_FALLBACK_POOL: ReadonlyArray<string> = [
 /**
  * Pick a deterministic seed image for a listing whose `images` array is empty.
  * Returns the live DB image when present.
+ *
+ * Resolution order: dbImages → (vertical, subCategory) → vertical → generic.
+ * `subCategory` accepts listing.sub_category, key_metrics.commodity, or the
+ * URL slug — they're normalised to a common shape before lookup.
  */
 export function getListingHeroImage(
   vertical: string | null | undefined,
   listingId: number | string,
   dbImages: ReadonlyArray<string> | null | undefined,
+  subCategory?: string | null,
 ): string {
   if (dbImages && dbImages.length > 0 && dbImages[0]) return dbImages[0];
 
-  const pool = (vertical && VERTICAL_IMAGES[vertical]) || GENERIC_FALLBACK_POOL;
   const idNum = typeof listingId === "number" ? listingId : Number(listingId);
   const safeIdx = Number.isFinite(idNum) && idNum >= 0 ? idNum : 0;
+
+  const subKey = normaliseSubKey(subCategory);
+  const subPool = vertical && subKey
+    ? VERTICAL_SUBCATEGORY_IMAGES[vertical]?.[subKey]
+    : undefined;
+  const verticalPool = vertical ? VERTICAL_IMAGES[vertical] : undefined;
+  const pool = subPool || verticalPool || GENERIC_FALLBACK_POOL;
+
   const fallback = pool[safeIdx % pool.length] ?? GENERIC_FALLBACK_POOL[0]!;
   return fallback;
+}
+
+/**
+ * Pick a deterministic seed image keyed on a sector slug (e.g. "hydrogen",
+ * "lithium") and a stable string id (e.g. an ASX ticker). Used for the
+ * commodity-sector ticker / ETF cards which don't have a DB images column.
+ */
+export function getSectorThumbImage(
+  sectorSlug: string | null | undefined,
+  stableId: string,
+): string {
+  // Hash the stableId so different tickers in the same sector get
+  // different images deterministically.
+  let hash = 0;
+  for (let i = 0; i < stableId.length; i += 1) {
+    hash = ((hash << 5) - hash + stableId.charCodeAt(i)) | 0;
+  }
+  const safeIdx = Math.abs(hash);
+
+  const subKey = normaliseSubKey(sectorSlug);
+  // Sectors map onto either an "energy" or "mining" parent pool.
+  const energyMatch = subKey && VERTICAL_SUBCATEGORY_IMAGES.energy?.[subKey];
+  const miningMatch = subKey && VERTICAL_SUBCATEGORY_IMAGES.mining?.[subKey];
+  const pool =
+    energyMatch ||
+    miningMatch ||
+    VERTICAL_IMAGES.energy ||
+    GENERIC_FALLBACK_POOL;
+
+  return pool[safeIdx % pool.length] ?? GENERIC_FALLBACK_POOL[0]!;
 }


### PR DESCRIPTION
## Summary
Three image polishes that share `lib/listing-vertical-images.ts`.

1. **AsxTickerCard** (`/invest/hydrogen`, `/lithium`, `/uranium`, `/oil-gas`, etc.) — now renders a sector-themed thumbnail with the ticker + company name overlaid. Was previously a bare text card. New `getSectorThumbImage()` helper hashes the ticker so each card gets a stable, distinct image.
2. **Sub-category-aware seeds** — energy was one pool; now hydrogen, solar, wind, oil_gas, lithium, uranium, gold, iron_ore, copper each have dedicated pools. `getListingHeroImage` resolves `dbImages → (vertical, subCategory) → vertical → generic`. InvestListingCard / ListingCard pass `listing.sub_category ?? key_metrics.commodity` as sub-key.
3. **Listing detail pages** — `ListingImageGallery` was returning `null` when DB had no images, leaving the hero blank. Now optional `vertical` / `listingId` / `subCategory` props let it synthesise a single seed hero. 10 detail-page callers updated.

## Files changed (15)
- `lib/listing-vertical-images.ts` — new sub-category map + `getSectorThumbImage`
- `components/commodities/AsxTickerCard.tsx` — top thumbnail
- `components/ListingImageGallery.tsx` — optional seed fallback
- `components/InvestListingCard.tsx` + `components/ListingCard.tsx` — pass sub-key
- 10 × `app/invest/*/listings/[slug]/page.tsx` — pass new gallery props

## Test plan
- [x] `npm run type-check` clean
- [x] `npm run lint` clean
- [ ] Visual smoke on Vercel preview: `/invest/hydrogen` (ticker thumbnails), `/invest/buy-business/listings/<slug>` (detail-page hero), `/invest` (sub-category-aware seed images)

🤖 Generated with [Claude Code](https://claude.com/claude-code)