### PR TITLE
feat(hubs): surface free tools strip on /invest /compare /advisors

### DIFF
--- a/app/advisors/page.tsx
+++ b/app/advisors/page.tsx
@@ -3,6 +3,7 @@ import { createClient } from "@/lib/supabase/server";
 import type { Professional, AdvisorFirm } from "@/lib/types";
 import type { Metadata } from "next";
 import AdvisorsClient from "./AdvisorsClient";
+import HomeToolsStrip from "@/components/HomeToolsStrip";
 import { absoluteUrl, breadcrumbJsonLd, CURRENT_YEAR } from "@/lib/seo";
 import { logger } from "@/lib/logger";
 
@@ -77,6 +78,7 @@ export default function AdvisorsPage() {
       <Suspense fallback={<AdvisorsLoading />}>
         <AdvisorsData />
       </Suspense>
+      <HomeToolsStrip />
     </>
   );
 }

--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -5,6 +5,7 @@ import CompareClient from "./CompareClient";
 import CompareNav from "./CompareNav";
 import { absoluteUrl, UPDATED_LABEL } from "@/lib/seo";
 import ComplianceFooter from "@/components/ComplianceFooter";
+import HomeToolsStrip from "@/components/HomeToolsStrip";
 
 export const metadata = {
   title: "Compare Investing Platforms — Fees & Features",
@@ -159,6 +160,7 @@ export default function ComparePage() {
       <Suspense fallback={<ComparePageSkeleton />}>
         <CompareData />
       </Suspense>
+      <HomeToolsStrip />
       <div className="container-custom pb-8">
         <ComplianceFooter />
       </div>

--- a/app/invest/page.tsx
+++ b/app/invest/page.tsx
@@ -18,6 +18,7 @@ import type { InvestmentListing } from "@/lib/types";
 import { logger } from "@/lib/logger";
 import { listingUrl } from "@/lib/listing-url";
 import InvestListingsClient from "@/components/InvestListingsClient";
+import HomeToolsStrip from "@/components/HomeToolsStrip";
 import ScrollReveal from "@/components/ScrollReveal";
 import Icon from "@/components/Icon";
 
@@ -384,6 +385,7 @@ export default async function InvestMarketplacePage() {
             </ScrollReveal>
           </div>
         </div>
+        <HomeToolsStrip />
       </div>
     </>
   );


### PR DESCRIPTION
## Summary
- HomeToolsStrip (Switching, Trade Cost, Portfolio X-Ray, CGT, Franking, Mortgage, Retirement, FIRB + "See all 25 →") was homepage-only. Adds it to the three hub pages where users actually need to run the numbers.
- No new component — three import + one-line insertion per file.

## Files
- `app/invest/page.tsx` — strip after the "Browse by category" grid
- `app/compare/page.tsx` — strip after `<CompareData />`
- `app/advisors/page.tsx` — strip after `<AdvisorsData />`

🤖 Generated with [Claude Code](https://claude.com/claude-code)