### PR TITLE
test(r): R-COVERAGE-03 — quotes/[slug]/accept + reopen route coverage [audit remediation]

### DIFF
--- a/__tests__/api/quotes-slug-accept.test.ts
+++ b/__tests__/api/quotes-slug-accept.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const mockIsRateLimited = vi.fn();
+vi.mock("@/lib/rate-limit", () => ({
+  isRateLimited: (...args: unknown[]) => mockIsRateLimited(...args),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() })),
+}));
+
+const mockAdminFrom = vi.fn();
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+
+const mockSendAcceptedEmail = vi.fn();
+vi.mock("@/lib/quote-emails", () => ({
+  sendAdvisorBidAcceptedEmail: (...args: unknown[]) => mockSendAcceptedEmail(...args),
+}));
+
+import { POST } from "@/app/api/quotes/[slug]/accept/route";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function makeReq(body: unknown, slug = "my-job-abc123", ip = "1.2.3.4"): [NextRequest, { params: Promise<{ slug: string }> }] {
+  const req = new NextRequest(`http://localhost/api/quotes/${slug}/accept`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "x-forwarded-for": ip },
+    body: JSON.stringify(body),
+  });
+  return [req, { params: Promise.resolve({ slug }) }];
+}
+
+const VALID_BODY = {
+  bid_id: 42,
+  contact_email: "owner@example.com",
+};
+
+function makeAuction(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    contact_email: "owner@example.com",
+    contact_name: "Jane Owner",
+    status: "open",
+    slug: "my-job-abc123",
+    ...overrides,
+  };
+}
+
+function makeBid(overrides: Record<string, unknown> = {}) {
+  return { id: 42, advisor_id: 99, bid_amount: 150, auction_id: 1, status: "active", ...overrides };
+}
+
+function makeAdvisor() {
+  return { name: "Bob Advisor", email: "advisor@example.com", type: "financial_planner" };
+}
+
+/** Build a chainable Supabase mock that returns different data per table. */
+function makeAdmin({
+  auction = makeAuction(),
+  bid = makeBid(),
+  advisor = makeAdvisor() as Record<string, unknown> | null,
+  winnerErr = null as { message: string } | null,
+}: {
+  auction?: Record<string, unknown> | null;
+  bid?: Record<string, unknown> | null;
+  advisor?: Record<string, unknown> | null;
+  winnerErr?: { message: string } | null;
+} = {}) {
+  mockAdminFrom.mockImplementation((table: string) => {
+    if (table === "advisor_auctions") {
+      const chain = {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        update: vi.fn().mockReturnThis(),
+        maybeSingle: vi.fn().mockResolvedValue({ data: auction, error: null }),
+        then: undefined as unknown,
+      };
+      // update path: supports .eq() chains and resolves
+      const updateChain = {
+        eq: vi.fn().mockReturnThis(),
+        then: (cb: (v: { error: null }) => void) => { cb({ error: null }); return Promise.resolve({ error: null }); },
+      };
+      chain.update = vi.fn(() => updateChain);
+      return chain;
+    }
+    if (table === "advisor_auction_bids") {
+      const updateWinner = {
+        eq: vi.fn().mockReturnThis(),
+        then: (cb: (v: { error: typeof winnerErr }) => void) => { cb({ error: winnerErr }); return Promise.resolve({ error: winnerErr }); },
+      };
+      const updateLost = {
+        eq: vi.fn().mockReturnThis(),
+        neq: vi.fn().mockReturnThis(),
+        then: (cb: (v: { error: null }) => void) => { cb({ error: null }); return Promise.resolve({ error: null }); },
+      };
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        maybeSingle: vi.fn().mockResolvedValue({ data: bid, error: null }),
+        update: vi.fn((data: Record<string, unknown>) =>
+          data.status === "won" ? updateWinner : updateLost
+        ),
+      };
+    }
+    if (table === "professionals") {
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        maybeSingle: vi.fn().mockResolvedValue({ data: advisor, error: null }),
+      };
+    }
+    return {};
+  });
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("POST /api/quotes/[slug]/accept", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsRateLimited.mockResolvedValue(false);
+    mockSendAcceptedEmail.mockResolvedValue(undefined);
+    makeAdmin();
+  });
+
+  // ── Rate limiting ────────────────────────────────────────────────────────────
+
+  it("returns 429 when rate limited", async () => {
+    mockIsRateLimited.mockResolvedValue(true);
+    const [req, ctx] = makeReq(VALID_BODY);
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(429);
+  });
+
+  // ── Input validation ─────────────────────────────────────────────────────────
+
+  it("returns 400 for invalid JSON body", async () => {
+    const req = new NextRequest("http://localhost/api/quotes/my-job/accept", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not-json",
+    });
+    const res = await POST(req, { params: Promise.resolve({ slug: "my-job" }) });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when bid_id is missing", async () => {
+    const [req, ctx] = makeReq({ contact_email: "owner@example.com" });
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when contact_email is invalid", async () => {
+    const [req, ctx] = makeReq({ bid_id: 42, contact_email: "not-an-email" });
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(400);
+  });
+
+  // ── Authorization gates ──────────────────────────────────────────────────────
+
+  it("returns 404 when job slug not found", async () => {
+    makeAdmin({ auction: null });
+    const [req, ctx] = makeReq(VALID_BODY);
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when contact_email does not match auction owner", async () => {
+    makeAdmin({ auction: makeAuction({ contact_email: "different@example.com" }) });
+    const [req, ctx] = makeReq(VALID_BODY);
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 when auction is not open", async () => {
+    makeAdmin({ auction: makeAuction({ status: "awarded" }) });
+    const [req, ctx] = makeReq(VALID_BODY);
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toMatch(/no longer open/i);
+  });
+
+  it("returns 404 when bid_id not found in this auction", async () => {
+    makeAdmin({ bid: null });
+    const [req, ctx] = makeReq(VALID_BODY);
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(404);
+    const body = await res.json() as { error: string };
+    expect(body.error).toMatch(/bid not found/i);
+  });
+
+  // ── Happy path ───────────────────────────────────────────────────────────────
+
+  it("returns 200 with winning_bid_id on success", async () => {
+    const [req, ctx] = makeReq(VALID_BODY);
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { success: boolean; winning_bid_id: number };
+    expect(body.success).toBe(true);
+    expect(body.winning_bid_id).toBe(42);
+  });
+
+  it("email is fire-and-forget — does not throw when advisor has no email", async () => {
+    makeAdmin({ advisor: { name: "Bob", email: null, type: "financial_planner" } });
+    const [req, ctx] = makeReq(VALID_BODY);
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(200);
+    expect(mockSendAcceptedEmail).not.toHaveBeenCalled();
+  });
+
+  it("email is fire-and-forget — does not throw when advisor lookup returns null", async () => {
+    makeAdmin({ advisor: null });
+    const [req, ctx] = makeReq(VALID_BODY);
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(200);
+  });
+
+  // ── Error handling ───────────────────────────────────────────────────────────
+
+  it("returns 500 when marking winner fails in DB", async () => {
+    makeAdmin({ winnerErr: { message: "constraint violation" } });
+    const [req, ctx] = makeReq(VALID_BODY);
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(500);
+  });
+
+  it("email verification is case-insensitive", async () => {
+    const [req, ctx] = makeReq({ bid_id: 42, contact_email: "OWNER@EXAMPLE.COM" });
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(200);
+  });
+});

--- a/__tests__/api/quotes-slug-reopen.test.ts
+++ b/__tests__/api/quotes-slug-reopen.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const mockIsRateLimited = vi.fn();
+vi.mock("@/lib/rate-limit", () => ({
+  isRateLimited: (...args: unknown[]) => mockIsRateLimited(...args),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() })),
+}));
+
+const mockAdminFrom = vi.fn();
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+
+import { POST } from "@/app/api/quotes/[slug]/reopen/route";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function makeReq(body: unknown, slug = "my-job-abc123", ip = "1.2.3.4"): [NextRequest, { params: Promise<{ slug: string }> }] {
+  const req = new NextRequest(`http://localhost/api/quotes/${slug}/reopen`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "x-forwarded-for": ip },
+    body: JSON.stringify(body),
+  });
+  return [req, { params: Promise.resolve({ slug }) }];
+}
+
+const VALID_BODY = { contact_email: "owner@example.com" };
+
+function makeAuction(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    slug: "my-job-abc123",
+    status: "expired",
+    contact_email: "owner@example.com",
+    ends_at: new Date(Date.now() - 86400_000).toISOString(),
+    reopened_count: 0,
+    winning_bid_id: null,
+    ...overrides,
+  };
+}
+
+function makeAdmin({
+  auction = makeAuction() as Record<string, unknown> | null,
+  updateErr = null as { message: string } | null,
+} = {}) {
+  mockAdminFrom.mockImplementation((table: string) => {
+    if (table === "advisor_auctions") {
+      const updateChain = {
+        eq: vi.fn().mockReturnThis(),
+        then: (cb: (v: { error: typeof updateErr }) => void) => {
+          cb({ error: updateErr });
+          return Promise.resolve({ error: updateErr });
+        },
+      };
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        maybeSingle: vi.fn().mockResolvedValue({ data: auction, error: null }),
+        update: vi.fn(() => updateChain),
+      };
+    }
+    return {};
+  });
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("POST /api/quotes/[slug]/reopen", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsRateLimited.mockResolvedValue(false);
+    makeAdmin();
+  });
+
+  // ── Rate limiting ────────────────────────────────────────────────────────────
+
+  it("returns 429 when rate limited", async () => {
+    mockIsRateLimited.mockResolvedValue(true);
+    const [req, ctx] = makeReq(VALID_BODY);
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(429);
+  });
+
+  // ── Input validation ─────────────────────────────────────────────────────────
+
+  it("returns 400 for invalid JSON body", async () => {
+    const req = new NextRequest("http://localhost/api/quotes/my-job/reopen", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not-json",
+    });
+    const res = await POST(req, { params: Promise.resolve({ slug: "my-job" }) });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when contact_email is missing", async () => {
+    const [req, ctx] = makeReq({});
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when contact_email is not a valid email", async () => {
+    const [req, ctx] = makeReq({ contact_email: "not-an-email" });
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(400);
+  });
+
+  // ── Authorization gates ──────────────────────────────────────────────────────
+
+  it("returns 404 when job slug not found", async () => {
+    makeAdmin({ auction: null });
+    const [req, ctx] = makeReq(VALID_BODY);
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when contact_email does not match auction owner", async () => {
+    makeAdmin({ auction: makeAuction({ contact_email: "different@example.com" }) });
+    const [req, ctx] = makeReq(VALID_BODY);
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 when job already has an accepted bid", async () => {
+    makeAdmin({ auction: makeAuction({ winning_bid_id: 42 }) });
+    const [req, ctx] = makeReq(VALID_BODY);
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toMatch(/accepted quote/i);
+  });
+
+  it("returns 400 when reopened_count has reached the limit of 2", async () => {
+    makeAdmin({ auction: makeAuction({ reopened_count: 2 }) });
+    const [req, ctx] = makeReq(VALID_BODY);
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toMatch(/re-open limit/i);
+  });
+
+  it("returns 400 when reopened_count exceeds the limit", async () => {
+    makeAdmin({ auction: makeAuction({ reopened_count: 3 }) });
+    const [req, ctx] = makeReq(VALID_BODY);
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(400);
+  });
+
+  // ── Happy path ───────────────────────────────────────────────────────────────
+
+  it("returns 200 with success, ends_at, and incremented reopened_count", async () => {
+    const [req, ctx] = makeReq(VALID_BODY);
+    const before = Date.now();
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { success: boolean; ends_at: string; reopened_count: number };
+    expect(body.success).toBe(true);
+    expect(body.reopened_count).toBe(1);
+    const endsAt = new Date(body.ends_at).getTime();
+    expect(endsAt).toBeGreaterThan(before + 6 * 86400_000);
+    expect(endsAt).toBeLessThan(before + 8 * 86400_000);
+  });
+
+  it("allows reopen when reopened_count is 1 (one slot remaining)", async () => {
+    makeAdmin({ auction: makeAuction({ reopened_count: 1 }) });
+    const [req, ctx] = makeReq(VALID_BODY);
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { reopened_count: number };
+    expect(body.reopened_count).toBe(2);
+  });
+
+  it("email verification is case-insensitive", async () => {
+    const [req, ctx] = makeReq({ contact_email: "OWNER@EXAMPLE.COM" });
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(200);
+  });
+
+  // ── Error handling ───────────────────────────────────────────────────────────
+
+  it("returns 500 when DB update fails", async () => {
+    makeAdmin({ updateErr: { message: "deadlock detected" } });
+    const [req, ctx] = makeReq(VALID_BODY);
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(500);
+  });
+});


### PR DESCRIPTION
## Summary

Adds 26 tests covering two previously untested consumer-facing sub-routes:

- `POST /api/quotes/[slug]/accept` — consumer accepts a bid; irreversible auction state change (13 tests)
- `POST /api/quotes/[slug]/reopen` — consumer extends a closed job by 7 days, capped at 2 re-opens (13 tests)

## What's covered

**Accept route** (`__tests__/api/quotes-slug-accept.test.ts`):
- [ ] 429 rate limit
- [ ] 400 invalid JSON
- [ ] 400 missing `bid_id`
- [ ] 400 invalid email format
- [ ] 404 job not found
- [ ] 403 email mismatch (email-as-key auth)
- [ ] 400 job no longer open
- [ ] 404 bid not found in this auction
- [ ] 500 DB failure on winner marking
- [ ] 200 success — `winning_bid_id` returned
- [ ] Fire-and-forget email: advisor has no email (no send, no throw)
- [ ] Fire-and-forget email: advisor lookup null (no throw)
- [ ] Case-insensitive email verification

**Reopen route** (`__tests__/api/quotes-slug-reopen.test.ts`):
- [ ] 429 rate limit
- [ ] 400 invalid JSON
- [ ] 400 missing `contact_email`
- [ ] 400 invalid email format
- [ ] 404 job not found
- [ ] 403 email mismatch
- [ ] 400 job has accepted bid (`winning_bid_id` set)
- [ ] 400 `reopened_count` exactly at limit (2)
- [ ] 400 `reopened_count` exceeds limit
- [ ] 200 success — `ends_at` ≈ 7 days ahead, `reopened_count` incremented
- [ ] 200 success at last slot (`reopened_count` 1 → 2)
- [ ] Case-insensitive email verification
- [ ] 500 DB update failure

## Mock design

Per-table chainable Supabase mocks using **argument-based update dispatch** (`data.status === "won"` vs `"lost"`) rather than call-count tracking. Each `from()` call creates a fresh mock object, so count-based discrimination breaks when the route calls the same table multiple times; argument dispatch is stable.

## Test plan

- `npm test -- __tests__/api/quotes-slug-accept.test.ts` → 13/13 ✓
- `npm test -- __tests__/api/quotes-slug-reopen.test.ts` → 13/13 ✓
- No production code changed — test-only PR

Refs: #214
Audit: `docs/audits/codebase-health-2026-04-24.md` §Coverage
Queue: R-COVERAGE-03

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eyx1FEywbf6vRV6fFnDuB2)_