### PR TITLE
feat(account): PR-X5h goal tracker (W2.12)

### DIFF
--- a/.driftallowlist
+++ b/.driftallowlist
@@ -133,7 +133,6 @@ trading_signals            # trading product never shipped
 
 # Recent additions (dashboard-created via Supabase UI, pending Stream A backfill migration)
 business_accounts         # account-system expansion (Phase 2/3) — backfill migration pending
-investor_goals            # goals-tracking feature — backfill migration pending
 listing_owner_accounts    # marketplace listing-owner portal — backfill migration pending
 property_holdings         # portfolio / property-investing feature — backfill migration pending
 fund_reviews              # fund review content — backfill migration pending
@@ -143,4 +142,3 @@ spatial_ref_sys
 
 # W2 Phase — tables created in Supabase dashboard without migration files; pending Stream A backfill
 business_accounts  # W2 Phase 2.5 — business account type; migration pending
-investor_goals     # W2 Phase 2 — investor goals tracking; migration pending

--- a/__tests__/api/account-goals.test.ts
+++ b/__tests__/api/account-goals.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Mock state ────────────────────────────────────────────────────────────────
+
+const mockGetUser = vi.fn();
+const mockFrom = vi.fn();
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({
+    auth: { getUser: mockGetUser },
+    from: mockFrom,
+  })),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+// ── Import after mocks ────────────────────────────────────────────────────────
+
+import { GET, POST, PATCH, DELETE } from "@/app/api/account/goals/route";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const USER = { id: "user-uuid-1", email: "alice@example.com" };
+
+function jsonRequest(
+  method: "GET" | "POST" | "PATCH" | "DELETE",
+  body?: Record<string, unknown>,
+): NextRequest {
+  return new NextRequest("http://localhost/api/account/goals", {
+    method,
+    body: body ? JSON.stringify(body) : undefined,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/**
+ * Build a Supabase QueryBuilder-shaped chain. All terminal methods that the
+ * route uses (`order`, `single`) resolve to `result`; intermediate methods
+ * (`select`, `insert`, `update`, `delete`, `eq`) are fluent.
+ */
+function makeChain(result: { data: unknown; error: unknown }) {
+  const c: Record<string, ReturnType<typeof vi.fn>> = {};
+  for (const m of ["select", "insert", "update", "delete", "eq"]) {
+    c[m] = vi.fn(() => c);
+  }
+  c.order = vi.fn(() => Promise.resolve(result));
+  c.single = vi.fn(() => Promise.resolve(result));
+  return c;
+}
+
+const VALID_BODY = {
+  label: "House deposit",
+  goal_type: "home",
+  target_cents: 50_000_00,
+  target_date: "2030-12-31",
+  current_balance_cents: 10_000_00,
+  monthly_contribution_cents: 500_00,
+  expected_return_pct: 6,
+  notes: null,
+};
+
+describe("GET /api/account/goals", () => {
+  beforeEach(() => {
+    // Use mockReset (not clearAllMocks) so leftover mockResolvedValueOnce
+    // queues from validation-failure tests don't leak into later auth checks.
+    mockGetUser.mockReset();
+    mockFrom.mockReset();
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: null } });
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
+  it("returns the user's goals on success", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    const items = [{ id: 1, label: "House", target_cents: 100_000_00 }];
+    mockFrom.mockReturnValue(makeChain({ data: items, error: null }));
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect((await res.json()).items).toEqual(items);
+  });
+
+  it("returns 500 when the query errors", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    mockFrom.mockReturnValue(makeChain({ data: null, error: { message: "boom" } }));
+    const res = await GET();
+    expect(res.status).toBe(500);
+  });
+});
+
+describe("POST /api/account/goals", () => {
+  beforeEach(() => {
+    // Use mockReset (not clearAllMocks) so leftover mockResolvedValueOnce
+    // queues from validation-failure tests don't leak into later auth checks.
+    mockGetUser.mockReset();
+    mockFrom.mockReset();
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: null } });
+    const res = await POST(jsonRequest("POST", VALID_BODY));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 on missing label", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    const res = await POST(jsonRequest("POST", { ...VALID_BODY, label: "" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 on invalid date format", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    const res = await POST(
+      jsonRequest("POST", { ...VALID_BODY, target_date: "31/12/2030" }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 on non-positive target", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    const res = await POST(jsonRequest("POST", { ...VALID_BODY, target_cents: 0 }));
+    expect(res.status).toBe(400);
+  });
+
+  it("inserts a goal scoped to the authenticated user", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    const chain = makeChain({
+      data: { id: 7, ...VALID_BODY, created_at: "x", updated_at: "x" },
+      error: null,
+    });
+    mockFrom.mockReturnValue(chain);
+    const res = await POST(jsonRequest("POST", VALID_BODY));
+    expect(res.status).toBe(201);
+    expect(chain.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        auth_user_id: USER.id,
+        label: VALID_BODY.label,
+        goal_type: VALID_BODY.goal_type,
+        target_cents: VALID_BODY.target_cents,
+        target_date: VALID_BODY.target_date,
+        current_balance_cents: VALID_BODY.current_balance_cents,
+        monthly_contribution_cents: VALID_BODY.monthly_contribution_cents,
+        expected_return_pct: VALID_BODY.expected_return_pct,
+      }),
+    );
+  });
+
+  it("returns 500 when the insert errors", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    mockFrom.mockReturnValue(makeChain({ data: null, error: { message: "constraint" } }));
+    const res = await POST(jsonRequest("POST", VALID_BODY));
+    expect(res.status).toBe(500);
+  });
+});
+
+describe("PATCH /api/account/goals", () => {
+  beforeEach(() => {
+    // Use mockReset (not clearAllMocks) so leftover mockResolvedValueOnce
+    // queues from validation-failure tests don't leak into later auth checks.
+    mockGetUser.mockReset();
+    mockFrom.mockReset();
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: null } });
+    const res = await PATCH(jsonRequest("PATCH", { id: 1, label: "new" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when id missing", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    const res = await PATCH(jsonRequest("PATCH", { label: "renamed" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("updates the goal and scopes by id", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    const chain = makeChain({ data: { id: 7 }, error: null });
+    mockFrom.mockReturnValue(chain);
+    const res = await PATCH(
+      jsonRequest("PATCH", { id: 7, label: "Renamed", monthly_contribution_cents: 1000_00 }),
+    );
+    expect(res.status).toBe(200);
+    expect(chain.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        label: "Renamed",
+        monthly_contribution_cents: 1000_00,
+      }),
+    );
+    expect(chain.eq).toHaveBeenCalledWith("id", 7);
+  });
+});
+
+describe("DELETE /api/account/goals", () => {
+  beforeEach(() => {
+    // Use mockReset (not clearAllMocks) so leftover mockResolvedValueOnce
+    // queues from validation-failure tests don't leak into later auth checks.
+    mockGetUser.mockReset();
+    mockFrom.mockReset();
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: null } });
+    const res = await DELETE(jsonRequest("DELETE", { id: 1 }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when id is missing", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    const res = await DELETE(jsonRequest("DELETE", {}));
+    expect(res.status).toBe(400);
+  });
+
+  it("deletes the goal scoped by id", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    // DELETE's terminal `await` is on the eq(...) chain return, not single().
+    // Make eq itself resolve to the result.
+    const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+    chain.delete = vi.fn(() => chain);
+    chain.eq = vi.fn(() => Promise.resolve({ data: null, error: null }));
+    mockFrom.mockReturnValue(chain);
+    const res = await DELETE(jsonRequest("DELETE", { id: 7 }));
+    expect(res.status).toBe(200);
+    expect(chain.eq).toHaveBeenCalledWith("id", 7);
+  });
+});

--- a/__tests__/lib/holdings/goal-projection.test.ts
+++ b/__tests__/lib/holdings/goal-projection.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from "vitest";
+import {
+  projectGoal,
+  monthsBetween,
+} from "@/lib/holdings/goal-projection";
+
+describe("projectGoal", () => {
+  it("returns past-due when months=0 and target not yet reached", () => {
+    const r = projectGoal({
+      currentValueCents: 10_000_00,
+      targetCents: 50_000_00,
+      monthsToTarget: 0,
+      monthlyContributionCents: 0,
+      annualReturnPct: 6,
+    });
+    expect(r.status).toBe("past-due");
+    expect(r.monthsUsed).toBe(0);
+    expect(r.projectedValueAtTargetCents).toBe(10_000_00);
+    expect(r.summary).toMatch(/past/i);
+  });
+
+  it("returns ahead when months=0 and already at or above target", () => {
+    const r = projectGoal({
+      currentValueCents: 60_000_00,
+      targetCents: 50_000_00,
+      monthsToTarget: 0,
+      monthlyContributionCents: 0,
+      annualReturnPct: 6,
+    });
+    expect(r.status).toBe("ahead");
+    expect(r.summary).toMatch(/already/i);
+  });
+
+  it("flat-rate (0% return) projection sums principal + contributions", () => {
+    const r = projectGoal({
+      currentValueCents: 10_000_00,
+      targetCents: 25_000_00,
+      monthsToTarget: 60, // 5y
+      monthlyContributionCents: 250_00, // $250/mo
+      annualReturnPct: 0,
+    });
+    // FV = 10000 + 250 * 60 = 25000 exact ⇒ on-track (within 5% of target)
+    expect(r.projectedValueAtTargetCents).toBe(25_000_00);
+    expect(r.gapCents).toBe(0);
+    expect(r.status).toBe("on-track");
+  });
+
+  it("compound projection matches the standard FV formula", () => {
+    // FV = 1000 * (1.005)^12 + 100 * ((1.005)^12 − 1)/0.005
+    //    ≈ 1061.68 + 1233.56 ≈ 2295.24
+    const r = projectGoal({
+      currentValueCents: 1000_00,
+      targetCents: 3000_00,
+      monthsToTarget: 12,
+      monthlyContributionCents: 100_00,
+      annualReturnPct: 6, // 6% APR ⇒ 0.5% monthly
+    });
+    expect(r.projectedValueAtTargetCents).toBeGreaterThan(2294_00);
+    expect(r.projectedValueAtTargetCents).toBeLessThan(2296_00);
+    expect(r.gapCents).toBeGreaterThan(700_00); // ~$705 short
+    expect(r.status).toBe("short");
+  });
+
+  it("flags 'on-track' when projection is within 5% of target", () => {
+    const r = projectGoal({
+      currentValueCents: 95_000_00,
+      targetCents: 100_000_00,
+      monthsToTarget: 12, // future deadline so months>0 path applies
+      monthlyContributionCents: 0,
+      annualReturnPct: 0,
+    });
+    // 95k still 5% short with no growth → projected = 95k, gap = 5k = 5% of target ⇒ on-track
+    expect(r.projectedValueAtTargetCents).toBe(95_000_00);
+    expect(r.status).toBe("on-track");
+    expect(r.gapCents).toBe(5_000_00);
+  });
+
+  it("flags 'ahead' when projection exceeds target", () => {
+    const r = projectGoal({
+      currentValueCents: 110_000_00,
+      targetCents: 100_000_00,
+      monthsToTarget: 12,
+      monthlyContributionCents: 0,
+      annualReturnPct: 6,
+    });
+    expect(r.status).toBe("ahead");
+    expect(r.gapCents).toBeLessThan(0);
+  });
+
+  it("solves required contribution for a shortfall", () => {
+    // To reach $20k from $10k in 60 months at 0% return:
+    //   gap = 10000, required = 10000 / 60 = $166.67/mo ⇒ 16667 cents
+    const r = projectGoal({
+      currentValueCents: 10_000_00,
+      targetCents: 20_000_00,
+      monthsToTarget: 60,
+      monthlyContributionCents: 0,
+      annualReturnPct: 0,
+    });
+    expect(r.requiredMonthlyContributionCents).toBe(166_67);
+    expect(r.summary).toMatch(/need ~/);
+  });
+
+  it("returns null required contribution when already ahead", () => {
+    const r = projectGoal({
+      currentValueCents: 100_000_00,
+      targetCents: 50_000_00,
+      monthsToTarget: 60,
+      monthlyContributionCents: 0,
+      annualReturnPct: 0,
+    });
+    expect(r.requiredMonthlyContributionCents).toBeNull();
+    expect(r.status).toBe("ahead");
+  });
+
+  it("clamps negative months to 0", () => {
+    const r = projectGoal({
+      currentValueCents: 10_000_00,
+      targetCents: 50_000_00,
+      monthsToTarget: -5,
+      monthlyContributionCents: 0,
+      annualReturnPct: 6,
+    });
+    expect(r.monthsUsed).toBe(0);
+    expect(r.status).toBe("past-due");
+  });
+
+  it("handles negative annual return (drawdown scenario)", () => {
+    // -2% APR over 12 months on $10k = ~$9802
+    const r = projectGoal({
+      currentValueCents: 10_000_00,
+      targetCents: 12_000_00,
+      monthsToTarget: 12,
+      monthlyContributionCents: 0,
+      annualReturnPct: -2,
+    });
+    expect(r.projectedValueAtTargetCents).toBeLessThan(10_000_00);
+    expect(r.status).toBe("short");
+  });
+});
+
+describe("monthsBetween", () => {
+  it("computes positive months across a year boundary", () => {
+    expect(monthsBetween(new Date("2026-01-15"), new Date("2027-01-15"))).toBe(12);
+  });
+
+  it("returns 0 when end is before start of the same month", () => {
+    expect(monthsBetween(new Date("2026-05-20"), new Date("2026-05-25"))).toBe(0);
+  });
+
+  it("returns negative months when end is before start", () => {
+    expect(monthsBetween(new Date("2026-05-15"), new Date("2026-02-15"))).toBe(-3);
+  });
+
+  it("handles partial-month tail correctly", () => {
+    // Same month difference, but end day is earlier → one less month
+    expect(monthsBetween(new Date("2026-01-20"), new Date("2026-06-10"))).toBe(4);
+    expect(monthsBetween(new Date("2026-01-20"), new Date("2026-06-21"))).toBe(5);
+  });
+});

--- a/app/account/holdings/GoalsBlock.tsx
+++ b/app/account/holdings/GoalsBlock.tsx
@@ -1,0 +1,349 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { projectGoal, monthsBetween } from "@/lib/holdings/goal-projection";
+
+export interface GoalRow {
+  id: number;
+  label: string;
+  goalType: string;
+  targetCents: number;
+  targetDate: string;
+  currentBalanceCents: number;
+  monthlyContributionCents: number;
+  expectedReturnPct: number;
+  notes: string | null;
+}
+
+const GOAL_TYPES = ["retirement", "home", "education", "travel", "general"] as const;
+
+interface Props {
+  initialGoals: GoalRow[];
+  currentValueCents: number;
+}
+
+const fmtAud = (cents: number) =>
+  (cents / 100).toLocaleString("en-AU", {
+    style: "currency",
+    currency: "AUD",
+    maximumFractionDigits: 0,
+  });
+
+export default function GoalsBlock({ initialGoals, currentValueCents }: Props) {
+  const [goals, setGoals] = useState<GoalRow[]>(initialGoals);
+  const [showAdd, setShowAdd] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<number | null>(null);
+
+  const projections = useMemo(() => {
+    const now = new Date();
+    return goals.map((g) => {
+      const months = monthsBetween(now, new Date(`${g.targetDate}T00:00:00Z`));
+      // Starting value: prefer the goal's saved current_balance_cents when
+      // set (lets users track non-portfolio goals like "house deposit in
+      // savings"); fall back to live portfolio value so investment-style
+      // goals reflect actual holdings.
+      const startCents = g.currentBalanceCents > 0
+        ? g.currentBalanceCents
+        : currentValueCents;
+      return {
+        goal: g,
+        result: projectGoal({
+          currentValueCents: startCents,
+          targetCents: g.targetCents,
+          monthsToTarget: months,
+          monthlyContributionCents: g.monthlyContributionCents,
+          annualReturnPct: g.expectedReturnPct,
+        }),
+      };
+    });
+  }, [goals, currentValueCents]);
+
+  const handleAdd = async (form: FormData) => {
+    setError(null);
+    setSaving(true);
+    const body = {
+      label: String(form.get("label") ?? "").trim(),
+      goal_type: String(form.get("goalType") ?? "general"),
+      target_cents: Math.round(Number(form.get("target") ?? 0) * 100),
+      target_date: String(form.get("targetDate") ?? ""),
+      current_balance_cents: Math.round(Number(form.get("currentBalance") ?? 0) * 100),
+      monthly_contribution_cents: Math.round(Number(form.get("monthly") ?? 0) * 100),
+      expected_return_pct: Number(form.get("returnPct") ?? 6),
+      notes: (String(form.get("notes") ?? "").trim() || null),
+    };
+    try {
+      const res = await fetch("/api/account/goals", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const j = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(j.error ?? "add_failed");
+      }
+      const j = (await res.json()) as {
+        item: {
+          id: number;
+          label: string;
+          goal_type: string;
+          target_cents: string | number;
+          target_date: string;
+          current_balance_cents: string | number;
+          monthly_contribution_cents: string | number;
+          expected_return_pct: string | number;
+          notes: string | null;
+        };
+      };
+      const newRow: GoalRow = {
+        id: j.item.id,
+        label: j.item.label,
+        goalType: j.item.goal_type,
+        targetCents: Number(j.item.target_cents),
+        targetDate: j.item.target_date,
+        currentBalanceCents: Number(j.item.current_balance_cents),
+        monthlyContributionCents: Number(j.item.monthly_contribution_cents),
+        expectedReturnPct: Number(j.item.expected_return_pct),
+        notes: j.item.notes,
+      };
+      setGoals((prev) =>
+        [...prev, newRow].sort((a, b) => a.targetDate.localeCompare(b.targetDate)),
+      );
+      setShowAdd(false);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not add goal.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async (id: number) => {
+    setError(null);
+    const snapshot = goals;
+    setDeletingId(id);
+    setGoals((prev) => prev.filter((g) => g.id !== id));
+    try {
+      const res = await fetch("/api/account/goals", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id }),
+      });
+      if (!res.ok) throw new Error("delete_failed");
+    } catch {
+      setGoals(snapshot);
+      setError("Could not delete goal. Try again.");
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  return (
+    <section className="bg-indigo-50 border border-indigo-200 rounded-xl p-4">
+      <div className="flex items-baseline justify-between gap-3 flex-wrap mb-3">
+        <h2 className="text-base font-semibold text-indigo-900">Goals</h2>
+        <p className="text-xs text-indigo-800/80">
+          Projection only — general information, not financial advice.
+        </p>
+      </div>
+
+      {goals.length === 0 && !showAdd && (
+        <p className="text-sm text-indigo-900/90 mb-3">
+          Track a savings or investment goal. Examples: house deposit by 2030,
+          $500k retirement nest egg by 2040.
+        </p>
+      )}
+
+      {projections.length > 0 && (
+        <ul className="space-y-3 mb-3">
+          {projections.map(({ goal, result }) => (
+            <li
+              key={goal.id}
+              className="bg-white border border-indigo-100 rounded-lg p-3"
+            >
+              <div className="flex items-baseline justify-between gap-3 flex-wrap">
+                <div className="min-w-0">
+                  <div className="font-semibold text-slate-900">
+                    {goal.label}
+                  </div>
+                  <div className="text-xs text-slate-500 mt-0.5">
+                    Target {fmtAud(goal.targetCents)} by {goal.targetDate} ·
+                    {" "}
+                    {goal.monthlyContributionCents > 0
+                      ? `${fmtAud(goal.monthlyContributionCents)}/mo`
+                      : "no contributions"}
+                    {" · "}
+                    {goal.expectedReturnPct.toFixed(1)}% assumed return
+                    {goal.currentBalanceCents > 0 && (
+                      <> · started at {fmtAud(goal.currentBalanceCents)}</>
+                    )}
+                  </div>
+                </div>
+                <div className="text-right shrink-0">
+                  <StatusPill status={result.status} />
+                  <button
+                    type="button"
+                    onClick={() => void handleDelete(goal.id)}
+                    disabled={deletingId === goal.id}
+                    className="block text-xs text-red-700 hover:text-red-900 mt-1 disabled:opacity-50"
+                  >
+                    {deletingId === goal.id ? "Removing…" : "Remove"}
+                  </button>
+                </div>
+              </div>
+              <p className="text-sm text-slate-700 mt-2">{result.summary}</p>
+              {goal.notes && (
+                <p className="text-xs text-slate-500 italic mt-1">
+                  {goal.notes}
+                </p>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {!showAdd ? (
+        <button
+          type="button"
+          onClick={() => setShowAdd(true)}
+          className="text-sm font-semibold text-indigo-800 hover:text-indigo-900 underline underline-offset-2"
+        >
+          + Add a goal
+        </button>
+      ) : (
+        <form
+          className="grid grid-cols-1 sm:grid-cols-4 gap-3 bg-white border border-indigo-200 rounded-lg p-3"
+          onSubmit={(e) => {
+            e.preventDefault();
+            const fd = new FormData(e.currentTarget);
+            void handleAdd(fd);
+          }}
+        >
+          <label className="sm:col-span-3">
+            <span className="block text-xs font-medium text-slate-700 mb-1">Label</span>
+            <input
+              type="text"
+              name="label"
+              required
+              maxLength={120}
+              placeholder="House deposit"
+              className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm"
+            />
+          </label>
+          <label>
+            <span className="block text-xs font-medium text-slate-700 mb-1">Type</span>
+            <select
+              name="goalType"
+              defaultValue="general"
+              className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm"
+            >
+              {GOAL_TYPES.map((t) => (
+                <option key={t} value={t}>{t}</option>
+              ))}
+            </select>
+          </label>
+          <label>
+            <span className="block text-xs font-medium text-slate-700 mb-1">Target (AUD)</span>
+            <input
+              type="number"
+              name="target"
+              required
+              min="1"
+              step="100"
+              className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm"
+            />
+          </label>
+          <label>
+            <span className="block text-xs font-medium text-slate-700 mb-1">Target date</span>
+            <input
+              type="date"
+              name="targetDate"
+              required
+              className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm"
+            />
+          </label>
+          <label>
+            <span className="block text-xs font-medium text-slate-700 mb-1">Starting balance (AUD)</span>
+            <input
+              type="number"
+              name="currentBalance"
+              defaultValue="0"
+              min="0"
+              step="100"
+              className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm"
+            />
+          </label>
+          <label>
+            <span className="block text-xs font-medium text-slate-700 mb-1">Monthly contrib (AUD)</span>
+            <input
+              type="number"
+              name="monthly"
+              defaultValue="0"
+              min="0"
+              step="50"
+              className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm"
+            />
+          </label>
+          <label>
+            <span className="block text-xs font-medium text-slate-700 mb-1">Assumed return (%/yr)</span>
+            <input
+              type="number"
+              name="returnPct"
+              defaultValue="6"
+              min="-20"
+              max="30"
+              step="0.1"
+              className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm"
+            />
+          </label>
+          <label className="sm:col-span-4">
+            <span className="block text-xs font-medium text-slate-700 mb-1">Notes (optional)</span>
+            <input
+              type="text"
+              name="notes"
+              maxLength={500}
+              className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm"
+            />
+          </label>
+          <div className="sm:col-span-4 flex gap-2 justify-end">
+            <button
+              type="button"
+              onClick={() => setShowAdd(false)}
+              className="px-3 py-2 text-sm text-slate-700 hover:text-slate-900"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={saving}
+              className="px-4 py-2 bg-indigo-700 hover:bg-indigo-800 text-white text-sm font-medium rounded-lg disabled:opacity-50"
+            >
+              {saving ? "Saving…" : "Save goal"}
+            </button>
+          </div>
+        </form>
+      )}
+
+      {error && (
+        <p className="text-sm text-red-700 mt-2" role="alert">
+          {error}
+        </p>
+      )}
+    </section>
+  );
+}
+
+function StatusPill({ status }: { status: "on-track" | "short" | "ahead" | "past-due" }) {
+  const map = {
+    "on-track": { label: "On track", cls: "bg-emerald-100 text-emerald-900 border-emerald-300" },
+    "ahead": { label: "Ahead", cls: "bg-emerald-100 text-emerald-900 border-emerald-300" },
+    "short": { label: "Short", cls: "bg-amber-100 text-amber-900 border-amber-300" },
+    "past-due": { label: "Past due", cls: "bg-red-100 text-red-900 border-red-300" },
+  } as const;
+  const { label, cls } = map[status];
+  return (
+    <span className={`inline-block text-xs font-semibold px-2 py-0.5 border rounded ${cls}`}>
+      {label}
+    </span>
+  );
+}

--- a/app/account/holdings/HoldingsClient.tsx
+++ b/app/account/holdings/HoldingsClient.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import Link from "next/link";
 import { computeHealthScore } from "@/lib/holdings/health-score";
 import {
   buildSwitchingCoach,
   type BrokerForCoach,
 } from "@/lib/holdings/switching-coach";
+import GoalsBlock, { type GoalRow } from "./GoalsBlock";
 
 export interface HoldingRow {
   id: number;
@@ -30,6 +32,7 @@ export interface HoldingRow {
 interface Props {
   initialItems: HoldingRow[];
   brokers: BrokerForCoach[];
+  initialGoals: GoalRow[];
 }
 
 const TRADE_FREQ_OPTIONS = [
@@ -61,7 +64,7 @@ const fmtPct = (deltaCents: number, baseCents: number) => {
 const fmtShares = (n: number) =>
   n.toLocaleString("en-AU", { maximumFractionDigits: 4 });
 
-export default function HoldingsClient({ initialItems, brokers }: Props) {
+export default function HoldingsClient({ initialItems, brokers, initialGoals }: Props) {
   const [items, setItems] = useState<HoldingRow[]>(initialItems);
   const [adding, setAdding] = useState(false);
   const [deletingId, setDeletingId] = useState<number | null>(null);
@@ -243,15 +246,22 @@ export default function HoldingsClient({ initialItems, brokers }: Props) {
           </div>
           <p className="text-sm text-amber-900/90">{coach.summary}</p>
           {coach.estSavingCents > 0 && (
-            <a
+            <Link
               href="/best/share-trading"
               className="inline-block mt-3 text-sm font-semibold text-amber-900 underline underline-offset-2"
             >
               Compare brokers →
-            </a>
+            </Link>
           )}
         </section>
       )}
+
+      {/* Goals — projection against the current portfolio value. Shown
+       *  even when there are no holdings yet so users can start tracking. */}
+      <GoalsBlock
+        initialGoals={initialGoals}
+        currentValueCents={totals.totalValueCents}
+      />
 
       {/* Totals strip */}
       <section className="grid grid-cols-1 sm:grid-cols-3 gap-3">

--- a/app/account/holdings/page.tsx
+++ b/app/account/holdings/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import HoldingsClient, { type HoldingRow } from "./HoldingsClient";
+import type { GoalRow } from "./GoalsBlock";
 import { getCurrentPricesBatch, keyOf } from "@/lib/holdings/value";
 
 export const dynamic = "force-dynamic";
@@ -21,9 +22,10 @@ export default async function HoldingsPage() {
     redirect("/account/login?redirect=/account/holdings");
   }
 
-  // Fetch holdings + the broker fee table in parallel — the latter feeds
-  // the switching coach (asx_fee_value is the comparison axis).
-  const [{ data: holdings }, { data: brokers }] = await Promise.all([
+  // Fetch holdings + broker fee table + goals in parallel. Brokers feed
+  // the switching coach (asx_fee_value is the comparison axis); goals
+  // feed the goal-projection block.
+  const [{ data: holdings }, { data: brokers }, { data: goals }] = await Promise.all([
     supabase
       .from("investor_holdings")
       .select(
@@ -34,6 +36,12 @@ export default async function HoldingsPage() {
       .from("brokers")
       .select("slug, name, asx_fee_value")
       .eq("status", "active"),
+    supabase
+      .from("investor_goals")
+      .select(
+        "id, label, goal_type, target_cents, target_date, current_balance_cents, monthly_contribution_cents, expected_return_pct, notes",
+      )
+      .order("target_date", { ascending: true }),
   ]);
 
   const initialItems: HoldingRow[] = (holdings ?? []).map((r) => ({
@@ -74,6 +82,18 @@ export default async function HoldingsPage() {
     asx_fee_value: typeof b.asx_fee_value === "number" ? b.asx_fee_value : null,
   }));
 
+  const initialGoals: GoalRow[] = (goals ?? []).map((g) => ({
+    id: g.id as number,
+    label: g.label as string,
+    goalType: g.goal_type as string,
+    targetCents: Number(g.target_cents),
+    targetDate: g.target_date as string,
+    currentBalanceCents: Number(g.current_balance_cents),
+    monthlyContributionCents: Number(g.monthly_contribution_cents),
+    expectedReturnPct: Number(g.expected_return_pct),
+    notes: (g.notes as string | null) ?? null,
+  }));
+
   return (
     <main className="max-w-4xl mx-auto px-4 sm:px-6 py-8">
       <header className="mb-6">
@@ -84,7 +104,11 @@ export default async function HoldingsPage() {
           treatment.
         </p>
       </header>
-      <HoldingsClient initialItems={initialItems} brokers={brokerOptions} />
+      <HoldingsClient
+        initialItems={initialItems}
+        brokers={brokerOptions}
+        initialGoals={initialGoals}
+      />
     </main>
   );
 }

--- a/app/api/account/goals/route.ts
+++ b/app/api/account/goals/route.ts
@@ -1,0 +1,142 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { createClient } from "@/lib/supabase/server";
+import { withValidatedBody } from "@/lib/validation/withValidatedBody";
+import { logger } from "@/lib/logger";
+
+const log = logger("api:account:goals");
+
+export const runtime = "nodejs";
+
+/**
+ * /api/account/goals — investor goal-tracker CRUD (PR-X5h).
+ *
+ *   GET    — authenticated user's goals (RLS scopes to own rows)
+ *   POST   — add a goal
+ *   PATCH  — update a goal (id required)
+ *   DELETE — remove a goal (id required)
+ *
+ * RLS scopes per-user reads/writes; the handler uses the user-scoped
+ * supabase client so policies fire, never service-role.
+ *
+ * Column convention follows the existing dashboard-provisioned table
+ * (see migration 20260511000000_investor_goals.sql): label, goal_type,
+ * target_cents, target_date, current_balance_cents,
+ * monthly_contribution_cents, expected_return_pct, notes.
+ */
+
+const GOAL_TYPES = ["retirement", "home", "education", "travel", "general"] as const;
+
+const AddGoalBody = z.object({
+  label: z.string().min(1).max(120),
+  goal_type: z.enum(GOAL_TYPES).default("general"),
+  target_cents: z.coerce.number().int().positive().max(1_000_000_000_000),
+  target_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "YYYY-MM-DD required"),
+  current_balance_cents: z.coerce.number().int().min(0).max(1_000_000_000_000).default(0),
+  monthly_contribution_cents: z.coerce.number().int().min(0).max(100_000_000).default(0),
+  expected_return_pct: z.coerce.number().min(-20).max(30).default(6),
+  notes: z.string().max(500).nullish(),
+});
+
+const UpdateGoalBody = AddGoalBody.partial().extend({
+  id: z.coerce.number().int().positive(),
+});
+
+const RemoveGoalBody = z.object({
+  id: z.coerce.number().int().positive(),
+});
+
+const SELECT_COLS =
+  "id, label, goal_type, target_cents, target_date, current_balance_cents, monthly_contribution_cents, expected_return_pct, notes, created_at, updated_at";
+
+export async function GET() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+
+  const { data, error } = await supabase
+    .from("investor_goals")
+    .select(SELECT_COLS)
+    .order("target_date", { ascending: true });
+
+  if (error) {
+    log.warn("goals fetch failed", { error: error.message });
+    return NextResponse.json({ error: "fetch_failed" }, { status: 500 });
+  }
+  return NextResponse.json({ items: data ?? [] });
+}
+
+export const POST = withValidatedBody(AddGoalBody, async (req, body) => {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+
+  const { data, error } = await supabase
+    .from("investor_goals")
+    .insert({
+      auth_user_id: user.id,
+      label: body.label.trim(),
+      goal_type: body.goal_type,
+      target_cents: body.target_cents,
+      target_date: body.target_date,
+      current_balance_cents: body.current_balance_cents,
+      monthly_contribution_cents: body.monthly_contribution_cents,
+      expected_return_pct: body.expected_return_pct,
+      notes: body.notes ?? null,
+    })
+    .select(SELECT_COLS)
+    .single();
+
+  if (error) {
+    log.warn("goals insert failed", { error: error.message });
+    return NextResponse.json({ error: "insert_failed", detail: error.message }, { status: 500 });
+  }
+  return NextResponse.json({ item: data }, { status: 201 });
+});
+
+export const PATCH = withValidatedBody(UpdateGoalBody, async (req, body) => {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+
+  const { id, ...rest } = body;
+  const update: Record<string, unknown> = { updated_at: new Date().toISOString() };
+  if (rest.label !== undefined) update.label = rest.label.trim();
+  if (rest.goal_type !== undefined) update.goal_type = rest.goal_type;
+  if (rest.target_cents !== undefined) update.target_cents = rest.target_cents;
+  if (rest.target_date !== undefined) update.target_date = rest.target_date;
+  if (rest.current_balance_cents !== undefined) update.current_balance_cents = rest.current_balance_cents;
+  if (rest.monthly_contribution_cents !== undefined) update.monthly_contribution_cents = rest.monthly_contribution_cents;
+  if (rest.expected_return_pct !== undefined) update.expected_return_pct = rest.expected_return_pct;
+  if (rest.notes !== undefined) update.notes = rest.notes;
+
+  const { data, error } = await supabase
+    .from("investor_goals")
+    .update(update)
+    .eq("id", id)
+    .select(SELECT_COLS)
+    .single();
+
+  if (error) {
+    log.warn("goals update failed", { error: error.message });
+    return NextResponse.json({ error: "update_failed", detail: error.message }, { status: 500 });
+  }
+  return NextResponse.json({ item: data });
+});
+
+export const DELETE = withValidatedBody(RemoveGoalBody, async (req, body) => {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+
+  const { error } = await supabase
+    .from("investor_goals")
+    .delete()
+    .eq("id", body.id);
+
+  if (error) {
+    log.warn("goals delete failed", { error: error.message });
+    return NextResponse.json({ error: "delete_failed" }, { status: 500 });
+  }
+  return NextResponse.json({ ok: true });
+});

--- a/lib/holdings/goal-projection.ts
+++ b/lib/holdings/goal-projection.ts
@@ -1,0 +1,217 @@
+/**
+ * Goal projection (PR-X5h).
+ *
+ * Pure function. Inputs: current portfolio value, target amount, target
+ * date, monthly contribution assumption, annual return assumption.
+ * Outputs: projected value at the target date + status (on-track / short
+ * / ahead) + monthly contribution needed to actually hit the goal.
+ *
+ * Compliance: projection-only output framed as a factual computation, the
+ * same legal lane as the CGT estimator or switching coach. Never says
+ * "you should contribute X" — the UI labels the contribution-needed
+ * number "to reach your goal you would need to add ~$X/mo at this return"
+ * (a comparison-driven calculation, not advice). ASIC MoneySmart's
+ * compound-interest calculator uses the same maths; we're not introducing
+ * a new compliance surface.
+ */
+
+export interface GoalProjectionInput {
+  /** Current portfolio value in cents (the starting principal). */
+  currentValueCents: number;
+  /** Goal target in cents. */
+  targetCents: number;
+  /** Months from "now" to the target date. Caller computes this from the
+   *  target_date column + a clock the caller controls (`new Date()` in
+   *  prod; injectable in tests). Negative values are clamped to 0. */
+  monthsToTarget: number;
+  /** Monthly contribution in cents. 0 = no contribution. */
+  monthlyContributionCents: number;
+  /** Annual expected return as a percentage (e.g. 6 = 6.00%). Negative
+   *  allowed (worst-case modelling); typical inputs 0–15. */
+  annualReturnPct: number;
+}
+
+export type GoalStatus = "on-track" | "short" | "ahead" | "past-due";
+
+export interface GoalProjectionResult {
+  /** Months used in the projection (input clamped to ≥ 0). */
+  monthsUsed: number;
+  /** Future value of the portfolio at the target date, in cents. */
+  projectedValueAtTargetCents: number;
+  /** Gap = target − projected. Positive = short; negative = ahead. */
+  gapCents: number;
+  /** Monthly contribution (in cents) required to exactly hit the target,
+   *  given the same return assumption + months. null when no plausible
+   *  contribution can close the gap (e.g. target already reached without
+   *  contributions, or months=0). */
+  requiredMonthlyContributionCents: number | null;
+  status: GoalStatus;
+  /** Plain-English summary line for the UI. */
+  summary: string;
+}
+
+const CENTS_PER_DOLLAR = 100;
+
+export function projectGoal(input: GoalProjectionInput): GoalProjectionResult {
+  const monthsUsed = Math.max(0, Math.floor(input.monthsToTarget));
+  const monthlyRate = input.annualReturnPct / 100 / 12;
+  const monthlyContrib = Math.max(0, input.monthlyContributionCents);
+  const startValue = Math.max(0, input.currentValueCents);
+
+  const projectedValueAtTargetCents = futureValueCents(
+    startValue,
+    monthlyContrib,
+    monthlyRate,
+    monthsUsed,
+  );
+
+  const gapCents = input.targetCents - projectedValueAtTargetCents;
+
+  const requiredMonthlyContributionCents = solveRequiredContributionCents({
+    startValue,
+    targetCents: input.targetCents,
+    months: monthsUsed,
+    monthlyRate,
+  });
+
+  const status: GoalStatus = monthsUsed === 0
+    ? (startValue >= input.targetCents ? "ahead" : "past-due")
+    : (gapCents < 0
+        ? "ahead"
+        : gapCents <= input.targetCents * 0.05
+          ? "on-track"
+          : "short");
+
+  return {
+    monthsUsed,
+    projectedValueAtTargetCents,
+    gapCents,
+    requiredMonthlyContributionCents,
+    status,
+    summary: buildSummary({
+      status,
+      monthsUsed,
+      projectedValueAtTargetCents,
+      gapCents,
+      targetCents: input.targetCents,
+      monthlyContributionCents: monthlyContrib,
+      requiredMonthlyContributionCents,
+    }),
+  };
+}
+
+/**
+ * Compute the calendar months between two dates (signed). Helper for callers
+ * who store target_date as a YYYY-MM-DD string and want to feed
+ * `monthsToTarget` into projectGoal.
+ *
+ * Returns the floor of (end - start) in calendar months — a target 1 day
+ * away returns 0, a target 31 days away returns 1.
+ */
+export function monthsBetween(start: Date, end: Date): number {
+  const years = end.getUTCFullYear() - start.getUTCFullYear();
+  const months = end.getUTCMonth() - start.getUTCMonth();
+  let total = years * 12 + months;
+  if (end.getUTCDate() < start.getUTCDate()) total -= 1;
+  return total;
+}
+
+// ─── Internals ──────────────────────────────────────────────────────────────
+
+/**
+ * Standard compound-interest future-value formula with monthly contributions
+ * paid at end of each month:
+ *
+ *   FV = P(1+r)^n + C * [((1+r)^n − 1) / r]
+ *
+ * Special case r=0 collapses to P + C*n (handled to avoid divide-by-zero).
+ */
+function futureValueCents(
+  principalCents: number,
+  monthlyContribCents: number,
+  monthlyRate: number,
+  months: number,
+): number {
+  if (months <= 0) return Math.round(principalCents);
+  if (Math.abs(monthlyRate) < 1e-9) {
+    return Math.round(principalCents + monthlyContribCents * months);
+  }
+  const growthFactor = Math.pow(1 + monthlyRate, months);
+  const principalGrowth = principalCents * growthFactor;
+  const contribGrowth = monthlyContribCents * ((growthFactor - 1) / monthlyRate);
+  return Math.round(principalGrowth + contribGrowth);
+}
+
+/**
+ * Solve for the monthly contribution C that makes FV = target. Algebraically
+ * inverts futureValueCents() for C, given P, target, r, n.
+ *
+ *   target = P(1+r)^n + C * [((1+r)^n − 1) / r]
+ *   ⇒  C = (target − P(1+r)^n) / [((1+r)^n − 1) / r]
+ *
+ * Returns null when the gap is already closed without contributions, or when
+ * months=0 (no time to contribute).
+ */
+function solveRequiredContributionCents(opts: {
+  startValue: number;
+  targetCents: number;
+  months: number;
+  monthlyRate: number;
+}): number | null {
+  const { startValue, targetCents, months, monthlyRate } = opts;
+  if (months <= 0) return null;
+  if (Math.abs(monthlyRate) < 1e-9) {
+    const fvNoContrib = startValue;
+    const gap = targetCents - fvNoContrib;
+    if (gap <= 0) return null;
+    return Math.round(gap / months);
+  }
+  const growthFactor = Math.pow(1 + monthlyRate, months);
+  const fvNoContrib = startValue * growthFactor;
+  const gap = targetCents - fvNoContrib;
+  if (gap <= 0) return null;
+  const annuityFactor = (growthFactor - 1) / monthlyRate;
+  if (annuityFactor <= 0) return null;
+  return Math.round(gap / annuityFactor);
+}
+
+function buildSummary(opts: {
+  status: GoalStatus;
+  monthsUsed: number;
+  projectedValueAtTargetCents: number;
+  gapCents: number;
+  targetCents: number;
+  monthlyContributionCents: number;
+  requiredMonthlyContributionCents: number | null;
+}): string {
+  const projected = formatAud(opts.projectedValueAtTargetCents);
+  const target = formatAud(opts.targetCents);
+  switch (opts.status) {
+    case "past-due":
+      return `Target date is in the past. Reset the goal to keep tracking.`;
+    case "ahead":
+      return opts.monthsUsed === 0
+        ? `You're already at or above the target.`
+        : `On this projection you'd reach ${projected} by then — comfortably above the ${target} target.`;
+    case "on-track":
+      return `On this projection you'd reach ${projected} by then — within 5% of the ${target} target.`;
+    case "short": {
+      const required = opts.requiredMonthlyContributionCents;
+      const reqLine = required !== null
+        ? ` To close the gap at the same return you'd need ~${formatAud(required)}/mo (currently ${formatAud(opts.monthlyContributionCents)}/mo).`
+        : "";
+      return `On this projection you'd reach ${projected} by then — ${formatAud(opts.gapCents)} short of the ${target} target.${reqLine}`;
+    }
+  }
+}
+
+function formatAud(cents: number): string {
+  const sign = cents < 0 ? "−" : "";
+  const abs = Math.abs(cents);
+  const formatted = (abs / CENTS_PER_DOLLAR).toLocaleString("en-AU", {
+    style: "currency",
+    currency: "AUD",
+    maximumFractionDigits: 0,
+  });
+  return `${sign}${formatted}`;
+}

--- a/supabase/migrations/20260511000000_investor_goals.sql
+++ b/supabase/migrations/20260511000000_investor_goals.sql
@@ -1,0 +1,80 @@
+-- ============================================================================
+-- Migration: 20260511000000_investor_goals.sql
+-- Purpose: Investor goal tracker (PR-X5h). A goal is a target dollar amount
+--          + target date + monthly contribution + expected return assumption.
+--          Pure projection — "at current rate you'll hit $X by date Y" —
+--          comparison-driven, not advice. Surfaces alongside holdings on
+--          /account/holdings.
+--
+--          Note: the table was first created via the Supabase dashboard
+--          during iter 353 (commit c3a19667 regenerated database.types.ts
+--          for it). This migration is the canonical idempotent definition;
+--          on remote where the table already exists the CREATE skips and
+--          the policy DROP/CREATE pair re-establishes RLS. On a fresh local
+--          stack the migration creates the table with the same shape so
+--          dev parity is preserved.
+-- Audit ref: docs/plans/investor-account-end-to-end-plan.md Phase 3 X5h
+-- Risk: low — additive; RLS-scoped per-user; no public read.
+-- Rollback: DROP TABLE IF EXISTS public.investor_goals;
+--           (DESTRUCTIVE — discards user-entered goals. No seed; users would
+--           need to re-enter manually.)
+-- ============================================================================
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.investor_goals (
+  id              bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  auth_user_id    uuid   NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  label           text   NOT NULL,
+  goal_type       text   NOT NULL,
+  target_cents    bigint NOT NULL,
+  target_date     date   NOT NULL,
+  current_balance_cents bigint NOT NULL DEFAULT 0,
+  monthly_contribution_cents bigint NOT NULL DEFAULT 0,
+  expected_return_pct numeric NOT NULL DEFAULT 6,
+  notes           text,
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  updated_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_investor_goals_user
+  ON public.investor_goals (auth_user_id, target_date ASC);
+
+ALTER TABLE public.investor_goals ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.investor_goals FORCE ROW LEVEL SECURITY;
+
+-- Authenticated users see / write ONLY their own rows.
+DROP POLICY IF EXISTS "investor reads own goals" ON public.investor_goals;
+CREATE POLICY "investor reads own goals"
+  ON public.investor_goals FOR SELECT
+  TO authenticated
+  USING (auth.uid() = auth_user_id);
+
+DROP POLICY IF EXISTS "investor inserts own goals" ON public.investor_goals;
+CREATE POLICY "investor inserts own goals"
+  ON public.investor_goals FOR INSERT
+  TO authenticated
+  WITH CHECK (auth.uid() = auth_user_id);
+
+DROP POLICY IF EXISTS "investor updates own goals" ON public.investor_goals;
+CREATE POLICY "investor updates own goals"
+  ON public.investor_goals FOR UPDATE
+  TO authenticated
+  USING (auth.uid() = auth_user_id)
+  WITH CHECK (auth.uid() = auth_user_id);
+
+DROP POLICY IF EXISTS "investor deletes own goals" ON public.investor_goals;
+CREATE POLICY "investor deletes own goals"
+  ON public.investor_goals FOR DELETE
+  TO authenticated
+  USING (auth.uid() = auth_user_id);
+
+-- Service role full access for admin / cron / GDPR-export paths.
+DROP POLICY IF EXISTS "service_role full access investor_goals" ON public.investor_goals;
+CREATE POLICY "service_role full access investor_goals"
+  ON public.investor_goals FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+COMMIT;


### PR DESCRIPTION
## Summary
Investor goal tracker (W2.12 / PR-X5h): backfill migration for the dashboard-provisioned `investor_goals` table + projection logic + holdings-page integration.

## Why
The `investor_goals` table was created via the Supabase dashboard in iter 353 (commit c3a19667 regenerated `database.types.ts` for it) but had no migration file, no RLS, and no UI consumer. The pre-launch wave queue listed W2.12 as pending. This PR ships all three gaps end-to-end so investors on `/account/holdings` can set targets ("Save $500k by 2030 for house deposit") and see a projection vs the target.

## Tier
B — additive RLS migration + new API + additive UI block. No webhooks, no Stripe, no service-role bypass. RLS policies are explicit per-user via `auth.uid() = auth_user_id`.

## Files
- `supabase/migrations/20260511000000_investor_goals.sql` — canonical idempotent definition matching the existing dashboard schema (`label`, `goal_type`, `target_cents`, `target_date`, `current_balance_cents`, `monthly_contribution_cents`, `expected_return_pct`, `notes`) + per-user index + RLS policies. `CREATE TABLE IF NOT EXISTS` so remote (table already exists) is a no-op; local dev gets parity.
- `lib/holdings/goal-projection.ts` — pure future-value formula (compound interest + monthly annuity), `monthsBetween` helper. Returns projected value, gap, required-contribution-to-hit-target, status (on-track / short / ahead / past-due), summary string. **Comparison-driven, not advice.**
- `app/api/account/goals/route.ts` — full CRUD via user-scoped Supabase client (RLS does the per-user scoping); Zod-validated bodies via `withValidatedBody`.
- `app/account/holdings/GoalsBlock.tsx` — list + add-form + per-goal status pill. Projects against either the goal's stored starting balance (for non-portfolio goals like a house deposit in savings) or the live portfolio current value (for investment-style goals).
- `app/account/holdings/page.tsx` + `HoldingsClient.tsx` — fetch goals in the existing parallel server query, pass to `GoalsBlock` mounted above the totals strip. Incidental: converted the existing switching-coach `<a>` to `<Link>` (lint-staged blocked the commit).
- `__tests__/lib/holdings/goal-projection.test.ts` (14 tests) — covers all four status states, the FV formula vs hand-computed reference values, edge cases (months=0, negative return).
- `__tests__/api/account-goals.test.ts` (15 tests) — auth + Zod validation + per-method CRUD.
- `.driftallowlist` — removed `investor_goals` (now backed by a migration).

## Supersedes
_None._

## Compliance
The goal projection is a **factual computation**, identical legal lane to the CGT estimator + switching coach already on `/account/holdings`. The UI labels the contribution-needed number "to close the gap at the same return you'd need ~$X/mo" — a comparison-driven calculation, not advice. ASIC MoneySmart's compound-interest calculator uses the same maths.

## Test plan
- [x] `vitest run __tests__/lib/holdings/ __tests__/api/account-goals.test.ts` — 44/44 green locally
- [x] `tsc --noEmit` — clean
- [ ] CI: pending
- [ ] Visual (post-merge or on preview): sign in → `/account/holdings` → click "+ Add a goal" → enter House deposit / $500k / 2030-12-31 / 6% return → save → see projection + status pill

---
_Generated by [Claude Code](https://claude.ai/code/session_01KnZTnFDVzWttmrMNAus9kt)_