### PR TITLE
fix(tt): TT-02 — security header hardening (COOP + Permissions-Policy + PostHog CSP) [audit remediation]

### DIFF
--- a/__tests__/lib/proxy-security-headers.test.ts
+++ b/__tests__/lib/proxy-security-headers.test.ts
@@ -1,0 +1,117 @@
+/**
+ * TT-02: Verify security headers emitted by proxy.ts on every public request.
+ *
+ * Tests run against a public path so Supabase auth is never invoked;
+ * only the header-setting code path is exercised.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@supabase/ssr", () => ({
+  createServerClient: vi.fn(),
+}));
+
+vi.mock("@/lib/admin-mfa-cookie-edge", () => ({
+  verifyMfaCookieEdge: vi.fn().mockResolvedValue(false),
+  MFA_COOKIE_NAME: "admin_mfa_verified",
+}));
+
+async function getHeaders(pathname = "/") {
+  const { proxy } = await import("@/proxy");
+  const req = new NextRequest(`https://invest.com.au${pathname}`);
+  const res = await proxy(req);
+  return res.headers;
+}
+
+describe("proxy.ts — security headers (TT-02)", () => {
+  it("sets HSTS with preload and includeSubDomains", async () => {
+    const headers = await getHeaders();
+    const hsts = headers.get("Strict-Transport-Security");
+    expect(hsts).toContain("max-age=63072000");
+    expect(hsts).toContain("includeSubDomains");
+    expect(hsts).toContain("preload");
+  });
+
+  it("sets X-Frame-Options to DENY", async () => {
+    const headers = await getHeaders();
+    expect(headers.get("X-Frame-Options")).toBe("DENY");
+  });
+
+  it("sets X-Content-Type-Options to nosniff", async () => {
+    const headers = await getHeaders();
+    expect(headers.get("X-Content-Type-Options")).toBe("nosniff");
+  });
+
+  it("sets Referrer-Policy", async () => {
+    const headers = await getHeaders();
+    expect(headers.get("Referrer-Policy")).toBe(
+      "strict-origin-when-cross-origin"
+    );
+  });
+
+  it("sets Cross-Origin-Opener-Policy for Spectre isolation", async () => {
+    const headers = await getHeaders();
+    expect(headers.get("Cross-Origin-Opener-Policy")).toBe(
+      "same-origin-allow-popups"
+    );
+  });
+
+  it("Permissions-Policy denies high-risk APIs", async () => {
+    const headers = await getHeaders();
+    const policy = headers.get("Permissions-Policy") ?? "";
+    expect(policy).toContain("camera=()");
+    expect(policy).toContain("microphone=()");
+    expect(policy).toContain("payment=()");
+    expect(policy).toContain("usb=()");
+    expect(policy).toContain("gyroscope=()");
+    expect(policy).toContain("magnetometer=()");
+  });
+
+  it("CSP includes PostHog endpoints in connect-src", async () => {
+    const headers = await getHeaders();
+    const csp = headers.get("Content-Security-Policy") ?? "";
+    expect(csp).toContain("eu.i.posthog.com");
+    expect(csp).toContain("us.i.posthog.com");
+  });
+
+  it("CSP uses nonce-based strict-dynamic (no unsafe-inline in script-src)", async () => {
+    const headers = await getHeaders();
+    const csp = headers.get("Content-Security-Policy") ?? "";
+    expect(csp).toContain("strict-dynamic");
+    // nonce= is present (unique per request so we just check prefix)
+    expect(csp).toMatch(/nonce-[A-Za-z0-9+/]+=*'/);
+    expect(csp).not.toMatch(/script-src[^;]*'unsafe-inline'/);
+  });
+
+  it("CSP sets frame-ancestors none to block embedding", async () => {
+    const headers = await getHeaders();
+    const csp = headers.get("Content-Security-Policy") ?? "";
+    expect(csp).toContain("frame-ancestors 'none'");
+  });
+
+  it("CSP sets object-src none", async () => {
+    const headers = await getHeaders();
+    const csp = headers.get("Content-Security-Policy") ?? "";
+    expect(csp).toContain("object-src 'none'");
+  });
+
+  it("stamps a unique x-request-id on each response", async () => {
+    const [h1, h2] = await Promise.all([getHeaders(), getHeaders()]);
+    const id1 = h1.get("x-request-id");
+    const id2 = h2.get("x-request-id");
+    expect(id1).toBeTruthy();
+    expect(id2).toBeTruthy();
+    expect(id1).not.toBe(id2);
+  });
+
+  it("preview deploys get X-Robots-Tag noindex", async () => {
+    const original = process.env.VERCEL_ENV;
+    process.env.VERCEL_ENV = "preview";
+    try {
+      const headers = await getHeaders("/");
+      expect(headers.get("X-Robots-Tag")).toContain("noindex");
+    } finally {
+      process.env.VERCEL_ENV = original;
+    }
+  });
+});

--- a/proxy.ts
+++ b/proxy.ts
@@ -93,7 +93,12 @@ export async function proxy(request: NextRequest) {
   response.headers.set('X-Frame-Options', 'DENY')
   response.headers.set('X-Content-Type-Options', 'nosniff')
   response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin')
-  response.headers.set('Permissions-Policy', 'camera=(), microphone=(), geolocation=(self)')
+  response.headers.set(
+    'Permissions-Policy',
+    'camera=(), microphone=(), geolocation=(self), payment=(), usb=(), gyroscope=(), magnetometer=(), midi=(), ambient-light-sensor=(), battery=(), screen-wake-lock=()'
+  )
+  // Spectre/side-channel isolation: allow popups so Supabase OAuth flows work.
+  response.headers.set('Cross-Origin-Opener-Policy', 'same-origin-allow-popups')
   response.headers.set('X-DNS-Prefetch-Control', 'on')
   response.headers.set('Strict-Transport-Security', 'max-age=63072000; includeSubDomains; preload')
 
@@ -150,7 +155,7 @@ export async function proxy(request: NextRequest) {
     "style-src 'self' 'unsafe-inline'",
     "img-src 'self' data: blob: https:",
     "font-src 'self' data:",
-    "connect-src 'self' https://*.supabase.co https://va.vercel-scripts.com https://*.google-analytics.com https://*.analytics.google.com https://www.googletagmanager.com https://api.stripe.com https://cal.com https://app.cal.com https://*.sentry.io https://*.ingest.sentry.io",
+    "connect-src 'self' https://*.supabase.co https://va.vercel-scripts.com https://*.google-analytics.com https://*.analytics.google.com https://www.googletagmanager.com https://api.stripe.com https://cal.com https://app.cal.com https://*.sentry.io https://*.ingest.sentry.io https://eu.i.posthog.com https://us.i.posthog.com",
     "frame-src 'self' https://js.stripe.com https://hooks.stripe.com https://www.youtube-nocookie.com https://player.vimeo.com https://cal.com",
     "frame-ancestors 'none'",
     "base-uri 'self'",


### PR DESCRIPTION
## Summary

TT-02 audit of security/SSL headers set in `proxy.ts`. Three gaps fixed:

- **COOP missing**: Added `Cross-Origin-Opener-Policy: same-origin-allow-popups` for Spectre-class side-channel isolation while preserving Supabase OAuth popup flows
- **Narrow Permissions-Policy**: Extended to deny `payment`, `usb`, `gyroscope`, `magnetometer`, `midi`, `ambient-light-sensor`, `battery`, `screen-wake-lock` — APIs not used by a financial site and exploitable for fingerprinting/side-channels
- **PostHog blocked by CSP**: `eu.i.posthog.com` and `us.i.posthog.com` were absent from `connect-src`; PostHog analytics have silently failed since the PP-04 consent gate landed. Both regional endpoints added.

Existing headers already passing audit:
- HSTS: `max-age=63072000; includeSubDomains; preload` ✓
- X-Frame-Options: DENY ✓
- X-Content-Type-Options: nosniff ✓
- CSP: nonce-based `strict-dynamic` (no `unsafe-inline` in script-src) ✓
- CSP violation reporting via Report-To + report-uri ✓

## Test plan

- [x] 12 new tests in `__tests__/lib/proxy-security-headers.test.ts` — all pass locally
- [x] Tests cover: HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, COOP, Permissions-Policy deny list, CSP PostHog, CSP nonce/strict-dynamic, frame-ancestors none, object-src none, request-id uniqueness, preview noindex
- [x] Lint clean — `eslint proxy.ts __tests__/lib/proxy-security-headers.test.ts --max-warnings 0`
- [ ] CI green

## Supersedes

_None._

Refs: #222
Audit: `docs/audits/codebase-health-2026-04-24.md` §TT
Queue: `docs/audits/REMEDIATION_QUEUE.md` TT-02

---
_Generated by [Claude Code](https://claude.ai/code/session_0193bzMA4ULcipUCmYHUvwy6)_