### PR TITLE
feat(launch-ops): /api/bug-report POST + alert email

### DIFF
--- a/__tests__/api/bug-report.test.ts
+++ b/__tests__/api/bug-report.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const mockAdminFrom = vi.fn();
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  })),
+}));
+
+const mockIsAllowed = vi.fn();
+const mockIpKey = vi.fn(
+  (req: NextRequest) => req.headers.get("x-forwarded-for") ?? "unknown",
+);
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: (...args: unknown[]) => mockIsAllowed(...args),
+  ipKey: (req: NextRequest) => mockIpKey(req),
+}));
+
+const mockSendEmail = vi.fn();
+vi.mock("@/lib/resend", () => ({
+  sendEmail: (...args: unknown[]) => mockSendEmail(...args),
+}));
+
+import { POST } from "@/app/api/bug-report/route";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function makeInsertBuilder(
+  result: { id: string; created_at: string } | null = {
+    id: "11111111-2222-3333-4444-555555555555",
+    created_at: "2026-05-03T10:00:00.000Z",
+  },
+  error: { message: string } | null = null,
+) {
+  const single = vi.fn(() => Promise.resolve({ data: result, error }));
+  const select = vi.fn(() => ({ single }));
+  const insert = vi.fn(() => ({ select }));
+  return { insert, select, single };
+}
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/bug-report", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-forwarded-for": "1.2.3.4",
+      "user-agent": "Mozilla/5.0 (TestRunner)",
+    },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+}
+
+const VALID_BODY = {
+  page_url: "https://invest.com.au/best/share-trading",
+  route: "/best/[slug]",
+  user_message: "Stars render as zero on the IG card",
+  email: "user@example.com",
+  user_agent: "Mozilla/5.0 (RealClient)",
+  viewport: "1440x900",
+  severity_guess: "P2" as const,
+};
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("POST /api/bug-report", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowed.mockResolvedValue(true);
+    mockAdminFrom.mockReturnValue(makeInsertBuilder());
+    mockSendEmail.mockResolvedValue({ ok: true });
+  });
+
+  it("inserts a row and returns 201 with the new id on a valid submission", async () => {
+    const builder = makeInsertBuilder();
+    mockAdminFrom.mockReturnValue(builder);
+
+    const res = await POST(makeRequest(VALID_BODY));
+
+    expect(res.status).toBe(201);
+    expect(mockAdminFrom).toHaveBeenCalledWith("bug_reports");
+    expect(builder.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        page_url: VALID_BODY.page_url,
+        route: VALID_BODY.route,
+        user_message: VALID_BODY.user_message,
+        email: VALID_BODY.email,
+        viewport: VALID_BODY.viewport,
+        severity_guess: VALID_BODY.severity_guess,
+      }),
+    );
+    const json = (await res.json()) as { ok: boolean; id: string };
+    expect(json.ok).toBe(true);
+    expect(json.id).toBe("11111111-2222-3333-4444-555555555555");
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    mockIsAllowed.mockResolvedValue(false);
+    const res = await POST(makeRequest(VALID_BODY));
+    expect(res.status).toBe(429);
+    expect(mockAdminFrom).not.toHaveBeenCalled();
+  });
+
+  it("rejects an empty user_message with 400", async () => {
+    const res = await POST(
+      makeRequest({ ...VALID_BODY, user_message: "" }),
+    );
+    expect(res.status).toBe(400);
+    expect(mockAdminFrom).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-URL page_url with 400", async () => {
+    const res = await POST(
+      makeRequest({ ...VALID_BODY, page_url: "not a url" }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("accepts an empty-string email and stores it as null", async () => {
+    const builder = makeInsertBuilder();
+    mockAdminFrom.mockReturnValue(builder);
+
+    const res = await POST(makeRequest({ ...VALID_BODY, email: "" }));
+
+    expect(res.status).toBe(201);
+    expect(builder.insert).toHaveBeenCalledWith(
+      expect.objectContaining({ email: null }),
+    );
+  });
+
+  it("falls back to the request user-agent header when body omits it", async () => {
+    const builder = makeInsertBuilder();
+    mockAdminFrom.mockReturnValue(builder);
+
+    const { user_agent: _ua, ...withoutUa } = VALID_BODY;
+    const res = await POST(makeRequest(withoutUa));
+
+    expect(res.status).toBe(201);
+    expect(builder.insert).toHaveBeenCalledWith(
+      expect.objectContaining({ user_agent: "Mozilla/5.0 (TestRunner)" }),
+    );
+  });
+
+  it("returns 500 when the insert fails", async () => {
+    mockAdminFrom.mockReturnValue(
+      makeInsertBuilder(null, { message: "boom" }),
+    );
+
+    const res = await POST(makeRequest(VALID_BODY));
+    expect(res.status).toBe(500);
+    const json = (await res.json()) as { error: string };
+    expect(json.error).toBe("insert_failed");
+  });
+
+  it("still returns 201 when the alert email send fails", async () => {
+    mockSendEmail.mockResolvedValue({ ok: false, error: "no api key" });
+
+    const res = await POST(makeRequest(VALID_BODY));
+    expect(res.status).toBe(201);
+  });
+
+  it("rejects an invalid viewport string", async () => {
+    const res = await POST(
+      makeRequest({ ...VALID_BODY, viewport: "huge" }),
+    );
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/bug-report/route.ts
+++ b/app/api/bug-report/route.ts
@@ -1,0 +1,170 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { logger } from "@/lib/logger";
+import { isAllowed, ipKey } from "@/lib/rate-limit-db";
+import { sendEmail } from "@/lib/resend";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { withValidatedBody } from "@/lib/validation/withValidatedBody";
+
+export const runtime = "nodejs";
+
+const log = logger("bug-report");
+
+const ALERT_RECIPIENT = "finn@invest.com.au";
+
+/**
+ * POST /api/bug-report
+ *
+ * Backs the sitewide "Report a problem" button (PR 6 of launch-ops-plan.md).
+ * Stores the row in `bug_reports` (PR 4 migration) via the service-role
+ * client and emails an alert to the founder so triage can happen from the
+ * inbox instead of the admin UI.
+ *
+ * Per `docs/ops/launch-ops-plan.md` decision #2, alerts go to a single
+ * founder address — no Slack v1.
+ *
+ * Rate limit: 5/min per IP via `lib/rate-limit-db`. Generous enough that an
+ * honest user submitting a couple of follow-up reports isn't blocked, tight
+ * enough to blunt a synthetic flood.
+ */
+
+const Body = z.object({
+  page_url: z.string().url().max(2048),
+  route: z.string().max(512).optional(),
+  user_message: z.string().min(1).max(4000),
+  // Optional contact: accept empty string OR a valid email.
+  email: z
+    .union([z.literal(""), z.string().email().max(320)])
+    .optional()
+    .transform((v) => (v && v.length > 0 ? v : null)),
+  user_agent: z.string().max(1024).optional(),
+  viewport: z
+    .string()
+    .regex(/^\d{1,5}x\d{1,5}$/)
+    .optional(),
+  severity_guess: z.enum(["P0", "P1", "P2", "P3"]).optional(),
+});
+
+export const POST = withValidatedBody(Body, async (req: NextRequest, body) => {
+  const ip = ipKey(req);
+
+  if (!(await isAllowed("bug_report", ip, { max: 5, refillPerSec: 5 / 60 }))) {
+    return NextResponse.json(
+      { error: "rate_limited" },
+      { status: 429 },
+    );
+  }
+
+  const admin = createAdminClient();
+  const { data, error } = await admin
+    .from("bug_reports")
+    .insert({
+      page_url: body.page_url,
+      route: body.route ?? null,
+      user_message: body.user_message,
+      email: body.email,
+      user_agent: body.user_agent ?? req.headers.get("user-agent") ?? null,
+      viewport: body.viewport ?? null,
+      severity_guess: body.severity_guess ?? null,
+      // user_id is intentionally omitted v1 — anonymous-only intake.
+      // We can wire auth.uid() in once the founder confirms the dedup
+      // behaviour they want for logged-in submitters.
+    })
+    .select("id, created_at")
+    .single();
+
+  if (error || !data) {
+    log.error("bug_reports insert failed", {
+      error: error?.message ?? "no row returned",
+      page_url: body.page_url,
+    });
+    return NextResponse.json({ error: "insert_failed" }, { status: 500 });
+  }
+
+  // Fire-and-forget alert email. Resend helper is non-throwing; we surface
+  // failures to the log only — the user-facing 200 should never be gated on
+  // the alert succeeding.
+  void sendAlertEmail({
+    id: data.id,
+    createdAt: data.created_at,
+    pageUrl: body.page_url,
+    route: body.route,
+    userMessage: body.user_message,
+    email: body.email,
+    userAgent: body.user_agent ?? req.headers.get("user-agent") ?? null,
+    viewport: body.viewport,
+    severityGuess: body.severity_guess,
+    ip,
+  }).catch((err: unknown) => {
+    log.warn("alert email send threw", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  });
+
+  return NextResponse.json({ ok: true, id: data.id }, { status: 201 });
+});
+
+interface AlertPayload {
+  id: string;
+  createdAt: string;
+  pageUrl: string;
+  route?: string;
+  userMessage: string;
+  email: string | null;
+  userAgent: string | null;
+  viewport?: string;
+  severityGuess?: string;
+  ip: string;
+}
+
+async function sendAlertEmail(p: AlertPayload): Promise<void> {
+  const subject = `[bug-report] ${p.severityGuess ?? "?"} — ${truncate(p.userMessage, 60)}`;
+  const html = `
+    <h2 style="margin:0 0 12px;font:600 16px/1.3 system-ui,sans-serif;">New bug report</h2>
+    <table style="border-collapse:collapse;font:14px/1.4 system-ui,sans-serif;">
+      <tr><td style="padding:4px 12px 4px 0;color:#64748b;">id</td><td><code>${escapeHtml(p.id)}</code></td></tr>
+      <tr><td style="padding:4px 12px 4px 0;color:#64748b;">when</td><td>${escapeHtml(p.createdAt)}</td></tr>
+      <tr><td style="padding:4px 12px 4px 0;color:#64748b;">page</td><td><a href="${escapeHtml(p.pageUrl)}">${escapeHtml(p.pageUrl)}</a></td></tr>
+      <tr><td style="padding:4px 12px 4px 0;color:#64748b;">route</td><td>${escapeHtml(p.route ?? "—")}</td></tr>
+      <tr><td style="padding:4px 12px 4px 0;color:#64748b;">severity hint</td><td>${escapeHtml(p.severityGuess ?? "—")}</td></tr>
+      <tr><td style="padding:4px 12px 4px 0;color:#64748b;">reply-to</td><td>${escapeHtml(p.email ?? "(not provided)")}</td></tr>
+      <tr><td style="padding:4px 12px 4px 0;color:#64748b;">viewport</td><td>${escapeHtml(p.viewport ?? "—")}</td></tr>
+      <tr><td style="padding:4px 12px 4px 0;color:#64748b;">UA</td><td style="font-size:12px;color:#475569;">${escapeHtml(p.userAgent ?? "—")}</td></tr>
+      <tr><td style="padding:4px 12px 4px 0;color:#64748b;">IP</td><td><code>${escapeHtml(p.ip)}</code></td></tr>
+    </table>
+    <h3 style="margin:18px 0 6px;font:600 14px/1.3 system-ui,sans-serif;">Message</h3>
+    <pre style="white-space:pre-wrap;background:#f8fafc;border:1px solid #e2e8f0;padding:10px;border-radius:6px;font:13px/1.4 ui-monospace,monospace;">${escapeHtml(p.userMessage)}</pre>
+    <p style="margin:14px 0 0;font:12px/1.4 system-ui,sans-serif;color:#64748b;">
+      Triage at <a href="https://invest.com.au/admin/bug-reports">/admin/bug-reports</a>.
+      Use a canned reply from <code>docs/ops/launch-canned-responses.md</code>.
+    </p>
+  `;
+
+  const result = await sendEmail({
+    to: ALERT_RECIPIENT,
+    from: "Invest.com.au alerts <hello@invest.com.au>",
+    subject,
+    html,
+  });
+
+  if (!result.ok) {
+    log.warn("alert email send failed", { error: result.error });
+  }
+}
+
+function truncate(s: string, n: number): string {
+  return s.length <= n ? s : `${s.slice(0, n - 1)}…`;
+}
+
+const HTML_ESCAPES: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#39;",
+};
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, (ch) => HTML_ESCAPES[ch] ?? ch);
+}


### PR DESCRIPTION
PR 5 of \`docs/ops/launch-ops-plan.md\`. Adds the POST handler that the floating Report-a-Problem button (PR 6) calls.

- \`app/api/bug-report/route.ts\` — Zod via \`withValidatedBody\`, IP rate limit 5/min via \`lib/rate-limit-db\`, insert via \`lib/supabase/admin\` into \`bug_reports\` (table from PR 4 / #479), fire-and-forget Resend alert to \`finn@invest.com.au\` with a compact HTML summary.
- 9 unit tests (\`__tests__/api/bug-report.test.ts\`) covering: success path, rate-limit, validation rejects (empty message, bad URL, invalid viewport), empty-string email → null normalisation, UA fallback to header, DB-error 500, alert-send failure does not block 201.

Tier B.