### PR TITLE
chore(cm): multi-advisor matching [audit remediation]

### DIFF
--- a/app/find-advisor/life-event/page.tsx
+++ b/app/find-advisor/life-event/page.tsx
@@ -1,0 +1,266 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  LIFE_EVENTS,
+  LIFE_EVENT_CATEGORIES,
+  buildLifeEventUrl,
+} from "@/lib/life-events";
+import { breadcrumbJsonLd, SITE_URL } from "@/lib/seo";
+import { faqJsonLd } from "@/lib/schema-markup";
+
+export const revalidate = 86400;
+
+export const metadata: Metadata = {
+  title: "Find a Financial Advisor for Your Life Event | Invest.com.au",
+  description:
+    "Major life events need the right financial advice. Whether you're buying your first home, having a baby, selling a business, or approaching retirement — tell us what's happening and we'll match you with the right advisor.",
+  alternates: { canonical: `${SITE_URL}/find-advisor/life-event` },
+  openGraph: {
+    title: "Find a Financial Advisor for Your Life Event",
+    description:
+      "Match with the right type of financial professional based on what's happening in your life right now.",
+    url: `${SITE_URL}/find-advisor/life-event`,
+    type: "website",
+  },
+};
+
+const breadcrumb = breadcrumbJsonLd([
+  { name: "Home", url: "/" },
+  { name: "Find an Advisor", url: "/find-advisor" },
+  { name: "By Life Event", url: "/find-advisor/life-event" },
+]);
+
+const faq = faqJsonLd([
+  {
+    q: "Why should I use a life event to find an advisor?",
+    a: "Major life changes — buying a home, having a baby, getting married, selling a business — each need a specific type of financial professional. Describing your situation upfront lets us skip generic questions and route you straight to the right specialist.",
+  },
+  {
+    q: "What if my life event isn't listed?",
+    a: "You can always use the standard 'find by goal' flow, which lets you describe your financial priority in four categories: Buy Property, Grow Wealth, Protect Assets, or Tax & SMSF. Every advisor on the platform accepts enquiries through that path too.",
+  },
+  {
+    q: "Is the matching service free?",
+    a: "Yes, completely free. We're paid by advisors when they accept a lead — you never pay for the matching service. Your details are shared with one matched advisor only; we don't sell your information.",
+  },
+  {
+    q: "How quickly will the advisor respond?",
+    a: "Most advisors on the platform respond within 24 hours. You can see each advisor's typical response time on their profile before confirming the match.",
+  },
+]);
+
+export default function LifeEventPage() {
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faq) }}
+      />
+
+      <div className="min-h-screen bg-gradient-to-b from-slate-50 via-white to-white">
+        {/* Hero */}
+        <div className="max-w-4xl mx-auto px-4 pt-10 pb-4">
+          <nav className="text-xs text-slate-400 mb-6" aria-label="Breadcrumb">
+            <Link href="/" className="hover:text-slate-700 transition-colors">
+              Home
+            </Link>
+            <span className="mx-1.5 text-slate-300">/</span>
+            <Link
+              href="/find-advisor"
+              className="hover:text-slate-700 transition-colors"
+            >
+              Find an Advisor
+            </Link>
+            <span className="mx-1.5 text-slate-300">/</span>
+            <span className="text-slate-600 font-medium">By Life Event</span>
+          </nav>
+
+          <div className="text-center mb-12">
+            <div className="inline-flex items-center gap-2 bg-amber-50 border border-amber-200 text-amber-700 text-xs font-semibold px-3 py-1.5 rounded-full mb-5">
+              <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z" />
+              </svg>
+              Life-event matching
+            </div>
+            <h1 className="text-3xl md:text-4xl font-extrabold text-slate-900 mb-4 leading-tight">
+              What&apos;s happening in your life right now?
+            </h1>
+            <p className="text-base md:text-lg text-slate-500 max-w-2xl mx-auto leading-relaxed">
+              Major life events come with financial decisions that are hard to get
+              right alone. Choose your situation and we&apos;ll match you with the
+              right type of professional — free, in seconds.
+            </p>
+          </div>
+        </div>
+
+        {/* Life event grid grouped by category */}
+        <div className="max-w-4xl mx-auto px-4 pb-16">
+          {LIFE_EVENT_CATEGORIES.map((cat) => {
+            const events = LIFE_EVENTS.filter((e) => e.category === cat.id);
+            if (events.length === 0) return null;
+            return (
+              <section key={cat.id} className="mb-10" aria-labelledby={`cat-${cat.id}`}>
+                <h2
+                  id={`cat-${cat.id}`}
+                  className="flex items-center gap-2 text-base font-bold text-slate-700 mb-4"
+                >
+                  <span aria-hidden="true" className="text-xl">{cat.emoji}</span>
+                  {cat.label}
+                </h2>
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                  {events.map((event) => (
+                    <Link
+                      key={event.id}
+                      href={buildLifeEventUrl(event)}
+                      className="group flex items-start gap-4 p-5 rounded-2xl border-2 border-slate-200 bg-white hover:border-amber-400 hover:shadow-md hover:-translate-y-0.5 transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2"
+                    >
+                      <div
+                        className="text-3xl shrink-0 leading-none mt-0.5"
+                        aria-hidden="true"
+                      >
+                        {event.emoji}
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <h3 className="text-sm font-bold text-slate-900 mb-1 leading-tight">
+                          {event.title}
+                        </h3>
+                        <p className="text-xs text-slate-500 leading-relaxed mb-2.5">
+                          {event.subtitle}
+                        </p>
+                        <div className="flex flex-wrap gap-1.5">
+                          {event.suggestedTypes.slice(0, 2).map((t) => (
+                            <span
+                              key={t}
+                              className="text-[0.62rem] font-semibold text-amber-700 bg-amber-50 border border-amber-200 px-2 py-0.5 rounded-full"
+                            >
+                              {t}
+                            </span>
+                          ))}
+                          {event.relatedHub && (
+                            <span className="text-[0.62rem] font-semibold text-slate-500 bg-slate-50 border border-slate-200 px-2 py-0.5 rounded-full">
+                              Guide available
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                      <svg
+                        className="w-4 h-4 text-slate-300 group-hover:text-amber-500 transition-colors shrink-0 mt-1.5"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                        aria-hidden="true"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M9 5l7 7-7 7"
+                        />
+                      </svg>
+                    </Link>
+                  ))}
+                </div>
+              </section>
+            );
+          })}
+
+          {/* Fallback CTA */}
+          <div className="mt-4 text-center py-10 border-t border-slate-100">
+            <p className="text-sm text-slate-500 mb-4">
+              Don&apos;t see your situation listed above?
+            </p>
+            <Link
+              href="/find-advisor"
+              className="inline-flex items-center gap-2 px-6 py-3 bg-amber-500 hover:bg-amber-600 text-white text-sm font-bold rounded-xl transition-colors shadow-sm hover:shadow-md"
+            >
+              Find by financial goal instead
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+              </svg>
+            </Link>
+          </div>
+
+          {/* FAQ */}
+          <section className="mt-8" aria-labelledby="faq-heading">
+            <h2 id="faq-heading" className="text-xl font-bold text-slate-900 mb-5">
+              Common questions
+            </h2>
+            <div className="space-y-3">
+              {[
+                {
+                  q: "Why should I use a life event to find an advisor?",
+                  a: "Major life changes each need a specific type of financial professional. Choosing your situation upfront skips generic questions and routes you straight to the right specialist — saving time for both you and the advisor.",
+                },
+                {
+                  q: "What if my life event isn't listed?",
+                  a: "Use the standard 'find by goal' flow. It covers four categories — Buy Property, Grow Wealth, Protect Assets, and Tax & SMSF — and every advisor accepts enquiries through that path too.",
+                },
+                {
+                  q: "Is the matching service free?",
+                  a: "Yes, completely free. We're paid by advisors when they accept a lead — you never pay for matching. Your details go to one matched advisor only; we never sell your information.",
+                },
+                {
+                  q: "How quickly will the advisor respond?",
+                  a: "Most advisors respond within 24 hours. You can see each advisor's typical response time on their profile before confirming the match.",
+                },
+              ].map(({ q, a }) => (
+                <details
+                  key={q}
+                  className="group border border-slate-200 rounded-xl overflow-hidden"
+                >
+                  <summary className="flex items-center justify-between p-4 cursor-pointer hover:bg-slate-50 transition-colors list-none">
+                    <span className="text-sm font-semibold text-slate-800 pr-4">{q}</span>
+                    <svg
+                      className="w-4 h-4 text-slate-400 shrink-0 transition-transform group-open:rotate-180"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                      aria-hidden="true"
+                    >
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                    </svg>
+                  </summary>
+                  <div className="px-4 pb-4 text-sm text-slate-600 leading-relaxed border-t border-slate-100 pt-3">
+                    {a}
+                  </div>
+                </details>
+              ))}
+            </div>
+          </section>
+        </div>
+
+        {/* Trust signals */}
+        <div className="border-t border-slate-100 py-8 bg-slate-50">
+          <div className="max-w-4xl mx-auto px-4 flex flex-wrap items-center justify-center gap-x-8 gap-y-3">
+            {[
+              "ASIC-verified professionals",
+              "100% free to use",
+              "Your details shared with one advisor only",
+              "No spam — ever",
+            ].map((t) => (
+              <span key={t} className="flex items-center gap-2 text-xs text-slate-500">
+                <svg
+                  className="w-3.5 h-3.5 text-emerald-500 shrink-0"
+                  fill="currentColor"
+                  viewBox="0 0 20 20"
+                  aria-hidden="true"
+                >
+                  <path
+                    fillRule="evenodd"
+                    d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+                {t}
+              </span>
+            ))}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/find-advisor/page.tsx
+++ b/app/find-advisor/page.tsx
@@ -273,10 +273,12 @@ function FindAdvisorQuiz() {
   const prefilledIntent = needParam ? NEED_TO_INTENT[needParam] || null : null;
 
   // LX-04 — pre-filled form params from hub CTAs, calculators, onboarding results.
+  // CM-01 — context pre-fill from life-event matcher (?context=first_home,investment).
   const stateParam = searchParams.get("state");
   const postcodeParam = searchParams.get("postcode");
   const budgetParam = searchParams.get("budget");
   const firstNameParam = searchParams.get("first_name");
+  const contextParam = searchParams.get("context");
 
   // Read sessionStorage once synchronously so all lazy initialisers share the same
   // parsed value — avoids 5 separate JSON.parse calls and, crucially, avoids the
@@ -308,7 +310,8 @@ function FindAdvisorQuiz() {
     return {
       step: initialIntent ? 2 : 1,
       intent: initialIntent,
-      context: [],
+      // CM-01: pre-select context from life-event matcher (?context=first_home,income_protection,…)
+      context: contextParam ? contextParam.split(",").filter(Boolean) : [],
       // LX-04: seed state/postcode/budget/firstName from URL so Step 3 + Step 4
       // are pre-populated when the user reaches them — reduces form friction.
       state: stateParam ?? "",
@@ -330,7 +333,7 @@ function FindAdvisorQuiz() {
           ...prev,
           step: 2,
           intent,
-          context: [],
+          context: contextParam ? contextParam.split(",").filter(Boolean) : [],
           // Re-apply pre-fill params on navigation changes too
           state: stateParam ?? prev.state,
           postcode: postcodeParam ?? prev.postcode,
@@ -763,6 +766,11 @@ function Step1({ onSelect }: { onSelect: (intent: Intent) => void }) {
             {t}
           </span>
         ))}
+      </div>
+      <div className="mt-4 text-center">
+        <Link href="/find-advisor/life-event" className="text-xs text-amber-600 hover:text-amber-700 font-semibold">
+          Find by life event instead (getting married, new baby, selling a business\u2026) &rarr;
+        </Link>
       </div>
     </Card>
   );

--- a/app/foreign-investment/DASPCalculator.tsx
+++ b/app/foreign-investment/DASPCalculator.tsx
@@ -76,10 +76,11 @@ export default function DASPCalculator() {
         {/* Super balance */}
         <div className="space-y-3">
           <div>
-            <label className="block text-xs font-bold text-slate-700 mb-1.5">Super balance (AUD)</label>
+            <label htmlFor="dasp-balance" className="block text-xs font-bold text-slate-700 mb-1.5">Super balance (AUD)</label>
             <div className="relative">
               <span className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 text-sm font-medium">$</span>
               <input
+                id="dasp-balance"
                 type="text"
                 inputMode="decimal"
                 value={totalBalance}
@@ -90,12 +91,13 @@ export default function DASPCalculator() {
             </div>
           </div>
           <div>
-            <label className="block text-xs font-bold text-slate-700 mb-1">
+            <label htmlFor="dasp-tax-free-pct" className="block text-xs font-bold text-slate-700 mb-1">
               Tax-free component (%)
               <span className="font-normal text-slate-400 ms-1">— after-tax contributions only</span>
             </label>
             <div className="relative">
               <input
+                id="dasp-tax-free-pct"
                 type="number"
                 min={0}
                 max={100}

--- a/app/foreign-investment/WHTCalculator.tsx
+++ b/app/foreign-investment/WHTCalculator.tsx
@@ -73,10 +73,11 @@ export default function WHTCalculator({ countries, defaultRates }: Props) {
 
         {/* Gross amount */}
         <div>
-          <label className="block text-xs font-bold text-slate-700 mb-1.5">Gross amount (AUD)</label>
+          <label htmlFor="wht-gross-amount" className="block text-xs font-bold text-slate-700 mb-1.5">Gross amount (AUD)</label>
           <div className="relative">
             <span className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 text-sm font-medium">$</span>
             <input
+              id="wht-gross-amount"
               type="text"
               inputMode="decimal"
               value={grossAmount}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -73,7 +73,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     "/methodology", "/how-we-verify", "/terms", "/switch", "/editorial-policy", "/benchmark",
     "/billing-policy",
     "/health-scores", "/alerts", "/whats-new", "/costs", "/fee-impact", "/fee-alerts", "/score",
-    "/glossary", "/complaints", "/contact", "/advisors", "/find-advisor", "/community",
+    "/glossary", "/complaints", "/contact", "/advisors", "/find-advisor", "/find-advisor/life-event", "/community",
     "/community/share-trading", "/community/etfs-index-funds", "/community/crypto",
     "/community/super-retirement", "/community/property", "/community/tax-strategy",
     "/community/broker-reviews", "/community/beginners", "/community/off-topic",

--- a/lib/life-events.ts
+++ b/lib/life-events.ts
@@ -1,0 +1,236 @@
+import { buildAdvisorUrl } from "@/lib/prefill-url";
+
+export type LifeEventCategory =
+  | "property"
+  | "family"
+  | "career"
+  | "wealth"
+  | "business"
+  | "retirement";
+
+export interface LifeEvent {
+  id: string;
+  emoji: string;
+  title: string;
+  subtitle: string;
+  category: LifeEventCategory;
+  /** Maps to NEED_TO_INTENT in /find-advisor. */
+  need: string;
+  /** Pre-selects context checkboxes in find-advisor Step 2. */
+  context: string[];
+  /** Human-readable advisor types shown as chips on the card. */
+  suggestedTypes: string[];
+  /** Optional hub page to cross-link. */
+  relatedHub?: string;
+}
+
+export const LIFE_EVENT_CATEGORIES: {
+  id: LifeEventCategory;
+  label: string;
+  emoji: string;
+}[] = [
+  { id: "property", label: "Property", emoji: "🏠" },
+  { id: "family", label: "Family", emoji: "👨‍👩‍👧" },
+  { id: "career", label: "Career", emoji: "💼" },
+  { id: "wealth", label: "Wealth & Investing", emoji: "📈" },
+  { id: "business", label: "Business", emoji: "🏢" },
+  { id: "retirement", label: "Retirement & Estate", emoji: "🌴" },
+];
+
+export const LIFE_EVENTS: LifeEvent[] = [
+  // ─── Property ──────────────────────────────────────────────────────────────
+  {
+    id: "buying_first_home",
+    emoji: "🏠",
+    title: "Buying My First Home",
+    subtitle: "Deposits, FHSS, FHBG, stamp duty concessions, and mortgage options",
+    category: "property",
+    need: "mortgage",
+    context: ["first_home"],
+    suggestedTypes: ["Mortgage Broker", "Buyer's Agent"],
+    relatedHub: "/first-home-buyer",
+  },
+  {
+    id: "buying_investment_property",
+    emoji: "🏘️",
+    title: "Buying Investment Property",
+    subtitle: "Negative gearing, rental yield, depreciation, and financing",
+    category: "property",
+    need: "property",
+    context: ["investment"],
+    suggestedTypes: ["Mortgage Broker", "Buyer's Agent", "Tax Agent"],
+    relatedHub: "/property",
+  },
+  {
+    id: "refinancing_mortgage",
+    emoji: "🔄",
+    title: "Refinancing My Mortgage",
+    subtitle: "Better rates, cashout equity, and debt consolidation",
+    category: "property",
+    need: "mortgage",
+    context: ["refinance"],
+    suggestedTypes: ["Mortgage Broker"],
+  },
+
+  // ─── Family ────────────────────────────────────────────────────────────────
+  {
+    id: "getting_married",
+    emoji: "💒",
+    title: "Getting Married",
+    subtitle: "Combining finances, joint goals, income protection, and will updates",
+    category: "family",
+    need: "planning",
+    context: ["have_savings"],
+    suggestedTypes: ["Financial Planner", "Estate Planner"],
+  },
+  {
+    id: "having_baby",
+    emoji: "👶",
+    title: "Having a Baby",
+    subtitle: "Parental leave planning, life cover, super co-contributions, and will updates",
+    category: "family",
+    need: "insurance",
+    context: ["life_insurance", "income_protection"],
+    suggestedTypes: ["Insurance Broker", "Financial Planner"],
+  },
+  {
+    id: "getting_divorced",
+    emoji: "⚖️",
+    title: "Going Through a Divorce",
+    subtitle: "Property settlement, superannuation splitting, and financial separation",
+    category: "family",
+    need: "planning",
+    context: ["optimize"],
+    suggestedTypes: ["Financial Planner", "Estate Planner"],
+  },
+  {
+    id: "aged_care_planning",
+    emoji: "🏥",
+    title: "Planning for Aged Care",
+    subtitle: "Costs, Centrelink ACAT assessment, home care vs residential, and DVA",
+    category: "family",
+    need: "agedcare",
+    context: ["aged_care"],
+    suggestedTypes: ["Aged Care Advisor", "Financial Planner"],
+  },
+
+  // ─── Career ────────────────────────────────────────────────────────────────
+  {
+    id: "redundancy",
+    emoji: "📦",
+    title: "Made Redundant",
+    subtitle: "ETP tax treatment, rolling super, career transition, and cashflow",
+    category: "career",
+    need: "planning",
+    context: ["getting_started"],
+    suggestedTypes: ["Financial Planner", "Tax Agent"],
+    relatedHub: "/redundancy",
+  },
+  {
+    id: "starting_new_job",
+    emoji: "🚀",
+    title: "Starting a New Job",
+    subtitle: "Super fund choice, salary packaging, salary sacrifice, and novated lease",
+    category: "career",
+    need: "smsf",
+    context: ["tax_optimization"],
+    suggestedTypes: ["Financial Planner", "SMSF Accountant"],
+  },
+  {
+    id: "moving_to_australia",
+    emoji: "✈️",
+    title: "Moving To / From Australia",
+    subtitle: "DASP, tax residency status, FIRB property rules, and foreign pension transfers",
+    category: "career",
+    need: "tax",
+    context: ["tax_optimization"],
+    suggestedTypes: ["Tax Agent", "Migration Agent", "Financial Planner"],
+    relatedHub: "/foreign-investment",
+  },
+
+  // ─── Wealth & Investing ────────────────────────────────────────────────────
+  {
+    id: "received_inheritance",
+    emoji: "🏛️",
+    title: "Received an Inheritance",
+    subtitle: "Lump-sum investing strategy, CGT timing, and estate administration",
+    category: "wealth",
+    need: "planning",
+    context: ["optimize"],
+    suggestedTypes: ["Financial Planner", "Wealth Manager", "Tax Agent"],
+    relatedHub: "/inheritance",
+  },
+  {
+    id: "setting_up_smsf",
+    emoji: "🔐",
+    title: "Setting Up an SMSF",
+    subtitle: "Trustee structure, deed, investment strategy, and ongoing compliance",
+    category: "wealth",
+    need: "smsf",
+    context: ["smsf_setup"],
+    suggestedTypes: ["SMSF Accountant", "SMSF Specialist"],
+    relatedHub: "/smsf",
+  },
+  {
+    id: "crypto_tax",
+    emoji: "₿",
+    title: "Crypto Tax Time",
+    subtitle: "Disposal events, DeFi income, staking, and ATO data-matching compliance",
+    category: "wealth",
+    need: "crypto",
+    context: ["crypto_tax"],
+    suggestedTypes: ["Tax Agent", "Crypto Advisor"],
+  },
+
+  // ─── Business ──────────────────────────────────────────────────────────────
+  {
+    id: "selling_business",
+    emoji: "🤝",
+    title: "Selling My Business",
+    subtitle: "CGT small business concessions, valuation, exit planning, and reinvestment",
+    category: "business",
+    need: "planning",
+    context: ["optimize"],
+    suggestedTypes: ["Financial Planner", "Business Broker", "Tax Agent"],
+  },
+  {
+    id: "starting_business",
+    emoji: "🌱",
+    title: "Starting a Business",
+    subtitle: "Entity structure, GST registration, super obligations, and initial financing",
+    category: "business",
+    need: "tax",
+    context: ["tax_optimization"],
+    suggestedTypes: ["Tax Agent", "Financial Planner"],
+  },
+
+  // ─── Retirement & Estate ───────────────────────────────────────────────────
+  {
+    id: "approaching_retirement",
+    emoji: "🌅",
+    title: "Approaching Retirement",
+    subtitle: "TTR pension, concessional cap strategy, Centrelink Age Pension, and drawdown",
+    category: "retirement",
+    need: "planning",
+    context: ["retirement"],
+    suggestedTypes: ["Financial Planner", "SMSF Accountant"],
+    relatedHub: "/super",
+  },
+  {
+    id: "estate_planning",
+    emoji: "📜",
+    title: "Creating a Will / Estate Plan",
+    subtitle: "Wills, testamentary trusts, powers of attorney, and binding death nominations",
+    category: "retirement",
+    need: "estate",
+    context: ["estate_planning"],
+    suggestedTypes: ["Estate Planner"],
+  },
+];
+
+export function buildLifeEventUrl(
+  event: LifeEvent,
+  extras?: { state?: string; postcode?: string }
+): string {
+  return buildAdvisorUrl({ need: event.need, context: event.context, ...extras });
+}

--- a/lib/prefill-url.ts
+++ b/lib/prefill-url.ts
@@ -23,6 +23,12 @@ export interface AdvisorPrefillOptions {
   budget?: string;
   /** Pre-fill the user's first name in Step 4. */
   firstName?: string;
+  /**
+   * Pre-select context checkboxes in Step 2 (comma-separated in URL).
+   * Values must match the option IDs in CONTEXT_CONFIG for the resolved intent.
+   * CM-01: life-event matching passes pre-selected context so Step 2 is pre-populated.
+   */
+  context?: string[];
 }
 
 /**
@@ -38,6 +44,7 @@ export function buildAdvisorUrl(options: AdvisorPrefillOptions): string {
   if (options.postcode) params.set("postcode", options.postcode);
   if (options.budget) params.set("budget", options.budget);
   if (options.firstName) params.set("first_name", options.firstName);
+  if (options.context && options.context.length > 0) params.set("context", options.context.join(","));
   return `/find-advisor?${params.toString()}`;
 }
 


### PR DESCRIPTION
## Summary

Implements CM-01 (life-event matching) from the audit remediation queue — a new entry point to the find-advisor funnel that routes users based on their life situation rather than a generic financial intent.

### What's in this PR

- **`lib/life-events.ts`** — 17 life events across 6 categories (Property, Family, Career, Wealth & Investing, Business, Retirement & Estate). Each event carries: emoji, subtitle, advisor type chips for display, a `need` key that maps to the existing `/find-advisor` routing logic, pre-selected `context` items for Step 2, and an optional hub cross-link.
- **`lib/prefill-url.ts`** — Extended `AdvisorPrefillOptions` + `buildAdvisorUrl` with an optional `context?: string[]` field, serialised as `?context=item1,item2`. CM-01 is the first caller; future streams can use it too.
- **`app/find-advisor/life-event/page.tsx`** — New RSC landing page at `/find-advisor/life-event`. Card grid grouped by category. Each card links to `/find-advisor?need=X&context=Y` via `buildLifeEventUrl()`. Emits `BreadcrumbList` + `FAQPage` JSON-LD. `revalidate = 86400`.
- **`app/find-advisor/page.tsx`** — Reads new `?context=` URL param in the Step 2 state initialiser and late-navigation `useEffect`, so context checkboxes are pre-selected when arriving from the life-event page. Step 1 card gains a "find by life event" link at the bottom.
- **`app/sitemap.ts`** — `/find-advisor/life-event` added to high-priority block.

### Verification gates

- `node scripts/check-dated-strings.mjs` ✅ (0 bare dates in .tsx)
- `node scripts/check-jsonld-coverage.mjs` ✅ (all public routes — including new page)
- `npm run audit:rate-limits --strict` ✅ 100% (461 routes)
- No schema changes, no migrations, no API routes touched.

### Tier
Tier A — new UI landing page + lib constant + non-breaking extension to an existing lib function. No auth, no schema, no cron, no middleware changes.

### Unblocks
CM-02 (multi-advisor for high-value leads) and CM-03 (lead quality scoring) depend on CM-01 landing.

## Supersedes

_None._

---

Ref: audit-remediation stream CM · `docs/audits/REMEDIATION_QUEUE.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMjNrTE13LYz3p2jyAh8g7)_