### PR TITLE
refactor(x): swap /research pages to anon client (X-03) [audit remediation]

### DIFF
--- a/app/research/[slug]/page.tsx
+++ b/app/research/[slug]/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
-import { createAdminClient } from "@/lib/supabase/admin";
+import { createClient } from "@/lib/supabase/server";
 import Icon from "@/components/Icon";
 import ReportGate from "./ReportGate";
 
@@ -34,7 +34,7 @@ const SECTOR_LABELS: Record<string, string> = {
 
 async function fetchReport(slug: string): Promise<ReportRow | null> {
   try {
-    const supabase = createAdminClient();
+    const supabase = await createClient();
     const { data } = await supabase
       .from("sector_reports")
       .select("*")
@@ -53,7 +53,7 @@ async function fetchRelated(
 ): Promise<ReportRow[]> {
   if (!sector) return [];
   try {
-    const supabase = createAdminClient();
+    const supabase = await createClient();
     const { data } = await supabase
       .from("sector_reports")
       .select("id, title, slug, sector, summary, sponsor_name, sponsor_logo_url, gated, published_at, report_url, status")

--- a/app/research/page.tsx
+++ b/app/research/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import type { Metadata } from "next";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
-import { createAdminClient } from "@/lib/supabase/admin";
+import { createClient } from "@/lib/supabase/server";
 import Icon from "@/components/Icon";
 
 export const revalidate = 3600;
@@ -43,7 +43,7 @@ const SECTOR_LABELS: Record<string, string> = {
 
 async function fetchReports(): Promise<ReportRow[]> {
   try {
-    const supabase = createAdminClient();
+    const supabase = await createClient();
     const { data } = await supabase
       .from("sector_reports")
       .select(


### PR DESCRIPTION
## X-03 — `/research` family admin → anon client swap

Refs audit item X-03 from [codebase-health-2026-04-24.md](docs/audits/codebase-health-2026-04-24.md) §X (admin client scope), tracked in #218.

### Problem

`app/research/page.tsx` and `app/research/[slug]/page.tsx` were using the service-role `createAdminClient()` to read `sector_reports` rows with `status = 'published'`. Public research content is unauthenticated — the admin client was never necessary here and violated least-privilege.

### Fix

Swap both files to `createClient()` from `@/lib/supabase/server` (anon-key SSR client). The anon SELECT policy `"anon read published sector_reports"` was established in `20260429_o_iter7_rls_editorial_obs_secrets.sql` (confirmed by `20260510_rls_hardening.sql`) and already filters to `status = 'published'` — so RLS enforces the same constraint the queries apply explicitly.

### Files changed

| File | Change |
|------|--------|
| `app/research/page.tsx` | `createAdminClient()` → `await createClient()` |
| `app/research/[slug]/page.tsx` | Same, in `fetchReport()` and `fetchRelated()` |

### Verification

- [x] `sector_reports` anon SELECT policy confirmed in migrations
- [x] Both pages are RSC with `revalidate = 3600` (no user auth context needed)
- [x] No DB/schema changes; client-selection fix only
- [x] CI is the authoritative TS + build gate

### Checklist

- [x] X-03 done (both research files swapped)

Refs: #218
Audit: docs/audits/codebase-health-2026-04-24.md §X
Queue: X-03

---
_Generated by [Claude Code](https://claude.ai/code/session_011D7m4pGuLjHvb3pyb98Q1k)_