### PR TITLE
feat(country-mode): Phase 4 — country eligibility schema + renderer RFC

### DIFF
--- a/docs/rfcs/2026-05-08-country-mode-renderer-unification.md
+++ b/docs/rfcs/2026-05-08-country-mode-renderer-unification.md
@@ -1,0 +1,92 @@
+# RFC: Country Mode renderer unification
+
+- **Status:** Proposed
+- **Author:** Country Mode Phase 4
+- **Date:** 2026-05-08
+- **Related:** `docs/architecture/country-mode.md`, `lib/country-mode/`, `lib/foreign-investment-country-data.ts`, Phase 1+2 (12 country configs shipped)
+
+## 1. Current state
+
+`/foreign-investment/<country>` currently has **two parallel renderers** that produce different page shapes for overlapping country slugs.
+
+### 1a. Config-driven (canonical for the 12 shipped countries)
+
+- Source of truth: `lib/foreign-investment-country-data.ts` (4,300+ lines), exporting 12 `*_CONFIG` objects (`UK_CONFIG`, `US_CONFIG`, `CN_CONFIG`, `IN_CONFIG`, `HK_CONFIG`, `SG_CONFIG`, `NZ_CONFIG`, `JP_CONFIG`, `KR_CONFIG`, `MY_CONFIG`, `AE_CONFIG`, `SA_CONFIG`) plus the `COUNTRY_CONFIGS` registry keyed by `IntentCountryCode`.
+- `CountryConfig` shape is rich: hero, two-audience cards, DTA rate table, FIRB/property tiles, FX corridor, pension/inheritance, expat case, migration pathways, FAQ, related links, lead-capture form, plus the Phase 1+2 Country Mode hooks (homepageListingFilters, homepageExpertFilters, homepagePlatformFilters, homepageFeaturedTools, preferredLanguages, hasRtlLanguage, defaultLanguage, supportedLanguages, languageRoutes, rtlReady).
+- Each country has a thin standalone route file at `app/foreign-investment/<slug>/page.tsx` that imports the config and renders `<CountryHubTemplate config={…} />` (~30 lines, mostly metadata).
+- Files: `app/foreign-investment/{china,hong-kong,india,japan,malaysia,new-zealand,saudi-arabia,singapore,south-korea,united-arab-emirates,united-kingdom,united-states}/page.tsx`. 12 routes, all live.
+- Static, no DB query. Build-time copy; ISR `revalidate = 86400`.
+
+### 1b. DB-backed (legacy dynamic route)
+
+- Source of truth: Supabase tables `country_investment_profiles`, `foreign_investment_rates`, `professionals` (read-only filter by `accepts_international`).
+- Single dynamic route: `app/foreign-investment/[country]/page.tsx`. Hard-codes a 7-entry `SLUG_TO_CODE` map (`united-states` → `US`, `japan` → `JP`, `india` → `IN`, `malaysia` → `MY`, `new-zealand` → `NZ`, `south-korea` → `KR`, `saudi-arabia` → `SA`) and `notFound()`s anything else.
+- Page shape is **much thinner**: hero, 4-stat tile (DTA / Dividend WHT / Interest WHT / Annual FDI), NZ-specific notice, sectors grid, visa pathway grid, FIRB summary, stamp-duty surcharge table, advisor cards, CTA. No DTA rate table, no FX corridor, no pension transfer, no FAQ, no lead form.
+- `country_investment_profiles` columns: `country_code`, `country_name`, `flag_emoji`, `hero_title`, `hero_subtitle`, `primary_investment_sectors[]`, `has_dta`, `dta_year`, `fta_partner`, `estimated_annual_fdi_aud_millions`, `popular_visa_pathways[]`, `recommended_advisor_types[]`, `key_facts JSONB`, `meta_title`, `meta_description`, `sort_order`, `active`.
+
+### 1c. The conflict
+
+Next.js App Router routing precedence: a static segment beats a dynamic segment. So for the 7 slugs that exist in both `SLUG_TO_CODE` and as standalone files (us, jp, in, my, nz, kr, sa), **only the standalone config-driven file fires**. The DB-backed route is functionally dead for those — it can only ever serve a slug that's in `SLUG_TO_CODE` *and* doesn't have a standalone file. Today that set is **empty**.
+
+The DB-backed route is **dead code surfacing as live infra**: 540 lines of JSX, three Supabase queries, advisor join, all unreachable. `country_investment_profiles` has rows that nothing reads.
+
+Worse: if someone adds a thirteenth country slug (say `germany`) to `SLUG_TO_CODE` *without* a standalone file, the page rendered will be the thin DB shape — silently inconsistent with the other 12. Footgun.
+
+### 1d. Editor / admin-tooling state
+
+`grep -rn "country_investment_profiles" app/admin lib`: **zero matches** outside `lib/database.types.ts` and the dynamic route itself. No admin UI editing this table. Rows were seeded by migration; no human workflow currently depends on the DB-backed shape.
+
+`foreign_investment_rates` is also read by `app/api/foreign-investment/rates/route.ts` (a public JSON API). That endpoint is **independent** of the renderer choice and stays regardless.
+
+## 2. Migration plan — three options
+
+### Option A: Config canonical, retire DB renderer
+
+- **Code:** Delete `app/foreign-investment/[country]/page.tsx`.
+- **Data:** Mark `country_investment_profiles` rows for the 12 supported codes `active = false`. Leave the table; `foreign_investment_rates` stays for the JSON API.
+- **Editing flow:** Country copy edits go via PR to `lib/foreign-investment-country-data.ts`. Same flow Phase 1+2 used.
+- **Cost:** ~540 lines of JSX deleted. Zero data migration. Zero admin-UI rebuild.
+
+### Option B: DB canonical, port configs into rows
+
+- **Code:** Delete the 12 standalone routes. Expand the dynamic route to render every section in `CountryConfig`.
+- **Data:** Schema-evolve `country_investment_profiles` to hold every `CountryConfig` field (mostly JSONB blobs). Write a port script. ~12 rows × ~600 lines JSON each.
+- **Editing flow:** Build admin UI for editing 600-line JSON blob per country. Or accept Studio-only editing.
+- **Cost:** Big. Admin UI, schema migration, port script, regression tests, validation layer.
+
+### Option C: Hybrid — DB write, config read
+
+- **Code:** Same 12 standalone routes + `CountryHubTemplate`. Add cron / build-step that snapshots DB into a generated `lib/foreign-investment-country-data.generated.ts`.
+- **Data:** Same as Option B (DB holds everything). Plus generated file in git.
+- **Cost:** Schema migration + admin UI + generation script + cache-invalidation story.
+
+## 3. Recommendation
+
+**Option A. Retire the DB-backed renderer.**
+
+Reasoning, in order of weight:
+
+1. **No editor workflow exists today** that we'd be breaking (§1d). The "DB lets non-engineers edit copy" upside in B/C is hypothetical. We'd be paying real engineering cost (admin UI, JSON schema management, validation, migration) for an unconfirmed user.
+2. **The DB renderer is already unreachable** (§1c). Option A is closer to "delete dead code" than to "migrate".
+3. **Phase 1+2 already shipped 12 countries via the config path** with zero issues. The pattern is proven.
+4. **Type safety**: `CountryConfig` is strongly typed end-to-end. JSONB-in-DB sacrifices that for runtime Zod validation, a clear regression on a strict-TS codebase.
+5. **Git history wins on compliance copy** (DTA rates, FIRB thresholds, WHT %s). `git blame` gives audit trail; a Supabase `updated_at` column does not.
+6. **Reversibility**: if a Marketing-driven CMS need emerges in 6 months, we can move to C from A more cheaply than from B.
+
+Counter-arguments considered:
+- *"What if Marketing asks tomorrow?"* — Then we revisit. YAGNI-style we don't preempt.
+- *"`country_investment_profiles` already has rows we'd waste."* — Salvageable for a future admin UI; we just stop reading from the renderer.
+- *"Are we sure no admin uses the DB rows?"* — Verified §1d. If an undiscovered consumer surfaces, restore from `active = false` flag rather than full delete.
+
+## 4. Concrete next steps
+
+1. **Audit consumers.** `grep -rn "country_investment_profiles" app lib scripts` once more pre-merge — confirm no admin/cron/script reads. Document in PR description.
+2. **Delete the dynamic route.** Remove `app/foreign-investment/[country]/page.tsx`. Run `npm run type-check && npm run build` — confirm no broken imports.
+3. **Sweep links to the dynamic route.** Grep `/foreign-investment/[country]` and any hard-coded slug-builder; redirect targets should already point to standalone slugs.
+4. **Add unit test.** `__tests__/app/foreign-investment-routes.test.ts`: assert the 12 expected slugs all resolve and that an un-mapped slug `germany` returns 404.
+5. **Migration: deactivate stale rows.** New migration `<ts>_deactivate_legacy_country_investment_profiles.sql`: `UPDATE country_investment_profiles SET active = false WHERE country_code IN (...12 codes...)`. Idempotent.
+6. **Land Phase 4 schema migration.** `20260508120000_add_country_eligibility_to_brokers_and_professionals.sql` (separate deliverable, in this RFC pair).
+7. **Wire renderer to country_eligibility.** In `CountryHubTemplate` and `/best/[slug]`, filter broker/advisor lists by the visitor's `IntentCountryCode` against `country_eligibility.allowed_countries` / `blocked_countries`.
+8. **Update docs.** `docs/architecture/country-mode.md` — note the renderer is config-only; `country_investment_profiles` is preserved-but-deactivated; per-broker eligibility now lives on `brokers.country_eligibility` + `professionals.country_eligibility`.
+9. **Update CLAUDE.md "Single sources of truth" table** — country-mode entry already references `lib/country-mode/` + `lib/intent-context.ts`; add `lib/foreign-investment-country-data.ts`.
+10. **Post-merge observation window** (Tier B per `docs/audits/MERGE_AUTHORIZATION.md`): 15-minute watch on Vercel logs + Sentry for any 500s on `/foreign-investment/*`.

--- a/supabase/migrations/20260508120000_add_country_eligibility_to_brokers_and_professionals.sql
+++ b/supabase/migrations/20260508120000_add_country_eligibility_to_brokers_and_professionals.sql
@@ -1,0 +1,87 @@
+-- Country Mode Phase 4: country eligibility on brokers + professionals.
+--
+-- Adds a JSONB `country_eligibility` column to both tables capturing which
+-- ISO 3166-1 alpha-2 countries the broker/advisor accepts, blocks, or
+-- requires a visa for. Phase 1 + 2 already shipped country configs at the
+-- 12-country level; this column is the per-broker / per-advisor refinement
+-- so /best/[slug] and the advisor directory can filter by the visitor's
+-- detected country (priority chain in lib/country-mode/).
+--
+-- Shape (validated by CHECK constraint):
+--   {
+--     "allowed_countries": ["GB", "HK", "SG"],   -- explicit accept list
+--     "blocked_countries": ["US"],                -- explicit reject list
+--     "visa_required":     ["CN"],                -- visa/residency gated
+--     "verified_at": "2026-05-08T00:00:00Z",     -- when last verified
+--     "notes": null                              -- optional free-form
+--   }
+--
+-- Empty `{}` is the default and means "no eligibility metadata yet — fall
+-- back to AU-only assumption upstream". Country code arrays must be ISO
+-- 3166-1 alpha-2 (two uppercase letters); the CHECK constraint enforces
+-- shape, not the values themselves (catalogue lives in
+-- lib/intent-context.ts).
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS, DROP/ADD CONSTRAINT guarded.
+-- Safe to re-run.
+--
+-- RLS: brokers + professionals already have anon SELECT policies; the new
+-- column is picked up automatically. No new policies needed.
+--
+-- ROLLBACK STRATEGY (forward-only in prod, but for staging / local):
+--   ALTER TABLE brokers       DROP CONSTRAINT IF EXISTS brokers_country_eligibility_shape_check;
+--   ALTER TABLE professionals DROP CONSTRAINT IF EXISTS professionals_country_eligibility_shape_check;
+--   DROP INDEX IF EXISTS idx_brokers_country_eligibility;
+--   DROP INDEX IF EXISTS idx_professionals_country_eligibility;
+--   ALTER TABLE brokers       DROP COLUMN IF EXISTS country_eligibility;
+--   ALTER TABLE professionals DROP COLUMN IF EXISTS country_eligibility;
+-- Risk: any code path reading .country_eligibility 500s. Grep before drop.
+
+-- ── brokers ──────────────────────────────────────────────────────────
+ALTER TABLE brokers
+  ADD COLUMN IF NOT EXISTS country_eligibility JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+ALTER TABLE brokers
+  DROP CONSTRAINT IF EXISTS brokers_country_eligibility_shape_check;
+
+ALTER TABLE brokers
+  ADD CONSTRAINT brokers_country_eligibility_shape_check CHECK (
+    jsonb_typeof(country_eligibility) = 'object'
+    AND (NOT country_eligibility ? 'allowed_countries' OR jsonb_typeof(country_eligibility->'allowed_countries') = 'array')
+    AND (NOT country_eligibility ? 'blocked_countries' OR jsonb_typeof(country_eligibility->'blocked_countries') = 'array')
+    AND (NOT country_eligibility ? 'visa_required'     OR jsonb_typeof(country_eligibility->'visa_required')     = 'array')
+    AND (NOT country_eligibility ? 'verified_at'       OR jsonb_typeof(country_eligibility->'verified_at')       = 'string')
+    AND (NOT country_eligibility ? 'notes'             OR jsonb_typeof(country_eligibility->'notes') IN ('string', 'null'))
+  );
+
+-- GIN index so `country_eligibility @> '{"allowed_countries":["GB"]}'` and
+-- `country_eligibility ? 'blocked_countries'` filters stay sub-millisecond
+-- once the broker table grows.
+CREATE INDEX IF NOT EXISTS idx_brokers_country_eligibility
+  ON brokers USING GIN (country_eligibility);
+
+COMMENT ON COLUMN brokers.country_eligibility IS
+  'Country Mode Phase 4. JSONB: { allowed_countries: ISO-alpha-2[], blocked_countries: ISO-alpha-2[], visa_required: ISO-alpha-2[], verified_at: ISO-8601 string, notes: string|null }. Empty {} means "unverified — assume AU-resident only". See docs/architecture/country-mode.md and lib/country-mode/.';
+
+-- ── professionals ────────────────────────────────────────────────────
+ALTER TABLE professionals
+  ADD COLUMN IF NOT EXISTS country_eligibility JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+ALTER TABLE professionals
+  DROP CONSTRAINT IF EXISTS professionals_country_eligibility_shape_check;
+
+ALTER TABLE professionals
+  ADD CONSTRAINT professionals_country_eligibility_shape_check CHECK (
+    jsonb_typeof(country_eligibility) = 'object'
+    AND (NOT country_eligibility ? 'allowed_countries' OR jsonb_typeof(country_eligibility->'allowed_countries') = 'array')
+    AND (NOT country_eligibility ? 'blocked_countries' OR jsonb_typeof(country_eligibility->'blocked_countries') = 'array')
+    AND (NOT country_eligibility ? 'visa_required'     OR jsonb_typeof(country_eligibility->'visa_required')     = 'array')
+    AND (NOT country_eligibility ? 'verified_at'       OR jsonb_typeof(country_eligibility->'verified_at')       = 'string')
+    AND (NOT country_eligibility ? 'notes'             OR jsonb_typeof(country_eligibility->'notes') IN ('string', 'null'))
+  );
+
+CREATE INDEX IF NOT EXISTS idx_professionals_country_eligibility
+  ON professionals USING GIN (country_eligibility);
+
+COMMENT ON COLUMN professionals.country_eligibility IS
+  'Country Mode Phase 4. JSONB: { allowed_countries: ISO-alpha-2[], blocked_countries: ISO-alpha-2[], visa_required: ISO-alpha-2[], verified_at: ISO-8601 string, notes: string|null }. Empty {} means unverified — fall back to existing acceptance flags. See docs/architecture/country-mode.md.';


### PR DESCRIPTION
## Summary
Two Phase 4 deliverables:

1. **Schema migration** — adds `country_eligibility JSONB` to `brokers` and `professionals` (per the user-committed JSONB-with-restrictions-object decision over TEXT[]). Shape: `{ allowed_countries, blocked_countries, visa_required, verified_at, notes }`. CHECK constraint validates the object shape; GIN index for fast containment queries. Default `{}`.
2. **RFC** — `docs/rfcs/2026-05-08-country-mode-renderer-unification.md` proposes Option A (retire the DB-backed `[country]` route, deactivate stale `country_investment_profiles` rows). Verified no admin tooling reads the table today.

## Tier C announcement
This adds new schema columns. Per `docs/audits/MERGE_AUTHORIZATION.md` Tier C, announcing intent here. No `STOP` from review = proceed to merge.

## Out of scope
The RFC's 10-step renderer-unification plan executes in a follow-up PR. This PR ships the migration + the RFC document only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)