### PR TITLE
feat(gi): Wave 1 — /global-investing hub shell + program spec + queue [GI-stream]

### DIFF
--- a/app/global-investing/page.tsx
+++ b/app/global-investing/page.tsx
@@ -1,0 +1,380 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR, UPDATED_LABEL } from "@/lib/seo";
+import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
+import SectionHeading from "@/components/SectionHeading";
+
+export const revalidate = 86400;
+
+export const metadata: Metadata = {
+  title: `Global Investing for Australians (${CURRENT_YEAR}) — US Shares, ETFs, Property, Tax`,
+  description: `The complete guide for Australian residents investing globally. Compare foreign brokers (IBKR, Stake, Tiger, moomoo), AU-listed foreign exposure (IVV, VGS, IZZ), foreign property, FX providers, and the tax rules that matter (FITO, US estate tax, W-8BEN, CGT on foreign shares). ${UPDATED_LABEL}.`,
+  openGraph: {
+    title: `Global Investing for Australians (${CURRENT_YEAR})`,
+    description: "Two tracks under one hub: direct outbound via foreign brokers, and indirect via AU-listed ETFs and LICs. Plus the tax rules that decide which way is cheaper.",
+    url: `${SITE_URL}/global-investing`,
+    images: [
+      {
+        url: `/api/og?title=${encodeURIComponent("Global Investing for Australians")}&sub=${encodeURIComponent("US Shares · ETFs · Property · FX · Tax · " + CURRENT_YEAR)}`,
+        width: 1200,
+        height: 630,
+      },
+    ],
+  },
+  twitter: { card: "summary_large_image" },
+  alternates: { canonical: `${SITE_URL}/global-investing` },
+};
+
+const HUB_FAQS = [
+  {
+    question: "Can Australian residents invest in overseas markets?",
+    answer:
+      "Yes. Australian residents can invest globally through two main routes. (1) Direct: open a foreign broker account (IBKR, Stake, Tiger AU, moomoo AU, Webull AU, eToro, CommSec International, CMC International, Pearler) and buy stocks listed on NYSE/NASDAQ/LSE/HKEX/TSE/SGX/NZX directly. (2) Indirect: buy AU-listed ETFs and LICs that hold foreign shares — IVV (S&P 500), VGS (developed markets), VAE (Asia), IZZ (China), IEU (Europe), MFF/PMC (global LICs). Track A pays better per conversion to brokers; Track B is the lower-friction path for most Australians.",
+  },
+  {
+    question: "Is it cheaper to buy US shares directly or via ASX-listed ETFs?",
+    answer:
+      "It depends on your holding period, amount, and brokerage. For long-term holders, AU-listed ETFs like IVV (0.04% MER) often win after factoring FX conversion fees, foreign brokerage, custodial fees, and the W-8BEN paperwork. For active traders or specific stock exposure (e.g. you want Tesla, not the S&P 500), direct US shares are necessary. Use our /global-investing/calculators/direct-vs-asx-cost tool to compute total cost for your specific scenario, including FX (typically 0.40–0.70% spread on Stake/CommSec International, 0.002% on IBKR), brokerage, and tax friction.",
+  },
+  {
+    question: "Do I need to fill out a W-8BEN form to buy US shares?",
+    answer:
+      "Yes. The W-8BEN is a US IRS form that confirms you are a non-US resident eligible for reduced US tax rates under the Australia-US Double Tax Agreement. Without it, the IRS withholds 30% of US-source dividends; with it, the rate drops to 15%. Most AU-friendly brokers (Stake, IBKR, CommSec International, Tiger, moomoo) handle the W-8BEN inside their account-opening flow. The form is valid for three years and must be re-signed at expiry.",
+  },
+  {
+    question: "What is US estate tax and does it apply to Australian investors?",
+    answer:
+      "Yes — and most Australian investors don't know about it. The US imposes federal estate tax on US-situs assets held by non-resident aliens, with a low exemption of US$60,000 (compared to the US$13.6M exemption for US residents). If you die holding more than US$60,000 of US shares directly through a foreign broker, your estate may owe up to 40% federal estate tax on the excess. The Australia-US Estate Tax Treaty provides a unified credit that significantly mitigates this, but it's not automatic and requires proper structuring. AU-listed ETFs (like IVV) are NOT US-situs assets and avoid this exposure entirely. See /global-investing/tax/us-estate-tax for the full explainer and exposure calculator.",
+  },
+  {
+    question: "How are gains on foreign shares taxed in Australia?",
+    answer:
+      "Australian residents pay capital gains tax (CGT) on worldwide gains, including foreign shares. Cost base is calculated in AUD at the time of acquisition (using the RBA spot rate or your actual exchange rate); disposal value is calculated in AUD at the time of sale. This means FX movements affect your AUD-denominated gain even when the share price is flat. Foreign-source dividend income is also assessable. Where foreign tax has been paid (e.g. 15% US withholding), you may claim a Foreign Income Tax Offset (FITO) up to the AU tax payable on that income. See /global-investing/tax/cgt-on-foreign-shares and /global-investing/tax/fito for worked examples.",
+  },
+  {
+    question: "Which Australian brokers are best for international shares?",
+    answer:
+      "Depends on what you want. Stake offers fee-free US shares (with FX spread); Interactive Brokers (IBKR) has the lowest FX spread (~0.002%) and broadest market access (LSE, HKEX, TSE) but a steeper learning curve; Tiger AU and moomoo AU compete aggressively on signup bonuses; CommSec International is the bank-broker option with established trust; Webull and eToro fit specific niches. The custody model differs — Stake/Tiger/moomoo are custodial (held in nominee), CommSec International offers DRS (Direct Registration). See /global-investing/shares/us for the full broker comparison and /global-investing/guides/chess-vs-custodial-international for the ownership-model explainer.",
+  },
+  {
+    question: "Should I use a hedged or unhedged international ETF?",
+    answer:
+      "Most long-term Australian investors use unhedged. Over decades, currency exposure averages out and hedging costs (~0.06% p.a. on IVV vs IHVV) compound against returns. Unhedged means your AUD value rises when AUD weakens vs the foreign currency, and vice versa — this provides natural diversification against AUD-specific risk. Hedged ETFs (IHVV, HNDQ) make sense for shorter holding periods or when you want pure equity-return exposure without FX overlay. Decide based on horizon, not last quarter's FX move.",
+  },
+  {
+    question: "What FX provider should I use for international transfers?",
+    answer:
+      "For one-off broker funding, Wise typically beats banks by 1.5–2% on AUD/USD. For larger transfers (>AU$50k) OFX and WorldFirst offer better rates with dedicated dealers. For ongoing multi-currency accounts, Wise and Revolut offer card spending in foreign currencies. Bank-to-bank international transfers are usually the worst option (1.5–3% spread plus fixed fees). See /global-investing/currency/best-fx-providers for the full comparison.",
+  },
+];
+
+const SUB_PILLARS = [
+  {
+    href: "/global-investing/shares/us",
+    eyebrow: "Track A — Direct",
+    label: "Buy US shares from Australia",
+    description: "Compare Stake, IBKR, Tiger, moomoo, CommSec International. FX, W-8BEN, custody, total cost.",
+    color: "from-blue-50 to-white",
+  },
+  {
+    href: "/global-investing/etfs",
+    eyebrow: "Track B — AU-listed",
+    label: "AU-listed foreign exposure (ETFs)",
+    description: "IVV, VGS, NDQ, VAE, IZZ, IEU, NDIA. Compare region exposure on the ASX with no foreign account needed.",
+    color: "from-emerald-50 to-white",
+  },
+  {
+    href: "/global-investing/lics",
+    eyebrow: "Track B — AU-listed",
+    label: "Global LICs",
+    description: "MFF, WGB, PMC, FGG. Listed Investment Companies with global mandates trading at NTA premium/discount.",
+    color: "from-emerald-50 to-white",
+  },
+  {
+    href: "/global-investing/property",
+    eyebrow: "Track A — Direct",
+    label: "Foreign property",
+    description: "AU residents buying in NZ, US (FL/TX), Bali, UK, Portugal. Stamp duty, financing, foreign-buyer rules.",
+    color: "from-blue-50 to-white",
+  },
+  {
+    href: "/global-investing/currency",
+    eyebrow: "Track A — Direct",
+    label: "FX & currency accounts",
+    description: "Wise vs OFX vs WorldFirst vs Revolut vs Airwallex. Spreads, fees, and multi-currency accounts compared.",
+    color: "from-blue-50 to-white",
+  },
+  {
+    href: "/global-investing/bonds",
+    eyebrow: "Track A + B",
+    label: "Foreign bonds",
+    description: "US Treasuries direct via IBKR, plus AU-listed global bond ETFs. Yield, currency hedging, tax treatment.",
+    color: "from-violet-50 to-white",
+  },
+  {
+    href: "/global-investing/crypto",
+    eyebrow: "Track A — Direct",
+    label: "Global crypto exchanges",
+    description: "Binance, Kraken, Bybit from Australia vs domestic AUSTRAC-registered exchanges. KYC, tax, on-ramp.",
+    color: "from-violet-50 to-white",
+  },
+  {
+    href: "/global-investing/tax",
+    eyebrow: "The moat",
+    label: "Tax for global investors",
+    description: "FITO, US estate tax, CGT on foreign shares, W-8BEN, DTA tables, QROPS pension transfers.",
+    color: "from-amber-50 to-white",
+  },
+];
+
+const TRACK_A_VS_B = [
+  {
+    when: "You want a specific US stock (Tesla, Nvidia, Apple)",
+    use: "Track A — direct via foreign broker",
+    why: "ASX-listed ETFs only give you the index, not the individual ticker.",
+    cta: { href: "/global-investing/shares/us", label: "Compare US-share brokers" },
+  },
+  {
+    when: "You want broad US/global market exposure for the long term",
+    use: "Track B — AU-listed ETF",
+    why: "IVV (0.04% MER) usually beats VOO direct after FX, brokerage, and W-8BEN/estate-tax friction.",
+    cta: { href: "/global-investing/etfs/us", label: "Compare AU-listed US ETFs" },
+  },
+  {
+    when: "You want emerging-markets, Asia, China, or India exposure",
+    use: "Track B — AU-listed ETF",
+    why: "AU-listed VAE, IZZ, NDIA, IEM avoid the friction of opening accounts on HKEX, NSE, or KRX.",
+    cta: { href: "/global-investing/etfs", label: "Compare regional ETFs" },
+  },
+  {
+    when: "You're a frequent trader",
+    use: "Track A — IBKR specifically",
+    why: "0.002% FX spread vs 0.40–0.70% on retail brokers compounds quickly with high turnover.",
+    cta: { href: "/global-investing/guides/ibkr-australia-setup", label: "IBKR setup walkthrough" },
+  },
+  {
+    when: "You want to avoid US estate tax exposure entirely",
+    use: "Track B — AU-listed ETF",
+    why: "AU-domiciled ETFs are not US-situs assets. Direct US shares >US$60k are.",
+    cta: { href: "/global-investing/tax/us-estate-tax", label: "US estate tax explainer" },
+  },
+];
+
+const HERO_STATS = [
+  { label: "Brokers compared", value: "11+", sub: "Stake, IBKR, Tiger, moomoo, more" },
+  { label: "AU-listed regions", value: "9", sub: "US, EU, UK, JP, CN, IN, EM + global" },
+  { label: "Tax calculators", value: "4", sub: "FITO, US estate, FX impact, total cost" },
+  { label: "Updated", value: "Monthly", sub: "Fees verified each cycle" },
+];
+
+export default function GlobalInvestingHubPage() {
+  const breadcrumb = breadcrumbJsonLd([
+    { name: "Home", url: SITE_URL },
+    { name: "Global Investing" },
+  ]);
+
+  const faqSchema = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: HUB_FAQS.map((f) => ({
+      "@type": "Question",
+      name: f.question,
+      acceptedAnswer: { "@type": "Answer", text: f.answer },
+    })),
+  };
+
+  return (
+    <div className="bg-white min-h-screen">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+
+      {/* ── Hero ─────────────────────────────────────────────────────── */}
+      <section className="relative bg-white border-b border-slate-100 overflow-hidden py-8 md:py-12">
+        <div className="container-custom">
+          <nav className="text-xs text-slate-600 mb-5 flex items-center gap-1.5">
+            <Link href="/" className="hover:text-slate-900">Home</Link>
+            <span className="text-slate-300">/</span>
+            <span className="text-slate-900 font-medium">Global Investing</span>
+          </nav>
+
+          <div className="grid md:grid-cols-2 gap-10 items-start">
+            <div>
+              <div className="inline-flex items-center gap-2 px-3 py-1 bg-slate-100 rounded-full text-xs font-semibold text-slate-600 mb-4">
+                <span className="w-1.5 h-1.5 bg-amber-400 rounded-full" />
+                {UPDATED_LABEL} — All Tracks
+              </div>
+              <h1 className="text-2xl sm:text-3xl md:text-4xl font-extrabold leading-[1.1] mb-3 tracking-tight text-slate-900">
+                Global investing{" "}
+                <span className="text-amber-500">for Australians</span>
+              </h1>
+              <p className="text-sm md:text-base text-slate-600 leading-relaxed mb-5">
+                Two ways to put AUD into global markets — directly via a foreign broker, or via
+                AU-listed ETFs and LICs that hold foreign shares for you. We compare both, plus
+                the tax rules that decide which path is cheaper for your scenario.
+              </p>
+              <p className="text-xs text-slate-500 mb-5">Where do you want to start?</p>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 mb-5">
+                <Link
+                  href="/global-investing/shares/us"
+                  className="px-4 py-2.5 border border-slate-200 hover:bg-slate-50 hover:border-amber-300 text-slate-700 hover:text-slate-900 font-semibold rounded-xl text-xs text-left transition-colors"
+                >
+                  I want to buy US shares &rarr;
+                </Link>
+                <Link
+                  href="/global-investing/etfs"
+                  className="px-4 py-2.5 border border-slate-200 hover:bg-slate-50 hover:border-amber-300 text-slate-700 hover:text-slate-900 font-semibold rounded-xl text-xs text-left transition-colors"
+                >
+                  I want AU-listed global exposure &rarr;
+                </Link>
+                <Link
+                  href="/global-investing/property"
+                  className="px-4 py-2.5 border border-slate-200 hover:bg-slate-50 hover:border-amber-300 text-slate-700 hover:text-slate-900 font-semibold rounded-xl text-xs text-left transition-colors"
+                >
+                  I want to buy foreign property &rarr;
+                </Link>
+                <Link
+                  href="/global-investing/tax"
+                  className="px-4 py-2.5 border border-slate-200 hover:bg-slate-50 hover:border-amber-300 text-slate-700 hover:text-slate-900 font-semibold rounded-xl text-xs text-left transition-colors"
+                >
+                  I need to understand the tax &rarr;
+                </Link>
+              </div>
+              <Link
+                href="#tracks"
+                className="inline-block px-5 py-2.5 bg-amber-500 hover:bg-amber-400 text-slate-900 font-bold rounded-xl text-xs text-center transition-colors shadow-lg shadow-amber-500/20"
+              >
+                Show me Track A vs Track B &rarr;
+              </Link>
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              {HERO_STATS.map((s) => (
+                <div key={s.label} className="bg-slate-50 border border-slate-200 rounded-2xl p-4">
+                  <div className="text-xl md:text-2xl font-extrabold text-amber-600">{s.value}</div>
+                  <div className="text-[0.65rem] font-bold text-slate-900 mt-0.5">{s.label}</div>
+                  <div className="text-[0.6rem] text-slate-500 mt-0.5">{s.sub}</div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Two-track explainer ─────────────────────────────────────── */}
+      <section id="tracks" className="bg-slate-50 border-b border-slate-100 py-10">
+        <div className="container-custom">
+          <SectionHeading
+            eyebrow="Two tracks, one hub"
+            title="Track A vs Track B — pick the right path"
+            sub="Most Australians are better served by Track B (AU-listed exposure) for cost and simplicity. Track A makes sense for specific stocks, frequent trading, or markets the ASX doesn't cover."
+          />
+          <div className="grid md:grid-cols-2 gap-4">
+            {TRACK_A_VS_B.map((row) => (
+              <div key={row.when} className="bg-white border border-slate-200 rounded-2xl p-5">
+                <p className="text-[0.65rem] font-bold uppercase tracking-wider text-slate-500 mb-1">If</p>
+                <p className="font-semibold text-slate-900 text-sm mb-3">{row.when}</p>
+                <p className="text-[0.65rem] font-bold uppercase tracking-wider text-amber-600 mb-1">Use</p>
+                <p className="font-bold text-slate-900 text-sm mb-2">{row.use}</p>
+                <p className="text-xs text-slate-600 leading-relaxed mb-4">{row.why}</p>
+                <Link
+                  href={row.cta.href}
+                  className="inline-flex items-center gap-1 text-xs font-bold text-amber-600 hover:text-amber-700"
+                >
+                  {row.cta.label} &rarr;
+                </Link>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── Sub-pillar grid ─────────────────────────────────────────── */}
+      <section className="bg-white border-b border-slate-100 py-10">
+        <div className="container-custom">
+          <SectionHeading
+            eyebrow="Pillars"
+            title="Where to start"
+            sub="Eight sub-pillars — from direct foreign brokers to AU-listed ETFs to the tax rules that affect both."
+          />
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-3">
+            {SUB_PILLARS.map((p) => (
+              <Link
+                key={p.href}
+                href={p.href}
+                className={`group block bg-gradient-to-br ${p.color} border border-slate-200 rounded-2xl p-5 hover:border-amber-300 hover:shadow-md transition-all`}
+              >
+                <p className="text-[0.65rem] font-bold uppercase tracking-wider text-slate-500 mb-1">
+                  {p.eyebrow}
+                </p>
+                <p className="font-bold text-slate-900 text-sm mb-2 group-hover:text-amber-700">
+                  {p.label}
+                </p>
+                <p className="text-xs text-slate-600 leading-relaxed">{p.description}</p>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── FAQ ─────────────────────────────────────────────────────── */}
+      <section className="bg-slate-50 border-b border-slate-100 py-10">
+        <div className="container-custom">
+          <SectionHeading
+            eyebrow="FAQ"
+            title="Common questions about investing globally from Australia"
+          />
+          <div className="space-y-3 max-w-4xl">
+            {HUB_FAQS.map((faq) => (
+              <details
+                key={faq.question}
+                className="bg-white border border-slate-200 rounded-xl p-4 group"
+              >
+                <summary className="font-bold text-sm text-slate-900 cursor-pointer list-none flex items-start gap-3">
+                  <span className="text-amber-500 mt-0.5 group-open:rotate-90 transition-transform">&rarr;</span>
+                  <span className="flex-1">{faq.question}</span>
+                </summary>
+                <p className="mt-3 ml-7 text-xs text-slate-600 leading-relaxed whitespace-pre-line">
+                  {faq.answer}
+                </p>
+              </details>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── Cross-link to inbound counterpart ───────────────────────── */}
+      <section className="bg-white py-10">
+        <div className="container-custom">
+          <div className="bg-amber-50 border border-amber-200 rounded-2xl p-6 max-w-4xl">
+            <p className="text-[0.65rem] font-bold uppercase tracking-wider text-amber-700 mb-1">
+              Going the other way?
+            </p>
+            <p className="font-bold text-slate-900 text-base mb-2">
+              Foreign investors looking to invest in Australia
+            </p>
+            <p className="text-xs text-slate-600 leading-relaxed mb-3">
+              If you&apos;re a non-resident, visa holder, expat or new migrant looking at the AU
+              market from overseas, our inbound hub covers FIRB property rules, DASP super, DTA
+              withholding tax tables, and per-country guides for 14 countries.
+            </p>
+            <Link
+              href="/foreign-investment"
+              className="inline-flex items-center gap-1 text-xs font-bold text-amber-600 hover:text-amber-700"
+            >
+              See investing in Australia from overseas &rarr;
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Compliance footer ───────────────────────────────────────── */}
+      <section className="bg-slate-50 border-t border-slate-100 py-6">
+        <div className="container-custom">
+          <p className="text-[0.65rem] text-slate-500 leading-relaxed max-w-4xl">
+            {GENERAL_ADVICE_WARNING}
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -18,7 +18,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const supabase = hasSupabase ? await createClient() : null;
 
   // Static pages with tiered priorities
-  const highPriority = new Set(["/compare", "/quiz", "/reviews", "/deals", "/share-trading", "/crypto", "/savings", "/super", "/cfd", "/term-deposits", "/robo-advisors", "/versus", "/how-to", "/invest", "/foreign-investment", "/etfs", "/insurance", "/tax", "/property", "/grants", "/grants/rd-tax-incentive", "/smsf/setup", "/smsf/crypto", "/smsf/property", "/sell-business", "/sell-business/valuation", "/dividends", "/dividends/franking-credits", "/negative-gearing", "/lump-sum-investing", "/lump-sum-investing/redundancy", "/lump-sum-investing/inheritance", "/learn"]);
+  const highPriority = new Set(["/compare", "/quiz", "/reviews", "/deals", "/share-trading", "/crypto", "/savings", "/super", "/cfd", "/term-deposits", "/robo-advisors", "/versus", "/how-to", "/invest", "/foreign-investment", "/global-investing", "/etfs", "/insurance", "/tax", "/property", "/grants", "/grants/rd-tax-incentive", "/smsf/setup", "/smsf/crypto", "/smsf/property", "/sell-business", "/sell-business/valuation", "/dividends", "/dividends/franking-credits", "/negative-gearing", "/lump-sum-investing", "/lump-sum-investing/redundancy", "/lump-sum-investing/inheritance", "/learn"]);
   const medPriority = new Set(["/calculators", "/articles", "/scenarios", "/switch", "/stories", "/benchmark", "/health-scores", "/alerts", "/whats-new", "/costs", "/fee-impact", "/compound-interest-calculator", "/dividend-reinvestment-calculator", "/fire-calculator", "/property-vs-shares-calculator", "/super-contributions-calculator", "/tco-calculator", "/invest/mining", "/invest/buy-business", "/invest/farmland", "/invest/commercial-property", "/invest/renewable-energy", "/invest/startups", "/compare/non-residents", "/compare/money-transfer", "/grants/emdg", "/grants/industry-growth-program", "/grants/eligibility-quiz", "/smsf/investment-strategy", "/smsf/checklist", "/sell-business/checklist", "/visa-investment", "/dividends/calculator", "/negative-gearing/calculator", "/lump-sum-investing/calculator"]);
   // Everything else (about, how-we-earn, privacy, methodology, terms, etc.) → 0.4
 
@@ -97,7 +97,9 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     "/lump-sum-investing", "/lump-sum-investing/redundancy",
     "/lump-sum-investing/inheritance", "/lump-sum-investing/calculator",
     "/learn",
-    // Foreign investment hub
+    // Global investing hub (outbound — AU residents → world)
+    "/global-investing",
+    // Foreign investment hub (inbound — world → AU)
     "/foreign-investment",
     // Localised foreign-investor hub + sub-pages (zh, ko)
     "/zh/foreign-investment", "/ko/foreign-investment",

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -72,6 +72,7 @@ const investMegaMenu = [
 ];
 
 const foreignDropdown = [
+  { label: "Global Investing for Australians", href: "/global-investing", desc: "AU residents investing overseas — US shares, ETFs, FX, tax" },
   { label: "Foreign Investment Hub", href: "/foreign-investment", desc: "Start here — all verticals covered" },
   { label: "Shares for Non-Residents", href: "/foreign-investment/shares", desc: "Broker eligibility & withholding tax" },
   { label: "Crypto for Non-Residents", href: "/foreign-investment/crypto", desc: "AUSTRAC KYC & CGT treatment" },

--- a/docs/audits/GLOBAL_INVESTING_PROGRAM.md
+++ b/docs/audits/GLOBAL_INVESTING_PROGRAM.md
@@ -1,0 +1,391 @@
+# `/global-investing` — Outbound Hub Program
+
+Source of truth for the GI-stream build: AU residents investing globally
+(direct-outbound) and via AU-listed foreign exposure (indirect-outbound).
+Mirror of `/foreign-investment`, executed via existing `HubConfig`
+infrastructure (`lib/verticals.ts`, `docs/audits/HUB_BLUEPRINT.md`).
+
+**Authored:** 2026-05-04 from founder brief "build all of this in waves
+and loop it". Companion to the audit-remediation queue — every page in
+this doc is a queue item under stream **GI**.
+
+**Read by:** every GI-stream iteration. If this doc and a queue item
+conflict, the queue item wins for execution detail; this doc wins for
+strategic intent.
+
+---
+
+## 1. Why this exists
+
+`/foreign-investment` is heavily built (14 country pages, 9 sub-verticals,
+3 calculators, 2 localisations, dedicated advisor vertical). The
+outbound mirror — Australians investing globally — has **only 5 scattered
+pages and zero hub**. Surface-area ratio ≈ 50:1 in favour of inbound.
+
+The thesis: outbound is the bigger commercial opportunity by traffic
+(broader audience, English-only, no localisation cost) but currently
+fragmented across `/etfs/us-exposure`, `/etfs/international`, `/invest/forex`,
+and ~14 `/best/*` slugs that cannibalise each other. Consolidate +
+expand.
+
+### Two tracks, one hub
+
+| Track | Path pattern | Audience | Friction | Year-1 traffic share |
+|---|---|---|---|---|
+| **A — Direct outbound** | `/global-investing/shares/*`, `/property/*`, `/currency/*`, `/crypto/*` | Aspirational; uses foreign brokers | Higher (W-8BEN, foreign tax, FX) | ~30% |
+| **B — Indirect via ASX** | `/global-investing/etfs/*`, `/lics/*` | Mainstream; uses AU brokers | Lower (no foreign account needed) | ~70% |
+
+Track A pays better per conversion (foreign-broker CPAs $80-200). Track B
+captures the bigger funnel and feeds Track A via cross-link rails.
+
+---
+
+## 2. URL + page map (canonical)
+
+Every line below is either an existing page (`[exists]`) or a queue item
+(`[GI-XX]`). Loop iterations resolve queue items into shipped pages.
+
+```
+/global-investing                              [GI-01] HUB
+│
+├── /shares                                    [GI-10] sub-pillar
+│   ├── /us                                    [GI-02] CORNERSTONE (3-5k words)
+│   ├── /uk                                    [GI-11]
+│   ├── /hong-kong                             [GI-12]
+│   ├── /japan                                 [GI-13]
+│   ├── /singapore                             [GI-14]
+│   ├── /europe                                [GI-15]
+│   ├── /new-zealand                           [GI-16]
+│   └── /[ticker]-from-australia               [GI-17] PROGRAMMATIC, top 50 tickers
+│
+├── /etfs                                      [GI-20] sub-pillar
+│   ├── /us                                    [GI-03 redirect from /etfs/us-exposure]
+│   ├── /global                                [GI-03 redirect from /etfs/international]
+│   ├── /china                                 [GI-21]
+│   ├── /asia                                  [GI-22]
+│   ├── /japan                                 [GI-23]
+│   ├── /europe                                [GI-24]
+│   ├── /uk                                    [GI-25]
+│   ├── /india                                 [GI-26]
+│   └── /emerging-markets                      [GI-27]
+│
+├── /lics                                      [GI-30] sub-pillar
+│   ├── /global                                [GI-31] MFF, WGB, PMC, EAI, FGG
+│   ├── /asia                                  [GI-32]
+│   └── /us                                    [GI-33] (small)
+│
+├── /property                                  [GI-40] sub-pillar
+│   ├── /new-zealand                           [GI-41]
+│   ├── /united-states                         [GI-42] FL/TX retiree-investor angle
+│   ├── /indonesia                             [GI-43] Bali leasehold (tighter compliance)
+│   ├── /united-kingdom                        [GI-44]
+│   └── /portugal                              [GI-45] Golden-Visa equivalent
+│
+├── /currency                                  [GI-50] sub-pillar
+│   ├── /best-fx-providers                     [GI-51] Wise vs OFX vs WorldFirst
+│   ├── /multi-currency-accounts               [GI-52]
+│   └── /sending-money-overseas                [GI-53] mirror /foreign-investment/send-money-australia
+│
+├── /bonds                                     [GI-60] sub-pillar
+│   ├── /us-treasuries                         [GI-61]
+│   └── /global-bond-etfs                      [GI-62]
+│
+├── /crypto                                    [GI-70] sub-pillar
+│   ├── /global-exchanges                      [GI-71] Binance/Kraken/Bybit from AU
+│   └── /au-vs-global                          [GI-72] domestic vs offshore comparison
+│
+├── /tax                                       [GI-80] sub-pillar — THE MOAT
+│   ├── /fito                                  [GI-81] + calculator [GI-82]
+│   ├── /us-estate-tax                         [GI-83] + calculator [GI-84]
+│   ├── /cgt-on-foreign-shares                 [GI-85]
+│   ├── /w-8ben                                [GI-86] form walkthrough
+│   ├── /dta                                   [GI-87] outbound-side DTA table
+│   └── /super-pension-transfer                [GI-88] QROPS
+│
+├── /to/[country]                              [GI-90] PROGRAMMATIC mirror of /from/[country]
+│
+├── /guides                                    [GI-100] sub-pillar
+│   ├── stake-vs-commsec-international         [GI-101]
+│   ├── stake-vs-ibkr                          [GI-102]
+│   ├── moomoo-vs-tiger-vs-webull              [GI-103]
+│   ├── chess-vs-custodial-international       [GI-104]
+│   ├── ibkr-australia-setup                   [GI-105]
+│   ├── how-to-fill-w-8ben                     [GI-106]
+│   ├── us-estate-tax-australian-investors     [GI-107] lead magnet for tax-specialist routing
+│   ├── fito-explained                         [GI-108]
+│   ├── ato-foreign-shares-reporting           [GI-109]
+│   ├── currency-conversion-fees-explained     [GI-110]
+│   ├── direct-us-vs-asx-listed-equivalent     [GI-111] THE bridge between Track A and B
+│   └── global-etf-vs-direct-us                [GI-112] VGS vs VOO; very-high intent
+│
+└── /calculators                               [GI-120] sub-pillar
+    ├── /fx-impact-on-returns                  [GI-121]
+    ├── /fito                                  [GI-82]  (alias)
+    ├── /us-estate-tax-exposure                [GI-84]  (alias)
+    ├── /direct-vs-asx-cost                    [GI-122] BIGGEST LEAD MAGNET — compares total cost VOO vs IVV after FX/brokerage/tax
+    └── /total-cost-international-trade        [GI-123] extends existing /us-share-costs-calculator
+```
+
+### Reorganisation rules (canon)
+
+- **No namespace duplication.** `/etfs/us-exposure` 301 → `/global-investing/etfs/us`. `/etfs/international` 301 → `/global-investing/etfs/global`. Don't fork ETF content.
+- **Keep `/us-share-costs-calculator` at root.** It already ranks; only deep-link from the new hub.
+- **`/foreign-investment/china` (inbound) and `/global-investing/etfs/china` (outbound) co-exist.** Different intent, both should rank.
+
+---
+
+## 3. Redirect map (Wave 1, GI-03)
+
+301 permanent redirects. Land **after** the new target page is genuinely
+better content (3k+ words, schema, fresh data) — flipping redirects
+before content is upgraded loses ranking.
+
+| From | To |
+|---|---|
+| `/best/us-shares` | `/global-investing/shares/us` |
+| `/best/cheapest-us-shares` | `/global-investing/shares/us` |
+| `/best/us-shares-5000` | `/global-investing/shares/us` |
+| `/best/us-shares-monthly` | `/global-investing/shares/us` |
+| `/best/us-fee` | `/global-investing/shares/us` |
+| `/best/invest-in-us-shares` | `/global-investing/shares/us` |
+| `/best/international-shares` | `/global-investing/shares` |
+| `/best/best-international-etfs` | `/global-investing/etfs/global` |
+| `/best/forex` | `/global-investing/currency/best-fx-providers` |
+| `/best/start-forex-trading` | `/global-investing/currency/best-fx-providers` |
+| `/best/low-fx-fees` | `/global-investing/currency/best-fx-providers` |
+| `/etfs/us-exposure` | `/global-investing/etfs/us` |
+| `/etfs/international` | `/global-investing/etfs/global` |
+
+**Do NOT redirect:**
+- `/best/china`, `/best/japan`, `/best/hong-kong` — these may have inbound intent too; need per-slug review
+- `/us-share-costs-calculator` — root URL ranks; preserve
+- `/invest/forex` — leave for now; assess in Wave 4
+
+---
+
+## 4. Monetisation slot population (per `HubConfig`)
+
+For the hub itself (`/global-investing`):
+
+```ts
+{
+  slug: "global-investing",
+  audiences: ["expat", "founder", "hnw", "retiree"],  // any AU resident with capital
+  complianceKey: "general_advice_us_securities",       // NEW key, see compliance section
+  leadQueue: { kind: "general", topic: "global-investing" }, // until GI-specific queue ships
+  relatedHubs: ["foreign-investment", "smsf", "private-markets"],
+  // ... slots populated in GI-01
+}
+```
+
+Lever-by-lever year-1 expectation (loose, validate before sizing):
+
+| Lever | Slot | Source | Y1 estimate |
+|---|---|---|---|
+| #1 Lead routing | quiz at hub, calculator email-gates, footer CTA | International tax specialists, QROPS advisors, foreign property buyer's agents | AU$80k–300k |
+| #2 Sponsored placements | hero rail "Featured global broker", directory top row | IBKR/Stake/Tiger/moomoo paid placements | AU$40k–150k |
+| #3 Affiliate CPA | comparison tables, calculator results, in-article CTAs | Foreign brokers + FX providers (the biggest line) | AU$200k–900k |
+| #4 Affiliate revshare | Sharesight, Wise long-term recurring | Tail revenue, compounds | AU$20k–80k |
+| #5 Listings marketplace | `/property/listings/[slug]`, paid LIC manager featured slots | NZ property platforms, Bali developers, fund managers | AU$30k–120k |
+| #6 Premium subscription | "Global deal alerts" — IPOs, AUD/USD threshold alerts | $30-50/mo, 200-500 subs target by month 12 | AU$50k–150k |
+| #7 Sponsored content | "Advertising feature" articles by brokers, FX providers | $1.5-5k each, 1-2/mo | AU$30k–80k |
+| #8 Display ads | article side rails on long-form guides only | Programmatic, secondary | AU$5k–20k |
+| #9 Lead magnet | "AU US-tax pack" PDF, "W-8BEN walkthrough" PDF | Email capture → nurture | Indirect, feeds #1+#6 |
+| #10 Newsletter sponsor | per-send sponsorship of GI cohort | $500-1.5k per send, 2-4/mo once list >5k | AU$15k–60k |
+| #11 Events | quarterly "Global investing for Australians" webinar | $5-15k each, sponsored by broker | AU$20k–60k |
+| #12 Courses | "Buying US shares from Australia" course at $99-199 | Long-tail, converts from cornerstone | AU$10k–40k |
+
+**Year-1 reasonable range: AU$500k–2M.**
+Highest line: lever #3 affiliate CPA. Highest moat: lever #1 + #9 fed by US-estate-tax / FITO calculators.
+
+---
+
+## 5. SEO architecture
+
+### Pillar / cluster
+- `/global-investing` = pillar
+- Each top-level child (`/shares`, `/etfs`, `/property`, `/currency`, `/tax`, `/bonds`, `/crypto`, `/lics`) = sub-pillar
+- Each guide = cluster spoke linking up to its sub-pillar and laterally to 3-5 sibling guides
+
+### Internal-linking rules (enforced via component, not author discipline)
+- Every Track A page links to its Track B equivalent ("Don't want a foreign broker? Here's the ASX-listed alternative")
+- Every Track B page links to its Track A equivalent ("Want direct exposure? Here's how to buy on NYSE")
+- Every guide links to ≥1 calculator and ≥1 directory page
+- Every `/to/[country]` cross-links to `/from/[country]` if it exists ("Going the other way? See our inbound guide")
+
+### Programmatic SEO (`programmaticSeoTemplates` in `HubConfig`)
+- `/global-investing/shares/[ticker]-from-australia` × top 200 US tickers — pure programmatic, ~200 long-tail pages
+- `/global-investing/etfs/[region]` — 7 region pages (above)
+- `/global-investing/to/[country]` — 8 countries to start, expandable to 30
+- `/global-investing/guides/[broker-a]-vs-[broker-b]` — versus matrix; reuse `/etfs/vs/[slugs]` pattern
+
+**Estimate:** ~30 hand-written cornerstone pages + ~250 programmatic = **~280 indexable URLs**.
+
+### Schema.org / JSON-LD (reuse `lib/schema-markup.ts`, `lib/seo.ts`)
+- Hub: `WebPage` + `BreadcrumbList` + `FAQPage`
+- Comparison pages: `Product` + `AggregateRating` for each broker/ETF row
+- Guides: `Article` + `FAQPage`
+- Calculators: `WebApplication`
+
+### hreflang
+- Outbound is English-only (AU residents). **No `/zh` or `/ko` mirror.**
+- Add `<link rel="alternate" hreflang="en-AU" />` on every page.
+- Consider light `en-NZ` mirror later — `/to/new-zealand` already half-serves NZ residents.
+
+---
+
+## 6. Compliance
+
+The outbound thesis sits closer to personal tax/financial advice than the
+rest of the site. Compliance load is materially higher.
+
+### New `lib/compliance.ts` keys (GI-04)
+
+```ts
+GLOBAL_INVESTING_GENERAL_ADVICE   // covers /global-investing/* general
+US_SECURITIES_DISCLAIMER           // for /shares/us, /tax/*, /etfs/us
+TAX_AGENT_DISCLAIMER               // explicit "we are not tax agents" gate
+QROPS_DISCLAIMER                   // for /tax/super-pension-transfer
+FX_GENERAL_ADVICE                  // for /currency/*
+US_ESTATE_TAX_DISCLAIMER           // for /tax/us-estate-tax + calculator
+FITO_DISCLAIMER                    // for /tax/fito + calculator
+```
+
+### Required reviews before merge
+
+- **Tax-agent review** of US estate tax + FITO calculator outputs (NOT optional). Track in `docs/audits/handoffs/gi-tax-review.md`.
+- **QROPS** content needs an authorised QROPS advisor partnership OR a clear "factual information only" framing reviewed by tax counsel.
+- **Affiliate restrictions:** Robinhood (no AU), Fidelity (no), Schwab (no for new), E*TRADE (no), Public.com (no), M1 Finance (no). **Viable universe:** IBKR, Stake, Tiger AU, moomoo AU, Webull AU, eToro, Superhero (US lite), CMC International, CommSec International, Pearler (US lite), Vested.
+
+### Tier (per CLAUDE.md merge authorization)
+
+- Page UI / content / docs: **Tier A** — autonomous merge after CI green
+- New `lib/compliance.ts` keys: **Tier C** — announce before merge
+- New schema migration (`broker_markets` join table for GI-09): **Tier C** — announce before merge
+
+---
+
+## 7. Build sequencing — 4 waves
+
+Each wave is independently shippable. Pause anywhere → still net positive.
+
+### Wave 1: hub shell + cornerstone + redirects (queue items GI-01 → GI-09)
+**Target: 2-3 weeks via loop, ~1 long session for the foundation.**
+
+- **GI-01** Hub page `/global-investing` (HubConfig row + page.tsx + JSON-LD + FAQ)
+- **GI-02** Cornerstone `/global-investing/shares/us` (3-5k words, broker comparison, FAQ)
+- **GI-03** Redirect map (13 redirects above) in `next.config.ts`
+- **GI-04** New compliance keys in `lib/compliance.ts` (Tier C, announce)
+- **GI-05** Mega-menu entry (Header.tsx hand-edit until Y-stream lands)
+- **GI-06** Sitemap entry in `app/sitemap.ts`
+- **GI-07** Cross-link from `/share-trading` vertical → "Trading global markets?" CTA
+- **GI-08** Move existing `/etfs/us-exposure` content to `/global-investing/etfs/us` (clone, then 301)
+- **GI-09** `broker_markets` join table migration (Tier C, announce) — replaces fragile `accepts_global_trading` flag pattern
+
+### Wave 2: Track B AU-listed foreign exposure (queue items GI-20 → GI-32)
+**Target: 3-4 weeks via loop.** This is the bigger traffic funnel.
+
+- **GI-20** `/global-investing/etfs` sub-pillar
+- **GI-21**–**GI-27** 7 region pages (china, asia, japan, europe, uk, india, emerging-markets) modelled on `/etfs/us-exposure`
+- **GI-30** `/global-investing/lics` sub-pillar
+- **GI-31**–**GI-33** 3 LIC pages (global, asia, us)
+- **GI-111** Bridge guide: `direct-us-vs-asx-listed-equivalent`
+- **GI-101**–**GI-105** 5 versus pages (Stake-vs-IBKR, Stake-vs-CommSec-International, etc.)
+
+### Wave 3: tax moat + calculators (queue items GI-80 → GI-88, GI-120 → GI-123)
+**Target: 3-4 weeks via loop. Includes tax-agent review window.**
+
+- **GI-80** `/global-investing/tax` sub-pillar
+- **GI-81**–**GI-88** 8 tax pages (FITO, US estate tax, CGT on foreign shares, W-8BEN, DTA, QROPS)
+- **GI-82** FITO calculator (reuse engine from `non-resident-dividend-calculator`)
+- **GI-84** US estate tax exposure calculator (NEW, lead-gen gold)
+- **GI-122** `direct-vs-asx-cost` calculator — biggest single lead capture asset in build
+- **GI-130** `/advisors/global-investing-specialists` (mirror `/advisors/international-tax-specialists`)
+- **GI-131** Wire calculator results → email-gate → tax-specialist routing
+
+### Wave 4: country pages + currency + completion (queue items GI-40 → GI-72, GI-90, GI-17, etc.)
+**Target: 3-4 weeks via loop.**
+
+- **GI-90** `/to/[country]` programmatic — start with 8 countries
+- **GI-40**–**GI-45** 5 property pages
+- **GI-50**–**GI-53** Currency hub + 3 sub-pages
+- **GI-60**–**GI-62** Bonds hub + US treasuries + global bond ETFs
+- **GI-70**–**GI-72** Crypto sub-pages
+- **GI-17** `/shares/[ticker]-from-australia` programmatic — top 50 to start
+- **GI-140** Newsletter cohort + push category for "global-investing"
+
+---
+
+## 8. Definition of Done (per HUB_BLUEPRINT §6)
+
+A GI-stream item ships only when:
+
+- [ ] Slug registered (HubConfig row OR ad-hoc page until W-12 ships)
+- [ ] `revalidate=86400` on content pages, lower on data pages
+- [ ] Breadcrumb + JSON-LD via `lib/seo.ts` helpers
+- [ ] FAQ JSON-LD on long-form pages
+- [ ] All disclaimers via `lib/compliance.ts` keys (no inline strings)
+- [ ] All affiliate links via `getAffiliateLink()` from `lib/tracking.ts`
+- [ ] All dated stats via `<DatedStatBadge>` with `dataAsOf` + `stalesAt`
+- [ ] Mega-menu + sitemap entries (registry-driven once Y-stream lands; hand-edit until then)
+- [ ] Internal cross-links: ≥1 to a Track A/B counterpart, ≥1 to a calculator, ≥1 to a directory
+- [ ] `npm run type-check` clean
+- [ ] Vitest tests for any new helpers; integration test for redirect map
+- [ ] One human dev-session UAT before deploy (CLAUDE.md "Before shipping")
+- [ ] PR description ticks every box; reviewer can verify in 5 minutes
+
+---
+
+## 9. Risks (don't pretend these don't exist)
+
+1. **301 redirect risk.** `/best/us-shares*` slugs currently rank. If we redirect before the target is genuinely better, we lose 3-6 weeks during recrawl. Mitigation: Wave 1 lands target page **before** flipping redirects (GI-02 lands before GI-03).
+
+2. **Cannibalization with `/share-trading` and `/etfs/us-exposure`.**
+   - `/share-trading` = AU broker comparison (default, AU-listed)
+   - `/global-investing/shares/us` = direct-to-NYSE
+   - `/global-investing/etfs/us` = AU-listed US exposure
+   The three should cross-link, not compete. GI-07 enforces this.
+
+3. **Compliance load is higher than inbound.** GI-04 + tax-agent review. Don't merge calculators (GI-82, GI-84, GI-122) without tax-agent sign-off in `docs/audits/handoffs/gi-tax-review.md`.
+
+4. **Some brokers restrict AU traffic.** Filter list in §6.
+
+5. **AUD/USD cycle dependence.** Build evergreen content; don't tie page freshness to FX prints.
+
+6. **Opportunity cost.** Could instead build `/wholesale` or `/family-office` (Tier-1, higher RPV). Outbound chosen because it feeds the broader retail funnel that everything else hangs off.
+
+7. **Track B cannibalises Track A affiliate revenue.** A reader picking IVV over VOO loses the foreign-broker CPA. But they convert to a domestic broker (CommSec, SelfWealth) — net negative is small. Don't hide Track B; honest comparison ranks better long-term.
+
+---
+
+## 10. Anti-goals
+
+- **No `/zh` or `/ko` localisation for outbound.** Audience is English-speaking AU residents.
+- **No new dynamic `[country]` route at hub level** (only at `/to/[country]`). Avoids URL ambiguity with `/foreign-investment/[country]`.
+- **No bespoke layout per page** once W-12 ships HubPage HOC. Until then, follow `/foreign-investment/page.tsx` as the canonical hand-rolled pattern.
+- **No outbound DASP duplication.** DASP belongs in `/foreign-investment/super`. One cross-link from `/global-investing/tax/super-pension-transfer` is enough.
+- **No brand/visual differentiation** between inbound and outbound hubs. Two hubs, one design system.
+- **No premature monetisation slots.** Empty slots leave a clean page. Only populate when there's real inventory (real sponsors, real listings, real lead-routing partners).
+
+---
+
+## 11. Loop integration
+
+- Each `GI-XX` item lives in `docs/audits/REMEDIATION_QUEUE.md` under `### GI — Global Investing` section.
+- Loop iteration contract (per `REMEDIATION_DEFAULTS.md`): pick top non-blocked item, do it, update queue, exit.
+- This program is **Tier A by default** (page UI + content). Items flagged Tier C in §6 require chat-announcement before merge.
+- Diff cap: ≤800 LOC per iteration (existing convention). Long pages (cornerstones) may need 2 iterations: scaffold + content.
+- Cross-stream coordination: GI-stream depends on W-12 (HubPage HOC) eventually but doesn't block on it. Until W-12 lands, GI-XX items use the hand-rolled `/foreign-investment` pattern.
+
+---
+
+## 12. Status (live)
+
+| Wave | Status | Last update |
+|---|---|---|
+| 1 — Foundation | in-progress (this PR) | 2026-05-04 |
+| 2 — Track B ETFs | queued | — |
+| 3 — Tax moat | queued | — |
+| 4 — Long-tail | queued | — |
+
+Loop iterations append progress here.

--- a/docs/audits/REMEDIATION_QUEUE.md
+++ b/docs/audits/REMEDIATION_QUEUE.md
@@ -1145,6 +1145,128 @@ priority + §6 Definition of Done.
 | Z-26 | pending | `/super` hub (proper, not just `/super/smsf`) — sub-pages + fee-projection calc + fund table | 6-8 | **P1.** Massive search volume "best super fund"; fund affiliate $50-200/signup. ID renumbered from Z-NEW-12. **Deps:** stream W components, ASX/APRA fund-performance data feed. **DoD:** hub + sub-pages industry-vs-retail / best-super-funds / under-30 / over-60 / consolidate-super / lost-super-finder / switching-super / concessional-vs-non-concessional / division-296 (>$3M tax); top-fund comparison table (APRA performance data — handle staleness via `<DatedStatBadge>`); fee comparison calculator (15-yr projection of $X balance across N funds); quiz "is your super fund underperforming"; 15+ seeded articles; lead source `'super'` routing to super-fund affiliate + advisor queue; tests for fund-table data freshness, fee-projection calc unit (compounding correctness), quiz routing. **Compliance:** factual fund comparison, performance disclaimer, GAW. |
 | Z-27 | pending | `/tax-return` hub — sub-pages + decision-tree quiz + accountant directory | 6-8 | **P2.** June-October seasonal; accountant lead $50-200; plugs into every other hub. ID renumbered from Z-NEW-13. **Deps:** stream W components, BB-03 CGT calc. **DoD:** hub + sub-pages diy-vs-accountant / deductions-by-occupation (programmatic via AA-06) / crypto-tax / property-tax / cgt / negative-gearing-tax / work-from-home-deductions / late-lodgement / etax-vs-mytax-vs-accountant; accountant directory (add NEW advisor type via constraint update); decision tree quiz "DIY or hire accountant" routing; embedded BB-03; 12+ seeded articles; lead source `'tax-return'` routing to accountant queue (specialty-matched: crypto/property/business); tests for hub render, decision-tree quiz routing, CGT calc unit, directory specialty filter. **Compliance:** tax-agent territory, ASIC factual carve-out, no personal tax advice. |
 
+### Stream GI — `/global-investing` outbound hub (added 2026-05-04)
+
+Mirror of `/foreign-investment` for Australians investing globally. Two
+tracks under one hub: **A** direct-outbound (foreign brokers / foreign
+listings / foreign property / FX / foreign super) and **B** indirect via
+AU-listed exposure (region/sector/global ETFs + LICs). Year-1 reasonable
+revenue range AU$500k-2M, weighted heaviest on lever #3 affiliate CPA
+(IBKR/Stake/Tiger/moomoo) and lever #1 advisor lead routing
+(international tax specialists, QROPS advisors, foreign property buyer's
+agents). Reference: `docs/audits/GLOBAL_INVESTING_PROGRAM.md` is the full
+spec; queue items below resolve into shipped pages.
+
+**Sequencing:** Wave 1 (foundation) ships first — hub shell, cornerstone
+US-shares page, redirect map, compliance keys. Then Wave 2 (Track B ETFs
+— bigger funnel) → Wave 3 (tax/calculator moat) → Wave 4 (long-tail).
+Each wave is independently shippable; pause anywhere → still net positive.
+
+**Tier guidance:** page UI / content / docs are Tier A (autonomous merge
+after CI green). Tier C: GI-04 (compliance keys), GI-09 (`broker_markets`
+schema migration). Calculators GI-82 / GI-84 / GI-122 require tax-agent
+review captured in `docs/audits/handoffs/gi-tax-review.md` before merge.
+
+**Anti-goal:** no `/zh` or `/ko` localisation (audience is English-speaking
+AU residents); no bespoke layout per page once W-12 ships HubPage HOC —
+until then mirror `/foreign-investment/page.tsx` as the canonical pattern.
+
+#### Wave 1 — Foundation
+
+| ID | Status | Summary | Est. iterations | Notes |
+| --- | --- | --- | --- | --- |
+| GI-01 | in-progress | `/global-investing` hub page (HubConfig row + page.tsx + JSON-LD + FAQ + service grid) | 1 | Mirrors `/foreign-investment/page.tsx`. HubConfig row in `lib/verticals.ts` with `audiences:["expat","founder","hnw","retiree"]`, `complianceKey:"general_advice"` (until GI-04 lands), `leadQueue:{kind:"general",topic:"global-investing"}`, `relatedHubs:["foreign-investment","smsf","private-markets"]`. Service grid: shares / etfs / property / currency / tax / lics / bonds / crypto. Hero stats: brokers compared, regions covered, calculators, last verified. **DoD:** page renders, breadcrumb + FAQPage JSON-LD via `lib/seo.ts`, all FAQs sourced from spec §1; ≤3 dated stats wrapped in `<DatedStatBadge>`; mega-menu hand-edit (GI-05) + sitemap (GI-06) follow. |
+| GI-02 | pending | `/global-investing/shares/us` cornerstone (3-5k words) | 2 | THE cornerstone — "buy US shares from Australia". Sections: how it works, broker comparison (IBKR/Stake/Tiger/moomoo/Webull/eToro/CMC International/CommSec International/Pearler/Vested), CHESS vs custodial offshore, FX cost breakdown, W-8BEN explainer, capital-gains-in-AUD, US estate tax exposure (cross-link to GI-83), brokerage-vs-FX cost calculator inline (cross-link to GI-122), FAQ ≥10 entries with FAQPage JSON-LD, comparison table with `Product` + `AggregateRating` schema, sponsorship-aware top-row using `boostFeaturedPartner()`. Affiliate links via `getAffiliateLink()`. Cross-links: `/global-investing/etfs/us` (Track B alt), `/global-investing/tax/w-8ben`, `/global-investing/tax/us-estate-tax`. **Lands BEFORE GI-03 redirects flip.** **DoD:** ≥3,000 words, ≥10 FAQs, schema validated, all dated stats badged. |
+| GI-03 | pending | 301 redirect map in `next.config.ts` | 1 | 13 redirects per spec §3: `/best/{us-shares,cheapest-us-shares,us-shares-5000,us-shares-monthly,us-fee,invest-in-us-shares,international-shares,best-international-etfs,forex,start-forex-trading,low-fx-fees}`, `/etfs/us-exposure`, `/etfs/international`. **GATE: Do NOT flip until GI-02 + GI-08 are green in production.** Add integration test that asserts each `from` returns 301 → `to`. |
+| GI-04 | pending | New `lib/compliance.ts` keys for outbound | 1 | **Tier C — announce before merge.** Add: `GLOBAL_INVESTING_GENERAL_ADVICE`, `US_SECURITIES_DISCLAIMER`, `TAX_AGENT_DISCLAIMER`, `QROPS_DISCLAIMER`, `FX_GENERAL_ADVICE`, `US_ESTATE_TAX_DISCLAIMER`, `FITO_DISCLAIMER`. No inline disclaimers anywhere in GI pages — `lib/compliance.ts` keys only. |
+| GI-05 | pending | Mega-menu entry (Header.tsx hand-edit) | 1 | Hand-edit `components/Header.tsx` until Y-stream (Y-01/Y-02) lands the registry-driven mega-menu. Add `/global-investing` adjacent to `/foreign-investment` in the "Investing internationally" group. Once Y-02 ships, this gets removed in favour of the registry. |
+| GI-06 | pending | Sitemap entry | 1 | Add `/global-investing` and all its sub-pages to `app/sitemap.ts` with `priority: 0.85` for hub, `0.75` for sub-pillars, `0.7` for guides. Once Y-03 ships, this gets removed in favour of registry-driven sitemap. |
+| GI-07 | pending | Cross-link from `/share-trading` vertical → "Trading global markets?" CTA | 1 | Update `lib/verticals.ts` share-trading entry to surface a "Trading global markets?" link in subcategories or sections, pointing to `/global-investing/shares/us`. Prevents `/share-trading` and `/global-investing/shares/us` from cannibalising each other. |
+| GI-08 | pending | Move `/etfs/us-exposure` content to `/global-investing/etfs/us` (clone, then 301) | 1 | Two-phase: (a) clone the existing 362-line page to new path with updated breadcrumbs + canonical; (b) once new URL is indexed, flip 301. Same for `/etfs/international` → `/global-investing/etfs/global`. |
+| GI-09 | pending | `broker_markets` join table migration | 1 | **Tier C — announce before merge.** Replaces fragile `accepts_global_trading` flag pattern. New table `broker_markets (broker_id, market: 'asx'\|'nyse'\|'nasdaq'\|'lse'\|'hkex'\|'tse'\|'nzx'\|'sgx'\|'euronext', supported: bool, notes: text)`. RLS: anon SELECT, service_role write. Backfill from existing data. Idempotent migration with rollback header per G-stream conventions. |
+
+#### Wave 2 — Track B (AU-listed foreign exposure) — bigger traffic funnel
+
+| ID | Status | Summary | Est. iterations | Notes |
+| --- | --- | --- | --- | --- |
+| GI-20 | pending | `/global-investing/etfs` sub-pillar page | 1 | Hub for region pages. Quick comparison strip + cross-links into each region. Reuse the table component pattern from `/etfs/us-exposure`. |
+| GI-21 | pending | `/global-investing/etfs/china` | 1 | IZZ (iShares China Large-Cap), VAE (Vanguard Asia ex-Japan as China-tilt proxy), ASIA (Betashares Asia Tech Tigers), CIN (Betashares Australian Investment Grade Corporate Bond — wrong; remove) — verify ETF list before write. MER, AUM, holdings concentration, currency hedging stance, dividend treatment. |
+| GI-22 | pending | `/global-investing/etfs/asia` | 1 | VAE, IAA, ASIA, IEM-tilted Asia. |
+| GI-23 | pending | `/global-investing/etfs/japan` | 1 | IJP (iShares MSCI Japan), HJPN (BetaShares Japan ETF — verify). |
+| GI-24 | pending | `/global-investing/etfs/europe` | 1 | IEU (iShares Europe), VEQ (Vanguard FTSE Europe). |
+| GI-25 | pending | `/global-investing/etfs/uk` | 1 | Smaller cohort; IRE-related; verify ASX availability before commit. |
+| GI-26 | pending | `/global-investing/etfs/india` | 1 | NDIA (BetaShares India Quality), INDA-equivalents. |
+| GI-27 | pending | `/global-investing/etfs/emerging-markets` | 1 | IEM, VGE, EMKT. |
+| GI-30 | pending | `/global-investing/lics` sub-pillar page | 1 | LIC (Listed Investment Company) explainer + LIC vs ETF tradeoffs + cross-link to region pages. |
+| GI-31 | pending | `/global-investing/lics/global` | 1 | MFF (Magellan Flagship), WGB (WAM Global), PMC (Platinum Capital), EAI (Ellerston Asian Investments — wrong category; verify), FGG (Future Generation Global). NTA, premium/discount, fee, performance vs benchmark. |
+| GI-32 | pending | `/global-investing/lics/asia` | 1 | Platinum Asia (PAI), Pengana International. |
+| GI-33 | pending | `/global-investing/lics/us` | 1 | Sparse market; small content piece + cross-link to GI-21..27. |
+| GI-101 | pending | `/global-investing/guides/stake-vs-commsec-international` | 1 | Versus matrix; reuse `/etfs/vs/[slugs]` rendering pattern if applicable. |
+| GI-102 | pending | `/global-investing/guides/stake-vs-ibkr` | 1 | |
+| GI-103 | pending | `/global-investing/guides/moomoo-vs-tiger-vs-webull` | 1 | Three-way comparison; the Asian-broker cohort question. |
+| GI-104 | pending | `/global-investing/guides/chess-vs-custodial-international` | 1 | Unique-to-AU angle; explains why Stake/Tiger are custodial and what that means for ownership. |
+| GI-105 | pending | `/global-investing/guides/ibkr-australia-setup` | 1 | Walkthrough — hardest broker to onboard, highest CPA. |
+| GI-111 | pending | `/global-investing/guides/direct-us-vs-asx-listed-equivalent` | 1 | THE bridge between Track A and Track B. Decision framework: when to buy VOO direct vs IVV on ASX. Cross-link to GI-122 calculator. |
+| GI-112 | pending | `/global-investing/guides/global-etf-vs-direct-us` | 1 | VGS vs VOO; very-high intent. |
+
+#### Wave 3 — Tax moat + calculators (the moat that competitors can't copy)
+
+| ID | Status | Summary | Est. iterations | Notes |
+| --- | --- | --- | --- | --- |
+| GI-80 | pending | `/global-investing/tax` sub-pillar | 1 | Mirrors `/foreign-investment/tax`. Outbound-side DTA framing, FITO, US-source income, foreign-asset CGT. |
+| GI-81 | pending | `/global-investing/tax/fito` | 1 | Foreign Income Tax Offset explainer + worked examples. Cross-link to GI-82 calculator. |
+| GI-82 | pending | `/global-investing/calculators/fito` | 2 | **Tax-agent review required before merge.** Reuse engine from `non-resident-dividend-calculator`; AUD-source income + foreign-source income + foreign tax paid → FITO + AU tax owed. Email-gate "save my results" → tax-specialist routing. |
+| GI-83 | pending | `/global-investing/tax/us-estate-tax` | 1 | The fear-driven advisor lead magnet. Explains 40% estate tax exposure on US-situs assets >US$60k for non-resident aliens. AUS-US treaty unified-credit interaction. Cross-link to GI-84. |
+| GI-84 | pending | `/global-investing/calculators/us-estate-tax-exposure` | 2 | **Tax-agent review required before merge.** Inputs: US securities held + spouse status + AU-resident status. Output: estimated estate tax + suggested mitigations (W-8BEN, AU-domiciled ETFs, structuring through AU LLC/trust). Email-gate → tax-specialist + estate-planning advisor routing. **Highest-LTV lead capture in the build.** |
+| GI-85 | pending | `/global-investing/tax/cgt-on-foreign-shares` | 1 | AUD reporting + FX-affected gains/losses; cost-base in AUD at acquisition; disposal in AUD at sale. Sharesight as solution. |
+| GI-86 | pending | `/global-investing/tax/w-8ben` | 1 | Form walkthrough; high search volume. Step-by-step screenshots with privacy-redacted example. |
+| GI-87 | pending | `/global-investing/tax/dta` | 1 | Outbound-side DTA table — when AU residents earn US/UK/HK/JP/SG/etc income, what withholding tax applies and how to claim FITO. Mirror of `DTASearchTable` from inbound side. |
+| GI-88 | pending | `/global-investing/tax/super-pension-transfer` | 1 | QROPS (UK→AU), US 401(k) for returning Aussies. **Compliance:** needs authorised QROPS advisor partnership OR explicit "factual information only" framing reviewed by tax counsel. |
+| GI-122 | pending | `/global-investing/calculators/direct-vs-asx-cost` | 2 | **The cross-track decision tool — biggest single lead-capture asset.** Inputs: ticker (e.g. VOO) + ASX equivalent (e.g. IVV) + holding period + amount. Output: total cost via Stake (FX + brokerage + custody + W-8BEN simplified) vs total cost via CommSec for IVV. Email-gate "save analysis" → broker affiliate links + tax-specialist route. |
+| GI-121 | pending | `/global-investing/calculators/fx-impact-on-returns` | 1 | Interactive AUD/USD scenario over investment horizon. Hedged vs unhedged outcome difference. |
+| GI-123 | pending | `/global-investing/calculators/total-cost-international-trade` | 1 | Extends existing root `/us-share-costs-calculator` with multi-broker comparison + FX provider option. |
+| GI-130 | pending | `/advisors/global-investing-specialists` advisor vertical | 1 | Mirror `/advisors/international-tax-specialists` pattern. Match users to AU-licensed advisors with foreign-asset/QROPS/US-tax specialty. |
+| GI-131 | pending | Wire calculator results → email-gate → tax-specialist routing | 1 | Reuse existing lead-routing infra; add `lead_source: 'global-investing-calculator'` taxonomy. |
+
+#### Wave 4 — Long-tail + completion
+
+| ID | Status | Summary | Est. iterations | Notes |
+| --- | --- | --- | --- | --- |
+| GI-10 | pending | `/global-investing/shares` sub-pillar page | 1 | Aggregator over country share pages. |
+| GI-11 | pending | `/global-investing/shares/uk` | 1 | LSE access for AU residents. IBKR + CMC International. |
+| GI-12 | pending | `/global-investing/shares/hong-kong` | 1 | HKEX, China A-shares via Stock Connect. |
+| GI-13 | pending | `/global-investing/shares/japan` | 1 | Topix, Nikkei. |
+| GI-14 | pending | `/global-investing/shares/singapore` | 1 | SGX. |
+| GI-15 | pending | `/global-investing/shares/europe` | 1 | Euronext consolidated. |
+| GI-16 | pending | `/global-investing/shares/new-zealand` | 1 | NZX — often forgotten, low competition. |
+| GI-17 | pending | `/global-investing/shares/[ticker]-from-australia` programmatic — top 50 tickers initial | 3-5 | Top 50 US tickers (Tesla, Apple, Nvidia, Amazon, Microsoft, Meta, Alphabet, Berkshire, JPM, V, etc.) per page: how to buy from AU + brokers that offer + FX considerations + tax. Generate via `generateStaticParams`. Expandable to top 200 over Q2. |
+| GI-40 | pending | `/global-investing/property` sub-pillar | 1 | Outbound foreign property. |
+| GI-41 | pending | `/global-investing/property/new-zealand` | 1 | |
+| GI-42 | pending | `/global-investing/property/united-states` | 1 | FL/TX retiree-investor angle. |
+| GI-43 | pending | `/global-investing/property/indonesia` | 1 | Bali leasehold; **higher compliance load** — explicit risk framing per `lib/compliance.ts` `general_advice` + property disclaimers. |
+| GI-44 | pending | `/global-investing/property/united-kingdom` | 1 | |
+| GI-45 | pending | `/global-investing/property/portugal` | 1 | Golden-Visa equivalent angle. |
+| GI-50 | pending | `/global-investing/currency` sub-pillar | 1 | FX hub. |
+| GI-51 | pending | `/global-investing/currency/best-fx-providers` | 1 | Wise vs OFX vs WorldFirst vs Revolut vs Airwallex. Affiliate-rich. |
+| GI-52 | pending | `/global-investing/currency/multi-currency-accounts` | 1 | |
+| GI-53 | pending | `/global-investing/currency/sending-money-overseas` | 1 | Mirror `/foreign-investment/send-money-australia` (the inbound counterpart). |
+| GI-60 | pending | `/global-investing/bonds` sub-pillar | 1 | |
+| GI-61 | pending | `/global-investing/bonds/us-treasuries` | 1 | High search when AUD weak. IBKR access path. |
+| GI-62 | pending | `/global-investing/bonds/global-bond-etfs` | 1 | AU-listed; consolidates `/etfs/bonds` global tilt. |
+| GI-70 | pending | `/global-investing/crypto` sub-pillar | 1 | Outbound crypto angle. |
+| GI-71 | pending | `/global-investing/crypto/global-exchanges` | 1 | Binance/Kraken/Bybit from AU. **Compliance:** AUSTRAC + crypto-warning. |
+| GI-72 | pending | `/global-investing/crypto/au-vs-global` | 1 | Independent Reserve vs Binance comparison. |
+| GI-90 | pending | `/global-investing/to/[country]` programmatic — 8 countries | 2-3 | Mirror `/foreign-investment/from/[country]`. Per country: best brokers for that market access, tax (DTA reference), key listings, programmatic page. Initial 8: us, uk, nz, jp, sg, hk, in, id. Expandable to 30. |
+| GI-100 | pending | `/global-investing/guides` index page | 1 | Aggregator. |
+| GI-106 | pending | `/global-investing/guides/how-to-fill-w-8ben` | 1 | Companion to GI-86. |
+| GI-107 | pending | `/global-investing/guides/us-estate-tax-australian-investors` | 1 | Long-form companion to GI-83. **Lead-magnet PDF version**. |
+| GI-108 | pending | `/global-investing/guides/fito-explained` | 1 | Companion to GI-81. |
+| GI-109 | pending | `/global-investing/guides/ato-foreign-shares-reporting` | 1 | |
+| GI-110 | pending | `/global-investing/guides/currency-conversion-fees-explained` | 1 | |
+| GI-120 | pending | `/global-investing/calculators` index page | 1 | Aggregator. |
+| GI-140 | pending | Newsletter cohort + push category for "global-investing" | 1 | Lever #6 + #10. Re-uses existing newsletter infra; adds `cohort: 'global-investing'`. |
+| GI-141 | pending | "AU investor's US-tax pack" PDF (lead magnet) | 1 | Lever #9. Gated PDF combining FITO + W-8BEN + US estate tax + CGT-on-foreign. Email capture → newsletter cohort. |
+
 ### Stream AA — Programmatic SEO machine (added 2026-04-27)
 
 Build N templates that consume Supabase data and ISR-render thousands of


### PR DESCRIPTION
## Summary

Wave 1 of the new **GI-stream** (Global Investing — outbound hub for AU residents investing globally). Mirrors `/foreign-investment` (inbound). Surface-area ratio was ~50:1 in favour of inbound; this PR ships the hub foundation so the loop can ship the rest via GI-XX queue items.

- **`/global-investing`** hub page — two-track explainer (Track A direct foreign brokers vs Track B AU-listed exposure), 8 sub-pillar cards, 8 hub FAQs with FAQPage + Breadcrumb JSON-LD, ISR 86400s, cross-link to `/foreign-investment` as the inbound counterpart, `GENERAL_ADVICE_WARNING` compliance footer.
- **`docs/audits/GLOBAL_INVESTING_PROGRAM.md`** — full program spec (URL map, redirect map, monetisation matrix per the 12 levers, compliance keys, build sequencing, Definition of Done, anti-goals). Source of truth for every GI-XX iteration.
- **`docs/audits/REMEDIATION_QUEUE.md`** — new `### Stream GI` section with ~60 queue items (GI-01..GI-141) covering all 4 waves so the loop picks up the rest autonomously.
- **`components/Header.tsx`** + **`app/sitemap.ts`** — surface the new hub in nav and sitemap (registry-driven once Y-stream lands; hand-edit until then).

## Out of scope (queued for the loop, in spec §3 gate order)

- **GI-02** cornerstone `/global-investing/shares/us` (3-5k word page) — next loop iteration.
- **GI-03** 301 redirects from `/best/us-shares*`, `/etfs/us-exposure`, `/etfs/international` — **GATED** until GI-02 + GI-08 land in production. Flipping redirects before target is genuinely better content costs ranking.
- **GI-04** new `lib/compliance.ts` keys (Tier C — announced in queue).
- **GI-09** `broker_markets` join table migration (Tier C — announced).

## Tier

**Tier A** (page UI + content + docs). Calculators in Wave 3 (GI-82, GI-84, GI-122) will require tax-agent review per spec §6.

## Test plan

- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean on touched files (lint-staged hook ran on commit)
- [ ] Hub page renders (verified by reviewer in preview)
- [ ] Breadcrumb JSON-LD validates (Rich Results Test)
- [ ] FAQPage JSON-LD validates (Rich Results Test)
- [ ] All sub-pillar links resolve (some 404 expected — those are queued GI-XX items)
- [ ] `/foreign-investment` cross-link present and functional
- [ ] Mega-menu shows new "Global Investing for Australians" entry above "Foreign Investment Hub"
- [ ] `/sitemap.xml` includes `/global-investing` at priority 0.85+
- [ ] No new console warnings on page load

## Reference

- Full spec: `docs/audits/GLOBAL_INVESTING_PROGRAM.md`
- Hub blueprint: `docs/audits/HUB_BLUEPRINT.md` §2 (anatomy), §3 (HubConfig schema), §6 (DoD)
- Stream GI in queue: `docs/audits/REMEDIATION_QUEUE.md` (search "Stream GI")

🤖 Generated with [Claude Code](https://claude.com/claude-code)