### PR TITLE
feat(advisors): AI concierge CTAs + richer advisor embeddings

### DIFF
--- a/__tests__/api/cron-embeddings-refresh.test.ts
+++ b/__tests__/api/cron-embeddings-refresh.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+
+import { buildAdvisorEmbedText } from "@/app/api/cron/embeddings-refresh/route";
+
+describe("buildAdvisorEmbedText", () => {
+  it("returns name + firm + bio for a minimal row", () => {
+    const out = buildAdvisorEmbedText({
+      name: "Jane Smith",
+      firm_name: "Smith Wealth",
+      bio: "20 years advising Sydney professionals.",
+    });
+    expect(out).toContain("Jane Smith");
+    expect(out).toContain("Smith Wealth");
+    expect(out).toContain("20 years advising Sydney professionals.");
+  });
+
+  it("includes specialties, qualifications, languages from jsonb arrays", () => {
+    const out = buildAdvisorEmbedText({
+      name: "Test Advisor",
+      specialties: ["SMSF", "Retirement Planning"],
+      qualifications: ["CFP", "Diploma of Financial Planning"],
+      languages: ["English", "Mandarin"],
+    });
+    expect(out).toContain("Specialties: SMSF, Retirement Planning");
+    expect(out).toContain("Qualifications: CFP, Diploma of Financial Planning");
+    expect(out).toContain("Languages: English, Mandarin");
+  });
+
+  it("handles jsonb arrays of {label} objects", () => {
+    const out = buildAdvisorEmbedText({
+      name: "Test",
+      specialties: [{ label: "FATCA-Aware US Expat Planning" }, { label: "DASP Processing" }],
+    });
+    expect(out).toContain("FATCA-Aware US Expat Planning");
+    expect(out).toContain("DASP Processing");
+  });
+
+  it("includes fees, location, ideal_client, years_experience", () => {
+    const out = buildAdvisorEmbedText({
+      name: "Test",
+      fee_structure: "flat-fee",
+      fee_description: "$2,500 initial + $1,200/yr ongoing",
+      location_display: "Brisbane, QLD",
+      ideal_client: "Pre-retiree with $500k+ super balance",
+      years_experience: 15,
+    });
+    expect(out).toContain("Fees: flat-fee — $2,500 initial + $1,200/yr ongoing");
+    expect(out).toContain("Location: Brisbane, QLD");
+    expect(out).toContain("Ideal client: Pre-retiree with $500k+ super balance");
+    expect(out).toContain("Experience: 15 years");
+  });
+
+  it("normalises type underscores to spaces", () => {
+    const out = buildAdvisorEmbedText({ name: "Test", type: "private_wealth_manager" });
+    expect(out).toContain("private wealth manager");
+    expect(out).not.toContain("private_wealth_manager");
+  });
+
+  it("skips empty / null fields gracefully", () => {
+    const out = buildAdvisorEmbedText({
+      name: "Test",
+      firm_name: null,
+      bio: "",
+      specialties: null as unknown,
+      qualifications: undefined,
+      fee_structure: null,
+      fee_description: null,
+      location_display: null,
+      ideal_client: "",
+      years_experience: 0,
+    });
+    expect(out).toBe("Test");
+  });
+
+  it("caps output at 8000 chars to bound token cost", () => {
+    const out = buildAdvisorEmbedText({
+      name: "Test",
+      bio: "x".repeat(20_000),
+    });
+    expect(out.length).toBeLessThanOrEqual(8000);
+  });
+
+  it("a query-shaped string about a Brisbane SMSF flat-fee advisor would now hit on those tokens", () => {
+    // Sanity: the keywords a user would type are present in the chunk.
+    const out = buildAdvisorEmbedText({
+      name: "Casey Lin",
+      type: "financial_planner",
+      bio: "Helping SMSF trustees navigate compliance.",
+      specialties: ["SMSF strategy", "Pension transfer"],
+      languages: ["English", "Mandarin"],
+      fee_structure: "flat-fee",
+      location_display: "Brisbane, QLD",
+    });
+    for (const token of ["Brisbane", "SMSF", "flat-fee", "Mandarin", "financial planner"]) {
+      expect(out.toLowerCase()).toContain(token.toLowerCase());
+    }
+  });
+});

--- a/app/advisors/AdvisorsClient.tsx
+++ b/app/advisors/AdvisorsClient.tsx
@@ -54,6 +54,13 @@ const SORT_OPTIONS: { key: SortKey; label: string }[] = [
 
 const RESULTS_PER_PAGE = 12;
 
+// Seed prompt sent to /api/concierge when a user clicks the
+// "Ask the AI concierge" CTA. Kept educational (avoids personal-advice
+// triggers) and short enough to satisfy the concierge's 200-char seed
+// cap. Same string is used on /advisors/search for consistency.
+const ADVISOR_FINDER_SEED =
+  "I'm thinking about hiring a financial advisor. What should I look for, and what questions should I ask?";
+
 function formatCents(cents: number): string {
   return `$${(cents / 100).toLocaleString("en-AU", { maximumFractionDigits: 0 })}`;
 }
@@ -471,6 +478,13 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
             >
               Get matched
               <Icon name="arrow-right" size={14} />
+            </Link>
+            <Link
+              href={`/concierge?seed=${encodeURIComponent(ADVISOR_FINDER_SEED)}`}
+              className="inline-flex items-center gap-1.5 bg-white hover:bg-slate-50 border border-slate-300 text-slate-700 hover:text-slate-900 font-bold text-xs md:text-sm px-4 py-2 rounded-full transition-colors shadow-sm"
+            >
+              <Icon name="message-circle" size={14} />
+              Ask the AI concierge
             </Link>
             <div className="flex items-center gap-2 px-3 py-1.5 bg-white border border-slate-200 rounded-full shadow-sm text-[0.65rem] md:text-xs font-semibold text-slate-700">
               <span className="w-1.5 h-1.5 bg-emerald-500 rounded-full animate-pulse" />

--- a/app/advisors/compare/AdvisorCompareClient.tsx
+++ b/app/advisors/compare/AdvisorCompareClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
+import { useSearchParams, useRouter, usePathname } from "next/navigation";
 import Link from "next/link";
 import Image from "next/image";
 import { useAdvisorShortlist } from "@/lib/hooks/useAdvisorShortlist";
@@ -140,10 +141,38 @@ const COMPARE_ROWS: { label: string; render: (a: AdvisorData) => React.ReactNode
   },
 ];
 
+// Slug shape: lowercase letters, digits, hyphens. Reject anything else
+// so a crafted ?add=… URL can't inject arbitrary text into the
+// shortlist (which is rendered/used as part of API URLs downstream).
+const SLUG_RE = /^[a-z0-9][a-z0-9-]{0,80}$/;
+
 export default function AdvisorCompareClient() {
-  const { slugs, toggle, clear } = useAdvisorShortlist();
+  const { slugs, toggle, clear, has } = useAdvisorShortlist();
   const [advisors, setAdvisors] = useState<AdvisorData[]>([]);
   const [loading, setLoading] = useState(true);
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+  const addHandledRef = useRef(false);
+
+  // Deep-link support: /advisors/compare?add=<slug> auto-toggles the
+  // slug into the shortlist and strips the param from the URL. Lets
+  // the AI concierge, marketing emails, or partner sites populate the
+  // compare matrix in one click. Idempotent — re-clicking the link
+  // doesn't double-toggle thanks to addHandledRef + has().
+  useEffect(() => {
+    if (addHandledRef.current) return;
+    const raw = searchParams?.get("add")?.trim().toLowerCase() ?? "";
+    if (!raw) return;
+    addHandledRef.current = true;
+    if (SLUG_RE.test(raw) && !has(raw)) {
+      toggle(raw);
+    }
+    // Strip the param so refresh / share doesn't re-toggle.
+    router.replace(pathname ?? "/advisors/compare", { scroll: false });
+    // toggle/has change identity on every render; guarded by ref.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams, pathname, router]);
 
   useEffect(() => {
     if (slugs.length === 0) {

--- a/app/advisors/search/AdvisorSearchClient.tsx
+++ b/app/advisors/search/AdvisorSearchClient.tsx
@@ -230,9 +230,17 @@ export default function AdvisorSearchClient({ initialAdvisors }: Props) {
         </nav>
 
         <div className="mb-6">
-          <h1 className="text-2xl md:text-3xl font-extrabold text-slate-900 mb-1">
-            Advanced Advisor Search
-          </h1>
+          <div className="flex items-start justify-between gap-3 flex-wrap mb-1">
+            <h1 className="text-2xl md:text-3xl font-extrabold text-slate-900">
+              Advanced Advisor Search
+            </h1>
+            <Link
+              href={`/concierge?seed=${encodeURIComponent("I'm thinking about hiring a financial advisor. What should I look for, and what questions should I ask?")}`}
+              className="inline-flex items-center gap-1.5 bg-white hover:bg-slate-50 border border-slate-300 text-slate-700 hover:text-slate-900 font-bold text-xs md:text-sm px-3 py-1.5 rounded-full transition-colors shadow-sm shrink-0"
+            >
+              Not sure what to look for? Ask the AI →
+            </Link>
+          </div>
           <p className="text-sm text-slate-600">
             Filter ASIC-registered Australian advisors by specialty, location,
             language, availability and international-client status.{" "}

--- a/app/api/cron/embeddings-refresh/route.ts
+++ b/app/api/cron/embeddings-refresh/route.ts
@@ -85,9 +85,17 @@ async function handler(req: NextRequest) {
   stats.brokers = await upsertEmbeddings(supabase, brokerInputs);
 
   // ── Advisors ──
+  // Embed text intentionally pulls in specialties / qualifications /
+  // fee / location / languages / ideal_client / years_experience as
+  // well as bio. Queries like "Brisbane SMSF flat-fee Mandarin" will
+  // miss against name+firm+bio alone — almost none of those words
+  // live in `bio`. Same number of embed calls; embed cost barely
+  // moves (advisors only re-embed when source_updated_at advances).
   const { data: advisors } = await supabase
     .from("professionals")
-    .select("id, slug, name, firm_name, bio, updated_at")
+    .select(
+      "id, slug, name, firm_name, type, bio, specialties, qualifications, languages, fee_structure, fee_description, location_display, ideal_client, years_experience, updated_at",
+    )
     .eq("status", "active")
     .order("updated_at", { ascending: false })
     .limit(EMBED_BATCH_LIMIT);
@@ -98,7 +106,7 @@ async function handler(req: NextRequest) {
     title: `${a.name}${a.firm_name ? " — " + a.firm_name : ""}`,
     body_excerpt: ((a.bio as string) || "").slice(0, 500),
     source_updated_at: a.updated_at as string,
-    embed_text: `${a.name}\n${a.firm_name || ""}\n\n${(a.bio as string) || ""}`,
+    embed_text: buildAdvisorEmbedText(a as AdvisorRow),
   }));
   stats.advisors = await upsertEmbeddings(supabase, advisorInputs);
 
@@ -107,6 +115,70 @@ async function handler(req: NextRequest) {
 }
 
 type AdminClient = ReturnType<typeof createAdminClient>;
+
+export interface AdvisorRow {
+  name?: string | null;
+  firm_name?: string | null;
+  type?: string | null;
+  bio?: string | null;
+  specialties?: unknown;
+  qualifications?: unknown;
+  languages?: unknown;
+  fee_structure?: string | null;
+  fee_description?: string | null;
+  location_display?: string | null;
+  ideal_client?: string | null;
+  years_experience?: number | null;
+}
+
+function jsonbToStrings(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((v) => (typeof v === "string" ? v : typeof v === "object" && v && "label" in v ? String((v as { label: unknown }).label) : ""))
+    .filter((s) => s.trim().length > 0);
+}
+
+/**
+ * Builds the embedding chunk for an advisor row. Pure, exported for
+ * tests. Includes structured signals (specialties, qualifications,
+ * fees, location, languages, ideal client, years of experience) so
+ * RAG queries that mention those concepts actually hit.
+ */
+export function buildAdvisorEmbedText(a: AdvisorRow): string {
+  const lines: string[] = [];
+  if (a.name) lines.push(a.name);
+  if (a.firm_name) lines.push(a.firm_name);
+  if (a.type) lines.push(a.type.replace(/_/g, " "));
+  if (a.bio && a.bio.trim().length > 0) lines.push("", a.bio.trim());
+
+  const specialties = jsonbToStrings(a.specialties);
+  if (specialties.length > 0) lines.push(`Specialties: ${specialties.join(", ")}`);
+
+  const qualifications = jsonbToStrings(a.qualifications);
+  if (qualifications.length > 0) lines.push(`Qualifications: ${qualifications.join(", ")}`);
+
+  const languages = jsonbToStrings(a.languages);
+  if (languages.length > 0) lines.push(`Languages: ${languages.join(", ")}`);
+
+  const feeBits: string[] = [];
+  if (a.fee_structure) feeBits.push(a.fee_structure);
+  if (a.fee_description) feeBits.push(a.fee_description);
+  if (feeBits.length > 0) lines.push(`Fees: ${feeBits.join(" — ")}`);
+
+  if (a.location_display) lines.push(`Location: ${a.location_display}`);
+
+  if (a.ideal_client && a.ideal_client.trim().length > 0) {
+    lines.push(`Ideal client: ${a.ideal_client.trim()}`);
+  }
+
+  if (typeof a.years_experience === "number" && a.years_experience > 0) {
+    lines.push(`Experience: ${a.years_experience} years`);
+  }
+
+  // Cap at 8000 chars to match embedText's truncation, keeps token
+  // cost predictable even if some advisor has a wall-of-text bio.
+  return lines.join("\n").slice(0, 8000);
+}
 
 interface EmbeddingInput {
   document_type: string;

--- a/app/concierge/ConciergeClient.tsx
+++ b/app/concierge/ConciergeClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import Icon from "@/components/Icon";
 
@@ -64,6 +65,11 @@ function renderContent(content: string): React.ReactNode {
   return parts;
 }
 
+// Seed-param length cap. Long enough for any reasonable starter,
+// short enough that a malicious URL can't ship a full prompt-injection
+// payload. The /api/concierge route still rate-limits + cost-caps.
+const SEED_MAX_LEN = 200;
+
 export default function ConciergeClient() {
   const [sessionId, setSessionId] = useState<string | null>(null);
   const [messages, setMessages] = useState<Message[]>([]);
@@ -74,6 +80,8 @@ export default function ConciergeClient() {
   const bottomRef = useRef<HTMLDivElement | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const abortRef = useRef<AbortController | null>(null);
+  const searchParams = useSearchParams();
+  const seedFiredRef = useRef(false);
 
   // Restore session id on mount and fetch stored history.
   useEffect(() => {
@@ -235,6 +243,23 @@ export default function ConciergeClient() {
   const stopStream = useCallback(() => {
     abortRef.current?.abort();
   }, []);
+
+  // Auto-fire a seed prompt from the URL (?seed=…) on first mount,
+  // but only when starting fresh. Skipped if a stored session is
+  // hydrating or any messages already exist. Length-capped to bound
+  // any abuse vector — the route also rate-limits + cost-caps.
+  useEffect(() => {
+    if (seedFiredRef.current) return;
+    if (hydrating) return;
+    if (messages.length > 0) return;
+    const seed = searchParams?.get("seed")?.trim() ?? "";
+    if (!seed || seed.length > SEED_MAX_LEN) return;
+    seedFiredRef.current = true;
+    void send(seed);
+    // Intentionally omit `send` from deps — it changes when streaming
+    // flips, and seedFiredRef already guards against double-fire.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hydrating, messages.length, searchParams]);
 
   const clearSession = useCallback(async () => {
     if (streaming) return;

--- a/app/concierge/page.tsx
+++ b/app/concierge/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { Suspense } from "react";
 import { absoluteUrl, breadcrumbJsonLd, CURRENT_YEAR, SITE_NAME } from "@/lib/seo";
 import ComplianceFooter from "@/components/ComplianceFooter";
 import ConciergeClient from "./ConciergeClient";
@@ -45,7 +46,9 @@ export default function ConciergePage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(applicationLd) }}
       />
-      <ConciergeClient />
+      <Suspense fallback={null}>
+        <ConciergeClient />
+      </Suspense>
       <div className="container-custom pb-8 pt-2">
         <ComplianceFooter variant="default" />
       </div>

--- a/e2e/advisor-ai-cta.spec.ts
+++ b/e2e/advisor-ai-cta.spec.ts
@@ -1,0 +1,167 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Smoke checks for the cheap-now AI advisor surface shipped 2026-05-08:
+ *   1. /advisors hero has the "Ask the AI concierge" CTA → /concierge?seed=…
+ *   2. /advisors/search header has the same CTA shape
+ *   3. /concierge?seed=<text> auto-fires a POST /api/concierge with that text
+ *   4. /concierge?seed=… does NOT auto-fire when a stored session is hydrating
+ *   5. /advisors/compare?add=<slug> toggles the slug into the shortlist and
+ *      strips the ?add= param from the URL
+ *
+ * /api/concierge is intercepted in tests 3 + 4 so we never make a real
+ * Claude call (zero added inference cost).
+ */
+
+const SEED_TEXT =
+  "I'm thinking about hiring a financial advisor. What should I look for, and what questions should I ask?";
+
+function mockConciergeStream(sessionId = "test-session-1234") {
+  // Minimal SSE stream that satisfies ConciergeClient's parser.
+  return [
+    `data: ${JSON.stringify({ type: "session", session_id: sessionId })}\n\n`,
+    `data: ${JSON.stringify({ type: "delta", text: "Mock concierge reply." })}\n\n`,
+    `data: ${JSON.stringify({ type: "done", tokens_in: 0, tokens_out: 0 })}\n\n`,
+  ].join("");
+}
+
+test.describe("Advisor AI surface — cheap-now plan", () => {
+  test("/advisors hero shows the AI concierge CTA pointing to /concierge?seed=…", async ({ page }) => {
+    await page.goto("/advisors");
+    const cta = page.getByRole("link", { name: /Ask the AI concierge/i });
+    await expect(cta).toBeVisible();
+    const href = await cta.getAttribute("href");
+    expect(href).toContain("/concierge?seed=");
+    expect(decodeURIComponent(href ?? "")).toContain("hiring a financial advisor");
+  });
+
+  test("/advisors/search header shows the AI CTA", async ({ page }) => {
+    await page.goto("/advisors/search");
+    const cta = page.getByRole("link", { name: /Ask the AI/i });
+    await expect(cta).toBeVisible();
+    const href = await cta.getAttribute("href");
+    expect(href).toContain("/concierge?seed=");
+  });
+
+  test("/concierge?seed=… auto-fires a POST /api/concierge with the seed text", async ({ page }) => {
+    let capturedRequestBody: unknown = null;
+
+    await page.route("**/api/concierge", async (route, request) => {
+      if (request.method() === "POST") {
+        try {
+          capturedRequestBody = JSON.parse(request.postData() ?? "{}");
+        } catch {
+          capturedRequestBody = { __parseError: true };
+        }
+        await route.fulfill({
+          status: 200,
+          contentType: "text/event-stream; charset=utf-8",
+          body: mockConciergeStream(),
+        });
+        return;
+      }
+      // GET (history) — return empty list so we count as a fresh start.
+      await route.fulfill({ status: 200, contentType: "application/json", body: '{"messages":[]}' });
+    });
+
+    await page.goto(`/concierge?seed=${encodeURIComponent(SEED_TEXT)}`);
+
+    await expect(page.locator("text=Mock concierge reply.")).toBeVisible({ timeout: 10_000 });
+
+    expect(capturedRequestBody).not.toBeNull();
+    const body = capturedRequestBody as { message?: string };
+    expect(body.message).toBe(SEED_TEXT);
+  });
+
+  test("/concierge?seed=… does NOT auto-fire when a stored session is hydrating", async ({ page, context }) => {
+    let postCount = 0;
+    await context.addInitScript(() => {
+      try {
+        localStorage.setItem("ic_concierge_session_v1", "stored-sess-abcdef");
+      } catch {
+        /* ignore */
+      }
+    });
+
+    await page.route("**/api/concierge**", async (route, request) => {
+      const url = new URL(request.url());
+      if (request.method() === "GET" && url.searchParams.get("session_id")) {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            messages: [
+              { role: "user", content: "Earlier question" },
+              { role: "assistant", content: "Earlier answer" },
+            ],
+          }),
+        });
+        return;
+      }
+      if (request.method() === "POST") {
+        postCount += 1;
+        await route.fulfill({
+          status: 200,
+          contentType: "text/event-stream; charset=utf-8",
+          body: mockConciergeStream(),
+        });
+        return;
+      }
+      await route.fulfill({ status: 200, body: "" });
+    });
+
+    await page.goto(`/concierge?seed=${encodeURIComponent(SEED_TEXT)}`);
+
+    // Wait until prior history has rendered.
+    await expect(page.locator("text=Earlier answer")).toBeVisible({ timeout: 10_000 });
+    // Give the seed effect a chance to NOT fire.
+    await page.waitForTimeout(800);
+
+    expect(postCount).toBe(0);
+  });
+
+  test("/advisors/compare?add=<slug> toggles slug into shortlist and strips the param", async ({ page }) => {
+    // Stub /api/advisor-compare so the page renders an advisor card without
+    // needing real DB content. The deep-link logic runs purely client-side.
+    await page.route("**/api/advisor-compare**", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          advisors: [
+            {
+              id: 1,
+              slug: "acme-financial-planning",
+              name: "Acme Financial Planning",
+              firm_name: "Acme Wealth",
+              type: "financial_planner",
+              rating: 4.8,
+              review_count: 12,
+              verified: true,
+              specialties: ["SMSF"],
+            },
+          ],
+        }),
+      });
+    });
+
+    await page.goto("/advisors/compare?add=acme-financial-planning");
+
+    // URL should be cleaned up.
+    await expect.poll(() => new URL(page.url()).searchParams.get("add"), { timeout: 5_000 }).toBeNull();
+
+    // localStorage shortlist should contain the slug.
+    const slugs = await page.evaluate(() => {
+      try {
+        const raw = localStorage.getItem("invest_advisor_shortlist");
+        return raw ? (JSON.parse(raw) as string[]) : [];
+      } catch {
+        return [];
+      }
+    });
+    expect(slugs).toContain("acme-financial-planning");
+
+    // Compare card should render.
+    await expect(page.locator("text=Acme Financial Planning")).toBeVisible({ timeout: 10_000 });
+  });
+});


### PR DESCRIPTION
## Summary

Cheap-now wins ahead of the post-launch advisor-matchmaker build (deferred on cost grounds — a Claude-rerank matchmaker adds per-session inference, this PR doesn't).

- **Embedding cron now embeds the structured signals**, not just bio. `app/api/cron/embeddings-refresh/route.ts` adds specialties, qualifications, fees, location, languages, ideal_client and years_experience to the chunk via a new pure helper `buildAdvisorEmbedText`. Same number of embed calls; queries like "Brisbane SMSF flat-fee Mandarin" stop missing because none of those tokens previously lived in `bio`.
- **"Ask the AI concierge" CTAs** on `/advisors` and `/advisors/search` deep-link to `/concierge?seed=<starter>`. ConciergeClient auto-fires the seed once on first mount, length-capped (200 chars), guarded against a hydrated session and double-fire. Uses the existing concierge Claude budget — no new endpoint, no new infra cost.
- **`/advisors/compare?add=<slug>` deep-link** auto-toggles a slug into the saved shortlist and strips the param. Composable for the future matchmaker, partner links, and marketing emails. Slug regex-validated.

## Test plan

- [x] `tsc --noEmit` clean (pre-push hook)
- [x] 62 tests green across cron, embeddings, advisor-compare API, advisor-search API, concierge API
- [x] 8 new unit tests for `buildAdvisorEmbedText` (jsonb shapes, fees/location/years, length cap, sanity check that "Brisbane SMSF flat-fee Mandarin" tokens land in the chunk)
- [x] ESLint `--max-warnings 0` clean on every touched file (lint-staged ran on commit)
- [x] Dev server SSR ships both CTAs with correctly URL-encoded `/concierge?seed=…` hrefs
- [ ] Playwright smoke spec at `e2e/advisor-ai-cta.spec.ts` runs in CI — covers the four runtime behaviours (CTAs visible, seed auto-fire, hydrated-session no-fire, ?add=<slug> deep-link toggle + URL cleanup). Mocks `/api/concierge` so it makes no real Claude call.
- [ ] Manual click-through on `/advisors`, `/advisors/search`, `/concierge?seed=…`, `/advisors/compare?add=any-slug`

## Out of scope (post-launch backlog)

Full Claude-rerank matchmaker: structured intake → vector search → top-3 with AI-written rationale → lead-billing hookup, plus `review_sentiment_facets` backfill (currently 0 rows). Trigger to revisit: launch + measurable advisor-search traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)