### PR TITLE
fix(db): regenerate database.types.ts — add archived_at to feature_flags

### DIFF
--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -6149,6 +6149,7 @@ export type Database = {
       feature_flags: {
         Row: {
           allowlist: string[]
+          archived_at: string | null
           created_at: string
           denylist: string[]
           description: string | null
@@ -6162,6 +6163,7 @@ export type Database = {
         }
         Insert: {
           allowlist?: string[]
+          archived_at?: string | null
           created_at?: string
           denylist?: string[]
           description?: string | null
@@ -6175,6 +6177,7 @@ export type Database = {
         }
         Update: {
           allowlist?: string[]
+          archived_at?: string | null
           created_at?: string
           denylist?: string[]
           description?: string | null


### PR DESCRIPTION
## Supabase types drift fix

Fixes the `Supabase types drift` CI check failing on PR #667 (KK-01) and any other in-flight PRs opened after the FF stream migration landed.

### Root cause

The FF stream (`#656`) added an `archived_at` column to the `feature_flags` table in its migration. `lib/database.types.ts` was not regenerated at the time, so the live Supabase schema had `archived_at` but the generated types file did not — causing the drift check to fail.

### Change

3 lines added to `lib/database.types.ts`: `archived_at: string | null` in the `feature_flags` Row, Insert, and Update types. Regenerated via Supabase MCP `generate_typescript_types` against the live project `guggzyqceattncjwvgyc`.

### Impact

Once merged, the `Supabase types drift` check should pass on all open PRs that were failing due to this drift.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3JR3a2isu6NW3tvzSEJot)_