### PR TITLE
feat: squad tour and benchmarking

### DIFF
--- a/app/advisor/[slug]/AdvisorProfileClient.tsx
+++ b/app/advisor/[slug]/AdvisorProfileClient.tsx
@@ -293,6 +293,7 @@ export default function AdvisorProfileClient({
                     method={pro.verification_method ?? null}
                     abn={pro.abn ?? null}
                     afsl={pro.afsl_number ?? null}
+                    lastVerifiedAt={pro.last_verified_at ?? null}
                     compact
                   />
                   {pro.accepts_international_clients && (

--- a/components/VerifiedBadge.tsx
+++ b/components/VerifiedBadge.tsx
@@ -23,6 +23,15 @@ export interface VerifiedBadgeProps {
   afsl?: string | null;
   abn?: string | null;
   /**
+   * `professionals.last_verified_at` (or equivalent for teams). When
+   * provided, appended to the tooltip as "Re-verified <relative>" and
+   * surfaced as a small footnote under the pills so consumers see the
+   * badge isn't stale. ASIC + TPB credentials have annual review
+   * cycles; surfacing freshness is a meaningful trust signal beyond
+   * the binary pill.
+   */
+  lastVerifiedAt?: string | null;
+  /**
    * Render the "Seeded" grey pill. Default false so the pill
    * never leaks onto public pages. Admin surfaces pass true.
    */
@@ -37,10 +46,25 @@ function hasToken(method: string, token: string): boolean {
   return method.toLowerCase().split(/[+,\s]/).includes(token);
 }
 
+function relativeAgoLabel(iso: string): string | null {
+  const ts = new Date(iso).getTime();
+  if (!Number.isFinite(ts)) return null;
+  const ms = Date.now() - ts;
+  if (ms < 0) return null;
+  const days = Math.floor(ms / 86_400_000);
+  if (days < 1) return "today";
+  if (days < 30) return `${days} day${days === 1 ? "" : "s"} ago`;
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months} month${months === 1 ? "" : "s"} ago`;
+  const years = Math.floor(months / 12);
+  return `${years} year${years === 1 ? "" : "s"} ago`;
+}
+
 export default function VerifiedBadge({
   method,
   afsl,
   abn,
+  lastVerifiedAt,
   showSeeded = false,
   compact = false,
   className,
@@ -55,6 +79,9 @@ export default function VerifiedBadge({
   // Admin-only badge, hidden on public pages
   if (isSeeded && !showSeeded) return null;
 
+  const freshnessLabel = lastVerifiedAt ? relativeAgoLabel(lastVerifiedAt) : null;
+  const freshnessSuffix = freshnessLabel ? ` · Re-verified ${freshnessLabel}.` : "";
+
   const pills: Array<{
     label: string;
     title: string;
@@ -65,9 +92,10 @@ export default function VerifiedBadge({
   if (hasAbn) {
     pills.push({
       label: "ABN Verified",
-      title: abn
-        ? ABN_VERIFIED_NOTE.replace("ABN", `ABN ${abn}`)
-        : ABN_VERIFIED_NOTE,
+      title:
+        (abn
+          ? ABN_VERIFIED_NOTE.replace("ABN", `ABN ${abn}`)
+          : ABN_VERIFIED_NOTE) + freshnessSuffix,
       cls: "bg-emerald-100 text-emerald-800 border-emerald-200",
       icon: "check-circle",
     });
@@ -75,9 +103,10 @@ export default function VerifiedBadge({
   if (hasAfsl) {
     pills.push({
       label: "AFSL Current",
-      title: afsl
-        ? AFSL_VERIFIED_NOTE.replace("AFSL", `AFSL ${afsl}`)
-        : AFSL_VERIFIED_NOTE,
+      title:
+        (afsl
+          ? AFSL_VERIFIED_NOTE.replace("AFSL", `AFSL ${afsl}`)
+          : AFSL_VERIFIED_NOTE) + freshnessSuffix,
       cls: "bg-sky-100 text-sky-800 border-sky-200",
       icon: "shield-check",
     });
@@ -107,6 +136,14 @@ export default function VerifiedBadge({
           {p.label}
         </span>
       ))}
+      {freshnessLabel && !compact && (
+        <span
+          className="text-[10px] text-slate-500"
+          title={`Last verified: ${lastVerifiedAt ?? ""}`}
+        >
+          Re-verified {freshnessLabel}
+        </span>
+      )}
     </span>
   );
 }


### PR DESCRIPTION
Second-wave bundle from the audit follow-up. See commit body for detail.