### PR TITLE
feat(concierge): RAG retrieval, finder allowlist, hallucination guardrail

### DIFF
--- a/__tests__/lib/concierge-retrieval.test.ts
+++ b/__tests__/lib/concierge-retrieval.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  CONCIERGE_BASE_SYSTEM_PROMPT,
+  buildConciergeSystemPrompt,
+  extractCitedSlugs,
+  validateNoHallucinations,
+  type ConciergeRetrievedDoc,
+} from "@/lib/concierge-retrieval";
+
+const DOC = (
+  type: string,
+  id: string,
+  title: string,
+  excerpt = "body",
+  score = 0.9,
+): ConciergeRetrievedDoc => ({
+  document_type: type,
+  document_id: id,
+  title,
+  body_excerpt: excerpt,
+  score,
+});
+
+describe("CONCIERGE_BASE_SYSTEM_PROMPT", () => {
+  // Snapshot to catch silent prompt drift. If you intentionally edit
+  // the system prompt, run `npm test -- --update` to refresh.
+  it("matches the canonical snapshot", () => {
+    expect(CONCIERGE_BASE_SYSTEM_PROMPT).toMatchInlineSnapshot(`
+      "You are the invest.com.au investment concierge.
+      You help Australians find the right investment platforms, advisors,
+      and opportunities. You have access to Australia's leading comparison
+      platform.
+
+      Guidelines:
+      - Keep responses concise. Aim for 3-6 sentences per turn with actionable
+        links where possible.
+      - Always include at least one relevant internal link when you mention a
+        comparison, tool, or hub. Format: [Compare brokers](/compare).
+      - When you mention a SPECIFIC ADVISOR by name, always render it as a
+        link to their profile, e.g. [Casey Lin](/advisor/casey-lin), AND
+        offer to add them to a side-by-side compare via
+        [Add Casey Lin to compare](/advisors/compare?add=casey-lin).
+      - When you mention a SPECIFIC BROKER by name, render it as a link to
+        their page, e.g. [CommSec](/broker/commsec).
+      - Only mention advisors and brokers that appear in the RETRIEVED
+        CONTEXT below. Do not invent names, slugs, or fee figures.
+      - If the retrieved context doesn't cover the question, say so plainly
+        and suggest a tool or hub the user can explore.
+      - Never give personal financial advice. Recommend seeking a licensed
+        AFSL-authorised adviser for personal situations.
+      - Never state a broker is "best" universally; frame recommendations as
+        "best for X" scenarios and point to /best-for when appropriate.
+      - For SMSF questions, point to /smsf. For foreign investors, point to
+        /foreign-investment. For funds, /invest/funds. For the energy sector,
+        /invest/oil-gas / /invest/uranium / /invest/hydrogen.
+      - For users searching for a financial advisor, point to /find-advisor
+        (the structured wizard) and /advisors/search (faceted search).
+      - Decline questions about specific stocks or crypto trades — say we
+        cover platforms and educational context only.
+
+      Platform: invest.com.au."
+    `);
+  });
+
+  it("contains the AFSL personal-advice clause", () => {
+    expect(CONCIERGE_BASE_SYSTEM_PROMPT).toMatch(/Never give personal financial advice/i);
+    expect(CONCIERGE_BASE_SYSTEM_PROMPT).toMatch(/AFSL-authorised adviser/i);
+  });
+
+  it("contains the no-hallucination clause", () => {
+    expect(CONCIERGE_BASE_SYSTEM_PROMPT).toMatch(/Do not invent names, slugs, or fee figures/);
+  });
+});
+
+describe("buildConciergeSystemPrompt", () => {
+  it("appends a (no context retrieved) marker when retrieval is empty", () => {
+    const out = buildConciergeSystemPrompt([]);
+    expect(out).toContain(CONCIERGE_BASE_SYSTEM_PROMPT);
+    expect(out).toContain("(no context retrieved)");
+  });
+
+  it("renders each retrieved doc with index, type, title, slug + body", () => {
+    const out = buildConciergeSystemPrompt([
+      DOC("advisor", "casey-lin", "Casey Lin — Acme Wealth", "SMSF specialist in Brisbane"),
+      DOC("broker", "commsec", "CommSec", "Major Australian broker"),
+    ]);
+    expect(out).toContain("[1] advisor — Casey Lin — Acme Wealth (slug: casey-lin)");
+    expect(out).toContain("SMSF specialist in Brisbane");
+    expect(out).toContain("[2] broker — CommSec (slug: commsec)");
+    expect(out).toContain("Major Australian broker");
+  });
+});
+
+describe("extractCitedSlugs", () => {
+  it("returns empty for empty / linkless replies", () => {
+    expect(extractCitedSlugs("")).toEqual([]);
+    expect(extractCitedSlugs("No links here, just educational context.")).toEqual([]);
+  });
+
+  it("extracts /advisor/{slug}, /advisors/compare?add={slug}, /broker/{slug}", () => {
+    const reply = `Based on retrieved profiles, [Casey Lin](/advisor/casey-lin)
+specialises in SMSF. [Add Casey Lin to compare](/advisors/compare?add=casey-lin).
+For brokers, see [CommSec](/broker/commsec).`;
+    const out = extractCitedSlugs(reply);
+    expect(out).toEqual(
+      expect.arrayContaining([
+        { kind: "advisor", slug: "casey-lin" },
+        { kind: "advisor_compare", slug: "casey-lin" },
+        { kind: "broker", slug: "commsec" },
+      ]),
+    );
+  });
+
+  it("normalises slug case", () => {
+    expect(extractCitedSlugs("[X](/advisor/CASEY-LIN)")).toEqual([
+      { kind: "advisor", slug: "casey-lin" },
+    ]);
+  });
+
+  it("ignores invalid slugs", () => {
+    expect(extractCitedSlugs("[X](/advisor/!!bad!!)")).toEqual([]);
+    expect(extractCitedSlugs("[X](/advisor/)")).toEqual([]);
+  });
+});
+
+describe("validateNoHallucinations", () => {
+  const retrieved = [
+    DOC("advisor", "casey-lin", "Casey Lin"),
+    DOC("broker", "commsec", "CommSec"),
+  ];
+
+  it("returns empty when every cited slug is in retrieved context", () => {
+    const reply =
+      "[Casey Lin](/advisor/casey-lin) is a good option. [Add Casey Lin to compare](/advisors/compare?add=casey-lin). Brokers: [CommSec](/broker/commsec).";
+    expect(validateNoHallucinations(reply, retrieved)).toEqual([]);
+  });
+
+  it("flags an advisor slug not in retrieved context", () => {
+    const reply = "Try [Mystery Advisor](/advisor/mystery-advisor) instead.";
+    expect(validateNoHallucinations(reply, retrieved)).toEqual([
+      { kind: "advisor", slug: "mystery-advisor" },
+    ]);
+  });
+
+  it("flags an advisor_compare slug that doesn't match a retrieved advisor", () => {
+    const reply = "[Add to compare](/advisors/compare?add=fake-slug)";
+    expect(validateNoHallucinations(reply, retrieved)).toEqual([
+      { kind: "advisor_compare", slug: "fake-slug" },
+    ]);
+  });
+
+  it("flags a broker slug not in retrieved context", () => {
+    const reply = "[FakeBroker](/broker/fakebroker)";
+    expect(validateNoHallucinations(reply, retrieved)).toEqual([
+      { kind: "broker", slug: "fakebroker" },
+    ]);
+  });
+
+  it("a broker slug in retrieved-as-advisor space still flags as hallucinated", () => {
+    // Defence: if the model writes /broker/casey-lin (advisor masquerading
+    // as broker) we flag it.
+    const reply = "[X](/broker/casey-lin)";
+    expect(validateNoHallucinations(reply, retrieved)).toEqual([
+      { kind: "broker", slug: "casey-lin" },
+    ]);
+  });
+
+  it("returns empty for a reply with no cited slugs", () => {
+    expect(validateNoHallucinations("Just plain text.", retrieved)).toEqual([]);
+  });
+});

--- a/__tests__/lib/concierge-seeds.test.ts
+++ b/__tests__/lib/concierge-seeds.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+
+import { CONCIERGE_SEEDS, lookupSeed, isFinderKey } from "@/lib/concierge-seeds";
+
+describe("concierge-seeds", () => {
+  it("every seed has a non-empty label and prompt under 200 chars", () => {
+    for (const [key, seed] of Object.entries(CONCIERGE_SEEDS)) {
+      expect(seed.label, `${key} label`).toBeTruthy();
+      expect(seed.prompt, `${key} prompt`).toBeTruthy();
+      expect(seed.prompt.length, `${key} prompt length`).toBeLessThanOrEqual(200);
+    }
+  });
+
+  it("no seed prompt looks like a personal-advice request", () => {
+    // Mirrors lib/chatbot.ts PERSONAL_ADVICE_TRIGGERS — the route's
+    // classifier would refuse such seeds, blocking the fluid auto-fire
+    // experience.
+    const triggers = [
+      /should i (buy|sell|invest|put)/i,
+      /tell me exactly what to do with/i,
+      /what do you recommend for my/i,
+    ];
+    for (const [key, seed] of Object.entries(CONCIERGE_SEEDS)) {
+      for (const re of triggers) {
+        expect(re.test(seed.prompt), `${key} prompt must not match ${re}`).toBe(false);
+      }
+    }
+  });
+
+  it("lookupSeed returns null for unknown keys", () => {
+    expect(lookupSeed(null)).toBeNull();
+    expect(lookupSeed("")).toBeNull();
+    expect(lookupSeed("not-a-real-finder")).toBeNull();
+    expect(lookupSeed("../../../etc/passwd")).toBeNull();
+  });
+
+  it("lookupSeed returns the right seed for known keys (case-insensitive)", () => {
+    expect(lookupSeed("advisor-finder")?.label).toBe("Advisor finder");
+    expect(lookupSeed("ADVISOR-FINDER")?.label).toBe("Advisor finder");
+    expect(lookupSeed("  advisor-finder  ")?.label).toBe("Advisor finder");
+  });
+
+  it("isFinderKey rejects non-string + unknown values", () => {
+    expect(isFinderKey(undefined)).toBe(false);
+    expect(isFinderKey(null)).toBe(false);
+    expect(isFinderKey(42)).toBe(false);
+    expect(isFinderKey({})).toBe(false);
+    expect(isFinderKey("nope")).toBe(false);
+    expect(isFinderKey("advisor-finder")).toBe(true);
+  });
+});

--- a/app/advisors/AdvisorsClient.tsx
+++ b/app/advisors/AdvisorsClient.tsx
@@ -54,13 +54,6 @@ const SORT_OPTIONS: { key: SortKey; label: string }[] = [
 
 const RESULTS_PER_PAGE = 12;
 
-// Seed prompt sent to /api/concierge when a user clicks the
-// "Ask the AI concierge" CTA. Kept educational (avoids personal-advice
-// triggers) and short enough to satisfy the concierge's 200-char seed
-// cap. Same string is used on /advisors/search for consistency.
-const ADVISOR_FINDER_SEED =
-  "I'm thinking about hiring a financial advisor. What should I look for, and what questions should I ask?";
-
 function formatCents(cents: number): string {
   return `$${(cents / 100).toLocaleString("en-AU", { maximumFractionDigits: 0 })}`;
 }
@@ -480,7 +473,13 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
               <Icon name="arrow-right" size={14} />
             </Link>
             <Link
-              href={`/concierge?seed=${encodeURIComponent(ADVISOR_FINDER_SEED)}`}
+              href="/concierge?finder=advisor-finder"
+              onClick={() =>
+                trackEvent("concierge_seed_clicked", {
+                  finder: "advisor-finder",
+                  source: "advisors_hero",
+                })
+              }
               className="inline-flex items-center gap-1.5 bg-white hover:bg-slate-50 border border-slate-300 text-slate-700 hover:text-slate-900 font-bold text-xs md:text-sm px-4 py-2 rounded-full transition-colors shadow-sm"
             >
               <Icon name="message-circle" size={14} />

--- a/app/advisors/search/AdvisorSearchClient.tsx
+++ b/app/advisors/search/AdvisorSearchClient.tsx
@@ -9,6 +9,7 @@ import {
   AU_LANGUAGES,
   type ProfessionalType,
 } from "@/lib/types";
+import { trackEvent } from "@/lib/tracking";
 
 interface AdvisorRow {
   id: number;
@@ -235,7 +236,13 @@ export default function AdvisorSearchClient({ initialAdvisors }: Props) {
               Advanced Advisor Search
             </h1>
             <Link
-              href={`/concierge?seed=${encodeURIComponent("I'm thinking about hiring a financial advisor. What should I look for, and what questions should I ask?")}`}
+              href="/concierge?finder=advisor-finder"
+              onClick={() =>
+                trackEvent("concierge_seed_clicked", {
+                  finder: "advisor-finder",
+                  source: "advisor_search_header",
+                })
+              }
               className="inline-flex items-center gap-1.5 bg-white hover:bg-slate-50 border border-slate-300 text-slate-700 hover:text-slate-900 font-bold text-xs md:text-sm px-3 py-1.5 rounded-full transition-colors shadow-sm shrink-0"
             >
               Not sure what to look for? Ask the AI →

--- a/app/api/concierge/route.ts
+++ b/app/api/concierge/route.ts
@@ -12,6 +12,14 @@ import {
   capRejectionPayload,
 } from "@/lib/ai-cost-caps";
 import { sendCap80Alert } from "@/lib/ai-cost-alerts";
+import { embedText } from "@/lib/embeddings";
+import { classifyUserMessage } from "@/lib/chatbot";
+import {
+  buildConciergeSystemPrompt,
+  validateNoHallucinations,
+  type ConciergeRetrievedDoc,
+} from "@/lib/concierge-retrieval";
+import { isFinderKey, type FinderKey } from "@/lib/concierge-seeds";
 
 const log = logger("concierge");
 
@@ -34,33 +42,13 @@ export const maxDuration = 60;
 
 const MODEL = "claude-sonnet-4-20250514";
 const MAX_TOKENS = 1000;
-
-const SYSTEM_PROMPT = `You are the invest.com.au investment concierge.
-You help Australians find the right investment platforms, advisors,
-and opportunities. You have access to Australia's leading comparison
-platform.
-
-Guidelines:
-- Keep responses concise. Aim for 3-6 sentences per turn with actionable
-  links where possible.
-- Always include at least one relevant internal link when you mention a
-  comparison, tool, or hub. Format: [Compare brokers](/compare).
-- Never give personal financial advice. Recommend seeking a licensed
-  AFSL-authorised adviser for personal situations.
-- Never state a broker is "best" universally; frame recommendations as
-  "best for X" scenarios and point to /best-for when appropriate.
-- For SMSF questions, point to /smsf. For foreign investors, point to
-  /foreign-investment. For funds, /invest/funds. For the energy sector,
-  /invest/oil-gas / /invest/uranium / /invest/hydrogen.
-- Decline questions about specific stocks or crypto trades — say we
-  cover platforms and educational context only.
-
-Platform: invest.com.au.`;
+const RAG_TOP_K = 6;
 
 interface Body {
   message: string;
   session_id?: string;
   history?: Array<{ role: "user" | "assistant"; content: string }>;
+  finder?: FinderKey;
 }
 
 function parse(input: unknown): { ok: true; data: Body } | { ok: false; error: string } {
@@ -86,7 +74,52 @@ function parse(input: unknown): { ok: true; data: Body } | { ok: false; error: s
       }
     }
   }
-  return { ok: true, data: { message, session_id, history } };
+  const finder = isFinderKey(b.finder) ? (b.finder as FinderKey) : undefined;
+  return { ok: true, data: { message, session_id, history, finder } };
+}
+
+/**
+ * Vector-search the user's message against `search_embeddings`.
+ * Best-effort: failures (missing OPENAI_API_KEY in dev, KNN RPC
+ * timeout) return [] rather than throwing, so the concierge still
+ * answers — just without retrieval grounding.
+ */
+async function retrieveContext(
+  message: string,
+  limit = RAG_TOP_K,
+): Promise<ConciergeRetrievedDoc[]> {
+  try {
+    const embedding = await embedText(message);
+    if (!embedding) return [];
+    const supabase = createAdminClient();
+    const { data, error } = await supabase.rpc("search_embeddings_knn", {
+      query_embedding: embedding.vector,
+      match_limit: limit,
+      match_type: null,
+    });
+    if (error) {
+      log.warn("rag_retrieval_failed", { err: error.message });
+      return [];
+    }
+    return (data || []).map(
+      (r: {
+        document_type: string;
+        document_id: string;
+        title: string | null;
+        body_excerpt: string | null;
+        distance: number;
+      }) => ({
+        document_type: r.document_type,
+        document_id: r.document_id,
+        title: r.title || "",
+        body_excerpt: r.body_excerpt || "",
+        score: Math.max(0, 1 - (r.distance || 0)),
+      }),
+    );
+  } catch (err) {
+    log.warn("rag_retrieval_threw", { err: err instanceof Error ? err.message : String(err) });
+    return [];
+  }
 }
 
 function ensureSessionId(session_id?: string): string {
@@ -116,6 +149,7 @@ export async function POST(req: NextRequest) {
 
   let raw: unknown;
   try {
+    // eslint-disable-next-line invest/no-unvalidated-req-json -- validated via parse() below
     raw = await req.json();
   } catch {
     return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
@@ -124,6 +158,20 @@ export async function POST(req: NextRequest) {
   const v = parse(raw);
   if (!v.ok) {
     return NextResponse.json({ error: v.error }, { status: 400 });
+  }
+
+  // Defensive classifier — refuses prompt-injection + frames
+  // personal-advice asks with a compliant template before any
+  // Anthropic call. Same rules as /api/chatbot.
+  const classification = classifyUserMessage(v.data.message);
+  if (classification.flagged) {
+    return NextResponse.json(
+      {
+        error: "blocked",
+        reason: classification.reason,
+      },
+      { status: 400 },
+    );
   }
 
   const apiKey = process.env.ANTHROPIC_API_KEY;
@@ -154,6 +202,11 @@ export async function POST(req: NextRequest) {
   const session_id = ensureSessionId(v.data.session_id);
   const client = new Anthropic({ apiKey });
 
+  // Retrieve before streaming — the model needs the context block
+  // in its system prompt. Failure is non-fatal (returns []).
+  const retrieved = await retrieveContext(v.data.message);
+  const systemPrompt = buildConciergeSystemPrompt(retrieved);
+
   // Persist the user message first so we have a record even if
   // streaming fails halfway through.
   const supabase = createAdminClient();
@@ -162,6 +215,7 @@ export async function POST(req: NextRequest) {
     role: "user",
     content: v.data.message,
     model: MODEL,
+    context: { finder: v.data.finder ?? null, retrieved_count: retrieved.length },
   });
 
   // Build messages array — trim history to the last 10 turns to
@@ -182,11 +236,28 @@ export async function POST(req: NextRequest) {
         ),
       );
 
+      // Stream retrieval citations so the UI can render "Sources" under
+      // the reply as it arrives. Trimmed shape — full body_excerpt isn't
+      // needed client-side.
+      controller.enqueue(
+        encoder.encode(
+          `data: ${JSON.stringify({
+            type: "retrieved",
+            docs: retrieved.map((d) => ({
+              type: d.document_type,
+              id: d.document_id,
+              title: d.title,
+              score: d.score,
+            })),
+          })}\n\n`,
+        ),
+      );
+
       try {
         const response = client.messages.stream({
           model: MODEL,
           max_tokens: MAX_TOKENS,
-          system: SYSTEM_PROMPT,
+          system: systemPrompt,
           messages: [
             ...trimmedHistory,
             { role: "user", content: v.data.message },
@@ -226,9 +297,21 @@ export async function POST(req: NextRequest) {
           ),
         );
       } finally {
-        // Persist the assistant reply (best-effort; never blocks the
-        // stream closure).
+        // Persist the assistant reply + retrieval context (best-effort;
+        // never blocks the stream closure). Hallucination guardrail
+        // runs warn-only pre-launch — gives us real-world signal on
+        // how often the model invents slugs before we promote to
+        // refuse + retry. See lib/concierge-retrieval.ts.
         if (assembledAssistant) {
+          const hallucinated = validateNoHallucinations(assembledAssistant, retrieved);
+          if (hallucinated.length > 0) {
+            log.warn("concierge_hallucinated_slugs", {
+              session_id,
+              finder: v.data.finder ?? null,
+              hallucinated,
+              retrieved_count: retrieved.length,
+            });
+          }
           void supabase.from("chatbot_conversations").insert({
             session_id,
             role: "assistant",
@@ -236,6 +319,16 @@ export async function POST(req: NextRequest) {
             model: MODEL,
             tokens_in: tokensIn,
             tokens_out: tokensOut,
+            context: {
+              retrieved: retrieved.map((d) => ({
+                type: d.document_type,
+                id: d.document_id,
+                title: d.title,
+              })),
+              hallucinated_slugs: hallucinated,
+            },
+            flagged: hallucinated.length > 0,
+            flagged_reason: hallucinated.length > 0 ? "hallucinated_slug" : null,
           });
         }
         // V-NEW-06: post-record usage + 80% alert. Fire-and-forget;

--- a/app/concierge/ConciergeClient.tsx
+++ b/app/concierge/ConciergeClient.tsx
@@ -4,6 +4,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import Icon from "@/components/Icon";
+import { trackEvent } from "@/lib/tracking";
+import { lookupSeed, isFinderKey } from "@/lib/concierge-seeds";
 
 /**
  * Full-page concierge chat UI.
@@ -15,10 +17,33 @@ import Icon from "@/components/Icon";
  * steers readers to /advisors for personal questions.
  */
 
+interface Citation {
+  type: string;
+  id: string;
+  title: string;
+  score: number;
+}
+
 interface Message {
   role: "user" | "assistant";
   content: string;
   id: string;
+  citations?: Citation[];
+}
+
+function citationHref(c: Citation): string {
+  switch (c.type) {
+    case "article":
+      return `/article/${c.id}`;
+    case "broker":
+      return `/broker/${c.id}`;
+    case "advisor":
+      return `/advisor/${c.id}`;
+    case "qa":
+      return `/q/${c.id}`;
+    default:
+      return "#";
+  }
 }
 
 const STARTERS = [
@@ -65,10 +90,6 @@ function renderContent(content: string): React.ReactNode {
   return parts;
 }
 
-// Seed-param length cap. Long enough for any reasonable starter,
-// short enough that a malicious URL can't ship a full prompt-injection
-// payload. The /api/concierge route still rate-limits + cost-caps.
-const SEED_MAX_LEN = 200;
 
 export default function ConciergeClient() {
   const [sessionId, setSessionId] = useState<string | null>(null);
@@ -126,7 +147,7 @@ export default function ConciergeClient() {
   }, [messages, streaming]);
 
   const send = useCallback(
-    async (message: string) => {
+    async (message: string, opts?: { finder?: string }) => {
       const clean = message.trim();
       if (!clean || streaming) return;
       setError(null);
@@ -158,6 +179,7 @@ export default function ConciergeClient() {
             message: clean,
             session_id: sessionId ?? undefined,
             history,
+            finder: opts?.finder,
           }),
           signal: ac.signal,
         });
@@ -185,6 +207,7 @@ export default function ConciergeClient() {
             try {
               const json = JSON.parse(line.slice(5).trim()) as
                 | { type: "session"; session_id: string }
+                | { type: "retrieved"; docs: Citation[] }
                 | { type: "delta"; text: string }
                 | { type: "done"; tokens_in: number; tokens_out: number }
                 | { type: "error"; message: string };
@@ -196,6 +219,15 @@ export default function ConciergeClient() {
                 } catch {
                   // ignore
                 }
+              } else if (json.type === "retrieved") {
+                // Attach the citations to the in-flight assistant
+                // message so they render under the reply.
+                const docs = Array.isArray(json.docs) ? json.docs.slice(0, 4) : [];
+                setMessages((prev) =>
+                  prev.map((m) =>
+                    m.id === assistantId ? { ...m, citations: docs } : m,
+                  ),
+                );
               } else if (json.type === "delta") {
                 setMessages((prev) =>
                   prev.map((m) =>
@@ -244,18 +276,22 @@ export default function ConciergeClient() {
     abortRef.current?.abort();
   }, []);
 
-  // Auto-fire a seed prompt from the URL (?seed=…) on first mount,
-  // but only when starting fresh. Skipped if a stored session is
-  // hydrating or any messages already exist. Length-capped to bound
-  // any abuse vector — the route also rate-limits + cost-caps.
+  // Auto-fire a named seed prompt from the URL (?finder=<key>) on
+  // first mount, but only when starting fresh. The finder key is
+  // resolved against a server-defined allowlist in
+  // lib/concierge-seeds.ts — unknown keys are ignored, so a crafted
+  // URL can't ship arbitrary text into the chat.
   useEffect(() => {
     if (seedFiredRef.current) return;
     if (hydrating) return;
     if (messages.length > 0) return;
-    const seed = searchParams?.get("seed")?.trim() ?? "";
-    if (!seed || seed.length > SEED_MAX_LEN) return;
+    const finderRaw = searchParams?.get("finder") ?? "";
+    if (!isFinderKey(finderRaw)) return;
+    const seed = lookupSeed(finderRaw);
+    if (!seed) return;
     seedFiredRef.current = true;
-    void send(seed);
+    trackEvent("concierge_seed_fired", { finder: finderRaw, source: "auto" });
+    void send(seed.prompt, { finder: finderRaw });
     // Intentionally omit `send` from deps — it changes when streaming
     // flips, and seedFiredRef already guards against double-fire.
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -396,9 +432,27 @@ export default function ConciergeClient() {
                           <span className="w-1.5 h-1.5 rounded-full bg-slate-400 animate-pulse [animation-delay:300ms]" />
                         </span>
                       ) : (
-                        <p className="whitespace-pre-wrap">
-                          {renderContent(m.content)}
-                        </p>
+                        <>
+                          <p className="whitespace-pre-wrap">
+                            {renderContent(m.content)}
+                          </p>
+                          {m.role === "assistant" && m.citations && m.citations.length > 0 && (
+                            <div className="mt-2 pt-2 border-t border-slate-200 text-[0.65rem] text-slate-500">
+                              <span className="font-semibold">Sources:</span>{" "}
+                              {m.citations.map((c, idx) => (
+                                <span key={`${c.type}-${c.id}`}>
+                                  {idx > 0 && " · "}
+                                  <Link
+                                    href={citationHref(c)}
+                                    className="underline hover:text-slate-700"
+                                  >
+                                    {c.title.slice(0, 40) || c.id}
+                                  </Link>
+                                </span>
+                              ))}
+                            </div>
+                          )}
+                        </>
                       )}
                     </div>
                   </li>

--- a/e2e/advisor-ai-cta.spec.ts
+++ b/e2e/advisor-ai-cta.spec.ts
@@ -1,38 +1,56 @@
 import { test, expect } from "@playwright/test";
 
 /**
- * Smoke checks for the cheap-now AI advisor surface shipped 2026-05-08:
- *   1. /advisors hero has the "Ask the AI concierge" CTA → /concierge?seed=…
+ * Smoke checks for the AI advisor surface:
+ *   1. /advisors hero has "Ask the AI concierge" CTA → /concierge?finder=advisor-finder
  *   2. /advisors/search header has the same CTA shape
- *   3. /concierge?seed=<text> auto-fires a POST /api/concierge with that text
- *   4. /concierge?seed=… does NOT auto-fire when a stored session is hydrating
- *   5. /advisors/compare?add=<slug> toggles the slug into the shortlist and
+ *   3. /concierge?finder=advisor-finder auto-fires a POST /api/concierge
+ *      (with finder=advisor-finder + the server-mapped prompt)
+ *   4. /concierge?finder=… does NOT auto-fire when a stored session is hydrating
+ *   5. ConciergeClient renders Sources block when SSE emits a 'retrieved' event
+ *   6. Unknown finder values do NOT auto-fire
+ *   7. /advisors/compare?add=<slug> toggles the slug into the shortlist and
  *      strips the ?add= param from the URL
  *
- * /api/concierge is intercepted in tests 3 + 4 so we never make a real
+ * /api/concierge is intercepted in tests 3-6 so we never make a real
  * Claude call (zero added inference cost).
  */
 
-const SEED_TEXT =
+// Server-side prompt for finder=advisor-finder; kept in sync with
+// CONCIERGE_SEEDS in lib/concierge-seeds.ts. If you edit that file,
+// update this string.
+const ADVISOR_FINDER_PROMPT =
   "I'm thinking about hiring a financial advisor. What should I look for, and what questions should I ask?";
 
-function mockConciergeStream(sessionId = "test-session-1234") {
-  // Minimal SSE stream that satisfies ConciergeClient's parser.
-  return [
+function mockConciergeStream(opts?: {
+  sessionId?: string;
+  text?: string;
+  retrieved?: Array<{ type: string; id: string; title: string; score: number }>;
+}) {
+  const sessionId = opts?.sessionId ?? "test-session-1234";
+  const text = opts?.text ?? "Mock concierge reply.";
+  const events = [
     `data: ${JSON.stringify({ type: "session", session_id: sessionId })}\n\n`,
-    `data: ${JSON.stringify({ type: "delta", text: "Mock concierge reply." })}\n\n`,
+  ];
+  if (opts?.retrieved) {
+    events.push(
+      `data: ${JSON.stringify({ type: "retrieved", docs: opts.retrieved })}\n\n`,
+    );
+  }
+  events.push(
+    `data: ${JSON.stringify({ type: "delta", text })}\n\n`,
     `data: ${JSON.stringify({ type: "done", tokens_in: 0, tokens_out: 0 })}\n\n`,
-  ].join("");
+  );
+  return events.join("");
 }
 
-test.describe("Advisor AI surface — cheap-now plan", () => {
-  test("/advisors hero shows the AI concierge CTA pointing to /concierge?seed=…", async ({ page }) => {
+test.describe("Advisor AI surface", () => {
+  test("/advisors hero shows the AI concierge CTA pointing to /concierge?finder=advisor-finder", async ({ page }) => {
     await page.goto("/advisors");
     const cta = page.getByRole("link", { name: /Ask the AI concierge/i });
     await expect(cta).toBeVisible();
     const href = await cta.getAttribute("href");
-    expect(href).toContain("/concierge?seed=");
-    expect(decodeURIComponent(href ?? "")).toContain("hiring a financial advisor");
+    expect(href).toBe("/concierge?finder=advisor-finder");
   });
 
   test("/advisors/search header shows the AI CTA", async ({ page }) => {
@@ -40,10 +58,10 @@ test.describe("Advisor AI surface — cheap-now plan", () => {
     const cta = page.getByRole("link", { name: /Ask the AI/i });
     await expect(cta).toBeVisible();
     const href = await cta.getAttribute("href");
-    expect(href).toContain("/concierge?seed=");
+    expect(href).toBe("/concierge?finder=advisor-finder");
   });
 
-  test("/concierge?seed=… auto-fires a POST /api/concierge with the seed text", async ({ page }) => {
+  test("/concierge?finder=advisor-finder auto-fires a POST /api/concierge with the mapped prompt + finder", async ({ page }) => {
     let capturedRequestBody: unknown = null;
 
     await page.route("**/api/concierge", async (route, request) => {
@@ -64,16 +82,17 @@ test.describe("Advisor AI surface — cheap-now plan", () => {
       await route.fulfill({ status: 200, contentType: "application/json", body: '{"messages":[]}' });
     });
 
-    await page.goto(`/concierge?seed=${encodeURIComponent(SEED_TEXT)}`);
+    await page.goto("/concierge?finder=advisor-finder");
 
     await expect(page.locator("text=Mock concierge reply.")).toBeVisible({ timeout: 10_000 });
 
     expect(capturedRequestBody).not.toBeNull();
-    const body = capturedRequestBody as { message?: string };
-    expect(body.message).toBe(SEED_TEXT);
+    const body = capturedRequestBody as { message?: string; finder?: string };
+    expect(body.message).toBe(ADVISOR_FINDER_PROMPT);
+    expect(body.finder).toBe("advisor-finder");
   });
 
-  test("/concierge?seed=… does NOT auto-fire when a stored session is hydrating", async ({ page, context }) => {
+  test("/concierge?finder=… does NOT auto-fire when a stored session is hydrating", async ({ page, context }) => {
     let postCount = 0;
     await context.addInitScript(() => {
       try {
@@ -110,11 +129,54 @@ test.describe("Advisor AI surface — cheap-now plan", () => {
       await route.fulfill({ status: 200, body: "" });
     });
 
-    await page.goto(`/concierge?seed=${encodeURIComponent(SEED_TEXT)}`);
+    await page.goto("/concierge?finder=advisor-finder");
 
     // Wait until prior history has rendered.
     await expect(page.locator("text=Earlier answer")).toBeVisible({ timeout: 10_000 });
     // Give the seed effect a chance to NOT fire.
+    await page.waitForTimeout(800);
+
+    expect(postCount).toBe(0);
+  });
+
+  test("ConciergeClient renders the Sources block when SSE emits a 'retrieved' event", async ({ page }) => {
+    await page.route("**/api/concierge", async (route, request) => {
+      if (request.method() === "POST") {
+        await route.fulfill({
+          status: 200,
+          contentType: "text/event-stream; charset=utf-8",
+          body: mockConciergeStream({
+            retrieved: [
+              { type: "advisor", id: "casey-lin", title: "Casey Lin — Acme Wealth", score: 0.91 },
+              { type: "broker", id: "commsec", title: "CommSec", score: 0.84 },
+            ],
+            text: "Here is some general information.",
+          }),
+        });
+        return;
+      }
+      await route.fulfill({ status: 200, contentType: "application/json", body: '{"messages":[]}' });
+    });
+
+    await page.goto("/concierge?finder=advisor-finder");
+
+    await expect(page.locator("text=Sources:")).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByRole("link", { name: /Casey Lin/i })).toBeVisible();
+    await expect(page.getByRole("link", { name: /CommSec/i })).toBeVisible();
+  });
+
+  test("an unknown finder value does NOT auto-fire", async ({ page }) => {
+    let postCount = 0;
+    await page.route("**/api/concierge**", async (route, request) => {
+      if (request.method() === "POST") postCount += 1;
+      await route.fulfill({
+        status: 200,
+        contentType: request.method() === "POST" ? "text/event-stream; charset=utf-8" : "application/json",
+        body: request.method() === "POST" ? mockConciergeStream() : '{"messages":[]}',
+      });
+    });
+
+    await page.goto("/concierge?finder=unknown-finder-key");
     await page.waitForTimeout(800);
 
     expect(postCount).toBe(0);

--- a/lib/concierge-retrieval.ts
+++ b/lib/concierge-retrieval.ts
@@ -1,0 +1,135 @@
+/**
+ * Pure helpers shared between /api/concierge (server) and unit tests.
+ *
+ * - buildConciergeSystemPrompt(retrieved) — composes the system
+ *   prompt with retrieval context + link-rendering instructions.
+ * - extractCitedSlugs(reply) — regexes the Claude reply for
+ *   /advisor/{slug} and /advisors/compare?add={slug} hrefs.
+ * - validateNoHallucinations(reply, retrieved) — returns the slugs
+ *   the model cited that AREN'T in retrieved context. Empty array =
+ *   clean reply.
+ *
+ * Pure on purpose: no I/O, no Anthropic SDK, no Supabase. Lets
+ * unit tests cover the prompt + guardrail without a live model.
+ */
+
+export interface ConciergeRetrievedDoc {
+  document_type: string;
+  document_id: string;
+  title: string;
+  body_excerpt: string;
+  score: number;
+}
+
+export const CONCIERGE_BASE_SYSTEM_PROMPT = `You are the invest.com.au investment concierge.
+You help Australians find the right investment platforms, advisors,
+and opportunities. You have access to Australia's leading comparison
+platform.
+
+Guidelines:
+- Keep responses concise. Aim for 3-6 sentences per turn with actionable
+  links where possible.
+- Always include at least one relevant internal link when you mention a
+  comparison, tool, or hub. Format: [Compare brokers](/compare).
+- When you mention a SPECIFIC ADVISOR by name, always render it as a
+  link to their profile, e.g. [Casey Lin](/advisor/casey-lin), AND
+  offer to add them to a side-by-side compare via
+  [Add Casey Lin to compare](/advisors/compare?add=casey-lin).
+- When you mention a SPECIFIC BROKER by name, render it as a link to
+  their page, e.g. [CommSec](/broker/commsec).
+- Only mention advisors and brokers that appear in the RETRIEVED
+  CONTEXT below. Do not invent names, slugs, or fee figures.
+- If the retrieved context doesn't cover the question, say so plainly
+  and suggest a tool or hub the user can explore.
+- Never give personal financial advice. Recommend seeking a licensed
+  AFSL-authorised adviser for personal situations.
+- Never state a broker is "best" universally; frame recommendations as
+  "best for X" scenarios and point to /best-for when appropriate.
+- For SMSF questions, point to /smsf. For foreign investors, point to
+  /foreign-investment. For funds, /invest/funds. For the energy sector,
+  /invest/oil-gas / /invest/uranium / /invest/hydrogen.
+- For users searching for a financial advisor, point to /find-advisor
+  (the structured wizard) and /advisors/search (faceted search).
+- Decline questions about specific stocks or crypto trades — say we
+  cover platforms and educational context only.
+
+Platform: invest.com.au.`;
+
+/**
+ * Returns the full system prompt with retrieval context appended.
+ * If `retrieved` is empty the prompt still ships, with an explicit
+ * "(no context retrieved)" line so the model knows not to invent.
+ */
+export function buildConciergeSystemPrompt(retrieved: ConciergeRetrievedDoc[]): string {
+  const block =
+    retrieved.length === 0
+      ? "(no context retrieved)"
+      : retrieved
+          .map(
+            (d, i) =>
+              `[${i + 1}] ${d.document_type} — ${d.title} (slug: ${d.document_id})\n${d.body_excerpt}`,
+          )
+          .join("\n\n");
+  return `${CONCIERGE_BASE_SYSTEM_PROMPT}\n\nRETRIEVED CONTEXT:\n${block}`;
+}
+
+/**
+ * Pulls the slugs the model cited from a markdown-flavoured reply.
+ * Returns one entry per (linkType, slug) pair. Tracks both
+ * `/advisor/{slug}`, `/advisors/compare?add={slug}` and
+ * `/broker/{slug}`. Pure regex over the reply text.
+ */
+export function extractCitedSlugs(
+  reply: string,
+): Array<{ kind: "advisor" | "advisor_compare" | "broker"; slug: string }> {
+  const out: Array<{ kind: "advisor" | "advisor_compare" | "broker"; slug: string }> = [];
+  if (!reply) return out;
+  // /advisors/compare?add=<slug>  (matched first; greedier prefix)
+  const compareRe = /\/advisors\/compare\?add=([a-z0-9][a-z0-9-]{0,80})/gi;
+  // /advisor/<slug>
+  const advisorRe = /\/advisor\/([a-z0-9][a-z0-9-]{0,80})/gi;
+  // /broker/<slug>
+  const brokerRe = /\/broker\/([a-z0-9][a-z0-9-]{0,80})/gi;
+  let m: RegExpExecArray | null;
+  while ((m = compareRe.exec(reply)) !== null) {
+    out.push({ kind: "advisor_compare", slug: m[1]!.toLowerCase() });
+  }
+  while ((m = advisorRe.exec(reply)) !== null) {
+    out.push({ kind: "advisor", slug: m[1]!.toLowerCase() });
+  }
+  while ((m = brokerRe.exec(reply)) !== null) {
+    out.push({ kind: "broker", slug: m[1]!.toLowerCase() });
+  }
+  return out;
+}
+
+/**
+ * Returns the citations whose slug doesn't appear in the retrieved
+ * context. Empty array = clean reply.
+ *
+ * Match rule: an `advisor` or `advisor_compare` slug must match a
+ * retrieved doc with document_type='advisor' and document_id=slug.
+ * A `broker` slug must match document_type='broker'. Anything else
+ * is treated as hallucinated.
+ *
+ * Pre-launch we'll *log* hallucinations rather than refuse — gives
+ * us a real-world signal for how often Claude invents names. If
+ * the rate is non-trivial we promote to refuse + retry.
+ */
+export function validateNoHallucinations(
+  reply: string,
+  retrieved: ConciergeRetrievedDoc[],
+): Array<{ kind: "advisor" | "advisor_compare" | "broker"; slug: string }> {
+  const cited = extractCitedSlugs(reply);
+  if (cited.length === 0) return [];
+  const advisorSlugs = new Set(
+    retrieved.filter((d) => d.document_type === "advisor").map((d) => d.document_id.toLowerCase()),
+  );
+  const brokerSlugs = new Set(
+    retrieved.filter((d) => d.document_type === "broker").map((d) => d.document_id.toLowerCase()),
+  );
+  return cited.filter((c) => {
+    if (c.kind === "broker") return !brokerSlugs.has(c.slug);
+    return !advisorSlugs.has(c.slug);
+  });
+}

--- a/lib/concierge-seeds.ts
+++ b/lib/concierge-seeds.ts
@@ -1,0 +1,71 @@
+/**
+ * Named seed prompts for the Investment Concierge.
+ *
+ * UI surfaces (e.g. /advisors, /advisors/search, post-quiz drop-offs)
+ * deep-link to `/concierge?finder=<key>` and the client looks up the
+ * starter prompt here. Replacing the prior free-form `?seed=<text>`
+ * removes the URL-tampering vector entirely — only keys in this
+ * allowlist auto-fire a message.
+ *
+ * Adding a new finder:
+ *   1. Pick a short kebab-case key.
+ *   2. Add a label (shown in analytics) and prompt (≤200 chars).
+ *   3. Make sure the prompt is educational, not personal-advice
+ *      ("what should I look for?", not "should I buy X?"). The
+ *      classifier in lib/chatbot.ts blocks the latter anyway, but
+ *      good seeds avoid the friction.
+ */
+
+export type FinderKey =
+  | "advisor-finder"
+  | "broker-comparison"
+  | "smsf-101"
+  | "first-etf";
+
+export interface ConciergeSeed {
+  /** Short label for analytics + admin tooling. */
+  label: string;
+  /** Auto-fired starter message. Capped at 200 chars. */
+  prompt: string;
+}
+
+export const CONCIERGE_SEEDS: Record<FinderKey, ConciergeSeed> = {
+  "advisor-finder": {
+    label: "Advisor finder",
+    prompt:
+      "I'm thinking about hiring a financial advisor. What should I look for, and what questions should I ask?",
+  },
+  "broker-comparison": {
+    label: "Broker comparison",
+    prompt:
+      "I'm choosing between online share brokers in Australia. What are the main differences I should compare?",
+  },
+  "smsf-101": {
+    label: "SMSF basics",
+    prompt:
+      "What are the main pros, cons, and ongoing costs of running a self-managed super fund in Australia?",
+  },
+  "first-etf": {
+    label: "First ETF",
+    prompt:
+      "I'm a beginner looking to buy my first ETF. What concepts should I understand before choosing one?",
+  },
+};
+
+const FINDER_KEYS: ReadonlySet<string> = new Set(Object.keys(CONCIERGE_SEEDS));
+
+/**
+ * Returns the seed prompt for a given finder key, or null if the key
+ * isn't on the allowlist. Pure — safe for both server and client.
+ */
+export function lookupSeed(rawKey: string | null | undefined): ConciergeSeed | null {
+  if (!rawKey) return null;
+  const key = rawKey.trim().toLowerCase();
+  if (!FINDER_KEYS.has(key)) return null;
+  return CONCIERGE_SEEDS[key as FinderKey];
+}
+
+/** Type guard — useful in route handlers + tests. */
+export function isFinderKey(value: unknown): value is FinderKey {
+  return typeof value === "string" && FINDER_KEYS.has(value.trim().toLowerCase());
+}


### PR DESCRIPTION
## Summary

Pre-launch hardening pass on the AI advisor surface from #622.

- **`/api/concierge` now does RAG retrieval** against `search_embeddings` (the table the embeddings cron has been populating all along). Until now the streaming concierge had no retrieval and could invent advisor/broker names. New `lib/concierge-retrieval.ts` owns the system-prompt builder + slug-extraction guardrail (pure, fully unit-tested).
- **System prompt instructs the model to render advisor mentions as `[Name](/advisor/<slug>)` plus `[Add Name to compare](/advisors/compare?add=<slug>)`** — closing the loop with the deep-link shipped in #622.
- **`?seed=<text>` → `?finder=<key>`**: replaces the freeform seed param with a server-side allowlist in `lib/concierge-seeds.ts`. Removes the URL-tampering vector entirely. Unknown keys silently no-op rather than auto-firing arbitrary text into a paid AI endpoint.
- **Prompt-injection / personal-advice classifier** from `lib/chatbot.ts` is now applied to the concierge route too — defensive parity with `/api/chatbot`, refuses crafted inputs before they hit Anthropic.
- **Hallucination guardrail (warn-only)**: post-process Claude replies; any `/advisor/<slug>` or `/advisors/compare?add=<slug>` or `/broker/<slug>` not in retrieved context gets logged + flagged in `chatbot_conversations.context.hallucinated_slugs` with `flagged=true`. Gives Ops a query to see the rate ahead of promoting to refuse + retry.
- **Citations streamed as a new `retrieved` SSE event**, rendered as a "Sources:" block under each assistant message in `ConciergeClient`.
- **Analytics**: CTA click + auto-fire fire `trackEvent("concierge_seed_clicked"/"concierge_seed_fired", { finder, source })`.

## Test plan

- [x] `tsc --noEmit` clean
- [x] ESLint `--max-warnings 0` clean across all touched files
- [x] **82 tests pass** across 7 suites: new `concierge-seeds` (5), new `concierge-retrieval` (15, includes inline-snapshot of the system prompt to catch drift + hallucination detection edge cases), plus existing concierge API (19), embeddings (17), advisor-compare API (6), advisor-search API (12), cron-embeddings-refresh (8)
- [x] Playwright spec at `e2e/advisor-ai-cta.spec.ts` updated to cover: CTA href shape (`/concierge?finder=advisor-finder`), auto-fire of mapped prompt + finder, hydrated-session no-fire, **new: Sources block renders when SSE emits 'retrieved'**, **new: unknown finder key does not auto-fire**. All `/api/concierge` calls mocked → zero added inference cost.
- [ ] Manual click-through after merge: visit `/advisors`, click "Ask the AI concierge", confirm auto-fire renders Sources, confirm advisor links + compare deep-links work end-to-end.

## Backlog (post-launch, separate PRs)

- Promote hallucination guardrail from warn-only → refuse + retry once we have signal on the incidence rate.
- `/api/advisor-match` endpoint (full Claude rerank + AI-written "why this advisor" rationale per top-3 pick).
- `review_sentiment_facets` backfill (currently 0 rows) → enables facet-level rationale ("strong on fees, weak on response time").
- Save & resume concierge sessions to a logged-in profile (`/account/conversations`).

## Two pre-existing CI failures, not caused by this PR

`Supabase types drift` and `code-quality (PR delta)` — both fail on every open PR including this one and are addressed by #625 (separate effort). Required checks (Lint·Type-check·Test·Build, E2E, A11y, Lighthouse, Bundle, Vercel) are all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)