### PR TITLE
perf(fonts): PP-03 — drop unused font weights (JetBrains Mono 500, Source Serif 500+600)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -41,14 +41,14 @@ const jetbrainsMono = JetBrains_Mono({
   subsets: ["latin"],
   display: "swap",
   variable: "--font-jetbrains-mono",
-  weight: ["400", "500", "700", "800"],
+  weight: ["400", "700", "800"],
 });
 
 const sourceSerif = Source_Serif_4({
   subsets: ["latin"],
   display: "swap",
   variable: "--font-source-serif",
-  weight: ["400", "500", "600"],
+  weight: ["400"],
 });
 
 export const metadata: Metadata = {


### PR DESCRIPTION
## Summary

PP-03 font loading optimisation: removes unused weight variants from two Google Fonts loaded via `next/font/google`.

### Changes

**`app/layout.tsx`** — 2-line change:

| Font | Before | After | Rationale |
|------|--------|-------|-----------|
| `JetBrains_Mono` | `["400", "500", "700", "800"]` | `["400", "700", "800"]` | Weight 500 (`font-medium`) is never combined with `font-mono` in any component. Weights 400 (base), 700 (`font-bold`), and 800 (`font-black` on ETF tickers) are all in active use. |
| `Source_Serif_4` | `["400", "500", "600"]` | `["400"]` | Used in exactly one place: `HomeFridayBriefing.tsx` with no explicit weight modifier (defaults to 400). Weights 500 and 600 are never applied to serif text anywhere. |

### Impact

Each removed weight = one fewer font file downloaded by the browser on first visit (~30–50 KB each, woff2). Repeat visitors are unaffected (font cache). CWV benefit: reduced render-blocking font bytes on first load.

No visual change to any page — no component uses the removed weights.

### Not changed

- `Inter` (local woff2, `next/font/local`) — all 5 weights (400, 500, 600, 700, 800) are in active use across the site.
- `display: "swap"` — correct for a financial site where content must be readable immediately.

## Audit ref

PP-03 — `docs/audits/REMEDIATION_QUEUE.md` · Stream PP

## Tier

**A** — UI-only, no data model changes, no new dependencies.

## Test plan

- [ ] CI green (Lint · Type-check · Test · Build)
- [ ] Visual: ETF pages still show bold tickers (`font-mono font-black` uses weight 800 ✓)
- [ ] Visual: HomeFridayBriefing still renders in serif (uses weight 400 ✓)
- [ ] No new font layout shift in Lighthouse

https://claude.ai/code/session_016Z2djRsPr6JB7Wg2rDe1Pj

---
_Generated by [Claude Code](https://claude.ai/code/session_016Z2djRsPr6JB7Wg2rDe1Pj)_