### PR TITLE
fix(x): X-09 — swap preview/[token] to createClient; annotate advisor-portal keep-admin

### DIFF
--- a/app/advisor-portal/health/page.tsx
+++ b/app/advisor-portal/health/page.tsx
@@ -1,6 +1,7 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import Link from "next/link";
+// eslint-disable-next-line no-restricted-imports -- X-09 keep-admin: reads `advisor_sessions` (deny-all RLS by design; no anon/auth policy) for cookie-based advisor auth. Same pattern as advisor-portal/upgrade and require-advisor-session.ts.
 import { createAdminClient } from "@/lib/supabase/admin";
 import type { HealthFactor } from "@/lib/advisor-health";
 

--- a/app/advisor-portal/upgrade/page.tsx
+++ b/app/advisor-portal/upgrade/page.tsx
@@ -1,6 +1,7 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import Link from "next/link";
+// eslint-disable-next-line no-restricted-imports -- X-09 keep-admin: reads `advisor_sessions` (deny-all RLS by design; no anon/auth policy) for cookie-based advisor auth. Same pattern as advisor-portal/health and require-advisor-session.ts.
 import { createAdminClient } from "@/lib/supabase/admin";
 import { TIERS, type AdvisorTier } from "@/lib/advisor-tiers";
 import UpgradeClient from "./UpgradeClient";

--- a/app/preview/[token]/page.tsx
+++ b/app/preview/[token]/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { createAdminClient } from "@/lib/supabase/admin";
+import { createClient } from "@/lib/supabase/server";
 import { resolvePreviewToken } from "@/lib/article-preview-tokens";
 
 export const dynamic = "force-dynamic";
@@ -45,7 +45,7 @@ export default async function DraftPreviewPage({ params }: Props) {
   const resolved = await resolvePreviewToken(token);
   if (!resolved) notFound();
 
-  const supabase = createAdminClient();
+  const supabase = await createClient();
   const { data } = await supabase
     .from("articles")
     .select(

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -12087,6 +12087,33 @@ export type Database = {
           },
         ]
       }
+      user_watchlist_items: {
+        Row: {
+          added_at: string
+          display_name: string | null
+          id: number
+          item_slug: string
+          item_type: string
+          user_id: string
+        }
+        Insert: {
+          added_at?: string
+          display_name?: string | null
+          id?: never
+          item_slug: string
+          item_type: string
+          user_id: string
+        }
+        Update: {
+          added_at?: string
+          display_name?: string | null
+          id?: never
+          item_slug?: string
+          item_type?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
       versus_editorials: {
         Row: {
           broker_a_slug: string


### PR DESCRIPTION
## Summary

Final X-stream item. Three files, two patterns:

- **SWAP** `app/preview/[token]/page.tsx` — `createAdminClient` → `createClient` (server). The `articles` table has `CREATE POLICY "Public read articles" ... USING (TRUE)` (001_initial.sql line 185), meaning all rows including drafts are anon-readable. After `resolvePreviewToken` validates the share token, the anon client is sufficient to read the article.
- **KEEP-ADMIN + annotate** `app/advisor-portal/health/page.tsx` and `app/advisor-portal/upgrade/page.tsx` — both read `advisor_sessions` (deny-all RLS by design, no anon/auth SELECT policy) for cookie-based advisor auth. Matches the `lib/require-advisor-session.ts` pattern documented as legitimate in CLAUDE.md. Added `eslint-disable-next-line no-restricted-imports` with rationale so future reviewers see the justification inline.

After this PR merges, every non-admin/non-API `app/` page either uses the anon server client or carries a documented keep-admin annotation. **Stream X is complete.**

## Test plan

- [ ] CI passes
- [ ] `/preview/[valid-token]` still renders the draft article (Vercel preview)
- [ ] `/advisor-portal/health` still works for an authenticated advisor session

Refs: #218
Audit: docs/audits/codebase-health-2026-04-24.md §createAdminClient scope
Queue: X-09

---
_Generated by [Claude Code](https://claude.ai/code/session_01GWinRZSKXNWgDnW4z7Wz8L)_