### PR TITLE
feat(investor): AI portfolio analysis engine + gated route (X5j) [gated]

### DIFF
--- a/__tests__/api/holdings-ai-analysis.test.ts
+++ b/__tests__/api/holdings-ai-analysis.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { createChainableBuilder } from "@/__tests__/helpers";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const { mockGetUser, mockServerFrom, mockIsFlagEnabled, mockIsRateLimited, mockGetInvestorProfile, mockAnthropicCreate } =
+  vi.hoisted(() => ({
+    mockGetUser: vi.fn(),
+    mockServerFrom: vi.fn(),
+    mockIsFlagEnabled: vi.fn(),
+    mockIsRateLimited: vi.fn(),
+    mockGetInvestorProfile: vi.fn(),
+    mockAnthropicCreate: vi.fn(),
+  }));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({
+    auth: { getUser: mockGetUser },
+    from: mockServerFrom,
+  })),
+}));
+
+vi.mock("@/lib/feature-flags", () => ({
+  isFlagEnabled: (...args: unknown[]) => mockIsFlagEnabled(...args),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  isRateLimited: (...args: unknown[]) => mockIsRateLimited(...args),
+}));
+
+vi.mock("@/lib/investor-profiles", () => ({
+  getInvestorProfile: (...args: unknown[]) => mockGetInvestorProfile(...args),
+}));
+
+vi.mock("@anthropic-ai/sdk", () => {
+  // The route does `new Anthropic({ apiKey })`, so the default export
+  // must be a constructable class. A plain `vi.fn()` doesn't always
+  // satisfy `new` under the forks pool — use an explicit class.
+  class MockAnthropic {
+    messages = {
+      create: (...args: unknown[]) => mockAnthropicCreate(...args),
+    };
+  }
+  return { default: MockAnthropic };
+});
+
+// Logger no-op so test output stays clean.
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+import { POST } from "@/app/api/account/holdings/ai-analysis/route";
+import { GAW_AI_PREFIX } from "@/lib/compliance";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makePost(body: unknown = { acknowledge_general_information: true }): NextRequest {
+  return new NextRequest("http://localhost/api/account/holdings/ai-analysis", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function authedUser(id = "user-abc", email = "user@test.com") {
+  mockGetUser.mockResolvedValue({ data: { user: { id, email } } });
+}
+
+function holdingsChain(rows: unknown[] | null, error: unknown = null) {
+  const calls: Record<string, { method: string; args: unknown[] }[]> = {};
+  const chain = createChainableBuilder("investor_holdings", calls);
+  // Final await on .order() should resolve with rows/error.
+  chain.order = vi.fn(() => Promise.resolve({ data: rows, error })) as unknown as ReturnType<typeof vi.fn>;
+  mockServerFrom.mockReturnValue(chain);
+  return chain;
+}
+
+function defaultHoldings() {
+  return [
+    {
+      ticker: "VAS",
+      exchange: "ASX",
+      shares: 100,
+      cost_basis_per_share_cents: 9500,
+      acquired_at: "2025-01-15",
+      broker_slug: "selfwealth",
+    },
+    {
+      ticker: "VGS",
+      exchange: "ASX",
+      shares: 50,
+      cost_basis_per_share_cents: 11000,
+      acquired_at: "2024-12-10",
+      broker_slug: null,
+    },
+  ];
+}
+
+const SAFE_MODEL_OUTPUT =
+  `${GAW_AI_PREFIX}\n` +
+  `- Your portfolio is concentrated in Australian equities, higher than a global market-cap weighting.\n` +
+  `- Sector exposure leans toward financials and resources.\n` +
+  `- Index-tilted holdings dominate, consistent with low-cost passive exposure.`;
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("POST /api/account/holdings/ai-analysis", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.ANTHROPIC_API_KEY = "test-anthropic-key";
+    mockIsRateLimited.mockResolvedValue(false);
+    mockIsFlagEnabled.mockResolvedValue(true);
+    mockGetInvestorProfile.mockResolvedValue(null);
+    mockAnthropicCreate.mockResolvedValue({
+      content: [{ type: "text", text: SAFE_MODEL_OUTPUT }],
+    });
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    const res = await POST(makePost());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when the feature flag is disabled (default off)", async () => {
+    authedUser();
+    mockIsFlagEnabled.mockResolvedValue(false);
+    const res = await POST(makePost());
+    expect(res.status).toBe(404);
+    // Do not leak existence of the route via the body either.
+    const json = await res.json();
+    expect(json.error).toBe("not_found");
+  });
+
+  it("returns 400 when acknowledge_general_information is missing", async () => {
+    authedUser();
+    const res = await POST(makePost({}));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when acknowledge_general_information is false", async () => {
+    authedUser();
+    const res = await POST(makePost({ acknowledge_general_information: false }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 429 when the rate limit is exceeded", async () => {
+    authedUser();
+    mockIsRateLimited.mockResolvedValue(true);
+    const res = await POST(makePost());
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 400 when the user has no holdings", async () => {
+    authedUser();
+    holdingsChain([], null);
+    const res = await POST(makePost());
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.reason).toBe("no_holdings");
+  });
+
+  it("returns 503 when ANTHROPIC_API_KEY is missing", async () => {
+    process.env.ANTHROPIC_API_KEY = "";
+    authedUser();
+    holdingsChain(defaultHoldings(), null);
+    const res = await POST(makePost());
+    expect(res.status).toBe(503);
+  });
+
+  it("returns 200 with observations on the happy path", async () => {
+    authedUser();
+    holdingsChain(defaultHoldings(), null);
+    const res = await POST(makePost());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+    expect(Array.isArray(json.observations)).toBe(true);
+    expect(json.observations.length).toBeGreaterThanOrEqual(3);
+    expect(json.disclaimer).toBeDefined();
+  });
+
+  it("returns 200 with ok:false on a compliance filter rejection", async () => {
+    authedUser();
+    holdingsChain(defaultHoldings(), null);
+    mockAnthropicCreate.mockResolvedValue({
+      content: [
+        {
+          type: "text",
+          text: `${GAW_AI_PREFIX}\n- You should rebalance.\n- Concentration high.\n- Fees low.`,
+        },
+      ],
+    });
+    const res = await POST(makePost());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(false);
+    expect(json.reason).toBe("compliance_filter_failed");
+    expect(json.disclaimer).toBeDefined();
+  });
+
+  it("uses the user id in the rate-limit key", async () => {
+    authedUser("uid-zzz");
+    holdingsChain(defaultHoldings(), null);
+    await POST(makePost());
+    const args = mockIsRateLimited.mock.calls[0] as [string, number, number];
+    expect(args[0]).toContain("uid-zzz");
+  });
+
+  it("checks the investor_ai_analysis_enabled feature flag", async () => {
+    authedUser();
+    holdingsChain(defaultHoldings(), null);
+    await POST(makePost());
+    const args = mockIsFlagEnabled.mock.calls[0] as [string, unknown];
+    expect(args[0]).toBe("investor_ai_analysis_enabled");
+  });
+});

--- a/__tests__/lib/holdings/ai-analysis.test.ts
+++ b/__tests__/lib/holdings/ai-analysis.test.ts
@@ -1,0 +1,271 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  formatHoldingsForPrompt,
+  runHoldingsAnalysis,
+  ANALYSIS_SYSTEM_PROMPT,
+  HOLDINGS_PROMPT_CAP,
+  type HoldingForAnalysis,
+  type ProfileForAnalysis,
+} from "@/lib/holdings/ai-analysis";
+import { GAW_AI_PREFIX } from "@/lib/compliance";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function holding(overrides: Partial<HoldingForAnalysis> = {}): HoldingForAnalysis {
+  return {
+    ticker: "VAS",
+    exchange: "ASX",
+    shares: 100,
+    cost_basis_per_share_cents: 9500,
+    acquired_at: "2025-01-15",
+    broker_slug: null,
+    ...overrides,
+  };
+}
+
+const PROFILE: ProfileForAnalysis = {
+  isFhb: false,
+  isPreRetiree: false,
+  isBusinessOwner: false,
+  isCrossBorder: false,
+  isHnw: false,
+};
+
+/**
+ * Build a minimal mock for the injected Anthropic client. We only need
+ * `messages.create` to resolve to a `{ content: [{ type: "text", text }] }`
+ * shape — the engine doesn't touch anything else on the client.
+ */
+function mockAnthropic(text: string) {
+  return {
+    messages: {
+      create: vi.fn().mockResolvedValue({
+        content: [{ type: "text", text }],
+      }),
+    },
+    // The engine never touches these but Anthropic typings expect them.
+    // Cast through unknown so the test stays decoupled from SDK internals.
+  } as unknown as import("@anthropic-ai/sdk").default;
+}
+
+// ── formatHoldingsForPrompt ───────────────────────────────────────────────────
+
+describe("formatHoldingsForPrompt", () => {
+  it("includes ticker, exchange, shares, and cost basis", () => {
+    const prompt = formatHoldingsForPrompt(
+      [holding({ ticker: "VGS", exchange: "ASX", shares: 42, cost_basis_per_share_cents: 12345 })],
+      PROFILE,
+    );
+    expect(prompt).toContain("VGS");
+    expect(prompt).toContain("ASX");
+    expect(prompt).toContain("42 shares");
+    expect(prompt).toContain("A$123.45");
+  });
+
+  it("includes broker_slug when present", () => {
+    const prompt = formatHoldingsForPrompt(
+      [holding({ broker_slug: "stake" })],
+      PROFILE,
+    );
+    expect(prompt).toContain("via stake");
+  });
+
+  it("renders 'none recorded' when no life-event flags are set", () => {
+    const prompt = formatHoldingsForPrompt([holding()], PROFILE);
+    expect(prompt).toContain("Profile flags: none recorded.");
+  });
+
+  it("lists active life-event flags", () => {
+    const prompt = formatHoldingsForPrompt([holding()], {
+      isFhb: true,
+      isPreRetiree: false,
+      isBusinessOwner: true,
+      isCrossBorder: false,
+      isHnw: true,
+    });
+    expect(prompt).toContain("first-home buyer");
+    expect(prompt).toContain("business owner");
+    expect(prompt).toContain("high-net-worth");
+  });
+
+  it("caps holdings at HOLDINGS_PROMPT_CAP", () => {
+    const big = Array.from({ length: 200 }, (_, i) =>
+      holding({ ticker: `TKR${i}` }),
+    );
+    const prompt = formatHoldingsForPrompt(big, PROFILE);
+    // Last included ticker is TKR{cap-1}; first omitted is TKR{cap}.
+    expect(prompt).toContain(`TKR${HOLDINGS_PROMPT_CAP - 1}`);
+    expect(prompt).not.toContain(`TKR${HOLDINGS_PROMPT_CAP} `);
+    expect(prompt).toMatch(/100 additional holdings omitted/);
+  });
+});
+
+// ── ANALYSIS_SYSTEM_PROMPT ────────────────────────────────────────────────────
+
+describe("ANALYSIS_SYSTEM_PROMPT", () => {
+  it("explicitly forbids advice-shaped phrasing", () => {
+    expect(ANALYSIS_SYSTEM_PROMPT).toMatch(/you should/i);
+    expect(ANALYSIS_SYSTEM_PROMPT).toMatch(/we recommend/i);
+    expect(ANALYSIS_SYSTEM_PROMPT).toMatch(/buy now/i);
+    expect(ANALYSIS_SYSTEM_PROMPT).toMatch(/sell now/i);
+    expect(ANALYSIS_SYSTEM_PROMPT).toMatch(/personal advice/i);
+  });
+
+  it("asks for exactly 3 observations covering diversification, concentration, fees", () => {
+    expect(ANALYSIS_SYSTEM_PROMPT).toMatch(/EXACTLY 3 observations/);
+    expect(ANALYSIS_SYSTEM_PROMPT).toMatch(/diversification/i);
+    expect(ANALYSIS_SYSTEM_PROMPT).toMatch(/concentration/i);
+    expect(ANALYSIS_SYSTEM_PROMPT).toMatch(/fee efficiency/i);
+  });
+
+  it("requires the GAW prefix", () => {
+    expect(ANALYSIS_SYSTEM_PROMPT).toContain(GAW_AI_PREFIX);
+  });
+});
+
+// ── runHoldingsAnalysis ───────────────────────────────────────────────────────
+
+describe("runHoldingsAnalysis", () => {
+  it("returns no_holdings when given an empty list", async () => {
+    const client = mockAnthropic("unused");
+    const result = await runHoldingsAnalysis([], PROFILE, {
+      anthropicClient: client,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("no_holdings");
+  });
+
+  it("returns ok:true with observations when the model output passes the filter", async () => {
+    // No numeric stats in the body so we avoid the stat-citation rule entirely.
+    // The filter only requires citations directly after a numeric value, so
+    // qualitative observations sail through cleanly.
+    const safeText =
+      `${GAW_AI_PREFIX}\n` +
+      `- Your portfolio is concentrated in Australian equities, higher than a global market-cap weighting.\n` +
+      `- Sector exposure leans toward financials and resources.\n` +
+      `- Index-style holdings dominate, consistent with low-cost passive exposure.`;
+    const client = mockAnthropic(safeText);
+
+    const result = await runHoldingsAnalysis([holding()], PROFILE, {
+      anthropicClient: client,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.observations.length).toBeGreaterThanOrEqual(3);
+      expect(result.observations[0]).toMatch(/concentrat|portfolio/i);
+      expect(result.rawText).toContain(GAW_AI_PREFIX);
+    }
+  });
+
+  it("returns compliance_filter_failed when the model uses 'you should'", async () => {
+    const advicey =
+      `${GAW_AI_PREFIX}\n` +
+      `- You should rebalance into bonds.\n` +
+      `- Sector concentration is high.\n` +
+      `- Fees look efficient.`;
+    const client = mockAnthropic(advicey);
+
+    const result = await runHoldingsAnalysis([holding()], PROFILE, {
+      anthropicClient: client,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe("compliance_filter_failed");
+      expect(result.detail).toMatch(/personal-advice/i);
+    }
+  });
+
+  it("returns compliance_filter_failed when the GAW prefix is missing", async () => {
+    const client = mockAnthropic(
+      "- Diversification is reasonable.\n- Concentration is moderate.\n- Fees are low.",
+    );
+    const result = await runHoldingsAnalysis([holding()], PROFILE, {
+      anthropicClient: client,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("compliance_filter_failed");
+  });
+
+  it("returns empty_response when the model returns no text blocks", async () => {
+    const client = {
+      messages: { create: vi.fn().mockResolvedValue({ content: [] }) },
+    } as unknown as import("@anthropic-ai/sdk").default;
+    const result = await runHoldingsAnalysis([holding()], PROFILE, {
+      anthropicClient: client,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("empty_response");
+  });
+
+  it("returns model_call_failed when the Anthropic client throws", async () => {
+    const client = {
+      messages: {
+        create: vi.fn().mockRejectedValue(new Error("anthropic 500")),
+      },
+    } as unknown as import("@anthropic-ai/sdk").default;
+    const result = await runHoldingsAnalysis([holding()], PROFILE, {
+      anthropicClient: client,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe("model_call_failed");
+      expect(result.detail).toContain("anthropic 500");
+    }
+  });
+
+  it("caps input at HOLDINGS_PROMPT_CAP when 200 holdings are passed", async () => {
+    const safeText =
+      `${GAW_AI_PREFIX}\n- a\n- b\n- c`;
+    const client = mockAnthropic(safeText);
+
+    const big = Array.from({ length: 200 }, (_, i) =>
+      holding({ ticker: `T${i}` }),
+    );
+    await runHoldingsAnalysis(big, PROFILE, {
+      anthropicClient: client,
+    });
+
+    // Inspect the prompt the client received and ensure the 101st ticker
+    // was excluded — that confirms the cap was applied before the call.
+    const createMock = client.messages.create as unknown as ReturnType<
+      typeof vi.fn
+    >;
+    expect(createMock).toHaveBeenCalledTimes(1);
+    const callArgs = createMock.mock.calls[0]?.[0] as {
+      messages: { content: string }[];
+    };
+    const userContent = callArgs.messages[0]?.content ?? "";
+    expect(userContent).toContain(`T${HOLDINGS_PROMPT_CAP - 1}`);
+    expect(userContent).not.toMatch(new RegExp(`T${HOLDINGS_PROMPT_CAP}\\s`));
+    expect(userContent).toMatch(/100 additional holdings omitted/);
+  });
+
+  it("uses DEFAULT_ANALYSIS_MODEL when no modelId is given", async () => {
+    const safeText = `${GAW_AI_PREFIX}\n- a\n- b\n- c`;
+    const client = mockAnthropic(safeText);
+    await runHoldingsAnalysis([holding()], PROFILE, {
+      anthropicClient: client,
+    });
+    const createMock = client.messages.create as unknown as ReturnType<
+      typeof vi.fn
+    >;
+    const callArgs = createMock.mock.calls[0]?.[0] as { model: string };
+    expect(callArgs.model).toBe("claude-opus-4-7");
+  });
+
+  it("honours an injected modelId override", async () => {
+    const safeText = `${GAW_AI_PREFIX}\n- a\n- b\n- c`;
+    const client = mockAnthropic(safeText);
+    await runHoldingsAnalysis([holding()], PROFILE, {
+      anthropicClient: client,
+      modelId: "claude-opus-4-6",
+    });
+    const createMock = client.messages.create as unknown as ReturnType<
+      typeof vi.fn
+    >;
+    const callArgs = createMock.mock.calls[0]?.[0] as { model: string };
+    expect(callArgs.model).toBe("claude-opus-4-6");
+  });
+});

--- a/app/api/account/holdings/ai-analysis/route.ts
+++ b/app/api/account/holdings/ai-analysis/route.ts
@@ -1,0 +1,184 @@
+/**
+ * POST /api/account/holdings/ai-analysis — AI portfolio analysis (PR-X5j).
+ *
+ * COMPLIANCE NOTICE — read before changing this file:
+ *
+ *   Pre-AFSL: this route returns 404 unless the `investor_ai_analysis_enabled`
+ *   feature flag is true. Even when enabled, outputs MUST pass
+ *   `filterFactualOutput()` and the system prompt forbids advice language.
+ *   Enabling this flag pre-AFSL would be a compliance violation — only
+ *   flip after AFSL grants (~2026-11).
+ *
+ *   The 404 (rather than 403) is intentional: it does not leak that this
+ *   route exists, matching the rest of the platform's gating posture
+ *   while we are operating under the s766B(6)/(7) factual-information
+ *   carve-out.
+ *
+ *   The route also requires the caller to send `acknowledge_general_information: true`
+ *   in the body — an explicit, in-line acknowledgement that the output is
+ *   general information / factual comparison only, not personal advice.
+ */
+
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import Anthropic from "@anthropic-ai/sdk";
+import { createClient } from "@/lib/supabase/server";
+import { withValidatedBody } from "@/lib/validation/withValidatedBody";
+import { isFlagEnabled } from "@/lib/feature-flags";
+import { isRateLimited } from "@/lib/rate-limit";
+import { getInvestorProfile } from "@/lib/investor-profiles";
+import { logger } from "@/lib/logger";
+import {
+  runHoldingsAnalysis,
+  ANALYSIS_DISCLAIMER,
+  type HoldingForAnalysis,
+} from "@/lib/holdings/ai-analysis";
+import { RISK_WARNING_CTA } from "@/lib/compliance";
+
+const log = logger("api:account:ai-analysis");
+
+export const runtime = "nodejs";
+export const maxDuration = 60;
+
+const FEATURE_FLAG_KEY = "investor_ai_analysis_enabled";
+
+/**
+ * Rate-limit window: 5 analyses per user per 24 hours. Tuned to permit
+ * a few legitimate re-runs (e.g. after editing holdings) while bounding
+ * per-user model spend. `lib/rate-limit.ts` uses DB-backed counters so
+ * the limit survives serverless cold starts.
+ */
+const RATE_LIMIT_MAX = 5;
+const RATE_LIMIT_WINDOW_MINUTES = 24 * 60;
+
+const RequestBody = z.object({
+  /**
+   * Explicit per-request acknowledgement that the output is comparison /
+   * factual information only, not personal advice. Required `true` literal
+   * — anything else fails Zod parse and 400s.
+   */
+  acknowledge_general_information: z.literal(true),
+});
+
+export const POST = withValidatedBody(RequestBody, async (_req, _body) => {
+  // ── 1. Auth ────────────────────────────────────────────────────────────
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  // ── 2. Feature flag gate ───────────────────────────────────────────────
+  // 404 (not 403) so we do not leak that the route exists. This is
+  // deliberate — see the file header re: pre-AFSL posture.
+  const enabled = await isFlagEnabled(FEATURE_FLAG_KEY, {
+    userKey: user.email ?? user.id,
+    segment: "user",
+  });
+  if (!enabled) {
+    return NextResponse.json({ error: "not_found" }, { status: 404 });
+  }
+
+  // ── 3. Rate limit ──────────────────────────────────────────────────────
+  if (
+    await isRateLimited(
+      `ai_analysis:${user.id}`,
+      RATE_LIMIT_MAX,
+      RATE_LIMIT_WINDOW_MINUTES,
+    )
+  ) {
+    return NextResponse.json(
+      {
+        error: "rate_limited",
+        message: `Limit ${RATE_LIMIT_MAX} analyses per 24 hours.`,
+      },
+      { status: 429 },
+    );
+  }
+
+  // ── 4. Fetch holdings (user-scoped — RLS enforces ownership) ──────────
+  const { data: holdingsRows, error: holdingsError } = await supabase
+    .from("investor_holdings")
+    .select(
+      "ticker, exchange, shares, cost_basis_per_share_cents, acquired_at, broker_slug",
+    )
+    .order("acquired_at", { ascending: false });
+
+  if (holdingsError) {
+    log.warn("holdings fetch failed", { error: holdingsError.message });
+    return NextResponse.json({ error: "fetch_failed" }, { status: 500 });
+  }
+
+  const holdings: HoldingForAnalysis[] = (holdingsRows ?? []).map((row) => ({
+    ticker: String(row.ticker),
+    exchange: String(row.exchange),
+    shares: Number(row.shares),
+    cost_basis_per_share_cents: Number(row.cost_basis_per_share_cents),
+    acquired_at: String(row.acquired_at),
+    broker_slug: (row.broker_slug as string | null) ?? null,
+  }));
+
+  if (holdings.length === 0) {
+    return NextResponse.json(
+      {
+        ok: false,
+        reason: "no_holdings",
+        message: "Add at least one holding before running an analysis.",
+      },
+      { status: 400 },
+    );
+  }
+
+  // ── 5. Fetch profile (best-effort — engine handles null profile) ──────
+  const profile = await getInvestorProfile(user.id);
+  const profileFlags = {
+    isFhb: profile?.isFhb === true,
+    isPreRetiree: profile?.isPreRetiree === true,
+    isBusinessOwner: profile?.isBusinessOwner === true,
+    isCrossBorder: profile?.isCrossBorder === true,
+    isHnw: profile?.isHnw === true,
+  };
+
+  // ── 6. Anthropic config check ─────────────────────────────────────────
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    log.warn("ANTHROPIC_API_KEY missing — analysis cannot run");
+    return NextResponse.json(
+      { ok: false, reason: "not_configured" },
+      { status: 503 },
+    );
+  }
+
+  // ── 7. Run analysis ───────────────────────────────────────────────────
+  const anthropicClient = new Anthropic({ apiKey });
+  const result = await runHoldingsAnalysis(holdings, profileFlags, {
+    anthropicClient,
+  });
+
+  if (!result.ok) {
+    log.warn("analysis returned non-ok result", {
+      reason: result.reason,
+      detail: result.detail,
+      user_id: user.id,
+    });
+    return NextResponse.json(
+      {
+        ok: false,
+        reason: result.reason,
+        // Standard short risk-warning still surfaced on failure so the
+        // caller's UI can show the appropriate footer copy.
+        disclaimer: RISK_WARNING_CTA,
+      },
+      { status: 200 },
+    );
+  }
+
+  return NextResponse.json({
+    ok: true,
+    observations: result.observations,
+    raw_text: result.rawText,
+    disclaimer: ANALYSIS_DISCLAIMER,
+  });
+});

--- a/lib/holdings/ai-analysis.ts
+++ b/lib/holdings/ai-analysis.ts
@@ -1,0 +1,295 @@
+/**
+ * AI portfolio analysis engine — PR-X5j (Phase 4 of the investor-account roadmap).
+ *
+ * COMPLIANCE POSTURE (read before changing this file):
+ *
+ *   Invest.com.au operates under the s766B(6)/(7) factual-information
+ *   carve-outs of the Corporations Act 2001 — we do NOT hold an AFSL
+ *   (expected grant ~2026-11). Personalized AI commentary on a specific
+ *   user's portfolio sits very close to the personal-advice line. This
+ *   engine is built defensively:
+ *
+ *     1. The route that invokes it is gated by `investor_ai_analysis_enabled`
+ *        which is seeded `false` and MUST stay false until AFSL grants.
+ *     2. The system prompt explicitly frames every observation as factual
+ *        comparison, not a recommendation. It bans advice-shaped language.
+ *     3. The model's text reply is filtered through `filterFactualOutput()`
+ *        before it is returned to the caller. Any rejected span fails the
+ *        whole analysis — the engine reports `compliance_filter_failed`
+ *        rather than partial output.
+ *     4. Output is capped at 800 tokens and input at the top 100 holdings
+ *        so a malicious / accidental loop can't burn through tokens.
+ *
+ * This module is pure-ish: the `runHoldingsAnalysis` function takes an
+ * injected Anthropic client so tests can mock the call. There is NO
+ * module-level Anthropic client — the caller is responsible for
+ * instantiation (so we never accidentally fire requests during import).
+ */
+
+import type Anthropic from "@anthropic-ai/sdk";
+import {
+  filterFactualOutput,
+  GAW_AI_PREFIX,
+  RISK_WARNING_CTA,
+} from "@/lib/compliance";
+import type { InvestorProfile } from "@/lib/investor-profiles";
+
+/**
+ * Default Claude model used by the analysis engine. Latest Opus model
+ * keyed to the AI cost-cap pricing table in `lib/ai-cost-caps.ts`.
+ * Override at the call site for tests / experimentation.
+ */
+export const DEFAULT_ANALYSIS_MODEL = "claude-opus-4-7";
+
+/** Hard cap on the number of holdings we include in the prompt body. */
+export const HOLDINGS_PROMPT_CAP = 100;
+
+/** Hard cap on the model's response in output tokens. */
+export const MAX_OUTPUT_TOKENS = 800;
+
+/**
+ * Subset of the `investor_holdings` row shape needed for the prompt.
+ * Kept local so the engine doesn't take a hard dependency on the
+ * column list (which is allowed to evolve in unrelated PRs).
+ */
+export interface HoldingForAnalysis {
+  ticker: string;
+  exchange: string;
+  shares: number;
+  cost_basis_per_share_cents: number;
+  acquired_at: string;
+  broker_slug?: string | null;
+}
+
+/**
+ * Subset of `InvestorProfile` the prompt actually uses. We deliberately
+ * pass the small flag set rather than the whole row so we don't leak
+ * unrelated profile fields (display name, intent country, etc.) into
+ * the model's context.
+ */
+export interface ProfileForAnalysis {
+  isFhb: boolean;
+  isPreRetiree: boolean;
+  isBusinessOwner: boolean;
+  isCrossBorder: boolean;
+  isHnw: boolean;
+}
+
+/**
+ * Result returned by `runHoldingsAnalysis`. Either:
+ *   - `ok: true`  → model produced text that passed `filterFactualOutput`;
+ *     `observations` is the bullet list, `rawText` is the full filtered body.
+ *   - `ok: false` → either the model call failed, the response was empty,
+ *     or the compliance filter rejected the output. `reason` is a stable
+ *     machine-readable string suitable for logs + the API response.
+ */
+export type AnalysisResult =
+  | {
+      ok: true;
+      observations: string[];
+      rawText: string;
+    }
+  | {
+      ok: false;
+      reason:
+        | "compliance_filter_failed"
+        | "model_call_failed"
+        | "empty_response"
+        | "no_holdings";
+      detail?: string;
+    };
+
+/**
+ * Build the user-message body for the model. Pure function — easy to
+ * unit-test, no I/O. Numbers are rendered with explicit units so the
+ * model can't accidentally drop a `$` and mis-quote a cost basis.
+ *
+ * Holdings are capped at `HOLDINGS_PROMPT_CAP` to keep input tokens
+ * bounded; callers that pass more get the first N. Top-of-list bias
+ * is acceptable here — the cap is purely a token-budget control.
+ */
+export function formatHoldingsForPrompt(
+  holdings: readonly HoldingForAnalysis[],
+  profile: ProfileForAnalysis,
+): string {
+  const capped = holdings.slice(0, HOLDINGS_PROMPT_CAP);
+
+  const lifeEvents: string[] = [];
+  if (profile.isFhb) lifeEvents.push("first-home buyer");
+  if (profile.isPreRetiree) lifeEvents.push("pre-retiree");
+  if (profile.isBusinessOwner) lifeEvents.push("business owner");
+  if (profile.isCrossBorder) lifeEvents.push("cross-border investor");
+  if (profile.isHnw) lifeEvents.push("high-net-worth");
+  const lifeEventLine =
+    lifeEvents.length > 0
+      ? `Profile flags: ${lifeEvents.join(", ")}.`
+      : "Profile flags: none recorded.";
+
+  const rows = capped
+    .map((h, i) => {
+      const idx = String(i + 1).padStart(2, " ");
+      const costAud = (h.cost_basis_per_share_cents / 100).toFixed(2);
+      const broker = h.broker_slug ? ` via ${h.broker_slug}` : "";
+      return (
+        `${idx}. ${h.ticker} (${h.exchange}) — ` +
+        `${h.shares} shares @ A$${costAud} cost basis, ` +
+        `acquired ${h.acquired_at}${broker}`
+      );
+    })
+    .join("\n");
+
+  const truncated =
+    holdings.length > HOLDINGS_PROMPT_CAP
+      ? `\n\n(${holdings.length - HOLDINGS_PROMPT_CAP} additional holdings omitted to stay within the analysis token budget.)`
+      : "";
+
+  return (
+    `${lifeEventLine}\n\n` +
+    `Holdings (${capped.length} of ${holdings.length} total):\n${rows}${truncated}`
+  );
+}
+
+/**
+ * System prompt for the analysis engine. Frames the model strictly as
+ * a factual-comparison surface, lists banned advice phrases verbatim,
+ * and asks for exactly three observations so the response shape is
+ * predictable for downstream UI.
+ *
+ * If you change this prompt, update the test in
+ * `__tests__/lib/holdings/ai-analysis.test.ts` that asserts the banned
+ * phrases are still mentioned — the model needs them in-context, not
+ * just in the post-filter.
+ */
+export const ANALYSIS_SYSTEM_PROMPT =
+  `You are a factual-observation engine for Invest.com.au. Your job is to ` +
+  `produce comparison and factual observations about a user's portfolio. ` +
+  `You are NOT a financial adviser. Invest.com.au operates under the ` +
+  `factual-information carve-outs of the Australian Corporations Act 2001 ` +
+  `and does not hold an AFSL.\n\n` +
+  `STRICT RULES — failure to comply causes a compliance rejection:\n` +
+  `  1. Begin your response with the exact prefix: "${GAW_AI_PREFIX}"\n` +
+  `  2. Produce EXACTLY 3 observations, in order: (a) diversification, ` +
+  `(b) sector / position concentration, (c) fee efficiency vs market.\n` +
+  `  3. Each observation must be 1-3 sentences, comparison-style only.\n` +
+  `  4. Do NOT use any of these phrases or their conjugations: ` +
+  `"you should", "we recommend", "I recommend", "buy now", "sell now", ` +
+  `"best for you", "advise you to", "personal advice", "personally recommend", ` +
+  `"you ought to", "you must invest", "the best choice for you".\n` +
+  `  5. Do NOT recommend buying, selling, switching, or rebalancing. ` +
+  `Frame everything as "observation" or "your portfolio shows X".\n` +
+  `  6. If you cite a numeric statistic (e.g. "10%" or "$500"), follow ` +
+  `it immediately with a citation: (source: ...) or [^1].\n` +
+  `  7. Do not invent prices, returns, or fees. Observe only what the ` +
+  `user told you in the holdings list.\n` +
+  `  8. Format output as plain markdown bullets, one per observation, ` +
+  `prefixed by the GAW line above.\n\n` +
+  `Acceptable framing: "Your portfolio shows X% in technology, which is ` +
+  `higher than the ASX200 weighting of Y%." (factual comparison)\n` +
+  `Unacceptable framing: "You should diversify into bonds." (personal advice)`;
+
+/**
+ * Run the AI analysis. The Anthropic client is INJECTED so callers
+ * (and tests) decide how it's created — there is no module-level
+ * client to avoid accidental import-time API calls.
+ *
+ * Returns a discriminated result; never throws on a normal failure
+ * path (model error, empty body, filter rejection). Truly unexpected
+ * exceptions (e.g. the injected client is missing methods) bubble
+ * up so Sentry catches them.
+ */
+export async function runHoldingsAnalysis(
+  holdings: readonly HoldingForAnalysis[],
+  profile: ProfileForAnalysis | InvestorProfile,
+  opts: {
+    anthropicClient: Anthropic;
+    modelId?: string;
+  },
+): Promise<AnalysisResult> {
+  if (holdings.length === 0) {
+    return { ok: false, reason: "no_holdings" };
+  }
+
+  const promptBody = formatHoldingsForPrompt(holdings, {
+    isFhb: profile.isFhb === true,
+    isPreRetiree: profile.isPreRetiree === true,
+    isBusinessOwner: profile.isBusinessOwner === true,
+    isCrossBorder: profile.isCrossBorder === true,
+    isHnw: profile.isHnw === true,
+  });
+
+  let rawText: string;
+  try {
+    const response = await opts.anthropicClient.messages.create({
+      model: opts.modelId ?? DEFAULT_ANALYSIS_MODEL,
+      max_tokens: MAX_OUTPUT_TOKENS,
+      system: ANALYSIS_SYSTEM_PROMPT,
+      messages: [
+        {
+          role: "user",
+          content: promptBody,
+        },
+      ],
+    });
+    // The SDK returns a content-block array. We only consume `text` blocks
+    // and concatenate them in order. Other block types (e.g. tool_use) are
+    // not expected here — we don't pass tools — but ignoring them is safer
+    // than throwing if the model returns an unexpected shape.
+    const textParts: string[] = [];
+    for (const block of response.content) {
+      if (block.type === "text") {
+        textParts.push(block.text);
+      }
+    }
+    rawText = textParts.join("\n").trim();
+  } catch (err) {
+    return {
+      ok: false,
+      reason: "model_call_failed",
+      detail: err instanceof Error ? err.message : String(err),
+    };
+  }
+
+  if (!rawText) {
+    return { ok: false, reason: "empty_response" };
+  }
+
+  // The compliance gate. If this filter rejects, we do NOT return any of
+  // the model output — even partially — because that would defeat the
+  // point of having the filter. The caller falls back to a static template.
+  const filtered = filterFactualOutput(rawText);
+  if (!filtered.ok) {
+    return {
+      ok: false,
+      reason: "compliance_filter_failed",
+      detail: filtered.reason,
+    };
+  }
+
+  // Extract bullets so the API response can render structured observations.
+  // We accept either Markdown bullets (`-`, `*`) or numbered lines; anything
+  // that's not a bullet is dropped (the GAW prefix line, blank lines, etc.).
+  const observations = filtered.cleaned
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(
+      (line) =>
+        line.startsWith("- ") ||
+        line.startsWith("* ") ||
+        /^\d+\.\s/.test(line),
+    )
+    .map((line) => line.replace(/^[-*]\s+/, "").replace(/^\d+\.\s+/, ""))
+    .filter((line) => line.length > 0);
+
+  return {
+    ok: true,
+    observations,
+    rawText: filtered.cleaned,
+  };
+}
+
+/**
+ * Convenience: every route response that surfaces analysis output also
+ * surfaces the standard short risk-warning CTA. Re-exported here so
+ * callers don't import compliance.ts directly just for this constant.
+ */
+export const ANALYSIS_DISCLAIMER = RISK_WARNING_CTA;

--- a/supabase/migrations/20260514103038_x5j_investor_ai_analysis_flag.sql
+++ b/supabase/migrations/20260514103038_x5j_investor_ai_analysis_flag.sql
@@ -1,0 +1,43 @@
+-- ============================================================
+-- X5j: Seed investor_ai_analysis_enabled feature flag
+--
+-- Date: 2026-05-14
+-- Audit ref: docs/plans/investor-account-end-to-end-plan.md Phase 4 / PR-X5j
+-- Why: Phase 4 of the investor-account roadmap builds the AI portfolio
+--      analysis engine. Pre-AFSL we are NOT allowed to ship a personalized
+--      analysis surface — Corporations Act s766B(6)/(7) factual-information
+--      carve-outs limit us to comparison and factual computation only, and
+--      personalized AI commentary on a specific user's portfolio sits
+--      uncomfortably close to "personal advice" without a licence. AFSL
+--      grant is expected ~2026-11.
+--
+--      This flag MUST remain enabled=false until AFSL grants. The route
+--      handler at app/api/account/holdings/ai-analysis returns 404 unless
+--      this flag evaluates true. Even when flipped on, every AI output
+--      passes filterFactualOutput() before reaching the user.
+--
+-- Idempotency: INSERT ... ON CONFLICT (flag_key) DO NOTHING — re-running
+--              this migration is a safe no-op. Any admin-toggled state
+--              (e.g. once AFSL grants and the flag is flipped on) is
+--              preserved on re-run.
+-- Rollback:
+--   DELETE FROM public.feature_flags WHERE flag_key = 'investor_ai_analysis_enabled';
+--   (Safe — pure feature gate, no data dependencies.)
+-- ============================================================
+
+BEGIN;
+
+INSERT INTO public.feature_flags
+  (flag_key, description, enabled, rollout_pct, allowlist, denylist, segments)
+VALUES
+  ('investor_ai_analysis_enabled',
+   'AI portfolio analysis route (POST /api/account/holdings/ai-analysis). '
+   'PRE-AFSL GATE: must remain enabled=false until AFSL grants (~2026-11). '
+   'Flipping enabled=true while we are operating under the s766B(6)/(7) '
+   'factual-information carve-out would expose the platform to a personal-advice '
+   'finding under Corporations Act s911A. See docs/plans/investor-account-end-to-end-plan.md '
+   'Phase 4 / PR-X5j for the compliance rationale.',
+   false, 0, '{}', '{}', '{}')
+ON CONFLICT (flag_key) DO NOTHING;
+
+COMMIT;


### PR DESCRIPTION
## Summary

- Stands up the AI portfolio analysis engine + a gated POST route at `/api/account/holdings/ai-analysis`, behind feature flag `investor_ai_analysis_enabled` (seeded `enabled=false`).
- Engine is pure-injection (Anthropic client passed in) so the model call is fully testable; every reply runs through `filterFactualOutput()` before reaching the caller.
- UI is intentionally **out of scope** for this PR — there is no consumer of this route yet. Surfacing is a follow-up after AFSL grant.

## Files

- `supabase/migrations/20260514103038_x5j_investor_ai_analysis_flag.sql` — idempotent flag seed (enabled=false) with rollback strategy.
- `lib/holdings/ai-analysis.ts` — `formatHoldingsForPrompt()`, `runHoldingsAnalysis()`, `ANALYSIS_SYSTEM_PROMPT`, plus discriminated `AnalysisResult` type.
- `app/api/account/holdings/ai-analysis/route.ts` — auth, flag gate (404 when off), Zod-validated `acknowledge_general_information: true` body, rate limit (5/user/24h), engine call, filtered response.
- `__tests__/lib/holdings/ai-analysis.test.ts` — 17 tests covering format, prompt content, filter pass/reject, top-100 cap, model errors, model id overrides.
- `__tests__/api/holdings-ai-analysis.test.ts` — 11 tests covering 401 / 404 (flag off) / 400 (missing ack) / 429 / 200 happy path / 200 filter-reject path.

## Compliance — read before merging

Invest.com.au operates under the s766B(6)/(7) factual-information carve-outs of the Corporations Act 2001 and **does not hold an AFSL** (expected grant ~2026-11).

**This feature flag MUST stay `enabled=false` until AFSL grants.** Flipping it on while we are still pre-AFSL would expose the platform to a personal-advice finding under s911A, with corporate penalties of up to A\$1.65m and material risk of being pushed out of the s766B carve-out entirely.

Defence in depth (each layer independently sufficient):

1. Migration seeds the flag `enabled=false / rollout_pct=0` with a compliance comment in the `description` column.
2. Route returns **404** (not 403) when the flag is off — does not leak that the route exists.
3. Request body must include `acknowledge_general_information: true` (Zod `z.literal(true)`).
4. System prompt explicitly bans advice phrasing (`you should`, `recommend`, `buy now`, `sell now`, `personal advice`, etc.) and frames every observation as factual comparison only.
5. **Every model response is filtered through `filterFactualOutput()` from `lib/compliance.ts`.** On rejection the route returns `reason: "compliance_filter_failed"` and drops the model output entirely.
6. Input capped at the top 100 holdings; output capped at 800 tokens; rate-limited 5 calls / user / 24h via `lib/rate-limit.ts`.

> **Label request**: `do-not-merge-until-afsl-or-flag-stays-off`. At minimum: do not flip `investor_ai_analysis_enabled` to `true` pre-AFSL without sign-off from Fin.

## Test plan

- [x] `npx vitest run __tests__/lib/holdings/ai-analysis.test.ts __tests__/api/holdings-ai-analysis.test.ts` → 28/28 passing locally.
- [x] Migration is idempotent (`ON CONFLICT (flag_key) DO NOTHING`) — safe to re-run.
- [x] Confirmed default-off behaviour: with the migration applied and no admin flip, the route returns 404.
- [x] Confirmed compliance-filter wiring: tests use an Anthropic mock returning "You should …" and assert the route returns `ok: false, reason: "compliance_filter_failed"`.
- [ ] Full `tsc --noEmit` was OOM-killed in the agent worktree at the default + 8 GB heap (only 6.5 GB RAM available on this VM). Vitest passes through full TS compilation across both files — main-worktree push will run the pre-push `tsc` gate.
- [ ] Apply migration to staging Supabase and verify the row appears with `enabled=false`.

## Follow-ups (separate PRs)

- UI: read-only "Run analysis" surface in `/account/holdings`, post-AFSL only.
- Cost-cap wiring: route through `lib/ai-cost-caps.ts` like `/api/concierge` does before flipping the flag.
- Observability: persist analysis runs to a new `ai_analysis_history` table for audit.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>