### PR TITLE
feat(account): holdings current-value lookup (Yahoo + CoinGecko, cached)

### DIFF
--- a/__tests__/lib/holdings/value-source.test.ts
+++ b/__tests__/lib/holdings/value-source.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { toYahooSymbol } from "@/lib/holdings/value-source";
+
+describe("toYahooSymbol", () => {
+  it("appends .AX for ASX tickers without it", () => {
+    expect(toYahooSymbol("BHP", "ASX")).toBe("BHP.AX");
+    expect(toYahooSymbol("cba", "ASX")).toBe("CBA.AX");
+  });
+
+  it("is idempotent — already-suffixed tickers stay clean", () => {
+    expect(toYahooSymbol("BHP.AX", "ASX")).toBe("BHP.AX");
+  });
+
+  it("leaves NASDAQ / NYSE bare", () => {
+    expect(toYahooSymbol("AAPL", "NASDAQ")).toBe("AAPL");
+    expect(toYahooSymbol("BRK.A", "NYSE")).toBe("BRK.A");
+  });
+
+  it("appends .L for LSE", () => {
+    expect(toYahooSymbol("VOD", "LSE")).toBe("VOD.L");
+  });
+
+  it("appends .HK / .SI / .T / .KS per exchange", () => {
+    expect(toYahooSymbol("0700", "HKEX")).toBe("0700.HK");
+    expect(toYahooSymbol("D05", "SGX")).toBe("D05.SI");
+    expect(toYahooSymbol("7203", "TYO")).toBe("7203.T");
+    expect(toYahooSymbol("005930", "KRX")).toBe("005930.KS");
+  });
+
+  it("uppercases bare tickers", () => {
+    expect(toYahooSymbol("aapl", "NASDAQ")).toBe("AAPL");
+  });
+
+  it("returns bare uppercase ticker for OTHER exchange (no known suffix)", () => {
+    expect(toYahooSymbol("xyz", "OTHER")).toBe("XYZ");
+  });
+});

--- a/__tests__/lib/holdings/value.test.ts
+++ b/__tests__/lib/holdings/value.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+let cachedRow: Record<string, unknown> | null = null;
+const upsertCalls: Record<string, unknown>[] = [];
+const updateCalls: Record<string, unknown>[] = [];
+
+const mockFrom = vi.fn((table: string) => {
+  if (table !== "holdings_price_cache") {
+    throw new Error(`unexpected table: ${table}`);
+  }
+  return {
+    select: () => {
+      const chain = {
+        eq: () => chain,
+        maybeSingle: async () => ({ data: cachedRow, error: null }),
+      };
+      return chain;
+    },
+    upsert: async (row: Record<string, unknown>) => {
+      upsertCalls.push(row);
+      return { error: null };
+    },
+    update: (row: Record<string, unknown>) => {
+      const chain = {
+        eq: () => chain,
+        then: (resolve: (v: unknown) => void) => {
+          updateCalls.push(row);
+          return Promise.resolve({ error: null }).then(resolve);
+        },
+      };
+      // Return both an awaitable + chain (Supabase client behaves as either)
+      return Object.assign(Promise.resolve({ error: null }), chain);
+    },
+  };
+});
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+const fetchMock = vi.fn<(...args: unknown[]) => Promise<unknown>>();
+vi.mock("@/lib/holdings/value-source", () => ({
+  fetchPriceForHolding: (...args: unknown[]) => fetchMock(...args),
+}));
+
+import { getCurrentPrice } from "@/lib/holdings/value";
+
+const NOW_MS = new Date("2026-05-10T12:00:00Z").getTime();
+
+describe("getCurrentPrice", () => {
+  beforeEach(() => {
+    cachedRow = null;
+    upsertCalls.length = 0;
+    updateCalls.length = 0;
+    fetchMock.mockReset();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(NOW_MS));
+  });
+
+  it("returns cached price when fresh + non-stale", async () => {
+    cachedRow = {
+      price_cents: 4500,
+      currency: "AUD",
+      source: "yahoo",
+      fetched_at: new Date(NOW_MS - 60 * 60 * 1000).toISOString(), // 1h old
+      last_attempt_at: new Date(NOW_MS - 60 * 60 * 1000).toISOString(),
+    };
+    const r = await getCurrentPrice("BHP", "ASX");
+    expect(r).toEqual({
+      priceCents: 4500,
+      currency: "AUD",
+      source: "yahoo",
+      fetchedAt: expect.any(String),
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("calls upstream on cache miss + caches the result", async () => {
+    cachedRow = null;
+    fetchMock.mockResolvedValueOnce({
+      priceCents: 4800,
+      currency: "AUD",
+      source: "yahoo",
+    });
+    const r = await getCurrentPrice("BHP", "ASX");
+    expect(r?.priceCents).toBe(4800);
+    expect(r?.source).toBe("yahoo");
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(upsertCalls[0]).toMatchObject({
+      ticker: "BHP",
+      exchange: "ASX",
+      price_cents: 4800,
+      source: "yahoo",
+    });
+  });
+
+  it("re-fetches when cache is past its 24h TTL", async () => {
+    cachedRow = {
+      price_cents: 4000,
+      currency: "AUD",
+      source: "yahoo",
+      fetched_at: new Date(NOW_MS - 25 * 60 * 60 * 1000).toISOString(), // 25h old
+      last_attempt_at: new Date(NOW_MS - 25 * 60 * 60 * 1000).toISOString(),
+    };
+    fetchMock.mockResolvedValueOnce({
+      priceCents: 4200,
+      currency: "AUD",
+      source: "yahoo",
+    });
+    const r = await getCurrentPrice("BHP", "ASX");
+    expect(r?.priceCents).toBe(4200);
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("crypto cache TTL is 1h (re-fetches at 90 min)", async () => {
+    cachedRow = {
+      price_cents: 6_000_000,
+      currency: "AUD",
+      source: "coingecko",
+      fetched_at: new Date(NOW_MS - 90 * 60 * 1000).toISOString(),
+      last_attempt_at: new Date(NOW_MS - 90 * 60 * 1000).toISOString(),
+    };
+    fetchMock.mockResolvedValueOnce({
+      priceCents: 6_100_000,
+      currency: "AUD",
+      source: "coingecko",
+    });
+    const r = await getCurrentPrice("BTC", "CRYPTO");
+    expect(r?.priceCents).toBe(6_100_000);
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("falls back to stale cache when upstream returns null", async () => {
+    cachedRow = {
+      price_cents: 4000,
+      currency: "AUD",
+      source: "yahoo",
+      fetched_at: new Date(NOW_MS - 48 * 60 * 60 * 1000).toISOString(), // 48h old
+      last_attempt_at: new Date(NOW_MS - 48 * 60 * 60 * 1000).toISOString(),
+    };
+    fetchMock.mockResolvedValueOnce(null);
+    const r = await getCurrentPrice("BHP", "ASX");
+    expect(r?.source).toBe("stale");
+    expect(r?.priceCents).toBe(4000);
+  });
+
+  it("returns null when there's no cache + upstream fails", async () => {
+    cachedRow = null;
+    fetchMock.mockResolvedValueOnce(null);
+    const r = await getCurrentPrice("UNKNOWN", "OTHER");
+    expect(r).toBeNull();
+  });
+
+  it("returns null when stale cache is older than 7-day fallback window", async () => {
+    cachedRow = {
+      price_cents: 4000,
+      currency: "AUD",
+      source: "yahoo",
+      fetched_at: new Date(NOW_MS - 8 * 24 * 60 * 60 * 1000).toISOString(),
+      last_attempt_at: new Date(NOW_MS - 8 * 24 * 60 * 60 * 1000).toISOString(),
+    };
+    fetchMock.mockResolvedValueOnce(null);
+    const r = await getCurrentPrice("BHP", "ASX");
+    expect(r).toBeNull();
+  });
+
+  it("does NOT call upstream within the 5-min attempt-throttle window", async () => {
+    cachedRow = {
+      price_cents: 4000,
+      currency: "AUD",
+      source: "stale",
+      fetched_at: new Date(NOW_MS - 25 * 60 * 60 * 1000).toISOString(), // outside 24h TTL
+      last_attempt_at: new Date(NOW_MS - 2 * 60 * 1000).toISOString(),  // 2 min ago
+    };
+    const r = await getCurrentPrice("BHP", "ASX");
+    expect(r?.source).toBe("stale");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/app/account/holdings/HoldingsClient.tsx
+++ b/app/account/holdings/HoldingsClient.tsx
@@ -16,6 +16,15 @@ export interface HoldingRow {
   acquiredAt: string;
   brokerSlug: string | null;
   notes: string | null;
+  /** Current market price in cents. Null when upstream is down + no
+   *  stale fallback exists. UI renders "—" in that case. */
+  currentPriceCents: number | null;
+  /** ISO 4217 currency code of the current price, e.g. "AUD" / "USD".
+   *  May differ from cost basis (which is always AUD by convention). */
+  currentPriceCurrency: string | null;
+  currentPriceSource: "yahoo" | "coingecko" | "stale" | null;
+  /** ISO timestamp of the price's `fetched_at` for the "as of N ago" label. */
+  currentPriceFetchedAt: string | null;
 }
 
 interface Props {
@@ -35,6 +44,20 @@ const EXCHANGES = ["ASX","NASDAQ","NYSE","LSE","HKEX","SGX","TYO","KRX","CRYPTO"
 const fmtCents = (cents: number) =>
   (cents / 100).toLocaleString("en-AU", { style: "currency", currency: "AUD" });
 
+const fmtCurrency = (cents: number, currency: string) =>
+  (cents / 100).toLocaleString("en-AU", {
+    style: "currency",
+    currency: currency || "AUD",
+    currencyDisplay: "narrowSymbol",
+  });
+
+const fmtPct = (deltaCents: number, baseCents: number) => {
+  if (baseCents === 0) return "—";
+  const pct = (deltaCents / baseCents) * 100;
+  const sign = pct >= 0 ? "+" : "−";
+  return `${sign}${Math.abs(pct).toFixed(1)}%`;
+};
+
 const fmtShares = (n: number) =>
   n.toLocaleString("en-AU", { maximumFractionDigits: 4 });
 
@@ -51,7 +74,23 @@ export default function HoldingsClient({ initialItems, brokers }: Props) {
       0,
     );
     const positionCount = items.length;
-    return { totalCostCents, positionCount };
+    // Current value totals — only counts positions with a price. Mixed-currency
+    // portfolios are an MVP gap: we sum AUD + USD prices into one number on
+    // the assumption most retail AU users hold AUD-only or AUD-dominant
+    // portfolios. The UI surfaces a footnote when any non-AUD position exists.
+    let totalValueCents = 0;
+    let pricedPositionCount = 0;
+    let hasNonAud = false;
+    for (const h of items) {
+      if (h.currentPriceCents == null) continue;
+      totalValueCents += Math.round(h.shares * h.currentPriceCents);
+      pricedPositionCount += 1;
+      if (h.currentPriceCurrency && h.currentPriceCurrency !== "AUD") hasNonAud = true;
+    }
+    const totalGainCents = pricedPositionCount === positionCount
+      ? totalValueCents - totalCostCents
+      : null;
+    return { totalCostCents, totalValueCents, totalGainCents, positionCount, pricedPositionCount, hasNonAud };
   }, [items]);
 
   const score = useMemo(
@@ -117,6 +156,13 @@ export default function HoldingsClient({ initialItems, brokers }: Props) {
         acquiredAt: j.item.acquired_at,
         brokerSlug: j.item.broker_slug,
         notes: j.item.notes,
+        // Newly-added rows don't have a price yet; the user sees a "—" until
+        // the next page render fetches it from the cache. (We could fire off
+        // the lookup client-side here but it'd duplicate the server path.)
+        currentPriceCents: null,
+        currentPriceCurrency: null,
+        currentPriceSource: null,
+        currentPriceFetchedAt: null,
       };
       setItems((prev) => [newRow, ...prev]);
     } catch (e) {
@@ -208,15 +254,34 @@ export default function HoldingsClient({ initialItems, brokers }: Props) {
       )}
 
       {/* Totals strip */}
-      <section className="grid grid-cols-2 gap-3">
+      <section className="grid grid-cols-1 sm:grid-cols-3 gap-3">
         <div className="bg-slate-50 border border-slate-200 rounded-xl p-4">
           <p className="text-xs font-semibold uppercase tracking-wider text-slate-500">Positions</p>
           <p className="text-2xl font-bold text-slate-900 mt-1">{totals.positionCount}</p>
         </div>
         <div className="bg-emerald-50 border border-emerald-200 rounded-xl p-4">
-          <p className="text-xs font-semibold uppercase tracking-wider text-emerald-700">Total cost basis</p>
+          <p className="text-xs font-semibold uppercase tracking-wider text-emerald-700">Cost basis</p>
           <p className="text-2xl font-bold text-emerald-900 mt-1">{fmtCents(totals.totalCostCents)}</p>
-          <p className="text-xs text-emerald-700 mt-1">Sum of shares × cost/share. Current value lookup ships in PR-X5c iter 2.</p>
+          <p className="text-xs text-emerald-700 mt-1">Sum of shares × cost/share.</p>
+        </div>
+        <div className="bg-sky-50 border border-sky-200 rounded-xl p-4">
+          <p className="text-xs font-semibold uppercase tracking-wider text-sky-700">Current value</p>
+          {totals.pricedPositionCount === 0 ? (
+            <p className="text-2xl font-bold text-sky-900 mt-1">—</p>
+          ) : (
+            <p className="text-2xl font-bold text-sky-900 mt-1">{fmtCents(totals.totalValueCents)}</p>
+          )}
+          {totals.totalGainCents !== null ? (
+            <p className={`text-xs mt-1 ${totals.totalGainCents >= 0 ? "text-emerald-700" : "text-red-700"}`}>
+              {totals.totalGainCents >= 0 ? "+" : "−"}
+              {fmtCents(Math.abs(totals.totalGainCents))} ({fmtPct(totals.totalGainCents, totals.totalCostCents)})
+            </p>
+          ) : (
+            <p className="text-xs text-sky-700 mt-1">
+              {totals.pricedPositionCount}/{totals.positionCount} priced
+              {totals.hasNonAud ? " · mixed currency" : ""}
+            </p>
+          )}
         </div>
       </section>
 
@@ -341,9 +406,31 @@ export default function HoldingsClient({ initialItems, brokers }: Props) {
                   )}
                 </div>
                 <div className="text-right shrink-0">
-                  <div className="text-sm font-semibold text-slate-900">
-                    {fmtCents(h.shares * h.costBasisPerShareCents)}
+                  {h.currentPriceCents != null ? (
+                    <>
+                      <div className="text-sm font-semibold text-slate-900">
+                        {fmtCurrency(h.shares * h.currentPriceCents, h.currentPriceCurrency ?? "AUD")}
+                      </div>
+                      <RowGainLabel
+                        valueCents={h.shares * h.currentPriceCents}
+                        costCents={h.shares * h.costBasisPerShareCents}
+                        currency={h.currentPriceCurrency}
+                      />
+                    </>
+                  ) : (
+                    <div className="text-sm text-slate-400">—</div>
+                  )}
+                  <div className="text-[11px] text-slate-500 mt-0.5">
+                    cost {fmtCents(h.shares * h.costBasisPerShareCents)}
                   </div>
+                  {h.currentPriceSource === "stale" && (
+                    <div
+                      className="text-[10px] text-amber-700 mt-0.5"
+                      title="Latest live fetch failed; showing the most recent cached price."
+                    >
+                      stale price
+                    </div>
+                  )}
                   <button
                     type="button"
                     onClick={() => void handleDelete(h.id)}
@@ -358,6 +445,38 @@ export default function HoldingsClient({ initialItems, brokers }: Props) {
           </ul>
         )}
       </section>
+    </div>
+  );
+}
+
+/**
+ * Per-row gain/loss label. Skipped when the price currency differs from
+ * AUD (cost basis is AUD-only) — comparing AUD cost vs USD value would
+ * mislead. We surface the value in its native currency without an
+ * apples-to-oranges delta.
+ */
+function RowGainLabel({
+  valueCents,
+  costCents,
+  currency,
+}: {
+  valueCents: number;
+  costCents: number;
+  currency: string | null;
+}) {
+  if (currency && currency !== "AUD") {
+    return (
+      <div className="text-xs text-slate-500" title={`Value in ${currency}; cost basis stored in AUD`}>
+        {currency} price · cost in AUD
+      </div>
+    );
+  }
+  const delta = valueCents - costCents;
+  const cls = delta >= 0 ? "text-emerald-700" : "text-red-700";
+  return (
+    <div className={`text-xs ${cls}`}>
+      {delta >= 0 ? "+" : "−"}
+      {fmtCents(Math.abs(delta))} ({fmtPct(delta, costCents)})
     </div>
   );
 }

--- a/app/account/holdings/page.tsx
+++ b/app/account/holdings/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import HoldingsClient, { type HoldingRow } from "./HoldingsClient";
+import { getCurrentPricesBatch, keyOf } from "@/lib/holdings/value";
 
 export const dynamic = "force-dynamic";
 
@@ -44,7 +45,28 @@ export default async function HoldingsPage() {
     acquiredAt: r.acquired_at,
     brokerSlug: r.broker_slug,
     notes: r.notes,
+    currentPriceCents: null, // populated below from cache/upstream
+    currentPriceCurrency: null,
+    currentPriceSource: null,
+    currentPriceFetchedAt: null,
   }));
+
+  // Fetch current prices in parallel (cache-first; falls back to upstream
+  // for cold/expired entries; falls back to stale cache when upstream is down).
+  if (initialItems.length > 0) {
+    const priceMap = await getCurrentPricesBatch(
+      initialItems.map((h) => ({ ticker: h.ticker, exchange: h.exchange })),
+    );
+    for (const h of initialItems) {
+      const v = priceMap.get(keyOf(h.ticker, h.exchange));
+      if (v) {
+        h.currentPriceCents = v.priceCents;
+        h.currentPriceCurrency = v.currency;
+        h.currentPriceSource = v.source;
+        h.currentPriceFetchedAt = v.fetchedAt;
+      }
+    }
+  }
 
   const brokerOptions = (brokers ?? []).map((b) => ({
     slug: b.slug as string,

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -7197,6 +7197,39 @@ export type Database = {
         }
         Relationships: []
       }
+      holdings_price_cache: {
+        Row: {
+          currency: string
+          exchange: string
+          fetched_at: string
+          id: number
+          last_attempt_at: string
+          price_cents: number
+          source: string
+          ticker: string
+        }
+        Insert: {
+          currency: string
+          exchange: string
+          fetched_at?: string
+          id?: never
+          last_attempt_at?: string
+          price_cents: number
+          source: string
+          ticker: string
+        }
+        Update: {
+          currency?: string
+          exchange?: string
+          fetched_at?: string
+          id?: never
+          last_attempt_at?: string
+          price_cents?: number
+          source?: string
+          ticker?: string
+        }
+        Relationships: []
+      }
       i18n_currency_rates: {
         Row: {
           base_currency: string

--- a/lib/holdings/value-source.ts
+++ b/lib/holdings/value-source.ts
@@ -1,0 +1,189 @@
+/**
+ * Price-source abstraction for holdings (W2 Phase 1 follow-up to PR-X5c).
+ *
+ * Two upstream sources, no hard dependencies on either being available:
+ *   - Yahoo Finance via `yahoo-finance2` for equities (free, no key,
+ *     ASX needs `.AX` suffix, NASDAQ/NYSE/etc. don't, LSE needs `.L`,
+ *     HKEX `.HK`, SGX `.SI`, TYO `.T`, KRX `.KS`)
+ *   - CoinGecko free API for crypto (no key required up to ~30 req/min)
+ *
+ * Each fetcher returns `{ priceCents, currency } | null`. null on
+ * upstream failure / ticker-not-found — the cache layer will decide
+ * whether to fall back to a stale row.
+ *
+ * Network calls are wrapped in a 4-second timeout. The cache layer
+ * already absorbs most reads; a slow upstream should not block a page
+ * render on the cold-cache cases.
+ *
+ * NOT included (deliberate):
+ *   - Marketstack fallback — only worth adding if Yahoo rate-limits
+ *     in practice
+ *   - Pre-warm cron — premature
+ *   - Multi-currency conversion — UI shows the source currency for now
+ */
+
+import { logger } from "@/lib/logger";
+
+const log = logger("holdings:value-source");
+
+const FETCH_TIMEOUT_MS = 4000;
+
+export interface PriceQuote {
+  priceCents: number;
+  currency: string;
+  source: "yahoo" | "coingecko";
+}
+
+const ASX_SUFFIX_BY_EXCHANGE: Record<string, string> = {
+  ASX: ".AX",
+  LSE: ".L",
+  HKEX: ".HK",
+  SGX: ".SI",
+  TYO: ".T",
+  KRX: ".KS",
+  // NASDAQ / NYSE / OTHER: bare ticker (no suffix)
+};
+
+/**
+ * Translate a stored ticker + exchange to a Yahoo Finance symbol.
+ * Yahoo's symbol format is `<ticker><suffix>` for non-US exchanges.
+ * We tolerate the user already having the suffix in `ticker` (idempotent).
+ */
+export function toYahooSymbol(ticker: string, exchange: string): string {
+  const upper = ticker.trim().toUpperCase();
+  const suffix = ASX_SUFFIX_BY_EXCHANGE[exchange];
+  if (!suffix) return upper;
+  if (upper.endsWith(suffix)) return upper;
+  // Strip any other suffix the user may have typed in (e.g. ASX entered as .AX
+  // when exchange is already ASX → already fine; but tolerate ASX entered as
+  // bare without the suffix).
+  return `${upper}${suffix}`;
+}
+
+/**
+ * Fetch a current equity price from Yahoo Finance via the
+ * `yahoo-finance2` library. Lazy-imported so the dep doesn't pollute
+ * the bundle of routes that don't read prices.
+ */
+export async function fetchEquityPrice(
+  ticker: string,
+  exchange: string,
+): Promise<PriceQuote | null> {
+  const symbol = toYahooSymbol(ticker, exchange);
+  try {
+    const yfMod = await import("yahoo-finance2").catch(() => null);
+    if (!yfMod) {
+      log.debug("yahoo-finance2 not installed in this build");
+      return null;
+    }
+    const yf = (yfMod as { default?: unknown }).default ?? yfMod;
+    // yahoo-finance2 default export is a class instance with a `quote` method.
+    const quoteFn = (yf as { quote?: (s: string, opts?: unknown) => Promise<unknown> }).quote;
+    if (typeof quoteFn !== "function") {
+      log.warn("yahoo-finance2 quote not a function — library shape changed?");
+      return null;
+    }
+    const quote = await Promise.race([
+      quoteFn.call(yf, symbol),
+      timeoutPromise<unknown>("yahoo timeout"),
+    ]);
+    const q = quote as Record<string, unknown> | null;
+    if (!q) return null;
+    const priceRaw = q.regularMarketPrice ?? q.postMarketPrice ?? q.preMarketPrice;
+    const currency = (q.currency as string) || (q.financialCurrency as string) || "USD";
+    if (typeof priceRaw !== "number" || !isFinite(priceRaw) || priceRaw < 0) return null;
+    return {
+      priceCents: Math.round(priceRaw * 100),
+      currency: currency.toUpperCase().slice(0, 3),
+      source: "yahoo",
+    };
+  } catch (err) {
+    log.debug("yahoo fetch failed", { symbol, err: errMsg(err) });
+    return null;
+  }
+}
+
+/**
+ * Fetch a crypto spot price from CoinGecko free API in AUD.
+ * Tickers stored as 'BTC' or 'BTC-AUD' both resolve. We map common
+ * symbols to CoinGecko ids; unknown symbols return null.
+ */
+export async function fetchCryptoPrice(ticker: string): Promise<PriceQuote | null> {
+  const symbol = ticker.trim().toUpperCase().replace(/-AUD$/, "");
+  const id = COINGECKO_IDS[symbol];
+  if (!id) {
+    log.debug("coingecko id not mapped", { symbol });
+    return null;
+  }
+  try {
+    const url = `https://api.coingecko.com/api/v3/simple/price?ids=${id}&vs_currencies=aud`;
+    const res = await Promise.race([
+      fetch(url, { headers: { accept: "application/json" } }),
+      timeoutPromise<Response>("coingecko timeout"),
+    ]);
+    if (!res.ok) {
+      log.debug("coingecko non-ok", { id, status: res.status });
+      return null;
+    }
+    const body = (await res.json()) as Record<string, { aud?: number }>;
+    const priceAud = body[id]?.aud;
+    if (typeof priceAud !== "number" || !isFinite(priceAud) || priceAud <= 0) return null;
+    return {
+      priceCents: Math.round(priceAud * 100),
+      currency: "AUD",
+      source: "coingecko",
+    };
+  } catch (err) {
+    log.debug("coingecko fetch failed", { symbol, err: errMsg(err) });
+    return null;
+  }
+}
+
+/**
+ * Top-level dispatcher. Routes by exchange to the correct fetcher.
+ */
+export async function fetchPriceForHolding(
+  ticker: string,
+  exchange: string,
+): Promise<PriceQuote | null> {
+  if (exchange === "CRYPTO") return fetchCryptoPrice(ticker);
+  return fetchEquityPrice(ticker, exchange);
+}
+
+// ─── Internals ──────────────────────────────────────────────────────────────
+
+function timeoutPromise<T>(label: string): Promise<T> {
+  return new Promise((_, reject) => {
+    setTimeout(() => reject(new Error(label)), FETCH_TIMEOUT_MS);
+  });
+}
+
+function errMsg(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+// CoinGecko id mapping for the most common AU-investor tickers. Any
+// missing symbol returns null from fetchCryptoPrice — UI renders "—".
+// Extend this map as we see real holdings come in.
+const COINGECKO_IDS: Record<string, string> = {
+  BTC: "bitcoin",
+  ETH: "ethereum",
+  SOL: "solana",
+  XRP: "ripple",
+  ADA: "cardano",
+  DOGE: "dogecoin",
+  DOT: "polkadot",
+  LINK: "chainlink",
+  MATIC: "matic-network",
+  AVAX: "avalanche-2",
+  LTC: "litecoin",
+  BCH: "bitcoin-cash",
+  USDC: "usd-coin",
+  USDT: "tether",
+  BNB: "binancecoin",
+  ATOM: "cosmos",
+  ALGO: "algorand",
+  XLM: "stellar",
+  NEAR: "near",
+  TRX: "tron",
+};

--- a/lib/holdings/value.ts
+++ b/lib/holdings/value.ts
@@ -1,0 +1,186 @@
+/**
+ * Cached current-price reader for /account/holdings.
+ *
+ * Read path:
+ *   1. Look up `holdings_price_cache` for the (ticker, exchange) pair.
+ *   2. If row exists AND fetched_at < TTL → return cached price.
+ *   3. Otherwise fetch from upstream:
+ *      - On success: upsert cache, return fresh price.
+ *      - On failure: if we have a row at all (even outside TTL), return
+ *        it marked source='stale'; otherwise return null.
+ *
+ * TTL by exchange:
+ *   - CRYPTO: 1 hour (more volatile than equities)
+ *   - everything else: 24 hours
+ *
+ * Rate-limit hygiene:
+ *   - last_attempt_at on the cache row prevents tight retry loops
+ *     on a chronically-failing upstream. We won't re-attempt a cold
+ *     fetch within 5 min of the last attempt.
+ *   - Stale fallback caps at 7 days — anything older returns null,
+ *     because a week-old equity price is worse than no price.
+ *
+ * No anon access (table is service-role only). Always called from
+ * server contexts that hold the admin client.
+ */
+
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+import {
+  fetchPriceForHolding,
+  type PriceQuote,
+} from "./value-source";
+
+const log = logger("holdings:value");
+
+const TTL_MS_EQUITY = 24 * 60 * 60 * 1000;     // 24 hours
+const TTL_MS_CRYPTO = 60 * 60 * 1000;          // 1 hour
+const ATTEMPT_THROTTLE_MS = 5 * 60 * 1000;     // 5 min between cold retries
+const STALE_FALLBACK_MAX_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+export interface CurrentValue {
+  priceCents: number;
+  currency: string;
+  source: "yahoo" | "coingecko" | "stale";
+  fetchedAt: string; // ISO; for the UI's "as of <time ago>" label
+}
+
+function ttlForExchange(exchange: string): number {
+  return exchange === "CRYPTO" ? TTL_MS_CRYPTO : TTL_MS_EQUITY;
+}
+
+export async function getCurrentPrice(
+  ticker: string,
+  exchange: string,
+): Promise<CurrentValue | null> {
+  const supabase = createAdminClient();
+  const ttl = ttlForExchange(exchange);
+  const now = new Date();
+  const nowMs = now.getTime();
+
+  // 1. Look up cache.
+  const { data: cached, error: cacheErr } = await supabase
+    .from("holdings_price_cache")
+    .select("price_cents, currency, source, fetched_at, last_attempt_at")
+    .eq("ticker", ticker)
+    .eq("exchange", exchange)
+    .maybeSingle();
+
+  if (cacheErr) {
+    log.warn("cache read failed", { ticker, exchange, error: cacheErr.message });
+  }
+
+  if (cached) {
+    const fetchedMs = new Date(cached.fetched_at as string).getTime();
+    if (nowMs - fetchedMs < ttl && (cached.source as string) !== "stale") {
+      return {
+        priceCents: Number(cached.price_cents),
+        currency: cached.currency as string,
+        source: cached.source as "yahoo" | "coingecko",
+        fetchedAt: cached.fetched_at as string,
+      };
+    }
+    // Outside TTL or marked stale — check if we just attempted (don't hammer).
+    const attemptMs = new Date(cached.last_attempt_at as string).getTime();
+    if (nowMs - attemptMs < ATTEMPT_THROTTLE_MS) {
+      // Recent attempt and still no fresh data → return stale.
+      return staleFallback(cached, nowMs);
+    }
+  }
+
+  // 2. Cold or expired — fetch upstream.
+  const quote = await fetchPriceForHolding(ticker, exchange);
+
+  if (quote) {
+    await upsertCache(ticker, exchange, quote, now);
+    return {
+      priceCents: quote.priceCents,
+      currency: quote.currency,
+      source: quote.source,
+      fetchedAt: now.toISOString(),
+    };
+  }
+
+  // 3. Upstream failed — record the attempt + return stale if available.
+  if (cached) {
+    await markAttempt(ticker, exchange, now);
+    return staleFallback(cached, nowMs);
+  }
+  return null;
+}
+
+/**
+ * Batch helper — looks up many holdings in parallel. The page uses this
+ * to avoid serial DB hits on render.
+ */
+export async function getCurrentPricesBatch(
+  pairs: ReadonlyArray<{ ticker: string; exchange: string }>,
+): Promise<Map<string, CurrentValue | null>> {
+  const out = new Map<string, CurrentValue | null>();
+  await Promise.all(
+    pairs.map(async (p) => {
+      const v = await getCurrentPrice(p.ticker, p.exchange);
+      out.set(keyOf(p.ticker, p.exchange), v);
+    }),
+  );
+  return out;
+}
+
+export function keyOf(ticker: string, exchange: string): string {
+  return `${exchange}:${ticker.toUpperCase()}`;
+}
+
+// ─── Internals ──────────────────────────────────────────────────────────────
+
+function staleFallback(
+  cached: {
+    price_cents: number | string;
+    currency: string;
+    fetched_at: string;
+  },
+  nowMs: number,
+): CurrentValue | null {
+  const fetchedMs = new Date(cached.fetched_at).getTime();
+  if (nowMs - fetchedMs > STALE_FALLBACK_MAX_MS) return null;
+  return {
+    priceCents: Number(cached.price_cents),
+    currency: cached.currency,
+    source: "stale",
+    fetchedAt: cached.fetched_at,
+  };
+}
+
+async function upsertCache(
+  ticker: string,
+  exchange: string,
+  quote: PriceQuote,
+  now: Date,
+): Promise<void> {
+  const supabase = createAdminClient();
+  const { error } = await supabase
+    .from("holdings_price_cache")
+    .upsert(
+      {
+        ticker,
+        exchange,
+        price_cents: quote.priceCents,
+        currency: quote.currency,
+        source: quote.source,
+        fetched_at: now.toISOString(),
+        last_attempt_at: now.toISOString(),
+      },
+      { onConflict: "ticker,exchange" },
+    );
+  if (error) {
+    log.warn("cache upsert failed", { ticker, exchange, error: error.message });
+  }
+}
+
+async function markAttempt(ticker: string, exchange: string, now: Date): Promise<void> {
+  const supabase = createAdminClient();
+  await supabase
+    .from("holdings_price_cache")
+    .update({ last_attempt_at: now.toISOString() })
+    .eq("ticker", ticker)
+    .eq("exchange", exchange);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "posthog-node": "^5.33.2",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
-        "stripe": "^17.7.0"
+        "stripe": "^17.7.0",
+        "yahoo-finance2": "^3.14.0"
       },
       "devDependencies": {
         "@axe-core/playwright": "^4.11.3",
@@ -534,6 +535,46 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@deno/shim-deno": {
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@deno/shim-deno/-/shim-deno-0.18.2.tgz",
+      "integrity": "sha512-oQ0CVmOio63wlhwQF75zA4ioolPvOwAoK0yuzcS5bDC1JUvH3y1GS8xPh8EOpcoDQRU4FTG8OQfxhpR+c6DrzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deno/shim-deno-test": "^0.5.0",
+        "which": "^4.0.0"
+      }
+    },
+    "node_modules/@deno/shim-deno-test": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@deno/shim-deno-test/-/shim-deno-test-0.5.0.tgz",
+      "integrity": "sha512-4nMhecpGlPi0cSzT67L+Tm+GOJqvuk8gqHBziqcUQOarnuIax1z96/gJHCSIz2Z0zhxE6Rzwb3IZXPtFh51j+w==",
+      "license": "MIT"
+    },
+    "node_modules/@deno/shim-deno/node_modules/isexe": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
+      "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@deno/shim-deno/node_modules/which": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -6877,6 +6918,16 @@
         }
       }
     },
+    "node_modules/fetch-mock-cache": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/fetch-mock-cache/-/fetch-mock-cache-2.3.1.tgz",
+      "integrity": "sha512-hDk+Nbt0Y8Aq7KTEU6ASQAcpB34UjhkpD3QjzD6yvEKP4xVElAqXrjQ7maL+LYMGafx51Zq6qUfDM57PNu/qMw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "filenamify-url": "2.1.2"
+      }
+    },
     "node_modules/fflate": {
       "version": "0.4.8",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
@@ -6892,6 +6943,48 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/filename-reserved-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
+      "integrity": "sha512-lc1bnsSr4L4Bdif8Xb/qrtokGbq5zlsms/CYH8PP+WtCkGNF65DPiQY8vG3SakEdRn8Dlnm+gW/qWKKjS5sZzQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/filenamify": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-4.3.0.tgz",
+      "integrity": "sha512-hcFKyUG57yWGAzu1CMt/dPzYZuv+jAJUT85bL8mrXvNe6hWj6yEHEc4EdcgiA6Z3oi1/9wXJdZPXF2dZNgwgOg==",
+      "license": "MIT",
+      "dependencies": {
+        "filename-reserved-regex": "^2.0.0",
+        "strip-outer": "^1.0.1",
+        "trim-repeated": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/filenamify-url": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/filenamify-url/-/filenamify-url-2.1.2.tgz",
+      "integrity": "sha512-3rMbAr7vDNMOGsj1aMniQFl749QjgM+lMJ/77ZRSPTIgxvolZwoQbn8dXLs7xfd+hAdli+oTnSWZNkJJLWQFEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "filenamify": "^4.3.0",
+        "humanize-url": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/fill-range": {
@@ -7347,6 +7440,18 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/humanize-url": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/humanize-url/-/humanize-url-2.1.1.tgz",
+      "integrity": "sha512-V4nxsPGNE7mPjr1qDp471YfW8nhBiTRWrG/4usZlpvFU8I7gsV7Jvrrzv/snbLm5dWO3dr1ennu2YqnhTWFmYA==",
+      "license": "MIT",
+      "dependencies": {
+        "normalize-url": "^4.5.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/husky": {
@@ -8016,6 +8121,12 @@
       "version": "3.0.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-to-ts": {
       "version": "3.1.1",
@@ -8870,6 +8981,15 @@
       "version": "2.0.36",
       "license": "MIT"
     },
+    "node_modules/normalize-url": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
+      "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "dev": true,
@@ -9459,9 +9579,20 @@
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
     },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -9484,6 +9615,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
       "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
+      "license": "MIT"
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
       "license": "MIT"
     },
     "node_modules/queue-microtask": {
@@ -9607,6 +9744,12 @@
       "engines": {
         "node": ">=9.3.0 || >=8.10.0 <9.0.0"
       }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.8",
@@ -10367,6 +10510,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/strip-outer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
+      "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-outer/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/stripe": {
       "version": "17.7.0",
       "license": "MIT",
@@ -10605,6 +10769,33 @@
         "node": ">=16"
       }
     },
+    "node_modules/tough-cookie-file-store": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie-file-store/-/tough-cookie-file-store-2.0.3.tgz",
+      "integrity": "sha512-sMpZVcmFf6EYFHFFl+SYH4W1/OnXBYMGDsv2IlbQ2caHyFElW/UR/gpj/KYU1JwmP4dE9xqwv2+vWcmlXHojSw==",
+      "license": "MIT",
+      "dependencies": {
+        "tough-cookie": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie-file-store/node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/tr46": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
@@ -10616,6 +10807,27 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/trim-repeated": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+      "integrity": "sha512-pkonvlKk8/ZuR0D5tLW8ljt5I8kmxp2XKymhepUeOdCEfKpZaktSArkLHZt76OB1ZvO9bssUsDty4SWhLvZpLg==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/trim-repeated/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/ts-algebra": {
@@ -10814,6 +11026,15 @@
       "version": "6.21.0",
       "license": "MIT"
     },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",
       "dev": true,
@@ -10881,6 +11102,16 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -11459,6 +11690,55 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4"
+      }
+    },
+    "node_modules/yahoo-finance2": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/yahoo-finance2/-/yahoo-finance2-3.14.0.tgz",
+      "integrity": "sha512-gsT/tqgeizKtMxbIIWFiFyuhM/6MZE4yEyNLmPekr88AX14JL2HWw0/QNMOR081jVtzTjihqDW0zV7IayH1Wcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@deno/shim-deno": "~0.18.0",
+        "fetch-mock-cache": "npm:fetch-mock-cache@^2.1.3",
+        "json-schema": "^0.4.0",
+        "tough-cookie": "npm:tough-cookie@^5.1.1",
+        "tough-cookie-file-store": "npm:tough-cookie-file-store@^2.0.3"
+      },
+      "bin": {
+        "yahoo-finance": "esm/bin/yahoo-finance.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/yahoo-finance2/node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/yahoo-finance2/node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "license": "MIT"
+    },
+    "node_modules/yahoo-finance2/node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "posthog-node": "^5.33.2",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
-    "stripe": "^17.7.0"
+    "stripe": "^17.7.0",
+    "yahoo-finance2": "^3.14.0"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.3",

--- a/supabase/migrations/20260510160000_holdings_price_cache.sql
+++ b/supabase/migrations/20260510160000_holdings_price_cache.sql
@@ -1,0 +1,53 @@
+-- ============================================================================
+-- Migration: 20260510160000_holdings_price_cache.sql
+-- Purpose: Server-side cache for current market prices used by the
+--          /account/holdings gain/loss display (W2 Phase 1 follow-up).
+--          Caches Yahoo Finance + CoinGecko responses to stay under
+--          free-tier rate limits even with high traffic.
+-- Audit ref: docs/plans/investor-account-end-to-end-plan.md PR-X5c
+-- Risk: low — additive table; deny-all-anon (server-only reads via
+--       service-role); no user-data tied; safe to wipe.
+-- Rollback: DROP TABLE IF EXISTS public.holdings_price_cache;
+--           Cache rebuilds itself on demand from upstream.
+-- ============================================================================
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.holdings_price_cache (
+  id              bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  ticker          text   NOT NULL CHECK (length(ticker) > 0 AND length(ticker) <= 30),
+  exchange        text   NOT NULL CHECK (exchange IN (
+                    'ASX','NASDAQ','NYSE','LSE','HKEX','SGX','TYO','KRX','CRYPTO','OTHER'
+                  )),
+  -- Price stored in minor units (cents for fiat, satoshi-equiv for crypto?)
+  -- → use cents for everything. CoinGecko returns AUD price for crypto;
+  --   we multiply by 100 and round.
+  price_cents     bigint NOT NULL CHECK (price_cents >= 0),
+  currency        text   NOT NULL CHECK (length(currency) = 3),  -- 'AUD','USD','GBP', etc.
+  source          text   NOT NULL CHECK (source IN ('yahoo','coingecko','manual','stale')),
+  fetched_at      timestamptz NOT NULL DEFAULT now(),
+  -- An attempt at a fresh fetch that returned no data still updates this row
+  -- with the previous price marked source='stale' so the UI can render a
+  -- footnote ("price last updated N hours ago"). last_attempt_at lets us
+  -- avoid hammering an upstream that just rate-limited us.
+  last_attempt_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (ticker, exchange)
+);
+
+CREATE INDEX IF NOT EXISTS idx_holdings_price_cache_lookup
+  ON public.holdings_price_cache (ticker, exchange);
+
+ALTER TABLE public.holdings_price_cache ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.holdings_price_cache FORCE ROW LEVEL SECURITY;
+
+-- No anon / authenticated SELECT policy → deny-all by default. The cache
+-- is a server-side concern; users get prices via the holdings page which
+-- reads through service_role.
+DROP POLICY IF EXISTS "service_role full access holdings_price_cache" ON public.holdings_price_cache;
+CREATE POLICY "service_role full access holdings_price_cache"
+  ON public.holdings_price_cache FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+COMMIT;


### PR DESCRIPTION
## Summary
Adds live current-price + gain/loss to /account/holdings. Closes the loop on the holdings tracker shipped in PR #721 — turns it from "what I bought" into "what's it worth today."

## Tier
B — additive cache table + new lib + page edit. RLS isolation gate covers the new table (deny-all-anon, service-role only). No auth surface changes.

## What changed
- \`supabase/migrations/20260510160000_holdings_price_cache.sql\` — \`holdings_price_cache\` table (applied to live via MCP)
- \`lib/holdings/value-source.ts\` — Yahoo Finance (yahoo-finance2 lazy-import) + CoinGecko free API; ticker normalisation (.AX/.L/.HK/.SI/.T/.KS); 4s timeout; 20-symbol CoinGecko id map
- \`lib/holdings/value.ts\` — cached fetcher: 24h TTL (equity) / 1h (crypto); 7d stale fallback on upstream fail; 5min attempt-throttle to prevent tight retry loops
- \`app/account/holdings/page.tsx\` — fetches prices in parallel for each holding
- \`HoldingsClient.tsx\` — third totals card (current value + gain/loss); per-row gain/loss column; "stale price" badge; clean "—" for unpriced rows
- 15 vitest tests (8 cache logic + 7 ticker normalisation), all green

## Failure modes (documented in code)
- Yahoo rate-limits → cache absorbs most reads + 7d stale fallback + 5min throttle
- Delisted tickers → render "—" gracefully
- Mixed AUD/USD portfolios → show value in source currency, skip delta (cost in AUD, value in USD = false comparison)
- yahoo-finance2 unavailable → fetcher returns null, cache covers most reads anyway

## Compliance
Pure factual price display. Same legal footing as /best/[slug] broker rankings — no advice, no recommendation.

## Supersedes
_None._

## Test plan
- [x] 15/15 vitest local green (cache hit/miss/stale-fallback/throttle + ticker normalisation)
- [x] Type-check clean
- [ ] CI green
- [ ] Tier B 15-min observation post-merge
- [ ] Manual: log in to /account/holdings, add a holding (e.g. BHP/ASX), reload, verify current-price column populates within ~4s; verify totals card shows portfolio gain/loss