### PR TITLE
docs(g): G-03 batch 6 — rollback headers for 10 migrations (20260402–20260413) [audit remediation]

### DIFF
--- a/supabase/migrations/20260402_investment_verticals.sql
+++ b/supabase/migrations/20260402_investment_verticals.sql
@@ -1,6 +1,14 @@
 -- 20260402_investment_verticals.sql
 -- Investment verticals table and seed data for the /invest hub
 -- ============================================================
+--
+-- Rollback (in reverse order):
+--   3. DROP INDEX IF EXISTS investment_verticals_sort_idx;
+--   2. DROP INDEX IF EXISTS investment_verticals_slug_idx;
+--   1. DROP TABLE IF EXISTS investment_verticals;
+--   Note: Seed rows (INSERTs) are removed with the table. Re-running the
+--         migration re-seeds them from the INSERT block below.
+--         RLS policies drop with the table — no separate DROP POLICY needed.
 
 CREATE TABLE IF NOT EXISTS investment_verticals (
   id SERIAL PRIMARY KEY,

--- a/supabase/migrations/20260405_seed_listing_images.sql
+++ b/supabase/migrations/20260405_seed_listing_images.sql
@@ -1,6 +1,13 @@
 -- Seed investment listing images with curated Unsplash photos
 -- Each listing gets 3-4 images relevant to its vertical and type
 -- Also adds hero_image column to investment_verticals
+--
+-- Rollback:
+--   1. ALTER TABLE investment_verticals DROP COLUMN IF EXISTS hero_image;
+--   2. UPDATE investment_listings SET images = '{}' WHERE images IS NOT NULL;
+--   Note: The UPDATE seed rows are data-only (no schema change). The images
+--         array on investment_listings had no prior values before this migration
+--         ran, so resetting to empty array is the safe rollback path.
 
 -- ─── Add hero_image to investment_verticals ─────────────────────────────────
 ALTER TABLE investment_verticals ADD COLUMN IF NOT EXISTS hero_image TEXT;

--- a/supabase/migrations/20260408_tier1_revenue_features.sql
+++ b/supabase/migrations/20260408_tier1_revenue_features.sql
@@ -2,6 +2,18 @@
 -- Tier 1 Revenue Features Migration
 -- Features: Signup Tracking, A/B Testing, Drip Funnel
 -- ============================================================
+--
+-- Rollback (in reverse order):
+--   5. DROP TABLE IF EXISTS drip_affiliate_clicks;
+--   4. ALTER TABLE investor_drip_log
+--        DROP COLUMN IF EXISTS drip_type,
+--        DROP COLUMN IF EXISTS broker_recommendations,
+--        DROP COLUMN IF EXISTS opened_at,
+--        DROP COLUMN IF EXISTS clicked_at;
+--   3. DROP TABLE IF EXISTS site_ab_tests;
+--   2. DROP TABLE IF EXISTS affiliate_monthly_reports;
+--   1. DROP TABLE IF EXISTS broker_signups;
+--   Note: RLS policies and indexes drop with their tables.
 
 -- ── Feature 1: Broker Signup Tracking ───────────────────────
 

--- a/supabase/migrations/20260408_tier2_traffic_features.sql
+++ b/supabase/migrations/20260408_tier2_traffic_features.sql
@@ -2,6 +2,20 @@
 -- Tier 2 Traffic Features Migration
 -- Features: Fee Alerts, Suburb Guides, Newsletter Archive
 -- ============================================================
+--
+-- Rollback (in reverse order):
+--   4. DROP TABLE IF EXISTS newsletter_editions;
+--   3. DROP TABLE IF EXISTS newsletter_sends;
+--   2. DROP INDEX IF EXISTS idx_suburb_data_slug;
+--      ALTER TABLE suburb_data
+--        DROP COLUMN IF EXISTS slug,
+--        DROP COLUMN IF EXISTS seo_description,
+--        DROP COLUMN IF EXISTS investment_summary,
+--        DROP COLUMN IF EXISTS infrastructure_notes,
+--        DROP COLUMN IF EXISTS schools_rating,
+--        DROP COLUMN IF EXISTS transport_rating;
+--   1. DROP TABLE IF EXISTS fee_alert_subscriptions;
+--   Note: RLS policies and indexes drop with their tables.
 
 -- ── Feature 7: Fee Alert Subscriptions (formalize) ──────────
 

--- a/supabase/migrations/20260411_features_11_12_14_15_16_18.sql
+++ b/supabase/migrations/20260411_features_11_12_14_15_16_18.sql
@@ -3,6 +3,33 @@
 -- User Accounts, Price Drop Notifications, Q&A Upvoting,
 -- Review Verification, Financial Planner API, Regulatory Assessments
 -- ============================================================
+--
+-- NOTE: Per G-04-FINDING-4 (verified 2026-05-01 via Supabase MCP), this
+-- migration did NOT fully apply in the live database. A forward-fix-up
+-- migration is pending founder authorization (Tier C).
+--
+-- Rollback (in reverse order, if migration had applied):
+--   7. DROP TABLE IF EXISTS regulatory_broker_impacts;
+--   6. DROP TABLE IF EXISTS api_request_log;
+--   5. DROP TABLE IF EXISTS api_keys;
+--   4. DROP TABLE IF EXISTS qa_votes;
+--   3. DROP TABLE IF EXISTS price_drop_notifications;
+--   2. DROP TABLE IF EXISTS user_shortlisted_brokers;
+--   1. DROP TABLE IF EXISTS user_saved_comparisons;
+--   Columns added to existing tables:
+--     ALTER TABLE fee_alert_subscriptions DROP COLUMN IF EXISTS price_threshold,
+--       DROP COLUMN IF EXISTS last_notified_at, DROP COLUMN IF EXISTS notification_count;
+--     ALTER TABLE broker_questions DROP COLUMN IF EXISTS vote_count;
+--     ALTER TABLE broker_answers DROP COLUMN IF EXISTS vote_count,
+--       DROP COLUMN IF EXISTS helpful_count;
+--     ALTER TABLE user_reviews DROP COLUMN IF EXISTS is_verified_client,
+--       DROP COLUMN IF EXISTS verified_via, DROP COLUMN IF EXISTS verified_client_at;
+--     ALTER TABLE professional_reviews DROP COLUMN IF EXISTS is_verified_client,
+--       DROP COLUMN IF EXISTS lead_id, DROP COLUMN IF EXISTS verified_client_at;
+--     ALTER TABLE regulatory_alerts DROP COLUMN IF EXISTS affected_broker_slugs,
+--       DROP COLUMN IF EXISTS affected_platform_types, DROP COLUMN IF EXISTS change_category,
+--       DROP COLUMN IF EXISTS user_action_required, DROP COLUMN IF EXISTS compliance_deadline,
+--       DROP COLUMN IF EXISTS views_count;
 
 -- ── Feature 11: User Saved Comparisons ────────────────────────
 

--- a/supabase/migrations/20260413_admin_automation_dashboard.sql
+++ b/supabase/migrations/20260413_admin_automation_dashboard.sql
@@ -1,5 +1,24 @@
 -- Admin automation dashboard foundations.
 --
+-- Rollback (in reverse order):
+--   2. DROP COLUMN admin override audit cols from lead_disputes, advisor_applications,
+--        investment_listings, user_reviews, professional_reviews:
+--        ALTER TABLE public.lead_disputes DROP COLUMN IF EXISTS admin_overridden_at,
+--          DROP COLUMN IF EXISTS admin_overridden_by, DROP COLUMN IF EXISTS admin_override_reason;
+--        ALTER TABLE public.advisor_applications DROP COLUMN IF EXISTS admin_overridden_at,
+--          DROP COLUMN IF EXISTS admin_overridden_by;
+--        ALTER TABLE public.investment_listings DROP COLUMN IF EXISTS auto_classified_at,
+--          DROP COLUMN IF EXISTS auto_classified_verdict, DROP COLUMN IF EXISTS auto_classified_risk_score,
+--          DROP COLUMN IF EXISTS auto_classified_reasons, DROP COLUMN IF EXISTS admin_overridden_at,
+--          DROP COLUMN IF EXISTS admin_overridden_by;
+--        ALTER TABLE public.user_reviews DROP COLUMN IF EXISTS auto_moderated_at,
+--          DROP COLUMN IF EXISTS auto_moderated_verdict, DROP COLUMN IF EXISTS auto_moderated_reasons,
+--          DROP COLUMN IF EXISTS admin_overridden_at, DROP COLUMN IF EXISTS admin_overridden_by;
+--        ALTER TABLE public.professional_reviews DROP COLUMN IF EXISTS auto_moderated_at,
+--          DROP COLUMN IF EXISTS auto_moderated_verdict, DROP COLUMN IF EXISTS auto_moderated_reasons,
+--          DROP COLUMN IF EXISTS admin_overridden_at, DROP COLUMN IF EXISTS admin_overridden_by;
+--   1. DROP TABLE IF EXISTS public.cron_run_log;
+--
 -- Two changes:
 --   1. New `cron_run_log` table so every cron can persist a run
 --      record on completion. Without this there's no way to answer

--- a/supabase/migrations/20260413_advisor_lead_dispute_auto_resolve.sql
+++ b/supabase/migrations/20260413_advisor_lead_dispute_auto_resolve.sql
@@ -1,5 +1,16 @@
 -- Advisor lead dispute auto-resolution.
 --
+-- Rollback:
+--   2. DROP INDEX IF EXISTS idx_lead_disputes_auto_verdict;
+--   1. DROP INDEX IF EXISTS idx_lead_disputes_pending_created;
+--      ALTER TABLE public.lead_disputes
+--        DROP COLUMN IF EXISTS reason_code,
+--        DROP COLUMN IF EXISTS auto_resolved_at,
+--        DROP COLUMN IF EXISTS auto_resolved_verdict,
+--        DROP COLUMN IF EXISTS auto_resolved_confidence,
+--        DROP COLUMN IF EXISTS auto_resolved_reasons,
+--        DROP COLUMN IF EXISTS refunded_cents;
+--
 -- Extends `lead_disputes` so the classifier can record how (and why)
 -- it resolved a dispute without human review. Every existing column
 -- stays as-is; we only add optional metadata so existing code and

--- a/supabase/migrations/20260413_automation_wave_1.sql
+++ b/supabase/migrations/20260413_automation_wave_1.sql
@@ -1,5 +1,16 @@
 -- Schema additions for Automation Wave 1.
 --
+-- Rollback (in reverse order):
+--   3. DROP TABLE IF EXISTS public.lead_quality_weights;
+--   2. DROP TABLE IF EXISTS public.email_suppression_list;
+--   1. Column drops from altered tables:
+--        ALTER TABLE public.professionals DROP COLUMN IF EXISTS profile_gate_step;
+--        ALTER TABLE public.advisor_credit_topups DROP COLUMN IF EXISTS dunning_step,
+--          DROP COLUMN IF EXISTS dunning_last_attempt_at;
+--        ALTER TABLE public.broker_data_changes DROP COLUMN IF EXISTS auto_applied_at,
+--          DROP COLUMN IF EXISTS auto_applied_tier;
+--   Note: RLS policies and indexes drop with their tables.
+--
 -- Every feature in this wave either reuses existing tables or needs
 -- a small set of new columns / tables. Batching them into a single
 -- migration so the PR is easy to roll forward / back.

--- a/supabase/migrations/20260413_automation_wave_2.sql
+++ b/supabase/migrations/20260413_automation_wave_2.sql
@@ -1,5 +1,15 @@
 -- Automation wave 2 schema.
 --
+-- Rollback (in reverse order):
+--   7. DROP TABLE IF EXISTS public.automation_verdict_daily;
+--   6. DROP TABLE IF EXISTS public.admin_action_log;
+--   5. DROP TABLE IF EXISTS public.property_suburb_refresh_log;
+--   4. DROP TABLE IF EXISTS public.article_quality_scores;
+--   3. DROP TABLE IF EXISTS public.photo_moderation_log;
+--   2. DROP TABLE IF EXISTS public.automation_kill_switches;
+--   1. DROP TABLE IF EXISTS public.classifier_config;
+--   Note: RLS policies and indexes drop with their tables.
+--
 -- Covers:
 --   1. classifier_config       — live-editable thresholds per classifier
 --   2. automation_kill_switches — system-wide / per-feature disable flag

--- a/supabase/migrations/20260413_seed_stockbroker_firms.sql
+++ b/supabase/migrations/20260413_seed_stockbroker_firms.sql
@@ -1,3 +1,12 @@
+-- Rollback (data-only migration — no schema change):
+--   DELETE FROM public.professionals
+--     WHERE slug IN (
+--       'morgans-financial', 'ord-minnett', 'shaw-and-partners',
+--       'bell-potter-securities', 'wilsons-advisory'
+--     );
+--   Note: Forward-only in prod — deleting seed rows is destructive only if
+--         real advisor data has been merged onto these rows. Verify before deleting.
+--
 -- Seed the first 5 Australian full-service stockbroker firms.
 --
 -- Sources: each firm's public AFSL listing on the ASIC Financial


### PR DESCRIPTION
## Summary

G-03 batch 6 of ~11: adds explicit reverse-SQL rollback headers to 10 migrations (migrations 51–60 of ~108 that were missing them).

- [x] `20260402_investment_verticals.sql` — DROP TABLE IF EXISTS investment_verticals + indexes
- [x] `20260405_seed_listing_images.sql` — DROP COLUMN hero_image; reset images array
- [x] `20260408_tier1_revenue_features.sql` — DROP TABLE x3 (broker_signups, affiliate_monthly_reports, drip_affiliate_clicks); DROP COLUMN x4 from investor_drip_log
- [x] `20260408_tier2_traffic_features.sql` — DROP TABLE x3 (fee_alert_subscriptions, newsletter_sends, newsletter_editions); DROP COLUMN x6 + index from suburb_data
- [x] `20260411_features_11_12_14_15_16_18.sql` — DROP TABLE x7; DROP COLUMN x13 across 5 tables. *Tagged with G-04-FINDING-4 note (migration didn't fully apply in prod)*
- [x] `20260413_admin_automation_dashboard.sql` — DROP TABLE cron_run_log; DROP COLUMN audit override cols from 5 tables
- [x] `20260413_advisor_lead_dispute_auto_resolve.sql` — DROP INDEX x2; DROP COLUMN x6 from lead_disputes
- [x] `20260413_automation_wave_1.sql` — DROP TABLE x2; DROP COLUMN x5 from 3 tables
- [x] `20260413_automation_wave_2.sql` — DROP TABLE x7 (classifier_config, automation_kill_switches, photo_moderation_log, article_quality_scores, property_suburb_refresh_log, admin_action_log, automation_verdict_daily)
- [x] `20260413_seed_stockbroker_firms.sql` — DELETE from professionals WHERE slug IN (5 firm slugs)

**Comment-only additions. No SQL statement is modified. No functional change.**

Refs: #215
Audit: `docs/audits/codebase-health-2026-04-24.md` §5.4
Queue: `docs/audits/REMEDIATION_QUEUE.md` G-03 batch 6

---
_Generated by [Claude Code](https://claude.ai/code/session_01DvPP9mnmKeVW48BwCcUbt7)_