### PR TITLE
refactor(funds): use RLS-respecting createClient on funds RSC pages

### DIFF
--- a/app/invest/funds/[slug]/page.tsx
+++ b/app/invest/funds/[slug]/page.tsx
@@ -2,8 +2,7 @@ import Link from "next/link";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
-// eslint-disable-next-line no-restricted-imports -- pre-IA-refactor; admin client used here historically because the original schema lacked an anon SELECT policy on fund_listings. Migrate to createClient + an explicit anon policy on status='active' in a follow-up; out of scope for the 2026-05-07 IA refactor.
-import { createAdminClient } from "@/lib/supabase/admin";
+import { createClient } from "@/lib/supabase/server";
 import Icon from "@/components/Icon";
 import RegisterInterestForm from "@/components/funds/RegisterInterestForm";
 import type { FundListing } from "../FundsDirectoryClient";
@@ -12,7 +11,10 @@ export const revalidate = 600;
 
 async function fetchFund(slug: string): Promise<FundListing | null> {
   try {
-    const supabase = createAdminClient();
+    // RLS-respecting client. fund_listings has a public SELECT policy for
+    // anon + authenticated where status = 'active'. The .eq filter below
+    // is redundant with the policy but kept for query-clarity.
+    const supabase = await createClient();
     const { data } = await supabase
       .from("fund_listings")
       .select("*")
@@ -28,7 +30,7 @@ async function fetchFund(slug: string): Promise<FundListing | null> {
 async function fetchRelated(fundType: string | null, excludeId: number): Promise<FundListing[]> {
   if (!fundType) return [];
   try {
-    const supabase = createAdminClient();
+    const supabase = await createClient();
     const { data } = await supabase
       .from("fund_listings")
       .select("id, title, slug, fund_type, manager_name, min_investment_cents, target_return_percent, featured, featured_tier, siv_complying, open_to_retail, description, fund_size_cents, firb_relevant, status")

--- a/app/invest/funds/page.tsx
+++ b/app/invest/funds/page.tsx
@@ -2,8 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { Suspense } from "react";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
-// eslint-disable-next-line no-restricted-imports -- pre-IA-refactor; admin client used here historically because the original schema lacked an anon SELECT policy on fund_listings. Migrate to createClient + an explicit anon policy on status='active' in a follow-up; out of scope for the 2026-05-07 IA refactor.
-import { createAdminClient } from "@/lib/supabase/admin";
+import { createClient } from "@/lib/supabase/server";
 import FundsDirectoryClient, { type FundListing } from "./FundsDirectoryClient";
 import VerticalMarketplaceListings from "@/components/marketplace/VerticalMarketplaceListings";
 
@@ -24,7 +23,11 @@ export const metadata: Metadata = {
 
 async function fetchFunds(): Promise<FundListing[]> {
   try {
-    const supabase = createAdminClient();
+    // RLS-respecting client. fund_listings has a public SELECT policy for
+    // anon + authenticated where status = 'active' (see migration
+    // 20240312_fund_listings_rls.sql). The .eq("status","active") filter
+    // below is redundant with the policy but kept for query-clarity.
+    const supabase = await createClient();
     const { data } = await supabase
       .from("fund_listings")
       .select(


### PR DESCRIPTION
## Summary

Follow-up to #592. The funds directory (`/invest/funds`) and detail (`/invest/funds/[slug]`) RSC pages were using `createAdminClient()` — a service-role escape hatch that bypasses RLS — for what is plain anon-readable data. The `fund_listings` table already has an explicit anon SELECT policy for `status='active'` rows, so the admin client was unnecessary.

This PR switches both routes to `createClient()` from `@/lib/supabase/server`, which respects RLS and uses session cookies. It also removes the two scoped `eslint-disable` comments PR #592 added with a TODO to revisit; the underlying `no-restricted-imports` warning is now resolved without suppression.

## Why this is safe

Verified the policy exists on production:

| Policy | Roles | Cmd | Qualifier |
|---|---|---|---|
| `Public read active fund_listings` | `anon`, `authenticated` | `SELECT` | `status = 'active'` |
| `Service role write fund_listings` | `service_role` | `ALL` | `true` |

Both `fetchFunds()` (directory page) and `fetchFund(slug)` / `fetchRelated(...)` (detail page) already include `.eq("status", "active")` filters, so behavior is unchanged. Anon clients get the same rows back.

## Test plan

- [x] `npm run type-check` — clean
- [x] `npm run lint --max-warnings 0` on both files — clean (warning previously suppressed is now legitimately gone)
- [ ] Vercel preview: `/invest/funds` lists active funds. `/invest/funds/<slug>` renders detail page. \"Similar funds\" section populates.
- [ ] Production: same checks post-merge. RLS makes this functionally identical, but worth eyeballing.

## Why no schema change

The anon SELECT policy was already in place from a much earlier migration (`20240312_fund_listings_rls.sql`). PR #592's commit comment incorrectly speculated the schema lacked one — verified via `pg_policies` that it's there. No migration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)