### PR TITLE
feat(x): X-09 — ratchet no-restricted-imports warn→error for public RSC pages + route handlers [audit remediation]

### DIFF
--- a/app/advisor-portal/health/page.tsx
+++ b/app/advisor-portal/health/page.tsx
@@ -1,6 +1,7 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import Link from "next/link";
+// eslint-disable-next-line no-restricted-imports -- X-09 keep-admin: advisor session cookie validation requires service-role read of advisor_sessions; that table has no anon policy by design
 import { createAdminClient } from "@/lib/supabase/admin";
 import type { HealthFactor } from "@/lib/advisor-health";
 

--- a/app/advisor-portal/upgrade/page.tsx
+++ b/app/advisor-portal/upgrade/page.tsx
@@ -1,6 +1,7 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import Link from "next/link";
+// eslint-disable-next-line no-restricted-imports -- X-09 keep-admin: advisor session cookie validation requires service-role read of advisor_sessions; that table has no anon policy by design
 import { createAdminClient } from "@/lib/supabase/admin";
 import { TIERS, type AdvisorTier } from "@/lib/advisor-tiers";
 import UpgradeClient from "./UpgradeClient";

--- a/app/go/[slug]/route.ts
+++ b/app/go/[slug]/route.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports -- X-09 keep-admin: route reads campaigns (service-role-only SELECT, no anon policy per 20260610120000 migration) for CPC billing and writes affiliate_clicks (anon-writable per 001_initial + 20260309, but same client used for consistency). Server-only redirect+telemetry endpoint.
 import { createAdminClient } from "@/lib/supabase/admin";
 import { NextRequest, NextResponse } from "next/server";
 import { createHash } from "crypto";

--- a/app/preview/[token]/page.tsx
+++ b/app/preview/[token]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
+// eslint-disable-next-line no-restricted-imports -- X-09 keep-admin: token-gated draft preview; service-role enforces draft access regardless of row-level policy state on articles
 import { createAdminClient } from "@/lib/supabase/admin";
 import { resolvePreviewToken } from "@/lib/article-preview-tokens";
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -344,17 +344,17 @@ const eslintConfig = [
     // API / account routes are exempt because they legitimately need
     // elevated access.
     //
-    // Set as "warn" because there is a backlog of ~17 public pages still
-    // importing the admin client (best-for, invest/funds, research,
-    // how-to/transfer-from, advisors/search, etc). Ratchet to "error"
-    // once the backlog is cleared.
-    files: ["app/**/page.tsx", "app/**/layout.tsx"],
+    // Ratcheted to "error" in X-09 (PR #645) after the X-02..X-08 backlog
+    // of ~17 public pages was cleared. The five remaining KEEP-ADMIN files
+    // each carry a per-file eslint-disable-next-line annotation documenting
+    // which exception category applies (see x-admin-backlog-decision-matrix.md).
+    files: ["app/**/page.tsx", "app/**/layout.tsx", "app/**/route.ts"],
     ignores: ["app/admin/**", "app/api/**", "app/account/**"],
     rules: {
-      "no-restricted-imports": ["warn", {
+      "no-restricted-imports": ["error", {
         paths: [{
           name: "@/lib/supabase/admin",
-          message: "createAdminClient bypasses RLS and must not be used in public RSC pages. Use createClient from @/lib/supabase/server instead.",
+          message: "createAdminClient bypasses RLS and must not be used in public RSC pages or route handlers. Use createClient from @/lib/supabase/server instead, or add an eslint-disable-next-line annotation documenting the exception category.",
         }],
       }],
     },


### PR DESCRIPTION
## Summary

Closes the X stream. The X-02..X-08 iterations cleared the backlog of ~17 public pages that were using `createAdminClient()` (service-role bypass-RLS) for anonymous traffic. This PR ratchets the ESLint guardrail from `warn` to `error`, making the antipattern impossible to reintroduce silently.

**Changes:**
- `eslint.config.mjs`: rule `no-restricted-imports` on `app/**/page.tsx` + `app/**/layout.tsx` changed from `"warn"` → `"error"`. Adds `app/**/route.ts` to the file matcher (previously not covered).
- 4 KEEP-ADMIN files annotated with `// eslint-disable-next-line no-restricted-imports -- <justification>`:
  - `app/preview/[token]/page.tsx` — token-gated draft preview; service-role enforces draft access regardless of row-level policy state
  - `app/advisor-portal/health/page.tsx` — advisor session cookie validation against `advisor_sessions` (no anon policy by design)
  - `app/advisor-portal/upgrade/page.tsx` — same advisor_sessions pattern
  - `app/go/[slug]/route.ts` — CPC billing reads `campaigns` (service-role-only SELECT); telemetry-only server endpoint

**Exception source of truth:** `docs/audits/x-admin-backlog-decision-matrix.md`

## ⚠️ Merge order dependency

**Must merge after #641, #643, #644.** Those PRs clear the remaining three files on `main` that currently have unannotated admin imports:
- `app/how-to/transfer-from/page.tsx` + `[broker_slug]/page.tsx` → cleared by #641
- `app/advisors/search/page.tsx` + `app/foreign-investment/siv/page.tsx` → cleared by #643
- `app/go/[slug]/apply/page.tsx` → cleared by #644

Once those merge, all `app/**/page.tsx` and `app/**/route.ts` files (outside `app/admin/**`, `app/api/**`, `app/account/**`) will have either been swapped to `createClient` or carry an explicit annotation. This PR's CI will be **red until then** (expected — the ratchet correctly rejects the 5 files that the predecessor PRs haven't cleared yet).

## Refs

- Tracking issue: #257
- Audit: `docs/audits/codebase-health-2026-04-24.md` §X
- Queue: `docs/audits/REMEDIATION_QUEUE.md` item X-09
- Decision matrix: `docs/audits/x-admin-backlog-decision-matrix.md` §What X-09 needs

---
_Generated by [Claude Code](https://claude.ai/code/session_01EUUri6KCkmQ9AdmmbWyawK)_