### PR TITLE
feat(squad): squad ops bundle — decisions, referrals UI, presence indicator

### DIFF
--- a/app/api/teams/[slug]/decisions/route.ts
+++ b/app/api/teams/[slug]/decisions/route.ts
@@ -1,0 +1,164 @@
+/**
+ * POST /api/teams/[slug]/decisions — squad-inbox "not for us" / "snooze 7d"
+ * action. Records into `team_brief_decisions`. Authenticated team-member only.
+ *
+ * DELETE clears a prior decision (e.g., un-snooze).
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+import { createAdminClient } from "@/lib/supabase/admin";
+import { requireAdvisorSession } from "@/lib/require-advisor-session";
+import { isAllowed, ipKey } from "@/lib/rate-limit-db";
+import { logger } from "@/lib/logger";
+import {
+  clearDecision,
+  recordDecision,
+  type DecisionKind,
+} from "@/lib/team-brief-decisions";
+
+const log = logger("api:team-decisions");
+
+const PostBody = z.object({
+  briefId: z.number().int().positive(),
+  decision: z.enum(["not_for_us", "snoozed"]),
+  reason: z.string().max(1000).optional().nullable(),
+});
+
+const DeleteBody = z.object({
+  briefId: z.number().int().positive(),
+});
+
+async function resolveTeamAndMembership(
+  slug: string,
+  professionalId: number,
+): Promise<{ teamId: number } | { error: string; status: number }> {
+  const admin = createAdminClient();
+  const { data: team } = await admin
+    .from("expert_teams")
+    .select("id")
+    .eq("slug", slug)
+    .maybeSingle();
+  if (!team) return { error: "Team not found.", status: 404 };
+
+  const { data: member } = await admin
+    .from("expert_team_members")
+    .select("id")
+    .eq("team_id", team.id)
+    .eq("professional_id", professionalId)
+    .eq("status", "active")
+    .maybeSingle();
+  if (!member) {
+    return { error: "Not an active member of this team.", status: 403 };
+  }
+  return { teamId: team.id as number };
+}
+
+export async function POST(
+  request: NextRequest,
+  ctx: { params: Promise<{ slug: string }> },
+) {
+  if (
+    !(await isAllowed("team_decisions_post", ipKey(request), {
+      max: 40,
+      refillPerSec: 0.5,
+    }))
+  ) {
+    return NextResponse.json({ error: "Too many requests." }, { status: 429 });
+  }
+
+  const advisorId = await requireAdvisorSession(request);
+  if (!advisorId) {
+    return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+  }
+
+  let raw: unknown;
+  try {
+    raw = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+  const parsed = PostBody.safeParse(raw);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.issues[0]?.message ?? "Invalid body." },
+      { status: 400 },
+    );
+  }
+
+  const { slug } = await ctx.params;
+  const teamResolution = await resolveTeamAndMembership(slug, advisorId);
+  if ("error" in teamResolution) {
+    return NextResponse.json(
+      { error: teamResolution.error },
+      { status: teamResolution.status },
+    );
+  }
+
+  try {
+    const row = await recordDecision({
+      teamId: teamResolution.teamId,
+      briefId: parsed.data.briefId,
+      decision: parsed.data.decision as DecisionKind,
+      decidedByProfessionalId: advisorId,
+      reason: parsed.data.reason ?? null,
+    });
+    return NextResponse.json({ decision: row });
+  } catch (err) {
+    log.error("recordDecision failed", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json(
+      { error: "Failed to record decision." },
+      { status: 500 },
+    );
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  ctx: { params: Promise<{ slug: string }> },
+) {
+  if (
+    !(await isAllowed("team_decisions_delete", ipKey(request), {
+      max: 40,
+      refillPerSec: 0.5,
+    }))
+  ) {
+    return NextResponse.json({ error: "Too many requests." }, { status: 429 });
+  }
+
+  const advisorId = await requireAdvisorSession(request);
+  if (!advisorId) {
+    return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+  }
+
+  let raw: unknown;
+  try {
+    raw = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+  const parsed = DeleteBody.safeParse(raw);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.issues[0]?.message ?? "Invalid body." },
+      { status: 400 },
+    );
+  }
+
+  const { slug } = await ctx.params;
+  const teamResolution = await resolveTeamAndMembership(slug, advisorId);
+  if ("error" in teamResolution) {
+    return NextResponse.json(
+      { error: teamResolution.error },
+      { status: teamResolution.status },
+    );
+  }
+
+  await clearDecision({
+    teamId: teamResolution.teamId,
+    briefId: parsed.data.briefId,
+  });
+  return NextResponse.json({ ok: true });
+}

--- a/app/teams/[slug]/inbox/SquadInboxRowActions.tsx
+++ b/app/teams/[slug]/inbox/SquadInboxRowActions.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+interface OtherTeam {
+  id: number;
+  slug: string;
+  name: string;
+  team_category: string;
+}
+
+interface Props {
+  teamSlug: string;
+  briefId: number;
+  /** Other verified teams the caller can refer this brief to. */
+  otherTeams: OtherTeam[];
+  /** Whether this brief is currently snoozed (drives the "Un-snooze" UI). */
+  snoozed: boolean;
+}
+
+/**
+ * Inbox row-level actions: "Snooze 7d", "Not for us", "Refer".
+ * Wired to `/api/teams/[slug]/decisions` and `/api/teams/[slug]/referrals`.
+ * Kept separate from `SquadInboxClaimRow` so the claim-lifecycle UI stays
+ * narrow; these decisions all hide / forward the brief regardless of claim.
+ */
+export default function SquadInboxRowActions({
+  teamSlug,
+  briefId,
+  otherTeams,
+  snoozed,
+}: Props) {
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+  const [referOpen, setReferOpen] = useState(false);
+  const [referTarget, setReferTarget] = useState<string>("");
+  const [referNote, setReferNote] = useState("");
+
+  async function postDecision(decision: "not_for_us" | "snoozed") {
+    setError(null);
+    try {
+      const res = await fetch(`/api/teams/${teamSlug}/decisions`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ briefId, decision }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        setError(body.error || `Could not ${decision} this brief.`);
+        return;
+      }
+      startTransition(() => router.refresh());
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Network error.");
+    }
+  }
+
+  async function clearSnooze() {
+    setError(null);
+    try {
+      const res = await fetch(`/api/teams/${teamSlug}/decisions`, {
+        method: "DELETE",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ briefId }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        setError(body.error || "Could not un-snooze.");
+        return;
+      }
+      startTransition(() => router.refresh());
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Network error.");
+    }
+  }
+
+  async function submitReferral() {
+    if (!referTarget) return;
+    setError(null);
+    try {
+      const res = await fetch(`/api/teams/${teamSlug}/referrals`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          briefId,
+          toTeamId: Number(referTarget),
+          note: referNote.trim() || null,
+        }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        setError(body.error || "Could not refer this brief.");
+        return;
+      }
+      setReferOpen(false);
+      setReferTarget("");
+      setReferNote("");
+      startTransition(() => router.refresh());
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Network error.");
+    }
+  }
+
+  return (
+    <div className="mt-3 border-t border-slate-100 pt-3">
+      <div className="flex flex-wrap items-center gap-2 text-xs">
+        {!snoozed && (
+          <button
+            type="button"
+            onClick={() => postDecision("snoozed")}
+            disabled={pending}
+            className="text-slate-600 hover:text-slate-900 hover:bg-slate-50 rounded-md px-2 py-1.5 disabled:opacity-50"
+            title="Hide from inbox for 7 days"
+          >
+            😴 Snooze 7d
+          </button>
+        )}
+        {snoozed && (
+          <button
+            type="button"
+            onClick={clearSnooze}
+            disabled={pending}
+            className="text-amber-700 hover:bg-amber-50 rounded-md px-2 py-1.5 disabled:opacity-50"
+          >
+            ↩ Un-snooze
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={() => postDecision("not_for_us")}
+          disabled={pending}
+          className="text-slate-600 hover:text-rose-700 hover:bg-rose-50 rounded-md px-2 py-1.5 disabled:opacity-50"
+          title="Permanently hide from this team's inbox"
+        >
+          ✕ Not for us
+        </button>
+        {otherTeams.length > 0 && (
+          <button
+            type="button"
+            onClick={() => setReferOpen((s) => !s)}
+            disabled={pending}
+            className="text-slate-600 hover:text-violet-700 hover:bg-violet-50 rounded-md px-2 py-1.5 disabled:opacity-50"
+            title="Forward this brief to another verified squad"
+          >
+            ↗ Refer to another team
+          </button>
+        )}
+      </div>
+
+      {referOpen && (
+        <div className="mt-3 bg-violet-50 border border-violet-200 rounded-lg p-3 space-y-2">
+          <label className="block">
+            <span className="text-xs font-semibold text-violet-900">
+              Refer to
+            </span>
+            <select
+              value={referTarget}
+              onChange={(e) => setReferTarget(e.target.value)}
+              className="mt-1 w-full rounded-md border border-violet-300 bg-white text-sm px-2 py-1.5"
+            >
+              <option value="">— pick a verified squad —</option>
+              {otherTeams.map((t) => (
+                <option key={t.id} value={t.id}>
+                  {t.name} · {t.team_category}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="block">
+            <span className="text-xs font-semibold text-violet-900">
+              Note for them (optional)
+            </span>
+            <textarea
+              value={referNote}
+              onChange={(e) => setReferNote(e.target.value)}
+              rows={2}
+              maxLength={2000}
+              className="mt-1 w-full rounded-md border border-violet-300 bg-white text-sm px-2 py-1.5"
+              placeholder="Why this brief might fit them better."
+            />
+          </label>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={submitReferral}
+              disabled={!referTarget || pending}
+              className="rounded-md bg-violet-600 hover:bg-violet-500 disabled:opacity-50 text-white text-xs font-semibold px-3 py-1.5"
+            >
+              {pending ? "Sending…" : "Send referral"}
+            </button>
+            <button
+              type="button"
+              onClick={() => setReferOpen(false)}
+              className="rounded-md bg-white border border-violet-300 text-violet-700 text-xs font-semibold px-3 py-1.5"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      {error && (
+        <p className="mt-2 text-xs text-rose-600" role="alert">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/app/teams/[slug]/inbox/page.tsx
+++ b/app/teams/[slug]/inbox/page.tsx
@@ -10,7 +10,10 @@ import {
   listAssignmentsForBriefs,
   type TeamBriefAssignmentRow,
 } from "@/lib/team-brief-assignments";
+import { getHiddenBriefIdsForTeam } from "@/lib/team-brief-decisions";
+import PresencePinger from "@/components/PresencePinger";
 import SquadInboxClaimRow from "./SquadInboxClaimRow";
+import SquadInboxRowActions from "./SquadInboxRowActions";
 
 // Private surface — keep out of the index. JSON-LD coverage gate
 // auto-exempts pages with `robots: { index: false }`.
@@ -132,14 +135,42 @@ export default async function SquadInboxPage({ params, searchParams }: PageProps
     })
     .filter((m): m is MemberRow => m !== null);
 
-  // 4. Accepted briefs for this team.
-  const { data: briefsRaw } = await admin
+  // 4. Accepted briefs for this team. Hide briefs the squad has marked
+  // `not_for_us` (forever) or `snoozed` within the last 7 days — see
+  // `team_brief_decisions`.
+  const hiddenBriefIds = await getHiddenBriefIdsForTeam(team.id as number);
+  let briefQuery = admin
     .from("advisor_auctions")
     .select("id, slug, job_title, brief_template, created_at")
     .eq("accepted_by_team_id", team.id)
     .order("accepted_at", { ascending: false, nullsFirst: false })
     .range(offset, offset + PAGE_SIZE - 1);
+  if (hiddenBriefIds.size > 0) {
+    briefQuery = briefQuery.not(
+      "id",
+      "in",
+      `(${Array.from(hiddenBriefIds).join(",")})`,
+    );
+  }
+  const { data: briefsRaw } = await briefQuery;
   const briefs = (briefsRaw ?? []) as BriefRow[];
+
+  // 4b. Other verified teams the caller can refer briefs to — populates
+  // the "Refer to another team" picker in the row actions component.
+  const { data: otherTeamsRaw } = await admin
+    .from("expert_teams")
+    .select("id, slug, name, team_category")
+    .eq("public", true)
+    .eq("verification_status", "verified")
+    .neq("id", team.id)
+    .order("name", { ascending: true })
+    .limit(20);
+  const otherTeams = (otherTeamsRaw ?? []) as {
+    id: number;
+    slug: string;
+    name: string;
+    team_category: string;
+  }[];
 
   // 5. Claim assignments for those briefs.
   const briefIds = briefs.map((b) => b.id);
@@ -175,6 +206,11 @@ export default async function SquadInboxPage({ params, searchParams }: PageProps
 
   return (
     <div className="min-h-screen bg-slate-50">
+      {/* Heartbeat — keeps the caller's `presence_pings` row fresh while
+          they're sitting in the inbox. Drives the "X members online"
+          indicator on the public team profile. */}
+      <PresencePinger kind="professional" id={caller.id} />
+
       <div className="max-w-5xl mx-auto px-4 py-8 sm:py-12">
         <div className="flex items-center gap-2 text-xs text-slate-500 mb-4">
           <Link href={`/teams/${team.slug}`} className="hover:text-slate-700">
@@ -293,6 +329,12 @@ export default async function SquadInboxPage({ params, searchParams }: PageProps
                     activeAssignment={active}
                     claimerName={claimerPro?.name ?? null}
                     claimerPhotoUrl={claimerPro?.photo_url ?? null}
+                  />
+                  <SquadInboxRowActions
+                    teamSlug={team.slug as string}
+                    briefId={b.id}
+                    otherTeams={otherTeams}
+                    snoozed={false}
                   />
                 </li>
               );

--- a/app/teams/[slug]/page.tsx
+++ b/app/teams/[slug]/page.tsx
@@ -17,6 +17,7 @@ import {
   getPublicTestimonials,
 } from "@/lib/outcomes/profile-display";
 import { computeSquadTier } from "@/lib/expert-teams/badge-tier";
+import { getOnlineProsBatch } from "@/lib/presence";
 import SquadStack from "./_components/SquadStack";
 import BundledPricePreview from "./_components/BundledPricePreview";
 
@@ -143,6 +144,11 @@ export default async function TeamProfilePage({ params }: PageProps) {
     getPublicTestimonials({ teamId: team.id, limit: 5 }),
   ]);
 
+  // Presence indicator — how many squad members are pinging right now
+  // (heartbeat from /teams/[slug]/inbox). Fail-soft to empty set.
+  const onlineProIds = await getOnlineProsBatch(proIds);
+  const onlineNow = onlineProIds.size;
+
   // Is the calling visitor an active member of this team? If so, surface
   // the "Open squad inbox" link in the trust strip. We resolve the user
   // via the anon auth cookie, then look up the professional + membership
@@ -224,6 +230,18 @@ export default async function TeamProfilePage({ params }: PageProps) {
             <span className="text-xs text-slate-500">
               {String(team.team_category).replace(/_/g, " ")} · {String(team.team_type).replace(/_/g, " ")}
             </span>
+            {onlineNow > 0 && (
+              <span
+                className="inline-flex items-center gap-1.5 text-xs font-semibold bg-emerald-50 text-emerald-800 border border-emerald-200 px-2 py-1 rounded-full"
+                title="Squad members with an active session in the last 5 minutes"
+              >
+                <span className="relative flex h-2 w-2">
+                  <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
+                  <span className="relative inline-flex rounded-full h-2 w-2 bg-emerald-500" />
+                </span>
+                {onlineNow} member{onlineNow === 1 ? "" : "s"} online
+              </span>
+            )}
             {isActiveMember && (
               <Link
                 href={`/teams/${slug}/inbox`}

--- a/components/PresencePinger.tsx
+++ b/components/PresencePinger.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+interface Props {
+  /** Either "professional" (lights up `presence_pings.professional_id`)
+   * or "team" (lights up `presence_pings.team_id` — typically not used
+   * directly; team online state is derived from member pings). */
+  kind: "professional" | "team";
+  /** The professional_id or team_id row to keep fresh. */
+  id: number;
+}
+
+/**
+ * Heartbeat client. Pings `/api/presence/ping` every 90 seconds while the
+ * tab is visible. Server-side helpers in `lib/presence` consider a row
+ * "online" while the last ping is within 5 minutes (STALE_WINDOW_MS).
+ *
+ * Mount this once on a page the pro / member already has open while they
+ * work (e.g. the squad inbox, the pro dashboard). No UI rendered.
+ */
+export default function PresencePinger({ kind, id }: Props) {
+  const lastPingRef = useRef<number>(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    const POLL_MS = 90 * 1000;
+
+    async function ping() {
+      if (cancelled || document.hidden) return;
+      const now = Date.now();
+      if (now - lastPingRef.current < 60 * 1000) return;
+      lastPingRef.current = now;
+      try {
+        await fetch("/api/presence/ping", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ kind, id }),
+        });
+      } catch {
+        /* silent — best-effort heartbeat */
+      }
+    }
+
+    void ping();
+    const interval = window.setInterval(ping, POLL_MS);
+    document.addEventListener("visibilitychange", ping);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+      document.removeEventListener("visibilitychange", ping);
+    };
+  }, [kind, id]);
+
+  return null;
+}

--- a/lib/team-brief-decisions.ts
+++ b/lib/team-brief-decisions.ts
@@ -1,0 +1,140 @@
+/**
+ * Squad inbox decisions — "not for us" and "snooze 7 days" actions a team
+ * member can apply to a brief that's been routed to their squad inbox.
+ *
+ * Backed by `team_brief_decisions` (one row per (team_id, brief_id,
+ * decision) — UNIQUE index enforces idempotency). The squad inbox page
+ * filters out briefs that have a `not_for_us` decision (forever) or a
+ * `snoozed` decision newer than 7 days (until the snooze elapses).
+ */
+
+// eslint-disable-next-line no-restricted-imports -- service-role: API route resolves caller via advisor session then writes on their behalf with cross-row checks (team membership) that anon RLS can't see.
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+
+const log = logger("team-brief-decisions");
+
+export type DecisionKind = "not_for_us" | "snoozed";
+
+export const SNOOZE_DAYS = 7;
+const SNOOZE_MS = SNOOZE_DAYS * 24 * 60 * 60 * 1000;
+
+export interface TeamBriefDecisionRow {
+  id: number;
+  team_id: number;
+  brief_id: number;
+  decision: DecisionKind;
+  reason: string | null;
+  decided_by_professional_id: number | null;
+  created_at: string;
+}
+
+export class DecisionError extends Error {
+  status: number;
+  constructor(message: string, status = 400) {
+    super(message);
+    this.status = status;
+  }
+}
+
+export interface RecordDecisionInput {
+  teamId: number;
+  briefId: number;
+  decision: DecisionKind;
+  decidedByProfessionalId: number;
+  reason?: string | null;
+}
+
+export async function recordDecision(
+  input: RecordDecisionInput,
+): Promise<TeamBriefDecisionRow> {
+  const admin = createAdminClient();
+  const reason = (input.reason ?? "").trim().slice(0, 1000) || null;
+  // First clear any prior decision of the *other* kind on the same brief —
+  // a snooze followed by "not for us" should leave only the latter, and a
+  // re-snooze should refresh the timestamp.
+  await admin
+    .from("team_brief_decisions")
+    .delete()
+    .eq("team_id", input.teamId)
+    .eq("brief_id", input.briefId);
+
+  const { data, error } = await admin
+    .from("team_brief_decisions")
+    .insert({
+      team_id: input.teamId,
+      brief_id: input.briefId,
+      decision: input.decision,
+      reason,
+      decided_by_professional_id: input.decidedByProfessionalId,
+    })
+    .select("*")
+    .single();
+
+  if (error) {
+    log.error("recordDecision failed", {
+      teamId: input.teamId,
+      briefId: input.briefId,
+      decision: input.decision,
+      err: error.message,
+    });
+    throw new DecisionError("Failed to record decision.", 500);
+  }
+  return data as TeamBriefDecisionRow;
+}
+
+export async function clearDecision(input: {
+  teamId: number;
+  briefId: number;
+}): Promise<void> {
+  const admin = createAdminClient();
+  const { error } = await admin
+    .from("team_brief_decisions")
+    .delete()
+    .eq("team_id", input.teamId)
+    .eq("brief_id", input.briefId);
+  if (error) {
+    log.warn("clearDecision failed", {
+      teamId: input.teamId,
+      briefId: input.briefId,
+      err: error.message,
+    });
+  }
+}
+
+/**
+ * Returns the set of brief_ids that should currently be HIDDEN from the
+ * given team's inbox view. Filters: `not_for_us` (forever) or `snoozed`
+ * within the last SNOOZE_DAYS days.
+ */
+export async function getHiddenBriefIdsForTeam(
+  teamId: number,
+): Promise<Set<number>> {
+  const admin = createAdminClient();
+  const snoozeCutoff = new Date(Date.now() - SNOOZE_MS).toISOString();
+  const { data, error } = await admin
+    .from("team_brief_decisions")
+    .select("brief_id, decision, created_at")
+    .eq("team_id", teamId);
+  if (error) {
+    log.warn("getHiddenBriefIdsForTeam failed", {
+      teamId,
+      err: error.message,
+    });
+    return new Set();
+  }
+  const hidden = new Set<number>();
+  for (const row of data ?? []) {
+    const decision = row.decision as DecisionKind;
+    const briefId = row.brief_id as number;
+    if (decision === "not_for_us") {
+      hidden.add(briefId);
+      continue;
+    }
+    if (decision === "snoozed") {
+      const createdAt = row.created_at as string;
+      if (createdAt > snoozeCutoff) hidden.add(briefId);
+    }
+  }
+  return hidden;
+}


### PR DESCRIPTION
## Summary
Lights up three dormant tables/APIs that already exist but had no UI:

1. **Squad inbox decisions** (\`team_brief_decisions\`) — new row actions "Snooze 7d" and "Not for us" hide briefs from the inbox without releasing them. Snoozed briefs auto-return after 7 days; not-for-us hides forever. New API \`POST/DELETE /api/teams/[slug]/decisions\` + helper \`lib/team-brief-decisions.ts\`.
2. **Refer-to-another-team picker** — \`/api/teams/[slug]/referrals\` was wired but had no UI; this adds a "↗ Refer to another team" button with a picker of verified squads + optional note.
3. **Presence indicator** (\`presence_pings\`) — new client component \`<PresencePinger />\` mounts on the squad inbox and heartbeat-pings the existing \`/api/presence/ping\` route every 90s. Public team profile shows a pulsing "N members online" pill via \`getOnlineProsBatch()\`.

## Tier
B — additive: 1 new helper, 1 new API, 1 new client component, edits to 2 existing pages.

## Test plan
- [x] tsc --noEmit clean
- [ ] Manual: squad member opens \`/teams/<slug>/inbox\` → snooze a brief → it disappears for 7 days; un-snooze → returns
- [ ] Manual: refer a brief to another verified team → it shows in the recipient squad's inbox
- [ ] Manual: open \`/teams/<slug>/inbox\` in one tab → reload \`/teams/<slug>\` in another → see "1 member online" pill