### PR TITLE
feat(sm): SM-01 grouped service-line filter + SM-02 cultural routing [audit remediation]

### DIFF
--- a/app/advisors/AdvisorsClient.tsx
+++ b/app/advisors/AdvisorsClient.tsx
@@ -14,6 +14,7 @@ import Icon from "@/components/Icon";
 import VerifiedBadge from "@/components/VerifiedBadge";
 import { trackEvent } from "@/lib/tracking";
 import { useAdvisorShortlist } from "@/lib/hooks/useAdvisorShortlist";
+import { ADVISOR_SPECIALTY_CATEGORIES } from "@/lib/advisor-specialties";
 
 export interface ExpertTeamCard {
   id: number;
@@ -844,13 +845,47 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
               </button>
             </div>
 
-            {/* Specialties */}
+            {/* Service-line filter — SM-01: grouped by ADVISOR_SPECIALTY_CATEGORIES */}
             <div>
-              <label className="text-xs font-bold text-slate-700 mb-2 block">Specialties {specialtyFilters.length > 0 && <span className="text-amber-600">({specialtyFilters.length} selected)</span>}</label>
-              <div className="flex flex-wrap gap-1.5 max-h-28 overflow-y-auto">
-                {allSpecialties.map(s => (
-                  <button key={s} onClick={() => toggleSpecialty(s)} className={`px-2.5 py-1 text-[0.65rem] font-medium rounded-full transition-all ${specialtyFilters.includes(s) ? "bg-amber-100 text-amber-700 border border-amber-300" : "bg-slate-50 text-slate-500 border border-slate-200 hover:bg-slate-100"}`}>{s}</button>
-                ))}
+              <label className="text-xs font-bold text-slate-700 mb-2 block">
+                Service Line
+                {specialtyFilters.length > 0 && (
+                  <span className="text-amber-600 ml-1">({specialtyFilters.length} selected)</span>
+                )}
+              </label>
+              <div className="space-y-2 max-h-52 overflow-y-auto pr-1">
+                {ADVISOR_SPECIALTY_CATEGORIES.map(({ category, specialties }) => {
+                  const visibleSpecialties = specialties.filter(s =>
+                    allSpecialties.includes(s) || specialtyFilters.includes(s)
+                  );
+                  if (visibleSpecialties.length === 0) return null;
+                  const isCultural = category === "Cultural & Faith-Based";
+                  return (
+                    <details key={category} open={isCultural || specialties.some(s => specialtyFilters.includes(s))}>
+                      <summary className="text-[0.6rem] font-semibold text-slate-500 uppercase tracking-wide cursor-pointer select-none hover:text-slate-700 list-none flex items-center gap-1 mb-1">
+                        {isCultural && <span className="text-[0.7rem]">🌏</span>}
+                        {category}
+                      </summary>
+                      <div className="flex flex-wrap gap-1 pl-1">
+                        {visibleSpecialties.map(s => (
+                          <button
+                            key={s}
+                            onClick={() => toggleSpecialty(s)}
+                            className={`px-2 py-0.5 text-[0.6rem] font-medium rounded-full transition-all ${
+                              specialtyFilters.includes(s)
+                                ? isCultural
+                                  ? "bg-teal-100 text-teal-700 border border-teal-300"
+                                  : "bg-amber-100 text-amber-700 border border-amber-300"
+                                : "bg-slate-50 text-slate-500 border border-slate-200 hover:bg-slate-100"
+                            }`}
+                          >
+                            {s}
+                          </button>
+                        ))}
+                      </div>
+                    </details>
+                  );
+                })}
               </div>
             </div>
 
@@ -1321,6 +1356,22 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
                           {pro.specialties.length > 4 && (
                             <span className="text-[0.6rem] text-slate-400 self-center">+{pro.specialties.length - 4} more</span>
                           )}
+                        </div>
+                      )}
+
+                      {/* SM-02: Language / cultural routing badges — shown when advisor speaks
+                          non-English languages, helping users identify cultural match quickly */}
+                      {(pro.languages ?? []).filter(l => l && l !== "English").length > 0 && (
+                        <div className="flex flex-wrap gap-1 mt-1.5">
+                          {(pro.languages!).filter(l => l !== "English").slice(0, 3).map(lang => (
+                            <span key={lang} className={`text-[0.6rem] font-medium px-2 py-0.5 rounded-full border ${
+                              languageFilter === lang
+                                ? "bg-indigo-100 text-indigo-700 border-indigo-300"
+                                : "bg-indigo-50 text-indigo-600 border-indigo-200"
+                            }`}>
+                              🌏 {lang}
+                            </span>
+                          ))}
                         </div>
                       )}
 

--- a/lib/advisor-specialties.ts
+++ b/lib/advisor-specialties.ts
@@ -136,6 +136,20 @@ export const ADVISOR_SPECIALTY_CATEGORIES: {
       "FIRB Property (Non-Resident)",
     ],
   },
+  {
+    // SM-02: Cultural + faith-based routing (added 2026-05-18). Advisors who
+    // self-declare these tags appear in "Cultural Match" quick-filter results.
+    // Halal and ethical investing are distinct from ESG (methodology differs).
+    category: "Cultural & Faith-Based",
+    specialties: [
+      "Halal Investing",
+      "Ethical / ESG Investing",
+      "Buddhist Financial Principles",
+      "Culturally Sensitive Advice",
+      "Bilingual Financial Advice",
+      "Socially Responsible Investing",
+    ],
+  },
 ];
 
 // ═══════════════════════════════════════════════


### PR DESCRIPTION
## SM Stream — Service-line + Cultural Matching

Two parallel SM-stream items (slot 76 in priority order). Both are pure frontend improvements using existing data fields — no schema migration required.

### SM-01 — Fine-grained Service-line Tags

**File:** `app/advisors/AdvisorsClient.tsx` (updated)

Replaces the flat alphabetical specialty chip list in the filter sidebar with `<details>`/`<summary>` accordion groups, driven by the canonical `ADVISOR_SPECIALTY_CATEGORIES` from `lib/advisor-specialties.ts`. 

- Categories with zero matching advisors are hidden (only shows what the data supports)
- Active specialty selections auto-expand their parent category group
- Cultural & Faith-Based category uses teal highlight to visually distinguish from standard amber specialty highlighting
- Scrollable container capped at `max-h-52` — cleaner on mobile

### SM-02 — Cultural & Religious Routing

**Two changes:**

1. **`lib/advisor-specialties.ts`** — Added "Cultural & Faith-Based" specialty category with 6 tags:
   - Halal Investing
   - Ethical / ESG Investing
   - Buddhist Financial Principles
   - Culturally Sensitive Advice
   - Bilingual Financial Advice
   - Socially Responsible Investing
   
   Advisors who self-declare these in their profile appear under the new grouped filter category.

2. **`app/advisors/AdvisorsClient.tsx`** — advisor cards now show non-English language badges (indigo 🌏 pill) below specialty tags. Highlights in darker indigo when matching the active `languageFilter`. Shows up to 3 non-English languages per card — immediate cultural-match signal without opening the full profile.

## What changed

| File | Change |
|------|--------|
| `lib/advisor-specialties.ts` | Added "Cultural & Faith-Based" category (6 tags) |
| `app/advisors/AdvisorsClient.tsx` | Import `ADVISOR_SPECIALTY_CATEGORIES`; grouped service-line filter; language badges on cards |

No schema changes — uses existing `Professional.specialties[]` and `Professional.languages[]` fields.

## Supersedes

_None._

Refs: slot 76 in `docs/audits/REMEDIATION_DEFAULTS.md` · SM-01, SM-02
Queue: `docs/audits/REMEDIATION_QUEUE.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_01FDQ6zRaf6srFaWBoAb54FL)_