### PR TITLE
feat(kk): lead-routing maturity — typed submitLead client + SLA monitoring [audit remediation]

### DIFF
--- a/__tests__/lib/submit-lead-client.test.ts
+++ b/__tests__/lib/submit-lead-client.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { submitLead } from "@/lib/submit-lead-client";
+
+const { mockFetch } = vi.hoisted(() => ({ mockFetch: vi.fn() }));
+
+vi.stubGlobal("fetch", mockFetch);
+
+describe("submitLead", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("POSTs to /api/submit-lead with JSON payload", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ success: true, lead_id: 42, matched: null }),
+    });
+
+    const result = await submitLead({
+      lead_type: "advisor",
+      user_email: "test@example.com",
+      source_page: "/find-advisor",
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/submit-lead",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, { body: string }])[1].body,
+    );
+    expect(body.lead_type).toBe("advisor");
+    expect(body.user_email).toBe("test@example.com");
+    expect(result.lead_id).toBe(42);
+  });
+
+  it("throws when server returns non-2xx", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      json: () => Promise.resolve({ error: "Invalid email" }),
+    });
+
+    await expect(
+      submitLead({
+        lead_type: "advisor",
+        user_email: "bad",
+        source_page: "/find-advisor",
+      }),
+    ).rejects.toThrow("Invalid email");
+  });
+
+  it("throws generic message when error body is unparseable", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      json: () => Promise.reject(new Error("bad JSON")),
+    });
+
+    await expect(
+      submitLead({
+        lead_type: "advisor",
+        user_email: "test@example.com",
+        source_page: "/hub",
+      }),
+    ).rejects.toThrow("Lead submission failed");
+  });
+
+  it("passes dry_run and exclude_advisor_ids through", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ matched: { id: 7 } }),
+    });
+
+    await submitLead({
+      lead_type: "advisor",
+      user_email: "u@x.com",
+      source_page: "/find-advisor",
+      dry_run: true,
+      exclude_advisor_ids: [1, 2],
+    });
+
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, { body: string }])[1].body,
+    );
+    expect(body.dry_run).toBe(true);
+    expect(body.exclude_advisor_ids).toEqual([1, 2]);
+  });
+});

--- a/app/find-advisor/page.tsx
+++ b/app/find-advisor/page.tsx
@@ -11,6 +11,7 @@ import { Select } from "@/components/ui/Select";
 import { Card } from "@/components/ui/Card";
 import Icon from "@/components/Icon";
 import { trackEvent } from "@/lib/tracking";
+import { submitLead } from "@/lib/submit-lead-client";
 
 // ─── Types ─────────────────────────────────────────────────────────────────
 
@@ -373,57 +374,43 @@ function FindAdvisorQuiz() {
 
   /** Find a matching advisor WITHOUT creating a lead or sending any emails (dry run). */
   const findMatch = async (excludeList: number[] = []) => {
-    const res = await fetch("/api/submit-lead", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        lead_type: "advisor",
-        user_email: quiz.email.trim(),
-        user_name: quiz.firstName.trim(),
-        user_phone: quiz.phone.trim() || undefined,
-        user_location_state: quiz.state,
-        user_postcode: quiz.postcode || undefined,
-        user_suburb: quiz.suburb || undefined,
-        user_intent: {
-          need: intentToNeed(quiz.intent!),
-          context: quiz.context,
-          budget: quiz.budget,
-        },
-        source_page: "/find-advisor",
-        exclude_advisor_ids: excludeList,
-        dry_run: true,
-      }),
+    return submitLead({
+      lead_type: "advisor",
+      user_email: quiz.email.trim(),
+      user_name: quiz.firstName.trim(),
+      user_phone: quiz.phone.trim() || undefined,
+      user_location_state: quiz.state,
+      user_postcode: quiz.postcode || undefined,
+      user_suburb: quiz.suburb || undefined,
+      user_intent: {
+        need: intentToNeed(quiz.intent!),
+        context: quiz.context,
+        budget: quiz.budget,
+      },
+      source_page: "/find-advisor",
+      exclude_advisor_ids: excludeList,
+      dry_run: true,
     });
-    const data = await res.json();
-    if (!res.ok) throw new Error(data.error || "Something went wrong.");
-    return data;
   };
 
   /** Confirm a previewed advisor: creates the lead and sends advisor email. */
   const confirmMatch = async (advisorId: number) => {
-    const res = await fetch("/api/submit-lead", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        lead_type: "advisor",
-        user_email: quiz.email.trim(),
-        user_name: quiz.firstName.trim(),
-        user_phone: quiz.phone.trim() || undefined,
-        user_location_state: quiz.state,
-        user_postcode: quiz.postcode || undefined,
-        user_suburb: quiz.suburb || undefined,
-        user_intent: {
-          need: intentToNeed(quiz.intent!),
-          context: quiz.context,
-          budget: quiz.budget,
-        },
-        source_page: "/find-advisor",
-        confirm_advisor_id: advisorId,
-      }),
+    return submitLead({
+      lead_type: "advisor",
+      user_email: quiz.email.trim(),
+      user_name: quiz.firstName.trim(),
+      user_phone: quiz.phone.trim() || undefined,
+      user_location_state: quiz.state,
+      user_postcode: quiz.postcode || undefined,
+      user_suburb: quiz.suburb || undefined,
+      user_intent: {
+        need: intentToNeed(quiz.intent!),
+        context: quiz.context,
+        budget: quiz.budget,
+      },
+      source_page: "/find-advisor",
+      confirm_advisor_id: advisorId,
     });
-    const data = await res.json();
-    if (!res.ok) throw new Error(data.error || "Something went wrong.");
-    return data;
   };
 
   const validateStep4 = () => {

--- a/components/leads/HubLeadForm.tsx
+++ b/components/leads/HubLeadForm.tsx
@@ -3,6 +3,7 @@
 import { useState, type FormEvent, type ReactNode } from "react";
 import Icon from "@/components/Icon";
 import { isValidEmailClient, isDisposableEmail } from "@/lib/validate-email";
+import { submitLead } from "@/lib/submit-lead-client";
 
 type Intent = {
   need: string;
@@ -61,6 +62,13 @@ export default function HubLeadForm({
       return;
     }
 
+    // Honeypot: the hidden "website" field is never filled by real users.
+    // Bots that auto-fill all inputs will populate it — silent rejection.
+    if (String(fd.get("website") || "")) {
+      setDone(true);
+      return;
+    }
+
     setSubmitting(true);
 
     // Domain-specific extras get appended to source_page so the
@@ -74,29 +82,18 @@ export default function HubLeadForm({
     const sourcePage = extras.length ? `${source}|${extras.join("|")}` : source;
 
     try {
-      const res = await fetch("/api/submit-lead", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          lead_type: "advisor",
-          user_email: email,
-          user_name: name || undefined,
-          user_phone: phone || undefined,
-          user_location_state: state || undefined,
-          user_intent: intent,
-          source_page: sourcePage,
-          website: String(fd.get("website") || ""),
-        }),
+      await submitLead({
+        lead_type: "advisor",
+        user_email: email,
+        user_name: name || undefined,
+        user_phone: phone || undefined,
+        user_location_state: state || undefined,
+        user_intent: intent,
+        source_page: sourcePage,
       });
-      const json = await res.json();
-      if (!res.ok) {
-        setError(json?.error || "Something went wrong. Please try again.");
-        setSubmitting(false);
-        return;
-      }
       setDone(true);
-    } catch {
-      setError("Network error. Please try again.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong. Please try again.");
       setSubmitting(false);
     }
   }

--- a/lib/submit-lead-client.ts
+++ b/lib/submit-lead-client.ts
@@ -1,0 +1,66 @@
+/**
+ * Typed client for /api/submit-lead.
+ *
+ * KK-01: replaces the three raw `fetch("/api/submit-lead", ...)` calls
+ * scattered across find-advisor/page.tsx and HubLeadForm.tsx with a
+ * single typed wrapper. Source variant is captured in `source_page` and
+ * flows through to PostHog analytics and the leads table.
+ *
+ * The `website` honeypot field is excluded from the public type so callers
+ * cannot accidentally populate it and trigger the bot-rejection path.
+ */
+
+export interface SubmitLeadIntent {
+  need?: string;
+  context?: string[];
+  budget?: string;
+}
+
+export interface SubmitLeadPayload {
+  lead_type: "advisor" | "platform";
+  user_email: string;
+  user_name?: string;
+  user_phone?: string;
+  user_location_state?: string;
+  /** Passed through to the DB even though the API does not currently use it. */
+  user_postcode?: string;
+  user_suburb?: string;
+  user_intent?: SubmitLeadIntent;
+  professional_id?: number;
+  broker_slug?: string;
+  /** Free-form source tag: page path plus any hub extras, e.g. "/find-advisor" or "hub-super|goal=retire". */
+  source_page: string;
+  exclude_advisor_ids?: number[];
+  rematch?: boolean;
+  prev_lead_ids?: number[];
+  /** When true: run matching + return advisor but skip all DB writes and emails. */
+  dry_run?: boolean;
+  /** Skip matching, create lead directly for this advisor. */
+  confirm_advisor_id?: number;
+}
+
+export interface SubmitLeadResult {
+  success?: boolean;
+  lead_id?: number | null;
+  matched?: unknown | null;
+  error?: string;
+}
+
+/**
+ * Submit a lead via the /api/submit-lead route.
+ *
+ * Throws if the server returns a non-2xx status (with `error` from the
+ * response body as the message). Callers own the try/catch and UX.
+ */
+export async function submitLead(
+  payload: SubmitLeadPayload,
+): Promise<SubmitLeadResult> {
+  const res = await fetch("/api/submit-lead", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  const json: SubmitLeadResult = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(json.error ?? "Lead submission failed");
+  return json;
+}

--- a/lib/submit-lead-client.ts
+++ b/lib/submit-lead-client.ts
@@ -43,6 +43,7 @@ export interface SubmitLeadResult {
   success?: boolean;
   lead_id?: number | null;
   matched?: unknown | null;
+  no_more_matches?: boolean;
   error?: string;
 }
 


### PR DESCRIPTION
## Stream KK — Lead-routing maturity

### Progress

- [x] **KK-01** — Typed `submitLead()` client wrapper: `lib/submit-lead-client.ts` + migrate 3 raw fetch callers (commit `4e431a5`)
- [ ] **KK-02** — Queue health alert (no leads for N hours during business hours)
- [ ] **KK-03** — Advisor response-time tracking (per-advisor mean TTFR in portal)
- [ ] **KK-04** — Conversion analytics per source (PostHog funnel `lead_submit:<source>` → outcome)
- [ ] **KK-05** — ESLint rule banning raw `fetch("/api/submit-lead")` calls

### What's in this PR

**KK-01** (`4e431a5`): Creates `lib/submit-lead-client.ts` with typed `SubmitLeadPayload` interface and `submitLead()` wrapper. Migrates all 3 raw `fetch("/api/submit-lead", ...)` callers in `find-advisor/page.tsx` (×2) and `HubLeadForm.tsx` (×1) to use the typed function. Honeypot check moved client-side in `HubLeadForm` since the typed wrapper correctly excludes the `website` field.

Already implemented (not KK work):
- **SLA monitoring** — `app/api/cron/lead-sla-check/route.ts` (10-min cron, tier-based hot/warm/cold windows, Resend alert email)
- **SLA enforcement** — `app/api/cron/enforce-lead-sla/route.ts` (daily auto-pause advisors with 7+ unresponded leads)

### Refs

Audit: `docs/audits/ENTERPRISE_STANDARD.md § Lead form surface`
Queue: `docs/audits/REMEDIATION_QUEUE.md § Stream KK`

---
_Generated by [Claude Code](https://claude.ai/code/session_01ERubUYLDYAMPmwZDJSftS7)_