### PR TITLE
feat(w): W-03 — extract HubServiceGrid server component + 16 tests [audit remediation]

### DIFF
--- a/__tests__/components/HubServiceGrid.test.tsx
+++ b/__tests__/components/HubServiceGrid.test.tsx
@@ -1,0 +1,185 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, within } from "./setup";
+import HubServiceGrid from "@/components/HubServiceGrid";
+import type { HubServiceItem } from "@/components/HubServiceGrid";
+
+const baseItems: HubServiceItem[] = [
+  {
+    title: "Setup & Administration",
+    icon: "building",
+    description: "SMSF establishment and trust deed.",
+    href: "/advisors/smsf-specialists",
+    cta: "Find SMSF Specialists",
+  },
+  {
+    title: "Annual Auditing",
+    icon: "shield-check",
+    description: "Every SMSF must be audited annually.",
+    href: "/smsf/auditors",
+    cta: "Find SMSF Auditors",
+  },
+];
+
+describe("HubServiceGrid", () => {
+  describe("section structure", () => {
+    it("renders the section with data-testid=hub-service-grid", () => {
+      render(<HubServiceGrid heading="Four services" items={baseItems} />);
+      expect(screen.getByTestId("hub-service-grid")).toBeInTheDocument();
+    });
+
+    it("renders the heading as an h2", () => {
+      render(<HubServiceGrid heading="Four services" items={baseItems} />);
+      const h2 = screen.getByRole("heading", { level: 2 });
+      expect(h2).toHaveTextContent("Four services");
+    });
+
+    it("renders one card per item", () => {
+      render(<HubServiceGrid heading="Services" items={baseItems} />);
+      expect(screen.getAllByTestId("hub-service-grid-item")).toHaveLength(2);
+    });
+
+    it("renders nothing when items is empty (no cards)", () => {
+      render(<HubServiceGrid heading="Services" items={[]} />);
+      expect(screen.queryAllByTestId("hub-service-grid-item")).toHaveLength(0);
+    });
+  });
+
+  describe("card content", () => {
+    it("renders each item title as an h3", () => {
+      render(<HubServiceGrid heading="Services" items={baseItems} />);
+      const headings = screen.getAllByRole("heading", { level: 3 });
+      const titles = headings.map((h) => h.textContent);
+      expect(titles).toContain("Setup & Administration");
+      expect(titles).toContain("Annual Auditing");
+    });
+
+    it("renders each item description", () => {
+      render(<HubServiceGrid heading="Services" items={baseItems} />);
+      expect(screen.getByText("SMSF establishment and trust deed.")).toBeInTheDocument();
+      expect(screen.getByText("Every SMSF must be audited annually.")).toBeInTheDocument();
+    });
+
+    it("renders each item CTA text", () => {
+      render(<HubServiceGrid heading="Services" items={baseItems} />);
+      expect(screen.getByText("Find SMSF Specialists")).toBeInTheDocument();
+      expect(screen.getByText("Find SMSF Auditors")).toBeInTheDocument();
+    });
+
+    it("links each card to the configured href", () => {
+      render(<HubServiceGrid heading="Services" items={baseItems} />);
+      const cards = screen.getAllByTestId("hub-service-grid-item");
+      expect(cards[0]).toHaveAttribute("href", "/advisors/smsf-specialists");
+      expect(cards[1]).toHaveAttribute("href", "/smsf/auditors");
+    });
+
+    it("each card is a link element", () => {
+      render(<HubServiceGrid heading="Services" items={baseItems} />);
+      const cards = screen.getAllByTestId("hub-service-grid-item");
+      for (const card of cards) {
+        expect(card.tagName.toLowerCase()).toBe("a");
+      }
+    });
+  });
+
+  describe("grid columns", () => {
+    it("defaults to 2-column grid (md:grid-cols-2)", () => {
+      render(<HubServiceGrid heading="Services" items={baseItems} />);
+      const grid = screen.getByTestId("hub-service-grid").querySelector(".grid");
+      expect(grid?.className).toContain("md:grid-cols-2");
+      expect(grid?.className).not.toContain("lg:grid-cols-3");
+    });
+
+    it("renders 3-column grid when columns=3 is set", () => {
+      render(<HubServiceGrid heading="Services" items={baseItems} columns={3} />);
+      const grid = screen.getByTestId("hub-service-grid").querySelector(".grid");
+      expect(grid?.className).toContain("lg:grid-cols-3");
+    });
+
+    it("2-col grid does not include lg:grid-cols-3", () => {
+      render(<HubServiceGrid heading="Services" items={baseItems} columns={2} />);
+      const grid = screen.getByTestId("hub-service-grid").querySelector(".grid");
+      expect(grid?.className).not.toContain("lg:grid-cols-3");
+    });
+  });
+
+  describe("card isolation", () => {
+    it("each card contains its own title, description, and cta", () => {
+      render(<HubServiceGrid heading="Services" items={baseItems} />);
+      const cards = screen.getAllByTestId("hub-service-grid-item");
+      const firstCard = cards[0]!;
+      expect(within(firstCard).getByRole("heading", { level: 3 })).toHaveTextContent(
+        "Setup & Administration",
+      );
+      expect(
+        within(firstCard).getByText("SMSF establishment and trust deed."),
+      ).toBeInTheDocument();
+      expect(within(firstCard).getByText("Find SMSF Specialists")).toBeInTheDocument();
+    });
+  });
+
+  describe("theming", () => {
+    it("applies the default bg-white section style when no className override", () => {
+      render(<HubServiceGrid heading="Services" items={baseItems} />);
+      const section = screen.getByTestId("hub-service-grid");
+      expect(section.className).toContain("bg-white");
+    });
+
+    it("allows overriding the section className", () => {
+      render(
+        <HubServiceGrid
+          heading="Services"
+          items={baseItems}
+          className="py-16 bg-slate-50"
+        />,
+      );
+      const section = screen.getByTestId("hub-service-grid");
+      expect(section.className).toContain("bg-slate-50");
+      expect(section.className).not.toContain("bg-white");
+    });
+  });
+
+  describe("/smsf page parity", () => {
+    it("renders the smsf four-card shape end-to-end", () => {
+      const smsfItems: HubServiceItem[] = [
+        {
+          title: "Setup & Administration",
+          icon: "building",
+          description:
+            "SMSF establishment, trust deed, ongoing administration, and annual lodgement.",
+          href: "/advisors/smsf-specialists",
+          cta: "Find SMSF Specialists",
+        },
+        {
+          title: "Annual Auditing",
+          icon: "shield-check",
+          description:
+            "Every SMSF must be audited annually by an ASIC-approved auditor.",
+          href: "/smsf/auditors",
+          cta: "Find SMSF Auditors",
+        },
+        {
+          title: "Property in SMSF",
+          icon: "home",
+          description: "LRBA borrowing structures and in-specie transfers.",
+          href: "/advisors/smsf-specialists?focus=property",
+          cta: "Find SMSF Property Experts",
+        },
+        {
+          title: "Investment Strategy",
+          icon: "trending-up",
+          description:
+            "Written investment strategy review and asset allocation.",
+          href: "/advisors/smsf-specialists",
+          cta: "Find Strategy Advisers",
+        },
+      ];
+      render(
+        <HubServiceGrid heading="Four SMSF service categories" items={smsfItems} />,
+      );
+      expect(screen.getAllByTestId("hub-service-grid-item")).toHaveLength(4);
+      expect(screen.getByText("Four SMSF service categories")).toBeInTheDocument();
+      expect(screen.getByText("Find SMSF Auditors")).toBeInTheDocument();
+      expect(screen.getByText("Find SMSF Property Experts")).toBeInTheDocument();
+    });
+  });
+});

--- a/components/HubServiceGrid.tsx
+++ b/components/HubServiceGrid.tsx
@@ -1,0 +1,91 @@
+/**
+ * <HubServiceGrid> — reusable service-card grid for hub pages.
+ *
+ * Extracted from the bespoke `SERVICE_CARDS` section in `app/smsf/page.tsx`
+ * so every hub can render a typed, tested grid without re-implementing the
+ * icon + title + description + CTA card layout.
+ *
+ * Server component; no client JS required.
+ *
+ * W-03 — hub foundation stream (REMEDIATION_QUEUE.md).
+ */
+import Link from "next/link";
+import Icon from "@/components/Icon";
+
+export interface HubServiceItem {
+  /** Card heading, e.g. "Annual Auditing". */
+  title: string;
+  /** Lucide icon name passed to <Icon>, e.g. "shield-check". */
+  icon: string;
+  /** One-paragraph body copy explaining the service/category. */
+  description: string;
+  /** Destination URL for the card Link. */
+  href: string;
+  /** CTA label rendered below the description, e.g. "Find SMSF Auditors". */
+  cta: string;
+}
+
+interface HubServiceGridProps {
+  /** Section heading rendered as an <h2>. */
+  heading: string;
+  /** Array of service card definitions. */
+  items: HubServiceItem[];
+  /**
+   * Number of columns at md+ breakpoint.
+   * 2 (default) matches the /smsf layout; 3 suits wider grids like /grants.
+   */
+  columns?: 2 | 3;
+  /** Optional className applied to the root <section>. */
+  className?: string;
+}
+
+const GRID_CLASS: Record<NonNullable<HubServiceGridProps["columns"]>, string> = {
+  2: "grid grid-cols-1 md:grid-cols-2 gap-4",
+  3: "grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4",
+};
+
+export default function HubServiceGrid({
+  heading,
+  items,
+  columns = 2,
+  className,
+}: HubServiceGridProps) {
+  return (
+    <section
+      className={className ?? "py-12 bg-white"}
+      data-testid="hub-service-grid"
+    >
+      <div className="container-custom max-w-6xl">
+        <h2 className="text-2xl md:text-3xl font-extrabold text-slate-900 mb-6">
+          {heading}
+        </h2>
+        <div className={GRID_CLASS[columns]}>
+          {items.map((item) => (
+            <Link
+              key={item.title}
+              href={item.href}
+              className="group bg-slate-50 hover:bg-slate-100 border border-slate-200 rounded-xl p-6 transition-colors"
+              data-testid="hub-service-grid-item"
+            >
+              <div className="flex items-center gap-3 mb-3">
+                <div className="w-10 h-10 rounded-lg bg-amber-100 flex items-center justify-center shrink-0">
+                  <Icon name={item.icon} size={20} className="text-amber-700" />
+                </div>
+                <h3 className="text-lg font-extrabold text-slate-900 group-hover:text-amber-700">
+                  {item.title}
+                </h3>
+              </div>
+              <p className="text-sm text-slate-600 leading-relaxed mb-3">
+                {item.description}
+              </p>
+              <span className="inline-flex items-center gap-1.5 text-sm font-bold text-amber-600 group-hover:underline">
+                {item.cta}
+                <Icon name="arrow-right" size={14} />
+              </span>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

**W-03 — hub foundation stream.** The icon + title + description + CTA card grid is duplicated across hub pages (`/smsf`, `/grants`, etc.). This extracts it into a typed, tested server component so the W-12 `<HubPage>` HOC can render every hub's service section from config without copy-pasting layout.

### What changed

- `components/HubServiceGrid.tsx` — new server component. Props: `heading` (h2), `items[]{title,icon,description,href,cta}`, `columns` (2|3, default 2), `className` (section override).
- `__tests__/components/HubServiceGrid.test.tsx` — 16 tests across 6 suites: section structure, card content, href correctness, grid column variants, per-card isolation, theming, and /smsf four-card parity shape.

### Why

The service-card grid appears verbatim in `app/smsf/page.tsx` (lines 152–188) and is replicated in other hub pages. Without a shared component every new hub iteration (Z-stream, AA-stream) would copy the layout — this extraction is the velocity multiplier that lets W-12's `<HubPage>` HOC compose from config rows.

## Test plan
- [ ] CI: `Lint · Type-check · Test · Build` green
- [ ] 16 HubServiceGrid tests pass
- [ ] TypeScript strict mode passes on new component + test file

Audit: docs/audits/codebase-health-2026-04-24.md
Queue: W-03 (hub foundation stream)
Refs: #221

---
_Generated by [Claude Code](https://claude.ai/code/session_01NzjSCL9ZBoV8Rbm9HEeUWv)_