### PR TITLE
feat(calc): retrofit portfolio, debt, and non-resident-cgt-checker (Batch 3a)

### DIFF
--- a/app/debt-calculator/DebtCalculatorClient.tsx
+++ b/app/debt-calculator/DebtCalculatorClient.tsx
@@ -9,6 +9,7 @@ import { trackEvent, trackPageDuration } from "@/lib/tracking";
 import { getStoredUtm } from "@/components/UtmCapture";
 import { storeQualificationData } from "@/lib/qualification-store";
 import { formatCurrency } from "@/lib/utils";
+import { useCalculatorState } from "@/hooks/use-calculator-state";
 
 type DebtType = "credit_card" | "personal_loan" | "car_loan" | "hecs" | "other";
 
@@ -97,10 +98,12 @@ interface Results {
 
 let nextDebtId = 2;
 
+const DEFAULT_DEBTS: Debt[] = [
+  { id: 1, type: "credit_card", balance: 8000, rate: 20, minPayment: 200 },
+];
+
 export default function DebtCalculatorClient() {
-  const [debts, setDebts] = useState<Debt[]>([
-    { id: 1, type: "credit_card", balance: 8000, rate: 20, minPayment: 200 },
-  ]);
+  const [debts, setDebts] = useState<Debt[]>(DEFAULT_DEBTS);
   const [consolidationRate, setConsolidationRate] = useState(8);
   const [consolidationTerm, setConsolidationTerm] = useState(5);
   const [showResults, setShowResults] = useState(false);
@@ -108,6 +111,36 @@ export default function DebtCalculatorClient() {
   const [emailGated, setEmailGated] = useState(false);
   const [email, setEmail] = useState("");
   const [emailSubmitted, setEmailSubmitted] = useState(false);
+
+  const {
+    value: persistedInputs,
+    setValue: setPersistedInputs,
+    isHydrated: persistHydrated,
+  } = useCalculatorState<{
+    debts: Debt[];
+    consolidation_rate: number;
+    consolidation_term: number;
+  }>("debt_calculator", {
+    debts: DEFAULT_DEBTS,
+    consolidation_rate: 8,
+    consolidation_term: 5,
+  });
+
+  useEffect(() => {
+    if (!persistHydrated) return;
+    if (Array.isArray(persistedInputs.debts) && persistedInputs.debts.length > 0) {
+      setDebts(persistedInputs.debts);
+      const maxId = Math.max(...persistedInputs.debts.map((d) => d.id), 1);
+      nextDebtId = maxId + 1;
+    }
+    if (typeof persistedInputs.consolidation_rate === "number") setConsolidationRate(persistedInputs.consolidation_rate);
+    if (typeof persistedInputs.consolidation_term === "number") setConsolidationTerm(persistedInputs.consolidation_term);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- hydrate once
+  }, [persistHydrated]);
+
+  useEffect(() => {
+    setPersistedInputs({ debts, consolidation_rate: consolidationRate, consolidation_term: consolidationTerm });
+  }, [debts, consolidationRate, consolidationTerm, setPersistedInputs]);
 
   useEffect(() => { trackPageDuration("/debt-calculator"); }, []);
 

--- a/app/non-resident-cgt-checker/NonResidentCgtClient.tsx
+++ b/app/non-resident-cgt-checker/NonResidentCgtClient.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Link from "next/link";
 import Icon from "@/components/Icon";
+import { useCalculatorState } from "@/hooks/use-calculator-state";
 
 /**
  * Non-resident CGT exemption checker
@@ -59,6 +60,36 @@ export default function NonResidentCgtClient() {
   const [step, setStep] = useState(0);
   const [assetType, setAssetType] = useState<AssetType | null>(null);
   const [stake, setStake] = useState<StakePct | null>(null);
+
+  const {
+    value: persistedInputs,
+    setValue: setPersistedInputs,
+    isHydrated: persistHydrated,
+  } = useCalculatorState<{
+    step: number;
+    asset_type: AssetType | null;
+    stake: StakePct | null;
+  }>("non_resident_cgt_checker", {
+    step: 0,
+    asset_type: null,
+    stake: null,
+  });
+
+  useEffect(() => {
+    if (!persistHydrated) return;
+    if (typeof persistedInputs.step === "number") setStep(persistedInputs.step);
+    if (persistedInputs.asset_type === null || typeof persistedInputs.asset_type === "string") {
+      setAssetType(persistedInputs.asset_type as AssetType | null);
+    }
+    if (persistedInputs.stake === null || typeof persistedInputs.stake === "string") {
+      setStake(persistedInputs.stake as StakePct | null);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- hydrate once
+  }, [persistHydrated]);
+
+  useEffect(() => {
+    setPersistedInputs({ step, asset_type: assetType, stake });
+  }, [step, assetType, stake, setPersistedInputs]);
 
   function reset() {
     setStep(0);

--- a/app/portfolio-calculator/PortfolioCalculatorClient.tsx
+++ b/app/portfolio-calculator/PortfolioCalculatorClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import Link from "next/link";
 import Icon from "@/components/Icon";
 import { trackClick, trackEvent, getAffiliateLink, AFFILIATE_REL } from "@/lib/tracking";
@@ -10,6 +10,7 @@ import LeadMagnet from "@/components/LeadMagnet";
 import AdvisorPrompt from "@/components/AdvisorPrompt";
 import { storeQualificationData } from "@/lib/qualification-store";
 import AdvisorMatchCTA from "@/components/AdvisorMatchCTA";
+import { useCalculatorState } from "@/hooks/use-calculator-state";
 
 type Holding = {
   id: string;
@@ -18,14 +19,41 @@ type Holding = {
   avg_trade_size: number;
 };
 
+const DEFAULT_HOLDINGS: Holding[] = [
+  { id: "1", market: "asx", trades_per_year: 12, avg_trade_size: 2000 },
+];
+
 export default function PortfolioCalculatorClient({ brokers, inline }: { brokers: Broker[]; inline?: boolean }) {
-  const [holdings, setHoldings] = useState<Holding[]>([
-    { id: "1", market: "asx", trades_per_year: 12, avg_trade_size: 2000 },
-  ]);
+  const [holdings, setHoldings] = useState<Holding[]>(DEFAULT_HOLDINGS);
   const [currentBroker, setCurrentBroker] = useState("");
   const [showResults, setShowResults] = useState(false);
   const [email, setEmail] = useState("");
   const [emailCaptured, setEmailCaptured] = useState(false);
+
+  const {
+    value: persistedInputs,
+    setValue: setPersistedInputs,
+    isHydrated: persistHydrated,
+  } = useCalculatorState<{
+    holdings: Holding[];
+    current_broker: string;
+  }>("portfolio_calculator", {
+    holdings: DEFAULT_HOLDINGS,
+    current_broker: "",
+  });
+
+  useEffect(() => {
+    if (!persistHydrated) return;
+    if (Array.isArray(persistedInputs.holdings) && persistedInputs.holdings.length > 0) {
+      setHoldings(persistedInputs.holdings);
+    }
+    if (typeof persistedInputs.current_broker === "string") setCurrentBroker(persistedInputs.current_broker);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- hydrate once
+  }, [persistHydrated]);
+
+  useEffect(() => {
+    setPersistedInputs({ holdings, current_broker: currentBroker });
+  }, [holdings, currentBroker, setPersistedInputs]);
 
   const addHolding = () => {
     setHoldings([...holdings, {


### PR DESCRIPTION
## Summary
- Handles the array-state and wizard-state calcs that Batch 1 (#785) and Batch 2 (#786) deferred
- portfolio-calculator: Holding[]
- debt-calculator: Debt[] (preserves nextDebtId across hydration)
- non-resident-cgt-checker: step + nullable AssetType/StakePct (wizard resumes mid-flow)
- 13 of 21 calculators now retrofitted; remaining 8 use URL-sync and land in Batch 3b

## Test plan
- [x] Type-check passes (npx tsc --noEmit)
- [ ] CI green
- [ ] Manual: open each calc, change inputs, refresh — values restore
- [ ] Manual: sign in, verify user_calculator_state.state contains: portfolio_calculator, debt_calculator, non_resident_cgt_checker

🤖 Generated with [Claude Code](https://claude.com/claude-code)