### PR TITLE
feat(lx): LX-03 — cross-calculator navigation (RelatedCalculators) [audit remediation]

### DIFF
--- a/app/compound-interest-calculator/page.tsx
+++ b/app/compound-interest-calculator/page.tsx
@@ -3,6 +3,7 @@ import { CURRENT_YEAR, absoluteUrl, breadcrumbJsonLd } from "@/lib/seo";
 import { calculatorJsonLd, faqJsonLd } from "@/lib/schema-markup";
 import CompoundInterestClient from "./CompoundInterestClient";
 import ComplianceFooter from "@/components/ComplianceFooter";
+import RelatedCalculators from "@/components/RelatedCalculators";
 
 export const revalidate = 86400;
 
@@ -65,7 +66,16 @@ export default function CompoundInterestCalculatorPage() {
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }} />
       <CompoundInterestClient />
-      <div className="container-custom pb-8"><ComplianceFooter variant="calculator" /></div>
+      <div className="container-custom pb-8">
+        <RelatedCalculators
+          items={[
+            { name: "Savings Calculator", description: "Compare savings accounts and see how your balance grows with different rates.", href: "/savings-calculator" },
+            { name: "FIRE Calculator", description: "Find your Financial Independence number and the years until you can retire.", href: "/fire-calculator" },
+            { name: "Dividend Reinvestment Calculator", description: "Model the compounding effect of reinvesting dividends over time.", href: "/dividend-reinvestment-calculator" },
+          ]}
+        />
+        <ComplianceFooter variant="calculator" />
+      </div>
 
     </>
   );

--- a/app/mortgage-calculator/page.tsx
+++ b/app/mortgage-calculator/page.tsx
@@ -3,6 +3,7 @@ import { CURRENT_YEAR, SITE_NAME } from "@/lib/seo";
 import MortgageCalculatorClient from "./MortgageCalculatorClient";
 import ComplianceFooter from "@/components/ComplianceFooter";
 import CalcToPlanBridge from "@/components/get-matched/CalcToPlanBridge";
+import RelatedCalculators from "@/components/RelatedCalculators";
 
 export const revalidate = 3600;
 
@@ -35,6 +36,13 @@ export default function MortgageCalculatorPage() {
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
       <MortgageCalculatorClient />
       <div className="container-custom pb-8">
+        <RelatedCalculators
+          items={[
+            { name: "Property vs Shares Calculator", description: "Compare the long-run return of property versus a share portfolio side by side.", href: "/property-vs-shares-calculator" },
+            { name: "Savings Calculator", description: "Model how quickly you can save your deposit with different contribution rates.", href: "/savings-calculator" },
+            { name: "CGT Calculator", description: "Estimate capital gains tax when you sell an investment property.", href: "/cgt-calculator" },
+          ]}
+        />
         <CalcToPlanBridge goal="home" />
         <ComplianceFooter variant="calculator" />
       </div>

--- a/app/savings-calculator/page.tsx
+++ b/app/savings-calculator/page.tsx
@@ -5,6 +5,7 @@ import { calculatorJsonLd } from "@/lib/schema-markup";
 import SavingsCalculatorClient from "./SavingsCalculatorClient";
 import ComplianceFooter from "@/components/ComplianceFooter";
 import CalcToPlanBridge from "@/components/get-matched/CalcToPlanBridge";
+import RelatedCalculators from "@/components/RelatedCalculators";
 
 export const revalidate = 3600;
 
@@ -33,6 +34,13 @@ export default async function SavingsCalculatorPage() {
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(calculatorJsonLd({ name: "Savings Rate Calculator", description: "Compare savings account interest rates and calculate how much more you could earn.", path: "/savings-calculator" })) }} />
       <SavingsCalculatorClient accounts={accounts || []} />
       <div className="container-custom pb-8">
+        <RelatedCalculators
+          items={[
+            { name: "Compound Interest Calculator", description: "Model long-term investment growth with regular contributions and compound returns.", href: "/compound-interest-calculator" },
+            { name: "FIRE Calculator", description: "Calculate your Financial Independence number and retirement timeline.", href: "/fire-calculator" },
+            { name: "Mortgage Calculator", description: "See how much of your savings you could put toward a home deposit.", href: "/mortgage-calculator" },
+          ]}
+        />
         <CalcToPlanBridge
           goal="grow"
           headline="Want to start investing instead of just saving?"

--- a/app/smsf-calculator/page.tsx
+++ b/app/smsf-calculator/page.tsx
@@ -4,6 +4,7 @@ import { calculatorJsonLd } from "@/lib/schema-markup";
 import SMSFCalculatorClient from "./SMSFCalculatorClient";
 import ComplianceFooter from "@/components/ComplianceFooter";
 import CalcToPlanBridge from "@/components/get-matched/CalcToPlanBridge";
+import RelatedCalculators from "@/components/RelatedCalculators";
 
 export const revalidate = 3600;
 
@@ -31,6 +32,13 @@ export default function SMSFCalculatorPage() {
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(softwareLd) }} />
       <SMSFCalculatorClient />
       <div className="container-custom pb-8">
+        <RelatedCalculators
+          items={[
+            { name: "Super Contributions Calculator", description: "Model the impact of salary sacrifice and voluntary contributions on your retirement balance.", href: "/super-contributions-calculator" },
+            { name: "Compound Interest Calculator", description: "See how your SMSF balance compounds over time with your target return rate.", href: "/compound-interest-calculator" },
+            { name: "FIRE Calculator", description: "Calculate the balance you need to retire and how many years your SMSF needs to reach it.", href: "/fire-calculator" },
+          ]}
+        />
         <CalcToPlanBridge
           goal="super"
           headline="Want a personalised SMSF action plan?"

--- a/components/RelatedCalculators.tsx
+++ b/components/RelatedCalculators.tsx
@@ -1,0 +1,53 @@
+import Link from "next/link";
+
+export interface RelatedCalc {
+  name: string;
+  description: string;
+  href: string;
+  /** Short label shown in the chip, e.g. "Free tool" */
+  tag?: string;
+}
+
+interface Props {
+  items: RelatedCalc[];
+  heading?: string;
+}
+
+/**
+ * Cross-calculator navigation strip. Shown at the bottom of each calculator
+ * page to surface 2–3 contextually related tools (LX-03).
+ */
+export default function RelatedCalculators({
+  items,
+  heading = "Also useful",
+}: Props) {
+  if (items.length === 0) return null;
+  return (
+    <section className="mt-10 mb-2" aria-label="Related calculators">
+      <h2 className="text-sm font-semibold text-slate-500 uppercase tracking-wide mb-3">
+        {heading}
+      </h2>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+        {items.map((calc) => (
+          <Link
+            key={calc.href}
+            href={calc.href}
+            className="group flex flex-col gap-1 rounded-xl border border-slate-200 bg-slate-50 hover:bg-white hover:border-slate-300 hover:shadow-sm p-4 transition-all"
+          >
+            <div className="flex items-center justify-between gap-2">
+              <span className="text-sm font-semibold text-slate-800 group-hover:text-indigo-700 leading-snug">
+                {calc.name}
+              </span>
+              {calc.tag && (
+                <span className="shrink-0 text-xs font-medium text-indigo-600 bg-indigo-50 rounded-full px-2 py-0.5">
+                  {calc.tag}
+                </span>
+              )}
+            </div>
+            <p className="text-xs text-slate-500 leading-relaxed">{calc.description}</p>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## LX-03 — Cross-Calculator Navigation

Adds a `RelatedCalculators` component to the 4 main calculators so users discover related tools naturally after completing a calculation.

### What ships

- **`components/RelatedCalculators.tsx`** — server component. Accepts a `RelatedCalc[]` array (name, description, href, optional tag chip). Renders a responsive 1-3 column card grid. Positioned between the calculator output and the `CalcToPlanBridge` / `ComplianceFooter`.

- **Wired into 4 calculators:**
  | Calculator | Related tools shown |
  |---|---|
  | Compound Interest | Savings Calculator · FIRE Calculator · Dividend Reinvestment |
  | Mortgage | Property vs Shares · Savings Calculator · CGT Calculator |
  | Savings | Compound Interest · FIRE Calculator · Mortgage |
  | SMSF | Super Contributions · Compound Interest · FIRE |

### Why cross-calculator navigation matters

Each calculator answers one question — but investors typically need several answers in the same session. The component surfaces contextually relevant next steps at the natural "I have my answer" moment, reducing exit rate from the calculator section.

## Supersedes

_None._

## References

- Audit remediation queue: `docs/audits/REMEDIATION_QUEUE.md` — LX-03
- Tracking: #215

---
_Generated by [Claude Code](https://claude.ai/code/session_01XLc1iQ87whriDhmEiuBeyt)_