### PR TITLE
chore(cron): wire plan-resume-digest + saved-search-alerts into daily-23 dispatcher

### DIFF
--- a/__tests__/lib/cron-groups.test.ts
+++ b/__tests__/lib/cron-groups.test.ts
@@ -41,4 +41,10 @@ describe("CRON_GROUPS invariants", () => {
     expect(all).toContain("/api/cron/affiliate-payout-recon");
     expect(all).toContain("/api/cron/sponsored-placement-apply");
   });
+
+  it("registers the marketplace re-engagement crons", () => {
+    const all = Object.values(CRON_GROUPS).flat();
+    expect(all).toContain("/api/cron/plan-resume-digest");
+    expect(all).toContain("/api/cron/saved-search-alerts");
+  });
 });

--- a/lib/cron-groups.ts
+++ b/lib/cron-groups.ts
@@ -108,7 +108,11 @@ export const CRON_GROUPS: Record<string, readonly string[]> = {
   "daily-12": ["/api/cron/abandoned-form-drip", "/api/cron/exit-intent-nurture"],
   "daily-15": ["/api/cron/web-vitals-rollup"],
   "daily-16": ["/api/cron/attribution-rollup"],
-  "daily-23": ["/api/cron/quiz-follow-up"],
+  "daily-23": [
+    "/api/cron/quiz-follow-up",
+    "/api/cron/plan-resume-digest",
+    "/api/cron/saved-search-alerts",
+  ],
 
   "weekly-sun-0": ["/api/cron/rotate-featured-advisors"],
   "weekly-mon-3": [


### PR DESCRIPTION
## Summary

Two new daily cron handlers landed recently (`plan-resume-digest` in #838 and `saved-search-alerts` coming in #839) but they were missing from the `CRON_GROUPS` fan-out map in `lib/cron-groups.ts`, so Vercel would never invoke them — the cron secret check would pass, but the dispatcher would return 404 for an unknown group.

This wires both under the existing `daily-23` slot (9am AEST) — no new vercel.json schedule entry needed (we'd hit Vercel's 40-cron cap if we tried).

## Gates
- `tsc --noEmit` clean
- `eslint --max-warnings 0` clean


---
_Generated by [Claude Code](https://claude.ai/code/session_015JmqgxgJAaVt9RrUQ8uvNf)_