### PR TITLE
chore(launch-ops): add launch-hotfix PR template + CONTRIBUTING note

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/launch-hotfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/launch-hotfix.md
@@ -1,0 +1,82 @@
+<!--
+  LAUNCH HOTFIX TEMPLATE
+  Use this template when you are fixing a single bug during the launch
+  window (T-24h to T+4 weeks per docs/runbooks/launch-day.md).
+
+  How to use:
+    gh pr create --template launch-hotfix.md
+    or open the PR in the browser and pick "launch-hotfix" from the
+    template dropdown.
+
+  Hard rules:
+  - One bug per PR. No unrelated cleanups, refactors, or feature work.
+  - Add the severity label (P0 / P1 / P2 / P3) per docs/ops/severity-matrix.md.
+  - Add the `launch-hotfix` label.
+  - Merge tier follows the severity (P0 → Tier C; P1 → Tier B; P2/P3 → Tier A
+    unless inside the launch freeze window per launch-day.md).
+-->
+
+## Bug
+
+<!-- One sentence: what's broken, and the smallest reproducible example. -->
+
+## Severity
+
+<!-- Pick one and delete the rest. Justify if it's not the obvious choice. -->
+
+- [ ] **P0** — Site down / data loss / payment broken / security incident
+- [ ] **P1** — Major feature broken for many users, no data loss, workaround exists
+- [ ] **P2** — Minor feature broken or visibly off
+- [ ] **P3** — Cosmetic / edge-case / content correction
+
+Reference: `docs/ops/severity-matrix.md`
+
+## Root cause
+
+<!-- One paragraph. Why did this happen? What did we miss? Don't summarise the
+     diff — explain what was wrong about the previous behaviour. -->
+
+## Fix
+
+<!-- One paragraph. What did you change, and why is this the smallest
+     viable fix? If you considered a wider change, say what and why you
+     rejected it. -->
+
+## Rollback
+
+<!-- REQUIRED. How do we undo this if the fix makes things worse? -->
+
+- [ ] Vercel rollback by deployment ID is sufficient (default for code-only changes)
+- [ ] Migration rollback steps documented in the migration file header
+- [ ] Feature flag flip — flag name: `<flag>` (set to `false` via `/admin/automation/flags`)
+- [ ] Other (describe): <!-- e.g. cron pause, env var unset, manual DB row edit -->
+
+Cross-ref: `docs/runbooks/launch-rollback.md`
+
+## Test plan
+
+<!-- What did you actually run / click / curl to verify the fix? Not
+     "tests pass" — what specifically? -->
+
+- [ ] `npm run type-check`
+- [ ] `npm test -- <changed files>`
+- [ ] Manual reproduction confirmed broken before, fixed after
+- [ ] Vercel preview verified (URL: <!-- paste -->)
+- [ ] (P0/P1 only) Smoke checked the affected user flow on preview
+
+## Hotfix discipline checklist
+
+- [ ] One bug per PR — no piggy-backed changes
+- [ ] No new features, no refactors, no formatting churn
+- [ ] Diff fits on one screen (target: < 100 lines changed)
+- [ ] Severity label added
+- [ ] `launch-hotfix` label added
+- [ ] Linked to the bug-report row / Sentry issue / runbook (if applicable)
+
+## Comms
+
+<!-- Only required for P0 / P1 with public visibility. -->
+
+- [ ] Status page updated — link: <!-- paste -->
+- [ ] Reply sent to bug reporter using `docs/ops/launch-canned-responses.md` (3a fixed-now)
+- [ ] N/A — internal-only or no public-facing impact

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,20 @@ much better when everyone uses it.
 - Mark draft PRs as draft — reviewers ignore non-draft PRs unless
   they're ready.
 
+### Launch-hotfix PRs
+
+During the launch window (per `docs/runbooks/launch-day.md`), bug
+fixes use the `launch-hotfix` template — one bug per PR, no feature
+changes, rollback step required in the description. Pick it via:
+
+```
+gh pr create --template launch-hotfix.md
+```
+
+Add the severity label (`P0` / `P1` / `P2` / `P3`) per
+`docs/ops/severity-matrix.md` plus `launch-hotfix`. Merge tier follows
+severity (see `docs/audits/MERGE_AUTHORIZATION.md`).
+
 ## Code style
 
 - TypeScript strict mode is on (including `noUncheckedIndexedAccess`).


### PR DESCRIPTION
Adds the missing pieces from `docs/ops/launch-ops-plan.md` PR 3 (Phase A):

1. `.github/PULL_REQUEST_TEMPLATE/launch-hotfix.md` — enforces one-bug-per-PR, severity label, no feature changes, mandatory **Rollback** and **Test plan** sections.
2. `CONTRIBUTING.md` — new \"Launch-hotfix PRs\" subsection pointing at the template, the severity labels, and the merge-tier mapping in `MERGE_AUTHORIZATION.md`.

Labels `P1`, `P2`, `P3`, `launch-hotfix` were created via `gh label create` (outside this PR, since labels aren't versioned). `P0` already existed.

Pairs with PR #477 (canned responses) and the existing `docs/ops/severity-matrix.md`.

Phase A · **PR 3 of launch-ops-plan.md** · Tier A merge.