### PR TITLE
feat(country-mode): visible eligibility badge on broker cards (queue #12)

### DIFF
--- a/__tests__/components/EligibilityBadge.test.tsx
+++ b/__tests__/components/EligibilityBadge.test.tsx
@@ -1,0 +1,181 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "./setup";
+import EligibilityBadge from "@/components/EligibilityBadge";
+
+describe("EligibilityBadge", () => {
+  describe("returns null when…", () => {
+    it("intent country is null", () => {
+      const { container } = render(
+        <EligibilityBadge
+          entity={{ country_eligibility: { allowed_countries: ["GB"] } }}
+          intentCountry={null}
+        />,
+      );
+      expect(container.firstChild).toBeNull();
+    });
+
+    it("entity has no eligibility metadata + showWhenSilent=false", () => {
+      const { container } = render(
+        <EligibilityBadge entity={{}} intentCountry="uk" />,
+      );
+      expect(container.firstChild).toBeNull();
+    });
+
+    it("entity is eligible by default + showWhenSilent=false", () => {
+      const { container } = render(
+        <EligibilityBadge
+          entity={{ country_eligibility: {} }}
+          intentCountry="uk"
+        />,
+      );
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  describe("blocked state (red)", () => {
+    it("renders blocked badge when visitor ISO in blocked_countries", () => {
+      render(
+        <EligibilityBadge
+          entity={{ country_eligibility: { blocked_countries: ["US", "GB"] } }}
+          intentCountry="uk"
+        />,
+      );
+      const badge = screen.getByTestId("eligibility-badge-blocked");
+      expect(badge).toBeInTheDocument();
+      expect(badge).toHaveTextContent(/Not available in UK/i);
+    });
+
+    it("blocked beats allowed (defense in depth)", () => {
+      render(
+        <EligibilityBadge
+          entity={{
+            country_eligibility: {
+              allowed_countries: ["GB"],
+              blocked_countries: ["GB"],
+            },
+          }}
+          intentCountry="uk"
+        />,
+      );
+      expect(screen.getByTestId("eligibility-badge-blocked")).toBeInTheDocument();
+    });
+
+    it("case-insensitive ISO match", () => {
+      render(
+        <EligibilityBadge
+          entity={{ country_eligibility: { blocked_countries: ["gb"] } }}
+          intentCountry="uk"
+        />,
+      );
+      expect(screen.getByTestId("eligibility-badge-blocked")).toBeInTheDocument();
+    });
+  });
+
+  describe("visa-required state (amber)", () => {
+    it("renders visa badge when visitor ISO in visa_required", () => {
+      render(
+        <EligibilityBadge
+          entity={{ country_eligibility: { visa_required: ["GB", "CN"] } }}
+          intentCountry="cn"
+        />,
+      );
+      const badge = screen.getByTestId("eligibility-badge-visa");
+      expect(badge).toBeInTheDocument();
+      expect(badge).toHaveTextContent(/Visa required for Chinese/i);
+    });
+
+    it("blocked beats visa-required", () => {
+      render(
+        <EligibilityBadge
+          entity={{
+            country_eligibility: {
+              blocked_countries: ["GB"],
+              visa_required: ["GB"],
+            },
+          }}
+          intentCountry="uk"
+        />,
+      );
+      expect(screen.getByTestId("eligibility-badge-blocked")).toBeInTheDocument();
+      expect(screen.queryByTestId("eligibility-badge-visa")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("explicitly allowed state (green)", () => {
+    it("renders accepts badge when visitor ISO in allowed_countries", () => {
+      render(
+        <EligibilityBadge
+          entity={{ country_eligibility: { allowed_countries: ["GB", "HK"] } }}
+          intentCountry="uk"
+        />,
+      );
+      const badge = screen.getByTestId("eligibility-badge-allowed");
+      expect(badge).toBeInTheDocument();
+      expect(badge).toHaveTextContent(/Accepts UK clients/i);
+    });
+
+    it("does NOT render allowed when visitor ISO not in allow-list", () => {
+      const { container } = render(
+        <EligibilityBadge
+          entity={{ country_eligibility: { allowed_countries: ["HK", "SG"] } }}
+          intentCountry="uk"
+        />,
+      );
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  describe("showWhenSilent mode", () => {
+    it("renders 'Available globally' when no opinion + showWhenSilent=true", () => {
+      render(
+        <EligibilityBadge
+          entity={{ country_eligibility: {} }}
+          intentCountry="uk"
+          showWhenSilent
+        />,
+      );
+      const badge = screen.getByTestId("eligibility-badge-silent");
+      expect(badge).toBeInTheDocument();
+      expect(badge).toHaveTextContent(/Available globally/i);
+    });
+
+    it("blocked still wins over silent", () => {
+      render(
+        <EligibilityBadge
+          entity={{ country_eligibility: { blocked_countries: ["GB"] } }}
+          intentCountry="uk"
+          showWhenSilent
+        />,
+      );
+      expect(screen.getByTestId("eligibility-badge-blocked")).toBeInTheDocument();
+      expect(screen.queryByTestId("eligibility-badge-silent")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("compact mode", () => {
+    it("renders smaller styling when compact=true", () => {
+      render(
+        <EligibilityBadge
+          entity={{ country_eligibility: { allowed_countries: ["GB"] } }}
+          intentCountry="uk"
+          compact
+        />,
+      );
+      const badge = screen.getByTestId("eligibility-badge-allowed");
+      expect(badge.className).toContain("text-[0.58rem]");
+      expect(badge.className).toContain("px-1.5");
+    });
+
+    it("renders default styling when compact omitted", () => {
+      render(
+        <EligibilityBadge
+          entity={{ country_eligibility: { allowed_countries: ["GB"] } }}
+          intentCountry="uk"
+        />,
+      );
+      const badge = screen.getByTestId("eligibility-badge-allowed");
+      expect(badge.className).toContain("text-[0.65rem]");
+      expect(badge.className).toContain("px-2");
+    });
+  });
+});

--- a/components/BrokerCard.tsx
+++ b/components/BrokerCard.tsx
@@ -9,7 +9,9 @@ import Icon from "@/components/Icon";
 import ShortlistButton from "@/components/ShortlistButton";
 import BrokerLogo from "@/components/BrokerLogo";
 import FeeVerifiedPill from "@/components/FeeVerifiedPill";
+import EligibilityBadge from "@/components/EligibilityBadge";
 import { isSponsored } from "@/lib/sponsorship";
+import type { IntentCountryCode } from "@/lib/intent-context";
 
 export default memo(function BrokerCard({
   broker,
@@ -18,6 +20,7 @@ export default memo(function BrokerCard({
   isSelected,
   onToggleSelect,
   selectionDisabled,
+  intentCountry = null,
 }: {
   broker: Broker;
   badge?: string;
@@ -25,6 +28,11 @@ export default memo(function BrokerCard({
   isSelected?: boolean;
   onToggleSelect?: (slug: string) => void;
   selectionDisabled?: boolean;
+  /** PR queue #12 — visitor's resolved intent country. When set, the
+   *  card renders an EligibilityBadge based on the broker's
+   *  country_eligibility column. Caller is responsible for resolving
+   *  the cookie (server) or hook value (client). */
+  intentCountry?: IntentCountryCode | null;
 }) {
   const isSponsoredBroker = isSponsored(broker);
   const isShareOrCFD = broker.platform_type === 'share_broker' || broker.platform_type === 'cfd_forex';
@@ -68,13 +76,15 @@ export default memo(function BrokerCard({
         <div className="flex items-center gap-2.5 mb-2">
           <BrokerLogo broker={broker} size="md" />
           <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-1.5">
+            <div className="flex items-center gap-1.5 flex-wrap">
               <a href={`/broker/${broker.slug}`} className="font-bold text-sm text-slate-900 hover:text-slate-700 transition-colors truncate">
                 {broker.name}
               </a>
               {broker.affiliate_url && !isSponsoredBroker && (
                 <span title={AFFILIATE_AD_TOOLTIP} className="text-[0.6rem] font-semibold px-1 py-0.5 bg-slate-100 text-slate-400 rounded uppercase tracking-wide shrink-0">Ad</span>
               )}
+              {/* PR queue #12 — eligibility badge when visitor has intent country */}
+              <EligibilityBadge entity={broker} intentCountry={intentCountry} compact />
             </div>
             <div className="flex items-center gap-1.5">
               <span className="text-amber-400 text-xs">{renderStars(broker.rating || 0)}</span>

--- a/components/EligibilityBadge.tsx
+++ b/components/EligibilityBadge.tsx
@@ -1,0 +1,141 @@
+/**
+ * EligibilityBadge — visible signal that a broker / advisor / fund accepts
+ * (or doesn't) the current visitor's country.
+ *
+ * PR queue #12. Compounds with PR #683 (which silently filters incompatible
+ * brokers from /best/[slug]) by making the country-mode work *visible* to
+ * users on every card surface. Without this, a HK visitor sees fewer
+ * brokers but doesn't know why.
+ *
+ * Renders one of:
+ *   🟢 "Accepts {Country} clients"  — entity in allowed_countries OR
+ *                                      no opinion + visitor has intent
+ *   🟡 "Visa required for {Country}" — entity in visa_required
+ *   🔴 "Not available in {Country}"  — entity in blocked_countries
+ *                                      (usually filtered out, but on
+ *                                      browse-all surfaces shown grayed)
+ *   (null)                            — no intent country, or entity has
+ *                                       no eligibility metadata at all
+ *
+ * Pure client component — no DB / cookie access. Caller resolves the
+ * intent country (server-side via getIntentCountry, or client via
+ * useIntentCountry) and passes it down.
+ */
+
+import {
+  isEligibleForCountry,
+  requiresVisaForCountry,
+  type EntityWithEligibility,
+} from "@/lib/country-mode/eligibility-filter";
+import { intentCountryMeta, type IntentCountryCode } from "@/lib/intent-context";
+
+interface Props {
+  entity: EntityWithEligibility;
+  intentCountry: IntentCountryCode | null;
+  /** When true: show the badge even for "default eligible / no opinion" — useful on directory pages where users want explicit confirmation. */
+  showWhenSilent?: boolean;
+  /** When true: render in compact pill style (smaller, less padding). */
+  compact?: boolean;
+}
+
+export default function EligibilityBadge({
+  entity,
+  intentCountry,
+  showWhenSilent = false,
+  compact = false,
+}: Props) {
+  if (!intentCountry) return null;
+
+  const meta = intentCountryMeta(intentCountry);
+  const country = meta.label.replace(/ investors$/, "").trim() || meta.name;
+
+  const elig = entity.country_eligibility as
+    | { allowed_countries?: string[]; blocked_countries?: string[]; visa_required?: string[] }
+    | null
+    | undefined;
+
+  // Determine state in priority order: blocked > visa > allowed > silent
+  const visitorIso = meta.iso.toUpperCase();
+  const blocked = Array.isArray(elig?.blocked_countries)
+    ? elig.blocked_countries.map((c) => c.toUpperCase())
+    : [];
+  const allowed = Array.isArray(elig?.allowed_countries)
+    ? elig.allowed_countries.map((c) => c.toUpperCase())
+    : [];
+  const visa = Array.isArray(elig?.visa_required)
+    ? elig.visa_required.map((c) => c.toUpperCase())
+    : [];
+
+  const isBlocked = blocked.includes(visitorIso);
+  const requiresVisa = !isBlocked && visa.includes(visitorIso);
+  const isExplicitlyAllowed = !isBlocked && !requiresVisa && allowed.includes(visitorIso);
+  const isEligible = isEligibleForCountry(entity, intentCountry);
+
+  // Don't render anything when:
+  //   - visitor IS eligible
+  //   - AND no explicit allow / visa-required signal
+  //   - AND showWhenSilent=false
+  if (!isBlocked && !requiresVisa && !isExplicitlyAllowed && !showWhenSilent) {
+    return null;
+  }
+
+  // Style classes per state
+  const baseClasses = compact
+    ? "inline-flex items-center gap-1 text-[0.58rem] font-bold px-1.5 py-0.5 rounded-full border"
+    : "inline-flex items-center gap-1 text-[0.65rem] font-bold px-2 py-0.5 rounded-full border";
+
+  if (isBlocked) {
+    return (
+      <span
+        className={`${baseClasses} bg-red-50 text-red-700 border-red-200`}
+        title={`This option is not available in ${country}.`}
+        data-testid="eligibility-badge-blocked"
+      >
+        <span aria-hidden>{meta.flag}</span>
+        Not available in {country}
+      </span>
+    );
+  }
+
+  if (requiresVisa) {
+    return (
+      <span
+        className={`${baseClasses} bg-amber-50 text-amber-700 border-amber-200`}
+        title={`Available in ${country} with visa or residency documentation.`}
+        data-testid="eligibility-badge-visa"
+      >
+        <span aria-hidden>{meta.flag}</span>
+        Visa required for {country}
+      </span>
+    );
+  }
+
+  if (isExplicitlyAllowed) {
+    return (
+      <span
+        className={`${baseClasses} bg-emerald-50 text-emerald-700 border-emerald-200`}
+        title={`This option accepts ${country} clients.`}
+        data-testid="eligibility-badge-allowed"
+      >
+        <span aria-hidden>{meta.flag}</span>
+        Accepts {country} clients
+      </span>
+    );
+  }
+
+  // showWhenSilent + eligible-by-default → render a soft "available globally" pill
+  if (showWhenSilent && isEligible) {
+    return (
+      <span
+        className={`${baseClasses} bg-slate-50 text-slate-600 border-slate-200`}
+        title={`No country restrictions on file — available globally.`}
+        data-testid="eligibility-badge-silent"
+      >
+        <span aria-hidden>🌏</span>
+        Available globally
+      </span>
+    );
+  }
+
+  return null;
+}


### PR DESCRIPTION
Makes PR #683's country-eligibility filter VISIBLE to users. Without this, when we filter out 5 incompatible brokers from a HK visitor's view of /best/share-trading, they don't know why. With this badge, every card shows whether it accepts their country.

**Visual states**:
- 🟢 "Accepts UK clients" (allowed_countries match)
- 🟡 "Visa required for CN" (visa_required match)
- 🔴 "Not available in US" (blocked_countries — usually filtered, but on browse-all surfaces shown grayed)

**Tier A** — additive UI; opt-in prop on BrokerCard.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — pre-launch-wave loop iter 10
