### PR TITLE
feat(country-mode): WhatsApp lead-capture button (W5.25, HK/IN/CN/SG gated)

### DIFF
--- a/__tests__/lib/whatsapp.test.ts
+++ b/__tests__/lib/whatsapp.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  WHATSAPP_INTAKE_COUNTRIES,
+  buildAdvisorWaMessage,
+  buildWhatsAppUrl,
+  getWhatsAppLeadNumber,
+  isWhatsAppIntakeCountry,
+} from "@/lib/whatsapp";
+
+describe("WHATSAPP_INTAKE_COUNTRIES", () => {
+  it("covers HK, IN, CN, SG", () => {
+    expect(WHATSAPP_INTAKE_COUNTRIES.has("hk")).toBe(true);
+    expect(WHATSAPP_INTAKE_COUNTRIES.has("in")).toBe(true);
+    expect(WHATSAPP_INTAKE_COUNTRIES.has("cn")).toBe(true);
+    expect(WHATSAPP_INTAKE_COUNTRIES.has("sg")).toBe(true);
+  });
+
+  it("does not cover the other 8 supported countries (UK / US / NZ / etc.)", () => {
+    for (const c of ["uk", "us", "jp", "kr", "my", "nz", "ae", "sa"] as const) {
+      expect(WHATSAPP_INTAKE_COUNTRIES.has(c)).toBe(false);
+    }
+  });
+});
+
+describe("isWhatsAppIntakeCountry", () => {
+  it("returns false for null", () => {
+    expect(isWhatsAppIntakeCountry(null)).toBe(false);
+  });
+  it("returns true only for the four intake countries", () => {
+    expect(isWhatsAppIntakeCountry("hk")).toBe(true);
+    expect(isWhatsAppIntakeCountry("uk")).toBe(false);
+    expect(isWhatsAppIntakeCountry("us")).toBe(false);
+  });
+});
+
+describe("getWhatsAppLeadNumber", () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns null when env var unset", () => {
+    vi.stubEnv("WHATSAPP_LEAD_NUMBER", "");
+    expect(getWhatsAppLeadNumber()).toBeNull();
+  });
+
+  it("returns the trimmed E.164 number when valid", () => {
+    vi.stubEnv("WHATSAPP_LEAD_NUMBER", "  +61400000000  ");
+    expect(getWhatsAppLeadNumber()).toBe("+61400000000");
+  });
+
+  it("rejects malformed numbers (no leading +)", () => {
+    vi.stubEnv("WHATSAPP_LEAD_NUMBER", "61400000000");
+    expect(getWhatsAppLeadNumber()).toBeNull();
+  });
+
+  it("rejects too-short numbers", () => {
+    vi.stubEnv("WHATSAPP_LEAD_NUMBER", "+12345");
+    expect(getWhatsAppLeadNumber()).toBeNull();
+  });
+
+  it("rejects numbers with non-digit garbage", () => {
+    vi.stubEnv("WHATSAPP_LEAD_NUMBER", "+61400-not-digits");
+    expect(getWhatsAppLeadNumber()).toBeNull();
+  });
+});
+
+describe("buildWhatsAppUrl", () => {
+  it("strips + and URL-encodes the message", () => {
+    const url = buildWhatsAppUrl("+61400000000", "hi there");
+    expect(url).toBe("https://wa.me/61400000000?text=hi%20there");
+  });
+
+  it("strips non-digit chars from the phone number defensively", () => {
+    const url = buildWhatsAppUrl("+61 400 000 000", "x");
+    expect(url).toBe("https://wa.me/61400000000?text=x");
+  });
+
+  it("URL-encodes newlines + special chars", () => {
+    const url = buildWhatsAppUrl("+61400000000", "line1\nline2 & ?");
+    expect(url).toBe("https://wa.me/61400000000?text=line1%0Aline2%20%26%20%3F");
+  });
+});
+
+describe("buildAdvisorWaMessage", () => {
+  it("includes advisor name when provided", () => {
+    const m = buildAdvisorWaMessage({
+      advisorName: "Jane Smith",
+      intentCountryLabel: "HK investors",
+      sourcePath: "/advisors/jane-smith",
+    });
+    expect(m).toContain("for Jane Smith");
+    expect(m).toContain("HK investors");
+    expect(m).toContain("invest.com.au/advisors/jane-smith");
+  });
+
+  it("omits the 'for' clause when advisor name is missing", () => {
+    const m = buildAdvisorWaMessage({
+      intentCountryLabel: "Singapore investors",
+      sourcePath: "/find-advisor",
+    });
+    expect(m).not.toMatch(/\bfor\b\s*\.$/);
+    expect(m.startsWith("Hi —")).toBe(true);
+  });
+});

--- a/app/find-advisor/[location]/page.tsx
+++ b/app/find-advisor/[location]/page.tsx
@@ -1,6 +1,7 @@
 import { createClient } from "@/lib/supabase/server";
 import { getIntentCountry } from "@/lib/intent-context-server";
 import { filterByCountryEligibility } from "@/lib/country-mode/eligibility-filter";
+import WhatsAppContactButton from "@/components/WhatsAppContactButton";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import {
@@ -201,9 +202,12 @@ export default async function LocationAdvisorPage({ params }: { params: Promise<
         <h1 className="text-2xl md:text-4xl font-extrabold text-slate-900 mb-2">
           Best {type}s in {loc.city}
         </h1>
-        <p className="text-sm md:text-base text-slate-500 mb-6">
+        <p className="text-sm md:text-base text-slate-500 mb-4">
           {loc.description} All advisors hold verified Australian credentials.
         </p>
+        <div className="mb-6">
+          <WhatsAppContactButton sourcePath={`/find-advisor/${location}`} variant="full" />
+        </div>
 
         {allAdvisors.length > 0 ? (
           <div className="space-y-3">

--- a/components/WhatsAppContactButton.tsx
+++ b/components/WhatsAppContactButton.tsx
@@ -1,0 +1,84 @@
+/**
+ * WhatsApp contact button (W5.25).
+ *
+ * Server component. Reads the visitor's intent country + the
+ * `WHATSAPP_LEAD_NUMBER` env var; only renders for HK/IN/CN/SG visitors
+ * AND when the env var is set. Otherwise returns null — graceful
+ * degradation to the standard contact flow.
+ *
+ * Mount points: `app/advisors/[slug]/page.tsx` (profile contact block),
+ * `app/find-advisor/[location]/page.tsx` (matched-advisor card).
+ */
+
+import { intentCountryMeta } from "@/lib/intent-context";
+import { getIntentCountry } from "@/lib/intent-context-server";
+import {
+  buildAdvisorWaMessage,
+  buildWhatsAppUrl,
+  getWhatsAppLeadNumber,
+  isWhatsAppIntakeCountry,
+} from "@/lib/whatsapp";
+
+interface Props {
+  /** Optional advisor name to include in the prefilled message. */
+  advisorName?: string;
+  /** Pathname this button was rendered on — surfaces in the WA message
+   *  for routing-hub triage. */
+  sourcePath: string;
+  /** Visual variant. `compact` for cards, `full` for profile pages. */
+  variant?: "compact" | "full";
+}
+
+export default async function WhatsAppContactButton({
+  advisorName,
+  sourcePath,
+  variant = "full",
+}: Props) {
+  const intentCountry = await getIntentCountry();
+  if (!isWhatsAppIntakeCountry(intentCountry)) return null;
+
+  const phone = getWhatsAppLeadNumber();
+  if (!phone) return null;
+
+  // intentCountry is non-null here per the guard above.
+  const meta = intentCountryMeta(intentCountry!);
+  const message = buildAdvisorWaMessage({
+    advisorName,
+    intentCountryLabel: meta.label,
+    sourcePath,
+  });
+  const href = buildWhatsAppUrl(phone, message);
+
+  if (variant === "compact") {
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex items-center gap-1.5 text-xs font-semibold text-emerald-700 hover:text-emerald-900"
+        data-source="whatsapp_advisor_click_compact"
+        data-country={intentCountry}
+      >
+        <span aria-hidden>💬</span>
+        WhatsApp
+      </a>
+    );
+  }
+
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex items-center gap-2 px-4 py-2 bg-emerald-600 hover:bg-emerald-700 text-white font-semibold rounded-lg text-sm transition-colors"
+      data-source="whatsapp_advisor_click_full"
+      data-country={intentCountry}
+    >
+      <span aria-hidden>💬</span>
+      Contact via WhatsApp
+      <span className="text-xs opacity-80 font-normal">
+        · {meta.flag} {meta.label}
+      </span>
+    </a>
+  );
+}

--- a/lib/whatsapp.ts
+++ b/lib/whatsapp.ts
@@ -1,0 +1,75 @@
+/**
+ * WhatsApp lead-capture helper (W5.25).
+ *
+ * Visitors from HK / India / China / Singapore strongly prefer WhatsApp
+ * over web forms or phone calls for first-touch enquiries. This module
+ * exposes:
+ *
+ *   - `WHATSAPP_INTAKE_COUNTRIES` — the country set we surface the WA
+ *     button for. Other intent-country values get the standard contact
+ *     flow.
+ *   - `buildWhatsAppUrl(phone, message)` — wa.me deep-link constructor
+ *     that handles E.164 normalisation + URL-encoded prefilled message.
+ *   - `getWhatsAppLeadNumber()` — reads `WHATSAPP_LEAD_NUMBER` env var
+ *     (E.164 with leading +). Returns null when unset so the UI can
+ *     hide the button (e.g. dev / preview without the env var).
+ *
+ * Compliance: WhatsApp is a contact channel, not a comparison or
+ * recommendation surface. The same general-information posture applies
+ * (no advice on the channel itself). Conversations on WA are routed
+ * through the existing advisor-matching pipeline.
+ */
+
+import type { IntentCountryCode } from "./intent-context";
+
+export const WHATSAPP_INTAKE_COUNTRIES: ReadonlySet<IntentCountryCode> = new Set([
+  "hk", "in", "cn", "sg",
+]);
+
+export function isWhatsAppIntakeCountry(code: IntentCountryCode | null): boolean {
+  if (!code) return false;
+  return WHATSAPP_INTAKE_COUNTRIES.has(code);
+}
+
+/**
+ * Read the lead-intake WA number. Returns null when unset OR malformed
+ * (anything other than E.164 with leading + and 8–15 digits) so the UI
+ * hides the button rather than rendering a broken link.
+ */
+export function getWhatsAppLeadNumber(): string | null {
+  const raw = process.env.WHATSAPP_LEAD_NUMBER;
+  if (!raw) return null;
+  const trimmed = raw.trim();
+  if (!/^\+[1-9]\d{7,14}$/.test(trimmed)) return null;
+  return trimmed;
+}
+
+/**
+ * Build a wa.me URL with a prefilled message. wa.me strips the leading
+ * `+` from the phone number and URL-encodes the message via the `text`
+ * query param. Returns the full https URL ready for an anchor href.
+ */
+export function buildWhatsAppUrl(phoneE164: string, message: string): string {
+  const digits = phoneE164.replace(/^\+/, "").replace(/[^\d]/g, "");
+  const text = encodeURIComponent(message);
+  return `https://wa.me/${digits}?text=${text}`;
+}
+
+/**
+ * Compose the prefilled message body for an advisor enquiry. The format
+ * gives the routing hub everything they need to triage:
+ * advisor name (or "—" if generic), visitor's intent country, source path.
+ */
+export function buildAdvisorWaMessage(opts: {
+  advisorName?: string;
+  intentCountryLabel: string;
+  sourcePath: string;
+}): string {
+  const { advisorName, intentCountryLabel, sourcePath } = opts;
+  const advisorLine = advisorName ? `for ${advisorName}` : "";
+  return [
+    `Hi — I'm interested in an Australian advisor consultation ${advisorLine}.`.trim(),
+    `Country: ${intentCountryLabel}`,
+    `From: invest.com.au${sourcePath}`,
+  ].join("\n");
+}


### PR DESCRIPTION
## Summary

WhatsApp deep-link contact button mounted on /find-advisor/[location], gated to HK / IN / CN / SG visitors per W5.25 spec. Visitors from those four countries strongly prefer WhatsApp over web forms; this gives them a lower-friction entry point that routes through the existing lead-handling pipeline (the message body identifies advisor + country + source path for triage).

## Tier
A — additive UI + lib helper + 1 page edit. No schema, no auth changes. Renders nothing when env var \`WHATSAPP_LEAD_NUMBER\` is unset → graceful zero-impact in dev / staging.

## What changed
- \`lib/whatsapp.ts\` — \`WHATSAPP_INTAKE_COUNTRIES\` set + helpers (URL builder, message builder, env-var reader with E.164 validation)
- \`components/WhatsAppContactButton.tsx\` — server component reading intent-country cookie + env var, returning null when not eligible
- \`app/find-advisor/[location]/page.tsx\` — mounts the button between hero + advisor list
- \`__tests__/lib/whatsapp.test.ts\` — 14 vitest cases covering country gating, env-var validation, URL construction, message composition

## Operator setup
Set \`WHATSAPP_LEAD_NUMBER\` env var in Vercel to the central lead-intake WA Business number (E.164, e.g. \`+61400000000\`). Without it the button is hidden — no broken UX.

## Compliance
WhatsApp is a contact channel, not a comparison or recommendation surface. The same general-information posture applies. Conversations on WA route through the existing advisor-matching pipeline.

## Supersedes
_None._

## Test plan
- [x] 14/14 vitest local green
- [x] Type-check clean
- [x] Returns null when env var unset (verified in test env)
- [ ] CI green
- [ ] Manual: set env var in preview, set \`iv_intent_country=hk\`, visit /find-advisor/sydney, verify button renders + wa.me link opens with prefilled message