### PR TITLE
refactor(x): clear createAdminClient from /how-to/transfer-from pages (X-06)

### DIFF
--- a/app/how-to/transfer-from/[broker_slug]/page.tsx
+++ b/app/how-to/transfer-from/[broker_slug]/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
-import { createAdminClient } from "@/lib/supabase/admin";
+import { createClient } from "@/lib/supabase/server";
 import Icon from "@/components/Icon";
 
 export const revalidate = 3600;
@@ -41,7 +41,7 @@ interface BrokerRow {
 
 async function fetchGuide(brokerSlug: string): Promise<GuideRow | null> {
   try {
-    const supabase = createAdminClient();
+    const supabase = await createClient();
     const { data } = await supabase
       .from("broker_transfer_guides")
       .select("*")
@@ -55,7 +55,7 @@ async function fetchGuide(brokerSlug: string): Promise<GuideRow | null> {
 
 async function fetchBroker(slug: string): Promise<BrokerRow | null> {
   try {
-    const supabase = createAdminClient();
+    const supabase = await createClient();
     const { data } = await supabase
       .from("brokers")
       .select("slug, name, logo_url, rating, tagline, asx_fee, chess_sponsored, smsf_support")
@@ -69,7 +69,7 @@ async function fetchBroker(slug: string): Promise<BrokerRow | null> {
 
 async function fetchTopBrokers(excludeSlug: string): Promise<BrokerRow[]> {
   try {
-    const supabase = createAdminClient();
+    const supabase = await createClient();
     const { data } = await supabase
       .from("brokers")
       .select("slug, name, logo_url, rating, tagline, asx_fee, chess_sponsored, smsf_support")
@@ -86,7 +86,7 @@ async function fetchTopBrokers(excludeSlug: string): Promise<BrokerRow[]> {
 
 export async function generateStaticParams() {
   try {
-    const supabase = createAdminClient();
+    const supabase = await createClient();
     const { data } = await supabase
       .from("broker_transfer_guides")
       .select("broker_slug");

--- a/app/how-to/transfer-from/page.tsx
+++ b/app/how-to/transfer-from/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import type { Metadata } from "next";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
-import { createAdminClient } from "@/lib/supabase/admin";
+import { createClient } from "@/lib/supabase/server";
 import Icon from "@/components/Icon";
 
 export const revalidate = 3600;
@@ -30,7 +30,7 @@ interface BrokerRow {
 
 async function fetchGuides(): Promise<GuideRow[]> {
   try {
-    const supabase = createAdminClient();
+    const supabase = await createClient();
     const { data } = await supabase
       .from("broker_transfer_guides")
       .select(
@@ -46,7 +46,7 @@ async function fetchGuides(): Promise<GuideRow[]> {
 async function fetchBrokers(slugs: string[]): Promise<Record<string, BrokerRow>> {
   if (slugs.length === 0) return {};
   try {
-    const supabase = createAdminClient();
+    const supabase = await createClient();
     const { data } = await supabase
       .from("brokers")
       .select("slug, name, logo_url")

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -13744,4 +13744,3 @@ export const Constants = {
     Enums: {},
   },
 } as const
-

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -13744,3 +13744,4 @@ export const Constants = {
     Enums: {},
   },
 } as const
+


### PR DESCRIPTION
## Summary

- Replaces `createAdminClient()` (service-role) with `createClient()` (anon/server) in `/how-to/transfer-from/page.tsx` and `/how-to/transfer-from/[broker_slug]/page.tsx`
- Both tables queried (`broker_transfer_guides`, `brokers`) already carry explicit anon SELECT RLS policies — no new migrations needed
- Pure mechanical swap; no logic changes

## Context

`broker_transfer_guides` anon SELECT policy: migration `20260604140001_a04_backfill_broker_transfer_guides.sql` (A-04).
`brokers` anon SELECT policy: migration `001_initial.sql` — `"Public read for active brokers"` (`status = 'active'`).

Both are public ISR pages with no auth context. Service-role was unnecessary security escalation.

## Test plan

- [ ] CI green (type-check, lint, build)
- [ ] `/how-to/transfer-from` renders broker list via anon SELECT
- [ ] `/how-to/transfer-from/[broker_slug]` renders guide via anon SELECT
- [ ] Inactive broker slugs correctly 404 (filtered by brokers policy)

Refs: #218
Audit: docs/audits/codebase-health-2026-04-24.md (admin.ts scope, stream X)
Queue: docs/audits/REMEDIATION_QUEUE.md X-06

---
_Generated by [Claude Code](https://claude.ai/code/session_015WNosQH7P9FCgkKWWiReV2)_