### PR TITLE
feat(pp): PP-04 third-party script audit — consent unification + PostHog gate [audit remediation]

### DIFF
--- a/__tests__/lib/consent.test.ts
+++ b/__tests__/lib/consent.test.ts
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { hasAnalyticsConsent } from "@/lib/consent";
+
+describe("hasAnalyticsConsent", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("returns false when no consent key is set", () => {
+    expect(hasAnalyticsConsent()).toBe(false);
+  });
+
+  it("returns true when simple cookie-consent key is accepted", () => {
+    localStorage.setItem("cookie-consent", "accepted");
+    expect(hasAnalyticsConsent()).toBe(true);
+  });
+
+  it("returns false when simple cookie-consent key is declined", () => {
+    localStorage.setItem("cookie-consent", "declined");
+    expect(hasAnalyticsConsent()).toBe(false);
+  });
+
+  it("returns true when granular preferences have analytics: true", () => {
+    localStorage.setItem("cookie-preferences", JSON.stringify({ analytics: true, marketing: false }));
+    expect(hasAnalyticsConsent()).toBe(true);
+  });
+
+  it("returns false when granular preferences have analytics: false", () => {
+    localStorage.setItem("cookie-preferences", JSON.stringify({ analytics: false }));
+    expect(hasAnalyticsConsent()).toBe(false);
+  });
+
+  it("granular preferences take precedence over simple consent key", () => {
+    localStorage.setItem("cookie-consent", "accepted");
+    localStorage.setItem("cookie-preferences", JSON.stringify({ analytics: false }));
+    expect(hasAnalyticsConsent()).toBe(false);
+  });
+
+  it("returns false when granular preferences JSON is malformed", () => {
+    localStorage.setItem("cookie-preferences", "not-json{{{");
+    expect(hasAnalyticsConsent()).toBe(false);
+  });
+
+  it("returns false in SSR context (window undefined)", () => {
+    const originalWindow = global.window;
+    // @ts-expect-error deliberately removing window to simulate SSR
+    delete global.window;
+    expect(hasAnalyticsConsent()).toBe(false);
+    global.window = originalWindow;
+  });
+});

--- a/components/GoogleAnalytics.tsx
+++ b/components/GoogleAnalytics.tsx
@@ -3,59 +3,39 @@
 import Script from "next/script";
 import { usePathname, useSearchParams } from "next/navigation";
 import { useEffect, Suspense, useState } from "react";
+import { hasAnalyticsConsent } from "@/lib/consent";
 
 const GA_ID = process.env.NEXT_PUBLIC_GA_ID || "";
-
-/**
- * Check cookie consent from localStorage.
- * Returns "accepted", "declined", or null (not yet responded).
- */
-function getCookieConsent(): string | null {
-  if (typeof window === "undefined") return null;
-  return localStorage.getItem("cookie-consent");
-}
 
 function AnalyticsTracker() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const [consent, setConsent] = useState<string | null>(null);
+  const [consent, setConsent] = useState(false);
 
-  // Listen for consent changes (banner interaction)
+  // Listen for consent changes (banner interaction + cross-tab)
   useEffect(() => {
-    setConsent(getCookieConsent());
-    const handleStorage = () => setConsent(getCookieConsent());
+    setConsent(hasAnalyticsConsent());
+    const handleStorage = () => setConsent(hasAnalyticsConsent());
     window.addEventListener("storage", handleStorage);
-    // Also poll since localStorage events don't fire in the same tab
-    const interval = setInterval(() => {
-      const current = getCookieConsent();
-      setConsent(prev => prev !== current ? current : prev);
-    }, 1000);
+    // Poll for same-tab updates (localStorage events don't fire in the same tab)
+    const interval = setInterval(() => setConsent(hasAnalyticsConsent()), 1000);
     return () => { window.removeEventListener("storage", handleStorage); clearInterval(interval); };
   }, []);
 
-  // Update consent mode when consent changes
+  // Update GA consent mode when consent state changes
   useEffect(() => {
     if (!GA_ID || typeof window === "undefined" || !window.gtag) return;
-    if (consent === "accepted") {
-      window.gtag("consent", "update", {
-        analytics_storage: "granted",
-        ad_storage: "denied",
-        ad_user_data: "denied",
-        ad_personalization: "denied",
-      });
-    } else if (consent === "declined") {
-      window.gtag("consent", "update", {
-        analytics_storage: "denied",
-        ad_storage: "denied",
-        ad_user_data: "denied",
-        ad_personalization: "denied",
-      });
-    }
+    window.gtag("consent", "update", {
+      analytics_storage: consent ? "granted" : "denied",
+      ad_storage: "denied",
+      ad_user_data: "denied",
+      ad_personalization: "denied",
+    });
   }, [consent]);
 
   // Track page views only when consent is granted
   useEffect(() => {
-    if (!GA_ID || typeof window === "undefined" || consent !== "accepted") return;
+    if (!GA_ID || typeof window === "undefined" || !consent) return;
     const url = pathname + (searchParams?.toString() ? `?${searchParams.toString()}` : "");
     window.gtag?.("config", GA_ID, { page_path: url });
   }, [pathname, searchParams, consent]);
@@ -68,8 +48,12 @@ export default function GoogleAnalytics() {
 
   return (
     <>
-      {/* Set default consent to denied BEFORE gtag loads */}
-      <Script id="ga-consent-default" strategy="beforeInteractive">
+      {/* Set default consent to denied before the GA tag fires.
+          afterInteractive is sufficient here because the GA script also
+          uses afterInteractive — Next.js preserves DOM order so the
+          consent default executes first. beforeInteractive was unnecessary
+          and blocked page rendering (PP-04). */}
+      <Script id="ga-consent-default" strategy="afterInteractive">
         {`
           window.dataLayer = window.dataLayer || [];
           function gtag(){dataLayer.push(arguments);}

--- a/components/PostHogProvider.tsx
+++ b/components/PostHogProvider.tsx
@@ -3,6 +3,7 @@
 import { usePathname, useSearchParams } from 'next/navigation'
 import { Suspense, useEffect, useState } from 'react'
 import { initClientPostHog, getClientPostHog } from '@/lib/posthog/client'
+import { hasAnalyticsConsent } from '@/lib/consent'
 
 function PostHogPageviewTracker() {
   const pathname = usePathname()
@@ -10,6 +11,11 @@ function PostHogPageviewTracker() {
   const [ready, setReady] = useState(false)
 
   useEffect(() => {
+    // Only initialise PostHog after the user has accepted analytics cookies.
+    // Without this gate, PostHog would start capturing sessions for all
+    // visitors, including those who have not yet responded to the cookie
+    // banner — a consent gap under the Australian Privacy Act.
+    if (!hasAnalyticsConsent()) return
     void initClientPostHog().then(() => setReady(true))
   }, [])
 

--- a/components/TrackingPixels.tsx
+++ b/components/TrackingPixels.tsx
@@ -2,34 +2,17 @@
 
 import Script from "next/script";
 import { useEffect, useState } from "react";
+import { hasAnalyticsConsent } from "@/lib/consent";
 
 const FB_PIXEL_ID = process.env.NEXT_PUBLIC_FB_PIXEL_ID;
 const GOOGLE_ADS_ID = process.env.NEXT_PUBLIC_GOOGLE_ADS_ID;
-
-function hasConsent(): boolean {
-  if (typeof window === "undefined") return false;
-  try {
-    const raw = localStorage.getItem("cookie-preferences");
-    if (raw) {
-      const prefs = JSON.parse(raw);
-      return prefs.analytics === true;
-    }
-    return localStorage.getItem("cookie-consent") === "accepted";
-  } catch {
-    return false;
-  }
-}
 
 export default function TrackingPixels() {
   const [consent, setConsent] = useState(false);
 
   useEffect(() => {
-    // Read initial consent from localStorage on mount — must run client-side,
-    // can't use lazy initial state because hasConsent() reads window/localStorage.
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setConsent(hasConsent());
-    // Re-check consent on storage changes (fires from other tabs)
-    const handler = () => setConsent(hasConsent());
+    setConsent(hasAnalyticsConsent());
+    const handler = () => setConsent(hasAnalyticsConsent());
     window.addEventListener("storage", handler);
     return () => window.removeEventListener("storage", handler);
   }, []);

--- a/lib/consent.ts
+++ b/lib/consent.ts
@@ -1,0 +1,25 @@
+/**
+ * Consent helpers — single source of truth for checking analytics consent.
+ *
+ * Two consent pathways coexist:
+ *   1. Cookie banner (simple) → localStorage["cookie-consent"] = "accepted"
+ *   2. Granular preferences → localStorage["cookie-preferences"] = JSON with
+ *      { analytics: boolean, ... }
+ *
+ * Both are checked so users who set granular preferences don't inadvertently
+ * lose their choice if analytics scripts only read the simple key.
+ */
+
+export function hasAnalyticsConsent(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    const granular = localStorage.getItem("cookie-preferences");
+    if (granular) {
+      const prefs = JSON.parse(granular) as Record<string, unknown>;
+      return prefs["analytics"] === true;
+    }
+    return localStorage.getItem("cookie-consent") === "accepted";
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

PP-04 audit of all third-party scripts loaded site-wide. Three issues found and fixed:

### 1. `beforeInteractive` GA consent script → `afterInteractive`

`GoogleAnalytics.tsx` line 72 used `strategy="beforeInteractive"` for the GA consent-default script. `beforeInteractive` blocks main-thread execution before hydration — it was used to ensure the consent-denied default fired before the GA tag. This is unnecessary: both the consent script and the GA tag use `afterInteractive`, and Next.js preserves DOM order for same-strategy scripts. Switched to `afterInteractive` — render-blocking removed.

### 2. PostHog missing consent gate

`PostHogProvider.tsx` called `initClientPostHog()` unconditionally, capturing sessions and pageviews for all visitors regardless of cookie-banner state. Added `hasAnalyticsConsent()` guard before initialisation. Users who opt in still get full PostHog analytics.

### 3. Unified consent check (`lib/consent.ts`)

`GoogleAnalytics.tsx` read only `cookie-consent`; `TrackingPixels.tsx` read both `cookie-consent` AND `cookie-preferences.analytics`. A user with granular preferences (`analytics: true`) would get Facebook Pixel but not GA. Extracted `hasAnalyticsConsent()` to `lib/consent.ts` — single source of truth, both consent pathways supported.

## Third-party script inventory

| Script | Strategy | Consent-gated | Status |
|--------|----------|---------------|--------|
| GA4 | `afterInteractive` (was `beforeInteractive` for consent default) | ✅ | Fixed |
| Facebook Pixel | `afterInteractive` (dynamic, ssr:false) | ✅ | No change needed |
| Google Ads | `afterInteractive` (dynamic, ssr:false) | ✅ | No change needed |
| PostHog | dynamic `import()` in `useEffect` | ✅ | Added gate |
| Sentry | Next.js integration | N/A | Error monitoring, no consent needed |
| JSON-LD / theme-init | Inline `<script>` | N/A | No external network call |

## Test plan

- [ ] CI green (type-check, lint, unit tests)
- [ ] `__tests__/lib/consent.test.ts` — 8 tests covering both consent pathways, precedence, malformed JSON, SSR guard
- [ ] Manual: accept cookies → confirm GA + PostHog initialise; decline → confirm neither fires

## Supersedes

_None._

Refs: #222
Audit: `docs/audits/codebase-health-2026-04-24.md` §PP
Queue: `docs/audits/REMEDIATION_QUEUE.md` PP-04

---
_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01QfiacLLdKpsJgPJcuQD9Yw)_