### PR TITLE
fix(country-mode): RTL-safe logical properties across 5 foreign-investment files

### DIFF
--- a/app/foreign-investment/DASPCalculator.tsx
+++ b/app/foreign-investment/DASPCalculator.tsx
@@ -49,7 +49,7 @@ export default function DASPCalculator() {
               <button
                 key={v}
                 onClick={() => setVisaType(v)}
-                className={`rounded-xl border-2 px-3 py-2.5 text-xs font-semibold transition-all text-left ${
+                className={`rounded-xl border-2 px-3 py-2.5 text-xs font-semibold transition-all text-start ${
                   visaType === v
                     ? "border-amber-500 bg-amber-50 text-amber-800"
                     : "border-slate-200 bg-white text-slate-600 hover:border-slate-300"
@@ -85,14 +85,14 @@ export default function DASPCalculator() {
                 value={totalBalance}
                 onChange={(e) => setTotalBalance(e.target.value.replace(/[^0-9.]/g, ""))}
                 placeholder="10,000"
-                className="w-full pl-7 pr-4 py-2.5 text-sm border border-slate-300 rounded-xl bg-white text-slate-900 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-amber-400/50 focus:border-amber-400 transition"
+                className="w-full ps-7 pe-4 py-2.5 text-sm border border-slate-300 rounded-xl bg-white text-slate-900 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-amber-400/50 focus:border-amber-400 transition"
               />
             </div>
           </div>
           <div>
             <label className="block text-xs font-bold text-slate-700 mb-1">
               Tax-free component (%)
-              <span className="font-normal text-slate-400 ml-1">— after-tax contributions only</span>
+              <span className="font-normal text-slate-400 ms-1">— after-tax contributions only</span>
             </label>
             <div className="relative">
               <input
@@ -102,7 +102,7 @@ export default function DASPCalculator() {
                 value={taxFreePercent}
                 onChange={(e) => setTaxFreePercent(e.target.value)}
                 placeholder="0"
-                className="w-full pr-8 pl-3 py-2 text-sm border border-slate-300 rounded-xl bg-white text-slate-900 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-amber-400/50 focus:border-amber-400 transition"
+                className="w-full pe-8 ps-3 py-2 text-sm border border-slate-300 rounded-xl bg-white text-slate-900 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-amber-400/50 focus:border-amber-400 transition"
               />
               <span className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 text-sm">%</span>
             </div>

--- a/app/foreign-investment/guides/stamp-duty-foreign-buyers/page.tsx
+++ b/app/foreign-investment/guides/stamp-duty-foreign-buyers/page.tsx
@@ -124,7 +124,7 @@ export default function StampDutyForeignBuyersPage() {
           <div className="overflow-x-auto">
             <table className="w-full text-sm border border-slate-200 rounded-xl overflow-hidden">
               <thead>
-                <tr className="bg-slate-50 border-b border-slate-200 text-left">
+                <tr className="bg-slate-50 border-b border-slate-200 text-start">
                   <th className="px-4 py-3 font-semibold text-slate-600 text-xs">State / Territory</th>
                   <th className="px-4 py-3 font-semibold text-slate-600 text-xs">Stamp Duty Surcharge</th>
                   <th className="px-4 py-3 font-semibold text-slate-600 text-xs hidden md:table-cell">Land Tax Surcharge</th>
@@ -136,7 +136,7 @@ export default function StampDutyForeignBuyersPage() {
                   <tr key={s.stateCode} className="hover:bg-slate-50 transition-colors">
                     <td className="px-4 py-3">
                       <span className="font-medium text-slate-800">{s.state}</span>
-                      <span className="ml-2 text-xs text-slate-400">{s.stateCode}</span>
+                      <span className="ms-2 text-xs text-slate-400">{s.stateCode}</span>
                     </td>
                     <td className="px-4 py-3">
                       <span className={`font-bold text-lg ${s.surchargePercent > 0 ? "text-red-700" : "text-emerald-700"}`}>
@@ -173,7 +173,7 @@ export default function StampDutyForeignBuyersPage() {
           <div className="overflow-x-auto">
             <table className="w-full text-sm border border-slate-200 rounded-xl overflow-hidden">
               <thead>
-                <tr className="bg-slate-50 border-b border-slate-200 text-left">
+                <tr className="bg-slate-50 border-b border-slate-200 text-start">
                   <th className="px-4 py-3 font-semibold text-slate-600 text-xs">State</th>
                   <th className="px-4 py-3 font-semibold text-slate-600 text-xs">Rate</th>
                   {PRICE_EXAMPLES.map((p) => (

--- a/app/foreign-investment/page.tsx
+++ b/app/foreign-investment/page.tsx
@@ -163,25 +163,25 @@ export default async function ForeignInvestmentHubPage() {
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 mb-5">
                 <Link
                   href="/foreign-investment/shares"
-                  className="px-4 py-2.5 border border-slate-200 hover:bg-slate-50 hover:border-amber-300 text-slate-700 hover:text-slate-900 font-semibold rounded-xl text-xs text-left transition-colors"
+                  className="px-4 py-2.5 border border-slate-200 hover:bg-slate-50 hover:border-amber-300 text-slate-700 hover:text-slate-900 font-semibold rounded-xl text-xs text-start transition-colors"
                 >
                   I want to buy Australian shares &rarr;
                 </Link>
                 <Link
                   href="/foreign-investment/property"
-                  className="px-4 py-2.5 border border-slate-200 hover:bg-slate-50 hover:border-amber-300 text-slate-700 hover:text-slate-900 font-semibold rounded-xl text-xs text-left transition-colors"
+                  className="px-4 py-2.5 border border-slate-200 hover:bg-slate-50 hover:border-amber-300 text-slate-700 hover:text-slate-900 font-semibold rounded-xl text-xs text-start transition-colors"
                 >
                   I want to buy property &rarr;
                 </Link>
                 <Link
                   href="/foreign-investment/super"
-                  className="px-4 py-2.5 border border-slate-200 hover:bg-slate-50 hover:border-amber-300 text-slate-700 hover:text-slate-900 font-semibold rounded-xl text-xs text-left transition-colors"
+                  className="px-4 py-2.5 border border-slate-200 hover:bg-slate-50 hover:border-amber-300 text-slate-700 hover:text-slate-900 font-semibold rounded-xl text-xs text-start transition-colors"
                 >
                   I&apos;m leaving Australia — super &amp; tax help &rarr;
                 </Link>
                 <Link
                   href="#find-your-situation"
-                  className="px-4 py-2.5 border border-slate-200 hover:bg-slate-50 hover:border-amber-300 text-slate-700 hover:text-slate-900 font-semibold rounded-xl text-xs text-left transition-colors"
+                  className="px-4 py-2.5 border border-slate-200 hover:bg-slate-50 hover:border-amber-300 text-slate-700 hover:text-slate-900 font-semibold rounded-xl text-xs text-start transition-colors"
                 >
                   I&apos;m an expat or new migrant &rarr;
                 </Link>

--- a/app/foreign-investment/send-money-australia/page.tsx
+++ b/app/foreign-investment/send-money-australia/page.tsx
@@ -157,7 +157,7 @@ export default async function SendMoneyAustraliaPage() {
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b border-amber-200">
-                  <th className="text-left pb-2 font-semibold text-slate-600 text-xs">Provider</th>
+                  <th className="text-start pb-2 font-semibold text-slate-600 text-xs">Provider</th>
                   <th className="text-right pb-2 font-semibold text-slate-600 text-xs">Est. margin</th>
                   <th className="text-right pb-2 font-semibold text-slate-600 text-xs">Cost on $500K</th>
                   <th className="text-right pb-2 font-semibold text-slate-600 text-xs">You receive</th>
@@ -182,7 +182,7 @@ export default async function SendMoneyAustraliaPage() {
                       </td>
                       <td className="py-2 text-right font-bold text-slate-800">
                         ${received.toLocaleString("en-AU")}
-                        {isBest && <span className="ml-1 text-xs text-emerald-600">Best</span>}
+                        {isBest && <span className="ms-1 text-xs text-emerald-600">Best</span>}
                       </td>
                     </tr>
                   );

--- a/app/foreign-investment/tax/page.tsx
+++ b/app/foreign-investment/tax/page.tsx
@@ -175,10 +175,10 @@ export default async function ForeignTaxPage() {
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b border-slate-200 bg-slate-50">
-                  <th className="text-left px-4 py-3 text-xs font-bold text-slate-600 uppercase tracking-wide">Income type</th>
-                  <th className="text-left px-4 py-3 text-xs font-bold text-slate-600 uppercase tracking-wide">No DTA</th>
-                  <th className="text-left px-4 py-3 text-xs font-bold text-green-700 uppercase tracking-wide">With DTA</th>
-                  <th className="text-left px-4 py-3 text-xs font-bold text-slate-600 uppercase tracking-wide hidden md:table-cell">Notes</th>
+                  <th className="text-start px-4 py-3 text-xs font-bold text-slate-600 uppercase tracking-wide">Income type</th>
+                  <th className="text-start px-4 py-3 text-xs font-bold text-slate-600 uppercase tracking-wide">No DTA</th>
+                  <th className="text-start px-4 py-3 text-xs font-bold text-green-700 uppercase tracking-wide">With DTA</th>
+                  <th className="text-start px-4 py-3 text-xs font-bold text-slate-600 uppercase tracking-wide hidden md:table-cell">Notes</th>
                 </tr>
               </thead>
               <tbody>
@@ -296,7 +296,7 @@ export default async function ForeignTaxPage() {
               <details key={faq.question} className="group bg-white rounded-xl border border-slate-200">
                 <summary className="px-5 py-4 text-sm font-bold text-slate-900 cursor-pointer list-none flex items-center justify-between hover:bg-slate-50 rounded-xl transition-colors">
                   {faq.question}
-                  <span className="text-slate-400 group-open:rotate-180 transition-transform text-base ml-3">⌄</span>
+                  <span className="text-slate-400 group-open:rotate-180 transition-transform text-base ms-3">⌄</span>
                 </summary>
                 <div className="px-5 pb-4 text-sm text-slate-600 leading-relaxed border-t border-slate-100 pt-3">
                   {faq.answer}


### PR DESCRIPTION
## Summary
Per `docs/architecture/rtl-audit-2026-05-08.md`, converts LTR-only Tailwind utilities to logical equivalents across the public-Arabic critical-path files:

- `send-money-australia/page.tsx`
- `guides/stamp-duty-foreign-buyers/page.tsx`
- `tax/page.tsx`
- `DASPCalculator.tsx`
- `foreign-investment/page.tsx`

Replacements: `text-left` → `text-start`, `ml-N` → `ms-N`, `mr-N` → `me-N`, `pl-N` → `ps-N`, `pr-N` → `pe-N`.

Deliberately not touched: `text-right` on numeric/currency table cells (numbers stay LTR in RTL prose — per audit doc), `border-l/r` and `left-N/right-N` (need per-call-site judgement).

Combined with PR #631 (CountryHubTemplate), 6 of 7 public-Arabic critical-path files are now RTL-safe. 7th is admin-path; deferred.

Tier A — page UI fix. 18 line changes across 5 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)