### PR TITLE
feat(advisor-billing): cross-border specialty 1.75× premium pricing (queue #5)

### DIFF
--- a/__tests__/lib/advisor-billing-multipliers.test.ts
+++ b/__tests__/lib/advisor-billing-multipliers.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import {
+  CROSS_BORDER_SPECIALTIES,
+  CROSS_BORDER_PRICE_MULTIPLIER,
+  isCrossBorderSpecialty,
+  crossBorderLeadMultiplier,
+  calculateLeadPriceCents,
+} from "@/lib/advisor-billing-multipliers";
+
+describe("CROSS_BORDER_SPECIALTIES", () => {
+  it("includes the 4 canonical cross-border specialties", () => {
+    expect(CROSS_BORDER_SPECIALTIES).toContain("UK Pension Transfer");
+    expect(CROSS_BORDER_SPECIALTIES).toContain("FATCA-Aware US Expat Planning");
+    expect(CROSS_BORDER_SPECIALTIES).toContain("DASP Processing");
+    expect(CROSS_BORDER_SPECIALTIES).toContain("FIRB Property (Non-Resident)");
+    expect(CROSS_BORDER_SPECIALTIES).toHaveLength(4);
+  });
+});
+
+describe("isCrossBorderSpecialty", () => {
+  it("returns false for null", () => {
+    expect(isCrossBorderSpecialty(null)).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isCrossBorderSpecialty(undefined)).toBe(false);
+  });
+
+  it("returns false for empty array", () => {
+    expect(isCrossBorderSpecialty([])).toBe(false);
+  });
+
+  it("returns false for non-cross-border specialties", () => {
+    expect(isCrossBorderSpecialty(["First Home Buyers", "Small Business Owners"])).toBe(false);
+  });
+
+  it("returns true when UK Pension Transfer is present", () => {
+    expect(isCrossBorderSpecialty(["UK Pension Transfer"])).toBe(true);
+  });
+
+  it("returns true when FATCA-Aware US Expat Planning is present", () => {
+    expect(isCrossBorderSpecialty(["First Home Buyers", "FATCA-Aware US Expat Planning"])).toBe(true);
+  });
+
+  it("returns true when DASP Processing is present", () => {
+    expect(isCrossBorderSpecialty(["DASP Processing"])).toBe(true);
+  });
+
+  it("returns true when FIRB Property (Non-Resident) is present", () => {
+    expect(isCrossBorderSpecialty(["FIRB Property (Non-Resident)", "Property Investment"])).toBe(true);
+  });
+
+  it("returns true when multiple cross-border specialties are present", () => {
+    expect(
+      isCrossBorderSpecialty(["UK Pension Transfer", "DASP Processing"]),
+    ).toBe(true);
+  });
+
+  it("is case-sensitive (canonical names only)", () => {
+    expect(isCrossBorderSpecialty(["uk pension transfer"])).toBe(false);
+  });
+});
+
+describe("crossBorderLeadMultiplier", () => {
+  it("returns 1.0 for non-cross-border", () => {
+    expect(crossBorderLeadMultiplier(["First Home Buyers"])).toBe(1.0);
+    expect(crossBorderLeadMultiplier(null)).toBe(1.0);
+    expect(crossBorderLeadMultiplier([])).toBe(1.0);
+  });
+
+  it("returns 1.75 for cross-border specialty", () => {
+    expect(crossBorderLeadMultiplier(["UK Pension Transfer"])).toBe(1.75);
+  });
+
+  it("returns 1.75 only once (not multiplied per matching specialty)", () => {
+    expect(
+      crossBorderLeadMultiplier(["UK Pension Transfer", "DASP Processing", "FATCA-Aware US Expat Planning"]),
+    ).toBe(1.75);
+  });
+
+  it("matches the exported constant", () => {
+    expect(crossBorderLeadMultiplier(["UK Pension Transfer"])).toBe(CROSS_BORDER_PRICE_MULTIPLIER);
+  });
+});
+
+describe("calculateLeadPriceCents", () => {
+  // Standard tier (×1.0), no cross-border, $39 base
+  it("standard lead, no cross-border = base price", () => {
+    expect(calculateLeadPriceCents(3900, 1, ["First Home Buyers"])).toBe(3900);
+  });
+
+  // Standard tier (×1.0), cross-border = base × 1.75 = $68.25 → 6825 cents
+  it("standard lead with cross-border specialty = 1.75× base", () => {
+    expect(calculateLeadPriceCents(3900, 1, ["UK Pension Transfer"])).toBe(6825);
+  });
+
+  // Qualified tier (×2.0), no cross-border = $78
+  it("qualified lead, no cross-border = 2× base", () => {
+    expect(calculateLeadPriceCents(3900, 2, [])).toBe(7800);
+  });
+
+  // Qualified tier (×2.0), cross-border = $39 × 2 × 1.75 = $136.50
+  it("qualified lead with cross-border = stacks both multipliers", () => {
+    expect(calculateLeadPriceCents(3900, 2, ["DASP Processing"])).toBe(13650);
+  });
+
+  // International tier (×3.0), cross-border = $39 × 3 × 1.75 = $204.75
+  it("international lead with cross-border = full premium stack", () => {
+    expect(calculateLeadPriceCents(3900, 3, ["FATCA-Aware US Expat Planning"])).toBe(20475);
+  });
+
+  // Free lead (base = 0)
+  it("free lead is always 0 regardless of multipliers", () => {
+    expect(calculateLeadPriceCents(0, 3, ["UK Pension Transfer"])).toBe(0);
+  });
+
+  // Rounding behaviour
+  it("rounds to nearest cent (Math.round)", () => {
+    // 1234 × 1.75 = 2159.5 → rounds to 2160
+    expect(calculateLeadPriceCents(1234, 1, ["UK Pension Transfer"])).toBe(2160);
+  });
+});

--- a/app/api/advisor-enquiry/route.ts
+++ b/app/api/advisor-enquiry/route.ts
@@ -256,7 +256,7 @@ export async function POST(request: NextRequest) {
     // First 2 leads are free (trial), then deduct from credit balance
     const { data: advisor } = await supabase
       .from("professionals")
-      .select("free_leads_used, lead_price_cents, credit_balance_cents, lifetime_lead_spend_cents, total_leads, low_credit_alert_sent_at")
+      .select("free_leads_used, lead_price_cents, credit_balance_cents, lifetime_lead_spend_cents, total_leads, low_credit_alert_sent_at, specialties")
       .eq("id", professional_id)
       .single();
 
@@ -283,11 +283,20 @@ export async function POST(request: NextRequest) {
     const isFree = freeUsed < (categoryFreeLeads || freeTrialCount);
     // Pricing tiers: international = 3x, qualified = 2x, standard = 1x
     const basePriceCents = advisor?.lead_price_cents || categoryPrice;
-    const priceCents = isFree ? 0 : (
+    const tieredCents = isFree ? 0 : (
       leadTier === "international" ? basePriceCents * 3 :
       leadTier === "qualified" ? (categoryQualifiedPrice || basePriceCents * 2) :
       basePriceCents
     );
+    // Cross-border specialty premium (PR queue #5, FIN_NOTEBOOK Phase A):
+    // 1.75× when the advisor sells leads in UK Pension Transfer / FATCA /
+    // DASP / FIRB Property (Non-Resident). Stacks with tier multiplier
+    // because cross-border + international is the highest-LTV combination
+    // (UK arrival into AU with non-resident mortgage flow).
+    const { crossBorderLeadMultiplier } = await import("@/lib/advisor-billing-multipliers");
+    const priceCents = isFree
+      ? 0
+      : Math.round(tieredCents * crossBorderLeadMultiplier(advisor?.specialties));
     const balance = advisor?.credit_balance_cents || 0;
     const hasSufficientCredit = balance >= priceCents;
 

--- a/lib/advisor-billing-multipliers.ts
+++ b/lib/advisor-billing-multipliers.ts
@@ -1,0 +1,90 @@
+/**
+ * Premium pricing multipliers for cross-border specialties.
+ *
+ * FIN_NOTEBOOK 2026-05-01 entry #24 Phase A: cross-border lead LTV is
+ * 5–15× a domestic share-broker lead ($5-20k professional fees over 18
+ * months across pension transfer + non-resident mortgage + FX + FIRB
+ * lawyer + ongoing planner + insurance + recurring tax). Pricing
+ * captures a fraction of that LTV so the marketplace economics reflect
+ * the value flowing through.
+ *
+ * 1.75× was chosen because:
+ *   - Conservative versus the 5–15× LTV asymmetry — leaves room for
+ *     advisors to capture margin
+ *   - Stacks cleanly with existing tier multipliers (international 3×,
+ *     qualified 2×, standard 1×) without making any combination feel
+ *     extortionate
+ *   - Matches FIN_NOTEBOOK's stated target
+ *
+ * Pure module — no DB / Stripe / cookie access. Callers pass the
+ * advisor's `specialties` array.
+ */
+
+import type { AdvisorSpecialty } from "./advisor-specialties";
+
+/**
+ * The 4 cross-border specialties that justify premium pricing
+ * (ASIC RG 246-friendly: pricing reflects effort + risk profile +
+ * regulatory complexity, not personal advice quality).
+ */
+export const CROSS_BORDER_SPECIALTIES: ReadonlyArray<string> = [
+  "UK Pension Transfer",
+  "FATCA-Aware US Expat Planning",
+  "DASP Processing",
+  "FIRB Property (Non-Resident)",
+];
+
+/**
+ * Multiplier applied on top of base + tier multipliers when the
+ * advisor sells a lead in a cross-border specialty. Returns 1.0
+ * (no premium) for non-cross-border leads.
+ */
+export const CROSS_BORDER_PRICE_MULTIPLIER = 1.75;
+
+/**
+ * Returns true if any of the advisor's specialties is a cross-border
+ * specialty. Empty / null / undefined inputs return false.
+ */
+export function isCrossBorderSpecialty(
+  specialties: ReadonlyArray<string> | string[] | null | undefined,
+): boolean {
+  if (!specialties || specialties.length === 0) return false;
+  const set = new Set(CROSS_BORDER_SPECIALTIES);
+  return specialties.some((s) => set.has(s));
+}
+
+/**
+ * Multiplier to apply to the per-lead price. Returns
+ * CROSS_BORDER_PRICE_MULTIPLIER when any cross-border specialty is
+ * present, else 1.0.
+ *
+ * Designed to STACK with existing tier multipliers — the caller does:
+ *
+ *   priceCents = basePriceCents * tierMultiplier * crossBorderLeadMultiplier(specialties)
+ */
+export function crossBorderLeadMultiplier(
+  specialties: ReadonlyArray<string> | string[] | null | undefined,
+): number {
+  return isCrossBorderSpecialty(specialties) ? CROSS_BORDER_PRICE_MULTIPLIER : 1.0;
+}
+
+/**
+ * Calculate the final per-lead price for an advisor selling this lead.
+ * Composes: base × tier × cross-border premium.
+ *
+ * `tierMultiplier` is what advisor-enquiry already calculates from
+ * leadTier (international 3, qualified 2, standard 1). This function
+ * just adds the cross-border premium on top, returning a rounded cents
+ * integer.
+ */
+export function calculateLeadPriceCents(
+  basePriceCents: number,
+  tierMultiplier: number,
+  specialties: ReadonlyArray<string> | string[] | null | undefined,
+): number {
+  const crossBorder = crossBorderLeadMultiplier(specialties);
+  return Math.round(basePriceCents * tierMultiplier * crossBorder);
+}
+
+// Re-export for callers that want the type
+export type { AdvisorSpecialty };

--- a/lib/advisor-billing-multipliers.ts
+++ b/lib/advisor-billing-multipliers.ts
@@ -20,8 +20,6 @@
  * advisor's `specialties` array.
  */
 
-import type { AdvisorSpecialty } from "./advisor-specialties";
-
 /**
  * The 4 cross-border specialties that justify premium pricing
  * (ASIC RG 246-friendly: pricing reflects effort + risk profile +
@@ -86,5 +84,3 @@ export function calculateLeadPriceCents(
   return Math.round(basePriceCents * tierMultiplier * crossBorder);
 }
 
-// Re-export for callers that want the type
-export type { AdvisorSpecialty };


### PR DESCRIPTION
FIN_NOTEBOOK 2026-05-01 Phase A remaining. Cross-border lead LTV is 5-15× domestic; this captures fraction of that LTV via a 1.75× multiplier on lead pricing for advisors selling in UK Pension Transfer / FATCA-Aware US Expat Planning / DASP Processing / FIRB Property (Non-Resident) specialties.

Stacks with existing tier multipliers (international 3×, qualified 2×, standard 1×). UK pension lead at international tier: $39 × 3 × 1.75 = $204.75 (was $117). Standard cross-border: $39 → $68.25.

**Files**:
- `lib/advisor-billing-multipliers.ts` (new) — pure module, 5 exports
- `app/api/advisor-enquiry/route.ts` — adds `specialties` to select; one-line wire
- `__tests__/lib/advisor-billing-multipliers.test.ts` (new) — 22 tests

**Tier B** — additive multiplier on existing pricing; no schema change; no Stripe webhook touched (billing flow unchanged, only the cents number changes when applicable). ASIC RG 246 friendly: pricing reflects effort + risk profile + regulatory complexity, not personal advice quality.

Estimated **$15-40k/yr** direct margin uplift per FIN_NOTEBOOK.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — pre-launch-wave loop iter 5
