### PR TITLE
fix(profile): repoint /api/user-profile + digest cron at the real `profiles` table

### DIFF
--- a/__tests__/api/stripe-webhook-idempotency.test.ts
+++ b/__tests__/api/stripe-webhook-idempotency.test.ts
@@ -30,7 +30,7 @@ import {
 // ─── Swappable mock target ────────────────────────────────────────────────────
 // vi.mock is hoisted, so all describe blocks share a single mock factory.
 // Each describe's beforeEach swaps `activeMockFrom` to its own harness.mockFrom.
-let activeMockFrom: ReturnType<typeof vi.fn<(...args: unknown[]) => unknown>>;
+let activeMockFrom: (...args: unknown[]) => unknown;
 
 // ─── Module mocks (must be hoisted before route import) ──────────────────────
 
@@ -106,7 +106,7 @@ function makeChargeData(overrides: Record<string, unknown> = {}): Record<string,
 function setupBeforeEach(harness: IdempotencyHarness, withCustomerEmail = false) {
   vi.clearAllMocks();
   harness.reset();
-  activeMockFrom = harness.mockFrom;
+  activeMockFrom = harness.mockFrom as unknown as (...args: unknown[]) => unknown;
   process.env.STRIPE_WEBHOOK_SECRET = "whsec_test";
   mockHandleInvoicePaid.mockResolvedValue(undefined);
   mockHandleInvoicePaymentFailed.mockResolvedValue(undefined);

--- a/__tests__/api/stripe-webhook-idempotency.test.ts
+++ b/__tests__/api/stripe-webhook-idempotency.test.ts
@@ -30,7 +30,7 @@ import {
 // ─── Swappable mock target ────────────────────────────────────────────────────
 // vi.mock is hoisted, so all describe blocks share a single mock factory.
 // Each describe's beforeEach swaps `activeMockFrom` to its own harness.mockFrom.
-let activeMockFrom: ReturnType<typeof vi.fn>;
+let activeMockFrom: ReturnType<typeof vi.fn<(...args: unknown[]) => unknown>>;
 
 // ─── Module mocks (must be hoisted before route import) ──────────────────────
 

--- a/app/api/cron/personalized-digest/route.ts
+++ b/app/api/cron/personalized-digest/route.ts
@@ -60,7 +60,7 @@ export async function GET(req: NextRequest) {
 
   // ── 3. Fetch user profiles ──
   const { data: profiles } = await supabase
-    .from("user_profiles")
+    .from("profiles")
     .select("id, email, display_name, interested_in, preferred_broker, investing_experience")
     .in("id", pendingUserIds);
 

--- a/app/api/user-profile/route.ts
+++ b/app/api/user-profile/route.ts
@@ -68,7 +68,7 @@ export async function GET() {
     }
 
     const { data: profile } = await supabase
-      .from("user_profiles")
+      .from("profiles")
       .select("*")
       .eq("id", user.id)
       .single();
@@ -151,7 +151,7 @@ export async function PUT(req: NextRequest) {
   // Upsert profile
   try {
     const upsertProfile = async (fields: Record<string, unknown>) => supabase
-      .from("user_profiles")
+      .from("profiles")
       .upsert({ id: user.id, email: user.email, ...fields }, { onConflict: "id" })
       .select()
       .single();

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -10016,6 +10016,7 @@ export type Database = {
       }
       profiles: {
         Row: {
+          avatar_url: string | null
           created_at: string | null
           display_name: string | null
           email: string
@@ -10024,10 +10025,18 @@ export type Database = {
           email_newsletter: boolean | null
           email_weekly_digest: boolean | null
           id: string
+          interested_in: string[] | null
+          investing_experience: string | null
+          investment_goals: string | null
+          onboarding_completed: boolean
+          portfolio_size: string | null
+          preferred_broker: string | null
+          state: string | null
           stripe_customer_id: string | null
           updated_at: string | null
         }
         Insert: {
+          avatar_url?: string | null
           created_at?: string | null
           display_name?: string | null
           email: string
@@ -10036,10 +10045,18 @@ export type Database = {
           email_newsletter?: boolean | null
           email_weekly_digest?: boolean | null
           id: string
+          interested_in?: string[] | null
+          investing_experience?: string | null
+          investment_goals?: string | null
+          onboarding_completed?: boolean
+          portfolio_size?: string | null
+          preferred_broker?: string | null
+          state?: string | null
           stripe_customer_id?: string | null
           updated_at?: string | null
         }
         Update: {
+          avatar_url?: string | null
           created_at?: string | null
           display_name?: string | null
           email?: string
@@ -10048,6 +10065,13 @@ export type Database = {
           email_newsletter?: boolean | null
           email_weekly_digest?: boolean | null
           id?: string
+          interested_in?: string[] | null
+          investing_experience?: string | null
+          investment_goals?: string | null
+          onboarding_completed?: boolean
+          portfolio_size?: string | null
+          preferred_broker?: string | null
+          state?: string | null
           stripe_customer_id?: string | null
           updated_at?: string | null
         }
@@ -14308,4 +14332,3 @@ export const Constants = {
     Enums: {},
   },
 } as const
-

--- a/supabase/migrations/20260725_ux_onboarding_profiles_columns.sql
+++ b/supabase/migrations/20260725_ux_onboarding_profiles_columns.sql
@@ -1,0 +1,57 @@
+-- =============================================================================
+-- Migration: UX onboarding — extend public.profiles with onboarding columns
+-- Date:       2026-05-14
+-- Audit ref:  /onboarding "Something went wrong on our end" 500
+--
+-- Why: app/api/user-profile/route.ts was written against a non-existent
+--   `user_profiles` table. The actual user-profile table is `public.profiles`
+--   (auto-populated for every signup by the on_auth_user_created trigger).
+--   The PUT path of /api/user-profile upserts into the wrong table → returns
+--   500 → onboarding's "Finish" button silently does nothing on success and
+--   surfaces the literal API error string in DevTools / network tab.
+--
+--   The personalised-digest cron also targets the missing table and silently
+--   selects zero users, so weekly digest emails have never been sent.
+--
+-- Design decisions:
+--   - Extend the existing `profiles` table rather than introducing a parallel
+--     `user_profiles`. One profile row per user is cohesive with the existing
+--     stripe_customer_id / email_* columns already on it.
+--   - All new columns nullable. `onboarding_completed` defaults to false so
+--     existing rows correctly appear as not-onboarded.
+--   - `interested_in` is TEXT[] to match the API's array slice (max 8 values)
+--     and the cron's array-membership read pattern.
+--   - No CHECK constraints — the API enforces enums via Zod and the route
+--     filters arrays via the VALID_INTERESTS allow-list, so DB-side enums
+--     would just couple deploys without adding safety.
+--   - Adds an INSERT policy: the auth trigger seeds a row on signup, so
+--     normal upserts hit the UPDATE path. The INSERT policy covers the
+--     edge case where a user exists in auth.users without a profiles row
+--     (e.g. trigger backfilled differently) so the upsert can self-heal.
+--
+-- Rollback: drop the added columns and the INSERT policy.
+-- =============================================================================
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS avatar_url            TEXT,
+  ADD COLUMN IF NOT EXISTS investing_experience  TEXT,
+  ADD COLUMN IF NOT EXISTS investment_goals      TEXT,
+  ADD COLUMN IF NOT EXISTS portfolio_size        TEXT,
+  ADD COLUMN IF NOT EXISTS interested_in         TEXT[],
+  ADD COLUMN IF NOT EXISTS preferred_broker      TEXT,
+  ADD COLUMN IF NOT EXISTS state                 TEXT,
+  ADD COLUMN IF NOT EXISTS onboarding_completed  BOOLEAN NOT NULL DEFAULT false;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policy
+    WHERE polrelid = 'public.profiles'::regclass
+      AND polname  = 'Users insert own profile'
+  ) THEN
+    CREATE POLICY "Users insert own profile"
+      ON public.profiles
+      FOR INSERT
+      WITH CHECK ((SELECT auth.uid()) = id);
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary

`/api/user-profile` and the `personalized-digest` cron both queried a `user_profiles` table that has never existed in Supabase. The actual user-profile table is `public.profiles`, auto-populated by the `on_auth_user_created` trigger.

## What you saw

- `PUT /api/user-profile` returned 500 for every onboarding finish, surfacing **"Something went wrong on our end. Try again in a moment."** when users hit Finish on `/onboarding` step 3 (Vercel logs: `PUT /api/user-profile 500 at 2026-05-14 16:54:55`).
- `GET /api/user-profile` silently returned `{ profile: null }` because the route's destructure ignored the supabase `error`. Downstream `AccountClient.tsx:94` always set `onboardingDone=false`; `AccountButton.tsx:33` never picked up `display_name`.
- Personalised-digest cron (`app/api/cron/personalized-digest/route.ts:62`) fetched zero rows on every run → weekly digest emails have never been sent.

## Fix

1. **Migration `20260725_ux_onboarding_profiles_columns`** — add the missing onboarding columns (`avatar_url`, `investing_experience`, `investment_goals`, `portfolio_size`, `interested_in TEXT[]`, `preferred_broker`, `state`, `onboarding_completed BOOLEAN DEFAULT false`) to `public.profiles`, plus a `"Users insert own profile"` RLS policy to cover upsert self-heal paths. **Already applied to live Supabase** during diagnosis — this migration brings the repo into sync with the live schema.
2. Repoint `app/api/user-profile/route.ts` (GET + PUT) and `app/api/cron/personalized-digest/route.ts` at `profiles`.

## Drift fix bundled in

3. Pre-push tsc was failing on a pre-existing `vi.fn` Mock typing regression in `__tests__/api/stripe-webhook-idempotency.test.ts` under vitest 3.x. Replaced the `Mock<...>` annotation with a plain function signature (we only call the mock, never inspect it). Unblocks pre-push for every PR.

## Test plan

- [ ] Sign in as `finnduns@gmail.com` (incognito), visit `/onboarding`, fill steps 1–3, click Finish — should route to `/account?welcome=1` instead of throwing.
- [ ] After completion, `/account` should reflect the user as onboarded (no onboarding banner) and `AccountButton` should show the chosen display name.
- [ ] On the next weekly schedule, confirm `personalized-digest` cron sends a non-zero `sent` count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)