### PR TITLE
fix: unblock main CI — add isFlagEnabled mock (superseded by #523)

### DIFF
--- a/__tests__/api/advisor-enquiry.test.ts
+++ b/__tests__/api/advisor-enquiry.test.ts
@@ -3,6 +3,11 @@ import { makeRequest, createChainableBuilder } from "@/__tests__/helpers";
 
 // ── Mocks ──────────────────────────────────────────────────────────────────────
 
+const mockIsFlagEnabled = vi.fn();
+vi.mock("@/lib/feature-flags", () => ({
+  isFlagEnabled: (...args: unknown[]) => mockIsFlagEnabled(...args),
+}));
+
 const mockFrom = vi.fn();
 
 vi.mock("@/lib/supabase/admin", () => ({
@@ -121,8 +126,17 @@ function enquiryRequest(body: Record<string, unknown>, ip = "5.6.7.8") {
 describe("POST /api/advisor-enquiry", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockIsFlagEnabled.mockResolvedValue(true);
     process.env.RESEND_API_KEY = "re_test_key";
     (isRateLimited as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+  });
+
+  it("returns 503 when advisor_enquiry_intake flag is disabled", async () => {
+    mockIsFlagEnabled.mockResolvedValue(false);
+    const res = await POST(enquiryRequest(VALID_BODY));
+    expect(res.status).toBe(503);
+    const json = await res.json();
+    expect(json.error).toBe("temporarily_unavailable");
   });
 
   it("returns 429 when rate limited", async () => {

--- a/__tests__/api/concierge.test.ts
+++ b/__tests__/api/concierge.test.ts
@@ -3,6 +3,11 @@ import { NextRequest } from "next/server";
 
 // ── Mocks ──────────────────────────────────────────────────────────────────────
 
+const mockIsFlagEnabled = vi.fn();
+vi.mock("@/lib/feature-flags", () => ({
+  isFlagEnabled: (...args: unknown[]) => mockIsFlagEnabled(...args),
+}));
+
 const mockIsAllowed = vi.fn();
 vi.mock("@/lib/rate-limit-db", () => ({
   isAllowed: (...args: unknown[]) => mockIsAllowed(...args),
@@ -121,9 +126,18 @@ function makeSelectChain(result: { data: unknown; error: unknown }) {
 describe("POST /api/concierge", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockIsFlagEnabled.mockResolvedValue(true);
     mockIsAllowed.mockResolvedValue(true);
     process.env.ANTHROPIC_API_KEY = "sk-test";
     mockAdminFrom.mockReturnValue(makeInsert());
+  });
+
+  it("returns 503 when ai_generation flag is disabled", async () => {
+    mockIsFlagEnabled.mockResolvedValue(false);
+    const res = await POST(makePost({ message: "hello" }));
+    expect(res.status).toBe(503);
+    const json = await res.json();
+    expect(json.error).toBe("temporarily_unavailable");
   });
 
   it("returns 429 when rate limited", async () => {

--- a/__tests__/api/cron-abandoned-shortlist-drip.test.ts
+++ b/__tests__/api/cron-abandoned-shortlist-drip.test.ts
@@ -3,6 +3,11 @@ import type { NextRequest } from "next/server";
 
 // ─── Mocks ───────────────────────────────────────────────────────────────────
 
+const mockIsFlagEnabled = vi.fn();
+vi.mock("@/lib/feature-flags", () => ({
+  isFlagEnabled: (...args: unknown[]) => mockIsFlagEnabled(...args),
+}));
+
 vi.mock("@/lib/logger", () => ({
   logger: vi.fn(() => ({
     debug: vi.fn(),
@@ -86,6 +91,7 @@ const ONE_DAY_AGO = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
 describe("GET /api/cron/abandoned-shortlist-drip", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockIsFlagEnabled.mockResolvedValue(true);
     dbIdx = 0;
     dbQueue.length = 0;
     mockIsFeatureDisabled.mockResolvedValue(false);

--- a/__tests__/api/listings-checkout.test.ts
+++ b/__tests__/api/listings-checkout.test.ts
@@ -3,6 +3,11 @@ import { NextRequest } from "next/server";
 
 // ── Mocks ──────────────────────────────────────────────────────────────────────
 
+const mockIsFlagEnabled = vi.fn();
+vi.mock("@/lib/feature-flags", () => ({
+  isFlagEnabled: (...args: unknown[]) => mockIsFlagEnabled(...args),
+}));
+
 vi.mock("@/lib/logger", () => ({
   logger: vi.fn(() => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn() })),
 }));
@@ -65,6 +70,7 @@ const VALID_BODY = {
 describe("POST /api/listings/checkout", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockIsFlagEnabled.mockResolvedValue(true);
     mockAdminFrom
       .mockImplementationOnce(() => makeChain({ data: ACTIVE_PLAN, error: null }))
       .mockImplementationOnce(() => makeChain({ data: ACTIVE_LISTING, error: null }));


### PR DESCRIPTION
## Summary

Fixes 54 silently-failing tests across 4 route test files that were all returning 503 because `isFlagEnabled` was not mocked.

**Root cause:** Routes with launch-ops kill switches (`isFlagEnabled(...)`) return 503 when the flag is disabled. In placeholder-Supabase test environments, `isFlagEnabled` always returns `false`, causing every test that expects 2xx/4xx to receive 503 instead. These test files were written before their respective kill switches were added to the routes.

### Files fixed

| File | Tests fixed | Kill switch flag |
|------|------------|-----------------|
| `__tests__/api/advisor-enquiry.test.ts` | 20 | `advisor_enquiry_intake` |
| `__tests__/api/concierge.test.ts` | 10 | `ai_generation` |
| `__tests__/api/cron-abandoned-shortlist-drip.test.ts` | 10 | `email_drip_send` |
| `__tests__/api/listings-checkout.test.ts` | 14 | `stripe_checkout` |

**Total: 54 tests fixed + 2 new kill-switch tests added** (advisor-enquiry 503, concierge 503).

### Fix pattern

```typescript
const mockIsFlagEnabled = vi.fn();
vi.mock("@/lib/feature-flags", () => ({
  isFlagEnabled: (...args: unknown[]) => mockIsFlagEnabled(...args),
}));

// In beforeEach:
mockIsFlagEnabled.mockResolvedValue(true);
```

Same pattern applied in PR #521 for `listings-enquire` + `listings-submit`.

**Test-only change — no production code modified.**

## Test plan
- [x] All 4 files pass locally (66 tests)
- [x] ESLint clean
- [x] CI "Lint · Type-check · Test · Build" (authoritative gate — unblocks main CI and all open stream PRs)

Refs: #218

---
_Generated by [Claude Code](https://claude.ai/code/session_01NR8QfkMLmgiE83vstSGS5C)_