### PR TITLE
test(country-mode): update i18n test assertions for ar locale

### DIFF
--- a/__tests__/lib/i18n-dictionaries.test.ts
+++ b/__tests__/lib/i18n-dictionaries.test.ts
@@ -32,7 +32,13 @@ describe("foreign-investment dictionaries", () => {
     expect(new Set(counts).size).toBe(1);
   });
 
-  it.each(LOCALES)(
+  // Phase 5a added `ar` to the Locale union but its dictionary hasn't
+  // been authored yet — getForeignInvestmentDict falls back to EN for
+  // unauthored locales (see lib/i18n/dictionaries.ts). The href-prefix
+  // contract only applies to locales with their own dict entries.
+  const POPULATED_LOCALES = LOCALES.filter((l) => l !== "ar");
+
+  it.each(POPULATED_LOCALES)(
     "uses locale-correct href prefix on topicCards for %s",
     (locale) => {
       const cards = getForeignInvestmentDict(locale).topicCards;
@@ -47,6 +53,15 @@ describe("foreign-investment dictionaries", () => {
       }
     },
   );
+
+  it("ar falls back to en dictionary (Phase 5a Partial<Record<Locale,…>> fallback)", () => {
+    // Confirms the documented Partial-with-fallback behaviour: until a
+    // native-Arabic reviewer pass produces ar dictionary entries, ar
+    // requests get EN content.
+    const ar = getForeignInvestmentDict("ar");
+    const en = getForeignInvestmentDict("en");
+    expect(ar.meta.title).toBe(en.meta.title);
+  });
 });
 
 describe("sub-page dictionaries", () => {

--- a/__tests__/lib/i18n-locales.test.ts
+++ b/__tests__/lib/i18n-locales.test.ts
@@ -15,8 +15,8 @@ describe("locale registry", () => {
     expect(DEFAULT_LOCALE).toBe("en");
   });
 
-  it("includes en + zh + ko and nothing else", () => {
-    expect([...LOCALES].sort()).toEqual(["en", "ko", "zh"]);
+  it("includes en + zh + ko + ar (Phase 5a added ar for UAE / Saudi)", () => {
+    expect([...LOCALES].sort()).toEqual(["ar", "en", "ko", "zh"]);
   });
 
   it("every locale has a BCP-47 tag and a UI label", () => {


### PR DESCRIPTION
Fixes the two stale i18n tests that broke main on Phase 5a (#620) and triggered auto-revert PR #638 (wrong target).

`__tests__/lib/i18n-locales.test.ts`: asserted en + zh + ko ONLY. Now asserts the new 4-locale set including ar.

`__tests__/lib/i18n-dictionaries.test.ts`: "locale-correct href prefix on topicCards" test ran for every locale, but ar's dict isn't authored — it falls back to EN per the Partial<Record> change. Test now skips ar for that specific assertion + adds an explicit test confirming the EN-fallback behaviour.

Once this lands, the auto-revert PR #638 should be closed.

[skip-revert]

🤖 Generated with [Claude Code](https://claude.com/claude-code)