### PR TITLE
feat(country-mode): wire country_listing_click + country_expert_click

### DIFF
--- a/__tests__/components/TrackedCountryLink.test.tsx
+++ b/__tests__/components/TrackedCountryLink.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * Unit tests for TrackedCountryLink — the client wrapper that fires a
+ * Country Mode trackEvent on click before delegating navigation to
+ * next/link. Tracking must be fire-and-forget; failures must not block
+ * navigation or shadow a user-supplied onClick.
+ *
+ * Note: __tests__/components/setup.tsx mocks @/lib/tracking globally
+ * (trackEvent is replaced with vi.fn()). We grab that mock via
+ * vi.mocked rather than redeclaring vi.mock here, which would conflict.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, userEvent } from "./setup";
+import { trackEvent } from "@/lib/tracking";
+import TrackedCountryLink from "@/components/country-mode/TrackedCountryLink";
+
+const mockTrackEvent = vi.mocked(trackEvent);
+
+describe("TrackedCountryLink", () => {
+  beforeEach(() => {
+    mockTrackEvent.mockReset();
+  });
+
+  it("renders a link with the supplied href and children", () => {
+    render(
+      <TrackedCountryLink href="/advisors/jane-doe" eventType="country_expert_click">
+        Jane Doe
+      </TrackedCountryLink>,
+    );
+    const link = screen.getByRole("link", { name: "Jane Doe" });
+    expect(link).toBeInTheDocument();
+    expect(link.getAttribute("href")).toBe("/advisors/jane-doe");
+  });
+
+  it("fires trackEvent with eventType + eventData on click", async () => {
+    const user = userEvent.setup();
+    render(
+      <TrackedCountryLink
+        href="/invest/property/foo"
+        eventType="country_listing_click"
+        eventData={{ country: "hk", listing_slug: "foo" }}
+      >
+        click me
+      </TrackedCountryLink>,
+    );
+    await user.click(screen.getByRole("link", { name: "click me" }));
+    expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+    expect(mockTrackEvent).toHaveBeenCalledWith("country_listing_click", {
+      country: "hk",
+      listing_slug: "foo",
+    });
+  });
+
+  it("does not block navigation when trackEvent throws", async () => {
+    mockTrackEvent.mockImplementation(() => {
+      throw new Error("tracking down");
+    });
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render(
+      <TrackedCountryLink
+        href="/x"
+        eventType="country_listing_click"
+        onClick={onClick}
+      >
+        click me
+      </TrackedCountryLink>,
+    );
+    await user.click(screen.getByRole("link", { name: "click me" }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("forwards a user-supplied onClick after firing trackEvent", async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render(
+      <TrackedCountryLink
+        href="/x"
+        eventType="country_expert_click"
+        onClick={onClick}
+      >
+        click me
+      </TrackedCountryLink>,
+    );
+    await user.click(screen.getByRole("link", { name: "click me" }));
+    expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/components/country-mode/CountryExpertsPreview.tsx
+++ b/components/country-mode/CountryExpertsPreview.tsx
@@ -17,6 +17,7 @@ import {
   getHomepageFiltersForCountry,
 } from "@/lib/country-mode";
 import { createClient } from "@/lib/supabase/server";
+import TrackedCountryLink from "@/components/country-mode/TrackedCountryLink";
 
 interface PreviewExpert {
   slug: string;
@@ -88,8 +89,15 @@ export default async function CountryExpertsPreview() {
         <ul className="grid grid-cols-2 lg:grid-cols-4 gap-3">
           {visible.map((e) => (
             <li key={e.slug}>
-              <Link
+              <TrackedCountryLink
                 href={`/advisors/${e.slug}`}
+                eventType="country_expert_click"
+                eventData={{
+                  country: code,
+                  expert_slug: e.slug,
+                  expert_type: e.type,
+                  placement: "homepage_experts_preview",
+                }}
                 className="group block bg-slate-50 hover:bg-amber-50 border border-slate-200 hover:border-amber-200 rounded-xl p-3 transition-colors"
               >
                 <div className="flex items-start gap-3">
@@ -118,7 +126,7 @@ export default async function CountryExpertsPreview() {
                     )}
                   </div>
                 </div>
-              </Link>
+              </TrackedCountryLink>
             </li>
           ))}
         </ul>

--- a/components/country-mode/CountryListingsPreview.tsx
+++ b/components/country-mode/CountryListingsPreview.tsx
@@ -22,6 +22,7 @@ import {
   getHomepageFiltersForCountry,
 } from "@/lib/country-mode";
 import { createClient } from "@/lib/supabase/server";
+import TrackedCountryLink from "@/components/country-mode/TrackedCountryLink";
 
 interface PreviewListing {
   id: number;
@@ -95,8 +96,15 @@ export default async function CountryListingsPreview() {
         <ul className="grid grid-cols-2 lg:grid-cols-4 gap-3">
           {visible.map((l) => (
             <li key={l.id}>
-              <Link
+              <TrackedCountryLink
                 href={`/invest/${l.vertical}/${l.slug}`}
+                eventType="country_listing_click"
+                eventData={{
+                  country: code,
+                  listing_slug: l.slug,
+                  vertical: l.vertical,
+                  placement: "homepage_listings_preview",
+                }}
                 className="group block bg-slate-50 hover:bg-amber-50 border border-slate-200 hover:border-amber-200 rounded-xl overflow-hidden transition-colors"
               >
                 {l.hero_image && (
@@ -123,7 +131,7 @@ export default async function CountryListingsPreview() {
                     </p>
                   )}
                 </div>
-              </Link>
+              </TrackedCountryLink>
             </li>
           ))}
         </ul>

--- a/components/country-mode/TrackedCountryLink.tsx
+++ b/components/country-mode/TrackedCountryLink.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+/**
+ * Client wrapper around <Link> that fires a Country Mode trackEvent on
+ * click. Used by the homepage preview strips so we can attribute clicks
+ * to the country dimension instead of having to reconstruct from
+ * pathname + cookie on every $pageview.
+ *
+ * Tracking is fire-and-forget — failures must not block navigation.
+ */
+
+import Link, { type LinkProps } from "next/link";
+import type { AnchorHTMLAttributes, ReactNode } from "react";
+import { trackEvent } from "@/lib/tracking";
+
+type AnchorProps = Omit<AnchorHTMLAttributes<HTMLAnchorElement>, keyof LinkProps>;
+
+interface TrackedCountryLinkProps extends LinkProps, AnchorProps {
+  eventType: string;
+  eventData?: Record<string, unknown>;
+  children: ReactNode;
+}
+
+export default function TrackedCountryLink({
+  eventType,
+  eventData,
+  onClick,
+  children,
+  ...linkProps
+}: TrackedCountryLinkProps) {
+  return (
+    <Link
+      {...linkProps}
+      onClick={(event) => {
+        try {
+          trackEvent(eventType, eventData);
+        } catch {
+          // Never block navigation on a tracking failure.
+        }
+        onClick?.(event);
+      }}
+    >
+      {children}
+    </Link>
+  );
+}

--- a/docs/architecture/country-mode.md
+++ b/docs/architecture/country-mode.md
@@ -123,8 +123,18 @@ form) and extends one typed event:
 - `quiz_completed` (existing event) — extended with `country` dimension
   carrying the quiz key (e.g. `"hong_kong"`)
 
-Three click-event hooks (`country_listing_click`, `country_expert_click`,
-`country_tool_click`) are deferred to Phase 2 — easily reconstructed
+Two of the originally-deferred click-event hooks now fire from the
+homepage preview strips via `components/country-mode/TrackedCountryLink`:
+
+- `country_listing_click` — fired by `CountryListingsPreview` items.
+  `event_data: { country, listing_slug, vertical, placement }`.
+- `country_expert_click` — fired by `CountryExpertsPreview` items.
+  `event_data: { country, expert_slug, expert_type, placement }`.
+
+`country_tool_click` is still deferred — wiring it requires touching
+`HomeToolsStrip` so that featured tools (those hoisted by
+`CountryToolsStripWrapper`) fire a country-attributed event distinct
+from a default-order tool click. Easy to reconstruct in the meantime
 from `pathname` + cookie dimension on `$pageview`.
 
 ## Phase 5 language hooks (scaffolding only)


### PR DESCRIPTION
## Summary

Wires Country Mode click tracking into the two homepage preview strips that were missing it. Closes 2 of the 3 originally-deferred click-event hooks listed in `docs/architecture/country-mode.md` (the third, `country_tool_click`, needs `HomeToolsStrip` plumbing — flagged as follow-up).

- **New** `components/country-mode/TrackedCountryLink.tsx` (~40 LOC) — `"use client"` wrapper around `next/link` that calls `trackEvent(eventType, eventData)` before delegating navigation. Tracking is fire-and-forget — failures are caught so they can never block navigation, and a user-supplied `onClick` still fires.
- **Wired** into `CountryListingsPreview` (event `country_listing_click`, `event_data: { country, listing_slug, vertical, placement }`) and `CountryExpertsPreview` (event `country_expert_click`, `event_data: { country, expert_slug, expert_type, placement }`).
- **Test** `__tests__/components/TrackedCountryLink.test.tsx` (4 cases) — render, click fires `trackEvent` with the right shape, throw doesn't block navigation, user `onClick` is forwarded.
- **Doc** `docs/architecture/country-mode.md` "Tracking" section updated.

## Why this PR is small on purpose

The handoff RFC scoped option D as "~40 LOC + tests" wrapping `<Link>`. The two preview strips (Listings + Experts) are the highest-signal surfaces — direct outbound clicks to a country-tailored item — and they slot neatly into the same client wrapper.

`CountryComparePreview` (broker/platform clicks) and `HomeToolsStrip` (tool clicks) are deliberately out of scope:

- `CountryComparePreview` already redirects to `/broker/<slug>` which has its own outbound-click affiliate tracking (`trackClick`), so the country-attribution we'd add here would either double-count or need to coexist with the affiliate stream — non-trivial design.
- `HomeToolsStrip` renders both default and Country Mode-featured tools; firing `country_tool_click` only on the hoisted ones requires passing the featured-href set through the rendering. Worth doing, but a separate small PR.

## Tier

Tier B (additive component + tests, no schema or auth changes).

## Test plan

- [ ] CI green (Lint · Type-check · Test · Build)
- [x] `npx vitest run __tests__/components/TrackedCountryLink.test.tsx` — 4/4 passing locally
- [x] `npx vitest run __tests__/components/CountryHomepageWrappers.test.tsx` — 12/12 still passing (wired components didn't regress)
- [ ] `npm run type-check` clean (running)
- [ ] After merge: confirm `country_listing_click` and `country_expert_click` events arrive in `track_event` Supabase rows from a homepage visit with a country cookie set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)