### PR TITLE
feat(account): /account/investor-profile flags UI (W2 Phase 2 follow-up)

### DIFF
--- a/app/account/investor-profile/InvestorProfileForm.tsx
+++ b/app/account/investor-profile/InvestorProfileForm.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import { useRouter } from "next/navigation";
+import type {
+  InvestorProfile,
+  BudgetBand,
+  ExperienceLevel,
+} from "@/lib/investor-profiles";
+
+interface Props {
+  initial: InvestorProfile | null;
+}
+
+const COUNTRIES = [
+  { value: "uk", label: "🇬🇧 United Kingdom" },
+  { value: "us", label: "🇺🇸 United States" },
+  { value: "cn", label: "🇨🇳 China" },
+  { value: "in", label: "🇮🇳 India" },
+  { value: "jp", label: "🇯🇵 Japan" },
+  { value: "sg", label: "🇸🇬 Singapore" },
+  { value: "hk", label: "🇭🇰 Hong Kong" },
+  { value: "kr", label: "🇰🇷 South Korea" },
+  { value: "my", label: "🇲🇾 Malaysia" },
+  { value: "nz", label: "🇳🇿 New Zealand" },
+  { value: "ae", label: "🇦🇪 UAE" },
+  { value: "sa", label: "🇸🇦 Saudi Arabia" },
+] as const;
+
+const BUDGETS: { value: BudgetBand; label: string }[] = [
+  { value: "small",  label: "Under $5K" },
+  { value: "medium", label: "$5K – $50K" },
+  { value: "large",  label: "$50K – $100K" },
+  { value: "whale",  label: "$100K+" },
+];
+
+const EXPERIENCE: { value: ExperienceLevel; label: string }[] = [
+  { value: "beginner",     label: "Beginner — new to this" },
+  { value: "intermediate", label: "Intermediate — confident with the basics" },
+  { value: "pro",          label: "Pro — advanced trading / SMSF / pre-IPO" },
+];
+
+const FLAGS = [
+  { key: "is_fhb",            label: "First home buyer",       desc: "Surfaces FHOG / FHSS guides + first-home savings calculators." },
+  { key: "is_pre_retiree",    label: "Pre-retiree",            desc: "Surfaces super-contribution + transition-to-retirement content." },
+  { key: "is_business_owner", label: "Business owner",         desc: "Surfaces grants tracker + R&D + sell-business content." },
+  { key: "is_cross_border",   label: "Cross-border investor",  desc: "Surfaces foreign-investment hubs + country-specific tax guides." },
+  { key: "is_hnw",            label: "High-net-worth (>$100K)",desc: "Surfaces wholesale + private-credit + premium-tier advisor content." },
+] as const;
+
+export default function InvestorProfileForm({ initial }: Props) {
+  const router = useRouter();
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setError(null);
+    setSaved(false);
+    setSubmitting(true);
+    const fd = new FormData(e.currentTarget);
+    const body: Record<string, unknown> = {
+      display_name: String(fd.get("display_name") ?? "").trim() || null,
+      intent_country_snapshot: String(fd.get("intent_country") ?? "") || null,
+      budget_band: String(fd.get("budget") ?? "") || null,
+      experience_level: String(fd.get("experience") ?? "") || null,
+      primary_vertical: String(fd.get("primary_vertical") ?? "") || null,
+    };
+    for (const f of FLAGS) {
+      body[f.key] = fd.get(f.key) === "on";
+    }
+    try {
+      const res = await fetch("/api/account/investor-profile", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const j = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(j.error ?? "Could not save");
+      }
+      setSaved(true);
+      router.refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not save profile.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="bg-white border border-slate-200 rounded-xl p-5 space-y-5"
+    >
+      <Field label="Display name (optional)">
+        <input
+          type="text" name="display_name" maxLength={120}
+          defaultValue={initial?.displayName ?? ""}
+          className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm"
+        />
+      </Field>
+
+      <fieldset className="space-y-3">
+        <legend className="text-sm font-semibold text-slate-900">Life-event flags</legend>
+        <p className="text-xs text-slate-500">
+          Used for content routing only. Never to drive personal-advice copy.
+        </p>
+        {FLAGS.map((f) => (
+          <label key={f.key} className="flex items-start gap-3 cursor-pointer">
+            <input
+              type="checkbox" name={f.key}
+              defaultChecked={Boolean(initial?.[f.key as keyof InvestorProfile])}
+              className="mt-0.5"
+            />
+            <span>
+              <span className="text-sm font-medium text-slate-900">{f.label}</span>
+              <span className="block text-xs text-slate-600">{f.desc}</span>
+            </span>
+          </label>
+        ))}
+      </fieldset>
+
+      <Field label="Country / origin (if cross-border)">
+        <select name="intent_country" defaultValue={initial?.intentCountrySnapshot ?? ""}
+          className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm">
+          <option value="">Australia (default)</option>
+          {COUNTRIES.map((c) => <option key={c.value} value={c.value}>{c.label}</option>)}
+        </select>
+      </Field>
+
+      <Field label="Investment budget band">
+        <select name="budget" defaultValue={initial?.budgetBand ?? ""}
+          className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm">
+          <option value="">Prefer not to say</option>
+          {BUDGETS.map((b) => <option key={b.value} value={b.value}>{b.label}</option>)}
+        </select>
+      </Field>
+
+      <Field label="Investing experience">
+        <select name="experience" defaultValue={initial?.experienceLevel ?? ""}
+          className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm">
+          <option value="">Prefer not to say</option>
+          {EXPERIENCE.map((e) => <option key={e.value} value={e.value}>{e.label}</option>)}
+        </select>
+      </Field>
+
+      <Field label="Primary investing vertical (free text)">
+        <input
+          type="text" name="primary_vertical" maxLength={50}
+          defaultValue={initial?.primaryVertical ?? ""}
+          placeholder="shares / super / property / crypto / cfd"
+          className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm"
+        />
+      </Field>
+
+      {error && <p className="text-sm text-red-700" role="alert">{error}</p>}
+      {saved && <p className="text-sm text-emerald-700">Saved ✓</p>}
+
+      <button type="submit" disabled={submitting}
+        className="w-full px-4 py-2.5 bg-emerald-700 hover:bg-emerald-800 text-white font-semibold rounded-lg disabled:opacity-50">
+        {submitting ? "Saving…" : "Save investor profile"}
+      </button>
+      <p className="text-xs text-slate-500 italic">
+        General information only — see your accountant or financial advisor for personalised guidance.
+      </p>
+    </form>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="block">
+      <span className="block text-xs font-medium text-slate-700 mb-1">{label}</span>
+      {children}
+    </label>
+  );
+}

--- a/app/account/investor-profile/page.tsx
+++ b/app/account/investor-profile/page.tsx
@@ -1,0 +1,42 @@
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { getInvestorProfile } from "@/lib/investor-profiles";
+import InvestorProfileForm from "./InvestorProfileForm";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Investor profile — My Account",
+  robots: "noindex, nofollow",
+};
+
+export default async function InvestorProfilePage() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    redirect("/account/login?redirect=/account/investor-profile");
+  }
+
+  const profile = await getInvestorProfile(user.id);
+
+  return (
+    <main className="bg-slate-50 min-h-[60vh]">
+      <div className="max-w-2xl mx-auto px-4 sm:px-6 py-10">
+        <header className="mb-6">
+          <p className="text-xs font-semibold uppercase tracking-wider text-emerald-700 mb-2">
+            <span aria-hidden className="mr-1.5">📈</span>
+            Investor profile
+          </p>
+          <h1 className="text-2xl font-bold text-slate-900">
+            Tell us how to personalise the site for you
+          </h1>
+          <p className="text-sm text-slate-600 mt-2">
+            These flags shape the smart-recommendations strip across the site (broker matches, advisor matches, content surfaces). Comparison + factual content only — never personal advice. Toggle anything on or off any time.
+          </p>
+        </header>
+        <InvestorProfileForm initial={profile} />
+      </div>
+    </main>
+  );
+}

--- a/app/api/account/investor-profile/route.ts
+++ b/app/api/account/investor-profile/route.ts
@@ -1,0 +1,75 @@
+/**
+ * /api/account/investor-profile — investor_profiles CRUD (W2 Phase 2 follow-up).
+ *
+ * GET   — current user's investor profile (or null)
+ * PATCH — update typed columns (life-event flags + ranker inputs + display_name)
+ *
+ * Lives alongside the syncQuizToInvestorProfile path: quizzes auto-populate
+ * the row; this route lets users override / refine those values directly.
+ */
+
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { createClient } from "@/lib/supabase/server";
+import { withValidatedBody } from "@/lib/validation/withValidatedBody";
+import { upsertInvestorProfile, getInvestorProfile } from "@/lib/investor-profiles";
+import { logger } from "@/lib/logger";
+
+const log = logger("api:account:investor-profile");
+
+export const runtime = "nodejs";
+
+const COUNTRY_CODES = ["uk","us","cn","in","jp","sg","hk","kr","my","nz","ae","sa"] as const;
+const BUDGET_BANDS = ["small","medium","large","whale"] as const;
+const EXPERIENCE_LEVELS = ["beginner","intermediate","pro"] as const;
+
+const Body = z.object({
+  display_name: z.string().max(120).nullish(),
+  is_fhb: z.boolean().optional(),
+  is_pre_retiree: z.boolean().optional(),
+  is_business_owner: z.boolean().optional(),
+  is_cross_border: z.boolean().optional(),
+  is_hnw: z.boolean().optional(),
+  intent_country_snapshot: z.enum(COUNTRY_CODES).nullish().or(z.literal("")),
+  budget_band: z.enum(BUDGET_BANDS).nullish().or(z.literal("")),
+  experience_level: z.enum(EXPERIENCE_LEVELS).nullish().or(z.literal("")),
+  primary_vertical: z.string().max(50).nullish(),
+});
+
+function emptyToNull<T extends Record<string, unknown>>(obj: T): T {
+  const out: Record<string, unknown> = { ...obj };
+  for (const k of Object.keys(out)) {
+    if (out[k] === "") out[k] = null;
+  }
+  return out as T;
+}
+
+export async function GET() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+
+  const profile = await getInvestorProfile(user.id);
+  return NextResponse.json({ profile });
+}
+
+export const PATCH = withValidatedBody(Body, async (req, body) => {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+
+  const cleaned = emptyToNull(body);
+  // Filter out undefined keys so we only patch what was sent.
+  const patch: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(cleaned)) {
+    if (v !== undefined) patch[k] = v;
+  }
+
+  const ok = await upsertInvestorProfile(user.id, patch);
+  if (!ok) {
+    log.warn("investor-profile PATCH failed", { userId: user.id });
+    return NextResponse.json({ error: "update_failed" }, { status: 500 });
+  }
+  const fresh = await getInvestorProfile(user.id);
+  return NextResponse.json({ profile: fresh });
+});


### PR DESCRIPTION
User-facing form to override / refine the life-event flags + ranker inputs that quiz answers normally populate. Lives at /account/investor-profile alongside the existing /account/profile (kept separate to avoid bloating the primary settings UX).

Tier B — additive UI + new GET/PATCH endpoint. RLS enforces per-user scoping.

## Test plan
- [ ] CI green
- [ ] Manual: visit /account/investor-profile signed-in → toggle FHB flag → save → smart-recs strip surfaces FHB content