### PR TITLE
feat(q): Q-10..Q-12 — ACL revocation, DSAR, secret rotation log

### DIFF
--- a/docs/runbooks/acl-revocation.md
+++ b/docs/runbooks/acl-revocation.md
@@ -1,0 +1,138 @@
+# ACL / AFSL revocation incident
+
+## What just fired
+
+The Australian Financial Services Licence (AFSL) or Australian Credit
+Licence (ACL) that covers invest.com.au — or a key advisor's
+individual licence — has been suspended, cancelled, or revoked by
+ASIC. Or we've received a formal notice that revocation proceedings
+have commenced.
+
+> **Note:** As of 2026-05, invest.com.au operates as a financial
+> information platform under a referral model, not as a licensed
+> financial advice provider. The platform refers users to licensed
+> advisors; the primary licence risk is at the advisor level (an
+> advisor's individual AFSL or ACL is revoked), not the platform
+> level. This runbook covers both scenarios.
+
+## Legal clock
+
+ASIC may act immediately on suspension (effective the day of the
+notice). Unlike a court injunction, there is no automatic stay.
+You have **no grace period** — the licence ceases on the stated
+date.
+
+## Step 1 — Contain (within 2 hours of notice)
+
+### If a platform-level licence is affected
+
+> This scenario is unlikely in the current structure but documented
+> for completeness.
+
+1. Take the platform offline immediately (Vercel → pause deployments).
+2. Contact external legal counsel — do not issue any public statement
+   without legal review.
+3. Notify Stripe — financial services suspensions may trigger Stripe's
+   Know Your Customer (KYC) re-review. Contact Stripe risk team
+   proactively via `support@stripe.com`.
+4. Log the incident: date/time, ASIC notice reference number, the
+   specific condition(s) stated.
+
+### If an individual advisor's licence is revoked
+
+1. Set `professionals.status = 'suspended'` for the affected advisor:
+
+   ```sql
+   UPDATE professionals
+   SET status = 'suspended',
+       suspension_reason = 'ASIC licence revocation — [ASIC ref]',
+       suspended_at = now()
+   WHERE email = '<advisor_email>';
+   ```
+
+2. Remove the advisor's listing from all public-facing pages.
+   The `status = 'suspended'` filter is applied in listing queries —
+   verify via `WHERE status = 'active'` clauses in
+   `lib/advisor-search.ts` and related modules.
+
+3. Halt any pending lead sends to that advisor:
+
+   ```sql
+   -- Find pending leads for the advisor
+   SELECT * FROM professional_leads
+   WHERE professional_id = <advisor_id>
+     AND responded_at IS NULL;
+
+   -- Reroute or cancel them (business decision)
+   ```
+
+4. Notify any users who received a referral to that advisor in the
+   last 30 days:
+   - Use the breach-notification template in `docs/templates/` as a
+     starting point.
+   - Legal must approve the message before send.
+
+5. File an `admin_action_log` entry:
+
+   ```sql
+   INSERT INTO admin_action_log (action, details, created_at)
+   VALUES (
+     'advisor_suspended',
+     '{"reason": "ASIC licence revocation", "advisor_id": <id>, "asic_ref": "<ref>"}',
+     now()
+   );
+   ```
+
+## Step 2 — Assess and escalate
+
+1. Read the ASIC revocation notice carefully:
+   - Is it a suspension (temporary) or revocation (permanent)?
+   - Are there conditions under which the licence can be reinstated?
+   - Is the advisor required to notify their own clients directly?
+
+2. Determine the scope of exposure:
+   - How many users were referred to this advisor in the last 12 months?
+   - Are there any pending applications, reviews, or financial arrangements
+     the advisor was facilitating?
+
+3. Consult the TMD audit runbook (`tmd-coverage-gap.md`) — if this
+   advisor's services had a Target Market Determination on the platform,
+   the TMD must be removed or updated.
+
+## Step 3 — Publish disclosure (if required)
+
+ASIC RG 271 (Internal Dispute Resolution) and the Corporations Act
+may require the platform to notify users who received referrals to a
+now-unlicensed advisor. Legal determines this.
+
+If notification is required:
+- Use the job queue in batches of 100/min (Resend rate limit).
+- Send from `compliance@invest.com.au`.
+- Archive sent notifications in the `notification_log` table.
+
+## Step 4 — ASIC check integration (preventive)
+
+The `/api/cron/afsl-expiry-monitor` cron runs weekly (Monday 03:00)
+and checks advisor licence status via ASIC's public register. If it
+detects an expiry approaching (30-day window), it logs and alerts.
+Confirm this cron is healthy after the incident and that the affected
+advisor's record is flagged.
+
+## Recovery (if licence is reinstated)
+
+1. Update `professionals.status = 'active'` and clear
+   `suspension_reason`.
+2. Re-publish the advisor listing.
+3. Log the reinstatement in `admin_action_log`.
+4. Notify the advisor directly; do not automatically re-send pending
+   leads — the advisor should restart fresh.
+
+## Post-incident
+
+- Review `afsl-expiry-monitor` cron logs — did the weekly check flag
+  this before the revocation notice arrived?
+- If the monitor missed it, investigate whether ASIC's public register
+  API response was stale and file an OBS stream follow-up.
+- Update this runbook if any step was wrong or missing.
+- File an `slo_incidents` record with the advisor_id, revocation date,
+  and count of affected users.

--- a/docs/runbooks/dsar.md
+++ b/docs/runbooks/dsar.md
@@ -1,0 +1,146 @@
+# Data Subject Access Request (DSAR)
+
+## What just fired
+
+An individual has exercised their right of access under the
+**Privacy Act 1988 (Cth) Australian Privacy Principles (APP 12)**
+and requested a copy of the personal information we hold about them.
+Or they've submitted a correction request (APP 13) or deletion
+request (not a formal statutory right in Australia but common in
+practice, and mandatory under GDPR for EU residents).
+
+## Legal obligations
+
+| Right | Law | Deadline | Notes |
+|---|---|---|---|
+| Access to own data | Privacy Act APP 12 | "Reasonable time" (aim for 30 days) | Must be free; minor charges allowed if excessive |
+| Correction of data | Privacy Act APP 13 | 30 days | Notify third parties if data was shared |
+| Deletion ("right to be forgotten") | Privacy Act (no formal right) / GDPR Art 17 | 30 days (GDPR) | GDPR applies if the person is an EU resident |
+| Complaint handling | Privacy Act | 30 days to respond; 60 to resolve | OAIC can investigate unresolved complaints |
+
+Missing these deadlines may result in OAIC complaints or, for GDPR,
+fines up to €20M / 4% of annual turnover.
+
+## Step 1 — Receive and verify (within 2 business days)
+
+1. Log the request in `docs/compliance/regulatory-requests.md`
+   (create if absent): date received, requester name/email, type
+   (access/correction/deletion), deadline.
+2. Verify the requester's identity before releasing data:
+   - Request a copy of government-issued ID (email is insufficient
+     on its own — the account email could be compromised).
+   - Match the email address against `auth.users.email` and
+     `quiz_leads.email`.
+3. Acknowledge receipt within 5 business days: reply from
+   `privacy@invest.com.au` confirming we received the request and
+   stating the expected response date.
+
+## Step 2 — Extract the data (access requests)
+
+Run the following queries in Supabase SQL editor. Adjust as needed
+based on the subject's email.
+
+```sql
+-- All personal data for the subject
+SELECT
+  'auth.users'     AS source, id::text, email, created_at, last_sign_in_at::text AS updated_at FROM auth.users WHERE email = '<subject_email>'
+UNION ALL
+SELECT
+  'quiz_leads'     AS source, id::text, email, created_at::text, updated_at::text FROM quiz_leads WHERE email = '<subject_email>'
+UNION ALL
+SELECT
+  'email_captures' AS source, id::text, email, created_at::text, NULL FROM email_captures WHERE email = '<subject_email>'
+UNION ALL
+SELECT
+  'newsletter_subscribers' AS source, id::text, email, subscribed_at::text, NULL FROM newsletter_subscribers WHERE email = '<subject_email>'
+UNION ALL
+SELECT
+  'professional_leads' AS source, id::text, user_email AS email, created_at::text, NULL FROM professional_leads WHERE user_email = '<subject_email>'
+UNION ALL
+SELECT
+  'user_reviews'   AS source, id::text, email, created_at::text, NULL FROM user_reviews WHERE email = '<subject_email>';
+```
+
+Also check:
+- `admin_action_log` for any admin actions taken on the account
+- `cron_run_log` for any automated processing that referenced the email
+- IP hash fields — note these are hashed and cannot be reversed to
+  produce a specific IP address
+
+Export results as CSV via Supabase SQL editor → **Export**.
+
+## Step 3 — Respond
+
+**Access request**: Send the CSV extract(s) from `privacy@invest.com.au`
+with a plain-English cover note explaining each table and what it
+represents. Do not include internal fields that are operational
+only (e.g., `quality_score`, internal flags).
+
+**Correction request**: If the data is factually incorrect, update
+it directly in Supabase. Log the correction in `admin_action_log`.
+If third parties received the data (e.g., we sent the email to an
+advisor via `professional_leads`), notify them of the correction.
+
+**Deletion request (GDPR)**: 
+
+1. Check if there's a legal basis to retain the data (e.g.,
+   outstanding financial obligation, AUSTRAC record-keeping
+   requirement). If yes, note the basis in the response.
+2. If no retention basis, delete the records:
+
+   ```sql
+   -- Soft-delete approach (preferred for audit trail)
+   UPDATE quiz_leads SET
+     email = 'deleted-' || id || '@deleted.invalid',
+     user_name = 'Deleted User',
+     phone = NULL,
+     deleted_at = now()
+   WHERE email = '<subject_email>';
+
+   -- Repeat for each table that holds PII
+   -- professional_leads, email_captures, newsletter_subscribers,
+   -- user_reviews, auth.users (use Supabase admin dashboard for auth)
+   ```
+
+3. Log the deletion in `admin_action_log` with:
+   `{ action: 'gdpr_deletion', email_hash: sha256('<subject_email>') }`
+   (store a hash, not the email, for the audit trail).
+
+4. Note: `IP_HASH_SALT`-based hashed IPs are one-way — no deletion
+   is possible or required (they are not personal data once hashed).
+
+## Step 4 — Rejection (if applicable)
+
+You may refuse a request if:
+- Identity cannot be verified after reasonable attempts
+- The request is manifestly unfounded or excessive (excessive = same
+  person making the same request repeatedly for the same data)
+- A legal exception applies (e.g., law enforcement hold)
+
+If refusing, respond in writing within the normal deadline explaining
+the reason. The subject retains the right to complain to the OAIC.
+
+## Step 5 — Close the request
+
+1. Record the closure date and outcome in
+   `docs/compliance/regulatory-requests.md`.
+2. If data was deleted, confirm the GDPR purge cron will not
+   re-create the records (check for any derived or cached tables).
+3. Retain a copy of the correspondence (excluding the data extract)
+   for 7 years per ASIC record-keeping guidance.
+
+## Contacts
+
+| Role | Contact |
+|---|---|
+| Privacy inbox | privacy@invest.com.au |
+| OAIC (complaints, guidance) | enquiries@oaic.gov.au / 1300 363 992 |
+| External privacy legal | _TBD before go-live_ |
+
+## DSAR request log
+
+Maintain an ongoing log in `docs/compliance/regulatory-requests.md`:
+
+| Date received | Name | Type | Deadline | Status |
+|---|---|---|---|---|
+| — | — | — | — | — |

--- a/docs/runbooks/secret-rotation-log.md
+++ b/docs/runbooks/secret-rotation-log.md
@@ -1,0 +1,60 @@
+# Secret rotation log
+
+Append a row each time a production secret is rotated. This log
+satisfies the SOC 2 CC6.1 evidence requirement (access credentials
+are regularly rotated and the rotation is documented).
+
+Cross-reference: `secret-rotation.md` has the rotation procedure
+for each secret type.
+
+---
+
+## Log format
+
+Each entry records:
+
+| Field | Description |
+|---|---|
+| Date | ISO date the rotation was completed (YYYY-MM-DD) |
+| Secret | Env var name (e.g., `STRIPE_SECRET_KEY`) |
+| Reason | Routine / Suspected compromise / Incident |
+| Rotated by | Operator name or "loop" for automated rotation |
+| Vercel updated | ✓ / ✗ |
+| Consumers updated | ✓ / ✗ (cron schedules, webhooks, etc.) |
+| Notes | Any caveats (brief downtime, downstream impact) |
+
+---
+
+## Rotation history
+
+| Date | Secret | Reason | Rotated by | Vercel updated | Consumers updated | Notes |
+|---|---|---|---|---|---|---|
+| 2026-05-04 | _(initial setup — all secrets set at project creation)_ | Initial | Founder | ✓ | ✓ | Baseline; rotation log starts here |
+
+---
+
+## Upcoming rotations
+
+Calculated from the schedule in `secret-rotation.md`. Update after
+each rotation to keep this table current.
+
+| Secret | Last rotated | Next due | Owner |
+|---|---|---|---|
+| `CRON_SECRET` | 2026-05-04 | 2026-08-02 | Eng lead |
+| `INTERNAL_API_KEY` | 2026-05-04 | 2026-08-02 | Eng lead |
+| `REVALIDATE_SECRET` | 2026-05-04 | 2026-08-02 | Eng lead |
+| `SUPABASE_SERVICE_ROLE_KEY` | 2026-05-04 | 2026-11-01 | Eng lead |
+| `RESEND_API_KEY` | 2026-05-04 | 2026-11-01 | Eng lead |
+| `STRIPE_SECRET_KEY` | 2026-05-04 | 2027-05-04 | Eng lead |
+| `STRIPE_WEBHOOK_SECRET` | 2026-05-04 | 2027-05-04 | Eng lead |
+
+---
+
+## Revocation log (compromised credentials)
+
+Record any credential that was revoked due to a suspected or confirmed
+leak (separate from the routine rotation schedule).
+
+| Date | Secret | Reason | Incident ref | Rotated by |
+|---|---|---|---|---|
+| — | — | — | — | — |


### PR DESCRIPTION
## Summary

- **Q-10** `docs/runbooks/acl-revocation.md` — ACL/AFSL revocation incident response. Covers both platform-level (unlikely in current structure) and per-advisor licence revocation. Includes SQL to set `professionals.status = 'suspended'`, lead rerouting, TMD audit reference, and ASIC `afsl-expiry-monitor` cron integration. Notes: invest.com.au currently operates as a referral platform, not a direct AFSL holder.
- **Q-11** `docs/runbooks/dsar.md` — Data Subject Access Request handling per Privacy Act APP 12/13 (access, correction) and GDPR Art 17 (deletion). Includes complete SQL extraction queries for all PII tables (`quiz_leads`, `email_captures`, `professional_leads`, `user_reviews`, `newsletter_subscribers`, `auth.users`), soft-delete pattern with audit trail, rejection criteria, and OAIC escalation path.
- **Q-12** `docs/runbooks/secret-rotation-log.md` — SOC 2 CC6.1 evidence log. Provides the structured rotation history table and upcoming-rotation schedule (calculated from `secret-rotation.md`), plus a revocation log for incident-driven rotations. Resolves the dangling reference from `secret-rotation.md` that pointed to this file but it never existed.

All three are pure documentation additions — no code changes. Tier A (auto-merge-safe after CI green).

## Test plan

- [ ] CI green (doc-only)
- [ ] All three files present in `docs/runbooks/`
- [ ] Cross-references resolve: `secret-rotation.md`, `tmd-coverage-gap.md`, `breach-notification.md`, `docs/compliance/regulatory-requests.md` (noted as "create if absent")

https://claude.ai/code/session_0159eFCvv6n1oBwWXtuKut2u

---
_Generated by [Claude Code](https://claude.ai/code/session_0159eFCvv6n1oBwWXtuKut2u)_