### PR TITLE
Fix Zod error access, tighten quiz submit typing, and refine quiz UI/context text

### DIFF
--- a/app/api/questions/[id]/answer/route.ts
+++ b/app/api/questions/[id]/answer/route.ts
@@ -29,7 +29,7 @@ export async function POST(
       display_name: z.string().optional(),
     }).safeParse(await req.json());
     if (!parsed.success) {
-      return NextResponse.json({ error: parsed.error.errors[0]?.message ?? "Invalid request" }, { status: 400 });
+      return NextResponse.json({ error: parsed.error.issues[0]?.message ?? "Invalid request" }, { status: 400 });
     }
     const { answer, display_name } = parsed.data;
 

--- a/app/api/questions/moderate/route.ts
+++ b/app/api/questions/moderate/route.ts
@@ -127,7 +127,7 @@ export async function POST(req: Request) {
       action: z.enum(["approve", "reject"]),
     }).safeParse(await req.json());
     if (!parsed.success) {
-      return NextResponse.json({ error: parsed.error.errors[0]?.message ?? "Invalid request" }, { status: 400 });
+      return NextResponse.json({ error: parsed.error.issues[0]?.message ?? "Invalid request" }, { status: 400 });
     }
     const { type, id, action } = parsed.data;
 

--- a/app/api/quiz/submit/route.ts
+++ b/app/api/quiz/submit/route.ts
@@ -26,7 +26,7 @@ export const runtime = "nodejs";
  */
 
 const BodySchema = z.object({
-  answers: z.record(z.unknown()),
+  answers: z.record(z.string(), z.unknown()),
   email: z.string().refine(isValidEmail, "Invalid email"),
   name: z.string().max(120).optional(),
 });

--- a/app/quiz/_components/QuizResultsScreen.tsx
+++ b/app/quiz/_components/QuizResultsScreen.tsx
@@ -70,6 +70,15 @@ export default function QuizResultsScreen({
   const heroEnabled = outcome.kind !== "diy-broker";
   const showBrokerResults = !outcome.suppressBrokerResults;
   const showRunnerUps = !outcome.suppressRunnerUps;
+  const isBrokerPrimaryOutcome = outcome.kind === "diy-broker";
+  const headingText = isBrokerPrimaryOutcome
+    ? (alternativesCount > 0
+      ? `Your top match (and ${alternativesCount} ${alternativesCount === 1 ? "alternative" : "alternatives"})`
+      : "Your top match")
+    : "Your best next step";
+  const subheadingText = isBrokerPrimaryOutcome
+    ? "Scored against the criteria you selected — your #1 first, alternatives below."
+    : "Based on your answers, this is the strongest next move. Platform options are shown below when relevant.";
 
   // Edge case: no platforms matched (data fetch failed or empty DB)
   if (allResults.length === 0) {
@@ -126,11 +135,9 @@ export default function QuizResultsScreen({
             </div>
           </div>
           <h1 className="text-xl md:text-3xl font-extrabold mb-1 md:mb-2">
-            {alternativesCount > 0
-              ? `Your top match (and ${alternativesCount} ${alternativesCount === 1 ? "alternative" : "alternatives"})`
-              : "Your top match"}
+            {headingText}
           </h1>
-          <p className="text-[0.69rem] md:text-base text-slate-600">Scored against the criteria you selected — your #1 first, alternatives below.</p>
+          <p className="text-[0.69rem] md:text-base text-slate-600">{subheadingText}</p>
           <div className="flex items-center justify-center gap-2 md:gap-3 mt-2 md:mt-3 text-[0.62rem] md:text-xs text-slate-400">
             <span className="flex items-center gap-1">
               <svg className="w-2.5 h-2.5 md:w-3 md:h-3 text-emerald-600" fill="currentColor" viewBox="0 0 20 20"><path fillRule="evenodd" d="M2.166 4.999A11.954 11.954 0 0010 1.944 11.954 11.954 0 0017.834 5c.11.65.166 1.32.166 2.001 0 5.225-3.34 9.67-8 11.317C5.34 16.67 2 12.225 2 7c0-.682.057-1.35.166-2.001zm11.541 3.708a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" /></svg>

--- a/app/quiz/page.tsx
+++ b/app/quiz/page.tsx
@@ -781,6 +781,20 @@ export default function QuizPage() {
         body: "Cross-border tax, FIRB, and visa rules mean an advisor is usually the right starting point. A few quick questions to find the right specialist.",
       };
     }
+    if (currentId === "complexity" && (answers.goal === "help" || answers.mode === "help")) {
+      return {
+        tone: "info" as const,
+        title: "You chose expert help — we’ll tailor the specialist match",
+        body: "This route skips platform-only questions so we can recommend the most relevant advisor for your situation.",
+      };
+    }
+    if (currentId === "experience" && answers.mode === "diy") {
+      return {
+        tone: "info" as const,
+        title: "You chose the DIY route",
+        body: "We’ll now focus on experience, amount, and priorities to rank platforms for self-directed investing.",
+      };
+    }
     return null;
   })();
 


### PR DESCRIPTION
### Motivation
- Prevent runtime errors and surface correct validation messages by using the proper Zod error shape. 
- Ensure the quiz submit payload enforces string keys for `answers` to avoid unexpected runtime shapes. 
- Improve the quiz results and question flow UI copy to better reflect the inferred outcome and user choices.

### Description
- Replace `parsed.error.errors[0]?.message` with `parsed.error.issues[0]?.message` in `app/api/questions/[id]/answer/route.ts` and `app/api/questions/moderate/route.ts` to read Zod messages correctly. 
- Tighten the quiz submit body schema in `app/api/quiz/submit/route.ts` by changing `answers: z.record(z.unknown())` to `answers: z.record(z.string(), z.unknown())`. 
- Update `app/quiz/_components/QuizResultsScreen.tsx` to compute `headingText` and `subheadingText` based on `outcome.kind` and render those values instead of the previous static text. 
- Add new context banner branches in `app/quiz/page.tsx` for `currentId === "complexity"` when help is requested and for `currentId === "experience"` when `answers.mode === "diy"` to provide clearer guidance.

### Testing
- Ran TypeScript type checking with `tsc` and the codebase typechecks successfully. 
- Executed the test suite with `pnpm test` and all tests passed. 
- Ran linting with `eslint` and there are no new linter errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa012be128832287562ac446a1140c)