### PR TITLE
Remove homepage earnings section

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,7 +10,6 @@ import HomePostAJob from "@/components/HomePostAJob";
 import HomeCompareDeepDive, { type CompareBroker } from "@/components/HomeCompareDeepDive";
 import HomeCrossBorder from "@/components/HomeCrossBorder";
 import HomeFridayBriefing from "@/components/HomeFridayBriefing";
-import HomeHowWeEarn from "@/components/HomeHowWeEarn";
 import CountryListingsPreview from "@/components/country-mode/CountryListingsPreview";
 import CountryExpertsPreview from "@/components/country-mode/CountryExpertsPreview";
 import CountryComparePreview from "@/components/country-mode/CountryComparePreview";
@@ -298,10 +297,6 @@ export default async function HomePage() {
 
       <ScrollFadeIn>
         <HomeFridayBriefing />
-      </ScrollFadeIn>
-
-      <ScrollFadeIn>
-        <HomeHowWeEarn />
       </ScrollFadeIn>
 
       <ScrollFadeIn>


### PR DESCRIPTION
### Motivation
- Hide the “How invest.com.au earns” earnings breakdown from the homepage so the homepage no longer surfaces that disclosure block.

### Description
- Removed the `HomeHowWeEarn` import and the rendered `<ScrollFadeIn><HomeHowWeEarn /></ScrollFadeIn>` block from `app/page.tsx`, so the homepage now flows directly from `HomeFridayBriefing` to `CountryToolsStripWrapper`.

### Testing
- Ran `npx eslint app/page.tsx` and `git diff --check`, and both completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a038f88f0888322965641290106e426)