### PR TITLE
feat(e): E-04 batch 5 — Zod validation on account/analytics/reactions routes

### DIFF
--- a/__tests__/api/account-accept-terms.test.ts
+++ b/__tests__/api/account-accept-terms.test.ts
@@ -105,14 +105,12 @@ describe("POST /api/account/accept-terms", () => {
     });
   });
 
-  it("truncates oversized version strings to 50 chars", async () => {
+  it("rejects oversized version strings (>50 chars) with 400", async () => {
     mockGetUser.mockResolvedValueOnce({ data: { user: { id: "u1" } } });
     const long = "x".repeat(500);
-    await POST(makeReq({ tos_version: long, privacy_version: long }));
-    expect((insertCalls[0]?.tos_version as string).length).toBeLessThanOrEqual(50);
-    expect((insertCalls[0]?.privacy_version as string).length).toBeLessThanOrEqual(
-      50,
-    );
+    const res = await POST(makeReq({ tos_version: long, privacy_version: long }));
+    expect(res.status).toBe(400);
+    expect(insertCalls).toHaveLength(0);
   });
 
   it("treats a duplicate-row error (23505) as success (idempotent)", async () => {

--- a/app/api/account/accept-terms/route.ts
+++ b/app/api/account/accept-terms/route.ts
@@ -6,8 +6,8 @@ import { logger } from "@/lib/logger";
 const log = logger("accept-terms");
 
 const AcceptTermsBody = z.object({
-  tos_version: z.string().max(50),
-  privacy_version: z.string().max(50),
+  tos_version: z.string().min(1).max(50),
+  privacy_version: z.string().min(1).max(50),
 });
 
 export const runtime = "nodejs";
@@ -35,15 +35,14 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Authentication required" }, { status: 401 });
   }
 
-  const rawBody = await request.json().catch(() => null);
-  const bodyResult = AcceptTermsBody.safeParse(rawBody);
-  if (!bodyResult.success) {
+  const parsed = AcceptTermsBody.safeParse(await request.json().catch(() => ({})));
+  if (!parsed.success) {
     return NextResponse.json(
       { error: "tos_version and privacy_version are required" },
       { status: 400 }
     );
   }
-  const { tos_version, privacy_version } = bodyResult.data;
+  const { tos_version, privacy_version } = parsed.data;
 
   const ip = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() || null;
   const userAgent = request.headers.get("user-agent")?.slice(0, 500) || null;

--- a/app/api/account/bookmarks/route.ts
+++ b/app/api/account/bookmarks/route.ts
@@ -24,15 +24,15 @@ export const runtime = "nodejs";
  */
 const BOOKMARK_TYPES = ["article", "broker", "advisor", "scenario", "calculator"] as const;
 
-const BookmarkWriteBody = z.object({
+const AddBookmarkBody = z.object({
   type: z.enum(BOOKMARK_TYPES),
   ref: z.string().min(1).max(200),
-  label: z.string().max(200).optional(),
-  note: z.string().max(2000).optional(),
-  session_id: z.string().max(100).optional(),
+  label: z.string().max(200).nullish(),
+  note: z.string().max(2000).nullish(),
+  session_id: z.string().max(100).nullish(),
 });
 
-const BookmarkDeleteBody = z.object({
+const RemoveBookmarkBody = z.object({
   type: z.enum(BOOKMARK_TYPES),
   ref: z.string().min(1),
 });
@@ -63,16 +63,15 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Too many requests" }, { status: 429 });
   }
 
-  const rawBody = await request.json().catch(() => null);
-  const bodyResult = BookmarkWriteBody.safeParse(rawBody);
-  if (!bodyResult.success) {
+  const parsed = AddBookmarkBody.safeParse(await request.json().catch(() => ({})));
+  if (!parsed.success) {
     return NextResponse.json({ error: "Invalid type or ref" }, { status: 400 });
   }
-  const { type, ref, label, note, session_id: sessionId } = bodyResult.data;
+  const { type, ref, label = null, note = null, session_id: sessionId = null } = parsed.data;
 
   const user = await getUser();
   if (user) {
-    const ok = await addBookmark({ userId: user.id, type, ref, label, note });
+    const ok = await addBookmark({ userId: user.id, type, ref, label: label ?? null, note: note ?? null });
     return NextResponse.json({ ok });
   }
 
@@ -83,7 +82,7 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const ok = await addAnonymousSave({ sessionId, type, ref, label });
+  const ok = await addAnonymousSave({ sessionId, type, ref, label: label ?? null });
   if (!ok) log.warn("anonymous save failed", { sessionId, type, ref });
   return NextResponse.json({ ok, anonymous: true });
 }
@@ -92,12 +91,11 @@ export async function DELETE(request: NextRequest) {
   const user = await getUser();
   if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  const rawBody = await request.json().catch(() => null);
-  const deleteResult = BookmarkDeleteBody.safeParse(rawBody);
-  if (!deleteResult.success) {
+  const parsed = RemoveBookmarkBody.safeParse(await request.json().catch(() => ({})));
+  if (!parsed.success) {
     return NextResponse.json({ error: "Invalid type or ref" }, { status: 400 });
   }
-  const { type, ref } = deleteResult.data;
+  const { type, ref } = parsed.data;
   const ok = await removeBookmark({ userId: user.id, type, ref });
   return NextResponse.json({ ok });
 }

--- a/app/api/account/delete/route.ts
+++ b/app/api/account/delete/route.ts
@@ -80,9 +80,8 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Authentication required" }, { status: 401 });
   }
 
-  const rawBody = await request.json().catch(() => ({}));
-  const bodyResult = AccountDeleteBody.safeParse(rawBody);
-  const reason = bodyResult.success ? (bodyResult.data.reason ?? null) : null;
+  const parsed = AccountDeleteBody.safeParse(await request.json().catch(() => ({})));
+  const reason: string | null = parsed.success ? (parsed.data.reason ?? null) : null;
 
   const ip = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() || null;
   const userAgent = request.headers.get("user-agent")?.slice(0, 500) || null;

--- a/app/api/analytics/search-log/route.ts
+++ b/app/api/analytics/search-log/route.ts
@@ -1,8 +1,18 @@
 import { NextRequest, NextResponse } from "next/server";
-import { logSearchQuery, isValidSurface } from "@/lib/search-analytics";
+import { z } from "zod";
+import { logSearchQuery } from "@/lib/search-analytics";
 import { isAllowed, ipKey } from "@/lib/rate-limit-db";
 
 export const runtime = "nodejs";
+
+const SearchLogBody = z.object({
+  query: z.string().min(1),
+  surface: z.enum(["articles", "advisors", "compare", "best_for", "topic", "tag", "quiz", "global"]),
+  result_count: z.number().nullish(),
+  result_clicked: z.boolean().optional(),
+  clicked_rank: z.number().nullish(),
+  session_id: z.string().nullish(),
+});
 
 /**
  * POST /api/analytics/search-log
@@ -29,21 +39,19 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "rate_limited" }, { status: 429 });
   }
 
-  const body = await request.json().catch(() => ({}));
-  const query = typeof body.query === "string" ? body.query : null;
-  const surface = body.surface;
-  if (!query || !isValidSurface(surface)) {
+  const parsed = SearchLogBody.safeParse(await request.json().catch(() => ({})));
+  if (!parsed.success) {
     return NextResponse.json({ error: "invalid_request" }, { status: 400 });
   }
+  const { query, surface, result_count, result_clicked, clicked_rank, session_id } = parsed.data;
 
   const ok = await logSearchQuery({
     queryText: query,
     surface,
-    resultCount: typeof body.result_count === "number" ? body.result_count : null,
-    resultClicked: body.result_clicked === true,
-    clickedRank:
-      typeof body.clicked_rank === "number" ? body.clicked_rank : null,
-    sessionId: typeof body.session_id === "string" ? body.session_id : null,
+    resultCount: result_count ?? null,
+    resultClicked: result_clicked ?? false,
+    clickedRank: clicked_rank ?? null,
+    sessionId: session_id ?? null,
   });
 
   if (!ok) {

--- a/app/api/article-reactions/route.ts
+++ b/app/api/article-reactions/route.ts
@@ -1,13 +1,17 @@
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 import { createClient } from "@/lib/supabase/server";
 import {
   getReactionCounts,
   hashIp,
-  isValidReaction,
   reactToArticle,
-  type ReactionKind,
 } from "@/lib/article-comments";
 import { isAllowed, ipKey } from "@/lib/rate-limit-db";
+
+const ReactBody = z.object({
+  slug: z.string().min(1),
+  reaction: z.enum(["helpful", "like", "confused", "disagree"]),
+});
 
 export const runtime = "nodejs";
 
@@ -37,15 +41,14 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Too many requests" }, { status: 429 });
   }
 
-  const body = await request.json().catch(() => ({}));
-  const slug = typeof body.slug === "string" ? body.slug : null;
-  const reaction = body.reaction as ReactionKind;
-  if (!slug || !isValidReaction(reaction)) {
+  const parsed = ReactBody.safeParse(await request.json().catch(() => ({})));
+  if (!parsed.success) {
     return NextResponse.json(
       { error: "Missing slug or reaction" },
       { status: 400 },
     );
   }
+  const { slug, reaction } = parsed.data;
 
   // Prefer authenticated user id so the dedup is permanent. Anonymous
   // visitors dedup by IP hash (salted server-side).


### PR DESCRIPTION
## E-04 batch 5 — Zod validation backfill

Continues the `invest/no-unvalidated-req-json` backfill started in batches 1–4.

| Route | Schema |
|---|---|
| `account/accept-terms` | `AcceptTermsBody` — `tos_version` + `privacy_version` (max 50) |
| `account/bookmarks` | `AddBookmarkBody` (POST) + `RemoveBookmarkBody` (DELETE) — `z.enum` of BookmarkType |
| `account/delete` | `DeleteBody` — optional `reason` string (max 1000) |
| `analytics/search-log` | `SearchLogBody` — `SearchSurface` enum + optional numeric counts |
| `article-reactions` | `ReactBody` — `slug` + `z.enum` of ReactionKind |

**In-flight context:**
- Batch 4 (PR #566): `affiliate/click`, `quiz/submit`, `developer-leads`, `claim-listing`, `broker-review-invite`, `questions/*`
- Batches 2–3 (PRs #557/#560): `admin/foreign-investment/*`, `review-moderation`

**Safety notes:**
- No schema migrations, no RLS changes
- All routes are auth-gated or rate-limited before the body parse
- `analytics/search-log`: drops now-redundant `isValidSurface()` guard (enum covers same values)
- `article-reactions`: drops `isValidReaction()` guard (enum covers same values)
- `account/bookmarks` POST supports both authenticated + anonymous saves — both paths retained

Refs: #218
Audit: `docs/audits/codebase-health-2026-04-24.md` §E
Queue: E-04 batch 5

---
_Generated by [Claude Code](https://claude.ai/code/session_01P2yK64cFDzB1CnDorYd2mS)_