### PR TITLE
chore(db): regen database.types.ts — 5 dashboard tables (iter 353)

### DIFF
--- a/.driftallowlist
+++ b/.driftallowlist
@@ -136,6 +136,7 @@ business_accounts         # account-system expansion (Phase 2/3) — backfill mi
 investor_goals            # goals-tracking feature — backfill migration pending
 listing_owner_accounts    # marketplace listing-owner portal — backfill migration pending
 property_holdings         # portfolio / property-investing feature — backfill migration pending
+fund_reviews              # fund review content — backfill migration pending
 
 # PostGIS extension-managed (out of scope — comes from CREATE EXTENSION postgis)
 spatial_ref_sys

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -3844,6 +3844,57 @@ export type Database = {
           },
         ]
       }
+      business_accounts: {
+        Row: {
+          abn: string | null
+          acn: string | null
+          auth_user_id: string
+          business_name: string
+          created_at: string
+          employees_band: string | null
+          id: number
+          industry: string | null
+          legal_name: string | null
+          primary_state: string | null
+          revenue_band: string | null
+          status: string
+          updated_at: string
+          year_established: number | null
+        }
+        Insert: {
+          abn?: string | null
+          acn?: string | null
+          auth_user_id: string
+          business_name: string
+          created_at?: string
+          employees_band?: string | null
+          id?: never
+          industry?: string | null
+          legal_name?: string | null
+          primary_state?: string | null
+          revenue_band?: string | null
+          status?: string
+          updated_at?: string
+          year_established?: number | null
+        }
+        Update: {
+          abn?: string | null
+          acn?: string | null
+          auth_user_id?: string
+          business_name?: string
+          created_at?: string
+          employees_band?: string | null
+          id?: never
+          industry?: string | null
+          legal_name?: string | null
+          primary_state?: string | null
+          revenue_band?: string | null
+          status?: string
+          updated_at?: string
+          year_established?: number | null
+        }
+        Relationships: []
+      }
       buyer_agents: {
         Row: {
           agency_name: string | null
@@ -7134,6 +7185,89 @@ export type Database = {
         }
         Relationships: []
       }
+      fund_reviews: {
+        Row: {
+          body: string
+          communication_rating: number | null
+          cons: string | null
+          created_at: string
+          display_name: string
+          email: string
+          fees_rating: number | null
+          fund_id: number
+          fund_slug: string
+          hold_period_months: number | null
+          id: number
+          ip_hash: string | null
+          manager_rating: number | null
+          moderation_note: string | null
+          performance_rating: number | null
+          pros: string | null
+          rating: number
+          status: string
+          title: string
+          updated_at: string
+          verification_token: string | null
+          verified_at: string | null
+        }
+        Insert: {
+          body: string
+          communication_rating?: number | null
+          cons?: string | null
+          created_at?: string
+          display_name: string
+          email: string
+          fees_rating?: number | null
+          fund_id: number
+          fund_slug: string
+          hold_period_months?: number | null
+          id?: number
+          ip_hash?: string | null
+          manager_rating?: number | null
+          moderation_note?: string | null
+          performance_rating?: number | null
+          pros?: string | null
+          rating: number
+          status?: string
+          title: string
+          updated_at?: string
+          verification_token?: string | null
+          verified_at?: string | null
+        }
+        Update: {
+          body?: string
+          communication_rating?: number | null
+          cons?: string | null
+          created_at?: string
+          display_name?: string
+          email?: string
+          fees_rating?: number | null
+          fund_id?: number
+          fund_slug?: string
+          hold_period_months?: number | null
+          id?: number
+          ip_hash?: string | null
+          manager_rating?: number | null
+          moderation_note?: string | null
+          performance_rating?: number | null
+          pros?: string | null
+          rating?: number
+          status?: string
+          title?: string
+          updated_at?: string
+          verification_token?: string | null
+          verified_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "fund_reviews_fund_id_fkey"
+            columns: ["fund_id"]
+            isOneToOne: false
+            referencedRelation: "fund_listings"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       glossary_terms: {
         Row: {
           category: string | null
@@ -7493,6 +7627,51 @@ export type Database = {
           email?: string
           id?: number
           sent_at?: string | null
+        }
+        Relationships: []
+      }
+      investor_goals: {
+        Row: {
+          auth_user_id: string
+          created_at: string
+          current_balance_cents: number
+          expected_return_pct: number
+          goal_type: string
+          id: number
+          label: string
+          monthly_contribution_cents: number
+          notes: string | null
+          target_cents: number
+          target_date: string
+          updated_at: string
+        }
+        Insert: {
+          auth_user_id: string
+          created_at?: string
+          current_balance_cents?: number
+          expected_return_pct?: number
+          goal_type: string
+          id?: never
+          label: string
+          monthly_contribution_cents?: number
+          notes?: string | null
+          target_cents: number
+          target_date: string
+          updated_at?: string
+        }
+        Update: {
+          auth_user_id?: string
+          created_at?: string
+          current_balance_cents?: number
+          expected_return_pct?: number
+          goal_type?: string
+          id?: never
+          label?: string
+          monthly_contribution_cents?: number
+          notes?: string | null
+          target_cents?: number
+          target_date?: string
+          updated_at?: string
         }
         Relationships: []
       }
@@ -8012,6 +8191,7 @@ export type Database = {
       listing_claims: {
         Row: {
           admin_notes: string | null
+          auth_user_id: string | null
           claim_type: string
           company_role: string | null
           created_at: string | null
@@ -8025,6 +8205,7 @@ export type Database = {
         }
         Insert: {
           admin_notes?: string | null
+          auth_user_id?: string | null
           claim_type: string
           company_role?: string | null
           created_at?: string | null
@@ -8038,6 +8219,7 @@ export type Database = {
         }
         Update: {
           admin_notes?: string | null
+          auth_user_id?: string | null
           claim_type?: string
           company_role?: string | null
           created_at?: string | null
@@ -8100,6 +8282,36 @@ export type Database = {
             referencedColumns: ["id"]
           },
         ]
+      }
+      listing_owner_accounts: {
+        Row: {
+          auth_user_id: string
+          created_at: string
+          display_name: string | null
+          email_verified_at: string | null
+          id: number
+          status: string
+          updated_at: string
+        }
+        Insert: {
+          auth_user_id: string
+          created_at?: string
+          display_name?: string | null
+          email_verified_at?: string | null
+          id?: never
+          status?: string
+          updated_at?: string
+        }
+        Update: {
+          auth_user_id?: string
+          created_at?: string
+          display_name?: string | null
+          email_verified_at?: string | null
+          id?: never
+          status?: string
+          updated_at?: string
+        }
+        Relationships: []
       }
       listing_plans: {
         Row: {
@@ -9853,6 +10065,66 @@ export type Database = {
           stripe_customer_id?: string | null
           updated_at?: string | null
           website?: string | null
+        }
+        Relationships: []
+      }
+      property_holdings: {
+        Row: {
+          address_line: string
+          auth_user_id: string
+          created_at: string
+          current_value_estimate_cents: number | null
+          id: number
+          is_investment_property: boolean
+          loan_balance_cents: number | null
+          loan_rate_pct: number | null
+          notes: string | null
+          postcode: string | null
+          property_type: string | null
+          purchase_date: string
+          purchase_price_cents: number
+          state: string | null
+          suburb: string | null
+          updated_at: string
+          weekly_rent_cents: number | null
+        }
+        Insert: {
+          address_line: string
+          auth_user_id: string
+          created_at?: string
+          current_value_estimate_cents?: number | null
+          id?: never
+          is_investment_property?: boolean
+          loan_balance_cents?: number | null
+          loan_rate_pct?: number | null
+          notes?: string | null
+          postcode?: string | null
+          property_type?: string | null
+          purchase_date: string
+          purchase_price_cents: number
+          state?: string | null
+          suburb?: string | null
+          updated_at?: string
+          weekly_rent_cents?: number | null
+        }
+        Update: {
+          address_line?: string
+          auth_user_id?: string
+          created_at?: string
+          current_value_estimate_cents?: number | null
+          id?: never
+          is_investment_property?: boolean
+          loan_balance_cents?: number | null
+          loan_rate_pct?: number | null
+          notes?: string | null
+          postcode?: string | null
+          property_type?: string | null
+          purchase_date?: string
+          purchase_price_cents?: number
+          state?: string | null
+          suburb?: string | null
+          updated_at?: string
+          weekly_rent_cents?: number | null
         }
         Relationships: []
       }
@@ -12563,6 +12835,17 @@ export type Database = {
       }
     }
     Views: {
+      account_kind_membership: {
+        Row: {
+          auth_user_id: string | null
+          created_at: string | null
+          display_label: string | null
+          kind: string | null
+          kind_id: string | null
+          status: string | null
+        }
+        Relationships: []
+      }
       admin_advisor_health: {
         Row: {
           admin_tags: string[] | null


### PR DESCRIPTION
Fresh regen from live Supabase schema. Adds 5 tables created via Supabase dashboard that were missing from `lib/database.types.ts`: `business_accounts`, `investor_goals`, `listing_owner_accounts`, `property_holdings`, `fund_reviews`. Adds `fund_reviews` to `.driftallowlist`.

Fixes the `Supabase types drift` CI gate that was red on #741, #747, and #751.

## Supersedes

_None._

---
_Generated by [Claude Code](https://claude.ai/code/session_01B6XkGaPKNWGkphTJR9dGf1)_