### PR TITLE
fix(a): A-93 — migrate admin routes from open-coded CRON_SECRET to requireCronAuth [audit remediation]

### DIFF
--- a/__tests__/api/admin-content-revalidate-auth.test.ts
+++ b/__tests__/api/admin-content-revalidate-auth.test.ts
@@ -1,0 +1,230 @@
+/**
+ * A-93 auth migration tests — verify that requireCronAuth guards the three
+ * admin routes that previously used open-coded CRON_SECRET comparisons.
+ *
+ * Scope: auth rejection only. Full integration tests for business logic are
+ * out of scope (generate-draft calls Anthropic, calendar hits Supabase, etc).
+ * What matters here is that (a) missing auth → 401, (b) wrong key → 401,
+ * (c) valid CRON_SECRET → request proceeds past auth, (d) service-role key
+ * is no longer accepted by admin/revalidate (regression guard for A-91-style
+ * credential exposure).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({
+    from: vi.fn(() => ({
+      select: vi.fn().mockReturnThis(),
+      insert: vi.fn().mockReturnThis(),
+      update: vi.fn().mockReturnThis(),
+      delete: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: null, error: null }),
+    })),
+  })),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidateTag: vi.fn(),
+}));
+
+// Stub fetch so generate-draft doesn't actually call Anthropic.
+const mockFetch = vi.fn().mockResolvedValue(
+  new Response(JSON.stringify({ content: [{ type: "text", text: "draft" }] }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  }),
+);
+vi.stubGlobal("fetch", mockFetch);
+
+import { POST as generateDraftPOST } from "@/app/api/admin/content/generate-draft/route";
+import {
+  GET as calendarGET,
+  POST as calendarPOST,
+} from "@/app/api/admin/content/calendar/route";
+import { POST as revalidatePOST } from "@/app/api/admin/revalidate/route";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+const VALID_CRON_SECRET = "test-cron-secret-long-enough-16";
+const SERVICE_ROLE_KEY = "fake-service-role-key-that-must-not-work";
+
+function makeRequest(
+  method: string,
+  url: string,
+  body?: unknown,
+  authHeader?: string,
+): NextRequest {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (authHeader !== undefined) headers["authorization"] = authHeader;
+  return new NextRequest(url, {
+    method,
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+}
+
+// ── generate-draft ─────────────────────────────────────────────────────────────
+
+describe("POST /api/admin/content/generate-draft — auth (A-93)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = VALID_CRON_SECRET;
+    process.env.ANTHROPIC_API_KEY = "test-api-key";
+  });
+
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+    delete process.env.ANTHROPIC_API_KEY;
+  });
+
+  it("returns 401 when no auth header", async () => {
+    const res = await generateDraftPOST(
+      makeRequest("POST", "http://localhost/api/admin/content/generate-draft", { calendarId: 1 }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when wrong key", async () => {
+    const res = await generateDraftPOST(
+      makeRequest("POST", "http://localhost/api/admin/content/generate-draft", { calendarId: 1 }, "Bearer wrong-key"),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 500 when CRON_SECRET not set (fail-closed)", async () => {
+    delete process.env.CRON_SECRET;
+    const res = await generateDraftPOST(
+      makeRequest("POST", "http://localhost/api/admin/content/generate-draft", { calendarId: 1 }, `Bearer ${VALID_CRON_SECRET}`),
+    );
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data.error).toMatch(/misconfigured/i);
+  });
+
+  it("passes auth with valid CRON_SECRET", async () => {
+    const res = await generateDraftPOST(
+      makeRequest("POST", "http://localhost/api/admin/content/generate-draft", { calendarId: 1 }, `Bearer ${VALID_CRON_SECRET}`),
+    );
+    // Auth passed — we get past the 401 gate (business logic may fail without real DB)
+    expect(res.status).not.toBe(401);
+  });
+});
+
+// ── calendar ───────────────────────────────────────────────────────────────────
+
+describe("GET /api/admin/content/calendar — auth (A-93)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = VALID_CRON_SECRET;
+  });
+
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+  });
+
+  it("returns 401 when no auth header", async () => {
+    const res = await calendarGET(
+      makeRequest("GET", "http://localhost/api/admin/content/calendar"),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when wrong key", async () => {
+    const res = await calendarGET(
+      makeRequest("GET", "http://localhost/api/admin/content/calendar", undefined, "Bearer wrong-key"),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("passes auth with valid CRON_SECRET", async () => {
+    const res = await calendarGET(
+      makeRequest("GET", "http://localhost/api/admin/content/calendar", undefined, `Bearer ${VALID_CRON_SECRET}`),
+    );
+    expect(res.status).not.toBe(401);
+  });
+});
+
+describe("POST /api/admin/content/calendar — auth (A-93)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = VALID_CRON_SECRET;
+  });
+
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+  });
+
+  it("returns 401 when no auth header", async () => {
+    const res = await calendarPOST(
+      makeRequest("POST", "http://localhost/api/admin/content/calendar", { title: "Test" }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("passes auth with valid CRON_SECRET", async () => {
+    const res = await calendarPOST(
+      makeRequest("POST", "http://localhost/api/admin/content/calendar", { title: "Test" }, `Bearer ${VALID_CRON_SECRET}`),
+    );
+    expect(res.status).not.toBe(401);
+  });
+});
+
+// ── admin/revalidate ───────────────────────────────────────────────────────────
+
+describe("POST /api/admin/revalidate — auth (A-93, A-91 regression)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = VALID_CRON_SECRET;
+    process.env.SUPABASE_SERVICE_ROLE_KEY = SERVICE_ROLE_KEY;
+  });
+
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+  });
+
+  it("returns 401 when no auth header", async () => {
+    const res = await revalidatePOST(
+      makeRequest("POST", "http://localhost/api/admin/revalidate", { tags: ["brokers"] }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when wrong key", async () => {
+    const res = await revalidatePOST(
+      makeRequest("POST", "http://localhost/api/admin/revalidate", { tags: ["brokers"] }, "Bearer bad-key"),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when service-role key used (regression: must not be accepted)", async () => {
+    const res = await revalidatePOST(
+      makeRequest("POST", "http://localhost/api/admin/revalidate", { tags: ["brokers"] }, `Bearer ${SERVICE_ROLE_KEY}`),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when tags array is missing", async () => {
+    const res = await revalidatePOST(
+      makeRequest("POST", "http://localhost/api/admin/revalidate", {}, `Bearer ${VALID_CRON_SECRET}`),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 200 and calls revalidateTag on valid request", async () => {
+    const { revalidateTag } = await import("next/cache");
+    const res = await revalidatePOST(
+      makeRequest("POST", "http://localhost/api/admin/revalidate", { tags: ["brokers", "articles"] }, `Bearer ${VALID_CRON_SECRET}`),
+    );
+    expect(res.status).toBe(200);
+    expect(revalidateTag).toHaveBeenCalledWith("brokers", expect.anything());
+    expect(revalidateTag).toHaveBeenCalledWith("articles", expect.anything());
+  });
+});

--- a/app/api/admin/content/calendar/route.ts
+++ b/app/api/admin/content/calendar/route.ts
@@ -1,5 +1,6 @@
 import { createAdminClient } from "@/lib/supabase/admin";
 import { NextRequest, NextResponse } from "next/server";
+import { requireCronAuth } from "@/lib/cron-auth";
 
 export const runtime = "edge";
 
@@ -7,18 +8,13 @@ function getSupabase() {
   return createAdminClient();
 }
 
-function authorize(req: NextRequest): boolean {
-  return req.headers.get("authorization") === `Bearer ${process.env.CRON_SECRET}`;
-}
-
 /**
  * GET /api/admin/content/calendar
  * Query params: ?status=planned&limit=50
  */
 export async function GET(req: NextRequest) {
-  if (!authorize(req)) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const unauth = requireCronAuth(req);
+  if (unauth) return unauth;
 
   const url = new URL(req.url);
   const status = url.searchParams.get("status");
@@ -48,9 +44,8 @@ export async function GET(req: NextRequest) {
  * Create a new content calendar item
  */
 export async function POST(req: NextRequest) {
-  if (!authorize(req)) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const unauth = requireCronAuth(req);
+  if (unauth) return unauth;
 
   const body = await req.json();
   const supabase = getSupabase();
@@ -89,9 +84,8 @@ export async function POST(req: NextRequest) {
  * Update a content calendar item: { id, ...fields }
  */
 export async function PATCH(req: NextRequest) {
-  if (!authorize(req)) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const unauth = requireCronAuth(req);
+  if (unauth) return unauth;
 
   const body = await req.json();
   const { id, ...updates } = body;
@@ -120,9 +114,8 @@ export async function PATCH(req: NextRequest) {
  * Body: { id: number }
  */
 export async function DELETE(req: NextRequest) {
-  if (!authorize(req)) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const unauth = requireCronAuth(req);
+  if (unauth) return unauth;
 
   const { id } = await req.json();
   if (!id) {

--- a/app/api/admin/content/generate-draft/route.ts
+++ b/app/api/admin/content/generate-draft/route.ts
@@ -1,6 +1,7 @@
 import { createAdminClient } from "@/lib/supabase/admin";
 import { NextRequest, NextResponse } from "next/server";
 import { slugify } from "@/lib/utils";
+import { requireCronAuth } from "@/lib/cron-auth";
 
 export const runtime = "edge";
 export const maxDuration = 120;
@@ -13,10 +14,8 @@ export const maxDuration = 120;
  * Pulls broker data from the database to give the AI real fee data context.
  */
 export async function POST(req: NextRequest) {
-  const authHeader = req.headers.get("authorization");
-  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const unauth = requireCronAuth(req);
+  if (unauth) return unauth;
 
   const apiKey = process.env.ANTHROPIC_API_KEY;
   if (!apiKey) {

--- a/app/api/admin/revalidate/route.ts
+++ b/app/api/admin/revalidate/route.ts
@@ -1,6 +1,7 @@
 import { revalidateTag } from "next/cache";
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
+import { requireCronAuth } from "@/lib/cron-auth";
 
 /**
  * POST /api/admin/revalidate
@@ -8,8 +9,7 @@ import { z } from "zod";
  * On-demand cache invalidation endpoint. Call this from the admin dashboard
  * (or Supabase webhooks) after content is updated.
  *
- * Auth: requires a Bearer token matching either SUPABASE_SERVICE_ROLE_KEY
- * or CRON_SECRET.
+ * Auth: requires a Bearer token matching CRON_SECRET (via requireCronAuth).
  *
  * Body: { tags: string[] }
  *
@@ -34,23 +34,16 @@ import { z } from "zod";
  *   - "quiz-questions"    — quiz questions
  *
  * Example:
- *   curl -X POST https://invest.com.au/api/admin/revalidate \
- *     -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY" \
+ *   curl -X POST https://invest-com-au.vercel.app/api/admin/revalidate \
+ *     -H "Authorization: Bearer $CRON_SECRET" \
  *     -H "Content-Type: application/json" \
  *     -d '{"tags": ["brokers", "broker-reviews"]}'
  */
 const TagsBody = z.object({ tags: z.array(z.string()).min(1) });
 
 export async function POST(req: NextRequest) {
-  const authHeader = req.headers.get("authorization");
-  const token = authHeader?.replace("Bearer ", "");
-
-  if (
-    token !== process.env.SUPABASE_SERVICE_ROLE_KEY &&
-    token !== process.env.CRON_SECRET
-  ) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const unauth = requireCronAuth(req);
+  if (unauth) return unauth;
 
   let rawBody: unknown;
   try {


### PR DESCRIPTION
## Summary

Three admin routes used open-coded `authHeader !== \`Bearer ${CRON_SECRET}\`` comparisons that lack the entropy floor and fail-closed guard that `requireCronAuth` provides. A short or missing `CRON_SECRET` env var would reduce the guard to a trivially-bypassed literal. `admin/revalidate` also accepted `SUPABASE_SERVICE_ROLE_KEY` as a bearer token — same A-91-class credential exposure.

**Routes migrated:**
- `app/api/admin/content/generate-draft/route.ts` — edge runtime, POST
- `app/api/admin/content/calendar/route.ts` — edge runtime, GET/POST/PATCH/DELETE (local `authorize()` helper removed)
- `app/api/admin/revalidate/route.ts` — POST; also drops `SUPABASE_SERVICE_ROLE_KEY` from OR-auth (service-role as bearer removed)

**Not migrated (false positive / separate scope):**
- `automation/trigger/route.ts` — already uses Supabase session cookie auth; line 56 checks CRON_SECRET is *configured* before using it as an outbound credential, not as route auth
- `foreign-investment/seed/route.ts` + `revalidate/route.ts` — use `INTERNAL_API_KEY`, not `CRON_SECRET`; separate queue items

**Tests:** 11 cases in `__tests__/api/admin-content-revalidate-auth.test.ts` covering 401 on no/wrong header, fail-closed on missing secret, service-role key regression guard, and 200 success path.

Audit: `docs/audits/codebase-health-2026-04-24.md`
Queue item: A-93
Tracking: #214

---
_Generated by [Claude Code](https://claude.ai/code/session_01DUMm362c1xA99NuzXLCui7)_