### PR TITLE
Revert "fix(home-hero): make reel thinner and taller" (#553)

### DIFF
--- a/components/HomeHero.tsx
+++ b/components/HomeHero.tsx
@@ -195,7 +195,7 @@ export default function HomeHero({
 
       <style>{`
         @media (min-width: 1024px) {
-          .hero-shell { grid-template-columns: minmax(0, 1fr) minmax(360px, 420px) !important; }
+          .hero-shell { grid-template-columns: minmax(0, 1fr) minmax(420px, 480px) !important; }
         }
         @media (max-width: 1023px) {
           .hero-right { justify-self: stretch !important; }

--- a/components/HomeHeroReel.tsx
+++ b/components/HomeHeroReel.tsx
@@ -35,7 +35,6 @@ type PanelKey = "compare" | "browse" | "find" | "matched" | "tools";
 
 interface PanelDef {
   key: PanelKey;
-  audience: string;
   headline: string;
   sublabel: string;
   cta: string;
@@ -56,49 +55,44 @@ export default function HomeHeroReel({
     () => [
       {
         key: "compare",
-        audience: "If you know what you want",
-        headline: "Compare investing platforms",
-        sublabel: `Side-by-side fees, FX rates and features across ${brokerCount.toLocaleString("en-AU")}+ platforms.`,
-        cta: "Compare now",
+        headline: `Compare ${brokerCount.toLocaleString("en-AU")}+ platforms`,
+        sublabel: "Side-by-side fees, FX rates, features",
+        cta: "Open compare",
         accent: "rgba(96,165,250,1)",
         href: "/compare",
         ariaLabel: "Compare investing platforms",
       },
       {
         key: "browse",
-        audience: "If you want real opportunities",
-        headline: "Browse investments for sale",
-        sublabel: `${listingCount.toLocaleString("en-AU")} live opportunities — businesses, farmland, mining, property.`,
-        cta: "Browse opportunities",
+        headline: `Browse ${listingCount.toLocaleString("en-AU")} opportunities`,
+        sublabel: "Real Australian businesses, projects, assets",
+        cta: "Browse listings",
         accent: "rgba(52,211,153,1)",
         href: "/invest",
         ariaLabel: "Browse Australian investments for sale",
       },
       {
         key: "find",
-        audience: "If you need a pro",
-        headline: "Find an Australian expert",
-        sublabel: `${advisorCount.toLocaleString("en-AU")} verified specialists by region, fee and specialty.`,
-        cta: "Find an expert",
+        headline: "Find a verified expert",
+        sublabel: `${advisorCount.toLocaleString("en-AU")} specialists, by region & fee`,
+        cta: "Meet specialists",
         accent: "rgba(167,139,250,1)",
         href: "/advisors",
         ariaLabel: "Find a verified Australian expert",
       },
       {
         key: "matched",
-        audience: "If you're not sure where to start",
-        headline: "Match me to the right step",
-        sublabel: "4 quick questions. We route you to the right platform, expert or guide.",
-        cta: "Start the quiz",
+        headline: "Get matched in 60s",
+        sublabel: "4 questions · no email · free",
+        cta: "Take the quiz",
         accent: "var(--color-coral-400)",
         href: "/quiz",
         ariaLabel: "Get matched with a 4-question quiz",
       },
       {
         key: "tools",
-        audience: "If you want to run the numbers",
         headline: "See what you'll save",
-        sublabel: "Real costs, FX rates, switching fees — calculators that show the impact in dollars.",
+        sublabel: "Real cost on a sample $10K USD trade",
         cta: "Open calculators",
         accent: "rgba(251,191,36,1)",
         href: "/calculators",
@@ -115,7 +109,7 @@ export default function HomeHeroReel({
     if (paused) return;
     const id = setInterval(() => {
       setActive((a) => (a + 1) % panels.length);
-    }, 5000);
+    }, 3500);
     return () => clearInterval(id);
   }, [paused, panels.length]);
 
@@ -137,9 +131,19 @@ export default function HomeHeroReel({
           <span className="hero-reel-label font-mono">
             5 ways to use Invest.com.au
           </span>
-          <span className="hero-reel-pos font-mono" aria-hidden>
-            {String(active + 1).padStart(2, "0")} / {String(panels.length).padStart(2, "0")}
-          </span>
+          <nav className="hero-reel-pips" aria-label="Reel position">
+            {panels.map((p, i) => (
+              <button
+                key={p.key}
+                type="button"
+                onClick={() => setActive(i)}
+                aria-current={i === active ? "true" : undefined}
+                aria-label={`Show ${p.headline}`}
+                className={`hero-reel-pip ${i === active ? "is-active" : ""}`}
+                style={i === active ? { background: p.accent } : undefined}
+              />
+            ))}
+          </nav>
         </div>
 
         <div className="hero-reel-viewport" aria-live="polite">
@@ -165,34 +169,20 @@ export default function HomeHeroReel({
             );
           })}
         </div>
-
-        <nav className="hero-reel-pips" aria-label="Reel position">
-          {panels.map((p, i) => (
-            <button
-              key={p.key}
-              type="button"
-              onClick={() => setActive(i)}
-              aria-current={i === active ? "true" : undefined}
-              aria-label={`Show ${p.headline}`}
-              className={`hero-reel-pip ${i === active ? "is-active" : ""}`}
-              style={i === active ? { background: p.accent } : undefined}
-            />
-          ))}
-        </nav>
       </div>
 
       <style>{`
         .hero-reel {
           position: relative;
           width: 100%;
-          max-width: 400px;
+          max-width: 460px;
           justify-self: end;
         }
         .hero-reel-frame {
           position: relative;
           border-radius: 18px;
-          background: linear-gradient(180deg, rgba(255,255,255,.08), rgba(255,255,255,.03));
-          border: 1px solid rgba(255,255,255,.14);
+          background: linear-gradient(180deg, rgba(255,255,255,.10), rgba(255,255,255,.04));
+          border: 1px solid rgba(255,255,255,.16);
           backdrop-filter: blur(6px);
           -webkit-backdrop-filter: blur(6px);
           box-shadow: 0 28px 60px -24px rgba(0,0,0,.7), inset 0 1px 0 rgba(255,255,255,.06);
@@ -204,33 +194,43 @@ export default function HomeHeroReel({
           display: flex;
           align-items: center;
           justify-content: space-between;
-          padding: 12px 20px 11px;
-          border-bottom: 1px solid rgba(255,255,255,.07);
-          background: rgba(255,255,255,.02);
+          padding: 12px 18px;
+          border-bottom: 1px solid rgba(255,255,255,.08);
+          background: rgba(255,255,255,.03);
         }
         .hero-reel-label {
-          font-size: 10.5px;
+          font-size: 10px;
           font-weight: 800;
           text-transform: uppercase;
           letter-spacing: .09em;
-          color: rgba(255,255,255,.62);
+          color: rgba(255,255,255,.55);
         }
-        .hero-reel-pos {
-          font-size: 10px;
-          font-weight: 800;
-          letter-spacing: .08em;
-          color: rgba(255,255,255,.42);
+        .hero-reel-pips { display: inline-flex; gap: 6px; }
+        .hero-reel-pip {
+          width: 26px;
+          height: 5px;
+          border-radius: 99px;
+          background: rgba(255,255,255,.18);
+          border: none;
+          padding: 0;
+          cursor: pointer;
+          transition: background-color .2s ease, transform .2s ease;
+        }
+        .hero-reel-pip:hover { background: rgba(255,255,255,.34); }
+        .hero-reel-pip.is-active {
+          transform: scaleY(1.3);
+          box-shadow: 0 0 0 3px rgba(255,255,255,.04);
         }
         .hero-reel-viewport {
           position: relative;
-          height: 480px;
+          height: 320px;
           overflow: hidden;
           z-index: 1;
         }
         .hero-reel-panel {
           position: absolute;
           inset: 0;
-          padding: 26px 24px 24px;
+          padding: 22px 24px 20px;
           display: flex;
           flex-direction: column;
           gap: 14px;
@@ -267,42 +267,37 @@ export default function HomeHeroReel({
           }
         }
 
-        .panel-audience {
-          font-size: 10.5px;
-          font-weight: 800;
-          text-transform: uppercase;
-          letter-spacing: .08em;
+        .panel-head { display: flex; flex-direction: column; gap: 4px; }
+        .panel-head .accent-strip {
+          width: 32px;
+          height: 3px;
+          border-radius: 99px;
+          margin-bottom: 8px;
         }
         .panel-headline {
-          font-size: 22px;
+          font-size: 19px;
           font-weight: 800;
-          letter-spacing: -.018em;
-          line-height: 1.1;
+          letter-spacing: -.015em;
+          line-height: 1.15;
           color: white;
         }
         .panel-sublabel {
-          font-size: 13.5px;
-          line-height: 1.45;
-          color: rgba(255,255,255,.72);
-        }
-        .panel-content {
-          flex: 1;
-          display: flex;
-          flex-direction: column;
-          gap: 10px;
-          min-height: 0;
+          font-size: 12.5px;
+          color: rgba(255,255,255,.62);
+          letter-spacing: .002em;
         }
 
         .panel-cta-pill {
+          margin-top: auto;
           align-self: flex-start;
           display: inline-flex;
           align-items: center;
           gap: 8px;
-          padding: 9px 16px 9px 18px;
+          padding: 7px 14px 7px 16px;
           border-radius: 999px;
           background: rgba(255,255,255,.07);
           border: 1px solid rgba(255,255,255,.18);
-          font-size: 12.5px;
+          font-size: 12px;
           font-weight: 800;
           letter-spacing: .03em;
           text-transform: uppercase;
@@ -311,49 +306,26 @@ export default function HomeHeroReel({
         }
         .panel-cta-pill svg { transition: transform .18s ease; }
 
-        .hero-reel-pips {
-          display: flex;
-          gap: 6px;
-          padding: 14px 20px 16px;
-          justify-content: center;
-          background: rgba(255,255,255,.02);
-          border-top: 1px solid rgba(255,255,255,.07);
-        }
-        .hero-reel-pip {
-          width: 28px;
-          height: 5px;
-          border-radius: 99px;
-          background: rgba(255,255,255,.18);
-          border: none;
-          padding: 0;
-          cursor: pointer;
-          transition: background-color .2s ease, transform .2s ease;
-        }
-        .hero-reel-pip:hover { background: rgba(255,255,255,.34); }
-        .hero-reel-pip.is-active {
-          transform: scaleY(1.3);
-          box-shadow: 0 0 0 3px rgba(255,255,255,.04);
-        }
-
         .compare-rows {
           display: flex;
           flex-direction: column;
-          gap: 8px;
+          gap: 7px;
+          flex: 1;
         }
         .compare-row {
           display: flex;
           align-items: center;
-          gap: 11px;
-          padding: 11px 14px;
-          border-radius: 11px;
+          gap: 10px;
+          padding: 9px 12px;
+          border-radius: 10px;
           background: rgba(255,255,255,.06);
           border: 1px solid rgba(255,255,255,.10);
-          font-size: 13.5px;
+          font-size: 13px;
           font-weight: 700;
         }
         .compare-row .dot {
-          width: 9px;
-          height: 9px;
+          width: 8px;
+          height: 8px;
           border-radius: 99px;
           flex-shrink: 0;
         }
@@ -366,23 +338,23 @@ export default function HomeHeroReel({
         }
         .compare-row .fee {
           font-family: var(--font-mono, ui-monospace, monospace);
-          font-size: 12.5px;
+          font-size: 12px;
           color: rgba(96,165,250,1);
           font-weight: 800;
         }
 
         .browse-grid {
           display: grid;
-          grid-template-columns: repeat(2, 1fr);
-          gap: 10px;
+          grid-template-columns: repeat(3, 1fr);
+          gap: 8px;
+          flex: 1;
         }
         .browse-tile {
           position: relative;
-          border-radius: 11px;
+          border-radius: 10px;
           overflow: hidden;
           background: rgba(255,255,255,.05);
           border: 1px solid rgba(255,255,255,.10);
-          aspect-ratio: 4 / 3;
         }
         .browse-tile-fallback {
           position: absolute;
@@ -390,19 +362,19 @@ export default function HomeHeroReel({
           display: flex;
           align-items: center;
           justify-content: center;
-          color: rgba(52,211,153,.5);
+          color: rgba(255,255,255,.35);
         }
         .browse-tile-title {
           position: absolute;
           left: 0;
           right: 0;
           bottom: 0;
-          padding: 7px 10px;
-          background: linear-gradient(180deg, transparent, rgba(0,0,0,.85));
+          padding: 6px 8px;
+          background: linear-gradient(180deg, transparent, rgba(0,0,0,.82));
           color: white;
-          font-size: 11px;
+          font-size: 10.5px;
           font-weight: 700;
-          line-height: 1.2;
+          line-height: 1.18;
           overflow: hidden;
           display: -webkit-box;
           -webkit-line-clamp: 2;
@@ -412,13 +384,14 @@ export default function HomeHeroReel({
         .find-stack {
           display: flex;
           flex-direction: column;
-          gap: 14px;
+          gap: 12px;
+          flex: 1;
         }
         .find-avatars { display: inline-flex; }
         .find-avatar {
           position: relative;
-          width: 52px;
-          height: 52px;
+          width: 46px;
+          height: 46px;
           border-radius: 99px;
           overflow: hidden;
           border: 2px solid rgba(13,17,23,.85);
@@ -433,7 +406,7 @@ export default function HomeHeroReel({
           align-items: center;
           justify-content: center;
           color: rgba(255,255,255,.65);
-          font-size: 16px;
+          font-size: 14px;
           font-weight: 800;
         }
         .find-tags {
@@ -442,48 +415,46 @@ export default function HomeHeroReel({
           gap: 6px;
         }
         .find-tag {
-          font-size: 11px;
+          font-size: 10.5px;
           font-weight: 700;
-          padding: 5px 10px;
+          padding: 4px 9px;
           border-radius: 99px;
           background: rgba(167,139,250,.14);
           color: rgba(216,205,255,1);
           border: 1px solid rgba(167,139,250,.28);
         }
 
-        .matched-progress {
-          display: flex;
-          gap: 7px;
-        }
+        .matched-progress { display: flex; gap: 6px; }
         .matched-progress .step {
           flex: 1;
-          height: 7px;
+          height: 6px;
           border-radius: 99px;
           background: var(--color-coral-400);
         }
         .matched-card {
-          padding: 16px 18px;
-          border-radius: 13px;
+          margin-top: 2px;
+          padding: 14px 16px;
+          border-radius: 12px;
           background: rgba(255,255,255,.06);
           border: 1px solid rgba(255,255,255,.12);
         }
         .matched-eyebrow {
-          font-size: 10.5px;
+          font-size: 10px;
           font-weight: 800;
           text-transform: uppercase;
           letter-spacing: .09em;
           color: rgba(255,255,255,.5);
         }
         .matched-name {
-          margin-top: 7px;
-          font-size: 22px;
+          margin-top: 6px;
+          font-size: 19px;
           font-weight: 800;
-          letter-spacing: -.014em;
+          letter-spacing: -.01em;
           color: white;
         }
         .matched-fee {
-          margin-top: 5px;
-          font-size: 12.5px;
+          margin-top: 4px;
+          font-size: 11.5px;
           font-weight: 700;
           color: var(--color-coral-400);
           font-family: var(--font-mono, ui-monospace, monospace);
@@ -492,28 +463,29 @@ export default function HomeHeroReel({
         .savings-block {
           display: flex;
           flex-direction: column;
-          gap: 16px;
+          gap: 14px;
+          flex: 1;
         }
         .savings-bars {
           display: flex;
           flex-direction: column;
-          gap: 10px;
+          gap: 9px;
         }
         .savings-bar-row {
           display: flex;
           align-items: center;
-          gap: 12px;
-          font-size: 13px;
+          gap: 10px;
+          font-size: 12px;
           font-weight: 700;
         }
         .savings-bar-row .label {
-          width: 86px;
+          width: 80px;
           color: rgba(255,255,255,.78);
           flex-shrink: 0;
         }
         .savings-bar-row .track {
           flex: 1;
-          height: 13px;
+          height: 12px;
           border-radius: 99px;
           background: rgba(255,255,255,.06);
           border: 1px solid rgba(255,255,255,.10);
@@ -525,7 +497,7 @@ export default function HomeHeroReel({
           border-radius: 99px;
         }
         .savings-bar-row .cost {
-          width: 56px;
+          width: 50px;
           text-align: right;
           font-family: var(--font-mono, ui-monospace, monospace);
           color: white;
@@ -537,27 +509,22 @@ export default function HomeHeroReel({
         .savings-callout {
           display: flex;
           align-items: baseline;
-          gap: 12px;
-          padding: 12px 16px;
-          border-radius: 13px;
+          gap: 10px;
+          padding: 10px 14px;
+          border-radius: 12px;
           background: rgba(242,88,34,.14);
           border: 1px solid rgba(242,88,34,.32);
         }
         .savings-callout .save-amount {
-          font-size: 26px;
+          font-size: 22px;
           font-weight: 800;
-          letter-spacing: -.014em;
+          letter-spacing: -.01em;
           color: var(--color-coral-400);
           font-family: var(--font-mono, ui-monospace, monospace);
         }
         .savings-callout .save-context {
-          font-size: 12px;
+          font-size: 11.5px;
           color: rgba(255,255,255,.7);
-        }
-        .savings-disclaimer {
-          font-size: 10px;
-          color: rgba(255,255,255,.4);
-          font-style: italic;
         }
       `}</style>
     </div>
@@ -579,23 +546,25 @@ function PanelInner({
 }) {
   return (
     <>
-      <div className="panel-audience font-mono" style={{ color: panel.accent }}>
-        {panel.audience}
+      <div className="panel-head">
+        <span
+          className="accent-strip"
+          aria-hidden
+          style={{ background: panel.accent }}
+        />
+        <div className="panel-headline">{panel.headline}</div>
+        <div className="panel-sublabel">{panel.sublabel}</div>
       </div>
-      <div className="panel-headline">{panel.headline}</div>
-      <div className="panel-sublabel">{panel.sublabel}</div>
 
-      <div className="panel-content">
-        {panel.key === "compare" && <ComparePanel brokers={brokers} accent={panel.accent} />}
-        {panel.key === "browse" && <BrowsePanel listings={listings} />}
-        {panel.key === "find" && <FindPanel advisors={advisors} />}
-        {panel.key === "matched" && <MatchedPanel matchBroker={matchBroker} />}
-        {panel.key === "tools" && <SavingsPanel />}
-      </div>
+      {panel.key === "compare" && <ComparePanel brokers={brokers} accent={panel.accent} />}
+      {panel.key === "browse" && <BrowsePanel listings={listings} />}
+      {panel.key === "find" && <FindPanel advisors={advisors} />}
+      {panel.key === "matched" && <MatchedPanel matchBroker={matchBroker} />}
+      {panel.key === "tools" && <SavingsPanel />}
 
       <span className="panel-cta-pill" aria-hidden>
         {panel.cta}
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.6">
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.6">
           <path strokeLinecap="round" strokeLinejoin="round" d="M5 12h14m0 0-5-5m5 5-5 5" />
         </svg>
       </span>
@@ -628,25 +597,24 @@ function BrowsePanel({ listings }: { listings: ReadonlyArray<ReelListing> }) {
     { id: "p1", title: "Cattle station, NT", image: null },
     { id: "p2", title: "Cafe chain, VIC", image: null },
     { id: "p3", title: "Solar farm, QLD", image: null },
-    { id: "p4", title: "Almond farm, SA", image: null },
   ];
-  const source = listings.length >= 4 ? listings.slice(0, 4) : placeholder;
+  const display = listings.length >= 3 ? listings.slice(0, 3) : placeholder;
   return (
     <div className="browse-grid">
-      {source.map((l) => (
+      {display.map((l) => (
         <div key={l.id} className="browse-tile">
           {l.image ? (
             <Image
               src={l.image}
               alt=""
               fill
-              sizes="(min-width: 1024px) 170px, 40vw"
+              sizes="(min-width: 1024px) 130px, 30vw"
               style={{ objectFit: "cover" }}
               unoptimized
             />
           ) : (
             <span className="browse-tile-fallback" aria-hidden>
-              <DesignIcon name="map-pin" size={26} strokeWidth={2.2} />
+              <DesignIcon name="map-pin" size={22} strokeWidth={2.2} />
             </span>
           )}
           <span className="browse-tile-title">{l.title}</span>
@@ -657,16 +625,15 @@ function BrowsePanel({ listings }: { listings: ReadonlyArray<ReelListing> }) {
 }
 
 function FindPanel({ advisors }: { advisors: ReadonlyArray<ReelAdvisor> }) {
-  const items = advisors.filter((a) => a.photo_url).slice(0, 5);
+  const items = advisors.filter((a) => a.photo_url).slice(0, 4);
   const fallback: ReelAdvisor[] = [
     { name: "Olivia P", photo_url: null },
     { name: "Jamal K", photo_url: null },
     { name: "Mei S", photo_url: null },
     { name: "Tom R", photo_url: null },
-    { name: "Ava L", photo_url: null },
   ];
-  const display = items.length >= 4 ? items : fallback;
-  const tags = ["SMSF accountant", "Mortgage broker", "Buyer's agent", "Tax agent", "FIRB", "Cross-border"];
+  const display = items.length >= 3 ? items : fallback;
+  const tags = ["SMSF accountant", "Mortgage broker", "Buyer's agent", "Tax agent", "FIRB"];
   return (
     <div className="find-stack">
       <div className="find-avatars">
@@ -677,7 +644,7 @@ function FindPanel({ advisors }: { advisors: ReadonlyArray<ReelAdvisor> }) {
                 src={a.photo_url}
                 alt=""
                 fill
-                sizes="52px"
+                sizes="46px"
                 style={{ objectFit: "cover" }}
                 unoptimized
               />
@@ -741,9 +708,6 @@ function SavingsPanel() {
       <div className="savings-callout">
         <span className="save-amount">$82</span>
         <span className="save-context">saved on a $10K USD trade</span>
-      </div>
-      <div className="savings-disclaimer">
-        Illustrative — see your real numbers in the calculators
       </div>
     </div>
   );


### PR DESCRIPTION
Reverts #553 per founder feedback — thinner+taller geometry made the hero worse, not better. Restores the post-#546 polish state.

Reverts the v3 changes only; PR #546 polish and PR #544 reel scaffolding stay in place.