### PR TITLE
feat(calc): retrofit 5 more calculators to useCalculatorState (Batch 2)

### DIFF
--- a/app/dividends/calculator/FrankingCalculatorClient.tsx
+++ b/app/dividends/calculator/FrankingCalculatorClient.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import Link from "next/link";
 import Icon from "@/components/Icon";
 import { formatAUD } from "@/lib/currency";
+import { useCalculatorState } from "@/hooks/use-calculator-state";
 
 const TAX_RATES: Array<{ id: string; label: string; rate: number; isSmsf?: boolean; pension?: boolean }> = [
   { id: "0",        label: "0% — under threshold",   rate: 0 },
@@ -21,6 +22,32 @@ export default function FrankingCalculatorClient() {
   const [dividend, setDividend] = useState<number>(1_000);
   const [frankingPct, setFrankingPct] = useState<number>(100);
   const [taxRateId, setTaxRateId] = useState<string>("30");
+
+  const {
+    value: persistedInputs,
+    setValue: setPersistedInputs,
+    isHydrated: persistHydrated,
+  } = useCalculatorState<{
+    dividend: number;
+    franking_pct: number;
+    tax_rate_id: string;
+  }>("dividends_franking_calculator", {
+    dividend: 1_000,
+    franking_pct: 100,
+    tax_rate_id: "30",
+  });
+
+  useEffect(() => {
+    if (!persistHydrated) return;
+    if (typeof persistedInputs.dividend === "number") setDividend(persistedInputs.dividend);
+    if (typeof persistedInputs.franking_pct === "number") setFrankingPct(persistedInputs.franking_pct);
+    if (typeof persistedInputs.tax_rate_id === "string") setTaxRateId(persistedInputs.tax_rate_id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- hydrate once
+  }, [persistHydrated]);
+
+  useEffect(() => {
+    setPersistedInputs({ dividend, franking_pct: frankingPct, tax_rate_id: taxRateId });
+  }, [dividend, frankingPct, taxRateId, setPersistedInputs]);
 
   const calc = useMemo(() => {
     const tr = TAX_RATES.find((r) => r.id === taxRateId) || TAX_RATES[2]!;

--- a/app/lump-sum-investing/calculator/LumpSumCalculatorClient.tsx
+++ b/app/lump-sum-investing/calculator/LumpSumCalculatorClient.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import HubLeadForm from "@/components/leads/HubLeadForm";
 import { formatAUD } from "@/lib/currency";
+import { useCalculatorState } from "@/hooks/use-calculator-state";
 
 const TAX_OPTIONS = [
   { id: "none",   label: "No tax (super pension)",  rate: 0 },
@@ -38,6 +39,38 @@ export default function LumpSumCalculatorClient() {
   const [returnRate, setReturnRate] = useState<number>(7);
   const [years, setYears] = useState<number>(15);
   const [taxId, setTaxId] = useState<string>("32.5");
+
+  const {
+    value: persistedInputs,
+    setValue: setPersistedInputs,
+    isHydrated: persistHydrated,
+  } = useCalculatorState<{
+    lump_sum: number;
+    monthly: number;
+    return_rate: number;
+    years: number;
+    tax_id: string;
+  }>("lump_sum_calculator", {
+    lump_sum: 100_000,
+    monthly: 0,
+    return_rate: 7,
+    years: 15,
+    tax_id: "32.5",
+  });
+
+  useEffect(() => {
+    if (!persistHydrated) return;
+    if (typeof persistedInputs.lump_sum === "number") setLumpSum(persistedInputs.lump_sum);
+    if (typeof persistedInputs.monthly === "number") setMonthly(persistedInputs.monthly);
+    if (typeof persistedInputs.return_rate === "number") setReturnRate(persistedInputs.return_rate);
+    if (typeof persistedInputs.years === "number") setYears(persistedInputs.years);
+    if (typeof persistedInputs.tax_id === "string") setTaxId(persistedInputs.tax_id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- hydrate once
+  }, [persistHydrated]);
+
+  useEffect(() => {
+    setPersistedInputs({ lump_sum: lumpSum, monthly, return_rate: returnRate, years, tax_id: taxId });
+  }, [lumpSum, monthly, returnRate, years, taxId, setPersistedInputs]);
 
   const tax = useMemo(() => TAX_OPTIONS.find((t) => t.id === taxId) || TAX_OPTIONS[2]!, [taxId]);
 

--- a/app/negative-gearing/calculator/NegativeGearingCalculatorClient.tsx
+++ b/app/negative-gearing/calculator/NegativeGearingCalculatorClient.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import HubLeadForm from "@/components/leads/HubLeadForm";
 import { formatAUD } from "@/lib/currency";
+import { useCalculatorState } from "@/hooks/use-calculator-state";
 
 const TAX_RATES = [
   { label: "0% — under threshold", rate: 0 },
@@ -19,6 +20,48 @@ export default function NegativeGearingCalculatorClient() {
   const [otherCosts, setOtherCosts] = useState<number>(7_000);
   const [marginalRate, setMarginalRate] = useState<number>(0.37);
   const [growthRate, setGrowthRate] = useState<number>(4);
+
+  const {
+    value: persistedInputs,
+    setValue: setPersistedInputs,
+    isHydrated: persistHydrated,
+  } = useCalculatorState<{
+    property_value: number;
+    rental_income: number;
+    interest: number;
+    other_costs: number;
+    marginal_rate: number;
+    growth_rate: number;
+  }>("negative_gearing_calculator", {
+    property_value: 850_000,
+    rental_income: 28_000,
+    interest: 35_000,
+    other_costs: 7_000,
+    marginal_rate: 0.37,
+    growth_rate: 4,
+  });
+
+  useEffect(() => {
+    if (!persistHydrated) return;
+    if (typeof persistedInputs.property_value === "number") setPropertyValue(persistedInputs.property_value);
+    if (typeof persistedInputs.rental_income === "number") setRentalIncome(persistedInputs.rental_income);
+    if (typeof persistedInputs.interest === "number") setInterest(persistedInputs.interest);
+    if (typeof persistedInputs.other_costs === "number") setOtherCosts(persistedInputs.other_costs);
+    if (typeof persistedInputs.marginal_rate === "number") setMarginalRate(persistedInputs.marginal_rate);
+    if (typeof persistedInputs.growth_rate === "number") setGrowthRate(persistedInputs.growth_rate);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- hydrate once
+  }, [persistHydrated]);
+
+  useEffect(() => {
+    setPersistedInputs({
+      property_value: propertyValue,
+      rental_income: rentalIncome,
+      interest,
+      other_costs: otherCosts,
+      marginal_rate: marginalRate,
+      growth_rate: growthRate,
+    });
+  }, [propertyValue, rentalIncome, interest, otherCosts, marginalRate, growthRate, setPersistedInputs]);
 
   const calc = useMemo(() => {
     const totalCosts = interest + otherCosts;

--- a/app/non-resident-dividend-calculator/NonResidentDividendClient.tsx
+++ b/app/non-resident-dividend-calculator/NonResidentDividendClient.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import Link from "next/link";
 import Icon from "@/components/Icon";
+import { useCalculatorState } from "@/hooks/use-calculator-state";
 
 /**
  * Non-resident Australian dividend calculator
@@ -61,6 +62,32 @@ export default function NonResidentDividendClient() {
   const [dividend, setDividend] = useState<string>("10000");
   const [frankingPct, setFrankingPct] = useState<number>(100);
   const [countryCode, setCountryCode] = useState<string>("US");
+
+  const {
+    value: persistedInputs,
+    setValue: setPersistedInputs,
+    isHydrated: persistHydrated,
+  } = useCalculatorState<{
+    dividend: string;
+    franking_pct: number;
+    country_code: string;
+  }>("non_resident_dividend_calculator", {
+    dividend: "10000",
+    franking_pct: 100,
+    country_code: "US",
+  });
+
+  useEffect(() => {
+    if (!persistHydrated) return;
+    if (typeof persistedInputs.dividend === "string") setDividend(persistedInputs.dividend);
+    if (typeof persistedInputs.franking_pct === "number") setFrankingPct(persistedInputs.franking_pct);
+    if (typeof persistedInputs.country_code === "string") setCountryCode(persistedInputs.country_code);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- hydrate once
+  }, [persistHydrated]);
+
+  useEffect(() => {
+    setPersistedInputs({ dividend, franking_pct: frankingPct, country_code: countryCode });
+  }, [dividend, frankingPct, countryCode, setPersistedInputs]);
 
   const country = COUNTRIES.find((c) => c.code === countryCode) || COUNTRIES[0]!;
   const dividendNum = Math.max(0, parseFloat(dividend) || 0);

--- a/app/property-vs-shares-calculator/PropertyVsSharesClient.tsx
+++ b/app/property-vs-shares-calculator/PropertyVsSharesClient.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import Link from "next/link";
+import { useCalculatorState } from "@/hooks/use-calculator-state";
 
 const MORTGAGE_RATE = 0.065; // 6.5% assumption
 
@@ -20,6 +21,52 @@ export default function PropertyVsSharesClient() {
   const [holdingCosts, setHoldingCosts] = useState(1.5);
   const [sharesReturn, setSharesReturn] = useState(9);
   const [years, setYears] = useState(10);
+
+  const {
+    value: persistedInputs,
+    setValue: setPersistedInputs,
+    isHydrated: persistHydrated,
+  } = useCalculatorState<{
+    deposit: number;
+    property_value: number;
+    property_growth: number;
+    rental_yield: number;
+    holding_costs: number;
+    shares_return: number;
+    years: number;
+  }>("property_vs_shares_calculator", {
+    deposit: 150_000,
+    property_value: 750_000,
+    property_growth: 5,
+    rental_yield: 3.5,
+    holding_costs: 1.5,
+    shares_return: 9,
+    years: 10,
+  });
+
+  useEffect(() => {
+    if (!persistHydrated) return;
+    if (typeof persistedInputs.deposit === "number") setDeposit(persistedInputs.deposit);
+    if (typeof persistedInputs.property_value === "number") setPropertyValue(persistedInputs.property_value);
+    if (typeof persistedInputs.property_growth === "number") setPropertyGrowth(persistedInputs.property_growth);
+    if (typeof persistedInputs.rental_yield === "number") setRentalYield(persistedInputs.rental_yield);
+    if (typeof persistedInputs.holding_costs === "number") setHoldingCosts(persistedInputs.holding_costs);
+    if (typeof persistedInputs.shares_return === "number") setSharesReturn(persistedInputs.shares_return);
+    if (typeof persistedInputs.years === "number") setYears(persistedInputs.years);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- hydrate once
+  }, [persistHydrated]);
+
+  useEffect(() => {
+    setPersistedInputs({
+      deposit,
+      property_value: propertyValue,
+      property_growth: propertyGrowth,
+      rental_yield: rentalYield,
+      holding_costs: holdingCosts,
+      shares_return: sharesReturn,
+      years,
+    });
+  }, [deposit, propertyValue, propertyGrowth, rentalYield, holdingCosts, sharesReturn, years, setPersistedInputs]);
 
   const result = useMemo(() => {
     const dep = deposit;


### PR DESCRIPTION
## Summary
- Wires property-vs-shares, non-resident-dividend, dividends/calculator, negative-gearing, and lump-sum-investing calculators to the cross-calc persistence layer
- Same shape as Batch 1 (#785): typed shadow of local useState via useCalculatorState, one-shot hydration on mount, debounced live-sync on input change
- 10 of 21 calculators now retrofitted; remaining 11 deferred to Batch 3 (URL-sync conflict resolution + wizard / array state)

## Test plan
- [x] Type-check passes
- [x] Pre-push hooks pass
- [ ] CI green
- [ ] Manual: open each retrofitted calc, change inputs, refresh — values restore
- [ ] Manual: sign in, verify user_calculator_state.state contains the new keys (property_vs_shares_calculator, non_resident_dividend_calculator, dividends_franking_calculator, negative_gearing_calculator, lump_sum_calculator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)