### PR TITLE
feat(df): DF-01 decision flow engine + buy-vs-rent interactive tree [audit remediation]

### DIFF
--- a/app/decision/buy-vs-rent/page.tsx
+++ b/app/decision/buy-vs-rent/page.tsx
@@ -1,0 +1,64 @@
+import type { Metadata } from "next";
+import { DecisionFlowShell } from "@/components/DecisionFlowShell";
+import { BUY_VS_RENT_FLOW } from "@/lib/decision-flow-configs";
+import { breadcrumbJsonLd, absoluteUrl, SITE_NAME } from "@/lib/seo";
+import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
+
+export const revalidate = 86400;
+
+export const metadata: Metadata = {
+  title: `Should I Buy or Rent? Interactive Guide | ${SITE_NAME}`,
+  description:
+    "Answer 4 questions to get a personalised buy vs rent recommendation for your Australian property situation. Covers stamp duty, FHB grants, negative gearing, and market conditions.",
+  alternates: { canonical: absoluteUrl("/decision/buy-vs-rent") },
+  openGraph: {
+    title: "Should I Buy or Rent? | invest.com.au",
+    description:
+      "Work through Australia's most common property decision in under 2 minutes.",
+    url: absoluteUrl("/decision/buy-vs-rent"),
+  },
+};
+
+export default function BuyVsRentPage() {
+  const jsonLd = breadcrumbJsonLd([
+    { name: "Home", url: absoluteUrl("/") },
+    { name: "Decision Tools", url: absoluteUrl("/decision") },
+    { name: "Buy vs Rent", url: absoluteUrl("/decision/buy-vs-rent") },
+  ]);
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <main className="min-h-screen bg-gray-50 py-10 px-4">
+        <div className="max-w-3xl mx-auto">
+          <nav className="text-xs text-gray-500 mb-6">
+            <a href="/" className="hover:underline">
+              Home
+            </a>{" "}
+            /{" "}
+            <a href="/decision" className="hover:underline">
+              Decision Tools
+            </a>{" "}
+            / Buy vs Rent
+          </nav>
+          <div className="mb-8">
+            <h1 className="text-3xl font-bold text-gray-900 mb-2">
+              Should I Buy or Rent?
+            </h1>
+            <p className="text-gray-600">
+              Answer a few questions to get a personalised recommendation for
+              your Australian property situation.
+            </p>
+          </div>
+          <DecisionFlowShell flow={BUY_VS_RENT_FLOW} />
+          <p className="mt-10 text-xs text-gray-400 leading-relaxed">
+            {GENERAL_ADVICE_WARNING}
+          </p>
+        </div>
+      </main>
+    </>
+  );
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -120,6 +120,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     "/etfs/quiz",
     "/insurance/quiz",
     "/negative-gearing", "/negative-gearing/calculator", "/negative-gearing/quiz",
+    "/decision/buy-vs-rent",
     "/lump-sum-investing", "/lump-sum-investing/redundancy",
     "/lump-sum-investing/inheritance", "/lump-sum-investing/calculator",
     "/halal-investing",

--- a/components/DecisionFlowShell.tsx
+++ b/components/DecisionFlowShell.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useState } from "react";
+import type { DecisionFlow } from "@/lib/decision-flows";
+
+interface Props {
+  flow: DecisionFlow;
+}
+
+export function DecisionFlowShell({ flow }: Props) {
+  const [currentId, setCurrentId] = useState(flow.startId);
+  const [history, setHistory] = useState<string[]>([]);
+
+  const node = flow.nodes[currentId];
+  if (!node) return null;
+
+  const handleSelect = (nextId: string) => {
+    setHistory((h) => [...h, currentId]);
+    setCurrentId(nextId);
+  };
+
+  const handleBack = () => {
+    const prev = history[history.length - 1];
+    if (prev !== undefined) {
+      setHistory((h) => h.slice(0, -1));
+      setCurrentId(prev);
+    }
+  };
+
+  const handleRestart = () => {
+    setHistory([]);
+    setCurrentId(flow.startId);
+  };
+
+  if (node.type === "outcome") {
+    return (
+      <div className="max-w-2xl mx-auto">
+        {history.length > 0 && (
+          <button
+            onClick={handleBack}
+            className="text-sm text-blue-600 hover:underline mb-4 block"
+          >
+            ← Back
+          </button>
+        )}
+        <div className="bg-emerald-50 border border-emerald-200 rounded-xl p-6">
+          <div className="flex items-center gap-2 mb-3">
+            <span className="text-2xl" aria-hidden="true">
+              ✓
+            </span>
+            <h2 className="text-xl font-bold text-emerald-800">{node.title}</h2>
+          </div>
+          <p className="text-gray-700 mb-3">{node.summary}</p>
+          <p className="text-sm text-gray-600 bg-white rounded-lg p-3 border border-emerald-100 mb-5">
+            <span className="font-medium text-gray-800">Next step: </span>
+            {node.recommendation}
+          </p>
+          <div className="flex flex-col sm:flex-row gap-3">
+            <a
+              href={node.primaryCta.href}
+              className="bg-blue-600 text-white px-5 py-2.5 rounded-lg text-center font-medium hover:bg-blue-700 transition-colors"
+            >
+              {node.primaryCta.label}
+            </a>
+            {node.secondaryCta !== undefined && (
+              <a
+                href={node.secondaryCta.href}
+                className="border border-blue-600 text-blue-700 px-5 py-2.5 rounded-lg text-center font-medium hover:bg-blue-50 transition-colors"
+              >
+                {node.secondaryCta.label}
+              </a>
+            )}
+          </div>
+          {node.advisorCta === true && (
+            <div className="mt-5 p-4 bg-white rounded-lg border border-emerald-100">
+              <p className="text-sm font-medium text-gray-800 mb-1">
+                Want personalised advice?
+              </p>
+              <a
+                href="/find-advisor"
+                className="text-sm text-blue-600 hover:underline"
+              >
+                Connect with a licensed financial adviser →
+              </a>
+            </div>
+          )}
+        </div>
+        <button
+          onClick={handleRestart}
+          className="mt-4 text-sm text-gray-500 hover:text-gray-700 underline"
+        >
+          ↺ Start over
+        </button>
+      </div>
+    );
+  }
+
+  // Question node
+  const stepNum = history.length + 1;
+
+  return (
+    <div className="max-w-2xl mx-auto">
+      <div className="flex items-center justify-between mb-6">
+        <span className="text-xs font-medium text-gray-400 uppercase tracking-wide">
+          Step {stepNum}
+        </span>
+        {history.length > 0 && (
+          <button
+            onClick={handleBack}
+            className="text-sm text-blue-600 hover:underline"
+          >
+            ← Back
+          </button>
+        )}
+      </div>
+      <h2 className="text-xl font-bold text-gray-900 mb-2">{node.question}</h2>
+      {node.detail !== undefined && (
+        <p className="text-gray-500 text-sm mb-6">{node.detail}</p>
+      )}
+      <div className="flex flex-col gap-3" role="list">
+        {node.options.map((opt) => (
+          <button
+            key={opt.nextId}
+            onClick={() => handleSelect(opt.nextId)}
+            role="listitem"
+            className="text-left border border-gray-200 rounded-xl px-5 py-4 hover:border-blue-400 hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-blue-400 transition-colors"
+          >
+            <span className="font-medium text-gray-900 block">{opt.label}</span>
+            {opt.detail !== undefined && (
+              <span className="text-xs text-gray-500 mt-0.5 block">
+                {opt.detail}
+              </span>
+            )}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/lib/decision-flow-configs.ts
+++ b/lib/decision-flow-configs.ts
@@ -1,0 +1,258 @@
+import type { DecisionFlow } from "@/lib/decision-flows";
+
+export const BUY_VS_RENT_FLOW: DecisionFlow = {
+  title: "Should I Buy or Rent?",
+  description:
+    "Answer a few questions to get a personalised recommendation for your Australian property situation.",
+  startId: "q1-goal",
+  nodes: {
+    "q1-goal": {
+      type: "question",
+      id: "q1-goal",
+      question: "What's your primary housing goal right now?",
+      options: [
+        {
+          label: "Build long-term wealth through property",
+          nextId: "q2-deposit",
+        },
+        {
+          label: "Flexibility to move for work or lifestyle",
+          nextId: "out-rent-flex",
+        },
+        {
+          label: "Tax advantages (negative gearing)",
+          detail: "37–45% marginal tax rate is where this strategy works best",
+          nextId: "q2-ng",
+        },
+        {
+          label: "I already own and am considering upgrading",
+          nextId: "out-upgrade",
+        },
+      ],
+    },
+    "q2-deposit": {
+      type: "question",
+      id: "q2-deposit",
+      question: "How much deposit do you have saved?",
+      detail:
+        "20% avoids LMI (Lenders Mortgage Insurance). 5% is the typical lender minimum.",
+      options: [
+        { label: "20% or more", nextId: "q3-tenure" },
+        {
+          label: "5–20% saved (LMI territory)",
+          detail: "LMI can add $10,000–$30,000 to your loan",
+          nextId: "q-fhb",
+        },
+        {
+          label: "Under 5%",
+          detail: "Most lenders won't approve below 5%",
+          nextId: "out-save-first",
+        },
+      ],
+    },
+    "q3-tenure": {
+      type: "question",
+      id: "q3-tenure",
+      question: "How long do you plan to stay in this property?",
+      detail:
+        "Stamp duty (typically 3–5% of purchase price) makes buying costly if you move quickly.",
+      options: [
+        { label: "5+ years", nextId: "q4-market" },
+        { label: "3–5 years", nextId: "out-borderline" },
+        { label: "Under 3 years", nextId: "out-rent-short" },
+      ],
+    },
+    "q4-market": {
+      type: "question",
+      id: "q4-market",
+      question: "How would you describe your local property market?",
+      options: [
+        {
+          label: "Strong growth area",
+          detail: "Capital city core, coastal lifestyle, high-demand suburb",
+          nextId: "out-buy-growth",
+        },
+        {
+          label: "Stable / steady",
+          detail: "Regional city, established suburb with moderate growth",
+          nextId: "out-rent-invest",
+        },
+        {
+          label: "Uncertain / oversupplied",
+          detail: "New estates, mining towns, areas with falling prices",
+          nextId: "out-rent-uncertain",
+        },
+      ],
+    },
+    "q-fhb": {
+      type: "question",
+      id: "q-fhb",
+      question: "Are you a first home buyer?",
+      detail:
+        "First home buyers may qualify for grants, stamp duty concessions, and the FHSS scheme.",
+      options: [
+        { label: "Yes — first home buyer", nextId: "out-fhb" },
+        {
+          label: "No — I've owned property before",
+          detail: "Continue with standard buyer assessment",
+          nextId: "q3-tenure",
+        },
+      ],
+    },
+    "q2-ng": {
+      type: "question",
+      id: "q2-ng",
+      question: "What's your approximate marginal income tax rate?",
+      detail:
+        "Negative gearing works by offsetting rental losses against your income — the higher your rate, the greater the tax relief.",
+      options: [
+        {
+          label: "37–45% (income $120k+)",
+          nextId: "out-buy-ng",
+        },
+        {
+          label: "Under 37% (income under $120k)",
+          detail: "Still viable but less impactful — let's assess your situation",
+          nextId: "q2-deposit",
+        },
+      ],
+    },
+    "out-buy-growth": {
+      type: "outcome",
+      id: "out-buy-growth",
+      title: "Lean towards Buying",
+      summary:
+        "With a 20%+ deposit, a long intended tenure, and a growth market, buying stacks up well. The equity you build compounds over time and provides housing security.",
+      recommendation:
+        "Run the full numbers: compare estimated mortgage repayments against rent + investment returns on your deposit. Factor in stamp duty upfront (check your state concessions), council rates, strata if applicable, and maintenance (~1% of property value per year). A mortgage broker can model your serviceability at today's rates.",
+      primaryCta: { label: "Use the Mortgage Calculator", href: "/mortgage-calculator" },
+      secondaryCta: {
+        label: "Find a Mortgage Broker",
+        href: "/find-advisor?need=mortgage_broker",
+      },
+      advisorCta: true,
+    },
+    "out-rent-invest": {
+      type: "outcome",
+      id: "out-rent-invest",
+      title: "Consider Renting + Investing the Difference",
+      summary:
+        "In a stable market, renting frees up capital to invest in diversified assets (ETFs, index funds). Over 10–15 years, a disciplined 'rent and invest' approach often matches or beats buying in low-growth markets — especially when factoring in stamp duty, maintenance, and illiquidity.",
+      recommendation:
+        "Calculate the 'rent vs buy' gap: stamp duty + deposit opportunity cost + ongoing costs. Invest that difference in low-cost diversified funds (VGS + A200 is a common starting point). Revisit buying when your market shows stronger fundamentals or your savings exceed 25%.",
+      primaryCta: { label: "ETF Hub", href: "/etfs" },
+      secondaryCta: {
+        label: "Property Hub",
+        href: "/property",
+      },
+      advisorCta: true,
+    },
+    "out-rent-uncertain": {
+      type: "outcome",
+      id: "out-rent-uncertain",
+      title: "Rent for Now",
+      summary:
+        "Buying in an uncertain or oversupplied market means capital at risk and reduced liquidity. Stamp duty alone (3–5%) takes years to recoup if prices stagnate or fall.",
+      recommendation:
+        "Stay flexible: monitor the market for 12–24 months. Use the savings period to invest in liquid assets and build your deposit beyond 20%. You'll have more options and lower LVR when market fundamentals improve.",
+      primaryCta: { label: "High-Yield Savings Accounts", href: "/savings" },
+      secondaryCta: { label: "Property Hub", href: "/property" },
+    },
+    "out-rent-short": {
+      type: "outcome",
+      id: "out-rent-short",
+      title: "Rent — Timeline Too Short to Buy",
+      summary:
+        "Stamp duty (typically $15,000–$60,000 depending on state and price) plus agent fees (~2%), lender fees, and moving costs mean you need meaningful capital growth just to break even on a short hold.",
+      recommendation:
+        "Unless you're in a strongly appreciating market, buying for under 3 years rarely makes financial sense. Keep renting and stay liquid. Reassess when your timeline extends to 5+ years.",
+      primaryCta: { label: "Savings Calculator", href: "/savings-calculator" },
+      secondaryCta: { label: "Property Hub", href: "/property" },
+    },
+    "out-borderline": {
+      type: "outcome",
+      id: "out-borderline",
+      title: "It's Borderline — Run the Numbers",
+      summary:
+        "3–5 years is the grey zone. Stamp duty is a meaningful cost but capital growth can cover it in appreciating markets. The right answer depends on your specific market, property price, and investment alternatives.",
+      recommendation:
+        "Model your specific scenario: input your state's stamp duty rate, expected annual capital growth (3–8% depending on market), and the return you could earn investing your deposit in shares instead. A 1% difference in growth rate changes the answer significantly.",
+      primaryCta: {
+        label: "Property vs Shares Calculator",
+        href: "/tools",
+      },
+      secondaryCta: {
+        label: "Find a Buyer's Agent",
+        href: "/find-advisor?need=buyers_agent",
+      },
+      advisorCta: true,
+    },
+    "out-save-first": {
+      type: "outcome",
+      id: "out-save-first",
+      title: "Build Your Deposit First",
+      summary:
+        "Under 5% means most lenders won't approve you. Even with approval, LMI on a very small deposit can add $20,000–$40,000 to your total loan cost.",
+      recommendation:
+        "Accelerate your savings with a high-interest savings account and the First Home Super Saver Scheme (FHSS) — up to $50,000 in voluntary super contributions, taxed at 15% going in instead of your marginal rate, and accessible for a first home deposit. Aim for 10–20% before approaching lenders.",
+      primaryCta: { label: "First Home Buyer Hub", href: "/first-home-buyer" },
+      secondaryCta: { label: "Super Hub", href: "/super" },
+    },
+    "out-fhb": {
+      type: "outcome",
+      id: "out-fhb",
+      title: "First Home Buyer Path",
+      summary:
+        "First home buyers have access to significant government support that can offset the LMI cost and reduce upfront barriers: the First Home Owner Grant (up to $30,000 in some states), stamp duty concessions or exemptions (full exemption under price caps in most states), and the FHSS scheme for accessing super contributions tax-effectively.",
+      recommendation:
+        "Check your state's FHB grants and price caps, apply for the First Home Guarantee (federal scheme allowing 5% deposit without LMI), and explore FHSS if you've made voluntary super contributions. A mortgage broker can identify the best lenders for first home buyers at your deposit level.",
+      primaryCta: { label: "First Home Buyer Hub", href: "/first-home-buyer" },
+      secondaryCta: {
+        label: "Find a Mortgage Broker",
+        href: "/find-advisor?need=mortgage_broker",
+      },
+      advisorCta: true,
+    },
+    "out-rent-flex": {
+      type: "outcome",
+      id: "out-rent-flex",
+      title: "Rent — Flexibility Wins",
+      summary:
+        "If career mobility, lifestyle change, or personal flexibility is the priority, renting is the rational choice. Buying locks in significant transaction costs (~5–7% of property value) and a timeline to sell of months, making it poorly suited for mobile households.",
+      recommendation:
+        "Invest the money you would have used as a deposit in liquid, diversified assets (ETFs, managed funds). Revisit buying when your life situation stabilises and you have a longer-term view of where you want to live.",
+      primaryCta: { label: "ETF Hub", href: "/etfs" },
+      secondaryCta: { label: "Investment Hub", href: "/invest" },
+    },
+    "out-upgrade": {
+      type: "outcome",
+      id: "out-upgrade",
+      title: "Upgrading — Leverage Your Equity",
+      summary:
+        "As an existing owner, your equity is your key asset. In rising markets, selling and upgrading simultaneously avoids bridging finance risk. Your equity growth since purchase determines how much deposit you're bringing to the next purchase.",
+      recommendation:
+        "Get your current property independently valued. Speak to a mortgage broker about equity access, simultaneous sale and purchase timing, bridging finance (if needed), and the stamp duty cost of the new property. Consider whether a renovation on your existing property might deliver equivalent value at lower cost.",
+      primaryCta: {
+        label: "Find a Mortgage Broker",
+        href: "/find-advisor?need=mortgage_broker",
+      },
+      secondaryCta: { label: "Property Hub", href: "/property" },
+      advisorCta: true,
+    },
+    "out-buy-ng": {
+      type: "outcome",
+      id: "out-buy-ng",
+      title: "Buying for Tax — Check the Full Model",
+      summary:
+        "At 37%+ marginal rate, negative gearing provides real tax relief. But the strategy requires capital growth to be profitable overall — rental income rarely covers outgoings, so you depend on the property appreciating to come out ahead.",
+      recommendation:
+        "Model your negative gearing scenario carefully: annual interest costs, depreciation schedule (engage a quantity surveyor), rental yield, expected capital growth rate, and hold period. The 50% CGT discount applies after 12 months — making it most effective as a 5–10+ year strategy. An accountant can run the after-tax numbers for your specific situation.",
+      primaryCta: { label: "Negative Gearing Hub", href: "/negative-gearing" },
+      secondaryCta: {
+        label: "Find an Accountant/Adviser",
+        href: "/find-advisor?need=accountant",
+      },
+      advisorCta: true,
+    },
+  },
+};

--- a/lib/decision-flows.ts
+++ b/lib/decision-flows.ts
@@ -1,0 +1,38 @@
+/**
+ * Generic Decision Flow types — used by the DecisionFlowShell component and
+ * all DF-stream decision tree configs (buy-vs-rent, salary-sacrifice, SMSF setup).
+ */
+
+export type DecisionOption = {
+  label: string;
+  detail?: string;
+  nextId: string;
+};
+
+export type DecisionQuestionNode = {
+  type: "question";
+  id: string;
+  question: string;
+  detail?: string;
+  options: DecisionOption[];
+};
+
+export type DecisionOutcomeNode = {
+  type: "outcome";
+  id: string;
+  title: string;
+  summary: string;
+  recommendation: string;
+  primaryCta: { label: string; href: string };
+  secondaryCta?: { label: string; href: string };
+  advisorCta?: boolean;
+};
+
+export type DecisionNode = DecisionQuestionNode | DecisionOutcomeNode;
+
+export type DecisionFlow = {
+  title: string;
+  description: string;
+  startId: string;
+  nodes: Record<string, DecisionNode>;
+};


### PR DESCRIPTION
## Closing — superseded by #883

A parallel cloud routine opened PR #883 for DF-01 (DecisionTree engine) simultaneously. #883 landed first in the queue. Closing this PR to avoid a duplicate merge conflict.

The files on this branch (`components/DecisionFlowShell.tsx`, `lib/decision-flows.ts`, `lib/decision-flow-configs.ts`, `app/decision/buy-vs-rent/`) differ from #883's implementation (`components/DecisionTree.tsx`, `lib/decision-trees/`, `app/tools/buy-vs-rent/`). The #883 approach takes precedence.

## Supersedes
_None — this PR is itself superseded by #883._