### PR TITLE
feat(invest): pre_ipo as first-class listing vertical + s708 disclosure pages

### DIFF
--- a/__tests__/lib/advisor-application-resolver-db.test.ts
+++ b/__tests__/lib/advisor-application-resolver-db.test.ts
@@ -286,9 +286,9 @@ describe("notifyAdminApplicationEscalated", () => {
     });
 
     expect(mockFetch).toHaveBeenCalledOnce();
-    const [url, opts] = mockFetch.mock.calls[0]!;
+    const [url, opts] = mockFetch.mock.calls[0]! as unknown as [string, RequestInit];
     expect(url).toBe("https://api.resend.com/emails");
-    const body = JSON.parse((opts as RequestInit).body as string);
+    const body = JSON.parse(opts.body as string);
     expect(body.to).toBe("admin@invest.com.au");
     expect(body.subject).toContain("John Smith");
     expect(body.subject).toContain("escalated");

--- a/__tests__/lib/listing-url.test.ts
+++ b/__tests__/lib/listing-url.test.ts
@@ -22,6 +22,7 @@ describe("categoryForListing", () => {
     ["franchise", "franchise"],
     ["fund", "funds"],
     ["mining", "mining"],
+    ["pre_ipo", "pre-ipo"],
     ["startup", "startups"],
   ])("maps vertical %s to slug %s", (vertical, slug) => {
     expect(categoryForListing({ vertical, sub_category: undefined })).toBe(slug);

--- a/__tests__/lib/tracking-browser.test.ts
+++ b/__tests__/lib/tracking-browser.test.ts
@@ -81,7 +81,7 @@ describe("trackClick — fetch fallback path", () => {
       abVariant: "b",
     });
 
-    const call = mockFetch.mock.calls[0] as [string, RequestInit];
+    const call = mockFetch.mock.calls[0] as unknown as [string, RequestInit];
     const body = JSON.parse(call[1].body as string);
     expect(body.broker_slug).toBe("stake");
     expect(body.broker_name).toBe("Stake");
@@ -126,7 +126,7 @@ describe("trackEvent", () => {
     trackEvent("page_view", { broker: "stake" }, "/brokers");
 
     expect(mockFetch).toHaveBeenCalledOnce();
-    const call = mockFetch.mock.calls[0] as [string, RequestInit];
+    const call = mockFetch.mock.calls[0] as unknown as [string, RequestInit];
     expect(call[0]).toBe("/api/track-event");
     expect(call[1].method).toBe("POST");
     const body = JSON.parse(call[1].body as string);
@@ -142,7 +142,7 @@ describe("trackEvent", () => {
 
     trackEvent("click");
 
-    const call = mockFetch.mock.calls[0] as [string, RequestInit];
+    const call = mockFetch.mock.calls[0] as unknown as [string, RequestInit];
     const body = JSON.parse(call[1].body as string);
     expect(body.event_data).toEqual({});
   });

--- a/app/api/listings/submit/route.ts
+++ b/app/api/listings/submit/route.ts
@@ -17,6 +17,7 @@ const VALID_VERTICALS = [
   "energy",
   "fund",
   "startup",
+  "pre_ipo",
 ];
 
 interface SubmitBody {
@@ -46,6 +47,7 @@ export async function POST(request: NextRequest) {
 
     let body: Partial<SubmitBody>;
     try {
+      // eslint-disable-next-line invest/no-unvalidated-req-json -- pre-existing manual validation; Zod refactor tracked as follow-up
       body = await request.json();
     } catch {
       return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });

--- a/app/invest/list/ListingSubmitForm.tsx
+++ b/app/invest/list/ListingSubmitForm.tsx
@@ -15,6 +15,7 @@ const VERTICALS = [
   { value: "franchise", label: "Franchise Opportunity", icon: "🏪", desc: "Territory or franchise resale" },
   { value: "fund", label: "Investment Fund", icon: "📈", desc: "Managed fund or investment scheme" },
   { value: "startup", label: "Startup / Venture", icon: "🚀", desc: "Equity crowdfunding or angel raise" },
+  { value: "pre_ipo", label: "Pre-IPO (Wholesale)", icon: "🏛️", desc: "Late-stage private placement — sophisticated investors only (s708)" },
 ];
 
 const STATES = [
@@ -354,6 +355,7 @@ export default function ListingSubmitForm() {
                 form.vertical === "mining" ? "e.g. WA Lithium Tenement — 380ha, Pilbara" :
                 form.vertical === "farmland" ? "e.g. 1,200ha Grazing Property, Dubbo NSW" :
                 form.vertical === "energy" ? "e.g. 28 MW Solar Farm Development — QLD, Approved" :
+                form.vertical === "pre_ipo" ? "e.g. Series D Pre-IPO Round — Australian Fintech, $50M Raise" :
                 "Descriptive title for your listing"
               }
               className="w-full border border-slate-300 rounded-lg px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400 focus:border-transparent"

--- a/app/invest/pre-ipo/listings/[slug]/page.tsx
+++ b/app/invest/pre-ipo/listings/[slug]/page.tsx
@@ -1,0 +1,284 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
+import Icon from "@/components/Icon";
+import ListingImageGallery from "@/components/ListingImageGallery";
+import ListingCard, { type InvestmentListing } from "@/components/ListingCard";
+import ListingEnquiryForm from "@/components/ListingEnquiryForm";
+import ListingsEmptyState from "@/components/ListingsEmptyState";
+import {
+  fetchListingBySlug,
+  fetchRelatedListings,
+} from "@/lib/investment-listings-query";
+import ListingSchemaScripts from "@/components/ListingSchemaScripts";
+
+export const revalidate = 300;
+
+const CATEGORY_SLUG = "pre-ipo";
+const CATEGORY_LABEL = "Pre-IPO";
+const VERTICAL = "pre_ipo" as const;
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+
+  const listing = await fetchListingBySlug(VERTICAL, slug);
+  if (!listing) return { title: `Pre-IPO Investments (${CURRENT_YEAR})` };
+  const km = (listing.key_metrics ?? {}) as Record<string, unknown>;
+  const stage = km.stage as string | undefined;
+  const raising = km.raising_cents as number | undefined;
+  const raisingStr = raising ? ` — Raising $${Math.round(raising / 100).toLocaleString("en-AU")}` : "";
+  const title = `${listing.title}${raisingStr}${stage ? ` (${stage})` : ""} — Australian Pre-IPO (${CURRENT_YEAR})`;
+  return {
+    title,
+    description: listing.description?.slice(0, 160) ?? `Australian pre-IPO opportunity — wholesale investors only.`,
+    alternates: { canonical: `${SITE_URL}/invest/pre-ipo/listings/${slug}` },
+    openGraph: {
+      title,
+      description: listing.description?.slice(0, 160),
+      url: `${SITE_URL}/invest/pre-ipo/listings/${slug}`,
+      images: [{
+        url: `/api/og?title=${encodeURIComponent(listing.title)}&type=invest`,
+        width: 1200,
+        height: 630,
+        alt: listing.title,
+      }],
+    },
+    twitter: { card: "summary_large_image" as const },
+  };
+}
+
+function formatCents(cents: number): string {
+  if (cents >= 1_000_000_00) return `$${(cents / 1_000_000_00).toFixed(1)}M`;
+  if (cents >= 1_000_00) return `$${(cents / 1_000_00).toFixed(0)}K`;
+  return `$${(cents / 100).toLocaleString("en-AU")}`;
+}
+
+export default async function PreIpoOpportunityDetailPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+
+  const listing = await fetchListingBySlug(VERTICAL, slug);
+  if (!listing) {
+    return (
+      <ListingsEmptyState
+        categoryLabel={CATEGORY_LABEL}
+        categorySlug={CATEGORY_SLUG}
+      />
+    );
+  }
+  const l = listing as InvestmentListing;
+
+  const relatedListings = await fetchRelatedListings(VERTICAL, slug, null, 3);
+  const km = (l.key_metrics ?? {}) as Record<string, unknown>;
+  const location = [l.location_city, l.location_state].filter(Boolean).join(", ");
+  const ipoWindow = km.ipo_window as string | undefined;
+  const discount = km.ipo_discount_percent as number | undefined;
+
+  const breadcrumb = breadcrumbJsonLd([
+    { name: "Home", url: `${SITE_URL}/` },
+    { name: "Invest", url: `${SITE_URL}/invest` },
+    { name: "Pre-IPO", url: `${SITE_URL}/invest/pre-ipo` },
+    { name: "Opportunities", url: `${SITE_URL}/invest/pre-ipo/listings` },
+    { name: l.title },
+  ]);
+
+  return (
+    <div>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
+      />
+      <ListingSchemaScripts listing={l} vertical={CATEGORY_SLUG} />
+
+      <section className="bg-red-50 border-b-2 border-red-200 py-4">
+        <div className="container-custom">
+          <div className="flex items-start gap-3 max-w-4xl">
+            <Icon name="shield" size={18} className="text-red-800 shrink-0 mt-0.5" />
+            <p className="text-xs md:text-sm text-red-900 leading-relaxed">
+              <strong>Wholesale investors only (s708):</strong> this listing is a private
+              placement available only to sophisticated and wholesale investors. Retail
+              investors cannot subscribe. General information only — not financial advice.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="bg-white border-b border-slate-100 py-12">
+        <div className="container-custom">
+          <nav className="flex items-center gap-1.5 text-xs text-slate-500 mb-4" aria-label="Breadcrumb">
+            <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <Link href="/invest/pre-ipo/listings" className="hover:text-slate-900 transition-colors">Pre-IPO Opportunities</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <span className="text-slate-900 font-medium truncate max-w-40">{l.title}</span>
+          </nav>
+
+          <div className="flex flex-wrap gap-2 mb-3">
+            <span className="bg-red-600 text-white text-xs font-bold px-2.5 py-0.5 rounded-full">Wholesale Only</span>
+            {l.listing_type === "featured" && (
+              <span className="bg-amber-500 text-slate-900 text-xs font-bold px-2.5 py-0.5 rounded-full">Featured</span>
+            )}
+            {!!km.stage && (
+              <span className="bg-slate-700 text-slate-200 text-xs font-semibold px-2.5 py-0.5 rounded-full capitalize">
+                {String(km.stage)}
+              </span>
+            )}
+            {l.industry && (
+              <span className="bg-red-800 text-red-100 text-xs font-semibold px-2.5 py-0.5 rounded-full capitalize">
+                {l.industry.replace(/_/g, " ")}
+              </span>
+            )}
+          </div>
+
+          <h1 className="text-2xl md:text-3xl font-extrabold mb-2 text-slate-900">{l.title}</h1>
+          {location && (
+            <div className="flex items-center gap-1.5 text-slate-600 text-sm">
+              <Icon name="map-pin" size={14} />
+              {location}
+            </div>
+          )}
+        </div>
+      </section>
+
+      <section className="py-10 bg-slate-50">
+        <div className="container-custom">
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+            <div className="lg:col-span-2 space-y-6">
+              <ListingImageGallery images={l.images} alt={l.title} vertical={l.vertical} listingId={l.id} subCategory={l.sub_category} />
+              <div className="bg-white border border-slate-200 rounded-xl p-6">
+                <div className="flex flex-wrap items-center justify-between gap-4">
+                  <div>
+                    <p className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-1">
+                      {km.raising_cents ? "Round size" : "Investment Required"}
+                    </p>
+                    <p className="text-3xl font-extrabold text-slate-900">
+                      {km.raising_cents
+                        ? formatCents(km.raising_cents as number)
+                        : (l.price_display ?? (l.asking_price_cents ? formatCents(l.asking_price_cents) : "Price on application"))}
+                    </p>
+                  </div>
+                  {!!km.pre_money_valuation_cents && (
+                    <div className="text-right">
+                      <p className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-1">Pre-Money Valuation</p>
+                      <p className="text-xl font-bold text-slate-700">{formatCents(km.pre_money_valuation_cents as number)}</p>
+                    </div>
+                  )}
+                </div>
+                {(discount || ipoWindow) && (
+                  <div className="mt-4 pt-4 border-t border-slate-200 grid grid-cols-2 gap-4">
+                    {discount && (
+                      <div>
+                        <p className="text-xs text-slate-500 uppercase tracking-wide mb-0.5">IPO Discount</p>
+                        <p className="text-lg font-extrabold text-red-700">{discount}%</p>
+                      </div>
+                    )}
+                    {ipoWindow && (
+                      <div>
+                        <p className="text-xs text-slate-500 uppercase tracking-wide mb-0.5">Anticipated IPO Window</p>
+                        <p className="text-lg font-bold text-slate-900">{ipoWindow}</p>
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+
+              {Object.keys(km).length > 0 && (
+                <div className="bg-white border border-slate-200 rounded-xl p-6">
+                  <h2 className="text-base font-bold text-slate-900 mb-4">Deal Details</h2>
+                  <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+                    {Object.entries(km).map(([key, value]) => (
+                      <div key={key} className="bg-slate-50 rounded-lg p-3">
+                        <p className="text-xs text-slate-500 capitalize mb-1">{key.replace(/_/g, " ")}</p>
+                        <p className="text-sm font-bold text-slate-900">
+                          {typeof value === "boolean" ? (value ? "Yes" : "No") :
+                           typeof value === "number" && key.includes("cents") ? formatCents(value) :
+                           String(value)}
+                        </p>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {l.description && (
+                <div className="bg-white border border-slate-200 rounded-xl p-6">
+                  <h2 className="text-base font-bold text-slate-900 mb-3">About This Opportunity</h2>
+                  <div className="prose prose-slate prose-sm max-w-none">
+                    {l.description.split("\n").map((para, i) => (
+                      <p key={i}>{para}</p>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              <div className="bg-red-50 border border-red-200 rounded-xl p-5">
+                <p className="text-xs text-red-800 leading-relaxed">
+                  <strong>Pre-IPO risk warning:</strong> Pre-IPO investments are illiquid
+                  and high-risk. Capital is locked until IPO completion (often longer than
+                  signalled), the IPO can be cancelled, and lockups typically restrict
+                  selling for 6–24 months post-listing. You may lose some or all of your
+                  investment. Subscribers must qualify under s708(8) (sophisticated) or
+                  s708(11) (wholesale) of the Corporations Act 2001 (Cth). This is general
+                  information only — obtain independent legal, tax and financial advice
+                  before subscribing.
+                </p>
+              </div>
+            </div>
+
+            <div className="space-y-5">
+              <div className="bg-white border border-slate-200 rounded-xl p-6 sticky top-20">
+                <h2 className="text-base font-bold text-slate-900 mb-1">Express Interest</h2>
+                <p className="text-xs text-slate-500 mb-4">
+                  Send a confidential enquiry. The issuer will request s708 evidence
+                  (accountant&apos;s certificate or sophisticated-investor declaration)
+                  before sharing the offer document.
+                </p>
+                <ListingEnquiryForm listingId={l.id} listingTitle={l.title} vertical="pre_ipo" />
+              </div>
+              <div className="bg-slate-50 border border-slate-200 rounded-xl p-4 flex gap-6">
+                <div className="text-center">
+                  <p className="text-lg font-bold text-slate-900">{l.views ?? 0}</p>
+                  <p className="text-xs text-slate-500">Views</p>
+                </div>
+                <div className="text-center">
+                  <p className="text-lg font-bold text-slate-900">{l.enquiries ?? 0}</p>
+                  <p className="text-xs text-slate-500">Enquiries</p>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {relatedListings.length > 0 && (
+            <div className="mt-12">
+              <h2 className="text-xl font-extrabold text-slate-900 mb-6">Other Pre-IPO Opportunities</h2>
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                {relatedListings.map((rel) => (
+                  <ListingCard key={rel.id} listing={rel} vertical="pre_ipo" />
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      </section>
+
+      <section className="py-10 bg-white border-t border-slate-100">
+        <div className="container-custom text-center">
+          <Link
+            href="/invest/pre-ipo/listings"
+            className="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-400 text-slate-900 font-bold px-6 py-3 rounded-xl transition-colors"
+          >
+            Browse All Pre-IPO Opportunities
+            <Icon name="arrow-right" size={16} />
+          </Link>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/invest/pre-ipo/listings/page.tsx
+++ b/app/invest/pre-ipo/listings/page.tsx
@@ -1,0 +1,84 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Suspense } from "react";
+import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
+import { getAllInvestCategories } from "@/lib/invest-categories";
+import {
+  fetchListingsByVertical,
+  countListingsByVertical,
+} from "@/lib/investment-listings-query";
+import InvestListingsClient from "@/components/InvestListingsClient";
+import Icon from "@/components/Icon";
+
+export const revalidate = 300;
+
+export async function generateMetadata(): Promise<Metadata> {
+  const count = await countListingsByVertical("pre_ipo");
+  const countLabel = count > 0 ? `${count} ` : "";
+  return {
+    title: `Pre-IPO Investment Opportunities Australia — ${countLabel}Wholesale Deals (${CURRENT_YEAR})`,
+    description:
+      "Browse Australian pre-IPO opportunities — late-stage private placements, secondary share buys and broker-syndicated rounds. Wholesale and sophisticated investors only (s708).",
+    alternates: { canonical: `${SITE_URL}/invest/pre-ipo/listings` },
+    openGraph: {
+      title: `Pre-IPO Investment Opportunities Australia — ${countLabel}Wholesale Deals`,
+      url: `${SITE_URL}/invest/pre-ipo/listings`,
+    },
+  };
+}
+
+export default async function PreIpoOpportunitiesPage() {
+  const listings = await fetchListingsByVertical("pre_ipo");
+  const categoryTabs = getAllInvestCategories().map((c) => ({ slug: c.slug, label: c.label }));
+
+  const breadcrumb = breadcrumbJsonLd([
+    { name: "Home", url: `${SITE_URL}/` },
+    { name: "Invest", url: `${SITE_URL}/invest` },
+    { name: "Pre-IPO", url: `${SITE_URL}/invest/pre-ipo` },
+    { name: "Opportunities" },
+  ]);
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
+      />
+
+      <section className="bg-red-50 border-b-2 border-red-200 py-6">
+        <div className="container-custom">
+          <div className="flex items-start gap-3 max-w-4xl">
+            <div className="w-10 h-10 rounded-lg bg-red-200 flex items-center justify-center shrink-0 mt-0.5">
+              <Icon name="shield" size={20} className="text-red-800" />
+            </div>
+            <div>
+              <p className="text-xs font-extrabold uppercase tracking-wide text-red-800 mb-1">
+                Wholesale &amp; Sophisticated Investors Only
+              </p>
+              <p className="text-sm text-red-900 leading-relaxed">
+                Pre-IPO opportunities are private placements relying on the s708(8)–(11)
+                exemptions of the Corporations Act 2001 (Cth). Retail investors cannot
+                access these deals directly. Information is general only — not financial
+                advice and not an offer to subscribe.{" "}
+                <Link href="/invest/pre-ipo" className="font-bold underline hover:text-red-700">
+                  Read the wholesale-investor requirements
+                </Link>
+                .
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <Suspense fallback={<div className="py-12 text-center text-slate-400">Loading listings...</div>}>
+        <InvestListingsClient
+          listings={listings}
+          categories={categoryTabs}
+          lockedCategory="pre-ipo"
+          pageTitle="Pre-IPO Investment Listings"
+          pageSubtitle="Browse Australian late-stage private deals — convertible notes, preference share rounds, secondary share buys and broker-syndicated pre-IPO placements. Wholesale and sophisticated investors only."
+        />
+      </Suspense>
+    </>
+  );
+}

--- a/components/InvestListingsClient.tsx
+++ b/components/InvestListingsClient.tsx
@@ -45,6 +45,7 @@ const CATEGORY_COLORS: Record<
   franchise: { bg: "bg-purple-100", text: "text-purple-700", ring: "ring-purple-300" },
   "renewable-energy": { bg: "bg-emerald-100", text: "text-emerald-700", ring: "ring-emerald-300" },
   startups: { bg: "bg-indigo-100", text: "text-indigo-700", ring: "ring-indigo-300" },
+  "pre-ipo": { bg: "bg-red-100", text: "text-red-700", ring: "ring-red-300" },
   alternatives: { bg: "bg-rose-100", text: "text-rose-700", ring: "ring-rose-300" },
   "private-credit": { bg: "bg-teal-100", text: "text-teal-700", ring: "ring-teal-300" },
   infrastructure: { bg: "bg-cyan-100", text: "text-cyan-700", ring: "ring-cyan-300" },

--- a/components/ListingCard.tsx
+++ b/components/ListingCard.tsx
@@ -102,6 +102,13 @@ function getKeyMetric(listing: InvestmentListing): string | null {
       if (raising) return `Raising ${formatCents(raising)}${stage ? ` · ${stage}` : ""}`;
       return null;
     }
+    case "pre_ipo": {
+      const raising = km.raising_cents as number | undefined;
+      const discount = km.ipo_discount_percent as number | undefined;
+      if (raising) return `Raising ${formatCents(raising)}${discount ? ` · ${discount}% IPO discount` : ""}`;
+      if (discount) return `${discount}% IPO discount`;
+      return null;
+    }
     case "alternatives": {
       const subCat = listing.sub_category;
       const estValue = listing.price_display;
@@ -149,6 +156,8 @@ function getDetailPath(vertical: string, slug: string): string {
       return `/invest/funds/${slug}`;
     case "startup":
       return `/invest/startups/listings/${slug}`;
+    case "pre_ipo":
+      return `/invest/pre-ipo/listings/${slug}`;
     case "alternatives":
       return `/invest/alternatives/listings/${slug}`;
     case "private_credit":
@@ -169,6 +178,7 @@ const VERTICAL_GRADIENTS: Record<string, string> = {
   energy: "from-teal-700 to-teal-900",
   fund: "from-indigo-700 to-indigo-900",
   startup: "from-rose-700 to-rose-900",
+  pre_ipo: "from-red-700 to-red-900",
   alternatives: "from-rose-700 to-rose-900",
   private_credit: "from-indigo-700 to-indigo-900",
   infrastructure: "from-cyan-700 to-cyan-900",
@@ -183,6 +193,7 @@ const VERTICAL_ICONS: Record<string, string> = {
   energy: "zap",
   fund: "bar-chart-2",
   startup: "rocket",
+  pre_ipo: "trophy",
   alternatives: "gem",
   private_credit: "credit-card",
   infrastructure: "git-branch",

--- a/lib/invest-categories.ts
+++ b/lib/invest-categories.ts
@@ -1154,7 +1154,7 @@ const categories: InvestCategory[] = [
   {
     slug: "pre-ipo",
     label: "Pre-IPO",
-    dbVerticals: ["startup"],
+    dbVerticals: ["pre_ipo"],
     color: {
       bg: "bg-red-50",
       border: "border-red-200",

--- a/lib/listing-url.ts
+++ b/lib/listing-url.ts
@@ -12,6 +12,7 @@ export const VERTICAL_TO_CATEGORY: Record<InvestListingVertical, string> = {
   franchise: "franchise",
   fund: "funds",
   mining: "mining",
+  pre_ipo: "pre-ipo",
   startup: "startups",
 };
 

--- a/lib/listing-vertical-images.ts
+++ b/lib/listing-vertical-images.ts
@@ -140,6 +140,12 @@ const VERTICAL_IMAGES: Record<string, ReadonlyArray<string>> = {
     "https://images.unsplash.com/photo-1517048676732-d65bc937f952?w=1200&h=675&q=80&auto=format&fit=crop",
     "https://images.unsplash.com/photo-1559136555-9303baea8ebd?w=1200&h=675&q=80&auto=format&fit=crop",
   ],
+  pre_ipo: [
+    "https://images.unsplash.com/photo-1611974789855-9c2a0a7236a3?w=1200&h=675&q=80&auto=format&fit=crop",
+    "https://images.unsplash.com/photo-1454165804606-c3d57bc86b40?w=1200&h=675&q=80&auto=format&fit=crop",
+    "https://images.unsplash.com/photo-1551836022-deb4988cc6c0?w=1200&h=675&q=80&auto=format&fit=crop",
+    "https://images.unsplash.com/photo-1444653614773-995cb1ef9efa?w=1200&h=675&q=80&auto=format&fit=crop",
+  ],
 };
 
 const GENERIC_FALLBACK_POOL: ReadonlyArray<string> = [

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1345,6 +1345,7 @@ export type InvestListingVertical =
   | 'franchise'
   | 'fund'
   | 'mining'
+  | 'pre_ipo'
   | 'startup';
 
 export interface InvestmentListing {


### PR DESCRIPTION
## Summary
- Recovers ~30 min of hand-written feature work that survived a local computer crash on 2026-05-03 ~23:19 UTC.
- Adds \`pre_ipo\` as a first-class \`InvestListingVertical\` and wires it through types, categories, URL mapping, image pool, submit form, ListingCard, and the listings client.
- Adds two new pages with the s708 wholesale-investor compliance disclaimer required by Corporations Act 2001 (Cth) s708(8)–(11):
  - \`/invest/pre-ipo/listings\` — overview with locked-category filter
  - \`/invest/pre-ipo/listings/[slug]\` — detail page with Pre-IPO–specific metadata, key metrics (raising_cents, ipo_discount_percent, stage)
- Fixes a latent bug in \`lib/invest-categories.ts\`: the \`pre-ipo\` category had \`dbVerticals: ["startup"]\`, conflating retail-eligible angel raises with wholesale-restricted late-stage placements. Now points at its own \`["pre_ipo"]\` vertical.

## Drive-by changes
- \`app/api/listings/submit/route.ts\` — added the documented \`// eslint-disable-next-line invest/no-unvalidated-req-json\` escape hatch on the existing manual validation. Pre-existing tech debt, not introduced here. Zod refactor of this route is worth a follow-up PR.
- \`__tests__/lib/tracking-browser.test.ts\` and \`__tests__/lib/advisor-application-resolver-db.test.ts\` — fixed 6 mock.calls tuple-cast TS errors (\`as unknown as [string, RequestInit]\`). These were part of the documented main-branch test-TS drift; without these fixes, non-loop sessions can't pass pre-push without \`--no-verify\`.

## Test plan
- [ ] \`npm run dev\` and visit \`/invest/pre-ipo/listings\` — disclaimer renders, category tab is locked
- [ ] Click through to a sample listing detail page — schema markup, gallery, enquiry form all render
- [ ] Submit a listing via \`/invest/list\` with vertical = \`pre_ipo\` — form accepts, API persists with correct \`vertical\` value
- [ ] \`npm test -- __tests__/lib/listing-url.test.ts\` — pre_ipo→pre-ipo URL mapping covered
- [ ] \`npm run type-check\` — no regressions

## Notes
- Marked draft pending your review; per project workflow drafts need a manual mark-ready nudge.
- Branched off \`origin/main\` (not \`chore/listings-filtered-view-framing\` where the dirty work originally sat) so the diff is scope-pure to pre_ipo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)