### PR TITLE
fix(country-mode): rename "View global" → "Back to Australia"

### DIFF
--- a/__tests__/components/CountryModeBanner.test.tsx
+++ b/__tests__/components/CountryModeBanner.test.tsx
@@ -31,7 +31,7 @@ describe("CountryModeBanner", () => {
     expect(screen.getByText(/HK investors/i)).toBeInTheDocument();
     // Both escape hatches present
     expect(screen.getByRole("button", { name: /switch country/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /view global/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /back to australia/i })).toBeInTheDocument();
   });
 
   it("'Switch country' dispatches the open-selector custom event", async () => {
@@ -46,11 +46,11 @@ describe("CountryModeBanner", () => {
     window.removeEventListener("country-mode:open-selector", listener);
   });
 
-  it("'View global' button is a form submit (calls clearIntentCountryAction server action)", async () => {
+  it("'Back to Australia' button is a form submit (calls clearIntentCountryAction server action)", async () => {
     mockGetIntentCountry.mockResolvedValue("sa");
     const ui = await CountryModeBanner();
     render(<>{ui}</>);
-    const button = screen.getByRole("button", { name: /view global/i });
+    const button = screen.getByRole("button", { name: /back to australia/i });
     expect(button).toHaveAttribute("type", "submit");
     // The server action wiring is exercised at the framework level — the
     // contract here is just "this is a form submit, the action prop on

--- a/__tests__/components/LocationFlagButton.test.tsx
+++ b/__tests__/components/LocationFlagButton.test.tsx
@@ -109,11 +109,11 @@ describe("LocationFlagButton", () => {
     });
   });
 
-  describe("'Show me the global view' clears cookie + resets localStorage", () => {
+  describe("'Switch to Australia' clears cookie + resets localStorage", () => {
     it("calls clearIntentCountryAction and stores AU in localStorage", async () => {
       const user = userEvent.setup();
       // Start with HK as the active country so the popover renders the
-      // "Viewing as" branch with the global-reset button.
+      // "Viewing as" branch with the AU-reset button.
       localStorage.setItem("iv-location-flag-override", "HK");
       render(<LocationFlagButton />);
 
@@ -124,7 +124,7 @@ describe("LocationFlagButton", () => {
       );
 
       const resetButton = await screen.findByRole("button", {
-        name: /show me the global view/i,
+        name: /switch to australia/i,
       });
       await user.click(resetButton);
 

--- a/components/country-mode/CountryModeBanner.tsx
+++ b/components/country-mode/CountryModeBanner.tsx
@@ -39,7 +39,7 @@ export default async function CountryModeBanner() {
               type="submit"
               className="text-slate-600 hover:text-slate-900 underline underline-offset-2"
             >
-              View global
+              Back to Australia <span aria-hidden>🇦🇺</span>
             </button>
           </form>
         </div>

--- a/components/layout/LocationFlagButton.tsx
+++ b/components/layout/LocationFlagButton.tsx
@@ -337,7 +337,7 @@ export default function LocationFlagButton() {
                   }}
                   className="block w-full text-center text-sm font-medium text-slate-700 hover:text-slate-900 hover:bg-slate-50 border border-slate-200 rounded-xl px-3 py-2 mt-3 transition-colors"
                 >
-                  Show me the global view
+                  Switch to Australia <span aria-hidden>🇦🇺</span>
                 </button>
               </>
             ) : (


### PR DESCRIPTION
## Summary
For AU users (the default audience), the cookie-clear button labels **"View global"** and **"Show me the global view"** describe the *technical state* ("no country filter") rather than the *actual outcome* ("you'll land on the standard Aussie site").

Aussies who set 🇨🇳 China by mistake (or visited from a non-AU geo) and want to reset have to mentally translate "global = AU default" before clicking — friction that 100% of the audience hits.

## Changes
- `components/country-mode/CountryModeBanner.tsx`: `View global` → `Back to Australia 🇦🇺`
- `components/layout/LocationFlagButton.tsx`: `Show me the global view` → `Switch to Australia 🇦🇺`
- Two corresponding test assertions updated.

## Why "Back to Australia" not "Domestic"
- For AU users (~95% of audience): "Australia" is unambiguous and matches what they actually see
- For non-AU users: "Australia" tells them exactly what site they're switching to (the AU-default invest.com.au), without abstract "global" jargon
- "Domestic" would be wrong because for non-AU users, AU isn't *their* domestic

## Test plan
- [x] LocationFlagButton.test.tsx: 14/14 ✓ (assertion updated for "switch to australia")
- [x] CountryModeBanner.test.tsx: 4/4 ✓ (assertion updated for "back to australia")
- [ ] Visual: visit homepage with iv_intent_country=hk cookie → banner shows "Back to Australia 🇦🇺" → click returns to AU default
- [ ] Visual: tap location flag while on a non-AU override → popover shows "Switch to Australia 🇦🇺"

🤖 Generated with [Claude Code](https://claude.com/claude-code)