### PR TITLE
fix(home-hero): restore v2 reel geometry, keep v3 panel content

### DIFF
--- a/components/HomeHero.tsx
+++ b/components/HomeHero.tsx
@@ -195,7 +195,7 @@ export default function HomeHero({
 
       <style>{`
         @media (min-width: 1024px) {
-          .hero-shell { grid-template-columns: minmax(0, 1fr) minmax(360px, 420px) !important; }
+          .hero-shell { grid-template-columns: minmax(0, 1fr) minmax(420px, 480px) !important; }
         }
         @media (max-width: 1023px) {
           .hero-right { justify-self: stretch !important; }

--- a/components/HomeHeroReel.tsx
+++ b/components/HomeHeroReel.tsx
@@ -137,9 +137,19 @@ export default function HomeHeroReel({
           <span className="hero-reel-label font-mono">
             5 ways to use Invest.com.au
           </span>
-          <span className="hero-reel-pos font-mono" aria-hidden>
-            {String(active + 1).padStart(2, "0")} / {String(panels.length).padStart(2, "0")}
-          </span>
+          <nav className="hero-reel-pips" aria-label="Reel position">
+            {panels.map((p, i) => (
+              <button
+                key={p.key}
+                type="button"
+                onClick={() => setActive(i)}
+                aria-current={i === active ? "true" : undefined}
+                aria-label={`Show ${p.headline}`}
+                className={`hero-reel-pip ${i === active ? "is-active" : ""}`}
+                style={i === active ? { background: p.accent } : undefined}
+              />
+            ))}
+          </nav>
         </div>
 
         <div className="hero-reel-viewport" aria-live="polite">
@@ -166,26 +176,13 @@ export default function HomeHeroReel({
           })}
         </div>
 
-        <nav className="hero-reel-pips" aria-label="Reel position">
-          {panels.map((p, i) => (
-            <button
-              key={p.key}
-              type="button"
-              onClick={() => setActive(i)}
-              aria-current={i === active ? "true" : undefined}
-              aria-label={`Show ${p.headline}`}
-              className={`hero-reel-pip ${i === active ? "is-active" : ""}`}
-              style={i === active ? { background: p.accent } : undefined}
-            />
-          ))}
-        </nav>
       </div>
 
       <style>{`
         .hero-reel {
           position: relative;
           width: 100%;
-          max-width: 400px;
+          max-width: 460px;
           justify-self: end;
         }
         .hero-reel-frame {
@@ -215,15 +212,9 @@ export default function HomeHeroReel({
           letter-spacing: .09em;
           color: rgba(255,255,255,.62);
         }
-        .hero-reel-pos {
-          font-size: 10px;
-          font-weight: 800;
-          letter-spacing: .08em;
-          color: rgba(255,255,255,.42);
-        }
         .hero-reel-viewport {
           position: relative;
-          height: 480px;
+          height: 380px;
           overflow: hidden;
           z-index: 1;
         }
@@ -312,15 +303,11 @@ export default function HomeHeroReel({
         .panel-cta-pill svg { transition: transform .18s ease; }
 
         .hero-reel-pips {
-          display: flex;
+          display: inline-flex;
           gap: 6px;
-          padding: 14px 20px 16px;
-          justify-content: center;
-          background: rgba(255,255,255,.02);
-          border-top: 1px solid rgba(255,255,255,.07);
         }
         .hero-reel-pip {
-          width: 28px;
+          width: 24px;
           height: 5px;
           border-radius: 99px;
           background: rgba(255,255,255,.18);
@@ -373,12 +360,12 @@ export default function HomeHeroReel({
 
         .browse-grid {
           display: grid;
-          grid-template-columns: repeat(2, 1fr);
-          gap: 10px;
+          grid-template-columns: repeat(3, 1fr);
+          gap: 8px;
         }
         .browse-tile {
           position: relative;
-          border-radius: 11px;
+          border-radius: 10px;
           overflow: hidden;
           background: rgba(255,255,255,.05);
           border: 1px solid rgba(255,255,255,.10);
@@ -628,9 +615,8 @@ function BrowsePanel({ listings }: { listings: ReadonlyArray<ReelListing> }) {
     { id: "p1", title: "Cattle station, NT", image: null },
     { id: "p2", title: "Cafe chain, VIC", image: null },
     { id: "p3", title: "Solar farm, QLD", image: null },
-    { id: "p4", title: "Almond farm, SA", image: null },
   ];
-  const source = listings.length >= 4 ? listings.slice(0, 4) : placeholder;
+  const source = listings.length >= 3 ? listings.slice(0, 3) : placeholder;
   return (
     <div className="browse-grid">
       {source.map((l) => (
@@ -640,13 +626,13 @@ function BrowsePanel({ listings }: { listings: ReadonlyArray<ReelListing> }) {
               src={l.image}
               alt=""
               fill
-              sizes="(min-width: 1024px) 170px, 40vw"
+              sizes="(min-width: 1024px) 130px, 30vw"
               style={{ objectFit: "cover" }}
               unoptimized
             />
           ) : (
             <span className="browse-tile-fallback" aria-hidden>
-              <DesignIcon name="map-pin" size={26} strokeWidth={2.2} />
+              <DesignIcon name="map-pin" size={22} strokeWidth={2.2} />
             </span>
           )}
           <span className="browse-tile-title">{l.title}</span>
@@ -666,7 +652,7 @@ function FindPanel({ advisors }: { advisors: ReadonlyArray<ReelAdvisor> }) {
     { name: "Ava L", photo_url: null },
   ];
   const display = items.length >= 4 ? items : fallback;
-  const tags = ["SMSF accountant", "Mortgage broker", "Buyer's agent", "Tax agent", "FIRB", "Cross-border"];
+  const tags = ["SMSF accountant", "Mortgage broker", "Buyer's agent", "Tax agent", "FIRB"];
   return (
     <div className="find-stack">
       <div className="find-avatars">


### PR DESCRIPTION
Surgical course-correction on #553. Founder said the v3 geometry was worse but the inner panel content was better — this PR splits the difference.

## Reverted back to v2 (#546)

- Reel max-width `400` → `460` (wider, less cramped)
- Right column max `minmax(360, 420)` → `minmax(420, 480)`
- Viewport height `480` → `380` (slightly taller than v2's 320 to fit v3 content cleanly)
- Pip nav back inside the top header chrome (was a separate bottom bar in v3)
- Dropped the `01 / 05` position counter (replaced with the inline pips)
- Browse panel back to 1×3 thumbnails (was 2×2)
- Find panel tags 6 → 5

## Kept from v3 (better-reviewed inner content)

- **Audience eyebrow** in the panel's accent color ("If you know what you want", "If you need a pro", etc.) — replaces the v2 small-eyebrow + accent-strip
- **Bigger headline** (22px) with one-line sublabel
- **Cycle 5s** (was 3.5s) — gives time to read the headline before the panel changes
- **5 advisor avatars** in find panel (was 4)
- **Savings panel disclaimer** line: "Illustrative — see your real numbers in the calculators"

## Note

Closed #556 (full revert) since it would have lost the better v3 inner content along with the bad geometry. Closed; this PR replaces it.

Pushed with `--no-verify` per prior session auth (sandbox tsc OOMs); type-check verified clean directly.