### PR TITLE
refactor(f): F-07 batch 2 — migrate 5 calculator pages to schema-markup helpers [audit remediation]

### DIFF
--- a/app/cgt-calculator/page.tsx
+++ b/app/cgt-calculator/page.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from "react";
 import type { Metadata } from "next";
-import { absoluteUrl, breadcrumbJsonLd, CURRENT_YEAR, SITE_NAME } from "@/lib/seo";
+import { absoluteUrl, breadcrumbJsonLd, CURRENT_YEAR } from "@/lib/seo";
+import { calculatorJsonLd, faqJsonLd } from "@/lib/schema-markup";
 import CgtClient from "./CgtClient";
 import ComplianceFooter from "@/components/ComplianceFooter";
 
@@ -27,17 +28,12 @@ export const metadata: Metadata = {
   twitter: { card: "summary_large_image" as const },
 };
 
-const softwareLd = {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  name: `CGT Calculator — ${SITE_NAME}`,
+const softwareLd = calculatorJsonLd({
+  name: "CGT Calculator",
   description:
     "Free capital gains tax calculator for Australian investors. Includes 50% CGT discount for long-term holdings and calculates tax at marginal rate.",
-  url: absoluteUrl("/cgt-calculator"),
-  applicationCategory: "FinanceApplication",
-  operatingSystem: "Any",
-  offers: { "@type": "Offer", price: "0", priceCurrency: "AUD" },
-};
+  path: "/cgt-calculator",
+});
 
 const breadcrumbLd = breadcrumbJsonLd([
   { name: "Home", url: absoluteUrl("/") },
@@ -45,52 +41,28 @@ const breadcrumbLd = breadcrumbJsonLd([
   { name: "CGT Calculator", url: absoluteUrl("/cgt-calculator") },
 ]);
 
-const faqLd = {
-  "@context": "https://schema.org",
-  "@type": "FAQPage",
-  mainEntity: [
-    {
-      "@type": "Question",
-      name: "What is capital gains tax in Australia?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "CGT is the tax you pay on profits from selling investment assets like shares, ETFs, property or crypto. It's not a separate tax — your net capital gain is added to your assessable income and taxed at your marginal rate.",
-      },
-    },
-    {
-      "@type": "Question",
-      name: "When do I pay CGT?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "CGT is triggered by a CGT event, usually when you sell, gift or transfer an asset. You report the gain in your tax return for the financial year of the sale and pay it as part of your normal annual tax assessment.",
-      },
-    },
-    {
-      "@type": "Question",
-      name: "How is the 50% CGT discount calculated?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "If you hold an asset for more than 12 months as an individual or trust, you discount the gross capital gain by 50% before adding it to taxable income. SMSFs get 33.3%, and companies receive no CGT discount.",
-      },
-    },
-    {
-      "@type": "Question",
-      name: "Can I offset losses against capital gains?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "Yes. Capital losses offset capital gains in the same financial year. Unused losses carry forward indefinitely against future gains, but not against regular income. Losses apply before the 50% discount.",
-      },
-    },
-    {
-      "@type": "Question",
-      name: "Is my main residence CGT-exempt?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "Yes, generally. Your main residence is exempt provided it has been your principal place of residence, sits on land under 2 hectares, and hasn't been used to produce income. Partial exemptions apply in mixed-use cases.",
-      },
-    },
-  ],
-};
+const faqLd = faqJsonLd([
+  {
+    q: "What is capital gains tax in Australia?",
+    a: "CGT is the tax you pay on profits from selling investment assets like shares, ETFs, property or crypto. It's not a separate tax — your net capital gain is added to your assessable income and taxed at your marginal rate.",
+  },
+  {
+    q: "When do I pay CGT?",
+    a: "CGT is triggered by a CGT event, usually when you sell, gift or transfer an asset. You report the gain in your tax return for the financial year of the sale and pay it as part of your normal annual tax assessment.",
+  },
+  {
+    q: "How is the 50% CGT discount calculated?",
+    a: "If you hold an asset for more than 12 months as an individual or trust, you discount the gross capital gain by 50% before adding it to taxable income. SMSFs get 33.3%, and companies receive no CGT discount.",
+  },
+  {
+    q: "Can I offset losses against capital gains?",
+    a: "Yes. Capital losses offset capital gains in the same financial year. Unused losses carry forward indefinitely against future gains, but not against regular income. Losses apply before the 50% discount.",
+  },
+  {
+    q: "Is my main residence CGT-exempt?",
+    a: "Yes, generally. Your main residence is exempt provided it has been your principal place of residence, sits on land under 2 hectares, and hasn't been used to produce income. Partial exemptions apply in mixed-use cases.",
+  },
+]);
 
 function Loading() {
   return (

--- a/app/compound-interest-calculator/page.tsx
+++ b/app/compound-interest-calculator/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
-import { CURRENT_YEAR, SITE_NAME } from "@/lib/seo";
+import { CURRENT_YEAR, absoluteUrl, breadcrumbJsonLd } from "@/lib/seo";
+import { calculatorJsonLd, faqJsonLd } from "@/lib/schema-markup";
 import CompoundInterestClient from "./CompoundInterestClient";
 import ComplianceFooter from "@/components/ComplianceFooter";
 
@@ -25,76 +26,42 @@ export const metadata: Metadata = {
   twitter: { card: "summary_large_image" as const },
 };
 
-const jsonLd = {
-  "@context": "https://schema.org",
-  "@type": "WebApplication",
-  name: `Compound Interest Calculator — ${SITE_NAME}`,
+const softwareLd = calculatorJsonLd({
+  name: "Compound Interest Calculator",
   description:
     "Calculate the future value of your investments with compound interest, including regular contributions and different compounding frequencies.",
-  url: "https://invest.com.au/compound-interest-calculator",
-  applicationCategory: "FinanceApplication",
-  operatingSystem: "Any",
-  offers: { "@type": "Offer", price: "0", priceCurrency: "AUD" },
-};
+  path: "/compound-interest-calculator",
+});
 
-const breadcrumbLd = {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  itemListElement: [
-    { "@type": "ListItem", position: 1, name: "Home", item: "https://invest.com.au" },
-    { "@type": "ListItem", position: 2, name: "Calculators", item: "https://invest.com.au/calculators" },
-    {
-      "@type": "ListItem",
-      position: 3,
-      name: "Compound Interest Calculator",
-      item: "https://invest.com.au/compound-interest-calculator",
-    },
-  ],
-};
+const breadcrumbLd = breadcrumbJsonLd([
+  { name: "Home", url: absoluteUrl("/") },
+  { name: "Calculators", url: absoluteUrl("/calculators") },
+  { name: "Compound Interest Calculator", url: absoluteUrl("/compound-interest-calculator") },
+]);
 
-const faqLd = {
-  "@context": "https://schema.org",
-  "@type": "FAQPage",
-  mainEntity: [
-    {
-      "@type": "Question",
-      name: "What is compound interest?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "Compound interest is interest calculated on both the initial principal and the accumulated interest from previous periods. Unlike simple interest, compounding causes your money to grow exponentially over time — often called 'the eighth wonder of the world'.",
-      },
-    },
-    {
-      "@type": "Question",
-      name: "How often should I compound my investments?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "The more frequently interest compounds, the more you earn. Monthly compounding is common for savings accounts and many investment returns. However, the difference between monthly and daily compounding is relatively small — what matters more is starting early and keeping your money invested.",
-      },
-    },
-    {
-      "@type": "Question",
-      name: "What is a realistic compound interest rate for Australian investments?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "The Australian share market (ASX 200) has historically returned around 9-10% per annum including dividends over the long term. Diversified ETFs targeting global equities have returned 7-10% p.a. High-interest savings accounts currently offer 4-5%. Use a conservative 5-7% for long-term planning to account for inflation and fees.",
-      },
-    },
-    {
-      "@type": "Question",
-      name: "How do regular contributions affect compound growth?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "Regular contributions dramatically accelerate compound growth. Even small monthly additions — say $200/month — can add hundreds of thousands of dollars to your final balance over a 30-year period, because each contribution also compounds over time.",
-      },
-    },
-  ],
-};
+const faqLd = faqJsonLd([
+  {
+    q: "What is compound interest?",
+    a: "Compound interest is interest calculated on both the initial principal and the accumulated interest from previous periods. Unlike simple interest, compounding causes your money to grow exponentially over time — often called 'the eighth wonder of the world'.",
+  },
+  {
+    q: "How often should I compound my investments?",
+    a: "The more frequently interest compounds, the more you earn. Monthly compounding is common for savings accounts and many investment returns. However, the difference between monthly and daily compounding is relatively small — what matters more is starting early and keeping your money invested.",
+  },
+  {
+    q: "What is a realistic compound interest rate for Australian investments?",
+    a: "The Australian share market (ASX 200) has historically returned around 9-10% per annum including dividends over the long term. Diversified ETFs targeting global equities have returned 7-10% p.a. High-interest savings accounts currently offer 4-5%. Use a conservative 5-7% for long-term planning to account for inflation and fees.",
+  },
+  {
+    q: "How do regular contributions affect compound growth?",
+    a: "Regular contributions dramatically accelerate compound growth. Even small monthly additions — say $200/month — can add hundreds of thousands of dollars to your final balance over a 30-year period, because each contribution also compounds over time.",
+  },
+]);
 
 export default function CompoundInterestCalculatorPage() {
   return (
     <>
-      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(softwareLd) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }} />
       <CompoundInterestClient />

--- a/app/dividend-reinvestment-calculator/page.tsx
+++ b/app/dividend-reinvestment-calculator/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
-import { CURRENT_YEAR, SITE_NAME } from "@/lib/seo";
+import { CURRENT_YEAR, absoluteUrl, breadcrumbJsonLd } from "@/lib/seo";
+import { calculatorJsonLd, faqJsonLd } from "@/lib/schema-markup";
 import DividendReinvestmentClient from "./DividendReinvestmentClient";
 import ComplianceFooter from "@/components/ComplianceFooter";
 
@@ -25,76 +26,42 @@ export const metadata: Metadata = {
   twitter: { card: "summary_large_image" as const },
 };
 
-const jsonLd = {
-  "@context": "https://schema.org",
-  "@type": "WebApplication",
-  name: `Dividend Reinvestment Calculator — ${SITE_NAME}`,
+const softwareLd = calculatorJsonLd({
+  name: "Dividend Reinvestment Calculator",
   description:
     "Model the long-term portfolio growth difference between reinvesting dividends (DRP) versus taking them as cash.",
-  url: "https://invest.com.au/dividend-reinvestment-calculator",
-  applicationCategory: "FinanceApplication",
-  operatingSystem: "Any",
-  offers: { "@type": "Offer", price: "0", priceCurrency: "AUD" },
-};
+  path: "/dividend-reinvestment-calculator",
+});
 
-const breadcrumbLd = {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  itemListElement: [
-    { "@type": "ListItem", position: 1, name: "Home", item: "https://invest.com.au" },
-    { "@type": "ListItem", position: 2, name: "Calculators", item: "https://invest.com.au/calculators" },
-    {
-      "@type": "ListItem",
-      position: 3,
-      name: "Dividend Reinvestment Calculator",
-      item: "https://invest.com.au/dividend-reinvestment-calculator",
-    },
-  ],
-};
+const breadcrumbLd = breadcrumbJsonLd([
+  { name: "Home", url: absoluteUrl("/") },
+  { name: "Calculators", url: absoluteUrl("/calculators") },
+  { name: "Dividend Reinvestment Calculator", url: absoluteUrl("/dividend-reinvestment-calculator") },
+]);
 
-const faqLd = {
-  "@context": "https://schema.org",
-  "@type": "FAQPage",
-  mainEntity: [
-    {
-      "@type": "Question",
-      name: "What is a Dividend Reinvestment Plan (DRP)?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "A Dividend Reinvestment Plan (DRP) automatically uses your cash dividends to purchase additional shares in the same company or ETF, usually at a slight discount to the market price. This compounds your returns over time by continuously increasing your share count without any transaction fees.",
-      },
-    },
-    {
-      "@type": "Question",
-      name: "How much difference does DRP make over 20 years?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "Reinvesting dividends can make a dramatic difference over long periods. For a portfolio with a 4% dividend yield and 6% capital growth, choosing DRP over cash dividends can result in a final portfolio value 60-80% higher over 20 years, due to the compounding effect of continuously buying more shares.",
-      },
-    },
-    {
-      "@type": "Question",
-      name: "Are reinvested dividends taxed in Australia?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "Yes. In Australia, dividends are taxed in the year they are paid, regardless of whether you receive them as cash or reinvest them via DRP. The ATO treats reinvested dividends as assessable income. You also establish a new cost base for each parcel of shares acquired through DRP, which affects your future capital gains calculations.",
-      },
-    },
-    {
-      "@type": "Question",
-      name: "Which Australian ETFs offer DRP?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "Most major Australian ETFs offer DRP, including Vanguard (VAS, VGS, VDHG), iShares (IVV, IOZ), BetaShares (A200, NDQ, DHHF) and others. Check the fund's PDS or your broker's DRP enrolment options to confirm availability.",
-      },
-    },
-  ],
-};
+const faqLd = faqJsonLd([
+  {
+    q: "What is a Dividend Reinvestment Plan (DRP)?",
+    a: "A Dividend Reinvestment Plan (DRP) automatically uses your cash dividends to purchase additional shares in the same company or ETF, usually at a slight discount to the market price. This compounds your returns over time by continuously increasing your share count without any transaction fees.",
+  },
+  {
+    q: "How much difference does DRP make over 20 years?",
+    a: "Reinvesting dividends can make a dramatic difference over long periods. For a portfolio with a 4% dividend yield and 6% capital growth, choosing DRP over cash dividends can result in a final portfolio value 60-80% higher over 20 years, due to the compounding effect of continuously buying more shares.",
+  },
+  {
+    q: "Are reinvested dividends taxed in Australia?",
+    a: "Yes. In Australia, dividends are taxed in the year they are paid, regardless of whether you receive them as cash or reinvest them via DRP. The ATO treats reinvested dividends as assessable income. You also establish a new cost base for each parcel of shares acquired through DRP, which affects your future capital gains calculations.",
+  },
+  {
+    q: "Which Australian ETFs offer DRP?",
+    a: "Most major Australian ETFs offer DRP, including Vanguard (VAS, VGS, VDHG), iShares (IVV, IOZ), BetaShares (A200, NDQ, DHHF) and others. Check the fund's PDS or your broker's DRP enrolment options to confirm availability.",
+  },
+]);
 
 export default function DividendReinvestmentCalculatorPage() {
   return (
     <>
-      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(softwareLd) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }} />
       <DividendReinvestmentClient />

--- a/app/smsf-calculator/page.tsx
+++ b/app/smsf-calculator/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
-import { CURRENT_YEAR, SITE_NAME } from "@/lib/seo";
+import { CURRENT_YEAR } from "@/lib/seo";
+import { calculatorJsonLd } from "@/lib/schema-markup";
 import SMSFCalculatorClient from "./SMSFCalculatorClient";
 import ComplianceFooter from "@/components/ComplianceFooter";
 
@@ -17,21 +18,16 @@ export const metadata: Metadata = {
   twitter: { card: "summary_large_image" as const },
 };
 
-export default function SMSFCalculatorPage() {
-  const jsonLd = {
-    "@context": "https://schema.org",
-    "@type": "WebApplication",
-    name: `SMSF Eligibility Calculator — ${SITE_NAME}`,
-    description: "Calculate whether a Self-Managed Super Fund is worth it compared to your current super fund.",
-    url: "https://invest.com.au/smsf-calculator",
-    applicationCategory: "FinanceApplication",
-    operatingSystem: "Any",
-    offers: { "@type": "Offer", price: "0", priceCurrency: "AUD" },
-  };
+const softwareLd = calculatorJsonLd({
+  name: "SMSF Eligibility Calculator",
+  description: "Calculate whether a Self-Managed Super Fund is worth it compared to your current super fund.",
+  path: "/smsf-calculator",
+});
 
+export default function SMSFCalculatorPage() {
   return (
     <>
-      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(softwareLd) }} />
       <SMSFCalculatorClient />
       <div className="container-custom pb-8"><ComplianceFooter variant="calculator" /></div>
 

--- a/app/super-contributions-calculator/page.tsx
+++ b/app/super-contributions-calculator/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
-import { CURRENT_YEAR, SITE_NAME } from "@/lib/seo";
+import { CURRENT_YEAR, absoluteUrl, breadcrumbJsonLd } from "@/lib/seo";
+import { calculatorJsonLd, faqJsonLd } from "@/lib/schema-markup";
 import SuperContributionsClient from "./SuperContributionsClient";
 import ComplianceFooter from "@/components/ComplianceFooter";
 
@@ -25,75 +26,41 @@ export const metadata: Metadata = {
   twitter: { card: "summary_large_image" as const },
 };
 
-const jsonLd = {
-  "@context": "https://schema.org",
-  "@type": "WebApplication",
-  name: `Super Contributions Calculator — ${SITE_NAME}`,
+const softwareLd = calculatorJsonLd({
+  name: "Super Contributions Calculator",
   description:
     "Calculate your FY2026 concessional and non-concessional super contribution caps, tax savings from salary sacrifice, and Division 293 liability.",
-  url: "https://invest.com.au/super-contributions-calculator",
-  applicationCategory: "FinanceApplication",
-  operatingSystem: "Any",
-  offers: { "@type": "Offer", price: "0", priceCurrency: "AUD" },
-};
+  path: "/super-contributions-calculator",
+});
 
-const breadcrumbLd = {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  itemListElement: [
-    { "@type": "ListItem", position: 1, name: "Home", item: "https://invest.com.au" },
-    {
-      "@type": "ListItem",
-      position: 2,
-      name: "Super Contributions Calculator",
-      item: "https://invest.com.au/super-contributions-calculator",
-    },
-  ],
-};
+const breadcrumbLd = breadcrumbJsonLd([
+  { name: "Home", url: absoluteUrl("/") },
+  { name: "Super Contributions Calculator", url: absoluteUrl("/super-contributions-calculator") },
+]);
 
-const faqLd = {
-  "@context": "https://schema.org",
-  "@type": "FAQPage",
-  mainEntity: [
-    {
-      "@type": "Question",
-      name: "What is the concessional super contribution cap for FY2026?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "The concessional (before-tax) contribution cap is $30,000 for FY2026. This includes employer super guarantee (SG) contributions and any salary sacrifice or personal deductible contributions you make.",
-      },
-    },
-    {
-      "@type": "Question",
-      name: "What is the non-concessional super contribution cap?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "The non-concessional (after-tax) contribution cap is $120,000 per year for FY2026. If eligible, you can use the bring-forward rule to contribute up to $360,000 over three years.",
-      },
-    },
-    {
-      "@type": "Question",
-      name: "What is Division 293 tax?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "Division 293 is an additional 15% tax on concessional super contributions for individuals with income (including super contributions) exceeding $250,000. This brings the total super tax rate to 30% for high earners, rather than the standard 15%.",
-      },
-    },
-    {
-      "@type": "Question",
-      name: "Can I carry forward unused super contribution caps?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "Yes, if your total super balance is below $500,000 on 30 June of the previous financial year, you can carry forward unused concessional cap amounts from the preceding five financial years and use them in a single year.",
-      },
-    },
-  ],
-};
+const faqLd = faqJsonLd([
+  {
+    q: "What is the concessional super contribution cap for FY2026?",
+    a: "The concessional (before-tax) contribution cap is $30,000 for FY2026. This includes employer super guarantee (SG) contributions and any salary sacrifice or personal deductible contributions you make.",
+  },
+  {
+    q: "What is the non-concessional super contribution cap?",
+    a: "The non-concessional (after-tax) contribution cap is $120,000 per year for FY2026. If eligible, you can use the bring-forward rule to contribute up to $360,000 over three years.",
+  },
+  {
+    q: "What is Division 293 tax?",
+    a: "Division 293 is an additional 15% tax on concessional super contributions for individuals with income (including super contributions) exceeding $250,000. This brings the total super tax rate to 30% for high earners, rather than the standard 15%.",
+  },
+  {
+    q: "Can I carry forward unused super contribution caps?",
+    a: "Yes, if your total super balance is below $500,000 on 30 June of the previous financial year, you can carry forward unused concessional cap amounts from the preceding five financial years and use them in a single year.",
+  },
+]);
 
 export default function SuperContributionsCalculatorPage() {
   return (
     <>
-      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(softwareLd) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }} />
       <SuperContributionsClient />


### PR DESCRIPTION
## F-07 batch 2 — JSON-LD migration (5 calculator pages)

Continues from PR #527 (batch 1, merged). Migrates 5 more calculator pages from inline hardcoded JSON-LD objects to the typed helpers in `lib/schema-markup.ts` and `lib/seo.ts`.

| File | Before | After |
|------|--------|-------|
| `compound-interest-calculator` | inline `WebApplication` + `BreadcrumbList` + `FAQPage` | `calculatorJsonLd` + `breadcrumbJsonLd` + `faqJsonLd` |
| `super-contributions-calculator` | inline `WebApplication` + `BreadcrumbList` + `FAQPage` | `calculatorJsonLd` + `breadcrumbJsonLd` + `faqJsonLd` |
| `dividend-reinvestment-calculator` | inline `WebApplication` + `BreadcrumbList` + `FAQPage` | `calculatorJsonLd` + `breadcrumbJsonLd` + `faqJsonLd` |
| `cgt-calculator` | inline `SoftwareApplication` + `FAQPage` (breadcrumb already used helper) | `calculatorJsonLd` + `faqJsonLd` |
| `smsf-calculator` | inline `WebApplication` (inside component fn) | `calculatorJsonLd` (module-level const) |

### Also fixes
- `cgt-calculator` used `SoftwareApplication` — corrected to `WebApplication` via `calculatorJsonLd()` (a CGT calculator is a web tool, not a desktop app)
- `smsf-calculator` had the JSON-LD object defined inside the component function body (recreated on every render) — moved to module scope

### Batch checklist
- [x] F-07 batch 2: 5 calculator pages migrated (11/~42 blocks total across batch 1+2)

### Remaining
~31 hardcoded JSON-LD blocks remain across advisor-guides, foreign-investment/*, insurance/*, invest/*, compare/*, and other pages.

Refs: #215
Audit: docs/audits/codebase-health-2026-04-24.md §F
Queue: docs/audits/REMEDIATION_QUEUE.md F-07

---
_Generated by [Claude Code](https://claude.ai/code/session_017xcsdeneNBGE2q6toYXQNk)_