### PR TITLE
feat(concierge): homepage entry + booking handoff CTA (W1.1)

### DIFF
--- a/__tests__/components/ConciergeBookingHandoff.test.tsx
+++ b/__tests__/components/ConciergeBookingHandoff.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, userEvent } from "../components/setup";
+import ConciergeBookingHandoff from "@/components/ConciergeBookingHandoff";
+import * as tracking from "@/lib/tracking";
+
+vi.mock("@/components/Icon", () => ({
+  default: ({ name }: { name: string }) => <span data-testid={`icon-${name}`} />,
+}));
+
+describe("ConciergeBookingHandoff", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the heading and CTA", () => {
+    render(
+      <ConciergeBookingHandoff firstUserMessage={null} sessionId={null} messagesCount={0} />,
+    );
+    expect(screen.getByText(/ready for personal advice/i)).toBeInTheDocument();
+    expect(screen.getByTestId("concierge-booking-handoff-cta")).toHaveTextContent(
+      /book a call/i,
+    );
+  });
+
+  it("links to /find-advisor with source=concierge when no user message", () => {
+    render(
+      <ConciergeBookingHandoff firstUserMessage={null} sessionId={null} messagesCount={0} />,
+    );
+    const cta = screen.getByTestId("concierge-booking-handoff-cta");
+    expect(cta).toHaveAttribute("href", "/find-advisor?source=concierge");
+  });
+
+  it("forwards the first user message as seed (trimmed + 200-char capped)", () => {
+    const long = "  ETF for a beginner ".repeat(20);
+    render(
+      <ConciergeBookingHandoff
+        firstUserMessage={long}
+        sessionId={"abcdef12-3456-7890-1234-56789abcdef0"}
+        messagesCount={3}
+      />,
+    );
+    const cta = screen.getByTestId("concierge-booking-handoff-cta");
+    const href = cta.getAttribute("href") ?? "";
+    expect(href).toContain("source=concierge");
+    expect(href).toContain("concierge_session=abcdef12-3456-7890-1234-56789abcdef0");
+    const url = new URL(`http://x${href}`);
+    const seed = url.searchParams.get("seed") ?? "";
+    expect(seed.length).toBeGreaterThan(0);
+    expect(seed.length).toBeLessThanOrEqual(200);
+    expect(seed.startsWith(" ")).toBe(false);
+  });
+
+  it("omits seed param when first user message is empty / whitespace", () => {
+    render(
+      <ConciergeBookingHandoff
+        firstUserMessage={"   "}
+        sessionId={null}
+        messagesCount={1}
+      />,
+    );
+    const href = screen.getByTestId("concierge-booking-handoff-cta").getAttribute("href") ?? "";
+    expect(href).not.toContain("seed=");
+  });
+
+  it("emits a tracking event when the CTA is clicked", async () => {
+    const spy = vi.spyOn(tracking, "trackEvent");
+    const user = userEvent.setup();
+    render(
+      <ConciergeBookingHandoff
+        firstUserMessage={"hi"}
+        sessionId={"sess-12345"}
+        messagesCount={2}
+      />,
+    );
+    await user.click(screen.getByTestId("concierge-booking-handoff-cta"));
+    expect(spy).toHaveBeenCalledWith(
+      "concierge_booking_handoff_click",
+      expect.objectContaining({ session_id: "sess-12345", messages_count: 2 }),
+    );
+  });
+});

--- a/__tests__/components/ConciergeClient.test.tsx
+++ b/__tests__/components/ConciergeClient.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, waitFor } from "../components/setup";
+import ConciergeClient from "@/app/concierge/ConciergeClient";
+
+vi.mock("@/components/Icon", () => ({
+  default: ({ name }: { name: string }) => <span data-testid={`icon-${name}`} />,
+}));
+
+function fakeStreamResponse(payloads: string[]): Response {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const p of payloads) {
+        controller.enqueue(encoder.encode(`data: ${p}\n\n`));
+      }
+      controller.close();
+    },
+  });
+  return new Response(stream, {
+    status: 200,
+    headers: { "Content-Type": "text/event-stream" },
+  });
+}
+
+describe("ConciergeClient — sessionStorage seed + handoff", () => {
+  const fetchSpy = vi.fn();
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    localStorage.clear();
+    fetchSpy.mockReset();
+    vi.stubGlobal("fetch", fetchSpy);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("does NOT show the booking handoff before any assistant reply", async () => {
+    fetchSpy.mockResolvedValue(new Response(JSON.stringify({ messages: [] })));
+    render(<ConciergeClient />);
+    expect(screen.queryByTestId("concierge-booking-handoff")).not.toBeInTheDocument();
+  });
+
+  it("auto-fires the pending prompt from sessionStorage and clears it", async () => {
+    sessionStorage.setItem("ic_concierge_pending_prompt_v1", "what is SMSF?");
+
+    fetchSpy.mockImplementation((url: string, init?: RequestInit) => {
+      if (typeof url === "string" && url.startsWith("/api/concierge") && (!init || init.method !== "POST")) {
+        return Promise.resolve(new Response(JSON.stringify({ messages: [] })));
+      }
+      // POST: stream a session + done payload back so the component
+      // can settle without hanging on an unfinished stream.
+      return Promise.resolve(
+        fakeStreamResponse([
+          JSON.stringify({ type: "session", session_id: "test-session-id" }),
+          JSON.stringify({ type: "retrieved", docs: [] }),
+          JSON.stringify({ type: "delta", text: "SMSF stands for…" }),
+          JSON.stringify({ type: "done", tokens_in: 1, tokens_out: 2 }),
+        ]),
+      );
+    });
+
+    render(<ConciergeClient />);
+
+    await waitFor(() => {
+      const postCall = fetchSpy.mock.calls.find(
+        (c) => c[0] === "/api/concierge" && c[1]?.method === "POST",
+      );
+      expect(postCall).toBeDefined();
+      const body = JSON.parse(postCall![1].body as string) as { message: string };
+      expect(body.message).toBe("what is SMSF?");
+    });
+
+    // The seed is consumed exactly once.
+    expect(sessionStorage.getItem("ic_concierge_pending_prompt_v1")).toBeNull();
+  });
+
+  it("shows the booking handoff once an assistant reply has streamed in", async () => {
+    sessionStorage.setItem("ic_concierge_pending_prompt_v1", "hello");
+
+    fetchSpy.mockImplementation((url: string, init?: RequestInit) => {
+      if (typeof url === "string" && url.startsWith("/api/concierge") && (!init || init.method !== "POST")) {
+        return Promise.resolve(new Response(JSON.stringify({ messages: [] })));
+      }
+      return Promise.resolve(
+        fakeStreamResponse([
+          JSON.stringify({ type: "session", session_id: "test-session-id" }),
+          JSON.stringify({ type: "retrieved", docs: [] }),
+          JSON.stringify({ type: "delta", text: "Hi! Here is some info." }),
+          JSON.stringify({ type: "done", tokens_in: 1, tokens_out: 2 }),
+        ]),
+      );
+    });
+
+    render(<ConciergeClient />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("concierge-booking-handoff")).toBeInTheDocument();
+    });
+
+    const cta = screen.getByTestId("concierge-booking-handoff-cta");
+    expect(cta.getAttribute("href")).toContain("source=concierge");
+    expect(cta.getAttribute("href")).toContain("seed=hello");
+  });
+});

--- a/__tests__/components/HomeConciergeEntry.test.tsx
+++ b/__tests__/components/HomeConciergeEntry.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, userEvent, mockPush } from "../components/setup";
+import HomeConciergeEntry from "@/components/HomeConciergeEntry";
+import * as tracking from "@/lib/tracking";
+
+describe("HomeConciergeEntry", () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+    sessionStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  it("renders the input, submit button, and starter chips", () => {
+    render(<HomeConciergeEntry />);
+    expect(
+      screen.getByRole("textbox", { name: /ask the investment concierge/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("home-concierge-entry-submit")).toBeInTheDocument();
+    expect(screen.getAllByTestId("home-concierge-entry-chip").length).toBeGreaterThanOrEqual(4);
+  });
+
+  it("submit button is disabled when input is empty", () => {
+    render(<HomeConciergeEntry />);
+    const btn = screen.getByTestId("home-concierge-entry-submit");
+    expect(btn).toBeDisabled();
+  });
+
+  it("submitting writes prompt to sessionStorage and navigates to /concierge", async () => {
+    const user = userEvent.setup();
+    render(<HomeConciergeEntry />);
+    const textarea = screen.getByRole("textbox", { name: /ask the investment concierge/i });
+    await user.type(textarea, "what's the best ETF for a beginner?");
+    await user.click(screen.getByTestId("home-concierge-entry-submit"));
+
+    expect(sessionStorage.getItem("ic_concierge_pending_prompt_v1")).toBe(
+      "what's the best ETF for a beginner?",
+    );
+    expect(mockPush).toHaveBeenCalledWith("/concierge");
+  });
+
+  it("clicking a finder-bound chip navigates with the finder query and writes the chip text", async () => {
+    const user = userEvent.setup();
+    render(<HomeConciergeEntry />);
+    const chips = screen.getAllByTestId("home-concierge-entry-chip");
+    const advisorChip = chips.find((c) => /financial advisor/i.test(c.textContent ?? ""));
+    expect(advisorChip).toBeDefined();
+    await user.click(advisorChip!);
+
+    expect(sessionStorage.getItem("ic_concierge_pending_prompt_v1")).toBe(
+      "Choosing a financial advisor",
+    );
+    expect(mockPush).toHaveBeenCalledWith("/concierge?finder=advisor-finder");
+  });
+
+  it("trims whitespace + caps prompt at 200 chars before storage", async () => {
+    const user = userEvent.setup();
+    render(<HomeConciergeEntry />);
+    const textarea = screen.getByRole("textbox", { name: /ask the investment concierge/i });
+    // The textarea itself enforces maxLength=200, so typing 250 chars
+    // lands 200 in the field — verify storage gets the same.
+    const long = "a".repeat(250);
+    await user.type(textarea, long);
+    await user.click(screen.getByTestId("home-concierge-entry-submit"));
+
+    const stored = sessionStorage.getItem("ic_concierge_pending_prompt_v1");
+    expect(stored).not.toBeNull();
+    expect(stored!.length).toBeLessThanOrEqual(200);
+  });
+
+  it("emits a tracking event on submit including source=input", async () => {
+    const spy = vi.spyOn(tracking, "trackEvent");
+    const user = userEvent.setup();
+    render(<HomeConciergeEntry />);
+    const textarea = screen.getByRole("textbox", { name: /ask the investment concierge/i });
+    await user.type(textarea, "hello world");
+    await user.click(screen.getByTestId("home-concierge-entry-submit"));
+
+    expect(spy).toHaveBeenCalledWith(
+      "concierge_homepage_entry_submit",
+      expect.objectContaining({ source: "input" }),
+    );
+  });
+
+  it("emits a tracking event on chip click including source=chip", async () => {
+    const spy = vi.spyOn(tracking, "trackEvent");
+    const user = userEvent.setup();
+    render(<HomeConciergeEntry />);
+    const chip = screen.getAllByTestId("home-concierge-entry-chip")[0]!;
+    await user.click(chip);
+
+    expect(spy).toHaveBeenCalledWith(
+      "concierge_homepage_entry_submit",
+      expect.objectContaining({ source: "chip" }),
+    );
+  });
+
+  it("links to the full /concierge page", () => {
+    render(<HomeConciergeEntry />);
+    const link = screen.getByRole("link", { name: /open full concierge/i });
+    expect(link).toHaveAttribute("href", "/concierge");
+  });
+});

--- a/app/concierge/ConciergeClient.tsx
+++ b/app/concierge/ConciergeClient.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import Icon from "@/components/Icon";
 import { trackEvent } from "@/lib/tracking";
 import { lookupSeed, isFinderKey } from "@/lib/concierge-seeds";
+import ConciergeBookingHandoff from "@/components/ConciergeBookingHandoff";
 
 /**
  * Full-page concierge chat UI.
@@ -55,6 +56,20 @@ const STARTERS = [
 ];
 
 const SESSION_KEY = "ic_concierge_session_v1";
+const PENDING_PROMPT_KEY = "ic_concierge_pending_prompt_v1";
+const MAX_PENDING_PROMPT_LEN = 200;
+
+function readPendingPrompt(): string | null {
+  try {
+    const raw = sessionStorage.getItem(PENDING_PROMPT_KEY);
+    if (!raw) return null;
+    sessionStorage.removeItem(PENDING_PROMPT_KEY);
+    const clean = raw.replace(/\s+/g, " ").trim().slice(0, MAX_PENDING_PROMPT_LEN);
+    return clean || null;
+  } catch {
+    return null;
+  }
+}
 
 function genId(): string {
   return Math.random().toString(36).slice(2, 10);
@@ -276,15 +291,30 @@ export default function ConciergeClient() {
     abortRef.current?.abort();
   }, []);
 
-  // Auto-fire a named seed prompt from the URL (?finder=<key>) on
-  // first mount, but only when starting fresh. The finder key is
-  // resolved against a server-defined allowlist in
-  // lib/concierge-seeds.ts — unknown keys are ignored, so a crafted
-  // URL can't ship arbitrary text into the chat.
+  // Auto-fire on first mount when starting fresh. Two sources, in priority order:
+  //   1. sessionStorage `ic_concierge_pending_prompt_v1` — the homepage
+  //      concierge entry component writes the visitor's free-text question
+  //      here, then navigates to /concierge. Same-origin only, so this can't
+  //      be planted by a crafted URL.
+  //   2. URL `?finder=<key>` — allowlisted starter prompt from deep-links
+  //      in /advisors, /advisors/search, post-quiz drop-offs, etc.
   useEffect(() => {
     if (seedFiredRef.current) return;
     if (hydrating) return;
     if (messages.length > 0) return;
+
+    const pending = readPendingPrompt();
+    if (pending) {
+      seedFiredRef.current = true;
+      trackEvent("concierge_seed_fired", {
+        finder: null,
+        source: "homepage-entry",
+        prompt_length: pending.length,
+      });
+      void send(pending);
+      return;
+    }
+
     const finderRaw = searchParams?.get("finder") ?? "";
     if (!isFinderKey(finderRaw)) return;
     const seed = lookupSeed(finderRaw);
@@ -334,6 +364,18 @@ export default function ConciergeClient() {
   const canSend = useMemo(
     () => input.trim().length > 0 && !streaming,
     [input, streaming],
+  );
+
+  const showHandoff = useMemo(
+    () =>
+      messages.some(
+        (m) => m.role === "assistant" && m.content.trim().length > 0,
+      ),
+    [messages],
+  );
+  const firstUserMessage = useMemo(
+    () => messages.find((m) => m.role === "user")?.content ?? null,
+    [messages],
   );
 
   return (
@@ -503,6 +545,14 @@ export default function ConciergeClient() {
               </button>
             )}
           </form>
+
+          {showHandoff && (
+            <ConciergeBookingHandoff
+              firstUserMessage={firstUserMessage}
+              sessionId={sessionId}
+              messagesCount={messages.length}
+            />
+          )}
 
           <p className="text-[11px] text-slate-500 leading-relaxed mt-3">
             <strong>General information only.</strong> The concierge is an AI

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 import { createClient } from "@/lib/supabase/server";
 import type { Broker } from "@/lib/types";
 import HomeHero from "@/components/HomeHero";
+import HomeConciergeEntry from "@/components/HomeConciergeEntry";
 import HomeRouteCards from "@/components/HomeRouteCards";
 import CountryToolsStripWrapper from "@/components/country-mode/CountryToolsStripWrapper";
 import HomePathfinder from "@/components/HomePathfinder";
@@ -243,6 +244,8 @@ export default async function HomePage() {
         listingCount={totalListingCount}
         advisorCount={totalProfessionalCount}
       />
+
+      <HomeConciergeEntry />
 
       <ScrollFadeIn>
         <HomeRouteCards

--- a/components/ConciergeBookingHandoff.tsx
+++ b/components/ConciergeBookingHandoff.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import Link from "next/link";
+import Icon from "@/components/Icon";
+import { trackEvent } from "@/lib/tracking";
+
+/**
+ * Booking handoff CTA shown beneath the concierge chat after the
+ * model has produced at least one substantive reply.
+ *
+ * Concierge answers are educational; the CTA is the path from
+ * "I understand X" to "let me book a call with an advisor for
+ * personal advice on X". The first user turn is forwarded as a
+ * `seed` query so /find-advisor pre-fills the enquiry context.
+ */
+
+export interface ConciergeBookingHandoffProps {
+  firstUserMessage: string | null;
+  sessionId: string | null;
+  messagesCount: number;
+}
+
+export default function ConciergeBookingHandoff({
+  firstUserMessage,
+  sessionId,
+  messagesCount,
+}: ConciergeBookingHandoffProps) {
+  const params = new URLSearchParams({ source: "concierge" });
+  if (firstUserMessage && firstUserMessage.trim()) {
+    params.set("seed", firstUserMessage.trim().slice(0, 200));
+  }
+  if (sessionId) params.set("concierge_session", sessionId);
+  const href = `/find-advisor?${params.toString()}`;
+
+  const onClick = () => {
+    trackEvent("concierge_booking_handoff_click", {
+      session_id: sessionId,
+      messages_count: messagesCount,
+    });
+  };
+
+  return (
+    <div
+      data-testid="concierge-booking-handoff"
+      className="mt-3 flex flex-wrap items-center justify-between gap-3 rounded-xl border border-amber-200 bg-amber-50 p-3 md:p-4"
+    >
+      <div className="min-w-0 flex-1">
+        <p className="text-[13px] font-bold text-slate-900">
+          Ready for personal advice?
+        </p>
+        <p className="text-[11.5px] leading-relaxed text-slate-600">
+          We&apos;ll route your question to an AFSL-licensed advisor who
+          specialises in this area — most reply within a business day.
+        </p>
+      </div>
+      <Link
+        href={href}
+        onClick={onClick}
+        data-testid="concierge-booking-handoff-cta"
+        className="inline-flex shrink-0 items-center gap-1.5 rounded-lg bg-slate-900 px-4 py-2 text-xs font-bold text-white transition-colors hover:bg-slate-800"
+      >
+        Book a call
+        <Icon name="arrow-right" size={12} />
+      </Link>
+    </div>
+  );
+}

--- a/components/HomeConciergeEntry.tsx
+++ b/components/HomeConciergeEntry.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import { useCallback, useMemo, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { DesignIcon } from "@/components/design/DesignIcon";
+import { trackEvent } from "@/lib/tracking";
+
+/**
+ * Promotes the AI Investment Concierge to the homepage. Submits the
+ * typed question into sessionStorage and navigates to `/concierge`,
+ * which auto-fires the prompt on mount.
+ *
+ * Free text is intentionally NOT passed through the URL — the
+ * `/concierge` page already validates `?finder=<key>` against an
+ * allowlist. sessionStorage keeps the value same-origin and avoids
+ * a tampered-URL vector.
+ */
+
+const SEED_KEY = "ic_concierge_pending_prompt_v1";
+const MAX_PROMPT_LEN = 200;
+
+const STARTERS = [
+  { label: "Find me a broker for SMSF with $500k", finder: null as string | null },
+  { label: "Compare CommSec vs Stake for US shares", finder: null },
+  { label: "Choosing a financial advisor", finder: "advisor-finder" as const },
+  { label: "ETFs for beginners", finder: "first-etf" as const },
+];
+
+function sanitisePrompt(raw: string): string {
+  return raw.replace(/\s+/g, " ").trim().slice(0, MAX_PROMPT_LEN);
+}
+
+export default function HomeConciergeEntry() {
+  const router = useRouter();
+  const [input, setInput] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  const canSend = useMemo(() => input.trim().length > 0 && !submitting, [input, submitting]);
+
+  const launch = useCallback(
+    (prompt: string, source: "input" | "chip", finder?: string | null) => {
+      const clean = sanitisePrompt(prompt);
+      if (!clean) return;
+      setSubmitting(true);
+      try {
+        sessionStorage.setItem(SEED_KEY, clean);
+      } catch {
+        // sessionStorage blocked — fall back to navigating without seed
+      }
+      trackEvent("concierge_homepage_entry_submit", {
+        source,
+        prompt_length: clean.length,
+        finder: finder ?? null,
+      });
+      const href = finder ? `/concierge?finder=${encodeURIComponent(finder)}` : "/concierge";
+      router.push(href);
+    },
+    [router],
+  );
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    launch(input, "input");
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      launch(input, "input");
+    }
+  };
+
+  return (
+    <section
+      aria-labelledby="home-concierge-entry-heading"
+      style={{
+        background: "linear-gradient(180deg, var(--color-ink-900) 0%, #0d1726 100%)",
+        color: "white",
+        padding: "32px 36px 40px",
+        borderTop: "1px solid rgba(255,255,255,.06)",
+      }}
+    >
+      <div
+        style={{
+          maxWidth: 960,
+          margin: "0 auto",
+          display: "flex",
+          flexDirection: "column",
+          gap: 18,
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
+          <span
+            className="iv2-pill"
+            style={{
+              background: "rgba(242,88,34,.14)",
+              color: "var(--color-coral-400)",
+              border: "1px solid rgba(242,88,34,.32)",
+              fontSize: 11,
+              padding: "4px 11px",
+            }}
+          >
+            <span aria-hidden>✦</span> AI concierge · free
+          </span>
+          <span style={{ fontSize: 11, color: "rgba(255,255,255,.55)" }}>
+            Grounded in {`Invest.com.au`} brokers, advisors, ETFs & guides — not personal advice.
+          </span>
+        </div>
+
+        <h2
+          id="home-concierge-entry-heading"
+          className="font-display"
+          style={{
+            fontSize: "clamp(22px, 2.6vw, 30px)",
+            fontWeight: 800,
+            margin: 0,
+            letterSpacing: "-.02em",
+            lineHeight: 1.2,
+            textWrap: "balance",
+          }}
+        >
+          Ask the concierge — get answers grounded in real listings.
+        </h2>
+
+        <form
+          onSubmit={onSubmit}
+          data-testid="home-concierge-entry-form"
+          style={{ position: "relative" }}
+        >
+          <textarea
+            ref={textareaRef}
+            value={input}
+            onChange={(e) => setInput(e.target.value.slice(0, MAX_PROMPT_LEN))}
+            onKeyDown={onKeyDown}
+            placeholder="Ask about brokers, ETFs, SMSF, FIRB, advisors, foreign-investor rules…"
+            aria-label="Ask the investment concierge"
+            rows={2}
+            maxLength={MAX_PROMPT_LEN}
+            disabled={submitting}
+            style={{
+              width: "100%",
+              background: "rgba(255,255,255,.06)",
+              border: "1px solid rgba(255,255,255,.18)",
+              borderRadius: 14,
+              padding: "14px 110px 14px 16px",
+              fontSize: 15,
+              color: "white",
+              resize: "none",
+              outline: "none",
+              fontFamily: "inherit",
+            }}
+          />
+          <button
+            type="submit"
+            disabled={!canSend}
+            data-testid="home-concierge-entry-submit"
+            style={{
+              position: "absolute",
+              right: 10,
+              bottom: 10,
+              background: canSend
+                ? "linear-gradient(180deg, var(--color-coral-400), var(--color-coral-500))"
+                : "rgba(255,255,255,.18)",
+              color: "white",
+              fontWeight: 700,
+              fontSize: 13,
+              padding: "9px 16px",
+              borderRadius: 10,
+              border: "none",
+              cursor: canSend ? "pointer" : "not-allowed",
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 6,
+            }}
+          >
+            Ask <DesignIcon name="arrow-right" size={12} strokeWidth={2.6} />
+          </button>
+        </form>
+
+        <div
+          role="list"
+          aria-label="Concierge starter prompts"
+          style={{ display: "flex", flexWrap: "wrap", gap: 8 }}
+        >
+          {STARTERS.map((s) => (
+            <button
+              key={s.label}
+              type="button"
+              role="listitem"
+              onClick={() => launch(s.label, "chip", s.finder)}
+              data-testid="home-concierge-entry-chip"
+              style={{
+                background: "rgba(255,255,255,.04)",
+                color: "rgba(255,255,255,.85)",
+                border: "1px solid rgba(255,255,255,.14)",
+                borderRadius: 999,
+                padding: "6px 12px",
+                fontSize: 12,
+                fontWeight: 600,
+                cursor: "pointer",
+              }}
+            >
+              {s.label}
+            </button>
+          ))}
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            gap: 14,
+            flexWrap: "wrap",
+            fontSize: 11.5,
+            color: "rgba(255,255,255,.55)",
+            alignItems: "center",
+          }}
+        >
+          <Link href="/concierge" style={{ color: "rgba(255,255,255,.85)", textDecoration: "underline" }}>
+            Open full concierge →
+          </Link>
+          <span aria-hidden>·</span>
+          <span>Educational only. Always seek personal advice from a licensed AFSL adviser.</span>
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
Promotes the AI Investment Concierge to the homepage via a new compact entry component, and adds a booking handoff CTA that surfaces once the model has produced at least one reply.

## Why
W1.1 from `docs/plans/pre-launch-wave-master-prompt.md` — the concierge was already a fully built RAG-grounded chatbot at `/concierge`, but lived behind a separate route. Mounting it above the fold and routing AI conversations into the advisor matchmaking funnel closes the gap from "I now understand X" → "let me book a call with someone qualified to give personal advice on X". The existing RAG against `search_embeddings_knn` already returns broker / advisor / fund / article citations, so this PR focuses on the entry surface + handoff CTA.

## Tier
**B** — additive UI components + tests, no schema, no webhooks, no Stripe touches. Re-uses the existing `/api/concierge` route and the proven `lookupSeed` / `isFinderKey` validation. 15-min Sentry + Vercel observation per `docs/audits/MERGE_AUTHORIZATION.md`.

## Files
- `components/HomeConciergeEntry.tsx` (new) — compact textarea + 4 starter chips. Submission writes the question into sessionStorage (same-origin only — not URL-tampered) and navigates to `/concierge`. Tracking event `concierge_homepage_entry_submit` with `source=input|chip` for funnel attribution.
- `components/ConciergeBookingHandoff.tsx` (new) — the "Ready for personal advice?" card. Renders inside the concierge chat, forwards the first user message as `?seed=<text>` into `/find-advisor` (max 200 chars), and emits `concierge_booking_handoff_click`.
- `app/concierge/ConciergeClient.tsx` — auto-fire path now also reads `ic_concierge_pending_prompt_v1` from sessionStorage (in addition to the existing `?finder=<key>` allowlist). Single-read-and-clear pattern so a refresh doesn't replay. Renders `<ConciergeBookingHandoff>` once at least one assistant turn has produced text.
- `app/page.tsx` — mounts `<HomeConciergeEntry />` directly below `<HomeHero />` and above the route cards.
- `__tests__/components/HomeConciergeEntry.test.tsx` (new) — 8 tests covering input + chips rendering, submit disabled state, sessionStorage write, finder query routing, 200-char cap, and tracking event payloads.
- `__tests__/components/ConciergeBookingHandoff.test.tsx` (new) — 5 tests covering CTA href construction (with/without seed, with/without session id), 200-char seed cap, whitespace-only handling, and tracking event.
- `__tests__/components/ConciergeClient.test.tsx` (new) — 3 tests covering handoff hidden by default, sessionStorage seed auto-fire-and-clear, and handoff appearing after a streamed assistant reply (mocks SSE stream).

## Supersedes
_None._
<!-- The auto-close-superseded workflow reads this section on merge. -->

## Test plan
- [x] `npx vitest run __tests__/components/HomeConciergeEntry.test.tsx __tests__/components/ConciergeBookingHandoff.test.tsx __tests__/components/ConciergeClient.test.tsx` — **16/16 pass** locally
- [x] `npx vitest run __tests__/api/concierge.test.ts __tests__/lib/concierge-seeds.test.ts __tests__/lib/concierge-retrieval.test.ts` — **39/39 pass** (regression check on existing concierge surface)
- [x] `npx tsc --noEmit` — clean
- [x] Pre-push hook — `type-check`, `audit:rate-limits`, `test:changed` all green
- [ ] CI: pending
- [ ] Visual: open `/` in dev — entry section visible above route cards, dark inkblot background with coral pill; clicking a chip lands on `/concierge` with the chip's prompt streaming; after first reply the amber handoff card appears with a `Book a call` CTA linking to `/find-advisor?source=concierge&seed=…`
- [ ] Sentry: no `/api/concierge` 5xx spike in the 15 min post-merge window

## Tier C extra
_N/A — additive UI, reuses the existing concierge route + validation._

---
_Generated by [Claude Code](https://claude.ai/code/session_01JPQVsKTYjuVdor2Dk2yogD)_