### PR TITLE
Fix onboarding Finish flow — sanitize payload, surface errors, and handle redirects

### DIFF
--- a/__tests__/api/user-profile.test.ts
+++ b/__tests__/api/user-profile.test.ts
@@ -57,7 +57,9 @@ describe("GET /api/user-profile", () => {
     mockGetUser.mockResolvedValueOnce({ data: { user: null } });
     const res = await GET();
     expect(res.status).toBe(401);
-    expect(await res.json()).toMatchObject({ error: expect.stringContaining("sign in") });
+    expect(await res.json()).toMatchObject({
+      error: expect.stringContaining("sign in"),
+    });
   });
 
   it("returns { profile } when profile row exists", async () => {
@@ -108,7 +110,9 @@ describe("PUT /api/user-profile", () => {
     mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
     const res = await PUT(makePut({ unknown_field: "value" }));
     expect(res.status).toBe(400);
-    expect(await res.json()).toMatchObject({ error: expect.stringContaining("invalid") });
+    expect(await res.json()).toMatchObject({
+      error: expect.stringContaining("invalid"),
+    });
   });
 
   it("rejects invalid investing_experience enum value (no allowed fields → 400)", async () => {
@@ -149,13 +153,40 @@ describe("PUT /api/user-profile", () => {
     );
   });
 
+  it("accepts onboarding completion as a standalone update", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    const chain = makeChain({
+      data: { ...PROFILE, onboarding_completed: true },
+      error: null,
+    });
+    mockFrom.mockReturnValue(chain);
+    const res = await PUT(makePut({ onboarding_completed: true }));
+    expect(res.status).toBe(200);
+    expect(chain.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ onboarding_completed: true }),
+      expect.anything(),
+    );
+  });
+
   it("filters interested_in to known values and caps at 8", async () => {
     mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
     const chain = makeChain({ data: PROFILE, error: null });
     mockFrom.mockReturnValue(chain);
-    const interests = ["shares", "etfs", "crypto", "super", "property", "savings", "insurance", "cfd_forex", "bogus"];
+    const interests = [
+      "shares",
+      "etfs",
+      "crypto",
+      "super",
+      "property",
+      "savings",
+      "insurance",
+      "cfd_forex",
+      "bogus",
+    ];
     await PUT(makePut({ interested_in: interests }));
-    const upsertCall = chain.upsert.mock.calls[0][0] as { interested_in: string[] };
+    const upsertCall = chain.upsert.mock.calls[0][0] as {
+      interested_in: string[];
+    };
     expect(upsertCall.interested_in).not.toContain("bogus");
     expect(upsertCall.interested_in.length).toBeLessThanOrEqual(8);
   });
@@ -166,7 +197,9 @@ describe("PUT /api/user-profile", () => {
     mockFrom.mockReturnValue(chain);
     const longName = "  " + "A".repeat(150) + "  ";
     await PUT(makePut({ display_name: longName }));
-    const upsertCall = chain.upsert.mock.calls[0][0] as { display_name: string };
+    const upsertCall = chain.upsert.mock.calls[0][0] as {
+      display_name: string;
+    };
     expect(upsertCall.display_name.length).toBe(100);
     expect(upsertCall.display_name).not.toMatch(/^\s/);
   });
@@ -181,7 +214,9 @@ describe("PUT /api/user-profile", () => {
 
   it("returns 503 when createClient throws during PUT", async () => {
     mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
-    mockFrom.mockImplementation(() => { throw new Error("connection refused"); });
+    mockFrom.mockImplementation(() => {
+      throw new Error("connection refused");
+    });
     const res = await PUT(makePut({ display_name: "Alice" }));
     expect(res.status).toBe(503);
   });

--- a/__tests__/onboarding-payload.test.ts
+++ b/__tests__/onboarding-payload.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildOnboardingProfilePayload,
+  type OnboardingData,
+} from "@/app/onboarding/onboarding-payload";
+
+const baseForm: OnboardingData = {
+  interested_in: ["shares"],
+  investing_experience: "beginner",
+  investment_goals: "growth",
+  display_name: "Alex",
+  portfolio_size: "under_10k",
+  state: "NSW",
+};
+
+describe("buildOnboardingProfilePayload", () => {
+  it("always marks onboarding as completed", () => {
+    expect(buildOnboardingProfilePayload(baseForm)).toMatchObject({
+      onboarding_completed: true,
+    });
+  });
+
+  it("omits optional blank values from the final onboarding step", () => {
+    const payload = buildOnboardingProfilePayload({
+      ...baseForm,
+      display_name: "   ",
+      portfolio_size: "",
+      state: "",
+    });
+
+    expect(payload).not.toHaveProperty("display_name");
+    expect(payload).not.toHaveProperty("portfolio_size");
+    expect(payload).not.toHaveProperty("state");
+  });
+
+  it("trims supplied text fields before sending them to the profile API", () => {
+    expect(
+      buildOnboardingProfilePayload({
+        ...baseForm,
+        display_name: "  Alex Investor  ",
+      }),
+    ).toMatchObject({
+      display_name: "Alex Investor",
+    });
+  });
+});

--- a/app/onboarding/OnboardingClient.tsx
+++ b/app/onboarding/OnboardingClient.tsx
@@ -4,6 +4,10 @@ import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import Icon from "@/components/Icon";
 import { useUser } from "@/lib/hooks/useUser";
+import {
+  buildOnboardingProfilePayload,
+  type OnboardingData,
+} from "./onboarding-payload";
 
 /* ── Constants ── */
 
@@ -22,15 +26,31 @@ const INTEREST_OPTIONS = [
 
 const EXPERIENCE_OPTIONS = [
   { value: "beginner", label: "Beginner", description: "I'm new to investing" },
-  { value: "intermediate", label: "Intermediate", description: "I've been investing for 1-3 years" },
-  { value: "advanced", label: "Advanced", description: "I've invested for 3+ years" },
+  {
+    value: "intermediate",
+    label: "Intermediate",
+    description: "I've been investing for 1-3 years",
+  },
+  {
+    value: "advanced",
+    label: "Advanced",
+    description: "I've invested for 3+ years",
+  },
 ] as const;
 
 const GOAL_OPTIONS = [
   { value: "growth", label: "Growth", description: "Grow my wealth long-term" },
   { value: "income", label: "Income", description: "Generate regular income" },
-  { value: "preservation", label: "Preservation", description: "Protect what I have" },
-  { value: "speculation", label: "Speculation", description: "Active trading for returns" },
+  {
+    value: "preservation",
+    label: "Preservation",
+    description: "Protect what I have",
+  },
+  {
+    value: "speculation",
+    label: "Speculation",
+    description: "Active trading for returns",
+  },
 ] as const;
 
 const PORTFOLIO_OPTIONS = [
@@ -41,7 +61,16 @@ const PORTFOLIO_OPTIONS = [
   { value: "over_500k", label: "Over $500k" },
 ] as const;
 
-const AU_STATES = ["NSW", "VIC", "QLD", "WA", "SA", "TAS", "ACT", "NT"] as const;
+const AU_STATES = [
+  "NSW",
+  "VIC",
+  "QLD",
+  "WA",
+  "SA",
+  "TAS",
+  "ACT",
+  "NT",
+] as const;
 
 /* ── Subcomponents ── */
 
@@ -118,9 +147,13 @@ function RadioCard({
           <Icon name="check" size={12} className="text-white" />
         </span>
       )}
-      <span className="block text-sm font-semibold text-slate-900">{label}</span>
+      <span className="block text-sm font-semibold text-slate-900">
+        {label}
+      </span>
       {description && (
-        <span className="block text-xs text-slate-500 mt-0.5">{description}</span>
+        <span className="block text-xs text-slate-500 mt-0.5">
+          {description}
+        </span>
       )}
     </button>
   );
@@ -147,22 +180,17 @@ function InterestPill({
           : "bg-white text-slate-700 border-slate-200 hover:border-slate-300 hover:shadow-sm"
       }`}
     >
-      <Icon name={icon} size={16} className={selected ? "text-white" : "text-slate-400"} />
+      <Icon
+        name={icon}
+        size={16}
+        className={selected ? "text-white" : "text-slate-400"}
+      />
       {label}
     </button>
   );
 }
 
 /* ── Form state ── */
-
-interface OnboardingData {
-  interested_in: string[];
-  investing_experience: string;
-  investment_goals: string;
-  display_name: string;
-  portfolio_size: string;
-  state: string;
-}
 
 const emptyData: OnboardingData = {
   interested_in: [],
@@ -183,6 +211,7 @@ export default function OnboardingClient() {
   const [form, setForm] = useState<OnboardingData>(emptyData);
   const [checking, setChecking] = useState(true);
   const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
   const [direction, setDirection] = useState<"forward" | "back">("forward");
   const [animating, setAnimating] = useState(false);
 
@@ -213,7 +242,9 @@ export default function OnboardingClient() {
       }
     })();
 
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+    };
   }, [user, router]);
 
   // Step transition animation
@@ -234,31 +265,52 @@ export default function OnboardingClient() {
   // Navigation
   const canProceed = () => {
     if (step === 1) return form.interested_in.length >= 1;
-    if (step === 2) return form.investing_experience !== "" && form.investment_goals !== "";
+    if (step === 2)
+      return form.investing_experience !== "" && form.investment_goals !== "";
     return true; // Step 3 is all optional
   };
 
   const handleNext = () => {
+    setSubmitError(null);
     if (step < TOTAL_STEPS) goTo(step + 1);
   };
 
   const handleBack = () => {
+    setSubmitError(null);
     if (step > 1) goTo(step - 1);
   };
 
   const handleFinish = async () => {
+    setSubmitError(null);
     setSubmitting(true);
     try {
       const res = await fetch("/api/user-profile", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ ...form, onboarding_completed: true }),
+        body: JSON.stringify(buildOnboardingProfilePayload(form)),
       });
+
       if (res.ok) {
-        router.push("/account?welcome=1");
+        router.replace("/account?welcome=1");
+        router.refresh();
+        return;
       }
+
+      if (res.status === 401) {
+        router.replace("/auth/login?next=/onboarding");
+        return;
+      }
+
+      const data = (await res.json().catch(() => null)) as {
+        error?: string;
+      } | null;
+      setSubmitError(
+        data?.error ?? "We couldn't save your onboarding. Please try again.",
+      );
     } catch {
-      // Allow retry
+      setSubmitError(
+        "Connection issue. Please check your internet and try again.",
+      );
     } finally {
       setSubmitting(false);
     }
@@ -291,7 +343,8 @@ export default function OnboardingClient() {
     if (animating) {
       return {
         opacity: 0,
-        transform: direction === "forward" ? "translateX(40px)" : "translateX(-40px)",
+        transform:
+          direction === "forward" ? "translateX(40px)" : "translateX(-40px)",
         transition: "opacity 200ms ease, transform 200ms ease",
       };
     }
@@ -345,13 +398,20 @@ export default function OnboardingClient() {
               </p>
 
               <div className="mb-8">
-                <p className="text-sm font-medium text-slate-700 mb-3">Experience Level</p>
+                <p className="text-sm font-medium text-slate-700 mb-3">
+                  Experience Level
+                </p>
                 <div className="grid grid-cols-1 gap-2">
                   {EXPERIENCE_OPTIONS.map((opt) => (
                     <RadioCard
                       key={opt.value}
                       selected={form.investing_experience === opt.value}
-                      onClick={() => setForm((p) => ({ ...p, investing_experience: opt.value }))}
+                      onClick={() =>
+                        setForm((p) => ({
+                          ...p,
+                          investing_experience: opt.value,
+                        }))
+                      }
                       label={opt.label}
                       description={opt.description}
                     />
@@ -360,13 +420,17 @@ export default function OnboardingClient() {
               </div>
 
               <div>
-                <p className="text-sm font-medium text-slate-700 mb-3">Primary Goal</p>
+                <p className="text-sm font-medium text-slate-700 mb-3">
+                  Primary Goal
+                </p>
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
                   {GOAL_OPTIONS.map((opt) => (
                     <RadioCard
                       key={opt.value}
                       selected={form.investment_goals === opt.value}
-                      onClick={() => setForm((p) => ({ ...p, investment_goals: opt.value }))}
+                      onClick={() =>
+                        setForm((p) => ({ ...p, investment_goals: opt.value }))
+                      }
                       label={opt.label}
                       description={opt.description}
                     />
@@ -389,14 +453,19 @@ export default function OnboardingClient() {
               <div className="space-y-6">
                 {/* Display Name */}
                 <div>
-                  <label htmlFor="onboard_name" className="block text-sm font-medium text-slate-700 mb-1">
+                  <label
+                    htmlFor="onboard_name"
+                    className="block text-sm font-medium text-slate-700 mb-1"
+                  >
                     Display Name
                   </label>
                   <input
                     id="onboard_name"
                     type="text"
                     value={form.display_name}
-                    onChange={(e) => setForm((p) => ({ ...p, display_name: e.target.value }))}
+                    onChange={(e) =>
+                      setForm((p) => ({ ...p, display_name: e.target.value }))
+                    }
                     placeholder="How should we address you?"
                     className="w-full px-3 py-2.5 border border-slate-200 rounded-xl text-sm text-slate-900 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 transition-colors"
                     maxLength={100}
@@ -405,13 +474,17 @@ export default function OnboardingClient() {
 
                 {/* Portfolio Size */}
                 <div>
-                  <p className="text-sm font-medium text-slate-700 mb-2">Portfolio Size</p>
+                  <p className="text-sm font-medium text-slate-700 mb-2">
+                    Portfolio Size
+                  </p>
                   <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
                     {PORTFOLIO_OPTIONS.map((opt) => (
                       <RadioCard
                         key={opt.value}
                         selected={form.portfolio_size === opt.value}
-                        onClick={() => setForm((p) => ({ ...p, portfolio_size: opt.value }))}
+                        onClick={() =>
+                          setForm((p) => ({ ...p, portfolio_size: opt.value }))
+                        }
                         label={opt.label}
                       />
                     ))}
@@ -420,18 +493,25 @@ export default function OnboardingClient() {
 
                 {/* State */}
                 <div>
-                  <label htmlFor="onboard_state" className="block text-sm font-medium text-slate-700 mb-1">
+                  <label
+                    htmlFor="onboard_state"
+                    className="block text-sm font-medium text-slate-700 mb-1"
+                  >
                     State
                   </label>
                   <select
                     id="onboard_state"
                     value={form.state}
-                    onChange={(e) => setForm((p) => ({ ...p, state: e.target.value }))}
+                    onChange={(e) =>
+                      setForm((p) => ({ ...p, state: e.target.value }))
+                    }
                     className="w-full px-3 py-2.5 border border-slate-200 rounded-xl text-sm text-slate-900 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 transition-colors bg-white"
                   >
                     <option value="">Select your state</option>
                     {AU_STATES.map((s) => (
-                      <option key={s} value={s}>{s}</option>
+                      <option key={s} value={s}>
+                        {s}
+                      </option>
                     ))}
                   </select>
                 </div>
@@ -439,6 +519,15 @@ export default function OnboardingClient() {
             </div>
           )}
         </div>
+
+        {submitError && (
+          <div
+            role="alert"
+            className="mt-8 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm font-medium text-red-700"
+          >
+            {submitError}
+          </div>
+        )}
 
         {/* Navigation buttons */}
         <div className="flex items-center justify-between mt-10 gap-3">

--- a/app/onboarding/onboarding-payload.ts
+++ b/app/onboarding/onboarding-payload.ts
@@ -1,0 +1,59 @@
+export interface OnboardingData {
+  interested_in: string[];
+  investing_experience: string;
+  investment_goals: string;
+  display_name: string;
+  portfolio_size: string;
+  state: string;
+}
+
+export type OnboardingProfilePayload = Partial<OnboardingData> & {
+  onboarding_completed: true;
+};
+
+/**
+ * Builds the profile API payload for finishing onboarding.
+ *
+ * The final onboarding step is optional, so the UI keeps blank strings for
+ * unselected values. Sending those blank strings through the profile API can
+ * trigger enum/check-constraint failures in production. Only send fields the
+ * user actually supplied, plus the required completion flag.
+ */
+export function buildOnboardingProfilePayload(
+  form: OnboardingData,
+): OnboardingProfilePayload {
+  const payload: OnboardingProfilePayload = {
+    onboarding_completed: true,
+  };
+
+  if (form.interested_in.length > 0) {
+    payload.interested_in = form.interested_in;
+  }
+
+  const investingExperience = form.investing_experience.trim();
+  if (investingExperience) {
+    payload.investing_experience = investingExperience;
+  }
+
+  const investmentGoals = form.investment_goals.trim();
+  if (investmentGoals) {
+    payload.investment_goals = investmentGoals;
+  }
+
+  const displayName = form.display_name.trim();
+  if (displayName) {
+    payload.display_name = displayName;
+  }
+
+  const portfolioSize = form.portfolio_size.trim();
+  if (portfolioSize) {
+    payload.portfolio_size = portfolioSize;
+  }
+
+  const state = form.state.trim();
+  if (state) {
+    payload.state = state;
+  }
+
+  return payload;
+}


### PR DESCRIPTION
### Motivation
- The final onboarding "Finish" action could look like it did nothing when optional fields were sent as blank strings and rejected by the profile API, and sessions or network errors were not surfaced to the user. 
- The goal is to ensure the completion request only sends valid fields, surface save errors to the UI, and handle expired sessions and navigation reliably.

### Description
- Add a dedicated payload builder `app/onboarding/onboarding-payload.ts` that trims values, omits blank optional fields, and always includes `onboarding_completed: true` for the completion request. 
- Update the onboarding client (`app/onboarding/OnboardingClient.tsx`) to use `buildOnboardingProfilePayload(form)` when saving, and to `router.replace("/account?welcome=1")` + `router.refresh()` on success. 
- Surface save failures and network/session errors via a `submitError` state and an in-UI alert so the Finish button no longer appears to be stuck. 
- Add tests: `__tests__/onboarding-payload.test.ts` for payload behaviour and extend `__tests__/api/user-profile.test.ts` with a regression for standalone `onboarding_completed` updates.

### Testing
- Ran unit tests with `npm test -- __tests__/onboarding-payload.test.ts __tests__/api/user-profile.test.ts` and all tests passed (2 files, 19 tests total). 
- Ran linting on the changed files with `npx eslint` and fixes were applied successfully. 
- Ran `tsc --noEmit` (type-check) in this environment but the command timed out before completion.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a038ee6ed148322b65d22ea854b8094)