### PR TITLE
chore(db): regenerate database.types.ts — add feature_flags.archived_at

### DIFF
--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -6149,6 +6149,7 @@ export type Database = {
       feature_flags: {
         Row: {
           allowlist: string[]
+          archived_at: string | null
           created_at: string
           denylist: string[]
           description: string | null
@@ -6162,6 +6163,7 @@ export type Database = {
         }
         Insert: {
           allowlist?: string[]
+          archived_at?: string | null
           created_at?: string
           denylist?: string[]
           description?: string | null
@@ -6175,6 +6177,7 @@ export type Database = {
         }
         Update: {
           allowlist?: string[]
+          archived_at?: string | null
           created_at?: string
           denylist?: string[]
           description?: string | null


### PR DESCRIPTION
## Summary

- Adds `archived_at: string | null` to `feature_flags` Row/Insert/Update in `lib/database.types.ts`
- FF-04 migration added this column to the live Supabase schema; types on main were not updated
- This unblocks `Supabase types drift` CI gate on #641 (X-06) and #640 (R M2-B)

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, rebase #641 and #640 on updated main → types drift gate passes

Phase 1.5 auto-rescue. Generated via `mcp__Supabase__generate_typescript_types`.

Refs: #215

---
_Generated by [Claude Code](https://claude.ai/code/session_011d7vU3g6kQ9AVfh2fgvAfh)_