### PR TITLE
feat(kk): KK-03 — topic cluster map admin page [audit remediation]

### DIFF
--- a/__tests__/lib/hub-topic-clusters.test.ts
+++ b/__tests__/lib/hub-topic-clusters.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "vitest";
+import {
+  TOPIC_CLUSTERS,
+  getPillarForPath,
+  getClustersForPillar,
+  ALL_CLUSTER_PATHS,
+} from "@/lib/content/topic-clusters";
+
+describe("TOPIC_CLUSTERS registry", () => {
+  it("has entries for all major hub pillars from the KK-01 audit", () => {
+    const pillarPaths = TOPIC_CLUSTERS.map((tc) => tc.pillar);
+    expect(pillarPaths).toContain("/calculators");
+    expect(pillarPaths).toContain("/foreign-investment");
+    expect(pillarPaths).toContain("/etfs");
+    expect(pillarPaths).toContain("/super");
+    expect(pillarPaths).toContain("/smsf");
+    expect(pillarPaths).toContain("/insurance");
+    expect(pillarPaths).toContain("/tax");
+    expect(pillarPaths).toContain("/invest");
+  });
+
+  it("every cluster entry has a pillar, label, non-empty clusters, and non-empty supporting", () => {
+    for (const tc of TOPIC_CLUSTERS) {
+      expect(tc.pillar).toMatch(/^\//);
+      expect(tc.label).toBeTruthy();
+      expect(tc.clusters.length).toBeGreaterThan(0);
+      expect(tc.supporting.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("all paths start with /", () => {
+    for (const tc of TOPIC_CLUSTERS) {
+      expect(tc.pillar).toMatch(/^\//);
+      tc.clusters.forEach((p) => expect(p).toMatch(/^\//));
+      tc.supporting.forEach((p) => expect(p).toMatch(/^\//));
+    }
+  });
+
+  it("no pillar appears as its own cluster or supporting page", () => {
+    for (const tc of TOPIC_CLUSTERS) {
+      expect(tc.clusters).not.toContain(tc.pillar);
+      expect(tc.supporting).not.toContain(tc.pillar);
+    }
+  });
+
+  it("pillar paths are unique across the registry", () => {
+    const pillars = TOPIC_CLUSTERS.map((tc) => tc.pillar);
+    expect(new Set(pillars).size).toBe(pillars.length);
+  });
+
+  it("the calculators pillar covers the 8 orphaned calculator pages from KK-01", () => {
+    const calc = TOPIC_CLUSTERS.find((tc) => tc.pillar === "/calculators");
+    expect(calc).toBeDefined();
+    const knownOrphans = [
+      "/debt-calculator",
+      "/fire-calculator",
+      "/mortgage-calculator",
+      "/retirement-calculator",
+      "/smsf-calculator",
+      "/super-contributions-calculator",
+      "/dividend-reinvestment-calculator",
+    ];
+    for (const orphan of knownOrphans) {
+      expect(calc!.clusters).toContain(orphan);
+    }
+  });
+
+  it("/etfs pillar includes the three orphaned sub-category pages from KK-01", () => {
+    const etf = TOPIC_CLUSTERS.find((tc) => tc.pillar === "/etfs");
+    expect(etf).toBeDefined();
+    expect(etf!.clusters).toContain("/etfs/bonds");
+    expect(etf!.clusters).toContain("/etfs/international");
+    expect(etf!.clusters).toContain("/etfs/sectors");
+  });
+});
+
+describe("getPillarForPath", () => {
+  it("returns the cluster when querying a pillar path directly", () => {
+    const result = getPillarForPath("/calculators");
+    expect(result).toBeDefined();
+    expect(result!.pillar).toBe("/calculators");
+  });
+
+  it("returns the cluster when querying a cluster page path", () => {
+    const result = getPillarForPath("/mortgage-calculator");
+    expect(result).toBeDefined();
+    expect(result!.pillar).toBe("/calculators");
+  });
+
+  it("returns the cluster when querying a supporting page path", () => {
+    const result = getPillarForPath("/find-advisor");
+    expect(result).toBeDefined();
+  });
+
+  it("returns undefined for an unregistered path", () => {
+    expect(getPillarForPath("/completely-unknown-page-xyz")).toBeUndefined();
+  });
+});
+
+describe("getClustersForPillar", () => {
+  it("returns clusters + supporting for a known pillar", () => {
+    const result = getClustersForPillar("/foreign-investment");
+    expect(result).toBeDefined();
+    expect(result!.clusters).toContain("/foreign-investment/siv");
+    expect(result!.clusters).toContain("/foreign-investment/property");
+    expect(result!.supporting.length).toBeGreaterThan(0);
+  });
+
+  it("returns undefined for a non-pillar path", () => {
+    expect(getClustersForPillar("/mortgage-calculator")).toBeUndefined();
+    expect(getClustersForPillar("/unknown")).toBeUndefined();
+  });
+});
+
+describe("ALL_CLUSTER_PATHS", () => {
+  it("contains all pillar paths", () => {
+    for (const tc of TOPIC_CLUSTERS) {
+      expect(ALL_CLUSTER_PATHS).toContain(tc.pillar);
+    }
+  });
+
+  it("has no duplicates", () => {
+    expect(new Set(ALL_CLUSTER_PATHS).size).toBe(ALL_CLUSTER_PATHS.length);
+  });
+
+  it("every path starts with /", () => {
+    for (const p of ALL_CLUSTER_PATHS) {
+      expect(p).toMatch(/^\//);
+    }
+  });
+});

--- a/app/admin/topic-clusters/page.tsx
+++ b/app/admin/topic-clusters/page.tsx
@@ -1,0 +1,241 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import AdminShell from "@/components/AdminShell";
+import {
+  TOPIC_CLUSTERS,
+  getCrossClusterLinks,
+  getAllClusterArticleSlugs,
+} from "@/lib/topic-clusters";
+
+export const metadata: Metadata = {
+  title: "Topic Cluster Map — Admin",
+  robots: "noindex",
+};
+
+const CLUSTER_BORDER_COLORS = [
+  "border-blue-300",
+  "border-amber-300",
+  "border-emerald-300",
+  "border-purple-300",
+  "border-rose-300",
+  "border-indigo-300",
+  "border-teal-300",
+  "border-orange-300",
+  "border-cyan-300",
+  "border-lime-300",
+] as const;
+
+const CLUSTER_BG_COLORS = [
+  "bg-blue-50",
+  "bg-amber-50",
+  "bg-emerald-50",
+  "bg-purple-50",
+  "bg-rose-50",
+  "bg-indigo-50",
+  "bg-teal-50",
+  "bg-orange-50",
+  "bg-cyan-50",
+  "bg-lime-50",
+] as const;
+
+const PILLAR_DOT_COLORS = [
+  "bg-blue-500",
+  "bg-amber-500",
+  "bg-emerald-500",
+  "bg-purple-500",
+  "bg-rose-500",
+  "bg-indigo-500",
+  "bg-teal-500",
+  "bg-orange-500",
+  "bg-cyan-500",
+  "bg-lime-500",
+] as const;
+
+export default function TopicClusterMapPage() {
+  const totalSlugRefs = TOPIC_CLUSTERS.reduce(
+    (sum, c) => sum + 1 + c.clusterPages.length,
+    0
+  );
+
+  const allArticleSlugs = getAllClusterArticleSlugs();
+  const uniqueSlugCount = new Set(
+    TOPIC_CLUSTERS.flatMap((c) => [
+      c.pillar.slug,
+      ...c.clusterPages.map((p) => p.slug),
+    ])
+  ).size;
+
+  const crossClusterCount = totalSlugRefs - uniqueSlugCount;
+
+  const stats = [
+    { label: "Clusters", value: TOPIC_CLUSTERS.length },
+    { label: "Pages mapped", value: totalSlugRefs },
+    { label: "Unique slugs", value: uniqueSlugCount },
+    { label: "/article/ slugs", value: allArticleSlugs.length },
+    { label: "Cross-cluster pages", value: crossClusterCount },
+  ];
+
+  return (
+    <AdminShell
+      title="Topic Cluster Map"
+      subtitle="Pillar ↔ cluster ↔ spoke relationships powering ClusterNav + RelatedContentGrid (KK-03)"
+    >
+      {/* Summary row */}
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-3 mb-6">
+        {stats.map(({ label, value }) => (
+          <div
+            key={label}
+            className="bg-white border border-slate-200 rounded-xl p-4 text-center"
+          >
+            <p className="text-2xl font-extrabold text-slate-900">{value}</p>
+            <p className="text-xs text-slate-500 mt-0.5">{label}</p>
+          </div>
+        ))}
+      </div>
+
+      {/* Cluster cards */}
+      <div className="space-y-5">
+        {TOPIC_CLUSTERS.map((cluster, i) => {
+          const borderColor =
+            CLUSTER_BORDER_COLORS[i % CLUSTER_BORDER_COLORS.length] ??
+            "border-slate-300";
+          const bgColor =
+            CLUSTER_BG_COLORS[i % CLUSTER_BG_COLORS.length] ?? "bg-slate-50";
+          const dotColor =
+            PILLAR_DOT_COLORS[i % PILLAR_DOT_COLORS.length] ?? "bg-slate-500";
+
+          const crossLinks = getCrossClusterLinks(cluster.pillar.slug);
+
+          return (
+            <div
+              key={cluster.id}
+              className={`border-2 rounded-xl overflow-hidden ${borderColor} ${bgColor}`}
+            >
+              {/* Pillar row */}
+              <div
+                className={`px-4 py-3 border-b ${borderColor} bg-white/60`}
+              >
+                <div className="flex items-center gap-3">
+                  <span
+                    className={`w-2.5 h-2.5 rounded-full shrink-0 ${dotColor}`}
+                    aria-hidden="true"
+                  />
+                  <div className="flex-1 min-w-0">
+                    <p className="text-[0.65rem] font-semibold uppercase tracking-widest text-slate-400 mb-0.5">
+                      Pillar · {cluster.name}
+                    </p>
+                    <Link
+                      href={cluster.pillar.href}
+                      className="text-sm font-bold text-slate-900 hover:underline truncate block"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      {cluster.pillar.title}
+                    </Link>
+                    <p className="text-[0.65rem] font-mono text-slate-400 mt-0.5">
+                      {cluster.pillar.href}
+                    </p>
+                  </div>
+                  <span className="shrink-0 text-xs font-medium text-slate-500 bg-white/80 border border-slate-200 rounded-full px-2.5 py-0.5">
+                    {cluster.clusterPages.length} spokes
+                  </span>
+                </div>
+
+                {/* Cross-cluster links from pillar */}
+                {crossLinks.length > 0 && (
+                  <div className="mt-2 flex flex-wrap gap-1.5">
+                    {crossLinks.map((link) => (
+                      <span
+                        key={link.page.href}
+                        className="text-[0.6rem] px-2 py-0.5 bg-slate-100 text-slate-500 rounded-full border border-slate-200"
+                        title={`Cross-cluster link to ${link.clusterName}`}
+                      >
+                        ↗ {link.clusterName}
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </div>
+
+              {/* Spoke pages grid */}
+              <div className="px-4 py-3">
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
+                  {cluster.clusterPages.map((page) => {
+                    const isSharedSlug =
+                      TOPIC_CLUSTERS.filter((c) =>
+                        c.clusterPages.some((p) => p.slug === page.slug) ||
+                        c.pillar.slug === page.slug
+                      ).length > 1;
+
+                    return (
+                      <Link
+                        key={`${cluster.id}:${page.slug}`}
+                        href={page.href}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="flex items-start gap-2 p-2.5 bg-white/70 hover:bg-white rounded-lg border border-white hover:border-slate-200 transition-all group"
+                      >
+                        <span
+                          className="mt-1 w-1.5 h-1.5 rounded-full shrink-0 bg-slate-300"
+                          aria-hidden="true"
+                        />
+                        <div className="min-w-0 flex-1">
+                          <p className="text-xs font-medium text-slate-800 group-hover:text-slate-900 line-clamp-2 leading-snug">
+                            {page.title}
+                          </p>
+                          <p className="text-[0.6rem] font-mono text-slate-400 truncate mt-0.5">
+                            {page.href}
+                          </p>
+                        </div>
+                        {isSharedSlug && (
+                          <span
+                            className="shrink-0 mt-0.5 text-[0.55rem] px-1.5 py-0.5 bg-amber-100 text-amber-700 rounded font-semibold"
+                            title="Appears in multiple clusters"
+                          >
+                            ×2+
+                          </span>
+                        )}
+                      </Link>
+                    );
+                  })}
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* How it works */}
+      <div className="mt-8 bg-white border border-slate-200 rounded-xl p-5">
+        <h2 className="text-sm font-bold text-slate-900 mb-2">How this powers internal linking</h2>
+        <ul className="space-y-1.5 text-xs text-slate-600">
+          <li>
+            <span className="font-mono text-slate-500">getClustersForArticle(slug)</span>
+            {" "}— returns pillar + sibling pages for any article slug. Used by{" "}
+            <span className="font-mono text-slate-500">ClusterNav</span> on article pages.
+          </li>
+          <li>
+            <span className="font-mono text-slate-500">getClustersForBestPage(slug)</span>
+            {" "}— returns pillar + siblings for <span className="font-mono">/best/*</span> pages.
+          </li>
+          <li>
+            <span className="font-mono text-slate-500">getCrossClusterLinks(slug)</span>
+            {" "}— suggests pillar pages from topically related clusters (keyword overlap).
+          </li>
+          <li>
+            <span className="font-mono text-slate-500">RelatedContentGrid</span>
+            {" "}— renders related articles at the bottom of article + research pages using{" "}
+            <span className="font-mono text-slate-500">getClusterLinksForArticle()</span>.
+          </li>
+        </ul>
+        <p className="mt-3 text-xs text-slate-400">
+          Source of truth:{" "}
+          <span className="font-mono">lib/topic-clusters.ts</span> ·{" "}
+          <span className="font-mono">lib/internal-links.ts</span>. To add a
+          cluster, append to <span className="font-mono">TOPIC_CLUSTERS</span>;
+          links auto-propagate on next ISR revalidation.
+        </p>
+      </div>
+    </AdminShell>
+  );
+}

--- a/components/AdminSidebar.tsx
+++ b/components/AdminSidebar.tsx
@@ -40,6 +40,7 @@ const NAV_GROUPS = [
       { href: "/admin/advisor-articles", icon: "star", label: "Expert Articles" },
       { href: "/admin/content-calendar", icon: "calendar", label: "Content Calendar" },
       { href: "/admin/questions", icon: "message-circle", label: "Q&A" },
+      { href: "/admin/topic-clusters", icon: "git-branch", label: "Topic Clusters" },
     ],
   },
   {

--- a/docs/audits/kk-01-internal-link-audit.md
+++ b/docs/audits/kk-01-internal-link-audit.md
@@ -1,0 +1,202 @@
+# KK-01 Internal Link Audit
+
+**Date:** 2026-05-09  
+**Script:** `scripts/internal-link-audit.mjs`  
+**Queue item:** KK-01 — Identify orphaned pages + over-linked hubs  
+**Audit ref:** `docs/audits/codebase-health-2026-04-24.md` §5 (SEO + discoverability)
+
+---
+
+## Summary
+
+| Metric | Count |
+|--------|-------|
+| Total page routes scanned | 524 |
+| Orphaned (in-degree = 0) | 192 |
+| Low-linked (in-degree = 1) | 82 |
+| Over-linked hub (out-degree ≥ 25) | 1 |
+
+**How to regenerate:** `node scripts/internal-link-audit.mjs`
+
+---
+
+## Over-linked hubs
+
+Only one file exceeds the threshold (25 outgoing internal links):
+
+| File | Out-degree |
+|------|-----------|
+| `components/Footer.tsx` | 64 |
+
+The Footer is intentionally the primary navigation hub — no action needed. Its 64 links are the expected global nav surface. This does mean any page only linked from the footer is fragile (single point of inbound discoverability).
+
+---
+
+## Top 20 most-linked pages
+
+These are the pages with the most inbound links from other pages:
+
+| Rank | Route | In-degree |
+|------|-------|-----------|
+| 1 | `/compare` | 80 |
+| 2 | `/find-advisor` | 59 |
+| 3 | `/invest` | 54 |
+| 4 | `/advisors` | 50 |
+| 5 | `/quiz` | 38 |
+| 6 | `/foreign-investment` | 36 |
+| 7 | `/privacy` | 35 |
+| 8 | `/how-we-earn` | 25 |
+| 9 | `/calculators` | 24 |
+| 10 | `/methodology` | 21 |
+| 11 | `/terms` | 17 |
+| 12 | `/etfs` | 13 |
+| 13 | `/account` | 12 |
+| 13 | `/articles` | 12 |
+| 13 | `/editorial-policy` | 12 |
+| 13 | `/how-we-verify` | 12 |
+| 13 | `/quotes/post` | 12 |
+| 18 | `/advisor-portal` | 10 |
+| 19 | `/pro` | 9 |
+| 19 | `/property/buyer-agents` | 9 |
+
+---
+
+## Orphaned pages — classified
+
+### Category A: Expected orphans (no action needed)
+
+These pages are legitimately discovered via external links, search, or auth-gated flows rather than internal navigation:
+
+**Dynamic content routes** — crawled via sitemap, not cross-linked:
+- `/advisor/[slug]`, `/advisors/[type]`, `/advisors/[type]/[state]`
+- `/article/[slug]`, `/articles/[category]`
+- `/advisor-guides/[slug]`, `/best/[slug]`, `/best-for/[slug]`
+- `/broker/[slug]`, `/broker/[slug]/safety`, `/brokers/[slug]`, `/brokers/full-service/[slug]`
+- `/community/[category]`, `/community/[category]/[threadId]`
+- `/consultations/[slug]`, `/costs/[slug]`, `/course/[slug]`
+- `/courses/[slug]`, `/courses/[slug]/[lessonSlug]`
+- `/etfs/vs/[slugs]`, `/expert/[slug]`, `/firm/[slug]`
+- `/foreign-investment/[country]`, `/foreign-investment/from/[country]`
+- `/foreign-investment/guides/*` (3 country guides)
+- `/glossary/[term]`, `/how-to/[slug]`, `/invest/[slug]/*`
+- `/invest/funds/[slug]`, `/invest/*/listings/[slug]`
+- `/investing/[city]`, `/newsletter/[edition]`
+- `/property/buyer-agents/[slug]`, `/property/listings/[slug]`, `/property/suburbs/[slug]`
+- `/quotes/[slug]`, `/quotes/[slug]/review`, `/quotes/by/[type]/[state]`
+- `/reports/[slug]`, `/research/[slug]`, `/reviewers/[slug]`
+- `/scenario/[slug]`, `/stories`, `/tag/[slug]`, `/topic/[slug]`, `/versus/[slugs]`
+
+**Auth-gated / portal routes** — intentionally no public nav:
+- `/account/` (auth-gated, linked from header when signed in)
+- `/advisor-portal/*` (auth-gated)
+- `/broker-portal/*` (auth-gated)
+- `/dashboard`, `/portfolio`, `/preview/[token]`
+- `/review/[token]`, `/review/broker/[token]`
+
+**Utility / flow routes** — reached via redirect or form submission:
+- `/advertise/featured-placement/success`
+- `/export/comparison`, `/export/fee-impact`, `/export/quiz-results`
+- `/go/[slug]/apply` (affiliate redirect handler)
+- `/newsletter/confirm`, `/newsletter/unsubscribe`, `/unsubscribe`
+- `/share/shortlist/[code]`
+
+**Locale variants** — linked from language selector (not crawled as orphans):
+- `/ar/foreign-investment/*`, `/ko/foreign-investment/*`, `/zh/foreign-investment/*`
+
+---
+
+### Category B: Actionable orphans (add internal links)
+
+These pages should be linked from their natural parent hub but currently are not:
+
+#### Calculators (missing from `/calculators` hub)
+
+| Orphaned route | Natural parent | Recommended fix |
+|---------------|---------------|-----------------|
+| `/debt-calculator` | `/calculators` | Add card to calculators hub page |
+| `/dividend-reinvestment-calculator` | `/calculators` or `/dividends` | Add to calculators hub + dividends page |
+| `/fire-calculator` | `/calculators` | Add card to calculators hub page |
+| `/mortgage-calculator` | `/calculators` | Add card to calculators hub page |
+| `/property-vs-shares-calculator` | `/calculators` or `/property` | Add to calculators hub |
+| `/retirement-calculator` | `/calculators` | Add card to calculators hub page |
+| `/smsf-calculator` | `/calculators` or `/smsf` | Add card + link from `/smsf` |
+| `/super-contributions-calculator` | `/calculators` or `/super` | Add card + link from `/super` |
+
+#### Content pages (missing from relevant hubs)
+
+| Orphaned route | Natural parent | Recommended fix |
+|---------------|---------------|-----------------|
+| `/accessibility` | Footer or `/about` | Add to footer (compliance/trust section) |
+| `/api-docs` | Footer or `/for-advisors` | Add link from developer-facing pages |
+| `/benchmark` | `/research-tools` or admin | Add to research tools hub |
+| `/chess-lookup` | `/tools` or `/research` | Add to research tools |
+| `/course`, `/start` | Homepage or `/learn` | Add to homepage hero or nav |
+| `/embed` | `/for-advisors` or `/advertise` | Add to advertiser/developer pages |
+| `/for-advisors/pricing`, `/for-advisors/sponsored` | `/for-advisors` | Add to `/for-advisors` nav |
+| `/health-scores` | `/research-tools` | Add to research tools hub |
+| `/jobs` | Footer or `/about` | Add to footer |
+| `/press` | Footer or `/about` | Add to footer |
+| `/properties`, `/property-platforms` | `/property` | Add to property hub nav |
+| `/research-tools` | `/research` hub | Link from `/research` |
+| `/robo-advisors` | `/advisors` or `/invest` | Add to advisors hub |
+| `/term-deposits` | `/invest` or rates section | Link from `/invest` and `/rates` |
+
+#### Sub-pages missing parent links
+
+| Orphaned route | Missing link |
+|---------------|-------------|
+| `/advisor-guides/buyers-agent-vs-diy` | Should link from `/advisor-guides` hub |
+| `/advisor-guides/financial-planner-vs-robo-advisor` | Same |
+| `/advisor-guides/smsf-accountant-vs-diy` | Same |
+| `/advisor-guides/tax-agent-vs-accountant` | Same |
+| `/alerts/[slug]` | Should link from alert management UI |
+| `/best-for` | Should link from `/best` or `/compare` |
+| `/compare/etfs`, `/compare/insurance` | Should link from `/compare` hub |
+| `/dividends/franking-credits` | Should link from `/dividends` page |
+| `/etfs/bonds`, `/etfs/international`, `/etfs/sectors` | Should link from `/etfs` hub |
+| `/how-to/transfer-from/[broker_slug]` | Should link from `/how-to/transfer-from` |
+| `/insurance/health`, `/insurance/life`, `/insurance/income-protection`, etc. | Should link from `/insurance` hub |
+| `/invest/alternatives/guides` | Should link from `/invest/alternatives` |
+| `/invest/bonds`, `/invest/commodities`, `/invest/forex`, etc. | Should link from `/invest` hub |
+| `/lump-sum-investing/inheritance`, `/lump-sum-investing/redundancy` | Should link from `/lump-sum-investing` |
+| `/smsf/checklist`, `/smsf/crypto` | Should link from `/smsf` hub |
+| `/startup/grants` | Should link from `/startup` |
+| `/super/consolidation`, `/super/leaving-australia` | Should link from `/super` hub |
+| `/tax/crypto`, `/tax/negative-gearing` | Should link from `/tax` hub |
+
+---
+
+## Priority fixes for KK-02
+
+The highest-impact fixes (linking orphaned pages into their natural hubs) should be implemented in KK-02 (related-content widget) and KK-03 (topic cluster map). Immediate quick wins:
+
+1. **`/calculators` hub** — add 8 orphaned calculators as cards (highest traffic impact)
+2. **Footer** — add `/accessibility`, `/jobs`, `/press`, `/api-docs` to trust/company section
+3. **`/etfs` hub** — add sub-category nav: bonds, international, sectors
+4. **`/smsf` hub** — add links to checklist, crypto, calculator
+5. **`/insurance` hub** — add sub-type links to all 6 insurance sub-pages
+6. **`/invest` hub** — many orphaned sub-verticals (bonds, commodities, forex, etc.)
+
+---
+
+## Low-linked pages (in-degree = 1)
+
+82 pages have exactly one inbound link — fragile discoverability. Key examples:
+
+- `/cgt-calculator` — only linked from `FrankingClient.tsx` (add to calculators hub)
+- `/fee-simulator`, `/fee-tracker` — only linked from footer (add to calculators hub)
+- `/dividend-calculator` — only from one page (add to dividends hub)
+- `/foreign-investment/hong-kong`, `/foreign-investment/new-zealand` — only from `HomeCrossBorder.tsx`
+- `/brokers/full-service` — only from its own dynamic sub-page
+
+---
+
+## Recommended next steps
+
+| Priority | Item | Queue |
+|----------|------|-------|
+| High | Add 8 orphaned calculators to `/calculators` hub | KK-02 |
+| High | Add sub-category links in `/etfs`, `/smsf`, `/insurance`, `/super` hubs | KK-02 |
+| Medium | Related-content widget at bottom of article pages | KK-02 |
+| Medium | Topic cluster visualisation | KK-03 |
+| Low | Automated internal link injection (needs kill-switch) | KK-04 |

--- a/docs/audits/kk-03-topic-cluster-map.md
+++ b/docs/audits/kk-03-topic-cluster-map.md
@@ -1,0 +1,545 @@
+# KK-03 Topic Cluster Map
+
+**Date:** 2026-05-10  
+**Script:** `scripts/topic-cluster-map.mjs`  
+**Queue item:** KK-03 — Topic cluster map (pillar ↔ cluster ↔ supporting)  
+**Audit ref:** `docs/audits/codebase-health-2026-04-24.md` §5 (SEO + discoverability)
+
+---
+
+## Summary
+
+| Metric | Count |
+|--------|-------|
+| Hub pillar pages | 15 |
+| Cluster pages (direct sub-topics) | 61 |
+| Supporting pages (cross-hub links) | 67 |
+| Total unique paths in cluster map | 88 |
+
+---
+
+## Hub cluster overview
+
+| Pillar | Label | Clusters | Supporting |
+|--------|-------|----------|------------|
+| `/foreign-investment` | Foreign Investment | 9 | 4 |
+| `/calculators` | Calculators Hub | 16 | 5 |
+| `/compare` | Comparison Hub | 2 | 5 |
+| `/etfs` | ETFs Hub | 3 | 4 |
+| `/invest` | Investing Hub | 7 | 5 |
+| `/insurance` | Insurance Hub | 6 | 3 |
+| `/smsf` | SMSF Hub | 2 | 6 |
+| `/super` | Superannuation Hub | 2 | 4 |
+| `/tax` | Tax Hub | 2 | 5 |
+| `/property` | Property Hub | 1 | 6 |
+| `/advisors` | Advisors Hub | 3 | 7 |
+| `/research` | Research Hub | 4 | 3 |
+| `/startup` | Startup Hub | 1 | 3 |
+| `/lump-sum-investing` | Lump-Sum Investing Hub | 2 | 3 |
+| `/dividends` | Dividends Hub | 1 | 4 |
+
+---
+
+## Cluster map (Mermaid diagram)
+
+Solid arrows (→) = pillar → direct cluster sub-page.  
+Dashed arrows (⇢) = cross-hub structural links between pillars.
+
+```mermaid
+flowchart TD
+  foreign-investment["🏛️ Foreign Investment\n/foreign-investment"]:::pillar
+  foreign-investment_siv["Siv"]:::cluster
+  foreign-investment --> foreign-investment_siv
+  foreign-investment_property["Property"]:::cluster
+  foreign-investment --> foreign-investment_property
+  foreign-investment_tax["Tax"]:::cluster
+  foreign-investment --> foreign-investment_tax
+  foreign-investment_united-arab-emirates["United Arab Emirates"]:::cluster
+  foreign-investment --> foreign-investment_united-arab-emirates
+  foreign-investment_hong-kong["Hong Kong"]:::cluster
+  foreign-investment --> foreign-investment_hong-kong
+  foreign-investment_new-zealand["New Zealand"]:::cluster
+  foreign-investment --> foreign-investment_new-zealand
+  foreign-investment_guides_firb-guide["Firb Guide"]:::cluster
+  foreign-investment --> foreign-investment_guides_firb-guide
+  foreign-investment_guides_siv-guide["Siv Guide"]:::cluster
+  foreign-investment --> foreign-investment_guides_siv-guide
+  foreign-investment_guides_property-guide["Property Guide"]:::cluster
+  foreign-investment --> foreign-investment_guides_property-guide
+  calculators["🏛️ Calculators Hub\n/calculators"]:::pillar
+  mortgage-calculator["Mortgage Calculator"]:::cluster
+  calculators --> mortgage-calculator
+  super-contributions-calculator["Super Contributions Calculator"]:::cluster
+  calculators --> super-contributions-calculator
+  retirement-calculator["Retirement Calculator"]:::cluster
+  calculators --> retirement-calculator
+  debt-calculator["Debt Calculator"]:::cluster
+  calculators --> debt-calculator
+  fire-calculator["Fire Calculator"]:::cluster
+  calculators --> fire-calculator
+  property-vs-shares-calculator["Property Vs Shares Calculator"]:::cluster
+  calculators --> property-vs-shares-calculator
+  smsf-calculator["Smsf Calculator"]:::cluster
+  calculators --> smsf-calculator
+  dividend-reinvestment-calculator["Dividend Reinvestment Calculator"]:::cluster
+  calculators --> dividend-reinvestment-calculator
+  cgt-calculator["Cgt Calculator"]:::cluster
+  calculators --> cgt-calculator
+  fee-simulator["Fee Simulator"]:::cluster
+  calculators --> fee-simulator
+  fee-tracker["Fee Tracker"]:::cluster
+  calculators --> fee-tracker
+  dividend-calculator["Dividend Calculator"]:::cluster
+  calculators --> dividend-calculator
+  savings-calculator["Savings Calculator"]:::cluster
+  calculators --> savings-calculator
+  switching-calculator["Switching Calculator"]:::cluster
+  calculators --> switching-calculator
+  fee-impact["Fee Impact"]:::cluster
+  calculators --> fee-impact
+  borrowing-power-calculator["Borrowing Power Calculator"]:::cluster
+  calculators --> borrowing-power-calculator
+  compare["🏛️ Comparison Hub\n/compare"]:::pillar
+  compare_etfs["Etfs"]:::cluster
+  compare --> compare_etfs
+  compare_insurance["Insurance"]:::cluster
+  compare --> compare_insurance
+  etfs["🏛️ ETFs Hub\n/etfs"]:::pillar
+  etfs_bonds["Bonds"]:::cluster
+  etfs --> etfs_bonds
+  etfs_international["International"]:::cluster
+  etfs --> etfs_international
+  etfs_sectors["Sectors"]:::cluster
+  etfs --> etfs_sectors
+  invest["🏛️ Investing Hub\n/invest"]:::pillar
+  invest_bonds["Bonds"]:::cluster
+  invest --> invest_bonds
+  invest_commodities["Commodities"]:::cluster
+  invest --> invest_commodities
+  invest_forex["Forex"]:::cluster
+  invest --> invest_forex
+  invest_alternatives["Alternatives"]:::cluster
+  invest --> invest_alternatives
+  invest_alternatives_guides["Guides"]:::cluster
+  invest --> invest_alternatives_guides
+  invest_digital-infrastructure["Digital Infrastructure"]:::cluster
+  invest --> invest_digital-infrastructure
+  invest_startups["Startups"]:::cluster
+  invest --> invest_startups
+  insurance["🏛️ Insurance Hub\n/insurance"]:::pillar
+  insurance_health["Health"]:::cluster
+  insurance --> insurance_health
+  insurance_life["Life"]:::cluster
+  insurance --> insurance_life
+  insurance_income-protection["Income Protection"]:::cluster
+  insurance --> insurance_income-protection
+  insurance_total-and-permanent-disability["Total And Permanent Disability"]:::cluster
+  insurance --> insurance_total-and-permanent-disability
+  insurance_trauma["Trauma"]:::cluster
+  insurance --> insurance_trauma
+  insurance_business["Business"]:::cluster
+  insurance --> insurance_business
+  smsf["🏛️ SMSF Hub\n/smsf"]:::pillar
+  smsf_checklist["Checklist"]:::cluster
+  smsf --> smsf_checklist
+  smsf_crypto["Crypto"]:::cluster
+  smsf --> smsf_crypto
+  super["🏛️ Superannuation Hub\n/super"]:::pillar
+  super_consolidation["Consolidation"]:::cluster
+  super --> super_consolidation
+  super_leaving-australia["Leaving Australia"]:::cluster
+  super --> super_leaving-australia
+  tax["🏛️ Tax Hub\n/tax"]:::pillar
+  tax_crypto["Crypto"]:::cluster
+  tax --> tax_crypto
+  tax_negative-gearing["Negative Gearing"]:::cluster
+  tax --> tax_negative-gearing
+  property["🏛️ Property Hub\n/property"]:::pillar
+  property_buyer-agents["Buyer Agents"]:::cluster
+  property --> property_buyer-agents
+  advisors["🏛️ Advisors Hub\n/advisors"]:::pillar
+  advisors_financial-planners["Financial Planners"]:::cluster
+  advisors --> advisors_financial-planners
+  advisors_accountants["Accountants"]:::cluster
+  advisors --> advisors_accountants
+  advisors_mortgage-brokers["Mortgage Brokers"]:::cluster
+  advisors --> advisors_mortgage-brokers
+  research["🏛️ Research Hub\n/research"]:::pillar
+  research-tools["Research Tools"]:::cluster
+  research --> research-tools
+  health-scores["Health Scores"]:::cluster
+  research --> health-scores
+  benchmark["Benchmark"]:::cluster
+  research --> benchmark
+  chess-lookup["Chess Lookup"]:::cluster
+  research --> chess-lookup
+  startup["🏛️ Startup Hub\n/startup"]:::pillar
+  startup_grants["Grants"]:::cluster
+  startup --> startup_grants
+  lump-sum-investing["🏛️ Lump-Sum Investing Hub\n/lump-sum-investing"]:::pillar
+  lump-sum-investing_inheritance["Inheritance"]:::cluster
+  lump-sum-investing --> lump-sum-investing_inheritance
+  lump-sum-investing_redundancy["Redundancy"]:::cluster
+  lump-sum-investing --> lump-sum-investing_redundancy
+  dividends["🏛️ Dividends Hub\n/dividends"]:::pillar
+  dividends_franking-credits["Franking Credits"]:::cluster
+  dividends --> dividends_franking-credits
+  foreign-investment -.-> tax
+  foreign-investment -.-> property
+  calculators -.-> super
+  calculators -.-> property
+  calculators -.-> smsf
+  calculators -.-> compare
+  compare -.-> etfs
+  compare -.-> insurance
+  etfs -.-> invest
+  invest -.-> etfs
+  invest -.-> smsf
+  invest -.-> super
+  invest -.-> compare
+  insurance -.-> super
+  smsf -.-> super
+  smsf -.-> tax
+  smsf -.-> property
+  super -.-> smsf
+  tax -.-> property
+  tax -.-> invest
+  research -.-> etfs
+  research -.-> compare
+  startup -.-> tax
+  lump-sum-investing -.-> invest
+  lump-sum-investing -.-> tax
+  dividends -.-> etfs
+  dividends -.-> invest
+  classDef pillar fill:#2563eb,color:#fff,stroke:#1d4ed8,rx:8
+  classDef cluster fill:#dbeafe,color:#1e40af,stroke:#93c5fd
+```
+
+---
+
+## Detailed cluster tables
+
+### Foreign Investment (`/foreign-investment`)
+
+**Cluster pages** (should all link back to pillar + appear in pillar nav):
+
+- `/foreign-investment/siv`
+- `/foreign-investment/property`
+- `/foreign-investment/tax`
+- `/foreign-investment/united-arab-emirates`
+- `/foreign-investment/hong-kong`
+- `/foreign-investment/new-zealand`
+- `/foreign-investment/guides/firb-guide`
+- `/foreign-investment/guides/siv-guide`
+- `/foreign-investment/guides/property-guide`
+
+**Supporting pages** (bi-directional links where contextually natural):
+
+- `/find-advisor`
+- `/advisors/financial-planners`
+- `/tax`
+- `/property`
+
+---
+
+### Calculators Hub (`/calculators`)
+
+**Cluster pages** (should all link back to pillar + appear in pillar nav):
+
+- `/mortgage-calculator`
+- `/super-contributions-calculator`
+- `/retirement-calculator`
+- `/debt-calculator`
+- `/fire-calculator`
+- `/property-vs-shares-calculator`
+- `/smsf-calculator`
+- `/dividend-reinvestment-calculator`
+- `/cgt-calculator`
+- `/fee-simulator`
+- `/fee-tracker`
+- `/dividend-calculator`
+- `/savings-calculator`
+- `/switching-calculator`
+- `/fee-impact`
+- `/borrowing-power-calculator`
+
+**Supporting pages** (bi-directional links where contextually natural):
+
+- `/super`
+- `/property`
+- `/smsf`
+- `/compare`
+- `/find-advisor`
+
+---
+
+### Comparison Hub (`/compare`)
+
+**Cluster pages** (should all link back to pillar + appear in pillar nav):
+
+- `/compare/etfs`
+- `/compare/insurance`
+
+**Supporting pages** (bi-directional links where contextually natural):
+
+- `/best`
+- `/best-for`
+- `/quiz`
+- `/etfs`
+- `/insurance`
+
+---
+
+### ETFs Hub (`/etfs`)
+
+**Cluster pages** (should all link back to pillar + appear in pillar nav):
+
+- `/etfs/bonds`
+- `/etfs/international`
+- `/etfs/sectors`
+
+**Supporting pages** (bi-directional links where contextually natural):
+
+- `/compare/etfs`
+- `/best/etf-investing`
+- `/dividend-reinvestment-calculator`
+- `/invest`
+
+---
+
+### Investing Hub (`/invest`)
+
+**Cluster pages** (should all link back to pillar + appear in pillar nav):
+
+- `/invest/bonds`
+- `/invest/commodities`
+- `/invest/forex`
+- `/invest/alternatives`
+- `/invest/alternatives/guides`
+- `/invest/digital-infrastructure`
+- `/invest/startups`
+
+**Supporting pages** (bi-directional links where contextually natural):
+
+- `/etfs`
+- `/smsf`
+- `/super`
+- `/compare`
+- `/find-advisor`
+
+---
+
+### Insurance Hub (`/insurance`)
+
+**Cluster pages** (should all link back to pillar + appear in pillar nav):
+
+- `/insurance/health`
+- `/insurance/life`
+- `/insurance/income-protection`
+- `/insurance/total-and-permanent-disability`
+- `/insurance/trauma`
+- `/insurance/business`
+
+**Supporting pages** (bi-directional links where contextually natural):
+
+- `/compare/insurance`
+- `/find-advisor`
+- `/super`
+
+---
+
+### SMSF Hub (`/smsf`)
+
+**Cluster pages** (should all link back to pillar + appear in pillar nav):
+
+- `/smsf/checklist`
+- `/smsf/crypto`
+
+**Supporting pages** (bi-directional links where contextually natural):
+
+- `/smsf-calculator`
+- `/super`
+- `/tax`
+- `/property`
+- `/find-advisor`
+- `/advisors/financial-planners`
+
+---
+
+### Superannuation Hub (`/super`)
+
+**Cluster pages** (should all link back to pillar + appear in pillar nav):
+
+- `/super/consolidation`
+- `/super/leaving-australia`
+
+**Supporting pages** (bi-directional links where contextually natural):
+
+- `/super-contributions-calculator`
+- `/smsf`
+- `/retirement-calculator`
+- `/find-advisor`
+
+---
+
+### Tax Hub (`/tax`)
+
+**Cluster pages** (should all link back to pillar + appear in pillar nav):
+
+- `/tax/crypto`
+- `/tax/negative-gearing`
+
+**Supporting pages** (bi-directional links where contextually natural):
+
+- `/cgt-calculator`
+- `/property`
+- `/invest`
+- `/find-advisor`
+- `/advisors/financial-planners`
+
+---
+
+### Property Hub (`/property`)
+
+**Cluster pages** (should all link back to pillar + appear in pillar nav):
+
+- `/property/buyer-agents`
+
+**Supporting pages** (bi-directional links where contextually natural):
+
+- `/property-platforms`
+- `/mortgage-calculator`
+- `/property-vs-shares-calculator`
+- `/foreign-investment/property`
+- `/tax/negative-gearing`
+- `/find-advisor`
+
+---
+
+### Advisors Hub (`/advisors`)
+
+**Cluster pages** (should all link back to pillar + appear in pillar nav):
+
+- `/advisors/financial-planners`
+- `/advisors/accountants`
+- `/advisors/mortgage-brokers`
+
+**Supporting pages** (bi-directional links where contextually natural):
+
+- `/find-advisor`
+- `/quiz`
+- `/for-advisors`
+- `/advisor-guides/financial-planner-vs-robo-advisor`
+- `/advisor-guides/smsf-accountant-vs-diy`
+- `/advisor-guides/tax-agent-vs-accountant`
+- `/advisor-guides/buyers-agent-vs-diy`
+
+---
+
+### Research Hub (`/research`)
+
+**Cluster pages** (should all link back to pillar + appear in pillar nav):
+
+- `/research-tools`
+- `/health-scores`
+- `/benchmark`
+- `/chess-lookup`
+
+**Supporting pages** (bi-directional links where contextually natural):
+
+- `/articles`
+- `/etfs`
+- `/compare`
+
+---
+
+### Startup Hub (`/startup`)
+
+**Cluster pages** (should all link back to pillar + appear in pillar nav):
+
+- `/startup/grants`
+
+**Supporting pages** (bi-directional links where contextually natural):
+
+- `/invest/startups`
+- `/find-advisor`
+- `/tax`
+
+---
+
+### Lump-Sum Investing Hub (`/lump-sum-investing`)
+
+**Cluster pages** (should all link back to pillar + appear in pillar nav):
+
+- `/lump-sum-investing/inheritance`
+- `/lump-sum-investing/redundancy`
+
+**Supporting pages** (bi-directional links where contextually natural):
+
+- `/invest`
+- `/tax`
+- `/find-advisor`
+
+---
+
+### Dividends Hub (`/dividends`)
+
+**Cluster pages** (should all link back to pillar + appear in pillar nav):
+
+- `/dividends/franking-credits`
+
+**Supporting pages** (bi-directional links where contextually natural):
+
+- `/dividend-calculator`
+- `/dividend-reinvestment-calculator`
+- `/etfs`
+- `/invest`
+
+---
+
+## KK-01 orphan coverage
+
+Pages flagged as actionable orphans in KK-01 that are now mapped:
+
+| KK-01 orphaned page | Mapped pillar |
+|---------------------|---------------|
+| `/debt-calculator` | `/calculators` |
+| `/fire-calculator` | `/calculators` |
+| `/mortgage-calculator` | `/calculators` |
+| `/retirement-calculator` | `/calculators` |
+| `/smsf-calculator` | `/calculators` |
+| `/super-contributions-calculator` | `/calculators` |
+| `/dividend-reinvestment-calculator` | `/calculators` |
+| `/property-vs-shares-calculator` | `/calculators` |
+| `/etfs/bonds` | `/etfs` |
+| `/etfs/international` | `/etfs` |
+| `/etfs/sectors` | `/etfs` |
+| `/smsf/checklist` | `/smsf` |
+| `/smsf/crypto` | `/smsf` |
+| `/super/consolidation` | `/super` |
+| `/super/leaving-australia` | `/super` |
+| `/tax/crypto` | `/tax` |
+| `/tax/negative-gearing` | `/tax` |
+| `/insurance/health` | `/insurance` |
+| `/insurance/life` | `/insurance` |
+| `/insurance/income-protection` | `/insurance` |
+| `/lump-sum-investing/inheritance` | `/lump-sum-investing` |
+| `/lump-sum-investing/redundancy` | `/lump-sum-investing` |
+| `/dividends/franking-credits` | `/dividends` |
+| `/startup/grants` | `/startup` |
+
+Pages from KK-01 not yet addressed (require content or UX work, not just linking):
+- `/accessibility`, `/jobs`, `/press`, `/api-docs` — footer trust section items
+- `/benchmark`, `/chess-lookup`, `/health-scores` — research tools (mapped to `/research` pillar)
+- `/embed`, `/for-advisors/pricing`, `/for-advisors/sponsored` — advisor-facing surfaces
+
+---
+
+## Next steps
+
+| Priority | Item | Queue |
+|----------|------|-------|
+| High | Automated internal link injection using this cluster map | KK-04 |
+| High | Add orphaned calculators to `/calculators` hub page | KK-04 |
+| Medium | Add sub-category links in `/etfs`, `/smsf`, `/insurance` hub pages | KK-04 |
+| Low | Footer audit: add `/accessibility`, `/jobs`, `/press` | KK-04 |

--- a/lib/content/topic-clusters.ts
+++ b/lib/content/topic-clusters.ts
@@ -1,0 +1,314 @@
+/**
+ * Topic cluster map — KK-03 (audit remediation).
+ *
+ * Defines the INTENDED pillar → cluster → supporting page hierarchy for
+ * internal linking. This is the authoritative source for KK-04's automated
+ * link injection and for validating the KK-01 orphan findings against our
+ * planned information architecture.
+ *
+ * Structure:
+ *   pillar  — the hub page that owns the topic (high out-degree, indexed)
+ *   clusters — direct sub-topics that live under the pillar URL namespace
+ *   supporting — adjacent pages outside the namespace that strengthen the pillar
+ *
+ * Usage:
+ *   import { TOPIC_CLUSTERS, getPillarForPath, getClustersForPillar } from "@/lib/content/topic-clusters";
+ */
+
+export interface TopicCluster {
+  /** Canonical path of the pillar page. */
+  pillar: string;
+  /** Human label used in admin dashboards and audit reports. */
+  label: string;
+  /**
+   * Direct cluster pages — sub-topics under this pillar.
+   * Each should receive a contextual link from the pillar page.
+   */
+  clusters: string[];
+  /**
+   * Supporting pages — related content that reinforces the pillar but lives
+   * outside its URL namespace. Link should be bi-directional where natural.
+   */
+  supporting: string[];
+}
+
+export const TOPIC_CLUSTERS: TopicCluster[] = [
+  {
+    pillar: "/foreign-investment",
+    label: "Foreign Investment",
+    clusters: [
+      "/foreign-investment/siv",
+      "/foreign-investment/property",
+      "/foreign-investment/tax",
+      "/foreign-investment/united-arab-emirates",
+      "/foreign-investment/hong-kong",
+      "/foreign-investment/new-zealand",
+      "/foreign-investment/guides/firb-guide",
+      "/foreign-investment/guides/siv-guide",
+      "/foreign-investment/guides/property-guide",
+    ],
+    supporting: [
+      "/find-advisor",
+      "/advisors/financial-planners",
+      "/tax",
+      "/property",
+    ],
+  },
+  {
+    pillar: "/calculators",
+    label: "Calculators Hub",
+    clusters: [
+      "/mortgage-calculator",
+      "/super-contributions-calculator",
+      "/retirement-calculator",
+      "/debt-calculator",
+      "/fire-calculator",
+      "/property-vs-shares-calculator",
+      "/smsf-calculator",
+      "/dividend-reinvestment-calculator",
+      "/cgt-calculator",
+      "/fee-simulator",
+      "/fee-tracker",
+      "/dividend-calculator",
+      "/savings-calculator",
+      "/switching-calculator",
+      "/fee-impact",
+      "/borrowing-power-calculator",
+    ],
+    supporting: [
+      "/super",
+      "/property",
+      "/smsf",
+      "/compare",
+      "/find-advisor",
+    ],
+  },
+  {
+    pillar: "/compare",
+    label: "Comparison Hub",
+    clusters: [
+      "/compare/etfs",
+      "/compare/insurance",
+    ],
+    supporting: [
+      "/best",
+      "/best-for",
+      "/quiz",
+      "/etfs",
+      "/insurance",
+    ],
+  },
+  {
+    pillar: "/etfs",
+    label: "ETFs Hub",
+    clusters: [
+      "/etfs/bonds",
+      "/etfs/international",
+      "/etfs/sectors",
+    ],
+    supporting: [
+      "/compare/etfs",
+      "/best/etf-investing",
+      "/dividend-reinvestment-calculator",
+      "/invest",
+    ],
+  },
+  {
+    pillar: "/invest",
+    label: "Investing Hub",
+    clusters: [
+      "/invest/bonds",
+      "/invest/commodities",
+      "/invest/forex",
+      "/invest/alternatives",
+      "/invest/alternatives/guides",
+      "/invest/digital-infrastructure",
+      "/invest/startups",
+    ],
+    supporting: [
+      "/etfs",
+      "/smsf",
+      "/super",
+      "/compare",
+      "/find-advisor",
+    ],
+  },
+  {
+    pillar: "/insurance",
+    label: "Insurance Hub",
+    clusters: [
+      "/insurance/health",
+      "/insurance/life",
+      "/insurance/income-protection",
+      "/insurance/total-and-permanent-disability",
+      "/insurance/trauma",
+      "/insurance/business",
+    ],
+    supporting: [
+      "/compare/insurance",
+      "/find-advisor",
+      "/super",
+    ],
+  },
+  {
+    pillar: "/smsf",
+    label: "SMSF Hub",
+    clusters: [
+      "/smsf/checklist",
+      "/smsf/crypto",
+    ],
+    supporting: [
+      "/smsf-calculator",
+      "/super",
+      "/tax",
+      "/property",
+      "/find-advisor",
+      "/advisors/financial-planners",
+    ],
+  },
+  {
+    pillar: "/super",
+    label: "Superannuation Hub",
+    clusters: [
+      "/super/consolidation",
+      "/super/leaving-australia",
+    ],
+    supporting: [
+      "/super-contributions-calculator",
+      "/smsf",
+      "/retirement-calculator",
+      "/find-advisor",
+    ],
+  },
+  {
+    pillar: "/tax",
+    label: "Tax Hub",
+    clusters: [
+      "/tax/crypto",
+      "/tax/negative-gearing",
+    ],
+    supporting: [
+      "/cgt-calculator",
+      "/property",
+      "/invest",
+      "/find-advisor",
+      "/advisors/financial-planners",
+    ],
+  },
+  {
+    pillar: "/property",
+    label: "Property Hub",
+    clusters: [
+      "/property/buyer-agents",
+    ],
+    supporting: [
+      "/property-platforms",
+      "/mortgage-calculator",
+      "/property-vs-shares-calculator",
+      "/foreign-investment/property",
+      "/tax/negative-gearing",
+      "/find-advisor",
+    ],
+  },
+  {
+    pillar: "/advisors",
+    label: "Advisors Hub",
+    clusters: [
+      "/advisors/financial-planners",
+      "/advisors/accountants",
+      "/advisors/mortgage-brokers",
+    ],
+    supporting: [
+      "/find-advisor",
+      "/quiz",
+      "/for-advisors",
+      "/advisor-guides/financial-planner-vs-robo-advisor",
+      "/advisor-guides/smsf-accountant-vs-diy",
+      "/advisor-guides/tax-agent-vs-accountant",
+      "/advisor-guides/buyers-agent-vs-diy",
+    ],
+  },
+  {
+    pillar: "/research",
+    label: "Research Hub",
+    clusters: [
+      "/research-tools",
+      "/health-scores",
+      "/benchmark",
+      "/chess-lookup",
+    ],
+    supporting: [
+      "/articles",
+      "/etfs",
+      "/compare",
+    ],
+  },
+  {
+    pillar: "/startup",
+    label: "Startup Hub",
+    clusters: [
+      "/startup/grants",
+    ],
+    supporting: [
+      "/invest/startups",
+      "/find-advisor",
+      "/tax",
+    ],
+  },
+  {
+    pillar: "/lump-sum-investing",
+    label: "Lump-Sum Investing Hub",
+    clusters: [
+      "/lump-sum-investing/inheritance",
+      "/lump-sum-investing/redundancy",
+    ],
+    supporting: [
+      "/invest",
+      "/tax",
+      "/find-advisor",
+    ],
+  },
+  {
+    pillar: "/dividends",
+    label: "Dividends Hub",
+    clusters: [
+      "/dividends/franking-credits",
+    ],
+    supporting: [
+      "/dividend-calculator",
+      "/dividend-reinvestment-calculator",
+      "/etfs",
+      "/invest",
+    ],
+  },
+];
+
+/** Look up the pillar cluster entry for any path — returns undefined for paths
+ *  that are not a registered pillar, cluster, or supporting page. */
+export function getPillarForPath(
+  pathname: string,
+): TopicCluster | undefined {
+  return TOPIC_CLUSTERS.find(
+    (tc) =>
+      tc.pillar === pathname ||
+      tc.clusters.includes(pathname) ||
+      tc.supporting.includes(pathname),
+  );
+}
+
+/** Return all clusters (direct + supporting) for a given pillar path. */
+export function getClustersForPillar(
+  pillarPath: string,
+): { clusters: string[]; supporting: string[] } | undefined {
+  const tc = TOPIC_CLUSTERS.find((t) => t.pillar === pillarPath);
+  if (!tc) return undefined;
+  return { clusters: tc.clusters, supporting: tc.supporting };
+}
+
+/** All unique paths referenced in the cluster map — useful for link-injection
+ *  allow-listing and sitemap validation. */
+export const ALL_CLUSTER_PATHS: readonly string[] = [
+  ...new Set(
+    TOPIC_CLUSTERS.flatMap((tc) => [tc.pillar, ...tc.clusters, ...tc.supporting]),
+  ),
+];

--- a/scripts/internal-link-audit.mjs
+++ b/scripts/internal-link-audit.mjs
@@ -1,0 +1,255 @@
+#!/usr/bin/env node
+/**
+ * KK-01: Internal link audit — identify orphaned pages + over-linked hubs.
+ *
+ * Usage:
+ *   node scripts/internal-link-audit.mjs
+ *   node scripts/internal-link-audit.mjs --json   # machine-readable output
+ *   node scripts/internal-link-audit.mjs --threshold 30  # orphan in-degree threshold
+ *
+ * Outputs:
+ *   - Orphaned pages: in-degree = 0 (no other page links to them)
+ *   - Over-linked hubs: out-degree > OVER_LINK_THRESHOLD outgoing links
+ *   - Low-linked pages: in-degree = 1 (single inbound link — fragile)
+ *   - Top 20 most-linked pages (in-degree ranking)
+ */
+
+import { readFileSync, readdirSync, statSync } from "fs";
+import { join, relative } from "path";
+
+const ROOT = new URL("..", import.meta.url).pathname;
+const APP_DIR = join(ROOT, "app");
+const OVER_LINK_THRESHOLD = parseInt(
+  process.argv.find((a) => a.startsWith("--threshold="))?.split("=")[1] ?? "25"
+);
+const JSON_OUTPUT = process.argv.includes("--json");
+
+// ─── Discover all routes from app/**/page.tsx ───────────────────────────────
+
+function routeFromPath(absPath) {
+  const rel = relative(APP_DIR, absPath);
+  // app/foo/bar/page.tsx → /foo/bar
+  // app/page.tsx → /
+  // app/(group)/foo/page.tsx → /foo  (route groups stripped)
+  // app/[slug]/page.tsx → /[slug]
+  const segments = rel
+    .replace(/\/page\.tsx$/, "")
+    .split("/")
+    .filter(Boolean)
+    .filter((s) => !s.startsWith("("));
+  return "/" + segments.join("/");
+}
+
+function collectPages(dir, results = []) {
+  const entries = readdirSync(dir, { withFileTypes: true });
+  for (const e of entries) {
+    const full = join(dir, e.name);
+    if (e.isDirectory()) {
+      // skip node_modules, .next, __tests__
+      if (["node_modules", ".next", "__tests__", ".git"].includes(e.name)) continue;
+      collectPages(full, results);
+    } else if (e.name === "page.tsx") {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+const pageFiles = collectPages(APP_DIR);
+const allRoutes = new Set(pageFiles.map(routeFromPath));
+
+// ─── Extract internal links from all .tsx files ─────────────────────────────
+
+function collectTsx(dir, results = []) {
+  const entries = readdirSync(dir, { withFileTypes: true });
+  for (const e of entries) {
+    const full = join(dir, e.name);
+    if (e.isDirectory()) {
+      if (["node_modules", ".next", ".git"].includes(e.name)) continue;
+      collectTsx(full, results);
+    } else if (e.name.endsWith(".tsx") || e.name.endsWith(".ts")) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+// Patterns that capture the literal string of an href / to prop pointing internally.
+// Matches: href="/foo" href='/foo' href={"/foo"} href={`/foo`}
+const HREF_RE =
+  /(?:href|to)\s*=\s*(?:"(\/[^"]*?)"|'(\/[^']*?)'|\{["'`](\/[^"'`]*?)["'`]\})/g;
+
+/** Normalize a raw href to a canonical route string, stripping query/hash. */
+function normalizeHref(raw) {
+  if (!raw) return null;
+  // Strip query string and hash
+  const clean = raw.split("?")[0].split("#")[0];
+  // Ignore empty, external, or non-path hrefs
+  if (!clean || !clean.startsWith("/")) return null;
+  // Remove trailing slash (except root)
+  return clean.length > 1 ? clean.replace(/\/$/, "") : clean;
+}
+
+const allTsx = collectTsx(join(ROOT, "app"));
+// Also scan lib/ and components/ since they contain navigation components
+allTsx.push(...collectTsx(join(ROOT, "lib")));
+allTsx.push(...collectTsx(join(ROOT, "components")));
+
+// inDegree[route] = Set of source files that link to it
+// outDegree[sourceFile] = Set of target routes it links to
+const inDegree = new Map(); // route → Set<sourceFile>
+const outDegree = new Map(); // sourceFile → Set<route>
+
+for (const route of allRoutes) {
+  inDegree.set(route, new Set());
+}
+
+for (const file of allTsx) {
+  const source = relative(ROOT, file);
+  let content;
+  try {
+    content = readFileSync(file, "utf8");
+  } catch {
+    continue;
+  }
+
+  const targets = new Set();
+  let m;
+  HREF_RE.lastIndex = 0;
+  while ((m = HREF_RE.exec(content)) !== null) {
+    const raw = m[1] ?? m[2] ?? m[3];
+    const normalized = normalizeHref(raw);
+    if (!normalized) continue;
+    // Only count links to known routes (skip /api/*, /auth/*, dynamic segments we can't resolve)
+    if (allRoutes.has(normalized)) {
+      targets.add(normalized);
+      inDegree.get(normalized)?.add(source);
+    }
+  }
+
+  if (targets.size > 0) {
+    outDegree.set(source, targets);
+  }
+}
+
+// ─── Analysis ───────────────────────────────────────────────────────────────
+
+// Exclude known special routes that are legitimately not linked (auth callbacks, cron, etc.)
+const EXCLUDE_PREFIXES = [
+  "/api/",
+  "/auth/",
+  "/admin/",
+  "/_",
+  "/account/",   // gated behind auth, nav link sufficient
+];
+const EXCLUDE_EXACT = new Set([
+  "/",            // root is always in-degree 0 from other pages
+  "/sitemap",
+  "/robots",
+]);
+
+function isExcluded(route) {
+  if (EXCLUDE_EXACT.has(route)) return true;
+  return EXCLUDE_PREFIXES.some((p) => route.startsWith(p));
+}
+
+const orphaned = [];
+const lowLinked = [];
+
+for (const [route, sources] of inDegree.entries()) {
+  if (isExcluded(route)) continue;
+  if (sources.size === 0) orphaned.push(route);
+  else if (sources.size === 1) lowLinked.push({ route, sources: [...sources] });
+}
+
+orphaned.sort();
+lowLinked.sort((a, b) => a.route.localeCompare(b.route));
+
+const overLinked = [];
+for (const [file, targets] of outDegree.entries()) {
+  if (targets.size >= OVER_LINK_THRESHOLD) {
+    overLinked.push({ file, count: targets.size, targets: [...targets].sort() });
+  }
+}
+overLinked.sort((a, b) => b.count - a.count);
+
+// Top pages by in-degree
+const byInDegree = [...inDegree.entries()]
+  .filter(([r]) => !isExcluded(r))
+  .map(([r, s]) => ({ route: r, count: s.size }))
+  .sort((a, b) => b.count - a.count);
+
+// ─── Output ─────────────────────────────────────────────────────────────────
+
+if (JSON_OUTPUT) {
+  process.stdout.write(
+    JSON.stringify(
+      {
+        summary: {
+          totalRoutes: allRoutes.size,
+          orphaned: orphaned.length,
+          lowLinked: lowLinked.length,
+          overLinked: overLinked.length,
+        },
+        orphaned,
+        lowLinked,
+        overLinked,
+        topByInDegree: byInDegree.slice(0, 20),
+      },
+      null,
+      2
+    )
+  );
+} else {
+  const sep = "─".repeat(70);
+
+  console.log(`\nKK-01 Internal Link Audit — ${new Date().toISOString().split("T")[0]}`);
+  console.log(sep);
+  console.log(`Total page routes scanned: ${allRoutes.size}`);
+  console.log(`Orphaned (in-degree = 0):  ${orphaned.length}`);
+  console.log(`Low-linked (in-degree = 1): ${lowLinked.length}`);
+  console.log(`Over-linked (out-degree ≥ ${OVER_LINK_THRESHOLD}): ${overLinked.length}`);
+  console.log();
+
+  console.log("ORPHANED PAGES (no incoming internal links)");
+  console.log(sep);
+  if (orphaned.length === 0) {
+    console.log("  (none)");
+  } else {
+    for (const r of orphaned) console.log(`  ${r}`);
+  }
+  console.log();
+
+  console.log(`OVER-LINKED HUBS (≥${OVER_LINK_THRESHOLD} outgoing internal links)`);
+  console.log(sep);
+  if (overLinked.length === 0) {
+    console.log("  (none)");
+  } else {
+    for (const { file, count } of overLinked) {
+      console.log(`  ${file}  (${count} links)`);
+    }
+  }
+  console.log();
+
+  console.log("TOP 20 MOST-LINKED PAGES (in-degree)");
+  console.log(sep);
+  for (const { route, count } of byInDegree.slice(0, 20)) {
+    console.log(`  ${String(count).padStart(4)}  ${route}`);
+  }
+  console.log();
+
+  console.log("LOW-LINKED PAGES (exactly 1 incoming link — fragile)");
+  console.log(sep);
+  if (lowLinked.length === 0) {
+    console.log("  (none)");
+  } else {
+    for (const { route, sources } of lowLinked.slice(0, 30)) {
+      console.log(`  ${route}`);
+      console.log(`         linked from: ${sources[0]}`);
+    }
+    if (lowLinked.length > 30) {
+      console.log(`  ... and ${lowLinked.length - 30} more`);
+    }
+  }
+  console.log();
+}

--- a/scripts/topic-cluster-map.mjs
+++ b/scripts/topic-cluster-map.mjs
@@ -1,0 +1,364 @@
+#!/usr/bin/env node
+/**
+ * KK-03 — Topic cluster map generator
+ *
+ * Reads lib/content/topic-clusters.ts (hub-page clusters) and
+ * lib/topic-clusters.ts (article clusters), cross-references with the
+ * KK-01 internal link audit findings, and outputs either:
+ *   --mermaid   A Mermaid flowchart (default)
+ *   --json      Raw cluster data as JSON
+ *   --report    Markdown coverage report
+ *
+ * Usage:
+ *   node scripts/topic-cluster-map.mjs [--mermaid|--json|--report]
+ *   node scripts/topic-cluster-map.mjs --report > docs/audits/kk-03-topic-cluster-map.md
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, "..");
+
+// ---------------------------------------------------------------------------
+// Inline hub cluster data (mirrors lib/content/topic-clusters.ts — kept as JS
+// to avoid needing ts-node in the CI pipeline that runs this script)
+// ---------------------------------------------------------------------------
+const HUB_CLUSTERS = [
+  {
+    pillar: "/foreign-investment",
+    label: "Foreign Investment",
+    clusters: [
+      "/foreign-investment/siv",
+      "/foreign-investment/property",
+      "/foreign-investment/tax",
+      "/foreign-investment/united-arab-emirates",
+      "/foreign-investment/hong-kong",
+      "/foreign-investment/new-zealand",
+      "/foreign-investment/guides/firb-guide",
+      "/foreign-investment/guides/siv-guide",
+      "/foreign-investment/guides/property-guide",
+    ],
+    supporting: ["/find-advisor", "/advisors/financial-planners", "/tax", "/property"],
+  },
+  {
+    pillar: "/calculators",
+    label: "Calculators Hub",
+    clusters: [
+      "/mortgage-calculator",
+      "/super-contributions-calculator",
+      "/retirement-calculator",
+      "/debt-calculator",
+      "/fire-calculator",
+      "/property-vs-shares-calculator",
+      "/smsf-calculator",
+      "/dividend-reinvestment-calculator",
+      "/cgt-calculator",
+      "/fee-simulator",
+      "/fee-tracker",
+      "/dividend-calculator",
+      "/savings-calculator",
+      "/switching-calculator",
+      "/fee-impact",
+      "/borrowing-power-calculator",
+    ],
+    supporting: ["/super", "/property", "/smsf", "/compare", "/find-advisor"],
+  },
+  {
+    pillar: "/compare",
+    label: "Comparison Hub",
+    clusters: ["/compare/etfs", "/compare/insurance"],
+    supporting: ["/best", "/best-for", "/quiz", "/etfs", "/insurance"],
+  },
+  {
+    pillar: "/etfs",
+    label: "ETFs Hub",
+    clusters: ["/etfs/bonds", "/etfs/international", "/etfs/sectors"],
+    supporting: ["/compare/etfs", "/best/etf-investing", "/dividend-reinvestment-calculator", "/invest"],
+  },
+  {
+    pillar: "/invest",
+    label: "Investing Hub",
+    clusters: [
+      "/invest/bonds",
+      "/invest/commodities",
+      "/invest/forex",
+      "/invest/alternatives",
+      "/invest/alternatives/guides",
+      "/invest/digital-infrastructure",
+      "/invest/startups",
+    ],
+    supporting: ["/etfs", "/smsf", "/super", "/compare", "/find-advisor"],
+  },
+  {
+    pillar: "/insurance",
+    label: "Insurance Hub",
+    clusters: [
+      "/insurance/health",
+      "/insurance/life",
+      "/insurance/income-protection",
+      "/insurance/total-and-permanent-disability",
+      "/insurance/trauma",
+      "/insurance/business",
+    ],
+    supporting: ["/compare/insurance", "/find-advisor", "/super"],
+  },
+  {
+    pillar: "/smsf",
+    label: "SMSF Hub",
+    clusters: ["/smsf/checklist", "/smsf/crypto"],
+    supporting: ["/smsf-calculator", "/super", "/tax", "/property", "/find-advisor", "/advisors/financial-planners"],
+  },
+  {
+    pillar: "/super",
+    label: "Superannuation Hub",
+    clusters: ["/super/consolidation", "/super/leaving-australia"],
+    supporting: ["/super-contributions-calculator", "/smsf", "/retirement-calculator", "/find-advisor"],
+  },
+  {
+    pillar: "/tax",
+    label: "Tax Hub",
+    clusters: ["/tax/crypto", "/tax/negative-gearing"],
+    supporting: ["/cgt-calculator", "/property", "/invest", "/find-advisor", "/advisors/financial-planners"],
+  },
+  {
+    pillar: "/property",
+    label: "Property Hub",
+    clusters: ["/property/buyer-agents"],
+    supporting: ["/property-platforms", "/mortgage-calculator", "/property-vs-shares-calculator", "/foreign-investment/property", "/tax/negative-gearing", "/find-advisor"],
+  },
+  {
+    pillar: "/advisors",
+    label: "Advisors Hub",
+    clusters: ["/advisors/financial-planners", "/advisors/accountants", "/advisors/mortgage-brokers"],
+    supporting: [
+      "/find-advisor",
+      "/quiz",
+      "/for-advisors",
+      "/advisor-guides/financial-planner-vs-robo-advisor",
+      "/advisor-guides/smsf-accountant-vs-diy",
+      "/advisor-guides/tax-agent-vs-accountant",
+      "/advisor-guides/buyers-agent-vs-diy",
+    ],
+  },
+  {
+    pillar: "/research",
+    label: "Research Hub",
+    clusters: ["/research-tools", "/health-scores", "/benchmark", "/chess-lookup"],
+    supporting: ["/articles", "/etfs", "/compare"],
+  },
+  {
+    pillar: "/startup",
+    label: "Startup Hub",
+    clusters: ["/startup/grants"],
+    supporting: ["/invest/startups", "/find-advisor", "/tax"],
+  },
+  {
+    pillar: "/lump-sum-investing",
+    label: "Lump-Sum Investing Hub",
+    clusters: ["/lump-sum-investing/inheritance", "/lump-sum-investing/redundancy"],
+    supporting: ["/invest", "/tax", "/find-advisor"],
+  },
+  {
+    pillar: "/dividends",
+    label: "Dividends Hub",
+    clusters: ["/dividends/franking-credits"],
+    supporting: ["/dividend-calculator", "/dividend-reinvestment-calculator", "/etfs", "/invest"],
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Node ID helpers (Mermaid-safe, no slashes)
+// ---------------------------------------------------------------------------
+function nodeId(path) {
+  return path.replace(/\//g, "_").replace(/^_/, "") || "root";
+}
+
+function shortLabel(path) {
+  const parts = path.split("/").filter(Boolean);
+  if (parts.length === 0) return "/";
+  return parts[parts.length - 1].replace(/-/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+// ---------------------------------------------------------------------------
+// Mermaid output
+// ---------------------------------------------------------------------------
+function renderMermaid() {
+  const lines = ["```mermaid", "flowchart TD"];
+
+  for (const tc of HUB_CLUSTERS) {
+    const pid = nodeId(tc.pillar);
+    lines.push(`  ${pid}["🏛️ ${tc.label}\\n${tc.pillar}"]:::pillar`);
+
+    for (const c of tc.clusters) {
+      const cid = nodeId(c);
+      lines.push(`  ${cid}["${shortLabel(c)}"]:::cluster`);
+      lines.push(`  ${pid} --> ${cid}`);
+    }
+  }
+
+  // Pillar-to-pillar cross-links (supporting that are also pillars)
+  const pillarPaths = new Set(HUB_CLUSTERS.map((tc) => tc.pillar));
+  const seen = new Set();
+  for (const tc of HUB_CLUSTERS) {
+    for (const s of tc.supporting) {
+      if (pillarPaths.has(s)) {
+        const key = `${tc.pillar}::${s}`;
+        if (!seen.has(key)) {
+          seen.add(key);
+          lines.push(`  ${nodeId(tc.pillar)} -.-> ${nodeId(s)}`);
+        }
+      }
+    }
+  }
+
+  lines.push("  classDef pillar fill:#2563eb,color:#fff,stroke:#1d4ed8,rx:8");
+  lines.push("  classDef cluster fill:#dbeafe,color:#1e40af,stroke:#93c5fd");
+  lines.push("```");
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// JSON output
+// ---------------------------------------------------------------------------
+function renderJson() {
+  return JSON.stringify({ hub_clusters: HUB_CLUSTERS }, null, 2);
+}
+
+// ---------------------------------------------------------------------------
+// Markdown report
+// ---------------------------------------------------------------------------
+function renderReport() {
+  const totalClusters = HUB_CLUSTERS.reduce((n, tc) => n + tc.clusters.length, 0);
+  const totalSupporting = HUB_CLUSTERS.reduce((n, tc) => n + tc.supporting.length, 0);
+  const allPaths = new Set([
+    ...HUB_CLUSTERS.map((tc) => tc.pillar),
+    ...HUB_CLUSTERS.flatMap((tc) => tc.clusters),
+    ...HUB_CLUSTERS.flatMap((tc) => tc.supporting),
+  ]);
+
+  const lines = [
+    "# KK-03 Topic Cluster Map",
+    "",
+    `**Date:** ${new Date().toISOString().slice(0, 10)}  `,
+    "**Script:** `scripts/topic-cluster-map.mjs`  ",
+    "**Queue item:** KK-03 — Topic cluster map (pillar ↔ cluster ↔ supporting)  ",
+    "**Audit ref:** `docs/audits/codebase-health-2026-04-24.md` §5 (SEO + discoverability)",
+    "",
+    "---",
+    "",
+    "## Summary",
+    "",
+    "| Metric | Count |",
+    "|--------|-------|",
+    `| Hub pillar pages | ${HUB_CLUSTERS.length} |`,
+    `| Cluster pages (direct sub-topics) | ${totalClusters} |`,
+    `| Supporting pages (cross-hub links) | ${totalSupporting} |`,
+    `| Total unique paths in cluster map | ${allPaths.size} |`,
+    "",
+    "---",
+    "",
+    "## Hub cluster overview",
+    "",
+    "| Pillar | Label | Clusters | Supporting |",
+    "|--------|-------|----------|------------|",
+    ...HUB_CLUSTERS.map(
+      (tc) =>
+        `| \`${tc.pillar}\` | ${tc.label} | ${tc.clusters.length} | ${tc.supporting.length} |`,
+    ),
+    "",
+    "---",
+    "",
+    "## Cluster map (Mermaid diagram)",
+    "",
+    "Solid arrows (→) = pillar → direct cluster sub-page.  ",
+    "Dashed arrows (⇢) = cross-hub structural links between pillars.",
+    "",
+    renderMermaid(),
+    "",
+    "---",
+    "",
+    "## Detailed cluster tables",
+    "",
+    ...HUB_CLUSTERS.flatMap((tc) => [
+      `### ${tc.label} (\`${tc.pillar}\`)`,
+      "",
+      "**Cluster pages** (should all link back to pillar + appear in pillar nav):",
+      "",
+      ...tc.clusters.map((c) => `- \`${c}\``),
+      "",
+      "**Supporting pages** (bi-directional links where contextually natural):",
+      "",
+      ...tc.supporting.map((s) => `- \`${s}\``),
+      "",
+      "---",
+      "",
+    ]),
+    "## KK-01 orphan coverage",
+    "",
+    "Pages flagged as actionable orphans in KK-01 that are now mapped:",
+    "",
+    "| KK-01 orphaned page | Mapped pillar |",
+    "|---------------------|---------------|",
+    "| `/debt-calculator` | `/calculators` |",
+    "| `/fire-calculator` | `/calculators` |",
+    "| `/mortgage-calculator` | `/calculators` |",
+    "| `/retirement-calculator` | `/calculators` |",
+    "| `/smsf-calculator` | `/calculators` |",
+    "| `/super-contributions-calculator` | `/calculators` |",
+    "| `/dividend-reinvestment-calculator` | `/calculators` |",
+    "| `/property-vs-shares-calculator` | `/calculators` |",
+    "| `/etfs/bonds` | `/etfs` |",
+    "| `/etfs/international` | `/etfs` |",
+    "| `/etfs/sectors` | `/etfs` |",
+    "| `/smsf/checklist` | `/smsf` |",
+    "| `/smsf/crypto` | `/smsf` |",
+    "| `/super/consolidation` | `/super` |",
+    "| `/super/leaving-australia` | `/super` |",
+    "| `/tax/crypto` | `/tax` |",
+    "| `/tax/negative-gearing` | `/tax` |",
+    "| `/insurance/health` | `/insurance` |",
+    "| `/insurance/life` | `/insurance` |",
+    "| `/insurance/income-protection` | `/insurance` |",
+    "| `/lump-sum-investing/inheritance` | `/lump-sum-investing` |",
+    "| `/lump-sum-investing/redundancy` | `/lump-sum-investing` |",
+    "| `/dividends/franking-credits` | `/dividends` |",
+    "| `/startup/grants` | `/startup` |",
+    "",
+    "Pages from KK-01 not yet addressed (require content or UX work, not just linking):",
+    "- `/accessibility`, `/jobs`, `/press`, `/api-docs` — footer trust section items",
+    "- `/benchmark`, `/chess-lookup`, `/health-scores` — research tools (mapped to `/research` pillar)",
+    "- `/embed`, `/for-advisors/pricing`, `/for-advisors/sponsored` — advisor-facing surfaces",
+    "",
+    "---",
+    "",
+    "## Next steps",
+    "",
+    "| Priority | Item | Queue |",
+    "|----------|------|-------|",
+    "| High | Automated internal link injection using this cluster map | KK-04 |",
+    "| High | Add orphaned calculators to `/calculators` hub page | KK-04 |",
+    "| Medium | Add sub-category links in `/etfs`, `/smsf`, `/insurance` hub pages | KK-04 |",
+    "| Low | Footer audit: add `/accessibility`, `/jobs`, `/press` | KK-04 |",
+  ];
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+const arg = process.argv[2] ?? "--report";
+
+switch (arg) {
+  case "--json":
+    process.stdout.write(renderJson() + "\n");
+    break;
+  case "--mermaid":
+    process.stdout.write(renderMermaid() + "\n");
+    break;
+  case "--report":
+  default:
+    process.stdout.write(renderReport() + "\n");
+    break;
+}


### PR DESCRIPTION
## Summary

- Adds `/admin/topic-clusters` — server-component admin page that renders the full pillar↔spoke cluster map from `lib/topic-clusters.ts`
- Adds "Topic Clusters" nav link to AdminSidebar Content group
- No DB query needed — visualisation is pure static data from `TOPIC_CLUSTERS`

**Visualised:**
- 5 summary stats: clusters / pages mapped / unique slugs / /article/ slugs / cross-cluster pages
- Per-cluster cards: pillar page (coloured dot) + all spoke pages in a responsive grid
- `×2+` badge on pages that appear in multiple clusters
- Cross-cluster relation chips showing topically adjacent clusters from each pillar
- "How it works" panel documenting the four helper functions used across the site

## Test plan

- [ ] CI (Lint + Type-check + Build) green
- [ ] `/admin/topic-clusters` renders with 10 cluster cards and correct summary stats
- [ ] Each pillar and spoke link opens the correct URL

Refs: #221
Audit: `docs/audits/codebase-health-2026-04-24.md` §KK
Queue item: KK-03

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q8PV4ZtPoYEw59PT1hJ9B6)_