### PR TITLE
feat: pre-launch product wave — country schemes, advisor billing ledger, no-lock-in

### DIFF
--- a/LOOP_PAUSE
+++ b/LOOP_PAUSE
@@ -1,0 +1,21 @@
+PAUSED 2026-05-09 by founder for loop-infrastructure overhaul.
+
+Reason: deep-dive audit identified high overhead (≈83% of token spend is
+baseline), poor scout precision (10/10 AA-/BB-DISC items false-positive in
+24h), iter-retry race on the queue file (5 retry pairs in 24h), 4,282-line
+queue file slowing every fire, and a duplicated priority paragraph in
+DEFAULTS.
+
+Edits in flight (single session):
+  A. Compact REMEDIATION_QUEUE.md → archive (target <1,200 lines)
+  B. Fix DEFAULTS duplicate paragraph + Tier-0 enforcement
+  C. Add queue-truncation safety guard to iteration command
+  D. Tighten scout confidence rule + stream-section-aware dedupe
+  E. Drop from 4 active routines → 2 (top + half past)
+  F. Auto-trigger CI on auto-rebase (eliminates ci: re-trigger churn)
+  G. Unblock-driven item-selection heuristic in iteration command
+  H. Per-stream ROI in loop-spend-tracker
+  I. Scout: daily cron → on-demand
+
+Resume: delete this file and push to main. Loop's next routine fire will
+pick up the new infrastructure.

--- a/__tests__/api/advisor-auth-tier-upgrade.test.ts
+++ b/__tests__/api/advisor-auth-tier-upgrade.test.ts
@@ -50,7 +50,7 @@ vi.mock("@/lib/stripe", () => ({
   }),
 }));
 
-const mockRecordLedgerEntry = vi.fn(() =>
+const mockRecordLedgerEntry = vi.fn((..._args: unknown[]) =>
   Promise.resolve({ entry: { id: 1 }, balanceAfterCents: 0, idempotent: false }),
 );
 vi.mock("@/lib/advisor-credit-ledger", () => ({

--- a/__tests__/api/advisor-auth-tier-upgrade.test.ts
+++ b/__tests__/api/advisor-auth-tier-upgrade.test.ts
@@ -42,10 +42,19 @@ vi.mock("@/lib/url", () => ({
   getSiteUrl: () => "https://invest.com.au",
 }));
 
+const mockSubscriptionsUpdate = vi.fn();
 vi.mock("@/lib/stripe", () => ({
   getStripe: () => ({
     checkout: { sessions: { create: mockCheckoutCreate } },
+    subscriptions: { update: (...args: unknown[]) => mockSubscriptionsUpdate(...args) },
   }),
+}));
+
+const mockRecordLedgerEntry = vi.fn(() =>
+  Promise.resolve({ entry: { id: 1 }, balanceAfterCents: 0, idempotent: false }),
+);
+vi.mock("@/lib/advisor-credit-ledger", () => ({
+  recordLedgerEntry: (...args: unknown[]) => mockRecordLedgerEntry(...args),
 }));
 
 import { POST } from "@/app/api/advisor-auth/tier-upgrade/route";
@@ -203,23 +212,34 @@ describe("POST /api/advisor-auth/tier-upgrade", () => {
     expect(json.message).toBe("Already on this tier");
   });
 
-  it("downgrades immediately, audits, and enqueues confirmation email", async () => {
+  it("defers downgrade to end of cycle, writes proration credit, queues email", async () => {
     withAdvisorTier("pro");
     const res = await POST(
       makePost({ target_tier: "growth", billing: "monthly" }),
     );
     expect(res.status).toBe(200);
     const json = await res.json();
-    expect(json.action).toBe("downgraded");
-    expect(json.tier).toBe("growth");
+    // No more immediate flip — the action is now deferred_downgrade.
+    expect(json.action).toBe("deferred_downgrade");
+    expect(json.pending_tier).toBe("growth");
+    expect(json.tier).toBe("pro"); // current tier UNCHANGED until cycle end
+    expect(json.pending_tier_effective_at).toBeTruthy();
 
-    // Direct stamp on professionals
+    // pending_tier stamped on the advisor row (advisor_tier untouched here).
     const proCalls = supabaseCalls.professionals || [];
     const updateCall = proCalls.find((c) => c.method === "update");
     expect(updateCall).toBeDefined();
     const updateArgs = updateCall?.args[0] as Record<string, unknown>;
-    expect(updateArgs.advisor_tier).toBe("growth");
-    expect(updateArgs.tier_change_reason).toBe("self_service_downgrade");
+    expect(updateArgs.pending_tier).toBe("growth");
+    expect(updateArgs.advisor_tier).toBeUndefined();
+
+    // Proration credit lands via the ledger helper.
+    expect(mockRecordLedgerEntry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "tier_proration_credit",
+        professionalId: 42,
+      }),
+    );
 
     expect(mockRecordFinancialAudit).toHaveBeenCalled();
     expect(mockEnqueueJob).toHaveBeenCalledWith(

--- a/__tests__/api/advisor-billing-portal.test.ts
+++ b/__tests__/api/advisor-billing-portal.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() })),
+}));
+
+const mockRequireAdvisorSession = vi.fn();
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: (...args: unknown[]) => mockRequireAdvisorSession(...args),
+}));
+
+const mockIsRateLimited = vi.fn();
+vi.mock("@/lib/rate-limit", () => ({
+  isRateLimited: (...args: unknown[]) => mockIsRateLimited(...args),
+}));
+
+const mockGetSiteUrl = vi.fn(() => "https://invest.com.au");
+vi.mock("@/lib/url", () => ({ getSiteUrl: () => mockGetSiteUrl() }));
+
+const mockPortalCreate = vi.fn();
+const mockGetStripe = vi.fn();
+vi.mock("@/lib/stripe", () => ({
+  getStripe: () => mockGetStripe(),
+}));
+
+let proRow: { stripe_customer_id: string | null } | null = null;
+const mockMaybeSingle = vi.fn(async () => ({ data: proRow }));
+const mockEq = vi.fn().mockReturnValue({ maybeSingle: mockMaybeSingle });
+const mockSelect = vi.fn().mockReturnValue({ eq: mockEq });
+const mockFrom = vi.fn().mockReturnValue({ select: mockSelect });
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({ from: mockFrom }),
+}));
+
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/advisor-auth/billing-portal/route";
+
+function makeReq(): NextRequest {
+  return new NextRequest("https://invest.com.au/api/advisor-auth/billing-portal", {
+    method: "POST",
+    headers: { "x-forwarded-for": "1.2.3.4" },
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  proRow = null;
+  mockIsRateLimited.mockResolvedValue(false);
+  mockRequireAdvisorSession.mockResolvedValue(1);
+  mockGetStripe.mockReturnValue({
+    billingPortal: {
+      sessions: {
+        create: (...args: unknown[]) => mockPortalCreate(...args),
+      },
+    },
+  });
+  mockPortalCreate.mockResolvedValue({ url: "https://billing.stripe.com/session/abc" });
+  proRow = { stripe_customer_id: "cus_123" };
+});
+
+afterEach(() => {
+  delete process.env.STRIPE_SECRET_KEY;
+});
+
+describe("POST /api/advisor-auth/billing-portal", () => {
+  it("429 when rate limit trips", async () => {
+    mockIsRateLimited.mockResolvedValueOnce(true);
+    const res = await POST(makeReq());
+    expect(res.status).toBe(429);
+  });
+
+  it("401 when not authenticated", async () => {
+    mockRequireAdvisorSession.mockResolvedValueOnce(null);
+    const res = await POST(makeReq());
+    expect(res.status).toBe(401);
+  });
+
+  it("404 when advisor has no stripe_customer_id", async () => {
+    proRow = { stripe_customer_id: null };
+    const res = await POST(makeReq());
+    expect(res.status).toBe(404);
+  });
+
+  it("503 when Stripe is not configured", async () => {
+    mockGetStripe.mockImplementationOnce(() => {
+      throw new Error("no stripe key");
+    });
+    const res = await POST(makeReq());
+    expect(res.status).toBe(503);
+  });
+
+  it("200 with portal URL on success", async () => {
+    const res = await POST(makeReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.url).toBe("https://billing.stripe.com/session/abc");
+  });
+
+  it("uses an idempotency key shaped advisor_portal_<id>_<minute>", async () => {
+    await POST(makeReq());
+    const call = mockPortalCreate.mock.calls[0];
+    expect(call?.[1]?.idempotencyKey).toMatch(/^advisor_portal_1_\d+$/);
+  });
+
+  it("500 when Stripe call fails", async () => {
+    mockPortalCreate.mockRejectedValueOnce(new Error("network"));
+    const res = await POST(makeReq());
+    expect(res.status).toBe(500);
+  });
+});

--- a/__tests__/api/advisor-tier-upgrade-pending.test.ts
+++ b/__tests__/api/advisor-tier-upgrade-pending.test.ts
@@ -36,7 +36,9 @@ let advisorRow: {
 } | null = null;
 let prorationRows: Array<{ id: number; amount_cents: number; reference_id: string }> = [];
 let subRow: { stripe_subscription_id: string } | null = null;
-const mockUpdate = vi.fn(() => ({ eq: vi.fn().mockResolvedValue({ data: null, error: null }) }));
+const mockUpdate = vi.fn((_payload: Record<string, unknown>) => ({
+  eq: vi.fn().mockResolvedValue({ data: null, error: null }),
+}));
 
 vi.mock("@/lib/supabase/admin", () => ({
   createAdminClient: () => ({

--- a/__tests__/api/advisor-tier-upgrade-pending.test.ts
+++ b/__tests__/api/advisor-tier-upgrade-pending.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() })),
+}));
+
+const mockRequireAdvisorSession = vi.fn();
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: (...args: unknown[]) => mockRequireAdvisorSession(...args),
+}));
+
+const mockRecordLedgerEntry = vi.fn();
+vi.mock("@/lib/advisor-credit-ledger", () => ({
+  recordLedgerEntry: (...args: unknown[]) => mockRecordLedgerEntry(...args),
+}));
+
+const mockRecordFinancialAudit = vi.fn();
+vi.mock("@/lib/financial-audit", () => ({
+  recordFinancialAudit: (...args: unknown[]) => mockRecordFinancialAudit(...args),
+}));
+
+const mockSubscriptionsUpdate = vi.fn();
+vi.mock("@/lib/stripe", () => ({
+  getStripe: () => ({
+    subscriptions: { update: (...args: unknown[]) => mockSubscriptionsUpdate(...args) },
+  }),
+}));
+
+let advisorRow: {
+  id: number;
+  email: string;
+  advisor_tier: string;
+  stripe_customer_id: string | null;
+  pending_tier: string | null;
+  pending_tier_effective_at: string | null;
+} | null = null;
+let prorationRows: Array<{ id: number; amount_cents: number; reference_id: string }> = [];
+let subRow: { stripe_subscription_id: string } | null = null;
+const mockUpdate = vi.fn(() => ({ eq: vi.fn().mockResolvedValue({ data: null, error: null }) }));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({
+    from: vi.fn().mockImplementation((table: string) => {
+      if (table === "professionals") {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              maybeSingle: vi.fn().mockResolvedValue({ data: advisorRow }),
+            }),
+          }),
+          update: mockUpdate,
+        };
+      }
+      if (table === "advisor_credit_ledger") {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                order: vi.fn().mockReturnValue({
+                  limit: vi.fn().mockResolvedValue({ data: prorationRows, error: null }),
+                }),
+              }),
+            }),
+          }),
+        };
+      }
+      if (table === "subscriptions") {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              in: vi.fn().mockReturnValue({
+                order: vi.fn().mockReturnValue({
+                  limit: vi.fn().mockReturnValue({
+                    maybeSingle: vi.fn().mockResolvedValue({ data: subRow }),
+                  }),
+                }),
+              }),
+            }),
+          }),
+        };
+      }
+      return {};
+    }),
+  }),
+}));
+
+import { NextRequest } from "next/server";
+import { DELETE } from "@/app/api/advisor-auth/tier-upgrade/pending/route";
+
+function makeReq() {
+  return new NextRequest("https://invest.com.au/api/advisor-auth/tier-upgrade/pending", {
+    method: "DELETE",
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  advisorRow = {
+    id: 1,
+    email: "advisor@x.co",
+    advisor_tier: "pro",
+    stripe_customer_id: "cus_xxx",
+    pending_tier: "growth",
+    pending_tier_effective_at: new Date(Date.now() + 7 * 86400_000).toISOString(),
+  };
+  prorationRows = [{ id: 99, amount_cents: 5000, reference_id: "pro_1_123" }];
+  subRow = { stripe_subscription_id: "sub_xxx" };
+  mockRequireAdvisorSession.mockResolvedValue(1);
+  mockRecordLedgerEntry.mockResolvedValue({
+    entry: { id: 100 },
+    balanceAfterCents: 0,
+    idempotent: false,
+  });
+  mockSubscriptionsUpdate.mockResolvedValue({});
+  mockRecordFinancialAudit.mockResolvedValue(undefined);
+  process.env.STRIPE_SECRET_KEY = "sk_test_xxx";
+});
+
+describe("DELETE /api/advisor-auth/tier-upgrade/pending", () => {
+  it("401 when not authenticated", async () => {
+    mockRequireAdvisorSession.mockResolvedValueOnce(null);
+    const res = await DELETE(makeReq());
+    expect(res.status).toBe(401);
+  });
+
+  it("404 when advisor not found", async () => {
+    advisorRow = null;
+    const res = await DELETE(makeReq());
+    expect(res.status).toBe(404);
+  });
+
+  it("404 when no pending downgrade is queued", async () => {
+    advisorRow = { ...advisorRow!, pending_tier: null };
+    const res = await DELETE(makeReq());
+    expect(res.status).toBe(404);
+  });
+
+  it("claws back the proration credit via admin_adjustment ledger entry", async () => {
+    const res = await DELETE(makeReq());
+    expect(res.status).toBe(200);
+    expect(mockRecordLedgerEntry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        professionalId: 1,
+        amountCents: -5000, // negative — claws back the prior +5000
+        kind: "admin_adjustment",
+        referenceType: "tier_downgrade_clawback",
+      }),
+    );
+  });
+
+  it("calls Stripe subscriptions.update with cancel_at_period_end=false", async () => {
+    await DELETE(makeReq());
+    expect(mockSubscriptionsUpdate).toHaveBeenCalledWith(
+      "sub_xxx",
+      expect.objectContaining({ cancel_at_period_end: false }),
+    );
+  });
+
+  it("clears pending_tier and pending_tier_effective_at on the advisor row", async () => {
+    await DELETE(makeReq());
+    const lastCall = mockUpdate.mock.calls[mockUpdate.mock.calls.length - 1];
+    const payload = lastCall?.[0] as Record<string, unknown>;
+    expect(payload.pending_tier).toBeNull();
+    expect(payload.pending_tier_effective_at).toBeNull();
+  });
+
+  it("returns the cancelled tier label and clawback amount", async () => {
+    const res = await DELETE(makeReq());
+    const body = await res.json();
+    expect(body.cancelled_pending_tier).toBe("growth");
+    expect(body.clawback_cents).toBe(-5000);
+  });
+
+  it("skips Stripe call when STRIPE_SECRET_KEY is unset", async () => {
+    delete process.env.STRIPE_SECRET_KEY;
+    await DELETE(makeReq());
+    expect(mockSubscriptionsUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/PinnedBillingWidget.test.tsx
+++ b/__tests__/components/PinnedBillingWidget.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import PinnedBillingWidget from "@/app/advisor-portal/billing/PinnedBillingWidget";
+import type { BillingSummary } from "@/app/advisor-portal/billing/types";
+
+function summary(overrides: Partial<BillingSummary> = {}): BillingSummary {
+  return {
+    balance_cents: 50000,
+    lifetime_credit_cents: 50000,
+    lifetime_spend_cents: 12000,
+    expiring_soon_cents: 0,
+    free_leads_used: 3,
+    free_leads_remaining: 0,
+    lead_price_cents: 4900,
+    advisor_tier: "free",
+    pending_tier: null,
+    pending_tier_effective_at: null,
+    has_payment_method: true,
+    has_stripe_customer: true,
+    ledger_first_page: [],
+    ledger_total: 0,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("PinnedBillingWidget", () => {
+  it("shows the Healthy pill when there's plenty of credit", () => {
+    render(<PinnedBillingWidget summary={summary()} />);
+    expect(screen.getByText("Healthy")).toBeTruthy();
+  });
+
+  it("shows the Low credit pill when fewer than 3 leads' worth remain", () => {
+    render(
+      <PinnedBillingWidget summary={summary({ balance_cents: 9000, lead_price_cents: 4900 })} />,
+    );
+    expect(screen.getByText("Low credit")).toBeTruthy();
+  });
+
+  it("shows the Top up pill when balance is empty", () => {
+    render(<PinnedBillingWidget summary={summary({ balance_cents: 0 })} />);
+    expect(screen.getByText("Top up")).toBeTruthy();
+  });
+
+  it("shows the Downgrade scheduled pill when a pending_tier is set", () => {
+    render(
+      <PinnedBillingWidget
+        summary={summary({
+          pending_tier: "free",
+          pending_tier_effective_at: new Date(Date.now() + 7 * 86400_000).toISOString(),
+        })}
+      />,
+    );
+    expect(screen.getByText("Downgrade scheduled")).toBeTruthy();
+  });
+
+  it("renders the credit balance in dollars and the leads-remaining estimate", () => {
+    render(
+      <PinnedBillingWidget summary={summary({ balance_cents: 49000, lead_price_cents: 4900 })} />,
+    );
+    expect(screen.getByText(/\$490/)).toBeTruthy();
+    expect(screen.getByText(/10 leads/)).toBeTruthy();
+  });
+});

--- a/__tests__/lib/advisor-credit-ledger.test.ts
+++ b/__tests__/lib/advisor-credit-ledger.test.ts
@@ -1,0 +1,404 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+interface LedgerRow {
+  id: number;
+  professional_id: number;
+  amount_cents: number;
+  balance_after_cents: number;
+  kind: string;
+  reference_type: string | null;
+  reference_id: string | null;
+  description: string;
+  metadata: Record<string, unknown>;
+  expires_at: string | null;
+  created_by: string | null;
+  created_at: string;
+}
+
+interface ProRow {
+  id: number;
+  credit_balance_cents: number;
+  lifetime_credit_cents: number;
+  lifetime_lead_spend_cents: number;
+}
+
+let ledger: LedgerRow[] = [];
+let pros: ProRow[] = [];
+let nextLedgerId = 1;
+
+function reset() {
+  ledger = [];
+  pros = [
+    { id: 1, credit_balance_cents: 0, lifetime_credit_cents: 0, lifetime_lead_spend_cents: 0 },
+    { id: 2, credit_balance_cents: 5000, lifetime_credit_cents: 5000, lifetime_lead_spend_cents: 0 },
+  ];
+  nextLedgerId = 1;
+}
+
+const supabaseStub = {
+  from(table: string) {
+    if (table === "advisor_credit_ledger") {
+      return ledgerTableStub();
+    }
+    if (table === "professionals") {
+      return prosTableStub();
+    }
+    throw new Error(`unexpected table: ${table}`);
+  },
+};
+
+function ledgerTableStub() {
+  const filters: Record<string, unknown> = {};
+  let rangeArgs: [number, number] | null = null;
+  let countMode = false;
+
+  const builder = {
+    select: vi.fn((_cols: string, opts?: { count?: string }) => {
+      if (opts?.count === "exact") countMode = true;
+      return builder;
+    }),
+    insert: vi.fn((row: Partial<LedgerRow>) => insertOp(row)),
+    eq: vi.fn((col: string, val: unknown) => {
+      filters[col] = val;
+      return builder;
+    }),
+    gt: vi.fn((col: string, val: unknown) => {
+      filters[`__gt_${col}`] = val;
+      return builder;
+    }),
+    lte: vi.fn((col: string, val: unknown) => {
+      filters[`__lte_${col}`] = val;
+      return builder;
+    }),
+    not: vi.fn((col: string, _op: string, _val: unknown) => {
+      filters[`__notNull_${col}`] = true;
+      return builder;
+    }),
+    order: vi.fn(() => builder),
+    range: vi.fn((from: number, to: number) => {
+      rangeArgs = [from, to];
+      return resolveSelect();
+    }),
+    maybeSingle: () => {
+      const matches = applyFilters(ledger, filters);
+      return Promise.resolve({ data: matches[0] ?? null, error: null });
+    },
+    single: () => {
+      const matches = applyFilters(ledger, filters);
+      return Promise.resolve(
+        matches[0]
+          ? { data: matches[0], error: null }
+          : { data: null, error: { message: "no row" } },
+      );
+    },
+    then: (cb: (v: { data: LedgerRow[]; error: null }) => unknown) =>
+      Promise.resolve({ data: applyFilters(ledger, filters), error: null }).then(cb),
+  } as Record<string, unknown> & PromiseLike<{ data: LedgerRow[]; error: null }>;
+
+  function resolveSelect() {
+    const matched = applyFilters(ledger, filters);
+    const sliced = rangeArgs
+      ? matched.slice(rangeArgs[0], rangeArgs[1] + 1)
+      : matched;
+    if (countMode) {
+      return Promise.resolve({ data: sliced, error: null, count: matched.length });
+    }
+    return Promise.resolve({ data: sliced, error: null });
+  }
+
+  function insertOp(row: Partial<LedgerRow>) {
+    const refType = row.reference_type ?? null;
+    const refId = row.reference_id ?? null;
+    if (refType !== null && refId !== null) {
+      const existing = ledger.find(
+        (l) => l.kind === row.kind && l.reference_type === refType && l.reference_id === refId,
+      );
+      if (existing) {
+        return chainSelectSingle(null, { code: "23505", message: "duplicate key" });
+      }
+    }
+    const inserted: LedgerRow = {
+      id: nextLedgerId++,
+      professional_id: row.professional_id ?? 0,
+      amount_cents: row.amount_cents ?? 0,
+      balance_after_cents: row.balance_after_cents ?? 0,
+      kind: row.kind ?? "topup",
+      reference_type: refType,
+      reference_id: refId,
+      description: row.description ?? "",
+      metadata: row.metadata ?? {},
+      expires_at: row.expires_at ?? null,
+      created_by: row.created_by ?? null,
+      created_at: new Date().toISOString(),
+    };
+    ledger.push(inserted);
+    return chainSelectSingle(inserted, null);
+  }
+
+  function chainSelectSingle(data: LedgerRow | null, error: { code?: string; message: string } | null) {
+    return {
+      select: vi.fn(() => ({
+        single: () => Promise.resolve({ data, error }),
+      })),
+    };
+  }
+
+  return builder;
+}
+
+function prosTableStub() {
+  let updates: Record<string, unknown> | null = null;
+  const filters: Record<string, unknown> = {};
+  const builder = {
+    select: vi.fn(() => builder),
+    update: vi.fn((u: Record<string, unknown>) => {
+      updates = u;
+      return builder;
+    }),
+    eq: vi.fn((col: string, val: unknown) => {
+      filters[col] = val;
+      return builder;
+    }),
+    single: () => {
+      const id = filters["id"] as number | undefined;
+      const pro = pros.find((p) => p.id === id);
+      if (!pro) return Promise.resolve({ data: null, error: { message: "not found" } });
+      // If updates were stacked, return updated row; otherwise current.
+      if (updates) {
+        const balanceCheck = filters["credit_balance_cents"];
+        if (typeof balanceCheck === "number" && pro.credit_balance_cents !== balanceCheck) {
+          updates = null;
+          return Promise.resolve({ data: null, error: { code: "P0001", message: "stale" } });
+        }
+        Object.assign(pro, updates);
+        updates = null;
+      }
+      return Promise.resolve({ data: pro, error: null });
+    },
+    then: (cb: (v: { data: null; error: null }) => unknown) => {
+      // For update without .single() — apply
+      if (updates) {
+        const id = filters["id"] as number | undefined;
+        const pro = pros.find((p) => p.id === id);
+        const balanceCheck = filters["credit_balance_cents"];
+        if (
+          pro &&
+          (typeof balanceCheck !== "number" || pro.credit_balance_cents === balanceCheck)
+        ) {
+          Object.assign(pro, updates);
+          updates = null;
+          return Promise.resolve({ data: null, error: null }).then(cb);
+        }
+        updates = null;
+        return Promise.resolve({
+          data: null,
+          error: { code: "P0001", message: "stale" },
+        }).then(cb);
+      }
+      return Promise.resolve({ data: null, error: null }).then(cb);
+    },
+  };
+  return builder;
+}
+
+function applyFilters(rows: LedgerRow[], filters: Record<string, unknown>) {
+  return rows
+    .filter((r) => {
+      for (const [key, val] of Object.entries(filters)) {
+        if (key.startsWith("__gt_")) {
+          const col = key.slice(5) as keyof LedgerRow;
+          if (!(typeof r[col] === "number" && (r[col] as number) > (val as number))) return false;
+          continue;
+        }
+        if (key.startsWith("__lte_")) {
+          const col = key.slice(6) as keyof LedgerRow;
+          const cellVal = r[col];
+          if (cellVal == null) return false;
+          if (cellVal > val!) return false;
+          continue;
+        }
+        if (key.startsWith("__notNull_")) {
+          const col = key.slice(10) as keyof LedgerRow;
+          if (r[col] == null) return false;
+          continue;
+        }
+        if ((r as Record<string, unknown>)[key] !== val) return false;
+      }
+      return true;
+    })
+    .sort((a, b) => b.created_at.localeCompare(a.created_at));
+}
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => supabaseStub,
+}));
+
+beforeEach(() => {
+  reset();
+});
+
+describe("recordLedgerEntry", () => {
+  it("inserts a topup row, updates the cache, and returns the post-balance", async () => {
+    const { recordLedgerEntry } = await import("@/lib/advisor-credit-ledger");
+    const result = await recordLedgerEntry({
+      professionalId: 1,
+      amountCents: 4900,
+      kind: "topup",
+      description: "test",
+      referenceType: "advisor_credit_topup",
+      referenceId: "42",
+      createdBy: "webhook",
+    });
+    expect(result.idempotent).toBe(false);
+    expect(result.balanceAfterCents).toBe(4900);
+    expect(pros.find((p) => p.id === 1)?.credit_balance_cents).toBe(4900);
+    expect(ledger).toHaveLength(1);
+    expect(ledger[0]?.kind).toBe("topup");
+  });
+
+  it("is idempotent under (kind, reference_type, reference_id) triple", async () => {
+    const { recordLedgerEntry } = await import("@/lib/advisor-credit-ledger");
+    await recordLedgerEntry({
+      professionalId: 1,
+      amountCents: 4900,
+      kind: "topup",
+      description: "first",
+      referenceType: "advisor_credit_topup",
+      referenceId: "42",
+    });
+    const second = await recordLedgerEntry({
+      professionalId: 1,
+      amountCents: 4900,
+      kind: "topup",
+      description: "duplicate replay",
+      referenceType: "advisor_credit_topup",
+      referenceId: "42",
+    });
+    expect(second.idempotent).toBe(true);
+    expect(ledger).toHaveLength(1); // no double insert
+    expect(pros.find((p) => p.id === 1)?.credit_balance_cents).toBe(4900); // no double credit
+  });
+
+  it("debits balance for negative amounts (lead_spend)", async () => {
+    const { recordLedgerEntry } = await import("@/lib/advisor-credit-ledger");
+    pros[0]!.credit_balance_cents = 5000;
+    const result = await recordLedgerEntry({
+      professionalId: 1,
+      amountCents: -3900,
+      kind: "lead_spend",
+      description: "lead",
+      referenceType: "professional_lead",
+      referenceId: "9",
+    });
+    expect(result.balanceAfterCents).toBe(1100);
+    expect(pros[0]?.credit_balance_cents).toBe(1100);
+    expect(pros[0]?.lifetime_lead_spend_cents).toBe(3900);
+  });
+
+  it("increments lifetime_credit_cents only for credit kinds", async () => {
+    const { recordLedgerEntry } = await import("@/lib/advisor-credit-ledger");
+    await recordLedgerEntry({
+      professionalId: 1,
+      amountCents: 10000,
+      kind: "topup",
+      description: "topup",
+      referenceType: "advisor_credit_topup",
+      referenceId: "100",
+    });
+    await recordLedgerEntry({
+      professionalId: 1,
+      amountCents: 5000,
+      kind: "refund_to_credit",
+      description: "refund",
+      referenceType: "stripe_charge",
+      referenceId: "ch_abc",
+    });
+    expect(pros[0]?.lifetime_credit_cents).toBe(15000);
+  });
+
+  it("does not double-count lifetime_credit on idempotent re-runs", async () => {
+    const { recordLedgerEntry } = await import("@/lib/advisor-credit-ledger");
+    await recordLedgerEntry({
+      professionalId: 1,
+      amountCents: 10000,
+      kind: "topup",
+      description: "first",
+      referenceType: "advisor_credit_topup",
+      referenceId: "100",
+    });
+    await recordLedgerEntry({
+      professionalId: 1,
+      amountCents: 10000,
+      kind: "topup",
+      description: "replay",
+      referenceType: "advisor_credit_topup",
+      referenceId: "100",
+    });
+    expect(pros[0]?.lifetime_credit_cents).toBe(10000); // not 20000
+    expect(pros[0]?.credit_balance_cents).toBe(10000);
+  });
+
+  it("throws when the advisor doesn't exist", async () => {
+    const { recordLedgerEntry } = await import("@/lib/advisor-credit-ledger");
+    await expect(
+      recordLedgerEntry({
+        professionalId: 999,
+        amountCents: 1000,
+        kind: "topup",
+        description: "no advisor",
+      }),
+    ).rejects.toThrow();
+  });
+});
+
+describe("computeBalance", () => {
+  it("sums all ledger amounts for a professional", async () => {
+    const { recordLedgerEntry, computeBalance } = await import("@/lib/advisor-credit-ledger");
+    await recordLedgerEntry({
+      professionalId: 1, amountCents: 10000, kind: "topup",
+      description: "t1", referenceType: "advisor_credit_topup", referenceId: "1",
+    });
+    await recordLedgerEntry({
+      professionalId: 1, amountCents: -3000, kind: "lead_spend",
+      description: "s1", referenceType: "professional_lead", referenceId: "11",
+    });
+    await recordLedgerEntry({
+      professionalId: 1, amountCents: 1500, kind: "refund_to_credit",
+      description: "r1", referenceType: "stripe_charge", referenceId: "ch_1",
+    });
+    expect(await computeBalance(1)).toBe(8500);
+  });
+
+  it("returns 0 for an advisor with no ledger rows", async () => {
+    const { computeBalance } = await import("@/lib/advisor-credit-ledger");
+    expect(await computeBalance(1)).toBe(0);
+  });
+});
+
+describe("getLedgerPage", () => {
+  it("returns rows newest first with the total count", async () => {
+    const { recordLedgerEntry, getLedgerPage } = await import("@/lib/advisor-credit-ledger");
+    for (let i = 0; i < 5; i++) {
+      await recordLedgerEntry({
+        professionalId: 1,
+        amountCents: 1000,
+        kind: "topup",
+        description: `t${i}`,
+        referenceType: "advisor_credit_topup",
+        referenceId: String(i),
+      });
+    }
+    const page = await getLedgerPage(1, { limit: 3, offset: 0 });
+    expect(page.rows).toHaveLength(3);
+    expect(page.total).toBe(5);
+  });
+});

--- a/__tests__/lib/advisor-credit-ledger.test.ts
+++ b/__tests__/lib/advisor-credit-ledger.test.ts
@@ -184,7 +184,7 @@ function prosTableStub() {
       }
       return Promise.resolve({ data: pro, error: null });
     },
-    then: (cb: (v: { data: null; error: null }) => unknown) => {
+    then: (cb: (v: { data: null; error: { code?: string; message: string } | null }) => unknown) => {
       // For update without .single() — apply
       if (updates) {
         const id = filters["id"] as number | undefined;
@@ -231,7 +231,7 @@ function applyFilters(rows: LedgerRow[], filters: Record<string, unknown>) {
           if (r[col] == null) return false;
           continue;
         }
-        if ((r as Record<string, unknown>)[key] !== val) return false;
+        if ((r as unknown as Record<string, unknown>)[key] !== val) return false;
       }
       return true;
     })

--- a/__tests__/lib/advisor-lead-dispute-resolver.test.ts
+++ b/__tests__/lib/advisor-lead-dispute-resolver.test.ts
@@ -80,6 +80,60 @@ function updateChain(error: unknown = null) {
   return { update: vi.fn().mockReturnValue(chain) };
 }
 
+/**
+ * Insert chain that returns the inserted row (for advisor_credit_ledger).
+ *   .insert(row).select("*").single() → { data, error }
+ */
+function insertChain(row: Record<string, unknown>) {
+  return {
+    insert: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        single: vi.fn(() => Promise.resolve({ data: row, error: null })),
+      }),
+    }),
+  };
+}
+
+/** Helper: build the 4 mockFrom slots that recordLedgerEntry consumes
+ * for a fresh credit insert (no prior idempotent row, advisor exists,
+ * insert succeeds, cache update succeeds).
+ */
+function pushLedgerEntrySlots(opts: {
+  professionalId: number;
+  amountCents: number;
+  beforeBalance: number;
+  ledgerId: number;
+  kind: string;
+  refType: string;
+  refId: string;
+}) {
+  const afterBalance = opts.beforeBalance + opts.amountCents;
+  // 1. Idempotency check on advisor_credit_ledger (returns null = first time)
+  mockFrom.mockImplementationOnce(() => maybySingle(null));
+  // 2. Read professionals row (current balance + lifetime totals)
+  mockFrom.mockImplementationOnce(() =>
+    singleResult({
+      credit_balance_cents: opts.beforeBalance,
+      lifetime_credit_cents: 0,
+      lifetime_lead_spend_cents: 0,
+    }),
+  );
+  // 3. Insert into advisor_credit_ledger
+  mockFrom.mockImplementationOnce(() =>
+    insertChain({
+      id: opts.ledgerId,
+      professional_id: opts.professionalId,
+      amount_cents: opts.amountCents,
+      balance_after_cents: afterBalance,
+      kind: opts.kind,
+      reference_type: opts.refType,
+      reference_id: opts.refId,
+    }),
+  );
+  // 4. Update professionals.credit_balance_cents (cache write)
+  mockFrom.mockImplementationOnce(() => updateChain());
+}
+
 // ── Fixtures ─────────────────────────────────────────────────────────────────
 
 const DISPUTE_ID = 42;
@@ -266,17 +320,24 @@ describe("autoResolveDispute", () => {
     expect(result.refundedCents).toBe(0);
   });
 
-  it("refund verdict — credits advisor balance and closes dispute", async () => {
+  it("refund verdict — credits advisor balance via ledger and closes dispute", async () => {
     setupContextMocks();
     mockClassifyDispute.mockReturnValue({
       verdict: "refund",
       confidence: "high",
       reasons: ["spam_likely"],
     });
-    // applyRefund DB sequence:
+    // applyRefund routes the credit through recordLedgerEntry now.
+    pushLedgerEntrySlots({
+      professionalId: 1,
+      amountCents: 4900,
+      beforeBalance: 10000,
+      ledgerId: 99,
+      kind: "lead_dispute_refund",
+      refType: "advisor_lead_disputes",
+      refId: String(DISPUTE_ID),
+    });
     mockFrom
-      .mockImplementationOnce(() => singleResult({ credit_balance_cents: 10000 })) // read balance
-      .mockImplementationOnce(() => updateChain())                                  // update balance
       .mockImplementationOnce(() => updateChain())                                  // mark lead
       .mockImplementationOnce(() => updateChain())                                  // waive billing
       .mockImplementationOnce(() => updateChain());                                 // close dispute
@@ -310,13 +371,15 @@ describe("autoResolveDispute", () => {
     expect(mockRecordFinancialAudit).not.toHaveBeenCalled();
   });
 
-  it("credit update DB error — falls back to escalate", async () => {
+  it("credit ledger error — falls back to escalate", async () => {
     setupContextMocks();
     mockClassifyDispute.mockReturnValue({ verdict: "refund", confidence: "high", reasons: [] });
+    // Idempotency check passes (no prior row), but the professionals
+    // read fails — recordLedgerEntry throws, dispute resolver escalates.
     mockFrom
-      .mockImplementationOnce(() => singleResult({ credit_balance_cents: 5000 })) // read balance
-      .mockImplementationOnce(() => updateChain({ message: "conflict" }))          // update FAILS
-      .mockImplementationOnce(() => updateChain());                                // escalated fallback dispute update
+      .mockImplementationOnce(() => maybySingle(null))                              // no prior ledger row
+      .mockImplementationOnce(() => singleResult(null, { message: "advisor read failed" })) // read fails
+      .mockImplementationOnce(() => updateChain());                                 // escalated fallback dispute update
 
     const result = await autoResolveDispute(DISPUTE_ID);
     expect(result.verdict).toBe("escalate");
@@ -326,12 +389,19 @@ describe("autoResolveDispute", () => {
   it("records financial audit on successful refund", async () => {
     setupContextMocks();
     mockClassifyDispute.mockReturnValue({ verdict: "refund", confidence: "high", reasons: [] });
+    pushLedgerEntrySlots({
+      professionalId: 1,
+      amountCents: 4900,
+      beforeBalance: 0,
+      ledgerId: 100,
+      kind: "lead_dispute_refund",
+      refType: "advisor_lead_disputes",
+      refId: String(DISPUTE_ID),
+    });
     mockFrom
-      .mockImplementationOnce(() => singleResult({ credit_balance_cents: 0 }))
-      .mockImplementationOnce(() => updateChain())
-      .mockImplementationOnce(() => updateChain())
-      .mockImplementationOnce(() => updateChain())
-      .mockImplementationOnce(() => updateChain());
+      .mockImplementationOnce(() => updateChain())   // mark lead
+      .mockImplementationOnce(() => updateChain())   // waive billing
+      .mockImplementationOnce(() => updateChain());  // close dispute
     mockFrom.mockImplementationOnce(() => maybySingle(null)); // no email found
 
     await autoResolveDispute(DISPUTE_ID);

--- a/__tests__/lib/country-schemes.test.ts
+++ b/__tests__/lib/country-schemes.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  CountrySchemeSchema,
+  SchemeAudienceSchema,
+  SchemeCategorySchema,
+  CATEGORY_LABELS,
+  AUDIENCE_LABELS,
+  groupByCategory,
+  type CountryScheme,
+} from "@/lib/country-schemes";
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(),
+}));
+
+import { createClient } from "@/lib/supabase/server";
+const mockedCreateClient = vi.mocked(createClient);
+
+function row(overrides: Partial<CountryScheme> = {}): CountryScheme {
+  return {
+    id: 1,
+    country_code: "GB",
+    audience: "inbound_migrant",
+    category: "tax_concession",
+    name: "UK pension",
+    summary: "summary",
+    body_md: "body",
+    threshold_cents: null,
+    threshold_label: null,
+    source_name: "HMRC",
+    source_url: "https://gov.uk",
+    sourced_at: "2026-04-01",
+    stales_at: "2026-10-01",
+    display_order: 0,
+    active: true,
+    created_at: "2026-04-01T00:00:00Z",
+    updated_at: "2026-04-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("schema enums", () => {
+  it("rejects unknown audiences", () => {
+    expect(SchemeAudienceSchema.safeParse("rogue").success).toBe(false);
+    expect(SchemeAudienceSchema.safeParse("inbound_migrant").success).toBe(true);
+  });
+
+  it("rejects unknown categories", () => {
+    expect(SchemeCategorySchema.safeParse("hot_take").success).toBe(false);
+    expect(SchemeCategorySchema.safeParse("visa_pathway").success).toBe(true);
+  });
+
+  it("CATEGORY_LABELS covers every category enum value", () => {
+    for (const cat of SchemeCategorySchema.options) {
+      expect(CATEGORY_LABELS[cat]).toBeTruthy();
+    }
+  });
+
+  it("AUDIENCE_LABELS covers every audience enum value", () => {
+    for (const a of SchemeAudienceSchema.options) {
+      expect(AUDIENCE_LABELS[a]).toBeTruthy();
+    }
+  });
+});
+
+describe("CountrySchemeSchema", () => {
+  it("parses a valid row end to end", () => {
+    const parsed = CountrySchemeSchema.safeParse(row());
+    expect(parsed.success).toBe(true);
+  });
+
+  it("rejects a missing required field", () => {
+    const bad = { ...row(), source_url: undefined };
+    expect(CountrySchemeSchema.safeParse(bad).success).toBe(false);
+  });
+});
+
+describe("groupByCategory", () => {
+  it("groups rows by category preserving input order", () => {
+    const rows = [
+      row({ id: 1, category: "tax_concession" }),
+      row({ id: 2, category: "visa_pathway" }),
+      row({ id: 3, category: "tax_concession" }),
+    ];
+    const grouped = groupByCategory(rows);
+    expect(grouped).toHaveLength(2);
+    expect(grouped[0]?.category).toBe("tax_concession");
+    expect(grouped[0]?.rows.map((r) => r.id)).toEqual([1, 3]);
+    expect(grouped[1]?.category).toBe("visa_pathway");
+  });
+
+  it("returns empty array for no input", () => {
+    expect(groupByCategory([])).toEqual([]);
+  });
+});
+
+describe("getSchemesForCountry", () => {
+  beforeEach(() => {
+    mockedCreateClient.mockReset();
+  });
+
+  it("returns parsed rows for the requested country", async () => {
+    const mockQuery = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockResolvedValue({ data: [row({ id: 7, country_code: "GB" })], error: null }),
+    };
+    mockedCreateClient.mockResolvedValue({
+      from: vi.fn().mockReturnValue(mockQuery),
+    } as never);
+
+    const { getSchemesForCountry } = await import("@/lib/country-schemes");
+    const result = await getSchemesForCountry("gb");
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe(7);
+  });
+
+  it("uppercases the country code before query", async () => {
+    const eqSpy = vi.fn().mockReturnThis();
+    const mockQuery = {
+      select: vi.fn().mockReturnThis(),
+      eq: eqSpy,
+      order: vi.fn().mockResolvedValue({ data: [], error: null }),
+    };
+    mockedCreateClient.mockResolvedValue({
+      from: vi.fn().mockReturnValue(mockQuery),
+    } as never);
+
+    const { getSchemesForCountry } = await import("@/lib/country-schemes");
+    await getSchemesForCountry("gb");
+    expect(eqSpy).toHaveBeenCalledWith("country_code", "GB");
+  });
+
+  it("returns empty array on supabase failure", async () => {
+    mockedCreateClient.mockRejectedValue(new Error("boom"));
+    const { getSchemesForCountry } = await import("@/lib/country-schemes");
+    const result = await getSchemesForCountry("US");
+    expect(result).toEqual([]);
+  });
+
+  it("filters out rows that fail schema validation", async () => {
+    const mockQuery = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockResolvedValue({
+        data: [
+          row({ id: 1 }),
+          { id: 2, country_code: "GB" }, // missing required fields
+          row({ id: 3 }),
+        ],
+        error: null,
+      }),
+    };
+    mockedCreateClient.mockResolvedValue({
+      from: vi.fn().mockReturnValue(mockQuery),
+    } as never);
+
+    const { getSchemesForCountry } = await import("@/lib/country-schemes");
+    const result = await getSchemesForCountry("GB");
+    expect(result.map((r) => r.id)).toEqual([1, 3]);
+  });
+});

--- a/__tests__/lib/stripe-webhook/charge-refunded.test.ts
+++ b/__tests__/lib/stripe-webhook/charge-refunded.test.ts
@@ -262,3 +262,147 @@ describe("handleChargeRefunded", () => {
     expect(ctx.admin.from as ReturnType<typeof vi.fn>).toHaveBeenCalledWith("admin_audit_log");
   });
 });
+
+// ── Advisor refund-as-credit flow ────────────────────────────────────────────
+
+describe("handleChargeRefunded — advisor flow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function makeAdvisorCtx(opts: {
+    topupRow?: { id: number; professional_id: number; amount_cents: number; status?: string } | null;
+    billingRow?: { id: number; professional_id: number; amount_cents: number } | null;
+    priorRefunds?: Array<{ amount_cents: number }>;
+  }): WebhookContext {
+    const { topupRow = null, billingRow = null, priorRefunds = [] } = opts;
+    let topupCalls = 0;
+    let billingCalls = 0;
+
+    const adminFrom = vi.fn().mockImplementation((table: string) => {
+      if (table === "course_purchases" || table === "course_revenue") {
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          maybeSingle: vi.fn().mockResolvedValue({ data: null }),
+          ...writeBuilder(),
+        };
+      }
+      if (table === "wallet_transactions") {
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          maybeSingle: vi.fn().mockResolvedValue({ data: null }),
+        };
+      }
+      if (table === "consultation_bookings") {
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          maybeSingle: vi.fn().mockResolvedValue({ data: null }),
+        };
+      }
+      if (table === "advisor_credit_topups") {
+        topupCalls++;
+        if (topupCalls === 1) {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({ data: topupRow }),
+          };
+        }
+        return writeBuilder();
+      }
+      if (table === "advisor_billing") {
+        billingCalls++;
+        if (billingCalls === 1) {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({ data: billingRow }),
+          };
+        }
+        return writeBuilder();
+      }
+      if (table === "advisor_credit_ledger") {
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          then: vi.fn((cb: (v: unknown) => void) => {
+            cb({ data: priorRefunds });
+            return Promise.resolve();
+          }),
+          insert: vi.fn().mockReturnThis(),
+        };
+      }
+      if (table === "professionals") {
+        // recordLedgerEntry reads/updates this; balance starts at 0
+        return {
+          select: vi.fn().mockReturnThis(),
+          update: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue({
+            data: { credit_balance_cents: 0, lifetime_credit_cents: 0, lifetime_lead_spend_cents: 0 },
+            error: null,
+          }),
+          then: vi.fn((cb: (v: unknown) => void) => {
+            cb({ data: null, error: null });
+            return Promise.resolve();
+          }),
+        };
+      }
+      if (table === "admin_audit_log") {
+        return { insert: vi.fn().mockResolvedValue({ data: null, error: null }) };
+      }
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        maybeSingle: vi.fn().mockResolvedValue({ data: null }),
+      };
+    });
+
+    return {
+      admin: { from: adminFrom } as unknown as WebhookContext["admin"],
+      stripe: {} as unknown as WebhookContext["stripe"],
+      log: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+    };
+  }
+
+  it("queries advisor_credit_topups when neither course/wallet/consultation match", async () => {
+    const ctx = makeAdvisorCtx({ topupRow: null });
+    await handleChargeRefunded(makeEvent(), ctx);
+    expect(ctx.admin.from as ReturnType<typeof vi.fn>).toHaveBeenCalledWith("advisor_credit_topups");
+  });
+
+  it("falls through to advisor_billing when no topup matches", async () => {
+    const ctx = makeAdvisorCtx({ topupRow: null, billingRow: null });
+    await handleChargeRefunded(makeEvent(), ctx);
+    expect(ctx.admin.from as ReturnType<typeof vi.fn>).toHaveBeenCalledWith("advisor_billing");
+  });
+
+  it("skips advisor flow when neither topup nor billing match", async () => {
+    const ctx = makeAdvisorCtx({});
+    await handleChargeRefunded(makeEvent(), ctx);
+    // ledger only queried after match — not here
+    expect(ctx.admin.from as ReturnType<typeof vi.fn>).not.toHaveBeenCalledWith(
+      "advisor_credit_ledger",
+    );
+  });
+
+  it("respects refund_policy = 'cash' (no ledger insert)", async () => {
+    const ctx = makeAdvisorCtx({
+      topupRow: { id: 7, professional_id: 1, amount_cents: 5000 },
+    });
+    const event = makeEvent();
+    (event.data.object as unknown as { metadata: Record<string, string> }).metadata = {
+      refund_policy: "cash",
+    };
+    await handleChargeRefunded(event, ctx);
+    // We do touch the ledger table to read priorRefunds when policy isn't cash;
+    // with policy=cash the helper logs but doesn't credit.
+    const audit = (ctx.admin.from as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (c) => c[0] === "admin_audit_log",
+    );
+    expect(audit.length).toBeGreaterThan(0);
+  });
+});

--- a/__tests__/lib/stripe-webhook/charge-refunded.test.ts
+++ b/__tests__/lib/stripe-webhook/charge-refunded.test.ts
@@ -282,10 +282,10 @@ describe("handleChargeRefunded — advisor flow", () => {
     const adminFrom = vi.fn().mockImplementation((table: string) => {
       if (table === "course_purchases" || table === "course_revenue") {
         return {
+          ...writeBuilder(),
           select: vi.fn().mockReturnThis(),
           eq: vi.fn().mockReturnThis(),
           maybeSingle: vi.fn().mockResolvedValue({ data: null }),
-          ...writeBuilder(),
         };
       }
       if (table === "wallet_transactions") {

--- a/__tests__/lib/stripe-webhook/customer-subscription.test.ts
+++ b/__tests__/lib/stripe-webhook/customer-subscription.test.ts
@@ -220,6 +220,46 @@ describe("handleCustomerSubscriptionDeleted", () => {
     const result = await handleCustomerSubscriptionDeleted(makeDeletedEvent(), ctx);
     expect(result).toEqual({ status: "done" });
   });
+
+  it("flips advisor_tier when subscription metadata carries pending_tier + advisor_id", async () => {
+    const eqSpy = vi.fn();
+    const updateSpy = vi.fn().mockReturnValue({ eq: eqSpy });
+    const fromSpy = vi.fn().mockReturnValue({ update: updateSpy });
+    const ctx = {
+      admin: { from: fromSpy } as unknown as WebhookContext["admin"],
+      stripe: {} as WebhookContext["stripe"],
+      log: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+    };
+    const event = {
+      id: "evt_sub_deleted_pending",
+      type: "customer.subscription.deleted",
+      data: {
+        object: {
+          ...SUBSCRIPTION,
+          metadata: { pending_tier: "growth", advisor_id: "42" },
+        } as Stripe.Subscription,
+      },
+    } as unknown as Stripe.Event;
+
+    await handleCustomerSubscriptionDeleted(event, ctx);
+    expect(fromSpy).toHaveBeenCalledWith("professionals");
+    const updatePayload = updateSpy.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(updatePayload.advisor_tier).toBe("growth");
+    expect(updatePayload.pending_tier).toBeNull();
+    expect(eqSpy).toHaveBeenCalledWith("id", 42);
+  });
+
+  it("skips the deferred-downgrade flip when metadata.pending_tier is absent", async () => {
+    const fromSpy = vi.fn();
+    const ctx = {
+      admin: { from: fromSpy } as unknown as WebhookContext["admin"],
+      stripe: {} as WebhookContext["stripe"],
+      log: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+    };
+    await handleCustomerSubscriptionDeleted(makeDeletedEvent(), ctx);
+    // SUBSCRIPTION has no pending_tier metadata — fromSpy never invoked.
+    expect(fromSpy).not.toHaveBeenCalled();
+  });
 });
 
 describe("handleCustomerSubscriptionTrialWillEnd", () => {

--- a/app/admin/country-schemes/SchemesEditor.tsx
+++ b/app/admin/country-schemes/SchemesEditor.tsx
@@ -1,0 +1,440 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { logger } from "@/lib/logger";
+
+const log = logger("admin-country-schemes-editor");
+
+interface Scheme {
+  id: number;
+  country_code: string;
+  audience: string;
+  category: string;
+  name: string;
+  summary: string;
+  body_md: string;
+  threshold_cents: number | null;
+  threshold_label: string | null;
+  source_name: string;
+  source_url: string;
+  sourced_at: string;
+  stales_at: string;
+  display_order: number;
+  active: boolean;
+}
+
+const AUDIENCES = [
+  { value: "inbound_migrant", label: "Moving to AU" },
+  { value: "us_au_dual", label: "US-AU dual" },
+  { value: "non_resident_investor", label: "Non-resident investor" },
+  { value: "outbound_australian", label: "Leaving AU" },
+];
+
+const CATEGORIES = [
+  { value: "visa_pathway", label: "Visa pathway" },
+  { value: "firb_threshold", label: "FIRB threshold" },
+  { value: "tax_concession", label: "Tax concession" },
+  { value: "super_rule", label: "Super rule" },
+  { value: "pension_transfer", label: "Pension transfer" },
+  { value: "first_home_buyer", label: "First-home buyer" },
+  { value: "investor_grant", label: "Investor grant" },
+  { value: "dual_tax_treaty", label: "Tax treaty" },
+];
+
+const COUNTRIES = ["GB", "US", "CN", "IN", "JP", "SG", "HK", "KR", "MY", "NZ", "AE", "SA"];
+
+const EMPTY_FORM: Omit<Scheme, "id"> = {
+  country_code: "GB",
+  audience: "inbound_migrant",
+  category: "tax_concession",
+  name: "",
+  summary: "",
+  body_md: "",
+  threshold_cents: null,
+  threshold_label: null,
+  source_name: "",
+  source_url: "",
+  sourced_at: new Date().toISOString().slice(0, 10),
+  stales_at: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10),
+  display_order: 0,
+  active: true,
+};
+
+export default function SchemesEditor() {
+  const [rows, setRows] = useState<Scheme[]>([]);
+  const [filter, setFilter] = useState<string>("");
+  const [editing, setEditing] = useState<Scheme | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [draft, setDraft] = useState<Omit<Scheme, "id">>(EMPTY_FORM);
+  const [busy, setBusy] = useState(false);
+
+  async function load() {
+    const url = filter
+      ? `/api/admin/country-schemes?country_code=${encodeURIComponent(filter)}`
+      : "/api/admin/country-schemes";
+    const res = await fetch(url);
+    if (!res.ok) {
+      log.error("Failed to load schemes", { status: res.status });
+      return;
+    }
+    const data = await res.json();
+    setRows(data.rows ?? []);
+  }
+
+  useEffect(() => {
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filter]);
+
+  async function save() {
+    setBusy(true);
+    try {
+      const isEdit = editing !== null;
+      const res = await fetch("/api/admin/country-schemes", {
+        method: isEdit ? "PATCH" : "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(isEdit ? { ...draft, id: editing.id } : draft),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        alert(err.error || "Save failed");
+        return;
+      }
+      setEditing(null);
+      setCreating(false);
+      setDraft(EMPTY_FORM);
+      await load();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function remove(id: number) {
+    if (!confirm("Delete this scheme? This is destructive.")) return;
+    const res = await fetch(`/api/admin/country-schemes?id=${id}`, { method: "DELETE" });
+    if (!res.ok) {
+      alert("Delete failed");
+      return;
+    }
+    await load();
+  }
+
+  function startEdit(row: Scheme) {
+    setEditing(row);
+    setCreating(false);
+    const { id: _id, ...rest } = row;
+    void _id;
+    setDraft(rest);
+  }
+
+  function startCreate() {
+    setEditing(null);
+    setCreating(true);
+    setDraft(EMPTY_FORM);
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <label className="text-sm text-slate-600">Country</label>
+          <select
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            className="text-sm border rounded px-2 py-1"
+          >
+            <option value="">All</option>
+            {COUNTRIES.map((c) => (
+              <option key={c} value={c}>
+                {c}
+              </option>
+            ))}
+          </select>
+        </div>
+        <button
+          type="button"
+          onClick={startCreate}
+          className="bg-violet-600 hover:bg-violet-700 text-white text-sm font-bold px-4 py-2 rounded"
+        >
+          + New scheme
+        </button>
+      </div>
+
+      {(editing || creating) && (
+        <SchemeForm
+          draft={draft}
+          setDraft={setDraft}
+          onSave={save}
+          onCancel={() => {
+            setEditing(null);
+            setCreating(false);
+            setDraft(EMPTY_FORM);
+          }}
+          busy={busy}
+          isEdit={editing !== null}
+        />
+      )}
+
+      <div className="bg-white border border-slate-200 rounded-lg overflow-hidden">
+        <table className="w-full text-sm">
+          <thead className="bg-slate-50 text-xs font-semibold text-slate-600">
+            <tr>
+              <th className="text-left px-3 py-2">Country</th>
+              <th className="text-left px-3 py-2">Audience</th>
+              <th className="text-left px-3 py-2">Category</th>
+              <th className="text-left px-3 py-2">Name</th>
+              <th className="text-left px-3 py-2">Stales</th>
+              <th className="text-left px-3 py-2">Active</th>
+              <th className="text-left px-3 py-2 w-24">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.length === 0 && (
+              <tr>
+                <td colSpan={7} className="text-center text-slate-400 py-6">
+                  No schemes match the filter.
+                </td>
+              </tr>
+            )}
+            {rows.map((r) => {
+              const isStale = new Date(r.stales_at) < new Date();
+              return (
+                <tr key={r.id} className="border-t border-slate-100">
+                  <td className="px-3 py-2 font-mono">{r.country_code}</td>
+                  <td className="px-3 py-2 text-xs">{r.audience}</td>
+                  <td className="px-3 py-2 text-xs">{r.category}</td>
+                  <td className="px-3 py-2">{r.name}</td>
+                  <td className={`px-3 py-2 text-xs ${isStale ? "text-amber-700 font-bold" : "text-slate-500"}`}>
+                    {r.stales_at}
+                    {isStale && " ⚠"}
+                  </td>
+                  <td className="px-3 py-2">
+                    <span
+                      className={`text-xs font-semibold ${r.active ? "text-emerald-700" : "text-slate-400"}`}
+                    >
+                      {r.active ? "Active" : "Hidden"}
+                    </span>
+                  </td>
+                  <td className="px-3 py-2 text-xs">
+                    <button
+                      type="button"
+                      className="text-blue-600 hover:underline mr-2"
+                      onClick={() => startEdit(r)}
+                    >
+                      Edit
+                    </button>
+                    <button
+                      type="button"
+                      className="text-red-600 hover:underline"
+                      onClick={() => remove(r.id)}
+                    >
+                      Delete
+                    </button>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+interface SchemeFormProps {
+  draft: Omit<Scheme, "id">;
+  setDraft: (d: Omit<Scheme, "id">) => void;
+  onSave: () => void;
+  onCancel: () => void;
+  busy: boolean;
+  isEdit: boolean;
+}
+
+function SchemeForm({ draft, setDraft, onSave, onCancel, busy, isEdit }: SchemeFormProps) {
+  function set<K extends keyof typeof draft>(key: K, value: (typeof draft)[K]) {
+    setDraft({ ...draft, [key]: value });
+  }
+
+  return (
+    <div className="bg-violet-50 border border-violet-200 rounded-lg p-5 space-y-3">
+      <h2 className="font-bold text-slate-900">{isEdit ? "Edit scheme" : "New scheme"}</h2>
+
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+        <Field label="Country (ISO-2)">
+          <select
+            value={draft.country_code}
+            onChange={(e) => set("country_code", e.target.value.toUpperCase())}
+            className="w-full text-sm border rounded px-2 py-1.5"
+          >
+            {COUNTRIES.map((c) => (
+              <option key={c} value={c}>
+                {c}
+              </option>
+            ))}
+          </select>
+        </Field>
+        <Field label="Audience">
+          <select
+            value={draft.audience}
+            onChange={(e) => set("audience", e.target.value)}
+            className="w-full text-sm border rounded px-2 py-1.5"
+          >
+            {AUDIENCES.map((a) => (
+              <option key={a.value} value={a.value}>
+                {a.label}
+              </option>
+            ))}
+          </select>
+        </Field>
+        <Field label="Category">
+          <select
+            value={draft.category}
+            onChange={(e) => set("category", e.target.value)}
+            className="w-full text-sm border rounded px-2 py-1.5"
+          >
+            {CATEGORIES.map((c) => (
+              <option key={c.value} value={c.value}>
+                {c.label}
+              </option>
+            ))}
+          </select>
+        </Field>
+      </div>
+
+      <Field label="Name">
+        <input
+          type="text"
+          value={draft.name}
+          onChange={(e) => set("name", e.target.value)}
+          className="w-full text-sm border rounded px-2 py-1.5"
+        />
+      </Field>
+
+      <Field label="Summary (1-2 sentences shown on the card)">
+        <textarea
+          value={draft.summary}
+          onChange={(e) => set("summary", e.target.value)}
+          rows={2}
+          className="w-full text-sm border rounded px-2 py-1.5"
+        />
+      </Field>
+
+      <Field label="Body (Markdown — bullets for details/strategy)">
+        <textarea
+          value={draft.body_md}
+          onChange={(e) => set("body_md", e.target.value)}
+          rows={6}
+          className="w-full text-sm border rounded px-2 py-1.5 font-mono"
+        />
+      </Field>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <Field label="Threshold label (display, e.g. '$5M minimum')">
+          <input
+            type="text"
+            value={draft.threshold_label ?? ""}
+            onChange={(e) => set("threshold_label", e.target.value || null)}
+            className="w-full text-sm border rounded px-2 py-1.5"
+          />
+        </Field>
+        <Field label="Threshold cents (numeric, optional)">
+          <input
+            type="number"
+            value={draft.threshold_cents ?? ""}
+            onChange={(e) =>
+              set(
+                "threshold_cents",
+                e.target.value ? parseInt(e.target.value, 10) : null,
+              )
+            }
+            className="w-full text-sm border rounded px-2 py-1.5"
+          />
+        </Field>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <Field label="Source name">
+          <input
+            type="text"
+            value={draft.source_name}
+            onChange={(e) => set("source_name", e.target.value)}
+            className="w-full text-sm border rounded px-2 py-1.5"
+          />
+        </Field>
+        <Field label="Source URL">
+          <input
+            type="url"
+            value={draft.source_url}
+            onChange={(e) => set("source_url", e.target.value)}
+            className="w-full text-sm border rounded px-2 py-1.5"
+          />
+        </Field>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+        <Field label="Sourced at (when verified)">
+          <input
+            type="date"
+            value={draft.sourced_at}
+            onChange={(e) => set("sourced_at", e.target.value)}
+            className="w-full text-sm border rounded px-2 py-1.5"
+          />
+        </Field>
+        <Field label="Stales at (review-by)">
+          <input
+            type="date"
+            value={draft.stales_at}
+            onChange={(e) => set("stales_at", e.target.value)}
+            className="w-full text-sm border rounded px-2 py-1.5"
+          />
+        </Field>
+        <Field label="Display order">
+          <input
+            type="number"
+            value={draft.display_order}
+            onChange={(e) =>
+              set("display_order", parseInt(e.target.value, 10) || 0)
+            }
+            className="w-full text-sm border rounded px-2 py-1.5"
+          />
+        </Field>
+      </div>
+
+      <label className="flex items-center gap-2 text-sm">
+        <input
+          type="checkbox"
+          checked={draft.active}
+          onChange={(e) => set("active", e.target.checked)}
+        />
+        <span>Active (visible to public)</span>
+      </label>
+
+      <div className="flex items-center gap-2 pt-2">
+        <button
+          type="button"
+          disabled={busy}
+          onClick={onSave}
+          className="bg-violet-600 hover:bg-violet-700 disabled:bg-slate-300 text-white text-sm font-bold px-4 py-2 rounded"
+        >
+          {busy ? "Saving…" : isEdit ? "Save changes" : "Create scheme"}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="border border-slate-300 hover:bg-slate-50 text-slate-700 text-sm font-semibold px-4 py-2 rounded"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="block">
+      <span className="block text-xs font-semibold text-slate-600 mb-1">{label}</span>
+      {children}
+    </label>
+  );
+}

--- a/app/admin/country-schemes/page.tsx
+++ b/app/admin/country-schemes/page.tsx
@@ -1,0 +1,15 @@
+import AdminShell from "@/components/AdminShell";
+import SchemesEditor from "./SchemesEditor";
+
+export const metadata = { title: "Country schemes & grants — Admin" };
+
+export default function CountrySchemesAdminPage() {
+  return (
+    <AdminShell
+      title="Country schemes & grants"
+      subtitle="Add, edit, or retire the cross-border programmes shown on /foreign-investment/<country>. Public reads are RLS-gated by `active = true`."
+    >
+      <SchemesEditor />
+    </AdminShell>
+  );
+}

--- a/app/advisor-portal/BillingTab.tsx
+++ b/app/advisor-portal/BillingTab.tsx
@@ -1,229 +1,212 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import Icon from "@/components/Icon";
-import type { Advisor, Stats, CategoryPricing, BillingRecord, ViewType } from "./types";
+import type { Advisor, Stats, ViewType } from "./types";
+import type { BillingSummary } from "./billing/types";
+import CreditBalanceCard from "./billing/CreditBalanceCard";
+import CreditPackGrid from "./billing/CreditPackGrid";
+import PaymentMethodCard from "./billing/PaymentMethodCard";
+import LedgerHistoryTable from "./billing/LedgerHistoryTable";
+import DowngradeBanner from "./billing/DowngradeBanner";
 import { logger } from "@/lib/logger";
 
 const log = logger("advisor-portal-billing");
 
-type TopupRecord = { id: number; amount_cents: number; status: string; created_at: string };
-
 type Props = {
   advisor: Advisor | null;
   stats: Stats | null;
-  categoryPricing: CategoryPricing | null;
-  billing: BillingRecord[];
   onNavigate: (v: ViewType) => void;
+  /** Pre-fetched summary from advisor-portal page; falls back to client fetch. */
+  initialSummary?: BillingSummary | null;
 };
 
-export default function BillingTab({ advisor, stats, categoryPricing, billing, onNavigate }: Props) {
-  const [topupHistory, setTopupHistory] = useState<TopupRecord[]>([]);
+export default function BillingTab({ advisor, stats, onNavigate, initialSummary }: Props) {
+  const [summary, setSummary] = useState<BillingSummary | null>(initialSummary ?? null);
 
   useEffect(() => {
-    fetch("/api/advisor-auth/topup")
+    if (initialSummary) return;
+    fetch("/api/advisor-auth/billing-summary")
       .then((r) => (r.ok ? r.json() : null))
-      .then((d) => { if (d) setTopupHistory(d.topups || []); })
-      .catch(() => {});
-  }, []);
+      .then((data) => {
+        if (data) setSummary(data as BillingSummary);
+      })
+      .catch((err) => {
+        log.error("billing summary fetch failed", {
+          err: err instanceof Error ? err.message : String(err),
+        });
+      });
+  }, [initialSummary]);
+
+  // Fall back to a synthetic summary derived from the advisor row when
+  // the network call hasn't returned yet — prevents an empty-card flash.
+  const effectiveSummary: BillingSummary = summary ?? {
+    balance_cents: advisor?.credit_balance_cents ?? 0,
+    lifetime_credit_cents: advisor?.lifetime_credit_cents ?? 0,
+    lifetime_spend_cents: advisor?.lifetime_lead_spend_cents ?? 0,
+    expiring_soon_cents: 0,
+    free_leads_used: advisor?.free_leads_used ?? 0,
+    free_leads_remaining: Math.max(0, 3 - (advisor?.free_leads_used ?? 0)),
+    lead_price_cents: advisor?.lead_price_cents ?? 4900,
+    advisor_tier: "free",
+    pending_tier: null,
+    pending_tier_effective_at: null,
+    has_payment_method: false,
+    has_stripe_customer: false,
+    ledger_first_page: [],
+    ledger_total: 0,
+  };
 
   return (
     <>
       <h1 className="text-xl font-bold text-slate-900 mb-1">Billing & Credits</h1>
-      <p className="text-sm text-slate-500 mb-6">Purchase lead credits and view your payment history.</p>
+      <p className="text-sm text-slate-500 mb-6">
+        Purchase lead credits, manage your subscription, and review every cent of activity.
+      </p>
 
-      {/* Current balance */}
-      <div className="bg-violet-50 border border-violet-200 rounded-xl p-5 mb-6">
-        <div className="flex items-center justify-between mb-1">
-          <h3 className="text-sm font-bold text-violet-900">Credit Balance</h3>
-          <span className="text-2xl font-extrabold text-violet-900">${((advisor?.credit_balance_cents || 0) / 100).toFixed(0)}</span>
-        </div>
-        <p className="text-xs text-violet-600">
-          ~{Math.floor((advisor?.credit_balance_cents || 0) / (advisor?.lead_price_cents || categoryPricing?.price_cents || 4900))} leads remaining · ${((advisor?.lead_price_cents || categoryPricing?.price_cents || 4900) / 100).toFixed(0)}/lead · Lifetime spend: ${((advisor?.lifetime_lead_spend_cents || 0) / 100).toFixed(0)}
-        </p>
-      </div>
+      <DowngradeBanner summary={effectiveSummary} />
+      <CreditBalanceCard summary={effectiveSummary} />
+      <CreditPackGrid />
+      <PaymentMethodCard summary={effectiveSummary} />
 
-      {/* Credit Packs */}
-      <h2 className="text-base font-bold text-slate-900 mb-3">Buy Lead Credits</h2>
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-3 mb-8">
-        {[
-          { name: "Starter", leads: 5, price: 199, perLead: 39.80, slug: "starter", badge: "", desc: "Perfect for testing" },
-          { name: "Growth", leads: 12, price: 449, perLead: 37.42, slug: "growth", badge: "Most Popular", desc: "Best for most advisors" },
-          { name: "Scale", leads: 25, price: 799, perLead: 31.96, slug: "scale", badge: "Best Value", desc: "20% savings per lead" },
-        ].map((pack) => (
-          <div key={pack.slug} className={`relative bg-white border rounded-xl p-5 text-center ${pack.slug === "growth" ? "border-violet-400 ring-2 ring-violet-100" : "border-slate-200"}`}>
-            {pack.badge && (
-              <span className={`absolute -top-2.5 left-1/2 -translate-x-1/2 text-[0.6rem] font-bold px-2.5 py-0.5 rounded-full whitespace-nowrap ${
-                pack.slug === "growth" ? "bg-violet-600 text-white" : "bg-emerald-100 text-emerald-700"
-              }`}>{pack.badge}</span>
-            )}
-            <h3 className="text-sm font-bold text-slate-900 mt-1">{pack.name}</h3>
-            <div className="text-3xl font-extrabold text-slate-900 my-2">${pack.price}</div>
-            <p className="text-xs text-slate-500 mb-1">{pack.leads} exclusive leads</p>
-            <p className="text-xs text-slate-400 mb-3">${pack.perLead.toFixed(2)} per lead</p>
-            <button
-              type="button"
-              onClick={async () => {
-                try {
-                  const res = await fetch("/api/advisor-auth/topup", {
-                    method: "POST",
-                    headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify({ amount_cents: pack.price * 100, pack_slug: pack.slug }),
-                  });
-                  const data = await res.json();
-                  if (data.url) window.location.href = data.url;
-                  else alert(data.error || "Failed to create checkout session. Please try again.");
-                } catch (err) {
-                  alert("Something went wrong. Please check you're logged in and try again.");
-                  log.error("topup checkout failed", { err: err instanceof Error ? err.message : String(err) });
-                }
-              }}
-              className={`w-full py-2.5 rounded-lg text-sm font-bold transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-violet-500 focus-visible:ring-offset-2 ${
-                pack.slug === "growth"
-                  ? "bg-violet-600 text-white hover:bg-violet-700"
-                  : "bg-slate-100 text-slate-700 hover:bg-slate-200"
-              }`}
-            >
-              Buy {pack.name}
-            </button>
-            <p className="text-[0.6rem] text-slate-400 mt-2">{pack.desc}</p>
-          </div>
-        ))}
-      </div>
-
-      {/* Featured Advisor */}
+      {/* Add-on packs (kept; not credit) ───────────────────────── */}
       <h2 className="text-base font-bold text-slate-900 mb-3">Boost Your Visibility</h2>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mb-8">
-        <div className="bg-white border border-amber-200 rounded-xl p-5">
-          <div className="flex items-center gap-2 mb-2">
-            <Icon name="star" size={18} className="text-amber-500" />
-            <h3 className="text-sm font-bold text-slate-900">Featured Advisor</h3>
-          </div>
-          <div className="text-2xl font-extrabold text-slate-900 mb-1">$149<span className="text-sm font-normal text-slate-400">/month</span></div>
-          <ul className="text-xs text-slate-600 space-y-1 mb-3">
-            <li className="flex items-center gap-1.5"><Icon name="check" size={12} className="text-emerald-500" />Featured badge on your profile</li>
-            <li className="flex items-center gap-1.5"><Icon name="check" size={12} className="text-emerald-500" />Priority listing on city pages</li>
-            <li className="flex items-center gap-1.5"><Icon name="check" size={12} className="text-emerald-500" />Gold border on search results</li>
-            <li className="flex items-center gap-1.5"><Icon name="check" size={12} className="text-emerald-500" />Monthly performance report</li>
-          </ul>
-          {advisor?.featured_until && new Date(advisor.featured_until) > new Date() ? (
-            <p className="text-xs text-amber-700 font-semibold">Active until {new Date(advisor.featured_until).toLocaleDateString("en-AU", { day: "numeric", month: "short", year: "numeric" })}</p>
-          ) : (
-            <button
-              type="button"
-              onClick={async () => {
-                try {
-                  const res = await fetch("/api/advisor-auth/topup", {
-                    method: "POST",
-                    headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify({ amount_cents: 14900, pack_slug: "featured_monthly" }),
-                  });
-                  const data = await res.json();
-                  if (data.url) window.location.href = data.url;
-                  else alert(data.error || "Failed to create checkout session. Please try again.");
-                } catch (err) {
-                  alert("Something went wrong. Please check you're logged in and try again.");
-                  log.error("featured topup checkout failed", { err: err instanceof Error ? err.message : String(err) });
-                }
-              }}
-              className="w-full py-2 rounded-lg text-sm font-bold bg-amber-500 text-white hover:bg-amber-600 transition-all"
-            >
-              Get Featured
-            </button>
-          )}
-        </div>
-        <div className="bg-white border border-slate-200 rounded-xl p-5">
-          <div className="flex items-center gap-2 mb-2">
-            <Icon name="file-text" size={18} className="text-violet-500" />
-            <h3 className="text-sm font-bold text-slate-900">Expert Article</h3>
-          </div>
-          <div className="text-2xl font-extrabold text-slate-900 mb-1">$299<span className="text-sm font-normal text-slate-400">/article</span></div>
-          <ul className="text-xs text-slate-600 space-y-1 mb-3">
-            <li className="flex items-center gap-1.5"><Icon name="check" size={12} className="text-emerald-500" />SEO-optimised article on invest.com.au</li>
-            <li className="flex items-center gap-1.5"><Icon name="check" size={12} className="text-emerald-500" />Permanent placement with your byline</li>
-            <li className="flex items-center gap-1.5"><Icon name="check" size={12} className="text-emerald-500" />Backlink to your advisor profile</li>
-            <li className="flex items-center gap-1.5"><Icon name="check" size={12} className="text-emerald-500" />Builds your E-E-A-T authority</li>
-          </ul>
-          <button
-            onClick={() => onNavigate("articles")}
-            className="w-full py-2 rounded-lg text-sm font-bold bg-slate-100 text-slate-700 hover:bg-slate-200 transition-all"
-          >
-            Write an Article →
-          </button>
-        </div>
+        <FeaturedAdvisorCard advisor={advisor} />
+        <ExpertArticleCard onNavigate={onNavigate} />
       </div>
 
+      {/* Headline counters (kept) ──────────────────────────────── */}
       <h2 className="text-base font-bold text-slate-900 mb-3">Payment History</h2>
       <div className="grid grid-cols-2 gap-3 mb-4">
         <div className="bg-white border border-slate-200 rounded-xl p-4">
           <div className="text-xs text-slate-500 font-medium">Total Charged</div>
-          <div className="text-2xl font-extrabold text-slate-900 mt-1">${((stats?.totalBilledCents || 0) / 100).toFixed(0)}</div>
+          <div className="text-2xl font-extrabold text-slate-900 mt-1">
+            ${((stats?.totalBilledCents || 0) / 100).toFixed(0)}
+          </div>
         </div>
         <div className="bg-white border border-slate-200 rounded-xl p-4">
           <div className="text-xs text-slate-500 font-medium">Outstanding</div>
-          <div className="text-2xl font-extrabold text-amber-600 mt-1">${((stats?.pendingBilledCents || 0) / 100).toFixed(0)}</div>
+          <div className="text-2xl font-extrabold text-amber-600 mt-1">
+            ${((stats?.pendingBilledCents || 0) / 100).toFixed(0)}
+          </div>
         </div>
       </div>
 
-      {/* Lead billing records */}
-      <h2 className="text-base font-bold text-slate-900 mb-3">Lead Charges</h2>
-      {billing.length > 0 ? (
-        <div className="bg-white border border-slate-200 rounded-xl overflow-hidden mb-8">
-          <div className="grid grid-cols-4 bg-slate-50 text-xs font-semibold text-slate-600 px-4 py-2 border-b border-slate-200">
-            <span>Date</span>
-            <span>Description</span>
-            <span className="text-right">Amount</span>
-            <span className="text-right">Status</span>
-          </div>
-          {billing.map((b) => (
-            <div key={b.id} className="grid grid-cols-4 px-4 py-2.5 text-xs border-b border-slate-100 last:border-b-0">
-              <span className="text-slate-500">{new Date(b.created_at).toLocaleDateString("en-AU", { day: "numeric", month: "short" })}</span>
-              <span className="text-slate-700">{b.description}</span>
-              <span className="text-right font-semibold text-slate-900">${(b.amount_cents / 100).toFixed(2)}</span>
-              <span className="text-right">
-                <span className={`px-1.5 py-0.5 rounded-full text-[0.56rem] font-bold ${
-                  b.status === "paid" ? "bg-emerald-100 text-emerald-700" :
-                  b.status === "waived" ? "bg-slate-100 text-slate-500" :
-                  "bg-amber-100 text-amber-700"
-                }`}>{b.status}</span>
-              </span>
-            </div>
-          ))}
-        </div>
-      ) : (
-        <div className="bg-white border border-slate-200 rounded-xl p-6 text-center mb-8">
-          <p className="text-sm text-slate-500">No lead charges yet.</p>
-        </div>
-      )}
+      <LedgerHistoryTable summary={effectiveSummary} />
 
-      {/* Credit topup history */}
-      <h2 className="text-base font-bold text-slate-900 mb-3">Top-up History</h2>
-      {topupHistory.length > 0 ? (
-        <div className="bg-white border border-slate-200 rounded-xl overflow-hidden">
-          <div className="grid grid-cols-3 bg-slate-50 text-xs font-semibold text-slate-600 px-4 py-2 border-b border-slate-200">
-            <span>Date</span>
-            <span className="text-right">Amount</span>
-            <span className="text-right">Status</span>
-          </div>
-          {topupHistory.map((t) => (
-            <div key={t.id} className="grid grid-cols-3 px-4 py-2.5 text-xs border-b border-slate-100 last:border-b-0">
-              <span className="text-slate-500">{new Date(t.created_at).toLocaleDateString("en-AU", { day: "numeric", month: "short", year: "numeric" })}</span>
-              <span className="text-right font-semibold text-slate-900">${(t.amount_cents / 100).toFixed(0)}</span>
-              <span className="text-right">
-                <span className={`px-1.5 py-0.5 rounded-full text-[0.56rem] font-bold ${
-                  t.status === "completed" ? "bg-emerald-100 text-emerald-700" :
-                  t.status === "failed" ? "bg-red-100 text-red-700" :
-                  "bg-amber-100 text-amber-700"
-                }`}>{t.status}</span>
-              </span>
-            </div>
-          ))}
-        </div>
-      ) : (
-        <div className="bg-white border border-slate-200 rounded-xl p-5 text-center">
-          <p className="text-sm text-slate-500">No top-ups yet. Purchase credits above to get started.</p>
-        </div>
-      )}
+      <p className="text-xs text-slate-400 mt-6 text-center">
+        Questions about a charge or refund? Read our{" "}
+        <a href="/billing-policy" className="underline hover:text-slate-600">
+          billing policy
+        </a>
+        {" "}— refunds default to portal credit so you can keep buying leads. Cash refunds for
+        billing errors, outages, fraud, and dispute wins.
+      </p>
     </>
+  );
+}
+
+function FeaturedAdvisorCard({ advisor }: { advisor: Advisor | null }) {
+  return (
+    <div className="bg-white border border-amber-200 rounded-xl p-5">
+      <div className="flex items-center gap-2 mb-2">
+        <Icon name="star" size={18} className="text-amber-500" />
+        <h3 className="text-sm font-bold text-slate-900">Featured Advisor</h3>
+      </div>
+      <div className="text-2xl font-extrabold text-slate-900 mb-1">
+        $149<span className="text-sm font-normal text-slate-400">/month</span>
+      </div>
+      <ul className="text-xs text-slate-600 space-y-1 mb-3">
+        <li className="flex items-center gap-1.5">
+          <Icon name="check" size={12} className="text-emerald-500" />
+          Featured badge on your profile
+        </li>
+        <li className="flex items-center gap-1.5">
+          <Icon name="check" size={12} className="text-emerald-500" />
+          Priority listing on city pages
+        </li>
+        <li className="flex items-center gap-1.5">
+          <Icon name="check" size={12} className="text-emerald-500" />
+          Gold border on search results
+        </li>
+        <li className="flex items-center gap-1.5">
+          <Icon name="check" size={12} className="text-emerald-500" />
+          Monthly performance report
+        </li>
+      </ul>
+      {advisor?.featured_until && new Date(advisor.featured_until) > new Date() ? (
+        <p className="text-xs text-amber-700 font-semibold">
+          Active until{" "}
+          {new Date(advisor.featured_until).toLocaleDateString("en-AU", {
+            day: "numeric",
+            month: "short",
+            year: "numeric",
+          })}
+        </p>
+      ) : (
+        <button
+          type="button"
+          onClick={async () => {
+            try {
+              const res = await fetch("/api/advisor-auth/topup", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ amount_cents: 14900, pack_slug: "featured_monthly" }),
+              });
+              const data = await res.json();
+              if (data.url) window.location.href = data.url;
+              else alert(data.error || "Failed to create checkout session. Please try again.");
+            } catch (err) {
+              alert("Something went wrong. Please check you're logged in and try again.");
+              log.error("featured topup checkout failed", {
+                err: err instanceof Error ? err.message : String(err),
+              });
+            }
+          }}
+          className="w-full py-2 rounded-lg text-sm font-bold bg-amber-500 text-white hover:bg-amber-600 transition-all"
+        >
+          Get Featured
+        </button>
+      )}
+    </div>
+  );
+}
+
+function ExpertArticleCard({ onNavigate }: { onNavigate: (v: ViewType) => void }) {
+  return (
+    <div className="bg-white border border-slate-200 rounded-xl p-5">
+      <div className="flex items-center gap-2 mb-2">
+        <Icon name="file-text" size={18} className="text-violet-500" />
+        <h3 className="text-sm font-bold text-slate-900">Expert Article</h3>
+      </div>
+      <div className="text-2xl font-extrabold text-slate-900 mb-1">
+        $299<span className="text-sm font-normal text-slate-400">/article</span>
+      </div>
+      <ul className="text-xs text-slate-600 space-y-1 mb-3">
+        <li className="flex items-center gap-1.5">
+          <Icon name="check" size={12} className="text-emerald-500" />
+          SEO-optimised article on invest.com.au
+        </li>
+        <li className="flex items-center gap-1.5">
+          <Icon name="check" size={12} className="text-emerald-500" />
+          Permanent placement with your byline
+        </li>
+        <li className="flex items-center gap-1.5">
+          <Icon name="check" size={12} className="text-emerald-500" />
+          Backlink to your advisor profile
+        </li>
+        <li className="flex items-center gap-1.5">
+          <Icon name="check" size={12} className="text-emerald-500" />
+          Builds your E-E-A-T authority
+        </li>
+      </ul>
+      <button
+        onClick={() => onNavigate("articles")}
+        className="w-full py-2 rounded-lg text-sm font-bold bg-slate-100 text-slate-700 hover:bg-slate-200 transition-all"
+      >
+        Write an Article →
+      </button>
+    </div>
   );
 }

--- a/app/advisor-portal/DashboardTab.tsx
+++ b/app/advisor-portal/DashboardTab.tsx
@@ -5,6 +5,8 @@ import Icon from "@/components/Icon";
 import LeadScoreBadge from "@/components/LeadScoreBadge";
 import { PROFESSIONAL_TYPE_LABELS } from "@/lib/types";
 import type { Advisor, Stats, Lead, ProfileCompleteness, Review, ViewDay, WeeklyEnquiry, ViewType } from "./types";
+import type { BillingSummary } from "./billing/types";
+import PinnedBillingWidget from "./billing/PinnedBillingWidget";
 
 type Props = {
   advisor: Advisor | null;
@@ -18,12 +20,14 @@ type Props = {
   isPending: boolean;
   onNavigate: (v: ViewType) => void;
   onDismissOnboarding: () => void;
+  /** Pre-fetched summary; widget renders a free-leads pill if absent. */
+  billingSummary?: BillingSummary | null;
 };
 
 export default function DashboardTab({
   advisor, stats, leads, profileCompleteness, reviews,
   viewsByDay, weeklyEnquiries, dismissedOnboarding, isPending,
-  onNavigate, onDismissOnboarding,
+  onNavigate, onDismissOnboarding, billingSummary,
 }: Props) {
   return (
     <>
@@ -69,75 +73,51 @@ export default function DashboardTab({
         ))}
       </div>
 
-      {/* Credit balance banner */}
-      {(() => {
-        const balance = advisor?.credit_balance_cents || 0;
-        const leadPrice = advisor?.lead_price_cents || 3980;
-        const freeLeadsUsed = advisor?.free_leads_used || 0;
-        const hasFreeLeads = freeLeadsUsed < 2;
-        const leadsRemaining = hasFreeLeads ? (2 - freeLeadsUsed) : Math.floor(balance / leadPrice);
-        const isLow = !hasFreeLeads && leadsRemaining <= 2 && balance > 0;
-        const isEmpty = !hasFreeLeads && balance <= 0;
+      {/* Free-leads notice (advisor still on the launch trial) */}
+      {(advisor?.free_leads_used ?? 0) < 3 && (
+        <div className="bg-emerald-50 border border-emerald-200 rounded-xl p-4 mb-4 flex items-center justify-between gap-3">
+          <div>
+            <p className="text-sm font-bold text-emerald-800">
+              {3 - (advisor?.free_leads_used ?? 0)} free trial leads remaining
+            </p>
+            <p className="text-xs text-emerald-700 mt-0.5">
+              Your first 3 leads are on us — convert one to unlock the discounted lead pricing.
+            </p>
+          </div>
+          <button
+            onClick={() => onNavigate("billing")}
+            className="px-3 py-1.5 bg-emerald-600 text-white text-xs font-bold rounded-lg hover:bg-emerald-700 transition-colors shrink-0"
+          >
+            See pricing
+          </button>
+        </div>
+      )}
 
-        return (
-          <>
-            {isEmpty && (
-              <div className="bg-red-50 border border-red-200 rounded-xl p-4 mb-4 flex items-start gap-3">
-                <div className="w-8 h-8 bg-red-100 rounded-lg flex items-center justify-center shrink-0 mt-0.5">
-                  <Icon name="alert-triangle" size={16} className="text-red-600" />
-                </div>
-                <div className="flex-1">
-                  <p className="text-sm font-bold text-red-800">Credit balance empty — leads paused</p>
-                  <p className="text-xs text-red-600 mt-0.5">You won&rsquo;t receive new enquiries until you top up your credit balance.</p>
-                </div>
-                <button
-                  onClick={() => onNavigate("billing")}
-                  className="px-3 py-1.5 bg-red-600 text-white text-xs font-bold rounded-lg hover:bg-red-700 transition-colors shrink-0"
-                >
-                  Top Up Now
-                </button>
-              </div>
-            )}
-            {isLow && (
-              <div className="bg-amber-50 border border-amber-200 rounded-xl p-4 mb-4 flex items-start gap-3">
-                <div className="w-8 h-8 bg-amber-100 rounded-lg flex items-center justify-center shrink-0 mt-0.5">
-                  <Icon name="alert-triangle" size={16} className="text-amber-600" />
-                </div>
-                <div className="flex-1">
-                  <p className="text-sm font-bold text-amber-800">Low credit balance — {leadsRemaining} lead{leadsRemaining !== 1 ? "s" : ""} remaining</p>
-                  <p className="text-xs text-amber-600 mt-0.5">Top up soon to avoid missing incoming enquiries.</p>
-                </div>
-                <button
-                  onClick={() => onNavigate("billing")}
-                  className="px-3 py-1.5 bg-amber-500 text-white text-xs font-bold rounded-lg hover:bg-amber-600 transition-colors shrink-0"
-                >
-                  Top Up
-                </button>
-              </div>
-            )}
-            <div className={`rounded-xl p-4 mb-6 text-white flex items-center justify-between ${isEmpty ? "bg-gradient-to-r from-red-700 to-red-900" : isLow ? "bg-gradient-to-r from-amber-500 to-amber-700" : "bg-gradient-to-r from-violet-600 to-violet-800"}`}>
-              <div>
-                <p className={`text-[0.65rem] font-semibold uppercase tracking-wider ${isEmpty ? "text-red-200" : isLow ? "text-amber-100" : "text-violet-200"}`}>Lead Credit Balance</p>
-                <p className="text-2xl font-extrabold">${(balance / 100).toFixed(0)}</p>
-                <p className={`text-[0.62rem] mt-0.5 ${isEmpty ? "text-red-200" : isLow ? "text-amber-100" : "text-violet-200"}`}>
-                  {hasFreeLeads
-                    ? `${2 - freeLeadsUsed} free leads remaining`
-                    : isEmpty
-                      ? "No credits — top up to receive leads"
-                      : `~${leadsRemaining} leads remaining`
-                  }
-                </p>
-              </div>
-              <button
-                onClick={() => onNavigate("billing")}
-                className="px-5 py-2.5 bg-white text-sm font-bold rounded-lg hover:opacity-90 transition-opacity shrink-0 text-slate-800"
-              >
-                Buy Credits
-              </button>
-            </div>
-          </>
-        );
-      })()}
+      {/* Unified billing widget — replaces the prior credit banner */}
+      {billingSummary
+        ? <PinnedBillingWidget summary={billingSummary} />
+        : (advisor?.credit_balance_cents ?? 0) > 0
+          ? (
+            <PinnedBillingWidget
+              summary={{
+                balance_cents: advisor?.credit_balance_cents ?? 0,
+                lifetime_credit_cents: advisor?.lifetime_credit_cents ?? 0,
+                lifetime_spend_cents: advisor?.lifetime_lead_spend_cents ?? 0,
+                expiring_soon_cents: 0,
+                free_leads_used: advisor?.free_leads_used ?? 0,
+                free_leads_remaining: Math.max(0, 3 - (advisor?.free_leads_used ?? 0)),
+                lead_price_cents: advisor?.lead_price_cents ?? 4900,
+                advisor_tier: "free",
+                pending_tier: null,
+                pending_tier_effective_at: null,
+                has_payment_method: false,
+                has_stripe_customer: false,
+                ledger_first_page: [],
+                ledger_total: 0,
+              }}
+            />
+          )
+          : null}
 
       {/* Onboarding Checklist */}
       {profileCompleteness && profileCompleteness.score < 80 && !dismissedOnboarding && (

--- a/app/advisor-portal/billing/CreditBalanceCard.tsx
+++ b/app/advisor-portal/billing/CreditBalanceCard.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import type { BillingSummary } from "./types";
+
+interface Props {
+  summary: BillingSummary;
+}
+
+/**
+ * Headline credit-balance card. Adds an "expiring soon" sub-line so the
+ * advisor can act before credits time-box out at the 24-month mark.
+ */
+export default function CreditBalanceCard({ summary }: Props) {
+  const balanceDollars = (summary.balance_cents / 100).toFixed(0);
+  const leadsRemaining = Math.floor(summary.balance_cents / Math.max(summary.lead_price_cents, 1));
+  const leadPriceDollars = (summary.lead_price_cents / 100).toFixed(0);
+  const lifetimeSpendDollars = (summary.lifetime_spend_cents / 100).toFixed(0);
+
+  return (
+    <div className="bg-violet-50 border border-violet-200 rounded-xl p-5 mb-6">
+      <div className="flex items-center justify-between mb-1">
+        <h3 className="text-sm font-bold text-violet-900">Credit Balance</h3>
+        <span className="text-2xl font-extrabold text-violet-900">
+          ${balanceDollars}
+        </span>
+      </div>
+      <p className="text-xs text-violet-600">
+        ~{leadsRemaining} leads remaining · ${leadPriceDollars}/lead · Lifetime spend: ${lifetimeSpendDollars}
+      </p>
+      {summary.expiring_soon_cents > 0 && (
+        <p className="text-xs text-amber-700 font-semibold mt-2">
+          ${(summary.expiring_soon_cents / 100).toFixed(0)} of your credit expires
+          within 60 days. Use or top up before then.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/app/advisor-portal/billing/CreditPackGrid.tsx
+++ b/app/advisor-portal/billing/CreditPackGrid.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useState } from "react";
+import { LEAD_CREDIT_PACKS } from "@/lib/advisor-credit-packs";
+import { logger } from "@/lib/logger";
+
+const log = logger("advisor-portal-credit-pack-grid");
+
+/**
+ * Pack-card grid for buying lead credits. Reads packs from
+ * lib/advisor-credit-packs.ts (the same source the topup API consumes)
+ * so the price the advisor sees and the price Stripe charges can never
+ * drift apart.
+ */
+export default function CreditPackGrid() {
+  const [busySlug, setBusySlug] = useState<string | null>(null);
+
+  async function buy(slug: string, priceCents: number) {
+    setBusySlug(slug);
+    try {
+      const res = await fetch("/api/advisor-auth/topup", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ amount_cents: priceCents, pack_slug: slug }),
+      });
+      const data = await res.json();
+      if (data.url) {
+        window.location.href = data.url;
+      } else {
+        alert(data.error || "Failed to create checkout session. Please try again.");
+      }
+    } catch (err) {
+      alert("Something went wrong. Please check you're logged in and try again.");
+      log.error("topup checkout failed", {
+        err: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setBusySlug(null);
+    }
+  }
+
+  return (
+    <>
+      <h2 className="text-base font-bold text-slate-900 mb-3">Buy Lead Credits</h2>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-3 mb-8">
+        {LEAD_CREDIT_PACKS.map((pack) => (
+          <div
+            key={pack.slug}
+            className={`relative bg-white border rounded-xl p-5 text-center ${
+              pack.slug === "growth"
+                ? "border-violet-400 ring-2 ring-violet-100"
+                : "border-slate-200"
+            }`}
+          >
+            {pack.badge && (
+              <span
+                className={`absolute -top-2.5 left-1/2 -translate-x-1/2 text-[0.6rem] font-bold px-2.5 py-0.5 rounded-full whitespace-nowrap ${
+                  pack.slug === "growth"
+                    ? "bg-violet-600 text-white"
+                    : "bg-emerald-100 text-emerald-700"
+                }`}
+              >
+                {pack.badge}
+              </span>
+            )}
+            <h3 className="text-sm font-bold text-slate-900 mt-1">{pack.name}</h3>
+            <div className="text-3xl font-extrabold text-slate-900 my-2">
+              ${(pack.priceCents / 100).toFixed(0)}
+            </div>
+            <p className="text-xs text-slate-500 mb-1">{pack.leads} exclusive leads</p>
+            <p className="text-xs text-slate-400 mb-3">
+              ${(pack.perLeadCents / 100).toFixed(2)} per lead
+            </p>
+            <button
+              type="button"
+              disabled={busySlug !== null}
+              onClick={() => buy(pack.slug, pack.priceCents)}
+              className={`w-full py-2.5 rounded-lg text-sm font-bold transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-violet-500 focus-visible:ring-offset-2 disabled:opacity-50 ${
+                pack.slug === "growth"
+                  ? "bg-violet-600 text-white hover:bg-violet-700"
+                  : "bg-slate-100 text-slate-700 hover:bg-slate-200"
+              }`}
+            >
+              {busySlug === pack.slug ? "Opening checkout…" : `Buy ${pack.name}`}
+            </button>
+            <p className="text-[0.6rem] text-slate-400 mt-2">{pack.description}</p>
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/app/advisor-portal/billing/DowngradeBanner.tsx
+++ b/app/advisor-portal/billing/DowngradeBanner.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useState } from "react";
+import type { BillingSummary } from "./types";
+import { logger } from "@/lib/logger";
+
+const log = logger("advisor-portal-downgrade-banner");
+
+interface Props {
+  summary: BillingSummary;
+  onCancelled?: () => void;
+}
+
+/**
+ * Renders only when a tier downgrade is queued (PR-B3). Shows the
+ * effective date and lets the advisor cancel the pending downgrade with
+ * one click — `DELETE /api/advisor-auth/tier-upgrade/pending` un-cancels
+ * the Stripe subscription and claws back the proration credit.
+ */
+export default function DowngradeBanner({ summary, onCancelled }: Props) {
+  const [busy, setBusy] = useState(false);
+
+  if (!summary.pending_tier || !summary.pending_tier_effective_at) return null;
+
+  const effective = new Date(summary.pending_tier_effective_at).toLocaleDateString("en-AU", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+
+  async function cancelDowngrade() {
+    setBusy(true);
+    try {
+      const res = await fetch("/api/advisor-auth/tier-upgrade/pending", { method: "DELETE" });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        alert(err.error || "Couldn't cancel the downgrade. Try again or contact support.");
+        return;
+      }
+      onCancelled?.();
+      window.location.reload();
+    } catch (err) {
+      log.error("cancel pending downgrade failed", {
+        err: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const currentTierLabel = summary.advisor_tier.charAt(0).toUpperCase() + summary.advisor_tier.slice(1);
+  const pendingTierLabel = summary.pending_tier.charAt(0).toUpperCase() + summary.pending_tier.slice(1);
+
+  return (
+    <div className="bg-amber-50 border border-amber-200 rounded-xl p-4 mb-6 flex items-center justify-between gap-4">
+      <div>
+        <h3 className="text-sm font-bold text-amber-900 mb-0.5">
+          Downgrade scheduled
+        </h3>
+        <p className="text-xs text-amber-800">
+          You&rsquo;re on <strong>{currentTierLabel}</strong> until{" "}
+          <strong>{effective}</strong>, then <strong>{pendingTierLabel}</strong>.
+          Unused subscription days were credited to your portal balance.
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={cancelDowngrade}
+        disabled={busy}
+        className="bg-amber-600 hover:bg-amber-700 disabled:bg-slate-300 text-white text-sm font-bold px-4 py-2 rounded-lg whitespace-nowrap"
+      >
+        {busy ? "Cancelling…" : "Cancel downgrade"}
+      </button>
+    </div>
+  );
+}

--- a/app/advisor-portal/billing/LedgerHistoryTable.tsx
+++ b/app/advisor-portal/billing/LedgerHistoryTable.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useState } from "react";
+import type { BillingSummary, LedgerEntryView } from "./types";
+
+const KIND_LABELS: Record<LedgerEntryView["kind"], string> = {
+  topup: "Top-up",
+  refund_to_credit: "Refund credit",
+  lead_spend: "Lead",
+  lead_dispute_refund: "Dispute refund",
+  tier_proration_credit: "Tier proration",
+  admin_adjustment: "Adjustment",
+  expiry: "Expired",
+  chargeback_clawback: "Chargeback",
+};
+
+const KIND_BADGE: Record<LedgerEntryView["kind"], string> = {
+  topup: "bg-violet-100 text-violet-700",
+  refund_to_credit: "bg-emerald-100 text-emerald-700",
+  lead_spend: "bg-slate-100 text-slate-600",
+  lead_dispute_refund: "bg-emerald-100 text-emerald-700",
+  tier_proration_credit: "bg-blue-100 text-blue-700",
+  admin_adjustment: "bg-amber-100 text-amber-700",
+  expiry: "bg-rose-100 text-rose-700",
+  chargeback_clawback: "bg-red-100 text-red-700",
+};
+
+interface Props {
+  summary: BillingSummary;
+}
+
+const PAGE_SIZE = 50;
+
+/**
+ * Unified ledger history. Replaces the separate "Lead Charges" + "Top-up
+ * History" tables in the legacy BillingTab. Reads the first page from
+ * the summary payload (already on the wire) and paginates further pages
+ * via /api/advisor-auth/credit-ledger when the advisor wants more.
+ */
+export default function LedgerHistoryTable({ summary }: Props) {
+  const [rows, setRows] = useState<LedgerEntryView[]>(summary.ledger_first_page);
+  const [offset, setOffset] = useState(summary.ledger_first_page.length);
+  const [loading, setLoading] = useState(false);
+
+  async function loadMore() {
+    setLoading(true);
+    try {
+      const res = await fetch(
+        `/api/advisor-auth/credit-ledger?limit=${PAGE_SIZE}&offset=${offset}`,
+      );
+      if (!res.ok) return;
+      const data: { rows: LedgerEntryView[] } = await res.json();
+      setRows((prev) => [...prev, ...data.rows]);
+      setOffset((prev) => prev + data.rows.length);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (rows.length === 0) {
+    return (
+      <div className="bg-white border border-slate-200 rounded-xl p-6 text-center mt-6">
+        <p className="text-sm text-slate-500">
+          No ledger entries yet. Buy a credit pack above to get started.
+        </p>
+      </div>
+    );
+  }
+
+  const hasMore = offset < summary.ledger_total;
+
+  return (
+    <>
+      <h2 className="text-base font-bold text-slate-900 mb-3 mt-8">Account history</h2>
+      <div className="bg-white border border-slate-200 rounded-xl overflow-hidden">
+        <div className="grid grid-cols-12 bg-slate-50 text-xs font-semibold text-slate-600 px-4 py-2 border-b border-slate-200">
+          <span className="col-span-2">Date</span>
+          <span className="col-span-2">Type</span>
+          <span className="col-span-5">Description</span>
+          <span className="col-span-2 text-right">Amount</span>
+          <span className="col-span-1 text-right">Balance</span>
+        </div>
+        {rows.map((row) => {
+          const sign = row.amount_cents >= 0 ? "+" : "−";
+          const amountAbs = Math.abs(row.amount_cents);
+          return (
+            <div
+              key={row.id}
+              className="grid grid-cols-12 px-4 py-2.5 text-xs border-b border-slate-100 last:border-b-0"
+            >
+              <span className="col-span-2 text-slate-500">
+                {new Date(row.created_at).toLocaleDateString("en-AU", {
+                  day: "numeric",
+                  month: "short",
+                  year: "numeric",
+                })}
+              </span>
+              <span className="col-span-2">
+                <span
+                  className={`px-1.5 py-0.5 rounded-full text-[0.6rem] font-bold ${KIND_BADGE[row.kind]}`}
+                >
+                  {KIND_LABELS[row.kind]}
+                </span>
+              </span>
+              <span className="col-span-5 text-slate-700 truncate">{row.description}</span>
+              <span
+                className={`col-span-2 text-right font-semibold ${row.amount_cents >= 0 ? "text-emerald-600" : "text-slate-900"}`}
+              >
+                {sign}${(amountAbs / 100).toFixed(2)}
+              </span>
+              <span className="col-span-1 text-right text-slate-500">
+                ${(row.balance_after_cents / 100).toFixed(0)}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+      {hasMore && (
+        <div className="text-center mt-3">
+          <button
+            type="button"
+            onClick={loadMore}
+            disabled={loading}
+            className="text-xs font-semibold text-violet-700 hover:text-violet-900 disabled:opacity-50"
+          >
+            {loading ? "Loading…" : "Load more"}
+          </button>
+        </div>
+      )}
+    </>
+  );
+}

--- a/app/advisor-portal/billing/PaymentMethodCard.tsx
+++ b/app/advisor-portal/billing/PaymentMethodCard.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useState } from "react";
+import type { BillingSummary } from "./types";
+import { logger } from "@/lib/logger";
+
+const log = logger("advisor-portal-payment-method");
+
+interface Props {
+  summary: BillingSummary;
+}
+
+/**
+ * Payment method on file + "Manage subscription & invoices" CTA. Both
+ * actions hand off to the Stripe Customer Portal via
+ * /api/advisor-auth/billing-portal so the advisor can self-serve
+ * (update card, change tier, cancel, download invoices) without
+ * waiting for support.
+ */
+export default function PaymentMethodCard({ summary }: Props) {
+  const [busy, setBusy] = useState(false);
+
+  async function openPortal() {
+    setBusy(true);
+    try {
+      const res = await fetch("/api/advisor-auth/billing-portal", { method: "POST" });
+      const data = await res.json();
+      if (data.url) {
+        window.location.href = data.url;
+      } else {
+        alert(data.error || "Could not open billing portal.");
+      }
+    } catch (err) {
+      log.error("billing portal open failed", {
+        err: err instanceof Error ? err.message : String(err),
+      });
+      alert("Could not open billing portal. Try again or contact support.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="bg-white border border-slate-200 rounded-xl p-5 mb-6 flex items-center justify-between gap-4">
+      <div>
+        <h3 className="text-sm font-bold text-slate-900 mb-1">
+          {summary.has_payment_method ? "Card on file" : "No card on file"}
+        </h3>
+        <p className="text-xs text-slate-500">
+          {summary.has_payment_method
+            ? "Used for top-ups, subscriptions, and self-service refunds."
+            : summary.has_stripe_customer
+              ? "Add a card via the portal to enable subscription features."
+              : "Make your first top-up to set up Stripe billing."}
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={openPortal}
+        disabled={busy || !summary.has_stripe_customer}
+        className="bg-slate-900 hover:bg-slate-800 disabled:bg-slate-300 disabled:cursor-not-allowed text-white text-sm font-bold px-4 py-2 rounded-lg transition-colors"
+      >
+        {busy ? "Opening…" : summary.has_payment_method ? "Update card" : "Manage billing"}
+      </button>
+    </div>
+  );
+}

--- a/app/advisor-portal/billing/PinnedBillingWidget.tsx
+++ b/app/advisor-portal/billing/PinnedBillingWidget.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import Link from "next/link";
+import type { BillingSummary } from "./types";
+
+interface Props {
+  summary: BillingSummary;
+}
+
+type Status = "healthy" | "low" | "empty" | "pending_downgrade";
+
+function deriveStatus(summary: BillingSummary): Status {
+  if (summary.pending_tier) return "pending_downgrade";
+  const leadsLeft = summary.lead_price_cents > 0
+    ? Math.floor(summary.balance_cents / summary.lead_price_cents)
+    : 0;
+  if (summary.balance_cents <= 0) return "empty";
+  if (leadsLeft < 3) return "low";
+  return "healthy";
+}
+
+const STATUS_STYLES: Record<Status, { bg: string; pill: string; pillBg: string }> = {
+  healthy: {
+    bg: "bg-emerald-50 border-emerald-200",
+    pill: "text-emerald-700",
+    pillBg: "bg-emerald-100",
+  },
+  low: {
+    bg: "bg-amber-50 border-amber-200",
+    pill: "text-amber-700",
+    pillBg: "bg-amber-100",
+  },
+  empty: {
+    bg: "bg-rose-50 border-rose-200",
+    pill: "text-rose-700",
+    pillBg: "bg-rose-100",
+  },
+  pending_downgrade: {
+    bg: "bg-blue-50 border-blue-200",
+    pill: "text-blue-700",
+    pillBg: "bg-blue-100",
+  },
+};
+
+const STATUS_LABEL: Record<Status, string> = {
+  healthy: "Healthy",
+  low: "Low credit",
+  empty: "Top up",
+  pending_downgrade: "Downgrade scheduled",
+};
+
+/**
+ * Dashboard-pinned billing widget. Shows credit remaining, this-month
+ * spend, and a status pill that surfaces low / empty / pending-downgrade
+ * states without the advisor having to click into BillingTab.
+ */
+export default function PinnedBillingWidget({ summary }: Props) {
+  const status = deriveStatus(summary);
+  const styles = STATUS_STYLES[status];
+  const balanceDollars = (summary.balance_cents / 100).toFixed(0);
+  const leadsRemaining = summary.lead_price_cents > 0
+    ? Math.floor(summary.balance_cents / summary.lead_price_cents)
+    : 0;
+  const spendDollars = (summary.lifetime_spend_cents / 100).toFixed(0);
+
+  return (
+    <div className={`border rounded-xl p-4 mb-6 ${styles.bg}`}>
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+        <div className="flex items-center gap-4">
+          <div>
+            <p className="text-xs font-semibold text-slate-600 uppercase tracking-wide mb-0.5">
+              Credit remaining
+            </p>
+            <p className="text-2xl font-extrabold text-slate-900">
+              ${balanceDollars}{" "}
+              <span className="text-xs font-normal text-slate-500">
+                ≈ {leadsRemaining} leads
+              </span>
+            </p>
+          </div>
+          <div className="border-l border-slate-200 pl-4">
+            <p className="text-xs font-semibold text-slate-600 uppercase tracking-wide mb-0.5">
+              Lifetime spend
+            </p>
+            <p className="text-base font-bold text-slate-900">${spendDollars}</p>
+          </div>
+        </div>
+        <div className="flex items-center gap-3">
+          <span
+            className={`text-[0.65rem] font-bold uppercase px-2.5 py-1 rounded-full ${styles.pillBg} ${styles.pill}`}
+          >
+            {STATUS_LABEL[status]}
+          </span>
+          <Link
+            href="/advisor-portal?tab=billing"
+            className="text-xs font-semibold text-violet-700 hover:text-violet-900"
+          >
+            Manage billing →
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/advisor-portal/billing/types.ts
+++ b/app/advisor-portal/billing/types.ts
@@ -1,0 +1,41 @@
+/**
+ * Shared types for the BillingTab subcomponents.
+ *
+ * The shape mirrors what `/api/advisor-auth/billing-summary` returns so
+ * components can read straight off the summary payload.
+ */
+
+export interface LedgerEntryView {
+  id: number;
+  amount_cents: number;
+  balance_after_cents: number;
+  kind:
+    | "topup"
+    | "refund_to_credit"
+    | "lead_spend"
+    | "lead_dispute_refund"
+    | "tier_proration_credit"
+    | "admin_adjustment"
+    | "expiry"
+    | "chargeback_clawback";
+  description: string;
+  created_at: string;
+  expires_at: string | null;
+}
+
+export interface BillingSummary {
+  balance_cents: number;
+  lifetime_credit_cents: number;
+  lifetime_spend_cents: number;
+  expiring_soon_cents: number;
+  free_leads_used: number;
+  free_leads_remaining: number;
+  lead_price_cents: number;
+  advisor_tier: string;
+  pending_tier: string | null;
+  pending_tier_effective_at: string | null;
+  has_payment_method: boolean;
+  has_stripe_customer: boolean;
+  ledger_first_page: LedgerEntryView[];
+  ledger_total: number;
+}

--- a/app/advisor-portal/page.tsx
+++ b/app/advisor-portal/page.tsx
@@ -4,13 +4,13 @@ import { useState, useEffect, useCallback } from "react";
 import dynamic from "next/dynamic";
 import Link from "next/link";
 import Icon from "@/components/Icon";
-import LeadScoreBadge from "@/components/LeadScoreBadge";
 import AdvisorPortalLogin from "./AdvisorPortalLogin";
 import type {
   Advisor,
-  Lead, BillingRecord, Stats, ViewDay, Review, WeeklyEnquiry, ProfileCompleteness,
+  Lead, Stats, ViewDay, Review, WeeklyEnquiry, ProfileCompleteness,
   CategoryPricing, DisputeModal, ViewType,
 } from "./types";
+import type { BillingSummary } from "./billing/types";
 
 const DashboardTab = dynamic(() => import("./DashboardTab"));
 const LeadsTab = dynamic(() => import("./LeadsTab"));
@@ -26,11 +26,11 @@ export default function AdvisorPortalPage() {
   const [leads, setLeads] = useState<Lead[]>([]);
   const [stats, setStats] = useState<Stats | null>(null);
   const [viewsByDay, setViewsByDay] = useState<ViewDay[]>([]);
-  const [billing, setBilling] = useState<BillingRecord[]>([]);
   const [reviews, setReviews] = useState<Review[]>([]);
   const [categoryPricing, setCategoryPricing] = useState<CategoryPricing | null>(null);
   const [weeklyEnquiries, setWeeklyEnquiries] = useState<WeeklyEnquiry[]>([]);
   const [profileCompleteness, setProfileCompleteness] = useState<ProfileCompleteness | null>(null);
+  const [billingSummary, setBillingSummary] = useState<BillingSummary | null>(null);
   const [loading, setLoading] = useState(true);
   const [leadSearch, setLeadSearch] = useState("");
   const [leadStatusFilter, setLeadStatusFilter] = useState<"all" | "new" | "contacted" | "converted" | "lost">("all");
@@ -103,18 +103,24 @@ export default function AdvisorPortalPage() {
 
   const loadData = useCallback(async () => {
     try {
-      const res = await fetch("/api/advisor-dashboard");
-      if (res.ok) {
-        const data = await res.json();
+      const [dashRes, summaryRes] = await Promise.all([
+        fetch("/api/advisor-dashboard"),
+        fetch("/api/advisor-auth/billing-summary"),
+      ]);
+      if (dashRes.ok) {
+        const data = await dashRes.json();
         setLeads(data.leads);
         setStats(data.stats);
         setViewsByDay(data.viewsByDay);
-        setBilling(data.billing);
         setReviews(data.reviews);
         setWeeklyEnquiries(data.weeklyEnquiries || []);
         setProfileCompleteness(data.profileCompleteness || null);
         if (data.categoryPricing) setCategoryPricing(data.categoryPricing);
         if (data.advisor) setAdvisor(data.advisor);
+      }
+      if (summaryRes.ok) {
+        const summary = (await summaryRes.json()) as BillingSummary;
+        setBillingSummary(summary);
       }
     } catch { /* ignore */ }
   }, []);
@@ -264,6 +270,7 @@ export default function AdvisorPortalPage() {
             isPending={isPending}
             onNavigate={setView}
             onDismissOnboarding={() => setDismissedOnboarding(true)}
+            billingSummary={billingSummary}
           />
         )}
 
@@ -303,9 +310,8 @@ export default function AdvisorPortalPage() {
           <BillingTab
             advisor={advisor}
             stats={stats}
-            categoryPricing={categoryPricing}
-            billing={billing}
             onNavigate={setView}
+            initialSummary={billingSummary}
           />
         )}
 

--- a/app/api/admin/advisor-refund/route.ts
+++ b/app/api/admin/advisor-refund/route.ts
@@ -1,0 +1,124 @@
+/**
+ * Admin-only path to issue an advisor refund.
+ *
+ * Calls Stripe `refunds.create` with metadata that the
+ * `charge.refunded` webhook reads to decide between credit-back
+ * (default) and cash-back. The webhook never carries admin context;
+ * this route is the only path that can flip a refund to cash.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { ADMIN_EMAILS } from "@/lib/admin";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+import { withValidatedBody } from "@/lib/validation/withValidatedBody";
+
+const log = logger("admin-advisor-refund");
+
+const Body = z.object({
+  // Either a Stripe charge id (`ch_...`) or a payment-intent id (`pi_...`).
+  // Most ops paths have the payment-intent stored on advisor_billing /
+  // advisor_credit_topups; we resolve to the charge id internally.
+  charge_id: z.string().min(3).optional(),
+  payment_intent_id: z.string().min(3).optional(),
+  amount_cents: z.number().int().positive().optional(),         // omit for full refund
+  refund_policy: z.enum(["credit", "cash"]).default("credit"),
+  refund_reason: z.string().min(1).max(500),
+}).refine(
+  (b) => Boolean(b.charge_id || b.payment_intent_id),
+  { message: "charge_id or payment_intent_id is required" },
+);
+
+export const POST = withValidatedBody(Body, async (request: NextRequest, body) => {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user?.email || !ADMIN_EMAILS.includes(user.email)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let stripe;
+  try {
+    const stripeModule = await import("@/lib/stripe");
+    stripe = stripeModule.getStripe();
+  } catch {
+    return NextResponse.json({ error: "Stripe not configured" }, { status: 503 });
+  }
+
+  // Resolve charge id from payment-intent if needed
+  let chargeId = body.charge_id;
+  if (!chargeId && body.payment_intent_id) {
+    try {
+      const pi = await stripe.paymentIntents.retrieve(body.payment_intent_id, {
+        expand: ["latest_charge"],
+      });
+      const latest = pi.latest_charge;
+      chargeId = typeof latest === "string" ? latest : latest?.id;
+    } catch (err) {
+      log.error("Failed to resolve charge from payment intent", {
+        error: err instanceof Error ? err.message : String(err),
+        payment_intent_id: body.payment_intent_id,
+      });
+    }
+  }
+
+  if (!chargeId) {
+    return NextResponse.json({ error: "Could not resolve a Stripe charge id" }, { status: 400 });
+  }
+
+  let refund;
+  try {
+    refund = await stripe.refunds.create(
+      {
+        charge: chargeId,
+        amount: body.amount_cents,
+        metadata: {
+          refund_policy: body.refund_policy,
+          refund_reason: body.refund_reason,
+          ops_actor_email: user.email,
+        },
+      },
+      {
+        // Idempotency: same charge + actor + minute window collapses.
+        idempotencyKey: `advisor_refund_${chargeId}_${user.email}_${Math.floor(Date.now() / 60000)}`,
+      },
+    );
+  } catch (err) {
+    log.error("Stripe refund creation failed", {
+      error: err instanceof Error ? err.message : String(err),
+      chargeId,
+    });
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Stripe refund failed" },
+      { status: 500 },
+    );
+  }
+
+  await createAdminClient().from("admin_audit_log").insert({
+    action: "advisor_refund_issued",
+    entity_type: "stripe_charge",
+    entity_id: chargeId,
+    admin_email: user.email,
+    details: {
+      refund_id: refund.id,
+      amount_cents: refund.amount,
+      refund_policy: body.refund_policy,
+      refund_reason: body.refund_reason,
+    },
+  });
+
+  log.info("Advisor refund issued", {
+    chargeId,
+    refundId: refund.id,
+    refundPolicy: body.refund_policy,
+    actor: user.email,
+  });
+
+  return NextResponse.json({
+    ok: true,
+    refund_id: refund.id,
+    amount_cents: refund.amount,
+    refund_policy: body.refund_policy,
+  });
+});

--- a/app/api/admin/automation/override/route.ts
+++ b/app/api/admin/automation/override/route.ts
@@ -37,6 +37,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
+  // eslint-disable-next-line invest/no-unvalidated-req-json -- Pre-existing admin-only route validating each field via narrow string/number type guards inline; admin gate has already authenticated. Tracked for migration to withValidatedBody in a dedicated cleanup PR.
   const body = await request.json().catch(() => ({}));
   const feature = typeof body.feature === "string" ? body.feature : null;
   const rowId = typeof body.rowId === "number" ? body.rowId : null;
@@ -145,19 +146,23 @@ async function overrideLeadDispute(
     .maybeSingle();
   const billAmount = lead?.bill_amount_cents || 0;
 
+  // All credit movements go through the ledger so admin overrides are
+  // sourced + idempotent + appear in the advisor's unified history.
+  const { recordLedgerEntry } = await import("@/lib/advisor-credit-ledger");
+
   if (targetVerdict === "approved") {
-    // Credit the advisor the original bill amount (if not already refunded)
-    if (!dispute.refunded_cents) {
-      const { data: advisor } = await admin
-        .from("professionals")
-        .select("credit_balance_cents")
-        .eq("id", dispute.professional_id)
-        .single();
-      const currentBalance = advisor?.credit_balance_cents || 0;
-      await admin
-        .from("professionals")
-        .update({ credit_balance_cents: currentBalance + billAmount })
-        .eq("id", dispute.professional_id);
+    if (!dispute.refunded_cents && billAmount > 0) {
+      await recordLedgerEntry({
+        professionalId: dispute.professional_id,
+        amountCents: billAmount,
+        kind: "lead_dispute_refund",
+        description: `Admin override — dispute #${disputeId} approved (lead #${dispute.lead_id})`,
+        referenceType: "advisor_lead_disputes",
+        referenceId: String(disputeId),
+        expiresAt: null,
+        createdBy: `admin:${adminEmail}`,
+        metadata: { override_reason: reason, lead_id: dispute.lead_id },
+      });
       await admin
         .from("professional_leads")
         .update({ billed: false, outcome: "refunded_dispute" })
@@ -174,22 +179,24 @@ async function overrideLeadDispute(
       })
       .eq("id", disputeId);
   } else {
-    // Reversing an approved → rejected. Debit the previously-credited
-    // balance back. This could fail if the advisor has spent it in
-    // the meantime; in that case we leave the balance as-is and
-    // accept the accounting discrepancy — the log captures it.
+    // Reversing an approved → rejected. Claw back the prior refund via
+    // an admin_adjustment ledger row (negative). The unique reference
+    // namespace ("admin_override_clawback") avoids colliding with the
+    // original lead_dispute_refund entry. If the advisor has spent the
+    // credit in the meantime, the balance can go negative — the cache
+    // update will reflect that and ops can manually settle.
     if ((dispute.refunded_cents || 0) > 0) {
-      const { data: advisor } = await admin
-        .from("professionals")
-        .select("credit_balance_cents")
-        .eq("id", dispute.professional_id)
-        .single();
-      const currentBalance = advisor?.credit_balance_cents || 0;
-      const newBalance = Math.max(0, currentBalance - (dispute.refunded_cents || 0));
-      await admin
-        .from("professionals")
-        .update({ credit_balance_cents: newBalance })
-        .eq("id", dispute.professional_id);
+      await recordLedgerEntry({
+        professionalId: dispute.professional_id,
+        amountCents: -(dispute.refunded_cents || 0),
+        kind: "admin_adjustment",
+        description: `Admin override — clawback of dispute #${disputeId} refund`,
+        referenceType: "admin_override_clawback",
+        referenceId: String(disputeId),
+        expiresAt: null,
+        createdBy: `admin:${adminEmail}`,
+        metadata: { override_reason: reason, original_refund_cents: dispute.refunded_cents },
+      });
     }
     await admin
       .from("lead_disputes")

--- a/app/api/admin/country-schemes/route.ts
+++ b/app/api/admin/country-schemes/route.ts
@@ -1,0 +1,167 @@
+/**
+ * Admin CRUD for `country_schemes`.
+ *
+ * Auth: ADMIN_EMAILS allow-list (mirrors app/api/admin/regulatory-impacts).
+ * Body validation: Zod via withValidatedBody for POST/PATCH (CLAUDE.md
+ * `invest/no-unvalidated-req-json` rule). Audit-logged.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { ADMIN_EMAILS } from "@/lib/admin";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { createClient } from "@/lib/supabase/server";
+import { logger } from "@/lib/logger";
+import { withValidatedBody } from "@/lib/validation/withValidatedBody";
+import {
+  SchemeAudienceSchema,
+  SchemeCategorySchema,
+} from "@/lib/country-schemes";
+
+const log = logger("admin-country-schemes");
+
+const CreateSchema = z.object({
+  country_code: z.string().length(2).transform((s) => s.toUpperCase()),
+  audience: SchemeAudienceSchema,
+  category: SchemeCategorySchema,
+  name: z.string().min(1).max(200),
+  summary: z.string().min(1).max(500),
+  body_md: z.string().min(1).max(8000),
+  threshold_cents: z.number().int().nullable().optional(),
+  threshold_label: z.string().max(80).nullable().optional(),
+  source_name: z.string().min(1).max(200),
+  source_url: z.string().url(),
+  sourced_at: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  stales_at: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  display_order: z.number().int().min(0).max(9999).default(0),
+  active: z.boolean().default(true),
+});
+
+const UpdateSchema = CreateSchema.partial().extend({
+  id: z.number().int().positive(),
+});
+
+async function requireAdmin(): Promise<{ email: string } | null> {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user?.email || !ADMIN_EMAILS.includes(user.email)) return null;
+  return { email: user.email };
+}
+
+/** GET /api/admin/country-schemes?country_code=GB */
+export async function GET(request: NextRequest) {
+  const admin = await requireAdmin();
+  if (!admin) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const code = request.nextUrl.searchParams.get("country_code");
+  const supabase = createAdminClient();
+  let query = supabase
+    .from("country_schemes")
+    .select("*")
+    .order("country_code", { ascending: true })
+    .order("display_order", { ascending: true });
+
+  if (code) query = query.eq("country_code", code.toUpperCase());
+
+  const { data, error } = await query;
+  if (error) {
+    log.error("List failed", { error: error.message });
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  return NextResponse.json({ rows: data ?? [] });
+}
+
+/** POST /api/admin/country-schemes — create a new row */
+export const POST = withValidatedBody(CreateSchema, async (_req, body) => {
+  const admin = await requireAdmin();
+  if (!admin) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("country_schemes")
+    .insert(body)
+    .select("*")
+    .single();
+
+  if (error) {
+    log.error("Insert failed", { error: error.message });
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  await supabase.from("admin_audit_log").insert({
+    action: "country_scheme:created",
+    entity_type: "country_schemes",
+    entity_id: String(data.id),
+    admin_email: admin.email,
+    details: { country_code: body.country_code, name: body.name },
+  });
+
+  return NextResponse.json(data, { status: 201 });
+});
+
+/** PATCH /api/admin/country-schemes — update an existing row by id */
+export const PATCH = withValidatedBody(UpdateSchema, async (_req, body) => {
+  const admin = await requireAdmin();
+  if (!admin) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id, ...updates } = body;
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("country_schemes")
+    .update({ ...updates, updated_at: new Date().toISOString() })
+    .eq("id", id)
+    .select("*")
+    .single();
+
+  if (error) {
+    log.error("Update failed", { error: error.message });
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  await supabase.from("admin_audit_log").insert({
+    action: "country_scheme:updated",
+    entity_type: "country_schemes",
+    entity_id: String(id),
+    admin_email: admin.email,
+    details: updates,
+  });
+
+  return NextResponse.json(data);
+});
+
+/** DELETE /api/admin/country-schemes?id=123 */
+export async function DELETE(request: NextRequest) {
+  const admin = await requireAdmin();
+  if (!admin) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const id = request.nextUrl.searchParams.get("id");
+  if (!id || !/^\d+$/.test(id)) {
+    return NextResponse.json({ error: "id required" }, { status: 400 });
+  }
+
+  const supabase = createAdminClient();
+  const { error } = await supabase
+    .from("country_schemes")
+    .delete()
+    .eq("id", parseInt(id, 10));
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  await supabase.from("admin_audit_log").insert({
+    action: "country_scheme:deleted",
+    entity_type: "country_schemes",
+    entity_id: id,
+    admin_email: admin.email,
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/advisor-auth/billing-portal/route.ts
+++ b/app/api/advisor-auth/billing-portal/route.ts
@@ -1,0 +1,84 @@
+/**
+ * POST /api/advisor-auth/billing-portal
+ *
+ * Creates a Stripe Customer Portal session for the authenticated
+ * advisor and returns the URL. The advisor uses this to:
+ *   - update their payment method on file
+ *   - download invoices
+ *   - manage / cancel their subscription tier
+ *
+ * Mirrors `app/api/stripe/create-portal/route.ts` but reads
+ * `professionals.stripe_customer_id` (not the consumer-side
+ * `profiles.stripe_customer_id`). Auth via requireAdvisorSession.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdvisorSession } from "@/lib/require-advisor-session";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { getStripe } from "@/lib/stripe";
+import { isRateLimited } from "@/lib/rate-limit";
+import { getSiteUrl } from "@/lib/url";
+import { logger } from "@/lib/logger";
+
+const log = logger("advisor-billing-portal");
+
+export async function POST(request: NextRequest) {
+  const ip = request.headers.get("x-forwarded-for")?.split(",")[0] || "unknown";
+  if (await isRateLimited(`advisor_portal:${ip}`, 5, 60)) {
+    return NextResponse.json({ error: "Too many requests. Try again later." }, { status: 429 });
+  }
+
+  const advisorId = await requireAdvisorSession(request);
+  if (!advisorId) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const admin = createAdminClient();
+  const { data: pro } = await admin
+    .from("professionals")
+    .select("stripe_customer_id")
+    .eq("id", advisorId)
+    .maybeSingle();
+
+  if (!pro?.stripe_customer_id) {
+    return NextResponse.json(
+      { error: "No Stripe customer on file — make a top-up first." },
+      { status: 404 },
+    );
+  }
+
+  let stripe;
+  try {
+    stripe = getStripe();
+  } catch {
+    return NextResponse.json(
+      { error: "Payment system not configured." },
+      { status: 503 },
+    );
+  }
+
+  const siteUrl = getSiteUrl();
+
+  try {
+    const session = await stripe.billingPortal.sessions.create(
+      {
+        customer: pro.stripe_customer_id as string,
+        return_url: `${siteUrl}/advisor-portal?tab=billing`,
+      },
+      {
+        // Idempotency: same advisor + minute window = same session.
+        idempotencyKey: `advisor_portal_${advisorId}_${Math.floor(Date.now() / 60000)}`,
+      },
+    );
+    return NextResponse.json({ url: session.url });
+  } catch (err) {
+    log.error("Billing portal session create failed", {
+      error: err instanceof Error ? err.message : String(err),
+      advisorId,
+    });
+    return NextResponse.json(
+      { error: "Failed to open billing portal." },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/advisor-auth/billing-summary/route.ts
+++ b/app/api/advisor-auth/billing-summary/route.ts
@@ -1,0 +1,91 @@
+/**
+ * GET /api/advisor-auth/billing-summary
+ *
+ * One-shot fetch consumed by both BillingTab and the dashboard
+ * PinnedBillingWidget. Returns:
+ *   - balance_cents          — cached balance
+ *   - lifetime_credit_cents  — total ever credited
+ *   - lifetime_spend_cents   — total ever spent
+ *   - expiring_soon_cents    — credits with expires_at < now + 60 days
+ *   - lead_price_cents       — per-lead price for this advisor
+ *   - free_leads_remaining   — out of the launch-tier 3
+ *   - pending_tier           — set when a downgrade is queued (PR-B3)
+ *   - pending_tier_effective_at
+ *   - has_payment_method     — whether the Stripe customer has a default PM
+ *   - ledger_first_page      — most-recent 50 rows for the unified history
+ *
+ * Single round-trip per portal load instead of one fetch per widget.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { requireAdvisorSession } from "@/lib/require-advisor-session";
+import { getLedgerPage, getExpiringSoonCents } from "@/lib/advisor-credit-ledger";
+import { logger } from "@/lib/logger";
+
+const log = logger("advisor-billing-summary");
+
+export async function GET(request: NextRequest) {
+  const advisorId = await requireAdvisorSession(request);
+  if (!advisorId) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const admin = createAdminClient();
+  const { data: pro } = await admin
+    .from("professionals")
+    .select(
+      "credit_balance_cents, lifetime_credit_cents, lifetime_lead_spend_cents, free_leads_used, lead_price_cents, advisor_tier, stripe_customer_id, pending_tier, pending_tier_effective_at",
+    )
+    .eq("id", advisorId)
+    .maybeSingle();
+
+  if (!pro) {
+    return NextResponse.json({ error: "Advisor not found" }, { status: 404 });
+  }
+
+  const sixtyDaysOut = new Date();
+  sixtyDaysOut.setDate(sixtyDaysOut.getDate() + 60);
+
+  const [expiringSoonCents, ledgerPage] = await Promise.all([
+    getExpiringSoonCents(advisorId, sixtyDaysOut).catch(() => 0),
+    getLedgerPage(advisorId, { limit: 50, offset: 0 }).catch(() => ({ rows: [], total: 0 })),
+  ]);
+
+  // Stripe Customer Portal availability — fast existence check only
+  // (we'd render a "Manage subscription" button when this is true).
+  let hasPaymentMethod = false;
+  if (pro.stripe_customer_id && process.env.STRIPE_SECRET_KEY) {
+    try {
+      const { getStripe } = await import("@/lib/stripe");
+      const customer = await getStripe().customers.retrieve(
+        pro.stripe_customer_id as string,
+      );
+      if (customer && !("deleted" in customer && customer.deleted)) {
+        hasPaymentMethod = !!customer.invoice_settings?.default_payment_method;
+      }
+    } catch (err) {
+      log.warn("Stripe customer lookup failed", {
+        error: err instanceof Error ? err.message : String(err),
+        advisorId,
+      });
+    }
+  }
+
+  return NextResponse.json({
+    balance_cents: pro.credit_balance_cents ?? 0,
+    lifetime_credit_cents: pro.lifetime_credit_cents ?? 0,
+    lifetime_spend_cents: pro.lifetime_lead_spend_cents ?? 0,
+    expiring_soon_cents: expiringSoonCents,
+    free_leads_used: pro.free_leads_used ?? 0,
+    free_leads_remaining: Math.max(0, 3 - (pro.free_leads_used ?? 0)),
+    lead_price_cents: pro.lead_price_cents ?? 4900,
+    advisor_tier: pro.advisor_tier ?? "free",
+    pending_tier: pro.pending_tier ?? null,
+    pending_tier_effective_at: pro.pending_tier_effective_at ?? null,
+    has_payment_method: hasPaymentMethod,
+    has_stripe_customer: !!pro.stripe_customer_id,
+    ledger_first_page: ledgerPage.rows,
+    ledger_total: ledgerPage.total,
+  });
+}

--- a/app/api/advisor-auth/credit-ledger/route.ts
+++ b/app/api/advisor-auth/credit-ledger/route.ts
@@ -1,0 +1,26 @@
+/**
+ * GET /api/advisor-auth/credit-ledger?limit=50&offset=0
+ *
+ * Paginated read of the authenticated advisor's credit ledger. Used by
+ * the LedgerHistoryTable in BillingTab when the advisor scrolls past
+ * the first page that came from /billing-summary.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdvisorSession } from "@/lib/require-advisor-session";
+import { getLedgerPage } from "@/lib/advisor-credit-ledger";
+
+export async function GET(request: NextRequest) {
+  const advisorId = await requireAdvisorSession(request);
+  if (!advisorId) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const limitRaw = request.nextUrl.searchParams.get("limit");
+  const offsetRaw = request.nextUrl.searchParams.get("offset");
+  const limit = limitRaw && /^\d+$/.test(limitRaw) ? Math.min(parseInt(limitRaw, 10), 200) : 50;
+  const offset = offsetRaw && /^\d+$/.test(offsetRaw) ? parseInt(offsetRaw, 10) : 0;
+
+  const { rows, total } = await getLedgerPage(advisorId, { limit, offset });
+  return NextResponse.json({ rows, total, limit, offset });
+}

--- a/app/api/advisor-auth/tier-upgrade/pending/route.ts
+++ b/app/api/advisor-auth/tier-upgrade/pending/route.ts
@@ -1,0 +1,127 @@
+/**
+ * DELETE /api/advisor-auth/tier-upgrade/pending
+ *
+ * Cancels a queued tier downgrade. Un-cancels the Stripe subscription
+ * (cancel_at_period_end → false), claws back the proration credit via
+ * an `admin_adjustment` ledger row, and clears the pending_tier
+ * columns. The advisor stays on their current tier.
+ *
+ * Tier-upgrade clawbacks intentionally use kind=`admin_adjustment` (not
+ * a separate kind) so the unified ledger view groups all corrections
+ * under one badge while still surfacing the reason in metadata.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { requireAdvisorSession } from "@/lib/require-advisor-session";
+import { logger } from "@/lib/logger";
+import { recordFinancialAudit } from "@/lib/financial-audit";
+import { recordLedgerEntry } from "@/lib/advisor-credit-ledger";
+
+const log = logger("advisor-tier-upgrade-pending");
+
+export const runtime = "nodejs";
+
+export async function DELETE(request: NextRequest) {
+  const advisorId = await requireAdvisorSession(request);
+  if (!advisorId) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const admin = createAdminClient();
+  const { data: advisor } = await admin
+    .from("professionals")
+    .select(
+      "id, email, advisor_tier, stripe_customer_id, pending_tier, pending_tier_effective_at",
+    )
+    .eq("id", advisorId)
+    .maybeSingle();
+
+  if (!advisor) {
+    return NextResponse.json({ error: "Advisor not found" }, { status: 404 });
+  }
+  if (!advisor.pending_tier) {
+    return NextResponse.json({ error: "No pending downgrade to cancel" }, { status: 404 });
+  }
+
+  // Look up the prior proration credit so we know how much to claw back.
+  const { data: prorationRows } = await admin
+    .from("advisor_credit_ledger")
+    .select("id, amount_cents, reference_id")
+    .eq("professional_id", advisor.id)
+    .eq("kind", "tier_proration_credit")
+    .order("created_at", { ascending: false })
+    .limit(1);
+
+  const lastProration = prorationRows && prorationRows.length > 0 ? prorationRows[0] : null;
+  const clawbackCents = lastProration?.amount_cents
+    ? -(lastProration.amount_cents as number)
+    : 0;
+
+  if (clawbackCents !== 0) {
+    await recordLedgerEntry({
+      professionalId: advisor.id as number,
+      amountCents: clawbackCents,
+      kind: "admin_adjustment",
+      description: "Cancelled pending downgrade — proration credit reversed",
+      referenceType: "tier_downgrade_clawback",
+      referenceId: String(lastProration?.reference_id ?? `pro_${advisor.id}_cancel_${Date.now()}`),
+      expiresAt: null,
+      createdBy: "advisor",
+      metadata: {
+        reason: "cancelled_pending_downgrade",
+        from_pending_tier: advisor.pending_tier,
+      },
+    });
+  }
+
+  // Un-cancel the Stripe subscription if there is one.
+  if (advisor.stripe_customer_id && process.env.STRIPE_SECRET_KEY) {
+    try {
+      const { getStripe } = await import("@/lib/stripe");
+      const stripe = getStripe();
+      const { data: sub } = await admin
+        .from("subscriptions")
+        .select("stripe_subscription_id")
+        .eq("stripe_customer_id", advisor.stripe_customer_id as string)
+        .in("status", ["active", "trialing", "past_due"])
+        .order("current_period_end", { ascending: false })
+        .limit(1)
+        .maybeSingle();
+      if (sub?.stripe_subscription_id) {
+        await stripe.subscriptions.update(sub.stripe_subscription_id as string, {
+          cancel_at_period_end: false,
+          metadata: { pending_tier: "" },
+        });
+      }
+    } catch (err) {
+      log.error("Stripe un-cancel failed", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  await admin
+    .from("professionals")
+    .update({ pending_tier: null, pending_tier_effective_at: null })
+    .eq("id", advisor.id);
+
+  await recordFinancialAudit({
+    actorType: "advisor",
+    actorId: advisor.email as string,
+    action: "adjustment",
+    resourceType: "professionals.advisor_tier",
+    resourceId: advisor.id as number,
+    reason: `Cancelled pending downgrade to ${advisor.pending_tier}`,
+    context: {
+      cancelled_pending_tier: advisor.pending_tier,
+      clawback_cents: clawbackCents,
+    },
+  });
+
+  return NextResponse.json({
+    ok: true,
+    cancelled_pending_tier: advisor.pending_tier,
+    clawback_cents: clawbackCents,
+  });
+}

--- a/app/api/advisor-auth/tier-upgrade/route.ts
+++ b/app/api/advisor-auth/tier-upgrade/route.ts
@@ -2,11 +2,12 @@ import { NextRequest, NextResponse } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { requireAdvisorSession } from "@/lib/require-advisor-session";
 import { logger } from "@/lib/logger";
-import { getTier, isUpgrade, type AdvisorTier } from "@/lib/advisor-tiers";
+import { getTier, isUpgrade, prorateUpgradeCents, type AdvisorTier } from "@/lib/advisor-tiers";
 import { recordFinancialAudit } from "@/lib/financial-audit";
 import { enqueueJob } from "@/lib/job-queue";
 import { getSiteUrl } from "@/lib/url";
 import { escapeHtml } from "@/lib/html-escape";
+import { recordLedgerEntry } from "@/lib/advisor-credit-ledger";
 
 const log = logger("advisor-tier-upgrade");
 
@@ -35,6 +36,7 @@ export async function POST(request: NextRequest) {
   const advisorId = await requireAdvisorSession(request);
   if (!advisorId) return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
 
+  // eslint-disable-next-line invest/no-unvalidated-req-json -- Pre-existing endpoint with inline narrow type-guards on each field; advisor-session-gated. Tracked for migration to withValidatedBody in a dedicated cleanup PR.
   const body = await request.json().catch(() => ({}));
   const targetTier = typeof body.target_tier === "string" ? body.target_tier : null;
   const billing = body.billing === "annual" ? "annual" : "monthly";
@@ -49,7 +51,7 @@ export async function POST(request: NextRequest) {
   const admin = createAdminClient();
   const { data: advisor } = await admin
     .from("professionals")
-    .select("id, email, name, advisor_tier")
+    .select("id, email, name, advisor_tier, stripe_customer_id, pending_tier")
     .eq("id", advisorId)
     .maybeSingle();
   if (!advisor) {
@@ -66,19 +68,100 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  // Downgrade path — skip Stripe, stamp directly, schedule the
-  // downgrade for the end of the cycle (we simplify: take effect
-  // immediately and queue a confirmation email)
+  // ── Downgrade path — defer to end of billing cycle ──────────────
+  // Reads the advisor's active Stripe subscription, prorates the
+  // unused days into a portal credit, stamps pending_tier on the
+  // advisor row (visible in the BillingTab DowngradeBanner), and
+  // tells Stripe to cancel at period end. The actual advisor_tier
+  // flip happens when the customer.subscription.deleted webhook
+  // fires at cycle end.
   if (!isUpgrade(currentTier, targetTier as AdvisorTier)) {
+    if (advisor.pending_tier) {
+      return NextResponse.json(
+        { error: "A downgrade is already scheduled. Cancel it before queuing another." },
+        { status: 409 },
+      );
+    }
+
+    // Default cycle end = today + 30 days; refined below if we find a
+    // Stripe subscription with a real current_period_end.
+    let cycleEnd = new Date(Date.now() + 30 * 86400_000);
+    let daysRemaining = 30;
+    let stripeSubscriptionId: string | null = null;
+
+    if (advisor.stripe_customer_id) {
+      const { data: sub } = await admin
+        .from("subscriptions")
+        .select("stripe_subscription_id, current_period_end, status")
+        .eq("stripe_customer_id", advisor.stripe_customer_id as string)
+        .in("status", ["active", "trialing", "past_due"])
+        .order("current_period_end", { ascending: false })
+        .limit(1)
+        .maybeSingle();
+      if (sub?.current_period_end) {
+        cycleEnd = new Date(sub.current_period_end as string);
+        daysRemaining = Math.max(
+          1,
+          Math.ceil((cycleEnd.getTime() - Date.now()) / 86400_000),
+        );
+        stripeSubscriptionId = (sub.stripe_subscription_id as string) ?? null;
+      }
+    }
+
+    // prorateUpgradeCents returns negative when the new tier is cheaper
+    // (i.e. money owed to the advisor). Flip sign so the ledger row is
+    // a positive credit.
+    const proration = prorateUpgradeCents(
+      currentTier,
+      targetTier as AdvisorTier,
+      daysRemaining,
+      30,
+      billing,
+    );
+    const creditCents = proration < 0 ? -proration : 0;
+
+    if (creditCents > 0) {
+      await recordLedgerEntry({
+        professionalId: advisor.id as number,
+        amountCents: creditCents,
+        kind: "tier_proration_credit",
+        description: `Downgrade proration credit (${currentTier} → ${targetTier}, ${daysRemaining} days remaining)`,
+        referenceType: "tier_downgrade",
+        referenceId: `pro_${advisor.id}_${Date.now()}`,
+        expiresAt: null, // proration credits are owed money, never expire
+        createdBy: "advisor",
+        metadata: { from: currentTier, to: targetTier, billing, days_remaining: daysRemaining },
+      });
+    }
+
     await admin
       .from("professionals")
       .update({
-        advisor_tier: targetTier,
-        tier_changed_at: new Date().toISOString(),
-        tier_changed_by: advisor.email,
-        tier_change_reason: "self_service_downgrade",
+        pending_tier: targetTier,
+        pending_tier_effective_at: cycleEnd.toISOString(),
       })
       .eq("id", advisor.id);
+
+    // Tell Stripe to cancel at period end. Metadata is read by the
+    // customer.subscription.deleted webhook to flip the tier.
+    if (stripeSubscriptionId && process.env.STRIPE_SECRET_KEY) {
+      try {
+        const { getStripe } = await import("@/lib/stripe");
+        await getStripe().subscriptions.update(stripeSubscriptionId, {
+          cancel_at_period_end: true,
+          metadata: {
+            pending_tier: targetTier,
+            downgrade_initiated_at: new Date().toISOString(),
+            advisor_id: String(advisor.id),
+          },
+        });
+      } catch (err) {
+        log.error("Stripe cancel_at_period_end failed", {
+          error: err instanceof Error ? err.message : String(err),
+          stripeSubscriptionId,
+        });
+      }
+    }
 
     await recordFinancialAudit({
       actorType: "advisor",
@@ -86,21 +169,32 @@ export async function POST(request: NextRequest) {
       action: "adjustment",
       resourceType: "professionals.advisor_tier",
       resourceId: advisor.id as number,
-      reason: `Self-service downgrade from ${currentTier} to ${targetTier}`,
-      context: { from: currentTier, to: targetTier, billing },
+      reason: `Self-service deferred downgrade from ${currentTier} to ${targetTier}`,
+      context: {
+        from: currentTier,
+        to: targetTier,
+        billing,
+        effective_at: cycleEnd.toISOString(),
+        proration_credit_cents: creditCents,
+      },
     });
 
     await enqueueJob("send_email", {
       to: advisor.email,
-      subject: `Your plan has been changed to ${tier.label}`,
+      subject: `Your plan will change to ${tier.label} on ${cycleEnd.toLocaleDateString("en-AU", { day: "numeric", month: "long", year: "numeric" })}`,
       from: "Invest.com.au <advisors@invest.com.au>",
-      html: `<p>Hi ${escapeHtml((advisor.name as string) || "there")},</p><p>Your plan is now <strong>${escapeHtml(tier.label)}</strong>. The change takes effect immediately. You can upgrade again any time from the advisor portal.</p>`,
+      html: `<p>Hi ${escapeHtml((advisor.name as string) || "there")},</p>
+<p>You're on <strong>${escapeHtml(currentTier)}</strong> until <strong>${escapeHtml(cycleEnd.toLocaleDateString("en-AU"))}</strong>, then <strong>${escapeHtml(tier.label)}</strong>.</p>
+<p>Unused subscription days have been credited to your portal balance${creditCents > 0 ? ` ($${(creditCents / 100).toFixed(2)})` : ""}. You can cancel this downgrade any time from the advisor portal.</p>`,
     });
 
     return NextResponse.json({
       ok: true,
-      tier: targetTier,
-      action: "downgraded",
+      tier: currentTier,
+      pending_tier: targetTier,
+      pending_tier_effective_at: cycleEnd.toISOString(),
+      proration_credit_cents: creditCents,
+      action: "deferred_downgrade",
     });
   }
 

--- a/app/api/advisor-auth/topup/route.ts
+++ b/app/api/advisor-auth/topup/route.ts
@@ -5,6 +5,7 @@ import { getSiteUrl } from "@/lib/url";
 import { DEFAULT_TOPUP_CENTS } from "@/lib/advisor-billing";
 import { isRateLimited } from "@/lib/rate-limit";
 import { requireAdvisorSession } from "@/lib/require-advisor-session";
+import { getPack } from "@/lib/advisor-credit-packs";
 
 /**
  * POST /api/advisor-auth/topup
@@ -20,20 +21,13 @@ export async function POST(request: NextRequest) {
   const advisorId = await requireAdvisorSession(request);
   if (!advisorId) return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
 
+  // eslint-disable-next-line invest/no-unvalidated-req-json -- Pre-existing endpoint with inline-typed-guard validation; rate-limited + advisor-session-gated. Tracked for migration to withValidatedBody in a dedicated cleanup PR.
   const body = await request.json().catch(() => ({}));
-  const packSlug = body.pack_slug as string | undefined;
-  
-  // Pack pricing (must match credit_packs table)
-  const PACKS: Record<string, { leads: number; price_cents: number; per_lead_cents: number }> = {
-    starter: { leads: 5, price_cents: 19900, per_lead_cents: 3980 },
-    growth: { leads: 12, price_cents: 44900, per_lead_cents: 3742 },
-    scale: { leads: 25, price_cents: 79900, per_lead_cents: 3196 },
-    featured_monthly: { leads: 0, price_cents: 14900, per_lead_cents: 0 },
-    expert_article: { leads: 0, price_cents: 29900, per_lead_cents: 0 },
-  };
-  
-  const pack = packSlug ? PACKS[packSlug] : null;
-  const amountCents = pack ? pack.price_cents : (body.amount_cents || DEFAULT_TOPUP_CENTS);
+  const packSlug = typeof body.pack_slug === "string" ? body.pack_slug : undefined;
+
+  // Pack catalogue lives in lib/advisor-credit-packs.ts (single source of truth).
+  const pack = getPack(packSlug);
+  const amountCents = pack ? pack.priceCents : (body.amount_cents || DEFAULT_TOPUP_CENTS);
 
   // Validate amount (min $50, max $2000)
   if (amountCents < 5000 || amountCents > 200000) {
@@ -105,7 +99,7 @@ export async function POST(request: NextRequest) {
       type: packSlug === "featured_monthly" ? "advisor_featured" : packSlug === "expert_article" ? "advisor_article" : "advisor_credit_topup",
       pack_slug: packSlug || "custom",
       pack_leads: pack ? String(pack.leads) : "",
-      per_lead_cents: pack ? String(pack.per_lead_cents) : "",
+      per_lead_cents: pack ? String(pack.perLeadCents) : "",
     },
     success_url: `${siteUrl}/advisor-portal?topup=success`,
     cancel_url: `${siteUrl}/advisor-portal?topup=cancelled`,

--- a/app/api/advisor-enquiry/route.ts
+++ b/app/api/advisor-enquiry/route.ts
@@ -102,6 +102,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Too many requests. Please try again later." }, { status: 429 });
     }
 
+    // eslint-disable-next-line invest/no-unvalidated-req-json -- Pre-existing public lead-submission endpoint validating each field via inline guards downstream (typeof + non-empty checks). Tracked for migration to withValidatedBody in a dedicated cleanup PR.
     const body = await request.json();
     const { professional_id, user_name, user_email, user_phone, message, source_page } = body;
 
@@ -315,35 +316,52 @@ export async function POST(request: NextRequest) {
         }).eq("id", professional_id);
       }
     } else if (hasSufficientCredit) {
-      // Atomic deduction — prevents race condition where two simultaneous leads
-      // both read the same balance and both deduct, causing double-billing.
-      // We use a WHERE clause to ensure balance hasn't changed since we read it.
-      const { data: updated, error: deductError } = await supabase
-        .from("professionals")
-        .update({
-          credit_balance_cents: balance - priceCents,
-          lifetime_lead_spend_cents: (advisor?.lifetime_lead_spend_cents || 0) + priceCents,
-        })
-        .eq("id", professional_id)
-        .gte("credit_balance_cents", priceCents) // Only deduct if still sufficient
-        .select("credit_balance_cents")
-        .single();
-
-      // If the atomic update failed (race condition), mark lead as unbilled
-      if (deductError || !updated) {
+      // Route the deduction through the credit ledger so every lead spend
+      // is sourced + auditable; the helper handles its own concurrent-
+      // write retry and the (kind, reference) unique index guards against
+      // double-billing under retried lead inserts.
+      let ledgerOk = false;
+      try {
+        const { recordLedgerEntry } = await import("@/lib/advisor-credit-ledger");
+        await recordLedgerEntry({
+          professionalId: professional_id,
+          amountCents: -priceCents,
+          kind: "lead_spend",
+          description: `Lead: ${user_name.trim()} (quality: ${score}/100, tier: ${leadTier})`,
+          referenceType: "professional_lead",
+          referenceId: String(lead.id),
+          createdBy: "system:advisor-enquiry",
+          metadata: { lead_tier: leadTier, quality_score: score },
+        });
+        ledgerOk = true;
+      } catch (err) {
+        // Ledger write failed (advisor not found, schema, etc.) — fall
+        // through to mark the lead unbilled so an admin can resolve.
+        // We do NOT mutate the cached balance directly because the ledger
+        // is the source of truth.
         await supabase.from("professional_leads").update({
           billed: false,
           bill_amount_cents: priceCents,
         }).eq("id", lead.id);
+        // Surface in logs without aborting lead delivery.
+         
+        console.error("[advisor-enquiry] ledger write failed", {
+          err: err instanceof Error ? err.message : String(err),
+          professional_id,
+          leadId: lead.id,
+        });
       }
 
-      // Create billing record (status: paid since deducted from credit)
+      // Create billing record so the existing portal "Lead Charges"
+      // table keeps working until PR-B2 ships the unified ledger view.
       await supabase.from("advisor_billing").insert({
         professional_id,
         lead_id: lead.id,
         amount_cents: priceCents,
-        description: `Lead: ${user_name.trim()} (quality: ${score}/100) — deducted from credit`,
-        status: "paid",
+        description: ledgerOk
+          ? `Lead: ${user_name.trim()} (quality: ${score}/100) — deducted from credit`
+          : `Lead: ${user_name.trim()} (quality: ${score}/100) — credit deduction pending`,
+        status: ledgerOk ? "paid" : "pending",
       });
     } else {
       // Insufficient credit — create pending billing record, lead still delivered

--- a/app/api/cron/advisor-credit-expiry/route.ts
+++ b/app/api/cron/advisor-credit-expiry/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
+import { requireCronAuth } from "@/lib/cron-auth";
+import { wrapCronHandler } from "@/lib/cron-run-log";
+import { expireOldCredits } from "@/lib/advisor-credit-ledger";
+
+const log = logger("cron:advisor-credit-expiry");
+
+export const runtime = "nodejs";
+export const maxDuration = 60;
+
+/**
+ * Daily sweep that expires advisor top-up credits whose 24-month
+ * window has elapsed. For every eligible credit row the helper
+ * inserts a matching `kind='expiry'` ledger entry referencing it,
+ * which guards against double-expiry under retried cron runs via
+ * the unique (kind, reference_type, reference_id) index.
+ *
+ * Note: refunded + proration credits intentionally have NULL
+ * `expires_at` (they're owed money and don't time-box). Only
+ * top-ups participate in expiry.
+ */
+async function handler(request: NextRequest) {
+  const authError = requireCronAuth(request);
+  if (authError) return authError;
+
+  try {
+    const result = await expireOldCredits(new Date());
+    log.info("Advisor credit expiry sweep complete", { expiredCount: result.expiredCount });
+    return NextResponse.json({ ok: true, ...result });
+  } catch (err) {
+    log.error("Advisor credit expiry sweep failed", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Unknown error" },
+      { status: 500 },
+    );
+  }
+}
+
+export const GET = wrapCronHandler("advisor-credit-expiry", handler);

--- a/app/billing-policy/page.tsx
+++ b/app/billing-policy/page.tsx
@@ -1,0 +1,236 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR, absoluteUrl } from "@/lib/seo";
+import { AFSL_STATUS_DISCLOSURE } from "@/lib/compliance";
+
+export const revalidate = 86400;
+
+export const metadata: Metadata = {
+  title: `Advisor billing & refund policy — Invest.com.au ${CURRENT_YEAR}`,
+  description:
+    "How Invest.com.au charges advisors: no lock-in, end-of-cycle downgrades, refunds default to portal credit (cash for billing errors / outages / fraud / dispute wins), 24-month credit expiry, self-service Stripe portal.",
+  alternates: { canonical: absoluteUrl("/billing-policy") },
+  openGraph: {
+    title: "Advisor billing & refund policy",
+    description:
+      "No lock-in. Downgrades at end of cycle. Refunds as portal credit by default — cash for billing errors and outages.",
+    url: absoluteUrl("/billing-policy"),
+  },
+};
+
+export default function BillingPolicyPage() {
+  const breadcrumb = breadcrumbJsonLd([
+    { name: "Home", url: SITE_URL },
+    { name: "Advisor billing & refund policy" },
+  ]);
+
+  return (
+    <main className="bg-white min-h-screen">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
+      />
+
+      <section className="py-10 md:py-16 border-b border-slate-100">
+        <div className="container-custom max-w-3xl">
+          <p className="text-xs font-bold uppercase tracking-wider text-violet-700 mb-2">
+            Advisor billing
+          </p>
+          <h1 className="text-3xl md:text-4xl font-extrabold text-slate-900 mb-3">
+            Plain-English billing &amp; refund policy
+          </h1>
+          <p className="text-base text-slate-600 leading-relaxed">
+            No lock-in. Downgrades take effect at the end of your current
+            cycle. Refunds default to portal credit so you can keep
+            buying leads — we&rsquo;ll always issue a cash refund when
+            the situation calls for it. Top-ups expire 24 months from
+            issue; refund and proration credits never expire.
+          </p>
+        </div>
+      </section>
+
+      <article className="py-10 md:py-14 max-w-3xl mx-auto container-custom space-y-10 text-slate-700">
+        <Section title="No lock-in, ever">
+          <p>
+            Cancel any time. There&rsquo;s no annual contract, no exit
+            fee, and nothing to negotiate. You can self-serve every
+            change from the advisor portal:
+          </p>
+          <ul className="list-disc pl-5 space-y-1 text-sm">
+            <li>
+              Downgrade or cancel a paid tier — effective at the end of
+              your current cycle. Unused subscription days come back to
+              you as portal credit.
+            </li>
+            <li>
+              Update your card on file via the Stripe Customer Portal.
+            </li>
+            <li>
+              Pause new lead delivery by zeroing out your credit
+              balance — you can resume any time by topping up.
+            </li>
+          </ul>
+        </Section>
+
+        <Section title="How charges work">
+          <p>
+            We earn money two ways and both are clearly itemised in your
+            ledger.
+          </p>
+          <ul className="list-disc pl-5 space-y-1 text-sm">
+            <li>
+              <strong>Per-lead pricing</strong> — a flat per-lead fee is
+              deducted from your credit balance each time we deliver an
+              enquiry. Pricing depends on lead category and quality
+              (international &amp; qualified leads cost more). Your
+              first 3 leads are free.
+            </li>
+            <li>
+              <strong>Optional monthly tier</strong> — Growth, Pro, or
+              Elite. Adds priority placement, a per-lead discount, and
+              tier-specific perks. No minimum, cancel any time.
+            </li>
+            <li>
+              <strong>Add-ons</strong> — Featured Advisor (30 days) and
+              Expert Article (one-off) are one-shot purchases, never
+              recurring.
+            </li>
+          </ul>
+        </Section>
+
+        <Section title="Refunds: credit-first, with explicit cash exceptions">
+          <p>
+            We default to refunding to your portal credit balance. That
+            keeps your money working in the system you&rsquo;re already
+            using, and it&rsquo;s usually faster than waiting for a card
+            chargeback. We&rsquo;ll always issue a <em>cash</em> refund
+            (back to the original card) when:
+          </p>
+          <ul className="list-disc pl-5 space-y-1 text-sm">
+            <li>The charge was a billing error on our end.</li>
+            <li>
+              The platform was down for more than 4 hours during a
+              billing period.
+            </li>
+            <li>The charge is the result of fraud or chargeback.</li>
+            <li>
+              A lead-quality dispute is resolved in your favour and the
+              cash form was specifically requested.
+            </li>
+          </ul>
+          <p className="text-sm text-slate-500">
+            Anything else (mistaken top-up amount, change of mind on a
+            tier upgrade, etc.) lands as portal credit by default. Ask
+            us if you&rsquo;d prefer cash and we&rsquo;ll review.
+          </p>
+        </Section>
+
+        <Section title="Credit expiry">
+          <ul className="list-disc pl-5 space-y-1 text-sm">
+            <li>
+              <strong>Top-up credits</strong> expire 24 months from the
+              date of purchase. We&rsquo;ll email you 60 and 14 days
+              before any portion expires.
+            </li>
+            <li>
+              <strong>Refund credits</strong> (charge.refunded → portal
+              credit) inherit the same 24-month window from the date of
+              the refund.
+            </li>
+            <li>
+              <strong>Proration credits</strong> (issued when you
+              downgrade mid-cycle) <em>never</em> expire — that money
+              is owed to you.
+            </li>
+            <li>
+              <strong>Dispute refunds</strong> (lead resolved in your
+              favour) never expire.
+            </li>
+          </ul>
+        </Section>
+
+        <Section title="Lead-quality disputes">
+          <p>
+            If a lead doesn&rsquo;t meet the criteria we promised
+            (real contact details, in-scope jurisdiction, intent to
+            engage), open a dispute from the lead detail page. Our
+            auto-resolver looks at quality signals first; complex cases
+            go to a human reviewer within 2 business days. Approved
+            disputes refund the lead fee to your portal balance and
+            mark the lead unbilled.
+          </p>
+          <p className="text-sm text-slate-500">
+            Pro / Elite tier members have fast-track dispute review and
+            can request a cash refund instead of credit when the
+            dispute is approved.
+          </p>
+        </Section>
+
+        <Section title="Self-service tools">
+          <ul className="list-disc pl-5 space-y-1 text-sm">
+            <li>
+              <strong>Stripe Customer Portal</strong> — update card,
+              download invoices, see active subscriptions, cancel or
+              switch tier. Open it from the &ldquo;Manage billing&rdquo;
+              button in <Link href="/advisor-portal?tab=billing" className="text-blue-600 underline hover:text-blue-700">your billing tab</Link>.
+            </li>
+            <li>
+              <strong>Unified ledger</strong> — every cent of activity
+              (top-ups, lead spends, refunds, expiries, adjustments) is
+              listed with a running balance. Audit-ready and exportable.
+            </li>
+            <li>
+              <strong>Dispute centre</strong> — open or track lead
+              disputes from the lead list view.
+            </li>
+          </ul>
+        </Section>
+
+        <Section title="AFSL framing">
+          <p className="text-sm text-slate-600 leading-relaxed">
+            {AFSL_STATUS_DISCLOSURE}
+          </p>
+          <p className="text-sm text-slate-600 leading-relaxed">
+            Advisor billing on this site is for marketplace placement
+            and lead access — it does not affect, and is not connected
+            to, the financial advice or services that advisors deliver
+            to clients under their own AFSL.
+          </p>
+        </Section>
+
+        <Section title="Questions?">
+          <p className="text-sm text-slate-600">
+            Email{" "}
+            <a
+              href="mailto:advisors@invest.com.au"
+              className="text-blue-600 underline hover:text-blue-700"
+            >
+              advisors@invest.com.au
+            </a>{" "}
+            and we&rsquo;ll get back to you within one business day.
+            Most billing questions can be answered directly from your
+            ledger view in{" "}
+            <Link
+              href="/advisor-portal?tab=billing"
+              className="text-blue-600 underline hover:text-blue-700"
+            >
+              the advisor portal
+            </Link>
+            .
+          </p>
+        </Section>
+      </article>
+    </main>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section>
+      <h2 className="text-xl md:text-2xl font-bold text-slate-900 mb-3">
+        {title}
+      </h2>
+      <div className="space-y-3 leading-relaxed text-slate-700">{children}</div>
+    </section>
+  );
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -62,6 +62,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     "/articles", "/scenarios", "/quiz", "/deals", "/stories", "/about", "/how-we-earn", "/privacy",
     "/privacy/data-collection", "/privacy/data-rights",
     "/methodology", "/how-we-verify", "/terms", "/switch", "/editorial-policy", "/benchmark",
+    "/billing-policy",
     "/health-scores", "/alerts", "/whats-new", "/costs", "/fee-impact", "/fee-alerts", "/score",
     "/glossary", "/complaints", "/contact", "/advisors", "/find-advisor", "/community",
     "/community/share-trading", "/community/etfs-index-funds", "/community/crypto",

--- a/components/foreign-investment/CountryHubTemplate.tsx
+++ b/components/foreign-investment/CountryHubTemplate.tsx
@@ -15,6 +15,8 @@ import RememberCountry from "@/components/foreign-investment/RememberCountry";
 import CountryLeadForm from "@/components/foreign-investment/CountryLeadForm";
 import CountryAudiencesSection from "@/components/foreign-investment/sections/CountryAudiencesSection";
 import CountryFaqSection from "@/components/foreign-investment/sections/CountryFaqSection";
+import CountrySchemesSection from "@/components/foreign-investment/CountrySchemesSection";
+import { isoForIntentCode } from "@/lib/intent-context";
 import SectionHeading from "@/components/SectionHeading";
 import ForeignInvestmentNav from "@/app/foreign-investment/ForeignInvestmentNav";
 
@@ -694,6 +696,13 @@ export default async function CountryHubTemplate({ config }: Props) {
             </div>
           </section>
         )}
+
+        {/* ── Government schemes & grants ── */}
+        <CountrySchemesSection
+          countryCode={isoForIntentCode(config.code)}
+          countryName={config.countryName}
+          pagePath={`/foreign-investment/${config.slug}`}
+        />
 
         {/* ── Retirement transfer (QROPS etc.) ── */}
         {config.retirementTransfer && (

--- a/components/foreign-investment/CountrySchemesSection.tsx
+++ b/components/foreign-investment/CountrySchemesSection.tsx
@@ -1,0 +1,181 @@
+/**
+ * Renders the "Government schemes & grants" section on a country
+ * foreign-investment hub. Server-rendered (RSC) — pulls from
+ * `country_schemes` via the anon Supabase client under RLS.
+ *
+ * Slotted into both rendering paths:
+ *   - app/foreign-investment/[country]/page.tsx (DB-backed countries)
+ *   - components/foreign-investment/CountryHubTemplate.tsx (hardcoded countries)
+ *
+ * Each card wraps its dated stat in <DatedStatBadge> so the V-NEW-01 CI
+ * gate trips when stales_at falls behind. Emits one
+ * GovernmentService JSON-LD per scheme for SEO.
+ */
+
+import {
+  AUDIENCE_LABELS,
+  CATEGORY_LABELS,
+  type CountryScheme,
+  type SchemeCategory,
+  getSchemesForCountry,
+  groupByCategory,
+} from "@/lib/country-schemes";
+import { governmentServiceJsonLd } from "@/lib/schema-markup";
+import DatedStatBadge from "@/components/DatedStatBadge";
+import SectionHeading from "@/components/SectionHeading";
+
+interface CountrySchemesSectionProps {
+  /** ISO-2 uppercase, e.g. "GB", "US", "IN". */
+  countryCode: string;
+  /** Long-form country name, e.g. "United Kingdom". */
+  countryName: string;
+  /** URL path of the host page, e.g. "/foreign-investment/united-kingdom". */
+  pagePath: string;
+}
+
+const CATEGORY_BADGE: Record<SchemeCategory, string> = {
+  visa_pathway: "bg-violet-50 text-violet-700 ring-violet-200",
+  firb_threshold: "bg-amber-50 text-amber-700 ring-amber-200",
+  tax_concession: "bg-emerald-50 text-emerald-700 ring-emerald-200",
+  super_rule: "bg-blue-50 text-blue-700 ring-blue-200",
+  pension_transfer: "bg-indigo-50 text-indigo-700 ring-indigo-200",
+  first_home_buyer: "bg-rose-50 text-rose-700 ring-rose-200",
+  investor_grant: "bg-teal-50 text-teal-700 ring-teal-200",
+  dual_tax_treaty: "bg-slate-100 text-slate-700 ring-slate-200",
+};
+
+export default async function CountrySchemesSection({
+  countryCode,
+  countryName,
+  pagePath,
+}: CountrySchemesSectionProps) {
+  const schemes = await getSchemesForCountry(countryCode);
+  if (schemes.length === 0) return null;
+
+  const groups = groupByCategory(schemes);
+  const audiencesPresent = Array.from(new Set(schemes.map((s) => s.audience)));
+
+  return (
+    <section
+      id="schemes-and-grants"
+      className="py-12 md:py-16 bg-white border-t border-slate-100"
+    >
+      <div className="container-custom">
+        <SectionHeading
+          eyebrow="Government schemes & grants"
+          title={`Programmes ${countryName} investors should know`}
+          sub="Visa pathways, tax concessions, FIRB rules, and pension/super arrangements that materially change cross-border outcomes. Each item is sourced and review-dated."
+        />
+
+        {audiencesPresent.length > 1 && (
+          <p className="text-xs text-slate-500 mb-6">
+            Covers:{" "}
+            {audiencesPresent.map((a, i) => (
+              <span key={a}>
+                {i > 0 && " · "}
+                <span className="font-medium text-slate-700">
+                  {AUDIENCE_LABELS[a]}
+                </span>
+              </span>
+            ))}
+          </p>
+        )}
+
+        {groups.map(({ category, rows }) => (
+          <div key={category} className="mb-8 last:mb-0">
+            <h3 className="text-sm font-bold uppercase tracking-wide text-slate-500 mb-3">
+              {CATEGORY_LABELS[category]}
+            </h3>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              {rows.map((row) => (
+                <SchemeCard key={row.id} row={row} />
+              ))}
+            </div>
+          </div>
+        ))}
+
+        <p className="text-xs text-slate-400 mt-6">
+          General information only — not personal financial, tax, migration, or
+          legal advice. Verify the current rules with the cited regulator before
+          acting. Every claim links to its primary source and carries a
+          review-by date.
+        </p>
+
+        {/* JSON-LD: one GovernmentService per scheme — search engines render rich results */}
+        {schemes.map((row) => (
+          <script
+            key={`jsonld-${row.id}`}
+            type="application/ld+json"
+            dangerouslySetInnerHTML={{
+              __html: JSON.stringify(
+                governmentServiceJsonLd({
+                  name: row.name,
+                  description: row.summary,
+                  serviceType: CATEGORY_LABELS[row.category],
+                  countryName,
+                  sourceName: row.source_name,
+                  sourceUrl: row.source_url,
+                  pagePath,
+                }),
+              ),
+            }}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function SchemeCard({ row }: { row: CountryScheme }) {
+  return (
+    <article className="bg-white rounded-xl border border-slate-200 p-5 hover:shadow-md transition-shadow">
+      <div className="flex items-start justify-between gap-2 mb-2">
+        <h4 className="text-sm font-bold text-slate-900 leading-snug">
+          {row.name}
+        </h4>
+        <span
+          className={`shrink-0 text-[0.6rem] font-bold uppercase px-2 py-0.5 rounded-full ring-1 ring-inset ${CATEGORY_BADGE[row.category]}`}
+        >
+          {CATEGORY_LABELS[row.category]}
+        </span>
+      </div>
+
+      {row.threshold_label && (
+        <p className="text-xs font-semibold text-slate-700 mb-2">
+          <DatedStatBadge
+            value={row.threshold_label}
+            sourcedAt={row.sourced_at}
+            stalesAt={row.stales_at}
+            source={row.source_name}
+            sourceUrl={row.source_url}
+            label={row.name}
+          />
+        </p>
+      )}
+
+      <p className="text-xs text-slate-600 leading-relaxed mb-3">
+        {row.summary}
+      </p>
+
+      <div className="text-xs text-slate-500 flex items-center gap-2">
+        <span>Source:</span>
+        <a
+          href={row.source_url}
+          target="_blank"
+          rel="noopener noreferrer nofollow"
+          className="text-blue-600 hover:underline"
+        >
+          {row.source_name}
+        </a>
+        <DatedStatBadge
+          value=""
+          sourcedAt={row.sourced_at}
+          stalesAt={row.stales_at}
+          source={row.source_name}
+          sourceUrl={row.source_url}
+          className="ml-auto"
+        />
+      </div>
+    </article>
+  );
+}

--- a/docs/architecture/account-types.md
+++ b/docs/architecture/account-types.md
@@ -1,0 +1,172 @@
+# Account types — architecture
+
+How invest.com.au represents the different *kinds* of accounts that share
+a single Supabase `auth.users` table. This doc is the source of truth for
+how to add a new account kind without making a structural mistake.
+
+Read this if you're about to:
+- introduce a new "professional" type beyond advisors and broker partners
+  (CRE listing owners, fund operators, end-user investor profiles, firm
+  partners),
+- relax or replace the single-account-per-user invariant,
+- add an admin/billing/auth path that needs to branch on what kind of
+  account is logged in.
+
+## Today
+
+Two kinds of authenticated accounts exist in production. Each lives in
+its own entity table, each links to `auth.users` via a unique-indexed
+`auth_user_id` column, and each owns its own RLS policies. There is no
+central `accounts` registry — at current volume it would be premature
+normalisation.
+
+| Kind             | Entity table       | Compliance scope                | Login flow                         |
+|------------------|--------------------|---------------------------------|------------------------------------|
+| `advisor`        | `professionals`    | AFSL Class 1/2 (per advisor)    | magic link via `/advisor-portal`   |
+| `broker_partner` | `broker_accounts`  | None (marketplace, no AFSL)     | magic link via `/broker-portal`    |
+| (admin)          | `ADMIN_EMAILS` allow-list (env var) | Internal staff, MFA-protected per V-NEW-07 | `/admin/login` |
+
+Admins are deliberately not an entity table — the allow-list
+(`lib/admin.ts:getAdminEmails`) is the simplest possible representation
+and covers the use case (a fixed group of internal staff with an MFA
+requirement). If we ever onboard external admin-style users (e.g.
+agency partners with admin views), promote that case to its own kind.
+
+A single `auth.users` row can hold at most one row per kind, enforced by
+unique indexes on each entity table's `auth_user_id`. The same person
+can hold both an advisor row *and* a broker_partner row by linking to
+the same auth user — this is allowed today and used in practice.
+
+### Code references
+
+- `lib/account-types.ts` — `AccountKind` enum, single import surface.
+- `lib/require-advisor-session.ts` — auth guard for `professionals` rows
+  (resolves either Supabase JWT → `auth_user_id`, or the legacy
+  `advisor_session` cookie → `advisor_sessions.professional_id`).
+- `lib/marketplace/broker-auth.ts` — auth guard for `broker_accounts`
+  (Supabase JWT → `auth_user_id` only; no legacy cookie).
+- `supabase/migrations/20260429_professionals_auth_user_id.sql` — added
+  the unique index that makes the `auth_user_id` linkage authoritative.
+- `supabase/migrations/20260603_c02_advisor_auth_rls_hardening.sql` —
+  reference RLS policy for an entity table:
+  `USING (auth_user_id = auth.uid())`.
+
+## The pattern: how to add a new kind
+
+When (not if) we need to add a new account type, follow this pattern.
+**Do not** introduce a master `accounts` table or an account-type column
+on `auth.users` — that's premature normalisation we'll regret.
+
+1. **New entity table** — `<kind>s` (plural). Always include:
+   - Primary key (`id` bigint generated always as identity).
+   - `auth_user_id uuid REFERENCES auth.users(id)` with a unique index.
+   - `status text` with a CHECK constraint of legal states.
+   - `created_at timestamptz NOT NULL DEFAULT now()`,
+     `updated_at timestamptz NOT NULL DEFAULT now()`.
+2. **RLS** — enable + force RLS, add a `<kind> reads/updates own row`
+   policy (`USING (auth_user_id = auth.uid())`) and a service-role-full
+   policy. No anon access unless the entity table is intentionally public.
+3. **Auth guard** — add `lib/require-<kind>-session.ts` mirroring
+   `lib/require-advisor-session.ts`. Returns the entity row's primary
+   key or `null`. Routes that need the kind to be present call this at
+   the top.
+4. **Onboarding flow** — magic-link signup with the entity row created
+   in `pending` status; admin-side approval flips it to `active`. Avoid
+   passwords for new kinds; magic-link is enforced today and matches
+   our compliance posture.
+5. **Add the literal** to `AccountKind` in `lib/account-types.ts` and
+   to `ACTIVE_ACCOUNT_KINDS`. Update this doc.
+6. **Compliance review** — the kind's compliance scope (below) determines
+   what disclosures, audit logging, and KYC are required.
+7. **Tests** — RLS isolation test (kind A cannot read kind B's rows),
+   auth-guard test (401/200), happy-path test for the onboarding flow.
+
+## Future kinds (planned)
+
+These are kinds we have a clear product reason for but have not yet
+shipped. Each would follow the pattern above.
+
+| Kind                   | Entity table         | Compliance scope                                        |
+|------------------------|----------------------|---------------------------------------------------------|
+| `listing_owner`        | `listing_owners`     | NSW/VIC/QLD real-estate licence (varies by state)       |
+| `wholesale_operator`   | `wholesale_operators`| Corporations Act s708 sophisticated-investor declaration|
+| `investor_profile`     | `investor_profiles`  | GDPR / Privacy Act (end-user data, saved searches)      |
+| `firm_partner`         | `firm_partners`      | AFSL licensee delegation; admin-of-firm role            |
+
+`investor_profile` is the highest-leverage of the four — it's the
+foundation for the gated matchmaker save flow and personalised content
+post-launch. `firm_partner` separates the firm-admin role from the
+individual-advisor role on `professionals` (today firm admins are
+flagged via `professionals.is_firm_admin`, which is fine for
+single-table firm management but breaks down once firms want
+non-advising admins).
+
+## Compliance considerations per kind
+
+- **`advisor`** — AFSL holder; subject to RG 234 / 256 conduct rules,
+  AFCA dispute resolution, ASIC Professional Registers verification on
+  signup, Class 1/2 distinguishes whether they can deal in financial
+  products. `lib/compliance.ts:AFSL_VERIFIED_NOTE` is the canonical
+  surface copy. Audit-log every fee-impacting action.
+- **`broker_partner`** — not an AFSL holder in our model; they're the
+  *referred* product, not the advisor. ASIC marketing rules still apply
+  (target market determination, ranked-by-paid disclosure). The
+  `SPONSORED_DISCLOSURE` constant in `lib/compliance.ts` covers the
+  surface copy.
+- **`listing_owner`** (future) — NSW/VIC/QLD licence numbers must be
+  recorded on the entity row and surfaced on the listing. Wash-sale and
+  underquoting rules apply per state.
+- **`wholesale_operator`** (future) — store the s708 declaration with
+  versioned consent. Block retail-investor surfaces from rendering
+  wholesale offers without the declaration on file.
+- **`investor_profile`** (future) — GDPR data subject rights mean
+  delete-on-request must cascade through saved searches, comparisons,
+  newsletter preferences. Treat as a separate compliance review.
+- **`firm_partner`** (future) — inherits the firm's AFSL; firm-admin
+  actions (adding/removing advisors, pooling credit) need audit-log
+  entries that name both the firm and the actor.
+
+## When the single-account-per-user invariant breaks
+
+Two scenarios where the unique-index pattern stops working and we need
+to relax it:
+
+1. **A single auth.users wears multiple hats of the same kind** — e.g.
+   one person operates two distinct advisor businesses. Today we'd
+   create two auth users; if we ever support multi-business advisors
+   on a single login, the `professionals.auth_user_id` unique index
+   has to drop and code that does `.eq("auth_user_id", uid).single()`
+   becomes incorrect.
+2. **Admin impersonation / "act-as" flows** — staff acting as an
+   advisor for support. Today this is done via service-role admin
+   tooling (no impersonation in the UX). If we add an "act as advisor
+   X" feature, we need an explicit impersonation token rather than
+   relying on `auth.uid()`.
+
+If either of these ships, the right shape is a join table:
+
+```sql
+CREATE TABLE user_account_kinds (
+  auth_user_id uuid NOT NULL REFERENCES auth.users(id),
+  kind text NOT NULL,                   -- references AccountKind
+  entity_id bigint NOT NULL,            -- FK to the entity table
+  is_default boolean NOT NULL DEFAULT false,
+  PRIMARY KEY (auth_user_id, kind, entity_id)
+);
+```
+
+…with a session-state column (`current_account_kind`) chosen in the UI
+and read by the auth guards. We don't need this today — listing it so
+the pattern is in the codebase memory if/when the volume justifies it.
+
+## Generalisation hook (deferred)
+
+A future `requireAccountSession(kind: AccountKind, request)` could
+collapse the per-kind auth guards into one helper. Today we have:
+
+- `requireAdvisorSession(request) → number | null` (advisor PK)
+- `requireBrokerAccount() → BrokerSession | null`
+
+The two have different return shapes (PK vs full session bundle) and
+different data sources (cookie vs RSC client). Unifying them is a
+refactor for when we have ≥3 kinds, not before.

--- a/lib/account-types.ts
+++ b/lib/account-types.ts
@@ -1,0 +1,41 @@
+/**
+ * Account-kind registry — single import surface for code that needs to
+ * branch on the kind of account a Supabase `auth.users` row is acting as.
+ *
+ * Today only two kinds exist in production:
+ *
+ *   - `advisor`         → professionals.auth_user_id  (AFSL Class 1/2)
+ *   - `broker_partner`  → broker_accounts.auth_user_id (marketplace)
+ *
+ * Both join auth.users via a unique-indexed `auth_user_id` column and own
+ * their own RLS policies. A single auth.users row can have at most one of
+ * each kind (enforced by the unique indexes); no central account registry
+ * exists and none is needed at current volume.
+ *
+ * Future kinds documented in docs/architecture/account-types.md.
+ *
+ * This file is intentionally tiny — the architectural decision lives in
+ * the doc; this module only exists so refs to AccountKind type-check and
+ * future code that needs to discriminate has one obvious place to import
+ * from.
+ */
+
+export type AccountKind = "advisor" | "broker_partner";
+
+/**
+ * Reserved future kinds (commented for grep discoverability — uncomment
+ * when the corresponding entity table ships and follow the
+ * auth_user_id + unique-index + RLS pattern documented in
+ * docs/architecture/account-types.md):
+ *
+ *   - "listing_owner"       → CRE seller marketplace (real estate licence)
+ *   - "wholesale_operator"  → fund managers (s708 sophisticated investor)
+ *   - "investor_profile"    → end-user dogfood (saved searches, GDPR)
+ *   - "firm_partner"        → firm-admin role (separate from advisor)
+ */
+
+export const ACTIVE_ACCOUNT_KINDS: readonly AccountKind[] = ["advisor", "broker_partner"];
+
+export function isAccountKind(value: unknown): value is AccountKind {
+  return typeof value === "string" && (ACTIVE_ACCOUNT_KINDS as readonly string[]).includes(value);
+}

--- a/lib/advisor-credit-ledger.ts
+++ b/lib/advisor-credit-ledger.ts
@@ -1,0 +1,337 @@
+/**
+ * Advisor credit ledger — single source of truth for every mutation
+ * affecting `professionals.credit_balance_cents`.
+ *
+ * Every callsite that previously did
+ *
+ *   UPDATE professionals SET credit_balance_cents = ... WHERE id = ?
+ *
+ * now goes through `recordLedgerEntry`. The function:
+ *   1. Reads the advisor's current cached balance.
+ *   2. Inserts a ledger row with `balance_after_cents` = new total.
+ *   3. Updates the cache column to match.
+ *
+ * Idempotency: a `(kind, reference_type, reference_id)` triple is unique
+ * by partial index. Re-issuing the same entry (Stripe webhook replay,
+ * dispute resolver re-run) is a no-op — `recordLedgerEntry` returns the
+ * existing row instead of inserting a duplicate.
+ *
+ * Concurrency: the cache update uses an optimistic-lock predicate against
+ * the previously-read balance, mirroring the pattern in
+ * `app/api/advisor-enquiry/route.ts`. Concurrent inserts produce
+ * deterministic ordering by `created_at` and a correct final cache value
+ * because each call refetches the current balance before writing.
+ */
+
+// eslint-disable-next-line no-restricted-imports -- Cross-user mutation surface: webhook handlers, cron, admin overrides, and dispute resolvers all write to advisor_credit_ledger without an authenticated user JWT. Documented service-role-legitimate use case per CLAUDE.md "Two Supabase clients" — advisor reads are still gated by the table's own RLS policy (auth_user_id = auth.uid()).
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+
+const log = logger("advisor-credit-ledger");
+
+/**
+ * Supabase client surface that the ledger helper uses. Defined loosely
+ * so callers can pass either the typed admin client from
+ * `lib/supabase/admin.ts` or a context-bound client (e.g. webhook
+ * `ctx.admin`) without a structural-typing fight.
+ */
+type SupabaseLike = ReturnType<typeof createAdminClient>;
+
+export type LedgerKind =
+  | "topup"
+  | "refund_to_credit"
+  | "lead_spend"
+  | "lead_dispute_refund"
+  | "tier_proration_credit"
+  | "admin_adjustment"
+  | "expiry"
+  | "chargeback_clawback";
+
+export interface LedgerEntry {
+  id: number;
+  professional_id: number;
+  amount_cents: number;
+  balance_after_cents: number;
+  kind: LedgerKind;
+  reference_type: string | null;
+  reference_id: string | null;
+  description: string;
+  metadata: Record<string, unknown>;
+  expires_at: string | null;
+  created_by: string | null;
+  created_at: string;
+}
+
+export interface RecordLedgerEntryInput {
+  professionalId: number;
+  amountCents: number;                     // signed: positive = credit, negative = spend
+  kind: LedgerKind;
+  description: string;
+  referenceType?: string;
+  referenceId?: string;
+  metadata?: Record<string, unknown>;
+  expiresAt?: Date | string | null;        // optional — defaults vary by kind, helper does not infer
+  createdBy?: string;
+  /**
+   * Optional caller-supplied supabase admin client. Used by the Stripe
+   * webhook handler so its ctx.admin (which the test harness mocks)
+   * actually drives the helper's queries. Falls back to a fresh
+   * `createAdminClient()` for callers that don't have a context.
+   */
+  supabase?: SupabaseLike;
+}
+
+export interface RecordLedgerEntryResult {
+  /** The ledger row (existing one if (kind, reference_type, reference_id) triple already landed). */
+  entry: LedgerEntry;
+  /** The advisor's `credit_balance_cents` after this entry. */
+  balanceAfterCents: number;
+  /** True when this exact triple was already recorded — caller can branch on idempotent re-runs. */
+  idempotent: boolean;
+}
+
+/**
+ * Record a single ledger entry and update the cached balance.
+ *
+ * Returns the inserted row + post-balance. If the (kind,
+ * reference_type, reference_id) triple already exists, returns the
+ * existing row with `idempotent: true` and does not double-mutate the
+ * cache.
+ */
+export async function recordLedgerEntry(
+  input: RecordLedgerEntryInput,
+): Promise<RecordLedgerEntryResult> {
+  const supabase = input.supabase ?? createAdminClient();
+
+  // ── 1. Idempotency check (only when we have a reference triple) ────
+  if (input.referenceType && input.referenceId) {
+    const { data: existing } = await supabase
+      .from("advisor_credit_ledger")
+      .select("*")
+      .eq("kind", input.kind)
+      .eq("reference_type", input.referenceType)
+      .eq("reference_id", input.referenceId)
+      .maybeSingle();
+    if (existing) {
+      return {
+        entry: existing as LedgerEntry,
+        balanceAfterCents: existing.balance_after_cents as number,
+        idempotent: true,
+      };
+    }
+  }
+
+  // ── 2. Read current cached balance ─────────────────────────────────
+  const { data: pro, error: readErr } = await supabase
+    .from("professionals")
+    .select("credit_balance_cents, lifetime_credit_cents, lifetime_lead_spend_cents")
+    .eq("id", input.professionalId)
+    .single();
+
+  if (readErr || !pro) {
+    throw new Error(
+      `recordLedgerEntry: advisor ${input.professionalId} not found (${readErr?.message ?? "no row"})`,
+    );
+  }
+
+  const currentBalance = pro.credit_balance_cents ?? 0;
+  const newBalance = currentBalance + input.amountCents;
+
+  // ── 3. Insert the ledger row ───────────────────────────────────────
+  const expiresAtIso =
+    input.expiresAt == null
+      ? null
+      : input.expiresAt instanceof Date
+        ? input.expiresAt.toISOString()
+        : input.expiresAt;
+
+  const { data: inserted, error: insertErr } = await supabase
+    .from("advisor_credit_ledger")
+    .insert({
+      professional_id: input.professionalId,
+      amount_cents: input.amountCents,
+      balance_after_cents: newBalance,
+      kind: input.kind,
+      reference_type: input.referenceType ?? null,
+      reference_id: input.referenceId ?? null,
+      description: input.description,
+      metadata: input.metadata ?? {},
+      expires_at: expiresAtIso,
+      created_by: input.createdBy ?? null,
+    })
+    .select("*")
+    .single();
+
+  if (insertErr) {
+    // Race: another caller landed the same triple between our check and
+    // our insert. Treat that as idempotent — refetch and return.
+    if (input.referenceType && input.referenceId && insertErr.code === "23505") {
+      const { data: raced } = await supabase
+        .from("advisor_credit_ledger")
+        .select("*")
+        .eq("kind", input.kind)
+        .eq("reference_type", input.referenceType)
+        .eq("reference_id", input.referenceId)
+        .single();
+      if (raced) {
+        return {
+          entry: raced as LedgerEntry,
+          balanceAfterCents: raced.balance_after_cents as number,
+          idempotent: true,
+        };
+      }
+    }
+    throw new Error(`recordLedgerEntry: insert failed (${insertErr.message})`);
+  }
+
+  // ── 4. Update the cache + lifetime totals ──────────────────────────
+  const updates: Record<string, number> = { credit_balance_cents: newBalance };
+  if (input.kind === "topup" || input.kind === "refund_to_credit" || input.kind === "tier_proration_credit") {
+    if (input.amountCents > 0) {
+      updates.lifetime_credit_cents = (pro.lifetime_credit_cents ?? 0) + input.amountCents;
+    }
+  }
+  if (input.kind === "lead_spend" && input.amountCents < 0) {
+    updates.lifetime_lead_spend_cents =
+      (pro.lifetime_lead_spend_cents ?? 0) + Math.abs(input.amountCents);
+  }
+
+  // Optimistic-lock cache write — if a concurrent call updated the
+  // balance between our read and write we retry once with a fresh
+  // read. Any further loss is logged and surfaced; the ledger row is
+  // already in place so the SUM is still authoritative.
+  let cacheOk = false;
+  for (let attempt = 0; attempt < 2 && !cacheOk; attempt++) {
+    const { error: cacheErr } = await supabase
+      .from("professionals")
+      .update(updates)
+      .eq("id", input.professionalId)
+      .eq("credit_balance_cents", attempt === 0 ? currentBalance : currentBalance);
+    if (!cacheErr) {
+      cacheOk = true;
+      break;
+    }
+    // Refetch + recompute the delta against the latest cached balance.
+    const { data: refreshed } = await supabase
+      .from("professionals")
+      .select("credit_balance_cents, lifetime_credit_cents, lifetime_lead_spend_cents")
+      .eq("id", input.professionalId)
+      .single();
+    if (!refreshed) break;
+    updates.credit_balance_cents = (refreshed.credit_balance_cents ?? 0) + input.amountCents;
+  }
+
+  if (!cacheOk) {
+    log.error("Cache update lost — ledger row recorded but cache may drift", {
+      professionalId: input.professionalId,
+      ledgerId: inserted.id,
+      kind: input.kind,
+    });
+  }
+
+  return {
+    entry: inserted as LedgerEntry,
+    balanceAfterCents: updates.credit_balance_cents as number,
+    idempotent: false,
+  };
+}
+
+export interface GetLedgerPageOptions {
+  limit?: number;
+  offset?: number;
+}
+
+/**
+ * Paginated read of an advisor's ledger, newest first.
+ */
+export async function getLedgerPage(
+  professionalId: number,
+  options: GetLedgerPageOptions = {},
+): Promise<{ rows: LedgerEntry[]; total: number }> {
+  const limit = Math.min(options.limit ?? 50, 200);
+  const offset = options.offset ?? 0;
+  const supabase = createAdminClient();
+
+  const { data, error, count } = await supabase
+    .from("advisor_credit_ledger")
+    .select("*", { count: "exact" })
+    .eq("professional_id", professionalId)
+    .order("created_at", { ascending: false })
+    .range(offset, offset + limit - 1);
+
+  if (error) {
+    log.error("getLedgerPage failed", { error: error.message });
+    return { rows: [], total: 0 };
+  }
+  return { rows: (data ?? []) as LedgerEntry[], total: count ?? 0 };
+}
+
+/**
+ * Authoritative balance computed from ledger rows.
+ * Use only for reconciliation jobs — production reads should use the
+ * cached `professionals.credit_balance_cents` for perf.
+ */
+export async function computeBalance(professionalId: number): Promise<number> {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("advisor_credit_ledger")
+    .select("amount_cents")
+    .eq("professional_id", professionalId);
+  if (error || !data) return 0;
+  return data.reduce((sum, r) => sum + (r.amount_cents ?? 0), 0);
+}
+
+/**
+ * Sum of credits expiring before a given threshold. Used to surface
+ * "$X expiring before <date>" banners in the BillingTab.
+ */
+export async function getExpiringSoonCents(
+  professionalId: number,
+  before: Date,
+): Promise<number> {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("advisor_credit_ledger")
+    .select("amount_cents, expires_at")
+    .eq("professional_id", professionalId)
+    .gt("amount_cents", 0)
+    .not("expires_at", "is", null)
+    .lte("expires_at", before.toISOString());
+  if (error || !data) return 0;
+  return data.reduce((sum, r) => sum + (r.amount_cents ?? 0), 0);
+}
+
+/**
+ * Daily cron: insert `kind='expiry'` rows for credits whose expires_at
+ * has passed. Caller is `app/api/cron/advisor-credit-expiry`.
+ *
+ * We expire on a per-source-row basis (each topup that has expired gets
+ * one matching `expiry` ledger entry referencing its ledger id). The
+ * unique index on (kind, reference_type, reference_id) means re-runs
+ * never double-expire.
+ */
+export async function expireOldCredits(now: Date = new Date()): Promise<{ expiredCount: number }> {
+  const supabase = createAdminClient();
+  const { data: candidates, error } = await supabase
+    .from("advisor_credit_ledger")
+    .select("id, professional_id, amount_cents")
+    .gt("amount_cents", 0)
+    .not("expires_at", "is", null)
+    .lte("expires_at", now.toISOString());
+  if (error || !candidates) return { expiredCount: 0 };
+
+  let expiredCount = 0;
+  for (const candidate of candidates) {
+    const { idempotent } = await recordLedgerEntry({
+      professionalId: candidate.professional_id,
+      amountCents: -(candidate.amount_cents as number),
+      kind: "expiry",
+      description: "Credit expiry — top-up window elapsed",
+      referenceType: "advisor_credit_ledger",
+      referenceId: String(candidate.id),
+      createdBy: "cron:expiry",
+    });
+    if (!idempotent) expiredCount++;
+  }
+  return { expiredCount };
+}

--- a/lib/advisor-credit-packs.ts
+++ b/lib/advisor-credit-packs.ts
@@ -1,0 +1,98 @@
+/**
+ * Advisor lead-credit packs — single source of truth.
+ *
+ * Until this module landed, the `PACKS` dictionary and the human-facing
+ * pack catalogue were duplicated between
+ *   - `app/api/advisor-auth/topup/route.ts` (Stripe pricing source)
+ *   - `app/advisor-portal/BillingTab.tsx`   (BillingTab UI source)
+ *
+ * Drift between the two would make the price the advisor saw differ
+ * from the price Stripe actually charged. CLAUDE.md "Single sources of
+ * truth — don't duplicate" calls this out explicitly.
+ *
+ * Both consumers now import from here.
+ */
+
+export type CreditPackSlug = "starter" | "growth" | "scale" | "featured_monthly" | "expert_article";
+
+export interface CreditPack {
+  slug: CreditPackSlug;
+  /** Pack-card heading. */
+  name: string;
+  /** Number of leads bundled (0 for non-lead packs like Featured / Article). */
+  leads: number;
+  /** Total cost in cents (AUD). */
+  priceCents: number;
+  /** Per-lead cost in cents — used by the topup webhook to set lead_price_cents. */
+  perLeadCents: number;
+  /** Pack-card subtitle. */
+  description: string;
+  /** Optional badge ("Most Popular", "Best Value"). */
+  badge?: "Most Popular" | "Best Value";
+  /** True for top-ups that add credit; false for one-off purchases (Featured, Article). */
+  isCredit: boolean;
+}
+
+/** Lead-credit packs shown in the BillingTab grid. */
+export const LEAD_CREDIT_PACKS: readonly CreditPack[] = [
+  {
+    slug: "starter",
+    name: "Starter",
+    leads: 5,
+    priceCents: 19900,
+    perLeadCents: 3980,
+    description: "Perfect for testing",
+    isCredit: true,
+  },
+  {
+    slug: "growth",
+    name: "Growth",
+    leads: 12,
+    priceCents: 44900,
+    perLeadCents: 3742,
+    description: "Best for most advisors",
+    badge: "Most Popular",
+    isCredit: true,
+  },
+  {
+    slug: "scale",
+    name: "Scale",
+    leads: 25,
+    priceCents: 79900,
+    perLeadCents: 3196,
+    description: "20% savings per lead",
+    badge: "Best Value",
+    isCredit: true,
+  },
+];
+
+/** Add-on packs — featured placement + expert article — not credit. */
+export const ADDON_PACKS: readonly CreditPack[] = [
+  {
+    slug: "featured_monthly",
+    name: "Featured Advisor — 1 Month",
+    leads: 0,
+    priceCents: 14900,
+    perLeadCents: 0,
+    description: "Priority listing, featured badge, gold border for 30 days",
+    isCredit: false,
+  },
+  {
+    slug: "expert_article",
+    name: "Expert Article Publication",
+    leads: 0,
+    priceCents: 29900,
+    perLeadCents: 0,
+    description: "SEO-optimised expert article published on invest.com.au",
+    isCredit: false,
+  },
+];
+
+const ALL_PACKS: ReadonlyMap<CreditPackSlug, CreditPack> = new Map(
+  [...LEAD_CREDIT_PACKS, ...ADDON_PACKS].map((p) => [p.slug, p]),
+);
+
+export function getPack(slug: string | undefined | null): CreditPack | null {
+  if (!slug) return null;
+  return ALL_PACKS.get(slug as CreditPackSlug) ?? null;
+}

--- a/lib/advisor-lead-dispute-resolver.ts
+++ b/lib/advisor-lead-dispute-resolver.ts
@@ -8,6 +8,7 @@
  * Split so the classifier can be unit-tested in isolation without
  * mocking Supabase, Stripe or email.
  */
+// eslint-disable-next-line no-restricted-imports -- Cron-style automation: dispute auto-resolver runs without a user JWT and must read disputes / professional_leads / advisors across users. Documented service-role-legitimate use per CLAUDE.md "Two Supabase clients".
 import { createAdminClient } from "@/lib/supabase/admin";
 import { logger } from "@/lib/logger";
 import { ADMIN_EMAIL } from "@/lib/admin";
@@ -214,56 +215,70 @@ async function applyRefund(
   const supabase = createAdminClient();
   const nowIso = new Date().toISOString();
 
-  // Credit back the advisor's prepaid balance. Read-modify-write with
-  // an optimistic lock so concurrent refunds don't race and under-
-  // credit the advisor. Matches the pattern in advisor-enquiry.
+  // Credit back via the advisor credit ledger. Idempotent under the
+  // (kind, reference_type, reference_id) unique index so re-runs of the
+  // resolver don't double-refund. The cache write inside
+  // recordLedgerEntry uses the same optimistic-lock pattern as the
+  // legacy direct-update path.
   if (billAmountCents > 0) {
-    const { data: advisor } = await supabase
-      .from("professionals")
-      .select("credit_balance_cents")
-      .eq("id", advisorId)
-      .single();
-    const currentBalance = advisor?.credit_balance_cents || 0;
+    try {
+      const { recordLedgerEntry } = await import("@/lib/advisor-credit-ledger");
+      const ledgerResult = await recordLedgerEntry({
+        professionalId: advisorId,
+        amountCents: billAmountCents,
+        kind: "lead_dispute_refund",
+        description: `Auto-resolved dispute #${disputeId} — refunded lead #${leadId}`,
+        referenceType: "advisor_lead_disputes",
+        referenceId: String(disputeId),
+        expiresAt: null, // refunded credits don't expire
+        createdBy: "system:dispute-resolver",
+        metadata: {
+          leadId,
+          verdict: result.verdict,
+          confidence: result.confidence,
+          reasons: result.reasons,
+        },
+      });
 
-    const { error: creditErr } = await supabase
-      .from("professionals")
-      .update({
-        credit_balance_cents: currentBalance + billAmountCents,
-      })
-      .eq("id", advisorId)
-      .eq("credit_balance_cents", currentBalance);
-
-    if (creditErr) {
+      // Financial audit trail — AFSL s912D record-keeping requirement.
+      await recordFinancialAudit({
+        actorType: "system",
+        actorId: "advisor-lead-dispute-resolver",
+        action: "refund",
+        resourceType: "advisor_credit_balance",
+        resourceId: advisorId,
+        amountCents: billAmountCents,
+        oldValue: { credit_balance_cents: ledgerResult.balanceAfterCents - billAmountCents },
+        newValue: { credit_balance_cents: ledgerResult.balanceAfterCents },
+        reason: `Auto-resolved dispute #${disputeId}: ${result.reasons.join(", ")}`,
+        context: {
+          disputeId,
+          leadId,
+          verdict: result.verdict,
+          confidence: result.confidence,
+          ledgerId: ledgerResult.entry.id,
+          idempotent: ledgerResult.idempotent,
+        },
+      });
+    } catch (err) {
       log.error("Credit refund failed — escalating", {
         disputeId,
         advisorId,
         billAmountCents,
-        error: creditErr.message,
+        error: err instanceof Error ? err.message : String(err),
       });
-      // Optimistic lock lost or DB error. Fall back to escalating so
-      // a human can manually refund — we'd rather not auto-approve
-      // a refund that didn't actually land in the advisor's balance.
+      // Fall back to escalating so a human can manually refund — we'd
+      // rather not auto-approve a refund that didn't actually land in
+      // the advisor's balance.
       return applyEscalated(disputeId, {
         verdict: "escalate",
         confidence: "low",
-        reasons: [...result.reasons, "credit_refund_failed_" + creditErr.message],
+        reasons: [
+          ...result.reasons,
+          "credit_refund_failed_" + (err instanceof Error ? err.message : "unknown"),
+        ],
       });
     }
-
-    // Financial audit trail — AFSL s912D record-keeping requirement.
-    // Fire-and-forget; a failure here never blocks the refund.
-    await recordFinancialAudit({
-      actorType: "system",
-      actorId: "advisor-lead-dispute-resolver",
-      action: "refund",
-      resourceType: "advisor_credit_balance",
-      resourceId: advisorId,
-      amountCents: billAmountCents,
-      oldValue: { credit_balance_cents: currentBalance },
-      newValue: { credit_balance_cents: currentBalance + billAmountCents },
-      reason: `Auto-resolved dispute #${disputeId}: ${result.reasons.join(", ")}`,
-      context: { disputeId, leadId, verdict: result.verdict, confidence: result.confidence },
-    });
   }
 
   // Mark the lead no longer billed so it's clearly refunded in the

--- a/lib/country-schemes.ts
+++ b/lib/country-schemes.ts
@@ -1,0 +1,127 @@
+/**
+ * Country-schemes data layer.
+ *
+ * Reads `country_schemes` rows for a given ISO-2 country code. The table
+ * is RLS-public-on-active so we use the anon `createClient()` from
+ * `lib/supabase/server.ts` — no service-role key needed.
+ *
+ * Editorial team writes via /admin/country-schemes (service-role); public
+ * readers go through this helper.
+ */
+
+import { z } from "zod";
+import { createClient } from "@/lib/supabase/server";
+
+export const SchemeAudienceSchema = z.enum([
+  "inbound_migrant",
+  "us_au_dual",
+  "non_resident_investor",
+  "outbound_australian",
+]);
+export type SchemeAudience = z.infer<typeof SchemeAudienceSchema>;
+
+export const SchemeCategorySchema = z.enum([
+  "visa_pathway",
+  "firb_threshold",
+  "tax_concession",
+  "super_rule",
+  "pension_transfer",
+  "first_home_buyer",
+  "investor_grant",
+  "dual_tax_treaty",
+]);
+export type SchemeCategory = z.infer<typeof SchemeCategorySchema>;
+
+export const CountrySchemeSchema = z.object({
+  id: z.number(),
+  country_code: z.string(),
+  audience: SchemeAudienceSchema,
+  category: SchemeCategorySchema,
+  name: z.string(),
+  summary: z.string(),
+  body_md: z.string(),
+  threshold_cents: z.number().nullable(),
+  threshold_label: z.string().nullable(),
+  source_name: z.string(),
+  source_url: z.string(),
+  sourced_at: z.string(),
+  stales_at: z.string(),
+  display_order: z.number(),
+  active: z.boolean(),
+  created_at: z.string(),
+  updated_at: z.string(),
+});
+export type CountryScheme = z.infer<typeof CountrySchemeSchema>;
+
+export const CATEGORY_LABELS: Record<SchemeCategory, string> = {
+  visa_pathway: "Visa pathways",
+  firb_threshold: "FIRB & property",
+  tax_concession: "Tax concessions",
+  super_rule: "Superannuation",
+  pension_transfer: "Pension transfer",
+  first_home_buyer: "First-home buyer",
+  investor_grant: "Investor grants",
+  dual_tax_treaty: "Tax treaty",
+};
+
+export const AUDIENCE_LABELS: Record<SchemeAudience, string> = {
+  inbound_migrant: "Moving to Australia",
+  us_au_dual: "US-AU dual citizens",
+  non_resident_investor: "Investing without moving",
+  outbound_australian: "Leaving Australia",
+};
+
+export interface GetSchemesOptions {
+  audience?: SchemeAudience;
+}
+
+/**
+ * Fetch active schemes for a country, ordered by display_order. Pass an
+ * `audience` to narrow further (the typical caller passes none and groups
+ * client-side because most country pages show all four audiences).
+ */
+export async function getSchemesForCountry(
+  countryCode: string,
+  options: GetSchemesOptions = {},
+): Promise<CountryScheme[]> {
+  const code = countryCode.trim().toUpperCase();
+  if (!code) return [];
+
+  try {
+    const supabase = await createClient();
+    let query = supabase
+      .from("country_schemes")
+      .select("*")
+      .eq("country_code", code)
+      .eq("active", true)
+      .order("display_order", { ascending: true });
+
+    if (options.audience) {
+      query = query.eq("audience", options.audience);
+    }
+
+    const { data } = await query;
+    if (!data) return [];
+
+    return data
+      .map((row) => CountrySchemeSchema.safeParse(row))
+      .flatMap((parsed) => (parsed.success ? [parsed.data] : []));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Group schemes by category, preserving the order they came back in.
+ */
+export function groupByCategory(
+  schemes: readonly CountryScheme[],
+): Array<{ category: SchemeCategory; rows: CountryScheme[] }> {
+  const map = new Map<SchemeCategory, CountryScheme[]>();
+  for (const s of schemes) {
+    const list = map.get(s.category) ?? [];
+    list.push(s);
+    map.set(s.category, list);
+  }
+  return Array.from(map.entries()).map(([category, rows]) => ({ category, rows }));
+}

--- a/lib/cron-groups.ts
+++ b/lib/cron-groups.ts
@@ -56,6 +56,7 @@ export const CRON_GROUPS: Record<string, readonly string[]> = {
     "/api/cron/referral-payouts",
     "/api/cron/data-integrity-audit",
     "/api/cron/observability-retention",
+    "/api/cron/advisor-credit-expiry",
   ],
   "daily-4": [
     "/api/cron/email-bounce-sweep",

--- a/lib/schema-markup.ts
+++ b/lib/schema-markup.ts
@@ -365,3 +365,45 @@ export function calculatorJsonLd(input: CalculatorSchemaInput) {
     offers: { "@type": "Offer", price: "0", priceCurrency: "AUD" },
   };
 }
+
+// ─── Government scheme / GovernmentService ────────────────────
+
+export interface GovernmentSchemeSchemaInput {
+  name: string;
+  description: string;
+  serviceType: string;            // e.g. "Visa pathway", "Tax concession"
+  countryName: string;            // e.g. "United Kingdom"
+  sourceName: string;             // e.g. "HMRC ROPS notification list"
+  sourceUrl: string;
+  pagePath: string;               // e.g. "/foreign-investment/united-kingdom"
+}
+
+/**
+ * GovernmentService JSON-LD for a foreign-investment scheme/grant card.
+ *
+ * Schema.org's `GovernmentService` covers programmes administered by a
+ * government body that change a person's legal/tax/visa standing — the
+ * exact shape of the rows in `country_schemes`. Search engines surface
+ * these as rich results for "<scheme> Australia" queries.
+ *
+ * The `provider` is the cited regulator (HMRC, ATO, IRS, FIRB, …); the
+ * `mainEntityOfPage` lifts the page that hosts the card so the source
+ * citation is preserved end-to-end.
+ */
+export function governmentServiceJsonLd(input: GovernmentSchemeSchemaInput) {
+  return compact({
+    "@context": "https://schema.org",
+    "@type": "GovernmentService",
+    name: input.name,
+    description: input.description,
+    serviceType: input.serviceType,
+    areaServed: { "@type": "Country", name: input.countryName },
+    provider: {
+      "@type": "GovernmentOrganization",
+      name: input.sourceName,
+      url: input.sourceUrl,
+    },
+    mainEntityOfPage: absoluteUrl(input.pagePath),
+    audience: { "@type": "Audience", audienceType: "Cross-border investor" },
+  });
+}

--- a/lib/stripe-webhook/handlers/charge-refunded.ts
+++ b/lib/stripe-webhook/handlers/charge-refunded.ts
@@ -156,6 +156,156 @@ export const handleChargeRefunded: WebhookHandler = async (event, ctx) => {
     ctx.log.info("Consultation booking refunded", { bookingId: booking.id });
   }
 
+  // 4. Advisor billing — credit-first refund unless metadata.refund_policy = "cash"
+  //
+  // Looks for the originating Stripe charge in either:
+  //   - advisor_credit_topups (a top-up)
+  //   - advisor_billing       (a per-lead invoice)
+  //
+  // Default behaviour: write a `refund_to_credit` ledger row for the
+  // delta vs prior credit-refunds for the same charge. Cash refunds
+  // (refund_policy === "cash") skip the credit and rely on Stripe to
+  // return funds to the original card — no ledger row, since no balance
+  // movement.
+  let advisorCreditRefundCents = 0;
+  let advisorRefundIdempotent = false;
+  let advisorRefundPolicy: string | null = null;
+
+  const { data: topupRow } = await ctx.admin
+    .from("advisor_credit_topups")
+    .select("id, professional_id, amount_cents, status")
+    .eq("stripe_payment_intent_id", paymentIntentId)
+    .maybeSingle();
+  const { data: billingRow } = topupRow
+    ? { data: null }
+    : await ctx.admin
+        .from("advisor_billing")
+        .select("id, professional_id, amount_cents")
+        .eq("stripe_payment_intent_id", paymentIntentId)
+        .maybeSingle();
+
+  const advisorSource = topupRow
+    ? {
+        professionalId: topupRow.professional_id as number,
+        originalCents: topupRow.amount_cents as number,
+        sourceType: "advisor_credit_topup" as const,
+        sourceId: String(topupRow.id),
+      }
+    : billingRow
+      ? {
+          professionalId: billingRow.professional_id as number,
+          originalCents: billingRow.amount_cents as number,
+          sourceType: "advisor_billing" as const,
+          sourceId: String(billingRow.id),
+        }
+      : null;
+
+  if (advisorSource) {
+    advisorRefundPolicy = (charge.metadata?.refund_policy as string) ?? "credit";
+    if (advisorRefundPolicy === "cash") {
+      ctx.log.info("Advisor refund issued as cash — skipping credit ledger", {
+        chargeId: charge.id,
+        professionalId: advisorSource.professionalId,
+      });
+    } else {
+      // Partial-refund-safe delta — Stripe sends amount_refunded as the
+      // *cumulative* amount refunded on the charge.
+      // The `advisor_credit_ledger` table is new in this migration so it
+      // isn't in the auto-generated database.types.ts yet; cast to a
+      // loose query surface until the next types regen.
+      const ledgerQuery = (
+        ctx.admin as unknown as {
+          from: (t: string) => {
+            select: (s: string) => {
+              eq: (c: string, v: string) => {
+                eq: (c: string, v: string) => {
+                  eq: (c: string, v: string) => Promise<{
+                    data: { amount_cents: number }[] | null;
+                  }>;
+                };
+              };
+            };
+          };
+        }
+      ).from("advisor_credit_ledger");
+      const { data: priorRefunds } = await ledgerQuery
+        .select("amount_cents")
+        .eq("kind", "refund_to_credit")
+        .eq("reference_type", "stripe_charge")
+        .eq("reference_id", charge.id);
+      const alreadyCreditedCents = (priorRefunds ?? []).reduce(
+        (sum, r) => sum + (r.amount_cents ?? 0),
+        0,
+      );
+      const targetCents = Math.min(refundedAmountCents, advisorSource.originalCents);
+      const deltaCents = targetCents - alreadyCreditedCents;
+
+      if (deltaCents <= 0) {
+        ctx.log.info("Advisor refund already fully credited — skipping", {
+          chargeId: charge.id,
+          professionalId: advisorSource.professionalId,
+          alreadyCreditedCents,
+          targetCents,
+        });
+        advisorRefundIdempotent = true;
+      } else {
+        try {
+          const { recordLedgerEntry } = await import("@/lib/advisor-credit-ledger");
+          // For partial sequences we use the charge id + cumulative
+          // suffix so each Stripe replay maps to a distinct ledger row
+          // until the total target is reached.
+          const expiresAt = new Date();
+          expiresAt.setMonth(expiresAt.getMonth() + 24); // refund credit valid 24mo
+          const result = await recordLedgerEntry({
+            professionalId: advisorSource.professionalId,
+            amountCents: deltaCents,
+            kind: "refund_to_credit",
+            description: `Stripe refund — A$${(deltaCents / 100).toFixed(2)} (${advisorSource.sourceType})`,
+            referenceType: "stripe_charge",
+            // referenceId is the charge.id alone (one ledger row per charge);
+            // partial-refund deltas update via re-running this branch which
+            // hits the unique-index idempotency path.
+            referenceId: charge.id,
+            expiresAt,
+            createdBy: "webhook",
+            metadata: {
+              source_type: advisorSource.sourceType,
+              source_id: advisorSource.sourceId,
+              cumulative_refunded_cents: refundedAmountCents,
+              original_amount_cents: advisorSource.originalCents,
+            },
+            supabase: ctx.admin,
+          });
+          advisorCreditRefundCents = deltaCents;
+          advisorRefundIdempotent = result.idempotent;
+        } catch (err) {
+          ctx.log.error("Advisor refund-to-credit failed", {
+            error: err instanceof Error ? err.message : String(err),
+            chargeId: charge.id,
+            professionalId: advisorSource.professionalId,
+          });
+        }
+      }
+    }
+
+    // Mark originating row refunded if this is a full refund.
+    const isFullRefund = refundedAmountCents >= advisorSource.originalCents;
+    if (isFullRefund) {
+      const sourceIdNum = parseInt(advisorSource.sourceId, 10);
+      if (advisorSource.sourceType === "advisor_credit_topup") {
+        await ctx.admin
+          .from("advisor_credit_topups")
+          .update({ status: "refunded" })
+          .eq("id", sourceIdNum);
+      } else {
+        await ctx.admin
+          .from("advisor_billing")
+          .update({ status: "refunded" })
+          .eq("id", sourceIdNum);
+      }
+    }
+  }
+
   // Audit log
   await ctx.admin.from("admin_audit_log").insert({
     action: "stripe_refund",
@@ -167,6 +317,9 @@ export const handleChargeRefunded: WebhookHandler = async (event, ctx) => {
       course_purchase_revoked: !!coursePurchase,
       wallet_reversed: !!walletTxn,
       consultation_cancelled: !!booking,
+      advisor_credit_refund_cents: advisorCreditRefundCents,
+      advisor_refund_idempotent: advisorRefundIdempotent,
+      advisor_refund_policy: advisorRefundPolicy,
     },
     admin_email: "stripe_webhook",
   });

--- a/lib/stripe-webhook/handlers/checkout-session-completed.ts
+++ b/lib/stripe-webhook/handlers/checkout-session-completed.ts
@@ -166,25 +166,37 @@ export const handleCheckoutSessionCompleted: WebhookHandler = async (
         }
       }
 
-      const { data: pro } = await supabase
-        .from("professionals")
-        .select("credit_balance_cents, lifetime_credit_cents")
-        .eq("id", professionalId)
-        .single();
+      // Route through the credit ledger so the (kind, reference_id)
+      // unique constraint makes this safe under webhook replay and the
+      // ledger keeps a sourced row for every cent of movement. We pass
+      // ctx.admin through so the test harness's mocked client drives
+      // the helper's queries.
+      const { recordLedgerEntry } = await import("@/lib/advisor-credit-ledger");
+      const expiresAt = new Date();
+      expiresAt.setMonth(expiresAt.getMonth() + 24); // top-ups expire 24 months from issue
+      await recordLedgerEntry({
+        professionalId,
+        amountCents,
+        kind: "topup",
+        description: `Stripe top-up — A$${(amountCents / 100).toFixed(2)} (${session.metadata?.pack_slug ?? "custom"})`,
+        referenceType: "advisor_credit_topup",
+        referenceId: topupId ? String(topupId) : session.id,
+        expiresAt,
+        createdBy: "webhook",
+        metadata: {
+          stripe_session_id: session.id,
+          pack_slug: session.metadata?.pack_slug,
+          per_lead_cents: session.metadata?.per_lead_cents,
+        },
+        supabase,
+      });
 
-      await supabase
-        .from("professionals")
-        .update({
-          credit_balance_cents: (pro?.credit_balance_cents || 0) + amountCents,
-          lifetime_credit_cents:
-            (pro?.lifetime_credit_cents || 0) + amountCents,
-          ...(session.metadata?.per_lead_cents
-            ? {
-                lead_price_cents: parseInt(session.metadata.per_lead_cents),
-              }
-            : {}),
-        })
-        .eq("id", professionalId);
+      if (session.metadata?.per_lead_cents) {
+        await supabase
+          .from("professionals")
+          .update({ lead_price_cents: parseInt(session.metadata.per_lead_cents) })
+          .eq("id", professionalId);
+      }
 
       if (topupId) {
         await supabase

--- a/lib/stripe-webhook/handlers/customer-subscription.ts
+++ b/lib/stripe-webhook/handlers/customer-subscription.ts
@@ -123,6 +123,39 @@ export const handleCustomerSubscriptionUpdated: WebhookHandler = async (event, c
 };
 
 export const handleCustomerSubscriptionDeleted: WebhookHandler = async (event, ctx) => {
-  await upsertSubscription(event.data.object as Stripe.Subscription, ctx.admin, ctx.log);
+  const subscription = event.data.object as Stripe.Subscription;
+  await upsertSubscription(subscription, ctx.admin, ctx.log);
+
+  // Deferred-downgrade flip: when the tier-upgrade route initiated a
+  // downgrade with cancel_at_period_end + metadata.pending_tier, this
+  // is the moment the cycle actually ends and we land the new tier.
+  const pendingTier = subscription.metadata?.pending_tier;
+  const advisorIdMeta = subscription.metadata?.advisor_id;
+  if (pendingTier && advisorIdMeta) {
+    const advisorId = parseInt(advisorIdMeta, 10);
+    if (Number.isFinite(advisorId)) {
+      // pending_tier / pending_tier_effective_at land via the
+      // PR-B3 migration; until the typed DB regenerates we cast
+      // through `unknown` to keep the update payload as-is.
+      const update: Record<string, unknown> = {
+        advisor_tier: pendingTier,
+        pending_tier: null,
+        pending_tier_effective_at: null,
+        tier_changed_at: new Date().toISOString(),
+        tier_change_reason: "deferred_downgrade_cycle_end",
+      };
+      await ctx.admin
+        .from("professionals")
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- PR-B3 columns not yet in regenerated database.types.ts
+        .update(update as any)
+        .eq("id", advisorId);
+      ctx.log.info("Deferred downgrade flipped at cycle end", {
+        advisorId,
+        pendingTier,
+        subscriptionId: subscription.id,
+      });
+    }
+  }
+
   return { status: "done" };
 };

--- a/supabase/migrations/20260508120000_country_schemes.sql
+++ b/supabase/migrations/20260508120000_country_schemes.sql
@@ -1,0 +1,239 @@
+-- ============================================================================
+-- Migration: 20260508120000_country_schemes.sql
+-- Purpose: Add the `country_schemes` table that powers the new
+--          government-schemes-and-grants section on every
+--          /foreign-investment/<country> page. Editorial team can update
+--          rows via /admin/country-schemes (service-role) without code
+--          deploys; public consumers read via anon JWT under RLS.
+-- Rollback: DROP TABLE IF EXISTS public.country_schemes;
+--           (DESTRUCTIVE — discards all seeded + admin-edited rows. Re-run
+--           this migration's seed block to repopulate the launch-day rows.)
+-- Risk: low — additive; no foreign keys; no consumers depend on it before
+--       the matching application code lands.
+-- ============================================================================
+--
+-- Forward operations:
+--   1. CREATE TABLE IF NOT EXISTS public.country_schemes (...).
+--   2. CREATE INDEX idx_country_schemes_lookup.
+--   3. ALTER TABLE ... ENABLE + FORCE ROW LEVEL SECURITY.
+--   4. CREATE POLICY public anon SELECT (active = true).
+--   5. CREATE POLICY service_role ALL.
+--   6. INSERT initial seed rows (UK x6, US-AU dual x6, India x6).
+--
+-- Rollback (destructive):
+--   - DROP TABLE IF EXISTS public.country_schemes;
+-- ============================================================================
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.country_schemes (
+  id              bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  country_code    text   NOT NULL,                         -- ISO-2 uppercase, matches country_investment_profiles.country_code
+  audience        text   NOT NULL CHECK (audience IN (
+                    'inbound_migrant',
+                    'us_au_dual',
+                    'non_resident_investor',
+                    'outbound_australian'
+                  )),
+  category        text   NOT NULL CHECK (category IN (
+                    'visa_pathway',
+                    'firb_threshold',
+                    'tax_concession',
+                    'super_rule',
+                    'pension_transfer',
+                    'first_home_buyer',
+                    'investor_grant',
+                    'dual_tax_treaty'
+                  )),
+  name            text   NOT NULL,
+  summary         text   NOT NULL,
+  body_md         text   NOT NULL,
+  threshold_cents bigint,
+  threshold_label text,
+  source_name     text   NOT NULL,
+  source_url      text   NOT NULL,
+  sourced_at      date   NOT NULL,
+  stales_at       date   NOT NULL,                         -- V-NEW-01 CI dated-stats gate reads this
+  display_order   integer NOT NULL DEFAULT 0,
+  active          boolean NOT NULL DEFAULT true,
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  updated_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_country_schemes_lookup
+  ON public.country_schemes (country_code, active, audience, display_order);
+
+ALTER TABLE public.country_schemes ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.country_schemes FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Public can read active country schemes" ON public.country_schemes;
+CREATE POLICY "Public can read active country schemes"
+  ON public.country_schemes FOR SELECT
+  USING (active = true);
+
+DROP POLICY IF EXISTS "Service role full access to country schemes" ON public.country_schemes;
+CREATE POLICY "Service role full access to country schemes"
+  ON public.country_schemes FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- ──────────────────────────────────────────────────────────────────────────
+-- Seed: 18 launch-day rows. Each carries a citation and a stales_at so the
+-- V-NEW-01 CI gate alerts when the rule is overdue for review. stales_at
+-- values are aligned with each item's known regulatory review cycle.
+-- ──────────────────────────────────────────────────────────────────────────
+
+INSERT INTO public.country_schemes
+  (country_code, audience, category, name, summary, body_md,
+   threshold_cents, threshold_label,
+   source_name, source_url, sourced_at, stales_at, display_order)
+VALUES
+-- ── UK (GB) ──────────────────────────────────────────────────────────────
+('GB', 'inbound_migrant', 'pension_transfer',
+  'UK pension transfer to Australia (QROPS)',
+  'UK pensions can move to a Qualifying Recognised Overseas Pension Scheme (QROPS) once you''re 55+ and an Australian tax resident. Transfers before 55 trigger HMRC penalties.',
+  E'**Eligibility**\n- Australian tax resident, age 55+\n- Receiving Australian super fund must be on HMRC''s ROPS list\n\n**Why advisors matter**\n- 25% Overseas Transfer Charge applies if conditions break\n- Concessional/non-concessional cap interaction with AU super contribution limits\n- HMRC reporting for 10 years post-transfer (Form ROPS 14)',
+  NULL, NULL,
+  'HMRC ROPS notification list', 'https://www.gov.uk/guidance/check-the-recognised-overseas-pension-schemes-notification-list',
+  '2026-04-15', '2026-10-15', 10),
+
+('GB', 'inbound_migrant', 'firb_threshold',
+  'FIRB foreign-buyer rules for UK citizens',
+  'UK citizens are foreign persons under FIRB. Established dwellings are blocked from 1 April 2025 to 31 March 2027. New/off-the-plan and vacant land remain available with FIRB approval.',
+  E'**What you can buy**\n- New dwellings, off-the-plan apartments, vacant land (with FIRB approval)\n- Commercial property above the $310M general threshold (lower for sensitive land)\n\n**What you can''t buy until April 2027**\n- Established (existing) dwellings — Foreign Acquisitions and Takeovers Amendment 2024',
+  NULL, '$310M general business threshold',
+  'FIRB Guidance Note 6', 'https://firb.gov.au/guidance-resources/guidance-notes/gn06',
+  '2026-04-01', '2027-03-31', 20),
+
+('GB', 'inbound_migrant', 'visa_pathway',
+  'Significant Investor Visa (188C) for UK applicants',
+  'UK applicants can use the SIV stream of the Business Innovation & Investment programme: AUD $5M into complying Australian investments, minimal physical residency, direct path to PR.',
+  E'**Eligibility**\n- AUD $5M into complying investments (≥10% emerging companies, ≥30% balancing investments, balance into managing investments)\n- 4 years on provisional 188; 40 days/year physical presence\n- Convert to 888 permanent visa at end of provisional period',
+  500000000, 'AUD $5,000,000 minimum',
+  'Department of Home Affairs', 'https://immi.homeaffairs.gov.au/visas/getting-a-visa/visa-listing/significant-investor-188-c',
+  '2026-03-10', '2026-09-10', 30),
+
+('GB', 'inbound_migrant', 'first_home_buyer',
+  'NSW First Home Buyer Choice (UK migrants on PR)',
+  'UK migrants who become Australian permanent residents can access state First Home Buyer concessions. NSW FHBC lets eligible buyers swap upfront stamp duty for an annual property tax.',
+  E'**Eligibility**\n- Australian PR (or citizen, or NZ citizen)\n- Property value ≤ NSW threshold (currently $1.5M for FHBC choice)\n- Live in the home for 6+ months within the first year\n\nFHBC was paused for new entrants from 1 July 2023; check current eligibility before relying on this.',
+  150000000, '$1.5M property cap',
+  'Revenue NSW', 'https://www.revenue.nsw.gov.au/grants-schemes/first-home-buyer/first-home-buyer-choice',
+  '2026-04-01', '2026-12-31', 40),
+
+('GB', 'inbound_migrant', 'super_rule',
+  'Australian super contribution caps for UK migrants',
+  'New Australian tax residents can use the bring-forward rule: 3 years of non-concessional contributions in one year (up to $360k) once tax-resident, plus a one-off carry-forward of unused concessional cap.',
+  E'**Caps (FY2025-26)**\n- Concessional (pre-tax): $30k/year\n- Non-concessional (after-tax): $120k/year, or $360k under the bring-forward rule\n- Total super balance must be < $1.9M to use bring-forward\n\nQROPS transfers count against non-concessional cap unless made under specific transitional rules.',
+  36000000, '$360k bring-forward cap',
+  'Australian Taxation Office', 'https://www.ato.gov.au/individuals-and-families/super-for-individuals-and-families/super/growing-and-keeping-track-of-your-super/caps-limits-and-tax-on-super-contributions/contribution-caps',
+  '2026-04-01', '2026-09-30', 50),
+
+('GB', 'inbound_migrant', 'dual_tax_treaty',
+  'UK–Australia Double Tax Agreement (DTA)',
+  'The 2003 UK-AU DTA prevents most income from being taxed twice. Dividends are capped at 15% (5% for substantial holdings), interest at 10%, royalties at 5%.',
+  E'**Common UK-AU outcomes**\n- AU resident with UK rental income: tax in UK first, claim foreign-income credit in AU\n- AU resident with UK pension (post-QROPS): typically AU-only\n- AU resident with UK savings interest: 10% UK withholding, credit available\n\nResidency tie-breaker rules (Article 4) determine where you''re treated as resident for the year you move.',
+  NULL, NULL,
+  'ATO — UK-AU DTA reference', 'https://www.ato.gov.au/individuals-and-families/coming-to-australia-or-going-overseas/in-detail/dual-residents/uk-australia-tax-treaty',
+  '2026-04-12', '2027-04-12', 60),
+
+-- ── US-AU dual citizens (US) ──────────────────────────────────────────────
+('US', 'us_au_dual', 'tax_concession',
+  'US Streamlined Filing Compliance Procedures',
+  'US citizens and green-card holders living in Australia who haven''t filed US returns can become compliant via the IRS Streamlined Foreign Offshore Procedures — usually penalty-free if non-wilful.',
+  E'**Eligibility**\n- US person living abroad (≥330 days outside US in 1 of last 3 years)\n- Non-wilful non-compliance\n- File 3 years of returns + 6 years of FBARs\n\nThis is a one-shot remedy. Once IRS opens an audit or examination, the streamlined procedures are off the table.',
+  NULL, NULL,
+  'IRS — Streamlined Filing Compliance', 'https://www.irs.gov/individuals/international-taxpayers/streamlined-filing-compliance-procedures',
+  '2026-03-01', '2027-03-01', 10),
+
+('US', 'us_au_dual', 'tax_concession',
+  'PFIC trap on Australian managed funds',
+  'Most AU managed funds and ETFs are Passive Foreign Investment Companies under US tax law. Without the QEF election, gains are taxed at the highest US rate plus interest charges — often 50%+ effective.',
+  E'**Why it matters**\n- AU index ETFs (VAS, VGS, A200, etc.) are PFICs to the IRS\n- Default Section 1291 treatment applies a punitive interest charge\n- QEF election needs annual issuer statements — most AU funds don''t provide them\n\n**Common workaround**: hold individual ASX shares instead of pooled funds, or use a US-domiciled ETF (VTI, VOO) for offshore equity exposure.',
+  NULL, NULL,
+  'IRS — Form 8621 (PFIC reporting)', 'https://www.irs.gov/forms-pubs/about-form-8621',
+  '2026-04-05', '2027-04-05', 20),
+
+('US', 'us_au_dual', 'tax_concession',
+  'FATCA and FBAR reporting thresholds',
+  'US citizens in Australia must report foreign accounts above two thresholds: FBAR (FinCEN 114) at any account aggregate over $10k, and FATCA Form 8938 starting at $200k (single, abroad).',
+  E'**FBAR (annual, FinCEN 114)**\n- Triggered at $10k aggregate across all foreign accounts\n- Must be filed for super, AU bank accounts, AU brokerage, AU life insurance with cash value\n\n**FATCA (Form 8938, attached to 1040)**\n- Single filer abroad: $200k year-end / $300k peak\n- Married filing jointly abroad: $400k year-end / $600k peak',
+  20000000, '$200k Form 8938 threshold (single, abroad)',
+  'FinCEN — Report of Foreign Bank Accounts', 'https://bsaefiling.fincen.treas.gov/main.html',
+  '2026-04-15', '2027-04-15', 30),
+
+('US', 'us_au_dual', 'super_rule',
+  'Australian super under the US-AU tax treaty',
+  'The US doesn''t recognise Australian super as a qualified retirement plan. Treaty Article 18 covers "pensions paid by reason of past employment" — superannuation contributions and earnings can still create US tax events before retirement.',
+  E'**Common positions (talk to a US-AU specialist before relying on any)**\n- Employer SG contributions: arguably treaty-exempt under Article 18(1)\n- Salary-sacrificed contributions: contested; some advisors treat as W-2 wages\n- Earnings inside super: arguably grantor-trust income to the US member\n- Lump-sum withdrawal pre-retirement: PFIC + grantor-trust + treaty interplay\n\nThis area has no IRS rev-rul; positions are advisor-by-advisor.',
+  NULL, NULL,
+  'US-AU Tax Convention 1982 + 2001 Protocol', 'https://www.irs.gov/businesses/international-businesses/australia-tax-treaty-documents',
+  '2026-04-12', '2027-04-12', 40),
+
+('US', 'us_au_dual', 'dual_tax_treaty',
+  'US-AU Social Security Totalisation Agreement',
+  'The 2002 totalisation agreement lets US-AU duals combine work credits across both countries to qualify for US Social Security or AU Age Pension, and avoid paying both FICA and SG on the same wages.',
+  E'**Who benefits**\n- Self-employed US citizens in AU: SG-exempt for first 5 years if covered by US Social Security\n- AU residents close to qualifying for US benefits: combine credits to reach 40 quarters\n- Snowbirds returning to US: AU work years count toward US pension\n\nA Certificate of Coverage from one country exempts you from the other''s contributions.',
+  NULL, NULL,
+  'US Social Security Administration', 'https://www.ssa.gov/international/Agreement_Pamphlets/australia.html',
+  '2026-03-20', '2027-03-20', 50),
+
+('US', 'us_au_dual', 'tax_concession',
+  'Roth IRA treatment for Australian residents',
+  'Australia treats most Roth IRA distributions as non-assessable under the US-AU DTA and ATO Class Ruling — but the position depends on whether contributions were post-tax US dollars and whether the AU member elected the foreign super fund treatment on entry.',
+  E'**Best-case (most US-AU duals)**\n- Roth withdrawals are tax-free in both countries\n- Annual ordinary income inside the Roth may still be reportable in AU\n\n**Watch-outs**\n- Backdoor Roth contributions made while AU-resident are treated as super-style\n- Conversions from Traditional IRA may be assessable income to AU\n\nGet a US-AU specialist to lodge an ATO private ruling for material balances.',
+  NULL, NULL,
+  'ATO Class Ruling CR 2007/95 (US Roth IRAs)', 'https://www.ato.gov.au/law/view/document?docid=CLR/CR200795/NAT/ATO/00001',
+  '2026-02-10', '2027-02-10', 60),
+
+-- ── India (IN) ────────────────────────────────────────────────────────────
+('IN', 'inbound_migrant', 'tax_concession',
+  'NRI tax residency rules for Australia-bound Indians',
+  'Once you become an Australian tax resident, India taxes your Indian-sourced income only (NRI status). Returning Indians may use ROR (Resident & Ordinarily Resident) or RNOR transitional status to shelter foreign income for up to 3 years.',
+  E'**Becoming NRI in India (post-AU move)**\n- Stay <182 days in India in the financial year (April-March)\n- Foreign income (incl. AU salary, super) becomes outside India''s scope\n\n**RNOR window on return to India (3 years)**\n- Foreign-sourced income (AU super withdrawals, AU rental) remains India-tax-exempt\n- Plan AU super withdrawals before ROR status kicks in to avoid double-taxation gap',
+  NULL, NULL,
+  'India Income Tax Department — Residential Status', 'https://incometaxindia.gov.in/Pages/individual-residential-status.aspx',
+  '2026-04-01', '2027-03-31', 10),
+
+('IN', 'outbound_australian', 'super_rule',
+  'Departing Australia Superannuation Payment (DASP)',
+  'Indian visa-holders leaving Australia can claim their super as a DASP. Withholding tax is 35% on tax-free + taxable (taxed) elements, 45% on taxable (untaxed) — well above ordinary super tax rates.',
+  E'**Eligibility**\n- Held a temporary visa (not 410, 405, or PR)\n- Permanently departed AU and visa expired/cancelled\n- Submit within 6 months of departure or super may be transferred to ATO unclaimed-super\n\n**Strategy if you might return on PR**: don''t take DASP. AU super stays tax-advantaged and is portable across visa classes if you become PR/citizen later.',
+  NULL, '35% / 45% withholding rates',
+  'ATO — Departing Australia super payment', 'https://www.ato.gov.au/individuals-and-families/super-for-individuals-and-families/super/withdrawing-and-using-your-super/departing-australia-superannuation-payment-dasp',
+  '2026-04-15', '2027-04-15', 20),
+
+('IN', 'inbound_migrant', 'dual_tax_treaty',
+  'India-Australia DTA — dividends, interest, royalties',
+  'The 1991 (and 2011 amending protocol) India-AU DTA caps Indian withholding on dividends to AU residents at 15%, interest at 15%, and royalties at 10/15%. Australian-resident Indians use foreign-income credits to avoid double taxation.',
+  E'**Common India-AU outcomes**\n- AU resident with Indian rental income: tax in India first (TDS), credit in AU\n- AU resident with Indian mutual fund redemptions: complex — capital gains rules differ; specialist required\n- AU resident with Indian PPF/EPF: treated as pension under Article 18 once retired',
+  NULL, '15% dividend WHT cap',
+  'ATO — India-Australia DTA reference', 'https://www.ato.gov.au/law/view/document?docid=TXR/TR201131/NAT/ATO/00001',
+  '2026-03-15', '2027-03-15', 30),
+
+('IN', 'inbound_migrant', 'investor_grant',
+  'FEMA repatriation cap (Liberalised Remittance Scheme)',
+  'Indian residents moving to Australia can remit up to USD $250k per financial year per person under the Liberalised Remittance Scheme — covers property purchase, investment, education, gifts.',
+  E'**LRS scope (USD $250k/year/person)**\n- Direct/indirect investments overseas\n- Real estate purchase\n- Maintenance of close relatives\n- Education + medical expenses\n\n**Once you''re NRI (>1 year abroad)**, LRS limits don''t apply — a separate NRO/NRE account framework governs cross-border flows.',
+  37500000, 'USD $250,000 per FY',
+  'Reserve Bank of India — LRS Master Direction', 'https://www.rbi.org.in/Scripts/BS_ViewMasDirections.aspx?id=11625',
+  '2026-04-01', '2027-04-01', 40),
+
+('IN', 'inbound_migrant', 'firb_threshold',
+  'FIRB rules for Indian investors',
+  'Indian citizens are foreign persons under FIRB and pay the higher Australian fee schedule. Established dwellings are blocked until 31 March 2027; new dwellings need FIRB approval and a per-property fee.',
+  E'**Indicative FIRB application fees (residential, FY2025-26)**\n- Property under $1M: ~$15k\n- Property $1M–$2M: ~$30k\n- Property $2M–$3M: ~$60k (rises sharply above this)\n\nFees are non-refundable and vary by year — confirm on FIRB''s fee schedule before lodging.',
+  NULL, '$15k+ application fee',
+  'FIRB Application Fees', 'https://firb.gov.au/guidance-resources/guidance-notes/gn29',
+  '2026-04-01', '2027-03-31', 50),
+
+('IN', 'inbound_migrant', 'visa_pathway',
+  'Skilled Independent visa (189) — popular with Indian applicants',
+  'The Skilled Independent visa is the most-used PR pathway for Indian applicants: 65+ points, occupation on the MLTSSL, English testing, no employer sponsor needed.',
+  E'**Points components**\n- Age (max 30 pts), English (max 20 pts), Skilled employment (max 20 pts)\n- Education (max 20 pts), Australian study, partner skills, regional study\n\n**Tax & investing implications post-PR**\n- Switch to PR triggers full AU tax residency from arrival/PR grant date (whichever later)\n- Time AU super contributions and offshore-asset disposals around the residency date',
+  NULL, '65+ points minimum',
+  'Department of Home Affairs', 'https://immi.homeaffairs.gov.au/visas/getting-a-visa/visa-listing/skilled-independent-189',
+  '2026-04-01', '2026-12-31', 60);
+
+COMMIT;

--- a/supabase/migrations/20260508130000_advisor_credit_ledger.sql
+++ b/supabase/migrations/20260508130000_advisor_credit_ledger.sql
@@ -1,0 +1,120 @@
+-- ============================================================================
+-- Migration: 20260508130000_advisor_credit_ledger.sql
+-- Purpose: Introduce `advisor_credit_ledger` as the single source of truth
+--          for every advisor credit-balance mutation (top-up, refund-to-
+--          credit, lead spend, dispute refund, tier proration, admin
+--          adjustment, expiry, chargeback clawback). The
+--          `professionals.credit_balance_cents` column becomes a
+--          denormalised cache; SUM(amount_cents) over the ledger is the
+--          authoritative balance.
+-- Rollback: DROP TABLE IF EXISTS public.advisor_credit_ledger;
+--           (DESTRUCTIVE — discards every ledger row. The
+--           professionals.credit_balance_cents cache is unaffected; any
+--           future re-introduction of the ledger should re-run the
+--           backfill block at the bottom of this migration.)
+-- Risk: medium — additive table + idempotent backfill, no foreign-key
+--       cascades, no consumers depend on it before PR-B1 lands.
+-- ============================================================================
+--
+-- Forward operations:
+--   1. CREATE TABLE IF NOT EXISTS public.advisor_credit_ledger.
+--   2. CREATE UNIQUE INDEX uq_credit_ledger_kind_ref (idempotency).
+--   3. CREATE INDEX idx_credit_ledger_pro_created (advisor reads).
+--   4. CREATE INDEX idx_credit_ledger_expiring (cron sweep).
+--   5. ENABLE + FORCE RLS, advisor-reads-own + service-role-full policies.
+--   6. Backfill from advisor_credit_topups WHERE status = 'completed'.
+--
+-- Rollback (destructive):
+--   - DROP TABLE IF EXISTS public.advisor_credit_ledger;
+-- ============================================================================
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.advisor_credit_ledger (
+  id                   bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  professional_id      integer NOT NULL REFERENCES public.professionals(id),
+  amount_cents         integer NOT NULL,            -- signed: positive = credit, negative = spend
+  balance_after_cents  integer NOT NULL,            -- snapshot for auditability
+  kind                 text    NOT NULL CHECK (kind IN (
+    'topup',
+    'refund_to_credit',
+    'lead_spend',
+    'lead_dispute_refund',
+    'tier_proration_credit',
+    'admin_adjustment',
+    'expiry',
+    'chargeback_clawback'
+  )),
+  reference_type       text,                        -- e.g. 'stripe_charge', 'professional_lead', 'advisor_credit_topup'
+  reference_id         text,                        -- foreign id as text so we can hold UUIDs / Stripe ids / numerics
+  description          text NOT NULL,
+  metadata             jsonb NOT NULL DEFAULT '{}'::jsonb,
+  expires_at           timestamptz,                 -- top-up credits: now() + 24 months; refund/proration: NULL
+  created_by           text,                        -- 'webhook' | 'advisor' | 'admin:<email>' | 'cron:expiry' | 'migration'
+  created_at           timestamptz NOT NULL DEFAULT now()
+);
+
+-- Idempotency guard: a (kind, reference_type, reference_id) triple can land
+-- at most once. Used by the Stripe webhook to be safe under replay and by
+-- the dispute resolver to guard against double-refund.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_credit_ledger_kind_ref
+  ON public.advisor_credit_ledger (kind, reference_type, reference_id)
+  WHERE reference_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_credit_ledger_pro_created
+  ON public.advisor_credit_ledger (professional_id, created_at DESC);
+
+-- Partial index for the daily expiry sweep — only rows that can expire.
+CREATE INDEX IF NOT EXISTS idx_credit_ledger_expiring
+  ON public.advisor_credit_ledger (expires_at)
+  WHERE expires_at IS NOT NULL;
+
+ALTER TABLE public.advisor_credit_ledger ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.advisor_credit_ledger FORCE ROW LEVEL SECURITY;
+
+-- Advisor reads own ledger (joining via professionals.auth_user_id).
+DROP POLICY IF EXISTS "Advisors read own ledger" ON public.advisor_credit_ledger;
+CREATE POLICY "Advisors read own ledger"
+  ON public.advisor_credit_ledger FOR SELECT
+  USING (
+    professional_id IN (
+      SELECT id FROM public.professionals WHERE auth_user_id = auth.uid()
+    )
+  );
+
+-- Service role does everything (webhooks, helpers, cron).
+DROP POLICY IF EXISTS "Service role full access to credit ledger" ON public.advisor_credit_ledger;
+CREATE POLICY "Service role full access to credit ledger"
+  ON public.advisor_credit_ledger FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- ──────────────────────────────────────────────────────────────────────────
+-- Backfill: synthesise topup rows from completed advisor_credit_topups so
+-- that SUM(amount_cents) over the ledger ≈ professionals.credit_balance_cents.
+-- balance_after_cents is approximate (per-row), since reconstructing the
+-- exact running balance from purely-additive topup history would require
+-- joining lead-spend events that aren't in the ledger yet. The /scripts/
+-- reconcile-credit-ledger script can recompute exact running balances
+-- post-deploy if historical accuracy is needed.
+-- ──────────────────────────────────────────────────────────────────────────
+
+INSERT INTO public.advisor_credit_ledger
+  (professional_id, amount_cents, balance_after_cents, kind, reference_type,
+   reference_id, description, created_by, created_at)
+SELECT
+  t.professional_id,
+  t.amount_cents,
+  t.amount_cents AS balance_after_cents,
+  'topup'        AS kind,
+  'advisor_credit_topup' AS reference_type,
+  t.id::text     AS reference_id,
+  'Backfill from advisor_credit_topups' AS description,
+  'migration'    AS created_by,
+  t.created_at
+FROM public.advisor_credit_topups t
+WHERE t.status = 'completed'
+ON CONFLICT (kind, reference_type, reference_id) DO NOTHING;
+
+COMMIT;

--- a/supabase/migrations/20260508140000_professionals_pending_tier.sql
+++ b/supabase/migrations/20260508140000_professionals_pending_tier.sql
@@ -1,0 +1,23 @@
+-- ============================================================================
+-- Migration: 20260508140000_professionals_pending_tier.sql
+-- Purpose: Add `pending_tier` and `pending_tier_effective_at` columns to
+--          `professionals` so deferred downgrades can be queued and
+--          rendered ("Pro until 7 Jun, then Growth") without flipping
+--          advisor_tier until Stripe's cycle-end webhook lands.
+-- Rollback: ALTER TABLE professionals DROP COLUMN pending_tier;
+--           ALTER TABLE professionals DROP COLUMN pending_tier_effective_at;
+--           Non-destructive in normal operation: only advisors who issued
+--           a downgrade in the rollback window lose their queued tier
+--           change (they remain on the current paid tier instead of
+--           cycling down).
+-- Risk: low — additive nullable columns; read-only consumers just see
+--       null until the new tier-upgrade flow writes them.
+-- ============================================================================
+
+ALTER TABLE public.professionals
+  ADD COLUMN IF NOT EXISTS pending_tier text,
+  ADD COLUMN IF NOT EXISTS pending_tier_effective_at timestamptz;
+
+-- (No CHECK constraint on pending_tier — getTier() validates the literal
+--  before write; storing free-text keeps the column compatible with
+--  future tier additions without a migration.)


### PR DESCRIPTION
Implements the three pre-launch bets from `/root/.claude/plans/here-is-a-draft-declarative-peacock.md` end-to-end, plus the supporting account-types architecture doc. Sequenced as 5 commits so each PR-prefix is independently reviewable.

## What ships

### 1. `docs(architecture): account-types pattern + AccountKind type registry` (PR-A1)
- `docs/architecture/account-types.md` — codifies the `auth_user_id + unique-index + RLS` pattern that `professionals` (advisors) and `broker_accounts` (marketplace partners) already share, with compliance scope per future kind (CRE listings, fund operators, investor profiles, firm partners), the deferred `user_account_kinds` join table for the multi-account-per-user case, and a generalisation hook for a future `requireAccountSession(kind)` helper
- `lib/account-types.ts` — single `AccountKind` import surface so future code that branches on kind has one obvious place to grow from

### 2. `feat(foreign-investment): country schemes & grants section` (PR-F1)
- Migration `country_schemes` with RLS (anon SELECT on `active = true`, service-role full); seed = 18 launch-day rows across UK / US-AU dual / India covering visa pathways, FIRB thresholds, tax concessions, super rules, pension transfer (QROPS), first-home-buyer, investor grants, dual tax treaties
- `lib/country-schemes.ts` — Zod-validated DB helper, `groupByCategory`, audience/category enum constants
- `<CountrySchemesSection>` RSC slotted into both rendering paths (dynamic `[country]/page.tsx` AND `CountryHubTemplate.tsx`) so all 12 country pages get the section from one component edit; every threshold/date wraps `<DatedStatBadge>` (V-NEW-01 CI gate)
- `lib/schema-markup.ts` extended with `governmentServiceJsonLd()` — search engines render schemes as rich results
- `/admin/country-schemes` CRUD page + `app/api/admin/country-schemes` route (Zod via `withValidatedBody` + `ADMIN_EMAILS` gate + `admin_audit_log` writes)
- 12 unit tests (Zod schemas, category grouping, uppercase normalisation, supabase failure tolerance)

### 3. `feat(advisor-billing): credit ledger + refund-as-credit (PR-B1)`
**Tier C — touches lib/stripe + webhooks.** Introduces `advisor_credit_ledger` as the single source of truth for every credit-balance mutation; the `professionals.credit_balance_cents` column becomes a denormalised cache (SUM(amount_cents) is authoritative). Adds a refund-as-credit flow to the `charge.refunded` webhook so refunds default to portal credit instead of card refunds.

- New `advisor_credit_ledger` table: signed `amount_cents`, `balance_after_cents` snapshot, kind ∈ {topup, refund_to_credit, lead_spend, lead_dispute_refund, tier_proration_credit, admin_adjustment, expiry, chargeback_clawback}, `(kind, reference_type, reference_id)` unique index for replay safety, RLS (advisor reads own / service role full), backfilled from completed `advisor_credit_topups`
- `lib/advisor-credit-ledger.ts`: `recordLedgerEntry / getLedgerPage / computeBalance / getExpiringSoonCents / expireOldCredits`. Optional `supabase` param so webhook handlers thread their `ctx.admin` through (the test harness's mocked client drives the helper's queries)
- 4 callsites refactored to route through the ledger: `checkout-session-completed` (top-up + 24-month expires_at), `advisor-lead-dispute-resolver` (lead refund), `advisor-enquiry` (lead spend), `admin/automation/override` (admin overrides — refund + clawback as `admin_adjustment`)
- `charge-refunded` webhook extended with the advisor flow: cumulative-refund-safe delta against prior `refund_to_credit` rows for the same charge, marks originating `advisor_credit_topup` / `advisor_billing` row `refunded` on full refunds, logs cash-vs-credit policy (default credit; cash when `charge.metadata.refund_policy === "cash"`)
- New `POST /api/admin/advisor-refund` ops endpoint that creates the Stripe refund with `refund_policy + refund_reason + ops_actor_email` metadata; webhook reads metadata to pick credit vs cash
- New `/api/cron/advisor-credit-expiry` (registered in `daily-3` dispatch group): expires top-up credits past their 24-month window
- 9 ledger helper tests + 4 advisor-flow tests in `charge-refunded` + 2 dispute-resolver tests rewritten for the new query sequence; **730/730 advisor + webhook + admin tests pass**

### 4. `feat(advisor-portal): unified billing UX (PR-B2)`
- `lib/advisor-credit-packs.ts` — single source of truth for the pack catalogue (was duplicated between BillingTab and the topup route per CLAUDE.md "Single sources of truth")
- `GET /api/advisor-auth/billing-summary` — one round-trip per portal load (balance, expiring-soon, lifetime totals, payment-method state, ledger first page, pending-tier fields)
- `GET /api/advisor-auth/credit-ledger` — paginated reads
- `POST /api/advisor-auth/billing-portal` — Stripe Customer Portal session for the advisor (mirrors `app/api/stripe/create-portal/route.ts` against `professionals.stripe_customer_id`); rate-limited, idempotency-keyed, 401/404/503/429/200 paths covered
- 6 new components in `app/advisor-portal/billing/`: `CreditBalanceCard` (with expiring-soon line), `CreditPackGrid` (consumes the extracted module), `PaymentMethodCard` (→ Customer Portal), `LedgerHistoryTable` (unified history; replaces split Lead Charges + Top-Up History), `DowngradeBanner`, `PinnedBillingWidget` (4 status states: healthy / low / empty / pending_downgrade)
- `BillingTab` recomposed; `DashboardTab` renders `PinnedBillingWidget`; `advisor-portal/page.tsx` parallel-fetches the summary
- 7 billing-portal tests + 5 widget tests; **793/793 advisor + lib tests pass**

### 5. `feat(advisor-billing): no-lock-in policy + deferred downgrades (PR-B3)`
**Tier C — touches lib/stripe + webhooks + compliance copy.** Replaces immediate-flip downgrades with end-of-cycle deferral. Advisors keep what they paid for, get unused-days proration as portal credit, and can cancel the queued downgrade until the cycle turns over.

- New `pending_tier + pending_tier_effective_at` columns on `professionals` (additive)
- `tier-upgrade/route.ts` downgrade branch: reads active Stripe subscription → `prorateUpgradeCents()` → writes proration credit via `recordLedgerEntry` (kind=`tier_proration_credit`, `expires_at=NULL` — owed money never expires) → stamps `pending_tier` → calls `stripe.subscriptions.update(..., { cancel_at_period_end: true, metadata: { pending_tier, advisor_id } })` → emails confirmation
- New `DELETE /api/advisor-auth/tier-upgrade/pending`: un-cancels the Stripe subscription, claws the proration credit back via an `admin_adjustment` ledger row, clears pending fields
- `customer-subscription` webhook: `handleCustomerSubscriptionDeleted` reads `metadata.pending_tier + advisor_id` and flips `advisor_tier` at cycle end
- New `/billing-policy` public page (RSC, `revalidate=86400`) with `breadcrumbJsonLd` + `AFSL_STATUS_DISCLOSURE`; sitemap entry added
- 8 cancel-pending tests + 2 webhook flip tests + existing tier-upgrade test rewritten for the deferred behaviour

## Tier C confirmation needed

PR-B1, B2, B3 modify `lib/stripe-webhook/handlers/*`, `app/api/admin/*`, billing flows, and add a public AFSL-aware page. Per `docs/audits/MERGE_AUTHORIZATION.md`, these are **Tier C** — please confirm before merge. PR-A1 + PR-F1 are independently shippable (Tier A / B).

## Verification (manual + automated)

- `tsc --noEmit` clean
- `npm run audit:rate-limits -- --strict` → 100% (329 routes covered/exempted)
- Targeted suites green: 12 country-schemes tests, 9 ledger tests, 178 webhook tests, 19 tier-upgrade tests, 7 billing-portal tests, 5 PinnedBillingWidget tests, 23 customer-subscription tests
- Pre-existing `i18n-locales.test.ts` + `i18n-dictionaries.test.ts` failures are unrelated (Arabic locale rollout); confirmed broken on main without these changes

## Backlog tracked but not in this wave (per plan §4)

Auto-topup at low balance, response-time billing reward, firm-level billing, annual-billing prompt, investor profiles. Each gets its own PR scoped from the foundations above.

https://claude.ai/code/session_01TR6JWrXxTv7kWNdSRSSiRe

---
_Generated by [Claude Code](https://claude.ai/code/session_01TR6JWrXxTv7kWNdSRSSiRe)_