### PR TITLE
feat(account): re-engagement digest for abandoned Get Matched plans

### DIFF
--- a/__tests__/lib/account/plan-resume-digest.test.ts
+++ b/__tests__/lib/account/plan-resume-digest.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+  renderDigestEmail,
+  shouldSkip,
+} from "@/lib/account/plan-resume-digest";
+
+describe("renderDigestEmail", () => {
+  it("uses the goal in the subject when present", () => {
+    const { subject } = renderDigestEmail({
+      goal: "Buy property through SMSF",
+      intent_slug: null,
+      share_token: "tok-abc",
+      baseUrl: "https://invest.com.au",
+    });
+    expect(subject).toBe(
+      "Pick up where you left off — Buy property through SMSF",
+    );
+  });
+
+  it("falls back to humanised intent_slug when no goal", () => {
+    const { subject } = renderDigestEmail({
+      goal: null,
+      intent_slug: "smsf_property",
+      share_token: "tok-abc",
+      baseUrl: "https://invest.com.au",
+    });
+    expect(subject).toBe("Pick up where you left off — smsf property");
+  });
+
+  it("uses a generic line when no goal and no intent", () => {
+    const { subject } = renderDigestEmail({
+      goal: null,
+      intent_slug: null,
+      share_token: "tok-abc",
+      baseUrl: "https://invest.com.au",
+    });
+    expect(subject).toBe("Pick up where you left off — your action plan");
+  });
+
+  it("escapes html in the goal", () => {
+    const { html } = renderDigestEmail({
+      goal: "<script>alert('x')</script>",
+      intent_slug: null,
+      share_token: "tok-abc",
+      baseUrl: "https://invest.com.au",
+    });
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
+
+  it("builds an absolute resume URL from baseUrl + token", () => {
+    const { html } = renderDigestEmail({
+      goal: "X",
+      intent_slug: null,
+      share_token: "tok-abc",
+      baseUrl: "https://invest.com.au/",
+    });
+    expect(html).toContain("https://invest.com.au/plans/tok-abc");
+  });
+});
+
+describe("shouldSkip", () => {
+  it("returns true when user is in the recent-sends set", () => {
+    expect(
+      shouldSkip({ auth_user_id: "u1" }, new Set(["u1", "u2"])),
+    ).toBe(true);
+  });
+
+  it("returns false when user is not in the recent-sends set", () => {
+    expect(shouldSkip({ auth_user_id: "u3" }, new Set(["u1"]))).toBe(false);
+  });
+});

--- a/app/api/cron/plan-resume-digest/route.ts
+++ b/app/api/cron/plan-resume-digest/route.ts
@@ -1,0 +1,135 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { sendEmail } from "@/lib/resend";
+import { logger } from "@/lib/logger";
+import { requireCronAuth } from "@/lib/cron-auth";
+import {
+  renderDigestEmail,
+  shouldSkip,
+  type DigestCandidate,
+} from "@/lib/account/plan-resume-digest";
+
+const log = logger("plan-resume-digest");
+
+export const maxDuration = 60;
+
+const DRAFT_AGE_DAYS = 3;
+const DEDUP_WINDOW_DAYS = 7;
+
+/**
+ * Cron: daily nudge to users who started a Get Matched plan and
+ * abandoned it >3 days ago. One email per user per 7 days.
+ */
+export async function GET(req: NextRequest) {
+  const unauth = requireCronAuth(req);
+  if (unauth) return unauth;
+
+  const admin = createAdminClient();
+  const baseUrl =
+    process.env.NEXT_PUBLIC_BASE_URL || "https://invest.com.au";
+
+  const draftCutoff = new Date(
+    Date.now() - DRAFT_AGE_DAYS * 86400_000,
+  ).toISOString();
+  const dedupCutoff = new Date(
+    Date.now() - DEDUP_WINDOW_DAYS * 86400_000,
+  ).toISOString();
+
+  // 1. Pull stale draft plans owned by authed users.
+  const { data: plans, error: planErr } = await admin
+    .from("get_matched_action_plans")
+    .select("id, auth_user_id, goal, intent_slug, share_token, updated_at")
+    .eq("status", "draft")
+    .not("auth_user_id", "is", null)
+    .lt("updated_at", draftCutoff)
+    .order("updated_at", { ascending: false })
+    .limit(500);
+
+  if (planErr) {
+    log.error("plan fetch failed", { error: planErr.message });
+    return NextResponse.json({ error: planErr.message }, { status: 500 });
+  }
+
+  if (!plans || plans.length === 0) {
+    return NextResponse.json({ sent: 0, message: "no stale drafts" });
+  }
+
+  const userIds = Array.from(
+    new Set(plans.map((p) => p.auth_user_id as string)),
+  );
+
+  // 2. Skip users who got the digest in the last DEDUP_WINDOW_DAYS.
+  const { data: recent } = await admin
+    .from("plan_resume_emails")
+    .select("auth_user_id")
+    .in("auth_user_id", userIds)
+    .gte("sent_at", dedupCutoff);
+
+  const recentSet = new Set((recent ?? []).map((r) => r.auth_user_id as string));
+
+  // 3. Resolve emails — one email per user, pick the most recently
+  //    updated plan so the copy references the freshest goal.
+  const byUser = new Map<string, (typeof plans)[number]>();
+  for (const p of plans) {
+    const uid = p.auth_user_id as string;
+    if (!byUser.has(uid)) byUser.set(uid, p);
+  }
+
+  const targetUserIds = Array.from(byUser.keys()).filter(
+    (uid) => !shouldSkip({ auth_user_id: uid }, recentSet),
+  );
+
+  if (targetUserIds.length === 0) {
+    return NextResponse.json({ sent: 0, message: "all deduped" });
+  }
+
+  const { data: users } = await admin.auth.admin.listUsers({
+    page: 1,
+    perPage: Math.min(targetUserIds.length * 2, 1000),
+  });
+
+  const emailByUser = new Map<string, string>();
+  for (const u of users?.users ?? []) {
+    if (u.id && u.email && targetUserIds.includes(u.id)) {
+      emailByUser.set(u.id, u.email);
+    }
+  }
+
+  let sent = 0;
+  let failed = 0;
+  for (const uid of targetUserIds) {
+    const plan = byUser.get(uid)!;
+    const email = emailByUser.get(uid);
+    if (!email) continue;
+    const candidate: DigestCandidate = {
+      plan_id: plan.id as number,
+      auth_user_id: uid,
+      email,
+      goal: (plan.goal as string | null) ?? null,
+      intent_slug: (plan.intent_slug as string | null) ?? null,
+      share_token: plan.share_token as string,
+      updated_at: plan.updated_at as string,
+    };
+    const { subject, html } = renderDigestEmail({
+      goal: candidate.goal,
+      intent_slug: candidate.intent_slug,
+      share_token: candidate.share_token,
+      baseUrl,
+    });
+    const result = await sendEmail({ to: email, subject, html });
+    if (result.ok) {
+      sent += 1;
+      const { error: insertErr } = await admin
+        .from("plan_resume_emails")
+        .insert({ auth_user_id: uid, plan_id: candidate.plan_id });
+      if (insertErr) {
+        log.warn("dedup insert failed", { uid, err: insertErr.message });
+      }
+    } else {
+      failed += 1;
+      log.warn("send failed", { uid, err: result.error });
+    }
+  }
+
+  return NextResponse.json({ sent, failed, scanned: plans.length });
+}

--- a/lib/account/plan-resume-digest.ts
+++ b/lib/account/plan-resume-digest.ts
@@ -1,0 +1,67 @@
+/**
+ * Plan-resume-digest helpers — selects the draft action plans that
+ * deserve a "pick up where you left off" nudge and renders the email.
+ *
+ * Selection rules (all must hold):
+ *   - status = 'draft'
+ *   - auth_user_id IS NOT NULL (we need someone to email)
+ *   - updated_at < now - 3 days (not actively in-flight)
+ *   - no plan_resume_emails row in the last 7 days for the user
+ *
+ * Pure rendering kept separate from the Supabase + send side so unit
+ * tests can pin the copy without mocking the DB.
+ */
+
+export interface DigestCandidate {
+  plan_id: number;
+  auth_user_id: string;
+  email: string;
+  goal: string | null;
+  intent_slug: string | null;
+  share_token: string;
+  updated_at: string;
+}
+
+export function renderDigestEmail(candidate: {
+  goal: string | null;
+  intent_slug: string | null;
+  share_token: string;
+  baseUrl: string;
+}): { subject: string; html: string } {
+  const goalLine = candidate.goal
+    ? candidate.goal
+    : candidate.intent_slug
+      ? candidate.intent_slug.replace(/_/g, " ")
+      : "your action plan";
+  const url = `${candidate.baseUrl.replace(/\/$/, "")}/plans/${candidate.share_token}`;
+  const subject = `Pick up where you left off — ${goalLine}`;
+  const html = `
+    <p>Hi,</p>
+    <p>You started building an investment action plan for <strong>${escapeHtml(goalLine)}</strong> but didn't finish.</p>
+    <p>It takes under a minute to wrap up, and you'll see your matched route + recommended next steps straight after.</p>
+    <p><a href="${url}" style="display:inline-block;background:#f59e0b;color:#0f172a;padding:12px 24px;border-radius:12px;text-decoration:none;font-weight:700;">Resume my plan</a></p>
+    <p style="color:#64748b;font-size:12px;margin-top:24px;">You're getting this because you saved a plan on Invest.com.au. Reply to opt out.</p>
+  `.trim();
+  return { subject, html };
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/**
+ * Decide whether a candidate should be skipped because we already
+ * emailed them recently. `recentSends` is the set of auth_user_id
+ * strings with a `plan_resume_emails` row in the last 7 days.
+ */
+export function shouldSkip(
+  candidate: { auth_user_id: string },
+  recentSends: Set<string>,
+): boolean {
+  return recentSends.has(candidate.auth_user_id);
+}

--- a/supabase/migrations/20260514_mm11_plan_resume_emails.sql
+++ b/supabase/migrations/20260514_mm11_plan_resume_emails.sql
@@ -1,0 +1,26 @@
+-- mm11_plan_resume_emails.sql
+-- Dedup ledger for the "pick up where you left off" re-engagement email.
+-- Cron /api/cron/plan-resume-digest finds get_matched_action_plans rows
+-- in status='draft' that have been quiet for >3 days, then sends an
+-- email to the owner — but only if we haven't already emailed them in
+-- the last 7 days. This table is the dedup record.
+--
+-- Rollback: DROP TABLE plan_resume_emails;
+
+CREATE TABLE IF NOT EXISTS plan_resume_emails (
+  id bigserial PRIMARY KEY,
+  auth_user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  plan_id bigint NOT NULL,
+  sent_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS plan_resume_emails_user_sent_idx
+  ON plan_resume_emails (auth_user_id, sent_at DESC);
+
+ALTER TABLE plan_resume_emails ENABLE ROW LEVEL SECURITY;
+
+-- Service-role-only — this table is internal cron bookkeeping, never
+-- exposed to authenticated reads.
+DROP POLICY IF EXISTS "plan_resume_emails_service_role" ON plan_resume_emails;
+CREATE POLICY "plan_resume_emails_service_role" ON plan_resume_emails
+  FOR ALL TO service_role USING (true) WITH CHECK (true);


### PR DESCRIPTION
## Summary

Daily cron `/api/cron/plan-resume-digest` finds Get Matched action plans in `status='draft'` owned by an authed user that haven't been touched in 3+ days, and emails the owner once per 7 days with a one-click resume link to `/plans/[share_token]`.

- New `plan_resume_emails` dedup ledger (service-role only RLS).
- `lib/account/plan-resume-digest.ts` keeps `renderDigestEmail` + `shouldSkip` as pure helpers so the copy and dedup logic are unit-tested.
- 7 vitest cases covering subject resolution, html escaping, dedup membership.

The goal: recover the ~30-40% of Get Matched starters who bounce mid-flow without ever seeing their action plan.

## Gates
- `tsc --noEmit` clean, `eslint --max-warnings 0` clean
- `npm run audit:rate-limits -- --strict` → 100%
- 7 new vitest cases pass

## Wiring (post-merge)
Add to `vercel.json` cron schedule:
```json
{ "path": "/api/cron/plan-resume-digest", "schedule": "0 23 * * *" }
```
(23:00 UTC = 9am AEST — same window as personalized-digest.)

## Test plan
- [ ] Locally: `curl -H "Authorization: Bearer $CRON_SECRET" /api/cron/plan-resume-digest` — confirm it returns `{sent, failed, scanned}`.
- [ ] Insert a fixture plan with `updated_at` 4 days ago, `status='draft'` — confirm one email sends.
- [ ] Re-run within 7 days — confirm `{sent: 0, message: "all deduped"}`.


---
_Generated by [Claude Code](https://claude.ai/code/session_015JmqgxgJAaVt9RrUQ8uvNf)_