### PR TITLE
feat(profile): #6 — verified testimonials + outcome score badge on provider profiles

### DIFF
--- a/app/advisor/[slug]/page.tsx
+++ b/app/advisor/[slug]/page.tsx
@@ -8,6 +8,12 @@ import { absoluteUrl, breadcrumbJsonLd } from "@/lib/seo";
 import { PROFESSIONAL_TYPE_LABELS } from "@/lib/types";
 import ComplianceFooter from "@/components/ComplianceFooter";
 import ClaimListingButton from "@/components/claims/ClaimListingButton";
+import OutcomeBadge from "@/components/outcomes/OutcomeBadge";
+import TestimonialList from "@/components/outcomes/TestimonialList";
+import {
+  getProviderOutcomeBadge,
+  getPublicTestimonials,
+} from "@/lib/outcomes/profile-display";
 
 export const revalidate = 1800;
 
@@ -146,6 +152,13 @@ export default async function AdvisorProfilePage({ params }: { params: Promise<{
   if (pro.linkedin_url) sameAs.push(pro.linkedin_url);
   if (pro.twitter_url) sameAs.push(pro.twitter_url);
 
+  // Outcome flywheel display data — fetched in parallel to keep the
+  // page render fast. Both helpers fail-soft on DB errors.
+  const [outcomeBadge, testimonials] = await Promise.all([
+    getProviderOutcomeBadge({ professionalId: pro.id }),
+    getPublicTestimonials({ professionalId: pro.id, limit: 5 }),
+  ]);
+
   const personLd: Record<string, unknown> = {
     "@context": "https://schema.org",
     "@type": "Person",
@@ -206,6 +219,19 @@ export default async function AdvisorProfilePage({ params }: { params: Promise<{
         }) }} />
       )}
       <AdvisorProfileClient professional={pro as Professional} similar={similar} reviews={reviews} teamMembers={teamMembers} firm={firm} expertArticles={expertArticles} />
+      {/* Outcome-flywheel badge + verified testimonials — fetched in
+          parallel above. Renders below the main profile so it
+          augments without disrupting the existing layout. */}
+      {(outcomeBadge || testimonials.length > 0) && (
+        <div className="container-custom max-w-4xl mt-6 space-y-4">
+          {outcomeBadge && (
+            <div className="flex items-center gap-2 px-1">
+              <OutcomeBadge badge={outcomeBadge} />
+            </div>
+          )}
+          <TestimonialList testimonials={testimonials} />
+        </div>
+      )}
       <ClaimListingButton
         claimType="advisor"
         targetSlug={pro.slug}

--- a/app/teams/[slug]/page.tsx
+++ b/app/teams/[slug]/page.tsx
@@ -7,6 +7,12 @@ import { absoluteUrl, breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo
 import { BRIEF_TEMPLATE_LABELS } from "@/lib/briefs/templates";
 import { estimateBundledPrice } from "@/lib/expert-teams/pricing";
 import Icon from "@/components/Icon";
+import OutcomeBadge from "@/components/outcomes/OutcomeBadge";
+import TestimonialList from "@/components/outcomes/TestimonialList";
+import {
+  getProviderOutcomeBadge,
+  getPublicTestimonials,
+} from "@/lib/outcomes/profile-display";
 import SquadStack from "./_components/SquadStack";
 import BundledPricePreview from "./_components/BundledPricePreview";
 
@@ -127,6 +133,12 @@ export default async function TeamProfilePage({ params }: PageProps) {
     }),
   );
 
+  // Outcome flywheel data (fail-soft, both null → section hides).
+  const [outcomeBadge, testimonials] = await Promise.all([
+    getProviderOutcomeBadge({ teamId: team.id }),
+    getPublicTestimonials({ teamId: team.id, limit: 5 }),
+  ]);
+
   const breadcrumb = breadcrumbJsonLd([
     { name: "Home", url: absoluteUrl("/") },
     { name: "Experts", url: absoluteUrl("/advisors") },
@@ -208,7 +220,17 @@ export default async function TeamProfilePage({ params }: PageProps) {
             </div>
           )}
 
+          {outcomeBadge && (
+            <div className="flex items-center gap-2">
+              <OutcomeBadge badge={outcomeBadge} />
+            </div>
+          )}
+
           <BundledPricePreview estimate={priceEstimate} />
+
+          {testimonials.length > 0 && (
+            <TestimonialList testimonials={testimonials} />
+          )}
 
           <SquadStack members={squadMembers} />
 

--- a/components/outcomes/OutcomeBadge.tsx
+++ b/components/outcomes/OutcomeBadge.tsx
@@ -1,0 +1,37 @@
+import Icon from "@/components/Icon";
+import { badgeToneFor, type ProviderOutcomeBadge } from "@/lib/outcomes/profile-display";
+
+/**
+ * Outcome score badge — shown inline on provider profile pages.
+ * Derived from the N4 outcome-flywheel scoreboard. Compliance copy:
+ * "completion rate based on consumer reviews" — passive, no advice.
+ */
+
+interface Props {
+  badge: ProviderOutcomeBadge;
+}
+
+const TONE_CLASSES: Record<"emerald" | "amber" | "slate", string> = {
+  emerald: "bg-emerald-50 border-emerald-200 text-emerald-800",
+  amber: "bg-amber-50 border-amber-200 text-amber-800",
+  slate: "bg-slate-50 border-slate-200 text-slate-700",
+};
+
+export default function OutcomeBadge({ badge }: Props) {
+  const pct = badge.completion_rate_pct;
+  if (pct === null || pct === undefined) return null;
+  const tone = TONE_CLASSES[badgeToneFor(pct)];
+
+  return (
+    <div
+      className={`inline-flex items-center gap-2 ${tone} border rounded-full px-3 py-1`}
+      aria-label={`Completion rate ${pct}% based on ${badge.outcomes_submitted} consumer reviews`}
+    >
+      <Icon name="check-circle" size={12} />
+      <span className="text-xs font-bold">{pct}% completed</span>
+      <span className="text-[10px] opacity-70">
+        · {badge.outcomes_submitted} review{badge.outcomes_submitted === 1 ? "" : "s"}
+      </span>
+    </div>
+  );
+}

--- a/components/outcomes/TestimonialList.tsx
+++ b/components/outcomes/TestimonialList.tsx
@@ -1,0 +1,68 @@
+import Icon from "@/components/Icon";
+import type { PublicTestimonial } from "@/lib/outcomes/profile-display";
+
+/**
+ * Public testimonials section — shown on provider profile pages.
+ * Sourced from N4 outcome-flywheel submissions where the consumer
+ * opted-in (`show_testimonial = true`) and provided free-text feedback.
+ *
+ * Consumer name + email are never exposed (the column doesn't surface
+ * them); testimonials are anonymous-by-default by design.
+ */
+
+interface Props {
+  testimonials: PublicTestimonial[];
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString("en-AU", { year: "numeric", month: "short" });
+}
+
+export default function TestimonialList({ testimonials }: Props) {
+  if (testimonials.length === 0) return null;
+  return (
+    <section className="bg-white rounded-2xl border border-slate-200 p-5 sm:p-6">
+      <div className="flex items-center gap-2 mb-4">
+        <Icon name="message-circle" size={16} className="text-amber-500" />
+        <h2 className="text-base font-bold text-slate-900">
+          What clients say
+        </h2>
+        <span className="text-xs text-slate-400">
+          ({testimonials.length} verified review{testimonials.length === 1 ? "" : "s"})
+        </span>
+      </div>
+      <div className="space-y-4">
+        {testimonials.map((t) => (
+          <article key={t.id} className="border-l-2 border-amber-200 pl-4">
+            {t.rating !== null && (
+              <div className="flex items-center gap-0.5 mb-1.5" aria-label={`${t.rating} out of 5`}>
+                {[1, 2, 3, 4, 5].map((n) => (
+                  <span
+                    key={n}
+                    className={`text-sm ${
+                      t.rating !== null && t.rating >= n
+                        ? "text-amber-500"
+                        : "text-slate-200"
+                    }`}
+                  >
+                    ★
+                  </span>
+                ))}
+              </div>
+            )}
+            <p className="text-sm text-slate-700 leading-relaxed mb-1.5">
+              &ldquo;{t.testimonial}&rdquo;
+            </p>
+            <p className="text-xs text-slate-400">
+              — Verified client · {formatDate(t.submitted_at)}
+            </p>
+          </article>
+        ))}
+      </div>
+      <p className="text-[10px] text-slate-400 mt-4">
+        Testimonials are collected anonymously from consumers ~4 weeks after engagement. General information only.
+      </p>
+    </section>
+  );
+}

--- a/lib/outcomes/profile-display.ts
+++ b/lib/outcomes/profile-display.ts
@@ -1,0 +1,127 @@
+/**
+ * Provider profile display helpers — surfaces N4 outcome-flywheel data
+ * (testimonials + completion score) on advisor + expert-team profile
+ * pages.
+ *
+ * Pure-ish: reads from `brief_outcomes` and `provider_outcome_scores`
+ * via the service-role admin client (RLS allows public reads but
+ * service-role keeps the path simple). Falls back to empty results on
+ * any DB failure so the profile page still renders.
+ */
+
+// eslint-disable-next-line no-restricted-imports -- public-read provider profile data; service-role keeps the path consistent with the rest of lib/outcomes.
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+
+const log = logger("outcomes:profile");
+
+export interface PublicTestimonial {
+  id: number;
+  rating: number | null;
+  testimonial: string;
+  submitted_at: string;
+}
+
+export interface ProviderOutcomeBadge {
+  completion_rate_pct: number | null;
+  outcomes_submitted: number;
+  avg_rating: number | null;
+}
+
+/**
+ * Pull the most recent N opt-in testimonials for a provider. Caller
+ * passes either professional_id or team_id; the other is left null.
+ * Returns at most `limit` rows ordered by submitted_at desc.
+ */
+export async function getPublicTestimonials(opts: {
+  professionalId?: number | null;
+  teamId?: number | null;
+  limit?: number;
+}): Promise<PublicTestimonial[]> {
+  try {
+    const admin = createAdminClient();
+    let q = admin
+      .from("brief_outcomes")
+      .select("id, rating, testimonial, submitted_at")
+      .eq("show_testimonial", true)
+      .not("submitted_at", "is", null)
+      .not("testimonial", "is", null)
+      .order("submitted_at", { ascending: false })
+      .limit(opts.limit ?? 5);
+
+    if (opts.professionalId) {
+      q = q.eq("professional_id", opts.professionalId);
+    } else if (opts.teamId) {
+      q = q.eq("team_id", opts.teamId);
+    } else {
+      return [];
+    }
+
+    const { data, error } = await q;
+    if (error) throw error;
+
+    return (data ?? [])
+      .filter((r) => typeof r.testimonial === "string" && r.testimonial.length > 0)
+      .map((r) => ({
+        id: r.id as number,
+        rating: r.rating as number | null,
+        testimonial: r.testimonial as string,
+        submitted_at: r.submitted_at as string,
+      }));
+  } catch (err) {
+    log.warn("getPublicTestimonials failed", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return [];
+  }
+}
+
+/**
+ * Load the latest provider scoreboard row for the badge. Returns null
+ * when no scoreboard row exists yet (e.g. provider hasn't accepted
+ * enough briefs to be scored).
+ */
+export async function getProviderOutcomeBadge(opts: {
+  professionalId?: number | null;
+  teamId?: number | null;
+}): Promise<ProviderOutcomeBadge | null> {
+  try {
+    const admin = createAdminClient();
+    let q = admin
+      .from("provider_outcome_scores")
+      .select("completion_rate_pct, outcomes_submitted, avg_rating")
+      .order("window_end", { ascending: false })
+      .limit(1);
+    if (opts.professionalId) {
+      q = q.eq("professional_id", opts.professionalId);
+    } else if (opts.teamId) {
+      q = q.eq("team_id", opts.teamId);
+    } else {
+      return null;
+    }
+    const { data, error } = await q.maybeSingle();
+    if (error) throw error;
+    if (!data) return null;
+    // Don't display until at least 3 outcomes are submitted — single-
+    // outcome scores are noisy and easy to game.
+    if ((data.outcomes_submitted ?? 0) < 3) return null;
+    return {
+      completion_rate_pct: data.completion_rate_pct as number | null,
+      outcomes_submitted: data.outcomes_submitted as number,
+      avg_rating: data.avg_rating as number | null,
+    };
+  } catch (err) {
+    log.warn("getProviderOutcomeBadge failed", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}
+
+/** Pretty label for the badge tone. */
+export function badgeToneFor(pct: number | null): "emerald" | "amber" | "slate" {
+  if (pct === null || pct === undefined) return "slate";
+  if (pct >= 80) return "emerald";
+  if (pct >= 60) return "amber";
+  return "slate";
+}


### PR DESCRIPTION
## Summary

Closes the trust loop on N4's outcome flywheel (just merged in #831). Provider profile pages now display:
- **Outcome score badge** — "87% completed · 12 reviews" — gated to ≥3 submitted outcomes
- **"What clients say" testimonial section** — anonymous opt-in quotes from `brief_outcomes`

ROI: social proof is the #1 marketplace conversion lever. Compounds with every Match Request that produces an outcome submission — zero ongoing admin work.

## What ships

### `lib/outcomes/profile-display.ts` (new)
- `getPublicTestimonials({professionalId | teamId, limit})` — reads `brief_outcomes` where `show_testimonial=true` AND `submitted_at IS NOT NULL`, most-recent-first
- `getProviderOutcomeBadge({professionalId | teamId})` — pulls latest `provider_outcome_scores`; gated to ≥3 submitted outcomes before display
- `badgeToneFor(pct)` — emerald ≥80, amber ≥60, slate otherwise

### `components/outcomes/OutcomeBadge.tsx` (new)
Inline pill: "87% completed · 12 reviews" with tone-aware colour.

### `components/outcomes/TestimonialList.tsx` (new)
"What clients say" section — 1-5 star rating + quoted testimonial + "Verified client · Mar 2026" attribution. Consumer name/email never exposed.

### `app/advisor/[slug]/page.tsx` + `app/teams/[slug]/page.tsx` (edits)
Parallel fetch of badge + testimonials; renders below the existing profile content. Both pages.

## Compliance

- "Verified client" attribution only — no PII surfaced
- Passive copy ("completion rate based on consumer reviews")
- Display gate (≥3 outcomes) prevents low-data game-ability
- Disclosure footer: "Testimonials collected anonymously from consumers ~4 weeks after engagement. General information only."

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] JSON-LD coverage gate passes
- [x] Pre-push checks pass
- [ ] Manual: visit `/advisor/[slug]` and `/teams/[slug]` — confirm badge + testimonials section hides cleanly when no data yet, populates once outcomes exist

---
_Generated by [Claude Code](https://claude.ai/code/session_015JmqgxgJAaVt9RrUQ8uvNf)_