### PR TITLE
feat(seo): JSON-LD coverage gate + breadcrumb schema on 13 missing pages (W1.3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,9 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      - name: JSON-LD coverage gate
+        run: node scripts/check-jsonld-coverage.mjs
+
       - name: Test with coverage
         run: npm run test:coverage
 

--- a/__tests__/components/JsonLd.test.tsx
+++ b/__tests__/components/JsonLd.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * Render-time tests for the <JsonLd> helper.
+ *
+ * Verifies the component emits a valid `application/ld+json` script tag
+ * with the serialised payload — the contract that the coverage gate
+ * depends on.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import JsonLd from "@/components/JsonLd";
+
+describe("<JsonLd>", () => {
+  it("renders one <script> tag for a single object", () => {
+    const data = { "@context": "https://schema.org", "@type": "WebSite", name: "Foo" };
+    const { container } = render(<JsonLd data={data} />);
+    const scripts = container.querySelectorAll('script[type="application/ld+json"]');
+    expect(scripts).toHaveLength(1);
+    expect(JSON.parse(scripts[0]!.innerHTML)).toEqual(data);
+  });
+
+  it("renders one <script> per entry when given an array", () => {
+    const data = [
+      { "@type": "BreadcrumbList", itemListElement: [] },
+      { "@type": "FAQPage", mainEntity: [] },
+    ];
+    const { container } = render(<JsonLd data={data} />);
+    const scripts = container.querySelectorAll('script[type="application/ld+json"]');
+    expect(scripts).toHaveLength(2);
+    expect(JSON.parse(scripts[0]!.innerHTML)["@type"]).toBe("BreadcrumbList");
+    expect(JSON.parse(scripts[1]!.innerHTML)["@type"]).toBe("FAQPage");
+  });
+
+  it("renders nothing when data is null or undefined", () => {
+    const { container: c1 } = render(<JsonLd data={null} />);
+    const { container: c2 } = render(<JsonLd data={undefined} />);
+    expect(c1.querySelectorAll("script")).toHaveLength(0);
+    expect(c2.querySelectorAll("script")).toHaveLength(0);
+  });
+
+  it("appends data-testid on each block when testId is provided", () => {
+    const data = [{ a: 1 }, { b: 2 }];
+    const { container } = render(<JsonLd data={data} testId="ld" />);
+    const scripts = container.querySelectorAll('script[type="application/ld+json"]');
+    expect(scripts[0]!.getAttribute("data-testid")).toBe("ld-0");
+    expect(scripts[1]!.getAttribute("data-testid")).toBe("ld-1");
+  });
+
+  it("omits data-testid when testId is not provided", () => {
+    const { container } = render(<JsonLd data={{ a: 1 }} />);
+    const script = container.querySelector('script[type="application/ld+json"]');
+    expect(script!.hasAttribute("data-testid")).toBe(false);
+  });
+});

--- a/__tests__/scripts/check-jsonld-coverage.test.ts
+++ b/__tests__/scripts/check-jsonld-coverage.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Tests for scripts/check-jsonld-coverage.mjs.
+ *
+ * Exercises the exported pure helpers directly. The audit() entrypoint is
+ * filesystem-driven and is covered indirectly by CI running it on every PR.
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { join } from "node:path";
+
+const gatePath = join(process.cwd(), "scripts/check-jsonld-coverage.mjs");
+
+let routeOf: (filePath: string) => string;
+let findExemption: (route: string) => { prefix: string; category: string } | null;
+let isRedirectOnly: (body: string) => boolean;
+let isNoIndex: (body: string) => boolean;
+let emitsJsonLd: (body: string) => boolean;
+
+beforeAll(async () => {
+  const mod = await import(gatePath);
+  routeOf = mod.routeOf;
+  findExemption = mod.findExemption;
+  isRedirectOnly = mod.isRedirectOnly;
+  isNoIndex = mod.isNoIndex;
+  emitsJsonLd = mod.emitsJsonLd;
+});
+
+describe("routeOf", () => {
+  it("strips app/ prefix and /page.tsx suffix", () => {
+    expect(routeOf("app/article/[slug]/page.tsx")).toBe("article/[slug]");
+  });
+  it("returns empty for non-page paths", () => {
+    expect(routeOf("scripts/foo.mjs")).toBe("");
+  });
+  it("normalises Windows separators", () => {
+    expect(routeOf("app\\broker\\[slug]\\page.tsx")).toBe("broker/[slug]");
+  });
+  it("matches layout.tsx files alongside page.tsx", () => {
+    expect(routeOf("app/find-advisor/layout.tsx")).toBe("find-advisor");
+  });
+});
+
+describe("findExemption", () => {
+  it("returns null for a public content route", () => {
+    expect(findExemption("article/[slug]")).toBeNull();
+    expect(findExemption("best/[slug]")).toBeNull();
+    expect(findExemption("foreign-investment")).toBeNull();
+  });
+  it("matches PORTAL prefixes", () => {
+    expect(findExemption("admin/dashboard")?.category).toBe("PORTAL");
+    expect(findExemption("advisor-portal/billing")?.category).toBe("PORTAL");
+    expect(findExemption("account/profile")?.category).toBe("PORTAL");
+  });
+  it("matches FORM prefixes", () => {
+    expect(findExemption("review/abc-token")?.category).toBe("FORM");
+    expect(findExemption("review/broker/abc")?.category).toBe("FORM");
+    expect(findExemption("find-advisor")?.category).toBe("FORM");
+  });
+  it("matches UTILITY prefixes", () => {
+    expect(findExemption("newsletter/confirm")?.category).toBe("UTILITY");
+    expect(findExemption("export/comparison")?.category).toBe("UTILITY");
+    expect(findExemption("go/some-broker/apply")?.category).toBe("UTILITY");
+  });
+  it("matches LEGAL prefixes", () => {
+    expect(findExemption("legal")?.category).toBe("LEGAL");
+    expect(findExemption("fsg")?.category).toBe("LEGAL");
+  });
+  it("matches SALES prefixes", () => {
+    expect(findExemption("for-advisors/pricing")?.category).toBe("SALES");
+    expect(findExemption("advertise/packages")?.category).toBe("SALES");
+  });
+  it("does not falsely match prefix substrings", () => {
+    // `admin` is a PORTAL prefix; `admins` should not match it.
+    expect(findExemption("admins-list-public")).toBeNull();
+    // `review` is FORM; `reviews/something-else` should NOT match unless explicitly listed.
+    expect(findExemption("reviews/write")?.category).toBe("FORM");
+  });
+});
+
+describe("isNoIndex", () => {
+  it("detects metadata.robots.index = false", () => {
+    expect(isNoIndex("robots: { index: false, follow: true }")).toBe(true);
+  });
+  it("detects literal noindex string", () => {
+    expect(isNoIndex(`robots: "noindex,follow"`)).toBe(true);
+  });
+  it("returns false for indexable pages", () => {
+    expect(isNoIndex("export const metadata = { title: 'Hello' };")).toBe(false);
+  });
+});
+
+describe("isRedirectOnly", () => {
+  it("detects bare redirect()", () => {
+    const body = `
+      import { redirect } from "next/navigation";
+      export default function Page() { redirect("/somewhere"); }
+    `;
+    expect(isRedirectOnly(body)).toBe(true);
+  });
+  it("detects permanentRedirect()", () => {
+    const body = `
+      import { permanentRedirect } from "next/navigation";
+      export default function Page() { permanentRedirect("/foo"); }
+    `;
+    expect(isRedirectOnly(body)).toBe(true);
+  });
+  it("detects redirect inside a larger metadata-only file", () => {
+    const body = `
+      import { permanentRedirect, notFound } from "next/navigation";
+      const ALLOWED: Record<string, string> = {};
+      export async function generateMetadata() {
+        return { title: "Foo" };
+      }
+      export default async function Page({ params }: any) {
+        const { slug } = await params;
+        if (!ALLOWED[slug]) notFound();
+        permanentRedirect(\`/articles?category=\${slug}\`);
+      }
+    `;
+    expect(isRedirectOnly(body)).toBe(true);
+  });
+  it("returns false for a real page that calls redirect conditionally inside JSX flow", () => {
+    const body = `
+      import { redirect } from "next/navigation";
+      export default function Page() {
+        const ok = check();
+        return (<div>Hello</div>);
+      }
+    `;
+    expect(isRedirectOnly(body)).toBe(false);
+  });
+});
+
+describe("emitsJsonLd", () => {
+  it("detects literal application/ld+json script tag", () => {
+    expect(emitsJsonLd(`<script type="application/ld+json" />`)).toBe(true);
+  });
+  it("detects HubPage wrapper mount", () => {
+    expect(emitsJsonLd(`<HubPage config={cfg} />`)).toBe(true);
+  });
+  it("detects VerticalPillarPage wrapper mount", () => {
+    expect(emitsJsonLd(`<VerticalPillarPage data={data} />`)).toBe(true);
+  });
+  it("detects JsonLd helper component", () => {
+    expect(emitsJsonLd(`<JsonLd data={breadcrumb} />`)).toBe(true);
+  });
+  it("detects schema helper invocation", () => {
+    expect(emitsJsonLd(`const ld = breadcrumbJsonLd([]);`)).toBe(true);
+    expect(emitsJsonLd(`articleJsonLd({ title: 't' })`)).toBe(true);
+    expect(emitsJsonLd(`governmentServiceJsonLd(input)`)).toBe(true);
+  });
+  it("returns false for a page with no JSON-LD signal", () => {
+    expect(emitsJsonLd(`<div>Hello world</div>`)).toBe(false);
+  });
+  it("returns false when only the import is present (no usage)", () => {
+    // Bare import is not enough — the function must be invoked. The current
+    // heuristic uses `name(` so an import line alone does not trip it.
+    expect(emitsJsonLd(`import { breadcrumbJsonLd } from "@/lib/seo";`)).toBe(false);
+  });
+});

--- a/app/advisors/search/page.tsx
+++ b/app/advisors/search/page.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import { createClient } from "@/lib/supabase/server";
 import { logger } from "@/lib/logger";
 import AdvisorSearchClient from "./AdvisorSearchClient";
+import JsonLd from "@/components/JsonLd";
+import { absoluteUrl, breadcrumbJsonLd } from "@/lib/seo";
 
 const log = logger("advisors-search");
 
@@ -77,5 +79,16 @@ export default async function AdvisorSearchPage() {
     });
   }
 
-  return <AdvisorSearchClient initialAdvisors={advisors} />;
+  const breadcrumb = breadcrumbJsonLd([
+    { name: "Home", url: absoluteUrl("/") },
+    { name: "Find an Advisor", url: absoluteUrl("/find-advisor") },
+    { name: "Advanced Search" },
+  ]);
+
+  return (
+    <>
+      <JsonLd data={breadcrumb} testId="advisors-search-jsonld" />
+      <AdvisorSearchClient initialAdvisors={advisors} />
+    </>
+  );
 }

--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -7,6 +7,8 @@ import ArticleSearchInput from "@/components/ArticleSearchInput";
 import ArticleCategoryFilter from "@/components/ArticleCategoryFilter";
 import LeadMagnet from "@/components/LeadMagnet";
 import Icon from "@/components/Icon";
+import JsonLd from "@/components/JsonLd";
+import { absoluteUrl, breadcrumbJsonLd } from "@/lib/seo";
 
 export const metadata = {
   title: "Investing Guides & Articles",
@@ -298,8 +300,14 @@ export default async function ArticlesPage({
     ? allArticles.filter((a) => !ALL_CLUSTER_SLUGS.has(a.slug))
     : [];
 
+  const breadcrumb = breadcrumbJsonLd([
+    { name: "Home", url: absoluteUrl("/") },
+    { name: "Guides & Articles" },
+  ]);
+
   return (
     <div className="pt-5 pb-8 md:py-12">
+      <JsonLd data={breadcrumb} testId="articles-jsonld" />
       <div className="container-custom">
         <nav className="text-xs md:text-sm text-slate-500 mb-2 md:mb-4">
           <Link href="/" className="hover:text-slate-900">Home</Link>

--- a/app/authors/page.tsx
+++ b/app/authors/page.tsx
@@ -2,7 +2,8 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import Image from "next/image";
 import { createClient } from "@/lib/supabase/server";
-import { formatRole, SITE_NAME } from "@/lib/seo";
+import { absoluteUrl, breadcrumbJsonLd, formatRole, SITE_NAME } from "@/lib/seo";
+import JsonLd from "@/components/JsonLd";
 
 export const revalidate = 3600;
 
@@ -39,8 +40,14 @@ export default async function AuthorsIndexPage() {
 
   const members = (data as (TeamMember & { display_order: number | null })[] | null) || [];
 
+  const breadcrumb = breadcrumbJsonLd([
+    { name: "Home", url: absoluteUrl("/") },
+    { name: "Our Editorial Team" },
+  ]);
+
   return (
     <div className="py-8 md:py-14">
+      <JsonLd data={breadcrumb} testId="authors-jsonld" />
       <div className="container-custom max-w-5xl">
         <nav className="text-xs md:text-sm text-slate-500 mb-3">
           <Link href="/" className="hover:text-slate-900">Home</Link>

--- a/app/press/page.tsx
+++ b/app/press/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { SITE_NAME, SITE_URL } from "@/lib/seo";
+import { absoluteUrl, breadcrumbJsonLd, SITE_NAME, SITE_URL } from "@/lib/seo";
+import JsonLd from "@/components/JsonLd";
 
 export const revalidate = 86400;
 
@@ -36,8 +37,14 @@ const BRAND_COLORS = [
  *      as a source the media actually cites.
  */
 export default function PressPage() {
+  const breadcrumb = breadcrumbJsonLd([
+    { name: "Home", url: absoluteUrl("/") },
+    { name: "Press & Media" },
+  ]);
+
   return (
     <div className="py-8 md:py-14">
+      <JsonLd data={breadcrumb} testId="press-jsonld" />
       <div className="container-custom max-w-4xl">
         <nav className="text-xs md:text-sm text-slate-500 mb-3">
           <Link href="/" className="hover:text-slate-900">Home</Link>

--- a/app/properties/page.tsx
+++ b/app/properties/page.tsx
@@ -1,4 +1,6 @@
 import PropertiesClient from "./PropertiesClient";
+import JsonLd from "@/components/JsonLd";
+import { absoluteUrl, breadcrumbJsonLd } from "@/lib/seo";
 
 export const metadata = {
   title: "Investment Property Listings — Australian Property Opportunities (2026)",
@@ -23,5 +25,14 @@ export const metadata = {
 export const revalidate = 3600;
 
 export default function PropertiesPage() {
-  return <PropertiesClient />;
+  const breadcrumb = breadcrumbJsonLd([
+    { name: "Home", url: absoluteUrl("/") },
+    { name: "Investment Properties" },
+  ]);
+  return (
+    <>
+      <JsonLd data={breadcrumb} testId="properties-jsonld" />
+      <PropertiesClient />
+    </>
+  );
 }

--- a/app/property/buyer-agents/page.tsx
+++ b/app/property/buyer-agents/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import BuyerAgentsClient from "./BuyerAgentsClient";
 import ComplianceFooter from "@/components/ComplianceFooter";
+import JsonLd from "@/components/JsonLd";
+import { absoluteUrl, breadcrumbJsonLd } from "@/lib/seo";
 
 export const revalidate = 3600;
 
@@ -17,8 +19,14 @@ export const metadata: Metadata = {
 };
 
 export default function BuyerAgentsPage() {
+  const breadcrumb = breadcrumbJsonLd([
+    { name: "Home", url: absoluteUrl("/") },
+    { name: "Property", url: absoluteUrl("/properties") },
+    { name: "Buyer's Agents" },
+  ]);
   return (
     <>
+      <JsonLd data={breadcrumb} testId="buyer-agents-jsonld" />
       <BuyerAgentsClient />
       <div className="max-w-6xl mx-auto px-4 pb-8">
         <ComplianceFooter variant="property" />

--- a/app/property/listings/page.tsx
+++ b/app/property/listings/page.tsx
@@ -2,6 +2,8 @@ import { Suspense } from "react";
 import type { Metadata } from "next";
 import ListingsClient from "./ListingsClient";
 import ComplianceFooter from "@/components/ComplianceFooter";
+import JsonLd from "@/components/JsonLd";
+import { absoluteUrl, breadcrumbJsonLd } from "@/lib/seo";
 
 export const revalidate = 3600;
 
@@ -18,8 +20,14 @@ export const metadata: Metadata = {
 };
 
 export default function PropertyListingsPage() {
+  const breadcrumb = breadcrumbJsonLd([
+    { name: "Home", url: absoluteUrl("/") },
+    { name: "Property", url: absoluteUrl("/properties") },
+    { name: "New Developments & Listings" },
+  ]);
   return (
     <>
+      <JsonLd data={breadcrumb} testId="property-listings-jsonld" />
       <Suspense fallback={<div className="min-h-screen bg-white" />}>
         <ListingsClient />
       </Suspense>

--- a/app/property/suburbs/page.tsx
+++ b/app/property/suburbs/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import SuburbsClient from "./SuburbsClient";
 import ComplianceFooter from "@/components/ComplianceFooter";
+import JsonLd from "@/components/JsonLd";
+import { absoluteUrl, breadcrumbJsonLd } from "@/lib/seo";
 
 export const revalidate = 3600;
 
@@ -17,8 +19,14 @@ export const metadata: Metadata = {
 };
 
 export default function SuburbResearchPage() {
+  const breadcrumb = breadcrumbJsonLd([
+    { name: "Home", url: absoluteUrl("/") },
+    { name: "Property", url: absoluteUrl("/properties") },
+    { name: "Suburb Research" },
+  ]);
   return (
     <>
+      <JsonLd data={breadcrumb} testId="suburbs-jsonld" />
       <SuburbsClient />
       <div className="max-w-6xl mx-auto px-4 pb-8">
         <ComplianceFooter variant="property" />

--- a/app/switch-scripts/page.tsx
+++ b/app/switch-scripts/page.tsx
@@ -1,8 +1,9 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { listSwitchScripts } from "@/lib/switch-scripts";
-import { absoluteUrl, SITE_NAME } from "@/lib/seo";
+import { absoluteUrl, breadcrumbJsonLd, SITE_NAME } from "@/lib/seo";
 import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
+import JsonLd from "@/components/JsonLd";
 
 export const revalidate = 3600;
 
@@ -15,15 +16,20 @@ export const metadata: Metadata = {
 
 export default function SwitchScriptsIndexPage() {
   const scripts = listSwitchScripts();
+  const breadcrumb = breadcrumbJsonLd([
+    { name: "Home", url: absoluteUrl("/") },
+    { name: "Broker Switch Scripts" },
+  ]);
   return (
     <main className="mx-auto max-w-4xl px-4 py-10 md:py-14">
+      <JsonLd data={breadcrumb} testId="switch-scripts-jsonld" />
       <header className="mb-10">
         <h1 className="text-3xl font-bold text-slate-900 md:text-4xl">
           Broker switch scripts
         </h1>
         <p className="mt-3 max-w-2xl text-lg text-slate-700">
           Most users never ask their existing broker for a better deal — and
-          most brokers won't volunteer one. These scripts help you negotiate
+          most brokers won&rsquo;t volunteer one. These scripts help you negotiate
           first, then walk you through the transfer process if you do decide to
           leave (CHESS in-specie for ASX, ACATS for US, with AU tax notes).
         </p>

--- a/app/tag/[slug]/page.tsx
+++ b/app/tag/[slug]/page.tsx
@@ -4,6 +4,8 @@ import Image from "next/image";
 import { notFound } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import type { Article } from "@/lib/types";
+import { absoluteUrl, breadcrumbJsonLd } from "@/lib/seo";
+import JsonLd from "@/components/JsonLd";
 
 export const revalidate = 3600;
 
@@ -52,9 +54,15 @@ export default async function TagPage({ params }: Props) {
   if (articles.length === 0) notFound();
 
   const tagDisplay = prettifyTag(slug);
+  const breadcrumb = breadcrumbJsonLd([
+    { name: "Home", url: absoluteUrl("/") },
+    { name: "Articles", url: absoluteUrl("/articles") },
+    { name: `Tag: ${tagDisplay}` },
+  ]);
 
   return (
     <div className="py-6 md:py-12">
+      <JsonLd data={breadcrumb} testId="tag-jsonld" />
       <div className="container-custom">
         <nav className="text-xs md:text-sm text-slate-500 mb-2 md:mb-4">
           <Link href="/" className="hover:text-slate-900">Home</Link>

--- a/app/tools/page.tsx
+++ b/app/tools/page.tsx
@@ -1,4 +1,6 @@
 import ToolsClient from "./ToolsClient";
+import JsonLd from "@/components/JsonLd";
+import { absoluteUrl, breadcrumbJsonLd } from "@/lib/seo";
 
 export const metadata = {
   title: "Best Financial Tools & Apps in Australia (2026)",
@@ -23,5 +25,14 @@ export const metadata = {
 export const revalidate = 3600;
 
 export default function ToolsPage() {
-  return <ToolsClient />;
+  const breadcrumb = breadcrumbJsonLd([
+    { name: "Home", url: absoluteUrl("/") },
+    { name: "Financial Tools & Apps" },
+  ]);
+  return (
+    <>
+      <JsonLd data={breadcrumb} testId="tools-jsonld" />
+      <ToolsClient />
+    </>
+  );
 }

--- a/components/ForeignInvestmentLocalizedPage.tsx
+++ b/components/ForeignInvestmentLocalizedPage.tsx
@@ -1,6 +1,8 @@
 import Link from "next/link";
 import { BCP47_TAG, LOCALE_LABEL, LOCALES, type Locale } from "@/lib/i18n/locales";
 import { getForeignInvestmentDict } from "@/lib/i18n/dictionaries";
+import { absoluteUrl, breadcrumbJsonLd } from "@/lib/seo";
+import JsonLd from "@/components/JsonLd";
 
 interface Props {
   locale: Locale;
@@ -25,8 +27,14 @@ export default function ForeignInvestmentLocalizedPage({ locale }: Props) {
   const canonicalBase =
     locale === "en" ? "/foreign-investment" : `/${locale}/foreign-investment`;
 
+  const breadcrumb = breadcrumbJsonLd([
+    { name: "Home", url: absoluteUrl(locale === "en" ? "/" : `/${locale}`) },
+    { name: dict.hero.heading },
+  ]);
+
   return (
     <div lang={BCP47_TAG[locale]}>
+      <JsonLd data={breadcrumb} testId="foreign-investment-localized-jsonld" />
       <section className="bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 text-white py-10 md:py-14">
         <div className="container-custom max-w-4xl">
           <p className="text-[11px] font-bold uppercase tracking-wide text-amber-300 mb-2">

--- a/components/ForeignInvestmentSubPage.tsx
+++ b/components/ForeignInvestmentSubPage.tsx
@@ -1,6 +1,15 @@
 import Link from "next/link";
 import { BCP47_TAG, LOCALE_LABEL, LOCALES, type Locale } from "@/lib/i18n/locales";
 import { getSubPageDict, type SubPageDict } from "@/lib/i18n/dictionaries";
+import { absoluteUrl, breadcrumbJsonLd } from "@/lib/seo";
+import JsonLd from "@/components/JsonLd";
+
+const SUB_PAGE_HUB_LABEL: Record<Locale, string> = {
+  en: "Foreign investment",
+  zh: "外国人投资",
+  ko: "외국인 투자",
+  ar: "الاستثمار الأجنبي",
+};
 
 interface Props {
   locale: Locale;
@@ -31,8 +40,16 @@ export default function ForeignInvestmentSubPage({ locale, slug }: Props) {
   const dict: SubPageDict = getSubPageDict(slug, locale);
   const canonicalPath = `/${locale === "en" ? "" : `${locale}/`}foreign-investment/${slug}`;
 
+  const hubPath = locale === "en" ? "/foreign-investment" : `/${locale}/foreign-investment`;
+  const breadcrumb = breadcrumbJsonLd([
+    { name: "Home", url: absoluteUrl(locale === "en" ? "/" : `/${locale}`) },
+    { name: SUB_PAGE_HUB_LABEL[locale], url: absoluteUrl(hubPath) },
+    { name: dict.hero.heading },
+  ]);
+
   return (
     <div lang={BCP47_TAG[locale]}>
+      <JsonLd data={breadcrumb} testId="foreign-investment-subpage-jsonld" />
       <section className="bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 text-white py-10 md:py-14">
         <div className="container-custom max-w-4xl">
           <p className="text-[11px] font-bold uppercase tracking-wide text-amber-300 mb-2">

--- a/components/JsonLd.tsx
+++ b/components/JsonLd.tsx
@@ -1,0 +1,47 @@
+/**
+ * Tiny render-side wrapper for JSON-LD structured data.
+ *
+ * Centralises the boilerplate `<script type="application/ld+json">` block
+ * so page authors only have to compute the schema object — the helper
+ * handles serialisation, the script tag, and array-of-blocks fan-out.
+ *
+ * Pair with builders from `lib/seo.ts` (`breadcrumbJsonLd`),
+ * `lib/json-ld.ts`, or `lib/schema-markup.ts`.
+ *
+ * Example:
+ *
+ *     <JsonLd
+ *       data={breadcrumbJsonLd([
+ *         { name: "Home", url: absoluteUrl("/") },
+ *         { name: "Articles" },
+ *       ])}
+ *     />
+ *
+ * Multiple blocks (e.g. BreadcrumbList + ItemList on a listing page):
+ *
+ *     <JsonLd data={[breadcrumb, itemList]} />
+ */
+
+interface JsonLdProps {
+  /** A single JSON-LD object, or an array of them (one <script> per item). */
+  data: object | object[] | null | undefined;
+  /** Optional `data-testid` prefix. Each block gets `${testId}-${index}`. */
+  testId?: string;
+}
+
+export default function JsonLd({ data, testId }: JsonLdProps) {
+  if (!data) return null;
+  const items = Array.isArray(data) ? data : [data];
+  return (
+    <>
+      {items.map((d, i) => (
+        <script
+          key={i}
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(d) }}
+          {...(testId ? { "data-testid": `${testId}-${i}` } : {})}
+        />
+      ))}
+    </>
+  );
+}

--- a/docs/plans/pre-launch-wave-status.md
+++ b/docs/plans/pre-launch-wave-status.md
@@ -1,8 +1,8 @@
 # Pre-launch wave — autonomous loop status
 
-**Plan source:** `docs/plans/sleepy-growing-planet.md`
+**Plan source:** `docs/plans/pre-launch-wave-master-prompt.md` (Wave 1-6)
 **Loop prompt:** `docs/plans/pre-launch-wave-loop-prompt.md`
-**Last updated:** 2026-05-09 (initial design)
+**Last updated:** 2026-05-09 (cron iter — JSON-LD audit + ratchet shipped)
 
 ---
 
@@ -34,23 +34,51 @@
 
 ## Queue (in order)
 
-| # | Item | Tier | Status | PR | Notes |
+### Legacy queue (sleepy-growing-planet plan) — reconciliation
+
+The original 15-item legacy queue was largely shipped during the 2026-05-09 burst (29 PRs). The master prompt at `docs/plans/pre-launch-wave-master-prompt.md` is now the source of truth; this section is kept for audit traceability.
+
+| # | Item | Tier | Status | PR |
+|---|---|---|---|---|
+| 1 | PR #645 rebase + CI + merge (bundled wave) | C | ✅ done | #645 |
+| 2 | PR-X4 — annual-billing dashboard prompt | B | ✅ done | #682 |
+| 3 | Country-eligibility broker/advisor filter UI | B | ✅ done | #683 |
+| 4 | Cross-border specialty CTA wiring | A | ✅ done | #684 |
+| 5 | Premium 1.75× lead pricing for cross-border specialties | B | ✅ done | #685 |
+| 6 | Saudi Arabia Arabic page + UAE/SA → /ar/ auto-route | B | partial | #687 (UAE only — SA Arabic page deferred to Wave 6 housekeeping) |
+| 7 | Response-time badge on advisor cards | A | ✅ done | #686 |
+| 8 | PR-X1 — auto-topup at low balance | C | ✅ done | #688 |
+| 9 | PR-X2 — lead-quality SLA + response-time reward | B | ✅ done | #690 |
+| 10 | PR-X3 — firm-level billing dashboard | C | pending → see Wave 4 #23 in master prompt | — |
+| 11 | PR-X5 — investor / end-user accounts | B | pending → see Wave 2 in master prompt | — |
+| 12 | Eligibility match badge on cards | A | ✅ done | #691 |
+| 12.5 | EligibilityBadge on advisor cards | A | ✅ done | #693 |
+| 13 | Eligibility-aware quiz skip banner | A | ✅ done | #692 |
+| 14 | Cross-page smart recommendations strip | B | pending → see Wave 4 #20 in master prompt | — |
+| 15 | Personalized notifications (rule changes / opportunities) | C | partial | #694 (banner shipped) — DB+CRUD+digest tracked in Wave 4 #21/#22 |
+
+### Wave 1-6 master queue
+
+Source: `docs/plans/pre-launch-wave-master-prompt.md`. Lowercase rows mirror that file's tables — status flips here as iters land.
+
+| # | PR | Tier | Status | PR # | Notes |
 |---|---|---|---|---|---|
-| 1 | PR #645 rebase + CI + merge (bundled wave) | C | ✅ done 14:37 UTC | #645 | A1+F1+B1+B2+B3 shipped together |
-| 2 | PR-X4 — annual-billing dashboard prompt | B | 🔄 PR open, CI in flight | #682 | 4 files, +110 lines, 8/8 vitest local |
-| 3 | **NEW: Country-eligibility broker/advisor filter UI** | B | pending | — | Schema (PR #619+#623) is wasted until UI reads it. Half day. ~$5-10k MRR uplift. Filter `/best/[slug]` + `/find-advisor` by visitor's `iv_intent_country` against `country_eligibility.allowed_countries`/`blocked_countries` |
-| 4 | **NEW: Cross-border specialty CTA wiring** | A | pending | — | FIN_NOTEBOOK 2026-05-01 Phase A remaining. Half day. ~$15k+/yr. Each `/foreign-investment/<slug>` page's "Find specialist" CTA → `/find-advisor?specialty=UK+Pension+Transfer` (mapped per country) |
-| 5 | **NEW: Premium 1.75× lead pricing for cross-border specialties** | B | pending | — | FIN_NOTEBOOK Phase A remaining. Half day. ~$15-40k/yr direct margin. Edit `lib/advisor-billing.ts` to apply multiplier when lead specialty matches the cross-border set |
-| 6 | **NEW: Saudi Arabia Arabic page + UAE/SA → /ar/ auto-route** | B | pending | — | Completes Phase 5d+5e+5g. ~1 day. Clone UAE Arabic structure for SA; modify LocationFlagButton click handler to route UAE/SA → /ar/...; language toggle |
-| 7 | **NEW: Response-time badge on advisor cards** | A | pending | — | Mirror PR-X2 on visitor side. Half day. Badge advisors with `avg_response_minutes < 60` on `/find-advisor` cards. Lifts conversion |
-| 8 | PR-X1 — auto-topup at low balance | **C** | pending | — | Highest-stakes; opt-in + $500 cap + 24h cooldown. Tier C announce + 30-min wait + 2hr post-merge observation |
-| 9 | PR-X2 — lead-quality SLA + response-time reward (advisor side) | B | pending | — | Pairs with item #7. "Respond in 60 min, next lead at 25% off". Affects ranker; 15-min observation |
-| 10 | PR-X3 — firm-level billing dashboard | **C** | pending | — | Aggregates `firm_credit_balance_cents` view across firm's advisors. New `/firm-portal/billing` route |
-| 11 | PR-X5 — investor / end-user accounts | B | pending | — | Depends on PR-A1 foundation (in #645). New `investor_profiles` table; auth flows; saved searches/comparisons. Ship in 4 parts: migration → auth scaffold → portal shell → saved-comparisons feature. **NOT** week-sized — pre-launch window has runway, ship parts iteratively |
-| 12 | **NEW: Eligibility match badge on cards** | A | pending | — | Visible signal on every broker/advisor/fund card based on visitor's iv_intent_country + country_eligibility column (PR #619). 🟢 accepts / 🟡 visa-required / 🔴 not available. Compounds with PR #683 filter (filter hides incompatible; badge highlights matches). ~half day |
-| 13 | **NEW: Eligibility-aware quiz skip banner** | A | pending | — | On /find-advisor entry: "🇺🇰 We have 4 UK-AU specialists — skip quiz?" Reduces quiz friction for users who've already declared country. ~1 day. Item #12 must ship first |
-| 14 | **NEW: Cross-page smart recommendations strip** | B | pending | — | After find-advisor quiz, save answers + cookie. On subsequent pages render "Based on your profile: [matched advisors / brokers / opportunities]". Ranker uses quiz intent + country + budget. ~2-3 days |
-| 15 | **NEW: Personalized notifications (rule changes / opportunities)** | C | pending | — | In-app banners or email pushes for country-relevant rule changes ("FIRB threshold changes Mar 2026 — affects UK residents"). Per founder 2026-05-09 "no post-launch deferral": ship infra now (table + admin CRUD + banner component), seed with 2-3 real notifications, expand content over the runway |
+| W1.1 | AI Concierge homepage entry | B | pending | — | 2 days |
+| W1.2 | Calculator → lead capture funnel | B | pending | — | 1-2 days, 8+ calculators |
+| W1.3 | JSON-LD audit + ratchet | A | ✅ done | (this iter) | scripts/check-jsonld-coverage.mjs + 13 page fixes + CI gate |
+| W1.4 | Reverse marketplace ("Post a Request") | C | pending | — | 4-5 days, lib/stripe |
+| W2.5–W2.17 | PR-X5a–PR-X5m investor accounts | B/C | pending | — | 13 PRs across 5 phases |
+| W3.18 | Verified user reviews engine | B | pending | — | mirror PR #441 moderation |
+| W3.19 | First Home Buyer end-to-end journey | B | pending | — | 4 monetization levers |
+| W4.20 | Smart recommendations strip (legacy #14) | B | pending | — | 2-3 days |
+| W4.21 | Country rule alerts DB + admin CRUD (legacy #15 part 2) | B | pending | — | migrate ALERTS_BY_COUNTRY |
+| W4.22 | Country rule alerts email digest (legacy #15 part 4) | B | pending | — | weekly Resend cron |
+| W4.23 | PR-X3 firm billing dashboard (legacy #10) | C | pending | — | aggregate view |
+| W5.24 | Embed comparison widget | A | pending | — | iframe + UTM |
+| W5.25 | WhatsApp lead capture | B | pending | — | per-country gate |
+| W5.26 | Sponsored placement A/B testing | B | pending | — | placement_experiments table |
+| W5.27 | Halal / Sharia investing hub | B | pending | — | new vertical |
+| W6.28 | Stale PR sweep | maintenance | pending | — | pre-flight rebase loop |
 
 ## Decision log
 
@@ -66,6 +94,9 @@
 - 2026-05-09 14:35 | meta | Tier C gate = 30-min observation | Recommended balance per founder's prior pattern in workflow memory
 - 2026-05-09 14:35 | meta | Auto-topup = opt-in + $500 cap + 24h cooldown | All three guardrails layered; defense in depth
 - 2026-05-09 14:35 | #2 | Split-or-bundle deferred to per-iteration | If single PR works, ship; if Tier C blocks, split
+- 2026-05-09 22:25 | W1.3 | Picked JSON-LD audit + ratchet over W1.1/W1.2 | W1.1 (AI Concierge, 2 days) and W1.2 (calculator funnel, 1-2 days) won't fit in one cron fire; W1.3 is a half-day Tier A item that ships cleanly end-to-end. Lowest-numbered tractable Wave-1 item.
+- 2026-05-09 22:25 | W1.3 | Coverage gate strategy = "≥1 JSON-LD block per public route" | Per-type checks (Article vs FAQPage vs FinancialProduct) considered and rejected as too brittle — same page legitimately ships several blocks; new schema.org types appear regularly. Type correctness stays with page authors.
+- 2026-05-09 22:25 | W1.3 | noindex pages auto-exempt | Pages with `robots.index: false` opt out of search indexing; rich-snippet schema is wasted work. Detected via metadata-text scan
 
 ## Pause history
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "audit:console-calls": "node scripts/check-console-calls.mjs",
     "audit:duplicate-functions": "node scripts/check-duplicate-functions.mjs",
     "audit:stale-branches": "node scripts/check-stale-branches.mjs",
+    "audit:jsonld-coverage": "node scripts/check-jsonld-coverage.mjs",
     "db:types": "npx supabase gen types typescript --project-id ${SUPABASE_PROJECT_ID} > lib/database.types.ts",
     "db:types:check": "npx supabase gen types typescript --project-id ${SUPABASE_PROJECT_ID} > /tmp/database.types.generated.ts && diff -u lib/database.types.ts /tmp/database.types.generated.ts",
     "prepare": "husky || true"

--- a/scripts/check-jsonld-coverage.mjs
+++ b/scripts/check-jsonld-coverage.mjs
@@ -1,0 +1,381 @@
+#!/usr/bin/env node
+// @ts-check
+/**
+ * JSON-LD coverage gate.
+ *
+ * Walks every `app/**\/page.tsx` route, classifies it as public-content vs
+ * exempt (form / utility / portal / redirect / locale-fallback), and verifies
+ * that public-content routes emit at least one structured-data block —
+ * either a literal `<script type="application/ld+json">` tag or a wrapper
+ * component / helper from the allowlists below that emits one transitively.
+ *
+ * Why it exists:
+ *   Rich-snippet completeness drives SERP CTR. New public pages that ship
+ *   without JSON-LD silently regress organic discoverability, and a manual
+ *   audit re-discovers the same gaps every quarter. This gate catches the
+ *   regression at PR time.
+ *
+ * What's enforced:
+ *   - PUBLIC routes (everything not classified as EXEMPT) must emit JSON-LD.
+ *   - The check fires on every PR via `.github/workflows/jsonld-coverage.yml`.
+ *
+ * What's NOT enforced:
+ *   - Specific schema types per route. We require ≥1 JSON-LD block; the type
+ *     correctness is up to the page author. Per-type checks were considered
+ *     and rejected as too brittle (the same page legitimately ships several
+ *     blocks; new schema.org types appear regularly).
+ *
+ * Adding an exemption:
+ *   Update `EXEMPT_ROUTE_PATTERNS` with the route prefix and a one-line
+ *   reason in the leading comment. No allowlist file; the source is the
+ *   audit trail.
+ *
+ * Usage:
+ *   node scripts/check-jsonld-coverage.mjs            # audit + exit non-zero on miss
+ *   node scripts/check-jsonld-coverage.mjs --json     # machine-readable report
+ *   node scripts/check-jsonld-coverage.mjs --verbose  # include OK pages
+ */
+
+import { fileURLToPath } from "node:url";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+const APP_ROOT = "app";
+
+/**
+ * Wrapper components that themselves emit at least one JSON-LD block.
+ * A page that mounts one of these is considered covered.
+ */
+const WRAPPER_COMPONENTS = [
+  "HubPage",
+  "VerticalPillarPage",
+  "CountryHubTemplate",
+  "ListingSchemaScripts",
+  "ListingProductSchema",
+  "ForeignInvestmentLocalizedPage",
+  "ForeignInvestmentSubPage",
+  "JsonLd",
+];
+
+/**
+ * Helper functions in lib/json-ld.ts and lib/schema-markup.ts (and
+ * lib/seo.ts breadcrumbJsonLd) that return JSON-LD payloads.
+ * If a page calls one of these, it's considered covered — render-side is
+ * the page author's responsibility but pages that import + invoke a
+ * helper are verifiably emitting structured data.
+ */
+const SCHEMA_HELPER_NAMES = [
+  "articleJsonLd",
+  "articleLd",
+  "articleAuthorJsonLd",
+  "articleFaqJsonLd",
+  "brokerProductLd",
+  "brokerFinancialProductJsonLd",
+  "advisorProfileLd",
+  "advisorJsonLd",
+  "breadcrumbLd",
+  "breadcrumbJsonLd",
+  "faqLd",
+  "faqJsonLd",
+  "reviewLd",
+  "itemListJsonLd",
+  "listingProductJsonLd",
+  "calculatorJsonLd",
+  "versusComparisonJsonLd",
+  "governmentServiceJsonLd",
+  "ORGANIZATION_JSONLD",
+  "organizationLd",
+];
+
+/**
+ * Route patterns that are NOT public-content. Each entry is a path prefix
+ * relative to `app/` (no trailing slash) plus a category tag and a one-line
+ * justification. Pages whose path startsWith any prefix are exempt.
+ *
+ * Categories:
+ *   - PORTAL: authenticated portal surface (admin / advisor / broker / firm /
+ *     marketplace / account / dashboard / shortlist / onboarding)
+ *   - FORM: user-submission form whose primary purpose is data capture, not
+ *     content surfacing (review forms, signup, complaints)
+ *   - UTILITY: confirmation / unsubscribe / export / redirect-target pages
+ *     that have no SEO surface
+ *   - LEGAL: legal disclosures / privacy controls — no rich-snippet value;
+ *     content is deliberately compact and standardized
+ *   - INTERNAL: dev tools, preview routes, internal experiments
+ *   - SALES: B2B sales/pricing pages aimed at advisors not consumers; no
+ *     consumer-search demand
+ */
+const EXEMPT_ROUTE_PATTERNS = [
+  // PORTAL
+  { prefix: "admin", category: "PORTAL" },
+  { prefix: "account", category: "PORTAL" },
+  { prefix: "auth", category: "PORTAL" },
+  { prefix: "onboarding", category: "PORTAL" },
+  { prefix: "dashboard", category: "PORTAL" },
+  { prefix: "advisor-portal", category: "PORTAL" },
+  { prefix: "broker-portal", category: "PORTAL" },
+  { prefix: "firm-portal", category: "PORTAL" },
+  { prefix: "marketplace-portal", category: "PORTAL" },
+  { prefix: "shortlist", category: "PORTAL" },
+  { prefix: "invest/my-listings", category: "PORTAL" },
+  // FORM
+  { prefix: "advisor-signup", category: "FORM" },
+  { prefix: "advisor-apply", category: "FORM" },
+  { prefix: "broker-signup", category: "FORM" },
+  { prefix: "marketplace/register", category: "FORM" },
+  { prefix: "community/new", category: "FORM" },
+  { prefix: "complaints/submit", category: "FORM" },
+  { prefix: "review", category: "FORM" }, // /review/[token], /review/broker/[token]
+  { prefix: "reviews/write", category: "FORM" },
+  { prefix: "quotes", category: "FORM" }, // /quotes/[slug]/review
+  { prefix: "feedback", category: "FORM" },
+  { prefix: "find-advisor", category: "FORM" }, // interactive quiz; OG/metadata cover SERP
+  { prefix: "quick-audit", category: "FORM" },
+  { prefix: "quiz", category: "FORM" },
+  // UTILITY
+  { prefix: "newsletter/confirm", category: "UTILITY" },
+  { prefix: "newsletter/unsubscribe", category: "UTILITY" },
+  { prefix: "unsubscribe", category: "UTILITY" },
+  { prefix: "export", category: "UTILITY" }, // /export/* are PDF/print routes
+  { prefix: "go", category: "UTILITY" }, // /go/[slug]/apply is an outbound redirect handler
+  { prefix: "preview", category: "INTERNAL" },
+  { prefix: "dev", category: "INTERNAL" },
+  { prefix: "api", category: "INTERNAL" }, // route handlers get caught here only if a page.tsx exists alongside
+  // LEGAL — minimal SEO surface; standardized boilerplate
+  { prefix: "fsg", category: "LEGAL" },
+  { prefix: "legal", category: "LEGAL" },
+  { prefix: "privacy/data-rights", category: "LEGAL" },
+  { prefix: "accessibility", category: "LEGAL" },
+  // SALES — B2B advisor-facing, low consumer search demand
+  { prefix: "for-advisors", category: "SALES" },
+  { prefix: "advertise", category: "SALES" },
+];
+
+/**
+ * Routes that look exempt by prefix but actually need coverage. Empty for now;
+ * keep as escape hatch for future false positives where a SALES/etc. prefix
+ * does have rich-snippet value.
+ */
+const EXEMPT_OVERRIDE_PATTERNS = [];
+
+/* ────────────────────────────────────────────────────────────────────────── */
+/*  Helpers — exported for unit tests                                         */
+/* ────────────────────────────────────────────────────────────────────────── */
+
+/** Recursively list every `page.tsx` under `dir`. */
+export async function listPageFiles(dir) {
+  const out = [];
+  /** @type {Array<import("node:fs").Dirent>} */
+  let entries;
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    const p = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...(await listPageFiles(p)));
+    } else if (entry.name === "page.tsx" || entry.name === "layout.tsx") {
+      out.push(p);
+    }
+  }
+  return out;
+}
+
+/**
+ * Convert a filesystem page path (e.g. `app/article/[slug]/page.tsx`) to its
+ * route prefix relative to `app/` (e.g. `article/[slug]`).
+ */
+export function routeOf(filePath) {
+  const f = filePath.replaceAll("\\", "/");
+  const m = f.match(/^app\/(.+)\/(page|layout)\.tsx$/);
+  return m ? m[1] : "";
+}
+
+/**
+ * Returns the matching exemption entry for a route, or null if the route
+ * is public-content. The override list short-circuits a prefix match.
+ */
+export function findExemption(route) {
+  const r = route + "/";
+  for (const o of EXEMPT_OVERRIDE_PATTERNS) {
+    if (r.startsWith(o.prefix + "/")) return null;
+  }
+  for (const p of EXEMPT_ROUTE_PATTERNS) {
+    if (r.startsWith(p.prefix + "/")) return p;
+  }
+  return null;
+}
+
+/**
+ * Returns true when the page metadata declares `robots.index: false` (or
+ * the bare `noindex` directive in a literal robots string). Pages that
+ * opt out of indexing don't need rich-snippet schema — search engines
+ * won't surface them. The check is text-based so it picks up both the
+ * inline metadata literal and the `Metadata`-typed object form.
+ */
+export function isNoIndex(body) {
+  if (/\bindex\s*:\s*false\b/.test(body)) return true;
+  if (/robots\s*:\s*["'`][^"'`]*\bnoindex\b/i.test(body)) return true;
+  return false;
+}
+
+/**
+ * Returns true when the file body is just a `redirect()` /
+ * `permanentRedirect()` / standalone `notFound()`. These are routing
+ * forwarders without rendered content; SEO is tracked at the destination.
+ *
+ * Heuristic: the file calls `redirect(...)` / `permanentRedirect(...)`
+ * AND has no JSX return — i.e. nothing of the shape `return ( <` or
+ * `return <` in the body. Pages with `generateMetadata`, allowlists,
+ * etc. but no rendered output still qualify.
+ */
+export function isRedirectOnly(body) {
+  const stripped = body
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/\/\/[^\n]*/g, "");
+  const hasRedirect =
+    /\b(?:permanentRedirect|redirect)\(\s*[`"']/.test(stripped);
+  const hasJsxReturn = /\breturn\s*\(?\s*</.test(stripped);
+  if (hasRedirect && !hasJsxReturn) return true;
+  // notFound-only pages (rare; the route exists to gate access on auth/etc.).
+  const isNotFoundShim =
+    /\bnotFound\(\s*\)/.test(stripped) &&
+    !hasJsxReturn &&
+    stripped.split("\n").length < 30;
+  return isNotFoundShim;
+}
+
+/**
+ * Returns true when the page body or one of its same-directory layouts emits
+ * at least one JSON-LD block — directly via a `<script type="application/ld+json">`
+ * tag, or transitively via a wrapper component / helper invocation from the
+ * allowlists.
+ */
+export function emitsJsonLd(body) {
+  if (body.includes("application/ld+json")) return true;
+  for (const w of WRAPPER_COMPONENTS) {
+    if (new RegExp(`<\\s*${w}[\\s/>]`).test(body)) return true;
+  }
+  for (const fn of SCHEMA_HELPER_NAMES) {
+    if (new RegExp(`\\b${fn}\\s*\\(`).test(body)) return true;
+  }
+  return false;
+}
+
+/**
+ * Read a page file plus its in-tree layouts (same directory and ancestor
+ * directories up to `app/`). Layouts can emit JSON-LD that covers all
+ * descendant pages — e.g. `/find-advisor/layout.tsx` covers the client page.
+ */
+export async function readPageBundle(pageFile) {
+  const f = pageFile.replaceAll("\\", "/");
+  const parts = f.split("/");
+  const fragments = [await fs.readFile(pageFile, "utf8")];
+  // Walk up the path emitting each `layout.tsx` between this page and `app/`.
+  for (let i = parts.length - 1; i > 0; i--) {
+    if (parts[i - 1] !== APP_ROOT && i - 1 > 0) {
+      const dir = parts.slice(0, i).join("/");
+      const layoutPath = `${dir}/layout.tsx`;
+      try {
+        fragments.push(await fs.readFile(layoutPath, "utf8"));
+      } catch {
+        // No layout at this level — skip.
+      }
+    }
+  }
+  return fragments.join("\n/* ----- layout-boundary ----- */\n");
+}
+
+/* ────────────────────────────────────────────────────────────────────────── */
+/*  Main                                                                      */
+/* ────────────────────────────────────────────────────────────────────────── */
+
+export async function audit() {
+  const files = (await listPageFiles(APP_ROOT)).filter((f) =>
+    f.endsWith("page.tsx"),
+  );
+  /** @type {{ public: number, exempt: Record<string, number>, redirect: number, noindex: number, missing: string[] }} */
+  const report = { public: 0, exempt: {}, redirect: 0, noindex: 0, missing: [] };
+
+  for (const file of files) {
+    const route = routeOf(file);
+    const exempt = findExemption(route);
+    if (exempt) {
+      report.exempt[exempt.category] = (report.exempt[exempt.category] || 0) + 1;
+      continue;
+    }
+    const body = await fs.readFile(file, "utf8");
+    if (isRedirectOnly(body)) {
+      report.redirect++;
+      continue;
+    }
+    if (isNoIndex(body)) {
+      report.noindex++;
+      continue;
+    }
+    report.public++;
+    const bundle = await readPageBundle(file);
+    if (!emitsJsonLd(bundle)) {
+      report.missing.push(file.replaceAll("\\", "/"));
+    }
+  }
+  return report;
+}
+
+async function main() {
+  const args = new Set(process.argv.slice(2));
+  const report = await audit();
+
+  if (args.has("--json")) {
+    process.stdout.write(JSON.stringify(report, null, 2) + "\n");
+    process.exit(report.missing.length === 0 ? 0 : 1);
+  }
+
+  const totalExempt = Object.values(report.exempt).reduce(
+    (a, b) => a + b,
+    0,
+  );
+  console.log("JSON-LD coverage report");
+  console.log("───────────────────────");
+  console.log(`Public routes audited:         ${report.public}`);
+  console.log(`Redirect-only (no SEO surface): ${report.redirect}`);
+  console.log(`No-index (robots opt-out):      ${report.noindex}`);
+  console.log(`Exempt by category:`);
+  for (const [cat, n] of Object.entries(report.exempt)) {
+    console.log(`  - ${cat.padEnd(10)} ${n}`);
+  }
+  console.log(`Exempt total:                   ${totalExempt}`);
+  console.log("");
+
+  if (report.missing.length === 0) {
+    console.log("✅ All public routes emit JSON-LD.");
+    process.exit(0);
+  }
+
+  console.log(`❌ ${report.missing.length} public route(s) missing JSON-LD:`);
+  for (const m of report.missing) {
+    console.log(`  - ${m}`);
+  }
+  console.log("");
+  console.log("Fix: add a <script type=\"application/ld+json\"> block to the");
+  console.log("page (use helpers from lib/json-ld.ts, lib/schema-markup.ts,");
+  console.log("or lib/seo.ts breadcrumbJsonLd), OR mount one of the wrapper");
+  console.log("components (HubPage, VerticalPillarPage, CountryHubTemplate).");
+  console.log("");
+  console.log("If the route is genuinely exempt, add it to");
+  console.log("EXEMPT_ROUTE_PATTERNS in scripts/check-jsonld-coverage.mjs");
+  console.log("with a category and one-line reason.");
+  process.exit(1);
+}
+
+const isMain =
+  import.meta.url === `file://${process.argv[1]}` ||
+  fileURLToPath(import.meta.url) === process.argv[1];
+if (isMain) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(2);
+  });
+}


### PR DESCRIPTION
## Summary

Closes pre-launch wave queue item **W1.3** (JSON-LD audit + ratchet). Adds a CI gate that fails when a public route ships without structured data, and lifts current coverage from "best-effort" to "every public route emits JSON-LD".

## Why

Rich-snippet completeness drives SERP CTR. New public pages have been silently regressing organic discoverability — manual quarterly audits keep re-discovering the same gaps. This catches it at PR time.

## Tier

**A** — content/data + CI-gate addition only. No schema changes, no auth, no Stripe, no cron, no migrations.

## What's enforced

- **Public routes** (everything not classified as exempt) must emit ≥1 JSON-LD block — directly via `<script type="application/ld+json">`, via a wrapper component (`HubPage`, `VerticalPillarPage`, `CountryHubTemplate`, `ForeignInvestmentLocalizedPage`, `ForeignInvestmentSubPage`, `JsonLd`), or via a schema-builder helper (`breadcrumbJsonLd`, `articleJsonLd`, `governmentServiceJsonLd`, etc.).
- Per-type checks (Article vs FAQPage vs FinancialProduct) considered and rejected as too brittle — same page legitimately ships several blocks; new schema.org types appear regularly. Type correctness stays with page authors. The script is the floor.

## Coverage today

```
Public routes audited:           306 (all emit JSON-LD)
Redirect-only:                   9
No-index (robots opt-out):       16
Exempt by category:              200
  - PORTAL    164  (admin / *-portal / account / dashboard / onboarding)
  - FORM       17  (review / signup / quiz / complaint forms)
  - SALES       7  (advertise, for-advisors B2B pages)
  - UTILITY     7  (newsletter confirm, export PDFs, /go redirect handlers)
  - LEGAL       4  (legal, fsg, privacy/data-rights, accessibility)
  - INTERNAL    1  (preview/dev routes)
```

## Files

**New**
- `scripts/check-jsonld-coverage.mjs` — the gate (walk + classify + assert)
- `components/JsonLd.tsx` — small wrapper around `<script type="application/ld+json">` boilerplate
- `__tests__/scripts/check-jsonld-coverage.test.ts` — 25 cases for the helpers
- `__tests__/components/JsonLd.test.tsx` — 5 cases for the component

**CI / config**
- `.github/workflows/ci.yml` — new "JSON-LD coverage gate" step after lint
- `package.json` — adds `audit:jsonld-coverage` script

**Page fixes (breadcrumb JSON-LD)**
- `components/ForeignInvestmentLocalizedPage.tsx` — covers /foreign-investment + /zh + /ko hubs
- `components/ForeignInvestmentSubPage.tsx` — covers 9 sub-routes (siv/property/tax × en/zh/ko)
- `app/articles/page.tsx`
- `app/authors/page.tsx`
- `app/press/page.tsx`
- `app/properties/page.tsx`
- `app/property/buyer-agents/page.tsx`
- `app/property/listings/page.tsx`
- `app/property/suburbs/page.tsx`
- `app/switch-scripts/page.tsx`
- `app/tag/[slug]/page.tsx`
- `app/tools/page.tsx`
- `app/advisors/search/page.tsx`

**Plan tracking**
- `docs/plans/pre-launch-wave-status.md` — reconciles legacy queue with master prompt's Wave 1-6, marks W1.3 done

## Test plan

- [x] `node scripts/check-jsonld-coverage.mjs` → ✅ All 306 public routes emit JSON-LD
- [x] `npx vitest run __tests__/scripts/check-jsonld-coverage.test.ts __tests__/components/JsonLd.test.tsx` → 30/30 pass
- [x] `npx tsc --noEmit` → clean (strict + noUncheckedIndexedAccess)
- [x] `eslint` on every changed file → 0 warnings
- [x] Pre-push hook (tsc + rate-limit audit) → green
- [ ] CI: pending

https://claude.ai/code/session_01NvzKAWLqMtaUyzi2ikJNxJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01NvzKAWLqMtaUyzi2ikJNxJ)_