### PR TITLE
fix(invest): replace "Platforms" copy with "Brokers" on 8 listed-securities verticals

### DIFF
--- a/app/invest/commodities/page.tsx
+++ b/app/invest/commodities/page.tsx
@@ -114,13 +114,13 @@ export default async function CommoditiesPage() {
               href="/compare"
               className="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-400 text-slate-900 font-semibold text-sm px-5 py-2.5 rounded-lg transition-colors"
             >
-              Compare Platforms &rarr;
+              Compare Brokers &rarr;
             </Link>
             <Link
               href="/compare"
               className="inline-flex items-center gap-2 border-slate-200 text-slate-700 hover:bg-slate-50 hover:border-slate-300 font-semibold text-sm px-5 py-2.5 rounded-lg border transition-colors"
             >
-              Filter Platforms
+              Filter Brokers
             </Link>
           </div>
         </div>
@@ -354,11 +354,11 @@ export default async function CommoditiesPage() {
       </section>
 
 
-      {/* Compare Platforms */}
+      {/* Compare Brokers */}
       {brokers && brokers.length > 0 && (
         <section className="py-14 bg-slate-50">
           <div className="container-custom max-w-4xl">
-            <p className="text-xs font-bold uppercase tracking-wider text-amber-500 mb-1">Compare Platforms</p>
+            <p className="text-xs font-bold uppercase tracking-wider text-amber-500 mb-1">Compare Brokers</p>
             <h2 className="text-2xl font-extrabold text-slate-900 mb-2">Where to Trade Commodities</h2>
             <p className="text-sm text-slate-500 mb-6">Top-rated Australian platforms ranked by fees, features, and user ratings.</p>
             <div className="space-y-3">
@@ -402,7 +402,7 @@ export default async function CommoditiesPage() {
             </div>
             <div className="mt-4 text-center">
               <Link href="/compare" className="text-sm font-semibold text-amber-600 hover:text-amber-700">
-                Compare all platforms &rarr;
+                Compare all brokers &rarr;
               </Link>
             </div>
             {!SHOW_EDITORIAL_BADGES && (

--- a/app/invest/dividend-investing/page.tsx
+++ b/app/invest/dividend-investing/page.tsx
@@ -114,13 +114,13 @@ export default async function DividendInvestingPage() {
               href="/compare"
               className="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-400 text-slate-900 font-semibold text-sm px-5 py-2.5 rounded-lg transition-colors"
             >
-              Compare Platforms &rarr;
+              Compare Brokers &rarr;
             </Link>
             <Link
               href="/compare"
               className="inline-flex items-center gap-2 border-slate-200 text-slate-700 hover:bg-slate-50 hover:border-slate-300 font-semibold text-sm px-5 py-2.5 rounded-lg border transition-colors"
             >
-              Filter Platforms
+              Filter Brokers
             </Link>
           </div>
         </div>
@@ -367,11 +367,11 @@ export default async function DividendInvestingPage() {
       </section>
 
 
-      {/* Compare Platforms */}
+      {/* Compare Brokers */}
       {brokers && brokers.length > 0 && (
         <section className="py-14 bg-slate-50">
           <div className="container-custom max-w-4xl">
-            <p className="text-xs font-bold uppercase tracking-wider text-amber-500 mb-1">Compare Platforms</p>
+            <p className="text-xs font-bold uppercase tracking-wider text-amber-500 mb-1">Compare Brokers</p>
             <h2 className="text-2xl font-extrabold text-slate-900 mb-2">Best Platforms for Dividend Investing</h2>
             <p className="text-sm text-slate-500 mb-6">Top-rated Australian platforms ranked by fees, features, and user ratings.</p>
             <div className="space-y-3">
@@ -415,7 +415,7 @@ export default async function DividendInvestingPage() {
             </div>
             <div className="mt-4 text-center">
               <Link href="/compare" className="text-sm font-semibold text-amber-600 hover:text-amber-700">
-                Compare all platforms &rarr;
+                Compare all brokers &rarr;
               </Link>
             </div>
             {!SHOW_EDITORIAL_BADGES && (

--- a/app/invest/hybrid-securities/page.tsx
+++ b/app/invest/hybrid-securities/page.tsx
@@ -121,7 +121,7 @@ export default async function HybridSecuritiesPage() {
               href="/compare"
               className="inline-flex items-center gap-2 border-slate-200 text-slate-700 hover:bg-slate-50 hover:border-slate-300 font-semibold text-sm px-5 py-2.5 rounded-lg border transition-colors"
             >
-              Filter Platforms
+              Filter Brokers
             </Link>
           </div>
         </div>
@@ -324,11 +324,11 @@ export default async function HybridSecuritiesPage() {
       </section>
 
 
-      {/* Compare Platforms */}
+      {/* Compare Brokers */}
       {brokers && brokers.length > 0 && (
         <section className="py-14 bg-slate-50">
           <div className="container-custom max-w-4xl">
-            <p className="text-xs font-bold uppercase tracking-wider text-amber-500 mb-1">Compare Platforms</p>
+            <p className="text-xs font-bold uppercase tracking-wider text-amber-500 mb-1">Compare Brokers</p>
             <h2 className="text-2xl font-extrabold text-slate-900 mb-2">Where to Buy Hybrid Securities</h2>
             <p className="text-sm text-slate-500 mb-6">Top-rated Australian platforms ranked by fees, features, and user ratings.</p>
             <div className="space-y-3">
@@ -372,7 +372,7 @@ export default async function HybridSecuritiesPage() {
             </div>
             <div className="mt-4 text-center">
               <Link href="/compare" className="text-sm font-semibold text-amber-600 hover:text-amber-700">
-                Compare all platforms &rarr;
+                Compare all brokers &rarr;
               </Link>
             </div>
             {!SHOW_EDITORIAL_BADGES && (

--- a/app/invest/infrastructure/page.tsx
+++ b/app/invest/infrastructure/page.tsx
@@ -121,7 +121,7 @@ export default async function InfrastructurePage() {
               href="/compare"
               className="inline-flex items-center gap-2 border-slate-200 text-slate-700 hover:bg-slate-50 hover:border-slate-300 font-semibold text-sm px-5 py-2.5 rounded-lg border transition-colors"
             >
-              Filter Platforms
+              Filter Brokers
             </Link>
           </div>
         </div>
@@ -330,11 +330,11 @@ export default async function InfrastructurePage() {
       </section>
 
 
-      {/* Compare Platforms */}
+      {/* Compare Brokers */}
       {brokers && brokers.length > 0 && (
         <section className="py-14 bg-slate-50">
           <div className="container-custom max-w-4xl">
-            <p className="text-xs font-bold uppercase tracking-wider text-amber-500 mb-1">Compare Platforms</p>
+            <p className="text-xs font-bold uppercase tracking-wider text-amber-500 mb-1">Compare Brokers</p>
             <h2 className="text-2xl font-extrabold text-slate-900 mb-2">Where to Buy Infrastructure Stocks</h2>
             <p className="text-sm text-slate-500 mb-6">Top-rated Australian platforms ranked by fees, features, and user ratings.</p>
             <div className="space-y-3">
@@ -378,7 +378,7 @@ export default async function InfrastructurePage() {
             </div>
             <div className="mt-4 text-center">
               <Link href="/compare" className="text-sm font-semibold text-amber-600 hover:text-amber-700">
-                Compare all platforms &rarr;
+                Compare all brokers &rarr;
               </Link>
             </div>
             {!SHOW_EDITORIAL_BADGES && (

--- a/app/invest/managed-funds/page.tsx
+++ b/app/invest/managed-funds/page.tsx
@@ -114,13 +114,13 @@ export default async function ManagedFundsPage() {
               href="/compare"
               className="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-400 text-slate-900 font-semibold text-sm px-5 py-2.5 rounded-lg transition-colors"
             >
-              Compare Platforms &rarr;
+              Compare Brokers &rarr;
             </Link>
             <Link
               href="/compare"
               className="inline-flex items-center gap-2 border-slate-200 text-slate-700 hover:bg-slate-50 hover:border-slate-300 font-semibold text-sm px-5 py-2.5 rounded-lg border transition-colors"
             >
-              Filter Platforms
+              Filter Brokers
             </Link>
           </div>
         </div>
@@ -314,11 +314,11 @@ export default async function ManagedFundsPage() {
         </div>
       </section>
 
-      {/* Compare Platforms */}
+      {/* Compare Brokers */}
       {brokers && brokers.length > 0 && (
         <section className="py-14 bg-slate-50">
           <div className="container-custom max-w-4xl">
-            <p className="text-xs font-bold uppercase tracking-wider text-amber-500 mb-1">Compare Platforms</p>
+            <p className="text-xs font-bold uppercase tracking-wider text-amber-500 mb-1">Compare Brokers</p>
             <h2 className="text-2xl font-extrabold text-slate-900 mb-2">Where to Buy Managed Funds &amp; ETFs</h2>
             <p className="text-sm text-slate-500 mb-6">Top-rated Australian platforms ranked by fees, features, and user ratings.</p>
             <div className="space-y-3">
@@ -362,7 +362,7 @@ export default async function ManagedFundsPage() {
             </div>
             <div className="mt-4 text-center">
               <Link href="/compare" className="text-sm font-semibold text-amber-600 hover:text-amber-700">
-                Compare all platforms &rarr;
+                Compare all brokers &rarr;
               </Link>
             </div>
             {!SHOW_EDITORIAL_BADGES && (

--- a/app/invest/options-trading/page.tsx
+++ b/app/invest/options-trading/page.tsx
@@ -114,13 +114,13 @@ export default async function OptionsDerivativesPage() {
               href="/compare"
               className="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-400 text-slate-900 font-semibold text-sm px-5 py-2.5 rounded-lg transition-colors"
             >
-              Compare Platforms &rarr;
+              Compare Brokers &rarr;
             </Link>
             <Link
               href="/compare"
               className="inline-flex items-center gap-2 border-slate-200 text-slate-700 hover:bg-slate-50 hover:border-slate-300 font-semibold text-sm px-5 py-2.5 rounded-lg border transition-colors"
             >
-              Filter Platforms
+              Filter Brokers
             </Link>
           </div>
         </div>
@@ -353,11 +353,11 @@ export default async function OptionsDerivativesPage() {
       </section>
 
 
-      {/* Compare Platforms */}
+      {/* Compare Brokers */}
       {brokers && brokers.length > 0 && (
         <section className="py-14 bg-slate-50">
           <div className="container-custom max-w-4xl">
-            <p className="text-xs font-bold uppercase tracking-wider text-amber-500 mb-1">Compare Platforms</p>
+            <p className="text-xs font-bold uppercase tracking-wider text-amber-500 mb-1">Compare Brokers</p>
             <h2 className="text-2xl font-extrabold text-slate-900 mb-2">Best Options &amp; CFD Platforms</h2>
             <p className="text-sm text-slate-500 mb-6">Top-rated Australian platforms ranked by fees, features, and user ratings.</p>
             <div className="space-y-3">
@@ -401,7 +401,7 @@ export default async function OptionsDerivativesPage() {
             </div>
             <div className="mt-4 text-center">
               <Link href="/compare" className="text-sm font-semibold text-amber-600 hover:text-amber-700">
-                Compare all platforms &rarr;
+                Compare all brokers &rarr;
               </Link>
             </div>
             {!SHOW_EDITORIAL_BADGES && (
@@ -496,7 +496,7 @@ export default async function OptionsDerivativesPage() {
               href="/compare"
               className="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-400 text-slate-900 font-semibold text-sm px-5 py-2.5 rounded-lg transition-colors shrink-0"
             >
-              Compare Platforms &rarr;
+              Compare Brokers &rarr;
             </Link>
           </div>
         </div>

--- a/app/invest/reits/page.tsx
+++ b/app/invest/reits/page.tsx
@@ -114,13 +114,13 @@ export default async function ReitsPage() {
               href="/compare"
               className="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-400 text-slate-900 font-semibold text-sm px-5 py-2.5 rounded-lg transition-colors"
             >
-              Compare Platforms &rarr;
+              Compare Brokers &rarr;
             </Link>
             <Link
               href="/compare"
               className="inline-flex items-center gap-2 border-slate-200 text-slate-700 hover:bg-slate-50 hover:border-slate-300 font-semibold text-sm px-5 py-2.5 rounded-lg border transition-colors"
             >
-              Filter Platforms
+              Filter Brokers
             </Link>
           </div>
         </div>
@@ -360,11 +360,11 @@ export default async function ReitsPage() {
       </section>
 
 
-      {/* Compare Platforms */}
+      {/* Compare Brokers */}
       {brokers && brokers.length > 0 && (
         <section className="py-14 bg-slate-50">
           <div className="container-custom max-w-4xl">
-            <p className="text-xs font-bold uppercase tracking-wider text-amber-500 mb-1">Compare Platforms</p>
+            <p className="text-xs font-bold uppercase tracking-wider text-amber-500 mb-1">Compare Brokers</p>
             <h2 className="text-2xl font-extrabold text-slate-900 mb-2">Where to Buy A-REITs</h2>
             <p className="text-sm text-slate-500 mb-6">Top-rated Australian platforms ranked by fees, features, and user ratings.</p>
             <div className="space-y-3">
@@ -408,7 +408,7 @@ export default async function ReitsPage() {
             </div>
             <div className="mt-4 text-center">
               <Link href="/compare" className="text-sm font-semibold text-amber-600 hover:text-amber-700">
-                Compare all platforms &rarr;
+                Compare all brokers &rarr;
               </Link>
             </div>
             {!SHOW_EDITORIAL_BADGES && (

--- a/app/invest/smsf/page.tsx
+++ b/app/invest/smsf/page.tsx
@@ -121,7 +121,7 @@ export default async function SmsfInvestmentPage() {
               href="/compare"
               className="inline-flex items-center gap-2 border-slate-200 text-slate-700 hover:bg-slate-50 hover:border-slate-300 font-semibold text-sm px-5 py-2.5 rounded-lg border transition-colors"
             >
-              Filter Platforms
+              Filter Brokers
             </Link>
           </div>
         </div>
@@ -432,11 +432,11 @@ export default async function SmsfInvestmentPage() {
       </section>
 
 
-      {/* Compare Platforms */}
+      {/* Compare Brokers */}
       {brokers && brokers.length > 0 && (
         <section className="py-14 bg-slate-50">
           <div className="container-custom max-w-4xl">
-            <p className="text-xs font-bold uppercase tracking-wider text-amber-500 mb-1">Compare Platforms</p>
+            <p className="text-xs font-bold uppercase tracking-wider text-amber-500 mb-1">Compare Brokers</p>
             <h2 className="text-2xl font-extrabold text-slate-900 mb-2">Best SMSF Trading Platforms</h2>
             <p className="text-sm text-slate-500 mb-6">Top-rated Australian platforms ranked by fees, features, and user ratings.</p>
             <div className="space-y-3">
@@ -480,7 +480,7 @@ export default async function SmsfInvestmentPage() {
             </div>
             <div className="mt-4 text-center">
               <Link href="/compare" className="text-sm font-semibold text-amber-600 hover:text-amber-700">
-                Compare all platforms &rarr;
+                Compare all brokers &rarr;
               </Link>
             </div>
             {!SHOW_EDITORIAL_BADGES && (


### PR DESCRIPTION
## Summary

Eight `/invest/*` verticals had hero CTAs reading "Compare Platforms" / "Filter Platforms" — copy carried across from `/share-trading` or `/crypto` when these pages were templated. The data layer on each correctly queries `platform_type='share_broker'`, so the comparison rendered IS a broker comparison. Only the **labels** were wrong.

## Affected pages

| Page | Broker query | Now reads |
|---|---|---|
| `/invest/reits` | `share_broker` | Compare Brokers |
| `/invest/dividend-investing` | `share_broker` | Compare Brokers |
| `/invest/managed-funds` | `share_broker` + `robo_advisor` | Compare Brokers |
| `/invest/hybrid-securities` | `share_broker` | Compare Brokers |
| `/invest/commodities` | `share_broker` + `cfd_forex` | Compare Brokers |
| `/invest/infrastructure` | `share_broker` | Compare Brokers |
| `/invest/options-trading` | `cfd_forex` + `share_broker` | Compare Brokers |
| `/invest/smsf` | `share_broker` | Compare Brokers |

## Untouched (genuine platform contexts)

| Page | Why "Platforms" stays |
|---|---|
| `/invest/alternatives` + `/alternatives/guides` | Fractional alts (Vinovest, Masterworks, Maverix, Rally) ARE platforms |
| `/invest/crypto-staking` | Crypto exchanges (Coinbase, Kraken, Binance) ARE platforms |
| `/invest/forex` | CFD/FX platforms (Pepperstone, IC Markets, IG, CMC) ARE platforms |
| `/invest/private-credit` | P2P lending (Plenti, La Trobe Financial) ARE platforms |

## Tier

**Tier A** — pure copy fix. No data layer, no schema, no API.

## Test plan

- [ ] Visit `/invest/reits` — confirm hero CTA reads "Compare Brokers"
- [ ] Spot-check 2–3 other affected pages
- [ ] Confirm `/invest/alternatives` and `/invest/forex` still read "Compare Platforms" (correct context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)