### PR TITLE
Compare: category-aware engine with scenarios, true-cost calc, shortlist and row disclosures

### DIFF
--- a/__tests__/lib/compare-engine.test.ts
+++ b/__tests__/lib/compare-engine.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import type { Broker } from "@/lib/types";
+import {
+  CATEGORY_SCHEMAS,
+  calculateAnnualCost,
+  filterBrokers,
+  getMobileCardFields,
+  rankBrokers,
+  sortRankedBrokers,
+  updateShortlist,
+} from "@/lib/compare-engine";
+
+function broker(overrides: Partial<Broker>): Broker {
+  return {
+    id: 1,
+    name: "Alpha",
+    slug: "alpha",
+    color: "#111827",
+    chess_sponsored: true,
+    smsf_support: false,
+    is_crypto: false,
+    deal: false,
+    editors_pick: false,
+    status: "active",
+    platform_type: "share_broker",
+    rating: 4,
+    asx_fee: "$5",
+    asx_fee_value: 5,
+    us_fee: "$2",
+    us_fee_value: 2,
+    fx_rate: 0.5,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+const alpha = broker({ id: 1, slug: "alpha", name: "Alpha", asx_fee_value: 5, us_fee_value: 2, fx_rate: 0.4, rating: 4.6, smsf_support: true });
+const beta = broker({ id: 2, slug: "beta", name: "Beta", asx_fee_value: 0, us_fee_value: 8, fx_rate: 0.9, rating: 3.8, chess_sponsored: false });
+const crypto = broker({ id: 3, slug: "coin", name: "Coin", platform_type: "crypto_exchange", is_crypto: true, asx_fee_value: 1, rating: 4.2 });
+const superFund = broker({ id: 4, slug: "super", name: "Super", platform_type: "super_fund", asx_fee_value: 0.7, rating: 4.4 });
+
+describe("compare engine", () => {
+  it("filters by category and feature without leaking irrelevant product rows", () => {
+    const result = filterBrokers([alpha, beta, crypto, superFund], {
+      category: "share-trading",
+      features: new Set(["chess"]),
+    });
+
+    expect(result.map((item) => item.slug)).toEqual(["alpha"]);
+  });
+
+  it("uses category-specific table schemas that hide irrelevant columns", () => {
+    expect(CATEGORY_SCHEMAS["crypto-exchanges"].columns.map((column) => column.label)).toContain("AUD funding");
+    expect(CATEGORY_SCHEMAS["crypto-exchanges"].columns.map((column) => column.label)).not.toContain("CHESS");
+    expect(CATEGORY_SCHEMAS["super-funds"].columns.map((column) => column.label)).toContain("Admin/investment fee");
+  });
+
+  it("calculates indicative annual cost from user inputs", () => {
+    const cost = calculateAnnualCost(alpha, {
+      tradesPerMonth: 2,
+      averageTradeSize: 1000,
+      usTradesPerMonth: 1,
+      averageUsTradeSize: 2000,
+      portfolioBalance: 50000,
+    });
+
+    expect(cost).toBe(240); // ASX $120 + US $24 + FX $96
+  });
+
+  it("sorts ranked providers by calculated annual cost", () => {
+    const rows = rankBrokers([alpha, beta], "low-cost", {
+      tradesPerMonth: 2,
+      averageTradeSize: 1000,
+      usTradesPerMonth: 0,
+      averageUsTradeSize: 1000,
+      portfolioBalance: 10000,
+    });
+
+    expect(sortRankedBrokers(rows, "estimated_annual_cost", 1)[0].broker.slug).toBe("beta");
+  });
+
+  it("caps and toggles the side-by-side shortlist at four providers", () => {
+    expect(updateShortlist(["a", "b", "c", "d"], "e")).toEqual(["a", "b", "c", "d"]);
+    expect(updateShortlist(["a", "b"], "b")).toEqual(["a"]);
+  });
+
+  it("scenario ranking boosts SMSF-friendly providers", () => {
+    const rows = rankBrokers([alpha, beta], "smsf-investor");
+    const alphaRow = rows.find((row) => row.broker.slug === "alpha")!;
+    const betaRow = rows.find((row) => row.broker.slug === "beta")!;
+
+    expect(alphaRow.rankScore).toBeGreaterThan(betaRow.rankScore);
+    expect(alphaRow.why.join(" ")).toContain("SMSF account support");
+  });
+
+  it("provides mobile card fields from the active schema", () => {
+    expect(getMobileCardFields(CATEGORY_SCHEMAS["international-shares"])).toEqual([
+      "US brokerage",
+      "FX markup",
+      "Markets",
+      "Est. annual cost",
+    ]);
+  });
+});

--- a/app/compare/CompareClient.tsx
+++ b/app/compare/CompareClient.tsx
@@ -13,7 +13,6 @@ const XIcon = ({ className }: { className?: string }) => (
 );
 import type { Broker } from "@/lib/types";
 import { trackEvent, getAffiliateLink, trackClick, AFFILIATE_REL } from "@/lib/tracking";
-import BrokerCard from "@/components/BrokerCard";
 import SocialProofCounter from "@/components/SocialProofCounter";
 import { FeesFreshnessIndicator } from "@/components/FeesFreshnessIndicator";
 import { getMostRecentFeeCheck } from "@/lib/utils";
@@ -27,101 +26,33 @@ import CompareFooter from "./_components/CompareFooter";
 import CompareCrossSellBanner from "@/components/CompareCrossSellBanner";
 import type { ABTestConfig } from "@/lib/ab-test";
 import { createClient } from "@/lib/supabase/client";
+import {
+  CATEGORY_ALIASES,
+  CATEGORY_SCHEMAS,
+  DEFAULT_COST_INPUTS,
+  SCENARIOS,
+  filterBrokers,
+  rankBrokers,
+  scenarioCategory,
+  sortRankedBrokers,
+  updateShortlist,
+  type CompareCategory,
+  type CostInputs,
+  type FeatureFilter,
+  type ScenarioMode,
+  type SortCol,
+} from "@/lib/compare-engine";
 
-type PlatformType = 'all' | 'shares' | 'crypto' | 'super' | 'robo' | 'savings' | 'term-deposits' | 'property' | 'cfd' | 'research';
-type FeatureFilter = 'chess' | 'free' | 'smsf' | 'low-fx' | 'us' | 'has-deal';
-type SortCol = 'name' | 'asx_fee_value' | 'us_fee_value' | 'fx_rate' | 'rating';
+const platformTypes: { key: CompareCategory; label: string; short?: string }[] = Object.values(CATEGORY_SCHEMAS).map((schema) => ({
+  key: schema.key,
+  label: schema.label,
+  short: schema.shortLabel,
+}));
 
-/* ─── Vertical-specific column/sort config ─── */
-const VERTICAL_CONFIG: Record<PlatformType, {
-  sortOptions: { col: SortCol; label: string }[];
-  featureLabel: string; // replaces "ASX Fee" in mobile cards etc.
-  featureFilters: FeatureFilter[];
-  description: string;
-}> = {
-  all: {
-    sortOptions: [{ col: 'rating', label: 'Rating' }, { col: 'asx_fee_value', label: 'ASX Fee' }, { col: 'us_fee_value', label: 'US Fee' }, { col: 'fx_rate', label: 'FX Rate' }, { col: 'name', label: 'Name' }],
-    featureLabel: 'ASX Fee',
-    featureFilters: ['chess', 'free', 'smsf', 'low-fx', 'us', 'has-deal'],
-    description: 'Compare fees, features & safety across Australian investing platforms.',
-  },
-  shares: {
-    sortOptions: [{ col: 'rating', label: 'Rating' }, { col: 'asx_fee_value', label: 'Brokerage' }, { col: 'us_fee_value', label: 'US Fee' }, { col: 'fx_rate', label: 'FX Rate' }, { col: 'name', label: 'Name' }],
-    featureLabel: 'Brokerage',
-    featureFilters: ['chess', 'free', 'smsf', 'low-fx', 'us', 'has-deal'],
-    description: 'Compare brokerage fees, CHESS sponsorship, market access & features.',
-  },
-  crypto: {
-    sortOptions: [{ col: 'rating', label: 'Rating' }, { col: 'asx_fee_value', label: 'Trading Fee' }, { col: 'name', label: 'Name' }],
-    featureLabel: 'Trading Fee',
-    featureFilters: ['has-deal'],
-    description: 'Compare spreads, AUD deposits, staking, custody & coin coverage.',
-  },
-  super: {
-    sortOptions: [{ col: 'rating', label: 'Rating' }, { col: 'asx_fee_value', label: 'Admin Fee' }, { col: 'name', label: 'Name' }],
-    featureLabel: 'Admin Fee',
-    featureFilters: ['has-deal'],
-    description: 'Compare admin fees, investment options, insurance & fund performance.',
-  },
-  robo: {
-    sortOptions: [{ col: 'rating', label: 'Rating' }, { col: 'asx_fee_value', label: 'Mgmt Fee' }, { col: 'name', label: 'Name' }],
-    featureLabel: 'Mgmt Fee',
-    featureFilters: ['has-deal'],
-    description: 'Compare management fees, portfolios, minimums & automation features.',
-  },
-  savings: {
-    sortOptions: [{ col: 'rating', label: 'Rating' }, { col: 'name', label: 'Name' }],
-    featureLabel: 'Interest Rate',
-    featureFilters: ['has-deal'],
-    description: 'Compare interest rates, bonus conditions & access for savings accounts.',
-  },
-  'term-deposits': {
-    sortOptions: [{ col: 'rating', label: 'Rating' }, { col: 'name', label: 'Name' }],
-    featureLabel: 'Rate',
-    featureFilters: ['has-deal'],
-    description: 'Compare term deposit rates, terms, minimum deposits & institutions.',
-  },
-  property: {
-    sortOptions: [{ col: 'rating', label: 'Rating' }, { col: 'asx_fee_value', label: 'Min Investment' }, { col: 'name', label: 'Name' }],
-    featureLabel: 'Min Investment',
-    featureFilters: ['has-deal'],
-    description: 'Compare property investment platforms, minimum investment & returns.',
-  },
-  cfd: {
-    sortOptions: [{ col: 'rating', label: 'Rating' }, { col: 'asx_fee_value', label: 'Commission' }, { col: 'fx_rate', label: 'Spread' }, { col: 'name', label: 'Name' }],
-    featureLabel: 'Commission',
-    featureFilters: ['has-deal'],
-    description: 'Compare CFD/forex spreads, commissions, leverage & regulation.',
-  },
-  research: {
-    sortOptions: [{ col: 'rating', label: 'Rating' }, { col: 'asx_fee_value', label: 'Price' }, { col: 'name', label: 'Name' }],
-    featureLabel: 'Price',
-    featureFilters: ['has-deal'],
-    description: 'Compare charting, screeners, alerts, portfolio tools & pricing.',
-  },
-};
+const filters = platformTypes; // for URL compat
 
-const platformTypes: { key: PlatformType; label: string; short?: string }[] = [
-  { key: 'all', label: 'All Platforms' },
-  { key: 'shares', label: 'Share Trading', short: 'Brokerages' },
-  { key: 'crypto', label: 'Crypto Exchanges' },
-  { key: 'super', label: 'Super Funds' },
-  { key: 'robo', label: 'Robo-Advisors' },
-  { key: 'savings', label: 'Savings Accounts' },
-  { key: 'term-deposits', label: 'Term Deposits' },
-  { key: 'property', label: 'Property' },
-  { key: 'cfd', label: 'CFD & Forex' },
-  { key: 'research', label: 'Research Tools' },
-];
-
-const featureFilters: { key: FeatureFilter; label: string; icon: string }[] = [
-  { key: 'chess', label: 'CHESS Sponsored', icon: 'shield' },
-  { key: 'free', label: '$0 Trades', icon: 'zap' },
-  { key: 'us', label: 'US Shares', icon: 'globe' },
-  { key: 'smsf', label: 'SMSF Support', icon: 'building' },
-  { key: 'low-fx', label: 'Low FX (<0.5%)', icon: 'dollar-sign' },
-  { key: 'has-deal', label: 'Has Deal', icon: 'tag' },
-];
+/** Map URL ?category= values to platform category keys */
+const CATEGORY_TO_FILTER: Record<string, CompareCategory> = CATEGORY_ALIASES;
 
 const maxFeeOptions = [
   { value: 999, label: 'Any' },
@@ -138,30 +69,13 @@ const minRatingOptions = [
   { value: 3.5, label: '3.5+' },
 ];
 
-const filters = platformTypes; // for URL compat
-
-/** Map URL ?category= values to platform type keys */
-const CATEGORY_TO_FILTER: Record<string, PlatformType> = {
-  shares: 'shares',
-  crypto: 'crypto',
-  robo: 'robo',
-  'robo-advisors': 'robo',
-  'research-tools': 'research',
-  research: 'research',
-  'super-funds': 'super',
-  super: 'super',
-  property: 'property',
-  'cfd-forex': 'cfd',
-  cfd: 'cfd',
-  savings: 'savings',
-  'term-deposits': 'term-deposits',
-};
-
-const feeTooltips: Record<string, string> = {
-  asx_fee_value: "The fee your platform charges each time you buy or sell Australian shares.",
-  us_fee_value: "The fee to buy or sell US shares — like Apple, Tesla, or US ETFs.",
-  fx_rate: "The currency conversion markup when you buy shares in a foreign currency. Lower is better.",
-  chess: "Shares registered in your name on the ASX register — not held by your platform. Safer if the platform goes bust.",
+const featureFilterMeta: Record<FeatureFilter, { label: string; icon: string }> = {
+  chess: { label: 'CHESS Sponsored', icon: 'shield' },
+  free: { label: '$0 Trades', icon: 'zap' },
+  us: { label: 'US Shares', icon: 'globe' },
+  smsf: { label: 'SMSF Support', icon: 'building' },
+  'low-fx': { label: 'Low FX (<0.5%)', icon: 'dollar-sign' },
+  'has-deal': { label: 'Has Deal', icon: 'tag' },
 };
 
 function InfoTip({ text }: { text: string }) {
@@ -207,8 +121,8 @@ export default function CompareClient({ brokers }: { brokers: Broker[] }) {
   // Derive initial filter/query from URL params (?filter= or ?category=)
   const urlFilter = searchParams.get("filter");
   const urlCategory = searchParams.get("category");
-  const initialFilter: PlatformType = (() => {
-    if (urlFilter && platformTypes.some(fl => fl.key === urlFilter)) return urlFilter as PlatformType;
+  const initialFilter: CompareCategory = (() => {
+    if (urlFilter && platformTypes.some(fl => fl.key === urlFilter)) return urlFilter as CompareCategory;
     if (urlCategory && CATEGORY_TO_FILTER[urlCategory]) return CATEGORY_TO_FILTER[urlCategory];
     return 'all';
   })();
@@ -217,7 +131,7 @@ export default function CompareClient({ brokers }: { brokers: Broker[] }) {
   // Sort state is URL-persisted so shared/bookmarked compare pages recreate
   // exactly what the recipient expected to see (critical for "look at this
   // broker ranking" affiliate share-outs).
-  const validSortCols: SortCol[] = ['name', 'asx_fee_value', 'us_fee_value', 'fx_rate', 'rating'];
+  const validSortCols: SortCol[] = ['name', 'asx_fee_value', 'us_fee_value', 'fx_rate', 'rating', 'estimated_annual_cost', 'rank_score'];
   const urlSortCol = searchParams.get("sort");
   const initialSortCol: SortCol = (urlSortCol && (validSortCols as string[]).includes(urlSortCol))
     ? (urlSortCol as SortCol)
@@ -243,7 +157,7 @@ export default function CompareClient({ brokers }: { brokers: Broker[] }) {
     return next;
   })();
   const [searchQuery, setSearchQuery] = useState(urlQuery);
-  const [activeFilter, setActiveFilter] = useState<PlatformType>(initialFilter);
+  const [activeFilter, setActiveFilter] = useState<CompareCategory>(initialFilter);
   const [activeFeatures, setActiveFeatures] = useState<Set<FeatureFilter>>(initialFeatures);
   const [maxFee, setMaxFee] = useState(999);
   const [minRating, setMinRating] = useState(0);
@@ -256,6 +170,8 @@ export default function CompareClient({ brokers }: { brokers: Broker[] }) {
   const [selected, setSelected] = useState<Set<string>>(initialSelected);
   const [showMobileCompare, setShowMobileCompare] = useState(false);
   const [sheetOpen, setSheetOpen] = useState(false);
+  const [scenario, setScenario] = useState<ScenarioMode | "none">((searchParams.get("scenario") as ScenarioMode) || "none");
+  const [costInputs, setCostInputs] = useState<CostInputs>(DEFAULT_COST_INPUTS);
 
   // Sync URL when filter, search or sort changes (for sharing/bookmarking).
   // Using replaceState (not push) so the back button doesn't get polluted
@@ -283,8 +199,13 @@ export default function CompareClient({ brokers }: { brokers: Broker[] }) {
     } else {
       url.searchParams.set('dir', 'asc');
     }
+    if (scenario === 'none') {
+      url.searchParams.delete('scenario');
+    } else {
+      url.searchParams.set('scenario', scenario);
+    }
     window.history.replaceState({}, '', url.toString());
-  }, [activeFilter, searchQuery, sortCol, sortDir]);
+  }, [activeFilter, searchQuery, sortCol, sortDir, scenario]);
 
   // Marketplace campaign allocation
   const [campaignWinners, setCampaignWinners] = useState<PlacementWinner[]>([]);
@@ -321,34 +242,13 @@ export default function CompareClient({ brokers }: { brokers: Broker[] }) {
 
   // Build a map of platform filter key → top broker logo URLs (up to 4 per category)
   const filterLogos = useMemo(() => {
-    const PLATFORM_KEY_MAP: Record<string, PlatformType | 'crypto'> = {
-      shares: 'shares',
-      crypto: 'crypto',
-      robo: 'robo',
-      research: 'research',
-      super: 'super',
-      property: 'property',
-      cfd: 'cfd',
-      savings: 'savings',
-      'term-deposits': 'term-deposits',
-    };
+    const PLATFORM_KEY_MAP = CATEGORY_SCHEMAS;
 
     const result: Record<string, { slug: string; name: string; logo_url?: string; color: string }[]> = {};
 
-    for (const [filterKey] of Object.entries(PLATFORM_KEY_MAP)) {
-      let matches: Broker[];
-      switch (filterKey) {
-        case 'shares': matches = brokers.filter(b => (b.platform_type || 'share_broker') === 'share_broker'); break;
-        case 'crypto': matches = brokers.filter(b => b.is_crypto); break;
-        case 'robo': matches = brokers.filter(b => b.platform_type === 'robo_advisor'); break;
-        case 'research': matches = brokers.filter(b => b.platform_type === 'research_tool'); break;
-        case 'super': matches = brokers.filter(b => b.platform_type === 'super_fund'); break;
-        case 'property': matches = brokers.filter(b => b.platform_type === 'property_platform'); break;
-        case 'cfd': matches = brokers.filter(b => b.platform_type === 'cfd_forex'); break;
-        case 'savings': matches = brokers.filter(b => b.platform_type === 'savings_account'); break;
-        case 'term-deposits': matches = brokers.filter(b => b.platform_type === 'term_deposit'); break;
-        default: matches = [];
-      }
+    for (const [filterKey, schema] of Object.entries(PLATFORM_KEY_MAP)) {
+      let matches = brokers.filter(b => schema.platformTypes.includes(b.platform_type) || (schema.key === 'crypto-exchanges' && b.is_crypto));
+      if (schema.include) matches = matches.filter(schema.include);
       // Sort by rating desc, take top 4 with logo_url
       const withLogos = matches
         .filter(b => b.logo_url)
@@ -370,15 +270,12 @@ export default function CompareClient({ brokers }: { brokers: Broker[] }) {
 
   function toggleSelected(slug: string) {
     setSelected(prev => {
-      const next = new Set(prev);
-      if (next.has(slug)) {
-        next.delete(slug);
-      } else {
-        if (next.size >= 4) return prev; // cap at 4
-        next.add(slug);
+      const before = Array.from(prev);
+      const after = updateShortlist(before, slug, 4);
+      if (!prev.has(slug) && after.includes(slug)) {
         trackEvent('compare_select', { broker: slug }, '/compare');
       }
-      return next;
+      return new Set(after);
     });
   }
 
@@ -393,7 +290,7 @@ export default function CompareClient({ brokers }: { brokers: Broker[] }) {
     const f = searchParams.get("filter");
     const c = searchParams.get("category");
     if (f && platformTypes.some(fl => fl.key === f)) {
-      setActiveFilter(f as PlatformType);
+      setActiveFilter(f as CompareCategory);
     } else if (c && CATEGORY_TO_FILTER[c]) {
       setActiveFilter(CATEGORY_TO_FILTER[c]);
     } else if (!f && !c) {
@@ -420,78 +317,32 @@ export default function CompareClient({ brokers }: { brokers: Broker[] }) {
     }
   }
 
-  const filtered = useMemo(() => {
-    let list = [...brokers];
-    
-    // 1. Platform type filter (single-select)
-    switch (activeFilter) {
-      case 'shares': list = list.filter(b => (b.platform_type || 'share_broker') === 'share_broker'); break;
-      case 'crypto': list = list.filter(b => b.is_crypto); break;
-      case 'robo': list = list.filter(b => b.platform_type === 'robo_advisor'); break;
-      case 'research': list = list.filter(b => b.platform_type === 'research_tool'); break;
-      case 'super': list = list.filter(b => b.platform_type === 'super_fund'); break;
-      case 'property': list = list.filter(b => b.platform_type === 'property_platform'); break;
-      case 'cfd': list = list.filter(b => b.platform_type === 'cfd_forex'); break;
-      case 'savings': list = list.filter(b => b.platform_type === 'savings_account'); break;
-      case 'term-deposits': list = list.filter(b => b.platform_type === 'term_deposit'); break;
-    }
-    
-    // 2. Feature filters (multi-select — all must match)
-    if (activeFeatures.has('chess')) list = list.filter(b => b.chess_sponsored);
-    if (activeFeatures.has('free')) list = list.filter(b => (b.asx_fee_value === 0) || (b.us_fee_value === 0));
-    if (activeFeatures.has('us')) list = list.filter(b => b.us_fee_value != null && b.us_fee_value <= 5);
-    if (activeFeatures.has('smsf')) list = list.filter(b => b.smsf_support);
-    if (activeFeatures.has('low-fx')) list = list.filter(b => b.fx_rate != null && b.fx_rate > 0 && b.fx_rate < 0.5);
-    if (activeFeatures.has('has-deal')) list = list.filter(b => b.deal && b.deal_text);
-    
-    // 3. Fee range filter
-    if (maxFee < 999) {
-      list = list.filter(b => (b.asx_fee_value ?? 999) <= maxFee);
-    }
-    
-    // 4. Rating filter
-    if (minRating > 0) {
-      list = list.filter(b => (b.rating ?? 0) >= minRating);
-    }
-    
-    // 5. Text search filter
-    if (searchQuery.trim()) {
-      const q = searchQuery.trim().toLowerCase();
-      list = list.filter(b =>
-        b.name.toLowerCase().includes(q) ||
-        (b.tagline && b.tagline.toLowerCase().includes(q)) ||
-        b.slug.toLowerCase().includes(q)
-      );
-    }
-    return list;
-  }, [brokers, activeFilter, activeFeatures, maxFee, minRating, searchQuery]);
+  const effectiveCategory = scenarioCategory(scenario, activeFilter);
+  const schema = CATEGORY_SCHEMAS[effectiveCategory];
+  const filtered = useMemo(() => filterBrokers(brokers, {
+    category: activeFilter,
+    features: activeFeatures,
+    maxFee,
+    minRating,
+    searchQuery,
+    scenario,
+  }), [brokers, activeFilter, activeFeatures, maxFee, minRating, searchQuery, scenario]);
 
-  const sorted = useMemo(() => {
-    // Campaign winners from marketplace get priority over sponsorship tiers
+  const ranked = useMemo(() => rankBrokers(filtered, scenario, costInputs), [filtered, scenario, costInputs]);
+
+  const sortedRows = useMemo(() => {
     const campaignWinnerSlugs = new Set(campaignWinners.map(w => w.broker_slug));
-
-    const baseSorted = [...filtered].sort((a, b) => {
-      // Campaign winners get top priority (position 0)
-      const aIsCampaignWinner = campaignWinnerSlugs.has(a.slug) ? 0 : 1;
-      const bIsCampaignWinner = campaignWinnerSlugs.has(b.slug) ? 0 : 1;
-      if (aIsCampaignWinner !== bIsCampaignWinner) return aIsCampaignWinner - bIsCampaignWinner;
-
-      // Then sponsored brokers
-      const aPriority = getSponsorSortPriority(a.sponsorship_tier);
-      const bPriority = getSponsorSortPriority(b.sponsorship_tier);
-      if (aPriority !== bPriority) return aPriority - bPriority;
-
-      // Then apply user's selected sort
-      const av = a[sortCol] ?? 999;
-      const bv = b[sortCol] ?? 999;
-      if (typeof av === 'string' && typeof bv === 'string') {
-        return av.toLowerCase() < bv.toLowerCase() ? -sortDir : sortDir;
-      }
-      return ((av as number) - (bv as number)) * sortDir;
+    return sortRankedBrokers(ranked, sortCol, sortDir).sort((a, b) => {
+      const aCampaign = campaignWinnerSlugs.has(a.broker.slug) ? 0 : 1;
+      const bCampaign = campaignWinnerSlugs.has(b.broker.slug) ? 0 : 1;
+      if (aCampaign !== bCampaign) return aCampaign - bCampaign;
+      const aPriority = getSponsorSortPriority(a.broker.sponsorship_tier);
+      const bPriority = getSponsorSortPriority(b.broker.sponsorship_tier);
+      return aPriority - bPriority;
     });
+  }, [ranked, sortCol, sortDir, campaignWinners]);
 
-    return baseSorted;
-  }, [filtered, sortCol, sortDir, campaignWinners]);
+  const sorted = useMemo(() => sortedRows.map(row => row.broker), [sortedRows]);
 
   // Compute editor picks
   const editorPicks = useMemo(() => {
@@ -658,6 +509,65 @@ export default function CompareClient({ brokers }: { brokers: Broker[] }) {
           );
         })()}
 
+        <section className="mb-4 grid gap-3 lg:grid-cols-[1.1fr_0.9fr]" aria-label="Scenario and true-cost calculator">
+          <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+            <div className="flex items-start justify-between gap-3 mb-3">
+              <div>
+                <p className="text-xs font-bold uppercase tracking-wide text-blue-700">Scenario modes</p>
+                <h2 className="text-lg font-extrabold text-slate-900">Rank by a general scenario</h2>
+                <p className="text-xs text-slate-500 mt-1">{schema.description} Rankings are factual comparisons, not personal financial advice or a recommendation.</p>
+              </div>
+              <select
+                value={scenario}
+                onChange={(e) => setScenario(e.target.value as ScenarioMode | "none")}
+                className="rounded-lg border border-slate-200 px-3 py-2 text-sm font-semibold"
+                aria-label="Scenario mode"
+              >
+                <option value="none">No scenario</option>
+                {SCENARIOS.map((item) => <option key={item.key} value={item.key}>{item.label}</option>)}
+              </select>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {SCENARIOS.map((item) => (
+                <button
+                  key={item.key}
+                  onClick={() => setScenario(item.key)}
+                  className={`rounded-full px-3 py-1.5 text-xs font-semibold transition-colors ${scenario === item.key ? 'bg-slate-900 text-white' : 'bg-slate-100 text-slate-700 hover:bg-slate-200'}`}
+                  title={item.description}
+                >
+                  {item.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4 shadow-sm">
+            <p className="text-xs font-bold uppercase tracking-wide text-emerald-700">True-cost calculator</p>
+            <h2 className="text-lg font-extrabold text-slate-900">Estimate annual platform cost</h2>
+            <p className="text-xs text-slate-500 mb-3">Inputs are used only for the indicative annual-cost column. Check provider terms before acting.</p>
+            <div className="grid grid-cols-2 gap-2">
+              {[
+                ['tradesPerMonth', 'ASX trades/mo'],
+                ['averageTradeSize', 'Avg ASX trade'],
+                ['usTradesPerMonth', 'US trades/mo'],
+                ['averageUsTradeSize', 'Avg US trade'],
+                ['portfolioBalance', 'Portfolio/balance'],
+              ].map(([key, label]) => (
+                <label key={key} className="text-[0.7rem] font-semibold text-slate-600">
+                  {label}
+                  <input
+                    type="number"
+                    min="0"
+                    value={costInputs[key as keyof CostInputs]}
+                    onChange={(e) => setCostInputs((prev) => ({ ...prev, [key]: Number(e.target.value) }))}
+                    className="mt-1 w-full rounded-lg border border-slate-200 bg-white px-2 py-1.5 text-sm"
+                  />
+                </label>
+              ))}
+            </div>
+          </div>
+        </section>
+
         {/* Desktop Filter System */}
         <div className="hidden md:block mb-4 space-y-3">
           {/* Row 1: Platform type pills with logos */}
@@ -688,16 +598,18 @@ export default function CompareClient({ brokers }: { brokers: Broker[] }) {
           
           {/* Row 2: Feature toggles + Advanced filters */}
           <div className="flex items-center gap-2 flex-wrap">
-            {featureFilters.map(f => (
+            {schema.featureFilters.map(key => {
+              const f = featureFilterMeta[key];
+              return (
               <button
-                key={f.key}
+                key={key}
                 onClick={() => setActiveFeatures(prev => {
                   const next = new Set(prev);
-                  if (next.has(f.key)) next.delete(f.key); else next.add(f.key);
+                  if (next.has(key)) next.delete(key); else next.add(key);
                   return next;
                 })}
                 className={`shrink-0 px-3 py-1.5 text-xs font-semibold rounded-lg border transition-all flex items-center gap-1.5 ${
-                  activeFeatures.has(f.key)
+                  activeFeatures.has(key)
                     ? 'bg-emerald-50 border-emerald-300 text-emerald-700 shadow-sm'
                     : 'bg-white border-slate-200 text-slate-500 hover:border-slate-300 hover:text-slate-700'
                 }`}
@@ -705,7 +617,7 @@ export default function CompareClient({ brokers }: { brokers: Broker[] }) {
                 <Icon name={f.icon} size={12} />
                 {f.label}
               </button>
-            ))}
+            );})}
             
             <span className="w-px h-5 bg-slate-200 mx-1" />
             
@@ -784,7 +696,7 @@ export default function CompareClient({ brokers }: { brokers: Broker[] }) {
             <div className="mb-4">
               <p className="text-[0.65rem] font-semibold uppercase tracking-wider text-slate-400 mb-2">Sort by</p>
               <div className="flex flex-wrap gap-2">
-                {(VERTICAL_CONFIG[activeFilter as PlatformType] || VERTICAL_CONFIG.all).sortOptions.map(s => (
+                {schema.sortOptions.map(s => (
                   <button
                     key={s.col}
                     onClick={() => handleSort(s.col)}
@@ -825,23 +737,25 @@ export default function CompareClient({ brokers }: { brokers: Broker[] }) {
             <div className="mb-4">
               <p className="text-[0.65rem] font-semibold uppercase tracking-wider text-slate-400 mb-2">Features</p>
               <div className="flex flex-wrap gap-2">
-                {featureFilters.map(f => (
+                {schema.featureFilters.map(key => {
+                  const f = featureFilterMeta[key];
+                  return (
                   <button
-                    key={f.key}
+                    key={key}
                     onClick={() => setActiveFeatures(prev => {
                       const next = new Set(prev);
-                      if (next.has(f.key)) next.delete(f.key); else next.add(f.key);
+                      if (next.has(key)) next.delete(key); else next.add(key);
                       return next;
                     })}
                     className={`px-3 py-2 text-sm font-medium rounded-full ${
-                      activeFeatures.has(f.key)
+                      activeFeatures.has(key)
                         ? 'bg-emerald-600 text-white shadow-sm'
                         : 'bg-slate-100 text-slate-700 hover:bg-slate-200'
                     }`}
                   >
                     {f.label}
                   </button>
-                ))}
+                );})}
               </div>
             </div>
             {/* Fee & Rating */}
@@ -934,7 +848,8 @@ export default function CompareClient({ brokers }: { brokers: Broker[] }) {
         {/* Desktop Table */}
         <div ref={resultsRef} className="scroll-mt-16">
         <CompareDesktopTable
-          sorted={sorted}
+          rows={sortedRows}
+          schema={schema}
           activeFilter={activeFilter}
           searchQuery={searchQuery}
           sortCol={sortCol}
@@ -948,7 +863,6 @@ export default function CompareClient({ brokers }: { brokers: Broker[] }) {
           onToggleSelected={toggleSelected}
           sortArrow={sortArrow}
           InfoTip={InfoTip}
-          feeTooltips={feeTooltips}
         />
 
         {/* Mobile Cards */}
@@ -962,17 +876,45 @@ export default function CompareClient({ brokers }: { brokers: Broker[] }) {
               Tap ○ to select 2–4 for side-by-side comparison
             </div>
           )}
-          {sorted.map(broker => (
-            <BrokerCard
-              key={broker.id}
-              broker={broker}
-              badge={isSponsored(broker) ? undefined : editorPicks[broker.slug]}
-              context="compare"
-              isSelected={selected.has(broker.slug)}
-              onToggleSelect={toggleSelected}
-              selectionDisabled={!selected.has(broker.slug) && selected.size >= 4}
-            />
-          ))}
+          {sortedRows.map(row => {
+            const broker = row.broker;
+            const mobileColumns = schema.columns.slice(0, 4);
+            return (
+            <article key={broker.id} data-testid="compare-mobile-card" className="rounded-2xl border border-slate-200 bg-white p-3 shadow-sm">
+              <div className="flex items-start gap-3">
+                <input
+                  type="checkbox"
+                  checked={selected.has(broker.slug)}
+                  disabled={!selected.has(broker.slug) && selected.size >= 4}
+                  onChange={() => toggleSelected(broker.slug)}
+                  className="mt-1 h-5 w-5 accent-slate-900"
+                  aria-label={`Pin ${broker.name} to shortlist`}
+                />
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center justify-between gap-2">
+                    <Link href={`/broker/${broker.slug}`} className="font-bold text-slate-900 truncate">{broker.name}</Link>
+                    <span className="rounded-full bg-slate-100 px-2 py-1 text-[0.62rem] font-bold uppercase text-slate-500">{row.commercialDisclosure}</span>
+                  </div>
+                  {editorPicks[broker.slug] && !isSponsored(broker) && <p className="text-[0.68rem] font-semibold text-emerald-700">{editorPicks[broker.slug]}</p>}
+                </div>
+              </div>
+              <div className="mt-3 grid grid-cols-2 gap-2">
+                {mobileColumns.map((column) => (
+                  <div key={column.key} className="rounded-xl bg-slate-50 p-2">
+                    <p className="text-[0.62rem] font-bold uppercase tracking-wide text-slate-400">{column.label}</p>
+                    <p className="text-sm font-semibold text-slate-800">{column.value(broker, row)}</p>
+                  </div>
+                ))}
+              </div>
+              <details className="mt-3 rounded-xl border border-slate-100 bg-white p-2 text-xs text-slate-600">
+                <summary className="cursor-pointer font-bold text-slate-800">Why this result?</summary>
+                <ul className="mt-2 list-disc pl-4 space-y-1">
+                  {row.why.map((why) => <li key={why}>{why}</li>)}
+                </ul>
+              </details>
+            </article>
+            );
+          })}
         </div>
         </div>{/* close scroll ref */}
 
@@ -989,6 +931,39 @@ export default function CompareClient({ brokers }: { brokers: Broker[] }) {
           onToggleMobileCompare={() => setShowMobileCompare(prev => !prev)}
           onToggleSelected={toggleSelected}
         />
+
+
+
+        {selected.size > 0 && (
+          <aside className="fixed right-4 top-24 z-30 hidden w-80 rounded-2xl border border-slate-200 bg-white p-4 shadow-2xl lg:block" aria-label="Pinned provider shortlist drawer">
+            <div className="mb-3 flex items-center justify-between">
+              <div>
+                <p className="text-xs font-bold uppercase tracking-wide text-blue-700">Shortlist</p>
+                <h2 className="text-lg font-extrabold text-slate-900">Pinned providers ({selected.size}/4)</h2>
+              </div>
+              <button onClick={() => setSelected(new Set())} className="text-xs font-semibold text-slate-400 hover:text-slate-700">Clear</button>
+            </div>
+            {selected.size < 2 && <p className="mb-3 rounded-lg bg-amber-50 p-2 text-xs text-amber-800">Pin at least 2 providers for a side-by-side shortlist.</p>}
+            <div className="space-y-2">
+              {Array.from(selected).map((slug) => {
+                const row = sortedRows.find((item) => item.broker.slug === slug) ?? rankBrokers(brokers.filter((item) => item.slug === slug), scenario, costInputs)[0];
+                if (!row) return null;
+                return (
+                  <div key={slug} className="rounded-xl border border-slate-100 p-3">
+                    <div className="flex items-start justify-between gap-2">
+                      <div>
+                        <p className="font-bold text-slate-900">{row.broker.name}</p>
+                        <p className="text-xs text-slate-500">Annual cost: ${row.estimatedAnnualCost.toLocaleString('en-AU')}</p>
+                      </div>
+                      <button onClick={() => toggleSelected(slug)} className="text-xs font-bold text-red-500">Remove</button>
+                    </div>
+                    <p className="mt-2 text-xs text-slate-600">{row.why[0]}</p>
+                  </div>
+                );
+              })}
+            </div>
+          </aside>
+        )}
 
         {sorted.length === 0 && (
           <div className="text-center py-8 md:py-12 text-slate-500" role="status">

--- a/app/compare/_components/CompareDesktopTable.tsx
+++ b/app/compare/_components/CompareDesktopTable.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import type { Broker } from "@/lib/types";
 import { getAffiliateLink, renderStars } from "@/lib/tracking";
 import ScrollReveal from "@/components/ScrollReveal";
 import PromoBadge from "@/components/PromoBadge";
@@ -11,100 +10,12 @@ import BrokerLogo from "@/components/BrokerLogo";
 import type { PlacementWinner } from "@/lib/sponsorship";
 import ABTestCTA from "@/components/ABTestCTA";
 import type { ABTestConfig } from "@/lib/ab-test";
-
-type FilterType = 'all' | 'shares' | 'beginner' | 'chess' | 'free' | 'us' | 'smsf' | 'low-fx' | 'crypto' | 'robo' | 'research' | 'super' | 'property' | 'cfd' | 'savings' | 'term-deposits' | 'has-deal';
-type SortCol = 'name' | 'asx_fee_value' | 'us_fee_value' | 'fx_rate' | 'rating';
-
-/* ─── Vertical-specific column headers & tooltips ─── */
-interface ColumnConfig {
-  col1: { label: string; tooltip: string; sortCol: SortCol };
-  col2: { label: string; tooltip: string; sortCol: SortCol };
-  col3: { label: string; tooltip: string; sortCol: SortCol };
-  feat1: { label: string; tooltip: string };
-  feat2: { label: string };
-}
-
-const DEFAULT_COLUMNS: ColumnConfig = {
-  col1: { label: 'ASX Fee', tooltip: '', sortCol: 'asx_fee_value' },
-  col2: { label: 'US Fee', tooltip: '', sortCol: 'us_fee_value' },
-  col3: { label: 'FX Rate', tooltip: '', sortCol: 'fx_rate' },
-  feat1: { label: 'CHESS', tooltip: '' },
-  feat2: { label: 'SMSF' },
-};
-
-const COLUMN_CONFIG: Partial<Record<FilterType, ColumnConfig>> = {
-  shares: {
-    col1: { label: 'ASX Fee', tooltip: 'Brokerage per trade on ASX', sortCol: 'asx_fee_value' },
-    col2: { label: 'US Fee', tooltip: 'Commission per US stock trade', sortCol: 'us_fee_value' },
-    col3: { label: 'FX Rate', tooltip: 'Currency conversion fee percentage', sortCol: 'fx_rate' },
-    feat1: { label: 'CHESS', tooltip: 'CHESS-sponsored holdings' },
-    feat2: { label: 'SMSF' },
-  },
-  super: {
-    col1: { label: 'Mgmt Fee', tooltip: 'Annual administration / management fee', sortCol: 'asx_fee_value' },
-    col2: { label: 'Type', tooltip: 'Industry, retail, or public-sector fund', sortCol: 'us_fee_value' },
-    col3: { label: 'Insurance', tooltip: 'Default insurance cover included', sortCol: 'fx_rate' },
-    feat1: { label: 'Options', tooltip: 'Number of investment options available' },
-    feat2: { label: 'ESG' },
-  },
-  savings: {
-    col1: { label: 'Rate', tooltip: 'Annual interest rate (with conditions met)', sortCol: 'asx_fee_value' },
-    col2: { label: 'Min Deposit', tooltip: 'Minimum deposit to open', sortCol: 'us_fee_value' },
-    col3: { label: 'Conditions', tooltip: 'Requirements to earn bonus rate', sortCol: 'fx_rate' },
-    feat1: { label: 'ADI', tooltip: 'Government deposit guarantee (up to $250,000)' },
-    feat2: { label: 'Online' },
-  },
-  'term-deposits': {
-    col1: { label: 'Rate', tooltip: 'Term deposit rate (6-month term)', sortCol: 'asx_fee_value' },
-    col2: { label: 'Min Deposit', tooltip: 'Minimum deposit to open', sortCol: 'us_fee_value' },
-    col3: { label: 'Conditions', tooltip: 'Terms and early withdrawal rules', sortCol: 'fx_rate' },
-    feat1: { label: 'ADI', tooltip: 'Government deposit guarantee (up to $250,000)' },
-    feat2: { label: 'Online' },
-  },
-  crypto: {
-    col1: { label: 'Trading Fee', tooltip: 'Fee per crypto trade (maker/taker)', sortCol: 'asx_fee_value' },
-    col2: { label: 'Coins', tooltip: 'Number of cryptocurrencies available', sortCol: 'us_fee_value' },
-    col3: { label: 'FX Rate', tooltip: 'AUD deposit/withdrawal fee', sortCol: 'fx_rate' },
-    feat1: { label: 'Staking', tooltip: 'Staking rewards supported' },
-    feat2: { label: 'Wallet' },
-  },
-  cfd: {
-    col1: { label: 'Spread', tooltip: 'Typical spread on major pairs', sortCol: 'asx_fee_value' },
-    col2: { label: 'Leverage', tooltip: 'Maximum leverage for retail clients', sortCol: 'us_fee_value' },
-    col3: { label: 'Markets', tooltip: 'Number of tradeable instruments', sortCol: 'fx_rate' },
-    feat1: { label: 'Demo', tooltip: 'Free demo account available' },
-    feat2: { label: 'MT4/MT5' },
-  },
-  robo: {
-    col1: { label: 'Mgmt Fee', tooltip: 'Annual management fee percentage', sortCol: 'asx_fee_value' },
-    col2: { label: 'Min Investment', tooltip: 'Minimum initial investment', sortCol: 'us_fee_value' },
-    col3: { label: 'Portfolio Type', tooltip: 'ETF, direct shares, or hybrid', sortCol: 'fx_rate' },
-    feat1: { label: 'ESG', tooltip: 'Ethical/ESG portfolio option available' },
-    feat2: { label: 'Tax-Loss' },
-  },
-  property: {
-    col1: { label: 'Min Investment', tooltip: 'Minimum investment amount', sortCol: 'asx_fee_value' },
-    col2: { label: 'Returns', tooltip: 'Historical or projected annual return', sortCol: 'us_fee_value' },
-    col3: { label: 'Type', tooltip: 'REIT, fractional, or direct property', sortCol: 'fx_rate' },
-    feat1: { label: 'Liquidity', tooltip: 'Ability to sell/redeem investment' },
-    feat2: { label: 'SMSF' },
-  },
-  research: {
-    col1: { label: 'Price', tooltip: 'Monthly subscription cost', sortCol: 'asx_fee_value' },
-    col2: { label: 'Markets', tooltip: 'Number of markets covered', sortCol: 'us_fee_value' },
-    col3: { label: 'Alerts', tooltip: 'Real-time alerts and notifications', sortCol: 'fx_rate' },
-    feat1: { label: 'Screener', tooltip: 'Stock screener included' },
-    feat2: { label: 'API' },
-  },
-};
-
-function getColumnConfig(filter: FilterType): ColumnConfig {
-  return COLUMN_CONFIG[filter] || DEFAULT_COLUMNS;
-}
+import type { CategorySchema, RankedBroker, SortCol } from "@/lib/compare-engine";
 
 interface Props {
-  sorted: Broker[];
-  activeFilter: FilterType;
+  rows: RankedBroker[];
+  schema: CategorySchema;
+  activeFilter: string;
   searchQuery: string;
   sortCol: SortCol;
   sortDir: 1 | -1;
@@ -117,11 +28,11 @@ interface Props {
   onToggleSelected: (slug: string) => void;
   sortArrow: (col: SortCol) => React.ReactNode;
   InfoTip: React.ComponentType<{ text: string }>;
-  feeTooltips: Record<string, string>;
 }
 
 export default function CompareDesktopTable({
-  sorted,
+  rows,
+  schema,
   activeFilter,
   searchQuery,
   sortCol,
@@ -135,10 +46,7 @@ export default function CompareDesktopTable({
   onToggleSelected,
   sortArrow,
   InfoTip,
-  feeTooltips,
 }: Props) {
-  const cols = getColumnConfig(activeFilter);
-
   return (
     <div key={`${activeFilter}-${searchQuery}`} className="hidden md:block overflow-x-auto tab-content-enter">
       <ScrollReveal key={`table-${activeFilter}-${searchQuery}-${sortCol}-${sortDir}`} animation="table-row-stagger" as="table" className="w-full border border-slate-200 rounded-lg compare-table">
@@ -150,114 +58,86 @@ export default function CompareDesktopTable({
                 Platform{sortArrow('name')}
               </button>
             </th>
-            <th scope="col" className="px-4 py-3 text-left font-semibold text-sm" aria-sort={sortCol === cols.col1.sortCol ? (sortDir === 1 ? 'ascending' : 'descending') : undefined}>
-              <button onClick={() => onSort(cols.col1.sortCol)} className="hover:text-slate-900 transition-colors" aria-label={`Sort by ${cols.col1.label}`}>
-                {cols.col1.label}{sortArrow(cols.col1.sortCol)}
-              </button>
-              <InfoTip text={cols.col1.tooltip || feeTooltips.asx_fee_value} />
-            </th>
-            <th scope="col" className="px-4 py-3 text-left font-semibold text-sm" aria-sort={sortCol === cols.col2.sortCol ? (sortDir === 1 ? 'ascending' : 'descending') : undefined}>
-              <button onClick={() => onSort(cols.col2.sortCol)} className="hover:text-slate-900 transition-colors" aria-label={`Sort by ${cols.col2.label}`}>
-                {cols.col2.label}{sortArrow(cols.col2.sortCol)}
-              </button>
-              <InfoTip text={cols.col2.tooltip || feeTooltips.us_fee_value} />
-            </th>
-            <th scope="col" className="px-4 py-3 text-left font-semibold text-sm" aria-sort={sortCol === cols.col3.sortCol ? (sortDir === 1 ? 'ascending' : 'descending') : undefined}>
-              <button onClick={() => onSort(cols.col3.sortCol)} className="hover:text-slate-900 transition-colors" aria-label={`Sort by ${cols.col3.label}`}>
-                {cols.col3.label}{sortArrow(cols.col3.sortCol)}
-              </button>
-              <InfoTip text={cols.col3.tooltip || feeTooltips.fx_rate} />
-            </th>
-            <th scope="col" className="px-4 py-3 text-center font-semibold text-sm">
-              {cols.feat1.label}
-              <InfoTip text={cols.feat1.tooltip || feeTooltips.chess} />
-            </th>
-            <th scope="col" className="px-4 py-3 text-center font-semibold text-sm">{cols.feat2.label}</th>
-            <th scope="col" className="px-4 py-3 text-center font-semibold text-sm" aria-sort={sortCol === 'rating' ? (sortDir === 1 ? 'ascending' : 'descending') : undefined}>
-              <button onClick={() => onSort('rating')} className="hover:text-slate-900 transition-colors" aria-label="Sort by rating">
-                Rating{sortArrow('rating')}
-              </button>
-            </th>
+            {schema.columns.map((column) => (
+              <th key={column.key} scope="col" className={`px-4 py-3 text-${column.align ?? 'left'} font-semibold text-sm`} aria-sort={column.sortCol && sortCol === column.sortCol ? (sortDir === 1 ? 'ascending' : 'descending') : undefined}>
+                {column.sortCol ? (
+                  <button onClick={() => onSort(column.sortCol!)} className="hover:text-slate-900 transition-colors" aria-label={`Sort by ${column.label}`}>
+                    {column.label}{sortArrow(column.sortCol)}
+                  </button>
+                ) : column.label}
+                <InfoTip text={column.tooltip} />
+              </th>
+            ))}
+            <th scope="col" className="px-4 py-3 text-center font-semibold text-sm">Why this result?</th>
             <th scope="col" className="px-4 py-3 text-center font-semibold text-sm"></th>
           </tr>
         </thead>
         <tbody className="divide-y divide-slate-200">
-          {sorted.map(broker => (
-            <tr
-              key={broker.id}
-              className={`group hover:bg-slate-50 transition-colors duration-150 ${
-                isSponsored(broker)
-                  ? 'bg-blue-50/30 border-l-2 border-l-blue-400'
-                  : editorPicks[broker.slug]
-                  ? 'bg-emerald-50/40'
-                  : ''
-              }`}
-            >
-              <td className="px-3 py-3">
-                <input
-                  type="checkbox"
-                  checked={selected.has(broker.slug)}
-                  disabled={!selected.has(broker.slug) && selected.size >= 4}
-                  onChange={() => onToggleSelected(broker.slug)}
-                  className="w-4 h-4 accent-slate-700 rounded disabled:opacity-40 disabled:cursor-not-allowed"
-                  aria-label={`Select ${broker.name} for comparison`}
-                />
-              </td>
-              <td className="px-4 py-3">
-                <div className="flex items-center gap-2.5 flex-wrap">
-                  <BrokerLogo broker={broker} size="sm" className="transition-transform duration-200 group-hover:scale-110 shrink-0" />
-                  <div className="flex items-center gap-1.5 flex-wrap min-w-0">
-                    <a href={`/broker/${broker.slug}`} className="font-semibold text-brand hover:text-slate-900 transition-colors">
-                      {broker.name}
-                    </a>
-                    {!isSponsored(broker) && editorPicks[broker.slug] && (
-                      <span className="text-[0.62rem] font-bold px-1.5 py-0.5 bg-emerald-100 text-emerald-700 rounded-full uppercase tracking-wide whitespace-nowrap">
-                        {editorPicks[broker.slug]}
-                      </span>
-                    )}
-                    <PromoBadge broker={broker} />
-                    {campaignWinners.some(w => w.broker_slug === broker.slug) && (
-                      <span className="text-[0.69rem] font-bold px-1.5 py-0.5 bg-blue-50 text-blue-600 rounded-full uppercase tracking-wide">Sponsored</span>
-                    )}
-                    {!campaignWinners.some(w => w.broker_slug === broker.slug) && <SponsorBadge broker={broker} />}
-                    {broker.affiliate_url && !isSponsored(broker) && !campaignWinners.some(w => w.broker_slug === broker.slug) && (
-                      <span title="We may earn a commission if you visit this platform" className="text-[0.62rem] font-semibold px-1.5 py-0.5 bg-slate-100 text-slate-400 rounded-full uppercase tracking-wide">Ad</span>
-                    )}
+          {rows.map(row => {
+            const broker = row.broker;
+            const isCampaignWinner = campaignWinners.some(w => w.broker_slug === broker.slug);
+            return (
+              <tr
+                key={broker.id}
+                className={`group hover:bg-slate-50 transition-colors duration-150 ${
+                  isSponsored(broker)
+                    ? 'bg-blue-50/30 border-l-2 border-l-blue-400'
+                    : editorPicks[broker.slug]
+                    ? 'bg-emerald-50/40'
+                    : ''
+                }`}
+              >
+                <td className="px-3 py-3">
+                  <input
+                    type="checkbox"
+                    checked={selected.has(broker.slug)}
+                    disabled={!selected.has(broker.slug) && selected.size >= 4}
+                    onChange={() => onToggleSelected(broker.slug)}
+                    className="w-4 h-4 accent-slate-700 rounded disabled:opacity-40 disabled:cursor-not-allowed"
+                    aria-label={`Pin ${broker.name} to shortlist`}
+                  />
+                </td>
+                <td className="px-4 py-3 min-w-56">
+                  <div className="flex items-center gap-2.5 flex-wrap">
+                    <BrokerLogo broker={broker} size="sm" className="transition-transform duration-200 group-hover:scale-110 shrink-0" />
+                    <div className="flex items-center gap-1.5 flex-wrap min-w-0">
+                      <a href={`/broker/${broker.slug}`} className="font-semibold text-brand hover:text-slate-900 transition-colors">{broker.name}</a>
+                      {!isSponsored(broker) && editorPicks[broker.slug] && <span className="text-[0.62rem] font-bold px-1.5 py-0.5 bg-emerald-100 text-emerald-700 rounded-full uppercase tracking-wide whitespace-nowrap">{editorPicks[broker.slug]}</span>}
+                      <PromoBadge broker={broker} />
+                      {isCampaignWinner && <span className="text-[0.69rem] font-bold px-1.5 py-0.5 bg-blue-50 text-blue-600 rounded-full uppercase tracking-wide">Sponsored</span>}
+                      {!isCampaignWinner && <SponsorBadge broker={broker} />}
+                    </div>
+                    <ShortlistButton slug={broker.slug} name={broker.name} size="sm" />
                   </div>
-                  <ShortlistButton slug={broker.slug} name={broker.name} size="sm" />
-                </div>
-              </td>
-              <td className="px-4 py-3 text-sm">{broker.asx_fee || 'N/A'}</td>
-              <td className="px-4 py-3 text-sm">{broker.us_fee || 'N/A'}</td>
-              <td className="px-4 py-3 text-sm">{broker.fx_rate != null ? `${broker.fx_rate}%` : 'N/A'}</td>
-              <td className="px-4 py-3 text-center">
-                <span className={broker.chess_sponsored ? 'text-emerald-600 font-semibold' : 'text-red-500'}>
-                  {broker.chess_sponsored ? '✓ Yes' : '✗ No'}
-                </span>
-              </td>
-              <td className="px-4 py-3 text-center">
-                <span className={broker.smsf_support ? 'text-emerald-600 font-semibold' : 'text-red-500'}>
-                  {broker.smsf_support ? '✓ Yes' : '✗ No'}
-                </span>
-              </td>
-              <td className="px-4 py-3 text-center">
-                <span className="text-amber">{renderStars(broker.rating || 0)}</span>
-                <span className="text-sm text-slate-500 ml-1">{broker.rating}</span>
-              </td>
-              <td className="px-4 py-3 text-center">
-                <ABTestCTA
-                  broker={broker}
-                  activeTests={activeABTests}
-                  page="/compare"
-                  cpcCampaignLink={(() => {
-                    const link = getAffiliateLink(broker);
-                    const cid = cpcCampaignMap.get(broker.slug);
-                    return cid ? `${link}${link.includes('?') ? '&' : '?'}cid=${cid}` : `/go/${broker.slug}?placement=compare_cta`;
-                  })()}
-                />
-              </td>
-            </tr>
-          ))}
+                  <p className="mt-1 text-[0.68rem] uppercase tracking-wide text-slate-400">{row.commercialDisclosure}</p>
+                </td>
+                {schema.columns.map((column) => (
+                  <td key={column.key} className={`px-4 py-3 text-sm align-top ${column.align === 'center' ? 'text-center' : ''}`}>{column.value(broker, row)}</td>
+                ))}
+                <td className="px-4 py-3 text-xs text-slate-600 align-top min-w-64">
+                  <details>
+                    <summary className="cursor-pointer font-semibold text-slate-800">Why this result?</summary>
+                    <ul className="mt-2 list-disc pl-4 space-y-1">
+                      {row.why.map((why) => <li key={why}>{why}</li>)}
+                    </ul>
+                  </details>
+                </td>
+                <td className="px-4 py-3 text-center">
+                  <div className="mb-2 whitespace-nowrap"><span className="text-amber">{renderStars(broker.rating || 0)}</span><span className="text-sm text-slate-500 ml-1">{broker.rating}</span></div>
+                  <ABTestCTA
+                    broker={broker}
+                    activeTests={activeABTests}
+                    page="/compare"
+                    cpcCampaignLink={(() => {
+                      const link = getAffiliateLink(broker);
+                      const cid = cpcCampaignMap.get(broker.slug);
+                      return cid ? `${link}${link.includes('?') ? '&' : '?'}cid=${cid}` : `/go/${broker.slug}?placement=compare_cta`;
+                    })()}
+                  />
+                </td>
+              </tr>
+            );
+          })}
         </tbody>
       </ScrollReveal>
     </div>

--- a/app/compare/_components/CompareFooter.tsx
+++ b/app/compare/_components/CompareFooter.tsx
@@ -10,7 +10,7 @@ import AdSlot from "@/components/AdSlot";
 import AdvisorPrompt from "@/components/AdvisorPrompt";
 import LeadMagnet from "@/components/LeadMagnet";
 
-type FilterType = 'all' | 'shares' | 'beginner' | 'chess' | 'free' | 'us' | 'smsf' | 'low-fx' | 'crypto' | 'robo' | 'research' | 'super' | 'property' | 'cfd' | 'savings' | 'term-deposits' | 'has-deal';
+type FilterType = string;
 
 interface Props {
   sorted: Broker[];
@@ -84,13 +84,13 @@ export default function CompareFooter({ sorted, brokers, activeFilter }: Props) 
       {/* Contextual risk warnings based on active filter */}
       <div className="mt-2 text-[0.65rem] md:text-[0.72rem] text-slate-400 text-center leading-relaxed max-w-3xl mx-auto space-y-1.5">
         <p>{PDS_CONSIDERATION} {FSG_NOTE}</p>
-        {(activeFilter === 'cfd' || activeFilter === 'all') && (
+        {(activeFilter === 'cfd' || activeFilter === 'cfd-forex' || activeFilter === 'all') && (
           <p className="text-red-400/80">{CFD_WARNING_SHORT}</p>
         )}
-        {(activeFilter === 'crypto' || activeFilter === 'all') && (
+        {(activeFilter === 'crypto' || activeFilter === 'crypto-exchanges' || activeFilter === 'all') && (
           <p className="text-amber-500/80">{CRYPTO_WARNING}</p>
         )}
-        {(activeFilter === 'super' || activeFilter === 'all') && (
+        {(activeFilter === 'super' || activeFilter === 'super-funds' || activeFilter === 'all') && (
           <p>{SUPER_WARNING_SHORT}</p>
         )}
         <p>{AFCA_REFERENCE}</p>
@@ -105,10 +105,10 @@ export default function CompareFooter({ sorted, brokers, activeFilter }: Props) 
       />
 
       {/* Contextual advisor prompt — changes based on active filter */}
-      {(activeFilter === 'smsf' || activeFilter === 'property' || activeFilter === 'all') && (
+      {(activeFilter === 'smsf' || activeFilter === 'smsf-brokers' || activeFilter === 'property' || activeFilter === 'property-platforms' || activeFilter === 'all') && (
         <div className="mt-4 md:mt-6">
           <AdvisorPrompt
-            context={activeFilter === 'smsf' ? 'smsf' : activeFilter === 'property' ? 'property' : 'general'}
+            context={(activeFilter === 'smsf' || activeFilter === 'smsf-brokers') ? 'smsf' : (activeFilter === 'property' || activeFilter === 'property-platforms') ? 'property' : 'general'}
             compact={activeFilter === 'all'}
           />
         </div>

--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -85,7 +85,7 @@ async function CompareData() {
 
   const { data: brokers } = await supabase
     .from('brokers')
-    .select("id, name, slug, color, icon, logo_url, rating, asx_fee, asx_fee_value, us_fee, us_fee_value, fx_rate, chess_sponsored, smsf_support, is_crypto, platform_type, deal, deal_text, deal_expiry, editors_pick, tagline, cta_text, affiliate_url, sponsorship_tier, benefit_cta, updated_at, fee_last_checked, fee_verified_date, status, promoted_placement, cpa_value, affiliate_priority")
+    .select("id, name, slug, color, icon, logo_url, rating, asx_fee, asx_fee_value, us_fee, us_fee_value, fx_rate, chess_sponsored, smsf_support, is_crypto, platform_type, deal, deal_text, deal_expiry, editors_pick, tagline, cta_text, affiliate_url, sponsorship_tier, benefit_cta, updated_at, fee_last_checked, fee_verified_date, status, promoted_placement, cpa_value, affiliate_priority, fee_source_url, fee_source_tcs_url, deal_source, min_deposit, payment_methods, markets, platforms, regulated_by, accepts_non_residents, requires_australian_address")
     .eq('status', 'active')
     // Revenue-weighted: promoted first, then by rating
     .order('promoted_placement', { ascending: false })

--- a/lib/compare-engine.ts
+++ b/lib/compare-engine.ts
@@ -1,0 +1,364 @@
+import type { Broker, PlatformType as BrokerPlatformType } from "@/lib/types";
+
+export type CompareCategory =
+  | "all"
+  | "share-trading"
+  | "etfs"
+  | "international-shares"
+  | "smsf-brokers"
+  | "crypto-exchanges"
+  | "super-funds"
+  | "savings-accounts"
+  | "term-deposits"
+  | "research-tools"
+  | "property-platforms";
+
+export type ScenarioMode =
+  | "beginner"
+  | "active-trader"
+  | "etf-investor"
+  | "smsf-investor"
+  | "us-shares"
+  | "non-resident"
+  | "low-cost"
+  | "chess-only";
+
+export type SortCol = "name" | "asx_fee_value" | "us_fee_value" | "fx_rate" | "rating" | "estimated_annual_cost" | "rank_score";
+export type FeatureFilter = "chess" | "free" | "smsf" | "low-fx" | "us" | "has-deal";
+
+export interface CostInputs {
+  tradesPerMonth: number;
+  averageTradeSize: number;
+  usTradesPerMonth: number;
+  averageUsTradeSize: number;
+  portfolioBalance: number;
+}
+
+export interface CompareColumn {
+  key: string;
+  label: string;
+  tooltip: string;
+  sortCol?: SortCol;
+  align?: "left" | "center" | "right";
+  value: (broker: Broker, ranked?: RankedBroker) => string;
+}
+
+export interface CategorySchema {
+  key: CompareCategory;
+  label: string;
+  shortLabel: string;
+  description: string;
+  platformTypes: BrokerPlatformType[];
+  include?: (broker: Broker) => boolean;
+  sortOptions: { col: SortCol; label: string }[];
+  featureFilters: FeatureFilter[];
+  columns: CompareColumn[];
+}
+
+export interface RankedBroker {
+  broker: Broker;
+  estimatedAnnualCost: number;
+  rankScore: number;
+  why: string[];
+  commercialDisclosure: "promoted" | "affiliate partner" | "no commercial relationship";
+  feesLastChecked: string;
+  offerExpiry: string;
+  sourceNote: string;
+}
+
+export interface FilterOptions {
+  category: CompareCategory;
+  features?: Set<FeatureFilter>;
+  maxFee?: number;
+  minRating?: number;
+  searchQuery?: string;
+  scenario?: ScenarioMode | "none";
+}
+
+export const DEFAULT_COST_INPUTS: CostInputs = {
+  tradesPerMonth: 2,
+  averageTradeSize: 1000,
+  usTradesPerMonth: 0,
+  averageUsTradeSize: 1000,
+  portfolioBalance: 25000,
+};
+
+const money = (n: number) => `$${Math.round(n).toLocaleString("en-AU")}`;
+const pct = (n?: number) => (n == null ? "N/A" : `${n}%`);
+const yn = (v?: boolean | null) => (v ? "Yes" : "No");
+const text = (v?: string | number | null) => (v == null || v === "" ? "N/A" : String(v));
+
+function genericColumn(key: string, label: string, tooltip: string, value: CompareColumn["value"], sortCol?: SortCol): CompareColumn {
+  return { key, label, tooltip, value, sortCol };
+}
+
+const annualCostColumn = genericColumn(
+  "estimatedAnnualCost",
+  "Est. annual cost",
+  "Indicative annual cost based on the calculator inputs on this page. It is general information only and may not include every fee.",
+  (_broker, ranked) => (ranked ? money(ranked.estimatedAnnualCost) : "Enter inputs"),
+  "estimated_annual_cost",
+);
+const ratingColumn = genericColumn("rating", "Rating", "Editorial rating shown for comparison only.", (b) => text(b.rating), "rating");
+const commercialColumn = genericColumn("commercial", "Commercial", "Commercial relationship for this row.", (_b, r) => r?.commercialDisclosure ?? "no commercial relationship");
+const freshnessColumn = genericColumn("freshness", "Freshness", "Fee check date, offer expiry and source/admin note.", (_b, r) => `Fees checked: ${r?.feesLastChecked ?? "Not recorded"} · Offer expiry: ${r?.offerExpiry ?? "Not recorded"} · Source: ${r?.sourceNote ?? "Not recorded"}`);
+
+export const CATEGORY_SCHEMAS: Record<CompareCategory, CategorySchema> = {
+  all: {
+    key: "all",
+    label: "All platforms",
+    shortLabel: "All",
+    description: "Compare categories first, then switch to a specific category to hide irrelevant columns.",
+    platformTypes: ["share_broker", "crypto_exchange", "super_fund", "savings_account", "term_deposit", "research_tool", "property_platform"],
+    sortOptions: [{ col: "rank_score", label: "Scenario rank" }, { col: "rating", label: "Rating" }, { col: "estimated_annual_cost", label: "Est. annual cost" }, { col: "name", label: "Name" }],
+    featureFilters: ["chess", "free", "smsf", "low-fx", "us", "has-deal"],
+    columns: [annualCostColumn, ratingColumn, commercialColumn, freshnessColumn],
+  },
+  "share-trading": {
+    key: "share-trading",
+    label: "Share trading",
+    shortLabel: "Shares",
+    description: "ASX brokerage, CHESS sponsorship and account features for Australian share trading.",
+    platformTypes: ["share_broker"],
+    sortOptions: [{ col: "rank_score", label: "Scenario rank" }, { col: "asx_fee_value", label: "ASX brokerage" }, { col: "estimated_annual_cost", label: "Est. annual cost" }, { col: "rating", label: "Rating" }],
+    featureFilters: ["chess", "free", "smsf", "has-deal"],
+    columns: [genericColumn("asx", "ASX brokerage", "Brokerage per Australian share trade.", (b) => text(b.asx_fee), "asx_fee_value"), genericColumn("chess", "CHESS", "Whether CHESS-sponsored holdings are available.", (b) => yn(b.chess_sponsored)), genericColumn("smsf", "SMSF", "Whether SMSF accounts are supported.", (b) => yn(b.smsf_support)), annualCostColumn, ratingColumn, commercialColumn, freshnessColumn],
+  },
+  etfs: {
+    key: "etfs",
+    label: "ETFs",
+    shortLabel: "ETFs",
+    description: "Brokerage, CHESS availability and recurring-investing considerations for ETF investors.",
+    platformTypes: ["share_broker", "robo_advisor"],
+    sortOptions: [{ col: "rank_score", label: "Scenario rank" }, { col: "asx_fee_value", label: "ETF brokerage" }, { col: "estimated_annual_cost", label: "Est. annual cost" }, { col: "rating", label: "Rating" }],
+    featureFilters: ["chess", "free", "smsf", "has-deal"],
+    columns: [genericColumn("etfFee", "ETF brokerage", "Brokerage for ETF trades where available.", (b) => text(b.asx_fee), "asx_fee_value"), genericColumn("min", "Minimum", "Minimum deposit or typical starting amount where available.", (b) => text(b.min_deposit)), genericColumn("chess", "CHESS", "CHESS can matter for direct ASX ETF holdings.", (b) => yn(b.chess_sponsored)), annualCostColumn, commercialColumn, freshnessColumn],
+  },
+  "international-shares": {
+    key: "international-shares",
+    label: "US/international shares",
+    shortLabel: "US shares",
+    description: "International brokerage, FX markup and market access for global share investing.",
+    platformTypes: ["share_broker"],
+    include: (b) => b.us_fee_value != null || (b.markets ?? []).some((m) => /us|international|global/i.test(m)),
+    sortOptions: [{ col: "rank_score", label: "Scenario rank" }, { col: "fx_rate", label: "FX rate" }, { col: "us_fee_value", label: "US brokerage" }, { col: "estimated_annual_cost", label: "Est. annual cost" }],
+    featureFilters: ["us", "low-fx", "smsf", "has-deal"],
+    columns: [genericColumn("us", "US brokerage", "Brokerage for US share trades.", (b) => text(b.us_fee), "us_fee_value"), genericColumn("fx", "FX markup", "Currency conversion markup where recorded.", (b) => pct(b.fx_rate), "fx_rate"), genericColumn("markets", "Markets", "Markets listed by the provider.", (b) => (b.markets?.length ? b.markets.join(", ") : "N/A")), annualCostColumn, commercialColumn, freshnessColumn],
+  },
+  "smsf-brokers": {
+    key: "smsf-brokers",
+    label: "SMSF brokers",
+    shortLabel: "SMSF",
+    description: "Broker accounts and custody features commonly checked by SMSF investors and auditors.",
+    platformTypes: ["share_broker", "robo_advisor", "property_platform"],
+    include: (b) => Boolean(b.smsf_support),
+    sortOptions: [{ col: "rank_score", label: "Scenario rank" }, { col: "asx_fee_value", label: "Brokerage" }, { col: "estimated_annual_cost", label: "Est. annual cost" }, { col: "rating", label: "Rating" }],
+    featureFilters: ["smsf", "chess", "low-fx", "has-deal"],
+    columns: [genericColumn("smsf", "SMSF support", "Whether SMSF accounts are supported.", (b) => yn(b.smsf_support)), genericColumn("chess", "CHESS", "Direct HIN/CHESS support where available.", (b) => yn(b.chess_sponsored)), genericColumn("asx", "Brokerage", "Trade brokerage where available.", (b) => text(b.asx_fee), "asx_fee_value"), annualCostColumn, commercialColumn, freshnessColumn],
+  },
+  "crypto-exchanges": {
+    key: "crypto-exchanges",
+    label: "Crypto exchanges",
+    shortLabel: "Crypto",
+    description: "Trading fees, AUD support and custody notes for crypto exchanges.",
+    platformTypes: ["crypto_exchange"],
+    include: (b) => b.is_crypto || b.platform_type === "crypto_exchange",
+    sortOptions: [{ col: "rank_score", label: "Scenario rank" }, { col: "asx_fee_value", label: "Trading fee" }, { col: "rating", label: "Rating" }],
+    featureFilters: ["has-deal"],
+    columns: [genericColumn("trade", "Trading fee", "Recorded spot trading fee or fee label.", (b) => text(b.asx_fee), "asx_fee_value"), genericColumn("funding", "AUD funding", "Recorded payment methods.", (b) => b.payment_methods?.join(", ") || "N/A"), genericColumn("regulated", "Regulatory note", "Regulator or registration note where recorded.", (b) => text(b.regulated_by)), annualCostColumn, commercialColumn, freshnessColumn],
+  },
+  "super-funds": {
+    key: "super-funds",
+    label: "Super funds",
+    shortLabel: "Super",
+    description: "Admin/investment fee labels and fund features. This is general information only.",
+    platformTypes: ["super_fund"],
+    sortOptions: [{ col: "rank_score", label: "Scenario rank" }, { col: "asx_fee_value", label: "Admin fee" }, { col: "rating", label: "Rating" }],
+    featureFilters: ["has-deal"],
+    columns: [genericColumn("admin", "Admin/investment fee", "Fee label recorded for the fund.", (b) => text(b.asx_fee), "asx_fee_value"), genericColumn("minimum", "Minimum", "Minimum balance/deposit where recorded.", (b) => text(b.min_deposit)), genericColumn("notes", "Notes", "General platform notes.", (b) => text(b.tagline)), annualCostColumn, commercialColumn, freshnessColumn],
+  },
+  "savings-accounts": {
+    key: "savings-accounts",
+    label: "Savings accounts",
+    shortLabel: "Savings",
+    description: "Interest-rate labels, conditions and deposit-account notes.",
+    platformTypes: ["savings_account"],
+    sortOptions: [{ col: "rank_score", label: "Scenario rank" }, { col: "asx_fee_value", label: "Rate/value" }, { col: "rating", label: "Rating" }],
+    featureFilters: ["has-deal"],
+    columns: [genericColumn("rate", "Rate", "Recorded interest-rate label.", (b) => text(b.asx_fee), "asx_fee_value"), genericColumn("minimum", "Minimum deposit", "Minimum opening deposit where recorded.", (b) => text(b.min_deposit)), genericColumn("conditions", "Conditions", "Bonus-rate or account conditions where recorded.", (b) => text(b.tagline)), annualCostColumn, commercialColumn, freshnessColumn],
+  },
+  "term-deposits": {
+    key: "term-deposits",
+    label: "Term deposits",
+    shortLabel: "Term deposits",
+    description: "Rate labels, terms and minimum deposits for fixed-term cash products.",
+    platformTypes: ["term_deposit"],
+    sortOptions: [{ col: "rank_score", label: "Scenario rank" }, { col: "asx_fee_value", label: "Rate/value" }, { col: "rating", label: "Rating" }],
+    featureFilters: ["has-deal"],
+    columns: [genericColumn("rate", "Rate", "Recorded rate label.", (b) => text(b.asx_fee), "asx_fee_value"), genericColumn("minimum", "Minimum deposit", "Minimum deposit where recorded.", (b) => text(b.min_deposit)), genericColumn("term", "Term/conditions", "Term or early-withdrawal condition notes where recorded.", (b) => text(b.tagline)), annualCostColumn, commercialColumn, freshnessColumn],
+  },
+  "research-tools": {
+    key: "research-tools",
+    label: "Research tools",
+    shortLabel: "Research",
+    description: "Pricing, market coverage and research-tool features.",
+    platformTypes: ["research_tool"],
+    sortOptions: [{ col: "rank_score", label: "Scenario rank" }, { col: "asx_fee_value", label: "Price" }, { col: "rating", label: "Rating" }],
+    featureFilters: ["has-deal"],
+    columns: [genericColumn("price", "Price", "Subscription price label.", (b) => text(b.asx_fee), "asx_fee_value"), genericColumn("markets", "Markets/data", "Markets covered where recorded.", (b) => b.markets?.join(", ") || "N/A"), genericColumn("platforms", "Platforms", "Supported platforms/devices where recorded.", (b) => b.platforms?.join(", ") || "N/A"), annualCostColumn, commercialColumn, freshnessColumn],
+  },
+  "property-platforms": {
+    key: "property-platforms",
+    label: "Property platforms",
+    shortLabel: "Property",
+    description: "Minimum investment, structure and liquidity notes for property platforms.",
+    platformTypes: ["property_platform"],
+    sortOptions: [{ col: "rank_score", label: "Scenario rank" }, { col: "asx_fee_value", label: "Minimum/value" }, { col: "rating", label: "Rating" }],
+    featureFilters: ["smsf", "has-deal"],
+    columns: [genericColumn("minimum", "Minimum investment", "Minimum investment label.", (b) => text(b.asx_fee || b.min_deposit), "asx_fee_value"), genericColumn("structure", "Structure", "General platform structure note.", (b) => text(b.tagline)), genericColumn("smsf", "SMSF", "Whether SMSF investing is supported.", (b) => yn(b.smsf_support)), annualCostColumn, commercialColumn, freshnessColumn],
+  },
+};
+
+export const CATEGORY_ALIASES: Record<string, CompareCategory> = {
+  shares: "share-trading",
+  "share-trading": "share-trading",
+  etfs: "etfs",
+  us: "international-shares",
+  "us-shares": "international-shares",
+  "international-shares": "international-shares",
+  smsf: "smsf-brokers",
+  "smsf-brokers": "smsf-brokers",
+  crypto: "crypto-exchanges",
+  "crypto-exchanges": "crypto-exchanges",
+  super: "super-funds",
+  "super-funds": "super-funds",
+  savings: "savings-accounts",
+  "savings-accounts": "savings-accounts",
+  "term-deposits": "term-deposits",
+  research: "research-tools",
+  "research-tools": "research-tools",
+  property: "property-platforms",
+  "property-platforms": "property-platforms",
+};
+
+export const SCENARIOS: { key: ScenarioMode; label: string; description: string }[] = [
+  { key: "beginner", label: "Beginner", description: "Emphasises lower headline fees, higher ratings and straightforward feature sets." },
+  { key: "active-trader", label: "Active trader", description: "Weights lower brokerage and FX costs more heavily." },
+  { key: "etf-investor", label: "ETF investor", description: "Emphasises low recurring ASX/ETF trading cost and CHESS availability." },
+  { key: "smsf-investor", label: "SMSF investor", description: "Weights SMSF support, custody signals and audit-friendly features." },
+  { key: "us-shares", label: "US shares", description: "Weights US brokerage, FX markup and global-market access." },
+  { key: "non-resident", label: "Non-resident", description: "Highlights platforms that record non-resident access information." },
+  { key: "low-cost", label: "Low-cost", description: "Ranks primarily by the true-cost calculator output." },
+  { key: "chess-only", label: "CHESS-only", description: "Restricts results to platforms with CHESS-sponsored holdings recorded." },
+];
+
+export function calculateAnnualCost(broker: Broker, inputs: CostInputs = DEFAULT_COST_INPUTS): number {
+  const asxBrokerage = Math.max(0, broker.asx_fee_value ?? 0) * Math.max(0, inputs.tradesPerMonth) * 12;
+  const usBrokerage = Math.max(0, broker.us_fee_value ?? 0) * Math.max(0, inputs.usTradesPerMonth) * 12;
+  const fxMarkup = ((broker.fx_rate ?? 0) / 100) * Math.max(0, inputs.averageUsTradeSize) * Math.max(0, inputs.usTradesPerMonth) * 12;
+  const percentageFee = broker.platform_type === "super_fund" || broker.platform_type === "robo_advisor" ? ((broker.asx_fee_value ?? 0) / 100) * Math.max(0, inputs.portfolioBalance) : 0;
+  return Math.round((asxBrokerage + usBrokerage + fxMarkup + percentageFee) * 100) / 100;
+}
+
+export function commercialDisclosureFor(broker: Broker): RankedBroker["commercialDisclosure"] {
+  if (broker.promoted_placement || broker.sponsorship_tier === "featured_partner" || broker.sponsorship_tier === "deal_of_month") return "promoted";
+  if (broker.affiliate_url || broker.commission_type || broker.cpa_value || broker.affiliate_priority) return "affiliate partner";
+  return "no commercial relationship";
+}
+
+export function dataFreshnessFor(broker: Broker) {
+  return {
+    feesLastChecked: broker.fee_last_checked || broker.fee_verified_date || broker.updated_at || "Not recorded",
+    offerExpiry: broker.deal_expiry || "Not recorded",
+    sourceNote: broker.fee_source_url || broker.fee_source_tcs_url || broker.deal_source || "Admin/source note not public",
+  };
+}
+
+export function scenarioCategory(scenario: ScenarioMode | "none" | undefined, fallback: CompareCategory): CompareCategory {
+  if (scenario === "etf-investor") return "etfs";
+  if (scenario === "smsf-investor") return "smsf-brokers";
+  if (scenario === "us-shares" || scenario === "non-resident") return "international-shares";
+  if (scenario === "chess-only" || scenario === "active-trader" || scenario === "beginner" || scenario === "low-cost") return fallback === "all" ? "share-trading" : fallback;
+  return fallback;
+}
+
+export function filterBrokers(brokers: Broker[], options: FilterOptions): Broker[] {
+  const scenario = options.scenario === "none" ? undefined : options.scenario;
+  const category = scenarioCategory(scenario, options.category);
+  const schema = CATEGORY_SCHEMAS[category];
+  let list = brokers.filter((b) => schema.platformTypes.includes(b.platform_type) || (schema.key === "crypto-exchanges" && b.is_crypto));
+  if (schema.include) list = list.filter(schema.include);
+  const features = options.features ?? new Set<FeatureFilter>();
+  if (scenario === "chess-only") list = list.filter((b) => b.chess_sponsored);
+  if (scenario === "non-resident") list = list.filter((b) => b.accepts_non_residents !== false && b.requires_australian_address !== true);
+  if (features.has("chess")) list = list.filter((b) => b.chess_sponsored);
+  if (features.has("free")) list = list.filter((b) => b.asx_fee_value === 0 || b.us_fee_value === 0);
+  if (features.has("us")) list = list.filter((b) => b.us_fee_value != null || (b.markets ?? []).some((m) => /us|international|global/i.test(m)));
+  if (features.has("smsf")) list = list.filter((b) => b.smsf_support);
+  if (features.has("low-fx")) list = list.filter((b) => b.fx_rate != null && b.fx_rate >= 0 && b.fx_rate < 0.5);
+  if (features.has("has-deal")) list = list.filter((b) => Boolean(b.deal && b.deal_text));
+  if ((options.maxFee ?? 999) < 999) list = list.filter((b) => (b.asx_fee_value ?? 999) <= (options.maxFee ?? 999));
+  if ((options.minRating ?? 0) > 0) list = list.filter((b) => (b.rating ?? 0) >= (options.minRating ?? 0));
+  const q = options.searchQuery?.trim().toLowerCase();
+  if (q) list = list.filter((b) => [b.name, b.tagline, b.slug].some((v) => v?.toLowerCase().includes(q)));
+  return list;
+}
+
+export function explainBroker(broker: Broker, scenario: ScenarioMode | "none" | undefined, annualCost: number): string[] {
+  const why: string[] = [];
+  why.push(`Estimated annual cost is ${money(annualCost)} using the current calculator inputs.`);
+  if (broker.rating != null) why.push(`Editorial rating recorded as ${broker.rating}/5.`);
+  if (broker.chess_sponsored) why.push("CHESS-sponsored holdings are recorded as available.");
+  if (broker.smsf_support) why.push("SMSF account support is recorded.");
+  if (broker.us_fee_value != null) why.push(`US brokerage field is ${text(broker.us_fee)} and FX markup is ${pct(broker.fx_rate)}.`);
+  if (scenario === "non-resident") why.push(broker.accepts_non_residents ? "Non-resident access is recorded as available." : "Non-resident access is not recorded as blocked; confirm directly with the provider.");
+  if (broker.deal && broker.deal_text) why.push("A current offer is recorded; check terms and expiry before acting.");
+  return why.slice(0, 5);
+}
+
+export function rankBroker(broker: Broker, scenario: ScenarioMode | "none" | undefined, inputs: CostInputs = DEFAULT_COST_INPUTS): RankedBroker {
+  const estimatedAnnualCost = calculateAnnualCost(broker, inputs);
+  const ratingScore = (broker.rating ?? 0) * 20;
+  const costScore = Math.max(0, 100 - estimatedAnnualCost / 10);
+  let rankScore = ratingScore * 0.45 + costScore * 0.35;
+  if (broker.chess_sponsored) rankScore += 5;
+  if (broker.smsf_support && scenario === "smsf-investor") rankScore += 18;
+  if (broker.us_fee_value != null && scenario === "us-shares") rankScore += 8;
+  if ((broker.fx_rate ?? 99) < 0.5 && (scenario === "us-shares" || scenario === "active-trader")) rankScore += 10;
+  if (scenario === "low-cost") rankScore = costScore * 0.75 + ratingScore * 0.15 + (broker.chess_sponsored ? 5 : 0);
+  if (scenario === "beginner" && (broker.asx_fee_value ?? 999) <= 5) rankScore += 8;
+  if (scenario === "etf-investor" && broker.chess_sponsored) rankScore += 10;
+  if (scenario === "non-resident" && broker.accepts_non_residents) rankScore += 12;
+  const fresh = dataFreshnessFor(broker);
+  return {
+    broker,
+    estimatedAnnualCost,
+    rankScore: Math.round(rankScore * 10) / 10,
+    why: explainBroker(broker, scenario, estimatedAnnualCost),
+    commercialDisclosure: commercialDisclosureFor(broker),
+    ...fresh,
+  };
+}
+
+export function rankBrokers(brokers: Broker[], scenario: ScenarioMode | "none" | undefined, inputs: CostInputs = DEFAULT_COST_INPUTS): RankedBroker[] {
+  return brokers.map((broker) => rankBroker(broker, scenario, inputs));
+}
+
+export function sortRankedBrokers(rows: RankedBroker[], sortCol: SortCol, sortDir: 1 | -1): RankedBroker[] {
+  return [...rows].sort((a, b) => {
+    const av = sortCol === "estimated_annual_cost" ? a.estimatedAnnualCost : sortCol === "rank_score" ? a.rankScore : a.broker[sortCol as keyof Broker] ?? (sortCol === "name" ? "" : 999);
+    const bv = sortCol === "estimated_annual_cost" ? b.estimatedAnnualCost : sortCol === "rank_score" ? b.rankScore : b.broker[sortCol as keyof Broker] ?? (sortCol === "name" ? "" : 999);
+    if (typeof av === "string" && typeof bv === "string") return av.localeCompare(bv) * sortDir;
+    return ((av as number) - (bv as number)) * sortDir;
+  });
+}
+
+export function updateShortlist(current: string[], slug: string, max = 4): string[] {
+  if (current.includes(slug)) return current.filter((s) => s !== slug);
+  if (current.length >= max) return current;
+  return [...current, slug];
+}
+
+export function getMobileCardFields(schema: CategorySchema): string[] {
+  return schema.columns.slice(0, 4).map((c) => c.label);
+}


### PR DESCRIPTION
### Motivation

- Provide category-specific comparison views so irrelevant columns are hidden and comparisons are more meaningful per product vertical. 
- Surface a transparent, reproducible ranking that incorporates user scenarios and a true-cost estimate rather than relying only on filter toggles. 
- Improve mobile and shortlist UX while adding publisher disclosures and fee freshness metadata at the row level.

### Description

- Added a reusable compare engine `lib/compare-engine.ts` with category schemas (`CATEGORY_SCHEMAS`), scenario modes (`SCENARIOS`), a `calculateAnnualCost` true-cost calculator, ranking helpers (`rankBroker`, `rankBrokers`, `sortRankedBrokers`), filtering (`filterBrokers`), shortlist helper (`updateShortlist`) and mobile-card helpers (`getMobileCardFields`).
- Reworked the compare UI to consume the engine: replaced generic filtering/sorting with category-aware controls and scenario selector in `app/compare/CompareClient.tsx`, added the true-cost input panel, and wired scenario → effective category logic and ranking inputs into the results pipeline.
- Reimplemented the desktop table as a schema-driven component (`app/compare/_components/CompareDesktopTable.tsx`) that renders category-specific columns, row-level commercial disclosure, data-freshness fields and an expandable “Why this result?” explanation for each provider.
- Replaced generic mobile cards with category-aware mobile cards that use the schema column set, and added a pinned shortlist drawer (2–4 providers) to the compare page for side-by-side pinning and quick inspection (`CompareClient` changes). 
- Extended server data selection in `app/compare/page.tsx` to include fee/source/freshness and eligibility fields used by the new engine (e.g. `fee_source_url`, `fee_last_checked`, `accepts_non_residents`, `markets`, etc.).
- Added unit tests `__tests__/lib/compare-engine.test.ts` covering category filtering, schema composition, annual cost calculation, sorting/ranking, shortlist caps/toggle behaviour, scenario boosts and mobile field extraction.

### Testing

- Ran static/type checks with `npm run type-check` and fixed reported issues (type-check succeeded).
- Ran linter with `npx eslint app/compare/CompareClient.tsx app/compare/_components/CompareDesktopTable.tsx app/compare/_components/CompareFooter.tsx lib/compare-engine.ts __tests__/lib/compare-engine.test.ts` (no blocking warnings/errors after fixes).
- Executed unit tests with `npx vitest run __tests__/lib/compare-engine.test.ts`; all tests passed (filtering, sorting, cost calc, shortlist, scenario ranking, mobile layout assertions).
- Attempted a Playwright mobile screenshot to validate layout, but browser binaries are not installed in the environment so the screenshot step was skipped (non-blocking manual check advised in CI/preview environments).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03a2fb31188322acb24d2423d0d2f9)