### PR TITLE
feat(country-mode): country-eligibility filter on /best/[slug] (queue #3)

### DIFF
--- a/__tests__/lib/country-mode/eligibility-filter.test.ts
+++ b/__tests__/lib/country-mode/eligibility-filter.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from "vitest";
+import {
+  isEligibleForCountry,
+  filterByCountryEligibility,
+  requiresVisaForCountry,
+} from "@/lib/country-mode/eligibility-filter";
+
+describe("isEligibleForCountry", () => {
+  it("includes when intent country is null (no filter)", () => {
+    expect(isEligibleForCountry({ country_eligibility: { blocked_countries: ["GB"] } }, null)).toBe(true);
+  });
+
+  it("includes when country_eligibility is undefined", () => {
+    expect(isEligibleForCountry({}, "uk")).toBe(true);
+  });
+
+  it("includes when country_eligibility is empty object", () => {
+    expect(isEligibleForCountry({ country_eligibility: {} }, "uk")).toBe(true);
+  });
+
+  it("includes when country_eligibility is null", () => {
+    expect(isEligibleForCountry({ country_eligibility: null }, "uk")).toBe(true);
+  });
+
+  it("EXCLUDES when blocked_countries includes visitor ISO", () => {
+    expect(
+      isEligibleForCountry({ country_eligibility: { blocked_countries: ["GB", "US"] } }, "uk"),
+    ).toBe(false);
+  });
+
+  it("EXCLUDES with case-insensitive ISO match in blocked", () => {
+    expect(
+      isEligibleForCountry({ country_eligibility: { blocked_countries: ["gb"] } }, "uk"),
+    ).toBe(false);
+  });
+
+  it("EXCLUDES when allowed_countries set and visitor ISO not in it", () => {
+    expect(
+      isEligibleForCountry(
+        { country_eligibility: { allowed_countries: ["HK", "SG"] } },
+        "uk",
+      ),
+    ).toBe(false);
+  });
+
+  it("includes when allowed_countries set and visitor ISO IS in it", () => {
+    expect(
+      isEligibleForCountry(
+        { country_eligibility: { allowed_countries: ["GB", "HK", "SG"] } },
+        "uk",
+      ),
+    ).toBe(true);
+  });
+
+  it("includes when allowed_countries is empty array (treats as 'no opinion')", () => {
+    expect(
+      isEligibleForCountry({ country_eligibility: { allowed_countries: [] } }, "uk"),
+    ).toBe(true);
+  });
+
+  it("blocked beats allowed (defense in depth)", () => {
+    expect(
+      isEligibleForCountry(
+        {
+          country_eligibility: {
+            allowed_countries: ["GB", "HK"],
+            blocked_countries: ["GB"],
+          },
+        },
+        "uk",
+      ),
+    ).toBe(false);
+  });
+
+  it("visa_required does NOT exclude (informational only)", () => {
+    expect(
+      isEligibleForCountry({ country_eligibility: { visa_required: ["GB"] } }, "uk"),
+    ).toBe(true);
+  });
+
+  it("non-object country_eligibility returns true (defensive)", () => {
+    expect(
+      isEligibleForCountry({ country_eligibility: "garbage" as unknown as Record<string, unknown> }, "uk"),
+    ).toBe(true);
+  });
+});
+
+describe("filterByCountryEligibility", () => {
+  const brokers = [
+    { id: 1, name: "AU-only", country_eligibility: { allowed_countries: ["AU"] } },
+    { id: 2, name: "Global, blocks US", country_eligibility: { blocked_countries: ["US"] } },
+    { id: 3, name: "UK + HK", country_eligibility: { allowed_countries: ["GB", "HK"] } },
+    { id: 4, name: "Unverified", country_eligibility: {} },
+    { id: 5, name: "No metadata" },
+  ];
+
+  it("returns all when intent country is null", () => {
+    expect(filterByCountryEligibility(brokers, null)).toHaveLength(5);
+  });
+
+  it("filters for UK visitor (GB) — keeps eligible only", () => {
+    const result = filterByCountryEligibility(brokers, "uk");
+    // 1 excluded (AU-only allow-list), 2 included (no GB block), 3 included (GB in allow), 4+5 included (no opinion)
+    expect(result.map((b) => b.id)).toEqual([2, 3, 4, 5]);
+  });
+
+  it("filters for US visitor (US) — excludes 2 (blocks US) and 1+3 (allow-list excludes US)", () => {
+    const result = filterByCountryEligibility(brokers, "us");
+    expect(result.map((b) => b.id)).toEqual([4, 5]);
+  });
+
+  it("filters for HK visitor (HK) — keeps 3 (HK in allow), 2+4+5 (no opinion / no block)", () => {
+    const result = filterByCountryEligibility(brokers, "hk");
+    expect(result.map((b) => b.id)).toEqual([2, 3, 4, 5]);
+  });
+
+  it("preserves array order", () => {
+    const ordered = [
+      { id: "z", country_eligibility: {} },
+      { id: "a", country_eligibility: {} },
+      { id: "m", country_eligibility: {} },
+    ];
+    expect(filterByCountryEligibility(ordered, "uk").map((e) => e.id)).toEqual(["z", "a", "m"]);
+  });
+});
+
+describe("requiresVisaForCountry", () => {
+  it("returns false when intent country is null", () => {
+    expect(requiresVisaForCountry({ country_eligibility: { visa_required: ["GB"] } }, null)).toBe(false);
+  });
+
+  it("returns false when no visa list present", () => {
+    expect(requiresVisaForCountry({ country_eligibility: {} }, "uk")).toBe(false);
+  });
+
+  it("returns true when visitor ISO in visa_required", () => {
+    expect(
+      requiresVisaForCountry({ country_eligibility: { visa_required: ["GB", "US"] } }, "uk"),
+    ).toBe(true);
+  });
+
+  it("case-insensitive match", () => {
+    expect(
+      requiresVisaForCountry({ country_eligibility: { visa_required: ["gb"] } }, "uk"),
+    ).toBe(true);
+  });
+});

--- a/app/best/[slug]/page.tsx
+++ b/app/best/[slug]/page.tsx
@@ -38,6 +38,8 @@ import {
 } from "@/lib/compliance";
 import { getArticleFiltersForBestPage, CATEGORY_COLORS } from "@/lib/internal-links";
 import { boostFeaturedPartner, isSponsored } from "@/lib/sponsorship";
+import { getIntentCountry } from "@/lib/intent-context-server";
+import { filterByCountryEligibility } from "@/lib/country-mode/eligibility-filter";
 import SponsorBadge from "@/components/SponsorBadge";
 import JargonTooltip from "@/components/JargonTooltip";
 import OnThisPage from "@/components/OnThisPage";
@@ -105,15 +107,24 @@ export default async function BestBrokerPage({
     orParts.push(`tags.ov.{${articleFilters.tags.join(",")}}`);
   }
 
-  // Fetch brokers + articles in parallel
-  const [{ data: brokers }, articleResult] = await Promise.all([
+  // Fetch brokers + articles + visitor's intent country in parallel
+  const [{ data: brokers }, articleResult, intentCountry] = await Promise.all([
     supabase.from("brokers").select("*").eq("status", "active"),
     orParts.length > 0
       ? supabase.from("articles").select("id, title, slug, category, read_time").or(orParts.join(",")).limit(3)
       : Promise.resolve({ data: null }),
+    getIntentCountry(),
   ]);
 
-  const allBrokers = (brokers as Broker[]) || [];
+  // Country-eligibility filter: hide brokers that block the visitor's country
+  // (or whose allow-list excludes it). When intentCountry is null this is a no-op.
+  // PR #619 added the schema; this is the first reader.
+  const eligibleBrokers = filterByCountryEligibility(
+    (brokers as Broker[]) || [],
+    intentCountry,
+  );
+
+  const allBrokers = eligibleBrokers;
   const filtered = boostFeaturedPartner(
     allBrokers.filter(cat.filter).sort(cat.sort),
     0

--- a/lib/country-mode/eligibility-filter.ts
+++ b/lib/country-mode/eligibility-filter.ts
@@ -1,0 +1,100 @@
+/**
+ * Country-eligibility filter — uses the per-broker / per-advisor
+ * `country_eligibility` JSONB column added in Phase 4 (PR #619 + #623)
+ * to hide entities that have explicitly blocked the visitor's country
+ * or whose allow-list excludes it.
+ *
+ * Shape (validated by CHECK constraint on brokers + professionals):
+ *   {
+ *     "allowed_countries": ["GB", "HK", "SG"],   -- explicit accept list
+ *     "blocked_countries": ["US"],                -- explicit reject list
+ *     "visa_required":     ["CN"],                -- visa/residency gated
+ *     "verified_at": "2026-05-08T00:00:00Z",
+ *     "notes": null
+ *   }
+ *
+ * Decision rules ("augment, never replace" — when in doubt, show):
+ *   1. No intent country → no filter, return all
+ *   2. `country_eligibility` empty `{}` (default) → include (un-verified, no opinion)
+ *   3. `blocked_countries` includes visitor ISO → EXCLUDE
+ *   4. `allowed_countries` set AND visitor ISO not in it → EXCLUDE
+ *   5. Otherwise → include
+ *
+ * `visa_required` is informational only — does not exclude. UI may
+ * surface a "visa required" badge separately.
+ *
+ * Pure function — no DB / cookie access. Caller resolves the intent
+ * country and passes the ISO.
+ */
+
+import { intentCountryMeta, type IntentCountryCode } from "../intent-context";
+
+export interface CountryEligibility {
+  allowed_countries?: string[];
+  blocked_countries?: string[];
+  visa_required?: string[];
+  verified_at?: string;
+  notes?: string | null;
+}
+
+export interface EntityWithEligibility {
+  country_eligibility?: CountryEligibility | Record<string, unknown> | null;
+}
+
+/**
+ * Returns true when the entity is eligible for a visitor with the
+ * given intent country. See decision rules in the file header.
+ */
+export function isEligibleForCountry(
+  entity: EntityWithEligibility,
+  intentCountry: IntentCountryCode | null,
+): boolean {
+  if (!intentCountry) return true;
+
+  const elig = entity.country_eligibility as CountryEligibility | null | undefined;
+  if (!elig || typeof elig !== "object") return true;
+
+  const meta = intentCountryMeta(intentCountry);
+  const visitorIso = meta.iso.toUpperCase();
+
+  const blocked = Array.isArray(elig.blocked_countries) ? elig.blocked_countries : null;
+  if (blocked && blocked.map((c) => c.toUpperCase()).includes(visitorIso)) {
+    return false;
+  }
+
+  const allowed = Array.isArray(elig.allowed_countries) ? elig.allowed_countries : null;
+  if (allowed && allowed.length > 0 && !allowed.map((c) => c.toUpperCase()).includes(visitorIso)) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Filter an array of entities by country eligibility. Convenience
+ * wrapper over isEligibleForCountry — preserves array order.
+ */
+export function filterByCountryEligibility<T extends EntityWithEligibility>(
+  entities: ReadonlyArray<T>,
+  intentCountry: IntentCountryCode | null,
+): T[] {
+  if (!intentCountry) return [...entities];
+  return entities.filter((e) => isEligibleForCountry(e, intentCountry));
+}
+
+/**
+ * Returns true when visa is required for the entity for the given
+ * country. UI uses this to surface a "visa required" badge.
+ */
+export function requiresVisaForCountry(
+  entity: EntityWithEligibility,
+  intentCountry: IntentCountryCode | null,
+): boolean {
+  if (!intentCountry) return false;
+  const elig = entity.country_eligibility as CountryEligibility | null | undefined;
+  if (!elig || typeof elig !== "object") return false;
+  const visa = Array.isArray(elig.visa_required) ? elig.visa_required : null;
+  if (!visa) return false;
+  const meta = intentCountryMeta(intentCountry);
+  return visa.map((c) => c.toUpperCase()).includes(meta.iso.toUpperCase());
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -53,6 +53,8 @@ export interface Broker {
   icon?: string;
   logo_url?: string;
   cta_text?: string;
+  /** PR #619 country-mode Phase 4. JSONB shape: { allowed_countries?, blocked_countries?, visa_required?, verified_at?, notes? } */
+  country_eligibility?: Record<string, unknown> | null;
   benefit_cta?: string;
   tagline?: string;
   asx_fee?: string;


### PR DESCRIPTION
## Summary
PR #619 added `brokers.country_eligibility` (JSONB) and PR #623 retired the legacy renderer. Until now **no surface read the new column** — the schema was wasted. This wires the first reader.

When a UK / IN / HK / SG / etc. country-mode visitor lands on `/best/[slug]`, the broker grid now hides brokers that have explicitly blocked their country (or whose allow-list excludes it). When the cookie is unset the filter is a no-op so the global view is unchanged.

## What ships
- **New pure helper `lib/country-mode/eligibility-filter.ts`**:
  - `isEligibleForCountry(entity, intentCountry)` — single-entity decision
  - `filterByCountryEligibility(entities, intentCountry)` — array convenience
  - `requiresVisaForCountry(entity, intentCountry)` — informational badge hook (UI follow-up)
- **`/best/[slug]/page.tsx`** reads `getIntentCountry()` in parallel with the brokers fetch and applies the filter before sponsor-boost / sort.

## Decision rules
Per `docs/architecture/country-mode.md` "augment, never replace" pattern:

1. No intent country → include (no filter)
2. `country_eligibility` empty `{}` or null → include (un-verified, no opinion)
3. `blocked_countries` includes visitor ISO → **EXCLUDE**
4. `allowed_countries` set AND visitor ISO not in it → **EXCLUDE**
5. `visa_required` is informational only — does NOT exclude

## Tier classification
**Tier B** per `docs/audits/MERGE_AUTHORIZATION.md` — additive read-side filter on existing column; no migration; no admin / cron / webhook surface; no Stripe / supabase/admin paths.

## Test plan
- [x] 21 unit tests covering all decision paths + edge cases (case-insensitive ISO, empty allow-list = no opinion, blocked beats allowed, visa-required is informational only, array-order preservation)
- [x] Local `npx vitest run __tests__/lib/country-mode/eligibility-filter.test.ts` → 21/21 ✓
- [ ] CI: type-check + full test suite
- [ ] Visual: visit `/best/share-trading` with `iv_intent_country=hk` cookie → should hide brokers with `blocked_countries: ["HK"]` or `allowed_countries: ["AU", "US"]` (i.e. HK not in allow-list)
- [ ] Visual: same URL with cookie cleared → see full broker list

## Why this is high-ROI
- HK / IN / UK / SG / etc. visitors today see the full broker list — half won't accept them
- With this filter, country-mode visitors only see brokers that will actually take their business → conversion goes up
- Schema was already in place; cheap implementation
- Estimated $5-10k MRR uplift per FIN_NOTEBOOK 2026-05-01 entry

## Follow-up
Same filter needs to be applied to:
- `/find-advisor` matching API (`app/api/submit-lead/route.ts`)
- `CountryComparePreview` / `CountryExpertsPreview` server components
- Admin search / lead-route fairness checks

Each is a separate small PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — pre-launch-wave loop iter 3