### PR TITLE
feat(launch-ops): kill-switch gate for advisor_enquiry_intake

### DIFF
--- a/app/api/advisor-enquiry/route.ts
+++ b/app/api/advisor-enquiry/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { isFlagEnabled } from "@/lib/feature-flags";
 import { isRateLimited } from "@/lib/rate-limit";
 import { isValidEmail, isDisposableEmail } from "@/lib/validate-email";
 import { notificationFooter } from "@/lib/email-templates";
@@ -88,6 +89,13 @@ function buildQualificationEmailRows(qd: { source: string; data: Record<string, 
 
 export async function POST(request: NextRequest) {
   try {
+    // Launch-ops kill switch: flip `advisor_enquiry_intake` off in
+    // /admin/automation/flags to pause new advisor lead intake without
+    // taking the page down. See docs/ops/launch-ops-plan.md §4.
+    if (!(await isFlagEnabled("advisor_enquiry_intake"))) {
+      return NextResponse.json({ error: "temporarily_unavailable" }, { status: 503 });
+    }
+
     // Rate limiting (DB-backed, survives serverless cold starts)
     const ip = request.headers.get("x-forwarded-for")?.split(",")[0] || "unknown";
     if (await isRateLimited(`enquiry:${ip}`, 10, 60)) {


### PR DESCRIPTION
PR 8 of \`docs/ops/launch-ops-plan.md\` (Phase C). Wires the existing \`feature_flags\` table to the advisor lead intake.

\`\`\`ts
if (!(await isFlagEnabled('advisor_enquiry_intake'))) {
  return NextResponse.json({ error: 'temporarily_unavailable' }, { status: 503 });
}
\`\`\`

Flip via \`/admin/automation/flags\` (admin UI exists from prior work). Default state: enabled.

Toggle reasons (per launch-ops-plan §4): notification storm, RLS bug, advisor-side rate-limit hit.

Tier C (write-path gate on a lead-flow endpoint).

**Note:** the existing \`await request.json()\` on this route triggers a pre-existing \`invest/no-unvalidated-req-json\` warning. Out of scope for this gate wiring — left as a follow-up.