### PR TITLE
feat(intent): country-cookie + cross-page filter badge

### DIFF
--- a/app/advisors/page.tsx
+++ b/app/advisors/page.tsx
@@ -4,6 +4,7 @@ import type { Professional, AdvisorFirm } from "@/lib/types";
 import type { Metadata } from "next";
 import AdvisorsClient from "./AdvisorsClient";
 import HomeToolsStrip from "@/components/HomeToolsStrip";
+import IntentCountryBadge from "@/components/foreign-investment/IntentCountryBadge";
 import { absoluteUrl, breadcrumbJsonLd, CURRENT_YEAR } from "@/lib/seo";
 import { logger } from "@/lib/logger";
 
@@ -75,6 +76,7 @@ export default function AdvisorsPage() {
   return (
     <>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }} />
+      <div className="container-custom pt-4"><IntentCountryBadge /></div>
       <Suspense fallback={<AdvisorsLoading />}>
         <AdvisorsData />
       </Suspense>

--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -6,6 +6,7 @@ import CompareNav from "./CompareNav";
 import { absoluteUrl, UPDATED_LABEL } from "@/lib/seo";
 import ComplianceFooter from "@/components/ComplianceFooter";
 import HomeToolsStrip from "@/components/HomeToolsStrip";
+import IntentCountryBadge from "@/components/foreign-investment/IntentCountryBadge";
 
 export const metadata = {
   title: "Compare Investing Platforms — Fees & Features",
@@ -150,6 +151,7 @@ export default function ComparePage() {
       <Suspense><CompareNav /></Suspense>
       {/* Server-rendered H1 for crawlers that don't execute client JS — streams immediately */}
       <div className="container-custom pt-5 md:pt-10">
+        <div className="mb-3"><IntentCountryBadge /></div>
         <h1 className="text-3xl md:text-4xl font-extrabold text-slate-900 tracking-tight">
           Compare Australian Investment Platforms
         </h1>

--- a/app/foreign-investment/china/page.tsx
+++ b/app/foreign-investment/china/page.tsx
@@ -5,6 +5,7 @@ import { breadcrumbJsonLd, SITE_URL } from "@/lib/seo";
 import { FOREIGN_INVESTOR_GENERAL_DISCLAIMER, DTA_DISCLAIMER } from "@/lib/compliance";
 import type { Broker } from "@/lib/types";
 import ForeignInvestmentNav from "../ForeignInvestmentNav";
+import RememberCountry from "@/components/foreign-investment/RememberCountry";
 import SectionHeading from "@/components/SectionHeading";
 
 export const metadata: Metadata = {
@@ -64,6 +65,7 @@ export default async function ChinaInvestingPage() {
         }}
       />
 
+      <RememberCountry code="cn" />
       <ForeignInvestmentNav current="/foreign-investment/china" />
 
       {/* ── Hero ── */}

--- a/app/foreign-investment/hong-kong/page.tsx
+++ b/app/foreign-investment/hong-kong/page.tsx
@@ -5,6 +5,7 @@ import { breadcrumbJsonLd, SITE_URL } from "@/lib/seo";
 import { FOREIGN_INVESTOR_GENERAL_DISCLAIMER, DTA_DISCLAIMER } from "@/lib/compliance";
 import type { Broker } from "@/lib/types";
 import ForeignInvestmentNav from "../ForeignInvestmentNav";
+import RememberCountry from "@/components/foreign-investment/RememberCountry";
 import SectionHeading from "@/components/SectionHeading";
 
 export const metadata: Metadata = {
@@ -64,6 +65,7 @@ export default async function HongKongInvestingPage() {
         }}
       />
 
+      <RememberCountry code="hk" />
       <ForeignInvestmentNav current="/foreign-investment/hong-kong" />
 
       {/* ── Hero ── */}

--- a/app/foreign-investment/india/page.tsx
+++ b/app/foreign-investment/india/page.tsx
@@ -5,6 +5,7 @@ import { breadcrumbJsonLd, SITE_URL } from "@/lib/seo";
 import { FOREIGN_INVESTOR_GENERAL_DISCLAIMER, DTA_DISCLAIMER } from "@/lib/compliance";
 import type { Broker } from "@/lib/types";
 import ForeignInvestmentNav from "../ForeignInvestmentNav";
+import RememberCountry from "@/components/foreign-investment/RememberCountry";
 import SectionHeading from "@/components/SectionHeading";
 import { AFFILIATE_REL } from "@/lib/tracking";
 
@@ -65,6 +66,7 @@ export default async function IndiaInvestingPage() {
         }}
       />
 
+      <RememberCountry code="in" />
       <ForeignInvestmentNav current="/foreign-investment/india" />
 
       {/* ── Hero ── */}

--- a/app/foreign-investment/japan/page.tsx
+++ b/app/foreign-investment/japan/page.tsx
@@ -5,6 +5,7 @@ import { breadcrumbJsonLd, SITE_URL } from "@/lib/seo";
 import { FOREIGN_INVESTOR_GENERAL_DISCLAIMER, DTA_DISCLAIMER } from "@/lib/compliance";
 import type { Broker } from "@/lib/types";
 import ForeignInvestmentNav from "../ForeignInvestmentNav";
+import RememberCountry from "@/components/foreign-investment/RememberCountry";
 import SectionHeading from "@/components/SectionHeading";
 import { AFFILIATE_REL } from "@/lib/tracking";
 
@@ -65,6 +66,7 @@ export default async function JapanInvestingPage() {
         }}
       />
 
+      <RememberCountry code="jp" />
       <ForeignInvestmentNav current="/foreign-investment/japan" />
 
       {/* ── Hero ── */}

--- a/app/foreign-investment/malaysia/page.tsx
+++ b/app/foreign-investment/malaysia/page.tsx
@@ -5,6 +5,7 @@ import { breadcrumbJsonLd, SITE_URL } from "@/lib/seo";
 import { FOREIGN_INVESTOR_GENERAL_DISCLAIMER, DTA_DISCLAIMER } from "@/lib/compliance";
 import type { Broker } from "@/lib/types";
 import ForeignInvestmentNav from "../ForeignInvestmentNav";
+import RememberCountry from "@/components/foreign-investment/RememberCountry";
 import SectionHeading from "@/components/SectionHeading";
 import { AFFILIATE_REL } from "@/lib/tracking";
 
@@ -65,6 +66,7 @@ export default async function MalaysiaInvestingPage() {
         }}
       />
 
+      <RememberCountry code="my" />
       <ForeignInvestmentNav current="/foreign-investment/malaysia" />
 
       {/* ── Hero ── */}

--- a/app/foreign-investment/new-zealand/page.tsx
+++ b/app/foreign-investment/new-zealand/page.tsx
@@ -5,6 +5,7 @@ import { breadcrumbJsonLd, SITE_URL } from "@/lib/seo";
 import { FOREIGN_INVESTOR_GENERAL_DISCLAIMER, DTA_DISCLAIMER } from "@/lib/compliance";
 import type { Broker } from "@/lib/types";
 import ForeignInvestmentNav from "../ForeignInvestmentNav";
+import RememberCountry from "@/components/foreign-investment/RememberCountry";
 import SectionHeading from "@/components/SectionHeading";
 import { AFFILIATE_REL } from "@/lib/tracking";
 
@@ -65,6 +66,7 @@ export default async function NewZealandInvestingPage() {
         }}
       />
 
+      <RememberCountry code="nz" />
       <ForeignInvestmentNav current="/foreign-investment/new-zealand" />
 
       {/* ── Hero ── */}

--- a/app/foreign-investment/saudi-arabia/page.tsx
+++ b/app/foreign-investment/saudi-arabia/page.tsx
@@ -5,6 +5,7 @@ import { breadcrumbJsonLd, SITE_URL } from "@/lib/seo";
 import { FOREIGN_INVESTOR_GENERAL_DISCLAIMER, DTA_DISCLAIMER } from "@/lib/compliance";
 import type { Broker } from "@/lib/types";
 import ForeignInvestmentNav from "../ForeignInvestmentNav";
+import RememberCountry from "@/components/foreign-investment/RememberCountry";
 import SectionHeading from "@/components/SectionHeading";
 import { AFFILIATE_REL } from "@/lib/tracking";
 
@@ -65,6 +66,7 @@ export default async function SaudiArabiaInvestingPage() {
         }}
       />
 
+      <RememberCountry code="sa" />
       <ForeignInvestmentNav current="/foreign-investment/saudi-arabia" />
 
       {/* ── Hero ── */}

--- a/app/foreign-investment/singapore/page.tsx
+++ b/app/foreign-investment/singapore/page.tsx
@@ -5,6 +5,7 @@ import { breadcrumbJsonLd, SITE_URL } from "@/lib/seo";
 import { FOREIGN_INVESTOR_GENERAL_DISCLAIMER, DTA_DISCLAIMER } from "@/lib/compliance";
 import type { Broker } from "@/lib/types";
 import ForeignInvestmentNav from "../ForeignInvestmentNav";
+import RememberCountry from "@/components/foreign-investment/RememberCountry";
 import SectionHeading from "@/components/SectionHeading";
 
 export const metadata: Metadata = {
@@ -108,6 +109,7 @@ export default async function SingaporeInvestingPage() {
         }}
       />
 
+      <RememberCountry code="sg" />
       <ForeignInvestmentNav current="/foreign-investment/singapore" />
 
       {/* ── Hero ── */}

--- a/app/foreign-investment/south-korea/page.tsx
+++ b/app/foreign-investment/south-korea/page.tsx
@@ -5,6 +5,7 @@ import { breadcrumbJsonLd, SITE_URL } from "@/lib/seo";
 import { FOREIGN_INVESTOR_GENERAL_DISCLAIMER, DTA_DISCLAIMER } from "@/lib/compliance";
 import type { Broker } from "@/lib/types";
 import ForeignInvestmentNav from "../ForeignInvestmentNav";
+import RememberCountry from "@/components/foreign-investment/RememberCountry";
 import SectionHeading from "@/components/SectionHeading";
 import { AFFILIATE_REL } from "@/lib/tracking";
 
@@ -65,6 +66,7 @@ export default async function SouthKoreaInvestingPage() {
         }}
       />
 
+      <RememberCountry code="kr" />
       <ForeignInvestmentNav current="/foreign-investment/south-korea" />
 
       {/* ── Hero ── */}

--- a/app/foreign-investment/united-arab-emirates/page.tsx
+++ b/app/foreign-investment/united-arab-emirates/page.tsx
@@ -5,6 +5,7 @@ import { breadcrumbJsonLd, SITE_URL } from "@/lib/seo";
 import { FOREIGN_INVESTOR_GENERAL_DISCLAIMER, DTA_DISCLAIMER } from "@/lib/compliance";
 import type { Broker } from "@/lib/types";
 import ForeignInvestmentNav from "../ForeignInvestmentNav";
+import RememberCountry from "@/components/foreign-investment/RememberCountry";
 import SectionHeading from "@/components/SectionHeading";
 
 export const metadata: Metadata = {
@@ -64,6 +65,7 @@ export default async function UAEInvestingPage() {
         }}
       />
 
+      <RememberCountry code="ae" />
       <ForeignInvestmentNav current="/foreign-investment/united-arab-emirates" />
 
       {/* ── Hero ── */}

--- a/app/foreign-investment/united-kingdom/page.tsx
+++ b/app/foreign-investment/united-kingdom/page.tsx
@@ -5,6 +5,7 @@ import { breadcrumbJsonLd, SITE_URL } from "@/lib/seo";
 import { FOREIGN_INVESTOR_GENERAL_DISCLAIMER, DTA_DISCLAIMER } from "@/lib/compliance";
 import type { Broker } from "@/lib/types";
 import ForeignInvestmentNav from "../ForeignInvestmentNav";
+import RememberCountry from "@/components/foreign-investment/RememberCountry";
 import SectionHeading from "@/components/SectionHeading";
 
 export const metadata: Metadata = {
@@ -138,6 +139,7 @@ export default async function UKInvestingPage() {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
       />
 
+      <RememberCountry code="uk" />
       <ForeignInvestmentNav current="/foreign-investment/united-kingdom" />
 
       {/* ── Hero ── */}

--- a/app/foreign-investment/united-states/page.tsx
+++ b/app/foreign-investment/united-states/page.tsx
@@ -5,6 +5,7 @@ import { breadcrumbJsonLd, SITE_URL } from "@/lib/seo";
 import { FOREIGN_INVESTOR_GENERAL_DISCLAIMER, DTA_DISCLAIMER } from "@/lib/compliance";
 import type { Broker } from "@/lib/types";
 import ForeignInvestmentNav from "../ForeignInvestmentNav";
+import RememberCountry from "@/components/foreign-investment/RememberCountry";
 import SectionHeading from "@/components/SectionHeading";
 import { AFFILIATE_REL } from "@/lib/tracking";
 
@@ -65,6 +66,7 @@ export default async function USAInvestingPage() {
         }}
       />
 
+      <RememberCountry code="us" />
       <ForeignInvestmentNav current="/foreign-investment/united-states" />
 
       {/* ── Hero ── */}

--- a/app/invest/page.tsx
+++ b/app/invest/page.tsx
@@ -19,6 +19,7 @@ import { logger } from "@/lib/logger";
 import { listingUrl } from "@/lib/listing-url";
 import InvestListingsClient from "@/components/InvestListingsClient";
 import HomeToolsStrip from "@/components/HomeToolsStrip";
+import IntentCountryBadge from "@/components/foreign-investment/IntentCountryBadge";
 import ScrollReveal from "@/components/ScrollReveal";
 import Icon from "@/components/Icon";
 
@@ -233,6 +234,7 @@ export default async function InvestMarketplacePage() {
 
           {/* Header */}
           <div className="bg-gradient-to-br from-slate-50 to-white border border-slate-200/50 rounded-2xl p-4 md:p-6 mb-3 md:mb-4">
+            <div className="mb-3"><IntentCountryBadge /></div>
             <h1 className="text-xl md:text-4xl font-extrabold mb-2 md:mb-3 text-slate-900">
               Australian Investment Marketplace
             </h1>

--- a/components/foreign-investment/ClearIntentCountryButton.tsx
+++ b/components/foreign-investment/ClearIntentCountryButton.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useTransition } from "react";
+import { clearIntentCountryAction } from "@/lib/intent-context-actions";
+
+/**
+ * Small button that clears the intent-country cookie and refreshes the
+ * current page so server components see the cleared state. Used inside
+ * IntentCountryBadge where the user wants to drop the filter.
+ */
+export default function ClearIntentCountryButton({
+  className,
+  children,
+}: {
+  className?: string;
+  children: React.ReactNode;
+}) {
+  const router = useRouter();
+  const [pending, start] = useTransition();
+
+  return (
+    <button
+      type="button"
+      disabled={pending}
+      onClick={() =>
+        start(async () => {
+          await clearIntentCountryAction();
+          router.refresh();
+        })
+      }
+      className={className}
+    >
+      {children}
+    </button>
+  );
+}

--- a/components/foreign-investment/IntentCountryBadge.tsx
+++ b/components/foreign-investment/IntentCountryBadge.tsx
@@ -1,0 +1,50 @@
+import Link from "next/link";
+import { getIntentCountry, intentCountryMeta } from "@/lib/intent-context";
+import ClearIntentCountryButton from "./ClearIntentCountryButton";
+
+/**
+ * Reads the iv_intent_country cookie and renders a small badge
+ * indicating that the surrounding page is filtered for that country.
+ * Renders nothing when no cookie is set.
+ *
+ * Drop this into /compare, /advisors, /invest pages where the country
+ * dimension shapes the default filter. The badge gives the user one
+ * click to clear the filter (if they didn't realise it was applied)
+ * and one click to revisit the country hub.
+ */
+export default async function IntentCountryBadge({
+  className = "",
+}: {
+  className?: string;
+}) {
+  const code = await getIntentCountry();
+  if (!code) return null;
+
+  const meta = intentCountryMeta(code);
+
+  return (
+    <div
+      className={`inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-amber-50 border border-amber-200 text-xs font-semibold text-amber-900 ${className}`}
+    >
+      <span aria-hidden className="text-sm leading-none">
+        {meta.flag}
+      </span>
+      <span>Filtered for {meta.label}</span>
+      <span aria-hidden className="text-amber-300">
+        ·
+      </span>
+      <Link
+        href={`/foreign-investment/${meta.slug}`}
+        className="underline decoration-dotted hover:text-amber-700"
+      >
+        Hub
+      </Link>
+      <span aria-hidden className="text-amber-300">
+        ·
+      </span>
+      <ClearIntentCountryButton className="underline decoration-dotted hover:text-amber-700 cursor-pointer disabled:opacity-50">
+        Clear
+      </ClearIntentCountryButton>
+    </div>
+  );
+}

--- a/components/foreign-investment/RememberCountry.tsx
+++ b/components/foreign-investment/RememberCountry.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { setIntentCountryAction } from "@/lib/intent-context-actions";
+
+/**
+ * Drop into a /foreign-investment/<country> page to remember the user's
+ * country in a cookie for 90 days. Renders nothing.
+ *
+ * Idempotent — calls the action once per page load. Safe to render
+ * unconditionally; if the user has already opted out by clearing the
+ * cookie elsewhere, they'll just see the country re-set on their next
+ * visit to this page (which mirrors the user's actual intent — they
+ * came back).
+ */
+export default function RememberCountry({ code }: { code: string }) {
+  const fired = useRef(false);
+
+  useEffect(() => {
+    if (fired.current) return;
+    fired.current = true;
+    // Server action — runs over RSC channel, no fetch boilerplate needed.
+    void setIntentCountryAction(code);
+  }, [code]);
+
+  return null;
+}

--- a/lib/intent-context-actions.ts
+++ b/lib/intent-context-actions.ts
@@ -1,0 +1,34 @@
+"use server";
+
+/**
+ * Server actions for the intent-country cookie.
+ *
+ * Lives in a separate file from `lib/intent-context.ts` because Next.js
+ * requires the "use server" directive at the top of the file and that
+ * marks every export as a server action. Keeping the read helpers
+ * (which need to be importable into RSC server components) in a
+ * non-action file avoids confusing the bundler.
+ */
+
+import { cookies } from "next/headers";
+import {
+  INTENT_COUNTRY_COOKIE,
+  INTENT_COUNTRY_TTL_SECONDS,
+  isKnownIntentCountry,
+} from "./intent-context";
+
+export async function setIntentCountryAction(code: string): Promise<void> {
+  if (!isKnownIntentCountry(code)) return;
+  const c = await cookies();
+  c.set(INTENT_COUNTRY_COOKIE, code, {
+    maxAge: INTENT_COUNTRY_TTL_SECONDS,
+    httpOnly: false, // client may read for UX (e.g. analytics dimension)
+    sameSite: "lax",
+    path: "/",
+  });
+}
+
+export async function clearIntentCountryAction(): Promise<void> {
+  const c = await cookies();
+  c.delete(INTENT_COUNTRY_COOKIE);
+}

--- a/lib/intent-context.ts
+++ b/lib/intent-context.ts
@@ -1,0 +1,106 @@
+/**
+ * Intent context — "I am a UK investor" sticks for the session.
+ *
+ * When a user lands on a /foreign-investment/<country> page we set
+ * `iv_intent_country` (90-day TTL). Other public pages that have a
+ * country dimension (/compare/non-residents, /advisors, /invest) read
+ * the cookie to default their filter; the user can always clear it
+ * via the badge that surfaces on those pages.
+ *
+ * Why a cookie and not a query param: a query param is per-link; the
+ * cookie persists across navigation, so when the UK user clicks
+ * Compare → Advisors → Invest, the filter follows them without each
+ * page having to forward the param. The badge keeps it visible and
+ * the clear action is one click away — discoverable, not magic.
+ */
+
+import { cookies } from "next/headers";
+
+export const INTENT_COUNTRY_COOKIE = "iv_intent_country";
+const TTL_SECONDS = 60 * 60 * 24 * 90; // 90 days
+
+/**
+ * Canonical 2-letter codes for countries with a foreign-investment hub.
+ * Keep in sync with the routes under app/foreign-investment/<country>/.
+ */
+export type IntentCountryCode =
+  | "uk"
+  | "us"
+  | "cn"
+  | "in"
+  | "jp"
+  | "sg"
+  | "hk"
+  | "kr"
+  | "my"
+  | "nz"
+  | "ae"
+  | "sa";
+
+interface IntentCountryMeta {
+  /** Folder name under app/foreign-investment/ */
+  slug: string;
+  /** UI label, e.g. "UK investors" */
+  label: string;
+  /** Emoji flag for badges */
+  flag: string;
+  /** ISO 4217 currency the user is most likely sending from */
+  currency: string;
+  /** ATO non-resident DTA status — quick UX hint, not legal advice */
+  hasDta: boolean;
+}
+
+const KNOWN: Record<IntentCountryCode, IntentCountryMeta> = {
+  uk: { slug: "united-kingdom",       label: "UK investors",         flag: "🇬🇧", currency: "GBP", hasDta: true },
+  us: { slug: "united-states",        label: "US investors",         flag: "🇺🇸", currency: "USD", hasDta: true },
+  cn: { slug: "china",                label: "Chinese investors",    flag: "🇨🇳", currency: "CNY", hasDta: true },
+  in: { slug: "india",                label: "Indian investors",     flag: "🇮🇳", currency: "INR", hasDta: true },
+  jp: { slug: "japan",                label: "Japanese investors",   flag: "🇯🇵", currency: "JPY", hasDta: true },
+  sg: { slug: "singapore",            label: "Singapore investors",  flag: "🇸🇬", currency: "SGD", hasDta: true },
+  hk: { slug: "hong-kong",            label: "HK investors",         flag: "🇭🇰", currency: "HKD", hasDta: false },
+  kr: { slug: "south-korea",          label: "Korean investors",     flag: "🇰🇷", currency: "KRW", hasDta: true },
+  my: { slug: "malaysia",             label: "Malaysian investors",  flag: "🇲🇾", currency: "MYR", hasDta: true },
+  nz: { slug: "new-zealand",          label: "NZ investors",         flag: "🇳🇿", currency: "NZD", hasDta: true },
+  ae: { slug: "united-arab-emirates", label: "UAE investors",        flag: "🇦🇪", currency: "AED", hasDta: true },
+  sa: { slug: "saudi-arabia",         label: "Saudi investors",      flag: "🇸🇦", currency: "SAR", hasDta: false },
+};
+
+const CODE_BY_SLUG: Record<string, IntentCountryCode> = Object.fromEntries(
+  (Object.entries(KNOWN) as [IntentCountryCode, IntentCountryMeta][]).map(
+    ([code, meta]) => [meta.slug, code],
+  ),
+);
+
+export function isKnownIntentCountry(value: string): value is IntentCountryCode {
+  return value in KNOWN;
+}
+
+export function intentCountryFromSlug(
+  slug: string | null | undefined,
+): IntentCountryCode | null {
+  if (!slug) return null;
+  return CODE_BY_SLUG[slug] ?? null;
+}
+
+export function intentCountryMeta(code: IntentCountryCode): IntentCountryMeta {
+  return KNOWN[code];
+}
+
+/**
+ * Read the user's intent country from the cookie. Returns null if
+ * the cookie isn't set or if the value isn't a known country code.
+ *
+ * Server-side only — uses next/headers cookies().
+ */
+export async function getIntentCountry(): Promise<IntentCountryCode | null> {
+  const c = await cookies();
+  const raw = c.get(INTENT_COUNTRY_COOKIE)?.value;
+  if (!raw) return null;
+  return isKnownIntentCountry(raw) ? raw : null;
+}
+
+/**
+ * Cookie max-age, exposed for callers that need to pass it through to
+ * a Set-Cookie header (e.g. server actions, route handlers).
+ */
+export const INTENT_COUNTRY_TTL_SECONDS = TTL_SECONDS;


### PR DESCRIPTION
## Summary
Foundational plumbing for the foreign-investment funnel rebuild. When a user lands on `/foreign-investment/<country>` they self-identify — today the site throws that information away the moment they navigate elsewhere. This PR adds a country cookie that follows them across `/compare`, `/advisors` and `/invest`, plus a small badge that surfaces the active filter and a one-click "clear".

This PR adds the **plumbing only**. Default-filter logic (which actually changes what those pages show) lands in PR 2 so the change is risk-isolated.

## Files added
- `lib/intent-context.ts` — registry of 12 known intent countries (slug, label, flag, currency, DTA flag), `getIntentCountry()` for RSC, `intentCountryMeta()` for UI strings
- `lib/intent-context-actions.ts` — server actions to set/clear `iv_intent_country` (90-day TTL, sameSite=lax)
- `components/foreign-investment/RememberCountry.tsx` — client component that fires the set-cookie action on mount of any country page
- `components/foreign-investment/IntentCountryBadge.tsx` — server component that reads the cookie and renders "Filtered for UK investors · Hub · Clear"
- `components/foreign-investment/ClearIntentCountryButton.tsx` — calls clear action + router.refresh

## Files wired
- 12 country pages: UK, US, China, India, Japan, Singapore, HK, Korea, Malaysia, NZ, UAE, Saudi → render `<RememberCountry code="..." />`
- 3 filter pages: /compare, /advisors, /invest → render `<IntentCountryBadge />`

## Test plan
- [x] type-check + lint clean on all 20 changed files
- [x] Dev: hit `/foreign-investment/united-kingdom`, then curl `/compare /advisors /invest` with `Cookie: iv_intent_country=uk` — badge "Filtered for UK investors" renders on all three
- [ ] Visual smoke on Vercel preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)