### PR TITLE
Temporarily hide HomeConciergeEntry and reposition CountryToolsStripWrapper on homepage

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,6 @@
 import { createClient } from "@/lib/supabase/server";
 import type { Broker } from "@/lib/types";
 import HomeHero from "@/components/HomeHero";
-import HomeConciergeEntry from "@/components/HomeConciergeEntry";
 import HomeRouteCards from "@/components/HomeRouteCards";
 import CountryToolsStripWrapper from "@/components/country-mode/CountryToolsStripWrapper";
 import HomePathfinder from "@/components/HomePathfinder";
@@ -245,7 +244,8 @@ export default async function HomePage() {
         advisorCount={totalProfessionalCount}
       />
 
-      <HomeConciergeEntry />
+      {/* Temporarily hidden for the next few months. Keep the component intact
+          so the homepage AI concierge entry can be restored without rebuilding it. */}
 
       <ScrollFadeIn>
         <HomeRouteCards
@@ -256,10 +256,6 @@ export default async function HomePage() {
           topListings={topListingsForCards}
           topAdvisors={topAdvisorsForCards}
         />
-      </ScrollFadeIn>
-
-      <ScrollFadeIn>
-        <CountryToolsStripWrapper />
       </ScrollFadeIn>
 
       <CountryPopularLinks />
@@ -306,6 +302,10 @@ export default async function HomePage() {
 
       <ScrollFadeIn>
         <HomeHowWeEarn />
+      </ScrollFadeIn>
+
+      <ScrollFadeIn>
+        <CountryToolsStripWrapper />
       </ScrollFadeIn>
 
       <MobileBottomNav />


### PR DESCRIPTION
### Motivation

- Temporarily remove the AI concierge entry from the homepage while preserving the component for easy restoration later. 
- Move the country tools strip to later in the page flow to adjust homepage layout and rendering order.

### Description

- Removed the `HomeConciergeEntry` render from the homepage and deleted its import, leaving a commented note explaining the temporary hide. 
- Reinserted `CountryToolsStripWrapper` inside a `ScrollFadeIn` block near the bottom of the homepage and removed its earlier placement. 
- Kept all other homepage components and metadata intact to preserve ISR cacheability and country-mode behavior.

### Testing

- Ran TypeScript type-check with `tsc --noEmit` and it completed without errors. 
- Ran lint with `eslint .` and no new issues were reported. 
- Executed the project's test suite with `npm test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a033594df5c83229fc1e29eca78c17d)