### PR TITLE
feat(account): listing_owner promotion — full Supabase Auth + JWT/OTP dual-tier (W2 Phase 4)

### DIFF
--- a/__tests__/lib/require-listing-owner-session.test.ts
+++ b/__tests__/lib/require-listing-owner-session.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+let mockUser: { id: string; email?: string } | null = null;
+let mockAccountRow: { id: number } | null = null;
+let mockCookie: string | undefined = undefined;
+let mockOtpResult: { ok: boolean; email?: string; reason?: string } = { ok: false, reason: "missing" };
+
+const mockFrom = vi.fn(() => {
+  const chain = {
+    select: () => chain,
+    eq: () => chain,
+    maybeSingle: async () => ({ data: mockAccountRow, error: null }),
+  };
+  return chain;
+});
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({
+    auth: { getUser: async () => ({ data: { user: mockUser } }) },
+    from: mockFrom,
+  }),
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: async () => ({
+    get: (name: string) =>
+      name === "listing_owner_verified" && mockCookie
+        ? { name, value: mockCookie }
+        : undefined,
+  }),
+}));
+
+vi.mock("@/lib/listing-owner-cookie", () => ({
+  LISTING_OWNER_COOKIE_NAME: "listing_owner_verified",
+  verifyListingOwnerCookie: () => mockOtpResult,
+}));
+
+import { requireListingOwnerSession } from "@/lib/require-listing-owner-session";
+
+describe("requireListingOwnerSession", () => {
+  beforeEach(() => {
+    mockUser = null;
+    mockAccountRow = null;
+    mockCookie = undefined;
+    mockOtpResult = { ok: false, reason: "missing" };
+    vi.clearAllMocks();
+  });
+
+  it("returns null when neither JWT nor OTP cookie present", async () => {
+    expect(await requireListingOwnerSession()).toBeNull();
+  });
+
+  it("returns JWT session when user has listing_owner_accounts row", async () => {
+    mockUser = { id: "u1", email: "owner@example.com" };
+    mockAccountRow = { id: 7 };
+    const r = await requireListingOwnerSession();
+    expect(r).toEqual({ kind: "jwt", userId: "u1", accountId: 7 });
+  });
+
+  it("falls back to OTP cookie when JWT lookup misses", async () => {
+    mockUser = null;
+    mockAccountRow = null;
+    mockCookie = "valid-cookie";
+    mockOtpResult = { ok: true, email: "otpowner@example.com" };
+    const r = await requireListingOwnerSession();
+    expect(r).toEqual({ kind: "otp", email: "otpowner@example.com" });
+  });
+
+  it("returns null when OTP cookie verification fails", async () => {
+    mockUser = null;
+    mockCookie = "tampered";
+    mockOtpResult = { ok: false, reason: "bad_signature" };
+    expect(await requireListingOwnerSession()).toBeNull();
+  });
+
+  it("prefers JWT path even when OTP cookie is also present", async () => {
+    mockUser = { id: "u1", email: "owner@example.com" };
+    mockAccountRow = { id: 7 };
+    mockCookie = "valid-cookie";
+    mockOtpResult = { ok: true, email: "otpowner@example.com" };
+    const r = await requireListingOwnerSession();
+    expect(r?.kind).toBe("jwt");
+  });
+});

--- a/app/api/listings/my-listings/claim/route.ts
+++ b/app/api/listings/my-listings/claim/route.ts
@@ -1,0 +1,108 @@
+/**
+ * /api/listings/my-listings/claim — JWT-required listing claim (W2 Phase 4).
+ *
+ * Authenticated user POSTs `{ listing_id, listing_table }` to claim a
+ * listing they own (validated by matching email on the listing record).
+ *
+ * Side-effects:
+ *   1. Insert/update `listing_claims` with `auth_user_id = user.id`
+ *   2. Upsert a `listing_owner_accounts` row for the user
+ *
+ * Pre-existing OTP-cookie path at /api/listings/my-listings/verify is
+ * unchanged; that's the legacy tier for users who haven't signed up yet.
+ */
+
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { withValidatedBody } from "@/lib/validation/withValidatedBody";
+import { logger } from "@/lib/logger";
+
+const log = logger("api:listings:my-listings:claim");
+
+export const runtime = "nodejs";
+
+const Body = z.object({
+  listing_id: z.coerce.number().int().positive(),
+  listing_table: z.enum(["investment_listings", "property_listings"]),
+});
+
+export const POST = withValidatedBody(Body, async (req, body) => {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user || !user.email) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  // Look up the target listing's contact_email via service-role (the
+  // user-scoped client may not have anon SELECT on these columns).
+  const admin = createAdminClient();
+  const { data: listing, error: listingErr } = await admin
+    .from(body.listing_table)
+    .select("id, contact_email, slug, title")
+    .eq("id", body.listing_id)
+    .maybeSingle();
+
+  if (listingErr || !listing) {
+    return NextResponse.json({ error: "listing_not_found" }, { status: 404 });
+  }
+
+  const listingEmail = ((listing as { contact_email?: string }).contact_email ?? "").trim().toLowerCase();
+  const userEmail = user.email.trim().toLowerCase();
+  if (!listingEmail || listingEmail !== userEmail) {
+    return NextResponse.json({ error: "email_mismatch" }, { status: 403 });
+  }
+
+  // Upsert the claim row. listing_claims has `claim_type` + `target_slug`
+  // shape; we key on (auth_user_id, target_slug, claim_type) to enable
+  // idempotent re-claims.
+  const claimType = body.listing_table === "property_listings" ? "property_listing" : "listing";
+  const targetSlug = (listing as { slug?: string }).slug ?? String(body.listing_id);
+
+  const { error: claimErr } = await admin
+    .from("listing_claims")
+    .upsert(
+      {
+        auth_user_id: user.id,
+        email: user.email,
+        claim_type: claimType,
+        target_slug: targetSlug,
+        status: "verified",
+      },
+      { onConflict: "auth_user_id,claim_type,target_slug" },
+    );
+  if (claimErr) {
+    log.warn("listing_claims upsert failed", {
+      userId: user.id,
+      error: claimErr.message,
+    });
+    return NextResponse.json({ error: "claim_insert_failed", detail: claimErr.message }, { status: 500 });
+  }
+
+  // Upsert listing_owner_accounts so future logins land on the listing
+  // workspace. Idempotent — UNIQUE(auth_user_id) prevents duplicates.
+  const { error: accountErr } = await admin
+    .from("listing_owner_accounts")
+    .upsert(
+      {
+        auth_user_id: user.id,
+        display_name: user.email,
+        email_verified_at: new Date().toISOString(),
+        status: "active",
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: "auth_user_id" },
+    );
+  if (accountErr) {
+    log.warn("listing_owner_accounts upsert failed", {
+      userId: user.id,
+      error: accountErr.message,
+    });
+  }
+
+  return NextResponse.json({
+    ok: true,
+    listing: { id: body.listing_id, table: body.listing_table, title: (listing as { title?: string }).title ?? null },
+  });
+});

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -3844,6 +3844,57 @@ export type Database = {
           },
         ]
       }
+      business_accounts: {
+        Row: {
+          abn: string | null
+          acn: string | null
+          auth_user_id: string
+          business_name: string
+          created_at: string
+          employees_band: string | null
+          id: number
+          industry: string | null
+          legal_name: string | null
+          primary_state: string | null
+          revenue_band: string | null
+          status: string
+          updated_at: string
+          year_established: number | null
+        }
+        Insert: {
+          abn?: string | null
+          acn?: string | null
+          auth_user_id: string
+          business_name: string
+          created_at?: string
+          employees_band?: string | null
+          id?: never
+          industry?: string | null
+          legal_name?: string | null
+          primary_state?: string | null
+          revenue_band?: string | null
+          status?: string
+          updated_at?: string
+          year_established?: number | null
+        }
+        Update: {
+          abn?: string | null
+          acn?: string | null
+          auth_user_id?: string
+          business_name?: string
+          created_at?: string
+          employees_band?: string | null
+          id?: never
+          industry?: string | null
+          legal_name?: string | null
+          primary_state?: string | null
+          revenue_band?: string | null
+          status?: string
+          updated_at?: string
+          year_established?: number | null
+        }
+        Relationships: []
+      }
       buyer_agents: {
         Row: {
           agency_name: string | null
@@ -8012,6 +8063,7 @@ export type Database = {
       listing_claims: {
         Row: {
           admin_notes: string | null
+          auth_user_id: string | null
           claim_type: string
           company_role: string | null
           created_at: string | null
@@ -8025,6 +8077,7 @@ export type Database = {
         }
         Insert: {
           admin_notes?: string | null
+          auth_user_id?: string | null
           claim_type: string
           company_role?: string | null
           created_at?: string | null
@@ -8038,6 +8091,7 @@ export type Database = {
         }
         Update: {
           admin_notes?: string | null
+          auth_user_id?: string | null
           claim_type?: string
           company_role?: string | null
           created_at?: string | null
@@ -8100,6 +8154,36 @@ export type Database = {
             referencedColumns: ["id"]
           },
         ]
+      }
+      listing_owner_accounts: {
+        Row: {
+          auth_user_id: string
+          created_at: string
+          display_name: string | null
+          email_verified_at: string | null
+          id: number
+          status: string
+          updated_at: string
+        }
+        Insert: {
+          auth_user_id: string
+          created_at?: string
+          display_name?: string | null
+          email_verified_at?: string | null
+          id?: never
+          status?: string
+          updated_at?: string
+        }
+        Update: {
+          auth_user_id?: string
+          created_at?: string
+          display_name?: string | null
+          email_verified_at?: string | null
+          id?: never
+          status?: string
+          updated_at?: string
+        }
+        Relationships: []
       }
       listing_plans: {
         Row: {
@@ -12563,6 +12647,17 @@ export type Database = {
       }
     }
     Views: {
+      account_kind_membership: {
+        Row: {
+          auth_user_id: string | null
+          created_at: string | null
+          display_label: string | null
+          kind: string | null
+          kind_id: string | null
+          status: string | null
+        }
+        Relationships: []
+      }
       admin_advisor_health: {
         Row: {
           admin_tags: string[] | null

--- a/lib/require-listing-owner-session.ts
+++ b/lib/require-listing-owner-session.ts
@@ -1,0 +1,77 @@
+/**
+ * Listing-owner session resolver (W2 Phase 4).
+ *
+ * Two-tier auth:
+ *   1. JWT (full Supabase Auth): user has a `listing_owner_accounts` row.
+ *      Returned shape: `{ kind: "jwt", userId, accountId }`.
+ *   2. OTP cookie fallback (legacy at `/invest/my-listings`): the existing
+ *      `iv_listing_owner_otp` HMAC-signed cookie issued by /api/listings/
+ *      my-listings/verify is still valid. Returned shape:
+ *      `{ kind: "otp", email }`.
+ *   3. Neither → null.
+ *
+ * The dual-auth pattern lets us promote the OTP cookie to a full account
+ * over a 60-day rollout without breaking existing OTP-verified users.
+ * Phase 4b deprecates the cookie path once dual-write metrics show ≥80%
+ * conversion.
+ */
+
+import { createClient } from "@/lib/supabase/server";
+import { logger } from "@/lib/logger";
+
+const log = logger("require-listing-owner-session");
+
+export type ListingOwnerSession =
+  | { kind: "jwt"; userId: string; accountId: number }
+  | { kind: "otp"; email: string };
+
+export async function requireListingOwnerSession(): Promise<ListingOwnerSession | null> {
+  // 1. Try JWT first.
+  try {
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (user) {
+      const { data, error } = await supabase
+        .from("listing_owner_accounts")
+        .select("id")
+        .eq("auth_user_id", user.id)
+        .eq("status", "active")
+        .maybeSingle();
+      if (error) {
+        log.warn("listing-owner JWT lookup failed", {
+          userId: user.id,
+          error: error.message,
+        });
+      } else if (data) {
+        return { kind: "jwt", userId: user.id, accountId: data.id as number };
+      }
+    }
+  } catch (err) {
+    log.warn("requireListingOwnerSession JWT path threw", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  // 2. Try OTP cookie fallback. The cookie helper is sync; we read the
+  // cookie via next/headers and pass the value in.
+  try {
+    const { cookies } = await import("next/headers");
+    const { verifyListingOwnerCookie, LISTING_OWNER_COOKIE_NAME } = await import(
+      "@/lib/listing-owner-cookie"
+    );
+    const c = await cookies();
+    const value = c.get(LISTING_OWNER_COOKIE_NAME)?.value;
+    if (value) {
+      const result = verifyListingOwnerCookie(value);
+      if (result.ok && result.email) {
+        return { kind: "otp", email: result.email };
+      }
+    }
+  } catch (err) {
+    log.debug("OTP cookie fallback failed (non-fatal)", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  return null;
+}

--- a/supabase/migrations/20260510240000_listing_owner_accounts.sql
+++ b/supabase/migrations/20260510240000_listing_owner_accounts.sql
@@ -1,0 +1,93 @@
+-- ============================================================================
+-- Migration: 20260510240000_listing_owner_accounts.sql
+-- Purpose: listing_owner AccountKind — promotes the existing OTP-cookie
+--          flow at /invest/my-listings to a full Supabase Auth account.
+--          OTP cookie path stays as a 60-day fallback tier.
+-- Audit ref: account-system-expansion plan, Phase 4.
+-- Risk: low — additive table + nullable column on listing_claims.
+-- Rollback: DROP TABLE IF EXISTS public.listing_owner_accounts;
+--           ALTER TABLE public.listing_claims DROP COLUMN IF EXISTS auth_user_id;
+-- ============================================================================
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.listing_owner_accounts (
+  id              bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  auth_user_id    uuid   NOT NULL UNIQUE REFERENCES auth.users(id) ON DELETE CASCADE,
+  display_name    text,
+  email_verified_at timestamptz,
+  status          text   NOT NULL DEFAULT 'active'
+                  CHECK (status IN ('active','inactive')),
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  updated_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_listing_owner_accounts_auth_user
+  ON public.listing_owner_accounts (auth_user_id);
+
+ALTER TABLE public.listing_owner_accounts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.listing_owner_accounts FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "listing_owner reads own account" ON public.listing_owner_accounts;
+CREATE POLICY "listing_owner reads own account"
+  ON public.listing_owner_accounts FOR SELECT
+  TO authenticated
+  USING (auth.uid() = auth_user_id);
+
+DROP POLICY IF EXISTS "listing_owner upserts own account" ON public.listing_owner_accounts;
+CREATE POLICY "listing_owner upserts own account"
+  ON public.listing_owner_accounts FOR INSERT
+  TO authenticated
+  WITH CHECK (auth.uid() = auth_user_id);
+
+DROP POLICY IF EXISTS "listing_owner updates own account" ON public.listing_owner_accounts;
+CREATE POLICY "listing_owner updates own account"
+  ON public.listing_owner_accounts FOR UPDATE
+  TO authenticated
+  USING (auth.uid() = auth_user_id)
+  WITH CHECK (auth.uid() = auth_user_id);
+
+DROP POLICY IF EXISTS "service_role full access listing_owner_accounts"
+  ON public.listing_owner_accounts;
+CREATE POLICY "service_role full access listing_owner_accounts"
+  ON public.listing_owner_accounts FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- listing_claims gets an auth_user_id column so claimed listings can be
+-- aggregated per-user. Existing OTP-cookie claims have NULL here; the
+-- claim API populates the column when the user is authenticated.
+ALTER TABLE public.listing_claims
+  ADD COLUMN IF NOT EXISTS auth_user_id uuid REFERENCES auth.users(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_listing_claims_auth_user
+  ON public.listing_claims (auth_user_id) WHERE auth_user_id IS NOT NULL;
+
+-- Update account_kind_membership view to UNION in listing_owner_accounts.
+CREATE OR REPLACE VIEW public.account_kind_membership AS
+  SELECT auth_user_id, 'advisor'::text AS kind, id::text AS kind_id, status,
+    COALESCE(firm_name, name) AS display_label, created_at
+  FROM public.professionals WHERE auth_user_id IS NOT NULL
+UNION ALL
+  SELECT auth_user_id, 'broker_partner'::text, id::text, status,
+    COALESCE(company_name, full_name, broker_slug), created_at
+  FROM public.broker_accounts WHERE auth_user_id IS NOT NULL
+UNION ALL
+  SELECT auth_user_id, 'investor'::text, id::text, 'active'::text,
+    COALESCE(display_name, 'Investor account'), created_at
+  FROM public.investor_profiles WHERE auth_user_id IS NOT NULL
+UNION ALL
+  SELECT auth_user_id, 'business_owner'::text, id::text, status,
+    COALESCE(legal_name, business_name), created_at
+  FROM public.business_accounts WHERE auth_user_id IS NOT NULL
+UNION ALL
+  SELECT auth_user_id, 'listing_owner'::text, id::text, status,
+    COALESCE(display_name, 'Listing owner account'), created_at
+  FROM public.listing_owner_accounts WHERE auth_user_id IS NOT NULL;
+
+REVOKE ALL ON public.account_kind_membership FROM anon, authenticated, service_role;
+GRANT SELECT ON public.account_kind_membership TO service_role;
+GRANT SELECT ON public.account_kind_membership TO authenticated;
+
+COMMIT;


### PR DESCRIPTION
## Summary
Promotes the existing OTP-cookie flow at /invest/my-listings to a full Supabase Auth account. OTP cookie stays as a 60-day fallback tier so existing users aren't disrupted. Adds `auth_user_id` to `listing_claims` for per-user listing aggregation.

## Tier
C — new schema migration + alter existing table + new auth flow. Migration applied to live via MCP.

## What changed
- `supabase/migrations/20260510240000_listing_owner_accounts.sql` — table + RLS + listing_claims.auth_user_id column + view update
- `lib/require-listing-owner-session.ts` — dual-tier resolver (JWT first, OTP cookie fallback)
- `app/api/listings/my-listings/claim/route.ts` — JWT-required claim endpoint validates email match, upserts listing_claims + listing_owner_accounts
- `__tests__/lib/require-listing-owner-session.test.ts` — 5 dual-auth tests
- types regen'd

## What's NOT in this PR (next session)
- /invest/my-listings page UI updates (sign-up CTA when OTP-only; aggregated dashboard when JWT)
- Business-CTA at first claim ("This looks like a business listing — track grants too?")
- Phase 4b: OTP cookie deprecation after 60-day rollout

## Supersedes
_None._

## Test plan
- [x] 5/5 vitest local green (JWT priority, OTP fallback, neither, error states)
- [x] Migration applied to live; account_kind_membership view UNIONs listing_owner_accounts
- [ ] CI green
- [ ] Manual: existing OTP-verified user still hits OTP path (legacy unchanged)
- [ ] Manual: signed-in user with matching email POSTs /api/listings/my-listings/claim → row in listing_claims with auth_user_id + listing_owner_accounts row