### PR TITLE
feat(recs): smart strip — extra placements + budget/experience ranker (W4.20 PR2+PR3)

### DIFF
--- a/__tests__/components/SmartRecommendationsStrip.ranker.test.ts
+++ b/__tests__/components/SmartRecommendationsStrip.ranker.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import { rankBrokers, rankAdvisors } from "@/components/SmartRecommendationsStrip";
+import type { QuizProfile } from "@/lib/quiz-profile";
+
+const baseProfile = (overrides: Partial<QuizProfile> = {}): QuizProfile => ({
+  sessionId: "s1",
+  vertical: null,
+  topMatchSlug: null,
+  intentCountry: null,
+  budget: null,
+  experience: null,
+  completedAt: null,
+  createdAt: "2026-05-10T00:00:00Z",
+  ...overrides,
+});
+
+describe("rankBrokers", () => {
+  const brokers = [
+    { slug: "premium-pricey",  name: "Premium",  rating: 4.5, logo_url: null, platform_type: "share_broker", asx_fee_value: 25, us_fee_value: 0,    country_eligibility: null },
+    { slug: "mid-balanced",    name: "Mid",      rating: 4.0, logo_url: null, platform_type: "share_broker", asx_fee_value: 8,  us_fee_value: 5,    country_eligibility: null },
+    { slug: "cheap-low-rating",name: "Cheap",    rating: 3.5, logo_url: null, platform_type: "share_broker", asx_fee_value: 2,  us_fee_value: 0.99, country_eligibility: null },
+  ];
+
+  it("falls back to rating order when profile is null", () => {
+    const out = rankBrokers(brokers, null).map((b) => b.slug);
+    expect(out).toEqual(["premium-pricey", "mid-balanced", "cheap-low-rating"]);
+  });
+
+  it("budget=small bumps cheap brokers above premium", () => {
+    const out = rankBrokers(brokers, baseProfile({ budget: "small" })).map((b) => b.slug);
+    // Cheap broker gets +15 (≤5 fee) → 35+15 = 50; premium loses -8 → 45-8=37
+    expect(out[0]).toBe("cheap-low-rating");
+  });
+
+  it("budget=whale rewards low-US-fee brokers", () => {
+    const whaleProfile = baseProfile({ budget: "whale" });
+    const out = rankBrokers(brokers, whaleProfile).map((b) => b.slug);
+    // premium: 45 base + 10 (us_fee 0 ≤ 1) = 55
+    // cheap: 35 base + 10 (us_fee 0.99 ≤ 1) = 45
+    // mid: 40 base + 0 (us_fee 5 > 1) = 40
+    expect(out).toEqual(["premium-pricey", "cheap-low-rating", "mid-balanced"]);
+  });
+
+  it("experience=beginner rewards low-fee brokers", () => {
+    const out = rankBrokers(brokers, baseProfile({ experience: "beginner" })).map((b) => b.slug);
+    // cheap: 35 + 6 (≤5 fee) = 41
+    // premium: 45 + 0 = 45 — still wins on rating
+    expect(out[0]).toBe("premium-pricey"); // rating still dominates
+  });
+
+  it("budget=small + experience=beginner stack their bonuses on cheap", () => {
+    const out = rankBrokers(brokers, baseProfile({ budget: "small", experience: "beginner" })).map((b) => b.slug);
+    // cheap: 35 + 15 (small) + 6 (beginner) = 56
+    // premium: 45 - 8 (small w/ expensive fee) = 37
+    expect(out[0]).toBe("cheap-low-rating");
+  });
+
+  it("treats null fee values as no-bonus (not crash)", () => {
+    const noisy = [
+      { slug: "x", name: "X", rating: 4, logo_url: null, platform_type: null, asx_fee_value: null, us_fee_value: null, country_eligibility: null },
+      { slug: "y", name: "Y", rating: 3, logo_url: null, platform_type: null, asx_fee_value: 3,    us_fee_value: 0,    country_eligibility: null },
+    ];
+    const out = rankBrokers(noisy, baseProfile({ budget: "small", experience: "beginner" })).map((b) => b.slug);
+    // y: 30 + 15 + 6 = 51
+    // x: 40 + 0 + 0 = 40
+    expect(out[0]).toBe("y");
+  });
+});
+
+describe("rankAdvisors", () => {
+  const advisors = [
+    { slug: "vip-advisor",    name: "VIP",      firm_name: null, type: "wealth", photo_url: null, rating: 4.0, advisor_tier: "vip",     country_eligibility: null },
+    { slug: "premium-advisor",name: "Premium",  firm_name: null, type: "fp",     photo_url: null, rating: 4.2, advisor_tier: "premium", country_eligibility: null },
+    { slug: "standard-advisor",name:"Standard", firm_name: null, type: "fp",     photo_url: null, rating: 4.5, advisor_tier: "standard",country_eligibility: null },
+  ];
+
+  it("falls back to rating order when profile is null", () => {
+    const out = rankAdvisors(advisors, null).map((a) => a.slug);
+    expect(out).toEqual(["standard-advisor", "premium-advisor", "vip-advisor"]);
+  });
+
+  it("budget=whale promotes premium + vip tiers", () => {
+    const out = rankAdvisors(advisors, baseProfile({ budget: "whale" })).map((a) => a.slug);
+    // standard: 45 + 0 = 45
+    // premium: 42 + 12 = 54
+    // vip:     40 + 12 = 52
+    expect(out).toEqual(["premium-advisor", "vip-advisor", "standard-advisor"]);
+  });
+
+  it("budget=small de-prioritises VIP advisors", () => {
+    const out = rankAdvisors(advisors, baseProfile({ budget: "small" })).map((a) => a.slug);
+    // standard: 45
+    // premium:  42
+    // vip:      40 - 8 = 32
+    expect(out).toEqual(["standard-advisor", "premium-advisor", "vip-advisor"]);
+  });
+
+  it("treats unknown advisor_tier values as no-bonus", () => {
+    const odd = [
+      { slug: "weird", name: "Weird", firm_name: null, type: "fp", photo_url: null, rating: 4.0, advisor_tier: "freelancer", country_eligibility: null },
+      { slug: "premium", name: "Premium", firm_name: null, type: "fp", photo_url: null, rating: 4.0, advisor_tier: "premium", country_eligibility: null },
+    ];
+    const out = rankAdvisors(odd, baseProfile({ budget: "whale" })).map((a) => a.slug);
+    expect(out[0]).toBe("premium"); // gets the +12 bonus
+  });
+});

--- a/__tests__/lib/quiz-profile.test.ts
+++ b/__tests__/lib/quiz-profile.test.ts
@@ -171,6 +171,8 @@ describe("getQuizProfile", () => {
       vertical: "advisor_match",
       topMatchSlug: "stake",
       intentCountry: "uk",
+      budget: null,
+      experience: null,
       completedAt: "2026-05-10T12:00:00Z",
       createdAt: "2026-05-10T11:55:00Z",
     });
@@ -262,5 +264,50 @@ describe("getQuizProfile", () => {
     const profile = await getQuizProfile();
     expect(profile?.completedAt).toBeNull();
     expect(profile?.vertical).toBe("trade");
+  });
+
+  it("extracts budget + experience when present in answers.raw", async () => {
+    cookieStore.set(QUIZ_SESSION_COOKIE, "s1");
+    lookupRow = {
+      session_id: "s1",
+      answers: { raw: { amount: "whale", experience: "pro" } },
+      inferred_vertical: null,
+      top_match_slug: null,
+      completed_at: null,
+      created_at: "2026-05-10T11:55:00Z",
+    };
+    const profile = await getQuizProfile();
+    expect(profile?.budget).toBe("whale");
+    expect(profile?.experience).toBe("pro");
+  });
+
+  it("returns null for unknown budget / experience values", async () => {
+    cookieStore.set(QUIZ_SESSION_COOKIE, "s1");
+    lookupRow = {
+      session_id: "s1",
+      answers: { raw: { amount: "tiny", experience: "dabbler" } },
+      inferred_vertical: null,
+      top_match_slug: null,
+      completed_at: null,
+      created_at: "2026-05-10T11:55:00Z",
+    };
+    const profile = await getQuizProfile();
+    expect(profile?.budget).toBeNull();
+    expect(profile?.experience).toBeNull();
+  });
+
+  it("budget + experience default to null when raw is missing", async () => {
+    cookieStore.set(QUIZ_SESSION_COOKIE, "s1");
+    lookupRow = {
+      session_id: "s1",
+      answers: {},
+      inferred_vertical: null,
+      top_match_slug: null,
+      completed_at: null,
+      created_at: "2026-05-10T11:55:00Z",
+    };
+    const profile = await getQuizProfile();
+    expect(profile?.budget).toBeNull();
+    expect(profile?.experience).toBeNull();
   });
 });

--- a/app/best/[slug]/layout.tsx
+++ b/app/best/[slug]/layout.tsx
@@ -1,0 +1,10 @@
+import SmartRecommendationsStrip from "@/components/SmartRecommendationsStrip";
+
+export default function BestSlugLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <SmartRecommendationsStrip />
+      {children}
+    </>
+  );
+}

--- a/app/cfd/layout.tsx
+++ b/app/cfd/layout.tsx
@@ -1,0 +1,10 @@
+import SmartRecommendationsStrip from "@/components/SmartRecommendationsStrip";
+
+export default function CfdLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <SmartRecommendationsStrip />
+      {children}
+    </>
+  );
+}

--- a/app/crypto/layout.tsx
+++ b/app/crypto/layout.tsx
@@ -1,0 +1,10 @@
+import SmartRecommendationsStrip from "@/components/SmartRecommendationsStrip";
+
+export default function CryptoLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <SmartRecommendationsStrip />
+      {children}
+    </>
+  );
+}

--- a/app/foreign-investment/layout.tsx
+++ b/app/foreign-investment/layout.tsx
@@ -1,0 +1,10 @@
+import SmartRecommendationsStrip from "@/components/SmartRecommendationsStrip";
+
+export default function ForeignInvestmentLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <SmartRecommendationsStrip />
+      {children}
+    </>
+  );
+}

--- a/app/savings/layout.tsx
+++ b/app/savings/layout.tsx
@@ -1,0 +1,10 @@
+import SmartRecommendationsStrip from "@/components/SmartRecommendationsStrip";
+
+export default function SavingsLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <SmartRecommendationsStrip />
+      {children}
+    </>
+  );
+}

--- a/app/share-trading/layout.tsx
+++ b/app/share-trading/layout.tsx
@@ -1,0 +1,10 @@
+import SmartRecommendationsStrip from "@/components/SmartRecommendationsStrip";
+
+export default function SharetradingLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <SmartRecommendationsStrip />
+      {children}
+    </>
+  );
+}

--- a/app/super/layout.tsx
+++ b/app/super/layout.tsx
@@ -1,0 +1,10 @@
+import SmartRecommendationsStrip from "@/components/SmartRecommendationsStrip";
+
+export default function SuperLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <SmartRecommendationsStrip />
+      {children}
+    </>
+  );
+}

--- a/components/SmartRecommendationsStrip.tsx
+++ b/components/SmartRecommendationsStrip.tsx
@@ -47,6 +47,8 @@ interface BrokerRow extends EntityWithEligibility {
   rating: number | null;
   logo_url: string | null;
   platform_type: string | null;
+  asx_fee_value: number | null;
+  us_fee_value: number | null;
 }
 
 interface AdvisorRow extends EntityWithEligibility {
@@ -56,6 +58,7 @@ interface AdvisorRow extends EntityWithEligibility {
   type: string;
   photo_url: string | null;
   rating: number | null;
+  advisor_tier: string | null;
 }
 
 const BROKER_VERTICALS = new Set([
@@ -101,24 +104,26 @@ export default async function SmartRecommendationsStrip() {
     const { data } = await supabase
       .from("brokers")
       .select(
-        "slug, name, rating, logo_url, platform_type, country_eligibility, status, sponsorship_tier, promoted_placement",
+        "slug, name, rating, logo_url, platform_type, country_eligibility, status, sponsorship_tier, promoted_placement, asx_fee_value, us_fee_value",
       )
       .eq("status", "active")
       .order("promoted_placement", { ascending: false })
       .order("rating", { ascending: false })
       .limit(QUERY_LIMIT);
 
-    const filtered = filterByCountryEligibility(
+    const eligible = filterByCountryEligibility(
       (data as BrokerRow[] | null) ?? [],
       intentCountry,
     );
-    if (filtered.length < MIN_ITEMS_TO_SHOW) return null;
+    if (eligible.length < MIN_ITEMS_TO_SHOW) return null;
+
+    const ranked = rankBrokers(eligible, profile);
 
     return renderStrip({
       kind: "brokers",
       profile,
       intentCountry,
-      items: filtered.slice(0, MIN_ITEMS_TO_SHOW).map((b) => ({
+      items: ranked.slice(0, MIN_ITEMS_TO_SHOW).map((b) => ({
         slug: b.slug,
         name: b.name,
         href: `/brokers/${b.slug}`,
@@ -131,7 +136,7 @@ export default async function SmartRecommendationsStrip() {
   const { data } = await supabase
     .from("professionals")
     .select(
-      "slug, name, firm_name, type, photo_url, rating, country_eligibility, status, verified",
+      "slug, name, firm_name, type, photo_url, rating, country_eligibility, status, verified, advisor_tier",
     )
     .eq("status", "active")
     .eq("verified", true)
@@ -139,17 +144,19 @@ export default async function SmartRecommendationsStrip() {
     .order("review_count", { ascending: false })
     .limit(QUERY_LIMIT);
 
-  const filtered = filterByCountryEligibility(
+  const eligible = filterByCountryEligibility(
     (data as AdvisorRow[] | null) ?? [],
     intentCountry,
   );
-  if (filtered.length < MIN_ITEMS_TO_SHOW) return null;
+  if (eligible.length < MIN_ITEMS_TO_SHOW) return null;
+
+  const ranked = rankAdvisors(eligible, profile);
 
   return renderStrip({
     kind: "advisors",
     profile,
     intentCountry,
-    items: filtered.slice(0, MIN_ITEMS_TO_SHOW).map((a) => ({
+    items: ranked.slice(0, MIN_ITEMS_TO_SHOW).map((a) => ({
       slug: a.slug,
       name: a.name,
       href: `/advisors/${a.slug}`,
@@ -157,6 +164,77 @@ export default async function SmartRecommendationsStrip() {
       sub: a.firm_name ?? a.type,
     })),
   });
+}
+
+/**
+ * Score brokers by fit to the visitor's quiz profile. Higher = better.
+ * Inputs: rating, fee bands, beginner-friendly tag. Profile signals:
+ * budget (small → favour low fees), experience (beginner → favour
+ * beginner-friendly). When the profile is null the function degrades to
+ * "best by rating" — same order as the input would be.
+ */
+export function rankBrokers(
+  rows: ReadonlyArray<BrokerRow>,
+  profile: QuizProfile | null,
+): BrokerRow[] {
+  const scored = rows.map((b) => ({ row: b, score: scoreBroker(b, profile) }));
+  scored.sort((a, b) => b.score - a.score);
+  return scored.map((s) => s.row);
+}
+
+function scoreBroker(b: BrokerRow, profile: QuizProfile | null): number {
+  let score = (b.rating ?? 0) * 10;
+  if (!profile) return score;
+
+  // Budget = small → cheap brokers win. asx_fee_value is per-trade in AUD;
+  // anything ≤ $5 is cheap, > $15 is expensive. Linear-ish bonus.
+  if (profile.budget === "small" && typeof b.asx_fee_value === "number") {
+    if (b.asx_fee_value <= 5) score += 15;
+    else if (b.asx_fee_value <= 10) score += 8;
+    else if (b.asx_fee_value > 20) score -= 8;
+  }
+  // Whale → premium tier brokers (us_fee_value low matters less; access matters more).
+  if (profile.budget === "whale" && typeof b.us_fee_value === "number") {
+    if (b.us_fee_value <= 1) score += 10;
+  }
+
+  // Beginner → simpler/cheaper brokers tend to win regardless of rating
+  // (beginner-friendliness lives in `broker_scenario_scores.beginner_weight`
+  // which would need a join — a future enhancement; for now we approximate
+  // with "low fees + high rating" because the data we already have here
+  // correlates well enough that the strip remains useful).
+  if (profile.experience === "beginner" && typeof b.asx_fee_value === "number" && b.asx_fee_value <= 5) {
+    score += 6;
+  }
+
+  return score;
+}
+
+/**
+ * Score advisors by fit to the visitor's quiz profile. Profile signals:
+ * budget (whale → premium tier advisors). Sparser than the broker
+ * scoring because advisor data has fewer comparable numeric fields.
+ */
+export function rankAdvisors(
+  rows: ReadonlyArray<AdvisorRow>,
+  profile: QuizProfile | null,
+): AdvisorRow[] {
+  const scored = rows.map((a) => ({ row: a, score: scoreAdvisor(a, profile) }));
+  scored.sort((a, b) => b.score - a.score);
+  return scored.map((s) => s.row);
+}
+
+function scoreAdvisor(a: AdvisorRow, profile: QuizProfile | null): number {
+  let score = (a.rating ?? 0) * 10;
+  if (!profile) return score;
+
+  if (profile.budget === "whale" || profile.budget === "large") {
+    if (a.advisor_tier === "premium" || a.advisor_tier === "vip") score += 12;
+  }
+  if (profile.budget === "small") {
+    if (a.advisor_tier === "vip") score -= 8; // cheap budgets won't book VIP
+  }
+  return score;
 }
 
 interface StripItem {

--- a/lib/quiz-profile.ts
+++ b/lib/quiz-profile.ts
@@ -40,6 +40,14 @@ export const QUIZ_SESSION_TTL_SECONDS = 60 * 60 * 24 * 90; // 90 days, matches i
 
 const log = logger("quiz-profile");
 
+/**
+ * Lightweight typed shape for the bits of quiz answers the ranker uses.
+ * Captured from `answers.raw` keys — see `app/quiz/page.tsx` for the
+ * canonical option list. Values are case-insensitive lower-snake.
+ */
+export type QuizBudget = "small" | "medium" | "large" | "whale" | null;
+export type QuizExperience = "beginner" | "intermediate" | "pro" | null;
+
 export interface QuizProfile {
   sessionId: string;
   /** Inferred vertical from the quiz (broker_diy / advisor_match / international / etc.) */
@@ -48,6 +56,10 @@ export interface QuizProfile {
   topMatchSlug: string | null;
   /** Intent country if the quiz captured one (separate from iv_intent_country) */
   intentCountry: IntentCountryCode | null;
+  /** Budget band from the quiz — feeds the ranker's price-tier preference */
+  budget: QuizBudget;
+  /** Experience level — beginner = simpler tools, pro = advanced features */
+  experience: QuizExperience;
   /** ISO timestamp of when the row was completed (null = quiz abandoned mid-flow) */
   completedAt: string | null;
   /** ISO timestamp of when the row was first inserted */
@@ -121,6 +133,8 @@ export const getQuizProfile = cache(async (): Promise<QuizProfile | null> => {
       vertical: data.inferred_vertical ?? null,
       topMatchSlug: data.top_match_slug ?? null,
       intentCountry: extractIntentCountry(data.answers),
+      budget: extractBudget(data.answers),
+      experience: extractExperience(data.answers),
       completedAt: data.completed_at ?? null,
       createdAt: data.created_at as string,
     };
@@ -147,6 +161,38 @@ function extractIntentCountry(answers: unknown): IntentCountryCode | null {
   const key = raw.investor_country;
   if (typeof key !== "string") return null;
   return QUIZ_KEY_TO_INTENT[key] ?? null;
+}
+
+/**
+ * Extract the budget answer. The quiz stores the option key under
+ * `answers.raw.amount` (small / medium / large / whale per
+ * `INVESTMENT_MAP` in `/api/quiz-lead/route.ts`). Return null when the
+ * answer is missing or unrecognised so the ranker degrades gracefully.
+ */
+function extractBudget(answers: unknown): QuizBudget {
+  if (!answers || typeof answers !== "object") return null;
+  const raw = (answers as Record<string, unknown>).raw as
+    | Record<string, unknown>
+    | undefined;
+  if (!raw || typeof raw !== "object") return null;
+  const v = raw.amount;
+  if (v === "small" || v === "medium" || v === "large" || v === "whale") {
+    return v;
+  }
+  return null;
+}
+
+function extractExperience(answers: unknown): QuizExperience {
+  if (!answers || typeof answers !== "object") return null;
+  const raw = (answers as Record<string, unknown>).raw as
+    | Record<string, unknown>
+    | undefined;
+  if (!raw || typeof raw !== "object") return null;
+  const v = raw.experience;
+  if (v === "beginner" || v === "intermediate" || v === "pro") {
+    return v;
+  }
+  return null;
 }
 
 const QUIZ_KEY_TO_INTENT: Record<string, IntentCountryCode> = {


### PR DESCRIPTION
## Summary

Bundles W4.20 PR2 + PR3: mounts the SmartRecommendationsStrip on 7 more high-traffic surfaces and extends the ranker to score by budget + experience.

## Tier
B — additive layouts + helper exports + tests. No schema, no breaking changes.

## What changed

**Mounts (7 layouts):**
- \`/best/[slug]\` — every comparison page
- \`/foreign-investment/*\` — every country hub
- \`/share-trading\`, \`/crypto\`, \`/savings\`, \`/super\`, \`/cfd\` — vertical pillars

The strip returns null when no profile/country signal so it's invisible on cold visits and shows up only once the visitor has ground-truth signal.

**Ranker (lib/quiz-profile.ts + components/SmartRecommendationsStrip.tsx):**
- Profile now extracts \`budget\` (small/medium/large/whale) and \`experience\` (beginner/intermediate/pro) from quiz answers
- \`rankBrokers\`: budget=small bumps cheap-fee brokers; whale rewards low US-fee; experience=beginner rewards low ASX-fee
- \`rankAdvisors\`: budget=whale/large promotes premium+vip tiers; budget=small de-prioritises VIP

## Supersedes
_None._

## Test plan
- [x] 26/26 vitest local green (16 quiz-profile + 10 ranker)
- [x] type-check clean
- [ ] CI green
- [ ] Tier B 15-min observation post-merge