### PR TITLE
feat(country-mode): eligibility badge on advisor cards (queue #12.5)

### DIFF
--- a/app/advisors/AdvisorsClient.tsx
+++ b/app/advisors/AdvisorsClient.tsx
@@ -7,6 +7,7 @@ import { useSearchParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import Image from "next/image";
 import type { Professional, ProfessionalType, AdvisorFirm } from "@/lib/types";
+import EligibilityBadge from "@/components/EligibilityBadge";
 import { PROFESSIONAL_TYPE_LABELS, PROFESSIONAL_TYPE_ICONS, AU_STATES } from "@/lib/types";
 import Icon from "@/components/Icon";
 import VerifiedBadge from "@/components/VerifiedBadge";
@@ -158,7 +159,7 @@ function UseMyLocation({ onLocate }: { onLocate: (lat: number, lng: number) => v
   );
 }
 
-export default function AdvisorsClient({ professionals, initialType, initialState, pageTitle, pageDescription, faqs = [], editorial, firms = [], firmMemberCounts = {} }: {
+export default function AdvisorsClient({ professionals, initialType, initialState, pageTitle, pageDescription, faqs = [], editorial, firms = [], firmMemberCounts = {}, intentCountry = null }: {
   professionals: Professional[];
   initialType?: ProfessionalType;
   initialState?: string;
@@ -168,6 +169,8 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
   editorial?: { howToChoose: string[]; costGuide: string; industryInsight: string };
   firms?: AdvisorFirm[];
   firmMemberCounts?: Record<number, number>;
+  /** PR queue #12.5 — visitor's resolved intent country. When set, every advisor card renders an EligibilityBadge based on country_eligibility. */
+  intentCountry?: import("@/lib/intent-context").IntentCountryCode | null;
 }) {
   const searchParams = useSearchParams();
   const router = useRouter();
@@ -915,6 +918,8 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
                                 Fast reply
                               </span>
                             )}
+                            {/* PR queue #12.5 — eligibility badge per visitor's intent country */}
+                            <EligibilityBadge entity={pro} intentCountry={intentCountry} compact />
                             {pro.accepts_international_clients && (
                               <span className="shrink-0 text-[0.58rem] font-bold px-1.5 py-0.5 rounded-full bg-blue-50 text-blue-700 border border-blue-100">🌏 Intl</span>
                             )}

--- a/app/advisors/page.tsx
+++ b/app/advisors/page.tsx
@@ -28,8 +28,9 @@ export const metadata: Metadata = {
 
 async function AdvisorsData() {
   const supabase = await createClient();
+  const { getIntentCountry } = await import("@/lib/intent-context-server");
 
-  const [proResult, firmResult] = await Promise.all([
+  const [proResult, firmResult, intentCountry] = await Promise.all([
     supabase
       .from("professionals")
       .select("*")
@@ -42,6 +43,7 @@ async function AdvisorsData() {
       .select("*")
       .eq("status", "active")
       .order("name", { ascending: true }),
+    getIntentCountry(),
   ]);
 
   // Surface Supabase errors to the error boundary so users see a retry
@@ -65,7 +67,7 @@ async function AdvisorsData() {
     if (p.firm_id) firmMemberCounts[p.firm_id] = (firmMemberCounts[p.firm_id] || 0) + 1;
   });
 
-  return <AdvisorsClient professionals={professionals} firms={firms} firmMemberCounts={firmMemberCounts} />;
+  return <AdvisorsClient professionals={professionals} firms={firms} firmMemberCounts={firmMemberCounts} intentCountry={intentCountry} />;
 }
 
 export default function AdvisorsPage() {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1004,6 +1004,8 @@ export interface Professional {
   firm_name?: string;
   type: ProfessionalType;
   specialties: string[];
+  /** PR #619 country-mode Phase 4. Same shape as brokers.country_eligibility. */
+  country_eligibility?: Record<string, unknown> | null;
   location_state?: string;
   location_suburb?: string;
   location_display?: string;


### PR DESCRIPTION
Extends PR #691 (eligibility badges on broker cards) to advisor cards on /advisors. Country-mode visitors now see at-a-glance whether each advisor accepts their country.

**Tier A** — additive UI prop; null when no country signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — pre-launch-wave loop iter 12
