### PR TITLE
test(email-templates): fix quizFollowUp2Email broker-list assertion

### DIFF
--- a/__tests__/lib/email-templates.test.ts
+++ b/__tests__/lib/email-templates.test.ts
@@ -373,15 +373,18 @@ describe("quizFollowUp1Email", () => {
 });
 
 describe("quizFollowUp2Email", () => {
-  it("renders with broker list", () => {
+  it("renders with broker list and a tradingInterest-matched callout", () => {
     const html = quizFollowUp2Email(
       "Frank",
       [{ name: "Stake", slug: "stake", rating: 4.5, asx_fee: "$3", us_fee: "$0" }],
-      "ETF investing"
+      "Active trading"
     );
     expect(html).toContain("Frank");
     expect(html).toContain("Stake");
-    expect(html).toContain("ETF investing");
+    // The implementation does not echo the raw `tradingInterest` value;
+    // it renders one of four keyword-matched callouts. "Active trading"
+    // hits the "active"/"trad" branch in lib/email-templates.ts.
+    expect(html).toContain("For Active Traders");
   });
 
   it("renders with null tradingInterest", () => {


### PR DESCRIPTION
The assertion \`expect(html).toContain(\"ETF investing\")\` was added in PR #471 but never matched the implementation — \`quizFollowUp2Email\` does not echo the raw \`tradingInterest\` argument; it renders one of four keyword-matched callouts (\`crypto\` / \`income\`|\`dividend\` / \`active\`|\`trad\` / \`growth\`|\`long\`).

Switch the input to \"Active trading\" (which hits the active/trad branch) and assert against the callout string the implementation actually emits.

Verified locally: 57/57 in \`__tests__/lib/email-templates.test.ts\` pass after this change.

Tier A.