### PR TITLE
feat(country-mode): click-tracking events on homepage preview wrappers

### DIFF
--- a/__tests__/components/TrackedCountryLink.test.tsx
+++ b/__tests__/components/TrackedCountryLink.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, userEvent } from "./setup";
+
+vi.mock("@/lib/tracking");
+
+import TrackedCountryLink from "@/components/country-mode/TrackedCountryLink";
+import { trackEvent } from "@/lib/tracking";
+
+const mockTrackEvent = vi.mocked(trackEvent);
+
+describe("TrackedCountryLink", () => {
+  beforeEach(() => {
+    mockTrackEvent.mockClear();
+  });
+
+  it("renders as an anchor with the given href", () => {
+    render(
+      <TrackedCountryLink
+        href="/invest/property/sydney-cbd-office"
+        eventName="country_listing_click"
+        country="hk"
+      >
+        Sydney CBD office
+      </TrackedCountryLink>,
+    );
+    const link = screen.getByRole("link", { name: /Sydney CBD office/i });
+    expect(link).toHaveAttribute("href", "/invest/property/sydney-cbd-office");
+  });
+
+  it("fires the configured event with country + target + source on click", async () => {
+    const user = userEvent.setup();
+    render(
+      <TrackedCountryLink
+        href="/advisors/alex-tax"
+        eventName="country_expert_click"
+        country="hk"
+        targetId="alex-tax"
+        source="homepage_preview"
+      >
+        Alex Tax
+      </TrackedCountryLink>,
+    );
+
+    await user.click(screen.getByRole("link", { name: /Alex Tax/i }));
+
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      "country_expert_click",
+      expect.objectContaining({
+        country: "hk",
+        target: "alex-tax",
+        source: "homepage_preview",
+      }),
+    );
+  });
+
+  it("nulls out optional dimensions when not provided", async () => {
+    const user = userEvent.setup();
+    render(
+      <TrackedCountryLink
+        href="/compare/non-residents"
+        eventName="country_compare_click"
+        country="uk"
+      >
+        Compare all
+      </TrackedCountryLink>,
+    );
+
+    await user.click(screen.getByRole("link", { name: /Compare all/i }));
+
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      "country_compare_click",
+      expect.objectContaining({
+        country: "uk",
+        target: null,
+        source: null,
+      }),
+    );
+  });
+
+  it("does not block navigation if trackEvent throws", async () => {
+    mockTrackEvent.mockImplementation(() => {
+      throw new Error("Tracking endpoint down");
+    });
+    const user = userEvent.setup();
+    render(
+      <TrackedCountryLink
+        href="/invest/funds/foo"
+        eventName="country_listing_click"
+        country="hk"
+        targetId={42}
+      >
+        Some listing
+      </TrackedCountryLink>,
+    );
+
+    // Clicking should not throw, and the link's href is intact.
+    await user.click(screen.getByRole("link", { name: /Some listing/i }));
+    expect(screen.getByRole("link", { name: /Some listing/i })).toHaveAttribute(
+      "href",
+      "/invest/funds/foo",
+    );
+    expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+  });
+});

--- a/components/country-mode/CountryComparePreview.tsx
+++ b/components/country-mode/CountryComparePreview.tsx
@@ -8,10 +8,10 @@
  * "compare" strip with fewer than 3 options has nothing to compare).
  */
 
-import Link from "next/link";
 import Image from "next/image";
 import { intentCountryMeta } from "@/lib/intent-context";
 import { getIntentCountry } from "@/lib/intent-context-server";
+import TrackedCountryLink from "./TrackedCountryLink";
 import {
   applySupplyThresholds,
   getHomepageFiltersForCountry,
@@ -79,22 +79,29 @@ export default async function CountryComparePreview() {
                 : `Platforms popular with investors from ${meta.name}`}
             </h2>
           </div>
-          <Link
+          <TrackedCountryLink
             href={
               filters.platforms.nonResidentsOnly
                 ? "/compare/non-residents"
                 : "/compare"
             }
+            eventName="country_compare_click"
+            country={code}
+            source="see_all"
             className="text-sm font-medium text-amber-700 hover:text-amber-900 underline underline-offset-2"
           >
             Compare all &rarr;
-          </Link>
+          </TrackedCountryLink>
         </div>
         <ul className="grid grid-cols-2 lg:grid-cols-4 gap-3">
           {visible.map((b) => (
             <li key={b.id}>
-              <Link
+              <TrackedCountryLink
                 href={`/broker/${b.slug}`}
+                eventName="country_compare_click"
+                country={code}
+                targetId={b.id}
+                source="homepage_preview"
                 className="group block bg-slate-50 hover:bg-amber-50 border border-slate-200 hover:border-amber-200 rounded-xl p-3 transition-colors"
               >
                 <div className="flex items-center gap-3">
@@ -129,7 +136,7 @@ export default async function CountryComparePreview() {
                     </div>
                   )}
                 </div>
-              </Link>
+              </TrackedCountryLink>
             </li>
           ))}
         </ul>

--- a/components/country-mode/CountryExpertsPreview.tsx
+++ b/components/country-mode/CountryExpertsPreview.tsx
@@ -8,7 +8,6 @@
  * below the supply threshold so the global teaser carries the experience.
  */
 
-import Link from "next/link";
 import Image from "next/image";
 import { intentCountryMeta } from "@/lib/intent-context";
 import { getIntentCountry } from "@/lib/intent-context-server";
@@ -17,6 +16,7 @@ import {
   getHomepageFiltersForCountry,
 } from "@/lib/country-mode";
 import { createClient } from "@/lib/supabase/server";
+import TrackedCountryLink from "./TrackedCountryLink";
 
 interface PreviewExpert {
   slug: string;
@@ -78,18 +78,25 @@ export default async function CountryExpertsPreview() {
               Specialists for investors from {meta.name}
             </h2>
           </div>
-          <Link
+          <TrackedCountryLink
             href="/advisors"
+            eventName="country_expert_click"
+            country={code}
+            source="see_all"
             className="text-sm font-medium text-amber-700 hover:text-amber-900 underline underline-offset-2"
           >
             See all experts &rarr;
-          </Link>
+          </TrackedCountryLink>
         </div>
         <ul className="grid grid-cols-2 lg:grid-cols-4 gap-3">
           {visible.map((e) => (
             <li key={e.slug}>
-              <Link
+              <TrackedCountryLink
                 href={`/advisors/${e.slug}`}
+                eventName="country_expert_click"
+                country={code}
+                targetId={e.slug}
+                source="homepage_preview"
                 className="group block bg-slate-50 hover:bg-amber-50 border border-slate-200 hover:border-amber-200 rounded-xl p-3 transition-colors"
               >
                 <div className="flex items-start gap-3">
@@ -118,7 +125,7 @@ export default async function CountryExpertsPreview() {
                     )}
                   </div>
                 </div>
-              </Link>
+              </TrackedCountryLink>
             </li>
           ))}
         </ul>

--- a/components/country-mode/CountryListingsPreview.tsx
+++ b/components/country-mode/CountryListingsPreview.tsx
@@ -13,7 +13,6 @@
  * cookies() is called.
  */
 
-import Link from "next/link";
 import Image from "next/image";
 import { intentCountryMeta } from "@/lib/intent-context";
 import { getIntentCountry } from "@/lib/intent-context-server";
@@ -22,6 +21,7 @@ import {
   getHomepageFiltersForCountry,
 } from "@/lib/country-mode";
 import { createClient } from "@/lib/supabase/server";
+import TrackedCountryLink from "./TrackedCountryLink";
 
 interface PreviewListing {
   id: number;
@@ -85,18 +85,25 @@ export default async function CountryListingsPreview() {
               Investments often considered by investors from {meta.name}
             </h2>
           </div>
-          <Link
+          <TrackedCountryLink
             href="/invest"
+            eventName="country_listing_click"
+            country={code}
+            source="see_all"
             className="text-sm font-medium text-amber-700 hover:text-amber-900 underline underline-offset-2"
           >
             See all opportunities &rarr;
-          </Link>
+          </TrackedCountryLink>
         </div>
         <ul className="grid grid-cols-2 lg:grid-cols-4 gap-3">
           {visible.map((l) => (
             <li key={l.id}>
-              <Link
+              <TrackedCountryLink
                 href={`/invest/${l.vertical}/${l.slug}`}
+                eventName="country_listing_click"
+                country={code}
+                targetId={l.id}
+                source="homepage_preview"
                 className="group block bg-slate-50 hover:bg-amber-50 border border-slate-200 hover:border-amber-200 rounded-xl overflow-hidden transition-colors"
               >
                 {l.hero_image && (
@@ -123,7 +130,7 @@ export default async function CountryListingsPreview() {
                     </p>
                   )}
                 </div>
-              </Link>
+              </TrackedCountryLink>
             </li>
           ))}
         </ul>

--- a/components/country-mode/TrackedCountryLink.tsx
+++ b/components/country-mode/TrackedCountryLink.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+/**
+ * Country Mode tracked link — fires a country-dimensioned analytics
+ * event before navigating. Used by the homepage preview wrappers
+ * (CountryListingsPreview, CountryExpertsPreview, CountryComparePreview)
+ * to capture click-through on country-tailored surfaces.
+ *
+ * Server components import this client component and pass props
+ * server-side; the Next.js boundary handles the hand-off cleanly.
+ */
+
+import Link, { type LinkProps } from "next/link";
+import type { ReactNode, MouseEvent } from "react";
+import { trackEvent } from "@/lib/tracking";
+
+export type CountryClickEvent =
+  | "country_listing_click"
+  | "country_expert_click"
+  | "country_compare_click"
+  | "country_tool_click";
+
+interface TrackedCountryLinkProps extends LinkProps {
+  /** Event name fired before navigation. */
+  eventName: CountryClickEvent;
+  /** Country dimension — intent code (e.g. "hk", "uk"). */
+  country: string;
+  /** Optional target dimension — slug, id, or other identifier. */
+  targetId?: string | number;
+  /**
+   * Optional source dimension — which surface fired the click
+   * (e.g. "homepage_preview", "see_all"). Lets analytics distinguish
+   * card clicks from "see all opportunities" links.
+   */
+  source?: string;
+  className?: string;
+  children: ReactNode;
+  ariaLabel?: string;
+}
+
+export default function TrackedCountryLink({
+  eventName,
+  country,
+  targetId,
+  source,
+  className,
+  children,
+  ariaLabel,
+  ...linkProps
+}: TrackedCountryLinkProps) {
+  const handleClick = (_e: MouseEvent<HTMLAnchorElement>) => {
+    // Fire-and-forget — trackEvent uses a beacon-style POST internally
+    // and shouldn't block the navigation. If it throws, the click
+    // still proceeds.
+    try {
+      trackEvent(eventName, {
+        country,
+        target: targetId ?? null,
+        source: source ?? null,
+      });
+    } catch {
+      /* swallow tracking failures */
+    }
+  };
+
+  return (
+    <Link
+      {...linkProps}
+      onClick={handleClick}
+      className={className}
+      aria-label={ariaLabel}
+    >
+      {children}
+    </Link>
+  );
+}


### PR DESCRIPTION
## Summary

Adds the three deferred click-tracking events from the Phase 1 punch list:
- `country_listing_click` — fires on Country Listings preview cards + 'See all opportunities'
- `country_expert_click` — fires on Country Experts preview cards + 'See all experts'
- `country_compare_click` — fires on Country Compare preview cards + 'Compare all'

Each carries `country` + `target` + `source` dimensions so analytics can break engagement by inbound corridor and by surface (`homepage_preview` vs `see_all`).

`country_tool_click` deliberately omitted — HomeToolsStrip is shared with non-country-mode users; pathname + cookie dim on `$pageview` is sufficient to reconstruct tool engagement by country without a parallel rendering path.

## Implementation

`TrackedCountryLink` is a small client wrapper around `next/link` that fires the event before navigating. Trackers swallow throws so a flaky tracking endpoint never blocks navigation.

## Test plan
- [x] TrackedCountryLink unit tests: event firing, null defaults, swallow-on-throw
- [x] Existing CountryHomepageWrappers tests still pass (DOM remains `<a>` — tracking only fires on click, not render)

🤖 Generated with [Claude Code](https://claude.com/claude-code)