### PR TITLE
feat(deps): P-03 + P-04 — bump @anthropic-ai/sdk 0.90→0.93, posthog-js 1.371→1.372, posthog-node 5.30→5.33 [audit remediation]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,15 +8,15 @@
       "name": "invest-com-au",
       "version": "0.1.0",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.90.0",
+        "@anthropic-ai/sdk": "^0.93.0",
         "@sentry/nextjs": "^10.51.0",
         "@supabase/ssr": "^0.10.2",
         "@supabase/supabase-js": "^2.104.0",
         "@tailwindcss/typography": "^0.5.16",
         "@vercel/speed-insights": "^2.0.0",
         "next": "16.2.4",
-        "posthog-js": "^1.371.3",
-        "posthog-node": "^5.30.1",
+        "posthog-js": "^1.372.8",
+        "posthog-node": "^5.33.2",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "stripe": "^17.7.0"
@@ -76,9 +76,9 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.90.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.90.0.tgz",
-      "integrity": "sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg==",
+      "version": "0.93.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.93.0.tgz",
+      "integrity": "sha512-q9vaSZQVFx6B/gPxetGYfLXSJD5v0sOmh0OpZDq7yCrTSA+Rscvrtyol7JJTW40wEpQB4U1B4JXzxQitbQ3CAA==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "^3.1.1"
@@ -2864,18 +2864,18 @@
       "license": "MIT"
     },
     "node_modules/@posthog/core": {
-      "version": "1.27.2",
-      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.27.2.tgz",
-      "integrity": "sha512-y4YzMnUPbuVmL9s31JnJ2lTXxqy1QBTttxzjtfAuogQCN7nGpeDJoVAFz48CMFfLVFexLC2zt7LnkVWfq2hrxw==",
+      "version": "1.28.2",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.28.2.tgz",
+      "integrity": "sha512-Dii3pxDheG1WioztvV/MqHQMnb16jSFrl2HkDR1T5yf5/R7lPqJCFYt+eXkEdp/oAv/PD+1joyG6Ap/2quFmtQ==",
       "license": "MIT",
       "dependencies": {
-        "@posthog/types": "1.371.3"
+        "@posthog/types": "1.372.8"
       }
     },
     "node_modules/@posthog/types": {
-      "version": "1.371.3",
-      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.371.3.tgz",
-      "integrity": "sha512-oRmCJUMTM43tgbiH8fgGTu5ksjN5d6Lc6ckEYGUpbEMUVB+Of/yIOjb7Okaaqw0erSvtQumFM0teEP+nUI3JtQ==",
+      "version": "1.372.8",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.372.8.tgz",
+      "integrity": "sha512-ALpfCnWsMSM9Cw/6kyLPVpd81ZReEdZwmDxOi+DTJuIo7wDxBiu2cAsjOuA6D/AL22v7HOJrHsmBAPAWqS5X7Q==",
       "license": "MIT"
     },
     "node_modules/@prisma/instrumentation": {
@@ -9337,9 +9337,9 @@
       }
     },
     "node_modules/posthog-js": {
-      "version": "1.371.3",
-      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.371.3.tgz",
-      "integrity": "sha512-/LiSEOqgAPSX6oQx0DOsKxTyDI2hPcgRy+RS+4DGNZ4vk/cbQh6821Vr3qSnJUFdd48bq5uvvlMMZk6+s82Zzw==",
+      "version": "1.372.8",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.372.8.tgz",
+      "integrity": "sha512-NAFWVScFGnU5jgGNLkrY/UnGH82uULs9RsJ/f26LkLn1l0MOZfq+/z+2RaOOQQX4NHruIVuxqz3J/50bgRG68A==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
@@ -9347,8 +9347,8 @@
         "@opentelemetry/exporter-logs-otlp-http": "^0.208.0",
         "@opentelemetry/resources": "^2.2.0",
         "@opentelemetry/sdk-logs": "^0.208.0",
-        "@posthog/core": "1.27.2",
-        "@posthog/types": "1.371.3",
+        "@posthog/core": "1.28.2",
+        "@posthog/types": "1.372.8",
         "core-js": "^3.38.1",
         "dompurify": "^3.3.2",
         "fflate": "^0.4.8",
@@ -9370,12 +9370,12 @@
       }
     },
     "node_modules/posthog-node": {
-      "version": "5.30.1",
-      "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-5.30.1.tgz",
-      "integrity": "sha512-eAmKDGgA4Au7JBgwgftExDgSLjF6KO8RWBntAM50hNuNHGNF9MSko0M+0HTQUg27dLzmg5DIjwyJVOFDAWBFsw==",
+      "version": "5.33.2",
+      "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-5.33.2.tgz",
+      "integrity": "sha512-QZOT2uoEue4BGh/mrBUc7zfddtuLgCU7tTmW0MH8sTr8iK6argv82M7pQbJP/ENsiRYZa/ojpOIjTM9vO1xa6Q==",
       "license": "MIT",
       "dependencies": {
-        "@posthog/core": "1.27.2"
+        "@posthog/core": "1.28.2"
       },
       "engines": {
         "node": "^20.20.0 || >=22.22.0"

--- a/package.json
+++ b/package.json
@@ -33,15 +33,15 @@
     "prepare": "husky || true"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.90.0",
+    "@anthropic-ai/sdk": "^0.93.0",
     "@sentry/nextjs": "^10.51.0",
     "@supabase/ssr": "^0.10.2",
     "@supabase/supabase-js": "^2.104.0",
     "@tailwindcss/typography": "^0.5.16",
     "@vercel/speed-insights": "^2.0.0",
     "next": "16.2.4",
-    "posthog-js": "^1.371.3",
-    "posthog-node": "^5.30.1",
+    "posthog-js": "^1.372.8",
+    "posthog-node": "^5.33.2",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "stripe": "^17.7.0"


### PR DESCRIPTION
## Summary

- Bumps `@anthropic-ai/sdk` `0.90.0` → `0.93.0` (3 minor versions)
- Bumps `posthog-js` `1.371.3` → `1.372.8` (1 minor version)
- Bumps `posthog-node` `5.30.1` → `5.33.2` (3 minor versions)

All three are backwards-compatible minor/patch upgrades with no API changes at the call sites used in this repo.

**Bonus:** upgrading `@anthropic-ai/sdk` closes one of the 3 remaining `npm audit` moderate findings that P-01 (Sentry v10, PR #468) described as "not fixable without breaking changes." The SDK's own advisory was resolved in a later release. `npm audit` now reports 2 moderates (postcss/next — still not fixable without downgrading Next.js).

## What was checked

| SDK | Callers in repo | Test result |
|---|---|---|
| `@anthropic-ai/sdk` | `app/api/concierge/route.ts`, `app/api/admin/ai-chat/route.ts` | 19/19 concierge tests green |
| `posthog-node` | `lib/posthog/server.ts` | 25/25 SLO tests green |
| `posthog-js` | `lib/posthog/client.ts` | browser-only; no mock changes needed |

## Test plan

- [ ] CI `Lint · Type-check · Test · Build` green
- [ ] `npm audit` in CI shows 2 moderates (postcss/next), not 3

## Audit trail

- Queue items: **P-03**, **P-04** (`docs/audits/REMEDIATION_QUEUE.md`)
- Audit source: `docs/audits/codebase-health-2026-04-24.md` §3 (dependency hygiene)
- Tracking issue: #221

https://claude.ai/code/session_01MLA7kS5RgjLJdDgdDP3S6b

---
_Generated by [Claude Code](https://claude.ai/code/session_01MLA7kS5RgjLJdDgdDP3S6b)_