### PR TITLE
feat(account): investor holdings tracker + portfolio health + brokerage coach (W2 Phase 1)

### DIFF
--- a/__tests__/lib/holdings/health-score.test.ts
+++ b/__tests__/lib/holdings/health-score.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import { computeHealthScore, type HoldingForScore } from "@/lib/holdings/health-score";
+
+const todayMinus = (days: number) => {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - days);
+  return d.toISOString().slice(0, 10);
+};
+
+const h = (overrides: Partial<HoldingForScore> = {}): HoldingForScore => ({
+  ticker: "BHP.AX",
+  exchange: "ASX",
+  shares: 100,
+  costBasisPerShareCents: 4500_00,
+  acquiredAt: todayMinus(180),
+  ...overrides,
+});
+
+describe("computeHealthScore", () => {
+  it("returns the empty-portfolio response when no holdings", () => {
+    const r = computeHealthScore([]);
+    expect(r.overallScore).toBe(0);
+    expect(r.callouts[0]).toMatch(/Add some holdings/);
+  });
+
+  it("flags single-position concentration", () => {
+    const r = computeHealthScore([h({ ticker: "ALL-IN", shares: 1000 })]);
+    expect(r.callouts.some((c) => /largest position/.test(c))).toBe(true);
+    expect(r.diversificationScore).toBeLessThan(50);
+  });
+
+  it("scores a 10-position evenly-weighted portfolio higher than a top-heavy one", () => {
+    const even: HoldingForScore[] = Array.from({ length: 10 }, (_, i) =>
+      h({ ticker: `T${i}`, shares: 100, costBasisPerShareCents: 1000_00, acquiredAt: todayMinus(30 + i * 30) }),
+    );
+    const heavy: HoldingForScore[] = [
+      h({ ticker: "BIG", shares: 9000, costBasisPerShareCents: 1000_00 }),
+      ...Array.from({ length: 9 }, (_, i) => h({ ticker: `T${i}`, shares: 1, costBasisPerShareCents: 1000_00 })),
+    ];
+    expect(computeHealthScore(even).diversificationScore).toBeGreaterThan(
+      computeHealthScore(heavy).diversificationScore,
+    );
+  });
+
+  it("flags 100% AU concentration", () => {
+    const r = computeHealthScore([
+      h({ ticker: "BHP.AX", exchange: "ASX" }),
+      h({ ticker: "CBA.AX", exchange: "ASX" }),
+      h({ ticker: "WBC.AX", exchange: "ASX" }),
+    ]);
+    expect(r.callouts.some((c) => /Every holding is AU-listed/.test(c))).toBe(true);
+  });
+
+  it("flags 0% AU when only international names", () => {
+    const r = computeHealthScore([
+      h({ ticker: "AAPL", exchange: "NASDAQ" }),
+      h({ ticker: "MSFT", exchange: "NASDAQ" }),
+    ]);
+    expect(r.callouts.some((c) => /No AU-listed/.test(c))).toBe(true);
+  });
+
+  it("rewards a balanced AU/global mix with a high exchangeSpreadScore", () => {
+    const balanced = computeHealthScore([
+      h({ ticker: "BHP.AX", shares: 100, exchange: "ASX" }),
+      h({ ticker: "AAPL", shares: 100, exchange: "NASDAQ", costBasisPerShareCents: 4500_00 }),
+    ]);
+    const auOnly = computeHealthScore([
+      h({ ticker: "BHP.AX", exchange: "ASX" }),
+    ]);
+    expect(balanced.exchangeSpreadScore).toBeGreaterThan(auOnly.exchangeSpreadScore);
+  });
+
+  it("rewards holdings spread across acquired_at dates over recent-only", () => {
+    const spread = computeHealthScore(
+      [10, 90, 200, 365].map((d, i) =>
+        h({ ticker: `T${i}`, acquiredAt: todayMinus(d) }),
+      ),
+    );
+    const allRecent = computeHealthScore(
+      [1, 2, 3, 4].map((d, i) => h({ ticker: `T${i}`, acquiredAt: todayMinus(d) })),
+    );
+    expect(spread.ageDiversityScore).toBeGreaterThan(allRecent.ageDiversityScore);
+  });
+
+  it("flags fewer-than-3-positions portfolios", () => {
+    const r = computeHealthScore([h(), h({ ticker: "BHP2" })]);
+    expect(r.callouts.some((c) => /Only 2 positions/.test(c))).toBe(true);
+  });
+
+  it("clamps overall score between 0 and 100", () => {
+    const r = computeHealthScore([h()]);
+    expect(r.overallScore).toBeGreaterThanOrEqual(0);
+    expect(r.overallScore).toBeLessThanOrEqual(100);
+  });
+});

--- a/__tests__/lib/holdings/switching-coach.test.ts
+++ b/__tests__/lib/holdings/switching-coach.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { buildSwitchingCoach, type BrokerForCoach } from "@/lib/holdings/switching-coach";
+
+const brokers: BrokerForCoach[] = [
+  { slug: "stake", name: "Stake", asx_fee_value: 3 },
+  { slug: "selfwealth", name: "SelfWealth", asx_fee_value: 9.5 },
+  { slug: "commsec", name: "CommSec", asx_fee_value: 19.95 },
+  { slug: "no-fee-listed", name: "NoFee", asx_fee_value: null }, // ignored
+];
+
+describe("buildSwitchingCoach", () => {
+  it("returns a tag-prompt when the user hasn't tagged any broker", () => {
+    const r = buildSwitchingCoach({ currentBrokerSlugs: [], tradesPerYear: 20, brokers });
+    expect(r.currentBroker).toBeNull();
+    expect(r.summary).toMatch(/Tag a broker/);
+  });
+
+  it("returns frequency-prompt when tradesPerYear is 0", () => {
+    const r = buildSwitchingCoach({ currentBrokerSlugs: ["commsec"], tradesPerYear: 0, brokers });
+    expect(r.summary).toMatch(/trade frequency/);
+  });
+
+  it("computes saving when current broker is more expensive than cheapest", () => {
+    const r = buildSwitchingCoach({ currentBrokerSlugs: ["commsec"], tradesPerYear: 20, brokers });
+    expect(r.currentBroker?.slug).toBe("commsec");
+    expect(r.cheapest?.slug).toBe("stake");
+    // commsec: $19.95 × 20 = $399 = 39900 cents
+    expect(r.currentBroker?.estCostCents).toBe(39900);
+    // stake: $3 × 20 = $60 = 6000 cents
+    expect(r.cheapest?.estCostCents).toBe(6000);
+    expect(r.estSavingCents).toBe(33900);
+    expect(r.summary).toMatch(/saving ~/);
+  });
+
+  it("returns 0 saving when current broker is already the cheapest", () => {
+    const r = buildSwitchingCoach({ currentBrokerSlugs: ["stake"], tradesPerYear: 20, brokers });
+    expect(r.estSavingCents).toBe(0);
+    expect(r.summary).toMatch(/lowest-fee match/);
+  });
+
+  it("ignores brokers without a usable asx_fee_value", () => {
+    const r = buildSwitchingCoach({ currentBrokerSlugs: ["no-fee-listed"], tradesPerYear: 10, brokers });
+    expect(r.currentBroker).toBeNull(); // user's tagged broker has null fee → not in the eligible set
+  });
+
+  it("uses the cheapest of multiple tagged current brokers (generous comparison)", () => {
+    // User holds stuff at both selfwealth and commsec; we compare against
+    // their cheapest (selfwealth) so the saving is not artificially inflated.
+    const r = buildSwitchingCoach({ currentBrokerSlugs: ["commsec","selfwealth"], tradesPerYear: 50, brokers });
+    expect(r.currentBroker?.slug).toBe("selfwealth");
+    expect(r.cheapest?.slug).toBe("stake");
+  });
+});

--- a/app/account/holdings/HoldingsClient.tsx
+++ b/app/account/holdings/HoldingsClient.tsx
@@ -1,0 +1,376 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { computeHealthScore } from "@/lib/holdings/health-score";
+import {
+  buildSwitchingCoach,
+  type BrokerForCoach,
+} from "@/lib/holdings/switching-coach";
+
+export interface HoldingRow {
+  id: number;
+  ticker: string;
+  exchange: string;
+  shares: number;
+  costBasisPerShareCents: number;
+  acquiredAt: string;
+  brokerSlug: string | null;
+  notes: string | null;
+}
+
+interface Props {
+  initialItems: HoldingRow[];
+  brokers: BrokerForCoach[];
+}
+
+const TRADE_FREQ_OPTIONS = [
+  { key: "rare", label: "I rarely trade", trades: 4 },
+  { key: "few",  label: "Few times a year", trades: 12 },
+  { key: "monthly", label: "Monthly", trades: 24 },
+  { key: "weekly",  label: "Weekly+", trades: 60 },
+] as const;
+
+const EXCHANGES = ["ASX","NASDAQ","NYSE","LSE","HKEX","SGX","TYO","KRX","CRYPTO","OTHER"] as const;
+
+const fmtCents = (cents: number) =>
+  (cents / 100).toLocaleString("en-AU", { style: "currency", currency: "AUD" });
+
+const fmtShares = (n: number) =>
+  n.toLocaleString("en-AU", { maximumFractionDigits: 4 });
+
+export default function HoldingsClient({ initialItems, brokers }: Props) {
+  const [items, setItems] = useState<HoldingRow[]>(initialItems);
+  const [adding, setAdding] = useState(false);
+  const [deletingId, setDeletingId] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [tradeFreqKey, setTradeFreqKey] = useState<string>("few");
+
+  const totals = useMemo(() => {
+    const totalCostCents = items.reduce(
+      (sum, h) => sum + h.shares * h.costBasisPerShareCents,
+      0,
+    );
+    const positionCount = items.length;
+    return { totalCostCents, positionCount };
+  }, [items]);
+
+  const score = useMemo(
+    () =>
+      computeHealthScore(
+        items.map((i) => ({
+          ticker: i.ticker,
+          exchange: i.exchange,
+          shares: i.shares,
+          costBasisPerShareCents: i.costBasisPerShareCents,
+          acquiredAt: i.acquiredAt,
+        })),
+      ),
+    [items],
+  );
+
+  const coach = useMemo(() => {
+    const tradesPerYear =
+      TRADE_FREQ_OPTIONS.find((o) => o.key === tradeFreqKey)?.trades ?? 12;
+    const tagged = Array.from(
+      new Set(
+        items
+          .map((i) => i.brokerSlug?.trim().toLowerCase())
+          .filter((s): s is string => Boolean(s)),
+      ),
+    );
+    return buildSwitchingCoach({
+      currentBrokerSlugs: tagged,
+      tradesPerYear,
+      brokers,
+    });
+  }, [items, brokers, tradeFreqKey]);
+
+  const handleAdd = async (form: FormData) => {
+    setError(null);
+    setAdding(true);
+    const body = {
+      ticker: String(form.get("ticker") ?? "").trim().toUpperCase(),
+      exchange: String(form.get("exchange") ?? ""),
+      shares: Number(form.get("shares") ?? 0),
+      cost_basis_per_share_cents: Math.round(Number(form.get("costPerShare") ?? 0) * 100),
+      acquired_at: String(form.get("acquired") ?? ""),
+      broker_slug: (String(form.get("broker") ?? "").trim() || null),
+      notes: (String(form.get("notes") ?? "").trim() || null),
+    };
+    try {
+      const res = await fetch("/api/account/holdings", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const j = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(j.error ?? "add_failed");
+      }
+      const j = (await res.json()) as { item: { id: number; ticker: string; exchange: string; shares: string; cost_basis_per_share_cents: string; acquired_at: string; broker_slug: string | null; notes: string | null } };
+      const newRow: HoldingRow = {
+        id: j.item.id,
+        ticker: j.item.ticker,
+        exchange: j.item.exchange,
+        shares: Number(j.item.shares),
+        costBasisPerShareCents: Number(j.item.cost_basis_per_share_cents),
+        acquiredAt: j.item.acquired_at,
+        brokerSlug: j.item.broker_slug,
+        notes: j.item.notes,
+      };
+      setItems((prev) => [newRow, ...prev]);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not add holding.");
+    } finally {
+      setAdding(false);
+    }
+  };
+
+  const handleDelete = async (id: number) => {
+    setError(null);
+    const snapshot = items;
+    setDeletingId(id);
+    setItems((prev) => prev.filter((h) => h.id !== id));
+    try {
+      const res = await fetch("/api/account/holdings", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id }),
+      });
+      if (!res.ok) throw new Error("delete_failed");
+    } catch {
+      setItems(snapshot);
+      setError("Could not delete holding. Try again.");
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Health score block — comparison-driven, not advice. */}
+      {items.length > 0 && (
+        <section className="bg-emerald-50 border border-emerald-200 rounded-xl p-4">
+          <div className="flex items-baseline justify-between gap-3 flex-wrap mb-3">
+            <h2 className="text-base font-semibold text-emerald-900">
+              Portfolio health: {score.overallScore}/100
+            </h2>
+            <p className="text-xs text-emerald-800/80">
+              Comparison-only. General information — not financial advice.
+            </p>
+          </div>
+          <div className="grid grid-cols-3 gap-2 text-center mb-3">
+            <ScorePill label="Diversification" score={score.diversificationScore} />
+            <ScorePill label="Exchange spread" score={score.exchangeSpreadScore} />
+            <ScorePill label="Age diversity" score={score.ageDiversityScore} />
+          </div>
+          {score.callouts.length > 0 && (
+            <ul className="space-y-1.5 text-sm text-emerald-900/90">
+              {score.callouts.map((c, i) => (
+                <li key={i} className="flex gap-2">
+                  <span aria-hidden>•</span>
+                  <span>{c}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+      )}
+
+      {/* Switching coach — comparison vs cheapest eligible broker. */}
+      {items.length > 0 && (
+        <section className="bg-amber-50 border border-amber-200 rounded-xl p-4">
+          <div className="flex items-baseline justify-between gap-3 flex-wrap mb-2">
+            <h2 className="text-base font-semibold text-amber-900">Brokerage coach</h2>
+            <label className="text-xs text-amber-900">
+              Trade frequency:{" "}
+              <select
+                value={tradeFreqKey}
+                onChange={(e) => setTradeFreqKey(e.target.value)}
+                className="border border-amber-300 rounded px-2 py-1 text-xs bg-white"
+              >
+                {TRADE_FREQ_OPTIONS.map((o) => (
+                  <option key={o.key} value={o.key}>{o.label}</option>
+                ))}
+              </select>
+            </label>
+          </div>
+          <p className="text-sm text-amber-900/90">{coach.summary}</p>
+          {coach.estSavingCents > 0 && (
+            <a
+              href="/best/share-trading"
+              className="inline-block mt-3 text-sm font-semibold text-amber-900 underline underline-offset-2"
+            >
+              Compare brokers →
+            </a>
+          )}
+        </section>
+      )}
+
+      {/* Totals strip */}
+      <section className="grid grid-cols-2 gap-3">
+        <div className="bg-slate-50 border border-slate-200 rounded-xl p-4">
+          <p className="text-xs font-semibold uppercase tracking-wider text-slate-500">Positions</p>
+          <p className="text-2xl font-bold text-slate-900 mt-1">{totals.positionCount}</p>
+        </div>
+        <div className="bg-emerald-50 border border-emerald-200 rounded-xl p-4">
+          <p className="text-xs font-semibold uppercase tracking-wider text-emerald-700">Total cost basis</p>
+          <p className="text-2xl font-bold text-emerald-900 mt-1">{fmtCents(totals.totalCostCents)}</p>
+          <p className="text-xs text-emerald-700 mt-1">Sum of shares × cost/share. Current value lookup ships in PR-X5c iter 2.</p>
+        </div>
+      </section>
+
+      {/* Add form */}
+      <section className="bg-white border border-slate-200 rounded-xl p-4">
+        <h2 className="text-base font-semibold text-slate-900 mb-3">Add holding</h2>
+        <form
+          className="grid grid-cols-1 sm:grid-cols-6 gap-3"
+          onSubmit={(e) => {
+            e.preventDefault();
+            const fd = new FormData(e.currentTarget);
+            void handleAdd(fd);
+            e.currentTarget.reset();
+          }}
+        >
+          <label className="sm:col-span-2">
+            <span className="block text-xs font-medium text-slate-700 mb-1">Ticker</span>
+            <input
+              type="text"
+              name="ticker"
+              required
+              maxLength={30}
+              placeholder="BHP.AX"
+              className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm"
+            />
+          </label>
+          <label>
+            <span className="block text-xs font-medium text-slate-700 mb-1">Exchange</span>
+            <select name="exchange" defaultValue="ASX" className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm">
+              {EXCHANGES.map((e) => <option key={e} value={e}>{e}</option>)}
+            </select>
+          </label>
+          <label>
+            <span className="block text-xs font-medium text-slate-700 mb-1">Shares</span>
+            <input
+              type="number"
+              name="shares"
+              required
+              min="0"
+              step="any"
+              className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm"
+            />
+          </label>
+          <label>
+            <span className="block text-xs font-medium text-slate-700 mb-1">Cost / share (AUD)</span>
+            <input
+              type="number"
+              name="costPerShare"
+              required
+              min="0"
+              step="0.01"
+              className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm"
+            />
+          </label>
+          <label>
+            <span className="block text-xs font-medium text-slate-700 mb-1">Acquired</span>
+            <input
+              type="date"
+              name="acquired"
+              required
+              className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm"
+            />
+          </label>
+          <label className="sm:col-span-3">
+            <span className="block text-xs font-medium text-slate-700 mb-1">Broker (optional)</span>
+            <input
+              type="text"
+              name="broker"
+              maxLength={100}
+              placeholder="e.g. CommSec"
+              className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm"
+            />
+          </label>
+          <label className="sm:col-span-3">
+            <span className="block text-xs font-medium text-slate-700 mb-1">Notes (optional)</span>
+            <input
+              type="text"
+              name="notes"
+              maxLength={500}
+              className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm"
+            />
+          </label>
+          <div className="sm:col-span-6 flex justify-end">
+            <button
+              type="submit"
+              disabled={adding}
+              className="px-4 py-2 bg-emerald-700 hover:bg-emerald-800 text-white text-sm font-medium rounded-lg disabled:opacity-50"
+            >
+              {adding ? "Adding…" : "Add holding"}
+            </button>
+          </div>
+        </form>
+        {error && (
+          <p className="text-sm text-red-700 mt-2" role="alert">
+            {error}
+          </p>
+        )}
+      </section>
+
+      {/* List */}
+      <section>
+        <h2 className="text-base font-semibold text-slate-900 mb-3">Your holdings</h2>
+        {items.length === 0 ? (
+          <p className="text-sm text-slate-500 italic">No holdings yet — add your first above.</p>
+        ) : (
+          <ul className="divide-y divide-slate-200 border border-slate-200 rounded-xl">
+            {items.map((h) => (
+              <li key={h.id} className="px-4 py-3 flex items-start justify-between gap-3">
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <span className="font-semibold text-slate-900">{h.ticker}</span>
+                    <span className="text-xs px-2 py-0.5 bg-slate-100 text-slate-600 rounded">{h.exchange}</span>
+                    {h.brokerSlug && (
+                      <span className="text-xs text-slate-500">via {h.brokerSlug}</span>
+                    )}
+                  </div>
+                  <div className="text-sm text-slate-600 mt-1">
+                    {fmtShares(h.shares)} shares · {fmtCents(h.costBasisPerShareCents)}/share · acquired {h.acquiredAt}
+                  </div>
+                  {h.notes && (
+                    <p className="text-xs text-slate-500 italic mt-1 truncate">{h.notes}</p>
+                  )}
+                </div>
+                <div className="text-right shrink-0">
+                  <div className="text-sm font-semibold text-slate-900">
+                    {fmtCents(h.shares * h.costBasisPerShareCents)}
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => void handleDelete(h.id)}
+                    disabled={deletingId === h.id}
+                    className="text-xs text-red-700 hover:text-red-900 mt-1 disabled:opacity-50"
+                  >
+                    {deletingId === h.id ? "Removing…" : "Remove"}
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function ScorePill({ label, score }: { label: string; score: number }) {
+  const tone =
+    score >= 70 ? "bg-emerald-100 text-emerald-900 border-emerald-300"
+    : score >= 40 ? "bg-amber-100 text-amber-900 border-amber-300"
+    : "bg-red-100 text-red-900 border-red-300";
+  return (
+    <div className={`border rounded-lg px-2 py-2 ${tone}`}>
+      <p className="text-[10px] font-semibold uppercase tracking-wider opacity-80">{label}</p>
+      <p className="text-xl font-bold">{score}</p>
+    </div>
+  );
+}

--- a/app/account/holdings/page.tsx
+++ b/app/account/holdings/page.tsx
@@ -1,0 +1,68 @@
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import HoldingsClient, { type HoldingRow } from "./HoldingsClient";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Holdings — My Account",
+  robots: "noindex, nofollow",
+};
+
+export default async function HoldingsPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/account/login?redirect=/account/holdings");
+  }
+
+  // Fetch holdings + the broker fee table in parallel — the latter feeds
+  // the switching coach (asx_fee_value is the comparison axis).
+  const [{ data: holdings }, { data: brokers }] = await Promise.all([
+    supabase
+      .from("investor_holdings")
+      .select(
+        "id, ticker, exchange, shares, cost_basis_per_share_cents, acquired_at, broker_slug, notes",
+      )
+      .order("acquired_at", { ascending: false }),
+    supabase
+      .from("brokers")
+      .select("slug, name, asx_fee_value")
+      .eq("status", "active"),
+  ]);
+
+  const initialItems: HoldingRow[] = (holdings ?? []).map((r) => ({
+    id: r.id as number,
+    ticker: r.ticker,
+    exchange: r.exchange,
+    shares: Number(r.shares),
+    costBasisPerShareCents: Number(r.cost_basis_per_share_cents),
+    acquiredAt: r.acquired_at,
+    brokerSlug: r.broker_slug,
+    notes: r.notes,
+  }));
+
+  const brokerOptions = (brokers ?? []).map((b) => ({
+    slug: b.slug as string,
+    name: b.name as string,
+    asx_fee_value: typeof b.asx_fee_value === "number" ? b.asx_fee_value : null,
+  }));
+
+  return (
+    <main className="max-w-4xl mx-auto px-4 sm:px-6 py-8">
+      <header className="mb-6">
+        <h1 className="text-2xl font-bold text-slate-900">Holdings</h1>
+        <p className="text-sm text-slate-600 mt-1">
+          Track what you own across brokers in one place. Manual entry only —
+          general information, not financial advice. See your accountant for tax
+          treatment.
+        </p>
+      </header>
+      <HoldingsClient initialItems={initialItems} brokers={brokerOptions} />
+    </main>
+  );
+}

--- a/app/api/account/holdings/route.ts
+++ b/app/api/account/holdings/route.ts
@@ -1,0 +1,133 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { createClient } from "@/lib/supabase/server";
+import { withValidatedBody } from "@/lib/validation/withValidatedBody";
+import { logger } from "@/lib/logger";
+
+const log = logger("api:account:holdings");
+
+export const runtime = "nodejs";
+
+/**
+ * /api/account/holdings — investor manual-holdings CRUD.
+ *
+ *   GET    — authenticated user's holdings (RLS scopes to own rows)
+ *   POST   — add a holding
+ *   PATCH  — update a holding (id required)
+ *   DELETE — remove a holding (id required)
+ *
+ * RLS does the heavy lifting (deny-all anonymous; user reads/writes own
+ * rows only). The handler still uses the user-scoped supabase client so
+ * the policies fire, never service-role.
+ */
+
+const EXCHANGES = ["ASX","NASDAQ","NYSE","LSE","HKEX","SGX","TYO","KRX","CRYPTO","OTHER"] as const;
+
+const AddHoldingBody = z.object({
+  ticker: z.string().min(1).max(30),
+  exchange: z.enum(EXCHANGES),
+  shares: z.coerce.number().positive().max(1e12),
+  cost_basis_per_share_cents: z.coerce.number().int().min(0).max(1e15),
+  acquired_at: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "YYYY-MM-DD required"),
+  broker_slug: z.string().max(100).nullish(),
+  notes: z.string().max(500).nullish(),
+});
+
+const UpdateHoldingBody = AddHoldingBody.partial().extend({
+  id: z.coerce.number().int().positive(),
+});
+
+const RemoveHoldingBody = z.object({
+  id: z.coerce.number().int().positive(),
+});
+
+export async function GET() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+
+  const { data, error } = await supabase
+    .from("investor_holdings")
+    .select("id, ticker, exchange, shares, cost_basis_per_share_cents, acquired_at, broker_slug, notes, created_at, updated_at")
+    .order("acquired_at", { ascending: false });
+
+  if (error) {
+    log.warn("holdings fetch failed", { error: error.message });
+    return NextResponse.json({ error: "fetch_failed" }, { status: 500 });
+  }
+  return NextResponse.json({ items: data ?? [] });
+}
+
+export const POST = withValidatedBody(AddHoldingBody, async (req, body) => {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+
+  const { data, error } = await supabase
+    .from("investor_holdings")
+    .insert({
+      auth_user_id: user.id,
+      ticker: body.ticker.trim().toUpperCase(),
+      exchange: body.exchange,
+      shares: body.shares,
+      cost_basis_per_share_cents: body.cost_basis_per_share_cents,
+      acquired_at: body.acquired_at,
+      broker_slug: body.broker_slug ?? null,
+      notes: body.notes ?? null,
+    })
+    .select("id, ticker, exchange, shares, cost_basis_per_share_cents, acquired_at, broker_slug, notes, created_at, updated_at")
+    .single();
+
+  if (error) {
+    log.warn("holdings insert failed", { error: error.message });
+    return NextResponse.json({ error: "insert_failed", detail: error.message }, { status: 500 });
+  }
+  return NextResponse.json({ item: data }, { status: 201 });
+});
+
+export const PATCH = withValidatedBody(UpdateHoldingBody, async (req, body) => {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+
+  const { id, ...rest } = body;
+  // Prepare clean update payload; drop undefined fields so PATCH is true-partial.
+  const update: Record<string, unknown> = { updated_at: new Date().toISOString() };
+  if (rest.ticker !== undefined) update.ticker = rest.ticker.trim().toUpperCase();
+  if (rest.exchange !== undefined) update.exchange = rest.exchange;
+  if (rest.shares !== undefined) update.shares = rest.shares;
+  if (rest.cost_basis_per_share_cents !== undefined) update.cost_basis_per_share_cents = rest.cost_basis_per_share_cents;
+  if (rest.acquired_at !== undefined) update.acquired_at = rest.acquired_at;
+  if (rest.broker_slug !== undefined) update.broker_slug = rest.broker_slug;
+  if (rest.notes !== undefined) update.notes = rest.notes;
+
+  const { data, error } = await supabase
+    .from("investor_holdings")
+    .update(update)
+    .eq("id", id)
+    .select("id, ticker, exchange, shares, cost_basis_per_share_cents, acquired_at, broker_slug, notes, created_at, updated_at")
+    .single();
+
+  if (error) {
+    log.warn("holdings update failed", { error: error.message });
+    return NextResponse.json({ error: "update_failed", detail: error.message }, { status: 500 });
+  }
+  return NextResponse.json({ item: data });
+});
+
+export const DELETE = withValidatedBody(RemoveHoldingBody, async (req, body) => {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+
+  const { error } = await supabase
+    .from("investor_holdings")
+    .delete()
+    .eq("id", body.id);
+
+  if (error) {
+    log.warn("holdings delete failed", { error: error.message });
+    return NextResponse.json({ error: "delete_failed" }, { status: 500 });
+  }
+  return NextResponse.json({ ok: true });
+});

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -7463,6 +7463,48 @@ export type Database = {
         }
         Relationships: []
       }
+      investor_holdings: {
+        Row: {
+          acquired_at: string
+          auth_user_id: string
+          broker_slug: string | null
+          cost_basis_per_share_cents: number
+          created_at: string
+          exchange: string
+          id: number
+          notes: string | null
+          shares: number
+          ticker: string
+          updated_at: string
+        }
+        Insert: {
+          acquired_at: string
+          auth_user_id: string
+          broker_slug?: string | null
+          cost_basis_per_share_cents: number
+          created_at?: string
+          exchange: string
+          id?: never
+          notes?: string | null
+          shares: number
+          ticker: string
+          updated_at?: string
+        }
+        Update: {
+          acquired_at?: string
+          auth_user_id?: string
+          broker_slug?: string | null
+          cost_basis_per_share_cents?: number
+          created_at?: string
+          exchange?: string
+          id?: never
+          notes?: string | null
+          shares?: number
+          ticker?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
       investor_journey_touchpoints: {
         Row: {
           active: boolean | null

--- a/lib/holdings/health-score.ts
+++ b/lib/holdings/health-score.ts
@@ -1,0 +1,143 @@
+/**
+ * Portfolio health score (PR-X5d).
+ *
+ * Pure function. Inputs: an investor's holdings as stored in
+ * `investor_holdings` (cost basis only — current value lookup is a
+ * separate concern, see lib/holdings/value.ts when it ships). Outputs:
+ * three sub-scores 0–100 + an overall score + a list of plain-English
+ * callouts the UI can render.
+ *
+ * What the score means:
+ *   - "diversification": penalises single-position concentration + few
+ *     positions overall. A 10-position evenly-weighted portfolio scores
+ *     higher than a 30-position with one 60% concentration.
+ *   - "exchangeSpread": penalises 100% AU concentration. Some exposure
+ *     to US / global is a *factual* risk-management signal — not advice
+ *     to act, but a comparison-driven observation.
+ *   - "ageDiversity": penalises everything-bought-this-month patterns
+ *     (a possible market-timing signal). Older average holding age =
+ *     dollar-cost-averaged or held through a cycle.
+ *
+ * Compliance: this is a comparison-and-observation score, not advice.
+ * The callouts are factual ("80% of cost basis is in one position")
+ * and contain no recommendations to act. UI must surface the
+ * "general information only — see your accountant" disclaimer.
+ */
+
+export interface HoldingForScore {
+  ticker: string;
+  exchange: string;
+  shares: number;
+  costBasisPerShareCents: number;
+  acquiredAt: string; // YYYY-MM-DD
+}
+
+export interface HealthScore {
+  diversificationScore: number;
+  exchangeSpreadScore: number;
+  ageDiversityScore: number;
+  overallScore: number;
+  callouts: string[];
+}
+
+const AU_EXCHANGES = new Set(["ASX"]);
+// Treat HKEX/SGX/TYO/KRX/LSE as "international", same bucket as US.
+// CRYPTO + OTHER also count as non-AU exposure.
+
+export function computeHealthScore(holdings: ReadonlyArray<HoldingForScore>): HealthScore {
+  if (holdings.length === 0) {
+    return {
+      diversificationScore: 0,
+      exchangeSpreadScore: 0,
+      ageDiversityScore: 0,
+      overallScore: 0,
+      callouts: ["Add some holdings to see your portfolio's diversification score."],
+    };
+  }
+
+  const positionValues = holdings.map((h) => ({
+    h,
+    cents: h.shares * h.costBasisPerShareCents,
+  }));
+  const totalCents = positionValues.reduce((s, p) => s + p.cents, 0) || 1;
+
+  // ── Diversification: position count + max concentration ───────────────
+  const sortedDesc = [...positionValues].sort((a, b) => b.cents - a.cents);
+  const top1Share = sortedDesc[0]!.cents / totalCents;
+  const top3Share = sortedDesc.slice(0, 3).reduce((s, p) => s + p.cents, 0) / totalCents;
+
+  const positionCountScore = Math.min(holdings.length / 10, 1) * 100; // 10+ positions = full marks
+  const concentrationPenalty = top1Share > 0.5
+    ? (top1Share - 0.5) * 200 // 50% → 0; 80% → 60-point penalty
+    : 0;
+  const diversificationScore = clamp(positionCountScore - concentrationPenalty);
+
+  // ── Exchange spread: AU vs non-AU ─────────────────────────────────────
+  const auCents = positionValues
+    .filter((p) => AU_EXCHANGES.has(p.h.exchange))
+    .reduce((s, p) => s + p.cents, 0);
+  const auShare = auCents / totalCents;
+  // Sweet spot 30–80% AU. Very low (no AU) and very high (all AU) both penalised.
+  const exchangeSpreadScore = clamp(100 - Math.max(0, Math.abs(auShare - 0.55) - 0.25) * 200);
+
+  // ── Age diversity: stdev of acquired-at days ago ──────────────────────
+  const today = new Date();
+  const days = positionValues.map((p) => Math.max(0, daysBetween(today, p.h.acquiredAt)));
+  const meanDays = days.reduce((s, d) => s + d, 0) / days.length;
+  const variance = days.reduce((s, d) => s + (d - meanDays) ** 2, 0) / days.length;
+  const stdev = Math.sqrt(variance);
+  // 90+ days stdev = full marks; everything-this-week = 0.
+  const ageDiversityScore = clamp((stdev / 90) * 100);
+
+  const overallScore = Math.round(
+    diversificationScore * 0.5 + exchangeSpreadScore * 0.3 + ageDiversityScore * 0.2,
+  );
+
+  // ── Callouts: plain-English factual observations ──────────────────────
+  const callouts: string[] = [];
+  if (top1Share >= 0.4) {
+    callouts.push(
+      `Your largest position (${sortedDesc[0]!.h.ticker}) is ${(top1Share * 100).toFixed(0)}% of cost basis. High-concentration portfolios swing harder than diversified ones.`,
+    );
+  }
+  if (top3Share >= 0.85 && holdings.length > 3) {
+    callouts.push(
+      `Your top 3 positions are ${(top3Share * 100).toFixed(0)}% of cost basis — most of your other holdings are footnotes by weight.`,
+    );
+  }
+  if (auShare === 1) {
+    callouts.push(
+      "Every holding is AU-listed. Adding US or global names is one way investors diversify across currency + economic cycles — see /best/share-trading for international-friendly brokers.",
+    );
+  }
+  if (auShare === 0 && holdings.length > 0) {
+    callouts.push(
+      "No AU-listed holdings. AU residents often anchor part of their portfolio in ASX names for franking + currency match — see /best/share-trading.",
+    );
+  }
+  if (holdings.length < 3) {
+    callouts.push(
+      `Only ${holdings.length} position${holdings.length === 1 ? "" : "s"} on file. Diversification scores improve once you have 5+ positions across different sectors.`,
+    );
+  }
+
+  return {
+    diversificationScore: Math.round(diversificationScore),
+    exchangeSpreadScore: Math.round(exchangeSpreadScore),
+    ageDiversityScore: Math.round(ageDiversityScore),
+    overallScore,
+    callouts,
+  };
+}
+
+function clamp(n: number): number {
+  if (n < 0) return 0;
+  if (n > 100) return 100;
+  return n;
+}
+
+function daysBetween(today: Date, isoDate: string): number {
+  const acquired = new Date(`${isoDate}T00:00:00Z`).getTime();
+  const now = today.getTime();
+  return Math.floor((now - acquired) / 86400_000);
+}

--- a/lib/holdings/switching-coach.ts
+++ b/lib/holdings/switching-coach.ts
@@ -1,0 +1,103 @@
+/**
+ * Switching coach (PR-X5d).
+ *
+ * Pure function. Inputs: an investor's holdings + estimated trades-per-year
+ * (a single number — UI lets the user pick from "I rarely trade" / "few
+ * times a year" / "monthly" / "weekly"). Output: a comparison row showing
+ * estimated annual brokerage at the user's current broker (read from
+ * `broker_slug` on each holding) versus the cheapest eligible broker on
+ * the brokers table for the same trade-count assumption.
+ *
+ * Compliance note: this is a **comparison-driven** output, identical in
+ * legal footing to the public /best/share-trading rankings — it just
+ * uses the user's actual holdings to make the comparison personal.
+ * It says "Broker X charges Y, Broker Z charges W" — never "you should
+ * switch". The UI labels the CTA "Compare brokers →" not "Switch to
+ * Broker Z". Same lane as the country eligibility filter or the
+ * response-time SLA reward — comparisons all the way down.
+ */
+
+export interface BrokerForCoach {
+  slug: string;
+  name: string;
+  asx_fee_value: number | null; // AUD per ASX trade
+}
+
+export interface SwitchingCoachInput {
+  /** Set of broker_slugs the user has tagged on their holdings. */
+  currentBrokerSlugs: ReadonlyArray<string>;
+  /** Estimate of total trades / year across all brokers. */
+  tradesPerYear: number;
+  /** Eligible brokers to compare against (caller should pre-filter for status='active' + country eligibility). */
+  brokers: ReadonlyArray<BrokerForCoach>;
+}
+
+export interface SwitchingCoachResult {
+  /** null when the user hasn't tagged broker_slugs OR the current broker isn't on the brokers table. */
+  currentBroker: { slug: string; name: string; estCostCents: number } | null;
+  /** null when no cheaper broker exists in the input set OR estimate would be invalid. */
+  cheapest: { slug: string; name: string; estCostCents: number } | null;
+  /** Estimated annual saving in cents. 0 when current is already the cheapest. */
+  estSavingCents: number;
+  /** Plain-English summary line for the UI. */
+  summary: string;
+}
+
+export function buildSwitchingCoach(input: SwitchingCoachInput): SwitchingCoachResult {
+  const { currentBrokerSlugs, tradesPerYear, brokers } = input;
+
+  // Map slug → broker for fast lookup; skip brokers without a usable fee value.
+  const eligible = brokers.filter((b) => typeof b.asx_fee_value === "number" && b.asx_fee_value! >= 0);
+
+  const cheapest = eligible.length > 0
+    ? eligible.reduce((best, b) => (b.asx_fee_value! < best.asx_fee_value! ? b : best))
+    : null;
+
+  // Pick the user's "current broker" — if they tagged multiple, use the
+  // cheapest of theirs (a generous comparison: the UI shows the saving
+  // even if their cheapest current broker beats their tagged-most one).
+  const currentMatches = currentBrokerSlugs
+    .map((slug) => eligible.find((b) => b.slug === slug))
+    .filter((b): b is BrokerForCoach => Boolean(b));
+  const current = currentMatches.length > 0
+    ? currentMatches.reduce((best, b) => (b.asx_fee_value! < best.asx_fee_value! ? b : best))
+    : null;
+
+  if (!current || !cheapest || tradesPerYear <= 0) {
+    return {
+      currentBroker: null,
+      cheapest: cheapest && tradesPerYear > 0
+        ? {
+            slug: cheapest.slug,
+            name: cheapest.name,
+            estCostCents: Math.round(cheapest.asx_fee_value! * 100 * tradesPerYear),
+          }
+        : null,
+      estSavingCents: 0,
+      summary: !current
+        ? "Tag a broker on your holdings (and pick a trade frequency below) to see how much you'd save by switching."
+        : tradesPerYear <= 0
+          ? "Pick a trade frequency to estimate annual brokerage cost."
+          : "No comparable brokers loaded.",
+    };
+  }
+
+  const currentCostCents = Math.round(current.asx_fee_value! * 100 * tradesPerYear);
+  const cheapestCostCents = Math.round(cheapest.asx_fee_value! * 100 * tradesPerYear);
+  const estSavingCents = Math.max(0, currentCostCents - cheapestCostCents);
+
+  const summary = current.slug === cheapest.slug
+    ? `${current.name} is the lowest-fee match in our ASX broker set for your trade frequency. No estimated saving from switching.`
+    : `Estimated brokerage at ${current.name}: ${formatAud(currentCostCents)}/yr · at ${cheapest.name}: ${formatAud(cheapestCostCents)}/yr · saving ~${formatAud(estSavingCents)}/yr.`;
+
+  return {
+    currentBroker: { slug: current.slug, name: current.name, estCostCents: currentCostCents },
+    cheapest: { slug: cheapest.slug, name: cheapest.name, estCostCents: cheapestCostCents },
+    estSavingCents,
+    summary,
+  };
+}
+
+function formatAud(cents: number): string {
+  return (cents / 100).toLocaleString("en-AU", { style: "currency", currency: "AUD" });
+}

--- a/supabase/migrations/20260510140000_investor_holdings.sql
+++ b/supabase/migrations/20260510140000_investor_holdings.sql
@@ -1,0 +1,75 @@
+-- ============================================================================
+-- Migration: 20260510140000_investor_holdings.sql
+-- Purpose: Investor manual-holdings tracker for /account/holdings (PR-X5c
+--          collapsed: skipping the separate investor_profiles intermediary
+--          since auth.users + the existing /account/profile already cover
+--          identity. Holdings FK to auth.users directly.
+-- Audit ref: docs/plans/investor-account-end-to-end-plan.md Phase 1 X5c
+-- Risk: low — additive table; RLS-scoped per-user; no public read.
+-- Rollback: DROP TABLE IF EXISTS public.investor_holdings;
+--           (DESTRUCTIVE — discards user-entered holdings. There is no seed
+--           data to restore — users would need to re-enter manually.)
+-- ============================================================================
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.investor_holdings (
+  id              bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  auth_user_id    uuid   NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  ticker          text   NOT NULL CHECK (length(ticker) > 0 AND length(ticker) <= 30),
+  exchange        text   NOT NULL CHECK (exchange IN (
+                    'ASX','NASDAQ','NYSE','LSE','HKEX','SGX','TYO','KRX','CRYPTO','OTHER'
+                  )),
+  shares          numeric(20, 8) NOT NULL CHECK (shares > 0),
+  cost_basis_per_share_cents bigint NOT NULL CHECK (cost_basis_per_share_cents >= 0),
+  acquired_at     date NOT NULL,
+  broker_slug     text,                                  -- which broker holds it (free-text; FK-soft to brokers.slug)
+  notes           text CHECK (notes IS NULL OR length(notes) <= 500),
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  updated_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_investor_holdings_user
+  ON public.investor_holdings (auth_user_id, acquired_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_investor_holdings_ticker_lookup
+  ON public.investor_holdings (ticker, exchange);
+
+ALTER TABLE public.investor_holdings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.investor_holdings FORCE ROW LEVEL SECURITY;
+
+-- Authenticated users see / write ONLY their own rows.
+DROP POLICY IF EXISTS "investor reads own holdings" ON public.investor_holdings;
+CREATE POLICY "investor reads own holdings"
+  ON public.investor_holdings FOR SELECT
+  TO authenticated
+  USING (auth.uid() = auth_user_id);
+
+DROP POLICY IF EXISTS "investor inserts own holdings" ON public.investor_holdings;
+CREATE POLICY "investor inserts own holdings"
+  ON public.investor_holdings FOR INSERT
+  TO authenticated
+  WITH CHECK (auth.uid() = auth_user_id);
+
+DROP POLICY IF EXISTS "investor updates own holdings" ON public.investor_holdings;
+CREATE POLICY "investor updates own holdings"
+  ON public.investor_holdings FOR UPDATE
+  TO authenticated
+  USING (auth.uid() = auth_user_id)
+  WITH CHECK (auth.uid() = auth_user_id);
+
+DROP POLICY IF EXISTS "investor deletes own holdings" ON public.investor_holdings;
+CREATE POLICY "investor deletes own holdings"
+  ON public.investor_holdings FOR DELETE
+  TO authenticated
+  USING (auth.uid() = auth_user_id);
+
+-- Service role full access for admin / cron / GDPR-export paths.
+DROP POLICY IF EXISTS "service_role full access investor_holdings" ON public.investor_holdings;
+CREATE POLICY "service_role full access investor_holdings"
+  ON public.investor_holdings FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+COMMIT;


### PR DESCRIPTION
## Summary

W2 Phase 1 (X5a + X5c + X5d combined). Adds `investor_holdings` schema + CRUD + UI + portfolio health-score + switching-coach. Authenticated users at `/account/holdings` can manually track holdings across brokers + see comparison-driven feedback.

## Tier
C — new schema migration + new API route + service-role-permitted policies. Migration applied to live via Supabase MCP ahead of merge so drift check passes on the regenerated types.

## What changed
- \`supabase/migrations/20260510140000_investor_holdings.sql\` — table + RLS + 4 user-scoped policies + service-role allow
- \`app/api/account/holdings/route.ts\` — GET/POST/PATCH/DELETE, Zod-validated, user-scoped supabase client (RLS does the heavy lifting)
- \`app/account/holdings/page.tsx\` + \`HoldingsClient.tsx\` — add form + list + totals + score block + brokerage coach
- \`lib/holdings/health-score.ts\` — pure function: diversification + exchange-spread + age-diversity sub-scores → 0-100 overall + plain-English callouts
- \`lib/holdings/switching-coach.ts\` — pure function: comparison vs cheapest eligible broker for the user's trade frequency
- \`lib/database.types.ts\` — regenerated to include investor_holdings
- 15 vitest tests (9 health-score + 6 switching-coach), all green

## Compliance
Per \`docs/plans/investor-account-end-to-end-plan.md\` Phase 1 — display + comparison only, no recommendations to act. Page header carries the "general information only — see your accountant" disclaimer. The switching coach uses comparison language identical to /best/share-trading rankings, just personalised by the user's broker_slug tags.

## Skipped from the original plan (deliberate)
- Separate \`investor_profiles\` intermediary table (auth.users + /account/profile already cover identity)
- \`/investor-portal\` namespace (use existing /account/*)
- Current-value lookup via Yahoo / Marketstack (Phase 2 follow-up)

## Supersedes
_None._

## Test plan
- [x] Migration applied to live; \`SELECT count(*) FROM investor_holdings\` returns 0 rows (clean install)
- [x] 15/15 vitest local green
- [x] Type-check clean
- [ ] CI green
- [ ] Tier C 30-min observation post-merge (or 5-min with LOOP_RESPONSIVE sentinel — sentinel not currently set; you're at the keyboard so direct override applies)
- [ ] Manual: log in via /account/login, visit /account/holdings, add a holding, verify score appears