### PR TITLE
refactor(x): swap createAdminClient → createClient in /invest/[slug] pages (X-05) [audit remediation]

### DIFF
--- a/app/invest/[slug]/etfs/page.tsx
+++ b/app/invest/[slug]/etfs/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
-import { createAdminClient } from "@/lib/supabase/admin";
+import { createClient } from "@/lib/supabase/server";
 import Icon from "@/components/Icon";
 
 export const revalidate = 1800;
@@ -28,7 +28,7 @@ interface SectorRow {
 
 async function fetchSector(slug: string): Promise<SectorRow | null> {
   try {
-    const supabase = createAdminClient();
+    const supabase = await createClient();
     const { data } = await supabase
       .from("commodity_sectors")
       .select("slug, display_name")
@@ -43,7 +43,7 @@ async function fetchSector(slug: string): Promise<SectorRow | null> {
 
 async function fetchEtfs(sectorSlug: string): Promise<EtfRow[]> {
   try {
-    const supabase = createAdminClient();
+    const supabase = await createClient();
     const { data } = await supabase
       .from("commodity_etfs")
       .select("*")
@@ -58,7 +58,7 @@ async function fetchEtfs(sectorSlug: string): Promise<EtfRow[]> {
 
 export async function generateStaticParams() {
   try {
-    const supabase = createAdminClient();
+    const supabase = await createClient();
     const { data } = await supabase
       .from("commodity_sectors")
       .select("slug")

--- a/app/invest/[slug]/stocks/[ticker]/page.tsx
+++ b/app/invest/[slug]/stocks/[ticker]/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
-import { createAdminClient } from "@/lib/supabase/admin";
+import { createClient } from "@/lib/supabase/server";
 import Icon from "@/components/Icon";
 
 export const revalidate = 3600;
@@ -41,7 +41,7 @@ interface BrokerRow {
 
 async function fetchStock(sectorSlug: string, ticker: string): Promise<StockRow | null> {
   try {
-    const supabase = createAdminClient();
+    const supabase = await createClient();
     const { data } = await supabase
       .from("commodity_stocks")
       .select("*")
@@ -57,7 +57,7 @@ async function fetchStock(sectorSlug: string, ticker: string): Promise<StockRow 
 
 async function fetchSector(slug: string): Promise<SectorRow | null> {
   try {
-    const supabase = createAdminClient();
+    const supabase = await createClient();
     const { data } = await supabase
       .from("commodity_sectors")
       .select("slug, display_name")
@@ -72,7 +72,7 @@ async function fetchSector(slug: string): Promise<SectorRow | null> {
 
 async function fetchRelated(sectorSlug: string, excludeTicker: string): Promise<StockRow[]> {
   try {
-    const supabase = createAdminClient();
+    const supabase = await createClient();
     const { data } = await supabase
       .from("commodity_stocks")
       .select("id, sector_slug, ticker, company_name, market_cap_bucket, dividend_yield_pct, pe_ratio, blurb, primary_exposure, foreign_ownership_risk, last_reviewed_at, status, included_in_indices")
@@ -89,7 +89,7 @@ async function fetchRelated(sectorSlug: string, excludeTicker: string): Promise<
 
 async function fetchTopBrokers(): Promise<BrokerRow[]> {
   try {
-    const supabase = createAdminClient();
+    const supabase = await createClient();
     const { data } = await supabase
       .from("brokers")
       .select("slug, name, logo_url, asx_fee, rating, chess_sponsored, tagline, affiliate_url")

--- a/app/invest/[slug]/stocks/page.tsx
+++ b/app/invest/[slug]/stocks/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
-import { createAdminClient } from "@/lib/supabase/admin";
+import { createClient } from "@/lib/supabase/server";
 import Icon from "@/components/Icon";
 
 export const revalidate = 1800;
@@ -29,7 +29,7 @@ interface SectorRow {
 
 async function fetchSector(slug: string): Promise<SectorRow | null> {
   try {
-    const supabase = createAdminClient();
+    const supabase = await createClient();
     const { data } = await supabase
       .from("commodity_sectors")
       .select("slug, display_name, hero_description")
@@ -44,7 +44,7 @@ async function fetchSector(slug: string): Promise<SectorRow | null> {
 
 async function fetchStocks(sectorSlug: string): Promise<StockRow[]> {
   try {
-    const supabase = createAdminClient();
+    const supabase = await createClient();
     const { data } = await supabase
       .from("commodity_stocks")
       .select(
@@ -61,7 +61,7 @@ async function fetchStocks(sectorSlug: string): Promise<StockRow[]> {
 
 export async function generateStaticParams() {
   try {
-    const supabase = createAdminClient();
+    const supabase = await createClient();
     const { data } = await supabase
       .from("commodity_sectors")
       .select("slug")


### PR DESCRIPTION
## X-05: Swap `createAdminClient` → `createClient` in `/invest/[slug]` pages

Refs: #218
Audit: `docs/audits/codebase-health-2026-04-24.md` §C/X (admin.ts scope reset)
Queue: `docs/audits/REMEDIATION_QUEUE.md` X-05

---

### What

Replaces `createAdminClient()` (service-role, RLS bypass) with `await createClient()` (RSC server client, respects RLS) in three public-facing pages:
- `app/invest/[slug]/etfs/page.tsx` — 3 call sites
- `app/invest/[slug]/stocks/page.tsx` — 3 call sites
- `app/invest/[slug]/stocks/[ticker]/page.tsx` — 4 call sites

### Why

All tables queried by these pages have public-read RLS policies:
- `commodity_sectors`, `commodity_etfs`, `commodity_stocks` — `"Public read active ..."` policies (migration `20260510_rls_hardening.sql`) allowing anon SELECT WHERE `status = 'active'`
- `brokers` — `"Public read for active brokers"` policy (migration `001_initial.sql:184`) allowing SELECT WHERE `status = 'active'`

Using service-role for public pages with anon-accessible tables bypasses RLS without any security benefit and widens the admin client's scope beyond the boundaries in `CLAUDE.md`. The existing `status = 'active'` WHERE clauses in each function provide the same data filtering that the RLS policies enforce.

### Verification

Per X-stream gate: confirmed all 4 tables have anon SELECT policies before swapping. No existing WHERE clauses removed — the queries are unchanged except for the client.

### Checklist

- [x] X-05: 3 files × etfs + stocks + stocks/[ticker] swapped
- [ ] X-06: `/how-to/transfer-from/` (2 files) — next pending
- [ ] X-07: advisor-portal pages (4 files, may legitimately need admin)
- [ ] X-08: token-gated routes (expected to keep admin)
- [ ] X-09: Ratchet ESLint rule to error


---
_Generated by [Claude Code](https://claude.ai/code/session_016hn2G91ZmDe7NaTmn8BDcW)_