### PR TITLE
feat(country-mode): Phase 5c — dynamic html lang/dir from locale prefix

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata, Viewport } from "next";
 import localFont from "next/font/local";
 import { JetBrains_Mono, Source_Serif_4 } from "next/font/google";
 import { Suspense } from "react";
+import { headers } from "next/headers";
+import { stripLocalePrefix, BCP47_TAG, LOCALE_DIR } from "@/lib/i18n/locales";
 import "./globals.css";
 import LayoutShell from "@/components/LayoutShell";
 import CountryModeBanner from "@/components/country-mode/CountryModeBanner";
@@ -117,8 +119,19 @@ export default async function RootLayout({
     ? newsletterExitIntentFlag.enabled &&
       newsletterExitIntentFlag.rollout_pct > 0
     : true;
+
+  // Country Mode / Language Mode: derive the active locale from the
+  // URL prefix and set <html lang> + <html dir> accordingly. proxy.ts
+  // stamps x-pathname so we can read it here (Next.js root layouts
+  // don't get pathname via params).
+  const headerStore = await headers();
+  const pathname = headerStore.get("x-pathname") ?? "/";
+  const { locale } = stripLocalePrefix(pathname);
+  const htmlLang = BCP47_TAG[locale];
+  const htmlDir = LOCALE_DIR[locale];
+
   return (
-    <html lang="en-AU" suppressHydrationWarning className={`${inter.variable} ${jetbrainsMono.variable} ${sourceSerif.variable}`}>
+    <html lang={htmlLang} dir={htmlDir} suppressHydrationWarning className={`${inter.variable} ${jetbrainsMono.variable} ${sourceSerif.variable}`}>
       {/* Inline script adds .js-ready immediately so CSS animations only run when JS is available.
           Without this, hero-fade-up starts at opacity:0 and stays invisible until JS loads. */}
       <head>

--- a/proxy.ts
+++ b/proxy.ts
@@ -61,6 +61,11 @@ export async function proxy(request: NextRequest) {
   // x-request-id via request.headers.get('x-request-id').
   const forwardedHeaders = new Headers(request.headers)
   forwardedHeaders.set('x-request-id', requestId)
+  // Country Mode / Language Mode: stamp the pathname so the root
+  // layout can derive the active locale from the URL prefix and set
+  // <html lang> + <html dir> dynamically. Server components have no
+  // other way to read the pathname for root layouts (no params).
+  forwardedHeaders.set('x-pathname', pathname)
 
   const response = NextResponse.next({
     request: { headers: forwardedHeaders },


### PR DESCRIPTION
## Summary

Two-line fix for an SEO bug present since /zh and /ko routes shipped: the root `<html lang="en-AU">` was static, so Googlebot crawling /zh/foreign-investment got an EN `lang` attribute (hreflang lie) and /ar/* couldn't render RTL.

`proxy.ts` stamps `x-pathname` on the request headers (one line — piggybacks on the existing forwardedHeaders block that sets x-request-id). Server components inside the root layout have no other way to read the pathname (no params on root layouts).

`app/layout.tsx` reads x-pathname, runs through `stripLocalePrefix` to get the active locale, sets `<html lang=…>` from BCP47_TAG and `<html dir=…>` from LOCALE_DIR (both maps already in lib/i18n/locales.ts).

## Effect
- `/foreign-investment` — lang=en-AU dir=ltr (unchanged)
- `/zh/foreign-investment` — lang=zh-CN dir=ltr (was en-AU; SEO fix)
- `/ko/foreign-investment` — lang=ko-KR dir=ltr (was en-AU; SEO fix)
- `/ar/foreign-investment/uae` — lang=ar-AE dir=rtl (Phase 5b page now flows correctly)

## Tier C announcement
Touches proxy.ts. Header stamp is read-only metadata for SSR consumption — no auth/routing logic affected. Per merge-auth doc, announcing intent here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)