### PR TITLE
chore(invest): build-touch 4 PR #447 pages to force prerender refresh

### DIFF
--- a/app/invest/income-assets/page.tsx
+++ b/app/invest/income-assets/page.tsx
@@ -10,6 +10,7 @@ import {
 import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
 
 export const revalidate = 3600;
+// Build-touch 2026-05-03 — force fresh prerender (cached version had stuck client-render).
 
 export const metadata: Metadata = {
   title: `Income-Generating Asset Businesses in Australia (${CURRENT_YEAR}) — Vending, ATMs, Self-Storage & More`,

--- a/app/invest/ipo-calendar/page.tsx
+++ b/app/invest/ipo-calendar/page.tsx
@@ -11,6 +11,7 @@ import {
 import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
 
 export const revalidate = 3600;
+// Build-touch 2026-05-03 — force fresh prerender (cached version had stuck client-render).
 
 export const metadata: Metadata = {
   title: `ASX IPO Calendar (${CURRENT_YEAR}) — Upcoming Australian IPOs & Recent Listings`,

--- a/app/invest/pre-ipo/page.tsx
+++ b/app/invest/pre-ipo/page.tsx
@@ -10,6 +10,7 @@ import {
 import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
 
 export const revalidate = 3600;
+// Build-touch 2026-05-03 — force fresh prerender (cached version had stuck client-render).
 
 export const metadata: Metadata = {
   title: `Pre-IPO Investing in Australia (${CURRENT_YEAR}) — Wholesale-Only Late-Stage Private Deals`,

--- a/app/invest/royalties/page.tsx
+++ b/app/invest/royalties/page.tsx
@@ -10,6 +10,7 @@ import {
 import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
 
 export const revalidate = 3600;
+// Build-touch 2026-05-03 — force fresh prerender (cached version had stuck client-render).
 
 export const metadata: Metadata = {
   title: `Invest in Royalty Streams in Australia (${CURRENT_YEAR}) — Mining, Music & IP Royalties`,


### PR DESCRIPTION
## Why

User reports /invest/royalties sticking on skeleton (and 3 sister pages from PR #447 likely affected — same SSR fingerprint).

Server returns 200 with valid HTML. All chunks load. Incognito doesn't fix it. Most likely a **stale / broken Vercel ISR prerender cache** from the original PR #447 build.

## What

4 one-line comments to force fresh prerenders on next deploy:

- /invest/royalties
- /invest/income-assets  
- /invest/pre-ipo
- /invest/ipo-calendar

No behaviour change. Tier A. Auto-merge eligible.