### PR TITLE
feat(marketplace): calendar consultations + realtime chat in brief tracker

### DIFF
--- a/__tests__/lib/brief-messages/messages.test.ts
+++ b/__tests__/lib/brief-messages/messages.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * Unit tests for the brief-messages helpers (Ship #10 / MM32).
+ *
+ * Covers:
+ *   - sendMessage happy path → returns inserted row
+ *   - sendMessage rejects empty bodies + bodies over 4000 chars
+ *   - sendMessage requires sender_professional_id when kind='professional'
+ *   - listMessagesForBrief returns rows in chronological order
+ *   - markRead is idempotent (no-ops when nothing left to mark)
+ *
+ * The admin client is mocked via `vi.hoisted` so the import order doesn't
+ * race vi.mock hoisting (CLAUDE.md: "vi.mock(...) is hoisted to the top
+ * of the test file before any const/let").
+ */
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const { mockFrom } = vi.hoisted(() => ({ mockFrom: vi.fn() }));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+// Import AFTER the mock so the helpers see the mocked admin client.
+import {
+  BRIEF_MESSAGE_MAX_BODY_LENGTH,
+  BriefMessageError,
+  listMessagesForBrief,
+  markRead,
+  sendMessage,
+} from "@/lib/brief-messages";
+
+// ── Tiny chainable mock-builder factory ────────────────────────────────────────
+
+interface ChainOptions {
+  /** Resolved promise when the query chain ends in `.order(...)` (list). */
+  order?: { data: unknown; error?: unknown };
+  /** Resolved promise when the query chain ends in `.single()`. */
+  single?: { data: unknown; error?: unknown };
+  /** Resolved promise when the query chain ends in `.select(...)` after update. */
+  selectAfterUpdate?: { data: unknown; error?: unknown };
+}
+
+function chain(opts: ChainOptions = {}) {
+  const builder: Record<string, unknown> = {};
+  const passthrough = () => builder;
+  for (const m of ["insert", "update", "delete", "eq", "in", "is", "limit"]) {
+    builder[m] = vi.fn(passthrough);
+  }
+  // `.select(...)` may be terminal (after update with .select()) or
+  // mid-chain (before .eq/.order). We make it return either the resolved
+  // promise (when selectAfterUpdate is supplied) or the builder.
+  builder.select = vi.fn(() => {
+    if (opts.selectAfterUpdate) {
+      // Thenable + chainable: the helper does .update(...).eq(...).is(...).select("id")
+      // and awaits the result directly. Returning a promise here satisfies that.
+      return Promise.resolve(opts.selectAfterUpdate);
+    }
+    return builder;
+  });
+  // `.order(...)` is terminal for list queries.
+  builder.order = vi.fn(() =>
+    opts.order ? Promise.resolve(opts.order) : builder,
+  );
+  builder.single = vi.fn(() =>
+    Promise.resolve(opts.single ?? { data: null, error: null }),
+  );
+  return builder;
+}
+
+// ── sendMessage ────────────────────────────────────────────────────────────────
+
+describe("sendMessage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("inserts the row and returns it on the happy path", async () => {
+    const inserted = {
+      id: 7,
+      brief_id: 42,
+      sender_kind: "consumer",
+      sender_user_id: "u-1",
+      sender_professional_id: null,
+      sender_team_id: null,
+      body: "Hi there!",
+      read_by_consumer_at: null,
+      read_by_pro_at: null,
+      created_at: "2026-05-15T00:00:00Z",
+    };
+    mockFrom.mockReturnValueOnce(chain({ single: { data: inserted } }));
+
+    const row = await sendMessage({
+      briefId: 42,
+      senderKind: "consumer",
+      senderUserId: "u-1",
+      body: "Hi there!",
+    });
+
+    expect(row.id).toBe(7);
+    expect(row.body).toBe("Hi there!");
+    expect(row.sender_kind).toBe("consumer");
+    expect(mockFrom).toHaveBeenCalledWith("brief_messages");
+  });
+
+  it("rejects an empty body with a 400 BriefMessageError", async () => {
+    await expect(
+      sendMessage({ briefId: 1, senderKind: "consumer", body: "   " }),
+    ).rejects.toMatchObject({
+      name: "BriefMessageError",
+      status: 400,
+    });
+    // No DB call should have been issued for input validation failures.
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  it("rejects a body over BRIEF_MESSAGE_MAX_BODY_LENGTH (4000)", async () => {
+    const tooLong = "x".repeat(BRIEF_MESSAGE_MAX_BODY_LENGTH + 1);
+    await expect(
+      sendMessage({ briefId: 1, senderKind: "consumer", body: tooLong }),
+    ).rejects.toBeInstanceOf(BriefMessageError);
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  it("requires sender_professional_id when sender_kind='professional'", async () => {
+    await expect(
+      sendMessage({ briefId: 1, senderKind: "professional", body: "Hi" }),
+    ).rejects.toMatchObject({ status: 400 });
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  it("requires sender_team_id when sender_kind='team'", async () => {
+    await expect(
+      sendMessage({ briefId: 1, senderKind: "team", body: "Hi" }),
+    ).rejects.toMatchObject({ status: 400 });
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  it("accepts boundary length (exactly 4000 chars)", async () => {
+    const exact = "y".repeat(BRIEF_MESSAGE_MAX_BODY_LENGTH);
+    const inserted = {
+      id: 8,
+      brief_id: 1,
+      sender_kind: "consumer",
+      sender_user_id: null,
+      sender_professional_id: null,
+      sender_team_id: null,
+      body: exact,
+      read_by_consumer_at: null,
+      read_by_pro_at: null,
+      created_at: "2026-05-15T00:00:00Z",
+    };
+    mockFrom.mockReturnValueOnce(chain({ single: { data: inserted } }));
+
+    const row = await sendMessage({
+      briefId: 1,
+      senderKind: "consumer",
+      body: exact,
+    });
+    expect(row.body.length).toBe(BRIEF_MESSAGE_MAX_BODY_LENGTH);
+  });
+});
+
+// ── listMessagesForBrief ───────────────────────────────────────────────────────
+
+describe("listMessagesForBrief", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns rows in chronological order (oldest first)", async () => {
+    const ordered = [
+      {
+        id: 1,
+        brief_id: 9,
+        sender_kind: "consumer",
+        sender_user_id: null,
+        sender_professional_id: null,
+        sender_team_id: null,
+        body: "first",
+        read_by_consumer_at: null,
+        read_by_pro_at: null,
+        created_at: "2026-05-15T00:00:00Z",
+      },
+      {
+        id: 2,
+        brief_id: 9,
+        sender_kind: "professional",
+        sender_user_id: null,
+        sender_professional_id: 11,
+        sender_team_id: null,
+        body: "second",
+        read_by_consumer_at: null,
+        read_by_pro_at: null,
+        created_at: "2026-05-15T00:01:00Z",
+      },
+    ];
+    mockFrom.mockReturnValueOnce(chain({ order: { data: ordered } }));
+
+    const rows = await listMessagesForBrief(9);
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.body).toBe("first");
+    expect(rows[1]?.body).toBe("second");
+    // Sanity: the first row's created_at is earlier.
+    expect(
+      new Date(rows[0]!.created_at).getTime() <
+        new Date(rows[1]!.created_at).getTime(),
+    ).toBe(true);
+  });
+
+  it("returns an empty array when no rows exist", async () => {
+    mockFrom.mockReturnValueOnce(chain({ order: { data: [] } }));
+    const rows = await listMessagesForBrief(123);
+    expect(rows).toEqual([]);
+  });
+
+  it("throws a BriefMessageError when the query fails", async () => {
+    mockFrom.mockReturnValueOnce(
+      chain({ order: { data: null, error: { message: "boom" } } }),
+    );
+    await expect(listMessagesForBrief(123)).rejects.toBeInstanceOf(
+      BriefMessageError,
+    );
+  });
+});
+
+// ── markRead ───────────────────────────────────────────────────────────────────
+
+describe("markRead", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the number of rows whose read_by_consumer_at was flipped", async () => {
+    mockFrom.mockReturnValueOnce(
+      chain({ selectAfterUpdate: { data: [{ id: 1 }, { id: 2 }] } }),
+    );
+    const n = await markRead({ briefId: 42, asKind: "consumer" });
+    expect(n).toBe(2);
+  });
+
+  it("is idempotent — returns 0 when there's nothing left to mark", async () => {
+    // Second call sees no unread rows (the IS NULL filter excludes them).
+    mockFrom.mockReturnValueOnce(
+      chain({ selectAfterUpdate: { data: [] } }),
+    );
+    const n = await markRead({ briefId: 42, asKind: "consumer" });
+    expect(n).toBe(0);
+  });
+
+  it("flips the pro column when asKind='pro'", async () => {
+    mockFrom.mockReturnValueOnce(
+      chain({ selectAfterUpdate: { data: [{ id: 3 }] } }),
+    );
+    const n = await markRead({ briefId: 42, asKind: "pro" });
+    expect(n).toBe(1);
+  });
+
+  it("returns 0 (fail-soft) when the DB returns an error", async () => {
+    mockFrom.mockReturnValueOnce(
+      chain({
+        selectAfterUpdate: { data: null, error: { message: "permission denied" } },
+      }),
+    );
+    const n = await markRead({ briefId: 42, asKind: "consumer" });
+    expect(n).toBe(0);
+  });
+});

--- a/__tests__/lib/consultations/consultations.test.ts
+++ b/__tests__/lib/consultations/consultations.test.ts
@@ -1,0 +1,308 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * Unit tests for the in-app consultation booking helpers (MM33).
+ *
+ * The admin client is mocked with a per-table chainable builder so each
+ * helper can swap in the specific query path it walks. We mock the
+ * "@/lib/supabase/admin" module so the lib's `createAdminClient()` calls
+ * resolve to our test double.
+ */
+
+// ── Mocks ────────────────────────────────────────────────────────────────
+
+const { mockFrom } = vi.hoisted(() => ({ mockFrom: vi.fn() }));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+import {
+  bookSlot,
+  cancelBooking,
+  confirmBooking,
+  ConsultationError,
+  createSlot,
+  listAvailabilityForPro,
+} from "@/lib/consultations";
+
+// ── Tiny chainable mock-builder factory ──────────────────────────────────
+
+interface ChainOptions {
+  maybeSingle?: { data: unknown; error?: unknown };
+  single?: { data: unknown; error?: unknown };
+  /** Resolved value when the chain is awaited (no `.single()` / `.maybeSingle()`).
+   *  Used for list queries that resolve a Promise<{data, error}> directly. */
+  resolve?: { data: unknown; error?: unknown };
+}
+
+function chain(opts: ChainOptions = {}): Record<string, unknown> {
+  const builder: Record<string, unknown> = {};
+  const passthrough = () => builder;
+  for (const m of [
+    "select",
+    "insert",
+    "update",
+    "delete",
+    "eq",
+    "in",
+    "gte",
+    "lte",
+    "order",
+    "limit",
+    "is",
+  ]) {
+    builder[m] = vi.fn(passthrough);
+  }
+  builder.maybeSingle = vi.fn(() =>
+    Promise.resolve(opts.maybeSingle ?? { data: null, error: null }),
+  );
+  builder.single = vi.fn(() =>
+    Promise.resolve(opts.single ?? { data: null, error: null }),
+  );
+  // When awaited directly (e.g. `await admin.from(...).select(...).eq(...)`),
+  // Postgrest builders behave as a thenable resolving to {data, error}.
+  if (opts.resolve) {
+    const resolved = opts.resolve;
+    builder.then = (
+      onFulfilled: (v: { data: unknown; error?: unknown }) => unknown,
+    ) => Promise.resolve(resolved).then(onFulfilled);
+  }
+  return builder;
+}
+
+// ── createSlot ───────────────────────────────────────────────────────────
+
+describe("createSlot", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects when end_at is not strictly after start_at", async () => {
+    const start = "2026-06-01T10:00:00Z";
+    const end = "2026-06-01T10:00:00Z"; // identical → invalid
+    await expect(
+      createSlot({ professionalId: 1, startAt: start, endAt: end }),
+    ).rejects.toBeInstanceOf(ConsultationError);
+    await expect(
+      createSlot({ professionalId: 1, startAt: start, endAt: end }),
+    ).rejects.toMatchObject({ code: "invalid_input", status: 400 });
+    // The helper should reject up front — no DB call should fire.
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  it("creates a slot when the time range is valid", async () => {
+    const row = {
+      id: 1,
+      professional_id: 1,
+      team_id: null,
+      start_at: "2026-06-01T10:00:00Z",
+      end_at: "2026-06-01T10:30:00Z",
+      status: "open",
+      created_at: "2026-05-15T00:00:00Z",
+    };
+    mockFrom.mockReturnValueOnce(chain({ single: { data: row } }));
+
+    const result = await createSlot({
+      professionalId: 1,
+      startAt: row.start_at,
+      endAt: row.end_at,
+    });
+    expect(result.id).toBe(1);
+    expect(result.status).toBe("open");
+  });
+});
+
+// ── bookSlot ─────────────────────────────────────────────────────────────
+
+describe("bookSlot", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("transitions slot status from open to booked and inserts a booking", async () => {
+    const claimed = {
+      id: 10,
+      professional_id: 1,
+      team_id: null,
+      start_at: "2026-06-01T10:00:00Z",
+      end_at: "2026-06-01T10:30:00Z",
+      status: "booked",
+      created_at: "2026-05-15T00:00:00Z",
+    };
+    const booking = {
+      id: 100,
+      slot_id: 10,
+      brief_id: 42,
+      consumer_user_id: null,
+      consumer_email: "user@example.com",
+      consumer_notes: null,
+      meet_url: null,
+      status: "pending",
+      created_at: "2026-05-15T00:00:00Z",
+      updated_at: "2026-05-15T00:00:00Z",
+    };
+    // 1st from() → optimistic update on slot → returns claimed row.
+    // 2nd from() → insert booking → returns booking row.
+    mockFrom
+      .mockReturnValueOnce(chain({ maybeSingle: { data: claimed } }))
+      .mockReturnValueOnce(chain({ single: { data: booking } }));
+
+    const result = await bookSlot({
+      slotId: 10,
+      briefId: 42,
+      consumerEmail: "User@Example.com",
+    });
+
+    expect(result.slot.status).toBe("booked");
+    expect(result.booking.status).toBe("pending");
+    expect(result.booking.consumer_email).toBe("user@example.com");
+  });
+
+  it("rejects with slot_not_open when the slot is already booked", async () => {
+    // First mocked from() returns null on maybeSingle — the optimistic
+    // update matched zero rows because the WHERE status='open' clause
+    // was no longer true. The helper should bail without touching the
+    // bookings table.
+    mockFrom.mockReturnValueOnce(chain({ maybeSingle: { data: null } }));
+
+    await expect(
+      bookSlot({
+        slotId: 10,
+        briefId: 42,
+        consumerEmail: "user@example.com",
+      }),
+    ).rejects.toMatchObject({ code: "slot_not_open", status: 409 });
+    // Only the slot-claim call — no bookings insert.
+    expect(mockFrom).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ── cancelBooking ────────────────────────────────────────────────────────
+
+describe("cancelBooking", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("flips booking to cancelled and frees the underlying slot", async () => {
+    const existing = {
+      id: 100,
+      slot_id: 10,
+      brief_id: 42,
+      consumer_user_id: null,
+      consumer_email: "user@example.com",
+      consumer_notes: null,
+      meet_url: null,
+      status: "pending",
+      created_at: "2026-05-15T00:00:00Z",
+      updated_at: "2026-05-15T00:00:00Z",
+    };
+    const updated = { ...existing, status: "cancelled" };
+    const slotFreed = chain();
+    mockFrom
+      .mockReturnValueOnce(chain({ maybeSingle: { data: existing } })) // load booking
+      .mockReturnValueOnce(chain({ single: { data: updated } })) // update booking
+      .mockReturnValueOnce(slotFreed); // free slot
+
+    const result = await cancelBooking(100, "consumer");
+    expect(result.status).toBe("cancelled");
+
+    // Confirm the slot table was touched — the third from() call hits
+    // pro_availability_slots and chains update().eq() → check eq saw 10.
+    expect(mockFrom).toHaveBeenNthCalledWith(3, "pro_availability_slots");
+  });
+});
+
+// ── listAvailabilityForPro ───────────────────────────────────────────────
+
+describe("listAvailabilityForPro", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("filters by status='open' and orders by start_at", async () => {
+    const rows = [
+      {
+        id: 1,
+        professional_id: 1,
+        team_id: null,
+        start_at: "2026-06-01T10:00:00Z",
+        end_at: "2026-06-01T10:30:00Z",
+        status: "open",
+        created_at: "2026-05-15T00:00:00Z",
+      },
+      {
+        id: 2,
+        professional_id: 1,
+        team_id: null,
+        start_at: "2026-06-02T10:00:00Z",
+        end_at: "2026-06-02T10:30:00Z",
+        status: "open",
+        created_at: "2026-05-15T00:00:00Z",
+      },
+    ];
+    const builder = chain({ resolve: { data: rows, error: null } });
+    mockFrom.mockReturnValueOnce(builder);
+
+    const result = await listAvailabilityForPro(1);
+    expect(result).toHaveLength(2);
+    expect(result[0]?.id).toBe(1);
+    // Verify the .eq("status","open") guard was applied.
+    const eqCalls = (builder.eq as ReturnType<typeof vi.fn>).mock.calls;
+    const hasStatusOpenFilter = eqCalls.some(
+      (c) => c[0] === "status" && c[1] === "open",
+    );
+    expect(hasStatusOpenFilter).toBe(true);
+    // And the .order("start_at", { ascending: true }) sort was applied.
+    expect(builder.order).toHaveBeenCalledWith("start_at", {
+      ascending: true,
+    });
+  });
+});
+
+// ── confirmBooking ───────────────────────────────────────────────────────
+
+describe("confirmBooking", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("attaches meet_url and flips status to confirmed", async () => {
+    const updated = {
+      id: 100,
+      slot_id: 10,
+      brief_id: 42,
+      consumer_user_id: null,
+      consumer_email: "user@example.com",
+      consumer_notes: null,
+      meet_url: "https://meet.google.com/abc-defg-hij",
+      status: "confirmed",
+      created_at: "2026-05-15T00:00:00Z",
+      updated_at: "2026-05-15T00:01:00Z",
+    };
+    const builder = chain({ maybeSingle: { data: updated } });
+    mockFrom.mockReturnValueOnce(builder);
+
+    const result = await confirmBooking(100, {
+      meetUrl: "https://meet.google.com/abc-defg-hij",
+    });
+    expect(result.status).toBe("confirmed");
+    expect(result.meet_url).toBe("https://meet.google.com/abc-defg-hij");
+    // Verify the update payload included both fields.
+    const updateCall = (builder.update as ReturnType<typeof vi.fn>).mock
+      .calls[0]?.[0];
+    expect(updateCall).toMatchObject({
+      status: "confirmed",
+      meet_url: "https://meet.google.com/abc-defg-hij",
+    });
+  });
+
+  it("rejects an invalid meet_url with invalid_input", async () => {
+    await expect(
+      confirmBooking(100, { meetUrl: "not a url" }),
+    ).rejects.toMatchObject({ code: "invalid_input", status: 400 });
+    // Validation runs before any DB call.
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+});

--- a/app/api/bookings/[id]/cancel/route.ts
+++ b/app/api/bookings/[id]/cancel/route.ts
@@ -1,0 +1,140 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+import { createAdminClient } from "@/lib/supabase/admin";
+import { createClient } from "@/lib/supabase/server";
+import { requireAdvisorSession } from "@/lib/require-advisor-session";
+import { isAllowed, ipKey } from "@/lib/rate-limit-db";
+import { logger } from "@/lib/logger";
+import {
+  cancelBooking,
+  ConsultationError,
+  getBooking,
+  getSlot,
+} from "@/lib/consultations";
+
+const log = logger("consultations:cancel");
+
+const Body = z.object({
+  // Consumer-side email-as-key auth path; pro-side uses session.
+  contact_email: z.string().email().max(200).optional(),
+});
+
+/**
+ * POST /api/bookings/[id]/cancel — Either party cancels a booking.
+ */
+export async function POST(
+  request: NextRequest,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  try {
+    if (
+      !(await isAllowed("bookings_cancel", ipKey(request), {
+        max: 30,
+        refillPerSec: 0.5,
+      }))
+    ) {
+      return NextResponse.json({ error: "Too many requests." }, { status: 429 });
+    }
+
+    const { id } = await ctx.params;
+    const bookingId = Number(id);
+    if (!Number.isInteger(bookingId) || bookingId <= 0) {
+      return NextResponse.json({ error: "Invalid booking id." }, { status: 400 });
+    }
+
+    let rawBody: unknown = {};
+    try {
+      rawBody = await request.json();
+    } catch {
+      // body is optional
+    }
+    const parsed = Body.safeParse(rawBody);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.issues[0]?.message ?? "Invalid body." },
+        { status: 400 },
+      );
+    }
+
+    const booking = await getBooking(bookingId);
+    if (!booking) {
+      return NextResponse.json({ error: "Booking not found." }, { status: 404 });
+    }
+    const slot = await getSlot(booking.slot_id);
+    if (!slot) {
+      return NextResponse.json({ error: "Slot not found." }, { status: 404 });
+    }
+
+    // Resolve which party is cancelling.
+    let byKind: "consumer" | "professional" | null = null;
+
+    // Try pro session first.
+    const advisorId = await requireAdvisorSession(request).catch(() => null);
+    if (advisorId && slot.professional_id === advisorId) {
+      byKind = "professional";
+    }
+
+    if (!byKind) {
+      // Try consumer paths: signed-in OR email-key.
+      if (parsed.data.contact_email) {
+        if (
+          parsed.data.contact_email.toLowerCase().trim() ===
+          booking.consumer_email.toLowerCase().trim()
+        ) {
+          byKind = "consumer";
+        }
+      } else {
+        const supabase = await createClient();
+        const {
+          data: { user },
+        } = await supabase.auth.getUser();
+        if (
+          user?.email &&
+          user.email.toLowerCase() === booking.consumer_email.toLowerCase()
+        ) {
+          byKind = "consumer";
+        }
+      }
+    }
+
+    if (!byKind) {
+      return NextResponse.json(
+        { error: "You are not authorised to cancel this booking." },
+        { status: 403 },
+      );
+    }
+
+    const cancelled = await cancelBooking(bookingId, byKind);
+    log.info("booking cancelled", { bookingId, byKind });
+
+    // Optionally log a brief tracker event so the consumer page reflects it.
+    try {
+      const admin = createAdminClient();
+      await admin.from("brief_tracker_events").insert({
+        brief_id: booking.brief_id,
+        event_type: "consultation_cancelled",
+        actor_kind: byKind,
+        payload: { booking_id: bookingId },
+      });
+    } catch {
+      // best effort
+    }
+
+    return NextResponse.json({ success: true, booking: cancelled });
+  } catch (err) {
+    if (err instanceof ConsultationError) {
+      return NextResponse.json(
+        { error: err.message, code: err.code },
+        { status: err.status },
+      );
+    }
+    log.error("cancel error", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json(
+      { error: "Failed to cancel booking." },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/bookings/[id]/confirm/route.ts
+++ b/app/api/bookings/[id]/confirm/route.ts
@@ -1,0 +1,132 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+import { requireAdvisorSession } from "@/lib/require-advisor-session";
+import { isAllowed, ipKey } from "@/lib/rate-limit-db";
+import { logger } from "@/lib/logger";
+import {
+  confirmBooking,
+  ConsultationError,
+  getBooking,
+  getSlot,
+} from "@/lib/consultations";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { sendConsumerConsultationConfirmed } from "@/lib/marketplace-emails";
+
+const log = logger("consultations:confirm");
+
+const Body = z.object({
+  meet_url: z.string().url().max(500).optional(),
+});
+
+/**
+ * POST /api/bookings/[id]/confirm — Pro confirms a pending booking.
+ */
+export async function POST(
+  request: NextRequest,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  try {
+    if (
+      !(await isAllowed("bookings_confirm", ipKey(request), {
+        max: 30,
+        refillPerSec: 0.5,
+      }))
+    ) {
+      return NextResponse.json({ error: "Too many requests." }, { status: 429 });
+    }
+
+    const advisorId = await requireAdvisorSession(request);
+    if (!advisorId) {
+      return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+    }
+
+    const { id } = await ctx.params;
+    const bookingId = Number(id);
+    if (!Number.isInteger(bookingId) || bookingId <= 0) {
+      return NextResponse.json({ error: "Invalid booking id." }, { status: 400 });
+    }
+
+    let rawBody: unknown = {};
+    try {
+      rawBody = await request.json();
+    } catch {
+      // body is optional
+    }
+    const parsed = Body.safeParse(rawBody);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.issues[0]?.message ?? "Invalid body." },
+        { status: 400 },
+      );
+    }
+
+    const existing = await getBooking(bookingId);
+    if (!existing) {
+      return NextResponse.json({ error: "Booking not found." }, { status: 404 });
+    }
+    const slot = await getSlot(existing.slot_id);
+    if (!slot) {
+      return NextResponse.json({ error: "Slot not found." }, { status: 404 });
+    }
+    if (slot.professional_id !== advisorId) {
+      return NextResponse.json({ error: "Not your booking." }, { status: 403 });
+    }
+
+    const booking = await confirmBooking(bookingId, {
+      meetUrl: parsed.data.meet_url ?? null,
+    });
+
+    log.info("booking confirmed", { bookingId, professionalId: advisorId });
+
+    // ── Best-effort email to consumer ──
+    void (async () => {
+      try {
+        const admin = createAdminClient();
+        const { data: brief } = await admin
+          .from("advisor_auctions")
+          .select("slug, job_title, contact_name")
+          .eq("id", booking.brief_id)
+          .maybeSingle();
+        const { data: pro } = await admin
+          .from("professionals")
+          .select("name")
+          .eq("id", advisorId)
+          .maybeSingle();
+        if (brief?.slug) {
+          await sendConsumerConsultationConfirmed({
+            consumerEmail: booking.consumer_email,
+            consumerName: (brief.contact_name as string) ?? "",
+            providerName: (pro?.name as string) ?? "Your pro",
+            briefTitle: (brief.job_title as string) ?? "Your consultation",
+            briefSlug: brief.slug as string,
+            startAt: slot.start_at,
+            endAt: slot.end_at,
+            meetUrl: booking.meet_url,
+          });
+        }
+      } catch (err) {
+        log.warn("confirm notification failed", {
+          bookingId,
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
+    })();
+
+    return NextResponse.json({ success: true, booking });
+  } catch (err) {
+    if (err instanceof ConsultationError) {
+      return NextResponse.json(
+        { error: err.message, code: err.code },
+        { status: err.status },
+      );
+    }
+    log.error("confirm error", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json(
+      { error: "Failed to confirm booking." },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/briefs/[slug]/book-slot/route.ts
+++ b/app/api/briefs/[slug]/book-slot/route.ts
@@ -1,0 +1,220 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+import { createAdminClient } from "@/lib/supabase/admin";
+import { isAllowed, ipKey } from "@/lib/rate-limit-db";
+import { logger } from "@/lib/logger";
+import {
+  bookSlot,
+  ConsultationError,
+  getSlot,
+} from "@/lib/consultations";
+import {
+  sendProConsultationBooked,
+  sendConsumerConsultationPending,
+} from "@/lib/marketplace-emails";
+
+const log = logger("consultations:book-slot");
+
+const Body = z.object({
+  slot_id: z.number().int().positive(),
+  notes: z.string().max(2000).optional(),
+  // Optional — when present we treat it as an email-as-key check
+  // (mirrors /api/briefs/[slug]/withdraw). The signed-in path uses
+  // the JWT instead.
+  contact_email: z.string().email().max(200).optional(),
+});
+
+/**
+ * POST /api/briefs/[slug]/book-slot — Consumer books a consultation slot.
+ *
+ * Auth: caller must be the brief owner. We resolve identity either from:
+ *   1. The signed-in Supabase user (matching contact_email), or
+ *   2. The `contact_email` body field matching the brief's contact_email
+ *      (mirrors the existing email-as-key pattern from /withdraw).
+ */
+export async function POST(
+  request: NextRequest,
+  ctx: { params: Promise<{ slug: string }> },
+) {
+  try {
+    if (
+      !(await isAllowed("briefs_book_slot", ipKey(request), {
+        max: 20,
+        refillPerSec: 0.3,
+      }))
+    ) {
+      return NextResponse.json({ error: "Too many requests." }, { status: 429 });
+    }
+
+    const { slug } = await ctx.params;
+    let rawBody: unknown;
+    try {
+      rawBody = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+    }
+    const parsed = Body.safeParse(rawBody);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.issues[0]?.message ?? "Invalid body." },
+        { status: 400 },
+      );
+    }
+
+    const admin = createAdminClient();
+    const { data: brief } = await admin
+      .from("advisor_auctions")
+      .select(
+        "id, slug, job_title, contact_email, contact_name, accepted_by_professional_id, accepted_by_team_id",
+      )
+      .eq("slug", slug)
+      .eq("flow_type", "accept")
+      .maybeSingle();
+
+    if (!brief) {
+      return NextResponse.json({ error: "Brief not found." }, { status: 404 });
+    }
+
+    const briefRow = brief as {
+      id: number;
+      slug: string;
+      job_title: string;
+      contact_email: string | null;
+      contact_name: string | null;
+      accepted_by_professional_id: number | null;
+      accepted_by_team_id: number | null;
+    };
+
+    if (!briefRow.accepted_by_professional_id) {
+      return NextResponse.json(
+        { error: "Brief has not been accepted yet." },
+        { status: 400 },
+      );
+    }
+
+    // Resolve consumer identity.
+    let consumerEmail: string | null = null;
+    let consumerUserId: string | null = null;
+
+    if (parsed.data.contact_email) {
+      const provided = parsed.data.contact_email.toLowerCase().trim();
+      const expected = (briefRow.contact_email ?? "").toLowerCase().trim();
+      if (!expected || expected !== provided) {
+        return NextResponse.json(
+          { error: "Email does not match brief owner." },
+          { status: 403 },
+        );
+      }
+      consumerEmail = provided;
+    } else {
+      // Try signed-in route.
+      const { createClient } = await import("@/lib/supabase/server");
+      const supabase = await createClient();
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (!user || !user.email) {
+        return NextResponse.json(
+          { error: "Sign in or provide contact_email." },
+          { status: 401 },
+        );
+      }
+      if (
+        (briefRow.contact_email ?? "").toLowerCase() !==
+        user.email.toLowerCase()
+      ) {
+        return NextResponse.json(
+          { error: "You do not own this brief." },
+          { status: 403 },
+        );
+      }
+      consumerEmail = user.email.toLowerCase();
+      consumerUserId = user.id;
+    }
+
+    // Verify the slot belongs to the accepting pro (no cross-pro booking).
+    const slot = await getSlot(parsed.data.slot_id);
+    if (!slot) {
+      return NextResponse.json({ error: "Slot not found." }, { status: 404 });
+    }
+    if (slot.professional_id !== briefRow.accepted_by_professional_id) {
+      return NextResponse.json(
+        { error: "Slot does not belong to the accepting pro." },
+        { status: 400 },
+      );
+    }
+
+    const result = await bookSlot({
+      slotId: parsed.data.slot_id,
+      briefId: briefRow.id,
+      consumerEmail,
+      consumerUserId,
+      consumerNotes: parsed.data.notes ?? null,
+    });
+
+    log.info("consultation booked", {
+      bookingId: result.booking.id,
+      slotId: result.slot.id,
+      briefId: briefRow.id,
+    });
+
+    // ── Best-effort email notifications ──
+    void (async () => {
+      try {
+        const { data: pro } = await admin
+          .from("professionals")
+          .select("name, email")
+          .eq("id", briefRow.accepted_by_professional_id)
+          .maybeSingle();
+        if (pro?.email) {
+          await sendProConsultationBooked({
+            providerEmail: pro.email as string,
+            providerName: (pro.name as string) ?? "there",
+            consumerName: briefRow.contact_name ?? "",
+            consumerEmail: consumerEmail!,
+            briefTitle: briefRow.job_title,
+            briefSlug: briefRow.slug,
+            startAt: result.slot.start_at,
+            endAt: result.slot.end_at,
+            notes: parsed.data.notes ?? null,
+          });
+        }
+        await sendConsumerConsultationPending({
+          consumerEmail: consumerEmail!,
+          consumerName: briefRow.contact_name ?? "",
+          providerName: (pro?.name as string) ?? "Your pro",
+          briefTitle: briefRow.job_title,
+          briefSlug: briefRow.slug,
+          startAt: result.slot.start_at,
+          endAt: result.slot.end_at,
+        });
+      } catch (err) {
+        log.warn("booking notification email failed", {
+          bookingId: result.booking.id,
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
+    })();
+
+    return NextResponse.json({
+      success: true,
+      booking: result.booking,
+      slot: result.slot,
+    });
+  } catch (err) {
+    if (err instanceof ConsultationError) {
+      return NextResponse.json(
+        { error: err.message, code: err.code },
+        { status: err.status },
+      );
+    }
+    log.error("book-slot error", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json(
+      { error: "Failed to book consultation." },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/briefs/[slug]/messages/mark-read/route.ts
+++ b/app/api/briefs/[slug]/messages/mark-read/route.ts
@@ -1,0 +1,120 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { requireAdvisorSession } from "@/lib/require-advisor-session";
+import { isAllowed, ipKey } from "@/lib/rate-limit-db";
+import {
+  BriefMessageError,
+  markRead,
+  type MarkReadAsKind,
+} from "@/lib/brief-messages";
+import { isProfessionalOnTeam } from "@/lib/expert-teams";
+import { logger } from "@/lib/logger";
+
+const log = logger("api:briefs:messages:mark-read");
+
+interface BriefMeta {
+  id: number;
+  contact_email: string | null;
+  accepted_at: string | null;
+  accepted_by_professional_id: number | null;
+  accepted_by_team_id: number | null;
+}
+
+export async function POST(
+  request: NextRequest,
+  ctx: { params: Promise<{ slug: string }> },
+) {
+  try {
+    // Mark-read is invoked aggressively (every viewport-enter); a high
+    // burst per IP is fine but cap it so a stuck client can't hammer DB.
+    if (
+      !(await isAllowed("brief_messages_mark_read", ipKey(request), {
+        max: 60,
+        refillPerSec: 1,
+      }))
+    ) {
+      return NextResponse.json({ error: "Too many requests." }, { status: 429 });
+    }
+
+    const { slug } = await ctx.params;
+
+    // Empty body is OK — we accept either no body or {}.
+    // eslint-disable-next-line invest/no-unvalidated-req-json -- Empty/optional body. The mark-read endpoint takes no payload; only the slug + caller identity matter, both validated below.
+    await request.json().catch(() => ({}));
+
+    const admin = createAdminClient();
+    const { data: briefRaw } = await admin
+      .from("advisor_auctions")
+      .select(
+        "id, contact_email, accepted_at, accepted_by_professional_id, accepted_by_team_id",
+      )
+      .eq("slug", slug)
+      .eq("flow_type", "accept")
+      .maybeSingle();
+
+    if (!briefRaw) {
+      return NextResponse.json({ error: "Brief not found." }, { status: 404 });
+    }
+    const brief = briefRaw as BriefMeta;
+
+    if (!brief.accepted_at) {
+      // Nothing to mark — chat panel isn't open yet.
+      return NextResponse.json({ updated: 0 });
+    }
+
+    const asKind = await resolveMarkReadKind(request, brief);
+    if (!asKind) {
+      return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+    }
+
+    const updated = await markRead({ briefId: brief.id, asKind });
+    return NextResponse.json({ updated });
+  } catch (err) {
+    if (err instanceof BriefMessageError) {
+      return NextResponse.json({ error: err.message }, { status: err.status });
+    }
+    log.error("mark-read failed", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json({ error: "Failed to mark read." }, { status: 500 });
+  }
+}
+
+/**
+ * Mark-read maps the caller to one of the two read-state columns
+ * (`read_by_consumer_at` vs `read_by_pro_at`). Pros and team members
+ * share the same `read_by_pro_at` column — the read state is one-per-side.
+ */
+async function resolveMarkReadKind(
+  request: NextRequest,
+  brief: BriefMeta,
+): Promise<MarkReadAsKind | null> {
+  const advisorId = await requireAdvisorSession(request);
+  if (advisorId) {
+    if (
+      brief.accepted_by_professional_id !== null &&
+      brief.accepted_by_professional_id === advisorId
+    ) {
+      return "pro";
+    }
+    if (brief.accepted_by_team_id !== null) {
+      const onTeam = await isProfessionalOnTeam(
+        brief.accepted_by_team_id,
+        advisorId,
+      );
+      if (onTeam) return "pro";
+    }
+  }
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (user?.email && brief.contact_email) {
+    if (user.email.toLowerCase() === brief.contact_email.toLowerCase()) {
+      return "consumer";
+    }
+  }
+  return null;
+}

--- a/app/api/briefs/[slug]/messages/route.ts
+++ b/app/api/briefs/[slug]/messages/route.ts
@@ -1,0 +1,210 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { requireAdvisorSession } from "@/lib/require-advisor-session";
+import { isAllowed, ipKey } from "@/lib/rate-limit-db";
+import { SendBriefMessageRequest } from "@/lib/api-schemas";
+import {
+  BriefMessageError,
+  sendMessage,
+  type BriefMessageSenderKind,
+} from "@/lib/brief-messages";
+import { isProfessionalOnTeam } from "@/lib/expert-teams";
+import { logger } from "@/lib/logger";
+
+const log = logger("api:briefs:messages");
+
+interface ResolvedSender {
+  kind: BriefMessageSenderKind;
+  userId: string | null;
+  professionalId: number | null;
+  teamId: number | null;
+}
+
+interface BriefMeta {
+  id: number;
+  contact_email: string | null;
+  accepted_at: string | null;
+  accepted_by_professional_id: number | null;
+  accepted_by_team_id: number | null;
+}
+
+export async function POST(
+  request: NextRequest,
+  ctx: { params: Promise<{ slug: string }> },
+) {
+  try {
+    // ── Rate limits ─────────────────────────────────────────────────────
+    if (
+      !(await isAllowed("brief_messages_send_ip", ipKey(request), {
+        max: 30,
+        refillPerSec: 30 / 60,
+      }))
+    ) {
+      return NextResponse.json({ error: "Too many requests." }, { status: 429 });
+    }
+
+    const { slug } = await ctx.params;
+
+    // ── Body validation ─────────────────────────────────────────────────
+    let rawBody: unknown;
+    try {
+      rawBody = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+    }
+    const parsed = SendBriefMessageRequest.safeParse(rawBody);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.issues[0]?.message || "Invalid body." },
+        { status: 400 },
+      );
+    }
+
+    // ── Brief lookup ────────────────────────────────────────────────────
+    const admin = createAdminClient();
+    const { data: briefRaw } = await admin
+      .from("advisor_auctions")
+      .select(
+        "id, contact_email, accepted_at, accepted_by_professional_id, accepted_by_team_id",
+      )
+      .eq("slug", slug)
+      .eq("flow_type", "accept")
+      .maybeSingle();
+
+    if (!briefRaw) {
+      return NextResponse.json({ error: "Brief not found." }, { status: 404 });
+    }
+    const brief = briefRaw as BriefMeta;
+
+    if (!brief.accepted_at) {
+      return NextResponse.json(
+        { error: "Chat is not available until the brief has been accepted." },
+        { status: 409 },
+      );
+    }
+
+    // ── Sender resolution ───────────────────────────────────────────────
+    const sender = await resolveSender(request, brief);
+    if (!sender) {
+      return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+    }
+
+    // ── Per-user-per-brief throttle (max 30 messages / min) ─────────────
+    const userKey =
+      sender.userId ??
+      (sender.professionalId ? `pro:${sender.professionalId}` : null) ??
+      ipKey(request);
+    if (
+      !(await isAllowed("brief_messages_send_user", `${brief.id}:${userKey}`, {
+        max: 30,
+        refillPerSec: 30 / 60,
+      }))
+    ) {
+      return NextResponse.json(
+        { error: "You're sending messages too quickly. Try again in a minute." },
+        { status: 429 },
+      );
+    }
+
+    // ── Insert ──────────────────────────────────────────────────────────
+    const row = await sendMessage({
+      briefId: brief.id,
+      senderKind: sender.kind,
+      senderUserId: sender.userId,
+      senderProfessionalId: sender.professionalId,
+      senderTeamId: sender.teamId,
+      body: parsed.data.body,
+    });
+
+    return NextResponse.json({ message: row });
+  } catch (err) {
+    if (err instanceof BriefMessageError) {
+      return NextResponse.json({ error: err.message }, { status: err.status });
+    }
+    log.error("send brief message failed", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json({ error: "Failed to send message." }, { status: 500 });
+  }
+}
+
+/**
+ * Resolve who is sending. Priority:
+ *   1. Advisor session → professional. If the brief was accepted by a team
+ *      we belong to, send as 'team'; otherwise as 'professional'.
+ *   2. Supabase Auth (auth.users) where the email matches contact_email → 'consumer'.
+ *
+ * Returns null if neither path matches — the route 401s in that case.
+ */
+async function resolveSender(
+  request: NextRequest,
+  brief: BriefMeta,
+): Promise<ResolvedSender | null> {
+  const advisorId = await requireAdvisorSession(request);
+  if (advisorId) {
+    // Is this advisor the accepted professional?
+    if (
+      brief.accepted_by_professional_id !== null &&
+      brief.accepted_by_professional_id === advisorId
+    ) {
+      // If they accepted on behalf of a team, send-as 'team' so the
+      // consumer sees the team name. Otherwise individual 'professional'.
+      if (brief.accepted_by_team_id !== null) {
+        const onTeam = await isProfessionalOnTeam(
+          brief.accepted_by_team_id,
+          advisorId,
+        );
+        if (onTeam) {
+          return {
+            kind: "team",
+            userId: null,
+            professionalId: advisorId,
+            teamId: brief.accepted_by_team_id,
+          };
+        }
+      }
+      return {
+        kind: "professional",
+        userId: null,
+        professionalId: advisorId,
+        teamId: null,
+      };
+    }
+    // Not the accepted lead, but still an active member of the accepted team?
+    if (brief.accepted_by_team_id !== null) {
+      const onTeam = await isProfessionalOnTeam(
+        brief.accepted_by_team_id,
+        advisorId,
+      );
+      if (onTeam) {
+        return {
+          kind: "team",
+          userId: null,
+          professionalId: advisorId,
+          teamId: brief.accepted_by_team_id,
+        };
+      }
+    }
+    // Falls through — advisor is signed in but not on this brief's pro/team
+    // side. Could still be the consumer (a pro buying advice for themselves);
+    // continue to the consumer-path check below.
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (user?.email && brief.contact_email) {
+    if (user.email.toLowerCase() === brief.contact_email.toLowerCase()) {
+      return {
+        kind: "consumer",
+        userId: user.id,
+        professionalId: null,
+        teamId: null,
+      };
+    }
+  }
+  return null;
+}

--- a/app/api/pros/[slug]/availability/route.ts
+++ b/app/api/pros/[slug]/availability/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { createAdminClient } from "@/lib/supabase/admin";
+import { isAllowed, ipKey } from "@/lib/rate-limit-db";
+import { logger } from "@/lib/logger";
+import { listAvailabilityForPro } from "@/lib/consultations";
+
+const log = logger("consultations:availability");
+
+/**
+ * GET /api/pros/[slug]/availability — Public list of a pro's open
+ * availability slots. Anon-readable so the consumer can render the
+ * options on the brief tracker without signing in.
+ */
+export async function GET(
+  request: NextRequest,
+  ctx: { params: Promise<{ slug: string }> },
+) {
+  try {
+    if (
+      !(await isAllowed("pros_availability_public", ipKey(request), {
+        max: 120,
+        refillPerSec: 2,
+      }))
+    ) {
+      return NextResponse.json({ error: "Too many requests." }, { status: 429 });
+    }
+    const { slug } = await ctx.params;
+    if (!slug || slug.length > 200) {
+      return NextResponse.json({ error: "Invalid slug." }, { status: 400 });
+    }
+
+    const admin = createAdminClient();
+    const { data: pro } = await admin
+      .from("professionals")
+      .select("id, name, slug")
+      .eq("slug", slug)
+      .in("status", ["active", "pending"])
+      .maybeSingle();
+    if (!pro) {
+      return NextResponse.json({ error: "Pro not found." }, { status: 404 });
+    }
+
+    const slots = await listAvailabilityForPro(pro.id as number);
+    return NextResponse.json({
+      professional: { id: pro.id, name: pro.name, slug: pro.slug },
+      slots,
+    });
+  } catch (err) {
+    log.error("public availability list error", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json(
+      { error: "Failed to list availability." },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/pros/availability/[id]/route.ts
+++ b/app/api/pros/availability/[id]/route.ts
@@ -1,0 +1,85 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { createAdminClient } from "@/lib/supabase/admin";
+import { requireAdvisorSession } from "@/lib/require-advisor-session";
+import { isAllowed, ipKey } from "@/lib/rate-limit-db";
+import { logger } from "@/lib/logger";
+
+const log = logger("consultations:availability");
+
+/**
+ * DELETE /api/pros/availability/[id] — Pro removes their own open slot.
+ *
+ * Booked slots can't be deleted via this route — the pro must cancel
+ * the booking first (which frees the slot) and then delete it.
+ */
+export async function DELETE(
+  request: NextRequest,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  try {
+    if (
+      !(await isAllowed("pros_availability_delete", ipKey(request), {
+        max: 30,
+        refillPerSec: 0.5,
+      }))
+    ) {
+      return NextResponse.json({ error: "Too many requests." }, { status: 429 });
+    }
+
+    const advisorId = await requireAdvisorSession(request);
+    if (!advisorId) {
+      return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+    }
+    const { id } = await ctx.params;
+    const slotId = Number(id);
+    if (!Number.isInteger(slotId) || slotId <= 0) {
+      return NextResponse.json({ error: "Invalid slot id." }, { status: 400 });
+    }
+
+    const admin = createAdminClient();
+    const { data: slot } = await admin
+      .from("pro_availability_slots")
+      .select("id, professional_id, status")
+      .eq("id", slotId)
+      .maybeSingle();
+    if (!slot) {
+      return NextResponse.json({ error: "Slot not found." }, { status: 404 });
+    }
+    if (slot.professional_id !== advisorId) {
+      return NextResponse.json({ error: "Not your slot." }, { status: 403 });
+    }
+    if (slot.status === "booked") {
+      return NextResponse.json(
+        { error: "Slot has been booked — cancel the booking first." },
+        { status: 409 },
+      );
+    }
+
+    const { error } = await admin
+      .from("pro_availability_slots")
+      .delete()
+      .eq("id", slotId);
+    if (error) {
+      log.warn("delete slot failed", { slotId, err: error.message });
+      return NextResponse.json(
+        { error: "Could not delete slot." },
+        { status: 500 },
+      );
+    }
+
+    log.info("availability slot deleted", {
+      slotId,
+      professionalId: advisorId,
+    });
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    log.error("availability delete error", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json(
+      { error: "Failed to delete slot." },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/pros/availability/route.ts
+++ b/app/api/pros/availability/route.ts
@@ -1,0 +1,112 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+import { requireAdvisorSession } from "@/lib/require-advisor-session";
+import { isAllowed, ipKey } from "@/lib/rate-limit-db";
+import { logger } from "@/lib/logger";
+import {
+  createSlot,
+  ConsultationError,
+  listAllSlotsForPro,
+} from "@/lib/consultations";
+
+const log = logger("consultations:availability");
+
+const Body = z.object({
+  start_at: z.string().min(1).max(64),
+  end_at: z.string().min(1).max(64),
+  team_id: z.number().int().positive().nullable().optional(),
+});
+
+/**
+ * POST /api/pros/availability — Pro publishes a new open availability slot.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    if (
+      !(await isAllowed("pros_availability_create", ipKey(request), {
+        max: 30,
+        refillPerSec: 0.5,
+      }))
+    ) {
+      return NextResponse.json({ error: "Too many requests." }, { status: 429 });
+    }
+
+    const advisorId = await requireAdvisorSession(request);
+    if (!advisorId) {
+      return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+    }
+
+    let rawBody: unknown;
+    try {
+      rawBody = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+    }
+    const parsed = Body.safeParse(rawBody);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.issues[0]?.message ?? "Invalid body." },
+        { status: 400 },
+      );
+    }
+
+    const slot = await createSlot({
+      professionalId: advisorId,
+      teamId: parsed.data.team_id ?? null,
+      startAt: parsed.data.start_at,
+      endAt: parsed.data.end_at,
+    });
+    log.info("availability slot created", {
+      slotId: slot.id,
+      professionalId: advisorId,
+    });
+    return NextResponse.json({ slot });
+  } catch (err) {
+    if (err instanceof ConsultationError) {
+      return NextResponse.json(
+        { error: err.message, code: err.code },
+        { status: err.status },
+      );
+    }
+    log.error("availability create error", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json(
+      { error: "Failed to create slot." },
+      { status: 500 },
+    );
+  }
+}
+
+/**
+ * GET /api/pros/availability — Pro's own upcoming slots (any status).
+ *
+ * Used by the pros/availability page to render the calendar view.
+ */
+export async function GET(request: NextRequest) {
+  try {
+    if (
+      !(await isAllowed("pros_availability_list", ipKey(request), {
+        max: 60,
+        refillPerSec: 1,
+      }))
+    ) {
+      return NextResponse.json({ error: "Too many requests." }, { status: 429 });
+    }
+    const advisorId = await requireAdvisorSession(request);
+    if (!advisorId) {
+      return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+    }
+    const slots = await listAllSlotsForPro(advisorId);
+    return NextResponse.json({ slots });
+  } catch (err) {
+    log.error("availability list error", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json(
+      { error: "Failed to list availability." },
+      { status: 500 },
+    );
+  }
+}

--- a/app/briefs/[slug]/BookConsultationPanel.tsx
+++ b/app/briefs/[slug]/BookConsultationPanel.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import { useEffect, useState, useTransition } from "react";
+
+import type {
+  AvailabilitySlot,
+  ConsultationBooking,
+} from "@/lib/consultations";
+
+interface Props {
+  briefSlug: string;
+  proSlug: string;
+  proName: string;
+  /** Provided when the consumer navigated with `?email=` — passed to the
+   * API as an email-as-key auth fallback for unauthenticated visitors. */
+  contactEmail: string | null;
+  existingBooking: ConsultationBooking | null;
+  existingSlot: AvailabilitySlot | null;
+}
+
+export default function BookConsultationPanel({
+  briefSlug,
+  proSlug,
+  proName,
+  contactEmail,
+  existingBooking,
+  existingSlot,
+}: Props) {
+  const [slots, setSlots] = useState<AvailabilitySlot[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [notes, setNotes] = useState("");
+  const [pending, startTransition] = useTransition();
+  const [booking, setBooking] = useState<ConsultationBooking | null>(
+    existingBooking,
+  );
+  const [bookedSlot, setBookedSlot] = useState<AvailabilitySlot | null>(
+    existingSlot,
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    if (booking) return;
+    setLoading(true);
+    fetch(`/api/pros/${proSlug}/availability`)
+      .then((r) => r.json())
+      .then((body: { slots?: AvailabilitySlot[]; error?: string }) => {
+        if (cancelled) return;
+        if (body.slots) setSlots(body.slots);
+      })
+      .catch(() => {
+        /* silent */
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [proSlug, booking]);
+
+  function handleBook(slot: AvailabilitySlot) {
+    setError(null);
+    startTransition(async () => {
+      try {
+        const body: Record<string, unknown> = { slot_id: slot.id };
+        if (notes.trim()) body.notes = notes.trim();
+        if (contactEmail) body.contact_email = contactEmail;
+        const res = await fetch(`/api/briefs/${briefSlug}/book-slot`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(body),
+        });
+        const parsed = (await res.json().catch(() => ({}))) as {
+          booking?: ConsultationBooking;
+          slot?: AvailabilitySlot;
+          error?: string;
+        };
+        if (!res.ok || !parsed.booking) {
+          throw new Error(parsed.error ?? `HTTP ${res.status}`);
+        }
+        setBooking(parsed.booking);
+        setBookedSlot(parsed.slot ?? slot);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to book.");
+      }
+    });
+  }
+
+  if (booking) {
+    return (
+      <div className="bg-emerald-50 border border-emerald-200 rounded-2xl p-5">
+        <p className="text-xs uppercase tracking-widest text-emerald-700 mb-2">
+          {booking.status === "confirmed"
+            ? "Meeting confirmed"
+            : "Booking received"}
+        </p>
+        <p className="text-base font-bold text-emerald-900">
+          {bookedSlot ? formatRange(bookedSlot.start_at, bookedSlot.end_at) : ""}
+        </p>
+        <p className="text-sm text-emerald-800 mt-1">with {proName}</p>
+        {booking.meet_url && (
+          <p className="text-sm mt-3">
+            <span className="font-semibold">Meeting link:</span>{" "}
+            <a
+              href={booking.meet_url}
+              className="text-emerald-700 underline break-all"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {booking.meet_url}
+            </a>
+          </p>
+        )}
+        {booking.status === "pending" && (
+          <p className="text-xs text-emerald-700 mt-3">
+            {proName} will confirm shortly and share a meeting link.
+          </p>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white rounded-2xl border border-slate-200 p-5">
+      <p className="text-xs uppercase tracking-widest text-slate-500 mb-2">
+        Book a consultation
+      </p>
+      <p className="text-sm text-slate-600 mb-4">
+        Pick an open slot from {proName}&apos;s availability below.
+      </p>
+
+      {loading && <p className="text-sm text-slate-500">Loading availability…</p>}
+
+      {!loading && slots.length === 0 && (
+        <p className="text-sm text-slate-500">
+          {proName} hasn&apos;t published any availability yet. They&apos;ll
+          email you to coordinate a time.
+        </p>
+      )}
+
+      {slots.length > 0 && (
+        <>
+          <label className="block mb-3">
+            <span className="text-xs text-slate-600 font-semibold">
+              Notes for {proName} (optional)
+            </span>
+            <textarea
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              rows={2}
+              maxLength={2000}
+              className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm"
+              placeholder="Anything they should know before the call?"
+            />
+          </label>
+
+          {error && (
+            <p className="text-xs text-rose-600 bg-rose-50 border border-rose-200 rounded-lg px-3 py-2 mb-3">
+              {error}
+            </p>
+          )}
+
+          <ul className="space-y-2">
+            {slots.map((s) => (
+              <li
+                key={s.id}
+                className="flex items-center justify-between bg-slate-50 rounded-xl border border-slate-200 p-3"
+              >
+                <p className="text-sm font-semibold text-slate-900">
+                  {formatRange(s.start_at, s.end_at)}
+                </p>
+                <button
+                  type="button"
+                  onClick={() => handleBook(s)}
+                  disabled={pending}
+                  className="rounded-lg bg-amber-500 px-3 py-1.5 text-xs font-semibold text-slate-900 hover:bg-amber-400 disabled:opacity-50"
+                >
+                  {pending ? "Booking…" : "Book"}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+    </div>
+  );
+}
+
+function formatRange(startAt: string, endAt: string): string {
+  const start = new Date(startAt);
+  const end = new Date(endAt);
+  const startStr = start.toLocaleString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+  const endStr = end.toLocaleString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+  return `${startStr} → ${endStr}`;
+}

--- a/app/briefs/[slug]/BriefChatPanel.tsx
+++ b/app/briefs/[slug]/BriefChatPanel.tsx
@@ -1,0 +1,300 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { createClient } from "@/lib/supabase/client";
+import {
+  BRIEF_MESSAGE_MAX_BODY_LENGTH,
+  type BriefMessageRow,
+} from "@/lib/brief-messages";
+
+interface Props {
+  slug: string;
+  briefId: number;
+  initialMessages: BriefMessageRow[];
+  /** "consumer" | "pro" — controls which read-state column we flip & label alignment. */
+  viewerSide: "consumer" | "pro";
+  /** Display name we show next to the viewer's own sent rows. */
+  viewerName: string;
+  /** Display name we show next to messages from the other side. */
+  counterpartyName: string;
+}
+
+interface DisplayMessage extends BriefMessageRow {
+  /** Optimistic-only id (negative); replaced when the server insert lands. */
+  optimistic?: boolean;
+}
+
+function formatTime(iso: string): string {
+  const d = new Date(iso);
+  const today = new Date();
+  const sameDay =
+    d.getFullYear() === today.getFullYear() &&
+    d.getMonth() === today.getMonth() &&
+    d.getDate() === today.getDate();
+  if (sameDay) {
+    return d.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
+  }
+  return d.toLocaleString([], {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function senderIsViewer(
+  msg: BriefMessageRow,
+  viewerSide: "consumer" | "pro",
+): boolean {
+  if (viewerSide === "consumer") return msg.sender_kind === "consumer";
+  return msg.sender_kind === "professional" || msg.sender_kind === "team";
+}
+
+export default function BriefChatPanel({
+  slug,
+  briefId,
+  initialMessages,
+  viewerSide,
+  viewerName,
+  counterpartyName,
+}: Props) {
+  const [messages, setMessages] = useState<DisplayMessage[]>(initialMessages);
+  const [draft, setDraft] = useState("");
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
+
+  // Stable ref for the mark-read fetch so the IntersectionObserver effect
+  // doesn't need to re-create on every render.
+  const markReadInflight = useRef(false);
+
+  const markRead = useCallback(async () => {
+    if (markReadInflight.current) return;
+    markReadInflight.current = true;
+    try {
+      await fetch(`/api/briefs/${slug}/messages/mark-read`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{}",
+      });
+    } catch {
+      /* fire-and-forget — UI is unaffected on failure */
+    } finally {
+      markReadInflight.current = false;
+    }
+  }, [slug]);
+
+  // ── Realtime subscription ────────────────────────────────────────────
+  useEffect(() => {
+    const supabase = createClient();
+    const channel = supabase
+      .channel(`brief-messages-${briefId}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "INSERT",
+          schema: "public",
+          table: "brief_messages",
+          filter: `brief_id=eq.${briefId}`,
+        },
+        (payload) => {
+          const row = payload.new as BriefMessageRow;
+          setMessages((prev) => {
+            // De-dup: server may echo our own optimistic insert. Replace any
+            // optimistic placeholder with matching body+sender_kind from this
+            // viewer instead of appending a duplicate.
+            const optimisticIdx = prev.findIndex(
+              (m) =>
+                m.optimistic === true &&
+                m.body === row.body &&
+                m.sender_kind === row.sender_kind,
+            );
+            if (optimisticIdx >= 0) {
+              const next = prev.slice();
+              next[optimisticIdx] = row;
+              return next;
+            }
+            if (prev.some((m) => m.id === row.id)) return prev;
+            return [...prev, row];
+          });
+        },
+      )
+      .subscribe();
+
+    return () => {
+      // Critical: avoid Realtime channel leaks across remounts (Strict
+      // Mode dev, route transitions, etc.). removeChannel awaits the
+      // unsubscribe internally.
+      void supabase.removeChannel(channel);
+    };
+  }, [briefId]);
+
+  // ── Auto-scroll to bottom on new messages ───────────────────────────
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollTop = el.scrollHeight;
+  }, [messages.length]);
+
+  // ── Mark-as-read when the panel is visible ──────────────────────────
+  useEffect(() => {
+    const el = panelRef.current;
+    if (!el || typeof IntersectionObserver === "undefined") {
+      // Fallback: fire once on mount.
+      void markRead();
+      return;
+    }
+    const obs = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            void markRead();
+          }
+        }
+      },
+      { threshold: 0.1 },
+    );
+    obs.observe(el);
+    return () => obs.disconnect();
+  }, [markRead, messages.length]);
+
+  async function onSend(e: React.FormEvent): Promise<void> {
+    e.preventDefault();
+    const trimmed = draft.trim();
+    if (trimmed.length === 0 || sending) return;
+    if (trimmed.length > BRIEF_MESSAGE_MAX_BODY_LENGTH) {
+      setError(
+        `Message must be ${BRIEF_MESSAGE_MAX_BODY_LENGTH} characters or fewer.`,
+      );
+      return;
+    }
+    setError(null);
+    setSending(true);
+    const optimisticId = -Date.now();
+    const optimistic: DisplayMessage = {
+      id: optimisticId,
+      brief_id: briefId,
+      sender_kind:
+        viewerSide === "consumer"
+          ? "consumer"
+          : ("professional" as const),
+      sender_user_id: null,
+      sender_professional_id: null,
+      sender_team_id: null,
+      body: trimmed,
+      read_by_consumer_at: null,
+      read_by_pro_at: null,
+      created_at: new Date().toISOString(),
+      optimistic: true,
+    };
+    setMessages((prev) => [...prev, optimistic]);
+    setDraft("");
+
+    try {
+      const res = await fetch(`/api/briefs/${slug}/messages`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ body: trimmed }),
+      });
+      const json = (await res.json()) as {
+        error?: string;
+        message?: BriefMessageRow;
+      };
+      if (!res.ok || !json.message) {
+        throw new Error(json.error ?? "Could not send message.");
+      }
+      // Reconcile: replace the optimistic row with the server row.
+      setMessages((prev) =>
+        prev.map((m) => (m.id === optimisticId ? json.message! : m)),
+      );
+    } catch (err) {
+      // Roll the optimistic row back so the user can retry.
+      setMessages((prev) => prev.filter((m) => m.id !== optimisticId));
+      setDraft(trimmed);
+      setError(err instanceof Error ? err.message : "Could not send message.");
+    } finally {
+      setSending(false);
+    }
+  }
+
+  return (
+    <div
+      ref={panelRef}
+      className="bg-white rounded-2xl border border-slate-200 p-6 mb-6"
+    >
+      <p className="text-xs uppercase tracking-widest text-slate-500 mb-3">
+        Chat
+      </p>
+
+      <div
+        ref={scrollRef}
+        className="max-h-80 overflow-y-auto rounded-xl border border-slate-100 bg-slate-50 p-3 mb-3 space-y-2"
+        aria-live="polite"
+        aria-label="Conversation"
+      >
+        {messages.length === 0 && (
+          <p className="text-xs text-slate-500 text-center py-4">
+            No messages yet. Send the first one below.
+          </p>
+        )}
+        {messages.map((m) => {
+          const mine = senderIsViewer(m, viewerSide);
+          return (
+            <div
+              key={m.id}
+              className={`flex ${mine ? "justify-end" : "justify-start"}`}
+            >
+              <div
+                className={`max-w-[80%] rounded-2xl px-3 py-2 text-sm ${
+                  mine
+                    ? "bg-amber-500 text-slate-900"
+                    : "bg-white border border-slate-200 text-slate-800"
+                } ${m.optimistic ? "opacity-70" : ""}`}
+              >
+                <p className="text-[10px] font-semibold mb-0.5 opacity-80">
+                  {mine ? viewerName : counterpartyName}
+                </p>
+                <p className="whitespace-pre-line break-words">{m.body}</p>
+                <p className="text-[10px] mt-1 opacity-60">
+                  {formatTime(m.created_at)}
+                </p>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <form onSubmit={onSend} className="flex flex-col gap-2">
+        <textarea
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          rows={2}
+          maxLength={BRIEF_MESSAGE_MAX_BODY_LENGTH}
+          placeholder={`Message ${counterpartyName}…`}
+          className="w-full rounded-xl border border-slate-200 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-amber-300"
+          disabled={sending}
+        />
+        <div className="flex items-center justify-between">
+          <span className="text-[10px] text-slate-400">
+            {draft.length}/{BRIEF_MESSAGE_MAX_BODY_LENGTH}
+          </span>
+          <button
+            type="submit"
+            disabled={sending || draft.trim().length === 0}
+            className="rounded-xl bg-slate-900 text-white text-xs font-semibold px-4 py-2 disabled:opacity-50"
+          >
+            {sending ? "Sending…" : "Send"}
+          </button>
+        </div>
+        {error && (
+          <p className="text-xs text-rose-600" role="alert">
+            {error}
+          </p>
+        )}
+      </form>
+    </div>
+  );
+}

--- a/app/briefs/[slug]/page.tsx
+++ b/app/briefs/[slug]/page.tsx
@@ -3,14 +3,17 @@ import { notFound } from "next/navigation";
 import Link from "next/link";
 
 import { createClient } from "@/lib/supabase/server";
-// eslint-disable-next-line no-restricted-imports -- The email-key tracker path has no advisor JWT but still needs to detect whether the signed-in user is the accepted pro / a member of the accepted team (expert_team_members is deny-all-anon). Per CLAUDE.md § "Two Supabase clients", cross-table membership lookups that can't be scoped to auth.uid() are a legitimate service-role use case.
-import { createAdminClient } from "@/lib/supabase/admin";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
 import { BRIEF_TEMPLATE_LABELS } from "@/lib/briefs/templates";
 import type { BriefRow, TrackerStatus } from "@/lib/briefs/types";
-import { listMessagesForBrief } from "@/lib/brief-messages";
+import {
+  getSlot,
+  listBookingsForBrief,
+  type AvailabilitySlot,
+  type ConsultationBooking,
+} from "@/lib/consultations";
 
-import BriefChatPanel from "./BriefChatPanel";
+import BookConsultationPanel from "./BookConsultationPanel";
 
 export const dynamic = "force-dynamic";
 
@@ -91,102 +94,6 @@ async function loadAccepted(brief: BriefRow): Promise<AcceptedInfo> {
   return info;
 }
 
-interface ChatBlock {
-  initialMessages: Awaited<ReturnType<typeof listMessagesForBrief>>;
-  viewerSide: "consumer" | "pro";
-  viewerName: string;
-  counterpartyName: string;
-}
-
-/**
- * Detect which side of the conversation the signed-in viewer is on
- * and pre-load the message history for SSR. Returns null if the viewer
- * isn't on either side (anonymous / wrong account) — caller hides the
- * chat panel in that case.
- *
- * Email-key access (`?email=…`) is enough for *visibility* of the
- * tracker, but the chat panel writes via authenticated API routes that
- * gate on auth.users / advisor session. We render the panel for the
- * email-key consumer path because the API will 401 if they aren't
- * actually signed-in — better to show the input + a clear error than
- * silently hide the chat from the brief owner.
- */
-async function loadChatContext(
-  brief: BriefRow,
-  emailMatches: boolean,
-  accepted: AcceptedInfo,
-): Promise<ChatBlock | null> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  const proName =
-    accepted.team?.name ?? accepted.professional?.name ?? "Your provider";
-  const consumerName = brief.contact_name?.trim() || "You";
-
-  let viewerSide: "consumer" | "pro" | null = null;
-
-  // Pro side: signed-in user matches the accepted professional (by email
-  // — pros log in via Supabase auth, and the professionals.email column
-  // is the same address). Membership lookups on expert_team_members are
-  // deny-all-anon so we use the service-role admin client for those reads.
-  if (user?.email) {
-    const admin = createAdminClient();
-    const { data: pro } = await admin
-      .from("professionals")
-      .select("id")
-      .eq("email", user.email)
-      .maybeSingle();
-    if (pro) {
-      if (
-        brief.accepted_by_professional_id !== null &&
-        (pro.id as number) === brief.accepted_by_professional_id
-      ) {
-        viewerSide = "pro";
-      } else if (brief.accepted_by_team_id !== null) {
-        const { data: membership } = await admin
-          .from("expert_team_members")
-          .select("id")
-          .eq("team_id", brief.accepted_by_team_id)
-          .eq("professional_id", pro.id as number)
-          .eq("status", "active")
-          .maybeSingle();
-        if (membership) viewerSide = "pro";
-      }
-    }
-  }
-
-  // Consumer side: signed-in email matches contact_email, OR the
-  // email-key query string matched (covers the magic-link path before
-  // a full auth session is established).
-  if (
-    viewerSide === null &&
-    ((user?.email &&
-      brief.contact_email &&
-      user.email.toLowerCase() === brief.contact_email.toLowerCase()) ||
-      emailMatches)
-  ) {
-    viewerSide = "consumer";
-  }
-
-  if (viewerSide === null) return null;
-
-  let initialMessages: Awaited<ReturnType<typeof listMessagesForBrief>> = [];
-  try {
-    initialMessages = await listMessagesForBrief(brief.id);
-  } catch {
-    // Non-fatal — render an empty chat. Error logged in the helper.
-  }
-
-  return {
-    initialMessages,
-    viewerSide,
-    viewerName: viewerSide === "consumer" ? consumerName : proName,
-    counterpartyName: viewerSide === "consumer" ? proName : consumerName,
-  };
-}
-
 export default async function BriefTrackerPage({
   params,
   searchParams,
@@ -214,14 +121,19 @@ export default async function BriefTrackerPage({
 
   const accepted = await loadAccepted(brief);
 
-  // ── Chat-panel visibility ──────────────────────────────────────────
-  // Only render the chat panel once a provider has accepted the brief.
-  // We also need to know which "side" the viewer is on so the bubble
-  // alignment + mark-read column match. Anonymous viewers (no JWT, no
-  // email match) don't see the panel at all.
-  const chatBlock = brief.accepted_at
-    ? await loadChatContext(brief, emailMatches, accepted)
-    : null;
+  // Load any existing consultation booking for this brief (latest non-cancelled).
+  let existingBooking: ConsultationBooking | null = null;
+  let existingSlot: AvailabilitySlot | null = null;
+  if (accepted.professional) {
+    const bookings = await listBookingsForBrief(brief.id);
+    const active = bookings.find(
+      (b) => b.status === "pending" || b.status === "confirmed",
+    );
+    if (active) {
+      existingBooking = active;
+      existingSlot = await getSlot(active.slot_id);
+    }
+  }
 
   const stepIndex = STATUS_ORDER.indexOf(brief.tracker_status);
 
@@ -278,16 +190,13 @@ export default async function BriefTrackerPage({
               </div>
             )}
 
-            {/* 5 status dots side-by-side. Labels can wrap to 2 lines on
-                narrow viewports — `break-words` prevents the longest label
-                ("Engagement confirmed") from forcing horizontal overflow. */}
-            <ol className="mt-4 grid grid-cols-5 gap-1.5 sm:gap-2">
+            <ol className="mt-4 grid grid-cols-5 gap-2">
               {STATUS_ORDER.map((s, idx) => {
                 const reached = idx <= stepIndex;
                 return (
-                  <li key={s} className="text-center min-w-0">
+                  <li key={s} className="text-center">
                     <div
-                      className={`w-7 h-7 rounded-full mx-auto flex items-center justify-center text-[11px] font-bold ${
+                      className={`w-7 h-7 rounded-full mx-auto flex items-center justify-center text-[10px] font-bold ${
                         reached
                           ? "bg-amber-500 text-slate-900"
                           : "bg-slate-100 text-slate-400"
@@ -296,7 +205,7 @@ export default async function BriefTrackerPage({
                       {idx + 1}
                     </div>
                     <p
-                      className={`text-[10px] sm:text-[11px] mt-1 leading-tight break-words ${
+                      className={`text-[10px] mt-1 ${
                         reached ? "text-slate-700 font-semibold" : "text-slate-400"
                       }`}
                     >
@@ -346,16 +255,18 @@ export default async function BriefTrackerPage({
             </div>
           )}
 
-          {/* Chat panel — only renders once a provider has accepted */}
-          {chatBlock && (
-            <BriefChatPanel
-              slug={brief.slug}
-              briefId={brief.id}
-              initialMessages={chatBlock.initialMessages}
-              viewerSide={chatBlock.viewerSide}
-              viewerName={chatBlock.viewerName}
-              counterpartyName={chatBlock.counterpartyName}
-            />
+          {/* Book consultation — only shown once the brief is accepted */}
+          {accepted.professional?.slug && (
+            <div className="mb-6">
+              <BookConsultationPanel
+                briefSlug={brief.slug}
+                proSlug={accepted.professional.slug}
+                proName={accepted.professional.name}
+                contactEmail={emailMatches ? email : null}
+                existingBooking={existingBooking}
+                existingSlot={existingSlot}
+              />
+            </div>
           )}
 
           {/* Brief summary */}
@@ -398,7 +309,7 @@ export default async function BriefTrackerPage({
           {!emailMatches && (
             <div className="bg-slate-100 border border-slate-200 rounded-2xl p-4 text-xs text-slate-600">
               Looking for the full owner view? Use the link we emailed you, or
-              add <code className="break-all">?email=&lt;your-email&gt;</code> to this page.
+              add <code>?email=&lt;your-email&gt;</code> to this page.
             </div>
           )}
         </div>

--- a/app/briefs/[slug]/page.tsx
+++ b/app/briefs/[slug]/page.tsx
@@ -3,9 +3,14 @@ import { notFound } from "next/navigation";
 import Link from "next/link";
 
 import { createClient } from "@/lib/supabase/server";
+// eslint-disable-next-line no-restricted-imports -- The email-key tracker path has no advisor JWT but still needs to detect whether the signed-in user is the accepted pro / a member of the accepted team (expert_team_members is deny-all-anon). Per CLAUDE.md § "Two Supabase clients", cross-table membership lookups that can't be scoped to auth.uid() are a legitimate service-role use case.
+import { createAdminClient } from "@/lib/supabase/admin";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
 import { BRIEF_TEMPLATE_LABELS } from "@/lib/briefs/templates";
 import type { BriefRow, TrackerStatus } from "@/lib/briefs/types";
+import { listMessagesForBrief } from "@/lib/brief-messages";
+
+import BriefChatPanel from "./BriefChatPanel";
 
 export const dynamic = "force-dynamic";
 
@@ -86,6 +91,102 @@ async function loadAccepted(brief: BriefRow): Promise<AcceptedInfo> {
   return info;
 }
 
+interface ChatBlock {
+  initialMessages: Awaited<ReturnType<typeof listMessagesForBrief>>;
+  viewerSide: "consumer" | "pro";
+  viewerName: string;
+  counterpartyName: string;
+}
+
+/**
+ * Detect which side of the conversation the signed-in viewer is on
+ * and pre-load the message history for SSR. Returns null if the viewer
+ * isn't on either side (anonymous / wrong account) — caller hides the
+ * chat panel in that case.
+ *
+ * Email-key access (`?email=…`) is enough for *visibility* of the
+ * tracker, but the chat panel writes via authenticated API routes that
+ * gate on auth.users / advisor session. We render the panel for the
+ * email-key consumer path because the API will 401 if they aren't
+ * actually signed-in — better to show the input + a clear error than
+ * silently hide the chat from the brief owner.
+ */
+async function loadChatContext(
+  brief: BriefRow,
+  emailMatches: boolean,
+  accepted: AcceptedInfo,
+): Promise<ChatBlock | null> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  const proName =
+    accepted.team?.name ?? accepted.professional?.name ?? "Your provider";
+  const consumerName = brief.contact_name?.trim() || "You";
+
+  let viewerSide: "consumer" | "pro" | null = null;
+
+  // Pro side: signed-in user matches the accepted professional (by email
+  // — pros log in via Supabase auth, and the professionals.email column
+  // is the same address). Membership lookups on expert_team_members are
+  // deny-all-anon so we use the service-role admin client for those reads.
+  if (user?.email) {
+    const admin = createAdminClient();
+    const { data: pro } = await admin
+      .from("professionals")
+      .select("id")
+      .eq("email", user.email)
+      .maybeSingle();
+    if (pro) {
+      if (
+        brief.accepted_by_professional_id !== null &&
+        (pro.id as number) === brief.accepted_by_professional_id
+      ) {
+        viewerSide = "pro";
+      } else if (brief.accepted_by_team_id !== null) {
+        const { data: membership } = await admin
+          .from("expert_team_members")
+          .select("id")
+          .eq("team_id", brief.accepted_by_team_id)
+          .eq("professional_id", pro.id as number)
+          .eq("status", "active")
+          .maybeSingle();
+        if (membership) viewerSide = "pro";
+      }
+    }
+  }
+
+  // Consumer side: signed-in email matches contact_email, OR the
+  // email-key query string matched (covers the magic-link path before
+  // a full auth session is established).
+  if (
+    viewerSide === null &&
+    ((user?.email &&
+      brief.contact_email &&
+      user.email.toLowerCase() === brief.contact_email.toLowerCase()) ||
+      emailMatches)
+  ) {
+    viewerSide = "consumer";
+  }
+
+  if (viewerSide === null) return null;
+
+  let initialMessages: Awaited<ReturnType<typeof listMessagesForBrief>> = [];
+  try {
+    initialMessages = await listMessagesForBrief(brief.id);
+  } catch {
+    // Non-fatal — render an empty chat. Error logged in the helper.
+  }
+
+  return {
+    initialMessages,
+    viewerSide,
+    viewerName: viewerSide === "consumer" ? consumerName : proName,
+    counterpartyName: viewerSide === "consumer" ? proName : consumerName,
+  };
+}
+
 export default async function BriefTrackerPage({
   params,
   searchParams,
@@ -112,6 +213,15 @@ export default async function BriefTrackerPage({
     !!email && (brief.contact_email ?? "").toLowerCase() === email;
 
   const accepted = await loadAccepted(brief);
+
+  // ── Chat-panel visibility ──────────────────────────────────────────
+  // Only render the chat panel once a provider has accepted the brief.
+  // We also need to know which "side" the viewer is on so the bubble
+  // alignment + mark-read column match. Anonymous viewers (no JWT, no
+  // email match) don't see the panel at all.
+  const chatBlock = brief.accepted_at
+    ? await loadChatContext(brief, emailMatches, accepted)
+    : null;
 
   const stepIndex = STATUS_ORDER.indexOf(brief.tracker_status);
 
@@ -231,6 +341,18 @@ export default async function BriefTrackerPage({
                 team you engage — under their own licence and terms.
               </p>
             </div>
+          )}
+
+          {/* Chat panel — only renders once a provider has accepted */}
+          {chatBlock && (
+            <BriefChatPanel
+              slug={brief.slug}
+              briefId={brief.id}
+              initialMessages={chatBlock.initialMessages}
+              viewerSide={chatBlock.viewerSide}
+              viewerName={chatBlock.viewerName}
+              counterpartyName={chatBlock.counterpartyName}
+            />
           )}
 
           {/* Brief summary */}

--- a/app/pros/availability/AvailabilityClient.tsx
+++ b/app/pros/availability/AvailabilityClient.tsx
@@ -1,0 +1,239 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+
+import type { AvailabilitySlot } from "@/lib/consultations";
+
+interface Props {
+  initialSlots: AvailabilitySlot[];
+}
+
+type Duration = 30 | 60;
+
+export default function AvailabilityClient({ initialSlots }: Props) {
+  const [slots, setSlots] = useState<AvailabilitySlot[]>(initialSlots);
+  const [startAt, setStartAt] = useState<string>("");
+  const [duration, setDuration] = useState<Duration>(30);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  const { upcoming, past } = useMemo(() => {
+    const now = Date.now();
+    const up: AvailabilitySlot[] = [];
+    const ps: AvailabilitySlot[] = [];
+    for (const s of slots) {
+      if (new Date(s.start_at).getTime() >= now) up.push(s);
+      else ps.push(s);
+    }
+    up.sort(
+      (a, b) =>
+        new Date(a.start_at).getTime() - new Date(b.start_at).getTime(),
+    );
+    ps.sort(
+      (a, b) =>
+        new Date(b.start_at).getTime() - new Date(a.start_at).getTime(),
+    );
+    return { upcoming: up, past: ps };
+  }, [slots]);
+
+  function handleAdd(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    if (!startAt) {
+      setError("Pick a start time.");
+      return;
+    }
+    const start = new Date(startAt);
+    if (Number.isNaN(start.getTime())) {
+      setError("Invalid start time.");
+      return;
+    }
+    const end = new Date(start.getTime() + duration * 60 * 1000);
+
+    startTransition(async () => {
+      try {
+        const res = await fetch("/api/pros/availability", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            start_at: start.toISOString(),
+            end_at: end.toISOString(),
+          }),
+        });
+        const body = (await res.json().catch(() => ({}))) as {
+          slot?: AvailabilitySlot;
+          error?: string;
+        };
+        if (!res.ok || !body.slot) {
+          throw new Error(body.error ?? `HTTP ${res.status}`);
+        }
+        setSlots((prev) => [...prev, body.slot!]);
+        setStartAt("");
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to add slot.");
+      }
+    });
+  }
+
+  function handleDelete(slotId: number) {
+    if (!window.confirm("Remove this slot?")) return;
+    setError(null);
+    startTransition(async () => {
+      try {
+        const res = await fetch(`/api/pros/availability/${slotId}`, {
+          method: "DELETE",
+        });
+        if (!res.ok) {
+          const body = (await res.json().catch(() => ({}))) as { error?: string };
+          throw new Error(body.error ?? `HTTP ${res.status}`);
+        }
+        setSlots((prev) => prev.filter((s) => s.id !== slotId));
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to remove slot.");
+      }
+    });
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Add slot form */}
+      <form
+        onSubmit={handleAdd}
+        className="bg-white rounded-2xl border border-slate-200 p-5 space-y-3"
+      >
+        <h2 className="text-sm font-bold text-slate-900">Add a slot</h2>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <label className="block">
+            <span className="text-xs text-slate-600 font-semibold">
+              Start (your local time)
+            </span>
+            <input
+              type="datetime-local"
+              value={startAt}
+              onChange={(e) => setStartAt(e.target.value)}
+              className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm"
+              required
+            />
+          </label>
+          <label className="block">
+            <span className="text-xs text-slate-600 font-semibold">
+              Duration
+            </span>
+            <select
+              value={duration}
+              onChange={(e) =>
+                setDuration(Number(e.target.value) === 60 ? 60 : 30)
+              }
+              className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm"
+            >
+              <option value={30}>30 minutes</option>
+              <option value={60}>60 minutes</option>
+            </select>
+          </label>
+        </div>
+
+        {error && (
+          <p className="text-xs text-rose-600 bg-rose-50 border border-rose-200 rounded-lg px-3 py-2">
+            {error}
+          </p>
+        )}
+
+        <button
+          type="submit"
+          disabled={pending}
+          className="rounded-lg bg-amber-500 px-4 py-2 text-sm font-semibold text-slate-900 hover:bg-amber-400 disabled:opacity-50"
+        >
+          {pending ? "Saving…" : "Add slot"}
+        </button>
+      </form>
+
+      {/* Upcoming */}
+      <section>
+        <h2 className="text-sm font-bold text-slate-900 mb-3">
+          Upcoming ({upcoming.length})
+        </h2>
+        {upcoming.length === 0 ? (
+          <p className="text-sm text-slate-500">
+            No upcoming slots yet. Add one above so accepted clients can book.
+          </p>
+        ) : (
+          <ul className="space-y-2">
+            {upcoming.map((s) => (
+              <li
+                key={s.id}
+                className="flex items-center justify-between bg-white rounded-xl border border-slate-200 p-3"
+              >
+                <div>
+                  <p className="text-sm font-semibold text-slate-900">
+                    {formatRange(s.start_at, s.end_at)}
+                  </p>
+                  <p className="text-xs text-slate-500">
+                    Status:{" "}
+                    <span
+                      className={
+                        s.status === "booked"
+                          ? "text-amber-600 font-semibold"
+                          : s.status === "cancelled"
+                            ? "text-slate-400"
+                            : "text-emerald-600 font-semibold"
+                      }
+                    >
+                      {s.status}
+                    </span>
+                  </p>
+                </div>
+                {s.status === "open" && (
+                  <button
+                    type="button"
+                    onClick={() => handleDelete(s.id)}
+                    disabled={pending}
+                    className="text-xs text-slate-500 hover:text-rose-600 disabled:opacity-50"
+                  >
+                    Remove
+                  </button>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {/* Past */}
+      {past.length > 0 && (
+        <section>
+          <h2 className="text-sm font-bold text-slate-900 mb-3">Past</h2>
+          <ul className="space-y-2">
+            {past.map((s) => (
+              <li
+                key={s.id}
+                className="flex items-center justify-between bg-slate-50 rounded-xl border border-slate-200 p-3"
+              >
+                <p className="text-sm text-slate-600">
+                  {formatRange(s.start_at, s.end_at)}
+                </p>
+                <span className="text-xs text-slate-400">{s.status}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </div>
+  );
+}
+
+function formatRange(startAt: string, endAt: string): string {
+  const start = new Date(startAt);
+  const end = new Date(endAt);
+  const startStr = start.toLocaleString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+  const endStr = end.toLocaleString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+  return `${startStr} → ${endStr}`;
+}

--- a/app/pros/availability/page.tsx
+++ b/app/pros/availability/page.tsx
@@ -1,0 +1,72 @@
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+import Link from "next/link";
+
+// eslint-disable-next-line no-restricted-imports -- pro-settings surface; mirrors app/pros/settings/pricing-tier/page.tsx.
+import { createAdminClient } from "@/lib/supabase/admin";
+import { createClient } from "@/lib/supabase/server";
+import { SITE_URL } from "@/lib/seo";
+import { listAllSlotsForPro } from "@/lib/consultations";
+
+import AvailabilityClient from "./AvailabilityClient";
+
+export const metadata: Metadata = {
+  title: "Availability — Invest.com.au",
+  description: "Manage your consultation availability slots.",
+  alternates: { canonical: `${SITE_URL}/pros/availability` },
+  robots: { index: false, follow: false },
+};
+
+export const dynamic = "force-dynamic";
+
+export default async function ProsAvailabilityPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    redirect("/account/login?redirect=/pros/availability");
+  }
+
+  const admin = createAdminClient();
+  const { data: pro } = await admin
+    .from("professionals")
+    .select("id, name")
+    .or(`auth_user_id.eq.${user.id},email.eq.${user.email}`)
+    .in("status", ["active", "pending"])
+    .maybeSingle();
+
+  if (!pro) {
+    redirect("/pros/join");
+  }
+
+  const slots = await listAllSlotsForPro(pro.id as number);
+
+  return (
+    <main className="max-w-3xl mx-auto px-4 sm:px-6 py-10">
+      <nav className="text-xs text-slate-500 mb-4">
+        <Link href="/account" className="hover:underline">
+          Account
+        </Link>
+        <span className="mx-2">/</span>
+        <Link href="/pros/billing" className="hover:underline">
+          Pros
+        </Link>
+        <span className="mx-2">/</span>
+        <span className="text-slate-700">Availability</span>
+      </nav>
+
+      <h1 className="text-2xl font-extrabold text-slate-900 mb-2">
+        Consultation availability
+      </h1>
+      <p className="text-sm text-slate-600 mb-6 leading-relaxed">
+        Publish open windows when you&apos;re available for an intro call.
+        Consumers whose Match Request you&apos;ve accepted will see these on
+        their tracker and can book one. You confirm the booking and
+        (optionally) paste a Google Meet or Zoom link.
+      </p>
+
+      <AvailabilityClient initialSlots={slots} />
+    </main>
+  );
+}

--- a/lib/api-schemas.ts
+++ b/lib/api-schemas.ts
@@ -287,6 +287,14 @@ export const SquadCompleteBriefRequest = z.object({
   note: z.string().max(2000).optional(),
 });
 
+// ─── /api/briefs/[slug]/messages (MM32 — brief tracker chat) ──────
+
+export const SendBriefMessageRequest = z.object({
+  body: z.string().min(1).max(4000),
+});
+
+export const MarkBriefMessagesReadRequest = z.object({}).optional();
+
 export const SquadReleaseBriefRequest = z.object({
   note: z.string().max(2000).optional(),
 });

--- a/lib/brief-messages/index.ts
+++ b/lib/brief-messages/index.ts
@@ -1,0 +1,193 @@
+/**
+ * Brief messages — chat thread between the consumer and the accepted
+ * professional/team on a marketplace brief (Ship #10 / MM32).
+ *
+ * A "brief" here means a row in `public.advisor_auctions` with
+ * `flow_type='accept'`. Once a brief is accepted (`accepted_at IS NOT NULL`),
+ * the tracker page mounts a chat panel; both sides get a single shared
+ * thread keyed by `brief_id`.
+ *
+ * Helpers in this module use the service-role admin client because:
+ *   - The consumer side has anonymous (no-JWT) brief paths — the
+ *     `advisor_auctions` row is identified by slug + contact_email match,
+ *     not by `auth.uid()`. The route handlers do the authorization gate
+ *     before calling these helpers (see app/api/briefs/[slug]/messages).
+ *   - mark-read flips multiple rows at once — RLS-scoped UPDATEs work
+ *     in principle but we prefer the explicit cross-row write path to
+ *     match `team-brief-assignments.ts` and friends.
+ *
+ * Live-updates: the underlying table is added to the `supabase_realtime`
+ * publication by 20260515_mm32_brief_messages.sql. Browser subscribes via
+ * `supabase.channel('brief-messages-${briefId}')` and appends to local
+ * state on each INSERT. Mark-read is fire-and-forget; the count of
+ * unread shows up via the read_by_*_at columns on next refresh.
+ */
+
+// eslint-disable-next-line no-restricted-imports -- Anonymous consumer briefs have no JWT; cross-row mark-read updates can't be scoped to auth.uid(). Per CLAUDE.md § "Two Supabase clients", anonymous-path helpers + cross-user writes are a legitimate service-role use case.
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+
+const log = logger("brief-messages");
+
+export type BriefMessageSenderKind = "consumer" | "professional" | "team";
+export type MarkReadAsKind = "consumer" | "pro";
+
+export const BRIEF_MESSAGE_MAX_BODY_LENGTH = 4000 as const;
+
+export interface BriefMessageRow {
+  id: number;
+  brief_id: number;
+  sender_kind: BriefMessageSenderKind;
+  sender_user_id: string | null;
+  sender_professional_id: number | null;
+  sender_team_id: number | null;
+  body: string;
+  read_by_consumer_at: string | null;
+  read_by_pro_at: string | null;
+  created_at: string;
+}
+
+export interface SendMessageInput {
+  briefId: number;
+  senderKind: BriefMessageSenderKind;
+  senderUserId?: string | null;
+  senderProfessionalId?: number | null;
+  senderTeamId?: number | null;
+  body: string;
+}
+
+export interface MarkReadInput {
+  briefId: number;
+  asKind: MarkReadAsKind;
+}
+
+export class BriefMessageError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+  ) {
+    super(message);
+    this.name = "BriefMessageError";
+  }
+}
+
+function normaliseBody(raw: string): string {
+  // Trim trailing whitespace; preserve internal newlines for multi-line
+  // messages. Empty after trim → 400.
+  return raw.replace(/\s+$/g, "");
+}
+
+/**
+ * List every message on a brief in chronological order (oldest first —
+ * the UI scrolls to the bottom so the newest sits at the bottom).
+ */
+export async function listMessagesForBrief(
+  briefId: number,
+): Promise<BriefMessageRow[]> {
+  const admin = createAdminClient();
+  const { data, error } = await admin
+    .from("brief_messages")
+    .select(
+      "id, brief_id, sender_kind, sender_user_id, sender_professional_id, sender_team_id, body, read_by_consumer_at, read_by_pro_at, created_at",
+    )
+    .eq("brief_id", briefId)
+    .order("created_at", { ascending: true });
+
+  if (error) {
+    log.error("listMessagesForBrief failed", {
+      briefId,
+      error: error.message,
+    });
+    throw new BriefMessageError("Failed to load messages.", 500);
+  }
+  return (data ?? []) as BriefMessageRow[];
+}
+
+/**
+ * Insert a new message. The caller is expected to have already verified
+ * the sender's identity against the brief (route handlers do this gate).
+ * Returns the inserted row so the client can reconcile its optimistic
+ * placeholder.
+ */
+export async function sendMessage(
+  input: SendMessageInput,
+): Promise<BriefMessageRow> {
+  const body = normaliseBody(input.body);
+  if (body.length === 0) {
+    throw new BriefMessageError("Message cannot be empty.", 400);
+  }
+  if (body.length > BRIEF_MESSAGE_MAX_BODY_LENGTH) {
+    throw new BriefMessageError(
+      `Message cannot exceed ${BRIEF_MESSAGE_MAX_BODY_LENGTH} characters.`,
+      400,
+    );
+  }
+  if (input.senderKind === "professional" && !input.senderProfessionalId) {
+    throw new BriefMessageError(
+      "sender_professional_id is required when sender_kind is 'professional'.",
+      400,
+    );
+  }
+  if (input.senderKind === "team" && !input.senderTeamId) {
+    throw new BriefMessageError(
+      "sender_team_id is required when sender_kind is 'team'.",
+      400,
+    );
+  }
+
+  const admin = createAdminClient();
+  const { data, error } = await admin
+    .from("brief_messages")
+    .insert({
+      brief_id: input.briefId,
+      sender_kind: input.senderKind,
+      sender_user_id: input.senderUserId ?? null,
+      sender_professional_id: input.senderProfessionalId ?? null,
+      sender_team_id: input.senderTeamId ?? null,
+      body,
+    })
+    .select()
+    .single();
+
+  if (error || !data) {
+    log.error("sendMessage failed", {
+      briefId: input.briefId,
+      senderKind: input.senderKind,
+      error: error?.message,
+    });
+    throw new BriefMessageError("Failed to send message.", 500);
+  }
+  return data as BriefMessageRow;
+}
+
+/**
+ * Flip the appropriate `read_by_*_at` column on every previously-unread
+ * message in this brief. Idempotent — already-read rows are excluded by
+ * the `IS NULL` filter so re-calling is a no-op. Returns the count of
+ * rows updated.
+ */
+export async function markRead(input: MarkReadInput): Promise<number> {
+  const admin = createAdminClient();
+  const nowIso = new Date().toISOString();
+  const column =
+    input.asKind === "consumer" ? "read_by_consumer_at" : "read_by_pro_at";
+
+  // Only flip rows that haven't already been marked — keeps the call
+  // idempotent and prevents stomping an earlier timestamp on retries.
+  const { data, error } = await admin
+    .from("brief_messages")
+    .update({ [column]: nowIso })
+    .eq("brief_id", input.briefId)
+    .is(column, null)
+    .select("id");
+
+  if (error) {
+    log.warn("markRead failed", {
+      briefId: input.briefId,
+      asKind: input.asKind,
+      error: error.message,
+    });
+    return 0;
+  }
+  return (data ?? []).length;
+}

--- a/lib/consultations/index.ts
+++ b/lib/consultations/index.ts
@@ -1,0 +1,457 @@
+/**
+ * In-app consultation booking helpers (MM33 / Ship #5).
+ *
+ * v1 is intentionally minimal — no external calendar OAuth. The pro
+ * publishes open availability slots; the consumer (whose brief has just
+ * been accepted) picks one from the brief tracker page. The pro
+ * eventually pastes a Google Meet / Zoom URL on confirmation.
+ *
+ * Schema lives in `supabase/migrations/20260515_mm33_consultations.sql`.
+ *
+ * All mutating helpers go through the service-role admin client because:
+ *   - bookSlot needs an atomic open→booked transition the anon role
+ *     can't guarantee under RLS (no SELECT ... FOR UPDATE on the wire);
+ *   - cancelBooking touches two tables on behalf of either party;
+ *   - confirmBooking writes the pro's meet URL plus a status change.
+ * The corresponding API routes still enforce caller authorisation up
+ * front (pro session or brief-email match) — these helpers assume the
+ * caller already verified that the action is permitted.
+ */
+
+// eslint-disable-next-line no-restricted-imports -- service-role legitimate per CLAUDE.md: bookSlot performs an atomic open->booked compare-and-set across two tables (pro_availability_slots + consultation_bookings); cancelBooking and confirmBooking similarly span both tables. The API routes own authorisation; this lib enforces transactional consistency only.
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+
+const log = logger("consultations:lib");
+
+// ── Types ────────────────────────────────────────────────────────────────
+
+export type AvailabilitySlotStatus = "open" | "booked" | "cancelled";
+
+export interface AvailabilitySlot {
+  id: number;
+  professional_id: number;
+  team_id: number | null;
+  start_at: string;
+  end_at: string;
+  status: AvailabilitySlotStatus;
+  created_at: string;
+}
+
+export type BookingStatus = "pending" | "confirmed" | "cancelled" | "completed";
+
+export interface ConsultationBooking {
+  id: number;
+  slot_id: number;
+  brief_id: number;
+  consumer_user_id: string | null;
+  consumer_email: string;
+  consumer_notes: string | null;
+  meet_url: string | null;
+  status: BookingStatus;
+  created_at: string;
+  updated_at: string;
+}
+
+// ── Errors ───────────────────────────────────────────────────────────────
+
+export class ConsultationError extends Error {
+  readonly code:
+    | "invalid_input"
+    | "slot_not_found"
+    | "slot_not_open"
+    | "booking_not_found"
+    | "db_error";
+  readonly status: number;
+  constructor(
+    code: ConsultationError["code"],
+    message: string,
+    status: number,
+  ) {
+    super(message);
+    this.code = code;
+    this.status = status;
+  }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+interface CreateSlotInput {
+  professionalId: number;
+  teamId?: number | null;
+  startAt: string;
+  endAt: string;
+}
+
+/**
+ * Create a new open availability slot for a pro.
+ *
+ * Returns 400-shaped errors when start/end are invalid or the DB rejects
+ * (typically the overlap-prevention EXCLUDE constraint).
+ */
+export async function createSlot(
+  input: CreateSlotInput,
+): Promise<AvailabilitySlot> {
+  const start = new Date(input.startAt);
+  const end = new Date(input.endAt);
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+    throw new ConsultationError(
+      "invalid_input",
+      "start_at and end_at must be valid ISO timestamps.",
+      400,
+    );
+  }
+  if (end.getTime() <= start.getTime()) {
+    throw new ConsultationError(
+      "invalid_input",
+      "end_at must be strictly after start_at.",
+      400,
+    );
+  }
+
+  const admin = createAdminClient();
+  const { data, error } = await admin
+    .from("pro_availability_slots")
+    .insert({
+      professional_id: input.professionalId,
+      team_id: input.teamId ?? null,
+      start_at: start.toISOString(),
+      end_at: end.toISOString(),
+      status: "open",
+    })
+    .select("*")
+    .single();
+
+  if (error) {
+    // Most common cause: the EXCLUDE constraint fires when this slot
+    // overlaps an existing open / booked slot for the same pro.
+    log.warn("createSlot insert failed", {
+      professionalId: input.professionalId,
+      err: error.message,
+    });
+    throw new ConsultationError(
+      "db_error",
+      "Could not create slot — does it overlap with an existing one?",
+      409,
+    );
+  }
+  return data as unknown as AvailabilitySlot;
+}
+
+/**
+ * List availability for a given pro. By default returns only `open`
+ * future slots (so the brief tracker can offer them to the consumer).
+ * Callers that want booked / past slots pass an explicit window.
+ */
+export async function listAvailabilityForPro(
+  professionalId: number,
+  fromDate?: string,
+  toDate?: string,
+): Promise<AvailabilitySlot[]> {
+  const admin = createAdminClient();
+  let query = admin
+    .from("pro_availability_slots")
+    .select("*")
+    .eq("professional_id", professionalId)
+    .eq("status", "open")
+    .order("start_at", { ascending: true });
+
+  // Default lower bound: now (no past slots).
+  const lower = fromDate ?? new Date().toISOString();
+  query = query.gte("start_at", lower);
+  if (toDate) query = query.lte("start_at", toDate);
+
+  const { data, error } = await query;
+  if (error) {
+    log.warn("listAvailabilityForPro failed", {
+      professionalId,
+      err: error.message,
+    });
+    return [];
+  }
+  return (data ?? []) as unknown as AvailabilitySlot[];
+}
+
+/**
+ * Pro-side listing — includes all slot statuses, both upcoming and a
+ * 30-day history window so the pros/availability page can render what
+ * happened recently too.
+ */
+export async function listAllSlotsForPro(
+  professionalId: number,
+): Promise<AvailabilitySlot[]> {
+  const admin = createAdminClient();
+  const lower = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+  const { data, error } = await admin
+    .from("pro_availability_slots")
+    .select("*")
+    .eq("professional_id", professionalId)
+    .gte("start_at", lower)
+    .order("start_at", { ascending: true });
+  if (error) {
+    log.warn("listAllSlotsForPro failed", {
+      professionalId,
+      err: error.message,
+    });
+    return [];
+  }
+  return (data ?? []) as unknown as AvailabilitySlot[];
+}
+
+interface BookSlotInput {
+  slotId: number;
+  briefId: number;
+  consumerEmail: string;
+  consumerUserId?: string | null;
+  consumerNotes?: string | null;
+}
+
+export interface BookSlotResult {
+  slot: AvailabilitySlot;
+  booking: ConsultationBooking;
+}
+
+/**
+ * Book an open slot. Atomic in two stages:
+ *
+ *   1. UPDATE pro_availability_slots SET status='booked'
+ *      WHERE id = $1 AND status = 'open'  RETURNING *;
+ *      → if zero rows returned, the slot is gone (someone beat us).
+ *   2. INSERT INTO consultation_bookings (...).
+ *      → on UNIQUE(slot_id) collision the insert fails and we roll the
+ *        slot back to 'open' so the next consumer can try.
+ *
+ * The two-step pattern is safer than a single INSERT-with-trigger
+ * because the slot status check is the source of truth — Postgres won't
+ * let us double-book.
+ */
+export async function bookSlot(input: BookSlotInput): Promise<BookSlotResult> {
+  const admin = createAdminClient();
+
+  // ── 1. Optimistic claim on the slot row ──
+  const { data: claimed, error: claimErr } = await admin
+    .from("pro_availability_slots")
+    .update({ status: "booked" })
+    .eq("id", input.slotId)
+    .eq("status", "open")
+    .select("*")
+    .maybeSingle();
+
+  if (claimErr) {
+    log.warn("bookSlot slot claim failed", {
+      slotId: input.slotId,
+      err: claimErr.message,
+    });
+    throw new ConsultationError("db_error", "Could not book slot.", 500);
+  }
+  if (!claimed) {
+    throw new ConsultationError(
+      "slot_not_open",
+      "This slot is no longer available.",
+      409,
+    );
+  }
+
+  // ── 2. Create the booking row ──
+  const { data: booking, error: bookErr } = await admin
+    .from("consultation_bookings")
+    .insert({
+      slot_id: input.slotId,
+      brief_id: input.briefId,
+      consumer_user_id: input.consumerUserId ?? null,
+      consumer_email: input.consumerEmail.toLowerCase().trim(),
+      consumer_notes: input.consumerNotes ?? null,
+      status: "pending",
+    })
+    .select("*")
+    .single();
+
+  if (bookErr || !booking) {
+    // Roll the slot back so the next booker can try.
+    await admin
+      .from("pro_availability_slots")
+      .update({ status: "open" })
+      .eq("id", input.slotId);
+    log.warn("bookSlot insert failed (rolled back slot)", {
+      slotId: input.slotId,
+      briefId: input.briefId,
+      err: bookErr?.message,
+    });
+    throw new ConsultationError(
+      "db_error",
+      "Could not create booking.",
+      500,
+    );
+  }
+
+  return {
+    slot: claimed as unknown as AvailabilitySlot,
+    booking: booking as unknown as ConsultationBooking,
+  };
+}
+
+/**
+ * Cancel a booking by either party. Flips both the booking and the
+ * underlying slot — the slot is restored to 'open' so it can be
+ * re-booked (caller decides whether to also delete the slot).
+ *
+ * `byKind` is recorded for audit; behaviour is identical for either
+ * party today, but keeps the door open for "consumer-cancelled" specific
+ * notifications later.
+ */
+export async function cancelBooking(
+  bookingId: number,
+  byKind: "consumer" | "professional",
+): Promise<ConsultationBooking> {
+  const admin = createAdminClient();
+  const { data: existing } = await admin
+    .from("consultation_bookings")
+    .select("*")
+    .eq("id", bookingId)
+    .maybeSingle();
+  if (!existing) {
+    throw new ConsultationError(
+      "booking_not_found",
+      "Booking not found.",
+      404,
+    );
+  }
+
+  const { data: updated, error } = await admin
+    .from("consultation_bookings")
+    .update({
+      status: "cancelled",
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", bookingId)
+    .select("*")
+    .single();
+  if (error || !updated) {
+    log.warn("cancelBooking failed", {
+      bookingId,
+      err: error?.message,
+    });
+    throw new ConsultationError(
+      "db_error",
+      "Could not cancel booking.",
+      500,
+    );
+  }
+
+  // Free the slot so it can be re-booked.
+  await admin
+    .from("pro_availability_slots")
+    .update({ status: "open" })
+    .eq("id", existing.slot_id as number);
+
+  log.info("booking cancelled", { bookingId, byKind });
+  return updated as unknown as ConsultationBooking;
+}
+
+interface ConfirmBookingInput {
+  meetUrl?: string | null;
+}
+
+/**
+ * Pro confirms a booking. Optionally attaches a meet URL (Google Meet,
+ * Zoom, etc.) — v1 doesn't validate the URL host beyond "looks like a
+ * URL" because pros may use first-party Calendly / internal tools.
+ */
+export async function confirmBooking(
+  bookingId: number,
+  input: ConfirmBookingInput = {},
+): Promise<ConsultationBooking> {
+  const admin = createAdminClient();
+  const patch: Record<string, unknown> = {
+    status: "confirmed",
+    updated_at: new Date().toISOString(),
+  };
+  if (input.meetUrl !== undefined && input.meetUrl !== null) {
+    const trimmed = input.meetUrl.trim();
+    if (trimmed.length > 0) {
+      try {
+        // Throws on invalid URL. We don't store the parsed value — we
+        // keep what the pro typed so it's identical in their tooling.
+        new URL(trimmed);
+        patch.meet_url = trimmed;
+      } catch {
+        throw new ConsultationError(
+          "invalid_input",
+          "meet_url must be a valid URL.",
+          400,
+        );
+      }
+    }
+  }
+
+  const { data, error } = await admin
+    .from("consultation_bookings")
+    .update(patch)
+    .eq("id", bookingId)
+    .select("*")
+    .maybeSingle();
+  if (error) {
+    log.warn("confirmBooking failed", { bookingId, err: error.message });
+    throw new ConsultationError(
+      "db_error",
+      "Could not confirm booking.",
+      500,
+    );
+  }
+  if (!data) {
+    throw new ConsultationError(
+      "booking_not_found",
+      "Booking not found.",
+      404,
+    );
+  }
+  return data as unknown as ConsultationBooking;
+}
+
+/**
+ * Fetch a single booking by id.
+ */
+export async function getBooking(
+  bookingId: number,
+): Promise<ConsultationBooking | null> {
+  const admin = createAdminClient();
+  const { data } = await admin
+    .from("consultation_bookings")
+    .select("*")
+    .eq("id", bookingId)
+    .maybeSingle();
+  return (data as unknown as ConsultationBooking) ?? null;
+}
+
+/**
+ * Fetch the slot a booking refers to.
+ */
+export async function getSlot(slotId: number): Promise<AvailabilitySlot | null> {
+  const admin = createAdminClient();
+  const { data } = await admin
+    .from("pro_availability_slots")
+    .select("*")
+    .eq("id", slotId)
+    .maybeSingle();
+  return (data as unknown as AvailabilitySlot) ?? null;
+}
+
+/**
+ * List bookings tied to a particular brief — used by the brief tracker
+ * UI to show "you have a meeting confirmed for …".
+ */
+export async function listBookingsForBrief(
+  briefId: number,
+): Promise<ConsultationBooking[]> {
+  const admin = createAdminClient();
+  const { data, error } = await admin
+    .from("consultation_bookings")
+    .select("*")
+    .eq("brief_id", briefId)
+    .order("created_at", { ascending: false });
+  if (error) {
+    log.warn("listBookingsForBrief failed", { briefId, err: error.message });
+    return [];
+  }
+  return (data ?? []) as unknown as ConsultationBooking[];
+}

--- a/lib/marketplace-emails.ts
+++ b/lib/marketplace-emails.ts
@@ -181,3 +181,117 @@ export async function sendConsumerStaleBriefNudge(input: {
   });
   return ok;
 }
+
+// ─── Consultation booking (MM33) ─────────────────────────────────────────
+
+/**
+ * Pro is notified that a consumer booked one of their availability
+ * slots. Fired by POST /api/briefs/[slug]/book-slot. Best-effort —
+ * failures are swallowed and logged inside `sendEmail`.
+ */
+export async function sendProConsultationBooked(input: {
+  providerEmail: string;
+  providerName: string;
+  consumerName: string;
+  consumerEmail: string;
+  briefTitle: string;
+  briefSlug: string;
+  startAt: string;
+  endAt: string;
+  notes: string | null;
+}): Promise<boolean> {
+  const trackerUrl = `${SITE_URL}/briefs/${input.briefSlug}`;
+  const notesLine = input.notes
+    ? `<p style="font-size:13px;color:#475569;margin:8px 0"><strong>Notes from consumer:</strong> ${input.notes}</p>`
+    : "";
+  const { ok } = await sendEmail({
+    from: FROM,
+    to: input.providerEmail,
+    subject: `Consultation booked — ${input.briefTitle}`,
+    html: wrap(
+      "A consumer booked a consultation",
+      `<p style="font-size:15px">Hi ${input.providerName},</p>
+      <p style="font-size:14px;color:#475569">A consumer just booked one of your open availability slots. Please confirm the call and (optionally) paste a Google Meet or Zoom link.</p>
+      <div style="background:#fff;border:1px solid #e2e8f0;border-radius:8px;padding:16px;margin:16px 0">
+        <p style="font-size:14px;font-weight:600;color:#0f172a;margin:0">${input.briefTitle}</p>
+        <p style="font-size:13px;color:#475569;margin:4px 0"><strong>When:</strong> ${input.startAt} → ${input.endAt}</p>
+        <p style="font-size:13px;color:#475569;margin:4px 0"><strong>Consumer:</strong> ${input.consumerName || input.consumerEmail}</p>
+        ${notesLine}
+      </div>
+      ${btn(trackerUrl, "View brief →")}
+      ${disclosure()}`,
+    ),
+  });
+  return ok;
+}
+
+/**
+ * Consumer is notified that their booking was registered. They'll get a
+ * follow-up `sendConsumerConsultationConfirmed` when the pro confirms.
+ */
+export async function sendConsumerConsultationPending(input: {
+  consumerEmail: string;
+  consumerName: string;
+  providerName: string;
+  briefTitle: string;
+  briefSlug: string;
+  startAt: string;
+  endAt: string;
+}): Promise<boolean> {
+  const trackerUrl = `${SITE_URL}/briefs/${input.briefSlug}`;
+  const { ok } = await sendEmail({
+    from: FROM,
+    to: input.consumerEmail,
+    subject: `Consultation requested — ${input.briefTitle}`,
+    html: wrap(
+      "Consultation booked",
+      `<p style="font-size:15px">Hi ${input.consumerName || "there"},</p>
+      <p style="font-size:14px;color:#475569">You've booked a consultation with <strong>${input.providerName}</strong>. They'll confirm shortly and share a meeting link.</p>
+      <div style="background:#fff;border:1px solid #e2e8f0;border-radius:8px;padding:16px;margin:16px 0">
+        <p style="font-size:14px;font-weight:600;color:#0f172a;margin:0">${input.briefTitle}</p>
+        <p style="font-size:13px;color:#475569;margin:4px 0"><strong>When:</strong> ${input.startAt} → ${input.endAt}</p>
+      </div>
+      ${btn(trackerUrl, "View status →")}
+      ${disclosure()}`,
+    ),
+  });
+  return ok;
+}
+
+/**
+ * Consumer is notified that the pro confirmed the consultation and
+ * (optionally) attached a meeting URL.
+ */
+export async function sendConsumerConsultationConfirmed(input: {
+  consumerEmail: string;
+  consumerName: string;
+  providerName: string;
+  briefTitle: string;
+  briefSlug: string;
+  startAt: string;
+  endAt: string;
+  meetUrl: string | null;
+}): Promise<boolean> {
+  const trackerUrl = `${SITE_URL}/briefs/${input.briefSlug}`;
+  const meetingLine = input.meetUrl
+    ? `<p style="font-size:13px;color:#475569;margin:8px 0"><strong>Meeting link:</strong> <a href="${input.meetUrl}" style="color:#0f172a">${input.meetUrl}</a></p>`
+    : `<p style="font-size:13px;color:#475569;margin:8px 0">${input.providerName} will share the meeting link separately.</p>`;
+  const { ok } = await sendEmail({
+    from: FROM,
+    to: input.consumerEmail,
+    subject: `Consultation confirmed — ${input.briefTitle}`,
+    html: wrap(
+      "Consultation confirmed",
+      `<p style="font-size:15px">Hi ${input.consumerName || "there"},</p>
+      <p style="font-size:14px;color:#475569"><strong>${input.providerName}</strong> confirmed your consultation.</p>
+      <div style="background:#fff;border:1px solid #e2e8f0;border-radius:8px;padding:16px;margin:16px 0">
+        <p style="font-size:14px;font-weight:600;color:#0f172a;margin:0">${input.briefTitle}</p>
+        <p style="font-size:13px;color:#475569;margin:4px 0"><strong>When:</strong> ${input.startAt} → ${input.endAt}</p>
+        ${meetingLine}
+      </div>
+      ${btn(trackerUrl, "View status →")}
+      ${disclosure()}`,
+    ),
+  });
+  return ok;
+}

--- a/supabase/migrations/20260515_mm32_brief_messages.sql
+++ b/supabase/migrations/20260515_mm32_brief_messages.sql
@@ -1,0 +1,204 @@
+-- ============================================================================
+-- Migration: 20260515_mm32_brief_messages.sql
+-- Purpose: Real-time chat between consumer and accepted provider/team on
+--          the brief tracker page (Ship #10 / MM32). Once a brief is in the
+--          'accept' flow and has been accepted, both sides get a single
+--          shared thread for follow-up Qs, scheduling, etc.
+--
+-- Why: Consumers were emailing the support inbox to reach the accepted
+-- provider because the tracker page only showed the static status. A
+-- lightweight in-page chat closes the loop without dragging more work into
+-- email + reduces accidental disclosure of contact details before
+-- engagement is formal.
+--
+-- Idempotency: CREATE TABLE / INDEX IF NOT EXISTS + DROP POLICY IF EXISTS /
+-- CREATE POLICY. Safe to re-apply. The Realtime publication add is wrapped
+-- in DO ... EXCEPTION so re-running doesn't fail on a duplicate add.
+--
+-- Rollback (destructive):
+--   ALTER PUBLICATION supabase_realtime DROP TABLE public.brief_messages;
+--   DROP TABLE IF EXISTS public.brief_messages;
+--
+-- Risk: low — additive table, additive publication entry. The publication
+-- broadcast doesn't expose data outside the RLS check on SELECT.
+-- ============================================================================
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.brief_messages (
+  id                       bigserial PRIMARY KEY,
+  brief_id                 integer NOT NULL REFERENCES public.advisor_auctions(id) ON DELETE CASCADE,
+  sender_kind              text NOT NULL
+    CHECK (sender_kind IN ('consumer', 'professional', 'team')),
+  -- Nullable for backward compat with anonymous consumer briefs (no auth.users row).
+  sender_user_id           uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  sender_professional_id   integer REFERENCES public.professionals(id) ON DELETE SET NULL,
+  sender_team_id           integer REFERENCES public.expert_teams(id) ON DELETE SET NULL,
+  body                     text NOT NULL
+    CHECK (length(body) > 0 AND length(body) <= 4000),
+  read_by_consumer_at      timestamptz,
+  read_by_pro_at           timestamptz,
+  created_at               timestamptz NOT NULL DEFAULT now()
+);
+
+-- Newest-first scan for the tracker chat panel.
+CREATE INDEX IF NOT EXISTS idx_brief_messages_brief_created
+  ON public.brief_messages (brief_id, created_at DESC);
+
+-- ── Realtime publication ──────────────────────────────────────────────────
+-- Subscribe via supabase.channel('brief-messages-${briefId}') in the browser.
+-- Postgres errors if the table is already in the publication, so swallow the
+-- duplicate_object exception to keep the migration idempotent.
+DO $$
+BEGIN
+  ALTER PUBLICATION supabase_realtime ADD TABLE public.brief_messages;
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+-- ── RLS ───────────────────────────────────────────────────────────────────
+ALTER TABLE public.brief_messages ENABLE ROW LEVEL SECURITY;
+
+-- service_role full access — used by the API route handlers which write
+-- through the admin client (anonymous consumer briefs have no auth.uid()).
+DROP POLICY IF EXISTS "service_role full access brief_messages"
+  ON public.brief_messages;
+CREATE POLICY "service_role full access brief_messages"
+  ON public.brief_messages
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- Authenticated SELECT — the brief owner (matches advisor_auctions.contact_email
+-- against the signed-in auth.users email) or the accepting professional / team
+-- member can read messages. Same predicate shape as
+-- 20260514_mm10_pro_intake_questions.sql so future audits can grep for it.
+DROP POLICY IF EXISTS "Brief owner or acceptor read brief messages"
+  ON public.brief_messages;
+CREATE POLICY "Brief owner or acceptor read brief messages"
+  ON public.brief_messages
+  FOR SELECT
+  TO authenticated
+  USING (
+    brief_id IN (
+      SELECT a.id
+        FROM public.advisor_auctions a
+        JOIN auth.users u ON u.id = auth.uid()
+       WHERE lower(a.contact_email) = lower(u.email)
+    )
+    OR brief_id IN (
+      SELECT a.id
+        FROM public.advisor_auctions a
+        JOIN public.professionals p
+          ON p.id = a.accepted_by_professional_id
+       WHERE p.auth_user_id = auth.uid()
+    )
+    OR brief_id IN (
+      SELECT a.id
+        FROM public.advisor_auctions a
+        JOIN public.expert_team_members m
+          ON m.team_id = a.accepted_by_team_id
+        JOIN public.professionals p
+          ON p.id = m.professional_id
+       WHERE p.auth_user_id = auth.uid()
+         AND m.status = 'active'
+    )
+  );
+
+-- Authenticated INSERT — same predicate as SELECT. The handler additionally
+-- resolves sender_kind from the caller's role so the row faithfully records
+-- who sent the message, but the RLS gate is "can you see this thread?".
+DROP POLICY IF EXISTS "Brief owner or acceptor insert brief messages"
+  ON public.brief_messages;
+CREATE POLICY "Brief owner or acceptor insert brief messages"
+  ON public.brief_messages
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    brief_id IN (
+      SELECT a.id
+        FROM public.advisor_auctions a
+        JOIN auth.users u ON u.id = auth.uid()
+       WHERE lower(a.contact_email) = lower(u.email)
+    )
+    OR brief_id IN (
+      SELECT a.id
+        FROM public.advisor_auctions a
+        JOIN public.professionals p
+          ON p.id = a.accepted_by_professional_id
+       WHERE p.auth_user_id = auth.uid()
+    )
+    OR brief_id IN (
+      SELECT a.id
+        FROM public.advisor_auctions a
+        JOIN public.expert_team_members m
+          ON m.team_id = a.accepted_by_team_id
+        JOIN public.professionals p
+          ON p.id = m.professional_id
+       WHERE p.auth_user_id = auth.uid()
+         AND m.status = 'active'
+    )
+  );
+
+-- Authenticated UPDATE — used by mark-read to flip the read_by_*_at columns.
+-- The handler bounds which column the caller can flip; RLS just gates access
+-- to the row at all.
+DROP POLICY IF EXISTS "Brief owner or acceptor update brief messages"
+  ON public.brief_messages;
+CREATE POLICY "Brief owner or acceptor update brief messages"
+  ON public.brief_messages
+  FOR UPDATE
+  TO authenticated
+  USING (
+    brief_id IN (
+      SELECT a.id
+        FROM public.advisor_auctions a
+        JOIN auth.users u ON u.id = auth.uid()
+       WHERE lower(a.contact_email) = lower(u.email)
+    )
+    OR brief_id IN (
+      SELECT a.id
+        FROM public.advisor_auctions a
+        JOIN public.professionals p
+          ON p.id = a.accepted_by_professional_id
+       WHERE p.auth_user_id = auth.uid()
+    )
+    OR brief_id IN (
+      SELECT a.id
+        FROM public.advisor_auctions a
+        JOIN public.expert_team_members m
+          ON m.team_id = a.accepted_by_team_id
+        JOIN public.professionals p
+          ON p.id = m.professional_id
+       WHERE p.auth_user_id = auth.uid()
+         AND m.status = 'active'
+    )
+  )
+  WITH CHECK (
+    brief_id IN (
+      SELECT a.id
+        FROM public.advisor_auctions a
+        JOIN auth.users u ON u.id = auth.uid()
+       WHERE lower(a.contact_email) = lower(u.email)
+    )
+    OR brief_id IN (
+      SELECT a.id
+        FROM public.advisor_auctions a
+        JOIN public.professionals p
+          ON p.id = a.accepted_by_professional_id
+       WHERE p.auth_user_id = auth.uid()
+    )
+    OR brief_id IN (
+      SELECT a.id
+        FROM public.advisor_auctions a
+        JOIN public.expert_team_members m
+          ON m.team_id = a.accepted_by_team_id
+        JOIN public.professionals p
+          ON p.id = m.professional_id
+       WHERE p.auth_user_id = auth.uid()
+         AND m.status = 'active'
+    )
+  );
+
+COMMIT;

--- a/supabase/migrations/20260515_mm33_consultations.sql
+++ b/supabase/migrations/20260515_mm33_consultations.sql
@@ -1,0 +1,263 @@
+-- ============================================================================
+-- Migration: 20260515_mm33_consultations.sql
+-- Purpose: In-app consultation booking (Ship #5 / MM33).
+--
+-- After a verified pro accepts a Match Request, the consumer and pro need
+-- to book an intro call. Today they coordinate over email. This migration
+-- introduces two tables that let the pro publish availability slots and
+-- the consumer book one of them from the brief tracker page.
+--
+-- v1 is intentionally minimal:
+--   - no external calendar OAuth (Google / Calendly come later);
+--   - the pro pastes a Google Meet / Zoom URL on confirmation.
+--
+-- Tables:
+--   pro_availability_slots — pro-side calendar (open windows for booking).
+--   consultation_bookings  — one booking per slot, tied to a brief.
+--
+-- Idempotency: CREATE EXTENSION IF NOT EXISTS, CREATE TABLE IF NOT EXISTS,
+-- CREATE INDEX IF NOT EXISTS, DO blocks for the EXCLUDE constraint, and
+-- DROP POLICY IF EXISTS / CREATE POLICY everywhere. Safe to re-apply.
+--
+-- Rollback (destructive):
+--   DROP TABLE IF EXISTS public.consultation_bookings;
+--   DROP TABLE IF EXISTS public.pro_availability_slots;
+--   -- btree_gist stays installed; it's harmless to leave behind.
+--
+-- Risk: low — additive tables, no changes to existing data. Consumer-side
+-- contact_email match policy mirrors the brief tracker access pattern
+-- already used by /api/briefs/[slug]/intake-answers.
+-- ============================================================================
+
+BEGIN;
+
+-- ── Extension ────────────────────────────────────────────────────────────
+-- btree_gist lets us mix the equality op-class for `professional_id` with
+-- the range op-class on `tstzrange(start_at, end_at)` inside a single
+-- EXCLUDE constraint. Without this extension, EXCLUDE USING gist refuses
+-- to accept integer columns alongside a range column.
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+
+-- ── Table 1: pro_availability_slots ──────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.pro_availability_slots (
+  id               bigserial PRIMARY KEY,
+  professional_id  integer NOT NULL
+                   REFERENCES public.professionals(id) ON DELETE CASCADE,
+  team_id          integer
+                   REFERENCES public.expert_teams(id) ON DELETE SET NULL,
+  start_at         timestamptz NOT NULL,
+  end_at           timestamptz NOT NULL,
+  status           text NOT NULL DEFAULT 'open'
+                   CHECK (status IN ('open', 'booked', 'cancelled')),
+  created_at       timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT pro_availability_slots_end_after_start
+    CHECK (end_at > start_at)
+);
+
+-- Prevent overlapping non-cancelled slots per professional. The pro can
+-- have many cancelled slots but at most one open/booked slot covering
+-- any given moment.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'pro_availability_slots_no_overlap'
+      AND conrelid = 'public.pro_availability_slots'::regclass
+  ) THEN
+    ALTER TABLE public.pro_availability_slots
+      ADD CONSTRAINT pro_availability_slots_no_overlap
+      EXCLUDE USING gist (
+        professional_id WITH =,
+        tstzrange(start_at, end_at, '[)') WITH &&
+      )
+      WHERE (status IN ('open', 'booked'));
+  END IF;
+END
+$$;
+
+CREATE INDEX IF NOT EXISTS idx_pro_availability_slots_pro_start
+  ON public.pro_availability_slots (professional_id, start_at);
+
+CREATE INDEX IF NOT EXISTS idx_pro_availability_slots_team
+  ON public.pro_availability_slots (team_id)
+  WHERE team_id IS NOT NULL;
+
+ALTER TABLE public.pro_availability_slots ENABLE ROW LEVEL SECURITY;
+
+-- Anyone can SELECT open slots so the consumer can see them from the
+-- brief tracker without needing a JWT for the pro. The booked status
+-- column isn't sensitive — exposing it lets the consumer's tracker
+-- show "this slot was taken" if the page is reloaded mid-booking.
+DROP POLICY IF EXISTS "Anyone can read availability slots"
+  ON public.pro_availability_slots;
+CREATE POLICY "Anyone can read availability slots"
+  ON public.pro_availability_slots FOR SELECT
+  TO anon, authenticated
+  USING (true);
+
+-- Pro or active team member can INSERT a slot under their own professional_id.
+DROP POLICY IF EXISTS "Pro can insert own availability slots"
+  ON public.pro_availability_slots;
+CREATE POLICY "Pro can insert own availability slots"
+  ON public.pro_availability_slots FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    professional_id IN (
+      SELECT p.id FROM public.professionals p
+      WHERE p.auth_user_id = auth.uid()
+    )
+  );
+
+-- Pro can UPDATE / DELETE their own slots.
+DROP POLICY IF EXISTS "Pro can update own availability slots"
+  ON public.pro_availability_slots;
+CREATE POLICY "Pro can update own availability slots"
+  ON public.pro_availability_slots FOR UPDATE
+  TO authenticated
+  USING (
+    professional_id IN (
+      SELECT p.id FROM public.professionals p
+      WHERE p.auth_user_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    professional_id IN (
+      SELECT p.id FROM public.professionals p
+      WHERE p.auth_user_id = auth.uid()
+    )
+  );
+
+DROP POLICY IF EXISTS "Pro can delete own availability slots"
+  ON public.pro_availability_slots;
+CREATE POLICY "Pro can delete own availability slots"
+  ON public.pro_availability_slots FOR DELETE
+  TO authenticated
+  USING (
+    professional_id IN (
+      SELECT p.id FROM public.professionals p
+      WHERE p.auth_user_id = auth.uid()
+    )
+  );
+
+DROP POLICY IF EXISTS "Service role full access pro_availability_slots"
+  ON public.pro_availability_slots;
+CREATE POLICY "Service role full access pro_availability_slots"
+  ON public.pro_availability_slots FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- ── Table 2: consultation_bookings ───────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.consultation_bookings (
+  id                bigserial PRIMARY KEY,
+  slot_id           bigint NOT NULL
+                    REFERENCES public.pro_availability_slots(id) ON DELETE CASCADE,
+  brief_id          integer NOT NULL
+                    REFERENCES public.advisor_auctions(id) ON DELETE CASCADE,
+  consumer_user_id  uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  consumer_email    text NOT NULL,
+  consumer_notes    text,
+  meet_url          text,
+  status            text NOT NULL DEFAULT 'pending'
+                    CHECK (status IN ('pending', 'confirmed', 'cancelled', 'completed')),
+  created_at        timestamptz NOT NULL DEFAULT now(),
+  updated_at        timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT consultation_bookings_one_per_slot UNIQUE (slot_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_consultation_bookings_brief_status
+  ON public.consultation_bookings (brief_id, status);
+
+ALTER TABLE public.consultation_bookings ENABLE ROW LEVEL SECURITY;
+
+-- Consumer can SELECT bookings they own (by email or auth.uid()).
+DROP POLICY IF EXISTS "Consumer can read own bookings"
+  ON public.consultation_bookings;
+CREATE POLICY "Consumer can read own bookings"
+  ON public.consultation_bookings FOR SELECT
+  TO authenticated
+  USING (
+    (consumer_user_id IS NOT NULL AND consumer_user_id = auth.uid())
+    OR lower(consumer_email) = lower(coalesce((auth.jwt() ->> 'email'), ''))
+  );
+
+-- Pro (and active team members) can SELECT bookings against their own
+-- availability slots.
+DROP POLICY IF EXISTS "Pro can read own slot bookings"
+  ON public.consultation_bookings;
+CREATE POLICY "Pro can read own slot bookings"
+  ON public.consultation_bookings FOR SELECT
+  TO authenticated
+  USING (
+    slot_id IN (
+      SELECT s.id
+      FROM public.pro_availability_slots s
+      JOIN public.professionals p ON p.id = s.professional_id
+      WHERE p.auth_user_id = auth.uid()
+    )
+  );
+
+-- INSERT: authenticated user whose JWT email matches the brief's
+-- contact_email (or whose auth.uid() matches a consumer_user_id we're
+-- about to write). Mirrors the brief tracker access pattern.
+DROP POLICY IF EXISTS "Brief owner can insert booking"
+  ON public.consultation_bookings;
+CREATE POLICY "Brief owner can insert booking"
+  ON public.consultation_bookings FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    brief_id IN (
+      SELECT id
+      FROM public.advisor_auctions
+      WHERE lower(coalesce(contact_email, '')) = lower(coalesce((auth.jwt() ->> 'email'), ''))
+    )
+  );
+
+-- UPDATE: pro updates bookings on their own slots; consumer updates
+-- bookings owned by them.
+DROP POLICY IF EXISTS "Pro can update own slot bookings"
+  ON public.consultation_bookings;
+CREATE POLICY "Pro can update own slot bookings"
+  ON public.consultation_bookings FOR UPDATE
+  TO authenticated
+  USING (
+    slot_id IN (
+      SELECT s.id
+      FROM public.pro_availability_slots s
+      JOIN public.professionals p ON p.id = s.professional_id
+      WHERE p.auth_user_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    slot_id IN (
+      SELECT s.id
+      FROM public.pro_availability_slots s
+      JOIN public.professionals p ON p.id = s.professional_id
+      WHERE p.auth_user_id = auth.uid()
+    )
+  );
+
+DROP POLICY IF EXISTS "Consumer can update own booking"
+  ON public.consultation_bookings;
+CREATE POLICY "Consumer can update own booking"
+  ON public.consultation_bookings FOR UPDATE
+  TO authenticated
+  USING (
+    (consumer_user_id IS NOT NULL AND consumer_user_id = auth.uid())
+    OR lower(consumer_email) = lower(coalesce((auth.jwt() ->> 'email'), ''))
+  )
+  WITH CHECK (
+    (consumer_user_id IS NOT NULL AND consumer_user_id = auth.uid())
+    OR lower(consumer_email) = lower(coalesce((auth.jwt() ->> 'email'), ''))
+  );
+
+DROP POLICY IF EXISTS "Service role full access consultation_bookings"
+  ON public.consultation_bookings;
+CREATE POLICY "Service role full access consultation_bookings"
+  ON public.consultation_bookings FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+COMMIT;


### PR DESCRIPTION
## Summary

### #5 In-app consultation booking
- `pro_availability_slots` + `consultation_bookings` tables (mm33). EXCLUDE constraint on overlapping slots per pro.
- `/pros/availability` lets pros add open slots; `/briefs/[slug]` tracker shows a "Book a consultation" panel for consumers after accept.
- API: `POST/GET /api/pros/availability`, `DELETE /api/pros/availability/[id]`, `GET /api/pros/[slug]/availability` (public), `POST /api/briefs/[slug]/book-slot`, `POST /api/bookings/[id]/{confirm,cancel}`.
- Pro can attach a Meet/Zoom URL on confirmation. No external calendar OAuth — pure in-app for v1.
- 8 vitest cases.

### #10 Realtime chat in brief tracker
- `brief_messages` table (mm32) with Supabase Realtime publication added (idempotent `DO ... EXCEPTION`).
- `/briefs/[slug]` mounts `BriefChatPanel.tsx` after acceptance — message list + textarea + optimistic send.
- API: `POST /api/briefs/[slug]/messages`, `POST /api/briefs/[slug]/messages/mark-read`. Body ≤4000 chars; dual rate limit (IP + per-user-per-brief).
- Channel naming: `brief-messages-${briefId}` (integer ID for stability across slug edits).
- 13 vitest cases.

## Gates
- `tsc --noEmit` clean
- `eslint --max-warnings 0` clean
- `npm run audit:rate-limits -- --strict` → 100% (446 routes)
- 21 new vitest cases pass

## Test plan
- [ ] Pro adds two overlapping slots → second rejected by EXCLUDE constraint.
- [ ] Consumer books a slot → status flips `open → booked`, booking created `pending`.
- [ ] Pro confirms with a Meet URL → consumer sees URL on tracker.
- [ ] Either party cancels → slot freed, booking `cancelled`.
- [ ] Consumer sends a chat → realtime channel pushes the message to pro's open tracker.
- [ ] Message > 4000 chars rejected with 400.


---
_Generated by [Claude Code](https://claude.ai/code/session_015JmqgxgJAaVt9RrUQ8uvNf)_