### PR TITLE
feat(placement): W5.26 — sponsored-placement A/B testing on /best/&lt;slug&gt;

### DIFF
--- a/__tests__/api/placement-experiment-event.test.ts
+++ b/__tests__/api/placement-experiment-event.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// createRateLimiter is called at module-init time; returning a controlled
+// fn via this mock means the module-level isRateLimited uses our spy.
+const rateLimitFn = vi.hoisted(() => vi.fn<() => boolean>(() => false));
+
+vi.mock("@/lib/rate-limiter", () => ({
+  createRateLimiter: () => rateLimitFn,
+}));
+
+const recordMock = vi.hoisted(() => vi.fn<(...args: unknown[]) => Promise<void>>());
+
+vi.mock("@/lib/placement-experiments-server", () => ({
+  recordPlacementEvent: recordMock,
+}));
+
+import { POST } from "@/app/api/placement-experiment/event/route";
+
+function makeReq(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/placement-experiment/event", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json", "x-forwarded-for": "5.6.7.8" },
+  });
+}
+
+describe("POST /api/placement-experiment/event", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    rateLimitFn.mockReturnValue(false);
+    recordMock.mockResolvedValue(undefined);
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    rateLimitFn.mockReturnValueOnce(true);
+    const res = await POST(
+      makeReq({ experiment_id: 1, variant: "control", event_type: "impressions" }),
+    );
+    expect(res.status).toBe(429);
+    expect(recordMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 on invalid JSON body", async () => {
+    const req = new NextRequest("http://localhost/api/placement-experiment/event", {
+      method: "POST",
+      body: "bad json{{",
+      headers: { "Content-Type": "application/json", "x-forwarded-for": "1.2.3.4" },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when experiment_id is missing", async () => {
+    const res = await POST(makeReq({ variant: "control", event_type: "impressions" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when experiment_id is non-positive", async () => {
+    const res = await POST(
+      makeReq({ experiment_id: 0, variant: "control", event_type: "impressions" }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when variant fails the regex", async () => {
+    const res = await POST(
+      makeReq({ experiment_id: 1, variant: "Control", event_type: "impressions" }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when event_type is unknown", async () => {
+    const res = await POST(
+      makeReq({ experiment_id: 1, variant: "a", event_type: "view" }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 200 + invokes recordPlacementEvent on impressions", async () => {
+    const res = await POST(
+      makeReq({ experiment_id: 9, variant: "challenger", event_type: "impressions" }),
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+    expect(recordMock).toHaveBeenCalledWith(9, "challenger", "impressions");
+  });
+
+  it("returns 200 + invokes recordPlacementEvent on clicks", async () => {
+    const res = await POST(
+      makeReq({ experiment_id: 12, variant: "a", event_type: "clicks" }),
+    );
+    expect(res.status).toBe(200);
+    expect(recordMock).toHaveBeenCalledWith(12, "a", "clicks");
+  });
+
+  it("returns 200 on conversions even if record swallows errors", async () => {
+    // recordPlacementEvent is best-effort — it never throws. Asserting
+    // here that even when it does nothing visible, the route still 200s.
+    recordMock.mockResolvedValueOnce(undefined);
+    const res = await POST(
+      makeReq({ experiment_id: 3, variant: "b", event_type: "conversions" }),
+    );
+    expect(res.status).toBe(200);
+  });
+});

--- a/__tests__/lib/placement-experiments.test.ts
+++ b/__tests__/lib/placement-experiments.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect } from "vitest";
+import {
+  applyPlacementVariant,
+  conversionRate,
+  ctr,
+  fnv1a32,
+  normaliseMetrics,
+  normaliseVariants,
+  pickVariant,
+  VARIANT_LABEL_PATTERN,
+  type PlacementVariant,
+} from "@/lib/placement-experiments";
+import type { Broker } from "@/lib/types";
+
+function mkBroker(slug: string, name = slug, rating = 4): Broker {
+  return {
+    id: slug.length,
+    slug,
+    name,
+    color: "slate",
+    rating,
+    chess_sponsored: false,
+    smsf_support: false,
+    is_crypto: false,
+    platform_type: "share_broker",
+    deal: false,
+    editors_pick: false,
+    status: "active",
+  } as unknown as Broker;
+}
+
+describe("fnv1a32", () => {
+  it("is deterministic", () => {
+    expect(fnv1a32("hello")).toBe(fnv1a32("hello"));
+  });
+
+  it("differs for distinct strings", () => {
+    expect(fnv1a32("a")).not.toBe(fnv1a32("b"));
+  });
+
+  it("stays within 32-bit unsigned range", () => {
+    const h = fnv1a32("placement-experiments-2026");
+    expect(h).toBeGreaterThanOrEqual(0);
+    expect(h).toBeLessThanOrEqual(0xffffffff);
+  });
+});
+
+describe("VARIANT_LABEL_PATTERN", () => {
+  it("accepts valid labels", () => {
+    for (const label of ["control", "a", "v1", "challenger_2", "long-label-30char"]) {
+      expect(VARIANT_LABEL_PATTERN.test(label)).toBe(true);
+    }
+  });
+
+  it("rejects invalid labels", () => {
+    for (const label of ["", "Control", "_x", "-x", "v 1", "a".repeat(32)]) {
+      expect(VARIANT_LABEL_PATTERN.test(label)).toBe(false);
+    }
+  });
+});
+
+describe("pickVariant", () => {
+  const variants: PlacementVariant[] = [
+    { label: "a", broker_slug: null, weight: 50 },
+    { label: "b", broker_slug: "challenger", weight: 50 },
+  ];
+
+  it("returns one of the configured variants", () => {
+    const v = pickVariant({ id: 1, variants }, "fingerprint");
+    expect(["a", "b"]).toContain(v.label);
+  });
+
+  it("is deterministic for the same fingerprint + experiment id", () => {
+    const v1 = pickVariant({ id: 42, variants }, "203.0.113.4|Mozilla/5.0");
+    const v2 = pickVariant({ id: 42, variants }, "203.0.113.4|Mozilla/5.0");
+    expect(v1.label).toBe(v2.label);
+  });
+
+  it("differs across distinct experiment ids for the same fingerprint", () => {
+    // With two equal-weight variants this is a property test — across
+    // 50 different experiment ids we expect both to be represented.
+    const seen = new Set<string>();
+    for (let i = 0; i < 50; i++) {
+      const v = pickVariant({ id: i, variants }, "fingerprint-x");
+      seen.add(v.label);
+    }
+    expect(seen.size).toBe(2);
+  });
+
+  it("approximates the configured weight distribution", () => {
+    const skewed: PlacementVariant[] = [
+      { label: "a", broker_slug: null, weight: 90 },
+      { label: "b", broker_slug: "ch", weight: 10 },
+    ];
+    let aCount = 0;
+    const total = 2000;
+    for (let i = 0; i < total; i++) {
+      const v = pickVariant({ id: 1, variants: skewed }, `fp-${i}`);
+      if (v.label === "a") aCount++;
+    }
+    const aRate = aCount / total;
+    // Allow ±5pp around the 90% target. fnv1a32 + small ids is uniform
+    // enough that this stays well-bounded; if it ever flakes, the bucket
+    // boundaries in pickVariant are the place to look.
+    expect(aRate).toBeGreaterThan(0.85);
+    expect(aRate).toBeLessThan(0.95);
+  });
+
+  it("falls back to weighted random when fingerprint is empty", () => {
+    // Just assert it doesn't throw and returns a valid variant.
+    const v = pickVariant({ id: 1, variants }, "");
+    expect(["a", "b"]).toContain(v.label);
+  });
+
+  it("returns the first variant when all weights are zero (misconfigured)", () => {
+    const zeroed: PlacementVariant[] = [
+      { label: "a", broker_slug: null, weight: 0 },
+      { label: "b", broker_slug: "x", weight: 0 },
+    ];
+    const v = pickVariant({ id: 1, variants: zeroed }, "fp");
+    expect(v.label).toBe("a");
+  });
+
+  it("ignores negative-weight variants", () => {
+    const mixed: PlacementVariant[] = [
+      { label: "a", broker_slug: null, weight: -5 },
+      { label: "b", broker_slug: "x", weight: 100 },
+    ];
+    for (let i = 0; i < 20; i++) {
+      const v = pickVariant({ id: 1, variants: mixed }, `fp-${i}`);
+      expect(v.label).toBe("b");
+    }
+  });
+
+  it("throws when variants array is empty", () => {
+    expect(() => pickVariant({ id: 1, variants: [] }, "fp")).toThrow();
+  });
+});
+
+describe("applyPlacementVariant", () => {
+  const brokers = [
+    mkBroker("alpha"),
+    mkBroker("bravo"),
+    mkBroker("charlie"),
+    mkBroker("delta"),
+  ];
+
+  it("returns a clone when variant.broker_slug is null (control)", () => {
+    const out = applyPlacementVariant(brokers, {
+      label: "control",
+      broker_slug: null,
+      weight: 50,
+    });
+    expect(out).not.toBe(brokers);
+    expect(out.map((b) => b.slug)).toEqual(["alpha", "bravo", "charlie", "delta"]);
+  });
+
+  it("promotes the named broker to position 0", () => {
+    const out = applyPlacementVariant(brokers, {
+      label: "a",
+      broker_slug: "charlie",
+      weight: 50,
+    });
+    expect(out.map((b) => b.slug)).toEqual(["charlie", "alpha", "bravo", "delta"]);
+  });
+
+  it("is a no-op when the named broker is already at position 0", () => {
+    const out = applyPlacementVariant(brokers, {
+      label: "a",
+      broker_slug: "alpha",
+      weight: 50,
+    });
+    expect(out.map((b) => b.slug)).toEqual(["alpha", "bravo", "charlie", "delta"]);
+  });
+
+  it("is a no-op when the named broker is not in the list", () => {
+    const out = applyPlacementVariant(brokers, {
+      label: "a",
+      broker_slug: "missing-slug",
+      weight: 50,
+    });
+    expect(out.map((b) => b.slug)).toEqual(["alpha", "bravo", "charlie", "delta"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const before = brokers.map((b) => b.slug).join(",");
+    applyPlacementVariant(brokers, { label: "a", broker_slug: "delta", weight: 1 });
+    expect(brokers.map((b) => b.slug).join(",")).toBe(before);
+  });
+});
+
+describe("normaliseVariants", () => {
+  it("filters out malformed entries", () => {
+    const raw = [
+      { label: "a", broker_slug: null, weight: 50 },
+      { label: 123, broker_slug: null, weight: 50 }, // bad label
+      { broker_slug: "x", weight: 10 }, // missing label
+      { label: "b", broker_slug: "x", weight: 50 },
+      null,
+      "junk",
+    ];
+    const out = normaliseVariants(raw);
+    expect(out.map((v) => v.label)).toEqual(["a", "b"]);
+  });
+
+  it("defaults weight to 0 when missing or non-numeric", () => {
+    const out = normaliseVariants([
+      { label: "x", broker_slug: null, weight: "abc" },
+      { label: "y", broker_slug: null }, // no weight
+    ]);
+    expect(out).toEqual([
+      { label: "x", broker_slug: null, weight: 0 },
+      { label: "y", broker_slug: null, weight: 0 },
+    ]);
+  });
+
+  it("returns [] when input is not an array", () => {
+    expect(normaliseVariants(null)).toEqual([]);
+    expect(normaliseVariants({})).toEqual([]);
+    expect(normaliseVariants("abc")).toEqual([]);
+  });
+});
+
+describe("normaliseMetrics", () => {
+  it("keeps only known counter fields", () => {
+    const raw = {
+      a: { impressions: 100, clicks: 5, conversions: 1, junk: 999 },
+      b: { impressions: "bad", clicks: 2 },
+    };
+    const out = normaliseMetrics(raw);
+    expect(out.a).toEqual({ impressions: 100, clicks: 5, conversions: 1 });
+    expect(out.b).toEqual({ clicks: 2 });
+  });
+
+  it("returns {} for non-object inputs", () => {
+    expect(normaliseMetrics(null)).toEqual({});
+    expect(normaliseMetrics([])).toEqual({});
+    expect(normaliseMetrics("abc")).toEqual({});
+  });
+});
+
+describe("ctr / conversionRate", () => {
+  it("returns 0 for zero impressions", () => {
+    expect(ctr({})).toBe(0);
+    expect(ctr({ impressions: 0, clicks: 5 })).toBe(0);
+    expect(conversionRate({ impressions: 0, conversions: 2 })).toBe(0);
+  });
+
+  it("computes the expected ratio", () => {
+    expect(ctr({ impressions: 100, clicks: 5 })).toBeCloseTo(0.05);
+    expect(conversionRate({ impressions: 200, conversions: 4 })).toBeCloseTo(0.02);
+  });
+});

--- a/app/admin/placement-experiments/PlacementExperimentsEditor.tsx
+++ b/app/admin/placement-experiments/PlacementExperimentsEditor.tsx
@@ -1,0 +1,616 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { logger } from "@/lib/logger";
+import {
+  ctr,
+  conversionRate,
+  normaliseVariants,
+  normaliseMetrics,
+  VARIANT_LABEL_PATTERN,
+  type PlacementExperiment,
+  type PlacementExperimentStatus,
+  type PlacementVariant,
+} from "@/lib/placement-experiments";
+
+const log = logger("admin-placement-experiments-editor");
+
+const STATUS_COLORS: Record<PlacementExperimentStatus, string> = {
+  draft: "bg-slate-100 text-slate-600",
+  running: "bg-emerald-100 text-emerald-700",
+  paused: "bg-amber-100 text-amber-700",
+  completed: "bg-blue-100 text-blue-700",
+};
+
+interface DraftExperiment {
+  slug: string;
+  name: string;
+  status: PlacementExperimentStatus;
+  variants: PlacementVariant[];
+  notes: string | null;
+}
+
+const EMPTY_DRAFT: DraftExperiment = {
+  slug: "best/low-fees",
+  name: "",
+  status: "draft",
+  variants: [
+    { label: "control", broker_slug: null, weight: 50 },
+    { label: "challenger", broker_slug: "", weight: 50 },
+  ],
+  notes: null,
+};
+
+function parseRow(raw: unknown): PlacementExperiment | null {
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  const id = typeof r.id === "number" ? r.id : null;
+  const slug = typeof r.slug === "string" ? r.slug : null;
+  const name = typeof r.name === "string" ? r.name : null;
+  const status =
+    typeof r.status === "string" &&
+    ["draft", "running", "paused", "completed"].includes(r.status)
+      ? (r.status as PlacementExperimentStatus)
+      : null;
+  if (id === null || !slug || !name || !status) return null;
+  return {
+    id,
+    slug,
+    name,
+    status,
+    variants: normaliseVariants(r.variants),
+    metrics: normaliseMetrics(r.metrics),
+    notes: typeof r.notes === "string" ? r.notes : null,
+    winner_variant: typeof r.winner_variant === "string" ? r.winner_variant : null,
+    created_at: typeof r.created_at === "string" ? r.created_at : "",
+    updated_at: typeof r.updated_at === "string" ? r.updated_at : "",
+    started_at: typeof r.started_at === "string" ? r.started_at : null,
+    ended_at: typeof r.ended_at === "string" ? r.ended_at : null,
+  };
+}
+
+export default function PlacementExperimentsEditor() {
+  const [rows, setRows] = useState<PlacementExperiment[]>([]);
+  const [filter, setFilter] = useState<"" | PlacementExperimentStatus>("");
+  const [editing, setEditing] = useState<PlacementExperiment | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [draft, setDraft] = useState<DraftExperiment>(EMPTY_DRAFT);
+  const [busy, setBusy] = useState(false);
+
+  async function load() {
+    const url = filter
+      ? `/api/admin/placement-experiments?status=${filter}`
+      : "/api/admin/placement-experiments";
+    const res = await fetch(url);
+    if (!res.ok) {
+      log.error("Failed to load experiments", { status: res.status });
+      return;
+    }
+    const data = (await res.json()) as { rows?: unknown[] };
+    const parsed = (data.rows ?? [])
+      .map(parseRow)
+      .filter((r): r is PlacementExperiment => r !== null);
+    setRows(parsed);
+  }
+
+  useEffect(() => {
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filter]);
+
+  function validateDraft(d: DraftExperiment): string | null {
+    if (!d.slug) return "Slug is required";
+    if (!d.name) return "Name is required";
+    if (d.variants.length < 2) return "Need at least 2 variants";
+    const labels = new Set<string>();
+    for (const v of d.variants) {
+      if (!VARIANT_LABEL_PATTERN.test(v.label)) {
+        return `Variant label "${v.label}" must be [a-z0-9][a-z0-9_-]{0,30}`;
+      }
+      if (labels.has(v.label)) return `Duplicate variant label: ${v.label}`;
+      labels.add(v.label);
+      if (v.weight < 0) return `Negative weight on ${v.label}`;
+      if (
+        v.broker_slug !== null &&
+        v.broker_slug !== "" &&
+        !/^[a-z0-9][a-z0-9-]*$/.test(v.broker_slug)
+      ) {
+        return `Invalid broker_slug on ${v.label}: ${v.broker_slug}`;
+      }
+    }
+    return null;
+  }
+
+  async function save() {
+    // Coerce empty broker_slug strings to null before validation, so
+    // editors can leave the control variant's slug blank.
+    const cleaned: DraftExperiment = {
+      ...draft,
+      variants: draft.variants.map((v) => ({
+        ...v,
+        broker_slug: v.broker_slug === "" ? null : v.broker_slug,
+      })),
+    };
+    const err = validateDraft(cleaned);
+    if (err) {
+      alert(err);
+      return;
+    }
+
+    setBusy(true);
+    try {
+      const isEdit = editing !== null;
+      const body = isEdit
+        ? {
+            id: editing.id,
+            name: cleaned.name,
+            status: cleaned.status,
+            variants: cleaned.variants,
+            notes: cleaned.notes,
+          }
+        : cleaned;
+      const res = await fetch("/api/admin/placement-experiments", {
+        method: isEdit ? "PATCH" : "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const errData = (await res.json().catch(() => ({}))) as { error?: string };
+        alert(errData.error || "Save failed");
+        return;
+      }
+      setEditing(null);
+      setCreating(false);
+      setDraft(EMPTY_DRAFT);
+      await load();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function remove(id: number) {
+    if (!confirm("Delete this experiment? Metrics will be lost.")) return;
+    const res = await fetch(`/api/admin/placement-experiments?id=${id}`, {
+      method: "DELETE",
+    });
+    if (!res.ok) {
+      alert("Delete failed");
+      return;
+    }
+    await load();
+  }
+
+  async function setStatus(row: PlacementExperiment, status: PlacementExperimentStatus) {
+    setBusy(true);
+    try {
+      const res = await fetch("/api/admin/placement-experiments", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id: row.id, status }),
+      });
+      if (!res.ok) {
+        const errData = (await res.json().catch(() => ({}))) as { error?: string };
+        alert(errData.error || "Status change failed");
+        return;
+      }
+      await load();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function startEdit(row: PlacementExperiment) {
+    setEditing(row);
+    setCreating(false);
+    setDraft({
+      slug: row.slug,
+      name: row.name,
+      status: row.status,
+      variants: row.variants.length >= 2 ? row.variants : EMPTY_DRAFT.variants,
+      notes: row.notes,
+    });
+  }
+
+  function startCreate() {
+    setEditing(null);
+    setCreating(true);
+    setDraft(EMPTY_DRAFT);
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <label className="text-sm text-slate-600">Status</label>
+          <select
+            value={filter}
+            onChange={(e) =>
+              setFilter(e.target.value as "" | PlacementExperimentStatus)
+            }
+            className="text-sm border rounded px-2 py-1"
+          >
+            <option value="">All</option>
+            <option value="draft">Draft</option>
+            <option value="running">Running</option>
+            <option value="paused">Paused</option>
+            <option value="completed">Completed</option>
+          </select>
+        </div>
+        <button
+          type="button"
+          onClick={startCreate}
+          className="bg-violet-600 hover:bg-violet-700 text-white text-sm font-bold px-4 py-2 rounded"
+        >
+          + New experiment
+        </button>
+      </div>
+
+      {(editing || creating) && (
+        <ExperimentForm
+          draft={draft}
+          setDraft={setDraft}
+          onSave={save}
+          onCancel={() => {
+            setEditing(null);
+            setCreating(false);
+            setDraft(EMPTY_DRAFT);
+          }}
+          busy={busy}
+          isEdit={editing !== null}
+        />
+      )}
+
+      {rows.length === 0 ? (
+        <div className="bg-white border border-slate-200 rounded-lg p-8 text-center text-slate-400">
+          No experiments match the filter.
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {rows.map((row) => (
+            <ExperimentCard
+              key={row.id}
+              row={row}
+              onEdit={() => startEdit(row)}
+              onDelete={() => remove(row.id)}
+              onStatus={(s) => setStatus(row, s)}
+              busy={busy}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ExperimentCard({
+  row,
+  onEdit,
+  onDelete,
+  onStatus,
+  busy,
+}: {
+  row: PlacementExperiment;
+  onEdit: () => void;
+  onDelete: () => void;
+  onStatus: (status: PlacementExperimentStatus) => void;
+  busy: boolean;
+}) {
+  return (
+    <div className="bg-white border border-slate-200 rounded-xl p-5 shadow-sm">
+      <div className="flex items-start justify-between mb-3">
+        <div>
+          <div className="flex items-center gap-2 flex-wrap">
+            <h3 className="text-base font-bold text-slate-900">{row.name}</h3>
+            <span
+              className={`text-xs font-semibold px-2 py-0.5 rounded-full ${STATUS_COLORS[row.status]}`}
+            >
+              {row.status}
+            </span>
+            {row.winner_variant && (
+              <span className="text-xs font-bold px-2 py-0.5 rounded-full bg-emerald-100 text-emerald-700">
+                Winner: {row.winner_variant}
+              </span>
+            )}
+          </div>
+          <p className="text-xs text-slate-500 mt-0.5 font-mono">
+            {row.slug}
+            {row.started_at && (
+              <> &middot; Started: {new Date(row.started_at).toLocaleDateString()}</>
+            )}
+            {row.ended_at && (
+              <> &middot; Ended: {new Date(row.ended_at).toLocaleDateString()}</>
+            )}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          {row.status === "draft" && (
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => onStatus("running")}
+              className="px-3 py-1.5 bg-emerald-600 text-white text-xs font-semibold rounded-lg hover:bg-emerald-700 disabled:opacity-50"
+            >
+              Start
+            </button>
+          )}
+          {row.status === "running" && (
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => onStatus("paused")}
+              className="px-3 py-1.5 bg-amber-500 text-white text-xs font-semibold rounded-lg hover:bg-amber-600 disabled:opacity-50"
+            >
+              Pause
+            </button>
+          )}
+          {row.status === "paused" && (
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => onStatus("running")}
+              className="px-3 py-1.5 bg-emerald-600 text-white text-xs font-semibold rounded-lg hover:bg-emerald-700 disabled:opacity-50"
+            >
+              Resume
+            </button>
+          )}
+          {(row.status === "running" || row.status === "paused") && (
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => onStatus("completed")}
+              className="px-3 py-1.5 bg-slate-600 text-white text-xs font-semibold rounded-lg hover:bg-slate-700 disabled:opacity-50"
+            >
+              Complete
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={onEdit}
+            className="text-blue-600 text-xs font-semibold hover:underline px-2"
+          >
+            Edit
+          </button>
+          <button
+            type="button"
+            onClick={onDelete}
+            className="text-red-600 text-xs font-semibold hover:underline px-2"
+          >
+            Delete
+          </button>
+        </div>
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-slate-200">
+              <th className="text-left py-2 px-3 text-xs font-semibold text-slate-500">Variant</th>
+              <th className="text-left py-2 px-3 text-xs font-semibold text-slate-500">Broker</th>
+              <th className="text-right py-2 px-3 text-xs font-semibold text-slate-500">Weight</th>
+              <th className="text-right py-2 px-3 text-xs font-semibold text-slate-500">Impressions</th>
+              <th className="text-right py-2 px-3 text-xs font-semibold text-slate-500">Clicks</th>
+              <th className="text-right py-2 px-3 text-xs font-semibold text-slate-500">CTR</th>
+              <th className="text-right py-2 px-3 text-xs font-semibold text-slate-500">Conv</th>
+              <th className="text-right py-2 px-3 text-xs font-semibold text-slate-500">CR</th>
+            </tr>
+          </thead>
+          <tbody>
+            {row.variants.map((v) => {
+              const m = row.metrics[v.label] ?? {};
+              return (
+                <tr key={v.label} className="border-b border-slate-100">
+                  <td className="py-2 px-3 font-semibold">
+                    {v.label}
+                    {row.winner_variant === v.label && (
+                      <span className="ml-2 text-emerald-600">✓</span>
+                    )}
+                  </td>
+                  <td className="py-2 px-3 text-xs font-mono text-slate-600">
+                    {v.broker_slug ?? <em className="text-slate-400">— control —</em>}
+                  </td>
+                  <td className="py-2 px-3 text-right tabular-nums">{v.weight}</td>
+                  <td className="py-2 px-3 text-right tabular-nums">
+                    {(m.impressions ?? 0).toLocaleString()}
+                  </td>
+                  <td className="py-2 px-3 text-right tabular-nums">
+                    {(m.clicks ?? 0).toLocaleString()}
+                  </td>
+                  <td className="py-2 px-3 text-right tabular-nums font-medium">
+                    {(ctr(m) * 100).toFixed(2)}%
+                  </td>
+                  <td className="py-2 px-3 text-right tabular-nums">
+                    {(m.conversions ?? 0).toLocaleString()}
+                  </td>
+                  <td className="py-2 px-3 text-right tabular-nums">
+                    {(conversionRate(m) * 100).toFixed(2)}%
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {row.notes && (
+        <p className="text-xs text-slate-500 mt-3 italic">{row.notes}</p>
+      )}
+    </div>
+  );
+}
+
+function ExperimentForm({
+  draft,
+  setDraft,
+  onSave,
+  onCancel,
+  busy,
+  isEdit,
+}: {
+  draft: DraftExperiment;
+  setDraft: (d: DraftExperiment) => void;
+  onSave: () => void;
+  onCancel: () => void;
+  busy: boolean;
+  isEdit: boolean;
+}) {
+  function setVariant(i: number, patch: Partial<PlacementVariant>) {
+    const next = draft.variants.map((v, idx) =>
+      idx === i ? { ...v, ...patch } : v,
+    );
+    setDraft({ ...draft, variants: next });
+  }
+  function addVariant() {
+    if (draft.variants.length >= 8) return;
+    setDraft({
+      ...draft,
+      variants: [
+        ...draft.variants,
+        { label: `variant_${draft.variants.length}`, broker_slug: "", weight: 25 },
+      ],
+    });
+  }
+  function removeVariant(i: number) {
+    if (draft.variants.length <= 2) return;
+    setDraft({
+      ...draft,
+      variants: draft.variants.filter((_, idx) => idx !== i),
+    });
+  }
+
+  return (
+    <div className="bg-violet-50 border border-violet-200 rounded-lg p-5 space-y-3">
+      <h2 className="font-bold text-slate-900">
+        {isEdit ? "Edit experiment" : "New experiment"}
+      </h2>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <Field label="Placement slug (e.g. best/low-fees)">
+          <input
+            type="text"
+            value={draft.slug}
+            onChange={(e) => setDraft({ ...draft, slug: e.target.value })}
+            disabled={isEdit}
+            className="w-full text-sm border rounded px-2 py-1.5 font-mono disabled:bg-slate-100"
+          />
+        </Field>
+        <Field label="Status">
+          <select
+            value={draft.status}
+            onChange={(e) =>
+              setDraft({
+                ...draft,
+                status: e.target.value as PlacementExperimentStatus,
+              })
+            }
+            className="w-full text-sm border rounded px-2 py-1.5"
+          >
+            <option value="draft">Draft</option>
+            <option value="running">Running</option>
+            <option value="paused">Paused</option>
+            <option value="completed">Completed</option>
+          </select>
+        </Field>
+      </div>
+
+      <Field label="Experiment name (internal)">
+        <input
+          type="text"
+          value={draft.name}
+          onChange={(e) => setDraft({ ...draft, name: e.target.value })}
+          placeholder="e.g. low-fees top-pick rotation — May 2026"
+          className="w-full text-sm border rounded px-2 py-1.5"
+        />
+      </Field>
+
+      <div className="space-y-2">
+        <span className="block text-xs font-semibold text-slate-600">
+          Variants (at least 2, max 8)
+        </span>
+        {draft.variants.map((v, i) => (
+          <div
+            key={i}
+            className="grid grid-cols-12 gap-2 items-center bg-white rounded border border-slate-200 p-2"
+          >
+            <input
+              type="text"
+              value={v.label}
+              onChange={(e) => setVariant(i, { label: e.target.value })}
+              placeholder="label"
+              className="col-span-3 text-sm border rounded px-2 py-1 font-mono"
+            />
+            <input
+              type="text"
+              value={v.broker_slug ?? ""}
+              onChange={(e) => setVariant(i, { broker_slug: e.target.value })}
+              placeholder="broker slug (blank = control)"
+              className="col-span-6 text-sm border rounded px-2 py-1 font-mono"
+            />
+            <input
+              type="number"
+              value={v.weight}
+              onChange={(e) => setVariant(i, { weight: parseInt(e.target.value, 10) || 0 })}
+              min={0}
+              max={10000}
+              className="col-span-2 text-sm border rounded px-2 py-1"
+            />
+            <button
+              type="button"
+              onClick={() => removeVariant(i)}
+              disabled={draft.variants.length <= 2}
+              className="col-span-1 text-red-600 text-xs font-bold disabled:opacity-30"
+              aria-label="Remove variant"
+            >
+              ✕
+            </button>
+          </div>
+        ))}
+        <button
+          type="button"
+          onClick={addVariant}
+          disabled={draft.variants.length >= 8}
+          className="text-xs font-semibold text-violet-700 hover:underline disabled:opacity-50"
+        >
+          + Add variant
+        </button>
+      </div>
+
+      <Field label="Notes (optional — context for editorial / future-you)">
+        <textarea
+          value={draft.notes ?? ""}
+          onChange={(e) =>
+            setDraft({ ...draft, notes: e.target.value || null })
+          }
+          rows={2}
+          className="w-full text-sm border rounded px-2 py-1.5"
+        />
+      </Field>
+
+      <div className="flex items-center gap-2 pt-2">
+        <button
+          type="button"
+          disabled={busy}
+          onClick={onSave}
+          className="bg-violet-600 hover:bg-violet-700 disabled:bg-slate-300 text-white text-sm font-bold px-4 py-2 rounded"
+        >
+          {busy ? "Saving…" : isEdit ? "Save changes" : "Create experiment"}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="border border-slate-300 hover:bg-slate-50 text-slate-700 text-sm font-semibold px-4 py-2 rounded"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="block">
+      <span className="block text-xs font-semibold text-slate-600 mb-1">{label}</span>
+      {children}
+    </label>
+  );
+}

--- a/app/admin/placement-experiments/page.tsx
+++ b/app/admin/placement-experiments/page.tsx
@@ -1,0 +1,15 @@
+import AdminShell from "@/components/AdminShell";
+import PlacementExperimentsEditor from "./PlacementExperimentsEditor";
+
+export const metadata = { title: "Placement experiments — Admin" };
+
+export default function PlacementExperimentsAdminPage() {
+  return (
+    <AdminShell
+      title="Placement experiments"
+      subtitle="A/B test which broker sits at position 1 on /best/<slug> pages. CTR + conversion counters update live via /api/placement-experiment/event."
+    >
+      <PlacementExperimentsEditor />
+    </AdminShell>
+  );
+}

--- a/app/api/admin/placement-experiments/route.ts
+++ b/app/api/admin/placement-experiments/route.ts
@@ -1,0 +1,251 @@
+/**
+ * Admin CRUD for `placement_experiments`.
+ *
+ * Auth: ADMIN_EMAILS allow-list (mirrors app/api/admin/country-rule-alerts).
+ * Body validation: Zod via withValidatedBody. Audit-logged via admin_audit_log.
+ *
+ * Endpoints:
+ *   GET    /api/admin/placement-experiments?status=running    → list rows
+ *   POST   /api/admin/placement-experiments                   → create
+ *   PATCH  /api/admin/placement-experiments                   → partial update by id
+ *   DELETE /api/admin/placement-experiments?id=<n>            → delete
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { getAdminEmails } from "@/lib/admin";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { createClient } from "@/lib/supabase/server";
+import { logger } from "@/lib/logger";
+import { withValidatedBody } from "@/lib/validation/withValidatedBody";
+import { VARIANT_LABEL_PATTERN } from "@/lib/placement-experiments";
+
+const log = logger("admin-placement-experiments");
+
+const StatusSchema = z.enum(["draft", "running", "paused", "completed"]);
+
+const VariantSchema = z.object({
+  label: z.string().regex(VARIANT_LABEL_PATTERN, {
+    message: "label must match [a-z0-9][a-z0-9_-]{0,30}",
+  }),
+  broker_slug: z
+    .string()
+    .min(1)
+    .max(120)
+    .regex(/^[a-z0-9][a-z0-9-]*$/, "lowercase letters, digits, hyphens only")
+    .nullable(),
+  weight: z.number().int().min(0).max(10000),
+});
+
+const CreateSchema = z.object({
+  slug: z.string().regex(/^[a-z0-9][a-z0-9/_-]{1,80}$/, {
+    message: "slug must match [a-z0-9][a-z0-9/_-]{1,80}",
+  }),
+  name: z.string().min(1).max(200),
+  status: StatusSchema.default("draft"),
+  variants: z.array(VariantSchema).min(2).max(8),
+  notes: z.string().max(2000).nullable().optional(),
+});
+
+const UpdateSchema = z
+  .object({
+    id: z.number().int().positive(),
+    name: z.string().min(1).max(200).optional(),
+    status: StatusSchema.optional(),
+    variants: z.array(VariantSchema).min(2).max(8).optional(),
+    notes: z.string().max(2000).nullable().optional(),
+    winner_variant: z
+      .string()
+      .regex(VARIANT_LABEL_PATTERN)
+      .nullable()
+      .optional(),
+  })
+  .strict();
+
+async function requireAdmin(): Promise<{ email: string } | null> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user?.email) return null;
+  const allowed = getAdminEmails();
+  const email = user.email.toLowerCase();
+  if (!allowed.includes(email)) return null;
+  return { email };
+}
+
+/** Reject duplicate variant labels — they would collide in the metrics jsonb. */
+function uniqueLabels<T extends { label: string }>(variants: T[]): boolean {
+  const seen = new Set<string>();
+  for (const v of variants) {
+    if (seen.has(v.label)) return false;
+    seen.add(v.label);
+  }
+  return true;
+}
+
+export async function GET(request: NextRequest) {
+  const admin = await requireAdmin();
+  if (!admin) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const status = request.nextUrl.searchParams.get("status");
+  const supabase = createAdminClient();
+  let query = supabase
+    .from("placement_experiments")
+    .select("*")
+    .order("status", { ascending: true })
+    .order("created_at", { ascending: false });
+
+  if (status) {
+    const parsed = StatusSchema.safeParse(status);
+    if (!parsed.success) {
+      return NextResponse.json({ error: "Invalid status" }, { status: 400 });
+    }
+    query = query.eq("status", parsed.data);
+  }
+
+  const { data, error } = await query;
+  if (error) {
+    log.error("List failed", { error: error.message });
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  return NextResponse.json({ rows: data ?? [] });
+}
+
+export const POST = withValidatedBody(CreateSchema, async (_req, body) => {
+  const admin = await requireAdmin();
+  if (!admin) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  if (!uniqueLabels(body.variants)) {
+    return NextResponse.json(
+      { error: "variant labels must be unique" },
+      { status: 400 },
+    );
+  }
+
+  const supabase = createAdminClient();
+  const insertRow = {
+    slug: body.slug,
+    name: body.name,
+    status: body.status,
+    variants: body.variants,
+    notes: body.notes ?? null,
+    started_at: body.status === "running" ? new Date().toISOString() : null,
+  };
+  const { data, error } = await supabase
+    .from("placement_experiments")
+    .insert(insertRow)
+    .select("*")
+    .single();
+
+  if (error) {
+    log.error("Insert failed", { error: error.message });
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  await supabase.from("admin_audit_log").insert({
+    action: "placement_experiment:created",
+    entity_type: "placement_experiments",
+    entity_id: String(data.id),
+    admin_email: admin.email,
+    details: { slug: body.slug, status: body.status },
+  });
+
+  return NextResponse.json(data, { status: 201 });
+});
+
+export const PATCH = withValidatedBody(UpdateSchema, async (_req, body) => {
+  const admin = await requireAdmin();
+  if (!admin) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  if (body.variants && !uniqueLabels(body.variants)) {
+    return NextResponse.json(
+      { error: "variant labels must be unique" },
+      { status: 400 },
+    );
+  }
+
+  const supabase = createAdminClient();
+
+  // Status transitions: stamp started_at on first → running, ended_at on
+  // transition to completed. Keep idempotent so re-applying the same status
+  // doesn't reset timestamps.
+  const updates: Record<string, unknown> = { updated_at: new Date().toISOString() };
+  if (body.name !== undefined) updates.name = body.name;
+  if (body.status !== undefined) updates.status = body.status;
+  if (body.variants !== undefined) updates.variants = body.variants;
+  if (body.notes !== undefined) updates.notes = body.notes;
+  if (body.winner_variant !== undefined) updates.winner_variant = body.winner_variant;
+
+  if (body.status === "running") {
+    // Stamp started_at if missing.
+    const { data: existing } = await supabase
+      .from("placement_experiments")
+      .select("started_at")
+      .eq("id", body.id)
+      .maybeSingle();
+    if (existing && !existing.started_at) {
+      updates.started_at = new Date().toISOString();
+    }
+  } else if (body.status === "completed") {
+    updates.ended_at = new Date().toISOString();
+  }
+
+  const { data, error } = await supabase
+    .from("placement_experiments")
+    .update(updates)
+    .eq("id", body.id)
+    .select("*")
+    .single();
+
+  if (error) {
+    log.error("Update failed", { error: error.message });
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  await supabase.from("admin_audit_log").insert({
+    action: "placement_experiment:updated",
+    entity_type: "placement_experiments",
+    entity_id: String(body.id),
+    admin_email: admin.email,
+    details: updates,
+  });
+
+  return NextResponse.json(data);
+});
+
+export async function DELETE(request: NextRequest) {
+  const admin = await requireAdmin();
+  if (!admin) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const id = request.nextUrl.searchParams.get("id");
+  if (!id || !/^\d+$/.test(id)) {
+    return NextResponse.json({ error: "id required" }, { status: 400 });
+  }
+
+  const supabase = createAdminClient();
+  const { error } = await supabase
+    .from("placement_experiments")
+    .delete()
+    .eq("id", parseInt(id, 10));
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  await supabase.from("admin_audit_log").insert({
+    action: "placement_experiment:deleted",
+    entity_type: "placement_experiments",
+    entity_id: id,
+    admin_email: admin.email,
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/placement-experiment/event/route.ts
+++ b/app/api/placement-experiment/event/route.ts
@@ -1,0 +1,54 @@
+/**
+ * POST /api/placement-experiment/event
+ *
+ * Records a placement-experiment event (impression / click / conversion).
+ * Used by the `<PlacementImpressionTracker>` client component mounted on
+ * /best/<slug> pages.
+ *
+ * Body shape (Zod-validated):
+ *   {
+ *     experiment_id: number,
+ *     variant: string,
+ *     event_type: "impressions" | "clicks" | "conversions",
+ *   }
+ *
+ * Rate-limited per IP (120 events/min) to keep abuse from inflating the
+ * counters. The underlying RPC is also gated on `status IN ('running','paused')`
+ * — events on completed experiments are silent no-ops.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { createRateLimiter } from "@/lib/rate-limiter";
+import { withValidatedBody } from "@/lib/validation/withValidatedBody";
+import { recordPlacementEvent } from "@/lib/placement-experiments-server";
+import {
+  VARIANT_LABEL_PATTERN,
+  type PlacementEventType,
+} from "@/lib/placement-experiments";
+
+const isRateLimited = createRateLimiter(60_000, 120);
+
+const EventBody = z.object({
+  experiment_id: z.number().int().positive(),
+  variant: z.string().regex(VARIANT_LABEL_PATTERN, {
+    message: "variant label must match [a-z0-9][a-z0-9_-]{0,30}",
+  }),
+  event_type: z.enum(["impressions", "clicks", "conversions"]),
+});
+
+export const POST = withValidatedBody(EventBody, async (request: NextRequest, body) => {
+  const forwarded = request.headers.get("x-forwarded-for");
+  const ip = forwarded ? forwarded.split(",")[0].trim() : "unknown";
+  if (isRateLimited(ip)) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+  }
+
+  await recordPlacementEvent(
+    body.experiment_id,
+    body.variant,
+    body.event_type as PlacementEventType,
+  );
+
+  return NextResponse.json({ ok: true });
+});

--- a/app/best/[slug]/page.tsx
+++ b/app/best/[slug]/page.tsx
@@ -40,7 +40,15 @@ import { getArticleFiltersForBestPage, CATEGORY_COLORS } from "@/lib/internal-li
 import { boostFeaturedPartner, isSponsored } from "@/lib/sponsorship";
 import { getIntentCountry } from "@/lib/intent-context-server";
 import { filterByCountryEligibility } from "@/lib/country-mode/eligibility-filter";
+import { headers } from "next/headers";
+import { getActivePlacementExperiment } from "@/lib/placement-experiments-server";
+import {
+  applyPlacementVariant,
+  pickVariant,
+  type PlacementVariant,
+} from "@/lib/placement-experiments";
 import SponsorBadge from "@/components/SponsorBadge";
+import PlacementImpressionTracker from "@/components/PlacementImpressionTracker";
 import JargonTooltip from "@/components/JargonTooltip";
 import OnThisPage from "@/components/OnThisPage";
 import type { Article } from "@/lib/types";
@@ -125,10 +133,26 @@ export default async function BestBrokerPage({
   );
 
   const allBrokers = eligibleBrokers;
-  const filtered = boostFeaturedPartner(
+  const naturalOrder = boostFeaturedPartner(
     allBrokers.filter(cat.filter).sort(cat.sort),
     0
   );
+
+  // Placement A/B testing (W5.26). When an active experiment is configured
+  // for `best/<slug>`, hash the visitor's IP + UA to pick a variant
+  // deterministically and reorder so the variant's broker_slug sits at
+  // position 1. Reading `headers()` makes this render dynamic for that slug
+  // while the experiment is live; slugs without an experiment stay ISR.
+  const placementExperiment = await getActivePlacementExperiment(`best/${slug}`);
+  let placementVariant: PlacementVariant | null = null;
+  let filtered = naturalOrder;
+  if (placementExperiment && placementExperiment.status === "running") {
+    const h = await headers();
+    const fingerprint = `${h.get("x-forwarded-for") ?? ""}|${h.get("user-agent") ?? ""}`;
+    placementVariant = pickVariant(placementExperiment, fingerprint);
+    filtered = applyPlacementVariant(naturalOrder, placementVariant);
+  }
+
   const topPick = filtered[0] || null;
   const hasSponsored = filtered.some(isSponsored);
   const relatedArticles: Pick<Article, "id" | "title" | "slug" | "category" | "read_time">[] = articleResult?.data || [];
@@ -215,6 +239,12 @@ export default async function BestBrokerPage({
 
   return (
     <>
+      {placementExperiment && placementVariant && (
+        <PlacementImpressionTracker
+          experimentId={placementExperiment.id}
+          variant={placementVariant.label}
+        />
+      )}
       {/* JSON-LD */}
       <script
         type="application/ld+json"
@@ -415,6 +445,12 @@ export default async function BestBrokerPage({
                   target="_blank"
                   rel={AFFILIATE_REL}
                   className="shrink-0 px-6 py-3 bg-amber-600 text-white font-semibold rounded-lg hover:bg-amber-700 transition-colors text-center"
+                  {...(placementExperiment && placementVariant
+                    ? {
+                        "data-pe-experiment-id": String(placementExperiment.id),
+                        "data-pe-variant": placementVariant.label,
+                      }
+                    : {})}
                 >
                   {getBenefitCta(topPick, "compare")}
                 </a>
@@ -477,6 +513,14 @@ export default async function BestBrokerPage({
                         target="_blank"
                         rel={AFFILIATE_REL}
                         className="inline-block px-4 py-2 bg-amber-600 text-white text-sm font-semibold rounded-lg hover:bg-amber-700 transition-colors"
+                        {...(i === 0 && placementExperiment && placementVariant
+                          ? {
+                              "data-pe-experiment-id": String(
+                                placementExperiment.id,
+                              ),
+                              "data-pe-variant": placementVariant.label,
+                            }
+                          : {})}
                       >
                         {getBenefitCta(broker, "compare")}
                       </a>
@@ -489,14 +533,27 @@ export default async function BestBrokerPage({
 
           {/* Mobile cards */}
           <div className="md:hidden space-y-2 mb-6">
-            {filtered.map((broker, i) => (
-              <BrokerCard
-                key={broker.id}
-                broker={broker}
-                badge={i === 0 ? "Top Pick" : undefined}
-                context="compare"
-              />
-            ))}
+            {filtered.map((broker, i) => {
+              const card = (
+                <BrokerCard
+                  broker={broker}
+                  badge={i === 0 ? "Top Pick" : undefined}
+                  context="compare"
+                />
+              );
+              if (i === 0 && placementExperiment && placementVariant) {
+                return (
+                  <div
+                    key={broker.id}
+                    data-pe-experiment-id={String(placementExperiment.id)}
+                    data-pe-variant={placementVariant.label}
+                  >
+                    {card}
+                  </div>
+                );
+              }
+              return <div key={broker.id}>{card}</div>;
+            })}
           </div>
           <CompactDisclaimerLine />
 

--- a/components/AdminSidebar.tsx
+++ b/components/AdminSidebar.tsx
@@ -60,6 +60,7 @@ const NAV_GROUPS = [
       { href: "/admin/affiliate-dashboard", icon: "pie-chart", label: "Affiliate Performance" },
       { href: "/admin/sponsored-queue", icon: "calendar", label: "Sponsored Queue" },
       { href: "/admin/ab-tests", icon: "git-branch", label: "A/B Tests" },
+      { href: "/admin/placement-experiments", icon: "arrow-right-left", label: "Placement A/B" },
       { href: "/admin/fee-queue", icon: "dollar-sign", label: "Fee Queue" },
       { href: "/admin/deal-of-month", icon: "trophy", label: "Deal of Month" },
     ],

--- a/components/PlacementImpressionTracker.tsx
+++ b/components/PlacementImpressionTracker.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+/**
+ * Fires a single impression event + binds delegated click handling for an
+ * active placement experiment. Mounted by `/best/[slug]/page.tsx` once
+ * `getActivePlacementExperiment(slug)` returns a live row.
+ *
+ * Impression dedupe: a sessionStorage marker keyed by
+ * `pe:${experimentId}:${variant}:${pathname}` ensures we don't double-bill
+ * impressions when the visitor navigates back to the same page in the
+ * same tab. Resets per tab close.
+ *
+ * Click tracking: delegated click listener on `data-pe-experiment-id`
+ * elements. Server-rendered affiliate buttons inside the experiment-wrapped
+ * region get those data attributes so this listener catches them without
+ * intercepting unrelated clicks elsewhere on the page.
+ *
+ * Best-effort: every fetch uses `keepalive: true` so it survives navigation,
+ * and all errors are swallowed. Tracking is never allowed to break the page.
+ */
+export default function PlacementImpressionTracker({
+  experimentId,
+  variant,
+}: {
+  experimentId: number;
+  variant: string;
+}) {
+  const sentRef = useRef(false);
+
+  useEffect(() => {
+    if (sentRef.current) return;
+    sentRef.current = true;
+
+    const pathname =
+      typeof window !== "undefined" ? window.location.pathname : "";
+    const key = `pe:${experimentId}:${variant}:${pathname}`;
+
+    let alreadySent = false;
+    try {
+      alreadySent = window.sessionStorage.getItem(key) === "1";
+    } catch {
+      // Storage may be unavailable (private mode / quota); proceed and
+      // accept potential double-count rather than fail closed.
+    }
+
+    if (!alreadySent) {
+      try {
+        window.sessionStorage.setItem(key, "1");
+      } catch {
+        /* ignore */
+      }
+
+      void fetch("/api/placement-experiment/event", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          experiment_id: experimentId,
+          variant,
+          event_type: "impressions",
+        }),
+        keepalive: true,
+      }).catch(() => {
+        /* swallow */
+      });
+    }
+
+    function onClick(event: MouseEvent) {
+      const target = event.target as HTMLElement | null;
+      if (!target) return;
+      const anchor = target.closest<HTMLElement>("[data-pe-experiment-id]");
+      if (!anchor) return;
+      const expIdAttr = anchor.getAttribute("data-pe-experiment-id");
+      const variantAttr = anchor.getAttribute("data-pe-variant");
+      if (!expIdAttr || !variantAttr) return;
+      const expIdNum = Number(expIdAttr);
+      if (!Number.isFinite(expIdNum) || expIdNum <= 0) return;
+
+      void fetch("/api/placement-experiment/event", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          experiment_id: expIdNum,
+          variant: variantAttr,
+          event_type: "clicks",
+        }),
+        keepalive: true,
+      }).catch(() => {
+        /* swallow */
+      });
+    }
+
+    document.addEventListener("click", onClick, { capture: true });
+    return () => {
+      document.removeEventListener("click", onClick, { capture: true });
+    };
+  }, [experimentId, variant]);
+
+  return null;
+}

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -8931,6 +8931,51 @@ export type Database = {
         }
         Relationships: []
       }
+      placement_experiments: {
+        Row: {
+          created_at: string
+          ended_at: string | null
+          id: number
+          metrics: Json
+          name: string
+          notes: string | null
+          slug: string
+          started_at: string | null
+          status: string
+          updated_at: string
+          variants: Json
+          winner_variant: string | null
+        }
+        Insert: {
+          created_at?: string
+          ended_at?: string | null
+          id?: never
+          metrics?: Json
+          name: string
+          notes?: string | null
+          slug: string
+          started_at?: string | null
+          status?: string
+          updated_at?: string
+          variants: Json
+          winner_variant?: string | null
+        }
+        Update: {
+          created_at?: string
+          ended_at?: string | null
+          id?: never
+          metrics?: Json
+          name?: string
+          notes?: string | null
+          slug?: string
+          started_at?: string | null
+          status?: string
+          updated_at?: string
+          variants?: Json
+          winner_variant?: string | null
+        }
+        Relationships: []
+      }
       platform_snapshots: {
         Row: {
           created_at: string
@@ -13390,6 +13435,14 @@ export type Database = {
       gettransactionid: { Args: never; Returns: unknown }
       increment_advisor_view: {
         Args: { p_date: string; p_professional_id: number }
+        Returns: undefined
+      }
+      increment_placement_event: {
+        Args: {
+          p_event_type: string
+          p_experiment_id: number
+          p_variant: string
+        }
         Returns: undefined
       }
       increment_listing_enquiries: {

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -13437,20 +13437,20 @@ export type Database = {
         Args: { p_date: string; p_professional_id: number }
         Returns: undefined
       }
-      increment_placement_event: {
-        Args: {
-          p_event_type: string
-          p_experiment_id: number
-          p_variant: string
-        }
-        Returns: undefined
-      }
       increment_listing_enquiries: {
         Args: { listing_id: number }
         Returns: undefined
       }
       increment_listing_views: {
         Args: { listing_id: number }
+        Returns: undefined
+      }
+      increment_placement_event: {
+        Args: {
+          p_event_type: string
+          p_experiment_id: number
+          p_variant: string
+        }
         Returns: undefined
       }
       is_admin: { Args: never; Returns: boolean }

--- a/lib/placement-experiments-server.ts
+++ b/lib/placement-experiments-server.ts
@@ -1,0 +1,120 @@
+/**
+ * Server-only placement-experiments helpers.
+ *
+ * Kept separate from `placement-experiments.ts` because Supabase's server
+ * client transitively imports `next/headers`, which is forbidden in client
+ * bundles. Mirrors the `country-rule-alerts-server.ts` split.
+ *
+ * The table has anon SELECT on running/paused rows, so we use the anon
+ * `createClient()` for read paths — no service role required.
+ */
+
+import { createClient } from "@/lib/supabase/server";
+import { logger } from "@/lib/logger";
+import {
+  normaliseMetrics,
+  normaliseVariants,
+  type PlacementEventType,
+  type PlacementExperiment,
+} from "@/lib/placement-experiments";
+
+const log = logger("placement-experiments-server");
+
+/**
+ * Fetch the single live experiment for a placement slug, if any.
+ *
+ * Returns null when:
+ *   - the slug has no experiment (most common)
+ *   - the latest experiment is draft/completed (not live)
+ *   - the DB read errors (best-effort — must never break the page render)
+ *
+ * The unique partial index on `(slug) WHERE status='running'` guarantees at
+ * most one running row; we pick the running row if present, else fall back
+ * to the most recent paused row (so editorial can pause without losing
+ * impression context, then resume).
+ */
+export async function getActivePlacementExperiment(
+  slug: string,
+): Promise<PlacementExperiment | null> {
+  if (!slug) return null;
+
+  try {
+    const supabase = await createClient();
+    const { data, error } = await supabase
+      .from("placement_experiments")
+      .select(
+        "id, slug, name, status, variants, metrics, notes, winner_variant, created_at, updated_at, started_at, ended_at",
+      )
+      .eq("slug", slug)
+      .in("status", ["running", "paused"])
+      .order("status", { ascending: true }) // 'paused' > 'running' alphabetically — we want running first, so re-sort below
+      .limit(2);
+
+    if (error || !data || data.length === 0) return null;
+
+    // Prefer running over paused when both exist (shouldn't happen given the
+    // unique partial index, but be defensive).
+    const running = data.find((r) => r.status === "running");
+    const row = running ?? data[0];
+    if (!row) return null;
+
+    return {
+      id: row.id,
+      slug: row.slug,
+      name: row.name,
+      status: row.status as PlacementExperiment["status"],
+      variants: normaliseVariants(row.variants),
+      metrics: normaliseMetrics(row.metrics),
+      notes: row.notes,
+      winner_variant: row.winner_variant,
+      created_at: row.created_at,
+      updated_at: row.updated_at,
+      started_at: row.started_at,
+      ended_at: row.ended_at,
+    };
+  } catch (err) {
+    log.warn("getActivePlacementExperiment failed", {
+      slug,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}
+
+/**
+ * Bump a counter on a live experiment. Best-effort — failures are logged
+ * and swallowed so a flaky DB write never breaks the visitor's render.
+ *
+ * Uses the anon client because the `increment_placement_event` RPC is
+ * SECURITY DEFINER + granted to anon — the function elevates privileges
+ * internally, so there's no need for service-role RLS bypass here.
+ */
+export async function recordPlacementEvent(
+  experimentId: number,
+  variant: string,
+  eventType: PlacementEventType,
+): Promise<void> {
+  try {
+    const supabase = await createClient();
+    const { error } = await supabase.rpc("increment_placement_event", {
+      p_experiment_id: experimentId,
+      p_variant: variant,
+      p_event_type: eventType,
+    });
+    if (error) {
+      log.warn("recordPlacementEvent rpc failed", {
+        experimentId,
+        variant,
+        eventType,
+        error: error.message,
+      });
+    }
+  } catch (err) {
+    log.warn("recordPlacementEvent threw", {
+      experimentId,
+      variant,
+      eventType,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}

--- a/lib/placement-experiments.ts
+++ b/lib/placement-experiments.ts
@@ -1,0 +1,195 @@
+/**
+ * Placement A/B testing — shared types + variant assignment.
+ *
+ * W5.26 — rotate which broker appears in position 1 on /best/<slug> pages.
+ * Editorial configures experiments in /admin/placement-experiments; the
+ * `/best/[slug]` server component picks a variant per request and reorders
+ * the broker list before render. Impression + click events are aggregated
+ * into the row's `metrics` jsonb via the `increment_placement_event` RPC.
+ *
+ * Assignment is deterministic for stability — same fingerprint within the
+ * same experiment always sees the same variant. That keeps the order stable
+ * across the visitor's tabs/refreshes within a session (and across sessions
+ * if the upstream IP is sticky, which is the common case for residential
+ * connections). Weighted random fallback applies when no fingerprint exists.
+ */
+import type { Broker } from "./types";
+
+/** Variant labels are short identifiers — keep stable; they key into metrics. */
+export const VARIANT_LABEL_PATTERN = /^[a-z0-9][a-z0-9_-]{0,30}$/;
+
+export type PlacementExperimentStatus =
+  | "draft"
+  | "running"
+  | "paused"
+  | "completed";
+
+export type PlacementEventType = "impressions" | "clicks" | "conversions";
+
+/** Single A/B variant — `broker_slug = null` means "no override" (control). */
+export interface PlacementVariant {
+  /** Stable identifier; metrics counters key off this. */
+  label: string;
+  /** Slug of the broker to promote to position 1, or null for control. */
+  broker_slug: string | null;
+  /** Relative weight for random assignment; must be > 0. */
+  weight: number;
+}
+
+export interface PlacementVariantMetrics {
+  impressions: number;
+  clicks: number;
+  conversions: number;
+}
+
+export interface PlacementExperiment {
+  id: number;
+  slug: string;
+  name: string;
+  status: PlacementExperimentStatus;
+  variants: PlacementVariant[];
+  metrics: Record<string, Partial<PlacementVariantMetrics>>;
+  notes: string | null;
+  winner_variant: string | null;
+  created_at: string;
+  updated_at: string;
+  started_at: string | null;
+  ended_at: string | null;
+}
+
+/**
+ * 32-bit FNV-1a — good-enough deterministic hash for variant bucketing.
+ * Not cryptographic; we just need a uniform-ish distribution over a 32-bit
+ * space so the modulo against `totalWeight` is unbiased for typical weights.
+ */
+export function fnv1a32(input: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    h ^= input.charCodeAt(i);
+    // imul keeps the 32-bit overflow semantics — without it the hash drifts
+    // into doubles and adjacent inputs map to nearby buckets.
+    h = Math.imul(h, 0x01000193);
+  }
+  return h >>> 0;
+}
+
+/**
+ * Pick a variant deterministically from a fingerprint string.
+ * - When `fingerprint` is non-empty: hash with the experiment id, pick by
+ *   weighted bucket. Same fingerprint + same experiment → same variant.
+ * - When `fingerprint` is empty (server can't read headers / no IP): fall
+ *   back to weighted random so test still rotates instead of pinning to one.
+ */
+export function pickVariant(
+  experiment: Pick<PlacementExperiment, "id" | "variants">,
+  fingerprint: string,
+): PlacementVariant {
+  const variants = experiment.variants;
+  if (variants.length === 0) {
+    throw new Error("placement-experiments: variants array is empty");
+  }
+
+  const totalWeight = variants.reduce(
+    (sum, v) => sum + (v.weight > 0 ? v.weight : 0),
+    0,
+  );
+  if (totalWeight <= 0) {
+    // Misconfigured (all weights zero) — fall back to the first variant.
+    return variants[0]!;
+  }
+
+  let bucket: number;
+  if (fingerprint && fingerprint.length > 0) {
+    const h = fnv1a32(`${experiment.id}:${fingerprint}`);
+    bucket = h % totalWeight;
+  } else {
+    bucket = Math.floor(Math.random() * totalWeight);
+  }
+
+  let acc = 0;
+  for (const v of variants) {
+    if (v.weight <= 0) continue;
+    acc += v.weight;
+    if (bucket < acc) return v;
+  }
+  // Numerically unreachable when totalWeight > 0; satisfy the type checker.
+  return variants[variants.length - 1]!;
+}
+
+/**
+ * Reorder `brokers` so the variant's `broker_slug` (if any) sits at
+ * position 0. No-ops when:
+ *   - variant.broker_slug is null (control)
+ *   - the slug isn't in the list (e.g. broker went inactive after launch)
+ *   - the slug is already in position 0
+ *
+ * Returns a new array; never mutates the input.
+ */
+export function applyPlacementVariant(
+  brokers: Broker[],
+  variant: PlacementVariant,
+): Broker[] {
+  if (!variant.broker_slug) return [...brokers];
+  const idx = brokers.findIndex((b) => b.slug === variant.broker_slug);
+  if (idx <= 0) return [...brokers];
+  const next = [...brokers];
+  const [promoted] = next.splice(idx, 1);
+  if (!promoted) return next;
+  next.unshift(promoted);
+  return next;
+}
+
+/** Coerce a DB row's `variants`/`metrics` jsonb into typed values. Defensive. */
+export function normaliseVariants(raw: unknown): PlacementVariant[] {
+  if (!Array.isArray(raw)) return [];
+  const out: PlacementVariant[] = [];
+  for (const item of raw) {
+    if (!item || typeof item !== "object") continue;
+    const obj = item as Record<string, unknown>;
+    const label = typeof obj.label === "string" ? obj.label : null;
+    const brokerSlug =
+      typeof obj.broker_slug === "string"
+        ? obj.broker_slug
+        : obj.broker_slug === null
+          ? null
+          : null;
+    const weight =
+      typeof obj.weight === "number" && Number.isFinite(obj.weight)
+        ? obj.weight
+        : 0;
+    if (!label) continue;
+    out.push({ label, broker_slug: brokerSlug, weight });
+  }
+  return out;
+}
+
+export function normaliseMetrics(
+  raw: unknown,
+): Record<string, Partial<PlacementVariantMetrics>> {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
+  const out: Record<string, Partial<PlacementVariantMetrics>> = {};
+  for (const [label, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (!value || typeof value !== "object") continue;
+    const v = value as Record<string, unknown>;
+    const entry: Partial<PlacementVariantMetrics> = {};
+    if (typeof v.impressions === "number") entry.impressions = v.impressions;
+    if (typeof v.clicks === "number") entry.clicks = v.clicks;
+    if (typeof v.conversions === "number") entry.conversions = v.conversions;
+    out[label] = entry;
+  }
+  return out;
+}
+
+/** Compute CTR = clicks / impressions (0 when denominator is 0). */
+export function ctr(metrics: Partial<PlacementVariantMetrics> | undefined): number {
+  if (!metrics?.impressions || metrics.impressions === 0) return 0;
+  return (metrics.clicks ?? 0) / metrics.impressions;
+}
+
+/** Compute conversion rate = conversions / impressions. */
+export function conversionRate(
+  metrics: Partial<PlacementVariantMetrics> | undefined,
+): number {
+  if (!metrics?.impressions || metrics.impressions === 0) return 0;
+  return (metrics.conversions ?? 0) / metrics.impressions;
+}

--- a/supabase/migrations/20260511011337_placement_experiments.sql
+++ b/supabase/migrations/20260511011337_placement_experiments.sql
@@ -1,0 +1,131 @@
+-- ============================================================================
+-- Migration: 20260511011337_placement_experiments.sql
+-- Purpose: W5.26 — sponsored-placement A/B testing infrastructure.
+--          Lets editorial run rotations of which broker is in position 1
+--          on /best/<slug> pages (e.g. swap Stake ↔ Sharesies for two weeks)
+--          and capture CTR/CR per variant to inform sponsorship pricing
+--          and ranking heuristics.
+--
+-- Audit ref: docs/plans/pre-launch-wave-master-prompt.md W5.26
+-- Risk: low — additive; new tables; no foreign keys to existing entities.
+-- Rollback:
+--   DROP FUNCTION IF EXISTS public.increment_placement_event(bigint, text, text);
+--   DROP TABLE IF EXISTS public.placement_experiments;
+--   (DESTRUCTIVE — discards experiment history. Replay the migration to
+--   re-create the schema; aggregated counters are NOT recoverable.)
+--
+-- Forward operations:
+--   1. CREATE TABLE IF NOT EXISTS public.placement_experiments.
+--   2. UNIQUE partial index — at most one running experiment per slug.
+--   3. Status + slug index for the admin list view.
+--   4. RLS: anon SELECT on running/paused rows (server picks the active
+--      experiment on /best/<slug>); service_role full access for admin CRUD.
+--   5. RPC `increment_placement_event` for atomic counter bumps.
+-- ============================================================================
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.placement_experiments (
+  id            bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  slug          text   NOT NULL,                  -- placement key, e.g. "best/low-fees"
+  name          text   NOT NULL,
+  status        text   NOT NULL DEFAULT 'draft'
+                  CHECK (status IN ('draft','running','paused','completed')),
+  variants      jsonb  NOT NULL,                  -- [{label, broker_slug|null, weight}]
+  metrics       jsonb  NOT NULL DEFAULT '{}'::jsonb,
+                                                  -- {label: {impressions:int, clicks:int, conversions:int}}
+  notes         text,
+  winner_variant text,
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  updated_at    timestamptz NOT NULL DEFAULT now(),
+  started_at    timestamptz,
+  ended_at      timestamptz,
+
+  CONSTRAINT placement_experiments_variants_array
+    CHECK (jsonb_typeof(variants) = 'array'
+           AND jsonb_array_length(variants) >= 2),
+  CONSTRAINT placement_experiments_slug_format
+    CHECK (slug ~ '^[a-z0-9][a-z0-9/_-]{1,80}$')
+);
+
+-- Only one running experiment per placement key — admin UI relies on this
+-- to keep "what's live right now" deterministic.
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_placement_experiments_running_slug
+  ON public.placement_experiments (slug)
+  WHERE status = 'running';
+
+CREATE INDEX IF NOT EXISTS idx_placement_experiments_status_slug
+  ON public.placement_experiments (status, slug);
+
+ALTER TABLE public.placement_experiments ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.placement_experiments FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Public can read live placement experiments" ON public.placement_experiments;
+CREATE POLICY "Public can read live placement experiments"
+  ON public.placement_experiments FOR SELECT
+  USING (status IN ('running', 'paused'));
+
+DROP POLICY IF EXISTS "Service role full access to placement experiments" ON public.placement_experiments;
+CREATE POLICY "Service role full access to placement experiments"
+  ON public.placement_experiments FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- ──────────────────────────────────────────────────────────────────────────
+-- RPC: atomic counter bump.
+-- The metrics jsonb is shaped as {variant_label: {impressions, clicks, conversions}}.
+-- `jsonb_set` writes the path; if the path doesn't exist yet, it creates it.
+-- The function refuses bumps for non-live experiments (status not running/paused).
+-- ──────────────────────────────────────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION public.increment_placement_event(
+  p_experiment_id bigint,
+  p_variant text,
+  p_event_type text
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_current_count int;
+BEGIN
+  IF p_event_type NOT IN ('impressions', 'clicks', 'conversions') THEN
+    RAISE EXCEPTION 'invalid event_type: %', p_event_type;
+  END IF;
+
+  IF p_variant IS NULL OR length(trim(p_variant)) = 0 THEN
+    RAISE EXCEPTION 'variant required';
+  END IF;
+
+  SELECT COALESCE(
+           (metrics -> p_variant ->> p_event_type)::int, 0
+         )
+    INTO v_current_count
+    FROM public.placement_experiments
+    WHERE id = p_experiment_id
+      AND status IN ('running', 'paused')
+    FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN; -- silent no-op for completed/draft experiments; client-side cache may lag
+  END IF;
+
+  UPDATE public.placement_experiments
+  SET metrics = jsonb_set(
+        COALESCE(metrics, '{}'::jsonb),
+        ARRAY[p_variant, p_event_type],
+        to_jsonb(v_current_count + 1),
+        true
+      ),
+      updated_at = now()
+  WHERE id = p_experiment_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.increment_placement_event(bigint, text, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.increment_placement_event(bigint, text, text) TO anon, authenticated, service_role;
+
+COMMIT;


### PR DESCRIPTION
## Summary
Editorial can now run A/B rotations of which broker sits at position 1 on `/best/<slug>` pages and watch per-variant CTR + conversion rate live from a new `/admin/placement-experiments` dashboard.

## Why
W5.26 from `docs/plans/pre-launch-wave-master-prompt.md` — ongoing revenue uplift via data-driven sponsorship pricing. The existing `site_ab_tests` table handles CTA copy/colour tests on `/compare`; this is the first infrastructure for **placement** tests (which broker, not which copy) and the first to attach to `/best/<slug>` pages.

## Tier
**B** — additive RLS-passing migration + public read API + admin CRUD. No webhook, cron, `lib/stripe`, or `proxy.ts` touches. Per `docs/audits/MERGE_AUTHORIZATION.md`: merge after CI green, observe Sentry + Vercel for 15 min.

## Files
- `supabase/migrations/20260511011337_placement_experiments.sql` — `placement_experiments` table + RLS + `increment_placement_event` RPC. Migration has already been applied to the live DB via the Supabase MCP `apply_migration` call from this fire (the types-drift gate compares against the live schema, so applying before merge is necessary).
- `lib/database.types.ts` — `placement_experiments` Row/Insert/Update + RPC type, in canonical `supabase gen types` order (placed alphabetically after `increment_listing_views`).
- `lib/placement-experiments.ts` — variant assignment (`fnv1a32` + `pickVariant`), reorder (`applyPlacementVariant`), defensive `normaliseVariants`/`normaliseMetrics`, `ctr`/`conversionRate` helpers
- `lib/placement-experiments-server.ts` — `getActivePlacementExperiment` (anon SELECT), `recordPlacementEvent` (anon RPC; the RPC is SECURITY DEFINER so no service-role bypass needed)
- `app/api/placement-experiment/event/route.ts` — public POST with `withValidatedBody` + 120/min/IP rate limit
- `app/api/admin/placement-experiments/route.ts` — admin GET/POST/PATCH/DELETE with `ADMIN_EMAILS` gate + audit_log
- `app/admin/placement-experiments/{page,PlacementExperimentsEditor}.tsx` — admin shell + CRUD editor with live CTR/CR table per variant
- `components/PlacementImpressionTracker.tsx` — client island: sessionStorage-deduped impression ping + delegated click listener on `[data-pe-experiment-id]`
- `app/best/[slug]/page.tsx` — applies the variant only when an active experiment is configured (ISR preserved for slugs without one); decorates top-pick + table-row-1 CTAs + mobile card with `data-pe-*` attributes
- `components/AdminSidebar.tsx` — Revenue → "Placement A/B" link
- `__tests__/lib/placement-experiments.test.ts` — 25 cases (hash determinism, weight distribution, no-op when slug missing, malformed-input resilience, CTR math)
- `__tests__/api/placement-experiment-event.test.ts` — 9 cases (rate limit, invalid JSON, Zod field rejection, success paths)

## Supersedes
- #759 (this PR is a clean re-do off main after the smoke-test commit polluted the previous branch's history and the proxy 403'd repeated push attempts on the dirty branch).

## Test plan
- [x] vitest local: 34/34 pass on the two new test files
- [x] type-check: clean (`NODE_OPTIONS=--max-old-space-size=5120 tsc --noEmit` → 0 errors)
- [x] eslint: 0 warnings on all changed files (the `invest/no-unvalidated-req-json` rule is satisfied — both new POST routes use `withValidatedBody`)
- [x] migration applied to live DB; types order matches `supabase gen types` output (verified via local diff)
- [x] no `// TODO`, no `// FIXME`, no `it.skip`, no `console.log` (uses `lib/logger.ts`)
- [ ] CI: pending
- [ ] Visual: with no rows in `placement_experiments`, `/best/low-fees` renders identically to main (ISR preserved). After seeding a `running` row with two variants, the page reorders + the admin dashboard shows live CTR/CR.

## ISR + dynamic-rendering note
The page calls `getActivePlacementExperiment(slug)` first — that's a DB read but does NOT trigger dynamic rendering. Only when an experiment is live do we read `headers()` (which Next.js treats as a dynamic-data accessor, opting that request out of the static cache). So slugs without a configured experiment keep the existing hourly ISR; slugs with a live experiment cost one DB read per request. Acceptable for the v1 ship.

## Why anon, not service-role
`increment_placement_event` is `SECURITY DEFINER` with `EXECUTE GRANT TO anon`, so the function elevates internally — no need for `createAdminClient` from `lib/*` helpers (which would trip the CLAUDE.md "two Supabase clients" rule). Admin CRUD continues to use `createAdminClient` because it sits under `app/api/admin/*` which is the documented service-role-allowed path.

## Rollback
`DROP FUNCTION IF EXISTS public.increment_placement_event(bigint, text, text); DROP TABLE IF EXISTS public.placement_experiments;` — destructive (loses experiment history). Code rollback is a clean revert of this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_013tjFrfkm6iZ3HeaGSQQEC4)_