### PR TITLE
feat(funds): verified user reviews engine for funds (W3.18)

### DIFF
--- a/__tests__/api/fund-review-moderate.test.ts
+++ b/__tests__/api/fund-review-moderate.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn() })),
+}));
+
+vi.mock("@/lib/email-templates", () => ({
+  notificationFooter: (_email: string) => "<footer>unsubscribe</footer>",
+}));
+
+vi.mock("@/lib/admin", () => ({
+  ADMIN_EMAILS: ["admin@invest.com.au"],
+}));
+
+const mockAuth = { getUser: vi.fn() };
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(() => Promise.resolve({ auth: mockAuth })),
+}));
+
+const mockAdminFrom = vi.fn();
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+import { POST } from "@/app/api/fund-review/moderate/route";
+
+const ADMIN_USER = { id: "admin-1", email: "admin@invest.com.au" };
+const NON_ADMIN = { id: "user-1", email: "user@example.com" };
+
+function makeRequest(body: unknown) {
+  return new NextRequest("http://localhost/api/fund-review/moderate", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeUpdateChain(result: { data: unknown; error: unknown }) {
+  const chain: Record<string, unknown> = {};
+  for (const m of ["update", "eq", "select"]) {
+    chain[m] = vi.fn(() => chain);
+  }
+  chain.single = vi.fn(() => Promise.resolve(result));
+  return chain;
+}
+
+describe("POST /api/fund-review/moderate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.RESEND_API_KEY;
+    mockAuth.getUser.mockResolvedValue({ data: { user: ADMIN_USER }, error: null });
+    mockFetch.mockResolvedValue({ ok: true });
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockAuth.getUser.mockResolvedValue({ data: { user: null }, error: new Error("no session") });
+    const res = await POST(makeRequest({ review_id: 1, action: "approve" }));
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json.error).toBe("Unauthorized");
+  });
+
+  it("returns 401 when user is not an admin", async () => {
+    mockAuth.getUser.mockResolvedValue({ data: { user: NON_ADMIN }, error: null });
+    const res = await POST(makeRequest({ review_id: 1, action: "approve" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 on invalid JSON body", async () => {
+    const req = new NextRequest("http://localhost/api/fund-review/moderate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not-json",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/Invalid JSON/i);
+  });
+
+  it("returns 400 when review_id is missing", async () => {
+    const res = await POST(makeRequest({ action: "approve" }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/review_id/i);
+  });
+
+  it("returns 400 when action is invalid", async () => {
+    const res = await POST(makeRequest({ review_id: 42, action: "delete" }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/approve or reject/i);
+  });
+
+  it("returns 200 on approve success", async () => {
+    const chain = makeUpdateChain({ data: { id: 42, status: "approved" }, error: null });
+    mockAdminFrom.mockReturnValue(chain);
+    const res = await POST(makeRequest({ review_id: 42, action: "approve" }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.success).toBe(true);
+    expect(json.review.status).toBe("approved");
+  });
+
+  it("returns 200 on reject success", async () => {
+    const chain = makeUpdateChain({ data: { id: 42, status: "rejected" }, error: null });
+    mockAdminFrom.mockReturnValue(chain);
+    const res = await POST(makeRequest({ review_id: 42, action: "reject", moderation_note: "Spam content" }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.success).toBe(true);
+  });
+
+  it("returns 404 when review data is null after update", async () => {
+    const chain = makeUpdateChain({ data: null, error: null });
+    mockAdminFrom.mockReturnValue(chain);
+    const res = await POST(makeRequest({ review_id: 99, action: "approve" }));
+    expect(res.status).toBe(404);
+    const json = await res.json();
+    expect(json.error).toMatch(/not found/i);
+  });
+
+  it("returns 500 on DB error", async () => {
+    const chain = makeUpdateChain({ data: null, error: { message: "DB down" } });
+    mockAdminFrom.mockReturnValue(chain);
+    const res = await POST(makeRequest({ review_id: 1, action: "approve" }));
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toMatch(/Failed to update/i);
+  });
+
+  it("sends approval email when RESEND_API_KEY is set", async () => {
+    process.env.RESEND_API_KEY = "test-key";
+    const updateChain = makeUpdateChain({ data: { id: 1, status: "approved" }, error: null });
+    const selectChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({
+        data: {
+          display_name: "Alice Smith",
+          email: "alice@example.com",
+          fund_slug: "pengana-fund",
+          fund_listings: [{ title: "Pengana Fund" }],
+        },
+      }),
+    };
+    mockAdminFrom
+      .mockReturnValueOnce(updateChain)
+      .mockReturnValueOnce(selectChain);
+    await POST(makeRequest({ review_id: 1, action: "approve" }));
+    expect(mockFetch).toHaveBeenCalled();
+    const [url, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("resend.com");
+    const body = JSON.parse(opts.body as string);
+    expect(body.subject).toContain("Pengana Fund");
+    expect(body.subject).toContain("live");
+  });
+
+  it("does not send email when RESEND_API_KEY is not set", async () => {
+    const chain = makeUpdateChain({ data: { id: 1, status: "approved" }, error: null });
+    mockAdminFrom.mockReturnValue(chain);
+    await POST(makeRequest({ review_id: 1, action: "approve" }));
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("sends rejection email with moderation_note when rejecting", async () => {
+    process.env.RESEND_API_KEY = "test-key";
+    const updateChain = makeUpdateChain({ data: { id: 1, status: "rejected" }, error: null });
+    const selectChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({
+        data: {
+          display_name: "Bob",
+          email: "bob@example.com",
+          fund_slug: "syndicate-property-fund",
+          fund_listings: [{ title: "Syndicate Property Fund" }],
+        },
+      }),
+    };
+    mockAdminFrom
+      .mockReturnValueOnce(updateChain)
+      .mockReturnValueOnce(selectChain);
+    await POST(makeRequest({ review_id: 1, action: "reject", moderation_note: "Off topic" }));
+    expect(mockFetch).toHaveBeenCalled();
+    const [, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(opts.body as string);
+    expect(body.subject).toContain("Syndicate Property Fund");
+    expect(body.html).toContain("Off topic");
+  });
+});

--- a/__tests__/api/fund-review-verify.test.ts
+++ b/__tests__/api/fund-review-verify.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn() })),
+}));
+
+vi.mock("@/lib/url", () => ({
+  getSiteUrl: () => "https://invest.com.au",
+}));
+
+const mockIsAllowed = vi.hoisted(() => vi.fn<() => Promise<boolean>>().mockResolvedValue(true));
+const mockIpKey = vi.hoisted(() => vi.fn().mockReturnValue("127.0.0.1"));
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: mockIsAllowed,
+  ipKey: mockIpKey,
+}));
+
+const mockAdminFrom = vi.fn();
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+
+import { GET } from "@/app/api/fund-review/verify/route";
+
+function makeRequest(token?: string) {
+  const url = token
+    ? `http://localhost/api/fund-review/verify?token=${token}`
+    : "http://localhost/api/fund-review/verify";
+  return new NextRequest(url);
+}
+
+const CLEAN_REVIEW = {
+  id: 1,
+  fund_slug: "pengana-fund",
+  status: "pending",
+  title: "Great fund",
+  body: "I have held this fund for five years and the manager has been transparent.",
+  pros: "Low fees",
+  cons: null,
+  display_name: "Alice",
+};
+
+const PROFANITY_REVIEW = {
+  ...CLEAN_REVIEW,
+  body: "This shit fund cost me money over the years",
+};
+
+const URL_REVIEW = {
+  ...CLEAN_REVIEW,
+  body: "Check out https://spam.com for better managed-fund options",
+};
+
+const SHORT_REVIEW = {
+  ...CLEAN_REVIEW,
+  body: "Bad fund",
+};
+
+function makeSelectChain(result: { data: unknown }) {
+  return {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue(result),
+  };
+}
+
+function makeUpdateChain(result: { error: unknown }) {
+  const chain: Record<string, unknown> = {};
+  for (const m of ["update", "eq"]) {
+    chain[m] = vi.fn(() => chain);
+  }
+  chain.then = (cb: (v: unknown) => void) => {
+    cb(result);
+    return Promise.resolve(result);
+  };
+  return chain;
+}
+
+describe("GET /api/fund-review/verify", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowed.mockResolvedValue(true);
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    mockIsAllowed.mockResolvedValue(false);
+    const res = await GET(makeRequest("validtoken123456"));
+    expect(res.status).toBe(429);
+    const json = await res.json();
+    expect(json.error).toMatch(/Too many/i);
+  });
+
+  it("redirects with invalid_token when token is missing", async () => {
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toContain("error=invalid_token");
+  });
+
+  it("redirects with invalid_token when token is too short (<10 chars)", async () => {
+    const res = await GET(makeRequest("short"));
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toContain("error=invalid_token");
+  });
+
+  it("redirects with review_not_found when token lookup fails", async () => {
+    mockAdminFrom.mockReturnValue(makeSelectChain({ data: null }));
+    const res = await GET(makeRequest("validtoken1234567890"));
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toContain("error=review_not_found");
+  });
+
+  it("auto-approves a clean review and redirects to fund page", async () => {
+    const selectChain = makeSelectChain({ data: CLEAN_REVIEW });
+    const updateChain = makeUpdateChain({ error: null });
+    mockAdminFrom
+      .mockReturnValueOnce(selectChain)
+      .mockReturnValueOnce(updateChain);
+    const res = await GET(makeRequest("cleanvalidtoken1234567890"));
+    expect(res.status).toBe(307);
+    const location = res.headers.get("location")!;
+    expect(location).toContain("/invest/funds/pengana-fund");
+    expect(location).toContain("review_verified=1");
+    expect(updateChain.update).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "approved" }),
+    );
+  });
+
+  it("holds profanity review as 'verified' (not auto-approved)", async () => {
+    const selectChain = makeSelectChain({ data: PROFANITY_REVIEW });
+    const updateChain = makeUpdateChain({ error: null });
+    mockAdminFrom
+      .mockReturnValueOnce(selectChain)
+      .mockReturnValueOnce(updateChain);
+    await GET(makeRequest("cleanvalidtoken1234567890"));
+    expect(updateChain.update).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "verified" }),
+    );
+  });
+
+  it("holds review with spam URL as 'verified'", async () => {
+    const selectChain = makeSelectChain({ data: URL_REVIEW });
+    const updateChain = makeUpdateChain({ error: null });
+    mockAdminFrom
+      .mockReturnValueOnce(selectChain)
+      .mockReturnValueOnce(updateChain);
+    await GET(makeRequest("cleanvalidtoken1234567890"));
+    expect(updateChain.update).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "verified" }),
+    );
+  });
+
+  it("holds review with body too short as 'verified'", async () => {
+    const selectChain = makeSelectChain({ data: SHORT_REVIEW });
+    const updateChain = makeUpdateChain({ error: null });
+    mockAdminFrom
+      .mockReturnValueOnce(selectChain)
+      .mockReturnValueOnce(updateChain);
+    await GET(makeRequest("cleanvalidtoken1234567890"));
+    expect(updateChain.update).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "verified" }),
+    );
+  });
+
+  it("skips update and redirects for non-pending review", async () => {
+    const alreadyApproved = { ...CLEAN_REVIEW, status: "approved" };
+    const selectChain = makeSelectChain({ data: alreadyApproved });
+    mockAdminFrom.mockReturnValue(selectChain);
+    const res = await GET(makeRequest("cleanvalidtoken1234567890"));
+    expect(res.status).toBe(307);
+    expect(mockAdminFrom).toHaveBeenCalledTimes(1);
+    expect(res.headers.get("location")).toContain("/invest/funds/pengana-fund");
+  });
+
+  it("redirects with verification_failed on DB update error", async () => {
+    const selectChain = makeSelectChain({ data: CLEAN_REVIEW });
+    const updateChain = makeUpdateChain({ error: { message: "DB error" } });
+    mockAdminFrom
+      .mockReturnValueOnce(selectChain)
+      .mockReturnValueOnce(updateChain);
+    const res = await GET(makeRequest("cleanvalidtoken1234567890"));
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toContain("error=verification_failed");
+  });
+
+  it("sets moderation_note on auto-held review", async () => {
+    const selectChain = makeSelectChain({ data: PROFANITY_REVIEW });
+    const updateChain = makeUpdateChain({ error: null });
+    mockAdminFrom
+      .mockReturnValueOnce(selectChain)
+      .mockReturnValueOnce(updateChain);
+    await GET(makeRequest("cleanvalidtoken1234567890"));
+    expect(updateChain.update).toHaveBeenCalledWith(
+      expect.objectContaining({ moderation_note: expect.stringContaining("Auto-held") }),
+    );
+  });
+});

--- a/__tests__/api/fund-review.test.ts
+++ b/__tests__/api/fund-review.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() })),
+}));
+
+const isValidEmailMock = vi.hoisted(() => vi.fn<(e: string) => boolean>(() => true));
+
+vi.mock("@/lib/validate-email", () => ({
+  isValidEmail: (email: string) => isValidEmailMock(email),
+}));
+
+const rateLimitFn = vi.hoisted(() => vi.fn<() => boolean>(() => false));
+
+vi.mock("@/lib/rate-limiter", () => ({
+  createRateLimiter: () => rateLimitFn,
+}));
+
+vi.mock("@/lib/url", () => ({
+  getSiteUrl: vi.fn(() => "https://invest.com.au"),
+}));
+
+let fundRow: { id: number; title: string; slug: string } | null = { id: 1, title: "Pengana Fund", slug: "pengana-fund" };
+let fundError: { message: string } | null = null;
+let insertError: { message: string } | null = null;
+
+const adminFromMock = vi.fn();
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: adminFromMock })),
+}));
+
+const fetchMock = vi.fn<(input: unknown, init?: unknown) => Promise<Response>>();
+vi.stubGlobal("fetch", fetchMock);
+
+import { POST } from "@/app/api/fund-review/route";
+
+function makeReq(body: Record<string, unknown>): NextRequest {
+  return new NextRequest("http://localhost/api/fund-review", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json", "x-forwarded-for": "9.9.9.9" },
+  });
+}
+
+const VALID_BODY = {
+  fund_slug: "pengana-fund",
+  display_name: "Jane Doe",
+  email: "jane@example.com",
+  rating: 5,
+  title: "Great fund",
+  body: "I have held this fund for 3 years and the manager has been transparent.",
+};
+
+function chain(result: unknown): Record<string, unknown> {
+  const b: Record<string, unknown> = {};
+  for (const m of ["select", "eq", "gte", "limit", "insert"]) {
+    b[m] = vi.fn(() => b);
+  }
+  b.single = vi.fn(() => Promise.resolve(result));
+  b.then = (cb: (v: unknown) => void) => { cb(result); return Promise.resolve(); };
+  return b;
+}
+
+function setupHappyPath(existing: { id: number }[] | null = null) {
+  adminFromMock.mockReturnValueOnce(chain({ data: fundRow, error: fundError }));
+  adminFromMock.mockReturnValueOnce(chain({ data: existing }));
+  adminFromMock.mockReturnValueOnce(chain({ error: insertError }));
+}
+
+describe("POST /api/fund-review", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isValidEmailMock.mockReturnValue(true);
+    rateLimitFn.mockReturnValue(false);
+    fundRow = { id: 1, title: "Pengana Fund", slug: "pengana-fund" };
+    fundError = null;
+    insertError = null;
+    fetchMock.mockResolvedValue(new Response(JSON.stringify({ id: "email-1" }), { status: 200 }));
+  });
+
+  it("returns 400 on invalid JSON body", async () => {
+    const req = new NextRequest("http://localhost/api/fund-review", {
+      method: "POST",
+      body: "not-json",
+      headers: { "Content-Type": "application/json", "x-forwarded-for": "9.9.9.9" },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when fund_slug is missing", async () => {
+    const res = await POST(makeReq({ ...VALID_BODY, fund_slug: undefined }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when email is invalid", async () => {
+    isValidEmailMock.mockReturnValueOnce(false);
+    const res = await POST(makeReq({ ...VALID_BODY, email: "not-an-email" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when rating is 0 (below range)", async () => {
+    const res = await POST(makeReq({ ...VALID_BODY, rating: 0 }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/rating/i);
+  });
+
+  it("returns 400 when rating is 6 (above range)", async () => {
+    const res = await POST(makeReq({ ...VALID_BODY, rating: 6 }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when rating is a float (non-integer)", async () => {
+    const res = await POST(makeReq({ ...VALID_BODY, rating: 3.5 }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when display_name is too short (< 2 chars)", async () => {
+    const res = await POST(makeReq({ ...VALID_BODY, display_name: "J" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when title is too short (< 3 chars)", async () => {
+    const res = await POST(makeReq({ ...VALID_BODY, title: "ok" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when review body is too short (< 10 chars)", async () => {
+    const res = await POST(makeReq({ ...VALID_BODY, body: "Short" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when a dimension rating is out of 1-5 range", async () => {
+    const res = await POST(makeReq({ ...VALID_BODY, performance_rating: 6 }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/performance_rating/i);
+  });
+
+  it("returns 400 when hold_period_months is negative", async () => {
+    const res = await POST(makeReq({ ...VALID_BODY, hold_period_months: -1 }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/hold_period_months/i);
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    rateLimitFn.mockReturnValueOnce(true);
+    const res = await POST(makeReq(VALID_BODY));
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 404 when fund does not exist", async () => {
+    adminFromMock.mockReturnValueOnce(chain({ data: null, error: null }));
+    const res = await POST(makeReq(VALID_BODY));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 409 when user has already reviewed this fund recently", async () => {
+    adminFromMock.mockReturnValueOnce(chain({ data: fundRow, error: null }));
+    adminFromMock.mockReturnValueOnce(chain({ data: [{ id: 99 }] }));
+    const res = await POST(makeReq(VALID_BODY));
+    expect(res.status).toBe(409);
+  });
+
+  it("returns 500 on DB insert error", async () => {
+    insertError = { message: "unique constraint violation" };
+    setupHappyPath();
+    const res = await POST(makeReq(VALID_BODY));
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 200 on success without RESEND_API_KEY — no email sent", async () => {
+    delete process.env.RESEND_API_KEY;
+    setupHappyPath();
+    const res = await POST(makeReq(VALID_BODY));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.success).toBe(true);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 200 on success with RESEND_API_KEY — fires verification email", async () => {
+    process.env.RESEND_API_KEY = "test-resend-key";
+    setupHappyPath();
+    const res = await POST(makeReq(VALID_BODY));
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const fetchArg = fetchMock.mock.calls[0]?.[0] as string;
+    expect(fetchArg).toContain("resend.com");
+  });
+
+  it("returns 200 even when Resend email send throws (non-blocking)", async () => {
+    process.env.RESEND_API_KEY = "test-resend-key";
+    setupHappyPath();
+    fetchMock.mockRejectedValueOnce(new Error("network error"));
+    const res = await POST(makeReq(VALID_BODY));
+    expect(res.status).toBe(200);
+  });
+});

--- a/app/admin/fund-reviews/error.tsx
+++ b/app/admin/fund-reviews/error.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import AdminShell from "@/components/AdminShell";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <AdminShell>
+      <div className="flex flex-col items-center justify-center py-16">
+        <div className="w-12 h-12 bg-red-50 rounded-full flex items-center justify-center mb-4">
+          <svg className="w-6 h-6 text-red-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z" />
+          </svg>
+        </div>
+        <h2 className="text-lg font-bold text-slate-900 mb-2">Something went wrong</h2>
+        <p className="text-sm text-slate-500 mb-4 text-center max-w-md">
+          {error.message || "An unexpected error occurred. Please try again."}
+        </p>
+        <button
+          onClick={reset}
+          className="px-4 py-2 bg-emerald-700 text-white text-sm font-semibold rounded-lg hover:bg-emerald-800 transition-colors"
+        >
+          Try Again
+        </button>
+      </div>
+    </AdminShell>
+  );
+}

--- a/app/admin/fund-reviews/page.tsx
+++ b/app/admin/fund-reviews/page.tsx
@@ -1,0 +1,403 @@
+"use client";
+
+import { useEffect, useState, useMemo } from "react";
+import { createClient } from "@/lib/supabase/client";
+import AdminShell from "@/components/AdminShell";
+import { downloadCSV } from "@/lib/csv-export";
+import { logger } from "@/lib/logger";
+
+const log = logger("admin-fund-reviews");
+
+type Review = {
+  id: number;
+  fund_id: number;
+  fund_slug: string;
+  display_name: string;
+  email: string;
+  rating: number;
+  title: string;
+  body: string;
+  pros: string | null;
+  cons: string | null;
+  status: "pending" | "verified" | "approved" | "rejected";
+  verification_token: string | null;
+  verified_at: string | null;
+  moderation_note: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+type StatusTab = "all" | "pending" | "verified" | "approved" | "rejected";
+
+const PAGE_SIZE = 20;
+
+const statusColors: Record<string, string> = {
+  pending: "bg-yellow-100 text-yellow-700",
+  verified: "bg-blue-100 text-blue-700",
+  approved: "bg-emerald-100 text-emerald-700",
+  rejected: "bg-red-100 text-red-700",
+};
+
+function Stars({ rating }: { rating: number }) {
+  return (
+    <span className="inline-flex items-center gap-0.5" aria-label={`${rating} stars`}>
+      {[1, 2, 3, 4, 5].map((s) => (
+        <svg
+          key={s}
+          viewBox="0 0 24 24"
+          fill={s <= rating ? "#f59e0b" : "none"}
+          stroke={s <= rating ? "#f59e0b" : "#cbd5e1"}
+          strokeWidth={1.5}
+          className="w-3.5 h-3.5"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M11.48 3.499a.562.562 0 011.04 0l2.125 5.111a.563.563 0 00.475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 00-.182.557l1.285 5.385a.562.562 0 01-.84.61l-4.725-2.885a.562.562 0 00-.586 0L6.982 20.54a.562.562 0 01-.84-.61l1.285-5.386a.562.562 0 00-.182-.557l-4.204-3.602a.562.562 0 01.321-.988l5.518-.442a.563.563 0 00.475-.345L11.48 3.5z"
+          />
+        </svg>
+      ))}
+    </span>
+  );
+}
+
+export default function AdminFundReviewsPage() {
+  const [reviews, setReviews] = useState<Review[]>([]);
+  const [search, setSearch] = useState("");
+  const [tab, setTab] = useState<StatusTab>("all");
+  const [page, setPage] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [actionLoading, setActionLoading] = useState<number | null>(null);
+  const [expandedId, setExpandedId] = useState<number | null>(null);
+  const [selected, setSelected] = useState<Set<number>>(new Set());
+
+  const supabase = createClient();
+
+  const load = async () => {
+    setLoading(true);
+    const { data } = await supabase
+      .from("fund_reviews")
+      .select(
+        "id, fund_id, fund_slug, email, display_name, rating, title, body, pros, cons, status, verification_token, verified_at, moderation_note, created_at, updated_at",
+      )
+      .order("created_at", { ascending: false })
+      .limit(1000);
+    if (data) setReviews(data as unknown as Review[]);
+    setLoading(false);
+  };
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-once load; mirrors app/admin/user-reviews/page.tsx pattern
+  useEffect(() => { load(); }, []);
+  useEffect(() => { setPage(0); }, [search, tab]);
+
+  const stats = useMemo(() => {
+    const total = reviews.length;
+    const pending = reviews.filter((r) => r.status === "pending").length;
+    const verified = reviews.filter((r) => r.status === "verified").length;
+    const approved = reviews.filter((r) => r.status === "approved").length;
+    const rejected = reviews.filter((r) => r.status === "rejected").length;
+    return { total, pending, verified, approved, rejected };
+  }, [reviews]);
+
+  const filtered = useMemo(() => {
+    let list = reviews;
+    if (tab !== "all") {
+      list = list.filter((r) => r.status === tab);
+    }
+    if (search) {
+      const q = search.toLowerCase();
+      list = list.filter(
+        (r) =>
+          r.display_name.toLowerCase().includes(q) ||
+          r.email.toLowerCase().includes(q) ||
+          r.fund_slug.toLowerCase().includes(q) ||
+          r.title.toLowerCase().includes(q),
+      );
+    }
+    return list;
+  }, [reviews, tab, search]);
+
+  const totalPages = Math.ceil(filtered.length / PAGE_SIZE);
+  const paginated = filtered.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);
+
+  const exportReviews = () => {
+    downloadCSV(
+      `fund-reviews-${new Date().toISOString().split("T")[0]}.csv`,
+      ["Fund", "Name", "Email", "Rating", "Title", "Body", "Status", "Date"],
+      filtered.map((r) => [
+        r.fund_slug, r.display_name, r.email, String(r.rating),
+        r.title, r.body, r.status,
+        new Date(r.created_at).toLocaleDateString("en-AU"),
+      ]),
+    );
+  };
+
+  async function handleModerate(reviewId: number, action: "approve" | "reject") {
+    setActionLoading(reviewId);
+    try {
+      const res = await fetch("/api/fund-review/moderate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ review_id: reviewId, action }),
+      });
+      if (res.ok) {
+        setReviews((prev) =>
+          prev.map((r) =>
+            r.id === reviewId
+              ? { ...r, status: action === "approve" ? "approved" : "rejected", updated_at: new Date().toISOString() }
+              : r,
+          ),
+        );
+      }
+    } catch (err) {
+      log.error("Moderate error", { error: err instanceof Error ? err.message : String(err) });
+    }
+    setActionLoading(null);
+  }
+
+  const tabs: { key: StatusTab; label: string; count: number }[] = [
+    { key: "all", label: "All", count: stats.total },
+    { key: "pending", label: "Pending", count: stats.pending },
+    { key: "verified", label: "Verified", count: stats.verified },
+    { key: "approved", label: "Approved", count: stats.approved },
+    { key: "rejected", label: "Rejected", count: stats.rejected },
+  ];
+
+  return (
+    <AdminShell>
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold text-slate-900">Fund Reviews</h1>
+          <p className="text-sm text-slate-500 mt-1">
+            Moderate user-submitted fund reviews. Reviews need approval before appearing on fund pages.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <button onClick={exportReviews} className="bg-emerald-600 hover:bg-emerald-700 text-white font-semibold rounded-lg px-4 py-2 text-sm transition-colors">Export CSV ↓</button>
+          <button
+            onClick={load}
+            className="bg-slate-200 hover:bg-slate-300 text-slate-700 font-semibold rounded-lg px-4 py-2 text-sm transition-colors"
+          >
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 md:grid-cols-5 gap-3 mb-6">
+        <StatCard label="Total" value={stats.total} />
+        <StatCard label="Pending" value={stats.pending} highlight={stats.pending > 0} />
+        <StatCard label="Verified" value={stats.verified} highlight={stats.verified > 0} />
+        <StatCard label="Approved" value={stats.approved} />
+        <StatCard label="Rejected" value={stats.rejected} />
+      </div>
+
+      <div className="flex flex-wrap gap-2 mb-4">
+        {tabs.map((t) => (
+          <button
+            key={t.key}
+            onClick={() => setTab(t.key)}
+            className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
+              tab === t.key
+                ? "bg-emerald-800 text-white"
+                : "bg-slate-100 text-slate-600 hover:bg-slate-200"
+            }`}
+          >
+            {t.label} ({t.count})
+          </button>
+        ))}
+      </div>
+
+      <input
+        type="text"
+        placeholder="Search by name, email, fund, or title..."
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        className="w-full bg-white border border-slate-300 rounded-lg px-3 py-2 text-sm text-slate-900 placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-amber-500/30 mb-4"
+      />
+
+      {selected.size > 0 && (
+        <div className="mb-4 bg-blue-50 border border-blue-200 rounded-lg px-4 py-3 flex items-center justify-between">
+          <span className="text-sm text-blue-700 font-medium">{selected.size} review{selected.size !== 1 ? "s" : ""} selected</span>
+          <div className="flex items-center gap-2">
+            <button onClick={async () => { for (const id of selected) await handleModerate(id, "approve"); setSelected(new Set()); }} className="px-3 py-1.5 text-xs font-medium bg-emerald-600 text-white rounded-lg hover:bg-emerald-700 transition-colors">Approve All</button>
+            <button onClick={async () => { for (const id of selected) await handleModerate(id, "reject"); setSelected(new Set()); }} className="px-3 py-1.5 text-xs font-medium bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors">Reject All</button>
+            <button onClick={() => setSelected(new Set())} className="px-3 py-1.5 text-xs text-slate-500 hover:text-slate-900 transition-colors">Clear</button>
+          </div>
+        </div>
+      )}
+
+      {loading ? (
+        <div className="py-12 text-center text-slate-500 text-sm animate-pulse">Loading reviews...</div>
+      ) : (
+        <div className="bg-white border border-slate-200 rounded-lg overflow-x-auto">
+          <table className="w-full">
+            <thead className="bg-slate-50">
+              <tr>
+                <th className="px-3 py-3 w-8">
+                  <input type="checkbox" checked={paginated.length > 0 && selected.size === paginated.length} onChange={() => { if (selected.size === paginated.length) setSelected(new Set()); else setSelected(new Set(paginated.map(r => r.id))); }} className="w-4 h-4 rounded border-slate-300" />
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-slate-500 uppercase">Fund</th>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-slate-500 uppercase">Name</th>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-slate-500 uppercase">Rating</th>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-slate-500 uppercase">Title</th>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-slate-500 uppercase">Status</th>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-slate-500 uppercase">Date</th>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-slate-500 uppercase">Actions</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-200">
+              {paginated.map((review) => (
+                <tr key={review.id} className="hover:bg-slate-50">
+                  <td className="px-3 py-3 w-8">
+                    <input type="checkbox" checked={selected.has(review.id)} onChange={() => { setSelected(prev => { const next = new Set(prev); if (next.has(review.id)) next.delete(review.id); else next.add(review.id); return next; }); }} className="w-4 h-4 rounded border-slate-300" />
+                  </td>
+                  <td className="px-4 py-3 text-sm text-slate-700 font-medium">{review.fund_slug}</td>
+                  <td className="px-4 py-3">
+                    <div className="text-sm text-slate-900">{review.display_name}</div>
+                    <div className="text-xs text-slate-400">{review.email}</div>
+                  </td>
+                  <td className="px-4 py-3">
+                    <Stars rating={review.rating} />
+                  </td>
+                  <td className="px-4 py-3">
+                    <button
+                      onClick={() => setExpandedId(expandedId === review.id ? null : review.id)}
+                      className="text-sm text-slate-700 hover:text-emerald-700 text-left max-w-50 truncate transition-colors"
+                      title={review.title}
+                    >
+                      {review.title}
+                    </button>
+                  </td>
+                  <td className="px-4 py-3">
+                    <span className={`text-xs px-2 py-1 rounded-full font-medium ${statusColors[review.status]}`}>
+                      {review.status}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-xs text-slate-500">
+                    {new Date(review.created_at).toLocaleDateString("en-AU", { day: "numeric", month: "short", year: "numeric" })}
+                  </td>
+                  <td className="px-4 py-3">
+                    {(review.status === "verified" || review.status === "pending") ? (
+                      <div className="flex gap-1">
+                        <button
+                          onClick={() => handleModerate(review.id, "approve")}
+                          disabled={actionLoading === review.id}
+                          className="px-2 py-1 text-xs bg-emerald-100 text-emerald-700 rounded hover:bg-emerald-200 transition-colors disabled:opacity-50 font-medium"
+                        >
+                          Approve
+                        </button>
+                        <button
+                          onClick={() => handleModerate(review.id, "reject")}
+                          disabled={actionLoading === review.id}
+                          className="px-2 py-1 text-xs bg-red-100 text-red-700 rounded hover:bg-red-200 transition-colors disabled:opacity-50 font-medium"
+                        >
+                          Reject
+                        </button>
+                      </div>
+                    ) : review.status === "approved" ? (
+                      <button
+                        onClick={() => handleModerate(review.id, "reject")}
+                        disabled={actionLoading === review.id}
+                        className="px-2 py-1 text-xs bg-red-50 text-red-500 rounded hover:bg-red-100 transition-colors disabled:opacity-50"
+                      >
+                        Reject
+                      </button>
+                    ) : (
+                      <button
+                        onClick={() => handleModerate(review.id, "approve")}
+                        disabled={actionLoading === review.id}
+                        className="px-2 py-1 text-xs bg-emerald-50 text-emerald-500 rounded hover:bg-emerald-100 transition-colors disabled:opacity-50"
+                      >
+                        Approve
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              ))}
+              {paginated.length === 0 && (
+                <tr>
+                  <td colSpan={8} className="px-4 py-8 text-center text-sm text-slate-500">
+                    {search || tab !== "all" ? "No reviews match your filters." : "No fund reviews yet."}
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+
+          {expandedId && (() => {
+            const r = reviews.find((rv) => rv.id === expandedId);
+            if (!r) return null;
+            return (
+              <div className="border-t border-slate-200 bg-slate-50 p-5">
+                <div className="flex items-center justify-between mb-3">
+                  <h3 className="font-bold text-slate-900">{r.title}</h3>
+                  <button
+                    onClick={() => setExpandedId(null)}
+                    className="text-xs text-slate-400 hover:text-slate-600"
+                  >
+                    Close
+                  </button>
+                </div>
+                <p className="text-sm text-slate-700 whitespace-pre-line mb-3">{r.body}</p>
+                {r.pros && (
+                  <div className="bg-emerald-50 rounded-lg p-3 mb-2">
+                    <p className="text-xs font-bold text-emerald-700 mb-1">Pros</p>
+                    <p className="text-xs text-slate-700">{r.pros}</p>
+                  </div>
+                )}
+                {r.cons && (
+                  <div className="bg-red-50 rounded-lg p-3 mb-2">
+                    <p className="text-xs font-bold text-red-700 mb-1">Cons</p>
+                    <p className="text-xs text-slate-700">{r.cons}</p>
+                  </div>
+                )}
+                <div className="text-xs text-slate-400 mt-3 space-y-1">
+                  <p>Email: {r.email}</p>
+                  <p>Verified: {r.verified_at ? new Date(r.verified_at).toLocaleString("en-AU") : "Not yet"}</p>
+                  <p>Last updated: {new Date(r.updated_at).toLocaleString("en-AU")}</p>
+                  {r.moderation_note && <p>Note: {r.moderation_note}</p>}
+                </div>
+              </div>
+            );
+          })()}
+        </div>
+      )}
+
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between mt-4">
+          <span className="text-xs text-slate-500">
+            Page {page + 1} of {totalPages} · {filtered.length} result{filtered.length !== 1 ? "s" : ""}
+          </span>
+          <div className="flex gap-2">
+            <button
+              onClick={() => setPage((p) => Math.max(0, p - 1))}
+              disabled={page === 0}
+              className="px-3 py-1.5 text-xs bg-slate-200 text-slate-600 rounded-lg hover:bg-slate-300 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+            >
+              ← Prev
+            </button>
+            <button
+              onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+              disabled={page >= totalPages - 1}
+              className="px-3 py-1.5 text-xs bg-slate-200 text-slate-600 rounded-lg hover:bg-slate-300 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+            >
+              Next →
+            </button>
+          </div>
+        </div>
+      )}
+    </AdminShell>
+  );
+}
+
+function StatCard({ label, value, highlight }: { label: string; value: number; highlight?: boolean }) {
+  return (
+    <div className={`border rounded-lg p-4 ${highlight ? "bg-amber-50 border-amber-200" : "bg-white border-slate-200"}`}>
+      <div className="text-xs text-slate-500 font-medium mb-1">{label}</div>
+      <div className={`text-2xl font-bold ${highlight ? "text-amber-700" : "text-slate-900"}`}>
+        {value.toLocaleString()}
+      </div>
+    </div>
+  );
+}

--- a/app/api/fund-review/moderate/route.ts
+++ b/app/api/fund-review/moderate/route.ts
@@ -1,0 +1,99 @@
+import { createAdminClient } from "@/lib/supabase/admin";
+import { createClient as createServerClient } from "@/lib/supabase/server";
+import { NextRequest, NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
+import { notificationFooter } from "@/lib/email-templates";
+import { ADMIN_EMAILS } from "@/lib/admin";
+
+const log = logger("fund-review");
+
+export async function POST(request: NextRequest) {
+  const supabaseAuth = await createServerClient();
+  const { data: { user }, error: authError } = await supabaseAuth.auth.getUser();
+  if (authError || !user || !ADMIN_EMAILS.includes(user.email?.toLowerCase() || "")) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    // eslint-disable-next-line invest/no-unvalidated-req-json -- mirrors app/api/user-review/moderate/route.ts (broker reviews); admin-only path behind ADMIN_EMAILS auth check above
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { review_id, action, moderation_note } = body as {
+    review_id?: number;
+    action?: "approve" | "reject";
+    moderation_note?: string;
+  };
+
+  if (!review_id || typeof review_id !== "number") {
+    return NextResponse.json({ error: "review_id is required" }, { status: 400 });
+  }
+  if (!action || !["approve", "reject"].includes(action)) {
+    return NextResponse.json({ error: "action must be approve or reject" }, { status: 400 });
+  }
+
+  const supabase = createAdminClient();
+  const newStatus = action === "approve" ? "approved" : "rejected";
+
+  const { data, error } = await supabase
+    .from("fund_reviews")
+    .update({
+      status: newStatus,
+      updated_at: new Date().toISOString(),
+      moderation_note: moderation_note ? String(moderation_note).slice(0, 500) : null,
+    })
+    .eq("id", review_id)
+    .select("id, status")
+    .single();
+
+  if (error) {
+    log.error("fund_review moderate error", { error: error.message });
+    return NextResponse.json({ error: "Failed to update review" }, { status: 500 });
+  }
+
+  if (!data) {
+    return NextResponse.json({ error: "Review not found" }, { status: 404 });
+  }
+
+  if (process.env.RESEND_API_KEY) {
+    const { data: review } = await supabase
+      .from("fund_reviews")
+      .select("display_name, email, fund_slug, fund_listings(title)")
+      .eq("id", review_id)
+      .single();
+
+    if (review?.email) {
+      const fundTitle = ((review.fund_listings as { title: string }[] | null)?.[0])?.title || review.fund_slug;
+      const firstName = (review.display_name || "there").split(" ")[0];
+
+      if (action === "approve") {
+        await fetch("https://api.resend.com/emails", {
+          method: "POST",
+          headers: { Authorization: `Bearer ${process.env.RESEND_API_KEY}`, "Content-Type": "application/json" },
+          body: JSON.stringify({
+            from: "Invest.com.au <reviews@invest.com.au>",
+            to: review.email,
+            subject: `Your review of ${fundTitle} is now live`,
+            html: `<div style="font-family:Arial,sans-serif;max-width:500px;margin:0 auto"><h2 style="color:#0f172a;font-size:16px">Review Published ✓</h2><p style="color:#64748b;font-size:14px">Hi ${firstName}, your review of <strong>${fundTitle}</strong> has been approved and is now visible on the platform.</p><p style="color:#64748b;font-size:14px">Thank you for contributing — your feedback helps other investors make better decisions.</p>${notificationFooter(review.email)}</div>`,
+          }),
+        }).catch((err) => log.error("Approval notification email failed", { error: err instanceof Error ? err.message : String(err) }));
+      } else if (action === "reject" && moderation_note) {
+        await fetch("https://api.resend.com/emails", {
+          method: "POST",
+          headers: { Authorization: `Bearer ${process.env.RESEND_API_KEY}`, "Content-Type": "application/json" },
+          body: JSON.stringify({
+            from: "Invest.com.au <reviews@invest.com.au>",
+            to: review.email,
+            subject: `Update on your review of ${fundTitle}`,
+            html: `<div style="font-family:Arial,sans-serif;max-width:500px;margin:0 auto"><h2 style="color:#0f172a;font-size:16px">Review Update</h2><p style="color:#64748b;font-size:14px">Hi ${firstName}, your review of <strong>${fundTitle}</strong> was not published.</p>${moderation_note ? `<p style="background:#fef2f2;padding:10px;border-radius:6px;font-size:13px;color:#991b1b;border-left:3px solid #ef4444"><strong>Reason:</strong> ${moderation_note}</p>` : ""}<p style="color:#64748b;font-size:14px">You're welcome to submit a new review.</p>${notificationFooter(review.email)}</div>`,
+          }),
+        }).catch((err) => log.error("Rejection notification email failed", { error: err instanceof Error ? err.message : String(err) }));
+      }
+    }
+  }
+
+  return NextResponse.json({ success: true, review: data });
+}

--- a/app/api/fund-review/route.ts
+++ b/app/api/fund-review/route.ts
@@ -1,0 +1,222 @@
+import { createAdminClient } from "@/lib/supabase/admin";
+import { NextRequest, NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
+import { isValidEmail } from "@/lib/validate-email";
+import { createRateLimiter } from "@/lib/rate-limiter";
+
+const log = logger("fund-review");
+
+const checkRateLimit = createRateLimiter(300_000, 3);
+
+function sanitize(str: unknown, maxLen: number): string {
+  if (typeof str !== "string") return "";
+  return str.trim().slice(0, maxLen);
+}
+
+function buildVerificationEmail(displayName: string, fundTitle: string, verifyUrl: string): string {
+  return `
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Verify Your Review</title>
+</head>
+<body style="margin: 0; padding: 0; background-color: #f1f5f9; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;">
+  <div style="max-width: 560px; margin: 0 auto; padding: 24px 16px;">
+    <div style="background: linear-gradient(135deg, #15803d 0%, #166534 100%); border-radius: 12px 12px 0 0; padding: 24px; text-align: center;">
+      <h1 style="color: #ffffff; font-size: 20px; margin: 0; font-weight: 800;">Verify Your Review</h1>
+    </div>
+    <div style="background: #ffffff; padding: 24px; border-radius: 0 0 12px 12px; box-shadow: 0 1px 3px rgba(0,0,0,0.1);">
+      <p style="color: #334155; font-size: 14px; line-height: 1.6; margin: 0 0 16px 0;">
+        Hi ${displayName},
+      </p>
+      <p style="color: #334155; font-size: 14px; line-height: 1.6; margin: 0 0 16px 0;">
+        Thanks for reviewing <strong>${fundTitle}</strong> on Invest.com.au. Click the button below to verify your email and submit your review for approval.
+      </p>
+      <div style="text-align: center; margin: 24px 0;">
+        <a href="${verifyUrl}" style="display: inline-block; padding: 12px 32px; background-color: #15803d; color: #ffffff; font-weight: 700; font-size: 14px; border-radius: 8px; text-decoration: none;">
+          Verify My Review
+        </a>
+      </div>
+      <p style="color: #94a3b8; font-size: 12px; text-align: center; margin: 16px 0 0 0; line-height: 1.5;">
+        If you didn't write this review, you can safely ignore this email.<br>
+        This link expires in 7 days.
+      </p>
+      <p style="color: #94a3b8; font-size: 11px; text-align: center; margin: 16px 0 0 0;">
+        <a href="https://invest.com.au" style="color: #94a3b8;">invest.com.au</a>
+      </p>
+    </div>
+  </div>
+</body>
+</html>`;
+}
+
+export async function POST(request: NextRequest) {
+  let body: Record<string, unknown>;
+  try {
+    // eslint-disable-next-line invest/no-unvalidated-req-json -- mirrors app/api/user-review/route.ts (broker reviews); field-specific error envelopes match the editorial-review contract used by the admin moderation surface
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const {
+    fund_slug,
+    display_name,
+    email,
+    rating,
+    title,
+    body: reviewBody,
+    pros,
+    cons,
+    performance_rating,
+    communication_rating,
+    fees_rating,
+    manager_rating,
+    hold_period_months,
+  } = body as {
+    fund_slug?: string;
+    display_name?: string;
+    email?: string;
+    rating?: number;
+    title?: string;
+    body?: string;
+    pros?: string | null;
+    cons?: string | null;
+    performance_rating?: number | null;
+    communication_rating?: number | null;
+    fees_rating?: number | null;
+    manager_rating?: number | null;
+    hold_period_months?: number | null;
+  };
+
+  if (!fund_slug || typeof fund_slug !== "string") {
+    return NextResponse.json({ error: "Fund is required" }, { status: 400 });
+  }
+  if (!isValidEmail(email as string)) {
+    return NextResponse.json({ error: "Valid email is required" }, { status: 400 });
+  }
+  if (!rating || typeof rating !== "number" || rating < 1 || rating > 5 || !Number.isInteger(rating)) {
+    return NextResponse.json({ error: "Rating must be 1-5" }, { status: 400 });
+  }
+  if (!display_name || typeof display_name !== "string" || display_name.trim().length < 2) {
+    return NextResponse.json({ error: "Display name is required (min 2 characters)" }, { status: 400 });
+  }
+  if (!title || typeof title !== "string" || title.trim().length < 3) {
+    return NextResponse.json({ error: "Review title is required (min 3 characters)" }, { status: 400 });
+  }
+  if (!reviewBody || typeof reviewBody !== "string" || reviewBody.trim().length < 10) {
+    return NextResponse.json({ error: "Review body is required (min 10 characters)" }, { status: 400 });
+  }
+
+  for (const [fieldName, fieldValue] of [
+    ["performance_rating", performance_rating],
+    ["communication_rating", communication_rating],
+    ["fees_rating", fees_rating],
+    ["manager_rating", manager_rating],
+  ] as const) {
+    if (fieldValue != null && (typeof fieldValue !== "number" || !Number.isInteger(fieldValue) || fieldValue < 1 || fieldValue > 5)) {
+      return NextResponse.json({ error: `${fieldName} must be 1-5 if provided` }, { status: 400 });
+    }
+  }
+
+  if (hold_period_months != null && (typeof hold_period_months !== "number" || !Number.isInteger(hold_period_months) || hold_period_months < 1)) {
+    return NextResponse.json({ error: "hold_period_months must be a positive integer if provided" }, { status: 400 });
+  }
+
+  const forwarded = request.headers.get("x-forwarded-for");
+  const ip = forwarded ? forwarded.split(",")[0].trim() : "unknown";
+
+  if (checkRateLimit(ip)) {
+    return NextResponse.json({ error: "Too many requests. Please try again later." }, { status: 429 });
+  }
+
+  const supabase = createAdminClient();
+
+  const { data: fund } = await supabase
+    .from("fund_listings")
+    .select("id, title, slug")
+    .eq("slug", fund_slug)
+    .eq("status", "active")
+    .single();
+
+  if (!fund) {
+    return NextResponse.json({ error: "Fund not found" }, { status: 404 });
+  }
+
+  const ninetyDaysAgo = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString();
+  const sanitizedEmail = (email as string).trim().toLowerCase().slice(0, 254);
+
+  const { data: existing } = await supabase
+    .from("fund_reviews")
+    .select("id")
+    .eq("fund_slug", fund.slug)
+    .eq("email", sanitizedEmail)
+    .gte("created_at", ninetyDaysAgo)
+    .limit(1);
+
+  if (existing && existing.length > 0) {
+    return NextResponse.json({ error: "You have already reviewed this fund recently." }, { status: 409 });
+  }
+
+  const verificationToken = crypto.randomUUID();
+
+  const sanitizedName = sanitize(display_name, 50);
+  const sanitizedTitle = sanitize(title, 120);
+  const sanitizedBody = sanitize(reviewBody, 2000);
+  const sanitizedPros = pros ? sanitize(pros, 500) : null;
+  const sanitizedCons = cons ? sanitize(cons, 500) : null;
+
+  const { error: insertError } = await supabase.from("fund_reviews").insert({
+    fund_id: fund.id,
+    fund_slug: fund.slug,
+    display_name: sanitizedName,
+    email: sanitizedEmail,
+    rating,
+    title: sanitizedTitle,
+    body: sanitizedBody,
+    pros: sanitizedPros,
+    cons: sanitizedCons,
+    performance_rating: performance_rating || null,
+    communication_rating: communication_rating || null,
+    fees_rating: fees_rating || null,
+    manager_rating: manager_rating || null,
+    hold_period_months: hold_period_months || null,
+    verification_token: verificationToken,
+    status: "pending",
+  });
+
+  if (insertError) {
+    log.error("fund_review insert error", { error: insertError.message });
+    return NextResponse.json({ error: "Failed to submit review" }, { status: 500 });
+  }
+
+  const { getSiteUrl } = await import("@/lib/url");
+  const siteUrl = getSiteUrl();
+  const verifyUrl = `${siteUrl}/api/fund-review/verify?token=${verificationToken}`;
+
+  const resendApiKey = process.env.RESEND_API_KEY;
+  if (resendApiKey) {
+    try {
+      const html = buildVerificationEmail(sanitizedName, fund.title, verifyUrl);
+      await fetch("https://api.resend.com/emails", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${resendApiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          from: "Invest.com.au <fees@invest.com.au>",
+          to: [sanitizedEmail],
+          subject: `Verify your review of ${fund.title} — Invest.com.au`,
+          html,
+        }),
+      });
+    } catch (err) {
+      log.error("Failed to send verification email", { error: err instanceof Error ? err.message : String(err) });
+    }
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/app/api/fund-review/verify/route.ts
+++ b/app/api/fund-review/verify/route.ts
@@ -1,0 +1,96 @@
+import { createAdminClient } from "@/lib/supabase/admin";
+import { NextRequest, NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
+import { isAllowed, ipKey } from "@/lib/rate-limit-db";
+
+const log = logger("fund-review");
+
+const PROFANITY_LIST = [
+  "fuck", "shit", "cunt", "bitch", "asshole", "dick", "piss",
+  "bastard", "wanker", "slut", "whore", "nigger", "faggot", "retard",
+];
+
+const SPAM_URL_REGEX = /https?:\/\/[^\s]+/i;
+const profanityRegex = new RegExp(`\\b(${PROFANITY_LIST.join("|")})\\b`, "i");
+
+interface ReviewContent {
+  title: string;
+  body: string;
+  pros: string | null;
+  cons: string | null;
+  display_name: string;
+}
+
+function checkBlocklist(review: ReviewContent): string | null {
+  const allText = [review.title, review.body, review.pros, review.cons, review.display_name]
+    .filter(Boolean)
+    .join(" ");
+
+  if (profanityRegex.test(allText)) return "Contains profanity";
+  if (SPAM_URL_REGEX.test(allText)) return "Contains URL";
+  if (review.body.trim().length < 20) return "Body too short";
+
+  if (review.body.length >= 30) {
+    const upperCount = (review.body.match(/[A-Z]/g) || []).length;
+    const letterCount = (review.body.match(/[A-Za-z]/g) || []).length;
+    if (letterCount > 0 && upperCount / letterCount > 0.6) return "Excessive caps";
+  }
+
+  if (/(.)\1{5,}/.test(allText)) return "Repetitive characters";
+
+  return null;
+}
+
+export async function GET(request: NextRequest) {
+  if (!(await isAllowed("fund_review_verify_get", ipKey(request), { max: 30, refillPerSec: 0.2 }))) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+  }
+
+  const token = request.nextUrl.searchParams.get("token");
+
+  if (!token || typeof token !== "string" || token.length < 10) {
+    return NextResponse.redirect(new URL("/?error=invalid_token", request.url));
+  }
+
+  const supabase = createAdminClient();
+
+  const { data: review } = await supabase
+    .from("fund_reviews")
+    .select("id, fund_slug, status, title, body, pros, cons, display_name")
+    .eq("verification_token", token)
+    .single();
+
+  if (!review) {
+    return NextResponse.redirect(new URL("/?error=review_not_found", request.url));
+  }
+
+  if (review.status === "pending") {
+    const blockReason = checkBlocklist({
+      title: review.title,
+      body: review.body,
+      pros: review.pros,
+      cons: review.cons,
+      display_name: review.display_name,
+    });
+
+    const newStatus = blockReason ? "verified" : "approved";
+
+    const { error } = await supabase
+      .from("fund_reviews")
+      .update({
+        status: newStatus,
+        verified_at: new Date().toISOString(),
+        ...(blockReason ? { moderation_note: `Auto-held: ${blockReason}` } : {}),
+      })
+      .eq("id", review.id);
+
+    if (error) {
+      log.error("fund_review verify error", { error: error.message });
+      return NextResponse.redirect(new URL("/?error=verification_failed", request.url));
+    }
+  }
+
+  const { getSiteUrl } = await import("@/lib/url");
+  const siteUrl = getSiteUrl();
+  return NextResponse.redirect(new URL(`/invest/funds/${review.fund_slug}?review_verified=1`, siteUrl));
+}

--- a/app/invest/funds/[slug]/page.tsx
+++ b/app/invest/funds/[slug]/page.tsx
@@ -5,6 +5,8 @@ import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
 import { createClient } from "@/lib/supabase/server";
 import Icon from "@/components/Icon";
 import RegisterInterestForm from "@/components/funds/RegisterInterestForm";
+import FundReviewsList from "@/components/FundReviewsList";
+import type { FundReview, FundReviewStats } from "@/lib/types";
 import type { FundListing } from "../FundsDirectoryClient";
 
 export const revalidate = 600;
@@ -21,6 +23,43 @@ async function fetchFund(slug: string): Promise<FundListing | null> {
     return (data as FundListing | null) || null;
   } catch {
     return null;
+  }
+}
+
+async function fetchReviews(fundId: number): Promise<{ reviews: FundReview[]; stats: FundReviewStats | null }> {
+  try {
+    const supabase = await createClient();
+    const { data } = await supabase
+      .from("fund_reviews")
+      .select(
+        "id, fund_id, fund_slug, display_name, rating, title, body, pros, cons, performance_rating, communication_rating, fees_rating, manager_rating, hold_period_months, status, created_at",
+      )
+      .eq("fund_id", fundId)
+      .eq("status", "approved")
+      .order("created_at", { ascending: false })
+      .limit(20);
+
+    const reviews = (data ?? []) as FundReview[];
+    if (reviews.length === 0) return { reviews, stats: null };
+
+    const avg = (key: keyof FundReview) => {
+      const nums = reviews.map((r) => r[key]).filter((v): v is number => typeof v === "number");
+      if (nums.length === 0) return undefined;
+      return nums.reduce((a, b) => a + b, 0) / nums.length;
+    };
+
+    const stats: FundReviewStats = {
+      fund_id: fundId,
+      review_count: reviews.length,
+      average_rating: reviews.reduce((a, r) => a + r.rating, 0) / reviews.length,
+      avg_performance_rating: avg("performance_rating"),
+      avg_communication_rating: avg("communication_rating"),
+      avg_fees_rating: avg("fees_rating"),
+      avg_manager_rating: avg("manager_rating"),
+    };
+    return { reviews, stats };
+  } catch {
+    return { reviews: [], stats: null };
   }
 }
 
@@ -97,7 +136,10 @@ export default async function FundDetailPage({
   const { slug } = await params;
   const fund = await fetchFund(slug);
   if (!fund) notFound();
-  const related = await fetchRelated(fund.fund_type, fund.id);
+  const [related, { reviews, stats: reviewStats }] = await Promise.all([
+    fetchRelated(fund.fund_type, fund.id),
+    fetchReviews(fund.id),
+  ]);
 
   const typeLabel = fund.fund_type
     ? FUND_TYPE_LABELS[fund.fund_type] ?? "Fund"
@@ -303,6 +345,15 @@ export default async function FundDetailPage({
                   returns. Consider obtaining personal advice from a licensed
                   adviser before investing.
                 </p>
+              </div>
+
+              <div className="bg-white border border-slate-200 rounded-xl p-6">
+                <FundReviewsList
+                  reviews={reviews}
+                  stats={reviewStats}
+                  fundSlug={fund.slug}
+                  fundTitle={fund.title}
+                />
               </div>
             </div>
 

--- a/components/AdminSidebar.tsx
+++ b/components/AdminSidebar.tsx
@@ -49,6 +49,7 @@ const NAV_GROUPS = [
       { href: "/admin/advisor-moderation", icon: "check-circle", label: "Pending Advisors" },
       { href: "/admin/review-moderation", icon: "star", label: "Pending Reviews" },
       { href: "/admin/user-reviews", icon: "clipboard-list", label: "User Reviews" },
+      { href: "/admin/fund-reviews", icon: "clipboard-list", label: "Fund Reviews" },
       { href: "/admin/switch-stories", icon: "shuffle", label: "Switch Stories" },
       { href: "/admin/moderation", icon: "shield-check", label: "Content Moderation" },
     ],

--- a/components/FundReviewForm.tsx
+++ b/components/FundReviewForm.tsx
@@ -1,0 +1,310 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import StarRatingInput from "./StarRatingInput";
+
+interface FundReviewFormProps {
+  fundSlug: string;
+  fundTitle: string;
+}
+
+export default function FundReviewForm({ fundSlug, fundTitle }: FundReviewFormProps) {
+  const [rating, setRating] = useState(0);
+  const [displayName, setDisplayName] = useState("");
+  const [email, setEmail] = useState("");
+  const [title, setTitle] = useState("");
+  const [body, setBody] = useState("");
+  const [pros, setPros] = useState("");
+  const [cons, setCons] = useState("");
+  const [performanceRating, setPerformanceRating] = useState(0);
+  const [communicationRating, setCommunicationRating] = useState(0);
+  const [feesRating, setFeesRating] = useState(0);
+  const [managerRating, setManagerRating] = useState(0);
+  const [holdPeriodMonths, setHoldPeriodMonths] = useState<number | null>(null);
+  const [consent, setConsent] = useState(false);
+  const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
+  const [errorMsg, setErrorMsg] = useState("");
+  const [isOpen, setIsOpen] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setErrorMsg("");
+
+    if (rating === 0) {
+      setErrorMsg("Please select a star rating.");
+      return;
+    }
+    if (!displayName.trim() || !email.trim() || !title.trim() || !body.trim()) {
+      setErrorMsg("Please fill in all required fields.");
+      return;
+    }
+    if (!consent) {
+      setErrorMsg("Please agree to the terms to continue.");
+      return;
+    }
+
+    setStatus("loading");
+    try {
+      const res = await fetch("/api/fund-review", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          fund_slug: fundSlug,
+          display_name: displayName.trim(),
+          email: email.trim(),
+          rating,
+          title: title.trim(),
+          body: body.trim(),
+          pros: pros.trim() || null,
+          cons: cons.trim() || null,
+          performance_rating: performanceRating || null,
+          communication_rating: communicationRating || null,
+          fees_rating: feesRating || null,
+          manager_rating: managerRating || null,
+          hold_period_months: holdPeriodMonths,
+        }),
+      });
+
+      if (res.ok) {
+        setStatus("success");
+      } else {
+        const data = await res.json();
+        setErrorMsg(data.error || "Something went wrong. Please try again.");
+        setStatus("error");
+      }
+    } catch {
+      setErrorMsg("Network error. Please try again.");
+      setStatus("error");
+    }
+  }
+
+  if (status === "success") {
+    return (
+      <div className="bg-slate-50 border border-slate-200 rounded-xl p-6 text-center">
+        <div className="text-2xl mb-2">📧</div>
+        <h4 className="text-lg font-bold text-slate-900 mb-1">Check your inbox!</h4>
+        <p className="text-sm text-slate-600">
+          We&apos;ve sent a verification email to <strong>{email}</strong>.
+          Click the link to confirm your review — it&apos;ll appear on this page once approved.
+        </p>
+      </div>
+    );
+  }
+
+  if (!isOpen) {
+    return (
+      <button
+        onClick={() => setIsOpen(true)}
+        className="w-full py-3 bg-amber-50 border border-amber-200 rounded-xl text-amber-800 font-semibold text-sm hover:bg-amber-100 transition-colors"
+      >
+        Write a Review of {fundTitle}
+      </button>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} noValidate className="bg-white border border-slate-200 rounded-xl p-5 space-y-4">
+      <h4 className="text-base font-bold text-slate-900">Write Your Review of {fundTitle}</h4>
+
+      <div>
+        <label className="block text-sm font-medium text-slate-700 mb-1">
+          Your Rating <span className="text-red-500">*</span>
+        </label>
+        <StarRatingInput value={rating} onChange={setRating} size="lg" />
+      </div>
+
+      <div className="bg-slate-50 rounded-lg p-3">
+        <p className="text-xs font-medium text-slate-500 mb-2">Rate specific aspects <span className="text-slate-400 font-normal">(optional)</span></p>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-2">
+          {([
+            { label: "Performance vs target", value: performanceRating, setter: setPerformanceRating },
+            { label: "Manager communication", value: communicationRating, setter: setCommunicationRating },
+            { label: "Fees & total cost", value: feesRating, setter: setFeesRating },
+            { label: "Manager confidence", value: managerRating, setter: setManagerRating },
+          ] as const).map((dim) => (
+            <div key={dim.label} className="flex items-center gap-2">
+              <span className="text-xs text-slate-600 w-36 shrink-0">{dim.label}</span>
+              <div className="flex items-center gap-0.5">
+                {[1, 2, 3, 4, 5].map((star) => (
+                  <button
+                    key={star}
+                    type="button"
+                    onClick={() => dim.setter(star === dim.value ? 0 : star)}
+                    className={`text-base leading-none ${star <= dim.value ? "text-amber-400" : "text-slate-200"} hover:scale-110 transition-transform`}
+                    aria-label={`${dim.label} ${star} star${star !== 1 ? "s" : ""}`}
+                  >
+                    ★
+                  </button>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+        <div className="mt-3">
+          <label htmlFor="fund-review-hold-period" className="text-xs text-slate-600">
+            How long have you held this fund?
+          </label>
+          <select
+            id="fund-review-hold-period"
+            value={holdPeriodMonths ?? ""}
+            onChange={(e) => setHoldPeriodMonths(e.target.value ? Number(e.target.value) : null)}
+            className="mt-1 w-full sm:w-auto px-3 py-1.5 rounded-lg border border-slate-200 text-xs text-slate-700 bg-white focus:outline-none focus:ring-2 focus:ring-blue-700/40 focus:border-blue-700"
+          >
+            <option value="">Select...</option>
+            <option value="3">Less than 6 months</option>
+            <option value="9">6-12 months</option>
+            <option value="18">1-2 years</option>
+            <option value="36">2-3 years</option>
+            <option value="60">3-5 years</option>
+            <option value="120">5+ years</option>
+          </select>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <div>
+          <label htmlFor="fund-review-name" className="block text-sm font-medium text-slate-700 mb-1">
+            Display Name <span className="text-red-500">*</span>
+          </label>
+          <input
+            id="fund-review-name"
+            type="text"
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+            placeholder="e.g. Sarah M."
+            maxLength={50}
+            required
+            className="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm text-slate-900 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-blue-700/40 focus:border-blue-700"
+          />
+        </div>
+        <div>
+          <label htmlFor="fund-review-email" className="block text-sm font-medium text-slate-700 mb-1">
+            Email <span className="text-red-500">*</span>
+          </label>
+          <input
+            id="fund-review-email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="you@email.com"
+            maxLength={254}
+            required
+            className="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm text-slate-900 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-blue-700/40 focus:border-blue-700"
+          />
+          <p className="text-xs text-slate-400 mt-1">For verification only — never displayed.</p>
+        </div>
+      </div>
+
+      <div>
+        <label htmlFor="fund-review-title" className="block text-sm font-medium text-slate-700 mb-1">
+          Review Title <span className="text-red-500">*</span>
+        </label>
+        <input
+          id="fund-review-title"
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Summarise your experience in a few words"
+          maxLength={120}
+          required
+          className="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm text-slate-900 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-blue-700/40 focus:border-blue-700"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="fund-review-body" className="block text-sm font-medium text-slate-700 mb-1">
+          Your Review <span className="text-red-500">*</span>
+        </label>
+        <textarea
+          id="fund-review-body"
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          placeholder="What was your experience investing in this fund? Returns vs expectations, manager communication, fees, anything else?"
+          rows={4}
+          maxLength={2000}
+          required
+          className="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm text-slate-900 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-400/30 focus:border-slate-400 resize-y"
+        />
+        <p className="text-xs text-slate-400 mt-1 text-right">{body.length}/2000</p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <div>
+          <label htmlFor="fund-review-pros" className="block text-sm font-medium text-slate-700 mb-1">
+            Pros <span className="text-slate-400 font-normal">(optional)</span>
+          </label>
+          <textarea
+            id="fund-review-pros"
+            value={pros}
+            onChange={(e) => setPros(e.target.value)}
+            placeholder="What worked well?"
+            rows={2}
+            maxLength={500}
+            className="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm text-slate-900 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-400/30 focus:border-slate-400 resize-y"
+          />
+        </div>
+        <div>
+          <label htmlFor="fund-review-cons" className="block text-sm font-medium text-slate-700 mb-1">
+            Cons <span className="text-slate-400 font-normal">(optional)</span>
+          </label>
+          <textarea
+            id="fund-review-cons"
+            value={cons}
+            onChange={(e) => setCons(e.target.value)}
+            placeholder="What could be improved?"
+            rows={2}
+            maxLength={500}
+            className="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm text-slate-900 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-400/30 focus:border-slate-400 resize-y"
+          />
+        </div>
+      </div>
+
+      <div className="bg-amber-50 border border-amber-200 rounded-lg p-3">
+        <p className="text-[11px] text-amber-900 leading-relaxed">
+          <strong>General advice notice.</strong> Reviews reflect personal investor experience only.
+          Past performance described in any review is not a reliable indicator of future returns.
+          Consider the fund&apos;s PDS / IM and speak to a licensed adviser before investing.
+        </p>
+      </div>
+
+      <label className="flex items-start gap-2 cursor-pointer">
+        <input
+          type="checkbox"
+          checked={consent}
+          onChange={(e) => setConsent(e.target.checked)}
+          required
+          className="mt-0.5 w-4 h-4 rounded border-slate-300 accent-slate-700 shrink-0"
+        />
+        <span className="text-xs text-slate-500 leading-tight">
+          I confirm this review is based on my genuine experience as an investor in this fund. I agree to the{" "}
+          <Link href="/privacy" className="underline hover:text-slate-900">
+            Privacy Policy
+          </Link>
+          . My email will only be used for verification.
+        </span>
+      </label>
+
+      {errorMsg && (
+        <p className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg px-3 py-2">{errorMsg}</p>
+      )}
+
+      <div className="flex items-center gap-3">
+        <button
+          type="submit"
+          disabled={status === "loading"}
+          className="px-5 py-2.5 bg-slate-900 text-white text-sm font-bold rounded-lg hover:bg-slate-800 transition-colors disabled:opacity-60"
+        >
+          {status === "loading" ? "Submitting..." : "Submit Review"}
+        </button>
+        <button
+          type="button"
+          onClick={() => setIsOpen(false)}
+          className="px-4 py-2.5 text-sm text-slate-500 hover:text-slate-700 transition-colors"
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/components/FundReviewsList.tsx
+++ b/components/FundReviewsList.tsx
@@ -1,0 +1,173 @@
+import type { FundReview, FundReviewStats } from "@/lib/types";
+import FundReviewForm from "./FundReviewForm";
+
+interface FundReviewsListProps {
+  reviews: FundReview[];
+  stats: FundReviewStats | null;
+  fundSlug: string;
+  fundTitle: string;
+}
+
+function StarDisplay({ rating, size = "sm" }: { rating: number; size?: "sm" | "md" }) {
+  const sizeClass = size === "md" ? "w-5 h-5" : "w-4 h-4";
+  return (
+    <div className="inline-flex items-center gap-0.5" aria-label={`${rating} out of 5 stars`}>
+      {[1, 2, 3, 4, 5].map((star) => (
+        <svg
+          key={star}
+          viewBox="0 0 24 24"
+          fill={star <= Math.round(rating) ? "#f59e0b" : "none"}
+          stroke={star <= Math.round(rating) ? "#f59e0b" : "#cbd5e1"}
+          strokeWidth={1.5}
+          className={sizeClass}
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M11.48 3.499a.562.562 0 011.04 0l2.125 5.111a.563.563 0 00.475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 00-.182.557l1.285 5.385a.562.562 0 01-.84.61l-4.725-2.885a.562.562 0 00-.586 0L6.982 20.54a.562.562 0 01-.84-.61l1.285-5.386a.562.562 0 00-.182-.557l-4.204-3.602a.562.562 0 01.321-.988l5.518-.442a.563.563 0 00.475-.345L11.48 3.5z"
+          />
+        </svg>
+      ))}
+    </div>
+  );
+}
+
+function RatingBar({ star, count, total }: { star: number; count: number; total: number }) {
+  const pct = total > 0 ? (count / total) * 100 : 0;
+  return (
+    <div className="flex items-center gap-2 text-xs">
+      <span className="w-3 text-slate-500 text-right">{star}</span>
+      <div className="flex-1 bg-slate-100 rounded-full h-2 overflow-hidden">
+        <div
+          className="bg-amber-400 h-full rounded-full transition-all duration-500"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <span className="w-6 text-slate-400 text-right">{count}</span>
+    </div>
+  );
+}
+
+export default function FundReviewsList({ reviews, stats, fundSlug, fundTitle }: FundReviewsListProps) {
+  const distribution = [5, 4, 3, 2, 1].map((star) => ({
+    star,
+    count: reviews.filter((r) => r.rating === star).length,
+  }));
+
+  return (
+    <section className="mb-8" id="fund-reviews">
+      <h2 className="text-xl font-extrabold text-slate-900 mb-4">Investor Reviews</h2>
+
+      {stats && stats.review_count > 0 ? (
+        <div className="bg-slate-50 rounded-xl p-5 mb-5">
+          <div className="flex flex-col sm:flex-row gap-5">
+            <div className="text-center sm:text-left shrink-0">
+              <div className="text-2xl md:text-4xl font-black text-slate-900">
+                {stats.average_rating.toFixed(1)}
+              </div>
+              <StarDisplay rating={stats.average_rating} size="md" />
+              <p className="text-xs text-slate-500 mt-1">
+                {stats.review_count} investor review{stats.review_count !== 1 ? "s" : ""}
+              </p>
+            </div>
+
+            <div className="flex-1 space-y-1.5">
+              {distribution.map(({ star, count }) => (
+                <RatingBar key={star} star={star} count={count} total={reviews.length} />
+              ))}
+            </div>
+          </div>
+
+          {stats && (stats.avg_performance_rating || stats.avg_communication_rating || stats.avg_fees_rating || stats.avg_manager_rating) && (
+            <div className="grid grid-cols-2 gap-x-6 gap-y-1 mt-3">
+              {[
+                { label: "Performance", value: stats.avg_performance_rating },
+                { label: "Communication", value: stats.avg_communication_rating },
+                { label: "Fees", value: stats.avg_fees_rating },
+                { label: "Manager", value: stats.avg_manager_rating },
+              ].filter((d) => d.value != null).map((d) => (
+                <div key={d.label} className="flex items-center gap-2 text-xs">
+                  <span className="text-slate-500 w-20">{d.label}</span>
+                  <div className="flex-1 bg-slate-100 rounded-full h-1.5">
+                    <div
+                      className="bg-amber-400 h-1.5 rounded-full"
+                      style={{ width: `${((d.value || 0) / 5) * 100}%` }}
+                    />
+                  </div>
+                  <span className="text-slate-600 font-medium w-7 text-right">{d.value?.toFixed(1)}</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      ) : (
+        <div className="bg-slate-50 rounded-xl p-5 mb-5 text-center">
+          <p className="text-sm text-slate-500">
+            No investor reviews yet. Be the first to share your experience with this fund.
+          </p>
+        </div>
+      )}
+
+      {reviews.length > 0 && (
+        <div className="space-y-4 mb-5">
+          {reviews.map((review) => (
+            <div key={review.id} className="bg-white border border-slate-200 rounded-xl p-5">
+              <div className="flex items-start justify-between gap-3 mb-2">
+                <div>
+                  <StarDisplay rating={review.rating} />
+                  <h4 className="text-sm font-bold text-slate-900 mt-1">{review.title}</h4>
+                </div>
+                <div className="text-xs text-slate-400 shrink-0">
+                  {new Date(review.created_at).toLocaleDateString("en-AU", {
+                    day: "numeric",
+                    month: "short",
+                    year: "numeric",
+                  })}
+                </div>
+              </div>
+
+              <p className="text-sm text-slate-700 leading-relaxed whitespace-pre-line mb-3">
+                {review.body}
+              </p>
+
+              {(review.pros || review.cons) && (
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-3">
+                  {review.pros && (
+                    <div className="bg-slate-50 rounded-lg p-3">
+                      <p className="text-xs font-bold text-slate-700 mb-1">Pros</p>
+                      <p className="text-xs text-slate-700 leading-relaxed">{review.pros}</p>
+                    </div>
+                  )}
+                  {review.cons && (
+                    <div className="bg-red-50 rounded-lg p-3">
+                      <p className="text-xs font-bold text-red-700 mb-1">Cons</p>
+                      <p className="text-xs text-slate-700 leading-relaxed">{review.cons}</p>
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {review.hold_period_months != null && (
+                <p className="text-[11px] text-slate-500 mb-1">
+                  Held for {formatHoldPeriod(review.hold_period_months)}
+                </p>
+              )}
+
+              <div className="text-xs text-slate-400">— {review.display_name}</div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <FundReviewForm fundSlug={fundSlug} fundTitle={fundTitle} />
+    </section>
+  );
+}
+
+function formatHoldPeriod(months: number): string {
+  if (months < 12) return `${months} month${months !== 1 ? "s" : ""}`;
+  const years = months / 12;
+  if (years < 2) return "1+ year";
+  return `${Math.floor(years)}+ years`;
+}

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -7134,6 +7134,89 @@ export type Database = {
         }
         Relationships: []
       }
+      fund_reviews: {
+        Row: {
+          body: string
+          communication_rating: number | null
+          cons: string | null
+          created_at: string
+          display_name: string
+          email: string
+          fees_rating: number | null
+          fund_id: number
+          fund_slug: string
+          hold_period_months: number | null
+          id: number
+          ip_hash: string | null
+          manager_rating: number | null
+          moderation_note: string | null
+          performance_rating: number | null
+          pros: string | null
+          rating: number
+          status: string
+          title: string
+          updated_at: string
+          verification_token: string | null
+          verified_at: string | null
+        }
+        Insert: {
+          body: string
+          communication_rating?: number | null
+          cons?: string | null
+          created_at?: string
+          display_name: string
+          email: string
+          fees_rating?: number | null
+          fund_id: number
+          fund_slug: string
+          hold_period_months?: number | null
+          id?: number
+          ip_hash?: string | null
+          manager_rating?: number | null
+          moderation_note?: string | null
+          performance_rating?: number | null
+          pros?: string | null
+          rating: number
+          status?: string
+          title: string
+          updated_at?: string
+          verification_token?: string | null
+          verified_at?: string | null
+        }
+        Update: {
+          body?: string
+          communication_rating?: number | null
+          cons?: string | null
+          created_at?: string
+          display_name?: string
+          email?: string
+          fees_rating?: number | null
+          fund_id?: number
+          fund_slug?: string
+          hold_period_months?: number | null
+          id?: number
+          ip_hash?: string | null
+          manager_rating?: number | null
+          moderation_note?: string | null
+          performance_rating?: number | null
+          pros?: string | null
+          rating?: number
+          status?: string
+          title?: string
+          updated_at?: string
+          verification_token?: string | null
+          verified_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "fund_reviews_fund_id_fkey"
+            columns: ["fund_id"]
+            isOneToOne: false
+            referencedRelation: "fund_listings"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       glossary_terms: {
         Row: {
           category: string | null

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -341,6 +341,40 @@ export interface BrokerReviewStats {
   avg_reliability_rating?: number;
 }
 
+export interface FundReview {
+  id: number;
+  fund_id: number;
+  fund_slug: string;
+  display_name: string;
+  email?: string;
+  rating: number;
+  title: string;
+  body: string;
+  pros?: string | null;
+  cons?: string | null;
+  performance_rating?: number | null;
+  communication_rating?: number | null;
+  fees_rating?: number | null;
+  manager_rating?: number | null;
+  hold_period_months?: number | null;
+  status: 'pending' | 'verified' | 'approved' | 'rejected';
+  verification_token?: string;
+  verified_at?: string | null;
+  moderation_note?: string | null;
+  created_at: string;
+  updated_at?: string;
+}
+
+export interface FundReviewStats {
+  fund_id: number;
+  review_count: number;
+  average_rating: number;
+  avg_performance_rating?: number;
+  avg_communication_rating?: number;
+  avg_fees_rating?: number;
+  avg_manager_rating?: number;
+}
+
 export interface SwitchStory {
   id: number;
   source_broker_id: number;

--- a/supabase/migrations/20260722_fund_reviews.sql
+++ b/supabase/migrations/20260722_fund_reviews.sql
@@ -1,0 +1,108 @@
+-- ============================================================================
+-- Migration: fund_reviews — verified user reviews for fund_listings (W3.18)
+-- Date:      2026-05-10
+-- Plan ref:  docs/plans/pre-launch-wave-master-prompt.md (W3.18)
+--
+-- Purpose
+--   Mirrors public.user_reviews (brokers) and public.professional_reviews
+--   (advisors) for the third entity type in the editorial-review pattern:
+--   funds. Email-verified submission, auto-moderation on verify, manual
+--   override via /admin/fund-reviews. Display on /invest/funds/[slug].
+--
+-- Rollback
+--   BEGIN;
+--     DROP POLICY IF EXISTS "service_role full access"    ON public.fund_reviews;
+--     DROP POLICY IF EXISTS "Public read approved fund reviews" ON public.fund_reviews;
+--     DROP POLICY IF EXISTS "Insert fund reviews"         ON public.fund_reviews;
+--     ALTER TABLE public.fund_reviews DISABLE ROW LEVEL SECURITY;
+--     DROP TABLE public.fund_reviews;  -- DESTRUCTIVE — discards all reviews
+--   COMMIT;
+--
+-- RLS
+--   - service_role: explicit FOR ALL allow (audit visibility; the route
+--     uses createAdminClient() so RLS is bypassed regardless — the policy
+--     makes intent visible in pg_policies for auditors).
+--   - anon + authenticated SELECT WHERE status = 'approved': consumed by
+--     the fund detail page server component.
+--   - anon + authenticated INSERT with validation: defence-in-depth so a
+--     fresh-rebuild env enforces the same shape as the application route.
+--
+-- Idempotency
+--   - CREATE TABLE IF NOT EXISTS — no-op on existing table
+--   - ENABLE ROW LEVEL SECURITY — no-op if already enabled
+--   - DROP POLICY IF EXISTS + CREATE POLICY — safe to re-run
+-- ============================================================================
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.fund_reviews (
+  id                     serial      PRIMARY KEY,
+  fund_id                integer     NOT NULL REFERENCES public.fund_listings(id),
+  fund_slug              text        NOT NULL,
+  display_name           text        NOT NULL,
+  email                  text        NOT NULL,
+  rating                 integer     NOT NULL CHECK (rating BETWEEN 1 AND 5),
+  title                  text        NOT NULL,
+  body                   text        NOT NULL,
+  pros                   text,
+  cons                   text,
+  -- Per-dimension scores (1-5, optional). Funds-specific dimensions:
+  --   performance — perceived returns vs target
+  --   communication — manager reporting cadence / clarity
+  --   fees — total cost-of-ownership
+  --   manager — confidence in the team
+  performance_rating     integer     CHECK (performance_rating IS NULL OR performance_rating BETWEEN 1 AND 5),
+  communication_rating   integer     CHECK (communication_rating IS NULL OR communication_rating BETWEEN 1 AND 5),
+  fees_rating            integer     CHECK (fees_rating IS NULL OR fees_rating BETWEEN 1 AND 5),
+  manager_rating         integer     CHECK (manager_rating IS NULL OR manager_rating BETWEEN 1 AND 5),
+  hold_period_months     integer     CHECK (hold_period_months IS NULL OR hold_period_months >= 1),
+  status                 text        NOT NULL DEFAULT 'pending'
+                                       CHECK (status IN ('pending','verified','approved','rejected')),
+  verification_token     text,
+  verified_at            timestamptz,
+  moderation_note        text,
+  ip_hash                text,
+  created_at             timestamptz NOT NULL DEFAULT now(),
+  updated_at             timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_fund_reviews_fund_id     ON public.fund_reviews (fund_id);
+CREATE INDEX IF NOT EXISTS idx_fund_reviews_fund_slug   ON public.fund_reviews (fund_slug);
+CREATE INDEX IF NOT EXISTS idx_fund_reviews_email       ON public.fund_reviews (email);
+CREATE INDEX IF NOT EXISTS idx_fund_reviews_status      ON public.fund_reviews (status);
+CREATE INDEX IF NOT EXISTS idx_fund_reviews_fund_approved
+  ON public.fund_reviews (fund_id, created_at DESC)
+  WHERE status = 'approved';
+
+ALTER TABLE public.fund_reviews ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.fund_reviews FORCE  ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "service_role full access"          ON public.fund_reviews;
+DROP POLICY IF EXISTS "Public read approved fund reviews" ON public.fund_reviews;
+DROP POLICY IF EXISTS "Insert fund reviews"               ON public.fund_reviews;
+
+CREATE POLICY "service_role full access"
+  ON public.fund_reviews
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+CREATE POLICY "Public read approved fund reviews"
+  ON public.fund_reviews
+  FOR SELECT
+  TO anon, authenticated
+  USING (status = 'approved');
+
+CREATE POLICY "Insert fund reviews"
+  ON public.fund_reviews
+  FOR INSERT
+  TO anon, authenticated
+  WITH CHECK (
+    email IS NOT NULL AND length(trim(email)) > 0
+    AND display_name IS NOT NULL AND length(trim(display_name)) > 0
+    AND fund_id IS NOT NULL
+    AND rating BETWEEN 1 AND 5
+  );
+
+COMMIT;


### PR DESCRIPTION
## Summary
**Superseded by #751** — local git proxy was returning HTTP 403 on every fast-forward push to this branch, so the Supabase types drift fix had to be pushed onto a fresh branch (`pre-launch/funds-reviews-230706-v2`). Logical scope is identical; PR #751 is the same fund-reviews feature plus the regenerated `lib/database.types.ts` that picks up 5 pre-existing W2 drift entries.

Extends the broker + advisor editorial-review pattern to the third entity type, completing W3.18. Email-verified submission, auto-blocklist moderation on verify, manual override via `/admin/fund-reviews`. Reviews display on `/invest/funds/[slug]` with per-dimension scores (performance / communication / fees / manager) and aggregate stats.

## Why
The pre-launch wave master plan (W3.18) calls for the user-reviews engine to cover brokers, advisors, **and funds**. Brokers (`user_reviews`) and advisors (`professional_reviews`) already have full submit / verify / moderate / display flows. Funds were the missing third surface.

## Tier
**B** — additive RLS migration, new admin route, no Stripe / webhook / lib/supabase/admin touched.

## Files
See PR #751 for the active diff.

## Supersedes
_None._

---
_Generated by [Claude Code](https://claude.ai/code/session_01DhamyVEAz4SkeSZinwHfjU)_