### PR TITLE
feat(tt): TT-03 iter 1 — Plausible Analytics integration (cookieless, GDPR-compliant) [audit remediation]

### DIFF
--- a/__tests__/components/PlausibleAnalytics.test.tsx
+++ b/__tests__/components/PlausibleAnalytics.test.tsx
@@ -1,0 +1,68 @@
+import { render } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("next/script", () => ({
+  default: vi.fn(({ src, "data-domain": dataDomain, strategy, defer }: {
+    src?: string;
+    "data-domain"?: string;
+    strategy?: string;
+    defer?: boolean;
+  }) => (
+    // eslint-disable-next-line @next/next/no-sync-scripts -- test mock only, not real DOM
+    <script
+      data-testid="plausible-script"
+      src={src}
+      data-domain={dataDomain}
+      data-strategy={strategy}
+      data-defer={defer ? "true" : undefined}
+    />
+  )),
+}));
+
+describe("PlausibleAnalytics", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.resetModules();
+  });
+
+  it("renders nothing when NEXT_PUBLIC_PLAUSIBLE_DOMAIN is not set", async () => {
+    delete process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN;
+    const { default: PlausibleAnalytics } = await import(
+      "@/components/PlausibleAnalytics"
+    );
+    const { container } = render(<PlausibleAnalytics />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the Plausible script when domain is configured", async () => {
+    process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN = "invest.com.au";
+    const { default: PlausibleAnalytics } = await import(
+      "@/components/PlausibleAnalytics"
+    );
+    const { getByTestId } = render(<PlausibleAnalytics />);
+    const script = getByTestId("plausible-script");
+    expect(script).toBeTruthy();
+    expect(script.getAttribute("src")).toBe(
+      "https://plausible.io/js/script.js"
+    );
+    expect(script.getAttribute("data-domain")).toBe("invest.com.au");
+    expect(script.getAttribute("data-strategy")).toBe("afterInteractive");
+  });
+
+  it("uses afterInteractive strategy (does not block render)", async () => {
+    process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN = "invest.com.au";
+    const { default: PlausibleAnalytics } = await import(
+      "@/components/PlausibleAnalytics"
+    );
+    const { getByTestId } = render(<PlausibleAnalytics />);
+    expect(getByTestId("plausible-script").getAttribute("data-strategy")).toBe(
+      "afterInteractive"
+    );
+  });
+});

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,6 +9,7 @@ import LayoutShell from "@/components/LayoutShell";
 import CountryModeBanner from "@/components/country-mode/CountryModeBanner";
 import { ThemeProvider } from "@/components/ThemeProvider";
 import GoogleAnalytics from "@/components/GoogleAnalytics";
+import PlausibleAnalytics from "@/components/PlausibleAnalytics";
 import { PostHogProvider } from "@/components/PostHogProvider";
 import UtmCapture from "@/components/UtmCapture";
 import RouteChangeFocus from "@/components/RouteChangeFocus";
@@ -166,6 +167,7 @@ export default async function RootLayout({
           </div>
         </noscript>
         <GoogleAnalytics />
+        <PlausibleAnalytics />
         <PostHogProvider>
         <Suspense fallback={null}><UtmCapture /></Suspense>
         <Suspense fallback={null}><RouteChangeFocus /></Suspense>

--- a/components/PlausibleAnalytics.tsx
+++ b/components/PlausibleAnalytics.tsx
@@ -1,0 +1,26 @@
+import Script from "next/script";
+
+const PLAUSIBLE_DOMAIN = process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN;
+
+/**
+ * Plausible Analytics — cookieless, GDPR-compliant pageview tracking.
+ *
+ * Unlike GA4, Plausible collects no personal data and requires no cookie
+ * consent banner. It can load unconditionally for all visitors. The
+ * data-domain attribute tells Plausible which site to attribute traffic to.
+ *
+ * No consent gate needed (see TT-03 migration notes in REMEDIATION_QUEUE.md).
+ * GA4 removal (GoogleAnalytics.tsx + NEXT_PUBLIC_GA_ID) is deferred to TT-03 iter 2.
+ */
+export default function PlausibleAnalytics() {
+  if (!PLAUSIBLE_DOMAIN) return null;
+
+  return (
+    <Script
+      defer
+      data-domain={PLAUSIBLE_DOMAIN}
+      src="https://plausible.io/js/script.js"
+      strategy="afterInteractive"
+    />
+  );
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -155,7 +155,7 @@ export async function proxy(request: NextRequest) {
     "style-src 'self' 'unsafe-inline'",
     "img-src 'self' data: blob: https:",
     "font-src 'self' data:",
-    "connect-src 'self' https://*.supabase.co https://va.vercel-scripts.com https://*.google-analytics.com https://*.analytics.google.com https://www.googletagmanager.com https://api.stripe.com https://cal.com https://app.cal.com https://*.sentry.io https://*.ingest.sentry.io https://eu.i.posthog.com https://us.i.posthog.com",
+    "connect-src 'self' https://*.supabase.co https://va.vercel-scripts.com https://*.google-analytics.com https://*.analytics.google.com https://www.googletagmanager.com https://api.stripe.com https://cal.com https://app.cal.com https://*.sentry.io https://*.ingest.sentry.io https://eu.i.posthog.com https://us.i.posthog.com https://plausible.io",
     "frame-src 'self' https://js.stripe.com https://hooks.stripe.com https://www.youtube-nocookie.com https://player.vimeo.com https://cal.com",
     "frame-ancestors 'none'",
     "base-uri 'self'",


### PR DESCRIPTION
## Summary\n\nTT-03 iter 1 — first step of privacy analytics migration (GA4 → Plausible).\n\n**Plausible runs alongside GA4 in this iteration.** GA4 removal is deferred to TT-03 iter 2 to avoid analytics gaps before Plausible is confirmed collecting data in production.\n\n### What's added\n\n- `components/PlausibleAnalytics.tsx` — renders Plausible's tracking script when `NEXT_PUBLIC_PLAUSIBLE_DOMAIN` is set; returns null if unset (safe for staging/local without Plausible account)\n- `app/layout.tsx` — `<PlausibleAnalytics />` rendered after `<GoogleAnalytics />` (both present until iter 2)\n- `proxy.ts` — `https://plausible.io` added to CSP `connect-src` (Plausible's event endpoint)\n- `__tests__/components/PlausibleAnalytics.test.tsx` — 3 unit tests\n\n### Why Plausible\n\n- Open-source, self-hostable if needed\n- **No cookies, no personal data** — GDPR-compliant without a consent gate\n- `afterInteractive` strategy — doesn't block LCP\n- Simple `data-domain` attribution, no SDK required\n- More transparent than GA4 for a site positioned around investor trust\n\n### Deploy checklist\n\n- [ ] Add `NEXT_PUBLIC_PLAUSIBLE_DOMAIN=invest.com.au` to Vercel environment variables\n- [ ] Create Plausible account / add `invest.com.au` to dashboard\n- [ ] Verify pageviews appearing in Plausible before proceeding to TT-03 iter 2 (GA4 removal)\n\n## Supersedes\n\n_None._\n\nAudit: `docs/audits/codebase-health-2026-04-24.md` §TT\nQueue: `docs/audits/REMEDIATION_QUEUE.md` — TT-03\n\nhttps://claude.ai/code/session_016c1BRAT17qAtgqr3dorJmq

---
_Generated by [Claude Code](https://claude.ai/code/session_016c1BRAT17qAtgqr3dorJmq)_