### PR TITLE
feat(watchlist): weekly email digest cron + per-user opt-in (W2.13 / WW-02)

### DIFF
--- a/__tests__/api/account-watchlist-alerts.test.ts
+++ b/__tests__/api/account-watchlist-alerts.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockGetUser = vi.fn();
+const mockFrom = vi.fn();
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({
+    auth: { getUser: mockGetUser },
+    from: mockFrom,
+  })),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import { GET, PUT } from "@/app/api/account/watchlist/alerts/route";
+
+const USER = { id: "user-uuid-1", email: "alice@example.com" };
+
+function makePut(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/account/watchlist/alerts", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+// Builds a thenable chain stub that returns the given final result.
+function makeSelectChain(result: { data: unknown; error: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  for (const m of ["select", "eq", "maybeSingle"]) chain[m] = vi.fn(() => chain);
+  chain.maybeSingle = vi.fn(() => Promise.resolve(result));
+  return chain;
+}
+
+function makeUpsertChain(result: { error: unknown }) {
+  return {
+    upsert: vi.fn(() => Promise.resolve(result)),
+  };
+}
+
+describe("GET /api/account/watchlist/alerts", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: null } });
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
+  it("returns the user's current preference", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    mockFrom.mockReturnValueOnce(
+      makeSelectChain({
+        data: { alerts_opted_in: true, last_digest_sent_at: "2026-05-05T09:00:00Z" },
+        error: null,
+      }),
+    );
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      alerts_opted_in: true,
+      last_digest_sent_at: "2026-05-05T09:00:00Z",
+    });
+  });
+
+  it("defaults to opted_in=false when no row exists", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    mockFrom.mockReturnValueOnce(makeSelectChain({ data: null, error: null }));
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      alerts_opted_in: false,
+      last_digest_sent_at: null,
+    });
+  });
+
+  it("returns 500 when the read errors", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    mockFrom.mockReturnValueOnce(
+      makeSelectChain({ data: null, error: { message: "boom" } }),
+    );
+    const res = await GET();
+    expect(res.status).toBe(500);
+  });
+});
+
+describe("PUT /api/account/watchlist/alerts", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: null } });
+    const res = await PUT(makePut({ alerts_opted_in: true }));
+    expect(res.status).toBe(401);
+  });
+
+  it("upserts the preference and echoes it back", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    const upsertChain = makeUpsertChain({ error: null });
+    mockFrom.mockReturnValueOnce(upsertChain);
+    const res = await PUT(makePut({ alerts_opted_in: true }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ alerts_opted_in: true });
+    expect(upsertChain.upsert).toHaveBeenCalledOnce();
+    const upsertArgs = upsertChain.upsert.mock.calls[0] as unknown as [Record<string, unknown>];
+    expect(upsertArgs[0]).toMatchObject({ user_id: USER.id, alerts_opted_in: true });
+  });
+
+  it("rejects invalid body via validation wrapper", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    const res = await PUT(makePut({ alerts_opted_in: "yes" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 500 when the upsert errors", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    mockFrom.mockReturnValueOnce(makeUpsertChain({ error: { message: "boom" } }));
+    const res = await PUT(makePut({ alerts_opted_in: false }));
+    expect(res.status).toBe(500);
+  });
+});

--- a/__tests__/api/cron-watchlist-alerts.test.ts
+++ b/__tests__/api/cron-watchlist-alerts.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { NextRequest } from "next/server";
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+vi.mock("@/lib/cron-auth", () => ({
+  requireCronAuth: vi.fn(() => null),
+}));
+
+interface SendArgs {
+  to: string;
+  subject: string;
+  html: string;
+}
+const sendEmailMock = vi.fn(async (_opts: SendArgs) => ({ ok: true as const }));
+vi.mock("@/lib/resend", () => ({
+  sendEmail: (opts: SendArgs) => sendEmailMock(opts),
+}));
+
+interface PreferenceRow {
+  user_id: string;
+  last_digest_window_start: string | null;
+}
+interface ItemRow {
+  user_id: string;
+  id: number;
+  item_type: string;
+  item_slug: string;
+  display_name: string | null;
+}
+interface BrokerRow {
+  slug: string;
+  name: string;
+  updated_at: string;
+}
+interface ArticleRow {
+  slug: string;
+  title: string;
+  excerpt: string | null;
+  related_brokers: unknown;
+  published_at: string;
+}
+
+const state = {
+  prefs: [] as PreferenceRow[],
+  items: [] as ItemRow[],
+  brokers: [] as BrokerRow[],
+  articles: [] as ArticleRow[],
+  updateCalls: [] as { user_id: string; patch: Record<string, unknown> }[],
+  authUsers: [] as { id: string; email: string | null; user_metadata: Record<string, string> }[],
+};
+
+function thenable<T>(value: T) {
+  return {
+    then: (resolve: (v: T) => unknown) => Promise.resolve(value).then(resolve),
+  };
+}
+
+const mockFrom = vi.fn((table: string) => {
+  if (table === "watchlist_alert_preferences") {
+    const chain = {
+      select: () => chain,
+      eq: () => chain,
+      update: (patch: Record<string, unknown>) => ({
+        eq: (_col: string, userId: string) => {
+          state.updateCalls.push({ user_id: userId, patch });
+          return Promise.resolve({ error: null });
+        },
+      }),
+      ...thenable({ data: state.prefs, error: null }),
+    };
+    return chain;
+  }
+  if (table === "user_watchlist_items") {
+    const chain = {
+      select: () => chain,
+      in: () => chain,
+      ...thenable({ data: state.items, error: null }),
+    };
+    return chain;
+  }
+  if (table === "brokers") {
+    const chain = {
+      select: () => chain,
+      in: () => chain,
+      gte: () => chain,
+      ...thenable({ data: state.brokers, error: null }),
+    };
+    return chain;
+  }
+  if (table === "articles") {
+    const chain = {
+      select: () => chain,
+      gte: () => chain,
+      order: () => chain,
+      limit: () => chain,
+      ...thenable({ data: state.articles, error: null }),
+    };
+    return chain;
+  }
+  throw new Error(`unexpected table: ${table}`);
+});
+
+const mockListUsers = vi.fn(async (_opts: { page: number; perPage: number }) => ({
+  data: { users: state.authUsers },
+  error: null,
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({
+    from: mockFrom,
+    auth: { admin: { listUsers: mockListUsers } },
+  })),
+}));
+
+import { GET } from "@/app/api/cron/watchlist-alerts/route";
+
+function makeReq(): NextRequest {
+  return {
+    headers: new Headers({ Authorization: "Bearer test" }),
+    url: "https://invest.com.au/api/cron/watchlist-alerts",
+  } as unknown as NextRequest;
+}
+
+describe("cron/watchlist-alerts", () => {
+  beforeEach(() => {
+    vi.stubEnv("RESEND_API_KEY", "test-key");
+    state.prefs = [];
+    state.items = [];
+    state.brokers = [];
+    state.articles = [];
+    state.updateCalls.length = 0;
+    state.authUsers = [];
+    sendEmailMock.mockClear();
+    mockListUsers.mockClear();
+  });
+
+  it("returns 500 when RESEND_API_KEY is unset", async () => {
+    vi.stubEnv("RESEND_API_KEY", "");
+    const res = await GET(makeReq());
+    expect(res.status).toBe(500);
+  });
+
+  it("skips silently when no users have opted in", async () => {
+    state.prefs = [];
+    const res = await GET(makeReq());
+    const body = await res.json();
+    expect(body).toEqual({ ok: true, skipped: "no_opt_in" });
+    expect(sendEmailMock).not.toHaveBeenCalled();
+  });
+
+  it("skips users whose watchlists produced no signal", async () => {
+    state.prefs = [{ user_id: "u-1", last_digest_window_start: null }];
+    state.items = [{ user_id: "u-1", id: 1, item_type: "broker", item_slug: "commsec", display_name: "CommSec" }];
+    state.brokers = []; // no recent broker updates
+    state.articles = [];
+    state.authUsers = [{ id: "u-1", email: "alice@x.com", user_metadata: {} }];
+    const res = await GET(makeReq());
+    const body = await res.json();
+    expect(body.skipped_empty).toBe(1);
+    expect(body.sent).toBe(0);
+    expect(sendEmailMock).not.toHaveBeenCalled();
+  });
+
+  it("sends a digest when there is a recent broker update", async () => {
+    const now = new Date();
+    state.prefs = [{ user_id: "u-1", last_digest_window_start: null }];
+    state.items = [{ user_id: "u-1", id: 1, item_type: "broker", item_slug: "commsec", display_name: "CommSec" }];
+    state.brokers = [{ slug: "commsec", name: "CommSec", updated_at: now.toISOString() }];
+    state.authUsers = [{ id: "u-1", email: "alice@x.com", user_metadata: { full_name: "Alice" } }];
+    const res = await GET(makeReq());
+    const body = await res.json();
+    expect(body.sent).toBe(1);
+    expect(sendEmailMock).toHaveBeenCalledOnce();
+    const sendCall = sendEmailMock.mock.calls[0] as unknown as [SendArgs];
+    const sendArgs = sendCall[0];
+    expect(sendArgs.to).toBe("alice@x.com");
+    expect(sendArgs.subject).toMatch(/1 update/);
+    expect(sendArgs.html).toContain("Hi Alice");
+    expect(state.updateCalls).toHaveLength(1);
+    expect(state.updateCalls[0]?.user_id).toBe("u-1");
+  });
+
+  it("skips users with no email on file rather than failing the run", async () => {
+    state.prefs = [{ user_id: "u-1", last_digest_window_start: null }];
+    state.items = [{ user_id: "u-1", id: 1, item_type: "broker", item_slug: "commsec", display_name: "CommSec" }];
+    state.brokers = [{ slug: "commsec", name: "CommSec", updated_at: new Date().toISOString() }];
+    state.authUsers = [{ id: "u-1", email: null, user_metadata: {} }];
+    const res = await GET(makeReq());
+    const body = await res.json();
+    expect(body.sent).toBe(0);
+    expect(body.skipped_no_email).toBe(1);
+    expect(sendEmailMock).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/lib/watchlist-alerts.test.ts
+++ b/__tests__/lib/watchlist-alerts.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect } from "vitest";
+import {
+  collectChangesForUser,
+  isWatchableType,
+  renderWatchlistDigestHtml,
+  type ArticleSnapshot,
+  type BrokerSnapshot,
+  type WatchlistItemRow,
+} from "@/lib/watchlist-alerts";
+
+const NOW = new Date("2026-05-12T09:00:00Z");
+const WINDOW_START = new Date(NOW.getTime() - 7 * 86400_000);
+const BEFORE_WINDOW = new Date(WINDOW_START.getTime() - 86400_000).toISOString();
+const AFTER_WINDOW = new Date(WINDOW_START.getTime() + 86400_000).toISOString();
+
+function watchedBroker(slug: string, name = slug): WatchlistItemRow {
+  return { id: 1, item_type: "broker", item_slug: slug, display_name: name };
+}
+
+function brokerSnap(slug: string, updated_at: string): BrokerSnapshot {
+  return { slug, name: slug.toUpperCase(), updated_at };
+}
+
+function articleSnap(opts: Partial<ArticleSnapshot> & { slug: string; related_brokers: string[] }): ArticleSnapshot {
+  return {
+    title: "Article title",
+    excerpt: "Article excerpt",
+    published_at: AFTER_WINDOW,
+    ...opts,
+  };
+}
+
+describe("isWatchableType", () => {
+  it("recognises known types", () => {
+    expect(isWatchableType("broker")).toBe(true);
+    expect(isWatchableType("etf")).toBe(true);
+    expect(isWatchableType("stock")).toBe(true);
+    expect(isWatchableType("fund")).toBe(true);
+    expect(isWatchableType("crypto")).toBe(true);
+  });
+
+  it("rejects unknown types", () => {
+    expect(isWatchableType("bond")).toBe(false);
+    expect(isWatchableType("")).toBe(false);
+  });
+});
+
+describe("collectChangesForUser", () => {
+  it("returns an empty list when nothing changed in the window", () => {
+    const changes = collectChangesForUser({
+      items: [watchedBroker("commsec")],
+      windowStart: WINDOW_START,
+      brokers: [brokerSnap("commsec", BEFORE_WINDOW)],
+      articles: [],
+    });
+    expect(changes).toEqual([]);
+  });
+
+  it("emits a broker_update when the broker row updated inside the window", () => {
+    const changes = collectChangesForUser({
+      items: [watchedBroker("commsec", "CommSec")],
+      windowStart: WINDOW_START,
+      brokers: [brokerSnap("commsec", AFTER_WINDOW)],
+      articles: [],
+    });
+    expect(changes).toHaveLength(1);
+    expect(changes[0]).toMatchObject({
+      kind: "broker_update",
+      item_slug: "commsec",
+      display_name: "CommSec",
+      href: "/brokers/commsec",
+    });
+  });
+
+  it("emits a related_article when an article tags a watched broker", () => {
+    const changes = collectChangesForUser({
+      items: [watchedBroker("stake")],
+      windowStart: WINDOW_START,
+      brokers: [],
+      articles: [
+        articleSnap({
+          slug: "stake-fees-2026",
+          title: "Stake cuts US fees",
+          excerpt: "From May 2026 Stake is dropping US trade fees…",
+          related_brokers: ["stake"],
+        }),
+      ],
+    });
+    expect(changes).toHaveLength(1);
+    expect(changes[0]).toMatchObject({
+      kind: "related_article",
+      headline: "New: Stake cuts US fees",
+      href: "/articles/stake-fees-2026",
+    });
+  });
+
+  it("ignores articles tagged with brokers the user isn't watching", () => {
+    const changes = collectChangesForUser({
+      items: [watchedBroker("stake")],
+      windowStart: WINDOW_START,
+      brokers: [],
+      articles: [
+        articleSnap({
+          slug: "commsec-news",
+          title: "CommSec news",
+          related_brokers: ["commsec"],
+        }),
+      ],
+    });
+    expect(changes).toEqual([]);
+  });
+
+  it("ignores articles published before the window starts", () => {
+    const changes = collectChangesForUser({
+      items: [watchedBroker("stake")],
+      windowStart: WINDOW_START,
+      brokers: [],
+      articles: [
+        articleSnap({
+          slug: "old-article",
+          title: "Old news",
+          related_brokers: ["stake"],
+          published_at: BEFORE_WINDOW,
+        }),
+      ],
+    });
+    expect(changes).toEqual([]);
+  });
+
+  it("skips items with unknown types defensively", () => {
+    const changes = collectChangesForUser({
+      items: [{ id: 1, item_type: "bond", item_slug: "x", display_name: null }],
+      windowStart: WINDOW_START,
+      brokers: [],
+      articles: [],
+    });
+    expect(changes).toEqual([]);
+  });
+
+  it("sorts changes newest-first", () => {
+    const oldArticle = articleSnap({
+      slug: "first",
+      title: "First",
+      related_brokers: ["commsec"],
+      published_at: new Date(WINDOW_START.getTime() + 86400_000).toISOString(),
+    });
+    const newArticle = articleSnap({
+      slug: "second",
+      title: "Second",
+      related_brokers: ["commsec"],
+      published_at: new Date(WINDOW_START.getTime() + 2 * 86400_000).toISOString(),
+    });
+    const changes = collectChangesForUser({
+      items: [watchedBroker("commsec")],
+      windowStart: WINDOW_START,
+      brokers: [],
+      articles: [oldArticle, newArticle],
+    });
+    expect(changes.map((c) => c.headline)).toEqual(["New: Second", "New: First"]);
+  });
+});
+
+describe("renderWatchlistDigestHtml", () => {
+  it("returns null for empty change lists", () => {
+    expect(
+      renderWatchlistDigestHtml({
+        changes: [],
+        recipientName: "Alex",
+        now: NOW,
+        unsubscribeHref: "/account/watchlist",
+        manageHref: "/account/watchlist",
+      }),
+    ).toBeNull();
+  });
+
+  it("renders one block per change with HTML-escaped content", () => {
+    const html = renderWatchlistDigestHtml({
+      changes: [
+        {
+          kind: "broker_update",
+          item_slug: "commsec",
+          item_type: "broker",
+          display_name: "CommSec",
+          headline: "CommSec & friends",
+          body: "Fees changed — '<script>' won't run here",
+          href: "/brokers/commsec",
+          occurred_at: AFTER_WINDOW,
+        },
+      ],
+      recipientName: "Alex",
+      now: NOW,
+      unsubscribeHref: "/account/watchlist",
+      manageHref: "/account/watchlist",
+    });
+    expect(html).toContain("Hi Alex");
+    expect(html).toContain("CommSec &amp; friends");
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("/brokers/commsec");
+  });
+
+  it("falls back to 'Hi there' when recipient name is null", () => {
+    const html = renderWatchlistDigestHtml({
+      changes: [
+        {
+          kind: "broker_update",
+          item_slug: "x",
+          item_type: "broker",
+          display_name: "X",
+          headline: "h",
+          body: "b",
+          href: "/brokers/x",
+          occurred_at: AFTER_WINDOW,
+        },
+      ],
+      recipientName: null,
+      now: NOW,
+      unsubscribeHref: "/account/watchlist",
+      manageHref: "/account/watchlist",
+    });
+    expect(html).toContain("Hi there");
+  });
+});

--- a/__tests__/lib/watchlist_alert_preferences.rls.test.ts
+++ b/__tests__/lib/watchlist_alert_preferences.rls.test.ts
@@ -1,0 +1,122 @@
+/**
+ * RLS isolation test for watchlist_alert_preferences (V-NEW-04 gate).
+ *
+ * The table's only owner column is `user_id` (also the PK). Policies in
+ * 20260722_ww02_watchlist_alert_preferences.sql:
+ *   - "user reads own watchlist alert pref" — SELECT WHERE user_id = auth.uid()
+ *   - "user writes own watchlist alert pref" — ALL WHERE user_id = auth.uid()
+ *   - "service_role full access ..." — service role bypass
+ *
+ * This mock simulates the user-facing semantics: user A cannot see, insert
+ * on behalf of, update, or delete user B's row.
+ */
+
+// rls-isolation: watchlist_alert_preferences
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+interface Row {
+  user_id: string;
+  alerts_opted_in: boolean;
+}
+
+function buildMockTableClient(rows: Row[], callerUid: string) {
+  const visible = () => rows.filter((r) => r.user_id === callerUid);
+
+  return {
+    select: vi.fn().mockResolvedValue({ data: visible(), error: null }),
+    insert: vi.fn().mockImplementation((newRow: Partial<Row>) => {
+      if (newRow.user_id !== callerUid) {
+        return Promise.resolve({ data: null, error: { code: "42501", message: "RLS violation" } });
+      }
+      return Promise.resolve({ data: { ...newRow }, error: null });
+    }),
+    update: vi.fn().mockImplementation((patch: Partial<Row>) => ({
+      eq: (_col: string, val: string) => {
+        const target = rows.find((r) => r.user_id === val);
+        if (!target || target.user_id !== callerUid) {
+          return Promise.resolve({ data: null, error: { code: "42501", message: "RLS violation" } });
+        }
+        return Promise.resolve({ data: { ...target, ...patch }, error: null });
+      },
+    })),
+    delete: vi.fn().mockReturnValue({
+      eq: (_col: string, val: string) => {
+        const target = rows.find((r) => r.user_id === val);
+        if (!target || target.user_id !== callerUid) {
+          return Promise.resolve({ data: null, error: { code: "42501", message: "RLS violation" } });
+        }
+        return Promise.resolve({ data: target, error: null });
+      },
+    }),
+  };
+}
+
+const USER_A_UID = "user-a-uuid-0000-0000-000000000001";
+const USER_B_UID = "user-b-uuid-0000-0000-000000000002";
+
+const SEED_ROWS: Row[] = [
+  { user_id: USER_A_UID, alerts_opted_in: true },
+  { user_id: USER_B_UID, alerts_opted_in: false },
+];
+
+describe("watchlist_alert_preferences — RLS isolation", () => {
+  let clientA: ReturnType<typeof buildMockTableClient>;
+  let clientB: ReturnType<typeof buildMockTableClient>;
+
+  beforeEach(() => {
+    clientA = buildMockTableClient([...SEED_ROWS], USER_A_UID);
+    clientB = buildMockTableClient([...SEED_ROWS], USER_B_UID);
+  });
+
+  it("user A only sees their own row on SELECT", async () => {
+    const { data, error } = await clientA.select();
+    expect(error).toBeNull();
+    expect(data).toHaveLength(1);
+    expect(data![0].user_id).toBe(USER_A_UID);
+  });
+
+  it("user A's SELECT never leaks user B's row", async () => {
+    const { data } = await clientA.select();
+    expect(data!.some((r: Row) => r.user_id === USER_B_UID)).toBe(false);
+  });
+
+  it("user B only sees their own row on SELECT", async () => {
+    const { data, error } = await clientB.select();
+    expect(error).toBeNull();
+    expect(data).toHaveLength(1);
+    expect(data![0].user_id).toBe(USER_B_UID);
+  });
+
+  it("user A can INSERT a row keyed to themselves", async () => {
+    const { data, error } = await clientA.insert({ user_id: USER_A_UID, alerts_opted_in: true });
+    expect(error).toBeNull();
+    expect(data).toBeTruthy();
+  });
+
+  it("user A cannot INSERT a row keyed to user B", async () => {
+    const { data, error } = await clientA.insert({ user_id: USER_B_UID, alerts_opted_in: true });
+    expect(data).toBeNull();
+    expect(error?.code).toBe("42501");
+  });
+
+  it("user A can UPDATE their own row", async () => {
+    const { error } = await clientA.update({ alerts_opted_in: false }).eq("user_id", USER_A_UID);
+    expect(error).toBeNull();
+  });
+
+  it("user A cannot UPDATE user B's row", async () => {
+    const { error } = await clientA.update({ alerts_opted_in: true }).eq("user_id", USER_B_UID);
+    expect(error?.code).toBe("42501");
+  });
+
+  it("user A can DELETE their own row", async () => {
+    const { error } = await clientA.delete().eq("user_id", USER_A_UID);
+    expect(error).toBeNull();
+  });
+
+  it("user A cannot DELETE user B's row", async () => {
+    const { error } = await clientA.delete().eq("user_id", USER_B_UID);
+    expect(error?.code).toBe("42501");
+  });
+});

--- a/app/account/watchlist/WatchlistAlertsToggle.tsx
+++ b/app/account/watchlist/WatchlistAlertsToggle.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useState } from "react";
+
+interface Props {
+  initialOptedIn: boolean;
+  hasItems: boolean;
+}
+
+export default function WatchlistAlertsToggle({ initialOptedIn, hasItems }: Props) {
+  const [optedIn, setOptedIn] = useState(initialOptedIn);
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const toggle = async () => {
+    const target = !optedIn;
+    setPending(true);
+    setError(null);
+    // Optimistic flip — revert on error.
+    setOptedIn(target);
+
+    try {
+      const res = await fetch("/api/account/watchlist/alerts", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ alerts_opted_in: target }),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    } catch {
+      setOptedIn(!target);
+      setError("Couldn't save that change. Try again.");
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-4 mb-5">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-semibold text-slate-900">Weekly email digest</p>
+          <p className="text-xs text-slate-500 mt-1">
+            {hasItems
+              ? "Get one email a week when items on your watchlist have news or updates. We skip the email when there's nothing to report."
+              : "Add items to your watchlist below to enable the weekly digest."}
+          </p>
+        </div>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={optedIn}
+          aria-label="Weekly watchlist email digest"
+          onClick={toggle}
+          disabled={pending || !hasItems}
+          className={`shrink-0 inline-flex h-6 w-11 items-center rounded-full transition-colors disabled:opacity-50 ${
+            optedIn ? "bg-emerald-600" : "bg-slate-300"
+          }`}
+        >
+          <span
+            className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+              optedIn ? "translate-x-6" : "translate-x-1"
+            }`}
+          />
+        </button>
+      </div>
+      {error && (
+        <p className="mt-2 text-xs text-red-600">{error}</p>
+      )}
+    </div>
+  );
+}

--- a/app/account/watchlist/page.tsx
+++ b/app/account/watchlist/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
+import WatchlistAlertsToggle from "./WatchlistAlertsToggle";
 import WatchlistClient from "./WatchlistClient";
 
 export const dynamic = "force-dynamic";
@@ -35,6 +36,13 @@ export default async function WatchlistPage() {
     added_at: row.added_at as string,
   }));
 
+  const { data: alertPref } = await supabase
+    .from("watchlist_alert_preferences")
+    .select("alerts_opted_in")
+    .eq("user_id", user.id)
+    .maybeSingle();
+  const alertsOptedIn = alertPref?.alerts_opted_in ?? false;
+
   return (
     <div className="py-6 md:py-10">
       <div className="container-custom max-w-3xl">
@@ -53,6 +61,8 @@ export default async function WatchlistPage() {
             </p>
           </div>
         </div>
+
+        <WatchlistAlertsToggle initialOptedIn={alertsOptedIn} hasItems={items.length > 0} />
 
         <WatchlistClient initialItems={items} />
       </div>

--- a/app/api/account/watchlist/alerts/route.ts
+++ b/app/api/account/watchlist/alerts/route.ts
@@ -1,0 +1,81 @@
+/**
+ * /api/account/watchlist/alerts — per-user opt-in for the watchlist
+ * weekly digest (W2.13 / WW-02). GET returns the current preference,
+ * PUT toggles it. Default (no row) is opted-out.
+ */
+
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { createClient } from "@/lib/supabase/server";
+import { withValidatedBody } from "@/lib/validation/withValidatedBody";
+import { logger } from "@/lib/logger";
+
+const log = logger("api:account:watchlist:alerts");
+
+export const runtime = "nodejs";
+
+const PutBody = z.object({
+  alerts_opted_in: z.boolean(),
+});
+
+interface PreferenceResponse {
+  alerts_opted_in: boolean;
+  last_digest_sent_at: string | null;
+}
+
+export async function GET() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { data, error } = await supabase
+    .from("watchlist_alert_preferences")
+    .select("alerts_opted_in, last_digest_sent_at")
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  if (error) {
+    log.error("preference fetch failed", { userId: user.id, error: error.message });
+    return NextResponse.json({ error: "Failed to load preference" }, { status: 500 });
+  }
+
+  const response: PreferenceResponse = {
+    alerts_opted_in: data?.alerts_opted_in ?? false,
+    last_digest_sent_at: data?.last_digest_sent_at ?? null,
+  };
+  return NextResponse.json(response);
+}
+
+export const PUT = withValidatedBody(PutBody, async (_req, body) => {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { error } = await supabase
+    .from("watchlist_alert_preferences")
+    .upsert(
+      {
+        user_id: user.id,
+        alerts_opted_in: body.alerts_opted_in,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: "user_id" },
+    );
+
+  if (error) {
+    log.error("preference upsert failed", { userId: user.id, error: error.message });
+    return NextResponse.json({ error: "Failed to save preference" }, { status: 500 });
+  }
+
+  const response: PreferenceResponse = {
+    alerts_opted_in: body.alerts_opted_in,
+    last_digest_sent_at: null,
+  };
+  return NextResponse.json(response);
+});

--- a/app/api/cron/watchlist-alerts/route.ts
+++ b/app/api/cron/watchlist-alerts/route.ts
@@ -1,0 +1,309 @@
+/**
+ * Cron: watchlist weekly digest (W2.13 / WW-02).
+ *
+ * For each user with `watchlist_alert_preferences.alerts_opted_in=true`,
+ * scan their watchlist for changes since their `last_digest_window_start`
+ * (or 7d ago if unset), and send a Resend digest if there's anything to
+ * report.
+ *
+ * Behaviour:
+ *   - Empty digests are skipped per-user — never send "nothing changed".
+ *   - last_digest_window_start advances to "now" on every successful send,
+ *     so weeks with no signal don't carry forward into a giant catch-up
+ *     digest the next time something changes.
+ *   - De-dup: a successful send updates last_digest_sent_at on the user's
+ *     preference row; re-running within the same edition window won't
+ *     re-send.
+ *
+ * Wired into lib/cron-groups.ts under weekly-mon-9. Pure helpers live in
+ * lib/watchlist-alerts.ts.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+import { requireCronAuth } from "@/lib/cron-auth";
+import { sendEmail } from "@/lib/resend";
+import {
+  collectChangesForUser,
+  renderWatchlistDigestHtml,
+  type ArticleSnapshot,
+  type BrokerSnapshot,
+  type WatchlistItemRow,
+} from "@/lib/watchlist-alerts";
+
+const log = logger("cron:watchlist-alerts");
+
+export const runtime = "nodejs";
+export const maxDuration = 300;
+
+const DEFAULT_WINDOW_MS = 7 * 86400_000;
+const UNSUBSCRIBE_HREF = "/account/watchlist";
+const MANAGE_HREF = "/account/watchlist";
+
+interface PreferenceRow {
+  user_id: string;
+  last_digest_window_start: string | null;
+}
+
+interface UserRow {
+  id: string;
+  email: string | null;
+  raw_user_meta_data: { full_name?: string; name?: string } | null;
+}
+
+export async function GET(req: NextRequest) {
+  const unauth = requireCronAuth(req);
+  if (unauth) return unauth;
+
+  const resendApiKey = process.env.RESEND_API_KEY;
+  if (!resendApiKey) {
+    return NextResponse.json({ error: "RESEND_API_KEY not configured" }, { status: 500 });
+  }
+
+  const supabase = createAdminClient();
+  const now = new Date();
+  const fallbackWindowStart = new Date(now.getTime() - DEFAULT_WINDOW_MS);
+
+  // 1. Opted-in user IDs.
+  const { data: prefs, error: prefsErr } = await supabase
+    .from("watchlist_alert_preferences")
+    .select("user_id, last_digest_window_start")
+    .eq("alerts_opted_in", true);
+
+  if (prefsErr) {
+    log.error("preferences fetch failed", { error: prefsErr.message });
+    return NextResponse.json(
+      { error: "prefs_fetch_failed", detail: prefsErr.message },
+      { status: 500 },
+    );
+  }
+
+  const optedIn = (prefs ?? []) as PreferenceRow[];
+  if (optedIn.length === 0) {
+    log.info("no opted-in users — skipping run");
+    return NextResponse.json({ ok: true, skipped: "no_opt_in" });
+  }
+
+  // 2. Load shared change-detection inputs (brokers + recent articles)
+  //    in two batched queries. Per-user filtering happens in pure JS.
+  const userIds = optedIn.map((p) => p.user_id);
+  const oldestWindowStart = optedIn.reduce<Date>((acc, p) => {
+    const t = p.last_digest_window_start ? new Date(p.last_digest_window_start) : fallbackWindowStart;
+    return t < acc ? t : acc;
+  }, fallbackWindowStart);
+
+  const { data: itemsRaw, error: itemsErr } = await supabase
+    .from("user_watchlist_items")
+    .select("user_id, id, item_type, item_slug, display_name")
+    .in("user_id", userIds);
+
+  if (itemsErr) {
+    log.error("watchlist items fetch failed", { error: itemsErr.message });
+    return NextResponse.json(
+      { error: "items_fetch_failed", detail: itemsErr.message },
+      { status: 500 },
+    );
+  }
+
+  const itemsByUser = new Map<string, WatchlistItemRow[]>();
+  for (const row of itemsRaw ?? []) {
+    const r = row as unknown as { user_id: string } & WatchlistItemRow;
+    const list = itemsByUser.get(r.user_id) ?? [];
+    list.push({
+      id: r.id,
+      item_type: r.item_type,
+      item_slug: r.item_slug,
+      display_name: r.display_name,
+    });
+    itemsByUser.set(r.user_id, list);
+  }
+
+  // Resolve the set of broker slugs watched across all opted-in users.
+  const watchedBrokerSlugs = new Set<string>();
+  for (const items of itemsByUser.values()) {
+    for (const item of items) {
+      if (item.item_type === "broker") watchedBrokerSlugs.add(item.item_slug);
+    }
+  }
+
+  const brokers: BrokerSnapshot[] = await fetchBrokerSnapshots(
+    supabase,
+    Array.from(watchedBrokerSlugs),
+    oldestWindowStart,
+  );
+  const articles: ArticleSnapshot[] = await fetchArticleSnapshots(
+    supabase,
+    oldestWindowStart,
+  );
+
+  // 3. Per-user: build the digest, send if non-empty, record state.
+  const users = await fetchAuthUsers(supabase, userIds);
+  const stats = { sent: 0, skipped_empty: 0, skipped_no_email: 0, failed: 0 };
+
+  for (const pref of optedIn) {
+    const items = itemsByUser.get(pref.user_id) ?? [];
+    if (items.length === 0) {
+      stats.skipped_empty += 1;
+      continue;
+    }
+    const windowStart = pref.last_digest_window_start
+      ? new Date(pref.last_digest_window_start)
+      : fallbackWindowStart;
+
+    const changes = collectChangesForUser({ items, windowStart, brokers, articles });
+    if (changes.length === 0) {
+      stats.skipped_empty += 1;
+      continue;
+    }
+
+    const user = users.get(pref.user_id);
+    if (!user?.email) {
+      stats.skipped_no_email += 1;
+      continue;
+    }
+
+    const recipientName =
+      user.raw_user_meta_data?.full_name?.trim() ||
+      user.raw_user_meta_data?.name?.trim() ||
+      null;
+
+    const html = renderWatchlistDigestHtml({
+      changes,
+      recipientName,
+      now,
+      unsubscribeHref: UNSUBSCRIBE_HREF,
+      manageHref: MANAGE_HREF,
+    });
+
+    if (!html) {
+      stats.skipped_empty += 1;
+      continue;
+    }
+
+    const result = await sendEmail({
+      to: user.email,
+      subject: `📈 Your watchlist this week — ${changes.length} update${changes.length === 1 ? "" : "s"}`,
+      html,
+    });
+
+    if (!result.ok) {
+      stats.failed += 1;
+      log.warn("send failed", { userId: pref.user_id, error: result.error });
+      continue;
+    }
+
+    stats.sent += 1;
+    const nowIso = now.toISOString();
+    const { error: updateErr } = await supabase
+      .from("watchlist_alert_preferences")
+      .update({
+        last_digest_sent_at: nowIso,
+        last_digest_window_start: nowIso,
+        updated_at: nowIso,
+      })
+      .eq("user_id", pref.user_id);
+
+    if (updateErr) {
+      log.warn("preference update after send failed", {
+        userId: pref.user_id,
+        error: updateErr.message,
+      });
+    }
+  }
+
+  log.info("watchlist digest sweep complete", { ...stats, opted_in: optedIn.length });
+  return NextResponse.json({ ok: true, ...stats, opted_in: optedIn.length });
+}
+
+async function fetchBrokerSnapshots(
+  supabase: ReturnType<typeof createAdminClient>,
+  slugs: string[],
+  windowStart: Date,
+): Promise<BrokerSnapshot[]> {
+  if (slugs.length === 0) return [];
+  const { data, error } = await supabase
+    .from("brokers")
+    .select("slug, name, updated_at")
+    .in("slug", slugs)
+    .gte("updated_at", windowStart.toISOString());
+
+  if (error) {
+    log.warn("brokers fetch failed", { error: error.message });
+    return [];
+  }
+  return (data ?? []).map((r) => {
+    const row = r as { slug: string; name: string; updated_at: string };
+    return { slug: row.slug, name: row.name, updated_at: row.updated_at };
+  });
+}
+
+async function fetchArticleSnapshots(
+  supabase: ReturnType<typeof createAdminClient>,
+  windowStart: Date,
+): Promise<ArticleSnapshot[]> {
+  const { data, error } = await supabase
+    .from("articles")
+    .select("slug, title, excerpt, related_brokers, published_at")
+    .gte("published_at", windowStart.toISOString())
+    .order("published_at", { ascending: false })
+    .limit(200);
+
+  if (error) {
+    log.warn("articles fetch failed", { error: error.message });
+    return [];
+  }
+
+  return (data ?? []).map((r) => {
+    const row = r as {
+      slug: string;
+      title: string;
+      excerpt: string | null;
+      related_brokers: unknown;
+      published_at: string;
+    };
+    return {
+      slug: row.slug,
+      title: row.title,
+      excerpt: row.excerpt,
+      related_brokers: Array.isArray(row.related_brokers)
+        ? (row.related_brokers as unknown[]).filter((s): s is string => typeof s === "string")
+        : [],
+      published_at: row.published_at,
+    };
+  });
+}
+
+async function fetchAuthUsers(
+  supabase: ReturnType<typeof createAdminClient>,
+  userIds: string[],
+): Promise<Map<string, UserRow>> {
+  const out = new Map<string, UserRow>();
+  if (userIds.length === 0) return out;
+
+  // auth.admin.listUsers paginates; iterate until we've seen every requested id.
+  const requested = new Set(userIds);
+  let page = 1;
+  const perPage = 200;
+  for (;;) {
+    const { data, error } = await supabase.auth.admin.listUsers({ page, perPage });
+    if (error) {
+      log.warn("auth user listing failed", { error: error.message, page });
+      break;
+    }
+    const users = data?.users ?? [];
+    for (const u of users) {
+      if (!requested.has(u.id)) continue;
+      out.set(u.id, {
+        id: u.id,
+        email: u.email ?? null,
+        raw_user_meta_data: (u.user_metadata ?? null) as UserRow["raw_user_meta_data"],
+      });
+    }
+    if (users.length < perPage) break;
+    if (out.size >= requested.size) break;
+    page += 1;
+    if (page > 50) break; // hard cap — 10k users at 200/page; revisit if we cross this
+  }
+  return out;
+}

--- a/lib/cron-groups.ts
+++ b/lib/cron-groups.ts
@@ -116,7 +116,7 @@ export const CRON_GROUPS: Record<string, readonly string[]> = {
     "/api/cron/weekly-rate-update",
     "/api/cron/personalized-digest",
   ],
-  "weekly-mon-9": ["/api/cron/fee-digest", "/api/cron/content-freshness", "/api/cron/stale-fee-editorial", "/api/cron/check-secret-rotation", "/api/cron/country-rule-alerts-digest"],
+  "weekly-mon-9": ["/api/cron/fee-digest", "/api/cron/content-freshness", "/api/cron/stale-fee-editorial", "/api/cron/check-secret-rotation", "/api/cron/country-rule-alerts-digest", "/api/cron/watchlist-alerts"],
   "weekly-mon-11": ["/api/cron/advisor-dormant-nudge"],
 
   "monthly-1-3": ["/api/cron/property-suburb-refresh"],

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -12758,6 +12758,33 @@ export type Database = {
         }
         Relationships: []
       }
+      watchlist_alert_preferences: {
+        Row: {
+          alerts_opted_in: boolean
+          created_at: string
+          last_digest_sent_at: string | null
+          last_digest_window_start: string | null
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          alerts_opted_in?: boolean
+          created_at?: string
+          last_digest_sent_at?: string | null
+          last_digest_window_start?: string | null
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          alerts_opted_in?: boolean
+          created_at?: string
+          last_digest_sent_at?: string | null
+          last_digest_window_start?: string | null
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
       web_vitals_daily_rollup: {
         Row: {
           device_kind: string

--- a/lib/watchlist-alerts.ts
+++ b/lib/watchlist-alerts.ts
@@ -1,0 +1,210 @@
+/**
+ * Watchlist alert helpers (W2.13 / WW-02).
+ *
+ * The weekly cron at /api/cron/watchlist-alerts uses these pure functions to:
+ *   1. Resolve which watched entities have changed since the last digest.
+ *   2. Render the digest email HTML.
+ *
+ * Compliance: this is comparison + factual surfacing only ("a broker you're
+ * watching updated its fees last week"). Never personalised advice. See
+ * lib/compliance.ts for the disclaimer copy referenced in the footer.
+ */
+
+import { escapeHtml } from "@/lib/html-escape";
+
+export type WatchableType = "stock" | "etf" | "broker" | "fund" | "crypto";
+
+export interface WatchlistItemRow {
+  id: number;
+  item_type: string;
+  item_slug: string;
+  display_name: string | null;
+}
+
+export interface BrokerSnapshot {
+  slug: string;
+  name: string;
+  updated_at: string;
+}
+
+export interface ArticleSnapshot {
+  slug: string;
+  title: string;
+  excerpt: string | null;
+  related_brokers: string[];
+  published_at: string;
+}
+
+export type WatchlistChangeKind = "broker_update" | "related_article";
+
+export interface WatchlistChange {
+  kind: WatchlistChangeKind;
+  item_slug: string;
+  item_type: WatchableType;
+  display_name: string;
+  headline: string;
+  body: string;
+  href: string;
+  occurred_at: string;
+}
+
+const TYPE_HREF_PREFIX: Record<WatchableType, string> = {
+  broker: "/brokers/",
+  etf: "/etfs/",
+  stock: "/stocks/",
+  fund: "/funds/",
+  crypto: "/crypto/",
+};
+
+const KNOWN_TYPES = new Set<WatchableType>(["stock", "etf", "broker", "fund", "crypto"]);
+
+export function isWatchableType(value: string): value is WatchableType {
+  return KNOWN_TYPES.has(value as WatchableType);
+}
+
+/**
+ * Build the change list for a single user.
+ *
+ * Pure function — takes everything it needs as inputs. Cron route is
+ * responsible for batching DB reads (one query for all brokers, one for all
+ * articles in window) and passing them in. Keeps the function testable
+ * without mocking Supabase.
+ */
+export function collectChangesForUser(opts: {
+  items: WatchlistItemRow[];
+  windowStart: Date;
+  brokers: BrokerSnapshot[];
+  articles: ArticleSnapshot[];
+}): WatchlistChange[] {
+  const { items, windowStart, brokers, articles } = opts;
+  const windowMs = windowStart.getTime();
+  const changes: WatchlistChange[] = [];
+
+  const brokerSlugsWatched = new Set<string>();
+  for (const item of items) {
+    if (item.item_type === "broker") brokerSlugsWatched.add(item.item_slug);
+  }
+
+  const brokerBySlug = new Map<string, BrokerSnapshot>();
+  for (const b of brokers) brokerBySlug.set(b.slug, b);
+
+  for (const item of items) {
+    if (!isWatchableType(item.item_type)) continue;
+    const display = item.display_name?.trim() || item.item_slug;
+    const href = `${TYPE_HREF_PREFIX[item.item_type]}${item.item_slug}`;
+
+    // Broker-specific signal: brokers row updated in window.
+    if (item.item_type === "broker") {
+      const broker = brokerBySlug.get(item.item_slug);
+      if (broker && new Date(broker.updated_at).getTime() >= windowMs) {
+        changes.push({
+          kind: "broker_update",
+          item_slug: item.item_slug,
+          item_type: "broker",
+          display_name: display,
+          headline: `${broker.name} listing was updated`,
+          body: "Fees, features or eligibility may have changed since you last looked. Tap through for the current detail.",
+          href,
+          occurred_at: broker.updated_at,
+        });
+      }
+    }
+
+    // Related-article signal: any article tagged with the broker slug.
+    if (item.item_type === "broker" && brokerSlugsWatched.has(item.item_slug)) {
+      for (const article of articles) {
+        if (!article.related_brokers.includes(item.item_slug)) continue;
+        if (new Date(article.published_at).getTime() < windowMs) continue;
+        changes.push({
+          kind: "related_article",
+          item_slug: item.item_slug,
+          item_type: "broker",
+          display_name: display,
+          headline: `New: ${article.title}`,
+          body: article.excerpt ?? `New analysis touching ${display}.`,
+          href: `/articles/${article.slug}`,
+          occurred_at: article.published_at,
+        });
+      }
+    }
+  }
+
+  // Stable order: newest event first.
+  changes.sort((a, b) => b.occurred_at.localeCompare(a.occurred_at));
+  return changes;
+}
+
+/**
+ * Render the digest HTML for one recipient. Returns null when there's
+ * nothing to send — callers should skip sending entirely rather than
+ * mailing an empty digest.
+ */
+export function renderWatchlistDigestHtml(opts: {
+  changes: WatchlistChange[];
+  recipientName: string | null;
+  now: Date;
+  unsubscribeHref: string;
+  manageHref: string;
+}): string | null {
+  const { changes, recipientName, now, unsubscribeHref, manageHref } = opts;
+  if (changes.length === 0) return null;
+
+  const greeting = recipientName ? `Hi ${escapeHtml(recipientName)}` : "Hi there";
+  const dateStr = now.toLocaleDateString("en-AU", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+
+  const changeBlocks = changes
+    .map((c) => {
+      const tagColour = c.kind === "broker_update" ? "#0369a1" : "#15803d";
+      const tagLabel = c.kind === "broker_update" ? "Listing update" : "New article";
+      return `
+      <div style="border-left: 3px solid ${tagColour}; background: #f8fafc; padding: 14px 16px; margin: 0 0 14px; border-radius: 4px;">
+        <div style="font-size: 11px; font-weight: 700; color: ${tagColour}; text-transform: uppercase; letter-spacing: 0.5px; margin: 0 0 4px;">
+          ${tagLabel} · ${escapeHtml(c.display_name)}
+        </div>
+        <div style="font-size: 15px; font-weight: 700; color: #0f172a; margin: 0 0 6px;">
+          ${escapeHtml(c.headline)}
+        </div>
+        <div style="font-size: 13px; color: #334155; line-height: 1.5; margin: 0 0 6px;">
+          ${escapeHtml(c.body)}
+        </div>
+        <a href="https://invest.com.au${escapeHtml(c.href)}" style="display: inline-block; color: #15803d; font-size: 13px; font-weight: 600; text-decoration: none;">View →</a>
+      </div>
+    `;
+    })
+    .join("");
+
+  return `
+<!DOCTYPE html>
+<html>
+<body style="margin: 0; padding: 0; background: #f1f5f9; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;">
+  <div style="max-width: 600px; margin: 0 auto; background: #fff; padding: 32px 24px;">
+    <div style="text-align: center; margin: 0 0 24px;">
+      <div style="font-size: 12px; font-weight: 700; color: #15803d; text-transform: uppercase; letter-spacing: 1px; margin: 0 0 4px;">
+        Your watchlist this week
+      </div>
+      <h1 style="font-size: 22px; color: #0f172a; margin: 0;">${greeting} — here's what changed</h1>
+      <div style="font-size: 13px; color: #64748b; margin: 8px 0 0;">${dateStr} · ${changes.length} update${changes.length === 1 ? "" : "s"}</div>
+    </div>
+
+    ${changeBlocks}
+
+    <div style="text-align: center; margin: 32px 0 0; padding: 20px 0 0; border-top: 1px solid #e2e8f0;">
+      <p style="font-size: 12px; color: #64748b; line-height: 1.6; margin: 0 0 8px;">
+        You're receiving this because you turned on watchlist email alerts on
+        invest.com.au. General information only — not financial advice.
+      </p>
+      <p style="font-size: 12px; margin: 0;">
+        <a href="https://invest.com.au${escapeHtml(manageHref)}" style="color: #64748b;">Manage watchlist</a>
+        &nbsp;·&nbsp;
+        <a href="https://invest.com.au${escapeHtml(unsubscribeHref)}" style="color: #64748b;">Turn off alerts</a>
+      </p>
+    </div>
+  </div>
+</body>
+</html>
+  `.trim();
+}

--- a/supabase/migrations/20260722_ww02_watchlist_alert_preferences.sql
+++ b/supabase/migrations/20260722_ww02_watchlist_alert_preferences.sql
@@ -1,0 +1,81 @@
+-- =============================================================================
+-- Migration: WW-02 — watchlist_alert_preferences per-user opt-in
+-- Date:       2026-07-22
+-- Audit ref:  docs/plans/pre-launch-wave-master-prompt.md Wave 2 / W2.13 PR-X5i
+--             docs/plans/investor-account-end-to-end-plan.md Phase 3
+--             docs/audits/REMEDIATION_QUEUE.md § "Stream WW — Watchlist / portfolio tracker"
+-- Queue item: WW-02
+--
+-- Why: WW-01 (20260716) added user_watchlist_items but not the digest opt-in.
+--   The weekly cron at /api/cron/watchlist-alerts sends a per-user digest only
+--   for users with alerts_opted_in=true. Absence of a row means "opted out",
+--   matching the wider product default of "no email until you tick a box".
+--
+-- Design decisions:
+--   - PK on user_id (one row per user) — there's nothing to disambiguate.
+--   - last_digest_sent_at lets the cron skip users who already received this
+--     edition's digest (re-runs / partial failures don't re-send).
+--   - last_digest_window_start records the timestamp the digest scanned from,
+--     so the next sweep can resume where the last one ended (handles weeks
+--     where the cron didn't fire on time — surface anything since the last
+--     successful send rather than a fixed 7-day rolling window).
+--   - No service-role-only policy: cron writes via the existing service-role
+--     escape hatch (per CLAUDE.md, cron jobs use createAdminClient()).
+--
+-- Idempotency: CREATE TABLE IF NOT EXISTS; DROP POLICY IF EXISTS before
+--   each CREATE POLICY; ENABLE/FORCE ROW LEVEL SECURITY is idempotent.
+--
+-- Rollback:
+--   BEGIN;
+--     DROP POLICY IF EXISTS "user reads own watchlist alert pref"
+--       ON public.watchlist_alert_preferences;
+--     DROP POLICY IF EXISTS "user writes own watchlist alert pref"
+--       ON public.watchlist_alert_preferences;
+--     DROP POLICY IF EXISTS "service_role full access watchlist_alert_preferences"
+--       ON public.watchlist_alert_preferences;
+--     ALTER TABLE public.watchlist_alert_preferences DISABLE ROW LEVEL SECURITY;
+--     -- DROP TABLE public.watchlist_alert_preferences; -- only on clean rebuild
+--   COMMIT;
+-- =============================================================================
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.watchlist_alert_preferences (
+  user_id                  uuid PRIMARY KEY REFERENCES auth.users (id) ON DELETE CASCADE,
+  alerts_opted_in          boolean      NOT NULL DEFAULT false,
+  last_digest_sent_at      timestamptz,
+  last_digest_window_start timestamptz,
+  created_at               timestamptz  NOT NULL DEFAULT now(),
+  updated_at               timestamptz  NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_watchlist_alert_preferences_opted_in
+  ON public.watchlist_alert_preferences (user_id)
+  WHERE alerts_opted_in = true;
+
+ALTER TABLE public.watchlist_alert_preferences ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.watchlist_alert_preferences FORCE  ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "user reads own watchlist alert pref"
+  ON public.watchlist_alert_preferences;
+CREATE POLICY "user reads own watchlist alert pref"
+  ON public.watchlist_alert_preferences
+  FOR SELECT TO authenticated
+  USING (user_id = auth.uid());
+
+DROP POLICY IF EXISTS "user writes own watchlist alert pref"
+  ON public.watchlist_alert_preferences;
+CREATE POLICY "user writes own watchlist alert pref"
+  ON public.watchlist_alert_preferences
+  FOR ALL TO authenticated
+  USING     (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());
+
+DROP POLICY IF EXISTS "service_role full access watchlist_alert_preferences"
+  ON public.watchlist_alert_preferences;
+CREATE POLICY "service_role full access watchlist_alert_preferences"
+  ON public.watchlist_alert_preferences
+  FOR ALL TO service_role
+  USING (true) WITH CHECK (true);
+
+COMMIT;


### PR DESCRIPTION
## Summary
Adds the watchlist weekly email digest path promised in the investor-account
plan since Phase 3 (PR-X5i). Per-user opt-in (default off); the cron skips
empty digests; sends one email per opted-in user with non-empty changes.

## Why
WW-01 shipped the watchlist data model in 20260716 but the email path was
left to a follow-up. Without it, watchlists are a passive page nobody
revisits — the weekly digest is the recurring touchpoint that makes
watching a thing worthwhile, and it's the foundation the wider investor
portal needs before goal-based notifications make sense.

## Tier
**Tier B** — additive table + cron + UI. RLS-scoped per user; cron writes
via the existing service-role escape hatch (covered by CLAUDE.md's allowed
scope for cron jobs). Subject to the standard 15-min Sentry/Vercel
observation window post-merge.

## Files
- `supabase/migrations/20260722_ww02_watchlist_alert_preferences.sql` — new
  table, RLS, indexes, rollback documented.
- `lib/database.types.ts` — generated type entry.
- `lib/watchlist-alerts.ts` — pure helpers: `collectChangesForUser`,
  `renderWatchlistDigestHtml`, `isWatchableType`.
- `app/api/cron/watchlist-alerts/route.ts` — weekly Mon-9 cron.
- `app/api/account/watchlist/alerts/route.ts` — GET/PUT toggle.
- `app/account/watchlist/WatchlistAlertsToggle.tsx` + `page.tsx` — UI
  toggle mounted above the watchlist list.
- `lib/cron-groups.ts` — wires cron into `weekly-mon-9`.
- 3 new test files (25 tests).

## Supersedes
_None._

## Test plan
- [x] vitest local: 25/25 pass across the 3 new test files
- [x] `tsc --noEmit`: clean
- [x] pre-push hook: type-check + rate-limit audit + changed-test run all pass
- [ ] CI: pending
- [ ] Visual: sign in → /account/watchlist → toggle the new switch on/off
  (verify it persists after refresh; verify it's disabled when watchlist
  is empty)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FtBMD93PSNhpw3k1v8mBj1)_