### PR TITLE
feat(kk): KK-04 iter 1 — link-injection kill-switch + density cap [audit remediation]

### DIFF
--- a/__tests__/lib/keyword-linking.test.ts
+++ b/__tests__/lib/keyword-linking.test.ts
@@ -119,6 +119,50 @@ describe("GLOSSARY_LINK_TARGETS", () => {
   });
 });
 
+describe("splitByLinks — density cap (maxLinks)", () => {
+  it("caps injected links to the specified maximum", () => {
+    const text = "CommSec and SelfWealth and Pearler are all brokers.";
+    const out = splitByLinks(text, 2);
+    const links = out.filter((p) => typeof p !== "string");
+    expect(links.length).toBe(2);
+  });
+
+  it("maxLinks=0 injects no links and returns the full text as one string", () => {
+    const out = splitByLinks("CommSec is a broker.", 0);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toBe("CommSec is a broker.");
+  });
+
+  it("maxLinks=1 injects exactly one link", () => {
+    const out = splitByLinks("CommSec and SelfWealth.", 1);
+    const links = out.filter((p) => typeof p !== "string");
+    expect(links.length).toBe(1);
+  });
+
+  it("without a cap, injects all first occurrences (existing behaviour)", () => {
+    const text = "CommSec and SelfWealth and Pearler.";
+    const out = splitByLinks(text);
+    const links = out.filter((p) => typeof p !== "string");
+    // Three distinct broker keywords — all should be linked.
+    expect(links.length).toBe(3);
+  });
+
+  it("preserves the full text content after capping — no characters lost", () => {
+    const original = "CommSec and SelfWealth and Pearler end.";
+    const out = splitByLinks(original, 1);
+    const reconstructed = out.map((p) => (typeof p === "string" ? p : p.label)).join("");
+    expect(reconstructed).toBe(original);
+  });
+
+  it("skipped keywords after cap appear as plain text, not links", () => {
+    const out = splitByLinks("CommSec and SelfWealth and Pearler.", 1);
+    const plainParts = out.filter((p) => typeof p === "string").join("");
+    // "SelfWealth" and "Pearler" should appear in plain text segments.
+    expect(plainParts).toContain("SelfWealth");
+    expect(plainParts).toContain("Pearler");
+  });
+});
+
 describe("splitByLinks — glossary terms", () => {
   it("links a glossary term in prose", () => {
     // "Dividend" is a glossary term not covered by INTERNAL_LINK_TARGETS

--- a/app/article/[slug]/page.tsx
+++ b/app/article/[slug]/page.tsx
@@ -26,6 +26,7 @@ import AdSlot from "@/components/AdSlot";
 import AdvisorPrompt from "@/components/AdvisorPrompt";
 import LinkifiedText from "@/components/LinkifiedText";
 import FloatingRightCTA from "@/components/FloatingRightCTA";
+import { isFlagEnabled } from "@/lib/feature-flags";
 
 export const revalidate = 3600; // ISR: revalidate every hour
 
@@ -141,12 +142,13 @@ export default async function ArticlePage({
     ? supabase.from("articles").select("slug, title, category, read_time, id, tags").eq("status", "published").neq("category", a.category || "").neq("slug", slug).overlaps("tags", a.tags).order("published_at", { ascending: false }).limit(3)
     : Promise.resolve({ data: null });
 
-  const [relatedBrokersRes, fxBrokersRes, allActiveBrokersRes, relatedArticlesRes, crossCategoryRes] = await Promise.all([
+  const [relatedBrokersRes, fxBrokersRes, allActiveBrokersRes, relatedArticlesRes, crossCategoryRes, linkInjectionEnabled] = await Promise.all([
     relatedBrokersPromise,
     fxBrokersPromise,
     allActiveBrokersPromise,
     relatedArticlesPromise,
     crossCategoryPromise,
+    isFlagEnabled("internal_link_injection"),
   ]);
 
   const relatedBrokers = (relatedBrokersRes.data as Broker[]) || [];
@@ -424,6 +426,8 @@ export default async function ArticlePage({
                     <LinkifiedText
                       text={a.sections[0].body}
                       skipHrefs={[`/article/${a.slug}`]}
+                      disabled={!linkInjectionEnabled}
+                      maxLinks={5}
                     />
                   </section>
 
@@ -453,6 +457,8 @@ export default async function ArticlePage({
                         <LinkifiedText
                           text={section.body}
                           skipHrefs={[`/article/${a.slug}`]}
+                          disabled={!linkInjectionEnabled}
+                          maxLinks={5}
                         />
                       </section>
                     )
@@ -505,6 +511,8 @@ export default async function ArticlePage({
                           <LinkifiedText
                             text={section.body}
                             skipHrefs={[`/article/${a.slug}`]}
+                            disabled={!linkInjectionEnabled}
+                            maxLinks={5}
                           />
                         </section>
                         {/* In-content ad after 2nd section (only if 4+ sections for density) */}

--- a/components/LinkifiedText.tsx
+++ b/components/LinkifiedText.tsx
@@ -11,6 +11,18 @@ interface Props {
   skipHrefs?: string[];
   /** Tailwind classes for the wrapper — kept transparent by default. */
   className?: string;
+  /**
+   * Kill-switch: when true, renders the text as plain prose with no link
+   * injection. Controlled by the `internal_link_injection` feature flag
+   * checked in the parent RSC page component.
+   */
+  disabled?: boolean;
+  /**
+   * Maximum unique keywords to inject as links per block of text.
+   * Limits link density — text after the cap renders as plain text.
+   * Default: unlimited (existing behaviour when omitted).
+   */
+  maxLinks?: number;
 }
 
 /**
@@ -22,15 +34,20 @@ interface Props {
  * returns an array of `string | {href,label}` nodes that React renders
  * natively.
  */
-export default function LinkifiedText({ text, skipHrefs, className }: Props) {
+export default function LinkifiedText({ text, skipHrefs, className, disabled, maxLinks }: Props) {
   if (!text) return null;
+
+  const wrapperClass = `max-w-none text-slate-700 leading-relaxed whitespace-pre-line ${className ?? ""}`;
+
+  if (disabled) {
+    return <div className={wrapperClass}>{text}</div>;
+  }
+
   const skip = new Set(skipHrefs ?? []);
-  const parts = splitByLinks(text);
+  const parts = splitByLinks(text, maxLinks);
 
   return (
-    <div
-      className={`max-w-none text-slate-700 leading-relaxed whitespace-pre-line ${className ?? ""}`}
-    >
+    <div className={wrapperClass}>
       {parts.map((p, i) => {
         if (typeof p === "string") return <span key={i}>{p}</span>;
         if (skip.has(p.href)) return <span key={i}>{p.label}</span>;

--- a/lib/keyword-linking.ts
+++ b/lib/keyword-linking.ts
@@ -160,8 +160,12 @@ export type TextOrLink =
  * objects. Only the first occurrence of each keyword is linked —
  * subsequent occurrences render as plain text. Safe for React
  * rendering without dangerouslySetInnerHTML.
+ *
+ * @param maxLinks - Maximum unique keywords to inject as links. Defaults to
+ *   unlimited (all first occurrences). Pass a small integer (e.g. 5) to cap
+ *   link density per text block — text after the cap renders as plain text.
  */
-export function splitByLinks(text: string): TextOrLink[] {
+export function splitByLinks(text: string, maxLinks = Infinity): TextOrLink[] {
   if (!text) return [];
   const out: TextOrLink[] = [];
   const used = new Set<string>();
@@ -169,6 +173,10 @@ export function splitByLinks(text: string): TextOrLink[] {
   let lastIndex = 0;
   let m: RegExpExecArray | null;
   while ((m = rx.exec(text)) !== null) {
+    // Density cap: once we've injected maxLinks unique keywords, skip further
+    // injections. The regex still scans forward so remaining text is captured
+    // correctly in the final text.slice(lastIndex) below.
+    if (used.size >= maxLinks) continue;
     const match = m[0];
     const key = match.toLowerCase();
     if (used.has(key)) continue;

--- a/supabase/migrations/20260721_kk04_link_injection_flag.sql
+++ b/supabase/migrations/20260721_kk04_link_injection_flag.sql
@@ -1,0 +1,33 @@
+-- ============================================================
+-- KK-04 (iter 1): Seed internal_link_injection feature flag
+--
+-- Date: 2026-05-10
+-- Audit ref: codebase-health-2026-04-24.md — KK stream, KK-04
+-- Queue item: KK-04 (knowledge graph / internal linking)
+-- Why: The keyword auto-linker (lib/keyword-linking.ts) runs on every
+--      article render with no kill-switch and no density cap. This migration
+--      seeds the feature flag that guards it. Flipping enabled=false in the
+--      admin flag panel (/admin/automation/flags) instantly disables all
+--      in-prose link injection without a deploy.
+--      Seeded enabled=true/rollout_pct=100 to preserve existing behaviour;
+--      the flag is additive — it does not change the current render output.
+-- Idempotency: INSERT ... ON CONFLICT (flag_key) DO NOTHING — re-running
+--              this migration is a safe no-op. Any admin-toggled state is
+--              preserved on re-run.
+-- Rollback:
+--   DELETE FROM public.feature_flags WHERE flag_key = 'internal_link_injection';
+-- ============================================================
+
+BEGIN;
+
+INSERT INTO public.feature_flags
+  (flag_key, description, enabled, rollout_pct, allowlist, denylist, segments)
+VALUES
+  ('internal_link_injection',
+   'Keyword auto-linker on article pages (lib/keyword-linking.ts). '
+   'Kill switch: set enabled=false to strip all in-prose link injection without a deploy. '
+   'Per-section density cap is controlled in code via LinkifiedText maxLinks prop.',
+   true, 100, '{}', '{}', '{}')
+ON CONFLICT (flag_key) DO NOTHING;
+
+COMMIT;


### PR DESCRIPTION
## Summary

KK-04 iter 1 of ~5. Adds a kill-switch and density cap to the keyword auto-linker that runs on every article page render.

### Problem

`lib/keyword-linking.ts` / `LinkifiedText` was always-on with no emergency stop and no density limit. An article with many broker and glossary keywords could accumulate 40+ injected links, harming readability and bloating the internal link graph. There was no way to disable injection without a code deploy.

### What changed

- **`supabase/migrations/20260721_kk04_link_injection_flag.sql`** — seeds `internal_link_injection` feature flag (`enabled=true, rollout_pct=100`). Preserves existing behaviour; the admin can flip to `enabled=false` in `/admin/automation/flags` to globally kill injection without a deploy.

- **`lib/keyword-linking.ts`** — `splitByLinks(text, maxLinks?)` now accepts an optional density cap. Once `maxLinks` unique keywords have been linked, further matches render as plain text. Default is `Infinity` (backward-compatible — existing callers are unaffected).

- **`components/LinkifiedText.tsx`** — two new optional props: `disabled` (kill-switch — renders plain text when true) and `maxLinks` (threads into `splitByLinks`).

- **`app/article/[slug]/page.tsx`** — checks `isFlagEnabled("internal_link_injection")` once (parallel with existing data fetches), passes `disabled={!linkInjectionEnabled}` and `maxLinks={5}` to all three `LinkifiedText` usages.

- **`__tests__/lib/keyword-linking.test.ts`** — 6 new tests covering the density cap: zero links, one link, two links, unlimited (existing behaviour), full text reconstruction, and plain-text rendering of skipped keywords.

### Audit reference

- Audit: `docs/audits/codebase-health-2026-04-24.md` — KK stream, KK-04
- Queue: `docs/audits/REMEDIATION_QUEUE.md` — KK stream
- Deps satisfied: KK-02 (RelatedContentGrid, PR #670) + KK-03 (topic-cluster-map admin page, PR #703)

### Remaining iters (2–5)

- Iter 2: LSI/topic-cluster-aware dynamic target selection (use article's cluster membership to choose which pages to link to, rather than the static `INTERNAL_LINK_TARGETS` list)
- Iter 3: Per-article-type density config (pillar pages: 8 links; spoke pages: 5 links; news: 3 links)
- Iter 4: Admin UI for per-article link overrides
- Iter 5: Integration tests + Playwright smoke

https://claude.ai/code/session_01TnFK6SxUeEgpcWvFKQmX93

---
_Generated by [Claude Code](https://claude.ai/code/session_01TnFK6SxUeEgpcWvFKQmX93)_