### PR TITLE
feat(account): business_owner AccountKind + grants quiz wiring (W2 Phase 3)

### DIFF
--- a/__tests__/lib/require-business-session.test.ts
+++ b/__tests__/lib/require-business-session.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+let mockUser: { id: string } | null = null;
+let mockRow: { id: number } | null = null;
+let mockError: { message: string } | null = null;
+
+const mockFrom = vi.fn((table: string) => {
+  if (table !== "business_accounts") {
+    throw new Error(`unexpected table: ${table}`);
+  }
+  const chain = {
+    select: () => chain,
+    eq: () => chain,
+    in: () => chain,
+    maybeSingle: async () =>
+      mockError ? { data: null, error: mockError } : { data: mockRow, error: null },
+  };
+  return chain;
+});
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({
+    auth: { getUser: async () => ({ data: { user: mockUser } }) },
+    from: mockFrom,
+  }),
+}));
+
+import { requireBusinessSession } from "@/lib/require-business-session";
+
+describe("requireBusinessSession", () => {
+  beforeEach(() => {
+    mockUser = null;
+    mockRow = null;
+    mockError = null;
+    vi.clearAllMocks();
+  });
+
+  it("returns null for unauthenticated requests", async () => {
+    expect(await requireBusinessSession()).toBeNull();
+  });
+
+  it("returns null when user has no business_accounts row", async () => {
+    mockUser = { id: "u1" };
+    mockRow = null;
+    expect(await requireBusinessSession()).toBeNull();
+  });
+
+  it("returns the business id when user has an active row", async () => {
+    mockUser = { id: "u1" };
+    mockRow = { id: 42 };
+    expect(await requireBusinessSession()).toBe(42);
+  });
+
+  it("returns null when DB lookup errors out", async () => {
+    mockUser = { id: "u1" };
+    mockError = { message: "rls denied" };
+    expect(await requireBusinessSession()).toBeNull();
+  });
+});

--- a/app/account/upgrade/business/BusinessUpgradeForm.tsx
+++ b/app/account/upgrade/business/BusinessUpgradeForm.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import { useRouter } from "next/navigation";
+
+interface ExistingProfile {
+  business_name: string;
+  legal_name: string | null;
+  abn: string | null;
+  acn: string | null;
+  industry: string | null;
+  employees_band: string | null;
+  revenue_band: string | null;
+  primary_state: string | null;
+  year_established: number | null;
+}
+
+interface Props {
+  existing: ExistingProfile | null;
+  prefillName: string | null;
+  isEdit: boolean;
+}
+
+const EMPLOYEES_BANDS = ["1", "2-4", "5-19", "20-199", "200+"] as const;
+const REVENUE_BANDS = [
+  { value: "under_75k", label: "Under $75k" },
+  { value: "75k_2m",   label: "$75k – $2M" },
+  { value: "2m_10m",   label: "$2M – $10M" },
+  { value: "10m_50m",  label: "$10M – $50M" },
+  { value: "50m_plus", label: "$50M+" },
+] as const;
+const STATES = ["NSW", "VIC", "QLD", "WA", "SA", "TAS", "NT", "ACT"] as const;
+
+export default function BusinessUpgradeForm({ existing, prefillName, isEdit }: Props) {
+  const router = useRouter();
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const initialName = existing?.business_name ?? prefillName ?? "";
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setError(null);
+    setSubmitting(true);
+    const fd = new FormData(e.currentTarget);
+    const body: Record<string, unknown> = {
+      business_name: String(fd.get("business_name") ?? "").trim(),
+      legal_name: String(fd.get("legal_name") ?? "").trim() || null,
+      abn: String(fd.get("abn") ?? "").replace(/\s/g, "") || null,
+      acn: String(fd.get("acn") ?? "").replace(/\s/g, "") || null,
+      industry: String(fd.get("industry") ?? "").trim() || null,
+      employees_band: String(fd.get("employees_band") ?? "") || null,
+      revenue_band: String(fd.get("revenue_band") ?? "") || null,
+      primary_state: String(fd.get("primary_state") ?? "") || null,
+      year_established: fd.get("year_established") ? Number(fd.get("year_established")) : null,
+    };
+    try {
+      const res = await fetch("/api/account/business", {
+        method: isEdit ? "PATCH" : "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const j = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(j.error ?? "Could not save");
+      }
+      // Set workspace cookie + redirect to portal.
+      await fetch("/api/account/active-kind", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ kind: "business_owner" }),
+      });
+      router.push("/business-portal");
+      router.refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not save business profile.");
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="bg-white border border-slate-200 rounded-xl p-5 space-y-4"
+    >
+      <Field label="Business name" required>
+        <input type="text" name="business_name" required maxLength={200} defaultValue={initialName}
+          className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm" />
+      </Field>
+      <Field label="Legal name (if different)">
+        <input type="text" name="legal_name" maxLength={200} defaultValue={existing?.legal_name ?? ""}
+          className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm" />
+      </Field>
+      <div className="grid grid-cols-2 gap-3">
+        <Field label="ABN (11 digits)">
+          <input type="text" name="abn" maxLength={11} defaultValue={existing?.abn ?? ""}
+            className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm" />
+        </Field>
+        <Field label="ACN (9 digits, optional)">
+          <input type="text" name="acn" maxLength={9} defaultValue={existing?.acn ?? ""}
+            className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm" />
+        </Field>
+      </div>
+      <Field label="Industry (free text)">
+        <input type="text" name="industry" maxLength={100} defaultValue={existing?.industry ?? ""}
+          placeholder="e.g. SaaS, retail, professional services"
+          className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm" />
+      </Field>
+      <div className="grid grid-cols-2 gap-3">
+        <Field label="Employees">
+          <select name="employees_band" defaultValue={existing?.employees_band ?? ""}
+            className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm">
+            <option value="">Select…</option>
+            {EMPLOYEES_BANDS.map((b) => <option key={b} value={b}>{b}</option>)}
+          </select>
+        </Field>
+        <Field label="Annual revenue">
+          <select name="revenue_band" defaultValue={existing?.revenue_band ?? ""}
+            className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm">
+            <option value="">Select…</option>
+            {REVENUE_BANDS.map((b) => <option key={b.value} value={b.value}>{b.label}</option>)}
+          </select>
+        </Field>
+      </div>
+      <div className="grid grid-cols-2 gap-3">
+        <Field label="Primary state">
+          <select name="primary_state" defaultValue={existing?.primary_state ?? ""}
+            className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm">
+            <option value="">Select…</option>
+            {STATES.map((s) => <option key={s} value={s}>{s}</option>)}
+          </select>
+        </Field>
+        <Field label="Year established">
+          <input type="number" name="year_established" min={1850} max={2100}
+            defaultValue={existing?.year_established ?? ""}
+            className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm" />
+        </Field>
+      </div>
+      {error && <p className="text-sm text-red-700" role="alert">{error}</p>}
+      <button type="submit" disabled={submitting}
+        className="w-full px-4 py-2.5 bg-violet-600 hover:bg-violet-700 text-white font-semibold rounded-lg disabled:opacity-50">
+        {submitting ? "Saving…" : isEdit ? "Save changes" : "Create business workspace"}
+      </button>
+      <p className="text-xs text-slate-500 italic">
+        General information only — see your accountant for tax / legal advice on grant eligibility, R&D claims, or sale prep.
+      </p>
+    </form>
+  );
+}
+
+function Field({ label, required, children }: { label: string; required?: boolean; children: React.ReactNode }) {
+  return (
+    <label className="block">
+      <span className="block text-xs font-medium text-slate-700 mb-1">
+        {label} {required && <span className="text-red-600">*</span>}
+      </span>
+      {children}
+    </label>
+  );
+}

--- a/app/account/upgrade/business/page.tsx
+++ b/app/account/upgrade/business/page.tsx
@@ -1,0 +1,72 @@
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import BusinessUpgradeForm from "./BusinessUpgradeForm";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Add business profile — Invest.com.au",
+  robots: "noindex, nofollow",
+};
+
+interface PageProps {
+  searchParams: Promise<{ prefill?: string; edit?: string }>;
+}
+
+export default async function BusinessUpgradePage({ searchParams }: PageProps) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    redirect("/account/login?redirect=/account/upgrade/business");
+  }
+
+  const params = await searchParams;
+  const prefillName = params.prefill ?? null;
+  const isEdit = params.edit === "1";
+
+  // If editing, fetch the existing row to pre-populate the form.
+  let existing: {
+    business_name: string;
+    legal_name: string | null;
+    abn: string | null;
+    acn: string | null;
+    industry: string | null;
+    employees_band: string | null;
+    revenue_band: string | null;
+    primary_state: string | null;
+    year_established: number | null;
+  } | null = null;
+  if (isEdit) {
+    const { data } = await supabase
+      .from("business_accounts")
+      .select("business_name, legal_name, abn, acn, industry, employees_band, revenue_band, primary_state, year_established")
+      .eq("auth_user_id", user.id)
+      .maybeSingle();
+    if (data) existing = data;
+  }
+
+  return (
+    <main className="bg-slate-50 min-h-[60vh]">
+      <div className="max-w-2xl mx-auto px-4 sm:px-6 py-10">
+        <header className="mb-6">
+          <p className="text-xs font-semibold uppercase tracking-wider text-violet-700 mb-2">
+            <span aria-hidden className="mr-1.5">🏢</span>
+            {isEdit ? "Edit business profile" : "Add business workspace"}
+          </p>
+          <h1 className="text-2xl font-bold text-slate-900">
+            {isEdit ? "Update your business" : "Tell us about your business"}
+          </h1>
+          <p className="text-sm text-slate-600 mt-2">
+            Adds a Business Owner workspace to your account so you can track grants, run R&D claim eligibility, and prep your business for sale. Comparison + factual computation only — no personal advice.
+          </p>
+        </header>
+        <BusinessUpgradeForm
+          existing={existing}
+          prefillName={prefillName}
+          isEdit={isEdit}
+        />
+      </div>
+    </main>
+  );
+}

--- a/app/api/account/business/route.ts
+++ b/app/api/account/business/route.ts
@@ -1,0 +1,114 @@
+/**
+ * /api/account/business — business_accounts CRUD (W2 Phase 3).
+ *
+ * GET    — current user's business profile (or null)
+ * POST   — create profile (status='pending'); upserts on auth_user_id
+ * PATCH  — update profile (any subset of fields)
+ *
+ * RLS does the heavy lifting: per-user policies on business_accounts
+ * scope reads/writes to auth.uid(). The handler uses createClient()
+ * (user-scoped) so policies fire automatically.
+ */
+
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { createClient } from "@/lib/supabase/server";
+import { withValidatedBody } from "@/lib/validation/withValidatedBody";
+import { logger } from "@/lib/logger";
+
+const log = logger("api:account:business");
+
+export const runtime = "nodejs";
+
+const EMPLOYEES_BANDS = ["1", "2-4", "5-19", "20-199", "200+"] as const;
+const REVENUE_BANDS = ["under_75k", "75k_2m", "2m_10m", "10m_50m", "50m_plus"] as const;
+const STATES = ["NSW", "VIC", "QLD", "WA", "SA", "TAS", "NT", "ACT"] as const;
+
+const Body = z.object({
+  business_name: z.string().min(1).max(200),
+  legal_name: z.string().max(200).nullish(),
+  abn: z.string().regex(/^\d{11}$/).nullish().or(z.literal("")),
+  acn: z.string().regex(/^\d{9}$/).nullish().or(z.literal("")),
+  industry: z.string().max(100).nullish(),
+  employees_band: z.enum(EMPLOYEES_BANDS).nullish().or(z.literal("")),
+  revenue_band: z.enum(REVENUE_BANDS).nullish().or(z.literal("")),
+  primary_state: z.enum(STATES).nullish().or(z.literal("")),
+  year_established: z.coerce.number().int().min(1850).max(2100).nullish(),
+});
+
+const PatchBody = Body.partial();
+
+function normaliseEmptyToNull<T extends Record<string, unknown>>(obj: T): T {
+  const out: Record<string, unknown> = { ...obj };
+  for (const k of Object.keys(out)) {
+    if (out[k] === "") out[k] = null;
+  }
+  return out as T;
+}
+
+export async function GET() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+
+  const { data, error } = await supabase
+    .from("business_accounts")
+    .select("*")
+    .eq("auth_user_id", user.id)
+    .maybeSingle();
+  if (error) {
+    log.warn("business GET failed", { userId: user.id, error: error.message });
+    return NextResponse.json({ error: "fetch_failed" }, { status: 500 });
+  }
+  return NextResponse.json({ account: data ?? null });
+}
+
+export const POST = withValidatedBody(Body, async (req, body) => {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+
+  const cleaned = normaliseEmptyToNull(body);
+  const { data, error } = await supabase
+    .from("business_accounts")
+    .upsert(
+      {
+        auth_user_id: user.id,
+        ...cleaned,
+        status: "pending",
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: "auth_user_id" },
+    )
+    .select("*")
+    .single();
+  if (error) {
+    log.warn("business POST failed", { userId: user.id, error: error.message });
+    return NextResponse.json({ error: "insert_failed", detail: error.message }, { status: 500 });
+  }
+  return NextResponse.json({ account: data }, { status: 201 });
+});
+
+export const PATCH = withValidatedBody(PatchBody, async (req, body) => {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+
+  const cleaned = normaliseEmptyToNull(body);
+  const update: Record<string, unknown> = { updated_at: new Date().toISOString() };
+  for (const [k, v] of Object.entries(cleaned)) {
+    if (v !== undefined) update[k] = v;
+  }
+
+  const { data, error } = await supabase
+    .from("business_accounts")
+    .update(update)
+    .eq("auth_user_id", user.id)
+    .select("*")
+    .single();
+  if (error) {
+    log.warn("business PATCH failed", { userId: user.id, error: error.message });
+    return NextResponse.json({ error: "update_failed", detail: error.message }, { status: 500 });
+  }
+  return NextResponse.json({ account: data });
+});

--- a/app/business-portal/layout.tsx
+++ b/app/business-portal/layout.tsx
@@ -1,0 +1,38 @@
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { requireBusinessSession } from "@/lib/require-business-session";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Business portal — Invest.com.au",
+  robots: "noindex, nofollow",
+};
+
+/**
+ * Gate every /business-portal/* route on:
+ *   1. Authenticated user (else → /account/login)
+ *   2. Active or pending business_accounts row (else → /account/upgrade/business)
+ *
+ * Per-portal active-kind enforcement (the "strict separation" workspace
+ * promise) lands in a separate PR; for now, just check membership here.
+ */
+export default async function BusinessPortalLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    redirect("/account/login?redirect=/business-portal");
+  }
+
+  const businessId = await requireBusinessSession();
+  if (!businessId) {
+    redirect("/account/upgrade/business");
+  }
+
+  return <>{children}</>;
+}

--- a/app/business-portal/page.tsx
+++ b/app/business-portal/page.tsx
@@ -1,0 +1,164 @@
+/**
+ * Business owner dashboard home (W2 Phase 3).
+ *
+ * Shows business profile summary + grants tracker + R&D claims placeholder
+ * + sell-business prep links. Compliance posture: factual computation +
+ * comparison-driven content only. No "you should claim X" copy.
+ */
+
+import Link from "next/link";
+import type { Metadata } from "next";
+import { createClient } from "@/lib/supabase/server";
+import { redirect } from "next/navigation";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Business dashboard — Invest.com.au",
+  robots: "noindex, nofollow",
+};
+
+interface BusinessRow {
+  id: number;
+  business_name: string;
+  legal_name: string | null;
+  abn: string | null;
+  industry: string | null;
+  employees_band: string | null;
+  revenue_band: string | null;
+  primary_state: string | null;
+  status: string;
+}
+
+export default async function BusinessPortalPage() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    redirect("/account/login?redirect=/business-portal");
+  }
+
+  const { data } = await supabase
+    .from("business_accounts")
+    .select("id, business_name, legal_name, abn, industry, employees_band, revenue_band, primary_state, status")
+    .eq("auth_user_id", user.id)
+    .maybeSingle();
+
+  if (!data) {
+    redirect("/account/upgrade/business");
+  }
+
+  const account = data as BusinessRow;
+
+  return (
+    <main className="bg-slate-50 min-h-[60vh]">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 py-8 space-y-6">
+        <header className="flex items-baseline justify-between gap-4 flex-wrap">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wider text-violet-700 mb-1">
+              <span aria-hidden className="mr-1.5">🏢</span>
+              Business workspace
+            </p>
+            <h1 className="text-2xl font-bold text-slate-900">
+              {account.business_name}
+            </h1>
+            {account.legal_name && account.legal_name !== account.business_name && (
+              <p className="text-sm text-slate-600 mt-0.5">{account.legal_name}</p>
+            )}
+          </div>
+          <Link
+            href="/account/upgrade/business?edit=1"
+            className="text-xs font-semibold text-slate-600 hover:text-slate-900 underline underline-offset-2"
+          >
+            Edit business profile
+          </Link>
+        </header>
+
+        {/* Profile summary */}
+        <section className="bg-white border border-slate-200 rounded-xl p-5">
+          <h2 className="text-sm font-semibold text-slate-900 mb-3">Profile</h2>
+          <dl className="grid grid-cols-2 sm:grid-cols-4 gap-4 text-sm">
+            <div>
+              <dt className="text-xs text-slate-500 uppercase tracking-wider">Status</dt>
+              <dd className="text-slate-900 font-medium mt-0.5">{account.status}</dd>
+            </div>
+            {account.abn && (
+              <div>
+                <dt className="text-xs text-slate-500 uppercase tracking-wider">ABN</dt>
+                <dd className="text-slate-900 font-medium mt-0.5">{account.abn}</dd>
+              </div>
+            )}
+            {account.industry && (
+              <div>
+                <dt className="text-xs text-slate-500 uppercase tracking-wider">Industry</dt>
+                <dd className="text-slate-900 font-medium mt-0.5">{account.industry}</dd>
+              </div>
+            )}
+            {account.primary_state && (
+              <div>
+                <dt className="text-xs text-slate-500 uppercase tracking-wider">State</dt>
+                <dd className="text-slate-900 font-medium mt-0.5">{account.primary_state}</dd>
+              </div>
+            )}
+          </dl>
+        </section>
+
+        {/* Grants */}
+        <section className="bg-white border border-slate-200 rounded-xl p-5">
+          <div className="flex items-baseline justify-between gap-2 mb-3">
+            <h2 className="text-sm font-semibold text-slate-900">Grants tracker</h2>
+            <Link
+              href="/grants/eligibility-quiz"
+              className="text-xs text-emerald-700 hover:text-emerald-900 underline underline-offset-2"
+            >
+              Run eligibility quiz →
+            </Link>
+          </div>
+          <p className="text-sm text-slate-600">
+            Eligibility checks for EMDG (export), R&D Tax Incentive, and Industry Growth Program. Take the eligibility quiz once and your answers persist here for follow-up review.
+          </p>
+          <p className="text-xs text-slate-500 italic mt-3">
+            General eligibility info only — confirm with your accountant or business.gov.au before claiming.
+          </p>
+        </section>
+
+        {/* Sell business prep */}
+        <section className="bg-white border border-slate-200 rounded-xl p-5">
+          <h2 className="text-sm font-semibold text-slate-900 mb-3">Selling your business</h2>
+          <ul className="space-y-2 text-sm">
+            <li>
+              <Link
+                href="/sell-business/valuation"
+                className="text-emerald-700 hover:text-emerald-900 underline underline-offset-2"
+              >
+                Run a valuation →
+              </Link>
+              <span className="text-slate-600 ml-2">EBITDA-multiple estimate</span>
+            </li>
+            <li>
+              <Link
+                href="/sell-business/checklist"
+                className="text-emerald-700 hover:text-emerald-900 underline underline-offset-2"
+              >
+                Sale-prep checklist →
+              </Link>
+              <span className="text-slate-600 ml-2">due-diligence prep + CGT concessions</span>
+            </li>
+            <li>
+              <Link
+                href="/advisors/business-brokers"
+                className="text-emerald-700 hover:text-emerald-900 underline underline-offset-2"
+              >
+                Find a business broker →
+              </Link>
+              <span className="text-slate-600 ml-2">verified AU brokers</span>
+            </li>
+          </ul>
+        </section>
+
+        <p className="text-xs text-slate-500 italic text-center">
+          Invest.com.au provides general information and comparison content — not advice tailored to your business. See your accountant or financial advisor for personalised guidance.
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/app/grants/eligibility-quiz/EligibilityQuizClient.tsx
+++ b/app/grants/eligibility-quiz/EligibilityQuizClient.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useEffect, useState, useMemo } from "react";
 import Icon from "@/components/Icon";
 import HubLeadForm from "@/components/leads/HubLeadForm";
+import { useCalculatorState } from "@/hooks/use-calculator-state";
 
 type Q = {
   id: string;
@@ -148,6 +149,35 @@ export default function EligibilityQuizClient() {
   const [done, setDone] = useState(false);
   const results = useMemo(() => (done ? evaluate(answers) : []), [done, answers]);
 
+  // Persist answers across sessions for signed-in business-owner users
+  // (W2 Phase 3). Anonymous users still get sessionStorage continuity via
+  // the same hook. Stored under `grants_eligibility_quiz` so the
+  // /business-portal/grants surface can read them later without re-prompt.
+  const {
+    value: persistedAnswers,
+    setValue: setPersistedAnswers,
+    isHydrated: persistHydrated,
+  } = useCalculatorState<Answers>("grants_eligibility_quiz", {});
+
+  useEffect(() => {
+    if (!persistHydrated) return;
+    if (persistedAnswers && Object.keys(persistedAnswers).length > 0) {
+      setAnswers(persistedAnswers);
+      // If the persisted answers cover every question, jump to results.
+      if (QUESTIONS.every((q) => typeof persistedAnswers[q.id] === "string")) {
+        setDone(true);
+        setStep(QUESTIONS.length);
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- hydrate once
+  }, [persistHydrated]);
+
+  useEffect(() => {
+    if (Object.keys(answers).length > 0) {
+      setPersistedAnswers(answers);
+    }
+  }, [answers, setPersistedAnswers]);
+
   function answer(q: Q, value: string) {
     const next = { ...answers, [q.id]: value };
     setAnswers(next);
@@ -160,6 +190,7 @@ export default function EligibilityQuizClient() {
 
   function reset() {
     setAnswers({});
+    setPersistedAnswers({});
     setStep(0);
     setDone(false);
   }

--- a/lib/account-kinds.ts
+++ b/lib/account-kinds.ts
@@ -28,11 +28,10 @@ const log = logger("account-kinds");
 export const ACTIVE_KIND_COOKIE = "iv_active_kind";
 export const ACTIVE_KIND_TTL_SECONDS = 60 * 60 * 24 * 30; // 30 days
 
-// AccountKind today only includes "advisor" + "broker_partner" — adding
-// "investor" + "business_owner" + "listing_owner" is Phase 3+4 work.
-// For Phase 2.5 we surface "investor" as a string literal here so the
-// chooser works end-to-end before the union expansion lands.
-export type WorkspaceKind = AccountKind | "investor" | "business_owner" | "listing_owner";
+// As of W2 Phase 3, AccountKind covers all 5 workspace kinds. WorkspaceKind
+// is kept as an alias for call-site readability ("workspace" semantics
+// vs "account membership" semantics) but they're the same union.
+export type WorkspaceKind = AccountKind;
 
 export interface KindMembership {
   authUserId: string;

--- a/lib/account-types.ts
+++ b/lib/account-types.ts
@@ -20,21 +20,28 @@
  * from.
  */
 
-export type AccountKind = "advisor" | "broker_partner";
+export type AccountKind =
+  | "advisor"
+  | "broker_partner"
+  | "investor"        // investor_profiles.auth_user_id (end-user dashboard)
+  | "business_owner"  // business_accounts.auth_user_id (W2 Phase 3)
+  | "listing_owner";  // listing_owner_accounts.auth_user_id (W2 Phase 4 — table pending)
 
 /**
- * Reserved future kinds (commented for grep discoverability — uncomment
- * when the corresponding entity table ships and follow the
- * auth_user_id + unique-index + RLS pattern documented in
- * docs/architecture/account-types.md):
+ * Reserved future kinds (uncomment when the corresponding entity table
+ * ships):
  *
- *   - "listing_owner"       → CRE seller marketplace (real estate licence)
  *   - "wholesale_operator"  → fund managers (s708 sophisticated investor)
- *   - "investor_profile"    → end-user dogfood (saved searches, GDPR)
  *   - "firm_partner"        → firm-admin role (separate from advisor)
  */
 
-export const ACTIVE_ACCOUNT_KINDS: readonly AccountKind[] = ["advisor", "broker_partner"];
+export const ACTIVE_ACCOUNT_KINDS: readonly AccountKind[] = [
+  "advisor",
+  "broker_partner",
+  "investor",
+  "business_owner",
+  "listing_owner",
+];
 
 export function isAccountKind(value: unknown): value is AccountKind {
   return typeof value === "string" && (ACTIVE_ACCOUNT_KINDS as readonly string[]).includes(value);

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -3844,6 +3844,57 @@ export type Database = {
           },
         ]
       }
+      business_accounts: {
+        Row: {
+          abn: string | null
+          acn: string | null
+          auth_user_id: string
+          business_name: string
+          created_at: string
+          employees_band: string | null
+          id: number
+          industry: string | null
+          legal_name: string | null
+          primary_state: string | null
+          revenue_band: string | null
+          status: string
+          updated_at: string
+          year_established: number | null
+        }
+        Insert: {
+          abn?: string | null
+          acn?: string | null
+          auth_user_id: string
+          business_name: string
+          created_at?: string
+          employees_band?: string | null
+          id?: never
+          industry?: string | null
+          legal_name?: string | null
+          primary_state?: string | null
+          revenue_band?: string | null
+          status?: string
+          updated_at?: string
+          year_established?: number | null
+        }
+        Update: {
+          abn?: string | null
+          acn?: string | null
+          auth_user_id?: string
+          business_name?: string
+          created_at?: string
+          employees_band?: string | null
+          id?: never
+          industry?: string | null
+          legal_name?: string | null
+          primary_state?: string | null
+          revenue_band?: string | null
+          status?: string
+          updated_at?: string
+          year_established?: number | null
+        }
+        Relationships: []
+      }
       buyer_agents: {
         Row: {
           agency_name: string | null
@@ -12563,6 +12614,17 @@ export type Database = {
       }
     }
     Views: {
+      account_kind_membership: {
+        Row: {
+          auth_user_id: string | null
+          created_at: string | null
+          display_label: string | null
+          kind: string | null
+          kind_id: string | null
+          status: string | null
+        }
+        Relationships: []
+      }
       admin_advisor_health: {
         Row: {
           admin_tags: string[] | null

--- a/lib/require-business-session.ts
+++ b/lib/require-business-session.ts
@@ -1,0 +1,49 @@
+/**
+ * Business-account session resolver (W2 Phase 3).
+ *
+ * JWT-only resolver for the business_owner AccountKind. Returns the
+ * `business_accounts.id` when the JWT user has an active business account,
+ * else null. Mirrors the require-advisor-session shape but skipping the
+ * legacy-cookie fallback (no equivalent for business_accounts).
+ *
+ * Used by /business-portal/* layouts + any /api/business-* routes that
+ * need to scope to the active business profile.
+ *
+ * RLS isolates rows by auth.uid() in `business_accounts`; this resolver
+ * uses createClient() (user-scoped) so the policies fire and rejection
+ * is automatic — no admin-client bypass needed.
+ */
+
+import { createClient } from "@/lib/supabase/server";
+import { logger } from "@/lib/logger";
+
+const log = logger("require-business-session");
+
+export async function requireBusinessSession(): Promise<number | null> {
+  try {
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return null;
+
+    const { data, error } = await supabase
+      .from("business_accounts")
+      .select("id")
+      .eq("auth_user_id", user.id)
+      .in("status", ["active", "pending"])
+      .maybeSingle();
+
+    if (error) {
+      log.warn("business session lookup failed", {
+        userId: user.id,
+        error: error.message,
+      });
+      return null;
+    }
+    return (data?.id as number | null) ?? null;
+  } catch (err) {
+    log.warn("requireBusinessSession threw", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}

--- a/supabase/migrations/20260510220000_business_accounts.sql
+++ b/supabase/migrations/20260510220000_business_accounts.sql
@@ -1,0 +1,104 @@
+-- ============================================================================
+-- Migration: 20260510220000_business_accounts.sql
+-- Purpose: business_owner AccountKind — typed profile for business owners
+--          claiming grants, R&D incentives, sell-business prep, etc. Mirrors
+--          the professionals + broker_accounts pattern: per-user FK to
+--          auth.users with RLS-scoped read/write on own row only.
+-- Audit ref: account-system-expansion plan, Phase 3.
+-- Risk: low — additive table; per-user RLS; no FK to anything besides
+--       auth.users.
+-- Rollback: DROP TABLE IF EXISTS public.business_accounts;
+-- ============================================================================
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.business_accounts (
+  id              bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  auth_user_id    uuid   NOT NULL UNIQUE REFERENCES auth.users(id) ON DELETE CASCADE,
+  business_name   text   NOT NULL CHECK (length(business_name) > 0 AND length(business_name) <= 200),
+  legal_name      text,
+  abn             text   CHECK (abn IS NULL OR length(abn) = 11),
+  acn             text   CHECK (acn IS NULL OR length(acn) = 9),
+  industry        text,
+  employees_band  text   CHECK (employees_band IS NULL OR employees_band IN (
+                    '1','2-4','5-19','20-199','200+'
+                  )),
+  revenue_band    text   CHECK (revenue_band IS NULL OR revenue_band IN (
+                    'under_75k','75k_2m','2m_10m','10m_50m','50m_plus'
+                  )),
+  primary_state   text   CHECK (primary_state IS NULL OR primary_state IN (
+                    'NSW','VIC','QLD','WA','SA','TAS','NT','ACT'
+                  )),
+  year_established integer CHECK (year_established IS NULL OR (year_established >= 1850 AND year_established <= 2100)),
+  status          text   NOT NULL DEFAULT 'pending'
+                  CHECK (status IN ('pending','active','inactive')),
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  updated_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_business_accounts_auth_user
+  ON public.business_accounts (auth_user_id);
+CREATE INDEX IF NOT EXISTS idx_business_accounts_status
+  ON public.business_accounts (status) WHERE status = 'active';
+
+ALTER TABLE public.business_accounts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.business_accounts FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "business reads own account" ON public.business_accounts;
+CREATE POLICY "business reads own account"
+  ON public.business_accounts FOR SELECT
+  TO authenticated
+  USING (auth.uid() = auth_user_id);
+
+DROP POLICY IF EXISTS "business inserts own account" ON public.business_accounts;
+CREATE POLICY "business inserts own account"
+  ON public.business_accounts FOR INSERT
+  TO authenticated
+  WITH CHECK (auth.uid() = auth_user_id);
+
+DROP POLICY IF EXISTS "business updates own account" ON public.business_accounts;
+CREATE POLICY "business updates own account"
+  ON public.business_accounts FOR UPDATE
+  TO authenticated
+  USING (auth.uid() = auth_user_id)
+  WITH CHECK (auth.uid() = auth_user_id);
+
+DROP POLICY IF EXISTS "service_role full access business_accounts" ON public.business_accounts;
+CREATE POLICY "service_role full access business_accounts"
+  ON public.business_accounts FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- ──────────────────────────────────────────────────────────────────────
+-- Update account_kind_membership view to UNION in the new table.
+-- The view has CREATE OR REPLACE semantics so we re-emit the full
+-- definition with the new branch appended.
+-- ──────────────────────────────────────────────────────────────────────
+
+CREATE OR REPLACE VIEW public.account_kind_membership AS
+  SELECT
+    auth_user_id, 'advisor'::text AS kind, id::text AS kind_id, status,
+    COALESCE(firm_name, name) AS display_label, created_at
+  FROM public.professionals WHERE auth_user_id IS NOT NULL
+UNION ALL
+  SELECT
+    auth_user_id, 'broker_partner'::text, id::text, status,
+    COALESCE(company_name, full_name, broker_slug), created_at
+  FROM public.broker_accounts WHERE auth_user_id IS NOT NULL
+UNION ALL
+  SELECT
+    auth_user_id, 'investor'::text, id::text, 'active'::text,
+    COALESCE(display_name, 'Investor account'), created_at
+  FROM public.investor_profiles WHERE auth_user_id IS NOT NULL
+UNION ALL
+  SELECT
+    auth_user_id, 'business_owner'::text, id::text, status,
+    COALESCE(legal_name, business_name), created_at
+  FROM public.business_accounts WHERE auth_user_id IS NOT NULL;
+
+REVOKE ALL ON public.account_kind_membership FROM anon, authenticated, service_role;
+GRANT SELECT ON public.account_kind_membership TO service_role;
+GRANT SELECT ON public.account_kind_membership TO authenticated;
+
+COMMIT;


### PR DESCRIPTION
## Summary
Adds the `business_owner` AccountKind — biggest unserved persona on the site. Business owners hitting /grants/* and /sell-business/* now get a real account with a dashboard, a persisted grants-eligibility quiz, and sale-prep links. Activates the upgrade-from-listing CTA wiring planned in Phase 4.

## Tier
C — new schema migration + new portal + new auth flow. Migration applied to live via MCP.

## What changed
- `supabase/migrations/20260510220000_business_accounts.sql` — table + RLS + view update
- `lib/account-types.ts` — AccountKind union expanded to all 5 active kinds
- `lib/account-kinds.ts` — WorkspaceKind = AccountKind alias
- `lib/require-business-session.ts` — JWT-only resolver
- `app/business-portal/{layout,page}.tsx` — gated dashboard
- `app/account/upgrade/business/page.tsx` + `BusinessUpgradeForm.tsx` — create/edit form
- `app/api/account/business/route.ts` — GET / POST / PATCH CRUD
- `app/grants/eligibility-quiz/EligibilityQuizClient.tsx` — `useCalculatorState` persistence
- `__tests__/lib/require-business-session.test.ts` — 4 tests

## Compliance
Existing /grants/eligibility-quiz already shows amount + criteria framing per the user's plan-review choice. No new disclaimer copy needed beyond what's in /grants/* already. Future /business-portal/grants surfaces will pull stored answers + reference `lib/compliance.ts`.

## Supersedes
_None._

## Test plan
- [x] 4/4 vitest local green
- [x] Migration applied to live; account_kind_membership view UNIONs business_accounts
- [ ] CI green
- [ ] Manual: log in → /account/upgrade/business → fill form → land on /business-portal
- [ ] Manual: anon take grants quiz → reload → answers restore from sessionStorage