### PR TITLE
fix(test): hoist mock vars in admin-campaign-notify (unbreak main CI)

### DIFF
--- a/__tests__/api/admin-marketplace-campaign-notify.test.ts
+++ b/__tests__/api/admin-marketplace-campaign-notify.test.ts
@@ -3,13 +3,15 @@ import { NextRequest } from "next/server";
 
 // ── Mocks ──────────────────────────────────────────────────────────────────────
 
-const mockAdminFrom = vi.fn();
+const { mockAdminFrom, mockRequireAdmin } = vi.hoisted(() => ({
+  mockAdminFrom: vi.fn(),
+  mockRequireAdmin: vi.fn(),
+}));
 
 vi.mock("@/lib/supabase/admin", () => ({
   createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
 }));
 
-const mockRequireAdmin = vi.fn();
 vi.mock("@/lib/require-admin", () => ({
   requireAdmin: mockRequireAdmin,
 }));


### PR DESCRIPTION
## Summary
- Wraps `mockAdminFrom` and `mockRequireAdmin` in `vi.hoisted()` so they're available when `vi.mock()` factories run.

## Why
PR #545 added `__tests__/api/admin-marketplace-campaign-notify.test.ts` with mock vars declared as top-level const but referenced inside hoisted `vi.mock()` factories. Vitest hoisting evaluates the mocks before the const declarations — the test file failed with:

```
Error: [vitest] There was an error when mocking a module. If you are using "vi.mock" factory, make sure there are no top level variables inside, since this call is hoisted to top of the file.
```

This broke main CI starting at commit `114bc33b` (PR #545 merge) and is also blocking PR #557's CI.

## Test plan
- [x] `npx vitest run __tests__/api/admin-marketplace-campaign-notify.test.ts` — 7/7 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)