### PR TITLE
feat(intent): country-aware recommendation cards + ?firb=eligible filter

### DIFF
--- a/app/advisors/page.tsx
+++ b/app/advisors/page.tsx
@@ -5,6 +5,7 @@ import type { Metadata } from "next";
 import AdvisorsClient from "./AdvisorsClient";
 import HomeToolsStrip from "@/components/HomeToolsStrip";
 import IntentCountryBadge from "@/components/foreign-investment/IntentCountryBadge";
+import IntentCountryRecommendation from "@/components/foreign-investment/IntentCountryRecommendation";
 import { absoluteUrl, breadcrumbJsonLd, CURRENT_YEAR } from "@/lib/seo";
 import { logger } from "@/lib/logger";
 
@@ -76,7 +77,10 @@ export default function AdvisorsPage() {
   return (
     <>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }} />
-      <div className="container-custom pt-4"><IntentCountryBadge /></div>
+      <div className="container-custom pt-4">
+        <IntentCountryBadge />
+        <IntentCountryRecommendation surface="advisors" />
+      </div>
       <Suspense fallback={<AdvisorsLoading />}>
         <AdvisorsData />
       </Suspense>

--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -7,6 +7,7 @@ import { absoluteUrl, UPDATED_LABEL } from "@/lib/seo";
 import ComplianceFooter from "@/components/ComplianceFooter";
 import HomeToolsStrip from "@/components/HomeToolsStrip";
 import IntentCountryBadge from "@/components/foreign-investment/IntentCountryBadge";
+import IntentCountryRecommendation from "@/components/foreign-investment/IntentCountryRecommendation";
 
 export const metadata = {
   title: "Compare Investing Platforms — Fees & Features",
@@ -152,6 +153,7 @@ export default function ComparePage() {
       {/* Server-rendered H1 for crawlers that don't execute client JS — streams immediately */}
       <div className="container-custom pt-5 md:pt-10">
         <div className="mb-3"><IntentCountryBadge /></div>
+        <IntentCountryRecommendation surface="compare" />
         <h1 className="text-3xl md:text-4xl font-extrabold text-slate-900 tracking-tight">
           Compare Australian Investment Platforms
         </h1>

--- a/app/invest/page.tsx
+++ b/app/invest/page.tsx
@@ -20,6 +20,7 @@ import { listingUrl } from "@/lib/listing-url";
 import InvestListingsClient from "@/components/InvestListingsClient";
 import HomeToolsStrip from "@/components/HomeToolsStrip";
 import IntentCountryBadge from "@/components/foreign-investment/IntentCountryBadge";
+import IntentCountryRecommendation from "@/components/foreign-investment/IntentCountryRecommendation";
 import ScrollReveal from "@/components/ScrollReveal";
 import Icon from "@/components/Icon";
 
@@ -235,6 +236,7 @@ export default async function InvestMarketplacePage() {
           {/* Header */}
           <div className="bg-gradient-to-br from-slate-50 to-white border border-slate-200/50 rounded-2xl p-4 md:p-6 mb-3 md:mb-4">
             <div className="mb-3"><IntentCountryBadge /></div>
+            <IntentCountryRecommendation surface="invest" />
             <h1 className="text-xl md:text-4xl font-extrabold mb-2 md:mb-3 text-slate-900">
               Australian Investment Marketplace
             </h1>

--- a/components/InvestListingsClient.tsx
+++ b/components/InvestListingsClient.tsx
@@ -114,6 +114,11 @@ export default function InvestListingsClient({
   const activeState = searchParams.get("state") ?? "";
   const activePriceIdx = resolvePriceIdx(searchParams.get("price"));
   const activeSort = (searchParams.get("sort") ?? "newest") as SortKey;
+  // FIRB-eligibility filter — typically auto-applied for users who came
+  // through a /foreign-investment/<country> page (and therefore have an
+  // intent-country cookie). Leaves all listings visible by default for
+  // domestic users.
+  const activeFirbOnly = searchParams.get("firb") === "eligible";
 
   // Keyword search is a separate, local state rather than a URL param
   // so typing doesn't spam history entries. Submitting (Enter or
@@ -137,7 +142,7 @@ export default function InvestListingsClient({
 
   const clearAll = useCallback(() => {
     const next = new URLSearchParams(searchParams.toString());
-    for (const key of ["category", "sub", "state", "price", "sort", "q"]) {
+    for (const key of ["category", "sub", "state", "price", "sort", "q", "firb"]) {
       next.delete(key);
     }
     if (lockedCategory) next.delete("category");
@@ -206,6 +211,10 @@ export default function InvestListingsClient({
       });
     }
 
+    if (activeFirbOnly) {
+      result = result.filter((l) => l.firb_eligible === true);
+    }
+
     const sorted = [...result];
     if (activeSort === "newest") {
       sorted.sort((a, b) => b.created_at.localeCompare(a.created_at));
@@ -228,6 +237,7 @@ export default function InvestListingsClient({
     activePriceIdx,
     activeSort,
     activeQuery,
+    activeFirbOnly,
   ]);
 
   // Build a list of active-filter chips so the reader can see exactly
@@ -264,6 +274,12 @@ export default function InvestListingsClient({
         setSearchInput("");
         setParam({ q: "" });
       },
+    });
+  }
+  if (activeFirbOnly) {
+    activeChips.push({
+      label: "FIRB-eligible only",
+      onClear: () => setParam({ firb: "" }),
     });
   }
 

--- a/components/foreign-investment/IntentCountryBadge.tsx
+++ b/components/foreign-investment/IntentCountryBadge.tsx
@@ -29,7 +29,7 @@ export default async function IntentCountryBadge({
       <span aria-hidden className="text-sm leading-none">
         {meta.flag}
       </span>
-      <span>Filtered for {meta.label}</span>
+      <span>Browsing as {meta.label}</span>
       <span aria-hidden className="text-amber-300">
         ·
       </span>

--- a/components/foreign-investment/IntentCountryRecommendation.tsx
+++ b/components/foreign-investment/IntentCountryRecommendation.tsx
@@ -1,0 +1,117 @@
+import Link from "next/link";
+import { getIntentCountry, intentCountryMeta } from "@/lib/intent-context";
+
+type SurfaceKind = "compare" | "advisors" | "invest";
+
+interface Recommendation {
+  /** Headline for the country-specific CTA card. */
+  title: string;
+  /** One-line explanation of why this is being recommended. */
+  body: string;
+  /** Where the primary CTA lands. Pre-filtered URL where possible. */
+  href: string;
+  /** Primary CTA label. */
+  cta: string;
+}
+
+/**
+ * Country-aware contextual CTA card.
+ *
+ * Reads the iv_intent_country cookie and renders a "Recommended for
+ * <country> investors" card on /compare, /advisors and /invest. The
+ * card links to the most relevant pre-filtered destination on that
+ * page — for example, on /compare it points to /compare/non-residents
+ * because that's the strict subset of brokers that work for non-AU
+ * residents.
+ *
+ * Renders nothing when no country is set (most users) so the standard
+ * page experience is unchanged.
+ */
+export default async function IntentCountryRecommendation({
+  surface,
+}: {
+  surface: SurfaceKind;
+}) {
+  const code = await getIntentCountry();
+  if (!code) return null;
+
+  // The "nz" code is treated as non-AU but very low-friction (free trade,
+  // shared rules in many areas). Show a slightly softer recommendation.
+  const meta = intentCountryMeta(code);
+  const isHighFriction = code !== "nz";
+
+  const rec = buildRecommendation(surface, code, meta.label, isHighFriction);
+  if (!rec) return null;
+
+  return (
+    <div className="bg-amber-50 border border-amber-200 rounded-2xl p-4 md:p-5 my-4">
+      <div className="flex items-start justify-between gap-4 flex-wrap">
+        <div className="flex items-start gap-3">
+          <span aria-hidden className="text-2xl leading-none mt-0.5">
+            {meta.flag}
+          </span>
+          <div>
+            <p className="text-xs font-extrabold uppercase tracking-wider text-amber-700 mb-0.5">
+              Recommended for {meta.label}
+            </p>
+            <h3 className="text-base font-bold text-slate-900 mb-1">
+              {rec.title}
+            </h3>
+            <p className="text-sm text-slate-700 max-w-xl leading-snug">
+              {rec.body}
+            </p>
+          </div>
+        </div>
+        <Link
+          href={rec.href}
+          className="shrink-0 px-4 py-2 bg-amber-500 hover:bg-amber-400 text-slate-900 font-bold text-sm rounded-lg transition-colors"
+        >
+          {rec.cta} &rarr;
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+function buildRecommendation(
+  surface: SurfaceKind,
+  code: string,
+  label: string,
+  isHighFriction: boolean,
+): Recommendation | null {
+  switch (surface) {
+    case "compare":
+      return {
+        title: `Show only brokers that accept ${label.replace(" investors", "")} residents`,
+        body: `Most retail Australian brokers don't onboard non-residents. The non-resident comparison is the right filter — it pre-filters to platforms that explicitly accept overseas applicants.`,
+        href: "/compare/non-residents",
+        cta: "Non-resident brokers",
+      };
+    case "advisors":
+      return {
+        title: `Cross-border tax accountants for ${label.replace(" investors", "")} clients`,
+        body: `International tax specialists handle UK/AU dual reporting, FIRB property advice, QROPS pension transfers and treaty positions — the four areas where DIY most often goes wrong.`,
+        href: "/advisors/international-tax-specialists",
+        cta: "Specialist advisors",
+      };
+    case "invest":
+      if (!isHighFriction) {
+        return {
+          title: `New properties and FIRB-eligible listings for ${label.replace(" investors", "")}`,
+          body: `Even with the trans-Tasman framework, FIRB rules still apply on most direct property purchases. Pre-filter to FIRB-eligible listings to skip the items you can't buy.`,
+          href: "/invest?firb=eligible",
+          cta: "FIRB-eligible only",
+        };
+      }
+      return {
+        title: `FIRB-eligible new properties — what ${label.replace(" investors", "")} can actually buy`,
+        body: `The 2025–2027 ban blocks foreign buyers from established Australian dwellings. New dwellings, off-the-plan and commercial property remain open with FIRB approval. Pre-filter to those.`,
+        href: "/invest?firb=eligible",
+        cta: "FIRB-eligible only",
+      };
+    default:
+      // Exhaustiveness — should never hit at runtime.
+      return null;
+  }
+  void code;
+}


### PR DESCRIPTION
## Summary
PR 1 added the intent-country cookie + plumbing. This PR turns the cookie into actual conversion levers.

- **Honest badge wording**: "Filtered for UK investors" → "Browsing as UK investor". The cookie alone doesn't filter; the new wording matches what we're actually doing.
- **`IntentCountryRecommendation`** server component — country-aware "Recommended for X investors" card on /compare, /advisors and /invest. Renders nothing when no country is set (most users).
  - `/compare` → point to `/compare/non-residents`
  - `/advisors` → point to `/advisors/international-tax-specialists`
  - `/invest` → link to `?firb=eligible` (real filter; see below)
- **`?firb=eligible` URL filter on `InvestListingsClient`** — filters the marketplace grid to FIRB-eligible listings. Surfaces as a removable chip. Cleared by the page-wide clear-all and by the intent-country badge.

## Test plan
- [x] `npm run type-check` clean
- [x] `npm run lint --max-warnings 0` clean
- [ ] Visual smoke on Vercel preview with `Cookie: iv_intent_country=uk` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)