### PR TITLE
feat(pmp): provider marketplace foundation — Investor Briefs + Expert Teams + credit accept

### DIFF
--- a/__tests__/lib/briefs/mask.test.ts
+++ b/__tests__/lib/briefs/mask.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { maskBriefForProvider } from "@/lib/briefs/mask";
+import type { BriefRow } from "@/lib/briefs/types";
+
+function row(over: Partial<BriefRow> = {}): BriefRow {
+  return {
+    id: 1,
+    slug: "sample-brief",
+    flow_type: "accept",
+    brief_template: "smsf_property",
+    brief_payload: { smsf_status: "no_smsf" },
+    provider_preference: "expert_team",
+    routing_mode: "smart_match",
+    target_professional_id: null,
+    target_firm_id: null,
+    target_team_id: null,
+    accept_credits_cost: 25,
+    accepted_by_professional_id: null,
+    accepted_by_team_id: null,
+    accepted_at: null,
+    tracker_status: "new",
+    risk_flags: [],
+    risk_review_status: "clear",
+    listing_id: null,
+    job_title: "SMSF property strategy",
+    job_description: "Long description...".padEnd(400, "x"),
+    budget_band: "10k_plus",
+    advisor_types: null,
+    location: "NSW",
+    contact_name: "Alice Smith",
+    contact_email: "alice@example.com",
+    contact_phone: "+61400000000",
+    status: "open",
+    ends_at: "2026-08-01T00:00:00Z",
+    created_at: "2026-05-14T00:00:00Z",
+    ...over,
+  };
+}
+
+describe("maskBriefForProvider", () => {
+  it("strips contact details", () => {
+    const masked = maskBriefForProvider(row());
+    expect(masked).not.toHaveProperty("contact_email");
+    expect(masked).not.toHaveProperty("contact_name");
+    expect(masked).not.toHaveProperty("contact_phone");
+  });
+
+  it("retains routing + budget + template fields", () => {
+    const masked = maskBriefForProvider(row());
+    expect(masked.budget_band).toBe("10k_plus");
+    expect(masked.location).toBe("NSW");
+    expect(masked.brief_template).toBe("smsf_property");
+    expect(masked.provider_preference).toBe("expert_team");
+    expect(masked.routing_mode).toBe("smart_match");
+    expect(masked.accept_credits_cost).toBe(25);
+  });
+
+  it("truncates the description preview", () => {
+    const masked = maskBriefForProvider(row());
+    expect(masked.description_preview.length).toBeLessThanOrEqual(281);
+    expect(masked.description_preview.endsWith("…")).toBe(true);
+  });
+
+  it("keeps short descriptions untruncated", () => {
+    const masked = maskBriefForProvider(
+      row({ job_description: "Short description." }),
+    );
+    expect(masked.description_preview).toBe("Short description.");
+  });
+});

--- a/__tests__/lib/briefs/risk-flags.test.ts
+++ b/__tests__/lib/briefs/risk-flags.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { scanBriefSync, type RiskPattern } from "@/lib/briefs/risk-flags";
+
+const PATTERNS: RiskPattern[] = [
+  { pattern: "withdraw super", category: "super_withdrawal", severity: "review" },
+  { pattern: "guaranteed returns", category: "guaranteed_returns", severity: "review" },
+  { pattern: "tax avoidance", category: "tax_avoidance", severity: "block" },
+  { pattern: "high yield", category: "high_yield", severity: "warn" },
+];
+
+describe("scanBriefSync", () => {
+  it("returns clear when no patterns match", () => {
+    const result = scanBriefSync("I want a normal SMSF setup", PATTERNS);
+    expect(result.flags).toEqual([]);
+    expect(result.severity).toBe("clear");
+    expect(result.reviewStatus).toBe("clear");
+    expect(result.shouldRouteNow).toBe(true);
+  });
+
+  it("flags warn-severity matches but still routes", () => {
+    const result = scanBriefSync("looking for high yield options", PATTERNS);
+    expect(result.flags).toContain("high_yield");
+    expect(result.severity).toBe("warn");
+    expect(result.reviewStatus).toBe("clear");
+    expect(result.shouldRouteNow).toBe(true);
+  });
+
+  it("holds review-severity matches for compliance approval", () => {
+    const result = scanBriefSync("guaranteed returns please", PATTERNS);
+    expect(result.flags).toContain("guaranteed_returns");
+    expect(result.severity).toBe("review");
+    expect(result.reviewStatus).toBe("pending_review");
+    expect(result.shouldRouteNow).toBe(false);
+  });
+
+  it("picks the highest severity when multiple matches hit", () => {
+    const result = scanBriefSync(
+      "I want to use tax avoidance with high yield products",
+      PATTERNS,
+    );
+    expect(result.flags.sort()).toEqual(["high_yield", "tax_avoidance"]);
+    expect(result.severity).toBe("block");
+    expect(result.reviewStatus).toBe("pending_review");
+    expect(result.shouldRouteNow).toBe(false);
+  });
+
+  it("is case-insensitive", () => {
+    const result = scanBriefSync("WITHDRAW SUPER NOW", PATTERNS);
+    expect(result.flags).toContain("super_withdrawal");
+  });
+});

--- a/__tests__/lib/briefs/routing.test.ts
+++ b/__tests__/lib/briefs/routing.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import type { BriefRow } from "@/lib/briefs/types";
+
+type SupabaseFn = ReturnType<typeof vi.fn>;
+
+const fromMock: SupabaseFn = vi.fn();
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({ from: fromMock }),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}));
+
+function chainFor(rows: unknown[]) {
+  // Self-returning Proxy so any chained call (`.select`, `.eq`, `.in`, `.or`,
+  // `.contains`, etc.) keeps the chain alive without needing to enumerate
+  // every PostgREST verb. `.limit()` and `await` resolve to the rows.
+  const target: Record<string, unknown> = {
+    limit: vi.fn(() => Promise.resolve({ data: rows, error: null })),
+    then: (cb: (value: { data: unknown[]; error: null }) => unknown) =>
+      cb({ data: rows, error: null }),
+  };
+  const proxy: object = new Proxy(target, {
+    get(t, prop) {
+      if (prop in t) return (t as Record<string | symbol, unknown>)[prop];
+      return () => proxy;
+    },
+  });
+  return proxy as Record<string, unknown>;
+}
+
+function buildBrief(over: Partial<BriefRow> = {}): BriefRow {
+  return {
+    id: 99,
+    slug: "x",
+    flow_type: "accept",
+    brief_template: "smsf_property",
+    brief_payload: {},
+    provider_preference: "any",
+    routing_mode: "smart_match",
+    target_professional_id: null,
+    target_firm_id: null,
+    target_team_id: null,
+    accept_credits_cost: 25,
+    accepted_by_professional_id: null,
+    accepted_by_team_id: null,
+    accepted_at: null,
+    tracker_status: "new",
+    risk_flags: [],
+    risk_review_status: "clear",
+    listing_id: null,
+    job_title: "T",
+    job_description: "D",
+    budget_band: "10k_plus",
+    advisor_types: null,
+    location: "NSW",
+    contact_name: null,
+    contact_email: null,
+    contact_phone: null,
+    status: "open",
+    ends_at: "2026-08-01T00:00:00Z",
+    created_at: "2026-05-14T00:00:00Z",
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  fromMock.mockReset();
+});
+
+describe("resolveEligibleProviders", () => {
+  it("returns only direct targets for routing_mode='direct'", async () => {
+    const { resolveEligibleProviders } = await import("@/lib/briefs/routing");
+    const brief = buildBrief({
+      routing_mode: "direct",
+      target_team_id: 7,
+      target_professional_id: 42,
+    });
+    const result = await resolveEligibleProviders(brief);
+    expect(result.find((r) => r.kind === "expert_team" && r.id === 7)).toBeDefined();
+    expect(result.find((r) => r.kind === "individual" && r.id === 42)).toBeDefined();
+    expect(fromMock).not.toHaveBeenCalled();
+  });
+
+  it("applies highest-priority matching rule first (smart_match)", async () => {
+    fromMock.mockImplementation((table: string) => {
+      if (table === "brief_routing_rules") {
+        return chainFor([
+          {
+            id: 1,
+            name: "SMSF Property -> Expert Team first",
+            priority: 10,
+            enabled: true,
+            match_conditions: { brief_template: "smsf_property" },
+            route_to: { prefer: "expert_team", fallback: ["individual"] },
+          },
+        ]);
+      }
+      if (table === "expert_teams") {
+        return chainFor([{ id: 11 }, { id: 12 }]);
+      }
+      if (table === "professionals") {
+        return chainFor([{ id: 21, type: "smsf_accountant" }]);
+      }
+      if (table === "advisor_firms") {
+        return chainFor([]);
+      }
+      return chainFor([]);
+    });
+
+    const { resolveEligibleProviders } = await import("@/lib/briefs/routing");
+    const brief = buildBrief();
+    const result = await resolveEligibleProviders(brief);
+    const kinds = result.map((r) => r.kind);
+    expect(kinds[0]).toBe("expert_team");
+    expect(result.some((r) => r.kind === "individual" && r.id === 21)).toBe(true);
+  });
+
+  it("dedupes across preferred + fallback", async () => {
+    fromMock.mockImplementation((table: string) => {
+      if (table === "brief_routing_rules") {
+        return chainFor([
+          {
+            id: 1,
+            name: "any",
+            priority: 100,
+            enabled: true,
+            match_conditions: {},
+            route_to: { prefer: "any" },
+          },
+        ]);
+      }
+      if (table === "expert_teams") return chainFor([{ id: 5 }]);
+      if (table === "professionals") return chainFor([{ id: 5, type: null }]);
+      if (table === "advisor_firms") return chainFor([{ id: 5 }]);
+      return chainFor([]);
+    });
+
+    const { resolveEligibleProviders } = await import("@/lib/briefs/routing");
+    const result = await resolveEligibleProviders(buildBrief());
+    // Three different kinds with the same numeric id all kept.
+    expect(result).toHaveLength(3);
+    const keys = result.map((r) => `${r.kind}:${r.id}`).sort();
+    expect(keys).toEqual([
+      "expert_team:5",
+      "firm:5",
+      "individual:5",
+    ]);
+  });
+});

--- a/__tests__/lib/briefs/templates.test.ts
+++ b/__tests__/lib/briefs/templates.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import {
+  BRIEF_TEMPLATES,
+  BRIEF_TEMPLATE_LABELS,
+  BRIEF_TEMPLATE_BLURBS,
+  BRIEF_TEMPLATE_FIELDS,
+  BRIEF_TEMPLATE_SCHEMAS,
+  getTemplateSchema,
+  isBriefTemplate,
+} from "@/lib/briefs/templates";
+
+describe("brief template registry", () => {
+  it("has labels + blurbs + field hints + schemas for every template", () => {
+    for (const t of BRIEF_TEMPLATES) {
+      expect(BRIEF_TEMPLATE_LABELS[t]).toBeTruthy();
+      expect(BRIEF_TEMPLATE_BLURBS[t]).toBeTruthy();
+      expect(BRIEF_TEMPLATE_FIELDS[t]).toBeDefined();
+      expect(BRIEF_TEMPLATE_SCHEMAS[t]).toBeDefined();
+    }
+  });
+
+  it("isBriefTemplate gatekeeps", () => {
+    expect(isBriefTemplate("smsf_property")).toBe(true);
+    expect(isBriefTemplate("not_a_real_template")).toBe(false);
+    expect(isBriefTemplate(123)).toBe(false);
+  });
+
+  it("smsf_property schema requires structured fields", () => {
+    const schema = getTemplateSchema("smsf_property");
+    const result = schema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+
+  it("smsf_property schema accepts a complete payload", () => {
+    const schema = getTemplateSchema("smsf_property");
+    const result = schema.safeParse({
+      smsf_status: "no_smsf",
+      property_budget: "700k_900k",
+      timeline: "3_6_months",
+      help_needed: ["smsf_setup", "lending"],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("general schema accepts notes-only payload", () => {
+    const schema = getTemplateSchema("general");
+    expect(schema.safeParse({}).success).toBe(true);
+    expect(schema.safeParse({ notes: "Hi" }).success).toBe(true);
+  });
+});

--- a/__tests__/lib/getmatched/embeds.test.ts
+++ b/__tests__/lib/getmatched/embeds.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import {
+  HOMEPAGE_GOAL_CHIPS,
+  getEmbedConfig,
+  isEmbedContext,
+} from "@/lib/getmatched/embeds";
+
+describe("getEmbedConfig", () => {
+  it("returns a config for every supported context", () => {
+    const contexts = [
+      "homepage",
+      "smsf_guide",
+      "opportunity",
+      "advisor_directory",
+      "platform_compare",
+    ] as const;
+    for (const c of contexts) {
+      const cfg = getEmbedConfig(c);
+      expect(cfg.context).toBe(c);
+      expect(cfg.headline).toBeTruthy();
+      expect(cfg.subtitle).toBeTruthy();
+    }
+  });
+
+  it("pre-fills intent for non-homepage contexts", () => {
+    expect(getEmbedConfig("smsf_guide").intent_prefill).toBe("smsf_property");
+    expect(getEmbedConfig("opportunity").intent_prefill).toBe("opportunity_assessment");
+    expect(getEmbedConfig("advisor_directory").intent_prefill).toBe("financial_advice");
+    expect(getEmbedConfig("platform_compare").intent_prefill).toBe("compare_platform");
+  });
+
+  it("homepage has no intent pre-fill (chip picker)", () => {
+    expect(getEmbedConfig("homepage").intent_prefill).toBeUndefined();
+  });
+});
+
+describe("isEmbedContext", () => {
+  it("accepts the 5 contexts", () => {
+    expect(isEmbedContext("homepage")).toBe(true);
+    expect(isEmbedContext("smsf_guide")).toBe(true);
+    expect(isEmbedContext("opportunity")).toBe(true);
+    expect(isEmbedContext("advisor_directory")).toBe(true);
+    expect(isEmbedContext("platform_compare")).toBe(true);
+  });
+  it("rejects others", () => {
+    expect(isEmbedContext("nope")).toBe(false);
+    expect(isEmbedContext(123)).toBe(false);
+  });
+});
+
+describe("HOMEPAGE_GOAL_CHIPS", () => {
+  it("has all 9 chips from the PDF spec", () => {
+    expect(HOMEPAGE_GOAL_CHIPS.length).toBe(9);
+  });
+
+  it("every chip has value/label/icon", () => {
+    for (const c of HOMEPAGE_GOAL_CHIPS) {
+      expect(c.value).toBeTruthy();
+      expect(c.label).toBeTruthy();
+      expect(c.icon).toBeTruthy();
+    }
+  });
+});

--- a/__tests__/lib/getmatched/engine.test.ts
+++ b/__tests__/lib/getmatched/engine.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildChecklist,
+  deriveRoute,
+  goalLabel,
+} from "@/lib/getmatched/engine";
+import type { IntentDef, ResultTemplate } from "@/lib/getmatched/types";
+
+const INTENTS: IntentDef[] = [
+  {
+    id: 1,
+    slug: "compare_platform",
+    label: "Compare investing platforms",
+    description: null,
+    default_route: "compare",
+    default_brief_template: null,
+    risk_level: "low",
+    enabled: true,
+    sort_order: 10,
+    meta: {},
+  },
+  {
+    id: 2,
+    slug: "smsf_property",
+    label: "Invest through SMSF",
+    description: null,
+    default_route: "expert_team",
+    default_brief_template: "smsf_property",
+    risk_level: "medium",
+    enabled: true,
+    sort_order: 30,
+    meta: {},
+  },
+  {
+    id: 3,
+    slug: "not_sure",
+    label: "Not sure yet",
+    description: null,
+    default_route: "guide",
+    default_brief_template: null,
+    risk_level: "low",
+    enabled: true,
+    sort_order: 999,
+    meta: {},
+  },
+];
+
+describe("deriveRoute", () => {
+  it("falls back to the intent default when no help_preference", () => {
+    const result = deriveRoute({ intent: "smsf_property" }, INTENTS);
+    expect(result.intent).toBe("smsf_property");
+    expect(result.route).toBe("expert_team");
+  });
+
+  it("respects an explicit help_preference override", () => {
+    const result = deriveRoute(
+      { intent: "smsf_property", help_preference: "compare" },
+      INTENTS,
+    );
+    expect(result.route).toBe("compare");
+  });
+
+  it("treats help_preference=not_sure as no override", () => {
+    const result = deriveRoute(
+      { intent: "smsf_property", help_preference: "not_sure" },
+      INTENTS,
+    );
+    expect(result.route).toBe("expert_team");
+  });
+
+  it("falls back to guide when no intent is set", () => {
+    const result = deriveRoute({}, INTENTS);
+    expect(result.intent).toBe(null);
+    expect(result.route).toBe("guide");
+  });
+
+  it("derives a secondary intent from help_needed", () => {
+    const result = deriveRoute(
+      {
+        intent: "smsf_property",
+        help_needed: ["lending"],
+      },
+      INTENTS,
+    );
+    expect(result.secondary).toBe("mortgage_help");
+  });
+});
+
+describe("buildChecklist", () => {
+  it("clones items with done=false", () => {
+    const template = {
+      checklist: [{ label: "Step 1" }, { label: "Step 2", href: "/x" }],
+    } as unknown as ResultTemplate;
+    expect(buildChecklist(template)).toEqual([
+      { label: "Step 1", done: false },
+      { label: "Step 2", href: "/x", done: false },
+    ]);
+  });
+});
+
+describe("goalLabel", () => {
+  it("returns the intent label", () => {
+    expect(goalLabel("smsf_property", INTENTS)).toBe("Invest through SMSF");
+  });
+  it("returns null for unknown intent", () => {
+    expect(goalLabel(null, INTENTS)).toBe(null);
+  });
+});

--- a/__tests__/lib/getmatched/intents.test.ts
+++ b/__tests__/lib/getmatched/intents.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { defaultRouteForIntent } from "@/lib/getmatched/intents";
+import type { IntentDef } from "@/lib/getmatched/types";
+
+const INTENTS: IntentDef[] = [
+  {
+    id: 1,
+    slug: "smsf_property",
+    label: "Invest through SMSF",
+    description: null,
+    default_route: "expert_team",
+    default_brief_template: "smsf_property",
+    risk_level: "medium",
+    enabled: true,
+    sort_order: 30,
+    meta: {},
+  },
+  {
+    id: 2,
+    slug: "compare_platform",
+    label: "Compare investing platforms",
+    description: null,
+    default_route: "compare",
+    default_brief_template: null,
+    risk_level: "low",
+    enabled: true,
+    sort_order: 10,
+    meta: {},
+  },
+];
+
+describe("defaultRouteForIntent", () => {
+  it("returns the intent's default route", () => {
+    expect(defaultRouteForIntent("smsf_property", INTENTS)).toBe("expert_team");
+    expect(defaultRouteForIntent("compare_platform", INTENTS)).toBe("compare");
+  });
+
+  it("falls back to guide when intent is unknown", () => {
+    expect(defaultRouteForIntent("unknown_intent", INTENTS)).toBe("guide");
+  });
+
+  it("falls back to guide when intent is null", () => {
+    expect(defaultRouteForIntent(null, INTENTS)).toBe("guide");
+  });
+});

--- a/__tests__/lib/getmatched/questions.test.ts
+++ b/__tests__/lib/getmatched/questions.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import { nextQuestion, shownIfMatches } from "@/lib/getmatched/questions";
+import type { QuestionDef } from "@/lib/getmatched/types";
+
+function q(over: Partial<QuestionDef>): QuestionDef {
+  return {
+    id: 1,
+    slug: "s",
+    step: 1,
+    kind: "select",
+    prompt: "p",
+    subtitle: null,
+    options: [],
+    shown_if: {},
+    maps_to: "s",
+    risk_weight: 0,
+    mode: "both",
+    enabled: true,
+    sort_order: 100,
+    ...over,
+  };
+}
+
+describe("shownIfMatches", () => {
+  it("returns true when no conditions", () => {
+    expect(shownIfMatches(q({}), {})).toBe(true);
+  });
+
+  it("returns true when condition matches", () => {
+    expect(
+      shownIfMatches(
+        q({ shown_if: { intent: ["smsf_property"] } }),
+        { intent: "smsf_property" },
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false when intent does not match", () => {
+    expect(
+      shownIfMatches(
+        q({ shown_if: { intent: ["smsf_property"] } }),
+        { intent: "compare_platform" },
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false when required answer missing", () => {
+    expect(
+      shownIfMatches(
+        q({ shown_if: { intent: ["smsf_property"] } }),
+        {},
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("nextQuestion", () => {
+  const questions = [
+    q({ slug: "starting_point", step: 1, maps_to: "starting_point" }),
+    q({ slug: "goal", step: 2, maps_to: "intent" }),
+    q({
+      slug: "smsf_situation",
+      step: 3,
+      shown_if: { intent: ["smsf_property"] },
+      maps_to: "smsf_status",
+    }),
+    q({
+      slug: "opportunity_situation",
+      step: 3,
+      shown_if: { intent: ["opportunity_assessment"] },
+      maps_to: "opportunity_context",
+    }),
+    q({ slug: "budget", step: 5, maps_to: "budget_band" }),
+  ];
+
+  it("returns the first eligible unanswered question", () => {
+    const result = nextQuestion(questions, {});
+    expect(result.done).toBe(false);
+    if (!result.done) {
+      expect(result.question.slug).toBe("starting_point");
+      expect(result.currentStep).toBe(1);
+    }
+  });
+
+  it("skips over already-answered questions", () => {
+    const result = nextQuestion(questions, {
+      starting_point: "australia",
+      intent: "smsf_property",
+      smsf_situation: "smsf_property",
+      smsf_status: "smsf_property",
+    });
+    if (!result.done) {
+      expect(result.question.slug).toBe("budget");
+    }
+  });
+
+  it("skips questions whose shown_if is not satisfied", () => {
+    const result = nextQuestion(questions, {
+      starting_point: "australia",
+      intent: "compare_platform",
+    });
+    if (!result.done) {
+      expect(result.question.slug).toBe("budget");
+      // smsf_situation and opportunity_situation are skipped
+    }
+  });
+
+  it("returns done when all eligible questions are answered", () => {
+    const result = nextQuestion(questions, {
+      starting_point: "australia",
+      intent: "compare_platform",
+      budget: "10k_100k",
+      budget_band: "10k_100k",
+    });
+    expect(result.done).toBe(true);
+  });
+});

--- a/app/account/AccountActionPlansTiles.tsx
+++ b/app/account/AccountActionPlansTiles.tsx
@@ -1,0 +1,99 @@
+import Link from "next/link";
+import Icon from "@/components/Icon";
+import type { ActionPlan } from "@/lib/getmatched/types";
+
+interface Props {
+  plans: ActionPlan[];
+}
+
+/**
+ * Top-of-account tiles for plans + briefs + "do next". Rendered server-side
+ * so the dashboard paints in one round-trip.
+ */
+export default function AccountActionPlansTiles({ plans }: Props) {
+  const latest = plans[0];
+  const briefCount = plans.filter((p) => p.linked_brief_id).length;
+  const nextSteps = latest
+    ? latest.checklist
+        .filter((c) => !c.done)
+        .slice(0, 3)
+    : [];
+
+  return (
+    <section aria-label="Your action plans" className="mb-6">
+      <h2 className="text-base font-semibold text-slate-900 mb-3">
+        Your action plans
+      </h2>
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+        <Link
+          href="/account/plans"
+          className="bg-rose-50 border border-rose-200 hover:border-rose-400 rounded-xl p-4 block transition-colors"
+        >
+          <div className="flex items-center gap-2 mb-1">
+            <Icon name="file-text" size={16} className="text-rose-700" />
+            <p className="text-sm font-bold text-slate-900">My Action Plans</p>
+          </div>
+          <p className="text-2xl font-extrabold text-slate-900">{plans.length}</p>
+          {latest && (
+            <p className="text-xs text-slate-600 truncate mt-1">
+              Latest: {latest.goal ?? latest.intent_slug ?? "—"}
+            </p>
+          )}
+          <p className="text-xs text-rose-700 mt-2 font-semibold">View all →</p>
+        </Link>
+
+        <Link
+          href="/account/plans"
+          className="bg-emerald-50 border border-emerald-200 hover:border-emerald-400 rounded-xl p-4 block transition-colors"
+        >
+          <div className="flex items-center gap-2 mb-1">
+            <Icon name="check-circle" size={16} className="text-emerald-700" />
+            <p className="text-sm font-bold text-slate-900">My Briefs</p>
+          </div>
+          <p className="text-2xl font-extrabold text-slate-900">{briefCount}</p>
+          {latest?.linked_brief_id && (
+            <p className="text-xs text-slate-600 mt-1">
+              Latest brief opened from a plan.
+            </p>
+          )}
+          <p className="text-xs text-emerald-700 mt-2 font-semibold">
+            View briefs →
+          </p>
+        </Link>
+
+        <div className="bg-amber-50 border border-amber-200 rounded-xl p-4">
+          <div className="flex items-center gap-2 mb-1">
+            <Icon name="trending-up" size={16} className="text-amber-700" />
+            <p className="text-sm font-bold text-slate-900">Do next</p>
+          </div>
+          {nextSteps.length === 0 ? (
+            <p className="text-xs text-slate-600 mt-1">
+              Build a new plan to get personalised next steps.
+            </p>
+          ) : (
+            <ul className="text-xs text-slate-700 space-y-1 mt-1">
+              {nextSteps.map((s, i) => (
+                <li key={i} className="flex items-start gap-1">
+                  <Icon name="arrow-right" size={12} className="mt-0.5 text-amber-700 shrink-0" />
+                  {s.href ? (
+                    <Link href={s.href} className="hover:underline">
+                      {s.label}
+                    </Link>
+                  ) : (
+                    <span>{s.label}</span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+          <Link
+            href="/get-matched"
+            className="text-xs text-amber-700 mt-2 font-semibold inline-block"
+          >
+            Build a new plan →
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -2,8 +2,11 @@ import type { Metadata } from "next";
 import { Suspense } from "react";
 import AccountClient from "./AccountClient";
 import AccountKindCards from "./AccountKindCards";
+import AccountActionPlansTiles from "./AccountActionPlansTiles";
 import { createClient } from "@/lib/supabase/server";
 import { getKindsForUser, type KindMembership } from "@/lib/account-kinds";
+import { listPlansForUser } from "@/lib/getmatched/action-plans";
+import type { ActionPlan } from "@/lib/getmatched/types";
 
 export const dynamic = "force-dynamic";
 
@@ -17,11 +20,15 @@ export default async function AccountPage() {
   // without a client-side waterfall. AccountClient stays as-is below for
   // the existing legacy account UX (subscription, notification prefs).
   let memberships: KindMembership[] = [];
+  let plans: ActionPlan[] = [];
   try {
     const supabase = await createClient();
     const { data: { user } } = await supabase.auth.getUser();
     if (user) {
-      memberships = await getKindsForUser(user.id);
+      [memberships, plans] = await Promise.all([
+        getKindsForUser(user.id),
+        listPlansForUser(user.id),
+      ]);
     }
   } catch {
     /* fall through with empty memberships — AccountClient still renders */
@@ -29,6 +36,11 @@ export default async function AccountPage() {
 
   return (
     <>
+      {plans.length > 0 && (
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 pt-8">
+          <AccountActionPlansTiles plans={plans} />
+        </div>
+      )}
       {memberships.length > 0 && (
         <div className="max-w-4xl mx-auto px-4 sm:px-6 pt-8">
           <AccountKindCards memberships={memberships} />

--- a/app/account/plans/[id]/page.tsx
+++ b/app/account/plans/[id]/page.tsx
@@ -1,0 +1,144 @@
+import { redirect, notFound } from "next/navigation";
+import Link from "next/link";
+import type { Metadata } from "next";
+
+import { createClient } from "@/lib/supabase/server";
+import { getPlanById } from "@/lib/getmatched/action-plans";
+import { getResultTemplate } from "@/lib/getmatched/templates";
+import type { IntentSlug, RouteType } from "@/lib/getmatched/types";
+import Icon from "@/components/Icon";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Action Plan — Invest.com.au",
+  robots: "noindex, nofollow",
+};
+
+function humanise(s: string | null): string {
+  if (!s) return "—";
+  return s.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+export default async function MyPlanDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const planId = Number(id);
+  if (!Number.isFinite(planId)) notFound();
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect(`/auth/login?next=/account/plans/${planId}`);
+
+  const plan = await getPlanById(planId);
+  if (!plan || plan.auth_user_id !== user.id) notFound();
+
+  const template = plan.route
+    ? await getResultTemplate(
+        plan.route as RouteType,
+        plan.intent_slug as IntentSlug | null,
+      )
+    : null;
+
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 py-10">
+        <div className="flex items-center gap-2 text-xs text-slate-500 mb-4">
+          <Link href="/account" className="hover:text-slate-700">
+            Account
+          </Link>
+          <span>/</span>
+          <Link href="/account/plans" className="hover:text-slate-700">
+            Action plans
+          </Link>
+          <span>/</span>
+          <span className="text-slate-700">{plan.goal ?? `#${plan.id}`}</span>
+        </div>
+
+        <h1 className="text-2xl sm:text-3xl font-extrabold text-slate-900 mb-2">
+          {plan.goal ?? "Investment Action Plan"}
+        </h1>
+        <p className="text-sm text-slate-500 mb-6">
+          {template?.why_text ??
+            "Your saved action plan and any briefs you've created from it."}
+        </p>
+
+        <div className="bg-white border border-slate-200 rounded-2xl p-6 mb-4">
+          <p className="text-[11px] font-bold uppercase tracking-widest text-amber-700 bg-amber-50 border border-amber-200 rounded-full px-2.5 py-1 w-fit mb-3">
+            Route · {humanise(plan.route ?? null)}
+          </p>
+          <h2 className="text-base font-bold text-slate-900 mb-2">Your checklist</h2>
+          <ul className="space-y-2 mb-4">
+            {plan.checklist.map((item, idx) => (
+              <li key={idx} className="flex items-start gap-3 text-sm text-slate-700">
+                <span
+                  className={`mt-0.5 w-5 h-5 rounded-full border-2 flex items-center justify-center shrink-0 ${
+                    item.done ? "border-emerald-500 bg-emerald-500" : "border-slate-300"
+                  }`}
+                >
+                  {item.done && <Icon name="check" size={12} className="text-white" />}
+                </span>
+                {item.href ? (
+                  <Link href={item.href} className="hover:underline">
+                    {item.label}
+                  </Link>
+                ) : (
+                  item.label
+                )}
+              </li>
+            ))}
+          </ul>
+          <div className="flex flex-wrap gap-2">
+            {plan.linked_brief_id ? (
+              <Link
+                href={`/briefs/${plan.linked_brief_id}`}
+                className="inline-flex items-center gap-2 bg-emerald-600 hover:bg-emerald-500 text-white font-bold text-sm px-4 py-2.5 rounded-lg"
+              >
+                <Icon name="check-circle" size={14} /> View Brief Tracker
+              </Link>
+            ) : (
+              <Link
+                href={`/briefs/new?plan_id=${plan.id}`}
+                className="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-400 text-slate-900 font-bold text-sm px-4 py-2.5 rounded-lg"
+              >
+                Create an Investor Brief
+                <Icon name="arrow-right" size={14} />
+              </Link>
+            )}
+            <Link
+              href={`/get-matched?plan_id=${plan.id}`}
+              className="inline-flex items-center gap-2 bg-slate-100 hover:bg-slate-200 text-slate-800 font-semibold text-sm px-4 py-2.5 rounded-lg"
+            >
+              <Icon name="edit" size={14} /> Edit answers
+            </Link>
+          </div>
+        </div>
+
+        <div className="bg-white border border-slate-200 rounded-2xl p-6">
+          <p className="text-xs uppercase tracking-widest text-slate-500 mb-2">
+            What we used
+          </p>
+          <dl className="text-sm text-slate-700 grid grid-cols-2 gap-2">
+            <dt className="text-slate-500">Intent</dt>
+            <dd>{humanise(plan.intent_slug ?? null)}</dd>
+            <dt className="text-slate-500">Budget band</dt>
+            <dd>{humanise(plan.budget_band ?? null)}</dd>
+            <dt className="text-slate-500">Timeline</dt>
+            <dd>{humanise(plan.timeline ?? null)}</dd>
+            <dt className="text-slate-500">Location</dt>
+            <dd>{plan.location_state ?? "—"}</dd>
+            <dt className="text-slate-500">Help needed</dt>
+            <dd>{plan.help_needed.length > 0 ? plan.help_needed.join(", ") : "—"}</dd>
+            <dt className="text-slate-500">Status</dt>
+            <dd className="capitalize">{plan.status}</dd>
+          </dl>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/account/plans/page.tsx
+++ b/app/account/plans/page.tsx
@@ -1,0 +1,117 @@
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+import Link from "next/link";
+
+import { createClient } from "@/lib/supabase/server";
+import { listPlansForUser } from "@/lib/getmatched/action-plans";
+import Icon from "@/components/Icon";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "My Action Plans — Invest.com.au",
+  robots: "noindex, nofollow",
+};
+
+function humanise(s: string | null): string {
+  if (!s) return "—";
+  return s.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+export default async function MyPlansPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/auth/login?next=/account/plans");
+
+  const plans = await listPlansForUser(user.id);
+
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 py-10">
+        <div className="flex items-center gap-2 text-xs text-slate-500 mb-4">
+          <Link href="/account" className="hover:text-slate-700">
+            Account
+          </Link>
+          <span>/</span>
+          <span className="text-slate-700">Action plans</span>
+        </div>
+
+        <h1 className="text-2xl sm:text-3xl font-extrabold text-slate-900 mb-2">
+          My Action Plans
+        </h1>
+        <p className="text-sm text-slate-500 mb-6">
+          Plans you&apos;ve created via Get Matched. Each one carries your route, checklist, and any briefs you sent.
+        </p>
+
+        <div className="mb-6">
+          <Link
+            href="/get-matched"
+            className="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-400 text-slate-900 font-bold text-sm px-4 py-2 rounded-lg"
+          >
+            <Icon name="plus" size={14} /> Build a new plan
+          </Link>
+        </div>
+
+        {plans.length === 0 ? (
+          <div className="bg-white border border-slate-200 rounded-2xl p-8 text-center">
+            <p className="text-sm text-slate-600">
+              You don&apos;t have any action plans yet. Build one in under a minute.
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {plans.map((p) => (
+              <article
+                key={p.id}
+                className="bg-white border border-slate-200 rounded-2xl p-5"
+              >
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <p className="text-[10px] font-bold uppercase tracking-widest text-slate-500 mb-1">
+                      {humanise(p.intent_slug ?? null)} · {humanise(p.route ?? null)}
+                    </p>
+                    <h2 className="text-base font-bold text-slate-900">
+                      {p.goal ?? "Investment Action Plan"}
+                    </h2>
+                    <p className="text-xs text-slate-500 mt-1">
+                      Created {new Date(p.created_at).toLocaleDateString()} ·{" "}
+                      <span
+                        className={`uppercase font-semibold ${
+                          p.status === "converted"
+                            ? "text-emerald-700"
+                            : p.status === "saved"
+                              ? "text-slate-700"
+                              : "text-slate-400"
+                        }`}
+                      >
+                        {p.status}
+                      </span>
+                    </p>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    <Link
+                      href={`/account/plans/${p.id}`}
+                      className="text-xs font-semibold bg-slate-900 hover:bg-slate-800 text-white px-3 py-1.5 rounded-md"
+                    >
+                      Open
+                    </Link>
+                    {p.linked_brief_id && (
+                      <Link
+                        href={`/briefs/${p.linked_brief_id}`}
+                        className="text-xs font-semibold bg-emerald-100 text-emerald-800 px-3 py-1.5 rounded-md"
+                      >
+                        View linked brief
+                      </Link>
+                    )}
+                  </div>
+                </div>
+              </article>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/admin/briefs/page.tsx
+++ b/app/admin/briefs/page.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+import AdminShell from "@/components/AdminShell";
+import Link from "next/link";
+
+interface BriefRow {
+  id: number;
+  slug: string;
+  job_title: string;
+  brief_template: string | null;
+  status: string;
+  tracker_status: string;
+  risk_review_status: string;
+  risk_flags: string[];
+  provider_preference: string | null;
+  routing_mode: string | null;
+  created_at: string;
+  accept_credits_cost: number | null;
+  contact_email: string | null;
+}
+
+const TABS = [
+  { value: "pending_review", label: "Risk review" },
+  { value: "open_no_accept", label: "Open · unaccepted" },
+  { value: "accepted", label: "Accepted" },
+  { value: "rejected", label: "Rejected" },
+] as const;
+
+type Tab = (typeof TABS)[number]["value"];
+
+export default function AdminBriefsPage() {
+  const supabase = createClient();
+  const [tab, setTab] = useState<Tab>("pending_review");
+  const [briefs, setBriefs] = useState<BriefRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState<number | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    let q = supabase
+      .from("advisor_auctions")
+      .select(
+        "id, slug, job_title, brief_template, status, tracker_status, risk_review_status, risk_flags, provider_preference, routing_mode, created_at, accept_credits_cost, contact_email",
+      )
+      .eq("flow_type", "accept")
+      .order("created_at", { ascending: false })
+      .limit(100);
+    if (tab === "pending_review") q = q.eq("risk_review_status", "pending_review");
+    if (tab === "open_no_accept")
+      q = q.eq("status", "open").is("accepted_by_professional_id", null).is("accepted_by_team_id", null);
+    if (tab === "accepted") q = q.not("accepted_at", "is", null);
+    if (tab === "rejected") q = q.eq("risk_review_status", "rejected");
+    const { data } = await q;
+    setBriefs((data ?? []) as BriefRow[]);
+    setLoading(false);
+  }, [supabase, tab]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  async function reviewAction(id: number, action: "approve" | "reject") {
+    setBusy(id);
+    setError(null);
+    try {
+      const res = await fetch(`/api/admin/briefs/${id}/risk`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action }),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json?.error ?? "Action failed");
+      await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Action failed");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  return (
+    <AdminShell title="Investor Briefs" subtitle="Risk review queue, routing visibility, and audit.">
+      <div className="bg-white border border-slate-200 rounded-xl p-4">
+        <div className="flex flex-wrap gap-2 mb-4">
+          {TABS.map((t) => (
+            <button
+              key={t.value}
+              type="button"
+              onClick={() => setTab(t.value)}
+              className={`text-xs font-semibold uppercase tracking-wider px-3 py-1.5 rounded-full border ${
+                tab === t.value
+                  ? "bg-slate-900 text-white border-slate-900"
+                  : "bg-white text-slate-600 border-slate-200 hover:border-slate-300"
+              }`}
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
+
+        {error && (
+          <div className="bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg p-3 mb-3">
+            {error}
+          </div>
+        )}
+
+        {loading ? (
+          <p className="text-sm text-slate-500">Loading…</p>
+        ) : briefs.length === 0 ? (
+          <p className="text-sm text-slate-500">No briefs in this state.</p>
+        ) : (
+          <div className="space-y-2">
+            {briefs.map((b) => (
+              <article key={b.id} className="border border-slate-200 rounded-xl p-3">
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <Link
+                      href={`/briefs/${b.slug}`}
+                      className="text-sm font-bold text-slate-900 hover:underline"
+                    >
+                      {b.job_title}
+                    </Link>
+                    <p className="text-xs text-slate-500">
+                      {b.brief_template} · {b.provider_preference ?? "any"} ·{" "}
+                      {b.routing_mode ?? "smart_match"} ·{" "}
+                      {new Date(b.created_at).toLocaleString()}
+                    </p>
+                    {b.risk_flags?.length > 0 && (
+                      <p className="text-xs text-amber-700 mt-1">
+                        Flags: {b.risk_flags.join(", ")}
+                      </p>
+                    )}
+                  </div>
+                  {tab === "pending_review" && (
+                    <div className="flex gap-2">
+                      <button
+                        type="button"
+                        disabled={busy === b.id}
+                        onClick={() => reviewAction(b.id, "approve")}
+                        className="text-xs bg-emerald-600 hover:bg-emerald-500 text-white font-bold px-3 py-1.5 rounded-md"
+                      >
+                        Approve
+                      </button>
+                      <button
+                        type="button"
+                        disabled={busy === b.id}
+                        onClick={() => reviewAction(b.id, "reject")}
+                        className="text-xs bg-red-600 hover:bg-red-500 text-white font-bold px-3 py-1.5 rounded-md"
+                      >
+                        Reject
+                      </button>
+                    </div>
+                  )}
+                </div>
+              </article>
+            ))}
+          </div>
+        )}
+      </div>
+    </AdminShell>
+  );
+}

--- a/app/admin/credit-pricing/page.tsx
+++ b/app/admin/credit-pricing/page.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import AdminShell from "@/components/AdminShell";
+
+interface PriceRow {
+  id: number;
+  brief_template: string;
+  provider_type: string;
+  credits_cost: number;
+  notes: string | null;
+  updated_at: string;
+  updated_by: string | null;
+}
+
+export default function AdminCreditPricingPage() {
+  const [rows, setRows] = useState<PriceRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [edited, setEdited] = useState<Record<number, number>>({});
+  const [saving, setSaving] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      setLoading(true);
+      const res = await fetch("/api/admin/credit-pricing");
+      const json = await res.json();
+      if (!res.ok) throw new Error(json?.error ?? "Failed to load prices");
+      setRows((json.prices ?? []) as PriceRow[]);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load prices");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  async function save() {
+    setSaving(true);
+    setError(null);
+    try {
+      const payload = rows.map((r) => ({
+        brief_template: r.brief_template,
+        provider_type: r.provider_type,
+        credits_cost: edited[r.id] ?? r.credits_cost,
+        notes: r.notes ?? undefined,
+      }));
+      const res = await fetch("/api/admin/credit-pricing", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ rows: payload }),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json?.error ?? "Save failed");
+      setEdited({});
+      await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <AdminShell title="Brief credit pricing" subtitle="What it costs a provider to accept a brief.">
+      <div className="bg-white border border-slate-200 rounded-xl p-4">
+        {error && (
+          <div className="bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg p-3 mb-3">
+            {error}
+          </div>
+        )}
+        {loading ? (
+          <p className="text-sm text-slate-500">Loading…</p>
+        ) : (
+          <>
+            <table className="w-full text-sm">
+              <thead className="text-xs uppercase tracking-wider text-slate-500">
+                <tr>
+                  <th className="text-left py-2 pr-3">Template</th>
+                  <th className="text-left py-2 pr-3">Provider type</th>
+                  <th className="text-left py-2 pr-3">Credits</th>
+                  <th className="text-left py-2 pr-3">Notes</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((r) => (
+                  <tr key={r.id} className="border-t border-slate-100">
+                    <td className="py-2 pr-3 font-mono">{r.brief_template}</td>
+                    <td className="py-2 pr-3">{r.provider_type}</td>
+                    <td className="py-2 pr-3">
+                      <input
+                        type="number"
+                        min={0}
+                        max={1000}
+                        value={edited[r.id] ?? r.credits_cost}
+                        onChange={(e) =>
+                          setEdited({ ...edited, [r.id]: Number(e.target.value) })
+                        }
+                        className="w-20 border border-slate-300 rounded-md px-2 py-1 text-sm"
+                      />
+                    </td>
+                    <td className="py-2 pr-3 text-slate-500">{r.notes ?? ""}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <button
+              type="button"
+              onClick={save}
+              disabled={saving || Object.keys(edited).length === 0}
+              className="mt-4 inline-flex items-center gap-1.5 bg-slate-900 hover:bg-slate-800 disabled:bg-slate-400 text-white text-xs font-bold px-3 py-2 rounded-lg"
+            >
+              {saving ? "Saving…" : "Save changes"}
+            </button>
+          </>
+        )}
+      </div>
+    </AdminShell>
+  );
+}

--- a/app/admin/expert-teams/page.tsx
+++ b/app/admin/expert-teams/page.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+import AdminShell from "@/components/AdminShell";
+import Link from "next/link";
+
+interface TeamRow {
+  id: number;
+  slug: string;
+  name: string;
+  team_category: string;
+  team_type: string;
+  verification_status: string;
+  public: boolean;
+  accepts_briefs: boolean;
+  description: string | null;
+  disclosure: string | null;
+  created_at: string;
+}
+
+const STATUS_TABS = ["submitted", "verified", "rejected", "draft", "suspended"] as const;
+
+type Tab = (typeof STATUS_TABS)[number];
+
+export default function AdminExpertTeamsPage() {
+  const supabase = createClient();
+  const [teams, setTeams] = useState<TeamRow[]>([]);
+  const [tab, setTab] = useState<Tab>("submitted");
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [rejectReason, setRejectReason] = useState("");
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    const { data } = await supabase
+      .from("expert_teams")
+      .select("*")
+      .eq("verification_status", tab)
+      .order("created_at", { ascending: false });
+    setTeams((data ?? []) as TeamRow[]);
+    setLoading(false);
+  }, [supabase, tab]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  async function action(id: number, approved: boolean) {
+    setBusy(id);
+    setError(null);
+    try {
+      const res = await fetch(`/api/admin/expert-teams/${id}/verify`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          approved,
+          rejection_reason: approved ? undefined : rejectReason || "Did not meet criteria",
+        }),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json?.error ?? "Action failed");
+      setRejectReason("");
+      await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Action failed");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  return (
+    <AdminShell title="Expert Teams" subtitle="Verification queue + public teams.">
+      <div className="bg-white border border-slate-200 rounded-xl p-4">
+        <div className="flex flex-wrap gap-2 mb-4">
+          {STATUS_TABS.map((t) => (
+            <button
+              key={t}
+              type="button"
+              onClick={() => setTab(t)}
+              className={`text-xs font-semibold uppercase tracking-wider px-3 py-1.5 rounded-full border ${
+                tab === t
+                  ? "bg-slate-900 text-white border-slate-900"
+                  : "bg-white text-slate-600 border-slate-200 hover:border-slate-300"
+              }`}
+            >
+              {t}
+            </button>
+          ))}
+        </div>
+
+        {error && (
+          <div className="bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg p-3 mb-3">
+            {error}
+          </div>
+        )}
+
+        {loading ? (
+          <p className="text-sm text-slate-500">Loading…</p>
+        ) : teams.length === 0 ? (
+          <p className="text-sm text-slate-500">No teams in this state.</p>
+        ) : (
+          <div className="space-y-3">
+            {teams.map((t) => (
+              <article
+                key={t.id}
+                className="border border-slate-200 rounded-xl p-4"
+              >
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <p className="text-sm font-bold text-slate-900">{t.name}</p>
+                    <p className="text-xs text-slate-500">
+                      {t.team_category.replace(/_/g, " ")} · {t.team_type.replace(/_/g, " ")} ·
+                      created {new Date(t.created_at).toLocaleDateString()}
+                    </p>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {tab === "submitted" && (
+                      <>
+                        <button
+                          type="button"
+                          disabled={busy === t.id}
+                          onClick={() => action(t.id, true)}
+                          className="text-xs bg-emerald-600 hover:bg-emerald-500 text-white font-bold px-3 py-1.5 rounded-md"
+                        >
+                          Approve
+                        </button>
+                        <input
+                          type="text"
+                          placeholder="Rejection reason"
+                          value={rejectReason}
+                          onChange={(e) => setRejectReason(e.target.value)}
+                          className="text-xs border border-slate-300 rounded-md px-2 py-1"
+                        />
+                        <button
+                          type="button"
+                          disabled={busy === t.id}
+                          onClick={() => action(t.id, false)}
+                          className="text-xs bg-red-600 hover:bg-red-500 text-white font-bold px-3 py-1.5 rounded-md"
+                        >
+                          Reject
+                        </button>
+                      </>
+                    )}
+                    <Link
+                      href={`/teams/${t.slug}`}
+                      className="text-xs text-amber-700 underline"
+                    >
+                      Public profile
+                    </Link>
+                  </div>
+                </div>
+                {t.description && (
+                  <p className="text-sm text-slate-600 mt-2">{t.description}</p>
+                )}
+                {t.disclosure && (
+                  <p className="text-xs text-slate-500 mt-2">
+                    <strong>Disclosure:</strong> {t.disclosure}
+                  </p>
+                )}
+              </article>
+            ))}
+          </div>
+        )}
+      </div>
+    </AdminShell>
+  );
+}

--- a/app/admin/get-matched/funnel/page.tsx
+++ b/app/admin/get-matched/funnel/page.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import AdminShell from "@/components/AdminShell";
+
+interface FunnelData {
+  since: string;
+  totals: Record<string, number>;
+  routeCounts: Record<string, number>;
+  intentCounts: Record<string, number>;
+  sampleCount: number;
+}
+
+const FUNNEL_ORDER = [
+  "started",
+  "question_answered",
+  "plan_shown",
+  "cta_clicked",
+  "plan_saved",
+  "account_created",
+  "brief_drafted",
+  "brief_submitted",
+  "risk_flagged",
+];
+
+export default function AdminGmFunnelPage() {
+  const [data, setData] = useState<FunnelData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/admin/get-matched/funnel");
+      const json = await res.json();
+      if (!res.ok) throw new Error(json?.error ?? "Failed to load");
+      setData(json as FunnelData);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  if (loading) {
+    return (
+      <AdminShell title="Get Matched · Funnel" subtitle="Last 30 days.">
+        <p className="text-sm text-slate-500">Loading…</p>
+      </AdminShell>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <AdminShell title="Get Matched · Funnel" subtitle="Last 30 days.">
+        <div className="bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg p-3">
+          {error ?? "No data."}
+        </div>
+      </AdminShell>
+    );
+  }
+
+  const maxTotal = Math.max(1, ...Object.values(data.totals));
+
+  return (
+    <AdminShell title="Get Matched · Funnel" subtitle="Last 30 days.">
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+        <section className="bg-white border border-slate-200 rounded-xl p-4 lg:col-span-2">
+          <h2 className="text-sm font-bold text-slate-900 uppercase tracking-widest mb-3">
+            Funnel
+          </h2>
+          <ul className="space-y-2">
+            {FUNNEL_ORDER.map((event) => {
+              const count = data.totals[event] ?? 0;
+              const width = Math.round((count / maxTotal) * 100);
+              return (
+                <li key={event} className="text-xs">
+                  <div className="flex justify-between mb-0.5">
+                    <span className="font-mono">{event}</span>
+                    <span className="font-semibold">{count}</span>
+                  </div>
+                  <div className="h-2 bg-slate-100 rounded-full overflow-hidden">
+                    <div
+                      className="h-2 bg-amber-500"
+                      style={{ width: `${width}%` }}
+                    />
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+          <p className="text-[10px] text-slate-400 mt-3">
+            Sample: {data.sampleCount} events since {new Date(data.since).toLocaleDateString()}
+          </p>
+        </section>
+
+        <section className="bg-white border border-slate-200 rounded-xl p-4">
+          <h2 className="text-sm font-bold text-slate-900 uppercase tracking-widest mb-3">
+            Top routes
+          </h2>
+          <ul className="space-y-1.5 text-sm">
+            {Object.entries(data.routeCounts)
+              .sort(([, a], [, b]) => b - a)
+              .map(([route, count]) => (
+                <li key={route} className="flex justify-between">
+                  <span className="text-slate-700">{route}</span>
+                  <span className="font-semibold">{count}</span>
+                </li>
+              ))}
+          </ul>
+
+          <h2 className="text-sm font-bold text-slate-900 uppercase tracking-widest mt-5 mb-3">
+            Top intents
+          </h2>
+          <ul className="space-y-1.5 text-sm">
+            {Object.entries(data.intentCounts)
+              .sort(([, a], [, b]) => b - a)
+              .map(([intent, count]) => (
+                <li key={intent} className="flex justify-between">
+                  <span className="text-slate-700 font-mono text-xs">{intent}</span>
+                  <span className="font-semibold">{count}</span>
+                </li>
+              ))}
+          </ul>
+        </section>
+      </div>
+    </AdminShell>
+  );
+}

--- a/app/admin/get-matched/questions/page.tsx
+++ b/app/admin/get-matched/questions/page.tsx
@@ -1,0 +1,279 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import AdminShell from "@/components/AdminShell";
+
+interface QuestionRow {
+  id: number;
+  slug: string;
+  step: number;
+  kind: string;
+  prompt: string;
+  subtitle: string | null;
+  options: Record<string, unknown>[];
+  shown_if: Record<string, unknown>;
+  maps_to: string;
+  risk_weight: number;
+  mode: string;
+  enabled: boolean;
+  sort_order: number;
+}
+
+const KINDS = ["select", "multiselect", "text", "number", "contextual"] as const;
+const MODES = ["fast", "guided", "both"] as const;
+
+export default function AdminGmQuestionsPage() {
+  const [rows, setRows] = useState<QuestionRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [edited, setEdited] = useState<Record<number, Partial<QuestionRow>>>({});
+  const [saving, setSaving] = useState<number | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/admin/get-matched/questions");
+      const json = await res.json();
+      if (!res.ok) throw new Error(json?.error ?? "Failed to load");
+      setRows((json.questions ?? []) as QuestionRow[]);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  async function save(id: number) {
+    setSaving(id);
+    setError(null);
+    try {
+      const row = rows.find((r) => r.id === id);
+      if (!row) return;
+      const merged = { ...row, ...edited[id] };
+      const res = await fetch("/api/admin/get-matched/questions", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          id: merged.id,
+          slug: merged.slug,
+          step: merged.step,
+          kind: merged.kind,
+          prompt: merged.prompt,
+          subtitle: merged.subtitle ?? undefined,
+          options: merged.options,
+          shown_if: merged.shown_if,
+          maps_to: merged.maps_to,
+          risk_weight: merged.risk_weight,
+          mode: merged.mode,
+          enabled: merged.enabled,
+          sort_order: merged.sort_order,
+        }),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json?.error ?? "Save failed");
+      setEdited((e) => {
+        const next = { ...e };
+        delete next[id];
+        return next;
+      });
+      await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Save failed");
+    } finally {
+      setSaving(null);
+    }
+  }
+
+  return (
+    <AdminShell
+      title="Get Matched · Questions"
+      subtitle="Adaptive question registry. Edit prompts, options, and shown-if rules."
+    >
+      {error && (
+        <div className="bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg p-3 mb-3">
+          {error}
+        </div>
+      )}
+      <div className="bg-white border border-slate-200 rounded-xl p-4 space-y-3">
+        {loading ? (
+          <p className="text-sm text-slate-500">Loading…</p>
+        ) : rows.length === 0 ? (
+          <p className="text-sm text-slate-500">No questions.</p>
+        ) : (
+          rows.map((r) => {
+            const draft = edited[r.id] ?? {};
+            const merged = { ...r, ...draft };
+            return (
+              <article key={r.id} className="border border-slate-200 rounded-xl p-3">
+                <div className="flex items-center gap-2 mb-2">
+                  <span className="text-xs uppercase tracking-widest text-slate-500">
+                    step {merged.step}
+                  </span>
+                  <span className="text-xs font-mono">{merged.slug}</span>
+                  <span className="ml-auto text-xs">
+                    <select
+                      value={merged.kind}
+                      onChange={(e) =>
+                        setEdited({
+                          ...edited,
+                          [r.id]: { ...draft, kind: e.target.value },
+                        })
+                      }
+                      className="border border-slate-300 rounded-md px-1 py-0.5"
+                    >
+                      {KINDS.map((k) => (
+                        <option key={k} value={k}>
+                          {k}
+                        </option>
+                      ))}
+                    </select>
+                  </span>
+                  <span className="text-xs">
+                    <select
+                      value={merged.mode}
+                      onChange={(e) =>
+                        setEdited({
+                          ...edited,
+                          [r.id]: { ...draft, mode: e.target.value },
+                        })
+                      }
+                      className="border border-slate-300 rounded-md px-1 py-0.5"
+                    >
+                      {MODES.map((m) => (
+                        <option key={m} value={m}>
+                          {m}
+                        </option>
+                      ))}
+                    </select>
+                  </span>
+                </div>
+                <input
+                  type="text"
+                  value={merged.prompt}
+                  onChange={(e) =>
+                    setEdited({
+                      ...edited,
+                      [r.id]: { ...draft, prompt: e.target.value },
+                    })
+                  }
+                  className="w-full border border-slate-300 rounded-md px-2 py-1 text-sm font-semibold mb-2"
+                />
+                <input
+                  type="text"
+                  value={merged.subtitle ?? ""}
+                  onChange={(e) =>
+                    setEdited({
+                      ...edited,
+                      [r.id]: { ...draft, subtitle: e.target.value },
+                    })
+                  }
+                  placeholder="Subtitle (optional)"
+                  className="w-full border border-slate-300 rounded-md px-2 py-1 text-xs mb-2 text-slate-600"
+                />
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                  <div>
+                    <p className="text-xs font-semibold text-slate-500 mb-1">
+                      options (JSON)
+                    </p>
+                    <textarea
+                      rows={4}
+                      value={JSON.stringify(merged.options, null, 2)}
+                      onChange={(e) => {
+                        try {
+                          const parsed = JSON.parse(e.target.value);
+                          setEdited({
+                            ...edited,
+                            [r.id]: { ...draft, options: parsed },
+                          });
+                        } catch {
+                          /* keep typing */
+                        }
+                      }}
+                      className="w-full border border-slate-300 rounded-md px-2 py-1 text-[11px] font-mono"
+                    />
+                  </div>
+                  <div>
+                    <p className="text-xs font-semibold text-slate-500 mb-1">
+                      shown_if (JSON)
+                    </p>
+                    <textarea
+                      rows={4}
+                      value={JSON.stringify(merged.shown_if, null, 2)}
+                      onChange={(e) => {
+                        try {
+                          const parsed = JSON.parse(e.target.value);
+                          setEdited({
+                            ...edited,
+                            [r.id]: { ...draft, shown_if: parsed },
+                          });
+                        } catch {
+                          /* keep typing */
+                        }
+                      }}
+                      className="w-full border border-slate-300 rounded-md px-2 py-1 text-[11px] font-mono"
+                    />
+                  </div>
+                </div>
+                <div className="mt-2 flex flex-wrap gap-2 items-center text-xs">
+                  <label className="flex items-center gap-1">
+                    maps_to
+                    <input
+                      type="text"
+                      value={merged.maps_to}
+                      onChange={(e) =>
+                        setEdited({
+                          ...edited,
+                          [r.id]: { ...draft, maps_to: e.target.value },
+                        })
+                      }
+                      className="border border-slate-300 rounded-md px-2 py-1 w-32"
+                    />
+                  </label>
+                  <label className="flex items-center gap-1">
+                    sort
+                    <input
+                      type="number"
+                      value={merged.sort_order}
+                      onChange={(e) =>
+                        setEdited({
+                          ...edited,
+                          [r.id]: { ...draft, sort_order: Number(e.target.value) },
+                        })
+                      }
+                      className="border border-slate-300 rounded-md px-2 py-1 w-20"
+                    />
+                  </label>
+                  <label className="flex items-center gap-1">
+                    enabled
+                    <input
+                      type="checkbox"
+                      checked={merged.enabled}
+                      onChange={(e) =>
+                        setEdited({
+                          ...edited,
+                          [r.id]: { ...draft, enabled: e.target.checked },
+                        })
+                      }
+                    />
+                  </label>
+                  <button
+                    type="button"
+                    onClick={() => save(r.id)}
+                    disabled={saving === r.id || Object.keys(draft).length === 0}
+                    className="ml-auto text-xs bg-slate-900 hover:bg-slate-800 disabled:bg-slate-400 text-white font-bold px-3 py-1.5 rounded-md"
+                  >
+                    {saving === r.id ? "Saving…" : "Save"}
+                  </button>
+                </div>
+              </article>
+            );
+          })
+        )}
+      </div>
+    </AdminShell>
+  );
+}

--- a/app/admin/get-matched/result-templates/page.tsx
+++ b/app/admin/get-matched/result-templates/page.tsx
@@ -1,0 +1,236 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import AdminShell from "@/components/AdminShell";
+
+interface TemplateRow {
+  id: number;
+  route: string;
+  intent_slug: string | null;
+  headline: string;
+  why_text: string;
+  checklist: { label: string; href?: string; brief_template?: string }[];
+  primary_cta: { label: string; href: string };
+  secondary_ctas: { label: string; href: string }[];
+  cross_sells: { label: string; href: string; icon?: string }[];
+  enabled: boolean;
+}
+
+export default function AdminGmResultTemplatesPage() {
+  const [rows, setRows] = useState<TemplateRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [edited, setEdited] = useState<Record<number, Partial<TemplateRow>>>({});
+  const [saving, setSaving] = useState<number | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/admin/get-matched/result-templates");
+      const json = await res.json();
+      if (!res.ok) throw new Error(json?.error ?? "Failed to load");
+      setRows((json.templates ?? []) as TemplateRow[]);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  async function save(id: number) {
+    setSaving(id);
+    setError(null);
+    try {
+      const row = rows.find((r) => r.id === id);
+      if (!row) return;
+      const merged = { ...row, ...edited[id] };
+      const res = await fetch("/api/admin/get-matched/result-templates", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          id: merged.id,
+          route: merged.route,
+          intent_slug: merged.intent_slug ?? null,
+          headline: merged.headline,
+          why_text: merged.why_text,
+          checklist: merged.checklist,
+          primary_cta: merged.primary_cta,
+          secondary_ctas: merged.secondary_ctas,
+          cross_sells: merged.cross_sells,
+          enabled: merged.enabled,
+        }),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json?.error ?? "Save failed");
+      setEdited((e) => {
+        const next = { ...e };
+        delete next[id];
+        return next;
+      });
+      await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Save failed");
+    } finally {
+      setSaving(null);
+    }
+  }
+
+  return (
+    <AdminShell
+      title="Get Matched · Result templates"
+      subtitle="The headline, checklist, primary CTA and cross-sells for each route × intent combo."
+    >
+      {error && (
+        <div className="bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg p-3 mb-3">
+          {error}
+        </div>
+      )}
+      <div className="bg-white border border-slate-200 rounded-xl p-4 space-y-3">
+        {loading ? (
+          <p className="text-sm text-slate-500">Loading…</p>
+        ) : rows.length === 0 ? (
+          <p className="text-sm text-slate-500">No templates.</p>
+        ) : (
+          rows.map((r) => {
+            const draft = edited[r.id] ?? {};
+            const merged = { ...r, ...draft };
+            return (
+              <article key={r.id} className="border border-slate-200 rounded-xl p-3">
+                <div className="flex items-center gap-2 mb-2 text-xs">
+                  <span className="font-bold uppercase tracking-widest text-slate-700">
+                    {merged.route}
+                  </span>
+                  {merged.intent_slug && (
+                    <span className="text-slate-500">
+                      · intent: {merged.intent_slug}
+                    </span>
+                  )}
+                  <label className="ml-auto flex items-center gap-1">
+                    enabled
+                    <input
+                      type="checkbox"
+                      checked={merged.enabled}
+                      onChange={(e) =>
+                        setEdited({
+                          ...edited,
+                          [r.id]: { ...draft, enabled: e.target.checked },
+                        })
+                      }
+                    />
+                  </label>
+                </div>
+                <input
+                  type="text"
+                  value={merged.headline}
+                  onChange={(e) =>
+                    setEdited({
+                      ...edited,
+                      [r.id]: { ...draft, headline: e.target.value },
+                    })
+                  }
+                  className="w-full border border-slate-300 rounded-md px-2 py-1 text-sm font-semibold mb-2"
+                />
+                <textarea
+                  rows={2}
+                  value={merged.why_text}
+                  onChange={(e) =>
+                    setEdited({
+                      ...edited,
+                      [r.id]: { ...draft, why_text: e.target.value },
+                    })
+                  }
+                  className="w-full border border-slate-300 rounded-md px-2 py-1 text-xs mb-2"
+                />
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                  <JsonField
+                    label="checklist"
+                    value={merged.checklist}
+                    onChange={(v) =>
+                      setEdited({
+                        ...edited,
+                        [r.id]: { ...draft, checklist: v as TemplateRow["checklist"] },
+                      })
+                    }
+                  />
+                  <JsonField
+                    label="primary_cta"
+                    value={merged.primary_cta}
+                    onChange={(v) =>
+                      setEdited({
+                        ...edited,
+                        [r.id]: { ...draft, primary_cta: v as TemplateRow["primary_cta"] },
+                      })
+                    }
+                  />
+                  <JsonField
+                    label="secondary_ctas (max 3)"
+                    value={merged.secondary_ctas}
+                    onChange={(v) =>
+                      setEdited({
+                        ...edited,
+                        [r.id]: { ...draft, secondary_ctas: v as TemplateRow["secondary_ctas"] },
+                      })
+                    }
+                  />
+                  <JsonField
+                    label="cross_sells (max 3)"
+                    value={merged.cross_sells}
+                    onChange={(v) =>
+                      setEdited({
+                        ...edited,
+                        [r.id]: { ...draft, cross_sells: v as TemplateRow["cross_sells"] },
+                      })
+                    }
+                  />
+                </div>
+                <div className="mt-2 flex justify-end">
+                  <button
+                    type="button"
+                    onClick={() => save(r.id)}
+                    disabled={saving === r.id || Object.keys(draft).length === 0}
+                    className="text-xs bg-slate-900 hover:bg-slate-800 disabled:bg-slate-400 text-white font-bold px-3 py-1.5 rounded-md"
+                  >
+                    {saving === r.id ? "Saving…" : "Save"}
+                  </button>
+                </div>
+              </article>
+            );
+          })
+        )}
+      </div>
+    </AdminShell>
+  );
+}
+
+function JsonField({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: unknown;
+  onChange: (v: unknown) => void;
+}) {
+  return (
+    <div>
+      <p className="text-xs font-semibold text-slate-500 mb-1">{label}</p>
+      <textarea
+        rows={4}
+        value={JSON.stringify(value, null, 2)}
+        onChange={(e) => {
+          try {
+            const parsed = JSON.parse(e.target.value);
+            onChange(parsed);
+          } catch {
+            /* keep typing */
+          }
+        }}
+        className="w-full border border-slate-300 rounded-md px-2 py-1 text-[11px] font-mono"
+      />
+    </div>
+  );
+}

--- a/app/admin/intents/page.tsx
+++ b/app/admin/intents/page.tsx
@@ -1,0 +1,233 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import AdminShell from "@/components/AdminShell";
+
+interface IntentRow {
+  id: number;
+  slug: string;
+  label: string;
+  description: string | null;
+  default_route: string;
+  default_brief_template: string | null;
+  risk_level: "low" | "medium" | "high";
+  enabled: boolean;
+  sort_order: number;
+}
+
+const ROUTES = [
+  "compare",
+  "browse",
+  "individual",
+  "firm",
+  "expert_team",
+  "investor_brief",
+  "listing_brief",
+  "second_opinion",
+  "guide",
+] as const;
+
+const RISK_LEVELS = ["low", "medium", "high"] as const;
+
+export default function AdminIntentsPage() {
+  const [intents, setIntents] = useState<IntentRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [savingId, setSavingId] = useState<number | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/admin/intents");
+      const json = await res.json();
+      if (!res.ok) throw new Error(json?.error ?? "Failed to load");
+      setIntents((json.intents ?? []) as IntentRow[]);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  async function save(row: IntentRow) {
+    setSavingId(row.id);
+    try {
+      await fetch("/api/admin/intents", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          id: row.id,
+          slug: row.slug,
+          label: row.label,
+          description: row.description ?? undefined,
+          default_route: row.default_route,
+          default_brief_template: row.default_brief_template ?? null,
+          risk_level: row.risk_level,
+          enabled: row.enabled,
+          sort_order: row.sort_order,
+        }),
+      });
+      await load();
+    } finally {
+      setSavingId(null);
+    }
+  }
+
+  return (
+    <AdminShell
+      title="Intent taxonomy"
+      subtitle="Top-level user goals Get Matched routes against."
+    >
+      <div className="bg-white border border-slate-200 rounded-xl p-4">
+        {error && (
+          <div className="bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg p-3 mb-3">
+            {error}
+          </div>
+        )}
+        {loading ? (
+          <p className="text-sm text-slate-500">Loading…</p>
+        ) : (
+          <table className="w-full text-sm">
+            <thead className="text-xs uppercase tracking-wider text-slate-500">
+              <tr>
+                <th className="text-left py-2 pr-3">Slug</th>
+                <th className="text-left py-2 pr-3">Label</th>
+                <th className="text-left py-2 pr-3">Default route</th>
+                <th className="text-left py-2 pr-3">Brief template</th>
+                <th className="text-left py-2 pr-3">Risk</th>
+                <th className="text-left py-2 pr-3">Order</th>
+                <th className="text-left py-2 pr-3">Enabled</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {intents.map((row) => (
+                <tr key={row.id} className="border-t border-slate-100">
+                  <td className="py-2 pr-3 font-mono text-xs">{row.slug}</td>
+                  <td className="py-2 pr-3">
+                    <input
+                      type="text"
+                      value={row.label}
+                      onChange={(e) =>
+                        setIntents((rs) =>
+                          rs.map((r) =>
+                            r.id === row.id ? { ...r, label: e.target.value } : r,
+                          ),
+                        )
+                      }
+                      className="border border-slate-300 rounded-md px-2 py-1 text-sm w-full"
+                    />
+                  </td>
+                  <td className="py-2 pr-3">
+                    <select
+                      value={row.default_route}
+                      onChange={(e) =>
+                        setIntents((rs) =>
+                          rs.map((r) =>
+                            r.id === row.id
+                              ? { ...r, default_route: e.target.value }
+                              : r,
+                          ),
+                        )
+                      }
+                      className="border border-slate-300 rounded-md px-2 py-1 text-xs"
+                    >
+                      {ROUTES.map((r) => (
+                        <option key={r} value={r}>
+                          {r}
+                        </option>
+                      ))}
+                    </select>
+                  </td>
+                  <td className="py-2 pr-3">
+                    <input
+                      type="text"
+                      value={row.default_brief_template ?? ""}
+                      onChange={(e) =>
+                        setIntents((rs) =>
+                          rs.map((r) =>
+                            r.id === row.id
+                              ? {
+                                  ...r,
+                                  default_brief_template: e.target.value || null,
+                                }
+                              : r,
+                          ),
+                        )
+                      }
+                      className="border border-slate-300 rounded-md px-2 py-1 text-xs w-28"
+                    />
+                  </td>
+                  <td className="py-2 pr-3">
+                    <select
+                      value={row.risk_level}
+                      onChange={(e) =>
+                        setIntents((rs) =>
+                          rs.map((r) =>
+                            r.id === row.id
+                              ? { ...r, risk_level: e.target.value as IntentRow["risk_level"] }
+                              : r,
+                          ),
+                        )
+                      }
+                      className="border border-slate-300 rounded-md px-2 py-1 text-xs"
+                    >
+                      {RISK_LEVELS.map((r) => (
+                        <option key={r} value={r}>
+                          {r}
+                        </option>
+                      ))}
+                    </select>
+                  </td>
+                  <td className="py-2 pr-3">
+                    <input
+                      type="number"
+                      value={row.sort_order}
+                      onChange={(e) =>
+                        setIntents((rs) =>
+                          rs.map((r) =>
+                            r.id === row.id
+                              ? { ...r, sort_order: Number(e.target.value) }
+                              : r,
+                          ),
+                        )
+                      }
+                      className="border border-slate-300 rounded-md px-2 py-1 text-xs w-20"
+                    />
+                  </td>
+                  <td className="py-2 pr-3">
+                    <input
+                      type="checkbox"
+                      checked={row.enabled}
+                      onChange={(e) =>
+                        setIntents((rs) =>
+                          rs.map((r) =>
+                            r.id === row.id ? { ...r, enabled: e.target.checked } : r,
+                          ),
+                        )
+                      }
+                    />
+                  </td>
+                  <td className="py-2 pr-3">
+                    <button
+                      type="button"
+                      onClick={() => save(row)}
+                      disabled={savingId === row.id}
+                      className="text-xs bg-slate-900 hover:bg-slate-800 text-white font-bold px-3 py-1.5 rounded-md"
+                    >
+                      Save
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </AdminShell>
+  );
+}

--- a/app/admin/risk-flags/page.tsx
+++ b/app/admin/risk-flags/page.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import AdminShell from "@/components/AdminShell";
+
+interface Pattern {
+  id: number;
+  pattern: string;
+  category: string;
+  severity: "warn" | "review" | "block";
+  enabled: boolean;
+  notes: string | null;
+}
+
+const SEVERITIES = ["warn", "review", "block"] as const;
+
+export default function AdminRiskFlagsPage() {
+  const [patterns, setPatterns] = useState<Pattern[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [draftNew, setDraftNew] = useState({
+    pattern: "",
+    category: "",
+    severity: "warn" as Pattern["severity"],
+    notes: "",
+  });
+  const [busy, setBusy] = useState<number | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/admin/risk-patterns");
+      const json = await res.json();
+      if (!res.ok) throw new Error(json?.error ?? "Failed to load");
+      setPatterns((json.patterns ?? []) as Pattern[]);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  async function update(p: Pattern) {
+    setBusy(p.id);
+    try {
+      await fetch("/api/admin/risk-patterns", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          id: p.id,
+          pattern: p.pattern,
+          category: p.category,
+          severity: p.severity,
+          enabled: p.enabled,
+          notes: p.notes ?? undefined,
+        }),
+      });
+      await load();
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function deletePattern(id: number) {
+    if (!confirm("Delete this pattern?")) return;
+    setBusy(id);
+    try {
+      await fetch(`/api/admin/risk-patterns?id=${id}`, { method: "DELETE" });
+      await load();
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function addNew() {
+    setError(null);
+    try {
+      const res = await fetch("/api/admin/risk-patterns", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          pattern: draftNew.pattern,
+          category: draftNew.category,
+          severity: draftNew.severity,
+          enabled: true,
+          notes: draftNew.notes || undefined,
+        }),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json?.error ?? "Save failed");
+      setDraftNew({ pattern: "", category: "", severity: "warn", notes: "" });
+      await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Save failed");
+    }
+  }
+
+  return (
+    <AdminShell title="Brief risk flags" subtitle="Pattern → category → severity. Used by /api/briefs to flag or block submissions.">
+      <div className="bg-white border border-slate-200 rounded-xl p-4 mb-4">
+        <h2 className="text-sm font-bold text-slate-900 uppercase tracking-wider mb-3">
+          Add pattern
+        </h2>
+        <div className="grid grid-cols-1 sm:grid-cols-5 gap-2 items-center">
+          <input
+            type="text"
+            placeholder="pattern (substring)"
+            value={draftNew.pattern}
+            onChange={(e) => setDraftNew({ ...draftNew, pattern: e.target.value })}
+            className="border border-slate-300 rounded-md px-2 py-1 text-sm sm:col-span-2"
+          />
+          <input
+            type="text"
+            placeholder="category"
+            value={draftNew.category}
+            onChange={(e) => setDraftNew({ ...draftNew, category: e.target.value })}
+            className="border border-slate-300 rounded-md px-2 py-1 text-sm"
+          />
+          <select
+            value={draftNew.severity}
+            onChange={(e) =>
+              setDraftNew({ ...draftNew, severity: e.target.value as Pattern["severity"] })
+            }
+            className="border border-slate-300 rounded-md px-2 py-1 text-sm"
+          >
+            {SEVERITIES.map((s) => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ))}
+          </select>
+          <button
+            type="button"
+            onClick={addNew}
+            disabled={!draftNew.pattern || !draftNew.category}
+            className="text-xs bg-slate-900 hover:bg-slate-800 disabled:bg-slate-400 text-white font-bold px-3 py-2 rounded-md"
+          >
+            Add
+          </button>
+        </div>
+        <input
+          type="text"
+          placeholder="optional notes"
+          value={draftNew.notes}
+          onChange={(e) => setDraftNew({ ...draftNew, notes: e.target.value })}
+          className="border border-slate-300 rounded-md px-2 py-1 text-sm w-full mt-2"
+        />
+      </div>
+
+      {error && (
+        <div className="bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg p-3 mb-3">
+          {error}
+        </div>
+      )}
+
+      <div className="bg-white border border-slate-200 rounded-xl p-4">
+        {loading ? (
+          <p className="text-sm text-slate-500">Loading…</p>
+        ) : (
+          <table className="w-full text-sm">
+            <thead className="text-xs uppercase tracking-wider text-slate-500">
+              <tr>
+                <th className="text-left py-2 pr-3">Pattern</th>
+                <th className="text-left py-2 pr-3">Category</th>
+                <th className="text-left py-2 pr-3">Severity</th>
+                <th className="text-left py-2 pr-3">Enabled</th>
+                <th className="text-left py-2 pr-3">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {patterns.map((p) => (
+                <tr key={p.id} className="border-t border-slate-100">
+                  <td className="py-2 pr-3 font-mono">{p.pattern}</td>
+                  <td className="py-2 pr-3">{p.category}</td>
+                  <td className="py-2 pr-3">
+                    <select
+                      value={p.severity}
+                      onChange={(e) =>
+                        setPatterns((rows) =>
+                          rows.map((r) =>
+                            r.id === p.id ? { ...r, severity: e.target.value as Pattern["severity"] } : r,
+                          ),
+                        )
+                      }
+                      className="border border-slate-300 rounded-md px-1 py-0.5 text-xs"
+                    >
+                      {SEVERITIES.map((s) => (
+                        <option key={s} value={s}>
+                          {s}
+                        </option>
+                      ))}
+                    </select>
+                  </td>
+                  <td className="py-2 pr-3">
+                    <input
+                      type="checkbox"
+                      checked={p.enabled}
+                      onChange={(e) =>
+                        setPatterns((rows) =>
+                          rows.map((r) =>
+                            r.id === p.id ? { ...r, enabled: e.target.checked } : r,
+                          ),
+                        )
+                      }
+                    />
+                  </td>
+                  <td className="py-2 pr-3 flex gap-2">
+                    <button
+                      type="button"
+                      onClick={() => update(p)}
+                      disabled={busy === p.id}
+                      className="text-xs bg-slate-900 hover:bg-slate-800 text-white font-bold px-2 py-1 rounded-md"
+                    >
+                      Save
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => deletePattern(p.id)}
+                      disabled={busy === p.id}
+                      className="text-xs bg-red-600 hover:bg-red-500 text-white font-bold px-2 py-1 rounded-md"
+                    >
+                      Delete
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </AdminShell>
+  );
+}

--- a/app/admin/routing-rules/page.tsx
+++ b/app/admin/routing-rules/page.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import AdminShell from "@/components/AdminShell";
+
+interface RoutingRule {
+  id: number;
+  name: string;
+  priority: number;
+  enabled: boolean;
+  match_conditions: Record<string, unknown>;
+  route_to: Record<string, unknown>;
+  notes: string | null;
+}
+
+export default function AdminRoutingRulesPage() {
+  const [rules, setRules] = useState<RoutingRule[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [edited, setEdited] = useState<Record<number, Partial<RoutingRule>>>({});
+  const [saving, setSaving] = useState<number | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/admin/routing-rules");
+      const json = await res.json();
+      if (!res.ok) throw new Error(json?.error ?? "Failed to load");
+      setRules((json.rules ?? []) as RoutingRule[]);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  async function saveRow(id: number) {
+    setSaving(id);
+    setError(null);
+    try {
+      const row = rules.find((r) => r.id === id);
+      if (!row) return;
+      const merged = { ...row, ...edited[id] };
+      const res = await fetch("/api/admin/routing-rules", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          id: merged.id,
+          name: merged.name,
+          priority: merged.priority,
+          enabled: merged.enabled,
+          match_conditions: merged.match_conditions,
+          route_to: merged.route_to,
+          notes: merged.notes ?? undefined,
+        }),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json?.error ?? "Save failed");
+      setEdited((e) => {
+        const next = { ...e };
+        delete next[id];
+        return next;
+      });
+      await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Save failed");
+    } finally {
+      setSaving(null);
+    }
+  }
+
+  async function deleteRule(id: number) {
+    if (!confirm("Delete this routing rule?")) return;
+    setSaving(id);
+    try {
+      await fetch(`/api/admin/routing-rules?id=${id}`, { method: "DELETE" });
+      await load();
+    } finally {
+      setSaving(null);
+    }
+  }
+
+  return (
+    <AdminShell title="Brief routing rules" subtitle="Admin-managed JSON rules for matching providers to briefs.">
+      <div className="bg-white border border-slate-200 rounded-xl p-4">
+        {error && (
+          <div className="bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg p-3 mb-3">
+            {error}
+          </div>
+        )}
+        {loading ? (
+          <p className="text-sm text-slate-500">Loading…</p>
+        ) : rules.length === 0 ? (
+          <p className="text-sm text-slate-500">No routing rules.</p>
+        ) : (
+          <div className="space-y-3">
+            {rules.map((r) => {
+              const draft = edited[r.id] ?? {};
+              const merged = { ...r, ...draft };
+              return (
+                <article key={r.id} className="border border-slate-200 rounded-xl p-3">
+                  <div className="flex items-center gap-2 mb-2">
+                    <input
+                      type="text"
+                      value={merged.name}
+                      onChange={(e) =>
+                        setEdited({
+                          ...edited,
+                          [r.id]: { ...draft, name: e.target.value },
+                        })
+                      }
+                      className="flex-1 border border-slate-300 rounded-md px-2 py-1 text-sm font-bold"
+                    />
+                    <input
+                      type="number"
+                      value={merged.priority}
+                      onChange={(e) =>
+                        setEdited({
+                          ...edited,
+                          [r.id]: { ...draft, priority: Number(e.target.value) },
+                        })
+                      }
+                      className="w-20 border border-slate-300 rounded-md px-2 py-1 text-sm"
+                    />
+                    <label className="text-xs flex items-center gap-1">
+                      <input
+                        type="checkbox"
+                        checked={merged.enabled}
+                        onChange={(e) =>
+                          setEdited({
+                            ...edited,
+                            [r.id]: { ...draft, enabled: e.target.checked },
+                          })
+                        }
+                      />
+                      enabled
+                    </label>
+                  </div>
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                    <div>
+                      <p className="text-xs font-semibold text-slate-500 mb-1">
+                        match_conditions (JSON)
+                      </p>
+                      <textarea
+                        rows={3}
+                        value={JSON.stringify(merged.match_conditions, null, 2)}
+                        onChange={(e) => {
+                          try {
+                            const parsed = JSON.parse(e.target.value);
+                            setEdited({
+                              ...edited,
+                              [r.id]: { ...draft, match_conditions: parsed },
+                            });
+                          } catch {
+                            /* keep typing */
+                          }
+                        }}
+                        className="w-full border border-slate-300 rounded-md px-2 py-1 text-xs font-mono"
+                      />
+                    </div>
+                    <div>
+                      <p className="text-xs font-semibold text-slate-500 mb-1">
+                        route_to (JSON)
+                      </p>
+                      <textarea
+                        rows={3}
+                        value={JSON.stringify(merged.route_to, null, 2)}
+                        onChange={(e) => {
+                          try {
+                            const parsed = JSON.parse(e.target.value);
+                            setEdited({
+                              ...edited,
+                              [r.id]: { ...draft, route_to: parsed },
+                            });
+                          } catch {
+                            /* keep typing */
+                          }
+                        }}
+                        className="w-full border border-slate-300 rounded-md px-2 py-1 text-xs font-mono"
+                      />
+                    </div>
+                  </div>
+                  <div className="mt-2 flex gap-2">
+                    <button
+                      type="button"
+                      onClick={() => saveRow(r.id)}
+                      disabled={saving === r.id || Object.keys(draft).length === 0}
+                      className="text-xs bg-slate-900 hover:bg-slate-800 disabled:bg-slate-400 text-white font-bold px-3 py-1.5 rounded-md"
+                    >
+                      {saving === r.id ? "Saving…" : "Save"}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => deleteRule(r.id)}
+                      disabled={saving === r.id}
+                      className="text-xs bg-red-600 hover:bg-red-500 text-white font-bold px-3 py-1.5 rounded-md"
+                    >
+                      Delete
+                    </button>
+                    {r.notes && (
+                      <span className="text-xs text-slate-500 italic self-center">{r.notes}</span>
+                    )}
+                  </div>
+                </article>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </AdminShell>
+  );
+}

--- a/app/advisor-portal/briefs/BriefsInboxClient.tsx
+++ b/app/advisor-portal/briefs/BriefsInboxClient.tsx
@@ -1,0 +1,246 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import Icon from "@/components/Icon";
+import type { MaskedBrief } from "@/lib/briefs/types";
+
+interface AcceptedBrief {
+  id: number;
+  slug: string;
+  job_title: string;
+  brief_template: string | null;
+  budget_band: string;
+  location: string | null;
+  tracker_status: string;
+  accepted_at: string;
+  contact_name: string | null;
+  contact_email: string | null;
+  contact_phone: string | null;
+  accepted_by_team_id: number | null;
+}
+
+interface InboxData {
+  available: MaskedBrief[];
+  accepted: AcceptedBrief[];
+  teamIds: number[];
+}
+
+const STATUSES = [
+  { value: "new", label: "New" },
+  { value: "contacted", label: "Contacted" },
+  { value: "call_booked", label: "Call booked" },
+  { value: "proposal_sent", label: "Proposal sent" },
+  { value: "won", label: "Engaged" },
+  { value: "lost", label: "Did not proceed" },
+];
+
+export default function BriefsInboxClient() {
+  const [data, setData] = useState<InboxData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [statusBusy, setStatusBusy] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      setLoading(true);
+      const res = await fetch("/api/briefs/inbox");
+      const json = await res.json();
+      if (!res.ok) throw new Error(json?.error ?? "Failed to load inbox");
+      setData(json as InboxData);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load inbox");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  async function accept(slug: string, teamId?: number) {
+    setBusy(slug);
+    setError(null);
+    try {
+      const res = await fetch(`/api/briefs/${slug}/accept`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ team_id: teamId }),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json?.error ?? "Could not accept");
+      await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not accept");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function changeStatus(slug: string, status: string) {
+    setStatusBusy(slug);
+    try {
+      await fetch(`/api/briefs/${slug}/status`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ tracker_status: status }),
+      });
+      await load();
+    } finally {
+      setStatusBusy(null);
+    }
+  }
+
+  if (loading) {
+    return <p className="text-sm text-slate-500">Loading…</p>;
+  }
+  if (error) {
+    return (
+      <div className="bg-red-50 border border-red-200 rounded-xl p-4 text-sm text-red-700">
+        {error}
+      </div>
+    );
+  }
+  if (!data) return null;
+
+  return (
+    <div className="space-y-12">
+      <section>
+        <h2 className="text-sm font-bold text-slate-900 uppercase tracking-wider mb-3">
+          Available briefs ({data.available.length})
+        </h2>
+        {data.available.length === 0 ? (
+          <p className="text-sm text-slate-500">
+            No briefs matching your profile right now. We&apos;ll surface new
+            briefs here as users submit them.
+          </p>
+        ) : (
+          <div className="grid grid-cols-1 gap-3">
+            {data.available.map((b) => (
+              <article
+                key={b.id}
+                className="bg-white border border-slate-200 rounded-2xl p-5"
+              >
+                <div className="flex items-start justify-between gap-4 mb-2">
+                  <div>
+                    <p className="text-xs uppercase tracking-wider text-slate-400 mb-0.5">
+                      {b.brief_template ?? "general"}
+                    </p>
+                    <h3 className="text-base font-bold text-slate-900">
+                      {b.job_title}
+                    </h3>
+                  </div>
+                  <span className="text-xs text-slate-500 whitespace-nowrap">
+                    {b.location ?? "AU"} · {b.budget_band}
+                  </span>
+                </div>
+                <p className="text-sm text-slate-600 mb-4">
+                  {b.description_preview}
+                </p>
+                <div className="flex flex-wrap items-center gap-3">
+                  <span className="text-xs text-slate-500">
+                    Accept cost: {" "}
+                    <strong className="text-slate-900">
+                      {b.accept_credits_cost ?? "?"} credits
+                    </strong>
+                  </span>
+                  {b.provider_preference === "expert_team" &&
+                    data.teamIds.length > 0 && (
+                      <select
+                        className="text-xs border border-slate-200 rounded-md px-2 py-1"
+                        onChange={(e) => {
+                          if (e.target.value) {
+                            void accept(b.slug, Number(e.target.value));
+                          }
+                        }}
+                        defaultValue=""
+                      >
+                        <option value="" disabled>
+                          Accept as team…
+                        </option>
+                        {data.teamIds.map((t) => (
+                          <option key={t} value={t}>
+                            Team #{t}
+                          </option>
+                        ))}
+                      </select>
+                    )}
+                  <button
+                    type="button"
+                    onClick={() => accept(b.slug)}
+                    disabled={busy === b.slug}
+                    className="inline-flex items-center gap-1.5 bg-amber-500 hover:bg-amber-400 disabled:bg-amber-300 text-slate-900 font-bold text-sm px-4 py-2 rounded-lg"
+                  >
+                    {busy === b.slug ? "Accepting…" : "Accept & unlock"}
+                    <Icon name="arrow-right" size={14} />
+                  </button>
+                </div>
+              </article>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section>
+        <h2 className="text-sm font-bold text-slate-900 uppercase tracking-wider mb-3">
+          Accepted briefs ({data.accepted.length})
+        </h2>
+        {data.accepted.length === 0 ? (
+          <p className="text-sm text-slate-500">
+            Briefs you accept will show up here with the consumer&apos;s contact details.
+          </p>
+        ) : (
+          <div className="grid grid-cols-1 gap-3">
+            {data.accepted.map((b) => (
+              <article
+                key={b.id}
+                className="bg-white border border-emerald-200 rounded-2xl p-5"
+              >
+                <div className="flex items-start justify-between gap-4 mb-2">
+                  <div>
+                    <p className="text-xs uppercase tracking-wider text-emerald-700 mb-0.5">
+                      Accepted · {new Date(b.accepted_at).toLocaleDateString()}
+                    </p>
+                    <h3 className="text-base font-bold text-slate-900">
+                      {b.job_title}
+                    </h3>
+                  </div>
+                </div>
+                <dl className="grid grid-cols-2 gap-x-3 gap-y-1 text-xs mb-3">
+                  <dt className="font-semibold text-slate-500">Name</dt>
+                  <dd className="text-slate-800">{b.contact_name ?? "—"}</dd>
+                  <dt className="font-semibold text-slate-500">Email</dt>
+                  <dd className="text-slate-800">{b.contact_email ?? "—"}</dd>
+                  <dt className="font-semibold text-slate-500">Phone</dt>
+                  <dd className="text-slate-800">{b.contact_phone ?? "—"}</dd>
+                  <dt className="font-semibold text-slate-500">Location</dt>
+                  <dd className="text-slate-800">{b.location ?? "—"}</dd>
+                  <dt className="font-semibold text-slate-500">Budget</dt>
+                  <dd className="text-slate-800">{b.budget_band}</dd>
+                </dl>
+                <div className="flex items-center gap-2">
+                  <select
+                    value={b.tracker_status}
+                    disabled={statusBusy === b.slug}
+                    onChange={(e) => changeStatus(b.slug, e.target.value)}
+                    className="text-xs border border-slate-200 rounded-md px-2 py-1"
+                  >
+                    {STATUSES.map((s) => (
+                      <option key={s.value} value={s.value}>
+                        {s.label}
+                      </option>
+                    ))}
+                  </select>
+                  <span className="text-xs text-slate-400">
+                    Update status as you progress.
+                  </span>
+                </div>
+              </article>
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/app/advisor-portal/briefs/page.tsx
+++ b/app/advisor-portal/briefs/page.tsx
@@ -1,0 +1,27 @@
+import type { Metadata } from "next";
+import BriefsInboxClient from "./BriefsInboxClient";
+
+export const metadata: Metadata = {
+  title: "Brief inbox — Advisor Portal",
+  robots: { index: false, follow: false },
+};
+
+export const dynamic = "force-dynamic";
+
+export default function AdvisorPortalBriefsPage() {
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <div className="max-w-5xl mx-auto px-4 py-8 sm:py-12">
+        <h1 className="text-2xl sm:text-3xl font-extrabold text-slate-900 mb-1">
+          Investor Brief inbox
+        </h1>
+        <p className="text-sm text-slate-500 mb-8">
+          Verified providers see masked previews. Accept a brief to unlock the
+          consumer&apos;s contact details — your credit balance is debited at
+          the moment of acceptance.
+        </p>
+        <BriefsInboxClient />
+      </div>
+    </div>
+  );
+}

--- a/app/advisor-portal/teams/TeamsManagerClient.tsx
+++ b/app/advisor-portal/teams/TeamsManagerClient.tsx
@@ -1,0 +1,470 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import Icon from "@/components/Icon";
+import {
+  BRIEF_TEMPLATES,
+  BRIEF_TEMPLATE_LABELS,
+} from "@/lib/briefs/templates";
+import type { BriefTemplate } from "@/lib/briefs/types";
+
+interface TeamRow {
+  id: number;
+  slug: string;
+  name: string;
+  team_category: string;
+  team_type: string;
+  description: string | null;
+  verification_status: string;
+  accepts_briefs: boolean;
+  public: boolean;
+  accepted_brief_templates: string[];
+  disclosure: string | null;
+}
+
+interface MemberRow {
+  id: number;
+  professional_id: number;
+  member_role: string;
+  public_title: string | null;
+  status: string;
+}
+
+interface InvitationRow {
+  id: number;
+  email: string;
+  name: string | null;
+  status: string;
+  expires_at: string;
+  invited_role: string;
+  token: string;
+}
+
+const TEAM_CATEGORIES = [
+  { value: "smsf_property", label: "SMSF Property Team" },
+  { value: "foreign_investor", label: "Foreign Investor Team" },
+  { value: "expat", label: "Expat Investing Team" },
+  { value: "commercial_property", label: "Commercial Property Team" },
+  { value: "business_acquisition", label: "Business Acquisition Team" },
+  { value: "due_diligence", label: "Opportunity Due Diligence Team" },
+  { value: "retirement", label: "Retirement Planning Team" },
+  { value: "custom", label: "Custom" },
+];
+
+const TEAM_TYPES = [
+  { value: "same_firm", label: "Same firm" },
+  { value: "independent", label: "Independent collaboration" },
+  { value: "private_referral", label: "Private referral" },
+  { value: "internal_firm", label: "Internal firm team" },
+];
+
+export default function TeamsManagerClient() {
+  const [teams, setTeams] = useState<TeamRow[]>([]);
+  const [selected, setSelected] = useState<number | null>(null);
+  const [detail, setDetail] = useState<{
+    team: TeamRow;
+    members: MemberRow[];
+    invitations: InvitationRow[];
+  } | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [newTeam, setNewTeam] = useState({
+    name: "",
+    team_category: "",
+    team_type: "",
+    description: "",
+    disclosure: "",
+    accepted_brief_templates: [] as BriefTemplate[],
+  });
+
+  const [inviteEmail, setInviteEmail] = useState("");
+  const [inviteRole, setInviteRole] = useState("member");
+
+  const loadTeams = useCallback(async () => {
+    try {
+      setLoading(true);
+      const res = await fetch("/api/expert-teams");
+      const json = await res.json();
+      if (!res.ok) throw new Error(json?.error ?? "Failed to load teams");
+      setTeams(json.teams ?? []);
+      if (json.teams?.length > 0 && selected === null) {
+        setSelected(json.teams[0].id);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load teams");
+    } finally {
+      setLoading(false);
+    }
+  }, [selected]);
+
+  const loadDetail = useCallback(async (id: number) => {
+    try {
+      const res = await fetch(`/api/expert-teams/${id}`);
+      const json = await res.json();
+      if (!res.ok) throw new Error(json?.error ?? "Failed to load team");
+      setDetail(json);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load team");
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadTeams();
+  }, [loadTeams]);
+
+  useEffect(() => {
+    if (selected) void loadDetail(selected);
+  }, [selected, loadDetail]);
+
+  async function submitNewTeam() {
+    setError(null);
+    try {
+      const res = await fetch("/api/expert-teams", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: newTeam.name,
+          team_category: newTeam.team_category,
+          team_type: newTeam.team_type,
+          description: newTeam.description || undefined,
+          disclosure: newTeam.disclosure || undefined,
+          accepted_brief_templates: newTeam.accepted_brief_templates,
+        }),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json?.error ?? "Failed to create team");
+      setNewTeam({
+        name: "",
+        team_category: "",
+        team_type: "",
+        description: "",
+        disclosure: "",
+        accepted_brief_templates: [],
+      });
+      setCreating(false);
+      await loadTeams();
+      setSelected(json.team.id);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create team");
+    }
+  }
+
+  async function sendInvite() {
+    if (!selected) return;
+    setError(null);
+    try {
+      const res = await fetch(`/api/expert-teams/${selected}/invite`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: inviteEmail, role: inviteRole }),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json?.error ?? "Failed to send invite");
+      setInviteEmail("");
+      await loadDetail(selected);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to send invite");
+    }
+  }
+
+  async function submitForVerification() {
+    if (!selected) return;
+    setError(null);
+    try {
+      const res = await fetch(`/api/expert-teams/${selected}/submit`, {
+        method: "POST",
+      });
+      const json = await res.json();
+      if (!res.ok) {
+        throw new Error(
+          json?.missing
+            ? `Missing required fields: ${json.missing.join(", ")}`
+            : (json?.error ?? "Failed to submit"),
+        );
+      }
+      await loadDetail(selected);
+      await loadTeams();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to submit");
+    }
+  }
+
+  if (loading) return <p className="text-sm text-slate-500">Loading teams…</p>;
+
+  return (
+    <div className="space-y-6">
+      {error && (
+        <div className="bg-red-50 border border-red-200 rounded-xl p-3 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      <div className="bg-white rounded-2xl border border-slate-200 p-5">
+        <div className="flex items-center justify-between mb-3">
+          <h2 className="text-sm font-bold text-slate-900 uppercase tracking-wider">
+            Your teams
+          </h2>
+          <button
+            type="button"
+            onClick={() => setCreating((v) => !v)}
+            className="inline-flex items-center gap-1.5 bg-amber-500 hover:bg-amber-400 text-slate-900 text-xs font-bold px-3 py-1.5 rounded-lg"
+          >
+            <Icon name="plus" size={14} /> {creating ? "Cancel" : "Create team"}
+          </button>
+        </div>
+
+        {creating && (
+          <div className="border border-slate-200 rounded-xl p-4 mb-4 space-y-3">
+            <div>
+              <label className="block text-xs font-semibold text-slate-700 mb-1">
+                Team name
+              </label>
+              <input
+                value={newTeam.name}
+                onChange={(e) => setNewTeam({ ...newTeam, name: e.target.value })}
+                className="w-full border border-slate-300 rounded-md px-3 py-2 text-sm"
+              />
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div>
+                <label className="block text-xs font-semibold text-slate-700 mb-1">
+                  Category
+                </label>
+                <select
+                  value={newTeam.team_category}
+                  onChange={(e) =>
+                    setNewTeam({ ...newTeam, team_category: e.target.value })
+                  }
+                  className="w-full border border-slate-300 rounded-md px-3 py-2 text-sm"
+                >
+                  <option value="">Select…</option>
+                  {TEAM_CATEGORIES.map((c) => (
+                    <option key={c.value} value={c.value}>
+                      {c.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className="block text-xs font-semibold text-slate-700 mb-1">
+                  Type
+                </label>
+                <select
+                  value={newTeam.team_type}
+                  onChange={(e) =>
+                    setNewTeam({ ...newTeam, team_type: e.target.value })
+                  }
+                  className="w-full border border-slate-300 rounded-md px-3 py-2 text-sm"
+                >
+                  <option value="">Select…</option>
+                  {TEAM_TYPES.map((t) => (
+                    <option key={t.value} value={t.value}>
+                      {t.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+            <div>
+              <label className="block text-xs font-semibold text-slate-700 mb-1">
+                Public description
+              </label>
+              <textarea
+                rows={3}
+                value={newTeam.description}
+                onChange={(e) =>
+                  setNewTeam({ ...newTeam, description: e.target.value })
+                }
+                className="w-full border border-slate-300 rounded-md px-3 py-2 text-sm"
+              />
+            </div>
+            <div>
+              <label className="block text-xs font-semibold text-slate-700 mb-1">
+                Disclosure
+              </label>
+              <textarea
+                rows={2}
+                value={newTeam.disclosure}
+                onChange={(e) =>
+                  setNewTeam({ ...newTeam, disclosure: e.target.value })
+                }
+                className="w-full border border-slate-300 rounded-md px-3 py-2 text-sm"
+              />
+            </div>
+            <div>
+              <label className="block text-xs font-semibold text-slate-700 mb-1">
+                Accepted brief templates
+              </label>
+              <div className="flex flex-wrap gap-2">
+                {BRIEF_TEMPLATES.map((t) => {
+                  const checked = newTeam.accepted_brief_templates.includes(t);
+                  return (
+                    <button
+                      key={t}
+                      type="button"
+                      onClick={() =>
+                        setNewTeam({
+                          ...newTeam,
+                          accepted_brief_templates: checked
+                            ? newTeam.accepted_brief_templates.filter((x) => x !== t)
+                            : [...newTeam.accepted_brief_templates, t],
+                        })
+                      }
+                      className={`text-xs px-2 py-1 rounded-full border ${
+                        checked
+                          ? "bg-amber-100 border-amber-400 text-amber-900"
+                          : "bg-slate-100 border-slate-200 text-slate-700"
+                      }`}
+                    >
+                      {BRIEF_TEMPLATE_LABELS[t]}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={submitNewTeam}
+              className="inline-flex items-center gap-1.5 bg-slate-900 hover:bg-slate-800 text-white text-xs font-bold px-3 py-2 rounded-lg"
+            >
+              Save draft team
+            </button>
+          </div>
+        )}
+
+        {teams.length === 0 ? (
+          <p className="text-sm text-slate-500">
+            You don&apos;t have any teams yet. Create one above.
+          </p>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            {teams.map((t) => (
+              <button
+                key={t.id}
+                type="button"
+                onClick={() => setSelected(t.id)}
+                className={`text-left p-3 rounded-xl border ${
+                  selected === t.id
+                    ? "border-amber-500 ring-2 ring-amber-300 bg-amber-50"
+                    : "border-slate-200 hover:border-slate-300"
+                }`}
+              >
+                <p className="text-sm font-bold text-slate-900">{t.name}</p>
+                <p className="text-xs text-slate-500">
+                  {t.team_category.replace(/_/g, " ")} · {t.team_type.replace(/_/g, " ")}
+                </p>
+                <p className="text-[10px] font-semibold uppercase mt-1 tracking-widest text-slate-500">
+                  {t.verification_status}
+                </p>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {detail && (
+        <div className="bg-white rounded-2xl border border-slate-200 p-5">
+          <div className="flex items-center justify-between gap-4 mb-3">
+            <div>
+              <h2 className="text-base font-bold text-slate-900">
+                {detail.team.name}
+              </h2>
+              <p className="text-xs text-slate-500">
+                {detail.team.verification_status} ·
+                {detail.team.public ? " public" : " not listed"} ·
+                {detail.team.accepts_briefs ? " accepting briefs" : " not accepting briefs"}
+              </p>
+            </div>
+            {detail.team.verification_status === "draft" && (
+              <button
+                type="button"
+                onClick={submitForVerification}
+                className="inline-flex items-center gap-1.5 bg-slate-900 hover:bg-slate-800 text-white text-xs font-bold px-3 py-2 rounded-lg"
+              >
+                Submit for verification <Icon name="arrow-right" size={12} />
+              </button>
+            )}
+            {detail.team.verification_status === "verified" && (
+              <Link
+                href={`/teams/${detail.team.slug}`}
+                className="text-xs text-amber-600 underline"
+              >
+                View public profile
+              </Link>
+            )}
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+            <section>
+              <h3 className="text-xs font-bold text-slate-900 uppercase tracking-wider mb-2">
+                Members ({detail.members.filter((m) => m.status === "active").length})
+              </h3>
+              <ul className="space-y-1 text-sm text-slate-700">
+                {detail.members.map((m) => (
+                  <li key={m.id} className="flex items-center gap-2">
+                    <span className="w-1.5 h-1.5 rounded-full bg-slate-300" />
+                    Pro #{m.professional_id} · {m.member_role}
+                    <span
+                      className={`text-[10px] font-semibold uppercase tracking-wider ml-2 ${
+                        m.status === "active" ? "text-emerald-700" : "text-slate-400"
+                      }`}
+                    >
+                      {m.status}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </section>
+
+            <section>
+              <h3 className="text-xs font-bold text-slate-900 uppercase tracking-wider mb-2">
+                Invite a member
+              </h3>
+              <div className="flex items-center gap-2 mb-2">
+                <input
+                  type="email"
+                  placeholder="email@example.com"
+                  value={inviteEmail}
+                  onChange={(e) => setInviteEmail(e.target.value)}
+                  className="flex-1 border border-slate-300 rounded-md px-3 py-2 text-sm"
+                />
+                <input
+                  type="text"
+                  placeholder="role"
+                  value={inviteRole}
+                  onChange={(e) => setInviteRole(e.target.value)}
+                  className="w-28 border border-slate-300 rounded-md px-3 py-2 text-sm"
+                />
+                <button
+                  type="button"
+                  onClick={sendInvite}
+                  className="inline-flex items-center gap-1.5 bg-amber-500 hover:bg-amber-400 text-slate-900 text-xs font-bold px-3 py-2 rounded-lg"
+                >
+                  Invite
+                </button>
+              </div>
+              <ul className="text-xs text-slate-600 space-y-1 mt-3">
+                {detail.invitations.map((inv) => (
+                  <li key={inv.id} className="flex items-center justify-between">
+                    <span>
+                      {inv.email}
+                      <span className="text-slate-400 ml-2">· {inv.status}</span>
+                    </span>
+                    {inv.status === "pending" && (
+                      <code className="text-[10px] bg-slate-100 px-1 py-0.5 rounded">
+                        token={inv.token.slice(0, 8)}…
+                      </code>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </section>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/advisor-portal/teams/page.tsx
+++ b/app/advisor-portal/teams/page.tsx
@@ -1,0 +1,27 @@
+import type { Metadata } from "next";
+import TeamsManagerClient from "./TeamsManagerClient";
+
+export const metadata: Metadata = {
+  title: "Expert Teams — Advisor Portal",
+  robots: { index: false, follow: false },
+};
+
+export const dynamic = "force-dynamic";
+
+export default function AdvisorPortalTeamsPage() {
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <div className="max-w-5xl mx-auto px-4 py-8 sm:py-12">
+        <h1 className="text-2xl sm:text-3xl font-extrabold text-slate-900 mb-1">
+          Expert Teams
+        </h1>
+        <p className="text-sm text-slate-500 mb-8">
+          Create a multi-discipline team — same firm, independent
+          collaboration, or private referral. Verified teams can receive
+          structured Investor Briefs.
+        </p>
+        <TeamsManagerClient />
+      </div>
+    </div>
+  );
+}

--- a/app/advisors/page.tsx
+++ b/app/advisors/page.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from "react";
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
+import GetMatchedEmbed from "@/components/get-matched/GetMatchedEmbed";
 import { filterByCountryEligibility } from "@/lib/country-mode/eligibility-filter";
 import type { Professional, AdvisorFirm } from "@/lib/types";
 import type { Metadata } from "next";
@@ -93,6 +94,9 @@ async function AdvisorsData() {
   return (
     <>
       <ProviderTypeTabs teamCount={expertTeams.length} />
+      <div className="container-custom mt-3 mb-4">
+        <GetMatchedEmbed context="advisor_directory" />
+      </div>
       <AdvisorsClient
         professionals={professionals}
         firms={firms}

--- a/app/advisors/page.tsx
+++ b/app/advisors/page.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from "react";
+import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
 import { filterByCountryEligibility } from "@/lib/country-mode/eligibility-filter";
 import type { Professional, AdvisorFirm } from "@/lib/types";
@@ -32,7 +33,7 @@ async function AdvisorsData() {
   const supabase = await createClient();
   const { getIntentCountry } = await import("@/lib/intent-context-server");
 
-  const [proResult, firmResult, intentCountry] = await Promise.all([
+  const [proResult, firmResult, teamResult, intentCountry] = await Promise.all([
     supabase
       .from("professionals")
       .select("*")
@@ -45,6 +46,14 @@ async function AdvisorsData() {
       .select("*")
       .eq("status", "active")
       .order("name", { ascending: true }),
+    supabase
+      .from("expert_teams")
+      .select(
+        "id, slug, name, team_category, team_type, description, location_state, accepted_brief_templates, accepts_briefs, public, verification_status",
+      )
+      .eq("public", true)
+      .eq("verification_status", "verified")
+      .order("created_at", { ascending: false }),
     getIntentCountry(),
   ]);
 
@@ -60,6 +69,11 @@ async function AdvisorsData() {
     });
     throw new Error("Failed to load advisors. Please try again.");
   }
+  // expert_teams missing pre-migration → log but degrade gracefully (page still
+  // renders without the teams strip).
+  if (teamResult.error) {
+    log.warn("Expert teams fetch failed", { error: teamResult.error.message });
+  }
 
   // Hide advisors whose country_eligibility blocks the visitor's
   // intent country. Compounds with the per-card EligibilityBadge —
@@ -74,7 +88,123 @@ async function AdvisorsData() {
     if (p.firm_id) firmMemberCounts[p.firm_id] = (firmMemberCounts[p.firm_id] || 0) + 1;
   });
 
-  return <AdvisorsClient professionals={professionals} firms={firms} firmMemberCounts={firmMemberCounts} intentCountry={intentCountry} />;
+  const expertTeams = (teamResult.data ?? []) as ExpertTeamCard[];
+
+  return (
+    <>
+      <ProviderTypeTabs teamCount={expertTeams.length} />
+      <AdvisorsClient
+        professionals={professionals}
+        firms={firms}
+        firmMemberCounts={firmMemberCounts}
+        intentCountry={intentCountry}
+      />
+      {expertTeams.length > 0 && <ExpertTeamsStrip teams={expertTeams} />}
+    </>
+  );
+}
+
+interface ExpertTeamCard {
+  id: number;
+  slug: string;
+  name: string;
+  team_category: string;
+  team_type: string;
+  description: string | null;
+  location_state: string | null;
+  accepted_brief_templates: string[] | null;
+}
+
+function ProviderTypeTabs({ teamCount }: { teamCount: number }) {
+  return (
+    <div className="container-custom pt-4">
+      <div className="flex flex-wrap items-center gap-2 mb-2">
+        <Link
+          href="/advisors"
+          className="text-xs font-semibold uppercase tracking-wider bg-slate-900 text-white px-3 py-1.5 rounded-full"
+        >
+          All
+        </Link>
+        <Link
+          href="/advisors?provider_type=individual"
+          className="text-xs font-semibold uppercase tracking-wider bg-white text-slate-700 border border-slate-200 px-3 py-1.5 rounded-full hover:border-slate-300"
+        >
+          Individuals
+        </Link>
+        <Link
+          href="/advisors?provider_type=firm"
+          className="text-xs font-semibold uppercase tracking-wider bg-white text-slate-700 border border-slate-200 px-3 py-1.5 rounded-full hover:border-slate-300"
+        >
+          Firms &amp; Brokerages
+        </Link>
+        <a
+          href="#expert-teams"
+          className="text-xs font-semibold uppercase tracking-wider bg-emerald-50 text-emerald-800 border border-emerald-200 px-3 py-1.5 rounded-full hover:border-emerald-400"
+        >
+          Expert Teams ({teamCount})
+        </a>
+      </div>
+    </div>
+  );
+}
+
+function ExpertTeamsStrip({ teams }: { teams: ExpertTeamCard[] }) {
+  return (
+    <section
+      id="expert-teams"
+      className="container-custom mt-12 pb-10 border-t border-slate-200 pt-8"
+    >
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="text-xl font-extrabold text-slate-900">
+          Verified Expert Teams
+        </h2>
+        <span className="text-xs text-slate-500">
+          Multi-discipline teams that handle structured Investor Briefs
+        </span>
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {teams.map((t) => (
+          <article
+            key={t.id}
+            className="bg-white border border-slate-200 rounded-2xl p-5 hover:border-emerald-300 transition-colors"
+          >
+            <span className="text-[10px] font-bold uppercase tracking-widest text-emerald-700 bg-emerald-50 px-2 py-0.5 rounded">
+              Verified Expert Team
+            </span>
+            <h3 className="text-base font-bold text-slate-900 mt-2 mb-1">
+              <Link href={`/teams/${t.slug}`} className="hover:underline">
+                {t.name}
+              </Link>
+            </h3>
+            <p className="text-xs text-slate-500 mb-2">
+              {t.team_category.replace(/_/g, " ")} ·{" "}
+              {t.team_type.replace(/_/g, " ")}
+              {t.location_state ? ` · ${t.location_state}` : ""}
+            </p>
+            {t.description && (
+              <p className="text-sm text-slate-600 line-clamp-3 mb-3">
+                {t.description}
+              </p>
+            )}
+            <div className="flex gap-2">
+              <Link
+                href={`/teams/${t.slug}`}
+                className="text-xs font-semibold text-slate-900 bg-white border border-slate-200 rounded-md px-3 py-1.5 hover:border-slate-300"
+              >
+                View team
+              </Link>
+              <Link
+                href={`/briefs/new?team=${encodeURIComponent(t.slug)}`}
+                className="text-xs font-bold text-slate-900 bg-amber-500 hover:bg-amber-400 rounded-md px-3 py-1.5"
+              >
+                Create brief
+              </Link>
+            </div>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
 }
 
 export default function AdvisorsPage() {

--- a/app/api/admin/briefs/[id]/risk/route.ts
+++ b/app/api/admin/briefs/[id]/risk/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+import { requireAdmin } from "@/lib/require-admin";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+
+const log = logger("admin:briefs:risk");
+
+const Body = z.object({
+  action: z.enum(["approve", "reject"]),
+  note: z.string().max(2000).optional(),
+});
+
+export async function POST(
+  request: NextRequest,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  const guard = await requireAdmin();
+  if (!guard.ok) return guard.response;
+
+  const { id } = await ctx.params;
+  const briefId = Number(id);
+  if (!Number.isFinite(briefId)) {
+    return NextResponse.json({ error: "Invalid brief id." }, { status: 400 });
+  }
+
+  let rawBody: unknown;
+  try {
+    rawBody = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+  const parsed = Body.safeParse(rawBody);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.issues[0]?.message || "Invalid body." },
+      { status: 400 },
+    );
+  }
+
+  const admin = createAdminClient();
+  const updates =
+    parsed.data.action === "approve"
+      ? { risk_review_status: "approved" }
+      : { risk_review_status: "rejected", status: "closed" };
+
+  await admin.from("advisor_auctions").update(updates).eq("id", briefId);
+  await admin.from("brief_tracker_events").insert({
+    brief_id: briefId,
+    event_type: parsed.data.action === "approve" ? "risk_approved" : "risk_rejected",
+    actor_kind: "admin",
+    actor_id: guard.email,
+    payload: { note: parsed.data.note ?? null },
+  });
+
+  log.info("Brief risk review actioned", {
+    briefId,
+    action: parsed.data.action,
+    by: guard.email,
+  });
+  return NextResponse.json({ success: true });
+}

--- a/app/api/admin/credit-pricing/route.ts
+++ b/app/api/admin/credit-pricing/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+import { requireAdmin } from "@/lib/require-admin";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { BRIEF_TEMPLATES } from "@/lib/api-schemas";
+
+const Upsert = z.object({
+  rows: z.array(
+    z.object({
+      brief_template: z.enum(BRIEF_TEMPLATES),
+      provider_type: z.enum(["any", "individual", "firm", "expert_team"]),
+      credits_cost: z.number().int().min(0).max(1000),
+      notes: z.string().max(500).optional(),
+    }),
+  ),
+});
+
+export async function GET() {
+  const guard = await requireAdmin();
+  if (!guard.ok) return guard.response;
+  const admin = createAdminClient();
+  const { data } = await admin
+    .from("brief_credit_prices")
+    .select("*")
+    .order("brief_template", { ascending: true });
+  return NextResponse.json({ prices: data ?? [] });
+}
+
+export async function PUT(request: NextRequest) {
+  const guard = await requireAdmin();
+  if (!guard.ok) return guard.response;
+  let rawBody: unknown;
+  try {
+    rawBody = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+  const parsed = Upsert.safeParse(rawBody);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.issues[0]?.message || "Invalid body." },
+      { status: 400 },
+    );
+  }
+  const admin = createAdminClient();
+  for (const row of parsed.data.rows) {
+    await admin
+      .from("brief_credit_prices")
+      .upsert(
+        {
+          ...row,
+          updated_by: guard.email,
+          updated_at: new Date().toISOString(),
+        },
+        { onConflict: "brief_template,provider_type" },
+      );
+  }
+  return NextResponse.json({ success: true, count: parsed.data.rows.length });
+}

--- a/app/api/admin/expert-teams/[id]/verify/route.ts
+++ b/app/api/admin/expert-teams/[id]/verify/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { requireAdmin } from "@/lib/require-admin";
+import { AdminVerifyExpertTeamRequest } from "@/lib/api-schemas";
+import { adminVerify, getTeamById } from "@/lib/expert-teams";
+import { logger } from "@/lib/logger";
+
+const log = logger("admin:expert-teams:verify");
+
+export async function POST(
+  request: NextRequest,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  const guard = await requireAdmin();
+  if (!guard.ok) return guard.response;
+
+  const { id } = await ctx.params;
+  const teamId = Number(id);
+  if (!Number.isFinite(teamId)) {
+    return NextResponse.json({ error: "Invalid team id." }, { status: 400 });
+  }
+  let rawBody: unknown;
+  try {
+    rawBody = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+  const parsed = AdminVerifyExpertTeamRequest.safeParse(rawBody);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.issues[0]?.message || "Invalid body." },
+      { status: 400 },
+    );
+  }
+
+  const existing = await getTeamById(teamId);
+  if (!existing) {
+    return NextResponse.json({ error: "Team not found." }, { status: 404 });
+  }
+
+  const team = await adminVerify({
+    teamId,
+    approved: parsed.data.approved,
+    rejectionReason: parsed.data.rejection_reason,
+    acceptsBriefs: parsed.data.accepts_briefs,
+  });
+  log.info("Expert team verification updated", {
+    teamId,
+    approved: parsed.data.approved,
+    by: guard.email,
+  });
+  return NextResponse.json({ team });
+}

--- a/app/api/admin/get-matched/funnel/route.ts
+++ b/app/api/admin/get-matched/funnel/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from "next/server";
+
+import { requireAdmin } from "@/lib/require-admin";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+export async function GET() {
+  const guard = await requireAdmin();
+  if (!guard.ok) return guard.response;
+
+  const admin = createAdminClient();
+  const since = new Date(Date.now() - 30 * 86_400_000).toISOString();
+
+  const { data } = await admin
+    .from("get_matched_events")
+    .select("event_type, payload, created_at")
+    .gte("created_at", since)
+    .order("created_at", { ascending: false })
+    .limit(5000);
+
+  const rows = (data ?? []) as {
+    event_type: string;
+    payload: Record<string, unknown> | null;
+    created_at: string;
+  }[];
+
+  const totals: Record<string, number> = {};
+  const routeCounts: Record<string, number> = {};
+  const intentCounts: Record<string, number> = {};
+
+  for (const row of rows) {
+    totals[row.event_type] = (totals[row.event_type] ?? 0) + 1;
+    if (row.event_type === "plan_shown") {
+      const route = String(row.payload?.route ?? "unknown");
+      const intent = String(row.payload?.intent ?? "unknown");
+      routeCounts[route] = (routeCounts[route] ?? 0) + 1;
+      intentCounts[intent] = (intentCounts[intent] ?? 0) + 1;
+    }
+  }
+
+  return NextResponse.json({
+    since,
+    totals,
+    routeCounts,
+    intentCounts,
+    sampleCount: rows.length,
+  });
+}

--- a/app/api/admin/get-matched/questions/route.ts
+++ b/app/api/admin/get-matched/questions/route.ts
@@ -1,0 +1,82 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+import { requireAdmin } from "@/lib/require-admin";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { GM_QUESTION_MODES } from "@/lib/api-schemas";
+
+const Upsert = z.object({
+  id: z.number().int().positive().optional(),
+  slug: z.string().min(2).max(80),
+  step: z.number().int().min(0).max(50).default(0),
+  kind: z.enum(["select", "multiselect", "text", "number", "contextual"]),
+  prompt: z.string().min(3).max(400),
+  subtitle: z.string().max(400).optional(),
+  options: z.array(z.record(z.string(), z.unknown())).max(40).default([]),
+  shown_if: z.record(z.string(), z.unknown()).default({}),
+  maps_to: z.string().min(1).max(80),
+  risk_weight: z.number().int().min(0).max(100).default(0),
+  mode: z.enum(GM_QUESTION_MODES).default("both"),
+  enabled: z.boolean().default(true),
+  sort_order: z.number().int().min(0).max(10000).default(100),
+});
+
+export async function GET() {
+  const guard = await requireAdmin();
+  if (!guard.ok) return guard.response;
+  const admin = createAdminClient();
+  const { data } = await admin
+    .from("get_matched_questions")
+    .select("*")
+    .order("step", { ascending: true })
+    .order("sort_order", { ascending: true });
+  return NextResponse.json({ questions: data ?? [] });
+}
+
+export async function PUT(request: NextRequest) {
+  const guard = await requireAdmin();
+  if (!guard.ok) return guard.response;
+
+  let rawBody: unknown;
+  try {
+    rawBody = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+  const parsed = Upsert.safeParse(rawBody);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.issues[0]?.message ?? "Invalid body." },
+      { status: 400 },
+    );
+  }
+  const admin = createAdminClient();
+  const { id, ...payload } = parsed.data;
+  if (id) {
+    const { data } = await admin
+      .from("get_matched_questions")
+      .update({ ...payload, updated_at: new Date().toISOString() })
+      .eq("id", id)
+      .select("*")
+      .single();
+    return NextResponse.json({ question: data });
+  }
+  const { data } = await admin
+    .from("get_matched_questions")
+    .upsert(payload, { onConflict: "slug" })
+    .select("*")
+    .single();
+  return NextResponse.json({ question: data });
+}
+
+export async function DELETE(request: NextRequest) {
+  const guard = await requireAdmin();
+  if (!guard.ok) return guard.response;
+  const id = Number(request.nextUrl.searchParams.get("id"));
+  if (!Number.isFinite(id)) {
+    return NextResponse.json({ error: "Invalid id." }, { status: 400 });
+  }
+  const admin = createAdminClient();
+  await admin.from("get_matched_questions").delete().eq("id", id);
+  return NextResponse.json({ success: true });
+}

--- a/app/api/admin/get-matched/result-templates/route.ts
+++ b/app/api/admin/get-matched/result-templates/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+import { requireAdmin } from "@/lib/require-admin";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { GM_INTENT_SLUGS, GM_ROUTE_TYPES } from "@/lib/api-schemas";
+
+const ChecklistItem = z.object({
+  label: z.string().min(1).max(200),
+  href: z.string().max(500).optional(),
+  brief_template: z.string().max(80).optional(),
+});
+
+const Cta = z.object({
+  label: z.string().min(1).max(120),
+  href: z.string().min(1).max(500),
+});
+
+const CrossSell = z.object({
+  label: z.string().min(1).max(160),
+  href: z.string().min(1).max(500),
+  icon: z.string().max(40).optional(),
+});
+
+const Upsert = z.object({
+  id: z.number().int().positive().optional(),
+  route: z.enum(GM_ROUTE_TYPES),
+  intent_slug: z.enum(GM_INTENT_SLUGS).nullable().optional(),
+  headline: z.string().min(3).max(200),
+  why_text: z.string().min(3).max(2000),
+  checklist: z.array(ChecklistItem).max(10).default([]),
+  primary_cta: Cta,
+  secondary_ctas: z.array(Cta).max(3).default([]),
+  cross_sells: z.array(CrossSell).max(3).default([]),
+  enabled: z.boolean().default(true),
+});
+
+export async function GET() {
+  const guard = await requireAdmin();
+  if (!guard.ok) return guard.response;
+  const admin = createAdminClient();
+  const { data } = await admin
+    .from("get_matched_result_templates")
+    .select("*")
+    .order("route", { ascending: true })
+    .order("intent_slug", { ascending: true, nullsFirst: true });
+  return NextResponse.json({ templates: data ?? [] });
+}
+
+export async function PUT(request: NextRequest) {
+  const guard = await requireAdmin();
+  if (!guard.ok) return guard.response;
+
+  let rawBody: unknown;
+  try {
+    rawBody = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+  const parsed = Upsert.safeParse(rawBody);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.issues[0]?.message ?? "Invalid body." },
+      { status: 400 },
+    );
+  }
+  const admin = createAdminClient();
+  const { id, ...payload } = parsed.data;
+  const updated_by = guard.email;
+  const updated_at = new Date().toISOString();
+  if (id) {
+    const { data } = await admin
+      .from("get_matched_result_templates")
+      .update({ ...payload, updated_by, updated_at })
+      .eq("id", id)
+      .select("*")
+      .single();
+    return NextResponse.json({ template: data });
+  }
+  const { data } = await admin
+    .from("get_matched_result_templates")
+    .upsert(
+      { ...payload, updated_by, updated_at },
+      { onConflict: "route,intent_slug" },
+    )
+    .select("*")
+    .single();
+  return NextResponse.json({ template: data });
+}
+
+export async function DELETE(request: NextRequest) {
+  const guard = await requireAdmin();
+  if (!guard.ok) return guard.response;
+  const id = Number(request.nextUrl.searchParams.get("id"));
+  if (!Number.isFinite(id)) {
+    return NextResponse.json({ error: "Invalid id." }, { status: 400 });
+  }
+  const admin = createAdminClient();
+  await admin.from("get_matched_result_templates").delete().eq("id", id);
+  return NextResponse.json({ success: true });
+}

--- a/app/api/admin/intents/route.ts
+++ b/app/api/admin/intents/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+import { requireAdmin } from "@/lib/require-admin";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { GM_INTENT_SLUGS, GM_ROUTE_TYPES } from "@/lib/api-schemas";
+
+const Upsert = z.object({
+  id: z.number().int().positive().optional(),
+  slug: z.enum(GM_INTENT_SLUGS),
+  label: z.string().min(2).max(120),
+  description: z.string().max(2000).optional(),
+  default_route: z.enum(GM_ROUTE_TYPES),
+  default_brief_template: z.string().max(80).optional().nullable(),
+  risk_level: z.enum(["low", "medium", "high"]).default("low"),
+  enabled: z.boolean().default(true),
+  sort_order: z.number().int().min(0).max(10000).default(100),
+});
+
+export async function GET() {
+  const guard = await requireAdmin();
+  if (!guard.ok) return guard.response;
+  const admin = createAdminClient();
+  const { data } = await admin
+    .from("intent_taxonomy")
+    .select("*")
+    .order("sort_order", { ascending: true });
+  return NextResponse.json({ intents: data ?? [] });
+}
+
+export async function PUT(request: NextRequest) {
+  const guard = await requireAdmin();
+  if (!guard.ok) return guard.response;
+
+  let rawBody: unknown;
+  try {
+    rawBody = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+  const parsed = Upsert.safeParse(rawBody);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.issues[0]?.message ?? "Invalid body." },
+      { status: 400 },
+    );
+  }
+  const admin = createAdminClient();
+  const { id, ...payload } = parsed.data;
+  if (id) {
+    const { data } = await admin
+      .from("intent_taxonomy")
+      .update({ ...payload, updated_at: new Date().toISOString() })
+      .eq("id", id)
+      .select("*")
+      .single();
+    return NextResponse.json({ intent: data });
+  }
+  const { data } = await admin
+    .from("intent_taxonomy")
+    .upsert(payload, { onConflict: "slug" })
+    .select("*")
+    .single();
+  return NextResponse.json({ intent: data });
+}

--- a/app/api/admin/risk-patterns/route.ts
+++ b/app/api/admin/risk-patterns/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+import { requireAdmin } from "@/lib/require-admin";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+const CreateOrUpdate = z.object({
+  id: z.number().int().positive().optional(),
+  pattern: z.string().min(2).max(200),
+  category: z.string().min(2).max(80),
+  severity: z.enum(["warn", "review", "block"]),
+  enabled: z.boolean().default(true),
+  notes: z.string().max(500).optional(),
+});
+
+export async function GET() {
+  const guard = await requireAdmin();
+  if (!guard.ok) return guard.response;
+  const admin = createAdminClient();
+  const { data } = await admin
+    .from("brief_risk_patterns")
+    .select("*")
+    .order("severity", { ascending: false });
+  return NextResponse.json({ patterns: data ?? [] });
+}
+
+export async function PUT(request: NextRequest) {
+  const guard = await requireAdmin();
+  if (!guard.ok) return guard.response;
+  let rawBody: unknown;
+  try {
+    rawBody = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+  const parsed = CreateOrUpdate.safeParse(rawBody);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.issues[0]?.message || "Invalid body." },
+      { status: 400 },
+    );
+  }
+  const admin = createAdminClient();
+  const { id, ...payload } = parsed.data;
+  if (id) {
+    const { data } = await admin
+      .from("brief_risk_patterns")
+      .update(payload)
+      .eq("id", id)
+      .select("*")
+      .single();
+    return NextResponse.json({ pattern: data });
+  }
+  const { data } = await admin
+    .from("brief_risk_patterns")
+    .upsert(payload, { onConflict: "pattern,category" })
+    .select("*")
+    .single();
+  return NextResponse.json({ pattern: data });
+}
+
+export async function DELETE(request: NextRequest) {
+  const guard = await requireAdmin();
+  if (!guard.ok) return guard.response;
+  const idStr = request.nextUrl.searchParams.get("id");
+  const id = Number(idStr);
+  if (!Number.isFinite(id)) {
+    return NextResponse.json({ error: "Invalid id." }, { status: 400 });
+  }
+  const admin = createAdminClient();
+  await admin.from("brief_risk_patterns").delete().eq("id", id);
+  return NextResponse.json({ success: true });
+}

--- a/app/api/admin/routing-rules/route.ts
+++ b/app/api/admin/routing-rules/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+import { requireAdmin } from "@/lib/require-admin";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+const CreateOrUpdate = z.object({
+  id: z.number().int().positive().optional(),
+  name: z.string().min(3).max(120),
+  priority: z.number().int().min(0).max(10000).default(100),
+  enabled: z.boolean().default(true),
+  match_conditions: z.record(z.string(), z.unknown()).default({}),
+  route_to: z.record(z.string(), z.unknown()).default({}),
+  notes: z.string().max(2000).optional(),
+});
+
+export async function GET() {
+  const guard = await requireAdmin();
+  if (!guard.ok) return guard.response;
+  const admin = createAdminClient();
+  const { data } = await admin
+    .from("brief_routing_rules")
+    .select("*")
+    .order("priority", { ascending: true });
+  return NextResponse.json({ rules: data ?? [] });
+}
+
+export async function PUT(request: NextRequest) {
+  const guard = await requireAdmin();
+  if (!guard.ok) return guard.response;
+  let rawBody: unknown;
+  try {
+    rawBody = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+  const parsed = CreateOrUpdate.safeParse(rawBody);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.issues[0]?.message || "Invalid body." },
+      { status: 400 },
+    );
+  }
+  const admin = createAdminClient();
+  const { id, ...payload } = parsed.data;
+  if (id) {
+    const { data } = await admin
+      .from("brief_routing_rules")
+      .update({ ...payload, updated_by: guard.email, updated_at: new Date().toISOString() })
+      .eq("id", id)
+      .select("*")
+      .single();
+    return NextResponse.json({ rule: data });
+  }
+  const { data } = await admin
+    .from("brief_routing_rules")
+    .insert({ ...payload, updated_by: guard.email })
+    .select("*")
+    .single();
+  return NextResponse.json({ rule: data });
+}
+
+export async function DELETE(request: NextRequest) {
+  const guard = await requireAdmin();
+  if (!guard.ok) return guard.response;
+  const idStr = request.nextUrl.searchParams.get("id");
+  const id = Number(idStr);
+  if (!Number.isFinite(id)) {
+    return NextResponse.json({ error: "Invalid id." }, { status: 400 });
+  }
+  const admin = createAdminClient();
+  await admin.from("brief_routing_rules").delete().eq("id", id);
+  return NextResponse.json({ success: true });
+}

--- a/app/api/briefs/[slug]/accept/route.ts
+++ b/app/api/briefs/[slug]/accept/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 
 import { createAdminClient } from "@/lib/supabase/admin";
 import { requireAdvisorSession } from "@/lib/require-advisor-session";
+import { isAllowed, ipKey } from "@/lib/rate-limit-db";
 import { logger } from "@/lib/logger";
 import { AcceptBriefRequest } from "@/lib/api-schemas";
 import { acceptBrief } from "@/lib/briefs/credits";
@@ -14,6 +15,9 @@ export async function POST(
   ctx: { params: Promise<{ slug: string }> },
 ) {
   try {
+    if (!(await isAllowed("briefs_accept", ipKey(request), { max: 30, refillPerSec: 0.5 }))) {
+      return NextResponse.json({ error: "Too many requests." }, { status: 429 });
+    }
     const advisorId = await requireAdvisorSession(request);
     if (!advisorId) {
       return NextResponse.json({ error: "Sign in required." }, { status: 401 });

--- a/app/api/briefs/[slug]/accept/route.ts
+++ b/app/api/briefs/[slug]/accept/route.ts
@@ -1,0 +1,115 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { createAdminClient } from "@/lib/supabase/admin";
+import { requireAdvisorSession } from "@/lib/require-advisor-session";
+import { logger } from "@/lib/logger";
+import { AcceptBriefRequest } from "@/lib/api-schemas";
+import { acceptBrief } from "@/lib/briefs/credits";
+import { isProfessionalOnTeam } from "@/lib/expert-teams";
+
+const log = logger("briefs:accept");
+
+export async function POST(
+  request: NextRequest,
+  ctx: { params: Promise<{ slug: string }> },
+) {
+  try {
+    const advisorId = await requireAdvisorSession(request);
+    if (!advisorId) {
+      return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+    }
+    const { slug } = await ctx.params;
+
+    let rawBody: unknown = {};
+    try {
+      rawBody = await request.json();
+    } catch {
+      // Body is optional — empty defaults handled by schema.
+    }
+    const parsed = AcceptBriefRequest.safeParse(rawBody);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.issues[0]?.message || "Invalid body." },
+        { status: 400 },
+      );
+    }
+
+    const admin = createAdminClient();
+    const { data: brief } = await admin
+      .from("advisor_auctions")
+      .select("id, contact_email, contact_name, contact_phone")
+      .eq("slug", slug)
+      .eq("flow_type", "accept")
+      .maybeSingle();
+
+    if (!brief) {
+      return NextResponse.json({ error: "Brief not found." }, { status: 404 });
+    }
+
+    // If team_id supplied, verify the advisor is an active member.
+    const teamId = parsed.data.team_id ?? null;
+    if (teamId !== null) {
+      const isMember = await isProfessionalOnTeam(teamId, advisorId);
+      if (!isMember) {
+        return NextResponse.json(
+          { error: "You are not an active member of this team." },
+          { status: 403 },
+        );
+      }
+    }
+
+    const result = await acceptBrief({
+      briefId: brief.id as number,
+      professionalId: advisorId,
+      teamId,
+    });
+
+    if (!result.accepted) {
+      const map: Record<string, { code: number; message: string }> = {
+        already_accepted: {
+          code: 409,
+          message: "Another provider has already accepted this brief.",
+        },
+        not_acceptable: {
+          code: 400,
+          message: "This brief is no longer accepting providers.",
+        },
+        insufficient_credits: {
+          code: 402,
+          message: "You do not have enough credits. Top up to accept this brief.",
+        },
+        brief_not_found: { code: 404, message: "Brief not found." },
+        risk_held: {
+          code: 403,
+          message: "This brief is held for review and is not available yet.",
+        },
+      };
+      const m = map[result.reason] ?? { code: 400, message: "Could not accept." };
+      return NextResponse.json({ error: m.message, reason: result.reason }, { status: m.code });
+    }
+
+    log.info("Brief accepted", {
+      briefId: brief.id,
+      professionalId: advisorId,
+      teamId,
+      credits: result.creditsSpent,
+    });
+
+    return NextResponse.json({
+      success: true,
+      credits_spent: result.creditsSpent,
+      balance_after_cents: result.balanceAfterCents,
+      contact: {
+        name: brief.contact_name,
+        email: brief.contact_email,
+        phone: brief.contact_phone,
+      },
+      brief: result.brief,
+    });
+  } catch (err) {
+    log.error("accept error", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json({ error: "Failed to accept brief." }, { status: 500 });
+  }
+}

--- a/app/api/briefs/[slug]/preview/route.ts
+++ b/app/api/briefs/[slug]/preview/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { createAdminClient } from "@/lib/supabase/admin";
+import { requireAdvisorSession } from "@/lib/require-advisor-session";
+import { logger } from "@/lib/logger";
+import { maskBriefForProvider } from "@/lib/briefs/mask";
+import { getAcceptCost } from "@/lib/briefs/credits";
+import type { BriefRow, ProviderKind } from "@/lib/briefs/types";
+
+const log = logger("briefs:preview");
+
+function providerKindForPref(p: string | null): ProviderKind {
+  if (p === "firm") return "firm";
+  if (p === "expert_team") return "expert_team";
+  return "individual";
+}
+
+export async function GET(
+  request: NextRequest,
+  ctx: { params: Promise<{ slug: string }> },
+) {
+  try {
+    const advisorId = await requireAdvisorSession(request);
+    if (!advisorId) {
+      return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+    }
+    const { slug } = await ctx.params;
+    const admin = createAdminClient();
+    const { data } = await admin
+      .from("advisor_auctions")
+      .select("*")
+      .eq("slug", slug)
+      .eq("flow_type", "accept")
+      .maybeSingle();
+    if (!data) {
+      return NextResponse.json({ error: "Brief not found." }, { status: 404 });
+    }
+    const brief = data as unknown as BriefRow;
+
+    // If risk-held, providers can't preview the contents — show a stub.
+    if (
+      brief.risk_review_status !== "clear" &&
+      brief.risk_review_status !== "approved"
+    ) {
+      return NextResponse.json({
+        masked: true,
+        held_for_review: true,
+        slug: brief.slug,
+        status: brief.status,
+      });
+    }
+
+    const masked = maskBriefForProvider(brief);
+
+    // If a provider preference was set but cost wasn't yet locked in,
+    // surface the live cost for the calling provider's kind. The
+    // accept_credits_cost stamped on the row remains the contract.
+    if (masked.accept_credits_cost == null && masked.brief_template) {
+      masked.accept_credits_cost = await getAcceptCost({
+        briefTemplate: masked.brief_template,
+        providerKind: providerKindForPref(masked.provider_preference),
+      });
+    }
+
+    return NextResponse.json({ masked: true, brief: masked });
+  } catch (err) {
+    log.error("preview error", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json({ error: "Failed to load brief." }, { status: 500 });
+  }
+}

--- a/app/api/briefs/[slug]/preview/route.ts
+++ b/app/api/briefs/[slug]/preview/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 
 import { createAdminClient } from "@/lib/supabase/admin";
 import { requireAdvisorSession } from "@/lib/require-advisor-session";
+import { isAllowed, ipKey } from "@/lib/rate-limit-db";
 import { logger } from "@/lib/logger";
 import { maskBriefForProvider } from "@/lib/briefs/mask";
 import { getAcceptCost } from "@/lib/briefs/credits";
@@ -20,6 +21,9 @@ export async function GET(
   ctx: { params: Promise<{ slug: string }> },
 ) {
   try {
+    if (!(await isAllowed("briefs_preview", ipKey(request), { max: 60, refillPerSec: 1 }))) {
+      return NextResponse.json({ error: "Too many requests." }, { status: 429 });
+    }
     const advisorId = await requireAdvisorSession(request);
     if (!advisorId) {
       return NextResponse.json({ error: "Sign in required." }, { status: 401 });

--- a/app/api/briefs/[slug]/status/route.ts
+++ b/app/api/briefs/[slug]/status/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { createAdminClient } from "@/lib/supabase/admin";
+import { requireAdvisorSession } from "@/lib/require-advisor-session";
+import { logger } from "@/lib/logger";
+import { BriefStatusUpdateRequest } from "@/lib/api-schemas";
+import { updateTrackerStatus } from "@/lib/briefs/credits";
+
+const log = logger("briefs:status");
+
+export async function POST(
+  request: NextRequest,
+  ctx: { params: Promise<{ slug: string }> },
+) {
+  try {
+    const advisorId = await requireAdvisorSession(request);
+    if (!advisorId) {
+      return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+    }
+    const { slug } = await ctx.params;
+    let rawBody: unknown;
+    try {
+      rawBody = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+    }
+    const parsed = BriefStatusUpdateRequest.safeParse(rawBody);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.issues[0]?.message || "Invalid body." },
+        { status: 400 },
+      );
+    }
+
+    const admin = createAdminClient();
+    const { data: brief } = await admin
+      .from("advisor_auctions")
+      .select("id, accepted_by_professional_id")
+      .eq("slug", slug)
+      .eq("flow_type", "accept")
+      .maybeSingle();
+    if (!brief) {
+      return NextResponse.json({ error: "Brief not found." }, { status: 404 });
+    }
+
+    const result = await updateTrackerStatus({
+      briefId: brief.id as number,
+      professionalId: advisorId,
+      newStatus: parsed.data.tracker_status,
+      note: parsed.data.note,
+    });
+    if (!result.ok) {
+      return NextResponse.json(
+        { error: result.reason ?? "Could not update status." },
+        { status: 403 },
+      );
+    }
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    log.error("status error", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json({ error: "Failed to update status." }, { status: 500 });
+  }
+}

--- a/app/api/briefs/[slug]/status/route.ts
+++ b/app/api/briefs/[slug]/status/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 
 import { createAdminClient } from "@/lib/supabase/admin";
 import { requireAdvisorSession } from "@/lib/require-advisor-session";
+import { isAllowed, ipKey } from "@/lib/rate-limit-db";
 import { logger } from "@/lib/logger";
 import { BriefStatusUpdateRequest } from "@/lib/api-schemas";
 import { updateTrackerStatus } from "@/lib/briefs/credits";
@@ -13,6 +14,9 @@ export async function POST(
   ctx: { params: Promise<{ slug: string }> },
 ) {
   try {
+    if (!(await isAllowed("briefs_status", ipKey(request), { max: 60, refillPerSec: 1 }))) {
+      return NextResponse.json({ error: "Too many requests." }, { status: 429 });
+    }
     const advisorId = await requireAdvisorSession(request);
     if (!advisorId) {
       return NextResponse.json({ error: "Sign in required." }, { status: 401 });

--- a/app/api/briefs/[slug]/withdraw/route.ts
+++ b/app/api/briefs/[slug]/withdraw/route.ts
@@ -1,0 +1,78 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+
+const log = logger("briefs:withdraw");
+
+const Body = z.object({
+  contact_email: z.string().email().max(200),
+});
+
+/**
+ * POST /api/briefs/[slug]/withdraw — User withdraws an open brief.
+ *
+ * Auth: email-as-key (matches the contact_email used to create the
+ * brief). Mirrors the consumer-side accept flow at
+ * /api/quotes/[slug]/accept.
+ */
+export async function POST(
+  request: NextRequest,
+  ctx: { params: Promise<{ slug: string }> },
+) {
+  try {
+    const { slug } = await ctx.params;
+    let rawBody: unknown;
+    try {
+      rawBody = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+    }
+    const parsed = Body.safeParse(rawBody);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.issues[0]?.message ?? "Invalid body." },
+        { status: 400 },
+      );
+    }
+    const email = parsed.data.contact_email;
+
+    const admin = createAdminClient();
+    const { data: brief } = await admin
+      .from("advisor_auctions")
+      .select("id, contact_email, status")
+      .eq("slug", slug)
+      .eq("flow_type", "accept")
+      .maybeSingle();
+    if (!brief) {
+      return NextResponse.json({ error: "Brief not found." }, { status: 404 });
+    }
+    if ((brief.contact_email as string).toLowerCase() !== email.toLowerCase().trim()) {
+      return NextResponse.json({ error: "Verification failed." }, { status: 403 });
+    }
+    if (brief.status === "withdrawn" || brief.status === "closed") {
+      return NextResponse.json({ error: "Brief is already closed." }, { status: 400 });
+    }
+
+    await admin
+      .from("advisor_auctions")
+      .update({ status: "closed", tracker_status: "withdrawn" })
+      .eq("id", brief.id);
+
+    await admin.from("brief_tracker_events").insert({
+      brief_id: brief.id,
+      event_type: "status_changed",
+      actor_kind: "user",
+      payload: { to: "withdrawn" },
+    });
+
+    log.info("Brief withdrawn", { briefId: brief.id });
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    log.error("withdraw error", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json({ error: "Failed to withdraw brief." }, { status: 500 });
+  }
+}

--- a/app/api/briefs/[slug]/withdraw/route.ts
+++ b/app/api/briefs/[slug]/withdraw/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 
 import { createAdminClient } from "@/lib/supabase/admin";
+import { isAllowed, ipKey } from "@/lib/rate-limit-db";
 import { logger } from "@/lib/logger";
 
 const log = logger("briefs:withdraw");
@@ -22,6 +23,9 @@ export async function POST(
   ctx: { params: Promise<{ slug: string }> },
 ) {
   try {
+    if (!(await isAllowed("briefs_withdraw", ipKey(request), { max: 10, refillPerSec: 0.1 }))) {
+      return NextResponse.json({ error: "Too many requests." }, { status: 429 });
+    }
     const { slug } = await ctx.params;
     let rawBody: unknown;
     try {

--- a/app/api/briefs/inbox/route.ts
+++ b/app/api/briefs/inbox/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 
 import { requireAdvisorSession } from "@/lib/require-advisor-session";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { isAllowed, ipKey } from "@/lib/rate-limit-db";
 import { maskBriefForProvider } from "@/lib/briefs/mask";
 import { logger } from "@/lib/logger";
 import type { BriefRow } from "@/lib/briefs/types";
@@ -27,6 +28,9 @@ const log = logger("briefs:inbox");
  */
 export async function GET(request: NextRequest) {
   try {
+    if (!(await isAllowed("briefs_inbox", ipKey(request), { max: 60, refillPerSec: 1 }))) {
+      return NextResponse.json({ error: "Too many requests." }, { status: 429 });
+    }
     const advisorId = await requireAdvisorSession(request);
     if (!advisorId) {
       return NextResponse.json({ error: "Sign in required." }, { status: 401 });

--- a/app/api/briefs/inbox/route.ts
+++ b/app/api/briefs/inbox/route.ts
@@ -1,0 +1,114 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { requireAdvisorSession } from "@/lib/require-advisor-session";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { maskBriefForProvider } from "@/lib/briefs/mask";
+import { logger } from "@/lib/logger";
+import type { BriefRow } from "@/lib/briefs/types";
+
+const log = logger("briefs:inbox");
+
+/**
+ * GET /api/briefs/inbox — returns the calling provider's brief inbox.
+ *
+ * Two buckets:
+ *   - `available`: open accept-flow briefs the provider is eligible for
+ *     (masked previews, no PII).
+ *   - `accepted`: briefs already accepted by this provider, with full
+ *     contact details.
+ *
+ * Eligibility heuristic (MVP):
+ *   - brief.status = 'open' AND flow_type = 'accept' AND
+ *     risk_review_status IN ('clear','approved') AND
+ *     accepted_by_professional_id IS NULL.
+ *   - Either: provider_preference = 'any'|'individual'|'multiple', OR
+ *     provider is on an active expert team that matches target_team_id.
+ *   - Direct-targeted briefs only show to the targeted entity.
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const advisorId = await requireAdvisorSession(request);
+    if (!advisorId) {
+      return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+    }
+
+    const admin = createAdminClient();
+
+    const { data: memberships } = await admin
+      .from("expert_team_members")
+      .select("team_id")
+      .eq("professional_id", advisorId)
+      .eq("status", "active");
+    const teamIds = (memberships ?? []).map((m) => m.team_id as number);
+
+    const { data: advisor } = await admin
+      .from("professionals")
+      .select("type, firm_id")
+      .eq("id", advisorId)
+      .maybeSingle();
+
+    // ── Available bucket ────────────────────────────────────────────
+    const { data: openBriefs } = await admin
+      .from("advisor_auctions")
+      .select("*")
+      .eq("flow_type", "accept")
+      .eq("status", "open")
+      .in("risk_review_status", ["clear", "approved"])
+      .is("accepted_by_professional_id", null)
+      .is("accepted_by_team_id", null)
+      .order("created_at", { ascending: false })
+      .limit(100);
+
+    const available = (openBriefs ?? [])
+      .filter((row) => {
+        const b = row as unknown as BriefRow;
+        // Direct-targeted briefs: only the matched provider sees them.
+        if (b.routing_mode === "direct") {
+          if (b.target_professional_id === advisorId) return true;
+          if (b.target_team_id && teamIds.includes(b.target_team_id)) return true;
+          if (b.target_firm_id && advisor?.firm_id === b.target_firm_id) return true;
+          return false;
+        }
+        // Preference filter.
+        if (b.provider_preference === "expert_team" && teamIds.length === 0) return false;
+        if (b.provider_preference === "firm" && !advisor?.firm_id) return false;
+        if (b.provider_preference === "individual") {
+          // Anyone with a professional row counts.
+        }
+        // Optional advisor_types filter — only if the brief specified types
+        // and the professional has a type assigned.
+        if (
+          b.advisor_types &&
+          b.advisor_types.length > 0 &&
+          advisor?.type &&
+          !b.advisor_types.includes(advisor.type)
+        ) {
+          return false;
+        }
+        return true;
+      })
+      .map((row) => maskBriefForProvider(row as unknown as BriefRow));
+
+    // ── Accepted bucket ────────────────────────────────────────────
+    const { data: acceptedRaw } = await admin
+      .from("advisor_auctions")
+      .select(
+        "id, slug, job_title, brief_template, budget_band, location, tracker_status, accepted_at, contact_name, contact_email, contact_phone, accepted_by_team_id",
+      )
+      .eq("flow_type", "accept")
+      .eq("accepted_by_professional_id", advisorId)
+      .order("accepted_at", { ascending: false })
+      .limit(50);
+
+    return NextResponse.json({
+      available,
+      accepted: acceptedRaw ?? [],
+      teamIds,
+    });
+  } catch (err) {
+    log.error("inbox error", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json({ error: "Failed to load inbox." }, { status: 500 });
+  }
+}

--- a/app/api/briefs/route.ts
+++ b/app/api/briefs/route.ts
@@ -1,0 +1,237 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { createAdminClient } from "@/lib/supabase/admin";
+import { isRateLimited } from "@/lib/rate-limit";
+import { isValidEmail, isDisposableEmail } from "@/lib/validate-email";
+import { logger } from "@/lib/logger";
+import { CreateBriefRequest } from "@/lib/api-schemas";
+import { scanBrief } from "@/lib/briefs/risk-flags";
+import { getAcceptCost } from "@/lib/briefs/credits";
+import {
+  BRIEF_TEMPLATE_SCHEMAS,
+  isBriefTemplate,
+} from "@/lib/briefs/templates";
+import type { BriefTemplate, ProviderKind } from "@/lib/briefs/types";
+
+const log = logger("briefs:create");
+
+function slugify(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .slice(0, 80);
+}
+
+function providerPrefToKind(pref: string | null): ProviderKind {
+  switch (pref) {
+    case "individual":
+      return "individual";
+    case "firm":
+      return "firm";
+    case "expert_team":
+      return "expert_team";
+    default:
+      return "individual";
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const ip =
+      request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() || "unknown";
+    if (await isRateLimited(`briefs-post:${ip}`, 5, 60)) {
+      return NextResponse.json(
+        { error: "Too many submissions. Please try again later." },
+        { status: 429 },
+      );
+    }
+
+    let rawBody: unknown;
+    try {
+      rawBody = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+    }
+
+    // Honeypot — silently 200 to bots.
+    const maybeBot = rawBody as Record<string, unknown>;
+    if (maybeBot.website || maybeBot.fax) {
+      return NextResponse.json({ success: true, brief_id: null, slug: null });
+    }
+
+    const parsed = CreateBriefRequest.safeParse(rawBody);
+    if (!parsed.success) {
+      const msg = parsed.error.issues[0]?.message || "Invalid request body.";
+      return NextResponse.json({ error: msg }, { status: 400 });
+    }
+    const body = parsed.data;
+
+    if (!isBriefTemplate(body.brief_template)) {
+      return NextResponse.json({ error: "Unknown brief template." }, { status: 400 });
+    }
+
+    // Validate brief_payload against the template-specific schema.
+    const payloadSchema = BRIEF_TEMPLATE_SCHEMAS[body.brief_template as BriefTemplate];
+    const payloadParsed = payloadSchema.safeParse(body.brief_payload ?? {});
+    if (!payloadParsed.success) {
+      const msg =
+        payloadParsed.error.issues[0]?.message ||
+        "Some required fields are missing.";
+      return NextResponse.json(
+        { error: `Brief details: ${msg}` },
+        { status: 400 },
+      );
+    }
+
+    if (!isValidEmail(body.contact_email) || isDisposableEmail(body.contact_email)) {
+      return NextResponse.json(
+        { error: "Please use a real email address." },
+        { status: 400 },
+      );
+    }
+
+    const admin = createAdminClient();
+
+    // Resolve direct-routing targets if slugs were supplied.
+    let targetTeamId: number | null = null;
+    let targetProfessionalId: number | null = null;
+    let targetFirmId: number | null = null;
+    if (body.target_team_slug) {
+      const { data: team } = await admin
+        .from("expert_teams")
+        .select("id")
+        .eq("slug", body.target_team_slug)
+        .maybeSingle();
+      if (team) targetTeamId = team.id as number;
+    }
+    if (body.target_professional_slug) {
+      const { data: pro } = await admin
+        .from("professionals")
+        .select("id")
+        .eq("slug", body.target_professional_slug)
+        .maybeSingle();
+      if (pro) targetProfessionalId = pro.id as number;
+    }
+    if (body.target_firm_slug) {
+      const { data: firm } = await admin
+        .from("advisor_firms")
+        .select("id")
+        .eq("slug", body.target_firm_slug)
+        .maybeSingle();
+      if (firm) targetFirmId = firm.id as number;
+    }
+
+    const providerKind = providerPrefToKind(body.provider_preference);
+    const credits = await getAcceptCost({
+      briefTemplate: body.brief_template,
+      providerKind,
+    });
+
+    const riskHaystack = [
+      body.job_title,
+      body.job_description,
+      JSON.stringify(body.brief_payload ?? {}),
+    ].join(" ");
+    const risk = await scanBrief(riskHaystack);
+
+    if (risk.severity === "block") {
+      return NextResponse.json(
+        {
+          error:
+            "We can't accept briefs containing this kind of content. Please contact our team if you believe this is a mistake.",
+        },
+        { status: 400 },
+      );
+    }
+
+    const baseSlug = slugify(body.job_title);
+    const slug = `${baseSlug}-${Date.now().toString(36)}`;
+    const endsAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
+
+    const insertRow: Record<string, unknown> = {
+      flow_type: "accept",
+      source: "public_brief",
+      is_public: false,
+      slug,
+      job_title: body.job_title.trim(),
+      job_description: body.job_description.trim(),
+      budget_band: body.budget_band,
+      advisor_types: body.advisor_types,
+      location: body.location_state,
+      contact_name: body.contact_name.trim(),
+      contact_email: body.contact_email.toLowerCase().trim(),
+      contact_phone: body.contact_phone?.trim() || null,
+      status: "open",
+      ends_at: endsAt,
+      brief_template: body.brief_template,
+      brief_payload: payloadParsed.data,
+      provider_preference: body.provider_preference,
+      routing_mode: body.routing_mode,
+      target_team_id: targetTeamId,
+      target_professional_id: targetProfessionalId,
+      target_firm_id: targetFirmId,
+      accept_credits_cost: credits,
+      tracker_status: "new",
+      risk_flags: risk.flags,
+      risk_review_status: risk.reviewStatus,
+      listing_id: body.listing_id ?? null,
+    };
+
+    const { data: brief, error: insertError } = await admin
+      .from("advisor_auctions")
+      .insert(insertRow)
+      .select("id, slug")
+      .single();
+
+    if (insertError || !brief) {
+      log.error("brief insert failed", { error: insertError?.message });
+      return NextResponse.json({ error: "Failed to create brief." }, { status: 500 });
+    }
+
+    await admin.from("brief_tracker_events").insert({
+      brief_id: brief.id,
+      event_type: "created",
+      actor_kind: "user",
+      actor_id: body.contact_email.toLowerCase().trim(),
+      payload: {
+        brief_template: body.brief_template,
+        provider_preference: body.provider_preference,
+        routing_mode: body.routing_mode,
+        risk_flags: risk.flags,
+        risk_severity: risk.severity,
+        credits_cost: credits,
+      },
+    });
+
+    if (risk.flags.length > 0) {
+      await admin.from("brief_tracker_events").insert({
+        brief_id: brief.id,
+        event_type: "risk_flagged",
+        actor_kind: "system",
+        payload: { flags: risk.flags, severity: risk.severity },
+      });
+    }
+
+    log.info("Brief created", {
+      briefId: brief.id,
+      slug: brief.slug,
+      template: body.brief_template,
+      riskSeverity: risk.severity,
+    });
+
+    return NextResponse.json({
+      success: true,
+      brief_id: brief.id,
+      slug: brief.slug,
+      accept_credits_cost: credits,
+      risk_review_status: risk.reviewStatus,
+    });
+  } catch (err) {
+    log.error("briefs POST error", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json({ error: "Failed to create brief." }, { status: 500 });
+  }
+}

--- a/app/api/cron/quote-expiry-reminders/route.ts
+++ b/app/api/cron/quote-expiry-reminders/route.ts
@@ -29,6 +29,7 @@ export async function GET(req: NextRequest) {
     .from("advisor_auctions")
     .select("id, slug, job_title, contact_email, contact_name, ends_at")
     .eq("source", "public_job")
+    .eq("flow_type", "auction")
     .eq("is_public", true)
     .eq("status", "open")
     .is("expiry_reminder_sent_at", null)

--- a/app/api/cron/quote-review-requests/route.ts
+++ b/app/api/cron/quote-review-requests/route.ts
@@ -39,6 +39,7 @@ export async function GET(req: NextRequest) {
     .from("advisor_auctions")
     .select("id, slug, job_title, contact_email, contact_name, winning_bid_id, updated_at")
     .eq("source", "public_job")
+    .eq("flow_type", "auction")
     .not("winning_bid_id", "is", null)
     .is("review_request_sent_at", null)
     .lte("updated_at", cutoff)

--- a/app/api/expert-teams/[id]/invite/route.ts
+++ b/app/api/expert-teams/[id]/invite/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { requireAdvisorSession } from "@/lib/require-advisor-session";
+import { isAllowed, ipKey } from "@/lib/rate-limit-db";
 import { InviteExpertTeamMemberRequest } from "@/lib/api-schemas";
 import { getTeamById, inviteMember } from "@/lib/expert-teams";
 import { logger } from "@/lib/logger";
@@ -12,6 +13,9 @@ export async function POST(
   ctx: { params: Promise<{ id: string }> },
 ) {
   try {
+    if (!(await isAllowed("expert_teams_invite", ipKey(request), { max: 20, refillPerSec: 0.1 }))) {
+      return NextResponse.json({ error: "Too many requests." }, { status: 429 });
+    }
     const advisorId = await requireAdvisorSession(request);
     if (!advisorId) {
       return NextResponse.json({ error: "Sign in required." }, { status: 401 });

--- a/app/api/expert-teams/[id]/invite/route.ts
+++ b/app/api/expert-teams/[id]/invite/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { requireAdvisorSession } from "@/lib/require-advisor-session";
+import { InviteExpertTeamMemberRequest } from "@/lib/api-schemas";
+import { getTeamById, inviteMember } from "@/lib/expert-teams";
+import { logger } from "@/lib/logger";
+
+const log = logger("expert-teams:invite");
+
+export async function POST(
+  request: NextRequest,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  try {
+    const advisorId = await requireAdvisorSession(request);
+    if (!advisorId) {
+      return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+    }
+    const { id } = await ctx.params;
+    const teamId = Number(id);
+    if (!Number.isFinite(teamId)) {
+      return NextResponse.json({ error: "Invalid team id." }, { status: 400 });
+    }
+    const team = await getTeamById(teamId);
+    if (!team) return NextResponse.json({ error: "Team not found." }, { status: 404 });
+    if (team.owner_professional_id !== advisorId) {
+      return NextResponse.json(
+        { error: "Only the team owner can invite members." },
+        { status: 403 },
+      );
+    }
+    let rawBody: unknown;
+    try {
+      rawBody = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+    }
+    const parsed = InviteExpertTeamMemberRequest.safeParse(rawBody);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.issues[0]?.message || "Invalid body." },
+        { status: 400 },
+      );
+    }
+    try {
+      const invitation = await inviteMember({
+        teamId,
+        invitedByProfessionalId: advisorId,
+        email: parsed.data.email,
+        name: parsed.data.name,
+        role: parsed.data.role,
+      });
+      return NextResponse.json({ invitation });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "invite_failed";
+      if (msg === "invitation_already_pending") {
+        return NextResponse.json(
+          { error: "That email already has a pending invitation." },
+          { status: 409 },
+        );
+      }
+      if (msg === "already_member") {
+        return NextResponse.json(
+          { error: "That professional is already on this team." },
+          { status: 409 },
+        );
+      }
+      throw err;
+    }
+  } catch (err) {
+    log.error("invite error", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json({ error: "Failed to invite member." }, { status: 500 });
+  }
+}

--- a/app/api/expert-teams/[id]/route.ts
+++ b/app/api/expert-teams/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { requireAdvisorSession } from "@/lib/require-advisor-session";
+import { isAllowed, ipKey } from "@/lib/rate-limit-db";
 import {
   getTeamById,
   listMembers,
@@ -12,6 +13,9 @@ export async function GET(
   request: NextRequest,
   ctx: { params: Promise<{ id: string }> },
 ) {
+  if (!(await isAllowed("expert_teams_get", ipKey(request), { max: 60, refillPerSec: 1 }))) {
+    return NextResponse.json({ error: "Too many requests." }, { status: 429 });
+  }
   const advisorId = await requireAdvisorSession(request);
   if (!advisorId) {
     return NextResponse.json({ error: "Sign in required." }, { status: 401 });

--- a/app/api/expert-teams/[id]/route.ts
+++ b/app/api/expert-teams/[id]/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { requireAdvisorSession } from "@/lib/require-advisor-session";
+import {
+  getTeamById,
+  listMembers,
+  listInvitations,
+  isProfessionalOnTeam,
+} from "@/lib/expert-teams";
+
+export async function GET(
+  request: NextRequest,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  const advisorId = await requireAdvisorSession(request);
+  if (!advisorId) {
+    return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+  }
+  const { id } = await ctx.params;
+  const teamId = Number(id);
+  if (!Number.isFinite(teamId)) {
+    return NextResponse.json({ error: "Invalid team id." }, { status: 400 });
+  }
+  const team = await getTeamById(teamId);
+  if (!team) return NextResponse.json({ error: "Team not found." }, { status: 404 });
+  const isMember =
+    team.owner_professional_id === advisorId ||
+    (await isProfessionalOnTeam(teamId, advisorId));
+  if (!isMember) {
+    return NextResponse.json({ error: "Not authorised." }, { status: 403 });
+  }
+  const [members, invitations] = await Promise.all([
+    listMembers(teamId),
+    listInvitations(teamId),
+  ]);
+  return NextResponse.json({ team, members, invitations });
+}

--- a/app/api/expert-teams/[id]/submit/route.ts
+++ b/app/api/expert-teams/[id]/submit/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { requireAdvisorSession } from "@/lib/require-advisor-session";
+import { submitForVerification } from "@/lib/expert-teams";
+import { logger } from "@/lib/logger";
+
+const log = logger("expert-teams:submit");
+
+export async function POST(
+  request: NextRequest,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  try {
+    const advisorId = await requireAdvisorSession(request);
+    if (!advisorId) {
+      return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+    }
+    const { id } = await ctx.params;
+    const teamId = Number(id);
+    if (!Number.isFinite(teamId)) {
+      return NextResponse.json({ error: "Invalid team id." }, { status: 400 });
+    }
+    try {
+      const team = await submitForVerification(teamId, advisorId);
+      return NextResponse.json({ team });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "submit_failed";
+      if (msg === "team_not_found") {
+        return NextResponse.json({ error: "Team not found." }, { status: 404 });
+      }
+      if (msg === "not_owner") {
+        return NextResponse.json(
+          { error: "Only the team owner can submit for verification." },
+          { status: 403 },
+        );
+      }
+      if (msg.startsWith("incomplete:")) {
+        return NextResponse.json(
+          {
+            error: "Team is not ready for verification.",
+            missing: msg.slice("incomplete:".length).split(","),
+          },
+          { status: 400 },
+        );
+      }
+      throw err;
+    }
+  } catch (err) {
+    log.error("submit error", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json({ error: "Failed to submit team." }, { status: 500 });
+  }
+}

--- a/app/api/expert-teams/[id]/submit/route.ts
+++ b/app/api/expert-teams/[id]/submit/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { requireAdvisorSession } from "@/lib/require-advisor-session";
+import { isAllowed, ipKey } from "@/lib/rate-limit-db";
 import { submitForVerification } from "@/lib/expert-teams";
 import { logger } from "@/lib/logger";
 
@@ -11,6 +12,9 @@ export async function POST(
   ctx: { params: Promise<{ id: string }> },
 ) {
   try {
+    if (!(await isAllowed("expert_teams_submit", ipKey(request), { max: 10, refillPerSec: 0.05 }))) {
+      return NextResponse.json({ error: "Too many requests." }, { status: 429 });
+    }
     const advisorId = await requireAdvisorSession(request);
     if (!advisorId) {
       return NextResponse.json({ error: "Sign in required." }, { status: 401 });

--- a/app/api/expert-teams/invite/accept/route.ts
+++ b/app/api/expert-teams/invite/accept/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { requireAdvisorSession } from "@/lib/require-advisor-session";
+import { AcceptExpertTeamInvitationRequest } from "@/lib/api-schemas";
+import { acceptInvitation } from "@/lib/expert-teams";
+import { logger } from "@/lib/logger";
+
+const log = logger("expert-teams:invite:accept");
+
+export async function POST(request: NextRequest) {
+  try {
+    const advisorId = await requireAdvisorSession(request);
+    if (!advisorId) {
+      return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+    }
+    let rawBody: unknown;
+    try {
+      rawBody = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+    }
+    const parsed = AcceptExpertTeamInvitationRequest.safeParse(rawBody);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.issues[0]?.message || "Invalid body." },
+        { status: 400 },
+      );
+    }
+    try {
+      const { teamId } = await acceptInvitation({
+        token: parsed.data.token,
+        professionalId: advisorId,
+      });
+      return NextResponse.json({ success: true, team_id: teamId });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "accept_failed";
+      const map: Record<string, { code: number; message: string }> = {
+        invalid_invitation: { code: 404, message: "Invalid invitation." },
+        invitation_unavailable: {
+          code: 410,
+          message: "This invitation has already been used or revoked.",
+        },
+        invitation_expired: { code: 410, message: "This invitation has expired." },
+      };
+      const m = map[msg];
+      if (m) return NextResponse.json({ error: m.message }, { status: m.code });
+      throw err;
+    }
+  } catch (err) {
+    log.error("accept invite error", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json({ error: "Failed to accept invitation." }, { status: 500 });
+  }
+}

--- a/app/api/expert-teams/invite/accept/route.ts
+++ b/app/api/expert-teams/invite/accept/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { requireAdvisorSession } from "@/lib/require-advisor-session";
+import { isAllowed, ipKey } from "@/lib/rate-limit-db";
 import { AcceptExpertTeamInvitationRequest } from "@/lib/api-schemas";
 import { acceptInvitation } from "@/lib/expert-teams";
 import { logger } from "@/lib/logger";
@@ -9,6 +10,9 @@ const log = logger("expert-teams:invite:accept");
 
 export async function POST(request: NextRequest) {
   try {
+    if (!(await isAllowed("expert_teams_invite_accept", ipKey(request), { max: 10, refillPerSec: 0.1 }))) {
+      return NextResponse.json({ error: "Too many requests." }, { status: 429 });
+    }
     const advisorId = await requireAdvisorSession(request);
     if (!advisorId) {
       return NextResponse.json({ error: "Sign in required." }, { status: 401 });

--- a/app/api/expert-teams/invite/route.ts
+++ b/app/api/expert-teams/invite/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { getInvitationByToken } from "@/lib/expert-teams";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { isAllowed, ipKey } from "@/lib/rate-limit-db";
+
+export async function GET(request: NextRequest) {
+  if (
+    !(await isAllowed("expert_teams_invite_get", ipKey(request), {
+      max: 20,
+      refillPerSec: 0.1,
+    }))
+  ) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+  }
+  const token = request.nextUrl.searchParams.get("token");
+  if (!token) {
+    return NextResponse.json({ error: "Token required." }, { status: 400 });
+  }
+  const invitation = await getInvitationByToken(token);
+  if (!invitation) {
+    return NextResponse.json({ error: "Invalid invitation." }, { status: 404 });
+  }
+  if (invitation.status !== "pending") {
+    return NextResponse.json(
+      { error: "This invitation has already been used or revoked." },
+      { status: 410 },
+    );
+  }
+  if (new Date(invitation.expires_at) < new Date()) {
+    return NextResponse.json({ error: "This invitation has expired." }, { status: 410 });
+  }
+  const admin = createAdminClient();
+  const { data: team } = await admin
+    .from("expert_teams")
+    .select("id, name, slug, team_category")
+    .eq("id", invitation.team_id)
+    .maybeSingle();
+
+  return NextResponse.json({
+    email: invitation.email,
+    name: invitation.name,
+    role: invitation.invited_role,
+    team,
+  });
+}

--- a/app/api/expert-teams/route.ts
+++ b/app/api/expert-teams/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { requireAdvisorSession } from "@/lib/require-advisor-session";
+import { CreateExpertTeamRequest } from "@/lib/api-schemas";
+import { createTeam, listTeamsForProfessional } from "@/lib/expert-teams";
+import { logger } from "@/lib/logger";
+
+const log = logger("expert-teams");
+
+export async function GET(request: NextRequest) {
+  const advisorId = await requireAdvisorSession(request);
+  if (!advisorId) {
+    return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+  }
+  const teams = await listTeamsForProfessional(advisorId);
+  return NextResponse.json({ teams });
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const advisorId = await requireAdvisorSession(request);
+    if (!advisorId) {
+      return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+    }
+
+    let rawBody: unknown;
+    try {
+      rawBody = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+    }
+    const parsed = CreateExpertTeamRequest.safeParse(rawBody);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.issues[0]?.message || "Invalid body." },
+        { status: 400 },
+      );
+    }
+
+    const team = await createTeam({
+      ownerProfessionalId: advisorId,
+      name: parsed.data.name,
+      teamCategory: parsed.data.team_category,
+      teamType: parsed.data.team_type,
+      description: parsed.data.description,
+      niche: parsed.data.niche,
+      locationState: parsed.data.location_state,
+      serviceAreas: parsed.data.service_areas,
+      firmId: parsed.data.firm_id ?? null,
+      disclosure: parsed.data.disclosure,
+      acceptedBriefTemplates: parsed.data.accepted_brief_templates,
+    });
+
+    log.info("Expert team created", { teamId: team.id, ownerId: advisorId });
+    return NextResponse.json({ team });
+  } catch (err) {
+    log.error("create team error", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json({ error: "Failed to create team." }, { status: 500 });
+  }
+}

--- a/app/api/expert-teams/route.ts
+++ b/app/api/expert-teams/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { requireAdvisorSession } from "@/lib/require-advisor-session";
+import { isAllowed, ipKey } from "@/lib/rate-limit-db";
 import { CreateExpertTeamRequest } from "@/lib/api-schemas";
 import { createTeam, listTeamsForProfessional } from "@/lib/expert-teams";
 import { logger } from "@/lib/logger";
@@ -8,6 +9,9 @@ import { logger } from "@/lib/logger";
 const log = logger("expert-teams");
 
 export async function GET(request: NextRequest) {
+  if (!(await isAllowed("expert_teams_list", ipKey(request), { max: 30, refillPerSec: 0.5 }))) {
+    return NextResponse.json({ error: "Too many requests." }, { status: 429 });
+  }
   const advisorId = await requireAdvisorSession(request);
   if (!advisorId) {
     return NextResponse.json({ error: "Sign in required." }, { status: 401 });
@@ -18,6 +22,9 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   try {
+    if (!(await isAllowed("expert_teams_create", ipKey(request), { max: 5, refillPerSec: 0.05 }))) {
+      return NextResponse.json({ error: "Too many requests." }, { status: 429 });
+    }
     const advisorId = await requireAdvisorSession(request);
     if (!advisorId) {
       return NextResponse.json({ error: "Sign in required." }, { status: 401 });

--- a/app/api/get-matched/answer/route.ts
+++ b/app/api/get-matched/answer/route.ts
@@ -1,0 +1,78 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { AnswerQuestionRequest } from "@/lib/api-schemas";
+import { isAllowed, ipKey } from "@/lib/rate-limit-db";
+import { getPlanById, updatePlan } from "@/lib/getmatched/action-plans";
+import { getQuestions, nextQuestion } from "@/lib/getmatched/questions";
+import { logEvent } from "@/lib/getmatched/events";
+import { logger } from "@/lib/logger";
+
+const log = logger("get-matched:answer");
+
+export async function POST(request: NextRequest) {
+  try {
+    if (
+      !(await isAllowed("gm_answer", ipKey(request), { max: 120, refillPerSec: 2 }))
+    ) {
+      return NextResponse.json({ error: "Too many requests." }, { status: 429 });
+    }
+
+    let rawBody: unknown;
+    try {
+      rawBody = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+    }
+    const parsed = AnswerQuestionRequest.safeParse(rawBody);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.issues[0]?.message ?? "Invalid body." },
+        { status: 400 },
+      );
+    }
+    const { plan_id, question_slug, value } = parsed.data;
+
+    const plan = await getPlanById(plan_id);
+    if (!plan) {
+      return NextResponse.json({ error: "Plan not found." }, { status: 404 });
+    }
+
+    const questions = await getQuestions("both");
+    const question = questions.find((q) => q.slug === question_slug);
+    if (!question) {
+      return NextResponse.json({ error: "Unknown question." }, { status: 400 });
+    }
+
+    // Idempotent: same answer for same slug = no-op.
+    const mergedAnswers = {
+      ...plan.answers,
+      [question.maps_to]: value,
+      [question_slug]: value,
+    };
+
+    const updated = await updatePlan({
+      id: plan.id,
+      answers: mergedAnswers,
+    });
+
+    void logEvent({
+      sessionId: plan.session_id,
+      authUserId: plan.auth_user_id,
+      eventType: "question_answered",
+      step: question.step,
+      payload: { question_slug, plan_id: plan.id },
+    });
+
+    const next = nextQuestion(questions, updated.answers, "both");
+
+    return NextResponse.json({ plan_id: plan.id, next });
+  } catch (err) {
+    log.error("answer error", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json(
+      { error: "Failed to save answer." },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/get-matched/events/route.ts
+++ b/app/api/get-matched/events/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { LogGmEventRequest } from "@/lib/api-schemas";
+import { isAllowed, ipKey } from "@/lib/rate-limit-db";
+import { logEvent } from "@/lib/getmatched/events";
+
+export async function POST(request: NextRequest) {
+  if (
+    !(await isAllowed("gm_events", ipKey(request), { max: 60, refillPerSec: 1 }))
+  ) {
+    return NextResponse.json({ error: "Too many requests." }, { status: 429 });
+  }
+
+  let rawBody: unknown;
+  try {
+    rawBody = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+  const parsed = LogGmEventRequest.safeParse(rawBody);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.issues[0]?.message ?? "Invalid body." },
+      { status: 400 },
+    );
+  }
+  await logEvent({
+    sessionId: parsed.data.session_id,
+    eventType: parsed.data.event_type,
+    step: parsed.data.step ?? null,
+    payload: parsed.data.payload,
+    sourcePage: parsed.data.source_page,
+    userAgent: request.headers.get("user-agent"),
+  });
+  return NextResponse.json({ success: true });
+}

--- a/app/api/get-matched/plans/[id]/checklist/route.ts
+++ b/app/api/get-matched/plans/[id]/checklist/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { ChecklistToggleRequest } from "@/lib/api-schemas";
+import { isAllowed, ipKey } from "@/lib/rate-limit-db";
+import {
+  getPlanById,
+  toggleChecklistItem,
+  updatePlan,
+} from "@/lib/getmatched/action-plans";
+import { logger } from "@/lib/logger";
+
+const log = logger("get-matched:plan:checklist");
+
+export async function POST(
+  request: NextRequest,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  try {
+    if (
+      !(await isAllowed("gm_checklist", ipKey(request), { max: 60, refillPerSec: 1 }))
+    ) {
+      return NextResponse.json({ error: "Too many requests." }, { status: 429 });
+    }
+    const { id } = await ctx.params;
+    const planId = Number(id);
+    if (!Number.isFinite(planId)) {
+      return NextResponse.json({ error: "Invalid plan id." }, { status: 400 });
+    }
+
+    let rawBody: unknown;
+    try {
+      rawBody = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+    }
+    const parsed = ChecklistToggleRequest.safeParse(rawBody);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.issues[0]?.message ?? "Invalid body." },
+        { status: 400 },
+      );
+    }
+    const plan = await getPlanById(planId);
+    if (!plan) {
+      return NextResponse.json({ error: "Plan not found." }, { status: 404 });
+    }
+    const next = toggleChecklistItem(plan.checklist, parsed.data.index);
+    const updated = await updatePlan({ id: planId, checklist: next });
+    return NextResponse.json({ checklist: updated.checklist });
+  } catch (err) {
+    log.error("checklist error", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json(
+      { error: "Failed to update checklist." },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/get-matched/plans/[id]/claim/route.ts
+++ b/app/api/get-matched/plans/[id]/claim/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { isAllowed, ipKey } from "@/lib/rate-limit-db";
+import { createClient } from "@/lib/supabase/server";
+import { claimPlanForUser } from "@/lib/getmatched/action-plans";
+import { logEvent } from "@/lib/getmatched/events";
+import { logger } from "@/lib/logger";
+
+const log = logger("get-matched:plan:claim");
+
+export async function POST(
+  request: NextRequest,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  try {
+    if (
+      !(await isAllowed("gm_plan_claim", ipKey(request), { max: 10, refillPerSec: 0.1 }))
+    ) {
+      return NextResponse.json({ error: "Too many requests." }, { status: 429 });
+    }
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) {
+      return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+    }
+    const { id } = await ctx.params;
+    const planId = Number(id);
+    if (!Number.isFinite(planId)) {
+      return NextResponse.json({ error: "Invalid plan id." }, { status: 400 });
+    }
+    const plan = await claimPlanForUser({
+      planId,
+      authUserId: user.id,
+      email: user.email ?? undefined,
+    });
+    void logEvent({
+      sessionId: plan.session_id,
+      authUserId: user.id,
+      eventType: "account_created",
+      payload: { plan_id: planId },
+    });
+    return NextResponse.json({ success: true, plan });
+  } catch (err) {
+    log.error("claim error", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json({ error: "Failed to claim plan." }, { status: 500 });
+  }
+}

--- a/app/api/get-matched/plans/[id]/save/route.ts
+++ b/app/api/get-matched/plans/[id]/save/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { SavePlanRequest } from "@/lib/api-schemas";
+import { isAllowed, ipKey } from "@/lib/rate-limit-db";
+import { getPlanById, updatePlan } from "@/lib/getmatched/action-plans";
+import { logEvent } from "@/lib/getmatched/events";
+import { logger } from "@/lib/logger";
+
+const log = logger("get-matched:plan:save");
+
+export async function POST(
+  request: NextRequest,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  try {
+    if (
+      !(await isAllowed("gm_plan_save", ipKey(request), { max: 10, refillPerSec: 0.1 }))
+    ) {
+      return NextResponse.json({ error: "Too many requests." }, { status: 429 });
+    }
+    const { id } = await ctx.params;
+    const planId = Number(id);
+    if (!Number.isFinite(planId)) {
+      return NextResponse.json({ error: "Invalid plan id." }, { status: 400 });
+    }
+
+    let rawBody: unknown;
+    try {
+      rawBody = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+    }
+    const parsed = SavePlanRequest.safeParse(rawBody);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.issues[0]?.message ?? "Invalid body." },
+        { status: 400 },
+      );
+    }
+    const plan = await getPlanById(planId);
+    if (!plan) {
+      return NextResponse.json({ error: "Plan not found." }, { status: 404 });
+    }
+    const updated = await updatePlan({
+      id: planId,
+      email: parsed.data.email.toLowerCase().trim(),
+      status: plan.status === "converted" ? plan.status : "saved",
+    });
+    void logEvent({
+      sessionId: plan.session_id,
+      authUserId: plan.auth_user_id,
+      eventType: "plan_saved",
+      payload: { plan_id: planId },
+    });
+    return NextResponse.json({
+      success: true,
+      share_token: updated.share_token,
+      view_url: `/plans/${updated.share_token}`,
+    });
+  } catch (err) {
+    log.error("save error", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json({ error: "Failed to save plan." }, { status: 500 });
+  }
+}

--- a/app/api/get-matched/plans/[id]/to-brief/route.ts
+++ b/app/api/get-matched/plans/[id]/to-brief/route.ts
@@ -1,0 +1,248 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { PlanToBriefRequest } from "@/lib/api-schemas";
+import { isAllowed, ipKey } from "@/lib/rate-limit-db";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { isValidEmail, isDisposableEmail } from "@/lib/validate-email";
+import {
+  getPlanById,
+  linkBriefToPlan,
+  updatePlan,
+} from "@/lib/getmatched/action-plans";
+import { getEnabledIntents } from "@/lib/getmatched/intents";
+import { resolveActionPlan } from "@/lib/getmatched/engine";
+import { scanBrief } from "@/lib/briefs/risk-flags";
+import { getAcceptCost } from "@/lib/briefs/credits";
+import { logEvent } from "@/lib/getmatched/events";
+import { logger } from "@/lib/logger";
+
+const log = logger("get-matched:plan:to-brief");
+
+function slugify(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .slice(0, 80);
+}
+
+export async function POST(
+  request: NextRequest,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  try {
+    if (
+      !(await isAllowed("gm_to_brief", ipKey(request), { max: 10, refillPerSec: 0.1 }))
+    ) {
+      return NextResponse.json({ error: "Too many requests." }, { status: 429 });
+    }
+    const { id } = await ctx.params;
+    const planId = Number(id);
+    if (!Number.isFinite(planId)) {
+      return NextResponse.json({ error: "Invalid plan id." }, { status: 400 });
+    }
+
+    let rawBody: unknown;
+    try {
+      rawBody = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+    }
+    const parsed = PlanToBriefRequest.safeParse(rawBody);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.issues[0]?.message ?? "Invalid body." },
+        { status: 400 },
+      );
+    }
+
+    if (
+      !isValidEmail(parsed.data.contact_email) ||
+      isDisposableEmail(parsed.data.contact_email)
+    ) {
+      return NextResponse.json(
+        { error: "Please use a real email address." },
+        { status: 400 },
+      );
+    }
+
+    const plan = await getPlanById(planId);
+    if (!plan) {
+      return NextResponse.json({ error: "Plan not found." }, { status: 404 });
+    }
+
+    // Re-run the resolver so the brief is created from the latest answers
+    // (the plan may have been updated since the user last saw the result).
+    const intents = await getEnabledIntents();
+    const resolved = await resolveActionPlan({
+      answers: plan.answers,
+      intents,
+    });
+
+    const template =
+      resolved.recommendedBriefTemplate ??
+      (plan.intent_slug
+        ? intents.find((i) => i.slug === plan.intent_slug)?.default_brief_template
+        : null) ??
+      "general";
+
+    const title = plan.goal ?? resolved.template.headline ?? "Investor brief";
+    const briefDescription = buildDescription(plan);
+    const risk = await scanBrief([title, briefDescription].join(" "));
+    if (risk.severity === "block") {
+      return NextResponse.json(
+        {
+          error:
+            "We can't accept briefs containing this kind of content. Please contact our team if you believe this is a mistake.",
+        },
+        { status: 400 },
+      );
+    }
+
+    const providerKind =
+      resolved.route === "expert_team"
+        ? "expert_team"
+        : resolved.route === "firm"
+          ? "firm"
+          : "individual";
+    const credits = await getAcceptCost({
+      briefTemplate: template,
+      providerKind,
+    });
+
+    const admin = createAdminClient();
+    const slug = `${slugify(title)}-${Date.now().toString(36)}`;
+    const endsAt = new Date(Date.now() + 30 * 86_400_000).toISOString();
+
+    const insertRow: Record<string, unknown> = {
+      flow_type: "accept",
+      source: "public_brief",
+      is_public: false,
+      slug,
+      job_title: title,
+      job_description: briefDescription,
+      budget_band: plan.budget_band ?? "not_sure",
+      advisor_types: [],
+      location: plan.location_state ?? "NSW",
+      contact_name: parsed.data.contact_name.trim(),
+      contact_email: parsed.data.contact_email.toLowerCase().trim(),
+      contact_phone: parsed.data.contact_phone?.trim() || null,
+      status: "open",
+      ends_at: endsAt,
+      brief_template: template,
+      brief_payload: plan.answers,
+      provider_preference:
+        parsed.data.provider_preference ??
+        (resolved.route === "expert_team"
+          ? "expert_team"
+          : resolved.route === "firm"
+            ? "firm"
+            : resolved.route === "individual"
+              ? "individual"
+              : "any"),
+      routing_mode: parsed.data.routing_mode,
+      accept_credits_cost: credits,
+      tracker_status: "new",
+      risk_flags: risk.flags,
+      risk_review_status: risk.reviewStatus,
+      linked_action_plan_id: plan.id,
+    };
+
+    const { data: brief, error } = await admin
+      .from("advisor_auctions")
+      .insert(insertRow)
+      .select("id, slug")
+      .single();
+    if (error || !brief) {
+      log.error("plan->brief insert failed", { error: error?.message });
+      return NextResponse.json({ error: "Failed to create brief." }, { status: 500 });
+    }
+
+    await admin.from("brief_tracker_events").insert({
+      brief_id: brief.id,
+      event_type: "created",
+      actor_kind: "user",
+      actor_id: parsed.data.contact_email.toLowerCase().trim(),
+      payload: {
+        from_plan_id: plan.id,
+        brief_template: template,
+        risk_flags: risk.flags,
+        risk_severity: risk.severity,
+        credits_cost: credits,
+      },
+    });
+    if (risk.flags.length > 0) {
+      await admin.from("brief_tracker_events").insert({
+        brief_id: brief.id,
+        event_type: "risk_flagged",
+        actor_kind: "system",
+        payload: { flags: risk.flags, severity: risk.severity },
+      });
+    }
+
+    await linkBriefToPlan(plan.id, brief.id as number);
+
+    await updatePlan({
+      id: plan.id,
+      email: parsed.data.contact_email.toLowerCase().trim(),
+    });
+
+    void logEvent({
+      sessionId: plan.session_id,
+      authUserId: plan.auth_user_id,
+      eventType: "brief_submitted",
+      payload: { plan_id: plan.id, brief_id: brief.id },
+    });
+
+    return NextResponse.json({
+      success: true,
+      brief_id: brief.id,
+      brief_slug: brief.slug,
+      risk_review_status: risk.reviewStatus,
+    });
+  } catch (err) {
+    log.error("plan->brief error", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json({ error: "Failed to create brief." }, { status: 500 });
+  }
+}
+
+function buildDescription(plan: ReturnType<typeof Object>): string {
+  // Compose a human description from the answer payload so brief cards
+  // render meaningfully. `plan.answers` is a record of slug→value.
+  const p = plan as {
+    goal?: string | null;
+    answers?: Record<string, unknown>;
+    budget_band?: string | null;
+    timeline?: string | null;
+    help_needed?: string[] | null;
+    country_of_residence?: string | null;
+    location_state?: string | null;
+  };
+  const parts: string[] = [];
+  if (p.goal) parts.push(`Goal: ${p.goal}`);
+  if (p.budget_band) parts.push(`Budget: ${formatBand(p.budget_band)}`);
+  if (p.timeline) parts.push(`Timeline: ${formatTimeline(p.timeline)}`);
+  if (p.location_state) parts.push(`Location: ${p.location_state}`);
+  if (p.country_of_residence) parts.push(`Country: ${p.country_of_residence}`);
+  if (p.help_needed && p.help_needed.length > 0) {
+    parts.push(`Help needed: ${p.help_needed.join(", ")}`);
+  }
+  const notes = (p.answers as Record<string, unknown> | undefined)?.notes;
+  if (typeof notes === "string" && notes.trim()) {
+    parts.push(`Notes: ${notes.trim()}`);
+  }
+  return parts.length > 0
+    ? parts.join("\n")
+    : "Investor brief created from Get Matched action plan.";
+}
+
+function formatBand(band: string): string {
+  return band.replace(/_/g, "–").replace("plus", "+");
+}
+
+function formatTimeline(value: string): string {
+  return value.replace(/_/g, " ");
+}

--- a/app/api/get-matched/plans/[token]/route.ts
+++ b/app/api/get-matched/plans/[token]/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { isAllowed, ipKey } from "@/lib/rate-limit-db";
+import { getPlanByToken } from "@/lib/getmatched/action-plans";
+import { getResultTemplate } from "@/lib/getmatched/templates";
+import { logger } from "@/lib/logger";
+import type { IntentSlug, RouteType } from "@/lib/getmatched/types";
+
+const log = logger("get-matched:plan:token");
+
+export async function GET(
+  request: NextRequest,
+  ctx: { params: Promise<{ token: string }> },
+) {
+  try {
+    if (
+      !(await isAllowed("gm_plan_token", ipKey(request), { max: 30, refillPerSec: 0.5 }))
+    ) {
+      return NextResponse.json({ error: "Too many requests." }, { status: 429 });
+    }
+    const { token } = await ctx.params;
+    if (!token || token.length < 20) {
+      return NextResponse.json({ error: "Invalid token." }, { status: 400 });
+    }
+    const plan = await getPlanByToken(token);
+    if (!plan) {
+      return NextResponse.json({ error: "Plan not found." }, { status: 404 });
+    }
+    const template = plan.route
+      ? await getResultTemplate(plan.route as RouteType, plan.intent_slug as IntentSlug | null)
+      : null;
+    return NextResponse.json({ plan, template });
+  } catch (err) {
+    log.error("token plan error", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json({ error: "Failed to load plan." }, { status: 500 });
+  }
+}

--- a/app/api/get-matched/plans/by-id/[id]/route.ts
+++ b/app/api/get-matched/plans/by-id/[id]/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { isAllowed, ipKey } from "@/lib/rate-limit-db";
+import { getPlanById } from "@/lib/getmatched/action-plans";
+import { getEnabledIntents } from "@/lib/getmatched/intents";
+import { logger } from "@/lib/logger";
+
+const log = logger("get-matched:plan:by-id");
+
+/**
+ * Pre-fill endpoint for `/briefs/new?plan_id=…`. Returns the plan + the
+ * recommended brief template + a human-readable description string so the
+ * BriefForm can paint the contact step without re-running the full
+ * resolver client-side.
+ *
+ * Anonymous-allowed (token would be ideal but we don't have the token on
+ * the redirect path; access is rate-limited and only exposes information
+ * the user already saw on their own action plan screen).
+ */
+export async function GET(
+  request: NextRequest,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  try {
+    if (
+      !(await isAllowed("gm_plan_by_id", ipKey(request), {
+        max: 30,
+        refillPerSec: 0.5,
+      }))
+    ) {
+      return NextResponse.json({ error: "Too many requests." }, { status: 429 });
+    }
+    const { id } = await ctx.params;
+    const planId = Number(id);
+    if (!Number.isFinite(planId)) {
+      return NextResponse.json({ error: "Invalid plan id." }, { status: 400 });
+    }
+    const plan = await getPlanById(planId);
+    if (!plan) {
+      return NextResponse.json({ error: "Plan not found." }, { status: 404 });
+    }
+    const intents = await getEnabledIntents();
+    const recommended =
+      intents.find((i) => i.slug === plan.intent_slug)?.default_brief_template ??
+      null;
+
+    const description = buildDescription(plan);
+    return NextResponse.json({
+      plan,
+      recommended_brief_template: recommended,
+      description,
+    });
+  } catch (err) {
+    log.error("plan by-id error", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json({ error: "Failed to load plan." }, { status: 500 });
+  }
+}
+
+function buildDescription(plan: {
+  goal: string | null;
+  budget_band: string | null;
+  timeline: string | null;
+  location_state: string | null;
+  country_of_residence: string | null;
+  help_needed: string[];
+  answers: Record<string, unknown>;
+}): string {
+  const parts: string[] = [];
+  if (plan.goal) parts.push(`Goal: ${plan.goal}`);
+  if (plan.budget_band) parts.push(`Budget band: ${plan.budget_band}`);
+  if (plan.timeline) parts.push(`Timeline: ${plan.timeline}`);
+  if (plan.location_state) parts.push(`Location: ${plan.location_state}`);
+  if (plan.country_of_residence)
+    parts.push(`Country: ${plan.country_of_residence}`);
+  if (plan.help_needed && plan.help_needed.length > 0) {
+    parts.push(`Help needed: ${plan.help_needed.join(", ")}`);
+  }
+  const notes = plan.answers?.notes;
+  if (typeof notes === "string" && notes.trim()) {
+    parts.push(`Notes: ${notes.trim()}`);
+  }
+  return parts.length > 0
+    ? parts.join("\n")
+    : "Investor brief from Get Matched action plan.";
+}

--- a/app/api/get-matched/resolve/route.ts
+++ b/app/api/get-matched/resolve/route.ts
@@ -1,0 +1,109 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { ResolvePlanRequest } from "@/lib/api-schemas";
+import { isAllowed, ipKey } from "@/lib/rate-limit-db";
+import { getPlanById, updatePlan } from "@/lib/getmatched/action-plans";
+import { getEnabledIntents } from "@/lib/getmatched/intents";
+import {
+  recommendedProviders,
+  resolveActionPlan,
+} from "@/lib/getmatched/engine";
+import { logEvent } from "@/lib/getmatched/events";
+import { logger } from "@/lib/logger";
+
+const log = logger("get-matched:resolve");
+
+export async function POST(request: NextRequest) {
+  try {
+    if (
+      !(await isAllowed("gm_resolve", ipKey(request), { max: 30, refillPerSec: 0.5 }))
+    ) {
+      return NextResponse.json({ error: "Too many requests." }, { status: 429 });
+    }
+
+    let rawBody: unknown;
+    try {
+      rawBody = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+    }
+    const parsed = ResolvePlanRequest.safeParse(rawBody);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.issues[0]?.message ?? "Invalid body." },
+        { status: 400 },
+      );
+    }
+    const plan = await getPlanById(parsed.data.plan_id);
+    if (!plan) {
+      return NextResponse.json({ error: "Plan not found." }, { status: 404 });
+    }
+
+    const intents = await getEnabledIntents();
+    const resolved = await resolveActionPlan({
+      answers: plan.answers,
+      intents,
+    });
+
+    const updated = await updatePlan({
+      id: plan.id,
+      intent_slug: resolved.intent,
+      secondary_intent_slug: resolved.secondaryIntent,
+      route: resolved.route,
+      goal: resolved.goal,
+      checklist: resolved.checklist,
+      budget_band: resolved.budgetBand,
+      timeline: resolved.timeline,
+      location_state: resolved.locationState,
+      country_of_residence: resolved.countryOfResidence,
+      help_needed: resolved.helpNeeded,
+      risk_flags: resolved.riskFlags,
+      risk_severity: resolved.riskSeverity,
+      status: plan.status === "draft" ? "draft" : plan.status,
+    });
+
+    const providers = await recommendedProviders({
+      intent: resolved.intent,
+      route: resolved.route,
+      briefTemplate: resolved.recommendedBriefTemplate,
+      budgetBand: resolved.budgetBand,
+      locationState: resolved.locationState,
+    });
+
+    void logEvent({
+      sessionId: plan.session_id,
+      authUserId: plan.auth_user_id,
+      eventType: "plan_shown",
+      payload: {
+        plan_id: plan.id,
+        intent: resolved.intent,
+        route: resolved.route,
+        risk_severity: resolved.riskSeverity,
+      },
+    });
+    if (resolved.riskFlags.length > 0) {
+      void logEvent({
+        sessionId: plan.session_id,
+        authUserId: plan.auth_user_id,
+        eventType: "risk_flagged",
+        payload: { plan_id: plan.id, flags: resolved.riskFlags },
+      });
+    }
+
+    return NextResponse.json({
+      plan: updated,
+      template: resolved.template,
+      recommended_brief_template: resolved.recommendedBriefTemplate,
+      accept_credits_cost: resolved.acceptCreditsCost,
+      recommended_providers: providers,
+    });
+  } catch (err) {
+    log.error("resolve error", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json(
+      { error: "Failed to resolve action plan." },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/get-matched/start/route.ts
+++ b/app/api/get-matched/start/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { StartGetMatchedRequest } from "@/lib/api-schemas";
+import { isAllowed, ipKey } from "@/lib/rate-limit-db";
+import { createPlan } from "@/lib/getmatched/action-plans";
+import { getQuestions, nextQuestion } from "@/lib/getmatched/questions";
+import { logEvent } from "@/lib/getmatched/events";
+import { logger } from "@/lib/logger";
+
+const log = logger("get-matched:start");
+
+export async function POST(request: NextRequest) {
+  try {
+    if (
+      !(await isAllowed("gm_start", ipKey(request), { max: 20, refillPerSec: 0.2 }))
+    ) {
+      return NextResponse.json({ error: "Too many requests." }, { status: 429 });
+    }
+
+    let rawBody: unknown;
+    try {
+      rawBody = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+    }
+    const parsed = StartGetMatchedRequest.safeParse(rawBody);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.issues[0]?.message ?? "Invalid body." },
+        { status: 400 },
+      );
+    }
+    const { session_id, mode, prefill, source_page } = parsed.data;
+
+    const plan = await createPlan({
+      sessionId: session_id,
+      initialAnswers: prefill ?? {},
+    });
+
+    const questions = await getQuestions(mode);
+    const next = nextQuestion(questions, plan.answers, mode);
+
+    void logEvent({
+      sessionId: session_id,
+      eventType: "started",
+      sourcePage: source_page,
+      payload: { mode, plan_id: plan.id },
+    });
+
+    return NextResponse.json({
+      plan_id: plan.id,
+      share_token: plan.share_token,
+      session_id,
+      next,
+    });
+  } catch (err) {
+    log.error("start error", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json(
+      { error: "Failed to start Get Matched." },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/quotes/route.ts
+++ b/app/api/quotes/route.ts
@@ -44,6 +44,7 @@ export async function GET(request: NextRequest) {
       .select("id, slug, job_title, job_description, budget_band, advisor_types, location, status, ends_at, created_at")
       .eq("is_public", true)
       .eq("source", "public_job")
+      .eq("flow_type", "auction")
       .eq("status", "open")
       .gt("ends_at", now)
       .order("created_at", { ascending: false })
@@ -146,6 +147,7 @@ export async function POST(request: NextRequest) {
       .from("advisor_auctions")
       .insert({
         source: "public_job",
+        flow_type: "auction",
         is_public: true,
         slug,
         job_title: body.job_title.trim(),

--- a/app/briefs/[slug]/page.tsx
+++ b/app/briefs/[slug]/page.tsx
@@ -1,0 +1,283 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import Link from "next/link";
+
+import { createClient } from "@/lib/supabase/server";
+import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
+import { BRIEF_TEMPLATE_LABELS } from "@/lib/briefs/templates";
+import type { BriefRow, TrackerStatus } from "@/lib/briefs/types";
+
+export const dynamic = "force-dynamic";
+
+const STATUS_LABELS: Record<TrackerStatus, string> = {
+  new: "New",
+  contacted: "Contacted",
+  call_booked: "Call booked",
+  proposal_sent: "Proposal sent",
+  won: "Engagement confirmed",
+  lost: "Did not proceed",
+  withdrawn: "Withdrawn",
+};
+
+const STATUS_ORDER: TrackerStatus[] = [
+  "new",
+  "contacted",
+  "call_booked",
+  "proposal_sent",
+  "won",
+];
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const admin = await createClient();
+  const { data } = await admin
+    .from("advisor_auctions")
+    .select("job_title")
+    .eq("slug", slug)
+    .eq("flow_type", "accept")
+    .maybeSingle();
+  const title = data?.job_title || "Investor Brief";
+  return {
+    title: `${title} — Brief Tracker (${CURRENT_YEAR})`,
+    robots: { index: false, follow: false },
+    alternates: { canonical: `${SITE_URL}/briefs/${slug}` },
+  };
+}
+
+interface AcceptedInfo {
+  professional?: { name: string; slug: string | null; email: string | null };
+  team?: { name: string; slug: string };
+}
+
+async function loadAccepted(brief: BriefRow): Promise<AcceptedInfo> {
+  const admin = await createClient();
+  const info: AcceptedInfo = {};
+  if (brief.accepted_by_professional_id) {
+    const { data } = await admin
+      .from("professionals")
+      .select("name, slug, email")
+      .eq("id", brief.accepted_by_professional_id)
+      .maybeSingle();
+    if (data) {
+      info.professional = {
+        name: data.name as string,
+        slug: (data.slug as string) ?? null,
+        email: (data.email as string) ?? null,
+      };
+    }
+  }
+  if (brief.accepted_by_team_id) {
+    const { data } = await admin
+      .from("expert_teams")
+      .select("name, slug")
+      .eq("id", brief.accepted_by_team_id)
+      .maybeSingle();
+    if (data) {
+      info.team = {
+        name: data.name as string,
+        slug: data.slug as string,
+      };
+    }
+  }
+  return info;
+}
+
+export default async function BriefTrackerPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ slug: string }>;
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const { slug } = await params;
+  const sp = (await searchParams) ?? {};
+  const email = typeof sp.email === "string" ? sp.email.toLowerCase().trim() : "";
+
+  const admin = await createClient();
+  const { data } = await admin
+    .from("advisor_auctions")
+    .select("*")
+    .eq("slug", slug)
+    .eq("flow_type", "accept")
+    .maybeSingle();
+
+  if (!data) notFound();
+  const brief = data as unknown as BriefRow;
+
+  const emailMatches =
+    !!email && (brief.contact_email ?? "").toLowerCase() === email;
+
+  const accepted = await loadAccepted(brief);
+
+  const stepIndex = STATUS_ORDER.indexOf(brief.tracker_status);
+
+  const breadcrumb = breadcrumbJsonLd([
+    { name: "Home", url: `${SITE_URL}/` },
+    { name: "Investor Briefs", url: `${SITE_URL}/briefs` },
+    { name: brief.job_title },
+  ]);
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
+      />
+
+      <div className="min-h-screen bg-slate-50">
+        <div className="max-w-3xl mx-auto px-4 py-8 sm:py-12">
+          <div className="flex items-center gap-2 text-xs text-slate-500 mb-4">
+            <Link href="/" className="hover:text-slate-700">
+              Home
+            </Link>
+            <span>/</span>
+            <Link href="/briefs/new" className="hover:text-slate-700">
+              Investor Briefs
+            </Link>
+            <span>/</span>
+            <span className="text-slate-700">Brief Tracker</span>
+          </div>
+
+          <h1 className="text-2xl sm:text-3xl font-extrabold text-slate-900 mb-1">
+            {brief.job_title}
+          </h1>
+          <p className="text-sm text-slate-500 mb-6">
+            {brief.brief_template ? BRIEF_TEMPLATE_LABELS[brief.brief_template] : ""}
+            {brief.location ? ` · ${brief.location}` : ""}
+          </p>
+
+          {/* Status banner */}
+          <div className="bg-white rounded-2xl border border-slate-200 p-6 mb-6">
+            <p className="text-xs uppercase tracking-widest text-slate-500 mb-2">
+              Status
+            </p>
+            <h2 className="text-lg font-bold text-slate-900 mb-3">
+              {brief.status === "closed"
+                ? "Closed"
+                : STATUS_LABELS[brief.tracker_status] ?? brief.tracker_status}
+            </h2>
+
+            {brief.risk_review_status === "pending_review" && (
+              <div className="mt-3 bg-amber-50 border border-amber-200 rounded-xl px-3 py-2 text-xs text-amber-800">
+                Your brief mentions topics that need a quick compliance review
+                before verified providers can see it. We&apos;ll email you once it&apos;s cleared.
+              </div>
+            )}
+
+            <ol className="mt-4 grid grid-cols-5 gap-2">
+              {STATUS_ORDER.map((s, idx) => {
+                const reached = idx <= stepIndex;
+                return (
+                  <li key={s} className="text-center">
+                    <div
+                      className={`w-7 h-7 rounded-full mx-auto flex items-center justify-center text-[10px] font-bold ${
+                        reached
+                          ? "bg-amber-500 text-slate-900"
+                          : "bg-slate-100 text-slate-400"
+                      }`}
+                    >
+                      {idx + 1}
+                    </div>
+                    <p
+                      className={`text-[10px] mt-1 ${
+                        reached ? "text-slate-700 font-semibold" : "text-slate-400"
+                      }`}
+                    >
+                      {STATUS_LABELS[s]}
+                    </p>
+                  </li>
+                );
+              })}
+            </ol>
+          </div>
+
+          {/* Accepted provider */}
+          {(accepted.professional || accepted.team) && (
+            <div className="bg-white rounded-2xl border border-slate-200 p-6 mb-6">
+              <p className="text-xs uppercase tracking-widest text-slate-500 mb-2">
+                Accepted by
+              </p>
+              {accepted.team && (
+                <p className="text-base font-bold text-slate-900">
+                  {accepted.team.name}{" "}
+                  <Link
+                    href={`/teams/${accepted.team.slug}`}
+                    className="text-xs text-amber-600 ml-1 hover:underline"
+                  >
+                    View team
+                  </Link>
+                </p>
+              )}
+              {accepted.professional && (
+                <p className="text-sm text-slate-700 mt-1">
+                  Lead contact:{" "}
+                  <span className="font-semibold">{accepted.professional.name}</span>
+                  {accepted.professional.slug && (
+                    <Link
+                      href={`/advisor/${accepted.professional.slug}`}
+                      className="text-xs text-amber-600 ml-1 hover:underline"
+                    >
+                      View profile
+                    </Link>
+                  )}
+                </p>
+              )}
+              <p className="text-xs text-slate-500 mt-3">
+                Advice and services are provided by the professional, firm or
+                team you engage — under their own licence and terms.
+              </p>
+            </div>
+          )}
+
+          {/* Brief summary */}
+          <div className="bg-white rounded-2xl border border-slate-200 p-6 mb-6">
+            <p className="text-xs uppercase tracking-widest text-slate-500 mb-2">
+              Brief summary
+            </p>
+            <p className="text-sm text-slate-700 whitespace-pre-line">
+              {brief.job_description}
+            </p>
+            <dl className="mt-4 grid grid-cols-2 gap-x-4 gap-y-2 text-xs text-slate-600">
+              <dt className="font-semibold">Template</dt>
+              <dd>
+                {brief.brief_template
+                  ? BRIEF_TEMPLATE_LABELS[brief.brief_template]
+                  : "—"}
+              </dd>
+              <dt className="font-semibold">Provider preference</dt>
+              <dd>{brief.provider_preference ?? "—"}</dd>
+              <dt className="font-semibold">Routing mode</dt>
+              <dd>{brief.routing_mode ?? "—"}</dd>
+              <dt className="font-semibold">Budget band</dt>
+              <dd>{brief.budget_band}</dd>
+              <dt className="font-semibold">Accept cost</dt>
+              <dd>
+                {brief.accept_credits_cost
+                  ? `${brief.accept_credits_cost} credits`
+                  : "—"}
+              </dd>
+            </dl>
+          </div>
+
+          {/* Email-key reveal */}
+          {emailMatches && (
+            <div className="bg-emerald-50 border border-emerald-200 rounded-2xl p-4 text-xs text-emerald-800">
+              You&apos;re viewing this Brief Tracker as the brief owner. We&apos;ll
+              email <strong>{brief.contact_email}</strong> when anything changes.
+            </div>
+          )}
+          {!emailMatches && (
+            <div className="bg-slate-100 border border-slate-200 rounded-2xl p-4 text-xs text-slate-600">
+              Looking for the full owner view? Use the link we emailed you, or
+              add <code>?email=&lt;your-email&gt;</code> to this page.
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/briefs/new/BriefForm.tsx
+++ b/app/briefs/new/BriefForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 
@@ -68,6 +68,13 @@ interface FormState {
   consent: boolean;
 }
 
+function providerPrefForRoute(route: string | null | undefined): string {
+  if (route === "expert_team") return "expert_team";
+  if (route === "firm") return "firm";
+  if (route === "individual") return "individual";
+  return "any";
+}
+
 const INITIAL: FormState = {
   brief_template: "",
   job_title: "",
@@ -88,12 +95,16 @@ export default function BriefForm() {
   const searchParams = useSearchParams();
   const presetTeam = searchParams?.get("team") ?? "";
   const presetTemplate = searchParams?.get("template") ?? "";
+  const presetProviderPreference = searchParams?.get("provider_preference") ?? "";
+  const presetRoutingMode = searchParams?.get("routing_mode") ?? "";
+  const planId = searchParams?.get("plan_id") ?? "";
 
   const [step, setStep] = useState<Step>("template");
   const [form, setForm] = useState<FormState>(() => ({
     ...INITIAL,
     target_team_slug: presetTeam || "",
-    routing_mode: presetTeam ? "direct" : "smart_match",
+    routing_mode: presetRoutingMode || (presetTeam ? "direct" : "smart_match"),
+    provider_preference: presetProviderPreference || "any",
     brief_template: (BRIEF_TEMPLATES.includes(presetTemplate as BriefTemplate)
       ? (presetTemplate as BriefTemplate)
       : "") as BriefTemplate | "",
@@ -105,6 +116,49 @@ export default function BriefForm() {
     accept_credits_cost: number | null;
     risk_review_status: string;
   } | null>(null);
+  const [planPrefilled, setPlanPrefilled] = useState(false);
+
+  // Pre-fill from Get Matched action plan if plan_id present.
+  useEffect(() => {
+    if (!planId) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(`/api/get-matched/plans/by-id/${planId}`);
+        if (!res.ok) return;
+        const data = await res.json();
+        const plan = data.plan;
+        const template =
+          (data.recommended_brief_template as BriefTemplate | null) ??
+          (BRIEF_TEMPLATES.includes(plan?.intent_slug)
+            ? (plan?.intent_slug as BriefTemplate)
+            : "general");
+        if (cancelled) return;
+        setForm((p) => ({
+          ...p,
+          brief_template: template,
+          job_title: plan?.goal ?? "Investment brief",
+          job_description: data.description ?? "Investment brief from action plan.",
+          budget_band: plan?.budget_band ?? "not_sure",
+          location_state: plan?.location_state ?? "NSW",
+          provider_preference:
+            presetProviderPreference || providerPrefForRoute(plan?.route),
+          routing_mode: presetRoutingMode || "smart_match",
+          payload: plan?.answers ?? {},
+        }));
+        setPlanPrefilled(true);
+        // Skip ahead to contact step since template + details + preference
+        // are now known.
+        setStep("contact");
+      } catch {
+        /* ignore */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [planId]);
 
   const fields: FieldHint[] = useMemo(() => {
     if (!form.brief_template) return [];
@@ -144,30 +198,46 @@ export default function BriefForm() {
     setLoading(true);
     setError(null);
     try {
-      const res = await fetch("/api/briefs", {
+      // If we have a plan_id, use the plan→brief endpoint so the brief is
+      // linked back to the action plan.
+      const fromPlan = !!planId && planPrefilled;
+      const url = fromPlan
+        ? `/api/get-matched/plans/${planId}/to-brief`
+        : "/api/briefs";
+      const body = fromPlan
+        ? {
+            contact_name: form.contact_name,
+            contact_email: form.contact_email,
+            contact_phone: form.contact_phone || undefined,
+            routing_mode: form.routing_mode,
+            provider_preference: form.provider_preference,
+            consent_share: form.consent,
+          }
+        : {
+            brief_template: form.brief_template,
+            brief_payload: form.payload,
+            job_title: form.job_title,
+            job_description: form.job_description,
+            budget_band: form.budget_band,
+            location_state: form.location_state,
+            provider_preference: form.provider_preference,
+            routing_mode: form.routing_mode,
+            target_team_slug: form.target_team_slug || undefined,
+            advisor_types: [],
+            contact_name: form.contact_name,
+            contact_email: form.contact_email,
+            contact_phone: form.contact_phone || undefined,
+            consent_share: form.consent,
+          };
+      const res = await fetch(url, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          brief_template: form.brief_template,
-          brief_payload: form.payload,
-          job_title: form.job_title,
-          job_description: form.job_description,
-          budget_band: form.budget_band,
-          location_state: form.location_state,
-          provider_preference: form.provider_preference,
-          routing_mode: form.routing_mode,
-          target_team_slug: form.target_team_slug || undefined,
-          advisor_types: [],
-          contact_name: form.contact_name,
-          contact_email: form.contact_email,
-          contact_phone: form.contact_phone || undefined,
-          consent_share: form.consent,
-        }),
+        body: JSON.stringify(body),
       });
       const data = await res.json();
       if (!res.ok) throw new Error(data?.error || "Failed to create brief.");
       setResult({
-        slug: data.slug,
+        slug: fromPlan ? (data.brief_slug as string) : (data.slug as string),
         accept_credits_cost: data.accept_credits_cost ?? null,
         risk_review_status: data.risk_review_status ?? "clear",
       });
@@ -524,6 +594,14 @@ export default function BriefForm() {
 
       {step === "contact" && (
         <div className="space-y-6">
+          {planPrefilled && (
+            <div className="bg-amber-50 border border-amber-200 rounded-xl p-3 flex items-start gap-2">
+              <Icon name="check-circle" size={14} className="text-amber-600 mt-0.5 shrink-0" />
+              <p className="text-xs text-amber-900 leading-relaxed">
+                <strong>Pre-filled from your Action Plan.</strong> We&apos;ll send this brief with the goal, budget, timeline and route you already picked. Edit anything you need below.
+              </p>
+            </div>
+          )}
           <div>
             <h2 className="text-xl font-bold text-slate-900 mb-1">
               Your details

--- a/app/briefs/new/BriefForm.tsx
+++ b/app/briefs/new/BriefForm.tsx
@@ -1,0 +1,738 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import Link from "next/link";
+
+import Icon from "@/components/Icon";
+import {
+  BRIEF_TEMPLATES,
+  BRIEF_TEMPLATE_LABELS,
+  BRIEF_TEMPLATE_BLURBS,
+  BRIEF_TEMPLATE_FIELDS,
+  type FieldHint,
+} from "@/lib/briefs/templates";
+import type { BriefTemplate } from "@/lib/briefs/types";
+
+type Step = "template" | "details" | "preference" | "contact" | "success";
+
+const STATES = ["NSW", "VIC", "QLD", "WA", "SA", "TAS", "ACT", "NT"];
+const BUDGETS = [
+  { value: "under_500", label: "Under $500" },
+  { value: "500_2k", label: "$500 – $2,000" },
+  { value: "2k_5k", label: "$2,000 – $5,000" },
+  { value: "5k_10k", label: "$5,000 – $10,000" },
+  { value: "10k_plus", label: "$10,000+" },
+  { value: "not_sure", label: "Budget TBD" },
+];
+
+const PROVIDER_PREFERENCES = [
+  { value: "any", label: "No preference" },
+  { value: "individual", label: "Individual expert" },
+  { value: "firm", label: "Firm / brokerage" },
+  { value: "expert_team", label: "Expert team" },
+  { value: "multiple", label: "Multiple professional responses" },
+];
+
+const ROUTING_MODES = [
+  {
+    value: "smart_match",
+    label: "Smart Match",
+    blurb: "We route to the most relevant verified providers.",
+  },
+  {
+    value: "direct",
+    label: "Send to a specific provider",
+    blurb: "Use a team/firm/individual slug from their profile page.",
+  },
+  {
+    value: "multi_response",
+    label: "Receive multiple responses",
+    blurb: "Open the brief up to several providers in parallel.",
+  },
+];
+
+interface FormState {
+  brief_template: BriefTemplate | "";
+  job_title: string;
+  job_description: string;
+  budget_band: string;
+  location_state: string;
+  payload: Record<string, unknown>;
+  provider_preference: string;
+  routing_mode: string;
+  target_team_slug: string;
+  contact_name: string;
+  contact_email: string;
+  contact_phone: string;
+  consent: boolean;
+}
+
+const INITIAL: FormState = {
+  brief_template: "",
+  job_title: "",
+  job_description: "",
+  budget_band: "",
+  location_state: "",
+  payload: {},
+  provider_preference: "any",
+  routing_mode: "smart_match",
+  target_team_slug: "",
+  contact_name: "",
+  contact_email: "",
+  contact_phone: "",
+  consent: false,
+};
+
+export default function BriefForm() {
+  const searchParams = useSearchParams();
+  const presetTeam = searchParams?.get("team") ?? "";
+  const presetTemplate = searchParams?.get("template") ?? "";
+
+  const [step, setStep] = useState<Step>("template");
+  const [form, setForm] = useState<FormState>(() => ({
+    ...INITIAL,
+    target_team_slug: presetTeam || "",
+    routing_mode: presetTeam ? "direct" : "smart_match",
+    brief_template: (BRIEF_TEMPLATES.includes(presetTemplate as BriefTemplate)
+      ? (presetTemplate as BriefTemplate)
+      : "") as BriefTemplate | "",
+  }));
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<{
+    slug: string;
+    accept_credits_cost: number | null;
+    risk_review_status: string;
+  } | null>(null);
+
+  const fields: FieldHint[] = useMemo(() => {
+    if (!form.brief_template) return [];
+    return BRIEF_TEMPLATE_FIELDS[form.brief_template] ?? [];
+  }, [form.brief_template]);
+
+  function setField<K extends keyof FormState>(key: K, value: FormState[K]) {
+    setForm((p) => ({ ...p, [key]: value }));
+  }
+
+  function setPayload(key: string, value: unknown) {
+    setForm((p) => ({ ...p, payload: { ...p.payload, [key]: value } }));
+  }
+
+  const canTemplate = !!form.brief_template;
+  const canDetails =
+    form.job_title.trim().length >= 8 &&
+    form.job_description.trim().length >= 30 &&
+    form.budget_band &&
+    form.location_state &&
+    fields
+      .filter((f) => f.required)
+      .every((f) => {
+        const v = form.payload[f.key];
+        if (f.kind === "multiselect") {
+          return Array.isArray(v) && v.length > 0;
+        }
+        return typeof v === "string" && v.length > 0;
+      });
+  const canPreference = !!form.provider_preference && !!form.routing_mode;
+  const canContact =
+    form.contact_name.trim().length > 0 &&
+    /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.contact_email) &&
+    form.consent;
+
+  async function submit() {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/briefs", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          brief_template: form.brief_template,
+          brief_payload: form.payload,
+          job_title: form.job_title,
+          job_description: form.job_description,
+          budget_band: form.budget_band,
+          location_state: form.location_state,
+          provider_preference: form.provider_preference,
+          routing_mode: form.routing_mode,
+          target_team_slug: form.target_team_slug || undefined,
+          advisor_types: [],
+          contact_name: form.contact_name,
+          contact_email: form.contact_email,
+          contact_phone: form.contact_phone || undefined,
+          consent_share: form.consent,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data?.error || "Failed to create brief.");
+      setResult({
+        slug: data.slug,
+        accept_credits_cost: data.accept_credits_cost ?? null,
+        risk_review_status: data.risk_review_status ?? "clear",
+      });
+      setStep("success");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (step === "success" && result) {
+    const heldForReview = result.risk_review_status === "pending_review";
+    return (
+      <div className="bg-white border border-emerald-200 rounded-2xl p-8 text-center max-w-2xl mx-auto">
+        <div className="w-14 h-14 bg-emerald-100 rounded-full flex items-center justify-center mx-auto mb-4">
+          <Icon name="check-circle" size={28} className="text-emerald-600" />
+        </div>
+        <h2 className="text-2xl font-extrabold text-slate-900 mb-2">
+          Investor Brief created
+        </h2>
+        <p className="text-slate-600 text-sm leading-relaxed mb-6 max-w-md mx-auto">
+          {heldForReview
+            ? "Your brief mentions topics that need a quick compliance review before verified providers can see it. We'll email you once it's cleared."
+            : `Verified providers can now see a masked preview of your brief. ${
+                result.accept_credits_cost
+                  ? `Accept cost: ~${result.accept_credits_cost} credits.`
+                  : ""
+              } We'll email you when a provider accepts.`}
+        </p>
+        <div className="flex flex-col sm:flex-row gap-3 justify-center">
+          <Link
+            href={`/briefs/${result.slug}?email=${encodeURIComponent(
+              form.contact_email,
+            )}`}
+            className="inline-flex items-center justify-center gap-2 bg-amber-500 hover:bg-amber-400 text-slate-900 font-bold px-6 py-3 rounded-xl transition-colors"
+          >
+            View your Brief Tracker
+            <Icon name="arrow-right" size={16} />
+          </Link>
+          <Link
+            href="/advisors"
+            className="inline-flex items-center justify-center gap-2 bg-white border border-slate-200 text-slate-700 font-semibold px-6 py-3 rounded-xl hover:border-slate-300 transition-colors"
+          >
+            Browse verified providers
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white border border-slate-200 rounded-2xl p-6 sm:p-8 shadow-sm">
+      {/* Progress */}
+      <div className="flex items-center gap-2 mb-8">
+        {(["template", "details", "preference", "contact"] as Step[]).map(
+          (s, i) => {
+            const order: Step[] = ["template", "details", "preference", "contact"];
+            const cur = order.indexOf(step);
+            const idx = order.indexOf(s);
+            const done = cur > idx;
+            const active = step === s;
+            const labels: Record<string, string> = {
+              template: "Template",
+              details: "Details",
+              preference: "Match",
+              contact: "Contact",
+            };
+            return (
+              <div key={s} className="flex items-center gap-2 flex-1">
+                {i > 0 && (
+                  <div
+                    className={`flex-1 h-px ${done ? "bg-amber-500" : "bg-slate-200"}`}
+                  />
+                )}
+                <div className="flex items-center gap-2">
+                  <div
+                    className={`w-7 h-7 rounded-full flex items-center justify-center text-xs font-bold ${
+                      done
+                        ? "bg-amber-500 text-slate-900"
+                        : active
+                          ? "bg-slate-900 text-white"
+                          : "bg-slate-200 text-slate-500"
+                    }`}
+                  >
+                    {done ? <Icon name="check" size={13} /> : i + 1}
+                  </div>
+                  <span
+                    className={`text-xs hidden sm:block ${active ? "text-slate-900 font-semibold" : "text-slate-400"}`}
+                  >
+                    {labels[s]}
+                  </span>
+                </div>
+              </div>
+            );
+          },
+        )}
+      </div>
+
+      {step === "template" && (
+        <div className="space-y-6">
+          <div>
+            <h2 className="text-xl font-bold text-slate-900 mb-1">
+              Pick a brief template
+            </h2>
+            <p className="text-sm text-slate-500">
+              Each template asks the right structured questions so verified providers can respond well.
+            </p>
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            {BRIEF_TEMPLATES.filter(
+              (t) => t !== "listing" && t !== "listing_readiness",
+            ).map((t) => (
+              <button
+                type="button"
+                key={t}
+                onClick={() => setField("brief_template", t)}
+                className={`text-left rounded-xl p-4 border transition-colors ${
+                  form.brief_template === t
+                    ? "border-amber-500 ring-2 ring-amber-300 bg-amber-50"
+                    : "border-slate-200 hover:border-slate-300"
+                }`}
+              >
+                <p className="font-bold text-sm text-slate-900">
+                  {BRIEF_TEMPLATE_LABELS[t]}
+                </p>
+                <p className="text-xs text-slate-500 mt-0.5 leading-snug">
+                  {BRIEF_TEMPLATE_BLURBS[t]}
+                </p>
+              </button>
+            ))}
+          </div>
+          <div className="flex justify-end">
+            <button
+              type="button"
+              disabled={!canTemplate}
+              onClick={() => setStep("details")}
+              className="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-400 disabled:bg-slate-200 disabled:text-slate-400 disabled:cursor-not-allowed text-slate-900 font-bold px-7 py-3 rounded-xl"
+            >
+              Continue <Icon name="arrow-right" size={16} />
+            </button>
+          </div>
+        </div>
+      )}
+
+      {step === "details" && form.brief_template && (
+        <div className="space-y-6">
+          <div>
+            <h2 className="text-xl font-bold text-slate-900 mb-1">
+              {BRIEF_TEMPLATE_LABELS[form.brief_template]}
+            </h2>
+            <p className="text-sm text-slate-500">
+              Be specific — verified providers respond better when the brief is clear.
+            </p>
+          </div>
+
+          <div>
+            <label className="block text-sm font-semibold text-slate-700 mb-1.5">
+              Title <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="text"
+              maxLength={120}
+              value={form.job_title}
+              onChange={(e) => setField("job_title", e.target.value)}
+              placeholder="e.g. SMSF property strategy in QLD"
+              className="w-full border border-slate-300 rounded-lg px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-semibold text-slate-700 mb-1.5">
+              Describe the situation <span className="text-red-500">*</span>
+            </label>
+            <textarea
+              rows={5}
+              maxLength={3000}
+              value={form.job_description}
+              onChange={(e) => setField("job_description", e.target.value)}
+              placeholder="What's the situation, what outcome you want, any deadlines."
+              className="w-full border border-slate-300 rounded-lg px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400 resize-y"
+            />
+            <p className="text-xs text-slate-400 mt-1">
+              {form.job_description.length} / 3000
+            </p>
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-semibold text-slate-700 mb-1.5">
+                State <span className="text-red-500">*</span>
+              </label>
+              <select
+                value={form.location_state}
+                onChange={(e) => setField("location_state", e.target.value)}
+                className="w-full border border-slate-300 rounded-lg px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400"
+              >
+                <option value="">Select state</option>
+                {STATES.map((s) => (
+                  <option key={s} value={s}>
+                    {s}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className="block text-sm font-semibold text-slate-700 mb-1.5">
+                Budget band <span className="text-red-500">*</span>
+              </label>
+              <select
+                value={form.budget_band}
+                onChange={(e) => setField("budget_band", e.target.value)}
+                className="w-full border border-slate-300 rounded-lg px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400"
+              >
+                <option value="">Select budget</option>
+                {BUDGETS.map((b) => (
+                  <option key={b.value} value={b.value}>
+                    {b.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          {fields.length > 0 && (
+            <div className="border-t border-slate-100 pt-6 space-y-4">
+              <p className="text-xs font-semibold uppercase tracking-wider text-slate-500">
+                Template-specific details
+              </p>
+              {fields.map((field) => (
+                <DynamicField
+                  key={field.key}
+                  field={field}
+                  value={form.payload[field.key]}
+                  onChange={(v) => setPayload(field.key, v)}
+                />
+              ))}
+            </div>
+          )}
+
+          <div className="flex justify-between">
+            <button
+              type="button"
+              onClick={() => setStep("template")}
+              className="inline-flex items-center gap-2 text-slate-600 hover:text-slate-900 font-semibold text-sm px-4 py-2.5"
+            >
+              <Icon name="arrow-left" size={14} /> Back
+            </button>
+            <button
+              type="button"
+              disabled={!canDetails}
+              onClick={() => setStep("preference")}
+              className="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-400 disabled:bg-slate-200 disabled:text-slate-400 disabled:cursor-not-allowed text-slate-900 font-bold px-7 py-3 rounded-xl"
+            >
+              Continue <Icon name="arrow-right" size={16} />
+            </button>
+          </div>
+        </div>
+      )}
+
+      {step === "preference" && (
+        <div className="space-y-6">
+          <div>
+            <h2 className="text-xl font-bold text-slate-900 mb-1">
+              Who do you want to hear from?
+            </h2>
+            <p className="text-sm text-slate-500">
+              Pick the provider type and the routing mode. You stay in control.
+            </p>
+          </div>
+
+          <div>
+            <p className="block text-sm font-semibold text-slate-700 mb-2">
+              Provider preference
+            </p>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+              {PROVIDER_PREFERENCES.map((p) => (
+                <button
+                  type="button"
+                  key={p.value}
+                  onClick={() => setField("provider_preference", p.value)}
+                  className={`text-left rounded-lg p-3 border text-sm transition-colors ${
+                    form.provider_preference === p.value
+                      ? "border-amber-500 ring-2 ring-amber-300 bg-amber-50"
+                      : "border-slate-200 hover:border-slate-300"
+                  }`}
+                >
+                  {p.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <p className="block text-sm font-semibold text-slate-700 mb-2">
+              Routing mode
+            </p>
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+              {ROUTING_MODES.map((m) => (
+                <button
+                  type="button"
+                  key={m.value}
+                  onClick={() => setField("routing_mode", m.value)}
+                  className={`text-left rounded-lg p-3 border text-sm transition-colors ${
+                    form.routing_mode === m.value
+                      ? "border-amber-500 ring-2 ring-amber-300 bg-amber-50"
+                      : "border-slate-200 hover:border-slate-300"
+                  }`}
+                >
+                  <p className="font-semibold text-slate-900">{m.label}</p>
+                  <p className="text-xs text-slate-500 mt-0.5">{m.blurb}</p>
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {form.routing_mode === "direct" && (
+            <div>
+              <label className="block text-sm font-semibold text-slate-700 mb-1.5">
+                Target team / firm / individual slug
+              </label>
+              <input
+                type="text"
+                value={form.target_team_slug}
+                onChange={(e) => setField("target_team_slug", e.target.value)}
+                placeholder="e.g. sydney-smsf-property-team"
+                className="w-full border border-slate-300 rounded-lg px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400"
+              />
+              <p className="text-xs text-slate-400 mt-1">
+                Use the slug from a verified team, firm or individual profile URL.
+              </p>
+            </div>
+          )}
+
+          <div className="flex justify-between">
+            <button
+              type="button"
+              onClick={() => setStep("details")}
+              className="inline-flex items-center gap-2 text-slate-600 hover:text-slate-900 font-semibold text-sm px-4 py-2.5"
+            >
+              <Icon name="arrow-left" size={14} /> Back
+            </button>
+            <button
+              type="button"
+              disabled={!canPreference}
+              onClick={() => setStep("contact")}
+              className="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-400 disabled:bg-slate-200 disabled:text-slate-400 disabled:cursor-not-allowed text-slate-900 font-bold px-7 py-3 rounded-xl"
+            >
+              Continue <Icon name="arrow-right" size={16} />
+            </button>
+          </div>
+        </div>
+      )}
+
+      {step === "contact" && (
+        <div className="space-y-6">
+          <div>
+            <h2 className="text-xl font-bold text-slate-900 mb-1">
+              Your details
+            </h2>
+            <p className="text-sm text-slate-500">
+              Hidden from providers until one accepts your brief.
+            </p>
+          </div>
+
+          <div>
+            <label className="block text-sm font-semibold text-slate-700 mb-1.5">
+              Name <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="text"
+              value={form.contact_name}
+              onChange={(e) => setField("contact_name", e.target.value)}
+              className="w-full border border-slate-300 rounded-lg px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400"
+            />
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-semibold text-slate-700 mb-1.5">
+                Email <span className="text-red-500">*</span>
+              </label>
+              <input
+                type="email"
+                value={form.contact_email}
+                onChange={(e) => setField("contact_email", e.target.value)}
+                placeholder="you@example.com"
+                className="w-full border border-slate-300 rounded-lg px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-semibold text-slate-700 mb-1.5">
+                Phone
+              </label>
+              <input
+                type="tel"
+                value={form.contact_phone}
+                onChange={(e) => setField("contact_phone", e.target.value)}
+                placeholder="+61 4XX XXX XXX"
+                className="w-full border border-slate-300 rounded-lg px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400"
+              />
+            </div>
+          </div>
+
+          <label className="flex items-start gap-3 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={form.consent}
+              onChange={(e) => setField("consent", e.target.checked)}
+              className="mt-0.5 w-4 h-4 accent-amber-500 shrink-0"
+            />
+            <span className="text-xs text-slate-600 leading-relaxed">
+              I&apos;m happy for my brief details (without contact information) to be shown to relevant verified providers. My contact details are only shared after a provider accepts. I&apos;ve read the{" "}
+              <Link href="/privacy" className="underline hover:text-slate-700">
+                privacy policy
+              </Link>
+              {" "}and{" "}
+              <Link href="/terms" className="underline hover:text-slate-700">
+                terms
+              </Link>
+              . I understand Invest.com.au provides general information only — the professional, firm or team I engage delivers the service under their own licence.
+            </span>
+          </label>
+
+          {error && (
+            <div className="bg-red-50 border border-red-200 rounded-xl p-3 text-sm text-red-700">
+              {error}
+            </div>
+          )}
+
+          <div className="flex justify-between">
+            <button
+              type="button"
+              onClick={() => setStep("preference")}
+              className="inline-flex items-center gap-2 text-slate-600 hover:text-slate-900 font-semibold text-sm px-4 py-2.5"
+            >
+              <Icon name="arrow-left" size={14} /> Back
+            </button>
+            <button
+              type="button"
+              disabled={!canContact || loading}
+              onClick={submit}
+              className="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-400 disabled:bg-amber-300 text-slate-900 font-bold px-8 py-3 rounded-xl"
+            >
+              {loading ? (
+                <>
+                  <div className="w-4 h-4 border-2 border-slate-900 border-t-transparent rounded-full animate-spin" />
+                  Creating…
+                </>
+              ) : (
+                <>
+                  Create Investor Brief <Icon name="check" size={16} />
+                </>
+              )}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function DynamicField({
+  field,
+  value,
+  onChange,
+}: {
+  field: FieldHint;
+  value: unknown;
+  onChange: (v: unknown) => void;
+}) {
+  if (field.kind === "text") {
+    return (
+      <div>
+        <label className="block text-sm font-semibold text-slate-700 mb-1.5">
+          {field.label}
+          {field.required && <span className="text-red-500"> *</span>}
+        </label>
+        <input
+          type="text"
+          maxLength={field.maxLength}
+          placeholder={field.placeholder}
+          value={typeof value === "string" ? value : ""}
+          onChange={(e) => onChange(e.target.value)}
+          className="w-full border border-slate-300 rounded-lg px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400"
+        />
+      </div>
+    );
+  }
+  if (field.kind === "textarea") {
+    return (
+      <div>
+        <label className="block text-sm font-semibold text-slate-700 mb-1.5">
+          {field.label}
+          {field.required && <span className="text-red-500"> *</span>}
+        </label>
+        <textarea
+          rows={3}
+          maxLength={field.maxLength}
+          placeholder={field.placeholder}
+          value={typeof value === "string" ? value : ""}
+          onChange={(e) => onChange(e.target.value)}
+          className="w-full border border-slate-300 rounded-lg px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400 resize-y"
+        />
+      </div>
+    );
+  }
+  if (field.kind === "select") {
+    return (
+      <div>
+        <label className="block text-sm font-semibold text-slate-700 mb-1.5">
+          {field.label}
+          {field.required && <span className="text-red-500"> *</span>}
+        </label>
+        <select
+          value={typeof value === "string" ? value : ""}
+          onChange={(e) => onChange(e.target.value)}
+          className="w-full border border-slate-300 rounded-lg px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400"
+        >
+          <option value="">Select…</option>
+          {field.options?.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+        </select>
+      </div>
+    );
+  }
+  // multiselect
+  const arr = Array.isArray(value) ? (value as string[]) : [];
+  return (
+    <div>
+      <p className="block text-sm font-semibold text-slate-700 mb-1.5">
+        {field.label}
+        {field.required && <span className="text-red-500"> *</span>}
+      </p>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+        {field.options?.map((o) => {
+          const checked = arr.includes(o.value);
+          return (
+            <label
+              key={o.value}
+              className={`flex items-center gap-2 rounded-lg border px-3 py-2 text-sm cursor-pointer transition-colors ${
+                checked
+                  ? "border-amber-500 bg-amber-50"
+                  : "border-slate-200 hover:border-slate-300"
+              }`}
+            >
+              <input
+                type="checkbox"
+                className="accent-amber-500"
+                checked={checked}
+                onChange={() => {
+                  const next = checked
+                    ? arr.filter((x) => x !== o.value)
+                    : [...arr, o.value];
+                  onChange(next);
+                }}
+              />
+              <span className="text-slate-700">{o.label}</span>
+            </label>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/app/briefs/new/page.tsx
+++ b/app/briefs/new/page.tsx
@@ -1,0 +1,138 @@
+import type { Metadata } from "next";
+import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
+import Icon from "@/components/Icon";
+import BriefForm from "./BriefForm";
+
+export const revalidate = 3600;
+
+export const metadata: Metadata = {
+  title: `Create an Investor Brief (${CURRENT_YEAR}) — Invest.com.au`,
+  description:
+    "Create a structured Investor Brief so verified Australian providers — individuals, firms or expert teams — can understand what you need and respond. General information only; the provider you engage delivers the service.",
+  alternates: { canonical: `${SITE_URL}/briefs/new` },
+  robots: { index: true, follow: true },
+};
+
+const TRUST_BLOCKS = [
+  {
+    icon: "shield-check",
+    title: "Verified providers only",
+    desc: "Every professional, firm and team is verified before they can receive briefs.",
+  },
+  {
+    icon: "lock",
+    title: "Your contact details stay private",
+    desc: "Providers see a masked preview. Contact details only unlock after a provider accepts.",
+  },
+  {
+    icon: "users",
+    title: "You stay in control",
+    desc: "Route to an individual, a firm, or an expert team. Pick the response that fits.",
+  },
+  {
+    icon: "info",
+    title: "General information",
+    desc: "We are a marketplace, not an adviser. Services are delivered by the provider you engage.",
+  },
+];
+
+export default function NewBriefPage({
+  searchParams,
+}: {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  void searchParams;
+  const breadcrumb = breadcrumbJsonLd([
+    { name: "Home", url: `${SITE_URL}/` },
+    { name: "Investor Briefs", url: `${SITE_URL}/briefs` },
+    { name: "Create" },
+  ]);
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
+      />
+
+      <section className="bg-gradient-to-b from-slate-900 via-slate-900 to-slate-800 text-white">
+        <div className="max-w-5xl mx-auto px-4 py-16 sm:py-20">
+          <div className="text-center">
+            <p className="text-amber-400 text-xs font-semibold uppercase tracking-widest mb-3">
+              Investor Brief · Australia
+            </p>
+            <h1 className="text-3xl sm:text-5xl font-extrabold mb-4">
+              Create an Investor Brief
+            </h1>
+            <p className="text-slate-300 max-w-2xl mx-auto leading-relaxed">
+              Tell verified Australian professionals, firms or expert teams what
+              you need help with. They&apos;ll see a masked preview and respond
+              only if it&apos;s a fit. You stay in control of who sees your
+              contact details.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 sm:gap-6 max-w-4xl mx-auto mt-12">
+            {TRUST_BLOCKS.map((t) => (
+              <div
+                key={t.title}
+                className="bg-white/5 rounded-xl p-4 border border-white/10"
+              >
+                <Icon name={t.icon} size={20} className="text-amber-400 mb-2" />
+                <p className="text-sm font-bold text-white mb-1">{t.title}</p>
+                <p className="text-xs text-slate-400 leading-snug">{t.desc}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="bg-slate-50 py-12 sm:py-16">
+        <div className="max-w-3xl mx-auto px-4">
+          <BriefForm />
+        </div>
+      </section>
+
+      <section className="bg-white py-12 sm:py-16">
+        <div className="max-w-4xl mx-auto px-4">
+          <h2 className="text-2xl sm:text-3xl font-extrabold text-slate-900 mb-2 text-center">
+            How an Investor Brief works
+          </h2>
+          <p className="text-sm text-slate-500 mb-10 text-center max-w-2xl mx-auto">
+            A structured way to bring verified providers into your decision.
+            Invest.com.au never gives personal advice — the professional or
+            firm you engage delivers the service under their own licence.
+          </p>
+
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-6">
+            {[
+              {
+                n: 1,
+                title: "Tell us what you need",
+                desc: "Pick a template, answer a few structured questions, and set how you want to be matched.",
+              },
+              {
+                n: 2,
+                title: "Verified providers may respond",
+                desc: "Eligible individuals, firms or expert teams see a masked preview and can accept with credits to unlock your details.",
+              },
+              {
+                n: 3,
+                title: "Follow along in the Brief Tracker",
+                desc: "Status, next step, and accepted provider — all in one place. The service itself sits with the professional.",
+              },
+            ].map((s) => (
+              <div key={s.n} className="text-center">
+                <div className="w-12 h-12 bg-amber-500 text-slate-900 rounded-full font-extrabold flex items-center justify-center mx-auto mb-3 text-lg">
+                  {s.n}
+                </div>
+                <p className="font-bold text-slate-900 mb-1">{s.title}</p>
+                <p className="text-sm text-slate-600 leading-relaxed">{s.desc}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -3,6 +3,7 @@ import { createClient } from "@/lib/supabase/server";
 import type { Broker } from "@/lib/types";
 import CompareClient from "./CompareClient";
 import CompareNav from "./CompareNav";
+import GetMatchedEmbed from "@/components/get-matched/GetMatchedEmbed";
 import { absoluteUrl, UPDATED_LABEL } from "@/lib/seo";
 import ComplianceFooter from "@/components/ComplianceFooter";
 import HomeToolsStrip from "@/components/HomeToolsStrip";
@@ -150,6 +151,9 @@ export default function ComparePage() {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }}
       />
       <Suspense><CompareNav /></Suspense>
+      <div className="container-custom pt-5">
+        <GetMatchedEmbed context="platform_compare" />
+      </div>
       {/* Server-rendered H1 for crawlers that don't execute client JS — streams immediately */}
       <div className="container-custom pt-5 md:pt-10">
         <div className="mb-3"><IntentCountryBadge /></div>

--- a/app/get-matched/GetMatchedClient.tsx
+++ b/app/get-matched/GetMatchedClient.tsx
@@ -1,0 +1,853 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+
+import Icon from "@/components/Icon";
+import type {
+  ActionPlan,
+  ActionPlanAnswers,
+  QuestionDef,
+  ResultTemplate,
+} from "@/lib/getmatched/types";
+
+type NextStep =
+  | {
+      done: false;
+      question: QuestionDef;
+      totalSteps: number;
+      currentStep: number;
+    }
+  | {
+      done: true;
+      totalSteps: number;
+      currentStep: number;
+    };
+
+interface StartResponse {
+  plan_id: number;
+  share_token: string;
+  session_id: string;
+  next: NextStep;
+}
+
+interface AnswerResponse {
+  plan_id: number;
+  next: NextStep;
+}
+
+interface ResolveResponse {
+  plan: ActionPlan;
+  template: ResultTemplate;
+  recommended_brief_template: string | null;
+  accept_credits_cost: number | null;
+  recommended_providers: { kind: string; id: number }[];
+}
+
+interface Props {
+  initialGoal: string | null;
+  initialIntent: string | null;
+  initialContext: string | null;
+  initialPlanId: number | null;
+  initialMode: "fast" | "guided" | "both";
+}
+
+const SESSION_STORAGE_KEY = "iv_gm_session";
+
+function newSessionId(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return Math.random().toString(36).slice(2) + Date.now().toString(36);
+}
+
+export default function GetMatchedClient(props: Props) {
+  const router = useRouter();
+  const [planId, setPlanId] = useState<number | null>(props.initialPlanId);
+  const [shareToken, setShareToken] = useState<string | null>(null);
+  const [step, setStep] = useState<NextStep | null>(null);
+  const [answers, setAnswers] = useState<ActionPlanAnswers>({});
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [result, setResult] = useState<ResolveResponse | null>(null);
+
+  // Anonymous session id, persisted across refreshes so Back keeps progress.
+  const sessionIdRef = useRef<string>("");
+  if (!sessionIdRef.current && typeof window !== "undefined") {
+    const stored = window.sessionStorage.getItem(SESSION_STORAGE_KEY);
+    sessionIdRef.current = stored ?? newSessionId();
+    window.sessionStorage.setItem(SESSION_STORAGE_KEY, sessionIdRef.current);
+  }
+
+  // Build the "start" payload based on context + goal hints from query.
+  const startPrefill = useMemo(() => {
+    const prefill: ActionPlanAnswers = {};
+    if (props.initialGoal) prefill.intent = props.initialGoal;
+    if (props.initialIntent && !prefill.intent) prefill.intent = props.initialIntent;
+    return prefill;
+  }, [props.initialGoal, props.initialIntent]);
+
+  const start = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/get-matched/start", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          session_id: sessionIdRef.current,
+          mode: props.initialMode,
+          prefill: startPrefill,
+          source_page: window.location.pathname,
+        }),
+      });
+      const data = (await res.json()) as StartResponse | { error: string };
+      if (!res.ok || !("plan_id" in data)) {
+        throw new Error("error" in data ? data.error : "Failed to start.");
+      }
+      setPlanId(data.plan_id);
+      setShareToken(data.share_token);
+      setAnswers(startPrefill);
+      setStep(data.next);
+      if (data.next.done) {
+        // Pre-filled everything — go straight to resolve.
+        await resolve(data.plan_id);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to start.");
+    } finally {
+      setLoading(false);
+    }
+  }, [props.initialMode, startPrefill]);
+
+  useEffect(() => {
+    void start();
+  }, [start]);
+
+  async function submitAnswer(value: ActionPlanAnswers[string]) {
+    if (!planId || !step || step.done) return;
+    setSubmitting(true);
+    setError(null);
+    const slug = step.question.slug;
+    const mapsTo = step.question.maps_to;
+    const nextAnswers = { ...answers, [slug]: value, [mapsTo]: value };
+    setAnswers(nextAnswers);
+    try {
+      const res = await fetch("/api/get-matched/answer", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          plan_id: planId,
+          question_slug: slug,
+          value,
+        }),
+      });
+      const data = (await res.json()) as AnswerResponse | { error: string };
+      if (!res.ok || !("plan_id" in data)) {
+        throw new Error("error" in data ? data.error : "Failed.");
+      }
+      setStep(data.next);
+      if (data.next.done) {
+        await resolve(planId);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save answer.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function resolve(id: number) {
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/get-matched/resolve", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ plan_id: id }),
+      });
+      const data = (await res.json()) as ResolveResponse | { error: string };
+      if (!res.ok || !("plan" in data)) {
+        throw new Error("error" in data ? data.error : "Failed to resolve.");
+      }
+      setResult(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to resolve.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="min-h-[60vh] flex items-center justify-center">
+        <div className="text-sm text-slate-500">Building your plan…</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="min-h-[60vh] flex items-center justify-center p-6">
+        <div className="bg-red-50 border border-red-200 text-red-700 text-sm rounded-xl p-4 max-w-md">
+          {error}
+          <button
+            type="button"
+            onClick={() => void start()}
+            className="mt-3 block text-xs underline"
+          >
+            Try again
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (result) {
+    return (
+      <ActionPlanScreen
+        result={result}
+        shareToken={shareToken}
+        onChecklistToggle={async (index) => {
+          if (!planId) return;
+          await fetch(`/api/get-matched/plans/${planId}/checklist`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ index }),
+          });
+        }}
+        onSaveByEmail={async (email) => {
+          if (!planId) return null;
+          const res = await fetch(`/api/get-matched/plans/${planId}/save`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ email }),
+          });
+          const data = await res.json();
+          if (!res.ok) throw new Error(data?.error ?? "Failed to save.");
+          return data.view_url as string;
+        }}
+        onCreateBrief={() => {
+          if (!planId) return;
+          router.push(`/briefs/new?plan_id=${planId}`);
+        }}
+        onRestart={() => {
+          window.sessionStorage.removeItem(SESSION_STORAGE_KEY);
+          sessionIdRef.current = newSessionId();
+          window.sessionStorage.setItem(
+            SESSION_STORAGE_KEY,
+            sessionIdRef.current,
+          );
+          setResult(null);
+          setAnswers({});
+          setStep(null);
+          setPlanId(null);
+          void start();
+        }}
+      />
+    );
+  }
+
+  if (!step || step.done) {
+    return (
+      <div className="min-h-[60vh] flex items-center justify-center">
+        <div className="text-sm text-slate-500">Finalising your plan…</div>
+      </div>
+    );
+  }
+
+  return (
+    <QuestionScreen
+      key={step.question.slug}
+      step={step}
+      answers={answers}
+      submitting={submitting}
+      onAnswer={(value) => void submitAnswer(value)}
+    />
+  );
+}
+
+// ─── Question screen ──────────────────────────────────────────────────────
+
+function QuestionScreen({
+  step,
+  answers,
+  submitting,
+  onAnswer,
+}: {
+  step: { done: false; question: QuestionDef; totalSteps: number; currentStep: number };
+  answers: ActionPlanAnswers;
+  submitting: boolean;
+  onAnswer: (value: ActionPlanAnswers[string]) => void;
+}) {
+  const { question, totalSteps, currentStep } = step;
+  const progress = Math.max(0, Math.min(100, (currentStep / totalSteps) * 100));
+
+  // The selected-multi state is keyed on `question.slug` so React resets it
+  // when we navigate to a new question — no setState-in-effect needed.
+  const initialSelected = (() => {
+    const v = answers[question.slug];
+    return Array.isArray(v) ? (v as string[]) : [];
+  })();
+  const [selectedMulti, setSelectedMulti] = useState<string[]>(initialSelected);
+
+  const intentSummary = (answers.intent as string | undefined) ?? null;
+  const helpSummary = (answers.help_preference as string | undefined) ?? null;
+
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 py-6 sm:py-10">
+        {/* Mobile progress */}
+        <div className="lg:hidden mb-4">
+          <div className="h-1 bg-slate-200 rounded-full overflow-hidden">
+            <div
+              className="h-1 bg-amber-500 transition-all"
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+          <p className="text-[10px] uppercase tracking-widest text-slate-500 mt-1">
+            Step {currentStep} of {totalSteps} · No account needed yet
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-[240px_minmax(0,1fr)_320px] gap-6 lg:gap-10">
+          {/* LEFT — progress + reassurance */}
+          <aside className="hidden lg:block">
+            <div className="sticky top-6">
+              <div className="h-1 bg-slate-200 rounded-full overflow-hidden mb-3">
+                <div
+                  className="h-1 bg-amber-500 transition-all"
+                  style={{ width: `${progress}%` }}
+                />
+              </div>
+              <p className="text-[10px] uppercase tracking-widest text-slate-500 mb-3">
+                Step {currentStep} of {totalSteps}
+              </p>
+              <ul className="text-xs text-slate-500 space-y-2">
+                <li className="flex items-start gap-2">
+                  <Icon name="check" size={12} className="mt-0.5 text-emerald-600 shrink-0" />
+                  No account needed yet
+                </li>
+                <li className="flex items-start gap-2">
+                  <Icon name="check" size={12} className="mt-0.5 text-emerald-600 shrink-0" />
+                  General information only
+                </li>
+                <li className="flex items-start gap-2">
+                  <Icon name="check" size={12} className="mt-0.5 text-emerald-600 shrink-0" />
+                  You stay in control
+                </li>
+                <li className="flex items-start gap-2">
+                  <Icon name="check" size={12} className="mt-0.5 text-emerald-600 shrink-0" />
+                  Providers deliver under their own licence
+                </li>
+              </ul>
+            </div>
+          </aside>
+
+          {/* CENTRE — question card */}
+          <main>
+            <article
+              key={question.slug}
+              className="bg-white border border-slate-200 rounded-2xl shadow-sm p-6 sm:p-8 transition-all duration-200"
+              style={{ animation: "iv-fade-in 200ms ease-out" }}
+            >
+              <h1 className="text-2xl sm:text-3xl font-extrabold text-slate-900 mb-2">
+                {question.prompt}
+              </h1>
+              {question.subtitle && (
+                <p className="text-sm text-slate-500 mb-6">{question.subtitle}</p>
+              )}
+              {(question.kind === "select" || question.kind === "contextual") && (
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5">
+                  {question.options.map((opt) => (
+                    <button
+                      type="button"
+                      key={opt.value}
+                      onClick={() => onAnswer(opt.value)}
+                      disabled={submitting}
+                      className={`text-left rounded-xl border p-4 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 ${
+                        answers[question.slug] === opt.value
+                          ? "border-amber-500 bg-amber-50 ring-2 ring-amber-300"
+                          : "border-slate-200 bg-white hover:border-slate-300"
+                      } disabled:opacity-60 disabled:cursor-not-allowed`}
+                    >
+                      <p className="text-sm font-semibold text-slate-900">
+                        {opt.label}
+                      </p>
+                    </button>
+                  ))}
+                </div>
+              )}
+              {question.kind === "multiselect" && (
+                <div className="space-y-3">
+                  <div className="flex items-center justify-between text-xs text-slate-500">
+                    <span>Pick all that apply</span>
+                    <span>{selectedMulti.length} selected</span>
+                  </div>
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5">
+                    {question.options.map((opt) => {
+                      const checked = selectedMulti.includes(opt.value);
+                      return (
+                        <button
+                          type="button"
+                          key={opt.value}
+                          onClick={() => {
+                            setSelectedMulti((prev) =>
+                              checked
+                                ? prev.filter((x) => x !== opt.value)
+                                : [...prev, opt.value],
+                            );
+                          }}
+                          className={`text-left rounded-xl border p-4 flex items-center gap-3 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 ${
+                            checked
+                              ? "border-amber-500 bg-amber-50 ring-2 ring-amber-300"
+                              : "border-slate-200 bg-white hover:border-slate-300"
+                          }`}
+                        >
+                          <span
+                            className={`w-5 h-5 rounded-md border-2 flex items-center justify-center shrink-0 ${
+                              checked
+                                ? "border-amber-500 bg-amber-500"
+                                : "border-slate-300"
+                            }`}
+                          >
+                            {checked && (
+                              <Icon name="check" size={12} className="text-white" />
+                            )}
+                          </span>
+                          <span className="text-sm font-semibold text-slate-900">
+                            {opt.label}
+                          </span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                  <div className="flex justify-end pt-2">
+                    <button
+                      type="button"
+                      onClick={() => onAnswer(selectedMulti)}
+                      disabled={submitting || selectedMulti.length === 0}
+                      className="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-400 disabled:bg-slate-200 disabled:text-slate-400 disabled:cursor-not-allowed text-slate-900 font-bold px-6 py-2.5 rounded-xl"
+                    >
+                      Continue <Icon name="arrow-right" size={14} />
+                    </button>
+                  </div>
+                </div>
+              )}
+              {question.kind === "text" && (
+                <TextInput
+                  initial={typeof answers[question.slug] === "string" ? (answers[question.slug] as string) : ""}
+                  onSubmit={(v) => onAnswer(v)}
+                  disabled={submitting}
+                />
+              )}
+              {question.kind === "number" && (
+                <NumberInput
+                  initial={typeof answers[question.slug] === "number" ? (answers[question.slug] as number) : null}
+                  onSubmit={(v) => onAnswer(v)}
+                  disabled={submitting}
+                />
+              )}
+            </article>
+
+            <p className="lg:hidden text-[10px] text-slate-400 mt-3 text-center">
+              General information only · You stay in control
+            </p>
+          </main>
+
+          {/* RIGHT — live action plan preview */}
+          <aside className="hidden lg:block">
+            <div
+              className="sticky top-6 rounded-2xl border border-slate-200 p-5 bg-gradient-to-br from-slate-50 to-white"
+              aria-live="polite"
+            >
+              <p className="text-[10px] uppercase tracking-widest text-slate-500 mb-2">
+                Your plan so far
+              </p>
+              <ul className="text-sm space-y-1.5">
+                {intentSummary && (
+                  <li className="text-slate-900">
+                    <strong>Goal:</strong> {humanise(intentSummary)}
+                  </li>
+                )}
+                {helpSummary && (
+                  <li className="text-slate-700">
+                    <strong>Likely route:</strong> {humanise(helpSummary)}
+                  </li>
+                )}
+                {(answers.budget_band as string | undefined) && (
+                  <li className="text-slate-700">
+                    <strong>Budget:</strong> {humanise(answers.budget_band as string)}
+                  </li>
+                )}
+                {(answers.timeline as string | undefined) && (
+                  <li className="text-slate-700">
+                    <strong>Timeline:</strong> {humanise(answers.timeline as string)}
+                  </li>
+                )}
+                {!intentSummary && (
+                  <li className="text-slate-400 italic">
+                    Answer the questions and your action plan appears here.
+                  </li>
+                )}
+              </ul>
+            </div>
+          </aside>
+        </div>
+      </div>
+      <style>{`
+        @keyframes iv-fade-in {
+          from { opacity: 0; transform: translateY(8px); }
+          to { opacity: 1; transform: translateY(0); }
+        }
+        @media (prefers-reduced-motion: reduce) {
+          [style*="iv-fade-in"] { animation: none !important; }
+        }
+      `}</style>
+    </div>
+  );
+}
+
+function TextInput({
+  initial,
+  onSubmit,
+  disabled,
+}: {
+  initial: string;
+  onSubmit: (v: string) => void;
+  disabled: boolean;
+}) {
+  const [value, setValue] = useState(initial);
+  return (
+    <div className="space-y-3">
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        maxLength={300}
+        className="w-full border border-slate-300 rounded-lg px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400"
+      />
+      <button
+        type="button"
+        onClick={() => onSubmit(value.trim())}
+        disabled={disabled || value.trim().length === 0}
+        className="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-400 disabled:bg-slate-200 disabled:text-slate-400 disabled:cursor-not-allowed text-slate-900 font-bold px-5 py-2.5 rounded-xl"
+      >
+        Continue <Icon name="arrow-right" size={14} />
+      </button>
+    </div>
+  );
+}
+
+function NumberInput({
+  initial,
+  onSubmit,
+  disabled,
+}: {
+  initial: number | null;
+  onSubmit: (v: number) => void;
+  disabled: boolean;
+}) {
+  const [value, setValue] = useState<string>(initial === null ? "" : String(initial));
+  return (
+    <div className="space-y-3">
+      <input
+        type="number"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        className="w-full border border-slate-300 rounded-lg px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400"
+      />
+      <button
+        type="button"
+        onClick={() => {
+          const num = Number(value);
+          if (Number.isFinite(num)) onSubmit(num);
+        }}
+        disabled={disabled || value.length === 0}
+        className="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-400 disabled:bg-slate-200 disabled:text-slate-400 disabled:cursor-not-allowed text-slate-900 font-bold px-5 py-2.5 rounded-xl"
+      >
+        Continue <Icon name="arrow-right" size={14} />
+      </button>
+    </div>
+  );
+}
+
+function humanise(s: string): string {
+  return s
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+// ─── Action plan result screen ────────────────────────────────────────────
+
+function ActionPlanScreen({
+  result,
+  shareToken,
+  onChecklistToggle,
+  onSaveByEmail,
+  onCreateBrief,
+  onRestart,
+}: {
+  result: ResolveResponse;
+  shareToken: string | null;
+  onChecklistToggle: (index: number) => Promise<void>;
+  onSaveByEmail: (email: string) => Promise<string | null>;
+  onCreateBrief: () => void;
+  onRestart: () => void;
+}) {
+  const { plan, template, accept_credits_cost } = result;
+  const [checklist, setChecklist] = useState(plan.checklist);
+  const [email, setEmail] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [savedUrl, setSavedUrl] = useState<string | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const isRiskHeld =
+    plan.risk_severity === "review" || plan.risk_severity === "block";
+
+  async function toggle(idx: number) {
+    const next = checklist.map((c, i) =>
+      i === idx ? { ...c, done: !c.done } : c,
+    );
+    setChecklist(next);
+    await onChecklistToggle(idx);
+  }
+
+  async function handleSave() {
+    setSaveError(null);
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      setSaveError("Please enter a valid email address.");
+      return;
+    }
+    setSaving(true);
+    try {
+      const url = await onSaveByEmail(email);
+      if (url) setSavedUrl(url);
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : "Could not save.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const primary = template.primary_cta;
+  const recommendedBriefHref =
+    result.recommended_brief_template && plan.id
+      ? `/briefs/new?plan_id=${plan.id}`
+      : primary?.href ?? "/";
+
+  return (
+    <div className="min-h-screen bg-slate-50">
+      {/* HEADLINE STRIP */}
+      <section className="bg-gradient-to-br from-slate-900 via-slate-900 to-slate-800 text-white">
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 py-12 sm:py-16">
+          <p className="text-amber-400 text-[11px] font-semibold uppercase tracking-widest mb-2">
+            Your Investment Action Plan
+          </p>
+          <h1 className="text-3xl sm:text-4xl font-extrabold mb-3">
+            {plan.goal ?? template.headline}
+          </h1>
+          <p className="text-slate-300 max-w-2xl leading-relaxed">
+            {template.why_text}
+          </p>
+          <div className="mt-6 flex flex-wrap gap-2 text-[11px]">
+            {["Verified providers", "Masked previews", "Credit-based accept", "You stay in control"].map((s) => (
+              <span
+                key={s}
+                className="inline-flex items-center gap-1.5 bg-white/10 border border-white/20 rounded-full px-2.5 py-1"
+              >
+                <Icon name="shield-check" size={11} className="text-amber-400" />
+                {s}
+              </span>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="max-w-5xl mx-auto px-4 sm:px-6 py-10">
+        {isRiskHeld && (
+          <div className="bg-amber-50 border border-amber-200 rounded-xl p-4 mb-6 text-sm text-amber-900">
+            <p className="font-semibold mb-1">Quick compliance check</p>
+            <p>
+              Your answers mention topics that need a brief review. If you create a brief from this plan, we&apos;ll hold it for review before routing it to providers — usually within a business day.
+            </p>
+          </div>
+        )}
+
+        <div className="bg-white rounded-3xl border border-slate-200 shadow-md p-6 sm:p-8 mb-6">
+          <span className="inline-flex items-center gap-1.5 text-[11px] font-bold uppercase tracking-widest text-amber-700 bg-amber-50 border border-amber-200 rounded-full px-2.5 py-1 mb-3">
+            <Icon name="check-circle" size={12} />
+            Recommended route · {humanise(plan.route ?? "guide")}
+          </span>
+
+          <h2 className="text-xl font-extrabold text-slate-900 mb-2">
+            Your checklist
+          </h2>
+          <p className="text-sm text-slate-500 mb-4">
+            Educational steps based on your answers — Invest.com.au never gives personal advice.
+          </p>
+          <ul className="space-y-2 mb-6">
+            {checklist.map((item, idx) => (
+              <li key={idx} className="flex items-start gap-3">
+                <button
+                  type="button"
+                  onClick={() => void toggle(idx)}
+                  aria-pressed={!!item.done}
+                  className={`mt-0.5 w-5 h-5 rounded-full border-2 flex items-center justify-center shrink-0 ${
+                    item.done
+                      ? "border-emerald-500 bg-emerald-500"
+                      : "border-slate-300 hover:border-slate-400"
+                  }`}
+                >
+                  {item.done && (
+                    <Icon name="check" size={12} className="text-white" />
+                  )}
+                </button>
+                <span
+                  className={`text-sm ${
+                    item.done ? "text-slate-400 line-through" : "text-slate-700"
+                  }`}
+                >
+                  {item.href ? (
+                    <Link href={item.href} className="hover:underline">
+                      {item.label}
+                    </Link>
+                  ) : (
+                    item.label
+                  )}
+                </span>
+              </li>
+            ))}
+          </ul>
+
+          <div className="flex flex-col gap-3">
+            {result.recommended_brief_template ? (
+              <button
+                type="button"
+                onClick={onCreateBrief}
+                className="w-full inline-flex items-center justify-center gap-2 bg-amber-500 hover:bg-amber-400 text-slate-900 font-bold text-base px-6 py-3.5 rounded-xl"
+              >
+                {primary?.label ?? "Continue"}
+                {accept_credits_cost ? (
+                  <span className="text-xs font-semibold opacity-80">
+                    · ~{accept_credits_cost} credits
+                  </span>
+                ) : null}
+                <Icon name="arrow-right" size={16} />
+              </button>
+            ) : (
+              <Link
+                href={recommendedBriefHref}
+                className="w-full inline-flex items-center justify-center gap-2 bg-amber-500 hover:bg-amber-400 text-slate-900 font-bold text-base px-6 py-3.5 rounded-xl"
+              >
+                {primary?.label ?? "Continue"}
+                <Icon name="arrow-right" size={16} />
+              </Link>
+            )}
+            {template.secondary_ctas?.length > 0 && (
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                {template.secondary_ctas.slice(0, 3).map((cta) => (
+                  <Link
+                    key={cta.href}
+                    href={cta.href}
+                    className="inline-flex items-center justify-center gap-2 bg-slate-100 hover:bg-slate-200 text-slate-800 font-semibold text-sm px-4 py-2.5 rounded-lg"
+                  >
+                    {cta.label}
+                  </Link>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {template.cross_sells?.length > 0 && (
+          <section className="mb-6">
+            <p className="text-xs uppercase tracking-widest text-slate-500 mb-3">
+              Other things you might find useful
+            </p>
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+              {template.cross_sells.slice(0, 3).map((c) => (
+                <Link
+                  key={c.href}
+                  href={c.href}
+                  className="bg-white border border-slate-200 rounded-xl p-4 flex items-start gap-3 hover:border-slate-300"
+                >
+                  <Icon name={c.icon ?? "arrow-right"} size={18} className="text-slate-500 mt-0.5" />
+                  <span className="text-sm font-semibold text-slate-800">
+                    {c.label}
+                  </span>
+                </Link>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {/* Save your plan strip */}
+        <section className="bg-white border border-slate-200 rounded-2xl p-5 mb-6">
+          <p className="font-semibold text-slate-900 mb-1">
+            Want to save this action plan or send a brief to verified professionals?
+          </p>
+          <p className="text-xs text-slate-500 mb-4">
+            We&apos;ll email you a private link. No account needed.
+          </p>
+          {savedUrl ? (
+            <div className="bg-emerald-50 border border-emerald-200 text-emerald-800 rounded-lg p-3 text-sm">
+              Saved. Your plan is at{" "}
+              <Link href={savedUrl} className="underline font-semibold">
+                {savedUrl}
+              </Link>
+              .
+            </div>
+          ) : (
+            <div className="flex flex-col sm:flex-row gap-2">
+              <input
+                type="email"
+                placeholder="you@example.com"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                className="flex-1 border border-slate-300 rounded-lg px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400"
+              />
+              <button
+                type="button"
+                onClick={() => void handleSave()}
+                disabled={saving}
+                className="inline-flex items-center justify-center gap-2 bg-slate-900 hover:bg-slate-800 disabled:bg-slate-400 text-white font-bold text-sm px-5 py-2.5 rounded-lg"
+              >
+                {saving ? "Saving…" : "Email me my plan"}
+              </button>
+              <Link
+                href="/auth/sign-up"
+                className="inline-flex items-center justify-center gap-2 bg-white border border-slate-200 text-slate-800 font-semibold text-sm px-5 py-2.5 rounded-lg hover:border-slate-300"
+              >
+                Create free account
+              </Link>
+            </div>
+          )}
+          {saveError && (
+            <p className="mt-2 text-xs text-red-700">{saveError}</p>
+          )}
+          {shareToken && !savedUrl && (
+            <p className="mt-3 text-[11px] text-slate-400">
+              Direct link:{" "}
+              <Link href={`/plans/${shareToken}`} className="underline">
+                /plans/{shareToken.slice(0, 8)}…
+              </Link>
+            </p>
+          )}
+        </section>
+
+        <div className="text-center">
+          <button
+            type="button"
+            onClick={onRestart}
+            className="text-xs text-slate-500 underline hover:text-slate-700"
+          >
+            Start over with different answers
+          </button>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/get-matched/page.tsx
+++ b/app/get-matched/page.tsx
@@ -1,0 +1,51 @@
+import type { Metadata } from "next";
+
+import GetMatchedClient from "./GetMatchedClient";
+import { CURRENT_YEAR, SITE_URL, breadcrumbJsonLd } from "@/lib/seo";
+
+export const metadata: Metadata = {
+  title: `Get Matched — Build your Investment Action Plan (${CURRENT_YEAR})`,
+  description:
+    "Tell us what you're trying to do. We'll build your investment action plan and guide you to the right next step — compare a platform, browse opportunities, or send an Investor Brief to verified Australian professionals.",
+  alternates: { canonical: `${SITE_URL}/get-matched` },
+  robots: { index: true, follow: true },
+};
+
+export const dynamic = "force-dynamic";
+
+interface SearchParams {
+  goal?: string;
+  intent?: string;
+  context?: string;
+  team?: string;
+  plan_id?: string;
+  mode?: string;
+}
+
+export default async function GetMatchedPage({
+  searchParams,
+}: {
+  searchParams?: Promise<SearchParams>;
+}) {
+  const sp = (await searchParams) ?? {};
+  const breadcrumb = breadcrumbJsonLd([
+    { name: "Home", url: `${SITE_URL}/` },
+    { name: "Get Matched" },
+  ]);
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
+      />
+      <GetMatchedClient
+        initialGoal={sp.goal ?? null}
+        initialIntent={sp.intent ?? null}
+        initialContext={sp.context ?? null}
+        initialPlanId={sp.plan_id ? Number(sp.plan_id) : null}
+        initialMode={sp.mode === "fast" || sp.mode === "guided" ? sp.mode : "both"}
+      />
+    </>
+  );
+}

--- a/app/invest/page.tsx
+++ b/app/invest/page.tsx
@@ -18,6 +18,7 @@ import type { InvestmentListing } from "@/lib/types";
 import { logger } from "@/lib/logger";
 import { listingUrl } from "@/lib/listing-url";
 import InvestListingsClient from "@/components/InvestListingsClient";
+import GetMatchedEmbed from "@/components/get-matched/GetMatchedEmbed";
 import HomeToolsStrip from "@/components/HomeToolsStrip";
 import IntentCountryBadge from "@/components/foreign-investment/IntentCountryBadge";
 import IntentCountryRecommendation from "@/components/foreign-investment/IntentCountryRecommendation";
@@ -417,6 +418,10 @@ export default async function InvestMarketplacePage() {
             </div>
           </div>
         )}
+
+        <div className="container-custom mb-6">
+          <GetMatchedEmbed context="opportunity" />
+        </div>
 
         {/* ── Marketplace grid (PRIMARY content — no two-step) ── */}
         <InvestListingsClient listings={listings} categories={categoryTabs} />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import HomeHero from "@/components/HomeHero";
 import HomeRouteCards from "@/components/HomeRouteCards";
 import CountryToolsStripWrapper from "@/components/country-mode/CountryToolsStripWrapper";
 import HomePathfinder from "@/components/HomePathfinder";
+import GetMatchedEmbed from "@/components/get-matched/GetMatchedEmbed";
 import HomeListingsTeaser, { type HomeListing } from "@/components/HomeListingsTeaser";
 import HomeAdvisorsTeaser, { type HomeAdvisor } from "@/components/HomeAdvisorsTeaser";
 import HomePostAJob from "@/components/HomePostAJob";
@@ -258,6 +259,12 @@ export default async function HomePage() {
       </ScrollFadeIn>
 
       <CountryPopularLinks />
+
+      <ScrollFadeIn>
+        <section className="container-custom my-10">
+          <GetMatchedEmbed context="homepage" />
+        </section>
+      </ScrollFadeIn>
 
       <ScrollFadeIn>
         <HomePathfinder />

--- a/app/plans/[token]/page.tsx
+++ b/app/plans/[token]/page.tsx
@@ -1,0 +1,136 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import Link from "next/link";
+
+import { SITE_URL, breadcrumbJsonLd, CURRENT_YEAR } from "@/lib/seo";
+import Icon from "@/components/Icon";
+import { getPlanByToken } from "@/lib/getmatched/action-plans";
+import { getResultTemplate } from "@/lib/getmatched/templates";
+import type { IntentSlug, RouteType } from "@/lib/getmatched/types";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: `Your Investment Action Plan (${CURRENT_YEAR})`,
+  robots: { index: false, follow: false },
+};
+
+export default async function PlanPublicPage({
+  params,
+}: {
+  params: Promise<{ token: string }>;
+}) {
+  const { token } = await params;
+  if (!token || token.length < 20) notFound();
+  const plan = await getPlanByToken(token);
+  if (!plan) notFound();
+  const template = plan.route
+    ? await getResultTemplate(
+        plan.route as RouteType,
+        plan.intent_slug as IntentSlug | null,
+      )
+    : null;
+
+  const breadcrumb = breadcrumbJsonLd([
+    { name: "Home", url: `${SITE_URL}/` },
+    { name: "Action Plan" },
+  ]);
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
+      />
+
+      <div className="min-h-screen bg-slate-50">
+        <section className="bg-gradient-to-br from-slate-900 via-slate-900 to-slate-800 text-white">
+          <div className="max-w-4xl mx-auto px-4 sm:px-6 py-12">
+            <p className="text-amber-400 text-[11px] font-semibold uppercase tracking-widest mb-2">
+              Your Investment Action Plan
+            </p>
+            <h1 className="text-3xl sm:text-4xl font-extrabold mb-3">
+              {plan.goal ?? template?.headline ?? "Action Plan"}
+            </h1>
+            {template?.why_text && (
+              <p className="text-slate-300 max-w-2xl leading-relaxed">
+                {template.why_text}
+              </p>
+            )}
+          </div>
+        </section>
+
+        <section className="max-w-4xl mx-auto px-4 sm:px-6 py-10">
+          <div className="bg-white border border-slate-200 rounded-3xl shadow-md p-6 sm:p-8 mb-6">
+            <div className="flex items-center gap-2 mb-4 text-[11px] font-bold uppercase tracking-widest text-amber-700 bg-amber-50 border border-amber-200 rounded-full px-2.5 py-1 w-fit">
+              <Icon name="check-circle" size={12} />
+              Route · {humanise(plan.route ?? "guide")}
+            </div>
+
+            <h2 className="text-xl font-bold text-slate-900 mb-3">Your checklist</h2>
+            <ul className="space-y-2 mb-6">
+              {plan.checklist.map((item, idx) => (
+                <li key={idx} className="flex items-start gap-3">
+                  <span
+                    className={`mt-0.5 w-5 h-5 rounded-full border-2 flex items-center justify-center shrink-0 ${
+                      item.done ? "border-emerald-500 bg-emerald-500" : "border-slate-300"
+                    }`}
+                  >
+                    {item.done && (
+                      <Icon name="check" size={12} className="text-white" />
+                    )}
+                  </span>
+                  <span
+                    className={`text-sm ${
+                      item.done ? "text-slate-400 line-through" : "text-slate-700"
+                    }`}
+                  >
+                    {item.href ? (
+                      <Link href={item.href} className="hover:underline">
+                        {item.label}
+                      </Link>
+                    ) : (
+                      item.label
+                    )}
+                  </span>
+                </li>
+              ))}
+            </ul>
+
+            {template?.primary_cta && (
+              <Link
+                href={
+                  plan.id
+                    ? `/briefs/new?plan_id=${plan.id}`
+                    : template.primary_cta.href
+                }
+                className="w-full inline-flex items-center justify-center gap-2 bg-amber-500 hover:bg-amber-400 text-slate-900 font-bold text-base px-6 py-3.5 rounded-xl"
+              >
+                {template.primary_cta.label}
+                <Icon name="arrow-right" size={16} />
+              </Link>
+            )}
+
+            {plan.linked_brief_id && (
+              <p className="mt-4 text-sm text-emerald-700">
+                Brief #{plan.linked_brief_id} has already been created from this plan.
+              </p>
+            )}
+          </div>
+
+          <div className="text-center text-xs text-slate-500">
+            Want to keep tracking this plan and any briefs you create?{" "}
+            <Link href="/auth/sign-up" className="underline">
+              Create a free account
+            </Link>
+            .
+          </div>
+        </section>
+      </div>
+    </>
+  );
+}
+
+function humanise(s: string): string {
+  return s.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}

--- a/app/quiz/layout.tsx
+++ b/app/quiz/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { SITE_NAME, absoluteUrl } from "@/lib/seo";
 
 export const metadata: Metadata = {
@@ -90,6 +91,19 @@ export default function QuizLayout({
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(howToJsonLd) }}
       />
+      <div className="bg-amber-50 border-b border-amber-200">
+        <div className="max-w-5xl mx-auto px-4 py-3 flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-3">
+          <p className="text-xs text-amber-900 leading-snug flex-1">
+            <strong>Get Matched has been upgraded.</strong> The new flow builds you a full Investment Action Plan — not just a broker shortlist.
+          </p>
+          <Link
+            href="/get-matched"
+            className="inline-flex items-center justify-center gap-2 bg-slate-900 hover:bg-slate-800 text-white font-bold text-xs px-4 py-2 rounded-lg whitespace-nowrap"
+          >
+            Try the new Get Matched →
+          </Link>
+        </div>
+      </div>
       {children}
     </>
   );

--- a/app/quotes/page.tsx
+++ b/app/quotes/page.tsx
@@ -34,6 +34,7 @@ async function getOpenJobs(): Promise<JobRow[]> {
     .select("id, slug, job_title, job_description, budget_band, advisor_types, location, status, ends_at, created_at")
     .eq("is_public", true)
     .eq("source", "public_job")
+    .eq("flow_type", "auction")
     .eq("status", "open")
     .gt("ends_at", now)
     .order("created_at", { ascending: false })

--- a/app/teams/[slug]/page.tsx
+++ b/app/teams/[slug]/page.tsx
@@ -1,0 +1,209 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import Link from "next/link";
+
+import { createClient } from "@/lib/supabase/server";
+import { absoluteUrl, breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
+import { BRIEF_TEMPLATE_LABELS } from "@/lib/briefs/templates";
+import Icon from "@/components/Icon";
+
+export const revalidate = 1800;
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const admin = await createClient();
+  const { data: team } = await admin
+    .from("expert_teams")
+    .select("name, description, team_category")
+    .eq("slug", slug)
+    .eq("public", true)
+    .eq("verification_status", "verified")
+    .maybeSingle();
+  if (!team) return {};
+  return {
+    title: `${team.name} — Verified Expert Team (${CURRENT_YEAR})`,
+    description: (team.description as string)?.slice(0, 155) ?? `${team.name} is a verified expert team on Invest.com.au.`,
+    alternates: { canonical: `${SITE_URL}/teams/${slug}` },
+  };
+}
+
+interface PageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export default async function TeamProfilePage({ params }: PageProps) {
+  const { slug } = await params;
+  const admin = await createClient();
+  const { data: team } = await admin
+    .from("expert_teams")
+    .select("*")
+    .eq("slug", slug)
+    .eq("public", true)
+    .eq("verification_status", "verified")
+    .maybeSingle();
+  if (!team) notFound();
+
+  const { data: membersRaw } = await admin
+    .from("expert_team_members")
+    .select(
+      "id, professional_id, member_role, public_title, can_appear_publicly, status",
+    )
+    .eq("team_id", team.id)
+    .eq("status", "active")
+    .eq("can_appear_publicly", true);
+  const members = (membersRaw ?? []) as {
+    id: number;
+    professional_id: number;
+    member_role: string;
+    public_title: string | null;
+    status: string;
+  }[];
+
+  const proIds = members.map((m) => m.professional_id);
+  let professionals: Record<
+    number,
+    { name: string; slug: string; type: string; photo_url: string | null }
+  > = {};
+  if (proIds.length > 0) {
+    const { data: pros } = await admin
+      .from("professionals")
+      .select("id, name, slug, type, photo_url")
+      .in("id", proIds);
+    professionals = Object.fromEntries(
+      ((pros ?? []) as { id: number; name: string; slug: string; type: string; photo_url: string | null }[]).map(
+        (p) => [p.id, p],
+      ),
+    );
+  }
+
+  const breadcrumb = breadcrumbJsonLd([
+    { name: "Home", url: absoluteUrl("/") },
+    { name: "Experts", url: absoluteUrl("/advisors") },
+    { name: team.name as string },
+  ]);
+
+  const acceptedTemplates = (team.accepted_brief_templates as string[]) ?? [];
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
+      />
+      <div className="min-h-screen bg-slate-50">
+        <div className="bg-white border-b border-slate-200">
+          <div className="max-w-5xl mx-auto px-4 py-3 text-xs text-slate-500 flex items-center gap-1.5">
+            <Link href="/" className="hover:text-slate-800">
+              Home
+            </Link>
+            <span>/</span>
+            <Link href="/advisors" className="hover:text-slate-800">
+              Experts
+            </Link>
+            <span>/</span>
+            <span className="text-slate-800 font-medium">{team.name as string}</span>
+          </div>
+        </div>
+
+        <div className="max-w-5xl mx-auto px-4 py-10">
+          <div className="flex flex-wrap items-center gap-3 mb-2">
+            <span className="inline-flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wider bg-emerald-100 text-emerald-800 px-2 py-1 rounded-full">
+              <Icon name="shield-check" size={12} /> Verified Expert Team
+            </span>
+            <span className="text-xs text-slate-500">
+              {String(team.team_category).replace(/_/g, " ")} · {String(team.team_type).replace(/_/g, " ")}
+            </span>
+          </div>
+          <h1 className="text-3xl sm:text-4xl font-extrabold text-slate-900 mb-3">
+            {team.name as string}
+          </h1>
+          {team.description && (
+            <p className="text-slate-600 leading-relaxed max-w-3xl mb-6">
+              {team.description as string}
+            </p>
+          )}
+
+          <div className="flex flex-wrap gap-3 mb-10">
+            <Link
+              href={`/briefs/new?team=${encodeURIComponent(slug)}`}
+              className="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-400 text-slate-900 font-bold px-5 py-3 rounded-xl"
+            >
+              <Icon name="edit" size={16} />
+              Create an Investor Brief for this team
+            </Link>
+            <Link
+              href="/briefs/new"
+              className="inline-flex items-center gap-2 bg-white border border-slate-200 text-slate-700 font-semibold px-5 py-3 rounded-xl hover:border-slate-300"
+            >
+              Compare other experts
+            </Link>
+          </div>
+
+          {acceptedTemplates.length > 0 && (
+            <div className="bg-white rounded-2xl border border-slate-200 p-6 mb-6">
+              <p className="text-xs uppercase tracking-widest text-slate-500 mb-2">
+                Briefs this team handles
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {acceptedTemplates.map((t) => (
+                  <span
+                    key={t}
+                    className="inline-flex items-center text-xs bg-slate-100 text-slate-700 rounded-full px-2 py-1"
+                  >
+                    {(BRIEF_TEMPLATE_LABELS as Record<string, string>)[t] ?? t}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          <div className="bg-white rounded-2xl border border-slate-200 p-6 mb-6">
+            <p className="text-xs uppercase tracking-widest text-slate-500 mb-3">
+              Team members
+            </p>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              {members.map((m) => {
+                const pro = professionals[m.professional_id];
+                if (!pro) return null;
+                return (
+                  <Link
+                    key={m.id}
+                    href={`/advisor/${pro.slug}`}
+                    className="flex items-center gap-3 p-3 border border-slate-100 rounded-xl hover:border-slate-300"
+                  >
+                    <div className="w-10 h-10 rounded-full bg-slate-100 flex items-center justify-center text-slate-500 text-xs font-bold uppercase">
+                      {pro.name
+                        .split(" ")
+                        .slice(0, 2)
+                        .map((n) => n[0])
+                        .join("")}
+                    </div>
+                    <div className="min-w-0">
+                      <p className="text-sm font-semibold text-slate-900 truncate">
+                        {pro.name}
+                      </p>
+                      <p className="text-xs text-slate-500 truncate">
+                        {m.public_title ?? String(m.member_role).replace(/_/g, " ")}
+                      </p>
+                    </div>
+                  </Link>
+                );
+              })}
+            </div>
+          </div>
+
+          {team.disclosure && (
+            <div className="bg-slate-100 border border-slate-200 rounded-2xl p-4 text-xs text-slate-600 leading-relaxed">
+              <p className="font-semibold text-slate-800 mb-1">Team disclosure</p>
+              <p>{team.disclosure as string}</p>
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/components/AdminSidebar.tsx
+++ b/components/AdminSidebar.tsx
@@ -92,6 +92,15 @@ const NAV_GROUPS = [
     ],
   },
   {
+    label: "Get Matched",
+    items: [
+      { href: "/admin/intents", icon: "target", label: "Intents" },
+      { href: "/admin/get-matched/questions", icon: "message-circle", label: "Questions" },
+      { href: "/admin/get-matched/result-templates", icon: "layout", label: "Result Templates" },
+      { href: "/admin/get-matched/funnel", icon: "filter", label: "Funnel" },
+    ],
+  },
+  {
     label: "Users",
     items: [
       { href: "/admin/subscribers", icon: "mail", label: "Subscribers" },

--- a/components/AdminSidebar.tsx
+++ b/components/AdminSidebar.tsx
@@ -82,6 +82,16 @@ const NAV_GROUPS = [
     ],
   },
   {
+    label: "Brief Marketplace",
+    items: [
+      { href: "/admin/briefs", icon: "edit", label: "Investor Briefs" },
+      { href: "/admin/expert-teams", icon: "users", label: "Expert Teams" },
+      { href: "/admin/credit-pricing", icon: "coins", label: "Credit Pricing" },
+      { href: "/admin/routing-rules", icon: "git-branch", label: "Routing Rules" },
+      { href: "/admin/risk-flags", icon: "shield", label: "Risk Flags" },
+    ],
+  },
+  {
     label: "Users",
     items: [
       { href: "/admin/subscribers", icon: "mail", label: "Subscribers" },

--- a/components/get-matched/GetMatchedEmbed.tsx
+++ b/components/get-matched/GetMatchedEmbed.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import Link from "next/link";
+import Icon from "@/components/Icon";
+import { HOMEPAGE_GOAL_CHIPS, getEmbedConfig } from "@/lib/getmatched/embeds";
+import type { EmbedContext } from "@/lib/getmatched/types";
+
+interface Props {
+  context: EmbedContext;
+  /** Optional listing id stamped onto the action plan for the `opportunity` context. */
+  listingId?: number;
+}
+
+/**
+ * Contextual entry point into Get Matched 2.0. Same engine, different skin
+ * per page context (homepage / SMSF guide / opportunity / advisor directory
+ * / platform compare).
+ *
+ * Homepage shows the 9-chip goal picker → deep-links into the full flow.
+ * Other contexts show a single CTA card that pre-fills the intent.
+ */
+export default function GetMatchedEmbed({ context, listingId }: Props) {
+  const cfg = getEmbedConfig(context);
+  const baseQuery = new URLSearchParams();
+  baseQuery.set("context", context);
+  if (cfg.intent_prefill) baseQuery.set("intent", cfg.intent_prefill);
+  if (cfg.start_step) baseQuery.set("start_step", String(cfg.start_step));
+  if (listingId) baseQuery.set("listing_id", String(listingId));
+
+  if (context === "homepage") {
+    return (
+      <section className="bg-gradient-to-b from-white to-slate-50 border border-slate-200 rounded-3xl p-6 sm:p-10 shadow-sm">
+        <div className="max-w-3xl mx-auto text-center">
+          <p className="text-amber-600 text-[11px] font-bold uppercase tracking-widest mb-2">
+            Start with your goal
+          </p>
+          <h2 className="text-2xl sm:text-4xl font-extrabold text-slate-900 mb-2">
+            {cfg.headline}
+          </h2>
+          <p className="text-sm sm:text-base text-slate-600 mb-6 sm:mb-8">
+            {cfg.subtitle}
+          </p>
+        </div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2.5 max-w-4xl mx-auto">
+          {HOMEPAGE_GOAL_CHIPS.map((chip) => {
+            const q = new URLSearchParams();
+            q.set("goal", chip.value);
+            q.set("context", "homepage");
+            return (
+              <Link
+                key={chip.value}
+                href={`/get-matched?${q.toString()}`}
+                className="group flex items-center gap-3 bg-white border border-slate-200 rounded-xl p-3.5 hover:border-amber-400 hover:bg-amber-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400"
+              >
+                <Icon
+                  name={chip.icon}
+                  size={18}
+                  className="text-slate-500 group-hover:text-amber-600 shrink-0"
+                />
+                <span className="text-sm font-semibold text-slate-900 text-left">
+                  {chip.label}
+                </span>
+                <Icon
+                  name="arrow-right"
+                  size={14}
+                  className="ml-auto text-slate-300 group-hover:text-amber-500"
+                />
+              </Link>
+            );
+          })}
+        </div>
+        <p className="text-[11px] text-slate-500 text-center mt-6">
+          Takes 60 seconds · No account needed to see your result · Create a brief only if you want professionals to respond
+        </p>
+      </section>
+    );
+  }
+
+  // Compact embed for all other contexts.
+  return (
+    <section className="bg-white border border-slate-200 rounded-2xl p-5 sm:p-6 shadow-sm">
+      <div className="flex flex-col sm:flex-row sm:items-center gap-4">
+        <div className="flex-1">
+          <p className="text-amber-600 text-[10px] font-bold uppercase tracking-widest mb-1">
+            Get Matched
+          </p>
+          <h3 className="text-lg sm:text-xl font-extrabold text-slate-900 mb-1">
+            {cfg.headline}
+          </h3>
+          <p className="text-xs sm:text-sm text-slate-500">{cfg.subtitle}</p>
+        </div>
+        <Link
+          href={`/get-matched?${baseQuery.toString()}`}
+          className="inline-flex items-center justify-center gap-2 bg-amber-500 hover:bg-amber-400 text-slate-900 font-bold text-sm px-5 py-3 rounded-xl whitespace-nowrap focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400"
+        >
+          Build my action plan
+          <Icon name="arrow-right" size={14} />
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/lib/api-schemas.ts
+++ b/lib/api-schemas.ts
@@ -278,6 +278,109 @@ export const AdminVerifyExpertTeamRequest = z.object({
   accepts_briefs: z.boolean().optional(),
 });
 
+// ─── /api/get-matched (Get Matched 2.0) ─────────────────────────────
+
+export const GM_INTENT_SLUGS = [
+  "compare_platform",
+  "start_investing",
+  "smsf_property",
+  "buy_property",
+  "opportunity_assessment",
+  "business_acquisition",
+  "commercial_property",
+  "foreign_investor",
+  "expat_investing",
+  "financial_advice",
+  "tax_help",
+  "mortgage_help",
+  "legal_help",
+  "second_opinion",
+  "listing_owner",
+  "listing_readiness",
+  "not_sure",
+] as const;
+
+export const GM_ROUTE_TYPES = [
+  "compare",
+  "browse",
+  "individual",
+  "firm",
+  "expert_team",
+  "investor_brief",
+  "listing_brief",
+  "second_opinion",
+  "guide",
+] as const;
+
+export const GM_QUESTION_MODES = ["fast", "guided", "both"] as const;
+
+const PlainAnswerValue = z.union([
+  z.string().max(500),
+  z.array(z.string().max(120)).max(20),
+  z.number().finite(),
+  z.boolean(),
+  z.null(),
+]);
+
+export const StartGetMatchedRequest = z.object({
+  session_id: z.string().min(8).max(120),
+  mode: z.enum(GM_QUESTION_MODES).default("both"),
+  prefill: z.record(z.string(), PlainAnswerValue).optional(),
+  source_page: z.string().max(500).optional(),
+});
+
+export const AnswerQuestionRequest = z.object({
+  plan_id: z.number().int().positive(),
+  question_slug: z.string().min(1).max(80),
+  value: PlainAnswerValue,
+});
+
+export const ResolvePlanRequest = z.object({
+  plan_id: z.number().int().positive(),
+});
+
+export const SavePlanRequest = z.object({
+  email: z.string().email().max(200),
+});
+
+export const ClaimPlanRequest = z.object({
+  plan_id: z.number().int().positive(),
+});
+
+export const PlanToBriefRequest = z.object({
+  contact_name: z.string().min(1).max(100),
+  contact_email: z.string().email().max(200),
+  contact_phone: z.string().max(20).optional(),
+  routing_mode: z.enum(ROUTING_MODES).default("smart_match"),
+  provider_preference: z.enum(PROVIDER_PREFERENCES).optional(),
+  consent_share: z.boolean().refine((v) => v === true, {
+    message: "Please confirm consent to share the brief with verified providers.",
+  }),
+});
+
+export const ChecklistToggleRequest = z.object({
+  index: z.number().int().nonnegative().max(50),
+});
+
+export const LogGmEventRequest = z.object({
+  session_id: z.string().min(8).max(120),
+  event_type: z.enum([
+    "started",
+    "question_answered",
+    "question_abandoned",
+    "plan_shown",
+    "cta_clicked",
+    "plan_saved",
+    "account_created",
+    "brief_drafted",
+    "brief_submitted",
+    "risk_flagged",
+  ]),
+  step: z.number().int().min(0).max(50).optional(),
+  payload: z.record(z.string(), z.unknown()).optional(),
+  source_page: z.string().max(500).optional(),
+});
+
 // ─── Helper: assert a response matches a schema ────────────────────
 
 /**

--- a/lib/api-schemas.ts
+++ b/lib/api-schemas.ts
@@ -157,6 +157,127 @@ export const PostJobResponse = z.object({
   ends_at: z.string(),
 });
 
+// ─── /api/briefs — Investor Brief marketplace ──────────────────────
+
+export const BRIEF_TEMPLATES = [
+  "general",
+  "smsf_property",
+  "foreign_investor",
+  "expat",
+  "opportunity_assessment",
+  "business_acquisition",
+  "commercial_property",
+  "second_opinion",
+  "mortgage",
+  "tax",
+  "smsf_accountant",
+  "financial_adviser",
+  "listing",
+  "listing_readiness",
+] as const;
+
+export const PROVIDER_PREFERENCES = [
+  "any",
+  "individual",
+  "firm",
+  "expert_team",
+  "multiple",
+] as const;
+
+export const ROUTING_MODES = ["smart_match", "direct", "multi_response"] as const;
+
+export const CreateBriefRequest = z.object({
+  brief_template: z.enum(BRIEF_TEMPLATES),
+  brief_payload: z.record(z.string(), z.unknown()).default({}),
+  job_title: z.string().min(8, "Title must be at least 8 characters.").max(160),
+  job_description: z.string().min(30, "Please add a little more context.").max(5000),
+  budget_band: z.enum(QUOTE_BUDGET_BANDS),
+  advisor_types: z.array(z.enum(QUOTE_ADVISOR_TYPES)).default([]),
+  location_state: z.enum(QUOTE_AU_STATES),
+  provider_preference: z.enum(PROVIDER_PREFERENCES).default("any"),
+  routing_mode: z.enum(ROUTING_MODES).default("smart_match"),
+  target_team_slug: z.string().max(120).optional(),
+  target_professional_slug: z.string().max(120).optional(),
+  target_firm_slug: z.string().max(120).optional(),
+  listing_id: z.number().int().positive().optional(),
+  contact_name: z.string().min(1).max(100),
+  contact_email: z.string().email().max(200),
+  contact_phone: z.string().max(20).optional(),
+  consent_share: z.boolean().refine((v) => v === true, {
+    message: "Please confirm consent to share the brief with verified providers.",
+  }),
+  // Honeypots — silently accept, ignore.
+  website: z.string().optional(),
+  fax: z.string().optional(),
+});
+
+export const AcceptBriefRequest = z.object({
+  team_id: z.number().int().positive().optional(),
+});
+
+export const BriefStatusUpdateRequest = z.object({
+  tracker_status: z.enum([
+    "new",
+    "contacted",
+    "call_booked",
+    "proposal_sent",
+    "won",
+    "lost",
+  ]),
+  note: z.string().max(2000).optional(),
+});
+
+// ─── /api/expert-teams ─────────────────────────────────────────────
+
+export const TEAM_TYPES = [
+  "same_firm",
+  "independent",
+  "private_referral",
+  "internal_firm",
+] as const;
+
+export const TEAM_CATEGORIES = [
+  "smsf_property",
+  "foreign_investor",
+  "expat",
+  "commercial_property",
+  "business_acquisition",
+  "due_diligence",
+  "retirement",
+  "custom",
+] as const;
+
+export const CreateExpertTeamRequest = z.object({
+  name: z.string().min(3).max(120),
+  team_category: z.enum(TEAM_CATEGORIES),
+  team_type: z.enum(TEAM_TYPES),
+  description: z.string().max(2000).optional(),
+  niche: z.string().max(200).optional(),
+  location_state: z.enum(QUOTE_AU_STATES).optional(),
+  service_areas: z.array(z.string().max(80)).max(20).optional(),
+  firm_id: z.number().int().positive().optional(),
+  disclosure: z.string().max(4000).optional(),
+  accepted_brief_templates: z.array(z.enum(BRIEF_TEMPLATES)).max(BRIEF_TEMPLATES.length).optional(),
+});
+
+export const InviteExpertTeamMemberRequest = z.object({
+  email: z.string().email().max(200),
+  name: z.string().max(120).optional(),
+  role: z.string().max(60).optional(),
+});
+
+export const AcceptExpertTeamInvitationRequest = z.object({
+  token: z.string().min(20).max(200),
+});
+
+export const SubmitExpertTeamRequest = z.object({});
+
+export const AdminVerifyExpertTeamRequest = z.object({
+  approved: z.boolean(),
+  rejection_reason: z.string().max(2000).optional(),
+  accepts_briefs: z.boolean().optional(),
+});
+
 // ─── Helper: assert a response matches a schema ────────────────────
 
 /**

--- a/lib/briefs/credits.ts
+++ b/lib/briefs/credits.ts
@@ -1,0 +1,260 @@
+/**
+ * Brief credit accept-and-unlock flow.
+ *
+ * One "credit" in the brief marketplace = A$1.00. The existing
+ * `professionals.credit_balance_cents` cache and `advisor_credit_ledger`
+ * remain the source of truth — `acceptBrief` records a negative
+ * `lead_spend` entry of `credits * CENTS_PER_CREDIT` and atomically
+ * flips the `advisor_auctions` row to `accepted_by_*` + `accepted_at`.
+ *
+ * If the row is already accepted (another provider got there first),
+ * the ledger entry is not recorded and the caller receives a
+ * `{ accepted: false, reason: 'already_accepted' }` result so the UI
+ * can show "another provider already accepted this brief".
+ */
+
+// eslint-disable-next-line no-restricted-imports -- service-role legitimate per CLAUDE.md: brief-accept mutates accepted_by_* columns + ledger writes; happens on the provider's behalf with cross-row checks (brief eligibility) that anon-role can't see.
+import { createAdminClient } from "@/lib/supabase/admin";
+import { recordLedgerEntry } from "@/lib/advisor-credit-ledger";
+import { logger } from "@/lib/logger";
+
+import type { BriefRow, ProviderKind } from "./types";
+
+const log = logger("briefs:credits");
+
+export const CENTS_PER_CREDIT = 100;
+
+export interface AcceptCostQuery {
+  briefTemplate: string;
+  providerKind: ProviderKind;
+}
+
+/**
+ * Resolve the credit cost for a brief template + provider kind.
+ *
+ * Priority: exact (template, providerKind) match → (template, 'any') →
+ * generic ('general', 'any') → fallback constant.
+ */
+export async function getAcceptCost({
+  briefTemplate,
+  providerKind,
+}: AcceptCostQuery): Promise<number> {
+  const admin = createAdminClient();
+  const { data } = await admin
+    .from("brief_credit_prices")
+    .select("brief_template, provider_type, credits_cost")
+    .in("brief_template", [briefTemplate, "general"])
+    .in("provider_type", [providerKind, "any"]);
+
+  const rows = (data ?? []) as {
+    brief_template: string;
+    provider_type: string;
+    credits_cost: number;
+  }[];
+
+  const exact = rows.find(
+    (r) => r.brief_template === briefTemplate && r.provider_type === providerKind,
+  );
+  if (exact) return exact.credits_cost;
+
+  const tmplAny = rows.find(
+    (r) => r.brief_template === briefTemplate && r.provider_type === "any",
+  );
+  if (tmplAny) return tmplAny.credits_cost;
+
+  const genericAny = rows.find(
+    (r) => r.brief_template === "general" && r.provider_type === "any",
+  );
+  if (genericAny) return genericAny.credits_cost;
+
+  return 2;
+}
+
+export interface AcceptBriefInput {
+  briefId: number;
+  professionalId: number;
+  teamId?: number | null;
+}
+
+export type AcceptBriefResult =
+  | {
+      accepted: true;
+      brief: BriefRow;
+      creditsSpent: number;
+      balanceAfterCents: number;
+    }
+  | {
+      accepted: false;
+      reason:
+        | "already_accepted"
+        | "not_acceptable"
+        | "insufficient_credits"
+        | "brief_not_found"
+        | "risk_held";
+      balanceAfterCents?: number;
+    };
+
+export async function acceptBrief({
+  briefId,
+  professionalId,
+  teamId,
+}: AcceptBriefInput): Promise<AcceptBriefResult> {
+  const admin = createAdminClient();
+
+  // ── 1. Load brief + check it is in accept flow + not already taken ─
+  const { data: brief } = await admin
+    .from("advisor_auctions")
+    .select("*")
+    .eq("id", briefId)
+    .maybeSingle();
+
+  if (!brief) {
+    return { accepted: false, reason: "brief_not_found" };
+  }
+
+  const row = brief as unknown as BriefRow;
+
+  if (row.flow_type !== "accept") {
+    return { accepted: false, reason: "not_acceptable" };
+  }
+  if (row.status !== "open") {
+    return { accepted: false, reason: "not_acceptable" };
+  }
+  if (row.risk_review_status !== "clear" && row.risk_review_status !== "approved") {
+    return { accepted: false, reason: "risk_held" };
+  }
+  if (row.accepted_by_professional_id || row.accepted_by_team_id) {
+    return { accepted: false, reason: "already_accepted" };
+  }
+
+  const credits = row.accept_credits_cost ?? 2;
+  const cents = credits * CENTS_PER_CREDIT;
+
+  // ── 2. Check sufficient balance ─────────────────────────────────────
+  const { data: pro } = await admin
+    .from("professionals")
+    .select("credit_balance_cents")
+    .eq("id", professionalId)
+    .maybeSingle();
+  const currentBalance = pro?.credit_balance_cents ?? 0;
+  if (currentBalance < cents) {
+    return {
+      accepted: false,
+      reason: "insufficient_credits",
+      balanceAfterCents: currentBalance,
+    };
+  }
+
+  // ── 3. Optimistic-lock claim on the brief row ──────────────────────
+  const acceptedAt = new Date().toISOString();
+  const updates: Record<string, unknown> = {
+    accepted_by_professional_id: professionalId,
+    accepted_at: acceptedAt,
+    tracker_status: "new",
+  };
+  if (teamId) updates.accepted_by_team_id = teamId;
+
+  const { data: claimed } = await admin
+    .from("advisor_auctions")
+    .update(updates)
+    .eq("id", briefId)
+    .is("accepted_by_professional_id", null)
+    .is("accepted_by_team_id", null)
+    .select("*")
+    .maybeSingle();
+
+  if (!claimed) {
+    return { accepted: false, reason: "already_accepted" };
+  }
+
+  // ── 4. Debit credits via ledger (idempotent on brief_id) ───────────
+  let balanceAfterCents = currentBalance;
+  try {
+    const result = await recordLedgerEntry({
+      professionalId,
+      amountCents: -cents,
+      kind: "lead_spend",
+      description: `Brief #${briefId} accept`,
+      referenceType: "brief_accept",
+      referenceId: String(briefId),
+      metadata: { team_id: teamId ?? null, credits },
+    });
+    balanceAfterCents = result.balanceAfterCents;
+  } catch (err) {
+    // Roll back the claim to keep things consistent.
+    await admin
+      .from("advisor_auctions")
+      .update({
+        accepted_by_professional_id: null,
+        accepted_by_team_id: null,
+        accepted_at: null,
+        tracker_status: "new",
+      })
+      .eq("id", briefId);
+    log.error("acceptBrief: ledger debit failed", {
+      briefId,
+      professionalId,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    throw err;
+  }
+
+  // ── 5. Emit tracker event ───────────────────────────────────────────
+  await admin.from("brief_tracker_events").insert({
+    brief_id: briefId,
+    event_type: "accepted",
+    actor_kind: "professional",
+    actor_id: String(professionalId),
+    payload: { credits, team_id: teamId ?? null },
+  });
+
+  return {
+    accepted: true,
+    brief: claimed as unknown as BriefRow,
+    creditsSpent: credits,
+    balanceAfterCents,
+  };
+}
+
+export interface UpdateTrackerStatusInput {
+  briefId: number;
+  professionalId: number;
+  newStatus:
+    | "new"
+    | "contacted"
+    | "call_booked"
+    | "proposal_sent"
+    | "won"
+    | "lost";
+  note?: string;
+}
+
+export async function updateTrackerStatus({
+  briefId,
+  professionalId,
+  newStatus,
+  note,
+}: UpdateTrackerStatusInput): Promise<{ ok: boolean; reason?: string }> {
+  const admin = createAdminClient();
+  const { data: brief } = await admin
+    .from("advisor_auctions")
+    .select("id, accepted_by_professional_id, tracker_status")
+    .eq("id", briefId)
+    .maybeSingle();
+  if (!brief) return { ok: false, reason: "brief_not_found" };
+  if (brief.accepted_by_professional_id !== professionalId) {
+    return { ok: false, reason: "not_owner" };
+  }
+  await admin
+    .from("advisor_auctions")
+    .update({ tracker_status: newStatus })
+    .eq("id", briefId);
+  await admin.from("brief_tracker_events").insert({
+    brief_id: briefId,
+    event_type: "status_changed",
+    actor_kind: "professional",
+    actor_id: String(professionalId),
+    payload: { from: brief.tracker_status, to: newStatus, note: note ?? null },
+  });
+  return { ok: true };
+}

--- a/lib/briefs/mask.ts
+++ b/lib/briefs/mask.ts
@@ -1,0 +1,36 @@
+/**
+ * maskBriefForProvider — strips PII from a brief row so it can be shown
+ * to providers in the inbox preview. Contact details (name, email,
+ * phone) are only re-attached after a successful credit-accept.
+ */
+
+import type { BriefRow, MaskedBrief } from "./types";
+
+const PREVIEW_LIMIT = 280;
+
+export function maskBriefForProvider(row: BriefRow): MaskedBrief {
+  const description = row.job_description ?? "";
+  const truncated =
+    description.length > PREVIEW_LIMIT
+      ? `${description.slice(0, PREVIEW_LIMIT).trimEnd()}…`
+      : description;
+
+  return {
+    id: row.id,
+    slug: row.slug,
+    brief_template: row.brief_template,
+    brief_payload: row.brief_payload ?? {},
+    provider_preference: row.provider_preference,
+    routing_mode: row.routing_mode,
+    budget_band: row.budget_band,
+    location: row.location,
+    advisor_types: row.advisor_types,
+    job_title: row.job_title,
+    description_preview: truncated,
+    accept_credits_cost: row.accept_credits_cost,
+    created_at: row.created_at,
+    ends_at: row.ends_at,
+    status: row.status,
+    tracker_status: row.tracker_status,
+  };
+}

--- a/lib/briefs/risk-flags.ts
+++ b/lib/briefs/risk-flags.ts
@@ -1,0 +1,146 @@
+/**
+ * Brief risk-flag scanner.
+ *
+ * Reads the active patterns from `brief_risk_patterns` and scans the
+ * supplied text for matches. Used by /api/briefs POST to set
+ * `risk_flags` and `risk_review_status` on the new row.
+ *
+ * Severity precedence: block > review > warn.
+ *   - block  → admin must approve before any routing happens. UI tells
+ *              the user the brief is held for review.
+ *   - review → routes after admin approves; admin queue surfaces it.
+ *   - warn   → routes immediately; admin queue shows it as a soft flag.
+ *   - clear  → no patterns matched.
+ */
+
+// eslint-disable-next-line no-restricted-imports -- public/anon path; risk patterns are not RLS-readable by anon. Service-role-legitimate per CLAUDE.md.
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+
+import type { RiskReviewStatus, RiskSeverity } from "./types";
+
+const log = logger("briefs:risk-flags");
+
+export interface RiskPattern {
+  pattern: string;
+  category: string;
+  severity: RiskSeverity;
+}
+
+export interface RiskScanResult {
+  /** Distinct flag categories matched. */
+  flags: string[];
+  /** Highest severity hit, or 'clear'. */
+  severity: RiskSeverity | "clear";
+  /** Suggested `risk_review_status` value for the brief row. */
+  reviewStatus: RiskReviewStatus;
+  /** Whether the brief should be routed immediately. */
+  shouldRouteNow: boolean;
+}
+
+const SEVERITY_RANK: Record<RiskSeverity, number> = {
+  warn: 1,
+  review: 2,
+  block: 3,
+};
+
+/**
+ * Loads enabled patterns and scans `text` for case-insensitive substring
+ * matches. Returns the flag set + the suggested review status. Falls back
+ * to `{ flags: [], severity: 'clear', reviewStatus: 'clear', shouldRouteNow: true }`
+ * if the DB read fails — better to ship the brief than to hard-block on a
+ * scanner outage; the admin queue still gets a visibility-level row in
+ * the same outage.
+ */
+export async function scanBrief(text: string): Promise<RiskScanResult> {
+  const haystack = text.toLowerCase();
+  let patterns: RiskPattern[] = [];
+
+  try {
+    const admin = createAdminClient();
+    const { data } = await admin
+      .from("brief_risk_patterns")
+      .select("pattern, category, severity")
+      .eq("enabled", true);
+    patterns = (data ?? []) as RiskPattern[];
+  } catch (err) {
+    log.warn("scanBrief failed to load patterns", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return {
+      flags: [],
+      severity: "clear",
+      reviewStatus: "clear",
+      shouldRouteNow: true,
+    };
+  }
+
+  const hits = new Map<string, RiskSeverity>();
+  for (const p of patterns) {
+    if (!p.pattern) continue;
+    if (haystack.includes(p.pattern.toLowerCase())) {
+      const current = hits.get(p.category);
+      if (!current || SEVERITY_RANK[p.severity] > SEVERITY_RANK[current]) {
+        hits.set(p.category, p.severity);
+      }
+    }
+  }
+
+  if (hits.size === 0) {
+    return {
+      flags: [],
+      severity: "clear",
+      reviewStatus: "clear",
+      shouldRouteNow: true,
+    };
+  }
+
+  const flags = [...hits.keys()];
+  const topSeverity = [...hits.values()].reduce<RiskSeverity>(
+    (best, s) => (SEVERITY_RANK[s] > SEVERITY_RANK[best] ? s : best),
+    "warn",
+  );
+
+  const reviewStatus: RiskReviewStatus =
+    topSeverity === "warn" ? "clear" : "pending_review";
+  return {
+    flags,
+    severity: topSeverity,
+    reviewStatus,
+    shouldRouteNow: topSeverity === "warn",
+  };
+}
+
+/** Pure variant for unit tests — caller supplies the pattern list. */
+export function scanBriefSync(text: string, patterns: RiskPattern[]): RiskScanResult {
+  const haystack = text.toLowerCase();
+  const hits = new Map<string, RiskSeverity>();
+  for (const p of patterns) {
+    if (!p.pattern) continue;
+    if (haystack.includes(p.pattern.toLowerCase())) {
+      const current = hits.get(p.category);
+      if (!current || SEVERITY_RANK[p.severity] > SEVERITY_RANK[current]) {
+        hits.set(p.category, p.severity);
+      }
+    }
+  }
+  if (hits.size === 0) {
+    return {
+      flags: [],
+      severity: "clear",
+      reviewStatus: "clear",
+      shouldRouteNow: true,
+    };
+  }
+  const flags = [...hits.keys()];
+  const topSeverity = [...hits.values()].reduce<RiskSeverity>(
+    (best, s) => (SEVERITY_RANK[s] > SEVERITY_RANK[best] ? s : best),
+    "warn",
+  );
+  return {
+    flags,
+    severity: topSeverity,
+    reviewStatus: topSeverity === "warn" ? "clear" : "pending_review",
+    shouldRouteNow: topSeverity === "warn",
+  };
+}

--- a/lib/briefs/routing.ts
+++ b/lib/briefs/routing.ts
@@ -1,0 +1,238 @@
+/**
+ * Brief routing — `resolveEligibleProviders(brief)` returns an ordered
+ * list of providers eligible to see the brief preview.
+ *
+ * Rules live in `brief_routing_rules`. Each rule has:
+ *   - match_conditions: jsonb filter (subset-equality on brief fields)
+ *   - route_to: jsonb action describing preferred provider kind + extras
+ *
+ * For `routing_mode='direct'` we route ONLY to the target_* the user
+ * picked. Otherwise we apply matching rules in priority order and
+ * concatenate eligible providers (deduped by kind+id).
+ *
+ * The function is intentionally simple: it returns up to 50 eligible
+ * providers for the brief. The provider's inbox endpoint filters
+ * further (subscription, country eligibility, accepts_new_clients).
+ */
+
+// eslint-disable-next-line no-restricted-imports -- routing cross-references advisor_firms + expert_teams + professionals across users; service-role legitimate (anon-RLS cannot see all rows).
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+
+import type { BriefRow, EligibleProvider, ProviderKind } from "./types";
+
+const log = logger("briefs:routing");
+
+interface RoutingRuleRow {
+  id: number;
+  name: string;
+  priority: number;
+  enabled: boolean;
+  match_conditions: Record<string, unknown>;
+  route_to: Record<string, unknown>;
+}
+
+const MAX_RESULTS = 50;
+
+export async function resolveEligibleProviders(
+  brief: BriefRow,
+): Promise<EligibleProvider[]> {
+  // Direct routing short-circuits rule evaluation.
+  if (brief.routing_mode === "direct") {
+    return directProviders(brief);
+  }
+
+  const admin = createAdminClient();
+  const { data: rulesData } = await admin
+    .from("brief_routing_rules")
+    .select("id, name, priority, enabled, match_conditions, route_to")
+    .eq("enabled", true)
+    .order("priority", { ascending: true });
+
+  const rules = (rulesData ?? []) as RoutingRuleRow[];
+
+  // First matching rule wins for ordering; if none matches, fall through
+  // to the implicit any-provider behaviour.
+  const matched = rules.find((r) => ruleMatches(r.match_conditions, brief));
+
+  if (!matched) {
+    log.info("resolveEligibleProviders: no rule matched", { briefId: brief.id });
+    return anyProviders(brief);
+  }
+
+  const prefer = (matched.route_to.prefer ?? "any") as ProviderKind | "any";
+  const fallback = Array.isArray(matched.route_to.fallback)
+    ? (matched.route_to.fallback as ProviderKind[])
+    : [];
+  const teamCategory =
+    typeof matched.route_to.team_category === "string"
+      ? (matched.route_to.team_category as string)
+      : null;
+
+  const out: EligibleProvider[] = [];
+
+  if (prefer === "expert_team") {
+    out.push(...(await fetchExpertTeams(brief, teamCategory)));
+  } else if (prefer === "individual") {
+    out.push(...(await fetchIndividuals(brief)));
+  } else if (prefer === "firm") {
+    out.push(...(await fetchFirms(brief)));
+  } else {
+    out.push(
+      ...(await fetchExpertTeams(brief, teamCategory)),
+      ...(await fetchIndividuals(brief)),
+      ...(await fetchFirms(brief)),
+    );
+  }
+
+  for (const fb of fallback) {
+    if (fb === "expert_team") out.push(...(await fetchExpertTeams(brief, teamCategory)));
+    if (fb === "individual") out.push(...(await fetchIndividuals(brief)));
+    if (fb === "firm") out.push(...(await fetchFirms(brief)));
+  }
+
+  return dedupe(out).slice(0, MAX_RESULTS);
+}
+
+function ruleMatches(conditions: Record<string, unknown>, brief: BriefRow): boolean {
+  for (const [key, value] of Object.entries(conditions)) {
+    if (key === "brief_template" && brief.brief_template !== value) return false;
+    if (key === "provider_preference" && brief.provider_preference !== value) return false;
+    if (key === "routing_mode" && brief.routing_mode !== value) return false;
+    if (key === "help_needed") {
+      const payload = brief.brief_payload ?? {};
+      const hn = (payload as Record<string, unknown>).help_needed;
+      const target = String(value);
+      if (Array.isArray(hn)) {
+        if (!hn.map(String).includes(target)) return false;
+      } else if (String(hn) !== target) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+function dedupe(list: EligibleProvider[]): EligibleProvider[] {
+  const seen = new Set<string>();
+  const out: EligibleProvider[] = [];
+  for (const p of list) {
+    const key = `${p.kind}:${p.id}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(p);
+  }
+  return out;
+}
+
+async function directProviders(brief: BriefRow): Promise<EligibleProvider[]> {
+  const out: EligibleProvider[] = [];
+  if (brief.target_team_id) {
+    out.push({
+      kind: "expert_team",
+      id: brief.target_team_id,
+      reason: "direct_target",
+      score: 100,
+    });
+  }
+  if (brief.target_professional_id) {
+    out.push({
+      kind: "individual",
+      id: brief.target_professional_id,
+      reason: "direct_target",
+      score: 100,
+    });
+  }
+  if (brief.target_firm_id) {
+    out.push({
+      kind: "firm",
+      id: brief.target_firm_id,
+      reason: "direct_target",
+      score: 100,
+    });
+  }
+  return out;
+}
+
+async function anyProviders(brief: BriefRow): Promise<EligibleProvider[]> {
+  return dedupe([
+    ...(await fetchExpertTeams(brief, null)),
+    ...(await fetchIndividuals(brief)),
+    ...(await fetchFirms(brief)),
+  ]).slice(0, MAX_RESULTS);
+}
+
+async function fetchExpertTeams(
+  brief: BriefRow,
+  teamCategory: string | null,
+): Promise<EligibleProvider[]> {
+  if (brief.provider_preference === "individual" || brief.provider_preference === "firm") {
+    return [];
+  }
+  const admin = createAdminClient();
+  let q = admin
+    .from("expert_teams")
+    .select("id, team_category, accepts_briefs, verification_status, public")
+    .eq("public", true)
+    .eq("verification_status", "verified")
+    .eq("accepts_briefs", true);
+  if (teamCategory) q = q.eq("team_category", teamCategory);
+  if (brief.brief_template) {
+    // Match teams whose accepted_brief_templates is empty (no restriction) or
+    // contains this template. PostgREST `or` syntax with array `cs.{…}`.
+    q = q.or(
+      `accepted_brief_templates.cs.{${brief.brief_template}},accepted_brief_templates.eq.{}`,
+    );
+  }
+  const { data } = await q.limit(20);
+  return (data ?? []).map((t) => ({
+    kind: "expert_team" as const,
+    id: t.id as number,
+    reason: teamCategory ? `team_category=${teamCategory}` : "verified_team",
+    score: 90,
+  }));
+}
+
+async function fetchIndividuals(brief: BriefRow): Promise<EligibleProvider[]> {
+  if (brief.provider_preference === "firm" || brief.provider_preference === "expert_team") {
+    return [];
+  }
+  const admin = createAdminClient();
+  const types =
+    brief.advisor_types && brief.advisor_types.length > 0 ? brief.advisor_types : null;
+  let q = admin
+    .from("professionals")
+    .select("id, type, accepts_new_clients, status")
+    .eq("status", "active")
+    .eq("accepts_new_clients", true);
+  if (types) q = q.in("type", types);
+  if (brief.location) q = q.or(`location_state.eq.${brief.location},location_state.is.null`);
+  const { data } = await q.limit(20);
+  return (data ?? []).map((p) => ({
+    kind: "individual" as const,
+    id: p.id as number,
+    reason: types ? `type=${p.type}` : "active_individual",
+    score: 70,
+  }));
+}
+
+async function fetchFirms(brief: BriefRow): Promise<EligibleProvider[]> {
+  if (
+    brief.provider_preference === "individual" ||
+    brief.provider_preference === "expert_team"
+  ) {
+    return [];
+  }
+  const admin = createAdminClient();
+  const { data } = await admin
+    .from("advisor_firms")
+    .select("id, status, location_state")
+    .eq("status", "active")
+    .limit(20);
+  return (data ?? []).map((f) => ({
+    kind: "firm" as const,
+    id: f.id as number,
+    reason: "active_firm",
+    score: 60,
+  }));
+}

--- a/lib/briefs/templates.ts
+++ b/lib/briefs/templates.ts
@@ -1,0 +1,431 @@
+/**
+ * Investor Brief template registry.
+ *
+ * Each template defines:
+ *   - label / description (UI copy)
+ *   - the Zod schema for `brief_payload` so we can validate the structured
+ *     answers before insert
+ *   - a small UI hint set used by the Brief form to render dynamic fields
+ *
+ * Four templates ship with proper structured fields. The remaining
+ * templates use the generic `notesPayloadSchema` (just a free-text
+ * `notes` field) so admins can flesh them out later without code changes
+ * on the form side.
+ */
+
+import { z } from "zod";
+
+import type { BriefTemplate } from "./types";
+
+export const BRIEF_TEMPLATES: BriefTemplate[] = [
+  "general",
+  "smsf_property",
+  "foreign_investor",
+  "expat",
+  "opportunity_assessment",
+  "business_acquisition",
+  "commercial_property",
+  "second_opinion",
+  "mortgage",
+  "tax",
+  "smsf_accountant",
+  "financial_adviser",
+  "listing",
+  "listing_readiness",
+];
+
+export const BRIEF_TEMPLATE_LABELS: Record<BriefTemplate, string> = {
+  general: "General Expert Brief",
+  smsf_property: "SMSF Property Brief",
+  foreign_investor: "Foreign Investor Brief",
+  expat: "Expat Investor Brief",
+  opportunity_assessment: "Opportunity Assessment Brief",
+  business_acquisition: "Business Acquisition Brief",
+  commercial_property: "Commercial Property Brief",
+  second_opinion: "Second Opinion Brief",
+  mortgage: "Mortgage Brief",
+  tax: "Tax / Accounting Brief",
+  smsf_accountant: "SMSF Accountant Brief",
+  financial_adviser: "Financial Adviser Brief",
+  listing: "Listing Brief",
+  listing_readiness: "Listing Readiness Check",
+};
+
+export const BRIEF_TEMPLATE_BLURBS: Record<BriefTemplate, string> = {
+  general: "Tell verified professionals what you need help with.",
+  smsf_property: "SMSF property strategy and the team you need to make it happen.",
+  foreign_investor: "Investing in Australia from overseas — tax, structuring, FIRB.",
+  expat: "Australians abroad — tax residency, super, investing.",
+  opportunity_assessment: "Help reviewing a specific opportunity or listing.",
+  business_acquisition: "Buying a business — diligence, lending, legal.",
+  commercial_property: "Commercial property purchase, lease, or investment.",
+  second_opinion: "Get a second opinion on advice you have already received.",
+  mortgage: "Home loan, investment loan, refinance or restructure.",
+  tax: "Tax planning or return preparation.",
+  smsf_accountant: "SMSF establishment, compliance, or accounting.",
+  financial_adviser: "General financial planning / wealth strategy.",
+  listing: "Post an investment listing — find buyers and stay compliant.",
+  listing_readiness: "Get your opportunity ready to list (legal, financial, copy).",
+};
+
+const TIMELINE_OPTIONS = [
+  "asap",
+  "1_3_months",
+  "3_6_months",
+  "6_12_months",
+  "12_months_plus",
+  "not_sure",
+] as const;
+
+const SMSF_STATUS_OPTIONS = [
+  "no_smsf",
+  "considering_smsf",
+  "smsf_established",
+  "not_sure",
+] as const;
+
+const SUPER_BALANCE_BANDS = [
+  "under_100k",
+  "100k_300k",
+  "300k_500k",
+  "500k_800k",
+  "800k_1_2m",
+  "1_2m_plus",
+  "not_sure",
+] as const;
+
+const PROPERTY_BUDGETS = [
+  "under_500k",
+  "500k_700k",
+  "700k_900k",
+  "900k_1_2m",
+  "1_2m_2m",
+  "2m_plus",
+  "not_sure",
+] as const;
+
+const SMSF_HELP_NEEDED = [
+  "smsf_setup",
+  "financial_advice",
+  "lending",
+  "property_search",
+  "conveyancing",
+  "not_sure",
+] as const;
+
+const OPPORTUNITY_HELP_NEEDED = [
+  "finance",
+  "tax_accounting",
+  "legal_review",
+  "due_diligence",
+  "full_specialist_team",
+  "not_sure",
+] as const;
+
+const FOREIGN_INVESTOR_HELP_NEEDED = [
+  "firb_application",
+  "tax_residency",
+  "structuring",
+  "lending",
+  "property_search",
+  "not_sure",
+] as const;
+
+const VISA_TYPES = [
+  "citizen_australia",
+  "permanent_resident",
+  "temporary_resident",
+  "non_resident",
+  "considering_migration",
+  "not_sure",
+] as const;
+
+// ─── Schemas ──────────────────────────────────────────────────────────────
+
+const notesPayloadSchema = z
+  .object({
+    notes: z.string().max(2000).optional(),
+  })
+  .strict();
+
+const generalPayloadSchema = z
+  .object({
+    goal: z.string().max(300).optional(),
+    notes: z.string().max(2000).optional(),
+    timeline: z.enum(TIMELINE_OPTIONS).optional(),
+  })
+  .strict();
+
+const smsfPropertyPayloadSchema = z
+  .object({
+    smsf_status: z.enum(SMSF_STATUS_OPTIONS),
+    super_balance_band: z.enum(SUPER_BALANCE_BANDS).optional(),
+    property_budget: z.enum(PROPERTY_BUDGETS),
+    target_location: z.string().max(120).optional(),
+    timeline: z.enum(TIMELINE_OPTIONS),
+    help_needed: z.array(z.enum(SMSF_HELP_NEEDED)).min(1).max(SMSF_HELP_NEEDED.length),
+    notes: z.string().max(2000).optional(),
+  })
+  .strict();
+
+const foreignInvestorPayloadSchema = z
+  .object({
+    country_of_residence: z.string().min(2).max(80),
+    visa_type: z.enum(VISA_TYPES).optional(),
+    investment_amount_aud: z.string().max(60).optional(),
+    asset_type: z.string().max(120).optional(),
+    timeline: z.enum(TIMELINE_OPTIONS),
+    help_needed: z.array(z.enum(FOREIGN_INVESTOR_HELP_NEEDED)).min(1),
+    notes: z.string().max(2000).optional(),
+  })
+  .strict();
+
+const opportunityAssessmentPayloadSchema = z
+  .object({
+    listing_url_or_name: z.string().max(500).optional(),
+    investment_amount_aud: z.string().max(60).optional(),
+    timeline: z.enum(TIMELINE_OPTIONS),
+    help_needed: z.array(z.enum(OPPORTUNITY_HELP_NEEDED)).min(1),
+    notes: z.string().max(2000).optional(),
+  })
+  .strict();
+
+// Map every template to its payload schema. Templates without a richer
+// schema fall back to `notesPayloadSchema` so admins can iterate copy
+// without a code change.
+export const BRIEF_TEMPLATE_SCHEMAS: Record<BriefTemplate, z.ZodTypeAny> = {
+  general: generalPayloadSchema,
+  smsf_property: smsfPropertyPayloadSchema,
+  foreign_investor: foreignInvestorPayloadSchema,
+  opportunity_assessment: opportunityAssessmentPayloadSchema,
+  expat: notesPayloadSchema,
+  business_acquisition: notesPayloadSchema,
+  commercial_property: notesPayloadSchema,
+  second_opinion: notesPayloadSchema,
+  mortgage: notesPayloadSchema,
+  tax: notesPayloadSchema,
+  smsf_accountant: notesPayloadSchema,
+  financial_adviser: notesPayloadSchema,
+  listing: notesPayloadSchema,
+  listing_readiness: notesPayloadSchema,
+};
+
+export function getTemplateSchema(template: BriefTemplate): z.ZodTypeAny {
+  return BRIEF_TEMPLATE_SCHEMAS[template];
+}
+
+export function isBriefTemplate(value: unknown): value is BriefTemplate {
+  return typeof value === "string" && (BRIEF_TEMPLATES as readonly string[]).includes(value);
+}
+
+/**
+ * UI hints consumed by the dynamic brief form to render structured fields
+ * for the shipped templates. Other templates rely on the generic notes
+ * textarea.
+ */
+export interface FieldHint {
+  key: string;
+  label: string;
+  kind: "text" | "textarea" | "select" | "multiselect";
+  options?: { value: string; label: string }[];
+  required?: boolean;
+  placeholder?: string;
+  maxLength?: number;
+}
+
+const TIMELINE_FIELD: FieldHint = {
+  key: "timeline",
+  label: "Timeline",
+  kind: "select",
+  required: true,
+  options: [
+    { value: "asap", label: "As soon as possible" },
+    { value: "1_3_months", label: "1–3 months" },
+    { value: "3_6_months", label: "3–6 months" },
+    { value: "6_12_months", label: "6–12 months" },
+    { value: "12_months_plus", label: "12+ months" },
+    { value: "not_sure", label: "Not sure yet" },
+  ],
+};
+
+const NOTES_FIELD: FieldHint = {
+  key: "notes",
+  label: "Anything else verified providers should know?",
+  kind: "textarea",
+  maxLength: 2000,
+  placeholder: "Optional context, deadlines, preferences.",
+};
+
+export const BRIEF_TEMPLATE_FIELDS: Record<BriefTemplate, FieldHint[]> = {
+  general: [
+    {
+      key: "goal",
+      label: "Your goal",
+      kind: "text",
+      maxLength: 300,
+      placeholder: "e.g. Long-term wealth-building plan",
+    },
+    TIMELINE_FIELD,
+    NOTES_FIELD,
+  ],
+  smsf_property: [
+    {
+      key: "smsf_status",
+      label: "SMSF status",
+      kind: "select",
+      required: true,
+      options: [
+        { value: "no_smsf", label: "I don't have an SMSF yet" },
+        { value: "considering_smsf", label: "Considering an SMSF" },
+        { value: "smsf_established", label: "Existing SMSF" },
+        { value: "not_sure", label: "Not sure" },
+      ],
+    },
+    {
+      key: "super_balance_band",
+      label: "Estimated super balance",
+      kind: "select",
+      options: [
+        { value: "under_100k", label: "Under $100k" },
+        { value: "100k_300k", label: "$100k – $300k" },
+        { value: "300k_500k", label: "$300k – $500k" },
+        { value: "500k_800k", label: "$500k – $800k" },
+        { value: "800k_1_2m", label: "$800k – $1.2m" },
+        { value: "1_2m_plus", label: "$1.2m+" },
+        { value: "not_sure", label: "Not sure" },
+      ],
+    },
+    {
+      key: "property_budget",
+      label: "Property budget",
+      kind: "select",
+      required: true,
+      options: [
+        { value: "under_500k", label: "Under $500k" },
+        { value: "500k_700k", label: "$500k – $700k" },
+        { value: "700k_900k", label: "$700k – $900k" },
+        { value: "900k_1_2m", label: "$900k – $1.2m" },
+        { value: "1_2m_2m", label: "$1.2m – $2m" },
+        { value: "2m_plus", label: "$2m+" },
+        { value: "not_sure", label: "Not sure" },
+      ],
+    },
+    {
+      key: "target_location",
+      label: "Target location",
+      kind: "text",
+      maxLength: 120,
+      placeholder: "e.g. Brisbane inner suburbs",
+    },
+    TIMELINE_FIELD,
+    {
+      key: "help_needed",
+      label: "Help needed",
+      kind: "multiselect",
+      required: true,
+      options: [
+        { value: "smsf_setup", label: "SMSF setup" },
+        { value: "financial_advice", label: "Financial advice" },
+        { value: "lending", label: "Lending" },
+        { value: "property_search", label: "Property search" },
+        { value: "conveyancing", label: "Conveyancing / legal" },
+        { value: "not_sure", label: "Not sure" },
+      ],
+    },
+    NOTES_FIELD,
+  ],
+  foreign_investor: [
+    {
+      key: "country_of_residence",
+      label: "Country of residence",
+      kind: "text",
+      required: true,
+      maxLength: 80,
+      placeholder: "e.g. Singapore",
+    },
+    {
+      key: "visa_type",
+      label: "Visa / residency status",
+      kind: "select",
+      options: [
+        { value: "citizen_australia", label: "Australian citizen" },
+        { value: "permanent_resident", label: "Permanent resident" },
+        { value: "temporary_resident", label: "Temporary resident" },
+        { value: "non_resident", label: "Non-resident" },
+        { value: "considering_migration", label: "Considering migration" },
+        { value: "not_sure", label: "Not sure" },
+      ],
+    },
+    {
+      key: "investment_amount_aud",
+      label: "Investment amount (AUD)",
+      kind: "text",
+      maxLength: 60,
+      placeholder: "e.g. A$1.5m",
+    },
+    {
+      key: "asset_type",
+      label: "Asset type",
+      kind: "text",
+      maxLength: 120,
+      placeholder: "e.g. Residential property, managed fund",
+    },
+    TIMELINE_FIELD,
+    {
+      key: "help_needed",
+      label: "Help needed",
+      kind: "multiselect",
+      required: true,
+      options: [
+        { value: "firb_application", label: "FIRB application" },
+        { value: "tax_residency", label: "Tax / residency" },
+        { value: "structuring", label: "Structuring" },
+        { value: "lending", label: "Lending" },
+        { value: "property_search", label: "Property search" },
+        { value: "not_sure", label: "Not sure" },
+      ],
+    },
+    NOTES_FIELD,
+  ],
+  opportunity_assessment: [
+    {
+      key: "listing_url_or_name",
+      label: "Listing URL or name",
+      kind: "text",
+      maxLength: 500,
+      placeholder: "Paste a listing URL or describe the opportunity",
+    },
+    {
+      key: "investment_amount_aud",
+      label: "Investment amount (AUD)",
+      kind: "text",
+      maxLength: 60,
+    },
+    TIMELINE_FIELD,
+    {
+      key: "help_needed",
+      label: "Help needed",
+      kind: "multiselect",
+      required: true,
+      options: [
+        { value: "finance", label: "Finance" },
+        { value: "tax_accounting", label: "Tax / accounting" },
+        { value: "legal_review", label: "Legal review" },
+        { value: "due_diligence", label: "Due diligence" },
+        { value: "full_specialist_team", label: "Full specialist team" },
+        { value: "not_sure", label: "Not sure" },
+      ],
+    },
+    NOTES_FIELD,
+  ],
+  expat: [NOTES_FIELD],
+  business_acquisition: [NOTES_FIELD],
+  commercial_property: [NOTES_FIELD],
+  second_opinion: [NOTES_FIELD],
+  mortgage: [NOTES_FIELD],
+  tax: [NOTES_FIELD],
+  smsf_accountant: [NOTES_FIELD],
+  financial_adviser: [NOTES_FIELD],
+  listing: [NOTES_FIELD],
+  listing_readiness: [NOTES_FIELD],
+};

--- a/lib/briefs/types.ts
+++ b/lib/briefs/types.ts
@@ -1,0 +1,114 @@
+/**
+ * Brief domain types — mirror the columns added by
+ * 20260723_pmp01_provider_marketplace_foundation.sql.
+ *
+ * A "brief" is a row in `advisor_auctions` with `flow_type='accept'`.
+ * `flow_type='auction'` rows remain the legacy bid-auction shape and are
+ * read/written by the existing /quotes/post and /api/quotes paths.
+ */
+
+export type BriefFlowType = "auction" | "accept";
+
+export type BriefTemplate =
+  | "general"
+  | "smsf_property"
+  | "foreign_investor"
+  | "expat"
+  | "opportunity_assessment"
+  | "business_acquisition"
+  | "commercial_property"
+  | "second_opinion"
+  | "mortgage"
+  | "tax"
+  | "smsf_accountant"
+  | "financial_adviser"
+  | "listing"
+  | "listing_readiness";
+
+export type ProviderPreference =
+  | "any"
+  | "individual"
+  | "firm"
+  | "expert_team"
+  | "multiple";
+
+export type RoutingMode = "smart_match" | "direct" | "multi_response";
+
+export type TrackerStatus =
+  | "new"
+  | "contacted"
+  | "call_booked"
+  | "proposal_sent"
+  | "won"
+  | "lost"
+  | "withdrawn";
+
+export type RiskReviewStatus =
+  | "clear"
+  | "pending_review"
+  | "approved"
+  | "rejected";
+
+export type RiskSeverity = "warn" | "review" | "block";
+
+export interface BriefRow {
+  id: number;
+  slug: string;
+  flow_type: BriefFlowType;
+  brief_template: BriefTemplate | null;
+  brief_payload: Record<string, unknown>;
+  provider_preference: ProviderPreference | null;
+  routing_mode: RoutingMode | null;
+  target_professional_id: number | null;
+  target_firm_id: number | null;
+  target_team_id: number | null;
+  accept_credits_cost: number | null;
+  accepted_by_professional_id: number | null;
+  accepted_by_team_id: number | null;
+  accepted_at: string | null;
+  tracker_status: TrackerStatus;
+  risk_flags: string[];
+  risk_review_status: RiskReviewStatus;
+  listing_id: number | null;
+  // Legacy/shared fields still on advisor_auctions:
+  job_title: string;
+  job_description: string;
+  budget_band: string;
+  advisor_types: string[] | null;
+  location: string | null;
+  contact_name: string | null;
+  contact_email: string | null;
+  contact_phone?: string | null;
+  status: string;
+  ends_at: string;
+  created_at: string;
+}
+
+export interface MaskedBrief {
+  id: number;
+  slug: string;
+  brief_template: BriefTemplate | null;
+  brief_payload: Record<string, unknown>;
+  provider_preference: ProviderPreference | null;
+  routing_mode: RoutingMode | null;
+  budget_band: string;
+  location: string | null;
+  advisor_types: string[] | null;
+  job_title: string;
+  // Deliberately short summary, no PII.
+  description_preview: string;
+  accept_credits_cost: number | null;
+  created_at: string;
+  ends_at: string;
+  status: string;
+  tracker_status: TrackerStatus;
+}
+
+export type ProviderKind = "individual" | "firm" | "expert_team";
+
+export interface EligibleProvider {
+  kind: ProviderKind;
+  id: number;
+  reason: string;
+  score: number;
+}

--- a/lib/expert-teams.ts
+++ b/lib/expert-teams.ts
@@ -1,0 +1,441 @@
+/**
+ * Expert Teams — CRUD + invitation flow.
+ *
+ * Mirrors the pattern in `app/api/advisor-auth/firm/invite/route.ts` but
+ * operates on `expert_teams` / `expert_team_members` / `expert_team_invitations`.
+ *
+ * The owner is the calling professional. Verification is required before
+ * a team can appear publicly or receive briefs.
+ */
+
+// eslint-disable-next-line no-restricted-imports -- multi-row writes across professionals/teams; service-role legitimate per CLAUDE.md.
+import { createAdminClient } from "@/lib/supabase/admin";
+import { randomBytes } from "crypto";
+import { logger } from "@/lib/logger";
+
+const log = logger("expert-teams");
+
+export type TeamType = "same_firm" | "independent" | "private_referral" | "internal_firm";
+
+export type TeamVerificationStatus =
+  | "draft"
+  | "submitted"
+  | "verified"
+  | "rejected"
+  | "suspended";
+
+export interface ExpertTeam {
+  id: number;
+  slug: string;
+  name: string;
+  team_category: string;
+  team_type: TeamType;
+  description: string | null;
+  niche: string | null;
+  location_state: string | null;
+  service_areas: string[];
+  owner_professional_id: number;
+  lead_professional_id: number | null;
+  firm_id: number | null;
+  disclosure: string | null;
+  accepted_brief_templates: string[];
+  accepts_briefs: boolean;
+  verification_status: TeamVerificationStatus;
+  verified_at: string | null;
+  public: boolean;
+  rejection_reason: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ExpertTeamMember {
+  id: number;
+  team_id: number;
+  professional_id: number;
+  member_role: string;
+  public_title: string | null;
+  can_receive_briefs: boolean;
+  can_appear_publicly: boolean;
+  status: "pending" | "active" | "removed";
+  accepted_at: string | null;
+}
+
+export interface ExpertTeamInvitation {
+  id: number;
+  team_id: number;
+  email: string;
+  name: string | null;
+  invited_professional_id: number | null;
+  invited_role: string;
+  invited_by: number;
+  token: string;
+  status: "pending" | "accepted" | "expired" | "revoked";
+  accepted_at: string | null;
+  expires_at: string;
+  created_at: string;
+}
+
+export interface CreateTeamInput {
+  ownerProfessionalId: number;
+  name: string;
+  teamCategory: string;
+  teamType: TeamType;
+  description?: string;
+  niche?: string;
+  locationState?: string;
+  serviceAreas?: string[];
+  firmId?: number | null;
+  disclosure?: string;
+  acceptedBriefTemplates?: string[];
+}
+
+function slugify(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .slice(0, 80);
+}
+
+export async function createTeam(input: CreateTeamInput): Promise<ExpertTeam> {
+  const admin = createAdminClient();
+  const slug = `${slugify(input.name)}-${Date.now().toString(36)}`;
+
+  const { data, error } = await admin
+    .from("expert_teams")
+    .insert({
+      slug,
+      name: input.name.trim(),
+      team_category: input.teamCategory,
+      team_type: input.teamType,
+      description: input.description ?? null,
+      niche: input.niche ?? null,
+      location_state: input.locationState ?? null,
+      service_areas: input.serviceAreas ?? [],
+      owner_professional_id: input.ownerProfessionalId,
+      lead_professional_id: input.ownerProfessionalId,
+      firm_id: input.firmId ?? null,
+      disclosure: input.disclosure ?? null,
+      accepted_brief_templates: input.acceptedBriefTemplates ?? [],
+      verification_status: "draft",
+      public: false,
+      accepts_briefs: false,
+    })
+    .select("*")
+    .single();
+
+  if (error || !data) {
+    throw new Error(`createTeam failed: ${error?.message ?? "no row"}`);
+  }
+
+  // Owner becomes the lead member automatically.
+  await admin
+    .from("expert_team_members")
+    .insert({
+      team_id: data.id,
+      professional_id: input.ownerProfessionalId,
+      member_role: "lead",
+      can_receive_briefs: true,
+      can_appear_publicly: true,
+      status: "active",
+      accepted_at: new Date().toISOString(),
+    })
+    .throwOnError();
+
+  return data as ExpertTeam;
+}
+
+export async function getTeamById(id: number): Promise<ExpertTeam | null> {
+  const admin = createAdminClient();
+  const { data } = await admin.from("expert_teams").select("*").eq("id", id).maybeSingle();
+  return (data as ExpertTeam) ?? null;
+}
+
+export async function getTeamBySlug(slug: string): Promise<ExpertTeam | null> {
+  const admin = createAdminClient();
+  const { data } = await admin.from("expert_teams").select("*").eq("slug", slug).maybeSingle();
+  return (data as ExpertTeam) ?? null;
+}
+
+export async function listMembers(teamId: number): Promise<ExpertTeamMember[]> {
+  const admin = createAdminClient();
+  const { data } = await admin
+    .from("expert_team_members")
+    .select("*")
+    .eq("team_id", teamId)
+    .order("status", { ascending: true });
+  return (data as ExpertTeamMember[]) ?? [];
+}
+
+export async function listInvitations(teamId: number): Promise<ExpertTeamInvitation[]> {
+  const admin = createAdminClient();
+  const { data } = await admin
+    .from("expert_team_invitations")
+    .select("*")
+    .eq("team_id", teamId)
+    .order("created_at", { ascending: false });
+  return (data as ExpertTeamInvitation[]) ?? [];
+}
+
+export interface InviteMemberInput {
+  teamId: number;
+  invitedByProfessionalId: number;
+  email: string;
+  name?: string;
+  role?: string;
+}
+
+export async function inviteMember(input: InviteMemberInput): Promise<ExpertTeamInvitation> {
+  const admin = createAdminClient();
+  const email = input.email.toLowerCase().trim();
+
+  const { data: existing } = await admin
+    .from("expert_team_invitations")
+    .select("id")
+    .eq("team_id", input.teamId)
+    .eq("email", email)
+    .eq("status", "pending")
+    .maybeSingle();
+  if (existing) {
+    throw new Error("invitation_already_pending");
+  }
+
+  const { data: maybePro } = await admin
+    .from("professionals")
+    .select("id")
+    .eq("email", email)
+    .maybeSingle();
+
+  if (maybePro) {
+    const { data: alreadyMember } = await admin
+      .from("expert_team_members")
+      .select("id, status")
+      .eq("team_id", input.teamId)
+      .eq("professional_id", maybePro.id)
+      .maybeSingle();
+    if (alreadyMember && alreadyMember.status !== "removed") {
+      throw new Error("already_member");
+    }
+  }
+
+  const token = randomBytes(32).toString("hex");
+
+  const { data, error } = await admin
+    .from("expert_team_invitations")
+    .insert({
+      team_id: input.teamId,
+      email,
+      name: input.name ?? null,
+      invited_professional_id: maybePro?.id ?? null,
+      invited_role: input.role ?? "member",
+      invited_by: input.invitedByProfessionalId,
+      token,
+      status: "pending",
+    })
+    .select("*")
+    .single();
+
+  if (error || !data) throw new Error(`inviteMember failed: ${error?.message ?? "no row"}`);
+  return data as ExpertTeamInvitation;
+}
+
+export async function getInvitationByToken(
+  token: string,
+): Promise<ExpertTeamInvitation | null> {
+  const admin = createAdminClient();
+  const { data } = await admin
+    .from("expert_team_invitations")
+    .select("*")
+    .eq("token", token)
+    .maybeSingle();
+  return (data as ExpertTeamInvitation) ?? null;
+}
+
+export interface AcceptInvitationInput {
+  token: string;
+  professionalId: number;
+}
+
+export async function acceptInvitation({
+  token,
+  professionalId,
+}: AcceptInvitationInput): Promise<{ teamId: number }> {
+  const admin = createAdminClient();
+  const invite = await getInvitationByToken(token);
+  if (!invite) throw new Error("invalid_invitation");
+  if (invite.status !== "pending") throw new Error("invitation_unavailable");
+  if (new Date(invite.expires_at) < new Date()) {
+    await admin
+      .from("expert_team_invitations")
+      .update({ status: "expired" })
+      .eq("id", invite.id);
+    throw new Error("invitation_expired");
+  }
+
+  // Promote/insert the membership.
+  const { data: existing } = await admin
+    .from("expert_team_members")
+    .select("id")
+    .eq("team_id", invite.team_id)
+    .eq("professional_id", professionalId)
+    .maybeSingle();
+
+  if (existing) {
+    await admin
+      .from("expert_team_members")
+      .update({ status: "active", accepted_at: new Date().toISOString() })
+      .eq("id", existing.id);
+  } else {
+    await admin
+      .from("expert_team_members")
+      .insert({
+        team_id: invite.team_id,
+        professional_id: professionalId,
+        member_role: invite.invited_role,
+        status: "active",
+        accepted_at: new Date().toISOString(),
+      })
+      .throwOnError();
+  }
+
+  await admin
+    .from("expert_team_invitations")
+    .update({ status: "accepted", accepted_at: new Date().toISOString() })
+    .eq("id", invite.id);
+
+  return { teamId: invite.team_id };
+}
+
+export async function submitForVerification(
+  teamId: number,
+  professionalId: number,
+): Promise<ExpertTeam> {
+  const admin = createAdminClient();
+  const { data: team } = await admin
+    .from("expert_teams")
+    .select("*")
+    .eq("id", teamId)
+    .maybeSingle();
+  if (!team) throw new Error("team_not_found");
+  if (team.owner_professional_id !== professionalId) throw new Error("not_owner");
+
+  // Sanity gate — team must have a lead, ≥1 active member, category, disclosure,
+  // accepted brief templates, before submission.
+  const { count: activeMemberCount } = await admin
+    .from("expert_team_members")
+    .select("id", { count: "exact", head: true })
+    .eq("team_id", teamId)
+    .eq("status", "active");
+
+  const missing: string[] = [];
+  if (!team.lead_professional_id) missing.push("lead_professional");
+  if (!activeMemberCount || activeMemberCount < 1) missing.push("active_member");
+  if (!team.team_category) missing.push("team_category");
+  if (!team.disclosure) missing.push("disclosure");
+  if (!team.accepted_brief_templates || team.accepted_brief_templates.length === 0) {
+    missing.push("accepted_brief_templates");
+  }
+  if (!team.description) missing.push("description");
+  if (missing.length > 0) {
+    log.info("submitForVerification rejected — missing fields", { teamId, missing });
+    throw new Error(`incomplete:${missing.join(",")}`);
+  }
+
+  const { data, error } = await admin
+    .from("expert_teams")
+    .update({
+      verification_status: "submitted",
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", teamId)
+    .select("*")
+    .single();
+  if (error || !data) throw new Error(`submitForVerification failed: ${error?.message}`);
+  return data as ExpertTeam;
+}
+
+export interface AdminVerifyInput {
+  teamId: number;
+  approved: boolean;
+  rejectionReason?: string;
+  acceptsBriefs?: boolean;
+}
+
+export async function adminVerify({
+  teamId,
+  approved,
+  rejectionReason,
+  acceptsBriefs,
+}: AdminVerifyInput): Promise<ExpertTeam> {
+  const admin = createAdminClient();
+  const updates: Record<string, unknown> = approved
+    ? {
+        verification_status: "verified",
+        verified_at: new Date().toISOString(),
+        public: true,
+        accepts_briefs: acceptsBriefs ?? true,
+        rejection_reason: null,
+      }
+    : {
+        verification_status: "rejected",
+        rejection_reason: rejectionReason ?? "Did not meet verification criteria.",
+        public: false,
+        accepts_briefs: false,
+      };
+  const { data, error } = await admin
+    .from("expert_teams")
+    .update(updates)
+    .eq("id", teamId)
+    .select("*")
+    .single();
+  if (error || !data) throw new Error(`adminVerify failed: ${error?.message}`);
+  return data as ExpertTeam;
+}
+
+export async function listTeamsForProfessional(
+  professionalId: number,
+): Promise<ExpertTeam[]> {
+  const admin = createAdminClient();
+  const { data: memberships } = await admin
+    .from("expert_team_members")
+    .select("team_id, status")
+    .eq("professional_id", professionalId)
+    .in("status", ["active", "pending"]);
+  const teamIds = (memberships ?? []).map((m) => m.team_id as number);
+  if (teamIds.length === 0) return [];
+  const { data } = await admin.from("expert_teams").select("*").in("id", teamIds);
+  return (data as ExpertTeam[]) ?? [];
+}
+
+export async function listVerifiedTeams(opts?: {
+  category?: string;
+  acceptsBriefsOnly?: boolean;
+}): Promise<ExpertTeam[]> {
+  const admin = createAdminClient();
+  let q = admin
+    .from("expert_teams")
+    .select("*")
+    .eq("public", true)
+    .eq("verification_status", "verified")
+    .order("created_at", { ascending: false })
+    .limit(50);
+  if (opts?.category) q = q.eq("team_category", opts.category);
+  if (opts?.acceptsBriefsOnly) q = q.eq("accepts_briefs", true);
+  const { data } = await q;
+  return (data as ExpertTeam[]) ?? [];
+}
+
+export async function isProfessionalOnTeam(
+  teamId: number,
+  professionalId: number,
+): Promise<boolean> {
+  const admin = createAdminClient();
+  const { data } = await admin
+    .from("expert_team_members")
+    .select("id, status")
+    .eq("team_id", teamId)
+    .eq("professional_id", professionalId)
+    .maybeSingle();
+  return Boolean(data && data.status === "active");
+}

--- a/lib/getmatched/action-plans.ts
+++ b/lib/getmatched/action-plans.ts
@@ -1,0 +1,197 @@
+/**
+ * Action Plan persistence — anonymous-first, with email-key share tokens
+ * and an account-claim path.
+ *
+ * RLS notes:
+ *   - `share_token` reads use admin client (token-keyed access; RLS would
+ *     deny anon SELECT without the token-side join).
+ *   - Authenticated owner reads go through the table's RLS policy
+ *     (`auth.uid() = auth_user_id`), so the API route can use the regular
+ *     server client.
+ */
+
+// eslint-disable-next-line no-restricted-imports -- anon path: share_token reads + cross-user writes for the claim flow. Service-role legitimate per CLAUDE.md.
+import { createAdminClient } from "@/lib/supabase/admin";
+import { randomBytes } from "crypto";
+import { logger } from "@/lib/logger";
+
+import type {
+  ActionPlan,
+  ActionPlanAnswers,
+  ChecklistItem,
+  IntentSlug,
+  PlanStatus,
+  RouteType,
+} from "./types";
+
+const log = logger("getmatched:action-plans");
+
+export function newShareToken(): string {
+  return randomBytes(24).toString("hex");
+}
+
+export interface CreatePlanInput {
+  sessionId: string;
+  authUserId?: string | null;
+  email?: string | null;
+  initialAnswers?: ActionPlanAnswers;
+}
+
+export async function createPlan(input: CreatePlanInput): Promise<ActionPlan> {
+  const admin = createAdminClient();
+  const { data, error } = await admin
+    .from("get_matched_action_plans")
+    .insert({
+      session_id: input.sessionId,
+      auth_user_id: input.authUserId ?? null,
+      email: input.email ?? null,
+      answers: input.initialAnswers ?? {},
+      share_token: newShareToken(),
+      status: "draft",
+    })
+    .select("*")
+    .single();
+  if (error || !data) {
+    throw new Error(`createPlan failed: ${error?.message ?? "no row"}`);
+  }
+  return data as ActionPlan;
+}
+
+export async function getPlanById(id: number): Promise<ActionPlan | null> {
+  const admin = createAdminClient();
+  const { data } = await admin
+    .from("get_matched_action_plans")
+    .select("*")
+    .eq("id", id)
+    .maybeSingle();
+  return (data as ActionPlan) ?? null;
+}
+
+export async function getPlanByToken(token: string): Promise<ActionPlan | null> {
+  const admin = createAdminClient();
+  const { data } = await admin
+    .from("get_matched_action_plans")
+    .select("*")
+    .eq("share_token", token)
+    .maybeSingle();
+  return (data as ActionPlan) ?? null;
+}
+
+export interface UpdatePlanInput {
+  id: number;
+  answers?: ActionPlanAnswers;
+  intent_slug?: IntentSlug | null;
+  secondary_intent_slug?: IntentSlug | null;
+  route?: RouteType | null;
+  goal?: string | null;
+  checklist?: ChecklistItem[];
+  budget_band?: string | null;
+  timeline?: string | null;
+  location_state?: string | null;
+  country_of_residence?: string | null;
+  help_needed?: string[];
+  risk_flags?: string[];
+  risk_severity?: string | null;
+  linked_brief_id?: number | null;
+  status?: PlanStatus;
+  email?: string | null;
+  auth_user_id?: string | null;
+  meta?: Record<string, unknown>;
+}
+
+export async function updatePlan(input: UpdatePlanInput): Promise<ActionPlan> {
+  const admin = createAdminClient();
+  const { id, ...patch } = input;
+  const updates = Object.fromEntries(
+    Object.entries(patch).filter(([, v]) => v !== undefined),
+  );
+  if (Object.keys(updates).length === 0) {
+    const existing = await getPlanById(id);
+    if (!existing) throw new Error("plan_not_found");
+    return existing;
+  }
+  const { data, error } = await admin
+    .from("get_matched_action_plans")
+    .update({ ...updates, updated_at: new Date().toISOString() })
+    .eq("id", id)
+    .select("*")
+    .single();
+  if (error || !data) {
+    throw new Error(`updatePlan failed: ${error?.message ?? "no row"}`);
+  }
+  return data as ActionPlan;
+}
+
+export interface ClaimPlanInput {
+  planId: number;
+  authUserId: string;
+  email?: string;
+}
+
+export async function claimPlanForUser({
+  planId,
+  authUserId,
+  email,
+}: ClaimPlanInput): Promise<ActionPlan> {
+  const admin = createAdminClient();
+  const { data, error } = await admin
+    .from("get_matched_action_plans")
+    .update({
+      auth_user_id: authUserId,
+      email: email ?? null,
+      status: "saved",
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", planId)
+    .is("auth_user_id", null)
+    .select("*")
+    .maybeSingle();
+  if (error) throw new Error(`claimPlanForUser failed: ${error.message}`);
+  if (!data) {
+    // Race: someone else already claimed it. Return the current state.
+    const current = await getPlanById(planId);
+    if (!current) throw new Error("plan_not_found");
+    return current;
+  }
+  log.info("Plan claimed by user", { planId, authUserId });
+  return data as ActionPlan;
+}
+
+export async function listPlansForUser(authUserId: string): Promise<ActionPlan[]> {
+  const admin = createAdminClient();
+  const { data } = await admin
+    .from("get_matched_action_plans")
+    .select("*")
+    .eq("auth_user_id", authUserId)
+    .order("updated_at", { ascending: false })
+    .limit(50);
+  return (data as ActionPlan[]) ?? [];
+}
+
+export async function linkBriefToPlan(
+  planId: number,
+  briefId: number,
+): Promise<void> {
+  const admin = createAdminClient();
+  await admin
+    .from("get_matched_action_plans")
+    .update({
+      linked_brief_id: briefId,
+      status: "converted",
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", planId);
+  await admin
+    .from("advisor_auctions")
+    .update({ linked_action_plan_id: planId })
+    .eq("id", briefId);
+}
+
+export function toggleChecklistItem(
+  checklist: ChecklistItem[],
+  index: number,
+): ChecklistItem[] {
+  return checklist.map((item, i) =>
+    i === index ? { ...item, done: !item.done } : item,
+  );
+}

--- a/lib/getmatched/embeds.ts
+++ b/lib/getmatched/embeds.ts
@@ -1,0 +1,72 @@
+/**
+ * Contextual embed configuration.
+ *
+ * One engine, different skins. Each context resolves to a headline, an
+ * optional intent pre-fill, and an optional starting step that lets us
+ * skip questions we already know the answer to.
+ */
+
+import type { EmbedConfig, EmbedContext, IntentSlug } from "./types";
+
+const CONFIGS: Record<EmbedContext, Omit<EmbedConfig, "context">> = {
+  homepage: {
+    headline: "What are you trying to do?",
+    subtitle:
+      "Tell us your goal. We'll build your investment action plan and guide you to the right next step.",
+  },
+  smsf_guide: {
+    headline: "Build your SMSF property action plan",
+    subtitle:
+      "Property through SMSF usually involves more than one professional. We'll map out who you actually need.",
+    intent_prefill: "smsf_property",
+    start_step: 3,
+    prefill_answers: { intent: "smsf_property" },
+  },
+  opportunity: {
+    headline: "Need help assessing this opportunity?",
+    subtitle:
+      "Tell us a little about the deal and we'll route you to the right help — finance, tax, legal, or a full due-diligence team.",
+    intent_prefill: "opportunity_assessment",
+    start_step: 3,
+    prefill_answers: { intent: "opportunity_assessment" },
+  },
+  advisor_directory: {
+    headline: "Not sure whether you need an individual, firm or team?",
+    subtitle:
+      "Answer 30 seconds of questions — we'll suggest the right kind of provider for your situation.",
+    intent_prefill: "financial_advice",
+    start_step: 4,
+    prefill_answers: { intent: "financial_advice" },
+  },
+  platform_compare: {
+    headline: "Not sure which platform fits your investing style?",
+    subtitle:
+      "We'll match you to the comparison shortlist that fits your budget, market and priorities.",
+    intent_prefill: "compare_platform",
+    start_step: 5,
+    prefill_answers: { intent: "compare_platform" },
+  },
+};
+
+export function getEmbedConfig(context: EmbedContext): EmbedConfig {
+  return { context, ...CONFIGS[context] };
+}
+
+export function isEmbedContext(value: unknown): value is EmbedContext {
+  return (
+    typeof value === "string" &&
+    Object.keys(CONFIGS).includes(value as EmbedContext)
+  );
+}
+
+export const HOMEPAGE_GOAL_CHIPS: { value: IntentSlug; label: string; icon: string }[] = [
+  { value: "compare_platform", label: "Compare investing platforms", icon: "git-compare" },
+  { value: "start_investing", label: "Start investing", icon: "trending-up" },
+  { value: "buy_property", label: "Buy investment property", icon: "home" },
+  { value: "smsf_property", label: "Invest through my SMSF", icon: "building" },
+  { value: "opportunity_assessment", label: "Assess an opportunity", icon: "search" },
+  { value: "business_acquisition", label: "Buy a business", icon: "briefcase" },
+  { value: "foreign_investor", label: "Invest from overseas", icon: "globe" },
+  { value: "financial_advice", label: "Get expert help", icon: "users" },
+  { value: "listing_owner", label: "Post / list an opportunity", icon: "tag" },
+];

--- a/lib/getmatched/engine.ts
+++ b/lib/getmatched/engine.ts
@@ -1,0 +1,254 @@
+/**
+ * Get Matched engine — turns Q&A answers into an `ActionPlan`.
+ *
+ * Sequence:
+ *   1. Resolve primary intent from `answers.intent` (Q2 mapping).
+ *   2. Pick a starting route from intent default + `help_preference` /
+ *      `route_hint` overrides on the latest answer.
+ *   3. Run the brief-marketplace risk scanner over the concatenated answer
+ *      payload — severity ≥ review forces `risk_review_status='pending_review'`
+ *      on any brief created downstream.
+ *   4. Look up the result template (route × intent override).
+ *   5. Build the action plan with checklist + risk flags + recommended
+ *      brief template.
+ *   6. (Server-only) Resolve up to 3 recommended providers by reusing
+ *      `lib/briefs/routing.ts::resolveEligibleProviders` over a synthetic
+ *      brief.
+ *
+ * The non-IO parts of this module are pure and unit-tested.
+ */
+
+import type { BriefRow } from "@/lib/briefs/types";
+import { scanBrief, type RiskScanResult } from "@/lib/briefs/risk-flags";
+import { resolveEligibleProviders } from "@/lib/briefs/routing";
+import { getAcceptCost } from "@/lib/briefs/credits";
+
+import type {
+  ActionPlanAnswers,
+  ChecklistItem,
+  IntentDef,
+  IntentSlug,
+  ResultTemplate,
+  RouteType,
+} from "./types";
+import { defaultRouteForIntent } from "./intents";
+import { getResultTemplate } from "./templates";
+
+export interface ResolveResult {
+  intent: IntentSlug | null;
+  secondaryIntent: IntentSlug | null;
+  route: RouteType;
+  goal: string | null;
+  template: ResultTemplate;
+  checklist: ChecklistItem[];
+  riskFlags: string[];
+  riskSeverity: RiskScanResult["severity"];
+  recommendedBriefTemplate: string | null;
+  acceptCreditsCost: number | null;
+  helpNeeded: string[];
+  budgetBand: string | null;
+  timeline: string | null;
+  locationState: string | null;
+  countryOfResidence: string | null;
+}
+
+/**
+ * Pure resolver — used by tests + the API route. The IO-bound provider
+ * preview is fetched separately so this stays testable without mocks.
+ */
+export function deriveRoute(
+  answers: ActionPlanAnswers,
+  intents: IntentDef[],
+): { intent: IntentSlug | null; secondary: IntentSlug | null; route: RouteType } {
+  const intent = (answers.intent as IntentSlug | undefined) ?? null;
+  const help = answers.help_preference;
+
+  // `help_preference` is the strongest user signal — they explicitly said
+  // what they want. Override the intent's default route when present.
+  const routeFromHelp = mapHelpPreferenceToRoute(help);
+  if (routeFromHelp) {
+    return { intent, secondary: null, route: routeFromHelp };
+  }
+
+  const route = defaultRouteForIntent(intent, intents);
+  return { intent, secondary: deriveSecondaryIntent(answers, intent), route };
+}
+
+function mapHelpPreferenceToRoute(value: unknown): RouteType | null {
+  if (typeof value !== "string") return null;
+  switch (value) {
+    case "info_only":
+      return "guide";
+    case "compare":
+      return "compare";
+    case "individual":
+      return "individual";
+    case "firm":
+      return "firm";
+    case "expert_team":
+      return "expert_team";
+    case "investor_brief":
+      return "investor_brief";
+    case "not_sure":
+      return null; // fall through to intent default
+    default:
+      return null;
+  }
+}
+
+function deriveSecondaryIntent(
+  answers: ActionPlanAnswers,
+  primary: IntentSlug | null,
+): IntentSlug | null {
+  // Heuristic: when the user picks a complex primary intent + says they
+  // also need lending, the secondary intent is `mortgage_help`. Same for
+  // tax / legal cues. These improve admin funnel reporting; they do not
+  // change routing today.
+  if (!primary) return null;
+  const helpNeeded = Array.isArray(answers.help_needed)
+    ? (answers.help_needed as string[])
+    : [];
+  if (helpNeeded.includes("lending")) return "mortgage_help";
+  if (helpNeeded.includes("tax_accounting")) return "tax_help";
+  if (helpNeeded.includes("legal_review")) return "legal_help";
+  return null;
+}
+
+export function buildChecklist(template: ResultTemplate): ChecklistItem[] {
+  return template.checklist.map((item) => ({ ...item, done: false }));
+}
+
+export function goalLabel(
+  intent: IntentSlug | null,
+  intents: IntentDef[],
+): string | null {
+  if (!intent) return null;
+  const match = intents.find((i) => i.slug === intent);
+  return match?.label ?? null;
+}
+
+export interface ResolveActionPlanOptions {
+  answers: ActionPlanAnswers;
+  intents: IntentDef[];
+}
+
+/**
+ * Full resolver — non-pure: scans risk patterns and computes accept cost.
+ * The DB writes happen in `lib/getmatched/action-plans.ts`.
+ */
+export async function resolveActionPlan({
+  answers,
+  intents,
+}: ResolveActionPlanOptions): Promise<ResolveResult> {
+  const { intent, secondary, route } = deriveRoute(answers, intents);
+  const template = await getResultTemplate(route, intent);
+  const goal = goalLabel(intent, intents);
+  const checklist = buildChecklist(template);
+
+  // Risk scan: stringify the structured answers + free-text fields.
+  const riskText = stringifyAnswers(answers);
+  const risk = await scanBrief(riskText);
+
+  const recommendedBriefTemplate =
+    intents.find((i) => i.slug === intent)?.default_brief_template ?? null;
+  const acceptCreditsCost = recommendedBriefTemplate
+    ? await getAcceptCost({
+        briefTemplate: recommendedBriefTemplate,
+        providerKind:
+          route === "expert_team"
+            ? "expert_team"
+            : route === "firm"
+              ? "firm"
+              : "individual",
+      })
+    : null;
+
+  return {
+    intent,
+    secondaryIntent: secondary,
+    route,
+    goal,
+    template,
+    checklist,
+    riskFlags: risk.flags,
+    riskSeverity: risk.severity,
+    recommendedBriefTemplate,
+    acceptCreditsCost,
+    helpNeeded: Array.isArray(answers.help_needed)
+      ? (answers.help_needed as string[])
+      : [],
+    budgetBand: (answers.budget_band as string | undefined) ?? null,
+    timeline: (answers.timeline as string | undefined) ?? null,
+    locationState: (answers.location_state as string | undefined) ?? null,
+    countryOfResidence:
+      (answers.country_of_residence as string | undefined) ?? null,
+  };
+}
+
+export interface RecommendedProvidersInput {
+  intent: IntentSlug | null;
+  route: RouteType;
+  briefTemplate: string | null;
+  budgetBand: string | null;
+  locationState: string | null;
+}
+
+/**
+ * Build a synthetic brief row and reuse the existing routing engine to pick
+ * up to 3 providers we can preview on the result screen. Returns IDs only;
+ * the caller hydrates profile data.
+ */
+export async function recommendedProviders(
+  input: RecommendedProvidersInput,
+): Promise<{ kind: "individual" | "firm" | "expert_team"; id: number }[]> {
+  const syntheticBrief: BriefRow = {
+    id: -1,
+    slug: "synthetic",
+    flow_type: "accept",
+    brief_template: (input.briefTemplate as BriefRow["brief_template"]) ?? null,
+    brief_payload: {},
+    provider_preference:
+      input.route === "expert_team"
+        ? "expert_team"
+        : input.route === "firm"
+          ? "firm"
+          : input.route === "individual"
+            ? "individual"
+            : "any",
+    routing_mode: "smart_match",
+    target_professional_id: null,
+    target_firm_id: null,
+    target_team_id: null,
+    accept_credits_cost: null,
+    accepted_by_professional_id: null,
+    accepted_by_team_id: null,
+    accepted_at: null,
+    tracker_status: "new",
+    risk_flags: [],
+    risk_review_status: "clear",
+    listing_id: null,
+    job_title: "",
+    job_description: "",
+    budget_band: input.budgetBand ?? "not_sure",
+    advisor_types: null,
+    location: input.locationState,
+    contact_name: null,
+    contact_email: null,
+    contact_phone: null,
+    status: "open",
+    ends_at: new Date(Date.now() + 30 * 86_400_000).toISOString(),
+    created_at: new Date().toISOString(),
+  };
+  const providers = await resolveEligibleProviders(syntheticBrief);
+  return providers.slice(0, 3).map((p) => ({ kind: p.kind, id: p.id }));
+}
+
+function stringifyAnswers(answers: ActionPlanAnswers): string {
+  return Object.values(answers)
+    .map((v) => {
+      if (Array.isArray(v)) return v.join(" ");
+      if (v == null) return "";
+      return String(v);
+    })
+    .join(" ");
+}

--- a/lib/getmatched/events.ts
+++ b/lib/getmatched/events.ts
@@ -1,0 +1,54 @@
+/**
+ * Get Matched funnel analytics — fire-and-forget event ingestion.
+ *
+ * The admin `/admin/funnel` view aggregates these rows. Failures must NEVER
+ * block the user experience.
+ */
+
+// eslint-disable-next-line no-restricted-imports -- anon path: events are inserted from the public flow.
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+
+const log = logger("getmatched:events");
+
+export type GmEventType =
+  | "started"
+  | "question_answered"
+  | "question_abandoned"
+  | "plan_shown"
+  | "cta_clicked"
+  | "plan_saved"
+  | "account_created"
+  | "brief_drafted"
+  | "brief_submitted"
+  | "risk_flagged";
+
+export interface LogEventInput {
+  sessionId: string;
+  authUserId?: string | null;
+  eventType: GmEventType;
+  step?: number | null;
+  payload?: Record<string, unknown>;
+  sourcePage?: string | null;
+  userAgent?: string | null;
+}
+
+export async function logEvent(input: LogEventInput): Promise<void> {
+  try {
+    const admin = createAdminClient();
+    await admin.from("get_matched_events").insert({
+      session_id: input.sessionId,
+      auth_user_id: input.authUserId ?? null,
+      event_type: input.eventType,
+      step: input.step ?? null,
+      payload: input.payload ?? {},
+      source_page: input.sourcePage ?? null,
+      user_agent: input.userAgent ?? null,
+    });
+  } catch (err) {
+    log.warn("logEvent failed (ignored)", {
+      err: err instanceof Error ? err.message : String(err),
+      eventType: input.eventType,
+    });
+  }
+}

--- a/lib/getmatched/intents.ts
+++ b/lib/getmatched/intents.ts
@@ -1,0 +1,55 @@
+/**
+ * Intent taxonomy helpers — thin read layer over `intent_taxonomy`.
+ *
+ * Intents are admin-editable; this module is the only place server-side
+ * code should look them up. Avoid hard-coding intent slugs anywhere except
+ * the type union in `./types.ts`.
+ */
+
+// eslint-disable-next-line no-restricted-imports -- public read of admin config; service-role legitimate per CLAUDE.md.
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+
+import type { IntentDef, IntentSlug, RouteType } from "./types";
+
+const log = logger("getmatched:intents");
+
+export async function getEnabledIntents(): Promise<IntentDef[]> {
+  try {
+    const admin = createAdminClient();
+    const { data } = await admin
+      .from("intent_taxonomy")
+      .select("*")
+      .eq("enabled", true)
+      .order("sort_order", { ascending: true });
+    return (data ?? []) as IntentDef[];
+  } catch (err) {
+    log.warn("getEnabledIntents failed", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return [];
+  }
+}
+
+export async function getIntent(slug: IntentSlug | string): Promise<IntentDef | null> {
+  const admin = createAdminClient();
+  const { data } = await admin
+    .from("intent_taxonomy")
+    .select("*")
+    .eq("slug", slug)
+    .maybeSingle();
+  return (data as IntentDef) ?? null;
+}
+
+/**
+ * Pure helper for tests + the engine: pick the default route for a given
+ * intent slug, falling back to 'guide' when the intent is unknown.
+ */
+export function defaultRouteForIntent(
+  slug: IntentSlug | string | null | undefined,
+  intents: IntentDef[],
+): RouteType {
+  if (!slug) return "guide";
+  const match = intents.find((i) => i.slug === slug);
+  return (match?.default_route as RouteType) ?? "guide";
+}

--- a/lib/getmatched/questions.ts
+++ b/lib/getmatched/questions.ts
@@ -1,0 +1,115 @@
+/**
+ * Adaptive question walker.
+ *
+ * Questions live in `get_matched_questions` with a `shown_if` jsonb predicate.
+ * The walker picks the next question by:
+ *   1. Filtering by mode (fast/guided/both).
+ *   2. Sorting by `(step, sort_order)`.
+ *   3. Skipping questions that have already been answered.
+ *   4. Skipping questions whose `shown_if` does not match the current answer
+ *      set.
+ *
+ * The predicate language is intentionally small: each key in `shown_if`
+ * maps to a value or array of values that the matching `maps_to` field
+ * must equal. Missing keys = "no restriction".
+ *
+ * Example:
+ *   shown_if = {"intent": ["smsf_property"]}
+ *   → only show when `answers.intent === 'smsf_property'`.
+ */
+
+// eslint-disable-next-line no-restricted-imports -- public read of admin config.
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+
+import type { ActionPlanAnswers, QuestionDef, QuestionMode } from "./types";
+
+const log = logger("getmatched:questions");
+
+export async function getQuestions(mode: QuestionMode = "both"): Promise<QuestionDef[]> {
+  try {
+    const admin = createAdminClient();
+    let q = admin
+      .from("get_matched_questions")
+      .select("*")
+      .eq("enabled", true);
+    if (mode !== "both") q = q.in("mode", [mode, "both"]);
+    const { data } = await q
+      .order("step", { ascending: true })
+      .order("sort_order", { ascending: true });
+    return (data ?? []) as QuestionDef[];
+  } catch (err) {
+    log.warn("getQuestions failed", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return [];
+  }
+}
+
+export interface NextQuestionResult {
+  done: false;
+  question: QuestionDef;
+  totalSteps: number;
+  currentStep: number;
+}
+
+export interface NextQuestionDone {
+  done: true;
+  totalSteps: number;
+  currentStep: number;
+}
+
+/**
+ * Pure: given the loaded question set + current answers, return the next
+ * question to show OR `done: true` if all eligible questions are answered.
+ */
+export function nextQuestion(
+  questions: QuestionDef[],
+  answers: ActionPlanAnswers,
+  mode: QuestionMode = "both",
+): NextQuestionResult | NextQuestionDone {
+  const filtered = questions
+    .filter((q) => q.enabled)
+    .filter((q) => mode === "both" || q.mode === mode || q.mode === "both")
+    .sort((a, b) => a.step - b.step || a.sort_order - b.sort_order);
+
+  const eligible = filtered.filter((q) => shownIfMatches(q, answers));
+
+  for (const q of eligible) {
+    const answeredBySlug = answers[q.slug];
+    const answeredByMappedKey = answers[q.maps_to];
+    const isAnswered =
+      (answeredBySlug !== undefined && answeredBySlug !== null) ||
+      (answeredByMappedKey !== undefined && answeredByMappedKey !== null);
+    if (!isAnswered) {
+      const currentStep = eligible.findIndex((x) => x.slug === q.slug) + 1;
+      return {
+        done: false,
+        question: q,
+        totalSteps: eligible.length,
+        currentStep,
+      };
+    }
+  }
+
+  return { done: true, totalSteps: eligible.length, currentStep: eligible.length };
+}
+
+export function shownIfMatches(
+  question: QuestionDef,
+  answers: ActionPlanAnswers,
+): boolean {
+  const conditions = question.shown_if ?? {};
+  for (const [key, value] of Object.entries(conditions)) {
+    if (value === undefined) continue;
+    const required = Array.isArray(value) ? value : [value];
+    const actual = answers[key];
+    if (actual === undefined || actual === null) return false;
+    if (Array.isArray(actual)) {
+      if (!actual.some((a) => required.includes(String(a)))) return false;
+    } else if (!required.includes(String(actual))) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/lib/getmatched/templates.ts
+++ b/lib/getmatched/templates.ts
@@ -1,0 +1,76 @@
+/**
+ * Result template resolver.
+ *
+ * `get_matched_result_templates` is keyed by (route, intent_slug?). Lookup
+ * precedence:
+ *   1. Exact (route, intent_slug) match — admin override for a specific
+ *      intent (e.g. SMSF property → bespoke checklist + CTA).
+ *   2. (route, NULL) — the default template for that route.
+ *   3. Hard-coded fallback — minimal "general" content if neither row exists
+ *      (defensive — admin can never delete the seed rows).
+ */
+
+// eslint-disable-next-line no-restricted-imports -- public read of admin config.
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+
+import type { IntentSlug, ResultTemplate, RouteType } from "./types";
+
+const log = logger("getmatched:templates");
+
+export async function getResultTemplate(
+  route: RouteType,
+  intentSlug?: IntentSlug | null,
+): Promise<ResultTemplate> {
+  try {
+    const admin = createAdminClient();
+    let exact: ResultTemplate | null = null;
+    if (intentSlug) {
+      const { data } = await admin
+        .from("get_matched_result_templates")
+        .select("*")
+        .eq("route", route)
+        .eq("intent_slug", intentSlug)
+        .eq("enabled", true)
+        .maybeSingle();
+      if (data) exact = data as ResultTemplate;
+    }
+    if (exact) return exact;
+
+    const { data: generic } = await admin
+      .from("get_matched_result_templates")
+      .select("*")
+      .eq("route", route)
+      .is("intent_slug", null)
+      .eq("enabled", true)
+      .maybeSingle();
+    if (generic) return generic as ResultTemplate;
+  } catch (err) {
+    log.warn("getResultTemplate failed", {
+      route,
+      intentSlug,
+      err: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  return fallbackTemplate(route);
+}
+
+function fallbackTemplate(route: RouteType): ResultTemplate {
+  return {
+    id: -1,
+    route,
+    intent_slug: null,
+    headline: "Your Investment Action Plan",
+    why_text:
+      "Here is the route that matches your answers. Invest.com.au provides general information only — the professional, firm or team you engage delivers the service under their own licence.",
+    checklist: [
+      { label: "Review your answers" },
+      { label: "Pick your next step" },
+    ],
+    primary_cta: { label: "Browse next steps", href: "/" },
+    secondary_ctas: [],
+    cross_sells: [],
+    enabled: true,
+  };
+}

--- a/lib/getmatched/types.ts
+++ b/lib/getmatched/types.ts
@@ -1,0 +1,167 @@
+/**
+ * Get Matched 2.0 domain types.
+ *
+ * The router operates on top of the brief-marketplace primitives shipped in
+ * PR #821. Every action plan ultimately resolves to one of eight `RouteType`s
+ * — six of them deep-link to existing surfaces (`/compare`, `/invest`,
+ * `/advisors`, `/briefs/new`, `/teams/<slug>`) and two are guide-only.
+ */
+
+export type IntentSlug =
+  | "compare_platform"
+  | "start_investing"
+  | "smsf_property"
+  | "buy_property"
+  | "opportunity_assessment"
+  | "business_acquisition"
+  | "commercial_property"
+  | "foreign_investor"
+  | "expat_investing"
+  | "financial_advice"
+  | "tax_help"
+  | "mortgage_help"
+  | "legal_help"
+  | "second_opinion"
+  | "listing_owner"
+  | "listing_readiness"
+  | "not_sure";
+
+export type RouteType =
+  | "compare"
+  | "browse"
+  | "individual"
+  | "firm"
+  | "expert_team"
+  | "investor_brief"
+  | "listing_brief"
+  | "second_opinion"
+  | "guide";
+
+export type QuestionKind =
+  | "select"
+  | "multiselect"
+  | "text"
+  | "number"
+  | "contextual";
+
+export type QuestionMode = "fast" | "guided" | "both";
+
+export interface QuestionOption {
+  value: string;
+  label: string;
+  intent_hint?: IntentSlug;
+  route_hint?: RouteType;
+  weight?: number;
+}
+
+export interface QuestionDef {
+  id: number;
+  slug: string;
+  step: number;
+  kind: QuestionKind;
+  prompt: string;
+  subtitle: string | null;
+  options: QuestionOption[];
+  shown_if: Record<string, string[] | string | undefined>;
+  maps_to: string;
+  risk_weight: number;
+  mode: QuestionMode;
+  enabled: boolean;
+  sort_order: number;
+}
+
+export interface IntentDef {
+  id: number;
+  slug: IntentSlug;
+  label: string;
+  description: string | null;
+  default_route: RouteType;
+  default_brief_template: string | null;
+  risk_level: "low" | "medium" | "high";
+  enabled: boolean;
+  sort_order: number;
+  meta: Record<string, unknown>;
+}
+
+export interface ChecklistItem {
+  label: string;
+  href?: string;
+  brief_template?: string;
+  done?: boolean;
+}
+
+export interface CrossSell {
+  label: string;
+  href: string;
+  icon?: string;
+}
+
+export interface ResultTemplate {
+  id: number;
+  route: RouteType;
+  intent_slug: IntentSlug | null;
+  headline: string;
+  why_text: string;
+  checklist: ChecklistItem[];
+  primary_cta: { label: string; href: string };
+  secondary_ctas: { label: string; href: string }[];
+  cross_sells: CrossSell[];
+  enabled: boolean;
+}
+
+export type PlanStatus = "draft" | "saved" | "converted" | "expired";
+
+export interface ActionPlanAnswers {
+  [questionSlug: string]: string | string[] | number | boolean | null;
+}
+
+export interface ActionPlan {
+  id: number;
+  session_id: string;
+  auth_user_id: string | null;
+  email: string | null;
+  intent_slug: IntentSlug | null;
+  secondary_intent_slug: IntentSlug | null;
+  route: RouteType | null;
+  goal: string | null;
+  answers: ActionPlanAnswers;
+  checklist: ChecklistItem[];
+  budget_band: string | null;
+  timeline: string | null;
+  location_state: string | null;
+  country_of_residence: string | null;
+  help_needed: string[];
+  risk_flags: string[];
+  risk_severity: string | null;
+  linked_brief_id: number | null;
+  share_token: string;
+  status: PlanStatus;
+  meta: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ResolvedPlan extends ActionPlan {
+  template: ResultTemplate;
+  /** Up to 3 providers selected by the resolver — not enriched with full profile. */
+  recommended_provider_ids: { kind: "individual" | "firm" | "expert_team"; id: number }[];
+  recommended_brief_template: string | null;
+  accept_credits_cost: number | null;
+}
+
+export type EmbedContext =
+  | "homepage"
+  | "smsf_guide"
+  | "opportunity"
+  | "advisor_directory"
+  | "platform_compare";
+
+export interface EmbedConfig {
+  context: EmbedContext;
+  headline: string;
+  subtitle: string;
+  intent_prefill?: IntentSlug;
+  start_step?: number;
+  /** Optional pre-filled answers that feed into `ActionPlanAnswers`. */
+  prefill_answers?: ActionPlanAnswers;
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -340,6 +340,15 @@ const nextConfig: NextConfig = {
         destination: "/global-investing/etfs/global",
         permanent: true,
       },
+      // ── PMP-01: /quotes/post relocated to /briefs/new ──
+      // The bid-auction Post-a-Request flow is replaced by the structured
+      // Investor Brief flow at /briefs/new. Legacy /quotes/* job pages
+      // remain live for previously-posted auction-style requests.
+      {
+        source: "/quotes/post",
+        destination: "/briefs/new",
+        permanent: true,
+      },
       // ── W-14: /grants hub relocated to /startup/grants ──
       // Canonical URL moves so the grants hub sits inside the /startup
       // content cluster. Subroutes (/grants/eligibility-quiz, /grants/rd-tax-

--- a/supabase/migrations/20260723_pmp01_provider_marketplace_foundation.sql
+++ b/supabase/migrations/20260723_pmp01_provider_marketplace_foundation.sql
@@ -1,0 +1,445 @@
+-- ============================================================================
+-- Migration: 20260723_pmp01_provider_marketplace_foundation.sql
+-- Purpose: Build the Provider Marketplace foundation that the future Get
+--          Matched quiz will route into. Introduces Expert Teams (cross-firm
+--          collaboration teams + members + invitations), extends
+--          advisor_auctions into a brief record with flow_type='accept' as
+--          an alternative to the existing bid-auction flow, and adds
+--          admin-managed tables for credit pricing, routing rules,
+--          risk-flag patterns, plus a brief tracker event log.
+--
+-- Why: existing /quotes/post + /api/quotes is bid-auction only. Plan calls
+-- for credit-accept-and-unlock briefs that can route to Individuals, Firms
+-- or Expert Teams with provider-preference + routing-mode + structured
+-- vertical payloads. Legacy auctions stay supported by flow_type='auction'.
+--
+-- Idempotency: ALTER TABLE … ADD COLUMN IF NOT EXISTS / CREATE TABLE IF NOT
+-- EXISTS / CREATE INDEX IF NOT EXISTS / ON CONFLICT DO NOTHING. Safe to
+-- re-apply.
+--
+-- Rollback (destructive, reverse order):
+--   DROP TABLE IF EXISTS public.brief_tracker_events;
+--   DROP TABLE IF EXISTS public.brief_risk_patterns;
+--   DROP TABLE IF EXISTS public.brief_routing_rules;
+--   DROP TABLE IF EXISTS public.brief_credit_prices;
+--   ALTER TABLE public.advisor_auctions
+--     DROP COLUMN IF EXISTS flow_type,
+--     DROP COLUMN IF EXISTS brief_template,
+--     DROP COLUMN IF EXISTS brief_payload,
+--     DROP COLUMN IF EXISTS provider_preference,
+--     DROP COLUMN IF EXISTS routing_mode,
+--     DROP COLUMN IF EXISTS target_professional_id,
+--     DROP COLUMN IF EXISTS target_firm_id,
+--     DROP COLUMN IF EXISTS target_team_id,
+--     DROP COLUMN IF EXISTS accept_credits_cost,
+--     DROP COLUMN IF EXISTS accepted_by_professional_id,
+--     DROP COLUMN IF EXISTS accepted_by_team_id,
+--     DROP COLUMN IF EXISTS accepted_at,
+--     DROP COLUMN IF EXISTS tracker_status,
+--     DROP COLUMN IF EXISTS risk_flags,
+--     DROP COLUMN IF EXISTS risk_review_status,
+--     DROP COLUMN IF EXISTS listing_id;
+--   DROP TABLE IF EXISTS public.expert_team_invitations;
+--   DROP TABLE IF EXISTS public.expert_team_members;
+--   DROP TABLE IF EXISTS public.expert_teams;
+--
+-- Risk: medium — additive only on advisor_auctions (no row-data loss on
+-- reverse), but seeded admin tables hold pricing/routing/risk-pattern
+-- config; destructive rollback discards admin tuning.
+-- ============================================================================
+
+BEGIN;
+
+-- ── 1. expert_teams ────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.expert_teams (
+  id                       serial PRIMARY KEY,
+  slug                     text   UNIQUE NOT NULL,
+  name                     text   NOT NULL,
+  team_category            text   NOT NULL,
+  team_type                text   NOT NULL DEFAULT 'independent'
+    CHECK (team_type IN ('same_firm', 'independent', 'private_referral', 'internal_firm')),
+  description              text,
+  niche                    text,
+  location_state           text,
+  service_areas            text[] DEFAULT '{}'::text[],
+  owner_professional_id    integer NOT NULL REFERENCES public.professionals(id),
+  lead_professional_id     integer REFERENCES public.professionals(id),
+  firm_id                  integer REFERENCES public.advisor_firms(id),
+  disclosure               text,
+  accepted_brief_templates text[] DEFAULT '{}'::text[],
+  accepts_briefs           boolean NOT NULL DEFAULT false,
+  verification_status      text NOT NULL DEFAULT 'draft'
+    CHECK (verification_status IN ('draft', 'submitted', 'verified', 'rejected', 'suspended')),
+  verified_at              timestamptz,
+  public                   boolean NOT NULL DEFAULT false,
+  rejection_reason         text,
+  created_at               timestamptz NOT NULL DEFAULT now(),
+  updated_at               timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_expert_teams_public
+  ON public.expert_teams (public, verification_status)
+  WHERE public = true;
+CREATE INDEX IF NOT EXISTS idx_expert_teams_owner
+  ON public.expert_teams (owner_professional_id);
+CREATE INDEX IF NOT EXISTS idx_expert_teams_category
+  ON public.expert_teams (team_category);
+CREATE INDEX IF NOT EXISTS idx_expert_teams_verification
+  ON public.expert_teams (verification_status, created_at DESC);
+
+ALTER TABLE public.expert_teams ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Public can read verified teams" ON public.expert_teams;
+CREATE POLICY "Public can read verified teams"
+  ON public.expert_teams FOR SELECT
+  USING (public = true AND verification_status = 'verified');
+
+DROP POLICY IF EXISTS "Service role full access expert_teams" ON public.expert_teams;
+CREATE POLICY "Service role full access expert_teams"
+  ON public.expert_teams FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- ── 2. expert_team_members ────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.expert_team_members (
+  id                    serial PRIMARY KEY,
+  team_id               integer NOT NULL REFERENCES public.expert_teams(id) ON DELETE CASCADE,
+  professional_id       integer NOT NULL REFERENCES public.professionals(id),
+  member_role           text NOT NULL DEFAULT 'member',
+  public_title          text,
+  can_receive_briefs    boolean NOT NULL DEFAULT true,
+  can_appear_publicly   boolean NOT NULL DEFAULT true,
+  status                text NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'active', 'removed')),
+  accepted_at           timestamptz,
+  start_date            date,
+  end_date              date,
+  created_at            timestamptz NOT NULL DEFAULT now(),
+  updated_at            timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (team_id, professional_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_expert_team_members_team
+  ON public.expert_team_members (team_id);
+CREATE INDEX IF NOT EXISTS idx_expert_team_members_professional
+  ON public.expert_team_members (professional_id);
+CREATE INDEX IF NOT EXISTS idx_expert_team_members_active
+  ON public.expert_team_members (team_id, status)
+  WHERE status = 'active';
+
+ALTER TABLE public.expert_team_members ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Public can read public members of verified teams" ON public.expert_team_members;
+CREATE POLICY "Public can read public members of verified teams"
+  ON public.expert_team_members FOR SELECT
+  USING (
+    can_appear_publicly = true
+    AND status = 'active'
+    AND team_id IN (
+      SELECT id FROM public.expert_teams
+      WHERE public = true AND verification_status = 'verified'
+    )
+  );
+
+DROP POLICY IF EXISTS "Service role full access expert_team_members" ON public.expert_team_members;
+CREATE POLICY "Service role full access expert_team_members"
+  ON public.expert_team_members FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- ── 3. expert_team_invitations ────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.expert_team_invitations (
+  id                       serial PRIMARY KEY,
+  team_id                  integer NOT NULL REFERENCES public.expert_teams(id) ON DELETE CASCADE,
+  email                    text NOT NULL,
+  name                     text,
+  invited_professional_id  integer REFERENCES public.professionals(id),
+  invited_role             text DEFAULT 'member',
+  invited_by               integer NOT NULL REFERENCES public.professionals(id),
+  token                    text NOT NULL UNIQUE,
+  status                   text NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'accepted', 'expired', 'revoked')),
+  accepted_at              timestamptz,
+  expires_at               timestamptz NOT NULL DEFAULT (now() + INTERVAL '7 days'),
+  created_at               timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_team_invitations_token
+  ON public.expert_team_invitations (token);
+CREATE INDEX IF NOT EXISTS idx_team_invitations_team
+  ON public.expert_team_invitations (team_id);
+CREATE INDEX IF NOT EXISTS idx_team_invitations_email
+  ON public.expert_team_invitations (email);
+
+ALTER TABLE public.expert_team_invitations ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Service role full access team_invitations" ON public.expert_team_invitations;
+CREATE POLICY "Service role full access team_invitations"
+  ON public.expert_team_invitations FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- ── 4. advisor_auctions: extend into brief record ─────────────────────────
+ALTER TABLE public.advisor_auctions
+  ADD COLUMN IF NOT EXISTS flow_type text NOT NULL DEFAULT 'auction',
+  ADD COLUMN IF NOT EXISTS brief_template text,
+  ADD COLUMN IF NOT EXISTS brief_payload jsonb NOT NULL DEFAULT '{}'::jsonb,
+  ADD COLUMN IF NOT EXISTS provider_preference text,
+  ADD COLUMN IF NOT EXISTS routing_mode text,
+  ADD COLUMN IF NOT EXISTS target_professional_id integer REFERENCES public.professionals(id),
+  ADD COLUMN IF NOT EXISTS target_firm_id integer REFERENCES public.advisor_firms(id),
+  ADD COLUMN IF NOT EXISTS target_team_id integer REFERENCES public.expert_teams(id),
+  ADD COLUMN IF NOT EXISTS accept_credits_cost integer,
+  ADD COLUMN IF NOT EXISTS accepted_by_professional_id integer REFERENCES public.professionals(id),
+  ADD COLUMN IF NOT EXISTS accepted_by_team_id integer REFERENCES public.expert_teams(id),
+  ADD COLUMN IF NOT EXISTS accepted_at timestamptz,
+  ADD COLUMN IF NOT EXISTS tracker_status text NOT NULL DEFAULT 'new',
+  ADD COLUMN IF NOT EXISTS risk_flags text[] NOT NULL DEFAULT '{}'::text[],
+  ADD COLUMN IF NOT EXISTS risk_review_status text NOT NULL DEFAULT 'clear',
+  ADD COLUMN IF NOT EXISTS listing_id integer REFERENCES public.investment_listings(id);
+
+-- CHECK constraints added separately so we can drop+recreate idempotently
+-- without ADD COLUMN failing on a re-run.
+ALTER TABLE public.advisor_auctions
+  DROP CONSTRAINT IF EXISTS advisor_auctions_flow_type_check;
+ALTER TABLE public.advisor_auctions
+  ADD CONSTRAINT advisor_auctions_flow_type_check
+  CHECK (flow_type IN ('auction', 'accept'));
+
+ALTER TABLE public.advisor_auctions
+  DROP CONSTRAINT IF EXISTS advisor_auctions_provider_preference_check;
+ALTER TABLE public.advisor_auctions
+  ADD CONSTRAINT advisor_auctions_provider_preference_check
+  CHECK (provider_preference IS NULL OR provider_preference IN
+    ('any', 'individual', 'firm', 'expert_team', 'multiple'));
+
+ALTER TABLE public.advisor_auctions
+  DROP CONSTRAINT IF EXISTS advisor_auctions_routing_mode_check;
+ALTER TABLE public.advisor_auctions
+  ADD CONSTRAINT advisor_auctions_routing_mode_check
+  CHECK (routing_mode IS NULL OR routing_mode IN
+    ('smart_match', 'direct', 'multi_response'));
+
+ALTER TABLE public.advisor_auctions
+  DROP CONSTRAINT IF EXISTS advisor_auctions_tracker_status_check;
+ALTER TABLE public.advisor_auctions
+  ADD CONSTRAINT advisor_auctions_tracker_status_check
+  CHECK (tracker_status IN
+    ('new', 'contacted', 'call_booked', 'proposal_sent', 'won', 'lost', 'withdrawn'));
+
+ALTER TABLE public.advisor_auctions
+  DROP CONSTRAINT IF EXISTS advisor_auctions_risk_review_check;
+ALTER TABLE public.advisor_auctions
+  ADD CONSTRAINT advisor_auctions_risk_review_check
+  CHECK (risk_review_status IN ('clear', 'pending_review', 'approved', 'rejected'));
+
+-- Inbox-style queries on the new accept flow.
+CREATE INDEX IF NOT EXISTS idx_advisor_auctions_flow_status
+  ON public.advisor_auctions (flow_type, status, tracker_status)
+  WHERE flow_type = 'accept';
+
+CREATE INDEX IF NOT EXISTS idx_advisor_auctions_accepted_by_pro
+  ON public.advisor_auctions (accepted_by_professional_id)
+  WHERE accepted_by_professional_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_advisor_auctions_accepted_by_team
+  ON public.advisor_auctions (accepted_by_team_id)
+  WHERE accepted_by_team_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_advisor_auctions_target_team
+  ON public.advisor_auctions (target_team_id)
+  WHERE target_team_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_advisor_auctions_risk_review
+  ON public.advisor_auctions (risk_review_status, created_at DESC)
+  WHERE risk_review_status <> 'clear';
+
+-- ── 5. brief_credit_prices ────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.brief_credit_prices (
+  id              serial PRIMARY KEY,
+  brief_template  text NOT NULL,
+  provider_type   text NOT NULL DEFAULT 'any'
+    CHECK (provider_type IN ('any', 'individual', 'firm', 'expert_team')),
+  credits_cost    integer NOT NULL CHECK (credits_cost >= 0),
+  notes           text,
+  updated_at      timestamptz NOT NULL DEFAULT now(),
+  updated_by      text,
+  UNIQUE (brief_template, provider_type)
+);
+
+ALTER TABLE public.brief_credit_prices ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Service role full access credit_prices" ON public.brief_credit_prices;
+CREATE POLICY "Service role full access credit_prices"
+  ON public.brief_credit_prices FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- Seed starting prices. Idempotent via UNIQUE (brief_template, provider_type).
+INSERT INTO public.brief_credit_prices (brief_template, provider_type, credits_cost, notes, updated_by) VALUES
+  ('general',                'any',          2, 'General expert enquiry',            'migration'),
+  ('mortgage',               'any',          5, 'Mortgage broker brief',             'migration'),
+  ('tax',                    'any',          8, 'Tax / accounting brief',            'migration'),
+  ('smsf_accountant',        'any',         10, 'SMSF accountant brief',             'migration'),
+  ('financial_adviser',      'any',         15, 'Financial adviser brief',           'migration'),
+  ('smsf_property',          'expert_team', 25, 'SMSF Property Team brief',          'migration'),
+  ('smsf_property',          'any',         15, 'SMSF Property fallback',            'migration'),
+  ('foreign_investor',       'any',         30, 'Foreign Investor brief',            'migration'),
+  ('expat',                  'any',         20, 'Expat investor brief',              'migration'),
+  ('opportunity_assessment', 'any',         15, 'Opportunity assessment brief',      'migration'),
+  ('opportunity_assessment', 'expert_team', 25, 'Opportunity with full team',        'migration'),
+  ('commercial_property',    'any',         40, 'Commercial Property brief',         'migration'),
+  ('business_acquisition',   'any',         50, 'Business Acquisition brief',        'migration'),
+  ('listing',                'any',         15, 'Listing brief (seller-side)',       'migration'),
+  ('listing_readiness',      'any',         30, 'Listing readiness check',           'migration'),
+  ('second_opinion',         'any',          5, 'Second opinion brief',              'migration')
+ON CONFLICT (brief_template, provider_type) DO NOTHING;
+
+-- ── 6. brief_routing_rules ────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.brief_routing_rules (
+  id                serial PRIMARY KEY,
+  name              text NOT NULL,
+  priority          integer NOT NULL DEFAULT 100,
+  enabled           boolean NOT NULL DEFAULT true,
+  match_conditions  jsonb NOT NULL DEFAULT '{}'::jsonb,
+  route_to          jsonb NOT NULL DEFAULT '{}'::jsonb,
+  notes             text,
+  created_at        timestamptz NOT NULL DEFAULT now(),
+  updated_at        timestamptz NOT NULL DEFAULT now(),
+  updated_by        text
+);
+
+CREATE INDEX IF NOT EXISTS idx_brief_routing_rules_priority
+  ON public.brief_routing_rules (priority)
+  WHERE enabled = true;
+
+ALTER TABLE public.brief_routing_rules ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Service role full access routing_rules" ON public.brief_routing_rules;
+CREATE POLICY "Service role full access routing_rules"
+  ON public.brief_routing_rules FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- Seed routing rules. Inserts are intentionally tolerant of repeat runs by
+-- de-duplicating on `name` (unique-ish by convention rather than by index —
+-- a runtime duplicate is acceptable, admin can prune).
+INSERT INTO public.brief_routing_rules (name, priority, match_conditions, route_to, notes, updated_by)
+SELECT * FROM (VALUES
+  (
+    'SMSF Property -> Expert Team first',
+    10,
+    '{"brief_template":"smsf_property"}'::jsonb,
+    '{"prefer":"expert_team","fallback":["individual","firm"]}'::jsonb,
+    'SMSF property routes to verified Expert Teams when available.',
+    'migration'
+  ),
+  (
+    'Mortgage -> Individuals + Firms',
+    20,
+    '{"brief_template":"mortgage"}'::jsonb,
+    '{"prefer":"any","types":["mortgage_broker"]}'::jsonb,
+    'Mortgage briefs go to individuals/firms with mortgage permissions.',
+    'migration'
+  ),
+  (
+    'Opportunity Assessment full team -> Due Diligence Team',
+    30,
+    '{"brief_template":"opportunity_assessment","help_needed":"full_specialist_team"}'::jsonb,
+    '{"prefer":"expert_team","team_category":"due_diligence"}'::jsonb,
+    'When the user ticks full-specialist-team, route to Due Diligence teams.',
+    'migration'
+  ),
+  (
+    'Foreign Investor -> Specialists',
+    40,
+    '{"brief_template":"foreign_investor"}'::jsonb,
+    '{"prefer":"expert_team","fallback":["individual","firm"],"team_category":"foreign_investor"}'::jsonb,
+    'Foreign investor briefs prefer Foreign Investor expert teams.',
+    'migration'
+  ),
+  (
+    'Default fallback',
+    1000,
+    '{}'::jsonb,
+    '{"prefer":"any"}'::jsonb,
+    'Catch-all when no higher-priority rule matches.',
+    'migration'
+  )
+) AS seed(name, priority, match_conditions, route_to, notes, updated_by)
+WHERE NOT EXISTS (
+  SELECT 1 FROM public.brief_routing_rules r WHERE r.name = seed.name
+);
+
+-- ── 7. brief_risk_patterns ────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.brief_risk_patterns (
+  id          serial PRIMARY KEY,
+  pattern     text NOT NULL,
+  category    text NOT NULL,
+  severity    text NOT NULL DEFAULT 'warn'
+    CHECK (severity IN ('warn', 'review', 'block')),
+  enabled     boolean NOT NULL DEFAULT true,
+  notes       text,
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (pattern, category)
+);
+
+CREATE INDEX IF NOT EXISTS idx_risk_patterns_enabled
+  ON public.brief_risk_patterns (severity)
+  WHERE enabled = true;
+
+ALTER TABLE public.brief_risk_patterns ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Service role full access risk_patterns" ON public.brief_risk_patterns;
+CREATE POLICY "Service role full access risk_patterns"
+  ON public.brief_risk_patterns FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+INSERT INTO public.brief_risk_patterns (pattern, category, severity, notes) VALUES
+  ('withdraw super',           'super_withdrawal',     'review', 'Possible illegal super early-release scheme.'),
+  ('early access to super',    'super_withdrawal',     'review', 'Likely illegal early-release pitch.'),
+  ('super switching',          'super_switching',      'warn',   'Heightened compliance risk; ensure SOA path.'),
+  ('guaranteed return',        'guaranteed_returns',   'review', 'Guaranteed-return language is a red flag.'),
+  ('guaranteed returns',       'guaranteed_returns',   'review', 'Guaranteed-return language is a red flag.'),
+  ('crypto leverage',          'crypto_leverage',      'review', 'Leveraged crypto exposure requires extra disclosure.'),
+  ('retirement advice',        'retirement_advice',    'warn',   'Personal advice scope check.'),
+  ('tax avoidance',            'tax_avoidance',        'block',  'Block — illegal tax avoidance schemes.'),
+  ('foreign ownership',        'foreign_ownership',    'warn',   'FIRB / foreign ownership compliance check.'),
+  ('managed investment scheme','managed_invest_scheme','warn',   'AFSL scope for MIS interests.'),
+  ('wholesale only',           'wholesale_only',       'warn',   'Wholesale-investor qualification check.'),
+  ('private credit',           'private_credit',       'warn',   'Private credit suitability check.'),
+  ('high yield',               'high_yield',           'warn',   'High-yield wording often signals risk-mismatch.'),
+  ('urgent advice',            'urgent_advice',        'warn',   'High pressure / urgency language.')
+ON CONFLICT (pattern, category) DO NOTHING;
+
+-- ── 8. brief_tracker_events ───────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.brief_tracker_events (
+  id           bigserial PRIMARY KEY,
+  brief_id     integer NOT NULL REFERENCES public.advisor_auctions(id) ON DELETE CASCADE,
+  event_type   text NOT NULL,
+  payload      jsonb NOT NULL DEFAULT '{}'::jsonb,
+  actor_kind   text,
+  actor_id     text,
+  created_at   timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_brief_tracker_events_brief
+  ON public.brief_tracker_events (brief_id, created_at);
+
+ALTER TABLE public.brief_tracker_events ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Service role full access tracker_events" ON public.brief_tracker_events;
+CREATE POLICY "Service role full access tracker_events"
+  ON public.brief_tracker_events FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+COMMIT;

--- a/supabase/migrations/20260724_gm01_get_matched_router.sql
+++ b/supabase/migrations/20260724_gm01_get_matched_router.sql
@@ -1,0 +1,657 @@
+-- ============================================================================
+-- Migration: 20260724_gm01_get_matched_router.sql
+-- Purpose: Get Matched 2.0 — turn the broker-quiz into the whole-site decision
+--          router that outputs an Investment Action Plan. Adds the intent
+--          taxonomy, adaptive question registry, route-result templates, the
+--          saveable Action Plan record, and the funnel analytics log. Also
+--          adds `linked_action_plan_id` to advisor_auctions so the Brief
+--          Tracker can show "from your action plan" provenance.
+--
+-- Idempotent: ALTER TABLE … ADD COLUMN IF NOT EXISTS / CREATE TABLE IF NOT
+-- EXISTS / CREATE INDEX IF NOT EXISTS / ON CONFLICT DO NOTHING. Safe to
+-- re-apply.
+--
+-- Rollback (destructive, reverse order):
+--   DROP TABLE IF EXISTS public.get_matched_events;
+--   DROP TABLE IF EXISTS public.get_matched_action_plans CASCADE;
+--   DROP TABLE IF EXISTS public.get_matched_result_templates;
+--   DROP TABLE IF EXISTS public.get_matched_questions;
+--   DROP TABLE IF EXISTS public.intent_taxonomy;
+--   ALTER TABLE public.advisor_auctions DROP COLUMN IF EXISTS linked_action_plan_id;
+--
+-- Risk: medium — additive only on advisor_auctions; new tables are seeded
+-- (intents/questions/result_templates) and discarding admin tuning on
+-- rollback. Plans + events tables hold user data.
+-- ============================================================================
+
+BEGIN;
+
+-- ── 1. intent_taxonomy ────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.intent_taxonomy (
+  id              serial PRIMARY KEY,
+  slug            text UNIQUE NOT NULL,
+  label           text NOT NULL,
+  description     text,
+  default_route   text NOT NULL DEFAULT 'guide'
+    CHECK (default_route IN (
+      'compare','browse','individual','firm','expert_team',
+      'investor_brief','listing_brief','second_opinion','guide'
+    )),
+  default_brief_template text,
+  risk_level      text NOT NULL DEFAULT 'low'
+    CHECK (risk_level IN ('low','medium','high')),
+  enabled         boolean NOT NULL DEFAULT true,
+  sort_order      int NOT NULL DEFAULT 100,
+  meta            jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  updated_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_intent_taxonomy_enabled
+  ON public.intent_taxonomy (enabled, sort_order);
+
+ALTER TABLE public.intent_taxonomy ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Public can read enabled intents" ON public.intent_taxonomy;
+CREATE POLICY "Public can read enabled intents"
+  ON public.intent_taxonomy FOR SELECT
+  USING (enabled = true);
+
+DROP POLICY IF EXISTS "Service role full access intents" ON public.intent_taxonomy;
+CREATE POLICY "Service role full access intents"
+  ON public.intent_taxonomy FOR ALL
+  TO service_role
+  USING (true) WITH CHECK (true);
+
+INSERT INTO public.intent_taxonomy (slug, label, description, default_route, default_brief_template, risk_level, sort_order) VALUES
+  ('compare_platform',      'Compare investing platforms',  'Compare brokers, super funds, robo-advisors or property platforms.',  'compare',         NULL,                       'low',    10),
+  ('start_investing',       'Start investing',              'New to investing — figure out the right first step.',                 'compare',         NULL,                       'low',    20),
+  ('smsf_property',         'Invest through SMSF',          'Property or shares inside a self-managed super fund.',                'expert_team',     'smsf_property',            'medium', 30),
+  ('buy_property',          'Buy investment property',      'Residential investment property.',                                    'individual',      'mortgage',                 'low',    40),
+  ('opportunity_assessment','Assess an opportunity',        'Get help reviewing a specific deal or listing.',                      'expert_team',     'opportunity_assessment',   'medium', 50),
+  ('business_acquisition',  'Buy a business',               'Acquire an Australian business.',                                     'expert_team',     'business_acquisition',     'medium', 60),
+  ('commercial_property',   'Commercial property',          'Buy, lease or invest in commercial property.',                        'expert_team',     'commercial_property',      'medium', 70),
+  ('foreign_investor',      'Invest from overseas',         'Non-resident or overseas investor into Australia.',                   'expert_team',     'foreign_investor',         'high',   80),
+  ('expat_investing',       'Australian expat investing',   'Australian living overseas investing back home.',                     'individual',      'expat',                    'medium', 90),
+  ('financial_advice',      'Get financial advice',         'Licensed financial planning advice.',                                 'individual',      'financial_adviser',        'high',  100),
+  ('tax_help',              'Get tax / accounting help',    'Tax planning or returns.',                                            'individual',      'tax',                      'medium',110),
+  ('mortgage_help',         'Get lending / mortgage help',  'Home, investment or commercial finance.',                             'individual',      'mortgage',                 'low',   120),
+  ('legal_help',            'Get legal / conveyancing help','Property settlement, contracts, structuring.',                        'individual',      'general',                  'medium',130),
+  ('second_opinion',        'Get a second opinion',         'Have advice or a deal independently reviewed.',                       'second_opinion',  'second_opinion',           'medium',140),
+  ('listing_owner',         'Post / list an opportunity',   'Seller of a business, property or other deal.',                       'listing_brief',   'listing',                  'low',   150),
+  ('listing_readiness',     'Prepare a listing',            'Get your opportunity ready to list.',                                 'listing_brief',   'listing_readiness',        'low',   160),
+  ('not_sure',              'Not sure yet',                 'Browse and figure it out as you go.',                                 'guide',           NULL,                       'low',   999)
+ON CONFLICT (slug) DO NOTHING;
+
+-- ── 2. get_matched_questions ──────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.get_matched_questions (
+  id              serial PRIMARY KEY,
+  slug            text UNIQUE NOT NULL,
+  step            int NOT NULL,
+  kind            text NOT NULL
+    CHECK (kind IN ('select','multiselect','text','number','contextual')),
+  prompt          text NOT NULL,
+  subtitle        text,
+  options         jsonb NOT NULL DEFAULT '[]'::jsonb,
+  shown_if        jsonb NOT NULL DEFAULT '{}'::jsonb,
+  maps_to         text NOT NULL,
+  risk_weight     int NOT NULL DEFAULT 0,
+  mode            text NOT NULL DEFAULT 'both'
+    CHECK (mode IN ('fast','guided','both')),
+  enabled         boolean NOT NULL DEFAULT true,
+  sort_order      int NOT NULL DEFAULT 100,
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  updated_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_get_matched_questions_enabled
+  ON public.get_matched_questions (enabled, step, sort_order);
+
+ALTER TABLE public.get_matched_questions ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Public can read enabled questions" ON public.get_matched_questions;
+CREATE POLICY "Public can read enabled questions"
+  ON public.get_matched_questions FOR SELECT
+  USING (enabled = true);
+
+DROP POLICY IF EXISTS "Service role full access questions" ON public.get_matched_questions;
+CREATE POLICY "Service role full access questions"
+  ON public.get_matched_questions FOR ALL
+  TO service_role
+  USING (true) WITH CHECK (true);
+
+-- Seed: 7 base questions + 4 branching questions. Options stored as jsonb
+-- arrays of {value,label,intent_hint?,route_hint?}.
+INSERT INTO public.get_matched_questions (slug, step, kind, prompt, subtitle, options, shown_if, maps_to, mode, sort_order) VALUES
+  (
+    'starting_point', 1, 'select',
+    'Where are you starting from?',
+    'We adapt the rest of the plan to your situation.',
+    '[
+      {"value":"australia","label":"Australia"},
+      {"value":"overseas","label":"Overseas"},
+      {"value":"expat","label":"Australian expat"},
+      {"value":"business","label":"Business / company"},
+      {"value":"professional","label":"Adviser / broker / professional"},
+      {"value":"listing_owner","label":"Listing owner / seller"}
+    ]'::jsonb,
+    '{}'::jsonb,
+    'starting_point', 'both', 10
+  ),
+  (
+    'goal', 2, 'select',
+    'What are you trying to do?',
+    'This is the most important step. Pick the closest match.',
+    '[
+      {"value":"compare_platform","label":"Compare investing platforms","intent_hint":"compare_platform","route_hint":"compare"},
+      {"value":"start_investing","label":"Start investing","intent_hint":"start_investing","route_hint":"compare"},
+      {"value":"buy_property","label":"Buy investment property","intent_hint":"buy_property","route_hint":"individual"},
+      {"value":"smsf_property","label":"Invest through my SMSF","intent_hint":"smsf_property","route_hint":"expert_team"},
+      {"value":"opportunity_assessment","label":"Assess an opportunity","intent_hint":"opportunity_assessment","route_hint":"expert_team"},
+      {"value":"business_acquisition","label":"Buy a business","intent_hint":"business_acquisition","route_hint":"expert_team"},
+      {"value":"commercial_property","label":"Commercial property","intent_hint":"commercial_property","route_hint":"expert_team"},
+      {"value":"foreign_investor","label":"Invest from overseas","intent_hint":"foreign_investor","route_hint":"expert_team"},
+      {"value":"financial_advice","label":"Get expert help","intent_hint":"financial_advice","route_hint":"individual"},
+      {"value":"listing_owner","label":"Post / list an opportunity","intent_hint":"listing_owner","route_hint":"listing_brief"},
+      {"value":"not_sure","label":"Not sure yet","intent_hint":"not_sure","route_hint":"guide"}
+    ]'::jsonb,
+    '{}'::jsonb,
+    'intent', 'both', 20
+  ),
+  (
+    'smsf_situation', 3, 'select',
+    'What best describes your SMSF situation?',
+    NULL,
+    '[
+      {"value":"no_smsf","label":"Thinking about setting up an SMSF"},
+      {"value":"considering_smsf","label":"Already considering one"},
+      {"value":"smsf_established","label":"I already have an SMSF"},
+      {"value":"smsf_property","label":"I want to buy property through SMSF"},
+      {"value":"not_sure","label":"Not sure"}
+    ]'::jsonb,
+    '{"intent":["smsf_property"]}'::jsonb,
+    'smsf_status', 'guided', 30
+  ),
+  (
+    'opportunity_situation', 3, 'select',
+    'What best describes the opportunity?',
+    NULL,
+    '[
+      {"value":"on_invest","label":"I found it on Invest.com.au"},
+      {"value":"elsewhere","label":"I found it elsewhere"},
+      {"value":"browsing","label":"I want to browse opportunities"},
+      {"value":"assessing","label":"I need help assessing a deal"},
+      {"value":"listing_it","label":"I want to list / sell one","route_hint":"listing_brief"}
+    ]'::jsonb,
+    '{"intent":["opportunity_assessment"]}'::jsonb,
+    'opportunity_context', 'guided', 30
+  ),
+  (
+    'foreign_situation', 3, 'select',
+    'What kind of investment from overseas?',
+    NULL,
+    '[
+      {"value":"property","label":"Australian property"},
+      {"value":"business","label":"Australian businesses"},
+      {"value":"tax_legal","label":"Need tax / legal help first"},
+      {"value":"finance","label":"Need finance / mortgage help"},
+      {"value":"not_sure","label":"Not sure where to start"}
+    ]'::jsonb,
+    '{"intent":["foreign_investor"]}'::jsonb,
+    'foreign_focus', 'guided', 30
+  ),
+  (
+    'help_preference', 4, 'select',
+    'How much help do you want?',
+    'You can change this later.',
+    '[
+      {"value":"info_only","label":"Just show me information","route_hint":"guide"},
+      {"value":"compare","label":"Show me platforms to compare","route_hint":"compare"},
+      {"value":"individual","label":"Show me individual experts","route_hint":"individual"},
+      {"value":"firm","label":"Show me firms / brokerages","route_hint":"firm"},
+      {"value":"expert_team","label":"Show me expert teams","route_hint":"expert_team"},
+      {"value":"investor_brief","label":"Create a brief for professionals","route_hint":"investor_brief"},
+      {"value":"not_sure","label":"Not sure — guide me"}
+    ]'::jsonb,
+    '{}'::jsonb,
+    'help_preference', 'both', 40
+  ),
+  (
+    'budget', 5, 'select',
+    'Budget or scale?',
+    'Bands only — keeps things private.',
+    '[
+      {"value":"under_10k","label":"Under A$10k"},
+      {"value":"10k_100k","label":"A$10k – A$100k"},
+      {"value":"100k_500k","label":"A$100k – A$500k"},
+      {"value":"500k_1m","label":"A$500k – A$1m"},
+      {"value":"1m_plus","label":"A$1m+"},
+      {"value":"prefer_not","label":"Prefer not to say"}
+    ]'::jsonb,
+    '{}'::jsonb,
+    'budget_band', 'both', 50
+  ),
+  (
+    'timeline', 6, 'select',
+    'Timeline?',
+    NULL,
+    '[
+      {"value":"now","label":"Now"},
+      {"value":"1_3_months","label":"1–3 months"},
+      {"value":"3_6_months","label":"3–6 months"},
+      {"value":"6_12_months","label":"6–12 months"},
+      {"value":"researching","label":"Just researching"}
+    ]'::jsonb,
+    '{}'::jsonb,
+    'timeline', 'both', 60
+  ),
+  (
+    'continue', 7, 'select',
+    'How should we continue?',
+    'Pick one — you can always come back.',
+    '[
+      {"value":"show_plan","label":"Show my action plan","route_hint":"guide"},
+      {"value":"create_brief","label":"Create an Investor Brief","route_hint":"investor_brief"},
+      {"value":"browse","label":"Browse recommended options"},
+      {"value":"email_me","label":"Email me my result"},
+      {"value":"create_account","label":"Create a free account to save"}
+    ]'::jsonb,
+    '{}'::jsonb,
+    'continue_choice', 'guided', 70
+  )
+ON CONFLICT (slug) DO NOTHING;
+
+-- ── 3. get_matched_result_templates ───────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.get_matched_result_templates (
+  id              serial PRIMARY KEY,
+  route           text NOT NULL
+    CHECK (route IN (
+      'compare','browse','individual','firm','expert_team',
+      'investor_brief','listing_brief','second_opinion','guide'
+    )),
+  intent_slug     text,
+  headline        text NOT NULL,
+  why_text        text NOT NULL,
+  checklist       jsonb NOT NULL DEFAULT '[]'::jsonb,
+  primary_cta     jsonb NOT NULL DEFAULT '{}'::jsonb,
+  secondary_ctas  jsonb NOT NULL DEFAULT '[]'::jsonb,
+  cross_sells     jsonb NOT NULL DEFAULT '[]'::jsonb,
+  enabled         boolean NOT NULL DEFAULT true,
+  updated_at      timestamptz NOT NULL DEFAULT now(),
+  updated_by      text,
+  UNIQUE (route, intent_slug)
+);
+
+CREATE INDEX IF NOT EXISTS idx_result_templates_route
+  ON public.get_matched_result_templates (route, enabled);
+
+ALTER TABLE public.get_matched_result_templates ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Public can read enabled result templates" ON public.get_matched_result_templates;
+CREATE POLICY "Public can read enabled result templates"
+  ON public.get_matched_result_templates FOR SELECT
+  USING (enabled = true);
+
+DROP POLICY IF EXISTS "Service role full access result templates" ON public.get_matched_result_templates;
+CREATE POLICY "Service role full access result templates"
+  ON public.get_matched_result_templates FOR ALL
+  TO service_role
+  USING (true) WITH CHECK (true);
+
+-- Seed: default template per route + rich overrides for the four big intents.
+-- Cross-sells capped at 3.
+INSERT INTO public.get_matched_result_templates
+  (route, intent_slug, headline, why_text, checklist, primary_cta, secondary_ctas, cross_sells)
+SELECT * FROM (VALUES
+  (
+    'compare', NULL,
+    'Compare Platforms',
+    'Based on your answers, the right next step is to compare platforms side-by-side. You can stay completely independent — Invest.com.au provides general information only.',
+    '[
+      {"label":"See the comparison shortlist"},
+      {"label":"Run the fee calculator"},
+      {"label":"Check what each broker actually charges"},
+      {"label":"Save your shortlist"}
+    ]'::jsonb,
+    '{"label":"Compare platforms","href":"/compare"}'::jsonb,
+    '[
+      {"label":"Fee calculator","href":"/calculators/fee-impact"},
+      {"label":"Get expert help if unsure","href":"/get-matched?goal=financial_advice"}
+    ]'::jsonb,
+    '[
+      {"label":"How brokerage actually adds up","href":"/article/how-brokerage-adds-up","icon":"calculator"},
+      {"label":"CHESS vs custodial","href":"/article/chess-vs-custodial","icon":"shield-check"}
+    ]'::jsonb
+  ),
+  (
+    'compare', 'compare_platform',
+    'Compare Investing Platforms',
+    'You told us you want to compare. Here are the verified comparison tables that match your budget and asset preferences.',
+    '[
+      {"label":"Open the comparison shortlist","href":"/compare"},
+      {"label":"Run the platform fee calculator","href":"/calculators/fee-impact"},
+      {"label":"Check CHESS sponsorship","href":"/chess-lookup"},
+      {"label":"Read this year''s broker review"}
+    ]'::jsonb,
+    '{"label":"Compare platforms","href":"/compare"}'::jsonb,
+    '[
+      {"label":"Find the cheapest US-shares broker","href":"/global-investing/shares/us"},
+      {"label":"Switch broker safely","href":"/switch"}
+    ]'::jsonb,
+    '[
+      {"label":"Best ETF brokers right now","href":"/best/cheapest-us-shares","icon":"trending-up"},
+      {"label":"Save your shortlist","href":"/shortlist","icon":"bookmark"}
+    ]'::jsonb
+  ),
+  (
+    'browse', NULL,
+    'Browse Opportunities',
+    'Open opportunities matching your shape. You stay anonymous unless you choose to enquire.',
+    '[
+      {"label":"View matching opportunities","href":"/invest"},
+      {"label":"Save your opportunity alerts"},
+      {"label":"Create an Opportunity Brief"}
+    ]'::jsonb,
+    '{"label":"View opportunities","href":"/invest"}'::jsonb,
+    '[
+      {"label":"Get help assessing","href":"/get-matched?goal=opportunity_assessment"}
+    ]'::jsonb,
+    '[
+      {"label":"How to read a private deal","href":"/articles","icon":"file-text"}
+    ]'::jsonb
+  ),
+  (
+    'individual', NULL,
+    'Verified Individual Expert',
+    'A single verified professional is likely the cleanest fit. You stay in control — they only see your details after you decide to share them.',
+    '[
+      {"label":"Browse verified individuals","href":"/advisors?provider_type=individual"},
+      {"label":"Compare two profiles side-by-side"},
+      {"label":"Create a brief for one professional"}
+    ]'::jsonb,
+    '{"label":"Browse individuals","href":"/advisors?provider_type=individual"}'::jsonb,
+    '[
+      {"label":"Or consider a firm","href":"/advisors?provider_type=firm"},
+      {"label":"Create an Investor Brief","href":"/briefs/new"}
+    ]'::jsonb,
+    '[
+      {"label":"Questions to ask any adviser","href":"/articles","icon":"message-circle"}
+    ]'::jsonb
+  ),
+  (
+    'firm', NULL,
+    'Firm or Brokerage',
+    'You prefer the structure of a firm. Browse verified firms — each one has at least one verified representative.',
+    '[
+      {"label":"Browse verified firms","href":"/advisors?provider_type=firm"},
+      {"label":"Compare firm representatives"},
+      {"label":"Create an Investor Brief"}
+    ]'::jsonb,
+    '{"label":"Browse firms","href":"/advisors?provider_type=firm"}'::jsonb,
+    '[
+      {"label":"View firm reviews","href":"/advisors"},
+      {"label":"Create an Investor Brief","href":"/briefs/new"}
+    ]'::jsonb,
+    '[
+      {"label":"Firm vs individual: how to pick","href":"/articles","icon":"users"}
+    ]'::jsonb
+  ),
+  (
+    'expert_team', NULL,
+    'Verified Expert Team',
+    'Your situation usually involves more than one professional. A verified expert team coordinates the work so you don''t.',
+    '[
+      {"label":"Browse verified expert teams","href":"/advisors#expert-teams"},
+      {"label":"See who is on each team"},
+      {"label":"Create an Investor Brief for a team"}
+    ]'::jsonb,
+    '{"label":"Browse expert teams","href":"/advisors#expert-teams"}'::jsonb,
+    '[
+      {"label":"Create an Investor Brief","href":"/briefs/new"},
+      {"label":"Who do I need on my team?","href":"/articles"}
+    ]'::jsonb,
+    '[
+      {"label":"How verified teams work","href":"/articles","icon":"users"}
+    ]'::jsonb
+  ),
+  (
+    'expert_team', 'smsf_property',
+    'Verified SMSF Property Expert Team',
+    'This usually involves more than one professional: SMSF structure, financial advice, lending and property selection. A verified team coordinates the work so you don''t.',
+    '[
+      {"label":"Read the SMSF property guide","href":"/smsf"},
+      {"label":"Compare SMSF-compatible platforms / brokers","href":"/compare"},
+      {"label":"Speak with an SMSF accountant"},
+      {"label":"Speak with a licensed financial adviser"},
+      {"label":"Check SMSF borrowing options"},
+      {"label":"Create your SMSF Property Brief"}
+    ]'::jsonb,
+    '{"label":"Create SMSF Property Brief","href":"/briefs/new?template=smsf_property&provider_preference=expert_team&routing_mode=smart_match"}'::jsonb,
+    '[
+      {"label":"Browse SMSF Expert Teams","href":"/advisors#expert-teams"},
+      {"label":"Compare SMSF brokers","href":"/compare"},
+      {"label":"Find SMSF accountants","href":"/advisors?type=smsf_accountant"}
+    ]'::jsonb,
+    '[
+      {"label":"SMSF property checklist","href":"/smsf-calculator","icon":"calculator"},
+      {"label":"How SMSF lending actually works","href":"/articles","icon":"landmark"}
+    ]'::jsonb
+  ),
+  (
+    'expert_team', 'foreign_investor',
+    'Verified Foreign Investor Expert Team',
+    'Investing in Australia from overseas usually needs tax, FIRB / legal, mortgage and a buyer''s agent. A verified team coordinates the work so you don''t.',
+    '[
+      {"label":"Read the foreign investor guide","href":"/foreign-investment"},
+      {"label":"Run the FIRB fee estimator","href":"/firb-fee-estimator"},
+      {"label":"Check your tax residency"},
+      {"label":"Get mortgage options for non-residents"},
+      {"label":"Create your Foreign Investor Brief"}
+    ]'::jsonb,
+    '{"label":"Create Foreign Investor Brief","href":"/briefs/new?template=foreign_investor&provider_preference=expert_team&routing_mode=smart_match"}'::jsonb,
+    '[
+      {"label":"Browse Foreign Investor teams","href":"/advisors#expert-teams"},
+      {"label":"Compare AU-friendly brokers","href":"/compare"}
+    ]'::jsonb,
+    '[
+      {"label":"FIRB application 101","href":"/foreign-investment","icon":"globe"},
+      {"label":"Non-resident CGT checker","href":"/non-resident-cgt-checker","icon":"calculator"}
+    ]'::jsonb
+  ),
+  (
+    'expert_team', 'opportunity_assessment',
+    'Verified Opportunity Due-Diligence Team',
+    'Assessing a deal is usually a team sport — finance, tax, legal, due diligence. A verified team coordinates the work so you don''t miss anything.',
+    '[
+      {"label":"List the opportunity you''re reviewing"},
+      {"label":"Identify the finance options","href":"/calculators/mortgage-calculator"},
+      {"label":"Get tax / accounting input"},
+      {"label":"Get legal review"},
+      {"label":"Create your Opportunity Brief"}
+    ]'::jsonb,
+    '{"label":"Create Opportunity Brief","href":"/briefs/new?template=opportunity_assessment&provider_preference=expert_team&routing_mode=smart_match"}'::jsonb,
+    '[
+      {"label":"Browse Due-Diligence teams","href":"/advisors#expert-teams"},
+      {"label":"Get finance only","href":"/get-matched?goal=mortgage_help"}
+    ]'::jsonb,
+    '[
+      {"label":"Private deal red flags","href":"/articles","icon":"shield"}
+    ]'::jsonb
+  ),
+  (
+    'investor_brief', NULL,
+    'Create an Investor Brief',
+    'You''re ready to be contacted by a verified provider. We''ll route your masked brief to the right professionals.',
+    '[
+      {"label":"Confirm the goal of your brief"},
+      {"label":"Pick smart-match, direct or multi-response"},
+      {"label":"Add contact and consent"}
+    ]'::jsonb,
+    '{"label":"Create brief","href":"/briefs/new"}'::jsonb,
+    '[
+      {"label":"Browse providers first","href":"/advisors"}
+    ]'::jsonb,
+    '[
+      {"label":"How accept works","href":"/articles","icon":"info"}
+    ]'::jsonb
+  ),
+  (
+    'listing_brief', NULL,
+    'Prepare Your Listing',
+    'You''re on the seller side. Prepare a Listing Brief so verified professionals can help you get listing-ready and reach buyers.',
+    '[
+      {"label":"Listing readiness check"},
+      {"label":"Get valuation help"},
+      {"label":"Prepare your due-diligence pack"},
+      {"label":"Create your Listing Brief"}
+    ]'::jsonb,
+    '{"label":"Create Listing Brief","href":"/briefs/new?template=listing_readiness"}'::jsonb,
+    '[
+      {"label":"Post your opportunity","href":"/invest"},
+      {"label":"Speak to listing experts","href":"/advisors"}
+    ]'::jsonb,
+    '[
+      {"label":"Listing checklist","href":"/articles","icon":"file-text"}
+    ]'::jsonb
+  ),
+  (
+    'second_opinion', NULL,
+    'Second Opinion Brief',
+    'You want an independent review of advice or a deal. Verified professionals can review it under their own licence and terms.',
+    '[
+      {"label":"Describe what needs reviewing"},
+      {"label":"Pick the right review type"},
+      {"label":"Create your Second Opinion Brief"}
+    ]'::jsonb,
+    '{"label":"Create Second Opinion Brief","href":"/briefs/new?template=second_opinion"}'::jsonb,
+    '[
+      {"label":"Find a licensed adviser","href":"/advisors?type=financial_planner"},
+      {"label":"Find a tax / accounting reviewer","href":"/advisors?type=tax_agent"}
+    ]'::jsonb,
+    '[
+      {"label":"When to get a second opinion","href":"/articles","icon":"shield"}
+    ]'::jsonb
+  ),
+  (
+    'guide', NULL,
+    'Start with information',
+    'You''re early — here is the curated reading and tooling for where you are.',
+    '[
+      {"label":"Read the most relevant guide"},
+      {"label":"Run a calculator"},
+      {"label":"Come back when you''re ready"}
+    ]'::jsonb,
+    '{"label":"Browse guides","href":"/articles"}'::jsonb,
+    '[
+      {"label":"Start the action plan over","href":"/get-matched"}
+    ]'::jsonb,
+    '[
+      {"label":"Most popular guides","href":"/articles","icon":"file-text"}
+    ]'::jsonb
+  )
+) AS seed(route, intent_slug, headline, why_text, checklist, primary_cta, secondary_ctas, cross_sells)
+WHERE NOT EXISTS (
+  SELECT 1 FROM public.get_matched_result_templates r
+  WHERE r.route = seed.route
+    AND (r.intent_slug IS NOT DISTINCT FROM seed.intent_slug)
+);
+
+-- ── 4. get_matched_action_plans ──────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.get_matched_action_plans (
+  id                    serial PRIMARY KEY,
+  session_id            text NOT NULL,
+  auth_user_id          uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  email                 text,
+  intent_slug           text REFERENCES public.intent_taxonomy(slug),
+  secondary_intent_slug text REFERENCES public.intent_taxonomy(slug),
+  route                 text
+    CHECK (route IS NULL OR route IN (
+      'compare','browse','individual','firm','expert_team',
+      'investor_brief','listing_brief','second_opinion','guide'
+    )),
+  goal                  text,
+  answers               jsonb NOT NULL DEFAULT '{}'::jsonb,
+  checklist             jsonb NOT NULL DEFAULT '[]'::jsonb,
+  budget_band           text,
+  timeline              text,
+  location_state        text,
+  country_of_residence  text,
+  help_needed           text[] NOT NULL DEFAULT '{}'::text[],
+  risk_flags            text[] NOT NULL DEFAULT '{}'::text[],
+  risk_severity         text,
+  linked_brief_id       int REFERENCES public.advisor_auctions(id) ON DELETE SET NULL,
+  share_token           text UNIQUE NOT NULL,
+  status                text NOT NULL DEFAULT 'draft'
+    CHECK (status IN ('draft','saved','converted','expired')),
+  meta                  jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at            timestamptz NOT NULL DEFAULT now(),
+  updated_at            timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_action_plans_session
+  ON public.get_matched_action_plans (session_id);
+CREATE INDEX IF NOT EXISTS idx_action_plans_auth_user
+  ON public.get_matched_action_plans (auth_user_id)
+  WHERE auth_user_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_action_plans_token
+  ON public.get_matched_action_plans (share_token);
+CREATE INDEX IF NOT EXISTS idx_action_plans_intent_route
+  ON public.get_matched_action_plans (intent_slug, route);
+
+ALTER TABLE public.get_matched_action_plans ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Owner reads own action plan" ON public.get_matched_action_plans;
+CREATE POLICY "Owner reads own action plan"
+  ON public.get_matched_action_plans FOR SELECT
+  TO authenticated
+  USING (auth.uid() = auth_user_id);
+
+DROP POLICY IF EXISTS "Owner updates own action plan" ON public.get_matched_action_plans;
+CREATE POLICY "Owner updates own action plan"
+  ON public.get_matched_action_plans FOR UPDATE
+  TO authenticated
+  USING (auth.uid() = auth_user_id)
+  WITH CHECK (auth.uid() = auth_user_id);
+
+DROP POLICY IF EXISTS "Service role full access action plans" ON public.get_matched_action_plans;
+CREATE POLICY "Service role full access action plans"
+  ON public.get_matched_action_plans FOR ALL
+  TO service_role
+  USING (true) WITH CHECK (true);
+
+-- ── 5. get_matched_events ─────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.get_matched_events (
+  id              bigserial PRIMARY KEY,
+  session_id      text,
+  auth_user_id    uuid,
+  event_type      text NOT NULL,
+  step            int,
+  payload         jsonb NOT NULL DEFAULT '{}'::jsonb,
+  source_page     text,
+  user_agent      text,
+  created_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_gm_events_type_created
+  ON public.get_matched_events (event_type, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_gm_events_session
+  ON public.get_matched_events (session_id, created_at);
+
+ALTER TABLE public.get_matched_events ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Service role full access gm events" ON public.get_matched_events;
+CREATE POLICY "Service role full access gm events"
+  ON public.get_matched_events FOR ALL
+  TO service_role
+  USING (true) WITH CHECK (true);
+
+-- ── 6. advisor_auctions extension: link back to action plan ──────────────
+ALTER TABLE public.advisor_auctions
+  ADD COLUMN IF NOT EXISTS linked_action_plan_id int
+    REFERENCES public.get_matched_action_plans(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_advisor_auctions_linked_plan
+  ON public.advisor_auctions (linked_action_plan_id)
+  WHERE linked_action_plan_id IS NOT NULL;
+
+COMMIT;


### PR DESCRIPTION
## Summary

Lays the spine for the routing-marketplace architecture described in the build brief. Users create **Investor Briefs** that route to verified **Individuals**, **Firms/Brokerages** or **Expert Teams**, providers see masked previews, accept with credits to unlock contact details, and the user follows along in a lightweight **Brief Tracker**. The Get Matched quiz redesign is explicitly out of scope — this PR builds the substrate so the future quiz routes into it.

Approach: extend rather than replace. `advisor_auctions` becomes the brief record (`flow_type='accept'` is the new path; `flow_type='auction'` keeps the legacy bid flow alive). Existing `/quotes/*`, affiliate paths, Compare, Opportunities and Experts are untouched.

### Schema (migration `20260723_pmp01_provider_marketplace_foundation.sql`)
- `expert_teams` + `expert_team_members` + `expert_team_invitations` — cross-firm collaboration teams with verification gating.
- `advisor_auctions` extended with `flow_type` / `brief_template` / `brief_payload` / `provider_preference` / `routing_mode` / `accept_credits_cost` / `accepted_by_*` / `tracker_status` / `risk_flags` / `risk_review_status` / `listing_id`.
- `brief_credit_prices`, `brief_routing_rules`, `brief_risk_patterns`, `brief_tracker_events` (admin-managed, all seeded).
- RLS + service-role policies on every new table, public-read only on verified+public expert teams.

### Libraries
- `lib/briefs/templates.ts` — registry with Zod payload schemas for `general`, `smsf_property`, `foreign_investor`, `opportunity_assessment`; notes-only stubs for the rest.
- `lib/briefs/risk-flags.ts` — pattern scanner with `warn/review/block` precedence; review+ holds for admin approval.
- `lib/briefs/routing.ts` — admin-rule-driven `resolveEligibleProviders(brief)` with direct-target short-circuit.
- `lib/briefs/credits.ts` — `acceptBrief` claims the row atomically, debits via existing `recordLedgerEntry` (`kind='lead_spend'`, idempotent on brief id), rolls back the claim if the ledger write fails.
- `lib/briefs/mask.ts` — strips PII for the provider preview surface.
- `lib/expert-teams.ts` — create/invite/accept/submit-for-verification, mirroring the existing firm invite shape.

### Surfaces
- `/briefs/new` — template selector → vertical-specific fields → provider preference + routing mode → masked-consent contact step.
- `/briefs/[slug]` — Brief Tracker with status timeline and accepted-provider card.
- `/teams/[slug]` — public Expert Team profile.
- `/advisor-portal/teams` — create + invite members + submit-for-verification.
- `/advisor-portal/briefs` — masked inbox + accept + status updates.
- `/advisors` — Provider-type tab strip + verified Expert Teams cards.
- Admin: `/admin/briefs`, `/admin/expert-teams`, `/admin/credit-pricing`, `/admin/routing-rules`, `/admin/risk-flags` exception-based queues + new "Brief Marketplace" sidebar group.

### Compatibility
- `/quotes/post` 308-redirects to `/briefs/new` (`next.config.ts`).
- `/quotes`, `/quotes/[slug]`, `/api/quotes`, `/api/cron/quote-expiry-reminders`, `/api/cron/quote-review-requests` all filter to `flow_type='auction'` so legacy bid auctions keep working.
- Affiliate, Compare, Opportunities, calculators, articles: zero edits.

### Compliance
- General-information language throughout; explicit "verified providers may respond" / "you stay in control" / "the professional or firm you engage delivers the service under their own licence" copy.
- Brief form ends with explicit shared-with-providers consent.
- Risk-flagged briefs (severity ≥ `review`) are held in `risk_review_status='pending_review'` and NOT routed until admin clears them.

## Out of scope (explicitly deferred)
- Full Case Room (vault, internal advice, chat, multi-party workflow, revenue splitting).
- Get Matched quiz redesign — quiz can call `POST /api/briefs` later.
- Vertical-specific brief-template UIs beyond the four shipped — others use a notes textarea.
- `/listings/new` reverse-flow UI (schema + brief templates exist, page is a follow-up).

## Test plan
- [ ] `npm run type-check` clean
- [ ] `npm test` — full suite passes (8,287 tests + 17 new `__tests__/lib/briefs/*`)
- [ ] `npm run audit:rate-limits` 100%
- [ ] Apply migration to a staging DB; verify seeded rows in `brief_credit_prices`, `brief_routing_rules`, `brief_risk_patterns`
- [ ] Create a brief at `/briefs/new` (template=`smsf_property`, preference=`expert_team`, mode=`smart_match`); confirm `advisor_auctions` row + `brief_tracker_events` entry
- [ ] As a verified professional on a seeded Expert Team: visit `/advisor-portal/briefs`, see masked preview, accept (credits debit), unlock contact details, update tracker status
- [ ] As the consumer: view `/briefs/<slug>?email=…`, see status timeline and accepted provider card
- [ ] Create + verify an Expert Team end-to-end via `/advisor-portal/teams` → `/admin/expert-teams`
- [ ] Submit a brief containing a `review`-severity phrase ("guaranteed returns") — confirm it appears in `/admin/briefs` risk queue and is NOT routed until approved
- [ ] Verify `/quotes/<existing-legacy-slug>` still renders the bid list

https://claude.ai/code/session_015JmqgxgJAaVt9RrUQ8uvNf

---
_Generated by [Claude Code](https://claude.ai/code/session_015JmqgxgJAaVt9RrUQ8uvNf)_