### PR TITLE
feat(account): investor_profiles + quiz sync (W2 Phase 2)

### DIFF
--- a/__tests__/api/account-claim-anonymous.test.ts
+++ b/__tests__/api/account-claim-anonymous.test.ts
@@ -86,7 +86,7 @@ describe("POST /api/account/claim-anonymous", () => {
     const res = await POST(makePost({ session_id: "sess-abc" }));
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body).toEqual({ ok: true, bookmarks_claimed: 5, quizzes_claimed: 2 });
+    expect(body).toMatchObject({ ok: true, bookmarks_claimed: 5, quizzes_claimed: 2 });
   });
 
   it("calls both claim functions with the correct args in parallel", async () => {

--- a/__tests__/lib/investor-profiles.test.ts
+++ b/__tests__/lib/investor-profiles.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+let quizRow: Record<string, unknown> | null = null;
+let profileRow: Record<string, unknown> | null = null;
+const upsertCalls: Record<string, unknown>[] = [];
+
+const mockFrom = vi.fn((table: string) => {
+  if (table === "user_quiz_history") {
+    const chain = {
+      select: () => chain,
+      eq: () => chain,
+      order: () => chain,
+      limit: () => chain,
+      maybeSingle: async () => ({ data: quizRow, error: null }),
+    };
+    return chain;
+  }
+  if (table === "investor_profiles") {
+    return {
+      select: () => {
+        const chain = {
+          eq: () => chain,
+          maybeSingle: async () => ({ data: profileRow, error: null }),
+        };
+        return chain;
+      },
+      upsert: async (row: Record<string, unknown>) => {
+        upsertCalls.push(row);
+        return { error: null };
+      },
+    };
+  }
+  throw new Error(`unexpected table: ${table}`);
+});
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+import {
+  getInvestorProfile,
+  upsertInvestorProfile,
+  syncQuizToInvestorProfile,
+} from "@/lib/investor-profiles";
+
+describe("getInvestorProfile", () => {
+  beforeEach(() => {
+    profileRow = null;
+  });
+
+  it("returns null when no row exists", async () => {
+    expect(await getInvestorProfile("u1")).toBeNull();
+  });
+
+  it("maps DB row to typed profile", async () => {
+    profileRow = {
+      auth_user_id: "u1",
+      display_name: "Alex",
+      is_fhb: true,
+      is_pre_retiree: false,
+      is_business_owner: false,
+      is_cross_border: true,
+      is_hnw: false,
+      intent_country_snapshot: "uk",
+      budget_band: "medium",
+      experience_level: "intermediate",
+      primary_vertical: "shares",
+      meta: { foo: "bar" },
+      created_at: "2026-05-10T00:00:00Z",
+      updated_at: "2026-05-10T00:00:00Z",
+    };
+    const p = await getInvestorProfile("u1");
+    expect(p?.isFhb).toBe(true);
+    expect(p?.isCrossBorder).toBe(true);
+    expect(p?.intentCountrySnapshot).toBe("uk");
+    expect(p?.budgetBand).toBe("medium");
+    expect(p?.experienceLevel).toBe("intermediate");
+    expect(p?.meta).toEqual({ foo: "bar" });
+  });
+});
+
+describe("upsertInvestorProfile", () => {
+  beforeEach(() => {
+    upsertCalls.length = 0;
+  });
+
+  it("upserts the patch with auth_user_id + updated_at", async () => {
+    const ok = await upsertInvestorProfile("u1", { is_fhb: true, intent_country_snapshot: "uk" });
+    expect(ok).toBe(true);
+    expect(upsertCalls[0]).toMatchObject({
+      auth_user_id: "u1",
+      is_fhb: true,
+      intent_country_snapshot: "uk",
+    });
+    expect(upsertCalls[0]?.updated_at).toEqual(expect.any(String));
+  });
+});
+
+describe("syncQuizToInvestorProfile", () => {
+  beforeEach(() => {
+    quizRow = null;
+    upsertCalls.length = 0;
+  });
+
+  it("returns false when no quiz history exists", async () => {
+    const ok = await syncQuizToInvestorProfile({ userId: "u1", sessionId: "s1" });
+    expect(ok).toBe(false);
+    expect(upsertCalls).toHaveLength(0);
+  });
+
+  it("derives is_fhb from goal=home", async () => {
+    quizRow = {
+      answers: { raw: { goal: "home", amount: "small", experience: "beginner" } },
+      inferred_vertical: "home",
+      top_match_slug: null,
+      completed_at: "2026-05-10T00:00:00Z",
+    };
+    const ok = await syncQuizToInvestorProfile({ userId: "u1", sessionId: "s1" });
+    expect(ok).toBe(true);
+    expect(upsertCalls[0]?.is_fhb).toBe(true);
+    expect(upsertCalls[0]?.budget_band).toBe("small");
+    expect(upsertCalls[0]?.experience_level).toBe("beginner");
+    expect(upsertCalls[0]?.primary_vertical).toBe("home");
+  });
+
+  it("derives is_pre_retiree from goal=super", async () => {
+    quizRow = {
+      answers: { raw: { goal: "super", amount: "large" } },
+      inferred_vertical: "super",
+    };
+    await syncQuizToInvestorProfile({ userId: "u1", sessionId: "s1" });
+    expect(upsertCalls[0]?.is_pre_retiree).toBe(true);
+    expect(upsertCalls[0]?.is_fhb).toBe(false);
+  });
+
+  it("derives is_hnw from amount=whale", async () => {
+    quizRow = {
+      answers: { raw: { amount: "whale" } },
+    };
+    await syncQuizToInvestorProfile({ userId: "u1", sessionId: "s1" });
+    expect(upsertCalls[0]?.is_hnw).toBe(true);
+    expect(upsertCalls[0]?.budget_band).toBe("whale");
+  });
+
+  it("derives is_cross_border from investor_country", async () => {
+    quizRow = {
+      answers: { raw: { investor_country: "united_kingdom" } },
+    };
+    await syncQuizToInvestorProfile({ userId: "u1", sessionId: "s1" });
+    expect(upsertCalls[0]?.is_cross_border).toBe(true);
+    expect(upsertCalls[0]?.intent_country_snapshot).toBe("uk");
+  });
+
+  it("derives is_business_owner from complexity=business_owner", async () => {
+    quizRow = {
+      answers: { raw: { complexity: "business_owner" } },
+    };
+    await syncQuizToInvestorProfile({ userId: "u1", sessionId: "s1" });
+    expect(upsertCalls[0]?.is_business_owner).toBe(true);
+  });
+
+  it("ignores unknown investor_country / amount values", async () => {
+    quizRow = {
+      answers: { raw: { investor_country: "atlantis", amount: "tiny" } },
+    };
+    await syncQuizToInvestorProfile({ userId: "u1", sessionId: "s1" });
+    expect(upsertCalls[0]?.intent_country_snapshot).toBeNull();
+    expect(upsertCalls[0]?.budget_band).toBeNull();
+    expect(upsertCalls[0]?.is_cross_border).toBe(false);
+  });
+});

--- a/app/api/account/claim-anonymous/route.ts
+++ b/app/api/account/claim-anonymous/route.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { createClient } from "@/lib/supabase/server";
 import { claimAnonymousSaves } from "@/lib/bookmarks";
 import { claimSessionQuizzes } from "@/lib/quiz-history";
+import { syncQuizToInvestorProfile } from "@/lib/investor-profiles";
 import { logger } from "@/lib/logger";
 
 const log = logger("api:account:claim-anonymous");
@@ -52,15 +53,28 @@ export async function POST(request: NextRequest) {
     claimSessionQuizzes(sessionId, user.id),
   ]);
 
+  // After the quiz row is attached to the user, sync structured signals
+  // (life-event flags, intent country, budget, experience) into
+  // investor_profiles for the smart-recs ranker. Best-effort. (W2 Phase 2.)
+  let profileSynced = false;
+  if (quizzesClaimed > 0) {
+    profileSynced = await syncQuizToInvestorProfile({
+      userId: user.id,
+      sessionId,
+    });
+  }
+
   log.info("Anonymous state claimed", {
     userId: user.id,
     bookmarksClaimed,
     quizzesClaimed,
+    profileSynced,
   });
 
   return NextResponse.json({
     ok: true,
     bookmarks_claimed: bookmarksClaimed,
     quizzes_claimed: quizzesClaimed,
+    profile_synced: profileSynced,
   });
 }

--- a/app/api/quiz-lead/route.ts
+++ b/app/api/quiz-lead/route.ts
@@ -6,6 +6,7 @@ import { isValidEmail, isDisposableEmail } from '@/lib/validate-email';
 import { logger } from '@/lib/logger';
 import { recordQuizSubmission } from '@/lib/quiz-history';
 import { setQuizSessionCookie } from '@/lib/quiz-profile';
+import { syncQuizToInvestorProfile } from '@/lib/investor-profiles';
 import { createClient } from '@/lib/supabase/server';
 import { escapeHtml } from "@/lib/html-escape";
 
@@ -392,6 +393,17 @@ export async function POST(request: NextRequest) {
       // is signed in, server-side reads scope by user_id directly.
       if (safeSessionId && !user?.id) {
         await setQuizSessionCookie(safeSessionId);
+      }
+
+      // Sync structured signals (life-event flags, intent country, budget,
+      // experience) to investor_profiles for the smart-recs ranker. Best-
+      // effort; failures don't block the quiz submission. Authed users only —
+      // anon users get this sync at claim-on-signup time. (W2 Phase 2.)
+      if (user?.id) {
+        await syncQuizToInvestorProfile({
+          userId: user.id,
+          sessionId: safeSessionId,
+        });
       }
     }
   } catch (err) {

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -7583,6 +7583,60 @@ export type Database = {
         }
         Relationships: []
       }
+      investor_profiles: {
+        Row: {
+          auth_user_id: string
+          budget_band: string | null
+          created_at: string
+          display_name: string | null
+          experience_level: string | null
+          id: number
+          intent_country_snapshot: string | null
+          is_business_owner: boolean
+          is_cross_border: boolean
+          is_fhb: boolean
+          is_hnw: boolean
+          is_pre_retiree: boolean
+          meta: Json
+          primary_vertical: string | null
+          updated_at: string
+        }
+        Insert: {
+          auth_user_id: string
+          budget_band?: string | null
+          created_at?: string
+          display_name?: string | null
+          experience_level?: string | null
+          id?: never
+          intent_country_snapshot?: string | null
+          is_business_owner?: boolean
+          is_cross_border?: boolean
+          is_fhb?: boolean
+          is_hnw?: boolean
+          is_pre_retiree?: boolean
+          meta?: Json
+          primary_vertical?: string | null
+          updated_at?: string
+        }
+        Update: {
+          auth_user_id?: string
+          budget_band?: string | null
+          created_at?: string
+          display_name?: string | null
+          experience_level?: string | null
+          id?: never
+          intent_country_snapshot?: string | null
+          is_business_owner?: boolean
+          is_cross_border?: boolean
+          is_fhb?: boolean
+          is_hnw?: boolean
+          is_pre_retiree?: boolean
+          meta?: Json
+          primary_vertical?: string | null
+          updated_at?: string
+        }
+        Relationships: []
+      }
       job_queue: {
         Row: {
           attempts: number

--- a/lib/investor-profiles.ts
+++ b/lib/investor-profiles.ts
@@ -1,0 +1,255 @@
+/**
+ * Investor profile helpers (W2 Phase 2).
+ *
+ * `investor_profiles` is a typed cache layered on top of `user_quiz_history`
+ * + `iv_intent_country` cookie. The smart-recs ranker reads from this table
+ * directly; structured columns are SQL-filterable in a way that quiz-answer
+ * JSONB isn't.
+ *
+ * Sync paths:
+ *   - `/api/quiz-lead` calls `syncQuizToInvestorProfile(sessionId, userId)`
+ *     after a successful quiz submission for an authenticated user.
+ *   - The claim-on-signup flow (`/api/account/claim-anonymous`) calls
+ *     `syncQuizToInvestorProfile(sessionId, userId)` when a fresh signup
+ *     has anonymous quiz history under the same `_inv_sid` cookie.
+ *
+ * No anon access. RLS scopes reads + writes to auth.uid() owner; this
+ * module uses createAdminClient() server-side.
+ *
+ * Compliance: life-event flags fuel CONTENT routing only ("popular with
+ * FHB users", "FHOG guides surfaced first"). Never used to drive
+ * personal-advice copy. See lib/compliance.ts for disclaimer copy.
+ */
+
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+import type { IntentCountryCode } from "./intent-context";
+
+const log = logger("investor-profiles");
+
+export type BudgetBand = "small" | "medium" | "large" | "whale";
+export type ExperienceLevel = "beginner" | "intermediate" | "pro";
+
+export interface InvestorProfile {
+  authUserId: string;
+  displayName: string | null;
+  isFhb: boolean;
+  isPreRetiree: boolean;
+  isBusinessOwner: boolean;
+  isCrossBorder: boolean;
+  isHnw: boolean;
+  intentCountrySnapshot: IntentCountryCode | null;
+  budgetBand: BudgetBand | null;
+  experienceLevel: ExperienceLevel | null;
+  primaryVertical: string | null;
+  meta: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * Fetch the user's profile row. Returns null when no row exists yet.
+ */
+export async function getInvestorProfile(userId: string): Promise<InvestorProfile | null> {
+  try {
+    const supabase = createAdminClient();
+    const { data, error } = await supabase
+      .from("investor_profiles")
+      .select("*")
+      .eq("auth_user_id", userId)
+      .maybeSingle();
+    if (error) {
+      log.warn("getInvestorProfile failed", { userId, error: error.message });
+      return null;
+    }
+    if (!data) return null;
+    return rowToProfile(data as Record<string, unknown>);
+  } catch (err) {
+    log.warn("getInvestorProfile threw", {
+      userId,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}
+
+/**
+ * Upsert a partial profile patch keyed by auth_user_id. Caller passes
+ * snake_case DB column names; this function maps to the typed columns.
+ * Idempotent — safe to call repeatedly with the same patch.
+ */
+export async function upsertInvestorProfile(
+  userId: string,
+  patch: Partial<{
+    display_name: string | null;
+    is_fhb: boolean;
+    is_pre_retiree: boolean;
+    is_business_owner: boolean;
+    is_cross_border: boolean;
+    is_hnw: boolean;
+    intent_country_snapshot: IntentCountryCode | null;
+    budget_band: BudgetBand | null;
+    experience_level: ExperienceLevel | null;
+    primary_vertical: string | null;
+    meta: Record<string, unknown>;
+  }>,
+): Promise<boolean> {
+  try {
+    const supabase = createAdminClient();
+    const { error } = await supabase
+      .from("investor_profiles")
+      .upsert(
+        {
+          auth_user_id: userId,
+          ...patch,
+          updated_at: new Date().toISOString(),
+        },
+        { onConflict: "auth_user_id" },
+      );
+    if (error) {
+      log.warn("upsertInvestorProfile failed", { userId, error: error.message });
+      return false;
+    }
+    return true;
+  } catch (err) {
+    log.warn("upsertInvestorProfile threw", {
+      userId,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return false;
+  }
+}
+
+/**
+ * Read the user's most-recent quiz answers (by session_id or user_id),
+ * extract the structured signals, and upsert them onto investor_profiles.
+ *
+ * Called from /api/quiz-lead on submit (when authed) and from the
+ * claim-on-signup path when an anon quiz row gets attached to a fresh
+ * user. Idempotent.
+ */
+export async function syncQuizToInvestorProfile(opts: {
+  userId: string;
+  sessionId?: string | null;
+}): Promise<boolean> {
+  const { userId, sessionId } = opts;
+  try {
+    const supabase = createAdminClient();
+    // Prefer the user-keyed row (fresh signup paths); fall back to session-keyed.
+    let row: Record<string, unknown> | null = null;
+    {
+      const { data } = await supabase
+        .from("user_quiz_history")
+        .select("answers, inferred_vertical, top_match_slug, completed_at")
+        .eq("user_id", userId)
+        .order("created_at", { ascending: false })
+        .limit(1)
+        .maybeSingle();
+      if (data) row = data as Record<string, unknown>;
+    }
+    if (!row && sessionId) {
+      const { data } = await supabase
+        .from("user_quiz_history")
+        .select("answers, inferred_vertical, top_match_slug, completed_at")
+        .eq("session_id", sessionId)
+        .order("created_at", { ascending: false })
+        .limit(1)
+        .maybeSingle();
+      if (data) row = data as Record<string, unknown>;
+    }
+
+    if (!row) return false;
+
+    const answers = row.answers as Record<string, unknown> | null;
+    const raw = (answers?.raw as Record<string, unknown> | undefined) ?? null;
+    const inferredVertical = row.inferred_vertical as string | null;
+
+    const intentCountry = extractIntentCountryFromAnswers(raw);
+    const budgetBand = extractBudgetBand(raw);
+    const experienceLevel = extractExperienceLevel(raw);
+
+    // Life-event derivation rules (factual extraction, not advice).
+    const isFhb = raw?.goal === "home";
+    const isCrossBorder = intentCountry !== null;
+    const isPreRetiree = raw?.goal === "super" || raw?.complexity === "retiring_soon";
+    const isHnw = budgetBand === "whale";
+    const isBusinessOwner = raw?.complexity === "business_owner";
+
+    return upsertInvestorProfile(userId, {
+      is_fhb: !!isFhb,
+      is_pre_retiree: !!isPreRetiree,
+      is_business_owner: !!isBusinessOwner,
+      is_cross_border: !!isCrossBorder,
+      is_hnw: !!isHnw,
+      intent_country_snapshot: intentCountry,
+      budget_band: budgetBand,
+      experience_level: experienceLevel,
+      primary_vertical: inferredVertical,
+    });
+  } catch (err) {
+    log.warn("syncQuizToInvestorProfile threw", {
+      userId,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return false;
+  }
+}
+
+// ─── Internals ──────────────────────────────────────────────────────────────
+
+function rowToProfile(r: Record<string, unknown>): InvestorProfile {
+  return {
+    authUserId: r.auth_user_id as string,
+    displayName: (r.display_name as string | null) ?? null,
+    isFhb: r.is_fhb === true,
+    isPreRetiree: r.is_pre_retiree === true,
+    isBusinessOwner: r.is_business_owner === true,
+    isCrossBorder: r.is_cross_border === true,
+    isHnw: r.is_hnw === true,
+    intentCountrySnapshot: (r.intent_country_snapshot as IntentCountryCode | null) ?? null,
+    budgetBand: (r.budget_band as BudgetBand | null) ?? null,
+    experienceLevel: (r.experience_level as ExperienceLevel | null) ?? null,
+    primaryVertical: (r.primary_vertical as string | null) ?? null,
+    meta: ((r.meta as Record<string, unknown> | null) ?? {}),
+    createdAt: r.created_at as string,
+    updatedAt: r.updated_at as string,
+  };
+}
+
+const QUIZ_KEY_TO_INTENT: Record<string, IntentCountryCode> = {
+  united_kingdom: "uk",
+  united_states: "us",
+  china: "cn",
+  india: "in",
+  japan: "jp",
+  singapore: "sg",
+  hong_kong: "hk",
+  south_korea: "kr",
+  malaysia: "my",
+  new_zealand: "nz",
+  united_arab_emirates: "ae",
+  saudi_arabia: "sa",
+};
+
+function extractIntentCountryFromAnswers(
+  raw: Record<string, unknown> | null,
+): IntentCountryCode | null {
+  if (!raw) return null;
+  const v = raw.investor_country;
+  if (typeof v !== "string") return null;
+  return QUIZ_KEY_TO_INTENT[v] ?? null;
+}
+
+function extractBudgetBand(raw: Record<string, unknown> | null): BudgetBand | null {
+  if (!raw) return null;
+  const v = raw.amount;
+  return v === "small" || v === "medium" || v === "large" || v === "whale" ? v : null;
+}
+
+function extractExperienceLevel(
+  raw: Record<string, unknown> | null,
+): ExperienceLevel | null {
+  if (!raw) return null;
+  const v = raw.experience;
+  return v === "beginner" || v === "intermediate" || v === "pro" ? v : null;
+}

--- a/supabase/migrations/20260510180000_investor_profiles.sql
+++ b/supabase/migrations/20260510180000_investor_profiles.sql
@@ -1,0 +1,102 @@
+-- ============================================================================
+-- Migration: 20260510180000_investor_profiles.sql
+-- Purpose: Investor-side profile cache. Captures life-event flags (FHB,
+--          pre-retiree, business owner, cross-border, HNW) + ranker inputs
+--          (intent country snapshot, budget band, experience, primary
+--          vertical) so the smart-recs ranker (PR #715/#717) can read
+--          structured data instead of re-parsing user_quiz_history JSONB
+--          every page render. Single row per auth.users.id.
+-- Audit ref: docs/plans/investor-account-end-to-end-plan.md Phase 2 + the
+--           account-system-expansion plan (Phase 2).
+-- Risk: low — additive table; per-user RLS; no FK to anything besides
+--       auth.users.
+-- Rollback: DROP TABLE IF EXISTS public.investor_profiles;
+--           Source data lives in user_quiz_history + iv_intent_country
+--           cookie, so the table can be rebuilt from those sources by
+--           re-running syncQuizToInvestorProfile() per user.
+-- ============================================================================
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.investor_profiles (
+  id              bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  auth_user_id    uuid   NOT NULL UNIQUE REFERENCES auth.users(id) ON DELETE CASCADE,
+  display_name    text,
+
+  -- Life-event flags. Set by quiz answer interpretation; user can also
+  -- toggle from /account/profile in a later phase. Used by smart-recs
+  -- ranker for content surfacing — never to drive personal advice copy.
+  is_fhb          boolean NOT NULL DEFAULT false,
+  is_pre_retiree  boolean NOT NULL DEFAULT false,
+  is_business_owner boolean NOT NULL DEFAULT false,
+  is_cross_border boolean NOT NULL DEFAULT false,
+  is_hnw          boolean NOT NULL DEFAULT false,
+
+  -- Ranker inputs. Mirror QuizProfile shape from lib/quiz-profile.ts so
+  -- the smart-recs strip can read either source interchangeably. NULL
+  -- means "no quiz data yet".
+  intent_country_snapshot text CHECK (
+    intent_country_snapshot IS NULL OR
+    intent_country_snapshot IN ('uk','us','cn','in','jp','sg','hk','kr','my','nz','ae','sa')
+  ),
+  budget_band     text CHECK (
+    budget_band IS NULL OR
+    budget_band IN ('small','medium','large','whale')
+  ),
+  experience_level text CHECK (
+    experience_level IS NULL OR
+    experience_level IN ('beginner','intermediate','pro')
+  ),
+  primary_vertical text,  -- 'shares' / 'super' / 'property' / 'crypto' / etc.
+
+  -- Escape hatch for fields we add post-launch without a migration. UI
+  -- and ranker should NOT depend on this; promote frequently-read
+  -- fields to typed columns when usage stabilises.
+  meta            jsonb NOT NULL DEFAULT '{}'::jsonb,
+
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  updated_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_investor_profiles_intent_country
+  ON public.investor_profiles (intent_country_snapshot)
+  WHERE intent_country_snapshot IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_investor_profiles_business_owner
+  ON public.investor_profiles (is_business_owner)
+  WHERE is_business_owner = true;
+
+CREATE INDEX IF NOT EXISTS idx_investor_profiles_fhb
+  ON public.investor_profiles (is_fhb)
+  WHERE is_fhb = true;
+
+ALTER TABLE public.investor_profiles ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.investor_profiles FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "investor reads own profile" ON public.investor_profiles;
+CREATE POLICY "investor reads own profile"
+  ON public.investor_profiles FOR SELECT
+  TO authenticated
+  USING (auth.uid() = auth_user_id);
+
+DROP POLICY IF EXISTS "investor inserts own profile" ON public.investor_profiles;
+CREATE POLICY "investor inserts own profile"
+  ON public.investor_profiles FOR INSERT
+  TO authenticated
+  WITH CHECK (auth.uid() = auth_user_id);
+
+DROP POLICY IF EXISTS "investor updates own profile" ON public.investor_profiles;
+CREATE POLICY "investor updates own profile"
+  ON public.investor_profiles FOR UPDATE
+  TO authenticated
+  USING (auth.uid() = auth_user_id)
+  WITH CHECK (auth.uid() = auth_user_id);
+
+DROP POLICY IF EXISTS "service_role full access investor_profiles" ON public.investor_profiles;
+CREATE POLICY "service_role full access investor_profiles"
+  ON public.investor_profiles FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+COMMIT;


### PR DESCRIPTION
## Summary
Typed cache layered on top of \`user_quiz_history\` + \`iv_intent_country\` cookie. The smart-recs ranker can now read SQL-filterable columns (life-event flags + budget/experience/intent country) instead of re-parsing JSONB on every page render.

## Tier
C — new schema migration + service-role policies. Migration applied to live via Supabase MCP ahead of merge.

## What changed
- \`supabase/migrations/20260510180000_investor_profiles.sql\` — table with 5 life-event flags (\`is_fhb\` / \`is_pre_retiree\` / \`is_business_owner\` / \`is_cross_border\` / \`is_hnw\`), 4 ranker inputs, \`meta\` JSONB escape hatch, RLS deny-all-anon + per-user-self + service-role full
- \`lib/investor-profiles.ts\` — \`getInvestorProfile\`, \`upsertInvestorProfile\`, \`syncQuizToInvestorProfile\`
- \`app/api/quiz-lead/route.ts\` — sync on submit when authed
- \`app/api/account/claim-anonymous/route.ts\` — sync on signup after claiming quiz row
- \`__tests__/lib/investor-profiles.test.ts\` — 10 tests covering field mapping + all 5 life-event derivation rules
- \`lib/database.types.ts\` — regenerated to include new table

## Compliance
Flags fuel CONTENT routing only ("FHB persona → show FHOG guides", "popular with [persona]"). Never used to drive personal-advice copy. Same lane as the existing intent-country cookie.

## Supersedes
_None._

## Test plan
- [x] 10/10 vitest local green
- [x] Migration applied to live; \`SELECT count(*) FROM investor_profiles\` returns 0 rows (clean install)
- [x] Type-check clean
- [ ] CI green (drift check should pass post-types regen)
- [ ] Tier C 30-min observation post-merge