### PR TITLE
chore(loop): coordination fixes — dedup guard, stale sweeper, supersedes auto-close, single-owner status doc

### DIFF
--- a/.claude/commands/audit-remediation-iteration.md
+++ b/.claude/commands/audit-remediation-iteration.md
@@ -177,10 +177,26 @@ Then, walk `REMEDIATION_DEFAULTS.md`'s priority order. For each stream in order:
 - **Skip items with status `blocked` or `false-positive`** — these are not picked up by the loop. Blocked items are the user's call; false-positives are already resolved.
 - If the stream's queue section has a `pending` item, that's the candidate.
 - If the candidate is the very first item of that stream and the stream has no branch yet:
+  - **PRECONDITION — duplicate-PR guard (added 2026-05-10 after the X-09 / PP-01 / KK-01 duplicate-PR cleanup).** Before creating the branch, search for an open PR already covering this stream item:
+
+    ```bash
+    DUP=$(gh pr list --state open --search "<X-NN> in:title" --json number,title,headRefName \
+            --jq '.[] | select(.title | test("\\b<X-NN>\\b"))' )
+    if [ -n "$DUP" ]; then
+      echo "STATUS: DUPLICATE · open PR already covers <X-NN>:"
+      echo "$DUP" | jq .
+      # Mark the queue item as `in_flight` referencing the existing PR (don't open a parallel one).
+      # If the existing PR is stale (>7 days old, no recent push), prefer to rebase its branch
+      # rather than open a duplicate. Surface to founder if the existing PR's approach diverges.
+      exit 0
+    fi
+    ```
+
+    Why: 2026-05-10 cleanup closed three duplicate-PR pairs (#648 vs #702 ratcheting X-09, #649 vs #706 shipping PP-01, #667 superseded by #703's KK-01 bundle). Each pair burned ~160k tokens on the loser. The dedup guard catches the second-comer before any code is written.
   - Create branch from `main`: `git checkout -b claude/audit-remediation/<letter>-<slug>`.
   - Make an initial empty commit (`git commit --allow-empty -m "chore(<stream-letter>): scaffold remediation stream"`).
   - Push: `git push -u origin <branch>`.
-  - Open a PR via `mcp__github__create_pull_request` with title `chore(<stream-letter>): <stream title> [audit remediation]` and body referencing the audit + tracking issue. Open it READY (not draft) — the `auto-merge-label.js` workflow applies `needs-human-review` automatically on touched paths, which is the actual safety gate; draft state on top of that is pure friction.
+  - Open a PR via `mcp__github__create_pull_request` with title `chore(<stream-letter>): <stream title> [audit remediation]` and body referencing the audit + tracking issue. The body MUST include a `## Supersedes` section (e.g. `## Supersedes\n\n_None._` or a list of `#NNN` it replaces) — the `auto-close-superseded.yml` workflow reads this on merge and closes named PRs automatically. Open it READY (not draft) — the `auto-merge-label.js` workflow applies `needs-human-review` automatically on touched paths, which is the actual safety gate; draft state on top of that is pure friction.
   - Update queue's In-flight table with branch + PR number.
 - Otherwise checkout the existing stream branch and pull.
 

--- a/.claude/commands/audit-remediation-parallel.md
+++ b/.claude/commands/audit-remediation-parallel.md
@@ -100,7 +100,28 @@ default 4 GB OOMs on this sandbox; 5 GB is enough.
 
 ## Step 4 — Open PRs
 
-For each branch:
+**PRECONDITION — duplicate-PR guard (added 2026-05-10).** For each item ID
+about to ship as a PR, first check no open PR already covers it:
+
+```bash
+for ITEM in <X-NN> <Y-NN> <Z-NN>; do
+  DUP=$(gh pr list --state open --search "$ITEM in:title" --json number,title \
+          --jq ".[] | select(.title | test(\"\\\\b$ITEM\\\\b\"))")
+  if [ -n "$DUP" ]; then
+    echo "DUPLICATE for $ITEM — skipping. Existing PR:"
+    echo "$DUP" | jq .
+    # Mark the queue row as in_flight referencing the existing PR; do NOT open a parallel one.
+  fi
+done
+```
+
+If a duplicate is found for any item, drop that item from this fire. Better
+to ship 2 of 3 cleanly than to ship 3 with one going to waste. The 2026-05-10
+cleanup closed #648 vs #702, #649 vs #706, #667 vs #703 — each pair was a
+parallel-fire collision that this gate catches.
+
+For non-duplicate items, open the PR. The PR body MUST include a `## Supersedes`
+section so the `auto-close-superseded.yml` workflow can pick it up on merge:
 
 ```bash
 gh pr create \
@@ -113,6 +134,10 @@ gh pr create \
 
 ## Queue item
 {ITEM_ID} — see docs/audits/REMEDIATION_QUEUE.md
+
+## Supersedes
+_None._
+<!-- or: list of #NNN this PR replaces. The auto-close workflow reads this section on merge. -->
 
 ## Test plan
 - [ ] CI green

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,49 @@
+<!--
+  Default PR template. The `## Supersedes` section is read by
+  `.github/workflows/auto-close-superseded.yml` on merge — fill it in
+  honestly. Empty section = no auto-close, but the section MUST be
+  present so the workflow's grep is reliable.
+
+  For launch hotfixes, switch to: ?template=launch-hotfix.md
+-->
+
+## Summary
+
+<!-- 1–2 sentences: what changed and why now. -->
+
+## Tier
+
+<!-- A / B / C / D / E per docs/audits/MERGE_AUTHORIZATION.md.
+     - A: tests / docs / content / page UI / loop PRs
+     - B: refactors / additive API tests / RLS migrations passing isolation gate
+     - C: webhooks, cron, middleware/proxy, auth, compliance, lib/stripe,
+          lib/supabase/admin, .github/workflows, new schema migrations
+     - D: PR body says "set X env var first"
+     - E: force-push / branch delete / repo settings -->
+
+## Supersedes
+
+_None._
+
+<!--
+  If this PR replaces or bundles in earlier PR(s), list them as a
+  bulleted list of `#NNN` references — the auto-close workflow will
+  close each on merge with a pointer comment. Examples:
+
+  ## Supersedes
+  - #648 — earlier attempt at the same X-09 ratchet (this PR uses createStaticClient)
+  - #649 — separate-workflow approach to bundle gate (this PR scripts inside ci.yml)
+
+  Always include the section, even if empty. The workflow greps for
+  `## Supersedes` literally; missing the section silently disables the
+  auto-close path.
+-->
+
+## Test plan
+
+<!--
+- [ ] vitest local: <result>
+- [ ] type-check: clean
+- [ ] CI: green
+- [ ] Visual / functional: <how to verify>
+-->

--- a/.github/workflows/auto-close-superseded.yml
+++ b/.github/workflows/auto-close-superseded.yml
@@ -1,0 +1,172 @@
+name: Auto-close superseded PRs
+
+# When a PR merges, parse its body for a `## Supersedes` section listing
+# `#NNN` references. For each open PR named, post a pointer comment and
+# close it. The merging PR is the canonical replacement.
+#
+# Why this exists:
+#   2026-05-10's cleanup closed three duplicate-PR pairs by hand:
+#     • #648 (X-09) was superseded by #702 (X-09b) — same intent, cleaner approach
+#     • #649 (PP-01 separate workflow) was superseded by #706 (PP-01 in ci.yml)
+#     • #667 (KK-01 audit) was superseded by #703 (KK-03 bundle that included it)
+#   Each pair sat open until manually triaged. Token cost on the loser
+#   PR was already paid. With this workflow, the bundling/canonical PR
+#   declares its supersede list in the body, and merge fires the close.
+#
+# Format (in the merging PR's body):
+#   ## Supersedes
+#   - #NNN — short reason
+#   - #MMM — short reason
+#
+# Or:
+#   ## Supersedes
+#   _None._
+#
+# The workflow extracts only the lines between `## Supersedes` and the
+# next `## ` heading. Anything outside that section is ignored, so
+# casual `#NNN` references in the Summary or commit messages don't get
+# accidentally closed.
+#
+# Safety:
+#   • Only fires on `pull_request: closed` with merged=true.
+#   • Skips numbers that are already closed (idempotent re-runs are
+#     no-ops, e.g. when a workflow re-runs on the same merged PR).
+#   • Will NOT close PRs from another repo (cross-repo `#NNN` references
+#     are not supported — gh resolves to the current repo by default).
+#   • Comments BEFORE closing so the trail is preserved if the close
+#     itself fails (e.g., transient API error).
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: auto-close-superseded-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  close-superseded:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Parse supersedes + close
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MERGED_PR: ${{ github.event.pull_request.number }}
+          MERGED_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${PR_BODY:-}" ]; then
+            echo "No PR body — nothing to parse."
+            exit 0
+          fi
+
+          # Extract the Supersedes section: everything between
+          #   ^## Supersedes
+          # and the next `## ` line (or EOF). awk is more robust than
+          # sed here for handling edge cases (no trailing heading, blank
+          # lines, etc.).
+          section=$(printf '%s\n' "$PR_BODY" | awk '
+            /^## Supersedes[[:space:]]*$/ { in_section = 1; next }
+            in_section && /^## / { exit }
+            in_section { print }
+          ')
+
+          if [ -z "$section" ]; then
+            echo "No '## Supersedes' section found — nothing to close."
+            exit 0
+          fi
+
+          echo "=== Supersedes section ==="
+          echo "$section"
+          echo "=========================="
+
+          # Pull every #NNN reference. Strip backticks (in case someone
+          # wrote `#123`), HTML comments, and the literal "_None._" text.
+          numbers=$(echo "$section" \
+            | sed -e 's/<!--[^>]*-->//g' \
+                  -e 's/`//g' \
+                  -e 's/_None\._//g' \
+            | grep -oE '#[0-9]+' \
+            | sed 's/#//' \
+            | sort -u || true)
+
+          if [ -z "$numbers" ]; then
+            echo "Section present but no #NNN references — done."
+            exit 0
+          fi
+
+          echo "Will attempt to close: $numbers"
+
+          closed=0
+          skipped=0
+          failed=0
+
+          for n in $numbers; do
+            # Don't close ourselves (in case someone references the
+            # merged PR's own number for some reason).
+            if [ "$n" = "$MERGED_PR" ]; then
+              echo "  ↪ #$n is the merging PR itself — skipping"
+              skipped=$(( skipped + 1 ))
+              continue
+            fi
+
+            state=$(gh pr view "$n" --repo "$REPO" --json state --jq '.state' 2>/dev/null || echo "MISSING")
+
+            case "$state" in
+              OPEN)
+                echo "  → closing #$n"
+                close_body="🤖 **Auto-close (superseded):** this PR was named in the \`## Supersedes\` section of #$MERGED_PR ($MERGED_TITLE), which has now merged. Closing as superseded."$'\n\n'"If this is wrong, reopen the PR and remove the reference from #$MERGED_PR's body for next time."
+                if gh pr comment "$n" --repo "$REPO" --body "$close_body" ; then
+                  if gh pr close "$n" --repo "$REPO" ; then
+                    closed=$(( closed + 1 ))
+                  else
+                    echo "  ⚠ comment posted but close failed for #$n"
+                    failed=$(( failed + 1 ))
+                  fi
+                else
+                  echo "  ⚠ comment failed for #$n"
+                  failed=$(( failed + 1 ))
+                fi
+                ;;
+              CLOSED|MERGED)
+                echo "  ↪ #$n already $state — skipping"
+                skipped=$(( skipped + 1 ))
+                ;;
+              MISSING)
+                echo "  ⚠ #$n not found in this repo — skipping"
+                skipped=$(( skipped + 1 ))
+                ;;
+              *)
+                echo "  ⚠ #$n unexpected state: $state — skipping"
+                skipped=$(( skipped + 1 ))
+                ;;
+            esac
+          done
+
+          echo ""
+          echo "=== Summary ==="
+          echo "Closed: $closed | Skipped: $skipped | Failed: $failed"
+
+          {
+            echo "## Auto-close superseded summary"
+            echo ""
+            echo "Triggered by merge of #$MERGED_PR — $MERGED_TITLE"
+            echo ""
+            echo "- Closed: $closed"
+            echo "- Skipped (already closed / not found / self): $skipped"
+            echo "- Failed: $failed"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # Don't fail the job on close errors — the workflow has already
+          # done its best, and a hard failure here would obscure other
+          # signals. Errors are surfaced in the summary.
+          exit 0

--- a/.github/workflows/stale-pr-sweeper.yml
+++ b/.github/workflows/stale-pr-sweeper.yml
@@ -1,0 +1,265 @@
+name: Stale-PR sweeper
+
+# Daily cron that flags + auto-closes PRs that have drifted too far from
+# main to be reasonably mergeable. Two failure modes from 2026-05-10's
+# cleanup motivated this:
+#   • #603 (SSOT consolidation): branched 2026-05-07, sat untouched until
+#     2026-05-10 by which point main had moved 657 files / 68k lines past
+#     it. No human noticed it had become un-rebaseable.
+#   • #705 (advisor eligibility filter): branched off pre-launch-wave
+#     during the 2026-05-09 burst; branch ended 600+ commits behind main
+#     within 24 hours. The diff against main showed thousands of phantom
+#     "deletions" that were really just "stuff main had merged since".
+#
+# Both cases were silently rotting PRs: nobody was working on them, but
+# they sat in `gh pr list` adding noise to triage. This workflow surfaces
+# them automatically.
+#
+# Two-stage policy:
+#   Stage 1 (label-only): comment with the staleness metric + apply
+#     `stale-pr` label. This is the "rebase or close" nudge.
+#   Stage 2 (auto-close): if the PR still has `stale-pr` >48h after the
+#     label was applied AND nothing else has touched it, close with
+#     a pointer comment. Force-pushing or pushing a fresh commit
+#     resets the clock (the label gets removed in stage 1's logic when
+#     the branch is no longer behind).
+#
+# Safety:
+#   • Opt-IN by branch prefix, not opt-out. Only branches whose head ref
+#     matches one of LOOP_BRANCH_PREFIXES (claude/, pre-launch/,
+#     chore/audit-loop-, chore/loop-) get processed. Anything else is
+#     ignored — founder-authored feature branches, dependabot, etc. are
+#     never touched. (Initially I keyed on author login, but loop work
+#     pushes from the founder's GitHub identity, so author is unreliable.)
+#   • Skips PRs with the `do-not-stale` or `pinned` label — explicit opt-out.
+#   • Reads label-applied timestamp from the issue events API, not from
+#     PR.updatedAt (which gets bumped by the label itself, defeating the
+#     48h clock).
+#   • Comments + labels via GITHUB_TOKEN — does not require a PAT.
+
+on:
+  schedule:
+    # 03:00 UTC daily — off-peak, after the 02:00 audit-remediation scout
+    # cron has finished, before the European morning when founder is most
+    # likely to be reviewing PRs.
+    - cron: "0 3 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: stale-pr-sweeper
+  cancel-in-progress: false
+
+env:
+  COMMITS_BEHIND_THRESHOLD: "100"  # PRs >N commits behind main get flagged
+  IDLE_DAYS_THRESHOLD: "7"          # PRs untouched for >N days get flagged
+  AUTO_CLOSE_HOURS: "48"            # close N hours after stale-pr label is applied
+  STALE_LABEL: "stale-pr"
+  OPT_OUT_LABELS: "do-not-stale,pinned"
+  # Comma-separated list of branch prefixes the sweeper is allowed to
+  # process. Opt-in: anything not matching is skipped.
+  LOOP_BRANCH_PREFIXES: "claude/,pre-launch/,chore/audit-loop-,chore/loop-,feat/audit-,feat/pre-launch-"
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sweep stale PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          REPO="${GITHUB_REPOSITORY}"
+          NOW_EPOCH=$(date -u +%s)
+          IDLE_SEC=$(( IDLE_DAYS_THRESHOLD * 86400 ))
+          AUTO_CLOSE_SEC=$(( AUTO_CLOSE_HOURS * 3600 ))
+
+          # Ensure the stale-pr label exists. Idempotent — if it's already
+          # there, gh exits non-zero, which we swallow.
+          gh label create "$STALE_LABEL" \
+            --repo "$REPO" \
+            --color "fbca04" \
+            --description "Branch is too far behind main; rebase or auto-close in 48h" \
+            2>/dev/null || true
+
+          # Pull every open PR. The fields we need:
+          #   number, headRefName, author, labels, updatedAt
+          mapfile -t prs < <(gh pr list \
+            --repo "$REPO" \
+            --state open \
+            --limit 200 \
+            --json number,headRefName,author,labels,updatedAt \
+            --jq '.[] | @base64')
+
+          if [ "${#prs[@]}" -eq 0 ]; then
+            echo "No open PRs."
+            exit 0
+          fi
+
+          echo "Considering ${#prs[@]} open PR(s)…"
+
+          flagged=0
+          closed=0
+          unstuck=0
+
+          for row in "${prs[@]}"; do
+            pr_json=$(echo "$row" | base64 -d)
+            num=$(echo "$pr_json" | jq -r '.number')
+            head=$(echo "$pr_json" | jq -r '.headRefName')
+            author=$(echo "$pr_json" | jq -r '.author.login')
+            updated_at=$(echo "$pr_json" | jq -r '.updatedAt')
+            labels=$(echo "$pr_json" | jq -r '.labels[].name' | tr '\n' ',' || true)
+
+            echo ""
+            echo "=== PR #$num · branch=$head · author=$author ==="
+
+            # Opt-IN by branch prefix. Authors are unreliable (loop work
+            # pushes from the founder's identity). Branch-prefix is the
+            # signal that distinguishes loop-authored PRs from
+            # human-authored feature work.
+            in_scope=0
+            IFS=',' read -ra LOOP_PREFIXES <<< "$LOOP_BRANCH_PREFIXES"
+            for prefix in "${LOOP_PREFIXES[@]}"; do
+              if [[ "$head" == "$prefix"* ]]; then
+                in_scope=1
+                break
+              fi
+            done
+            if [ "$in_scope" = "0" ]; then
+              echo "  ↪ skipping (branch prefix not in LOOP_BRANCH_PREFIXES)"
+              continue
+            fi
+
+            # Skip explicit opt-outs.
+            opt_out=0
+            IFS=',' read -ra OPT_OUT_ARR <<< "$OPT_OUT_LABELS"
+            for ol in "${OPT_OUT_ARR[@]}"; do
+              if echo ",$labels," | grep -q ",$ol,"; then
+                opt_out=1
+                break
+              fi
+            done
+            if [ "$opt_out" = "1" ]; then
+              echo "  ↪ skipping (opt-out label present)"
+              continue
+            fi
+
+            # Fetch the branch so we can compute commits-behind. If the
+            # branch was deleted post-close, skip.
+            if ! git fetch origin "$head" 2>/dev/null; then
+              echo "  ⚠ branch fetch failed — skipping"
+              continue
+            fi
+
+            commits_behind=$(git rev-list --count "FETCH_HEAD..origin/main")
+            updated_epoch=$(date -u -d "$updated_at" +%s)
+            idle_sec=$(( NOW_EPOCH - updated_epoch ))
+            idle_days=$(( idle_sec / 86400 ))
+
+            echo "  commits behind main: $commits_behind"
+            echo "  idle: ${idle_days}d ($idle_sec s)"
+
+            already_stale=0
+            if echo ",$labels," | grep -q ",$STALE_LABEL,"; then
+              already_stale=1
+            fi
+
+            is_stale=0
+            if [ "$commits_behind" -gt "$COMMITS_BEHIND_THRESHOLD" ]; then
+              is_stale=1
+              reason="$commits_behind commits behind main (threshold: $COMMITS_BEHIND_THRESHOLD)"
+            elif [ "$idle_sec" -gt "$IDLE_SEC" ]; then
+              is_stale=1
+              reason="${idle_days} days since last activity (threshold: $IDLE_DAYS_THRESHOLD)"
+            fi
+
+            if [ "$is_stale" = "0" ]; then
+              # PR is healthy — if it's currently labeled stale, the
+              # author has un-staled it (rebased or pushed). Remove the
+              # label so the 48h close clock resets.
+              if [ "$already_stale" = "1" ]; then
+                echo "  ✓ no longer stale — removing label"
+                gh pr edit "$num" --repo "$REPO" --remove-label "$STALE_LABEL" || true
+                unstuck=$(( unstuck + 1 ))
+              else
+                echo "  ✓ healthy — nothing to do"
+              fi
+              continue
+            fi
+
+            # PR is stale. Two paths: first-flag (apply label + comment),
+            # or auto-close (already labeled >$AUTO_CLOSE_HOURS ago).
+            if [ "$already_stale" = "0" ]; then
+              echo "  🟡 first-flag — applying label + comment"
+              body="🤖 **Stale-PR sweeper:** this PR is $reason. Rebase onto main + push, or close it. If neither happens in the next $AUTO_CLOSE_HOURS hours, the sweeper will auto-close it."$'\n\n'"To opt out of staleness checks, apply the \`do-not-stale\` label."
+              gh pr comment "$num" --repo "$REPO" --body "$body"
+              gh pr edit "$num" --repo "$REPO" --add-label "$STALE_LABEL"
+              flagged=$(( flagged + 1 ))
+              continue
+            fi
+
+            # Already labeled — find when. The label's "labeled" event in
+            # the issue timeline tells us the apply timestamp. We close
+            # only if that's >$AUTO_CLOSE_HOURS old AND nothing has been
+            # pushed to the branch since.
+            label_event=$(gh api "repos/$REPO/issues/$num/events" \
+              --jq "[.[] | select(.event == \"labeled\" and .label.name == \"$STALE_LABEL\")] | last")
+            if [ -z "$label_event" ] || [ "$label_event" = "null" ]; then
+              echo "  ⚠ labeled but no event found — re-labelling to reset clock"
+              gh pr edit "$num" --repo "$REPO" --remove-label "$STALE_LABEL" || true
+              gh pr edit "$num" --repo "$REPO" --add-label "$STALE_LABEL" || true
+              continue
+            fi
+
+            label_at=$(echo "$label_event" | jq -r '.created_at')
+            label_epoch=$(date -u -d "$label_at" +%s)
+            since_label=$(( NOW_EPOCH - label_epoch ))
+
+            # Branch may have moved since the label was applied (rebase /
+            # new push). git rev-list against the current head — if it's
+            # NOT $commits_behind anymore, someone is working on it.
+            head_sha=$(git rev-parse FETCH_HEAD)
+            head_committer_date=$(git show -s --format=%cI "$head_sha")
+            head_epoch=$(date -u -d "$head_committer_date" +%s)
+            if [ "$head_epoch" -gt "$label_epoch" ]; then
+              echo "  ✓ branch was pushed after label applied — not closing"
+              continue
+            fi
+
+            if [ "$since_label" -lt "$AUTO_CLOSE_SEC" ]; then
+              hrs_left=$(( (AUTO_CLOSE_SEC - since_label) / 3600 ))
+              echo "  🟡 still in grace period — ${hrs_left}h left before close"
+              continue
+            fi
+
+            echo "  🔴 auto-closing — labeled $((since_label / 3600))h ago, no activity since"
+            gh pr close "$num" --repo "$REPO" --comment "🤖 **Stale-PR sweeper:** auto-closing — this PR was flagged $((since_label / 3600))h ago and the branch has not been updated since. Reopen + rebase if you want to revive it."
+            closed=$(( closed + 1 ))
+          done
+
+          echo ""
+          echo "=== Summary ==="
+          echo "Flagged: $flagged"
+          echo "Auto-closed: $closed"
+          echo "Un-stuck (label removed): $unstuck"
+
+          # Emit a compact GitHub-actions summary line.
+          {
+            echo "## Stale-PR sweeper summary"
+            echo ""
+            echo "- Flagged: $flagged"
+            echo "- Auto-closed: $closed"
+            echo "- Un-stuck (label removed): $unstuck"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/plans/pre-launch-wave-master-prompt.md
+++ b/docs/plans/pre-launch-wave-master-prompt.md
@@ -214,8 +214,29 @@ If pre-push hook fails:
 
 ### Step 6 — Open PR
 
+**PRECONDITION — duplicate-PR guard (added 2026-05-10).** Before opening, check
+no open PR already covers this queue item. The two loops (audit-remediation +
+this one) plus manual edits all share the same repo, and 2026-05-10's cleanup
+closed nine duplicates. Search by the queue ID and the feature keyword:
+
 ```bash
-gh pr create --base main --head <branch> --title "<conventional-title>" --body "<markdown body with summary, scope, tier, test plan>"
+QUEUE_ID="<W4.NN-or-queue-N>"           # e.g. "W4.20" or "queue #14"
+FEATURE_KEY="<one stable keyword>"      # e.g. "country-rule-alerts" or "smart-recommendations"
+
+DUP=$(gh pr list --state open --search "$QUEUE_ID OR $FEATURE_KEY in:title" \
+        --json number,title,headRefName,createdAt)
+if [ "$(echo "$DUP" | jq 'length')" != "0" ]; then
+  echo "DUPLICATE — open PR(s) already cover this work:"
+  echo "$DUP" | jq .
+  # If existing PR is fresh + on track → mark this item as in-flight referencing it; STOP.
+  # If existing PR is stale (>7 days, no recent push) → rebase its branch + push there
+  # rather than opening a parallel PR. Surface to founder if approaches diverge meaningfully.
+  exit 0
+fi
+```
+
+```bash
+gh pr create --base main --head <branch> --title "<conventional-title>" --body "<markdown body with summary, scope, tier, supersedes, test plan>"
 ```
 
 PR body template:
@@ -231,6 +252,12 @@ PR body template:
 
 ## Files
 <bullet list>
+
+## Supersedes
+_None._
+<!-- or: list of #NNN this PR replaces. The auto-close-superseded workflow
+reads this section on merge and closes the named PRs with a pointer comment.
+Always include the section, even if empty, so the workflow's grep is reliable. -->
 
 ## Test plan
 - [x] vitest local: <result>
@@ -270,10 +297,25 @@ Then go to Step 1 for the next item.
 
 ### Step 10 — Update status doc
 
-Append to `docs/plans/pre-launch-wave-status.md` at end of each iter:
-- Item row → status `done` (with PR# + merge timestamp)
-- Decision log entry if any judgment call was made
-- Observation log entry for Tier C items
+**This loop is the SINGLE OWNER** of `docs/plans/pre-launch-wave-status.md`.
+Every other actor (audit-remediation loop, manual edits, founder, scout cron)
+drops their suggested updates as files in `docs/plans/queue-updates/` —
+consume that inbox here, then write the integrated update.
+
+Order of operations:
+
+1. **Drain the inbox.** List `docs/plans/queue-updates/*.md` (skip
+   `README.md`). Read each — they're free-form notes from other actors
+   suggesting status changes, decision-log entries, or cross-references.
+   You're the editor: keep what's useful, summarise, drop noise.
+2. **Write the integrated update** to `docs/plans/pre-launch-wave-status.md`:
+   - Item row → status `done` (with PR# + merge timestamp)
+   - Decision log entry if any judgment call was made
+   - Observation log entry for Tier C items
+   - Cross-references from inbox notes that landed
+3. **Delete consumed inbox files** in the same commit. The deletion is the
+   trigger that tells the inbox the update has been integrated.
+4. Commit message: `chore(plans): status doc reconcile — iter <N> + drained <K> inbox files`.
 
 ---
 

--- a/docs/plans/pre-launch-wave-status.md
+++ b/docs/plans/pre-launch-wave-status.md
@@ -1,7 +1,26 @@
 # Pre-launch wave — autonomous loop status
 
+<!--
+  ┌──────────────────────────────────────────────────────────────────┐
+  │  SINGLE-OWNER FILE                                               │
+  │  Only the pre-launch wave loop writes to this doc directly.      │
+  │  Other actors (audit-remediation loop, manual edits, the         │
+  │  founder, scout cron, etc.) MUST drop their proposed updates as  │
+  │  a new file under `docs/plans/queue-updates/` — the wave loop    │
+  │  consumes that inbox on its next iter and merges into here.      │
+  │                                                                  │
+  │  Why: 2026-05-10 saw three competing drafts (#701, #708, #714)   │
+  │  that all tried to reconcile this doc at the same time. The      │
+  │  loops have no shared lock, so concurrent edits race; the inbox  │
+  │  pattern collapses races into ordered append-then-merge.         │
+  │                                                                  │
+  │  See `docs/plans/queue-updates/README.md` for the inbox format.  │
+  └──────────────────────────────────────────────────────────────────┘
+-->
+
 **Plan source:** `docs/plans/pre-launch-wave-master-prompt.md` (Wave 1-6)
 **Loop prompt:** `docs/plans/pre-launch-wave-loop-prompt.md`
+**Update inbox:** `docs/plans/queue-updates/` (other actors drop notes here)
 **Last updated:** 2026-05-10 (cron iter — country rule alerts DB + admin CRUD shipped)
 
 ---

--- a/docs/plans/queue-updates/README.md
+++ b/docs/plans/queue-updates/README.md
@@ -1,0 +1,90 @@
+# Queue-updates inbox
+
+Drop one file per update. The pre-launch wave loop consumes this directory
+on its next iter, merges entries into `docs/plans/pre-launch-wave-status.md`,
+and deletes the consumed files.
+
+## Why this exists
+
+`pre-launch-wave-status.md` is single-owner: only the pre-launch wave loop
+writes to it directly. Two reasons that doc cannot tolerate concurrent
+writers:
+
+1. **Race conditions across loops.** The audit-remediation cloud loop, the
+   pre-launch wave loop, and manual edits all share `main` as their
+   merge target. They have no shared lock. On 2026-05-10 three competing
+   reconciliation drafts (#701, #708, #714) all tried to update this
+   doc at the same time — by the time the third was opened, the first
+   was already stale.
+
+2. **Authoritative narrative.** Status doc claims like "W4.21 ✅ done" need
+   to come from a single source. When two loops independently flip a
+   status line based on different signals (one sees the PR opened,
+   the other sees the migration applied), the diff fights itself.
+
+The fix: every other actor leaves a note here, and the wave loop is the
+single writer that integrates them in order.
+
+## File format
+
+Filename: `YYYY-MM-DD-HHMM-<source>-<short-slug>.md`. Examples:
+
+- `2026-05-10-1230-audit-loop-stream-cc-complete.md`
+- `2026-05-10-1335-manual-w420-pr1-opened.md`
+- `2026-05-10-1900-scout-newdrift-found.md`
+
+Body: free-form Markdown. The wave loop reads it as input — be specific
+about what changed and where it should land in the status doc.
+
+A typical update file:
+
+```markdown
+# Source: audit-remediation cloud loop, iter 347
+# Reaching: status doc decision log + W4.20 row
+
+The KK-04 link-injection kill-switch landed via #711. The status doc's
+W4 table currently says nothing about KK — that's the audit loop's
+domain, but if the wave loop wants a cross-reference, append to the
+decision log:
+
+> 2026-05-10 14:00 | meta | KK-04 (audit loop) shipped #711 — adds
+> link_injection feature flag + density cap. Independent of wave queue
+> but worth surfacing since the same mechanism could power the
+> recommendations strip later.
+```
+
+The wave loop is free to edit, summarise, or skip the suggestion — its
+judgment is the final filter. Sources should not assume their wording
+will land verbatim.
+
+## When to use
+
+- **Use the inbox** for: cross-loop status updates, founder one-off notes
+  during a session, scout-cron drift discoveries that aren't yet in the
+  master plan, audit-loop stream completion that wants a wave-side
+  cross-reference, anything where you want to *suggest* a status change.
+
+- **Don't use the inbox** for: scope items the wave loop already owns
+  (the wave loop's own iter just edits the doc directly), founder
+  high-priority blockers (those go in `LOOP_PAUSE` or a `BLOCKED:`
+  prefix on the status doc itself — the wave loop handles those
+  inline), or anything time-critical (the wave loop's iter cadence is
+  ~hourly; if you need an immediate update, edit and push directly
+  with a clear conventional commit explaining why you bypassed).
+
+## Cleanup
+
+The wave loop deletes consumed files in the same commit that updates
+the status doc. If you see files lingering >24h, the wave loop is
+either paused or hasn't seen them yet — fine to leave them; they'll be
+picked up next iter. If they linger >7d, surface to the founder.
+
+## Anti-patterns
+
+- ❌ Direct edits to `pre-launch-wave-status.md` from any actor other
+  than the wave loop. The wave loop's iter expects to be the source of
+  truth and will overwrite competing edits.
+- ❌ Deleting another actor's update file before the wave loop has
+  consumed it. The loop's commit is the trigger for cleanup.
+- ❌ Multi-update files with mixed sources. One file per source per
+  topic — easier to attribute, easier to redact if needed.


### PR DESCRIPTION
## Summary

Four additive fixes to prevent the duplicate-PR / stale-branch / status-doc-race waste that 2026-05-10's cleanup exposed (closed 9 stale/duplicate PRs by hand).

## Tier

A — workflow + prompt changes only, no code paths touched. Loop pause not required.

## What's in this PR

1. **Pre-flight dedup guard** in 3 loop prompts (`audit-remediation-iteration.md`, `audit-remediation-parallel.md`, `pre-launch-wave-master-prompt.md`). Loops MUST `gh pr list --search "<stream-id> in:title"` before opening a PR.
2. **Stale-PR sweeper** workflow — daily cron, two-stage flag→close, opt-in by branch prefix (only `claude/`, `pre-launch/`, `chore/audit-loop-` etc. — never founder feature branches).
3. **`## Supersedes` PR template field** + auto-close workflow. On merge, parses `## Supersedes` for `#NNN` references and closes them with a pointer comment.
4. **Single-owner header** on `pre-launch-wave-status.md` + new `docs/plans/queue-updates/` inbox where other actors drop suggested updates. Wave loop's Step 10 now drains the inbox.

## Supersedes

_None._

## Test plan

- [x] actionlint clean on both new workflows (validated locally with v1.7.7 binary)
- [x] Awk parser test suite: 7/7 synthetic PR-body shapes parse correctly (empty, _None._, list, backticks, summary-only false-positive guard, no-section legacy, HTML-comment-hash-ignored)
- [x] Branch-prefix opt-in test: all 6 stale PRs from 2026-05-10 (#603, #705, #614, #667, #648, #649) match a loop prefix; 0 founder branches in current open PR list would be touched
- [x] Dedup query test: `gh pr list --state all --search "X-09 in:title"` correctly finds the duplicate pair (#646, #648) from this morning's collision
- [ ] CI green
- [ ] Real-world: next time the audit loop fires, the iteration command's new Phase 3 dedup guard runs against the open PR set