### PR TITLE
test(r): R-06 — automation-metrics.ts async coverage (25% → ≥60%) [audit remediation]

### DIFF
--- a/__tests__/lib/admin-automation-metrics.test.ts
+++ b/__tests__/lib/admin-automation-metrics.test.ts
@@ -1,16 +1,53 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+// Must be declared before the module import so vitest's hoisting applies.
+const mockAdminFrom = vi.fn();
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+
 import {
   computeHealth,
   FEATURE_CONFIG,
   AUTOMATION_FEATURES,
+  getLatestCronRun,
+  getLeadDisputeOverview,
+  getAdvisorApplicationOverview,
+  getMarketplaceCampaignOverview,
+  getAllFeatureOverviews,
 } from "@/lib/admin/automation-metrics";
 
+// ── Chain helper ──────────────────────────────────────────────────────────────
 /**
- * automation-metrics has one crucial pure function (computeHealth)
- * and a static config (FEATURE_CONFIG). The 15+ getOverview funcs
- * all hit Supabase and are better covered as integration tests —
- * here we nail down the health state machine.
+ * Returns a fluent Supabase-style builder where every method returns `this`
+ * so test code can write `.from().select().eq()` etc without setting up every
+ * mock individually.  Terminal methods (`maybeSingle`, `single`) resolve with
+ * the supplied result.  The chain is also thenable so `await chain` resolves
+ * with the same result (handles implicit awaits like `await supabase.from(...).select(...)`).
  */
+function makeChain(result: { data?: unknown; count?: number | null; error?: unknown } = {}) {
+  const resolved = {
+    data: result.data !== undefined ? result.data : null,
+    count: result.count !== undefined ? result.count : null,
+    error: result.error !== undefined ? result.error : null,
+  };
+  const c: Record<string, unknown> = {};
+  for (const m of ["select", "eq", "gte", "lte", "order", "limit", "is", "in", "not", "upsert", "insert", "update"]) {
+    c[m] = vi.fn(() => c);
+  }
+  c.maybeSingle = vi.fn(() => Promise.resolve(resolved));
+  c.single = vi.fn(() => Promise.resolve(resolved));
+  c.then = (
+    onFulfilled: (v: unknown) => unknown,
+    onRejected?: (v: unknown) => unknown,
+  ) => Promise.resolve(resolved).then(onFulfilled, onRejected);
+  c.catch = (onRejected: (v: unknown) => unknown) =>
+    Promise.resolve(resolved).catch(onRejected);
+  return c;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe("computeHealth state machine", () => {
   const cadence = 24; // 24-hour expected cadence
@@ -152,5 +189,208 @@ describe("FEATURE_CONFIG + AUTOMATION_FEATURES", () => {
   it("slug values are all unique (routes under /admin/automation/<slug>)", () => {
     const slugs = AUTOMATION_FEATURES.map((f) => FEATURE_CONFIG[f].slug);
     expect(new Set(slugs).size).toBe(slugs.length);
+  });
+});
+
+describe("getLatestCronRun", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns never_run fallback when Supabase errors", async () => {
+    mockAdminFrom.mockReturnValue(
+      makeChain({ data: null, error: { message: "db unavailable" } }),
+    );
+    const result = await getLatestCronRun("auto-resolve-disputes");
+    expect(result.status).toBe("never_run");
+    expect(result.name).toBe("auto-resolve-disputes");
+    expect(result.startedAt).toBeNull();
+  });
+
+  it("returns never_run fallback when no row exists (empty table)", async () => {
+    mockAdminFrom.mockReturnValue(makeChain({ data: null, error: null }));
+    const result = await getLatestCronRun("some-cron");
+    expect(result.status).toBe("never_run");
+  });
+
+  it("maps cron_run_log row to LatestCronRun shape correctly", async () => {
+    const row = {
+      name: "auto-resolve-disputes",
+      started_at: "2026-05-01T12:00:00Z",
+      ended_at: "2026-05-01T12:05:00Z",
+      duration_ms: 300_000,
+      status: "ok",
+      stats: { processed: 5, refunded: 2 },
+      error_message: null,
+      triggered_by: "cron",
+    };
+    mockAdminFrom.mockReturnValue(makeChain({ data: row, error: null }));
+    const result = await getLatestCronRun("auto-resolve-disputes");
+    expect(result.name).toBe("auto-resolve-disputes");
+    expect(result.status).toBe("ok");
+    expect(result.startedAt).toBe("2026-05-01T12:00:00Z");
+    expect(result.durationMs).toBe(300_000);
+    expect(result.stats).toEqual({ processed: 5, refunded: 2 });
+    expect(result.triggeredBy).toBe("cron");
+  });
+});
+
+describe("getLeadDisputeOverview", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns correct pending count and health from DB data", async () => {
+    // Call sequence: pending count, recent data, cron_run_log (via getLatestCronRun)
+    mockAdminFrom
+      .mockImplementationOnce(() => makeChain({ count: 12, data: null }))   // pending count
+      .mockImplementationOnce(() => makeChain({ data: [], error: null }))    // recent data
+      .mockImplementationOnce(() => makeChain({ data: null, error: null })); // cron run log
+    const result = await getLeadDisputeOverview();
+    expect(result.feature).toBe("lead_disputes");
+    expect(result.pending).toBe(12);
+    expect(result.display.key).toBe("lead_disputes");
+    expect(["green", "amber", "red", "unknown"]).toContain(result.health);
+  });
+
+  it("aggregates recentCounts correctly for a mixed set of disputes", async () => {
+    const recentData = [
+      { auto_resolved_verdict: "refund", status: "approved", refunded_cents: 10000 },
+      { auto_resolved_verdict: "reject", status: "rejected", refunded_cents: 0 },
+      { auto_resolved_verdict: "escalate", status: "pending", refunded_cents: 0 },
+      { auto_resolved_verdict: null, status: "pending", refunded_cents: 0 },
+    ];
+    mockAdminFrom
+      .mockImplementationOnce(() => makeChain({ count: 3, data: null }))
+      .mockImplementationOnce(() => makeChain({ data: recentData, error: null }))
+      .mockImplementationOnce(() => makeChain({ data: null, error: null }));
+    const result = await getLeadDisputeOverview();
+    expect(result.recentCounts.autoActed).toBe(2);  // refund + reject
+    expect(result.recentCounts.escalated).toBe(1);  // escalate verdict
+    expect(result.recentCounts.total).toBe(4);
+    expect(result.recentCounts.refunded).toBe(10000);
+  });
+
+  it("exposes the cron run in lastRun when available", async () => {
+    const cronRow = {
+      name: "auto-resolve-disputes",
+      started_at: "2026-05-02T06:00:00Z",
+      ended_at: "2026-05-02T06:00:30Z",
+      duration_ms: 30_000,
+      status: "ok",
+      stats: { processed: 3 },
+      error_message: null,
+      triggered_by: "cron",
+    };
+    mockAdminFrom
+      .mockImplementationOnce(() => makeChain({ count: 0 }))
+      .mockImplementationOnce(() => makeChain({ data: [], error: null }))
+      .mockImplementationOnce(() => makeChain({ data: cronRow, error: null }));
+    const result = await getLeadDisputeOverview();
+    expect(result.lastRun?.status).toBe("ok");
+    expect(result.lastRun?.name).toBe("auto-resolve-disputes");
+    expect(result.health).toBe("green");
+  });
+});
+
+describe("getAdvisorApplicationOverview", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("counts auto-reviewed applications in autoActed", async () => {
+    const recentData = [
+      { status: "approved", reviewed_by: "auto" },
+      { status: "rejected", reviewed_by: "auto" },
+      { status: "pending", reviewed_by: null },
+    ];
+    mockAdminFrom
+      .mockImplementationOnce(() => makeChain({ count: 5 }))                      // pending count
+      .mockImplementationOnce(() => makeChain({ data: recentData, error: null })); // recent
+    const result = await getAdvisorApplicationOverview();
+    expect(result.feature).toBe("advisor_applications");
+    expect(result.recentCounts.autoActed).toBe(2); // two auto-reviewed (approved + rejected)
+    expect(result.recentCounts.escalated).toBe(1); // one still pending
+    expect(result.recentCounts.total).toBe(3);
+    expect(result.lastRun).toBeNull(); // no cron-driven
+  });
+
+  it("returns 0 counts on empty DB result", async () => {
+    mockAdminFrom
+      .mockImplementationOnce(() => makeChain({ count: 0 }))
+      .mockImplementationOnce(() => makeChain({ data: [], error: null }));
+    const result = await getAdvisorApplicationOverview();
+    expect(result.pending).toBe(0);
+    expect(result.recentCounts.total).toBe(0);
+  });
+});
+
+describe("getMarketplaceCampaignOverview", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns pending count and correct status breakdown", async () => {
+    const recentData = [
+      { status: "active" },
+      { status: "active" },
+      { status: "pending" },
+      { status: "rejected" },
+    ];
+    mockAdminFrom
+      .mockImplementationOnce(() => makeChain({ count: 7 }))
+      .mockImplementationOnce(() => makeChain({ data: recentData, error: null }));
+    const result = await getMarketplaceCampaignOverview();
+    expect(result.feature).toBe("marketplace_campaigns");
+    expect(result.pending).toBe(7);
+    expect(result.recentCounts.approved).toBe(2);  // active
+    expect(result.recentCounts.rejected).toBe(1);
+    expect(result.recentCounts.escalated).toBe(1); // pending status
+    expect(result.recentCounts.autoActed).toBe(3); // active + rejected
+    expect(result.recentCounts.total).toBe(4);
+  });
+
+  it("returns unknown health when there is no cron run and queue is empty", async () => {
+    mockAdminFrom
+      .mockImplementationOnce(() => makeChain({ count: 0 }))
+      .mockImplementationOnce(() => makeChain({ data: [], error: null }));
+    const result = await getMarketplaceCampaignOverview();
+    // marketplace_campaigns has no cron; with empty queue and no run → unknown
+    expect(result.health).toBe("unknown");
+    expect(result.lastRun).toBeNull();
+  });
+});
+
+describe("getAllFeatureOverviews", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns one entry per AUTOMATION_FEATURES key", async () => {
+    // Return an empty-data chain for every Supabase call so all feature
+    // functions succeed without needing exact per-feature mock ordering.
+    mockAdminFrom.mockImplementation(() => makeChain({ count: 0, data: [] }));
+    const results = await getAllFeatureOverviews();
+    expect(results).toHaveLength(AUTOMATION_FEATURES.length);
+    const keys = results.map((r) => r.feature);
+    for (const f of AUTOMATION_FEATURES) {
+      expect(keys).toContain(f);
+    }
+  });
+
+  it("degrades to 'unknown' health when a feature function throws (safeFallback)", async () => {
+    // Throw on the very first from() call so getLeadDisputeOverview crashes.
+    // All other calls get empty data so the remaining 12 features succeed.
+    let callCount = 0;
+    mockAdminFrom.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) throw new Error("DB unavailable");
+      return makeChain({ count: 0, data: [] });
+    });
+    const results = await getAllFeatureOverviews();
+    expect(results).toHaveLength(AUTOMATION_FEATURES.length);
+    const crashed = results.find((r) => r.feature === "lead_disputes");
+    expect(crashed?.health).toBe("unknown");
+    expect(crashed?.lastRun?.errorMessage).toContain("DB unavailable");
   });
 });

--- a/__tests__/lib/admin-automation-metrics.test.ts
+++ b/__tests__/lib/admin-automation-metrics.test.ts
@@ -272,10 +272,11 @@ describe("getLeadDisputeOverview", () => {
   });
 
   it("exposes the cron run in lastRun when available", async () => {
+    const recentStartedAt = new Date(Date.now() - 30 * 60 * 1000).toISOString(); // 30 min ago
     const cronRow = {
       name: "auto-resolve-disputes",
-      started_at: "2026-05-02T06:00:00Z",
-      ended_at: "2026-05-02T06:00:30Z",
+      started_at: recentStartedAt,
+      ended_at: new Date(Date.now() - 29 * 60 * 1000).toISOString(),
       duration_ms: 30_000,
       status: "ok",
       stats: { processed: 3 },


### PR DESCRIPTION
## Summary

Extends `__tests__/lib/admin-automation-metrics.test.ts` with async Supabase-backed function coverage, targeting ≥60% for `lib/admin/automation-metrics.ts` (previously ~25% — only the pure `computeHealth` state machine and static config were tested).

### What was missing

The file has 15+ exported async functions (`getLatestCronRun`, `getLeadDisputeOverview`, `getAdvisorApplicationOverview`, `getMarketplaceCampaignOverview`, …, `getAllFeatureOverviews`) that all call `createAdminClient()` and were entirely untested.

### What's added

- **`makeChain()` helper** — reusable fluent Supabase builder mock; all query methods chainable; chain is thenable so `await from().select()` resolves correctly without needing a terminal `.single()`
- **`getLatestCronRun`** — error path → `never_run` fallback; null row → `never_run`; full row-to-`LatestCronRun` field mapping
- **`getLeadDisputeOverview`** — pending count; mixed-verdict `recentCounts` (autoActed/escalated/refunded); `lastRun` field populated from cron row; `health=green` when fresh
- **`getAdvisorApplicationOverview`** — `autoActed` counted from `reviewed_by="auto"` records; escalated from still-pending; empty-DB baseline
- **`getMarketplaceCampaignOverview`** — full status breakdown (approved/rejected/escalated/autoActed); `health=unknown` with no cron and empty queue
- **`getAllFeatureOverviews`** — returns one entry per `AUTOMATION_FEATURES` key; `safeFallback` produces `health=unknown` + `errorMessage` when a feature function throws

## Test plan

- [ ] `npm test -- __tests__/lib/admin-automation-metrics.test.ts` passes green
- [ ] Coverage for `lib/admin/automation-metrics.ts` ≥ 60% in CI coverage report
- [ ] No regressions in existing `computeHealth` / config tests

Refs: #218
Audit: docs/audits/codebase-health-2026-04-24.md §2.3 (test coverage)
Queue: docs/audits/REMEDIATION_QUEUE.md R-06

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtYfkPkTvbNw5QVeuxjaxn)_