### PR TITLE
feat(uk): 4 in-page lead-capture forms — PDF gate, FX, property, pension

### DIFF
--- a/app/foreign-investment/united-kingdom/page.tsx
+++ b/app/foreign-investment/united-kingdom/page.tsx
@@ -6,6 +6,7 @@ import { FOREIGN_INVESTOR_GENERAL_DISCLAIMER, DTA_DISCLAIMER } from "@/lib/compl
 import type { Broker } from "@/lib/types";
 import ForeignInvestmentNav from "../ForeignInvestmentNav";
 import RememberCountry from "@/components/foreign-investment/RememberCountry";
+import CountryLeadForm from "@/components/foreign-investment/CountryLeadForm";
 import SectionHeading from "@/components/SectionHeading";
 
 export const metadata: Metadata = {
@@ -243,6 +244,31 @@ export default async function UKInvestingPage() {
               </ul>
             </div>
           </div>
+
+          <CountryLeadForm
+            kind="pdf-checklist"
+            countryCode="uk"
+            title="Free UK→AU 2026 Tax + Property checklist"
+            body="A 12-page PDF covering the UK and AU tax sides side-by-side, FIRB rules, QROPS gotchas, GBP→AUD timing and a UK-domicile IHT cheat sheet. Email it to me, then unsubscribe whenever."
+            ctaLabel="Send me the PDF"
+            successHeading="Sent — check your inbox."
+            successBody="The PDF is in your inbox now. We'll add you to the UK-investor monthly digest with new FIRB updates, broker offers and tax-year reminders. Unsubscribe anytime."
+            extraFields={[
+              {
+                name: "audience",
+                label: "Which describes you?",
+                type: "select",
+                required: false,
+                options: [
+                  { value: "uk-resident", label: "UK resident (not Australian)" },
+                  { value: "aussie-expat-uk", label: "Australian expat in the UK" },
+                  { value: "uk-au-migrating", label: "Moving from UK to Australia" },
+                  { value: "uk-au-returning", label: "Australian moving back from UK" },
+                ],
+              },
+            ]}
+            accent="amber"
+          />
         </section>
 
         {/* ── Property ── */}
@@ -309,6 +335,58 @@ export default async function UKInvestingPage() {
               Speak to a UK-AU property tax specialist &rarr;
             </Link>
           </div>
+
+          <CountryLeadForm
+            kind="property-budget"
+            countryCode="uk"
+            title="FIRB-eligible new properties in your budget"
+            body="Tell us your rough budget and preferred state — we'll send a shortlist of FIRB-eligible new dwellings, off-the-plan releases and commercial property that match. No obligation."
+            ctaLabel="Send me a shortlist"
+            successHeading="Got it."
+            successBody="A specialist will email you a curated shortlist within 1–2 business days. We'll only share your details with the specialist actively matching your budget."
+            extraFields={[
+              {
+                name: "budget_band",
+                label: "Budget (AUD)",
+                type: "select",
+                required: true,
+                options: [
+                  { value: "under-500k",   label: "Under A$500k" },
+                  { value: "500k-1m",      label: "A$500k – A$1m" },
+                  { value: "1m-2m",        label: "A$1m – A$2m" },
+                  { value: "2m-5m",        label: "A$2m – A$5m" },
+                  { value: "5m-plus",      label: "A$5m+" },
+                ],
+              },
+              {
+                name: "state_pref",
+                label: "Preferred state",
+                type: "select",
+                required: false,
+                options: [
+                  { value: "any", label: "Any state" },
+                  { value: "nsw", label: "NSW (Sydney)" },
+                  { value: "vic", label: "VIC (Melbourne)" },
+                  { value: "qld", label: "QLD (Brisbane / Gold Coast)" },
+                  { value: "wa",  label: "WA (Perth)" },
+                  { value: "sa",  label: "SA (Adelaide)" },
+                  { value: "act", label: "ACT (Canberra)" },
+                ],
+              },
+              {
+                name: "timeline",
+                label: "Timeline",
+                type: "select",
+                required: false,
+                options: [
+                  { value: "0-3m",   label: "Buying in 0–3 months" },
+                  { value: "3-12m",  label: "Buying in 3–12 months" },
+                  { value: "12m+",   label: "Researching, 12+ months out" },
+                ],
+              },
+            ]}
+            accent="emerald"
+          />
         </section>
 
         {/* ── Three paths to ASX shares ── */}
@@ -435,6 +513,45 @@ export default async function UKInvestingPage() {
               Compare GBP → AUD live rates &rarr;
             </Link>
           </div>
+
+          <CountryLeadForm
+            kind="fx-quote"
+            countryCode="uk"
+            title="Personalised GBP → AUD quote"
+            body="Tell us your transfer amount and we'll match you with the cheapest specialist provider for your size. Typical saving vs a high-street UK bank: 2–4% (£2,000–£4,000 on a £100k transfer)."
+            ctaLabel="Get a personalised quote"
+            successHeading="On its way."
+            successBody="A specialist provider will email you a live, locked-in rate quote within 1 business day. No commitment until you're happy with the rate."
+            extraFields={[
+              {
+                name: "transfer_amount_gbp",
+                label: "Transfer amount (£)",
+                type: "select",
+                required: true,
+                options: [
+                  { value: "under-10k",  label: "Under £10,000" },
+                  { value: "10k-50k",    label: "£10,000 – £50,000" },
+                  { value: "50k-250k",   label: "£50,000 – £250,000" },
+                  { value: "250k-1m",    label: "£250,000 – £1,000,000" },
+                  { value: "1m-plus",    label: "£1,000,000+" },
+                ],
+              },
+              {
+                name: "transfer_purpose",
+                label: "Purpose",
+                type: "select",
+                required: false,
+                options: [
+                  { value: "broker-funding", label: "Funding an AU broker account" },
+                  { value: "property",       label: "Property purchase / deposit" },
+                  { value: "moving",         label: "Personal move to Australia" },
+                  { value: "ongoing",        label: "Ongoing transfers (rent / salary / pension)" },
+                  { value: "other",          label: "Something else" },
+                ],
+              },
+            ]}
+            accent="blue"
+          />
         </section>
 
         {/* ── DTA + UK tax side ── */}
@@ -541,6 +658,57 @@ export default async function UKInvestingPage() {
               Australian super for non-residents
             </Link>
           </div>
+
+          <CountryLeadForm
+            kind="pension-transfer"
+            countryCode="uk"
+            title="Get 3 quotes from UK-AU pension transfer specialists"
+            body="QROPS-listed schemes only, both UK and AU sides. We'll match you with up to 3 specialists who handle the full process. No fee for the introduction."
+            ctaLabel="Match me with specialists"
+            successHeading="Matching you now."
+            successBody="Up to 3 specialists will email you within 1–2 business days. They'll review your scheme, age, residency and decide whether QROPS is the right call before quoting."
+            extraFields={[
+              {
+                name: "pension_value_gbp",
+                label: "Approximate pension value (£)",
+                type: "select",
+                required: true,
+                options: [
+                  { value: "under-50k",   label: "Under £50,000" },
+                  { value: "50k-150k",    label: "£50,000 – £150,000" },
+                  { value: "150k-500k",   label: "£150,000 – £500,000" },
+                  { value: "500k-1m",     label: "£500,000 – £1,000,000" },
+                  { value: "1m-plus",     label: "£1,000,000+" },
+                ],
+              },
+              {
+                name: "scheme_type",
+                label: "UK pension type",
+                type: "select",
+                required: false,
+                options: [
+                  { value: "sipp",     label: "SIPP / Personal pension" },
+                  { value: "workplace-dc", label: "Workplace defined contribution" },
+                  { value: "db",       label: "Defined benefit (final salary)" },
+                  { value: "mixed",    label: "Mixed / multiple schemes" },
+                  { value: "unsure",   label: "Not sure" },
+                ],
+              },
+              {
+                name: "age_band",
+                label: "Your age",
+                type: "select",
+                required: false,
+                options: [
+                  { value: "under-45", label: "Under 45" },
+                  { value: "45-54",    label: "45–54" },
+                  { value: "55-64",    label: "55–64" },
+                  { value: "65-plus",  label: "65+" },
+                ],
+              },
+            ]}
+            accent="slate"
+          />
         </section>
 
         {/* ── UK IHT ── */}

--- a/components/foreign-investment/CountryLeadForm.tsx
+++ b/components/foreign-investment/CountryLeadForm.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import { useState } from "react";
+
+/**
+ * Reusable in-page lead-capture form for the foreign-investment country
+ * hubs.
+ *
+ * Posts to the existing /api/email-capture endpoint with:
+ *   - source: `${countryCode}-${kind}` (e.g. "uk-pension-transfer")
+ *   - context: { country, kind, ...extraFields }
+ *
+ * The extra fields are configurable per instance — pension transfer
+ * needs age + pension type, the FX form needs an amount, the property
+ * form needs a budget range. Email is always required.
+ *
+ * The existing email-capture pipeline already handles dedup, rate
+ * limiting, the welcome / drip sequence and Resend notification.
+ */
+
+interface ExtraField {
+  name: string;
+  label: string;
+  type?: "text" | "tel" | "number" | "select";
+  options?: ReadonlyArray<{ value: string; label: string }>;
+  placeholder?: string;
+  required?: boolean;
+}
+
+interface Props {
+  /** Discriminator on what the form is collecting. Used as part of source. */
+  kind:
+    | "pdf-checklist"
+    | "pension-transfer"
+    | "fx-quote"
+    | "property-budget"
+    | "migration-consult";
+  /** Country code, e.g. "uk". Stored in context for segmentation. */
+  countryCode: string;
+  /** Form heading. */
+  title: string;
+  /** One-line description shown above the fields. */
+  body: string;
+  /** Button label. */
+  ctaLabel: string;
+  /** Success-state heading. */
+  successHeading: string;
+  /** Success-state body. */
+  successBody: string;
+  /** Extra fields beyond email + name. */
+  extraFields?: ReadonlyArray<ExtraField>;
+  /** Visual accent — Tailwind colour name (amber, emerald, blue). */
+  accent?: "amber" | "emerald" | "blue" | "slate";
+}
+
+const ACCENT: Record<NonNullable<Props["accent"]>, { bg: string; ring: string; btn: string; btnHover: string; text: string }> = {
+  amber:   { bg: "bg-amber-50",   ring: "border-amber-200",   btn: "bg-amber-500",   btnHover: "hover:bg-amber-400",   text: "text-amber-700" },
+  emerald: { bg: "bg-emerald-50", ring: "border-emerald-200", btn: "bg-emerald-600", btnHover: "hover:bg-emerald-500", text: "text-emerald-700" },
+  blue:    { bg: "bg-blue-50",    ring: "border-blue-200",    btn: "bg-blue-600",    btnHover: "hover:bg-blue-500",    text: "text-blue-700" },
+  slate:   { bg: "bg-slate-50",   ring: "border-slate-200",   btn: "bg-slate-900",   btnHover: "hover:bg-slate-800",   text: "text-slate-700" },
+};
+
+export default function CountryLeadForm({
+  kind,
+  countryCode,
+  title,
+  body,
+  ctaLabel,
+  successHeading,
+  successBody,
+  extraFields = [],
+  accent = "amber",
+}: Props) {
+  const colors = ACCENT[accent];
+  const [email, setEmail] = useState("");
+  const [name, setName] = useState("");
+  const [extra, setExtra] = useState<Record<string, string>>({});
+  const [status, setStatus] = useState<"idle" | "submitting" | "success" | "error">("idle");
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (status === "submitting" || status === "success") return;
+    if (!email.trim()) {
+      setErrorMsg("Email is required.");
+      setStatus("error");
+      return;
+    }
+    setStatus("submitting");
+    setErrorMsg(null);
+    try {
+      const res = await fetch("/api/email-capture", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email: email.trim(),
+          source: `${countryCode}-${kind}`,
+          name: name.trim() || undefined,
+          context: {
+            country: countryCode,
+            kind,
+            ...extra,
+          },
+        }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || `Request failed (${res.status})`);
+      }
+      setStatus("success");
+    } catch (err) {
+      setErrorMsg(err instanceof Error ? err.message : "Something went wrong.");
+      setStatus("error");
+    }
+  }
+
+  if (status === "success") {
+    return (
+      <div className={`${colors.bg} border ${colors.ring} rounded-2xl p-5 my-4`}>
+        <p className={`text-xs font-extrabold uppercase tracking-wider ${colors.text} mb-1`}>Thanks</p>
+        <h3 className="text-base font-bold text-slate-900 mb-1">{successHeading}</h3>
+        <p className="text-sm text-slate-700">{successBody}</p>
+      </div>
+    );
+  }
+
+  return (
+    <form
+      onSubmit={onSubmit}
+      className={`${colors.bg} border ${colors.ring} rounded-2xl p-5 my-4`}
+    >
+      <h3 className="text-base font-bold text-slate-900 mb-1">{title}</h3>
+      <p className="text-sm text-slate-700 mb-4">{body}</p>
+      <div className="grid sm:grid-cols-2 gap-3">
+        <input
+          type="text"
+          placeholder="Your name (optional)"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="w-full px-3 py-2 rounded-lg border border-slate-300 text-sm focus:outline-none focus:ring-2 focus:ring-amber-300"
+          autoComplete="name"
+        />
+        <input
+          type="email"
+          required
+          placeholder="Your email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="w-full px-3 py-2 rounded-lg border border-slate-300 text-sm focus:outline-none focus:ring-2 focus:ring-amber-300"
+          autoComplete="email"
+        />
+        {extraFields.map((field) => {
+          const val = extra[field.name] ?? "";
+          if (field.type === "select" && field.options) {
+            return (
+              <select
+                key={field.name}
+                value={val}
+                onChange={(e) => setExtra((s) => ({ ...s, [field.name]: e.target.value }))}
+                required={field.required}
+                className="w-full px-3 py-2 rounded-lg border border-slate-300 text-sm bg-white focus:outline-none focus:ring-2 focus:ring-amber-300"
+              >
+                <option value="">{field.label}</option>
+                {field.options.map((opt) => (
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+            );
+          }
+          return (
+            <input
+              key={field.name}
+              type={field.type ?? "text"}
+              required={field.required}
+              placeholder={field.placeholder ?? field.label}
+              value={val}
+              onChange={(e) => setExtra((s) => ({ ...s, [field.name]: e.target.value }))}
+              className="w-full px-3 py-2 rounded-lg border border-slate-300 text-sm focus:outline-none focus:ring-2 focus:ring-amber-300"
+            />
+          );
+        })}
+      </div>
+      <div className="flex items-center justify-between gap-3 mt-4 flex-wrap">
+        <p className="text-[11px] text-slate-500 leading-snug max-w-md">
+          We&apos;ll only use this to follow up on this enquiry. No spam. Unsubscribe anytime.
+          General information only — always check licensing, fees, risks and suitability.
+        </p>
+        <button
+          type="submit"
+          disabled={status === "submitting"}
+          className={`shrink-0 ${colors.btn} ${colors.btnHover} text-white font-bold text-sm px-5 py-2.5 rounded-lg disabled:opacity-50 transition-colors`}
+        >
+          {status === "submitting" ? "Sending…" : ctaLabel}
+        </button>
+      </div>
+      {status === "error" && errorMsg && (
+        <p className="text-xs text-red-600 mt-2">{errorMsg}</p>
+      )}
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
The UK country hub had outbound CTAs but no in-page forms. Every UK visitor who didn't click through to /advisors or /compare left without leaving any signal. This PR adds 4 dedicated lead-capture forms inline on the page, using the existing `/api/email-capture` pipeline (dedup, rate-limit, drip, Resend). No new endpoint, no migration.

## New component
`components/foreign-investment/CountryLeadForm.tsx` — reusable across foreign-investment country pages. Configurable kind, extraFields, accent. Posts to `/api/email-capture` with `source = ${countryCode}-${kind}` and `context = { country, kind, ...extraFields }`. Reusing it for the other 11 country pages in Phase 2 is one drop-in per country.

## Forms placed on UK page
1. **PDF checklist gate** (after audiences, amber) — top-of-funnel email capture + audience segmentation
2. **FIRB-eligible property shortlist** (after property, emerald) — budget band, state, timeline. High-intent.
3. **GBP→AUD personalised quote** (after FX, blue) — transfer amount, purpose. Highest-margin UK funnel.
4. **UK-AU pension transfer 3-quote** (after QROPS, slate) — pension value, scheme type, age. Highest CPL.

## Test plan
- [x] type-check + lint clean
- [ ] Visual smoke on Vercel preview — submit each form once
- [ ] Verify email_captures rows landed with the right source / context

🤖 Generated with [Claude Code](https://claude.com/claude-code)