### PR TITLE
fix(pp): PP-05 — lazy loading audit; add priority to firm logo [audit remediation]

### DIFF
--- a/app/firm/[slug]/page.tsx
+++ b/app/firm/[slug]/page.tsx
@@ -137,6 +137,7 @@ export default async function FirmProfilePage({ params }: { params: Promise<{ sl
                       width={96}
                       height={96}
                       className="w-full h-full object-contain"
+                      priority
                     />
                   ) : (
                     <span className="text-2xl sm:text-3xl font-bold text-violet-600">


### PR DESCRIPTION
## Summary\n\nLazy loading audit (PP-05) — full scan of Next.js `<Image>` usage across 71 files.\n\n**One fix:** `app/firm/[slug]/page.tsx` — firm logo (96×96, first rendered image, above the fold) was missing `priority`. Added to match the existing pattern in `app/brokers/full-service/[slug]/page.tsx`.\n\n**Everything else was already correct:**\n- `ListingImageGallery.tsx`: hero uses `priority`, thumbnail strip correctly uses `loading=\"lazy\"` ✓\n- All invest sector pages: only 48px advisor photos in below-fold card lists ✓\n- `brokers/full-service/[slug]`: already had `priority` ✓\n- `find-advisor`, `deals`, `courses`, `consultations`: 24–72px avatars in below-fold content ✓\n\n## Supersedes\n\n_None._\n\nhttps://claude.ai/code/session_01AC2CfEkfwvbM6aboB1uJYF

---
_Generated by [Claude Code](https://claude.ai/code/session_01AC2CfEkfwvbM6aboB1uJYF)_