### PR TITLE
feat(calc): retrofit 5 calculators to useCalculatorState (Batch 1)

### DIFF
--- a/app/dividend-reinvestment-calculator/DividendReinvestmentClient.tsx
+++ b/app/dividend-reinvestment-calculator/DividendReinvestmentClient.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import Link from "next/link";
+import { useCalculatorState } from "@/hooks/use-calculator-state";
 
 function fmt(n: number) {
   return new Intl.NumberFormat("en-AU", { style: "currency", currency: "AUD", maximumFractionDigits: 0 }).format(n);
@@ -16,6 +17,39 @@ export default function DividendReinvestmentClient() {
   const [divYield, setDivYield] = useState(4);
   const [growth, setGrowth] = useState(6);
   const [years, setYears] = useState(20);
+
+  const {
+    value: persistedInputs,
+    setValue: setPersistedInputs,
+    isHydrated: persistHydrated,
+  } = useCalculatorState<{
+    price: number;
+    shares: number;
+    div_yield: number;
+    growth: number;
+    years: number;
+  }>("dividend_reinvestment_calculator", {
+    price: 50,
+    shares: 1000,
+    div_yield: 4,
+    growth: 6,
+    years: 20,
+  });
+
+  useEffect(() => {
+    if (!persistHydrated) return;
+    if (typeof persistedInputs.price === "number") setPrice(persistedInputs.price);
+    if (typeof persistedInputs.shares === "number") setShares(persistedInputs.shares);
+    if (typeof persistedInputs.div_yield === "number") setDivYield(persistedInputs.div_yield);
+    if (typeof persistedInputs.growth === "number") setGrowth(persistedInputs.growth);
+    if (typeof persistedInputs.years === "number") setYears(persistedInputs.years);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- hydrate once
+  }, [persistHydrated]);
+
+  useEffect(() => {
+    setPersistedInputs({ price, shares, div_yield: divYield, growth, years });
+  }, [price, shares, divYield, growth, years, setPersistedInputs]);
+
   const result = useMemo(() => {
     const dy = divYield / 100;
     const gr = growth / 100;

--- a/app/property-yield-calculator/PropertyYieldCalculatorClient.tsx
+++ b/app/property-yield-calculator/PropertyYieldCalculatorClient.tsx
@@ -7,6 +7,7 @@ import SocialProofCounter from "@/components/SocialProofCounter";
 import { trackEvent, trackPageDuration, formatPercent } from "@/lib/tracking";
 import { getStoredUtm } from "@/components/UtmCapture";
 import { formatCurrency } from "@/lib/utils";
+import { useCalculatorState } from "@/hooks/use-calculator-state";
 
 /* ─── helpers ─── */
 // formatPercent imported from lib/tracking; default 2 decimals matches old local impl.
@@ -73,6 +74,68 @@ export default function PropertyYieldCalculatorClient() {
   const [emailGated, setEmailGated] = useState(false);
   const [email, setEmail] = useState("");
   const [emailSubmitted, setEmailSubmitted] = useState(false);
+
+  const {
+    value: persistedInputs,
+    setValue: setPersistedInputs,
+    isHydrated: persistHydrated,
+  } = useCalculatorState<{
+    purchase_price: number;
+    weekly_rent: number;
+    council_rates: number;
+    insurance: number;
+    maintenance: number;
+    management_pct: number;
+    strata: number;
+    other_expenses: number;
+    show_mortgage: boolean;
+    loan_amount: number;
+    interest_rate: number;
+  }>("property_yield_calculator", {
+    purchase_price: 750000,
+    weekly_rent: 550,
+    council_rates: 2000,
+    insurance: 1500,
+    maintenance: 2000,
+    management_pct: 7,
+    strata: 0,
+    other_expenses: 0,
+    show_mortgage: false,
+    loan_amount: 600000,
+    interest_rate: 6.2,
+  });
+
+  useEffect(() => {
+    if (!persistHydrated) return;
+    if (typeof persistedInputs.purchase_price === "number") setPurchasePrice(persistedInputs.purchase_price);
+    if (typeof persistedInputs.weekly_rent === "number") setWeeklyRent(persistedInputs.weekly_rent);
+    if (typeof persistedInputs.council_rates === "number") setCouncilRates(persistedInputs.council_rates);
+    if (typeof persistedInputs.insurance === "number") setInsurance(persistedInputs.insurance);
+    if (typeof persistedInputs.maintenance === "number") setMaintenance(persistedInputs.maintenance);
+    if (typeof persistedInputs.management_pct === "number") setManagementPct(persistedInputs.management_pct);
+    if (typeof persistedInputs.strata === "number") setStrata(persistedInputs.strata);
+    if (typeof persistedInputs.other_expenses === "number") setOtherExpenses(persistedInputs.other_expenses);
+    if (typeof persistedInputs.show_mortgage === "boolean") setShowMortgage(persistedInputs.show_mortgage);
+    if (typeof persistedInputs.loan_amount === "number") setLoanAmount(persistedInputs.loan_amount);
+    if (typeof persistedInputs.interest_rate === "number") setInterestRate(persistedInputs.interest_rate);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- hydrate once
+  }, [persistHydrated]);
+
+  useEffect(() => {
+    setPersistedInputs({
+      purchase_price: purchasePrice,
+      weekly_rent: weeklyRent,
+      council_rates: councilRates,
+      insurance,
+      maintenance,
+      management_pct: managementPct,
+      strata,
+      other_expenses: otherExpenses,
+      show_mortgage: showMortgage,
+      loan_amount: loanAmount,
+      interest_rate: interestRate,
+    });
+  }, [purchasePrice, weeklyRent, councilRates, insurance, maintenance, managementPct, strata, otherExpenses, showMortgage, loanAmount, interestRate, setPersistedInputs]);
 
   useEffect(() => { trackPageDuration("/property-yield-calculator"); }, []);
 

--- a/app/retirement-calculator/RetirementCalculatorClient.tsx
+++ b/app/retirement-calculator/RetirementCalculatorClient.tsx
@@ -9,6 +9,7 @@ import { getStoredUtm } from "@/components/UtmCapture";
 import { storeQualificationData } from "@/lib/qualification-store";
 import AdvisorMatchCTA from "@/components/AdvisorMatchCTA";
 import { formatCurrency } from "@/lib/utils";
+import { useCalculatorState } from "@/hooks/use-calculator-state";
 
 export default function RetirementCalculatorClient() {
   const [currentAge, setCurrentAge] = useState(35);
@@ -24,6 +25,60 @@ export default function RetirementCalculatorClient() {
   const [emailGated, setEmailGated] = useState(false);
   const [email, setEmail] = useState("");
   const [emailSubmitted, setEmailSubmitted] = useState(false);
+
+  const {
+    value: persistedInputs,
+    setValue: setPersistedInputs,
+    isHydrated: persistHydrated,
+  } = useCalculatorState<{
+    current_age: number;
+    retirement_age: number;
+    current_super: number;
+    annual_salary: number;
+    employer_rate: number;
+    additional_contributions: number;
+    expected_return: number;
+    inflation_rate: number;
+    desired_income: number;
+  }>("retirement_calculator", {
+    current_age: 35,
+    retirement_age: 67,
+    current_super: 150000,
+    annual_salary: 100000,
+    employer_rate: 12,
+    additional_contributions: 0,
+    expected_return: 7,
+    inflation_rate: 3,
+    desired_income: 60000,
+  });
+
+  useEffect(() => {
+    if (!persistHydrated) return;
+    if (typeof persistedInputs.current_age === "number") setCurrentAge(persistedInputs.current_age);
+    if (typeof persistedInputs.retirement_age === "number") setRetirementAge(persistedInputs.retirement_age);
+    if (typeof persistedInputs.current_super === "number") setCurrentSuper(persistedInputs.current_super);
+    if (typeof persistedInputs.annual_salary === "number") setAnnualSalary(persistedInputs.annual_salary);
+    if (typeof persistedInputs.employer_rate === "number") setEmployerRate(persistedInputs.employer_rate);
+    if (typeof persistedInputs.additional_contributions === "number") setAdditionalContributions(persistedInputs.additional_contributions);
+    if (typeof persistedInputs.expected_return === "number") setExpectedReturn(persistedInputs.expected_return);
+    if (typeof persistedInputs.inflation_rate === "number") setInflationRate(persistedInputs.inflation_rate);
+    if (typeof persistedInputs.desired_income === "number") setDesiredIncome(persistedInputs.desired_income);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- hydrate once
+  }, [persistHydrated]);
+
+  useEffect(() => {
+    setPersistedInputs({
+      current_age: currentAge,
+      retirement_age: retirementAge,
+      current_super: currentSuper,
+      annual_salary: annualSalary,
+      employer_rate: employerRate,
+      additional_contributions: additionalContributions,
+      expected_return: expectedReturn,
+      inflation_rate: inflationRate,
+      desired_income: desiredIncome,
+    });
+  }, [currentAge, retirementAge, currentSuper, annualSalary, employerRate, additionalContributions, expectedReturn, inflationRate, desiredIncome, setPersistedInputs]);
 
   useEffect(() => { trackPageDuration("/retirement-calculator"); }, []);
 

--- a/app/smsf-calculator/SMSFCalculatorClient.tsx
+++ b/app/smsf-calculator/SMSFCalculatorClient.tsx
@@ -7,6 +7,7 @@ import SocialProofCounter from "@/components/SocialProofCounter";
 import { trackEvent, trackPageDuration } from "@/lib/tracking";
 import { getStoredUtm } from "@/components/UtmCapture";
 import { formatCurrency } from "@/lib/utils";
+import { useCalculatorState } from "@/hooks/use-calculator-state";
 
 /* ── helpers ── */
 
@@ -58,6 +59,44 @@ export default function SMSFCalculatorClient() {
   const [emailGated, setEmailGated] = useState(false);
   const [email, setEmail] = useState("");
   const [emailSubmitted, setEmailSubmitted] = useState(false);
+
+  const {
+    value: persistedInputs,
+    setValue: setPersistedInputs,
+    isHydrated: persistHydrated,
+  } = useCalculatorState<{
+    balance: number;
+    annual_contribution: number;
+    current_fee_percent: number;
+    expected_return: number;
+    years_to_retirement: number;
+  }>("smsf_calculator", {
+    balance: 300_000,
+    annual_contribution: 27_500,
+    current_fee_percent: 1.2,
+    expected_return: 7,
+    years_to_retirement: 20,
+  });
+
+  useEffect(() => {
+    if (!persistHydrated) return;
+    if (typeof persistedInputs.balance === "number") setBalance(persistedInputs.balance);
+    if (typeof persistedInputs.annual_contribution === "number") setAnnualContribution(persistedInputs.annual_contribution);
+    if (typeof persistedInputs.current_fee_percent === "number") setCurrentFeePercent(persistedInputs.current_fee_percent);
+    if (typeof persistedInputs.expected_return === "number") setExpectedReturn(persistedInputs.expected_return);
+    if (typeof persistedInputs.years_to_retirement === "number") setYearsToRetirement(persistedInputs.years_to_retirement);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- hydrate once
+  }, [persistHydrated]);
+
+  useEffect(() => {
+    setPersistedInputs({
+      balance,
+      annual_contribution: annualContribution,
+      current_fee_percent: currentFeePercent,
+      expected_return: expectedReturn,
+      years_to_retirement: yearsToRetirement,
+    });
+  }, [balance, annualContribution, currentFeePercent, expectedReturn, yearsToRetirement, setPersistedInputs]);
 
   useEffect(() => { trackPageDuration("/smsf-calculator"); }, []);
 

--- a/app/super-contributions-calculator/SuperContributionsClient.tsx
+++ b/app/super-contributions-calculator/SuperContributionsClient.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import Link from "next/link";
 import { formatCurrency } from "@/lib/utils";
 import { formatPercent } from "@/lib/tracking";
+import { useCalculatorState } from "@/hooks/use-calculator-state";
 
 /* ── constants (FY2026) ── */
 
@@ -37,6 +38,48 @@ export default function SuperContributionsClient() {
   const [nonConcessional, setNonConcessional] = useState(0);
   const [superBalance, setSuperBalance] = useState(150_000);
   const [unusedCarryForward, setUnusedCarryForward] = useState(0);
+
+  const {
+    value: persistedInputs,
+    setValue: setPersistedInputs,
+    isHydrated: persistHydrated,
+  } = useCalculatorState<{
+    income: number;
+    current_concessional: number;
+    extra_concessional: number;
+    non_concessional: number;
+    super_balance: number;
+    unused_carry_forward: number;
+  }>("super_contributions_calculator", {
+    income: 90_000,
+    current_concessional: 12_000,
+    extra_concessional: 5_000,
+    non_concessional: 0,
+    super_balance: 150_000,
+    unused_carry_forward: 0,
+  });
+
+  useEffect(() => {
+    if (!persistHydrated) return;
+    if (typeof persistedInputs.income === "number") setIncome(persistedInputs.income);
+    if (typeof persistedInputs.current_concessional === "number") setCurrentConcessional(persistedInputs.current_concessional);
+    if (typeof persistedInputs.extra_concessional === "number") setExtraConcessional(persistedInputs.extra_concessional);
+    if (typeof persistedInputs.non_concessional === "number") setNonConcessional(persistedInputs.non_concessional);
+    if (typeof persistedInputs.super_balance === "number") setSuperBalance(persistedInputs.super_balance);
+    if (typeof persistedInputs.unused_carry_forward === "number") setUnusedCarryForward(persistedInputs.unused_carry_forward);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- hydrate once
+  }, [persistHydrated]);
+
+  useEffect(() => {
+    setPersistedInputs({
+      income,
+      current_concessional: currentConcessional,
+      extra_concessional: extraConcessional,
+      non_concessional: nonConcessional,
+      super_balance: superBalance,
+      unused_carry_forward: unusedCarryForward,
+    });
+  }, [income, currentConcessional, extraConcessional, nonConcessional, superBalance, unusedCarryForward, setPersistedInputs]);
 
   const result = useMemo(() => {
     const totalConcessional = currentConcessional + extraConcessional;


### PR DESCRIPTION
## Summary
- Wires super-contributions, dividend-reinvestment, retirement, smsf, and property-yield calculators to the cross-calc persistence layer shipped in W2 Phase 1
- Each retrofit follows the same shape: typed shadow of local useState via useCalculatorState, one-shot hydration on mount, debounced live-sync on input change
- 5 of 21 remaining calcs retrofitted; portfolio + debt (array state) deferred to a later batch with custom shape handling

## Test plan
- [x] Type-check passes (npx tsc --noEmit)
- [x] Pre-push hooks pass
- [ ] CI green
- [ ] Manual: open each retrofitted calc, change inputs, refresh — values restore from sessionStorage
- [ ] Manual: sign in, verify user_calculator_state.state contains the new keys (super_contributions_calculator, dividend_reinvestment_calculator, retirement_calculator, smsf_calculator, property_yield_calculator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)