### PR TITLE
feat(w): EligibilityQuiz generalised quiz shell (W-10) [audit remediation]

### DIFF
--- a/__tests__/components/EligibilityQuiz.test.tsx
+++ b/__tests__/components/EligibilityQuiz.test.tsx
@@ -1,0 +1,194 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import EligibilityQuiz, {
+  type QuizQuestion,
+  type QuizAnswers,
+} from "@/components/EligibilityQuiz";
+
+const QUESTIONS: QuizQuestion[] = [
+  {
+    id: "industry",
+    question: "What is your industry?",
+    options: [
+      { value: "tech", label: "Technology" },
+      { value: "finance", label: "Finance" },
+    ],
+  },
+  {
+    id: "size",
+    question: "How many employees?",
+    options: [
+      { value: "small", label: "1–10" },
+      { value: "large", label: "11+" },
+    ],
+  },
+  {
+    id: "stage",
+    question: "What stage are you at?",
+    options: [
+      { value: "early", label: "Early" },
+      { value: "growth", label: "Growth" },
+    ],
+  },
+];
+
+function renderQuiz(props?: Partial<Parameters<typeof EligibilityQuiz>[0]>) {
+  const renderResults = vi.fn((_answers: QuizAnswers, reset: () => void) => (
+    <div>
+      <span data-testid="results-view">Results</span>
+      <button onClick={reset} data-testid="reset-btn">
+        Start over
+      </button>
+    </div>
+  ));
+  render(
+    <EligibilityQuiz
+      questions={QUESTIONS}
+      renderResults={renderResults}
+      {...props}
+    />
+  );
+  return { renderResults };
+}
+
+describe("EligibilityQuiz", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the quiz container", () => {
+    renderQuiz();
+    expect(screen.getByTestId("eligibility-quiz")).toBeInTheDocument();
+  });
+
+  it("shows the first question on mount", () => {
+    renderQuiz();
+    expect(screen.getByTestId("eligibility-quiz-question")).toHaveTextContent(
+      "What is your industry?"
+    );
+  });
+
+  it("renders all options for the first question", () => {
+    renderQuiz();
+    expect(screen.getByTestId("eligibility-quiz-option-tech")).toHaveTextContent(
+      "Technology"
+    );
+    expect(
+      screen.getByTestId("eligibility-quiz-option-finance")
+    ).toHaveTextContent("Finance");
+  });
+
+  it("shows step 1 of N in the meta heading", () => {
+    renderQuiz();
+    expect(screen.getByTestId("eligibility-quiz-meta")).toHaveTextContent(
+      "1 of 3"
+    );
+  });
+
+  it("shows 0% progress on the first question", () => {
+    renderQuiz();
+    expect(
+      screen.getByTestId("eligibility-quiz-progress-label")
+    ).toHaveTextContent("0%");
+    expect(screen.getByRole("progressbar")).toHaveAttribute(
+      "aria-valuenow",
+      "0"
+    );
+  });
+
+  it("does not show back button on first step", () => {
+    renderQuiz();
+    expect(
+      screen.queryByTestId("eligibility-quiz-back")
+    ).not.toBeInTheDocument();
+  });
+
+  it("advances to the next question after selecting an option", async () => {
+    const user = userEvent.setup();
+    renderQuiz();
+    await user.click(screen.getByTestId("eligibility-quiz-option-tech"));
+    expect(screen.getByTestId("eligibility-quiz-question")).toHaveTextContent(
+      "How many employees?"
+    );
+  });
+
+  it("shows the back button after advancing past step 1", async () => {
+    const user = userEvent.setup();
+    renderQuiz();
+    await user.click(screen.getByTestId("eligibility-quiz-option-tech"));
+    expect(screen.getByTestId("eligibility-quiz-back")).toBeInTheDocument();
+  });
+
+  it("navigates back to the previous question", async () => {
+    const user = userEvent.setup();
+    renderQuiz();
+    await user.click(screen.getByTestId("eligibility-quiz-option-tech"));
+    await user.click(screen.getByTestId("eligibility-quiz-back"));
+    expect(screen.getByTestId("eligibility-quiz-question")).toHaveTextContent(
+      "What is your industry?"
+    );
+  });
+
+  it("updates the progress percentage as steps advance", async () => {
+    const user = userEvent.setup();
+    renderQuiz();
+    // step 0 → 0%
+    expect(screen.getByTestId("eligibility-quiz-progress-label")).toHaveTextContent("0%");
+    await user.click(screen.getByTestId("eligibility-quiz-option-tech"));
+    // step 1 → 33%
+    expect(screen.getByTestId("eligibility-quiz-progress-label")).toHaveTextContent("33%");
+    await user.click(screen.getByTestId("eligibility-quiz-option-small"));
+    // step 2 → 67%
+    expect(screen.getByTestId("eligibility-quiz-progress-label")).toHaveTextContent("67%");
+  });
+
+  it("uses the custom heading prop", () => {
+    renderQuiz({ heading: "R&D Tax Quiz" });
+    expect(screen.getByTestId("eligibility-quiz-meta")).toHaveTextContent(
+      "R&D Tax Quiz"
+    );
+  });
+
+  it("calls renderResults with collected answers after the last question", async () => {
+    const user = userEvent.setup();
+    const { renderResults } = renderQuiz();
+    await user.click(screen.getByTestId("eligibility-quiz-option-tech"));
+    await user.click(screen.getByTestId("eligibility-quiz-option-small"));
+    await user.click(screen.getByTestId("eligibility-quiz-option-early"));
+    expect(renderResults).toHaveBeenCalledOnce();
+    expect(renderResults).toHaveBeenCalledWith(
+      { industry: "tech", size: "small", stage: "early" },
+      expect.any(Function)
+    );
+  });
+
+  it("renders results view after all questions answered", async () => {
+    const user = userEvent.setup();
+    renderQuiz();
+    await user.click(screen.getByTestId("eligibility-quiz-option-tech"));
+    await user.click(screen.getByTestId("eligibility-quiz-option-small"));
+    await user.click(screen.getByTestId("eligibility-quiz-option-early"));
+    expect(screen.getByTestId("eligibility-quiz-results")).toBeInTheDocument();
+    expect(screen.getByTestId("results-view")).toBeInTheDocument();
+  });
+
+  it("reset from renderResults returns to step 1 with cleared answers", async () => {
+    const user = userEvent.setup();
+    renderQuiz();
+    await user.click(screen.getByTestId("eligibility-quiz-option-tech"));
+    await user.click(screen.getByTestId("eligibility-quiz-option-small"));
+    await user.click(screen.getByTestId("eligibility-quiz-option-early"));
+    await user.click(screen.getByTestId("reset-btn"));
+    expect(screen.getByTestId("eligibility-quiz")).toBeInTheDocument();
+    expect(screen.getByTestId("eligibility-quiz-question")).toHaveTextContent(
+      "What is your industry?"
+    );
+    expect(
+      screen.queryByTestId("eligibility-quiz-results")
+    ).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/components/EligibilityQuiz.test.tsx
+++ b/__tests__/components/EligibilityQuiz.test.tsx
@@ -9,6 +9,12 @@ import EligibilityQuiz, {
   type QuizAnswers,
 } from "@/components/EligibilityQuiz";
 
+vi.mock("@/components/Icon", () => ({
+  default: ({ name, ...rest }: { name: string; [key: string]: unknown }) => (
+    <span data-testid={`icon-${name}`} {...rest} />
+  ),
+}));
+
 const QUESTIONS: QuizQuestion[] = [
   {
     id: "industry",

--- a/__tests__/components/EligibilityQuiz.test.tsx
+++ b/__tests__/components/EligibilityQuiz.test.tsx
@@ -2,8 +2,7 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { render, screen, userEvent } from "./setup";
 import EligibilityQuiz, {
   type QuizQuestion,
   type QuizAnswers,

--- a/components/EligibilityQuiz.tsx
+++ b/components/EligibilityQuiz.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useState } from "react";
+import Icon from "@/components/Icon";
+
+/**
+ * <EligibilityQuiz> — generalised step-by-step quiz shell.
+ *
+ * Handles: question sequencing, progress bar, answer accumulation, back
+ * navigation, and "done" state. The caller provides questions and a
+ * renderResults callback that receives the collected answers and a reset
+ * function. All domain-specific logic (evaluation, results display, lead
+ * form) belongs in the renderResults callback.
+ *
+ * W-10 — hub foundation stream (REMEDIATION_QUEUE.md).
+ */
+
+export interface QuizQuestion {
+  /** Stable ID used as the key in the answers record. */
+  id: string;
+  /** Prompt displayed to the user. */
+  question: string;
+  options: QuizOption[];
+}
+
+export interface QuizOption {
+  value: string;
+  label: string;
+}
+
+/** Collected answers: question id → selected option value. */
+export type QuizAnswers = Record<string, string>;
+
+export interface EligibilityQuizProps {
+  questions: QuizQuestion[];
+  /**
+   * Called once all questions are answered. Return the full results view
+   * (table, cards, outcome text, lead form, etc.). `reset` clears state
+   * and returns to step 0.
+   */
+  renderResults: (answers: QuizAnswers, reset: () => void) => ReactNode;
+  /** Optional label shown above the progress bar. Defaults to "Eligibility Quiz". */
+  heading?: string;
+}
+
+export default function EligibilityQuiz({
+  questions,
+  renderResults,
+  heading = "Eligibility Quiz",
+}: EligibilityQuizProps) {
+  const [step, setStep] = useState(0);
+  const [answers, setAnswers] = useState<QuizAnswers>({});
+  const [done, setDone] = useState(false);
+
+  function handleOption(question: QuizQuestion, value: string) {
+    const next: QuizAnswers = { ...answers, [question.id]: value };
+    setAnswers(next);
+    if (step < questions.length - 1) {
+      setStep(step + 1);
+    } else {
+      setDone(true);
+    }
+  }
+
+  function handleBack() {
+    if (step > 0) setStep(step - 1);
+  }
+
+  function reset() {
+    setAnswers({});
+    setStep(0);
+    setDone(false);
+  }
+
+  if (done) {
+    return (
+      <div data-testid="eligibility-quiz-results">
+        {renderResults(answers, reset)}
+      </div>
+    );
+  }
+
+  const currentQuestion = questions[step];
+  if (!currentQuestion) return null;
+
+  const progressPct = Math.round((step / questions.length) * 100);
+
+  return (
+    <div
+      className="rounded-2xl border border-slate-200 bg-white p-6 md:p-8 shadow-sm"
+      data-testid="eligibility-quiz"
+    >
+      <div
+        className="flex items-center justify-between mb-5"
+        data-testid="eligibility-quiz-meta"
+      >
+        <p className="text-xs uppercase tracking-wider font-extrabold text-slate-500">
+          {heading} · {step + 1} of {questions.length}
+        </p>
+        <p
+          className="text-xs font-bold text-slate-500"
+          data-testid="eligibility-quiz-progress-label"
+        >
+          {progressPct}%
+        </p>
+      </div>
+
+      <div
+        role="progressbar"
+        aria-valuenow={progressPct}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label={`Quiz progress: ${progressPct}%`}
+        className="h-1.5 w-full bg-slate-100 rounded-full mb-6 overflow-hidden"
+        data-testid="eligibility-quiz-progress"
+      >
+        <div
+          className="h-full bg-amber-500 transition-all"
+          style={{ width: `${progressPct}%` }}
+        />
+      </div>
+
+      <h2
+        className="text-xl md:text-2xl font-extrabold text-slate-900 mb-5"
+        data-testid="eligibility-quiz-question"
+      >
+        {currentQuestion.question}
+      </h2>
+
+      <div className="space-y-2" data-testid="eligibility-quiz-options">
+        {currentQuestion.options.map((option) => (
+          <button
+            key={option.value}
+            type="button"
+            onClick={() => handleOption(currentQuestion, option.value)}
+            className="w-full text-left px-4 py-3 rounded-lg border border-slate-200 bg-slate-50 hover:bg-amber-50 hover:border-amber-300 transition-colors flex items-center justify-between gap-2"
+            data-testid={`eligibility-quiz-option-${option.value}`}
+          >
+            <span className="text-sm font-bold text-slate-900">{option.label}</span>
+            <Icon name="arrow-right" size={14} className="text-slate-400 shrink-0" />
+          </button>
+        ))}
+      </div>
+
+      {step > 0 && (
+        <button
+          type="button"
+          onClick={handleBack}
+          className="mt-5 inline-flex items-center gap-1.5 text-sm text-slate-500 hover:text-slate-800"
+          data-testid="eligibility-quiz-back"
+        >
+          <Icon name="chevron-left" size={14} /> Back
+        </button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## W-10: Extract `<EligibilityQuiz>` generalised quiz shell

Refs: #218
Audit: `docs/audits/codebase-health-2026-04-24.md` §W (hub foundation stream)
Queue: `docs/audits/REMEDIATION_QUEUE.md` W-10

---

### What

Adds `components/EligibilityQuiz.tsx` — a reusable step-by-step eligibility quiz shell for hub pages. Exports the component plus its TypeScript interfaces (`QuizQuestion`, `QuizOption`, `QuizAnswers`, `EligibilityQuizProps`) for type-safe consumption.

### Why

Multiple hub pages need a step-by-step eligibility quiz (grants, smsf, insurance, visa). The grants page already had a working implementation in `app/grants/eligibility-quiz/EligibilityQuizClient.tsx` with question sequencing, progress bar, back navigation, and answer accumulation — all hardcoded to the grants domain. Without extraction, every hub page would duplicate that shell, diverging over time. `EligibilityQuiz` lifts the shell into a shared component; hub pages supply only `questions[]` and a `renderResults` callback with their domain-specific results UI.

### API surface

```tsx
<EligibilityQuiz
  questions={QUESTIONS}          // QuizQuestion[]
  renderResults={(answers, reset) => <MyResults answers={answers} reset={reset} />}
  heading="Grants Eligibility"   // optional, default "Eligibility Quiz"
/>
```

### Test coverage

14 tests in `__tests__/components/EligibilityQuiz.test.tsx` (jsdom):
- Container renders, first question shown, options rendered
- Step meta (X of N) and progress % correct at each step
- Back button absent on step 0, shown after step 1+
- Back navigation returns to previous question
- `renderResults` called with collected answers after final question
- Results view rendered inside `data-testid="eligibility-quiz-results"`
- `reset()` from results callback clears state and returns to step 1
- Custom `heading` prop reflected in meta

### Checklist

- [x] W-10: `components/EligibilityQuiz.tsx` + 14 tests
- [ ] W-11: `<CrossHubLinks>` (next pending)
- [ ] W-12: `<HubPage>` HOC


---
_Generated by [Claude Code](https://claude.ai/code/session_016hn2G91ZmDe7NaTmn8BDcW)_