### PR TITLE
feat(w): extract <HubAdvisorCTA> + tests (W-06) [audit remediation]

### DIFF
--- a/__tests__/components/HubAdvisorCTA.test.tsx
+++ b/__tests__/components/HubAdvisorCTA.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from "@testing-library/react";
+import { vi, describe, it, expect } from "vitest";
+import HubAdvisorCTA from "@/components/HubAdvisorCTA";
+
+vi.mock("@/components/leads/HubLeadForm", () => ({
+  default: ({
+    heading,
+    subheading,
+    ctaLabel,
+  }: {
+    heading: string;
+    subheading?: string;
+    ctaLabel?: string;
+  }) => (
+    <div data-testid="hub-lead-form">
+      <span data-testid="heading">{heading}</span>
+      {subheading && <span data-testid="subheading">{subheading}</span>}
+      {ctaLabel && <span data-testid="cta-label">{ctaLabel}</span>}
+    </div>
+  ),
+}));
+
+describe("HubAdvisorCTA", () => {
+  const baseProps = {
+    heading: "Find an SMSF specialist",
+    intent: { need: "smsf", context: ["smsf_setup"] },
+    source: "smsf_hub",
+  };
+
+  it("renders HubLeadForm with passed heading", () => {
+    render(<HubAdvisorCTA {...baseProps} />);
+    expect(screen.getByTestId("hub-lead-form")).toBeInTheDocument();
+    expect(screen.getByTestId("heading")).toHaveTextContent("Find an SMSF specialist");
+  });
+
+  it("uses default slate background when no className provided", () => {
+    const { container } = render(<HubAdvisorCTA {...baseProps} />);
+    const section = container.querySelector("section");
+    expect(section?.className).toContain("bg-slate-50");
+    expect(section?.className).toContain("border-t");
+  });
+
+  it("applies custom className over default when provided", () => {
+    const { container } = render(
+      <HubAdvisorCTA {...baseProps} className="py-12 bg-white" />,
+    );
+    const section = container.querySelector("section");
+    expect(section?.className).toContain("bg-white");
+    expect(section?.className).not.toContain("bg-slate-50");
+  });
+
+  it("applies border-y variant via className", () => {
+    const { container } = render(
+      <HubAdvisorCTA {...baseProps} className="py-12 bg-slate-50 border-y border-slate-200" />,
+    );
+    const section = container.querySelector("section");
+    expect(section?.className).toContain("border-y");
+  });
+
+  it("preserves max-w-2xl container constraint", () => {
+    const { container } = render(<HubAdvisorCTA {...baseProps} />);
+    expect(container.querySelector(".max-w-2xl")).toBeInTheDocument();
+  });
+
+  it("forwards subheading to HubLeadForm", () => {
+    render(<HubAdvisorCTA {...baseProps} subheading="Expert SMSF advice" />);
+    expect(screen.getByTestId("subheading")).toHaveTextContent("Expert SMSF advice");
+  });
+
+  it("forwards ctaLabel to HubLeadForm", () => {
+    render(<HubAdvisorCTA {...baseProps} ctaLabel="Find a specialist" />);
+    expect(screen.getByTestId("cta-label")).toHaveTextContent("Find a specialist");
+  });
+
+  it("renders section as HTML section element", () => {
+    const { container } = render(<HubAdvisorCTA {...baseProps} />);
+    expect(container.firstChild?.nodeName).toBe("SECTION");
+  });
+});

--- a/__tests__/components/HubAdvisorCTA.test.tsx
+++ b/__tests__/components/HubAdvisorCTA.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from "@testing-library/react";
 import { vi, describe, it, expect } from "vitest";
+import { render, screen } from "./setup";
 import HubAdvisorCTA from "@/components/HubAdvisorCTA";
 
 vi.mock("@/components/leads/HubLeadForm", () => ({

--- a/app/grants/emdg/page.tsx
+++ b/app/grants/emdg/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import type { Metadata } from "next";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR, absoluteUrl } from "@/lib/seo";
 import Icon from "@/components/Icon";
-import HubLeadForm from "@/components/leads/HubLeadForm";
+import HubAdvisorCTA from "@/components/HubAdvisorCTA";
 
 export const revalidate = 3600;
 
@@ -121,18 +121,14 @@ export default function EmdgPage() {
         </section>
 
         {/* Lead form */}
-        <section className="py-12 bg-slate-50 border-t border-slate-200">
-          <div className="container-custom max-w-2xl">
-            <HubLeadForm
-              heading="Connect with an EMDG consultant"
-              subheading="Tier classification has a meaningful impact on the cheque size. A specialist gets it right and structures the reimbursement evidence."
-              intent={{ need: "tax", context: ["tax_optimization"] }}
-              source="grants_emdg"
-              ctaLabel="Get matched with an EMDG specialist"
-              extraFields={[{ name: "company", label: "Company name" }, { name: "target_markets", label: "Target export markets" }]}
-            />
-          </div>
-        </section>
+        <HubAdvisorCTA
+          heading="Connect with an EMDG consultant"
+          subheading="Tier classification has a meaningful impact on the cheque size. A specialist gets it right and structures the reimbursement evidence."
+          intent={{ need: "tax", context: ["tax_optimization"] }}
+          source="grants_emdg"
+          ctaLabel="Get matched with an EMDG specialist"
+          extraFields={[{ name: "company", label: "Company name" }, { name: "target_markets", label: "Target export markets" }]}
+        />
 
         {/* Cross-links */}
         <section className="py-10 bg-white border-t border-slate-200">

--- a/app/grants/industry-growth-program/page.tsx
+++ b/app/grants/industry-growth-program/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import type { Metadata } from "next";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR, absoluteUrl } from "@/lib/seo";
 import Icon from "@/components/Icon";
-import HubLeadForm from "@/components/leads/HubLeadForm";
+import HubAdvisorCTA from "@/components/HubAdvisorCTA";
 
 export const revalidate = 3600;
 
@@ -100,18 +100,15 @@ export default function IgpPage() {
         </section>
 
         {/* Lead form */}
-        <section className="py-12 bg-white">
-          <div className="container-custom max-w-2xl">
-            <HubLeadForm
-              heading="Get help with your IGP application"
-              subheading="At Stream 2 dollar values, the difference between a self-written and a professionally-supported application is significant."
-              intent={{ need: "tax", context: ["tax_optimization"] }}
-              source="grants_igp"
-              ctaLabel="Get matched with a grants specialist"
-              extraFields={[{ name: "company", label: "Company name" }, { name: "stream", label: "Target stream (1 or 2)" }]}
-            />
-          </div>
-        </section>
+        <HubAdvisorCTA
+          heading="Get help with your IGP application"
+          subheading="At Stream 2 dollar values, the difference between a self-written and a professionally-supported application is significant."
+          intent={{ need: "tax", context: ["tax_optimization"] }}
+          source="grants_igp"
+          ctaLabel="Get matched with a grants specialist"
+          extraFields={[{ name: "company", label: "Company name" }, { name: "stream", label: "Target stream (1 or 2)" }]}
+          className="py-12 bg-white"
+        />
 
         {/* Cross-links */}
         <section className="py-10 bg-slate-50 border-t border-slate-200">

--- a/app/lump-sum-investing/redundancy/page.tsx
+++ b/app/lump-sum-investing/redundancy/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import type { Metadata } from "next";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR, absoluteUrl } from "@/lib/seo";
-import HubLeadForm from "@/components/leads/HubLeadForm";
+import HubAdvisorCTA from "@/components/HubAdvisorCTA";
 
 export const revalidate = 3600;
 
@@ -80,17 +80,13 @@ export default function RedundancyPage() {
           </div>
         </section>
 
-        <section className="py-12 bg-slate-50 border-t border-slate-200">
-          <div className="container-custom max-w-2xl">
-            <HubLeadForm
-              heading="Speak to a financial planner about your redundancy"
-              subheading="Tax window planning, super contribution sequencing and the right cash-buffer level for your circumstances."
-              intent={{ need: "planning", context: ["retirement"] }}
-              source="lump_sum_redundancy"
-              ctaLabel="Find a financial planner"
-            />
-          </div>
-        </section>
+        <HubAdvisorCTA
+          heading="Speak to a financial planner about your redundancy"
+          subheading="Tax window planning, super contribution sequencing and the right cash-buffer level for your circumstances."
+          intent={{ need: "planning", context: ["retirement"] }}
+          source="lump_sum_redundancy"
+          ctaLabel="Find a financial planner"
+        />
 
         <section className="py-10 bg-white border-t border-slate-200">
           <div className="container-custom max-w-4xl">

--- a/app/negative-gearing/page.tsx
+++ b/app/negative-gearing/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import type { Metadata } from "next";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR, absoluteUrl } from "@/lib/seo";
 import Icon from "@/components/Icon";
-import HubLeadForm from "@/components/leads/HubLeadForm";
+import HubAdvisorCTA from "@/components/HubAdvisorCTA";
 
 export const revalidate = 3600;
 
@@ -101,17 +101,13 @@ export default function NegativeGearingHubPage() {
           </div>
         </section>
 
-        <section className="py-12 bg-slate-50 border-t border-slate-200">
-          <div className="container-custom max-w-2xl">
-            <HubLeadForm
-              heading="Speak to a tax agent about your investment property"
-              subheading="Tax structuring, depreciation schedules and capital-growth modelling — get the strategy right before you sign a contract."
-              intent={{ need: "tax", context: ["tax_optimization"] }}
-              source="negative_gearing_hub"
-              ctaLabel="Find a tax agent"
-            />
-          </div>
-        </section>
+        <HubAdvisorCTA
+          heading="Speak to a tax agent about your investment property"
+          subheading="Tax structuring, depreciation schedules and capital-growth modelling — get the strategy right before you sign a contract."
+          intent={{ need: "tax", context: ["tax_optimization"] }}
+          source="negative_gearing_hub"
+          ctaLabel="Find a tax agent"
+        />
 
         <section className="py-10 bg-white border-t border-slate-200">
           <div className="container-custom max-w-4xl">

--- a/app/sell-business/page.tsx
+++ b/app/sell-business/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import type { Metadata } from "next";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR, absoluteUrl } from "@/lib/seo";
 import Icon from "@/components/Icon";
-import HubLeadForm from "@/components/leads/HubLeadForm";
+import HubAdvisorCTA from "@/components/HubAdvisorCTA";
 
 export const revalidate = 3600;
 
@@ -102,21 +102,18 @@ export default function SellBusinessHubPage() {
           </div>
         </section>
 
-        <section className="py-12 bg-white">
-          <div className="container-custom max-w-2xl">
-            <HubLeadForm
-              heading="Get a free business valuation consultation"
-              subheading="A specialist broker will run a market-comparable analysis on your industry and provide an indicative range — usually within one business day."
-              intent={{ need: "planning", context: ["estate_planning"] }}
-              source="sell_business_hub"
-              ctaLabel="Get matched with a broker"
-              extraFields={[
-                { name: "industry", label: "Industry" },
-                { name: "annual_revenue", label: "Annual revenue (AUD)", type: "number" },
-              ]}
-            />
-          </div>
-        </section>
+        <HubAdvisorCTA
+          heading="Get a free business valuation consultation"
+          subheading="A specialist broker will run a market-comparable analysis on your industry and provide an indicative range — usually within one business day."
+          intent={{ need: "planning", context: ["estate_planning"] }}
+          source="sell_business_hub"
+          ctaLabel="Get matched with a broker"
+          extraFields={[
+            { name: "industry", label: "Industry" },
+            { name: "annual_revenue", label: "Annual revenue (AUD)", type: "number" },
+          ]}
+          className="py-12 bg-white"
+        />
 
         <section className="py-10 bg-slate-50 border-t border-slate-200">
           <div className="container-custom max-w-4xl">

--- a/app/smsf/setup/page.tsx
+++ b/app/smsf/setup/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import type { Metadata } from "next";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR, absoluteUrl } from "@/lib/seo";
-import HubLeadForm from "@/components/leads/HubLeadForm";
+import HubAdvisorCTA from "@/components/HubAdvisorCTA";
 import AdvisorPrompt from "@/components/AdvisorPrompt";
 import { createClient } from "@/lib/supabase/server";
 import { getAffiliateLink, AFFILIATE_REL, renderStars } from "@/lib/tracking";
@@ -144,17 +144,14 @@ export default async function SmsfSetupPage() {
           </div>
         </section>
 
-        <section className="py-12 bg-slate-50 border-y border-slate-200">
-          <div className="container-custom max-w-2xl">
-            <HubLeadForm
-              heading="Find an SMSF accountant or auditor"
-              subheading="A specialist will set up the deed, register with the ATO and run the first audit cycle. Setup is the easy part — ongoing compliance is where most SMSFs trip up."
-              intent={{ need: "smsf", context: ["smsf_setup"] }}
-              source="smsf_setup"
-              ctaLabel="Find an SMSF specialist"
-            />
-          </div>
-        </section>
+        <HubAdvisorCTA
+          heading="Find an SMSF accountant or auditor"
+          subheading="A specialist will set up the deed, register with the ATO and run the first audit cycle. Setup is the easy part — ongoing compliance is where most SMSFs trip up."
+          intent={{ need: "smsf", context: ["smsf_setup"] }}
+          source="smsf_setup"
+          ctaLabel="Find an SMSF specialist"
+          className="py-12 bg-slate-50 border-y border-slate-200"
+        />
 
         <section className="py-10 bg-white border-t border-slate-200">
           <div className="container-custom max-w-4xl">

--- a/app/visa-investment/page.tsx
+++ b/app/visa-investment/page.tsx
@@ -40,7 +40,7 @@ const PATHWAYS = [
   },
   {
     title: "Existing SIV Holders (188C)",
-    blurb: "If you hold a 188C visa granted before 31 July 2024, your complying investment obligations continue unchanged. The transition to permanent 888C remains.",
+    blurb: "If you hold a 188C visa granted before 31 July 2024, your complying investment obligations continue unchanged. The transition to permanent 888C remains.", // dated-ok — SIV closure is a fixed historical date
     href: "/foreign-investment/siv",
     cta: "SIV transition →",
   },
@@ -85,6 +85,7 @@ export default function VisaInvestmentPage() {
           <div className="container-custom max-w-5xl flex items-start gap-3">
             <Icon name="alert-triangle" size={20} className="text-amber-700 mt-0.5 shrink-0" />
             <p className="text-sm text-amber-900 leading-relaxed">
+              {/* // dated-ok — SIV closure is a fixed historical date, will not change */}
               <strong>SIV / BIIP closed.</strong> The Significant Investor Visa and Business Innovation and Investment Program permanently closed to new applications on 31 July 2024. The pathways below reflect the current {CURRENT_YEAR} landscape.
             </p>
           </div>

--- a/app/visa-investment/page.tsx
+++ b/app/visa-investment/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import type { Metadata } from "next";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR, absoluteUrl } from "@/lib/seo";
 import Icon from "@/components/Icon";
-import HubLeadForm from "@/components/leads/HubLeadForm";
+import HubAdvisorCTA from "@/components/HubAdvisorCTA";
 
 export const revalidate = 3600;
 
@@ -125,18 +125,15 @@ export default function VisaInvestmentPage() {
         </section>
 
         {/* Lead form */}
-        <section className="py-12 bg-white">
-          <div className="container-custom max-w-2xl">
-            <HubLeadForm
-              heading="Speak to a migration agent or immigration investment lawyer"
-              subheading="The right specialist will assess eligibility, sequence applications, and avoid the documentation traps that derail most investor applications."
-              intent={{ need: "planning", context: ["estate_planning"] }}
-              source="visa_investment_hub"
-              ctaLabel="Get matched with a specialist"
-              extraFields={[{ name: "current_country", label: "Current country of residence" }, { name: "intended_pathway", label: "Pathway of interest" }]}
-            />
-          </div>
-        </section>
+        <HubAdvisorCTA
+          heading="Speak to a migration agent or immigration investment lawyer"
+          subheading="The right specialist will assess eligibility, sequence applications, and avoid the documentation traps that derail most investor applications."
+          intent={{ need: "planning", context: ["estate_planning"] }}
+          source="visa_investment_hub"
+          ctaLabel="Get matched with a specialist"
+          extraFields={[{ name: "current_country", label: "Current country of residence" }, { name: "intended_pathway", label: "Pathway of interest" }]}
+          className="py-12 bg-white"
+        />
 
         <section className="py-10 bg-slate-50 border-t border-slate-200">
           <div className="container-custom max-w-4xl">

--- a/components/HubAdvisorCTA.tsx
+++ b/components/HubAdvisorCTA.tsx
@@ -1,0 +1,27 @@
+import HubLeadForm from "@/components/leads/HubLeadForm";
+import type { ComponentProps } from "react";
+
+interface HubAdvisorCTAProps extends ComponentProps<typeof HubLeadForm> {
+  /** Optional className for the root <section>. Defaults to slate background with top border. */
+  className?: string;
+}
+
+/**
+ * <HubAdvisorCTA> — bottom-of-page advisor lead-capture section for hub pages.
+ *
+ * Wraps <HubLeadForm> in the standard section + container layout extracted
+ * from the repeated pattern across hub pages. All HubLeadForm props are
+ * forwarded. Use className to override the section background when the page
+ * context requires white background or both-side borders.
+ *
+ * W-06 — hub foundation stream (REMEDIATION_QUEUE.md).
+ */
+export default function HubAdvisorCTA({ className, ...formProps }: HubAdvisorCTAProps) {
+  return (
+    <section className={className ?? "py-12 bg-slate-50 border-t border-slate-200"}>
+      <div className="container-custom max-w-2xl">
+        <HubLeadForm {...formProps} />
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## W-06 — Extract `<HubAdvisorCTA>` + tests

**Tracking:** #218 (stream W)
**Audit:** `docs/audits/codebase-health-2026-04-24.md` §W hub foundation

### What

Extracts the repeated bottom-of-page advisor lead-capture section pattern into a reusable `<HubAdvisorCTA>` component.

Every hub page had this bespoke wrapper duplicated verbatim:
```jsx
<section className="py-12 bg-slate-50 border-t border-slate-200">
  <div className="container-custom max-w-2xl">
    <HubLeadForm ... />
  </div>
</section>
```

### Why

- **W-12 HubPage HOC** needs a single stable component to render the lead-capture slot from config — not a pattern convention spread across 15+ pages.
- **Lever #1** (bottom-of-page lead capture) needs consistent presentation across all hubs.
- Eliminates the copy-paste surface where future hub pages can silently diverge on section class, container width, or border variant.

### What changed

**New files:**
- `components/HubAdvisorCTA.tsx` — wraps `HubLeadForm` in standard section + container layout; forwards all `HubLeadForm` props; accepts optional `className` to override section background when white or border-y variant needed.
- `__tests__/components/HubAdvisorCTA.test.tsx` — 8 tests covering: heading forwarding, default slate background, white background override, border-y variant, container constraint, subheading/ctaLabel forwarding, HTML element type.

**Migrated pages (7):**
- `app/negative-gearing/page.tsx` → default (slate + border-t)
- `app/lump-sum-investing/redundancy/page.tsx` → default
- `app/smsf/setup/page.tsx` → border-y override
- `app/sell-business/page.tsx` → bg-white override
- `app/visa-investment/page.tsx` → bg-white override
- `app/grants/emdg/page.tsx` → default
- `app/grants/industry-growth-program/page.tsx` → bg-white override

**Not migrated** (non-standalone pattern — HubLeadForm embedded alongside AdvisorPrompt in shared section): `smsf/property`, `smsf/crypto`, `smsf/investment-strategy`. These remain on `HubLeadForm` directly and will be addressed as part of W-12 migration.

### Checklist

- [x] `components/HubAdvisorCTA.tsx` created
- [x] `__tests__/components/HubAdvisorCTA.test.tsx` — 8 tests
- [x] 7 hub pages migrated
- [x] No DB/schema changes — pure display component
- [x] CI is authoritative gate (no node_modules on sandbox)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CyiGQCKNJpkcZ3sk5vMyKW)_