### PR TITLE
test(r): R-03 — 18-test suite for advisor-lead-dispute-resolver [audit remediation]

### DIFF
--- a/__tests__/lib/advisor-lead-dispute-resolver.test.ts
+++ b/__tests__/lib/advisor-lead-dispute-resolver.test.ts
@@ -1,0 +1,391 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockFrom = vi.fn();
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+const mockClassifyDispute = vi.fn();
+vi.mock("@/lib/advisor-lead-disputes", () => ({
+  classifyDispute: (...args: unknown[]) => mockClassifyDispute(...args),
+}));
+
+const mockRecordFinancialAudit = vi.fn();
+vi.mock("@/lib/financial-audit", () => ({
+  recordFinancialAudit: (...args: unknown[]) => mockRecordFinancialAudit(...args),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+vi.mock("@/lib/admin", () => ({ ADMIN_EMAIL: "admin@invest.com.au" }));
+vi.mock("@/lib/html-escape", () => ({ escapeHtml: (s: string) => s }));
+vi.mock("@/lib/url", () => ({ getSiteUrl: () => "https://invest.com.au" }));
+
+import {
+  buildClassifierContext,
+  autoResolveDispute,
+  notifyAdminEscalated,
+} from "@/lib/advisor-lead-dispute-resolver";
+
+// ── Query builder helpers ────────────────────────────────────────────────────
+
+/** Chainable select query ending at maybeSingle(). */
+function maybySingle(data: unknown, error: unknown = null) {
+  const b = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    neq: vi.fn().mockReturnThis(),
+    gte: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn(() => Promise.resolve({ data, error })),
+  };
+  return b;
+}
+
+/** Chainable select query ending at single(). */
+function singleResult(data: unknown, error: unknown = null) {
+  return {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    single: vi.fn(() => Promise.resolve({ data, error })),
+  };
+}
+
+/** Select query where gte() is the terminal (for count queries). */
+function countQuery(count: number) {
+  return {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    neq: vi.fn().mockReturnThis(),
+    gte: vi.fn(() => Promise.resolve({ count, error: null })),
+  };
+}
+
+/**
+ * A chainable update builder where the chain IS a real Promise (via
+ * Object.assign), so `await chain` works natively after any number of
+ * .eq() calls, and .in() also resolves immediately.
+ */
+function updateChain(error: unknown = null) {
+  const prom = Promise.resolve({ error });
+  const chain = Object.assign(prom, {
+    eq: vi.fn(),
+    in: vi.fn(() => prom),
+  });
+  chain.eq.mockReturnValue(chain);
+  return { update: vi.fn().mockReturnValue(chain) };
+}
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const DISPUTE_ID = 42;
+const LEAD_ID = 10;
+const ADVISOR_ID = 7;
+
+const DISPUTE = {
+  id: DISPUTE_ID,
+  lead_id: LEAD_ID,
+  professional_id: ADVISOR_ID,
+  reason: "spam",
+  reason_code: "spam_likely",
+  details: null,
+  status: "pending",
+};
+const LEAD = {
+  id: LEAD_ID,
+  user_name: "Jane",
+  user_email: "jane@test.com",
+  user_phone: "0411111111",
+  message: "hi",
+  source_page: "/invest",
+  utm_source: null,
+  utm_campaign: null,
+  quality_score: 50,
+  quality_signals: {},
+  bill_amount_cents: 4900,
+  created_at: "2026-01-01T00:00:00Z",
+  responded_at: null,
+};
+const ADVISOR = {
+  id: ADVISOR_ID,
+  type: "financial_planner",
+  specialties: ["super"],
+  location_state: "NSW",
+  office_states: ["NSW"],
+  service_areas: null,
+  min_client_balance_cents: 0,
+  accepts_international_clients: false,
+};
+
+function setupContextMocks() {
+  mockFrom
+    .mockImplementationOnce(() => maybySingle(DISPUTE))         // lead_disputes
+    .mockImplementationOnce(() => maybySingle(LEAD))            // professional_leads (lead)
+    .mockImplementationOnce(() => maybySingle(ADVISOR))         // professionals
+    .mockImplementationOnce(() => countQuery(0));               // prior leads count
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("buildClassifierContext", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns { ok: false } when dispute not found", async () => {
+    mockFrom.mockImplementationOnce(() => maybySingle(null));
+    const result = await buildClassifierContext(DISPUTE_ID);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("dispute_not_found");
+  });
+
+  it("returns { ok: false } when dispute DB errors", async () => {
+    mockFrom.mockImplementationOnce(() => maybySingle(null, { message: "db error" }));
+    const result = await buildClassifierContext(DISPUTE_ID);
+    expect(result.ok).toBe(false);
+  });
+
+  it("returns { ok: false } when dispute is not pending", async () => {
+    mockFrom.mockImplementationOnce(() =>
+      maybySingle({ ...DISPUTE, status: "approved" })
+    );
+    const result = await buildClassifierContext(DISPUTE_ID);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("dispute_already_approved");
+  });
+
+  it("returns { ok: false } when lead not found", async () => {
+    mockFrom
+      .mockImplementationOnce(() => maybySingle(DISPUTE))
+      .mockImplementationOnce(() => maybySingle(null));
+    const result = await buildClassifierContext(DISPUTE_ID);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("lead_not_found");
+  });
+
+  it("returns { ok: false } when advisor not found", async () => {
+    mockFrom
+      .mockImplementationOnce(() => maybySingle(DISPUTE))
+      .mockImplementationOnce(() => maybySingle(LEAD))
+      .mockImplementationOnce(() => maybySingle(null));
+    const result = await buildClassifierContext(DISPUTE_ID);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("advisor_not_found");
+  });
+
+  it("returns full context on success", async () => {
+    setupContextMocks();
+    const result = await buildClassifierContext(DISPUTE_ID);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.ctx.lead.id).toBe(LEAD_ID);
+    expect(result.ctx.advisor.id).toBe(ADVISOR_ID);
+    expect(result.ctx.reason).toBe("spam_likely");
+    expect(result.disputeStatus).toBe("pending");
+    expect(result.billAmountCents).toBe(4900);
+  });
+
+  it("includes priorLeadsByEmail count in context", async () => {
+    mockFrom
+      .mockImplementationOnce(() => maybySingle(DISPUTE))
+      .mockImplementationOnce(() => maybySingle(LEAD))
+      .mockImplementationOnce(() => maybySingle(ADVISOR))
+      .mockImplementationOnce(() => countQuery(3));
+    const result = await buildClassifierContext(DISPUTE_ID);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.ctx.priorLeadsByEmail).toBe(3);
+  });
+
+  it("parses reason_code from reason text when reason_code is null", async () => {
+    const disputeNoCode = { ...DISPUTE, reason_code: null, reason: "unreachable" };
+    mockFrom
+      .mockImplementationOnce(() => maybySingle(disputeNoCode))
+      .mockImplementationOnce(() => maybySingle(LEAD))
+      .mockImplementationOnce(() => maybySingle(ADVISOR))
+      .mockImplementationOnce(() => countQuery(0));
+    const result = await buildClassifierContext(DISPUTE_ID);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.ctx.reason).toBe("unreachable");
+  });
+});
+
+describe("autoResolveDispute", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // mockReset clears the mockImplementationOnce queue so unconsumed mocks
+    // from a prior test (e.g. advisor-email maybySingle when RESEND_API_KEY
+    // is absent) don't bleed into the next test's from() call sequence.
+    mockFrom.mockReset();
+    mockRecordFinancialAudit.mockResolvedValue(undefined);
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true }));
+  });
+
+  it("returns applied:false when context build fails", async () => {
+    mockFrom.mockImplementationOnce(() => maybySingle(null));
+    const result = await autoResolveDispute(DISPUTE_ID);
+    expect(result.applied).toBe(false);
+    expect(result.verdict).toBe("escalate");
+    expect(result.refundedCents).toBe(0);
+  });
+
+  it("escalate verdict — updates dispute status and returns applied:true", async () => {
+    setupContextMocks();
+    mockClassifyDispute.mockReturnValue({
+      verdict: "escalate",
+      confidence: "low",
+      reasons: ["low_quality"],
+    });
+    mockFrom
+      .mockImplementationOnce(() => updateChain()); // lead_disputes update (escalated)
+
+    const result = await autoResolveDispute(DISPUTE_ID);
+    expect(result.applied).toBe(true);
+    expect(result.verdict).toBe("escalate");
+    expect(result.refundedCents).toBe(0);
+  });
+
+  it("reject verdict — closes dispute without refund", async () => {
+    setupContextMocks();
+    mockClassifyDispute.mockReturnValue({
+      verdict: "reject",
+      confidence: "high",
+      reasons: ["spam_pattern_not_matched"],
+    });
+    mockFrom
+      .mockImplementationOnce(() => updateChain()); // lead_disputes update (rejected)
+
+    const result = await autoResolveDispute(DISPUTE_ID);
+    expect(result.applied).toBe(true);
+    expect(result.verdict).toBe("reject");
+    expect(result.refundedCents).toBe(0);
+  });
+
+  it("refund verdict — credits advisor balance and closes dispute", async () => {
+    setupContextMocks();
+    mockClassifyDispute.mockReturnValue({
+      verdict: "refund",
+      confidence: "high",
+      reasons: ["spam_likely"],
+    });
+    // applyRefund DB sequence:
+    mockFrom
+      .mockImplementationOnce(() => singleResult({ credit_balance_cents: 10000 })) // read balance
+      .mockImplementationOnce(() => updateChain())                                  // update balance
+      .mockImplementationOnce(() => updateChain())                                  // mark lead
+      .mockImplementationOnce(() => updateChain())                                  // waive billing
+      .mockImplementationOnce(() => updateChain());                                 // close dispute
+    // notifyAdvisorRefund (fire-and-forget)
+    mockFrom
+      .mockImplementationOnce(() => maybySingle({ name: "Bob", email: "bob@b.com" }));
+
+    const result = await autoResolveDispute(DISPUTE_ID);
+    expect(result.applied).toBe(true);
+    expect(result.verdict).toBe("refund");
+    expect(result.refundedCents).toBe(4900);
+  });
+
+  it("refund with 0 cents — skips credit update and audit trail", async () => {
+    const zeroCentLead = { ...LEAD, bill_amount_cents: 0 };
+    mockFrom
+      .mockImplementationOnce(() => maybySingle(DISPUTE))
+      .mockImplementationOnce(() => maybySingle(zeroCentLead))
+      .mockImplementationOnce(() => maybySingle(ADVISOR))
+      .mockImplementationOnce(() => countQuery(0));
+    mockClassifyDispute.mockReturnValue({ verdict: "refund", confidence: "medium", reasons: [] });
+    mockFrom
+      .mockImplementationOnce(() => updateChain())  // mark lead
+      .mockImplementationOnce(() => updateChain())  // waive billing
+      .mockImplementationOnce(() => updateChain()); // close dispute
+    mockFrom
+      .mockImplementationOnce(() => maybySingle({ name: "Bob", email: "bob@b.com" }));
+
+    const result = await autoResolveDispute(DISPUTE_ID);
+    expect(result.refundedCents).toBe(0);
+    expect(mockRecordFinancialAudit).not.toHaveBeenCalled();
+  });
+
+  it("credit update DB error — falls back to escalate", async () => {
+    setupContextMocks();
+    mockClassifyDispute.mockReturnValue({ verdict: "refund", confidence: "high", reasons: [] });
+    mockFrom
+      .mockImplementationOnce(() => singleResult({ credit_balance_cents: 5000 })) // read balance
+      .mockImplementationOnce(() => updateChain({ message: "conflict" }))          // update FAILS
+      .mockImplementationOnce(() => updateChain());                                // escalated fallback dispute update
+
+    const result = await autoResolveDispute(DISPUTE_ID);
+    expect(result.verdict).toBe("escalate");
+    expect(result.applied).toBe(true);
+  });
+
+  it("records financial audit on successful refund", async () => {
+    setupContextMocks();
+    mockClassifyDispute.mockReturnValue({ verdict: "refund", confidence: "high", reasons: [] });
+    mockFrom
+      .mockImplementationOnce(() => singleResult({ credit_balance_cents: 0 }))
+      .mockImplementationOnce(() => updateChain())
+      .mockImplementationOnce(() => updateChain())
+      .mockImplementationOnce(() => updateChain())
+      .mockImplementationOnce(() => updateChain());
+    mockFrom.mockImplementationOnce(() => maybySingle(null)); // no email found
+
+    await autoResolveDispute(DISPUTE_ID);
+    expect(mockRecordFinancialAudit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "refund",
+        resourceType: "advisor_credit_balance",
+        amountCents: 4900,
+      }),
+    );
+  });
+});
+
+describe("notifyAdminEscalated", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("calls Resend API with dispute details when RESEND_API_KEY is set", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", mockFetch);
+    process.env.RESEND_API_KEY = "test-key";
+
+    await notifyAdminEscalated(DISPUTE_ID, "Bob Advisor", "Jane Lead", "spam_likely", null, ["spam_likely"]);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://api.resend.com/emails",
+      expect.objectContaining({ method: "POST" }),
+    );
+    const body = JSON.parse((mockFetch.mock.calls[0]?.[1] as RequestInit)?.body as string);
+    expect(body.to).toContain("admin@invest.com.au");
+    expect(body.subject).toContain("escalated");
+
+    delete process.env.RESEND_API_KEY;
+  });
+
+  it("does not call fetch when RESEND_API_KEY is absent", async () => {
+    delete process.env.RESEND_API_KEY;
+    const mockFetch = vi.fn();
+    vi.stubGlobal("fetch", mockFetch);
+
+    await notifyAdminEscalated(DISPUTE_ID, "Bob", "Jane", "spam", null, []);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("does not throw when fetch rejects (fire-and-forget)", async () => {
+    process.env.RESEND_API_KEY = "test-key";
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network error")));
+
+    await expect(
+      notifyAdminEscalated(DISPUTE_ID, "Bob", "Jane", "spam", null, []),
+    ).resolves.not.toThrow();
+
+    delete process.env.RESEND_API_KEY;
+  });
+});


### PR DESCRIPTION
## Summary

Adds a comprehensive test suite for `lib/advisor-lead-dispute-resolver.ts` (480 LOC, 0% coverage prior to this PR). This module drives the auto-refund, escalation, and AFSL audit-trail path for advisor lead disputes — financial operations that need a regression harness.

**18 tests across 3 describe blocks:**

- `buildClassifierContext` (8): dispute not found / DB error / already-resolved guard / lead not found / advisor not found / full success / prior-leads count / reason_code fallback parsing
- `autoResolveDispute` (7): context-build failure → escalate; escalate verdict; reject verdict; refund with credit read-modify-write; zero-cent refund skips credit + audit; credit-update DB error falls back to escalate; `recordFinancialAudit` called on successful refund
- `notifyAdminEscalated` (3): sends to Resend when key present; skips fetch when key absent; fire-and-forget contract (doesn't throw on network error)

**Non-obvious mock decisions documented in test file:**
- `updateChain` uses `Object.assign(prom, {eq,in})` to make the chain an actual Promise — avoids fragile hand-rolled thenable `.then` binding
- `mockFrom.mockReset()` in `autoResolveDispute` `beforeEach` drains the `mockImplementationOnce` queue between tests; without it, an unconsumed advisor-email `maybySingle` (when `RESEND_API_KEY` is absent) bleeds into the next test's `from()` sequence and silently substitutes a zero-cent lead

## Checklist

- [x] 18/18 tests passing locally
- [x] No source changes — test-only PR
- [x] Follows `__tests__/lib/<x>.test.ts` naming convention

Refs: #218
Audit: `docs/audits/codebase-health-2026-04-24.md` §Coverage
Queue: R-03

---
_Generated by [Claude Code](https://claude.ai/code/session_01L9JMvuR7vyDzvku6ov7CWr)_