### PR TITLE
feat(holdings): add Stake / SelfWealth / NABTrade / IBKR CSV importers (W2.9)

### DIFF
--- a/__tests__/lib/holdings/csv-import/ibkr.test.ts
+++ b/__tests__/lib/holdings/csv-import/ibkr.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from "vitest";
+import { parseIbkrCsv } from "@/lib/holdings/csv-import/ibkr";
+
+// Minimal IBKR Activity Statement shape: irrelevant sections before
+// Trades, then the Trades section with a Header and a few Data rows.
+const STATEMENT_PREAMBLE = [
+  "Statement,Header,Field Name,Field Value",
+  "Statement,Data,BrokerName,Interactive Brokers",
+  "Account Information,Header,Field Name,Field Value",
+  "Account Information,Data,AccountAlias,test-account",
+].join("\n");
+
+const TRADES_HEADER =
+  "Trades,Header,DataDiscriminator,Asset Category,Currency,Symbol,Date/Time,Quantity,T. Price,C. Price,Proceeds,Comm/Fee,Basis,Realized P/L,MTM P/L,Code";
+
+function buildStatement(...tradeDataRows: string[]): string {
+  return [STATEMENT_PREAMBLE, TRADES_HEADER, ...tradeDataRows].join("\n");
+}
+
+describe("parseIbkrCsv", () => {
+  it("parses two Stocks BUY orders and infers exchange by currency", () => {
+    const csv = buildStatement(
+      'Trades,Data,Order,Stocks,USD,AAPL,"2026-01-15, 10:30:00",100,150.25,151.00,-15025,-1.00,15026,0,75,O',
+      'Trades,Data,Order,Stocks,AUD,BHP,"2026-02-20, 09:45:00",50,45.10,45.20,-2255,-7.50,2262.50,0,5,O',
+    );
+    const { rows, errors } = parseIbkrCsv(csv);
+    expect(errors).toEqual([]);
+    expect(rows).toHaveLength(2);
+
+    const [r0, r1] = rows;
+    expect(r0?.ticker).toBe("AAPL");
+    expect(r0?.exchange).toBe("NASDAQ");
+    expect(r0?.shares).toBe(100);
+    expect(r0?.cost_basis_per_share_cents).toBe(15025);
+    expect(r0?.acquired_at).toBe("2026-01-15");
+    expect(r0?.broker_slug).toBe("ibkr");
+
+    expect(r1?.ticker).toBe("BHP");
+    expect(r1?.exchange).toBe("ASX");
+  });
+
+  it("skips SubTotal / Total aggregation rows silently", () => {
+    const csv = buildStatement(
+      'Trades,Data,Order,Stocks,USD,AAPL,"2026-01-15, 10:30:00",100,150.00,150.00,-15000,-1.00,15001,0,0,O',
+      "Trades,SubTotal,,Stocks,USD,AAPL,,100,,,-15000,-1.00,15001,0,0,",
+      "Trades,Total,,Stocks,USD,,,,,,,-15000,-1.00,15001,0,0,",
+    );
+    const { rows, errors } = parseIbkrCsv(csv);
+    expect(rows).toHaveLength(1);
+    expect(errors).toEqual([]);
+  });
+
+  it("surfaces negative-quantity (SELL) rows as skipped errors", () => {
+    const csv = buildStatement(
+      'Trades,Data,Order,Stocks,USD,AAPL,"2026-01-15, 10:30:00",100,150.00,150.00,-15000,-1.00,15001,0,0,O',
+      'Trades,Data,Order,Stocks,USD,AAPL,"2026-02-15, 10:30:00",-50,160.00,160.00,8000,-1.00,-7501,499,0,C',
+    );
+    const { rows, errors } = parseIbkrCsv(csv);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.ticker).toBe("AAPL");
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.reason).toMatch(/SELL/);
+  });
+
+  it("skips non-stock asset categories with a clear error", () => {
+    const csv = buildStatement(
+      'Trades,Data,Order,Equity and Index Options,USD,AAPL  240119C00150000,"2026-01-10, 10:30:00",1,2.50,2.60,-250,-0.65,250.65,0,10,O',
+      'Trades,Data,Order,Stocks,USD,AAPL,"2026-01-15, 10:30:00",100,150.00,150.00,-15000,-1.00,15001,0,0,O',
+    );
+    const { rows, errors } = parseIbkrCsv(csv);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.ticker).toBe("AAPL");
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.reason).toMatch(/non-stock/);
+  });
+
+  it("maps currency to expected exchange", () => {
+    const csv = buildStatement(
+      'Trades,Data,Order,Stocks,GBP,VOD,"2026-01-15, 10:30:00",100,80.00,80.00,-8000,-1.00,8001,0,0,O',
+      'Trades,Data,Order,Stocks,HKD,0700,"2026-01-15, 10:30:00",100,330.00,330.00,-33000,-1.00,33001,0,0,O',
+      'Trades,Data,Order,Stocks,JPY,7203,"2026-01-15, 10:30:00",100,2500.00,2500.00,-250000,-1.00,250001,0,0,O',
+      'Trades,Data,Order,Stocks,SGD,D05,"2026-01-15, 10:30:00",100,30.00,30.00,-3000,-1.00,3001,0,0,O',
+    );
+    const { rows, errors } = parseIbkrCsv(csv);
+    expect(errors).toEqual([]);
+    expect(rows).toHaveLength(4);
+    expect(rows[0]?.exchange).toBe("LSE");
+    expect(rows[1]?.exchange).toBe("HKEX");
+    expect(rows[2]?.exchange).toBe("TYO");
+    expect(rows[3]?.exchange).toBe("SGX");
+  });
+
+  it("returns an error when the Trades section is absent", () => {
+    const { rows, errors } = parseIbkrCsv(STATEMENT_PREAMBLE);
+    expect(rows).toEqual([]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.reason).toMatch(/Trades.*Header/);
+  });
+
+  it("stops reading at the next section boundary", () => {
+    const csv =
+      [
+        STATEMENT_PREAMBLE,
+        TRADES_HEADER,
+        'Trades,Data,Order,Stocks,USD,AAPL,"2026-01-15, 10:30:00",10,150.00,150.00,-1500,-1.00,1501,0,0,O',
+        "Dividends,Header,Currency,Date,Description,Amount",
+        "Dividends,Data,USD,2026-03-01,AAPL Dividend,5.50",
+      ].join("\n");
+    const { rows, errors } = parseIbkrCsv(csv);
+    expect(rows).toHaveLength(1);
+    expect(errors).toEqual([]);
+  });
+
+  it("returns a cap error when Trades section exceeds 500 data rows", () => {
+    const row =
+      'Trades,Data,Order,Stocks,USD,AAPL,"2026-01-15, 10:30:00",1,150.00,150.00,-150,-1.00,151,0,0,O';
+    const csv = [STATEMENT_PREAMBLE, TRADES_HEADER, ...new Array(501).fill(row)].join(
+      "\n",
+    );
+    const { rows, errors } = parseIbkrCsv(csv);
+    expect(rows).toEqual([]);
+    expect(errors[0]?.reason).toMatch(/max 500/);
+  });
+
+  it("returns an explicit empty error for empty input", () => {
+    const { rows, errors } = parseIbkrCsv("");
+    expect(rows).toEqual([]);
+    expect(errors).toHaveLength(1);
+  });
+});

--- a/__tests__/lib/holdings/csv-import/nabtrade.test.ts
+++ b/__tests__/lib/holdings/csv-import/nabtrade.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import { parseNabTradeCsv } from "@/lib/holdings/csv-import/nabtrade";
+
+const HEADER =
+  "Trade Date,Settlement Date,Account,Order #,Action,Quantity,Symbol,Description,Price,Brokerage,GST,Amount,Currency";
+
+describe("parseNabTradeCsv", () => {
+  it("parses three Bought rows on ASX", () => {
+    const csv = [
+      HEADER,
+      "01/03/2026,03/03/2026,12345,A1,Bought,100,BHP,BHP Group Ltd,45.10,14.95,1.50,4510.00,AUD",
+      "15/03/2026,17/03/2026,12345,A2,Bought,50,CBA,Commonwealth Bank,109.50,14.95,1.50,5475.00,AUD",
+      "20/04/2026,22/04/2026,12345,A3,Bought,30,WBC,Westpac,30.10,14.95,1.50,903.00,AUD",
+    ].join("\n");
+
+    const { rows, errors } = parseNabTradeCsv(csv);
+    expect(errors).toEqual([]);
+    expect(rows).toHaveLength(3);
+
+    const [r0, r1, r2] = rows;
+    expect(r0?.ticker).toBe("BHP");
+    expect(r0?.exchange).toBe("ASX");
+    expect(r0?.shares).toBe(100);
+    expect(r0?.cost_basis_per_share_cents).toBe(4510);
+    expect(r0?.acquired_at).toBe("2026-03-01");
+    expect(r0?.broker_slug).toBe("nabtrade");
+
+    expect(r1?.ticker).toBe("CBA");
+    expect(r2?.cost_basis_per_share_cents).toBe(3010);
+  });
+
+  it("uses currency to route US orders to NASDAQ", () => {
+    const csv = [
+      HEADER,
+      "01/03/2026,03/03/2026,12345,A1,Bought,10,AAPL,Apple Inc.,150.00,9.95,0.00,1500.00,USD",
+      "01/03/2026,03/03/2026,12345,A2,Bought,5,VOD,Vodafone,80.00,9.95,0.00,400.00,GBP",
+    ].join("\n");
+    const { rows, errors } = parseNabTradeCsv(csv);
+    expect(errors).toEqual([]);
+    expect(rows[0]?.exchange).toBe("NASDAQ");
+    expect(rows[1]?.exchange).toBe("LSE");
+  });
+
+  it("surfaces Sold/Dividend rows as skipped errors", () => {
+    const csv = [
+      HEADER,
+      "01/03/2026,03/03/2026,12345,A1,Bought,100,BHP,BHP,45.00,14.95,1.50,4500.00,AUD",
+      "02/03/2026,04/03/2026,12345,A2,Sold,50,CBA,CBA,110.00,14.95,1.50,5500.00,AUD",
+      "03/03/2026,05/03/2026,12345,A3,Dividend,0,BHP,BHP dividend,1.45,0,0,145.00,AUD",
+    ].join("\n");
+    const { rows, errors } = parseNabTradeCsv(csv);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.ticker).toBe("BHP");
+    expect(errors).toHaveLength(2);
+    expect(errors[0]?.reason).toMatch(/non-BUY/);
+  });
+
+  it("rejects invalid date / quantity", () => {
+    const csv = [
+      HEADER,
+      "BAD-DATE,03/03/2026,12345,A1,Bought,100,BHP,BHP,45.00,14.95,1.50,4500.00,AUD",
+      "01/03/2026,03/03/2026,12345,A2,Bought,0,BHP,BHP,45.00,14.95,1.50,0,AUD",
+    ].join("\n");
+    const { rows, errors } = parseNabTradeCsv(csv);
+    expect(rows).toEqual([]);
+    expect(errors).toHaveLength(2);
+    expect(errors[0]?.reason).toMatch(/date/);
+    expect(errors[1]?.reason).toMatch(/quantity/);
+  });
+
+  it("accepts older Buy/Sell action vocab as fallback", () => {
+    const csv = [
+      HEADER,
+      "01/03/2026,03/03/2026,12345,A1,Buy,100,BHP,BHP,45.00,14.95,1.50,4500.00,AUD",
+    ].join("\n");
+    const { rows, errors } = parseNabTradeCsv(csv);
+    expect(errors).toEqual([]);
+    expect(rows).toHaveLength(1);
+  });
+
+  it("returns an error if the header is missing", () => {
+    const csv = "01/03/2026,03/03/2026,12345,A1,Bought,100,BHP,BHP,45.00,14.95,1.50,4500.00,AUD";
+    const { rows, errors } = parseNabTradeCsv(csv);
+    expect(rows).toEqual([]);
+    expect(errors[0]?.reason).toMatch(/header/);
+  });
+
+  it("returns a cap error when input exceeds 500 data rows", () => {
+    const row =
+      "01/03/2026,03/03/2026,12345,A1,Bought,1,BHP,BHP,45.00,14.95,1.50,45.00,AUD";
+    const csv = [HEADER, ...new Array(501).fill(row)].join("\n");
+    const { rows, errors } = parseNabTradeCsv(csv);
+    expect(rows).toEqual([]);
+    expect(errors[0]?.reason).toMatch(/max 500/);
+  });
+
+  it("returns an explicit empty error for empty input", () => {
+    const { rows, errors } = parseNabTradeCsv("");
+    expect(rows).toEqual([]);
+    expect(errors).toHaveLength(1);
+  });
+});

--- a/__tests__/lib/holdings/csv-import/selfwealth.test.ts
+++ b/__tests__/lib/holdings/csv-import/selfwealth.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import { parseSelfWealthCsv } from "@/lib/holdings/csv-import/selfwealth";
+
+const HEADER =
+  "Trade Date,Settlement Date,Account,Code,Order Type,Quantity,Price,Brokerage,Consideration,Net Value";
+
+describe("parseSelfWealthCsv", () => {
+  it("parses three BUY rows on ASX", () => {
+    const csv = [
+      HEADER,
+      "01/03/2026,03/03/2026,Trading,BHP,BUY,100,45.50,9.50,4550.00,4559.50",
+      "15/03/2026,17/03/2026,Trading,CBA,BUY,50,110.00,9.50,5500.00,5509.50",
+      "20/04/2026,22/04/2026,Trading,WBC,BUY,30,30.20,9.50,906.00,915.50",
+    ].join("\n");
+
+    const { rows, errors } = parseSelfWealthCsv(csv);
+    expect(errors).toEqual([]);
+    expect(rows).toHaveLength(3);
+
+    const [r0, r1, r2] = rows;
+    expect(r0?.ticker).toBe("BHP");
+    expect(r0?.exchange).toBe("ASX");
+    expect(r0?.shares).toBe(100);
+    expect(r0?.cost_basis_per_share_cents).toBe(4550);
+    expect(r0?.acquired_at).toBe("2026-03-01");
+    expect(r0?.broker_slug).toBe("selfwealth");
+
+    expect(r1?.ticker).toBe("CBA");
+    expect(r2?.cost_basis_per_share_cents).toBe(3020);
+  });
+
+  it("surfaces SELL rows as skipped errors", () => {
+    const csv = [
+      HEADER,
+      "01/03/2026,03/03/2026,Trading,BHP,BUY,100,45.50,9.50,4550.00,4559.50",
+      "02/03/2026,04/03/2026,Trading,CBA,SELL,50,111.00,9.50,5550.00,5540.50",
+    ].join("\n");
+    const { rows, errors } = parseSelfWealthCsv(csv);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.ticker).toBe("BHP");
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.reason).toMatch(/non-BUY/);
+  });
+
+  it("marks non-ASX-shaped codes as OTHER", () => {
+    const csv = [
+      HEADER,
+      "01/03/2026,03/03/2026,Trading,AAPL.US,BUY,10,150.00,9.50,1500.00,1509.50",
+    ].join("\n");
+    const { rows, errors } = parseSelfWealthCsv(csv);
+    expect(errors).toEqual([]);
+    expect(rows[0]?.exchange).toBe("OTHER");
+  });
+
+  it("rejects invalid quantity / price / date", () => {
+    const csv = [
+      HEADER,
+      "01/03/2026,03/03/2026,Trading,BHP,BUY,0,45.50,9.50,0,9.50",
+      "01/03/2026,03/03/2026,Trading,BHP,BUY,10,-5.00,9.50,-50.00,-40.50",
+      "BAD-DATE,03/03/2026,Trading,BHP,BUY,10,45.50,9.50,455.00,464.50",
+    ].join("\n");
+    const { rows, errors } = parseSelfWealthCsv(csv);
+    expect(rows).toEqual([]);
+    expect(errors).toHaveLength(3);
+    expect(errors[0]?.reason).toMatch(/quantity/);
+    expect(errors[1]?.reason).toMatch(/price/);
+    expect(errors[2]?.reason).toMatch(/date/);
+  });
+
+  it("returns an error if the header is missing", () => {
+    const csv = "01/03/2026,03/03/2026,Trading,BHP,BUY,100,45.50,9.50,4550.00,4559.50";
+    const { rows, errors } = parseSelfWealthCsv(csv);
+    expect(rows).toEqual([]);
+    expect(errors[0]?.reason).toMatch(/header/);
+  });
+
+  it("returns a cap error when input exceeds 500 data rows", () => {
+    const row = "01/03/2026,03/03/2026,Trading,BHP,BUY,1,45.50,9.50,45.50,55.00";
+    const csv = [HEADER, ...new Array(501).fill(row)].join("\n");
+    const { rows, errors } = parseSelfWealthCsv(csv);
+    expect(rows).toEqual([]);
+    expect(errors[0]?.reason).toMatch(/max 500/);
+  });
+
+  it("tolerates blank lines and CRLF line endings", () => {
+    const csv = [
+      HEADER,
+      "",
+      "01/03/2026,03/03/2026,Trading,BHP,BUY,100,45.50,9.50,4550.00,4559.50",
+      "",
+    ].join("\r\n");
+    const { rows, errors } = parseSelfWealthCsv(csv);
+    expect(rows).toHaveLength(1);
+    expect(errors).toEqual([]);
+  });
+
+  it("returns an explicit empty error for empty input", () => {
+    const { rows, errors } = parseSelfWealthCsv("");
+    expect(rows).toEqual([]);
+    expect(errors).toHaveLength(1);
+  });
+});

--- a/__tests__/lib/holdings/csv-import/stake.test.ts
+++ b/__tests__/lib/holdings/csv-import/stake.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import { parseStakeCsv } from "@/lib/holdings/csv-import/stake";
+
+const HEADER = "Date,Reference,Activity,Symbol,Description,Quantity,Price,Total,Currency";
+
+describe("parseStakeCsv", () => {
+  it("parses three BUY rows and infers exchange", () => {
+    const csv = [
+      HEADER,
+      "2026-03-01,T1,Buy,AAPL,Apple Inc.,10,150.25,1502.50,USD",
+      "2026-03-15,T2,Buy,MSFT,Microsoft Corp.,5,310.00,1550.00,USD",
+      "2026-04-20,T3,Buy,JNJ,Johnson & Johnson,7,160.00,1120.00,USD",
+    ].join("\n");
+
+    const { rows, errors } = parseStakeCsv(csv);
+    expect(errors).toEqual([]);
+    expect(rows).toHaveLength(3);
+
+    const [r0, r1, r2] = rows;
+    expect(r0?.ticker).toBe("AAPL");
+    expect(r0?.exchange).toBe("NASDAQ");
+    expect(r0?.shares).toBe(10);
+    expect(r0?.cost_basis_per_share_cents).toBe(15025);
+    expect(r0?.acquired_at).toBe("2026-03-01");
+    expect(r0?.broker_slug).toBe("stake");
+
+    expect(r1?.ticker).toBe("MSFT");
+    expect(r1?.exchange).toBe("NASDAQ");
+
+    expect(r2?.ticker).toBe("JNJ");
+    // JNJ is in the NYSE allowlist
+    expect(r2?.exchange).toBe("NYSE");
+  });
+
+  it("skips non-BUY activities and surfaces them as errors", () => {
+    const csv = [
+      HEADER,
+      "2026-03-01,T1,Buy,AAPL,Apple,10,150.00,1500.00,USD",
+      "2026-03-02,T2,Sell,AAPL,Apple,5,160.00,800.00,USD",
+      "2026-03-03,T3,Dividend,AAPL,Apple dividend,0,0,5.50,USD",
+      "2026-03-04,T4,Cash Deposit,,,0,0,1000.00,USD",
+    ].join("\n");
+    const { rows, errors } = parseStakeCsv(csv);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.ticker).toBe("AAPL");
+    expect(errors).toHaveLength(3);
+    expect(errors.every((e) => /non-BUY/.test(e.reason))).toBe(true);
+  });
+
+  it("tolerates $ prefix and thousands-separators on price/qty", () => {
+    const csv = [
+      HEADER,
+      '2026-03-01,T1,Buy,GOOG,"Alphabet Inc.","1,000","$2,750.50","2,750,500.00",USD',
+    ].join("\n");
+    const { rows, errors } = parseStakeCsv(csv);
+    expect(errors).toEqual([]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.shares).toBe(1000);
+    expect(rows[0]?.cost_basis_per_share_cents).toBe(275050);
+  });
+
+  it("rejects malformed dates and invalid tickers", () => {
+    const csv = [
+      HEADER,
+      "NOT-A-DATE,T1,Buy,AAPL,Apple,10,150.00,1500.00,USD",
+      "2026-03-02,T2,Buy,LONGTICKERZZ,Bad,1,1.00,1.00,USD",
+    ].join("\n");
+    const { rows, errors } = parseStakeCsv(csv);
+    expect(rows).toEqual([]);
+    expect(errors).toHaveLength(2);
+    expect(errors[0]?.reason).toMatch(/ticker|date/);
+    expect(errors[1]?.reason).toMatch(/ticker/);
+  });
+
+  it("returns an error if the header row is missing", () => {
+    const csv = "2026-03-01,T1,Buy,AAPL,Apple,10,150.00,1500.00,USD";
+    const { rows, errors } = parseStakeCsv(csv);
+    expect(rows).toEqual([]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.reason).toMatch(/header/);
+  });
+
+  it("accepts AU-style DD/MM/YYYY dates as a fallback", () => {
+    const csv = [
+      HEADER,
+      "01/03/2026,T1,Buy,AAPL,Apple,10,150.00,1500.00,USD",
+    ].join("\n");
+    const { rows, errors } = parseStakeCsv(csv);
+    expect(errors).toEqual([]);
+    expect(rows[0]?.acquired_at).toBe("2026-03-01");
+  });
+
+  it("returns a cap error when input exceeds 500 data rows", () => {
+    const buyRow = "2026-03-01,T1,Buy,AAPL,Apple,1,150.00,150.00,USD";
+    const csv = [HEADER, ...new Array(501).fill(buyRow)].join("\n");
+    const { rows, errors } = parseStakeCsv(csv);
+    expect(rows).toEqual([]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.reason).toMatch(/max 500/);
+  });
+
+  it("returns an explicit empty error for empty input", () => {
+    const { rows, errors } = parseStakeCsv("");
+    expect(rows).toEqual([]);
+    expect(errors).toHaveLength(1);
+  });
+});

--- a/app/account/holdings/CsvImportModal.tsx
+++ b/app/account/holdings/CsvImportModal.tsx
@@ -6,6 +6,10 @@ import { SUPPORTED_BROKER_SLUGS } from "@/lib/holdings/csv-import";
 
 const BROKER_LABELS: Record<(typeof SUPPORTED_BROKER_SLUGS)[number], string> = {
   commsec: "CommSec — Trading Account Transactions CSV",
+  stake: "Stake — Transactions / Trade History CSV",
+  selfwealth: "SelfWealth — Order History CSV",
+  nabtrade: "NABTrade — Transaction History CSV",
+  ibkr: "Interactive Brokers — Activity Statement CSV",
 };
 
 interface CsvParseError {

--- a/lib/holdings/csv-import/_utils.ts
+++ b/lib/holdings/csv-import/_utils.ts
@@ -1,0 +1,105 @@
+/**
+ * Shared helpers for broker CSV parsers.
+ *
+ * Each parser is otherwise self-contained — these helpers exist to keep
+ * the boilerplate (CSV line splitting, header detection, date parsing,
+ * row truncation) in one place so new brokers don't drift into subtly
+ * different behaviours over time.
+ */
+
+/**
+ * Minimal CSV line splitter: handles double-quoted fields containing
+ * commas. Good enough for broker exports we've seen — we don't try to be
+ * a fully general RFC-4180 parser. Adjacent quotes inside a quoted field
+ * are not interpreted as an escape; no broker we support uses that.
+ */
+export function splitCsvLine(line: string): string[] {
+  const out: string[] = [];
+  let cur = "";
+  let inQuote = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (ch === '"') {
+      inQuote = !inQuote;
+      continue;
+    }
+    if (ch === "," && !inQuote) {
+      out.push(cur);
+      cur = "";
+      continue;
+    }
+    cur += ch;
+  }
+  out.push(cur);
+  return out.map((c) => c.trim());
+}
+
+/** Bound `rawRow` length in error payloads so a runaway file can't blow
+ *  up the response. */
+export function truncate(s: string, max = 200): string {
+  return s.length <= max ? s : `${s.slice(0, max)}…`;
+}
+
+/** Parse `DD/MM/YYYY` or `DD/MM/YY` (the AU broker default). Two-digit
+ *  years ≥50 map to 19xx, otherwise 20xx — matching the convention used
+ *  by CommSec's legacy exports. */
+export function parseAuDate(raw: string): string | null {
+  const m = /^\s*(\d{1,2})\/(\d{1,2})\/(\d{2}|\d{4})\s*$/.exec(raw);
+  if (!m) return null;
+  const day = Number(m[1]);
+  const month = Number(m[2]);
+  let year = Number(m[3]);
+  if (!Number.isFinite(day) || !Number.isFinite(month) || !Number.isFinite(year)) {
+    return null;
+  }
+  if (year < 100) year = year >= 50 ? 1900 + year : 2000 + year;
+  return assembleDate(year, month, day);
+}
+
+/** Parse `YYYY-MM-DD` (ISO) — IBKR, Stake newer exports. Also tolerates
+ *  a trailing time portion separated by space, comma, or `T`. */
+export function parseIsoDate(raw: string): string | null {
+  const m = /^\s*(\d{4})-(\d{1,2})-(\d{1,2})(?:[ T,].*)?$/.exec(raw);
+  if (!m) return null;
+  return assembleDate(Number(m[1]), Number(m[2]), Number(m[3]));
+}
+
+/** Try ISO first, fall back to AU. Brokers occasionally tweak their
+ *  exports — being permissive on date format costs us nothing. */
+export function parseFlexibleDate(raw: string): string | null {
+  return parseIsoDate(raw) ?? parseAuDate(raw);
+}
+
+function assembleDate(year: number, month: number, day: number): string | null {
+  if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) {
+    return null;
+  }
+  if (month < 1 || month > 12) return null;
+  if (day < 1 || day > 31) return null;
+  // Reject obviously bogus calendar dates (e.g. 31/02). Cheap round-trip.
+  const d = new Date(Date.UTC(year, month - 1, day));
+  if (
+    d.getUTCFullYear() !== year ||
+    d.getUTCMonth() !== month - 1 ||
+    d.getUTCDate() !== day
+  ) {
+    return null;
+  }
+  const yyyy = String(year).padStart(4, "0");
+  const mm = String(month).padStart(2, "0");
+  const dd = String(day).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+/** Strip currency symbols, thousands-separators, and stray whitespace
+ *  before `Number()`-ing a price/amount cell. */
+export function parseMoney(raw: string): number {
+  if (!raw) return NaN;
+  const cleaned = raw.replace(/[A-Za-z$£€¥,\s]/g, "");
+  return Number(cleaned);
+}
+
+/** Hard limit on data rows per import. Bulk migrations aren't the
+ *  intended UX; the 500K-char body cap on the route already gates this
+ *  but we want a friendly error rather than a silent truncation. */
+export const MAX_INPUT_ROWS = 500;

--- a/lib/holdings/csv-import/ibkr.ts
+++ b/lib/holdings/csv-import/ibkr.ts
@@ -1,0 +1,273 @@
+/**
+ * Interactive Brokers Activity Statement CSV parser.
+ *
+ * IBKR's Activity Statement is a multi-section file — each section
+ * starts with a row beginning `<Section>,Header,...` followed by zero
+ * or more `<Section>,Data,...` rows. We care only about the `Trades`
+ * section, which has columns (the relevant ones):
+ *
+ *   Trades, Header, DataDiscriminator, Asset Category, Currency,
+ *   Symbol, Date/Time, Quantity, T. Price, ...
+ *
+ * Data rows for individual trade executions have
+ * `DataDiscriminator='Order'`; aggregation rows use `Total` /
+ * `SubTotal` / `Header` and are skipped.
+ *
+ * We only accept Stocks asset category (skip options, futures, forex,
+ * bonds, CFDs). BUY rows have positive `Quantity`; SELLs are negative
+ * and are surfaced as a skipped-row error.
+ *
+ * Multi-currency: IBKR is global. We use the `Currency` column to
+ * route the holding to the most-likely exchange:
+ *   USD → NASDAQ (default for US stocks; user can correct to NYSE)
+ *   AUD → ASX
+ *   GBP → LSE, HKD → HKEX, SGD → SGX, JPY → TYO, KRW → KRX
+ *   anything else → OTHER
+ *
+ * The parser is pure: no DB / network / fs access.
+ */
+
+import type {
+  BrokerCsvParser,
+  CsvParseError,
+  CsvParseResult,
+  ParsedHoldingRow,
+} from "./types";
+import {
+  MAX_INPUT_ROWS,
+  parseFlexibleDate,
+  parseMoney,
+  splitCsvLine,
+  truncate,
+} from "./_utils";
+
+const IBKR_BROKER_SLUG = "ibkr";
+
+function indexOf(headers: readonly string[], ...names: readonly string[]): number {
+  const targets = names.map((n) => n.toLowerCase());
+  for (let i = 0; i < headers.length; i++) {
+    if (targets.includes((headers[i] ?? "").toLowerCase())) return i;
+  }
+  return -1;
+}
+
+function inferExchange(currency: string): ParsedHoldingRow["exchange"] {
+  switch (currency.toUpperCase()) {
+    case "USD":
+      return "NASDAQ";
+    case "AUD":
+      return "ASX";
+    case "GBP":
+      return "LSE";
+    case "HKD":
+      return "HKEX";
+    case "SGD":
+      return "SGX";
+    case "JPY":
+      return "TYO";
+    case "KRW":
+      return "KRX";
+    default:
+      return "OTHER";
+  }
+}
+
+export const parseIbkrCsv: BrokerCsvParser = (csvText: string): CsvParseResult => {
+  const rows: ParsedHoldingRow[] = [];
+  const errors: CsvParseError[] = [];
+
+  if (!csvText || typeof csvText !== "string") {
+    return { rows, errors: [{ rowIndex: 0, rawRow: "", reason: "empty CSV" }] };
+  }
+
+  const rawLines = csvText.split(/\r?\n/);
+
+  // Find the most recent Trades-section header. IBKR can repeat headers
+  // mid-file (for subtotals); the last one before the data rows is the
+  // canonical one. We index headers by section.
+  let tradesHeader: string[] | null = null;
+  let tradesHeaderRowIdx = -1;
+
+  for (let i = 0; i < rawLines.length; i++) {
+    const line = (rawLines[i] ?? "").trim();
+    if (line.length === 0) continue;
+    const cells = splitCsvLine(line);
+    if (cells[0] === "Trades" && cells[1] === "Header") {
+      tradesHeader = cells;
+      tradesHeaderRowIdx = i;
+      break;
+    }
+  }
+
+  if (!tradesHeader || tradesHeaderRowIdx === -1) {
+    return {
+      rows,
+      errors: [
+        {
+          rowIndex: 0,
+          rawRow: "",
+          reason: "could not find Trades,Header row — is this an IBKR Activity Statement CSV?",
+        },
+      ],
+    };
+  }
+
+  const colDiscriminator = indexOf(tradesHeader, "DataDiscriminator");
+  const colAssetCategory = indexOf(tradesHeader, "Asset Category");
+  const colCurrency = indexOf(tradesHeader, "Currency");
+  const colSymbol = indexOf(tradesHeader, "Symbol");
+  const colDateTime = indexOf(tradesHeader, "Date/Time", "DateTime");
+  const colQty = indexOf(tradesHeader, "Quantity");
+  const colPrice = indexOf(tradesHeader, "T. Price", "Price", "TradePrice");
+
+  if (
+    colDiscriminator === -1 ||
+    colAssetCategory === -1 ||
+    colCurrency === -1 ||
+    colSymbol === -1 ||
+    colDateTime === -1 ||
+    colQty === -1 ||
+    colPrice === -1
+  ) {
+    return {
+      rows,
+      errors: [
+        {
+          rowIndex: tradesHeaderRowIdx + 1,
+          rawRow: truncate(rawLines[tradesHeaderRowIdx] ?? ""),
+          reason: "IBKR Trades header is missing one of DataDiscriminator / Asset Category / Currency / Symbol / Date/Time / Quantity / T. Price",
+        },
+      ],
+    };
+  }
+
+  // Collect data rows from the Trades section. IBKR section ends when
+  // we hit a row whose first cell != "Trades". We do not require strict
+  // contiguity (some exports have blank lines between sections).
+  const dataLines: { line: string; rowIndex: number; cells: string[] }[] = [];
+  for (let i = tradesHeaderRowIdx + 1; i < rawLines.length; i++) {
+    const line = (rawLines[i] ?? "").trim();
+    if (line.length === 0) continue;
+    const cells = splitCsvLine(line);
+    if (cells[0] !== "Trades") {
+      // Section change — done with Trades.
+      break;
+    }
+    if (cells[1] === "Header") {
+      // A second Trades,Header signals subtotal blocks; the canonical
+      // one is the first. Subsequent ones can be safely skipped here.
+      continue;
+    }
+    dataLines.push({ line, rowIndex: i + 1, cells });
+  }
+
+  if (dataLines.length > MAX_INPUT_ROWS) {
+    return {
+      rows: [],
+      errors: [
+        {
+          rowIndex: 0,
+          rawRow: "",
+          reason: `CSV has ${dataLines.length} trade rows; max ${MAX_INPUT_ROWS} per import. Split the file and re-upload.`,
+        },
+      ],
+    };
+  }
+
+  for (const { line, rowIndex, cells } of dataLines) {
+    if (
+      cells.length <= Math.max(
+        colDiscriminator,
+        colAssetCategory,
+        colCurrency,
+        colSymbol,
+        colDateTime,
+        colQty,
+        colPrice,
+      )
+    ) {
+      errors.push({ rowIndex, rawRow: truncate(line), reason: "row has too few columns" });
+      continue;
+    }
+
+    const discriminator = (cells[colDiscriminator] ?? "").toLowerCase();
+    if (discriminator !== "order") {
+      // SubTotal / Total / Notes — not individual executions. Skip
+      // silently; surfacing every aggregation row as an error would
+      // drown the user in noise.
+      continue;
+    }
+
+    const assetCategory = (cells[colAssetCategory] ?? "").toLowerCase();
+    if (assetCategory !== "stocks") {
+      errors.push({
+        rowIndex,
+        rawRow: truncate(line),
+        reason: `non-stock asset category skipped (${cells[colAssetCategory]})`,
+      });
+      continue;
+    }
+
+    const ticker = (cells[colSymbol] ?? "").toUpperCase();
+    if (ticker.length === 0) {
+      errors.push({ rowIndex, rawRow: truncate(line), reason: "missing ticker" });
+      continue;
+    }
+
+    const sharesRaw = (cells[colQty] ?? "").replace(/,/g, "");
+    const shares = Number(sharesRaw);
+    if (!Number.isFinite(shares) || shares === 0) {
+      errors.push({
+        rowIndex,
+        rawRow: truncate(line),
+        reason: `invalid quantity: ${cells[colQty]}`,
+      });
+      continue;
+    }
+    if (shares < 0) {
+      errors.push({
+        rowIndex,
+        rawRow: truncate(line),
+        reason: "SELL rows (negative quantity) are not imported as holdings",
+      });
+      continue;
+    }
+
+    const price = parseMoney(cells[colPrice] ?? "");
+    if (!Number.isFinite(price) || price < 0) {
+      errors.push({
+        rowIndex,
+        rawRow: truncate(line),
+        reason: `invalid price: ${cells[colPrice]}`,
+      });
+      continue;
+    }
+
+    // IBKR Date/Time looks like `2026-01-15, 10:30:00`; strip the time
+    // half before parsing.
+    const dateOnly = (cells[colDateTime] ?? "").split(/[, ]/)[0] ?? "";
+    const acquiredAt = parseFlexibleDate(dateOnly);
+    if (!acquiredAt) {
+      errors.push({
+        rowIndex,
+        rawRow: truncate(line),
+        reason: `unparseable date: ${cells[colDateTime]}`,
+      });
+      continue;
+    }
+
+    const currency = (cells[colCurrency] ?? "").trim();
+
+    rows.push({
+      ticker,
+      exchange: inferExchange(currency),
+      shares,
+      cost_basis_per_share_cents: Math.round(price * 100),
+      acquired_at: acquiredAt,
+      broker_slug: IBKR_BROKER_SLUG,
+      notes: null,
+    });
+  }
+
+  return { rows, errors };
+};

--- a/lib/holdings/csv-import/index.ts
+++ b/lib/holdings/csv-import/index.ts
@@ -11,13 +11,27 @@
  * `investor_holdings.broker_slug` back to a known broker in the DB.
  */
 import { parseCommSecCsv } from "./commsec";
+import { parseIbkrCsv } from "./ibkr";
+import { parseNabTradeCsv } from "./nabtrade";
+import { parseSelfWealthCsv } from "./selfwealth";
+import { parseStakeCsv } from "./stake";
 import type { BrokerCsvParser } from "./types";
 
-export const SUPPORTED_BROKER_SLUGS = ["commsec"] as const;
+export const SUPPORTED_BROKER_SLUGS = [
+  "commsec",
+  "stake",
+  "selfwealth",
+  "nabtrade",
+  "ibkr",
+] as const;
 export type SupportedBrokerSlug = (typeof SUPPORTED_BROKER_SLUGS)[number];
 
 export const CSV_IMPORT_PARSERS: Readonly<Record<SupportedBrokerSlug, BrokerCsvParser>> = {
   commsec: parseCommSecCsv,
+  stake: parseStakeCsv,
+  selfwealth: parseSelfWealthCsv,
+  nabtrade: parseNabTradeCsv,
+  ibkr: parseIbkrCsv,
 };
 
 export function getCsvImportParser(slug: SupportedBrokerSlug): BrokerCsvParser {

--- a/lib/holdings/csv-import/nabtrade.ts
+++ b/lib/holdings/csv-import/nabtrade.ts
@@ -1,0 +1,222 @@
+/**
+ * NABTrade Transaction History CSV parser.
+ *
+ * Real-world NABTrade export columns (Transactions → Export CSV):
+ *
+ *   Trade Date, Settlement Date, Account, Order #, Action, Quantity,
+ *   Symbol, Description, Price, Brokerage, GST, Amount, Currency
+ *
+ * Action values: `Bought` / `Sold` / `Dividend` / `Interest` / `Fee`.
+ * Only `Bought` rows become holdings.
+ *
+ * NABTrade supports ASX (default) plus a separate US/International tab —
+ * when the export includes a `Currency` column we use it to disambiguate
+ * the exchange. ASX-shaped tickers default to ASX; everything else falls
+ * back to OTHER and the user can correct in the holdings UI.
+ *
+ * The parser is pure: no DB / network / fs access.
+ */
+
+import type {
+  BrokerCsvParser,
+  CsvParseError,
+  CsvParseResult,
+  ParsedHoldingRow,
+} from "./types";
+import {
+  MAX_INPUT_ROWS,
+  parseFlexibleDate,
+  parseMoney,
+  splitCsvLine,
+  truncate,
+} from "./_utils";
+
+const NABTRADE_BROKER_SLUG = "nabtrade";
+
+function looksLikeNabTradeHeader(cells: readonly string[]): boolean {
+  const joined = cells.join(",").toLowerCase();
+  return (
+    (joined.includes("trade date") || joined.includes("date")) &&
+    joined.includes("action") &&
+    joined.includes("symbol") &&
+    joined.includes("quantity") &&
+    joined.includes("price")
+  );
+}
+
+function indexOfHeader(headers: readonly string[], ...names: readonly string[]): number {
+  const targets = names.map((n) => n.toLowerCase());
+  for (let i = 0; i < headers.length; i++) {
+    if (targets.includes((headers[i] ?? "").toLowerCase())) return i;
+  }
+  return -1;
+}
+
+function inferExchange(ticker: string, currency: string | null): ParsedHoldingRow["exchange"] {
+  const upperCurrency = (currency ?? "").toUpperCase();
+  if (upperCurrency === "AUD") {
+    return /^[A-Z]{3,4}$/.test(ticker) ? "ASX" : "OTHER";
+  }
+  if (upperCurrency === "USD") {
+    // NABTrade routes US orders to NASDAQ + NYSE; without an exchange
+    // column we pick NASDAQ as the default. The user can correct.
+    return "NASDAQ";
+  }
+  if (upperCurrency === "GBP") return "LSE";
+  if (upperCurrency === "HKD") return "HKEX";
+  if (upperCurrency === "SGD") return "SGX";
+  if (upperCurrency === "JPY") return "TYO";
+  return /^[A-Z]{3,4}$/.test(ticker) ? "ASX" : "OTHER";
+}
+
+export const parseNabTradeCsv: BrokerCsvParser = (csvText: string): CsvParseResult => {
+  const rows: ParsedHoldingRow[] = [];
+  const errors: CsvParseError[] = [];
+
+  if (!csvText || typeof csvText !== "string") {
+    return { rows, errors: [{ rowIndex: 0, rawRow: "", reason: "empty CSV" }] };
+  }
+
+  const rawLines = csvText.split(/\r?\n/);
+  let headerIdx = -1;
+  let headers: string[] = [];
+  for (let i = 0; i < rawLines.length; i++) {
+    const line = (rawLines[i] ?? "").trim();
+    if (line.length === 0) continue;
+    const cells = splitCsvLine(line);
+    if (looksLikeNabTradeHeader(cells)) {
+      headerIdx = i;
+      headers = cells;
+      break;
+    }
+  }
+
+  if (headerIdx === -1) {
+    return {
+      rows,
+      errors: [
+        {
+          rowIndex: 0,
+          rawRow: "",
+          reason: "could not find NABTrade header row (expected: Trade Date, Action, Symbol, Quantity, Price)",
+        },
+      ],
+    };
+  }
+
+  const colDate = indexOfHeader(headers, "Trade Date", "Date");
+  const colAction = indexOfHeader(headers, "Action", "Type", "Side");
+  const colSymbol = indexOfHeader(headers, "Symbol", "Code");
+  const colQty = indexOfHeader(headers, "Quantity", "Units");
+  const colPrice = indexOfHeader(headers, "Price", "Unit Price");
+  const colCurrency = indexOfHeader(headers, "Currency");
+
+  if (
+    colDate === -1 ||
+    colAction === -1 ||
+    colSymbol === -1 ||
+    colQty === -1 ||
+    colPrice === -1
+  ) {
+    return {
+      rows,
+      errors: [
+        {
+          rowIndex: headerIdx + 1,
+          rawRow: truncate(rawLines[headerIdx] ?? ""),
+          reason: "NABTrade header is missing one of Trade Date / Action / Symbol / Quantity / Price",
+        },
+      ],
+    };
+  }
+
+  const dataLines: { line: string; rowIndex: number }[] = [];
+  for (let i = headerIdx + 1; i < rawLines.length; i++) {
+    const line = (rawLines[i] ?? "").trim();
+    if (line.length === 0) continue;
+    dataLines.push({ line, rowIndex: i + 1 });
+  }
+
+  if (dataLines.length > MAX_INPUT_ROWS) {
+    return {
+      rows: [],
+      errors: [
+        {
+          rowIndex: 0,
+          rawRow: "",
+          reason: `CSV has ${dataLines.length} data rows; max ${MAX_INPUT_ROWS} per import. Split the file and re-upload.`,
+        },
+      ],
+    };
+  }
+
+  for (const { line, rowIndex } of dataLines) {
+    const cells = splitCsvLine(line);
+    if (cells.length <= Math.max(colDate, colAction, colSymbol, colQty, colPrice)) {
+      errors.push({ rowIndex, rawRow: truncate(line), reason: "row has too few columns" });
+      continue;
+    }
+
+    const action = (cells[colAction] ?? "").toLowerCase();
+    // NABTrade uses "Bought" / "Sold"; older exports use "Buy" / "Sell".
+    const isBuy = action === "bought" || action === "buy";
+    if (!isBuy) {
+      errors.push({
+        rowIndex,
+        rawRow: truncate(line),
+        reason: `non-BUY action skipped (${cells[colAction]})`,
+      });
+      continue;
+    }
+
+    const ticker = (cells[colSymbol] ?? "").toUpperCase();
+    if (ticker.length === 0) {
+      errors.push({ rowIndex, rawRow: truncate(line), reason: "missing ticker" });
+      continue;
+    }
+
+    const shares = Number((cells[colQty] ?? "").replace(/,/g, ""));
+    if (!Number.isFinite(shares) || shares <= 0) {
+      errors.push({
+        rowIndex,
+        rawRow: truncate(line),
+        reason: `invalid quantity: ${cells[colQty]}`,
+      });
+      continue;
+    }
+
+    const price = parseMoney(cells[colPrice] ?? "");
+    if (!Number.isFinite(price) || price < 0) {
+      errors.push({
+        rowIndex,
+        rawRow: truncate(line),
+        reason: `invalid price: ${cells[colPrice]}`,
+      });
+      continue;
+    }
+
+    const acquiredAt = parseFlexibleDate(cells[colDate] ?? "");
+    if (!acquiredAt) {
+      errors.push({
+        rowIndex,
+        rawRow: truncate(line),
+        reason: `unparseable date: ${cells[colDate]}`,
+      });
+      continue;
+    }
+
+    const currency = colCurrency === -1 ? null : (cells[colCurrency] ?? null);
+
+    rows.push({
+      ticker,
+      exchange: inferExchange(ticker, currency),
+      shares,
+      cost_basis_per_share_cents: Math.round(price * 100),
+      acquired_at: acquiredAt,
+      broker_slug: NABTRADE_BROKER_SLUG,
+      notes: null,
+    });
+  }
+
+  return { rows, errors };
+};

--- a/lib/holdings/csv-import/selfwealth.ts
+++ b/lib/holdings/csv-import/selfwealth.ts
@@ -1,0 +1,203 @@
+/**
+ * SelfWealth Order History CSV parser.
+ *
+ * Real-world SelfWealth export columns (Order History → "Download CSV"):
+ *
+ *   Trade Date, Settlement Date, Account, Code, Order Type, Quantity,
+ *   Price, Brokerage, Consideration, Net Value
+ *
+ * Order Type is `BUY` or `SELL`. SelfWealth is ASX-only on the local
+ * platform; their international tab uses a separate export which we
+ * don't try to disambiguate here — we mark non-ASX-shaped tickers as
+ * `OTHER` so the user can correct the exchange post-import.
+ *
+ * Dates are typically `DD/MM/YYYY`. Quantities are integer share counts.
+ *
+ * The parser is pure: no DB / network / fs access.
+ */
+
+import type {
+  BrokerCsvParser,
+  CsvParseError,
+  CsvParseResult,
+  ParsedHoldingRow,
+} from "./types";
+import {
+  MAX_INPUT_ROWS,
+  parseFlexibleDate,
+  parseMoney,
+  splitCsvLine,
+  truncate,
+} from "./_utils";
+
+const SELFWEALTH_BROKER_SLUG = "selfwealth";
+
+// ASX codes are 3-letter (occasionally 4). Anything outside that shape
+// is treated as `OTHER` so we don't mislabel international orders.
+const ASX_TICKER_RE = /^[A-Z]{3,4}$/;
+
+function looksLikeSelfWealthHeader(cells: readonly string[]): boolean {
+  const joined = cells.join(",").toLowerCase();
+  return (
+    (joined.includes("trade date") || joined.includes("date")) &&
+    joined.includes("code") &&
+    joined.includes("order type") &&
+    joined.includes("quantity") &&
+    joined.includes("price")
+  );
+}
+
+function indexOfHeader(headers: readonly string[], ...names: readonly string[]): number {
+  const targets = names.map((n) => n.toLowerCase());
+  for (let i = 0; i < headers.length; i++) {
+    if (targets.includes((headers[i] ?? "").toLowerCase())) return i;
+  }
+  return -1;
+}
+
+export const parseSelfWealthCsv: BrokerCsvParser = (csvText: string): CsvParseResult => {
+  const rows: ParsedHoldingRow[] = [];
+  const errors: CsvParseError[] = [];
+
+  if (!csvText || typeof csvText !== "string") {
+    return { rows, errors: [{ rowIndex: 0, rawRow: "", reason: "empty CSV" }] };
+  }
+
+  const rawLines = csvText.split(/\r?\n/);
+  let headerIdx = -1;
+  let headers: string[] = [];
+  for (let i = 0; i < rawLines.length; i++) {
+    const line = (rawLines[i] ?? "").trim();
+    if (line.length === 0) continue;
+    const cells = splitCsvLine(line);
+    if (looksLikeSelfWealthHeader(cells)) {
+      headerIdx = i;
+      headers = cells;
+      break;
+    }
+  }
+
+  if (headerIdx === -1) {
+    return {
+      rows,
+      errors: [
+        {
+          rowIndex: 0,
+          rawRow: "",
+          reason: "could not find SelfWealth header row (expected: Trade Date, Code, Order Type, Quantity, Price)",
+        },
+      ],
+    };
+  }
+
+  const colDate = indexOfHeader(headers, "Trade Date", "Date");
+  const colCode = indexOfHeader(headers, "Code", "Symbol");
+  const colOrderType = indexOfHeader(headers, "Order Type", "Type", "Side");
+  const colQty = indexOfHeader(headers, "Quantity", "Units");
+  const colPrice = indexOfHeader(headers, "Price", "Unit Price");
+
+  if (
+    colDate === -1 ||
+    colCode === -1 ||
+    colOrderType === -1 ||
+    colQty === -1 ||
+    colPrice === -1
+  ) {
+    return {
+      rows,
+      errors: [
+        {
+          rowIndex: headerIdx + 1,
+          rawRow: truncate(rawLines[headerIdx] ?? ""),
+          reason: "SelfWealth header is missing one of Trade Date / Code / Order Type / Quantity / Price",
+        },
+      ],
+    };
+  }
+
+  const dataLines: { line: string; rowIndex: number }[] = [];
+  for (let i = headerIdx + 1; i < rawLines.length; i++) {
+    const line = (rawLines[i] ?? "").trim();
+    if (line.length === 0) continue;
+    dataLines.push({ line, rowIndex: i + 1 });
+  }
+
+  if (dataLines.length > MAX_INPUT_ROWS) {
+    return {
+      rows: [],
+      errors: [
+        {
+          rowIndex: 0,
+          rawRow: "",
+          reason: `CSV has ${dataLines.length} data rows; max ${MAX_INPUT_ROWS} per import. Split the file and re-upload.`,
+        },
+      ],
+    };
+  }
+
+  for (const { line, rowIndex } of dataLines) {
+    const cells = splitCsvLine(line);
+    if (cells.length <= Math.max(colDate, colCode, colOrderType, colQty, colPrice)) {
+      errors.push({ rowIndex, rawRow: truncate(line), reason: "row has too few columns" });
+      continue;
+    }
+
+    const orderType = (cells[colOrderType] ?? "").toUpperCase();
+    if (orderType !== "BUY") {
+      errors.push({
+        rowIndex,
+        rawRow: truncate(line),
+        reason: `non-BUY order skipped (${cells[colOrderType]})`,
+      });
+      continue;
+    }
+
+    const ticker = (cells[colCode] ?? "").toUpperCase();
+    if (ticker.length === 0) {
+      errors.push({ rowIndex, rawRow: truncate(line), reason: "missing ticker" });
+      continue;
+    }
+
+    const shares = Number((cells[colQty] ?? "").replace(/,/g, ""));
+    if (!Number.isFinite(shares) || shares <= 0) {
+      errors.push({
+        rowIndex,
+        rawRow: truncate(line),
+        reason: `invalid quantity: ${cells[colQty]}`,
+      });
+      continue;
+    }
+
+    const price = parseMoney(cells[colPrice] ?? "");
+    if (!Number.isFinite(price) || price < 0) {
+      errors.push({
+        rowIndex,
+        rawRow: truncate(line),
+        reason: `invalid price: ${cells[colPrice]}`,
+      });
+      continue;
+    }
+
+    const acquiredAt = parseFlexibleDate(cells[colDate] ?? "");
+    if (!acquiredAt) {
+      errors.push({
+        rowIndex,
+        rawRow: truncate(line),
+        reason: `unparseable date: ${cells[colDate]}`,
+      });
+      continue;
+    }
+
+    rows.push({
+      ticker,
+      exchange: ASX_TICKER_RE.test(ticker) ? "ASX" : "OTHER",
+      shares,
+      cost_basis_per_share_cents: Math.round(price * 100),
+      acquired_at: acquiredAt,
+      broker_slug: SELFWEALTH_BROKER_SLUG,
+      notes: null,
+    });
+  }
+
+  return { rows, errors };
+};

--- a/lib/holdings/csv-import/stake.ts
+++ b/lib/holdings/csv-import/stake.ts
@@ -1,0 +1,245 @@
+/**
+ * Stake (AU) Trade History CSV parser.
+ *
+ * Stake AU is US-equities-only; tickers map to NASDAQ/NYSE. Their
+ * "Transactions" export columns are stable:
+ *
+ *   Date, Reference, Activity, Symbol, Description, Quantity, Price, Total, Currency
+ *
+ * Activity values we care about: `Buy` (kept as a holding). We surface
+ * everything else (`Sell`, `Dividend`, `Cash Deposit`, `FX`, etc.) as a
+ * skipped-row error so the user can see what didn't come through.
+ *
+ * Dates in the export are ISO (`YYYY-MM-DD`). Some legacy exports we've
+ * seen use DD/MM/YYYY — `parseFlexibleDate` covers both.
+ *
+ * The parser is pure: no DB / network / fs access.
+ */
+
+import type {
+  BrokerCsvParser,
+  CsvParseError,
+  CsvParseResult,
+  ParsedHoldingRow,
+} from "./types";
+import {
+  MAX_INPUT_ROWS,
+  parseFlexibleDate,
+  parseMoney,
+  splitCsvLine,
+  truncate,
+} from "./_utils";
+
+const STAKE_BROKER_SLUG = "stake";
+
+// US-listed ticker regex: 1-5 uppercase letters, optional dot-suffix
+// (`BRK.B`). We default to NASDAQ; a small list of well-known NYSE
+// tickers is overridden below — beyond that we don't try to disambiguate,
+// since the user can fix the exchange in the holdings UI if needed.
+const TICKER_RE = /^[A-Z]{1,5}(?:\.[A-Z])?$/;
+
+// Conservative NYSE allowlist for the most-traded names Australians hold
+// via Stake. Anything not on this list defaults to NASDAQ. Wrong-guess
+// cost is purely cosmetic — the cost basis is still correct.
+const NYSE_TICKERS = new Set([
+  "BAC",
+  "BRK.A",
+  "BRK.B",
+  "C",
+  "DIS",
+  "F",
+  "GE",
+  "GM",
+  "JNJ",
+  "JPM",
+  "KO",
+  "MCD",
+  "PFE",
+  "T",
+  "V",
+  "WFC",
+  "WMT",
+  "XOM",
+]);
+
+function inferStakeExchange(ticker: string): ParsedHoldingRow["exchange"] {
+  return NYSE_TICKERS.has(ticker) ? "NYSE" : "NASDAQ";
+}
+
+function looksLikeStakeHeader(cells: readonly string[]): boolean {
+  const joined = cells.join(",").toLowerCase();
+  return (
+    joined.includes("date") &&
+    (joined.includes("activity") || joined.includes("type")) &&
+    joined.includes("symbol")
+  );
+}
+
+/** Pull a column by case-insensitive header match. Returns -1 if not
+ *  found, so the caller can fall back to a positional index. */
+function indexOfHeader(headers: readonly string[], name: string): number {
+  const target = name.toLowerCase();
+  for (let i = 0; i < headers.length; i++) {
+    if ((headers[i] ?? "").toLowerCase() === target) return i;
+  }
+  return -1;
+}
+
+export const parseStakeCsv: BrokerCsvParser = (csvText: string): CsvParseResult => {
+  const rows: ParsedHoldingRow[] = [];
+  const errors: CsvParseError[] = [];
+
+  if (!csvText || typeof csvText !== "string") {
+    return { rows, errors: [{ rowIndex: 0, rawRow: "", reason: "empty CSV" }] };
+  }
+
+  const rawLines = csvText.split(/\r?\n/);
+
+  // Stake exports always include a header. Locate it, then read by name
+  // so order changes between export revisions don't break us.
+  let headerIdx = -1;
+  let headers: string[] = [];
+  for (let i = 0; i < rawLines.length; i++) {
+    const line = (rawLines[i] ?? "").trim();
+    if (line.length === 0) continue;
+    const cells = splitCsvLine(line);
+    if (looksLikeStakeHeader(cells)) {
+      headerIdx = i;
+      headers = cells;
+      break;
+    }
+  }
+
+  if (headerIdx === -1) {
+    return {
+      rows,
+      errors: [
+        {
+          rowIndex: 0,
+          rawRow: "",
+          reason: "could not find Stake header row (expected columns: Date, Activity, Symbol, Quantity, Price)",
+        },
+      ],
+    };
+  }
+
+  const colDate = indexOfHeader(headers, "Date");
+  const colActivity =
+    indexOfHeader(headers, "Activity") !== -1
+      ? indexOfHeader(headers, "Activity")
+      : indexOfHeader(headers, "Type");
+  const colSymbol = indexOfHeader(headers, "Symbol");
+  const colQty =
+    indexOfHeader(headers, "Quantity") !== -1
+      ? indexOfHeader(headers, "Quantity")
+      : indexOfHeader(headers, "Units");
+  const colPrice =
+    indexOfHeader(headers, "Price") !== -1
+      ? indexOfHeader(headers, "Price")
+      : indexOfHeader(headers, "Unit Price");
+
+  if (
+    colDate === -1 ||
+    colActivity === -1 ||
+    colSymbol === -1 ||
+    colQty === -1 ||
+    colPrice === -1
+  ) {
+    return {
+      rows,
+      errors: [
+        {
+          rowIndex: headerIdx + 1,
+          rawRow: truncate(rawLines[headerIdx] ?? ""),
+          reason: "Stake header is missing one of Date / Activity / Symbol / Quantity / Price",
+        },
+      ],
+    };
+  }
+
+  const dataLines: { line: string; rowIndex: number }[] = [];
+  for (let i = headerIdx + 1; i < rawLines.length; i++) {
+    const line = (rawLines[i] ?? "").trim();
+    if (line.length === 0) continue;
+    dataLines.push({ line, rowIndex: i + 1 });
+  }
+
+  if (dataLines.length > MAX_INPUT_ROWS) {
+    return {
+      rows: [],
+      errors: [
+        {
+          rowIndex: 0,
+          rawRow: "",
+          reason: `CSV has ${dataLines.length} data rows; max ${MAX_INPUT_ROWS} per import. Split the file and re-upload.`,
+        },
+      ],
+    };
+  }
+
+  for (const { line, rowIndex } of dataLines) {
+    const cells = splitCsvLine(line);
+    if (cells.length <= Math.max(colDate, colActivity, colSymbol, colQty, colPrice)) {
+      errors.push({ rowIndex, rawRow: truncate(line), reason: "row has too few columns" });
+      continue;
+    }
+
+    const activity = (cells[colActivity] ?? "").toLowerCase();
+    if (activity !== "buy") {
+      errors.push({
+        rowIndex,
+        rawRow: truncate(line),
+        reason: `non-BUY activity skipped (${cells[colActivity]})`,
+      });
+      continue;
+    }
+
+    const ticker = (cells[colSymbol] ?? "").toUpperCase();
+    if (!TICKER_RE.test(ticker)) {
+      errors.push({ rowIndex, rawRow: truncate(line), reason: `invalid ticker: ${ticker}` });
+      continue;
+    }
+
+    const shares = Number((cells[colQty] ?? "").replace(/,/g, ""));
+    if (!Number.isFinite(shares) || shares <= 0) {
+      errors.push({
+        rowIndex,
+        rawRow: truncate(line),
+        reason: `invalid quantity: ${cells[colQty]}`,
+      });
+      continue;
+    }
+
+    const price = parseMoney(cells[colPrice] ?? "");
+    if (!Number.isFinite(price) || price < 0) {
+      errors.push({
+        rowIndex,
+        rawRow: truncate(line),
+        reason: `invalid price: ${cells[colPrice]}`,
+      });
+      continue;
+    }
+
+    const acquiredAt = parseFlexibleDate(cells[colDate] ?? "");
+    if (!acquiredAt) {
+      errors.push({
+        rowIndex,
+        rawRow: truncate(line),
+        reason: `unparseable date: ${cells[colDate]}`,
+      });
+      continue;
+    }
+
+    rows.push({
+      ticker,
+      exchange: inferStakeExchange(ticker),
+      shares,
+      cost_basis_per_share_cents: Math.round(price * 100),
+      acquired_at: acquiredAt,
+      broker_slug: STAKE_BROKER_SLUG,
+      notes: null,
+    });
+  }
+
+  return { rows, errors };
+};


### PR DESCRIPTION
## Summary
Adds four broker CSV-import parsers (Stake, SelfWealth, NABTrade, IBKR) to complete W2.9 (X5e) — `/account/holdings` previously supported CommSec only.

## Why
W2.9 in `docs/plans/pre-launch-wave-master-prompt.md` calls for CommSec / Stake / SelfWealth / NABTrade / IBKR CSV import. Only CommSec had shipped; the status doc was carrying the row as "partial" with the rest "stubbed". Investors using any of the other four brokers had no way to bulk-load their holdings.

## Tier
**B** — additive parsers + dropdown labels. No schema changes, no payment / auth / webhook surface. Reuses the existing `/api/account/holdings/import-csv` route (RLS-scoped, user-cookie supabase client). 15-min Sentry/Vercel observation after merge.

## Files
- `lib/holdings/csv-import/_utils.ts` (new) — shared CSV-line splitter, flexible date parser, money parser, row-cap constant
- `lib/holdings/csv-import/stake.ts` (new)
- `lib/holdings/csv-import/selfwealth.ts` (new)
- `lib/holdings/csv-import/nabtrade.ts` (new)
- `lib/holdings/csv-import/ibkr.ts` (new)
- `lib/holdings/csv-import/index.ts` — register new parsers; `SUPPORTED_BROKER_SLUGS` widened from `["commsec"]` to all five
- `app/account/holdings/CsvImportModal.tsx` — `BROKER_LABELS` widened so the dropdown shows all five brokers
- `__tests__/lib/holdings/csv-import/{stake,selfwealth,nabtrade,ibkr}.test.ts` — 33 new tests (8/8/8/9)

## Design notes
- Each parser is a pure function (no DB / network), discovers its header row by column-name match so future export-format tweaks don't silently break.
- Non-BUY activity surfaces as an explicit skipped-row error so users see what wasn't imported.
- Capped at 500 data rows per upload (matches CommSec).
- Exchange inference uses the broker's currency column when present (NABTrade, IBKR); falls back to a conservative default the user can correct in the holdings UI.
- IBKR's multi-section Activity Statement: we scope strictly to the `Trades` section and stop reading at the next section boundary; SubTotal / Total aggregation rows are skipped silently to avoid drowning the user in noise.

## Supersedes
_None._

## Test plan
- [x] vitest local: `__tests__/lib/holdings/csv-import/` → **44/44 pass** (11 existing commsec + 33 new)
- [x] vitest local: `__tests__/api/holdings-import-csv.test.ts` → **7/7 pass** (registry expansion didn't break route tests)
- [x] type-check: `tsc --noEmit` clean
- [x] eslint: clean (lint-staged auto-formatted on commit)
- [ ] CI: pending
- [ ] Visual: in `/account/holdings`, "Import CSV from broker" dropdown should list all five brokers.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UxfXJpMoZ7eHKEGN8na6R7)_