### PR TITLE
feat(mk): MK-01 calendar embed + MK-02 video intro [audit remediation]

### DIFF
--- a/app/advisor/[slug]/AdvisorProfileClient.tsx
+++ b/app/advisor/[slug]/AdvisorProfileClient.tsx
@@ -8,6 +8,8 @@ import { PROFESSIONAL_TYPE_LABELS } from "@/lib/types";
 import Icon from "@/components/Icon";
 import BookingWidget from "@/components/BookingWidget";
 import AdvisorAppointmentsWidget from "@/components/AdvisorAppointmentsWidget";
+import AdvisorCalendarEmbed from "@/components/AdvisorCalendarEmbed";
+import AdvisorVideoIntro from "@/components/AdvisorVideoIntro";
 import AdvisorReviewForm from "@/components/AdvisorReviewForm";
 import VerifiedClientBadge from "@/components/VerifiedClientBadge";
 import VerifiedBadge from "@/components/VerifiedBadge";
@@ -766,18 +768,14 @@ export default function AdvisorProfileClient({
               </SectionCard>
             )}
 
-            {/* Intro Video */}
+            {/* Intro Video — MK-02: lazy-load with poster overlay + Vimeo support */}
             {pro.intro_video_url && (
               <SectionCard title="Introduction Video" icon="video">
-                <div className="relative w-full aspect-video rounded-xl overflow-hidden bg-slate-100">
-                  <iframe
-                    src={(pro.intro_video_url!).replace("watch?v=", "embed/").replace("youtu.be/", "youtube.com/embed/")}
-                    className="absolute inset-0 w-full h-full"
-                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                    allowFullScreen
-                    loading="lazy"
-                  />
-                </div>
+                <AdvisorVideoIntro
+                  videoUrl={pro.intro_video_url!}
+                  posterUrl={pro.intro_video_poster_url}
+                  advisorName={pro.name}
+                />
               </SectionCard>
             )}
 
@@ -845,6 +843,20 @@ export default function AdvisorProfileClient({
                 </div>
               </SectionCard>
             ) : null}
+
+            {/* MK-01: Calendly/Cal.com inline embed — shows when booking_link is
+                a supported calendar platform. Eliminates the new-tab context
+                switch that hurts conversion on mobile. Falls back to link for
+                other booking URLs. */}
+            {pro.booking_link && (
+              <SectionCard title="Book a Time" icon="calendar">
+                <AdvisorCalendarEmbed
+                  bookingLink={pro.booking_link}
+                  advisorName={pro.name}
+                  consultationLabel={pro.initial_consultation_free ? "free consultation" : "consultation"}
+                />
+              </SectionCard>
+            )}
 
             {/* Wave 17 first-party concrete-slot booking.
                 Renders nothing if the advisor has no open slots in

--- a/components/AdvisorCalendarEmbed.tsx
+++ b/components/AdvisorCalendarEmbed.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useState } from "react";
+
+type Props = {
+  bookingLink: string;
+  advisorName: string;
+  /** Shown above CTA, e.g. "Free 15-min consultation" */
+  consultationLabel?: string;
+};
+
+function getEmbedUrl(url: string): string | null {
+  // Calendly: https://calendly.com/<username>/<event-type>
+  if (url.includes("calendly.com/")) {
+    const base = url.split("?")[0];
+    return `${base}?embed_type=Inline&embed_domain=invest.com.au&primary_color=1d4ed8&hide_gdpr_banner=1`;
+  }
+  // Cal.com: https://cal.com/<username>/<event-type>
+  if (url.includes("cal.com/")) {
+    const base = url.split("?")[0];
+    return `${base}?embed=true`;
+  }
+  return null;
+}
+
+export default function AdvisorCalendarEmbed({
+  bookingLink,
+  advisorName,
+  consultationLabel = "Free consultation",
+}: Props) {
+  const [open, setOpen] = useState(false);
+  const embedUrl = getEmbedUrl(bookingLink);
+
+  if (!embedUrl) {
+    // Not a supported embed platform — render a plain CTA link
+    return (
+      <a
+        href={bookingLink}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex items-center justify-center gap-2 w-full py-3 px-4 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-xl text-sm transition-colors"
+      >
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} className="w-4 h-4" aria-hidden>
+          <rect x="3" y="4" width="18" height="18" rx="2" />
+          <line x1="16" y1="2" x2="16" y2="6" />
+          <line x1="8" y1="2" x2="8" y2="6" />
+          <line x1="3" y1="10" x2="21" y2="10" />
+        </svg>
+        Book {consultationLabel}
+      </a>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {!open ? (
+        <button
+          onClick={() => setOpen(true)}
+          className="flex items-center justify-center gap-2 w-full py-3 px-4 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-xl text-sm transition-colors"
+        >
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} className="w-4 h-4" aria-hidden>
+            <rect x="3" y="4" width="18" height="18" rx="2" />
+            <line x1="16" y1="2" x2="16" y2="6" />
+            <line x1="8" y1="2" x2="8" y2="6" />
+            <line x1="3" y1="10" x2="21" y2="10" />
+          </svg>
+          Book {consultationLabel}
+        </button>
+      ) : (
+        <div className="rounded-xl overflow-hidden border border-slate-200 bg-white">
+          <div className="flex items-center justify-between px-4 py-2 border-b border-slate-100 bg-slate-50">
+            <span className="text-sm font-medium text-slate-700">
+              Book with {advisorName}
+            </span>
+            <button
+              onClick={() => setOpen(false)}
+              className="text-xs text-slate-400 hover:text-slate-700"
+              aria-label="Close calendar"
+            >
+              ✕
+            </button>
+          </div>
+          <iframe
+            src={embedUrl}
+            width="100%"
+            height="630"
+            frameBorder="0"
+            title={`Book a time with ${advisorName}`}
+            className="block"
+            loading="lazy"
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/AdvisorVideoIntro.tsx
+++ b/components/AdvisorVideoIntro.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+
+type Props = {
+  videoUrl: string;
+  posterUrl?: string | null;
+  advisorName: string;
+};
+
+function parseVideoEmbed(url: string): { embedUrl: string; thumbnailUrl: string | null } {
+  const ytMatch =
+    url.match(/youtube\.com\/watch\?v=([^&]+)/) ||
+    url.match(/youtu\.be\/([^?]+)/) ||
+    url.match(/youtube\.com\/embed\/([^?]+)/);
+  if (ytMatch) {
+    const id = ytMatch[1];
+    return {
+      embedUrl: `https://www.youtube.com/embed/${id}?autoplay=1&rel=0`,
+      thumbnailUrl: `https://img.youtube.com/vi/${id}/hqdefault.jpg`,
+    };
+  }
+
+  const vimeoMatch = url.match(/vimeo\.com\/(?:video\/)?(\d+)/);
+  if (vimeoMatch) {
+    return {
+      embedUrl: `https://player.vimeo.com/video/${vimeoMatch[1]}?autoplay=1`,
+      thumbnailUrl: null,
+    };
+  }
+
+  return { embedUrl: url, thumbnailUrl: null };
+}
+
+export default function AdvisorVideoIntro({ videoUrl, posterUrl, advisorName }: Props) {
+  const [playing, setPlaying] = useState(false);
+  const { embedUrl, thumbnailUrl } = parseVideoEmbed(videoUrl);
+  const poster = posterUrl || thumbnailUrl;
+
+  return (
+    <div className="relative w-full aspect-video rounded-xl overflow-hidden bg-slate-900">
+      {playing ? (
+        <iframe
+          src={embedUrl}
+          className="absolute inset-0 w-full h-full"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowFullScreen
+          title={`${advisorName} introduction video`}
+        />
+      ) : (
+        <button
+          onClick={() => setPlaying(true)}
+          className="absolute inset-0 w-full h-full flex items-center justify-center group"
+          aria-label={`Play ${advisorName}'s introduction video`}
+        >
+          {poster ? (
+            <Image
+              src={poster}
+              alt={`${advisorName} video thumbnail`}
+              fill
+              className="object-cover group-hover:brightness-75 transition-all duration-200"
+              unoptimized
+            />
+          ) : (
+            <div className="absolute inset-0 bg-slate-800" />
+          )}
+          {/* Play button */}
+          <span className="relative z-10 flex items-center justify-center w-16 h-16 rounded-full bg-white/90 group-hover:bg-white shadow-lg transition-all duration-200 group-hover:scale-105">
+            <svg
+              viewBox="0 0 24 24"
+              fill="currentColor"
+              className="w-7 h-7 text-blue-600 ml-1"
+              aria-hidden
+            >
+              <path d="M8 5v14l11-7z" />
+            </svg>
+          </span>
+          <span className="absolute bottom-3 left-4 text-xs text-white/80 font-medium drop-shadow">
+            Watch introduction
+          </span>
+        </button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## MK Stream — Marketplace Conversion Features

Two parallel marketplace conversion improvements (slot 75 in priority order). Both use existing DB fields — no schema migration required.

### MK-01 — Advisor Calendar Embedding

**File:** `components/AdvisorCalendarEmbed.tsx` (new)

When an advisor's `booking_link` is a Calendly (`calendly.com/`) or Cal.com (`cal.com/`) URL, renders an inline iframe embed instead of a plain external link. The user clicks "Book [consultation type]" and the calendar expands in-page — eliminating the new-tab context switch that hurts mobile conversion. For other booking URLs the component falls back to a styled link button.

- Lazy: iframe only mounts on user click (no blocking iframe on page load)
- Dismiss: "✕" button collapses the embed back to the CTA
- `consultationLabel` auto-set to "free consultation" when `initial_consultation_free` is true
- Wired into `AdvisorProfileClient` as a "Book a Time" `SectionCard` (renders when `booking_link` is set)

### MK-02 — Advisor Video Intros

**File:** `components/AdvisorVideoIntro.tsx` (new)

Replaces the bare always-on iframe in the advisor profile with a poster-overlay player. The iframe only loads on click — faster initial page load and no autoplay jank.

- **Poster image**: Uses `intro_video_poster_url` if set; otherwise auto-fetches the YouTube `hqdefault.jpg` thumbnail. Vimeo has no free public thumbnail API so shows a dark placeholder.
- **Play button**: Centred with hover scale + white background.
- **Platform support**: YouTube (`watch?v=`, `youtu.be/`, existing `embed/`) + Vimeo (`vimeo.com/{id}`) — both get `autoplay=1` on click.
- Accessible `aria-label` + `title` on the iframe.

## What changed

| File | Change |
|------|--------|
| `components/AdvisorCalendarEmbed.tsx` | New — Calendly/Cal.com inline embed with fallback link |
| `components/AdvisorVideoIntro.tsx` | New — lazy-load video player with poster overlay |
| `app/advisor/[slug]/AdvisorProfileClient.tsx` | Import + wire both components into advisor profile |

## Supersedes

_None._

Refs: slot 75 in `docs/audits/REMEDIATION_DEFAULTS.md` · MK-01, MK-02
Queue: `docs/audits/REMEDIATION_QUEUE.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_01FDQ6zRaf6srFaWBoAb54FL)_