### PR TITLE
ops(cost): cut high-freq crons + skip builds on loop branches and docs

### DIFF
--- a/app/api/cron/cron-freshness/route.ts
+++ b/app/api/cron/cron-freshness/route.ts
@@ -18,6 +18,7 @@ export const maxDuration = 60;
  * cron name and compares it to the expected cadence:
  *
  *   hourly → 2h since last success
+ *   every-30m → 90m
  *   every-15m → 45m
  *   daily → 30h
  *   weekly → 8 days
@@ -38,10 +39,12 @@ interface CronExpectation {
 // a one-cycle miss.
 const EXPECTATIONS: CronExpectation[] = [
   // Every-few-minutes
-  { name: "retry-webhooks", maxAgeMs: 45 * 60_000, cadence: "15m" },
-  { name: "job-queue-worker", maxAgeMs: 20 * 60_000, cadence: "5m" },
-  { name: "confirm-lead-notify", maxAgeMs: 30 * 60_000, cadence: "10m" },
-  { name: "slo-monitor", maxAgeMs: 45 * 60_000, cadence: "15m" },
+  { name: "heartbeat", maxAgeMs: 90 * 60_000, cadence: "30m" },
+  { name: "retry-webhooks", maxAgeMs: 90 * 60_000, cadence: "30m" },
+  { name: "job-queue-worker", maxAgeMs: 45 * 60_000, cadence: "15m" },
+  { name: "synthetic-checks", maxAgeMs: 45 * 60_000, cadence: "15m" },
+  { name: "confirm-lead-notify", maxAgeMs: 45 * 60_000, cadence: "15m" },
+  { name: "slo-monitor", maxAgeMs: 2 * 3_600_000, cadence: "hourly" },
   // Hourly
   { name: "auto-resolve-disputes", maxAgeMs: 2 * 3_600_000, cadence: "hourly" },
   { name: "embeddings-refresh", maxAgeMs: 2 * 3_600_000, cadence: "hourly" },

--- a/app/api/cron/synthetic-checks/route.ts
+++ b/app/api/cron/synthetic-checks/route.ts
@@ -13,8 +13,8 @@ export const maxDuration = 60;
  * GET /api/cron/synthetic-checks
  *
  * Synthetic-check probes for the launch window. Per
- * docs/ops/launch-ops-plan.md §5 PR 15. Runs every 5 minutes via the
- * every-5m dispatcher; each probe writes a row to synthetic_check_runs
+ * docs/ops/launch-ops-plan.md §5 PR 15. Runs every 15 minutes via the
+ * every-15m dispatcher; each probe writes a row to synthetic_check_runs
  * (PR 14). When a flow has 2 consecutive failures, sends a single
  * digest email to OPS_ALERT_EMAIL (rate-limited to once per flow per
  * 30 minutes via the table itself — we only re-alert when the

--- a/lib/cron-groups.ts
+++ b/lib/cron-groups.ts
@@ -25,15 +25,14 @@ export const CRON_GROUPS: Record<string, readonly string[]> = {
   "hourly-5": ["/api/cron/broker-snapshot"],
   "hourly-15": ["/api/cron/automation-verdict-rollup", "/api/cron/quote-expiry-reminders"],
   "hourly-20": ["/api/cron/cron-freshness"],
-  "hourly-30": ["/api/cron/embeddings-refresh"],
+  "hourly-30": ["/api/cron/embeddings-refresh", "/api/cron/slo-monitor"],
 
-  "every-5m": [
-    "/api/cron/heartbeat",
+  "every-15m": [
     "/api/cron/job-queue-worker",
     "/api/cron/synthetic-checks",
+    "/api/cron/confirm-lead-notify",
   ],
-  "every-10m": ["/api/cron/confirm-lead-notify"],
-  "every-15m": ["/api/cron/retry-webhooks", "/api/cron/slo-monitor"],
+  "every-30m": ["/api/cron/heartbeat", "/api/cron/retry-webhooks"],
   "every-6h": ["/api/admin/run-migration"],
 
   "daily-0": ["/api/cron/auto-publish"],

--- a/scripts/vercel-skip-build.sh
+++ b/scripts/vercel-skip-build.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Vercel "Ignored Build Step" — exit 0 = SKIP build, exit 1 = BUILD.
+#
+# Wired in via vercel.json's `ignoreCommand`. Three skip rules:
+#
+#   1. Loop-authored branches (claude/audit-remediation/*) — these are
+#      code-only iterations verified by CI; nobody browses preview URLs
+#      for them. Skipping saves ~30-50% of build CPU on a busy loop day.
+#
+#   2. Docs-only commits — only files under docs/, *.md at root, or the
+#      remediation queue/log files. No runtime impact, no need to build.
+#
+#   3. Loop pause sentinel commits (LOOP_PAUSE) — pause/resume commits
+#      touch a single file and don't change behaviour.
+#
+# Anything else falls through and builds normally.
+
+set -e
+
+ref="${VERCEL_GIT_COMMIT_REF:-}"
+sha="${VERCEL_GIT_COMMIT_SHA:-HEAD}"
+
+# Rule 1 — loop branches
+case "$ref" in
+  claude/audit-remediation/*)
+    echo "skip: loop-authored branch ($ref)"
+    exit 0
+    ;;
+esac
+
+# Rule 2/3 — files-changed inspection
+# `git diff --quiet` exits 0 if no diff (i.e. excluded paths cover
+# everything), so we invert: if --quiet returns 0 after excluding
+# docs/markdown/queue files, the commit is docs-only and we skip.
+if git diff --quiet "$sha^" "$sha" -- \
+     ':(exclude)docs/' \
+     ':(exclude)*.md' \
+     ':(exclude)LOOP_PAUSE' \
+     2>/dev/null; then
+  echo "skip: docs-only / pause-sentinel commit"
+  exit 0
+fi
+
+# Otherwise: build
+echo "build: changes outside skip patterns"
+exit 1

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,8 @@
 {
+  "ignoreCommand": "bash scripts/vercel-skip-build.sh",
   "crons": [
-    { "path": "/api/cron/dispatch/every-5m", "schedule": "*/5 * * * *" },
-    { "path": "/api/cron/dispatch/every-10m", "schedule": "*/10 * * * *" },
     { "path": "/api/cron/dispatch/every-15m", "schedule": "*/15 * * * *" },
+    { "path": "/api/cron/dispatch/every-30m", "schedule": "0,30 * * * *" },
     { "path": "/api/cron/dispatch/every-6h", "schedule": "0 */6 * * *" },
 
     { "path": "/api/cron/dispatch/hourly-0", "schedule": "0 * * * *" },


### PR DESCRIPTION
## Summary

Vercel bill audit (2026-05-04) flagged ~52 days of build CPU consumed in one billing cycle. Two compounding causes:

1. **High-frequency crons** — \`every-5m\` / \`every-10m\` / \`every-15m\` groups firing ~1,200 handler invocations/day.
2. **Loop-driven build pressure** — audit-remediation loop pushing ~32 commits/day to main, each triggering a Vercel production build.

This PR cuts both.

## Changes

### \`vercel.json\`
- Drop \`*/5 * * * *\` schedule entirely
- Drop \`*/10 * * * *\` (handlers folded into \`*/15\`)
- Add \`*/30 * * * *\` for handlers that don't need 15min latency
- Add \`ignoreCommand: bash scripts/vercel-skip-build.sh\`
- Net schedules: 39 → 38 (under Vercel's 40 cap)

### \`lib/cron-groups.ts\` — regrouped
| Old group | Old cadence | New group | New cadence |
|---|---|---|---|
| every-5m: heartbeat | 5m | every-30m | 30m |
| every-5m: job-queue-worker | 5m | every-15m | 15m |
| every-5m: synthetic-checks | 5m | every-15m | 15m |
| every-10m: confirm-lead-notify | 10m | every-15m | 15m |
| every-15m: retry-webhooks | 15m | every-30m | 30m |
| every-15m: slo-monitor | 15m | hourly-30 | 60m |

### \`app/api/cron/cron-freshness/route.ts\`
Staleness tolerances bumped to match new cadences (90m for 30m crons, 45m for 15m crons, 2h for slo-monitor moved to hourly).

### \`scripts/vercel-skip-build.sh\` (new)
Vercel ignored-build-step that skips:
- Loop-authored branches (\`claude/audit-remediation/*\`) — code-only PRs verified by CI, no preview URL needed
- Docs-only commits (docs/, *.md, LOOP_PAUSE)

## Tradeoffs (decided pre-launch where traffic is low)

- **Lead→advisor SLA**: 15m hold + 15m cron = 30min worst case (was 25min at 10m cadence)
- **SLO breach detection**: 60min worst case (was 15min)
- **Cron-health-alert** thresholds unchanged — already 3h tolerance for any \`every-*\` group

## Verification plan

After merge:
1. Watch first new-cadence cron fire in \`cron_run_log\` (should appear within 30min)
2. Test build-skip: push empty commit to a \`claude/audit-remediation/test\` branch, confirm Vercel logs "skip"
3. Monitor OPS_ALERT_EMAIL for 60min — no false-positive staleness alerts expected

## Loop pause status

Loop is paused via \`LOOP_PAUSE\` on main. Resume after verification:
\`\`\`
git rm LOOP_PAUSE && git commit -m "ops: resume loop after vercel cost-reduction land" && git push
\`\`\`

## Estimated impact

- Daily cron handler invocations: 1,200 → 408 (**~66% reduction**)
- Daily Vercel cost: estimated **60-75% drop**
- Combined with manual loop pause during landing: near-zero builds for ~30 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)