### PR TITLE
chore(plans): pre-launch-wave — W1.3 merged, log 2 hr observation window

### DIFF
--- a/docs/plans/pre-launch-wave-status.md
+++ b/docs/plans/pre-launch-wave-status.md
@@ -2,7 +2,7 @@
 
 **Plan source:** `docs/plans/pre-launch-wave-master-prompt.md` (Wave 1-6)
 **Loop prompt:** `docs/plans/pre-launch-wave-loop-prompt.md`
-**Last updated:** 2026-05-09 (cron iter — JSON-LD audit + ratchet shipped)
+**Last updated:** 2026-05-10 01:13 UTC — W1.3 (JSON-LD coverage gate) merged via PR #697 (Tier C window elapsed without STOP); 2 hr post-merge observation window open until ~03:13 UTC
 
 ---
 
@@ -65,7 +65,7 @@ Source: `docs/plans/pre-launch-wave-master-prompt.md`. Lowercase rows mirror tha
 |---|---|---|---|---|---|
 | W1.1 | AI Concierge homepage entry | B | pending | — | 2 days |
 | W1.2 | Calculator → lead capture funnel | B | pending | — | 1-2 days, 8+ calculators |
-| W1.3 | JSON-LD audit + ratchet | A | ✅ done | (this iter) | scripts/check-jsonld-coverage.mjs + 13 page fixes + CI gate |
+| W1.3 | JSON-LD audit + ratchet | C* | ✅ done | #697 | scripts/check-jsonld-coverage.mjs + 13 page fixes + CI gate. *Re-classified to Tier C at PR open (workflows/ci.yml touch); 30-min STOP window opened 2026-05-09 23:50 UTC, no STOP, merged 2026-05-10 01:13 UTC |
 | W1.4 | Reverse marketplace ("Post a Request") | C | pending | — | 4-5 days, lib/stripe |
 | W2.5–W2.17 | PR-X5a–PR-X5m investor accounts | B/C | pending | — | 13 PRs across 5 phases |
 | W3.18 | Verified user reviews engine | B | pending | — | mirror PR #441 moderation |
@@ -114,4 +114,4 @@ Source: `docs/plans/pre-launch-wave-master-prompt.md`. Lowercase rows mirror tha
 
 (Tier C items get 2hr post-merge observation. Loop watches Sentry, Vercel deploy, billing flows; logs anomalies here.)
 
-— none yet —
+- **2026-05-10 01:13 UTC — PR #697 (W1.3 JSON-LD coverage gate)** — squash-merged to main as `cf6b4a16`. Tier C window opened 2026-05-09 23:50 UTC; elapsed >1 hr without STOP; required CI was green (Lint/Type-check/Test/Build, RLS, Stripe gates, Dated strings, A11y, E2E, Lighthouse, Bundle, Secret scan, RLS isolation, RLS migration). Known infra flake `Supabase types drift` red (same job failed in #698/#699 which already merged) and `Preview smoke` red because Vercel skipped the preview build (no preview URL → smoke can't reach any path). 2 hr post-merge observation window runs until ~03:13 UTC. Next fire: confirm Vercel deploy of `cf6b4a16` to production is healthy and no Sentry spike, then close window.


### PR DESCRIPTION
## Summary

Bookkeeping commit for the pre-launch-wave loop. PR #697 (W1.3 JSON-LD coverage gate) was squash-merged at 2026-05-10 01:13 UTC after the Tier C STOP window opened by the previous fire (2026-05-09 23:50 UTC) elapsed for >1 hr with no objection.

This PR records the merge in the queue table and opens a `Post-merge observation log` entry for the standard 2 hr Tier C observation window (closes ~03:13 UTC). The next cron fire picks up that observation entry, confirms Vercel prod is healthy + Sentry is clean, then closes the window.

## Why

The status doc is the queue-of-record for cross-fire handoff. Letting it lag behind merges silently breaks the contract that the next fire knows where the previous fire stopped. This is a 3-line edit; the rest of the doc was already updated by PR #697 itself.

## Tier

**A** — docs-only diff to a single file under `docs/plans/`. No code, no schema, no workflow, no Stripe surfaces.

## Files

- `docs/plans/pre-launch-wave-status.md` (+3 / −3)

## Test plan

- [x] Pre-push hook passed (tsc + rate-limit audit + changed-tests)
- [x] No code touched; lint/type-check/test all vacuous

## Loop iter

Pre-launch wave cron fire at 2026-05-10 01:13 UTC. Single item this fire = picking up the W1.3 STOP-window-elapsed handoff from the previous fire. Not grabbing the next pending Wave-1 item per the "one item per fire" contract.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PjLqkTxFoMYkyCprQGUJzm)_