### PR TITLE
fix(pp): PP-02 image audit — replace raw img with next/image [audit remediation]

### DIFF
--- a/app/quiz/_components/AdvisorResultsScreen.tsx
+++ b/app/quiz/_components/AdvisorResultsScreen.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import Link from "next/link";
+import Image from "next/image";
 import Icon from "@/components/Icon";
 import type { Broker } from "@/lib/types";
 import { trackEvent } from "@/lib/tracking";
@@ -529,8 +530,7 @@ export default function AdvisorResultsScreen({ advisorType, quizAnswers, platfor
             <div className="flex items-start gap-3">
               <div className="w-12 h-12 md:w-14 md:h-14 rounded-full bg-slate-100 flex items-center justify-center shrink-0 overflow-hidden">
                 {previewAdvisor.photo_url ? (
-                  // eslint-disable-next-line @next/next/no-img-element -- external advisor headshots from Supabase storage; next/image not configured for these hosts
-                  <img src={previewAdvisor.photo_url} alt={previewAdvisor.name} className="w-full h-full object-cover" />
+                  <Image src={previewAdvisor.photo_url} alt={previewAdvisor.name} width={56} height={56} className="object-cover" />
                 ) : (
                   <span className="text-base md:text-lg font-bold text-slate-500">
                     {previewAdvisor.name.split(" ").map(n => n[0]).slice(0, 2).join("")}

--- a/app/quotes/[slug]/InstantMatchPanel.tsx
+++ b/app/quotes/[slug]/InstantMatchPanel.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import Image from "next/image";
 import Icon from "@/components/Icon";
 import { createClient } from "@/lib/supabase/server";
 import { batchAdvisorResponseTimes, formatResponseTimeLabel } from "@/lib/advisor-response-time";
@@ -88,8 +89,7 @@ export default async function InstantMatchPanel({ advisorTypes, locationState, e
             >
               <div className="flex items-start gap-3 mb-2">
                 {a.photo_url ? (
-                  /* eslint-disable-next-line @next/next/no-img-element */
-                  <img src={a.photo_url} alt={a.name} className="w-10 h-10 rounded-full object-cover border border-slate-200 shrink-0" />
+                  <Image src={a.photo_url} alt={a.name} width={40} height={40} className="rounded-full object-cover border border-slate-200 shrink-0" />
                 ) : (
                   <div className="w-10 h-10 rounded-full bg-slate-100 flex items-center justify-center shrink-0">
                     <Icon name="user" size={16} className="text-slate-400" />

--- a/app/quotes/[slug]/QuoteBidsClient.tsx
+++ b/app/quotes/[slug]/QuoteBidsClient.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import Link from "next/link";
+import Image from "next/image";
 import Icon from "@/components/Icon";
 
 interface BidAdvisor {
@@ -173,8 +174,7 @@ export default function QuoteBidsClient({ slug, jobStatus, winningBidId, isExpir
                 <div key={b.id} className="border border-slate-200 rounded-xl p-4 flex flex-col">
                   <div className="flex items-center gap-2 mb-2">
                     {b.advisor?.photo_url ? (
-                      /* eslint-disable-next-line @next/next/no-img-element */
-                      <img src={b.advisor.photo_url} alt={b.advisor.name} className="w-10 h-10 rounded-full object-cover border border-slate-200" />
+                      <Image src={b.advisor.photo_url} alt={b.advisor.name} width={40} height={40} className="rounded-full object-cover border border-slate-200" />
                     ) : (
                       <div className="w-10 h-10 rounded-full bg-slate-100 flex items-center justify-center"><Icon name="user" size={16} className="text-slate-400" /></div>
                     )}

--- a/app/quotes/by/[type]/[state]/page.tsx
+++ b/app/quotes/by/[type]/[state]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import Link from "next/link";
+import Image from "next/image";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
 import { createClient } from "@/lib/supabase/server";
 import Icon from "@/components/Icon";
@@ -195,8 +196,7 @@ export default async function QuotesByTypeStatePage({ params }: PageProps) {
                   className="flex items-center gap-3 bg-white border border-slate-200 hover:border-amber-300 rounded-xl p-3"
                 >
                   {a.photo_url ? (
-                    /* eslint-disable-next-line @next/next/no-img-element */
-                    <img src={a.photo_url} alt={a.name} className="w-10 h-10 rounded-full object-cover border border-slate-200" />
+                    <Image src={a.photo_url} alt={a.name} width={40} height={40} className="rounded-full object-cover border border-slate-200" />
                   ) : (
                     <div className="w-10 h-10 rounded-full bg-slate-100 flex items-center justify-center">
                       <Icon name="user" size={16} className="text-slate-400" />


### PR DESCRIPTION
## Summary

PP-02 audit found 6 raw `<img>` usages (all in quotes/ + quiz/ + widget API):

- **4 converted** to `<Image>` from `next/image` — advisor avatar circles (40×40px) in quotes pages + quiz advisor preview screen
- **2 intentionally kept** as raw `<img>` in `app/api/widget/route.ts` — these are inside raw HTML strings for the embeddable third-party widget (Next.js Image is a React component and cannot be used in server-side HTML string generation)

Supabase storage domain was already in `next.config.ts` `remotePatterns` — no config change needed. Conversion brings automatic WebP/AVIF optimisation and proper lazy loading via Next.js image pipeline.

## Supersedes

_None._

https://claude.ai/code/session_016QTwWqgFjeqTMErLHBe1iY

---
_Generated by [Claude Code](https://claude.ai/code/session_016QTwWqgFjeqTMErLHBe1iY)_