### PR TITLE
chore(g): G-03 batch 8 — rollback headers on migrations 20260420–20260425 [audit remediation]

### DIFF
--- a/supabase/migrations/20260420_wave_16_growth_engine.sql
+++ b/supabase/migrations/20260420_wave_16_growth_engine.sql
@@ -1,5 +1,18 @@
 -- Wave 16 schema — growth engine.
 --
+-- Date: 2026-04-20
+-- Audit ref: codebase-health-2026-04-24.md §4.3 (G-03)
+-- Queue item: G-03 batch 8
+-- Why: four new tables power programmatic SEO (/best-for/<slug>),
+--      newsletter opt-in/out, and exit-intent A/B analytics.
+-- Idempotency: CREATE TABLE IF NOT EXISTS; safe to re-apply.
+-- Rollback (in reverse creation order):
+--   DROP TABLE IF EXISTS public.exit_intent_events;
+--   DROP TABLE IF EXISTS public.newsletter_subscriptions;
+--   DROP TABLE IF EXISTS public.newsletter_segments;
+--   DROP TABLE IF EXISTS public.best_for_scenarios;
+--   Note: RLS policies, indexes, and sequences drop with their tables.
+--
 -- Tables introduced:
 --   1. best_for_scenarios    — programmatic SEO seed for /best-for/<slug>
 --   2. newsletter_segments   — named segments for targeted sends

--- a/supabase/migrations/20260421_wave_17_advisor_marketplace_v2.sql
+++ b/supabase/migrations/20260421_wave_17_advisor_marketplace_v2.sql
@@ -1,5 +1,31 @@
 -- Wave 17 schema — advisor marketplace v2.
 --
+-- Date: 2026-04-21
+-- Audit ref: codebase-health-2026-04-24.md §4.3 (G-03)
+-- Queue item: G-03 batch 8
+-- Why: adds video intro, availability, booking, and lead-quality signals
+--      to the advisor marketplace to improve conversion and dispute
+--      resolution.
+-- Idempotency: ALTER TABLE IF EXISTS … ADD COLUMN IF NOT EXISTS;
+--              CREATE TABLE/INDEX IF NOT EXISTS. Safe to re-apply.
+-- Rollback (in reverse order):
+--   ALTER TABLE public.professional_leads
+--     DROP CONSTRAINT IF EXISTS professional_leads_quality_band_check;
+--   DROP INDEX IF EXISTS public.idx_professional_leads_quality_band;
+--   ALTER TABLE public.professional_leads
+--     DROP COLUMN IF EXISTS quality_band,
+--     DROP COLUMN IF EXISTS quality_signals;
+--   DROP TABLE IF EXISTS public.advisor_booking_appointments;
+--   DROP INDEX IF EXISTS public.idx_professionals_accepting_search;
+--   ALTER TABLE public.professionals
+--     DROP COLUMN IF EXISTS booking_link,
+--     DROP COLUMN IF EXISTS response_time_hours,
+--     DROP COLUMN IF EXISTS accepts_new_clients,
+--     DROP COLUMN IF EXISTS intro_video_poster_url,
+--     DROP COLUMN IF EXISTS intro_video_url;
+--   Note: advisor_booking_appointments RLS policies and indexes drop
+--         with the table.
+--
 -- Extensions + new tables:
 --   1. professionals.intro_video_url         — hosted video URL (Vimeo/Mux/R2)
 --   2. professionals.intro_video_poster_url  — still frame used as poster

--- a/supabase/migrations/20260422_wave_18_observability.sql
+++ b/supabase/migrations/20260422_wave_18_observability.sql
@@ -1,5 +1,21 @@
 -- Wave 18 schema — observability + search analytics.
 --
+-- Date: 2026-04-22
+-- Audit ref: codebase-health-2026-04-24.md §4.3 (G-03)
+-- Queue item: G-03 batch 8
+-- Why: four new observability tables capture raw search queries, web
+--      vitals beacons, daily web vitals rollups, and daily revenue
+--      attribution summaries for the exec dashboard.
+-- Idempotency: CREATE TABLE IF NOT EXISTS. Safe to re-apply.
+-- Rollback (in reverse creation order):
+--   DROP TABLE IF EXISTS public.revenue_attribution_daily;
+--   DROP TABLE IF EXISTS public.web_vitals_daily_rollup;
+--   DROP TABLE IF EXISTS public.web_vitals_samples;
+--   DROP TABLE IF EXISTS public.search_queries;
+--   Note: RLS policies, indexes, and sequences drop with their tables.
+--         Rollup rows are recomputable from attribution_touches and raw
+--         vitals source data.
+--
 -- Tables introduced:
 --   1. search_queries              — anonymous query log for the site search
 --                                     surfaces (articles, advisors, compare)

--- a/supabase/migrations/20260423124310_create_agent_analytics_table.sql
+++ b/supabase/migrations/20260423124310_create_agent_analytics_table.sql
@@ -3,8 +3,19 @@
 -- Purpose: Create `agent_analytics` — a daily per-agent success-rate
 --          rollup table written by n8n cron jobs and read by the admin
 --          observability dashboard.
--- Rollback: REVOKE grants, DROP policy, DISABLE RLS, DROP indexes,
---           DROP table.
+-- Rollback (in reverse order):
+--   REVOKE SELECT, INSERT, UPDATE, DELETE
+--     ON public.agent_analytics FROM authenticated;
+--   REVOKE SELECT, INSERT, UPDATE, DELETE
+--     ON public.agent_analytics FROM service_role;
+--   DROP POLICY IF EXISTS "Service role can manage analytics"
+--     ON public.agent_analytics;
+--   ALTER TABLE public.agent_analytics DISABLE ROW LEVEL SECURITY;
+--   DROP INDEX IF EXISTS public.idx_agent_analytics_agent_date;
+--   DROP INDEX IF EXISTS public.idx_agent_analytics_date;
+--   DROP INDEX IF EXISTS public.idx_agent_analytics_agent_name;
+--   DROP TABLE IF EXISTS public.agent_analytics;
+--   Note: historical rollup data is lost; recompute from agent logs.
 -- Risk: medium — DROP TABLE discards historical agent-success-rate
 --       rollups. Source data in agent logs survives, so the rollups can
 --       be recomputed; but any time-series gap in the dashboard during

--- a/supabase/migrations/20260424_seed_best_for_scenarios.sql
+++ b/supabase/migrations/20260424_seed_best_for_scenarios.sql
@@ -1,3 +1,16 @@
+-- Date: 2026-04-24
+-- Audit ref: codebase-health-2026-04-24.md §4.3 (G-03)
+-- Queue item: G-03 batch 8
+-- Why: expands best_for_scenarios from 3 seed rows to 30, powering
+--      27 new programmatic /best-for/<slug> pages.
+-- Idempotency: INSERT ... ON CONFLICT (slug) DO NOTHING. Safe to re-apply.
+-- Rollback:
+--   DELETE FROM public.best_for_scenarios
+--     WHERE slug NOT IN ('day-trading-asx', 'beginners-australia', 'long-term-investing');
+--   Note: INSERT-only migration; no DDL to reverse. The original 3 rows
+--         (seeded in 20260420_wave_16_growth_engine.sql) are preserved.
+--         Re-run this migration to restore the 27 deleted rows.
+
 -- Expand best_for_scenarios from 3 to 30.
 --
 -- Each scenario powers a /best-for/<slug> programmatic SEO page.

--- a/supabase/migrations/20260425_critical_minerals_boom.sql
+++ b/supabase/migrations/20260425_critical_minerals_boom.sql
@@ -1,3 +1,25 @@
+-- Date: 2026-04-25
+-- Audit ref: codebase-health-2026-04-24.md §4.3 (G-03)
+-- Queue item: G-03 batch 8
+-- Why: seeds 15 critical minerals investment listings and one guide
+--      article capitalising on the US-Australia bilateral framework
+--      and China rare earth restriction news cycle.
+-- Idempotency: INSERT ... ON CONFLICT (slug) DO NOTHING. Safe to re-apply.
+-- Rollback:
+--   DELETE FROM public.investment_listings WHERE slug IN (
+--     'mt-weld-south-rare-earths-ndpr', 'darling-range-gallium-germanium',
+--     'kwinana-lithium-hydroxide-refinery-expansion',
+--     'murrin-murrin-south-cobalt-nickel', 'julia-creek-vanadium-battery-storage',
+--     'pilbara-west-lithium-6-targets', 'groote-eylandt-manganese-royalty',
+--     'gawler-craton-iocg-copper-gold', 'north-qld-graphite-battery-anode',
+--     'kambalda-nickel-sulphide-dfs', 'tasmania-tin-tungsten-high-grade',
+--     'gascoyne-rare-earths-monazite-producer', 'lachlan-fold-belt-critical-minerals',
+--     'central-qld-scandium-cobalt', 'stuart-shelf-copper-gold-jv-olympic-dam'
+--   );
+--   DELETE FROM public.articles
+--     WHERE slug = 'australias-critical-minerals-boom-how-to-invest';
+--   Note: INSERT-only migration; no DDL to reverse.
+--
 -- ============================================================
 -- Critical Minerals Boom: 15 new mining listings + boom article
 -- Capitalises on US-Australia $8.5B framework, EU-Australia FTA,


### PR DESCRIPTION
## G-03 batch 8 — explicit SQL rollback headers (migrations 71–80 of 108)

Audit finding: `codebase-health-2026-04-24.md §4.3` — 108 migrations shipped without explicit SQL rollback instructions, leaving operators without a fast reverse path during incidents.

### Changes

6 of the 10 batch-8 migrations needed work (4 already had explicit SQL rollback headers):

| File | Action |
|------|--------|
| `20260420_wave_16_growth_engine.sql` | Added `DROP TABLE` for all 4 created tables in reverse order |
| `20260421_wave_17_advisor_marketplace_v2.sql` | Added `DROP TABLE advisor_booking_appointments` + `DROP COLUMN` on `professionals` (5) and `professional_leads` (2) in reverse order |
| `20260422_wave_18_observability.sql` | Added `DROP TABLE` for all 4 observability tables in reverse order |
| `20260423124310_create_agent_analytics_table.sql` | Replaced prose-only rollback with explicit `REVOKE` / `DROP POLICY` / `DISABLE RLS` / `DROP INDEX` / `DROP TABLE` |
| `20260424_seed_best_for_scenarios.sql` | Added header noting INSERT-only nature + `DELETE` on the 27 added slugs |
| `20260425_critical_minerals_boom.sql` | Added header with `DELETE` for all 15 listing slugs + article slug |

Already compliant (unchanged): `20260423142454`, `20260423_newsletter_editions`, `20260426_add_missing_fk_indexes`, `20260426_admin_audit_rls_policies`.

### Progress
- Batch 8 complete: **80/108** migrations now have explicit SQL rollback headers
- Remaining: 28 migrations (batches 9–11)

Refs: #218
Audit: `docs/audits/codebase-health-2026-04-24.md §4.3`
Queue: G-03

---
_Generated by [Claude Code](https://claude.ai/code/session_01FzqAztjZVN4CJVvvytwxXs)_