### PR TITLE
feat(invest): add royalties, income-assets, ipo-calendar, pre-ipo verticals

### DIFF
--- a/app/invest/income-assets/page.tsx
+++ b/app/invest/income-assets/page.tsx
@@ -1,0 +1,493 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import Icon from "@/components/Icon";
+import {
+  breadcrumbJsonLd,
+  SITE_URL,
+  SITE_NAME,
+  CURRENT_YEAR,
+} from "@/lib/seo";
+import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
+
+export const revalidate = 3600;
+
+export const metadata: Metadata = {
+  title: `Income-Generating Asset Businesses in Australia (${CURRENT_YEAR}) — Vending, ATMs, Self-Storage & More`,
+  description:
+    "Independent guide to income-asset businesses for sale in Australia — vending routes, ATM networks, car washes, laundromats, self-storage, billboards. Yields, capex profile, finance options.",
+  alternates: { canonical: `${SITE_URL}/invest/income-assets` },
+  openGraph: {
+    title: `Income-Generating Asset Businesses in Australia (${CURRENT_YEAR})`,
+    description:
+      "Cash-flow asset businesses — vending, ATM networks, car washes, laundromats, self-storage and billboards.",
+    url: `${SITE_URL}/invest/income-assets`,
+  },
+};
+
+const WAYS_TO_INVEST = [
+  {
+    id: "vending-routes",
+    label: "Vending machine routes",
+    body:
+      "A vending route is a portfolio of placed machines on contracted host sites — offices, gyms, transit hubs, manufacturing plants. Australian operators typically run 20–200 machines per route. Entry tickets run $80,000–$500,000 depending on machine count, brand contracts (Pepsi / Coca-Cola Amatil exclusivity), and location quality. Net yields of 12%–25% before financing are common where route management is in-sourced; passive operator-managed structures clear 8%–12%. The lever is location quality — premium sites with employee-counts above 200 service multiple machines profitably.",
+    cta: { label: "Find a business broker", href: "/advisors/business-brokers" },
+  },
+  {
+    id: "atm-networks",
+    label: "ATM networks",
+    body:
+      "ATM ownership in Australia is a mature, declining-volume business — interchange fees were abolished in 2017, so revenue today is operator-set surcharges plus advertising on the screen. Banktech and DC Payments are the dominant aggregators; private route operators sit alongside. Tickets run $30,000–$300,000 for a 5–30 machine route. Net yields 15%–25% on premium sites (pubs, clubs, late-night venues), 5%–10% on tail sites. The decline curve is real — cash transactions fall ~5–8% p.a. — and is the principal investment risk.",
+    cta: { label: "Find a business broker", href: "/advisors/business-brokers" },
+  },
+  {
+    id: "car-washes",
+    label: "Car washes",
+    body:
+      "Drive-through automated car washes — usually tunnel-style with brushless soft-touch or touchless laser-guided wash bays — are the dominant new format in Australia. Single-site freehold buy-ins run $400,000–$2M for a leased site, $1.5M–$5M+ for freehold. Yields net of staff and chemical cost run 12%–20% on a leased site, lower on freehold but with property capital growth. Hand-wash hybrid models (semi-automated) carry meaningfully higher labour cost but command premium pricing on detailing services.",
+    cta: { label: "Browse commercial property listings", href: "/advisors/commercial-property-agents" },
+  },
+  {
+    id: "laundromats",
+    label: "Laundromats",
+    body:
+      "Coin and card-operated laundromats remain a low-touch cash-flow business in inner-city, university-suburb and high-density rental locations. A single-site Australian laundromat typically costs $200,000–$600,000 to acquire, with $50,000–$150,000 of that being commercial-grade Speed Queen / Maytag washers and dryers. Net yields after rent, utilities and maintenance run 10%–18%. The trade-off is high utility costs (water, gas, electricity) and theft / vandalism exposure.",
+    cta: { label: "Find a business broker", href: "/advisors/business-brokers" },
+  },
+  {
+    id: "self-storage",
+    label: "Self-storage facilities",
+    body:
+      "Self-storage is the institutional end of the income-asset spectrum. National Storage REIT (ASX: NSR) is the listed pure-play; Storage King and Kennards are the major private operators. Single-site freehold acquisitions run $1M–$10M depending on storage area and metro vs regional location. Direct-buy yields are 6%–9% on a stabilised facility; greenfield development can target mid-teens IRR. Easy financing through commercial real estate lenders and well-understood demand drivers (downsizing, e-commerce inventory, urban density) make this the most institutionally-investable income-asset class.",
+    cta: { label: "Find a commercial property agent", href: "/advisors/commercial-property-agents" },
+  },
+  {
+    id: "billboards",
+    label: "Billboard & outdoor rights",
+    body:
+      "Outdoor advertising rights on private land — billboards, building wraps, digital screens — pay landowners 30%–60% of net advertising revenue under operator agreements with oOh!media (ASX: OML), JCDecaux, or QMS. Direct ownership of an unencumbered billboard with planning approval generates $30,000–$300,000 p.a. depending on traffic count and digital vs static format. Council planning consent is the binding constraint — most metro councils now restrict new digital billboards.",
+    cta: { label: "Find a commercial property agent", href: "/advisors/commercial-property-agents" },
+  },
+];
+
+const FAQS = [
+  {
+    question: "Which income-asset businesses are franchise vs independent?",
+    answer:
+      "Vending and ATM operations are mostly independent — the franchise overlay is rare in Australia beyond brand-exclusive supply contracts (e.g. Coca-Cola Amatil vending agreements). Car washes split between independent operators and franchise networks like Magic Hand Carwash. Laundromats are almost entirely independent. Self-storage is dominated by branded networks (Storage King franchises, Kennards corporate) but unbranded independents exist. Billboard rights are independent, with operator partnerships rather than franchises.",
+  },
+  {
+    question: "How is GST treated on these business acquisitions?",
+    answer:
+      "Going-concern transfers — where the seller transfers all assets necessary to continue operating the business and both parties agree in writing — are GST-free under section 38-325 of the GST Act. Asset-only sales that do not meet the going-concern requirements attract 10% GST on the sale price. Commercial freehold component (e.g. self-storage land, car wash freehold) may be taxed under the margin scheme if eligible. ATO scrutiny on going-concern transfers is heavy — get the contract drafted by a specialist business-sale lawyer.",
+  },
+  {
+    question: "What finance options exist for buying income-asset businesses?",
+    answer:
+      "Asset finance through a commercial broker (chattel mortgage on the equipment), commercial real estate finance for the freehold component (self-storage, car wash freehold), unsecured business loans up to ~$500,000 from non-bank lenders, and SBA-equivalent vendor finance from the seller (typically 20%–40% of price over 3–5 years). Major banks lend conservatively against vending, ATM and laundromat businesses; non-bank specialists (Prospa, GetCapital, Banjo) are more flexible at higher rates.",
+  },
+  {
+    question: "How passive are these businesses really?",
+    answer:
+      "Passive on a spectrum. Self-storage with an outsourced manager is genuinely passive — 4–8 hours per month of owner involvement. Vending and ATM routes need 10–30 hours per week if owner-managed, near-zero if route-management is contracted out at 15%–25% of gross revenue. Car washes and laundromats are part-time-active — typically a $15K–$40K p.a. on-site supervisor or owner-time commitment. Billboards are fully passive once installed. Match the business to your time availability — undisclosed time commitment is the main reason buyers regret these acquisitions.",
+  },
+  {
+    question: "What yields should I realistically expect?",
+    answer:
+      "Net yield (cash to owner after all operating costs but before financing and tax) ranges meaningfully by asset class and quality. Vending: 8%–25%. ATMs: 5%–25%. Car washes: 8%–20%. Laundromats: 10%–18%. Self-storage: 6%–9% (lower because the asset class is institutional and bid up). Billboards: 15%–40% on owner-cleared land. Higher headline yields almost always reflect lower asset quality — a 25% vending yield often means tail sites with high churn, not premium captive routes.",
+  },
+  {
+    question: "Are these businesses recession-resistant?",
+    answer:
+      "Mixed. Vending in offices is exposed to white-collar employment; vending in factories and transit hubs is more resilient. ATM volumes are in structural decline regardless of recession. Self-storage is counter-cyclical — recession drives downsizing demand. Car washes are mid-cyclical — premium services drop in recessions, basic washes hold. Laundromats are weakly counter-cyclical — renters tend to laundromat when household appliances break and replacement is deferred.",
+  },
+];
+
+export default function IncomeAssetsPage() {
+  const breadcrumb = breadcrumbJsonLd([
+    { name: "Home", url: `${SITE_URL}/` },
+    { name: "Invest", url: `${SITE_URL}/invest` },
+    { name: "Income-Asset Businesses" },
+  ]);
+
+  const webPage = {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    name: `Income-Asset Businesses in Australia (${CURRENT_YEAR})`,
+    url: `${SITE_URL}/invest/income-assets`,
+    publisher: { "@type": "Organization", name: SITE_NAME, url: SITE_URL },
+  };
+
+  const faqPage = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: FAQS.map((f) => ({
+      "@type": "Question",
+      name: f.question,
+      acceptedAnswer: { "@type": "Answer", text: f.answer },
+    })),
+  };
+
+  return (
+    <div>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqPage) }}
+      />
+
+      {/* Hero */}
+      <section className="relative bg-white border-b border-slate-100 overflow-hidden py-8 md:py-12">
+        <div className="container-custom">
+          <nav
+            className="flex items-center gap-1.5 text-xs text-slate-500 mb-6"
+            aria-label="Breadcrumb"
+          >
+            <Link href="/" className="hover:text-slate-900 transition-colors">
+              Home
+            </Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <Link href="/invest" className="hover:text-slate-900 transition-colors">
+              Invest
+            </Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <span className="text-slate-900 font-medium">Income-Asset Businesses</span>
+          </nav>
+
+          <div className="flex flex-wrap items-center gap-2 mb-4">
+            <span className="text-[11px] font-bold uppercase px-2.5 py-0.5 rounded-full bg-emerald-100 text-emerald-800">
+              Cash-flow business
+            </span>
+            <span className="text-[11px] font-bold uppercase px-2.5 py-0.5 rounded-full bg-slate-100 text-slate-700">
+              Independent research
+            </span>
+            <span className="text-[11px] font-bold uppercase px-2.5 py-0.5 rounded-full bg-slate-100 text-slate-700">
+              Updated {CURRENT_YEAR}
+            </span>
+          </div>
+
+          <h1 className="text-3xl md:text-4xl lg:text-5xl font-extrabold leading-tight mb-4 max-w-3xl text-slate-900">
+            Income-Generating Asset Businesses in Australia
+          </h1>
+          <p className="text-base md:text-lg text-slate-600 leading-relaxed max-w-2xl mb-6">
+            Vending routes, ATM networks, car washes, laundromats, self-storage
+            and billboard rights — physical-asset businesses bought for the
+            cash flow they throw off rather than capital growth. Entry tickets
+            from $30,000 to $10M, net yields from 6% to 25%, and a wide
+            spectrum of owner-time commitment.
+          </p>
+
+          <dl className="grid grid-cols-2 md:grid-cols-4 gap-3 max-w-2xl">
+            {[
+              { label: "Typical net yield range", value: "6–25%" },
+              { label: "Entry ticket (vending)", value: "$80K+" },
+              { label: "Entry ticket (self-storage)", value: "$1M+" },
+              { label: "Self-storage ASX", value: "NSR" },
+            ].map((s) => (
+              <div
+                key={s.label}
+                className="border border-slate-200 rounded-lg bg-slate-50 px-3 py-2"
+              >
+                <dt className="text-[10px] font-bold uppercase text-slate-500 tracking-wide">
+                  {s.label}
+                </dt>
+                <dd className="text-sm font-extrabold text-slate-900 mt-0.5">
+                  {s.value}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+      </section>
+
+      {/* Context banner */}
+      <section className="py-6 md:py-8 bg-emerald-50 border-y border-emerald-200">
+        <div className="container-custom">
+          <div className="flex items-start gap-4 max-w-4xl">
+            <div className="w-10 h-10 rounded-lg bg-emerald-200 flex items-center justify-center shrink-0 mt-0.5">
+              <Icon name="info" size={20} className="text-emerald-800" />
+            </div>
+            <div>
+              <h2 className="text-sm font-extrabold uppercase tracking-wide text-emerald-800 mb-1">
+                Yield is not return
+              </h2>
+              <p className="text-sm md:text-base text-emerald-900 leading-relaxed">
+                Headline net yield on an income-asset business is the cash
+                return after operating costs but before financing, tax,
+                replacement capex and the seller&apos;s exit value. Sustainable
+                long-term return on capital is typically 30%–60% of the
+                headline yield once equipment depreciation, lease renewal
+                contingency and your owner-time are properly costed. Always
+                model a 7–10 year horizon, not a one-year yield.
+              </p>
+              <p className="text-xs text-emerald-700 mt-2">
+                <span className="italic">
+                  General information only, not financial advice.
+                </span>
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Ways to invest */}
+      <section className="py-10 md:py-12 bg-white" id="ways-to-invest">
+        <div className="container-custom">
+          <div className="mb-6 max-w-3xl">
+            <p className="text-xs font-bold uppercase tracking-wider text-emerald-600 mb-1">
+              Section 1 &middot; Six asset categories
+            </p>
+            <h2 className="text-2xl md:text-3xl font-extrabold text-slate-900">
+              Income-asset business categories
+            </h2>
+            <p className="text-sm text-slate-500 mt-1">
+              Each category has a distinct entry ticket, yield range and
+              owner-time commitment. Match the asset to your capital and time
+              availability before you start shortlisting deals.
+            </p>
+          </div>
+
+          <div className="flex flex-wrap gap-2 mb-6" role="tablist">
+            {WAYS_TO_INVEST.map((w, i) => (
+              <a
+                key={w.id}
+                href={`#${w.id}`}
+                className={`inline-flex items-center gap-1.5 text-xs md:text-sm font-semibold px-3 py-1.5 rounded-full border transition-colors ${
+                  i === 0
+                    ? "bg-emerald-600 text-white border-emerald-600"
+                    : "bg-white text-slate-700 border-slate-200 hover:border-emerald-400 hover:text-emerald-700"
+                }`}
+              >
+                <span className="w-5 h-5 rounded-full bg-white/20 text-[11px] font-bold flex items-center justify-center">
+                  {i + 1}
+                </span>
+                {w.label}
+              </a>
+            ))}
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {WAYS_TO_INVEST.map((w, i) => (
+              <div
+                key={w.id}
+                id={w.id}
+                className="bg-slate-50 border border-slate-200 rounded-xl p-5 scroll-mt-24"
+              >
+                <div className="flex items-center gap-3 mb-3">
+                  <span className="w-8 h-8 rounded-full bg-emerald-600 text-white font-extrabold flex items-center justify-center">
+                    {i + 1}
+                  </span>
+                  <h3 className="text-lg font-bold text-slate-900">{w.label}</h3>
+                </div>
+                <p className="text-sm text-slate-700 leading-relaxed mb-4">
+                  {w.body}
+                </p>
+                <Link
+                  href={w.cta.href}
+                  className="inline-flex items-center gap-1.5 text-sm font-bold text-primary hover:underline"
+                >
+                  {w.cta.label}
+                  <Icon name="bookmark" size={14} />
+                </Link>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Market overview */}
+      <section className="py-10 md:py-12 bg-slate-50 border-y border-slate-100">
+        <div className="container-custom max-w-4xl">
+          <p className="text-xs font-bold uppercase tracking-wider text-emerald-600 mb-1">
+            Section 2 &middot; Market overview
+          </p>
+          <h2 className="text-2xl md:text-3xl font-extrabold text-slate-900 mb-4">
+            Australian income-asset market context
+          </h2>
+
+          <div className="prose prose-slate max-w-none">
+            <p>
+              The Australian income-asset market is fragmented and almost
+              entirely unbranded at the small-business end. Most deals clear
+              through general business brokers (Linkbusiness, Bsale,
+              BusinessForSale.com.au) or via direct-to-buyer listings.
+              Self-storage and billboard rights have institutional buyers (NSR,
+              Storage King, oOh!media, JCDecaux); the rest is dominated by
+              owner-operators acquiring and rolling up portfolios.
+            </p>
+            <p>
+              Pricing is typically quoted as a multiple of seller&apos;s
+              discretionary earnings (SDE) — gross profit minus operating
+              expenses but before owner&apos;s salary. Multiples range from 1.5×–3×
+              SDE for vending and ATM routes, 2×–4× SDE for car washes and
+              laundromats (with freehold component priced separately on a cap
+              rate basis), and 6–10× SDE for self-storage facilities (priced
+              materially closer to commercial real estate cap rates).
+            </p>
+            <p>
+              Due diligence priorities differ from operating-business
+              acquisitions. Equipment age and replacement schedule, host-site
+              contract terms (vending), interchange-fee arrangements (ATMs),
+              council planning approval (billboards) and lease tenure (every
+              category) are the key items to verify. ATO compliance, BAS
+              history and bank-statement reconciliation against cash takings
+              are essential — under-banked cash businesses are a long-standing
+              ATO focus.
+            </p>
+            <p>
+              Long-term holders typically buy a single asset, learn the
+              operations, then roll up — adding a second, third and fifth
+              location while leveraging the first asset&apos;s cash flow as
+              acquisition equity.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* FAQs */}
+      <section className="py-10 md:py-12 bg-white" id="faqs">
+        <div className="container-custom max-w-4xl">
+          <p className="text-xs font-bold uppercase tracking-wider text-emerald-600 mb-1">
+            Section 3 &middot; FAQs
+          </p>
+          <h2 className="text-2xl md:text-3xl font-extrabold text-slate-900 mb-6">
+            Income-asset investing — frequently asked
+          </h2>
+
+          <div className="space-y-3">
+            {FAQS.map((f) => (
+              <details
+                key={f.question}
+                className="group bg-slate-50 border border-slate-200 rounded-xl px-5 py-4"
+              >
+                <summary className="cursor-pointer font-bold text-slate-900 text-sm md:text-base flex items-start justify-between gap-3">
+                  <span>{f.question}</span>
+                  <Icon
+                    name="plus"
+                    size={18}
+                    className="text-slate-400 group-open:rotate-45 transition-transform shrink-0 mt-0.5"
+                  />
+                </summary>
+                <p className="text-sm text-slate-700 leading-relaxed mt-3">
+                  {f.answer}
+                </p>
+              </details>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Advisor CTA */}
+      <section className="py-12 md:py-14 bg-slate-900 text-white" id="find-advisor">
+        <div className="container-custom max-w-4xl">
+          <p className="text-xs font-bold uppercase tracking-wider text-emerald-400 mb-2">
+            Section 4 &middot; Get specialist help
+          </p>
+          <h2 className="text-2xl md:text-3xl font-extrabold mb-3">
+            Speak with a business-acquisition specialist
+          </h2>
+          <p className="text-sm md:text-base text-slate-300 leading-relaxed mb-6 max-w-2xl">
+            Income-asset businesses are deal-volume businesses for brokers —
+            you&apos;ll see better off-market deals through a relationship-led
+            broker than via portal listings alone. A specialist also knows the
+            quirks of each asset category — host-contract assignments, lease
+            novation, council planning, ATO going-concern positioning.
+          </p>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
+            <Link
+              href="/advisors/business-brokers"
+              className="group bg-white/5 hover:bg-white/10 border border-white/10 rounded-xl p-5 transition-colors"
+            >
+              <div className="flex items-center gap-3 mb-2">
+                <Icon name="briefcase" size={20} className="text-emerald-400" />
+                <h3 className="text-base font-extrabold text-white group-hover:text-emerald-300">
+                  Business brokers
+                </h3>
+              </div>
+              <p className="text-xs md:text-sm text-slate-300">
+                Brokers experienced in vending, ATM, laundromat and car-wash
+                acquisitions, with off-market deal flow and host-contract
+                novation experience.
+              </p>
+            </Link>
+
+            <Link
+              href="/advisors/commercial-property-agents"
+              className="group bg-white/5 hover:bg-white/10 border border-white/10 rounded-xl p-5 transition-colors"
+            >
+              <div className="flex items-center gap-3 mb-2">
+                <Icon name="building" size={20} className="text-emerald-400" />
+                <h3 className="text-base font-extrabold text-white group-hover:text-emerald-300">
+                  Commercial property agents
+                </h3>
+              </div>
+              <p className="text-xs md:text-sm text-slate-300">
+                Commercial agents specialising in self-storage, car-wash
+                freehold and billboard easement transactions across metro and
+                regional Australia.
+              </p>
+            </Link>
+
+            <Link
+              href="/advisors/tax-agents"
+              className="group bg-white/5 hover:bg-white/10 border border-white/10 rounded-xl p-5 transition-colors"
+            >
+              <div className="flex items-center gap-3 mb-2">
+                <Icon name="calculator" size={20} className="text-emerald-400" />
+                <h3 className="text-base font-extrabold text-white group-hover:text-emerald-300">
+                  Tax agents
+                </h3>
+              </div>
+              <p className="text-xs md:text-sm text-slate-300">
+                Going-concern GST positioning, asset depreciation schedules
+                and small-business CGT concessions for income-asset
+                acquisitions.
+              </p>
+            </Link>
+
+            <Link
+              href="/advisors/mortgage-brokers"
+              className="group bg-white/5 hover:bg-white/10 border border-white/10 rounded-xl p-5 transition-colors"
+            >
+              <div className="flex items-center gap-3 mb-2">
+                <Icon name="wallet" size={20} className="text-emerald-400" />
+                <h3 className="text-base font-extrabold text-white group-hover:text-emerald-300">
+                  Commercial finance brokers
+                </h3>
+              </div>
+              <p className="text-xs md:text-sm text-slate-300">
+                Asset finance, commercial real estate finance and unsecured
+                business loans across bank and non-bank lenders.
+              </p>
+            </Link>
+          </div>
+
+          <Link
+            href="/find-advisor?focus=income-assets"
+            className="inline-flex items-center gap-2 bg-emerald-500 hover:bg-emerald-400 text-white font-extrabold text-sm md:text-base px-6 py-3 rounded-lg transition-colors"
+          >
+            Match me with an adviser
+            <Icon name="bookmark" size={16} />
+          </Link>
+        </div>
+      </section>
+
+      {/* Compliance footer */}
+      <section className="py-6 bg-slate-50 border-t border-slate-200">
+        <div className="container-custom max-w-4xl">
+          <p className="text-[11px] text-slate-500 leading-relaxed">
+            <strong className="text-slate-600">General Advice Warning:</strong>{" "}
+            {GENERAL_ADVICE_WARNING}
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/invest/ipo-calendar/page.tsx
+++ b/app/invest/ipo-calendar/page.tsx
@@ -1,0 +1,541 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import Icon from "@/components/Icon";
+import NewsletterSignup from "@/components/NewsletterSignup";
+import {
+  breadcrumbJsonLd,
+  SITE_URL,
+  SITE_NAME,
+  CURRENT_YEAR,
+} from "@/lib/seo";
+import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
+
+export const revalidate = 3600;
+
+export const metadata: Metadata = {
+  title: `ASX IPO Calendar (${CURRENT_YEAR}) — Upcoming Australian IPOs & Recent Listings`,
+  description:
+    "Track upcoming ASX IPOs and recent Australian listings. Broker priority allocations, retail allocation rules, lockup periods and first-day pop history.",
+  alternates: { canonical: `${SITE_URL}/invest/ipo-calendar` },
+  openGraph: {
+    title: `ASX IPO Calendar (${CURRENT_YEAR})`,
+    description:
+      "Upcoming ASX IPOs, recently listed companies and how to access broker IPO allocations as a retail investor.",
+    url: `${SITE_URL}/invest/ipo-calendar`,
+  },
+};
+
+const ACCESS_ROUTES = [
+  {
+    id: "broker-priority",
+    label: "Broker priority allocations",
+    body:
+      "CommSec, nabtrade, Macquarie Direct, Morgans and Bell Direct receive priority allocations from corporate advisors managing the IPO. Eligible retail clients of those brokers can apply through the broker's IPO portal — typically a digital application 5–10 business days before the offer closes. Allocations are not guaranteed; oversubscribed IPOs are scaled back. Premium brokers (Morgans, Bell Direct) tend to receive larger retail allocations than discount brokers.",
+    cta: { label: "Compare ASX brokers", href: "/compare?category=shares" },
+  },
+  {
+    id: "broker-managed-offers",
+    label: "Broker-managed offers",
+    body:
+      "Where a stockbroker is the lead manager or co-manager on an IPO, their clients receive priority. Morgans, Bell Potter, E&P (formerly Evans Dixon), Wilsons and Canaccord are the principal mid-cap IPO desks. To access these offers reliably you typically need a meaningful trading account or a private wealth relationship — retail accounts at these brokers see allocations on smaller IPOs and roll-overs, not the marquee deals.",
+    cta: { label: "Find a private wealth manager", href: "/advisors/private-wealth-managers" },
+  },
+  {
+    id: "general-public-offer",
+    label: "General public offer",
+    body:
+      "Some IPOs include a general public offer accessible without a brokerage relationship — you complete the application form attached to the prospectus and pay by BPAY or cheque. Public offers are most common on smaller-cap (sub-$200M) ASX listings where the corporate advisor needs broad retail subscription to hit the minimum spread. ASIC requires every IPO to include a prospectus accessible via OnMarket, the company website and offerlists.",
+    cta: { label: "Browse the prospectus library", href: "/invest/ipos" },
+  },
+  {
+    id: "onmarket",
+    label: "OnMarket platform",
+    body:
+      "OnMarket is the dominant Australian platform aggregating public-offer IPOs and small-cap placements for retail investors. Free to register; no brokerage relationship required. The platform handles allocation, settlement and CHESS HIN cross-reference. Useful for accessing smaller deals where the discount broker channel doesn't get an allocation.",
+    cta: { label: "Find a stockbroker", href: "/advisors/stockbroker-firms" },
+  },
+];
+
+const RECENT_LISTINGS = [
+  {
+    code: "GYG",
+    name: "Guzman y Gomez",
+    sector: "Consumer (Restaurants)",
+    listingDate: "Jun 2024",
+    issuePrice: "$22.00",
+    raised: "$335M",
+    note: "First-day pop ~36%",
+  },
+  {
+    code: "DIGICO",
+    name: "DigiCo Infrastructure REIT",
+    sector: "Infrastructure REIT",
+    listingDate: "Dec 2024",
+    issuePrice: "$5.00",
+    raised: "$2.0B",
+    note: "Largest 2024 ASX IPO by raise",
+  },
+  {
+    code: "RVA",
+    name: "Reventon Resources",
+    sector: "Critical minerals",
+    listingDate: "Q4 2024",
+    issuePrice: "$0.20",
+    raised: "$10M",
+    note: "Small-cap mining listing",
+  },
+  {
+    code: "NICK",
+    name: "Nickel Industries (re-list)",
+    sector: "Mining",
+    listingDate: "2024",
+    issuePrice: "n/a",
+    raised: "$300M+",
+    note: "Compliance re-listing",
+  },
+  {
+    code: "ARI",
+    name: "Aerison Group",
+    sector: "Industrial services",
+    listingDate: "Q1 2025",
+    issuePrice: "$1.50",
+    raised: "$60M",
+    note: "Mid-cap industrial",
+  },
+  {
+    code: "VIRGIN",
+    name: "Virgin Australia (re-list)",
+    sector: "Aviation",
+    listingDate: "Pending",
+    issuePrice: "TBC",
+    raised: "$685M (target)",
+    note: "Bain Capital re-list",
+  },
+];
+
+const FAQS = [
+  {
+    question: "How do I apply for an ASX IPO as a retail investor?",
+    answer:
+      "Three routes: through a broker that holds priority allocation (CommSec, nabtrade, Morgans, Bell Direct, Macquarie Direct), through a public offer attached to the prospectus by completing the application form and paying via BPAY, or through OnMarket which aggregates retail-eligible offers. Most marquee ASX IPOs are channelled through brokers with priority allocation rather than public offers.",
+  },
+  {
+    question: "How are retail vs institutional allocations split?",
+    answer:
+      "Retail allocations on Australian IPOs typically run 5%–15% of the total raise, depending on size and demand profile. Institutional allocation (priority bookbuild) takes the bulk. Larger IPOs above $500M raise typically have higher retail allocations because the retail tail is needed for spread requirements; smaller mid-cap IPOs often allocate >90% to institutions and broker-priority retail.",
+  },
+  {
+    question: "What is a lockup period and why does it matter?",
+    answer:
+      "Lockups (also called escrow) restrict pre-IPO shareholders — founders, employees, pre-IPO investors and advisors — from selling shares for a defined period after listing, usually 6, 12 or 24 months. ASX-imposed escrow applies to vendors of mining and biotech companies that listed via prospectus assets. Discretionary escrow is negotiated by the corporate advisor as part of the IPO. Lockup expiry days frequently trigger meaningful share-price selling pressure as escrowed holders sell.",
+  },
+  {
+    question: "How do ASX IPOs perform vs the index historically?",
+    answer:
+      "Australian IPO first-day returns average around 7%–10% across the long-run historical record (ASIC, Aussie IPO and the SIRCA database), but median first-day return is closer to flat — averages are skewed by the tail of high-pop deals. 12-month post-IPO returns are mixed — IPOs underperform the ASX 200 over the medium term on average, with significant dispersion. Picking IPOs that beat the index requires real research; passive IPO exposure does not historically pay.",
+  },
+  {
+    question: "Can I get an allocation as a small retail investor?",
+    answer:
+      "Yes for general public offers (apply via prospectus or OnMarket), and for smaller-cap IPOs through CommSec, nabtrade and OnMarket where minimum applications start at $1,000–$2,500. Marquee large-cap IPOs (DigiCo, GYG-style) are heavily oversubscribed and retail allocations are scaled meaningfully — you may apply for $20,000 and receive $2,000. A private wealth or premium-broker relationship is the practical route to consistent allocations on the bigger deals.",
+  },
+  {
+    question: "What's the tax treatment of IPO shares?",
+    answer:
+      "Shares acquired via IPO are treated as standard share acquisitions for CGT purposes — cost base is the issue price. Selling within 12 months attracts the full CGT rate at your marginal income; 50% CGT discount applies after 12 months for individuals. Stag-trade strategies (selling on day one) realise the gain at full marginal rate. IPOs settled via SRN rather than CHESS HIN have separate tax administration — most retail subscribers receive CHESS-sponsored shares through their broker.",
+  },
+  {
+    question: "Do all ASX IPOs include a public offer?",
+    answer:
+      "No. Many ASX IPOs are placement-only or broker-firm-only — accessible only to clients of the lead and co-managers and to wholesale investors via the institutional bookbuild. Public offers are more common on smaller cap and on raises where the corporate advisor wants broad retail spread. Read the prospectus front-cover allocation note to check whether a public offer is included.",
+  },
+];
+
+export default function IpoCalendarPage() {
+  const breadcrumb = breadcrumbJsonLd([
+    { name: "Home", url: `${SITE_URL}/` },
+    { name: "Invest", url: `${SITE_URL}/invest` },
+    { name: "ASX IPO Calendar" },
+  ]);
+
+  const webPage = {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    name: `ASX IPO Calendar (${CURRENT_YEAR})`,
+    url: `${SITE_URL}/invest/ipo-calendar`,
+    publisher: { "@type": "Organization", name: SITE_NAME, url: SITE_URL },
+  };
+
+  const faqPage = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: FAQS.map((f) => ({
+      "@type": "Question",
+      name: f.question,
+      acceptedAnswer: { "@type": "Answer", text: f.answer },
+    })),
+  };
+
+  return (
+    <div>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqPage) }}
+      />
+
+      {/* Hero */}
+      <section className="relative bg-white border-b border-slate-100 overflow-hidden py-8 md:py-12">
+        <div className="container-custom">
+          <nav
+            className="flex items-center gap-1.5 text-xs text-slate-500 mb-6"
+            aria-label="Breadcrumb"
+          >
+            <Link href="/" className="hover:text-slate-900 transition-colors">
+              Home
+            </Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <Link href="/invest" className="hover:text-slate-900 transition-colors">
+              Invest
+            </Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <span className="text-slate-900 font-medium">ASX IPO Calendar</span>
+          </nav>
+
+          <div className="flex flex-wrap items-center gap-2 mb-4">
+            <span className="text-[11px] font-bold uppercase px-2.5 py-0.5 rounded-full bg-indigo-100 text-indigo-800">
+              Calendar
+            </span>
+            <span className="text-[11px] font-bold uppercase px-2.5 py-0.5 rounded-full bg-slate-100 text-slate-700">
+              Independent research
+            </span>
+            <span className="text-[11px] font-bold uppercase px-2.5 py-0.5 rounded-full bg-slate-100 text-slate-700">
+              Updated {CURRENT_YEAR}
+            </span>
+          </div>
+
+          <h1 className="text-3xl md:text-4xl lg:text-5xl font-extrabold leading-tight mb-4 max-w-3xl text-slate-900">
+            ASX IPO Calendar
+          </h1>
+          <p className="text-base md:text-lg text-slate-600 leading-relaxed max-w-2xl mb-6">
+            Upcoming Australian IPOs, recent listings and how to access ASX
+            offers as a retail investor — broker priority allocations,
+            public offers, OnMarket aggregation and lockup mechanics.
+          </p>
+
+          <dl className="grid grid-cols-2 md:grid-cols-4 gap-3 max-w-2xl">
+            {[
+              { label: "ASX IPOs YTD (approx)", value: "~30" },
+              { label: "Average first-day return", value: "7–10%" },
+              { label: "Typical retail allocation", value: "5–15%" },
+              { label: "Public-offer minimum", value: "$1K–$2.5K" },
+            ].map((s) => (
+              <div
+                key={s.label}
+                className="border border-slate-200 rounded-lg bg-slate-50 px-3 py-2"
+              >
+                <dt className="text-[10px] font-bold uppercase text-slate-500 tracking-wide">
+                  {s.label}
+                </dt>
+                <dd className="text-sm font-extrabold text-slate-900 mt-0.5">
+                  {s.value}
+                </dd>
+              </div>
+            ))}
+          </dl>
+
+          <p className="text-[11px] text-slate-400 mt-3 max-w-2xl">
+            Sources: ASX listing data, ASIC IPO Outcomes report. YTD count and
+            first-day return ranges are editorially reviewed snapshots.
+          </p>
+        </div>
+      </section>
+
+      {/* Roadmap notice */}
+      <section className="py-6 md:py-8 bg-indigo-50 border-y border-indigo-200">
+        <div className="container-custom">
+          <div className="flex items-start gap-4 max-w-4xl">
+            <div className="w-10 h-10 rounded-lg bg-indigo-200 flex items-center justify-center shrink-0 mt-0.5">
+              <Icon name="info" size={20} className="text-indigo-800" />
+            </div>
+            <div>
+              <h2 className="text-sm font-extrabold uppercase tracking-wide text-indigo-800 mb-1">
+                Live data on the roadmap
+              </h2>
+              <p className="text-sm md:text-base text-indigo-900 leading-relaxed">
+                The recent-listings list below is editorially compiled. A
+                live-feed integration with ASX listing announcements is on the
+                product roadmap and will replace the static seed list with
+                automatically-updating upcoming and recent IPOs. Subscribe
+                below to be notified when the live calendar goes live and to
+                receive early notice of upcoming ASX IPOs.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* How to access ASX IPOs */}
+      <section className="py-10 md:py-12 bg-white" id="how-to-access">
+        <div className="container-custom">
+          <div className="mb-6 max-w-3xl">
+            <p className="text-xs font-bold uppercase tracking-wider text-indigo-600 mb-1">
+              Section 1 &middot; Four access routes
+            </p>
+            <h2 className="text-2xl md:text-3xl font-extrabold text-slate-900">
+              How to access ASX IPOs as a retail investor
+            </h2>
+            <p className="text-sm text-slate-500 mt-1">
+              Allocation mechanics differ meaningfully between marquee and
+              small-cap IPOs. The right access route depends on the deal size,
+              your broker relationship and whether the offer includes a public
+              offer.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {ACCESS_ROUTES.map((w, i) => (
+              <div
+                key={w.id}
+                id={w.id}
+                className="bg-slate-50 border border-slate-200 rounded-xl p-5 scroll-mt-24"
+              >
+                <div className="flex items-center gap-3 mb-3">
+                  <span className="w-8 h-8 rounded-full bg-indigo-600 text-white font-extrabold flex items-center justify-center">
+                    {i + 1}
+                  </span>
+                  <h3 className="text-lg font-bold text-slate-900">{w.label}</h3>
+                </div>
+                <p className="text-sm text-slate-700 leading-relaxed mb-4">
+                  {w.body}
+                </p>
+                <Link
+                  href={w.cta.href}
+                  className="inline-flex items-center gap-1.5 text-sm font-bold text-primary hover:underline"
+                >
+                  {w.cta.label}
+                  <Icon name="bookmark" size={14} />
+                </Link>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Filter / demo table */}
+      <section className="py-10 md:py-12 bg-slate-50 border-y border-slate-100" id="recent-listings">
+        <div className="container-custom max-w-5xl">
+          <p className="text-xs font-bold uppercase tracking-wider text-indigo-600 mb-1">
+            Section 2 &middot; Recent ASX listings
+          </p>
+          <h2 className="text-2xl md:text-3xl font-extrabold text-slate-900 mb-1">
+            Recently listed (last 6 months)
+          </h2>
+          <p className="text-sm text-slate-500 mb-6 max-w-2xl">
+            Editorially compiled snapshot of meaningful ASX IPOs. Filter by
+            sector and listing date is on the product roadmap once the live
+            ASX integration ships.
+          </p>
+
+          <div className="overflow-x-auto bg-white border border-slate-200 rounded-xl">
+            <table className="w-full text-sm border-collapse">
+              <thead>
+                <tr className="bg-slate-50 border-b border-slate-200">
+                  <th className="text-left py-3 px-4 font-semibold text-slate-700">
+                    Code
+                  </th>
+                  <th className="text-left py-3 px-4 font-semibold text-slate-700">
+                    Company
+                  </th>
+                  <th className="text-left py-3 px-4 font-semibold text-slate-700">
+                    Sector
+                  </th>
+                  <th className="text-left py-3 px-4 font-semibold text-slate-700">
+                    Listed
+                  </th>
+                  <th className="text-left py-3 px-4 font-semibold text-slate-700">
+                    Issue
+                  </th>
+                  <th className="text-left py-3 px-4 font-semibold text-slate-700">
+                    Raised
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {RECENT_LISTINGS.map((l, i) => (
+                  <tr
+                    key={l.code}
+                    className={i % 2 === 0 ? "bg-white" : "bg-slate-50/40"}
+                  >
+                    <td className="py-3 px-4 font-bold text-indigo-700 border-b border-slate-100">
+                      {l.code}
+                    </td>
+                    <td className="py-3 px-4 text-slate-800 border-b border-slate-100">
+                      <div className="font-semibold">{l.name}</div>
+                      <div className="text-xs text-slate-500 mt-0.5">
+                        {l.note}
+                      </div>
+                    </td>
+                    <td className="py-3 px-4 text-slate-600 border-b border-slate-100">
+                      {l.sector}
+                    </td>
+                    <td className="py-3 px-4 text-slate-600 border-b border-slate-100">
+                      {l.listingDate}
+                    </td>
+                    <td className="py-3 px-4 text-slate-600 border-b border-slate-100 tabular-nums">
+                      {l.issuePrice}
+                    </td>
+                    <td className="py-3 px-4 text-slate-600 border-b border-slate-100 tabular-nums">
+                      {l.raised}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <p className="text-[11px] text-slate-400 mt-3">
+            Data is editorially compiled and reviewed; market data moves
+            intraday and historical IPO data is sourced from public ASX
+            announcements.
+          </p>
+        </div>
+      </section>
+
+      {/* Newsletter signup */}
+      <section className="py-10 md:py-12 bg-white" id="alerts">
+        <div className="container-custom max-w-3xl">
+          <p className="text-xs font-bold uppercase tracking-wider text-indigo-600 mb-1">
+            Section 3 &middot; Get IPO alerts
+          </p>
+          <h2 className="text-2xl md:text-3xl font-extrabold text-slate-900 mb-2">
+            ASX IPO alerts &amp; subscriptions
+          </h2>
+          <p className="text-sm text-slate-500 mb-6">
+            Get a weekly email summary of upcoming ASX IPOs, recently lodged
+            prospectuses and broker priority-allocation windows.
+          </p>
+
+          <NewsletterSignup
+            heading="ASX IPO Calendar — Weekly"
+            body="Upcoming IPOs, prospectus lodgements and recent listing performance — short, no spam, unsubscribe any time."
+            source="ipo-calendar"
+            variant="full"
+          />
+        </div>
+      </section>
+
+      {/* FAQs */}
+      <section className="py-10 md:py-12 bg-slate-50 border-y border-slate-100" id="faqs">
+        <div className="container-custom max-w-4xl">
+          <p className="text-xs font-bold uppercase tracking-wider text-indigo-600 mb-1">
+            Section 4 &middot; FAQs
+          </p>
+          <h2 className="text-2xl md:text-3xl font-extrabold text-slate-900 mb-6">
+            ASX IPO investing — frequently asked
+          </h2>
+
+          <div className="space-y-3">
+            {FAQS.map((f) => (
+              <details
+                key={f.question}
+                className="group bg-white border border-slate-200 rounded-xl px-5 py-4"
+              >
+                <summary className="cursor-pointer font-bold text-slate-900 text-sm md:text-base flex items-start justify-between gap-3">
+                  <span>{f.question}</span>
+                  <Icon
+                    name="plus"
+                    size={18}
+                    className="text-slate-400 group-open:rotate-45 transition-transform shrink-0 mt-0.5"
+                  />
+                </summary>
+                <p className="text-sm text-slate-700 leading-relaxed mt-3">
+                  {f.answer}
+                </p>
+              </details>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Advisor CTA */}
+      <section className="py-12 md:py-14 bg-slate-900 text-white" id="find-advisor">
+        <div className="container-custom max-w-4xl">
+          <p className="text-xs font-bold uppercase tracking-wider text-indigo-400 mb-2">
+            Section 5 &middot; Get specialist help
+          </p>
+          <h2 className="text-2xl md:text-3xl font-extrabold mb-3">
+            Speak with a stockbroker for IPO access
+          </h2>
+          <p className="text-sm md:text-base text-slate-300 leading-relaxed mb-6 max-w-2xl">
+            Consistent IPO allocations on marquee deals come through full-service
+            stockbrokers and private wealth managers — not discount platforms.
+            Our directory is filtered to firms with active IPO desk presence
+            and disclosed allocation history.
+          </p>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
+            <Link
+              href="/advisors/stockbroker-firms"
+              className="group bg-white/5 hover:bg-white/10 border border-white/10 rounded-xl p-5 transition-colors"
+            >
+              <div className="flex items-center gap-3 mb-2">
+                <Icon name="trophy" size={20} className="text-indigo-400" />
+                <h3 className="text-base font-extrabold text-white group-hover:text-indigo-300">
+                  Stockbroker firms
+                </h3>
+              </div>
+              <p className="text-xs md:text-sm text-slate-300">
+                Full-service stockbrokers (Morgans, Bell Potter, Wilsons,
+                Canaccord) with active IPO desks and broker-priority retail
+                allocations.
+              </p>
+            </Link>
+
+            <Link
+              href="/advisors/private-wealth-managers"
+              className="group bg-white/5 hover:bg-white/10 border border-white/10 rounded-xl p-5 transition-colors"
+            >
+              <div className="flex items-center gap-3 mb-2">
+                <Icon name="briefcase" size={20} className="text-indigo-400" />
+                <h3 className="text-base font-extrabold text-white group-hover:text-indigo-300">
+                  Private wealth managers
+                </h3>
+              </div>
+              <p className="text-xs md:text-sm text-slate-300">
+                Private banks and wealth managers (UBS, Macquarie, Morgan
+                Stanley, JBWere) with consistent access to mid and large-cap
+                ASX IPO allocations.
+              </p>
+            </Link>
+          </div>
+
+          <Link
+            href="/find-advisor?focus=ipos"
+            className="inline-flex items-center gap-2 bg-indigo-500 hover:bg-indigo-400 text-white font-extrabold text-sm md:text-base px-6 py-3 rounded-lg transition-colors"
+          >
+            Match me with an adviser
+            <Icon name="bookmark" size={16} />
+          </Link>
+        </div>
+      </section>
+
+      {/* Compliance footer */}
+      <section className="py-6 bg-slate-50 border-t border-slate-200">
+        <div className="container-custom max-w-4xl">
+          <p className="text-[11px] text-slate-500 leading-relaxed">
+            <strong className="text-slate-600">General Advice Warning:</strong>{" "}
+            {GENERAL_ADVICE_WARNING}
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/invest/page.tsx
+++ b/app/invest/page.tsx
@@ -108,6 +108,18 @@ const CATEGORY_ICONS: Record<string, React.ReactNode> = {
   funds: (
     <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" /></svg>
   ),
+  royalties: (
+    <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8V6m0 12v2m9-10a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+  ),
+  "income-assets": (
+    <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M3 3h2l.4 2M7 13h10l4-8H5.4M7 13L5.4 5M7 13l-2.293 2.293c-.63.63-.184 1.707.707 1.707H17m0 0a2 2 0 100 4 2 2 0 000-4zm-8 2a2 2 0 11-4 0 2 2 0 014 0z" /></svg>
+  ),
+  "ipo-calendar": (
+    <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" /></svg>
+  ),
+  "pre-ipo": (
+    <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" /></svg>
+  ),
 };
 
 const ACCENT_COLORS: Record<string, { card: string; badge: string; hover: string }> = {
@@ -122,6 +134,10 @@ const ACCENT_COLORS: Record<string, { card: string; badge: string; hover: string
   "private-credit": { card: "border-teal-200 hover:border-teal-400", badge: "bg-teal-100 text-teal-700", hover: "group-hover:text-teal-700" },
   infrastructure: { card: "border-cyan-200 hover:border-cyan-400", badge: "bg-cyan-100 text-cyan-700", hover: "group-hover:text-cyan-700" },
   funds: { card: "border-violet-200 hover:border-violet-400", badge: "bg-violet-100 text-violet-700", hover: "group-hover:text-violet-700" },
+  royalties: { card: "border-rose-200 hover:border-rose-400", badge: "bg-rose-100 text-rose-700", hover: "group-hover:text-rose-700" },
+  "income-assets": { card: "border-emerald-200 hover:border-emerald-400", badge: "bg-emerald-100 text-emerald-700", hover: "group-hover:text-emerald-700" },
+  "ipo-calendar": { card: "border-indigo-200 hover:border-indigo-400", badge: "bg-indigo-100 text-indigo-700", hover: "group-hover:text-indigo-700" },
+  "pre-ipo": { card: "border-red-200 hover:border-red-400", badge: "bg-red-100 text-red-700", hover: "group-hover:text-red-700" },
 };
 
 const DEFAULT_ACCENT = { card: "border-slate-200 hover:border-slate-400", badge: "bg-slate-100 text-slate-700", hover: "group-hover:text-slate-700" };
@@ -138,6 +154,10 @@ const CATEGORY_DESCRIPTIONS: Record<string, string> = {
   "private-credit": "Private lending, mezzanine debt & structured credit.",
   infrastructure: "Toll roads, airports, utilities & public-private partnerships.",
   funds: "Hedge funds, private credit funds, REITs & SIV-complying funds.",
+  royalties: "Mining royalties (DRR), music catalogue, IP & oil-gas royalty streams.",
+  "income-assets": "Vending, ATMs, car washes, laundromats, self-storage & billboards.",
+  "ipo-calendar": "Upcoming ASX IPOs, recent listings & broker priority allocations.",
+  "pre-ipo": "Wholesale-only late-stage private placements before IPO.",
 };
 
 // Energy + commodity sector hubs. These are EDUCATIONAL pillar pages

--- a/app/invest/pre-ipo/page.tsx
+++ b/app/invest/pre-ipo/page.tsx
@@ -1,0 +1,500 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import Icon from "@/components/Icon";
+import {
+  breadcrumbJsonLd,
+  SITE_URL,
+  SITE_NAME,
+  CURRENT_YEAR,
+} from "@/lib/seo";
+import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
+
+export const revalidate = 3600;
+
+export const metadata: Metadata = {
+  title: `Pre-IPO Investing in Australia (${CURRENT_YEAR}) — Wholesale-Only Late-Stage Private Deals`,
+  description:
+    "Independent guide to pre-IPO investing in Australia. Wholesale-only — sophisticated investor (s708) requirements, common deal structures, Australian platforms (PrimaryMarkets, OnMarket Pre-IPO) and risks.",
+  alternates: { canonical: `${SITE_URL}/invest/pre-ipo` },
+  openGraph: {
+    title: `Pre-IPO Investing in Australia (${CURRENT_YEAR})`,
+    description:
+      "Late-stage private placements before IPO — sophisticated and wholesale investor only. Requirements, structures, platforms and risks.",
+    url: `${SITE_URL}/invest/pre-ipo`,
+  },
+};
+
+const SECTIONS = [
+  {
+    id: "what-it-means",
+    label: "What pre-IPO investing means in Australia",
+    body:
+      "Pre-IPO investing is the purchase of equity in a private company at a late stage of growth, usually 12–36 months before an anticipated initial public offering. In the Australian market, deals reach pre-IPO investors through three primary channels: late-stage private placements led by the company's corporate advisor, secondary share buys from existing shareholders (employees, early VCs, founders) on platforms like PrimaryMarkets, and broker-syndicated pre-IPO rounds run by Macquarie, UBS, Morgans and other syndicate desks. The thesis is the IPO discount — pre-IPO shares typically clear 15%–30% below the eventual IPO offer price, plus pre-IPO upside from operational growth and pre-listing valuation expansion.",
+  },
+  {
+    id: "wholesale-requirements",
+    label: "Wholesale / sophisticated investor requirements",
+    body:
+      "Pre-IPO deals are structured as private placements relying on the section 708 disclosure exemptions in the Corporations Act 2001 (Cth). The two relevant exemptions: section 708(8) — sophisticated investor — requires either gross income of $250,000+ in each of the previous two financial years, or net assets of $2.5M (subject to the Reg 6D.2.03 calculation, which excludes the family home). Section 708(11) — wholesale investor — typically requires an accountant's certificate confirming net assets of $2.5M or gross income of $250,000+ for each of the last two years. Professional investor status (s708(11)(c)) covers AFSL holders, APRA-regulated entities and corporates with more than $10M of assets. ASIC has signalled the dollar thresholds may be reviewed in coming years, but for now they are unchanged since 2002.",
+  },
+  {
+    id: "deal-structures",
+    label: "Common pre-IPO deal structures",
+    body:
+      "Convertible notes are the most common pre-IPO structure in Australia — the note converts to equity at the IPO at a discount (typically 15%–25%) to the offer price, with a valuation cap protecting against an unexpectedly large up-round. Preference shares (with liquidation preference, anti-dilution and conversion to ordinary at IPO) are common in larger pre-IPO rounds and follow Silicon Valley conventions adapted to Australian Corporations Act drafting. SAFEs (Simple Agreement for Future Equity) are less common in Australia than the US — they exist but most Australian corporate counsel prefers convertible notes for ASIC compliance certainty. Secondary share buys from existing shareholders are growing — these transfer ordinary shares at a negotiated valuation, with the seller bearing the existing share class economics.",
+  },
+  {
+    id: "risks",
+    label: "Risks unique to pre-IPO",
+    body:
+      "Illiquidity is the dominant risk — pre-IPO shares cannot be sold until the IPO completes, and IPO timing slips. Companies that signal an 18-month IPO window often miss it, sometimes by years. Marquee Australian pre-IPOs that delayed beyond original timing include Canva, Airwallex, SafetyCulture and others. IPO pricing risk — the IPO can clear below the pre-IPO valuation if market conditions shift. Valuation marks vs realised value — convertible note 409A and last-round-mark valuations are not market-tested until exit; markdowns at IPO are common. Lockup risk post-IPO — pre-IPO investors are routinely subject to 6–12 month lockup post-listing, exposing them to share-price decline during escrow. Operational risk — the company can fail or pivot before IPO; pre-IPO equity can be wiped out in distress.",
+  },
+  {
+    id: "platforms",
+    label: "Australian platforms & channels",
+    body:
+      "PrimaryMarkets — the dominant Australian secondary marketplace for late-stage private company shares; trades shares in unlisted companies between accredited investors. OnMarket Pre-IPO — primary issuance platform; companies use OnMarket to run pre-IPO rounds open to wholesale investors. Birchal — equity crowdfunding under CSF rules (different regime — section 738 not 708); some pre-IPO rounds are accessible to retail through CSF up to $10K per investor. Sophisticated Investor Network (SIN) — invitation-only deal flow for sophisticated investors. Broker syndicate desks at Macquarie Capital, UBS Australia, Morgans, Bell Potter and Canaccord Genuity manage pre-IPO rounds for their wholesale and HNW clients alongside subsequent IPO mandates. Family offices and accountancy networks (BDO, Pitcher Partners, Findex) also intermediate pre-IPO deal flow for HNW clients with accountant's certificates in place.",
+  },
+];
+
+const FAQS = [
+  {
+    question: "Can a retail investor in Australia invest in pre-IPO?",
+    answer:
+      "Generally no — direct pre-IPO investments are wholesale-only under the section 708 disclosure exemptions. The two exceptions are: equity crowdfunding under the CSF regime (section 738) which allows retail investment up to $10,000 per company per year through licensed CSF intermediaries like Birchal and Equitise — companies under $25M assets and revenue can raise up to $5M per year via CSF; and ASX-listed pre-IPO funds (e.g. some structured offerings on the LIC market) which give indirect listed exposure to a basket of pre-IPO investments.",
+  },
+  {
+    question: "How does the accountant's certificate work?",
+    answer:
+      "An accountant's certificate (Form 708-11) is signed by a qualified accountant — registered tax agent, CA, CPA or IPA — confirming the investor has net assets of at least $2.5M or gross income of at least $250,000 for each of the last two years. The certificate is valid for two years and is provided to the issuer along with the application. The accountant should hold a current Public Practice Certificate. Misrepresentation on a 708-11 certificate exposes both the investor and accountant to penalties — Corporations Act breach plus professional disciplinary action against the accountant.",
+  },
+  {
+    question: "How are pre-IPO gains taxed in Australia?",
+    answer:
+      "Capital gains on pre-IPO shares held for more than 12 months by individuals or trusts qualify for the 50% CGT discount. Discount is not available for companies. Convertible notes have specific tax treatment under TOFA (Taxation of Financial Arrangements) — the conversion event triggers a CGT event G3 at the conversion price, with the cost base of the resulting shares becoming the conversion price plus accrued interest. Employee Share Schemes for pre-IPO shares have specific concessional rules under Division 83A — startup ESS concessions are particularly favourable for genuine startups with revenue below $50M. Always engage a tax adviser before signing a pre-IPO subscription.",
+  },
+  {
+    question: "What lockups apply post-IPO to pre-IPO shares?",
+    answer:
+      "Discretionary escrow imposed by the lead corporate advisor typically requires pre-IPO investors to hold for 6–12 months post-listing, with staggered release (e.g. 50% at 6 months, 50% at 12 months). For mining and biotech IPOs, ASX mandatory escrow rules under Listing Rule Chapter 9 may impose 12–24 months on vendor and pre-IPO holders. Escrow terms are disclosed in the prospectus — read the escrow section before subscribing pre-IPO. Escrow expiry is typically a meaningful share-price event.",
+  },
+  {
+    question: "Can foreign wholesale investors access Australian pre-IPO?",
+    answer:
+      "Yes — non-resident wholesale investors can subscribe to Australian pre-IPO offerings, but should consider FIRB notification requirements (private acquisitions of 20%+ of an Australian business above the relevant threshold trigger notification regardless of public listing status) and DTA-relief for Australian withholding tax on subsequent dividends. Foreign investment lawyers experienced with FIRB and ASIC pre-IPO compliance are essential — most wholesale offers include a foreign-investor questionnaire.",
+  },
+  {
+    question: "What's a typical pre-IPO ticket size?",
+    answer:
+      "Pre-IPO ticket sizes vary by deal. Smaller pre-IPO rounds run by OnMarket and smaller corporate advisors accept $25,000–$100,000 minimums. Mid-sized rounds (most ASX-bound mid-caps) typically clear at $100,000–$500,000 minimums. Large pre-IPOs (Canva, Airwallex-style rounds) typically have $1M+ minimums and are limited to family offices, super funds, institutional VCs and the largest HNW clients of broker syndicate desks. Ticket size doesn't determine return outcome — discipline on entry valuation matters more than allocation size.",
+  },
+  {
+    question: "How do I evaluate pre-IPO valuation honestly?",
+    answer:
+      "Compare the pre-IPO offer price to the company's recent funding rounds (Series B, C, D), to listed-comp trading multiples (revenue multiple, EBITDA multiple where applicable), and to the projected IPO offer range from the corporate advisor. Discount the projected IPO range by 30%–40% to account for IPO-window risk and pricing variance. Check the cap table — pre-IPO investors are typically junior to multiple preferred share classes; in distress, ordinary share cost basis may not be recovered. Material adverse change clauses, anti-dilution provisions and ratchet rights all materially affect the economic outcome and are disclosed in the subscription agreement.",
+  },
+];
+
+export default function PreIpoPage() {
+  const breadcrumb = breadcrumbJsonLd([
+    { name: "Home", url: `${SITE_URL}/` },
+    { name: "Invest", url: `${SITE_URL}/invest` },
+    { name: "Pre-IPO" },
+  ]);
+
+  const webPage = {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    name: `Pre-IPO Investing in Australia (${CURRENT_YEAR})`,
+    url: `${SITE_URL}/invest/pre-ipo`,
+    publisher: { "@type": "Organization", name: SITE_NAME, url: SITE_URL },
+  };
+
+  const faqPage = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: FAQS.map((f) => ({
+      "@type": "Question",
+      name: f.question,
+      acceptedAnswer: { "@type": "Answer", text: f.answer },
+    })),
+  };
+
+  return (
+    <div>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqPage) }}
+      />
+
+      {/* Hero */}
+      <section className="relative bg-white border-b border-slate-100 overflow-hidden py-8 md:py-12">
+        <div className="container-custom">
+          <nav
+            className="flex items-center gap-1.5 text-xs text-slate-500 mb-6"
+            aria-label="Breadcrumb"
+          >
+            <Link href="/" className="hover:text-slate-900 transition-colors">
+              Home
+            </Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <Link href="/invest" className="hover:text-slate-900 transition-colors">
+              Invest
+            </Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <span className="text-slate-900 font-medium">Pre-IPO</span>
+          </nav>
+
+          <div className="flex flex-wrap items-center gap-2 mb-4">
+            <span className="text-[11px] font-bold uppercase px-2.5 py-0.5 rounded-full bg-red-100 text-red-800">
+              Wholesale only
+            </span>
+            <span className="text-[11px] font-bold uppercase px-2.5 py-0.5 rounded-full bg-amber-100 text-amber-800">
+              High risk
+            </span>
+            <span className="text-[11px] font-bold uppercase px-2.5 py-0.5 rounded-full bg-slate-100 text-slate-700">
+              Independent research
+            </span>
+            <span className="text-[11px] font-bold uppercase px-2.5 py-0.5 rounded-full bg-slate-100 text-slate-700">
+              Updated {CURRENT_YEAR}
+            </span>
+          </div>
+
+          <h1 className="text-3xl md:text-4xl lg:text-5xl font-extrabold leading-tight mb-4 max-w-3xl text-slate-900">
+            Pre-IPO Investing in Australia
+          </h1>
+          <p className="text-base md:text-lg text-slate-600 leading-relaxed max-w-2xl mb-6">
+            Late-stage private company investments before initial public
+            offering — accessible only to sophisticated and wholesale investors
+            under the Corporations Act section 708 exemptions. Material risks,
+            illiquidity and IPO timing variance.
+          </p>
+
+          <dl className="grid grid-cols-2 md:grid-cols-4 gap-3 max-w-2xl">
+            {[
+              { label: "Typical ticket size", value: "$50K–$1M" },
+              { label: "Discount-to-IPO heuristic", value: "15–30%" },
+              { label: "Holding period", value: "1–3 years" },
+              { label: "Sophisticated threshold", value: "$2.5M / $250K" },
+            ].map((s) => (
+              <div
+                key={s.label}
+                className="border border-slate-200 rounded-lg bg-slate-50 px-3 py-2"
+              >
+                <dt className="text-[10px] font-bold uppercase text-slate-500 tracking-wide">
+                  {s.label}
+                </dt>
+                <dd className="text-sm font-extrabold text-slate-900 mt-0.5">
+                  {s.value}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+      </section>
+
+      {/* Wholesale-only declaration banner */}
+      <section className="py-8 md:py-10 bg-red-50 border-y-2 border-red-200">
+        <div className="container-custom">
+          <div className="flex items-start gap-4 max-w-4xl">
+            <div className="w-12 h-12 rounded-lg bg-red-200 flex items-center justify-center shrink-0 mt-0.5">
+              <Icon name="shield" size={24} className="text-red-800" />
+            </div>
+            <div>
+              <h2 className="text-base font-extrabold uppercase tracking-wide text-red-800 mb-2">
+                Wholesale &amp; Sophisticated Investors Only
+              </h2>
+              <p className="text-sm md:text-base text-red-900 leading-relaxed mb-3">
+                Pre-IPO investments described on this page are available
+                exclusively to investors meeting the wholesale or sophisticated
+                investor tests under sections 708(8), 708(10) and 708(11) of
+                the Corporations Act 2001 (Cth). Retail investors cannot access
+                these deals directly. The information on this page is general
+                information only — not financial advice, not a recommendation,
+                and not an offer to subscribe for shares or any financial
+                product. Pre-IPO investments are illiquid, high-risk, and may
+                result in total loss of capital.
+              </p>
+              <p className="text-sm md:text-base text-red-900 leading-relaxed mb-3">
+                <strong>Sophisticated investor (s708(8)) tests:</strong> gross
+                income of A$250,000+ for each of the last two financial years,
+                <em>or</em> net assets of A$2.5M (subject to Reg 6D.2.03
+                calculation excluding the family home).
+              </p>
+              <p className="text-sm md:text-base text-red-900 leading-relaxed">
+                <strong>Wholesale investor (s708(11)) tests:</strong>{" "}
+                accountant&apos;s certificate confirming net assets of A$2.5M+ or
+                gross income of A$250,000+ for each of the last two years;
+                <em> or</em> professional investor status (AFSL holder,
+                APRA-regulated entity, body corporate with more than A$10M of
+                assets).
+              </p>
+              <p className="text-xs text-red-700 mt-3">
+                Sources: Corporations Act 2001 (Cth) ss708(8)–(11);
+                Corporations Regulations 2001 reg 6D.2.03.{" "}
+                <span className="italic">
+                  Always obtain independent legal, tax and financial advice
+                  before subscribing to any pre-IPO offer.
+                </span>
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Sections */}
+      <section className="py-10 md:py-12 bg-white" id="sections">
+        <div className="container-custom">
+          <div className="mb-6 max-w-3xl">
+            <p className="text-xs font-bold uppercase tracking-wider text-red-600 mb-1">
+              Section 1 &middot; Five things to understand
+            </p>
+            <h2 className="text-2xl md:text-3xl font-extrabold text-slate-900">
+              Pre-IPO investing in Australia
+            </h2>
+            <p className="text-sm text-slate-500 mt-1">
+              The mechanics, the gating, the structures, the risks and the
+              platforms — read all five before considering a pre-IPO
+              subscription.
+            </p>
+          </div>
+
+          <div className="flex flex-wrap gap-2 mb-6" role="tablist">
+            {SECTIONS.map((s, i) => (
+              <a
+                key={s.id}
+                href={`#${s.id}`}
+                className={`inline-flex items-center gap-1.5 text-xs md:text-sm font-semibold px-3 py-1.5 rounded-full border transition-colors ${
+                  i === 0
+                    ? "bg-red-600 text-white border-red-600"
+                    : "bg-white text-slate-700 border-slate-200 hover:border-red-400 hover:text-red-700"
+                }`}
+              >
+                <span className="w-5 h-5 rounded-full bg-white/20 text-[11px] font-bold flex items-center justify-center">
+                  {i + 1}
+                </span>
+                {s.label}
+              </a>
+            ))}
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {SECTIONS.map((s, i) => (
+              <div
+                key={s.id}
+                id={s.id}
+                className="bg-slate-50 border border-slate-200 rounded-xl p-5 scroll-mt-24"
+              >
+                <div className="flex items-center gap-3 mb-3">
+                  <span className="w-8 h-8 rounded-full bg-red-600 text-white font-extrabold flex items-center justify-center">
+                    {i + 1}
+                  </span>
+                  <h3 className="text-lg font-bold text-slate-900">{s.label}</h3>
+                </div>
+                <p className="text-sm text-slate-700 leading-relaxed">
+                  {s.body}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Honest risk block */}
+      <section className="py-10 md:py-12 bg-amber-50 border-y border-amber-200">
+        <div className="container-custom max-w-4xl">
+          <div className="flex items-start gap-4">
+            <div className="w-10 h-10 rounded-lg bg-amber-200 flex items-center justify-center shrink-0 mt-0.5">
+              <Icon name="info" size={20} className="text-amber-800" />
+            </div>
+            <div>
+              <h2 className="text-sm font-extrabold uppercase tracking-wide text-amber-800 mb-2">
+                Honest disclosure on pre-IPO returns
+              </h2>
+              <p className="text-sm md:text-base text-amber-900 leading-relaxed mb-3">
+                Pre-IPO is glamorised in financial media because winners are
+                public — Canva, Atlassian (already listed), SafetyCulture,
+                Airwallex. Losers and broken IPO timing slips are not
+                publicised at the same volume. The realistic distribution of
+                pre-IPO returns for individual deals is wide:
+              </p>
+              <ul className="text-sm text-amber-900 leading-relaxed space-y-1.5 mb-3">
+                <li>
+                  <strong>~20–30%</strong> of pre-IPO investments deliver the
+                  intended IPO timing and meaningful uplift
+                </li>
+                <li>
+                  <strong>~30–40%</strong> deliver flat or modestly positive
+                  returns after IPO with delays vs original timeline
+                </li>
+                <li>
+                  <strong>~20–30%</strong> stall — IPO does not happen in the
+                  expected window and capital remains locked up
+                </li>
+                <li>
+                  <strong>~10–20%</strong> result in material capital impairment
+                  or total loss
+                </li>
+              </ul>
+              <p className="text-sm md:text-base text-amber-900 leading-relaxed">
+                Diversification across 8–15 pre-IPO investments rather than
+                concentrating in one or two is the typical pattern for
+                experienced wholesale investors. Pre-IPO should be sized as a
+                single-digit-percent allocation of total investable assets,
+                not a core holding.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* FAQs */}
+      <section className="py-10 md:py-12 bg-white" id="faqs">
+        <div className="container-custom max-w-4xl">
+          <p className="text-xs font-bold uppercase tracking-wider text-red-600 mb-1">
+            Section 2 &middot; FAQs
+          </p>
+          <h2 className="text-2xl md:text-3xl font-extrabold text-slate-900 mb-6">
+            Pre-IPO investing — frequently asked
+          </h2>
+
+          <div className="space-y-3">
+            {FAQS.map((f) => (
+              <details
+                key={f.question}
+                className="group bg-slate-50 border border-slate-200 rounded-xl px-5 py-4"
+              >
+                <summary className="cursor-pointer font-bold text-slate-900 text-sm md:text-base flex items-start justify-between gap-3">
+                  <span>{f.question}</span>
+                  <Icon
+                    name="plus"
+                    size={18}
+                    className="text-slate-400 group-open:rotate-45 transition-transform shrink-0 mt-0.5"
+                  />
+                </summary>
+                <p className="text-sm text-slate-700 leading-relaxed mt-3">
+                  {f.answer}
+                </p>
+              </details>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Advisor CTA */}
+      <section className="py-12 md:py-14 bg-slate-900 text-white" id="find-advisor">
+        <div className="container-custom max-w-4xl">
+          <p className="text-xs font-bold uppercase tracking-wider text-red-400 mb-2">
+            Section 3 &middot; Get specialist help
+          </p>
+          <h2 className="text-2xl md:text-3xl font-extrabold mb-3">
+            Speak with a wholesale investment specialist
+          </h2>
+          <p className="text-sm md:text-base text-slate-300 leading-relaxed mb-6 max-w-2xl">
+            Pre-IPO requires a wholesale-investor declaration, careful
+            valuation analysis and tax structuring. A private wealth manager
+            with active pre-IPO deal flow plus a foreign-investment lawyer (for
+            cross-border subscribers) is the standard setup before signing a
+            subscription agreement.
+          </p>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
+            <Link
+              href="/advisors/private-wealth-managers"
+              className="group bg-white/5 hover:bg-white/10 border border-white/10 rounded-xl p-5 transition-colors"
+            >
+              <div className="flex items-center gap-3 mb-2">
+                <Icon name="briefcase" size={20} className="text-red-400" />
+                <h3 className="text-base font-extrabold text-white group-hover:text-red-300">
+                  Private wealth managers
+                </h3>
+              </div>
+              <p className="text-xs md:text-sm text-slate-300">
+                Macquarie, UBS, Morgan Stanley, JBWere and boutique wealth
+                managers with consistent pre-IPO deal flow and wholesale-client
+                allocation.
+              </p>
+            </Link>
+
+            <Link
+              href="/advisors/foreign-investment-lawyers"
+              className="group bg-white/5 hover:bg-white/10 border border-white/10 rounded-xl p-5 transition-colors"
+            >
+              <div className="flex items-center gap-3 mb-2">
+                <Icon name="globe" size={20} className="text-red-400" />
+                <h3 className="text-base font-extrabold text-white group-hover:text-red-300">
+                  Foreign investment lawyers
+                </h3>
+              </div>
+              <p className="text-xs md:text-sm text-slate-300">
+                FIRB notification, ASIC pre-IPO compliance and DTA-relief
+                structuring for non-resident wholesale investors entering
+                Australian pre-IPO deals.
+              </p>
+            </Link>
+
+            <Link
+              href="/advisors/tax-agents"
+              className="group bg-white/5 hover:bg-white/10 border border-white/10 rounded-xl p-5 transition-colors"
+            >
+              <div className="flex items-center gap-3 mb-2">
+                <Icon name="calculator" size={20} className="text-red-400" />
+                <h3 className="text-base font-extrabold text-white group-hover:text-red-300">
+                  Tax agents
+                </h3>
+              </div>
+              <p className="text-xs md:text-sm text-slate-300">
+                Section 708-11 accountant&apos;s certificate, Division 83A ESS
+                interaction, TOFA convertible-note treatment and CGT discount
+                eligibility on pre-IPO holdings.
+              </p>
+            </Link>
+
+            <Link
+              href="/advisors/wealth-managers"
+              className="group bg-white/5 hover:bg-white/10 border border-white/10 rounded-xl p-5 transition-colors"
+            >
+              <div className="flex items-center gap-3 mb-2">
+                <Icon name="trophy" size={20} className="text-red-400" />
+                <h3 className="text-base font-extrabold text-white group-hover:text-red-300">
+                  Wealth managers
+                </h3>
+              </div>
+              <p className="text-xs md:text-sm text-slate-300">
+                Independent wealth managers with off-market pre-IPO and
+                secondary-market access through PrimaryMarkets, OnMarket and
+                broker syndicate desks.
+              </p>
+            </Link>
+          </div>
+
+          <Link
+            href="/find-advisor?focus=pre-ipo"
+            className="inline-flex items-center gap-2 bg-red-500 hover:bg-red-400 text-white font-extrabold text-sm md:text-base px-6 py-3 rounded-lg transition-colors"
+          >
+            Match me with a wholesale specialist
+            <Icon name="bookmark" size={16} />
+          </Link>
+        </div>
+      </section>
+
+      {/* Compliance footer */}
+      <section className="py-6 bg-slate-50 border-t border-slate-200">
+        <div className="container-custom max-w-4xl">
+          <p className="text-[11px] text-slate-500 leading-relaxed">
+            <strong className="text-slate-600">General Advice Warning:</strong>{" "}
+            {GENERAL_ADVICE_WARNING}
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/invest/royalties/page.tsx
+++ b/app/invest/royalties/page.tsx
@@ -1,0 +1,481 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import Icon from "@/components/Icon";
+import {
+  breadcrumbJsonLd,
+  SITE_URL,
+  SITE_NAME,
+  CURRENT_YEAR,
+} from "@/lib/seo";
+import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
+
+export const revalidate = 3600;
+
+export const metadata: Metadata = {
+  title: `Invest in Royalty Streams in Australia (${CURRENT_YEAR}) — Mining, Music & IP Royalties`,
+  description:
+    "Independent guide to royalty investing in Australia. Mining royalties (Deterra DRR), music catalogue royalties, IP / patent royalties, oil & gas overriding royalties — structures, tax and access.",
+  alternates: { canonical: `${SITE_URL}/invest/royalties` },
+  openGraph: {
+    title: `Invest in Royalty Streams in Australia (${CURRENT_YEAR})`,
+    description:
+      "Mining royalty streams, music catalogue royalties, IP royalties and oil & gas overriding royalties — Australian context.",
+    url: `${SITE_URL}/invest/royalties`,
+  },
+};
+
+const WAYS_TO_INVEST = [
+  {
+    id: "mining-royalties",
+    label: "Mining royalty streams",
+    body:
+      "Mining royalty companies hold the right to a percentage of revenue (gross-revenue royalty) or net smelter return (NSR) from a producing mineral asset, without bearing operating cost or capex risk. Deterra Royalties (ASX: DRR) — spun out of Iluka in 2020 — is the dominant ASX-listed pure-play, holding a 1.232% NSR over BHP's Mining Area C iron ore tenements in WA. Elemental Altus Royalties (ASX: ELT) is a global gold-focused royalty player. Cash flow is operator-driven and royalty holders rank above equity but below senior debt in distress scenarios.",
+    cta: { label: "Find a royalty broker", href: "/advisors/royalty-brokers" },
+  },
+  {
+    id: "music-royalties",
+    label: "Music catalogue royalties",
+    body:
+      "Music royalties — performance, mechanical and synchronisation income on a catalogue of songs — became an institutional asset class through funds like Hipgnosis Songs Fund (UK-listed), Round Hill Music and Concord. The US-listed Royalty Exchange platform offers fractional access to specific catalogues. In Australia, retail access is via wholesale-fund vehicles and listed UK / US wrappers; APRA AMCOS distributes performance royalties domestically. Returns are bond-like with optional growth from sync demand and inflation indexing.",
+    cta: { label: "Compare wholesale fund managers", href: "/advisors/resources-fund-managers" },
+  },
+  {
+    id: "ip-royalties",
+    label: "IP & patent royalties",
+    body:
+      "Patent and IP royalties pay licence fees on protected technology — university tech-transfer offices (CSIRO, UniMelb, UNSW) license discoveries to industry; specialised IP funds (e.g. Fortress IP, IPwe) buy or finance patent portfolios. The asset class is opaque, valuation-heavy and concentrated in litigation outcomes. Best suited to wholesale investors with patent counsel in place. Australian capital gains rules treat patent licence fees as ordinary income, not capital gains.",
+    cta: { label: "Find a wealth manager", href: "/advisors/wealth-managers" },
+  },
+  {
+    id: "petroleum-royalties",
+    label: "Oil & gas overriding royalties",
+    body:
+      "Overriding royalties (ORRIs) pay a percentage of petroleum production revenue — typically 1%–5% — independent of working-interest economics. Net-profits royalties pay a share of net cash flow. Sliding-scale royalties step up with Brent or Henry Hub price bands. Domestic transactions overlap with state petroleum royalty regimes (WA, QLD, NT) and the federal PRRT. This is the income side of the oil-gas thesis covered separately on /invest/oil-gas.",
+    cta: { label: "Find a petroleum royalties advisor", href: "/advisors/petroleum-royalties-advisors" },
+  },
+  {
+    id: "asx-royalty-plays",
+    label: "ASX-listed royalty plays",
+    body:
+      "Direct equity exposure via ASX is the most liquid route for retail investors. Deterra Royalties (DRR) trades on a trailing dividend yield around 5%, paid out near-100% of free cash flow. Lynas Rare Earths (LYC) has a residual royalty over Mt Weld processed through its Malaysian plant. Sandfire Resources (SFR) and other named royalty residues exist on smaller mid-caps. Listed exposure carries equity volatility but eliminates direct-deal minimums.",
+    cta: { label: "Compare ASX brokers", href: "/compare?category=shares" },
+  },
+];
+
+const FAQS = [
+  {
+    question: "How is a royalty deal structured in Australia?",
+    answer:
+      "Most direct royalty deals are structured as a deed of grant of royalty over a defined revenue stream — gross revenue, net smelter return (NSR), net profits, or a sliding-scale royalty linked to commodity price bands. The deed registers against the underlying tenement or asset where state law allows. The royalty holder receives quarterly or monthly payments, audit rights and a step-in right on operator default. Wholesale-investor terms are standard for non-listed deals; minimum allocations typically start at $250,000.",
+  },
+  {
+    question: "How are royalty payments taxed for Australian residents?",
+    answer:
+      "Royalties received by an Australian resident are assessable as ordinary income under section 6-5 of ITAA 1997 — they are not capital gains and the 50% CGT discount does not apply. Mining and petroleum royalties paid to non-residents are subject to royalty withholding tax under section 12-280 of the TAA, generally 30% but reduced by applicable double-tax agreements (often to 5% or 10%). Trust distributions of royalty income retain their character at the beneficiary level. Always engage a tax adviser before signing a royalty deed.",
+  },
+  {
+    question: "Can retail investors access royalty deals directly?",
+    answer:
+      "Most direct royalty deals are wholesale-only because they rely on the section 708 carve-outs from the disclosure regime. Section 708(8) (sophisticated investor: $250,000 income or $2.5M net assets) and section 708(11) (wholesale via accountant's certificate) are the typical gates. Retail investors get exposure indirectly through ASX-listed royalty companies (DRR, ELT) or registered managed investment schemes that hold royalty assets.",
+  },
+  {
+    question: "What's the difference between an NSR and a gross-revenue royalty?",
+    answer:
+      "A gross-revenue royalty pays a percentage of total revenue at the mine gate before any operator deductions — simpler to administer and harder to dispute. A net smelter return (NSR) pays a percentage of revenue after refining, smelting and transport costs are deducted by the operator. NSRs are more common for precious-metals royalties; gross-revenue royalties are common in iron ore (the Deterra-BHP MAC royalty is gross-revenue based). Net-profits royalties pay a share of net cash flow and carry materially more variability.",
+  },
+  {
+    question: "What are the main risks of royalty investing?",
+    answer:
+      "Operator concentration (one operator failing materially impacts cash flow), commodity price exposure (royalty income is leveraged to producer revenue, not cost), policy risk (state royalty regimes change), audit and disclosure risk (operators dispute royalty calculations), and illiquidity for direct deals. Music royalties add streaming-platform concentration and copyright-term decay. IP royalties add litigation outcome and patent-validity risk.",
+  },
+  {
+    question: "What minimum allocation is typical for direct royalty deals?",
+    answer:
+      "Direct mining or petroleum royalty acquisitions typically need $250,000–$5M to be commercially viable for both parties. Music catalogue secondary sales on Royalty Exchange start at $5,000 but most institutional catalogues clear at $500K+. Wholesale royalty funds offered via private placement memorandum run $50,000–$250,000 minimums. ASX-listed royalty equities have no minimum beyond standard brokerage settlement size.",
+  },
+];
+
+export default function RoyaltiesPage() {
+  const breadcrumb = breadcrumbJsonLd([
+    { name: "Home", url: `${SITE_URL}/` },
+    { name: "Invest", url: `${SITE_URL}/invest` },
+    { name: "Royalties" },
+  ]);
+
+  const webPage = {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    name: `Invest in Royalty Streams in Australia (${CURRENT_YEAR})`,
+    url: `${SITE_URL}/invest/royalties`,
+    publisher: { "@type": "Organization", name: SITE_NAME, url: SITE_URL },
+  };
+
+  const faqPage = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: FAQS.map((f) => ({
+      "@type": "Question",
+      name: f.question,
+      acceptedAnswer: { "@type": "Answer", text: f.answer },
+    })),
+  };
+
+  return (
+    <div>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqPage) }}
+      />
+
+      {/* Hero */}
+      <section className="relative bg-white border-b border-slate-100 overflow-hidden py-8 md:py-12">
+        <div className="container-custom">
+          <nav
+            className="flex items-center gap-1.5 text-xs text-slate-500 mb-6"
+            aria-label="Breadcrumb"
+          >
+            <Link href="/" className="hover:text-slate-900 transition-colors">
+              Home
+            </Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <Link href="/invest" className="hover:text-slate-900 transition-colors">
+              Invest
+            </Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <span className="text-slate-900 font-medium">Royalties</span>
+          </nav>
+
+          <div className="flex flex-wrap items-center gap-2 mb-4">
+            <span className="text-[11px] font-bold uppercase px-2.5 py-0.5 rounded-full bg-rose-100 text-rose-800">
+              Income asset
+            </span>
+            <span className="text-[11px] font-bold uppercase px-2.5 py-0.5 rounded-full bg-slate-100 text-slate-700">
+              Independent research
+            </span>
+            <span className="text-[11px] font-bold uppercase px-2.5 py-0.5 rounded-full bg-slate-100 text-slate-700">
+              Updated {CURRENT_YEAR}
+            </span>
+          </div>
+
+          <h1 className="text-3xl md:text-4xl lg:text-5xl font-extrabold leading-tight mb-4 max-w-3xl text-slate-900">
+            Invest in Royalty Streams in Australia
+          </h1>
+          <p className="text-base md:text-lg text-slate-600 leading-relaxed max-w-2xl mb-6">
+            Royalty income — paid as a percentage of revenue or net profits from
+            an underlying asset — sits between bonds and equity in the capital
+            stack. Australian retail investors can access mining royalties via
+            ASX names like Deterra (DRR), or direct music, IP and petroleum
+            royalty deals via the wholesale market.
+          </p>
+
+          <dl className="grid grid-cols-2 md:grid-cols-4 gap-3 max-w-2xl">
+            {[
+              { label: "DRR trailing yield", value: "~5%" },
+              { label: "Direct deal minimum", value: "$250K+" },
+              { label: "Royalty WHT (non-resident)", value: "30% / DTA" },
+              { label: "ASX royalty pure-plays", value: "DRR · ELT" },
+            ].map((s) => (
+              <div
+                key={s.label}
+                className="border border-slate-200 rounded-lg bg-slate-50 px-3 py-2"
+              >
+                <dt className="text-[10px] font-bold uppercase text-slate-500 tracking-wide">
+                  {s.label}
+                </dt>
+                <dd className="text-sm font-extrabold text-slate-900 mt-0.5">
+                  {s.value}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+      </section>
+
+      {/* Context banner */}
+      <section className="py-6 md:py-8 bg-rose-50 border-y border-rose-200">
+        <div className="container-custom">
+          <div className="flex items-start gap-4 max-w-4xl">
+            <div className="w-10 h-10 rounded-lg bg-rose-200 flex items-center justify-center shrink-0 mt-0.5">
+              <Icon name="info" size={20} className="text-rose-800" />
+            </div>
+            <div>
+              <h2 className="text-sm font-extrabold uppercase tracking-wide text-rose-800 mb-1">
+                What a royalty actually pays
+              </h2>
+              <p className="text-sm md:text-base text-rose-900 leading-relaxed">
+                A royalty is a contractual right to a slice of revenue or net
+                profits, separate from the equity or debt of the operator. The
+                economic position is closer to a preferred bond than common
+                equity — payments are senior to dividends, capped at the
+                contracted percentage, and not exposed to operator cost
+                blow-outs. The trade-off is no upside beyond the contracted
+                rate and exposure to underlying production decline. Royalty
+                income is taxed as ordinary income, not capital gains.
+              </p>
+              <p className="text-xs text-rose-700 mt-2">
+                <span className="italic">
+                  General information only, not financial advice.
+                </span>
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Ways to invest */}
+      <section className="py-10 md:py-12 bg-white" id="ways-to-invest">
+        <div className="container-custom">
+          <div className="mb-6 max-w-3xl">
+            <p className="text-xs font-bold uppercase tracking-wider text-rose-600 mb-1">
+              Section 1 &middot; Five ways in
+            </p>
+            <h2 className="text-2xl md:text-3xl font-extrabold text-slate-900">
+              Ways to invest in royalty streams
+            </h2>
+            <p className="text-sm text-slate-500 mt-1">
+              From ASX-listed pure-plays to direct mining royalties to music
+              catalogue funds — each route carries a different liquidity,
+              minimum and tax profile.
+            </p>
+          </div>
+
+          <div className="flex flex-wrap gap-2 mb-6" role="tablist">
+            {WAYS_TO_INVEST.map((w, i) => (
+              <a
+                key={w.id}
+                href={`#${w.id}`}
+                className={`inline-flex items-center gap-1.5 text-xs md:text-sm font-semibold px-3 py-1.5 rounded-full border transition-colors ${
+                  i === 0
+                    ? "bg-rose-600 text-white border-rose-600"
+                    : "bg-white text-slate-700 border-slate-200 hover:border-rose-400 hover:text-rose-700"
+                }`}
+              >
+                <span className="w-5 h-5 rounded-full bg-white/20 text-[11px] font-bold flex items-center justify-center">
+                  {i + 1}
+                </span>
+                {w.label}
+              </a>
+            ))}
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {WAYS_TO_INVEST.map((w, i) => (
+              <div
+                key={w.id}
+                id={w.id}
+                className="bg-slate-50 border border-slate-200 rounded-xl p-5 scroll-mt-24"
+              >
+                <div className="flex items-center gap-3 mb-3">
+                  <span className="w-8 h-8 rounded-full bg-rose-600 text-white font-extrabold flex items-center justify-center">
+                    {i + 1}
+                  </span>
+                  <h3 className="text-lg font-bold text-slate-900">{w.label}</h3>
+                </div>
+                <p className="text-sm text-slate-700 leading-relaxed mb-4">
+                  {w.body}
+                </p>
+                <Link
+                  href={w.cta.href}
+                  className="inline-flex items-center gap-1.5 text-sm font-bold text-primary hover:underline"
+                >
+                  {w.cta.label}
+                  <Icon name="bookmark" size={14} />
+                </Link>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Market overview */}
+      <section className="py-10 md:py-12 bg-slate-50 border-y border-slate-100">
+        <div className="container-custom max-w-4xl">
+          <p className="text-xs font-bold uppercase tracking-wider text-rose-600 mb-1">
+            Section 2 &middot; Market overview
+          </p>
+          <h2 className="text-2xl md:text-3xl font-extrabold text-slate-900 mb-4">
+            Australian royalty market context
+          </h2>
+
+          <div className="prose prose-slate max-w-none">
+            <p>
+              The Australian royalty market is dominated by mining royalties —
+              the legacy of state-government held royalties on iron ore, coal
+              and gold, plus a small cohort of private royalty deeds carved out
+              over decades of resource project development. Deterra Royalties
+              (ASX: DRR) sits at the centre of the listed market, with its
+              Mining Area C royalty over BHP delivering the bulk of distributable
+              cash. Elemental Altus (ELT), Sandfire (SFR) and a long tail of
+              smaller royalty residues round out the listed universe.
+            </p>
+            <p>
+              Petroleum royalties are concentrated in WA, QLD and the NT. State
+              royalty regimes differ — WA&apos;s North West Shelf royalty regime
+              shares revenue between the Commonwealth and state, while QLD
+              petroleum royalties run through the Petroleum and Gas (Production
+              and Safety) Act. Federal PRRT applies to most offshore petroleum
+              projects on top of state royalty obligations.
+            </p>
+            <p>
+              Music catalogue and IP royalty exposure for Australian investors
+              is mostly via offshore vehicles — UK-listed Hipgnosis (HSF),
+              US-listed Round Hill Music, and the Royalty Exchange secondary
+              marketplace. APRA AMCOS administers performance royalties for
+              Australian songwriters; SoundExchange is the US equivalent for
+              digital performance.
+            </p>
+            <p>
+              Pricing typically references a discount rate of 7%–12% for
+              producing mining royalties, 5%–8% for established music
+              catalogues, and 12%–20% for development-stage or pre-production
+              royalties carrying execution risk.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* FAQs */}
+      <section className="py-10 md:py-12 bg-white" id="faqs">
+        <div className="container-custom max-w-4xl">
+          <p className="text-xs font-bold uppercase tracking-wider text-rose-600 mb-1">
+            Section 3 &middot; FAQs
+          </p>
+          <h2 className="text-2xl md:text-3xl font-extrabold text-slate-900 mb-6">
+            Royalty investing — frequently asked
+          </h2>
+
+          <div className="space-y-3">
+            {FAQS.map((f) => (
+              <details
+                key={f.question}
+                className="group bg-slate-50 border border-slate-200 rounded-xl px-5 py-4"
+              >
+                <summary className="cursor-pointer font-bold text-slate-900 text-sm md:text-base flex items-start justify-between gap-3">
+                  <span>{f.question}</span>
+                  <Icon
+                    name="plus"
+                    size={18}
+                    className="text-slate-400 group-open:rotate-45 transition-transform shrink-0 mt-0.5"
+                  />
+                </summary>
+                <p className="text-sm text-slate-700 leading-relaxed mt-3">
+                  {f.answer}
+                </p>
+              </details>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Advisor CTA */}
+      <section className="py-12 md:py-14 bg-slate-900 text-white" id="find-advisor">
+        <div className="container-custom max-w-4xl">
+          <p className="text-xs font-bold uppercase tracking-wider text-rose-400 mb-2">
+            Section 4 &middot; Get specialist help
+          </p>
+          <h2 className="text-2xl md:text-3xl font-extrabold mb-3">
+            Speak with a royalties-aware adviser
+          </h2>
+          <p className="text-sm md:text-base text-slate-300 leading-relaxed mb-6 max-w-2xl">
+            Royalty deals turn on the deed wording, the operator&apos;s audit
+            rights, and the tax characterisation of the income stream. A
+            specialist adviser saves more in deal terms than they cost in fees.
+          </p>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
+            <Link
+              href="/advisors/royalty-brokers"
+              className="group bg-white/5 hover:bg-white/10 border border-white/10 rounded-xl p-5 transition-colors"
+            >
+              <div className="flex items-center gap-3 mb-2">
+                <Icon name="coins" size={20} className="text-rose-400" />
+                <h3 className="text-base font-extrabold text-white group-hover:text-rose-300">
+                  Royalty brokers
+                </h3>
+              </div>
+              <p className="text-xs md:text-sm text-slate-300">
+                Specialists who source and structure mining and petroleum
+                royalty acquisitions, secondary-market royalty sales and
+                sliding-scale deal terms.
+              </p>
+            </Link>
+
+            <Link
+              href="/advisors/petroleum-royalties-advisors"
+              className="group bg-white/5 hover:bg-white/10 border border-white/10 rounded-xl p-5 transition-colors"
+            >
+              <div className="flex items-center gap-3 mb-2">
+                <Icon name="flame" size={20} className="text-rose-400" />
+                <h3 className="text-base font-extrabold text-white group-hover:text-rose-300">
+                  Petroleum royalties advisors
+                </h3>
+              </div>
+              <p className="text-xs md:text-sm text-slate-300">
+                State petroleum royalty regimes, PRRT interaction, ORRI deal
+                structuring and secondary-market royalty valuation.
+              </p>
+            </Link>
+
+            <Link
+              href="/advisors/wealth-managers"
+              className="group bg-white/5 hover:bg-white/10 border border-white/10 rounded-xl p-5 transition-colors"
+            >
+              <div className="flex items-center gap-3 mb-2">
+                <Icon name="briefcase" size={20} className="text-rose-400" />
+                <h3 className="text-base font-extrabold text-white group-hover:text-rose-300">
+                  Wealth managers
+                </h3>
+              </div>
+              <p className="text-xs md:text-sm text-slate-300">
+                Private wealth managers with access to wholesale royalty funds
+                and offshore music / IP royalty wrappers.
+              </p>
+            </Link>
+
+            <Link
+              href="/advisors/mining-tax-advisors"
+              className="group bg-white/5 hover:bg-white/10 border border-white/10 rounded-xl p-5 transition-colors"
+            >
+              <div className="flex items-center gap-3 mb-2">
+                <Icon name="calculator" size={20} className="text-rose-400" />
+                <h3 className="text-base font-extrabold text-white group-hover:text-rose-300">
+                  Mining tax advisors
+                </h3>
+              </div>
+              <p className="text-xs md:text-sm text-slate-300">
+                Section 6-5 ordinary income treatment, royalty withholding tax,
+                DTA interaction and trust-distribution character flow-through.
+              </p>
+            </Link>
+          </div>
+
+          <Link
+            href="/find-advisor?focus=royalties"
+            className="inline-flex items-center gap-2 bg-rose-500 hover:bg-rose-400 text-white font-extrabold text-sm md:text-base px-6 py-3 rounded-lg transition-colors"
+          >
+            Match me with an adviser
+            <Icon name="bookmark" size={16} />
+          </Link>
+        </div>
+      </section>
+
+      {/* Compliance footer */}
+      <section className="py-6 bg-slate-50 border-t border-slate-200">
+        <div className="container-custom max-w-4xl">
+          <p className="text-[11px] text-slate-500 leading-relaxed">
+            <strong className="text-slate-600">General Advice Warning:</strong>{" "}
+            {GENERAL_ADVICE_WARNING}
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -34,6 +34,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     "/invest/hybrid-securities", "/invest/crypto-staking", "/invest/smsf",
     "/invest/private-equity", "/invest/bonds", "/invest/gold", "/invest/ipos",
     "/invest/oil-gas", "/invest/lithium", "/invest/uranium", "/invest/hydrogen",
+    "/invest/royalties", "/invest/income-assets", "/invest/ipo-calendar", "/invest/pre-ipo",
     "/smsf", "/smsf/auditors",
     "/research",
     "/foreign-investment/siv",

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -122,6 +122,10 @@ export default function Footer() {
                 <li><Link href="/invest/commercial-property" className="hover:text-white transition-colors inline-block py-0.5">Commercial Property</Link></li>
                 <li><Link href="/invest/renewable-energy" className="hover:text-white transition-colors inline-block py-0.5">Renewable Energy</Link></li>
                 <li><Link href="/invest/startups" className="hover:text-white transition-colors inline-block py-0.5">Startups & Tech</Link></li>
+                <li><Link href="/invest/royalties" className="hover:text-white transition-colors inline-block py-0.5">Royalties</Link></li>
+                <li><Link href="/invest/income-assets" className="hover:text-white transition-colors inline-block py-0.5">Income-Asset Businesses</Link></li>
+                <li><Link href="/invest/ipo-calendar" className="hover:text-white transition-colors inline-block py-0.5">ASX IPO Calendar</Link></li>
+                <li><Link href="/invest/pre-ipo" className="hover:text-white transition-colors inline-block py-0.5">Pre-IPO (Wholesale)</Link></li>
                 <li><Link href="/sell-business" className="hover:text-white transition-colors inline-block py-0.5">Sell a Business</Link></li>
                 <li><Link href="/dividends" className="hover:text-white transition-colors inline-block py-0.5">Dividends</Link></li>
               </ul>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -37,6 +37,8 @@ const investMegaMenu = [
       { label: "Commercial Property", href: "/invest/commercial-property", desc: "Office, industrial, hotels" },
       { label: "Startups & Tech", href: "/invest/startups", desc: "VC, angel, crowdfunding" },
       { label: "Infrastructure", href: "/invest/infrastructure", desc: "Toll roads, airports, utilities" },
+      { label: "ASX IPO Calendar", href: "/invest/ipo-calendar", desc: "Upcoming IPOs & recent listings" },
+      { label: "Pre-IPO (Wholesale)", href: "/invest/pre-ipo", desc: "Late-stage private placements" },
     ],
   },
   {
@@ -63,6 +65,8 @@ const investMegaMenu = [
       { label: "Super & SMSF", href: "/compare/super", desc: "Super fund comparisons" },
       { label: "Dividend Hub", href: "/dividends", desc: "Franking credits, ASX yield & ETFs" },
       { label: "Sell a Business", href: "/sell-business", desc: "Valuation, broker, CGT concessions" },
+      { label: "Royalty Streams", href: "/invest/royalties", desc: "Mining, music, IP & oil-gas royalties" },
+      { label: "Income-Asset Businesses", href: "/invest/income-assets", desc: "Vending, ATMs, self-storage, car washes" },
     ],
   },
 ];

--- a/lib/invest-categories.ts
+++ b/lib/invest-categories.ts
@@ -1003,6 +1003,183 @@ const categories: InvestCategory[] = [
       },
     ],
   },
+
+  // ─── Royalties ───
+  {
+    slug: "royalties",
+    label: "Royalties",
+    dbVerticals: ["fund"],
+    dbFundSubCategories: ["royalty_stream"],
+    color: {
+      bg: "bg-rose-50",
+      border: "border-rose-200",
+      text: "text-rose-700",
+      accent: "bg-rose-600",
+      gradient: "from-rose-50 to-white",
+    },
+    icon: "coins",
+    title: `Invest in Royalty Streams in Australia (${yr})`,
+    h1: "Invest in Royalty Streams in Australia",
+    metaDescription: `Mining royalties (Deterra DRR, Elemental Altus), music catalogue royalties, IP / patent royalties and oil & gas overriding royalties. ${upd}.`,
+    intro: `Royalty income — paid as a percentage of revenue or net profits from an underlying asset — sits between bonds and equity in the capital stack. Australian retail investors can access mining royalties via ASX names like Deterra (DRR), or direct music, IP and petroleum royalty deals via the wholesale market.`,
+    sections: [
+      {
+        heading: "What a royalty actually pays",
+        body: "A royalty is a contractual right to a slice of revenue or net profits, separate from the equity or debt of the operator. The economic position is closer to a preferred bond than common equity — payments are senior to dividends, capped at the contracted percentage, and not exposed to operator cost blow-outs. The trade-off is no upside beyond the contracted rate and exposure to underlying production decline.",
+      },
+      {
+        heading: "Australian royalty market context",
+        body: "The Australian royalty market is dominated by mining royalties — the legacy of state-government held royalties on iron ore, coal and gold, plus a small cohort of private royalty deeds. Deterra Royalties (ASX: DRR) sits at the centre of the listed market, with its Mining Area C royalty over BHP delivering the bulk of distributable cash. Petroleum royalties are concentrated in WA, QLD and the NT, overlapping with state royalty regimes and federal PRRT.",
+      },
+    ],
+    faqs: [
+      {
+        question: "How are royalty payments taxed for Australian residents?",
+        answer: "Royalties received by an Australian resident are assessable as ordinary income under section 6-5 of ITAA 1997 — they are not capital gains and the 50% CGT discount does not apply. Mining and petroleum royalties paid to non-residents are subject to royalty withholding tax under section 12-280 of the TAA, generally 30% but reduced by applicable double-tax agreements (often to 5% or 10%).",
+      },
+      {
+        question: "Can retail investors access royalty deals directly?",
+        answer: "Most direct royalty deals are wholesale-only, relying on the section 708 carve-outs from the disclosure regime. Retail investors get exposure indirectly through ASX-listed royalty companies (DRR, ELT) or registered managed investment schemes that hold royalty assets.",
+      },
+      {
+        question: "What minimum allocation is typical for direct royalty deals?",
+        answer: "Direct mining or petroleum royalty acquisitions typically need $250,000–$5M. Music catalogue secondary sales on Royalty Exchange start at $5,000 but most institutional catalogues clear at $500K+. ASX-listed royalty equities have no minimum beyond standard brokerage.",
+      },
+    ],
+    subcategories: [],
+  },
+
+  // ─── Income-Asset Businesses ───
+  {
+    slug: "income-assets",
+    label: "Income-Asset Businesses",
+    dbVerticals: ["business"],
+    color: {
+      bg: "bg-emerald-50",
+      border: "border-emerald-200",
+      text: "text-emerald-700",
+      accent: "bg-emerald-600",
+      gradient: "from-emerald-50 to-white",
+    },
+    icon: "wallet",
+    title: `Income-Generating Asset Businesses in Australia (${yr})`,
+    h1: "Income-Generating Asset Businesses in Australia",
+    metaDescription: `Vending routes, ATM networks, car washes, laundromats, self-storage and billboard rights — cash-flow businesses with $30K–$10M entry tickets. ${upd}.`,
+    intro: `Vending routes, ATM networks, car washes, laundromats, self-storage and billboard rights — physical-asset businesses bought for the cash flow they throw off rather than capital growth. Entry tickets from $30,000 to $10M, net yields from 6% to 25%, and a wide spectrum of owner-time commitment.`,
+    sections: [
+      {
+        heading: "Yield is not return",
+        body: "Headline net yield on an income-asset business is the cash return after operating costs but before financing, tax, replacement capex and the seller's exit value. Sustainable long-term return on capital is typically 30%–60% of the headline yield once equipment depreciation, lease renewal contingency and your owner-time are properly costed. Always model a 7–10 year horizon, not a one-year yield.",
+      },
+      {
+        heading: "Australian income-asset market context",
+        body: "The market is fragmented and almost entirely unbranded at the small-business end. Self-storage and billboard rights have institutional buyers (NSR, Storage King, oOh!media, JCDecaux); the rest is dominated by owner-operators acquiring and rolling up portfolios. Pricing is typically quoted as a multiple of seller's discretionary earnings (SDE) — 1.5×–3× for vending and ATM routes, 2×–4× for car washes and laundromats, 6–10× for self-storage facilities.",
+      },
+    ],
+    faqs: [
+      {
+        question: "How is GST treated on these business acquisitions?",
+        answer: "Going-concern transfers are GST-free under section 38-325 of the GST Act when the seller transfers all assets necessary to continue operating and both parties agree in writing. Asset-only sales not meeting the going-concern test attract 10% GST. Commercial freehold component (e.g. self-storage land, car wash freehold) may be taxed under the margin scheme if eligible.",
+      },
+      {
+        question: "What yields should I realistically expect?",
+        answer: "Net yield ranges by asset class: vending 8%–25%, ATMs 5%–25%, car washes 8%–20%, laundromats 10%–18%, self-storage 6%–9% (institutional bid-up), billboards 15%–40% on owner-cleared land. Higher headline yields almost always reflect lower asset quality.",
+      },
+      {
+        question: "How passive are these businesses really?",
+        answer: "Passive on a spectrum. Self-storage with an outsourced manager is genuinely passive (4–8 hours/month). Vending and ATM routes need 10–30 hours/week if owner-managed, near-zero if route-management is contracted out at 15%–25% of gross revenue. Car washes and laundromats are part-time-active.",
+      },
+    ],
+    subcategories: [],
+  },
+
+  // ─── ASX IPO Calendar ───
+  {
+    slug: "ipo-calendar",
+    label: "ASX IPO Calendar",
+    dbVerticals: ["startup"],
+    color: {
+      bg: "bg-indigo-50",
+      border: "border-indigo-200",
+      text: "text-indigo-700",
+      accent: "bg-indigo-600",
+      gradient: "from-indigo-50 to-white",
+    },
+    icon: "calendar",
+    title: `ASX IPO Calendar (${yr}) — Upcoming Australian IPOs`,
+    h1: "ASX IPO Calendar",
+    metaDescription: `Track upcoming ASX IPOs and recent Australian listings. Broker priority allocations, retail allocation rules, lockup periods. ${upd}.`,
+    intro: `Upcoming Australian IPOs, recent listings and how to access ASX offers as a retail investor — broker priority allocations, public offers, OnMarket aggregation and lockup mechanics.`,
+    sections: [
+      {
+        heading: "How to access ASX IPOs as a retail investor",
+        body: "Three primary routes: broker priority allocations through CommSec, nabtrade, Morgans, Bell Direct or Macquarie Direct; broker-managed offers via Morgans, Bell Potter, E&P, Wilsons or Canaccord (where you typically need a meaningful trading or wealth relationship); and general public offers attached to the prospectus, accessible via OnMarket or directly via BPAY application.",
+      },
+      {
+        heading: "Retail vs institutional allocation split",
+        body: "Retail allocations on Australian IPOs typically run 5%–15% of the total raise. Institutional priority bookbuild takes the bulk. Larger IPOs (above $500M raise) tend to have higher retail allocations because spread requirements demand a retail tail; smaller mid-cap IPOs often allocate >90% to institutions and broker-priority retail.",
+      },
+    ],
+    faqs: [
+      {
+        question: "How do ASX IPOs perform vs the index historically?",
+        answer: "Australian IPO first-day returns average around 7%–10% (ASIC, SIRCA database) but median first-day return is closer to flat — averages are skewed by the tail of high-pop deals. 12-month post-IPO returns are mixed; IPOs underperform the ASX 200 over the medium term on average, with significant dispersion. Picking IPOs that beat the index requires real research.",
+      },
+      {
+        question: "Can I get an allocation as a small retail investor?",
+        answer: "Yes for general public offers (apply via prospectus or OnMarket from $1,000–$2,500) and for smaller-cap IPOs through CommSec, nabtrade and OnMarket. Marquee large-cap IPOs are heavily oversubscribed and retail allocations are scaled meaningfully. A private wealth or premium-broker relationship is the practical route to consistent allocations.",
+      },
+      {
+        question: "What is a lockup period?",
+        answer: "Lockups (escrow) restrict pre-IPO shareholders from selling for 6, 12 or 24 months post-listing. ASX-imposed escrow applies under Listing Rule Chapter 9 to vendors of mining and biotech companies. Discretionary escrow is negotiated by the corporate advisor. Lockup expiry days frequently trigger meaningful share-price selling pressure.",
+      },
+    ],
+    subcategories: [],
+  },
+
+  // ─── Pre-IPO ───
+  {
+    slug: "pre-ipo",
+    label: "Pre-IPO",
+    dbVerticals: ["startup"],
+    color: {
+      bg: "bg-red-50",
+      border: "border-red-200",
+      text: "text-red-700",
+      accent: "bg-red-600",
+      gradient: "from-red-50 to-white",
+    },
+    icon: "trophy",
+    title: `Pre-IPO Investing in Australia (${yr}) — Wholesale Only`,
+    h1: "Pre-IPO Investing in Australia",
+    metaDescription: `Late-stage private placements before IPO — wholesale only. Sophisticated investor (s708) requirements, deal structures, Australian platforms and risks. ${upd}.`,
+    intro: `Late-stage private company investments before initial public offering — accessible only to sophisticated and wholesale investors under the Corporations Act section 708 exemptions. Material risks, illiquidity and IPO timing variance.`,
+    sections: [
+      {
+        heading: "Wholesale and sophisticated investors only",
+        body: "Pre-IPO deals are structured as private placements relying on section 708 disclosure exemptions. Sophisticated investor (s708(8)): gross income of $250,000+ for each of the last two years, or net assets of $2.5M (subject to Reg 6D.2.03 calculation excluding the family home). Wholesale investor (s708(11)): accountant's certificate confirming the equivalent thresholds, or professional investor status. Retail investors cannot access these deals directly.",
+      },
+      {
+        heading: "Australian platforms and channels",
+        body: "PrimaryMarkets dominates the secondary marketplace for late-stage private company shares. OnMarket Pre-IPO runs primary issuance for wholesale investors. Broker syndicate desks at Macquarie Capital, UBS Australia, Morgans, Bell Potter and Canaccord Genuity manage pre-IPO rounds for wholesale and HNW clients. Equity crowdfunding under CSF (s738) is a separate retail-accessible regime, capped at $10K per investor per company.",
+      },
+    ],
+    faqs: [
+      {
+        question: "Can a retail investor in Australia invest in pre-IPO?",
+        answer: "Generally no — direct pre-IPO investments are wholesale-only under section 708. The exceptions are equity crowdfunding under the CSF regime (section 738) which allows retail investment up to $10,000 per company per year through licensed CSF intermediaries like Birchal and Equitise, and ASX-listed pre-IPO funds which give indirect listed exposure to a basket of pre-IPO investments.",
+      },
+      {
+        question: "What's the realistic distribution of pre-IPO returns?",
+        answer: "Pre-IPO is glamorised because winners are public. The realistic individual-deal distribution: ~20–30% deliver intended IPO timing and meaningful uplift, ~30–40% flat or modestly positive after IPO with delays, ~20–30% stall (no IPO in the expected window, capital locked), ~10–20% material capital impairment or total loss. Diversify across 8–15 deals; size as a single-digit-percent allocation of total assets.",
+      },
+      {
+        question: "How are pre-IPO gains taxed?",
+        answer: "Capital gains on pre-IPO shares held more than 12 months by individuals or trusts qualify for the 50% CGT discount. Convertible notes have specific TOFA treatment — conversion triggers CGT event G3 with cost base equal to conversion price plus accrued interest. Division 83A ESS startup concessions can apply for genuine startups under $50M revenue. Always engage a tax adviser.",
+      },
+    ],
+    subcategories: [],
+  },
 ];
 
 // ═══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Four new top-level invest verticals + full nav/footer/sitemap/grid wiring:

- `/invest/royalties` — music catalogue royalties, mining royalty streams, IP royalties, oil-gas overrides. ASX exposure: Deterra Royalties (DRR). Advisor CTA → `/advisors/royalty-brokers`.
- `/invest/income-assets` — vending routes, ATM networks, car washes, laundromats, self-storage, billboard rights. Net yield + capex framing. Advisor CTA → `/advisors/business-brokers`.
- `/invest/ipo-calendar` — calendar-of-upcoming-ASX-IPOs view, broker priority allocation explainer, recently-listed seed list. Different angle from existing `/invest/ipos` generic pillar.
- `/invest/pre-ipo` — late-stage private deals. **Wholesale-investor s708 declaration block prominent in copy** — retail can't access these directly. Advisor CTA → `/advisors/private-wealth-managers`.

Each page follows the oil-gas/uranium hand-rolled pattern: hero, breadcrumb, key-stats strip, "ways to invest" sections, market overview, FAQs, JSON-LD (WebPage + Breadcrumb + FAQPage), advisor CTA, compliance footer. ISR `revalidate = 3600`.

Wiring:
- `lib/invest-categories.ts` — 4 new InvestCategory entries
- `app/invest/page.tsx` — 4 new entries in CATEGORY_ICONS / ACCENT_COLORS / CATEGORY_DESCRIPTIONS lookup tables (the grid is data-driven via getAllInvestCategories but per-slug visual config isn't, so visible cards required these)
- `components/Header.tsx` investMegaMenu — ipo-calendar + pre-ipo to "Sectors & Assets"; royalties + income-assets to "Income & Alternatives"
- `components/Footer.tsx` Invest column — 4 new entries
- `app/sitemap.ts` — 4 new staticPages

## Tier

**Tier A** — page UI + content. No schema migration, no API routes. Auto-merge-safe.

## Test plan

- [ ] Visit each of the 4 new URLs — confirm 200, breadcrumb correct, JSON-LD valid, FAQs render
- [ ] `/invest` homepage grid — confirm 4 new cards appear with distinct icons + accents
- [ ] Header Invest dropdown — confirm 4 new entries in correct columns
- [ ] Footer Invest column — confirm 4 new entries
- [ ] `/sitemap.xml` — confirm 4 new paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)