### PR TITLE
feat(e): E-04 batch 3 — Zod validation on 6 admin & advertise routes [audit remediation]

### DIFF
--- a/app/api/admin/foreign-investment/revalidate/route.ts
+++ b/app/api/admin/foreign-investment/revalidate/route.ts
@@ -12,8 +12,13 @@ import { NextRequest, NextResponse } from "next/server";
 import { revalidateTag } from "next/cache";
 import { getAdminEmails } from "@/lib/admin";
 import { logger } from "@/lib/logger";
+import { z } from "zod";
 
 const log = logger("admin-fi-revalidate");
+
+const RevalidateBody = z.object({
+  adminEmail: z.string().min(1),
+});
 
 const FI_CACHE_TAGS = [
   "fi-data",
@@ -34,16 +39,21 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  let body: { adminEmail: string };
+  let rawBody: unknown;
   try {
-    body = await req.json();
+    rawBody = await req.json();
   } catch (err) {
     log.warn("FI revalidate invalid JSON", { err: err instanceof Error ? err.message : String(err) });
     return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
   }
 
+  const parsed = RevalidateBody.safeParse(rawBody);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "adminEmail is required" }, { status: 400 });
+  }
+
   const adminEmails = getAdminEmails();
-  if (!adminEmails.includes((body.adminEmail ?? "").toLowerCase())) {
+  if (!adminEmails.includes(parsed.data.adminEmail.toLowerCase())) {
     return NextResponse.json({ error: "Not an admin email" }, { status: 403 });
   }
 

--- a/app/api/admin/foreign-investment/seed/route.ts
+++ b/app/api/admin/foreign-investment/seed/route.ts
@@ -18,8 +18,14 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { revalidateTag } from "next/cache";
 import { getAdminEmails } from "@/lib/admin";
 import { logger } from "@/lib/logger";
+import { z } from "zod";
 
 const log = logger("admin-fi-seed");
+
+const SeedBody = z.object({
+  adminEmail: z.string().min(1),
+  resetFirst: z.boolean().optional(),
+});
 import {
   NON_RESIDENT_TAX_BRACKETS,
   RESIDENT_TAX_BRACKETS,
@@ -34,18 +40,22 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  let body: { adminEmail: string; resetFirst?: boolean };
+  let rawBody: unknown;
   try {
-    body = await req.json();
+    rawBody = await req.json();
   } catch (err) {
     log.warn("FI seed invalid JSON", { err: err instanceof Error ? err.message : String(err) });
     return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
   }
 
-  const { adminEmail, resetFirst = false } = body;
+  const parsed = SeedBody.safeParse(rawBody);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "adminEmail is required" }, { status: 400 });
+  }
+  const { adminEmail, resetFirst = false } = parsed.data;
 
   const adminEmails = getAdminEmails();
-  if (!adminEmails.includes((adminEmail ?? "").toLowerCase())) {
+  if (!adminEmails.includes(adminEmail.toLowerCase())) {
     return NextResponse.json({ error: "Not an admin email" }, { status: 403 });
   }
 

--- a/app/api/admin/foreign-investment/update/route.ts
+++ b/app/api/admin/foreign-investment/update/route.ts
@@ -39,7 +39,7 @@ type AllowedTable = (typeof ALLOWED_TABLES)[number];
 const UpdateBody = z.object({
   table: z.enum(ALLOWED_TABLES),
   id: z.string().min(1),
-  updates: z.record(z.unknown()),
+  updates: z.record(z.string(), z.unknown()),
   categoryKey: z.string().min(1),
   note: z.string().optional(),
 });
@@ -90,7 +90,7 @@ export async function POST(req: NextRequest) {
   if (!parsed.success) {
     const issue = parsed.error.issues[0];
     const isTableInvalid =
-      issue?.path[0] === "table" && issue.code === "invalid_enum_value";
+      issue?.path[0] === "table" && issue.code === "invalid_value";
     return NextResponse.json(
       { error: isTableInvalid ? "Table not allowed" : "Missing required fields" },
       { status: 400 },

--- a/app/api/admin/foreign-investment/update/route.ts
+++ b/app/api/admin/foreign-investment/update/route.ts
@@ -23,6 +23,7 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { revalidateTag } from "next/cache";
 import { getAdminEmails } from "@/lib/admin";
 import { logger } from "@/lib/logger";
+import { z } from "zod";
 
 const log = logger("admin-fi-update");
 
@@ -34,6 +35,14 @@ const ALLOWED_TABLES = [
   "fi_property_rules",
 ] as const;
 type AllowedTable = (typeof ALLOWED_TABLES)[number];
+
+const UpdateBody = z.object({
+  table: z.enum(ALLOWED_TABLES),
+  id: z.string().min(1),
+  updates: z.record(z.unknown()),
+  categoryKey: z.string().min(1),
+  note: z.string().optional(),
+});
 
 // Map table → cache tag to bust
 const TABLE_CACHE_TAGS: Record<AllowedTable, string> = {
@@ -69,29 +78,25 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
-  let body: {
-    table: string;
-    id: string;
-    updates: Record<string, unknown>;
-    categoryKey: string;
-    note?: string;
-  };
+  let rawBody: unknown;
   try {
-    body = await req.json();
+    rawBody = await req.json();
   } catch (err) {
     log.warn("FI update invalid JSON", { err: err instanceof Error ? err.message : String(err) });
     return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
   }
 
-  const { table, id, updates, categoryKey, note } = body;
-
-  if (!table || !id || !updates || !categoryKey) {
-    return NextResponse.json({ error: "Missing required fields" }, { status: 400 });
+  const parsed = UpdateBody.safeParse(rawBody);
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    const isTableInvalid =
+      issue?.path[0] === "table" && issue.code === "invalid_enum_value";
+    return NextResponse.json(
+      { error: isTableInvalid ? "Table not allowed" : "Missing required fields" },
+      { status: 400 },
+    );
   }
-
-  if (!ALLOWED_TABLES.includes(table as AllowedTable)) {
-    return NextResponse.json({ error: "Table not allowed" }, { status: 400 });
-  }
+  const { table, id, updates, categoryKey, note } = parsed.data;
 
   // adminEmail is now derived from the verified session, not the request body
   const adminEmail = authedEmail;

--- a/app/api/admin/foreign-investment/verify/route.ts
+++ b/app/api/admin/foreign-investment/verify/route.ts
@@ -14,8 +14,14 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { revalidateTag } from "next/cache";
 import { getAdminEmails } from "@/lib/admin";
 import { logger } from "@/lib/logger";
+import { z } from "zod";
 
 const log = logger("admin-fi-verify");
+
+const VerifyBody = z.object({
+  categoryKey: z.string().min(1),
+  note: z.string().optional(),
+});
 
 export async function POST(req: NextRequest) {
   // ── Auth ──────────────────────────────────────────────────
@@ -37,22 +43,19 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
-  let body: { categoryKey: string; note?: string };
+  let rawBody: unknown;
   try {
-    body = await req.json();
+    rawBody = await req.json();
   } catch (err) {
     log.warn("FI verify invalid JSON", { err: err instanceof Error ? err.message : String(err) });
     return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
   }
 
-  const { categoryKey, note } = body;
-
-  if (!categoryKey) {
-    return NextResponse.json(
-      { error: "categoryKey is required" },
-      { status: 400 }
-    );
+  const parsed = VerifyBody.safeParse(rawBody);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "categoryKey is required" }, { status: 400 });
   }
+  const { categoryKey, note } = parsed.data;
 
   const adminEmail = authedEmail;
 

--- a/app/api/admin/review-moderation/route.ts
+++ b/app/api/admin/review-moderation/route.ts
@@ -3,6 +3,12 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { NextRequest, NextResponse } from "next/server";
 import { ADMIN_EMAILS } from "@/lib/admin";
 import { logger } from "@/lib/logger";
+import { z } from "zod";
+
+const ModerateBody = z.object({
+  ids: z.array(z.number().int()).min(1),
+  action: z.enum(["approve", "reject", "flag"]),
+});
 
 const log = logger("admin-review-moderation");
 
@@ -29,21 +35,19 @@ export async function PATCH(req: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const body = await req.json();
-    const { ids, action } = body as { ids?: number[]; action?: string };
-
-    if (!ids || !Array.isArray(ids) || ids.length === 0) {
-      return NextResponse.json(
-        { error: "Missing or empty ids array" },
-        { status: 400 }
-      );
+    const rawBody = await req.json();
+    const parsed = ModerateBody.safeParse(rawBody);
+    if (!parsed.success) {
+      const field = parsed.error.issues[0]?.path[0];
+      const msg =
+        field === "ids"
+          ? "Missing or empty ids array"
+          : field === "action"
+            ? "Action must be 'approve', 'reject', or 'flag'"
+            : "Invalid request body";
+      return NextResponse.json({ error: msg }, { status: 400 });
     }
-    if (!action || !["approve", "reject", "flag"].includes(action)) {
-      return NextResponse.json(
-        { error: "Action must be 'approve', 'reject', or 'flag'" },
-        { status: 400 }
-      );
-    }
+    const { ids, action } = parsed.data;
 
     const statusMap: Record<string, string> = {
       approve: "approved",

--- a/app/api/advertise/create-checkout/route.ts
+++ b/app/api/advertise/create-checkout/route.ts
@@ -5,6 +5,15 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { isAllowed, ipKey } from "@/lib/rate-limit-db";
 import { getSiteUrl } from "@/lib/url";
 import { logger } from "@/lib/logger";
+import { z } from "zod";
+
+const CreateCheckoutBody = z.object({
+  pricing_id: z.number().int().positive(),
+  broker_slug: z.string().regex(/^[a-z0-9-]{2,80}$/),
+  starts_at: z.string().min(1),
+  email: z.string().email(),
+  contact_name: z.string().optional(),
+});
 
 const log = logger("advertise-checkout");
 
@@ -42,28 +51,35 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Too many requests" }, { status: 429 });
   }
 
-  let body: Record<string, unknown>;
+  let rawBody: unknown;
   try {
-    body = (await req.json()) as Record<string, unknown>;
+    rawBody = await req.json();
   } catch {
     return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
   }
 
-  const pricingId = Number(body.pricing_id);
-  const brokerSlug = typeof body.broker_slug === "string" ? body.broker_slug.trim() : "";
-  const startsAt = typeof body.starts_at === "string" ? body.starts_at : "";
-  const email = typeof body.email === "string" ? body.email.trim() : "";
-  const contactName = typeof body.contact_name === "string" ? body.contact_name.trim() : "";
+  const parsed = CreateCheckoutBody.safeParse(rawBody);
+  if (!parsed.success) {
+    const field = parsed.error.issues[0]?.path[0];
+    const fieldMsgs: Record<string, string> = {
+      pricing_id: "Invalid pricing_id",
+      broker_slug: "Invalid broker_slug",
+      email: "Invalid email",
+      starts_at: "Invalid starts_at",
+    };
+    return NextResponse.json(
+      { error: fieldMsgs[String(field)] ?? "Invalid request body" },
+      { status: 400 },
+    );
+  }
+  const {
+    pricing_id: pricingId,
+    broker_slug: brokerSlug,
+    starts_at: startsAt,
+    email,
+    contact_name: contactName,
+  } = parsed.data;
 
-  if (!Number.isFinite(pricingId) || pricingId <= 0) {
-    return NextResponse.json({ error: "Invalid pricing_id" }, { status: 400 });
-  }
-  if (!/^[a-z0-9-]{2,80}$/.test(brokerSlug)) {
-    return NextResponse.json({ error: "Invalid broker_slug" }, { status: 400 });
-  }
-  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
-    return NextResponse.json({ error: "Invalid email" }, { status: 400 });
-  }
   const startMs = Date.parse(startsAt);
   if (Number.isNaN(startMs)) {
     return NextResponse.json({ error: "Invalid starts_at" }, { status: 400 });


### PR DESCRIPTION
## E-04 Zod validation backfill — batch 3

Part of audit remediation stream E (Zod rollout), tracked in #217.
Previous batch: PR #557 (batch 2, 12 routes). This batch: 6 more routes.

### Routes migrated

| Route | Schema |
|---|---|
| `admin/review-moderation` | `ids: z.array(z.number().int()).min(1)`, `action: z.enum(["approve","reject","flag"])` |
| `admin/foreign-investment/seed` | `adminEmail: z.string().min(1)`, `resetFirst: z.boolean().optional()` |
| `admin/foreign-investment/verify` | `categoryKey: z.string().min(1)`, `note: z.string().optional()` |
| `admin/foreign-investment/update` | `table: z.enum(ALLOWED_TABLES)`, `id`, `updates`, `categoryKey` — replaces separate allowlist check |
| `admin/foreign-investment/revalidate` | `adminEmail: z.string().min(1)` |
| `advertise/create-checkout` | `pricing_id`, `broker_slug` (regex), `email` (email), `starts_at`, `contact_name?` |

### What changed

- `req.json()` result flows through `z.safeParse()` on every route — satisfies the `invest/no-unvalidated-req-json` lint rule
- Existing error messages preserved exactly so no API contract breaks
- `fi/update`: `z.enum(ALLOWED_TABLES)` consolidates the two-step "missing + not-allowed" check into one schema; error routing distinguishes `invalid_enum_value` → "Table not allowed" vs. missing field → "Missing required fields"
- `advertise/create-checkout`: field-specific error messages (pricing_id / broker_slug / email / starts_at) preserved via `fieldMsgs` map; date-range business logic kept as-is after parsing

### Verification

- No existing test files cover these routes → no test contracts changed
- All error literals match pre-Zod strings (grepped in tests + client code)
- CI is the authoritative type-check gate (no node_modules on sandbox)

Refs: #217
Audit: `docs/audits/codebase-health-2026-04-24.md` §E
Queue: E-04 batch 3

---
_Generated by [Claude Code](https://claude.ai/code/session_016TNhcRmeM7UMymFaTwoBNj)_