### PR TITLE
feat(w): CrossHubLinks registry-driven hub rail (W-11) [audit remediation]

### DIFF
--- a/__tests__/components/CrossHubLinks.test.tsx
+++ b/__tests__/components/CrossHubLinks.test.tsx
@@ -1,9 +1,15 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "./setup";
 import CrossHubLinks, { HUB_REGISTRY } from "@/components/CrossHubLinks";
+
+vi.mock("@/components/Icon", () => ({
+  default: ({ name, ...rest }: { name: string; [key: string]: unknown }) => (
+    <span data-testid={`icon-${name}`} {...rest} />
+  ),
+}));
 
 describe("CrossHubLinks", () => {
   it("renders the section container", () => {

--- a/__tests__/components/CrossHubLinks.test.tsx
+++ b/__tests__/components/CrossHubLinks.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import CrossHubLinks, { HUB_REGISTRY } from "@/components/CrossHubLinks";
+
+describe("CrossHubLinks", () => {
+  it("renders the section container", () => {
+    render(<CrossHubLinks hubs={["smsf", "grants"]} />);
+    expect(screen.getByTestId("cross-hub-links")).toBeInTheDocument();
+  });
+
+  it("shows the default heading", () => {
+    render(<CrossHubLinks hubs={["smsf"]} />);
+    expect(screen.getByTestId("cross-hub-links-heading")).toHaveTextContent(
+      "Explore more guides"
+    );
+  });
+
+  it("uses a custom heading when provided", () => {
+    render(<CrossHubLinks hubs={["smsf"]} heading="Related hubs" />);
+    expect(screen.getByTestId("cross-hub-links-heading")).toHaveTextContent(
+      "Related hubs"
+    );
+  });
+
+  it("renders a card for each known slug", () => {
+    render(<CrossHubLinks hubs={["smsf", "grants", "dividends"]} />);
+    expect(screen.getByTestId("cross-hub-link-smsf")).toBeInTheDocument();
+    expect(screen.getByTestId("cross-hub-link-grants")).toBeInTheDocument();
+    expect(screen.getByTestId("cross-hub-link-dividends")).toBeInTheDocument();
+  });
+
+  it("renders the correct href for each slug", () => {
+    render(<CrossHubLinks hubs={["smsf", "lump-sum-investing"]} />);
+    expect(screen.getByTestId("cross-hub-link-smsf")).toHaveAttribute(
+      "href",
+      "/smsf"
+    );
+    expect(
+      screen.getByTestId("cross-hub-link-lump-sum-investing")
+    ).toHaveAttribute("href", "/lump-sum-investing");
+  });
+
+  it("renders the hub label and tagline inside each card", () => {
+    render(<CrossHubLinks hubs={["smsf"]} />);
+    const card = screen.getByTestId("cross-hub-link-smsf");
+    expect(card).toHaveTextContent("SMSF");
+    expect(card).toHaveTextContent(
+      "Setup, audit, and investment strategy for self-managed super funds."
+    );
+  });
+
+  it("skips unknown slugs silently", () => {
+    render(<CrossHubLinks hubs={["smsf", "unknown-hub-xyz"]} />);
+    expect(screen.getByTestId("cross-hub-link-smsf")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("cross-hub-link-unknown-hub-xyz")
+    ).not.toBeInTheDocument();
+  });
+
+  it("returns null when all slugs are unknown", () => {
+    const { container } = render(
+      <CrossHubLinks hubs={["not-a-hub", "also-not-a-hub"]} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("returns null for an empty hubs array", () => {
+    const { container } = render(<CrossHubLinks hubs={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders multiple hubs in the grid", () => {
+    render(
+      <CrossHubLinks
+        hubs={["smsf", "grants", "super", "retirement", "insurance"]}
+      />
+    );
+    const grid = screen.getByTestId("cross-hub-links-grid");
+    expect(grid.children).toHaveLength(5);
+  });
+
+  it("HUB_REGISTRY covers at least 10 hubs", () => {
+    expect(Object.keys(HUB_REGISTRY).length).toBeGreaterThanOrEqual(10);
+  });
+
+  it("every HUB_REGISTRY entry has a non-empty label and tagline", () => {
+    for (const [slug, meta] of Object.entries(HUB_REGISTRY)) {
+      expect(meta.label.length, `${slug} label empty`).toBeGreaterThan(0);
+      expect(meta.tagline.length, `${slug} tagline empty`).toBeGreaterThan(0);
+    }
+  });
+
+  it("renders find-advisor hub with correct href", () => {
+    render(<CrossHubLinks hubs={["find-advisor"]} />);
+    expect(
+      screen.getByTestId("cross-hub-link-find-advisor")
+    ).toHaveAttribute("href", "/find-advisor");
+  });
+});

--- a/components/CrossHubLinks.tsx
+++ b/components/CrossHubLinks.tsx
@@ -1,0 +1,151 @@
+import Link from "next/link";
+import Icon from "@/components/Icon";
+
+/**
+ * <CrossHubLinks> — cross-hub navigation rail.
+ *
+ * Renders a grid of cards linking to adjacent hubs. The caller passes slugs
+ * from `HubConfig.relatedHubs`; this component resolves them via the built-in
+ * registry. Unknown slugs are skipped silently. If no resolvable slugs remain,
+ * the component returns null so the hub page emits no empty section.
+ *
+ * W-11 — hub foundation stream (REMEDIATION_QUEUE.md).
+ */
+
+export interface CrossHubLinksProps {
+  /** Slugs from HubConfig.relatedHubs. Resolved via the built-in registry. */
+  hubs: string[];
+  /** Section heading. Defaults to "Explore more guides". */
+  heading?: string;
+}
+
+interface HubMeta {
+  label: string;
+  tagline: string;
+}
+
+export const HUB_REGISTRY: Record<string, HubMeta> = {
+  smsf: {
+    label: "SMSF",
+    tagline: "Setup, audit, and investment strategy for self-managed super funds.",
+  },
+  grants: {
+    label: "Grants & Incentives",
+    tagline: "R&D tax incentives, EMDG, and industry growth programs.",
+  },
+  "lump-sum-investing": {
+    label: "Lump Sum Investing",
+    tagline: "Put a windfall to work with a structured investment plan.",
+  },
+  "negative-gearing": {
+    label: "Negative Gearing",
+    tagline: "Property tax strategy, deductibility rules, and worked examples.",
+  },
+  "sell-business": {
+    label: "Sell Your Business",
+    tagline: "Valuation, M&A advisors, and exit strategy for founders.",
+  },
+  dividends: {
+    label: "Dividends",
+    tagline: "Franking credits, DRP, and dividend growth strategy.",
+  },
+  "visa-investment": {
+    label: "Visa Investment",
+    tagline: "Significant Investor Visa and Business Innovation Visa.",
+  },
+  "foreign-investment": {
+    label: "Foreign Investment",
+    tagline: "FIRB rules, investment structures, and Australian property.",
+  },
+  "global-investing": {
+    label: "Global Investing",
+    tagline: "US shares, international ETFs, and portfolio diversification.",
+  },
+  super: {
+    label: "Superannuation",
+    tagline: "Compare super funds, contribution strategies, and employer SG.",
+  },
+  "private-markets": {
+    label: "Private Markets",
+    tagline: "Pre-IPO, secondary, and wholesale investment opportunities.",
+  },
+  insurance: {
+    label: "Insurance",
+    tagline: "Life, income protection, and TPD comparison for Australians.",
+  },
+  retirement: {
+    label: "Retirement",
+    tagline: "Drawdown strategy, account-based pensions, and age pension.",
+  },
+  "first-home-buyer": {
+    label: "First Home Buyer",
+    tagline: "FHSS, home guarantee, stamp duty, and borrowing power guides.",
+  },
+  redundancy: {
+    label: "Redundancy",
+    tagline: "ETP tax treatment, payout strategy, and what to do next.",
+  },
+  inheritance: {
+    label: "Inheritance",
+    tagline: "Probate by state, estate tax, and executor guides.",
+  },
+  "find-advisor": {
+    label: "Find a Financial Adviser",
+    tagline: "Match with an AFSL-authorised adviser for your situation.",
+  },
+};
+
+export default function CrossHubLinks({
+  hubs,
+  heading = "Explore more guides",
+}: CrossHubLinksProps) {
+  const resolved = hubs
+    .map((slug) => {
+      const meta = HUB_REGISTRY[slug];
+      return meta ? { slug, ...meta } : null;
+    })
+    .filter((h): h is { slug: string } & HubMeta => h !== null);
+
+  if (resolved.length === 0) return null;
+
+  return (
+    <section
+      className="py-12 bg-slate-50 border-t border-slate-200"
+      data-testid="cross-hub-links"
+    >
+      <div className="container-custom max-w-6xl">
+        <h2
+          className="text-2xl md:text-3xl font-extrabold text-slate-900 mb-6"
+          data-testid="cross-hub-links-heading"
+        >
+          {heading}
+        </h2>
+
+        <div
+          className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4"
+          data-testid="cross-hub-links-grid"
+        >
+          {resolved.map(({ slug, label, tagline }) => (
+            <Link
+              key={slug}
+              href={`/${slug}`}
+              className="group bg-white hover:bg-amber-50 border border-slate-200 hover:border-amber-200 rounded-xl p-5 transition-colors"
+              data-testid={`cross-hub-link-${slug}`}
+            >
+              <h3 className="text-base font-extrabold text-slate-900 group-hover:text-amber-700 mb-1.5">
+                {label}
+              </h3>
+              <p className="text-sm text-slate-600 leading-relaxed mb-3">
+                {tagline}
+              </p>
+              <span className="inline-flex items-center gap-1.5 text-sm font-bold text-amber-600 group-hover:underline">
+                Explore guide
+                <Icon name="arrow-right" size={14} />
+              </span>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## W-11: Build `<CrossHubLinks>` registry-driven hub rail

Refs: #218
Audit: `docs/audits/codebase-health-2026-04-24.md` §W (hub foundation stream)
Queue: `docs/audits/REMEDIATION_QUEUE.md` W-11

---

### What

Adds `components/CrossHubLinks.tsx` — a cross-hub navigation rail component and `HUB_REGISTRY` (exported for tests). Resolves `HubConfig.relatedHubs` slugs to display labels and taglines via a built-in registry. Unknown slugs are skipped silently; an empty resolved set returns null (no empty section emitted).

### Why

The hub anatomy (`docs/audits/HUB_BLUEPRINT.md` §2, line 89) places a CROSS-HUB RAIL at the bottom of every hub page. The hub graph is the platform's main cross-sell moat — each hub must be able to surface its adjacent hubs consistently. Without a shared component, every hub page would embed its own link grid with different markup, copy, and link styles. `CrossHubLinks` centralises the registry and the rendering so hub pages declare adjacency once in `HubConfig.relatedHubs` and get the rail automatically from `<HubPage>` (W-12).

### API surface

```tsx
<CrossHubLinks
  hubs={config.relatedHubs}           // string[] — slugs from HubConfig
  heading="Explore more guides"       // optional, default shown
/>
```

### Registry

17 hubs pre-registered (all current + planned): `smsf`, `grants`, `lump-sum-investing`, `negative-gearing`, `sell-business`, `dividends`, `visa-investment`, `foreign-investment`, `global-investing`, `super`, `private-markets`, `insurance`, `retirement`, `first-home-buyer`, `redundancy`, `inheritance`, `find-advisor`.

### Test coverage

12 tests in `__tests__/components/CrossHubLinks.test.tsx` (jsdom):
- Container renders; default and custom heading
- Cards for each known slug with correct href, label, and tagline
- Unknown slugs skipped; all-unknown → null; empty hubs → null
- Multiple hubs grid length
- Registry has ≥10 entries; every entry has non-empty label + tagline

### Checklist

- [x] W-11: `components/CrossHubLinks.tsx` + 12 tests
- [ ] W-12: `<HubPage>` HOC (next pending)


---
_Generated by [Claude Code](https://claude.ai/code/session_016hn2G91ZmDe7NaTmn8BDcW)_