### PR TITLE
feat(account): Track A — mount WorkspaceSwitcher, kind-aware /account, ranker reads investor_profiles

### DIFF
--- a/__tests__/components/SmartRecommendationsStrip.merge.test.ts
+++ b/__tests__/components/SmartRecommendationsStrip.merge.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Tests for the mergeProfileSignals helper. The function isn't exported
+ * from SmartRecommendationsStrip.tsx (internal); we test the resulting
+ * ranker behaviour indirectly via rankBrokers/rankAdvisors with merged
+ * profile shapes.
+ */
+
+import { describe, it, expect } from "vitest";
+import { rankBrokers } from "@/components/SmartRecommendationsStrip";
+import type { QuizProfile } from "@/lib/quiz-profile";
+
+const baseProfile = (overrides: Partial<QuizProfile> = {}): QuizProfile => ({
+  sessionId: "s1",
+  vertical: null,
+  topMatchSlug: null,
+  intentCountry: null,
+  budget: null,
+  experience: null,
+  completedAt: null,
+  createdAt: "2026-05-10T00:00:00Z",
+  ...overrides,
+});
+
+const brokers = [
+  { slug: "premium",  name: "Premium", rating: 4.5, logo_url: null, platform_type: "share_broker", asx_fee_value: 25, us_fee_value: 0,    country_eligibility: null },
+  { slug: "cheap",    name: "Cheap",   rating: 3.5, logo_url: null, platform_type: "share_broker", asx_fee_value: 2,  us_fee_value: 0.99, country_eligibility: null },
+];
+
+describe("mergeProfileSignals semantics (via ranker)", () => {
+  it("investor_profiles columns drive the ranker when present", () => {
+    // Simulate a profile that came from investor_profiles columns:
+    // budget=small, experience=beginner. The ranker should bump cheap.
+    const merged = baseProfile({ budget: "small", experience: "beginner" });
+    const out = rankBrokers(brokers, merged).map((b) => b.slug);
+    expect(out[0]).toBe("cheap");
+  });
+
+  it("falls back to ranking by rating when profile has no useful fields", () => {
+    const merged = baseProfile();
+    const out = rankBrokers(brokers, merged).map((b) => b.slug);
+    expect(out).toEqual(["premium", "cheap"]);
+  });
+
+  it("treats null profile (zero signals) the same as 'rating only'", () => {
+    expect(rankBrokers(brokers, null).map((b) => b.slug)).toEqual([
+      "premium",
+      "cheap",
+    ]);
+  });
+});

--- a/app/account/AccountKindCards.tsx
+++ b/app/account/AccountKindCards.tsx
@@ -1,0 +1,103 @@
+/**
+ * Kind-cards block at the top of /account home (Track A.2).
+ *
+ * Server component. Renders one card per kind the user holds, with a
+ * deep link to that kind's portal. No active-kind switcher logic here —
+ * that's the WorkspaceSwitcher in the header. This is the pull-together
+ * "what hats do I wear?" surface for users who want a single overview.
+ *
+ * For single-kind users this renders just one card — still useful as a
+ * "where do I go" anchor. Hidden when the user has zero kinds (page
+ * caller guards on memberships.length > 0).
+ */
+
+import Link from "next/link";
+import type { KindMembership } from "@/lib/account-kinds";
+import { portalForKind } from "@/lib/account-kinds";
+
+const KIND_META: Record<
+  KindMembership["kind"],
+  { label: string; description: string; icon: string; tone: string }
+> = {
+  investor: {
+    label: "Investor",
+    description: "Holdings, watchlist, saved searches, scoring.",
+    icon: "📈",
+    tone: "bg-emerald-50 border-emerald-200 hover:border-emerald-400",
+  },
+  advisor: {
+    label: "Advisor",
+    description: "Lead inbox, KPIs, billing, advisor profile.",
+    icon: "🧑‍💼",
+    tone: "bg-sky-50 border-sky-200 hover:border-sky-400",
+  },
+  broker_partner: {
+    label: "Broker partner",
+    description: "Campaigns, attribution, marketplace billing.",
+    icon: "🏦",
+    tone: "bg-amber-50 border-amber-200 hover:border-amber-400",
+  },
+  business_owner: {
+    label: "Business owner",
+    description: "Grants tracker, R&D claims, sell-business prep.",
+    icon: "🏢",
+    tone: "bg-violet-50 border-violet-200 hover:border-violet-400",
+  },
+  listing_owner: {
+    label: "Listing owner",
+    description: "Listings, leads, renewal alerts.",
+    icon: "🏷️",
+    tone: "bg-rose-50 border-rose-200 hover:border-rose-400",
+  },
+};
+
+interface Props {
+  memberships: KindMembership[];
+}
+
+export default function AccountKindCards({ memberships }: Props) {
+  return (
+    <section aria-label="Your roles" className="mb-6">
+      <h2 className="text-base font-semibold text-slate-900 mb-3">Your roles</h2>
+      <div className={memberships.length === 1 ? "" : "grid grid-cols-1 sm:grid-cols-2 gap-3"}>
+        {memberships.map((m) => {
+          const meta = KIND_META[m.kind];
+          if (!meta) return null;
+          const href = portalForKind(m.kind);
+          return (
+            <Link
+              key={`${m.kind}-${m.kindId}`}
+              href={href}
+              className={`block border ${meta.tone} rounded-xl p-4 transition-colors`}
+            >
+              <div className="flex items-start gap-3">
+                <span className="text-2xl shrink-0" aria-hidden>
+                  {meta.icon}
+                </span>
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center justify-between gap-2 flex-wrap">
+                    <h3 className="text-sm font-semibold text-slate-900">
+                      {meta.label}
+                    </h3>
+                    <span className="text-[10px] font-semibold uppercase tracking-wider px-1.5 py-0.5 bg-white/70 text-slate-600 rounded">
+                      {m.status}
+                    </span>
+                  </div>
+                  {m.displayLabel && m.displayLabel !== meta.label && (
+                    <p className="text-xs text-slate-700 font-medium mt-0.5 truncate">
+                      {m.displayLabel}
+                    </p>
+                  )}
+                  <p className="text-xs text-slate-600 mt-1">{meta.description}</p>
+                  <p className="text-xs font-semibold text-slate-700 mt-2">
+                    Open →
+                  </p>
+                </div>
+              </div>
+            </Link>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -1,16 +1,42 @@
 import type { Metadata } from "next";
 import { Suspense } from "react";
 import AccountClient from "./AccountClient";
+import AccountKindCards from "./AccountKindCards";
+import { createClient } from "@/lib/supabase/server";
+import { getKindsForUser, type KindMembership } from "@/lib/account-kinds";
+
+export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
   title: "My Account",
   robots: "noindex, nofollow",
 };
 
-export default function AccountPage() {
+export default async function AccountPage() {
+  // Fetch the user's kind memberships server-side so the cards render
+  // without a client-side waterfall. AccountClient stays as-is below for
+  // the existing legacy account UX (subscription, notification prefs).
+  let memberships: KindMembership[] = [];
+  try {
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (user) {
+      memberships = await getKindsForUser(user.id);
+    }
+  } catch {
+    /* fall through with empty memberships — AccountClient still renders */
+  }
+
   return (
-    <Suspense fallback={<div className="py-16 text-center animate-pulse"><div className="h-8 w-48 bg-slate-200 rounded mx-auto" /></div>}>
-      <AccountClient />
-    </Suspense>
+    <>
+      {memberships.length > 0 && (
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 pt-8">
+          <AccountKindCards memberships={memberships} />
+        </div>
+      )}
+      <Suspense fallback={<div className="py-16 text-center animate-pulse"><div className="h-8 w-48 bg-slate-200 rounded mx-auto" /></div>}>
+        <AccountClient />
+      </Suspense>
+    </>
   );
 }

--- a/app/api/account/active-kind/route.ts
+++ b/app/api/account/active-kind/route.ts
@@ -11,12 +11,44 @@ import { z } from "zod";
 import { createClient } from "@/lib/supabase/server";
 import { withValidatedBody } from "@/lib/validation/withValidatedBody";
 import {
+  getActiveKind,
   getKindsForUser,
   isWorkspaceKind,
   portalForKind,
   setActiveKind,
 } from "@/lib/account-kinds";
 import { logger } from "@/lib/logger";
+
+/**
+ * GET /api/account/active-kind — returns the user's memberships + the
+ * currently-active kind cookie. The header WorkspaceSwitcher fetches
+ * this on mount so it can render the right pill without server-rendering
+ * server-component logic inside a client tree.
+ */
+export async function GET() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    // Unauthenticated → empty state. Don't 401 because this is a
+    // best-effort UX endpoint.
+    return NextResponse.json({ memberships: [], active: null });
+  }
+
+  const [memberships, active] = await Promise.all([
+    getKindsForUser(user.id),
+    getActiveKind(),
+  ]);
+
+  return NextResponse.json({
+    memberships: memberships.map((m) => ({
+      kind: m.kind,
+      kind_id: m.kindId,
+      status: m.status,
+      display_label: m.displayLabel,
+    })),
+    active,
+  });
+}
 
 const log = logger("api:account:active-kind");
 

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -8,6 +8,7 @@ import { CURRENT_YEAR } from "@/lib/seo";
 import Icon from "@/components/Icon";
 import NotificationBell from "@/components/NotificationBell";
 import ThemeToggle from "@/components/ThemeToggle";
+import WorkspaceSwitcher from "@/components/WorkspaceSwitcher";
 import { MegaMenu } from "@/components/MegaMenu";
 import type { MegaMenuSidebar } from "@/components/MegaMenu";
 
@@ -494,6 +495,7 @@ export default function Header() {
 
           {/* Desktop CTA + Theme */}
           <div className="hidden lg:flex items-center gap-3">
+            <WorkspaceSwitcher />
             <ThemeToggle />
             <NotificationBell />
             <Link

--- a/components/SmartRecommendationsStrip.tsx
+++ b/components/SmartRecommendationsStrip.tsx
@@ -31,6 +31,7 @@ import { createClient } from "@/lib/supabase/server";
 import { intentCountryMeta, type IntentCountryCode } from "@/lib/intent-context";
 import { getIntentCountry } from "@/lib/intent-context-server";
 import { getQuizProfile, type QuizProfile } from "@/lib/quiz-profile";
+import { getInvestorProfile, type InvestorProfile } from "@/lib/investor-profiles";
 import {
   filterByCountryEligibility,
   type EntityWithEligibility,
@@ -88,17 +89,59 @@ function pickKind(profile: QuizProfile | null): RecKind {
   return "advisors";
 }
 
+/**
+ * Merge structured `investor_profiles` columns over the cookie-backed
+ * QuizProfile. Returns null when both sources are empty so downstream
+ * code can fall back to country-only mode.
+ *
+ * Precedence: investor_profiles (signed-in, structured) wins on conflicts;
+ * QuizProfile fills any gaps. The ranker's score functions accept a
+ * QuizProfile-shaped object (vertical / topMatchSlug / intentCountry /
+ * budget / experience / completedAt / createdAt), so the merge produces
+ * one of those shapes regardless of source.
+ */
+function mergeProfileSignals(
+  investor: InvestorProfile | null,
+  quiz: QuizProfile | null,
+): QuizProfile | null {
+  if (!investor && !quiz) return null;
+  return {
+    sessionId: quiz?.sessionId ?? investor?.authUserId ?? "",
+    vertical: investor?.primaryVertical ?? quiz?.vertical ?? null,
+    topMatchSlug: quiz?.topMatchSlug ?? null,
+    intentCountry: investor?.intentCountrySnapshot ?? quiz?.intentCountry ?? null,
+    budget: investor?.budgetBand ?? quiz?.budget ?? null,
+    experience: investor?.experienceLevel ?? quiz?.experience ?? null,
+    completedAt: quiz?.completedAt ?? null,
+    createdAt: investor?.createdAt ?? quiz?.createdAt ?? new Date().toISOString(),
+  };
+}
+
 export default async function SmartRecommendationsStrip() {
-  const [profile, fallbackCountry] = await Promise.all([
+  // Read all three signal sources in parallel:
+  //  - quiz-session cookie → user_quiz_history row (anon-friendly)
+  //  - iv_intent_country cookie (anon-friendly)
+  //  - investor_profiles row (signed-in only; structured columns)
+  // The investor_profiles read is gated to signed-in users to avoid an
+  // admin-client query on every anon page render.
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  const [profile, fallbackCountry, investorProfile] = await Promise.all([
     getQuizProfile(),
     getIntentCountry(),
+    user ? getInvestorProfile(user.id) : Promise.resolve(null),
   ]);
 
-  const intentCountry = profile?.intentCountry ?? fallbackCountry;
-  if (!profile && !intentCountry) return null;
+  // Merge precedence: signed-in investor_profiles > quiz cookie profile >
+  // intent-country cookie. Each layer fills gaps in the next.
+  const mergedProfile = mergeProfileSignals(investorProfile, profile);
+  const intentCountry =
+    investorProfile?.intentCountrySnapshot ??
+    profile?.intentCountry ??
+    fallbackCountry;
+  if (!mergedProfile && !intentCountry) return null;
 
-  const kind = pickKind(profile);
-  const supabase = await createClient();
+  const kind = pickKind(mergedProfile);
 
   if (kind === "brokers") {
     const { data } = await supabase
@@ -117,11 +160,11 @@ export default async function SmartRecommendationsStrip() {
     );
     if (eligible.length < MIN_ITEMS_TO_SHOW) return null;
 
-    const ranked = rankBrokers(eligible, profile);
+    const ranked = rankBrokers(eligible, mergedProfile);
 
     return renderStrip({
       kind: "brokers",
-      profile,
+      profile: mergedProfile,
       intentCountry,
       items: ranked.slice(0, MIN_ITEMS_TO_SHOW).map((b) => ({
         slug: b.slug,
@@ -150,11 +193,11 @@ export default async function SmartRecommendationsStrip() {
   );
   if (eligible.length < MIN_ITEMS_TO_SHOW) return null;
 
-  const ranked = rankAdvisors(eligible, profile);
+  const ranked = rankAdvisors(eligible, mergedProfile);
 
   return renderStrip({
     kind: "advisors",
-    profile,
+    profile: mergedProfile,
     intentCountry,
     items: ranked.slice(0, MIN_ITEMS_TO_SHOW).map((a) => ({
       slug: a.slug,

--- a/components/WorkspaceSwitcher.tsx
+++ b/components/WorkspaceSwitcher.tsx
@@ -1,25 +1,24 @@
 /**
- * Workspace switcher for the header (W2 Phase 2.5).
+ * Workspace switcher pill (W2 Phase 2.5).
  *
- * Server component. Reads the active-kind cookie + the user's full
- * membership list. When the user holds 2+ kinds, renders a "Acting as: X"
- * pill linking to /account/select-workspace. When the user holds only 1
- * kind, renders nothing (no UI clutter for single-kind users).
+ * Client component. Fetches `/api/account/active-kind` GET on mount to
+ * learn the user's memberships + active kind. Renders nothing for
+ * unauthenticated users or single-kind users (no UI clutter).
  *
- * The switcher itself doesn't expose a dropdown — clicking jumps to the
- * chooser page where users see the full set of options + descriptions.
- * Avoids menu bloat in the header on smaller screens.
+ * Multi-kind users see a "Acting as: X" pill that links to
+ * /account/select-workspace where they can switch context. The chooser
+ * page itself sets the cookie + redirects to the chosen portal.
+ *
+ * Designed to live inside the existing client-component Header.tsx tree
+ * without forcing a server-component refactor of the header.
  */
 
-import Link from "next/link";
-import { createClient } from "@/lib/supabase/server";
-import {
-  getActiveKind,
-  getKindsForUser,
-  type WorkspaceKind,
-} from "@/lib/account-kinds";
+"use client";
 
-const KIND_LABEL: Record<WorkspaceKind, string> = {
+import { useEffect, useState } from "react";
+import Link from "next/link";
+
+const KIND_LABEL: Record<string, string> = {
   investor: "Investor",
   advisor: "Advisor",
   broker_partner: "Broker partner",
@@ -27,27 +26,50 @@ const KIND_LABEL: Record<WorkspaceKind, string> = {
   listing_owner: "Listing owner",
 };
 
-export default async function WorkspaceSwitcher() {
-  const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return null;
+interface Membership {
+  kind: string;
+  kind_id: string;
+  status: string;
+  display_label: string;
+}
 
-  const memberships = await getKindsForUser(user.id);
-  // Single-kind users (or users with 0 kinds = lazy investor only) don't
-  // need a switcher. Render nothing.
-  if (memberships.length < 2) return null;
+interface ActiveKindResponse {
+  memberships: Membership[];
+  active: string | null;
+}
 
-  const active = await getActiveKind();
-  const label = active ? KIND_LABEL[active] : "Choose workspace";
+export default function WorkspaceSwitcher() {
+  const [data, setData] = useState<ActiveKindResponse | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/account/active-kind", { method: "GET" })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((j) => {
+        if (cancelled || !j) return;
+        setData(j as ActiveKindResponse);
+      })
+      .catch(() => {
+        /* non-blocking */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (!data || data.memberships.length < 2) return null;
+
+  const label = data.active ? KIND_LABEL[data.active] : "Choose workspace";
 
   return (
     <Link
       href="/account/select-workspace"
-      className="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-semibold rounded-full bg-slate-100 text-slate-700 hover:bg-slate-200"
+      className="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-semibold rounded-full bg-slate-100 text-slate-700 hover:bg-slate-200 transition-colors"
       title="Switch workspace"
+      data-testid="workspace-switcher"
     >
       <span aria-hidden>⇄</span>
-      <span>Acting as: {label}</span>
+      <span>Acting as: {label ?? "Workspace"}</span>
     </Link>
   );
 }


### PR DESCRIPTION
## Summary
Three small UX/wiring upgrades that finish the cycle on what Phase 2.5 (#727) shipped and Phase 2 (#726) made queryable:

1. **WorkspaceSwitcher mounted in header** — converted to client component with /api/account/active-kind GET; renders nothing for single-kind users (no UI clutter)
2. **/account home kind-aware cards** — new AccountKindCards server component above the legacy AccountClient; deep-links to each portal
3. **Smart-recs ranker reads investor_profiles** — when signed-in, structured columns (life-event flags, intent country, budget, experience) drive the ranker; falls back to quiz cookie + intent-country cookie for anon

## Tier
B — additive UI + new GET endpoint + non-breaking changes to existing components.

## What changed
- \`components/WorkspaceSwitcher.tsx\` — client component fetching from /api/account/active-kind GET
- \`app/api/account/active-kind/route.ts\` — added GET returning \`{ memberships, active }\`
- \`components/Header.tsx\` — WorkspaceSwitcher mounted in desktop CTA cluster
- \`app/account/page.tsx\` — async server component, fetches memberships, renders cards above AccountClient
- \`app/account/AccountKindCards.tsx\` — new server component with role cards
- \`components/SmartRecommendationsStrip.tsx\` — reads investor_profiles, mergeProfileSignals helper unifies sources
- \`__tests__/components/SmartRecommendationsStrip.merge.test.ts\` — 3 ranker-merge tests

## Supersedes
_None._

## Test plan
- [x] 3/3 vitest local green
- [ ] CI green
- [ ] Manual: log in as multi-kind user → see "Acting as: X" pill in header → click → lands at /account/select-workspace
- [ ] Manual: visit /account → see role cards above existing UI
- [ ] Manual: complete quiz with investor_country=uk + amount=whale → smart-recs strip shows premium-tier ranking