### PR TITLE
fix(x): X-08 — swap go/apply page + annotate go-redirect route (keep-admin)

### DIFF
--- a/app/go/[slug]/apply/page.tsx
+++ b/app/go/[slug]/apply/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
-import { createAdminClient } from "@/lib/supabase/admin";
+import { createClient } from "@/lib/supabase/server";
 import ApplyClient from "./ApplyClient";
 
 export const revalidate = 3600;
@@ -31,7 +31,7 @@ export async function generateMetadata({
   params: Promise<{ slug: string }>;
 }): Promise<Metadata> {
   const { slug } = await params;
-  const supabase = createAdminClient();
+  const supabase = await createClient();
 
   const { data: broker } = await supabase
     .from("brokers")
@@ -56,7 +56,7 @@ export default async function ApplyPage({
   params: Promise<{ slug: string }>;
 }) {
   const { slug } = await params;
-  const supabase = createAdminClient();
+  const supabase = await createClient();
 
   const { data: broker } = await supabase
     .from("brokers")

--- a/app/go/[slug]/route.ts
+++ b/app/go/[slug]/route.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports -- X-08 keep-admin: route reads `campaigns` (service-role-only SELECT, no anon policy per 20260610120000 migration) for CPC billing and writes `affiliate_clicks` (anon-writable per 001_initial + 20260309, but same client used for consistency). Server-only redirect+telemetry endpoint; not a public RSC page.
 import { createAdminClient } from "@/lib/supabase/admin";
 import { NextRequest, NextResponse } from "next/server";
 import { createHash } from "crypto";


### PR DESCRIPTION
## Summary

- `app/go/[slug]/apply/page.tsx`: replaces `createAdminClient()` with `createClient()` (anon/server). Pure `brokers` SELECT — anon-readable.
- `app/go/[slug]/route.ts`: **retains** `createAdminClient()` but adds `eslint-disable-next-line no-restricted-imports` annotation documenting the justified exception.

## Why the route keeps admin client

`go/[slug]/route.ts` reads the `campaigns` table to look up CPC bid rates. `campaigns` has **no anon SELECT policy** — only `service_role` and authenticated-broker policies (per migration `20260610120000_a03_batch5_revenue_products.sql`). Swapping to the anon client would silently return `null` for every campaign lookup, breaking CPC billing revenue attribution. Documented as KEEP-ADMIN per X-01 decision matrix.

## RLS coverage for the swap

**`brokers`:** `001_initial.sql` — `"Public read for active brokers"` (FOR SELECT TO anon USING status='active'). The apply page already filters `.eq("status", "active")` — same row-set.

## Test plan

- [ ] CI green (type-check, lint, build)
- [ ] `/go/[slug]/apply` renders broker apply page via anon SELECT
- [ ] Inactive broker slugs correctly 404
- [ ] `go/[slug]` redirect still records CPC clicks correctly (route unchanged)

Refs: #218
Audit: docs/audits/codebase-health-2026-04-24.md (admin.ts scope, stream X)
Queue: docs/audits/REMEDIATION_QUEUE.md X-08

---
_Generated by [Claude Code](https://claude.ai/code/session_01EUUri6KCkmQ9AdmmbWyawK)_