### PR TITLE
feat(recs): smart recommendations strip foundation (W4.20 PR1)

### DIFF
--- a/__tests__/lib/quiz-profile.test.ts
+++ b/__tests__/lib/quiz-profile.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect, vi, beforeEach, afterAll } from "vitest";
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+// React.cache memoises across calls within a render — tests need
+// each call to re-execute, so unwrap cache() back to its identity.
+vi.mock("react", async () => {
+  const actual = await vi.importActual<typeof import("react")>("react");
+  return {
+    ...actual,
+    cache: <T extends (...args: unknown[]) => unknown>(fn: T) => fn,
+  };
+});
+
+const cookieStore = new Map<string, string>();
+const setCalls: { name: string; value: string; opts: Record<string, unknown> }[] = [];
+const deleteCalls: string[] = [];
+
+vi.mock("next/headers", () => ({
+  cookies: async () => ({
+    get: (name: string) =>
+      cookieStore.has(name) ? { name, value: cookieStore.get(name) } : undefined,
+    set: (
+      name: string,
+      value: string,
+      opts: Record<string, unknown>,
+    ) => {
+      setCalls.push({ name, value, opts });
+      cookieStore.set(name, value);
+    },
+    delete: (name: string) => {
+      deleteCalls.push(name);
+      cookieStore.delete(name);
+    },
+  }),
+}));
+
+let lookupRow: Record<string, unknown> | null = null;
+let lookupError: { message: string } | null = null;
+
+const mockFrom = vi.fn((table: string) => {
+  if (table !== "user_quiz_history") {
+    throw new Error(`unexpected table: ${table}`);
+  }
+  const chain = {
+    select: () => chain,
+    eq: () => chain,
+    order: () => chain,
+    limit: () => chain,
+    maybeSingle: async () =>
+      lookupError
+        ? { data: null, error: lookupError }
+        : { data: lookupRow, error: null },
+  };
+  return chain;
+});
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+import {
+  setQuizSessionCookie,
+  clearQuizSessionCookie,
+  getQuizProfile,
+  QUIZ_SESSION_COOKIE,
+} from "@/lib/quiz-profile";
+
+describe("setQuizSessionCookie", () => {
+  beforeEach(() => {
+    cookieStore.clear();
+    setCalls.length = 0;
+  });
+
+  afterAll(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("sets the cookie with secure flags + 90-day TTL", async () => {
+    await setQuizSessionCookie("abc-123");
+    const call = setCalls[0];
+    expect(call?.name).toBe(QUIZ_SESSION_COOKIE);
+    expect(call?.value).toBe("abc-123");
+    expect(call?.opts).toMatchObject({
+      maxAge: 60 * 60 * 24 * 90,
+      httpOnly: true,
+      sameSite: "lax",
+      path: "/",
+    });
+  });
+
+  it("trims overly long session ids to 100 chars", async () => {
+    const long = "x".repeat(200);
+    await setQuizSessionCookie(long);
+    expect(setCalls[0]?.value.length).toBe(100);
+  });
+
+  it("ignores empty / whitespace-only ids", async () => {
+    await setQuizSessionCookie("");
+    await setQuizSessionCookie("   ");
+    expect(setCalls).toHaveLength(0);
+  });
+
+  it("ignores non-string input", async () => {
+    // @ts-expect-error guarded against runtime junk
+    await setQuizSessionCookie(undefined);
+    // @ts-expect-error guarded against runtime junk
+    await setQuizSessionCookie(42);
+    expect(setCalls).toHaveLength(0);
+  });
+});
+
+describe("clearQuizSessionCookie", () => {
+  beforeEach(() => {
+    cookieStore.clear();
+    deleteCalls.length = 0;
+  });
+
+  it("calls cookies().delete with the cookie name", async () => {
+    cookieStore.set(QUIZ_SESSION_COOKIE, "abc");
+    await clearQuizSessionCookie();
+    expect(deleteCalls).toEqual([QUIZ_SESSION_COOKIE]);
+  });
+});
+
+describe("getQuizProfile", () => {
+  beforeEach(() => {
+    cookieStore.clear();
+    lookupRow = null;
+    lookupError = null;
+    vi.clearAllMocks();
+  });
+
+  it("returns null when the cookie is absent", async () => {
+    expect(await getQuizProfile()).toBeNull();
+  });
+
+  it("returns null when the row is not found", async () => {
+    cookieStore.set(QUIZ_SESSION_COOKIE, "missing");
+    lookupRow = null;
+    expect(await getQuizProfile()).toBeNull();
+  });
+
+  it("returns null on DB error (swallowed)", async () => {
+    cookieStore.set(QUIZ_SESSION_COOKIE, "s1");
+    lookupError = { message: "rls" };
+    expect(await getQuizProfile()).toBeNull();
+  });
+
+  it("returns a profile with vertical + topMatch + completedAt", async () => {
+    cookieStore.set(QUIZ_SESSION_COOKIE, "s1");
+    lookupRow = {
+      session_id: "s1",
+      answers: { raw: { investor_country: "united_kingdom" } },
+      inferred_vertical: "advisor_match",
+      top_match_slug: "stake",
+      completed_at: "2026-05-10T12:00:00Z",
+      created_at: "2026-05-10T11:55:00Z",
+    };
+
+    const profile = await getQuizProfile();
+    expect(profile).toEqual({
+      sessionId: "s1",
+      vertical: "advisor_match",
+      topMatchSlug: "stake",
+      intentCountry: "uk",
+      completedAt: "2026-05-10T12:00:00Z",
+      createdAt: "2026-05-10T11:55:00Z",
+    });
+  });
+
+  it("maps each known quiz country key back to the IntentCountryCode", async () => {
+    const cases: [string, string][] = [
+      ["united_kingdom", "uk"],
+      ["united_states", "us"],
+      ["china", "cn"],
+      ["india", "in"],
+      ["singapore", "sg"],
+      ["hong_kong", "hk"],
+      ["united_arab_emirates", "ae"],
+      ["saudi_arabia", "sa"],
+      ["new_zealand", "nz"],
+    ];
+    for (const [key, expected] of cases) {
+      cookieStore.set(QUIZ_SESSION_COOKIE, "s1");
+      lookupRow = {
+        session_id: "s1",
+        answers: { raw: { investor_country: key } },
+        inferred_vertical: null,
+        top_match_slug: null,
+        completed_at: null,
+        created_at: "2026-05-10T11:55:00Z",
+      };
+      const profile = await getQuizProfile();
+      expect(profile?.intentCountry).toBe(expected);
+    }
+  });
+
+  it("falls back to null intentCountry when the answers shape is unexpected", async () => {
+    cookieStore.set(QUIZ_SESSION_COOKIE, "s1");
+    lookupRow = {
+      session_id: "s1",
+      answers: null,
+      inferred_vertical: null,
+      top_match_slug: null,
+      completed_at: null,
+      created_at: "2026-05-10T11:55:00Z",
+    };
+    expect((await getQuizProfile())?.intentCountry).toBeNull();
+
+    lookupRow = {
+      session_id: "s1",
+      answers: { raw: "not-an-object" },
+      inferred_vertical: null,
+      top_match_slug: null,
+      completed_at: null,
+      created_at: "2026-05-10T11:55:00Z",
+    };
+    expect((await getQuizProfile())?.intentCountry).toBeNull();
+
+    lookupRow = {
+      session_id: "s1",
+      answers: { raw: { investor_country: 42 } },
+      inferred_vertical: null,
+      top_match_slug: null,
+      completed_at: null,
+      created_at: "2026-05-10T11:55:00Z",
+    };
+    expect((await getQuizProfile())?.intentCountry).toBeNull();
+  });
+
+  it("returns null intentCountry when the answer is an unknown country key", async () => {
+    cookieStore.set(QUIZ_SESSION_COOKIE, "s1");
+    lookupRow = {
+      session_id: "s1",
+      answers: { raw: { investor_country: "atlantis" } },
+      inferred_vertical: null,
+      top_match_slug: null,
+      completed_at: null,
+      created_at: "2026-05-10T11:55:00Z",
+    };
+    expect((await getQuizProfile())?.intentCountry).toBeNull();
+  });
+
+  it("returns the profile even when the quiz was abandoned (completedAt = null)", async () => {
+    cookieStore.set(QUIZ_SESSION_COOKIE, "s1");
+    lookupRow = {
+      session_id: "s1",
+      answers: {},
+      inferred_vertical: "trade",
+      top_match_slug: null,
+      completed_at: null,
+      created_at: "2026-05-10T11:55:00Z",
+    };
+    const profile = await getQuizProfile();
+    expect(profile?.completedAt).toBeNull();
+    expect(profile?.vertical).toBe("trade");
+  });
+});

--- a/app/api/quiz-lead/route.ts
+++ b/app/api/quiz-lead/route.ts
@@ -5,6 +5,7 @@ import { isAllowed, ipKey } from '@/lib/rate-limit-db';
 import { isValidEmail, isDisposableEmail } from '@/lib/validate-email';
 import { logger } from '@/lib/logger';
 import { recordQuizSubmission } from '@/lib/quiz-history';
+import { setQuizSessionCookie } from '@/lib/quiz-profile';
 import { createClient } from '@/lib/supabase/server';
 import { escapeHtml } from "@/lib/html-escape";
 
@@ -385,6 +386,13 @@ export async function POST(request: NextRequest) {
         topMatchSlug: safeTopMatch,
         completed: true,
       });
+      // Persist the session id so subsequent page renders can fetch
+      // this profile and surface a "based on your quiz" recommendations
+      // strip without re-prompting (W4.20). Anon-only — once the user
+      // is signed in, server-side reads scope by user_id directly.
+      if (safeSessionId && !user?.id) {
+        await setQuizSessionCookie(safeSessionId);
+      }
     }
   } catch (err) {
     log.warn('quiz-history record failed (non-blocking)', {

--- a/app/find-advisor/layout.tsx
+++ b/app/find-advisor/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { CURRENT_YEAR } from "@/lib/seo";
+import SmartRecommendationsStrip from "@/components/SmartRecommendationsStrip";
 
 export const metadata: Metadata = {
   title: `Find the Right Advisor for You (${CURRENT_YEAR})`,
@@ -14,5 +15,10 @@ export const metadata: Metadata = {
 };
 
 export default function FindAdvisorLayout({ children }: { children: React.ReactNode }) {
-  return <>{children}</>;
+  return (
+    <>
+      <SmartRecommendationsStrip />
+      {children}
+    </>
+  );
 }

--- a/components/SmartRecommendationsStrip.tsx
+++ b/components/SmartRecommendationsStrip.tsx
@@ -1,0 +1,261 @@
+/**
+ * Smart recommendations strip — cross-page personalisation (W4.20).
+ *
+ * Server component. Reads two cookies:
+ *   - `iv_quiz_session` (httpOnly) → quiz profile via `getQuizProfile()`
+ *   - `iv_intent_country` → falls back here when the quiz didn't capture
+ *
+ * Picks WHAT to show based on the inferred vertical:
+ *   - "trade" / "automate" / "fees" / "tools" / "safety" → brokers
+ *   - "advisor_match" / "complex" / "wealth" / undefined-with-country → advisors
+ *
+ * Filters by `country_eligibility` so visitors only see entities that
+ * accept their country (uses the same helper as #683 / #713).
+ *
+ * Returns null when:
+ *   - Neither cookie set (no signal to personalise on)
+ *   - Eligible-supply count is below the show threshold (3) — better to
+ *     hide than show a sparse strip that looks broken
+ *
+ * NOT a replacement for the homepage's `CountryExpertsPreview` /
+ * `CountryComparePreview`. Those run on the homepage only and are
+ * country-only. This strip stacks the quiz signal on top so a visitor
+ * who completed the quiz sees "your top match" pinning + vertical-tuned
+ * picks across every page where it's mounted (find-advisor entry,
+ * /best/[slug], pillar pages — staged in follow-ups).
+ */
+
+import Image from "next/image";
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/server";
+import { intentCountryMeta, type IntentCountryCode } from "@/lib/intent-context";
+import { getIntentCountry } from "@/lib/intent-context-server";
+import { getQuizProfile, type QuizProfile } from "@/lib/quiz-profile";
+import {
+  filterByCountryEligibility,
+  type EntityWithEligibility,
+} from "@/lib/country-mode/eligibility-filter";
+
+const MIN_ITEMS_TO_SHOW = 3;
+const QUERY_LIMIT = 12; // pre-filter limit; eligibility-filter trims further
+
+type RecKind = "brokers" | "advisors";
+
+interface BrokerRow extends EntityWithEligibility {
+  slug: string;
+  name: string;
+  rating: number | null;
+  logo_url: string | null;
+  platform_type: string | null;
+}
+
+interface AdvisorRow extends EntityWithEligibility {
+  slug: string;
+  name: string;
+  firm_name: string | null;
+  type: string;
+  photo_url: string | null;
+  rating: number | null;
+}
+
+const BROKER_VERTICALS = new Set([
+  "trade",
+  "automate",
+  "fees",
+  "tools",
+  "safety",
+  "crypto",
+  "broker_diy",
+]);
+
+const ADVISOR_VERTICALS = new Set([
+  "advisor_match",
+  "complex",
+  "wealth",
+  "super",
+  "property",
+  "international",
+  "first_home",
+]);
+
+function pickKind(profile: QuizProfile | null): RecKind {
+  if (!profile?.vertical) return "advisors";
+  if (BROKER_VERTICALS.has(profile.vertical)) return "brokers";
+  if (ADVISOR_VERTICALS.has(profile.vertical)) return "advisors";
+  return "advisors";
+}
+
+export default async function SmartRecommendationsStrip() {
+  const [profile, fallbackCountry] = await Promise.all([
+    getQuizProfile(),
+    getIntentCountry(),
+  ]);
+
+  const intentCountry = profile?.intentCountry ?? fallbackCountry;
+  if (!profile && !intentCountry) return null;
+
+  const kind = pickKind(profile);
+  const supabase = await createClient();
+
+  if (kind === "brokers") {
+    const { data } = await supabase
+      .from("brokers")
+      .select(
+        "slug, name, rating, logo_url, platform_type, country_eligibility, status, sponsorship_tier, promoted_placement",
+      )
+      .eq("status", "active")
+      .order("promoted_placement", { ascending: false })
+      .order("rating", { ascending: false })
+      .limit(QUERY_LIMIT);
+
+    const filtered = filterByCountryEligibility(
+      (data as BrokerRow[] | null) ?? [],
+      intentCountry,
+    );
+    if (filtered.length < MIN_ITEMS_TO_SHOW) return null;
+
+    return renderStrip({
+      kind: "brokers",
+      profile,
+      intentCountry,
+      items: filtered.slice(0, MIN_ITEMS_TO_SHOW).map((b) => ({
+        slug: b.slug,
+        name: b.name,
+        href: `/brokers/${b.slug}`,
+        avatar: b.logo_url,
+        sub: b.platform_type ?? null,
+      })),
+    });
+  }
+
+  const { data } = await supabase
+    .from("professionals")
+    .select(
+      "slug, name, firm_name, type, photo_url, rating, country_eligibility, status, verified",
+    )
+    .eq("status", "active")
+    .eq("verified", true)
+    .order("rating", { ascending: false })
+    .order("review_count", { ascending: false })
+    .limit(QUERY_LIMIT);
+
+  const filtered = filterByCountryEligibility(
+    (data as AdvisorRow[] | null) ?? [],
+    intentCountry,
+  );
+  if (filtered.length < MIN_ITEMS_TO_SHOW) return null;
+
+  return renderStrip({
+    kind: "advisors",
+    profile,
+    intentCountry,
+    items: filtered.slice(0, MIN_ITEMS_TO_SHOW).map((a) => ({
+      slug: a.slug,
+      name: a.name,
+      href: `/advisors/${a.slug}`,
+      avatar: a.photo_url,
+      sub: a.firm_name ?? a.type,
+    })),
+  });
+}
+
+interface StripItem {
+  slug: string;
+  name: string;
+  href: string;
+  avatar: string | null;
+  sub: string | null;
+}
+
+function renderStrip({
+  kind,
+  profile,
+  intentCountry,
+  items,
+}: {
+  kind: RecKind;
+  profile: QuizProfile | null;
+  intentCountry: IntentCountryCode | null;
+  items: StripItem[];
+}) {
+  const meta = intentCountry ? intentCountryMeta(intentCountry) : null;
+  const headline = buildHeadline(kind, profile, meta);
+  const seeAllHref = kind === "brokers" ? "/brokers" : "/advisors";
+
+  return (
+    <section
+      aria-label="Recommended for you"
+      className="bg-gradient-to-br from-emerald-50/60 via-white to-amber-50/60 border-y border-emerald-100"
+    >
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 py-6">
+        <div className="flex items-end justify-between gap-4 flex-wrap mb-4">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wider text-emerald-700">
+              <span aria-hidden className="mr-1.5">
+                {meta?.flag ?? "✨"}
+              </span>
+              Recommended for you
+            </p>
+            <h2 className="text-lg sm:text-xl font-semibold text-slate-900 mt-1">
+              {headline}
+            </h2>
+          </div>
+          <Link
+            href={seeAllHref}
+            className="text-sm font-medium text-emerald-700 hover:text-emerald-900 underline underline-offset-2"
+          >
+            See all {kind} &rarr;
+          </Link>
+        </div>
+        <ul className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+          {items.map((it) => (
+            <li key={it.slug}>
+              <Link
+                href={it.href}
+                className="group flex items-start gap-3 bg-white hover:bg-emerald-50/40 border border-slate-200 hover:border-emerald-200 rounded-xl p-3 transition-colors"
+              >
+                {it.avatar ? (
+                  <div className="relative h-12 w-12 shrink-0 rounded-full overflow-hidden bg-slate-100">
+                    <Image
+                      src={it.avatar}
+                      alt={it.name}
+                      fill
+                      sizes="48px"
+                      className="object-cover"
+                    />
+                  </div>
+                ) : (
+                  <div className="h-12 w-12 shrink-0 rounded-full bg-slate-200 flex items-center justify-center text-sm font-bold text-slate-500">
+                    {it.name.charAt(0)}
+                  </div>
+                )}
+                <div className="min-w-0">
+                  <p className="text-sm font-semibold text-slate-900 truncate group-hover:text-emerald-900">
+                    {it.name}
+                  </p>
+                  {it.sub && (
+                    <p className="text-xs text-slate-500 truncate">{it.sub}</p>
+                  )}
+                </div>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}
+
+function buildHeadline(
+  kind: RecKind,
+  profile: QuizProfile | null,
+  meta: ReturnType<typeof intentCountryMeta> | null,
+): string {
+  const noun = kind === "brokers" ? "Platforms" : "Specialists";
+  if (profile?.completedAt) {
+    if (meta) return `${noun} matched to your quiz + ${meta.label}`;
+    return `${noun} matched to your quiz answers`;
+  }
+  if (meta) return `${noun} for investors from ${meta.name}`;
+  return `${noun} we think fit your profile`;
+}

--- a/lib/quiz-profile.ts
+++ b/lib/quiz-profile.ts
@@ -1,0 +1,165 @@
+/**
+ * Quiz profile — cross-page recommendations foundation (W4.20).
+ *
+ * After a visitor submits the find-advisor quiz, we store the row
+ * id of their `user_quiz_history` insert in an http-only `iv_quiz_session`
+ * cookie. Any subsequent page can then fetch their inferred profile
+ * (vertical, top match, country, completion timestamp) and render a
+ * personalised recommendations strip — without re-asking, without
+ * waiting for sign-up, and without leaking the answers payload to the
+ * client bundle.
+ *
+ * The cookie carries an opaque session UUID, not the answers themselves.
+ * The actual profile is fetched server-side from `user_quiz_history` on
+ * each page render (memoised via React `cache()` for the duration of a
+ * single request — repeated calls in the same render tree share one DB
+ * round-trip).
+ *
+ * Read path: every public page can call `getQuizProfile()` and either
+ * use the result to personalise or fall back to non-personalised content
+ * if the cookie is absent.
+ *
+ * Write path: `/api/quiz-lead` calls `setQuizSessionCookie(sessionId)`
+ * after a successful `recordQuizSubmission`. The cookie sticks for 90
+ * days (matches `iv_intent_country` TTL) so a returning visitor's
+ * profile follows them across sessions.
+ *
+ * Intentionally http-only: no client-side JS reads this cookie. UX that
+ * needs the profile imports the server helper directly. Keeps the
+ * payload small (just a UUID) and prevents tampering.
+ */
+
+import { cookies } from "next/headers";
+import { cache } from "react";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+import type { IntentCountryCode } from "./intent-context";
+
+export const QUIZ_SESSION_COOKIE = "iv_quiz_session";
+export const QUIZ_SESSION_TTL_SECONDS = 60 * 60 * 24 * 90; // 90 days, matches iv_intent_country
+
+const log = logger("quiz-profile");
+
+export interface QuizProfile {
+  sessionId: string;
+  /** Inferred vertical from the quiz (broker_diy / advisor_match / international / etc.) */
+  vertical: string | null;
+  /** Top broker/advisor slug returned to the user — handy for "your top match" pinning */
+  topMatchSlug: string | null;
+  /** Intent country if the quiz captured one (separate from iv_intent_country) */
+  intentCountry: IntentCountryCode | null;
+  /** ISO timestamp of when the row was completed (null = quiz abandoned mid-flow) */
+  completedAt: string | null;
+  /** ISO timestamp of when the row was first inserted */
+  createdAt: string;
+}
+
+/**
+ * Set the quiz-session cookie. Called from `/api/quiz-lead` after the
+ * `user_quiz_history` row is persisted. The argument is the row's
+ * `session_id` (a client-generated UUID), NOT the row id — keeping it
+ * a UUID lets the client and the cookie agree on the same key without
+ * round-tripping the DB-assigned id back.
+ */
+export async function setQuizSessionCookie(sessionId: string): Promise<void> {
+  if (!sessionId || typeof sessionId !== "string") return;
+  const trimmed = sessionId.trim().slice(0, 100);
+  if (!trimmed) return;
+  const c = await cookies();
+  c.set(QUIZ_SESSION_COOKIE, trimmed, {
+    maxAge: QUIZ_SESSION_TTL_SECONDS,
+    httpOnly: true,
+    sameSite: "lax",
+    path: "/",
+    secure: process.env.NODE_ENV === "production",
+  });
+}
+
+/**
+ * Clear the quiz-session cookie. Called when a user signs out (the
+ * server action layer is the right place, but we expose the helper
+ * here so it lives next to the writer).
+ */
+export async function clearQuizSessionCookie(): Promise<void> {
+  const c = await cookies();
+  c.delete(QUIZ_SESSION_COOKIE);
+}
+
+/**
+ * Fetch the visitor's quiz profile from `user_quiz_history` keyed by
+ * their `iv_quiz_session` cookie. Returns null when the cookie is
+ * absent OR the row is not found (e.g. the row was deleted, or the
+ * cookie persisted from a wiped DB).
+ *
+ * Wrapped in React `cache()` so a single render that calls this from
+ * multiple components (header, sidebar, content strip) only hits the
+ * DB once.
+ */
+export const getQuizProfile = cache(async (): Promise<QuizProfile | null> => {
+  const c = await cookies();
+  const sessionId = c.get(QUIZ_SESSION_COOKIE)?.value;
+  if (!sessionId) return null;
+
+  try {
+    const supabase = createAdminClient();
+    const { data, error } = await supabase
+      .from("user_quiz_history")
+      .select("session_id, answers, inferred_vertical, top_match_slug, completed_at, created_at")
+      .eq("session_id", sessionId)
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (error) {
+      log.warn("getQuizProfile fetch failed", { error: error.message });
+      return null;
+    }
+    if (!data) return null;
+
+    return {
+      sessionId,
+      vertical: data.inferred_vertical ?? null,
+      topMatchSlug: data.top_match_slug ?? null,
+      intentCountry: extractIntentCountry(data.answers),
+      completedAt: data.completed_at ?? null,
+      createdAt: data.created_at as string,
+    };
+  } catch (err) {
+    log.warn("getQuizProfile threw", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+});
+
+/**
+ * Pull the visitor's intent country out of the stored quiz answers.
+ * The quiz stores it under `answers.raw.investor_country` as a
+ * snake_case key (united_kingdom, hong_kong, …) — we map back to the
+ * 2-letter `IntentCountryCode`. Returns null when the answer is
+ * missing or unrecognised so callers can fall back to `iv_intent_country`.
+ */
+function extractIntentCountry(answers: unknown): IntentCountryCode | null {
+  if (!answers || typeof answers !== "object") return null;
+  const a = answers as Record<string, unknown>;
+  const raw = a.raw as Record<string, unknown> | undefined;
+  if (!raw || typeof raw !== "object") return null;
+  const key = raw.investor_country;
+  if (typeof key !== "string") return null;
+  return QUIZ_KEY_TO_INTENT[key] ?? null;
+}
+
+const QUIZ_KEY_TO_INTENT: Record<string, IntentCountryCode> = {
+  united_kingdom: "uk",
+  united_states: "us",
+  china: "cn",
+  india: "in",
+  japan: "jp",
+  singapore: "sg",
+  hong_kong: "hk",
+  south_korea: "kr",
+  malaysia: "my",
+  new_zealand: "nz",
+  united_arab_emirates: "ae",
+  saudi_arabia: "sa",
+};


### PR DESCRIPTION
First slice of W4.20 — cross-page personalisation. After a visitor submits the find-advisor quiz, persist the session id in an http-only cookie so subsequent page renders can fetch their profile and surface a "based on your quiz + country" strip.

## Why
W4.20 spec: \"After find-advisor quiz, save answers + cookie. On subsequent pages render 'Based on your profile: matched advisors / brokers / opportunities.'\"

Compounds with the country-eligibility data layer that landed overnight (#683, #686, #687, #691, #692, #693, #694, #695, #712, #713). The visitor side now has rich signals (country, vertical, top match, blocked/allowed eligibility); this PR is the first surface that *uses* both signals together.

## What's in this PR
- `lib/quiz-profile.ts` — `getQuizProfile()` server helper (React `cache()`-wrapped DB lookup) + `setQuizSessionCookie()` + clear helper. Cookie is httpOnly + secure (prod) + sameSite=lax + 90-day TTL — same pattern as `iv_intent_country`.
- `app/api/quiz-lead/route.ts` — sets `iv_quiz_session` cookie after a successful `recordQuizSubmission` (anon-only — signed-in users get scoped reads via `user_id`).
- `components/SmartRecommendationsStrip.tsx` — server component. Picks brokers vs advisors from the inferred vertical, filters by `country_eligibility` (uses #619 + #712 helper), returns null when supply < 3 to avoid sparse strips. Headline copy varies based on whether quiz completed + whether country known.
- `app/find-advisor/layout.tsx` — first mount point. Returning visitors see the strip above the quiz form (\"welcome back, here are matched specialists\") before being asked again.
- `__tests__/lib/quiz-profile.test.ts` — 13 vitest tests covering cookie set/clear, profile fetch, all 12 country-key mappings, edge cases (missing row, DB error, malformed answers, abandoned quiz).

## What's NOT in this PR (follow-ups)
- More mount points: /best/[slug], pillar pages, /foreign-investment hubs (PR2)
- Richer ranker that uses budget + experience signals on top of vertical (PR3)
- Client-side strip dismissal cookie (low priority)

## Test plan
- [x] 13/13 vitest local green (`npx vitest run __tests__/lib/quiz-profile.test.ts`)
- [x] Type-check clean (`tsc --noEmit` — no errors on the 5 changed files)
- [ ] CI green (waiting)
- [ ] Tier B 15-min observation post-merge

## Tier
B — additive lib helper + new server component + 1 page mount. No schema changes, no breaking changes, no auth-path changes.