### PR TITLE
feat(account): copy-link share button on saved action plans

### DIFF
--- a/app/account/plans/[id]/SharePlanButton.tsx
+++ b/app/account/plans/[id]/SharePlanButton.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useState } from "react";
+import Icon from "@/components/Icon";
+
+/**
+ * Copy-link button on /account/plans/[id]. The owner gets a public
+ * read-only URL (/plans/[share_token]) they can pass to a partner /
+ * adviser / family member to look over before turning it into a
+ * Match Request.
+ */
+export default function SharePlanButton({ shareToken }: { shareToken: string }) {
+  const [copied, setCopied] = useState(false);
+  const [showUrl, setShowUrl] = useState(false);
+
+  const baseUrl =
+    typeof window !== "undefined"
+      ? window.location.origin
+      : "https://invest.com.au";
+  const url = `${baseUrl}/plans/${shareToken}`;
+
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setShowUrl(true);
+    }
+  }
+
+  return (
+    <div className="inline-flex flex-col gap-1.5">
+      <button
+        type="button"
+        onClick={copy}
+        className="inline-flex items-center gap-2 bg-slate-100 hover:bg-slate-200 text-slate-800 font-semibold text-sm px-4 py-2.5 rounded-lg"
+      >
+        <Icon name={copied ? "check" : "link"} size={14} />
+        {copied ? "Link copied" : "Share plan"}
+      </button>
+      {showUrl && (
+        <input
+          type="text"
+          readOnly
+          value={url}
+          onFocus={(e) => e.currentTarget.select()}
+          className="text-xs text-slate-600 border border-slate-200 rounded px-2 py-1 max-w-xs"
+        />
+      )}
+    </div>
+  );
+}

--- a/app/account/plans/[id]/page.tsx
+++ b/app/account/plans/[id]/page.tsx
@@ -7,6 +7,7 @@ import { getPlanById } from "@/lib/getmatched/action-plans";
 import { getResultTemplate } from "@/lib/getmatched/templates";
 import type { IntentSlug, RouteType } from "@/lib/getmatched/types";
 import Icon from "@/components/Icon";
+import SharePlanButton from "./SharePlanButton";
 
 export const dynamic = "force-dynamic";
 
@@ -116,6 +117,7 @@ export default async function MyPlanDetailPage({
             >
               <Icon name="edit" size={14} /> Edit answers
             </Link>
+            <SharePlanButton shareToken={plan.share_token} />
           </div>
         </div>
 


### PR DESCRIPTION
## Summary

Adds a one-click "Share plan" button on `/account/plans/[id]` that copies the public `/plans/[share_token]` URL to the clipboard. The owner can hand the link to a partner/advisor/family member for review before turning the plan into a Match Request.

The read-only share infra (`share_token` column + `/plans/[token]` public page) already exists from Get Matched 2.0 — this just exposes the link from the authenticated detail page.

Falls back to a focusable input when the clipboard API is unavailable.

## Test plan
- [ ] Visit `/account/plans/[id]` while signed in → click Share plan → URL copied; button text flips to "Link copied" for 2s.
- [ ] Open the copied URL in an incognito window → loads the public read-only plan render.


---
_Generated by [Claude Code](https://claude.ai/code/session_015JmqgxgJAaVt9RrUQ8uvNf)_