### PR TITLE
feat(advisor-portal): annual-billing prompt on dashboard (PR-X4)

### DIFF
--- a/__tests__/components/AnnualBillingPrompt.test.tsx
+++ b/__tests__/components/AnnualBillingPrompt.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "../components/setup";
+import AnnualBillingPrompt from "@/app/advisor-portal/billing/AnnualBillingPrompt";
+
+describe("AnnualBillingPrompt", () => {
+  it("renders nothing for free tier", () => {
+    const { container } = render(<AnnualBillingPrompt advisorTier="free" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing for launch tier", () => {
+    const { container } = render(<AnnualBillingPrompt advisorTier="launch" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing for null tier", () => {
+    const { container } = render(<AnnualBillingPrompt advisorTier={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing for an unknown tier id", () => {
+    const { container } = render(<AnnualBillingPrompt advisorTier="legacy_pro_v0" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the prompt for Growth tier with correct savings", () => {
+    render(<AnnualBillingPrompt advisorTier="growth" />);
+    // Growth: $49/mo × 12 = $588/yr; annual $470 → save $118/yr (≈2 months free)
+    expect(screen.getByText(/Switch to annual on Growth/i)).toBeInTheDocument();
+    expect(screen.getByText(/save \$118\/yr/i)).toBeInTheDocument();
+    expect(screen.getByText(/2 months free/i)).toBeInTheDocument();
+  });
+
+  it("renders the prompt for Pro tier with correct savings", () => {
+    render(<AnnualBillingPrompt advisorTier="pro" />);
+    // Pro: $149/mo × 12 = $1788/yr; annual $1430 → save $358/yr (≈2 months free)
+    expect(screen.getByText(/Switch to annual on Pro/i)).toBeInTheDocument();
+    expect(screen.getByText(/save \$358\/yr/i)).toBeInTheDocument();
+  });
+
+  it("renders the prompt for Elite tier with correct savings", () => {
+    render(<AnnualBillingPrompt advisorTier="elite" />);
+    // Elite: $499/mo × 12 = $5988/yr; annual $4790 → save $1198/yr
+    expect(screen.getByText(/Switch to annual on Elite/i)).toBeInTheDocument();
+    expect(screen.getByText(/save \$1198\/yr/i)).toBeInTheDocument();
+  });
+
+  it("CTA links to /advisor-portal/upgrade (where annual is pre-selected)", () => {
+    render(<AnnualBillingPrompt advisorTier="growth" />);
+    const cta = screen.getByTestId("annual-billing-prompt-cta");
+    expect(cta).toHaveAttribute("href", "/advisor-portal/upgrade");
+    expect(cta).toHaveTextContent(/Switch to annual/i);
+  });
+});

--- a/app/advisor-portal/DashboardTab.tsx
+++ b/app/advisor-portal/DashboardTab.tsx
@@ -7,6 +7,7 @@ import { PROFESSIONAL_TYPE_LABELS } from "@/lib/types";
 import type { Advisor, Stats, Lead, ProfileCompleteness, Review, ViewDay, WeeklyEnquiry, ViewType } from "./types";
 import type { BillingSummary } from "./billing/types";
 import PinnedBillingWidget from "./billing/PinnedBillingWidget";
+import AnnualBillingPrompt from "./billing/AnnualBillingPrompt";
 
 type Props = {
   advisor: Advisor | null;
@@ -92,6 +93,9 @@ export default function DashboardTab({
           </button>
         </div>
       )}
+
+      {/* Annual-billing nudge for paid-tier advisors — PR-X4 */}
+      <AnnualBillingPrompt advisorTier={advisor?.advisor_tier ?? null} />
 
       {/* Unified billing widget — replaces the prior credit banner */}
       {billingSummary

--- a/app/advisor-portal/billing/AnnualBillingPrompt.tsx
+++ b/app/advisor-portal/billing/AnnualBillingPrompt.tsx
@@ -1,0 +1,51 @@
+/**
+ * AnnualBillingPrompt — dashboard nudge to switch from monthly to annual.
+ *
+ * Pre-launch wave PR-X4. Renders a small banner above the PinnedBillingWidget
+ * for paid-tier advisors (Growth / Pro / Elite). Click → upgrade flow with
+ * annual already selected (UpgradeClient defaults to annual).
+ *
+ * Hidden for free / launch tiers (no annual option for free).
+ */
+
+import Link from "next/link";
+import { getTier, type AdvisorTier } from "@/lib/advisor-tiers";
+
+interface Props {
+  advisorTier: AdvisorTier | string | null;
+}
+
+export default function AnnualBillingPrompt({ advisorTier }: Props) {
+  if (!advisorTier || advisorTier === "free" || advisorTier === "launch") return null;
+
+  const tier = getTier(advisorTier);
+  if (!tier || tier.monthlyPriceCents === 0) return null;
+
+  // Savings = (12 × monthly) − annual; expressed in dollars.
+  const annualEquivOfMonthly = tier.monthlyPriceCents * 12;
+  const savingsCents = annualEquivOfMonthly - tier.annualPriceCents;
+  if (savingsCents <= 0) return null;
+
+  const savingsDollars = Math.round(savingsCents / 100);
+  const monthsFree = Math.round(savingsCents / tier.monthlyPriceCents);
+
+  return (
+    <div
+      className="rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 mb-4 flex flex-wrap items-center justify-between gap-x-4 gap-y-2"
+      role="region"
+      aria-label="Annual billing offer"
+    >
+      <p className="text-sm text-emerald-900 leading-snug">
+        <strong>Switch to annual on {tier.label} and save ${savingsDollars}/yr</strong>
+        {" "}— that&rsquo;s {monthsFree} {monthsFree === 1 ? "month" : "months"} free.
+      </p>
+      <Link
+        href="/advisor-portal/upgrade"
+        className="inline-flex items-center gap-1.5 text-sm font-bold text-emerald-700 hover:text-emerald-900 underline underline-offset-2"
+        data-testid="annual-billing-prompt-cta"
+      >
+        Switch to annual <span aria-hidden>→</span>
+      </Link>
+    </div>
+  );
+}

--- a/app/advisor-portal/types.ts
+++ b/app/advisor-portal/types.ts
@@ -21,6 +21,7 @@ export type Advisor = {
   free_leads_used?: number; lead_price_cents?: number;
   credit_balance_cents?: number; lifetime_credit_cents?: number; lifetime_lead_spend_cents?: number;
   featured_until?: string;
+  advisor_tier?: string | null;
 };
 
 export type FirmMember = { id: number; name: string; slug: string; email?: string; type: string; photo_url?: string; verified?: boolean; status?: string; created_at: string; role?: string; is_firm_admin?: boolean };


### PR DESCRIPTION
## Summary
PR-X4 from `~/.claude/plans/sleepy-growing-planet.md` §4.4 — dashboard nudge for paid-tier advisors to switch monthly → annual billing.

Renders a small banner above PinnedBillingWidget on the advisor dashboard for paid-tier advisors (Growth / Pro / Elite). Click → `/advisor-portal/upgrade` where annual is already pre-selected by default in `UpgradeClient`.

Hidden for free / launch tiers (no annual option). Hidden when the selected tier id doesn't resolve in the TIERS catalogue (defensive fallback for legacy or unknown tier strings).

## Savings calculation
Pulled from `lib/advisor-tiers.ts` so a future price change flows through automatically:

| Tier | Save / yr | ≈ Months free |
|---|---|---|
| Growth | $118 | 2 |
| Pro | $358 | 2 |
| Elite | $1,198 | 2 |

## Tier classification
**Tier B** per `docs/audits/MERGE_AUTHORIZATION.md` — additive UI + display logic; reuses existing `UpgradeClient` annual-default + the existing `tier-upgrade` API surface that already accepts `billing: 'annual'`. No DB schema, no migrations, no Stripe webhook changes.

## Test plan
- [x] AnnualBillingPrompt.test.tsx: 8 tests (free/launch/null/unknown tiers hidden; growth/pro/elite render correct savings; CTA link target)
- [x] Local `npx vitest run __tests__/components/AnnualBillingPrompt.test.tsx` → 8/8 ✓
- [ ] CI: type-check + full test suite
- [ ] Visual: dashboard view as a Pro advisor → see banner above billing widget; click → land on /advisor-portal/upgrade with annual selected

## Files
- `app/advisor-portal/billing/AnnualBillingPrompt.tsx` (new, ~50 lines)
- `app/advisor-portal/DashboardTab.tsx` (mount above PinnedBillingWidget)
- `app/advisor-portal/types.ts` (`Advisor.advisor_tier` opt prop)
- `__tests__/components/AnnualBillingPrompt.test.tsx` (8 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code) — pre-launch-wave loop iter 2