### PR TITLE
feat(marketplace): Stripe Connect Express payouts — consumer→pro payments with 10% platform fee

### DIFF
--- a/__tests__/lib/stripe-connect/stripe-connect.test.ts
+++ b/__tests__/lib/stripe-connect/stripe-connect.test.ts
@@ -1,0 +1,311 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const { mockFrom, mockPaymentIntentsCreate, mockAccountsCreate, mockAccountLinksCreate, mockAccountsRetrieve } = vi.hoisted(() => ({
+  mockFrom: vi.fn(),
+  mockPaymentIntentsCreate: vi.fn(),
+  mockAccountsCreate: vi.fn(),
+  mockAccountLinksCreate: vi.fn(),
+  mockAccountsRetrieve: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+vi.mock("@/lib/stripe", () => ({
+  getStripe: vi.fn(() => ({
+    paymentIntents: { create: mockPaymentIntentsCreate },
+    accounts: { create: mockAccountsCreate, retrieve: mockAccountsRetrieve },
+    accountLinks: { create: mockAccountLinksCreate },
+  })),
+}));
+
+import {
+  createPaymentForBrief,
+  createConnectOnboardingLink,
+  getMarketplaceTakeRateBps,
+  refreshConnectAccountStatus,
+  handleConnectWebhook,
+} from "@/lib/stripe-connect";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete process.env.MARKETPLACE_TAKE_RATE_BPS;
+  vi.stubEnv("STRIPE_SECRET_KEY", "sk_test_dummy");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("getMarketplaceTakeRateBps", () => {
+  it("defaults to 10% (1000 bps)", () => {
+    expect(getMarketplaceTakeRateBps()).toBe(1000);
+  });
+
+  it("honours MARKETPLACE_TAKE_RATE_BPS env override", () => {
+    process.env.MARKETPLACE_TAKE_RATE_BPS = "1500";
+    expect(getMarketplaceTakeRateBps()).toBe(1500);
+  });
+
+  it("clamps invalid values to default", () => {
+    process.env.MARKETPLACE_TAKE_RATE_BPS = "9999"; // > 3000 cap
+    expect(getMarketplaceTakeRateBps()).toBe(1000);
+    process.env.MARKETPLACE_TAKE_RATE_BPS = "-1";
+    expect(getMarketplaceTakeRateBps()).toBe(1000);
+  });
+});
+
+describe("createPaymentForBrief", () => {
+  it("returns 'no_secret' when STRIPE_SECRET_KEY missing", async () => {
+    vi.stubEnv("STRIPE_SECRET_KEY", "");
+    const result = await createPaymentForBrief({
+      briefId: 1,
+      professionalId: 1,
+      consumerEmail: "x@example.com",
+      amountCents: 10000,
+      description: "test",
+    });
+    expect(result.unavailable).toBe("no_secret");
+  });
+
+  it("returns 'pro_not_connected' when pro has no connect account or payouts disabled", async () => {
+    mockFrom.mockImplementation(() => ({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          maybeSingle: vi.fn().mockResolvedValue({
+            data: {
+              stripe_connect_account_id: null,
+              stripe_connect_status: "not_connected",
+              stripe_connect_payouts_enabled: false,
+              stripe_connect_charges_enabled: false,
+            },
+            error: null,
+          }),
+        }),
+      }),
+    }));
+    const result = await createPaymentForBrief({
+      briefId: 1,
+      professionalId: 1,
+      consumerEmail: "x@example.com",
+      amountCents: 10000,
+      description: "test",
+    });
+    expect(result.unavailable).toBe("pro_not_connected");
+  });
+
+  it("sets application_fee_amount to 10% by default and routes via transfer_data", async () => {
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "professionals") {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              maybeSingle: vi.fn().mockResolvedValue({
+                data: {
+                  stripe_connect_account_id: "acct_test",
+                  stripe_connect_status: "active",
+                  stripe_connect_payouts_enabled: true,
+                  stripe_connect_charges_enabled: true,
+                },
+                error: null,
+              }),
+            }),
+          }),
+        };
+      }
+      return {
+        insert: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            single: vi
+              .fn()
+              .mockResolvedValue({ data: { id: 99 }, error: null }),
+          }),
+        }),
+      };
+    });
+    mockPaymentIntentsCreate.mockResolvedValue({
+      id: "pi_test",
+      client_secret: "cs_test",
+    });
+    const result = await createPaymentForBrief({
+      briefId: 5,
+      professionalId: 7,
+      consumerEmail: "c@example.com",
+      amountCents: 50000, // $500
+      description: "1 hour consultation",
+    });
+    expect(result.paymentIntentId).toBe("pi_test");
+    expect(result.clientSecret).toBe("cs_test");
+    expect(result.paymentId).toBe(99);
+    const callArgs = mockPaymentIntentsCreate.mock.calls[0]?.[0];
+    expect(callArgs.amount).toBe(50000);
+    expect(callArgs.application_fee_amount).toBe(5000); // 10% of 50000
+    expect(callArgs.transfer_data?.destination).toBe("acct_test");
+    expect(callArgs.metadata?.kind).toBe("marketplace_payment");
+    expect(callArgs.metadata?.brief_id).toBe("5");
+  });
+});
+
+describe("createConnectOnboardingLink", () => {
+  it("creates an account if pro doesn't have one", async () => {
+    mockFrom.mockImplementation(() => {
+      return {
+        select: vi.fn().mockImplementation(() => {
+          return {
+            eq: vi.fn().mockReturnValue({
+              maybeSingle: vi.fn().mockResolvedValue({
+                data: {
+                  stripe_connect_account_id: null,
+                  stripe_connect_status: "not_connected",
+                  stripe_connect_payouts_enabled: false,
+                  stripe_connect_charges_enabled: false,
+                },
+                error: null,
+              }),
+            }),
+          };
+        }),
+        update: vi.fn().mockReturnValue({
+          eq: vi.fn().mockResolvedValue({ data: null, error: null }),
+        }),
+      };
+    });
+    mockAccountsCreate.mockResolvedValue({ id: "acct_new" });
+    mockAccountLinksCreate.mockResolvedValue({ url: "https://stripe.com/onboard" });
+    const result = await createConnectOnboardingLink({
+      professionalId: 1,
+      email: "pro@example.com",
+      refreshUrl: "https://invest.com.au/r",
+      returnUrl: "https://invest.com.au/c",
+    });
+    expect(result.url).toBe("https://stripe.com/onboard");
+    expect(mockAccountsCreate).toHaveBeenCalled();
+    const arg = mockAccountsCreate.mock.calls[0]?.[0];
+    expect(arg.type).toBe("express");
+    expect(arg.country).toBe("AU");
+  });
+
+  it("reuses existing account when present", async () => {
+    mockFrom.mockImplementation(() => ({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          maybeSingle: vi.fn().mockResolvedValue({
+            data: {
+              stripe_connect_account_id: "acct_existing",
+              stripe_connect_status: "onboarding",
+              stripe_connect_payouts_enabled: false,
+              stripe_connect_charges_enabled: false,
+            },
+            error: null,
+          }),
+        }),
+      }),
+    }));
+    mockAccountLinksCreate.mockResolvedValue({ url: "https://stripe.com/onboard" });
+    const result = await createConnectOnboardingLink({
+      professionalId: 1,
+      email: "pro@example.com",
+      refreshUrl: "https://invest.com.au/r",
+      returnUrl: "https://invest.com.au/c",
+    });
+    expect(result.url).toBe("https://stripe.com/onboard");
+    expect(mockAccountsCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe("refreshConnectAccountStatus", () => {
+  it("maps charges+payouts enabled to active", async () => {
+    mockFrom.mockImplementation(() => ({
+      update: vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ data: null, error: null }),
+      }),
+    }));
+    mockAccountsRetrieve.mockResolvedValue({
+      id: "acct_x",
+      charges_enabled: true,
+      payouts_enabled: true,
+      requirements: {},
+    });
+    await refreshConnectAccountStatus("acct_x");
+    // Verify the update used 'active' status
+    const updateCalls = mockFrom.mock.results.flatMap((r) =>
+      (r.value as { update: ReturnType<typeof vi.fn> }).update.mock.calls.map(
+        (c) => c[0],
+      ),
+    );
+    expect(updateCalls.some((u) => u.stripe_connect_status === "active")).toBe(true);
+    expect(
+      updateCalls.some((u) => u.stripe_connect_payouts_enabled === true),
+    ).toBe(true);
+  });
+
+  it("maps disabled_reason to rejected", async () => {
+    mockFrom.mockImplementation(() => ({
+      update: vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ data: null, error: null }),
+      }),
+    }));
+    mockAccountsRetrieve.mockResolvedValue({
+      id: "acct_x",
+      charges_enabled: false,
+      payouts_enabled: false,
+      requirements: { disabled_reason: "fields_needed" },
+    });
+    await refreshConnectAccountStatus("acct_x");
+    const updateCalls = mockFrom.mock.results.flatMap((r) =>
+      (r.value as { update: ReturnType<typeof vi.fn> }).update.mock.calls.map(
+        (c) => c[0],
+      ),
+    );
+    expect(updateCalls.some((u) => u.stripe_connect_status === "rejected")).toBe(true);
+  });
+});
+
+describe("handleConnectWebhook", () => {
+  it("flips marketplace_payments.status to succeeded on payment_intent.succeeded", async () => {
+    const update = vi.fn().mockReturnValue({
+      eq: vi.fn().mockResolvedValue({ data: null, error: null }),
+    });
+    mockFrom.mockImplementation(() => ({ update }));
+    await handleConnectWebhook({
+      type: "payment_intent.succeeded",
+      data: {
+        object: {
+          id: "pi_x",
+          metadata: { kind: "marketplace_payment" },
+        },
+      },
+    } as never);
+    const arg = update.mock.calls[0]?.[0];
+    expect(arg.status).toBe("succeeded");
+  });
+
+  it("ignores PaymentIntents that aren't marketplace payments", async () => {
+    const update = vi.fn();
+    mockFrom.mockImplementation(() => ({ update }));
+    await handleConnectWebhook({
+      type: "payment_intent.succeeded",
+      data: {
+        object: {
+          id: "pi_x",
+          metadata: { kind: "subscription_topup" }, // not marketplace
+        },
+      },
+    } as never);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it("flips status to refunded on charge.refunded", async () => {
+    const update = vi.fn().mockReturnValue({
+      eq: vi.fn().mockResolvedValue({ data: null, error: null }),
+    });
+    mockFrom.mockImplementation(() => ({ update }));
+    await handleConnectWebhook({
+      type: "charge.refunded",
+      data: { object: { id: "ch_x", payment_intent: "pi_x" } },
+    } as never);
+    const arg = update.mock.calls[0]?.[0];
+    expect(arg.status).toBe("refunded");
+  });
+});

--- a/app/api/briefs/[slug]/payment/route.ts
+++ b/app/api/briefs/[slug]/payment/route.ts
@@ -1,0 +1,111 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { isAllowed, ipKey } from "@/lib/rate-limit-db";
+import { createPaymentForBrief } from "@/lib/stripe-connect";
+import { logger } from "@/lib/logger";
+
+const log = logger("api:briefs:payment");
+
+const Body = z.object({
+  amount_cents: z.number().int().min(100).max(50_000_000),
+  description: z.string().min(3).max(500),
+});
+
+export async function POST(
+  request: NextRequest,
+  ctx: { params: Promise<{ slug: string }> },
+) {
+  if (
+    !(await isAllowed("briefs_marketplace_payment", ipKey(request), {
+      max: 30,
+      refillPerSec: 0.1,
+    }))
+  ) {
+    return NextResponse.json({ error: "Too many requests." }, { status: 429 });
+  }
+
+  let raw: unknown;
+  try {
+    raw = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+  const parsed = Body.safeParse(raw);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.issues[0]?.message ?? "Invalid body." },
+      { status: 400 },
+    );
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user?.email) {
+    return NextResponse.json({ error: "Auth required." }, { status: 401 });
+  }
+
+  const { slug } = await ctx.params;
+  const admin = createAdminClient();
+  const { data: brief } = await admin
+    .from("advisor_auctions")
+    .select(
+      "id, contact_email, accepted_by_professional_id, accepted_at, status",
+    )
+    .eq("slug", slug)
+    .maybeSingle();
+  if (!brief) {
+    return NextResponse.json({ error: "Brief not found." }, { status: 404 });
+  }
+  if (brief.contact_email !== user.email) {
+    return NextResponse.json({ error: "Forbidden." }, { status: 403 });
+  }
+  if (!brief.accepted_by_professional_id || !brief.accepted_at) {
+    return NextResponse.json(
+      { error: "Brief not yet accepted by a pro." },
+      { status: 409 },
+    );
+  }
+
+  const result = await createPaymentForBrief({
+    briefId: brief.id as number,
+    professionalId: brief.accepted_by_professional_id as number,
+    consumerEmail: user.email,
+    consumerUserId: user.id,
+    amountCents: parsed.data.amount_cents,
+    description: parsed.data.description,
+  });
+
+  if (result.unavailable === "no_secret") {
+    return NextResponse.json(
+      { error: "Stripe not configured." },
+      { status: 503 },
+    );
+  }
+  if (result.unavailable === "pro_not_connected") {
+    return NextResponse.json(
+      { error: "Provider has not completed Connect onboarding." },
+      { status: 409 },
+    );
+  }
+  if (!result.clientSecret) {
+    log.warn("payment creation failed", {
+      brief_id: brief.id,
+      detail: result.detail,
+    });
+    return NextResponse.json(
+      { error: result.detail ?? "Payment creation failed." },
+      { status: 502 },
+    );
+  }
+
+  return NextResponse.json({
+    client_secret: result.clientSecret,
+    payment_id: result.paymentId,
+    payment_intent_id: result.paymentIntentId,
+  });
+}

--- a/app/api/pros/connect/onboarding/route.ts
+++ b/app/api/pros/connect/onboarding/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { isAllowed, ipKey } from "@/lib/rate-limit-db";
+import { createConnectOnboardingLink } from "@/lib/stripe-connect";
+import { SITE_URL } from "@/lib/seo";
+import { logger } from "@/lib/logger";
+
+const log = logger("api:pros:connect:onboarding");
+
+export async function POST(request: NextRequest) {
+  if (
+    !(await isAllowed("pros_connect_onboarding", ipKey(request), {
+      max: 10,
+      refillPerSec: 0.1,
+    }))
+  ) {
+    return NextResponse.json({ error: "Too many requests." }, { status: 429 });
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Auth required." }, { status: 401 });
+  }
+
+  const admin = createAdminClient();
+  const { data: pro } = await admin
+    .from("professionals")
+    .select("id, email")
+    .or(`auth_user_id.eq.${user.id},email.eq.${user.email}`)
+    .in("status", ["active", "pending"])
+    .maybeSingle();
+  if (!pro) {
+    return NextResponse.json({ error: "Pro not found." }, { status: 404 });
+  }
+
+  const result = await createConnectOnboardingLink({
+    professionalId: pro.id as number,
+    email: (pro.email as string) ?? user.email!,
+    refreshUrl: `${SITE_URL}/pros/connect?refresh=1`,
+    returnUrl: `${SITE_URL}/pros/connect?completed=1`,
+  });
+
+  if (result.unavailable === "no_secret") {
+    log.warn("STRIPE_SECRET_KEY missing");
+    return NextResponse.json(
+      { error: "Stripe Connect not configured." },
+      { status: 503 },
+    );
+  }
+  if (!result.url) {
+    return NextResponse.json(
+      { error: result.detail ?? "Failed to create link." },
+      { status: 502 },
+    );
+  }
+  return NextResponse.json({ url: result.url });
+}

--- a/app/api/pros/connect/refresh/route.ts
+++ b/app/api/pros/connect/refresh/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { isAllowed, ipKey } from "@/lib/rate-limit-db";
+import { refreshConnectAccountStatus } from "@/lib/stripe-connect";
+
+export async function POST(request: NextRequest) {
+  if (
+    !(await isAllowed("pros_connect_refresh", ipKey(request), {
+      max: 20,
+      refillPerSec: 0.2,
+    }))
+  ) {
+    return NextResponse.json({ error: "Too many requests." }, { status: 429 });
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Auth required." }, { status: 401 });
+  }
+
+  const admin = createAdminClient();
+  const { data: pro } = await admin
+    .from("professionals")
+    .select("id, stripe_connect_account_id")
+    .or(`auth_user_id.eq.${user.id},email.eq.${user.email}`)
+    .maybeSingle();
+  if (!pro?.stripe_connect_account_id) {
+    return NextResponse.json({ error: "No Connect account." }, { status: 404 });
+  }
+  await refreshConnectAccountStatus(pro.stripe_connect_account_id as string);
+  return NextResponse.json({ ok: true });
+}

--- a/app/pros/connect/ConnectClient.tsx
+++ b/app/pros/connect/ConnectClient.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import type { StripeConnectStatus } from "@/lib/stripe-connect";
+
+interface Props {
+  professionalId: number;
+  status: StripeConnectStatus;
+  payoutsEnabled: boolean;
+  chargesEnabled: boolean;
+}
+
+const STATUS_LABEL: Record<StripeConnectStatus, { label: string; tone: string }> = {
+  not_connected: {
+    label: "Not connected",
+    tone: "bg-slate-50 border-slate-200 text-slate-800",
+  },
+  onboarding: {
+    label: "Onboarding in progress",
+    tone: "bg-amber-50 border-amber-200 text-amber-900",
+  },
+  active: {
+    label: "Connected — payouts enabled",
+    tone: "bg-emerald-50 border-emerald-200 text-emerald-900",
+  },
+  restricted: {
+    label: "Restricted — action required",
+    tone: "bg-amber-50 border-amber-200 text-amber-900",
+  },
+  rejected: {
+    label: "Rejected",
+    tone: "bg-rose-50 border-rose-200 text-rose-800",
+  },
+};
+
+export default function ConnectClient({
+  status,
+  payoutsEnabled,
+  chargesEnabled,
+}: Props) {
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  function handleStart() {
+    setError(null);
+    startTransition(async () => {
+      try {
+        const res = await fetch("/api/pros/connect/onboarding", { method: "POST" });
+        const body = (await res.json()) as { url?: string; error?: string };
+        if (!res.ok || !body.url) {
+          throw new Error(body.error ?? `HTTP ${res.status}`);
+        }
+        window.location.href = body.url;
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to start.");
+      }
+    });
+  }
+
+  function handleRefresh() {
+    setError(null);
+    startTransition(async () => {
+      try {
+        const res = await fetch("/api/pros/connect/refresh", { method: "POST" });
+        if (!res.ok) {
+          const body = (await res.json().catch(() => ({}))) as { error?: string };
+          throw new Error(body.error ?? `HTTP ${res.status}`);
+        }
+        window.location.reload();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Refresh failed.");
+      }
+    });
+  }
+
+  const meta = STATUS_LABEL[status];
+
+  return (
+    <div className="space-y-4">
+      <div className={`rounded-2xl border p-4 ${meta.tone}`}>
+        <p className="text-[11px] uppercase tracking-widest font-bold opacity-80 mb-1">
+          Status
+        </p>
+        <p className="text-base font-extrabold">{meta.label}</p>
+        <p className="text-xs mt-2 opacity-80">
+          Charges {chargesEnabled ? "enabled" : "disabled"} · Payouts{" "}
+          {payoutsEnabled ? "enabled" : "disabled"}
+        </p>
+      </div>
+
+      {error && (
+        <p className="text-sm text-rose-700 bg-rose-50 border border-rose-200 rounded-lg px-3 py-2">
+          {error}
+        </p>
+      )}
+
+      <div className="flex flex-wrap gap-3">
+        {status === "not_connected" && (
+          <button
+            type="button"
+            onClick={handleStart}
+            disabled={pending}
+            className="bg-amber-500 hover:bg-amber-400 disabled:bg-slate-200 text-slate-900 font-bold text-sm px-5 py-2.5 rounded-xl"
+          >
+            {pending ? "Starting…" : "Connect with Stripe"}
+          </button>
+        )}
+        {status === "onboarding" && (
+          <button
+            type="button"
+            onClick={handleStart}
+            disabled={pending}
+            className="bg-amber-500 hover:bg-amber-400 disabled:bg-slate-200 text-slate-900 font-bold text-sm px-5 py-2.5 rounded-xl"
+          >
+            {pending ? "Loading…" : "Continue onboarding"}
+          </button>
+        )}
+        {(status === "active" || status === "restricted") && (
+          <button
+            type="button"
+            onClick={handleRefresh}
+            disabled={pending}
+            className="bg-slate-100 hover:bg-slate-200 text-slate-900 font-semibold text-sm px-5 py-2.5 rounded-xl"
+          >
+            {pending ? "Refreshing…" : "Refresh status"}
+          </button>
+        )}
+      </div>
+
+      <p className="text-[11px] text-slate-400">
+        Platform fee: 10% of each transaction. Funds payout to your bank per
+        your Stripe schedule.
+      </p>
+    </div>
+  );
+}

--- a/app/pros/connect/page.tsx
+++ b/app/pros/connect/page.tsx
@@ -1,0 +1,56 @@
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+
+import { createClient } from "@/lib/supabase/server";
+// eslint-disable-next-line no-restricted-imports -- service-role legitimate: pending pros may not be visible to anon-RLS; mirrors /pros/billing pattern.
+import { createAdminClient } from "@/lib/supabase/admin";
+import { getConnectInfo } from "@/lib/stripe-connect";
+import { SITE_URL } from "@/lib/seo";
+
+import ConnectClient from "./ConnectClient";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Stripe Connect — Invest.com.au",
+  alternates: { canonical: `${SITE_URL}/pros/connect` },
+  robots: { index: false, follow: false },
+};
+
+export default async function ProsConnectPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/account/login?redirect=/pros/connect");
+
+  const admin = createAdminClient();
+  const { data: pro } = await admin
+    .from("professionals")
+    .select("id, name")
+    .or(`auth_user_id.eq.${user.id},email.eq.${user.email}`)
+    .in("status", ["active", "pending"])
+    .maybeSingle();
+  if (!pro) redirect("/pros/join");
+
+  const info = await getConnectInfo(pro.id as number);
+
+  return (
+    <main className="max-w-2xl mx-auto px-4 sm:px-6 py-10">
+      <h1 className="text-2xl font-extrabold text-slate-900 mb-2">
+        Stripe Connect — get paid by consumers
+      </h1>
+      <p className="text-sm text-slate-600 mb-6 leading-relaxed">
+        Connect your bank account to receive payouts from consumers through
+        invest.com.au. We take a small platform fee on each payment; the rest
+        goes straight to your bank.
+      </p>
+      <ConnectClient
+        professionalId={pro.id as number}
+        status={info.status}
+        payoutsEnabled={info.payoutsEnabled}
+        chargesEnabled={info.chargesEnabled}
+      />
+    </main>
+  );
+}

--- a/lib/stripe-connect/index.ts
+++ b/lib/stripe-connect/index.ts
@@ -1,0 +1,357 @@
+/**
+ * Stripe Connect Express marketplace payouts.
+ *
+ * Flow:
+ *   1. Pro hits `/pros/connect` → onboarding link created → completes Connect
+ *      Express onboarding on Stripe's hosted page.
+ *   2. Webhook `account.updated` syncs `stripe_connect_*` columns on the pro.
+ *   3. Once `stripe_connect_payouts_enabled=true`, consumers can pay the pro
+ *      through the brief tracker. PaymentIntent uses `application_fee_amount`
+ *      so the platform automatically retains the take rate; the rest is
+ *      transferred to the pro's connected account.
+ *   4. Webhook `payment_intent.succeeded` flips `marketplace_payments.status`
+ *      to 'succeeded'. `charge.refunded` flips to 'refunded'.
+ *
+ * Take rate: env `MARKETPLACE_TAKE_RATE_BPS`, default 1000 (10%). Clamped
+ * to [0, 3000] (max 30%).
+ */
+import type Stripe from "stripe";
+
+import { getStripe } from "@/lib/stripe";
+// eslint-disable-next-line no-restricted-imports -- service-role legitimate: webhook-driven writes + cross-pro reads on professionals where the caller's JWT isn't available.
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+
+const log = logger("stripe-connect");
+
+const DEFAULT_TAKE_RATE_BPS = 1_000;
+
+export function getMarketplaceTakeRateBps(): number {
+  const raw = process.env.MARKETPLACE_TAKE_RATE_BPS;
+  if (!raw) return DEFAULT_TAKE_RATE_BPS;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 3_000) {
+    log.warn("MARKETPLACE_TAKE_RATE_BPS out of range, using default", { raw });
+    return DEFAULT_TAKE_RATE_BPS;
+  }
+  return parsed;
+}
+
+export type StripeConnectStatus =
+  | "not_connected"
+  | "onboarding"
+  | "active"
+  | "restricted"
+  | "rejected";
+
+export interface ConnectAccountInfo {
+  professionalId: number;
+  stripeAccountId: string | null;
+  status: StripeConnectStatus;
+  payoutsEnabled: boolean;
+  chargesEnabled: boolean;
+}
+
+export async function getConnectInfo(
+  professionalId: number,
+): Promise<ConnectAccountInfo> {
+  const admin = createAdminClient();
+  const { data } = await admin
+    .from("professionals")
+    .select(
+      "stripe_connect_account_id, stripe_connect_status, stripe_connect_payouts_enabled, stripe_connect_charges_enabled",
+    )
+    .eq("id", professionalId)
+    .maybeSingle();
+  return {
+    professionalId,
+    stripeAccountId: (data?.stripe_connect_account_id as string | null) ?? null,
+    status: ((data?.stripe_connect_status as StripeConnectStatus | null) ??
+      "not_connected") as StripeConnectStatus,
+    payoutsEnabled: Boolean(data?.stripe_connect_payouts_enabled),
+    chargesEnabled: Boolean(data?.stripe_connect_charges_enabled),
+  };
+}
+
+export interface CreateOnboardingLinkInput {
+  professionalId: number;
+  refreshUrl: string;
+  returnUrl: string;
+  email: string;
+}
+
+export interface CreateOnboardingLinkResult {
+  url: string | null;
+  unavailable?: "no_secret" | "stripe_error";
+  detail?: string;
+}
+
+export async function createConnectOnboardingLink(
+  input: CreateOnboardingLinkInput,
+): Promise<CreateOnboardingLinkResult> {
+  if (!process.env.STRIPE_SECRET_KEY) {
+    return { url: null, unavailable: "no_secret" };
+  }
+  const stripe = getStripe();
+
+  // Get or create the Connect account for this pro.
+  let accountId = (await getConnectInfo(input.professionalId)).stripeAccountId;
+  if (!accountId) {
+    try {
+      const account = await stripe.accounts.create({
+        type: "express",
+        email: input.email,
+        country: "AU",
+        capabilities: {
+          card_payments: { requested: true },
+          transfers: { requested: true },
+        },
+        metadata: { professional_id: String(input.professionalId) },
+      });
+      accountId = account.id;
+      const admin = createAdminClient();
+      await admin
+        .from("professionals")
+        .update({
+          stripe_connect_account_id: accountId,
+          stripe_connect_status: "onboarding",
+        })
+        .eq("id", input.professionalId);
+    } catch (err) {
+      log.error("accounts.create failed", {
+        professional_id: input.professionalId,
+        err: err instanceof Error ? err.message : String(err),
+      });
+      return {
+        url: null,
+        unavailable: "stripe_error",
+        detail: err instanceof Error ? err.message : "unknown",
+      };
+    }
+  }
+
+  try {
+    const link = await stripe.accountLinks.create({
+      account: accountId!,
+      refresh_url: input.refreshUrl,
+      return_url: input.returnUrl,
+      type: "account_onboarding",
+    });
+    return { url: link.url };
+  } catch (err) {
+    log.error("accountLinks.create failed", {
+      professional_id: input.professionalId,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return {
+      url: null,
+      unavailable: "stripe_error",
+      detail: err instanceof Error ? err.message : "unknown",
+    };
+  }
+}
+
+/**
+ * Sync Stripe-side capabilities into the pro's row. Called by the webhook
+ * on `account.updated`; can also be invoked manually to force-refresh.
+ */
+export async function refreshConnectAccountStatus(
+  accountId: string,
+): Promise<void> {
+  if (!process.env.STRIPE_SECRET_KEY) return;
+  const stripe = getStripe();
+  let account: Stripe.Account;
+  try {
+    account = await stripe.accounts.retrieve(accountId);
+  } catch (err) {
+    log.warn("accounts.retrieve failed", {
+      account_id: accountId,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return;
+  }
+  const status = mapStripeAccountToStatus(account);
+  const admin = createAdminClient();
+  await admin
+    .from("professionals")
+    .update({
+      stripe_connect_status: status,
+      stripe_connect_payouts_enabled: Boolean(account.payouts_enabled),
+      stripe_connect_charges_enabled: Boolean(account.charges_enabled),
+    })
+    .eq("stripe_connect_account_id", accountId);
+}
+
+function mapStripeAccountToStatus(account: Stripe.Account): StripeConnectStatus {
+  if (account.requirements?.disabled_reason) return "rejected";
+  if (account.charges_enabled && account.payouts_enabled) return "active";
+  const hasPastDue = (account.requirements?.past_due ?? []).length > 0;
+  if (hasPastDue) return "restricted";
+  return "onboarding";
+}
+
+export interface CreatePaymentInput {
+  briefId: number;
+  professionalId: number;
+  consumerEmail: string;
+  consumerUserId?: string | null;
+  amountCents: number;
+  description: string;
+}
+
+export interface CreatePaymentResult {
+  paymentId: number | null;
+  paymentIntentId: string | null;
+  clientSecret: string | null;
+  unavailable?: "no_secret" | "pro_not_connected" | "stripe_error";
+  detail?: string;
+}
+
+export async function createPaymentForBrief(
+  input: CreatePaymentInput,
+): Promise<CreatePaymentResult> {
+  if (!process.env.STRIPE_SECRET_KEY) {
+    return {
+      paymentId: null,
+      paymentIntentId: null,
+      clientSecret: null,
+      unavailable: "no_secret",
+    };
+  }
+
+  const info = await getConnectInfo(input.professionalId);
+  if (!info.stripeAccountId || !info.payoutsEnabled) {
+    return {
+      paymentId: null,
+      paymentIntentId: null,
+      clientSecret: null,
+      unavailable: "pro_not_connected",
+    };
+  }
+
+  const takeBps = getMarketplaceTakeRateBps();
+  const platformFeeCents = Math.floor((input.amountCents * takeBps) / 10_000);
+
+  const stripe = getStripe();
+  let intent: Stripe.PaymentIntent;
+  try {
+    intent = await stripe.paymentIntents.create({
+      amount: input.amountCents,
+      currency: "aud",
+      application_fee_amount: platformFeeCents,
+      transfer_data: { destination: info.stripeAccountId },
+      automatic_payment_methods: { enabled: true },
+      description: input.description,
+      receipt_email: input.consumerEmail,
+      metadata: {
+        brief_id: String(input.briefId),
+        professional_id: String(input.professionalId),
+        kind: "marketplace_payment",
+      },
+    });
+  } catch (err) {
+    log.error("paymentIntents.create failed", {
+      brief_id: input.briefId,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return {
+      paymentId: null,
+      paymentIntentId: null,
+      clientSecret: null,
+      unavailable: "stripe_error",
+      detail: err instanceof Error ? err.message : "unknown",
+    };
+  }
+
+  const admin = createAdminClient();
+  const { data: row, error } = await admin
+    .from("marketplace_payments")
+    .insert({
+      brief_id: input.briefId,
+      consumer_email: input.consumerEmail,
+      consumer_user_id: input.consumerUserId ?? null,
+      professional_id: input.professionalId,
+      amount_cents: input.amountCents,
+      platform_fee_cents: platformFeeCents,
+      currency: "aud",
+      stripe_payment_intent_id: intent.id,
+      status: "pending",
+      description: input.description,
+      metadata: { take_rate_bps: takeBps },
+    })
+    .select("id")
+    .single();
+  if (error) {
+    log.error("marketplace_payments insert failed", { error: error.message });
+    return {
+      paymentId: null,
+      paymentIntentId: intent.id,
+      clientSecret: intent.client_secret,
+      unavailable: "stripe_error",
+      detail: error.message,
+    };
+  }
+
+  return {
+    paymentId: row.id as number,
+    paymentIntentId: intent.id,
+    clientSecret: intent.client_secret,
+  };
+}
+
+/**
+ * Webhook entrypoint — extends the existing Stripe webhook to handle
+ * Connect events and marketplace payment intents.
+ */
+export async function handleConnectWebhook(event: Stripe.Event): Promise<void> {
+  switch (event.type) {
+    case "account.updated": {
+      const account = event.data.object as Stripe.Account;
+      await refreshConnectAccountStatus(account.id);
+      return;
+    }
+    case "payment_intent.succeeded":
+    case "payment_intent.payment_failed":
+    case "payment_intent.canceled": {
+      const intent = event.data.object as Stripe.PaymentIntent;
+      if (intent.metadata?.kind !== "marketplace_payment") return;
+      const status =
+        event.type === "payment_intent.succeeded"
+          ? "succeeded"
+          : event.type === "payment_intent.canceled"
+            ? "canceled"
+            : "failed";
+      await updatePaymentStatus(intent.id, status);
+      return;
+    }
+    case "charge.refunded": {
+      const charge = event.data.object as Stripe.Charge;
+      const paymentIntentId =
+        typeof charge.payment_intent === "string"
+          ? charge.payment_intent
+          : charge.payment_intent?.id;
+      if (!paymentIntentId) return;
+      await updatePaymentStatus(paymentIntentId, "refunded");
+      return;
+    }
+    default:
+      return;
+  }
+}
+
+async function updatePaymentStatus(
+  paymentIntentId: string,
+  status: "succeeded" | "refunded" | "failed" | "canceled",
+): Promise<void> {
+  const admin = createAdminClient();
+  const { error } = await admin
+    .from("marketplace_payments")
+    .update({ status, updated_at: new Date().toISOString() })
+    .eq("stripe_payment_intent_id", paymentIntentId);
+  if (error) {
+    log.error("updatePaymentStatus failed", {
+      payment_intent_id: paymentIntentId,
+      error: error.message,
+    });
+  }
+}

--- a/lib/stripe-webhook/handlers/charge-refunded.ts
+++ b/lib/stripe-webhook/handlers/charge-refunded.ts
@@ -324,5 +324,16 @@ export const handleChargeRefunded: WebhookHandler = async (event, ctx) => {
     admin_email: "stripe_webhook",
   });
 
+  // Mirror into marketplace_payments if this charge was a Connect payment
+  // routed through the platform. Fail-soft — handler is idempotent.
+  try {
+    const { handleConnectWebhook } = await import("@/lib/stripe-connect");
+    await handleConnectWebhook(event);
+  } catch (err) {
+    ctx.log.warn("connect-webhook mirror failed (charge.refunded)", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+  }
+
   return { status: "done" };
 };

--- a/lib/stripe-webhook/handlers/index.ts
+++ b/lib/stripe-webhook/handlers/index.ts
@@ -34,6 +34,11 @@ import {
 import { handlePaymentIntentPaymentFailed } from "./payment-intent-failed";
 import { handlePayoutFailed } from "./payout-failed";
 import { handleRadarEarlyFraudWarning } from "./radar-early-fraud-warning";
+import {
+  handleAccountUpdated,
+  handlePaymentIntentSucceeded,
+  handlePaymentIntentCanceled,
+} from "./marketplace-connect";
 
 registerHandler("charge.dispute.created", handleChargeDisputeCreated);
 registerHandler("charge.refunded", handleChargeRefunded);
@@ -49,3 +54,7 @@ registerHandler("invoice.payment_failed", handleInvoicePaymentFailedEvent);
 registerHandler("payment_intent.payment_failed", handlePaymentIntentPaymentFailed);
 registerHandler("payout.failed", handlePayoutFailed);
 registerHandler("radar.early_fraud_warning.created", handleRadarEarlyFraudWarning);
+// MM-34: Connect marketplace payouts.
+registerHandler("account.updated", handleAccountUpdated);
+registerHandler("payment_intent.succeeded", handlePaymentIntentSucceeded);
+registerHandler("payment_intent.canceled", handlePaymentIntentCanceled);

--- a/lib/stripe-webhook/handlers/marketplace-connect.ts
+++ b/lib/stripe-webhook/handlers/marketplace-connect.ts
@@ -1,0 +1,36 @@
+/**
+ * Stripe webhook handlers for marketplace Connect payouts (MM-34).
+ *
+ * Wires the existing `lib/stripe-connect::handleConnectWebhook` dispatch
+ * into the project's per-event registry. Each handler returns 'done'
+ * unconditionally — the underlying lib is fail-soft and idempotent.
+ */
+import type { WebhookHandler } from "../types";
+
+import { handleConnectWebhook } from "@/lib/stripe-connect";
+
+export const handleAccountUpdated: WebhookHandler = async (event) => {
+  await handleConnectWebhook(event);
+  return { status: "done" };
+};
+
+export const handlePaymentIntentSucceeded: WebhookHandler = async (event) => {
+  await handleConnectWebhook(event);
+  return { status: "done" };
+};
+
+export const handlePaymentIntentCanceled: WebhookHandler = async (event) => {
+  await handleConnectWebhook(event);
+  return { status: "done" };
+};
+
+/**
+ * Existing charge.refunded handler in `charge-refunded.ts` covers consumer
+ * Pro refunds. This wrapper additionally pings the Connect dispatcher so
+ * marketplace_payments rows flip to 'refunded' when a connected-account
+ * charge is refunded.
+ */
+export const handleChargeRefundedConnect: WebhookHandler = async (event) => {
+  await handleConnectWebhook(event);
+  return { status: "done" };
+};

--- a/supabase/migrations/20260516_mm34_stripe_connect.sql
+++ b/supabase/migrations/20260516_mm34_stripe_connect.sql
@@ -1,0 +1,93 @@
+-- ============================================================================
+-- Migration: 20260516_mm34_stripe_connect.sql
+-- Purpose: Stripe Connect Express marketplace payouts. Pros onboard via
+--          Connect to receive payouts from consumer payments routed through
+--          the platform. Platform takes a configurable application fee
+--          (default 10% = 1000 bps). Each consumer→pro payment is recorded
+--          in marketplace_payments with status synced from Stripe webhooks.
+--
+-- Idempotency: ADD COLUMN IF NOT EXISTS + CREATE TABLE IF NOT EXISTS.
+--
+-- Rollback:
+--   DROP TABLE IF EXISTS public.marketplace_payments;
+--   ALTER TABLE public.professionals
+--     DROP CONSTRAINT IF EXISTS professionals_stripe_connect_status_check,
+--     DROP COLUMN IF EXISTS stripe_connect_account_id,
+--     DROP COLUMN IF EXISTS stripe_connect_status,
+--     DROP COLUMN IF EXISTS stripe_connect_payouts_enabled,
+--     DROP COLUMN IF EXISTS stripe_connect_charges_enabled;
+--
+-- Risk: low — additive columns + new table. Existing pros default to
+-- 'not_connected'; no impact on subscription billing (separate column set).
+-- ============================================================================
+
+BEGIN;
+
+ALTER TABLE public.professionals
+  ADD COLUMN IF NOT EXISTS stripe_connect_account_id       text,
+  ADD COLUMN IF NOT EXISTS stripe_connect_status           text NOT NULL DEFAULT 'not_connected',
+  ADD COLUMN IF NOT EXISTS stripe_connect_payouts_enabled  boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS stripe_connect_charges_enabled  boolean NOT NULL DEFAULT false;
+
+ALTER TABLE public.professionals
+  DROP CONSTRAINT IF EXISTS professionals_stripe_connect_status_check;
+ALTER TABLE public.professionals
+  ADD CONSTRAINT professionals_stripe_connect_status_check
+  CHECK (stripe_connect_status IN ('not_connected','onboarding','active','restricted','rejected'));
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_professionals_connect_account_id
+  ON public.professionals (stripe_connect_account_id)
+  WHERE stripe_connect_account_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS public.marketplace_payments (
+  id                          bigserial PRIMARY KEY,
+  brief_id                    integer NOT NULL REFERENCES public.advisor_auctions(id) ON DELETE CASCADE,
+  consumer_email              text NOT NULL,
+  consumer_user_id            uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  professional_id             integer NOT NULL REFERENCES public.professionals(id) ON DELETE CASCADE,
+  amount_cents                integer NOT NULL CHECK (amount_cents > 0),
+  platform_fee_cents          integer NOT NULL CHECK (platform_fee_cents >= 0),
+  currency                    text NOT NULL DEFAULT 'aud',
+  stripe_payment_intent_id    text UNIQUE,
+  status                      text NOT NULL DEFAULT 'pending',
+  description                 text,
+  metadata                    jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at                  timestamptz NOT NULL DEFAULT now(),
+  updated_at                  timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.marketplace_payments
+  DROP CONSTRAINT IF EXISTS marketplace_payments_status_check;
+ALTER TABLE public.marketplace_payments
+  ADD CONSTRAINT marketplace_payments_status_check
+  CHECK (status IN ('pending','succeeded','refunded','failed','canceled'));
+
+CREATE INDEX IF NOT EXISTS idx_marketplace_payments_pro_status
+  ON public.marketplace_payments (professional_id, status, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_marketplace_payments_brief_status
+  ON public.marketplace_payments (brief_id, status);
+
+ALTER TABLE public.marketplace_payments ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "pro sees own payments" ON public.marketplace_payments;
+CREATE POLICY "pro sees own payments"
+  ON public.marketplace_payments
+  FOR SELECT
+  TO authenticated
+  USING (
+    professional_id IN (
+      SELECT id FROM public.professionals WHERE auth_user_id = auth.uid()
+    )
+  );
+
+DROP POLICY IF EXISTS "consumer sees own payments" ON public.marketplace_payments;
+CREATE POLICY "consumer sees own payments"
+  ON public.marketplace_payments
+  FOR SELECT
+  TO authenticated
+  USING (
+    consumer_user_id = auth.uid()
+    OR consumer_email = auth.email()
+  );
+
+COMMIT;


### PR DESCRIPTION
## Summary

Closes Bundle C with the final piece: Stripe Connect Express marketplace payouts.

### How it works
1. Pro hits `/pros/connect` → onboarding link → completes Connect Express on Stripe-hosted page.
2. Webhook `account.updated` syncs `stripe_connect_*` columns on the pro.
3. Once `payouts_enabled=true`, consumer pays via `POST /api/briefs/[slug]/payment` → PaymentIntent with `application_fee_amount` (10%) + `transfer_data[destination]` routing to the pro's connected account.
4. Webhook `payment_intent.succeeded` flips `marketplace_payments.status` to `succeeded`. `charge.refunded` flips to `refunded`.

### Files
- Migration `mm34` adds Connect columns + `marketplace_payments` table with RLS.
- `lib/stripe-connect/` — Express account create + account links, status refresh, payment creation, webhook dispatch.
- `lib/stripe-webhook/handlers/marketplace-connect.ts` — registers `account.updated`, `payment_intent.succeeded`, `payment_intent.canceled` into the existing webhook registry. `charge.refunded` extended in place.
- `/pros/connect` UI with onboarding/active/restricted/rejected states + refresh button.

### Env vars (prod)
- `STRIPE_SECRET_KEY` — already set
- `MARKETPLACE_TAKE_RATE_BPS` — defaults to 1000 (10%), clamped to [0, 3000]

## Gates
- `tsc --noEmit` clean
- `eslint --max-warnings 0` clean
- `npm run audit:rate-limits -- --strict` → 100% (449 routes)
- 13 new vitest cases pass

## Test plan
- [ ] Pro visits `/pros/connect` → "Connect with Stripe" button → completes Express onboarding.
- [ ] Webhook fires `account.updated` → status flips to `active` + `payouts_enabled=true`.
- [ ] Consumer hits `POST /api/briefs/[slug]/payment` → receives `client_secret` → completes payment on Stripe Elements.
- [ ] `payment_intent.succeeded` webhook → `marketplace_payments.status='succeeded'`.
- [ ] Refund the charge in Stripe → `marketplace_payments.status='refunded'`.
- [ ] Pro on `restricted` status sees the amber banner; clicking refresh re-syncs from Stripe.


---
_Generated by [Claude Code](https://claude.ai/code/session_015JmqgxgJAaVt9RrUQ8uvNf)_