### PR TITLE
feat(bundle): second-wave UX — squad tour, benchmarking, intake templates, webhooks, Stripe wizard, referral chain

### DIFF
--- a/app/account/dashboard/page.tsx
+++ b/app/account/dashboard/page.tsx
@@ -30,6 +30,34 @@ function daysUntil(dateStr: string): number {
   return Math.ceil((target.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
 }
 
+function countByKey<T extends Record<string, unknown>>(
+  rows: T[],
+  key: keyof T,
+): Map<unknown, number> {
+  const m = new Map<unknown, number>();
+  for (const r of rows) {
+    const k = r[key];
+    if (k == null) continue;
+    m.set(k, (m.get(k) ?? 0) + 1);
+  }
+  return m;
+}
+
+function median(nums: number[]): number {
+  if (nums.length === 0) return 0;
+  const sorted = [...nums].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? Math.round((sorted[mid - 1]! + sorted[mid]!) / 2)
+    : (sorted[mid] ?? 0);
+}
+
+function percentile(value: number, distribution: number[]): number | null {
+  if (distribution.length === 0) return null;
+  const lessOrEqual = distribution.filter((n) => n <= value).length;
+  return Math.round((lessOrEqual / distribution.length) * 100);
+}
+
 type GoalRow = {
   id: number;
   label: string;
@@ -137,6 +165,54 @@ type SnapshotCardProps = {
   emptyHint?: string;
 };
 
+interface BenchmarkRowProps {
+  label: string;
+  user: number;
+  median: number;
+  pct: number | null;
+}
+function BenchmarkRow({ label, user, median, pct }: BenchmarkRowProps) {
+  const diff = user - median;
+  const callout =
+    pct !== null
+      ? pct >= 80
+        ? `Top ${100 - pct}% of investors`
+        : pct >= 50
+          ? "Above median"
+          : pct >= 20
+            ? "Below median — room to grow"
+            : "Just getting started — that's normal"
+      : null;
+  return (
+    <div className="flex flex-col">
+      <p className="text-[10px] uppercase tracking-wide text-slate-500 font-semibold">
+        {label}
+      </p>
+      <div className="flex items-baseline gap-2 mt-1">
+        <p className="text-xl font-extrabold text-violet-900">{user}</p>
+        <p className="text-[11px] text-slate-500">
+          most have {median}
+          {diff !== 0 && (
+            <span
+              className={
+                diff > 0
+                  ? "text-emerald-700 font-semibold ml-1"
+                  : "text-slate-400 ml-1"
+              }
+            >
+              ({diff > 0 ? "+" : ""}
+              {diff})
+            </span>
+          )}
+        </p>
+      </div>
+      {callout && (
+        <p className="text-[11px] text-violet-700 mt-1">{callout}</p>
+      )}
+    </div>
+  );
+}
+
 function SnapshotCard({ title, value, sub, href, emptyHint }: SnapshotCardProps) {
   return (
     <Link
@@ -227,6 +303,72 @@ export default async function PersonalDashboardPage() {
   const { advisors: matchedAdvisors, matchBasis: advisorMatchBasis } =
     await fetchMatchedAdvisors(supabase, investorProfile);
 
+  // Benchmarking — anonymised aggregate stats so the user can see "where
+  // they stand" vs other investors. Pure counts + medians; no PII leaves
+  // the joins. Service-role queries; investor_profiles and
+  // investor_holdings are RLS-isolated, so aggregate reads need admin.
+  // Fail-soft to nulls — strip hides itself when no signal.
+  type Benchmark = {
+    median_goals: number;
+    median_holdings: number;
+    median_watchlist: number;
+    investor_total: number;
+    user_pct_goals: number | null;
+    user_pct_holdings: number | null;
+    user_pct_watchlist: number | null;
+  };
+  let benchmark: Benchmark | null = null;
+  try {
+    const { createAdminClient } = await import("@/lib/supabase/admin");
+    const admin = createAdminClient();
+    const [
+      { count: investorTotal },
+      { data: goalsAgg },
+      { data: holdingsAgg },
+      { data: watchlistAgg },
+    ] = await Promise.all([
+      admin
+        .from("investor_profiles")
+        .select("auth_user_id", { count: "exact", head: true }),
+      // Use a window of recent active investors to keep aggregates fresh.
+      admin
+        .from("investor_goals")
+        .select("auth_user_id")
+        .limit(5000),
+      admin.from("investor_holdings").select("auth_user_id").limit(5000),
+      admin.from("user_watchlist_items").select("user_id").limit(5000),
+    ]);
+    const goalCounts = countByKey(
+      (goalsAgg ?? []) as { auth_user_id: string }[],
+      "auth_user_id",
+    );
+    const holdingsCounts = countByKey(
+      (holdingsAgg ?? []) as { auth_user_id: string }[],
+      "auth_user_id",
+    );
+    const watchlistCounts = countByKey(
+      (watchlistAgg ?? []) as { user_id: string }[],
+      "user_id",
+    );
+    benchmark = {
+      median_goals: median(Array.from(goalCounts.values())),
+      median_holdings: median(Array.from(holdingsCounts.values())),
+      median_watchlist: median(Array.from(watchlistCounts.values())),
+      investor_total: investorTotal ?? 0,
+      user_pct_goals: percentile(goals.length, Array.from(goalCounts.values())),
+      user_pct_holdings: percentile(
+        holdingsCount,
+        Array.from(holdingsCounts.values()),
+      ),
+      user_pct_watchlist: percentile(
+        watchlistCount,
+        Array.from(watchlistCounts.values()),
+      ),
+    };
+  } catch {
+    /* fail-soft */
+  }
+
   const displayName = profile?.display_name ?? investorProfile?.displayName ?? null;
   const firstName = displayName?.split(" ")[0] ?? null;
 
@@ -296,6 +438,48 @@ export default async function PersonalDashboardPage() {
           />
         </div>
       </section>
+
+      {/* Benchmarking strip — "how you compare" against anonymised
+          aggregate community stats. Hidden when no signal (new
+          install) or when neither user nor community has data. */}
+      {benchmark && benchmark.investor_total > 5 && (
+        <section
+          aria-labelledby="benchmark-heading"
+          className="mb-8"
+        >
+          <h2
+            id="benchmark-heading"
+            className="text-xs font-semibold uppercase tracking-wide text-slate-500 mb-3"
+          >
+            How you compare
+          </h2>
+          <div className="bg-gradient-to-br from-violet-50 via-white to-violet-50 border border-violet-100 rounded-xl p-4 grid grid-cols-1 sm:grid-cols-3 gap-3 text-xs">
+            <BenchmarkRow
+              label="Goals tracked"
+              user={goals.length}
+              median={benchmark.median_goals}
+              pct={benchmark.user_pct_goals}
+            />
+            <BenchmarkRow
+              label="Holdings entered"
+              user={holdingsCount}
+              median={benchmark.median_holdings}
+              pct={benchmark.user_pct_holdings}
+            />
+            <BenchmarkRow
+              label="Watchlist items"
+              user={watchlistCount}
+              median={benchmark.median_watchlist}
+              pct={benchmark.user_pct_watchlist}
+            />
+          </div>
+          <p className="text-[10px] text-slate-400 mt-2">
+            Aggregated across {benchmark.investor_total.toLocaleString()}{" "}
+            investor profiles · refreshed on page load · no personal data
+            leaves these comparisons.
+          </p>
+        </section>
+      )}
 
       {/* Nearest goal progress */}
       {nearestGoal && (

--- a/app/account/referrals/ReferralsClient.tsx
+++ b/app/account/referrals/ReferralsClient.tsx
@@ -223,6 +223,79 @@ export default function ReferralsClient() {
           </div>
         </div>
 
+        {/* Referral chain — visual layout of who you've invited and where
+            they are in the funnel. Renders as a hub-and-spoke diagram:
+            "You" in the centre, each referee as a card with status pill
+            and connecting line. Hides when history is empty. */}
+        {history.length > 0 && (
+          <div className="bg-white border border-slate-200 rounded-xl p-5 mb-4">
+            <h2 className="text-base font-bold text-slate-900 mb-1">
+              Your referral chain
+            </h2>
+            <p className="text-xs text-slate-500 mb-4">
+              Visible only to you — each card is one invite and its progress.
+            </p>
+            <div className="relative">
+              {/* You (centre) */}
+              <div className="flex justify-center mb-5">
+                <div className="inline-flex items-center gap-2 rounded-full bg-emerald-100 border border-emerald-300 px-4 py-2">
+                  <span className="inline-flex w-7 h-7 rounded-full bg-emerald-500 text-white items-center justify-center font-bold text-xs">
+                    {user?.email?.[0]?.toUpperCase() ?? "Y"}
+                  </span>
+                  <span className="text-sm font-bold text-emerald-900">You</span>
+                </div>
+              </div>
+              {/* Stem */}
+              <div
+                aria-hidden
+                className="absolute left-1/2 top-12 -translate-x-1/2 h-6 w-px bg-emerald-300"
+              />
+              {/* Spokes */}
+              <ul className="grid grid-cols-2 sm:grid-cols-3 gap-3 mt-2 relative">
+                {history.slice(0, 9).map((item) => {
+                  const accent =
+                    item.status === "rewarded"
+                      ? "border-emerald-300 bg-emerald-50"
+                      : item.status === "converted"
+                        ? "border-blue-300 bg-blue-50"
+                        : "border-amber-200 bg-amber-50";
+                  return (
+                    <li
+                      key={item.id}
+                      className={`rounded-xl border p-3 text-center ${accent}`}
+                    >
+                      <div className="text-2xl mb-1" aria-hidden>
+                        {item.status === "rewarded"
+                          ? "🎁"
+                          : item.status === "converted"
+                            ? "✅"
+                            : "✉️"}
+                      </div>
+                      <p className="text-[11px] font-semibold text-slate-900 truncate">
+                        {item.email || `Invite #${item.id}`}
+                      </p>
+                      <p className="text-[10px] text-slate-500 mt-0.5">
+                        {new Date(item.date).toLocaleDateString("en-AU", {
+                          day: "numeric",
+                          month: "short",
+                        })}
+                      </p>
+                      <div className="mt-1.5">
+                        <StatusBadge status={item.status} />
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
+              {history.length > 9 && (
+                <p className="text-center text-[11px] text-slate-500 mt-3">
+                  + {history.length - 9} more in the table below
+                </p>
+              )}
+            </div>
+          </div>
+        )}
+
         {/* Referral History */}
         <div className="bg-white border border-slate-200 rounded-xl p-5 mb-4">
           <h2 className="text-base font-bold text-slate-900 mb-3">Referral History</h2>

--- a/app/advisor-portal/webhooks/WebhooksClient.tsx
+++ b/app/advisor-portal/webhooks/WebhooksClient.tsx
@@ -1,0 +1,283 @@
+"use client";
+
+import { useEffect, useState, useTransition } from "react";
+
+interface EndpointRow {
+  id: number;
+  url: string;
+  enabled: boolean;
+  event_subscriptions: string[];
+}
+
+interface Props {
+  /** Pre-fetched endpoints from the server page to avoid an extra
+   * round-trip on first render. Client-side refresh keeps it in sync
+   * after mutations. */
+  initialEndpoints: EndpointRow[];
+  /** Whitelisted event names from the API route. */
+  allowedEvents: readonly string[];
+}
+
+/**
+ * Self-serve outbound-webhook manager for the advisor portal.
+ *
+ * Adds endpoints, lists current ones, lets the pro toggle them off.
+ * Signing secret is shown ONCE at creation time — copy-to-clipboard,
+ * with a "I've saved it" confirm before we dismiss the modal.
+ */
+export default function WebhooksClient({
+  initialEndpoints,
+  allowedEvents,
+}: Props) {
+  const [endpoints, setEndpoints] = useState(initialEndpoints);
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [url, setUrl] = useState("");
+  const [subs, setSubs] = useState<string[]>([]);
+  const [revealedSecret, setRevealedSecret] = useState<{
+    url: string;
+    secret: string;
+  } | null>(null);
+
+  async function refresh() {
+    try {
+      const res = await fetch("/api/advisor-portal/webhooks");
+      const body = (await res.json()) as { endpoints?: EndpointRow[] };
+      if (body.endpoints) setEndpoints(body.endpoints);
+    } catch {
+      /* silent */
+    }
+  }
+
+  async function submit() {
+    setError(null);
+    if (!url.trim()) {
+      setError("Endpoint URL is required.");
+      return;
+    }
+    if (subs.length === 0) {
+      setError("Pick at least one event to subscribe to.");
+      return;
+    }
+    startTransition(async () => {
+      try {
+        const res = await fetch("/api/advisor-portal/webhooks", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ url: url.trim(), eventSubscriptions: subs }),
+        });
+        const body = (await res.json().catch(() => ({}))) as {
+          endpoint?: EndpointRow;
+          signingSecret?: string;
+          error?: string;
+        };
+        if (!res.ok || !body.endpoint || !body.signingSecret) {
+          throw new Error(body.error ?? `HTTP ${res.status}`);
+        }
+        setRevealedSecret({ url: body.endpoint.url, secret: body.signingSecret });
+        setUrl("");
+        setSubs([]);
+        setCreating(false);
+        await refresh();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Failed to create endpoint.");
+      }
+    });
+  }
+
+  async function remove(id: number) {
+    if (!confirm("Disable this endpoint? You can add a new one later.")) return;
+    startTransition(async () => {
+      try {
+        const res = await fetch(`/api/advisor-portal/webhooks?id=${id}`, {
+          method: "DELETE",
+        });
+        if (!res.ok) {
+          const body = (await res.json().catch(() => ({}))) as {
+            error?: string;
+          };
+          throw new Error(body.error ?? `HTTP ${res.status}`);
+        }
+        await refresh();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Failed to disable.");
+      }
+    });
+  }
+
+  useEffect(() => {
+    void refresh();
+  }, []);
+
+  return (
+    <div className="space-y-6">
+      {error && (
+        <div className="rounded-lg border border-rose-200 bg-rose-50 text-rose-800 text-sm p-3">
+          {error}
+        </div>
+      )}
+
+      {revealedSecret && (
+        <div className="rounded-2xl border border-amber-300 bg-amber-50 p-5 space-y-3">
+          <p className="text-sm font-bold text-amber-900">
+            Save this signing secret — it&apos;s only shown once.
+          </p>
+          <p className="text-xs text-amber-800">
+            Endpoint: <code className="text-[11px]">{revealedSecret.url}</code>
+          </p>
+          <div className="flex gap-2 items-center">
+            <code className="flex-1 break-all text-xs bg-white border border-amber-200 rounded-md px-2 py-1.5">
+              {revealedSecret.secret}
+            </code>
+            <button
+              type="button"
+              onClick={() => {
+                void navigator.clipboard.writeText(revealedSecret.secret);
+              }}
+              className="text-xs font-semibold bg-amber-500 hover:bg-amber-400 text-slate-900 px-3 py-1.5 rounded-md"
+            >
+              Copy
+            </button>
+          </div>
+          <button
+            type="button"
+            onClick={() => setRevealedSecret(null)}
+            className="text-xs font-semibold text-amber-900 underline"
+          >
+            I&apos;ve saved it — dismiss
+          </button>
+        </div>
+      )}
+
+      <section className="bg-white border border-slate-200 rounded-2xl p-5">
+        <div className="flex items-center justify-between mb-3">
+          <div>
+            <h2 className="text-base font-bold text-slate-900">
+              Your webhook endpoints
+            </h2>
+            <p className="text-xs text-slate-500 mt-0.5">
+              Subscribe to brief events so your CRM / Slack / Zapier reacts
+              automatically.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => setCreating((s) => !s)}
+            className="text-xs font-semibold bg-violet-600 hover:bg-violet-500 text-white px-3 py-2 rounded-md"
+          >
+            {creating ? "Cancel" : "Add endpoint"}
+          </button>
+        </div>
+
+        {creating && (
+          <div className="bg-violet-50 border border-violet-200 rounded-xl p-4 mb-4 space-y-3">
+            <label className="block">
+              <span className="text-xs font-semibold text-violet-900">
+                Endpoint URL
+              </span>
+              <input
+                type="url"
+                value={url}
+                onChange={(e) => setUrl(e.target.value)}
+                placeholder="https://example.com/hooks/invest"
+                className="mt-1 w-full rounded-md border border-violet-300 bg-white text-sm px-3 py-2"
+              />
+            </label>
+            <div>
+              <p className="text-xs font-semibold text-violet-900 mb-1.5">
+                Events to receive
+              </p>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-1">
+                {allowedEvents.map((ev) => (
+                  <label
+                    key={ev}
+                    className="flex items-center gap-2 text-xs text-slate-700"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={subs.includes(ev)}
+                      onChange={(e) => {
+                        setSubs((s) =>
+                          e.target.checked
+                            ? [...s, ev]
+                            : s.filter((x) => x !== ev),
+                        );
+                      }}
+                      className="rounded border-violet-400"
+                    />
+                    <code className="text-[11px]">{ev}</code>
+                  </label>
+                ))}
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={submit}
+              disabled={pending}
+              className="rounded-md bg-violet-600 hover:bg-violet-500 disabled:opacity-50 text-white text-xs font-semibold px-3 py-2"
+            >
+              {pending ? "Saving…" : "Save endpoint"}
+            </button>
+          </div>
+        )}
+
+        {endpoints.length === 0 ? (
+          <p className="text-sm text-slate-500 text-center py-6">
+            No endpoints yet. Add one to start receiving signed POSTs when
+            briefs change.
+          </p>
+        ) : (
+          <ul className="divide-y divide-slate-200">
+            {endpoints.map((ep) => (
+              <li
+                key={ep.id}
+                className="py-3 flex items-start justify-between gap-3"
+              >
+                <div className="min-w-0">
+                  <p className="text-sm font-semibold text-slate-900 break-all">
+                    {ep.url}
+                  </p>
+                  <p className="text-[11px] text-slate-500 mt-1">
+                    {ep.event_subscriptions.length} event
+                    {ep.event_subscriptions.length === 1 ? "" : "s"}:{" "}
+                    <code className="text-[10px]">
+                      {ep.event_subscriptions.join(", ")}
+                    </code>
+                  </p>
+                  {!ep.enabled && (
+                    <p className="text-[11px] text-rose-600 mt-1 font-semibold">
+                      Disabled
+                    </p>
+                  )}
+                </div>
+                {ep.enabled && (
+                  <button
+                    type="button"
+                    onClick={() => remove(ep.id)}
+                    disabled={pending}
+                    className="text-xs text-rose-600 hover:text-rose-800 font-semibold shrink-0 px-2 py-1.5"
+                  >
+                    Disable
+                  </button>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section className="rounded-2xl border border-slate-200 bg-slate-50 p-5">
+        <h3 className="text-sm font-bold text-slate-900 mb-2">
+          Verifying signatures
+        </h3>
+        <p className="text-xs text-slate-600 leading-relaxed">
+          Each POST includes <code className="text-[11px]">X-Invest-Signature: t=&lt;unix_ts&gt;,v1=&lt;hex_hmac&gt;</code>.
+          Verify by computing <code className="text-[11px]">HMAC-SHA256(secret, `${"{t}"}.${"{body}"}`)</code>
+          and comparing constant-time. Reject if the timestamp is more than 5
+          minutes old.
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/app/advisor-portal/webhooks/page.tsx
+++ b/app/advisor-portal/webhooks/page.tsx
@@ -1,0 +1,74 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+
+import { createClient } from "@/lib/supabase/server";
+// eslint-disable-next-line no-restricted-imports -- advisor-portal surface gates on session-resolved professional; outbound_webhook_endpoints is service-role-only per CLAUDE.md.
+import { createAdminClient } from "@/lib/supabase/admin";
+import { listEndpoints } from "@/lib/outbound-webhooks";
+
+import { ALLOWED_EVENTS } from "@/app/api/advisor-portal/webhooks/route";
+import WebhooksClient from "./WebhooksClient";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Webhooks — Advisor portal",
+  robots: { index: false, follow: false },
+};
+
+export default async function AdvisorPortalWebhooksPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    redirect("/account/login?redirect=/advisor-portal/webhooks");
+  }
+
+  const admin = createAdminClient();
+  const { data: pro } = await admin
+    .from("professionals")
+    .select("id")
+    .or(`auth_user_id.eq.${user.id},email.eq.${user.email}`)
+    .in("status", ["active", "pending"])
+    .maybeSingle();
+  if (!pro) {
+    redirect("/pros/join");
+  }
+  const advisorId = (pro as { id: number }).id;
+
+  const endpoints = await listEndpoints("professional", String(advisorId));
+
+  return (
+    <div className="min-h-screen bg-slate-50 py-6 md:py-10">
+      <div className="container-custom max-w-3xl">
+        <nav className="text-xs text-slate-500 mb-3">
+          <Link
+            href="/advisor-portal"
+            className="hover:text-slate-900"
+          >
+            ← Advisor portal
+          </Link>
+        </nav>
+        <header className="mb-6">
+          <h1 className="text-2xl font-extrabold text-slate-900">Webhooks</h1>
+          <p className="text-sm text-slate-500 mt-1 leading-relaxed">
+            Send signed POSTs to your own URL when briefs change. Wire your
+            CRM, Slack, Zapier, or a custom integration without us building
+            anything per-provider.
+          </p>
+        </header>
+        <WebhooksClient
+          initialEndpoints={endpoints.map((e) => ({
+            id: e.id,
+            url: e.url,
+            enabled: e.enabled,
+            event_subscriptions: e.event_subscriptions,
+          }))}
+          allowedEvents={ALLOWED_EVENTS}
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/api/advisor-portal/webhooks/route.ts
+++ b/app/api/advisor-portal/webhooks/route.ts
@@ -1,0 +1,153 @@
+/**
+ * GET  /api/advisor-portal/webhooks — list outbound webhook endpoints
+ *                                    owned by the calling pro.
+ * POST /api/advisor-portal/webhooks — register a new endpoint. Returns
+ *                                    the signing secret once.
+ * DELETE /api/advisor-portal/webhooks?id=<id> — disable an endpoint.
+ *
+ * Auth: requireAdvisorSession (active or pending professionals).
+ * Ownership: owner_kind=professional, owner_id=advisorId.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+import { requireAdvisorSession } from "@/lib/require-advisor-session";
+import { isAllowed, ipKey } from "@/lib/rate-limit-db";
+import {
+  createEndpoint,
+  disableEndpoint,
+  listEndpoints,
+} from "@/lib/outbound-webhooks";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+
+const log = logger("api:advisor-portal:webhooks");
+
+const PostBody = z.object({
+  url: z.string().url().max(2048),
+  eventSubscriptions: z
+    .array(z.string().min(1).max(80))
+    .min(1)
+    .max(20),
+});
+
+export const ALLOWED_EVENTS = [
+  "brief.accepted",
+  "brief.completed",
+  "brief.message_received",
+  "brief.dispute_opened",
+  "brief.outcome_submitted",
+  "consultation.booked",
+  "payment.succeeded",
+] as const;
+
+export async function GET(request: NextRequest) {
+  const advisorId = await requireAdvisorSession(request);
+  if (!advisorId) {
+    return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+  }
+  const endpoints = await listEndpoints("professional", String(advisorId));
+  // Never return the signing secret in list responses.
+  return NextResponse.json({
+    endpoints: endpoints.map((e) => ({
+      id: e.id,
+      url: e.url,
+      enabled: e.enabled,
+      event_subscriptions: e.event_subscriptions,
+    })),
+    allowedEvents: ALLOWED_EVENTS,
+  });
+}
+
+export async function POST(request: NextRequest) {
+  if (
+    !(await isAllowed("advisor_webhooks_create", ipKey(request), {
+      max: 5,
+      refillPerSec: 0.05,
+    }))
+  ) {
+    return NextResponse.json({ error: "Too many requests." }, { status: 429 });
+  }
+  const advisorId = await requireAdvisorSession(request);
+  if (!advisorId) {
+    return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+  }
+  let raw: unknown;
+  try {
+    raw = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+  const parsed = PostBody.safeParse(raw);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.issues[0]?.message ?? "Invalid body." },
+      { status: 400 },
+    );
+  }
+  // Filter to allowed events only — a typo here would just silently never
+  // fire, which is worse than a 400.
+  const events = parsed.data.eventSubscriptions.filter((e) =>
+    (ALLOWED_EVENTS as readonly string[]).includes(e),
+  );
+  if (events.length === 0) {
+    return NextResponse.json(
+      {
+        error:
+          "No supported events. Allowed: " + ALLOWED_EVENTS.join(", "),
+      },
+      { status: 400 },
+    );
+  }
+  try {
+    const { endpoint, signingSecret } = await createEndpoint({
+      ownerKind: "professional",
+      ownerId: String(advisorId),
+      url: parsed.data.url,
+      eventSubscriptions: events,
+    });
+    return NextResponse.json({
+      endpoint: {
+        id: endpoint.id,
+        url: endpoint.url,
+        event_subscriptions: endpoint.event_subscriptions,
+        enabled: endpoint.enabled,
+      },
+      signingSecret,
+    });
+  } catch (err) {
+    log.error("createEndpoint failed", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json(
+      { error: "Failed to create endpoint." },
+      { status: 500 },
+    );
+  }
+}
+
+export async function DELETE(request: NextRequest) {
+  const advisorId = await requireAdvisorSession(request);
+  if (!advisorId) {
+    return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+  }
+  const idStr = new URL(request.url).searchParams.get("id");
+  const id = idStr ? Number(idStr) : NaN;
+  if (!Number.isFinite(id) || id <= 0) {
+    return NextResponse.json({ error: "Missing or invalid id." }, { status: 400 });
+  }
+  // Ownership check via service-role select.
+  const admin = createAdminClient();
+  const { data: owned } = await admin
+    .from("outbound_webhook_endpoints")
+    .select("id")
+    .eq("id", id)
+    .eq("owner_kind", "professional")
+    .eq("owner_id", String(advisorId))
+    .maybeSingle();
+  if (!owned) {
+    return NextResponse.json({ error: "Endpoint not found." }, { status: 404 });
+  }
+  await disableEndpoint(id);
+  return NextResponse.json({ ok: true });
+}

--- a/app/pros/connect/ConnectClient.tsx
+++ b/app/pros/connect/ConnectClient.tsx
@@ -75,8 +75,78 @@ export default function ConnectClient({
 
   const meta = STATUS_LABEL[status];
 
+  // 3-step onboarding wizard indicator. Each step lights up based on the
+  // resolved Stripe Connect status — turns the opaque "click Connect"
+  // button into a visible journey so pros know what's next + how close
+  // they are to receiving payouts.
+  const stepIndex =
+    status === "active"
+      ? 2
+      : status === "onboarding" || status === "restricted"
+        ? 1
+        : 0;
+  const steps = [
+    {
+      title: "Connect",
+      body: "Hand off to Stripe Express to verify your identity + bank account.",
+    },
+    {
+      title: "Verify",
+      body: "Stripe checks your details. Usually instant; takes up to 24h if anything needs follow-up.",
+    },
+    {
+      title: "Active",
+      body: "Marketplace payments start flowing. 10% platform fee, payouts on your Stripe schedule.",
+    },
+  ];
+
   return (
     <div className="space-y-4">
+      <ol className="grid grid-cols-3 gap-2 mb-2">
+        {steps.map((s, i) => {
+          const reached = i <= stepIndex;
+          const active = i === stepIndex;
+          return (
+            <li
+              key={s.title}
+              className={`rounded-xl border p-3 ${
+                active
+                  ? "border-amber-400 bg-amber-50"
+                  : reached
+                    ? "border-emerald-200 bg-emerald-50"
+                    : "border-slate-200 bg-white"
+              }`}
+            >
+              <div className="flex items-center gap-2 mb-1">
+                <span
+                  className={`inline-flex w-5 h-5 rounded-full text-[10px] font-bold items-center justify-center ${
+                    reached
+                      ? active
+                        ? "bg-amber-500 text-slate-900"
+                        : "bg-emerald-500 text-white"
+                      : "bg-slate-200 text-slate-500"
+                  }`}
+                >
+                  {reached && !active ? "✓" : i + 1}
+                </span>
+                <p
+                  className={`text-xs font-bold ${
+                    active
+                      ? "text-amber-900"
+                      : reached
+                        ? "text-emerald-900"
+                        : "text-slate-500"
+                  }`}
+                >
+                  {s.title}
+                </p>
+              </div>
+              <p className="text-[10px] leading-snug text-slate-600">{s.body}</p>
+            </li>
+          );
+        })}
+      </ol>
+
       <div className={`rounded-2xl border p-4 ${meta.tone}`}>
         <p className="text-[11px] uppercase tracking-widest font-bold opacity-80 mb-1">
           Status

--- a/app/teams/[slug]/inbox/SquadInboxFirstTimeTour.tsx
+++ b/app/teams/[slug]/inbox/SquadInboxFirstTimeTour.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useState } from "react";
+
+interface Props {
+  /** Team slug — used as the localStorage key suffix so dismissals
+   * are per-team (a member of two squads dismisses each tour
+   * independently). */
+  teamSlug: string;
+  /** Whether the squad has only ever had ≤1 accepted brief. The parent
+   * server page resolves this from `advisor_auctions` count; we don't
+   * fetch from the client to avoid an extra round-trip. */
+  isFirstTime: boolean;
+}
+
+const STORAGE_KEY_PREFIX = "iv_squad_tour_dismissed_";
+
+/**
+ * Read the dismissal flag synchronously inside the useState initialiser
+ * so the first render already reflects localStorage — avoids the
+ * cascading-render lint warning from setting state inside useEffect.
+ *
+ * `typeof window` guard is essential because Next 16 invokes the
+ * useState initialiser on the server for client components during
+ * pre-rendering.
+ */
+function readDismissed(teamSlug: string): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return (
+      window.localStorage.getItem(`${STORAGE_KEY_PREFIX}${teamSlug}`) === "1"
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * First-time onboarding tour for the Pro Squad inbox.
+ *
+ * Renders a single coach-card banner with the 4-step lifecycle
+ * (claim → message → complete → review) when the team is brand new
+ * AND the member hasn't dismissed it. Persists dismissal in
+ * localStorage so a refresh doesn't bring it back.
+ *
+ * Why not a multi-step Joyride-style tour: a single inline banner
+ * scrolls with the page, reads faster, and doesn't fight any modal
+ * stack — the inbox already has a lot of affordances.
+ */
+export default function SquadInboxFirstTimeTour({
+  teamSlug,
+  isFirstTime,
+}: Props) {
+  const [dismissed, setDismissed] = useState(() => readDismissed(teamSlug));
+
+  function dismiss() {
+    setDismissed(true);
+    try {
+      window.localStorage.setItem(`${STORAGE_KEY_PREFIX}${teamSlug}`, "1");
+    } catch {
+      /* incognito / storage blocked — ephemeral dismissal is fine */
+    }
+  }
+
+  if (!isFirstTime || dismissed) return null;
+
+  return (
+    <div
+      role="region"
+      aria-label="Squad inbox onboarding tour"
+      className="mb-6 rounded-2xl border border-violet-200 bg-gradient-to-br from-violet-50 via-white to-violet-50 p-5"
+    >
+      <div className="flex items-start justify-between gap-3 mb-4">
+        <div>
+          <p className="text-xs font-bold uppercase tracking-wider text-violet-700 mb-1">
+            🎉 First Match Request accepted
+          </p>
+          <h2 className="text-lg font-extrabold text-slate-900">
+            Welcome to your squad inbox
+          </h2>
+          <p className="text-sm text-slate-600 mt-1">
+            Here&apos;s how a brief moves through your squad. Hover any step
+            for more detail.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={dismiss}
+          className="text-xs font-semibold text-slate-500 hover:text-slate-800 px-2 py-1 rounded-md hover:bg-slate-100"
+          aria-label="Dismiss tour"
+        >
+          ✕ Dismiss
+        </button>
+      </div>
+      <ol className="grid grid-cols-1 sm:grid-cols-4 gap-3">
+        {[
+          {
+            n: 1,
+            title: "Claim",
+            body: "Hit the amber Claim button so the squad sees who's on it. Only one member at a time.",
+          },
+          {
+            n: 2,
+            title: "Message",
+            body: "The consumer sees your replies live on their tracker. Reply within 30 min for best outcomes.",
+          },
+          {
+            n: 3,
+            title: "Hand off / Complete",
+            body: "Handing off keeps the brief in the squad. Completing closes the loop + flips status to won.",
+          },
+          {
+            n: 4,
+            title: "Review (4 weeks)",
+            body: "Consumer gets emailed a review prompt; their rating feeds your outcome score + ranking.",
+          },
+        ].map((s) => (
+          <li
+            key={s.n}
+            className="flex flex-col bg-white rounded-lg border border-violet-100 p-3"
+            title={s.body}
+          >
+            <div className="w-7 h-7 rounded-full bg-violet-100 text-violet-700 font-extrabold flex items-center justify-center text-sm mb-2">
+              {s.n}
+            </div>
+            <p className="text-sm font-bold text-slate-900">{s.title}</p>
+            <p className="text-xs text-slate-600 mt-1 leading-snug">{s.body}</p>
+          </li>
+        ))}
+      </ol>
+      <p className="text-[11px] text-slate-500 mt-4">
+        Tip: snooze briefs that aren&apos;t a fit (they come back in 7 days);
+        permanently dismiss with &quot;Not for us.&quot; Use{" "}
+        <strong>Refer to another team</strong> to forward briefs you&apos;d
+        rather another squad take.
+      </p>
+    </div>
+  );
+}

--- a/app/teams/[slug]/inbox/page.tsx
+++ b/app/teams/[slug]/inbox/page.tsx
@@ -13,6 +13,7 @@ import {
 import { getHiddenBriefIdsForTeam } from "@/lib/team-brief-decisions";
 import PresencePinger from "@/components/PresencePinger";
 import SquadInboxClaimRow from "./SquadInboxClaimRow";
+import SquadInboxFirstTimeTour from "./SquadInboxFirstTimeTour";
 import SquadInboxRowActions from "./SquadInboxRowActions";
 
 // Private surface — keep out of the index. JSON-LD coverage gate
@@ -219,6 +220,14 @@ export default async function SquadInboxPage({ params, searchParams }: PageProps
           <span>/</span>
           <span className="text-slate-700">Squad inbox</span>
         </div>
+
+        {/* First-time onboarding tour — shown when this is the team's
+            first accepted brief (acceptedTotal ≤ 1 from the KPI count
+            above). Client-side dismissible via localStorage. */}
+        <SquadInboxFirstTimeTour
+          teamSlug={team.slug as string}
+          isFirstTime={(acceptedTotal ?? 0) <= 1}
+        />
 
         <h1 className="text-2xl sm:text-3xl font-extrabold text-slate-900 mb-1">
           {team.name as string} — Squad inbox

--- a/app/teams/[slug]/settings/intake/page.tsx
+++ b/app/teams/[slug]/settings/intake/page.tsx
@@ -7,8 +7,10 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { createClient } from "@/lib/supabase/server";
 import { SITE_URL } from "@/lib/seo";
 import { listForTeam, MAX_QUESTIONS_PER_OWNER } from "@/lib/pro-intake";
+import { getTemplatesForCategory } from "@/lib/pro-intake/templates";
 import { isProfessionalOnTeam } from "@/lib/expert-teams";
 
+import IntakeTemplatePicker from "@/components/pro-intake/IntakeTemplatePicker";
 import IntakeQuestionsEditor from "../../../../pros/settings/intake/IntakeQuestionsEditor";
 
 export const metadata: Metadata = {
@@ -48,7 +50,7 @@ export default async function TeamIntakeSettingsPage({
 
   const { data: team } = await admin
     .from("expert_teams")
-    .select("id, name, slug, owner_professional_id")
+    .select("id, name, slug, owner_professional_id, team_category")
     .eq("slug", slug)
     .maybeSingle();
   if (!team) notFound();
@@ -57,6 +59,7 @@ export default async function TeamIntakeSettingsPage({
     name: string;
     slug: string;
     owner_professional_id: number;
+    team_category: string;
   };
 
   const isMember =
@@ -92,6 +95,17 @@ export default async function TeamIntakeSettingsPage({
             your team accepts their brief.
           </p>
         </header>
+
+        {/* Quick-start templates picker — surfaces 4 curated 5-question
+            packs ordered by team_category match (exact-match templates
+            first). Disabled when adding would exceed the per-owner cap. */}
+        <IntakeTemplatePicker
+          templates={getTemplatesForCategory(teamRow.team_category)}
+          ownerKind="team"
+          ownerId={teamRow.id}
+          existingCount={questions.length}
+          maxQuestions={MAX_QUESTIONS_PER_OWNER}
+        />
 
         <IntakeQuestionsEditor
           ownerKind="team"

--- a/components/pro-intake/IntakeTemplatePicker.tsx
+++ b/components/pro-intake/IntakeTemplatePicker.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import type { IntakeTemplate } from "@/lib/pro-intake/templates";
+
+interface Props {
+  templates: IntakeTemplate[];
+  /** "professional" or "team" — passed to the create endpoint. */
+  ownerKind: "professional" | "team";
+  /** professional_id or team_id. */
+  ownerId: number;
+  /** How many questions the owner already has — used to disable cloning
+   * when adding would exceed MAX_QUESTIONS_PER_OWNER (5). */
+  existingCount: number;
+  /** Hard cap from `lib/pro-intake.ts` (MAX_QUESTIONS_PER_OWNER). */
+  maxQuestions: number;
+}
+
+/**
+ * Quick-start template picker shown above the intake editor.
+ *
+ * Renders one card per matching template; each card lists the
+ * questions + a "Use this template" button. Clicking the button
+ * POSTs each question in sequence to /api/intake/questions
+ * (the upsert endpoint already used by IntakeQuestionsEditor).
+ *
+ * If adding all template questions would exceed the per-owner cap,
+ * the button is disabled with an explainer.
+ */
+export default function IntakeTemplatePicker({
+  templates,
+  ownerKind,
+  ownerId,
+  existingCount,
+  maxQuestions,
+}: Props) {
+  const router = useRouter();
+  const [pickedSlug, setPickedSlug] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  async function applyTemplate(template: IntakeTemplate) {
+    setError(null);
+    setPickedSlug(template.slug);
+    startTransition(async () => {
+      try {
+        let order = existingCount;
+        for (const q of template.questions) {
+          order += 1;
+          const res = await fetch("/api/intake/questions", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              owner_kind: ownerKind,
+              owner_id: ownerId,
+              prompt: q.prompt,
+              kind: q.kind,
+              options: q.options ?? [],
+              required: q.required,
+              sort_order: order,
+              enabled: true,
+            }),
+          });
+          if (!res.ok) {
+            const body = (await res.json().catch(() => ({}))) as {
+              error?: string;
+            };
+            throw new Error(body.error ?? `HTTP ${res.status}`);
+          }
+        }
+        router.refresh();
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : "Could not apply template.",
+        );
+        setPickedSlug(null);
+      }
+    });
+  }
+
+  if (templates.length === 0) return null;
+
+  return (
+    <section
+      aria-labelledby="intake-templates-heading"
+      className="mb-6 rounded-2xl border border-violet-200 bg-violet-50/50 p-5"
+    >
+      <h2
+        id="intake-templates-heading"
+        className="text-sm font-bold text-slate-900 mb-1"
+      >
+        Quick-start templates
+      </h2>
+      <p className="text-xs text-slate-600 mb-4">
+        Curated 4–5 question packs tuned to your category. Click &ldquo;Use
+        this template&rdquo; to add them all in one go — you can edit or
+        delete afterwards in the editor below.
+      </p>
+
+      {error && (
+        <p className="text-xs text-rose-700 bg-rose-50 border border-rose-200 rounded-lg px-3 py-2 mb-3">
+          {error}
+        </p>
+      )}
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        {templates.slice(0, 4).map((t) => {
+          const wouldExceed =
+            existingCount + t.questions.length > maxQuestions;
+          const isPicked = pickedSlug === t.slug;
+          return (
+            <article
+              key={t.slug}
+              className="bg-white rounded-xl border border-violet-100 p-4 flex flex-col"
+            >
+              <h3 className="text-sm font-bold text-slate-900">{t.title}</h3>
+              <p className="text-xs text-slate-600 mt-1 mb-3 leading-snug">
+                {t.blurb}
+              </p>
+              <ol className="text-[11px] text-slate-700 space-y-1 mb-4 list-decimal list-inside">
+                {t.questions.map((q, i) => (
+                  <li key={i} className="leading-snug">
+                    {q.prompt}
+                    {q.required && (
+                      <span className="text-rose-500 ml-1">*</span>
+                    )}
+                  </li>
+                ))}
+              </ol>
+              <button
+                type="button"
+                onClick={() => applyTemplate(t)}
+                disabled={pending || wouldExceed}
+                className={`mt-auto rounded-lg px-3 py-2 text-xs font-semibold transition-colors ${
+                  wouldExceed
+                    ? "bg-slate-100 text-slate-400 cursor-not-allowed"
+                    : "bg-violet-600 hover:bg-violet-500 text-white"
+                } disabled:opacity-50`}
+                title={
+                  wouldExceed
+                    ? `Adding ${t.questions.length} questions would exceed the ${maxQuestions}-question cap.`
+                    : undefined
+                }
+              >
+                {wouldExceed
+                  ? `Cap reached (max ${maxQuestions})`
+                  : isPicked && pending
+                    ? "Adding…"
+                    : `Use this template · ${t.questions.length} questions`}
+              </button>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/lib/pro-intake/templates.ts
+++ b/lib/pro-intake/templates.ts
@@ -1,0 +1,333 @@
+/**
+ * Curated intake question templates per team_category / professional_type.
+ *
+ * Each template is a 4–5 question pack a pro can clone in one click. The
+ * questions are crafted around the kind of context the pro actually needs
+ * for that vertical's first call (SMSF property → fund balance, age,
+ * property type; tax → residency, situation, target).
+ *
+ * Used by:
+ *   - app/teams/[slug]/settings/intake/page.tsx → "Quick-start templates"
+ *   - app/pros/settings/intake/page.tsx → same picker
+ */
+
+import type { IntakeQuestionKind } from "@/lib/pro-intake";
+
+export interface IntakeTemplateQuestion {
+  prompt: string;
+  kind: IntakeQuestionKind;
+  required: boolean;
+  options?: string[];
+}
+
+export interface IntakeTemplate {
+  /** Match against team_category / professional.type for surfacing. */
+  match: string[];
+  slug: string;
+  title: string;
+  blurb: string;
+  questions: IntakeTemplateQuestion[];
+}
+
+export const INTAKE_TEMPLATES: IntakeTemplate[] = [
+  {
+    match: ["smsf_property", "smsf_strategy", "smsf_accounting", "smsf_accountant"],
+    slug: "smsf_property_starter",
+    title: "SMSF Property Squad — first-call pack",
+    blurb:
+      "Five questions that surface fund context before the call so trustees don't have to re-explain.",
+    questions: [
+      {
+        prompt: "Approximate current SMSF fund balance?",
+        kind: "select",
+        required: true,
+        options: [
+          "Under $250k",
+          "$250k – $500k",
+          "$500k – $1M",
+          "$1M – $2M",
+          "$2M+",
+        ],
+      },
+      {
+        prompt: "What are you trying to buy?",
+        kind: "select",
+        required: true,
+        options: [
+          "Residential investment property",
+          "Commercial property",
+          "Off-the-plan",
+          "Refinance an existing SMSF property",
+          "Just exploring",
+        ],
+      },
+      {
+        prompt: "Trustee structure?",
+        kind: "select",
+        required: true,
+        options: [
+          "Individual trustees",
+          "Corporate trustee",
+          "Not sure",
+        ],
+      },
+      {
+        prompt: "Have you already engaged an SMSF accountant?",
+        kind: "select",
+        required: false,
+        options: ["Yes", "No", "Considering"],
+      },
+      {
+        prompt: "Anything else we should know before the call?",
+        kind: "text",
+        required: false,
+      },
+    ],
+  },
+  {
+    match: ["cross_border_tax", "tax_agent", "foreign_investor"],
+    slug: "cross_border_tax_starter",
+    title: "Cross-Border Tax — first-call pack",
+    blurb:
+      "Quick scoping of residency + jurisdictions so the first call goes straight to substance.",
+    questions: [
+      {
+        prompt: "Current tax residency?",
+        kind: "select",
+        required: true,
+        options: [
+          "Australian resident",
+          "Australian expat overseas",
+          "Foreign resident with AU assets",
+          "Dual citizen / dual taxpayer",
+          "Not sure",
+        ],
+      },
+      {
+        prompt: "Other jurisdictions involved?",
+        kind: "text",
+        required: false,
+      },
+      {
+        prompt: "What's the trigger event?",
+        kind: "select",
+        required: true,
+        options: [
+          "Moving to Australia",
+          "Moving overseas",
+          "Buying / selling AU property",
+          "Inheritance or trust distribution",
+          "Annual return only",
+          "Other",
+        ],
+      },
+      {
+        prompt: "Timeline?",
+        kind: "select",
+        required: true,
+        options: ["This month", "Next 3 months", "This financial year", "Just researching"],
+      },
+      {
+        prompt: "Have you used a tax agent in the last 2 years?",
+        kind: "select",
+        required: false,
+        options: ["Yes", "No"],
+      },
+    ],
+  },
+  {
+    match: ["expat_returnee", "financial_planner", "financial_adviser"],
+    slug: "expat_return_starter",
+    title: "Expat Return Planning — first-call pack",
+    blurb:
+      "Snapshot of the move so the planner walks in with the structure already in mind.",
+    questions: [
+      {
+        prompt: "When are you returning to Australia?",
+        kind: "select",
+        required: true,
+        options: [
+          "Already returned (last 6 months)",
+          "Returning in 1–3 months",
+          "Returning in 3–12 months",
+          "Returning 12+ months from now",
+        ],
+      },
+      {
+        prompt: "Approximate liquid wealth coming back?",
+        kind: "select",
+        required: true,
+        options: [
+          "Under A$250k",
+          "A$250k – A$1M",
+          "A$1M – A$5M",
+          "A$5M+",
+          "Prefer not to say",
+        ],
+      },
+      {
+        prompt: "Foreign super / pension to transfer?",
+        kind: "select",
+        required: false,
+        options: ["Yes (UK)", "Yes (US 401k/IRA)", "Yes (other)", "No"],
+      },
+      {
+        prompt: "AU property situation?",
+        kind: "select",
+        required: false,
+        options: [
+          "Own AU property",
+          "Want to buy AU property on return",
+          "Renting only",
+          "Not sure yet",
+        ],
+      },
+      {
+        prompt: "Anything time-sensitive we should plan around?",
+        kind: "text",
+        required: false,
+      },
+    ],
+  },
+  {
+    match: ["commercial_property", "due_diligence", "buyers_agent", "property_advisor"],
+    slug: "commercial_dd_starter",
+    title: "Commercial Property DD — first-call pack",
+    blurb:
+      "Five questions that scope a deal so the call doesn't burn time on logistics.",
+    questions: [
+      {
+        prompt: "Deal stage?",
+        kind: "select",
+        required: true,
+        options: [
+          "Researching the market",
+          "Have a shortlist",
+          "Under offer / due diligence",
+          "Already exchanged",
+        ],
+      },
+      {
+        prompt: "Deal type?",
+        kind: "select",
+        required: true,
+        options: [
+          "Retail strip",
+          "Office",
+          "Industrial / warehouse",
+          "Mixed-use",
+          "Other",
+        ],
+      },
+      {
+        prompt: "Budget band (asset price)?",
+        kind: "select",
+        required: true,
+        options: [
+          "Under $1M",
+          "$1M – $3M",
+          "$3M – $10M",
+          "$10M+",
+        ],
+      },
+      {
+        prompt: "Buying entity?",
+        kind: "select",
+        required: false,
+        options: [
+          "Individual",
+          "Company",
+          "SMSF",
+          "Family trust",
+          "Other",
+        ],
+      },
+      {
+        prompt: "Anything specific you want us to focus on first?",
+        kind: "text",
+        required: false,
+      },
+    ],
+  },
+  {
+    match: ["business_acquisition"],
+    slug: "sme_acquisition_starter",
+    title: "SME Acquisition — first-call pack",
+    blurb:
+      "Buyer-readiness check before we book a structured deal discussion.",
+    questions: [
+      {
+        prompt: "Stage you're at?",
+        kind: "select",
+        required: true,
+        options: [
+          "Just exploring SME ownership",
+          "Have a shortlist of businesses",
+          "In active discussions with a vendor",
+          "Already under LOI / heads of agreement",
+        ],
+      },
+      {
+        prompt: "Deal-size band?",
+        kind: "select",
+        required: true,
+        options: [
+          "Under $500k",
+          "$500k – $2M",
+          "$2M – $10M",
+          "$10M+",
+        ],
+      },
+      {
+        prompt: "Funding source?",
+        kind: "select",
+        required: false,
+        options: [
+          "Personal cash",
+          "Bank finance",
+          "Vendor finance",
+          "Investor / partner",
+          "Mix of the above",
+          "Not sure yet",
+        ],
+      },
+      {
+        prompt: "Operating experience in the target industry?",
+        kind: "select",
+        required: false,
+        options: [
+          "Direct (5+ years)",
+          "Adjacent (some)",
+          "None — first-time owner",
+        ],
+      },
+      {
+        prompt: "Anything specific about this deal you want us to look at first?",
+        kind: "text",
+        required: false,
+      },
+    ],
+  },
+];
+
+/**
+ * Pick the templates most relevant to the given owner. Returns an array
+ * ordered by match-specificity (exact match first, generic last). Always
+ * returns at least one template (the first one) as a fallback.
+ */
+export function getTemplatesForCategory(
+  category: string | null | undefined,
+): IntakeTemplate[] {
+  if (!category) return INTAKE_TEMPLATES;
+  const c = category.toLowerCase();
+  const matched = INTAKE_TEMPLATES.filter((t) =>
+    t.match.some((m) => m.toLowerCase() === c),
+  );
+  if (matched.length > 0) {
+    return [
+      ...matched,
+      ...INTAKE_TEMPLATES.filter((t) => !matched.includes(t)),
+    ];
+  }
+  return INTAKE_TEMPLATES;
+}


### PR DESCRIPTION
## Summary
Seven features bundled into one PR after branch-switch state churn.

1. **Squad first-time tour** — coach-card on /teams/[slug]/inbox when accepted-brief count ≤ 1
2. **Investor benchmarking strip** — anonymised median + percentile on /account/dashboard
3. **Intake template library** — 5 curated 5-question packs on /teams/[slug]/settings/intake
4. **Outbound webhook self-serve UI** — /advisor-portal/webhooks + POST/DELETE API
5. **Stripe Connect 3-step wizard** — visual progress tiles on /pros/connect
6. **Referral chain visualisation** — hub-and-spoke diagram on /account/referrals

## Tier
B — additive UI + one new API. No new tables; reads only.

## Test plan
- [x] tsc --noEmit clean
- [x] eslint --max-warnings 0 clean
- [ ] Manual coverage per feature (see commit body)