### PR TITLE
feat(cron): country-rule-alerts weekly digest (W4.22)

### DIFF
--- a/__tests__/api/cron-country-rule-alerts-digest.test.ts
+++ b/__tests__/api/cron-country-rule-alerts-digest.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { NextRequest } from "next/server";
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+vi.mock("@/lib/cron-auth", () => ({
+  requireCronAuth: vi.fn(() => null),
+}));
+
+const sendCalls: { to: string; subject: string }[] = [];
+const sendEmailMock = vi.fn(async (opts: { to: string; subject: string }) => {
+  sendCalls.push({ to: opts.to, subject: opts.subject });
+  return { ok: true };
+});
+vi.mock("@/lib/resend", () => ({
+  sendEmail: (opts: { to: string; subject: string; html: string }) => sendEmailMock(opts),
+}));
+
+let alertsRows: unknown[] = [];
+let subscriberRows: unknown[] = [];
+let alreadySentRows: unknown[] = [];
+const insertCalls: Record<string, unknown>[] = [];
+
+const mockFrom = vi.fn((table: string) => {
+  if (table === "country_rule_alerts") {
+    const chain = {
+      select: () => chain,
+      eq: () => chain,
+      or: () => chain,
+      order: () => chain,
+      then: (resolve: (v: unknown) => void) => Promise.resolve({ data: alertsRows, error: null }).then(resolve),
+    };
+    return chain;
+  }
+  if (table === "email_captures") {
+    const chain = {
+      select: () => chain,
+      eq: (col: string, val: unknown) => {
+        // simulate filtering: only return rows matching
+        if (col === "newsletter_opt_in" && val !== true) return { ...chain, then: (r: (v: unknown) => void) => Promise.resolve({ data: [], error: null }).then(r) };
+        return chain;
+      },
+      then: (resolve: (v: unknown) => void) => Promise.resolve({ data: subscriberRows, error: null }).then(resolve),
+    };
+    return chain;
+  }
+  if (table === "newsletter_sends") {
+    const selectChain = {
+      select: () => selectChain,
+      eq: () => selectChain,
+      then: (resolve: (v: unknown) => void) => Promise.resolve({ data: alreadySentRows, error: null }).then(resolve),
+    };
+    return {
+      select: () => selectChain,
+      insert: async (row: Record<string, unknown>) => {
+        insertCalls.push(row);
+        return { error: null };
+      },
+    };
+  }
+  throw new Error(`unexpected table: ${table}`);
+});
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+import { GET } from "@/app/api/cron/country-rule-alerts-digest/route";
+
+function makeReq(): NextRequest {
+  return {
+    headers: new Headers({ Authorization: "Bearer test" }),
+    url: "https://invest.com.au/api/cron/country-rule-alerts-digest",
+  } as unknown as NextRequest;
+}
+
+const SAMPLE_ALERT = {
+  alert_key: "uk-firb-2025",
+  country_code: "uk",
+  severity: "warning",
+  headline: "AU established-dwelling ban active until 31 March 2027",
+  body: "Foreign buyers cannot purchase established AU residential dwellings…",
+  source: "Treasury / FIRB",
+  cta_href: "/foreign-investment/united-kingdom",
+  cta_label: "UK investor guide",
+  created_at: "2026-05-08T00:00:00Z",
+  updated_at: null,
+};
+
+describe("country-rule-alerts-digest", () => {
+  beforeEach(() => {
+    vi.stubEnv("RESEND_API_KEY", "test-key");
+    sendCalls.length = 0;
+    insertCalls.length = 0;
+    alertsRows = [];
+    subscriberRows = [];
+    alreadySentRows = [];
+    sendEmailMock.mockClear();
+  });
+
+  it("returns 500 when RESEND_API_KEY is unset", async () => {
+    vi.stubEnv("RESEND_API_KEY", "");
+    const res = await GET(makeReq());
+    expect(res.status).toBe(500);
+  });
+
+  it("skips when there are no alerts in the last 7 days", async () => {
+    alertsRows = [];
+    subscriberRows = [{ email: "u@x.com", name: null }];
+    const res = await GET(makeReq());
+    const body = await res.json();
+    expect(body).toEqual({ ok: true, skipped: "no_alerts_in_window" });
+    expect(sendCalls).toHaveLength(0);
+  });
+
+  it("skips when there are alerts but no opted-in subscribers", async () => {
+    alertsRows = [SAMPLE_ALERT];
+    subscriberRows = [];
+    const res = await GET(makeReq());
+    const body = await res.json();
+    expect(body.skipped).toBe("no_subscribers");
+    expect(body.alerts).toBe(1);
+    expect(sendCalls).toHaveLength(0);
+  });
+
+  it("sends one email per recipient with the digest subject", async () => {
+    alertsRows = [SAMPLE_ALERT];
+    subscriberRows = [
+      { email: "a@x.com", name: "Alex" },
+      { email: "b@x.com", name: null },
+    ];
+    const res = await GET(makeReq());
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.sent).toBe(2);
+    expect(body.alerts).toBe(1);
+    expect(sendCalls).toHaveLength(2);
+    expect(sendCalls[0]?.subject).toMatch(/1 update/);
+  });
+
+  it("subject pluralises correctly", async () => {
+    alertsRows = [SAMPLE_ALERT, { ...SAMPLE_ALERT, alert_key: "us-fatca", country_code: "us" }];
+    subscriberRows = [{ email: "a@x.com", name: null }];
+    await GET(makeReq());
+    expect(sendCalls[0]?.subject).toMatch(/2 updates/);
+  });
+
+  it("dedupes against newsletter_sends — already-sent recipients are skipped", async () => {
+    alertsRows = [SAMPLE_ALERT];
+    subscriberRows = [
+      { email: "a@x.com", name: null },
+      { email: "b@x.com", name: null },
+    ];
+    alreadySentRows = [{ email: "a@x.com" }];
+    const res = await GET(makeReq());
+    const body = await res.json();
+    expect(body.sent).toBe(1);
+    expect(body.deduped).toBe(1);
+    expect(sendCalls.map((s) => s.to)).toEqual(["b@x.com"]);
+  });
+
+  it("inserts a newsletter_sends row for each successful send", async () => {
+    alertsRows = [SAMPLE_ALERT];
+    subscriberRows = [{ email: "a@x.com", name: "Alex" }];
+    await GET(makeReq());
+    expect(insertCalls).toHaveLength(1);
+    expect(insertCalls[0]).toMatchObject({
+      email: "a@x.com",
+      edition_date: expect.stringMatching(/^\d{4}-\d{2}-\d{2}-country-digest$/),
+    });
+  });
+});

--- a/app/api/cron/country-rule-alerts-digest/route.ts
+++ b/app/api/cron/country-rule-alerts-digest/route.ts
@@ -1,0 +1,242 @@
+/**
+ * Cron: country-rule-alerts weekly digest (W4.22, queue #15 part 4).
+ *
+ * Sends a once-a-week roundup of new + updated country regulatory
+ * alerts to the newsletter-opted-in audience.
+ *
+ * Behaviour:
+ *   - Queries `country_rule_alerts` for rows where active=true AND
+ *     (created_at >= NOW - 7d OR updated_at >= NOW - 7d).
+ *   - If zero alerts in window → skip the entire send. We don't send
+ *     empty digests; that's spam.
+ *   - Otherwise send to `email_captures` rows with
+ *     newsletter_opt_in=true AND unsubscribed=false.
+ *   - De-dup via `newsletter_sends` keyed on
+ *     edition_date='<YYYY-MM-DD>-country-digest'.
+ *
+ * Why piggyback on `newsletter_opt_in` rather than a dedicated
+ * country-digest opt-in column: this is part of the newsletter
+ * ecosystem, sends only when there's substance, and respects the
+ * existing unsubscribed flag. Adding a separate column for "yes I
+ * want country alerts but no I don't want general news" felt like
+ * over-segmentation for the size of the list — revisit when we
+ * have >5k subscribers.
+ *
+ * Tier C: cron + email + service-role writes. Wired into
+ * lib/cron-groups.ts under weekly-mon-9.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+import { requireCronAuth } from "@/lib/cron-auth";
+import { sendEmail } from "@/lib/resend";
+import { intentCountryMeta, type IntentCountryCode } from "@/lib/intent-context";
+import { escapeHtml } from "@/lib/html-escape";
+
+const log = logger("cron:country-rule-alerts-digest");
+
+export const runtime = "nodejs";
+export const maxDuration = 300;
+
+interface AlertRow {
+  alert_key: string;
+  country_code: string;
+  severity: string;
+  headline: string;
+  body: string;
+  source: string;
+  cta_href: string | null;
+  cta_label: string | null;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+interface SubscriberRow {
+  email: string;
+  name: string | null;
+}
+
+const SEVERITY_COLOUR: Record<string, string> = {
+  urgent: "#dc2626",
+  warning: "#d97706",
+  info: "#0369a1",
+};
+
+const SEVERITY_LABEL: Record<string, string> = {
+  urgent: "Urgent",
+  warning: "Heads-up",
+  info: "FYI",
+};
+
+export async function GET(req: NextRequest) {
+  const unauth = requireCronAuth(req);
+  if (unauth) return unauth;
+
+  const resendApiKey = process.env.RESEND_API_KEY;
+  if (!resendApiKey) {
+    return NextResponse.json({ error: "RESEND_API_KEY not configured" }, { status: 500 });
+  }
+
+  const supabase = createAdminClient();
+
+  const now = new Date();
+  const weekAgoIso = new Date(now.getTime() - 7 * 86400_000).toISOString();
+  const editionKey = `${now.toISOString().slice(0, 10)}-country-digest`;
+
+  // 1. Find this week's alerts.
+  const { data: alerts, error: alertsErr } = await supabase
+    .from("country_rule_alerts")
+    .select("alert_key, country_code, severity, headline, body, source, cta_href, cta_label, created_at, updated_at")
+    .eq("active", true)
+    .or(`created_at.gte.${weekAgoIso},updated_at.gte.${weekAgoIso}`)
+    .order("display_order", { ascending: false })
+    .order("created_at", { ascending: false });
+
+  if (alertsErr) {
+    log.error("country_rule_alerts fetch failed", { error: alertsErr.message });
+    return NextResponse.json({ error: "alerts_fetch_failed", detail: alertsErr.message }, { status: 500 });
+  }
+
+  if (!alerts || alerts.length === 0) {
+    log.info("no new alerts this week — skipping digest");
+    return NextResponse.json({ ok: true, skipped: "no_alerts_in_window" });
+  }
+
+  // 2. Fetch subscriber pool.
+  const { data: subscribers, error: subsErr } = await supabase
+    .from("email_captures")
+    .select("email, name")
+    .eq("newsletter_opt_in", true)
+    .eq("unsubscribed", false);
+
+  if (subsErr) {
+    log.error("email_captures fetch failed", { error: subsErr.message });
+    return NextResponse.json({ error: "subs_fetch_failed", detail: subsErr.message }, { status: 500 });
+  }
+
+  if (!subscribers || subscribers.length === 0) {
+    log.info("no opted-in subscribers");
+    return NextResponse.json({ ok: true, skipped: "no_subscribers", alerts: alerts.length });
+  }
+
+  // 3. Filter out anyone we've already sent this edition to.
+  const { data: alreadySent } = await supabase
+    .from("newsletter_sends")
+    .select("email")
+    .eq("edition_date", editionKey);
+
+  const alreadySentSet = new Set((alreadySent ?? []).map((r) => r.email));
+  const recipients = (subscribers as SubscriberRow[]).filter((s) => !alreadySentSet.has(s.email));
+
+  if (recipients.length === 0) {
+    log.info("all subscribers already received this edition");
+    return NextResponse.json({ ok: true, skipped: "all_already_sent", alerts: alerts.length });
+  }
+
+  // 4. Render HTML once — recipients all get the same digest.
+  const html = renderDigestHtml(alerts as AlertRow[], now);
+
+  const stats = { sent: 0, failed: 0, deduped: alreadySentSet.size };
+
+  for (const recipient of recipients) {
+    const result = await sendEmail({
+      to: recipient.email,
+      subject: `🌏 This week in cross-border investing — ${alerts.length} update${alerts.length === 1 ? "" : "s"}`,
+      html: personaliseHtml(html, recipient),
+    });
+
+    if (result.ok) {
+      stats.sent += 1;
+      await supabase.from("newsletter_sends").insert({
+        edition_date: editionKey,
+        email: recipient.email,
+        sent_at: now.toISOString(),
+      });
+    } else {
+      stats.failed += 1;
+      log.warn("send failed", { email: recipient.email, error: result.error });
+    }
+  }
+
+  log.info("digest sent", { ...stats, alerts: alerts.length });
+  return NextResponse.json({ ok: true, ...stats, alerts: alerts.length, edition: editionKey });
+}
+
+function renderDigestHtml(alerts: AlertRow[], now: Date): string {
+  const dateStr = now.toLocaleDateString("en-AU", { day: "numeric", month: "long", year: "numeric" });
+
+  const alertsHtml = alerts.map((a) => {
+    const meta = isKnownIntentCountry(a.country_code) ? intentCountryMeta(a.country_code) : null;
+    const flag = meta?.flag ?? "🌏";
+    const label = meta?.label ?? a.country_code.toUpperCase();
+    const severityColour = SEVERITY_COLOUR[a.severity] ?? "#475569";
+    const severityLabel = SEVERITY_LABEL[a.severity] ?? a.severity;
+    const ctaBlock = a.cta_href && a.cta_label
+      ? `<a href="https://invest.com.au${escapeHtml(a.cta_href)}" style="display: inline-block; margin-top: 8px; color: #15803d; font-size: 13px; font-weight: 600; text-decoration: none;">${escapeHtml(a.cta_label)} →</a>`
+      : "";
+
+    return `
+      <div style="border-left: 3px solid ${severityColour}; background: #f8fafc; padding: 14px 16px; margin: 0 0 14px; border-radius: 4px;">
+        <div style="font-size: 11px; font-weight: 700; color: ${severityColour}; text-transform: uppercase; letter-spacing: 0.5px; margin: 0 0 4px;">
+          ${flag} ${escapeHtml(label)} · ${severityLabel}
+        </div>
+        <div style="font-size: 15px; font-weight: 700; color: #0f172a; margin: 0 0 6px;">
+          ${escapeHtml(a.headline)}
+        </div>
+        <div style="font-size: 13px; color: #334155; line-height: 1.5; margin: 0 0 4px;">
+          ${escapeHtml(a.body)}
+        </div>
+        <div style="font-size: 11px; color: #64748b; font-style: italic; margin: 6px 0 0;">
+          Source: ${escapeHtml(a.source)}
+        </div>
+        ${ctaBlock}
+      </div>
+    `;
+  }).join("");
+
+  return `
+<!DOCTYPE html>
+<html>
+<body style="margin: 0; padding: 0; background: #f1f5f9; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;">
+  <div style="max-width: 600px; margin: 0 auto; background: #fff; padding: 32px 24px;">
+    <div style="text-align: center; margin: 0 0 24px;">
+      <div style="font-size: 12px; font-weight: 700; color: #15803d; text-transform: uppercase; letter-spacing: 1px; margin: 0 0 4px;">
+        Cross-border investing weekly
+      </div>
+      <h1 style="font-size: 22px; color: #0f172a; margin: 0;">{{GREETING}} — here's this week</h1>
+      <div style="font-size: 13px; color: #64748b; margin: 8px 0 0;">${dateStr} · ${alerts.length} regulatory update${alerts.length === 1 ? "" : "s"}</div>
+    </div>
+
+    ${alertsHtml}
+
+    <div style="text-align: center; margin: 32px 0 0; padding: 20px 0 0; border-top: 1px solid #e2e8f0;">
+      <p style="font-size: 12px; color: #64748b; line-height: 1.6; margin: 0 0 8px;">
+        You're receiving this because you opted into the invest.com.au newsletter.
+        <br>
+        General information only — not financial advice.
+      </p>
+      <p style="font-size: 12px; margin: 0;">
+        <a href="https://invest.com.au/account/email-preferences" style="color: #64748b;">Email preferences</a>
+        &nbsp;·&nbsp;
+        <a href="https://invest.com.au/unsubscribe" style="color: #64748b;">Unsubscribe</a>
+      </p>
+    </div>
+  </div>
+</body>
+</html>
+  `.trim();
+}
+
+function personaliseHtml(html: string, recipient: SubscriberRow): string {
+  const greeting = recipient.name ? `Hi ${escapeHtml(recipient.name)}` : "Hi there";
+  return html.replace("{{GREETING}}", greeting);
+}
+
+const KNOWN_INTENT_CODES = new Set<IntentCountryCode>([
+  "uk", "us", "cn", "in", "jp", "sg", "hk", "kr", "my", "nz", "ae", "sa",
+]);
+
+function isKnownIntentCountry(code: string): code is IntentCountryCode {
+  return KNOWN_INTENT_CODES.has(code as IntentCountryCode);
+}

--- a/lib/cron-groups.ts
+++ b/lib/cron-groups.ts
@@ -116,7 +116,7 @@ export const CRON_GROUPS: Record<string, readonly string[]> = {
     "/api/cron/weekly-rate-update",
     "/api/cron/personalized-digest",
   ],
-  "weekly-mon-9": ["/api/cron/fee-digest", "/api/cron/content-freshness", "/api/cron/stale-fee-editorial", "/api/cron/check-secret-rotation"],
+  "weekly-mon-9": ["/api/cron/fee-digest", "/api/cron/content-freshness", "/api/cron/stale-fee-editorial", "/api/cron/check-secret-rotation", "/api/cron/country-rule-alerts-digest"],
   "weekly-mon-11": ["/api/cron/advisor-dormant-nudge"],
 
   "monthly-1-3": ["/api/cron/property-suburb-refresh"],


### PR DESCRIPTION
## Summary

Weekly Resend cron that emails newsletter-opted-in subscribers a digest of country regulatory alerts that have been added or updated in the past 7 days. Only sends when there's substance — no empty digests.

## Tier
C — new cron + email send + service-role writes. Wired into \`weekly-mon-9\` dispatch group (Mondays 09:00 UTC).

## What changed
- \`app/api/cron/country-rule-alerts-digest/route.ts\` — handler. Scans \`country_rule_alerts\` for active rows where \`created_at\` or \`updated_at\` ≥ 7d ago. Skips entirely when zero. Otherwise sends a per-recipient HTML email with all alerts, severity-coloured borders, source attribution, and CTA links. Dedupes via \`newsletter_sends\` keyed on \`{date}-country-digest\`.
- \`lib/cron-groups.ts\` — added the new handler to \`weekly-mon-9\`.
- \`__tests__/api/cron-country-rule-alerts-digest.test.ts\` — 7 tests covering the empty-window skip, no-subscribers skip, send fan-out, subject pluralisation, dedup against newsletter_sends, insert tracking.

## Why piggyback on \`newsletter_opt_in\` (no new opt-in column)
- Sends only when there's substance → respects user time
- Existing \`unsubscribed\` flag still applies → opt-out path unchanged
- Adding a country-specific opt-in column for sub-5k subscriber list felt like over-segmentation
- Revisit when subscriber count justifies the segmentation infra

## Supersedes
_None._

## Test plan
- [x] 7/7 vitest local green
- [x] type-check clean
- [ ] CI green
- [ ] Tier C 30-min observation post-merge
- [ ] Manual: trigger the dispatch endpoint in dev with 0 alerts → expect skipped:no_alerts_in_window