### PR TITLE
chore(db): commit advisor_auctions backfill file + clean stale allowlist

### DIFF
--- a/.driftallowlist
+++ b/.driftallowlist
@@ -18,89 +18,27 @@
 # Categories follow the Stream A item map in docs/audits/drift-list.md.
 
 # A-04 (admin / audit)
-admin_audit_log
 
 # A-03 (advisor family)
-advisor_applications
-advisor_articles
-advisor_auth_tokens
-advisor_billing
-advisor_bookings
-advisor_booking_slots
-advisor_metrics_daily
-advisor_sessions
-advisor_specialties        # verify retirement before backfill
-advisor_verification_log
 
 # A-05 (affiliate / finance)
-affiliate_payout_reports
-affiliate_payout_variance
-conversion_events
-credit_packs
-finance_transactions
-subscriptions
 
 # A-06 (marketplace)
-allocation_decisions
-broker_accounts
-broker_activity_log
-broker_answers
-broker_data_changes
-broker_health_scores
-broker_packages
-broker_questions
-broker_review_invites
-broker_review_stats        # verify view vs table
-broker_wallets
-campaigns
-campaign_daily_stats
-campaign_events
-campaign_templates
-marketplace_invoices
 marketplace_placements
-sponsored_placement_bookings
-sponsored_placement_pricing
-wallet_transactions
 
 # A-07 (reference data)
-au_postcodes
 
 # A-08 (CRM / BD)
-bd_pipeline
-broker_outreach_log
-competitor_watch
 
 # A-09 (content tables)
-broker_transfer_guides
-content_calendar
-country_investment_profiles  # verify rename relationship to foreign_investment_dta
-fee_auto_rules
-fee_profiles
-fee_update_queue
-foreign_investment_rates     # verify whether folded into fi_* tables
-legal_documents
-regulatory_alerts
 switch_stories
-team_members
 
 # A-10 (consultations / courses)
-consultations
-consultation_bookings
-courses
-course_lessons
-course_progress
 course_purchases
-course_revenue
 
 # A-11 (ops / observability)
-cron_health_alerts
-posthog_events_mirror
-rate_limits
-webhook_delivery_queue
 
 # A-12 (email / lifecycle)
-investor_drip_log
-notification_preferences
 
 # A-13 (portfolio)
 portfolio_alerts
@@ -110,19 +48,12 @@ portfolio_holdings         # verify; may be JSONB on user_portfolios
 user_portfolios
 
 # A-14 (Pro tier)
-pro_deals
-pro_deal_redemptions
 
 # A-02 (lead family / user data) — leftovers after main A-02 ship
-international_leads        # FK index exists but no CREATE TABLE — high priority
-lead_disputes
-user_reviews
 
 # A-99 (retirement / regenerate types — these tables look retired)
 article_moderation_log     # superseded by advisor_article_moderation_log
-content_products           # never shipped
 data_license_subscribers   # never shipped
-featured_plans             # superseded by sponsored_placement_*
 foreign_investment_flags   # renamed to foreign_investment_dta in 20260322 migration
 investor_journey_touchpoints  # superseded by attribution_touches
 sentiment_signals          # never shipped
@@ -132,17 +63,8 @@ trading_signals            # trading product never shipped
 
 
 # Recent additions (dashboard-created via Supabase UI, pending Stream A backfill migration)
-business_accounts         # account-system expansion (Phase 2/3) — backfill migration pending
-investor_goals            # goals-tracking feature — backfill migration pending
-listing_owner_accounts    # marketplace listing-owner portal — backfill migration pending
-property_holdings         # portfolio / property-investing feature — backfill migration pending
-fund_reviews              # fund review content — backfill migration pending
-placement_experiments     # A/B placement testing feature — dashboard-created 2026-05-11, backfill migration pending
 
 # PostGIS extension-managed (out of scope — comes from CREATE EXTENSION postgis)
 spatial_ref_sys
 
 # W2 Phase — tables created in Supabase dashboard without migration files; pending Stream A backfill
-business_accounts  # W2 Phase 2.5 — business account type; migration pending
-investor_goals     # W2 Phase 2 — investor goals tracking; migration pending
-placement_experiments  # created in dashboard 2026-05-11; pending migration backfill (A-stream)

--- a/supabase/migrations/20260518_advisor_auctions_and_bids_backfill.sql
+++ b/supabase/migrations/20260518_advisor_auctions_and_bids_backfill.sql
@@ -1,0 +1,224 @@
+-- ============================================================================
+-- Migration: 20260518_advisor_auctions_and_bids_backfill.sql
+-- Purpose: Backfill the base `advisor_auctions` + `advisor_auction_bids`
+--          tables that the runbook (docs/runbooks/apply-pmp-foundation.md)
+--          claimed were created via the Supabase dashboard but never landed
+--          in prod. This file mirrors the migration that was applied via
+--          Supabase MCP on 2026-05-17 (tracked as
+--          `advisor_auctions_and_bids_backfill` in
+--          supabase_migrations.schema_migrations). The on-disk file
+--          ensures a fresh-clone replay reproduces the same schema.
+--
+--          Schema derived from the canonical insert/select payloads in:
+--            app/api/quotes/route.ts          (auction-flow insert + reads)
+--            app/api/briefs/route.ts          (accept-flow insert)
+--            app/api/advisor-auction/bid/*.ts (bids insert + reads)
+--          plus the column additions from the PMP foundation migration
+--          (supabase/migrations/20260723_pmp01_provider_marketplace_foundation.sql,
+--          sections 4 + 8) folded in.
+--
+-- Idempotency: CREATE TABLE IF NOT EXISTS / ADD COLUMN IF NOT EXISTS / DROP
+--          CONSTRAINT IF EXISTS / ON CONFLICT DO NOTHING.
+-- Rollback (destructive — discards every brief + bid):
+--   DROP TABLE IF EXISTS public.brief_tracker_events;
+--   DROP TABLE IF EXISTS public.advisor_auction_bids;
+--   DROP TABLE IF EXISTS public.advisor_auctions;
+-- Risk: medium — net-new base tables; expert_teams family already exists
+--          and FKs from advisor_auctions point at it.
+-- ============================================================================
+
+BEGIN;
+
+-- ── 1. advisor_auctions (base table — auction flow + brief flow combined) ─
+CREATE TABLE IF NOT EXISTS public.advisor_auctions (
+  id                            serial PRIMARY KEY,
+  source                        text   NOT NULL DEFAULT 'public_job',
+  flow_type                     text   NOT NULL DEFAULT 'auction',
+  is_public                     boolean NOT NULL DEFAULT true,
+  slug                          text   UNIQUE NOT NULL,
+  job_title                     text   NOT NULL,
+  job_description               text,
+  budget_band                   text,
+  advisor_types                 text[] NOT NULL DEFAULT '{}'::text[],
+  location                      text,
+  contact_name                  text,
+  contact_email                 text   NOT NULL,
+  contact_phone                 text,
+  status                        text   NOT NULL DEFAULT 'open',
+  ends_at                       timestamptz NOT NULL,
+  referrer_advisor_id           integer REFERENCES public.professionals(id),
+  -- PMP-foundation section-4 additions:
+  brief_template                text,
+  brief_payload                 jsonb  NOT NULL DEFAULT '{}'::jsonb,
+  provider_preference           text,
+  routing_mode                  text,
+  target_professional_id        integer REFERENCES public.professionals(id),
+  target_firm_id                integer REFERENCES public.advisor_firms(id),
+  target_team_id                integer REFERENCES public.expert_teams(id),
+  accept_credits_cost           integer,
+  accepted_by_professional_id   integer REFERENCES public.professionals(id),
+  accepted_by_team_id           integer REFERENCES public.expert_teams(id),
+  accepted_at                   timestamptz,
+  tracker_status                text   NOT NULL DEFAULT 'new',
+  risk_flags                    text[] NOT NULL DEFAULT '{}'::text[],
+  risk_review_status            text   NOT NULL DEFAULT 'clear',
+  listing_id                    integer REFERENCES public.investment_listings(id),
+  created_at                    timestamptz NOT NULL DEFAULT now()
+);
+
+-- CHECK constraints split out so re-runs don't fail on duplicate ADD COLUMN.
+ALTER TABLE public.advisor_auctions
+  DROP CONSTRAINT IF EXISTS advisor_auctions_flow_type_check;
+ALTER TABLE public.advisor_auctions
+  ADD CONSTRAINT advisor_auctions_flow_type_check
+  CHECK (flow_type IN ('auction', 'accept'));
+
+ALTER TABLE public.advisor_auctions
+  DROP CONSTRAINT IF EXISTS advisor_auctions_status_check;
+ALTER TABLE public.advisor_auctions
+  ADD CONSTRAINT advisor_auctions_status_check
+  CHECK (status IN ('open','closed','expired','withdrawn','awarded'));
+
+ALTER TABLE public.advisor_auctions
+  DROP CONSTRAINT IF EXISTS advisor_auctions_provider_preference_check;
+ALTER TABLE public.advisor_auctions
+  ADD CONSTRAINT advisor_auctions_provider_preference_check
+  CHECK (provider_preference IS NULL OR provider_preference IN
+    ('any', 'individual', 'firm', 'expert_team', 'multiple'));
+
+ALTER TABLE public.advisor_auctions
+  DROP CONSTRAINT IF EXISTS advisor_auctions_routing_mode_check;
+ALTER TABLE public.advisor_auctions
+  ADD CONSTRAINT advisor_auctions_routing_mode_check
+  CHECK (routing_mode IS NULL OR routing_mode IN
+    ('smart_match', 'direct', 'multi_response'));
+
+ALTER TABLE public.advisor_auctions
+  DROP CONSTRAINT IF EXISTS advisor_auctions_tracker_status_check;
+ALTER TABLE public.advisor_auctions
+  ADD CONSTRAINT advisor_auctions_tracker_status_check
+  CHECK (tracker_status IN
+    ('new', 'contacted', 'call_booked', 'proposal_sent', 'won', 'lost', 'withdrawn'));
+
+ALTER TABLE public.advisor_auctions
+  DROP CONSTRAINT IF EXISTS advisor_auctions_risk_review_check;
+ALTER TABLE public.advisor_auctions
+  ADD CONSTRAINT advisor_auctions_risk_review_check
+  CHECK (risk_review_status IN ('clear', 'pending_review', 'approved', 'rejected'));
+
+-- Auction-flow public listing indexes:
+CREATE INDEX IF NOT EXISTS idx_advisor_auctions_public_open
+  ON public.advisor_auctions (created_at DESC)
+  WHERE is_public = true AND flow_type = 'auction' AND status = 'open';
+
+CREATE INDEX IF NOT EXISTS idx_advisor_auctions_ends_at
+  ON public.advisor_auctions (ends_at)
+  WHERE status = 'open';
+
+CREATE INDEX IF NOT EXISTS idx_advisor_auctions_advisor_types
+  ON public.advisor_auctions USING GIN (advisor_types);
+
+-- Accept-flow inbox + tracking indexes (folded in from PMP foundation s4):
+CREATE INDEX IF NOT EXISTS idx_advisor_auctions_flow_status
+  ON public.advisor_auctions (flow_type, status, tracker_status)
+  WHERE flow_type = 'accept';
+
+CREATE INDEX IF NOT EXISTS idx_advisor_auctions_accepted_by_pro
+  ON public.advisor_auctions (accepted_by_professional_id)
+  WHERE accepted_by_professional_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_advisor_auctions_accepted_by_team
+  ON public.advisor_auctions (accepted_by_team_id)
+  WHERE accepted_by_team_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_advisor_auctions_target_team
+  ON public.advisor_auctions (target_team_id)
+  WHERE target_team_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_advisor_auctions_risk_review
+  ON public.advisor_auctions (risk_review_status, created_at DESC)
+  WHERE risk_review_status <> 'clear';
+
+ALTER TABLE public.advisor_auctions ENABLE ROW LEVEL SECURITY;
+
+-- Public auction-flow listings are visible anonymously (for /quotes).
+DROP POLICY IF EXISTS "Public read of public open auctions" ON public.advisor_auctions;
+CREATE POLICY "Public read of public open auctions"
+  ON public.advisor_auctions FOR SELECT
+  USING (is_public = true AND flow_type = 'auction' AND status = 'open');
+
+-- The accept-flow (briefs) is provider-only — handled entirely via service role
+-- through brief inbox / brief preview / brief accept routes.
+DROP POLICY IF EXISTS "Service role full access advisor_auctions" ON public.advisor_auctions;
+CREATE POLICY "Service role full access advisor_auctions"
+  ON public.advisor_auctions FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- ── 2. advisor_auction_bids ────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.advisor_auction_bids (
+  id           serial PRIMARY KEY,
+  auction_id   integer NOT NULL REFERENCES public.advisor_auctions(id) ON DELETE CASCADE,
+  advisor_id   integer NOT NULL REFERENCES public.professionals(id),
+  bid_amount   integer NOT NULL CHECK (bid_amount > 0),
+  status       text    NOT NULL DEFAULT 'active',
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (auction_id, advisor_id)
+);
+
+ALTER TABLE public.advisor_auction_bids
+  DROP CONSTRAINT IF EXISTS advisor_auction_bids_status_check;
+ALTER TABLE public.advisor_auction_bids
+  ADD CONSTRAINT advisor_auction_bids_status_check
+  CHECK (status IN ('active','withdrawn','accepted','rejected','expired'));
+
+CREATE INDEX IF NOT EXISTS idx_auction_bids_auction_active
+  ON public.advisor_auction_bids (auction_id, bid_amount DESC)
+  WHERE status = 'active';
+
+CREATE INDEX IF NOT EXISTS idx_auction_bids_advisor
+  ON public.advisor_auction_bids (advisor_id);
+
+ALTER TABLE public.advisor_auction_bids ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Advisors read own bids" ON public.advisor_auction_bids;
+CREATE POLICY "Advisors read own bids"
+  ON public.advisor_auction_bids FOR SELECT
+  USING (
+    advisor_id IN (
+      SELECT id FROM public.professionals WHERE auth_user_id = auth.uid()
+    )
+  );
+
+DROP POLICY IF EXISTS "Service role full access auction_bids" ON public.advisor_auction_bids;
+CREATE POLICY "Service role full access auction_bids"
+  ON public.advisor_auction_bids FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- ── 3. brief_tracker_events (section 8 of PMP foundation) ──────────────────
+CREATE TABLE IF NOT EXISTS public.brief_tracker_events (
+  id           bigserial PRIMARY KEY,
+  brief_id     integer NOT NULL REFERENCES public.advisor_auctions(id) ON DELETE CASCADE,
+  event_type   text NOT NULL,
+  payload      jsonb NOT NULL DEFAULT '{}'::jsonb,
+  actor_kind   text,
+  actor_id     text,
+  created_at   timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_brief_tracker_events_brief
+  ON public.brief_tracker_events (brief_id, created_at);
+
+ALTER TABLE public.brief_tracker_events ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Service role full access tracker_events" ON public.brief_tracker_events;
+CREATE POLICY "Service role full access tracker_events"
+  ON public.brief_tracker_events FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+COMMIT;


### PR DESCRIPTION
## Summary
Two halves of one cleanup:

1. Adds \`supabase/migrations/20260518_advisor_auctions_and_bids_backfill.sql\` mirroring the migration applied to prod via Supabase MCP on 2026-05-17. The on-disk file ensures a fresh-clone replay reproduces the schema; without it the \`check-database-types-drift\` CI gate fails because \`advisor_auctions\` / \`advisor_auction_bids\` / \`brief_tracker_events\` had no CREATE TABLE in the migration tree.

2. Strips 78 stale entries from \`.driftallowlist\`. Those tables now have CREATE TABLE statements in the migration tree (either via today's unapplied-migration backfill, or via earlier audit-remediation streams that wrote the migrations retroactively).

## After this PR

- \`npm run audit:drift-types\` → \"Database types drift gate passed — no drifted tables.\"
- \`npm run audit:unapplied-migrations\` → 0 repo-only tables.
- Allowlist: **92 → 17** entries.

## Tier
B — schema + allowlist cleanup, no runtime impact, additive only.

## Test plan
- [x] \`node scripts/check-database-types-drift.mjs\` → passes cleanly
- [x] \`node scripts/audit/unapplied-migrations.mjs\` → 0 repo-only
- [ ] CI: types drift gate passes on this branch