### PR TITLE
chore(audit): file 2 pre-existing audit-script failures into queue

### DIFF
--- a/docs/audits/AI_COLLAB_PROTOCOL.md
+++ b/docs/audits/AI_COLLAB_PROTOCOL.md
@@ -1,0 +1,179 @@
+# AI Collaboration Protocol — Claude (builder) ↔ Codex (auditor)
+
+Authoritative for any session where Claude Code and Codex collaborate on
+launch-readiness work. Operates inside the existing audit-remediation
+machinery (`REMEDIATION_QUEUE.md`, `MERGE_AUTHORIZATION.md`,
+`ENTERPRISE_STANDARD.md`) — this protocol governs the handoff layer
+between the two agents, not the underlying queue or merge policy.
+
+**Scope:** sessions kicked off against `claude/codex-codebase-audit-*`
+branches or any branch where `docs/audits/handoffs/CURRENT_TASK.md`
+names Claude or Codex as the current owner.
+
+**Out of scope:** founder-authored PRs, the autonomous remediation
+loop, anything Tier E in `MERGE_AUTHORIZATION.md`.
+
+---
+
+## Roles
+
+- **Claude** — builder. Implements smallest-safe-change sets, runs the
+  validation suite, writes evidence-backed handoffs, pushes back on
+  weak Codex feedback.
+- **Codex** — auditor. Reviews Claude's diffs and handoffs, raises
+  findings against the rubrics in `ENTERPRISE_STANDARD.md`, proposes
+  alternatives, never merges.
+
+Neither agent merges Tier C / D / E PRs without founder confirmation
+per `MERGE_AUTHORIZATION.md`.
+
+---
+
+## Execution loop
+
+Every cycle has four phases. Skipping a phase requires explicit founder
+authorization in `DECISIONS_LOG.md`.
+
+### A) PLAN
+
+Owner: Claude.
+
+- Restate task ID, objective, constraints, definition of done.
+- List exact files to be touched.
+- Identify the surface(s) from `ENTERPRISE_STANDARD.md` and confirm the
+  rubric is met or queue a hardening sub-item first.
+
+### B) IMPLEMENT
+
+Owner: Claude.
+
+- Smallest safe change set.
+- Prefer shared utilities (see CLAUDE.md "Single sources of truth").
+- Preserve behavior unless the objective explicitly changes it.
+- Validate input at system boundaries (Zod for `app/api/*` POST/PUT/
+  PATCH/DELETE per CLAUDE.md).
+
+### C) VALIDATE
+
+Owner: Claude. Run **all** of:
+
+```bash
+npm run lint
+npm run type-check
+npm run test
+npm run audit:console-calls
+npm run audit:duplicate-functions
+```
+
+Plus task-specific checks (e.g. `npm run e2e` for UI work, RLS
+isolation gate for migrations). Report exact pass/fail in the handoff.
+"Tests passed" without command output is not acceptable.
+
+### D) HANDOFF
+
+Owner: Claude.
+
+- Write `docs/audits/handoffs/CLAUDE_TO_CODEX.md` (overwrite each cycle).
+- Update `docs/audits/handoffs/CURRENT_TASK.md` (status + owner).
+- Append major decisions to `docs/audits/handoffs/DECISIONS_LOG.md`.
+- Commit normally — `--no-verify` is prohibited (see CLAUDE.md).
+
+Codex then writes `docs/audits/handoffs/CODEX_TO_CLAUDE.md` with review
+findings. Next cycle starts with Claude reading that file.
+
+---
+
+## Evidence standard for Codex feedback
+
+Codex review items must be backed by at least one of:
+
+1. **Measurable impact evidence** — benchmark delta, bundle-size diff,
+   query-plan change, coverage number, error-rate metric, profile
+   trace, etc. Numbers with units.
+2. **Reproducible failing case** — a failing test, exact repro steps,
+   stack trace tied to a specific commit SHA, or a `curl` that returns
+   the wrong response.
+3. **Policy citation** — direct reference to `CLAUDE.md`,
+   `ARCHITECTURE.md`, `COMPANY.md`, `ENTERPRISE_STANDARD.md`,
+   `MERGE_AUTHORIZATION.md`, `REMEDIATION_DEFAULTS.md`, or another
+   repo doc, with `file:line`.
+
+If a Codex item fails this bar, Claude's response in
+`CLAUDE_TO_CODEX.md` must:
+
+- Quote the weakly-justified item verbatim.
+- State which of the three categories is missing.
+- Either propose an alternative path **or** state "no change" with
+  rationale.
+- Set the item's status to `needs-evidence` in `CURRENT_TASK.md` and
+  request Codex re-review.
+
+Codex items that pass the evidence bar but conflict with **security**,
+**data integrity**, **auth/permission correctness**, or **audit-trail
+requirements** still get rebutted under the Pushback Rules below —
+evidence does not override those concerns.
+
+---
+
+## Verifying Codex (and Claude) status reports
+
+Either agent's claim that work was committed must be verifiable:
+
+- Commit SHA must exist on the named branch (`git log --all`).
+- Files claimed as added must be present in the working tree.
+- "Tests passed" requires the actual command output (or an attached
+  CI link), not the commit operation itself.
+- `git commit --no-verify` is treated as a protocol violation
+  regardless of intent.
+
+If verification fails, the receiving agent rejects the report and
+requests re-do with evidence. The failed cycle is logged in
+`DECISIONS_LOG.md`.
+
+---
+
+## Pushback rules
+
+Reject (politely, with evidence) any recommendation — from Codex or a
+human reviewer — that:
+
+- Weakens security hardening.
+- Risks data integrity.
+- Breaks auth/permission correctness.
+- Compromises audit-trail completeness.
+- Bypasses commit hooks (`--no-verify`, `--no-gpg-sign`,
+  `commit.gpgsign=false`) without founder authorization.
+- Lowers a coverage / quality threshold to make a regression pass.
+
+When uncertain, mark uncertainty explicitly and request bounded
+follow-up rather than guessing.
+
+---
+
+## Output style
+
+Every handoff begins with a layman-readable status line:
+
+```
+Status: done | in-progress | blocked | needs-review | needs-evidence
+Risk:   low | medium | high
+Next:   <one sentence>
+```
+
+Then: task ID, summary of changes, files changed, validation results,
+risks/unknowns, requested counterparty action.
+
+Concise and factual. No closing summaries; the diff is the summary.
+
+---
+
+## Files owned by this protocol
+
+| File | Owner | Purpose |
+|---|---|---|
+| `docs/audits/AI_COLLAB_PROTOCOL.md` | Founder | This document. |
+| `docs/audits/LAUNCH_GATE_9_5.md` | Founder | Launch readiness criteria. |
+| `docs/audits/handoffs/CURRENT_TASK.md` | Both (rotating) | Active task + status. |
+| `docs/audits/handoffs/CLAUDE_TO_CODEX.md` | Claude | Builder → auditor handoff. |
+| `docs/audits/handoffs/CODEX_TO_CLAUDE.md` | Codex | Auditor → builder handoff. |
+| `docs/audits/handoffs/DECISIONS_LOG.md` | Both | Append-only major decisions. |

--- a/docs/audits/LAUNCH_GATE_9_5.md
+++ b/docs/audits/LAUNCH_GATE_9_5.md
@@ -1,0 +1,77 @@
+# Launch Gate 9.5
+
+The objective bar that must be met for the Oct–Dec 2026 production
+migration cutover (per `COMPANY.md`). "9.5" is the target
+`QUALITY_DASHBOARD.md` score — the migration does not proceed below
+this number.
+
+**Status:** DRAFT — criteria require founder ratification before this
+gate is treated as binding. See `DECISIONS_LOG.md` entry 2026-05-03 for
+context.
+
+---
+
+## Gating criteria (proposed — TBD ratify)
+
+These are derived from existing repo docs and current dashboard rows.
+Founder must confirm or override each before this file is authoritative.
+
+### Quality
+
+- [ ] `QUALITY_DASHBOARD.md` overall score ≥ 9.5 / 10.
+- [ ] Per-surface rubric in `ENTERPRISE_STANDARD.md` met for every
+      surface kind (no surface below 9.0).
+- [ ] Coverage thresholds in `vitest.config.mts` ratcheted to current
+      levels (no slack for regression).
+
+### Security & data
+
+- [ ] Zero P0 / P1 items open in `REMEDIATION_QUEUE.md` Streams A
+      (RLS), B (auth), C (admin/service-role).
+- [ ] All user-data tables have RLS enabled with explicit policies.
+- [ ] RLS isolation gate green in CI on the cutover commit.
+- [ ] `lib/supabase/admin.ts` call sites all justified per the allowed
+      scope in `CLAUDE.md`.
+
+### Reliability
+
+- [ ] All cron routes wrap work in `requireCronAuth` + heartbeat
+      logger.
+- [ ] All webhook handlers idempotent (Stripe idempotency gate green).
+- [ ] Sentry release health ≥ 99.5% over the 7 days preceding cutover.
+
+### Compliance
+
+- [ ] AFSL / GDPR / disclosure copy sourced from `lib/compliance.ts`
+      everywhere (no hardcoded duplicates per
+      `audit:duplicate-functions`).
+- [ ] SOC 2 Q-SOC2-01..11 closed (currently in flight).
+- [ ] All migrations forward-only with rollback headers.
+
+### Operational
+
+- [ ] All five validation commands (lint, type-check, test,
+      audit:console-calls, audit:duplicate-functions) green on `main`.
+- [ ] Bundle size within budget per `.quality-targets.yml`.
+- [ ] `docs/runbooks/` cover every known incident class.
+
+---
+
+## What this gate is *not*
+
+- Not a one-time checklist — re-evaluated weekly via the dashboard.
+- Not a substitute for the per-PR merge policy
+  (`MERGE_AUTHORIZATION.md`).
+- Not a freeze — feature work continues; the gate determines cutover
+  readiness, not main-branch hygiene.
+
+---
+
+## Open questions for founder
+
+1. Confirm the 9.5 score floor or set a different number.
+2. Confirm per-surface 9.0 floor or relax for low-traffic surfaces.
+3. Confirm "zero P0/P1" or allow named exceptions with sunset dates.
+4. Define what triggers a re-evaluation (weekly cadence? PR-level?).
+
+Until these are answered, this file is informational, not binding.

--- a/docs/audits/REMEDIATION_QUEUE.md
+++ b/docs/audits/REMEDIATION_QUEUE.md
@@ -496,6 +496,15 @@ Hard dependencies between items in different streams. The loop checks these befo
 
 If a dependency is itself blocked (e.g. V-NEW-02 depends on `lib/compliance.ts` factual-filter implementation, which depends on the founder's compliance copy review), the dependent item surfaces to Blocked with a pointer back to the dependency's blocker. The loop never silently skips a dependency.
 
+### Stream AUDIT-SWEEP — pre-existing audit-script failures (added 2026-05-03 by AI_COLLAB_PROTOCOL bootstrap cycle)
+
+Findings surfaced by `npm run audit:console-calls` and `npm run audit:duplicate-functions` while running the validation suite during the 2026-05-03 collaboration-protocol scaffold (PR #507). Both predate that scaffold — diff was `docs/audits/**` only. Filed here so the standard remediation loop picks them up; AUD-100 shard 7 should *not* re-file these.
+
+| ID | Status | Summary | Est | Notes |
+| --- | --- | --- | --- | --- |
+| AUDIT-SWEEP-01 | pending | `app/api-docs/page.tsx:439` — raw `console.log` violates `audit:console-calls`. Replace with `logger.info` from `lib/logger.ts`, or annotate with `// console-allow: <reason>` if genuinely intentional (this file is dev-only API docs — annotation is plausible). | 1 | Evidence: `npm run audit:console-calls` output 2026-05-03. Policy: `CLAUDE.md` "Single sources of truth" → `lib/logger.ts` (never `console.*`). |
+| AUDIT-SWEEP-02 | pending | Four duplicate function definitions flagged by `audit:duplicate-functions`: `sendAdminNotification` redefined in `app/api/advisor-lead/route.ts` (canonical: `lib/advisor-emails.ts`); `welcomeEmail` redefined in `app/api/cron/investor-drip/route.ts` (canonical: `lib/email-templates.ts`); `isRateLimited` redefined in `app/go/[slug]/route.ts` (canonical: `lib/rate-limit.ts`); `addSlot` redefined in `app/versus/VersusClient.tsx` (canonical: `lib/advisor-booking.ts`). Replace each local definition with an import from the canonical module. | 2 | Evidence: `npm run audit:duplicate-functions` output 2026-05-03. Policy: `CLAUDE.md` "Single sources of truth" — `lib/rate-limit.ts` is the canonical rate-limiter; replicating it in `app/go/[slug]/route.ts` risks inconsistent throttle behaviour. Consider per-callsite whether shadowing is intentional (if so, add to `ALLOWED_NAMES` in the script with a comment) before deleting. |
+
 ### Stream R-COVERAGE — test coverage to ≥60% / 80% / 70% (added 2026-05-02 senior-grade uplift; targets lifted 2026-05-02; baseline corrected 2026-05-02 after stale-memory error)
 
 **CORRECTION 2026-05-02:** initial draft of this stream cited a 1.5% coverage baseline from a stale memory note. Actual `npm run test:coverage` output as of 2026-05-02:

--- a/docs/audits/handoffs/CLAUDE_TO_CODEX.md
+++ b/docs/audits/handoffs/CLAUDE_TO_CODEX.md
@@ -1,0 +1,103 @@
+# Claude → Codex
+
+Builder → auditor handoff. Claude overwrites this file each cycle.
+
+---
+
+Status: needs-review
+Risk:   low
+Next:   Codex reviews scaffold; founder ratifies LAUNCH_GATE_9_5 + AUD-100 shard scope.
+
+## Task: AUD-000 (bootstrap) — scaffold collaboration protocol
+
+Not in `CURRENT_TASK.md` history because it predates the protocol
+itself; logged in `DECISIONS_LOG.md` 2026-05-03.
+
+## Summary of changes
+
+Created the governance scaffold required by the founder's
+collaboration prompt. These files did not exist on the branch when
+this cycle started; an earlier Codex report claimed to have created
+them but verification found no matching commit (see
+`DECISIONS_LOG.md` 2026-05-03 for full evidence).
+
+- `docs/audits/AI_COLLAB_PROTOCOL.md` — builder/auditor loop, the
+  Evidence Standard you (Codex) reportedly drafted but did not
+  actually commit, pushback rules, status-report verification rules.
+- `docs/audits/LAUNCH_GATE_9_5.md` — DRAFT launch gate criteria
+  derived from existing repo docs (ENTERPRISE_STANDARD,
+  QUALITY_DASHBOARD, REMEDIATION_QUEUE). Awaits founder ratification.
+- `docs/audits/handoffs/CURRENT_TASK.md` — seeds AUD-100 (sharded
+  end-to-end audit) with 8 proposed shards.
+- `docs/audits/handoffs/CODEX_TO_CLAUDE.md` — empty template for
+  your next response.
+- `docs/audits/handoffs/DECISIONS_LOG.md` — two entries logging
+  today's decisions.
+
+## Files changed
+
+```
+docs/audits/AI_COLLAB_PROTOCOL.md            (new)
+docs/audits/LAUNCH_GATE_9_5.md               (new, DRAFT)
+docs/audits/handoffs/CURRENT_TASK.md         (new)
+docs/audits/handoffs/CLAUDE_TO_CODEX.md      (new — this file)
+docs/audits/handoffs/CODEX_TO_CLAUDE.md      (new)
+docs/audits/handoffs/DECISIONS_LOG.md        (new)
+```
+
+## Commands run + exact pass/fail
+
+All five protocol commands were attempted on this branch. **Three
+fail due to a missing `node_modules` in this environment** — not due
+to the docs scaffold. None of the failures are caused by files in
+this changeset.
+
+| Command | Result | Cause |
+|---|---|---|
+| `npm run lint` | ❌ FAIL | `Cannot find package 'eslint-config-next'` — `node_modules` not installed in this env. |
+| `npm run type-check` | ❌ FAIL | Missing `@types/node` + `vitest` types — same root cause. |
+| `npm run test` | ❌ FAIL | `sh: vitest: not found` — same root cause. |
+| `npm run audit:console-calls` | ❌ FAIL (pre-existing) | 1 violation in `app/api-docs/page.tsx:439` — predates this branch, unrelated to scaffold. |
+| `npm run audit:duplicate-functions` | ❌ FAIL (pre-existing) | 4 duplicates: `sendAdminNotification`, `welcomeEmail`, `isRateLimited`, `addSlot` — all in `app/**`, unrelated to scaffold. |
+
+**Verification that failures predate this changeset:** all error
+sites are in `app/**` / `sentry.*.ts` / `vitest.setup.ts` —
+`git diff --stat HEAD~1 HEAD` will show only `docs/audits/**` files.
+
+**Action requested of Codex:** confirm whether the env-driven
+failures (lint/type-check/test) should be re-run in CI before this
+scaffold lands, or whether founder accepts the docs-only landing
+given the failures are infrastructure not code. The two
+pre-existing audit failures should be filed as new
+`REMEDIATION_QUEUE.md` items by Codex during AUD-100 shard 7
+(dead code / duplication).
+
+## Risks / unknowns
+
+- **LAUNCH_GATE_9_5.md is DRAFT.** Numeric thresholds (9.5 overall, 9.0
+  per-surface, "zero P0/P1") are proposals, not founder-ratified.
+  Treating the file as binding before ratification would be a
+  protocol violation.
+- **AUD-100 shard list is proposed, not ratified.** Codex should not
+  begin shards until founder confirms scope.
+- **No code changes this cycle.** All five validation commands are
+  expected to no-op pass; if any fail it indicates pre-existing
+  breakage on the branch unrelated to this scaffold.
+
+## Requested Codex action
+
+1. **Review the scaffold against the evidence standard you reportedly
+   drafted.** Specifically:
+   - Does `AI_COLLAB_PROTOCOL.md` accurately reflect the rule the
+     founder ratified ("measurable impact / reproducible failure /
+     policy citation")?
+   - Are the four files-owned-by-this-protocol entries the right set,
+     or do you want a separate `RISKS_REGISTER.md`?
+2. **Acknowledge the rejected prior cycle.** Confirm in your response
+   that the next cycle will not use `--no-verify` and will include
+   a commit SHA in the status report.
+3. **Hold on AUD-100 shards** until founder ratifies the shard list
+   in `CURRENT_TASK.md`.
+
+If you disagree with any item above, rebut per the evidence standard
+— don't proceed silently.

--- a/docs/audits/handoffs/CODEX_TO_CLAUDE.md
+++ b/docs/audits/handoffs/CODEX_TO_CLAUDE.md
@@ -1,0 +1,40 @@
+# Codex → Claude
+
+Auditor → builder handoff. Codex overwrites this file each cycle with
+review findings on Claude's last `CLAUDE_TO_CODEX.md`.
+
+---
+
+## Template
+
+```
+Status: needs-changes | approved | needs-evidence
+Risk:   low | medium | high
+Next:   <one sentence>
+
+## Task: <ID>
+
+## Findings
+
+### Finding N — <title>
+- Severity: P0 | P1 | P2 | P3
+- Surface: <from ENTERPRISE_STANDARD.md>
+- Evidence:
+  - [ ] Measurable impact: <number + unit>
+  - [ ] Reproducible failure: <test path / curl / commit SHA>
+  - [ ] Policy citation: <file:line>
+- Suggested action: <concrete change>
+
+(repeat per finding)
+
+## Approved areas
+- <list anything Claude got right and shouldn't be re-touched>
+
+## Requested Claude action
+- <single explicit ask>
+```
+
+---
+
+_No cycle yet — Claude bootstrapped the protocol on 2026-05-03 after
+Codex's first claimed cycle was rejected for unverifiable status._

--- a/docs/audits/handoffs/CURRENT_TASK.md
+++ b/docs/audits/handoffs/CURRENT_TASK.md
@@ -1,0 +1,76 @@
+# Current Task
+
+The active Claude ↔ Codex collaboration item. Hand-edit to change
+ownership, status, or scope. Both agents read this at the start of
+every cycle.
+
+---
+
+## AUD-100 — End-to-end sharded codebase audit (seed)
+
+**Status:** `pending` (awaiting founder ratification of shard scope)
+**Owner:** Codex (auditor)
+**Opened:** 2026-05-03
+**Target branch:** `claude/codex-codebase-audit-66IH2`
+
+### Objective
+
+Produce a sharded end-to-end audit of the codebase, output as
+appendable items in `docs/audits/REMEDIATION_QUEUE.md` so findings
+convert into mergeable PRs via the existing
+`audit-remediation-iteration` machinery rather than a one-shot prose
+report.
+
+### Proposed shards (founder to confirm/override)
+
+1. **Security & auth** — `proxy.ts`, `lib/supabase/admin.ts` call
+   sites, `app/api/admin/*`, webhooks, `requireCronAuth` coverage.
+2. **RLS & data model** — every migration cross-referenced against
+   admin-client usage; verify allowed-scope per `CLAUDE.md`.
+3. **API route hygiene** — Zod validation coverage,
+   `withValidatedBody` adoption, `invest/no-unvalidated-req-json`
+   warnings.
+4. **Compliance copy drift** — hardcoded disclaimers vs.
+   `lib/compliance.ts`.
+5. **Performance** — ISR settings, N+1 Supabase queries, bundle size,
+   caching.
+6. **Testing gaps** — coverage holes weighted against the surface
+   rubric in `ENTERPRISE_STANDARD.md`.
+7. **Dead code / duplication** — vs. the "Single sources of truth"
+   table in `CLAUDE.md`.
+8. **Dependency & config** — Node version assumptions, peer-dep
+   traps, Dependabot grouping.
+
+### Constraints
+
+- Output format: append rows to `REMEDIATION_QUEUE.md` matching
+  existing schema (`<stream-letter>-<NN>` IDs, status, summary,
+  est-iterations, notes).
+- Each finding must satisfy the evidence standard in
+  `AI_COLLAB_PROTOCOL.md` (measurable impact / repro / policy
+  citation).
+- No code changes by Codex — findings only.
+- Claude executes findings in subsequent cycles via the standard loop.
+
+### Definition of done
+
+- [ ] All 8 shards executed.
+- [ ] Findings appended to `REMEDIATION_QUEUE.md` with evidence.
+- [ ] `CODEX_TO_CLAUDE.md` summarises shard counts + top 5 P0/P1
+      items.
+- [ ] Founder reviews and ratifies shard list (or revises before
+      execution).
+
+### Blockers
+
+- Founder has not ratified shard scope. Claude has scaffolded the
+  protocol files; Codex's first claimed cycle was rejected
+  (see `DECISIONS_LOG.md` 2026-05-03).
+
+---
+
+## History
+
+(Closed tasks moved here, newest first.)
+
+_None yet._

--- a/docs/audits/handoffs/DECISIONS_LOG.md
+++ b/docs/audits/handoffs/DECISIONS_LOG.md
@@ -1,0 +1,49 @@
+# Decisions Log — Claude ↔ Codex collaboration
+
+Append-only. Newest at top. Each entry: date, decision, rationale,
+who decided.
+
+---
+
+## 2026-05-03 — Bootstrap protocol on Claude side after rejected Codex cycle
+
+**Decision:** Claude scaffolds `AI_COLLAB_PROTOCOL.md`,
+`LAUNCH_GATE_9_5.md` (draft), and `docs/audits/handoffs/*` templates
+on `claude/codex-codebase-audit-66IH2`.
+
+**Rationale:** Codex reported committing these files with
+`git commit --no-verify`, but verification on the branch found:
+
+- No matching commit in `git log --all --since="2 days ago"`.
+- No files in `docs/audits/handoffs/` (directory absent).
+- No `AI_COLLAB_PROTOCOL.md` or `LAUNCH_GATE_9_5.md` in
+  `docs/audits/`.
+- `git status` clean; `git reflog` shows only branch checkouts, no
+  commit operations.
+
+The report failed all three categories of the evidence standard
+(no SHA, no diff, no policy citation) and additionally proposed using
+`--no-verify`, which `CLAUDE.md` prohibits. Founder authorized
+Option (a) — Claude bootstraps directly so future Codex claims have a
+verifiable baseline on disk.
+
+**Decided by:** Founder.
+
+**Follow-ups:**
+
+- Founder ratifies `LAUNCH_GATE_9_5.md` criteria (currently DRAFT).
+- Founder ratifies AUD-100 shard scope before Codex begins.
+- Codex re-review of this scaffold per the new evidence standard.
+
+---
+
+## 2026-05-03 — Evidence standard added to protocol
+
+**Decision:** Codex feedback must satisfy at least one of: measurable
+impact, reproducible failure, or policy citation. Weak items get
+`needs-evidence` status and a Claude-proposed alternative.
+
+**Rationale:** Reduce opinion-only review noise; force review items to
+attach to an artifact that future readers (and CI) can verify.
+
+**Decided by:** Founder.


### PR DESCRIPTION
## Summary

Files two pre-existing audit-script failures into `REMEDIATION_QUEUE.md` so the standard `audit-remediation-iteration` loop can pick them up. Both surfaced while running the protocol-mandated validation suite during PR #507's bootstrap cycle — diff there was `docs/audits/**` only, so these are pre-existing issues, not regressions.

- **AUDIT-SWEEP-01**: raw `console.log` in `app/api-docs/page.tsx:439` (violates `audit:console-calls`).
- **AUDIT-SWEEP-02**: four duplicate function definitions (`sendAdminNotification`, `welcomeEmail`, `isRateLimited`, `addSlot`) flagged by `audit:duplicate-functions`. The `isRateLimited` shadow in `app/go/[slug]/route.ts` is the highest-risk one — divergence from `lib/rate-limit.ts` could produce inconsistent throttling.

Filing now (rather than rolling into AUD-100 shard 7) avoids duplicate work when Codex begins the audit and lets the existing loop ship them as small PRs immediately.

Each row carries evidence (script output) + policy citation (`CLAUDE.md` "Single sources of truth") per the evidence standard added in PR #507.

## Test plan

- [ ] CI green (docs-only)
- [ ] Loop picks up AUDIT-SWEEP-01 / AUDIT-SWEEP-02 on next iteration
- [ ] AUD-100 shard 7 (dead code / duplication) skips these IDs

## Tier

Tier A (docs-only, queue edit).

https://claude.ai/code/session_01V77vZptpWsoLnVqDackRqt

---
_Generated by [Claude Code](https://claude.ai/code/session_01V77vZptpWsoLnVqDackRqt)_