### PR TITLE
fix(a): A-91+A-92 — remove service-role key from marketplace/notify auth [audit remediation]

### DIFF
--- a/__tests__/api/admin-marketplace-campaign-notify.test.ts
+++ b/__tests__/api/admin-marketplace-campaign-notify.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const mockAdminFrom = vi.fn();
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+
+const mockRequireAdmin = vi.fn();
+vi.mock("@/lib/require-admin", () => ({
+  requireAdmin: mockRequireAdmin,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: () => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn() }),
+}));
+
+import { POST } from "@/app/api/admin/marketplace/campaign-notify/route";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function makeRequest(body?: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/admin/marketplace/campaign-notify", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+}
+
+function makeValidBody(overrides = {}) {
+  return {
+    broker_slug: "commsec",
+    type: "campaign_approved",
+    title: "Campaign Approved",
+    message: "Your campaign has been approved.",
+    ...overrides,
+  };
+}
+
+function makeInsertBuilder(data: unknown = { id: 99 }, error: unknown = null) {
+  return {
+    insert: vi.fn().mockReturnThis(),
+    select: vi.fn().mockReturnThis(),
+    single: vi.fn(() => Promise.resolve({ data, error })),
+  };
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("POST /api/admin/marketplace/campaign-notify", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdmin.mockResolvedValue({ ok: true, email: "admin@invest.com.au", userId: "u1" });
+  });
+
+  afterEach(() => {
+    delete process.env.RESEND_API_KEY;
+  });
+
+  it("returns 401 when requireAdmin denies", async () => {
+    mockRequireAdmin.mockResolvedValue({
+      ok: false,
+      response: new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 }),
+    });
+    const res = await POST(makeRequest(makeValidBody()));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when required fields are missing", async () => {
+    const res = await POST(makeRequest({ broker_slug: "commsec" }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/required/i);
+  });
+
+  it("returns 200 with notification_id on success", async () => {
+    mockAdminFrom.mockReturnValue(makeInsertBuilder({ id: 99 }));
+    const res = await POST(makeRequest(makeValidBody()));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.success).toBe(true);
+    expect(data.notification_id).toBe(99);
+  });
+
+  it("inserts notification with correct fields", async () => {
+    const builder = makeInsertBuilder({ id: 1 });
+    mockAdminFrom.mockReturnValue(builder);
+    await POST(makeRequest(makeValidBody()));
+    expect(mockAdminFrom).toHaveBeenCalledWith("broker_notifications");
+    expect(builder.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        broker_slug: "commsec",
+        type: "campaign_approved",
+        title: "Campaign Approved",
+        is_read: false,
+        email_sent: false,
+      }),
+    );
+  });
+
+  it("returns 500 when insert fails", async () => {
+    mockAdminFrom.mockReturnValue(makeInsertBuilder(null, { message: "DB error" }));
+    const res = await POST(makeRequest(makeValidBody()));
+    expect(res.status).toBe(500);
+  });
+
+  it("does not call Resend when send_email is false", async () => {
+    process.env.RESEND_API_KEY = "re_test";
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue(new Response("{}", { status: 200 }));
+    mockAdminFrom.mockReturnValue(makeInsertBuilder({ id: 1 }));
+    await POST(makeRequest(makeValidBody({ send_email: false })));
+    // fetch would only be called for Resend if send_email=true + account found
+    // With send_email=false, no Resend fetch
+    const resendCalls = fetchSpy.mock.calls.filter(([url]) =>
+      typeof url === "string" && url.includes("resend.com"),
+    );
+    expect(resendCalls).toHaveLength(0);
+    fetchSpy.mockRestore();
+  });
+
+  it("skips email when RESEND_API_KEY is not set", async () => {
+    delete process.env.RESEND_API_KEY;
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue(new Response("{}", { status: 200 }));
+    mockAdminFrom.mockReturnValue(makeInsertBuilder({ id: 1 }));
+    await POST(makeRequest(makeValidBody({ send_email: true })));
+    const resendCalls = fetchSpy.mock.calls.filter(([url]) =>
+      typeof url === "string" && url.includes("resend.com"),
+    );
+    expect(resendCalls).toHaveLength(0);
+    fetchSpy.mockRestore();
+  });
+});

--- a/app/admin/marketplace/campaigns/page.tsx
+++ b/app/admin/marketplace/campaigns/page.tsx
@@ -114,32 +114,19 @@ export default function AdminCampaignsPage() {
         budget_exhausted: `Your campaign "${campaign.name}" has exhausted its budget. Top up your wallet to resume.`,
       };
 
-      supabase.from("broker_notifications").insert({
-        broker_slug: campaign.broker_slug,
-        type: notifTypes[newStatus],
-        title: notifTitles[newStatus],
-        message: notifMessages[newStatus],
-        link: "/broker-portal/campaigns",
-        is_read: false,
-        email_sent: false,
-      }).then(() => {
-        // Also send email notification
-        fetch("/api/marketplace/notify", {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "x-internal-key": "browser-admin",
-          },
-          body: JSON.stringify({
-            broker_slug: campaign.broker_slug,
-            type: notifTypes[newStatus],
-            title: notifTitles[newStatus],
-            message: notifMessages[newStatus],
-            link: "/broker-portal/campaigns",
-            send_email: true,
-          }),
-        }).catch((err) => log.error("campaign notification failed", { err: err instanceof Error ? err.message : String(err) }));
-      });
+      // admin-auth route — inserts notification via admin client + sends email
+      fetch("/api/admin/marketplace/campaign-notify", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          broker_slug: campaign.broker_slug,
+          type: notifTypes[newStatus],
+          title: notifTitles[newStatus],
+          message: notifMessages[newStatus],
+          link: "/broker-portal/campaigns",
+          send_email: true,
+        }),
+      }).catch((err) => log.error("campaign notification failed", { err: err instanceof Error ? err.message : String(err) }));
     }
 
     await loadCampaigns();
@@ -204,14 +191,16 @@ export default function AdminCampaignsPage() {
         };
         const n = notifMap[newStatus];
         if (n) {
-          await supabase.from("broker_notifications").insert({
-            broker_slug: campaign.broker_slug,
-            type: n.type,
-            title: n.title,
-            message: n.message,
-            link: "/broker-portal/campaigns",
-            is_read: false,
-            email_sent: false,
+          // admin-auth route — inserts notification via admin client (no email for bulk actions)
+          await fetch("/api/admin/marketplace/campaign-notify", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              broker_slug: campaign.broker_slug,
+              ...n,
+              link: "/broker-portal/campaigns",
+              send_email: false,
+            }),
           });
         }
       }

--- a/app/api/admin/marketplace/campaign-notify/route.ts
+++ b/app/api/admin/marketplace/campaign-notify/route.ts
@@ -1,0 +1,113 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { requireAdmin } from "@/lib/require-admin";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+
+const log = logger("admin-campaign-notify");
+
+const NotifyBody = z.object({
+  broker_slug: z.string().min(1),
+  type: z.string().min(1),
+  title: z.string().min(1),
+  message: z.string().min(1),
+  link: z.string().optional(),
+  send_email: z.boolean().optional().default(false),
+});
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/**
+ * POST /api/admin/marketplace/campaign-notify
+ * Admin-session–gated endpoint for inserting broker notifications + optional email.
+ * Used by the admin campaigns page instead of direct browser-client DB writes,
+ * which fail against broker_notifications' deny-all RLS policy.
+ */
+export async function POST(req: NextRequest) {
+  const guard = await requireAdmin();
+  if (!guard.ok) return guard.response;
+
+  const parsed = NotifyBody.safeParse(await req.json());
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Missing required fields" }, { status: 400 });
+  }
+
+  const { broker_slug, type, title, message, link, send_email } = parsed.data;
+  const supabaseAdmin = createAdminClient();
+
+  const { data: notification, error } = await supabaseAdmin
+    .from("broker_notifications")
+    .insert({
+      broker_slug,
+      type,
+      title,
+      message,
+      link: link ?? null,
+      is_read: false,
+      email_sent: false,
+    })
+    .select("id")
+    .single();
+
+  if (error) {
+    log.error("insert failed", { error: error.message });
+    return NextResponse.json({ error: "Failed to create notification" }, { status: 500 });
+  }
+
+  if (send_email && process.env.RESEND_API_KEY) {
+    const { data: account } = await supabaseAdmin
+      .from("broker_accounts")
+      .select("email, full_name, company_name")
+      .eq("broker_slug", broker_slug)
+      .eq("status", "active")
+      .maybeSingle();
+
+    if (account?.email) {
+      const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "https://invest.com.au";
+      try {
+        await fetch("https://api.resend.com/emails", {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${process.env.RESEND_API_KEY}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            from: "Invest.com.au <partners@invest.com.au>",
+            to: [account.email],
+            subject: `[Partner Portal] ${String(title).slice(0, 100)}`,
+            html: `
+              <div style="font-family: 'Inter', system-ui, sans-serif; max-width: 560px; margin: 0 auto;">
+                <div style="background: #0f172a; padding: 16px 24px; border-radius: 12px 12px 0 0;">
+                  <span style="color: #f59e0b; font-weight: 800; font-size: 14px;">Invest.com.au</span>
+                  <span style="color: #94a3b8; font-size: 12px;"> · Partner Portal</span>
+                </div>
+                <div style="background: #fff; border: 1px solid #e2e8f0; border-top: none; padding: 24px; border-radius: 0 0 12px 12px;">
+                  <h2 style="margin: 0 0 8px; font-size: 18px; color: #0f172a;">${escapeHtml(String(title))}</h2>
+                  <p style="margin: 0 0 16px; font-size: 14px; color: #475569; line-height: 1.6;">${escapeHtml(String(message))}</p>
+                  ${link ? `<a href="${baseUrl}${link}" style="display: inline-block; padding: 10px 20px; background: #0f172a; color: #fff; text-decoration: none; border-radius: 8px; font-size: 13px; font-weight: 600;">View in Portal →</a>` : ""}
+                  <p style="margin: 24px 0 0; font-size: 12px; color: #94a3b8;">
+                    You received this because you have an active partner account on Invest.com.au.
+                  </p>
+                </div>
+              </div>
+            `,
+          }),
+        });
+        await supabaseAdmin
+          .from("broker_notifications")
+          .update({ email_sent: true })
+          .eq("id", notification.id);
+      } catch (err) {
+        log.error("email send failed", { err });
+      }
+    }
+  }
+
+  return NextResponse.json({ success: true, notification_id: notification.id });
+}

--- a/app/api/marketplace/notify/route.ts
+++ b/app/api/marketplace/notify/route.ts
@@ -22,15 +22,15 @@ function escapeHtml(str: string): string {
 
 /**
  * Internal notification API — sends broker notifications and optionally emails.
- * Called by other API routes / cron jobs / admin actions.
- * Requires SUPABASE_SERVICE_ROLE_KEY (server-side only).
+ * Called by other API routes / cron jobs. Requires INTERNAL_API_KEY.
+ * Admin-UI calls use /api/admin/marketplace/campaign-notify (requireAdmin auth).
  */
 export async function POST(req: NextRequest) {
   try {
     const supabaseAdmin = createAdminClient();
     // Simple auth — internal calls only (check for internal API key or service role)
     const authHeader = req.headers.get("x-internal-key");
-    if (authHeader !== process.env.INTERNAL_API_KEY && authHeader !== process.env.SUPABASE_SERVICE_ROLE_KEY) {
+    if (authHeader !== process.env.INTERNAL_API_KEY) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 


### PR DESCRIPTION
## Summary

- **A-91**: Remove `SUPABASE_SERVICE_ROLE_KEY` as a bearer-equivalent auth value from `/api/marketplace/notify`. Using a service-role key as a request credential is a security risk — any proxy, log, or cache that captures the header achieves total DB compromise. Now only `INTERNAL_API_KEY` is accepted.
- **A-92**: The admin campaigns page was doubly broken: (1) direct `broker_notifications` insert via browser client silently failed (deny-all RLS); (2) the fetch to `/api/marketplace/notify` with `"x-internal-key": "browser-admin"` always returned 401. Created `/api/admin/marketplace/campaign-notify` with `requireAdmin()` auth + admin client so campaign status-change notifications actually reach brokers.

## Changed files

- `app/api/marketplace/notify/route.ts` — 1-line fix removing service-role OR-branch
- `app/api/admin/marketplace/campaign-notify/route.ts` — new admin-gated notification route
- `app/admin/marketplace/campaigns/page.tsx` — replaced two broken notification blocks with calls to new route
- `__tests__/api/admin-marketplace-campaign-notify.test.ts` — 7 tests covering auth gate, validation, insert, 500, email skip paths

## Test plan

- [ ] CI green on `Lint · Type-check · Test · Build`
- [ ] `/api/marketplace/notify` now rejects any request using a service-role key as `x-internal-key`
- [ ] Admin campaigns page status changes (approve/reject/pause) correctly insert broker notifications and send emails

Refs: #217
Audit: docs/audits/REMEDIATION_QUEUE.md items A-91, A-92

---
_Generated by [Claude Code](https://claude.ai/code/session_01DUMm362c1xA99NuzXLCui7)_