### PR TITLE
refactor: SSOT consolidation F-03/F-04/F-06 follow-ups (lint-staged sweep)

### DIFF
--- a/app/admin/consultations/page.tsx
+++ b/app/admin/consultations/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { createClient } from "@/lib/supabase/client";
 import { useToast } from "@/components/Toast";
 import AdminShell from "@/components/AdminShell";
@@ -8,6 +8,7 @@ import ConfirmDialog from "@/components/ConfirmDialog";
 import { downloadCSV } from "@/lib/csv-export";
 import TableSkeleton from "@/components/TableSkeleton";
 import { useUnsavedChanges } from "@/hooks/useUnsavedChanges";
+import { slugify } from "@/lib/utils";
 
 interface ConsultationRow {
   id: number;
@@ -78,59 +79,56 @@ export default function AdminConsultationsPage() {
 
   const [form, setForm] = useState(emptyForm);
 
-  useEffect(() => {
-    fetchData();
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    try {
+      const supabase = createClient();
+
+      // Fetch consultations with consultant
+      const { data: consultData } = await supabase
+        .from("consultations")
+        .select("*, consultant:team_members(id, full_name)")
+        .order("sort_order", { ascending: true });
+
+      type RawConsultation = Omit<ConsultationRow, "consultant"> & {
+        consultant: ConsultationRow["consultant"] | ConsultationRow["consultant"][];
+      };
+      const normalized: ConsultationRow[] = ((consultData ?? []) as RawConsultation[]).map((c) => ({
+        ...c,
+        consultant: Array.isArray(c.consultant) ? c.consultant[0] ?? null : c.consultant ?? null,
+      }));
+      setConsultations(normalized);
+
+      // Fetch team members for dropdown
+      const { data: members } = await supabase
+        .from("team_members")
+        .select("id, full_name")
+        .order("full_name");
+      setConsultants(members || []);
+
+      // Fetch bookings with consultation title
+      const { data: bookingData } = await supabase
+        .from("consultation_bookings")
+        .select("*, consultation:consultations(title)")
+        .order("booked_at", { ascending: false })
+        .limit(100);
+
+      type RawBooking = Omit<BookingRow, "consultation"> & {
+        consultation: BookingRow["consultation"] | BookingRow["consultation"][];
+      };
+      const normalizedBookings: BookingRow[] = ((bookingData ?? []) as RawBooking[]).map((b) => ({
+        ...b,
+        consultation: Array.isArray(b.consultation) ? b.consultation[0] ?? null : b.consultation ?? null,
+      }));
+      setBookings(normalizedBookings);
+    } finally {
+      setLoading(false);
+    }
   }, []);
 
-  const fetchData = async () => {
-    const supabase = createClient();
-
-    // Fetch consultations with consultant
-    const { data: consultData } = await supabase
-      .from("consultations")
-      .select("*, consultant:team_members(id, full_name)")
-      .order("sort_order", { ascending: true });
-
-    type RawConsultation = Omit<ConsultationRow, "consultant"> & {
-      consultant: ConsultationRow["consultant"] | ConsultationRow["consultant"][];
-    };
-    const normalized: ConsultationRow[] = ((consultData ?? []) as RawConsultation[]).map((c) => ({
-      ...c,
-      consultant: Array.isArray(c.consultant) ? c.consultant[0] ?? null : c.consultant ?? null,
-    }));
-    setConsultations(normalized);
-
-    // Fetch team members for dropdown
-    const { data: members } = await supabase
-      .from("team_members")
-      .select("id, full_name")
-      .order("full_name");
-    setConsultants(members || []);
-
-    // Fetch bookings with consultation title
-    const { data: bookingData } = await supabase
-      .from("consultation_bookings")
-      .select("*, consultation:consultations(title)")
-      .order("booked_at", { ascending: false })
-      .limit(100);
-
-    type RawBooking = Omit<BookingRow, "consultation"> & {
-      consultation: BookingRow["consultation"] | BookingRow["consultation"][];
-    };
-    const normalizedBookings: BookingRow[] = ((bookingData ?? []) as RawBooking[]).map((b) => ({
-      ...b,
-      consultation: Array.isArray(b.consultation) ? b.consultation[0] ?? null : b.consultation ?? null,
-    }));
-    setBookings(normalizedBookings);
-
-    setLoading(false);
-  };
-
-  const autoSlug = (title: string) =>
-    title
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, "-")
-      .replace(/^-|-$/g, "");
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
 
   const handleSave = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -140,7 +138,7 @@ export default function AdminConsultationsPage() {
     const supabase = createClient();
     const payload = {
       title: form.title.trim(),
-      slug: form.slug || autoSlug(form.title),
+      slug: form.slug || slugify(form.title),
       description: form.description || null,
       consultant_id: form.consultant_id ? parseInt(form.consultant_id) : null,
       duration_minutes: parseInt(form.duration_minutes) || 30,
@@ -377,7 +375,7 @@ export default function AdminConsultationsPage() {
                   setForm({
                     ...form,
                     title: e.target.value,
-                    slug: editingId ? form.slug : autoSlug(e.target.value),
+                    slug: editingId ? form.slug : slugify(e.target.value),
                   })
                 }
                 className="w-full border border-slate-200 rounded-lg px-3 py-2 text-sm"

--- a/app/admin/courses/[slug]/page.tsx
+++ b/app/admin/courses/[slug]/page.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import React, { useEffect, useState, use } from "react";
+import React, { useEffect, useState, use, useCallback } from "react";
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/client";
 import { useToast } from "@/components/Toast";
 import AdminShell from "@/components/AdminShell";
 import ConfirmDialog from "@/components/ConfirmDialog";
+import { slugify } from "@/lib/utils";
 
 interface CourseData {
   id: number;
@@ -71,37 +72,38 @@ export default function AdminCourseDetailPage({ params }: { params: Promise<{ sl
     content: "",
   });
 
-  useEffect(() => {
-    fetchData();
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    try {
+      const supabase = createClient();
+
+      const { data: courseData } = await supabase
+        .from("courses")
+        .select("*")
+        .eq("slug", slug)
+        .single();
+
+      if (courseData) {
+        setCourse(courseData as CourseData);
+        setCourseForm(courseData as CourseData);
+      }
+
+      const { data: lessonData } = await supabase
+        .from("course_lessons")
+        .select("*")
+        .eq("course_slug", slug)
+        .order("module_index")
+        .order("lesson_index");
+
+      setLessons((lessonData as LessonRow[]) || []);
+    } finally {
+      setLoading(false);
+    }
   }, [slug]);
 
-  const fetchData = async () => {
-    const supabase = createClient();
-
-    const { data: courseData } = await supabase
-      .from("courses")
-      .select("*")
-      .eq("slug", slug)
-      .single();
-
-    if (courseData) {
-      setCourse(courseData as CourseData);
-      setCourseForm(courseData as CourseData);
-    }
-
-    const { data: lessonData } = await supabase
-      .from("course_lessons")
-      .select("*")
-      .eq("course_slug", slug)
-      .order("module_index")
-      .order("lesson_index");
-
-    setLessons((lessonData as LessonRow[]) || []);
-    setLoading(false);
-  };
-
-  const autoSlug = (title: string) =>
-    title.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
 
   const handleSaveCourse = async () => {
     if (!course) return;
@@ -151,7 +153,7 @@ export default function AdminCourseDetailPage({ params }: { params: Promise<{ sl
     const { error } = await supabase.from("course_lessons").insert({
       course_slug: slug,
       title: lessonForm.title,
-      slug: lessonForm.slug || autoSlug(lessonForm.title),
+      slug: lessonForm.slug || slugify(lessonForm.title),
       module_index: parseInt(lessonForm.module_index),
       module_title: lessonForm.module_title,
       lesson_index: parseInt(lessonForm.lesson_index),
@@ -461,7 +463,7 @@ export default function AdminCourseDetailPage({ params }: { params: Promise<{ sl
               <input
                 type="text"
                 value={lessonForm.title}
-                onChange={(e) => setLessonForm({ ...lessonForm, title: e.target.value, slug: autoSlug(e.target.value) })}
+                onChange={(e) => setLessonForm({ ...lessonForm, title: e.target.value, slug: slugify(e.target.value) })}
                 className="w-full border border-slate-200 rounded-lg px-3 py-2 text-sm"
                 required
               />

--- a/app/admin/courses/page.tsx
+++ b/app/admin/courses/page.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/client";
 import { useToast } from "@/components/Toast";
 import AdminShell from "@/components/AdminShell";
 import { downloadCSV } from "@/lib/csv-export";
 import { useUnsavedChanges } from "@/hooks/useUnsavedChanges";
+import { slugify } from "@/lib/utils";
 import InfoTip from "@/components/InfoTip";
 
 interface CourseRow {
@@ -63,65 +64,69 @@ export default function AdminCoursesPage() {
     status: "draft",
   });
 
-  useEffect(() => {
-    fetchData();
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    try {
+      const supabase = createClient();
+
+      // Fetch courses with creator
+      const { data: coursesData } = await supabase
+        .from("courses")
+        .select("id, slug, title, status, price, pro_price, revenue_share_percent, featured, sort_order, created_at, creator:team_members(id, full_name)")
+        .order("sort_order", { ascending: true });
+
+      // Supabase returns joined relations as arrays; normalise to single object
+      type RawCourse = Omit<CourseRow, "creator"> & { creator: CourseRow["creator"] | CourseRow["creator"][] };
+      const normalized: CourseRow[] = ((coursesData ?? []) as RawCourse[]).map((c) => ({
+        ...c,
+        creator: Array.isArray(c.creator) ? c.creator[0] ?? null : c.creator ?? null,
+      }));
+      setCourses(normalized);
+
+      // Fetch team members for creator dropdown
+      const { data: members } = await supabase
+        .from("team_members")
+        .select("id, full_name")
+        .order("full_name");
+
+      setCreators(members || []);
+
+      // Fetch revenue summary
+      const { data: revenueData } = await supabase
+        .from("course_revenue")
+        .select("creator_id, total_amount, creator_amount, platform_amount, creator:team_members(full_name)");
+
+      // Group by creator
+      type RawRevenue = { creator_id: number; total_amount: number; creator_amount: number; platform_amount: number; creator: { full_name: string } | { full_name: string }[] | null };
+      const grouped = new Map<number, RevenueByCreator>();
+      ((revenueData ?? []) as RawRevenue[]).forEach((r) => {
+        const existing = grouped.get(r.creator_id);
+        if (existing) {
+          existing.total_revenue += r.total_amount;
+          existing.creator_share += r.creator_amount;
+          existing.platform_share += r.platform_amount;
+          existing.purchases += 1;
+        } else {
+          grouped.set(r.creator_id, {
+            creator_id: r.creator_id,
+            creator_name: (Array.isArray(r.creator) ? r.creator[0]?.full_name : r.creator?.full_name) || "Unknown",
+            total_revenue: r.total_amount,
+            creator_share: r.creator_amount,
+            platform_share: r.platform_amount,
+            purchases: 1,
+          });
+        }
+      });
+
+      setRevenue(Array.from(grouped.values()));
+    } finally {
+      setLoading(false);
+    }
   }, []);
 
-  const fetchData = async () => {
-    const supabase = createClient();
-
-    // Fetch courses with creator
-    const { data: coursesData } = await supabase
-      .from("courses")
-      .select("id, slug, title, status, price, pro_price, revenue_share_percent, featured, sort_order, created_at, creator:team_members(id, full_name)")
-      .order("sort_order", { ascending: true });
-
-    // Supabase returns joined relations as arrays; normalise to single object
-    type RawCourse = Omit<CourseRow, "creator"> & { creator: CourseRow["creator"] | CourseRow["creator"][] };
-    const normalized: CourseRow[] = ((coursesData ?? []) as RawCourse[]).map((c) => ({
-      ...c,
-      creator: Array.isArray(c.creator) ? c.creator[0] ?? null : c.creator ?? null,
-    }));
-    setCourses(normalized);
-
-    // Fetch team members for creator dropdown
-    const { data: members } = await supabase
-      .from("team_members")
-      .select("id, full_name")
-      .order("full_name");
-
-    setCreators(members || []);
-
-    // Fetch revenue summary
-    const { data: revenueData } = await supabase
-      .from("course_revenue")
-      .select("creator_id, total_amount, creator_amount, platform_amount, creator:team_members(full_name)");
-
-    // Group by creator
-    type RawRevenue = { creator_id: number; total_amount: number; creator_amount: number; platform_amount: number; creator: { full_name: string } | { full_name: string }[] | null };
-    const grouped = new Map<number, RevenueByCreator>();
-    ((revenueData ?? []) as RawRevenue[]).forEach((r) => {
-      const existing = grouped.get(r.creator_id);
-      if (existing) {
-        existing.total_revenue += r.total_amount;
-        existing.creator_share += r.creator_amount;
-        existing.platform_share += r.platform_amount;
-        existing.purchases += 1;
-      } else {
-        grouped.set(r.creator_id, {
-          creator_id: r.creator_id,
-          creator_name: (Array.isArray(r.creator) ? r.creator[0]?.full_name : r.creator?.full_name) || "Unknown",
-          total_revenue: r.total_amount,
-          creator_share: r.creator_amount,
-          platform_share: r.platform_amount,
-          purchases: 1,
-        });
-      }
-    });
-
-    setRevenue(Array.from(grouped.values()));
-    setLoading(false);
-  };
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
 
   const cloneCourse = (c: CourseRow) => {
     setForm({
@@ -143,12 +148,6 @@ export default function AdminCoursesPage() {
     setShowCreate(true);
   };
 
-  const autoSlug = (title: string) =>
-    title
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, "-")
-      .replace(/^-|-$/g, "");
-
   const handleCreate = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!form.title.trim()) return;
@@ -157,7 +156,7 @@ export default function AdminCoursesPage() {
     const supabase = createClient();
     const { error } = await supabase.from("courses").insert({
       title: form.title.trim(),
-      slug: form.slug || autoSlug(form.title),
+      slug: form.slug || slugify(form.title),
       subtitle: form.subtitle || null,
       description: form.description || null,
       price: Math.round(parseFloat(form.price || "0") * 100),
@@ -256,7 +255,7 @@ export default function AdminCoursesPage() {
               <input
                 type="text"
                 value={form.title}
-                onChange={(e) => setForm({ ...form, title: e.target.value, slug: autoSlug(e.target.value) })}
+                onChange={(e) => setForm({ ...form, title: e.target.value, slug: slugify(e.target.value) })}
                 className="w-full border border-slate-200 rounded-lg px-3 py-2 text-sm"
                 required
               />

--- a/app/admin/quarterly-reports/page.tsx
+++ b/app/admin/quarterly-reports/page.tsx
@@ -7,6 +7,7 @@ import { downloadCSV } from "@/lib/csv-export";
 import TableSkeleton from "@/components/TableSkeleton";
 import { useUnsavedChanges } from "@/hooks/useUnsavedChanges";
 import type { QuarterlyReport } from "@/lib/types";
+import { slugify } from "@/lib/utils";
 
 interface FormData {
   title: string;
@@ -33,13 +34,6 @@ const emptyForm: FormData = {
   new_entrants: "",
   status: "draft",
 };
-
-function slugify(text: string): string {
-  return text
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/(^-|-$)/g, "");
-}
 
 export default function QuarterlyReportsPage() {
   // C-05b: this page used to call `lib/supabase/client.ts` (browser

--- a/app/admin/regulatory-alerts/page.tsx
+++ b/app/admin/regulatory-alerts/page.tsx
@@ -8,6 +8,7 @@ import { downloadCSV } from "@/lib/csv-export";
 import TableSkeleton from "@/components/TableSkeleton";
 import { useUnsavedChanges } from "@/hooks/useUnsavedChanges";
 import type { RegulatoryAlert } from "@/lib/types";
+import { slugify } from "@/lib/utils";
 
 interface FormData {
   title: string;
@@ -37,15 +38,7 @@ const emptyForm: FormData = {
   status: "draft",
 };
 
-function slugify(text: string): string {
-  return text
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/(^-|-$)/g, "");
-}
-
 export default function RegulatoryAlertsPage() {
-  const supabase = createClient();
   const [items, setItems] = useState<RegulatoryAlert[]>([]);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -65,13 +58,17 @@ export default function RegulatoryAlertsPage() {
 
   const load = useCallback(async () => {
     setLoading(true);
-    const { data } = await supabase
-      .from("regulatory_alerts")
-      .select("*")
-      .order("created_at", { ascending: false });
-    if (data) setItems(data as RegulatoryAlert[]);
-    setLoading(false);
-  }, [supabase]);
+    try {
+      const supabase = createClient();
+      const { data } = await supabase
+        .from("regulatory_alerts")
+        .select("*")
+        .order("created_at", { ascending: false });
+      if (data) setItems(data as RegulatoryAlert[]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
 
   useEffect(() => {
     load();
@@ -118,6 +115,7 @@ export default function RegulatoryAlertsPage() {
       return;
     }
 
+    const supabase = createClient();
     let actionItemsJson;
     try {
       actionItemsJson = JSON.parse(form.action_items);
@@ -166,6 +164,7 @@ export default function RegulatoryAlertsPage() {
 
   const deleteItem = async () => {
     if (!deleteTarget) return;
+    const supabase = createClient();
     const { error } = await supabase
       .from("regulatory_alerts")
       .delete()

--- a/app/admin/team-members/page.tsx
+++ b/app/admin/team-members/page.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { createClient } from "@/lib/supabase/client";
 import AdminShell from "@/components/AdminShell";
 import ConfirmDialog from "@/components/ConfirmDialog";
 import { useToast } from "@/components/Toast";
 import { downloadCSV } from "@/lib/csv-export";
 import type { TeamMember } from "@/lib/types";
+import { slugify } from "@/lib/utils";
 
 const ROLES = [
   { value: "contributor", label: "Contributor" },
@@ -22,13 +23,6 @@ const ROLE_COLORS: Record<string, string> = {
   expert_reviewer: "bg-emerald-50 text-emerald-700",
 };
 
-function slugify(name: string): string {
-  return name
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/(^-|-$)/g, "");
-}
-
 export default function TeamMembersPage() {
   const [members, setMembers] = useState<TeamMember[]>([]);
   const [editing, setEditing] = useState<TeamMember | null>(null);
@@ -38,10 +32,10 @@ export default function TeamMembersPage() {
   const [deleteTarget, setDeleteTarget] = useState<TeamMember | null>(null);
   const [autoSlug, setAutoSlug] = useState(true);
 
-  const supabase = createClient();
   const { toast } = useToast();
 
-  const load = async () => {
+  const load = useCallback(async () => {
+    const supabase = createClient();
     const { data, error } = await supabase
       .from("team_members")
       .select("*")
@@ -51,11 +45,11 @@ export default function TeamMembersPage() {
     } else {
       setMembers(data || []);
     }
-  };
+  }, [toast]);
 
   useEffect(() => {
     load();
-  }, []);
+  }, [load]);
 
   const handleSave = async (formData: FormData) => {
     const full_name = (formData.get("full_name") as string)?.trim();
@@ -80,6 +74,7 @@ export default function TeamMembersPage() {
     }
 
     setSaving(true);
+    const supabase = createClient();
 
     const credentialsRaw = (formData.get("credentials") as string) || "";
     const credentials = credentialsRaw
@@ -144,6 +139,7 @@ export default function TeamMembersPage() {
 
   const handleDelete = async () => {
     if (!deleteTarget) return;
+    const supabase = createClient();
     try {
       const { error } = await supabase
         .from("team_members")

--- a/app/api/advisor-articles/route.ts
+++ b/app/api/advisor-articles/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { isRateLimited } from "@/lib/rate-limit";
@@ -7,6 +8,8 @@ import { notificationFooter } from "@/lib/email-templates";
 import { getSiteUrl } from "@/lib/url";
 import { getAdminEmail, getAdminEmails } from "@/lib/admin";
 import { logger } from "@/lib/logger";
+import { withValidatedBody } from "@/lib/validation/withValidatedBody";
+import { slugify } from "@/lib/utils";
 
 const log = logger("advisor-articles");
 
@@ -28,9 +31,35 @@ function calcReadTime(wordCount: number): number {
   return Math.max(1, Math.round(wordCount / 220));
 }
 
-function slugify(text: string): string {
-  return text.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 80);
-}
+const ArticlePostBody = z.object({
+  professional_id: z.number(),
+  title: z.string(),
+  content: z.string(),
+  excerpt: z.string().optional(),
+  category: z.string().optional(),
+  tags: z.array(z.string()).optional(),
+  pricing_tier: z.string().optional(),
+  action: z.string().optional(),
+});
+
+const ArticlePutBody = z.object({
+  id: z.number(),
+  action: z.string().optional(),
+  reviewed_by: z.string().optional(),
+  admin_notes: z.string().nullish(),
+  rejection_reason: z.string().optional(),
+  payment_reference: z.string().optional(),
+  title: z.string().optional(),
+  content: z.string().optional(),
+  excerpt: z.string().optional(),
+  meta_title: z.string().optional(),
+  meta_description: z.string().optional(),
+  category: z.string().optional(),
+  featured: z.boolean().optional(),
+  related_brokers: z.unknown().optional(),
+  related_advisor_types: z.unknown().optional(),
+  pricing_tier: z.string().optional(),
+});
 
 async function logMod(supabase: Awaited<ReturnType<typeof createClient>>, articleId: number, action: string, by: string, notes?: string, oldStatus?: string, newStatus?: string) {
   const { error } = await supabase.from("advisor_article_moderation_log").insert({ article_id: articleId, action, performed_by: by, notes, old_status: oldStatus, new_status: newStatus });
@@ -104,12 +133,11 @@ export async function GET(request: NextRequest) {
   return NextResponse.json(data || []);
 }
 
-export async function POST(request: NextRequest) {
+export const POST = withValidatedBody(ArticlePostBody, async (request, body) => {
   const ip = request.headers.get("x-forwarded-for")?.split(",")[0] || "unknown";
   if (await isRateLimited(`advisor_article:${ip}`, 10, 60)) return NextResponse.json({ error: "Too many requests" }, { status: 429 });
 
   const supabase = await createClient();
-  const body = await request.json();
   const { professional_id, title, content, excerpt, category, tags, pricing_tier, action } = body;
   if (!professional_id || !title?.trim() || !content?.trim()) return NextResponse.json({ error: "Title and content required" }, { status: 400 });
 
@@ -136,7 +164,7 @@ export async function POST(request: NextRequest) {
     }
   }
 
-  const articleSlug = slugify(title.trim()) + "-" + Date.now().toString(36);
+  const articleSlug = slugify(title.trim()).slice(0, 80) + "-" + Date.now().toString(36);
 
   const { data: article, error } = await supabase.from("advisor_articles").insert({
     professional_id: pro.id, author_name: pro.name, author_firm: pro.firm_name, author_slug: pro.slug,
@@ -158,17 +186,16 @@ export async function POST(request: NextRequest) {
       wrap("New Article Submitted", `<p style="color:#64748b;font-size:14px"><strong>${pro.name}</strong> (${pro.firm_name || "Independent"}) submitted an article.</p><p style="color:#334155;font-size:15px;font-weight:600">"${title}"</p><p style="color:#64748b;font-size:13px">Category: ${category || "General"} \xb7 Tier: ${pricing_tier || "standard"} \xb7 ${wordCount} words \xb7 ${readTime} min read</p>`, "Review \u2192", `${SITE_URL}/admin/advisor-articles`));
   }
   return NextResponse.json(article);
-}
+});
 
-export async function PUT(request: NextRequest) {
+export const PUT = withValidatedBody(ArticlePutBody, async (request, body) => {
   const supabase = await createClient();
-  const body = await request.json();
   const { id, action, ...updates } = body;
   if (!id) return NextResponse.json({ error: "Article ID required" }, { status: 400 });
 
   // Admin-only actions require auth verification
   const ADMIN_ACTIONS = ["approve", "request_revision", "reject", "mark_paid", "waive_fee", "publish", "unpublish", "admin_edit"];
-  if (ADMIN_ACTIONS.includes(action)) {
+  if (action && ADMIN_ACTIONS.includes(action)) {
     const adminEmail = await verifyAdmin();
     if (!adminEmail) return NextResponse.json({ error: "Unauthorized — admin access required" }, { status: 401 });
   }
@@ -182,7 +209,7 @@ export async function PUT(request: NextRequest) {
   if (action === "approve") {
     const { error } = await supabase.from("advisor_articles").update({ status: "approved", reviewed_at: new Date().toISOString(), reviewed_by: updates.reviewed_by || "admin", admin_notes: updates.admin_notes || null }).eq("id", id);
     if (error) return NextResponse.json({ error: "Operation failed" }, { status: 500 });
-    await logMod(supabase, id, "approved", updates.reviewed_by || "admin", updates.admin_notes, oldStatus, "approved");
+    await logMod(supabase, id, "approved", updates.reviewed_by || "admin", updates.admin_notes ?? undefined, oldStatus, "approved");
     if (advEmail) await sendEmail(advEmail, `Article approved: "${artTitle}"`, wrap("Article Approved ✓", `<p style="color:#334155;font-size:14px">Hi ${advName.split(" ")[0]},</p><p style="color:#64748b;font-size:14px"><strong>"${artTitle}"</strong> has been approved!</p>${updates.admin_notes ? `<p style="background:#f8fafc;padding:10px;border-radius:6px;font-size:13px;color:#64748b;border-left:3px solid #7c3aed"><strong>Note:</strong> ${updates.admin_notes}</p>` : ""}<p style="color:#64748b;font-size:14px">Once payment is confirmed, it will be published with your profile linked.</p>`, "View Portal →", `${SITE_URL}/advisor-portal`));
     return NextResponse.json({ status: "approved" });
   }
@@ -231,7 +258,7 @@ export async function PUT(request: NextRequest) {
 
   if (action === "admin_edit") {
     const fields: Record<string, unknown> = {};
-    for (const k of ["title", "content", "excerpt", "meta_title", "meta_description", "category", "featured", "related_brokers", "related_advisor_types"]) {
+    for (const k of ["title", "content", "excerpt", "meta_title", "meta_description", "category", "featured", "related_brokers", "related_advisor_types"] as const) {
       if (updates[k] !== undefined) fields[k] = updates[k];
     }
     if (updates.content) {
@@ -254,7 +281,7 @@ export async function PUT(request: NextRequest) {
     if (/(contact me|call us|my firm|visit our website|book a consultation with me|sign up now)/i.test(checkContent)) return NextResponse.json({ error: "Article contains promotional language." }, { status: 400 });
 
     const sf: Record<string, unknown> = { status: "submitted", submitted_at: new Date().toISOString() };
-    for (const k of ["title", "content", "excerpt", "category"]) { if (updates[k]) sf[k] = updates[k]; }
+    for (const k of ["title", "content", "excerpt", "category"] as const) { if (updates[k]) sf[k] = updates[k]; }
     if (updates.content) { sf.word_count = submitWc; sf.read_time = calcReadTime(submitWc); }
     const { error } = await supabase.from("advisor_articles").update(sf).eq("id", id);
     if (error) return NextResponse.json({ error: "Operation failed" }, { status: 500 });
@@ -265,7 +292,7 @@ export async function PUT(request: NextRequest) {
 
   // Generic save draft
   const df: Record<string, unknown> = {};
-  for (const k of ["title", "content", "excerpt", "category", "pricing_tier"]) { if (updates[k]) df[k] = updates[k]; }
+  for (const k of ["title", "content", "excerpt", "category", "pricing_tier"] as const) { if (updates[k]) df[k] = updates[k]; }
   if (updates.content) {
     const wc = calcWordCount(updates.content);
     df.word_count = wc;
@@ -274,4 +301,4 @@ export async function PUT(request: NextRequest) {
   const { error } = await supabase.from("advisor_articles").update(df).eq("id", id);
   if (error) return NextResponse.json({ error: "Operation failed" }, { status: 500 });
   return NextResponse.json({ updated: true });
-}
+});

--- a/app/api/advisor-signup/route.ts
+++ b/app/api/advisor-signup/route.ts
@@ -1,26 +1,42 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
+import { z } from "zod";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { isRateLimited } from "@/lib/rate-limit";
 import { isValidEmail } from "@/lib/validate-email";
 import { logger } from "@/lib/logger";
+import { withValidatedBody } from "@/lib/validation/withValidatedBody";
+import { slugify } from "@/lib/utils";
 
 const log = logger("advisor-signup");
 
-function slugify(text: string): string {
-  return text
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
-}
+const AdvisorSignupBody = z.object({
+  name: z.string().optional(),
+  email: z.string().optional(),
+  phone: z.string().optional(),
+  firm_name: z.string().optional(),
+  type: z.string().optional(),
+  afsl_number: z.string().optional(),
+  abn: z.string().optional(),
+  registration_number: z.string().optional(),
+  specialties: z.unknown().optional(),
+  location_state: z.string().optional(),
+  location_suburb: z.string().optional(),
+  bio: z.string().optional(),
+  fee_structure: z.string().optional(),
+  fee_description: z.string().optional(),
+  pitch_message: z.string().optional(),
+  years_experience: z.unknown().optional(),
+  client_types: z.string().optional(),
+  languages: z.string().optional(),
+});
 
-export async function POST(request: NextRequest) {
+export const POST = withValidatedBody(AdvisorSignupBody, async (request, body) => {
   try {
     const ip = request.headers.get("x-forwarded-for")?.split(",")[0] || "unknown";
     if (await isRateLimited(`advisor_signup:${ip}`, 3, 60)) {
       return NextResponse.json({ error: "Too many signup attempts. Please try again later." }, { status: 429 });
     }
 
-    const body = await request.json();
     const {
       name,
       email,
@@ -223,4 +239,4 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     );
   }
-}
+});

--- a/app/api/community/threads/route.ts
+++ b/app/api/community/threads/route.ts
@@ -4,6 +4,7 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { NextRequest, NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 import { isRateLimited } from "@/lib/rate-limit";
+import { slugify } from "@/lib/utils";
 
 // All fields optional so Zod v4 doesn't emit an invalid_type error for missing
 // required fields (v4 removed the required_error constructor param). Required
@@ -15,14 +16,6 @@ const ThreadPostBody = z.object({
 });
 
 const log = logger("community:threads");
-
-function generateSlug(title: string): string {
-  return title
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-|-$/g, "")
-    .slice(0, 80);
-}
 
 export async function GET(req: NextRequest) {
   try {
@@ -161,7 +154,7 @@ export async function POST(req: NextRequest) {
       user.email?.split("@")[0] ||
       "Anonymous";
 
-    const slug = generateSlug(title.trim());
+    const slug = slugify(title.trim()).slice(0, 80);
 
     // Insert thread
     const { data: thread, error: insertError } = await admin

--- a/app/api/marketplace/register/route.ts
+++ b/app/api/marketplace/register/route.ts
@@ -1,9 +1,12 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
+import { z } from "zod";
 import { createAdminClient } from "@/lib/supabase/admin";
 import crypto from "crypto";
 import { isRateLimited } from "@/lib/rate-limit";
 import { ADMIN_EMAIL } from "@/lib/admin";
 import { logger } from "@/lib/logger";
+import { withValidatedBody } from "@/lib/validation/withValidatedBody";
+import { slugify } from "@/lib/utils";
 
 const log = logger("marketplace:register");
 
@@ -16,7 +19,17 @@ function escapeHtml(str: string): string {
     .replace(/"/g, "&quot;");
 }
 
-export async function POST(req: NextRequest) {
+const RegisterBody = z.object({
+  email: z.string().optional(),
+  password: z.string().optional(),
+  full_name: z.string().optional(),
+  company_name: z.string().optional(),
+  phone: z.string().optional(),
+  broker_slug: z.string().optional(),
+  website: z.string().optional(),
+});
+
+export const POST = withValidatedBody(RegisterBody, async (req, body) => {
   try {
     const supabaseAdmin = createAdminClient();
     const ip = req.headers.get("x-forwarded-for")?.split(",")[0] || "unknown";
@@ -24,7 +37,6 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "Too many registration attempts. Please try again later." }, { status: 429 });
     }
 
-    const body = await req.json();
     const { email, password, full_name, company_name, phone, broker_slug, website } = body;
 
     // Validate required fields
@@ -57,10 +69,7 @@ export async function POST(req: NextRequest) {
     }
 
     // Generate broker slug if not provided
-    const slug = broker_slug || company_name
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, "-")
-      .replace(/^-|-$/g, "");
+    const slug = broker_slug || slugify(company_name ?? "");
 
     // Create Supabase auth user
     const { data: authData, error: authError } = await supabaseAdmin.auth.admin.createUser({
@@ -172,4 +181,4 @@ export async function POST(req: NextRequest) {
   } catch {
     return NextResponse.json({ error: "Internal server error." }, { status: 500 });
   }
-}
+});

--- a/app/mortgage-calculator/MortgageCalculatorClient.tsx
+++ b/app/mortgage-calculator/MortgageCalculatorClient.tsx
@@ -7,12 +7,9 @@ import SocialProofCounter from "@/components/SocialProofCounter";
 import { trackEvent, trackPageDuration } from "@/lib/tracking";
 import { getStoredUtm } from "@/components/UtmCapture";
 import { storeQualificationData } from "@/lib/qualification-store";
+import { formatCurrency } from "@/lib/utils";
 
 /* ── helpers ─────────────────────────────────────────── */
-
-function formatCurrency(n: number): string {
-  return new Intl.NumberFormat("en-AU", { style: "currency", currency: "AUD", maximumFractionDigits: 0 }).format(n);
-}
 
 function formatCurrencyExact(n: number): string {
   return new Intl.NumberFormat("en-AU", { style: "currency", currency: "AUD", minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(n);
@@ -146,7 +143,7 @@ export default function MortgageCalculatorClient() {
       <div className="bg-gradient-to-br from-rose-600 via-rose-700 to-rose-800 text-white py-8 md:py-14 px-4">
         <div className="container-custom max-w-3xl text-center">
           <h1 className="text-xl md:text-3xl font-extrabold mb-2">How much will your mortgage really cost?</h1>
-          <p className="text-sm md:text-base text-rose-100">Enter your loan details — we'll show you monthly repayments, total interest, and how rate changes affect the cost.</p>
+          <p className="text-sm md:text-base text-rose-100">Enter your loan details — we&apos;ll show you monthly repayments, total interest, and how rate changes affect the cost.</p>
           <div className="mt-3"><SocialProofCounter variant="badge" /></div>
         </div>
       </div>

--- a/app/savings-calculator/SavingsCalculatorClient.tsx
+++ b/app/savings-calculator/SavingsCalculatorClient.tsx
@@ -7,6 +7,7 @@ import { trackEvent, trackClick, getAffiliateLink, AFFILIATE_REL, trackPageDurat
 import { getStoredUtm } from "@/components/UtmCapture";
 import { storeQualificationData } from "@/lib/qualification-store";
 import AdvisorMatchCTA from "@/components/AdvisorMatchCTA";
+import { formatCurrency } from "@/lib/utils";
 
 type Account = {
   id: number; slug: string; name: string; platform_type: string;
@@ -16,10 +17,6 @@ type Account = {
 function parseRate(fee: string): number {
   const match = fee.match(/([\d.]+)/);
   return match ? parseFloat(match[1]) : 0;
-}
-
-function formatCurrency(n: number): string {
-  return new Intl.NumberFormat("en-AU", { style: "currency", currency: "AUD", maximumFractionDigits: 0 }).format(n);
 }
 
 export default function SavingsCalculatorClient({ accounts, inline }: { accounts: Account[]; inline?: boolean }) {
@@ -92,7 +89,7 @@ export default function SavingsCalculatorClient({ accounts, inline }: { accounts
       {!inline && <div className="bg-gradient-to-br from-amber-500 via-amber-600 to-amber-800 text-white py-8 md:py-14 px-4">
         <div className="container-custom max-w-3xl text-center">
           <h1 className="text-xl md:text-3xl font-extrabold mb-2">Are you earning enough on your savings?</h1>
-          <p className="text-sm md:text-base text-amber-100">Enter your balance and current rate — we'll show you exactly how much more you could earn.</p>
+          <p className="text-sm md:text-base text-amber-100">Enter your balance and current rate — we&apos;ll show you exactly how much more you could earn.</p>
           <div className="mt-3"><SocialProofCounter variant="badge" /></div>
         </div>
       </div>}
@@ -165,8 +162,8 @@ export default function SavingsCalculatorClient({ accounts, inline }: { accounts
                 </>
               ) : (
                 <>
-                  <p className="text-lg font-bold text-slate-700">You're already earning a competitive rate!</p>
-                  <p className="text-sm text-slate-500 mt-1">At {currentRate}%, you're close to the best available rates in Australia.</p>
+                  <p className="text-lg font-bold text-slate-700">You&apos;re already earning a competitive rate!</p>
+                  <p className="text-sm text-slate-500 mt-1">At {currentRate}%, you&apos;re close to the best available rates in Australia.</p>
                 </>
               )}
             </div>
@@ -270,7 +267,7 @@ export default function SavingsCalculatorClient({ accounts, inline }: { accounts
             <div className="bg-white border border-slate-200 rounded-2xl p-5 md:p-8">
               <h2 className="text-lg font-bold text-slate-900 mb-3">Why Your Savings Rate Matters</h2>
               <p className="text-sm text-slate-600 leading-relaxed mb-4">
-                Most Australians leave their savings in a Big 4 bank transaction account earning 0.01-0.5%. Meanwhile, online banks like ING, Ubank, and Macquarie offer 5%+ with simple conditions. On a $50,000 balance, the difference between 0.5% and 5.5% is <strong>$2,500 per year</strong> — that's real money lost to inertia.
+                Most Australians leave their savings in a Big 4 bank transaction account earning 0.01-0.5%. Meanwhile, online banks like ING, Ubank, and Macquarie offer 5%+ with simple conditions. On a $50,000 balance, the difference between 0.5% and 5.5% is <strong>$2,500 per year</strong> — that&apos;s real money lost to inertia.
               </p>
               <p className="text-sm text-slate-600 leading-relaxed mb-4">
                 All savings accounts listed here are with ADI-regulated Australian banks, meaning your deposits are government-guaranteed up to $250,000 per person per institution under the Financial Claims Scheme.

--- a/components/AdminHelpPanel.tsx
+++ b/components/AdminHelpPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { usePathname } from "next/navigation";
+import { ADMIN_SPAM_COMPLIANCE_NOTE } from "@/lib/compliance";
 
 interface HelpEntry {
   title: string;
@@ -82,7 +83,7 @@ const helpContent: Record<string, { description: string; tips: HelpEntry[] }> = 
     description: "View and manage all email signups from across the site. This includes quiz leads (visitors who completed the broker recommendation quiz), newsletter subscribers, and other email captures.",
     tips: [
       { title: "Signup Sources", items: ["Quiz — completed the broker recommendation quiz and left their email.", "Newsletter — signed up for the weekly email newsletter.", "Footer — entered their email in the site footer signup form.", "Article — signed up via the email capture form inside an article."] },
-      { title: "Managing Subscribers", items: ["Use filters to segment subscribers by source, date, or status.", "Export the list as CSV for use in your email marketing platform.", "Unsubscribed users are kept in the list but marked as inactive.", "Never send emails to unsubscribed users — this violates Australian spam laws."] },
+      { title: "Managing Subscribers", items: ["Use filters to segment subscribers by source, date, or status.", "Export the list as CSV for use in your email marketing platform.", "Unsubscribed users are kept in the list but marked as inactive.", ADMIN_SPAM_COMPLIANCE_NOTE] },
     ],
   },
   "/admin/pro-subscribers": {
@@ -304,17 +305,15 @@ const walkthroughKeys: Record<string, string> = {
 
 export default function AdminHelpPanel() {
   const pathname = usePathname();
-  const [open, setOpen] = useState(false);
+  const [openedOnPathname, setOpenedOnPathname] = useState<string | null>(null);
+  const open = openedOnPathname === pathname;
   const content = helpContent[pathname];
   const walkthroughKey = walkthroughKeys[pathname || ""];
-
-  // Close on route change
-  useEffect(() => { setOpen(false); }, [pathname]);
 
   // Close on Escape
   useEffect(() => {
     if (!open) return;
-    const handler = (e: KeyboardEvent) => { if (e.key === "Escape") setOpen(false); };
+    const handler = (e: KeyboardEvent) => { if (e.key === "Escape") setOpenedOnPathname(null); };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
   }, [open]);
@@ -325,7 +324,7 @@ export default function AdminHelpPanel() {
     <>
       {/* Trigger button */}
       <button
-        onClick={() => setOpen(!open)}
+        onClick={() => setOpenedOnPathname(open ? null : pathname)}
         className={`fixed bottom-4 right-4 z-40 w-10 h-10 rounded-full shadow-lg flex items-center justify-center text-lg font-bold transition-all ${
           open
             ? "bg-slate-800 text-white rotate-45 scale-110"
@@ -342,7 +341,7 @@ export default function AdminHelpPanel() {
         <>
           <div
             className="fixed inset-0 z-30 bg-black/10 md:bg-transparent"
-            onClick={() => setOpen(false)}
+            onClick={() => setOpenedOnPathname(null)}
           />
           <div className="fixed bottom-16 right-4 z-40 w-80 max-h-[70vh] bg-white border border-slate-200 rounded-xl shadow-xl overflow-hidden flex flex-col animate-in fade-in slide-in-from-bottom-2 duration-200">
             {/* Header */}
@@ -383,7 +382,7 @@ export default function AdminHelpPanel() {
                   <button
                     onClick={() => {
                       localStorage.removeItem(walkthroughKey);
-                      setOpen(false);
+                      setOpenedOnPathname(null);
                       window.location.reload();
                     }}
                     className="text-[0.6rem] text-amber-600 hover:text-amber-700 font-semibold"

--- a/lib/compliance.ts
+++ b/lib/compliance.ts
@@ -144,6 +144,13 @@ export const AFCA_REFERENCE =
   "Visit afca.org.au or call 1800 931 678.";
 
 /**
+ * Admin-facing reminder shown in the /admin/subscribers help panel.
+ * Sending to unsubscribed users violates the Spam Act 2003 (Cth).
+ */
+export const ADMIN_SPAM_COMPLIANCE_NOTE =
+  "Never send emails to unsubscribed users — this violates Australian spam laws.";
+
+/**
  * Financial Services Guide (FSG) notice.
  * ASIC requires that financial services providers give clients an FSG before providing services.
  * As a comparison site (not an AFSL holder), we reference this requirement and point users


### PR DESCRIPTION
## Summary

Completes three deferred SSOT-consolidation follow-ups from previously merged PRs (#370 F-03, #354 F-04, #355 F-06) that were blocked by lint-staged `--max-warnings 0` catching pre-existing warnings in the files to be staged.

**F-03 — calculator `formatCurrency` + unescaped entities (2 files)**
- `MortgageCalculatorClient`: replace local `formatCurrency` with canonical `lib/utils` import; escape `we&apos;ll` in hero subtitle
- `SavingsCalculatorClient`: same `formatCurrency` replacement; escape 4 apostrophes (`we&apos;ll`, `You&apos;re`, `you&apos;re`, `that&apos;s`)

**F-04 — admin pages: `slugify` SSOT + react-hooks lint fixes (8 files)**
- `quarterly-reports`: remove local `slugify`, import canonical
- `regulatory-alerts`: fix cascading render (`createClient()` moved inside `load` callback, wrapped in try/finally to satisfy `react-hooks/set-state-in-effect`); remove local `slugify`
- `team-members`: same `createClient()` fix; wrap `load` in `useCallback([toast])`; add `[load]` to effect deps; remove local `slugify`
- `consultations` + `courses/page.tsx`: move `fetchData` before `useEffect`; wrap in `useCallback([])` with try/finally; replace `autoSlug` with canonical `slugify`
- `courses/[slug]/page.tsx`: wrap `fetchData` in `useCallback([slug])`; update effect deps to `[fetchData]`; replace `autoSlug` with canonical `slugify`
- 4 API routes (`advisor-articles`, `advisor-signup`, `community/threads`, `marketplace/register`): define Zod schemas and migrate to `withValidatedBody`; remove local `slugify`/`generateSlug` functions, use canonical with `.slice(0,80)` preserved at call site where needed

**F-06 — compliance SSOT (2 files)**
- `lib/compliance.ts`: add `ADMIN_SPAM_COMPLIANCE_NOTE` (Spam Act 2003 admin reminder)
- `AdminHelpPanel`: import + use constant; fix pre-existing `set-state-in-effect` warning by replacing `open`/`setOpen` with derived state (`openedOnPathname === pathname`) — eliminates the pathname-change effect entirely without changing UX behaviour

## Test plan

- [ ] `npm run lint` — 0 warnings across all 14 changed files
- [ ] `npm run type-check` — clean (tsc strict + noUncheckedIndexedAccess)
- [ ] Pre-push hook passed: tsc, rate-limit audit, changed-file tests all green
- [ ] Calculators still display currency correctly (formatCurrency from utils: `minimumFractionDigits: 0, maximumFractionDigits: 2`)
- [ ] Admin help panel closes when navigating between routes (derived-state approach)
- [ ] API routes accept valid bodies and return 400 for invalid JSON (withValidatedBody)

https://claude.ai/code/session_01WG5VEcVa5sq7ueSEB6GoWu

---
_Generated by [Claude Code](https://claude.ai/code/session_01WG5VEcVa5sq7ueSEB6GoWu)_