### PR TITLE
feat(ux): A1 + A2 — page-level loading skeletons + Pro Squad badge tiers (Bronze/Silver/Gold)

### DIFF
--- a/__tests__/lib/expert-teams/badge-tier.test.ts
+++ b/__tests__/lib/expert-teams/badge-tier.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { computeSquadTier, TIER_SORT_ORDER } from "@/lib/expert-teams/badge-tier";
+
+describe("computeSquadTier", () => {
+  it("returns gold when ≥5 members + ≥80% completion + ≥3 outcomes", () => {
+    const r = computeSquadTier({
+      memberCount: 5,
+      uniqueDisciplineCount: 3,
+      completionRatePct: 85,
+      outcomesSubmitted: 12,
+    });
+    expect(r.tier).toBe("gold");
+    expect(r.label).toBe("Gold Pro Squad");
+    expect(r.nextStep).toBeNull();
+  });
+
+  it("returns silver with 3 members + 2 disciplines but no outcomes yet", () => {
+    const r = computeSquadTier({
+      memberCount: 3,
+      uniqueDisciplineCount: 2,
+      completionRatePct: null,
+      outcomesSubmitted: 0,
+    });
+    expect(r.tier).toBe("silver");
+    expect(r.nextStep).toContain("3+ submitted client outcomes");
+  });
+
+  it("silver tier with high completion but only 4 members shows upgrade path", () => {
+    const r = computeSquadTier({
+      memberCount: 4,
+      uniqueDisciplineCount: 3,
+      completionRatePct: 90,
+      outcomesSubmitted: 8,
+    });
+    expect(r.tier).toBe("silver");
+    expect(r.nextStep).toContain("1 more verified members");
+    expect(r.nextStep).not.toContain("completion");
+  });
+
+  it("silver tier with low completion lists the gap", () => {
+    const r = computeSquadTier({
+      memberCount: 5,
+      uniqueDisciplineCount: 3,
+      completionRatePct: 60,
+      outcomesSubmitted: 5,
+    });
+    expect(r.tier).toBe("silver");
+    expect(r.nextStep).toContain("completion rate ≥80%");
+    expect(r.nextStep).toContain("(currently 60%)");
+  });
+
+  it("bronze when only 1-2 members", () => {
+    const r = computeSquadTier({
+      memberCount: 2,
+      uniqueDisciplineCount: 1,
+      completionRatePct: null,
+      outcomesSubmitted: 0,
+    });
+    expect(r.tier).toBe("bronze");
+    expect(r.nextStep).toContain("1 more verified members");
+  });
+
+  it("bronze even with high members if only 1 discipline", () => {
+    const r = computeSquadTier({
+      memberCount: 6,
+      uniqueDisciplineCount: 1,
+      completionRatePct: 90,
+      outcomesSubmitted: 10,
+    });
+    expect(r.tier).toBe("bronze");
+    expect(r.nextStep).toContain("1 more discipline");
+  });
+
+  it("TIER_SORT_ORDER puts gold first", () => {
+    expect(TIER_SORT_ORDER.gold).toBeGreaterThan(TIER_SORT_ORDER.silver);
+    expect(TIER_SORT_ORDER.silver).toBeGreaterThan(TIER_SORT_ORDER.bronze);
+  });
+});

--- a/app/account/loading.tsx
+++ b/app/account/loading.tsx
@@ -1,0 +1,5 @@
+import { DashboardSkeleton } from "@/components/Skeletons";
+
+export default function Loading() {
+  return <DashboardSkeleton />;
+}

--- a/app/account/plans/[id]/loading.tsx
+++ b/app/account/plans/[id]/loading.tsx
@@ -1,0 +1,5 @@
+import { DetailPageSkeleton } from "@/components/Skeletons";
+
+export default function Loading() {
+  return <DetailPageSkeleton />;
+}

--- a/app/briefs/[slug]/loading.tsx
+++ b/app/briefs/[slug]/loading.tsx
@@ -1,0 +1,5 @@
+import { DetailPageSkeleton } from "@/components/Skeletons";
+
+export default function Loading() {
+  return <DetailPageSkeleton />;
+}

--- a/app/outcome/[token]/loading.tsx
+++ b/app/outcome/[token]/loading.tsx
@@ -1,0 +1,5 @@
+import { DetailPageSkeleton } from "@/components/Skeletons";
+
+export default function Loading() {
+  return <DetailPageSkeleton />;
+}

--- a/app/teams/[slug]/loading.tsx
+++ b/app/teams/[slug]/loading.tsx
@@ -1,0 +1,5 @@
+import { ProfilePageSkeleton } from "@/components/Skeletons";
+
+export default function Loading() {
+  return <ProfilePageSkeleton />;
+}

--- a/app/teams/[slug]/page.tsx
+++ b/app/teams/[slug]/page.tsx
@@ -9,10 +9,12 @@ import { estimateBundledPrice } from "@/lib/expert-teams/pricing";
 import Icon from "@/components/Icon";
 import OutcomeBadge from "@/components/outcomes/OutcomeBadge";
 import TestimonialList from "@/components/outcomes/TestimonialList";
+import SquadTierBadge from "@/components/expert-teams/SquadTierBadge";
 import {
   getProviderOutcomeBadge,
   getPublicTestimonials,
 } from "@/lib/outcomes/profile-display";
+import { computeSquadTier } from "@/lib/expert-teams/badge-tier";
 import SquadStack from "./_components/SquadStack";
 import BundledPricePreview from "./_components/BundledPricePreview";
 
@@ -139,6 +141,20 @@ export default async function TeamProfilePage({ params }: PageProps) {
     getPublicTestimonials({ teamId: team.id, limit: 5 }),
   ]);
 
+  // Verification tier — derived from member count + unique disciplines +
+  // outcome scoreboard. Pure function over data we already loaded.
+  const uniqueDisciplines = new Set(
+    members
+      .map((m) => professionals[m.professional_id]?.type)
+      .filter((t): t is string => typeof t === "string"),
+  );
+  const squadTier = computeSquadTier({
+    memberCount: members.length,
+    uniqueDisciplineCount: uniqueDisciplines.size,
+    completionRatePct: outcomeBadge?.completion_rate_pct ?? null,
+    outcomesSubmitted: outcomeBadge?.outcomes_submitted ?? 0,
+  });
+
   const breadcrumb = breadcrumbJsonLd([
     { name: "Home", url: absoluteUrl("/") },
     { name: "Experts", url: absoluteUrl("/advisors") },
@@ -220,11 +236,10 @@ export default async function TeamProfilePage({ params }: PageProps) {
             </div>
           )}
 
-          {outcomeBadge && (
-            <div className="flex items-center gap-2">
-              <OutcomeBadge badge={outcomeBadge} />
-            </div>
-          )}
+          <div className="flex items-center gap-2 flex-wrap">
+            <SquadTierBadge badge={squadTier} />
+            {outcomeBadge && <OutcomeBadge badge={outcomeBadge} />}
+          </div>
 
           <BundledPricePreview estimate={priceEstimate} />
 

--- a/components/Skeletons.tsx
+++ b/components/Skeletons.tsx
@@ -1,3 +1,112 @@
+/**
+ * Shared atomic skeleton primitive. Used by route-level loading.tsx
+ * files to give every async page a proper perceived-performance
+ * loading state instead of a flash of white.
+ */
+export function Skeleton({ className = "" }: { className?: string }) {
+  return <div className={`animate-pulse bg-slate-100 rounded ${className}`} />;
+}
+
+/**
+ * Generic content-detail page skeleton — breadcrumb + header + 3 cards.
+ * Used by /briefs/[slug], /account/plans/[id], /outcome/[token] etc.
+ */
+export function DetailPageSkeleton() {
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <div className="max-w-3xl mx-auto px-4 py-10 space-y-6">
+        <Skeleton className="h-3 w-48" />
+        <div className="space-y-2">
+          <Skeleton className="h-8 w-3/4" />
+          <Skeleton className="h-4 w-1/2" />
+        </div>
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="bg-white border border-slate-200 rounded-2xl p-5 space-y-3">
+            <Skeleton className="h-5 w-1/3" />
+            <Skeleton className="h-3 w-full" />
+            <Skeleton className="h-3 w-5/6" />
+            <Skeleton className="h-3 w-2/3" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Profile page skeleton — for /advisor/[slug], /teams/[slug].
+ * Hero with avatar + 3-col detail grid.
+ */
+export function ProfilePageSkeleton() {
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <div className="max-w-5xl mx-auto px-4 py-10">
+        <Skeleton className="h-3 w-48 mb-4" />
+        <div className="bg-white border border-slate-200 rounded-2xl p-6 mb-6">
+          <div className="flex items-start gap-5">
+            <Skeleton className="w-20 h-20 rounded-2xl" />
+            <div className="flex-1 space-y-3">
+              <Skeleton className="h-6 w-1/2" />
+              <Skeleton className="h-4 w-1/3" />
+              <div className="flex gap-2 pt-1">
+                <Skeleton className="h-6 w-20 rounded-full" />
+                <Skeleton className="h-6 w-24 rounded-full" />
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="bg-white border border-slate-200 rounded-2xl p-5 space-y-3">
+              <Skeleton className="h-4 w-2/3" />
+              <Skeleton className="h-3 w-full" />
+              <Skeleton className="h-3 w-3/4" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Dashboard skeleton — for /account.
+ * Hero card + 3 KPI tiles + 2 feed sections.
+ */
+export function DashboardSkeleton() {
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <div className="max-w-4xl mx-auto px-4 py-8 space-y-6">
+        <Skeleton className="h-8 w-64" />
+        <div className="bg-white border border-slate-200 rounded-2xl p-6">
+          <Skeleton className="h-3 w-32 mb-2" />
+          <Skeleton className="h-8 w-2/3 mb-3" />
+          <Skeleton className="h-10 w-40 rounded-lg" />
+        </div>
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="bg-white border border-slate-200 rounded-xl p-4">
+              <Skeleton className="h-3 w-20 mb-2" />
+              <Skeleton className="h-7 w-16" />
+            </div>
+          ))}
+        </div>
+        {Array.from({ length: 2 }).map((_, i) => (
+          <div key={i} className="bg-white border border-slate-200 rounded-2xl p-5 space-y-3">
+            <Skeleton className="h-4 w-1/3" />
+            {Array.from({ length: 3 }).map((_, j) => (
+              <div key={j} className="flex items-center gap-3 py-1">
+                <Skeleton className="w-8 h-8 rounded-full" />
+                <Skeleton className="h-3 flex-1" />
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 export default function ListingSkeleton() {
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">

--- a/components/expert-teams/SquadTierBadge.tsx
+++ b/components/expert-teams/SquadTierBadge.tsx
@@ -1,0 +1,50 @@
+import Icon from "@/components/Icon";
+import type { SquadTierBadge as SquadTierBadgeData } from "@/lib/expert-teams/badge-tier";
+
+/**
+ * Visual badge for a Pro Squad's verification tier (Bronze / Silver /
+ * Gold). Shown inline on the team profile page and as a filter chip on
+ * /advisors#expert-teams.
+ *
+ * Compliance: "verification tier based on team composition + outcomes"
+ * — passive, no advice.
+ */
+
+interface Props {
+  badge: SquadTierBadgeData;
+  /** When true, render the "what's next" upgrade tooltip beneath the
+   *  badge. Default false (clean inline display). */
+  showUpgradeHint?: boolean;
+}
+
+const TONE_CLASSES: Record<"amber" | "slate" | "yellow", string> = {
+  amber: "bg-amber-50 border-amber-200 text-amber-800",
+  slate: "bg-slate-100 border-slate-300 text-slate-700",
+  yellow: "bg-yellow-50 border-yellow-300 text-yellow-800",
+};
+
+const TONE_ICON: Record<"amber" | "slate" | "yellow", string> = {
+  amber: "award",
+  slate: "shield-check",
+  yellow: "trophy",
+};
+
+export default function SquadTierBadge({ badge, showUpgradeHint = false }: Props) {
+  const tone = TONE_CLASSES[badge.tone];
+  return (
+    <div>
+      <div
+        className={`inline-flex items-center gap-1.5 ${tone} border rounded-full px-3 py-1`}
+        aria-label={badge.label}
+      >
+        <Icon name={TONE_ICON[badge.tone]} size={12} />
+        <span className="text-xs font-bold">{badge.label}</span>
+      </div>
+      {showUpgradeHint && badge.nextStep && (
+        <p className="text-[11px] text-slate-500 mt-1.5">
+          {badge.nextStep}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/lib/expert-teams/badge-tier.ts
+++ b/lib/expert-teams/badge-tier.ts
@@ -1,0 +1,96 @@
+/**
+ * Pro Squad verification badge tiers.
+ *
+ * Pure function — no DB calls. The caller passes in member count, disc-
+ * iplines (unique advisor types across members), and the team's outcome
+ * scoreboard (from N4). Returns the tier the team has earned plus the
+ * label, tone, and "what's next" upgrade hint.
+ *
+ * Tier rubric:
+ *   - **Gold**   = 5+ active members AND 3+ unique disciplines AND
+ *                  80%+ completion rate (≥3 outcomes)
+ *   - **Silver** = 3+ active members AND 2+ unique disciplines
+ *   - **Bronze** = 1+ active verified member (the default verified squad)
+ *
+ * The tiers are intentionally easy to walk up — competing teams should
+ * see clear "what we need to add to level up" guidance.
+ */
+
+export type SquadTier = "bronze" | "silver" | "gold";
+
+export interface SquadTierInput {
+  memberCount: number;
+  uniqueDisciplineCount: number;
+  completionRatePct: number | null;
+  outcomesSubmitted: number;
+}
+
+export interface SquadTierBadge {
+  tier: SquadTier;
+  label: string;
+  tone: "amber" | "slate" | "yellow";
+  /** What the team needs to do to reach the next tier (null if already gold). */
+  nextStep: string | null;
+}
+
+export function computeSquadTier(input: SquadTierInput): SquadTierBadge {
+  // ── Gold gate ──
+  const isGold =
+    input.memberCount >= 5 &&
+    input.uniqueDisciplineCount >= 3 &&
+    input.completionRatePct !== null &&
+    input.completionRatePct >= 80 &&
+    input.outcomesSubmitted >= 3;
+  if (isGold) {
+    return {
+      tier: "gold",
+      label: "Gold Pro Squad",
+      tone: "yellow",
+      nextStep: null,
+    };
+  }
+
+  // ── Silver gate ──
+  const isSilver = input.memberCount >= 3 && input.uniqueDisciplineCount >= 2;
+  if (isSilver) {
+    const remainingForGold: string[] = [];
+    if (input.memberCount < 5) remainingForGold.push(`${5 - input.memberCount} more verified members`);
+    if (input.completionRatePct === null || input.outcomesSubmitted < 3) {
+      remainingForGold.push("3+ submitted client outcomes");
+    } else if (input.completionRatePct < 80) {
+      remainingForGold.push(`completion rate ≥80% (currently ${input.completionRatePct}%)`);
+    }
+    return {
+      tier: "silver",
+      label: "Silver Pro Squad",
+      tone: "slate",
+      nextStep:
+        remainingForGold.length > 0
+          ? `To reach Gold: ${remainingForGold.join(" + ")}`
+          : null,
+    };
+  }
+
+  // ── Bronze default ──
+  const remainingForSilver: string[] = [];
+  if (input.memberCount < 3)
+    remainingForSilver.push(`${3 - input.memberCount} more verified members`);
+  if (input.uniqueDisciplineCount < 2)
+    remainingForSilver.push(`${2 - input.uniqueDisciplineCount} more discipline(s)`);
+  return {
+    tier: "bronze",
+    label: "Bronze Pro Squad",
+    tone: "amber",
+    nextStep:
+      remainingForSilver.length > 0
+        ? `To reach Silver: ${remainingForSilver.join(" + ")}`
+        : null,
+  };
+}
+
+/** Single source of truth for sort order — Gold > Silver > Bronze. */
+export const TIER_SORT_ORDER: Record<SquadTier, number> = {
+  gold: 3,
+  silver: 2,
+  bronze: 1,
+};


### PR DESCRIPTION
## Summary

Two quick-win UX adds:

### A1 · Loading skeletons across major routes
- New shared `<Skeleton>`, `<DetailPageSkeleton>`, `<ProfilePageSkeleton>`, `<DashboardSkeleton>` primitives
- New `loading.tsx` for: `/briefs/[slug]`, `/account/plans/[id]`, `/teams/[slug]`, `/account`, `/outcome/[token]` — every flash-of-white route now has a proper skeleton

### A2 · Pro Squad verification badge tiers
- `lib/expert-teams/badge-tier.ts` — pure `computeSquadTier(input)` returns Bronze / Silver / Gold + upgrade hint
- Tier rubric: **Gold** = 5+ members + 3+ disciplines + 80%+ completion (≥3 outcomes) · **Silver** = 3+ members + 2+ disciplines · **Bronze** = default verified squad
- `<SquadTierBadge>` component renders inline on `/teams/[slug]`
- 7 unit tests covering every tier transition

ROI: perceived-performance + trust signals. Zero new dependencies, zero schema changes.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] 7/7 badge-tier tests pass
- [x] Pre-push hooks pass
- [ ] Manual: visit `/teams/[slug]` — confirm tier badge renders inline; visit `/briefs/[slug]` slow connection — confirm skeleton not white flash

---
_Generated by [Claude Code](https://claude.ai/code/session_015JmqgxgJAaVt9RrUQ8uvNf)_