### PR TITLE
chore(w): [DUPLICATE — closed] HubPage HOC W-12

### DIFF
--- a/__tests__/components/HubPage.test.tsx
+++ b/__tests__/components/HubPage.test.tsx
@@ -1,0 +1,244 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import HubPage from "@/components/HubPage";
+import type { HubConfig } from "@/lib/verticals";
+
+// Mock HubHero and HubServiceGrid — both import <Icon> which chains to
+// @/lib/logger and causes jsdom failures without a mock (same pattern as
+// EligibilityQuiz, Calculator, etc.).
+vi.mock("@/components/HubHero", () => ({
+  default: ({
+    breadcrumbs,
+  }: {
+    hero: unknown;
+    breadcrumbs: Array<{ name: string; href?: string }>;
+  }) => (
+    <div
+      data-testid="mock-hub-hero"
+      data-breadcrumb-count={breadcrumbs.length}
+    />
+  ),
+}));
+
+vi.mock("@/components/HubServiceGrid", () => ({
+  default: ({
+    items,
+    heading,
+    columns,
+  }: {
+    items: unknown[];
+    heading: string;
+    columns?: number;
+  }) => (
+    <div
+      data-testid="mock-hub-service-grid"
+      data-item-count={items.length}
+      data-heading={heading}
+      data-columns={columns ?? 2}
+    />
+  ),
+}));
+
+// Minimal HubConfig for most tests (no optional slots populated)
+const BASE_CONFIG: HubConfig = {
+  slug: "test-hub",
+  title: "Test Hub",
+  metaDescription: "A test hub for unit tests.",
+  audiences: ["trustee"],
+  complianceKey: "factual_information",
+  hero: {
+    headline: "Test Headline",
+    subhead: "Test subhead copy.",
+    primaryCta: { label: "Get started", href: "/test", lever: "lead_routing" },
+  },
+  faqs: [
+    { question: "What is a test?", answer: "A test verifies behaviour." },
+    { question: "Why test?", answer: "To prevent regressions." },
+  ],
+  leadQueue: { kind: "general", topic: "testing" },
+  relatedHubs: ["smsf", "grants"],
+  articleFilters: {},
+  primaryKeywords: ["test hub"],
+  schemaTypes: ["WebPage"],
+};
+
+function renderHub(overrides: Partial<HubConfig> = {}) {
+  const config = { ...BASE_CONFIG, ...overrides };
+  return render(<HubPage config={config} />);
+}
+
+describe("HubPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the hub-page container", () => {
+    renderHub();
+    expect(screen.getByTestId("hub-page")).toBeInTheDocument();
+  });
+
+  it("renders HubHero", () => {
+    renderHub();
+    expect(screen.getByTestId("mock-hub-hero")).toBeInTheDocument();
+  });
+
+  it("passes correct breadcrumb count to HubHero for top-level hub (no parentSlug)", () => {
+    renderHub();
+    // breadcrumbs = [Home, Test Hub] → 2
+    expect(screen.getByTestId("mock-hub-hero")).toHaveAttribute(
+      "data-breadcrumb-count",
+      "2"
+    );
+  });
+
+  it("passes correct breadcrumb count to HubHero when parentSlug is set", () => {
+    renderHub({ parentSlug: "super" });
+    // breadcrumbs = [Home, Super, Test Hub] → 3
+    expect(screen.getByTestId("mock-hub-hero")).toHaveAttribute(
+      "data-breadcrumb-count",
+      "3"
+    );
+  });
+
+  it("renders HubServiceGrid when serviceGrid is configured", () => {
+    renderHub({
+      serviceGrid: [
+        {
+          title: "Setup",
+          description: "Setup description.",
+          href: "/setup",
+          icon: "settings",
+          cta: "Get set up",
+        },
+        {
+          title: "Audit",
+          description: "Audit description.",
+          href: "/audit",
+          icon: "shield-check",
+        },
+      ],
+    });
+    expect(screen.getByTestId("mock-hub-service-grid")).toBeInTheDocument();
+  });
+
+  it("omits HubServiceGrid when serviceGrid is absent", () => {
+    renderHub({ serviceGrid: undefined });
+    expect(
+      screen.queryByTestId("mock-hub-service-grid")
+    ).not.toBeInTheDocument();
+  });
+
+  it("omits HubServiceGrid when serviceGrid is empty", () => {
+    renderHub({ serviceGrid: [] });
+    expect(
+      screen.queryByTestId("mock-hub-service-grid")
+    ).not.toBeInTheDocument();
+  });
+
+  it("passes 3 columns to HubServiceGrid when more than 4 items", () => {
+    renderHub({
+      serviceGrid: [
+        { title: "A", description: "d", href: "/a" },
+        { title: "B", description: "d", href: "/b" },
+        { title: "C", description: "d", href: "/c" },
+        { title: "D", description: "d", href: "/d" },
+        { title: "E", description: "d", href: "/e" },
+      ],
+    });
+    expect(screen.getByTestId("mock-hub-service-grid")).toHaveAttribute(
+      "data-columns",
+      "3"
+    );
+  });
+
+  it("passes 2 columns to HubServiceGrid when 4 or fewer items", () => {
+    renderHub({
+      serviceGrid: [
+        { title: "A", description: "d", href: "/a" },
+        { title: "B", description: "d", href: "/b" },
+      ],
+    });
+    expect(screen.getByTestId("mock-hub-service-grid")).toHaveAttribute(
+      "data-columns",
+      "2"
+    );
+  });
+
+  it("renders children in the content slot", () => {
+    render(
+      <HubPage config={BASE_CONFIG}>
+        <div data-testid="custom-slot">Custom content</div>
+      </HubPage>
+    );
+    expect(screen.getByTestId("custom-slot")).toBeInTheDocument();
+  });
+
+  it("renders FAQ section when faqs are configured", () => {
+    renderHub();
+    expect(screen.getByTestId("hub-faq-section")).toBeInTheDocument();
+    const items = screen.getAllByTestId("hub-faq-item");
+    expect(items).toHaveLength(2);
+    expect(items[0]).toHaveTextContent("What is a test?");
+    expect(items[1]).toHaveTextContent("Why test?");
+  });
+
+  it("omits FAQ section when faqs array is empty", () => {
+    renderHub({ faqs: [] });
+    expect(screen.queryByTestId("hub-faq-section")).not.toBeInTheDocument();
+  });
+
+  it("renders compliance block always", () => {
+    renderHub();
+    expect(screen.getByTestId("hub-compliance")).toBeInTheDocument();
+  });
+
+  it("renders key-specific compliance addendum for smsf", () => {
+    renderHub({ complianceKey: "smsf" });
+    expect(screen.getByTestId("hub-compliance-addendum")).toHaveTextContent(
+      "Self-Managed Super Funds"
+    );
+  });
+
+  it("renders key-specific compliance addendum for crypto", () => {
+    renderHub({ complianceKey: "crypto" });
+    expect(screen.getByTestId("hub-compliance-addendum")).toHaveTextContent(
+      "Cryptocurrency is highly speculative"
+    );
+  });
+
+  it("omits compliance addendum for factual_information key", () => {
+    renderHub({ complianceKey: "factual_information" });
+    expect(
+      screen.queryByTestId("hub-compliance-addendum")
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders breadcrumb JSON-LD script", () => {
+    renderHub();
+    const script = document.querySelector(
+      'script[data-testid="hub-breadcrumb-jsonld"]'
+    );
+    expect(script).not.toBeNull();
+    expect(script?.innerHTML).toContain("BreadcrumbList");
+  });
+
+  it("renders FAQPage JSON-LD when faqs exist", () => {
+    renderHub();
+    const script = document.querySelector(
+      'script[data-testid="hub-faqpage-jsonld"]'
+    );
+    expect(script).not.toBeNull();
+    expect(script?.innerHTML).toContain("FAQPage");
+  });
+
+  it("omits FAQPage JSON-LD when no faqs", () => {
+    renderHub({ faqs: [] });
+    const script = document.querySelector(
+      'script[data-testid="hub-faqpage-jsonld"]'
+    );
+    expect(script).toBeNull();
+  });
+});

--- a/components/HubPage.tsx
+++ b/components/HubPage.tsx
@@ -1,0 +1,197 @@
+import type { ReactNode } from "react";
+import { breadcrumbJsonLd, SITE_URL } from "@/lib/seo";
+import { faqJsonLd } from "@/lib/schema-markup";
+import {
+  GENERAL_ADVICE_WARNING,
+  REGULATORY_NOTE,
+  ADVERTISER_DISCLOSURE_SHORT,
+  CRYPTO_WARNING,
+  PROPERTY_GENERAL_DISCLAIMER,
+} from "@/lib/compliance";
+import HubHero from "@/components/HubHero";
+import HubServiceGrid from "@/components/HubServiceGrid";
+import type { HubConfig } from "@/lib/verticals";
+
+/**
+ * <HubPage> — config-driven hub layout HOC (W-12, hub foundation stream).
+ *
+ * Accepts a `HubConfig` from `lib/verticals.ts` and renders the canonical hub
+ * anatomy per HUB_BLUEPRINT.md §2:
+ *   breadcrumb + FAQPage JSON-LD → HubHero → HubServiceGrid → {children} →
+ *   FAQ accordion → compliance block.
+ *
+ * The `children` slot carries hub-specific content that depends on components
+ * still in open PRs (DirectoryGrid, CalculatorShell, EligibilityQuiz,
+ * HubArticleStrip, HubDeepDiveGrid, HubAdvisorCTA, CrossHubLinks). Those
+ * will be wired into HubPage as each PR merges.
+ *
+ * After W-12 lands, new hubs ship as: one HubConfig row in lib/verticals.ts +
+ * a page.tsx of ~10 LOC that passes the config here.
+ */
+
+// Per-complianceKey addenda appended below the standard GAW.
+const COMPLIANCE_ADDENDA: Record<string, string> = {
+  crypto: CRYPTO_WARNING,
+  property: PROPERTY_GENERAL_DISCLAIMER,
+  smsf:
+    "Self-Managed Super Funds are subject to superannuation law. SMSF trustees are responsible for ensuring their fund meets all legal obligations. Seek specialist SMSF advice from a licensed adviser before making decisions.",
+  grants:
+    "Grant eligibility, amounts, and program availability change frequently. Verify current details directly with the relevant government agency or program administrator before applying.",
+  wholesale_s708:
+    "Some opportunities referenced may only be available to wholesale investors as defined by s708 of the Corporations Act 2001 (Cth). Nothing on this page constitutes an offer of a financial product.",
+  aged_care:
+    "Aged care costs and means-testing rules are set by government regulation and change frequently. Verify current fees and assessment thresholds with My Aged Care or a licensed aged care adviser.",
+  tax_agent:
+    "Tax information on this page is general in nature. Tax laws change frequently. Consult a registered tax agent for advice specific to your situation.",
+};
+
+interface HubPageProps {
+  config: HubConfig;
+  /**
+   * Hub-specific content rendered between the service grid and the FAQ
+   * section — calculators, directories, quizzes, articles, deep-dives, etc.
+   */
+  children?: ReactNode;
+}
+
+export default function HubPage({ config, children }: HubPageProps) {
+  const { slug, parentSlug, title, hero, serviceGrid, faqs, complianceKey } =
+    config;
+
+  // ── Breadcrumbs (for HubHero nav + JSON-LD) ──────────────────────────────
+  const breadcrumbs = [
+    { name: "Home", href: "/" },
+    ...(parentSlug
+      ? [
+          {
+            name: parentSlug.charAt(0).toUpperCase() + parentSlug.slice(1),
+            href: `/${parentSlug}`,
+          },
+        ]
+      : []),
+    { name: title },
+  ];
+
+  // ── JSON-LD ───────────────────────────────────────────────────────────────
+  const breadcrumbLd = breadcrumbJsonLd([
+    { name: "Home", url: `${SITE_URL}/` },
+    ...(parentSlug
+      ? [{ name: parentSlug, url: `${SITE_URL}/${parentSlug}` }]
+      : []),
+    { name: title, url: `${SITE_URL}/${slug}` },
+  ]);
+
+  const faqLd =
+    faqs.length > 0
+      ? faqJsonLd(faqs.map((f) => ({ q: f.question, a: f.answer })))
+      : null;
+
+  // ── Compliance ────────────────────────────────────────────────────────────
+  const complianceAddendum = COMPLIANCE_ADDENDA[complianceKey] ?? null;
+
+  // ── Service grid mapping ──────────────────────────────────────────────────
+  // ServiceCard (HubConfig) → HubServiceItem (HubServiceGrid prop).
+  // icon defaults to "arrow-right"; cta defaults to "Learn more".
+  const serviceItems =
+    serviceGrid && serviceGrid.length > 0
+      ? serviceGrid.map((card) => ({
+          title: card.title,
+          description: card.description,
+          href: card.href,
+          icon: card.icon ?? "arrow-right",
+          cta: card.cta ?? "Learn more",
+        }))
+      : null;
+
+  const serviceGridColumns: 2 | 3 =
+    serviceItems && serviceItems.length > 4 ? 3 : 2;
+
+  return (
+    <>
+      {/* ── Structured data ──────────────────────────────────────────────── */}
+      <script
+        type="application/ld+json"
+        data-testid="hub-breadcrumb-jsonld"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
+      />
+      {faqLd && (
+        <script
+          type="application/ld+json"
+          data-testid="hub-faqpage-jsonld"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }}
+        />
+      )}
+
+      <div className="bg-white min-h-screen" data-testid="hub-page">
+        {/* ── §1 HERO ────────────────────────────────────────────────────── */}
+        <HubHero hero={hero} breadcrumbs={breadcrumbs} />
+
+        {/* ── §2 SERVICE GRID ───────────────────────────────────────────── */}
+        {serviceItems && (
+          <HubServiceGrid
+            heading={`${title} Services`}
+            items={serviceItems}
+            columns={serviceGridColumns}
+          />
+        )}
+
+        {/* ── §3 HUB-SPECIFIC CONTENT (children slot) ───────────────────── */}
+        {/* Filled progressively as W-04..W-11 PRs merge into main:
+            HubArticleStrip, HubDeepDiveGrid, HubAdvisorCTA, DirectoryGrid,
+            CalculatorShell, EligibilityQuiz, CrossHubLinks. */}
+        {children}
+
+        {/* ── §4 FAQ ACCORDION ──────────────────────────────────────────── */}
+        {faqs.length > 0 && (
+          <section
+            className="py-12 bg-slate-50"
+            data-testid="hub-faq-section"
+          >
+            <div className="container-custom max-w-4xl">
+              <h2 className="text-2xl md:text-3xl font-extrabold text-slate-900 mb-8">
+                Frequently Asked Questions
+              </h2>
+              <div className="divide-y divide-slate-200">
+                {faqs.map((faq, i) => (
+                  <details
+                    key={i}
+                    className="group py-4"
+                    data-testid="hub-faq-item"
+                  >
+                    <summary className="flex cursor-pointer items-center justify-between gap-4 text-base font-bold text-slate-900 list-none [&::-webkit-details-marker]:hidden">
+                      {faq.question}
+                      <span
+                        className="shrink-0 text-amber-500 transition-transform group-open:rotate-180"
+                        aria-hidden="true"
+                      >
+                        ▼
+                      </span>
+                    </summary>
+                    <p className="mt-3 text-sm leading-relaxed text-slate-600">
+                      {faq.answer}
+                    </p>
+                  </details>
+                ))}
+              </div>
+            </div>
+          </section>
+        )}
+
+        {/* ── §5 COMPLIANCE BLOCK ───────────────────────────────────────── */}
+        <section
+          className="border-t border-slate-200 bg-white py-8"
+          data-testid="hub-compliance"
+        >
+          <div className="container-custom max-w-4xl space-y-2 text-xs text-slate-500">
+            <p>{GENERAL_ADVICE_WARNING}</p>
+            {complianceAddendum && (
+              <p data-testid="hub-compliance-addendum">{complianceAddendum}</p>
+            )}
+            <p>{REGULATORY_NOTE}</p>
+            <p>{ADVERTISER_DISCLOSURE_SHORT}</p>
+          </div>
+        </section>
+      </div>
+    </>
+  );
+}

--- a/lib/verticals.ts
+++ b/lib/verticals.ts
@@ -123,6 +123,8 @@ export interface ServiceCard {
   description: string;
   href: string;
   icon?: string;
+  /** CTA label for the card's action link (e.g. "Find SMSF Auditors"). Defaults to "Learn more" in HubPage. */
+  cta?: string;
 }
 
 /** Long-form deep-dive card — links to `<hub>/<slug>` long-tail content. */


### PR DESCRIPTION
## W-12: Build `<HubPage>` HOC

Refs: #218
Audit: `docs/audits/codebase-health-2026-04-24.md` §W (hub foundation stream)
Queue: `docs/audits/REMEDIATION_QUEUE.md` W-12

---

### What

Adds `components/HubPage.tsx` — the config-driven hub layout HOC described in `HUB_BLUEPRINT.md §2`.

Accepts a `HubConfig` from `lib/verticals.ts` and renders the canonical hub anatomy:

```
breadcrumb JSON-LD + FAQPage JSON-LD
→ HubHero (config.hero + auto-generated breadcrumbs)
→ HubServiceGrid (config.serviceGrid, columns auto-set: >4 items → 3col)
→ {children} slot (hub-specific content)
→ FAQ accordion (native <details>, no JS required)
→ compliance block (per-complianceKey addendum + GAW + regulatory note)
```

Also adds `cta?: string` to `ServiceCard` in `lib/verticals.ts` (additive, backward-compatible).

### Why

Every hub page was 200–500 LOC of bespoke JSX. A new hub required re-implementing hero, service grid, FAQ accordion, breadcrumb JSON-LD, FAQPage JSON-LD, and compliance block from scratch. After W-12 merges, a new hub is:
1. A `HubConfig` row in `lib/verticals.ts`
2. A `page.tsx` of ~10 LOC: `return <HubPage config={smsfConfig} />;`
3. Hub-specific content in the `children` slot

### Children slot

The `children` slot is coarse-grained by design for this first iteration. W-04..W-11 components (HubArticleStrip, HubDeepDiveGrid, HubAdvisorCTA, HubFAQ, DirectoryGrid, CalculatorShell, EligibilityQuiz, CrossHubLinks) will be wired into HubPage in follow-on iterations as each PR merges — no mass-merge dependency required.

### Test coverage

18 tests in `__tests__/components/HubPage.test.tsx` (jsdom):
- Hub-page container renders
- HubHero renders; breadcrumb count for top-level hub (2) and nested hub (3)
- HubServiceGrid renders/omits correctly; 3-col for >4 items, 2-col for ≤4
- children slot rendered
- FAQs render with correct count; omitted when empty
- Compliance block always renders; addendum for `smsf`/`crypto`; absent for `factual_information`
- Breadcrumb JSON-LD script present and contains `BreadcrumbList`
- FAQPage JSON-LD present when faqs exist; absent when empty

### Checklist

- [x] W-12: `components/HubPage.tsx` + 18 tests
- [ ] W-13: Migrate `/smsf` onto `<HubPage>` (next pending)
- [ ] W-14: Migrate `/grants` onto `<HubPage>`

---
_Generated by [Claude Code](https://claude.ai/code/session_01XBu8mijZuUh3hbTLVc7yHq)_