### PR TITLE
chore(ci): unblock loop PR smoke tests — drop loop-branch skip rule

### DIFF
--- a/scripts/vercel-skip-build.sh
+++ b/scripts/vercel-skip-build.sh
@@ -1,34 +1,27 @@
 #!/bin/bash
 # Vercel "Ignored Build Step" — exit 0 = SKIP build, exit 1 = BUILD.
 #
-# Wired in via vercel.json's `ignoreCommand`. Three skip rules:
+# Wired in via vercel.json's `ignoreCommand`. Two skip rules:
 #
-#   1. Loop-authored branches (claude/audit-remediation/*) — these are
-#      code-only iterations verified by CI; nobody browses preview URLs
-#      for them. Skipping saves ~30-50% of build CPU on a busy loop day.
-#
-#   2. Docs-only commits — only files under docs/, *.md at root, or the
+#   1. Docs-only commits — only files under docs/, *.md at root, or the
 #      remediation queue/log files. No runtime impact, no need to build.
 #
-#   3. Loop pause sentinel commits (LOOP_PAUSE) — pause/resume commits
+#   2. Loop pause sentinel commits (LOOP_PAUSE) — pause/resume commits
 #      touch a single file and don't change behaviour.
 #
-# Anything else falls through and builds normally.
+# Anything else builds normally — including loop-authored branches
+# (claude/audit-remediation/*). Loop PRs MUST build because the
+# `Preview smoke test (critical URLs)` CI gate looks up the Vercel
+# deployment registered to the head SHA; if no build runs, no
+# deployment exists, and the gate times out — forcing admin-merge
+# bypasses on every loop PR. The CPU savings from skipping loop
+# branches were not worth that ergonomic cost.
 
 set -e
 
-ref="${VERCEL_GIT_COMMIT_REF:-}"
 sha="${VERCEL_GIT_COMMIT_SHA:-HEAD}"
 
-# Rule 1 — loop branches
-case "$ref" in
-  claude/audit-remediation/*)
-    echo "skip: loop-authored branch ($ref)"
-    exit 0
-    ;;
-esac
-
-# Rule 2/3 — files-changed inspection
+# Files-changed inspection
 # `git diff --quiet` exits 0 if no diff (i.e. excluded paths cover
 # everything), so we invert: if --quiet returns 0 after excluding
 # docs/markdown/queue files, the commit is docs-only and we skip.


### PR DESCRIPTION
## Summary

- Removes Rule 1 from `scripts/vercel-skip-build.sh` which unconditionally skipped Vercel builds on `claude/audit-remediation/*` branches
- The `Preview smoke test (critical URLs)` CI gate polls for a Vercel deployment registered to the head SHA; without a build, no deployment exists, so the gate times out → FAILURE
- This was the root cause behind today's two batches of admin-merge bypasses (5 PRs in the morning, 12 PRs this afternoon)

## Why

The CPU savings from skipping loop branches (estimated 30–50% on busy days) were costing more than they saved: every routine component-extraction / refactor / test PR from the loop required admin-merge to bypass the smoke-test gate. After this change, the gate works correctly and the auto-merge label can do its job autonomously.

Skip rules retained:
- Docs-only commits (only `docs/`, `*.md`, `LOOP_PAUSE` changes)
- `LOOP_PAUSE` sentinel commits

## Test plan

- [ ] Lint · Type-check · Test · Build green on this PR (sanity — script change can't affect TS/tests, but verifying the file itself parses)
- [ ] Preview smoke test green (validates that this PR's own build runs to completion under the new rules — the file change is non-loop-branch so existing rules don't kick in)
- [ ] Next loop-authored PR after this lands gets a real Vercel deployment + real smoke-test result

🤖 Generated with [Claude Code](https://claude.com/claude-code)