### PR TITLE
feat(country-mode): mount CountryRuleAlerts on /find-advisor + /advisors (queue #15 part 3)

### DIFF
--- a/app/advisors/page.tsx
+++ b/app/advisors/page.tsx
@@ -6,6 +6,7 @@ import AdvisorsClient from "./AdvisorsClient";
 import HomeToolsStrip from "@/components/HomeToolsStrip";
 import IntentCountryBadge from "@/components/foreign-investment/IntentCountryBadge";
 import IntentCountryRecommendation from "@/components/foreign-investment/IntentCountryRecommendation";
+import CountryRuleAlerts from "@/components/CountryRuleAlerts";
 import { absoluteUrl, breadcrumbJsonLd, CURRENT_YEAR } from "@/lib/seo";
 import { logger } from "@/lib/logger";
 
@@ -82,6 +83,7 @@ export default function AdvisorsPage() {
       <div className="container-custom pt-4">
         <IntentCountryBadge />
         <IntentCountryRecommendation surface="advisors" />
+        <CountryRuleAlerts />
       </div>
       <Suspense fallback={<AdvisorsLoading />}>
         <AdvisorsData />

--- a/app/find-advisor/page.tsx
+++ b/app/find-advisor/page.tsx
@@ -13,6 +13,7 @@ import Icon from "@/components/Icon";
 import { trackEvent } from "@/lib/tracking";
 import { submitLead } from "@/lib/submit-lead-client";
 import EligibilityQuizSkipBanner from "@/components/EligibilityQuizSkipBanner";
+import CountryRuleAlerts from "@/components/CountryRuleAlerts";
 
 // ─── Types ─────────────────────────────────────────────────────────────────
 
@@ -606,6 +607,7 @@ function FindAdvisorQuiz() {
         {/* Step 1 */}
         {quiz.step === 1 && (
           <>
+            <CountryRuleAlerts />
             <EligibilityQuizSkipBanner />
             <Step1 onSelect={handleIntent} />
           </>


### PR DESCRIPTION
Extends the rule-alerts banner from #694 to 2 more high-traffic surfaces. Country-mode visitors now see relevant regulatory alerts on every major page they touch.

**Tier A** — purely additive component mounts; null-renders when no country cookie set.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — pre-launch-wave loop iter 14
