### PR TITLE
feat(briefs): tracker UX bundle — intake prompt, unread badge, review CTA, calendar grid

### DIFF
--- a/app/briefs/[slug]/BookConsultationPanel.tsx
+++ b/app/briefs/[slug]/BookConsultationPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useTransition } from "react";
+import { useEffect, useMemo, useState, useTransition } from "react";
 
 import type {
   AvailabilitySlot,
@@ -17,6 +17,8 @@ interface Props {
   existingBooking: ConsultationBooking | null;
   existingSlot: AvailabilitySlot | null;
 }
+
+const DAY_MS = 24 * 60 * 60 * 1000;
 
 export default function BookConsultationPanel({
   briefSlug,
@@ -37,6 +39,7 @@ export default function BookConsultationPanel({
   const [bookedSlot, setBookedSlot] = useState<AvailabilitySlot | null>(
     existingSlot,
   );
+  const [pickedSlotId, setPickedSlotId] = useState<number | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -59,8 +62,34 @@ export default function BookConsultationPanel({
     };
   }, [proSlug, booking]);
 
+  // Group slots into a 7-day calendar starting from the earliest available
+  // slot (or today if there are no slots in the past). Each cell is a list
+  // of pickable times on that date so the consumer can scan a week at a
+  // glance instead of scrolling a flat list.
+  const grid = useMemo(() => {
+    if (slots.length === 0) return [] as { date: Date; slots: AvailabilitySlot[] }[];
+    const sorted = [...slots].sort(
+      (a, b) => new Date(a.start_at).getTime() - new Date(b.start_at).getTime(),
+    );
+    const first = new Date(sorted[0]?.start_at ?? Date.now());
+    first.setHours(0, 0, 0, 0);
+    const startMs = first.getTime();
+    const grouped: { date: Date; slots: AvailabilitySlot[] }[] = [];
+    for (let i = 0; i < 7; i++) {
+      const dayStart = new Date(startMs + i * DAY_MS);
+      const dayEnd = new Date(dayStart.getTime() + DAY_MS);
+      const inDay = sorted.filter((s) => {
+        const t = new Date(s.start_at).getTime();
+        return t >= dayStart.getTime() && t < dayEnd.getTime();
+      });
+      grouped.push({ date: dayStart, slots: inDay });
+    }
+    return grouped;
+  }, [slots]);
+
   function handleBook(slot: AvailabilitySlot) {
     setError(null);
+    setPickedSlotId(slot.id);
     startTransition(async () => {
       try {
         const body: Record<string, unknown> = { slot_id: slot.id };
@@ -83,6 +112,7 @@ export default function BookConsultationPanel({
         setBookedSlot(parsed.slot ?? slot);
       } catch (err) {
         setError(err instanceof Error ? err.message : "Failed to book.");
+        setPickedSlotId(null);
       }
     });
   }
@@ -123,9 +153,17 @@ export default function BookConsultationPanel({
 
   return (
     <div className="bg-white rounded-2xl border border-slate-200 p-5">
-      <p className="text-xs uppercase tracking-widest text-slate-500 mb-2">
-        Book a consultation
-      </p>
+      <div className="flex items-baseline justify-between gap-2 mb-2">
+        <p className="text-xs uppercase tracking-widest text-slate-500">
+          Book a consultation
+        </p>
+        {slots.length > 0 && (
+          <p className="text-[11px] text-slate-500">
+            Times shown in your local timezone (
+            {Intl.DateTimeFormat().resolvedOptions().timeZone})
+          </p>
+        )}
+      </div>
       <p className="text-sm text-slate-600 mb-4">
         Pick an open slot from {proName}&apos;s availability below.
       </p>
@@ -161,26 +199,67 @@ export default function BookConsultationPanel({
             </p>
           )}
 
-          <ul className="space-y-2">
-            {slots.map((s) => (
-              <li
-                key={s.id}
-                className="flex items-center justify-between bg-slate-50 rounded-xl border border-slate-200 p-3"
-              >
-                <p className="text-sm font-semibold text-slate-900">
-                  {formatRange(s.start_at, s.end_at)}
-                </p>
-                <button
-                  type="button"
-                  onClick={() => handleBook(s)}
-                  disabled={pending}
-                  className="rounded-lg bg-amber-500 px-3 py-1.5 text-xs font-semibold text-slate-900 hover:bg-amber-400 disabled:opacity-50"
+          {/* 7-day calendar grid — each column is a date, each cell is a
+              clickable time chip. Scans much faster than a flat list once a
+              pro publishes more than ~10 open slots. */}
+          <div className="grid grid-cols-7 gap-1 sm:gap-2">
+            {grid.map(({ date, slots: daySlots }) => {
+              const isToday =
+                new Date().toDateString() === date.toDateString();
+              return (
+                <div
+                  key={date.toISOString()}
+                  className="flex flex-col rounded-lg bg-slate-50 border border-slate-200 p-1.5 sm:p-2 min-h-[120px]"
                 >
-                  {pending ? "Booking…" : "Book"}
-                </button>
-              </li>
-            ))}
-          </ul>
+                  <div
+                    className={`text-[10px] sm:text-xs font-semibold text-center pb-1 mb-1 border-b border-slate-200 ${
+                      isToday ? "text-amber-700" : "text-slate-600"
+                    }`}
+                  >
+                    {date.toLocaleDateString(undefined, {
+                      weekday: "short",
+                    })}
+                    <br />
+                    <span className="font-bold">
+                      {date.toLocaleDateString(undefined, { day: "numeric" })}
+                    </span>
+                  </div>
+                  <div className="flex flex-col gap-1">
+                    {daySlots.length === 0 && (
+                      <span className="text-[10px] text-slate-400 text-center py-2">
+                        —
+                      </span>
+                    )}
+                    {daySlots.map((s) => {
+                      const isPicked = pickedSlotId === s.id;
+                      return (
+                        <button
+                          key={s.id}
+                          type="button"
+                          onClick={() => handleBook(s)}
+                          disabled={pending}
+                          className={`text-[10px] sm:text-xs font-semibold rounded px-1 py-1 transition-colors ${
+                            isPicked
+                              ? "bg-amber-500 text-slate-900"
+                              : "bg-white text-slate-700 border border-slate-200 hover:bg-amber-50 hover:border-amber-300 disabled:opacity-50"
+                          }`}
+                          title={formatRange(s.start_at, s.end_at)}
+                        >
+                          {formatTime(s.start_at)}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          {pending && (
+            <p className="text-xs text-slate-500 mt-3 text-center">
+              Booking your slot…
+            </p>
+          )}
         </>
       )}
     </div>
@@ -202,4 +281,11 @@ function formatRange(startAt: string, endAt: string): string {
     minute: "2-digit",
   });
   return `${startStr} → ${endStr}`;
+}
+
+function formatTime(startAt: string): string {
+  return new Date(startAt).toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  });
 }

--- a/app/briefs/[slug]/page.tsx
+++ b/app/briefs/[slug]/page.tsx
@@ -170,6 +170,75 @@ export default async function BriefTrackerPage({
     }
   }
 
+  // Intake-question prompt: pros/teams can publish 1-5 questions the
+  // consumer should answer post-accept. Surface a banner when the brief
+  // has unanswered required questions so the consumer doesn't need to
+  // discover the /intake page on their own. Count via service-role —
+  // questions are public-readable but answers are owner-scoped.
+  let intakeOutstanding = 0;
+  if (brief.accepted_at) {
+    try {
+      const intakeAdmin = await createClient();
+      const targetTeam = brief.accepted_by_team_id;
+      const targetPro = brief.accepted_by_professional_id;
+      let questionFilter = intakeAdmin
+        .from("pro_intake_questions")
+        .select("id", { count: "exact", head: true })
+        .eq("enabled", true);
+      if (targetTeam) questionFilter = questionFilter.eq("team_id", targetTeam);
+      else if (targetPro) questionFilter = questionFilter.eq("professional_id", targetPro);
+      else questionFilter = questionFilter.eq("id", -1);
+      const { count: questionCount } = await questionFilter;
+      const { count: answeredCount } = await intakeAdmin
+        .from("pro_intake_answers")
+        .select("id", { count: "exact", head: true })
+        .eq("brief_id", brief.id);
+      intakeOutstanding = Math.max(0, (questionCount ?? 0) - (answeredCount ?? 0));
+    } catch {
+      /* silent — banner just doesn't render */
+    }
+  }
+
+  // Unread message count from the consumer's perspective — pros / team
+  // members who posted to brief_messages without the consumer having
+  // marked-read. Drives a small badge next to the "accepted by" panel.
+  let unreadFromPro = 0;
+  if (brief.accepted_at && emailMatches) {
+    try {
+      const msgAdmin = await createClient();
+      const { count } = await msgAdmin
+        .from("brief_messages")
+        .select("id", { count: "exact", head: true })
+        .eq("brief_id", brief.id)
+        .in("sender_kind", ["professional", "team"])
+        .is("read_by_consumer_at", null);
+      unreadFromPro = count ?? 0;
+    } catch {
+      /* silent */
+    }
+  }
+
+  // Outcome review prompt — once the cron has issued a brief_outcomes row
+  // (4 weeks post-accept by default) we show a "rate the engagement" CTA
+  // pointing the consumer at /review/<token>. The form itself already
+  // exists at app/review/[token]/page.tsx + app/api/outcomes/submit.
+  let outcomeReviewToken: string | null = null;
+  if (brief.accepted_at && (brief.tracker_status === "won" || emailMatches)) {
+    try {
+      const outcomeAdmin = await createClient();
+      const { data: outcomeRow } = await outcomeAdmin
+        .from("brief_outcomes")
+        .select("review_token, submitted_at")
+        .eq("brief_id", brief.id)
+        .maybeSingle();
+      if (outcomeRow && !outcomeRow.submitted_at) {
+        outcomeReviewToken = outcomeRow.review_token as string;
+      }
+    } catch {
+      /* silent */
+    }
+  }
+
   const stepIndex = STATUS_ORDER.indexOf(brief.tracker_status);
 
   const breadcrumb = breadcrumbJsonLd([
@@ -252,12 +321,70 @@ export default async function BriefTrackerPage({
             </ol>
           </div>
 
+          {/* Intake-question prompt — surfaces unanswered required questions
+              that the accepting provider published. Skipped silently when
+              questions are zero or all answered. */}
+          {intakeOutstanding > 0 && (
+            <div className="bg-amber-50 border border-amber-300 rounded-2xl p-5 mb-6 flex items-start gap-3">
+              <div className="text-2xl leading-none">✍️</div>
+              <div className="flex-1">
+                <p className="text-sm font-bold text-amber-900">
+                  Your provider has {intakeOutstanding} quick question
+                  {intakeOutstanding === 1 ? "" : "s"} before your first call
+                </p>
+                <p className="text-xs text-amber-800 mt-1">
+                  Answering these now means the first call lands with the context they need.
+                </p>
+                <Link
+                  href={`/briefs/${brief.slug}/intake${email ? `?email=${encodeURIComponent(email)}` : ""}`}
+                  className="inline-block mt-3 rounded-lg bg-amber-500 hover:bg-amber-400 text-slate-900 text-xs font-semibold px-3 py-2"
+                >
+                  Answer now →
+                </Link>
+              </div>
+            </div>
+          )}
+
+          {/* Outcome review prompt — once the 4-week cron has issued a
+              review_token for this brief, surface a small banner so the
+              consumer can submit feedback. Drives provider_outcome_scores. */}
+          {outcomeReviewToken && (
+            <div className="bg-violet-50 border border-violet-200 rounded-2xl p-5 mb-6 flex items-start gap-3">
+              <div className="text-2xl leading-none">⭐</div>
+              <div className="flex-1">
+                <p className="text-sm font-bold text-violet-900">
+                  How did your engagement go?
+                </p>
+                <p className="text-xs text-violet-800 mt-1">
+                  A two-minute review helps other investors and bumps your provider on their scoreboard.
+                </p>
+                <Link
+                  href={`/review/${outcomeReviewToken}`}
+                  className="inline-block mt-3 rounded-lg bg-violet-600 hover:bg-violet-500 text-white text-xs font-semibold px-3 py-2"
+                >
+                  Leave a review →
+                </Link>
+              </div>
+            </div>
+          )}
+
           {/* Accepted provider */}
           {(accepted.professional || accepted.team) && (
             <div className="bg-white rounded-2xl border border-slate-200 p-6 mb-6">
-              <p className="text-xs uppercase tracking-widest text-slate-500 mb-2">
-                Accepted by
-              </p>
+              <div className="flex items-center justify-between gap-2 mb-2">
+                <p className="text-xs uppercase tracking-widest text-slate-500">
+                  Accepted by
+                </p>
+                {unreadFromPro > 0 && (
+                  <span
+                    className="inline-flex items-center gap-1 rounded-full bg-rose-100 text-rose-700 text-[11px] font-bold px-2 py-0.5"
+                    title="Unread messages from your provider"
+                  >
+                    <span className="h-1.5 w-1.5 rounded-full bg-rose-500" aria-hidden />
+                    {unreadFromPro} new message{unreadFromPro === 1 ? "" : "s"}
+                  </span>
+                )}
+              </div>
               {accepted.team && (
                 <p className="text-base font-bold text-slate-900">
                   {accepted.team.name}{" "}


### PR DESCRIPTION
## Summary
Four UX wins on the brief tracker + booking flow, all wired to data tables already in prod.

1. **Intake-question prompt banner** — yellow banner with one-click jump to /briefs/[slug]/intake when accepting pro/team has \`pro_intake_questions\` set and consumer hasn't answered.
2. **Unread message badge** — rose pill counting \`brief_messages\` from the pro side with \`read_by_consumer_at IS NULL\`.
3. **Outcome review CTA banner** — violet banner deep-linking to \`/review/[token]\` once the 4-week cron has issued a \`brief_outcomes.review_token\`.
4. **Calendar grid for consultation booking** — \`BookConsultationPanel\` refactored from a flat list to a 7-day grid (columns = dates, cells = time chips, today highlighted, viewer's local timezone shown).

## Tier
B — additive UI on the tracker + booking panel. All data sources already in prod.

## Test plan
- [x] tsc --noEmit clean
- [ ] CI green