### PR TITLE
feat(find-advisor): response-time badge on matched-advisor card (queue #7)

### DIFF
--- a/app/api/submit-lead/route.ts
+++ b/app/api/submit-lead/route.ts
@@ -54,7 +54,7 @@ function resolveAdvisorTypes(need: string, context?: string[]): string[] {
 
 /* ─── Common select fields for matching queries ─── */
 
-const MATCH_SELECT = "id, slug, name, firm_name, type, photo_url, rating, review_count, location_display, location_state, specialties, fee_description, verified, bio, email";
+const MATCH_SELECT = "id, slug, name, firm_name, type, photo_url, rating, review_count, location_display, location_state, specialties, fee_description, verified, bio, email, avg_response_minutes";
 
 /**
  * POST /api/submit-lead

--- a/app/find-advisor/page.tsx
+++ b/app/find-advisor/page.tsx
@@ -30,6 +30,8 @@ interface MatchedAdvisor {
   specialties: string[];
   fee_description: string | null;
   verified: boolean;
+  /** Used by the response-time badge — null when no leads have been logged yet. */
+  avg_response_minutes?: number | null;
 }
 
 interface QuizState {
@@ -1239,12 +1241,20 @@ function MatchConfirmation({ userEmail, userFirstName, currentMatch, allMatches,
               <Icon name="zap" size={14} className="text-white" />
               <span className="text-xs font-bold tracking-wide uppercase">Your Matched Advisor</span>
             </div>
-            {currentMatch.verified && (
-              <div className="flex items-center gap-1 bg-white/20 backdrop-blur-sm rounded-full px-2.5 py-0.5">
-                <Icon name="shield-check" size={12} className="text-white" />
-                <span className="text-[0.65rem] font-semibold text-white">ASIC Verified</span>
-              </div>
-            )}
+            <div className="flex items-center gap-1.5">
+              {currentMatch.avg_response_minutes != null && currentMatch.avg_response_minutes <= 60 && (
+                <div className="flex items-center gap-1 bg-emerald-500/30 backdrop-blur-sm rounded-full px-2.5 py-0.5" title="Average response under 60 minutes">
+                  <Icon name="zap" size={12} className="text-white" />
+                  <span className="text-[0.65rem] font-semibold text-white">Fast reply (&lt;1h)</span>
+                </div>
+              )}
+              {currentMatch.verified && (
+                <div className="flex items-center gap-1 bg-white/20 backdrop-blur-sm rounded-full px-2.5 py-0.5">
+                  <Icon name="shield-check" size={12} className="text-white" />
+                  <span className="text-[0.65rem] font-semibold text-white">ASIC Verified</span>
+                </div>
+              )}
+            </div>
           </div>
 
           <div className="p-5 md:p-6">


### PR DESCRIPTION
When a visitor completes the find-advisor quiz and gets matched, the matched-advisor card now shows a "Fast reply (<1h)" badge when the advisor's avg_response_minutes ≤ 60.

Mirrors the "Fast reply" badges on /advisors and /advisor/[slug] but with a tighter 60-min threshold (vs 120-min there) — the matched-card moment is the highest-conversion surface and a tighter badge is more discriminating.

Pairs with PR-X2 (response-time SLA reward, advisor side): visitor-side badge + advisor-side reward = self-reinforcing flywheel.

**Files**:
- `app/find-advisor/page.tsx` — adds avg_response_minutes to MatchedAdvisor; renders green pill in card header
- `app/api/submit-lead/route.ts` — adds avg_response_minutes to MATCH_SELECT

**Tier A** — additive UI + read-side select column expansion.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — pre-launch-wave loop iter 6
