### PR TITLE
feat(kk): KK-04 iter 2 — LSI/cluster-aware internal link selection [audit remediation]

### DIFF
--- a/.driftallowlist
+++ b/.driftallowlist
@@ -140,7 +140,3 @@ fund_reviews              # fund review content — backfill migration pending
 
 # PostGIS extension-managed (out of scope — comes from CREATE EXTENSION postgis)
 spatial_ref_sys
-
-# W2 Phase — tables created in Supabase dashboard without migration files; pending Stream A backfill
-business_accounts  # W2 Phase 2.5 — business account type; migration pending
-investor_goals     # W2 Phase 2 — investor goals tracking; migration pending

--- a/.driftallowlist
+++ b/.driftallowlist
@@ -140,3 +140,7 @@ fund_reviews              # fund review content — backfill migration pending
 
 # PostGIS extension-managed (out of scope — comes from CREATE EXTENSION postgis)
 spatial_ref_sys
+
+# W2 Phase — tables created in Supabase dashboard without migration files; pending Stream A backfill
+business_accounts  # W2 Phase 2.5 — business account type; migration pending
+investor_goals     # W2 Phase 2 — investor goals tracking; migration pending

--- a/__tests__/lib/keyword-linking.test.ts
+++ b/__tests__/lib/keyword-linking.test.ts
@@ -4,6 +4,8 @@ import {
   GLOSSARY_LINK_TARGETS,
   linkifyHtml,
   splitByLinks,
+  pillarPathForCategory,
+  getClusterPaths,
 } from "@/lib/keyword-linking";
 
 describe("INTERNAL_LINK_TARGETS", () => {
@@ -229,5 +231,85 @@ describe("linkifyHtml", () => {
     const out = linkifyHtml("<p>CommSec without closing");
     expect(out).toContain("<p>");
     expect(out.length).toBeGreaterThan(0);
+  });
+});
+
+describe("pillarPathForCategory", () => {
+  it("maps known categories to their pillar paths", () => {
+    expect(pillarPathForCategory("smsf")).toBe("/smsf");
+    expect(pillarPathForCategory("tax")).toBe("/tax");
+    expect(pillarPathForCategory("etfs")).toBe("/etfs");
+    expect(pillarPathForCategory("property")).toBe("/property");
+  });
+
+  it("handles mixed-case category strings", () => {
+    expect(pillarPathForCategory("SMSF")).toBe("/smsf");
+    expect(pillarPathForCategory("Tax & Strategy")).toBe("/tax");
+  });
+
+  it("returns undefined for unknown or missing categories", () => {
+    expect(pillarPathForCategory("news")).toBeUndefined();
+    expect(pillarPathForCategory()).toBeUndefined();
+    expect(pillarPathForCategory("")).toBeUndefined();
+  });
+});
+
+describe("getClusterPaths", () => {
+  it("returns hrefs for a known pillar", () => {
+    const paths = getClusterPaths("/smsf");
+    expect(paths.has("/smsf")).toBe(true);
+    expect(paths.size).toBeGreaterThan(1);
+  });
+
+  it("returns an empty set for an unknown pillar path", () => {
+    expect(getClusterPaths("/unknown-path").size).toBe(0);
+  });
+});
+
+describe("splitByLinks — cluster-aware selection", () => {
+  it("without pillarPath: injects first-N links in text order", () => {
+    // CommSec appears first; SelfWealth second. Both are /broker/ paths — not SMSF cluster.
+    const text = "CommSec and SelfWealth are popular brokers. SMSF investors use different platforms.";
+    const out = splitByLinks(text, 1);
+    const links = out.filter((p) => typeof p !== "string");
+    expect(links).toHaveLength(1);
+    // Without cluster context, CommSec (first in text) wins.
+    expect(links[0]).toMatchObject({ href: "/broker/commsec" });
+  });
+
+  it("with SMSF pillarPath: prefers cluster-relevant SMSF link over earlier broker link", () => {
+    // CommSec appears first, SMSF appears second. With smsf cluster, SMSF should win.
+    const text = "CommSec and SelfWealth are popular brokers. SMSF investors use different platforms.";
+    const out = splitByLinks(text, 1, "/smsf");
+    const links = out.filter((p) => typeof p !== "string");
+    expect(links).toHaveLength(1);
+    expect(links[0]).toMatchObject({ href: "/smsf" });
+  });
+
+  it("preserves all text content when cluster selection skips an earlier match", () => {
+    const original = "CommSec and SelfWealth are popular. SMSF investors differ.";
+    const out = splitByLinks(original, 1, "/smsf");
+    const reconstructed = out.map((p) => (typeof p === "string" ? p : p.label)).join("");
+    expect(reconstructed).toBe(original);
+  });
+
+  it("fills remaining cap slots with non-cluster links after cluster links are selected", () => {
+    // With maxLinks=2 and SMSF cluster: first slot = /smsf (cluster), second = CommSec (generic).
+    const text = "CommSec and SelfWealth are brokers. SMSF investors need an SMSF accountant.";
+    const out = splitByLinks(text, 2, "/smsf");
+    const links = out.filter((p) => typeof p !== "string");
+    expect(links).toHaveLength(2);
+    const hrefs = links.map((l) => (typeof l !== "string" ? l.href : ""));
+    // SMSF accountant (/advisors/smsf-accountants) is cluster-relevant (supporting)
+    // CommSec or SelfWealth fills the second slot
+    expect(hrefs.some((h) => h.startsWith("/smsf") || h.startsWith("/advisors/smsf"))).toBe(true);
+  });
+
+  it("falls back to original behaviour when pillarPath resolves to no cluster", () => {
+    const text = "CommSec and SelfWealth are popular brokers.";
+    const withUnknown = splitByLinks(text, 1, "/unknown-pillar");
+    const withoutPillar = splitByLinks(text, 1);
+    // Both should inject CommSec (first in text) since no cluster context applies
+    expect(withUnknown).toEqual(withoutPillar);
   });
 });

--- a/app/article/[slug]/page.tsx
+++ b/app/article/[slug]/page.tsx
@@ -27,6 +27,7 @@ import AdvisorPrompt from "@/components/AdvisorPrompt";
 import LinkifiedText from "@/components/LinkifiedText";
 import FloatingRightCTA from "@/components/FloatingRightCTA";
 import { isFlagEnabled } from "@/lib/feature-flags";
+import { pillarPathForCategory } from "@/lib/keyword-linking";
 
 export const revalidate = 3600; // ISR: revalidate every hour
 
@@ -154,6 +155,7 @@ export default async function ArticlePage({
   const relatedBrokers = (relatedBrokersRes.data as Broker[]) || [];
   const allFxBrokers = (fxBrokersRes.data as Broker[]) || [];
   const allBrokersForWidget = (allActiveBrokersRes.data as Broker[]) || [];
+  const articlePillarPath = pillarPathForCategory(a.category);
   const relatedArticles = [
     ...((relatedArticlesRes.data || []) as Article[]),
     ...((crossCategoryRes.data || []) as Article[]).filter(
@@ -428,6 +430,7 @@ export default async function ArticlePage({
                       skipHrefs={[`/article/${a.slug}`]}
                       disabled={!linkInjectionEnabled}
                       maxLinks={5}
+                      pillarPath={articlePillarPath}
                     />
                   </section>
 
@@ -459,6 +462,7 @@ export default async function ArticlePage({
                           skipHrefs={[`/article/${a.slug}`]}
                           disabled={!linkInjectionEnabled}
                           maxLinks={5}
+                          pillarPath={articlePillarPath}
                         />
                       </section>
                     )
@@ -513,6 +517,7 @@ export default async function ArticlePage({
                             skipHrefs={[`/article/${a.slug}`]}
                             disabled={!linkInjectionEnabled}
                             maxLinks={5}
+                            pillarPath={articlePillarPath}
                           />
                         </section>
                         {/* In-content ad after 2nd section (only if 4+ sections for density) */}

--- a/components/LinkifiedText.tsx
+++ b/components/LinkifiedText.tsx
@@ -23,6 +23,12 @@ interface Props {
    * Default: unlimited (existing behaviour when omitted).
    */
   maxLinks?: number;
+  /**
+   * Hub pillar path for the article's topic cluster (e.g. "/smsf", "/tax").
+   * When provided with `maxLinks`, cluster-relevant links fill the cap first.
+   * Obtain via `pillarPathForCategory(article.category)`.
+   */
+  pillarPath?: string;
 }
 
 /**
@@ -34,7 +40,7 @@ interface Props {
  * returns an array of `string | {href,label}` nodes that React renders
  * natively.
  */
-export default function LinkifiedText({ text, skipHrefs, className, disabled, maxLinks }: Props) {
+export default function LinkifiedText({ text, skipHrefs, className, disabled, maxLinks, pillarPath }: Props) {
   if (!text) return null;
 
   const wrapperClass = `max-w-none text-slate-700 leading-relaxed whitespace-pre-line ${className ?? ""}`;
@@ -44,7 +50,7 @@ export default function LinkifiedText({ text, skipHrefs, className, disabled, ma
   }
 
   const skip = new Set(skipHrefs ?? []);
-  const parts = splitByLinks(text, maxLinks);
+  const parts = splitByLinks(text, maxLinks, pillarPath);
 
   return (
     <div className={wrapperClass}>

--- a/lib/keyword-linking.ts
+++ b/lib/keyword-linking.ts
@@ -20,6 +20,7 @@
  */
 
 import { GLOSSARY_ENTRIES } from "@/lib/glossary";
+import { getPillarForPath } from "@/lib/content/topic-clusters";
 
 export interface LinkTarget {
   /** Keyword match (case-insensitive, word-boundary) */
@@ -151,6 +152,46 @@ function findTarget(matchedText: string): LinkTarget | undefined {
   return SORTED_TARGETS.find((l) => l.keyword.toLowerCase() === lower);
 }
 
+/**
+ * Maps an article category string to its hub pillar path in the topic cluster
+ * map. Pass the result to `splitByLinks` / `linkifyHtml` so cluster-relevant
+ * links are preferred when the density cap is active.
+ */
+export function pillarPathForCategory(category?: string): string | undefined {
+  if (!category) return undefined;
+  const map: Record<string, string> = {
+    smsf: "/smsf",
+    "super & smsf": "/smsf",
+    super: "/super",
+    tax: "/tax",
+    "tax & strategy": "/tax",
+    etfs: "/etfs",
+    property: "/property",
+    insurance: "/insurance",
+    "foreign-investment": "/foreign-investment",
+    invest: "/invest",
+    investing: "/invest",
+    calculators: "/calculators",
+    compare: "/compare",
+    advisors: "/advisors",
+    research: "/research",
+    startup: "/startup",
+    dividends: "/dividends",
+  };
+  return map[category.toLowerCase()];
+}
+
+/**
+ * Returns the full set of hrefs belonging to a pillar's topic cluster
+ * (pillar + cluster pages + supporting pages). Empty set when the path
+ * is not a registered pillar.
+ */
+export function getClusterPaths(pillarPath: string): Set<string> {
+  const cluster = getPillarForPath(pillarPath);
+  if (!cluster) return new Set();
+  return new Set([cluster.pillar, ...cluster.clusters, ...cluster.supporting]);
+}
+
 export type TextOrLink =
   | string
   | { href: string; label: string; title?: string; rel?: string };
@@ -161,36 +202,95 @@ export type TextOrLink =
  * subsequent occurrences render as plain text. Safe for React
  * rendering without dangerouslySetInnerHTML.
  *
- * @param maxLinks - Maximum unique keywords to inject as links. Defaults to
+ * @param maxLinks   - Maximum unique keywords to inject as links. Defaults to
  *   unlimited (all first occurrences). Pass a small integer (e.g. 5) to cap
  *   link density per text block — text after the cap renders as plain text.
+ * @param pillarPath - Optional hub pillar path (e.g. "/smsf", "/tax") for
+ *   the article's topic cluster. When provided alongside a finite `maxLinks`,
+ *   the density cap is filled with cluster-relevant links first, then any
+ *   remaining slots with generic links — so an SMSF article's 5 auto-links
+ *   skew toward SMSF pages rather than unrelated broker or glossary entries.
+ *   Obtain the pillar path via `pillarPathForCategory(article.category)`.
  */
-export function splitByLinks(text: string, maxLinks = Infinity): TextOrLink[] {
+export function splitByLinks(
+  text: string,
+  maxLinks = Infinity,
+  pillarPath?: string,
+): TextOrLink[] {
   if (!text) return [];
-  const out: TextOrLink[] = [];
-  const used = new Set<string>();
+
+  const clusterPaths = pillarPath ? getClusterPaths(pillarPath) : new Set<string>();
+  const useClusterAware = clusterPaths.size > 0 && maxLinks < Infinity;
+
+  if (!useClusterAware) {
+    // Fast path: original single-pass algorithm (preserves all existing behaviour).
+    const out: TextOrLink[] = [];
+    const used = new Set<string>();
+    const rx = new RegExp(COMBINED_REGEX_SOURCE, "gi");
+    let lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = rx.exec(text)) !== null) {
+      if (used.size >= maxLinks) continue;
+      const match = m[0];
+      const key = match.toLowerCase();
+      if (used.has(key)) continue;
+      const target = findTarget(match);
+      if (!target) continue;
+      used.add(key);
+      if (m.index > lastIndex) out.push(text.slice(lastIndex, m.index));
+      out.push({ href: target.href, label: match, title: target.title, rel: target.rel });
+      lastIndex = m.index + match.length;
+    }
+    if (lastIndex < text.length) out.push(text.slice(lastIndex));
+    return out;
+  }
+
+  // Cluster-aware two-pass path:
+  //   Pass 1 — collect ALL first-occurrence matches in text order.
+  //   Pass 2 — select up to maxLinks, preferring cluster-relevant targets.
+  //   Reconstruct — emit selected matches in text order, plain text for the rest.
+  interface MatchInfo {
+    index: number;
+    length: number;
+    match: string;
+    target: LinkTarget;
+    inCluster: boolean;
+  }
+  const allMatches: MatchInfo[] = [];
+  const seenKeys = new Set<string>();
   const rx = new RegExp(COMBINED_REGEX_SOURCE, "gi");
-  let lastIndex = 0;
   let m: RegExpExecArray | null;
   while ((m = rx.exec(text)) !== null) {
-    // Density cap: once we've injected maxLinks unique keywords, skip further
-    // injections. The regex still scans forward so remaining text is captured
-    // correctly in the final text.slice(lastIndex) below.
-    if (used.size >= maxLinks) continue;
     const match = m[0];
     const key = match.toLowerCase();
-    if (used.has(key)) continue;
+    if (seenKeys.has(key)) continue;
     const target = findTarget(match);
     if (!target) continue;
-    used.add(key);
-    if (m.index > lastIndex) out.push(text.slice(lastIndex, m.index));
-    out.push({
-      href: target.href,
-      label: match,
-      title: target.title,
-      rel: target.rel,
+    seenKeys.add(key);
+    allMatches.push({
+      index: m.index,
+      length: match.length,
+      match,
+      target,
+      inCluster: clusterPaths.has(target.href),
     });
-    lastIndex = m.index + match.length;
+  }
+
+  // Rank: cluster-relevant first, then by text position. Slice to maxLinks.
+  const ranked = [...allMatches].sort((a, b) => {
+    if (a.inCluster !== b.inCluster) return a.inCluster ? -1 : 1;
+    return a.index - b.index;
+  });
+  const selectedIndices = new Set(ranked.slice(0, maxLinks).map((mi) => mi.index));
+
+  // Rebuild in original text order so the output reads naturally.
+  const out: TextOrLink[] = [];
+  let lastIndex = 0;
+  for (const { index, length, match, target } of allMatches) {
+    if (!selectedIndices.has(index)) continue;
+    if (index > lastIndex) out.push(text.slice(lastIndex, index));
+    out.push({ href: target.href, label: match, title: target.title, rel: target.rel });
+    lastIndex = index + length;
   }
   if (lastIndex < text.length) out.push(text.slice(lastIndex));
   return out;
@@ -206,8 +306,13 @@ export function splitByLinks(text: string, maxLinks = Infinity): TextOrLink[] {
  *   - Content inside tag attributes (href, alt, etc.)
  *
  * First-occurrence semantics per keyword so prose stays readable.
+ *
+ * @param pillarPath - Reserved for future cluster-aware density capping.
+ *   Accepted now so callers can be forward-compatible without a signature
+ *   change when a `maxLinks` param is added to `linkifyHtml`.
  */
-export function linkifyHtml(html: string): string {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function linkifyHtml(html: string, pillarPath?: string): string {
   if (!html) return "";
   const used = new Set<string>();
   let out = "";


### PR DESCRIPTION
## KK-04 iter 2 — Cluster-aware internal link injection

Follows #711 (iter 1: kill-switch + density cap, merged 2026-05-10).

### What changed

| File | Change |
|------|--------|
| `lib/keyword-linking.ts` | New `pillarPathForCategory()` + `getClusterPaths()` helpers; `splitByLinks()` gains optional `pillarPath` param with two-pass cluster-aware algorithm |
| `components/LinkifiedText.tsx` | New `pillarPath?` prop wired through to `splitByLinks` |
| `app/article/[slug]/page.tsx` | Derives `articlePillarPath` from `article.category`; passes to all three `<LinkifiedText>` usages |
| `__tests__/lib/keyword-linking.test.ts` | 5 new tests: `pillarPathForCategory`, `getClusterPaths`, cluster-vs-text-order selection, text preservation, fallback to fast path |

### Why

The density cap (maxLinks=5 per section) fills with the first 5 keywords found in text order. On an SMSF article, that could be CommSec, Stake, and three broker glossary terms — none reinforcing the page's topic signal for SEO.

The two-pass algorithm collects all first-occurrence matches, ranks cluster-relevant hrefs first, then fills remaining slots with generic links. Output is always rebuilt in text order so prose reads naturally.

### Backward compatibility

- When `pillarPath` is absent or resolves to no cluster, the original single-pass fast path runs unchanged.
- All 31 existing tests pass (none pass a `pillarPath` — they exercise the fast path).

## Supersedes

_None._

## KK-04 remaining iterations

- [x] iter 1: kill-switch + density cap (#711 merged)
- [x] iter 2: LSI/cluster-aware selection (this PR)
- [ ] iter 3: per-article-type density config
- [ ] iter 4: admin UI (override per article)
- [ ] iter 5: integration tests + Playwright smoke

Refs: #217
Audit: docs/audits/codebase-health-2026-04-24.md
Queue: KK-04 iter 2 (docs/audits/REMEDIATION_QUEUE.md)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B6XkGaPKNWGkphTJR9dGf1)_