### PR TITLE
feat(calc): lead-capture funnel beneath every calculator's results (W1.2)

### DIFF
--- a/__tests__/components/CalculatorLeadCapture.test.tsx
+++ b/__tests__/components/CalculatorLeadCapture.test.tsx
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "./setup";
+import CalculatorLeadCapture from "@/components/CalculatorLeadCapture";
+
+interface CapturedHubProps {
+  heading: string;
+  subheading?: string;
+  intent: { need: string; context?: string[] };
+  source: string;
+  ctaLabel?: string;
+}
+
+const capturedProps: { value: CapturedHubProps | null } = { value: null };
+
+vi.mock("@/components/leads/HubLeadForm", () => ({
+  default: (props: CapturedHubProps) => {
+    capturedProps.value = props;
+    return (
+      <div data-testid="hub-lead-form">
+        <span data-testid="heading">{props.heading}</span>
+        <span data-testid="subheading">{props.subheading}</span>
+        <span data-testid="source">{props.source}</span>
+        <span data-testid="cta">{props.ctaLabel}</span>
+      </div>
+    );
+  },
+}));
+
+describe("CalculatorLeadCapture", () => {
+  it("forwards the standard heading + CTA copy to HubLeadForm", () => {
+    render(
+      <CalculatorLeadCapture
+        calcSlug="cgt-calculator"
+        calcTitle="CGT"
+        need="tax"
+      />,
+    );
+
+    expect(screen.getByTestId("heading")).toHaveTextContent(
+      "Save these results — get a free 15-minute review",
+    );
+    expect(screen.getByTestId("cta")).toHaveTextContent("Get my free review");
+  });
+
+  it("includes the calculator title in the subheading", () => {
+    render(
+      <CalculatorLeadCapture
+        calcSlug="mortgage-calculator"
+        calcTitle="mortgage repayment"
+        need="mortgage"
+      />,
+    );
+
+    expect(screen.getByTestId("subheading")).toHaveTextContent(
+      /mortgage repayment numbers/,
+    );
+  });
+
+  it("tags source_page with the calculator slug so analytics can isolate calc-driven leads", () => {
+    render(
+      <CalculatorLeadCapture
+        calcSlug="smsf-calculator"
+        calcTitle="SMSF cost"
+        need="smsf"
+      />,
+    );
+
+    expect(screen.getByTestId("source")).toHaveTextContent(
+      "/calculator-leadbox|calc=smsf-calculator",
+    );
+  });
+
+  it("passes need + contextKeys through to the lead intent", () => {
+    render(
+      <CalculatorLeadCapture
+        calcSlug="cgt-calculator"
+        calcTitle="CGT"
+        need="tax"
+        contextKeys={["cgt", "tax-planning"]}
+      />,
+    );
+
+    expect(capturedProps.value?.intent).toEqual({
+      need: "tax",
+      context: ["cgt", "tax-planning"],
+    });
+  });
+
+  it("omits the context field entirely when no contextKeys are supplied", () => {
+    render(
+      <CalculatorLeadCapture
+        calcSlug="compound-interest-calculator"
+        calcTitle="compound interest"
+        need="planning"
+      />,
+    );
+
+    expect(capturedProps.value?.intent).toEqual({ need: "planning" });
+    expect(capturedProps.value?.intent.context).toBeUndefined();
+  });
+
+  it("omits context when contextKeys is an empty array (defensive — empty arrays would survive JSON)", () => {
+    render(
+      <CalculatorLeadCapture
+        calcSlug="fire-calculator"
+        calcTitle="FIRE projection"
+        need="planning"
+        contextKeys={[]}
+      />,
+    );
+
+    expect(capturedProps.value?.intent).toEqual({ need: "planning" });
+  });
+
+  it("renders the wrapper div with the testid hook used by mounted-on-pages assertions", () => {
+    render(
+      <CalculatorLeadCapture
+        calcSlug="cgt-calculator"
+        calcTitle="CGT"
+        need="tax"
+      />,
+    );
+
+    expect(screen.getByTestId("calculator-lead-capture")).toBeInTheDocument();
+    // Hub form is mounted inside it
+    expect(screen.getByTestId("hub-lead-form")).toBeInTheDocument();
+  });
+});

--- a/app/cgt-calculator/CgtClient.tsx
+++ b/app/cgt-calculator/CgtClient.tsx
@@ -4,6 +4,7 @@ import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import Icon from "@/components/Icon";
 import CgtCalculator from "@/app/calculators/_components/CgtCalculator";
+import CalculatorLeadCapture from "@/components/CalculatorLeadCapture";
 
 export default function CgtClient() {
   const searchParams = useSearchParams();
@@ -40,6 +41,13 @@ export default function CgtClient() {
         </div>
 
         <CgtCalculator searchParams={searchParams} />
+
+        <CalculatorLeadCapture
+          calcSlug="cgt-calculator"
+          calcTitle="CGT"
+          need="tax"
+          contextKeys={["cgt", "tax-planning"]}
+        />
 
         <div className="mt-8 md:mt-12 space-y-6">
           <div className="bg-white border border-slate-200 rounded-xl p-5 md:p-6">

--- a/app/cgt-calculator/CgtClient.tsx
+++ b/app/cgt-calculator/CgtClient.tsx
@@ -82,7 +82,7 @@ export default function CgtClient() {
               <p>
                 <strong className="text-slate-900">Common exemptions:</strong> Your main residence is generally CGT-exempt.
                 Personal use assets under $10,000 are exempt. Collectibles under $500 are exempt. Pre-CGT assets (acquired
-                before 20 September 1985) are exempt. Superannuation is taxed separately under its own rules. And losses can
+                before 20 September 1985) are exempt. Superannuation is taxed separately under its own rules. And losses can {/* // dated-ok — legal definition of pre-CGT assets, will never change */}
                 be carried forward indefinitely to offset future gains.
               </p>
             </div>

--- a/app/compound-interest-calculator/CompoundInterestClient.tsx
+++ b/app/compound-interest-calculator/CompoundInterestClient.tsx
@@ -3,6 +3,7 @@
 import { useState, useMemo, useEffect } from "react";
 import Link from "next/link";
 import { useCalculatorState } from "@/hooks/use-calculator-state";
+import CalculatorLeadCapture from "@/components/CalculatorLeadCapture";
 
 const FREQ_OPTIONS = [
   { label: "Monthly", value: 12 },
@@ -276,6 +277,13 @@ export default function CompoundInterestClient() {
             </div>
           </div>
         </div>
+
+        <CalculatorLeadCapture
+          calcSlug="compound-interest-calculator"
+          calcTitle="compound interest"
+          need="planning"
+          contextKeys={["compound-interest", "wealth-building"]}
+        />
 
         <p className="text-[0.65rem] text-slate-400 mt-8 leading-relaxed">
           This calculator provides general information only and does not constitute financial advice. Returns shown are projections only and are not guaranteed. Past performance is not indicative of future performance. Always seek independent financial advice before making investment decisions.

--- a/app/debt-calculator/DebtCalculatorClient.tsx
+++ b/app/debt-calculator/DebtCalculatorClient.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import Icon from "@/components/Icon";
 import SocialProofCounter from "@/components/SocialProofCounter";
 import AdvisorMatchCTA from "@/components/AdvisorMatchCTA";
+import CalculatorLeadCapture from "@/components/CalculatorLeadCapture";
 import { trackEvent, trackPageDuration } from "@/lib/tracking";
 import { getStoredUtm } from "@/components/UtmCapture";
 import { storeQualificationData } from "@/lib/qualification-store";
@@ -576,6 +577,13 @@ export default function DebtCalculatorClient() {
                 description="A debt advisor can negotiate with creditors, restructure repayments, and create a plan to get you debt-free faster."
               />
             </div>
+
+            <CalculatorLeadCapture
+              calcSlug="debt-calculator"
+              calcTitle="debt consolidation"
+              need="planning"
+              contextKeys={["debt-payoff", "consolidation"]}
+            />
 
             {/* SEO content */}
             <div className="bg-white border border-slate-200 rounded-2xl p-5 md:p-8">

--- a/app/dividend-reinvestment-calculator/DividendReinvestmentClient.tsx
+++ b/app/dividend-reinvestment-calculator/DividendReinvestmentClient.tsx
@@ -3,6 +3,7 @@
 import { useState, useMemo, useEffect } from "react";
 import Link from "next/link";
 import { useCalculatorState } from "@/hooks/use-calculator-state";
+import CalculatorLeadCapture from "@/components/CalculatorLeadCapture";
 
 function fmt(n: number) {
   return new Intl.NumberFormat("en-AU", { style: "currency", currency: "AUD", maximumFractionDigits: 0 }).format(n);
@@ -290,6 +291,13 @@ export default function DividendReinvestmentClient() {
             </div>
           </div>
         </div>
+
+        <CalculatorLeadCapture
+          calcSlug="dividend-reinvestment-calculator"
+          calcTitle="DRP projection"
+          need="wealth"
+          contextKeys={["dividend-reinvestment", "drp"]}
+        />
 
         <p className="text-[0.65rem] text-slate-400 mt-8 leading-relaxed">
           This calculator provides general information only and does not constitute financial advice. Projections assume constant dividend yield and share price growth, which will vary in practice. Dividends received via DRP are still assessable income in Australia. Always verify your tax position with a registered tax agent.

--- a/app/fire-calculator/FireCalculatorClient.tsx
+++ b/app/fire-calculator/FireCalculatorClient.tsx
@@ -3,6 +3,7 @@
 import { useState, useMemo, useEffect } from "react";
 import Link from "next/link";
 import { useCalculatorState } from "@/hooks/use-calculator-state";
+import CalculatorLeadCapture from "@/components/CalculatorLeadCapture";
 
 function fmt(n: number) {
   return new Intl.NumberFormat("en-AU", { style: "currency", currency: "AUD", maximumFractionDigits: 0 }).format(n);
@@ -331,6 +332,13 @@ export default function FireCalculatorClient() {
             </div>
           </div>
         </div>
+
+        <CalculatorLeadCapture
+          calcSlug="fire-calculator"
+          calcTitle="FIRE projection"
+          need="planning"
+          contextKeys={["fire", "early-retirement"]}
+        />
 
         <p className="text-[0.65rem] text-slate-400 mt-8 leading-relaxed">
           This calculator provides general information only and does not constitute financial advice. Returns are not guaranteed and the 4% withdrawal rate is based on US historical data and may not reflect Australian market conditions. Speak with a licensed financial adviser before making retirement planning decisions.

--- a/app/franking-credits-calculator/FrankingClient.tsx
+++ b/app/franking-credits-calculator/FrankingClient.tsx
@@ -4,6 +4,7 @@ import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import Icon from "@/components/Icon";
 import FrankingCalculator from "@/app/calculators/_components/FrankingCalculator";
+import CalculatorLeadCapture from "@/components/CalculatorLeadCapture";
 
 export default function FrankingClient() {
   const searchParams = useSearchParams();
@@ -40,6 +41,13 @@ export default function FrankingClient() {
         </div>
 
         <FrankingCalculator searchParams={searchParams} />
+
+        <CalculatorLeadCapture
+          calcSlug="franking-credits-calculator"
+          calcTitle="franking credit"
+          need="tax"
+          contextKeys={["franking-credits", "dividend-tax"]}
+        />
 
         <div className="mt-8 md:mt-12 space-y-6">
           <div className="bg-white border border-slate-200 rounded-xl p-5 md:p-6">

--- a/app/mortgage-calculator/MortgageCalculatorClient.tsx
+++ b/app/mortgage-calculator/MortgageCalculatorClient.tsx
@@ -8,6 +8,7 @@ import { trackEvent, trackPageDuration } from "@/lib/tracking";
 import { getStoredUtm } from "@/components/UtmCapture";
 import { storeQualificationData } from "@/lib/qualification-store";
 import { useCalculatorState } from "@/hooks/use-calculator-state";
+import CalculatorLeadCapture from "@/components/CalculatorLeadCapture";
 
 /* ── helpers ─────────────────────────────────────────── */
 
@@ -192,7 +193,7 @@ export default function MortgageCalculatorClient() {
       <div className="bg-gradient-to-br from-rose-600 via-rose-700 to-rose-800 text-white py-8 md:py-14 px-4">
         <div className="container-custom max-w-3xl text-center">
           <h1 className="text-xl md:text-3xl font-extrabold mb-2">How much will your mortgage really cost?</h1>
-          <p className="text-sm md:text-base text-rose-100">Enter your loan details — we'll show you monthly repayments, total interest, and how rate changes affect the cost.</p>
+          <p className="text-sm md:text-base text-rose-100">Enter your loan details — we&apos;ll show you monthly repayments, total interest, and how rate changes affect the cost.</p>
           <div className="mt-3"><SocialProofCounter variant="badge" /></div>
         </div>
       </div>
@@ -433,6 +434,13 @@ export default function MortgageCalculatorClient() {
               needKey="mortgage"
               headline="Could a broker get you a better rate?"
               description="Mortgage brokers compare 30+ lenders to find you the lowest rate — their service is free, paid by lenders."
+            />
+
+            <CalculatorLeadCapture
+              calcSlug="mortgage-calculator"
+              calcTitle="mortgage repayment"
+              need="mortgage"
+              contextKeys={["mortgage", "home-loan"]}
             />
 
             {/* SEO content */}

--- a/app/non-resident-dividend-calculator/NonResidentDividendClient.tsx
+++ b/app/non-resident-dividend-calculator/NonResidentDividendClient.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo, useEffect } from "react";
 import Link from "next/link";
 import Icon from "@/components/Icon";
 import { useCalculatorState } from "@/hooks/use-calculator-state";
+import CalculatorLeadCapture from "@/components/CalculatorLeadCapture";
 
 /**
  * Non-resident Australian dividend calculator
@@ -283,6 +284,15 @@ export default function NonResidentDividendClient() {
                 </tbody>
               </table>
             </div>
+          </div>
+
+          <div className="mt-6">
+            <CalculatorLeadCapture
+              calcSlug="non-resident-dividend-calculator"
+              calcTitle="non-resident dividend"
+              need="tax"
+              contextKeys={["non-resident", "withholding-tax", "cross-border"]}
+            />
           </div>
         </div>
       </section>

--- a/app/portfolio-calculator/PortfolioCalculatorClient.tsx
+++ b/app/portfolio-calculator/PortfolioCalculatorClient.tsx
@@ -10,6 +10,7 @@ import LeadMagnet from "@/components/LeadMagnet";
 import AdvisorPrompt from "@/components/AdvisorPrompt";
 import { storeQualificationData } from "@/lib/qualification-store";
 import AdvisorMatchCTA from "@/components/AdvisorMatchCTA";
+import CalculatorLeadCapture from "@/components/CalculatorLeadCapture";
 import { useCalculatorState } from "@/hooks/use-calculator-state";
 
 type Holding = {
@@ -378,6 +379,13 @@ export default function PortfolioCalculatorClient({ brokers, inline }: { brokers
                 description="A tax agent can help you maximise deductions on brokerage, platform fees, and investment-related expenses."
               />
             </div>
+
+            <CalculatorLeadCapture
+              calcSlug="portfolio-calculator"
+              calcTitle="portfolio"
+              need="wealth"
+              contextKeys={["portfolio-construction", "asset-allocation"]}
+            />
 
             <LeadMagnet />
           </>

--- a/app/property-vs-shares-calculator/PropertyVsSharesClient.tsx
+++ b/app/property-vs-shares-calculator/PropertyVsSharesClient.tsx
@@ -3,6 +3,7 @@
 import { useState, useMemo, useEffect } from "react";
 import Link from "next/link";
 import { useCalculatorState } from "@/hooks/use-calculator-state";
+import CalculatorLeadCapture from "@/components/CalculatorLeadCapture";
 
 const MORTGAGE_RATE = 0.065; // 6.5% assumption
 
@@ -435,6 +436,13 @@ export default function PropertyVsSharesClient() {
             </div>
           </div>
         </div>
+
+        <CalculatorLeadCapture
+          calcSlug="property-vs-shares-calculator"
+          calcTitle="property vs shares"
+          need="planning"
+          contextKeys={["asset-allocation", "property-vs-shares"]}
+        />
 
         <p className="text-[0.65rem] text-slate-400 mt-8 leading-relaxed">
           This calculator provides general information only and does not constitute financial or property investment advice. Assumes a {(MORTGAGE_RATE * 100).toFixed(1)}% interest rate on a 30-year principal and interest loan. Property figures do not include stamp duty, conveyancing, property management fees or depreciation. Returns are not guaranteed. Always obtain independent advice before making investment decisions.

--- a/app/property-yield-calculator/PropertyYieldCalculatorClient.tsx
+++ b/app/property-yield-calculator/PropertyYieldCalculatorClient.tsx
@@ -8,6 +8,7 @@ import { trackEvent, trackPageDuration, formatPercent } from "@/lib/tracking";
 import { getStoredUtm } from "@/components/UtmCapture";
 import { formatCurrency } from "@/lib/utils";
 import { useCalculatorState } from "@/hooks/use-calculator-state";
+import CalculatorLeadCapture from "@/components/CalculatorLeadCapture";
 
 /* ─── helpers ─── */
 // formatPercent imported from lib/tracking; default 2 decimals matches old local impl.
@@ -454,6 +455,13 @@ export default function PropertyYieldCalculatorClient() {
               needKey="property"
               headline="Want expert help building a property portfolio?"
               description="A property investment advisor can help you find high-yield areas, structure ownership, and build a portfolio strategy."
+            />
+
+            <CalculatorLeadCapture
+              calcSlug="property-yield-calculator"
+              calcTitle="rental yield"
+              need="property"
+              contextKeys={["property-investment", "rental-yield"]}
             />
 
             {/* SEO content */}

--- a/app/retirement-calculator/RetirementCalculatorClient.tsx
+++ b/app/retirement-calculator/RetirementCalculatorClient.tsx
@@ -8,6 +8,7 @@ import { trackEvent, trackPageDuration } from "@/lib/tracking";
 import { getStoredUtm } from "@/components/UtmCapture";
 import { storeQualificationData } from "@/lib/qualification-store";
 import AdvisorMatchCTA from "@/components/AdvisorMatchCTA";
+import CalculatorLeadCapture from "@/components/CalculatorLeadCapture";
 import { formatCurrency } from "@/lib/utils";
 import { useCalculatorState } from "@/hooks/use-calculator-state";
 
@@ -444,6 +445,13 @@ export default function RetirementCalculatorClient() {
                 description="A financial planner builds a strategy around your goals, super, investments, and tax — so you can retire with confidence."
               />
             </div>
+
+            <CalculatorLeadCapture
+              calcSlug="retirement-calculator"
+              calcTitle="retirement projection"
+              need="planning"
+              contextKeys={["retirement", "super-planning"]}
+            />
 
             {/* SEO content */}
             <div className="bg-white border border-slate-200 rounded-2xl p-5 md:p-8">

--- a/app/savings-calculator/SavingsCalculatorClient.tsx
+++ b/app/savings-calculator/SavingsCalculatorClient.tsx
@@ -8,6 +8,7 @@ import { getStoredUtm } from "@/components/UtmCapture";
 import { storeQualificationData } from "@/lib/qualification-store";
 import { useCalculatorState } from "@/hooks/use-calculator-state";
 import AdvisorMatchCTA from "@/components/AdvisorMatchCTA";
+import CalculatorLeadCapture from "@/components/CalculatorLeadCapture";
 
 type Account = {
   id: number; slug: string; name: string; platform_type: string;
@@ -114,7 +115,7 @@ export default function SavingsCalculatorClient({ accounts, inline }: { accounts
       {!inline && <div className="bg-gradient-to-br from-amber-500 via-amber-600 to-amber-800 text-white py-8 md:py-14 px-4">
         <div className="container-custom max-w-3xl text-center">
           <h1 className="text-xl md:text-3xl font-extrabold mb-2">Are you earning enough on your savings?</h1>
-          <p className="text-sm md:text-base text-amber-100">Enter your balance and current rate — we'll show you exactly how much more you could earn.</p>
+          <p className="text-sm md:text-base text-amber-100">Enter your balance and current rate — we&apos;ll show you exactly how much more you could earn.</p>
           <div className="mt-3"><SocialProofCounter variant="badge" /></div>
         </div>
       </div>}
@@ -187,8 +188,8 @@ export default function SavingsCalculatorClient({ accounts, inline }: { accounts
                 </>
               ) : (
                 <>
-                  <p className="text-lg font-bold text-slate-700">You're already earning a competitive rate!</p>
-                  <p className="text-sm text-slate-500 mt-1">At {currentRate}%, you're close to the best available rates in Australia.</p>
+                  <p className="text-lg font-bold text-slate-700">You&apos;re already earning a competitive rate!</p>
+                  <p className="text-sm text-slate-500 mt-1">At {currentRate}%, you&apos;re close to the best available rates in Australia.</p>
                 </>
               )}
             </div>
@@ -289,10 +290,17 @@ export default function SavingsCalculatorClient({ accounts, inline }: { accounts
               />
             </div>
 
+            <CalculatorLeadCapture
+              calcSlug="savings-calculator"
+              calcTitle="savings projection"
+              need="planning"
+              contextKeys={["savings", "cash-strategy"]}
+            />
+
             <div className="bg-white border border-slate-200 rounded-2xl p-5 md:p-8">
               <h2 className="text-lg font-bold text-slate-900 mb-3">Why Your Savings Rate Matters</h2>
               <p className="text-sm text-slate-600 leading-relaxed mb-4">
-                Most Australians leave their savings in a Big 4 bank transaction account earning 0.01-0.5%. Meanwhile, online banks like ING, Ubank, and Macquarie offer 5%+ with simple conditions. On a $50,000 balance, the difference between 0.5% and 5.5% is <strong>$2,500 per year</strong> — that's real money lost to inertia.
+                Most Australians leave their savings in a Big 4 bank transaction account earning 0.01-0.5%. Meanwhile, online banks like ING, Ubank, and Macquarie offer 5%+ with simple conditions. On a $50,000 balance, the difference between 0.5% and 5.5% is <strong>$2,500 per year</strong> — that&apos;s real money lost to inertia.
               </p>
               <p className="text-sm text-slate-600 leading-relaxed mb-4">
                 All savings accounts listed here are with ADI-regulated Australian banks, meaning your deposits are government-guaranteed up to $250,000 per person per institution under the Financial Claims Scheme.

--- a/app/smsf-calculator/SMSFCalculatorClient.tsx
+++ b/app/smsf-calculator/SMSFCalculatorClient.tsx
@@ -8,6 +8,7 @@ import { trackEvent, trackPageDuration } from "@/lib/tracking";
 import { getStoredUtm } from "@/components/UtmCapture";
 import { formatCurrency } from "@/lib/utils";
 import { useCalculatorState } from "@/hooks/use-calculator-state";
+import CalculatorLeadCapture from "@/components/CalculatorLeadCapture";
 
 /* ── helpers ── */
 
@@ -459,6 +460,13 @@ export default function SMSFCalculatorClient() {
                 description="An SMSF specialist handles setup, compliance, audit, and investment strategy — so you can focus on growing your wealth."
               />
             </div>
+
+            <CalculatorLeadCapture
+              calcSlug="smsf-calculator"
+              calcTitle="SMSF cost"
+              need="smsf"
+              contextKeys={["smsf", "self-managed-super"]}
+            />
 
             {/* SEO content */}
             <div className="bg-white border border-slate-200 rounded-2xl p-5 md:p-8 space-y-4">

--- a/app/super-contributions-calculator/SuperContributionsClient.tsx
+++ b/app/super-contributions-calculator/SuperContributionsClient.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { formatCurrency } from "@/lib/utils";
 import { formatPercent } from "@/lib/tracking";
 import { useCalculatorState } from "@/hooks/use-calculator-state";
+import CalculatorLeadCapture from "@/components/CalculatorLeadCapture";
 
 /* ── constants (FY2026) ── */
 
@@ -476,6 +477,13 @@ export default function SuperContributionsClient() {
             </div>
           </div>
         </div>
+
+        <CalculatorLeadCapture
+          calcSlug="super-contributions-calculator"
+          calcTitle="super contribution"
+          need="planning"
+          contextKeys={["super-contributions", "concessional-cap"]}
+        />
 
         {/* Disclaimer */}
         <p className="text-[0.65rem] text-slate-400 mt-8 leading-relaxed">

--- a/app/switching-calculator/SwitchingCalculatorClient.tsx
+++ b/app/switching-calculator/SwitchingCalculatorClient.tsx
@@ -10,6 +10,7 @@ import { getStoredUtm } from "@/components/UtmCapture";
 import type { Broker } from "@/lib/types";
 import { storeQualificationData } from "@/lib/qualification-store";
 import AdvisorMatchCTA from "@/components/AdvisorMatchCTA";
+import CalculatorLeadCapture from "@/components/CalculatorLeadCapture";
 
 function parseFee(feeStr: string | null | undefined): { flat: number; pct: number } {
   if (!feeStr) return { flat: 0, pct: 0 };
@@ -334,6 +335,15 @@ export default function SwitchingCalculatorClient({ brokers, inline }: { brokers
           </div>
         )}
 
+        {showResults && (
+          <CalculatorLeadCapture
+            calcSlug="switching-calculator"
+            calcTitle="broker switching"
+            need="wealth"
+            contextKeys={["broker-switching", "cost-optimisation"]}
+          />
+        )}
+
         {/* SEO content */}
         <div className="mt-8 md:mt-12 space-y-6 text-sm text-slate-600 leading-relaxed">
           {/* Contextual advisor prompt for large portfolios */}
@@ -353,7 +363,7 @@ export default function SwitchingCalculatorClient({ brokers, inline }: { brokers
           <p>Switching is easier than most people think. For CHESS-sponsored brokers, your HIN (Holder Identification Number) transfers directly — your shares stay in your name throughout. The process typically takes 3-5 business days. Read our <Link href="/switch" className="text-violet-600 hover:underline">complete switching guide</Link> for step-by-step instructions.</p>
           <div className="bg-amber-50 border border-amber-200 rounded-xl p-4 mt-4">
             <p className="text-sm font-bold text-amber-800 mb-1">Also check your savings rate</p>
-            <p className="text-xs text-amber-600">Most Australians earn 0.01% on their cash while top accounts offer 5%+. On $50k, that's $2,750/year difference.</p>
+            <p className="text-xs text-amber-600">Most Australians earn 0.01% on their cash while top accounts offer 5%+. On $50k, that&apos;s $2,750/year difference.</p>
             <Link href="/savings-calculator" className="inline-block mt-2 text-xs font-bold text-amber-700 hover:underline">Try the Savings Calculator →</Link>
           </div>
         </div>

--- a/app/tco-calculator/TcoClient.tsx
+++ b/app/tco-calculator/TcoClient.tsx
@@ -4,6 +4,7 @@ import { useSearchParams } from "next/navigation";
 import type { Broker } from "@/lib/types";
 import TotalCostCalculator from "@/app/calculators/_components/TotalCostCalculator";
 import Link from "next/link";
+import CalculatorLeadCapture from "@/components/CalculatorLeadCapture";
 
 export default function TcoClient({ brokers }: { brokers: Broker[] }) {
   const searchParams = useSearchParams();
@@ -34,6 +35,13 @@ export default function TcoClient({ brokers }: { brokers: Broker[] }) {
         {/* Calculator */}
         <TotalCostCalculator brokers={brokers} searchParams={searchParams} />
 
+        <CalculatorLeadCapture
+          calcSlug="tco-calculator"
+          calcTitle="broker total cost"
+          need="wealth"
+          contextKeys={["broker-tco", "cost-optimisation"]}
+        />
+
         {/* How it works */}
         <div className="mt-8 md:mt-12 space-y-6">
           <div className="bg-slate-50 border border-slate-200 rounded-xl p-5 md:p-6">
@@ -49,7 +57,7 @@ export default function TcoClient({ brokers }: { brokers: Broker[] }) {
               </div>
               <div>
                 <p className="font-semibold text-slate-800 mb-1">3. Total cost of ownership</p>
-                <p>We sum all costs for a full year. The "cheapest" label shows which platform minimises your total spend based on your trading pattern.</p>
+                <p>We sum all costs for a full year. The &ldquo;cheapest&rdquo; label shows which platform minimises your total spend based on your trading pattern.</p>
               </div>
             </div>
           </div>

--- a/app/trade-cost-calculator/TradeCostClient.tsx
+++ b/app/trade-cost-calculator/TradeCostClient.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import Icon from "@/components/Icon";
 import type { Broker } from "@/lib/types";
 import TradeCostCalculator from "@/app/calculators/_components/TradeCostCalculator";
+import CalculatorLeadCapture from "@/components/CalculatorLeadCapture";
 
 export default function TradeCostClient({ brokers }: { brokers: Broker[] }) {
   const searchParams = useSearchParams();
@@ -43,6 +44,13 @@ export default function TradeCostClient({ brokers }: { brokers: Broker[] }) {
 
         {/* Calculator */}
         <TradeCostCalculator brokers={brokers} searchParams={searchParams} />
+
+        <CalculatorLeadCapture
+          calcSlug="trade-cost-calculator"
+          calcTitle="trade cost"
+          need="wealth"
+          contextKeys={["broker-trade-cost", "cost-optimisation"]}
+        />
 
         {/* SEO content */}
         <div className="mt-8 md:mt-12 space-y-6">

--- a/app/us-share-costs-calculator/UsShareCostsClient.tsx
+++ b/app/us-share-costs-calculator/UsShareCostsClient.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import Icon from "@/components/Icon";
 import type { Broker } from "@/lib/types";
 import FxFeeCalculator from "@/app/calculators/_components/FxFeeCalculator";
+import CalculatorLeadCapture from "@/components/CalculatorLeadCapture";
 
 export default function UsShareCostsClient({ brokers }: { brokers: Broker[] }) {
   const searchParams = useSearchParams();
@@ -42,6 +43,13 @@ export default function UsShareCostsClient({ brokers }: { brokers: Broker[] }) {
         </div>
 
         <FxFeeCalculator brokers={brokers} searchParams={searchParams} />
+
+        <CalculatorLeadCapture
+          calcSlug="us-share-costs-calculator"
+          calcTitle="US share trading cost"
+          need="tax"
+          contextKeys={["us-shares", "withholding-tax", "fx-cost"]}
+        />
 
         <div className="mt-8 md:mt-12 space-y-6">
           <div className="bg-white border border-slate-200 rounded-xl p-5 md:p-6">

--- a/components/CalculatorLeadCapture.tsx
+++ b/components/CalculatorLeadCapture.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import HubLeadForm from "@/components/leads/HubLeadForm";
+
+/**
+ * Lead-capture box rendered beneath every calculator's results section
+ * (W1.2). Converts the post-result intent moment into a free advisor
+ * review.
+ *
+ * Mounted by each calculator's client component (CgtClient, MortgageCalculatorClient,
+ * etc). The lead lands in the standard advisor matching pipeline via
+ * /api/submit-lead with intent.need mapped to one of /find-advisor's
+ * NEED_TO_INTENT keys, so the routing engine treats it like any other
+ * advisor lead. source_page is tagged `/calculator-leadbox|calc=<slug>`
+ * so attribution can isolate calculator-driven leads in analytics.
+ */
+
+export type CalculatorLeadNeed =
+  | "mortgage"
+  | "buyers"
+  | "insurance"
+  | "planning"
+  | "tax"
+  | "wealth"
+  | "smsf"
+  | "estate"
+  | "agedcare"
+  | "property"
+  | "crypto";
+
+export interface CalculatorLeadCaptureProps {
+  /** URL slug of the calculator, e.g. "cgt-calculator". Used in source_page. */
+  calcSlug: string;
+  /** Human-readable calculator name used in the subheading copy. */
+  calcTitle: string;
+  /** Specialist category — maps to /find-advisor's NEED_TO_INTENT. */
+  need: CalculatorLeadNeed;
+  /** Free-form context tags appended to the lead's intent.context array. */
+  contextKeys?: string[];
+}
+
+export default function CalculatorLeadCapture({
+  calcSlug,
+  calcTitle,
+  need,
+  contextKeys,
+}: CalculatorLeadCaptureProps) {
+  return (
+    <div className="mt-6 md:mt-8" data-testid="calculator-lead-capture">
+      <HubLeadForm
+        heading="Save these results — get a free 15-minute review"
+        subheading={`A specialist will look at your ${calcTitle} numbers and explain what they mean for your situation. No cost, no obligation.`}
+        intent={{
+          need,
+          ...(contextKeys && contextKeys.length > 0 ? { context: contextKeys } : {}),
+        }}
+        source={`/calculator-leadbox|calc=${calcSlug}`}
+        ctaLabel="Get my free review"
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
CalculatorLeadCapture wraps HubLeadForm with calc-specific intent + context and is mounted under the results section of all 19 site calculators.

## Why
Pre-launch wave master plan W1.2: convert the post-result intent moment before the user navigates away. The 19 calculator pages are a high-traffic surface that previously only had a link-style "Match Me With a Broker" CTA — no in-page capture form, so users had to land on /find-advisor and re-enter context.

## Tier
**B** — adds a UI component + tests, no schema changes, no webhooks, no Stripe touches. `submitLead` is the same library code other lead surfaces already use. 15-min Sentry + Vercel observation after merge per `docs/audits/MERGE_AUTHORIZATION.md`.

## Files
- `components/CalculatorLeadCapture.tsx` (new) — thin wrapper around HubLeadForm with calc-specific copy + `source_page=/calculator-leadbox|calc=<slug>` so analytics can isolate calc-originated leads
- `__tests__/components/CalculatorLeadCapture.test.tsx` (new) — 7 unit tests covering heading, subheading, source_page tagging, intent.need pass-through, contextKeys handling, and empty-array defensive case
- 19 calculator client files — added the import + `<CalculatorLeadCapture ... />` mount under the results section. Each calc passes its own `need` (mapped to `/find-advisor`'s `NEED_TO_INTENT`) and `contextKeys` (free-form tags surfaced to the matching engine).

## Supersedes
_None._

## Test plan
- [x] vitest local: 7 tests pass for CalculatorLeadCapture
- [x] type-check: clean (`npx tsc --noEmit`, exit 0)
- [ ] CI: pending
- [ ] Visual: hit `/cgt-calculator`, `/mortgage-calculator`, `/smsf-calculator` in dev — verify form renders below results, submits, shows "thanks — we'll be in touch" success state.
- [ ] Sentry: no `/api/submit-lead` 4xx spike in first 15 min after merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PoWgxLjp8kXpKBvvQqy9qH)_