### PR TITLE
refactor(x): swap /invest/funds pages to anon client (X-04) [audit remediation]

### DIFF
--- a/app/invest/funds/[slug]/page.tsx
+++ b/app/invest/funds/[slug]/page.tsx
@@ -2,8 +2,7 @@ import Link from "next/link";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
-// eslint-disable-next-line no-restricted-imports -- pre-IA-refactor; admin client used here historically because the original schema lacked an anon SELECT policy on fund_listings. Migrate to createClient + an explicit anon policy on status='active' in a follow-up; out of scope for the 2026-05-07 IA refactor.
-import { createAdminClient } from "@/lib/supabase/admin";
+import { createClient } from "@/lib/supabase/server";
 import Icon from "@/components/Icon";
 import RegisterInterestForm from "@/components/funds/RegisterInterestForm";
 import type { FundListing } from "../FundsDirectoryClient";
@@ -12,7 +11,7 @@ export const revalidate = 600;
 
 async function fetchFund(slug: string): Promise<FundListing | null> {
   try {
-    const supabase = createAdminClient();
+    const supabase = await createClient();
     const { data } = await supabase
       .from("fund_listings")
       .select("*")
@@ -28,7 +27,7 @@ async function fetchFund(slug: string): Promise<FundListing | null> {
 async function fetchRelated(fundType: string | null, excludeId: number): Promise<FundListing[]> {
   if (!fundType) return [];
   try {
-    const supabase = createAdminClient();
+    const supabase = await createClient();
     const { data } = await supabase
       .from("fund_listings")
       .select("id, title, slug, fund_type, manager_name, min_investment_cents, target_return_percent, featured, featured_tier, siv_complying, open_to_retail, description, fund_size_cents, firb_relevant, status")

--- a/app/invest/funds/page.tsx
+++ b/app/invest/funds/page.tsx
@@ -2,8 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { Suspense } from "react";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
-// eslint-disable-next-line no-restricted-imports -- pre-IA-refactor; admin client used here historically because the original schema lacked an anon SELECT policy on fund_listings. Migrate to createClient + an explicit anon policy on status='active' in a follow-up; out of scope for the 2026-05-07 IA refactor.
-import { createAdminClient } from "@/lib/supabase/admin";
+import { createClient } from "@/lib/supabase/server";
 import FundsDirectoryClient, { type FundListing } from "./FundsDirectoryClient";
 import VerticalMarketplaceListings from "@/components/marketplace/VerticalMarketplaceListings";
 
@@ -24,7 +23,7 @@ export const metadata: Metadata = {
 
 async function fetchFunds(): Promise<FundListing[]> {
   try {
-    const supabase = createAdminClient();
+    const supabase = await createClient();
     const { data } = await supabase
       .from("fund_listings")
       .select(


### PR DESCRIPTION
## X-04 — `/invest/funds` family admin → anon client swap

Refs audit item X-04 from [codebase-health-2026-04-24.md](docs/audits/codebase-health-2026-04-24.md) §X (admin client scope), tracked in #218.

### Problem

`app/invest/funds/page.tsx` and `app/invest/funds/[slug]/page.tsx` used `createAdminClient()` to read `fund_listings`. Both files carried an `// eslint-disable-next-line no-restricted-imports` comment explaining the historical reason: "the original schema lacked an anon SELECT policy on fund_listings."

### Why the eslint-disable is now removable

`20260510_rls_hardening.sql` added:
```sql
CREATE POLICY "Public read active fund_listings"
  ON public.fund_listings FOR SELECT TO anon, authenticated
  USING (status = 'active');
```

Both pages filter `.eq("status", "active")` — the anon policy enforces the same constraint the queries already apply. No migration needed; the policy is already live.

### Files changed

| File | Change |
|------|--------|
| `app/invest/funds/page.tsx` | Remove eslint-disable + swap `createAdminClient()` → `await createClient()` |
| `app/invest/funds/[slug]/page.tsx` | Same, 3 call sites (`fetchFund`, `fetchRelated`) |

### Verification

- [x] `fund_listings` anon SELECT policy confirmed: `USING (status = 'active')` in `20260510_rls_hardening.sql`
- [x] Both pages filter `status='active'` — policy matches query
- [x] Both are RSC pages with `revalidate = 600` (no user auth context needed)
- [x] No remaining `createAdminClient` references in `/invest/funds/**`
- [x] No DB/schema changes; client-selection fix + eslint-disable removal only
- [x] CI is the authoritative TS + build gate

### Checklist

- [x] X-04 done (`/invest/funds` family swapped, eslint-disable comments removed)

Refs: #218
Audit: docs/audits/codebase-health-2026-04-24.md §X
Queue: X-04

---
_Generated by [Claude Code](https://claude.ai/code/session_011D7m4pGuLjHvb3pyb98Q1k)_