### PR TITLE
fix(ops): loop-spend-tracker — stage before diff to catch new STREAM_JSON

### DIFF
--- a/.github/workflows/loop-spend-tracker.yml
+++ b/.github/workflows/loop-spend-tracker.yml
@@ -214,11 +214,13 @@ jobs:
             "$today" "$alert_level" "${stream_json_entries%,}" "$flagged_json_arr" \
             > "$STREAM_JSON"
 
-          # Commit if any change
-          if ! git diff --quiet "$TRACK_FILE" "$STREAM_JSON"; then
-            git config user.name "loop-spend-tracker[bot]"
-            git config user.email "loop-spend-tracker@invest.com.au"
-            git add "$TRACK_FILE" "$STREAM_JSON"
+          # Commit if any change. Stage first so git diff --cached can detect
+          # both modified-tracked AND newly-added files (the untracked
+          # STREAM_JSON file confuses plain `git diff --quiet`).
+          git config user.name "loop-spend-tracker[bot]"
+          git config user.email "loop-spend-tracker@invest.com.au"
+          git add "$TRACK_FILE" "$STREAM_JSON"
+          if ! git diff --cached --quiet; then
             git commit -m "chore(ops): loop spend snapshot $today (commits=$loop_commits, est=${est_tokens_m}M)"
 
             # Retry push up to 3× in case main moved


### PR DESCRIPTION
## Problem
PR #698 added a write to `docs/ops/loop-spend-streams-latest.json` in `loop-spend-tracker.yml`. Manual `workflow_dispatch` on 2026-05-09 23:49 UTC ran successfully but produced no commit. Log ends at "Alert level: ok" — script exits without reaching push.

Cause: `git diff --quiet "\$TRACK_FILE" "\$STREAM_JSON"` returns 0 (no diff) for the untracked new file. The if-body never runs.

## Fix
Stage first with `git add`, then check `git diff --cached --quiet`. That detects both modified-tracked AND newly-added files.

Also moves `git config user.name/email` out of the if-block (idempotent, needed before any staging path).

## Tier
**C** — `.github/workflows/`. Founder authorized end-to-end during dashboard build session.

## Test plan
- [x] YAML lint clean (js-yaml parse OK)
- [x] Pre-push hook green
- [ ] Post-merge: re-trigger `gh workflow run loop-spend-tracker.yml`, confirm a new commit lands on main with both `loop-spend.md` row + `loop-spend-streams-latest.json` populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)