### PR TITLE
feat(home): activity-aware section for returning users

### DIFF
--- a/__tests__/components/HomeActivitySection.test.tsx
+++ b/__tests__/components/HomeActivitySection.test.tsx
@@ -1,0 +1,249 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "./setup";
+
+// ─── Hoisted mocks ────────────────────────────────────────────────────────────
+
+const { mockGetUser, mockServerFrom, mockAdminFrom, mockGetLatestForUser } = vi.hoisted(() => ({
+  mockGetUser: vi.fn(),
+  mockServerFrom: vi.fn(),
+  mockAdminFrom: vi.fn(),
+  mockGetLatestForUser: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: () =>
+    Promise.resolve({
+      auth: { getUser: mockGetUser },
+      from: mockServerFrom,
+    }),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({ from: mockAdminFrom }),
+}));
+
+vi.mock("@/lib/quiz-history", () => ({
+  getLatestForUser: mockGetLatestForUser,
+}));
+
+import HomeActivitySection from "@/components/HomeActivitySection";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * A chainable builder that resolves to { count, error } when awaited.
+ * Mirrors the Supabase PostgREST filter builder shape used in the component.
+ */
+function makeCountChain(count: number | null, error: unknown = null) {
+  const result = { count, error };
+  const chain: Record<string, unknown> = {
+    select: () => chain,
+    eq: () => chain,
+    then: (
+      onFulfilled?: (value: unknown) => unknown,
+      onRejected?: (reason: unknown) => unknown,
+    ) => Promise.resolve(result).then(onFulfilled, onRejected),
+    catch: (onRejected?: (reason: unknown) => unknown) =>
+      Promise.resolve(result).catch(onRejected),
+    finally: (onFinally?: () => void) => Promise.resolve(result).finally(onFinally),
+  };
+  return chain;
+}
+
+/** A chainable builder that rejects when awaited (simulates a network failure). */
+function makeFailChain() {
+  const chain: Record<string, unknown> = {
+    select: () => chain,
+    eq: () => chain,
+    then: (_: unknown, onRejected?: (reason: unknown) => unknown) =>
+      Promise.reject(new Error("network failure")).then(undefined, onRejected),
+    catch: (onRejected?: (reason: unknown) => unknown) =>
+      Promise.reject(new Error("network failure")).catch(onRejected),
+    finally: (onFinally?: () => void) =>
+      Promise.reject(new Error("network failure")).finally(onFinally),
+  };
+  return chain;
+}
+
+const ANON = { data: { user: null } };
+const AUTH_USER = { data: { user: { id: "user-abc" } } };
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("HomeActivitySection", () => {
+  beforeEach(() => {
+    mockGetUser.mockReset();
+    mockServerFrom.mockReset();
+    mockAdminFrom.mockReset();
+    mockGetLatestForUser.mockReset();
+  });
+
+  it("returns null for anonymous users", async () => {
+    mockGetUser.mockResolvedValue(ANON);
+    expect(await HomeActivitySection()).toBeNull();
+    // No DB queries should fire
+    expect(mockServerFrom).not.toHaveBeenCalled();
+    expect(mockAdminFrom).not.toHaveBeenCalled();
+  });
+
+  it("returns null for authenticated users with no activity", async () => {
+    mockGetUser.mockResolvedValue(AUTH_USER);
+    mockServerFrom.mockReturnValue(makeCountChain(0));
+    mockAdminFrom.mockReturnValue(makeCountChain(0));
+    mockGetLatestForUser.mockResolvedValue(null);
+    expect(await HomeActivitySection()).toBeNull();
+  });
+
+  it("renders the shortlist card when the user has shortlisted brokers", async () => {
+    mockGetUser.mockResolvedValue(AUTH_USER);
+    mockServerFrom.mockReturnValue(makeCountChain(3));
+    mockAdminFrom.mockReturnValue(makeCountChain(0));
+    mockGetLatestForUser.mockResolvedValue(null);
+
+    const ui = await HomeActivitySection();
+    render(<>{ui}</>);
+
+    expect(screen.getByText("3 brokers in your shortlist")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /3 brokers in your shortlist/i })).toHaveAttribute(
+      "href",
+      "/shortlist",
+    );
+  });
+
+  it("uses singular 'broker' when shortlist count is 1", async () => {
+    mockGetUser.mockResolvedValue(AUTH_USER);
+    mockServerFrom.mockReturnValue(makeCountChain(1));
+    mockAdminFrom.mockReturnValue(makeCountChain(0));
+    mockGetLatestForUser.mockResolvedValue(null);
+
+    const ui = await HomeActivitySection();
+    render(<>{ui}</>);
+    expect(screen.getByText("1 broker in your shortlist")).toBeInTheDocument();
+  });
+
+  it("renders the quiz match card linking to the broker slug", async () => {
+    mockGetUser.mockResolvedValue(AUTH_USER);
+    mockServerFrom.mockReturnValue(makeCountChain(0));
+    mockAdminFrom.mockReturnValue(makeCountChain(0));
+    mockGetLatestForUser.mockResolvedValue({
+      id: 1,
+      user_id: "user-abc",
+      session_id: null,
+      answers: {},
+      inferred_vertical: "shares",
+      top_match_slug: "commsec",
+      completed_at: "2026-05-01T10:00:00Z",
+      resumed_from: null,
+      created_at: "2026-05-01T10:00:00Z",
+    });
+
+    const ui = await HomeActivitySection();
+    render(<>{ui}</>);
+
+    const link = screen.getByRole("link", { name: /commsec — keep comparing/i });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", "/broker/commsec");
+  });
+
+  it("renders the saved advisors card", async () => {
+    mockGetUser.mockResolvedValue(AUTH_USER);
+    mockServerFrom.mockReturnValue(makeCountChain(0));
+    mockAdminFrom.mockImplementation((table: string) => {
+      if (table === "user_bookmarks") return makeCountChain(4);
+      return makeCountChain(0);
+    });
+    mockGetLatestForUser.mockResolvedValue(null);
+
+    const ui = await HomeActivitySection();
+    render(<>{ui}</>);
+
+    expect(screen.getByText("You saved 4 advisors")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /4 advisors/i })).toHaveAttribute(
+      "href",
+      "/account/bookmarks",
+    );
+  });
+
+  it("renders the saved comparisons card", async () => {
+    mockGetUser.mockResolvedValue(AUTH_USER);
+    mockServerFrom.mockReturnValue(makeCountChain(0));
+    mockAdminFrom.mockImplementation((table: string) => {
+      if (table === "saved_broker_comparisons") return makeCountChain(2);
+      return makeCountChain(0);
+    });
+    mockGetLatestForUser.mockResolvedValue(null);
+
+    const ui = await HomeActivitySection();
+    render(<>{ui}</>);
+
+    expect(screen.getByText("You have 2 saved comparisons")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /2 saved comparisons/i })).toHaveAttribute(
+      "href",
+      "/account/saved",
+    );
+  });
+
+  it("renders up to 4 cards when all activity data is present", async () => {
+    mockGetUser.mockResolvedValue(AUTH_USER);
+    mockServerFrom.mockReturnValue(makeCountChain(5));
+    mockAdminFrom.mockImplementation((table: string) => {
+      if (table === "user_bookmarks") return makeCountChain(3);
+      if (table === "saved_broker_comparisons") return makeCountChain(2);
+      return makeCountChain(0);
+    });
+    mockGetLatestForUser.mockResolvedValue({
+      id: 2,
+      user_id: "user-abc",
+      session_id: null,
+      answers: {},
+      inferred_vertical: "crypto",
+      top_match_slug: "stake",
+      completed_at: "2026-05-10T08:00:00Z",
+      resumed_from: null,
+      created_at: "2026-05-10T08:00:00Z",
+    });
+
+    const ui = await HomeActivitySection();
+    render(<>{ui}</>);
+
+    const links = screen.getAllByRole("link");
+    expect(links).toHaveLength(4);
+    expect(screen.getByText("5 brokers in your shortlist")).toBeInTheDocument();
+    expect(screen.getByText(/stake — keep comparing/i)).toBeInTheDocument();
+    expect(screen.getByText("You saved 3 advisors")).toBeInTheDocument();
+    expect(screen.getByText("You have 2 saved comparisons")).toBeInTheDocument();
+  });
+
+  it("renders the section heading when there is activity", async () => {
+    mockGetUser.mockResolvedValue(AUTH_USER);
+    mockServerFrom.mockReturnValue(makeCountChain(2));
+    mockAdminFrom.mockReturnValue(makeCountChain(0));
+    mockGetLatestForUser.mockResolvedValue(null);
+
+    const ui = await HomeActivitySection();
+    render(<>{ui}</>);
+
+    expect(
+      screen.getByText("Welcome back — pick up where you left off"),
+    ).toBeInTheDocument();
+  });
+
+  it("omits cards whose DB queries fail (resilience)", async () => {
+    mockGetUser.mockResolvedValue(AUTH_USER);
+    // Shortlist query rejects — that card should be skipped gracefully
+    mockServerFrom.mockReturnValue(makeFailChain());
+    mockAdminFrom.mockImplementation((table: string) => {
+      if (table === "user_bookmarks") return makeCountChain(1);
+      return makeCountChain(0);
+    });
+    mockGetLatestForUser.mockResolvedValue(null);
+
+    const ui = await HomeActivitySection();
+    render(<>{ui}</>);
+
+    // Advisor card still renders despite shortlist failure
+    expect(screen.getByText("You saved 1 advisor")).toBeInTheDocument();
+    // No shortlist card
+    expect(screen.queryByText(/shortlist/i)).toBeNull();
+  });
+});

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,6 +18,7 @@ import CountryComparePreview from "@/components/country-mode/CountryComparePrevi
 import CountryPopularLinks from "@/components/country-mode/CountryPopularLinks";
 import ScrollFadeIn from "@/components/ScrollFadeIn";
 import MobileBottomNav from "@/components/MobileBottomNav";
+import HomeActivitySection from "@/components/HomeActivitySection";
 import { ORGANIZATION_JSONLD, SITE_URL } from "@/lib/seo";
 
 export const metadata = {
@@ -235,6 +236,8 @@ export default async function HomePage() {
           }),
         }}
       />
+
+      <HomeActivitySection />
 
       <HomeHero
         topBrokers={topBrokersForHero}

--- a/components/HomeActivitySection.tsx
+++ b/components/HomeActivitySection.tsx
@@ -1,0 +1,112 @@
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import Link from "next/link";
+import { getLatestForUser } from "@/lib/quiz-history";
+
+interface ActivityCard {
+  label: string;
+  href: string;
+}
+
+async function loadActivityCards(userId: string): Promise<ActivityCard[]> {
+  const [serverClient, adminClient] = [await createClient(), createAdminClient()];
+
+  const [shortlistRes, quizRes, advisorRes, comparisonRes] = await Promise.allSettled([
+    serverClient
+      .from("user_shortlisted_brokers")
+      .select("broker_slug", { count: "exact", head: true })
+      .eq("user_id", userId),
+    getLatestForUser(userId),
+    adminClient
+      .from("user_bookmarks")
+      .select("id", { count: "exact", head: true })
+      .eq("user_id", userId)
+      .eq("bookmark_type", "advisor"),
+    adminClient
+      .from("saved_broker_comparisons")
+      .select("id", { count: "exact", head: true })
+      .eq("user_id", userId),
+  ]);
+
+  const cards: ActivityCard[] = [];
+
+  if (shortlistRes.status === "fulfilled") {
+    const n = (shortlistRes.value as { count: number | null }).count ?? 0;
+    if (n > 0) {
+      cards.push({
+        label: `${n} broker${n !== 1 ? "s" : ""} in your shortlist`,
+        href: "/shortlist",
+      });
+    }
+  }
+
+  if (quizRes.status === "fulfilled" && quizRes.value?.top_match_slug) {
+    const slug = quizRes.value.top_match_slug;
+    cards.push({
+      label: `You matched with ${slug} — keep comparing`,
+      href: `/broker/${slug}`,
+    });
+  }
+
+  if (advisorRes.status === "fulfilled") {
+    const n = (advisorRes.value as { count: number | null }).count ?? 0;
+    if (n > 0) {
+      cards.push({
+        label: `You saved ${n} advisor${n !== 1 ? "s" : ""}`,
+        href: "/account/bookmarks",
+      });
+    }
+  }
+
+  if (comparisonRes.status === "fulfilled") {
+    const n = (comparisonRes.value as { count: number | null }).count ?? 0;
+    if (n > 0) {
+      cards.push({
+        label: `You have ${n} saved comparison${n !== 1 ? "s" : ""}`,
+        href: "/account/saved",
+      });
+    }
+  }
+
+  return cards.slice(0, 4);
+}
+
+export default async function HomeActivitySection() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) return null;
+
+  const cards = await loadActivityCards(user.id);
+  if (cards.length === 0) return null;
+
+  return (
+    <section className="container-custom py-6">
+      <p className="mb-3 text-sm font-semibold text-ink-500">
+        Welcome back — pick up where you left off
+      </p>
+      <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        {cards.map((card) => (
+          <li key={card.href}>
+            <Link
+              href={card.href}
+              className="group flex items-center justify-between rounded-xl border border-ink-100 bg-white px-4 py-3 shadow-sm transition-all hover:border-ink-200 hover:shadow-md"
+            >
+              <span className="text-sm font-medium text-ink-800 group-hover:text-coral-600">
+                {card.label}
+              </span>
+              <span
+                aria-hidden="true"
+                className="ml-3 shrink-0 text-ink-300 transition-transform group-hover:translate-x-0.5 group-hover:text-coral-400"
+              >
+                →
+              </span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}


### PR DESCRIPTION
## Why

Returning users who have a shortlist, a quiz match, saved advisors, or saved comparisons currently land on the homepage with no visible thread back to their in-progress work. This section closes that gap — it's the multi-thread coordination layer for return visits that was scoped as Feature G in the May 2026 batch (deferred from PRs #386–#391 pending the v6 redesign landing).

## What it shows

A personalised strip of 1–4 cards rendered **above the hero**, each card deep-linking to one open thread:

| Signal | Card text | Link |
|---|---|---|
| Shortlisted brokers | `N broker(s) in your shortlist` | `/shortlist` |
| Last quiz match | `You matched with {slug} — keep comparing` | `/broker/{slug}` |
| Saved advisors | `You saved N advisor(s)` | `/account/bookmarks` |
| Saved comparisons | `You have N saved comparison(s)` | `/account/saved` |

Cards are only shown when the count/signal is non-zero. The section heading `Welcome back — pick up where you left off` only renders when at least one card is present. Cards are capped at 4.

## Auth gate

The component calls `createClient()` server-side and checks `getUser()`. Anonymous visitors receive `null` — no DOM output, no DB queries beyond the single auth check already performed by the homepage.

## Implementation notes

- **Additive only** — v6 hero, route cards, `HomePathfinder`, revenue band, and every other homepage component are untouched.
- **Server component** — no client-side JS added. `Promise.allSettled` used for all four data queries so a single table failure (e.g. `saved_broker_comparisons` not yet migrated) gracefully omits that card without breaking the others.
- **Follows existing lib patterns** — `user_shortlisted_brokers` queried via user-context client (consistent with `/api/sync-shortlist`); `user_quiz_history` and `user_bookmarks` use `createAdminClient()` (consistent with `lib/quiz-history.ts` and `lib/bookmarks.ts`).
- **Tier A** per `docs/audits/MERGE_AUTHORIZATION.md` (page UI, additive, no compliance/auth/cron/webhook surface touched) — left for founder review, not auto-merged.

## Test plan

- [ ] Anonymous visitor — section absent, homepage renders exactly as before
- [ ] Authenticated user, zero activity on all four tables — section absent
- [ ] Authenticated user with shortlist only — single card `N brokers in your shortlist` links to `/shortlist`
- [ ] Authenticated user with quiz match — card shows broker slug, links to `/broker/{slug}`
- [ ] Authenticated user with all four signals — four cards render, none overflow to a fifth
- [ ] Mobile spot-check — cards stack 1-col, readable at 375 px
- [ ] Tablet spot-check — 2-col grid at `sm` breakpoint
- [ ] `saved_broker_comparisons` table absent in DB — comparison card omitted, other cards unaffected
- [ ] Unit tests: `npm test -- __tests__/components/HomeActivitySection.test.tsx` (10 tests, all passing)

https://claude.ai/code/session_01EqZfBCkwiMc3MGDmmCtqj6

---
_Generated by [Claude Code](https://claude.ai/code/session_01EqZfBCkwiMc3MGDmmCtqj6)_