### PR TITLE
feat(account): per-portal active-kind gates (strict-separation enforcement)

### DIFF
--- a/app/account/holdings/page.tsx
+++ b/app/account/holdings/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import HoldingsClient, { type HoldingRow } from "./HoldingsClient";
 import { getCurrentPricesBatch, keyOf } from "@/lib/holdings/value";
+import { enforcePortalKind } from "@/lib/portal-gate";
 
 export const dynamic = "force-dynamic";
 
@@ -12,6 +13,12 @@ export const metadata: Metadata = {
 };
 
 export default async function HoldingsPage() {
+  // Strict-separation gate: holdings is investor-workspace data only. An
+  // advisor in advisor workspace navigating here gets redirected back to
+  // /account/select-workspace. RLS already isolates by auth.uid(); the
+  // gate just makes the workspace promise visible at the UX layer.
+  await enforcePortalKind("investor");
+
   const supabase = await createClient();
   const {
     data: { user },

--- a/app/advisor-portal/layout.tsx
+++ b/app/advisor-portal/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { enforcePortalKind } from "@/lib/portal-gate";
 
 export const metadata: Metadata = {
   title: "Advisor Portal — Invest.com.au",
@@ -6,6 +7,9 @@ export const metadata: Metadata = {
   robots: { index: false, follow: false },
 };
 
-export default function AdvisorPortalLayout({ children }: { children: React.ReactNode }) {
+export const dynamic = "force-dynamic";
+
+export default async function AdvisorPortalLayout({ children }: { children: React.ReactNode }) {
+  await enforcePortalKind("advisor");
   return <>{children}</>;
 }

--- a/lib/portal-gate.ts
+++ b/lib/portal-gate.ts
@@ -1,0 +1,84 @@
+/**
+ * Portal active-kind gate (W2 strict-separation enforcement).
+ *
+ * Each portal layout calls `enforcePortalKind(expected)` on every render.
+ * Returns null when the visitor is allowed; returns a redirect URL when
+ * they should be sent elsewhere.
+ *
+ * Decision matrix:
+ *
+ *   | active-kind cookie | holds expected kind | action                                          |
+ *   |--------------------|--------------------|-------------------------------------------------|
+ *   | absent             | yes                | set cookie to expected, allow                  |
+ *   | absent             | no                 | redirect to /account/select-workspace          |
+ *   | matches expected   | yes                | allow                                           |
+ *   | matches expected   | no                 | clear cookie, redirect to chooser              |
+ *   | mismatch           | yes                | redirect to /account/select-workspace          |
+ *   | mismatch           | no                 | redirect to /account/select-workspace          |
+ *
+ * The mismatch case is the load-bearing strict-separation gate. An
+ * advisor in advisor workspace navigating to /business-portal hits this:
+ * cookie says advisor, expected says business_owner → redirect to
+ * chooser. Chooser surfaces all kinds the user holds; they pick again
+ * deliberately.
+ *
+ * RLS on each kind's table is the underlying data isolation. This gate
+ * is the UX layer — without it, multi-kind users would silently see
+ * data from kinds they didn't intend to be acting as.
+ */
+
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import {
+  getActiveKind,
+  getKindsForUser,
+  setActiveKind,
+  type WorkspaceKind,
+} from "@/lib/account-kinds";
+
+const CHOOSER = "/account/select-workspace";
+
+export async function enforcePortalKind(expected: WorkspaceKind): Promise<void> {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    redirect(`/account/login?redirect=${encodeURIComponent(currentPortalPath(expected))}`);
+  }
+
+  const [active, memberships] = await Promise.all([
+    getActiveKind(),
+    getKindsForUser(user.id),
+  ]);
+  const holdsExpected = memberships.some((m) => m.kind === expected);
+
+  if (active === expected && holdsExpected) {
+    return; // happy path
+  }
+
+  if (active === null && holdsExpected) {
+    // First visit since cookie expired or new device. Set + allow.
+    await setActiveKind(expected);
+    return;
+  }
+
+  if (!holdsExpected) {
+    // User isn't entitled to this portal at all. Send to chooser; the
+    // chooser will only surface kinds they actually hold.
+    redirect(CHOOSER);
+  }
+
+  // Cookie mismatches expected: user holds this kind but is currently
+  // "acting as" a different one. Send to chooser to make the switch
+  // deliberate.
+  redirect(`${CHOOSER}?from=${encodeURIComponent(currentPortalPath(expected))}`);
+}
+
+function currentPortalPath(kind: WorkspaceKind): string {
+  switch (kind) {
+    case "advisor": return "/advisor-portal";
+    case "broker_partner": return "/broker-portal";
+    case "business_owner": return "/business-portal";
+    case "listing_owner": return "/invest/my-listings";
+    case "investor": return "/account";
+  }
+}


### PR DESCRIPTION
Closes the workspace strict-separation loop. New lib/portal-gate.ts called from /advisor-portal/layout and /account/holdings/page redirects to /account/select-workspace when active-kind cookie doesn't match. RLS already isolates per kind; this is the UX surface gate.

Tier B — server-only utility + 2 layout edits.

## Test plan
- [ ] CI green
- [ ] Manual: log in as multi-kind user, visit /account/holdings while in advisor workspace → redirected to chooser
- [ ] Manual: log in as advisor only, visit /account/holdings → redirected to chooser (lacks investor kind)