### PR TITLE
feat(conversion): AdvisorPrompt + broker widgets on FI guides + SMSF pages

### DIFF
--- a/app/foreign-investment/guides/buy-property-australia-foreigner/page.tsx
+++ b/app/foreign-investment/guides/buy-property-australia-foreigner/page.tsx
@@ -5,6 +5,10 @@ import { FIRB_FEES, STATE_SURCHARGES } from "@/lib/firb-data";
 import { FIRB_DISCLAIMER } from "@/lib/compliance";
 import SectionHeading from "@/components/SectionHeading";
 import ComplianceFooter from "@/components/ComplianceFooter";
+import AdvisorPrompt from "@/components/AdvisorPrompt";
+import { createClient } from "@/lib/supabase/server";
+import { getAffiliateLink, AFFILIATE_REL, renderStars } from "@/lib/tracking";
+import type { Broker } from "@/lib/types";
 
 export const metadata: Metadata = {
   title: "How to Buy Property in Australia as a Foreigner (2026 Guide)",
@@ -28,6 +32,21 @@ export const metadata: Metadata = {
 };
 
 export const revalidate = 86400;
+
+export default async function BuyPropertyAustralieForeignerPage() {
+  const supabase = await createClient();
+  const { data: fxProviders } = await supabase
+    .from("brokers")
+    .select("id, name, slug, color, affiliate_url, rating, tagline, cta_text, benefit_cta")
+    .eq("platform_type", "fx_provider")
+    .eq("status", "active")
+    .order("rating", { ascending: false })
+    .limit(3);
+
+  return <BuyPropertyAustralieForeignerPageInner fxProviders={fxProviders} />;
+}
+
+type FxProvider = Pick<Broker, "id" | "name" | "slug" | "color" | "affiliate_url" | "rating" | "tagline" | "cta_text" | "benefit_cta">;
 
 const STEPS = [
   {
@@ -116,7 +135,7 @@ const FAQS = [
   },
 ];
 
-export default function BuyPropertyAustralieForeignerPage() {
+function BuyPropertyAustralieForeignerPageInner({ fxProviders }: { fxProviders: FxProvider[] | null }) {
   return (
     <div className="bg-white min-h-screen">
       <script
@@ -430,6 +449,49 @@ export default function BuyPropertyAustralieForeignerPage() {
             ))}
           </div>
         </section>
+
+        {/* ── Advisor CTAs ── */}
+        <AdvisorPrompt
+          type="property_advisor"
+          heading="Find a buyer's agent who specialises in foreign purchases"
+        />
+
+        <AdvisorPrompt
+          type="mortgage_broker"
+          heading="Non-resident investment loan"
+        />
+
+        {/* ── FX mini-strip ── */}
+        {fxProviders && fxProviders.length > 0 && (
+          <section className="bg-slate-50 border border-slate-200 rounded-2xl p-6 space-y-4">
+            <div>
+              <p className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-1">FX Providers</p>
+              <h2 className="text-lg font-bold text-slate-900">Transfer your deposit to Australia</h2>
+              <p className="text-sm text-slate-500 mt-1">Use a specialist FX provider — not your bank — to transfer your deposit. Savings of 1–3% on $500K = $5,000–15,000.</p>
+            </div>
+            <div className="grid sm:grid-cols-3 gap-3">
+              {fxProviders.map((b) => (
+                <div key={b.slug} className="bg-white rounded-xl border border-slate-200 p-4 flex flex-col gap-3">
+                  <div>
+                    <p className="font-bold text-slate-900 text-sm">{b.name}</p>
+                    <p className="text-xs text-amber-500">{renderStars(Number(b.rating ?? 0))}</p>
+                    <p className="text-xs text-slate-500 mt-1 line-clamp-2">{b.tagline}</p>
+                  </div>
+                  <div className="mt-auto">
+                    <a
+                      href={getAffiliateLink(b as Broker)}
+                      rel={AFFILIATE_REL}
+                      target="_blank"
+                      className="block text-center w-full px-3 py-2 bg-amber-500 hover:bg-amber-400 text-slate-900 font-bold text-xs rounded-lg transition-colors"
+                    >
+                      {b.cta_text ?? "Learn More →"}
+                    </a>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
 
         {/* ── Disclaimer ── */}
         <div className="bg-slate-50 border border-slate-200 rounded-xl p-4">

--- a/app/foreign-investment/guides/firb-application-guide/page.tsx
+++ b/app/foreign-investment/guides/firb-application-guide/page.tsx
@@ -5,6 +5,7 @@ import { FIRB_FEES, FIRB_PROCESS_STEPS, FIRB_FAQS, WHO_NEEDS_FIRB } from "@/lib/
 import { FIRB_DISCLAIMER } from "@/lib/compliance";
 import SectionHeading from "@/components/SectionHeading";
 import ComplianceFooter from "@/components/ComplianceFooter";
+import AdvisorPrompt from "@/components/AdvisorPrompt";
 
 export const metadata: Metadata = {
   title: "FIRB Application: Complete Step-by-Step Guide (2026)",
@@ -308,6 +309,17 @@ export default function FirbApplicationGuidePage() {
             ))}
           </div>
         </section>
+
+        {/* ── Advisor CTAs ── */}
+        <AdvisorPrompt
+          type="property_advisor"
+          heading="Work with a FIRB-experienced buyer's agent"
+        />
+
+        <AdvisorPrompt
+          type="tax_agent"
+          heading="Understand the tax implications before you buy"
+        />
 
         <div className="bg-slate-50 border border-slate-200 rounded-xl p-4">
           <p className="text-xs text-slate-500 leading-relaxed">{FIRB_DISCLAIMER}</p>

--- a/app/foreign-investment/guides/property-ban-2025/page.tsx
+++ b/app/foreign-investment/guides/property-ban-2025/page.tsx
@@ -1,3 +1,4 @@
+// dated-strings-exempt — entire page documents a specific legislative ban period (1 April 2025–31 March 2027); all dates are immutable statute references
 import Link from "next/link";
 import type { Metadata } from "next";
 import { breadcrumbJsonLd, SITE_URL } from "@/lib/seo";

--- a/app/foreign-investment/guides/property-ban-2025/page.tsx
+++ b/app/foreign-investment/guides/property-ban-2025/page.tsx
@@ -5,6 +5,10 @@ import { STATE_SURCHARGES } from "@/lib/firb-data";
 import { FIRB_DISCLAIMER } from "@/lib/compliance";
 import SectionHeading from "@/components/SectionHeading";
 import ComplianceFooter from "@/components/ComplianceFooter";
+import AdvisorPrompt from "@/components/AdvisorPrompt";
+import { createClient } from "@/lib/supabase/server";
+import { getAffiliateLink, AFFILIATE_REL, renderStars } from "@/lib/tracking";
+import type { Broker } from "@/lib/types";
 
 export const metadata: Metadata = {
   title: "Australia's Foreign Buyer Property Ban 2025–2027: What You Can (and Can't) Buy",
@@ -29,7 +33,16 @@ export const metadata: Metadata = {
 
 export const revalidate = 86400;
 
-export default function PropertyBan2025Page() {
+export default async function PropertyBan2025Page() {
+  const supabase = await createClient();
+  const { data: nonResidentBrokers } = await supabase
+    .from("brokers")
+    .select("id, name, slug, color, affiliate_url, rating, tagline, cta_text, benefit_cta, asx_fee")
+    .eq("platform_type", "share_broker")
+    .eq("accepts_non_residents", true)
+    .eq("status", "active")
+    .order("rating", { ascending: false })
+    .limit(3);
   return (
     <div className="bg-white min-h-screen">
       <script
@@ -378,6 +391,44 @@ export default function PropertyBan2025Page() {
             ))}
           </div>
         </section>
+
+        {/* ── Advisor CTA ── */}
+        <AdvisorPrompt
+          type="property_advisor"
+          heading="Alternatives to direct property: find a buyer's agent"
+        />
+
+        {/* ── Non-resident broker mini-strip ── */}
+        {nonResidentBrokers && nonResidentBrokers.length > 0 && (
+          <section className="bg-slate-50 border border-slate-200 rounded-2xl p-6 space-y-4">
+            <div>
+              <p className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-1">Share Brokers</p>
+              <h2 className="text-lg font-bold text-slate-900">ASX brokers that accept non-residents</h2>
+              <p className="text-sm text-slate-500 mt-1">Non-residents can still invest in Australian shares while the property ban is in effect.</p>
+            </div>
+            <div className="grid sm:grid-cols-3 gap-3">
+              {nonResidentBrokers.map((b) => (
+                <div key={b.slug} className="bg-white rounded-xl border border-slate-200 p-4 flex flex-col gap-3">
+                  <div>
+                    <p className="font-bold text-slate-900 text-sm">{b.name}</p>
+                    <p className="text-xs text-amber-500">{renderStars(Number(b.rating ?? 0))}</p>
+                    <p className="text-xs text-slate-500 mt-1 line-clamp-2">{b.tagline}</p>
+                  </div>
+                  <div className="mt-auto">
+                    <a
+                      href={getAffiliateLink(b as Broker)}
+                      rel={AFFILIATE_REL}
+                      target="_blank"
+                      className="block text-center w-full px-3 py-2 bg-amber-500 hover:bg-amber-400 text-slate-900 font-bold text-xs rounded-lg transition-colors"
+                    >
+                      {b.cta_text ?? "Learn More →"}
+                    </a>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
 
         <div className="bg-slate-50 border border-slate-200 rounded-xl p-4">
           <p className="text-xs text-slate-500 leading-relaxed">{FIRB_DISCLAIMER}</p>

--- a/app/foreign-investment/guides/stamp-duty-foreign-buyers/page.tsx
+++ b/app/foreign-investment/guides/stamp-duty-foreign-buyers/page.tsx
@@ -2,9 +2,10 @@ import Link from "next/link";
 import type { Metadata } from "next";
 import { breadcrumbJsonLd, SITE_URL } from "@/lib/seo";
 import { STATE_SURCHARGES } from "@/lib/firb-data";
-import { FIRB_DISCLAIMER, FOREIGN_BUYER_STAMP_DUTY_WARNING } from "@/lib/compliance";
+import { FOREIGN_BUYER_STAMP_DUTY_WARNING } from "@/lib/compliance";
 import SectionHeading from "@/components/SectionHeading";
 import ComplianceFooter from "@/components/ComplianceFooter";
+import AdvisorPrompt from "@/components/AdvisorPrompt";
 
 export const metadata: Metadata = {
   title: "Foreign Buyer Stamp Duty by State (2026)",
@@ -331,6 +332,17 @@ export default function StampDutyForeignBuyersPage() {
             ))}
           </div>
         </section>
+
+        {/* ── Advisor CTAs ── */}
+        <AdvisorPrompt
+          type="tax_agent"
+          heading="Get a stamp duty and tax estimate for your purchase"
+        />
+
+        <AdvisorPrompt
+          type="property_advisor"
+          heading="Find a conveyancer or buyer's agent"
+        />
 
         <div className="bg-slate-50 border border-slate-200 rounded-xl p-4">
           <p className="text-xs text-slate-500 leading-relaxed">{FOREIGN_BUYER_STAMP_DUTY_WARNING}</p>

--- a/app/smsf/checklist/page.tsx
+++ b/app/smsf/checklist/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { breadcrumbJsonLd, SITE_URL, absoluteUrl } from "@/lib/seo";
 import SmsfChecklistClient from "./SmsfChecklistClient";
+import AdvisorPrompt from "@/components/AdvisorPrompt";
 
 export const revalidate = 86400;
 
@@ -36,6 +37,15 @@ export default function SmsfChecklistPage() {
         <section className="py-10 bg-slate-50">
           <div className="container-custom max-w-3xl">
             <SmsfChecklistClient />
+          </div>
+        </section>
+
+        <section className="py-12 bg-white border-t border-slate-200">
+          <div className="container-custom max-w-2xl">
+            <AdvisorPrompt
+              type="smsf_accountant"
+              heading="Work through your SMSF checklist with an expert"
+            />
           </div>
         </section>
       </div>

--- a/app/smsf/crypto/page.tsx
+++ b/app/smsf/crypto/page.tsx
@@ -3,6 +3,10 @@ import type { Metadata } from "next";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR, absoluteUrl } from "@/lib/seo";
 import Icon from "@/components/Icon";
 import HubLeadForm from "@/components/leads/HubLeadForm";
+import AdvisorPrompt from "@/components/AdvisorPrompt";
+import { createClient } from "@/lib/supabase/server";
+import { getAffiliateLink, AFFILIATE_REL, renderStars } from "@/lib/tracking";
+import type { Broker } from "@/lib/types";
 
 export const revalidate = 3600;
 
@@ -19,12 +23,26 @@ export const metadata: Metadata = {
   },
 };
 
-export default function SmsfCryptoPage() {
+type CryptoExchange = Pick<Broker, "id" | "name" | "slug" | "color" | "affiliate_url" | "rating" | "tagline" | "cta_text" | "benefit_cta">;
+
+export default async function SmsfCryptoPage() {
+  const supabase = await createClient();
+  const { data: cryptoExchanges } = await supabase
+    .from("brokers")
+    .select("id, name, slug, color, affiliate_url, rating, tagline, cta_text, benefit_cta")
+    .eq("platform_type", "crypto_exchange")
+    .eq("status", "active")
+    .order("rating", { ascending: false })
+    .limit(3);
   const breadcrumb = breadcrumbJsonLd([
     { name: "Home", url: `${SITE_URL}/` },
     { name: "SMSF", url: absoluteUrl("/smsf") },
     { name: "Crypto", url: absoluteUrl("/smsf/crypto") },
   ]);
+  return <SmsfCryptoPageInner cryptoExchanges={cryptoExchanges} breadcrumb={breadcrumb} />;
+}
+
+function SmsfCryptoPageInner({ cryptoExchanges, breadcrumb }: { cryptoExchanges: CryptoExchange[] | null; breadcrumb: object }) {
   return (
     <>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }} />
@@ -123,8 +141,49 @@ export default function SmsfCryptoPage() {
           </div>
         </section>
 
+        {/* ── Crypto exchange mini-strip ── */}
+        {cryptoExchanges && cryptoExchanges.length > 0 && (
+          <section className="py-12 bg-white border-t border-slate-200">
+            <div className="container-custom max-w-5xl">
+              <div className="bg-slate-50 border border-slate-200 rounded-2xl p-6 space-y-4">
+                <div>
+                  <p className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-1">Crypto Exchanges</p>
+                  <h2 className="text-lg font-bold text-slate-900">SMSF-eligible crypto exchanges</h2>
+                  <p className="text-sm text-slate-500 mt-1">Ensure the exchange can issue tax reports in the format your SMSF auditor requires.</p>
+                </div>
+                <div className="grid sm:grid-cols-3 gap-3">
+                  {cryptoExchanges.map((b) => (
+                    <div key={b.slug} className="bg-white rounded-xl border border-slate-200 p-4 flex flex-col gap-3">
+                      <div>
+                        <p className="font-bold text-slate-900 text-sm">{b.name}</p>
+                        <p className="text-xs text-amber-500">{renderStars(Number(b.rating ?? 0))}</p>
+                        <p className="text-xs text-slate-500 mt-1 line-clamp-2">{b.tagline}</p>
+                      </div>
+                      <div className="mt-auto">
+                        <a
+                          href={getAffiliateLink(b as Broker)}
+                          rel={AFFILIATE_REL}
+                          target="_blank"
+                          className="block text-center w-full px-3 py-2 bg-amber-500 hover:bg-amber-400 text-slate-900 font-bold text-xs rounded-lg transition-colors"
+                        >
+                          {b.cta_text ?? "Learn More →"}
+                        </a>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </section>
+        )}
+
+        {/* ── Advisor CTA + Lead Form ── */}
         <section className="py-12 bg-slate-50 border-t border-slate-200">
-          <div className="container-custom max-w-2xl">
+          <div className="container-custom max-w-2xl space-y-6">
+            <AdvisorPrompt
+              type="smsf_accountant"
+              heading="Crypto in SMSFs: get the compliance right"
+            />
             <HubLeadForm
               heading="Speak to an SMSF crypto specialist"
               subheading="Deed update, investment strategy review, and dedicated account setup — without breaching the sole-purpose test."

--- a/app/smsf/investment-strategy/page.tsx
+++ b/app/smsf/investment-strategy/page.tsx
@@ -82,6 +82,7 @@ export default async function SmsfInvestmentStrategyPage() {
         <section className="py-12 bg-amber-50 border-y border-amber-200">
           <div className="container-custom max-w-4xl">
             <h2 className="text-xl md:text-2xl font-extrabold text-amber-900 mb-3">Division 296 — what changes from July 2026</h2>
+            {/* dated-ok — Division 296 legislated commencement date, fixed by statute */}
             <p className="text-sm text-amber-900 leading-relaxed">
               From 1 July 2026, the new Division 296 framework applies an additional 30% tax rate on earnings attributable to the portion of a member&rsquo;s total super balance over $3 million. SMSFs with concentrated property or single-asset exposure are most affected because notional gains are included in the calculation. Trustees with balances approaching the threshold should model the impact and consider re-weighting before the transition.
             </p>

--- a/app/smsf/investment-strategy/page.tsx
+++ b/app/smsf/investment-strategy/page.tsx
@@ -82,8 +82,8 @@ export default async function SmsfInvestmentStrategyPage() {
         <section className="py-12 bg-amber-50 border-y border-amber-200">
           <div className="container-custom max-w-4xl">
             <h2 className="text-xl md:text-2xl font-extrabold text-amber-900 mb-3">Division 296 — what changes from July 2026</h2>
-            {/* dated-ok — Division 296 legislated commencement date, fixed by statute */}
             <p className="text-sm text-amber-900 leading-relaxed">
+              {/* // dated-ok — Division 296 legislated commencement date, fixed by statute */}
               From 1 July 2026, the new Division 296 framework applies an additional 30% tax rate on earnings attributable to the portion of a member&rsquo;s total super balance over $3 million. SMSFs with concentrated property or single-asset exposure are most affected because notional gains are included in the calculation. Trustees with balances approaching the threshold should model the impact and consider re-weighting before the transition.
             </p>
           </div>

--- a/app/smsf/investment-strategy/page.tsx
+++ b/app/smsf/investment-strategy/page.tsx
@@ -2,6 +2,10 @@ import Link from "next/link";
 import type { Metadata } from "next";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR, absoluteUrl } from "@/lib/seo";
 import HubLeadForm from "@/components/leads/HubLeadForm";
+import AdvisorPrompt from "@/components/AdvisorPrompt";
+import { createClient } from "@/lib/supabase/server";
+import { getAffiliateLink, AFFILIATE_REL, renderStars } from "@/lib/tracking";
+import type { Broker } from "@/lib/types";
 
 export const revalidate = 3600;
 
@@ -18,7 +22,16 @@ export const metadata: Metadata = {
   },
 };
 
-export default function SmsfInvestmentStrategyPage() {
+export default async function SmsfInvestmentStrategyPage() {
+  const supabase = await createClient();
+  const { data: smsfBrokers } = await supabase
+    .from("brokers")
+    .select("id, name, slug, color, affiliate_url, rating, tagline, cta_text, benefit_cta")
+    .eq("smsf_support", true)
+    .eq("status", "active")
+    .order("rating", { ascending: false })
+    .limit(3);
+
   const breadcrumb = breadcrumbJsonLd([
     { name: "Home", url: `${SITE_URL}/` },
     { name: "SMSF", url: absoluteUrl("/smsf") },
@@ -95,8 +108,48 @@ export default function SmsfInvestmentStrategyPage() {
           </div>
         </section>
 
+        {/* ── SMSF broker mini-strip ── */}
+        {smsfBrokers && smsfBrokers.length > 0 && (
+          <section className="py-12 bg-white border-t border-slate-200">
+            <div className="container-custom max-w-5xl">
+              <div className="bg-slate-50 border border-slate-200 rounded-2xl p-6 space-y-4">
+                <div>
+                  <p className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-1">Share Brokers</p>
+                  <h2 className="text-lg font-bold text-slate-900">Platforms that support SMSF investment strategies</h2>
+                  <p className="text-sm text-slate-500 mt-1">Your SMSF needs a broker that issues HINs to the fund — not to individual members.</p>
+                </div>
+                <div className="grid sm:grid-cols-3 gap-3">
+                  {smsfBrokers.map((b) => (
+                    <div key={b.slug} className="bg-white rounded-xl border border-slate-200 p-4 flex flex-col gap-3">
+                      <div>
+                        <p className="font-bold text-slate-900 text-sm">{b.name}</p>
+                        <p className="text-xs text-amber-500">{renderStars(Number(b.rating ?? 0))}</p>
+                        <p className="text-xs text-slate-500 mt-1 line-clamp-2">{b.tagline}</p>
+                      </div>
+                      <div className="mt-auto">
+                        <a
+                          href={getAffiliateLink(b as Broker)}
+                          rel={AFFILIATE_REL}
+                          target="_blank"
+                          className="block text-center w-full px-3 py-2 bg-amber-500 hover:bg-amber-400 text-slate-900 font-bold text-xs rounded-lg transition-colors"
+                        >
+                          {b.cta_text ?? "Learn More →"}
+                        </a>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </section>
+        )}
+
         <section className="py-12 bg-slate-50 border-t border-slate-200">
-          <div className="container-custom max-w-2xl">
+          <div className="container-custom max-w-2xl space-y-6">
+            <AdvisorPrompt
+              type="smsf_accountant"
+              heading="Get your SMSF investment strategy reviewed"
+            />
             <HubLeadForm
               heading="Get a financial planner to review your SMSF strategy"
               subheading="A formal review against ATO guidance plus a Division 296 stress-test for high-balance members."

--- a/app/smsf/property/page.tsx
+++ b/app/smsf/property/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import type { Metadata } from "next";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR, absoluteUrl } from "@/lib/seo";
 import HubLeadForm from "@/components/leads/HubLeadForm";
+import AdvisorPrompt from "@/components/AdvisorPrompt";
 
 export const revalidate = 3600;
 
@@ -102,7 +103,15 @@ export default function SmsfPropertyPage() {
         </section>
 
         <section className="py-12 bg-slate-50 border-y border-slate-200">
-          <div className="container-custom max-w-2xl">
+          <div className="container-custom max-w-2xl space-y-6">
+            <AdvisorPrompt
+              type="smsf_accountant"
+              heading="Get specialist SMSF advice before investing in property"
+            />
+            <AdvisorPrompt
+              type="mortgage_broker"
+              heading="SMSF limited recourse borrowing arrangement (LRBA)"
+            />
             <HubLeadForm
               heading="Speak to an SMSF property specialist"
               subheading="LRBA structuring, bare-trust setup, deed update — get the structure right before you make an offer."

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -3521,6 +3521,7 @@ export type Database = {
           fee_stale: boolean | null
           fee_stale_since: string | null
           fee_verified_date: string | null
+          foreign_investor_notes: string | null
           fx_rate: number | null
           headquarters: string | null
           icon: string | null
@@ -3597,6 +3598,7 @@ export type Database = {
           fee_stale?: boolean | null
           fee_stale_since?: string | null
           fee_verified_date?: string | null
+          foreign_investor_notes?: string | null
           fx_rate?: number | null
           headquarters?: string | null
           icon?: string | null
@@ -3673,6 +3675,7 @@ export type Database = {
           fee_stale?: boolean | null
           fee_stale_since?: string | null
           fee_verified_date?: string | null
+          foreign_investor_notes?: string | null
           fx_rate?: number | null
           headquarters?: string | null
           icon?: string | null


### PR DESCRIPTION
## Problem

Eight content pages — 4 foreign investment guides and 4 SMSF pages — had zero conversion components. High-intent readers researching property purchases, stamp duty, FIRB, and SMSF strategy had no path to act.

## What changed

### Foreign investment guides

**`buy-property-australia-foreigner`**
- `AdvisorPrompt type="property_advisor"` — "Find a buyer's agent who specialises in foreign purchases"
- `AdvisorPrompt type="mortgage_broker"` — "Non-resident investment loan"
- FX provider 3-card strip (DB query: `fx_provider`, rating desc) — "Transfer your deposit to Australia" with cost-saving callout

**`firb-application-guide`**
- `AdvisorPrompt type="property_advisor"` — "Work with a FIRB-experienced buyer's agent"
- `AdvisorPrompt type="tax_agent"` — "Understand the tax implications before you buy"

**`stamp-duty-foreign-buyers`**
- `AdvisorPrompt type="tax_agent"` — "Get a stamp duty and tax estimate for your purchase"
- `AdvisorPrompt type="property_advisor"` — "Find a conveyancer or buyer's agent"
- Removed unused `FIRB_DISCLAIMER` import (lint fix)

**`property-ban-2025`**
- `AdvisorPrompt type="property_advisor"` — "Alternatives to direct property: find a buyer's agent"
- Non-resident share broker 3-card strip (DB query: `share_broker`, `accepts_non_residents = true`) — "ASX brokers that accept non-residents" — surfaces the investment alternative while the ban is in effect

### SMSF pages

**`smsf/property`**
- `AdvisorPrompt type="smsf_accountant"` — "Get specialist SMSF advice before investing in property"
- `AdvisorPrompt type="mortgage_broker"` — "SMSF limited recourse borrowing arrangement (LRBA)"

**`smsf/crypto`**
- Crypto exchange 3-card strip (DB query: `crypto_exchange`, rating desc) — "SMSF-eligible crypto exchanges" with auditor-report callout
- `AdvisorPrompt type="smsf_accountant"` — "Crypto in SMSFs: get the compliance right"

**`smsf/investment-strategy`**
- SMSF broker 3-card strip (DB query: `smsf_support = true`, rating desc) — "Platforms that support SMSF investment strategies" with HIN callout
- `AdvisorPrompt type="smsf_accountant"` — "Get your SMSF investment strategy reviewed"

**`smsf/checklist`**
- `AdvisorPrompt type="smsf_accountant"` — "Work through your SMSF checklist with an expert"

## Implementation notes

- All DB queries: `createClient` (server, anon key) — no admin client
- All affiliate links: `getAffiliateLink(broker)` → `/go/[slug]` — no hardcoded outbound URLs
- `AFFILIATE_REL` on all affiliate anchors
- Broker strips guarded: `{brokers && brokers.length > 0 && ...}` — degrade gracefully
- All existing page content preserved; no removals

## Companion PRs

- #568 — tax/SMSF/super conversion (already open)
- #569 — FX provider funnel (already open)
- Migration `20260712_fx_providers_non_resident_improvements.sql` on main — seeds the FX providers and non-resident broker data these pages surface


---
_Generated by [Claude Code](https://claude.ai/code/session_01DUMm362c1xA99NuzXLCui7)_