### PR TITLE
feat(launch-ops): kill-switch gate for ai_generation

### DIFF
--- a/app/api/admin/ai-chat/route.ts
+++ b/app/api/admin/ai-chat/route.ts
@@ -1,6 +1,7 @@
 import Anthropic from "@anthropic-ai/sdk";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { createClient } from "@/lib/supabase/server";
+import { isFlagEnabled } from "@/lib/feature-flags";
 import { ADMIN_EMAILS } from "@/lib/admin";
 import { NextRequest, NextResponse } from "next/server";
 import {
@@ -647,6 +648,13 @@ async function executeTool(name: string, input: Record<string, unknown>): Promis
 
 export async function POST(req: NextRequest) {
   try {
+    // Launch-ops kill switch: flip `ai_generation` off in
+    // /admin/automation/flags to halt all AI calls. Same flag as the
+    // public concierge route. See docs/ops/launch-ops-plan.md §4.
+    if (!(await isFlagEnabled("ai_generation"))) {
+      return NextResponse.json({ error: "temporarily_unavailable" }, { status: 503 });
+    }
+
     // Require admin authentication
     const supabaseAuth = await createClient();
     const { data: { user }, error: authError } = await supabaseAuth.auth.getUser();

--- a/app/api/concierge/route.ts
+++ b/app/api/concierge/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import Anthropic from "@anthropic-ai/sdk";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { isAllowed, ipKey } from "@/lib/rate-limit-db";
+import { isFlagEnabled } from "@/lib/feature-flags";
 import { logger } from "@/lib/logger";
 import crypto from "node:crypto";
 import {
@@ -94,6 +95,16 @@ function ensureSessionId(session_id?: string): string {
 }
 
 export async function POST(req: NextRequest) {
+  // Launch-ops kill switch: flip `ai_generation` off in
+  // /admin/automation/flags to halt all AI calls (runaway cost,
+  // model regression, hallucinated compliance copy). Distinct from
+  // the per-route ai-cost-caps gate below — this one trips the
+  // entire AI surface at once. See docs/ops/launch-ops-plan.md §4
+  // and docs/ops/ai-cost-caps.md.
+  if (!(await isFlagEnabled("ai_generation"))) {
+    return NextResponse.json({ error: "temporarily_unavailable" }, { status: 503 });
+  }
+
   if (
     !(await isAllowed("concierge", ipKey(req), {
       max: 30,


### PR DESCRIPTION
PR 12 (Phase C). Gates POST /api/concierge + POST /api/admin/ai-chat on `ai_generation` flag. Returns 503 `temporarily_unavailable` when off. Other AI routes → follow-up. Tier C.