### PR TITLE
chore(ci): retarget LH CWV gate at funnel pages, bump runs to 5

### DIFF
--- a/.lighthouserc.cwv.json
+++ b/.lighthouserc.cwv.json
@@ -5,10 +5,10 @@
       "startServerReadyPattern": "Ready",
       "url": [
         "http://localhost:3000/",
-        "http://localhost:3000/glossary",
-        "http://localhost:3000/how-we-earn"
+        "http://localhost:3000/compare",
+        "http://localhost:3000/invest"
       ],
-      "numberOfRuns": 3,
+      "numberOfRuns": 5,
       "settings": {
         "preset": "desktop",
         "chromeFlags": "--no-sandbox --headless=new"


### PR DESCRIPTION
## Summary
LH Core Web Vitals gate flaked on /glossary and /how-we-earn (returning null for LCP/TBT) on PR #418 and elsewhere. Those are static pages with no user-funnel risk worth the runner noise.

- Swap URLs: `/`, `/compare`, `/invest` — the three primary funnel pages where a regression actually hurts.
- `numberOfRuns: 3 → 5` — median on 5 samples is meaningfully more stable. Adds ~30s.
- Gate stays advisory ("warn"). This PR is purely about *what* we sample.

🤖 Generated with [Claude Code](https://claude.com/claude-code)