### PR TITLE
feat(country-mode): country-eligibility filter on advisor surfaces

### DIFF
--- a/__tests__/api/submit-lead.test.ts
+++ b/__tests__/api/submit-lead.test.ts
@@ -14,6 +14,15 @@ vi.mock("@/lib/rate-limit", () => ({
   isRateLimited: vi.fn(() => Promise.resolve(false)),
 }));
 
+import type { IntentCountryCode } from "@/lib/intent-context";
+
+const mockGetIntentCountry = vi.fn<
+  () => Promise<IntentCountryCode | null>
+>(() => Promise.resolve(null));
+vi.mock("@/lib/intent-context-server", () => ({
+  getIntentCountry: () => mockGetIntentCountry(),
+}));
+
 const mockSendNewLeadNotification = vi.fn((..._args: unknown[]) =>
   Promise.resolve(),
 );
@@ -55,6 +64,20 @@ function resetCalls() {
   for (const k of Object.keys(supabaseCalls)) delete supabaseCalls[k];
 }
 
+const ADVISOR_BLOCKS_UK = {
+  ...ADVISOR,
+  id: 2,
+  slug: "blocks-uk",
+  country_eligibility: { blocked_countries: ["GB"] },
+};
+
+const ADVISOR_ALLOWS_UK = {
+  ...ADVISOR,
+  id: 3,
+  slug: "allows-uk",
+  country_eligibility: { allowed_countries: ["GB", "AU"] },
+};
+
 function buildRequest(body: Record<string, unknown>, ip = "9.9.9.9") {
   return makeRequest("/api/submit-lead", body, { ip });
 }
@@ -70,6 +93,7 @@ describe("POST /api/submit-lead", () => {
       createChainableBuilder(table, supabaseCalls),
     );
     (isRateLimited as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+    mockGetIntentCountry.mockResolvedValue(null);
   });
 
   // ── Validation ──
@@ -433,6 +457,186 @@ describe("POST /api/submit-lead", () => {
       const insertArgs = insertCall?.args[0] as Record<string, unknown>;
       // gold tier → 6000 cents
       expect(insertArgs.revenue_value_cents).toBe(6000);
+    });
+  });
+
+  // ── Country eligibility (PR #619 / Phase 4) ──
+
+  describe("country eligibility filtering", () => {
+    it("skips an advisor whose blocked_countries includes the visitor's country and picks the next eligible one", async () => {
+      mockGetIntentCountry.mockResolvedValue("uk");
+      mockFrom.mockImplementation((table: string) => {
+        const b = createChainableBuilder(table, supabaseCalls);
+        if (table === "professionals") {
+          b.limit = vi.fn(() => {
+            supabaseCalls[table]?.push({ method: "limit", args: [] });
+            // Top-ranked candidate blocks UK; next candidate allows UK.
+            return Promise.resolve({
+              data: [ADVISOR_BLOCKS_UK, ADVISOR_ALLOWS_UK],
+              error: null,
+            });
+          });
+          b.single = vi.fn(() =>
+            Promise.resolve({ data: { advisor_tier: "silver" }, error: null }),
+          );
+        }
+        if (table === "leads") {
+          b.single = vi.fn(() =>
+            Promise.resolve({ data: { id: 9001 }, error: null }),
+          );
+        }
+        return b;
+      });
+
+      const req = buildRequest({
+        lead_type: "advisor",
+        user_email: "uk-visitor@test.com",
+        user_name: "UK Visitor",
+        user_location_state: "NSW",
+        user_intent: { need: "planning" },
+      });
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      // Next eligible (id 3) wins, not the blocked top pick (id 2)
+      expect(json.matched.id).toBe(3);
+      expect(json.matched.slug).toBe("allows-uk");
+    });
+
+    it("returns no_more_matches with country-specific message when every advisor blocks the visitor's country", async () => {
+      mockGetIntentCountry.mockResolvedValue("uk");
+      mockFrom.mockImplementation((table: string) => {
+        const b = createChainableBuilder(table, supabaseCalls);
+        if (table === "professionals") {
+          b.limit = vi.fn(() => {
+            supabaseCalls[table]?.push({ method: "limit", args: [] });
+            // All candidates block UK
+            return Promise.resolve({
+              data: [ADVISOR_BLOCKS_UK],
+              error: null,
+            });
+          });
+        }
+        return b;
+      });
+
+      const req = buildRequest({
+        lead_type: "advisor",
+        user_email: "uk-blocked@test.com",
+        user_location_state: "NSW",
+        user_intent: { need: "planning" },
+      });
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.no_more_matches).toBe(true);
+      expect(json.matched).toBe(null);
+      expect(json.message).toContain("country");
+    });
+
+    it("does not filter when visitor has no intent country (preserves prior behavior)", async () => {
+      mockGetIntentCountry.mockResolvedValue(null);
+      mockFrom.mockImplementation((table: string) => {
+        const b = createChainableBuilder(table, supabaseCalls);
+        if (table === "professionals") {
+          b.limit = vi.fn(() => {
+            supabaseCalls[table]?.push({ method: "limit", args: [] });
+            // Top pick blocks UK — but visitor has no intent country, so include
+            return Promise.resolve({
+              data: [ADVISOR_BLOCKS_UK],
+              error: null,
+            });
+          });
+          b.single = vi.fn(() =>
+            Promise.resolve({ data: { advisor_tier: "bronze" }, error: null }),
+          );
+        }
+        if (table === "leads") {
+          b.single = vi.fn(() =>
+            Promise.resolve({ data: { id: 9100 }, error: null }),
+          );
+        }
+        return b;
+      });
+
+      const req = buildRequest({
+        lead_type: "advisor",
+        user_email: "au-visitor@test.com",
+        user_location_state: "NSW",
+        user_intent: { need: "planning" },
+      });
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.matched.id).toBe(2);
+    });
+
+    it("rejects confirm_advisor_id when the advisor's blocked_countries includes the visitor", async () => {
+      mockGetIntentCountry.mockResolvedValue("uk");
+      mockFrom.mockImplementation((table: string) => {
+        const b = createChainableBuilder(table, supabaseCalls);
+        if (table === "professionals") {
+          b.single = vi.fn(() =>
+            Promise.resolve({ data: ADVISOR_BLOCKS_UK, error: null }),
+          );
+        }
+        return b;
+      });
+
+      const req = buildRequest({
+        lead_type: "advisor",
+        user_email: "uk-confirm@test.com",
+        confirm_advisor_id: 2,
+      });
+      const res = await POST(req);
+      expect(res.status).toBe(409);
+      const json = await res.json();
+      expect(json.reason).toBe("country_ineligible");
+      expect(mockSendNewLeadNotification).not.toHaveBeenCalled();
+    });
+
+    it("allows confirm_advisor_id when the advisor explicitly allows the visitor's country", async () => {
+      mockGetIntentCountry.mockResolvedValue("uk");
+      let professionalsCallCount = 0;
+      let leadCallCount = 0;
+      mockFrom.mockImplementation((table: string) => {
+        const b = createChainableBuilder(table, supabaseCalls);
+        if (table === "professionals") {
+          b.single = vi.fn(() => {
+            professionalsCallCount++;
+            return Promise.resolve({
+              data:
+                professionalsCallCount === 1
+                  ? ADVISOR_ALLOWS_UK
+                  : { advisor_tier: "silver" },
+              error: null,
+            });
+          });
+        }
+        if (table === "leads") {
+          b.single = vi.fn(() => {
+            leadCallCount++;
+            return Promise.resolve({
+              data: leadCallCount === 1 ? null : { id: 9200 },
+              error: leadCallCount === 1 ? { code: "PGRST116" } : null,
+            });
+          });
+        }
+        return b;
+      });
+
+      const req = buildRequest({
+        lead_type: "advisor",
+        user_email: "uk-confirm-ok@test.com",
+        user_name: "UK OK",
+        user_intent: { need: "planning" },
+        confirm_advisor_id: 3,
+      });
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.lead_id).toBe(9200);
+      expect(json.matched.id).toBe(3);
     });
   });
 });

--- a/app/advisors/page.tsx
+++ b/app/advisors/page.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from "react";
 import { createClient } from "@/lib/supabase/server";
+import { filterByCountryEligibility } from "@/lib/country-mode/eligibility-filter";
 import type { Professional, AdvisorFirm } from "@/lib/types";
 import type { Metadata } from "next";
 import AdvisorsClient from "./AdvisorsClient";
@@ -60,8 +61,13 @@ async function AdvisorsData() {
     throw new Error("Failed to load advisors. Please try again.");
   }
 
-  // Count team members per firm
-  const professionals = (proResult.data as Professional[]) || [];
+  // Hide advisors whose country_eligibility blocks the visitor's
+  // intent country. Compounds with the per-card EligibilityBadge —
+  // filter hides explicit non-matches (US-only firms for a UK visitor),
+  // badge highlights matches and visa-required cases. No-op when
+  // intentCountry is null.
+  const allProfessionals = (proResult.data as Professional[]) || [];
+  const professionals = filterByCountryEligibility(allProfessionals, intentCountry);
   const firms = (firmResult.data as AdvisorFirm[]) || [];
   const firmMemberCounts: Record<number, number> = {};
   professionals.forEach(p => {

--- a/app/api/submit-lead/route.ts
+++ b/app/api/submit-lead/route.ts
@@ -6,6 +6,12 @@ import { logger } from "@/lib/logger";
 import { extractUtm, type UtmParams } from "@/lib/utm";
 import { sendNewLeadNotification, sendLeadConfirmationToUser } from "@/lib/advisor-emails";
 import { captureEdgeEvent } from "@/lib/posthog/capture-edge";
+import { getIntentCountry } from "@/lib/intent-context-server";
+import {
+  filterByCountryEligibility,
+  isEligibleForCountry,
+  type EntityWithEligibility,
+} from "@/lib/country-mode/eligibility-filter";
 
 export const runtime = "edge";
 
@@ -54,7 +60,15 @@ function resolveAdvisorTypes(need: string, context?: string[]): string[] {
 
 /* ─── Common select fields for matching queries ─── */
 
-const MATCH_SELECT = "id, slug, name, firm_name, type, photo_url, rating, review_count, location_display, location_state, specialties, fee_description, verified, bio, email, avg_response_minutes";
+const MATCH_SELECT = "id, slug, name, firm_name, type, photo_url, rating, review_count, location_display, location_state, specialties, fee_description, verified, bio, email, avg_response_minutes, country_eligibility";
+
+/**
+ * Per-attempt fetch limit when matching. Each ranked query pulls
+ * `MATCH_FETCH_LIMIT` candidates so post-fetch country-eligibility
+ * filtering (PR #619 / Phase 4) can skip ineligible top picks
+ * without losing the cascading fallback.
+ */
+const MATCH_FETCH_LIMIT = 20;
 
 /**
  * POST /api/submit-lead
@@ -200,6 +214,11 @@ export async function POST(request: NextRequest) {
   const advisorTypes = resolveAdvisorTypes(need, context);
   const userState = typeof user_location_state === "string" ? user_location_state : null;
 
+  // Visitor's resolved intent country (from iv_intent_country cookie).
+  // Used to filter advisors whose country_eligibility excludes the
+  // visitor — see filterByCountryEligibility for decision rules.
+  const intentCountry = await getIntentCountry();
+
   // ─── confirm_advisor_id fast-path ───
   // User already previewed an advisor and clicked "Connect" — skip matching,
   // fetch that specific advisor and proceed straight to lead creation.
@@ -213,6 +232,21 @@ export async function POST(request: NextRequest) {
 
     if (!confirmedAdvisor) {
       return NextResponse.json({ error: "Advisor not found" }, { status: 404 });
+    }
+
+    // Country-eligibility gate: if the user's intent country is in the
+    // advisor's blocked_countries, refuse the confirm (an advisor that
+    // doesn't serve UK residents shouldn't get a UK lead even if the
+    // user manually clicked Connect on a stale matched-list entry).
+    if (!isEligibleForCountry(confirmedAdvisor as EntityWithEligibility, intentCountry)) {
+      log.info("Confirm blocked by country eligibility", {
+        advisor_id: confirm_advisor_id,
+        intent_country: intentCountry,
+      });
+      return NextResponse.json(
+        { error: "This advisor isn't available for your country.", reason: "country_ineligible" },
+        { status: 409 },
+      );
     }
 
     // Dedup: prevent double-lead if user clicks "Connect" twice (network retry / double-click)
@@ -390,7 +424,9 @@ export async function POST(request: NextRequest) {
   // 24h ago for round-robin fairness
   const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
 
-  // Helper: build match query with exclusion
+  // Helper: build match query with exclusion. Pulls up to MATCH_FETCH_LIMIT
+  // candidates ordered by quality so post-fetch country-eligibility filtering
+  // can skip an ineligible top pick without losing the cascading fallback.
   function buildMatchQuery(opts: { state?: string; roundRobin?: boolean; anyType?: boolean }) {
     let query = supabase
       .from("professionals")
@@ -411,7 +447,20 @@ export async function POST(request: NextRequest) {
     return query
       .order("rating", { ascending: false })
       .order("review_count", { ascending: false })
-      .limit(1);
+      .limit(MATCH_FETCH_LIMIT);
+  }
+
+  // Take the highest-ranked candidate eligible for the visitor's
+  // country. When intentCountry is null, simply returns the top pick.
+  function pickFirstEligible(
+    rows: ReadonlyArray<Record<string, unknown>> | null | undefined,
+  ): Record<string, unknown> | null {
+    if (!rows || rows.length === 0) return null;
+    const eligible = filterByCountryEligibility(
+      rows as ReadonlyArray<EntityWithEligibility & Record<string, unknown>>,
+      intentCountry,
+    );
+    return eligible[0] ?? null;
   }
 
   // Try matching with 4-level fallback
@@ -420,46 +469,53 @@ export async function POST(request: NextRequest) {
   // Attempt 1: Same state + round-robin + exclusion
   if (userState) {
     const { data } = await buildMatchQuery({ state: userState, roundRobin: true });
-    if (data && data.length > 0) matchedAdvisor = data[0];
+    matchedAdvisor = pickFirstEligible(data);
   }
 
   // Attempt 2: Same state + exclusion (ignore round-robin)
   if (!matchedAdvisor && userState) {
     const { data } = await buildMatchQuery({ state: userState });
-    if (data && data.length > 0) matchedAdvisor = data[0];
+    matchedAdvisor = pickFirstEligible(data);
   }
 
   // Attempt 3: Any state + exclusion
   if (!matchedAdvisor) {
     const { data } = await buildMatchQuery({});
-    if (data && data.length > 0) matchedAdvisor = data[0];
+    matchedAdvisor = pickFirstEligible(data);
   }
 
   // Attempt 4: Any advisor + exclusion (any type)
   if (!matchedAdvisor) {
     const { data } = await buildMatchQuery({ anyType: true });
-    if (data && data.length > 0) matchedAdvisor = data[0];
+    matchedAdvisor = pickFirstEligible(data);
   }
 
-  // Attempt 5: Absolute fallback — if all advisors excluded, tell user
-  if (!matchedAdvisor && excludeArray.length > 0) {
-    // Try without exclusions to see if there are ANY advisors
+  // Attempt 5: Absolute fallback — if all advisors are excluded or
+  // every candidate is country-ineligible, tell the user. Original
+  // gate was `excludeArray.length > 0`; we also enter this branch
+  // when intentCountry filtered out the entire pool so a UK visitor
+  // (whose every match was blocked) gets a clear message instead of
+  // a silent null-professional lead.
+  if (!matchedAdvisor && (excludeArray.length > 0 || intentCountry !== null)) {
     const { data } = await supabase
       .from("professionals")
       .select(MATCH_SELECT)
       .eq("status", "active")
       .eq("verified", true)
       .order("rating", { ascending: false })
-      .limit(1);
+      .limit(MATCH_FETCH_LIMIT);
 
-    if (!data || data.length === 0) {
-      // No advisors at all
+    const anyEligible = pickFirstEligible(data);
+    if (!anyEligible) {
+      // No advisors at all (or none eligible for visitor's country)
       return NextResponse.json({
         success: true,
         lead_id: null,
         matched: null,
         no_more_matches: true,
-        message: "We've matched you with all available advisors in this category. Browse our full directory for more options.",
+        message: intentCountry
+          ? "No advisors in our network currently serve your country. Browse our full directory or contact us for help."
+          : "We've matched you with all available advisors in this category. Browse our full directory for more options.",
       });
     }
 

--- a/app/find-advisor/[location]/page.tsx
+++ b/app/find-advisor/[location]/page.tsx
@@ -1,4 +1,6 @@
 import { createClient } from "@/lib/supabase/server";
+import { getIntentCountry } from "@/lib/intent-context-server";
+import { filterByCountryEligibility } from "@/lib/country-mode/eligibility-filter";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import {
@@ -146,13 +148,23 @@ export default async function LocationAdvisorPage({ params }: { params: Promise<
   const supabase = await createClient();
   let query = supabase.from("professionals").select("*").eq("status", "active").eq("location_state", loc.stateCode);
   if (specialtyType) query = query.eq("type", specialtyType);
-  const { data: advisors } = await query;
+  const [{ data: advisors }, intentCountry] = await Promise.all([
+    query,
+    getIntentCountry(),
+  ]);
+
+  // Hide advisors whose country_eligibility blocks the visitor's
+  // intent country (or whose allow-list excludes it). When no intent
+  // country is set this is a no-op. Compounds with PR queue #12.5 —
+  // the eligibility badge highlights matches; this filter hides
+  // explicit non-matches.
+  const eligibleAdvisors = filterByCountryEligibility(advisors || [], intentCountry);
 
   // Rank via the learned lead_quality_weights blend rather than
   // sorting by raw rating. The ranker falls back to curated defaults
   // if the weights table is empty, so this is safe on a fresh DB.
   const weights = await getLatestQualityWeights(supabase);
-  const allAdvisors = rankAdvisors(advisors || [], weights);
+  const allAdvisors = rankAdvisors(eligibleAdvisors, weights);
 
   // JSON-LD
   const jsonLd = {
@@ -227,7 +239,7 @@ export default async function LocationAdvisorPage({ params }: { params: Promise<
         ) : (
           <div className="bg-slate-50 border border-slate-200 rounded-xl p-8 text-center">
             <p className="text-lg font-bold text-slate-900 mb-2">No {type.toLowerCase()}s listed in {loc.city} yet</p>
-            <p className="text-sm text-slate-500 mb-4">We're growing our network. Check back soon or browse all advisors.</p>
+            <p className="text-sm text-slate-500 mb-4">We&apos;re growing our network. Check back soon or browse all advisors.</p>
             <Link href="/find-advisor" className="inline-block px-5 py-2.5 bg-slate-900 text-white text-sm font-bold rounded-lg hover:bg-slate-800">
               Browse All Advisors →
             </Link>
@@ -240,7 +252,7 @@ export default async function LocationAdvisorPage({ params }: { params: Promise<
           <p>When choosing a {type.toLowerCase()} in {loc.city}, look for: verified credentials (AFSL or authorised representative status), transparent fee structure (fee-for-service is generally better for clients than commission-based), relevant specialties for your situation, and positive client reviews.</p>
           <p>All advisors listed on Invest.com.au have their credentials independently verified. We check AFSL status, ASIC registration, and professional memberships before listing any advisor.</p>
           <h3 className="text-base font-bold text-slate-900">How Much Does a {type} in {loc.city} Cost?</h3>
-          <p>Financial advice fees in {loc.city} typically range from $2,500-$5,000 for an initial Statement of Advice (SOA), with ongoing fees of $2,000-$4,000 per year. Some advisors offer fixed-fee packages while others charge hourly ($200-$450/hour). Fee-for-service advisors don't receive commissions, which means their advice is less likely to be conflicted.</p>
+          <p>Financial advice fees in {loc.city} typically range from $2,500-$5,000 for an initial Statement of Advice (SOA), with ongoing fees of $2,000-$4,000 per year. Some advisors offer fixed-fee packages while others charge hourly ($200-$450/hour). Fee-for-service advisors don&apos;t receive commissions, which means their advice is less likely to be conflicted.</p>
         </div>
 
         {/* Cross-links to other locations */}

--- a/docs/plans/pre-launch-wave-status.md
+++ b/docs/plans/pre-launch-wave-status.md
@@ -37,8 +37,8 @@
 | # | Item | Tier | Status | PR | Notes |
 |---|---|---|---|---|---|
 | 1 | PR #645 rebase + CI + merge (bundled wave) | C | ✅ done 14:37 UTC | #645 | A1+F1+B1+B2+B3 shipped together |
-| 2 | PR-X4 — annual-billing dashboard prompt | B | 🔄 PR open, CI in flight | #682 | 4 files, +110 lines, 8/8 vitest local |
-| 3 | **NEW: Country-eligibility broker/advisor filter UI** | B | pending | — | Schema (PR #619+#623) is wasted until UI reads it. Half day. ~$5-10k MRR uplift. Filter `/best/[slug]` + `/find-advisor` by visitor's `iv_intent_country` against `country_eligibility.allowed_countries`/`blocked_countries` |
+| 2 | PR-X4 — annual-billing dashboard prompt | B | ✅ done 15:26 UTC | #682 | 4 files, +110 lines, 8/8 vitest local |
+| 3 | **NEW: Country-eligibility broker/advisor filter UI** | B | 🔄 in flight (iter 3) | TBD | Schema readers: /advisors page, /find-advisor/[location], /api/submit-lead all now apply filterByCountryEligibility. /best/[slug] was already wired (PR #683). 5 new tests in submit-lead suite |
 | 4 | **NEW: Cross-border specialty CTA wiring** | A | pending | — | FIN_NOTEBOOK 2026-05-01 Phase A remaining. Half day. ~$15k+/yr. Each `/foreign-investment/<slug>` page's "Find specialist" CTA → `/find-advisor?specialty=UK+Pension+Transfer` (mapped per country) |
 | 5 | **NEW: Premium 1.75× lead pricing for cross-border specialties** | B | pending | — | FIN_NOTEBOOK Phase A remaining. Half day. ~$15-40k/yr direct margin. Edit `lib/advisor-billing.ts` to apply multiplier when lead specialty matches the cross-border set |
 | 6 | **NEW: Saudi Arabia Arabic page + UAE/SA → /ar/ auto-route** | B | pending | — | Completes Phase 5d+5e+5g. ~1 day. Clone UAE Arabic structure for SA; modify LocationFlagButton click handler to route UAE/SA → /ar/...; language toggle |
@@ -66,6 +66,7 @@
 - 2026-05-09 14:35 | meta | Tier C gate = 30-min observation | Recommended balance per founder's prior pattern in workflow memory
 - 2026-05-09 14:35 | meta | Auto-topup = opt-in + $500 cap + 24h cooldown | All three guardrails layered; defense in depth
 - 2026-05-09 14:35 | #2 | Split-or-bundle deferred to per-iteration | If single PR works, ship; if Tier C blocks, split
+- 2026-05-10 00:25 | #3 | Wired country-eligibility filter to advisor surfaces | Three readers added: `/advisors` server fetch (compounds with EligibilityBadge), `/find-advisor/[location]` city listings, `/api/submit-lead` matching cascade (post-fetch filter on bumped limit=20 so blocked top-pick falls through to next eligible). `confirm_advisor_id` returns 409 when blocked. Country-specific `no_more_matches` message when whole pool blocked. /best/[slug] was already wired in PR #683 — broker side complete.
 
 ## Pause history
 


### PR DESCRIPTION
## Summary
Wire the `country_eligibility` JSONB column (PR #619 / Phase 4) into the advisor discovery surfaces so visitors only see and get matched with advisors that serve their country. Completes the broker + advisor filter loop — `/best/[slug]` (broker side) was already wired in PR #683.

## Why
Schema has been live since 2026-05-08 but every advisor surface (the directory at `/advisors`, city listings at `/find-advisor/[location]`, and the matching cascade in `/api/submit-lead`) ignored it. A UK resident running the find-advisor quiz could be matched with an AU-residents-only firm, get a wasted lead, and frustrate both sides. Pre-launch wave queue item #3.

## Tier
**Tier B** — additive filter on existing data flows; no schema changes; no Stripe/webhook impact; matches the pattern PR #683 used for `/best/[slug]`.

## Files
- `app/advisors/page.tsx` — `filterByCountryEligibility` on the server fetch before `AdvisorsClient` receives the list.
- `app/find-advisor/[location]/page.tsx` — same filter applied on each city listing before rank. Also fixed two pre-existing apostrophe-escape lint warnings the file picked up.
- `app/api/submit-lead/route.ts` — three changes:
  - Bumped per-attempt fetch limit from 1 to 20 so the cascading matcher can post-filter and pick the highest-ranked eligible candidate (a blocked top pick now falls through to the next eligible one).
  - `confirm_advisor_id` fast-path returns `409 country_ineligible` when the visitor's country is in the advisor's `blocked_countries`.
  - Absolute fallback (`no_more_matches`) now also fires when `intent_country` is set, with a country-specific message — so a UK visitor whose whole eligible pool is blocked gets a clear "no advisors in our network currently serve your country" message instead of a silent null-professional lead.
- `__tests__/api/submit-lead.test.ts` — 5 new tests (mocks `getIntentCountry`).
- `docs/plans/pre-launch-wave-status.md` — queue update.

## Test plan
- [x] `npx vitest run __tests__/api/submit-lead.test.ts __tests__/api/submit-lead-confirm.test.ts` → 33/33 pass
- [x] `npx vitest run __tests__/lib/country-mode/eligibility-filter.test.ts __tests__/components/EligibilityBadge.test.tsx` → 35/35 pass (regression guard for the underlying helper)
- [x] `npx tsc --noEmit` → clean
- [ ] CI: pending
- [ ] Visual: with `iv_intent_country=uk` cookie, `/advisors` and `/find-advisor/sydney` should hide US-only advisors; the find-advisor quiz should not surface them as matches; clicking Connect on a stale UK-blocked advisor should return 409 not silently create a lead.

## New test cases
1. Top-ranked candidate blocks UK → next eligible (rank 2) is matched.
2. Whole pool blocks UK → `no_more_matches: true` with country-specific message.
3. Visitor with no intent country → no filtering (regression guard for AU traffic).
4. `confirm_advisor_id` blocked → 409 with `reason: "country_ineligible"`.
5. `confirm_advisor_id` explicitly allowed → proceeds normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — pre-launch-wave loop iter 3

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7Dq91gQ5rJhdb1fod2hTh)_