### PR TITLE
chore(g): G-03 batch 8 — rollback headers for 15 remaining migrations [audit remediation]

### DIFF
--- a/supabase/migrations/20260414_wave_3_trust_compliance.sql
+++ b/supabase/migrations/20260414_wave_3_trust_compliance.sql
@@ -1,5 +1,26 @@
 -- Wave 3: Trust + compliance foundations.
 --
+-- Date: 2026-04-14
+-- Audit ref: codebase-health-2026-04-24.md §4.3 (G-03)
+-- Queue item: G-03 batch 8
+-- Why: four tables/columns lay the trust + compliance foundations:
+--      DB-backed rate limiting, crash-robust Stripe idempotency,
+--      immutable money-movement audit log, and GDPR/Privacy Act
+--      data-request tracking.
+-- Idempotency: CREATE TABLE/INDEX IF NOT EXISTS;
+--              ALTER TABLE … ADD COLUMN IF NOT EXISTS. Safe to re-apply.
+-- Rollback (in reverse creation order):
+--   DROP TABLE IF EXISTS public.privacy_data_requests;
+--   DROP TABLE IF EXISTS public.financial_audit_log;
+--   ALTER TABLE public.stripe_webhook_events
+--     DROP COLUMN IF EXISTS processing_started_at,
+--     DROP COLUMN IF EXISTS processed_at,
+--     DROP COLUMN IF EXISTS status;
+--   DROP INDEX IF EXISTS public.idx_stripe_webhook_events_status_stale;
+--   DROP TABLE IF EXISTS public.rate_limit_buckets;
+--   Note: financial_audit_log is append-only; dropping it discards the
+--         full money-movement history. Export before any rollback.
+--
 -- Tables:
 --   1. rate_limit_buckets        — DB-backed token bucket (survives cold starts)
 --   2. stripe_webhook_events     — add processing/done status for crash-robust idempotency

--- a/supabase/migrations/20260414_wave_4_revenue_loop.sql
+++ b/supabase/migrations/20260414_wave_4_revenue_loop.sql
@@ -1,5 +1,34 @@
 -- Wave 4: Revenue loop schema.
 --
+-- Date: 2026-04-14
+-- Audit ref: codebase-health-2026-04-24.md §4.3 (G-03)
+-- Queue item: G-03 batch 8
+-- Why: three new tables and seven additive columns power paid advisor
+--      placements, referral payouts, attribution tracking, and drip /
+--      dormant-nudge automations.
+-- Idempotency: CREATE TABLE/INDEX IF NOT EXISTS;
+--              ALTER TABLE … ADD COLUMN IF NOT EXISTS. Safe to re-apply.
+-- Rollback (in reverse creation order):
+--   ALTER TABLE IF EXISTS public.email_captures DROP COLUMN IF EXISTS winback_sent_at;
+--   DROP INDEX IF EXISTS public.idx_email_captures_winback;
+--   ALTER TABLE IF EXISTS public.professionals DROP COLUMN IF EXISTS advisor_dormant_nudged_at;
+--   ALTER TABLE IF EXISTS public.quiz_leads
+--     DROP COLUMN IF EXISTS drip_step,
+--     DROP COLUMN IF EXISTS drip_sent_at;
+--   DROP INDEX IF EXISTS public.idx_quiz_leads_drip;
+--   ALTER TABLE IF EXISTS public.ab_tests
+--     DROP COLUMN IF EXISTS winner_variant,
+--     DROP COLUMN IF EXISTS winner_declared_at,
+--     DROP COLUMN IF EXISTS auto_promote_enabled;
+--   DROP TABLE IF EXISTS public.attribution_touches;
+--   DROP TABLE IF EXISTS public.referral_rewards;
+--   ALTER TABLE public.professionals
+--     DROP COLUMN IF EXISTS referral_code,
+--     DROP COLUMN IF EXISTS referral_count;
+--   DROP TABLE IF EXISTS public.sponsored_placements;
+--   Note: DELETE all attribution + referral rows first if preserving
+--         revenue/analytics data before dropping the tables.
+--
 -- Tables introduced:
 --   1. sponsored_placements   — paid advisor boost tier (bid + cap)
 --   2. referral_rewards       — referral payout state machine

--- a/supabase/migrations/20260414_wave_5_perf_indexes.sql
+++ b/supabase/migrations/20260414_wave_5_perf_indexes.sql
@@ -1,5 +1,31 @@
 -- Wave 5: DB indexes on observed hot query paths.
 --
+-- Date: 2026-04-14
+-- Audit ref: codebase-health-2026-04-24.md §4.3 (G-03)
+-- Queue item: G-03 batch 8
+-- Why: 20+ composite and partial indexes closing observed N+1 /
+--      full-scan patterns on affiliate_clicks, allocation_decisions,
+--      analytics_events, conversion_events, lead_disputes,
+--      professional_leads, user_reviews, advisor_profile_views,
+--      broker_answers, and other hot tables.
+-- Idempotency: CREATE INDEX IF NOT EXISTS. Safe to re-apply.
+-- Rollback: drop each index individually using IF NOT EXISTS — all are
+--   purely additive and can be removed without data loss. Key ones:
+--   DROP INDEX IF EXISTS public.idx_affiliate_clicks_clicked;
+--   DROP INDEX IF EXISTS public.idx_affiliate_clicks_broker_clicked;
+--   DROP INDEX IF EXISTS public.idx_affiliate_clicks_session;
+--   DROP INDEX IF EXISTS public.idx_allocation_decisions_created;
+--   DROP INDEX IF EXISTS public.idx_allocation_decisions_placement;
+--   DROP INDEX IF EXISTS public.idx_analytics_events_type_created;
+--   DROP INDEX IF EXISTS public.idx_conversion_events_created;
+--   DROP INDEX IF EXISTS public.idx_lead_disputes_status_created;
+--   DROP INDEX IF EXISTS public.idx_professional_leads_composite;
+--   DROP INDEX IF EXISTS public.idx_professional_leads_unresponded;
+--   DROP INDEX IF EXISTS public.idx_user_reviews_broker_published;
+--   DROP INDEX IF EXISTS public.idx_professional_reviews_prof_published;
+--   DROP INDEX IF EXISTS public.idx_advisor_profile_views_prof_date;
+--   (see file body for the remaining index names)
+--
 -- These target the N+1 / full-scan patterns found by inspecting
 -- the query planner + grepping the codebase. All IF NOT EXISTS so
 -- re-runs are safe.

--- a/supabase/migrations/20260426_wave_launch_readiness.sql
+++ b/supabase/migrations/20260426_wave_launch_readiness.sql
@@ -1,6 +1,35 @@
 -- ============================================================
 -- LAUNCH READINESS: Missing tables, thin content seeding,
 -- additional best-for scenarios, commodity data
+--
+-- Date: 2026-04-26
+-- Audit ref: codebase-health-2026-04-24.md §4.3 (G-03)
+-- Queue item: G-03 batch 8
+-- Why: creates newsletter_editions + five forum tables
+--      (forum_categories, forum_user_profiles, forum_threads,
+--       forum_posts, forum_votes), seeds forum categories, two
+--      newsletter editions, and 20 best_for_scenarios rows.
+-- Idempotency: CREATE TABLE IF NOT EXISTS; INSERT … ON CONFLICT DO NOTHING.
+--              Safe to re-apply.
+-- Rollback (in reverse creation order):
+--   DELETE FROM public.best_for_scenarios
+--     WHERE slug IN (
+--       'fractional-shares','copy-trading','margin-lending','family-accounts',
+--       'international-shares-beyond-us','demo-account','asx-small-caps',
+--       'high-frequency-api','ipo-investing','tax-reporting','corporate-accounts',
+--       'sustainable-super','share-trading-seniors','term-deposits',
+--       'high-interest-savings','share-trading-nz','cheapest-etf-portfolio',
+--       'joint-accounts','after-hours-trading','crypto-staking');
+--   DELETE FROM public.newsletter_editions WHERE edition_date IN ('2026-03-22','2026-03-29');
+--   DELETE FROM public.forum_categories WHERE slug IN (
+--       'general','brokers','shares','etfs','super','tax','property','crypto');
+--   DROP TABLE IF EXISTS public.forum_votes;
+--   DROP TABLE IF EXISTS public.forum_posts;
+--   DROP TABLE IF EXISTS public.forum_threads;
+--   DROP TABLE IF EXISTS public.forum_user_profiles;
+--   DROP TABLE IF EXISTS public.forum_categories;
+--   DROP TABLE IF EXISTS public.newsletter_editions;
+--   Note: forum table drop discards all user posts; export before rollback.
 -- ============================================================
 
 -- ────────────────────────────────────────────────────────────

--- a/supabase/migrations/20260429_oil_gas_expansion.sql
+++ b/supabase/migrations/20260429_oil_gas_expansion.sql
@@ -2,6 +2,24 @@
 -- Oil & Gas Expansion — vertical enrichment, 12 listings,
 -- 4 new advisor types and 12 professional seeds.
 --
+-- Date: 2026-04-29
+-- Audit ref: codebase-health-2026-04-24.md §4.3 (G-03)
+-- Queue item: G-03 batch 8
+-- Why: enriches the oil-and-gas investment vertical with 12
+--      listings, 4 advisor-type enum values, and 12 professional
+--      seed rows, plus two additive columns on professionals.
+-- Idempotency: ON CONFLICT (slug) DO UPDATE/DO NOTHING;
+--              ADD COLUMN IF NOT EXISTS. Safe to re-apply.
+-- Rollback:
+--   DELETE FROM public.professionals WHERE source = 'seed-oil-gas-2026-04-29';
+--   DELETE FROM public.investment_listings WHERE source = 'oil-gas-expansion';
+--   ALTER TABLE public.professionals
+--     DROP COLUMN IF EXISTS years_experience,
+--     DROP COLUMN IF EXISTS min_investable_assets;
+--   Note: professionals type CHECK constraint swap is idempotent;
+--         if rolling back, verify no live professionals use the
+--         newly-added types before removing the constraint.
+--
 -- Idempotent:
 --   * investment_verticals / investment_listings / professionals
 --     use ON CONFLICT (slug) DO UPDATE / DO NOTHING so re-runs

--- a/supabase/migrations/20260430_oil_gas_articles.sql
+++ b/supabase/migrations/20260430_oil_gas_articles.sql
@@ -1,6 +1,16 @@
 -- ============================================================
 -- Seed 15 oil-gas editorial articles.
 --
+-- Date: 2026-04-30
+-- Audit ref: codebase-health-2026-04-24.md §4.3 (G-03)
+-- Queue item: G-03 batch 8
+-- Why: seeds 15 editorial articles covering the oil-and-gas
+--      investment vertical to support organic search traffic.
+-- Idempotency: ON CONFLICT (slug) DO NOTHING. Safe to re-apply.
+-- Rollback:
+--   DELETE FROM public.articles WHERE category = 'oil-gas'
+--     AND created_at::date = '2026-04-30';
+--   Note: INSERT-only migration; no DDL to reverse.
 -- Idempotent: ON CONFLICT (slug) DO NOTHING — if an article
 -- already exists with the same slug, the insert is a no-op.
 -- To refresh content, update by slug manually.

--- a/supabase/migrations/20260501_uranium_expansion.sql
+++ b/supabase/migrations/20260501_uranium_expansion.sql
@@ -1,6 +1,18 @@
 -- ============================================================
 -- Uranium vertical expansion — new vertical row + 12 listings.
 --
+-- Date: 2026-05-01
+-- Audit ref: codebase-health-2026-04-24.md §4.3 (G-03)
+-- Queue item: G-03 batch 8
+-- Why: seeds the uranium investment vertical row and 12 listings
+--      to power the /uranium programmatic SEO hub.
+-- Idempotency: INSERT … ON CONFLICT (slug) DO NOTHING/DO UPDATE.
+--              Safe to re-apply.
+-- Rollback:
+--   DELETE FROM public.investment_listings WHERE source = 'uranium-expansion';
+--   DELETE FROM public.investment_verticals WHERE slug = 'uranium';
+--   Note: INSERT-only migration; no DDL to reverse.
+--
 -- Unlike the oil-gas expansion this migration does NOT change the
 -- professionals.type CHECK constraint: uranium investment is well
 -- served by existing types (resources_fund_manager, mining_lawyer,

--- a/supabase/migrations/20260502_uranium_articles.sql
+++ b/supabase/migrations/20260502_uranium_articles.sql
@@ -1,5 +1,16 @@
 -- ============================================================
 -- Seed 15 uranium editorial articles.
+--
+-- Date: 2026-05-02
+-- Audit ref: codebase-health-2026-04-24.md §4.3 (G-03)
+-- Queue item: G-03 batch 8
+-- Why: seeds 15 editorial articles covering the uranium vertical
+--      for organic search traffic.
+-- Idempotency: ON CONFLICT (slug) DO NOTHING. Safe to re-apply.
+-- Rollback:
+--   DELETE FROM public.articles WHERE category = 'uranium'
+--     AND created_at::date = '2026-05-02';
+--   Note: INSERT-only migration; no DDL to reverse.
 -- Idempotent: ON CONFLICT (slug) DO NOTHING.
 -- ============================================================
 

--- a/supabase/migrations/20260504_hydrogen_expansion.sql
+++ b/supabase/migrations/20260504_hydrogen_expansion.sql
@@ -2,6 +2,23 @@
 -- Hydrogen vertical expansion — commodity_sectors row, investment_verticals
 -- row, and 10 ASX hydrogen listings.
 --
+-- Date: 2026-05-04
+-- Audit ref: codebase-health-2026-04-24.md §4.3 (G-03)
+-- Queue item: G-03 batch 8
+-- Why: seeds the hydrogen investment vertical with a commodity_sectors
+--      entry, vertical row, 10 ASX hydrogen listings, commodity stocks,
+--      and commodity ETFs.
+-- Idempotency: ON CONFLICT (slug) DO UPDATE/DO NOTHING. Safe to re-apply.
+-- Rollback:
+--   DELETE FROM public.commodity_etfs WHERE sector_id = (
+--     SELECT id FROM public.commodity_sectors WHERE slug = 'hydrogen');
+--   DELETE FROM public.commodity_stocks WHERE sector_id = (
+--     SELECT id FROM public.commodity_sectors WHERE slug = 'hydrogen');
+--   DELETE FROM public.investment_listings WHERE source = 'hydrogen-expansion';
+--   DELETE FROM public.investment_verticals WHERE slug = 'hydrogen';
+--   DELETE FROM public.commodity_sectors WHERE slug = 'hydrogen';
+--   Note: INSERT-only migration; no DDL to reverse.
+--
 -- No new advisor types — hydrogen is covered by existing
 -- resources_fund_manager, energy_financial_planner, and
 -- foreign_investment_lawyer types.

--- a/supabase/migrations/20260505_hydrogen_articles.sql
+++ b/supabase/migrations/20260505_hydrogen_articles.sql
@@ -1,5 +1,16 @@
 -- ============================================================
 -- Seed 12 hydrogen editorial articles.
+--
+-- Date: 2026-05-05
+-- Audit ref: codebase-health-2026-04-24.md §4.3 (G-03)
+-- Queue item: G-03 batch 8
+-- Why: seeds 12 editorial articles covering the hydrogen vertical
+--      for organic search traffic.
+-- Idempotency: ON CONFLICT (slug) DO NOTHING. Safe to re-apply.
+-- Rollback:
+--   DELETE FROM public.articles WHERE category = 'hydrogen'
+--     AND created_at::date = '2026-05-05';
+--   Note: INSERT-only migration; no DDL to reverse.
 -- Idempotent: ON CONFLICT (slug) DO NOTHING.
 -- ============================================================
 

--- a/supabase/migrations/20260506_revenue_expansion.sql
+++ b/supabase/migrations/20260506_revenue_expansion.sql
@@ -1,6 +1,29 @@
 -- ============================================================
 -- Revenue expansion — phase 1 DB migration
 --
+-- Date: 2026-05-06
+-- Audit ref: codebase-health-2026-04-24.md §4.3 (G-03)
+-- Queue item: G-03 batch 8
+-- Why: adds 4 advisor types, 4 new tables (fund_listings,
+--      developer_leads, newsletter_sponsors, sector_reports),
+--      and seeds 8 fund_listings + 3 sector_reports rows.
+-- Idempotency: CREATE TABLE/INDEX IF NOT EXISTS;
+--              INSERT … ON CONFLICT (slug) DO NOTHING;
+--              CHECK-constraint DROP IF EXISTS + ADD. Safe to re-apply.
+-- Rollback (in reverse creation order):
+--   DELETE FROM public.sector_reports WHERE source = 'revenue-expansion-2026-05-06';
+--   DELETE FROM public.fund_listings WHERE source = 'revenue-expansion-2026-05-06';
+--   DROP TABLE IF EXISTS public.sector_reports;
+--   DROP TABLE IF EXISTS public.newsletter_sponsors;
+--   DROP TABLE IF EXISTS public.developer_leads;
+--   DROP TABLE IF EXISTS public.fund_listings;
+--   ALTER TABLE public.professionals
+--     DROP COLUMN IF EXISTS fund_manager_type,
+--     DROP COLUMN IF EXISTS fund_aum_millions;
+--   Note: CHECK constraint swap on professionals.type is reversible
+--         by removing the 4 added enum values, but only if no live
+--         professional rows use those types.
+--
 -- 1A. Add 4 new advisor types to professionals.type CHECK.
 -- 1B. fund_listings table (structured fund directory).
 -- 1C. developer_leads table (fund / listing / report lead capture).

--- a/supabase/migrations/20260507_slug_normalisation.sql
+++ b/supabase/migrations/20260507_slug_normalisation.sql
@@ -2,6 +2,26 @@
 -- Slug normalisation — align investment_listings.vertical with
 -- the route slugs used across /invest/[vertical].
 --
+-- Date: 2026-05-07
+-- Audit ref: codebase-health-2026-04-24.md §4.3 (G-03)
+-- Queue item: G-03 batch 8
+-- Why: normalises investment_listings.vertical from mixed
+--      underscore/hyphen/singular-plural values to the canonical
+--      route slugs in lib/listing-verticals.ts. Without this,
+--      vertical listing pages show zero results.
+-- Idempotency: UPDATEs are WHERE-filtered; re-applying converges
+--              to the same state. Creates a temp _slug_fix_log table
+--              as an audit trail (DROP IF EXISTS before re-apply).
+-- Rollback:
+--   UPDATE public.investment_listings SET vertical = 'commercial_property'
+--     WHERE vertical = 'commercial-property';
+--   UPDATE public.investment_listings SET vertical = 'fund'
+--     WHERE vertical = 'funds';
+--   -- (see file body for the full reverse-mapping list)
+--   DROP TABLE IF EXISTS _slug_fix_log;
+--   Note: this is a data-only migration; the only DDL is the temp
+--         log table which is safe to drop.
+--
 -- Currently the table mixes underscore and hyphen conventions
 -- (e.g. 'commercial_property' vs route 'commercial-property'),
 -- plus singular/plural ('fund' vs route 'funds'). This mismatch

--- a/supabase/migrations/20260509_sponsored_columns_and_freshness_log.sql
+++ b/supabase/migrations/20260509_sponsored_columns_and_freshness_log.sql
@@ -5,6 +5,23 @@
 --     columns, which stay in place for backwards compatibility).
 --   * Create content_freshness_log for audit-trail separate from
 --     the content_calendar queue.
+--
+-- Date: 2026-05-09
+-- Audit ref: codebase-health-2026-04-24.md §4.3 (G-03)
+-- Queue item: G-03 batch 8
+-- Why: adds three brokers columns needed by the sponsored-placement
+--      codebase path (lib/sponsorship.ts reads sponsored/sponsored_tier/
+--      sponsored_until) and creates content_freshness_log for the
+--      editorial freshness audit trail.
+-- Idempotency: ADD COLUMN IF NOT EXISTS;
+--              CREATE TABLE/INDEX IF NOT EXISTS. Safe to re-apply.
+-- Rollback:
+--   DROP TABLE IF EXISTS public.content_freshness_log;
+--   DROP INDEX IF EXISTS public.idx_brokers_sponsored;
+--   ALTER TABLE public.brokers
+--     DROP COLUMN IF EXISTS sponsored_until,
+--     DROP COLUMN IF EXISTS sponsored_tier,
+--     DROP COLUMN IF EXISTS sponsored;
 -- ============================================================
 
 -- ────────────────────────────────────────────────────────────

--- a/supabase/migrations/20260510_rls_hardening.sql
+++ b/supabase/migrations/20260510_rls_hardening.sql
@@ -1,6 +1,24 @@
 -- ============================================================
 -- RLS hardening — pre-launch security pass
 --
+-- Date: 2026-05-10
+-- Audit ref: codebase-health-2026-04-24.md §4.3 (G-03)
+-- Queue item: G-03 batch 8
+-- Why: (1) critical fix — quiz_leads was readable by anon via a
+--      mis-scoped SELECT policy; replaced with service-role-only.
+--      (2) public-read policies added to commodity_stocks/etfs/sectors,
+--      listing_claims, anonymous_saves, user_quiz_history, and
+--      agreement_acceptances — tables that had RLS enabled but
+--      zero policies (effectively deny-all, breaking live reads).
+-- Idempotency: DROP POLICY IF EXISTS + CREATE POLICY.
+--              ENABLE ROW LEVEL SECURITY if not already enabled.
+--              Safe to re-apply.
+-- Rollback:
+--   Restore the original policies by name if reverting is needed.
+--   The critical fix (quiz_leads) should NOT be reverted — it
+--   closes an active data-leak. For a full rollback list, see the
+--   DROP POLICY statements in this file (each names the prior policy).
+--
 -- 1. CRITICAL FIX: the "Allow service read on quiz_leads" policy
 --    was mis-scoped to {public} SELECT with qual=true. That
 --    exposed every quiz lead's email + answers to anon via

--- a/supabase/migrations/20260511_professionals_normalisation.sql
+++ b/supabase/migrations/20260511_professionals_normalisation.sql
@@ -1,6 +1,23 @@
 -- ============================================================
 -- Professionals data normalisation — pre-launch hygiene.
 --
+-- Date: 2026-05-11
+-- Audit ref: codebase-health-2026-04-24.md §4.3 (G-03)
+-- Queue item: G-03 batch 8
+-- Why: normalises professionals table data before launch:
+--      strips "AFSL " prefix + space from ABNs, labels legacy
+--      verified rows, revokes verified=true on empty profiles,
+--      and enables booking_enabled where booking_link is set.
+-- Idempotency: all UPDATEs are WHERE-filtered; re-applying
+--              is safe (WHERE conditions become false once applied).
+-- Rollback:
+--   UPDATE public.professionals SET afsl_number = 'AFSL ' || afsl_number
+--     WHERE afsl_number !~ 'AFSL ' AND afsl_number IS NOT NULL;
+--   Note: data normalisation UPDATEs are hard to reverse precisely
+--         because the WHERE conditions rely on pre-migration state.
+--         Take a snapshot of the professionals table before applying
+--         this migration if rollback may be needed.
+--
 -- 1. Strip "AFSL " prefix from afsl_number.
 -- 2. Strip spaces from abn.
 -- 3. Label legacy verified rows with verification_method='seeded_data'.


### PR DESCRIPTION
## Summary

Final G-03 batch — adds explicit `-- Rollback:` comment blocks to the last 15 migration files that were missing them. Every migration in `supabase/migrations/` (208 total) now carries a rollback header. **Stream G-03 complete.**

### Files covered

| File | Type | Rollback complexity |
|------|------|---------------------|
| `20260414_wave_3_trust_compliance.sql` | DDL (3 tables + cols) | DROP TABLE + ALTER DROP COLUMN |
| `20260414_wave_4_revenue_loop.sql` | DDL (3 tables + 7 cols) | DROP TABLE + ALTER DROP COLUMN |
| `20260414_wave_5_perf_indexes.sql` | Index-only | DROP INDEX list |
| `20260426_wave_launch_readiness.sql` | DDL (6 tables) + seed | DROP TABLE + DELETE seed rows |
| `20260429_oil_gas_expansion.sql` | Data + ALTER | DELETE rows + DROP COLUMN |
| `20260430_oil_gas_articles.sql` | Data only | DELETE articles |
| `20260501_uranium_expansion.sql` | Data only | DELETE rows |
| `20260502_uranium_articles.sql` | Data only | DELETE articles |
| `20260504_hydrogen_expansion.sql` | Data only | DELETE rows (4 tables) |
| `20260505_hydrogen_articles.sql` | Data only | DELETE articles |
| `20260506_revenue_expansion.sql` | DDL (4 tables) + seed | DROP TABLE + DELETE seeds |
| `20260507_slug_normalisation.sql` | Data UPDATE | Reverse UPDATE mapping |
| `20260509_sponsored_columns_and_freshness_log.sql` | DDL (1 table + cols) | DROP TABLE + ALTER DROP COLUMN |
| `20260510_rls_hardening.sql` | RLS policies | Named DROP POLICY list |
| `20260511_professionals_normalisation.sql` | Data UPDATE | Snapshot advisory |

### Why these were missing

- The three `20260414_wave_*` files fell in the gap between batch 6 (ending at `20260413_seed_stockbroker_firms.sql`) and batch 7 (starting at `20260415_*`) — a date-sort gap where `20260414` files were skipped.
- `20260426_wave_launch_readiness.sql` had RLS coverage from batch 8 but the rollback header was missed.
- Files `20260429`–`20260511` postdate the original G-03 scope; batch 8 picks them all up.

### What changed

Comment-only additions — zero SQL logic modified. Safe to merge immediately; no deploy risk.

## Test plan

- [ ] CI: Lint + Type-check + Test + Build (no TS files changed; vacuously passes)
- [ ] `npm run audit:rls-migrations` — no new migrations added, gate unaffected
- [ ] Confirm `git grep -L "rollback" supabase/migrations/*.sql` returns empty after merge

Audit: `docs/audits/codebase-health-2026-04-24.md` §4.3 (G-03)
Queue: G-03 batch 8 → done · stream G-03 complete (208/208 migrations covered)
Refs: #467 (batch 7 predecessor)

https://claude.ai/code/session_015ojq9FKLYB5oKDRYf551cY

---
_Generated by [Claude Code](https://claude.ai/code/session_015ojq9FKLYB5oKDRYf551cY)_