### PR TITLE
chore(g): G-03 batch 7 — rollback headers on 10 migrations (20260415–20260419) [audit remediation]

### DIFF
--- a/supabase/migrations/20260415_wave_10_critical_gaps.sql
+++ b/supabase/migrations/20260415_wave_10_critical_gaps.sql
@@ -11,6 +11,27 @@
 -- Extensions to existing tables:
 --   - subscriptions               → grace period + pause + dunning counters
 --   - professionals               → advisor_tier + tier upgraded/downgraded timestamps
+--
+-- Rollback (in reverse order):
+--   Columns added to existing tables:
+--     ALTER TABLE public.professionals
+--       DROP COLUMN IF EXISTS tier_changed_at,
+--       DROP COLUMN IF EXISTS tier_changed_by,
+--       DROP COLUMN IF EXISTS tier_change_reason;
+--     ALTER TABLE public.subscriptions
+--       DROP COLUMN IF EXISTS grace_period_until,
+--       DROP COLUMN IF EXISTS paused_at,
+--       DROP COLUMN IF EXISTS pause_reason,
+--       DROP COLUMN IF EXISTS dunning_attempt_count,
+--       DROP COLUMN IF EXISTS last_dunning_email_at;
+--   New tables (drop in reverse order):
+--   6. DROP TABLE IF EXISTS public.tmds;
+--   5. DROP TABLE IF EXISTS public.data_integrity_issues;
+--   4. DROP TABLE IF EXISTS public.churn_surveys;
+--   3. DROP TABLE IF EXISTS public.complaints_register;
+--   2. DROP TABLE IF EXISTS public.login_attempts;
+--   1. DROP TABLE IF EXISTS public.admin_mfa_enrollments;
+--   Note: RLS policies and indexes drop with their tables.
 
 -- ── 1. admin_mfa_enrollments ───────────────────────────────────────
 -- One row per admin user who has enrolled a TOTP authenticator.

--- a/supabase/migrations/20260415_wave_6_conversion_intelligence.sql
+++ b/supabase/migrations/20260415_wave_6_conversion_intelligence.sql
@@ -13,6 +13,25 @@
 --   - articles / brokers         → last_reviewed_at pass-through
 --
 -- Every table is RLS-enabled and service-role-only.
+--
+-- Rollback (in reverse order):
+--   Columns added to existing tables:
+--     ALTER TABLE public.email_captures
+--       DROP COLUMN IF EXISTS session_id,
+--       DROP COLUMN IF EXISTS recovery_sent_at;
+--     ALTER TABLE public.articles
+--       DROP COLUMN IF EXISTS last_reviewed_at,
+--       DROP COLUMN IF EXISTS last_reviewed_by;
+--     ALTER TABLE public.quiz_leads
+--       DROP COLUMN IF EXISTS inferred_vertical,
+--       DROP COLUMN IF EXISTS inferred_confidence;
+--   New tables (drop in reverse order):
+--   4. DROP TABLE IF EXISTS public.job_queue;
+--   3. DROP TABLE IF EXISTS public.review_sentiment_facets;
+--   2. DROP TABLE IF EXISTS public.search_embeddings;
+--   1. DROP TABLE IF EXISTS public.form_events;
+--   Extension: DROP EXTENSION IF EXISTS vector;  -- only if no other tables use pgvector
+--   Note: RLS policies and indexes drop with their tables.
 
 -- ── pgvector extension ─────────────────────────────────────────────
 CREATE EXTENSION IF NOT EXISTS vector;

--- a/supabase/migrations/20260415_wave_7_trust_ops.sql
+++ b/supabase/migrations/20260415_wave_7_trust_ops.sql
@@ -10,6 +10,13 @@
 --                                policy per table/column
 --
 -- Every table RLS-enabled and service-role only.
+--
+-- Rollback (in reverse order):
+--   4. DROP TABLE IF EXISTS public.retention_rules;
+--   3. DROP TABLE IF EXISTS public.slo_incidents;
+--   2. DROP TABLE IF EXISTS public.slo_definitions;
+--   1. DROP TABLE IF EXISTS public.feature_flags;
+--   Note: RLS policies and indexes drop with their tables.
 
 -- ── 1. feature_flags ───────────────────────────────────────────────
 -- Richer than automation_kill_switches: supports a percentage

--- a/supabase/migrations/20260415_wave_8_growth_engine.sql
+++ b/supabase/migrations/20260415_wave_8_growth_engine.sql
@@ -18,6 +18,20 @@
 --   - advisor_cohort_metrics   — monthly signup cohorts → leads /
 --                                spend / active months → powers
 --                                the retention dashboard
+--
+-- Rollback (in reverse order):
+--   Materialized view:
+--     DROP MATERIALIZED VIEW IF EXISTS public.advisor_cohort_metrics;
+--   Columns added to existing tables:
+--     ALTER TABLE public.professionals
+--       DROP COLUMN IF EXISTS health_score,
+--       DROP COLUMN IF EXISTS health_scored_at,
+--       DROP COLUMN IF EXISTS health_factors;
+--   New tables (drop in reverse order):
+--   3. DROP TABLE IF EXISTS public.dynamic_pricing_rules;
+--   2. DROP TABLE IF EXISTS public.newsletter_subscribers;
+--   1. DROP TABLE IF EXISTS public.nps_responses;
+--   Note: RLS policies and indexes drop with their tables.
 
 -- ── 1. nps_responses ───────────────────────────────────────────────
 -- One row per NPS / CSAT answer. Targetable at advisors or users.

--- a/supabase/migrations/20260415_wave_9_warehouse_ai.sql
+++ b/supabase/migrations/20260415_wave_9_warehouse_ai.sql
@@ -10,6 +10,14 @@
 --                                 (reviews / advisors / disputes)
 --   4. churn_scores             — advisor churn-risk snapshots
 --   5. i18n_currency_rates      — daily FX for currency conversion
+--
+-- Rollback (in reverse order):
+--   5. DROP TABLE IF EXISTS public.i18n_currency_rates;
+--   4. DROP TABLE IF EXISTS public.churn_scores;
+--   3. DROP TABLE IF EXISTS public.fraud_signals;
+--   2. DROP TABLE IF EXISTS public.chatbot_conversations;
+--   1. DROP TABLE IF EXISTS public.warehouse_daily_facts;
+--   Note: RLS policies and indexes drop with their tables.
 
 -- ── 1. warehouse_daily_facts ───────────────────────────────────────
 -- Append-only mart table. One row per (day, metric_name) so we

--- a/supabase/migrations/20260416_wave_11_reality_check.sql
+++ b/supabase/migrations/20260416_wave_11_reality_check.sql
@@ -16,6 +16,23 @@
 --   - tmds                         — loosen product_type check + add
 --                                    metadata columns
 --   - complaints_register          — SLA warning / escalation stamps
+--
+-- Rollback (in reverse order):
+--   Columns added to existing tables:
+--     ALTER TABLE public.complaints_register
+--       DROP COLUMN IF EXISTS sla_warning_sent_at,
+--       DROP COLUMN IF EXISTS auto_escalated_at;
+--   New tables (drop in reverse order):
+--   9. DROP TABLE IF EXISTS public.anonymous_saves;
+--   8. DROP TABLE IF EXISTS public.revenue_reconciliation_runs;
+--   7. DROP TABLE IF EXISTS public.financial_periods;
+--   6. DROP TABLE IF EXISTS public.advisor_kyc_documents;
+--   5. DROP TABLE IF EXISTS public.article_reactions;
+--   4. DROP TABLE IF EXISTS public.article_comments;
+--   3. DROP TABLE IF EXISTS public.user_bookmarks;
+--   2. DROP TABLE IF EXISTS public.user_quiz_history;
+--   1. DROP TABLE IF EXISTS public.user_notifications;
+--   Note: RLS policies, indexes, and CHECK constraints drop with their tables.
 
 -- ── 1. user_notifications ───────────────────────────────────────────
 -- One row per in-app notification. Users read them from a /account

--- a/supabase/migrations/20260417_wave_13_commodity_engine.sql
+++ b/supabase/migrations/20260417_wave_13_commodity_engine.sql
@@ -19,6 +19,13 @@
 --     articles we publish within 24h of a major story. Each row
 --     references an `articles` row so the normal content pipeline
 --     owns rendering + RSS + related-article surfacing.
+--
+-- Rollback (in reverse order):
+--   4. DROP TABLE IF EXISTS public.commodity_news_briefs;
+--   3. DROP TABLE IF EXISTS public.commodity_etfs;
+--   2. DROP TABLE IF EXISTS public.commodity_stocks;
+--   1. DROP TABLE IF EXISTS public.commodity_sectors;
+--   Note: RLS policies and indexes drop with their tables.
 
 -- ── 1. commodity_sectors ─────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS public.commodity_sectors (

--- a/supabase/migrations/20260418_wave_14_newsroom_engine.sql
+++ b/supabase/migrations/20260418_wave_14_newsroom_engine.sql
@@ -21,6 +21,12 @@
 --     nothing enforces that — they expire instead. This matches how
 --     Google Docs share-links work and is the simplest thing editors
 --     understand.
+--
+-- Rollback (in reverse order):
+--   3. DROP TABLE IF EXISTS public.article_preview_tokens;
+--   2. DROP TABLE IF EXISTS public.article_scorecard_runs;
+--   1. DROP TABLE IF EXISTS public.article_templates;
+--   Note: RLS policies and indexes drop with their tables.
 
 -- ── 1. article_templates ────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS public.article_templates (

--- a/supabase/migrations/20260419_glossary_terms.sql
+++ b/supabase/migrations/20260419_glossary_terms.sql
@@ -5,6 +5,13 @@
 -- deploy. Seeds the table with 200+ existing + new terms across
 -- SMSF, Mining, Foreign Investment, Super, Tax, Property, Crypto,
 -- CFD, Regulatory, and General Finance categories.
+--
+-- Rollback:
+--   1. DROP TABLE IF EXISTS public.glossary_terms;
+--   Note: The INSERT seed data drops with the table. Re-running
+--         this migration re-seeds all terms from the INSERT block
+--         below. Only run rollback if no user-edited terms exist —
+--         admin-added terms not in the seed block will be lost.
 -- ============================================================
 
 CREATE TABLE IF NOT EXISTS public.glossary_terms (

--- a/supabase/migrations/20260419_wave_15_price_snapshots.sql
+++ b/supabase/migrations/20260419_wave_15_price_snapshots.sql
@@ -18,6 +18,12 @@
 --     days of commodity snapshots (commodity charts need more
 --     history for "past year" views). Older rows get deleted by the
 --     cleanup cron.
+--
+-- Rollback (in reverse order):
+--   2. DROP TABLE IF EXISTS public.commodity_price_snapshots;
+--   1. DROP TABLE IF EXISTS public.broker_price_snapshots;
+--   Note: RLS policies and indexes drop with their tables.
+--         Snapshot data is regenerable by the cron on the next run.
 
 -- ── 1. broker_price_snapshots ──────────────────────────────────
 CREATE TABLE IF NOT EXISTS public.broker_price_snapshots (


### PR DESCRIPTION
## Summary

G-03 batch 7: adds explicit rollback SQL headers to the next 10 migrations in date order (20260415–20260419), bringing G-03 coverage from 60/108 to 70/108.

**Files changed:**
- `20260415_wave_10_critical_gaps.sql` — 6 new tables + column extensions on `subscriptions` and `professionals`
- `20260415_wave_6_conversion_intelligence.sql` — 4 new tables (form_events, search_embeddings, review_sentiment_facets, job_queue) + column extensions on 3 existing tables
- `20260415_wave_7_trust_ops.sql` — 4 new tables (feature_flags, slo_definitions, slo_incidents, retention_rules)
- `20260415_wave_8_growth_engine.sql` — 3 new tables + materialized view + professionals column extensions
- `20260415_wave_9_warehouse_ai.sql` — 5 new tables (warehouse, chatbot, fraud, churn, i18n)
- `20260416_wave_11_reality_check.sql` — 9 new user/content/compliance tables + complaints_register column extensions
- `20260417_wave_13_commodity_engine.sql` — 4 commodity tables
- `20260418_wave_14_newsroom_engine.sql` — 3 newsroom tables
- `20260419_glossary_terms.sql` — glossary_terms table + 200+ seed rows
- `20260419_wave_15_price_snapshots.sql` — 2 snapshot tables

**Why:** without rollback headers, an incident response requires reverse-engineering the rollback from the migration body — error-prone under time pressure. Wave 11 alone has 9 tables; a wrong DROP order cascades into FK violations.

**Safety:** comment-only changes. No SQL statements modified. All migrations remain idempotent.

## Test plan
- [x] CI: `rls-migrations-gate` (no new CREATE TABLE without RLS)
- [x] CI: `Lint · Type-check · Test · Build` (no TS changes)
- [x] All 10 files verified to have `Rollback` comment block

Refs: #214
Audit: `docs/audits/codebase-health-2026-04-24.md` §5
Queue: G-03 batch 7

---
_Generated by [Claude Code](https://claude.ai/code/session_01FzqAztjZVN4CJVvvytwxXs)_