### PR TITLE
feat(account): workspace plumbing — account_kind_membership view + switcher (W2 Phase 2.5)

### DIFF
--- a/__tests__/lib/account-kinds.test.ts
+++ b/__tests__/lib/account-kinds.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import {
+  chooseCallbackRedirect,
+  isWorkspaceKind,
+  portalForKind,
+  type KindMembership,
+} from "@/lib/account-kinds";
+
+const m = (kind: KindMembership["kind"], extras: Partial<KindMembership> = {}): KindMembership => ({
+  authUserId: "u1",
+  kind,
+  kindId: "1",
+  status: "active",
+  displayLabel: "Test",
+  createdAt: "2026-05-10T00:00:00Z",
+  ...extras,
+});
+
+describe("isWorkspaceKind", () => {
+  it("accepts every active workspace kind", () => {
+    expect(isWorkspaceKind("investor")).toBe(true);
+    expect(isWorkspaceKind("advisor")).toBe(true);
+    expect(isWorkspaceKind("broker_partner")).toBe(true);
+    expect(isWorkspaceKind("business_owner")).toBe(true);
+    expect(isWorkspaceKind("listing_owner")).toBe(true);
+  });
+  it("rejects unknown values", () => {
+    expect(isWorkspaceKind("admin")).toBe(false);
+    expect(isWorkspaceKind("")).toBe(false);
+    expect(isWorkspaceKind("INVESTOR")).toBe(false); // case-sensitive
+  });
+});
+
+describe("portalForKind", () => {
+  it("maps each kind to its portal", () => {
+    expect(portalForKind("advisor")).toBe("/advisor-portal");
+    expect(portalForKind("broker_partner")).toBe("/broker-portal");
+    expect(portalForKind("business_owner")).toBe("/business-portal");
+    expect(portalForKind("listing_owner")).toBe("/invest/my-listings");
+    expect(portalForKind("investor")).toBe("/account");
+  });
+  it("respects fallback for investor kind only", () => {
+    expect(portalForKind("investor", "/custom")).toBe("/custom");
+    expect(portalForKind("advisor", "/custom")).toBe("/advisor-portal");
+  });
+});
+
+describe("chooseCallbackRedirect", () => {
+  it("0 kinds → fallback + lazy-investor cookie", () => {
+    const r = chooseCallbackRedirect([], "/account");
+    expect(r.redirect).toBe("/account");
+    expect(r.setKind).toBe("investor");
+  });
+
+  it("1 kind → that portal + matching cookie", () => {
+    const r = chooseCallbackRedirect([m("advisor")], "/account");
+    expect(r.redirect).toBe("/advisor-portal");
+    expect(r.setKind).toBe("advisor");
+  });
+
+  it("2+ kinds → chooser, no cookie set", () => {
+    const r = chooseCallbackRedirect([m("advisor"), m("investor")], "/account");
+    expect(r.redirect).toBe("/account/select-workspace");
+    expect(r.setKind).toBeNull();
+  });
+
+  it("respects fallbackNext for the 0-kind case", () => {
+    const r = chooseCallbackRedirect([], "/find-advisor");
+    expect(r.redirect).toBe("/find-advisor");
+  });
+
+  it("uses portalForKind for the 1-kind broker_partner case", () => {
+    const r = chooseCallbackRedirect([m("broker_partner")], "/account");
+    expect(r.redirect).toBe("/broker-portal");
+  });
+});

--- a/app/account/select-workspace/SelectWorkspaceClient.tsx
+++ b/app/account/select-workspace/SelectWorkspaceClient.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useState } from "react";
+import type { KindMembership, WorkspaceKind } from "@/lib/account-kinds";
+
+interface Props {
+  memberships: KindMembership[];
+}
+
+const KIND_META: Record<
+  WorkspaceKind,
+  { label: string; description: string; icon: string; tone: string }
+> = {
+  investor: {
+    label: "Investor",
+    description: "Track your holdings, save searches, watchlist brokers and advisors.",
+    icon: "📈",
+    tone: "bg-emerald-50 border-emerald-200 hover:border-emerald-400",
+  },
+  advisor: {
+    label: "Advisor",
+    description: "Your professional dashboard — leads, KPIs, billing, advisor profile.",
+    icon: "🧑‍💼",
+    tone: "bg-sky-50 border-sky-200 hover:border-sky-400",
+  },
+  broker_partner: {
+    label: "Broker partner",
+    description: "Marketplace partner dashboard — campaigns, attribution, billing.",
+    icon: "🏦",
+    tone: "bg-amber-50 border-amber-200 hover:border-amber-400",
+  },
+  business_owner: {
+    label: "Business owner",
+    description: "Track grants, R&D claims, sell-business prep.",
+    icon: "🏢",
+    tone: "bg-violet-50 border-violet-200 hover:border-violet-400",
+  },
+  listing_owner: {
+    label: "Listing owner",
+    description: "Manage your listings, view leads, renew expiring placements.",
+    icon: "🏷️",
+    tone: "bg-rose-50 border-rose-200 hover:border-rose-400",
+  },
+};
+
+export default function SelectWorkspaceClient({ memberships }: Props) {
+  const [selecting, setSelecting] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const choose = async (kind: WorkspaceKind) => {
+    setSelecting(kind);
+    setError(null);
+    try {
+      const res = await fetch("/api/account/active-kind", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ kind }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string; redirect?: string };
+        throw new Error(body.error ?? "Could not switch workspace.");
+      }
+      const body = (await res.json()) as { redirect: string };
+      window.location.href = body.redirect;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not switch workspace.");
+      setSelecting(null);
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      {memberships.map((m) => {
+        const meta = KIND_META[m.kind];
+        if (!meta) return null;
+        return (
+          <button
+            key={`${m.kind}-${m.kindId}`}
+            type="button"
+            onClick={() => void choose(m.kind)}
+            disabled={selecting !== null}
+            className={`w-full text-left border-2 ${meta.tone} rounded-xl p-5 transition-colors disabled:opacity-50`}
+          >
+            <div className="flex items-start gap-4">
+              <span className="text-3xl shrink-0" aria-hidden>{meta.icon}</span>
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center justify-between gap-2 flex-wrap">
+                  <h2 className="text-base font-semibold text-slate-900">{meta.label}</h2>
+                  <span className="text-xs px-2 py-0.5 bg-white/60 text-slate-700 rounded-full">
+                    {m.status}
+                  </span>
+                </div>
+                {m.displayLabel && m.displayLabel !== meta.label && (
+                  <p className="text-sm text-slate-700 font-medium mt-0.5">
+                    {m.displayLabel}
+                  </p>
+                )}
+                <p className="text-sm text-slate-600 mt-1">{meta.description}</p>
+                <p className="text-xs font-semibold text-slate-700 mt-3">
+                  {selecting === m.kind ? "Opening…" : "Open this workspace →"}
+                </p>
+              </div>
+            </div>
+          </button>
+        );
+      })}
+      {error && (
+        <p className="text-sm text-red-700 mt-2" role="alert">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/app/account/select-workspace/page.tsx
+++ b/app/account/select-workspace/page.tsx
@@ -1,0 +1,67 @@
+/**
+ * Workspace chooser page (W2 Phase 2.5).
+ *
+ * Shown to multi-kind users right after authentication. Each card represents
+ * a kind the user holds; clicking sets `iv_active_kind` and redirects to
+ * that kind's portal. Acts as the central pivot point — users return here
+ * via the header switcher whenever they want to change context.
+ */
+
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import {
+  getKindsForUser,
+  type KindMembership,
+  type WorkspaceKind,
+} from "@/lib/account-kinds";
+import SelectWorkspaceClient from "./SelectWorkspaceClient";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Choose your workspace — Invest.com.au",
+  robots: "noindex, nofollow",
+};
+
+export default async function SelectWorkspacePage() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    redirect("/account/login?redirect=/account/select-workspace");
+  }
+
+  const memberships = await getKindsForUser(user.id);
+
+  // Synthesise an investor membership if the user has no rows yet — every
+  // signed-in user gets the investor workspace as a default. The
+  // investor_profiles row gets created lazily on first quiz / holdings write.
+  const augmented: KindMembership[] = memberships.length > 0
+    ? memberships
+    : [
+        {
+          authUserId: user.id,
+          kind: "investor",
+          kindId: user.id,
+          status: "active",
+          displayLabel: "Investor account",
+          createdAt: new Date().toISOString(),
+        },
+      ];
+
+  return (
+    <main className="bg-slate-50 min-h-[60vh]">
+      <div className="max-w-2xl mx-auto px-4 sm:px-6 py-12">
+        <header className="mb-8 text-center">
+          <h1 className="text-2xl font-bold text-slate-900 mb-2">
+            Choose your workspace
+          </h1>
+          <p className="text-sm text-slate-600">
+            You have multiple roles on Invest.com.au. Pick the workspace you'd like to start in — you can switch any time from the header menu.
+          </p>
+        </header>
+        <SelectWorkspaceClient memberships={augmented} />
+      </div>
+    </main>
+  );
+}

--- a/app/api/account/active-kind/route.ts
+++ b/app/api/account/active-kind/route.ts
@@ -1,0 +1,59 @@
+/**
+ * /api/account/active-kind — set the workspace cookie (W2 Phase 2.5).
+ *
+ * POST { kind } → validates the user has membership in that kind via
+ * `account_kind_membership`, sets the `iv_active_kind` cookie, returns
+ * the destination portal URL. The chooser UI navigates to that URL.
+ */
+
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { createClient } from "@/lib/supabase/server";
+import { withValidatedBody } from "@/lib/validation/withValidatedBody";
+import {
+  getKindsForUser,
+  isWorkspaceKind,
+  portalForKind,
+  setActiveKind,
+} from "@/lib/account-kinds";
+import { logger } from "@/lib/logger";
+
+const log = logger("api:account:active-kind");
+
+export const runtime = "nodejs";
+
+const Body = z.object({
+  kind: z.string(),
+});
+
+export const POST = withValidatedBody(Body, async (req, body) => {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  if (!isWorkspaceKind(body.kind)) {
+    return NextResponse.json({ error: "unknown_kind" }, { status: 400 });
+  }
+
+  // Validate membership: user must hold the kind they're trying to switch
+  // into. Investor is allowed for any signed-in user (lazy-provisioned).
+  const memberships = await getKindsForUser(user.id);
+  const holds = memberships.some((m) => m.kind === body.kind) || body.kind === "investor";
+  if (!holds) {
+    log.warn("user attempted to switch to unheld kind", {
+      userId: user.id,
+      kind: body.kind,
+    });
+    return NextResponse.json({ error: "no_membership" }, { status: 403 });
+  }
+
+  await setActiveKind(body.kind);
+
+  return NextResponse.json({
+    ok: true,
+    kind: body.kind,
+    redirect: portalForKind(body.kind),
+  });
+});

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,8 +1,37 @@
 import { createClient } from "@/lib/supabase/server";
 import { NextRequest, NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
+import {
+  chooseCallbackRedirect,
+  getKindsForUser,
+  setActiveKind,
+} from "@/lib/account-kinds";
 
 const log = logger("auth-callback");
+
+/**
+ * Decide where to send the user after a successful auth, based on the
+ * kinds they hold. Workspace-style routing per W2 Phase 2.5:
+ *   0 kinds  → fallback (typically /account; lazy investor provisioning)
+ *   1 kind   → that kind's portal, set iv_active_kind cookie
+ *   2+ kinds → /account/select-workspace, no cookie set
+ */
+async function postAuthRedirectUrl(origin: string, fallbackNext: string): Promise<URL> {
+  try {
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return new URL(fallbackNext, origin);
+    const memberships = await getKindsForUser(user.id);
+    const { redirect, setKind } = chooseCallbackRedirect(memberships, fallbackNext);
+    if (setKind) await setActiveKind(setKind);
+    return new URL(redirect, origin);
+  } catch (err) {
+    log.warn("postAuthRedirectUrl threw — falling back", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return new URL(fallbackNext, origin);
+  }
+}
 
 /**
  * Magic-link / email OTP callback. Supabase redirects here after the
@@ -72,7 +101,7 @@ export async function GET(request: NextRequest) {
   if (code) {
     const { error } = await supabase.auth.exchangeCodeForSession(code);
     if (!error) {
-      return NextResponse.redirect(new URL(next, origin));
+      return NextResponse.redirect(await postAuthRedirectUrl(origin, next));
     }
     log.warn("exchangeCodeForSession failed", {
       error: error.message,
@@ -98,7 +127,7 @@ export async function GET(request: NextRequest) {
       token_hash: tokenHash,
     });
     if (!error) {
-      return NextResponse.redirect(new URL(next, origin));
+      return NextResponse.redirect(await postAuthRedirectUrl(origin, next));
     }
     log.warn("verifyOtp failed", {
       error: error.message,

--- a/components/WorkspaceSwitcher.tsx
+++ b/components/WorkspaceSwitcher.tsx
@@ -1,0 +1,53 @@
+/**
+ * Workspace switcher for the header (W2 Phase 2.5).
+ *
+ * Server component. Reads the active-kind cookie + the user's full
+ * membership list. When the user holds 2+ kinds, renders a "Acting as: X"
+ * pill linking to /account/select-workspace. When the user holds only 1
+ * kind, renders nothing (no UI clutter for single-kind users).
+ *
+ * The switcher itself doesn't expose a dropdown — clicking jumps to the
+ * chooser page where users see the full set of options + descriptions.
+ * Avoids menu bloat in the header on smaller screens.
+ */
+
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/server";
+import {
+  getActiveKind,
+  getKindsForUser,
+  type WorkspaceKind,
+} from "@/lib/account-kinds";
+
+const KIND_LABEL: Record<WorkspaceKind, string> = {
+  investor: "Investor",
+  advisor: "Advisor",
+  broker_partner: "Broker partner",
+  business_owner: "Business owner",
+  listing_owner: "Listing owner",
+};
+
+export default async function WorkspaceSwitcher() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return null;
+
+  const memberships = await getKindsForUser(user.id);
+  // Single-kind users (or users with 0 kinds = lazy investor only) don't
+  // need a switcher. Render nothing.
+  if (memberships.length < 2) return null;
+
+  const active = await getActiveKind();
+  const label = active ? KIND_LABEL[active] : "Choose workspace";
+
+  return (
+    <Link
+      href="/account/select-workspace"
+      className="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-semibold rounded-full bg-slate-100 text-slate-700 hover:bg-slate-200"
+      title="Switch workspace"
+    >
+      <span aria-hidden>⇄</span>
+      <span>Acting as: {label}</span>
+    </Link>
+  );
+}

--- a/lib/account-kinds.ts
+++ b/lib/account-kinds.ts
@@ -1,0 +1,170 @@
+/**
+ * Account-kind multi-membership helpers (W2 Phase 2.5).
+ *
+ * Real-world users hold multiple kinds simultaneously: a sole-trader
+ * financial planner is an advisor + business owner + investor. The
+ * `account_kind_membership` view UNIONs across all `*_accounts`/profiles
+ * tables so we can answer "what hats does this user wear?" in one query.
+ *
+ * Workspace-style UX: at sign-in, if the user holds 2+ kinds, redirect to
+ * `/account/select-workspace`. The chosen kind is persisted in the
+ * `iv_active_kind` cookie (30-day TTL, sameSite=lax). Portal layouts read
+ * the cookie via `getActiveKind()` and redirect away if mismatch.
+ *
+ * Strict separation: investor `/account/holdings` is only accessible when
+ * `iv_active_kind === 'investor'`. An advisor in advisor workspace
+ * navigating to `/account/holdings` is redirected back to the chooser.
+ * RLS already isolates each table by auth.uid(); the cookie + redirect
+ * is the UX gate.
+ */
+
+import { cookies } from "next/headers";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+import type { AccountKind } from "@/lib/account-types";
+
+const log = logger("account-kinds");
+
+export const ACTIVE_KIND_COOKIE = "iv_active_kind";
+export const ACTIVE_KIND_TTL_SECONDS = 60 * 60 * 24 * 30; // 30 days
+
+// AccountKind today only includes "advisor" + "broker_partner" — adding
+// "investor" + "business_owner" + "listing_owner" is Phase 3+4 work.
+// For Phase 2.5 we surface "investor" as a string literal here so the
+// chooser works end-to-end before the union expansion lands.
+export type WorkspaceKind = AccountKind | "investor" | "business_owner" | "listing_owner";
+
+export interface KindMembership {
+  authUserId: string;
+  kind: WorkspaceKind;
+  kindId: string;
+  status: string;
+  displayLabel: string;
+  createdAt: string;
+}
+
+/**
+ * List every kind the user holds. Empty array means a brand-new auth.users
+ * row with no membership — onboarding flow should pick a kind to provision.
+ *
+ * Reads through `account_kind_membership` view via service-role so the
+ * caller doesn't need a JWT.
+ */
+export async function getKindsForUser(userId: string): Promise<KindMembership[]> {
+  try {
+    const supabase = createAdminClient();
+    const { data, error } = await supabase
+      .from("account_kind_membership")
+      .select("auth_user_id, kind, kind_id, status, display_label, created_at")
+      .eq("auth_user_id", userId)
+      .order("created_at", { ascending: true });
+    if (error) {
+      log.warn("getKindsForUser failed", { userId, error: error.message });
+      return [];
+    }
+    return (data ?? []).map((r) => ({
+      authUserId: r.auth_user_id as string,
+      kind: r.kind as WorkspaceKind,
+      kindId: r.kind_id as string,
+      status: r.status as string,
+      displayLabel: r.display_label as string,
+      createdAt: r.created_at as string,
+    }));
+  } catch (err) {
+    log.warn("getKindsForUser threw", {
+      userId,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return [];
+  }
+}
+
+/**
+ * Read the active workspace from the cookie. Returns null when unset or
+ * when the cookie value isn't a known kind.
+ *
+ * The caller should still validate against `getKindsForUser()` membership
+ * — a stale cookie pointing to a kind the user no longer holds (e.g.
+ * advisor account deactivated) should redirect to the chooser.
+ */
+export async function getActiveKind(): Promise<WorkspaceKind | null> {
+  const c = await cookies();
+  const raw = c.get(ACTIVE_KIND_COOKIE)?.value;
+  if (!raw) return null;
+  return isWorkspaceKind(raw) ? raw : null;
+}
+
+/**
+ * Set the active workspace cookie. Called from the chooser UI's server
+ * action when the user picks a kind. 30-day TTL; sameSite=lax; httpOnly
+ * is FALSE so the client can read for theming. Not security-critical:
+ * RLS still enforces data isolation per kind regardless of cookie value.
+ */
+export async function setActiveKind(kind: WorkspaceKind): Promise<void> {
+  const c = await cookies();
+  c.set(ACTIVE_KIND_COOKIE, kind, {
+    maxAge: ACTIVE_KIND_TTL_SECONDS,
+    httpOnly: false,
+    sameSite: "lax",
+    path: "/",
+    secure: process.env.NODE_ENV === "production",
+  });
+}
+
+export async function clearActiveKind(): Promise<void> {
+  const c = await cookies();
+  c.delete(ACTIVE_KIND_COOKIE);
+}
+
+const KNOWN_WORKSPACE_KINDS = new Set<WorkspaceKind>([
+  "advisor",
+  "broker_partner",
+  "investor",
+  "business_owner",
+  "listing_owner",
+]);
+
+export function isWorkspaceKind(value: string): value is WorkspaceKind {
+  return KNOWN_WORKSPACE_KINDS.has(value as WorkspaceKind);
+}
+
+/**
+ * Pure helper: pick the post-callback redirect URL based on the user's
+ * memberships. Used by `/auth/callback/route.ts` after a successful
+ * authentication.
+ *
+ *   0 kinds  → `/account` (default investor surface; new users can
+ *              create non-investor kinds from there)
+ *   1 kind   → that kind's portal, set cookie
+ *   2+ kinds → `/account/select-workspace`
+ */
+export function chooseCallbackRedirect(
+  memberships: ReadonlyArray<KindMembership>,
+  fallbackNext: string,
+): { redirect: string; setKind: WorkspaceKind | null } {
+  if (memberships.length === 0) {
+    return { redirect: fallbackNext, setKind: "investor" };
+  }
+  if (memberships.length === 1) {
+    return {
+      redirect: portalForKind(memberships[0]!.kind, fallbackNext),
+      setKind: memberships[0]!.kind,
+    };
+  }
+  return { redirect: "/account/select-workspace", setKind: null };
+}
+
+/**
+ * Map a workspace kind to its primary portal URL. The investor kind keeps
+ * the existing /account namespace; specialised kinds get their own.
+ */
+export function portalForKind(kind: WorkspaceKind, fallback = "/account"): string {
+  switch (kind) {
+    case "advisor": return "/advisor-portal";
+    case "broker_partner": return "/broker-portal";
+    case "business_owner": return "/business-portal";
+    case "listing_owner": return "/invest/my-listings";
+    case "investor": return fallback;
+    default: return fallback;
+  }
+}

--- a/supabase/migrations/20260510200000_account_kind_membership.sql
+++ b/supabase/migrations/20260510200000_account_kind_membership.sql
@@ -1,0 +1,64 @@
+-- ============================================================================
+-- Migration: 20260510200000_account_kind_membership.sql
+-- Purpose: Unified view across every kind table so application code can ask
+--          "what hats does this auth.users row wear?" in one query. Powers
+--          the workspace chooser at /account/select-workspace and the portal
+--          active-kind gates.
+-- Audit ref: account-system-expansion plan, Phase 2.5.
+-- Risk: low — view-only; no data writes; underlying tables unchanged.
+-- Rollback: DROP VIEW IF EXISTS public.account_kind_membership;
+-- ============================================================================
+
+BEGIN;
+
+-- View intentionally returns one row per (auth_user_id, kind) pair. A user
+-- with multiple hats gets multiple rows. Each kind's status is forwarded
+-- straight from its source table so callers can filter by 'active' /
+-- 'pending' / etc. as needed.
+--
+-- NOTE: investor_profiles has no status column today (every row is
+-- considered "active"); we synthesise 'active' as the literal. If we later
+-- add a status column to investor_profiles, alter this view in a follow-up.
+CREATE OR REPLACE VIEW public.account_kind_membership AS
+  SELECT
+    auth_user_id,
+    'advisor'::text AS kind,
+    id::text AS kind_id,
+    status,
+    COALESCE(firm_name, name) AS display_label,
+    created_at
+  FROM public.professionals
+  WHERE auth_user_id IS NOT NULL
+UNION ALL
+  SELECT
+    auth_user_id,
+    'broker_partner'::text AS kind,
+    id::text AS kind_id,
+    status,
+    COALESCE(company_name, full_name, broker_slug) AS display_label,
+    created_at
+  FROM public.broker_accounts
+  WHERE auth_user_id IS NOT NULL
+UNION ALL
+  SELECT
+    auth_user_id,
+    'investor'::text AS kind,
+    id::text AS kind_id,
+    'active'::text AS status,
+    COALESCE(display_name, 'Investor account') AS display_label,
+    created_at
+  FROM public.investor_profiles
+  WHERE auth_user_id IS NOT NULL;
+
+-- Views inherit the underlying tables' RLS, but we want callers to query
+-- this through service-role for the cross-kind summary. The view itself
+-- has no policy syntax; instead we GRANT SELECT only to service_role +
+-- authenticated, and the underlying tables' deny-all-anon RLS continues
+-- to protect rows.
+REVOKE ALL ON public.account_kind_membership FROM anon, authenticated, service_role;
+GRANT SELECT ON public.account_kind_membership TO service_role;
+-- Authenticated users CAN read (they'll only see their own rows because
+-- each underlying table's RLS scopes by auth.uid()).
+GRANT SELECT ON public.account_kind_membership TO authenticated;
+
+COMMIT;


### PR DESCRIPTION
## Summary
Architectural backbone for multi-kind users (the majority of real-world users wear ≥2 hats — sole-trader advisor + investor + business owner is the default case). Workspace-style UX: 0 kinds → /account (lazy investor); 1 kind → that portal + cookie; 2+ kinds → /account/select-workspace.

## Tier
C — new view migration + service-role grants + auth-callback redirect logic. Migration applied to live via MCP ahead of merge.

## What changed
- \`supabase/migrations/20260510200000_account_kind_membership.sql\` — view UNIONing professionals + broker_accounts + investor_profiles
- \`lib/account-kinds.ts\` — \`getKindsForUser\`, \`getActiveKind\`, \`setActiveKind\`, \`chooseCallbackRedirect\`, \`portalForKind\`, \`isWorkspaceKind\`
- \`app/account/select-workspace/page.tsx\` + \`SelectWorkspaceClient.tsx\` — chooser cards
- \`app/api/account/active-kind/route.ts\` — POST endpoint validates membership before setting cookie
- \`components/WorkspaceSwitcher.tsx\` — header pill (renders only when 2+ kinds)
- \`app/auth/callback/route.ts\` — \`postAuthRedirectUrl\` picks portal vs chooser based on membership
- \`__tests__/lib/account-kinds.test.ts\` — 9 tests

## Open scope (intentionally next-phase)
- Per-portal active-kind gates (strict separation enforcement) — lands in Phases 3+4 alongside new \`business-portal\` + listing-owner full-auth paths
- AccountKind union expansion — currently \`advisor\` + \`broker_partner\`. WorkspaceKind type extends with the next-phase kinds
- Header mount of \`<WorkspaceSwitcher />\` — separate small PR after Phase 3+4 land to avoid touching every portal layout twice

## Compliance
Cookie is non-security-critical (RLS still enforces data isolation). \`iv_active_kind\` is a UX dial, not an auth gate.

## Supersedes
_None._

## Test plan
- [x] 9/9 vitest local green
- [x] Migration applied to live
- [x] Type-check clean
- [ ] CI green (drift should pass post-types regen)
- [ ] Manual: log in as multi-kind user → lands at /account/select-workspace; pick a workspace → lands at portal