### PR TITLE
test(r): R-COVERAGE-02 — stripe-webhook registry + upsert-subscription + email builders [audit remediation]

### DIFF
--- a/__tests__/lib/stripe-webhook/email.test.ts
+++ b/__tests__/lib/stripe-webhook/email.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() })),
+}));
+vi.mock("@/lib/html-escape", () => ({
+  escapeHtml: (s: string) => s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;"),
+}));
+vi.mock("@/lib/stripe", () => ({
+  PLANS: {
+    monthly: { label: "$9/month" },
+    yearly: { label: "$89/year" },
+  },
+}));
+
+import {
+  emailWrapper,
+  buildProWelcomeEmail,
+  buildCourseReceiptEmail,
+  buildTrialEndingSoonEmail,
+  buildConsultationConfirmationEmail,
+  sendTransactionalEmail,
+} from "@/lib/stripe-webhook/lib/email";
+
+vi.stubGlobal(
+  "fetch",
+  vi.fn(() => Promise.resolve(new Response("{}", { status: 200 }))),
+);
+
+describe("emailWrapper", () => {
+  it("includes the heading and body content", () => {
+    const html = emailWrapper("Test Heading", "#ff0000", "<p>body</p>");
+    expect(html).toContain("Test Heading");
+    expect(html).toContain("<p>body</p>");
+    expect(html).toContain("#ff0000");
+  });
+
+  it("includes the unsubscribe link", () => {
+    const html = emailWrapper("H", "#000", "");
+    expect(html).toContain("invest.com.au/unsubscribe");
+  });
+});
+
+describe("buildProWelcomeEmail", () => {
+  it("renders yearly plan label for year interval", () => {
+    const html = buildProWelcomeEmail("year");
+    expect(html).toContain("$89/year");
+  });
+
+  it("renders monthly plan label for month interval", () => {
+    const html = buildProWelcomeEmail("month");
+    expect(html).toContain("$9/month");
+  });
+
+  it("renders monthly plan label for null interval", () => {
+    const html = buildProWelcomeEmail(null);
+    expect(html).toContain("$9/month");
+  });
+
+  it("includes account link", () => {
+    const html = buildProWelcomeEmail("month");
+    expect(html).toContain("invest.com.au/account");
+  });
+});
+
+describe("buildCourseReceiptEmail", () => {
+  it("converts amount from cents to dollars", () => {
+    const html = buildCourseReceiptEmail("My Course", "my-course", 4999);
+    expect(html).toContain("49.99");
+  });
+
+  it("includes the course name", () => {
+    const html = buildCourseReceiptEmail("ETF Masterclass", "etf-masterclass", 9900);
+    expect(html).toContain("ETF Masterclass");
+  });
+
+  it("includes the course slug in the CTA link", () => {
+    const html = buildCourseReceiptEmail("Course", "my-slug", 100);
+    expect(html).toContain("courses/my-slug");
+  });
+
+  it("escapes HTML in course name", () => {
+    const html = buildCourseReceiptEmail("<script>xss</script>", "safe-slug", 100);
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
+});
+
+describe("buildTrialEndingSoonEmail", () => {
+  it("renders 'yearly' for year interval", () => {
+    const html = buildTrialEndingSoonEmail("year", "31 May 2026");
+    expect(html).toContain("yearly");
+    expect(html).toContain("31 May 2026");
+  });
+
+  it("renders 'monthly' for non-year intervals", () => {
+    const html = buildTrialEndingSoonEmail("month", "15 Jun 2026");
+    expect(html).toContain("monthly");
+  });
+
+  it("renders 'monthly' for null interval", () => {
+    const html = buildTrialEndingSoonEmail(null, "1 Jul 2026");
+    expect(html).toContain("monthly");
+  });
+});
+
+describe("buildConsultationConfirmationEmail", () => {
+  it("converts amount from cents to dollars", () => {
+    const html = buildConsultationConfirmationEmail("SMSF Consult", "smsf-consult", 19900);
+    expect(html).toContain("199.00");
+  });
+
+  it("includes the consultation title", () => {
+    const html = buildConsultationConfirmationEmail("Tax Review", "tax-review", 9900);
+    expect(html).toContain("Tax Review");
+  });
+
+  it("includes the slug in the CTA link", () => {
+    const html = buildConsultationConfirmationEmail("C", "my-consult-slug", 100);
+    expect(html).toContain("consultations/my-consult-slug");
+  });
+
+  it("escapes HTML in consultation title", () => {
+    const html = buildConsultationConfirmationEmail("<b>bold</b>", "slug", 100);
+    expect(html).not.toContain("<b>bold</b>");
+    expect(html).toContain("&lt;b&gt;bold&lt;/b&gt;");
+  });
+});
+
+describe("sendTransactionalEmail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it("does nothing when RESEND_API_KEY is not set", async () => {
+    vi.stubEnv("RESEND_API_KEY", "");
+    await sendTransactionalEmail("a@b.com", "Hi", "<p>body</p>");
+    expect(vi.mocked(fetch)).not.toHaveBeenCalled();
+  });
+
+  it("calls Resend API with correct fields when key is set", async () => {
+    vi.stubEnv("RESEND_API_KEY", "re_test_key");
+    await sendTransactionalEmail("user@example.com", "Subject", "<p>Hi</p>");
+    expect(vi.mocked(fetch)).toHaveBeenCalledOnce();
+    const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://api.resend.com/emails");
+    const body = JSON.parse(init.body as string) as { to: string[]; subject: string };
+    expect(body.to).toContain("user@example.com");
+    expect(body.subject).toBe("Subject");
+  });
+
+  it("does not throw when Resend fetch rejects (fire-and-forget)", async () => {
+    vi.stubEnv("RESEND_API_KEY", "re_test_key");
+    vi.mocked(fetch).mockRejectedValueOnce(new Error("network error"));
+    await expect(
+      sendTransactionalEmail("a@b.com", "s", "<p>h</p>"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("sends with custom from address when provided", async () => {
+    vi.stubEnv("RESEND_API_KEY", "re_test_key");
+    await sendTransactionalEmail("a@b.com", "s", "<p>h</p>", "Custom <custom@example.com>");
+    const [, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string) as { from: string };
+    expect(body.from).toBe("Custom <custom@example.com>");
+  });
+});

--- a/__tests__/lib/stripe-webhook/registry.test.ts
+++ b/__tests__/lib/stripe-webhook/registry.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type Stripe from "stripe";
+import type { WebhookContext, WebhookHandlerResult } from "@/lib/stripe-webhook/types";
+
+import {
+  registerHandler,
+  dispatchEvent,
+  _resetRegistry,
+  _registeredEventTypes,
+} from "@/lib/stripe-webhook/registry";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeEvent(type: string): Stripe.Event {
+  return {
+    id: `evt_${type.replace(/\./g, "_")}`,
+    type,
+    data: { object: {} },
+  } as unknown as Stripe.Event;
+}
+
+function makeCtx(): WebhookContext {
+  return {
+    admin: {} as unknown as WebhookContext["admin"],
+    stripe: {} as unknown as WebhookContext["stripe"],
+    log: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("stripe-webhook registry", () => {
+  beforeEach(() => {
+    _resetRegistry();
+  });
+
+  it("returns handled:false for an unregistered event type", async () => {
+    const result = await dispatchEvent(makeEvent("unrecognised.event"), makeCtx());
+    expect(result).toEqual({ handled: false });
+  });
+
+  it("dispatches to a registered handler and returns its result", async () => {
+    const handler = vi.fn<[Stripe.Event, WebhookContext], Promise<WebhookHandlerResult>>(
+      async () => ({ status: "done" }),
+    );
+    registerHandler("invoice.paid", handler);
+
+    const evt = makeEvent("invoice.paid");
+    const ctx = makeCtx();
+    const result = await dispatchEvent(evt, ctx);
+
+    expect(result).toEqual({ handled: true, result: { status: "done" } });
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler).toHaveBeenCalledWith(evt, ctx);
+  });
+
+  it("wraps a handler that throws into { handled:true, result:{status:'error'} }", async () => {
+    const boom = new Error("boom");
+    registerHandler("payout.failed", async () => {
+      throw boom;
+    });
+
+    const result = await dispatchEvent(makeEvent("payout.failed"), makeCtx());
+    expect(result.handled).toBe(true);
+    if (result.handled) {
+      expect(result.result.status).toBe("error");
+      if (result.result.status === "error") {
+        expect(result.result.error).toBe(boom);
+      }
+    }
+  });
+
+  it("wraps a non-Error throw into an Error instance", async () => {
+    registerHandler("charge.refunded", async () => {
+      throw "string error"; // eslint-disable-line no-throw-literal
+    });
+
+    const result = await dispatchEvent(makeEvent("charge.refunded"), makeCtx());
+    expect(result.handled).toBe(true);
+    if (result.handled && result.result.status === "error") {
+      expect(result.result.error).toBeInstanceOf(Error);
+      expect(result.result.error.message).toBe("string error");
+    }
+  });
+
+  it("re-registering an event type replaces the prior handler (idempotent register)", async () => {
+    const first = vi.fn<[Stripe.Event, WebhookContext], Promise<WebhookHandlerResult>>(
+      async () => ({ status: "partial", reason: "first" }),
+    );
+    const second = vi.fn<[Stripe.Event, WebhookContext], Promise<WebhookHandlerResult>>(
+      async () => ({ status: "done" }),
+    );
+    registerHandler("radar.early_fraud_warning.created", first);
+    registerHandler("radar.early_fraud_warning.created", second);
+
+    await dispatchEvent(makeEvent("radar.early_fraud_warning.created"), makeCtx());
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledOnce();
+  });
+
+  it("_resetRegistry clears all registered handlers", async () => {
+    registerHandler("invoice.paid", async () => ({ status: "done" }));
+    _resetRegistry();
+    const result = await dispatchEvent(makeEvent("invoice.paid"), makeCtx());
+    expect(result).toEqual({ handled: false });
+  });
+
+  it("_registeredEventTypes returns sorted list of registered types", () => {
+    registerHandler("payout.failed", async () => ({ status: "done" }));
+    registerHandler("charge.refunded", async () => ({ status: "done" }));
+    registerHandler("invoice.paid", async () => ({ status: "done" }));
+    expect(_registeredEventTypes()).toEqual([
+      "charge.refunded",
+      "invoice.paid",
+      "payout.failed",
+    ]);
+  });
+
+  it("returns handled:partial from a handler that returns partial status", async () => {
+    registerHandler("charge.dispute.created", async () => ({
+      status: "partial",
+      reason: "email skipped",
+    }));
+
+    const result = await dispatchEvent(makeEvent("charge.dispute.created"), makeCtx());
+    expect(result).toEqual({
+      handled: true,
+      result: { status: "partial", reason: "email skipped" },
+    });
+  });
+});

--- a/__tests__/lib/stripe-webhook/registry.test.ts
+++ b/__tests__/lib/stripe-webhook/registry.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type Stripe from "stripe";
-import type { WebhookContext, WebhookHandlerResult } from "@/lib/stripe-webhook/types";
+import type { WebhookContext, WebhookHandler } from "@/lib/stripe-webhook/types";
 
 import {
   registerHandler,
@@ -40,7 +40,7 @@ describe("stripe-webhook registry", () => {
   });
 
   it("dispatches to a registered handler and returns its result", async () => {
-    const handler = vi.fn<[Stripe.Event, WebhookContext], Promise<WebhookHandlerResult>>(
+    const handler = vi.fn<WebhookHandler>(
       async () => ({ status: "done" }),
     );
     registerHandler("invoice.paid", handler);
@@ -84,10 +84,10 @@ describe("stripe-webhook registry", () => {
   });
 
   it("re-registering an event type replaces the prior handler (idempotent register)", async () => {
-    const first = vi.fn<[Stripe.Event, WebhookContext], Promise<WebhookHandlerResult>>(
+    const first = vi.fn<WebhookHandler>(
       async () => ({ status: "partial", reason: "first" }),
     );
-    const second = vi.fn<[Stripe.Event, WebhookContext], Promise<WebhookHandlerResult>>(
+    const second = vi.fn<WebhookHandler>(
       async () => ({ status: "done" }),
     );
     registerHandler("radar.early_fraud_warning.created", first);

--- a/__tests__/lib/stripe-webhook/upsert-subscription.test.ts
+++ b/__tests__/lib/stripe-webhook/upsert-subscription.test.ts
@@ -132,13 +132,16 @@ describe("upsertSubscription", () => {
   });
 
   it("upserts when the existing updated_at is older than the incoming event time", async () => {
-    const oldTs = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    // existing.updated_at = 2h ago; incoming current_period_start = 30min ago
+    // stripeEventTime = 30min ago > 2h ago → guard does NOT fire → upsert runs
+    const oldTs = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+    const recentStart = Math.floor((Date.now() - 30 * 60 * 1000) / 1000);
     const { client, upsertSpy } = makeAdmin({
       profileData: { id: "user-uuid-4" },
       subscriptionData: { updated_at: oldTs, status: "active" },
     });
     const log = makeLog();
-    await upsertSubscription(makeSub(), client, log);
+    await upsertSubscription(makeSub({ current_period_start: recentStart }), client, log);
     expect(upsertSpy).toHaveBeenCalledOnce();
     expect(log.error).not.toHaveBeenCalled();
   });

--- a/__tests__/lib/stripe-webhook/upsert-subscription.test.ts
+++ b/__tests__/lib/stripe-webhook/upsert-subscription.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/lib/database.types";
+import type { Logger } from "@/lib/logger";
+import type Stripe from "stripe";
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() })),
+}));
+
+import { upsertSubscription } from "@/lib/stripe-webhook/lib/upsert-subscription";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeLog(): Logger {
+  return { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() } as unknown as Logger;
+}
+
+/** Build a minimal Stripe.Subscription for test purposes. */
+function makeSub(overrides: Partial<Stripe.Subscription> = {}): Stripe.Subscription {
+  const now = Math.floor(Date.now() / 1000);
+  return {
+    id: "sub_test_001",
+    customer: "cus_test",
+    status: "active",
+    items: { data: [{ price: { id: "price_monthly", recurring: { interval: "month" } } }] },
+    current_period_start: now - 86400,
+    current_period_end: now + 86400 * 29,
+    cancel_at_period_end: false,
+    canceled_at: null,
+    cancel_at: null,
+    ...overrides,
+  } as unknown as Stripe.Subscription;
+}
+
+/**
+ * Build a chainable Supabase query mock for a sequence of table calls.
+ * Designed to handle: profiles.select().eq().single() and
+ * subscriptions.select().eq().maybeSingle() + subscriptions.upsert()
+ */
+function makeAdmin({
+  profileData,
+  subscriptionData,
+  upsertError = null,
+}: {
+  profileData: { id: string } | null;
+  subscriptionData?: { updated_at: string; status: string } | null;
+  upsertError?: { message: string } | null;
+}): { client: SupabaseClient<Database>; upsertSpy: ReturnType<typeof vi.fn> } {
+  const upsertSpy = vi.fn().mockResolvedValue({ error: upsertError });
+
+  const fromMock = vi.fn((table: string) => {
+    if (table === "profiles") {
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: profileData, error: null }),
+      };
+    }
+    if (table === "subscriptions") {
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        maybeSingle: vi.fn().mockResolvedValue({
+          data: subscriptionData ?? null,
+          error: null,
+        }),
+        upsert: upsertSpy,
+      };
+    }
+    return {};
+  });
+
+  return {
+    client: { from: fromMock } as unknown as SupabaseClient<Database>,
+    upsertSpy,
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("upsertSubscription", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns early without upserting when no profile is found for the customer", async () => {
+    const { client, upsertSpy } = makeAdmin({ profileData: null });
+    const log = makeLog();
+    await upsertSubscription(makeSub(), client, log);
+    expect(upsertSpy).not.toHaveBeenCalled();
+    expect(log.error).toHaveBeenCalledOnce();
+  });
+
+  it("resolves the customer id when customer is an object (not a string)", async () => {
+    const { client, upsertSpy } = makeAdmin({
+      profileData: { id: "user-uuid-1" },
+    });
+    const log = makeLog();
+    const sub = makeSub({ customer: { id: "cus_obj" } as unknown as Stripe.Customer });
+    await upsertSubscription(sub, client, log);
+    expect(upsertSpy).toHaveBeenCalledOnce();
+  });
+
+  it("skips the upsert when the existing updated_at is newer than the incoming event time", async () => {
+    const futureTs = new Date(Date.now() + 10 * 60 * 1000).toISOString();
+    const { client, upsertSpy } = makeAdmin({
+      profileData: { id: "user-uuid-2" },
+      subscriptionData: { updated_at: futureTs, status: "active" },
+    });
+    const log = makeLog();
+
+    const sub = makeSub({
+      current_period_start: Math.floor((Date.now() - 5 * 60 * 1000) / 1000),
+      cancel_at: null,
+    });
+
+    await upsertSubscription(sub, client, log);
+    expect(upsertSpy).not.toHaveBeenCalled();
+    expect(log.info).toHaveBeenCalledOnce();
+  });
+
+  it("upserts when no existing subscription row exists (first time)", async () => {
+    const { client, upsertSpy } = makeAdmin({
+      profileData: { id: "user-uuid-3" },
+      subscriptionData: null,
+    });
+    const log = makeLog();
+    await upsertSubscription(makeSub(), client, log);
+    expect(upsertSpy).toHaveBeenCalledOnce();
+    expect(log.error).not.toHaveBeenCalled();
+  });
+
+  it("upserts when the existing updated_at is older than the incoming event time", async () => {
+    const oldTs = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    const { client, upsertSpy } = makeAdmin({
+      profileData: { id: "user-uuid-4" },
+      subscriptionData: { updated_at: oldTs, status: "active" },
+    });
+    const log = makeLog();
+    await upsertSubscription(makeSub(), client, log);
+    expect(upsertSpy).toHaveBeenCalledOnce();
+    expect(log.error).not.toHaveBeenCalled();
+  });
+
+  it("logs an error when the upsert returns an error", async () => {
+    const { client } = makeAdmin({
+      profileData: { id: "user-uuid-5" },
+      upsertError: { message: "DB constraint violation" },
+    });
+    const log = makeLog();
+    await upsertSubscription(makeSub(), client, log);
+    expect(log.error).toHaveBeenCalledOnce();
+  });
+
+  it("upserts with the correct onConflict column (stripe_subscription_id)", async () => {
+    const { client, upsertSpy } = makeAdmin({
+      profileData: { id: "user-uuid-6" },
+    });
+    const log = makeLog();
+    await upsertSubscription(makeSub({ id: "sub_unique_001" }), client, log);
+    const [, opts] = upsertSpy.mock.calls[0] as [unknown, { onConflict: string }];
+    expect(opts.onConflict).toBe("stripe_subscription_id");
+  });
+
+  it("sets canceled_at to null when canceled_at is absent", async () => {
+    const { client, upsertSpy } = makeAdmin({
+      profileData: { id: "user-uuid-7" },
+    });
+    const log = makeLog();
+    await upsertSubscription(makeSub({ canceled_at: null }), client, log);
+    const [data] = upsertSpy.mock.calls[0] as [Record<string, unknown>];
+    expect(data.canceled_at).toBeNull();
+  });
+
+  it("sets cancel_at_period_end correctly", async () => {
+    const { client, upsertSpy } = makeAdmin({
+      profileData: { id: "user-uuid-8" },
+    });
+    const log = makeLog();
+    await upsertSubscription(makeSub({ cancel_at_period_end: true }), client, log);
+    const [data] = upsertSpy.mock.calls[0] as [Record<string, unknown>];
+    expect(data.cancel_at_period_end).toBe(true);
+  });
+});


### PR DESCRIPTION
## R-COVERAGE-02 — `lib/stripe-webhook` unit tests

Closes part of #216 (R stream: lib coverage).

### What

Adds tests for three previously-uncovered modules in `lib/stripe-webhook/`:

| Module | Tests added | Key invariants |
|--------|-------------|----------------|
| `registry.ts` | 7 | `dispatchEvent` returns `{handled:false}` for unregistered types; wraps handler throws into `{status:'error'}`; re-registration replaces prior handler (idempotent) |
| `lib/upsert-subscription.ts` | 8 | No-profile early return; **out-of-order drop** (newer `existing.updated_at` skips upsert); `onConflict: "stripe_subscription_id"` |
| `lib/email.ts` | 19 | Builder output: plan labels, amount cents→dollars, XSS escaping via `escapeHtml`; `sendTransactionalEmail` no-op without key, Resend POST shape, fire-and-forget no-throw |

### Why these three

- **registry.ts** is the dispatch backbone — a regression in `handled: false` fall-through would silently swallow Stripe events with no error.
- **upsert-subscription.ts** contains the out-of-order protection guard that prevents late-arriving events from reverting subscriptions to stale states. No prior test exercised that guard.
- **email.ts** builders are pure HTML functions; the XSS escaping path was untested.

### Files changed

- `__tests__/lib/stripe-webhook/registry.test.ts` — new (131 LOC)
- `__tests__/lib/stripe-webhook/upsert-subscription.test.ts` — new (185 LOC)
- `__tests__/lib/stripe-webhook/email.test.ts` — new (168 LOC)

### Checklist

- [x] R-COVERAGE-02: stripe-webhook registry + upsert-subscription + email builder tests

Refs: #216
Audit: docs/audits/codebase-health-2026-04-24.md §R
Queue: docs/audits/REMEDIATION_QUEUE.md R-COVERAGE-02

---
_Generated by [Claude Code](https://claude.ai/code/session_012UB7qb1PWdB2G8xaMGzSoe)_