### PR TITLE
Temporarily hide HomeConciergeEntry on homepage

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,6 @@
 import { createClient } from "@/lib/supabase/server";
 import type { Broker } from "@/lib/types";
 import HomeHero from "@/components/HomeHero";
-import HomeConciergeEntry from "@/components/HomeConciergeEntry";
 import HomeRouteCards from "@/components/HomeRouteCards";
 import CountryToolsStripWrapper from "@/components/country-mode/CountryToolsStripWrapper";
 import HomePathfinder from "@/components/HomePathfinder";
@@ -245,7 +244,8 @@ export default async function HomePage() {
         advisorCount={totalProfessionalCount}
       />
 
-      <HomeConciergeEntry />
+      {/* Temporarily hidden for the next few months. Keep the component intact
+          so the homepage AI concierge entry can be restored without rebuilding it. */}
 
       <ScrollFadeIn>
         <HomeRouteCards


### PR DESCRIPTION
### Motivation
- Temporarily remove the AI concierge entry from the homepage UI for the next few months while keeping the component available for easy restoration.

### Description
- Removed the `HomeConciergeEntry` import and commented out its render in `app/page.tsx`, replacing it with an explanatory inline comment so the component remains in the codebase.

### Testing
- Ran the project typecheck and build and lint checks (`pnpm build` and `pnpm lint`) after the change and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a033594df5c83229fc1e29eca78c17d)