### PR TITLE
fix(x): X-07 — swap createAdminClient → createClient in siv + advisors/search

### DIFF
--- a/app/advisors/search/page.tsx
+++ b/app/advisors/search/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { createAdminClient } from "@/lib/supabase/admin";
+import { createClient } from "@/lib/supabase/server";
 import { logger } from "@/lib/logger";
 import AdvisorSearchClient from "./AdvisorSearchClient";
 
@@ -57,7 +57,7 @@ interface AdvisorRow {
 export default async function AdvisorSearchPage() {
   let advisors: AdvisorRow[] = [];
   try {
-    const supabase = createAdminClient();
+    const supabase = await createClient();
     const { data, error } = await supabase
       .from("professionals")
       .select(

--- a/app/foreign-investment/siv/page.tsx
+++ b/app/foreign-investment/siv/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import type { Metadata } from "next";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
-import { createAdminClient } from "@/lib/supabase/admin";
+import { createClient } from "@/lib/supabase/server";
 import { FOREIGN_INVESTOR_GENERAL_DISCLAIMER } from "@/lib/compliance";
 import ForeignInvestmentNav from "../ForeignInvestmentNav";
 import SectionHeading from "@/components/SectionHeading";
@@ -34,7 +34,7 @@ export const metadata: Metadata = {
 
 async function fetchSivFunds(): Promise<FundListing[]> {
   try {
-    const supabase = createAdminClient();
+    const supabase = await createClient();
     const { data } = await supabase
       .from("fund_listings")
       .select(


### PR DESCRIPTION
## Summary

- Replaces `createAdminClient()` (service-role) with `createClient()` (anon/server) in `app/foreign-investment/siv/page.tsx` and `app/advisors/search/page.tsx`
- Both tables queried (`fund_listings`, `professionals`) already carry explicit anon SELECT RLS policies — no new migrations needed
- Pure mechanical swap; no logic changes

## RLS policy coverage

**`fund_listings`:** `20260510_rls_hardening.sql` — `"Public read active fund_listings"` (FOR SELECT TO anon USING status='active'). The SIV page further filters by `siv_complying=true` — same or fewer rows than anon policy allows.

**`professionals`:** `20260305_create_advisor_directory.sql` — `"Public can view active professionals"` (FOR SELECT TO anon USING is_active=true). The advisors/search page queries `.eq("status", "active")` — equivalent filter intent.

## Test plan

- [ ] CI green (type-check, lint, build)
- [ ] `/foreign-investment/siv` renders SIV-complying fund cards via anon SELECT
- [ ] `/advisors/search` renders advisor list via anon SELECT
- [ ] Inactive advisors/funds correctly excluded (filtered by RLS + page query)

Refs: #218
Audit: docs/audits/codebase-health-2026-04-24.md (admin.ts scope, stream X)
Queue: docs/audits/REMEDIATION_QUEUE.md X-07

---
_Generated by [Claude Code](https://claude.ai/code/session_01EUUri6KCkmQ9AdmmbWyawK)_