### PR TITLE
feat(at): AT-01 investor household account type selector [audit remediation]

### DIFF
--- a/app/account/profile/ProfileClient.tsx
+++ b/app/account/profile/ProfileClient.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import Icon from "@/components/Icon";
 import { useUser } from "@/lib/hooks/useUser";
 import { useToast } from "@/components/Toast";
+import { type InvestorAccountType, INVESTOR_ACCOUNT_TYPES } from "@/lib/account-types";
 
 /* ── Constants ── */
 
@@ -128,6 +129,10 @@ const emptyProfile: ProfileData = {
   preferred_broker: "",
 };
 
+interface InvestorMeta {
+  account_type: InvestorAccountType;
+}
+
 /* ── Main component ── */
 
 export default function ProfileClient() {
@@ -136,6 +141,7 @@ export default function ProfileClient() {
   const { toast } = useToast();
 
   const [form, setForm] = useState<ProfileData>(emptyProfile);
+  const [investorMeta, setInvestorMeta] = useState<InvestorMeta>({ account_type: "individual" });
   const [fetching, setFetching] = useState(true);
   const [saving, setSaving] = useState(false);
 
@@ -146,26 +152,37 @@ export default function ProfileClient() {
     }
   }, [authLoading, user, router]);
 
-  // Fetch profile on mount
+  // Fetch profile + investor meta on mount
   useEffect(() => {
     if (!user) return;
     let cancelled = false;
 
     (async () => {
       try {
-        const res = await fetch("/api/user-profile");
-        if (!res.ok) return;
-        const { profile } = await res.json();
-        if (cancelled || !profile) return;
-        setForm({
-          display_name: profile.display_name ?? "",
-          state: profile.state ?? "",
-          investing_experience: profile.investing_experience ?? "",
-          investment_goals: profile.investment_goals ?? "",
-          portfolio_size: profile.portfolio_size ?? "",
-          interested_in: Array.isArray(profile.interested_in) ? profile.interested_in : [],
-          preferred_broker: profile.preferred_broker ?? "",
-        });
+        const [profileRes, metaRes] = await Promise.all([
+          fetch("/api/user-profile"),
+          fetch("/api/account/account-type"),
+        ]);
+        if (!cancelled && profileRes.ok) {
+          const { profile } = await profileRes.json();
+          if (profile) {
+            setForm({
+              display_name: profile.display_name ?? "",
+              state: profile.state ?? "",
+              investing_experience: profile.investing_experience ?? "",
+              investment_goals: profile.investment_goals ?? "",
+              portfolio_size: profile.portfolio_size ?? "",
+              interested_in: Array.isArray(profile.interested_in) ? profile.interested_in : [],
+              preferred_broker: profile.preferred_broker ?? "",
+            });
+          }
+        }
+        if (!cancelled && metaRes.ok) {
+          const data = await metaRes.json();
+          if (data.account_type) {
+            setInvestorMeta({ account_type: data.account_type });
+          }
+        }
       } finally {
         if (!cancelled) setFetching(false);
       }
@@ -178,12 +195,19 @@ export default function ProfileClient() {
   const handleSave = async () => {
     setSaving(true);
     try {
-      const res = await fetch("/api/user-profile", {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(form),
-      });
-      if (res.ok) {
+      const [profileRes, metaRes] = await Promise.all([
+        fetch("/api/user-profile", {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(form),
+        }),
+        fetch("/api/account/account-type", {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ account_type: investorMeta.account_type }),
+        }),
+      ]);
+      if (profileRes.ok && metaRes.ok) {
         toast("Profile saved", "success");
       } else {
         toast("Failed to save profile", "error");
@@ -231,6 +255,23 @@ export default function ProfileClient() {
             <Icon name="arrow-left" size={18} className="text-slate-600" />
           </Link>
           <h1 className="text-2xl font-extrabold text-slate-900">Edit Profile</h1>
+        </div>
+
+        {/* Section 0: Account Type */}
+        <div className="bg-white border border-slate-200 rounded-2xl p-6 mb-4">
+          <h2 className="text-base font-bold text-slate-900 mb-1">Account Type</h2>
+          <p className="text-xs text-slate-500 mb-4">Helps us surface content relevant to your situation.</p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            {INVESTOR_ACCOUNT_TYPES.map((opt) => (
+              <RadioCard
+                key={opt.value}
+                selected={investorMeta.account_type === opt.value}
+                onClick={() => setInvestorMeta({ account_type: opt.value })}
+                label={opt.label}
+                description={opt.description}
+              />
+            ))}
+          </div>
         </div>
 
         {/* Section 1: Personal Info */}

--- a/app/api/account/account-type/route.ts
+++ b/app/api/account/account-type/route.ts
@@ -1,0 +1,50 @@
+/**
+ * /api/account/account-type — investor household type.
+ *
+ * GET  — returns current account_type from investor_profiles.meta (default: "individual")
+ * PUT  — sets account_type, merging into existing meta so other keys (e.g. digest prefs) survive
+ */
+
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { createClient } from "@/lib/supabase/server";
+import { getInvestorProfile, upsertInvestorProfile } from "@/lib/investor-profiles";
+import { withValidatedBody } from "@/lib/validation/withValidatedBody";
+import { getInvestorAccountType } from "@/lib/account-types";
+import { logger } from "@/lib/logger";
+
+export const runtime = "nodejs";
+
+const log = logger("api:account:account-type");
+
+const Body = z.object({
+  account_type: z.enum(["individual", "couple", "family", "business"]),
+});
+
+export async function GET() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+
+  const profile = await getInvestorProfile(user.id);
+  const account_type = getInvestorAccountType(profile?.meta ?? {});
+  return NextResponse.json({ account_type });
+}
+
+export const PUT = withValidatedBody(Body, async (_req, body) => {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+
+  const profile = await getInvestorProfile(user.id);
+  const mergedMeta: Record<string, unknown> = { ...(profile?.meta ?? {}) };
+  mergedMeta.account_type = body.account_type;
+
+  const ok = await upsertInvestorProfile(user.id, { meta: mergedMeta });
+  if (!ok) {
+    log.warn("account-type PUT failed", { userId: user.id });
+    return NextResponse.json({ error: "update_failed" }, { status: 500 });
+  }
+
+  return NextResponse.json({ account_type: body.account_type });
+});

--- a/lib/account-types.ts
+++ b/lib/account-types.ts
@@ -46,3 +46,28 @@ export const ACTIVE_ACCOUNT_KINDS: readonly AccountKind[] = [
 export function isAccountKind(value: unknown): value is AccountKind {
   return typeof value === "string" && (ACTIVE_ACCOUNT_KINDS as readonly string[]).includes(value);
 }
+
+// ─── Investor household type (AT stream) ────────────────────────────────────
+
+/**
+ * Household structure for investor-portal personalisation. Stored in
+ * `investor_profiles.meta.account_type`. Drives content routing and
+ * copy variants (AT-01..AT-04 audit stream). "individual" is the default.
+ */
+export type InvestorAccountType = "individual" | "couple" | "family" | "business";
+
+export const INVESTOR_ACCOUNT_TYPES: readonly {
+  value: InvestorAccountType;
+  label: string;
+  description: string;
+}[] = [
+  { value: "individual", label: "Individual", description: "Solo investor — personal finances only" },
+  { value: "couple", label: "Couple / household", description: "Shared finances with a partner" },
+  { value: "family", label: "Family", description: "Family household with dependants" },
+  { value: "business", label: "Business / SMSF", description: "Company, trust, or self-managed super" },
+] as const;
+
+export function getInvestorAccountType(meta: Record<string, unknown>): InvestorAccountType {
+  const v = meta.account_type;
+  return v === "individual" || v === "couple" || v === "family" || v === "business" ? v : "individual";
+}


### PR DESCRIPTION
## Summary

Implements AT-01 from the audit remediation queue — investor household account type selection. Stored in `investor_profiles.meta.account_type` (no schema migration required; `meta: Json` column already exists).

- **`lib/account-types.ts`** — adds `InvestorAccountType` (`"individual" | "couple" | "family" | "business"`), `INVESTOR_ACCOUNT_TYPES` display array, and `getInvestorAccountType(meta)` helper (defaults to `"individual"` when unset). Added to the existing file alongside `AccountKind`.
- **`app/api/account/account-type/route.ts`** — new authenticated GET/PUT route. GET returns the current value from `investor_profiles.meta`; PUT merges `account_type` into the existing meta object (preserving other keys such as digest preferences).
- **`app/account/profile/ProfileClient.tsx`** — new "Account Type" section at the top of the profile form (4 `RadioCard` options); fetches and saves in parallel with the `profiles` table PUT on save.

## Refs

- Audit stream: AT (account types)
- Items: AT-01 (unblocks AT-02 couple, AT-03 family, AT-04 business/SMSF content routing)
- Tracking issue: #217
- Original audit: PR #213

## Supersedes

_None._

## Tier

**Tier A** — new UI component + lib constant + authenticated API route, no schema migration, no auth/middleware/cron changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VMjNrTE13LYz3p2jyAh8g7)_