### PR TITLE
feat(tt): TT-04 — remove GA4 from layout; Plausible is sole page analytics [audit remediation]

### DIFF
--- a/app/admin/seo-health/page.tsx
+++ b/app/admin/seo-health/page.tsx
@@ -231,7 +231,7 @@ export default function SEOHealthPage() {
                 <h3 className="text-sm font-bold text-blue-700 mb-2">Next Steps</h3>
                 <ul className="text-xs text-blue-600 space-y-1">
                   <li>• Submit sitemap to <a href="https://search.google.com/search-console" target="_blank" rel="noopener noreferrer" className="underline">Google Search Console</a></li>
-                  <li>• Connect GA4 (set NEXT_PUBLIC_GA_ID env var)</li>
+                  <li>• Analytics via Plausible (set NEXT_PUBLIC_PLAUSIBLE_DOMAIN env var)</li>
                   <li>• Monitor indexed pages vs sitemap URLs</li>
                   <li>• Target &quot;best [category] australia&quot; keywords</li>
                   <li>• Build backlinks to highest-converting pages</li>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,7 +8,6 @@ import "./globals.css";
 import LayoutShell from "@/components/LayoutShell";
 import CountryModeBanner from "@/components/country-mode/CountryModeBanner";
 import { ThemeProvider } from "@/components/ThemeProvider";
-import GoogleAnalytics from "@/components/GoogleAnalytics";
 import PlausibleAnalytics from "@/components/PlausibleAnalytics";
 import { PostHogProvider } from "@/components/PostHogProvider";
 import UtmCapture from "@/components/UtmCapture";
@@ -166,7 +165,6 @@ export default async function RootLayout({
             </p>
           </div>
         </noscript>
-        <GoogleAnalytics />
         <PlausibleAnalytics />
         <PostHogProvider>
         <Suspense fallback={null}><UtmCapture /></Suspense>

--- a/components/GoogleAnalytics.tsx
+++ b/components/GoogleAnalytics.tsx
@@ -1,3 +1,5 @@
+// TT-04: removed from app/layout.tsx. Component kept for reference / re-enable.
+// Plausible Analytics (PlausibleAnalytics.tsx) is now the sole page analytics.
 "use client";
 
 import Script from "next/script";

--- a/components/PlausibleAnalytics.tsx
+++ b/components/PlausibleAnalytics.tsx
@@ -10,7 +10,7 @@ const PLAUSIBLE_DOMAIN = process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN;
  * data-domain attribute tells Plausible which site to attribute traffic to.
  *
  * No consent gate needed (see TT-03 migration notes in REMEDIATION_QUEUE.md).
- * GA4 removal (GoogleAnalytics.tsx + NEXT_PUBLIC_GA_ID) is deferred to TT-03 iter 2.
+ * GA4 (GoogleAnalytics.tsx) was removed in TT-04 — Plausible is now the sole page analytics.
  */
 export default function PlausibleAnalytics() {
   if (!PLAUSIBLE_DOMAIN) return null;

--- a/proxy.ts
+++ b/proxy.ts
@@ -155,7 +155,7 @@ export async function proxy(request: NextRequest) {
     "style-src 'self' 'unsafe-inline'",
     "img-src 'self' data: blob: https:",
     "font-src 'self' data:",
-    "connect-src 'self' https://*.supabase.co https://va.vercel-scripts.com https://*.google-analytics.com https://*.analytics.google.com https://www.googletagmanager.com https://api.stripe.com https://cal.com https://app.cal.com https://*.sentry.io https://*.ingest.sentry.io https://eu.i.posthog.com https://us.i.posthog.com https://plausible.io",
+    "connect-src 'self' https://*.supabase.co https://va.vercel-scripts.com https://www.googletagmanager.com https://api.stripe.com https://cal.com https://app.cal.com https://*.sentry.io https://*.ingest.sentry.io https://eu.i.posthog.com https://us.i.posthog.com https://plausible.io",
     "frame-src 'self' https://js.stripe.com https://hooks.stripe.com https://www.youtube-nocookie.com https://player.vimeo.com https://cal.com",
     "frame-ancestors 'none'",
     "base-uri 'self'",


### PR DESCRIPTION
## Summary

Completes TT-04 from the privacy-analytics audit stream. Now that Plausible Analytics (TT-03, #779 merged) provides cookieless GDPR-compliant pageview tracking, GA4 is removed from the render tree.

Changes:
- **`app/layout.tsx`**: remove `<GoogleAnalytics />` import and render
- **`proxy.ts` connect-src**: remove `*.google-analytics.com` and `*.analytics.google.com` (GA4 data endpoints). `www.googletagmanager.com` stays for Google Ads (TrackingPixels.tsx)
- **`components/GoogleAnalytics.tsx`**: add TT-04 note — component kept for reference but no longer rendered
- **`components/PlausibleAnalytics.tsx`**: update comment to reflect TT-04 completion
- **`app/admin/seo-health/page.tsx`**: update Next Steps hint from GA4 to Plausible env var

## Safety

- `WebVitals.tsx` already guards `"gtag" in window` — not broken by removal
- `FloatingRightCTA.tsx` same guard — not broken
- Web vitals still reach `/api/track-event` internal endpoint
- Google Ads conversion tracking (TrackingPixels.tsx) uses separate `GOOGLE_ADS_ID` env var and separate gtag init — unaffected

## Supersedes

_None._

## Tier

Tier C (proxy.ts change — CSP connect-src narrowing). Intent: removing two GA4 allowlist entries from connect-src tightens the CSP. No new domains added.

https://claude.ai/code/session_01FVBEM7BkmLA8xsMFPYMeNp

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVBEM7BkmLA8xsMFPYMeNp)_