### PR TITLE
feat(foreign-investment): animate + dismiss country recommendation card after CTA click

### DIFF
--- a/components/foreign-investment/IntentCountryRecommendation.tsx
+++ b/components/foreign-investment/IntentCountryRecommendation.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
 import { getIntentCountry, intentCountryMeta } from "@/lib/intent-context";
+import IntentCountryRecommendationCard from "./IntentCountryRecommendationCard";
 
 type SurfaceKind = "compare" | "advisors" | "invest";
 
@@ -44,32 +44,14 @@ export default async function IntentCountryRecommendation({
   if (!rec) return null;
 
   return (
-    <div className="bg-amber-50 border border-amber-200 rounded-2xl p-4 md:p-5 my-4">
-      <div className="flex items-start justify-between gap-4 flex-wrap">
-        <div className="flex items-start gap-3">
-          <span aria-hidden className="text-2xl leading-none mt-0.5">
-            {meta.flag}
-          </span>
-          <div>
-            <p className="text-xs font-extrabold uppercase tracking-wider text-amber-700 mb-0.5">
-              Recommended for {meta.label}
-            </p>
-            <h3 className="text-base font-bold text-slate-900 mb-1">
-              {rec.title}
-            </h3>
-            <p className="text-sm text-slate-700 max-w-xl leading-snug">
-              {rec.body}
-            </p>
-          </div>
-        </div>
-        <Link
-          href={rec.href}
-          className="shrink-0 px-4 py-2 bg-amber-500 hover:bg-amber-400 text-slate-900 font-bold text-sm rounded-lg transition-colors"
-        >
-          {rec.cta} &rarr;
-        </Link>
-      </div>
-    </div>
+    <IntentCountryRecommendationCard
+      flag={meta.flag}
+      audienceLabel={meta.label}
+      title={rec.title}
+      body={rec.body}
+      href={rec.href}
+      cta={rec.cta}
+    />
   );
 }
 

--- a/components/foreign-investment/IntentCountryRecommendationCard.tsx
+++ b/components/foreign-investment/IntentCountryRecommendationCard.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+interface Props {
+  flag: string;
+  audienceLabel: string;
+  title: string;
+  body: string;
+  href: string;
+  cta: string;
+}
+
+/**
+ * Interactive presentation layer for IntentCountryRecommendation.
+ *
+ * The server component resolves the user's intent country and decides
+ * whether to render at all; this client component handles three things
+ * that need browser state:
+ *
+ *   1. Self-dismissal once the recommendation has already been acted on
+ *      (URL matches the CTA target — filter or pre-filtered destination
+ *      already in effect). Without this, the card kept showing after
+ *      "FIRB-eligible only" had been applied, which left users unsure
+ *      whether the click had taken effect.
+ *
+ *   2. A confirmation animation on click — swap the CTA to a "✓ Applied"
+ *      pill, then fade + collapse the card so the user can see the
+ *      action took effect before the URL transition completes.
+ *
+ *   3. Soft client-side navigation that preserves scroll, so users stay
+ *      anchored to the listings grid rather than getting bumped to top.
+ */
+export default function IntentCountryRecommendationCard({
+  flag,
+  audienceLabel,
+  title,
+  body,
+  href,
+  cta,
+}: Props) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const [, startTransition] = useTransition();
+  const [applied, setApplied] = useState(false);
+
+  // Already in the recommended state? Don't render at all. This catches
+  // both query-param targets (/invest?firb=eligible) and pathname targets
+  // (/compare/non-residents).
+  if (matchesTarget(href, pathname, searchParams)) return null;
+
+  const onApply = () => {
+    if (applied) return;
+    setApplied(true);
+    // Run the route change inside a transition so the animation isn't
+    // interrupted by Suspense boundaries flashing to fallbacks.
+    setTimeout(() => {
+      startTransition(() => {
+        router.push(href, { scroll: false });
+      });
+    }, 450);
+  };
+
+  return (
+    <div
+      className={`overflow-hidden transition-all duration-500 ease-out ${
+        applied ? "opacity-0 max-h-0 my-0 scale-[0.98]" : "opacity-100 max-h-[400px] my-4 scale-100"
+      }`}
+      aria-hidden={applied}
+    >
+      <div className="bg-amber-50 border border-amber-200 rounded-2xl p-4 md:p-5">
+        <div className="flex items-start justify-between gap-4 flex-wrap">
+          <div className="flex items-start gap-3">
+            <span aria-hidden className="text-2xl leading-none mt-0.5">
+              {flag}
+            </span>
+            <div>
+              <p className="text-xs font-extrabold uppercase tracking-wider text-amber-700 mb-0.5">
+                Recommended for {audienceLabel}
+              </p>
+              <h3 className="text-base font-bold text-slate-900 mb-1">{title}</h3>
+              <p className="text-sm text-slate-700 max-w-xl leading-snug">{body}</p>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onApply}
+            disabled={applied}
+            className={`shrink-0 px-4 py-2 font-bold text-sm rounded-lg transition-all duration-300 ease-out ${
+              applied
+                ? "bg-emerald-500 text-white scale-105"
+                : "bg-amber-500 hover:bg-amber-400 text-slate-900"
+            }`}
+            aria-live="polite"
+          >
+            {applied ? (
+              <span className="inline-flex items-center gap-1.5">
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" />
+                </svg>
+                Applied
+              </span>
+            ) : (
+              <>{cta} &rarr;</>
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function matchesTarget(
+  href: string,
+  pathname: string,
+  searchParams: URLSearchParams,
+): boolean {
+  // Parse against a dummy origin so URL accepts both "/foo?bar=baz" and
+  // "/foo" without requiring an absolute href.
+  const target = new URL(href, "https://x");
+
+  if (target.pathname !== pathname) return false;
+
+  // Every query param on the target must already be present and equal in
+  // the current URL. Extra params on the current URL are fine (the user
+  // may have layered other filters).
+  for (const [key, value] of target.searchParams.entries()) {
+    if (searchParams.get(key) !== value) return false;
+  }
+  return true;
+}


### PR DESCRIPTION
## Summary
- Recommended-for-country cards on `/compare`, `/advisors` and `/invest` already point at pre-filtered destinations (e.g. `/invest?firb=eligible`). On click the URL changed and the filter applied — but the card sat there unchanged, so users couldn't tell whether the action had taken effect and ended up clicking again.
- New client component `IntentCountryRecommendationCard` adds two behaviours:
  1. **Self-dismissal** once the recommendation is in effect. The card parses its CTA href and compares against current pathname + searchParams; if the recommended state is already active, it returns `null`. Catches both query-param targets (`/invest?firb=eligible`) and pathname targets (`/compare/non-residents`).
  2. **Confirmation animation** on click. CTA pill swaps to a green "✓ Applied" badge, the card fades + collapses over ~500ms, then route change fires inside `startTransition` so Suspense boundaries don't flash to fallbacks mid-animation.
- `IntentCountryRecommendation` stays a server component (still resolves intent country from cookies + builds copy) and delegates the interactive UI to the new client child.

## Test plan
- [ ] Set intent country to UAE: visit `/foreign-investment/united-arab-emirates` once so the cookie is set.
- [ ] Visit `/invest`. The "Recommended for UAE investors / FIRB-eligible only" card should appear at the top.
- [ ] Click "FIRB-eligible only →". Pill should swap to "✓ Applied" in emerald, the card should fade + collapse over ~500ms, the URL should update to `/invest?firb=eligible`, listings should filter, and on the next render the card should be gone (because `firb=eligible` is now active in the URL).
- [ ] Direct-load `/invest?firb=eligible` with the UAE cookie set — card should never appear (already-applied state).
- [ ] Repeat on `/compare` (CTA → `/compare/non-residents`) and `/advisors` (CTA → `/advisors/international-tax-specialists`) to confirm the pathname-target detection works.
- [ ] CI: type-check + tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)