### PR TITLE
fix(ci): use FETCH_HEAD on auto-merge-stats shallow checkout

### DIFF
--- a/.github/workflows/auto-merge-stats.yml
+++ b/.github/workflows/auto-merge-stats.yml
@@ -69,8 +69,14 @@ jobs:
           git config user.name "auto-merge-stats-bot"
 
           if git ls-remote --exit-code origin "$BOT_BRANCH" > /dev/null 2>&1; then
+            # Shallow clones don't track arbitrary remote refs; after a
+            # bare `git fetch origin <branch>` the only reachable ref is
+            # FETCH_HEAD, not `origin/<branch>`. Checking out from
+            # FETCH_HEAD avoids the "is not a commit" failure we hit on
+            # 2026-05-17 when the previous form ran against a shallow
+            # checkout.
             git fetch origin "$BOT_BRANCH"
-            git checkout -B "$BOT_BRANCH" "origin/$BOT_BRANCH"
+            git checkout -B "$BOT_BRANCH" FETCH_HEAD
           else
             git checkout --orphan "$BOT_BRANCH"
             git rm -rf --cached . > /dev/null 2>&1 || true


### PR DESCRIPTION
## Summary
- Auto-merge stats workflow has been failing every hour since at least 2026-05-17T17:11Z (`fatal: 'origin/automerge-bot/stats' is not a commit`).
- `actions/checkout@v6` with sparse-checkout creates a shallow clone; a bare `git fetch origin <branch>` updates `FETCH_HEAD` but does NOT create the `refs/remotes/origin/<branch>` tracking ref, so the subsequent `git checkout -B "$BOT_BRANCH" "origin/$BOT_BRANCH"` fails.
- Switching to `FETCH_HEAD` after fetch picks up the just-fetched commit reliably.

## Tier
A — `.github/workflows/*.yml` typically Tier C (CI infra), but this workflow only publishes a shields.io badge to a bot-owned `automerge-bot/stats` branch — no impact on merging, deploys, or security. One-line surgical fix.

## Test plan
- [x] tsc --noEmit (pre-push hook ran clean)
- [ ] CI workflow validates YAML syntax
- [ ] Next scheduled fire (`13 * * * *`) lands a `stats.json` update on `automerge-bot/stats` instead of failing