### PR TITLE
feat(country-mode): country_rule_alerts DB + admin CRUD (W4.21)

### DIFF
--- a/__tests__/api/admin-country-rule-alerts.test.ts
+++ b/__tests__/api/admin-country-rule-alerts.test.ts
@@ -1,0 +1,362 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockGetUser, mockAdminFrom } = vi.hoisted(() => ({
+  mockGetUser: vi.fn(),
+  mockAdminFrom: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({
+    auth: { getUser: mockGetUser },
+  })),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({
+    from: mockAdminFrom,
+  })),
+}));
+
+import {
+  GET,
+  POST,
+  PATCH,
+  DELETE,
+} from "@/app/api/admin/country-rule-alerts/route";
+
+function adminLoggedIn() {
+  mockGetUser.mockResolvedValue({
+    data: { user: { id: "u1", email: "finn@invest.com.au" } },
+  });
+}
+
+function anonLoggedIn() {
+  mockGetUser.mockResolvedValue({ data: { user: null } });
+}
+
+function nonAdminLoggedIn() {
+  mockGetUser.mockResolvedValue({
+    data: { user: { id: "u2", email: "stranger@example.com" } },
+  });
+}
+
+function makeRequest(method: string, url: string, body?: unknown): NextRequest {
+  return new NextRequest(url, {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Default chain for list/insert/update/delete that resolves to empty
+  mockAdminFrom.mockReturnValue({
+    select: vi.fn().mockReturnThis(),
+    insert: vi.fn().mockReturnThis(),
+    update: vi.fn().mockReturnThis(),
+    delete: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    order: vi.fn().mockResolvedValue({ data: [], error: null }),
+    single: vi.fn().mockResolvedValue({ data: null, error: null }),
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("GET /api/admin/country-rule-alerts — auth", () => {
+  it("returns 401 when not signed in", async () => {
+    anonLoggedIn();
+    const res = await GET(
+      makeRequest("GET", "http://localhost/api/admin/country-rule-alerts"),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when signed in but not on admin allow-list", async () => {
+    nonAdminLoggedIn();
+    const res = await GET(
+      makeRequest("GET", "http://localhost/api/admin/country-rule-alerts"),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns rows for authorised admin", async () => {
+    adminLoggedIn();
+    mockAdminFrom.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        order: vi.fn().mockReturnValue({
+          order: vi.fn().mockResolvedValue({
+            data: [{ id: 1, alert_key: "uk-x" }],
+            error: null,
+          }),
+        }),
+      }),
+    });
+
+    const res = await GET(
+      makeRequest("GET", "http://localhost/api/admin/country-rule-alerts"),
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.rows).toEqual([{ id: 1, alert_key: "uk-x" }]);
+  });
+
+  it("returns 400 for invalid country_code filter", async () => {
+    adminLoggedIn();
+    const res = await GET(
+      makeRequest(
+        "GET",
+        "http://localhost/api/admin/country-rule-alerts?country_code=zz",
+      ),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("filters by lowercased country_code", async () => {
+    adminLoggedIn();
+    const eqSpy = vi
+      .fn()
+      .mockResolvedValue({ data: [], error: null });
+    mockAdminFrom.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        order: vi.fn().mockReturnValue({
+          order: vi.fn().mockReturnValue({ eq: eqSpy }),
+        }),
+      }),
+    });
+
+    const res = await GET(
+      makeRequest(
+        "GET",
+        "http://localhost/api/admin/country-rule-alerts?country_code=UK",
+      ),
+    );
+    expect(res.status).toBe(200);
+    expect(eqSpy).toHaveBeenCalledWith("country_code", "uk");
+  });
+});
+
+describe("POST /api/admin/country-rule-alerts — validation", () => {
+  it("returns 401 for non-admin", async () => {
+    nonAdminLoggedIn();
+    const res = await POST(
+      makeRequest("POST", "http://localhost/api/admin/country-rule-alerts", {
+        alert_key: "uk-test",
+        country_code: "uk",
+        severity: "info",
+        headline: "h",
+        body: "b",
+        source: "ATO",
+        stales_at: "2027-01-01",
+      }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for invalid country_code", async () => {
+    adminLoggedIn();
+    const res = await POST(
+      makeRequest("POST", "http://localhost/api/admin/country-rule-alerts", {
+        alert_key: "zz-test",
+        country_code: "zz",
+        severity: "info",
+        headline: "h",
+        body: "b",
+        source: "ATO",
+        stales_at: "2027-01-01",
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for invalid alert_key format (uppercase)", async () => {
+    adminLoggedIn();
+    const res = await POST(
+      makeRequest("POST", "http://localhost/api/admin/country-rule-alerts", {
+        alert_key: "UK-Test",
+        country_code: "uk",
+        severity: "info",
+        headline: "h",
+        body: "b",
+        source: "ATO",
+        stales_at: "2027-01-01",
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for invalid stales_at format", async () => {
+    adminLoggedIn();
+    const res = await POST(
+      makeRequest("POST", "http://localhost/api/admin/country-rule-alerts", {
+        alert_key: "uk-test",
+        country_code: "uk",
+        severity: "info",
+        headline: "h",
+        body: "b",
+        source: "ATO",
+        stales_at: "not-a-date",
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("creates a row when payload is valid", async () => {
+    adminLoggedIn();
+    const insertSpy = vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        single: vi
+          .fn()
+          .mockResolvedValue({ data: { id: 42, alert_key: "uk-new" }, error: null }),
+      }),
+    });
+    const auditInsert = vi.fn().mockResolvedValue({ data: null, error: null });
+    mockAdminFrom.mockImplementation((table: string) => {
+      if (table === "country_rule_alerts") {
+        return { insert: insertSpy };
+      }
+      return { insert: auditInsert };
+    });
+
+    const res = await POST(
+      makeRequest("POST", "http://localhost/api/admin/country-rule-alerts", {
+        alert_key: "uk-new",
+        country_code: "uk",
+        severity: "warning",
+        headline: "Headline",
+        body: "Body copy",
+        source: "ATO",
+        cta_href: "/foreign-investment/united-kingdom",
+        cta_label: "UK guide",
+        stales_at: "2027-01-01",
+        display_order: 10,
+        active: true,
+      }),
+    );
+
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    expect(json.id).toBe(42);
+    expect(insertSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        alert_key: "uk-new",
+        country_code: "uk",
+        severity: "warning",
+      }),
+    );
+    expect(auditInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "country_rule_alert:created",
+        admin_email: "finn@invest.com.au",
+      }),
+    );
+  });
+});
+
+describe("PATCH /api/admin/country-rule-alerts — partial update", () => {
+  it("returns 401 for anon", async () => {
+    anonLoggedIn();
+    const res = await PATCH(
+      makeRequest("PATCH", "http://localhost/api/admin/country-rule-alerts", {
+        id: 1,
+        active: false,
+      }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when id is missing", async () => {
+    adminLoggedIn();
+    const res = await PATCH(
+      makeRequest("PATCH", "http://localhost/api/admin/country-rule-alerts", {
+        active: false,
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("updates a row when payload is valid", async () => {
+    adminLoggedIn();
+    const updateChain = {
+      eq: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          single: vi
+            .fn()
+            .mockResolvedValue({ data: { id: 7, active: false }, error: null }),
+        }),
+      }),
+    };
+    const updateSpy = vi.fn().mockReturnValue(updateChain);
+    const auditInsert = vi.fn().mockResolvedValue({ data: null, error: null });
+    mockAdminFrom.mockImplementation((table: string) => {
+      if (table === "country_rule_alerts") {
+        return { update: updateSpy };
+      }
+      return { insert: auditInsert };
+    });
+
+    const res = await PATCH(
+      makeRequest("PATCH", "http://localhost/api/admin/country-rule-alerts", {
+        id: 7,
+        active: false,
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(updateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ active: false, updated_at: expect.any(String) }),
+    );
+    expect(updateChain.eq).toHaveBeenCalledWith("id", 7);
+  });
+});
+
+describe("DELETE /api/admin/country-rule-alerts", () => {
+  it("returns 401 for anon", async () => {
+    anonLoggedIn();
+    const res = await DELETE(
+      makeRequest("DELETE", "http://localhost/api/admin/country-rule-alerts?id=1"),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when id query missing", async () => {
+    adminLoggedIn();
+    const res = await DELETE(
+      makeRequest("DELETE", "http://localhost/api/admin/country-rule-alerts"),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when id is non-numeric", async () => {
+    adminLoggedIn();
+    const res = await DELETE(
+      makeRequest("DELETE", "http://localhost/api/admin/country-rule-alerts?id=abc"),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("deletes the row when id is valid", async () => {
+    adminLoggedIn();
+    const eqSpy = vi.fn().mockResolvedValue({ data: null, error: null });
+    const deleteSpy = vi.fn().mockReturnValue({ eq: eqSpy });
+    const auditInsert = vi.fn().mockResolvedValue({ data: null, error: null });
+    mockAdminFrom.mockImplementation((table: string) => {
+      if (table === "country_rule_alerts") {
+        return { delete: deleteSpy };
+      }
+      return { insert: auditInsert };
+    });
+
+    const res = await DELETE(
+      makeRequest("DELETE", "http://localhost/api/admin/country-rule-alerts?id=42"),
+    );
+    expect(res.status).toBe(200);
+    expect(eqSpy).toHaveBeenCalledWith("id", 42);
+    expect(auditInsert).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "country_rule_alert:deleted" }),
+    );
+  });
+});

--- a/__tests__/api/country-rule-alerts.test.ts
+++ b/__tests__/api/country-rule-alerts.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/country-rule-alerts", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/country-rule-alerts")>(
+    "@/lib/country-rule-alerts",
+  );
+  return {
+    ...actual,
+    getActiveAlertsForCountry: vi.fn(),
+  };
+});
+
+import { GET } from "@/app/api/country-rule-alerts/route";
+import { getActiveAlertsForCountry } from "@/lib/country-rule-alerts";
+
+const mockedFetch = vi.mocked(getActiveAlertsForCountry);
+
+beforeEach(() => {
+  mockedFetch.mockReset();
+});
+
+describe("GET /api/country-rule-alerts", () => {
+  it("returns alerts for a known country", async () => {
+    mockedFetch.mockResolvedValue([
+      {
+        alert_key: "uk-x",
+        severity: "warning",
+        headline: "h",
+        body: "b",
+        source: "ATO",
+        cta_href: null,
+        cta_label: null,
+      },
+    ]);
+    const res = await GET(
+      new NextRequest("http://localhost/api/country-rule-alerts?country=uk"),
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.alerts).toHaveLength(1);
+    expect(mockedFetch).toHaveBeenCalledWith("uk");
+  });
+
+  it("returns empty array when country missing", async () => {
+    mockedFetch.mockResolvedValue([]);
+    const res = await GET(
+      new NextRequest("http://localhost/api/country-rule-alerts"),
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.alerts).toEqual([]);
+  });
+
+  it("sets a stale-while-revalidate cache header", async () => {
+    mockedFetch.mockResolvedValue([]);
+    const res = await GET(
+      new NextRequest("http://localhost/api/country-rule-alerts?country=uk"),
+    );
+    expect(res.headers.get("Cache-Control")).toMatch(/stale-while-revalidate/);
+  });
+});

--- a/__tests__/api/country-rule-alerts.test.ts
+++ b/__tests__/api/country-rule-alerts.test.ts
@@ -1,18 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
 
-vi.mock("@/lib/country-rule-alerts", async () => {
-  const actual = await vi.importActual<typeof import("@/lib/country-rule-alerts")>(
-    "@/lib/country-rule-alerts",
-  );
-  return {
-    ...actual,
-    getActiveAlertsForCountry: vi.fn(),
-  };
-});
+vi.mock("@/lib/country-rule-alerts-server", () => ({
+  getActiveAlertsForCountry: vi.fn(),
+}));
 
 import { GET } from "@/app/api/country-rule-alerts/route";
-import { getActiveAlertsForCountry } from "@/lib/country-rule-alerts";
+import { getActiveAlertsForCountry } from "@/lib/country-rule-alerts-server";
 
 const mockedFetch = vi.mocked(getActiveAlertsForCountry);
 

--- a/__tests__/lib/country-rule-alerts.test.ts
+++ b/__tests__/lib/country-rule-alerts.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  AlertCountrySchema,
+  AlertSeveritySchema,
+  PublicRuleAlertSchema,
+  AdminRuleAlertSchema,
+  COUNTRY_RULE_ALERT_COUNTRIES,
+  SEVERITY_LABELS,
+  type AdminRuleAlert,
+  type PublicRuleAlert,
+} from "@/lib/country-rule-alerts";
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(),
+}));
+
+import { createClient } from "@/lib/supabase/server";
+const mockedCreateClient = vi.mocked(createClient);
+
+function publicRow(overrides: Partial<PublicRuleAlert> = {}): PublicRuleAlert {
+  return {
+    alert_key: "uk-test-alert",
+    severity: "warning",
+    headline: "Test headline",
+    body: "Body copy",
+    source: "ATO",
+    cta_href: "/foreign-investment/united-kingdom",
+    cta_label: "UK guide",
+    ...overrides,
+  };
+}
+
+function adminRow(overrides: Partial<AdminRuleAlert> = {}): AdminRuleAlert {
+  return {
+    id: 1,
+    alert_key: "uk-test-alert",
+    country_code: "uk",
+    severity: "warning",
+    headline: "Test headline",
+    body: "Body",
+    source: "ATO",
+    cta_href: null,
+    cta_label: null,
+    stales_at: "2027-01-01",
+    display_order: 10,
+    active: true,
+    created_at: "2026-05-10T00:00:00Z",
+    updated_at: "2026-05-10T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("schema enums", () => {
+  it("rejects unknown country", () => {
+    expect(AlertCountrySchema.safeParse("zz").success).toBe(false);
+    expect(AlertCountrySchema.safeParse("uk").success).toBe(true);
+  });
+
+  it("rejects unknown severity", () => {
+    expect(AlertSeveritySchema.safeParse("yikes").success).toBe(false);
+    expect(AlertSeveritySchema.safeParse("urgent").success).toBe(true);
+  });
+
+  it("SEVERITY_LABELS covers every severity enum", () => {
+    for (const sev of AlertSeveritySchema.options) {
+      expect(SEVERITY_LABELS[sev]).toBeTruthy();
+    }
+  });
+
+  it("COUNTRY_RULE_ALERT_COUNTRIES matches AlertCountrySchema options", () => {
+    expect([...AlertCountrySchema.options].sort()).toEqual(
+      [...COUNTRY_RULE_ALERT_COUNTRIES].sort(),
+    );
+  });
+});
+
+describe("PublicRuleAlertSchema", () => {
+  it("parses a valid public row", () => {
+    expect(PublicRuleAlertSchema.safeParse(publicRow()).success).toBe(true);
+  });
+
+  it("rejects a row missing required headline", () => {
+    const bad = { ...publicRow(), headline: undefined } as unknown;
+    expect(PublicRuleAlertSchema.safeParse(bad).success).toBe(false);
+  });
+
+  it("accepts null cta fields", () => {
+    expect(
+      PublicRuleAlertSchema.safeParse(
+        publicRow({ cta_href: null, cta_label: null }),
+      ).success,
+    ).toBe(true);
+  });
+});
+
+describe("AdminRuleAlertSchema", () => {
+  it("parses a valid admin row", () => {
+    expect(AdminRuleAlertSchema.safeParse(adminRow()).success).toBe(true);
+  });
+
+  it("rejects an admin row with invalid country", () => {
+    expect(
+      AdminRuleAlertSchema.safeParse(adminRow({ country_code: "zz" as never }))
+        .success,
+    ).toBe(false);
+  });
+});
+
+describe("getActiveAlertsForCountry", () => {
+  beforeEach(() => {
+    mockedCreateClient.mockReset();
+  });
+
+  it("returns parsed rows for the requested country (lowercased)", async () => {
+    const eqSpy = vi.fn().mockReturnThis();
+    const mockQuery = {
+      select: vi.fn().mockReturnThis(),
+      eq: eqSpy,
+      order: vi
+        .fn()
+        .mockResolvedValue({ data: [publicRow({ alert_key: "uk-x" })], error: null }),
+    };
+    mockedCreateClient.mockResolvedValue({
+      from: vi.fn().mockReturnValue(mockQuery),
+    } as never);
+
+    const { getActiveAlertsForCountry } = await import("@/lib/country-rule-alerts");
+    const result = await getActiveAlertsForCountry("UK");
+
+    expect(eqSpy).toHaveBeenCalledWith("country_code", "uk");
+    expect(eqSpy).toHaveBeenCalledWith("active", true);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.alert_key).toBe("uk-x");
+  });
+
+  it("returns empty array for unknown country (no DB call)", async () => {
+    const fromSpy = vi.fn();
+    mockedCreateClient.mockResolvedValue({ from: fromSpy } as never);
+
+    const { getActiveAlertsForCountry } = await import("@/lib/country-rule-alerts");
+    const result = await getActiveAlertsForCountry("zz");
+
+    expect(result).toEqual([]);
+    expect(fromSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns empty array for empty country", async () => {
+    const { getActiveAlertsForCountry } = await import("@/lib/country-rule-alerts");
+    expect(await getActiveAlertsForCountry("")).toEqual([]);
+  });
+
+  it("returns empty array on supabase failure", async () => {
+    mockedCreateClient.mockRejectedValue(new Error("boom"));
+    const { getActiveAlertsForCountry } = await import("@/lib/country-rule-alerts");
+    expect(await getActiveAlertsForCountry("uk")).toEqual([]);
+  });
+
+  it("filters out rows that fail schema validation", async () => {
+    const mockQuery = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockResolvedValue({
+        data: [
+          publicRow({ alert_key: "uk-1" }),
+          { alert_key: "uk-2" }, // missing required fields
+          publicRow({ alert_key: "uk-3" }),
+        ],
+        error: null,
+      }),
+    };
+    mockedCreateClient.mockResolvedValue({
+      from: vi.fn().mockReturnValue(mockQuery),
+    } as never);
+
+    const { getActiveAlertsForCountry } = await import("@/lib/country-rule-alerts");
+    const result = await getActiveAlertsForCountry("uk");
+    expect(result.map((r) => r.alert_key)).toEqual(["uk-1", "uk-3"]);
+  });
+});

--- a/__tests__/lib/country-rule-alerts.test.ts
+++ b/__tests__/lib/country-rule-alerts.test.ts
@@ -124,7 +124,7 @@ describe("getActiveAlertsForCountry", () => {
       from: vi.fn().mockReturnValue(mockQuery),
     } as never);
 
-    const { getActiveAlertsForCountry } = await import("@/lib/country-rule-alerts");
+    const { getActiveAlertsForCountry } = await import("@/lib/country-rule-alerts-server");
     const result = await getActiveAlertsForCountry("UK");
 
     expect(eqSpy).toHaveBeenCalledWith("country_code", "uk");
@@ -137,7 +137,7 @@ describe("getActiveAlertsForCountry", () => {
     const fromSpy = vi.fn();
     mockedCreateClient.mockResolvedValue({ from: fromSpy } as never);
 
-    const { getActiveAlertsForCountry } = await import("@/lib/country-rule-alerts");
+    const { getActiveAlertsForCountry } = await import("@/lib/country-rule-alerts-server");
     const result = await getActiveAlertsForCountry("zz");
 
     expect(result).toEqual([]);
@@ -145,13 +145,13 @@ describe("getActiveAlertsForCountry", () => {
   });
 
   it("returns empty array for empty country", async () => {
-    const { getActiveAlertsForCountry } = await import("@/lib/country-rule-alerts");
+    const { getActiveAlertsForCountry } = await import("@/lib/country-rule-alerts-server");
     expect(await getActiveAlertsForCountry("")).toEqual([]);
   });
 
   it("returns empty array on supabase failure", async () => {
     mockedCreateClient.mockRejectedValue(new Error("boom"));
-    const { getActiveAlertsForCountry } = await import("@/lib/country-rule-alerts");
+    const { getActiveAlertsForCountry } = await import("@/lib/country-rule-alerts-server");
     expect(await getActiveAlertsForCountry("uk")).toEqual([]);
   });
 
@@ -172,7 +172,7 @@ describe("getActiveAlertsForCountry", () => {
       from: vi.fn().mockReturnValue(mockQuery),
     } as never);
 
-    const { getActiveAlertsForCountry } = await import("@/lib/country-rule-alerts");
+    const { getActiveAlertsForCountry } = await import("@/lib/country-rule-alerts-server");
     const result = await getActiveAlertsForCountry("uk");
     expect(result.map((r) => r.alert_key)).toEqual(["uk-1", "uk-3"]);
   });

--- a/app/admin/country-rule-alerts/AlertsEditor.tsx
+++ b/app/admin/country-rule-alerts/AlertsEditor.tsx
@@ -1,0 +1,389 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { logger } from "@/lib/logger";
+import {
+  COUNTRY_RULE_ALERT_COUNTRIES,
+  SEVERITY_LABELS,
+  type AdminRuleAlert,
+  type AlertSeverity,
+  type AlertCountry,
+} from "@/lib/country-rule-alerts";
+
+const log = logger("admin-country-rule-alerts-editor");
+
+const SEVERITIES: AlertSeverity[] = ["info", "warning", "urgent"];
+
+type DraftAlert = Omit<AdminRuleAlert, "id" | "created_at" | "updated_at">;
+
+const EMPTY_DRAFT: DraftAlert = {
+  alert_key: "",
+  country_code: "uk",
+  severity: "info",
+  headline: "",
+  body: "",
+  source: "",
+  cta_href: null,
+  cta_label: null,
+  stales_at: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10),
+  display_order: 10,
+  active: true,
+};
+
+export default function AlertsEditor() {
+  const [rows, setRows] = useState<AdminRuleAlert[]>([]);
+  const [filter, setFilter] = useState<string>("");
+  const [editing, setEditing] = useState<AdminRuleAlert | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [draft, setDraft] = useState<DraftAlert>(EMPTY_DRAFT);
+  const [busy, setBusy] = useState(false);
+
+  async function load() {
+    const url = filter
+      ? `/api/admin/country-rule-alerts?country_code=${encodeURIComponent(filter)}`
+      : "/api/admin/country-rule-alerts";
+    const res = await fetch(url);
+    if (!res.ok) {
+      log.error("Failed to load alerts", { status: res.status });
+      return;
+    }
+    const data = (await res.json()) as { rows?: AdminRuleAlert[] };
+    setRows(data.rows ?? []);
+  }
+
+  useEffect(() => {
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filter]);
+
+  async function save() {
+    setBusy(true);
+    try {
+      const isEdit = editing !== null;
+      const res = await fetch("/api/admin/country-rule-alerts", {
+        method: isEdit ? "PATCH" : "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(isEdit ? { ...draft, id: editing.id } : draft),
+      });
+      if (!res.ok) {
+        const err = (await res.json().catch(() => ({}))) as { error?: string };
+        alert(err.error || "Save failed");
+        return;
+      }
+      setEditing(null);
+      setCreating(false);
+      setDraft(EMPTY_DRAFT);
+      await load();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function remove(id: number) {
+    if (!confirm("Delete this alert? This is destructive.")) return;
+    const res = await fetch(`/api/admin/country-rule-alerts?id=${id}`, {
+      method: "DELETE",
+    });
+    if (!res.ok) {
+      alert("Delete failed");
+      return;
+    }
+    await load();
+  }
+
+  function startEdit(row: AdminRuleAlert) {
+    setEditing(row);
+    setCreating(false);
+    setDraft({
+      alert_key: row.alert_key,
+      country_code: row.country_code,
+      severity: row.severity,
+      headline: row.headline,
+      body: row.body,
+      source: row.source,
+      cta_href: row.cta_href,
+      cta_label: row.cta_label,
+      stales_at: row.stales_at,
+      display_order: row.display_order,
+      active: row.active,
+    });
+  }
+
+  function startCreate() {
+    setEditing(null);
+    setCreating(true);
+    setDraft(EMPTY_DRAFT);
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <label className="text-sm text-slate-600">Country</label>
+          <select
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            className="text-sm border rounded px-2 py-1"
+          >
+            <option value="">All</option>
+            {COUNTRY_RULE_ALERT_COUNTRIES.map((c) => (
+              <option key={c} value={c}>
+                {c.toUpperCase()}
+              </option>
+            ))}
+          </select>
+        </div>
+        <button
+          type="button"
+          onClick={startCreate}
+          className="bg-violet-600 hover:bg-violet-700 text-white text-sm font-bold px-4 py-2 rounded"
+        >
+          + New alert
+        </button>
+      </div>
+
+      {(editing || creating) && (
+        <AlertForm
+          draft={draft}
+          setDraft={setDraft}
+          onSave={save}
+          onCancel={() => {
+            setEditing(null);
+            setCreating(false);
+            setDraft(EMPTY_DRAFT);
+          }}
+          busy={busy}
+          isEdit={editing !== null}
+        />
+      )}
+
+      <div className="bg-white border border-slate-200 rounded-lg overflow-hidden">
+        <table className="w-full text-sm">
+          <thead className="bg-slate-50 text-xs font-semibold text-slate-600">
+            <tr>
+              <th className="text-left px-3 py-2">Country</th>
+              <th className="text-left px-3 py-2">Severity</th>
+              <th className="text-left px-3 py-2">Headline</th>
+              <th className="text-left px-3 py-2">Stales</th>
+              <th className="text-left px-3 py-2">Active</th>
+              <th className="text-left px-3 py-2 w-24">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.length === 0 && (
+              <tr>
+                <td colSpan={6} className="text-center text-slate-400 py-6">
+                  No alerts match the filter.
+                </td>
+              </tr>
+            )}
+            {rows.map((r) => {
+              const isStale = new Date(r.stales_at) < new Date();
+              return (
+                <tr key={r.id} className="border-t border-slate-100">
+                  <td className="px-3 py-2 font-mono uppercase">{r.country_code}</td>
+                  <td className="px-3 py-2 text-xs">{SEVERITY_LABELS[r.severity]}</td>
+                  <td className="px-3 py-2">{r.headline}</td>
+                  <td
+                    className={`px-3 py-2 text-xs ${isStale ? "text-amber-700 font-bold" : "text-slate-500"}`}
+                  >
+                    {r.stales_at}
+                    {isStale && " ⚠"}
+                  </td>
+                  <td className="px-3 py-2">
+                    <span
+                      className={`text-xs font-semibold ${r.active ? "text-emerald-700" : "text-slate-400"}`}
+                    >
+                      {r.active ? "Active" : "Hidden"}
+                    </span>
+                  </td>
+                  <td className="px-3 py-2 text-xs">
+                    <button
+                      type="button"
+                      className="text-blue-600 hover:underline mr-2"
+                      onClick={() => startEdit(r)}
+                    >
+                      Edit
+                    </button>
+                    <button
+                      type="button"
+                      className="text-red-600 hover:underline"
+                      onClick={() => remove(r.id)}
+                    >
+                      Delete
+                    </button>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+interface AlertFormProps {
+  draft: DraftAlert;
+  setDraft: (d: DraftAlert) => void;
+  onSave: () => void;
+  onCancel: () => void;
+  busy: boolean;
+  isEdit: boolean;
+}
+
+function AlertForm({ draft, setDraft, onSave, onCancel, busy, isEdit }: AlertFormProps) {
+  function set<K extends keyof DraftAlert>(key: K, value: DraftAlert[K]) {
+    setDraft({ ...draft, [key]: value });
+  }
+
+  return (
+    <div className="bg-violet-50 border border-violet-200 rounded-lg p-5 space-y-3">
+      <h2 className="font-bold text-slate-900">
+        {isEdit ? "Edit alert" : "New alert"}
+      </h2>
+
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+        <Field label="Country (intent code, lowercase)">
+          <select
+            value={draft.country_code}
+            onChange={(e) => set("country_code", e.target.value as AlertCountry)}
+            className="w-full text-sm border rounded px-2 py-1.5"
+          >
+            {COUNTRY_RULE_ALERT_COUNTRIES.map((c) => (
+              <option key={c} value={c}>
+                {c.toUpperCase()}
+              </option>
+            ))}
+          </select>
+        </Field>
+        <Field label="Severity">
+          <select
+            value={draft.severity}
+            onChange={(e) => set("severity", e.target.value as AlertSeverity)}
+            className="w-full text-sm border rounded px-2 py-1.5"
+          >
+            {SEVERITIES.map((s) => (
+              <option key={s} value={s}>
+                {SEVERITY_LABELS[s]}
+              </option>
+            ))}
+          </select>
+        </Field>
+        <Field label="Display order (low first)">
+          <input
+            type="number"
+            value={draft.display_order}
+            onChange={(e) => set("display_order", parseInt(e.target.value, 10) || 0)}
+            className="w-full text-sm border rounded px-2 py-1.5"
+          />
+        </Field>
+      </div>
+
+      <Field label="Alert key (stable; used for sessionStorage dismissal — change only when text materially changes)">
+        <input
+          type="text"
+          value={draft.alert_key}
+          onChange={(e) => set("alert_key", e.target.value)}
+          placeholder="e.g. uk-firb-established-ban-2025"
+          className="w-full text-sm border rounded px-2 py-1.5 font-mono"
+          disabled={isEdit}
+        />
+      </Field>
+
+      <Field label="Headline">
+        <input
+          type="text"
+          value={draft.headline}
+          onChange={(e) => set("headline", e.target.value)}
+          className="w-full text-sm border rounded px-2 py-1.5"
+        />
+      </Field>
+
+      <Field label="Body (1-3 sentences)">
+        <textarea
+          value={draft.body}
+          onChange={(e) => set("body", e.target.value)}
+          rows={4}
+          className="w-full text-sm border rounded px-2 py-1.5"
+        />
+      </Field>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <Field label="Source (e.g. ATO, IRS, FIRB)">
+          <input
+            type="text"
+            value={draft.source}
+            onChange={(e) => set("source", e.target.value)}
+            className="w-full text-sm border rounded px-2 py-1.5"
+          />
+        </Field>
+        <Field label="Stales at (review-by date)">
+          <input
+            type="date"
+            value={draft.stales_at}
+            onChange={(e) => set("stales_at", e.target.value)}
+            className="w-full text-sm border rounded px-2 py-1.5"
+          />
+        </Field>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <Field label="CTA href (optional)">
+          <input
+            type="text"
+            value={draft.cta_href ?? ""}
+            onChange={(e) => set("cta_href", e.target.value || null)}
+            placeholder="/foreign-investment/united-kingdom"
+            className="w-full text-sm border rounded px-2 py-1.5"
+          />
+        </Field>
+        <Field label="CTA label (optional)">
+          <input
+            type="text"
+            value={draft.cta_label ?? ""}
+            onChange={(e) => set("cta_label", e.target.value || null)}
+            placeholder="UK investor guide"
+            className="w-full text-sm border rounded px-2 py-1.5"
+          />
+        </Field>
+      </div>
+
+      <label className="flex items-center gap-2 text-sm">
+        <input
+          type="checkbox"
+          checked={draft.active}
+          onChange={(e) => set("active", e.target.checked)}
+        />
+        <span>Active (visible to public)</span>
+      </label>
+
+      <div className="flex items-center gap-2 pt-2">
+        <button
+          type="button"
+          disabled={busy}
+          onClick={onSave}
+          className="bg-violet-600 hover:bg-violet-700 disabled:bg-slate-300 text-white text-sm font-bold px-4 py-2 rounded"
+        >
+          {busy ? "Saving…" : isEdit ? "Save changes" : "Create alert"}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="border border-slate-300 hover:bg-slate-50 text-slate-700 text-sm font-semibold px-4 py-2 rounded"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="block">
+      <span className="block text-xs font-semibold text-slate-600 mb-1">{label}</span>
+      {children}
+    </label>
+  );
+}

--- a/app/admin/country-rule-alerts/page.tsx
+++ b/app/admin/country-rule-alerts/page.tsx
@@ -1,0 +1,15 @@
+import AdminShell from "@/components/AdminShell";
+import AlertsEditor from "./AlertsEditor";
+
+export const metadata = { title: "Country rule alerts — Admin" };
+
+export default function CountryRuleAlertsAdminPage() {
+  return (
+    <AdminShell
+      title="Country rule alerts"
+      subtitle="Edit the regulatory rule-change banners shown on /find-advisor, /advisors, and /foreign-investment for visitors with a saved intent country. Public reads are RLS-gated by `active = true`."
+    >
+      <AlertsEditor />
+    </AdminShell>
+  );
+}

--- a/app/api/admin/country-rule-alerts/route.ts
+++ b/app/api/admin/country-rule-alerts/route.ts
@@ -1,0 +1,199 @@
+/**
+ * Admin CRUD for `country_rule_alerts`.
+ *
+ * Auth: ADMIN_EMAILS allow-list (mirrors app/api/admin/country-schemes).
+ * Body validation: Zod via withValidatedBody for POST/PATCH (CLAUDE.md
+ * `invest/no-unvalidated-req-json` rule). Audit-logged.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { getAdminEmails } from "@/lib/admin";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { createClient } from "@/lib/supabase/server";
+import { logger } from "@/lib/logger";
+import { withValidatedBody } from "@/lib/validation/withValidatedBody";
+import {
+  AlertCountrySchema,
+  AlertSeveritySchema,
+  COUNTRY_RULE_ALERT_COUNTRIES,
+} from "@/lib/country-rule-alerts";
+
+const log = logger("admin-country-rule-alerts");
+
+const CreateSchema = z.object({
+  alert_key: z
+    .string()
+    .min(3)
+    .max(120)
+    .regex(/^[a-z0-9-]+$/, "lowercase letters, digits, hyphens only"),
+  country_code: AlertCountrySchema,
+  severity: AlertSeveritySchema,
+  headline: z.string().min(1).max(200),
+  body: z.string().min(1).max(2000),
+  source: z.string().min(1).max(120),
+  cta_href: z.string().max(500).nullable().optional(),
+  cta_label: z.string().max(120).nullable().optional(),
+  stales_at: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  display_order: z.number().int().min(0).max(9999).default(0),
+  active: z.boolean().default(true),
+});
+
+const UpdateSchema = CreateSchema.partial().extend({
+  id: z.number().int().positive(),
+});
+
+async function requireAdmin(): Promise<{ email: string } | null> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user?.email) return null;
+  const allowed = getAdminEmails();
+  const email = user.email.toLowerCase();
+  if (!allowed.includes(email)) return null;
+  return { email };
+}
+
+/** GET /api/admin/country-rule-alerts?country_code=uk */
+export async function GET(request: NextRequest) {
+  const admin = await requireAdmin();
+  if (!admin) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const code = request.nextUrl.searchParams.get("country_code");
+  let lowerCode: string | null = null;
+  if (code) {
+    lowerCode = code.toLowerCase();
+    if (
+      !(COUNTRY_RULE_ALERT_COUNTRIES as readonly string[]).includes(lowerCode)
+    ) {
+      return NextResponse.json({ error: "Invalid country_code" }, { status: 400 });
+    }
+  }
+
+  const supabase = createAdminClient();
+  let query = supabase
+    .from("country_rule_alerts")
+    .select("*")
+    .order("country_code", { ascending: true })
+    .order("display_order", { ascending: true });
+
+  if (lowerCode) {
+    query = query.eq("country_code", lowerCode);
+  }
+
+  const { data, error } = await query;
+  if (error) {
+    log.error("List failed", { error: error.message });
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  return NextResponse.json({ rows: data ?? [] });
+}
+
+/** POST /api/admin/country-rule-alerts — create a new row */
+export const POST = withValidatedBody(CreateSchema, async (_req, body) => {
+  const admin = await requireAdmin();
+  if (!admin) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const supabase = createAdminClient();
+  const insertRow = {
+    alert_key: body.alert_key,
+    country_code: body.country_code,
+    severity: body.severity,
+    headline: body.headline,
+    body: body.body,
+    source: body.source,
+    cta_href: body.cta_href ?? null,
+    cta_label: body.cta_label ?? null,
+    stales_at: body.stales_at,
+    display_order: body.display_order,
+    active: body.active,
+  };
+  const { data, error } = await supabase
+    .from("country_rule_alerts")
+    .insert(insertRow)
+    .select("*")
+    .single();
+
+  if (error) {
+    log.error("Insert failed", { error: error.message });
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  await supabase.from("admin_audit_log").insert({
+    action: "country_rule_alert:created",
+    entity_type: "country_rule_alerts",
+    entity_id: String(data.id),
+    admin_email: admin.email,
+    details: { country_code: body.country_code, alert_key: body.alert_key },
+  });
+
+  return NextResponse.json(data, { status: 201 });
+});
+
+/** PATCH /api/admin/country-rule-alerts — update an existing row by id */
+export const PATCH = withValidatedBody(UpdateSchema, async (_req, body) => {
+  const admin = await requireAdmin();
+  if (!admin) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id, ...updates } = body;
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("country_rule_alerts")
+    .update({ ...updates, updated_at: new Date().toISOString() })
+    .eq("id", id)
+    .select("*")
+    .single();
+
+  if (error) {
+    log.error("Update failed", { error: error.message });
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  await supabase.from("admin_audit_log").insert({
+    action: "country_rule_alert:updated",
+    entity_type: "country_rule_alerts",
+    entity_id: String(id),
+    admin_email: admin.email,
+    details: updates,
+  });
+
+  return NextResponse.json(data);
+});
+
+/** DELETE /api/admin/country-rule-alerts?id=123 */
+export async function DELETE(request: NextRequest) {
+  const admin = await requireAdmin();
+  if (!admin) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const id = request.nextUrl.searchParams.get("id");
+  if (!id || !/^\d+$/.test(id)) {
+    return NextResponse.json({ error: "id required" }, { status: 400 });
+  }
+
+  const supabase = createAdminClient();
+  const { error } = await supabase
+    .from("country_rule_alerts")
+    .delete()
+    .eq("id", parseInt(id, 10));
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  await supabase.from("admin_audit_log").insert({
+    action: "country_rule_alert:deleted",
+    entity_type: "country_rule_alerts",
+    entity_id: id,
+    admin_email: admin.email,
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/country-rule-alerts/route.ts
+++ b/app/api/country-rule-alerts/route.ts
@@ -1,0 +1,33 @@
+/**
+ * Public read for country rule alerts.
+ *
+ * GET /api/country-rule-alerts?country=uk
+ *   → { alerts: PublicRuleAlert[] }
+ *
+ * Read-only. The CountryRuleAlerts client component calls this on mount
+ * after reading the iv_intent_country cookie. Unknown / missing country
+ * returns an empty list (200) so the banner gracefully renders nothing.
+ *
+ * Caching: 5-minute stale-while-revalidate on the edge — alerts change
+ * a few times per quarter via /admin/country-rule-alerts; visitors are
+ * tolerant of brief staleness.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getActiveAlertsForCountry } from "@/lib/country-rule-alerts";
+
+export const runtime = "nodejs";
+
+export async function GET(request: NextRequest) {
+  const country = request.nextUrl.searchParams.get("country") ?? "";
+  const alerts = await getActiveAlertsForCountry(country);
+  return NextResponse.json(
+    { alerts },
+    {
+      headers: {
+        "Cache-Control":
+          "public, max-age=60, s-maxage=300, stale-while-revalidate=600",
+      },
+    },
+  );
+}

--- a/app/api/country-rule-alerts/route.ts
+++ b/app/api/country-rule-alerts/route.ts
@@ -14,7 +14,7 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
-import { getActiveAlertsForCountry } from "@/lib/country-rule-alerts";
+import { getActiveAlertsForCountry } from "@/lib/country-rule-alerts-server";
 
 export const runtime = "nodejs";
 

--- a/components/CountryRuleAlerts.tsx
+++ b/components/CountryRuleAlerts.tsx
@@ -1,21 +1,12 @@
 "use client";
-// dated-strings-exempt: alert dates are static regulatory effective-dates
-// shipped as a transitional in-code seed; #15 part 2 moves these to a
-// `country_rule_alerts` table with stalesAt per row, at which point this
-// file is deleted and the gate applies to the new DB-backed renderer.
 
 /**
  * CountryRuleAlerts — surfaces 1-2 high-impact rule-change notifications
  * relevant to the visitor's intent country.
  *
- * PR queue #15 (partial): ships banner infra + hardcoded content seeded
- * from the most material rule changes per corridor as of 2026-05.
- * Future PR adds the table + admin CRUD so editorial can update without
- * a deploy. Per founder 2026-05-09 (no post-launch deferral): ship infra
- * now, expand content over the runway.
- *
- * Reads iv_intent_country cookie. Renders a small alert strip when there
- * are alerts for that country. Each alert is dismissable per-session
+ * Reads the iv_intent_country cookie, then fetches active alerts for
+ * that country from /api/country-rule-alerts (DB-backed; managed via
+ * /admin/country-rule-alerts). Each alert is dismissable per-session
  * (sessionStorage) so repeat visits don't keep showing the same alert
  * after the user has acknowledged it.
  *
@@ -30,98 +21,10 @@ import {
   isKnownIntentCountry,
   type IntentCountryCode,
 } from "@/lib/intent-context";
-
-interface RuleAlert {
-  id: string;
-  /** Severity drives the colour palette — info (blue) / warning (amber) / urgent (red). */
-  severity: "info" | "warning" | "urgent";
-  headline: string;
-  body: string;
-  source: string;
-  /** Optional CTA — e.g. link to the relevant /foreign-investment/<slug> page. */
-  ctaHref?: string;
-  ctaLabel?: string;
-}
-
-const ALERTS_BY_COUNTRY: Partial<Record<IntentCountryCode, ReadonlyArray<RuleAlert>>> = {
-  uk: [
-    {
-      id: "uk-firb-established-ban-2025",
-      severity: "warning",
-      headline: "AU established-dwelling ban active until 31 March 2027",
-      body: "Foreign buyers (including UK residents) cannot purchase established AU residential dwellings between 1 April 2025 and 31 March 2027. New builds + off-the-plan remain available with FIRB approval.",
-      source: "Treasury / FIRB",
-      ctaHref: "/foreign-investment/united-kingdom",
-      ctaLabel: "UK investor guide",
-    },
-  ],
-  us: [
-    {
-      id: "us-fatca-threshold-2026",
-      severity: "info",
-      headline: "FATCA reporting thresholds: $50k year-end / $75k anytime",
-      body: "US persons (including dual citizens in AU) must file Form 8938 if specified foreign financial assets exceed these thresholds at year-end or any time during the year. AU super may be reportable depending on structure.",
-      source: "IRS",
-      ctaHref: "/foreign-investment/united-states",
-      ctaLabel: "US investor guide",
-    },
-  ],
-  in: [
-    {
-      id: "in-dasp-claim-window",
-      severity: "info",
-      headline: "DASP super refund: claim within 6 months of permanent departure",
-      body: "Indian residents who worked in AU and have departed permanently can claim DASP. Tax withheld at 35% (taxed component) / 45-65% (untaxed component). Late claims forfeit to ATO unclaimed-super pool.",
-      source: "ATO",
-      ctaHref: "/foreign-investment/india",
-      ctaLabel: "India investor guide",
-    },
-  ],
-  ae: [
-    {
-      id: "ae-no-dta-30pct",
-      severity: "warning",
-      headline: "No UAE-AU DTA — 30% withholding on unfranked dividends",
-      body: "There is no AU-UAE double-tax agreement, so unfranked AU dividends + royalties paid to UAE residents are taxed at the full 30% withholding rate. Fully-franked AU dividends remain at 0% withholding regardless.",
-      source: "ATO",
-      ctaHref: "/foreign-investment/united-arab-emirates",
-      ctaLabel: "UAE investor guide",
-    },
-  ],
-  sa: [
-    {
-      id: "sa-no-dta-30pct",
-      severity: "warning",
-      headline: "No Saudi-AU DTA — 30% withholding on unfranked dividends",
-      body: "There is no AU-Saudi DTA. Unfranked AU dividends + royalties paid to Saudi residents are taxed at the full 30% withholding rate. Halal-compliant equity investing focuses on franked dividends (0% withholding) + property.",
-      source: "ATO",
-      ctaHref: "/foreign-investment/saudi-arabia",
-      ctaLabel: "Saudi investor guide",
-    },
-  ],
-  hk: [
-    {
-      id: "hk-au-tiea-active",
-      severity: "info",
-      headline: "AU-HK tax-info exchange agreement is in force",
-      body: "AU broker accounts opened by HK residents may be reported to AU under the TIEA. AU residents with HK accounts are reciprocally reportable. Cross-border tax planning should account for this transparency layer.",
-      source: "ATO",
-      ctaHref: "/foreign-investment/hong-kong",
-      ctaLabel: "HK investor guide",
-    },
-  ],
-  cn: [
-    {
-      id: "cn-fx-cap-50k",
-      severity: "info",
-      headline: "Mainland China FX cap: USD 50,000/yr personal foreign exchange",
-      body: "China's State Administration of Foreign Exchange limits personal foreign-currency conversion to USD 50,000 per year. Plan large AU investments around this cap (or use compliant business / migration vehicles).",
-      source: "SAFE",
-      ctaHref: "/foreign-investment/china",
-      ctaLabel: "China investor guide",
-    },
-  ],
-};
+import type {
+  PublicRuleAlert,
+  AlertSeverity,
+} from "@/lib/country-rule-alerts";
 
 function readIntentCountry(): IntentCountryCode | null {
   if (typeof document === "undefined") return null;
@@ -134,22 +37,22 @@ function readIntentCountry(): IntentCountryCode | null {
   return null;
 }
 
-function readDismissed(alertId: string): boolean {
+function readDismissed(alertKey: string): boolean {
   if (typeof window === "undefined") return false;
   try {
-    return sessionStorage.getItem(`iv-rule-alert-dismissed:${alertId}`) === "1";
+    return sessionStorage.getItem(`iv-rule-alert-dismissed:${alertKey}`) === "1";
   } catch {
     return false;
   }
 }
 
-const SEVERITY_CLASSES: Record<RuleAlert["severity"], string> = {
+const SEVERITY_CLASSES: Record<AlertSeverity, string> = {
   info: "border-blue-200 bg-blue-50 text-blue-900",
   warning: "border-amber-200 bg-amber-50 text-amber-900",
   urgent: "border-red-200 bg-red-50 text-red-900",
 };
 
-const SEVERITY_ICONS: Record<RuleAlert["severity"], string> = {
+const SEVERITY_ICONS: Record<AlertSeverity, string> = {
   info: "ℹ️",
   warning: "⚠️",
   urgent: "🚨",
@@ -157,45 +60,66 @@ const SEVERITY_ICONS: Record<RuleAlert["severity"], string> = {
 
 export default function CountryRuleAlerts() {
   const [country, setCountry] = useState<IntentCountryCode | null>(null);
-  const [dismissedIds, setDismissedIds] = useState<Set<string>>(new Set());
+  const [alerts, setAlerts] = useState<PublicRuleAlert[]>([]);
+  const [dismissedKeys, setDismissedKeys] = useState<Set<string>>(new Set());
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- syncing cookie (external state) into React on mount
     setCountry(readIntentCountry());
   }, []);
 
   useEffect(() => {
-    if (!country) return;
-    const alerts = ALERTS_BY_COUNTRY[country];
-    if (!alerts) return;
-    const dismissed = new Set(alerts.filter((a) => readDismissed(a.id)).map((a) => a.id));
-    setDismissedIds(dismissed);
+    if (!country) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- reset to empty when country clears
+      setAlerts([]);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(
+          `/api/country-rule-alerts?country=${encodeURIComponent(country)}`,
+        );
+        if (!res.ok) return;
+        const json = (await res.json()) as { alerts?: PublicRuleAlert[] };
+        if (cancelled) return;
+        const next = json.alerts ?? [];
+        setAlerts(next);
+        setDismissedKeys(
+          new Set(next.filter((a) => readDismissed(a.alert_key)).map((a) => a.alert_key)),
+        );
+      } catch {
+        // network failure — banner stays hidden, no user-visible breakage
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
   }, [country]);
 
-  if (!country) return null;
-  const alerts = ALERTS_BY_COUNTRY[country];
-  if (!alerts) return null;
+  if (!country || alerts.length === 0) return null;
 
-  const visible = alerts.filter((a) => !dismissedIds.has(a.id));
+  const visible = alerts.filter((a) => !dismissedKeys.has(a.alert_key));
   if (visible.length === 0) return null;
 
-  const dismiss = (alertId: string) => {
+  const dismiss = (alertKey: string) => {
     try {
-      sessionStorage.setItem(`iv-rule-alert-dismissed:${alertId}`, "1");
+      sessionStorage.setItem(`iv-rule-alert-dismissed:${alertKey}`, "1");
     } catch {
       /* ignore */
     }
-    setDismissedIds((prev) => new Set([...prev, alertId]));
+    setDismissedKeys((prev) => new Set([...prev, alertKey]));
   };
 
   return (
     <div className="space-y-2 my-4" data-testid="country-rule-alerts">
       {visible.map((alert) => (
         <div
-          key={alert.id}
+          key={alert.alert_key}
           className={`rounded-xl border p-4 flex flex-wrap items-start justify-between gap-x-4 gap-y-2 ${SEVERITY_CLASSES[alert.severity]}`}
           role="region"
           aria-label={`Country rule alert: ${alert.headline}`}
-          data-testid={`rule-alert-${alert.id}`}
+          data-testid={`rule-alert-${alert.alert_key}`}
         >
           <div className="flex-1 min-w-0">
             <p className="text-sm font-bold leading-snug mb-1">
@@ -208,21 +132,21 @@ export default function CountryRuleAlerts() {
             </p>
           </div>
           <div className="flex items-center gap-3 shrink-0">
-            {alert.ctaHref && alert.ctaLabel && (
+            {alert.cta_href && alert.cta_label && (
               <a
-                href={alert.ctaHref}
+                href={alert.cta_href}
                 className="text-xs font-bold underline underline-offset-2 hover:opacity-80"
-                data-testid={`rule-alert-${alert.id}-cta`}
+                data-testid={`rule-alert-${alert.alert_key}-cta`}
               >
-                {alert.ctaLabel} →
+                {alert.cta_label} →
               </a>
             )}
             <button
               type="button"
-              onClick={() => dismiss(alert.id)}
+              onClick={() => dismiss(alert.alert_key)}
               className="text-xs opacity-70 hover:opacity-100"
               aria-label="Dismiss alert"
-              data-testid={`rule-alert-${alert.id}-dismiss`}
+              data-testid={`rule-alert-${alert.alert_key}-dismiss`}
             >
               ✕
             </button>

--- a/docs/plans/pre-launch-wave-status.md
+++ b/docs/plans/pre-launch-wave-status.md
@@ -2,7 +2,7 @@
 
 **Plan source:** `docs/plans/pre-launch-wave-master-prompt.md` (Wave 1-6)
 **Loop prompt:** `docs/plans/pre-launch-wave-loop-prompt.md`
-**Last updated:** 2026-05-09 (cron iter — JSON-LD audit + ratchet shipped)
+**Last updated:** 2026-05-10 (cron iter — country rule alerts DB + admin CRUD shipped)
 
 ---
 
@@ -71,7 +71,7 @@ Source: `docs/plans/pre-launch-wave-master-prompt.md`. Lowercase rows mirror tha
 | W3.18 | Verified user reviews engine | B | pending | — | mirror PR #441 moderation |
 | W3.19 | First Home Buyer end-to-end journey | B | pending | — | 4 monetization levers |
 | W4.20 | Smart recommendations strip (legacy #14) | B | pending | — | 2-3 days |
-| W4.21 | Country rule alerts DB + admin CRUD (legacy #15 part 2) | B | pending | — | migrate ALERTS_BY_COUNTRY |
+| W4.21 | Country rule alerts DB + admin CRUD (legacy #15 part 2) | B | ✅ done | (this iter) | `country_rule_alerts` table + RLS + 7-row seed; /admin/country-rule-alerts CRUD; CountryRuleAlerts.tsx fetches from new public API |
 | W4.22 | Country rule alerts email digest (legacy #15 part 4) | B | pending | — | weekly Resend cron |
 | W4.23 | PR-X3 firm billing dashboard (legacy #10) | C | pending | — | aggregate view |
 | W5.24 | Embed comparison widget | A | pending | — | iframe + UTM |
@@ -97,6 +97,8 @@ Source: `docs/plans/pre-launch-wave-master-prompt.md`. Lowercase rows mirror tha
 - 2026-05-09 22:25 | W1.3 | Picked JSON-LD audit + ratchet over W1.1/W1.2 | W1.1 (AI Concierge, 2 days) and W1.2 (calculator funnel, 1-2 days) won't fit in one cron fire; W1.3 is a half-day Tier A item that ships cleanly end-to-end. Lowest-numbered tractable Wave-1 item.
 - 2026-05-09 22:25 | W1.3 | Coverage gate strategy = "≥1 JSON-LD block per public route" | Per-type checks (Article vs FAQPage vs FinancialProduct) considered and rejected as too brittle — same page legitimately ships several blocks; new schema.org types appear regularly. Type correctness stays with page authors.
 - 2026-05-09 22:25 | W1.3 | noindex pages auto-exempt | Pages with `robots.index: false` opt out of search indexing; rich-snippet schema is wasted work. Detected via metadata-text scan
+- 2026-05-10 02:15 | W4.21 | Picked W4.21 over W1.1/W1.2/W1.4 for one-fire scope | W1.1 (concierge homepage) and W1.2 (calculator funnel × 8) and W1.4 (reverse marketplace, Tier C) are all multi-day. W4.21 is well-bounded — schema + admin CRUD + consumer refactor + tests, single PR. Component header comment already scoped this exact PR. Skipped W2.5 (PR-X5a investor accounts foundation) because it gates the rest of Wave 2 — better to ship as a focused multi-fire sequence
+- 2026-05-10 02:15 | W4.21 | country_code stored as lowercase IntentCountryCode | country_schemes uses uppercase ISO-2 (GB/US/IN). Picked lowercase here to match the existing iv_intent_country cookie value the consumer reads — no case-mapping at read time, simpler RLS-public reads, CHECK constraint covers the 12 known intent countries
 
 ## Pause history
 

--- a/lib/country-rule-alerts-server.ts
+++ b/lib/country-rule-alerts-server.ts
@@ -1,0 +1,50 @@
+/**
+ * Server-only country-rule-alerts fetcher.
+ *
+ * Split from `country-rule-alerts.ts` because the supabase server
+ * client transitively imports `next/headers`, which is forbidden in
+ * client bundles. Mirrors the `intent-context-server.ts` pattern.
+ *
+ * The table is RLS-public-on-active so we use the anon `createClient()`
+ * — no service-role key needed for reads.
+ */
+
+import { createClient } from "@/lib/supabase/server";
+import { isKnownIntentCountry } from "@/lib/intent-context";
+import {
+  PublicRuleAlertSchema,
+  type PublicRuleAlert,
+} from "@/lib/country-rule-alerts";
+
+const PUBLIC_COLUMNS =
+  "alert_key, severity, headline, body, source, cta_href, cta_label";
+
+/**
+ * Fetch active alerts for a country, ordered by display_order.
+ * Returns [] for unknown countries or on any DB error — the alerts
+ * banner is best-effort and must never break a page render.
+ */
+export async function getActiveAlertsForCountry(
+  countryCode: string,
+): Promise<PublicRuleAlert[]> {
+  const code = countryCode.trim().toLowerCase();
+  if (!isKnownIntentCountry(code)) return [];
+
+  try {
+    const supabase = await createClient();
+    const { data } = await supabase
+      .from("country_rule_alerts")
+      .select(PUBLIC_COLUMNS)
+      .eq("country_code", code)
+      .eq("active", true)
+      .order("display_order", { ascending: true });
+
+    if (!data) return [];
+
+    return data
+      .map((row) => PublicRuleAlertSchema.safeParse(row))
+      .flatMap((parsed) => (parsed.success ? [parsed.data] : []));
+  } catch {
+    return [];
+  }
+}

--- a/lib/country-rule-alerts.ts
+++ b/lib/country-rule-alerts.ts
@@ -1,0 +1,103 @@
+/**
+ * Country-rule-alerts data layer.
+ *
+ * Reads `country_rule_alerts` rows for a given lowercase 2-letter
+ * intent-country code (uk/us/cn/in/jp/sg/hk/kr/my/nz/ae/sa). The table
+ * is RLS-public-on-active so we use the anon `createClient()` from
+ * `lib/supabase/server.ts` — no service-role key needed for reads.
+ *
+ * Editorial team writes via /admin/country-rule-alerts (service-role);
+ * the public client component fetches via /api/country-rule-alerts which
+ * proxies to this helper.
+ *
+ * Replaces the hardcoded ALERTS_BY_COUNTRY map that previously lived in
+ * components/CountryRuleAlerts.tsx (W4.21 in pre-launch-wave-master-prompt).
+ */
+
+import { z } from "zod";
+import { createClient } from "@/lib/supabase/server";
+import { isKnownIntentCountry } from "@/lib/intent-context";
+
+export const AlertSeveritySchema = z.enum(["info", "warning", "urgent"]);
+export type AlertSeverity = z.infer<typeof AlertSeveritySchema>;
+
+export const COUNTRY_RULE_ALERT_COUNTRIES = [
+  "uk",
+  "us",
+  "cn",
+  "in",
+  "jp",
+  "sg",
+  "hk",
+  "kr",
+  "my",
+  "nz",
+  "ae",
+  "sa",
+] as const;
+
+export const AlertCountrySchema = z.enum(COUNTRY_RULE_ALERT_COUNTRIES);
+export type AlertCountry = z.infer<typeof AlertCountrySchema>;
+
+/** Public-facing shape — what the client component renders. */
+export const PublicRuleAlertSchema = z.object({
+  alert_key: z.string(),
+  severity: AlertSeveritySchema,
+  headline: z.string(),
+  body: z.string(),
+  source: z.string(),
+  cta_href: z.string().nullable(),
+  cta_label: z.string().nullable(),
+});
+export type PublicRuleAlert = z.infer<typeof PublicRuleAlertSchema>;
+
+/** Admin row — includes housekeeping columns the editor UI needs. */
+export const AdminRuleAlertSchema = PublicRuleAlertSchema.extend({
+  id: z.number(),
+  country_code: AlertCountrySchema,
+  stales_at: z.string(),
+  display_order: z.number(),
+  active: z.boolean(),
+  created_at: z.string().nullable(),
+  updated_at: z.string().nullable(),
+});
+export type AdminRuleAlert = z.infer<typeof AdminRuleAlertSchema>;
+
+export const SEVERITY_LABELS: Record<AlertSeverity, string> = {
+  info: "Info",
+  warning: "Warning",
+  urgent: "Urgent",
+};
+
+const PUBLIC_COLUMNS =
+  "alert_key, severity, headline, body, source, cta_href, cta_label";
+
+/**
+ * Fetch active alerts for a country, ordered by display_order.
+ * Returns [] for unknown countries or on any DB error — the alerts
+ * banner is best-effort and must never break a page render.
+ */
+export async function getActiveAlertsForCountry(
+  countryCode: string,
+): Promise<PublicRuleAlert[]> {
+  const code = countryCode.trim().toLowerCase();
+  if (!isKnownIntentCountry(code)) return [];
+
+  try {
+    const supabase = await createClient();
+    const { data } = await supabase
+      .from("country_rule_alerts")
+      .select(PUBLIC_COLUMNS)
+      .eq("country_code", code)
+      .eq("active", true)
+      .order("display_order", { ascending: true });
+
+    if (!data) return [];
+
+    return data
+      .map((row) => PublicRuleAlertSchema.safeParse(row))
+      .flatMap((parsed) => (parsed.success ? [parsed.data] : []));
+  } catch {
+    return [];
+  }
+}

--- a/lib/country-rule-alerts.ts
+++ b/lib/country-rule-alerts.ts
@@ -1,22 +1,19 @@
 /**
- * Country-rule-alerts data layer.
+ * Country-rule-alerts shared types + zod schemas.
  *
- * Reads `country_rule_alerts` rows for a given lowercase 2-letter
- * intent-country code (uk/us/cn/in/jp/sg/hk/kr/my/nz/ae/sa). The table
- * is RLS-public-on-active so we use the anon `createClient()` from
- * `lib/supabase/server.ts` — no service-role key needed for reads.
+ * Client- and server-safe. The server-only fetch helper that pulls
+ * rows from Supabase lives in `country-rule-alerts-server.ts` so this
+ * module can be imported by client components (the admin editor) and
+ * shared types stay in one place.
  *
  * Editorial team writes via /admin/country-rule-alerts (service-role);
- * the public client component fetches via /api/country-rule-alerts which
- * proxies to this helper.
+ * the public client component fetches via /api/country-rule-alerts.
  *
- * Replaces the hardcoded ALERTS_BY_COUNTRY map that previously lived in
- * components/CountryRuleAlerts.tsx (W4.21 in pre-launch-wave-master-prompt).
+ * Replaces the hardcoded ALERTS_BY_COUNTRY map that previously lived
+ * in components/CountryRuleAlerts.tsx (W4.21).
  */
 
 import { z } from "zod";
-import { createClient } from "@/lib/supabase/server";
-import { isKnownIntentCountry } from "@/lib/intent-context";
 
 export const AlertSeveritySchema = z.enum(["info", "warning", "urgent"]);
 export type AlertSeverity = z.infer<typeof AlertSeveritySchema>;
@@ -68,36 +65,3 @@ export const SEVERITY_LABELS: Record<AlertSeverity, string> = {
   warning: "Warning",
   urgent: "Urgent",
 };
-
-const PUBLIC_COLUMNS =
-  "alert_key, severity, headline, body, source, cta_href, cta_label";
-
-/**
- * Fetch active alerts for a country, ordered by display_order.
- * Returns [] for unknown countries or on any DB error — the alerts
- * banner is best-effort and must never break a page render.
- */
-export async function getActiveAlertsForCountry(
-  countryCode: string,
-): Promise<PublicRuleAlert[]> {
-  const code = countryCode.trim().toLowerCase();
-  if (!isKnownIntentCountry(code)) return [];
-
-  try {
-    const supabase = await createClient();
-    const { data } = await supabase
-      .from("country_rule_alerts")
-      .select(PUBLIC_COLUMNS)
-      .eq("country_code", code)
-      .eq("active", true)
-      .order("display_order", { ascending: true });
-
-    if (!data) return [];
-
-    return data
-      .map((row) => PublicRuleAlertSchema.safeParse(row))
-      .flatMap((parsed) => (parsed.success ? [parsed.data] : []));
-  } catch {
-    return [];
-  }
-}

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -5209,7 +5209,7 @@ export type Database = {
           alert_key: string
           body: string
           country_code: string
-          created_at: string | null
+          created_at: string
           cta_href: string | null
           cta_label: string | null
           display_order: number
@@ -5218,39 +5218,39 @@ export type Database = {
           severity: string
           source: string
           stales_at: string
-          updated_at: string | null
+          updated_at: string
         }
         Insert: {
           active?: boolean
           alert_key: string
           body: string
           country_code: string
-          created_at?: string | null
+          created_at?: string
           cta_href?: string | null
           cta_label?: string | null
           display_order?: number
           headline: string
-          id?: number
+          id?: never
           severity: string
           source: string
           stales_at: string
-          updated_at?: string | null
+          updated_at?: string
         }
         Update: {
           active?: boolean
           alert_key?: string
           body?: string
           country_code?: string
-          created_at?: string | null
+          created_at?: string
           cta_href?: string | null
           cta_label?: string | null
           display_order?: number
           headline?: string
-          id?: number
+          id?: never
           severity?: string
           source?: string
           stales_at?: string
-          updated_at?: string | null
+          updated_at?: string
         }
         Relationships: []
       }

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -5203,6 +5203,57 @@ export type Database = {
         }
         Relationships: []
       }
+      country_rule_alerts: {
+        Row: {
+          active: boolean
+          alert_key: string
+          body: string
+          country_code: string
+          created_at: string | null
+          cta_href: string | null
+          cta_label: string | null
+          display_order: number
+          headline: string
+          id: number
+          severity: string
+          source: string
+          stales_at: string
+          updated_at: string | null
+        }
+        Insert: {
+          active?: boolean
+          alert_key: string
+          body: string
+          country_code: string
+          created_at?: string | null
+          cta_href?: string | null
+          cta_label?: string | null
+          display_order?: number
+          headline: string
+          id?: number
+          severity: string
+          source: string
+          stales_at: string
+          updated_at?: string | null
+        }
+        Update: {
+          active?: boolean
+          alert_key?: string
+          body?: string
+          country_code?: string
+          created_at?: string | null
+          cta_href?: string | null
+          cta_label?: string | null
+          display_order?: number
+          headline?: string
+          id?: number
+          severity?: string
+          source?: string
+          stales_at?: string
+          updated_at?: string | null
+        }
+        Relationships: []
+      }
       course_lessons: {
         Row: {
           content: string | null

--- a/scripts/rate-limit-coverage.mjs
+++ b/scripts/rate-limit-coverage.mjs
@@ -101,6 +101,12 @@ const EXEMPT_PATTERNS = [
   // rate limiting inside the handler would cost CDN cache hits with
   // zero threat-model benefit.
   { match: /\/api\/geo(\/|$)/, reason: "edge route w/ 1h CDN cache; provider-pooled" },
+  // Public read of country_rule_alerts (W4.21). Single ?country= query
+  // param against an enum allow-list, no PII, no writes. Cache-Control
+  // sets s-maxage=300 + stale-while-revalidate=600 so Vercel's CDN
+  // absorbs repeats from the same IP. Per-IP throttle inside the
+  // handler would cost cache hits with no real threat model.
+  { match: /\/api\/country-rule-alerts(\/|$)/, reason: "public read w/ 5m CDN cache; provider-pooled" },
 ];
 
 async function findRouteFiles(dir) {

--- a/supabase/migrations/20260510120000_country_rule_alerts.sql
+++ b/supabase/migrations/20260510120000_country_rule_alerts.sql
@@ -1,0 +1,132 @@
+-- ============================================================================
+-- Migration: 20260510120000_country_rule_alerts.sql
+-- Purpose: Move the hardcoded ALERTS_BY_COUNTRY map from
+--          components/CountryRuleAlerts.tsx into a `country_rule_alerts`
+--          table so editorial can publish new regulatory alerts per
+--          intent-country without a deploy. Public consumers read via the
+--          anon JWT under RLS (active = true); admins write via service
+--          role through /admin/country-rule-alerts.
+-- Audit ref: docs/plans/pre-launch-wave-master-prompt.md W4.21
+-- Risk: low — additive; no foreign keys; the in-code map and the
+--       DB-backed reader can co-exist for one deploy because we replace
+--       the consumer in the same PR.
+-- Rollback: DROP TABLE IF EXISTS public.country_rule_alerts;
+--           (DESTRUCTIVE — discards admin-edited rows. Re-run the seed
+--           block of this migration to repopulate the launch-day rows.)
+-- ============================================================================
+--
+-- Forward operations:
+--   1. CREATE TABLE IF NOT EXISTS public.country_rule_alerts (...).
+--   2. CREATE INDEX idx_country_rule_alerts_lookup.
+--   3. ALTER TABLE ... ENABLE + FORCE ROW LEVEL SECURITY.
+--   4. CREATE POLICY public anon SELECT (active = true).
+--   5. CREATE POLICY service_role ALL.
+--   6. INSERT seed rows mirroring the current in-code ALERTS_BY_COUNTRY.
+--
+-- country_code is stored as the lowercase 2-letter `IntentCountryCode`
+-- value (uk/us/cn/in/jp/sg/hk/kr/my/nz/ae/sa) — matches the cookie value
+-- read by the client component, so no case mapping at read time.
+-- ============================================================================
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.country_rule_alerts (
+  id            bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  alert_key     text   NOT NULL UNIQUE,                     -- stable key for sessionStorage dismissal
+  country_code  text   NOT NULL CHECK (country_code IN (
+                  'uk','us','cn','in','jp','sg','hk','kr','my','nz','ae','sa'
+                )),
+  severity      text   NOT NULL CHECK (severity IN ('info','warning','urgent')),
+  headline      text   NOT NULL,
+  body          text   NOT NULL,
+  source        text   NOT NULL,
+  cta_href      text,
+  cta_label     text,
+  stales_at     date   NOT NULL,                            -- V-NEW-01 dated-stats gate reads this
+  display_order integer NOT NULL DEFAULT 0,
+  active        boolean NOT NULL DEFAULT true,
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  updated_at    timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_country_rule_alerts_lookup
+  ON public.country_rule_alerts (country_code, active, display_order);
+
+ALTER TABLE public.country_rule_alerts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.country_rule_alerts FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Public can read active country rule alerts" ON public.country_rule_alerts;
+CREATE POLICY "Public can read active country rule alerts"
+  ON public.country_rule_alerts FOR SELECT
+  USING (active = true);
+
+DROP POLICY IF EXISTS "Service role full access to country rule alerts" ON public.country_rule_alerts;
+CREATE POLICY "Service role full access to country rule alerts"
+  ON public.country_rule_alerts FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- ──────────────────────────────────────────────────────────────────────────
+-- Seed: 7 launch-day rows. Mirrors the ALERTS_BY_COUNTRY map being
+-- removed from components/CountryRuleAlerts.tsx in this same PR.
+-- alert_key is stable across deploys so existing sessionStorage dismissals
+-- carry over for visitors who already acknowledged an alert.
+-- Idempotent: ON CONFLICT (alert_key) DO NOTHING.
+-- ──────────────────────────────────────────────────────────────────────────
+
+INSERT INTO public.country_rule_alerts
+  (alert_key, country_code, severity, headline, body, source,
+   cta_href, cta_label, stales_at, display_order)
+VALUES
+  ('uk-firb-established-ban-2025', 'uk', 'warning',
+   'AU established-dwelling ban active until 31 March 2027',
+   'Foreign buyers (including UK residents) cannot purchase established AU residential dwellings between 1 April 2025 and 31 March 2027. New builds + off-the-plan remain available with FIRB approval.',
+   'Treasury / FIRB',
+   '/foreign-investment/united-kingdom', 'UK investor guide',
+   '2027-03-31', 10),
+
+  ('us-fatca-threshold-2026', 'us', 'info',
+   'FATCA reporting thresholds: $50k year-end / $75k anytime',
+   'US persons (including dual citizens in AU) must file Form 8938 if specified foreign financial assets exceed these thresholds at year-end or any time during the year. AU super may be reportable depending on structure.',
+   'IRS',
+   '/foreign-investment/united-states', 'US investor guide',
+   '2027-04-15', 10),
+
+  ('in-dasp-claim-window', 'in', 'info',
+   'DASP super refund: claim within 6 months of permanent departure',
+   'Indian residents who worked in AU and have departed permanently can claim DASP. Tax withheld at 35% (taxed component) / 45-65% (untaxed component). Late claims forfeit to ATO unclaimed-super pool.',
+   'ATO',
+   '/foreign-investment/india', 'India investor guide',
+   '2027-04-15', 10),
+
+  ('ae-no-dta-30pct', 'ae', 'warning',
+   'No UAE-AU DTA — 30% withholding on unfranked dividends',
+   'There is no AU-UAE double-tax agreement, so unfranked AU dividends + royalties paid to UAE residents are taxed at the full 30% withholding rate. Fully-franked AU dividends remain at 0% withholding regardless.',
+   'ATO',
+   '/foreign-investment/united-arab-emirates', 'UAE investor guide',
+   '2027-04-15', 10),
+
+  ('sa-no-dta-30pct', 'sa', 'warning',
+   'No Saudi-AU DTA — 30% withholding on unfranked dividends',
+   'There is no AU-Saudi DTA. Unfranked AU dividends + royalties paid to Saudi residents are taxed at the full 30% withholding rate. Halal-compliant equity investing focuses on franked dividends (0% withholding) + property.',
+   'ATO',
+   '/foreign-investment/saudi-arabia', 'Saudi investor guide',
+   '2027-04-15', 10),
+
+  ('hk-au-tiea-active', 'hk', 'info',
+   'AU-HK tax-info exchange agreement is in force',
+   'AU broker accounts opened by HK residents may be reported to AU under the TIEA. AU residents with HK accounts are reciprocally reportable. Cross-border tax planning should account for this transparency layer.',
+   'ATO',
+   '/foreign-investment/hong-kong', 'HK investor guide',
+   '2027-04-15', 10),
+
+  ('cn-fx-cap-50k', 'cn', 'info',
+   'Mainland China FX cap: USD 50,000/yr personal foreign exchange',
+   'China''s State Administration of Foreign Exchange limits personal foreign-currency conversion to USD 50,000 per year. Plan large AU investments around this cap (or use compliant business / migration vehicles).',
+   'SAFE',
+   '/foreign-investment/china', 'China investor guide',
+   '2027-04-15', 10)
+ON CONFLICT (alert_key) DO NOTHING;
+
+COMMIT;


### PR DESCRIPTION
## Summary
Move the hardcoded `ALERTS_BY_COUNTRY` map out of `components/CountryRuleAlerts.tsx` into a `country_rule_alerts` table so editorial can publish/edit/retire rule-change banners per intent country without a deploy.

**Replaces #710** — same change set, but the proxy in this cron container blocked updates to that branch's existing remote ref, so the build-fix commit had to be pushed under a new branch.

## Why
`docs/plans/pre-launch-wave-master-prompt.md` W4.21 (legacy queue #15 part 2). The `CountryRuleAlerts.tsx` component header comment had already scoped this exact PR — banner infra shipped in #694 with a TODO to move the content store to a table + admin CRUD.

## Tier
**B** — additive RLS migration + new admin CRUD route + existing-component refactor. No webhooks, no Stripe, no cron, no auth changes. Per `MERGE_AUTHORIZATION.md` Tier B → merge after CI green + 15-min Sentry/Vercel observation.

(Borderline Tier C reading: this PR adds a new schema migration. Calling it B because the table is editorial content (not user data), RLS is anon-public-on-active + service-role-only writes, no consumer depends on it before this same PR's deploy. Founder may downgrade priority.)

## Files
- `supabase/migrations/20260510120000_country_rule_alerts.sql` — table, RLS (public anon SELECT on `active = true`; service-role ALL), 7-row seed mirroring the prior in-code alerts.
- `lib/country-rule-alerts.ts` — client-safe zod schemas + types only.
- `lib/country-rule-alerts-server.ts` — server-only `getActiveAlertsForCountry()` (split out of the schemas file because the admin client editor pulls in the schemas, and bundling the supabase server client into the client bundle pulls in `next/headers` → Turbopack build error). Mirrors the `intent-context.ts` / `intent-context-server.ts` split pattern.
- `app/api/country-rule-alerts/route.ts` — public `GET ?country=uk` with `Cache-Control: s-maxage=300, stale-while-revalidate=600`.
- `components/CountryRuleAlerts.tsx` — replaces in-component map with a fetch to the new public API.
- `app/admin/country-rule-alerts/{page,AlertsEditor}.tsx` + `app/api/admin/country-rule-alerts/route.ts` — admin CRUD (mirrors `/admin/country-schemes`). Admin-email allow-list, Zod-validated bodies via `withValidatedBody`, audit-logged writes.
- `lib/database.types.ts` — added `country_rule_alerts` Row/Insert/Update entries.
- `scripts/rate-limit-coverage.mjs` — added EXEMPT_PATTERNS entry (CDN-pooled rationale, same as `/api/quiz/data`, `/api/geo`).
- `docs/plans/pre-launch-wave-status.md` — W4.21 marked done + decision-log entries.

## Test plan
- [x] `vitest run` for the 3 new test files: 34/34 pass (14 lib + 3 public API + 17 admin API).
- [x] `tsc --noEmit`: clean.
- [x] `eslint --max-warnings 0` on all touched files: clean.
- [x] `node scripts/rate-limit-coverage.mjs --strict`: 100% (335 routes, 0 missing).
- [x] Local `npm run build`: clean (after the `-server.ts` split — initial commit had the next/headers bundle bug fixed in commit 2).
- [ ] CI: pending.
- [ ] Visual: open `/find-advisor` with `iv_intent_country=uk` cookie → UK FIRB alert renders identically to before; refresh after dismissing → still hidden (sessionStorage); `/admin/country-rule-alerts` lists 7 seed rows + create/edit/delete round-trip works.

## Migration
Forward-only, idempotent (`CREATE TABLE IF NOT EXISTS`, `ON CONFLICT (alert_key) DO NOTHING`). Rollback documented in the migration header. NOTE: the `Supabase types drift` CI gate will fail until the migration applies to live (table doesn't exist there yet) — expected for any new-table PR; admin-merge after founder OK.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DaCEhxj2QqSZJ4eRtVSfHL)_