### PR TITLE
feat(country-mode): Phase 1 — country-tailored homepage + cross-surface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,7 @@ npm run test:watch                 # watch mode
 | Affiliate links + benefit CTAs + star rendering | `lib/tracking.ts`                                      |
 | Sponsorship ranking helpers                  | `lib/sponsorship.ts`                                      |
 | Vertical config (pillar pages, categories)   | `lib/verticals.ts`                                        |
+| Country Mode (priority chain, filters, supply thresholds) | `lib/country-mode/` + `lib/intent-context.ts` (see `docs/architecture/country-mode.md`) |
 | Locale registry + path helpers               | `lib/i18n/locales.ts`, `lib/i18n/dictionaries.ts`         |
 | Schema.org JSON-LD builders                  | `lib/schema-markup.ts`                                    |
 | Structured logging                           | `lib/logger.ts` (never `console.*`)                       |

--- a/__tests__/components/CountryHomepageWrappers.test.tsx
+++ b/__tests__/components/CountryHomepageWrappers.test.tsx
@@ -1,0 +1,220 @@
+/**
+ * Smoke tests for the three Country Mode homepage preview wrappers.
+ *
+ * Each wrapper is a server component that:
+ *   1. Returns null when no country cookie
+ *   2. Returns null when the country has no homepage* filters configured
+ *   3. Returns null when Supabase returns < supply threshold
+ *   4. Renders content when filters + sufficient supply
+ *
+ * The third gate is what enforces "Don't fake supply" at runtime — see
+ * lib/country-mode/supply-thresholds.ts.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "./setup";
+
+// ─── Module mocks ─────────────────────────────────────────────────────
+
+const { mockGetIntentCountry, mockGetFilters, mockSupabaseLimit } = vi.hoisted(() => ({
+  mockGetIntentCountry: vi.fn(),
+  mockGetFilters: vi.fn(),
+  mockSupabaseLimit: vi.fn(),
+}));
+
+vi.mock("@/lib/intent-context", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/intent-context")>(
+    "@/lib/intent-context",
+  );
+  return {
+    ...actual,
+    getIntentCountry: mockGetIntentCountry,
+  };
+});
+
+vi.mock("@/lib/country-mode", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/country-mode")>(
+    "@/lib/country-mode",
+  );
+  return {
+    ...actual,
+    getHomepageFiltersForCountry: mockGetFilters,
+  };
+});
+
+// Supabase mock — chainable builder that always resolves to whatever
+// mockSupabaseLimit was last configured with.
+function makeQueryBuilder() {
+  const builder: Record<string, (...args: unknown[]) => unknown> = {};
+  ["select", "eq", "in", "order"].forEach((method) => {
+    builder[method] = () => builder;
+  });
+  builder.limit = mockSupabaseLimit;
+  return builder;
+}
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: () => Promise.resolve({ from: () => makeQueryBuilder() }),
+}));
+
+import CountryListingsPreview from "@/components/country-mode/CountryListingsPreview";
+import CountryExpertsPreview from "@/components/country-mode/CountryExpertsPreview";
+import CountryComparePreview from "@/components/country-mode/CountryComparePreview";
+
+// ─── Shared setup ─────────────────────────────────────────────────────
+
+const NULL_FILTERS = {
+  listings: null,
+  experts: null,
+  platforms: null,
+  tools: [],
+  popularLinks: [],
+};
+
+const HK_FILTERS = {
+  listings: { verticals: ["commercial-property"], firb: false },
+  experts: { specialties: ["tax"], languages: [] },
+  platforms: { types: ["share_broker"], nonResidentsOnly: true },
+  tools: [],
+  popularLinks: [],
+};
+
+beforeEach(() => {
+  mockGetIntentCountry.mockReset();
+  mockGetFilters.mockReset();
+  mockSupabaseLimit.mockReset();
+});
+
+// ─── CountryListingsPreview ───────────────────────────────────────────
+
+describe("CountryListingsPreview", () => {
+  it("returns null when no country is set", async () => {
+    mockGetIntentCountry.mockResolvedValue(null);
+    expect(await CountryListingsPreview()).toBeNull();
+  });
+
+  it("returns null when the country has no listing filters", async () => {
+    mockGetIntentCountry.mockResolvedValue("hk");
+    mockGetFilters.mockReturnValue(NULL_FILTERS);
+    expect(await CountryListingsPreview()).toBeNull();
+  });
+
+  it("returns null when supply falls below threshold (2 listings)", async () => {
+    mockGetIntentCountry.mockResolvedValue("hk");
+    mockGetFilters.mockReturnValue(HK_FILTERS);
+    mockSupabaseLimit.mockResolvedValue({
+      data: [{ id: 1, title: "Solo", slug: "solo", vertical: "commercial-property", images: [] }],
+      error: null,
+    });
+    expect(await CountryListingsPreview()).toBeNull();
+  });
+
+  it("renders when filters present and supply meets threshold", async () => {
+    mockGetIntentCountry.mockResolvedValue("hk");
+    mockGetFilters.mockReturnValue(HK_FILTERS);
+    mockSupabaseLimit.mockResolvedValue({
+      data: [
+        { id: 1, title: "Sydney CBD office", slug: "sydney-cbd-office", vertical: "commercial-property", images: ["/img/a.jpg"], location_state: "NSW", location_city: "Sydney", price_display: "AU$5M" },
+        { id: 2, title: "Melbourne medical", slug: "melbourne-medical", vertical: "commercial-property", images: [], location_state: "VIC", location_city: "Melbourne", price_display: null },
+        { id: 3, title: "Brisbane retail", slug: "brisbane-retail", vertical: "commercial-property", images: [], location_state: "QLD", location_city: "Brisbane", price_display: "AU$2M" },
+      ],
+      error: null,
+    });
+    const ui = await CountryListingsPreview();
+    render(<>{ui}</>);
+    expect(screen.getByText(/Tailored for HK investors/i)).toBeInTheDocument();
+    expect(screen.getByText("Sydney CBD office")).toBeInTheDocument();
+    expect(screen.getByText("Melbourne medical")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /See all opportunities/i })).toBeInTheDocument();
+  });
+});
+
+// ─── CountryExpertsPreview ────────────────────────────────────────────
+
+describe("CountryExpertsPreview", () => {
+  it("returns null when no country is set", async () => {
+    mockGetIntentCountry.mockResolvedValue(null);
+    expect(await CountryExpertsPreview()).toBeNull();
+  });
+
+  it("returns null when the country has no expert filters", async () => {
+    mockGetIntentCountry.mockResolvedValue("hk");
+    mockGetFilters.mockReturnValue(NULL_FILTERS);
+    expect(await CountryExpertsPreview()).toBeNull();
+  });
+
+  it("returns null when supply falls below threshold (2 experts)", async () => {
+    mockGetIntentCountry.mockResolvedValue("hk");
+    mockGetFilters.mockReturnValue(HK_FILTERS);
+    mockSupabaseLimit.mockResolvedValue({
+      data: [{ slug: "solo", name: "Solo", firm_name: null, type: "tax", location_display: null, photo_url: null }],
+      error: null,
+    });
+    expect(await CountryExpertsPreview()).toBeNull();
+  });
+
+  it("renders when filters present and supply meets threshold", async () => {
+    mockGetIntentCountry.mockResolvedValue("hk");
+    mockGetFilters.mockReturnValue(HK_FILTERS);
+    mockSupabaseLimit.mockResolvedValue({
+      data: [
+        { slug: "alex-tax", name: "Alex Tax", firm_name: "Tax Firm", type: "tax", location_display: "Sydney", photo_url: null },
+        { slug: "betty-tax", name: "Betty Tax", firm_name: null, type: "tax", location_display: "Melbourne", photo_url: null },
+      ],
+      error: null,
+    });
+    const ui = await CountryExpertsPreview();
+    render(<>{ui}</>);
+    expect(screen.getByText(/Specialists for investors from Hong Kong/i)).toBeInTheDocument();
+    expect(screen.getByText("Alex Tax")).toBeInTheDocument();
+    expect(screen.getByText("Betty Tax")).toBeInTheDocument();
+  });
+});
+
+// ─── CountryComparePreview ────────────────────────────────────────────
+
+describe("CountryComparePreview", () => {
+  it("returns null when no country is set", async () => {
+    mockGetIntentCountry.mockResolvedValue(null);
+    expect(await CountryComparePreview()).toBeNull();
+  });
+
+  it("returns null when the country has no platform filters", async () => {
+    mockGetIntentCountry.mockResolvedValue("hk");
+    mockGetFilters.mockReturnValue(NULL_FILTERS);
+    expect(await CountryComparePreview()).toBeNull();
+  });
+
+  it("returns null when supply falls below threshold (3 platforms — stricter)", async () => {
+    mockGetIntentCountry.mockResolvedValue("hk");
+    mockGetFilters.mockReturnValue(HK_FILTERS);
+    // 2 platforms is below the platforms threshold (3). For listings/experts
+    // the same count would pass — the stricter platforms gate matters here.
+    mockSupabaseLimit.mockResolvedValue({
+      data: [
+        { id: 1, slug: "a", name: "A", platform_type: "share_broker", logo_url: null, rating: 4.5, asx_fee: "$5", accepts_non_residents: true },
+        { id: 2, slug: "b", name: "B", platform_type: "share_broker", logo_url: null, rating: 4.0, asx_fee: "$10", accepts_non_residents: true },
+      ],
+      error: null,
+    });
+    expect(await CountryComparePreview()).toBeNull();
+  });
+
+  it("renders when filters present and supply meets threshold (3+ platforms)", async () => {
+    mockGetIntentCountry.mockResolvedValue("hk");
+    mockGetFilters.mockReturnValue(HK_FILTERS);
+    mockSupabaseLimit.mockResolvedValue({
+      data: [
+        { id: 1, slug: "ibkr-hk", name: "IBKR HK", platform_type: "share_broker", logo_url: null, rating: 4.7, asx_fee: "$5", accepts_non_residents: true },
+        { id: 2, slug: "saxo-hk", name: "Saxo HK", platform_type: "share_broker", logo_url: null, rating: 4.5, asx_fee: "$10", accepts_non_residents: true },
+        { id: 3, slug: "tiger-hk", name: "Tiger HK", platform_type: "share_broker", logo_url: null, rating: 4.3, asx_fee: "$8", accepts_non_residents: true },
+      ],
+      error: null,
+    });
+    const ui = await CountryComparePreview();
+    render(<>{ui}</>);
+    expect(screen.getByText(/Platforms that accept investors from Hong Kong/i)).toBeInTheDocument();
+    expect(screen.getByText("IBKR HK")).toBeInTheDocument();
+    expect(screen.getByText("Tiger HK")).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/CountryHomepageWrappers.test.tsx
+++ b/__tests__/components/CountryHomepageWrappers.test.tsx
@@ -22,15 +22,9 @@ const { mockGetIntentCountry, mockGetFilters, mockSupabaseLimit } = vi.hoisted((
   mockSupabaseLimit: vi.fn(),
 }));
 
-vi.mock("@/lib/intent-context", async () => {
-  const actual = await vi.importActual<typeof import("@/lib/intent-context")>(
-    "@/lib/intent-context",
-  );
-  return {
-    ...actual,
-    getIntentCountry: mockGetIntentCountry,
-  };
-});
+vi.mock("@/lib/intent-context-server", () => ({
+  getIntentCountry: mockGetIntentCountry,
+}));
 
 vi.mock("@/lib/country-mode", async () => {
   const actual = await vi.importActual<typeof import("@/lib/country-mode")>(

--- a/__tests__/components/CountryModeBanner.test.tsx
+++ b/__tests__/components/CountryModeBanner.test.tsx
@@ -1,21 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, userEvent } from "./setup";
 
-// Mock getIntentCountry — banner reads the cookie via next/headers, so
-// the test stubs the resolved value.
+// Mock getIntentCountry — banner reads the cookie via next/headers via
+// the server-only module split. The test stubs the resolved value.
 const { mockGetIntentCountry } = vi.hoisted(() => ({
   mockGetIntentCountry: vi.fn(),
 }));
 
-vi.mock("@/lib/intent-context", async () => {
-  const actual = await vi.importActual<typeof import("@/lib/intent-context")>(
-    "@/lib/intent-context",
-  );
-  return {
-    ...actual,
-    getIntentCountry: mockGetIntentCountry,
-  };
-});
+vi.mock("@/lib/intent-context-server", () => ({
+  getIntentCountry: mockGetIntentCountry,
+}));
 
 import CountryModeBanner from "@/components/country-mode/CountryModeBanner";
 

--- a/__tests__/components/CountryModeBanner.test.tsx
+++ b/__tests__/components/CountryModeBanner.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, userEvent } from "./setup";
+
+// Mock getIntentCountry — banner reads the cookie via next/headers, so
+// the test stubs the resolved value.
+const { mockGetIntentCountry } = vi.hoisted(() => ({
+  mockGetIntentCountry: vi.fn(),
+}));
+
+vi.mock("@/lib/intent-context", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/intent-context")>(
+    "@/lib/intent-context",
+  );
+  return {
+    ...actual,
+    getIntentCountry: mockGetIntentCountry,
+  };
+});
+
+import CountryModeBanner from "@/components/country-mode/CountryModeBanner";
+
+describe("CountryModeBanner", () => {
+  beforeEach(() => {
+    mockGetIntentCountry.mockReset();
+  });
+
+  it("returns null when the cookie isn't set (homepage stays clean)", async () => {
+    mockGetIntentCountry.mockResolvedValue(null);
+    const result = await CountryModeBanner();
+    expect(result).toBeNull();
+  });
+
+  it("renders the banner with the country label when the cookie is set", async () => {
+    mockGetIntentCountry.mockResolvedValue("hk");
+    const ui = await CountryModeBanner();
+    render(<>{ui}</>);
+    expect(screen.getByText(/HK investors/i)).toBeInTheDocument();
+    // Both escape hatches present
+    expect(screen.getByRole("button", { name: /switch country/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /view global/i })).toBeInTheDocument();
+  });
+
+  it("'Switch country' dispatches the open-selector custom event", async () => {
+    mockGetIntentCountry.mockResolvedValue("uk");
+    const ui = await CountryModeBanner();
+    render(<>{ui}</>);
+    const user = userEvent.setup();
+    const listener = vi.fn();
+    window.addEventListener("country-mode:open-selector", listener);
+    await user.click(screen.getByRole("button", { name: /switch country/i }));
+    expect(listener).toHaveBeenCalledTimes(1);
+    window.removeEventListener("country-mode:open-selector", listener);
+  });
+
+  it("'View global' button is a form submit (calls clearIntentCountryAction server action)", async () => {
+    mockGetIntentCountry.mockResolvedValue("sa");
+    const ui = await CountryModeBanner();
+    render(<>{ui}</>);
+    const button = screen.getByRole("button", { name: /view global/i });
+    expect(button).toHaveAttribute("type", "submit");
+    // The server action wiring is exercised at the framework level — the
+    // contract here is just "this is a form submit, the action prop on
+    // the form is what next/server invokes."
+    expect(button.closest("form")).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/CountryPopularLinks.test.tsx
+++ b/__tests__/components/CountryPopularLinks.test.tsx
@@ -6,15 +6,9 @@ const { mockGetIntentCountry, mockGetFilters } = vi.hoisted(() => ({
   mockGetFilters: vi.fn(),
 }));
 
-vi.mock("@/lib/intent-context", async () => {
-  const actual = await vi.importActual<typeof import("@/lib/intent-context")>(
-    "@/lib/intent-context",
-  );
-  return {
-    ...actual,
-    getIntentCountry: mockGetIntentCountry,
-  };
-});
+vi.mock("@/lib/intent-context-server", () => ({
+  getIntentCountry: mockGetIntentCountry,
+}));
 
 vi.mock("@/lib/country-mode", async () => {
   const actual = await vi.importActual<typeof import("@/lib/country-mode")>(

--- a/__tests__/components/CountryPopularLinks.test.tsx
+++ b/__tests__/components/CountryPopularLinks.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "./setup";
+
+const { mockGetIntentCountry, mockGetFilters } = vi.hoisted(() => ({
+  mockGetIntentCountry: vi.fn(),
+  mockGetFilters: vi.fn(),
+}));
+
+vi.mock("@/lib/intent-context", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/intent-context")>(
+    "@/lib/intent-context",
+  );
+  return {
+    ...actual,
+    getIntentCountry: mockGetIntentCountry,
+  };
+});
+
+vi.mock("@/lib/country-mode", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/country-mode")>(
+    "@/lib/country-mode",
+  );
+  return {
+    ...actual,
+    getHomepageFiltersForCountry: mockGetFilters,
+  };
+});
+
+import CountryPopularLinks from "@/components/country-mode/CountryPopularLinks";
+
+const HK_FILTERS_WITH_LINKS = {
+  listings: null,
+  experts: null,
+  platforms: null,
+  tools: [],
+  popularLinks: [
+    { emoji: "🤝", label: "Get matched for HK investors", sublabel: "60s quiz", href: "/quiz?country=hong-kong" },
+    { emoji: "🇭🇰", label: "Investing from Hong Kong", sublabel: "Full guide", href: "/foreign-investment/hong-kong" },
+    { emoji: "📈", label: "Brokers that accept HK residents", sublabel: "IBKR + Saxo", href: "/compare/non-residents" },
+    { emoji: "🏠", label: "FIRB-eligible properties", sublabel: "Sydney/Melbourne CBD", href: "/invest?firb=eligible" },
+    { emoji: "💱", label: "HKD → AUD transfers", sublabel: "FX corridor", href: "/foreign-investment/send-money-australia" },
+  ],
+};
+
+const EMPTY_FILTERS = {
+  listings: null,
+  experts: null,
+  platforms: null,
+  tools: [],
+  popularLinks: [],
+};
+
+describe("CountryPopularLinks", () => {
+  beforeEach(() => {
+    mockGetIntentCountry.mockReset();
+    mockGetFilters.mockReset();
+  });
+
+  it("returns null when no country is set", async () => {
+    mockGetIntentCountry.mockResolvedValue(null);
+    expect(await CountryPopularLinks()).toBeNull();
+  });
+
+  it("returns null when the country has no popular links", async () => {
+    mockGetIntentCountry.mockResolvedValue("hk");
+    mockGetFilters.mockReturnValue(EMPTY_FILTERS);
+    expect(await CountryPopularLinks()).toBeNull();
+  });
+
+  it("renders the country's popular links capped at 4", async () => {
+    mockGetIntentCountry.mockResolvedValue("hk");
+    mockGetFilters.mockReturnValue(HK_FILTERS_WITH_LINKS);
+    const ui = await CountryPopularLinks();
+    render(<>{ui}</>);
+
+    // First 4 links visible
+    expect(screen.getByRole("link", { name: /Get matched for HK investors/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Investing from Hong Kong/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Brokers that accept HK residents/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /FIRB-eligible properties/i })).toBeInTheDocument();
+    // 5th link cut off by the slice(0, 4)
+    expect(screen.queryByRole("link", { name: /HKD → AUD transfers/i })).not.toBeInTheDocument();
+  });
+
+  it("first link is the Get-matched bridge to country-aware quiz", async () => {
+    // Step 7's HK config seeds the popular-links list with Get-matched
+    // as item 1 — Country Mode's bridge into the matching funnel.
+    mockGetIntentCountry.mockResolvedValue("hk");
+    mockGetFilters.mockReturnValue(HK_FILTERS_WITH_LINKS);
+    const ui = await CountryPopularLinks();
+    render(<>{ui}</>);
+    const getMatched = screen.getByRole("link", { name: /Get matched for HK investors/i });
+    expect(getMatched).toHaveAttribute("href", "/quiz?country=hong-kong");
+  });
+});

--- a/__tests__/components/GeoSoftPrompt.test.tsx
+++ b/__tests__/components/GeoSoftPrompt.test.tsx
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, userEvent, waitFor } from "./setup";
+
+// Auto-mock the modules we care about — every named export becomes a
+// vi.fn(). After this, the imports below resolve to the mock fns
+// directly, so we can assert on them via the import binding.
+vi.mock("@/lib/intent-context-actions");
+vi.mock("@/lib/tracking");
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+import GeoSoftPrompt from "@/components/country-mode/GeoSoftPrompt";
+import { setIntentCountryAction, clearIntentCountryAction } from "@/lib/intent-context-actions";
+import { trackEvent } from "@/lib/tracking";
+
+const mockSetIntentCountry = vi.mocked(setIntentCountryAction);
+const mockClearIntentCountry = vi.mocked(clearIntentCountryAction);
+const mockTrackEvent = vi.mocked(trackEvent);
+// Suppress unused-warning for the mock import side-effect — the typed
+// `mockClearIntentCountry` reference keeps the binding live for tests
+// that may assert on it in the future.
+void mockClearIntentCountry;
+
+const FLAG_KEY = "iv-location-flag-override";
+const DISMISSED_KEY = "iv-country-prompt-dismissed";
+
+function clearAllSignals() {
+  localStorage.clear();
+  document.cookie = "iv_intent_country=; max-age=0; path=/";
+}
+
+describe("GeoSoftPrompt", () => {
+  beforeEach(() => {
+    mockSetIntentCountry.mockClear();
+    mockTrackEvent.mockClear();
+    mockFetch.mockReset();
+    clearAllSignals();
+  });
+
+  afterEach(() => {
+    clearAllSignals();
+  });
+
+  describe("eligibility gates", () => {
+    it("does NOT render when the cookie is already set", async () => {
+      document.cookie = "iv_intent_country=hk; path=/";
+      mockFetch.mockResolvedValue({ ok: true, json: async () => ({ country: "GB" }) });
+
+      render(<GeoSoftPrompt />);
+
+      // Give effects a chance — should never render.
+      await waitFor(() => {
+        // Sanity check that something rendered (or rather, that the
+        // component is mounted and we've passed React's first commit).
+        expect(document.body).toBeInTheDocument();
+      });
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      // Fetch should be skipped entirely when the cookie short-circuits.
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("does NOT render when localStorage flag-override is set", async () => {
+      localStorage.setItem(FLAG_KEY, "GB");
+      mockFetch.mockResolvedValue({ ok: true, json: async () => ({ country: "GB" }) });
+
+      render(<GeoSoftPrompt />);
+      await waitFor(() => expect(document.body).toBeInTheDocument());
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("does NOT render when the prompt has been dismissed before", async () => {
+      localStorage.setItem(DISMISSED_KEY, "1");
+      mockFetch.mockResolvedValue({ ok: true, json: async () => ({ country: "GB" }) });
+
+      render(<GeoSoftPrompt />);
+      await waitFor(() => expect(document.body).toBeInTheDocument());
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("does NOT render when geo returns an unsupported country", async () => {
+      mockFetch.mockResolvedValue({ ok: true, json: async () => ({ country: "DE" }) });
+
+      render(<GeoSoftPrompt />);
+      await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+
+    it("does NOT render when geo returns null", async () => {
+      mockFetch.mockResolvedValue({ ok: true, json: async () => ({ country: null }) });
+
+      render(<GeoSoftPrompt />);
+      await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("renders + tracking when conditions met", () => {
+    it("renders the suggestion and fires country_mode_detected", async () => {
+      mockFetch.mockResolvedValue({ ok: true, json: async () => ({ country: "HK" }) });
+
+      render(<GeoSoftPrompt />);
+
+      // Banner appears post-fetch
+      const dialog = await screen.findByRole("dialog");
+      expect(dialog).toHaveAttribute("aria-label", "Suggested country: Hong Kong");
+      expect(screen.getByText(/Looks like you/i)).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /View Hong Kong version/i })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /Stay on global/i })).toBeInTheDocument();
+
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        "country_mode_detected",
+        expect.objectContaining({ country: "hk", source: "geo" }),
+      );
+    });
+  });
+
+  describe("accept flow", () => {
+    it("clicking 'View X version' sets cookie + localStorage + fires selected event", async () => {
+      mockFetch.mockResolvedValue({ ok: true, json: async () => ({ country: "GB" }) });
+      const user = userEvent.setup();
+      render(<GeoSoftPrompt />);
+
+      const accept = await screen.findByRole("button", { name: /View UK version/i });
+      await user.click(accept);
+
+      expect(mockSetIntentCountry).toHaveBeenCalledWith("uk");
+      expect(localStorage.getItem(FLAG_KEY)).toBe("GB");
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        "country_mode_selected",
+        expect.objectContaining({ country: "uk", source: "geo_prompt" }),
+      );
+    });
+  });
+
+  describe("dismiss flow", () => {
+    it("clicking 'Stay on global' sets dismissed flag + fires dismissed event + does NOT touch cookie", async () => {
+      mockFetch.mockResolvedValue({ ok: true, json: async () => ({ country: "SG" }) });
+      const user = userEvent.setup();
+      render(<GeoSoftPrompt />);
+
+      const dismiss = await screen.findByRole("button", { name: /Stay on global/i });
+      await user.click(dismiss);
+
+      expect(localStorage.getItem(DISMISSED_KEY)).toBe("1");
+      expect(localStorage.getItem(FLAG_KEY)).toBeNull();
+      expect(mockSetIntentCountry).not.toHaveBeenCalled();
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        "country_mode_dismissed",
+        expect.objectContaining({ country: "sg", source: "geo_prompt" }),
+      );
+      // Banner unmounts after dismissal
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/__tests__/components/HomeCrossBorder.test.tsx
+++ b/__tests__/components/HomeCrossBorder.test.tsx
@@ -5,15 +5,9 @@ const { mockGetIntentCountry } = vi.hoisted(() => ({
   mockGetIntentCountry: vi.fn(),
 }));
 
-vi.mock("@/lib/intent-context", async () => {
-  const actual = await vi.importActual<typeof import("@/lib/intent-context")>(
-    "@/lib/intent-context",
-  );
-  return {
-    ...actual,
-    getIntentCountry: mockGetIntentCountry,
-  };
-});
+vi.mock("@/lib/intent-context-server", () => ({
+  getIntentCountry: mockGetIntentCountry,
+}));
 
 import HomeCrossBorder from "@/components/HomeCrossBorder";
 

--- a/__tests__/components/HomeCrossBorder.test.tsx
+++ b/__tests__/components/HomeCrossBorder.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "./setup";
+
+const { mockGetIntentCountry } = vi.hoisted(() => ({
+  mockGetIntentCountry: vi.fn(),
+}));
+
+vi.mock("@/lib/intent-context", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/intent-context")>(
+    "@/lib/intent-context",
+  );
+  return {
+    ...actual,
+    getIntentCountry: mockGetIntentCountry,
+  };
+});
+
+import HomeCrossBorder from "@/components/HomeCrossBorder";
+
+describe("HomeCrossBorder", () => {
+  beforeEach(() => {
+    mockGetIntentCountry.mockReset();
+  });
+
+  it("renders 4 arrival cards in default order when no country is set", async () => {
+    mockGetIntentCountry.mockResolvedValue(null);
+    const ui = await HomeCrossBorder();
+    render(<>{ui}</>);
+    const cards = screen.getAllByText(/Coming from /);
+    expect(cards).toHaveLength(4);
+    // Default order: UK, India, China, US
+    expect(cards[0]).toHaveTextContent("Coming from the UK");
+    expect(cards[3]).toHaveTextContent("Coming from the US");
+  });
+
+  it("hoists India to position 1 when intent country is 'in'", async () => {
+    mockGetIntentCountry.mockResolvedValue("in");
+    const ui = await HomeCrossBorder();
+    render(<>{ui}</>);
+    const cards = screen.getAllByText(/Coming from /);
+    expect(cards[0]).toHaveTextContent("Coming from India");
+    // Other cards remain present, just shifted
+    expect(cards).toHaveLength(4);
+  });
+
+  it("hoists US to position 1 when intent country is 'us'", async () => {
+    mockGetIntentCountry.mockResolvedValue("us");
+    const ui = await HomeCrossBorder();
+    render(<>{ui}</>);
+    const cards = screen.getAllByText(/Coming from /);
+    expect(cards[0]).toHaveTextContent("Coming from the US");
+  });
+
+  it("does NOT reorder for a country not in the 4-card set (HK)", async () => {
+    // FIN_NOTEBOOK 2026-05-01 stance: don't broaden the cross-border
+    // section beyond the 4 inbound-migrant audiences. HK selection
+    // shouldn't reshape the UI here — the country-mode strips above
+    // already cover that surface area.
+    mockGetIntentCountry.mockResolvedValue("hk");
+    const ui = await HomeCrossBorder();
+    render(<>{ui}</>);
+    const cards = screen.getAllByText(/Coming from /);
+    expect(cards[0]).toHaveTextContent("Coming from the UK");
+    expect(cards).toHaveLength(4);
+  });
+});

--- a/__tests__/components/HomePathfinder.test.tsx
+++ b/__tests__/components/HomePathfinder.test.tsx
@@ -5,15 +5,9 @@ const { mockGetIntentCountry } = vi.hoisted(() => ({
   mockGetIntentCountry: vi.fn(),
 }));
 
-vi.mock("@/lib/intent-context", async () => {
-  const actual = await vi.importActual<typeof import("@/lib/intent-context")>(
-    "@/lib/intent-context",
-  );
-  return {
-    ...actual,
-    getIntentCountry: mockGetIntentCountry,
-  };
-});
+vi.mock("@/lib/intent-context-server", () => ({
+  getIntentCountry: mockGetIntentCountry,
+}));
 
 import HomePathfinder from "@/components/HomePathfinder";
 

--- a/__tests__/components/HomePathfinder.test.tsx
+++ b/__tests__/components/HomePathfinder.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "./setup";
+
+const { mockGetIntentCountry } = vi.hoisted(() => ({
+  mockGetIntentCountry: vi.fn(),
+}));
+
+vi.mock("@/lib/intent-context", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/intent-context")>(
+    "@/lib/intent-context",
+  );
+  return {
+    ...actual,
+    getIntentCountry: mockGetIntentCountry,
+  };
+});
+
+import HomePathfinder from "@/components/HomePathfinder";
+
+describe("HomePathfinder", () => {
+  beforeEach(() => {
+    mockGetIntentCountry.mockReset();
+  });
+
+  it("links to /quiz when no country is set", async () => {
+    mockGetIntentCountry.mockResolvedValue(null);
+    const ui = await HomePathfinder();
+    render(<>{ui}</>);
+    const cta = screen.getByRole("link", { name: /Get matched in 60 seconds/i });
+    expect(cta).toHaveAttribute("href", "/quiz");
+  });
+
+  it("carries the country slug forward when in country mode", async () => {
+    mockGetIntentCountry.mockResolvedValue("hk");
+    const ui = await HomePathfinder();
+    render(<>{ui}</>);
+    const cta = screen.getByRole("link", { name: /Get matched in 60 seconds/i });
+    expect(cta).toHaveAttribute("href", "/quiz?country=hong-kong");
+  });
+
+  it("uses the long slug for multi-word countries", async () => {
+    mockGetIntentCountry.mockResolvedValue("uk");
+    const ui = await HomePathfinder();
+    render(<>{ui}</>);
+    const cta = screen.getByRole("link", { name: /Get matched in 60 seconds/i });
+    expect(cta).toHaveAttribute("href", "/quiz?country=united-kingdom");
+  });
+});

--- a/__tests__/components/HomeToolsStrip.test.tsx
+++ b/__tests__/components/HomeToolsStrip.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "./setup";
+
+import HomeToolsStrip from "@/components/HomeToolsStrip";
+
+describe("HomeToolsStrip", () => {
+  it("renders all tools in default order when no featuredHrefs prop", () => {
+    render(<HomeToolsStrip />);
+    // First tool in the default list should appear first by DOM order.
+    const tools = screen.getAllByRole("link");
+    // Filter out the "See all 25" link
+    const toolLinks = tools.filter((l) => /\/.*-calculator|\/portfolio-xray|\/property\/foreign-investment/.test(l.getAttribute("href") ?? ""));
+    expect(toolLinks.length).toBeGreaterThanOrEqual(8);
+    // Default first: Switching Calculator
+    expect(toolLinks[0]).toHaveTextContent(/Switching Calculator/);
+  });
+
+  it("hoists featured tools to the front, preserving their order in the prop", () => {
+    render(
+      <HomeToolsStrip
+        featuredHrefs={["/cgt-calculator", "/property/foreign-investment"]}
+      />,
+    );
+    const tools = screen.getAllByRole("link").filter((l) =>
+      /\/.*-calculator|\/portfolio-xray|\/property\/foreign-investment/.test(l.getAttribute("href") ?? ""),
+    );
+    // Hoisted in the order given
+    expect(tools[0]).toHaveTextContent(/CGT Calculator/);
+    expect(tools[1]).toHaveTextContent(/FIRB Cost Calculator/);
+    // Non-hoisted tools still render after, in their original order.
+    // Switching Calculator is the original-list-first non-hoisted entry.
+    expect(tools[2]).toHaveTextContent(/Switching Calculator/);
+  });
+
+  it("ignores featuredHrefs entries that don't match any existing tool", () => {
+    // Country configs may reference slugs that don't yet exist in the
+    // global tools list (e.g., HK's WHT calc). Unmatched hrefs are
+    // silently dropped — the strip never invents a new tool.
+    render(
+      <HomeToolsStrip
+        featuredHrefs={["/withholding-tax-calculator", "/cgt-calculator"]}
+      />,
+    );
+    const tools = screen.getAllByRole("link").filter((l) =>
+      /\/.*-calculator|\/portfolio-xray|\/property\/foreign-investment/.test(l.getAttribute("href") ?? ""),
+    );
+    // Only CGT was matched; first tool is CGT
+    expect(tools[0]).toHaveTextContent(/CGT Calculator/);
+    // Strip never shrinks — full 8-tool count preserved
+    expect(tools.length).toBeGreaterThanOrEqual(8);
+  });
+
+  it("renders the same 8 tools regardless of featuredHrefs (re-rank, never replace)", () => {
+    const defaultRender = render(<HomeToolsStrip />).container.querySelectorAll("a[href^='/']");
+    const featuredRender = render(
+      <HomeToolsStrip featuredHrefs={["/cgt-calculator"]} />,
+    ).container.querySelectorAll("a[href^='/']");
+    // Same number of links — Country Mode never shrinks the tool set
+    expect(featuredRender.length).toBe(defaultRender.length);
+  });
+});

--- a/__tests__/components/LocationFlagButton.test.tsx
+++ b/__tests__/components/LocationFlagButton.test.tsx
@@ -36,25 +36,32 @@ describe("LocationFlagButton", () => {
   });
 
   describe("trigger label", () => {
-    it("renders flag-only when AU (default state)", async () => {
+    it("renders flag + chevron with no country name when AU (default state)", async () => {
       render(<LocationFlagButton />);
       const trigger = screen.getByRole("button", {
         name: /switch to investing-from-overseas view/i,
       });
       expect(trigger).toBeInTheDocument();
-      // The country name short label is hidden (Tailwind 'hidden sm:inline')
-      // when AU. Asserting absence of any of the supported-country names
-      // suffices.
+      // Chevron telegraphs "menu" affordance — must always render.
+      expect(trigger).toHaveTextContent("▾");
+      // No country name on default state.
       expect(screen.queryByText(/Hong Kong|UK|India|Singapore/)).not.toBeInTheDocument();
     });
 
-    it("renders flag + short name when a country is selected (override → state)", async () => {
+    it("renders flag + ISO + long name + chevron when a country is selected", async () => {
       // Pre-stamp localStorage so the first effect picks it up
       localStorage.setItem("iv-location-flag-override", "HK");
       render(<LocationFlagButton />);
-      // Wait for the post-mount effect that reads localStorage
-      const nameLabel = await screen.findByText("Hong Kong");
-      expect(nameLabel).toBeInTheDocument();
+      const trigger = await screen.findByRole("button", {
+        name: /Investing from Hong Kong/i,
+      });
+      // Both the mobile-only ISO and the desktop long name render in the
+      // DOM (Tailwind responsive classes don't compute in jsdom). Both
+      // should be present so screen-readers and breakpoint switches
+      // hand off cleanly.
+      expect(trigger).toHaveTextContent("Hong Kong");
+      expect(trigger).toHaveTextContent("HK");
+      expect(trigger).toHaveTextContent("▾");
     });
   });
 
@@ -90,20 +97,20 @@ describe("LocationFlagButton", () => {
     });
   });
 
-  describe("'I'm browsing as Australian' clears cookie + resets localStorage", () => {
+  describe("'Show me the global view' clears cookie + resets localStorage", () => {
     it("calls clearIntentCountryAction and stores AU in localStorage", async () => {
       const user = userEvent.setup();
       // Start with HK as the active country so the popover renders the
-      // "Viewing as" branch with the AU-reset link.
+      // "Viewing as" branch with the global-reset button.
       localStorage.setItem("iv-location-flag-override", "HK");
       render(<LocationFlagButton />);
 
       // Wait for the override to settle, then open the popover
       await screen.findByText("Hong Kong");
-      await user.click(screen.getByRole("button"));
+      await user.click(screen.getByRole("button", { name: /Investing from Hong Kong/i }));
 
       const resetButton = await screen.findByRole("button", {
-        name: /browsing as an Australian/i,
+        name: /show me the global view/i,
       });
       await user.click(resetButton);
 

--- a/__tests__/components/LocationFlagButton.test.tsx
+++ b/__tests__/components/LocationFlagButton.test.tsx
@@ -1,28 +1,32 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, userEvent, waitFor } from "./setup";
+import { render, screen, userEvent, waitFor, act } from "./setup";
 
-// Mock the intent-country server actions. Hoisted so the vi.mock
-// factory can reference them — see CLAUDE.md vitest hoisting note.
-const { mockSetIntentCountry, mockClearIntentCountry } = vi.hoisted(() => ({
-  mockSetIntentCountry: vi.fn(),
-  mockClearIntentCountry: vi.fn(),
-}));
-
-vi.mock("@/lib/intent-context-actions", () => ({
-  setIntentCountryAction: mockSetIntentCountry,
-  clearIntentCountryAction: mockClearIntentCountry,
-}));
+// Auto-mock the modules we assert on — every named export becomes a
+// vi.fn() and the imports below resolve to those mock fns directly.
+// Avoids the partial-factory binding fragility we hit on the first try.
+vi.mock("@/lib/intent-context-actions");
+vi.mock("@/lib/tracking");
 
 // Mock /api/geo so the detection effect doesn't actually fetch.
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
 import LocationFlagButton from "@/components/layout/LocationFlagButton";
+import {
+  setIntentCountryAction,
+  clearIntentCountryAction,
+} from "@/lib/intent-context-actions";
+import { trackEvent } from "@/lib/tracking";
+
+const mockSetIntentCountry = vi.mocked(setIntentCountryAction);
+const mockClearIntentCountry = vi.mocked(clearIntentCountryAction);
+const mockTrackEvent = vi.mocked(trackEvent);
 
 describe("LocationFlagButton", () => {
   beforeEach(() => {
     mockSetIntentCountry.mockClear();
     mockClearIntentCountry.mockClear();
+    mockTrackEvent.mockClear();
     mockFetch.mockReset();
     mockFetch.mockResolvedValue({ ok: true, json: async () => ({ country: null }) });
     localStorage.clear();
@@ -52,8 +56,13 @@ describe("LocationFlagButton", () => {
       // Pre-stamp localStorage so the first effect picks it up
       localStorage.setItem("iv-location-flag-override", "HK");
       render(<LocationFlagButton />);
+      // Aria-label for confirmed selection: "Currently viewing as Hong
+      // Kong. Switch country" (vs the suggested-state "Investing from X?
+      // Switch view"). The label distinction is the contract — it's how
+      // a screen-reader user knows whether they've confirmed a country
+      // or whether the system has only guessed at one.
       const trigger = await screen.findByRole("button", {
-        name: /Investing from Hong Kong/i,
+        name: /Currently viewing as Hong Kong/i,
       });
       // Both the mobile-only ISO and the desktop long name render in the
       // DOM (Tailwind responsive classes don't compute in jsdom). Both
@@ -66,7 +75,10 @@ describe("LocationFlagButton", () => {
   });
 
   describe("grid click writes both localStorage + cookie", () => {
-    it("calls setIntentCountryAction with the intent code (not the ISO)", async () => {
+    // First grid-click run cold-starts userEvent + opens the popover; the
+    // default 5s timeout is enough on warm runs but flaky on cold. Bumping
+    // to 10s gives the cold path room without slowing the hot path.
+    it("calls setIntentCountryAction with the intent code (not the ISO)", { timeout: 10_000 }, async () => {
       const user = userEvent.setup();
       render(<LocationFlagButton />);
 
@@ -107,7 +119,9 @@ describe("LocationFlagButton", () => {
 
       // Wait for the override to settle, then open the popover
       await screen.findByText("Hong Kong");
-      await user.click(screen.getByRole("button", { name: /Investing from Hong Kong/i }));
+      await user.click(
+        screen.getByRole("button", { name: /Currently viewing as Hong Kong/i }),
+      );
 
       const resetButton = await screen.findByRole("button", {
         name: /show me the global view/i,
@@ -164,6 +178,100 @@ describe("LocationFlagButton", () => {
         expect(screen.getByRole("button")).toBeInTheDocument();
       });
       expect(mockSetIntentCountry).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("country-mode:open-selector event opens the popover", () => {
+    it("dispatches open the popover from elsewhere on the page", async () => {
+      render(<LocationFlagButton />);
+      // Popover starts closed
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+
+      act(() => {
+        window.dispatchEvent(new CustomEvent("country-mode:open-selector"));
+      });
+
+      // Popover is now open
+      expect(await screen.findByRole("menu")).toBeInTheDocument();
+    });
+  });
+
+  describe("popover suggested state (geo-detected, not user-confirmed)", () => {
+    beforeEach(() => {
+      mockFetch.mockReset();
+      // Detected country = HK, no override, no dismissal → suggested state
+      mockFetch.mockResolvedValue({ ok: true, json: async () => ({ country: "HK" }) });
+    });
+
+    it("shows soft prompt with View+Stay buttons (no action list)", async () => {
+      const user = userEvent.setup();
+      render(<LocationFlagButton />);
+
+      // Wait for state to propagate — fetch returning isn't enough; the
+      // .then chain needs to resolve and the setState commit to flush.
+      // Aria-label flip is the DOM-observable signal.
+      await waitFor(() =>
+        expect(
+          screen.getByRole("button", { name: /Investing from Hong Kong/i }),
+        ).toBeInTheDocument(),
+      );
+      await user.click(screen.getByRole("button", { name: /Investing from Hong Kong/i }));
+
+      // Soft prompt copy
+      expect(await screen.findByText(/Looks like you/i)).toBeInTheDocument();
+      // Both CTAs present
+      expect(screen.getByRole("link", { name: /View Hong Kong version/i })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /Stay on global/i })).toBeInTheDocument();
+    });
+
+    it("trigger does NOT show country name when state is merely suggested", async () => {
+      render(<LocationFlagButton />);
+      await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+      // Country name is suppressed in the trigger when not user-confirmed.
+      // The trigger still shows the flag (matching detected) but no label.
+      const trigger = screen.getByRole("button", { name: /Investing from Hong Kong/i });
+      // 'Hong Kong' label is absent from the trigger; only flag + chevron
+      expect(trigger.textContent ?? "").not.toContain("Hong Kong");
+    });
+
+    it("'Stay on global' marks dismissed and fires tracking", async () => {
+      const user = userEvent.setup();
+      render(<LocationFlagButton />);
+
+      // Wait for the fetch chain to resolve and state to commit.
+      await waitFor(() =>
+        expect(
+          screen.getByRole("button", { name: /Investing from Hong Kong/i }),
+        ).toBeInTheDocument(),
+      );
+      await user.click(screen.getByRole("button", { name: /Investing from Hong Kong/i }));
+
+      const stay = await screen.findByRole("button", { name: /Stay on global/i });
+      await user.click(stay);
+
+      expect(localStorage.getItem("iv-country-prompt-dismissed")).toBe("1");
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        "country_mode_dismissed",
+        expect.objectContaining({ country: "hk", source: "popover_suggestion" }),
+      );
+      // Cookie must NOT be touched — user is not in country mode, just
+      // not interested in the soft prompt.
+      expect(mockSetIntentCountry).not.toHaveBeenCalled();
+      expect(mockClearIntentCountry).not.toHaveBeenCalled();
+    });
+
+    it("dismissed state suppresses suggestion on next mount (popover shows generic AU)", async () => {
+      // Pre-set dismissed flag — mounts with prior dismissal in place.
+      localStorage.setItem("iv-country-prompt-dismissed", "1");
+      const user = userEvent.setup();
+      render(<LocationFlagButton />);
+
+      await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+      await user.click(screen.getByRole("button"));
+
+      // Should NOT see the soft prompt — generic state instead
+      expect(screen.queryByText(/Looks like you/i)).not.toBeInTheDocument();
+      expect(screen.getByText(/Investing from overseas\?/i)).toBeInTheDocument();
     });
   });
 });

--- a/__tests__/components/LocationFlagButton.test.tsx
+++ b/__tests__/components/LocationFlagButton.test.tsx
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, userEvent, waitFor } from "./setup";
+
+// Mock the intent-country server actions. Hoisted so the vi.mock
+// factory can reference them — see CLAUDE.md vitest hoisting note.
+const { mockSetIntentCountry, mockClearIntentCountry } = vi.hoisted(() => ({
+  mockSetIntentCountry: vi.fn(),
+  mockClearIntentCountry: vi.fn(),
+}));
+
+vi.mock("@/lib/intent-context-actions", () => ({
+  setIntentCountryAction: mockSetIntentCountry,
+  clearIntentCountryAction: mockClearIntentCountry,
+}));
+
+// Mock /api/geo so the detection effect doesn't actually fetch.
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+import LocationFlagButton from "@/components/layout/LocationFlagButton";
+
+describe("LocationFlagButton", () => {
+  beforeEach(() => {
+    mockSetIntentCountry.mockClear();
+    mockClearIntentCountry.mockClear();
+    mockFetch.mockReset();
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ country: null }) });
+    localStorage.clear();
+    // Clear any stray cookie state from a previous test
+    document.cookie = "iv_intent_country=; max-age=0; path=/";
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    document.cookie = "iv_intent_country=; max-age=0; path=/";
+  });
+
+  describe("trigger label", () => {
+    it("renders flag-only when AU (default state)", async () => {
+      render(<LocationFlagButton />);
+      const trigger = screen.getByRole("button", {
+        name: /switch to investing-from-overseas view/i,
+      });
+      expect(trigger).toBeInTheDocument();
+      // The country name short label is hidden (Tailwind 'hidden sm:inline')
+      // when AU. Asserting absence of any of the supported-country names
+      // suffices.
+      expect(screen.queryByText(/Hong Kong|UK|India|Singapore/)).not.toBeInTheDocument();
+    });
+
+    it("renders flag + short name when a country is selected (override → state)", async () => {
+      // Pre-stamp localStorage so the first effect picks it up
+      localStorage.setItem("iv-location-flag-override", "HK");
+      render(<LocationFlagButton />);
+      // Wait for the post-mount effect that reads localStorage
+      const nameLabel = await screen.findByText("Hong Kong");
+      expect(nameLabel).toBeInTheDocument();
+    });
+  });
+
+  describe("grid click writes both localStorage + cookie", () => {
+    it("calls setIntentCountryAction with the intent code (not the ISO)", async () => {
+      const user = userEvent.setup();
+      render(<LocationFlagButton />);
+
+      // Open the popover
+      await user.click(screen.getByRole("button"));
+
+      // The grid contains 12 country links. Pick UK — its label is "UK"
+      // (the "the " prefix is stripped on render).
+      const ukLink = await screen.findByRole("link", { name: /^UK$/ });
+      await user.click(ukLink);
+
+      // ISO code is "GB"; intent code is "uk". The action must receive
+      // "uk" — feeding "GB" would fail isKnownIntentCountry and silently
+      // skip the cookie write.
+      expect(mockSetIntentCountry).toHaveBeenCalledWith("uk");
+      expect(mockSetIntentCountry).toHaveBeenCalledTimes(1);
+      // localStorage gets the ISO ("GB") for the existing override flow
+      expect(localStorage.getItem("iv-location-flag-override")).toBe("GB");
+    });
+
+    it("maps Hong Kong correctly (HK ISO → hk intent)", async () => {
+      const user = userEvent.setup();
+      render(<LocationFlagButton />);
+      await user.click(screen.getByRole("button"));
+      await user.click(await screen.findByRole("link", { name: /^Hong Kong$/ }));
+      expect(mockSetIntentCountry).toHaveBeenCalledWith("hk");
+      expect(localStorage.getItem("iv-location-flag-override")).toBe("HK");
+    });
+  });
+
+  describe("'I'm browsing as Australian' clears cookie + resets localStorage", () => {
+    it("calls clearIntentCountryAction and stores AU in localStorage", async () => {
+      const user = userEvent.setup();
+      // Start with HK as the active country so the popover renders the
+      // "Viewing as" branch with the AU-reset link.
+      localStorage.setItem("iv-location-flag-override", "HK");
+      render(<LocationFlagButton />);
+
+      // Wait for the override to settle, then open the popover
+      await screen.findByText("Hong Kong");
+      await user.click(screen.getByRole("button"));
+
+      const resetButton = await screen.findByRole("button", {
+        name: /browsing as an Australian/i,
+      });
+      await user.click(resetButton);
+
+      expect(mockClearIntentCountry).toHaveBeenCalledTimes(1);
+      expect(localStorage.getItem("iv-location-flag-override")).toBe("AU");
+    });
+  });
+
+  describe("mount-time localStorage → cookie migration", () => {
+    it("syncs localStorage country to cookie when cookie is missing", async () => {
+      // Existing user: localStorage was set before Country Mode wired
+      // the server action, so the cookie isn't there yet.
+      localStorage.setItem("iv-location-flag-override", "GB");
+      // Cookie intentionally cleared in beforeEach
+      render(<LocationFlagButton />);
+
+      await waitFor(() => {
+        expect(mockSetIntentCountry).toHaveBeenCalledWith("uk");
+      });
+    });
+
+    it("does NOT sync when localStorage is 'AU'", async () => {
+      localStorage.setItem("iv-location-flag-override", "AU");
+      render(<LocationFlagButton />);
+
+      // Give effects a chance to run
+      await waitFor(() => {
+        expect(screen.getByRole("button")).toBeInTheDocument();
+      });
+      // Migration must skip "AU" — that's the explicit "I'm browsing
+      // as Australian" state, not a country mode.
+      expect(mockSetIntentCountry).not.toHaveBeenCalled();
+    });
+
+    it("does NOT sync when the cookie already exists", async () => {
+      localStorage.setItem("iv-location-flag-override", "HK");
+      document.cookie = "iv_intent_country=hk; path=/";
+      render(<LocationFlagButton />);
+
+      await waitFor(() => {
+        expect(screen.getByRole("button")).toBeInTheDocument();
+      });
+      expect(mockSetIntentCountry).not.toHaveBeenCalled();
+    });
+
+    it("does NOT sync when localStorage holds an unsupported ISO", async () => {
+      localStorage.setItem("iv-location-flag-override", "DE");
+      render(<LocationFlagButton />);
+
+      await waitFor(() => {
+        expect(screen.getByRole("button")).toBeInTheDocument();
+      });
+      expect(mockSetIntentCountry).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/__tests__/lib/country-mode/filters.test.ts
+++ b/__tests__/lib/country-mode/filters.test.ts
@@ -14,17 +14,34 @@ describe("getHomepageFiltersForCountry", () => {
     });
   });
 
-  describe("supported country code without homepage* fields populated", () => {
-    // Step 3 added the optional fields to the interface; Step 7 will
-    // populate them on a per-country basis. Until then, every country
-    // returns null filters — which the homepage wrappers read as
-    // "render the global teaser, no country filtering."
-    it.each(INTENT_COUNTRY_CODES)("%s returns null filters when no fields set", (code) => {
-      const result = getHomepageFiltersForCountry(code);
-      expect(result.listings).toBeNull();
-      expect(result.experts).toBeNull();
-      expect(result.platforms).toBeNull();
-      expect(result.tools).toEqual([]);
+  describe("supported country codes — population status", () => {
+    // Step 7 populates HK as the Phase 1 model country; the other 11 fall
+    // back to global until Phase 2. The two assertions below are the
+    // contract: populated countries return runtime filter shapes, the
+    // rest return nulls so wrappers render the global teasers.
+    const POPULATED: ReadonlyArray<string> = ["hk"];
+
+    it.each(INTENT_COUNTRY_CODES.filter((c) => !POPULATED.includes(c)))(
+      "%s returns null filters (not yet populated)",
+      (code) => {
+        const result = getHomepageFiltersForCountry(code);
+        expect(result.listings).toBeNull();
+        expect(result.experts).toBeNull();
+        expect(result.platforms).toBeNull();
+        expect(result.tools).toEqual([]);
+      },
+    );
+
+    it("hk returns populated runtime filter shapes", () => {
+      const result = getHomepageFiltersForCountry("hk");
+      expect(result.listings).not.toBeNull();
+      expect(result.listings?.verticals).toContain("commercial-property");
+      expect(result.experts).not.toBeNull();
+      expect(result.experts?.specialties).toContain("tax");
+      expect(result.platforms).not.toBeNull();
+      expect(result.platforms?.types).toContain("share_broker");
+      expect(result.platforms?.nonResidentsOnly).toBe(true);
+      expect(result.tools.length).toBeGreaterThan(0);
     });
   });
 

--- a/__tests__/lib/country-mode/filters.test.ts
+++ b/__tests__/lib/country-mode/filters.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { getHomepageFiltersForCountry } from "@/lib/country-mode";
+import { INTENT_COUNTRY_CODES } from "@/lib/intent-context";
+
+describe("getHomepageFiltersForCountry", () => {
+  describe("null country code (global / AU fallback)", () => {
+    it("returns the empty-filter shape", () => {
+      const result = getHomepageFiltersForCountry(null);
+      expect(result.listings).toBeNull();
+      expect(result.experts).toBeNull();
+      expect(result.platforms).toBeNull();
+      expect(result.tools).toEqual([]);
+      expect(result.popularLinks).toEqual([]);
+    });
+  });
+
+  describe("supported country code without homepage* fields populated", () => {
+    // Step 3 added the optional fields to the interface; Step 7 will
+    // populate them on a per-country basis. Until then, every country
+    // returns null filters — which the homepage wrappers read as
+    // "render the global teaser, no country filtering."
+    it.each(INTENT_COUNTRY_CODES)("%s returns null filters when no fields set", (code) => {
+      const result = getHomepageFiltersForCountry(code);
+      expect(result.listings).toBeNull();
+      expect(result.experts).toBeNull();
+      expect(result.platforms).toBeNull();
+      expect(result.tools).toEqual([]);
+    });
+  });
+
+  describe("popularLinks falls back to existing defaultActions[]", () => {
+    // Per the addendum: Country Mode reuses the country's existing
+    // defaultActions[] (used by the flag-button popover) as the
+    // homepage popular-starting-points strip. No duplicate config.
+    it("returns defaultActions for countries that have them", () => {
+      const ukResult = getHomepageFiltersForCountry("uk");
+      // UK has defaultActions populated in the existing config.
+      expect(ukResult.popularLinks.length).toBeGreaterThan(0);
+      ukResult.popularLinks.forEach((action) => {
+        expect(action.label).toBeTruthy();
+        expect(action.href).toBeTruthy();
+      });
+    });
+
+    it.each(INTENT_COUNTRY_CODES)(
+      "%s popularLinks is an array (never undefined)",
+      (code) => {
+        const result = getHomepageFiltersForCountry(code);
+        expect(Array.isArray(result.popularLinks)).toBe(true);
+      },
+    );
+  });
+
+  describe("shape stability", () => {
+    it("returns the same shape for null and for unknown configs", () => {
+      // All current 12 codes have configs, but the helper must defend
+      // against a future code being added before its config exists.
+      const fromNull = getHomepageFiltersForCountry(null);
+      const fromCode = getHomepageFiltersForCountry("uk");
+      expect(Object.keys(fromNull).sort()).toEqual(Object.keys(fromCode).sort());
+    });
+  });
+});

--- a/__tests__/lib/country-mode/resolve-country.test.ts
+++ b/__tests__/lib/country-mode/resolve-country.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from "vitest";
+import { resolveCountryFromContext } from "@/lib/country-mode";
+
+describe("resolveCountryFromContext", () => {
+  describe("priority chain", () => {
+    it("URL param wins over cookie wins over geo", () => {
+      expect(
+        resolveCountryFromContext({
+          urlParam: "hong-kong",
+          cookie: "uk",
+          geoIso: "US",
+        }),
+      ).toEqual({ code: "hk", source: "url" });
+
+      expect(
+        resolveCountryFromContext({
+          urlParam: null,
+          cookie: "uk",
+          geoIso: "US",
+        }),
+      ).toEqual({ code: "uk", source: "cookie" });
+
+      expect(
+        resolveCountryFromContext({
+          urlParam: null,
+          cookie: null,
+          geoIso: "US",
+        }),
+      ).toEqual({ code: "us", source: "geo" });
+
+      expect(
+        resolveCountryFromContext({
+          urlParam: null,
+          cookie: null,
+          geoIso: null,
+        }),
+      ).toEqual({ code: null, source: null });
+    });
+
+    it("falls through invalid URL slug to cookie", () => {
+      expect(
+        resolveCountryFromContext({
+          urlParam: "narnia",
+          cookie: "uk",
+          geoIso: "US",
+        }),
+      ).toEqual({ code: "uk", source: "cookie" });
+    });
+
+    it("falls through invalid cookie value to geo", () => {
+      expect(
+        resolveCountryFromContext({
+          urlParam: null,
+          cookie: "definitely-not-a-country",
+          geoIso: "GB",
+        }),
+      ).toEqual({ code: "uk", source: "geo" });
+    });
+
+    it("falls through unsupported geo ISO to null", () => {
+      expect(
+        resolveCountryFromContext({
+          urlParam: null,
+          cookie: null,
+          geoIso: "DE", // Germany not in supported set
+        }),
+      ).toEqual({ code: null, source: null });
+    });
+
+    it("empty / undefined / null inputs all fall through cleanly", () => {
+      expect(resolveCountryFromContext({})).toEqual({ code: null, source: null });
+      expect(
+        resolveCountryFromContext({ urlParam: "", cookie: "", geoIso: "" }),
+      ).toEqual({ code: null, source: null });
+      expect(
+        resolveCountryFromContext({
+          urlParam: undefined,
+          cookie: undefined,
+          geoIso: undefined,
+        }),
+      ).toEqual({ code: null, source: null });
+    });
+  });
+
+  describe("URL param accepts only slugs", () => {
+    it("rejects intent codes (e.g. 'hk')", () => {
+      // Intent codes aren't slugs — rejection is by design, see resolve-country.ts JSDoc.
+      expect(
+        resolveCountryFromContext({ urlParam: "hk", cookie: null, geoIso: null }),
+      ).toEqual({ code: null, source: null });
+    });
+
+    it("rejects ISO codes (e.g. 'GB')", () => {
+      expect(
+        resolveCountryFromContext({ urlParam: "GB", cookie: null, geoIso: null }),
+      ).toEqual({ code: null, source: null });
+    });
+
+    it("accepts long slugs", () => {
+      expect(
+        resolveCountryFromContext({
+          urlParam: "united-kingdom",
+          cookie: null,
+          geoIso: null,
+        }),
+      ).toEqual({ code: "uk", source: "url" });
+
+      expect(
+        resolveCountryFromContext({
+          urlParam: "united-arab-emirates",
+          cookie: null,
+          geoIso: null,
+        }),
+      ).toEqual({ code: "ae", source: "url" });
+
+      expect(
+        resolveCountryFromContext({
+          urlParam: "saudi-arabia",
+          cookie: null,
+          geoIso: null,
+        }),
+      ).toEqual({ code: "sa", source: "url" });
+    });
+  });
+
+  describe("cookie validation is case-sensitive (matches existing getIntentCountry)", () => {
+    it("accepts lowercase intent codes", () => {
+      expect(
+        resolveCountryFromContext({ urlParam: null, cookie: "hk", geoIso: null }),
+      ).toEqual({ code: "hk", source: "cookie" });
+    });
+
+    it("rejects uppercase variants — would otherwise re-introduce a normalisation surface", () => {
+      expect(
+        resolveCountryFromContext({ urlParam: null, cookie: "HK", geoIso: null }),
+      ).toEqual({ code: null, source: null });
+    });
+  });
+
+  describe("geo ISO is case-insensitive (Vercel returns uppercase but accept either)", () => {
+    it("accepts uppercase", () => {
+      expect(
+        resolveCountryFromContext({ urlParam: null, cookie: null, geoIso: "GB" }),
+      ).toEqual({ code: "uk", source: "geo" });
+    });
+
+    it("accepts lowercase", () => {
+      expect(
+        resolveCountryFromContext({ urlParam: null, cookie: null, geoIso: "gb" }),
+      ).toEqual({ code: "uk", source: "geo" });
+    });
+
+    it("accepts mixed case", () => {
+      expect(
+        resolveCountryFromContext({ urlParam: null, cookie: null, geoIso: "Gb" }),
+      ).toEqual({ code: "uk", source: "geo" });
+    });
+  });
+});

--- a/__tests__/lib/country-mode/supply-thresholds.test.ts
+++ b/__tests__/lib/country-mode/supply-thresholds.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import {
+  applySupplyThresholds,
+  SUPPLY_THRESHOLDS,
+} from "@/lib/country-mode";
+
+describe("SUPPLY_THRESHOLDS", () => {
+  it("matches the committed Phase 1 values", () => {
+    expect(SUPPLY_THRESHOLDS.listings).toBe(2);
+    expect(SUPPLY_THRESHOLDS.experts).toBe(2);
+    expect(SUPPLY_THRESHOLDS.platforms).toBe(3);
+  });
+});
+
+describe("applySupplyThresholds", () => {
+  it("returns rows unchanged when at or above the listings threshold", () => {
+    const exactlyAtThreshold = ["a", "b"]; // listings = 2
+    expect(applySupplyThresholds(exactlyAtThreshold, "listings")).toEqual({
+      rows: exactlyAtThreshold,
+      didFallback: false,
+    });
+
+    const aboveThreshold = ["a", "b", "c", "d"];
+    expect(applySupplyThresholds(aboveThreshold, "listings")).toEqual({
+      rows: aboveThreshold,
+      didFallback: false,
+    });
+  });
+
+  it("falls back when below listings threshold", () => {
+    expect(applySupplyThresholds(["solo"], "listings")).toEqual({
+      rows: [],
+      didFallback: true,
+    });
+    expect(applySupplyThresholds([], "listings")).toEqual({
+      rows: [],
+      didFallback: true,
+    });
+  });
+
+  it("uses experts threshold (2)", () => {
+    expect(applySupplyThresholds(["a"], "experts")).toEqual({
+      rows: [],
+      didFallback: true,
+    });
+    expect(applySupplyThresholds(["a", "b"], "experts")).toEqual({
+      rows: ["a", "b"],
+      didFallback: false,
+    });
+  });
+
+  it("uses platforms threshold (3) — stricter than listings/experts", () => {
+    // 2 platforms is below threshold even though 2 listings/experts pass
+    expect(applySupplyThresholds(["a", "b"], "platforms")).toEqual({
+      rows: [],
+      didFallback: true,
+    });
+    expect(applySupplyThresholds(["a", "b", "c"], "platforms")).toEqual({
+      rows: ["a", "b", "c"],
+      didFallback: false,
+    });
+  });
+
+  it("preserves row identity when above threshold (referential, not a copy)", () => {
+    const rows = [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }];
+    const result = applySupplyThresholds(rows, "platforms");
+    expect(result.didFallback).toBe(false);
+    expect(result.rows).toBe(rows);
+  });
+
+  it("never returns a partial slice — show all or none", () => {
+    // The rule: a near-miss country must not be ambiguously presented as
+    // a curated set. Either we have enough, or we hide the strip.
+    const oneShyOfPlatforms = ["a", "b"];
+    const result = applySupplyThresholds(oneShyOfPlatforms, "platforms");
+    expect(result.rows).toEqual([]);
+    expect(result.didFallback).toBe(true);
+  });
+});

--- a/__tests__/lib/intent-context.test.ts
+++ b/__tests__/lib/intent-context.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from "vitest";
+import {
+  INTENT_COUNTRY_CODES,
+  intentCountryMeta,
+  intentCountryFromSlug,
+  intentCountryFromQuizKey,
+  intentCountryFromIso,
+  quizKeyForIntentCode,
+  isoForIntentCode,
+  isKnownIntentCountry,
+  type IntentCountryCode,
+} from "@/lib/intent-context";
+
+describe("INTENT_COUNTRY_CODES", () => {
+  it("covers the 12 supported countries", () => {
+    expect(INTENT_COUNTRY_CODES).toHaveLength(12);
+    expect([...INTENT_COUNTRY_CODES].sort()).toEqual(
+      ["ae", "cn", "hk", "in", "jp", "kr", "my", "nz", "sa", "sg", "uk", "us"],
+    );
+  });
+});
+
+describe("intentCountryMeta", () => {
+  it.each(INTENT_COUNTRY_CODES)("%s has all required fields populated", (code) => {
+    const meta = intentCountryMeta(code);
+    expect(meta.slug).toBeTruthy();
+    expect(meta.label).toBeTruthy();
+    expect(meta.flag).toBeTruthy();
+    expect(meta.currency).toMatch(/^[A-Z]{3}$/);
+    expect(meta.quizKey).toBeTruthy();
+    expect(meta.iso).toMatch(/^[A-Z]{2}$/);
+    expect(typeof meta.hasDta).toBe("boolean");
+  });
+
+  it("uk maps to GB ISO (UK is reserved, not official alpha-2)", () => {
+    expect(intentCountryMeta("uk").iso).toBe("GB");
+  });
+
+  it("us maps to USA quiz key (not 'us')", () => {
+    expect(intentCountryMeta("us").quizKey).toBe("usa");
+  });
+});
+
+describe("isKnownIntentCountry", () => {
+  it("accepts every supported code", () => {
+    INTENT_COUNTRY_CODES.forEach((code) => {
+      expect(isKnownIntentCountry(code)).toBe(true);
+    });
+  });
+
+  it("rejects unsupported codes and arbitrary strings", () => {
+    expect(isKnownIntentCountry("de")).toBe(false);
+    expect(isKnownIntentCountry("UK")).toBe(false); // case-sensitive intent code
+    expect(isKnownIntentCountry("")).toBe(false);
+  });
+});
+
+describe("intentCountryFromSlug", () => {
+  it("maps every meta.slug back to its code", () => {
+    INTENT_COUNTRY_CODES.forEach((code) => {
+      const meta = intentCountryMeta(code);
+      expect(intentCountryFromSlug(meta.slug)).toBe(code);
+    });
+  });
+
+  it("returns null for unknown / empty / nullish slugs", () => {
+    expect(intentCountryFromSlug("germany")).toBeNull();
+    expect(intentCountryFromSlug("")).toBeNull();
+    expect(intentCountryFromSlug(null)).toBeNull();
+    expect(intentCountryFromSlug(undefined)).toBeNull();
+  });
+});
+
+describe("intentCountryFromQuizKey", () => {
+  it("maps every meta.quizKey back to its code", () => {
+    INTENT_COUNTRY_CODES.forEach((code) => {
+      const meta = intentCountryMeta(code);
+      expect(intentCountryFromQuizKey(meta.quizKey)).toBe(code);
+    });
+  });
+
+  it("handles the divergent us → usa mapping", () => {
+    expect(intentCountryFromQuizKey("usa")).toBe("us");
+    expect(intentCountryFromQuizKey("us")).toBeNull();
+  });
+
+  it("handles the snake_case quiz keys", () => {
+    expect(intentCountryFromQuizKey("hong_kong")).toBe("hk");
+    expect(intentCountryFromQuizKey("south_korea")).toBe("kr");
+    expect(intentCountryFromQuizKey("saudi_arabia")).toBe("sa");
+    expect(intentCountryFromQuizKey("new_zealand")).toBe("nz");
+    expect(intentCountryFromQuizKey("uae")).toBe("ae");
+  });
+
+  it("returns null for the 'other' option and unknown / nullish keys", () => {
+    expect(intentCountryFromQuizKey("other")).toBeNull();
+    expect(intentCountryFromQuizKey("germany")).toBeNull();
+    expect(intentCountryFromQuizKey("")).toBeNull();
+    expect(intentCountryFromQuizKey(null)).toBeNull();
+    expect(intentCountryFromQuizKey(undefined)).toBeNull();
+  });
+});
+
+describe("intentCountryFromIso", () => {
+  it("maps every meta.iso back to its code", () => {
+    INTENT_COUNTRY_CODES.forEach((code) => {
+      const meta = intentCountryMeta(code);
+      expect(intentCountryFromIso(meta.iso)).toBe(code);
+    });
+  });
+
+  it("is case-insensitive (Vercel returns uppercase, but accept both)", () => {
+    expect(intentCountryFromIso("gb")).toBe("uk");
+    expect(intentCountryFromIso("GB")).toBe("uk");
+    expect(intentCountryFromIso("Gb")).toBe("uk");
+  });
+
+  it("returns null for unsupported ISO codes (travellers, VPNs)", () => {
+    expect(intentCountryFromIso("DE")).toBeNull();
+    expect(intentCountryFromIso("FR")).toBeNull();
+    expect(intentCountryFromIso("BR")).toBeNull();
+  });
+
+  it("returns null for empty / nullish input", () => {
+    expect(intentCountryFromIso("")).toBeNull();
+    expect(intentCountryFromIso(null)).toBeNull();
+    expect(intentCountryFromIso(undefined)).toBeNull();
+  });
+});
+
+describe("quizKeyForIntentCode / isoForIntentCode round-trips", () => {
+  it.each(INTENT_COUNTRY_CODES)("%s round-trips through quizKey", (code) => {
+    expect(intentCountryFromQuizKey(quizKeyForIntentCode(code))).toBe(code);
+  });
+
+  it.each(INTENT_COUNTRY_CODES)("%s round-trips through iso", (code) => {
+    expect(intentCountryFromIso(isoForIntentCode(code))).toBe(code);
+  });
+
+  it.each(INTENT_COUNTRY_CODES)("%s round-trips through slug", (code) => {
+    expect(intentCountryFromSlug(intentCountryMeta(code).slug)).toBe(code);
+  });
+});
+
+describe("uniqueness of indexed fields", () => {
+  it("every slug, quizKey and iso is unique across the 12 countries", () => {
+    const slugs = new Set<string>();
+    const quizKeys = new Set<string>();
+    const isos = new Set<string>();
+    INTENT_COUNTRY_CODES.forEach((code: IntentCountryCode) => {
+      const meta = intentCountryMeta(code);
+      slugs.add(meta.slug);
+      quizKeys.add(meta.quizKey);
+      isos.add(meta.iso);
+    });
+    expect(slugs.size).toBe(12);
+    expect(quizKeys.size).toBe(12);
+    expect(isos.size).toBe(12);
+  });
+});

--- a/__tests__/lib/intent-context.test.ts
+++ b/__tests__/lib/intent-context.test.ts
@@ -24,12 +24,20 @@ describe("intentCountryMeta", () => {
   it.each(INTENT_COUNTRY_CODES)("%s has all required fields populated", (code) => {
     const meta = intentCountryMeta(code);
     expect(meta.slug).toBeTruthy();
+    expect(meta.name).toBeTruthy();
     expect(meta.label).toBeTruthy();
     expect(meta.flag).toBeTruthy();
     expect(meta.currency).toMatch(/^[A-Z]{3}$/);
     expect(meta.quizKey).toBeTruthy();
     expect(meta.iso).toMatch(/^[A-Z]{2}$/);
     expect(typeof meta.hasDta).toBe("boolean");
+  });
+
+  it("name is a place name (not the 'investors' label)", () => {
+    expect(intentCountryMeta("uk").name).toBe("the UK");
+    expect(intentCountryMeta("hk").name).toBe("Hong Kong");
+    expect(intentCountryMeta("sa").name).toBe("Saudi Arabia");
+    expect(intentCountryMeta("uk").name).not.toBe(intentCountryMeta("uk").label);
   });
 
   it("uk maps to GB ISO (UK is reserved, not official alpha-2)", () => {

--- a/__tests__/lib/intent-context.test.ts
+++ b/__tests__/lib/intent-context.test.ts
@@ -53,6 +53,16 @@ describe("isKnownIntentCountry", () => {
     expect(isKnownIntentCountry("UK")).toBe(false); // case-sensitive intent code
     expect(isKnownIntentCountry("")).toBe(false);
   });
+
+  it("rejects prototype-chain keys (hasOwnProperty hardening)", () => {
+    // Without hasOwnProperty.call, `value in KNOWN` walks the prototype
+    // chain and would accept these. Each one would then either crash a
+    // downstream consumer or write a garbage cookie value.
+    expect(isKnownIntentCountry("__proto__")).toBe(false);
+    expect(isKnownIntentCountry("toString")).toBe(false);
+    expect(isKnownIntentCountry("hasOwnProperty")).toBe(false);
+    expect(isKnownIntentCountry("constructor")).toBe(false);
+  });
 });
 
 describe("intentCountryFromSlug", () => {

--- a/app/foreign-investment/from/[country]/page.tsx
+++ b/app/foreign-investment/from/[country]/page.tsx
@@ -1,10 +1,11 @@
 import Link from "next/link";
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import type { Metadata } from "next";
 import { createClient } from "@/lib/supabase/server";
 import { breadcrumbJsonLd, SITE_URL } from "@/lib/seo";
 import { FOREIGN_INVESTOR_GENERAL_DISCLAIMER, DTA_DISCLAIMER } from "@/lib/compliance";
 import { DTA_COUNTRIES, DEFAULT_WHT, type DTACountry } from "@/lib/foreign-investment-data";
+import { intentCountryFromIso, intentCountryMeta } from "@/lib/intent-context";
 import type { Broker } from "@/lib/types";
 import ForeignInvestmentNav from "../../ForeignInvestmentNav";
 import SectionHeading from "@/components/SectionHeading";
@@ -83,6 +84,17 @@ export default async function CountryForeignInvestmentPage({
   params: Promise<{ country: string }>;
 }) {
   const { country } = await params;
+
+  // Country Mode redirect: the 12 supported countries have richer
+  // /foreign-investment/<slug> hubs than this tax-only template. Funnel
+  // those visitors (and their inbound link equity) to the canonical
+  // surface. The other ~32 DTA-only corridors (Brazil, Czech Republic,
+  // etc.) keep this page as their dedicated tax overview.
+  const intentCode = intentCountryFromIso(country);
+  if (intentCode) {
+    redirect(`/foreign-investment/${intentCountryMeta(intentCode).slug}`);
+  }
+
   const dtaCountry = getCountryBySlug(country);
   if (!dtaCountry) notFound();
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import { JetBrains_Mono, Source_Serif_4 } from "next/font/google";
 import { Suspense } from "react";
 import "./globals.css";
 import LayoutShell from "@/components/LayoutShell";
+import CountryModeBanner from "@/components/country-mode/CountryModeBanner";
 import { ThemeProvider } from "@/components/ThemeProvider";
 import GoogleAnalytics from "@/components/GoogleAnalytics";
 import { PostHogProvider } from "@/components/PostHogProvider";
@@ -159,7 +160,7 @@ export default async function RootLayout({
         <Suspense fallback={null}><ClaimAnonymousOnAuth /></Suspense>
 
         <ThemeProvider>
-          <LayoutShell>{children}</LayoutShell>
+          <LayoutShell countryModeBanner={<CountryModeBanner />}>{children}</LayoutShell>
           {chatEnabled && <ChatWidget />}
           {reportButtonEnabled && <ReportProblemButton />}
           {pushEnabled && <Suspense fallback={null}><PushNotificationOptIn /></Suspense>}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,7 +2,7 @@ import { createClient } from "@/lib/supabase/server";
 import type { Broker } from "@/lib/types";
 import HomeHero from "@/components/HomeHero";
 import HomeRouteCards from "@/components/HomeRouteCards";
-import HomeToolsStrip from "@/components/HomeToolsStrip";
+import CountryToolsStripWrapper from "@/components/country-mode/CountryToolsStripWrapper";
 import HomePathfinder from "@/components/HomePathfinder";
 import HomeListingsTeaser, { type HomeListing } from "@/components/HomeListingsTeaser";
 import HomeAdvisorsTeaser, { type HomeAdvisor } from "@/components/HomeAdvisorsTeaser";
@@ -256,7 +256,7 @@ export default async function HomePage() {
       </ScrollFadeIn>
 
       <ScrollFadeIn>
-        <HomeToolsStrip />
+        <CountryToolsStripWrapper />
       </ScrollFadeIn>
 
       <CountryPopularLinks />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,6 +14,7 @@ import HomeHowWeEarn from "@/components/HomeHowWeEarn";
 import CountryListingsPreview from "@/components/country-mode/CountryListingsPreview";
 import CountryExpertsPreview from "@/components/country-mode/CountryExpertsPreview";
 import CountryComparePreview from "@/components/country-mode/CountryComparePreview";
+import CountryPopularLinks from "@/components/country-mode/CountryPopularLinks";
 import ScrollFadeIn from "@/components/ScrollFadeIn";
 import MobileBottomNav from "@/components/MobileBottomNav";
 import { ORGANIZATION_JSONLD, SITE_URL } from "@/lib/seo";
@@ -257,6 +258,8 @@ export default async function HomePage() {
       <ScrollFadeIn>
         <HomeToolsStrip />
       </ScrollFadeIn>
+
+      <CountryPopularLinks />
 
       <ScrollFadeIn>
         <HomePathfinder />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,6 +11,9 @@ import HomeCompareDeepDive, { type CompareBroker } from "@/components/HomeCompar
 import HomeCrossBorder from "@/components/HomeCrossBorder";
 import HomeFridayBriefing from "@/components/HomeFridayBriefing";
 import HomeHowWeEarn from "@/components/HomeHowWeEarn";
+import CountryListingsPreview from "@/components/country-mode/CountryListingsPreview";
+import CountryExpertsPreview from "@/components/country-mode/CountryExpertsPreview";
+import CountryComparePreview from "@/components/country-mode/CountryComparePreview";
 import ScrollFadeIn from "@/components/ScrollFadeIn";
 import MobileBottomNav from "@/components/MobileBottomNav";
 import { ORGANIZATION_JSONLD, SITE_URL } from "@/lib/seo";
@@ -259,13 +262,25 @@ export default async function HomePage() {
         <HomePathfinder />
       </ScrollFadeIn>
 
+      {/* Country Mode preview wrappers — read iv_intent_country cookie in
+      their own subtree so the rest of the homepage stays ISR-cacheable.
+      Each renders nothing when no country selected, when the country has
+      no homepage* filters configured, or when the filtered slice falls
+      below the supply threshold. The global teasers below carry the
+      experience in those cases. See docs/architecture/country-mode.md. */}
+      <CountryComparePreview />
+
       <ScrollFadeIn>
         <HomeCompareDeepDive brokers={compareBrokers} />
       </ScrollFadeIn>
 
+      <CountryListingsPreview />
+
       <ScrollFadeIn>
         <HomeListingsTeaser listings={listingList} totalCount={totalListingCount} />
       </ScrollFadeIn>
+
+      <CountryExpertsPreview />
 
       <ScrollFadeIn>
         <HomeAdvisorsTeaser advisors={advisorList} totalCount={totalProfessionalCount} />

--- a/app/quiz/page.tsx
+++ b/app/quiz/page.tsx
@@ -7,6 +7,7 @@ import { trackEvent as phTrack } from "@/lib/posthog/events";
 import { storeQualificationData } from "@/lib/qualification-store";
 import { getPlacementWinners, type PlacementWinner } from "@/lib/sponsorship";
 import { scoreQuizResults, type WeightKey, type QuizWeights, type AmountKey } from "@/lib/quiz-scoring";
+import { intentCountryFromSlug, quizKeyForIntentCode } from "@/lib/intent-context";
 
 import QuizQuestionScreen from "./_components/QuizQuestionScreen";
 import QuizAnalyzingScreen from "./_components/QuizAnalyzingScreen";
@@ -60,16 +61,19 @@ const UNIFIED_QUESTIONS: Record<QuestionId, { text: string; options: { key: stri
   investor_country: {
     text: "Which country are you based in?",
     options: [
-      { key: "singapore",    label: "Singapore",     emoji: "🇸🇬" },
-      { key: "hong_kong",    label: "Hong Kong",     emoji: "🇭🇰" },
-      { key: "china",        label: "China",         emoji: "🇨🇳" },
-      { key: "india",        label: "India",         emoji: "🇮🇳" },
-      { key: "uae",          label: "UAE / Middle East", emoji: "🇦🇪" },
-      { key: "uk",           label: "United Kingdom", emoji: "🇬🇧" },
-      { key: "usa",          label: "United States", emoji: "🇺🇸" },
-      { key: "malaysia",     label: "Malaysia",      emoji: "🇲🇾" },
-      { key: "new_zealand",  label: "New Zealand",   emoji: "🇳🇿" },
-      { key: "other",        label: "Other country", emoji: "🌍" },
+      { key: "singapore",     label: "Singapore",     emoji: "🇸🇬" },
+      { key: "hong_kong",     label: "Hong Kong",     emoji: "🇭🇰" },
+      { key: "china",         label: "China",         emoji: "🇨🇳" },
+      { key: "india",         label: "India",         emoji: "🇮🇳" },
+      { key: "uae",           label: "UAE / Middle East", emoji: "🇦🇪" },
+      { key: "uk",            label: "United Kingdom", emoji: "🇬🇧" },
+      { key: "usa",           label: "United States", emoji: "🇺🇸" },
+      { key: "malaysia",      label: "Malaysia",      emoji: "🇲🇾" },
+      { key: "new_zealand",   label: "New Zealand",   emoji: "🇳🇿" },
+      { key: "japan",         label: "Japan",         emoji: "🇯🇵" },
+      { key: "south_korea",   label: "South Korea",   emoji: "🇰🇷" },
+      { key: "saudi_arabia",  label: "Saudi Arabia",  emoji: "🇸🇦" },
+      { key: "other",         label: "Other country", emoji: "🌍" },
     ],
   },
   visa_status: {
@@ -434,6 +438,39 @@ export default function QuizPage() {
       setResumeQuestionNumber(saved.history.length + 1);
       setResumeTotalQuestions(getTotalSteps(saved.answers));
     }
+  }, []);
+
+  // Country Mode URL prefill — soft default only, never skips Q1.
+  // Country pages and the popular-links strip link to /quiz?country=<slug>
+  // (and optionally &intent=<key>). We pre-seed investor_country and
+  // investor_goal_intl so the user doesn't have to re-enter them after
+  // confirming the location question. We do NOT pre-set `location` —
+  // an HK-resident, an HK passport-holder living in AU, and an Aussie
+  // expat in HK all might land here, and Q1 is the only signal that
+  // distinguishes them. Prefill is a hint, not a bypass. Per user
+  // decision #6 in the v2 plan.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const params = new URLSearchParams(window.location.search);
+    const countryParam = params.get("country");
+    const intentParam = params.get("intent");
+    if (!countryParam && !intentParam) return;
+
+    const seed: Partial<UnifiedAnswers> = {};
+    if (countryParam) {
+      const code = intentCountryFromSlug(countryParam);
+      if (code) seed.investor_country = quizKeyForIntentCode(code);
+    }
+    if (intentParam) {
+      const validIntents = ["property", "shares", "savings", "business"];
+      if (validIntents.includes(intentParam)) {
+        seed.investor_goal_intl = intentParam;
+      }
+    }
+
+    // Only seed when answers are still empty — don't override saved
+    // progress or in-flight user input.
+    setAnswers((prev) => (Object.keys(prev).length === 0 ? { ...prev, ...seed } : prev));
   }, []);
 
   useEffect(() => {

--- a/app/quiz/page.tsx
+++ b/app/quiz/page.tsx
@@ -538,8 +538,8 @@ export default function QuizPage() {
   // Track completion + persist results
   useEffect(() => {
     if ((phase === "diy-results" || phase === "advisor-results") && brokers.length > 0) {
-      trackEvent('quiz_complete', { answers: scoringAnswers, top_broker: results[0]?.slug || null }, '/quiz');
-      trackEvent('quiz_completed', { top_match: results[0]?.slug || null }, '/quiz');
+      trackEvent('quiz_complete', { answers: scoringAnswers, top_broker: results[0]?.slug || null, country: answers.investor_country ?? null }, '/quiz');
+      trackEvent('quiz_completed', { top_match: results[0]?.slug || null, country: answers.investor_country ?? null }, '/quiz');
       phTrack('quiz_completed', {
         quiz_type: phase === 'advisor-results' ? 'advisor_match' : 'diy_broker',
         time_taken_seconds: quizStartedAtRef.current
@@ -550,6 +550,7 @@ export default function QuizPage() {
         risk_profile: answers.experience ?? null,
         top_match_slug: results[0]?.slug ?? null,
         match_count: results.length,
+        country: answers.investor_country ?? null,
       });
       try {
         const topResults = results.slice(0, 5).filter(r => r.broker).map(r => ({

--- a/components/HomeCrossBorder.tsx
+++ b/components/HomeCrossBorder.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { DesignIcon } from "@/components/design/DesignIcon";
 import { FlagChip } from "@/components/design/Atoms";
+import { getIntentCountry, isoForIntentCode } from "@/lib/intent-context";
 
 // Cards on the homepage section serve audience A (inbound migrants — largest
 // absolute LTV). The other three cross-border audiences (US-AU dual citizens,
@@ -39,7 +40,32 @@ const ARRIVALS: ReadonlyArray<{
   },
 ];
 
-export default function HomeCrossBorder() {
+/**
+ * Hoist the matching arrival card to position 1 when the user is in
+ * country mode. Copy stays unchanged, no fifth card — just a small
+ * "we noticed you're from here" affordance. Falls through silently for
+ * countries not in the 4-card set (HK, SG, NZ, JP, KR, MY, AE, SA),
+ * preserving the FIN_NOTEBOOK 2026-05-01 stance against broadening
+ * the cross-border framing.
+ */
+function reorderForPriority(
+  arrivals: ReadonlyArray<(typeof ARRIVALS)[number]>,
+  priorityIso: string | null,
+): ReadonlyArray<(typeof ARRIVALS)[number]> {
+  if (!priorityIso) return arrivals;
+  const idx = arrivals.findIndex((a) => a.code === priorityIso);
+  if (idx <= 0) return arrivals; // not found, or already first
+  return [arrivals[idx]!, ...arrivals.slice(0, idx), ...arrivals.slice(idx + 1)];
+}
+
+export default async function HomeCrossBorder() {
+  const code = await getIntentCountry();
+  const priorityIso = code ? isoForIntentCode(code) : null;
+  const ordered = reorderForPriority(ARRIVALS, priorityIso);
+  return <HomeCrossBorderInner arrivals={ordered} />;
+}
+
+function HomeCrossBorderInner({ arrivals }: { arrivals: ReadonlyArray<(typeof ARRIVALS)[number]> }) {
   return (
     <section style={{ padding: "56px 36px 60px", maxWidth: 1280, margin: "0 auto" }}>
       <div style={{ marginBottom: 24, maxWidth: 720 }}>
@@ -74,7 +100,7 @@ export default function HomeCrossBorder() {
       </div>
 
       <div className="home-crossborder-grid" style={{ display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: 12 }}>
-        {ARRIVALS.map((p) => (
+        {arrivals.map((p) => (
           <Link
             key={p.code}
             href={p.href}

--- a/components/HomeCrossBorder.tsx
+++ b/components/HomeCrossBorder.tsx
@@ -1,7 +1,8 @@
 import Link from "next/link";
 import { DesignIcon } from "@/components/design/DesignIcon";
 import { FlagChip } from "@/components/design/Atoms";
-import { getIntentCountry, isoForIntentCode } from "@/lib/intent-context";
+import { isoForIntentCode } from "@/lib/intent-context";
+import { getIntentCountry } from "@/lib/intent-context-server";
 
 // Cards on the homepage section serve audience A (inbound migrants — largest
 // absolute LTV). The other three cross-border audiences (US-AU dual citizens,

--- a/components/HomePathfinder.tsx
+++ b/components/HomePathfinder.tsx
@@ -1,11 +1,26 @@
 import Link from "next/link";
 import { DesignIcon } from "@/components/design/DesignIcon";
+import {
+  getIntentCountry,
+  intentCountryMeta,
+} from "@/lib/intent-context";
 
 // Pathfinder section — secondary affordance for visitors who don't know
 // which route to pick. Per v5 spec the quiz lives BELOW the route cards
 // (not as the dominant hero card), so it helps users who are unsure
 // without overwhelming everyone else.
-export default function HomePathfinder() {
+//
+// When the user is in country mode, the Get-matched CTA carries the
+// country slug forward as ?country=<slug> so the quiz prefills the
+// international track (Step 12 wires the prefill itself). Copy stays
+// global — adding "for HK investors" here would clash with the
+// CountryPopularLinks strip directly above which already calls that
+// out explicitly.
+export default async function HomePathfinder() {
+  const code = await getIntentCountry();
+  const quizHref = code
+    ? `/quiz?country=${intentCountryMeta(code).slug}`
+    : "/quiz";
   return (
     <section style={{ padding: "40px 36px", maxWidth: 1280, margin: "0 auto" }}>
       <div
@@ -87,7 +102,7 @@ export default function HomePathfinder() {
             </li>
           </ul>
           <Link
-            href="/quiz"
+            href={quizHref}
             className="iv2-cta"
             style={{ fontSize: 14, padding: "12px 22px", borderRadius: 11 }}
           >

--- a/components/HomePathfinder.tsx
+++ b/components/HomePathfinder.tsx
@@ -1,9 +1,7 @@
 import Link from "next/link";
 import { DesignIcon } from "@/components/design/DesignIcon";
-import {
-  getIntentCountry,
-  intentCountryMeta,
-} from "@/lib/intent-context";
+import { intentCountryMeta } from "@/lib/intent-context";
+import { getIntentCountry } from "@/lib/intent-context-server";
 
 // Pathfinder section — secondary affordance for visitors who don't know
 // which route to pick. Per v5 spec the quiz lives BELOW the route cards

--- a/components/HomeToolsStrip.tsx
+++ b/components/HomeToolsStrip.tsx
@@ -59,7 +59,33 @@ const FEATURED_TOOLS: ReadonlyArray<ToolEntry> = [
   },
 ];
 
-export default function HomeToolsStrip() {
+interface HomeToolsStripProps {
+  /**
+   * Optional list of tool hrefs to hoist to the front of the strip.
+   * Order within the list is preserved; tools not in the list stay
+   * in their original order behind the hoisted ones. The strip never
+   * shrinks — Country Mode re-ranks, doesn't replace.
+   */
+  featuredHrefs?: ReadonlyArray<string>;
+}
+
+function reorderForFeatured(
+  tools: ReadonlyArray<ToolEntry>,
+  featuredHrefs: ReadonlyArray<string> | undefined,
+): ReadonlyArray<ToolEntry> {
+  if (!featuredHrefs || featuredHrefs.length === 0) return tools;
+  const featuredSet = new Set(featuredHrefs);
+  // Preserve the order in `featuredHrefs` for hoisted tools, then
+  // append the remaining tools in their original order.
+  const hoisted = featuredHrefs
+    .map((href) => tools.find((t) => t.href === href))
+    .filter((t): t is ToolEntry => Boolean(t));
+  const rest = tools.filter((t) => !featuredSet.has(t.href));
+  return [...hoisted, ...rest];
+}
+
+export default function HomeToolsStrip({ featuredHrefs }: HomeToolsStripProps = {}) {
+  const orderedTools = reorderForFeatured(FEATURED_TOOLS, featuredHrefs);
   return (
     <section
       style={{
@@ -126,7 +152,7 @@ export default function HomeToolsStrip() {
           gap: 10,
         }}
       >
-        {FEATURED_TOOLS.map((t) => (
+        {orderedTools.map((t) => (
           <Link
             key={t.href}
             href={t.href}

--- a/components/LayoutShell.tsx
+++ b/components/LayoutShell.tsx
@@ -24,9 +24,24 @@ const QuizPromptBar = dynamic(() => import("@/components/QuizPromptBar"), { ssr:
 const ExitIntentPopup = dynamic(() => import("@/components/ExitIntentPopup"), { ssr: false });
 const StickyAdFooter = dynamic(() => import("@/components/StickyAdFooter"), { ssr: false });
 const TrackingPixels = dynamic(() => import("@/components/TrackingPixels"), { ssr: false });
+// Country Mode soft prompt — CSR-only (reads /api/geo + localStorage),
+// renders only when the user has no preference and GeoIP detects a
+// supported corridor. See docs/architecture/country-mode.md.
+const GeoSoftPrompt = dynamic(() => import("@/components/country-mode/GeoSoftPrompt"), { ssr: false });
 
+interface LayoutShellProps {
+  children: React.ReactNode;
+  /**
+   * Country Mode persistent banner — server-rendered in app/layout.tsx
+   * (so it reads the iv_intent_country cookie on the request) and
+   * passed through as a slot. We can't import the server component
+   * directly in this client wrapper; the slot pattern keeps cookie
+   * reads on the server while letting LayoutShell stay client.
+   */
+  countryModeBanner?: React.ReactNode;
+}
 
-export default function LayoutShell({ children }: { children: React.ReactNode }) {
+export default function LayoutShell({ children, countryModeBanner }: LayoutShellProps) {
   const pathname = usePathname();
   const isAdmin = pathname.startsWith("/admin");
 
@@ -44,6 +59,7 @@ export default function LayoutShell({ children }: { children: React.ReactNode })
       </a>
 
       <Navigation />
+      {countryModeBanner}
       <main id="main-content" className="min-h-screen pb-14 sm:pb-0">{children}</main>
       <SiteFooter />
       <CookieBanner />
@@ -52,6 +68,7 @@ export default function LayoutShell({ children }: { children: React.ReactNode })
       <ExitIntentPopup />
       <StickyAdFooter />
       <TrackingPixels />
+      <GeoSoftPrompt />
     </>
   );
 }

--- a/components/country-mode/CountryComparePreview.tsx
+++ b/components/country-mode/CountryComparePreview.tsx
@@ -1,0 +1,141 @@
+/**
+ * Country Mode compare preview — "platforms for <country> investors"
+ * strip mounted ABOVE the global HomeCompareDeepDive.
+ *
+ * Server component. Filters the brokers feed by platform_type and
+ * (when set) accepts_non_residents. Returns null below the platforms
+ * supply threshold (3 — stricter than listings/experts because a
+ * "compare" strip with fewer than 3 options has nothing to compare).
+ */
+
+import Link from "next/link";
+import Image from "next/image";
+import {
+  getIntentCountry,
+  intentCountryMeta,
+} from "@/lib/intent-context";
+import {
+  applySupplyThresholds,
+  getHomepageFiltersForCountry,
+} from "@/lib/country-mode";
+import { createClient } from "@/lib/supabase/server";
+import type { PlatformType } from "@/lib/types";
+
+interface PreviewBroker {
+  id: number;
+  slug: string;
+  name: string;
+  platform_type: PlatformType | null;
+  logo_url: string | null;
+  rating: number | null;
+  asx_fee: string | null;
+  accepts_non_residents: boolean | null;
+}
+
+export default async function CountryComparePreview() {
+  const code = await getIntentCountry();
+  if (!code) return null;
+
+  const filters = getHomepageFiltersForCountry(code);
+  if (!filters.platforms || filters.platforms.types.length === 0) return null;
+
+  const supabase = await createClient();
+  let query = supabase
+    .from("brokers")
+    .select(
+      "id, slug, name, platform_type, logo_url, rating, asx_fee, accepts_non_residents",
+    )
+    .eq("status", "active")
+    .in("platform_type", [...filters.platforms.types])
+    .order("rating", { ascending: false });
+
+  if (filters.platforms.nonResidentsOnly) {
+    query = query.eq("accepts_non_residents", true);
+  }
+
+  const { data } = await query.limit(6);
+
+  const rows: PreviewBroker[] = (data ?? []) as PreviewBroker[];
+
+  const result = applySupplyThresholds(rows, "platforms");
+  if (result.didFallback) return null;
+
+  const meta = intentCountryMeta(code);
+  const visible = result.rows.slice(0, 4);
+
+  return (
+    <section
+      aria-label={`Platforms tailored for ${meta.label}`}
+      className="bg-white border-y border-amber-100"
+    >
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 py-6">
+        <div className="flex items-end justify-between mb-4 gap-4 flex-wrap">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wider text-amber-700">
+              <span aria-hidden className="mr-1.5">{meta.flag}</span>
+              Tailored for {meta.label}
+            </p>
+            <h2 className="text-lg sm:text-xl font-semibold text-slate-900 mt-1">
+              {filters.platforms.nonResidentsOnly
+                ? `Platforms that accept investors from ${meta.name}`
+                : `Platforms popular with investors from ${meta.name}`}
+            </h2>
+          </div>
+          <Link
+            href={
+              filters.platforms.nonResidentsOnly
+                ? "/compare/non-residents"
+                : "/compare"
+            }
+            className="text-sm font-medium text-amber-700 hover:text-amber-900 underline underline-offset-2"
+          >
+            Compare all &rarr;
+          </Link>
+        </div>
+        <ul className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+          {visible.map((b) => (
+            <li key={b.id}>
+              <Link
+                href={`/broker/${b.slug}`}
+                className="group block bg-slate-50 hover:bg-amber-50 border border-slate-200 hover:border-amber-200 rounded-xl p-3 transition-colors"
+              >
+                <div className="flex items-center gap-3">
+                  {b.logo_url ? (
+                    <div className="relative h-10 w-10 shrink-0 rounded-lg overflow-hidden bg-white border border-slate-200">
+                      <Image
+                        src={b.logo_url}
+                        alt={b.name}
+                        fill
+                        sizes="40px"
+                        className="object-contain p-1"
+                      />
+                    </div>
+                  ) : (
+                    <div className="h-10 w-10 shrink-0 rounded-lg bg-slate-200 flex items-center justify-center text-sm font-bold text-slate-500">
+                      {b.name.charAt(0)}
+                    </div>
+                  )}
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm font-semibold text-slate-900 truncate group-hover:text-amber-900">
+                      {b.name}
+                    </p>
+                    {b.platform_type && (
+                      <p className="text-xs text-slate-500 capitalize truncate">
+                        {b.platform_type.replace(/_/g, " ")}
+                      </p>
+                    )}
+                  </div>
+                  {typeof b.rating === "number" && (
+                    <div className="text-xs font-semibold text-amber-700 shrink-0">
+                      ★ {b.rating.toFixed(1)}
+                    </div>
+                  )}
+                </div>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/components/country-mode/CountryComparePreview.tsx
+++ b/components/country-mode/CountryComparePreview.tsx
@@ -10,10 +10,8 @@
 
 import Link from "next/link";
 import Image from "next/image";
-import {
-  getIntentCountry,
-  intentCountryMeta,
-} from "@/lib/intent-context";
+import { intentCountryMeta } from "@/lib/intent-context";
+import { getIntentCountry } from "@/lib/intent-context-server";
 import {
   applySupplyThresholds,
   getHomepageFiltersForCountry,

--- a/components/country-mode/CountryExpertsPreview.tsx
+++ b/components/country-mode/CountryExpertsPreview.tsx
@@ -1,0 +1,130 @@
+/**
+ * Country Mode experts preview — "specialists for <country> investors"
+ * strip mounted ABOVE the global HomeAdvisorsTeaser.
+ *
+ * Server component reading the iv_intent_country cookie. Filters the
+ * professionals feed by `type` (the canonical advisor-type field —
+ * `specialties` is jsonb and less reliable for filtering). Returns null
+ * below the supply threshold so the global teaser carries the experience.
+ */
+
+import Link from "next/link";
+import Image from "next/image";
+import {
+  getIntentCountry,
+  intentCountryMeta,
+} from "@/lib/intent-context";
+import {
+  applySupplyThresholds,
+  getHomepageFiltersForCountry,
+} from "@/lib/country-mode";
+import { createClient } from "@/lib/supabase/server";
+
+interface PreviewExpert {
+  slug: string;
+  name: string;
+  firm_name: string | null;
+  type: string;
+  location_display: string | null;
+  photo_url: string | null;
+}
+
+export default async function CountryExpertsPreview() {
+  const code = await getIntentCountry();
+  if (!code) return null;
+
+  const filters = getHomepageFiltersForCountry(code);
+  if (!filters.experts || filters.experts.specialties.length === 0) return null;
+
+  const supabase = await createClient();
+  const { data } = await supabase
+    .from("professionals")
+    .select(
+      "slug, name, firm_name, type, location_display, photo_url, rating, review_count, verified",
+    )
+    .eq("status", "active")
+    .eq("verified", true)
+    .in("type", [...filters.experts.specialties])
+    .order("rating", { ascending: false })
+    .order("review_count", { ascending: false })
+    .limit(8);
+
+  const rows: PreviewExpert[] = (data ?? []).map((r) => ({
+    slug: r.slug,
+    name: r.name,
+    firm_name: r.firm_name,
+    type: r.type,
+    location_display: r.location_display,
+    photo_url: r.photo_url,
+  }));
+
+  const result = applySupplyThresholds(rows, "experts");
+  if (result.didFallback) return null;
+
+  const meta = intentCountryMeta(code);
+  const visible = result.rows.slice(0, 4);
+
+  return (
+    <section
+      aria-label={`Experts tailored for ${meta.label}`}
+      className="bg-white border-y border-amber-100"
+    >
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 py-6">
+        <div className="flex items-end justify-between mb-4 gap-4 flex-wrap">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wider text-amber-700">
+              <span aria-hidden className="mr-1.5">{meta.flag}</span>
+              Tailored for {meta.label}
+            </p>
+            <h2 className="text-lg sm:text-xl font-semibold text-slate-900 mt-1">
+              Specialists for investors from {meta.name}
+            </h2>
+          </div>
+          <Link
+            href="/advisors"
+            className="text-sm font-medium text-amber-700 hover:text-amber-900 underline underline-offset-2"
+          >
+            See all experts &rarr;
+          </Link>
+        </div>
+        <ul className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+          {visible.map((e) => (
+            <li key={e.slug}>
+              <Link
+                href={`/advisors/${e.slug}`}
+                className="group block bg-slate-50 hover:bg-amber-50 border border-slate-200 hover:border-amber-200 rounded-xl p-3 transition-colors"
+              >
+                <div className="flex items-start gap-3">
+                  {e.photo_url ? (
+                    <div className="relative h-12 w-12 shrink-0 rounded-full overflow-hidden bg-slate-100">
+                      <Image
+                        src={e.photo_url}
+                        alt={e.name}
+                        fill
+                        sizes="48px"
+                        className="object-cover"
+                      />
+                    </div>
+                  ) : (
+                    <div className="h-12 w-12 shrink-0 rounded-full bg-slate-200 flex items-center justify-center text-sm font-bold text-slate-500">
+                      {e.name.charAt(0)}
+                    </div>
+                  )}
+                  <div className="min-w-0">
+                    <p className="text-sm font-semibold text-slate-900 truncate group-hover:text-amber-900">
+                      {e.name}
+                    </p>
+                    <p className="text-xs text-slate-500 truncate">{e.type}</p>
+                    {e.firm_name && (
+                      <p className="text-xs text-slate-400 truncate mt-0.5">{e.firm_name}</p>
+                    )}
+                  </div>
+                </div>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/components/country-mode/CountryExpertsPreview.tsx
+++ b/components/country-mode/CountryExpertsPreview.tsx
@@ -10,10 +10,8 @@
 
 import Link from "next/link";
 import Image from "next/image";
-import {
-  getIntentCountry,
-  intentCountryMeta,
-} from "@/lib/intent-context";
+import { intentCountryMeta } from "@/lib/intent-context";
+import { getIntentCountry } from "@/lib/intent-context-server";
 import {
   applySupplyThresholds,
   getHomepageFiltersForCountry,

--- a/components/country-mode/CountryListingsPreview.tsx
+++ b/components/country-mode/CountryListingsPreview.tsx
@@ -15,10 +15,8 @@
 
 import Link from "next/link";
 import Image from "next/image";
-import {
-  getIntentCountry,
-  intentCountryMeta,
-} from "@/lib/intent-context";
+import { intentCountryMeta } from "@/lib/intent-context";
+import { getIntentCountry } from "@/lib/intent-context-server";
 import {
   applySupplyThresholds,
   getHomepageFiltersForCountry,

--- a/components/country-mode/CountryListingsPreview.tsx
+++ b/components/country-mode/CountryListingsPreview.tsx
@@ -1,0 +1,135 @@
+/**
+ * Country Mode listings preview — slim "often considered by <country>
+ * investors" strip mounted ABOVE the global HomeListingsTeaser.
+ *
+ * Server component reading the iv_intent_country cookie. When set, fetches
+ * a vertical-filtered slice of the listings feed using the country
+ * config's homepageListingFilters. Below the supply threshold, returns
+ * null so the global teaser carries the experience — never shows a
+ * thin/fake-supply preview.
+ *
+ * Reads the cookie in this child only; the parent app/page.tsx stays
+ * ISR-cacheable. Next.js opts this subtree into dynamic rendering when
+ * cookies() is called.
+ */
+
+import Link from "next/link";
+import Image from "next/image";
+import {
+  getIntentCountry,
+  intentCountryMeta,
+} from "@/lib/intent-context";
+import {
+  applySupplyThresholds,
+  getHomepageFiltersForCountry,
+} from "@/lib/country-mode";
+import { createClient } from "@/lib/supabase/server";
+
+interface PreviewListing {
+  id: number;
+  title: string;
+  slug: string;
+  vertical: string;
+  location_display: string | null;
+  price_display: string | null;
+  hero_image: string | null;
+}
+
+export default async function CountryListingsPreview() {
+  const code = await getIntentCountry();
+  if (!code) return null;
+
+  const filters = getHomepageFiltersForCountry(code);
+  if (!filters.listings || filters.listings.verticals.length === 0) return null;
+
+  const supabase = await createClient();
+  const verticalsArr = [...filters.listings.verticals];
+  const { data } = await supabase
+    .from("investment_listings")
+    .select("id, title, slug, vertical, location_state, location_city, price_display, images, listing_type")
+    .eq("status", "active")
+    .in("vertical", verticalsArr)
+    .order("listing_type", { ascending: false })
+    .order("created_at", { ascending: false })
+    .limit(6);
+
+  const rows: PreviewListing[] = (data ?? []).map((r) => ({
+    id: r.id,
+    title: r.title,
+    slug: r.slug,
+    vertical: r.vertical,
+    location_display:
+      [r.location_city, r.location_state].filter(Boolean).join(", ") || null,
+    price_display: r.price_display ?? null,
+    hero_image:
+      Array.isArray(r.images) && r.images.length > 0 ? (r.images[0] as string) : null,
+  }));
+
+  const result = applySupplyThresholds(rows, "listings");
+  if (result.didFallback) return null;
+
+  const meta = intentCountryMeta(code);
+  const visible = result.rows.slice(0, 4);
+
+  return (
+    <section
+      aria-label={`Listings tailored for ${meta.label}`}
+      className="bg-white border-y border-amber-100"
+    >
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 py-6">
+        <div className="flex items-end justify-between mb-4 gap-4 flex-wrap">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wider text-amber-700">
+              <span aria-hidden className="mr-1.5">{meta.flag}</span>
+              Tailored for {meta.label}
+            </p>
+            <h2 className="text-lg sm:text-xl font-semibold text-slate-900 mt-1">
+              Investments often considered by investors from {meta.name}
+            </h2>
+          </div>
+          <Link
+            href="/invest"
+            className="text-sm font-medium text-amber-700 hover:text-amber-900 underline underline-offset-2"
+          >
+            See all opportunities &rarr;
+          </Link>
+        </div>
+        <ul className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+          {visible.map((l) => (
+            <li key={l.id}>
+              <Link
+                href={`/invest/${l.vertical}/${l.slug}`}
+                className="group block bg-slate-50 hover:bg-amber-50 border border-slate-200 hover:border-amber-200 rounded-xl overflow-hidden transition-colors"
+              >
+                {l.hero_image && (
+                  <div className="relative aspect-[5/3] bg-slate-100">
+                    <Image
+                      src={l.hero_image}
+                      alt={l.title}
+                      fill
+                      sizes="(max-width: 1024px) 50vw, 25vw"
+                      className="object-cover"
+                    />
+                  </div>
+                )}
+                <div className="p-3">
+                  <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider">
+                    {l.vertical}
+                  </p>
+                  <p className="text-sm font-semibold text-slate-900 mt-0.5 line-clamp-2 group-hover:text-amber-900">
+                    {l.title}
+                  </p>
+                  {(l.location_display || l.price_display) && (
+                    <p className="text-xs text-slate-500 mt-1 truncate">
+                      {[l.price_display, l.location_display].filter(Boolean).join(" · ")}
+                    </p>
+                  )}
+                </div>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/components/country-mode/CountryModeBanner.tsx
+++ b/components/country-mode/CountryModeBanner.tsx
@@ -1,0 +1,51 @@
+/**
+ * Country Mode persistent banner.
+ *
+ * Server component — reads the iv_intent_country cookie. If set, renders
+ * a thin sticky-under-nav strip telling the user they're in country
+ * mode plus two escape hatches: switch country (opens the flag selector
+ * via custom event) or view global (server action clears the cookie).
+ *
+ * If the cookie isn't set, returns null so non-country-mode users see
+ * the homepage exactly as before. Mounted once in app/layout.tsx so it
+ * appears site-wide.
+ */
+
+import {
+  getIntentCountry,
+  intentCountryMeta,
+} from "@/lib/intent-context";
+import { clearIntentCountryAction } from "@/lib/intent-context-actions";
+import CountryModeBannerSwitchButton from "./CountryModeBannerSwitchButton";
+
+export default async function CountryModeBanner() {
+  const code = await getIntentCountry();
+  if (!code) return null;
+  const meta = intentCountryMeta(code);
+
+  return (
+    <div
+      className="bg-amber-50 border-b border-amber-100"
+      role="status"
+      aria-live="polite"
+    >
+      <div className="max-w-7xl mx-auto px-4 py-2 flex flex-wrap items-center justify-between gap-x-4 gap-y-1 text-xs sm:text-sm">
+        <p className="text-slate-800">
+          <span aria-hidden className="mr-1.5">{meta.flag}</span>
+          You&rsquo;re viewing Invest.com.au for <strong>{meta.label}</strong>.
+        </p>
+        <div className="flex items-center gap-4">
+          <CountryModeBannerSwitchButton />
+          <form action={clearIntentCountryAction}>
+            <button
+              type="submit"
+              className="text-slate-600 hover:text-slate-900 underline underline-offset-2"
+            >
+              View global
+            </button>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/country-mode/CountryModeBanner.tsx
+++ b/components/country-mode/CountryModeBanner.tsx
@@ -11,10 +11,8 @@
  * appears site-wide.
  */
 
-import {
-  getIntentCountry,
-  intentCountryMeta,
-} from "@/lib/intent-context";
+import { intentCountryMeta } from "@/lib/intent-context";
+import { getIntentCountry } from "@/lib/intent-context-server";
 import { clearIntentCountryAction } from "@/lib/intent-context-actions";
 import CountryModeBannerSwitchButton from "./CountryModeBannerSwitchButton";
 

--- a/components/country-mode/CountryModeBannerSwitchButton.tsx
+++ b/components/country-mode/CountryModeBannerSwitchButton.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+/**
+ * Tiny client wrapper for the "Switch country" button inside
+ * CountryModeBanner (a server component). Dispatches a custom event
+ * that LocationFlagButton listens for to open its popover. Custom
+ * event keeps the banner and selector decoupled — neither imports
+ * the other directly.
+ */
+
+export const COUNTRY_MODE_OPEN_SELECTOR_EVENT = "country-mode:open-selector";
+
+export default function CountryModeBannerSwitchButton() {
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        if (typeof window !== "undefined") {
+          window.dispatchEvent(new CustomEvent(COUNTRY_MODE_OPEN_SELECTOR_EVENT));
+        }
+      }}
+      className="text-slate-600 hover:text-slate-900 underline underline-offset-2"
+    >
+      Switch country
+    </button>
+  );
+}

--- a/components/country-mode/CountryPopularLinks.tsx
+++ b/components/country-mode/CountryPopularLinks.tsx
@@ -1,0 +1,81 @@
+/**
+ * Country Mode popular-starting-points strip — rendered above the
+ * HomePathfinder when the user is in country mode. Each item is a
+ * pre-filtered destination tailored to the country (e.g. "Brokers
+ * that accept HK residents", "Get matched for HK investors").
+ *
+ * Reuses the country config's `defaultActions[]` directly — the same
+ * source of truth that feeds the flag-button popover. No duplicate
+ * config: changes to a country's headline links flow to both surfaces.
+ *
+ * Server component reading the iv_intent_country cookie. Renders
+ * nothing when no country is set, or when the country has neither
+ * homepagePopularLinks nor defaultActions defined.
+ */
+
+import Link from "next/link";
+import {
+  getIntentCountry,
+  intentCountryMeta,
+} from "@/lib/intent-context";
+import { getHomepageFiltersForCountry } from "@/lib/country-mode";
+
+export default async function CountryPopularLinks() {
+  const code = await getIntentCountry();
+  if (!code) return null;
+
+  const filters = getHomepageFiltersForCountry(code);
+  // Cap at 4 — keeps the strip compact and prevents config drift
+  // from turning it into a wall of links.
+  const links = filters.popularLinks.slice(0, 4);
+  if (links.length === 0) return null;
+
+  const meta = intentCountryMeta(code);
+
+  return (
+    <section
+      aria-label={`Popular starting points for ${meta.label}`}
+      className="bg-white border-y border-amber-100"
+    >
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 py-6">
+        <div className="mb-4">
+          <p className="text-xs font-semibold uppercase tracking-wider text-amber-700">
+            <span aria-hidden className="mr-1.5">{meta.flag}</span>
+            Tailored for {meta.label}
+          </p>
+          <h2 className="text-lg sm:text-xl font-semibold text-slate-900 mt-1">
+            Popular starting points for investors from {meta.name}
+          </h2>
+        </div>
+        <ul className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+          {links.map((link) => (
+            <li key={link.href + link.label}>
+              <Link
+                href={link.href}
+                className="group flex items-start gap-3 p-3 bg-slate-50 hover:bg-amber-50 border border-slate-200 hover:border-amber-200 rounded-xl transition-colors"
+              >
+                <span aria-hidden className="text-base leading-tight mt-0.5">
+                  {link.emoji}
+                </span>
+                <span className="flex-1 min-w-0">
+                  <span className="block text-sm font-semibold text-slate-900 group-hover:text-amber-900 line-clamp-1">
+                    {link.label}
+                  </span>
+                  <span className="block text-xs text-slate-500 leading-snug line-clamp-2 mt-0.5">
+                    {link.sublabel}
+                  </span>
+                </span>
+                <span
+                  aria-hidden
+                  className="text-slate-400 group-hover:text-amber-600 text-sm shrink-0 mt-0.5"
+                >
+                  →
+                </span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/components/country-mode/CountryPopularLinks.tsx
+++ b/components/country-mode/CountryPopularLinks.tsx
@@ -14,10 +14,8 @@
  */
 
 import Link from "next/link";
-import {
-  getIntentCountry,
-  intentCountryMeta,
-} from "@/lib/intent-context";
+import { intentCountryMeta } from "@/lib/intent-context";
+import { getIntentCountry } from "@/lib/intent-context-server";
 import { getHomepageFiltersForCountry } from "@/lib/country-mode";
 
 export default async function CountryPopularLinks() {

--- a/components/country-mode/CountryToolsStripWrapper.tsx
+++ b/components/country-mode/CountryToolsStripWrapper.tsx
@@ -1,0 +1,23 @@
+/**
+ * Country Mode wrapper around HomeToolsStrip.
+ *
+ * Server component reading the iv_intent_country cookie. Hands the
+ * resolved country's `homepageFeaturedTools` hrefs to HomeToolsStrip's
+ * `featuredHrefs` prop, which hoists matching tools to the front of
+ * the existing list. The strip never shrinks — Country Mode re-ranks,
+ * doesn't replace. When no country is set or the country has no
+ * featured tools, HomeToolsStrip renders in its default order.
+ */
+
+import { getIntentCountry } from "@/lib/intent-context";
+import { getHomepageFiltersForCountry } from "@/lib/country-mode";
+import HomeToolsStrip from "@/components/HomeToolsStrip";
+
+export default async function CountryToolsStripWrapper() {
+  const code = await getIntentCountry();
+  if (!code) return <HomeToolsStrip />;
+
+  const filters = getHomepageFiltersForCountry(code);
+  const featuredHrefs = filters.tools.map((t) => t.slug);
+  return <HomeToolsStrip featuredHrefs={featuredHrefs} />;
+}

--- a/components/country-mode/CountryToolsStripWrapper.tsx
+++ b/components/country-mode/CountryToolsStripWrapper.tsx
@@ -9,7 +9,7 @@
  * featured tools, HomeToolsStrip renders in its default order.
  */
 
-import { getIntentCountry } from "@/lib/intent-context";
+import { getIntentCountry } from "@/lib/intent-context-server";
 import { getHomepageFiltersForCountry } from "@/lib/country-mode";
 import HomeToolsStrip from "@/components/HomeToolsStrip";
 

--- a/components/country-mode/GeoSoftPrompt.tsx
+++ b/components/country-mode/GeoSoftPrompt.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+/**
+ * Country Mode soft prompt — the GeoIP-driven suggestion banner.
+ *
+ * Renders only when ALL of the following are true:
+ *   - The iv_intent_country cookie is empty (user hasn't picked a
+ *     country in the flag selector or via a /quiz?country= deeplink)
+ *   - The localStorage flag-button override is empty (existing visitors
+ *     who had set "AU" or a country pre-cookie-wiring shouldn't be
+ *     re-prompted)
+ *   - The "country prompt dismissed" localStorage flag is unset
+ *   - /api/geo returns an ISO code that maps to a supported
+ *     IntentCountryCode
+ *
+ * The first three are post-hydration checks; the fourth requires a
+ * fetch. We render nothing during SSR to avoid hydration mismatch and
+ * cache-fragmentation on the homepage edge cache. By design — see
+ * docs/architecture/country-mode.md for the SSR-vs-CSR tradeoffs.
+ *
+ * Soft prompt: per the addendum, GeoIP suggests, never forces. The two
+ * CTAs are equal-weight ("View HK version" / "Stay on global"), and
+ * dismissal is sticky (never re-shows for the same browser).
+ */
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import {
+  intentCountryFromIso,
+  intentCountryMeta,
+  INTENT_COUNTRY_COOKIE,
+  type IntentCountryCode,
+} from "@/lib/intent-context";
+import { setIntentCountryAction } from "@/lib/intent-context-actions";
+import { trackEvent } from "@/lib/tracking";
+
+const FLAG_OVERRIDE_KEY = "iv-location-flag-override";
+const DISMISSED_KEY = "iv-country-prompt-dismissed";
+
+function hasCookie(name: string): boolean {
+  if (typeof document === "undefined") return false;
+  return document.cookie
+    .split("; ")
+    .some((c) => c.startsWith(`${name}=`));
+}
+
+function safeLocalStorageGet(key: string): string | null {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function safeLocalStorageSet(key: string, value: string): void {
+  try {
+    localStorage.setItem(key, value);
+  } catch {
+    /* ignore */
+  }
+}
+
+export default function GeoSoftPrompt() {
+  const router = useRouter();
+  const [suggested, setSuggested] = useState<IntentCountryCode | null>(null);
+
+  useEffect(() => {
+    // Eligibility gates — short-circuit cheap checks before fetching.
+    if (hasCookie(INTENT_COUNTRY_COOKIE)) return;
+    if (safeLocalStorageGet(FLAG_OVERRIDE_KEY)) return;
+    if (safeLocalStorageGet(DISMISSED_KEY)) return;
+
+    let cancelled = false;
+    fetch("/api/geo")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (cancelled) return;
+        if (!data || typeof data.country !== "string") return;
+        const code = intentCountryFromIso(data.country);
+        if (!code) return;
+        setSuggested(code);
+        trackEvent("country_mode_detected", { country: code, source: "geo" });
+      })
+      .catch(() => {
+        /* dev mode / offline — leave hidden */
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (!suggested) return null;
+
+  const meta = intentCountryMeta(suggested);
+
+  return (
+    <div
+      className="bg-slate-900 text-white"
+      role="dialog"
+      aria-label={`Suggested country: ${meta.name}`}
+    >
+      <div className="max-w-7xl mx-auto px-4 py-3 flex flex-wrap items-center justify-between gap-x-4 gap-y-2 text-sm">
+        <p>
+          <span aria-hidden className="mr-2">{meta.flag}</span>
+          Looks like you&rsquo;re in {meta.name}. See the {meta.name.replace(/^the /, "")} investor view?
+        </p>
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={async () => {
+              trackEvent("country_mode_selected", {
+                country: suggested,
+                source: "geo_prompt",
+              });
+              try {
+                await setIntentCountryAction(suggested);
+              } catch {
+                /* surface as a missed conversion — don't block nav */
+              }
+              safeLocalStorageSet(FLAG_OVERRIDE_KEY, meta.iso);
+              setSuggested(null);
+              router.push(`/foreign-investment/${meta.slug}`);
+            }}
+            className="bg-amber-400 hover:bg-amber-300 text-slate-900 font-semibold px-3 py-1.5 rounded-lg transition-colors"
+          >
+            View {meta.name.replace(/^the /, "")} version
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              trackEvent("country_mode_dismissed", {
+                country: suggested,
+                source: "geo_prompt",
+              });
+              safeLocalStorageSet(DISMISSED_KEY, "1");
+              setSuggested(null);
+            }}
+            className="text-slate-300 hover:text-white underline underline-offset-2"
+          >
+            Stay on global
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/foreign-investment/IntentCountryBadge.tsx
+++ b/components/foreign-investment/IntentCountryBadge.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
-import { getIntentCountry, intentCountryMeta } from "@/lib/intent-context";
+import { intentCountryMeta } from "@/lib/intent-context";
+import { getIntentCountry } from "@/lib/intent-context-server";
 import ClearIntentCountryButton from "./ClearIntentCountryButton";
 
 /**

--- a/components/foreign-investment/IntentCountryRecommendation.tsx
+++ b/components/foreign-investment/IntentCountryRecommendation.tsx
@@ -1,4 +1,5 @@
-import { getIntentCountry, intentCountryMeta } from "@/lib/intent-context";
+import { intentCountryMeta } from "@/lib/intent-context";
+import { getIntentCountry } from "@/lib/intent-context-server";
 import IntentCountryRecommendationCard from "./IntentCountryRecommendationCard";
 
 type SurfaceKind = "compare" | "advisors" | "invest";

--- a/components/layout/LocationFlagButton.tsx
+++ b/components/layout/LocationFlagButton.tsx
@@ -169,10 +169,20 @@ export default function LocationFlagButton() {
       >
         <span aria-hidden>{flagEmoji(effective)}</span>
         {!isAU && supported && (
-          <span className="hidden sm:inline text-xs font-medium text-slate-700">
-            {supported.name.replace(/^the /, "")}
-          </span>
+          <>
+            {/* Mobile: ISO short ("HK"). ≥sm: full short name ("Hong Kong"). */}
+            <span className="sm:hidden text-xs font-semibold text-slate-700">
+              {supported.code}
+            </span>
+            <span className="hidden sm:inline text-xs font-medium text-slate-700">
+              {supported.name.replace(/^the /, "")}
+            </span>
+          </>
         )}
+        {/* Always-on chevron — telegraphs that the trigger is a menu, not a label. */}
+        <span aria-hidden className="text-[0.6rem] text-slate-400 leading-none">
+          ▾
+        </span>
       </button>
 
       {open && (
@@ -248,9 +258,9 @@ export default function LocationFlagButton() {
                     void clearIntentCountryAction();
                     setOpen(false);
                   }}
-                  className="block w-full text-left text-xs text-slate-500 hover:text-slate-900 underline underline-offset-2 mt-2"
+                  className="block w-full text-center text-sm font-medium text-slate-700 hover:text-slate-900 hover:bg-slate-50 border border-slate-200 rounded-xl px-3 py-2 mt-3 transition-colors"
                 >
-                  I&apos;m browsing as an Australian &rarr;
+                  Show me the global view
                 </button>
               </>
             ) : (

--- a/components/layout/LocationFlagButton.tsx
+++ b/components/layout/LocationFlagButton.tsx
@@ -3,7 +3,14 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import Link from "next/link";
 import { COUNTRY_CONFIGS } from "@/lib/foreign-investment-country-data";
-import type { IntentCountryCode } from "@/lib/intent-context";
+import {
+  INTENT_COUNTRY_COOKIE,
+  type IntentCountryCode,
+} from "@/lib/intent-context";
+import {
+  setIntentCountryAction,
+  clearIntentCountryAction,
+} from "@/lib/intent-context-actions";
 
 // ─── Country data (single source of truth, used to be split across
 // InternationalBanner) ──────────────────────────────────────────────────────
@@ -49,6 +56,13 @@ function flagEmoji(code: string): string {
 
 const STORAGE_KEY = "iv-location-flag-override";
 
+function hasIntentCountryCookie(): boolean {
+  if (typeof document === "undefined") return false;
+  return document.cookie
+    .split("; ")
+    .some((c) => c.startsWith(`${INTENT_COUNTRY_COOKIE}=`));
+}
+
 export default function LocationFlagButton() {
   const [open, setOpen] = useState(false);
   const [override, setOverride] = useState<string | null>(null);
@@ -58,11 +72,28 @@ export default function LocationFlagButton() {
   // Read any previously-set override from localStorage. We don't render the
   // localStorage value during SSR (hydration mismatch risk) — wait for
   // useEffect to populate it.
+  //
+  // Migration: if localStorage has a non-AU supported override but the
+  // iv_intent_country cookie isn't set, sync it. Existing users who
+  // selected a country before Country Mode wired the server action need
+  // this one-time write so the homepage / advisors / compare surfaces
+  // pick up their preference. localStorage "AU" maps to "no country
+  // mode" so we explicitly skip it.
   useEffect(() => {
     try {
       const stored = localStorage.getItem(STORAGE_KEY);
       // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: localStorage is read post-hydration to keep SSR markup consistent
       if (stored) setOverride(stored);
+      if (stored && stored !== "AU" && !hasIntentCountryCookie()) {
+        const match = SUPPORTED_COUNTRIES.find((c) => c.code === stored);
+        if (match) {
+          // Fire-and-forget — server action sets the cookie via
+          // Set-Cookie. No need to await: the page is already rendered
+          // with localStorage as the override; the cookie just needs
+          // to land before the next navigation.
+          void setIntentCountryAction(match.intentCode);
+        }
+      }
     } catch {
       /* ignore */
     }
@@ -134,9 +165,14 @@ export default function LocationFlagButton() {
             ? "Switch to investing-from-overseas view"
             : `Investing from ${supported?.name ?? "overseas"}? Switch view`
         }
-        className="p-2 rounded-xl text-base hover:bg-slate-100 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 leading-none"
+        className="px-2 py-2 rounded-xl text-base hover:bg-slate-100 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 leading-none flex items-center gap-1.5"
       >
         <span aria-hidden>{flagEmoji(effective)}</span>
+        {!isAU && supported && (
+          <span className="hidden sm:inline text-xs font-medium text-slate-700">
+            {supported.name.replace(/^the /, "")}
+          </span>
+        )}
       </button>
 
       {open && (
@@ -206,6 +242,10 @@ export default function LocationFlagButton() {
                   type="button"
                   onClick={() => {
                     setOverrideAndPersist("AU");
+                    // Clear the cookie too — otherwise downstream
+                    // surfaces (compare, advisors, homepage strips)
+                    // would still see the previous country preference.
+                    void clearIntentCountryAction();
                     setOpen(false);
                   }}
                   className="block w-full text-left text-xs text-slate-500 hover:text-slate-900 underline underline-offset-2 mt-2"
@@ -247,8 +287,12 @@ export default function LocationFlagButton() {
                   onClick={() => {
                     // Setting the override here lets the user "stick" to a
                     // country view if they intentionally pick one. The flag
-                    // updates to match.
+                    // updates to match. The cookie write feeds downstream
+                    // SSR surfaces (advisors / compare / homepage strips)
+                    // — without it, picking a country here only affected
+                    // this component's local UI.
                     setOverrideAndPersist(c.code);
+                    void setIntentCountryAction(c.intentCode);
                     setOpen(false);
                   }}
                   className="flex items-center gap-2 px-2 py-1.5 rounded-lg hover:bg-white transition-colors"

--- a/components/layout/LocationFlagButton.tsx
+++ b/components/layout/LocationFlagButton.tsx
@@ -11,6 +11,8 @@ import {
   setIntentCountryAction,
   clearIntentCountryAction,
 } from "@/lib/intent-context-actions";
+import { COUNTRY_MODE_OPEN_SELECTOR_EVENT } from "@/components/country-mode/CountryModeBannerSwitchButton";
+import { trackEvent } from "@/lib/tracking";
 
 // ─── Country data (single source of truth, used to be split across
 // InternationalBanner) ──────────────────────────────────────────────────────
@@ -55,6 +57,7 @@ function flagEmoji(code: string): string {
 }
 
 const STORAGE_KEY = "iv-location-flag-override";
+const DISMISSED_KEY = "iv-country-prompt-dismissed";
 
 function hasIntentCountryCookie(): boolean {
   if (typeof document === "undefined") return false;
@@ -67,6 +70,7 @@ export default function LocationFlagButton() {
   const [open, setOpen] = useState(false);
   const [override, setOverride] = useState<string | null>(null);
   const [detectedCountry, setDetectedCountry] = useState<string | null>(null);
+  const [dismissed, setDismissed] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
   // Read any previously-set override from localStorage. We don't render the
@@ -84,6 +88,7 @@ export default function LocationFlagButton() {
       const stored = localStorage.getItem(STORAGE_KEY);
       // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: localStorage is read post-hydration to keep SSR markup consistent
       if (stored) setOverride(stored);
+      if (localStorage.getItem(DISMISSED_KEY) === "1") setDismissed(true);
       if (stored && stored !== "AU" && !hasIntentCountryCookie()) {
         const match = SUPPORTED_COUNTRIES.find((c) => c.code === stored);
         if (match) {
@@ -137,6 +142,15 @@ export default function LocationFlagButton() {
     };
   }, [open]);
 
+  // Listen for the open-selector custom event — fired by
+  // CountryModeBanner's "Switch country" button. Decoupled from the
+  // banner so neither component imports the other directly.
+  useEffect(() => {
+    const handler = () => setOpen(true);
+    window.addEventListener(COUNTRY_MODE_OPEN_SELECTOR_EVENT, handler);
+    return () => window.removeEventListener(COUNTRY_MODE_OPEN_SELECTOR_EVENT, handler);
+  }, []);
+
   const setOverrideAndPersist = useCallback((value: string | null) => {
     setOverride(value);
     try {
@@ -149,9 +163,21 @@ export default function LocationFlagButton() {
 
   // Effective country = explicit override (user clicked one in the popover)
   // OR detected country OR fallback "AU" so the button always renders a flag.
-  const effective = override ?? detectedCountry ?? "AU";
+  // When the user has dismissed the soft-prompt, ignore the detected
+  // signal so the popover treats them as AU/global rather than re-prompting.
+  const detectedEffective = !override && dismissed ? null : detectedCountry;
+  const effective = override ?? detectedEffective ?? "AU";
   const supported = SUPPORTED_COUNTRIES.find((c) => c.code === effective);
-  const isAU = effective === "AU";
+  // Three popover states:
+  //   - explicit:  user picked a country (override) → show actions list + reset
+  //   - suggested: GeoIP detected an unconfirmed country → soft prompt
+  //   - generic:   AU / no signal → "Investing from overseas?" generic CTA
+  const popoverState: "explicit" | "suggested" | "generic" =
+    supported && override
+      ? "explicit"
+      : supported && !override && detectedEffective
+        ? "suggested"
+        : "generic";
 
   return (
     <div ref={ref} className="relative">
@@ -161,14 +187,19 @@ export default function LocationFlagButton() {
         aria-haspopup="menu"
         aria-expanded={open}
         aria-label={
-          isAU
-            ? "Switch to investing-from-overseas view"
-            : `Investing from ${supported?.name ?? "overseas"}? Switch view`
+          popoverState === "explicit" && supported
+            ? `Currently viewing as ${supported.name}. Switch country`
+            : popoverState === "suggested" && supported
+              ? `Investing from ${supported.name}? Switch view`
+              : "Switch to investing-from-overseas view"
         }
         className="px-2 py-2 rounded-xl text-base hover:bg-slate-100 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 leading-none flex items-center gap-1.5"
       >
         <span aria-hidden>{flagEmoji(effective)}</span>
-        {!isAU && supported && (
+        {/* Country name only renders for confirmed selection — a detected
+        but unconfirmed country shouldn't put a name in the nav, since
+        the user hasn't agreed they're in country mode yet. */}
+        {popoverState === "explicit" && supported && (
           <>
             {/* Mobile: ISO short ("HK"). ≥sm: full short name ("Hong Kong"). */}
             <span className="sm:hidden text-xs font-semibold text-slate-700">
@@ -191,15 +222,61 @@ export default function LocationFlagButton() {
           className="absolute right-0 top-full mt-2 z-[60] w-[360px] bg-white rounded-2xl border border-slate-200 shadow-xl shadow-slate-200/60 overflow-hidden"
         >
           <div className="p-4">
-            {supported && !isAU ? (
+            {popoverState === "suggested" && supported ? (
               <>
                 <p className="text-xs font-bold text-slate-500 uppercase tracking-wider mb-1">
-                  {override ? "Viewing as" : "Detected location"}
+                  Suggested
                 </p>
                 <p className="text-sm font-semibold text-slate-900 mb-3">
-                  {override
-                    ? `You're browsing as ${flagEmoji(effective)} ${supported.name}.`
-                    : `We've detected you're in ${flagEmoji(effective)} ${supported.name}.`}
+                  Looks like you&rsquo;re in {flagEmoji(effective)} {supported.name}. See the {supported.name.replace(/^the /, "")} investor view?
+                </p>
+                <div className="flex flex-col gap-2">
+                  <Link
+                    href={`/foreign-investment/${supported.slug}`}
+                    onClick={() => {
+                      setOverrideAndPersist(supported.code);
+                      void setIntentCountryAction(supported.intentCode);
+                      trackEvent("country_mode_selected", {
+                        country: supported.intentCode,
+                        source: "popover_suggestion",
+                      });
+                      setOpen(false);
+                    }}
+                    className="block text-center bg-amber-400 hover:bg-amber-300 text-slate-900 font-semibold px-3 py-2 rounded-xl transition-colors"
+                  >
+                    View {supported.name.replace(/^the /, "")} version
+                  </Link>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      // Don't lie about location — keep override empty
+                      // but mark the prompt dismissed so the popover
+                      // shows the generic state next time.
+                      try {
+                        localStorage.setItem(DISMISSED_KEY, "1");
+                      } catch {
+                        /* ignore */
+                      }
+                      setDismissed(true);
+                      trackEvent("country_mode_dismissed", {
+                        country: supported.intentCode,
+                        source: "popover_suggestion",
+                      });
+                      setOpen(false);
+                    }}
+                    className="text-center text-sm font-medium text-slate-600 hover:text-slate-900 hover:bg-slate-50 border border-slate-200 rounded-xl px-3 py-2 transition-colors"
+                  >
+                    Stay on global
+                  </button>
+                </div>
+              </>
+            ) : popoverState === "explicit" && supported ? (
+              <>
+                <p className="text-xs font-bold text-slate-500 uppercase tracking-wider mb-1">
+                  Viewing as
+                </p>
+                <p className="text-sm font-semibold text-slate-900 mb-3">
+                  You&rsquo;re browsing as {flagEmoji(effective)} {supported.name}.
                 </p>
                 {(() => {
                   const actions = COUNTRY_CONFIGS[supported.intentCode]?.defaultActions ?? [];
@@ -303,6 +380,10 @@ export default function LocationFlagButton() {
                     // this component's local UI.
                     setOverrideAndPersist(c.code);
                     void setIntentCountryAction(c.intentCode);
+                    trackEvent("country_mode_selected", {
+                      country: c.intentCode,
+                      source: "popover_grid",
+                    });
                     setOpen(false);
                   }}
                   className="flex items-center gap-2 px-2 py-1.5 rounded-lg hover:bg-white transition-colors"

--- a/docs/architecture/country-mode.md
+++ b/docs/architecture/country-mode.md
@@ -1,0 +1,167 @@
+# Country Mode — Architecture
+
+How invest.com.au tailors examples and CTAs around an inbound investor's
+country without changing the global navigation. Phase 1 ships the
+infrastructure + Hong Kong as the model country; Phase 2+ widens the
+populated set.
+
+## Five-level priority chain
+
+When deciding which country (if any) the user is in, we resolve in this
+order:
+
+1. **URL param** — `?country=<slug>` on /quiz, country page CTAs
+2. **User-selected country** — `iv_intent_country` cookie, written by
+   the flag selector / soft prompt accept
+3. **Stored cookie / preference** — same cookie (collapses with #2)
+4. **GeoIP detection** — `/api/geo` returns `x-vercel-ip-country`
+5. **AU / Global fallback** — no signal, render the global homepage
+
+Implementation: `lib/country-mode/resolve-country.ts:resolveCountryFromContext()`.
+Pure function — callers pass raw values from `cookies()` / `headers()` /
+`searchParams`, get back `{ code, source }`.
+
+GeoIP suggests, never forces. The soft-prompt UX (`GeoSoftPrompt`)
+fires only when (cookie empty) ∧ (localStorage override empty) ∧
+(`iv-country-prompt-dismissed` flag unset) ∧ (geo returns supported
+ISO). Dismissal is sticky — never re-shows in the same browser.
+
+## "Augment, never replace"
+
+The homepage stays broad and global by default. When a country is
+resolved, slim "Tailored for <X> investors" strips render **above** the
+existing teasers — they don't replace them.
+
+| Section | Country Mode behaviour |
+|---|---|
+| Hero, route cards | unchanged |
+| Tools strip | re-ranks tools (matching `homepageFeaturedTools` hoisted to front) — never shrinks |
+| Pathfinder | "Get matched" CTA gains `?country=<slug>` |
+| Compare deep dive | preview strip prepended (`CountryComparePreview`) |
+| Listings teaser | preview strip prepended (`CountryListingsPreview`) |
+| Advisors teaser | preview strip prepended (`CountryExpertsPreview`) |
+| Cross-border | matching arrival card hoisted to position 1 (only for UK/IN/CN/US — the four arrival audiences) |
+
+Each preview wrapper is a Server Component reading the cookie in its
+own subtree. Next.js opts only that subtree into dynamic rendering;
+the parent `app/page.tsx` keeps `revalidate = 3600` for visitors with
+no country preference.
+
+## Don't fake supply
+
+A country-tailored strip only renders when it has at least N real rows.
+Below the threshold, the strip silently hides and the global teaser
+below carries the experience.
+
+| Surface | Threshold | Rationale |
+|---|---|---|
+| Listings | 2 | Fewer reads as "we have one thing for you" — over-promises |
+| Experts | 2 | Same — one expert looks like a token mention |
+| Platforms | 3 | A "compare" surface needs ≥3 to actually compare |
+
+Implementation: `lib/country-mode/supply-thresholds.ts:applySupplyThresholds()`.
+Show all or none — never a partial slice (a near-miss country must not
+look ambiguously curated).
+
+## Adding a new country
+
+1. **Verify the country has an `IntentCountryCode` entry** in
+   `lib/intent-context.ts`. Slug, name, label, flag, currency, hasDta,
+   quizKey, iso are all required. The 12 supported corridors are
+   already in.
+2. **Confirm the standalone country page exists** at
+   `app/foreign-investment/<slug>/page.tsx`. All 12 already do.
+3. **Populate the country's `CountryConfig`** in
+   `lib/foreign-investment-country-data.ts`. The full hub config (DTA
+   table, FIRB tiles, FAQ, etc.) is what powers the
+   `/foreign-investment/<slug>` page.
+4. **Add Country Mode homepage hooks** (optional fields on
+   `CountryConfig`):
+   - `homepageListingFilters: { verticals: string[]; firb?: boolean }`
+   - `homepageExpertFilters: { specialties: string[]; languages?: string[] }`
+   - `homepagePlatformFilters: { types: PlatformType[]; nonResidentsOnly?: boolean }`
+   - `homepageFeaturedTools: { slug: string; label: string }[]` — slug
+     here is the tool's `href` (e.g. `/cgt-calculator`)
+   - `defaultActions[]` (already used by the flag-button popover —
+     reused as the homepage popular-links strip)
+   - `preferredLanguages: string[]` (ISO 639-1 hints; informs Phase 5
+     language routing)
+5. **The supply-threshold gate handles the rest**: if the filtered
+   query returns enough rows, the strip renders; if not, it hides.
+
+Phase 1 model country: **Hong Kong**. The other 11 fall back to global
+until Phase 2 fills them in.
+
+## Dual renderer for `/foreign-investment/<country>`
+
+Two paths exist today:
+
+- **`app/foreign-investment/<slug>/page.tsx`** (standalone, config-driven).
+  Each of the 12 countries has its own thin route file rendering
+  `<CountryHubTemplate config={…_CONFIG} />`. This is the canonical
+  surface.
+- **`app/foreign-investment/[country]/page.tsx`** (dynamic, DB-backed).
+  Older path that queries `country_investment_profiles` etc. Now
+  shadowed by the standalones for the 12 country-mode codes; reachable
+  only for slugs not in that set.
+
+Phase 4 will unify these — RFC required because backfill from config →
+DB or vice versa is non-trivial. Phase 1 leaves both in place.
+
+## Tracking
+
+Country Mode fires four events via `lib/tracking.ts:trackEvent` (free-
+form) and extends one typed event:
+
+- `country_mode_detected` — geo prompt rendered (GeoSoftPrompt mount)
+- `country_mode_selected` — user accepted, from any of: flag-popover
+  grid click, in-popover suggested-state accept, soft-prompt accept.
+  `source` property distinguishes (`popover_grid` / `popover_suggestion` /
+  `geo_prompt`)
+- `country_mode_dismissed` — user declined, from soft prompt or
+  in-popover suggested state
+- `quiz_completed` (existing event) — extended with `country` dimension
+  carrying the quiz key (e.g. `"hong_kong"`)
+
+Three click-event hooks (`country_listing_click`, `country_expert_click`,
+`country_tool_click`) are deferred to Phase 2 — easily reconstructed
+from `pathname` + cookie dimension on `$pageview`.
+
+## Phase 5 language hooks (scaffolding only)
+
+`CountryConfig` has five optional fields nothing reads in Phase 1:
+
+- `hasRtlLanguage: boolean` — true for SA/AE
+- `defaultLanguage: string` — ISO 639-1
+- `supportedLanguages: string[]`
+- `languageRoutes: Record<string, string>` — language code → localised
+  hub URL (e.g. `{ "zh-Hans": "/zh/foreign-investment/china" }`)
+- `rtlReady: boolean`
+
+Defining the shape now means Phase 5 plugs into a stable interface
+without restructuring 12 country configs. Country Mode comes first;
+Language Mode comes second.
+
+## Where the cookie lives
+
+| Layer | Key | Read | Write |
+|---|---|---|---|
+| HTTP cookie | `iv_intent_country` | `getIntentCountry()` (server, `cookies()`) | `setIntentCountryAction()` server action |
+| localStorage | `iv-location-flag-override` | `LocationFlagButton` mount effect | grid click + soft-prompt accept |
+| localStorage | `iv-country-prompt-dismissed` | GeoSoftPrompt + LocationFlagButton mount effects | "Stay on global" buttons |
+
+The cookie is **non-httpOnly** (`lib/intent-context-actions.ts:25`) so
+client analytics can include the country dimension without an
+additional request. `LocationFlagButton`'s mount-time migration syncs
+existing localStorage-only users to the cookie on first visit after
+this lands.
+
+## Type-system invariants
+
+- `noUncheckedIndexedAccess` is on. `KNOWN[code]` works only because
+  `code: IntentCountryCode` is a union of literal keys. Free-form
+  string lookups (`CODE_BY_SLUG[slug]`) return `T | undefined` and must
+  be guarded with `?? null`.
+- `isKnownIntentCountry` uses `Object.prototype.hasOwnProperty.call`
+  (not `in`) so prototype-chain keys (`__proto__`, `toString`,
+  `constructor`) can't slip past the type guard.

--- a/lib/country-mode/filters.ts
+++ b/lib/country-mode/filters.ts
@@ -1,0 +1,103 @@
+/**
+ * Country Mode filter resolution — given an IntentCountryCode (or null
+ * for global), return the homepage filter shape the preview wrappers
+ * use to query Supabase / re-rank tools.
+ *
+ * Returns null for any filter the country config doesn't define — the
+ * convention being "null = render the global teaser, no country
+ * filtering." This is the runtime expression of the "Don't fake
+ * supply" rule: a half-populated config can't accidentally turn into
+ * a thin country preview, because every missing field is null.
+ */
+
+import {
+  getCountryConfig,
+  type QuickAction,
+} from "../foreign-investment-country-data";
+import type { IntentCountryCode } from "../intent-context";
+import type { PlatformType } from "../types";
+
+export interface HomepageListingFiltersRuntime {
+  verticals: ReadonlyArray<string>;
+  firb: boolean;
+}
+
+export interface HomepageExpertFiltersRuntime {
+  specialties: ReadonlyArray<string>;
+  languages: ReadonlyArray<string>;
+}
+
+export interface HomepagePlatformFiltersRuntime {
+  types: ReadonlyArray<PlatformType>;
+  nonResidentsOnly: boolean;
+}
+
+export interface HomepageToolEntry {
+  slug: string;
+  label: string;
+  deeplinkParams?: Record<string, string>;
+}
+
+export interface HomepageFiltersForCountry {
+  /** null = render the global listings teaser, no country filtering. */
+  listings: HomepageListingFiltersRuntime | null;
+  /** null = render the global experts teaser, no country filtering. */
+  experts: HomepageExpertFiltersRuntime | null;
+  /** null = render the global compare grid, no country filtering. */
+  platforms: HomepagePlatformFiltersRuntime | null;
+  /** Empty array = no country-specific re-rank, render tools strip as-is. */
+  tools: ReadonlyArray<HomepageToolEntry>;
+  /**
+   * Popular-starting-points strip content. Falls back to the country's
+   * defaultActions[] (used by the flag-button popover) — the same
+   * source of truth feeds both surfaces. Empty when no country, or
+   * when a country has neither homepagePopularLinks nor defaultActions.
+   */
+  popularLinks: ReadonlyArray<QuickAction>;
+}
+
+const EMPTY_FILTERS: HomepageFiltersForCountry = {
+  listings: null,
+  experts: null,
+  platforms: null,
+  tools: [],
+  popularLinks: [],
+};
+
+export function getHomepageFiltersForCountry(
+  code: IntentCountryCode | null,
+): HomepageFiltersForCountry {
+  if (!code) return EMPTY_FILTERS;
+
+  const config = getCountryConfig(code);
+  if (!config) return EMPTY_FILTERS;
+
+  const listings = config.homepageListingFilters
+    ? {
+        verticals: config.homepageListingFilters.verticals,
+        firb: config.homepageListingFilters.firb ?? false,
+      }
+    : null;
+
+  const experts = config.homepageExpertFilters
+    ? {
+        specialties: config.homepageExpertFilters.specialties,
+        languages: config.homepageExpertFilters.languages ?? [],
+      }
+    : null;
+
+  const platforms = config.homepagePlatformFilters
+    ? {
+        types: config.homepagePlatformFilters.types,
+        nonResidentsOnly: config.homepagePlatformFilters.nonResidentsOnly ?? false,
+      }
+    : null;
+
+  return {
+    listings,
+    experts,
+    platforms,
+    tools: config.homepageFeaturedTools ?? [],
+    popularLinks: config.defaultActions ?? [],
+  };
+}

--- a/lib/country-mode/index.ts
+++ b/lib/country-mode/index.ts
@@ -1,0 +1,38 @@
+/**
+ * Country Mode — the layer that adapts examples, filters, and CTAs
+ * around a selected/detected country without changing the global
+ * navigation. See docs/architecture/country-mode.md for the contract.
+ *
+ * Public surface:
+ * - resolveCountryFromContext — five-level priority chain (URL > cookie
+ *   > GeoIP > AU/Global), returns the resolved code + which signal won
+ * - getHomepageFiltersForCountry — config-to-runtime mapper for the
+ *   homepage preview wrappers; returns nulls for "render global feed"
+ * - applySupplyThresholds — runtime "Don't fake supply" gate; below
+ *   threshold returns empty rows + didFallback so the country-specific
+ *   strip hides and the global teaser below carries the experience
+ * - SUPPLY_THRESHOLDS — exported constants for tests + admin tooling
+ */
+
+export {
+  resolveCountryFromContext,
+  type ResolvedCountry,
+  type ResolvedCountrySource,
+  type ResolveCountryInputs,
+} from "./resolve-country";
+
+export {
+  applySupplyThresholds,
+  SUPPLY_THRESHOLDS,
+  type SupplyKind,
+  type SupplyResult,
+} from "./supply-thresholds";
+
+export {
+  getHomepageFiltersForCountry,
+  type HomepageFiltersForCountry,
+  type HomepageListingFiltersRuntime,
+  type HomepageExpertFiltersRuntime,
+  type HomepagePlatformFiltersRuntime,
+  type HomepageToolEntry,
+} from "./filters";

--- a/lib/country-mode/resolve-country.ts
+++ b/lib/country-mode/resolve-country.ts
@@ -1,0 +1,72 @@
+/**
+ * Country Mode resolution — picks a single IntentCountryCode from the
+ * five-level priority chain.
+ *
+ * 1. Explicit URL param (`?country=hong-kong`)
+ * 2. User-selected country (persisted in the iv_intent_country cookie)
+ * 3. Stored cookie / preference  ← collapses with (2), since user
+ *    selection is what writes the cookie
+ * 4. GeoIP detection (ISO 3166-1 alpha-2 from /api/geo)
+ * 5. AU / Global fallback (returned as { code: null, source: null })
+ *
+ * The function is intentionally pure: callers pass raw values they read
+ * from `searchParams` / `cookies()` / `headers()`, and get back a
+ * resolved tuple. No I/O — trivial to unit-test.
+ *
+ * GeoIP suggests, never forces. Callers SHOULD only fall through to
+ * the geo signal when neither url nor cookie has a value, AND should
+ * prefer surfacing a soft-prompt UX (rather than silently switching
+ * mode) when the resolved source is "geo". The data layer can't
+ * enforce that — see components/country-mode/GeoSoftPrompt for the UX.
+ */
+
+import {
+  intentCountryFromIso,
+  intentCountryFromSlug,
+  isKnownIntentCountry,
+  type IntentCountryCode,
+} from "../intent-context";
+
+export type ResolvedCountrySource = "url" | "cookie" | "geo" | null;
+
+export interface ResolvedCountry {
+  code: IntentCountryCode | null;
+  source: ResolvedCountrySource;
+}
+
+export interface ResolveCountryInputs {
+  /**
+   * Raw `?country=` URL param value. Expected as a country slug
+   * ("hong-kong", "united-kingdom"). Intent codes ("hk") and ISO
+   * codes ("HK") are intentionally NOT accepted — country-mode CTAs
+   * always link with slugs, and accepting all three forms creates
+   * ambiguity (e.g. "us" could be a malformed iso or an intent code).
+   */
+  urlParam?: string | null;
+  /**
+   * Raw `iv_intent_country` cookie value. Validated against the
+   * supported set; arbitrary values fall through.
+   */
+  cookie?: string | null;
+  /**
+   * Raw ISO 3166-1 alpha-2 from /api/geo (case-insensitive). Returns
+   * null when the country isn't in the supported set.
+   */
+  geoIso?: string | null;
+}
+
+export function resolveCountryFromContext(
+  inputs: ResolveCountryInputs,
+): ResolvedCountry {
+  const fromUrl = intentCountryFromSlug(inputs.urlParam);
+  if (fromUrl) return { code: fromUrl, source: "url" };
+
+  if (inputs.cookie && isKnownIntentCountry(inputs.cookie)) {
+    return { code: inputs.cookie, source: "cookie" };
+  }
+
+  const fromGeo = intentCountryFromIso(inputs.geoIso);
+  if (fromGeo) return { code: fromGeo, source: "geo" };
+
+  return { code: null, source: null };
+}

--- a/lib/country-mode/supply-thresholds.ts
+++ b/lib/country-mode/supply-thresholds.ts
@@ -1,0 +1,59 @@
+/**
+ * Country Mode supply thresholds — the runtime check for "Don't fake
+ * supply." A country-tailored homepage strip only renders if it has at
+ * least N real rows. Below threshold, the strip hides and the global
+ * teaser below carries the experience instead.
+ *
+ * Numbers are deliberately conservative for Phase 1 launch:
+ * - listings: 2 — anything fewer reads as "we have one thing for you,"
+ *   which over-promises a curated funnel
+ * - experts: 2 — same reasoning; one expert looks like a token mention
+ * - platforms: 3 — comparison strips read as a "compare" surface; with
+ *   fewer than three options there's nothing to compare
+ *
+ * Centralised here so the supply rule stays consistent across all
+ * homepage strips and is easy to tune as country supply matures.
+ */
+
+export const SUPPLY_THRESHOLDS = {
+  listings: 2,
+  experts: 2,
+  platforms: 3,
+} as const;
+
+export type SupplyKind = keyof typeof SUPPLY_THRESHOLDS;
+
+export interface SupplyResult<T> {
+  /** Rows the caller should render. Empty when below threshold. */
+  rows: ReadonlyArray<T>;
+  /**
+   * True when `rows` is empty because the input was below threshold.
+   * Distinguishes "below threshold, hide the strip" from "got the
+   * rows we asked for, but the country happens to have zero of X."
+   * Either way the strip hides — but `didFallback` tells analytics /
+   * the docs/architecture which case fired.
+   */
+  didFallback: boolean;
+}
+
+/**
+ * Apply the supply threshold for a given kind. If `rows.length` meets
+ * or exceeds the threshold, returns the rows unchanged. Otherwise
+ * returns an empty array with `didFallback: true` — the consumer
+ * should hide the country-specific strip and let the global teaser
+ * carry the experience.
+ *
+ * Intentionally does NOT return a partial slice; the rule is "show all
+ * or none" so a near-miss country isn't ambiguously presented as a
+ * curated set.
+ */
+export function applySupplyThresholds<T>(
+  rows: ReadonlyArray<T>,
+  kind: SupplyKind,
+): SupplyResult<T> {
+  const threshold = SUPPLY_THRESHOLDS[kind];
+  if (rows.length < threshold) {
+    return { rows: [], didFallback: true };
+  }
+  return { rows, didFallback: false };
+}

--- a/lib/foreign-investment-country-data.ts
+++ b/lib/foreign-investment-country-data.ts
@@ -218,8 +218,105 @@ export interface CountryConfig {
    * 4–6 items per country. Lets a returning user jump straight to the
    * filtered slice that matches them instead of re-deriving the path
    * through the country guide every visit.
+   *
+   * Also re-used as the homepage popular-starting-points strip when this
+   * country is selected — Country Mode keeps a single source of truth
+   * for the country's headline links rather than duplicating copy.
    */
   defaultActions?: ReadonlyArray<QuickAction>;
+
+  // ─── Country Mode hooks (optional) ───────────────────────────────────
+  //
+  // Read by surfaces *other* than this country's foreign-investment hub
+  // — the homepage country-mode preview strips, the quiz prefill, the
+  // soft GeoIP prompt, Phase-5 language routing. All optional with
+  // global-feed fallbacks: a half-populated config produces the global
+  // homepage, never a broken or fake-supply one.
+
+  /**
+   * Filters the homepage listings preview when this country is the
+   * resolved Country Mode. `verticals` are slugs from `lib/verticals.ts`
+   * (e.g. "property", "shares"). `firb: true` further narrows to FIRB-
+   * eligible listings — meaningful for inbound property corridors. When
+   * omitted, the homepage falls through to the global listings feed.
+   */
+  homepageListingFilters?: {
+    verticals: ReadonlyArray<string>;
+    firb?: boolean;
+  };
+
+  /**
+   * Filters the homepage experts preview. `specialties` are advisor-type
+   * strings stored on `professionals` rows (free-text — e.g. "tax",
+   * "buyers-agent", "mortgage-broker"). `languages` is a list of ISO
+   * 639-1 codes (e.g. "zh", "ar") that narrows to experts who can serve
+   * the user in the target language. When omitted, falls through to
+   * the global experts feed.
+   */
+  homepageExpertFilters?: {
+    specialties: ReadonlyArray<string>;
+    languages?: ReadonlyArray<string>;
+  };
+
+  /**
+   * Filters the homepage compare-platforms preview. `types` are the
+   * `PlatformType` enum values to surface (typically share_broker for
+   * inbound corridors, plus crypto_exchange for crypto-active markets).
+   * `nonResidentsOnly: true` narrows to platforms with
+   * `accepts_non_residents = true` — meaningful for share_broker /
+   * cfd_forex / crypto_exchange where the column is populated. When
+   * omitted, falls through to the global compare grid.
+   */
+  homepagePlatformFilters?: {
+    types: ReadonlyArray<PlatformType>;
+    nonResidentsOnly?: boolean;
+  };
+
+  /**
+   * Tools to surface first in the homepage tools strip when this
+   * country is selected. Each entry is a tool slug plus optional URL
+   * params to pre-fill (e.g. `{ from: "GBP" }` on the FX-corridor
+   * calculator). The full tools list still renders — country mode
+   * re-ranks, it doesn't replace.
+   */
+  homepageFeaturedTools?: ReadonlyArray<{
+    slug: string;
+    label: string;
+    deeplinkParams?: Record<string, string>;
+  }>;
+
+  /**
+   * Languages the country-mode user is likely to read/speak — drives
+   * expert-language filtering today and Phase-5 language routing
+   * tomorrow. ISO 639-1 codes (e.g. ["en", "zh"], ["ar", "en"]).
+   */
+  preferredLanguages?: ReadonlyArray<string>;
+
+  // ─── Phase-5 language hooks (scaffolding only, not read yet) ─────────
+  //
+  // Reserved for the Language Mode work in Phase 5. Defining the shape
+  // now lets country configs declare language intent (RTL, default,
+  // route map) without restructuring later. Nothing reads these in
+  // Phase 1 — they exist purely so Phase 5 plugs into a stable
+  // interface.
+
+  /** Whether any of this country's supported languages is right-to-left (Arabic). */
+  hasRtlLanguage?: boolean;
+  /** Default language code for users in this country (ISO 639-1). */
+  defaultLanguage?: string;
+  /** All languages a user from this country may want (ISO 639-1 codes). */
+  supportedLanguages?: ReadonlyArray<string>;
+  /**
+   * Map from language code to the localised version of this country's
+   * hub (e.g. `{ "zh-Hans": "/zh/foreign-investment/china" }`). Phase 5
+   * will read this to emit hreflang and language-switcher links.
+   */
+  languageRoutes?: Record<string, string>;
+  /**
+   * Phase-5 readiness flag: true once translations + RTL pass exist
+   * for this country. Phase 1 ships this as undefined/false everywhere.
+   */
+  rtlReady?: boolean;
 
   /** Optional red-banner callout above the audiences section (e.g. US worldwide-tax warning). */
   criticalWarning?: CriticalWarning;

--- a/lib/foreign-investment-country-data.ts
+++ b/lib/foreign-investment-country-data.ts
@@ -2240,21 +2240,18 @@ export const HK_CONFIG: CountryConfig = {
     types: ["share_broker", "crypto_exchange"],
     nonResidentsOnly: true,
   },
-  // Featured tools for the (future, Step 9) tools-strip re-rank: WHT
-  // calculator with the HK preset, FX corridor calculator pre-set to
-  // HKD→AUD. Intentionally short — the global tools strip remains the
-  // full surface; Country Mode only re-ranks.
+  // Featured tools for the global tools-strip re-rank. `slug` is the
+  // tool's href — HomeToolsStrip hoists the matching entries to the
+  // front of the existing list (no replacement, no shrinkage). FIRB
+  // cost + CGT + mortgage are the three calculators most relevant to
+  // HK property + ASX investors. WHT calculator and FX-corridor
+  // calculator are flagged for Phase 2 once they land in the global
+  // tools list — adding them to homepageFeaturedTools today would be
+  // a no-op because there's nothing for the rerank to hoist.
   homepageFeaturedTools: [
-    {
-      slug: "withholding-tax-calculator",
-      label: "Withholding tax for HK residents",
-      deeplinkParams: { country: "hk" },
-    },
-    {
-      slug: "send-money-australia",
-      label: "HKD → AUD transfers",
-      deeplinkParams: { from: "HKD" },
-    },
+    { slug: "/property/foreign-investment", label: "FIRB cost (HK buyers)" },
+    { slug: "/cgt-calculator", label: "CGT for non-residents" },
+    { slug: "/mortgage-calculator", label: "Mortgage repayments" },
   ],
   preferredLanguages: ["en", "zh", "yue"],
   slug: "hong-kong",

--- a/lib/foreign-investment-country-data.ts
+++ b/lib/foreign-investment-country-data.ts
@@ -2206,6 +2206,7 @@ export const IN_CONFIG: CountryConfig = {
 export const HK_CONFIG: CountryConfig = {
   code: "hk",
   defaultActions: [
+    { emoji: "🤝", label: "Get matched for HK investors", sublabel: "60-second quiz — broker, advisor, or property strategy", href: "/quiz?country=hong-kong" },
     { emoji: "🇭🇰", label: "Investing in Australia from Hong Kong", sublabel: "DTA, no HK CGT, FIRB, ASX brokers — full guide", href: "/foreign-investment/hong-kong" },
     { emoji: "📈", label: "Brokers that accept HK residents", sublabel: "IBKR HK + Saxo HK most common", href: "/compare/non-residents" },
     { emoji: "🏠", label: "FIRB-eligible new properties", sublabel: "Sydney/Melbourne CBD apartments most popular with HK buyers", href: "/invest?firb=eligible" },
@@ -2213,6 +2214,49 @@ export const HK_CONFIG: CountryConfig = {
     { emoji: "🛂", label: "HK → AU pathway visas", sublabel: "BN(O)/SAR/HKBN holders have a reserved migration stream", href: "/advisors/migration-agents" },
     { emoji: "👤", label: "Find an HK-AU advisor", sublabel: "Cross-border tax + AU residency + FIRB", href: "/advisors" },
   ],
+  // Phase 1 model country for Country Mode homepage personalisation.
+  // The other 11 country configs fall back to global until Phase 2 fills
+  // them in. Numbers are conservative — supply thresholds (2 listings,
+  // 2 experts, 3 platforms) gate visibility regardless.
+  homepageListingFilters: {
+    // HK investors most often consider AU commercial property, business
+    // acquisitions, and private-market funds (per addendum module copy).
+    // These map to existing investment_listings.vertical slugs.
+    verticals: ["commercial-property", "buy-business", "funds"],
+    firb: false,
+  },
+  homepageExpertFilters: {
+    // Cross-border tax, buyer's agents, mortgage brokers — the three
+    // most-asked expert types for HK→AU investors. languages includes
+    // zh (Chinese, encompasses both Mandarin and Cantonese readers via
+    // ISO 639-1) and the Cantonese-specific yue tag where the
+    // `professionals.languages` jsonb has it.
+    specialties: ["tax", "buyers-agent", "mortgage-broker"],
+    languages: ["zh", "yue", "en"],
+  },
+  homepagePlatformFilters: {
+    // ASX shares + crypto are the active inbound corridors. Non-residents
+    // flag is on so we surface only brokers explicitly accepting HK IDs.
+    types: ["share_broker", "crypto_exchange"],
+    nonResidentsOnly: true,
+  },
+  // Featured tools for the (future, Step 9) tools-strip re-rank: WHT
+  // calculator with the HK preset, FX corridor calculator pre-set to
+  // HKD→AUD. Intentionally short — the global tools strip remains the
+  // full surface; Country Mode only re-ranks.
+  homepageFeaturedTools: [
+    {
+      slug: "withholding-tax-calculator",
+      label: "Withholding tax for HK residents",
+      deeplinkParams: { country: "hk" },
+    },
+    {
+      slug: "send-money-australia",
+      label: "HKD → AUD transfers",
+      deeplinkParams: { from: "HKD" },
+    },
+  ],
+  preferredLanguages: ["en", "zh", "yue"],
   slug: "hong-kong",
   countryName: "Hong Kong",
   countryShort: "HK",

--- a/lib/intent-context-server.ts
+++ b/lib/intent-context-server.ts
@@ -1,0 +1,34 @@
+/**
+ * Server-only intent-country helpers — split from `lib/intent-context.ts`
+ * because that module is imported by client components (Step 12 added
+ * the quiz prefill which needs the slug↔quizKey map). Importing
+ * `next/headers` from anywhere a client bundle reaches fails the
+ * Turbopack build with "next/headers is only available in Server
+ * Components".
+ *
+ * Pure helpers (registry, slug/iso/quizKey lookups, type guard) stay
+ * in lib/intent-context.ts and are safe for both client and server
+ * use. The cookie reader lives here.
+ */
+
+import { cookies } from "next/headers";
+import {
+  INTENT_COUNTRY_COOKIE,
+  isKnownIntentCountry,
+  type IntentCountryCode,
+} from "./intent-context";
+
+/**
+ * Read the user's intent country from the cookie. Returns null if
+ * the cookie isn't set or if the value isn't a known country code.
+ *
+ * Server-side only — uses next/headers cookies(). Calling this from
+ * a child Server Component opts that subtree into dynamic rendering
+ * while leaving the rest of the route's ISR shell intact.
+ */
+export async function getIntentCountry(): Promise<IntentCountryCode | null> {
+  const c = await cookies();
+  const raw = c.get(INTENT_COUNTRY_COOKIE)?.value;
+  if (!raw) return null;
+  return isKnownIntentCountry(raw) ? raw : null;
+}

--- a/lib/intent-context.ts
+++ b/lib/intent-context.ts
@@ -48,26 +48,55 @@ interface IntentCountryMeta {
   currency: string;
   /** ATO non-resident DTA status — quick UX hint, not legal advice */
   hasDta: boolean;
+  /**
+   * Answer key the `investor_country` quiz question stores for this country.
+   * Mirrors the `key` values in `UNIFIED_QUESTIONS.investor_country.options`
+   * in app/quiz/page.tsx — they're snake_case, not the 2-letter intent code.
+   *
+   * Some quiz keys aren't yet rendered as options (jp, kr, sa) — Step 12 adds
+   * those options. The map is the single source of truth so the option list
+   * and the link prefill agree.
+   */
+  quizKey: string;
+  /**
+   * ISO 3166-1 alpha-2 code, uppercase. Matches the `country` field that
+   * `/api/geo` returns from `x-vercel-ip-country`. Note `uk` → "GB" — UK is
+   * not an official ISO alpha-2 (it's an exceptionally-reserved alias),
+   * Vercel returns "GB".
+   */
+  iso: string;
 }
 
 const KNOWN: Record<IntentCountryCode, IntentCountryMeta> = {
-  uk: { slug: "united-kingdom",       label: "UK investors",         flag: "🇬🇧", currency: "GBP", hasDta: true },
-  us: { slug: "united-states",        label: "US investors",         flag: "🇺🇸", currency: "USD", hasDta: true },
-  cn: { slug: "china",                label: "Chinese investors",    flag: "🇨🇳", currency: "CNY", hasDta: true },
-  in: { slug: "india",                label: "Indian investors",     flag: "🇮🇳", currency: "INR", hasDta: true },
-  jp: { slug: "japan",                label: "Japanese investors",   flag: "🇯🇵", currency: "JPY", hasDta: true },
-  sg: { slug: "singapore",            label: "Singapore investors",  flag: "🇸🇬", currency: "SGD", hasDta: true },
-  hk: { slug: "hong-kong",            label: "HK investors",         flag: "🇭🇰", currency: "HKD", hasDta: false },
-  kr: { slug: "south-korea",          label: "Korean investors",     flag: "🇰🇷", currency: "KRW", hasDta: true },
-  my: { slug: "malaysia",             label: "Malaysian investors",  flag: "🇲🇾", currency: "MYR", hasDta: true },
-  nz: { slug: "new-zealand",          label: "NZ investors",         flag: "🇳🇿", currency: "NZD", hasDta: true },
-  ae: { slug: "united-arab-emirates", label: "UAE investors",        flag: "🇦🇪", currency: "AED", hasDta: true },
-  sa: { slug: "saudi-arabia",         label: "Saudi investors",      flag: "🇸🇦", currency: "SAR", hasDta: false },
+  uk: { slug: "united-kingdom",       label: "UK investors",         flag: "🇬🇧", currency: "GBP", hasDta: true,  quizKey: "uk",            iso: "GB" },
+  us: { slug: "united-states",        label: "US investors",         flag: "🇺🇸", currency: "USD", hasDta: true,  quizKey: "usa",           iso: "US" },
+  cn: { slug: "china",                label: "Chinese investors",    flag: "🇨🇳", currency: "CNY", hasDta: true,  quizKey: "china",         iso: "CN" },
+  in: { slug: "india",                label: "Indian investors",     flag: "🇮🇳", currency: "INR", hasDta: true,  quizKey: "india",         iso: "IN" },
+  jp: { slug: "japan",                label: "Japanese investors",   flag: "🇯🇵", currency: "JPY", hasDta: true,  quizKey: "japan",         iso: "JP" },
+  sg: { slug: "singapore",            label: "Singapore investors",  flag: "🇸🇬", currency: "SGD", hasDta: true,  quizKey: "singapore",     iso: "SG" },
+  hk: { slug: "hong-kong",            label: "HK investors",         flag: "🇭🇰", currency: "HKD", hasDta: false, quizKey: "hong_kong",     iso: "HK" },
+  kr: { slug: "south-korea",          label: "Korean investors",     flag: "🇰🇷", currency: "KRW", hasDta: true,  quizKey: "south_korea",   iso: "KR" },
+  my: { slug: "malaysia",             label: "Malaysian investors",  flag: "🇲🇾", currency: "MYR", hasDta: true,  quizKey: "malaysia",      iso: "MY" },
+  nz: { slug: "new-zealand",          label: "NZ investors",         flag: "🇳🇿", currency: "NZD", hasDta: true,  quizKey: "new_zealand",   iso: "NZ" },
+  ae: { slug: "united-arab-emirates", label: "UAE investors",        flag: "🇦🇪", currency: "AED", hasDta: true,  quizKey: "uae",           iso: "AE" },
+  sa: { slug: "saudi-arabia",         label: "Saudi investors",      flag: "🇸🇦", currency: "SAR", hasDta: false, quizKey: "saudi_arabia",  iso: "SA" },
 };
 
 const CODE_BY_SLUG: Record<string, IntentCountryCode> = Object.fromEntries(
   (Object.entries(KNOWN) as [IntentCountryCode, IntentCountryMeta][]).map(
     ([code, meta]) => [meta.slug, code],
+  ),
+);
+
+const CODE_BY_QUIZ_KEY: Record<string, IntentCountryCode> = Object.fromEntries(
+  (Object.entries(KNOWN) as [IntentCountryCode, IntentCountryMeta][]).map(
+    ([code, meta]) => [meta.quizKey, code],
+  ),
+);
+
+const CODE_BY_ISO: Record<string, IntentCountryCode> = Object.fromEntries(
+  (Object.entries(KNOWN) as [IntentCountryCode, IntentCountryMeta][]).map(
+    ([code, meta]) => [meta.iso, code],
   ),
 );
 
@@ -82,9 +111,47 @@ export function intentCountryFromSlug(
   return CODE_BY_SLUG[slug] ?? null;
 }
 
+/**
+ * Resolve a quiz `investor_country` answer key (e.g. "hong_kong", "uae")
+ * back to its `IntentCountryCode`. Returns null for unknown keys including
+ * the "other" option, which has no canonical country.
+ */
+export function intentCountryFromQuizKey(
+  key: string | null | undefined,
+): IntentCountryCode | null {
+  if (!key) return null;
+  return CODE_BY_QUIZ_KEY[key] ?? null;
+}
+
+/**
+ * Resolve an ISO 3166-1 alpha-2 code (case-insensitive) to an
+ * `IntentCountryCode`. Used by the GeoIP soft-prompt path: `/api/geo`
+ * returns the raw header value, which is uppercase but we accept either.
+ * Returns null for any country not in the supported set.
+ */
+export function intentCountryFromIso(
+  iso: string | null | undefined,
+): IntentCountryCode | null {
+  if (!iso) return null;
+  return CODE_BY_ISO[iso.toUpperCase()] ?? null;
+}
+
 export function intentCountryMeta(code: IntentCountryCode): IntentCountryMeta {
   return KNOWN[code];
 }
+
+/** Convenience: quiz answer key for an `IntentCountryCode`. */
+export function quizKeyForIntentCode(code: IntentCountryCode): string {
+  return KNOWN[code].quizKey;
+}
+
+/** Convenience: ISO 3166-1 alpha-2 (uppercase) for an `IntentCountryCode`. */
+export function isoForIntentCode(code: IntentCountryCode): string {
+  return KNOWN[code].iso;
+}
+
+/** All supported `IntentCountryCode` values, in insertion order. */
+export const INTENT_COUNTRY_CODES = Object.keys(KNOWN) as readonly IntentCountryCode[];
 
 /**
  * Read the user's intent country from the cookie. Returns null if

--- a/lib/intent-context.ts
+++ b/lib/intent-context.ts
@@ -40,6 +40,14 @@ export type IntentCountryCode =
 interface IntentCountryMeta {
   /** Folder name under app/foreign-investment/ */
   slug: string;
+  /**
+   * Place name used in banner/prompt copy, e.g. "the UK", "Hong Kong",
+   * "Saudi Arabia". Differs from `label` (which suffixes "investors")
+   * and `slug` (which is hyphenated for URLs). Articles ("the") are
+   * baked in where natural so copy reads "Looks like you're in <name>"
+   * without needing per-country sentence templates.
+   */
+  name: string;
   /** UI label, e.g. "UK investors" */
   label: string;
   /** Emoji flag for badges */
@@ -68,18 +76,18 @@ interface IntentCountryMeta {
 }
 
 const KNOWN: Record<IntentCountryCode, IntentCountryMeta> = {
-  uk: { slug: "united-kingdom",       label: "UK investors",         flag: "🇬🇧", currency: "GBP", hasDta: true,  quizKey: "uk",            iso: "GB" },
-  us: { slug: "united-states",        label: "US investors",         flag: "🇺🇸", currency: "USD", hasDta: true,  quizKey: "usa",           iso: "US" },
-  cn: { slug: "china",                label: "Chinese investors",    flag: "🇨🇳", currency: "CNY", hasDta: true,  quizKey: "china",         iso: "CN" },
-  in: { slug: "india",                label: "Indian investors",     flag: "🇮🇳", currency: "INR", hasDta: true,  quizKey: "india",         iso: "IN" },
-  jp: { slug: "japan",                label: "Japanese investors",   flag: "🇯🇵", currency: "JPY", hasDta: true,  quizKey: "japan",         iso: "JP" },
-  sg: { slug: "singapore",            label: "Singapore investors",  flag: "🇸🇬", currency: "SGD", hasDta: true,  quizKey: "singapore",     iso: "SG" },
-  hk: { slug: "hong-kong",            label: "HK investors",         flag: "🇭🇰", currency: "HKD", hasDta: false, quizKey: "hong_kong",     iso: "HK" },
-  kr: { slug: "south-korea",          label: "Korean investors",     flag: "🇰🇷", currency: "KRW", hasDta: true,  quizKey: "south_korea",   iso: "KR" },
-  my: { slug: "malaysia",             label: "Malaysian investors",  flag: "🇲🇾", currency: "MYR", hasDta: true,  quizKey: "malaysia",      iso: "MY" },
-  nz: { slug: "new-zealand",          label: "NZ investors",         flag: "🇳🇿", currency: "NZD", hasDta: true,  quizKey: "new_zealand",   iso: "NZ" },
-  ae: { slug: "united-arab-emirates", label: "UAE investors",        flag: "🇦🇪", currency: "AED", hasDta: true,  quizKey: "uae",           iso: "AE" },
-  sa: { slug: "saudi-arabia",         label: "Saudi investors",      flag: "🇸🇦", currency: "SAR", hasDta: false, quizKey: "saudi_arabia",  iso: "SA" },
+  uk: { slug: "united-kingdom",       name: "the UK",        label: "UK investors",         flag: "🇬🇧", currency: "GBP", hasDta: true,  quizKey: "uk",            iso: "GB" },
+  us: { slug: "united-states",        name: "the US",        label: "US investors",         flag: "🇺🇸", currency: "USD", hasDta: true,  quizKey: "usa",           iso: "US" },
+  cn: { slug: "china",                name: "China",         label: "Chinese investors",    flag: "🇨🇳", currency: "CNY", hasDta: true,  quizKey: "china",         iso: "CN" },
+  in: { slug: "india",                name: "India",         label: "Indian investors",     flag: "🇮🇳", currency: "INR", hasDta: true,  quizKey: "india",         iso: "IN" },
+  jp: { slug: "japan",                name: "Japan",         label: "Japanese investors",   flag: "🇯🇵", currency: "JPY", hasDta: true,  quizKey: "japan",         iso: "JP" },
+  sg: { slug: "singapore",            name: "Singapore",     label: "Singapore investors",  flag: "🇸🇬", currency: "SGD", hasDta: true,  quizKey: "singapore",     iso: "SG" },
+  hk: { slug: "hong-kong",            name: "Hong Kong",     label: "HK investors",         flag: "🇭🇰", currency: "HKD", hasDta: false, quizKey: "hong_kong",     iso: "HK" },
+  kr: { slug: "south-korea",          name: "South Korea",   label: "Korean investors",     flag: "🇰🇷", currency: "KRW", hasDta: true,  quizKey: "south_korea",   iso: "KR" },
+  my: { slug: "malaysia",             name: "Malaysia",      label: "Malaysian investors",  flag: "🇲🇾", currency: "MYR", hasDta: true,  quizKey: "malaysia",      iso: "MY" },
+  nz: { slug: "new-zealand",          name: "New Zealand",   label: "NZ investors",         flag: "🇳🇿", currency: "NZD", hasDta: true,  quizKey: "new_zealand",   iso: "NZ" },
+  ae: { slug: "united-arab-emirates", name: "the UAE",       label: "UAE investors",        flag: "🇦🇪", currency: "AED", hasDta: true,  quizKey: "uae",           iso: "AE" },
+  sa: { slug: "saudi-arabia",         name: "Saudi Arabia",  label: "Saudi investors",      flag: "🇸🇦", currency: "SAR", hasDta: false, quizKey: "saudi_arabia",  iso: "SA" },
 };
 
 const CODE_BY_SLUG: Record<string, IntentCountryCode> = Object.fromEntries(

--- a/lib/intent-context.ts
+++ b/lib/intent-context.ts
@@ -101,7 +101,11 @@ const CODE_BY_ISO: Record<string, IntentCountryCode> = Object.fromEntries(
 );
 
 export function isKnownIntentCountry(value: string): value is IntentCountryCode {
-  return value in KNOWN;
+  // Use hasOwnProperty rather than `in` so prototype-chain keys
+  // ("__proto__", "toString", "constructor") don't slip past the type
+  // guard and reach setIntentCountryAction or intentCountryMeta — which
+  // would either crash or write a garbage cookie.
+  return Object.prototype.hasOwnProperty.call(KNOWN, value);
 }
 
 export function intentCountryFromSlug(

--- a/lib/intent-context.ts
+++ b/lib/intent-context.ts
@@ -12,9 +12,14 @@
  * Compare → Advisors → Invest, the filter follows them without each
  * page having to forward the param. The badge keeps it visible and
  * the clear action is one click away — discoverable, not magic.
+ *
+ * This module is shared between server and client code — the quiz
+ * (a client component) imports the slug↔quizKey map. The server-only
+ * cookie reader (`getIntentCountry`) lives in
+ * `intent-context-server.ts` so this file stays free of
+ * `next/headers` and can be bundled into client components without
+ * the Turbopack "next/headers in client" build error.
  */
-
-import { cookies } from "next/headers";
 
 export const INTENT_COUNTRY_COOKIE = "iv_intent_country";
 const TTL_SECONDS = 60 * 60 * 24 * 90; // 90 days
@@ -164,19 +169,6 @@ export function isoForIntentCode(code: IntentCountryCode): string {
 
 /** All supported `IntentCountryCode` values, in insertion order. */
 export const INTENT_COUNTRY_CODES = Object.keys(KNOWN) as readonly IntentCountryCode[];
-
-/**
- * Read the user's intent country from the cookie. Returns null if
- * the cookie isn't set or if the value isn't a known country code.
- *
- * Server-side only — uses next/headers cookies().
- */
-export async function getIntentCountry(): Promise<IntentCountryCode | null> {
-  const c = await cookies();
-  const raw = c.get(INTENT_COUNTRY_COOKIE)?.value;
-  if (!raw) return null;
-  return isKnownIntentCountry(raw) ? raw : null;
-}
 
 /**
  * Cookie max-age, exposed for callers that need to pass it through to

--- a/lib/posthog/events.ts
+++ b/lib/posthog/events.ts
@@ -20,6 +20,15 @@ export interface EventProps {
     risk_profile: string | null
     top_match_slug: string | null
     match_count: number
+    /**
+     * Country Mode dimension — quiz answer key for investor_country
+     * (e.g. "hong_kong", "uk", "saudi_arabia") or null when the user
+     * stayed on the domestic / Australian-resident track. Set by both
+     * the URL-prefill path (/quiz?country=) and by users who manually
+     * pick a country at Q1. Lets analytics break quiz_completed by
+     * inbound corridor without a separate event name.
+     */
+    country: string | null
   }
   advisor_viewed: {
     advisor_id: number


### PR DESCRIPTION
## Summary

Phase 1 of Country Mode — adapts examples, filters, and CTAs around the user's country without changing the global navigation. Hong Kong populated as the model country; the other 11 inbound corridors fall back to global until Phase 2 fills them in.

## What ships

### Foundation (`lib/country-mode/`)
- Five-level priority chain resolver: URL > cookie > GeoIP > AU/Global
- Supply-threshold gate enforcing the "Don't fake supply" rule (2 listings, 2 experts, 3 platforms — show all or none)
- Config-to-runtime filter mapper
- Slug↔quizKey↔ISO map alongside `IntentCountryCode`
- `isKnownIntentCountry` hardened against prototype-chain keys (`__proto__`, etc.)

### UI surfaces
- `CountryModeBanner` (server-rendered, cookie-aware) — persistent strip under nav with Switch country / View global escape hatches
- `GeoSoftPrompt` (CSR-only, dismissable) — soft suggestion banner; never re-shows once dismissed
- `LocationFlagButton` — three-state popover (explicit / suggested / generic). Trigger gains chevron, mobile shows ISO short, desktop shows full name. Cookie writes synced with localStorage. In-popover soft prompt for detected-but-not-confirmed state.
- `CountryComparePreview` / `CountryListingsPreview` / `CountryExpertsPreview` — preview strips ABOVE each global teaser; render only when supply meets threshold
- `CountryPopularLinks` — popular-starting-points strip above `HomePathfinder`, reuses `defaultActions[]` (no duplicate config)
- `CountryToolsStripWrapper` — re-ranks `HomeToolsStrip`, never replaces
- `HomeCrossBorder` — matching arrival card hoisted to position 1 (UK/IN/CN/US only)
- `HomePathfinder` — Get-matched CTA carries `?country=<slug>` when in country mode

### Cross-surface
- Quiz: 12+1 country options (added JP/KR/SA), reads `?country=` and `?intent=` URL params, soft-prefills `investor_country` and `investor_goal_intl` — Q1 still confirms (never bypassed, per the soft-default rule)
- `/foreign-investment/from/<iso>` permanently redirects to `/foreign-investment/<slug>` for the 12 supported corridors; the ~32 DTA-only ISOs keep their page
- Navigation copy aligned to "Post a request"

### HK as model country
Listings filtered to `commercial-property` / `buy-business` / `funds`; experts filtered to `tax` / `buyers-agent` / `mortgage-broker` (with `zh` / `yue` / `en` language hints for Phase 2); platforms filtered to `share_broker` / `crypto_exchange` (non-residents only); tools hoisted to FIRB + CGT + mortgage; popular-links lead with "Get matched for HK investors" → `/quiz?country=hong-kong`.

### Tracking
- 3 new free-form events: `country_mode_detected` / `_selected` / `_dismissed` with `source` dimension
- Existing `quiz_completed` event extended with `country` dimension (typed)

### Docs
- `docs/architecture/country-mode.md` — priority chain, augment-not-replace rule, supply thresholds, how-to-add-a-country recipe, dual-renderer split, tracking catalogue, Phase 5 hooks, cookie layers, TS invariants
- `CLAUDE.md` single-source-of-truth pointer added

## Hard rules respected (per Country Mode addendum)

1. ✓ Country Mode ≠ Language Mode (Phase 5 hooks scaffolded but unread)
2. ✓ Country pages stay real crawlable URLs with unique title/meta/H1/canonical
3. ✓ Get matched stays separate from Post a request
4. ✓ No 5th main homepage card
5. ✓ Supply-threshold gate prevents thin pages
6. ✓ Pre-launch — no listings/experts implying verified/recommended status

## User-committed decisions (all honoured)

1. ✓ Augment, never replace homepage modules
2. ✓ Folded `homepagePopularLinks` into existing `defaultActions[]`
3. ✓ Supply thresholds 2/2/3
4. ✓ LocationFlagButton writes both cookie + localStorage
5. ✓ Reused IntentCountryRecommendation pattern (subtree-dynamic, page-ISR)
6. ✓ Soft-default only — quiz still confirms Q1
7. ✓ Get matched ≠ Post a request
8. ✓ Country dim on existing quiz_completed (no new event name)
9. ✓ No language/RTL build now — only architecture hooks

## Test plan

- [x] `npm run type-check` passes (verified before commit)
- [x] `npm test` passes — 312/312 across 22 affected files (verified pre-rollback)
- [x] `npx eslint --max-warnings 0` clean on all touched files
- [ ] CI: full type-check, lint, vitest, build all green
- [ ] Manual: `/?country=hong-kong` shows HK banner, HK strips above teasers, HK popular links
- [ ] Manual: `/foreign-investment/from/gb` 308-redirects to `/foreign-investment/united-kingdom`
- [ ] Manual: `/quiz?country=hong-kong&intent=property` prefills `investor_country=hong_kong` + `investor_goal_intl=property`, but Q1 still requires confirmation
- [ ] Manual: GeoSoftPrompt fires for new visitors with no cookie + supported geo
- [ ] Manual: Switch country / View global from banner round-trips correctly
- [ ] Manual: A11y — chevron/aria-labels readable, popover focus trap intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)