### PR TITLE
feat(cc): CC-02 — per-country supply thresholds, NZ experts=1 [audit remediation]

### DIFF
--- a/__tests__/lib/country-mode/supply-thresholds.test.ts
+++ b/__tests__/lib/country-mode/supply-thresholds.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   applySupplyThresholds,
   SUPPLY_THRESHOLDS,
+  PER_COUNTRY_THRESHOLDS,
 } from "@/lib/country-mode";
 
 describe("SUPPLY_THRESHOLDS", () => {
@@ -75,5 +76,64 @@ describe("applySupplyThresholds", () => {
     const result = applySupplyThresholds(oneShyOfPlatforms, "platforms");
     expect(result.rows).toEqual([]);
     expect(result.didFallback).toBe(true);
+  });
+});
+
+describe("PER_COUNTRY_THRESHOLDS", () => {
+  it("has NZ experts threshold lower than the global default", () => {
+    expect(PER_COUNTRY_THRESHOLDS["NZ"]?.experts).toBe(1);
+    expect((PER_COUNTRY_THRESHOLDS["NZ"]?.experts ?? 0) < SUPPLY_THRESHOLDS.experts).toBe(true);
+  });
+});
+
+describe("applySupplyThresholds — per-country overrides", () => {
+  it("NZ experts: one expert passes (below global threshold of 2)", () => {
+    expect(applySupplyThresholds(["nz-expert-1"], "experts", "NZ")).toEqual({
+      rows: ["nz-expert-1"],
+      didFallback: false,
+    });
+  });
+
+  it("NZ experts: zero experts still falls back", () => {
+    expect(applySupplyThresholds([], "experts", "NZ")).toEqual({
+      rows: [],
+      didFallback: true,
+    });
+  });
+
+  it("non-NZ country still uses global experts threshold", () => {
+    // AU: one expert is below global threshold of 2
+    expect(applySupplyThresholds(["au-expert-1"], "experts", "AU")).toEqual({
+      rows: [],
+      didFallback: true,
+    });
+    // AU: two experts passes
+    expect(applySupplyThresholds(["au-1", "au-2"], "experts", "AU")).toEqual({
+      rows: ["au-1", "au-2"],
+      didFallback: false,
+    });
+  });
+
+  it("no countryCode falls back to global threshold", () => {
+    expect(applySupplyThresholds(["x"], "experts")).toEqual({
+      rows: [],
+      didFallback: true,
+    });
+    expect(applySupplyThresholds(["x"], "experts", null)).toEqual({
+      rows: [],
+      didFallback: true,
+    });
+  });
+
+  it("NZ listings and platforms use global thresholds (no NZ override)", () => {
+    // NZ only overrides experts; listings/platforms use global
+    expect(applySupplyThresholds(["a"], "listings", "NZ")).toEqual({
+      rows: [],
+      didFallback: true,
+    });
+    expect(applySupplyThresholds(["a", "b"], "listings", "NZ")).toEqual({
+      rows: ["a", "b"],
+      didFallback: false,
+    });
   });
 });

--- a/components/country-mode/CountryComparePreview.tsx
+++ b/components/country-mode/CountryComparePreview.tsx
@@ -55,7 +55,7 @@ export default async function CountryComparePreview() {
 
   const rows: PreviewBroker[] = (data ?? []) as PreviewBroker[];
 
-  const result = applySupplyThresholds(rows, "platforms");
+  const result = applySupplyThresholds(rows, "platforms", code);
   if (result.didFallback) return null;
 
   const meta = intentCountryMeta(code);

--- a/components/country-mode/CountryExpertsPreview.tsx
+++ b/components/country-mode/CountryExpertsPreview.tsx
@@ -56,7 +56,7 @@ export default async function CountryExpertsPreview() {
     photo_url: r.photo_url,
   }));
 
-  const result = applySupplyThresholds(rows, "experts");
+  const result = applySupplyThresholds(rows, "experts", code);
   if (result.didFallback) return null;
 
   const meta = intentCountryMeta(code);

--- a/components/country-mode/CountryListingsPreview.tsx
+++ b/components/country-mode/CountryListingsPreview.tsx
@@ -63,7 +63,7 @@ export default async function CountryListingsPreview() {
       Array.isArray(r.images) && r.images.length > 0 ? (r.images[0] as string) : null,
   }));
 
-  const result = applySupplyThresholds(rows, "listings");
+  const result = applySupplyThresholds(rows, "listings", code);
   if (result.didFallback) return null;
 
   const meta = intentCountryMeta(code);

--- a/lib/country-mode/index.ts
+++ b/lib/country-mode/index.ts
@@ -24,6 +24,7 @@ export {
 export {
   applySupplyThresholds,
   SUPPLY_THRESHOLDS,
+  PER_COUNTRY_THRESHOLDS,
   type SupplyKind,
   type SupplyResult,
 } from "./supply-thresholds";

--- a/lib/country-mode/supply-thresholds.ts
+++ b/lib/country-mode/supply-thresholds.ts
@@ -23,6 +23,20 @@ export const SUPPLY_THRESHOLDS = {
 
 export type SupplyKind = keyof typeof SUPPLY_THRESHOLDS;
 
+/**
+ * Per-country overrides for supply thresholds. Only populated where a
+ * country's market size justifies a lower bar than the global default.
+ *
+ * NZ experts: 1 instead of 2. The NZ advisor market is legitimately
+ * smaller — one qualified NZ-focused expert is enough to surface a
+ * real recommendation rather than hiding the strip entirely.
+ */
+export const PER_COUNTRY_THRESHOLDS: Partial<
+  Record<string, Partial<Record<SupplyKind, number>>>
+> = {
+  NZ: { experts: 1 },
+};
+
 export interface SupplyResult<T> {
   /** Rows the caller should render. Empty when below threshold. */
   rows: ReadonlyArray<T>;
@@ -50,8 +64,10 @@ export interface SupplyResult<T> {
 export function applySupplyThresholds<T>(
   rows: ReadonlyArray<T>,
   kind: SupplyKind,
+  countryCode?: string | null,
 ): SupplyResult<T> {
-  const threshold = SUPPLY_THRESHOLDS[kind];
+  const perCountry = countryCode ? PER_COUNTRY_THRESHOLDS[countryCode] : undefined;
+  const threshold = perCountry?.[kind] ?? SUPPLY_THRESHOLDS[kind];
   if (rows.length < threshold) {
     return { rows: [], didFallback: true };
   }


### PR DESCRIPTION
## CC-02: Per-country supply thresholds — NZ experts threshold lowered to 1

Audit ref: `docs/audits/codebase-health-2026-04-24.md §CC`
Tracking issue: #218
Queue: `docs/audits/REMEDIATION_QUEUE.md`
Follows: PR #667 (CC-01 audit)

### Problem

`SUPPLY_THRESHOLDS` was global-only (`experts: 2` for all countries). The NZ expert filter uses a narrow specialty set (`smsf_accountant`, `financial_planner`, `tax_agent`, `property_advisor`) — appropriate for the NZ market but much harder to match than AU. With the global threshold of 2, the NZ experts homepage strip silently hides whenever fewer than 2 NZ-matching advisors are active, even when one well-matched advisor is available. One is enough to show a meaningful recommendation.

### Changes

- **`lib/country-mode/supply-thresholds.ts`** — Added `PER_COUNTRY_THRESHOLDS` map (`NZ: { experts: 1 }`). Updated `applySupplyThresholds()` to accept optional `countryCode`; per-country override takes precedence over global.
- **`lib/country-mode/index.ts`** — exports `PER_COUNTRY_THRESHOLDS`.
- **`CountryExpertsPreview`, `CountryListingsPreview`, `CountryComparePreview`** — each now passes `code` (already in scope from `getIntentCountry()`) as the third argument.
- **`__tests__/lib/country-mode/supply-thresholds.test.ts`** — 6 new test cases.

### Verification

- All 3 preview components already had `code` in scope — one-arg change each.
- NZ listings + platforms continue to use global thresholds (no override needed — NZ has broader listing verticals + `nonResidentsOnly: false` for platforms).
- Non-NZ countries unaffected; backward-compatible signature (third arg optional).
- No DB changes, no migration.

### Checklist

- [x] CC-02: `PER_COUNTRY_THRESHOLDS` added
- [x] CC-02: NZ experts threshold set to 1
- [x] CC-02: All 3 preview components wired
- [x] CC-02: 6 new tests
- [x] Queue updated (CC-02 done)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3JR3a2isu6NW3tvzSEJot)_