### PR TITLE
refactor(invest): Wave 1 — kind-aware cards, drawer filters, view modes, hero cleanup

### DIFF
--- a/app/invest/page.tsx
+++ b/app/invest/page.tsx
@@ -29,13 +29,14 @@ const log = logger("invest-marketplace");
 
 export const revalidate = 3600;
 
-// /invest is the canonical marketplace landing. The previous architecture
-// split this surface in two — /invest was a category aggregator (cards),
-// /invest/listings was the actual filterable grid. That two-step was the
-// source of "I clicked browse listings, why am I looking at category cards"
-// confusion. Pre-launch we collapsed it into one page: marketplace grid up
-// top (visitors see deals immediately), sector discovery below as secondary
-// browsing affordance. /invest/listings now redirects here (next.config.ts).
+// /invest is the canonical marketplace landing. Wave 1 of the rebuild
+// (2026-05) slimmed the hero, consolidated the two sticky filter bars
+// into one toolbar, deleted the redundant "Active listings by vertical"
+// chip strip (it duplicated the category tab bar with worse labels),
+// moved the GetMatched CTA to a "Can't find the right deal?" prompt
+// BELOW results, and moved compliance text to a bottom band so it
+// doesn't eat 40% of the fold on first paint. Per-listing card layouts
+// now branch on listing_kind (see lib/listing-kind.ts).
 export const metadata: Metadata = {
   title: `Australian Investment Opportunities — Marketplace (${CURRENT_YEAR}) | ${SITE_NAME}`,
   description:
@@ -76,102 +77,21 @@ async function fetchAllActiveListings(): Promise<InvestmentListing[]> {
 }
 
 const CATEGORY_ICONS: Record<string, React.ReactNode> = {
-  "buy-business": (
-    <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" /></svg>
-  ),
-  mining: (
-    <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4" /></svg>
-  ),
-  farmland: (
-    <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
-  ),
-  "commercial-property": (
-    <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M8 14v3m4-3v3m4-3v3M3 21h18M3 10h18M3 7l9-4 9 4M4 10h16v11H4V10z" /></svg>
-  ),
-  franchise: (
-    <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M16 11V7a4 4 0 00-8 0v4M5 9h14l1 12H4L5 9z" /></svg>
-  ),
-  "renewable-energy": (
-    <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M13 10V3L4 14h7v7l9-11h-7z" /></svg>
-  ),
-  startups: (
-    <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" /></svg>
-  ),
-  alternatives: (
-    <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z" /></svg>
-  ),
-  "private-credit": (
-    <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
-  ),
-  infrastructure: (
-    <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M19.428 15.428a2 2 0 00-1.022-.547l-2.387-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z" /></svg>
-  ),
-  funds: (
-    <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" /></svg>
-  ),
-  royalties: (
-    <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8V6m0 12v2m9-10a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
-  ),
-  "income-assets": (
-    <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M3 3h2l.4 2M7 13h10l4-8H5.4M7 13L5.4 5M7 13l-2.293 2.293c-.63.63-.184 1.707.707 1.707H17m0 0a2 2 0 100 4 2 2 0 000-4zm-8 2a2 2 0 11-4 0 2 2 0 014 0z" /></svg>
-  ),
-  "ipo-calendar": (
-    <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" /></svg>
-  ),
-  "pre-ipo": (
-    <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" /></svg>
-  ),
-  bonds: (
-    <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M3 21h18M3 10h18M5 6l7-3 7 3M4 10v11M20 10v11M8 14v3M12 14v3M16 14v3" /></svg>
-  ),
-  "hybrid-securities": (
-    <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" /></svg>
-  ),
-  "dividend-investing": (
-    <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
-  ),
-  reits: (
-    <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" /></svg>
-  ),
-  "crypto-staking": (
-    <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4" /></svg>
-  ),
-  forex: (
-    <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M3.6 9h16.8M3.6 15h16.8M11.5 3a17 17 0 000 18M12.5 3a17 17 0 010 18" /></svg>
-  ),
-  "options-trading": (
-    <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M3 17l6-6 4 4 8-8M14 7h7v7" /></svg>
-  ),
-  ipos: (
-    <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 14L4 9l5-5M4 9h11a4 4 0 014 4v8" /></svg>
-  ),
-  "managed-funds": (
-    <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M21 13.255A23.931 23.931 0 0112 15c-3.183 0-6.22-.62-9-1.745M16 6V4a2 2 0 00-2-2h-4a2 2 0 00-2 2v2m4 6h.01M5 20h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" /></svg>
-  ),
-  "private-equity": (
-    <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M21 13.255A23.931 23.931 0 0112 15c-3.183 0-6.22-.62-9-1.745M16 6V4a2 2 0 00-2-2h-4a2 2 0 00-2 2v2m4 6h.01" /></svg>
-  ),
-  smsf: (
-    <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 12l2 2 4-4M12 3l8 4v6c0 4-3.5 7.5-8 9-4.5-1.5-8-5-8-9V7l8-4z" /></svg>
-  ),
-  commodities: (
-    <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
-  ),
-  gold: (
-    <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9" strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} /><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 9.5h4a2 2 0 010 4H9V9zm0 4v3" /></svg>
-  ),
-  lithium: (
-    <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M13 10V3L4 14h7v7l9-11h-7z" /></svg>
-  ),
-  uranium: (
-    <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="2.5" strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} /><ellipse cx="12" cy="12" rx="9" ry="3.5" strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} /><ellipse cx="12" cy="12" rx="9" ry="3.5" transform="rotate(60 12 12)" strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} /><ellipse cx="12" cy="12" rx="9" ry="3.5" transform="rotate(-60 12 12)" strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} /></svg>
-  ),
-  "oil-gas": (
-    <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M17.657 18.657A8 8 0 016.343 7.343S7 9 9 10c0-2 .5-5 2.986-7C14 5 16.09 5.24 17 7.428c1.5 3.572.18 6.97-1.5 9.572.5-1.428 0-3.572-1-3.572 0 1-.667 1.999-1.5 2.999z" /></svg>
-  ),
-  hydrogen: (
-    <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><circle cx="8" cy="12" r="3" strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} /><circle cx="16" cy="12" r="3" strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} /><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M11 12h2" /></svg>
-  ),
+  "buy-business": <Icon name="store" size={20} />,
+  mining: <Icon name="pickaxe" size={20} />,
+  farmland: <Icon name="sprout" size={20} />,
+  "commercial-property": <Icon name="building" size={20} />,
+  franchise: <Icon name="store" size={20} />,
+  "renewable-energy": <Icon name="zap" size={20} />,
+  startups: <Icon name="rocket" size={20} />,
+  alternatives: <Icon name="gem" size={20} />,
+  "private-credit": <Icon name="dollar-sign" size={20} />,
+  infrastructure: <Icon name="factory" size={20} />,
+  funds: <Icon name="trending-up" size={20} />,
+  royalties: <Icon name="percent" size={20} />,
+  "income-assets": <Icon name="coins" size={20} />,
+  "pre-ipo": <Icon name="rocket" size={20} />,
+  "private-equity": <Icon name="trending-up" size={20} />,
 };
 
 const ACCENT_COLORS: Record<string, { card: string; badge: string; hover: string }> = {
@@ -188,25 +108,8 @@ const ACCENT_COLORS: Record<string, { card: string; badge: string; hover: string
   funds: { card: "border-violet-200 hover:border-violet-400", badge: "bg-violet-100 text-violet-700", hover: "group-hover:text-violet-700" },
   royalties: { card: "border-rose-200 hover:border-rose-400", badge: "bg-rose-100 text-rose-700", hover: "group-hover:text-rose-700" },
   "income-assets": { card: "border-emerald-200 hover:border-emerald-400", badge: "bg-emerald-100 text-emerald-700", hover: "group-hover:text-emerald-700" },
-  "ipo-calendar": { card: "border-indigo-200 hover:border-indigo-400", badge: "bg-indigo-100 text-indigo-700", hover: "group-hover:text-indigo-700" },
   "pre-ipo": { card: "border-red-200 hover:border-red-400", badge: "bg-red-100 text-red-700", hover: "group-hover:text-red-700" },
-  bonds: { card: "border-sky-200 hover:border-sky-400", badge: "bg-sky-100 text-sky-700", hover: "group-hover:text-sky-700" },
-  "hybrid-securities": { card: "border-stone-200 hover:border-stone-400", badge: "bg-stone-100 text-stone-700", hover: "group-hover:text-stone-700" },
-  "dividend-investing": { card: "border-lime-200 hover:border-lime-400", badge: "bg-lime-100 text-lime-700", hover: "group-hover:text-lime-700" },
-  reits: { card: "border-emerald-200 hover:border-emerald-400", badge: "bg-emerald-100 text-emerald-700", hover: "group-hover:text-emerald-700" },
-  "crypto-staking": { card: "border-fuchsia-200 hover:border-fuchsia-400", badge: "bg-fuchsia-100 text-fuchsia-700", hover: "group-hover:text-fuchsia-700" },
-  forex: { card: "border-zinc-200 hover:border-zinc-400", badge: "bg-zinc-100 text-zinc-700", hover: "group-hover:text-zinc-700" },
-  "options-trading": { card: "border-red-200 hover:border-red-400", badge: "bg-red-100 text-red-700", hover: "group-hover:text-red-700" },
-  ipos: { card: "border-pink-200 hover:border-pink-400", badge: "bg-pink-100 text-pink-700", hover: "group-hover:text-pink-700" },
-  "managed-funds": { card: "border-violet-200 hover:border-violet-400", badge: "bg-violet-100 text-violet-700", hover: "group-hover:text-violet-700" },
   "private-equity": { card: "border-purple-200 hover:border-purple-400", badge: "bg-purple-100 text-purple-700", hover: "group-hover:text-purple-700" },
-  smsf: { card: "border-teal-200 hover:border-teal-400", badge: "bg-teal-100 text-teal-700", hover: "group-hover:text-teal-700" },
-  commodities: { card: "border-orange-200 hover:border-orange-400", badge: "bg-orange-100 text-orange-700", hover: "group-hover:text-orange-700" },
-  gold: { card: "border-yellow-200 hover:border-yellow-400", badge: "bg-yellow-100 text-yellow-700", hover: "group-hover:text-yellow-700" },
-  lithium: { card: "border-gray-200 hover:border-gray-400", badge: "bg-gray-100 text-gray-700", hover: "group-hover:text-gray-700" },
-  uranium: { card: "border-green-200 hover:border-green-400", badge: "bg-green-100 text-green-700", hover: "group-hover:text-green-700" },
-  "oil-gas": { card: "border-amber-200 hover:border-amber-400", badge: "bg-amber-100 text-amber-700", hover: "group-hover:text-amber-700" },
-  hydrogen: { card: "border-neutral-200 hover:border-neutral-400", badge: "bg-neutral-100 text-neutral-700", hover: "group-hover:text-neutral-700" },
 };
 
 const DEFAULT_ACCENT = { card: "border-slate-200 hover:border-slate-400", badge: "bg-slate-100 text-slate-700", hover: "group-hover:text-slate-700" };
@@ -225,84 +128,32 @@ const CATEGORY_DESCRIPTIONS: Record<string, string> = {
   funds: "Hedge funds, private credit funds, REITs & SIV-complying funds.",
   royalties: "Mining royalties (DRR), music catalogue, IP & oil-gas royalty streams.",
   "income-assets": "Vending, ATMs, car washes, laundromats, self-storage & billboards.",
-  "ipo-calendar": "Upcoming ASX IPOs, recent listings & broker priority allocations.",
   "pre-ipo": "Wholesale-only late-stage private placements before IPO.",
-  bonds: "Government, corporate & ASX-listed bond ETFs (VGB, AGVT, IAF).",
-  "hybrid-securities": "Bank hybrids, sub-debt & capital notes (CBAPI, NABPF).",
-  "dividend-investing": "ASX 200 high-yield names, franking credits & ETFs (VHY, IHD).",
-  reits: "Goodman, Charter Hall, Mirvac, Stockland — plus VAP, MVA, DJRE.",
-  "crypto-staking": "Stake on AUSTRAC-registered exchanges — Swyftx, CoinSpot, Independent Reserve.",
-  forex: "ASIC-licensed CFD providers — Pepperstone, IC Markets, IG, CMC.",
-  "options-trading": "ASX options market — covered calls, cash-secured puts, XJO index options.",
-  ipos: "Recent ASX IPOs, broker priority allocations & 6-month escrow.",
-  "managed-funds": "Active Australian + global funds, mFund settlement, MER + APIR codes.",
   "private-equity": "Listed PE structures, wholesale s708 access, 7–10 year lockups.",
-  smsf: "Self-managed super — setup, audit, member limits & SISA s62A.",
-  commodities: "Gold, oil, LNG, iron ore, copper exposures via stocks, ETFs & futures.",
-  gold: "Perth Mint coins/bars, ASX gold ETFs (GOLD, NGLD) & gold miners.",
-  lithium: "ASX lithium pure-plays — PLS, MIN, LTR, IGO, AKE — battery-grade vs technical.",
-  uranium: "ASX producers (PDN, BOE), developers (DYL, BMN), explorers & ATOM ETF.",
-  "oil-gas": "ASX majors (WDS, STO), LNG export, gas reservation policy & FIRB review.",
-  hydrogen: "ASX hydrogen plays (HXG, FFI, GLN), Hydrogen Headstart program & export thesis.",
 };
 
-// Energy + commodity sector hubs. These are EDUCATIONAL pillar pages
-// (`/invest/{slug}` not `/invest/{slug}/listings`) — visitors learn about
-// the sector then click through to filtered marketplace if available.
-// Surfaced below the marketplace grid as secondary discovery.
-const SECTOR_HUBS = [
-  { slug: "oil-gas", label: "Oil & Gas", description: "LNG, exploration, refineries and energy infrastructure", icon: "fuel", accentCard: "border-amber-200 hover:border-amber-400", accentBadge: "bg-amber-100 text-amber-700", accentHover: "group-hover:text-amber-700" },
-  { slug: "uranium", label: "Uranium", description: "ASX uranium producers, explorers and sector ETFs", icon: "atom", accentCard: "border-yellow-200 hover:border-yellow-400", accentBadge: "bg-yellow-100 text-yellow-700", accentHover: "group-hover:text-yellow-700" },
-  { slug: "hydrogen", label: "Hydrogen", description: "Green hydrogen, fuel cells and H2 infrastructure", icon: "droplets", accentCard: "border-sky-200 hover:border-sky-400", accentBadge: "bg-sky-100 text-sky-700", accentHover: "group-hover:text-sky-700" },
-  { slug: "lithium", label: "Lithium", description: "Pilbara producers, downstream processing and battery metals", icon: "zap", accentCard: "border-emerald-200 hover:border-emerald-400", accentBadge: "bg-emerald-100 text-emerald-700", accentHover: "group-hover:text-emerald-700" },
-  { slug: "gold", label: "Gold & Precious Metals", description: "Perth Mint, gold ETFs and ASX gold miners", icon: "coins", accentCard: "border-amber-200 hover:border-amber-400", accentBadge: "bg-amber-100 text-amber-700", accentHover: "group-hover:text-amber-700" },
-];
-
 export default async function InvestMarketplacePage() {
-  const [listings, supabase] = await Promise.all([
-    fetchAllActiveListings(),
-    createClient(),
-  ]);
+  const listings = await fetchAllActiveListings();
 
-  // Per-vertical counts for the active-listings strip + the category cards.
+  // Per-vertical + per-kind counts for hero pills and discovery cards.
   const verticalCounts: Record<string, number> = {};
+  let firbCount = 0;
+  let sivCount = 0;
   for (const l of listings) {
     const v = l.vertical as string;
-    if (!v) continue;
-    verticalCounts[v] = (verticalCounts[v] || 0) + 1;
+    if (v) verticalCounts[v] = (verticalCounts[v] || 0) + 1;
+    if (l.firb_eligible) firbCount++;
+    if (l.siv_complying) sivCount++;
   }
-  const sortedCounts = Object.entries(verticalCounts)
-    // Drop counts for verticals that aren't part of the opportunity IA.
-    // Filter is applied lazily below — we still need the full counts
-    // for category-card rollups via getCategoryCount().
-    .sort(([, a], [, b]) => b - a);
 
-  // /invest is the canonical Browse-Opportunities surface. Compare-tagged
-  // categories are 301-redirected upstream; Guide-tagged categories stay
-  // live but are hidden here. See lib/invest-categories.ts INTENT_BY_SLUG.
   const categories = getOpportunityCategories();
-  const categoryTabs = categories.map((c) => ({
-    slug: c.slug,
-    label: c.label,
-  }));
-
-  // Build the set of DB vertical values that map to an opportunity
-  // category — used to prune the per-vertical count strip below so it
-  // doesn't surface demoted verticals.
-  const opportunityVerticalSet = new Set<string>(
-    categories.flatMap((c) => c.dbVerticals as readonly string[]),
-  );
+  const categoryTabs = categories.map((c) => ({ slug: c.slug, label: c.label }));
 
   function getCategoryCount(cat: InvestCategory): number {
     return cat.dbVerticals.reduce((sum, v) => sum + (verticalCounts[v] || 0), 0);
   }
 
-  // Secondary fetch is unused but kept for parity with old hub page if we
-  // need a separate "category aggregate" count later. Currently the
-  // marketplace listings already drive the per-category counts above.
-  void supabase;
-
-  // ── JSON-LD: ItemList ──
+  // ── JSON-LD ──
   const itemListJsonLd = {
     "@context": "https://schema.org",
     "@type": "ItemList",
@@ -316,13 +167,11 @@ export default async function InvestMarketplacePage() {
     })),
   };
 
-  // ── JSON-LD: BreadcrumbList ──
   const breadcrumbs = breadcrumbJsonLd([
     { name: "Home", url: absoluteUrl("/") },
     { name: "Opportunities" },
   ]);
 
-  // ── JSON-LD: WebPage ──
   const webPageJsonLd = {
     "@context": "https://schema.org",
     "@type": "WebPage",
@@ -330,11 +179,7 @@ export default async function InvestMarketplacePage() {
     description: metadata.description,
     url: absoluteUrl("/invest"),
     publisher: ORGANIZATION_JSONLD,
-    isPartOf: {
-      "@type": "WebSite",
-      name: SITE_NAME,
-      url: absoluteUrl("/"),
-    },
+    isPartOf: { "@type": "WebSite", name: SITE_NAME, url: absoluteUrl("/") },
   };
 
   return (
@@ -343,249 +188,177 @@ export default async function InvestMarketplacePage() {
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbs) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(webPageJsonLd) }} />
 
-      <div className="py-5 md:py-12">
-        <div className="container-custom max-w-6xl">
-          <nav className="text-xs md:text-sm text-slate-500 mb-3 md:mb-6">
-            <Link href="/" className="hover:text-slate-900">Home</Link>
-            <span className="mx-2">/</span>
-            <span className="text-slate-700">Opportunities</span>
-          </nav>
+      {/* ── Slim hero (was 40% of fold, now ~15%) ────────────────── */}
+      <div className="container-custom max-w-6xl pt-5 md:pt-8 pb-3">
+        <nav className="text-xs md:text-sm text-slate-500 mb-2">
+          <Link href="/" className="hover:text-slate-900">Home</Link>
+          <span className="mx-2">/</span>
+          <span className="text-slate-700">Opportunities</span>
+        </nav>
 
-          {/* Header */}
-          <div className="bg-gradient-to-br from-slate-50 to-white border border-slate-200/50 rounded-2xl p-4 md:p-6 mb-3 md:mb-4">
-            <div className="mb-3"><IntentCountryBadge /></div>
-            <IntentCountryRecommendation surface="invest" />
-            <h1 className="text-xl md:text-4xl font-extrabold mb-2 md:mb-3 text-slate-900">
-              Australian Investment Opportunities &mdash; Marketplace
-            </h1>
-            <p className="text-xs md:text-base text-slate-600 mb-2">
-              Browse Australian investment opportunities &mdash; businesses for sale,
-              mining tenements, farmland, commercial property, franchises, renewable energy
-              projects, startups, alternatives, private credit and managed funds. Looking
-              to compare super funds, share-trading platforms, savings accounts or
-              ETFs?{" "}
-              <Link href="/compare" className="text-amber-700 underline hover:no-underline">
-                Visit Compare
-              </Link>
-              .
-            </p>
-            <p className="text-[0.56rem] md:text-xs text-slate-400">
-              {ADVERTISER_DISCLOSURE_SHORT}
-            </p>
-          </div>
+        <div className="mb-2">
+          <IntentCountryBadge />
+        </div>
+        <IntentCountryRecommendation surface="invest" />
 
-          {/* General Advice Warning */}
-          <div className="hidden md:block bg-slate-50 border border-slate-200 rounded-lg p-3 mb-3 text-[0.69rem] text-slate-500 leading-relaxed">
-            <strong className="text-slate-600">General Advice Warning:</strong>{" "}
-            {GENERAL_ADVICE_WARNING}
+        <h1 className="text-2xl md:text-4xl font-extrabold mb-2 text-slate-900 tracking-tight">
+          Australian Investment Opportunities
+        </h1>
+        <p className="text-sm md:text-base text-slate-600 mb-3 max-w-3xl">
+          Businesses, property, projects, funds, syndicates & collectibles — all filterable in one place.
+          To compare super funds or share-trading platforms,{" "}
+          <Link href="/compare" className="text-amber-700 underline hover:no-underline">visit Compare</Link>.
+        </p>
+
+        {/* Trust pills */}
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="inline-flex items-center gap-1.5 px-3 py-1 bg-white border border-slate-200 rounded-full text-[0.65rem] md:text-xs font-semibold text-slate-700 shadow-sm">
+            <span className="w-1.5 h-1.5 bg-emerald-500 rounded-full animate-pulse" />
+            <span className="font-bold text-slate-900">{listings.length}</span> live opportunities
+          </span>
+          {firbCount > 0 && (
+            <span className="inline-flex items-center gap-1.5 px-3 py-1 bg-white border border-blue-200 rounded-full text-[0.65rem] md:text-xs font-semibold text-blue-700 shadow-sm">
+              <Icon name="globe" size={11} />
+              <span className="font-bold">{firbCount}</span> FIRB-eligible
+            </span>
+          )}
+          {sivCount > 0 && (
+            <span className="inline-flex items-center gap-1.5 px-3 py-1 bg-white border border-emerald-200 rounded-full text-[0.65rem] md:text-xs font-semibold text-emerald-700 shadow-sm">
+              <Icon name="shield-check" size={11} />
+              <span className="font-bold">{sivCount}</span> SIV-complying
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* ── Marketplace (primary — no two-step) ───────────────── */}
+      <InvestListingsClient listings={listings} categories={categoryTabs} />
+
+      {/* ── "Not sure?" CTA — moved BELOW results per UX rebuild.
+            Wedging this between filters and results was an anti-pattern
+            (browse intent hitting a "decide" CTA before any listing).
+            Below-results it's a recovery prompt. ── */}
+      <div className="container-custom max-w-5xl mb-10">
+        <GetMatchedEmbed context="opportunity" />
+      </div>
+
+      {/* ── Discovery: browse by category (single grid; sector hubs
+            merged in as commodity entries rather than a separate row). ── */}
+      <div className="container-custom max-w-6xl">
+        <div className="border-t border-slate-200 pt-8 md:pt-10 mb-10 md:mb-12">
+          <h2 className="text-lg md:text-2xl font-bold mb-1 text-slate-900">
+            Browse by sector
+          </h2>
+          <p className="text-xs md:text-sm text-slate-500 mb-4 md:mb-5">
+            Narrow the marketplace by what you&apos;re looking to invest in.
+          </p>
+          <ScrollReveal animation="scroll-fade-in">
+            <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 md:gap-4">
+              {categories.map((cat) => {
+                const accent = ACCENT_COLORS[cat.slug] || DEFAULT_ACCENT;
+                const count = getCategoryCount(cat);
+                const description = CATEGORY_DESCRIPTIONS[cat.slug] || cat.intro.slice(0, 80);
+                const icon = CATEGORY_ICONS[cat.slug] ?? <Icon name="circle" size={20} />;
+
+                return (
+                  <Link
+                    key={cat.slug}
+                    href={`/invest?category=${cat.slug}`}
+                    className={`group relative block rounded-xl border bg-white p-3 md:p-4 transition-all duration-200 hover:shadow-lg hover:scale-[1.01] ${accent.card}`}
+                  >
+                    <div className="flex items-start gap-2 mb-2">
+                      <span className={`shrink-0 p-1.5 rounded-lg ${accent.badge}`}>
+                        {icon}
+                      </span>
+                      <div className="min-w-0 flex-1">
+                        <h3 className={`font-bold text-sm md:text-base text-slate-900 transition-colors ${accent.hover}`}>
+                          {cat.label}
+                        </h3>
+                        <span className="text-[0.62rem] md:text-xs font-semibold text-slate-400 tabular-nums">
+                          {count} {count === 1 ? "listing" : "listings"}
+                        </span>
+                      </div>
+                    </div>
+                    <p className="text-[0.62rem] md:text-xs text-slate-500 leading-relaxed line-clamp-2">
+                      {description}
+                    </p>
+                  </Link>
+                );
+              })}
+            </div>
+          </ScrollReveal>
+        </div>
+      </div>
+
+      {/* ── Supply-side CTAs (compact at page bottom). ── */}
+      <div className="container-custom max-w-6xl">
+        <div className="border-t border-slate-200 pt-8 md:pt-10 pb-10 md:pb-12">
+          <h2 className="text-base md:text-lg font-bold mb-1 text-slate-900">Have an opportunity to promote?</h2>
+          <p className="text-xs text-slate-500 mb-3 md:mb-4 max-w-3xl">
+            Get your deal in front of Australian and foreign-investor traffic.
+          </p>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+            <Link href="/invest/list" className="group block rounded-xl border border-slate-200 bg-white p-3 transition-all duration-200 hover:shadow-md hover:border-amber-300">
+              <div className="flex items-center gap-2">
+                <span className="shrink-0 p-1.5 rounded-lg bg-amber-100 text-amber-700">
+                  <Icon name="plus-circle" size={16} />
+                </span>
+                <div className="min-w-0">
+                  <h3 className="font-bold text-sm text-slate-900 group-hover:text-amber-700">List an opportunity</h3>
+                  <p className="text-[0.6rem] text-slate-500 leading-snug">Business, fund, syndicate or asset.</p>
+                </div>
+              </div>
+            </Link>
+            <Link href="/advertise" className="group block rounded-xl border border-slate-200 bg-white p-3 transition-all duration-200 hover:shadow-md hover:border-amber-300">
+              <div className="flex items-center gap-2">
+                <span className="shrink-0 p-1.5 rounded-lg bg-amber-100 text-amber-700">
+                  <Icon name="star" size={16} />
+                </span>
+                <div className="min-w-0">
+                  <h3 className="font-bold text-sm text-slate-900 group-hover:text-amber-700">Featured placement</h3>
+                  <p className="text-[0.6rem] text-slate-500 leading-snug">Pinned in search, larger card, more photos.</p>
+                </div>
+              </div>
+            </Link>
+            <Link href="/contact?topic=promote-overseas" className="group block rounded-xl border border-slate-200 bg-white p-3 transition-all duration-200 hover:shadow-md hover:border-amber-300">
+              <div className="flex items-center gap-2">
+                <span className="shrink-0 p-1.5 rounded-lg bg-amber-100 text-amber-700">
+                  <Icon name="globe" size={16} />
+                </span>
+                <div className="min-w-0">
+                  <h3 className="font-bold text-sm text-slate-900 group-hover:text-amber-700">Reach overseas investors</h3>
+                  <p className="text-[0.6rem] text-slate-500 leading-snug">SIV & FIRB-targeted country placement.</p>
+                </div>
+              </div>
+            </Link>
           </div>
-          <div className="md:hidden mb-3">
-            <details className="bg-slate-50 border border-slate-200 rounded-lg">
-              <summary className="px-3 py-2 text-[0.62rem] text-slate-500 font-medium cursor-pointer flex items-center gap-1">
-                <svg className="w-3 h-3 text-amber-500 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
-                General advice only &mdash; not a personal recommendation.
-              </summary>
-              <p className="px-3 pb-2.5 text-[0.62rem] text-slate-500 leading-relaxed">
+        </div>
+      </div>
+
+      <HomeToolsStrip />
+
+      {/* ── Compliance band (page bottom; was above-the-fold before
+            the rebuild, eating 4 lines of small print before any
+            listing). Mandatory copy preserved verbatim. ── */}
+      <div className="border-t border-slate-200 bg-slate-50">
+        <div className="container-custom max-w-6xl py-5 md:py-6 space-y-2">
+          <details className="text-xs text-slate-600">
+            <summary className="font-semibold text-slate-700 cursor-pointer flex items-center gap-1.5">
+              <Icon name="shield-check" size={13} className="text-amber-500" />
+              General Advice Warning &amp; Advertiser Disclosure
+            </summary>
+            <div className="mt-2.5 space-y-2 leading-relaxed">
+              <p>
+                <strong className="text-slate-700">General Advice Warning:</strong>{" "}
                 {GENERAL_ADVICE_WARNING}
               </p>
-            </details>
-          </div>
-        </div>
-
-        {/* Per-vertical count strip */}
-        {sortedCounts.length > 0 && (
-          <div className="container-custom max-w-6xl mb-4">
-            <div className="bg-white border border-slate-200 rounded-xl p-4">
-              <p className="text-[10px] font-bold uppercase tracking-wide text-slate-500 mb-3">
-                Active listings by vertical
+              <p>
+                <strong className="text-slate-700">Advertiser Disclosure:</strong>{" "}
+                {ADVERTISER_DISCLOSURE_SHORT}
               </p>
-              <div className="flex flex-wrap gap-2">
-                {sortedCounts
-                  .filter(([slug]) => opportunityVerticalSet.has(slug))
-                  .map(([slug, count]) => (
-                    <Link
-                      key={slug}
-                      href={`/invest/${slug}/listings`}
-                      className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-slate-50 hover:bg-amber-50 border border-slate-200 hover:border-amber-200 transition-colors text-xs"
-                    >
-                      <span className="font-semibold text-slate-700 capitalize">
-                        {slug.replace(/-/g, " ")}
-                      </span>
-                      <span className="font-extrabold text-amber-700 tabular-nums">{count}</span>
-                    </Link>
-                  ))}
-              </div>
             </div>
-          </div>
-        )}
-
-        <div className="container-custom mb-6">
-          <GetMatchedEmbed context="opportunity" />
+          </details>
         </div>
-
-        {/* ── Marketplace grid (PRIMARY content — no two-step) ── */}
-        <InvestListingsClient listings={listings} categories={categoryTabs} />
-
-        {/* ── Secondary discovery: browse by category ── */}
-        <div className="container-custom max-w-6xl mt-12 md:mt-16">
-          <div className="border-t border-slate-200 pt-8 md:pt-10">
-            <h2 className="text-lg md:text-2xl font-bold mb-1 text-slate-900">
-              Browse opportunities by category
-            </h2>
-            <p className="text-xs md:text-sm text-slate-500 mb-4 md:mb-5">
-              Filter the marketplace by what you&apos;re looking to buy or invest in.
-            </p>
-            <ScrollReveal animation="scroll-fade-in">
-              <div className="grid grid-cols-2 md:grid-cols-3 gap-3 md:gap-4 mb-10 md:mb-12">
-                {categories.map((cat) => {
-                  const accent = ACCENT_COLORS[cat.slug] || DEFAULT_ACCENT;
-                  const count = getCategoryCount(cat);
-                  const description = CATEGORY_DESCRIPTIONS[cat.slug] || cat.intro.slice(0, 80);
-                  const icon = CATEGORY_ICONS[cat.slug];
-
-                  return (
-                    <Link
-                      key={cat.slug}
-                      href={`/invest/${cat.slug}/listings`}
-                      className={`group relative block rounded-xl border bg-white p-3 md:p-4 transition-all duration-200 hover:shadow-lg hover:scale-[1.01] ${accent.card}`}
-                    >
-                      <div className="flex items-start gap-2 mb-2">
-                        <span className={`shrink-0 p-1.5 rounded-lg ${accent.badge}`}>
-                          {icon}
-                        </span>
-                        <div className="min-w-0 flex-1">
-                          <h3 className={`font-bold text-sm md:text-base text-slate-900 transition-colors ${accent.hover}`}>
-                            {cat.label}
-                          </h3>
-                          <span className="text-[0.62rem] md:text-xs font-semibold text-slate-400">
-                            {count} {count === 1 ? "listing" : "listings"}
-                          </span>
-                        </div>
-                      </div>
-                      <p className="text-[0.62rem] md:text-xs text-slate-500 leading-relaxed line-clamp-2">
-                        {description}
-                      </p>
-                    </Link>
-                  );
-                })}
-              </div>
-            </ScrollReveal>
-          </div>
-        </div>
-
-        {/* ── Sector hubs (educational pillars, not marketplaces) ── */}
-        <div className="container-custom max-w-6xl">
-          <div className="border-t border-slate-200 pt-8 md:pt-10">
-            <h2 className="text-lg md:text-2xl font-bold mb-1 text-slate-900">
-              Energy &amp; commodity sector hubs
-            </h2>
-            <p className="text-xs md:text-sm text-slate-500 mb-4 md:mb-5 max-w-3xl">
-              ASX stocks, ETFs, and project-equity context across the commodities that move
-              Australian markets. These are sector guides &mdash; click through to learn the space
-              before browsing deals.
-            </p>
-            <ScrollReveal animation="scroll-fade-in">
-              <div className="grid grid-cols-2 md:grid-cols-3 gap-3 md:gap-4">
-                {SECTOR_HUBS.map((s) => {
-                  const count = verticalCounts[s.slug] || 0;
-                  return (
-                    <Link
-                      key={s.slug}
-                      href={`/invest/${s.slug}`}
-                      className={`group relative block rounded-xl border bg-white p-3 md:p-4 transition-all duration-200 hover:shadow-lg hover:scale-[1.01] ${s.accentCard}`}
-                    >
-                      <div className="flex items-start gap-2 mb-2">
-                        <span className={`shrink-0 p-1.5 rounded-lg ${s.accentBadge}`}>
-                          <Icon name={s.icon} size={18} className="" />
-                        </span>
-                        <div className="min-w-0 flex-1">
-                          <h3 className={`font-bold text-sm md:text-base text-slate-900 transition-colors ${s.accentHover}`}>
-                            {s.label}
-                          </h3>
-                          <span className="text-[0.62rem] md:text-xs font-semibold text-slate-400">
-                            {count > 0
-                              ? `${count} ${count === 1 ? "listing" : "listings"} · Sector hub`
-                              : "Sector hub"}
-                          </span>
-                        </div>
-                      </div>
-                      <p className="text-[0.62rem] md:text-xs text-slate-500 leading-relaxed line-clamp-2">
-                        {s.description}
-                      </p>
-                    </Link>
-                  );
-                })}
-              </div>
-            </ScrollReveal>
-          </div>
-        </div>
-        {/* ── Supply-side CTAs (List / Sponsor / Promote overseas) ── */}
-        <div className="container-custom max-w-6xl mt-12 md:mt-16">
-          <div className="border-t border-slate-200 pt-8 md:pt-10">
-            <h2 className="text-lg md:text-2xl font-bold mb-1 text-slate-900">
-              Have an opportunity to promote?
-            </h2>
-            <p className="text-xs md:text-sm text-slate-500 mb-4 md:mb-5 max-w-3xl">
-              Get your deal, fund or asset class in front of Australian and
-              foreign-investor traffic across this marketplace.
-            </p>
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-3 md:gap-4 mb-10 md:mb-12">
-              <Link
-                href="/invest/list"
-                className="group block rounded-xl border border-slate-200 bg-white p-4 md:p-5 transition-all duration-200 hover:shadow-lg hover:border-amber-300"
-              >
-                <div className="flex items-center gap-2 mb-2">
-                  <span className="shrink-0 p-1.5 rounded-lg bg-amber-100 text-amber-700">
-                    <Icon name="plus-circle" size={18} />
-                  </span>
-                  <h3 className="font-bold text-sm md:text-base text-slate-900 group-hover:text-amber-700">
-                    List an opportunity
-                  </h3>
-                </div>
-                <p className="text-[0.62rem] md:text-xs text-slate-500 leading-relaxed">
-                  Post a business, fund, syndicate or asset for sale. Reaches
-                  retail and wholesale buyers Australia-wide.
-                </p>
-              </Link>
-              <Link
-                href="/advertise"
-                className="group block rounded-xl border border-slate-200 bg-white p-4 md:p-5 transition-all duration-200 hover:shadow-lg hover:border-amber-300"
-              >
-                <div className="flex items-center gap-2 mb-2">
-                  <span className="shrink-0 p-1.5 rounded-lg bg-amber-100 text-amber-700">
-                    <Icon name="star" size={18} />
-                  </span>
-                  <h3 className="font-bold text-sm md:text-base text-slate-900 group-hover:text-amber-700">
-                    Become a sponsor
-                  </h3>
-                </div>
-                <p className="text-[0.62rem] md:text-xs text-slate-500 leading-relaxed">
-                  Featured placement on category pages, best-of lists and
-                  pillar articles. Disclosed advertiser relationship.
-                </p>
-              </Link>
-              <Link
-                href="/contact?topic=promote-overseas"
-                className="group block rounded-xl border border-slate-200 bg-white p-4 md:p-5 transition-all duration-200 hover:shadow-lg hover:border-amber-300"
-              >
-                <div className="flex items-center gap-2 mb-2">
-                  <span className="shrink-0 p-1.5 rounded-lg bg-amber-100 text-amber-700">
-                    <Icon name="globe" size={18} />
-                  </span>
-                  <h3 className="font-bold text-sm md:text-base text-slate-900 group-hover:text-amber-700">
-                    Promote to overseas investors
-                  </h3>
-                </div>
-                <p className="text-[0.62rem] md:text-xs text-slate-500 leading-relaxed">
-                  SIV and FIRB-relevant opportunities. Country-targeted
-                  placement on /investing-from/* and foreign-investment hubs.
-                </p>
-              </Link>
-            </div>
-          </div>
-        </div>
-
-        <HomeToolsStrip />
       </div>
     </>
   );

--- a/components/Icon.tsx
+++ b/components/Icon.tsx
@@ -621,6 +621,48 @@ const icons: Record<string, string[]> = {
     "M17.7 3.7a1 1 0 0 0-1.4 0l-4.6 4.6a1 1 0 0 0 0 1.4l2.6 2.6a1 1 0 0 0 1.4 0l4.6-4.6a1 1 0 0 0 0-1.4Z",
     "M19.686 8.314a12.501 12.501 0 0 1 1.356 10.225 1 1 0 0 1-1.752-.119 22 22 0 0 0-3.393-6.319",
   ],
+  // Icons added 2026-05 for the /invest rebuild (listing-kind variants
+  // + view-mode toggle + shortlist button states).
+  store: [
+    "M2 7h20l-1.5 4.5a2 2 0 0 1-2 1.5H5.5a2 2 0 0 1-2-1.5L2 7z",
+    "M4 13v8h16v-8",
+    "M9 21v-5h6v5",
+  ],
+  gem: [
+    "M6 3h12l4 6-10 13L2 9l4-6z",
+    "M11 3 8 9l4 13 4-13-3-6",
+    "M2 9h20",
+  ],
+  grid: [
+    "rect:3,3,7,7,1",
+    "rect:14,3,7,7,1",
+    "rect:14,14,7,7,1",
+    "rect:3,14,7,7,1",
+  ],
+  list: [
+    "M8 6h13",
+    "M8 12h13",
+    "M8 18h13",
+    "M3 6h.01",
+    "M3 12h.01",
+    "M3 18h.01",
+  ],
+  table: [
+    "rect:3,3,18,18,2",
+    "M3 9h18",
+    "M3 15h18",
+    "M9 3v18",
+    "M15 3v18",
+  ],
+  map: [
+    "M9 4 3 6v14l6-2 6 2 6-2V4l-6 2-6-2z",
+    "M9 4v16",
+    "M15 6v16",
+  ],
+  "bookmark-check": [
+    "M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z",
+    "m9 10 2 2 4-4",
+  ],
 };
 
 export default function Icon({ name, size = 24, className = "" }: IconProps) {

--- a/components/InvestListingCard.tsx
+++ b/components/InvestListingCard.tsx
@@ -3,6 +3,13 @@ import Image from "next/image";
 import type { InvestmentListing } from "@/lib/types";
 import { listingUrl } from "@/lib/listing-url";
 import { getListingHeroImage } from "@/lib/listing-vertical-images";
+import {
+  deriveListingKind,
+  listingKindMeta,
+  formatListingPrice,
+  freshnessSignal,
+} from "@/lib/listing-kind";
+import Icon from "@/components/Icon";
 import EnquireButton from "@/components/marketplace/EnquireButton";
 
 function formatLocation(state?: string, city?: string): string | null {
@@ -17,7 +24,6 @@ function formatKeyMetricValue(value: string | number | boolean): string {
 
 /**
  * Vertical → fallback gradient when listing has no images.
- * Each category gets a distinct, warm gradient so cards still look polished.
  */
 const VERTICAL_FALLBACK_GRADIENT: Record<string, string> = {
   business: "from-blue-100 via-indigo-50 to-blue-50",
@@ -30,9 +36,6 @@ const VERTICAL_FALLBACK_GRADIENT: Record<string, string> = {
   startup: "from-indigo-100 via-blue-50 to-cyan-50",
 };
 
-/**
- * Vertical → emoji icon for fallback when no images available.
- */
 const VERTICAL_ICON: Record<string, string> = {
   business: "🏢",
   commercial_property: "🏬",
@@ -44,14 +47,46 @@ const VERTICAL_ICON: Record<string, string> = {
   startup: "🚀",
 };
 
+/**
+ * Card variants:
+ *   - `grid` (default): full card with hero image (the marketplace grid)
+ *   - `list`: horizontal layout, denser, no large hero
+ *
+ * Card rendering keys off `listing_kind` (with safe derivation fallback)
+ * to pick:
+ *   - Price label ("Asking" / "Min investment" / "Raising" / "ASX")
+ *   - CTA verb ("Enquire" / "Request IM" / "Buy via broker" / "Express interest")
+ *   - Kind chip colour + icon
+ *
+ * The blanket "FIRB" badge that used to fire on every row is now gated
+ * to listings where the visitor's intent country matters AND the listing
+ * is foreign-investor-relevant — passed via the `showFirbBadge` prop so
+ * the listings client can decide once at parent level.
+ */
 export default function InvestListingCard({
   listing,
   badge,
+  variant = "grid",
+  showFirbBadge = false,
+  matchScore,
 }: {
   listing: InvestmentListing;
   badge?: string;
+  variant?: "grid" | "list";
+  /** Render the blue FIRB badge top-right. Off by default — only on
+   *  when the parent surface has a visitor-country signal that makes
+   *  the FIRB lens meaningful. */
+  showFirbBadge?: boolean;
+  /** Optional 0–100 smart-match score. Renders a green pill bottom-left
+   *  on the hero when set. (Wired up in Wave 3.) */
+  matchScore?: number;
 }) {
+  const kind = deriveListingKind(listing);
+  const meta = listingKindMeta(kind);
+  const fresh = freshnessSignal(listing);
+  const price = formatListingPrice(listing);
   const location = formatLocation(listing.location_state, listing.location_city);
+
   const metricEntries = listing.key_metrics
     ? Object.entries(listing.key_metrics).slice(0, 3)
     : [];
@@ -69,15 +104,107 @@ export default function InvestListingCard({
   const heroIsSeed = !dbHeroImage;
   const fallbackGradient = VERTICAL_FALLBACK_GRADIENT[listing.vertical] ?? "from-slate-100 to-slate-50";
   const fallbackIcon = VERTICAL_ICON[listing.vertical] ?? "📊";
+  const isFeatured = listing.listing_type === "featured" || listing.listing_type === "premium";
 
+  // ── List variant ──────────────────────────────────────────────────
+  if (variant === "list") {
+    return (
+      <Link
+        href={listingUrl(listing)}
+        className={`group flex gap-4 rounded-xl border bg-white p-3 shadow-sm hover:shadow-md hover:-translate-y-0.5 transition-all duration-200 ${meta.accent.border}`}
+      >
+        {/* Compact thumb */}
+        <div className="relative w-32 h-24 sm:w-40 sm:h-28 rounded-lg overflow-hidden shrink-0 bg-slate-100">
+          {heroImage ? (
+            <Image
+              src={heroImage}
+              alt={listing.title}
+              fill
+              sizes="160px"
+              className="object-cover transition-transform duration-500 group-hover:scale-105"
+              loading="lazy"
+            />
+          ) : (
+            <div className={`absolute inset-0 bg-gradient-to-br ${fallbackGradient} flex items-center justify-center text-3xl opacity-40`}>
+              {fallbackIcon}
+            </div>
+          )}
+          {heroImage && heroIsSeed && (
+            <div className={`absolute inset-0 bg-gradient-to-br ${fallbackGradient} opacity-30 mix-blend-multiply`} />
+          )}
+          {/* Top-left kind badge */}
+          <span className={`absolute top-1.5 left-1.5 inline-flex items-center gap-1 ${meta.accent.badge} text-[0.55rem] font-extrabold uppercase tracking-wider px-1.5 py-0.5 rounded shadow-sm`}>
+            <Icon name={meta.icon} size={9} />
+            {meta.label}
+          </span>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 min-w-0 flex flex-col">
+          <div className="flex items-start justify-between gap-2">
+            <h3 className={`font-bold text-sm md:text-base text-slate-900 line-clamp-2 leading-snug ${meta.accent.text.replace("text-", "group-hover:text-")}`}>
+              {listing.title}
+            </h3>
+            {price && (
+              <div className="shrink-0 text-right">
+                <div className="text-[0.55rem] text-slate-400 uppercase tracking-wide font-semibold">{price.label}</div>
+                <div className="text-sm font-extrabold text-slate-900">{price.value}</div>
+              </div>
+            )}
+          </div>
+          <div className="flex items-center gap-2 mt-1 text-xs text-slate-500 flex-wrap">
+            {location && (
+              <span className="inline-flex items-center gap-0.5">
+                <Icon name="map-pin" size={11} className="text-slate-400" />
+                {location}
+              </span>
+            )}
+            {listing.industry && <span>· {listing.industry}</span>}
+            {fresh === "new_this_week" && (
+              <span className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full bg-emerald-50 text-emerald-700 text-[0.55rem] font-bold uppercase tracking-wide">
+                New
+              </span>
+            )}
+            {fresh === "closing_soon" && (
+              <span className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full bg-rose-50 text-rose-700 text-[0.55rem] font-bold uppercase tracking-wide">
+                Closing soon
+              </span>
+            )}
+            {isFeatured && (
+              <span className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full bg-amber-100 text-amber-700 text-[0.55rem] font-bold uppercase tracking-wide">
+                ★ Featured
+              </span>
+            )}
+            {matchScore != null && (
+              <span className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full bg-emerald-600 text-white text-[0.55rem] font-bold uppercase tracking-wide">
+                {matchScore}% match
+              </span>
+            )}
+          </div>
+          {metricEntries.length > 0 && (
+            <div className="mt-auto pt-2 flex gap-3 text-[0.62rem] text-slate-600">
+              {metricEntries.map(([k, v]) => (
+                <span key={k}>
+                  <span className="text-slate-400 capitalize">{k.replace(/_/g, " ")}: </span>
+                  <span className="font-semibold text-slate-800">{formatKeyMetricValue(v)}</span>
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      </Link>
+    );
+  }
+
+  // ── Grid variant (default) ────────────────────────────────────────
   return (
     <Link
       href={listingUrl(listing)}
-      className="group relative block overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm hover:shadow-xl hover:border-slate-300 transition-all duration-300 hover:-translate-y-0.5"
+      className={`group relative block overflow-hidden rounded-2xl border bg-white shadow-sm hover:shadow-xl hover:border-slate-300 transition-all duration-300 hover:-translate-y-0.5 ${meta.accent.border} ${
+        isFeatured ? "ring-1 ring-amber-200/80 shadow-amber-50" : ""
+      }`}
     >
-      {/* Hero image — DB image when present, otherwise a deterministic
-          seed image from the listing's vertical. The gradient + emoji
-          path remains as a final guard if the seed pool is exhausted. */}
+      {/* Hero image */}
       <div className="relative aspect-[16/10] overflow-hidden bg-slate-100">
         {heroImage ? (
           <>
@@ -104,65 +231,79 @@ export default function InvestListingCard({
           </div>
         )}
 
-        {/* Top-left badges (Featured / pick) */}
-        {(badge || listing.listing_type === "featured") && (
-          <div className="absolute top-3 left-3 flex flex-wrap gap-1.5">
-            {listing.listing_type === "featured" && (
-              <span className="bg-amber-500 text-slate-900 text-[0.62rem] font-extrabold uppercase tracking-wider px-2 py-1 rounded-md shadow-sm">
-                ★ Featured
-              </span>
-            )}
-            {badge && (
-              <span className="bg-white/95 backdrop-blur text-slate-800 text-[0.62rem] font-extrabold uppercase tracking-wider px-2 py-1 rounded-md shadow-sm">
-                {badge}
-              </span>
-            )}
-          </div>
-        )}
+        {/* Top-left badges: kind + featured + provided badge */}
+        <div className="absolute top-3 left-3 flex flex-wrap gap-1.5 max-w-[70%]">
+          <span className={`inline-flex items-center gap-1 ${meta.accent.badge} text-[0.62rem] font-extrabold uppercase tracking-wider px-2 py-1 rounded-md shadow-sm`}>
+            <Icon name={meta.icon} size={10} />
+            {meta.label}
+          </span>
+          {isFeatured && (
+            <span className="bg-amber-500 text-slate-900 text-[0.62rem] font-extrabold uppercase tracking-wider px-2 py-1 rounded-md shadow-sm">
+              ★ Featured
+            </span>
+          )}
+          {badge && (
+            <span className="bg-white/95 backdrop-blur text-slate-800 text-[0.62rem] font-extrabold uppercase tracking-wider px-2 py-1 rounded-md shadow-sm">
+              {badge}
+            </span>
+          )}
+        </div>
 
-        {/* Top-right compliance badges */}
-        {(listing.firb_eligible || listing.siv_complying) && (
-          <div className="absolute top-3 right-3 flex gap-1.5">
-            {listing.firb_eligible && (
-              <span className="bg-blue-600 text-white text-[0.6rem] font-extrabold uppercase tracking-wider px-2 py-1 rounded-md shadow-sm">
-                FIRB
-              </span>
-            )}
-            {listing.siv_complying && (
-              <span className="bg-emerald-600 text-white text-[0.6rem] font-extrabold uppercase tracking-wider px-2 py-1 rounded-md shadow-sm">
-                SIV
-              </span>
-            )}
-          </div>
-        )}
+        {/* Top-right compliance + freshness */}
+        <div className="absolute top-3 right-3 flex flex-wrap gap-1.5 justify-end max-w-[40%]">
+          {showFirbBadge && listing.firb_eligible && (
+            <span className="bg-blue-600 text-white text-[0.6rem] font-extrabold uppercase tracking-wider px-2 py-1 rounded-md shadow-sm">
+              FIRB
+            </span>
+          )}
+          {listing.siv_complying && (
+            <span className="bg-emerald-600 text-white text-[0.6rem] font-extrabold uppercase tracking-wider px-2 py-1 rounded-md shadow-sm">
+              SIV
+            </span>
+          )}
+          {fresh === "new_this_week" && (
+            <span className="bg-emerald-500 text-white text-[0.6rem] font-extrabold uppercase tracking-wider px-2 py-1 rounded-md shadow-sm">
+              New
+            </span>
+          )}
+          {fresh === "closing_soon" && (
+            <span className="bg-rose-500 text-white text-[0.6rem] font-extrabold uppercase tracking-wider px-2 py-1 rounded-md shadow-sm">
+              Closing
+            </span>
+          )}
+        </div>
 
         {/* Bottom price overlay */}
-        {listing.price_display && (
-          <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent p-3">
-            <div className="text-white text-xs font-semibold opacity-80 uppercase tracking-wide">Asking</div>
-            <div className="text-white text-lg font-extrabold">{listing.price_display}</div>
+        {price && (
+          <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/80 via-black/40 to-transparent p-3">
+            <div className="flex items-end justify-between gap-2">
+              <div>
+                <div className="text-white text-[0.65rem] font-semibold opacity-80 uppercase tracking-wide">{price.label}</div>
+                <div className="text-white text-lg font-extrabold leading-tight">{price.value}</div>
+              </div>
+              {matchScore != null && (
+                <span className="bg-emerald-500 text-white text-[0.6rem] font-extrabold uppercase tracking-wider px-2 py-1 rounded-md shadow-sm">
+                  {matchScore}% match
+                </span>
+              )}
+            </div>
           </div>
         )}
       </div>
 
       {/* Content */}
       <div className="p-4">
-        {/* Title */}
-        <h3 className="font-bold text-base text-slate-900 group-hover:text-emerald-700 transition-colors line-clamp-2 mb-1.5 leading-snug">
+        <h3 className={`font-bold text-base text-slate-900 transition-colors line-clamp-2 mb-1.5 leading-snug ${meta.accent.text.replace("text-", "group-hover:text-")}`}>
           {listing.title}
         </h3>
 
-        {/* Location */}
         {location && (
           <p className="flex items-center gap-1 text-xs text-slate-500 mb-3">
-            <svg className="w-3 h-3 text-slate-400" fill="currentColor" viewBox="0 0 20 20">
-              <path fillRule="evenodd" d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z" clipRule="evenodd" />
-            </svg>
+            <Icon name="map-pin" size={11} className="text-slate-400" />
             {location}
           </p>
         )}
 
-        {/* Industry / sub-category pills */}
         {(listing.industry || listing.sub_category) && (
           <div className="flex flex-wrap items-center gap-1 mb-3">
             {listing.industry && (
@@ -178,7 +319,6 @@ export default function InvestListingCard({
           </div>
         )}
 
-        {/* Key metrics row */}
         {metricEntries.length > 0 && (
           <div className="grid grid-cols-3 gap-2 pt-3 mt-2 border-t border-slate-100">
             {metricEntries.map(([key, value]) => (
@@ -194,20 +334,24 @@ export default function InvestListingCard({
           </div>
         )}
 
-        {/* CTA row — Enquire button is a sibling <button> but we rely
-            on event.preventDefault + stopPropagation inside
-            EnquireButton to prevent the outer <Link> from firing. */}
+        {/* CTA row — kind-aware verb. Listed securities use an external
+            "Buy via broker" link to /compare instead of the Enquire flow. */}
         <div className="flex items-center gap-2 mt-4 pt-3 border-t border-slate-100">
-          <EnquireButton
-            listingId={listing.id}
-            listingTitle={listing.title}
-            buttonCls="bg-amber-500 hover:bg-amber-600 text-white"
-          />
-          <span className="flex-1 inline-flex items-center justify-end gap-1 text-xs font-bold text-emerald-600 group-hover:text-emerald-700 group-hover:gap-2 transition-all">
+          {meta.externalCta ? (
+            <span className={`inline-flex items-center gap-1 text-xs font-bold ${meta.accent.text}`}>
+              <Icon name="external-link" size={12} />
+              {meta.ctaLabel}
+            </span>
+          ) : (
+            <EnquireButton
+              listingId={listing.id}
+              listingTitle={listing.title}
+              buttonCls="bg-amber-500 hover:bg-amber-600 text-white"
+            />
+          )}
+          <span className={`flex-1 inline-flex items-center justify-end gap-1 text-xs font-bold ${meta.accent.text} group-hover:gap-2 transition-all`}>
             View Details
-            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M9 5l7 7-7 7" />
-            </svg>
+            <Icon name="chevron-right" size={12} />
           </span>
         </div>
       </div>

--- a/components/InvestListingsClient.tsx
+++ b/components/InvestListingsClient.tsx
@@ -1,11 +1,24 @@
 "use client";
 
 import Link from "next/link";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter, useSearchParams, usePathname } from "next/navigation";
-import type { InvestmentListing } from "@/lib/types";
+import type { InvestmentListing, ListingKind } from "@/lib/types";
 import { categoryForListing } from "@/lib/listing-url";
+import {
+  ALL_LISTING_KINDS,
+  TICKET_BUCKETS,
+  ticketBucketByKey,
+  INVESTOR_TYPES,
+  type InvestorType,
+  deriveListingKind,
+  listingKindMeta,
+  filterSpecForKind,
+  formatListingPrice,
+  freshnessSignal,
+} from "@/lib/listing-kind";
 import InvestListingCard from "@/components/InvestListingCard";
+import Icon from "@/components/Icon";
 
 // ─── Props ───────────────────────────────────────────────────────────
 export interface InvestListingsClientProps {
@@ -13,77 +26,47 @@ export interface InvestListingsClientProps {
   categories: { slug: string; label: string }[];
   initialCategory?: string;
   initialSubcategory?: string;
-  /**
-   * When set, the filter is locked to this category and the
-   * global category tab bar is hidden. Used on every
-   * /invest/[vertical]/listings page to prevent a ?category=
-   * URL param bleeding in from other pages and collapsing the
-   * result set to zero.
-   */
+  /** Vertical-listings pages pass this to lock the category and hide
+   *  the global category tab bar. */
   lockedCategory?: string;
-  /**
-   * Optional page title rendered above filters. Required on
-   * vertical listings pages per Phase 1D spec.
-   */
   pageTitle?: string;
-  /**
-   * Optional page subtitle / lead paragraph.
-   */
   pageSubtitle?: string;
+  /** Optional: visitor's intent country (set on FIRB / foreign-investment
+   *  funnels). When set, the FIRB badge on cards becomes meaningful and
+   *  the "FIRB eligible only" toggle is auto-surfaced in filters. */
+  intentCountry?: string | null;
 }
-
-// ─── Category colors (pill styling) ─────────────────────────────────
-const CATEGORY_COLORS: Record<
-  string,
-  { bg: string; text: string; ring: string }
-> = {
-  all: { bg: "bg-slate-100", text: "text-slate-700", ring: "ring-slate-300" },
-  "buy-business": { bg: "bg-blue-100", text: "text-blue-700", ring: "ring-blue-300" },
-  mining: { bg: "bg-amber-100", text: "text-amber-700", ring: "ring-amber-300" },
-  farmland: { bg: "bg-green-100", text: "text-green-700", ring: "ring-green-300" },
-  "commercial-property": { bg: "bg-slate-100", text: "text-slate-700", ring: "ring-slate-400" },
-  franchise: { bg: "bg-purple-100", text: "text-purple-700", ring: "ring-purple-300" },
-  "renewable-energy": { bg: "bg-emerald-100", text: "text-emerald-700", ring: "ring-emerald-300" },
-  startups: { bg: "bg-indigo-100", text: "text-indigo-700", ring: "ring-indigo-300" },
-  "pre-ipo": { bg: "bg-red-100", text: "text-red-700", ring: "ring-red-300" },
-  alternatives: { bg: "bg-rose-100", text: "text-rose-700", ring: "ring-rose-300" },
-  "private-credit": { bg: "bg-teal-100", text: "text-teal-700", ring: "ring-teal-300" },
-  infrastructure: { bg: "bg-cyan-100", text: "text-cyan-700", ring: "ring-cyan-300" },
-  funds: { bg: "bg-violet-100", text: "text-violet-700", ring: "ring-violet-300" },
-};
 
 // ─── Australian states ───────────────────────────────────────────────
 const STATES = ["NSW", "VIC", "QLD", "WA", "SA", "TAS", "ACT", "NT"] as const;
 
-// ─── Price ranges ────────────────────────────────────────────────────
-// URL-friendly keys so `?price=500k-1m` is human readable. Older index
-// params (`?price=3`) remain supported as a fallback for inbound links.
-const PRICE_RANGES = [
-  { key: "", label: "Any price", min: 0, max: Infinity },
-  { key: "under-100k", label: "Under $100k", min: 0, max: 10_000_000 },
-  { key: "100k-500k", label: "$100k – $500k", min: 10_000_000, max: 50_000_000 },
-  { key: "500k-1m", label: "$500k – $1M", min: 50_000_000, max: 100_000_000 },
-  { key: "1m-5m", label: "$1M – $5M", min: 100_000_000, max: 500_000_000 },
-  { key: "5m-plus", label: "$5M+", min: 500_000_000, max: Infinity },
-] as const;
-
 // ─── Sort options ────────────────────────────────────────────────────
-type SortKey = "newest" | "price-asc" | "price-desc";
+type SortKey = "newest" | "price-asc" | "price-desc" | "popular" | "closing-soon";
 const SORT_OPTIONS: { value: SortKey; label: string }[] = [
-  { value: "newest", label: "Newest" },
+  { value: "newest", label: "Newest first" },
   { value: "price-asc", label: "Price: low to high" },
   { value: "price-desc", label: "Price: high to low" },
+  { value: "popular", label: "Most viewed" },
+  { value: "closing-soon", label: "Closing soon" },
 ];
 
-/** Resolve the current price range index from the URL param, accepting
- *  both the new key form (`?price=500k-1m`) and the legacy numeric
- *  form (`?price=3`). Returns 0 (any) for anything unrecognised. */
-function resolvePriceIdx(raw: string | null): number {
-  if (!raw) return 0;
+// ─── View modes ──────────────────────────────────────────────────────
+type ViewMode = "grid" | "list" | "table";
+const VIEW_MODES: { value: ViewMode; label: string; icon: string }[] = [
+  { value: "grid", label: "Grid", icon: "grid" },
+  { value: "list", label: "List", icon: "list" },
+  { value: "table", label: "Table", icon: "table" },
+];
+
+function resolveTicketBucketKey(raw: string | null): string {
+  if (!raw) return "";
+  // Legacy numeric index form (?price=3) → translate to new key
   const asNum = Number(raw);
-  if (!Number.isNaN(asNum) && asNum >= 0 && asNum < PRICE_RANGES.length) return asNum;
-  const idx = PRICE_RANGES.findIndex((r) => r.key === raw);
-  return idx >= 0 ? idx : 0;
+  if (!Number.isNaN(asNum) && asNum >= 0 && asNum < TICKET_BUCKETS.length) {
+    return TICKET_BUCKETS[asNum].key;
+  }
+  // New key form (?price=100k-1m)
+  return TICKET_BUCKETS.some((b) => b.key === raw) ? raw : "";
 }
 
 function prettyCategory(slug: string, categories: { slug: string; label: string }[]): string {
@@ -100,37 +83,51 @@ export default function InvestListingsClient({
   lockedCategory,
   pageTitle,
   pageSubtitle,
+  intentCountry,
 }: InvestListingsClientProps) {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
-  // When a vertical listings page passes lockedCategory, that value
-  // wins unconditionally — a ?category= URL param from another page
-  // must not bleed in. Otherwise fall back to the URL search param,
-  // then the initial prop, then 'all'.
+  // ── State from URL (single source of truth — keeps Back/Forward + sharing working) ──
   const activeCategory = lockedCategory
     ? lockedCategory
     : (searchParams.get("category") ?? initialCategory ?? "all");
   const activeSubcategory = searchParams.get("sub") ?? initialSubcategory ?? "";
   const activeState = searchParams.get("state") ?? "";
-  const activePriceIdx = resolvePriceIdx(searchParams.get("price"));
+  const activeTicket = resolveTicketBucketKey(searchParams.get("price"));
   const activeSort = (searchParams.get("sort") ?? "newest") as SortKey;
-  // FIRB-eligibility filter — typically auto-applied for users who came
-  // through a /foreign-investment/<country> page (and therefore have an
-  // intent-country cookie). Leaves all listings visible by default for
-  // domestic users.
-  const activeFirbOnly = searchParams.get("firb") === "eligible";
+  const activeView = (searchParams.get("view") ?? "grid") as ViewMode;
 
-  // Keyword search is a separate, local state rather than a URL param
-  // so typing doesn't spam history entries. Submitting (Enter or
-  // natural debounce via filter) applies it to the grid.
+  // Kind filter — `?kind=fund` narrows to one listing kind. Multi-kind
+  // selection encoded as comma-separated values.
+  const activeKindsRaw = searchParams.get("kind") ?? "";
+  const activeKinds = useMemo(
+    () => new Set(activeKindsRaw.split(",").filter(Boolean) as ListingKind[]),
+    [activeKindsRaw],
+  );
+
+  // Universal advanced filters
+  const activeInvestorType = (searchParams.get("investor") ?? "") as InvestorType;
+  const activeFirbOnly = searchParams.get("firb") === "eligible";
+  const activeSivOnly = searchParams.get("siv") === "complying";
+  const activeWholesaleOnly = searchParams.get("wholesale") === "true";
+  const activeFreshness = searchParams.get("fresh") ?? ""; // 'new_this_week' | 'closing_soon'
+  const activeFeaturedOnly = searchParams.get("featured") === "true";
+  const activeMinYield = searchParams.get("min_yield") ?? ""; // numeric % string
+  const activeEsicOnly = searchParams.get("esic") === "true";
+
+  // Free-text search (URL-backed so back-button works + share-able)
   const initialQuery = searchParams.get("q") ?? "";
   const [searchInput, setSearchInput] = useState(initialQuery);
+  useEffect(() => { setSearchInput(initialQuery); }, [initialQuery]);
   const activeQuery = initialQuery.toLowerCase();
 
-  // Build new URLSearchParams and push
-  const setParam = useCallback(
+  // Filter drawer open state — kept local, never persisted
+  const [drawerOpen, setDrawerOpen] = useState(false);
+
+  // ── URL update helper ──
+  const setParams = useCallback(
     (updates: Record<string, string>) => {
       const next = new URLSearchParams(searchParams.toString());
       for (const [k, v] of Object.entries(updates)) {
@@ -142,24 +139,30 @@ export default function InvestListingsClient({
     [router, pathname, searchParams],
   );
 
-  const clearAll = useCallback(() => {
+  const clearAllFilters = useCallback(() => {
     const next = new URLSearchParams(searchParams.toString());
-    for (const key of ["category", "sub", "state", "price", "sort", "q", "firb"]) {
+    for (const key of [
+      "category", "sub", "state", "price", "sort", "q", "firb", "siv",
+      "wholesale", "investor", "kind", "fresh", "featured", "min_yield", "esic",
+    ]) {
       next.delete(key);
     }
-    if (lockedCategory) next.delete("category");
+    // View mode is a display preference, NOT a filter — preserve it.
     setSearchInput("");
     router.replace(`${pathname}?${next.toString()}`, { scroll: false });
-  }, [router, pathname, searchParams, lockedCategory]);
+  }, [router, pathname, searchParams]);
 
-  const submitSearch = useCallback(
-    (q: string) => {
-      setParam({ q: q.trim() });
-    },
-    [setParam],
-  );
+  const toggleKind = useCallback((k: ListingKind) => {
+    const next = new Set(activeKinds);
+    if (next.has(k)) next.delete(k); else next.add(k);
+    setParams({ kind: Array.from(next).join(",") });
+  }, [activeKinds, setParams]);
 
-  // Derive unique sub_categories for the active category
+  const submitSearch = useCallback((q: string) => {
+    setParams({ q: q.trim() });
+  }, [setParams]);
+
+  // ── Derived sub-categories for the active category ──
   const subCategories = useMemo(() => {
     if (activeCategory === "all") return [];
     const subs = new Set<string>();
@@ -171,9 +174,33 @@ export default function InvestListingsClient({
     return Array.from(subs).sort();
   }, [listings, activeCategory]);
 
-  // ── Filter + sort ──
+  // ── Per-kind counts for the segmented control ──
+  const kindCounts = useMemo(() => {
+    const counts: Record<string, number> = { all: listings.length };
+    for (const l of listings) {
+      const k = deriveListingKind(l);
+      counts[k] = (counts[k] ?? 0) + 1;
+    }
+    return counts;
+  }, [listings]);
+
+  // ── Per-category counts ──
+  const categoryCounts = useMemo(() => {
+    const counts: Record<string, number> = { all: listings.length };
+    for (const l of listings) {
+      const c = categoryForListing(l);
+      if (c) counts[c] = (counts[c] ?? 0) + 1;
+    }
+    return counts;
+  }, [listings]);
+
+  // ── The main filter + sort pipeline ──
   const filtered = useMemo(() => {
     let result = listings;
+
+    if (activeKinds.size > 0) {
+      result = result.filter((l) => activeKinds.has(deriveListingKind(l)));
+    }
 
     if (activeCategory !== "all") {
       result = result.filter((l) => categoryForListing(l) === activeCategory);
@@ -187,24 +214,27 @@ export default function InvestListingsClient({
       result = result.filter((l) => l.location_state === activeState);
     }
 
-    if (activePriceIdx > 0 && activePriceIdx < PRICE_RANGES.length) {
-      const range = PRICE_RANGES[activePriceIdx];
+    if (activeTicket) {
+      const range = ticketBucketByKey(activeTicket);
       result = result.filter((l) => {
-        const p = l.asking_price_cents;
-        if (p == null) return false;
-        return p >= range.min && p < range.max;
+        const km = (l.key_metrics ?? {}) as Record<string, unknown>;
+        const minInvest = km["min_investment_aud"] ?? km["min_commit_aud"] ?? km["min_investment"];
+        const minInvestCents = typeof minInvest === "number" ? minInvest * 100 : undefined;
+        const ticket = l.asking_price_cents ?? minInvestCents;
+        if (ticket == null) return false;
+        return ticket >= range.min && ticket < range.max;
       });
     }
 
     if (activeQuery) {
       result = result.filter((l) => {
+        const km = (l.key_metrics ?? {}) as Record<string, unknown>;
         const haystack = [
-          l.title,
-          l.description,
-          l.location_city,
-          l.location_state,
-          l.industry,
-          l.sub_category,
+          l.title, l.description, l.location_city, l.location_state,
+          l.industry, l.sub_category,
+          String(km["asx_ticker"] ?? ""),
+          String(km["brand"] ?? ""),
+          String(km["commodity"] ?? ""),
         ]
           .filter((x): x is string => typeof x === "string")
           .join(" ")
@@ -213,228 +243,215 @@ export default function InvestListingsClient({
       });
     }
 
-    if (activeFirbOnly) {
-      result = result.filter((l) => l.firb_eligible === true);
+    if (activeFirbOnly) result = result.filter((l) => l.firb_eligible === true);
+    if (activeSivOnly) result = result.filter((l) => l.siv_complying === true);
+
+    if (activeWholesaleOnly) {
+      result = result.filter((l) => {
+        const km = (l.key_metrics ?? {}) as Record<string, unknown>;
+        return km["wholesale_only"] === true || km["s708_required"] === true || km["accredited_only"] === true;
+      });
     }
 
+    if (activeInvestorType === "retail") {
+      result = result.filter((l) => {
+        const km = (l.key_metrics ?? {}) as Record<string, unknown>;
+        const wholesaleOnly = km["wholesale_only"] === true || km["s708_required"] === true || km["accredited_only"] === true;
+        return !wholesaleOnly || km["open_to_retail"] === true;
+      });
+    }
+    if (activeInvestorType === "siv") {
+      result = result.filter((l) => l.siv_complying === true);
+    }
+
+    if (activeFreshness === "new_this_week") {
+      result = result.filter((l) => freshnessSignal(l) === "new_this_week");
+    }
+    if (activeFreshness === "closing_soon") {
+      result = result.filter((l) => freshnessSignal(l) === "closing_soon");
+    }
+
+    if (activeFeaturedOnly) {
+      result = result.filter((l) => l.listing_type === "featured" || l.listing_type === "premium");
+    }
+
+    if (activeMinYield) {
+      const minYield = Number(activeMinYield);
+      if (!Number.isNaN(minYield)) {
+        result = result.filter((l) => {
+          const km = (l.key_metrics ?? {}) as Record<string, unknown>;
+          const candidates = [
+            km["distribution_yield"], km["target_yield_pct"], km["target_yield_pa"],
+            km["dividend_yield"], km["yield_percent"], km["target_irr_percent"],
+            km["target_irr"], km["historical_return_pa"], km["return_5yr_pa"],
+            km["target_return_pa"], km["estimated_return_percent"],
+          ];
+          for (const c of candidates) {
+            if (typeof c === "number" && c >= minYield) return true;
+            if (typeof c === "string") {
+              const n = Number(c.replace(/[^\d.]/g, ""));
+              if (!Number.isNaN(n) && n >= minYield) return true;
+            }
+          }
+          return false;
+        });
+      }
+    }
+
+    if (activeEsicOnly) {
+      result = result.filter((l) => {
+        const km = (l.key_metrics ?? {}) as Record<string, unknown>;
+        return km["esic_eligible"] === true;
+      });
+    }
+
+    // Sort
     const sorted = [...result];
-    if (activeSort === "newest") {
-      sorted.sort((a, b) => b.created_at.localeCompare(a.created_at));
-    } else if (activeSort === "price-asc") {
-      sorted.sort(
-        (a, b) => (a.asking_price_cents ?? 0) - (b.asking_price_cents ?? 0),
-      );
-    } else {
-      sorted.sort(
-        (a, b) => (b.asking_price_cents ?? 0) - (a.asking_price_cents ?? 0),
-      );
+    switch (activeSort) {
+      case "newest":
+        sorted.sort((a, b) => b.created_at.localeCompare(a.created_at));
+        break;
+      case "price-asc":
+        sorted.sort((a, b) => (a.asking_price_cents ?? Infinity) - (b.asking_price_cents ?? Infinity));
+        break;
+      case "price-desc":
+        sorted.sort((a, b) => (b.asking_price_cents ?? 0) - (a.asking_price_cents ?? 0));
+        break;
+      case "popular":
+        sorted.sort((a, b) => (b.views ?? 0) - (a.views ?? 0));
+        break;
+      case "closing-soon":
+        sorted.sort((a, b) => {
+          const ax = a.expires_at ? new Date(a.expires_at).getTime() : Infinity;
+          const bx = b.expires_at ? new Date(b.expires_at).getTime() : Infinity;
+          return ax - bx;
+        });
+        break;
     }
 
     return sorted;
   }, [
-    listings,
-    activeCategory,
-    activeSubcategory,
-    activeState,
-    activePriceIdx,
-    activeSort,
-    activeQuery,
-    activeFirbOnly,
+    listings, activeKinds, activeCategory, activeSubcategory, activeState,
+    activeTicket, activeQuery, activeFirbOnly, activeSivOnly, activeWholesaleOnly,
+    activeInvestorType, activeFreshness, activeFeaturedOnly, activeMinYield,
+    activeEsicOnly, activeSort,
   ]);
 
-  // Build a list of active-filter chips so the reader can see exactly
-  // what's filtering the results + remove any one with a click.
+  // ── Active-filter chips ──
   const activeChips: Array<{ label: string; onClear: () => void }> = [];
   if (!lockedCategory && activeCategory !== "all") {
     activeChips.push({
       label: `Category: ${prettyCategory(activeCategory, categories)}`,
-      onClear: () => setParam({ category: "", sub: "" }),
+      onClear: () => setParams({ category: "", sub: "" }),
+    });
+  }
+  if (activeKinds.size > 0) {
+    Array.from(activeKinds).forEach((k) => {
+      const meta = listingKindMeta(k);
+      activeChips.push({ label: meta.label, onClear: () => toggleKind(k) });
     });
   }
   if (activeSubcategory) {
-    activeChips.push({
-      label: `Sub: ${activeSubcategory.replace(/_/g, " ")}`,
-      onClear: () => setParam({ sub: "" }),
-    });
+    activeChips.push({ label: `Sub: ${activeSubcategory.replace(/_/g, " ")}`, onClear: () => setParams({ sub: "" }) });
   }
   if (activeState) {
+    activeChips.push({ label: `State: ${activeState}`, onClear: () => setParams({ state: "" }) });
+  }
+  if (activeTicket) {
+    activeChips.push({ label: `Ticket: ${ticketBucketByKey(activeTicket).label}`, onClear: () => setParams({ price: "" }) });
+  }
+  if (activeInvestorType) {
     activeChips.push({
-      label: `State: ${activeState}`,
-      onClear: () => setParam({ state: "" }),
+      label: INVESTOR_TYPES.find((t) => t.value === activeInvestorType)?.label ?? activeInvestorType,
+      onClear: () => setParams({ investor: "" }),
     });
   }
-  if (activePriceIdx > 0) {
+  if (activeFirbOnly) activeChips.push({ label: "FIRB-eligible", onClear: () => setParams({ firb: "" }) });
+  if (activeSivOnly) activeChips.push({ label: "SIV-complying", onClear: () => setParams({ siv: "" }) });
+  if (activeWholesaleOnly) activeChips.push({ label: "Wholesale only", onClear: () => setParams({ wholesale: "" }) });
+  if (activeFreshness) {
     activeChips.push({
-      label: `Price: ${PRICE_RANGES[activePriceIdx].label}`,
-      onClear: () => setParam({ price: "" }),
+      label: activeFreshness === "new_this_week" ? "New this week" : "Closing soon",
+      onClear: () => setParams({ fresh: "" }),
     });
   }
+  if (activeFeaturedOnly) activeChips.push({ label: "Featured only", onClear: () => setParams({ featured: "" }) });
+  if (activeMinYield) activeChips.push({ label: `Yield ≥ ${activeMinYield}%`, onClear: () => setParams({ min_yield: "" }) });
+  if (activeEsicOnly) activeChips.push({ label: "ESIC-eligible", onClear: () => setParams({ esic: "" }) });
   if (activeQuery) {
     activeChips.push({
       label: `"${initialQuery}"`,
-      onClear: () => {
-        setSearchInput("");
-        setParam({ q: "" });
-      },
-    });
-  }
-  if (activeFirbOnly) {
-    activeChips.push({
-      label: "FIRB-eligible only",
-      onClear: () => setParam({ firb: "" }),
+      onClear: () => { setSearchInput(""); setParams({ q: "" }); },
     });
   }
 
-  // All category tabs (prepend "All")
+  // Drive kind-specific filters off the active narrowed kind.
+  const narrowedKind: ListingKind | null = activeKinds.size === 1 ? Array.from(activeKinds)[0] : null;
+  const kindSpec = filterSpecForKind(narrowedKind);
+
   const tabs = useMemo(
     () => [{ slug: "all", label: "All" }, ...categories],
     [categories],
   );
 
-  const lockedCategoryLabel = lockedCategory
-    ? prettyCategory(lockedCategory, categories)
-    : null;
-  const lockedCategoryColors = lockedCategory
-    ? CATEGORY_COLORS[lockedCategory] ?? CATEGORY_COLORS.all
-    : null;
+  const lockedCategoryLabel = lockedCategory ? prettyCategory(lockedCategory, categories) : null;
 
   return (
     <div>
+      {/* ── Page-header band (vertical-listings pages only) ────── */}
       {pageTitle && (
         <div className="bg-white border-b border-slate-100 py-6 md:py-8">
           <div className="container-custom">
-            {/* Filtered-view framing: makes clear this is a slice of the
-                main /invest marketplace, not a separate catalogue. Only
-                renders when a vertical listings page locks the category. */}
-            {lockedCategory && lockedCategoryLabel && lockedCategoryColors && (
+            {lockedCategory && lockedCategoryLabel && (
               <div className="flex items-center gap-2 mb-3 text-xs flex-wrap">
-                <Link
-                  href="/invest"
-                  className="text-slate-500 hover:text-slate-900 font-semibold inline-flex items-center gap-1 transition-colors"
-                >
+                <Link href="/invest" className="text-slate-500 hover:text-slate-900 font-semibold inline-flex items-center gap-1 transition-colors">
                   <span aria-hidden="true">←</span> Browse all listings
                 </Link>
                 <span className="text-slate-300" aria-hidden="true">·</span>
-                <span
-                  className={`inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full font-semibold ring-1 ${lockedCategoryColors.bg} ${lockedCategoryColors.text} ${lockedCategoryColors.ring}`}
-                >
-                  <svg
-                    className="w-3 h-3"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                    aria-hidden="true"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z"
-                    />
-                  </svg>
+                <span className="inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full font-semibold ring-1 bg-amber-50 text-amber-700 ring-amber-200">
+                  <Icon name="filter" size={11} />
                   Filtered to {lockedCategoryLabel}
                 </span>
               </div>
             )}
-            <h1 className="text-2xl md:text-3xl lg:text-4xl font-extrabold text-slate-900 leading-tight">
-              {pageTitle}
-            </h1>
+            <h1 className="text-2xl md:text-3xl lg:text-4xl font-extrabold text-slate-900 leading-tight">{pageTitle}</h1>
             {pageSubtitle && (
-              <p className="text-sm md:text-base text-slate-600 leading-relaxed mt-2 max-w-3xl">
-                {pageSubtitle}
-              </p>
+              <p className="text-sm md:text-base text-slate-600 leading-relaxed mt-2 max-w-3xl">{pageSubtitle}</p>
             )}
           </div>
         </div>
       )}
 
-      {/* ── Sticky category tab bar — global page only ── */}
-      {!lockedCategory && (
-        <div className="sticky top-0 z-20 bg-white/95 backdrop-blur border-b border-slate-200">
-          <div className="container-custom overflow-x-auto scrollbar-hide">
-            <div className="flex gap-1.5 py-2.5 min-w-max">
-              {tabs.map((tab) => {
-                const isActive = tab.slug === activeCategory;
-                const colors = CATEGORY_COLORS[tab.slug] ?? CATEGORY_COLORS.all;
-                return (
-                  <button
-                    key={tab.slug}
-                    onClick={() =>
-                      setParam({ category: tab.slug === "all" ? "" : tab.slug, sub: "" })
-                    }
-                    className={`whitespace-nowrap rounded-full px-3.5 py-1.5 text-xs font-semibold transition-all ${
-                      isActive
-                        ? `${colors.bg} ${colors.text} ring-1 ${colors.ring}`
-                        : "text-slate-500 hover:bg-slate-50 hover:text-slate-700"
-                    }`}
-                  >
-                    {tab.label}
-                  </button>
-                );
-              })}
-            </div>
-          </div>
-        </div>
-      )}
-
-      {/* ── Sticky filter toolbar — visible as user scrolls. ──
-           Separate from the category bar (when present) so the selects
-           are always reachable without scrolling back up. */}
-      <div
-        className={`sticky z-10 bg-white/95 backdrop-blur border-b border-slate-200 ${
-          lockedCategory ? "top-0" : "top-[48px]"
-        }`}
-      >
-        <div className="container-custom py-3">
-          <div className="flex flex-col md:flex-row md:items-center gap-3">
-            {/* Search */}
+      {/* ── Single sticky toolbar (replaces the old two-bar stack) ── */}
+      <div className="sticky top-0 z-20 bg-white/95 backdrop-blur border-b border-slate-200">
+        <div className="container-custom py-3 space-y-2.5">
+          {/* Row 1: search · filters · sort · view-mode toggle */}
+          <div className="flex gap-2 items-center">
             <form
               role="search"
               className="flex-1 min-w-0"
-              onSubmit={(e) => {
-                e.preventDefault();
-                submitSearch(searchInput);
-              }}
+              onSubmit={(e) => { e.preventDefault(); submitSearch(searchInput); }}
             >
-              <label htmlFor="listings-search" className="sr-only">
-                Search listings
-              </label>
+              <label htmlFor="listings-search" className="sr-only">Search listings</label>
               <div className="relative">
-                <svg
-                  className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                  aria-hidden="true"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M21 21l-4.35-4.35M17 10.5a6.5 6.5 0 11-13 0 6.5 6.5 0 0113 0z"
-                  />
-                </svg>
+                <Icon name="search" size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400" />
                 <input
                   id="listings-search"
                   type="search"
                   inputMode="search"
                   value={searchInput}
                   onChange={(e) => setSearchInput(e.target.value)}
-                  onBlur={() => {
-                    if (searchInput.trim() !== initialQuery) {
-                      submitSearch(searchInput);
-                    }
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") submitSearch(searchInput);
+                    if (e.key === "Escape") { setSearchInput(""); submitSearch(""); }
                   }}
-                  placeholder="Search by keyword, city, industry…"
+                  placeholder="Search title, sector, ticker, suburb…"
                   className="w-full rounded-lg border border-slate-200 bg-white pl-9 pr-9 py-2 text-sm text-slate-800 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-amber-400 focus:border-amber-400"
                 />
                 {searchInput && (
                   <button
                     type="button"
-                    onClick={() => {
-                      setSearchInput("");
-                      submitSearch("");
-                    }}
+                    onClick={() => { setSearchInput(""); submitSearch(""); }}
                     aria-label="Clear search"
                     className="absolute right-2.5 top-1/2 -translate-y-1/2 w-5 h-5 rounded-full bg-slate-100 hover:bg-slate-200 text-slate-500 flex items-center justify-center text-[11px] font-bold"
                   >
@@ -444,52 +461,153 @@ export default function InvestListingsClient({
               </div>
             </form>
 
-            {/* Filter dropdowns — each with a visible inline label so
-                users always know what the current value means. */}
-            <div className="flex flex-wrap items-center gap-2">
-              <LabeledSelect
-                id="filter-state"
-                label="State"
-                value={activeState}
-                onChange={(v) => setParam({ state: v })}
-                options={[
-                  { value: "", label: "All states" },
-                  ...STATES.map((s) => ({ value: s, label: s })),
-                ]}
-              />
-              <LabeledSelect
-                id="filter-price"
-                label="Price"
-                value={PRICE_RANGES[activePriceIdx].key}
-                onChange={(v) => setParam({ price: v })}
-                options={PRICE_RANGES.map((r) => ({ value: r.key, label: r.label }))}
-              />
-              <LabeledSelect
-                id="filter-sort"
-                label="Sort"
-                value={activeSort === "newest" ? "" : activeSort}
-                onChange={(v) => setParam({ sort: v })}
-                options={SORT_OPTIONS.map((o) => ({
-                  value: o.value === "newest" ? "" : o.value,
-                  label: o.label,
-                }))}
-              />
+            <button
+              type="button"
+              onClick={() => setDrawerOpen(true)}
+              className={`shrink-0 inline-flex items-center gap-1.5 rounded-lg border px-3 py-2 text-sm font-semibold transition-all ${
+                activeChips.length > 0
+                  ? "bg-amber-50 border-amber-300 text-amber-700"
+                  : "bg-white border-slate-200 text-slate-700 hover:bg-slate-50"
+              }`}
+            >
+              <Icon name="sliders" size={16} />
+              <span className="hidden sm:inline">Filters</span>
+              {activeChips.length > 0 && (
+                <span className="bg-amber-600 text-white text-[0.6rem] font-bold rounded-full w-5 h-5 flex items-center justify-center">
+                  {activeChips.length}
+                </span>
+              )}
+            </button>
+
+            <select
+              value={activeSort}
+              onChange={(e) => setParams({ sort: e.target.value === "newest" ? "" : e.target.value })}
+              aria-label="Sort results"
+              className="shrink-0 hidden md:block rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 focus:outline-none focus:ring-2 focus:ring-amber-400 focus:border-amber-400"
+            >
+              {SORT_OPTIONS.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
+            </select>
+
+            <div className="shrink-0 hidden sm:inline-flex rounded-lg border border-slate-200 bg-white p-0.5" role="tablist" aria-label="View mode">
+              {VIEW_MODES.map((v) => (
+                <button
+                  key={v.value}
+                  type="button"
+                  role="tab"
+                  aria-selected={activeView === v.value}
+                  aria-label={`${v.label} view`}
+                  onClick={() => setParams({ view: v.value === "grid" ? "" : v.value })}
+                  className={`inline-flex items-center justify-center w-8 h-8 rounded-md text-slate-500 transition-all ${
+                    activeView === v.value ? "bg-slate-100 text-slate-900" : "hover:bg-slate-50"
+                  }`}
+                >
+                  <Icon name={v.icon} size={14} />
+                </button>
+              ))}
             </div>
           </div>
 
-          {/* Active-filter chips row — only shown when something is
-              filtering so the page isn't visually noisy otherwise. */}
+          {/* Row 2: kind segmented control */}
+          {!lockedCategory && (
+            <div className="overflow-x-auto scrollbar-hide -mx-1 px-1">
+              <div className="flex items-center gap-1.5 min-w-max">
+                <button
+                  type="button"
+                  onClick={() => setParams({ kind: "" })}
+                  aria-pressed={activeKinds.size === 0}
+                  className={`whitespace-nowrap rounded-full px-3 py-1.5 text-xs font-semibold transition-all inline-flex items-center gap-1.5 ${
+                    activeKinds.size === 0 ? "bg-slate-900 text-white" : "bg-white border border-slate-200 text-slate-600 hover:bg-slate-50"
+                  }`}
+                >
+                  All kinds
+                  <span className={`text-[0.6rem] font-bold px-1.5 py-0.5 rounded ${
+                    activeKinds.size === 0 ? "bg-white/20 text-white" : "bg-slate-100 text-slate-500"
+                  }`}>
+                    {kindCounts.all ?? 0}
+                  </span>
+                </button>
+                {ALL_LISTING_KINDS.map((k) => {
+                  const meta = listingKindMeta(k);
+                  const count = kindCounts[k] ?? 0;
+                  const isActive = activeKinds.has(k);
+                  const disabled = count === 0;
+                  return (
+                    <button
+                      key={k}
+                      type="button"
+                      onClick={() => !disabled && toggleKind(k)}
+                      disabled={disabled}
+                      aria-pressed={isActive}
+                      className={`whitespace-nowrap rounded-full px-3 py-1.5 text-xs font-semibold transition-all inline-flex items-center gap-1.5 ${
+                        isActive
+                          ? `${meta.accent.badge} shadow-sm`
+                          : disabled
+                            ? "bg-slate-50 text-slate-300 cursor-not-allowed"
+                            : `bg-white border border-slate-200 text-slate-600 hover:bg-slate-50`
+                      }`}
+                      title={meta.blurb}
+                    >
+                      <Icon name={meta.icon} size={11} />
+                      {meta.label}
+                      <span className={`text-[0.6rem] font-bold px-1.5 py-0.5 rounded ${
+                        isActive ? "bg-white/20 text-white" : disabled ? "bg-slate-100 text-slate-300" : "bg-slate-100 text-slate-500"
+                      }`}>
+                        {count}
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
+          {/* Row 3: category chips (secondary narrow by sector) */}
+          {!lockedCategory && tabs.length > 1 && (
+            <div className="overflow-x-auto scrollbar-hide -mx-1 px-1">
+              <div className="flex items-center gap-1.5 min-w-max">
+                {tabs.map((tab) => {
+                  const isActive = tab.slug === activeCategory;
+                  const count = categoryCounts[tab.slug] ?? 0;
+                  const isAll = tab.slug === "all";
+                  const disabled = !isAll && count === 0;
+                  return (
+                    <button
+                      key={tab.slug}
+                      type="button"
+                      onClick={() => !disabled && setParams({ category: tab.slug === "all" ? "" : tab.slug, sub: "" })}
+                      disabled={disabled}
+                      aria-pressed={isActive}
+                      className={`whitespace-nowrap rounded-full px-3 py-1 text-[0.7rem] font-medium transition-all inline-flex items-center gap-1 ${
+                        isActive
+                          ? "bg-slate-100 text-slate-900 ring-1 ring-slate-300"
+                          : disabled
+                            ? "text-slate-300 cursor-not-allowed"
+                            : "text-slate-500 hover:bg-slate-50"
+                      }`}
+                    >
+                      {tab.label}
+                      {!isAll && (
+                        <span className={`text-[0.55rem] font-bold tabular-nums ${disabled ? "text-slate-300" : "text-slate-400"}`}>
+                          {count}
+                        </span>
+                      )}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
+          {/* Active-filter chips */}
           {activeChips.length > 0 && (
-            <div className="flex flex-wrap items-center gap-2 mt-2.5">
-              <span className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">
-                Filtering:
-              </span>
+            <div className="flex flex-wrap items-center gap-1.5">
+              <span className="text-[10px] font-semibold uppercase tracking-wide text-slate-500">Filtering:</span>
               {activeChips.map((c) => (
                 <button
                   key={c.label}
                   type="button"
                   onClick={c.onClear}
-                  className="inline-flex items-center gap-1 rounded-full bg-amber-50 border border-amber-200 px-2.5 py-1 text-[11px] font-semibold text-amber-900 hover:bg-amber-100"
+                  className="inline-flex items-center gap-1 rounded-full bg-amber-50 border border-amber-200 px-2 py-0.5 text-[11px] font-semibold text-amber-900 hover:bg-amber-100"
                 >
                   {c.label}
                   <span className="text-amber-600" aria-hidden="true">×</span>
@@ -498,8 +616,8 @@ export default function InvestListingsClient({
               ))}
               <button
                 type="button"
-                onClick={clearAll}
-                className="text-[11px] font-bold text-slate-500 hover:text-slate-700 underline underline-offset-2"
+                onClick={clearAllFilters}
+                className="text-[11px] font-bold text-slate-500 hover:text-slate-700 underline underline-offset-2 ml-1"
               >
                 Clear all
               </button>
@@ -508,27 +626,21 @@ export default function InvestListingsClient({
         </div>
       </div>
 
+      {/* ── Results ───────────────────────────────────────────────── */}
       <div className="container-custom py-5 md:py-8">
-        {/* Sub-category pills — only meaningful when a single category
-            is selected. Collapsed into a compact chip row with a
-            visible label so readers know what the pills narrow. */}
         {subCategories.length > 0 && (
           <div className="mb-5">
-            <p className="text-[11px] font-semibold uppercase tracking-wide text-slate-500 mb-1.5">
-              Narrow by type
-            </p>
+            <p className="text-[11px] font-semibold uppercase tracking-wide text-slate-500 mb-1.5">Narrow by sub-type</p>
             <div className="flex flex-wrap gap-1.5">
               {subCategories.map((sub) => {
                 const isActive = sub === activeSubcategory;
                 return (
                   <button
                     key={sub}
-                    onClick={() => setParam({ sub: isActive ? "" : sub })}
+                    onClick={() => setParams({ sub: isActive ? "" : sub })}
                     aria-pressed={isActive}
                     className={`rounded-full px-3 py-1 text-xs font-medium transition-colors capitalize ${
-                      isActive
-                        ? "bg-slate-900 text-white"
-                        : "bg-slate-100 text-slate-600 hover:bg-slate-200"
+                      isActive ? "bg-slate-900 text-white" : "bg-slate-100 text-slate-600 hover:bg-slate-200"
                     }`}
                   >
                     {sub.replace(/_/g, " ")}
@@ -539,103 +651,407 @@ export default function InvestListingsClient({
           </div>
         )}
 
-        {/* Results count */}
         <p className="text-xs text-slate-500 mb-4">
-          {filtered.length} listing{filtered.length !== 1 ? "s" : ""} found
+          <span className="font-bold text-slate-700">{filtered.length}</span> listing{filtered.length !== 1 ? "s" : ""} found
+          {activeChips.length > 0 && (
+            <span className="text-slate-400"> · from {listings.length} total</span>
+          )}
         </p>
 
-        {/* Grid of cards */}
         {filtered.length === 0 ? (
-          <div className="flex flex-col items-center justify-center py-20 text-center">
-            <div className="text-4xl mb-3" aria-hidden="true">🔍</div>
-            <h3 className="text-lg font-bold text-slate-800 mb-1">
-              No listings match your filters
-            </h3>
-            <p className="text-sm text-slate-500 max-w-sm mb-5">
-              Try widening the search, choosing a different category, or
-              clearing one of the active filters.
-            </p>
-            {activeChips.length > 0 && (
-              <button
-                type="button"
-                onClick={clearAll}
-                className="inline-flex items-center gap-1.5 rounded-lg bg-amber-500 hover:bg-amber-600 text-white font-bold text-sm px-5 py-2.5 transition-colors"
-              >
-                Clear all filters
-              </button>
-            )}
+          <EmptyState onClearAll={clearAllFilters} hasFilters={activeChips.length > 0} />
+        ) : activeView === "table" ? (
+          <TableView listings={filtered} showFirbBadge={Boolean(intentCountry) || activeFirbOnly} />
+        ) : activeView === "list" ? (
+          <div className="flex flex-col gap-3">
+            {filtered.map((l) => (
+              <InvestListingCard key={l.id} listing={l} variant="list" showFirbBadge={Boolean(intentCountry) || activeFirbOnly} />
+            ))}
           </div>
         ) : (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
-            {filtered.map((listing) => (
-              <InvestListingCard key={listing.id} listing={listing} />
+            {filtered.map((l) => (
+              <InvestListingCard key={l.id} listing={l} showFirbBadge={Boolean(intentCountry) || activeFirbOnly} />
             ))}
           </div>
         )}
       </div>
+
+      <FilterDrawer
+        open={drawerOpen}
+        onClose={() => setDrawerOpen(false)}
+        resultCount={filtered.length}
+        onClearAll={clearAllFilters}
+        activeState={activeState}
+        activeTicket={activeTicket}
+        activeInvestorType={activeInvestorType}
+        activeFirbOnly={activeFirbOnly}
+        activeSivOnly={activeSivOnly}
+        activeWholesaleOnly={activeWholesaleOnly}
+        activeFreshness={activeFreshness}
+        activeFeaturedOnly={activeFeaturedOnly}
+        activeMinYield={activeMinYield}
+        activeEsicOnly={activeEsicOnly}
+        kindSpec={kindSpec}
+        intentCountry={intentCountry ?? null}
+        setParams={setParams}
+      />
     </div>
   );
 }
 
-/* ─── Labeled select helper ───────────────────────────────────────── */
-
-function LabeledSelect({
-  id,
-  label,
-  value,
-  onChange,
-  options,
-}: {
-  id: string;
-  label: string;
-  value: string;
-  onChange: (v: string) => void;
-  options: Array<{ value: string; label: string }>;
-}) {
-  // Inline label keeps the dropdown self-describing — once a user
-  // picks "QLD" they still see "State: QLD" on the button, so they
-  // remember what it is without re-opening the menu. Also gives
-  // screen readers a stable accessible name.
-  const current = options.find((o) => o.value === value);
-  const display = current ? current.label : options[0]?.label ?? "";
+// ─── Empty state ──────────────────────────────────────────────────────
+function EmptyState({ onClearAll, hasFilters }: { onClearAll: () => void; hasFilters: boolean }) {
   return (
-    <div className="relative">
-      <label htmlFor={id} className="sr-only">
-        {label}
-      </label>
-      <span
-        className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-[10px] font-bold uppercase tracking-wide text-slate-400"
-        aria-hidden="true"
-      >
-        {label}
-      </span>
-      <select
-        id={id}
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        aria-label={`${label}: ${display}`}
-        className="appearance-none rounded-lg border border-slate-200 bg-white pl-[52px] pr-8 py-2 text-xs font-medium text-slate-700 focus:outline-none focus:ring-2 focus:ring-amber-400 focus:border-amber-400 cursor-pointer"
-      >
-        {options.map((o) => (
-          <option key={o.value || "default"} value={o.value}>
-            {o.label}
-          </option>
-        ))}
-      </select>
-      <svg
-        className="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-slate-400"
-        fill="none"
-        stroke="currentColor"
-        viewBox="0 0 24 24"
-        aria-hidden="true"
-      >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth={2}
-          d="M19 9l-7 7-7-7"
-        />
-      </svg>
+    <div className="flex flex-col items-center justify-center py-20 text-center">
+      <div className="text-4xl mb-3" aria-hidden="true">🔍</div>
+      <h3 className="text-lg font-bold text-slate-800 mb-1">
+        {hasFilters ? "No listings match your filters" : "No listings yet"}
+      </h3>
+      <p className="text-sm text-slate-500 max-w-sm mb-5">
+        {hasFilters
+          ? "Try widening the search, choosing a different category, or clearing one of the active filters."
+          : "Check back soon — new opportunities are added weekly."}
+      </p>
+      {hasFilters && (
+        <button
+          type="button"
+          onClick={onClearAll}
+          className="inline-flex items-center gap-1.5 rounded-lg bg-amber-500 hover:bg-amber-600 text-white font-bold text-sm px-5 py-2.5 transition-colors"
+        >
+          Clear all filters
+        </button>
+      )}
     </div>
+  );
+}
+
+// ─── Table view ───────────────────────────────────────────────────────
+function TableView({ listings, showFirbBadge }: { listings: InvestmentListing[]; showFirbBadge: boolean }) {
+  return (
+    <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white">
+      <table className="min-w-full text-sm">
+        <thead className="bg-slate-50 text-[10px] uppercase tracking-wider text-slate-500">
+          <tr>
+            <th className="text-left px-4 py-2.5 font-bold">Listing</th>
+            <th className="text-left px-3 py-2.5 font-bold">Kind</th>
+            <th className="text-left px-3 py-2.5 font-bold">Sector</th>
+            <th className="text-left px-3 py-2.5 font-bold">Location</th>
+            <th className="text-right px-3 py-2.5 font-bold">Price</th>
+            <th className="text-left px-3 py-2.5 font-bold">Flags</th>
+            <th className="px-3 py-2.5"></th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-100">
+          {listings.map((l) => {
+            const kind = deriveListingKind(l);
+            const meta = listingKindMeta(kind);
+            const price = formatListingPrice(l);
+            const km = (l.key_metrics ?? {}) as Record<string, unknown>;
+            const wholesaleOnly = km["wholesale_only"] === true || km["s708_required"] === true || km["accredited_only"] === true;
+            return (
+              <tr key={l.id} className="hover:bg-slate-50">
+                <td className="px-4 py-3">
+                  <Link href={`/invest/listings/${l.slug}`} className="font-bold text-slate-900 hover:text-amber-700 line-clamp-1">
+                    {l.title}
+                  </Link>
+                  {l.industry && <div className="text-[0.62rem] text-slate-500 mt-0.5">{l.industry}</div>}
+                </td>
+                <td className="px-3 py-3">
+                  <span className={`inline-flex items-center gap-1 ${meta.accent.badgeSubtle} text-[0.6rem] font-bold uppercase tracking-wide px-2 py-0.5 rounded-full border`}>
+                    <Icon name={meta.icon} size={9} />
+                    {meta.label}
+                  </span>
+                </td>
+                <td className="px-3 py-3 text-xs text-slate-600 capitalize">{l.vertical.replace(/[-_]/g, " ")}</td>
+                <td className="px-3 py-3 text-xs text-slate-600">
+                  {l.location_state ?? "—"}{l.location_city ? ` · ${l.location_city}` : ""}
+                </td>
+                <td className="px-3 py-3 text-right">
+                  {price ? (
+                    <div>
+                      <div className="text-[0.55rem] text-slate-400 uppercase">{price.label}</div>
+                      <div className="text-xs font-bold text-slate-900">{price.value}</div>
+                    </div>
+                  ) : <span className="text-slate-300">—</span>}
+                </td>
+                <td className="px-3 py-3">
+                  <div className="flex gap-1 flex-wrap">
+                    {showFirbBadge && l.firb_eligible && <span className="bg-blue-100 text-blue-700 text-[0.55rem] font-bold uppercase tracking-wide px-1.5 py-0.5 rounded">FIRB</span>}
+                    {l.siv_complying && <span className="bg-emerald-100 text-emerald-700 text-[0.55rem] font-bold uppercase tracking-wide px-1.5 py-0.5 rounded">SIV</span>}
+                    {wholesaleOnly && <span className="bg-rose-100 text-rose-700 text-[0.55rem] font-bold uppercase tracking-wide px-1.5 py-0.5 rounded">Wholesale</span>}
+                  </div>
+                </td>
+                <td className="px-3 py-3 text-right">
+                  <Link href={`/invest/listings/${l.slug}`} className="text-xs font-bold text-amber-700 hover:text-amber-900 inline-flex items-center gap-0.5">
+                    View
+                    <Icon name="chevron-right" size={11} />
+                  </Link>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ─── Filter drawer (slide-over) ───────────────────────────────────────
+interface FilterDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  resultCount: number;
+  onClearAll: () => void;
+  activeState: string;
+  activeTicket: string;
+  activeInvestorType: InvestorType;
+  activeFirbOnly: boolean;
+  activeSivOnly: boolean;
+  activeWholesaleOnly: boolean;
+  activeFreshness: string;
+  activeFeaturedOnly: boolean;
+  activeMinYield: string;
+  activeEsicOnly: boolean;
+  kindSpec: ReturnType<typeof filterSpecForKind>;
+  intentCountry: string | null;
+  setParams: (updates: Record<string, string>) => void;
+}
+
+function FilterDrawer(props: FilterDrawerProps) {
+  const {
+    open, onClose, resultCount, onClearAll,
+    activeState, activeTicket, activeInvestorType,
+    activeFirbOnly, activeSivOnly, activeWholesaleOnly,
+    activeFreshness, activeFeaturedOnly, activeMinYield, activeEsicOnly,
+    kindSpec, intentCountry, setParams,
+  } = props;
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    document.addEventListener("keydown", onKey);
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.body.style.overflow = "";
+    };
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50">
+      <button
+        type="button"
+        aria-label="Close filters"
+        onClick={onClose}
+        className="absolute inset-0 bg-slate-900/40 backdrop-blur-sm"
+      />
+      <aside
+        role="dialog"
+        aria-label="Filters"
+        className="absolute right-0 top-0 bottom-0 w-full sm:max-w-md bg-white shadow-2xl flex flex-col"
+      >
+        <header className="flex items-center justify-between px-5 py-4 border-b border-slate-200 shrink-0">
+          <h2 className="text-lg font-extrabold text-slate-900 flex items-center gap-2">
+            <Icon name="sliders" size={18} />
+            Filters
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="w-8 h-8 rounded-full bg-slate-100 hover:bg-slate-200 text-slate-600 flex items-center justify-center"
+          >
+            <Icon name="x" size={16} />
+          </button>
+        </header>
+
+        <div className="flex-1 overflow-y-auto px-5 py-4 space-y-5">
+          <Section title="Location">
+            <select
+              value={activeState}
+              onChange={(e) => setParams({ state: e.target.value })}
+              className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400"
+            >
+              <option value="">All states</option>
+              {STATES.map((s) => <option key={s} value={s}>{s}</option>)}
+            </select>
+          </Section>
+
+          <Section title="Ticket size">
+            <div className="grid grid-cols-3 gap-1.5">
+              {TICKET_BUCKETS.map((b) => (
+                <button
+                  key={b.key || "any"}
+                  type="button"
+                  onClick={() => setParams({ price: b.key })}
+                  aria-pressed={activeTicket === b.key}
+                  className={`text-[11px] font-semibold rounded-lg px-2 py-1.5 transition-colors ${
+                    activeTicket === b.key
+                      ? "bg-amber-500 text-white shadow-sm"
+                      : "bg-slate-50 text-slate-600 hover:bg-slate-100"
+                  }`}
+                >
+                  {b.label}
+                </button>
+              ))}
+            </div>
+          </Section>
+
+          <Section title="Investor type">
+            <select
+              value={activeInvestorType}
+              onChange={(e) => setParams({ investor: e.target.value })}
+              className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400"
+            >
+              {INVESTOR_TYPES.map((t) => <option key={t.value} value={t.value}>{t.label}</option>)}
+            </select>
+            <p className="text-[10px] text-slate-500 mt-1.5 leading-snug">
+              Narrows out listings restricted to a category you don&apos;t qualify for. Doesn&apos;t verify status — that happens at enquiry.
+            </p>
+          </Section>
+
+          <Section title="Compliance & structure">
+            <div className="space-y-2">
+              <Toggle
+                label="FIRB-eligible only"
+                hint={intentCountry ? "Recommended — your visit comes via a foreign-investment page." : "Only show listings flagged eligible for foreign investment."}
+                checked={activeFirbOnly}
+                onChange={(v) => setParams({ firb: v ? "eligible" : "" })}
+              />
+              <Toggle
+                label="SIV-complying only"
+                hint="Significant Investor Visa qualifying ($5M+ over 4 years across complying assets)."
+                checked={activeSivOnly}
+                onChange={(v) => setParams({ siv: v ? "complying" : "" })}
+              />
+              <Toggle
+                label="Wholesale only"
+                hint="Restrict to s708 / sophisticated-investor offerings."
+                checked={activeWholesaleOnly}
+                onChange={(v) => setParams({ wholesale: v ? "true" : "" })}
+              />
+            </div>
+          </Section>
+
+          {kindSpec.showYield && (
+            <Section title="Minimum yield / return">
+              <div className="grid grid-cols-5 gap-1.5">
+                {["", "3", "5", "8", "12"].map((y) => (
+                  <button
+                    key={y || "any"}
+                    type="button"
+                    onClick={() => setParams({ min_yield: y })}
+                    aria-pressed={activeMinYield === y}
+                    className={`text-[11px] font-semibold rounded-lg px-2 py-1.5 transition-colors ${
+                      activeMinYield === y
+                        ? "bg-emerald-600 text-white shadow-sm"
+                        : "bg-slate-50 text-slate-600 hover:bg-slate-100"
+                    }`}
+                  >
+                    {y ? `${y}%+` : "Any"}
+                  </button>
+                ))}
+              </div>
+              <p className="text-[10px] text-slate-500 mt-1.5 leading-snug">
+                Matches any of: distribution yield, dividend yield, target IRR, historical return, target return.
+              </p>
+            </Section>
+          )}
+
+          {kindSpec.showEsicToggle && (
+            <Section title="Tax breaks">
+              <Toggle
+                label="ESIC-eligible"
+                hint="Early-Stage Innovation Company — investor gets a 20% non-refundable carry-forward tax offset (capped at $200k/yr)."
+                checked={activeEsicOnly}
+                onChange={(v) => setParams({ esic: v ? "true" : "" })}
+              />
+            </Section>
+          )}
+
+          <Section title="Listing status">
+            <div className="space-y-2">
+              <Toggle
+                label="New this week"
+                hint="Added in the last 7 days."
+                checked={activeFreshness === "new_this_week"}
+                onChange={(v) => setParams({ fresh: v ? "new_this_week" : "" })}
+              />
+              <Toggle
+                label="Closing soon"
+                hint="Expires within the next 7 days."
+                checked={activeFreshness === "closing_soon"}
+                onChange={(v) => setParams({ fresh: v ? "closing_soon" : "" })}
+              />
+              <Toggle
+                label="Featured only"
+                hint="Promoted (Featured / Premium tier)."
+                checked={activeFeaturedOnly}
+                onChange={(v) => setParams({ featured: v ? "true" : "" })}
+              />
+            </div>
+          </Section>
+        </div>
+
+        <footer className="border-t border-slate-200 px-5 py-3 flex items-center justify-between gap-2 bg-slate-50 shrink-0">
+          <button
+            type="button"
+            onClick={onClearAll}
+            className="text-xs font-bold text-slate-500 hover:text-slate-700 underline underline-offset-2"
+          >
+            Clear all
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            className="flex-1 rounded-lg bg-slate-900 hover:bg-slate-800 text-white font-bold text-sm px-4 py-2.5 transition-colors"
+          >
+            Show {resultCount} result{resultCount !== 1 ? "s" : ""}
+          </button>
+        </footer>
+      </aside>
+    </div>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section>
+      <h3 className="text-[10px] font-extrabold uppercase tracking-wider text-slate-500 mb-2">{title}</h3>
+      {children}
+    </section>
+  );
+}
+
+function Toggle({
+  label, hint, checked, onChange,
+}: {
+  label: string;
+  hint?: string;
+  checked: boolean;
+  onChange: (v: boolean) => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => onChange(!checked)}
+      aria-pressed={checked}
+      className={`w-full flex items-start justify-between gap-3 text-left px-3 py-2 rounded-lg border transition-colors ${
+        checked
+          ? "border-emerald-300 bg-emerald-50"
+          : "border-slate-200 bg-white hover:bg-slate-50"
+      }`}
+    >
+      <div className="min-w-0">
+        <div className={`text-sm font-semibold ${checked ? "text-emerald-900" : "text-slate-700"}`}>{label}</div>
+        {hint && <p className={`text-[10px] mt-0.5 leading-snug ${checked ? "text-emerald-700" : "text-slate-500"}`}>{hint}</p>}
+      </div>
+      <span className={`relative inline-flex h-5 w-9 shrink-0 rounded-full transition-colors mt-0.5 ${checked ? "bg-emerald-600" : "bg-slate-300"}`}>
+        <span className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform mt-0.5 ${checked ? "translate-x-4 ml-0.5" : "translate-x-0.5"}`} />
+      </span>
+    </button>
   );
 }

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -9769,6 +9769,7 @@ export type Database = {
           industry: string | null
           key_metrics: Json | null
           listed_by_professional_id: number | null
+          listing_kind: string | null
           listing_type: string | null
           location_city: string | null
           location_state: string | null
@@ -9805,6 +9806,7 @@ export type Database = {
           industry?: string | null
           key_metrics?: Json | null
           listed_by_professional_id?: number | null
+          listing_kind?: string | null
           listing_type?: string | null
           location_city?: string | null
           location_state?: string | null
@@ -9841,6 +9843,7 @@ export type Database = {
           industry?: string | null
           key_metrics?: Json | null
           listed_by_professional_id?: number | null
+          listing_kind?: string | null
           listing_type?: string | null
           location_city?: string | null
           location_state?: string | null

--- a/lib/listing-kind.ts
+++ b/lib/listing-kind.ts
@@ -1,0 +1,397 @@
+/**
+ * Helpers for the `listing_kind` discriminator on investment_listings.
+ *
+ * The DB column was added 2026-05 (migration `20260725200000_add_listing_kind`)
+ * to let `/invest` render per-kind cards and per-kind filters. This module
+ * holds:
+ *   - `deriveListingKind(row)` — fallback when the column is null (older
+ *     code paths inserting without setting it; SQL backfill missed it).
+ *   - per-kind display metadata: label / icon / accent / price-label semantic.
+ *   - filter helpers used by the new InvestListingsClient drawer.
+ */
+
+import type { InvestmentListing, ListingKind } from "@/lib/types";
+
+// ─── 1. Derivation fallback ──────────────────────────────────────────────
+
+/** Mirror of the SQL backfill in 20260725200000_add_listing_kind.sql.
+ *  Keep in sync if either side changes. */
+export function deriveListingKind(row: Pick<InvestmentListing, "vertical" | "key_metrics" | "asking_price_cents" | "listing_kind">): ListingKind {
+  if (row.listing_kind) return row.listing_kind;
+
+  const km = (row.key_metrics ?? {}) as Record<string, unknown>;
+  const v = row.vertical as string;
+
+  if (km["asx_ticker"] && row.asking_price_cents == null) return "listed_security";
+
+  const physicalKeys = [
+    "varietal", "vintage", "cask_type", "case_size_mm", "calibre",
+    "artist", "athlete", "engine", "model", "make", "distillery",
+    "producer", "sport", "grading", "expression", "transmission",
+    "medium", "representation", "colour", "signed",
+  ];
+  if (v === "fund" && physicalKeys.some((k) => k in km)) return "physical_asset";
+
+  if (v === "funds") return "fund";
+  if (v === "fund" && ["aum_billions", "min_investment", "mer_bps", "distribution_yield"].some((k) => k in km)) return "fund";
+  if (km["structure"] === "managed_fund" || km["stage"] === "fund") return "fund";
+
+  if (v === "royalties" || km["stage"] === "royalty" || km["royalty_type"]) return "royalty";
+
+  if (["buy-business", "franchise"].includes(v)) return "for_sale_business";
+  if (["commercial_property", "commercial-property", "farmland", "livestock"].includes(v)) return "for_sale_asset";
+  if (["startups", "startup", "pre_ipo", "pre-ipo"].includes(v)) return "equity_raise";
+
+  // Sector verticals — when not a ticker, default to project equity.
+  return "project_equity";
+}
+
+// ─── 2. Per-kind display metadata ────────────────────────────────────────
+
+export interface ListingKindMeta {
+  /** Short label used in card badges + filter chips. */
+  label: string;
+  /** Plural label used in segmented counts ("Funds (16)"). */
+  pluralLabel: string;
+  /** lucide-react icon name used by `<Icon name={…} />`. */
+  icon: string;
+  /** Tailwind accent classes for badges + borders + hovers. */
+  accent: {
+    badge: string;
+    badgeSubtle: string;
+    border: string;
+    text: string;
+    bg: string;
+  };
+  /** "Asking" / "Min investment" / "Market cap" / etc. — the right
+   *  prefix to render above the price on cards. Some kinds (listed
+   *  security, royalty) intentionally suppress the "Asking" label. */
+  priceLabel: string;
+  /** Free-text explainer shown in the kind-filter tooltip / segmented
+   *  control help. One sentence. */
+  blurb: string;
+  /** What CTA verb to use on the card ("Enquire" / "Request IM" /
+   *  "Buy via broker" / "Express interest"). */
+  ctaLabel: string;
+  /** True when the visitor doesn't enquire — the listing routes to
+   *  an external broker / DocSend / PDS. */
+  externalCta: boolean;
+}
+
+export const LISTING_KIND_META: Record<ListingKind, ListingKindMeta> = {
+  for_sale_business: {
+    label: "For-sale business",
+    pluralLabel: "For-sale businesses",
+    icon: "store",
+    accent: {
+      badge: "bg-blue-600 text-white",
+      badgeSubtle: "bg-blue-50 text-blue-700 border-blue-200",
+      border: "border-blue-200 hover:border-blue-400",
+      text: "text-blue-700",
+      bg: "bg-blue-100",
+    },
+    priceLabel: "Asking",
+    blurb: "An operating Australian business changing hands — cafes, agencies, e-commerce, franchises.",
+    ctaLabel: "Enquire",
+    externalCta: false,
+  },
+  for_sale_asset: {
+    label: "Asset for sale",
+    pluralLabel: "Assets for sale",
+    icon: "building",
+    accent: {
+      badge: "bg-slate-700 text-white",
+      badgeSubtle: "bg-slate-50 text-slate-700 border-slate-200",
+      border: "border-slate-200 hover:border-slate-400",
+      text: "text-slate-700",
+      bg: "bg-slate-100",
+    },
+    priceLabel: "Asking",
+    blurb: "A tangible asset for direct purchase — commercial property, farmland, livestock.",
+    ctaLabel: "Enquire",
+    externalCta: false,
+  },
+  equity_raise: {
+    label: "Equity raise",
+    pluralLabel: "Equity raises",
+    icon: "rocket",
+    accent: {
+      badge: "bg-indigo-600 text-white",
+      badgeSubtle: "bg-indigo-50 text-indigo-700 border-indigo-200",
+      border: "border-indigo-200 hover:border-indigo-400",
+      text: "text-indigo-700",
+      bg: "bg-indigo-100",
+    },
+    priceLabel: "Raising",
+    blurb: "Companies raising primary capital — seed to pre-IPO.",
+    ctaLabel: "Express interest",
+    externalCta: false,
+  },
+  project_equity: {
+    label: "Project equity",
+    pluralLabel: "Project equity",
+    icon: "factory",
+    accent: {
+      badge: "bg-amber-600 text-white",
+      badgeSubtle: "bg-amber-50 text-amber-700 border-amber-200",
+      border: "border-amber-200 hover:border-amber-400",
+      text: "text-amber-700",
+      bg: "bg-amber-100",
+    },
+    priceLabel: "Min commitment",
+    blurb: "Equity in a single project or SPV — mining tenements, renewables, infrastructure.",
+    ctaLabel: "Request data room",
+    externalCta: false,
+  },
+  royalty: {
+    label: "Royalty stream",
+    pluralLabel: "Royalty streams",
+    icon: "percent",
+    accent: {
+      badge: "bg-rose-600 text-white",
+      badgeSubtle: "bg-rose-50 text-rose-700 border-rose-200",
+      border: "border-rose-200 hover:border-rose-400",
+      text: "text-rose-700",
+      bg: "bg-rose-100",
+    },
+    priceLabel: "Royalty",
+    blurb: "Ongoing royalty interests in producing assets — mining, IP, music, oil-gas.",
+    ctaLabel: "Request data room",
+    externalCta: false,
+  },
+  fund: {
+    label: "Managed fund",
+    pluralLabel: "Managed funds",
+    icon: "trending-up",
+    accent: {
+      badge: "bg-violet-600 text-white",
+      badgeSubtle: "bg-violet-50 text-violet-700 border-violet-200",
+      border: "border-violet-200 hover:border-violet-400",
+      text: "text-violet-700",
+      bg: "bg-violet-100",
+    },
+    priceLabel: "Min investment",
+    blurb: "Australian-domiciled managed funds — wholesale, retail, SIV-complying.",
+    ctaLabel: "Request IM / PDS",
+    externalCta: false,
+  },
+  physical_asset: {
+    label: "Physical asset",
+    pluralLabel: "Physical assets",
+    icon: "gem",
+    accent: {
+      badge: "bg-fuchsia-600 text-white",
+      badgeSubtle: "bg-fuchsia-50 text-fuchsia-700 border-fuchsia-200",
+      border: "border-fuchsia-200 hover:border-fuchsia-400",
+      text: "text-fuchsia-700",
+      bg: "bg-fuchsia-100",
+    },
+    priceLabel: "Asking",
+    blurb: "Collectibles & physical assets — wine, whisky, watches, classic cars, art, sport memorabilia.",
+    ctaLabel: "Enquire",
+    externalCta: false,
+  },
+  listed_security: {
+    label: "Listed security",
+    pluralLabel: "Listed securities",
+    icon: "bar-chart-3",
+    accent: {
+      badge: "bg-sky-600 text-white",
+      badgeSubtle: "bg-sky-50 text-sky-700 border-sky-200",
+      border: "border-sky-200 hover:border-sky-400",
+      text: "text-sky-700",
+      bg: "bg-sky-100",
+    },
+    priceLabel: "Market",
+    blurb: "ASX-listed equities & ETFs — buy via a broker, not from us.",
+    ctaLabel: "Buy via broker",
+    externalCta: true,
+  },
+};
+
+export function listingKindMeta(kind: ListingKind | null | undefined): ListingKindMeta {
+  return LISTING_KIND_META[kind ?? "project_equity"];
+}
+
+// ─── 3. Filter helpers ───────────────────────────────────────────────────
+
+export const ALL_LISTING_KINDS: ListingKind[] = [
+  "for_sale_business",
+  "for_sale_asset",
+  "equity_raise",
+  "project_equity",
+  "royalty",
+  "fund",
+  "physical_asset",
+  "listed_security",
+];
+
+/** Ticket-size buckets — used by the universal "Ticket size" filter.
+ *  Values are in cents. Bucket-key strings match URL params. */
+export const TICKET_BUCKETS = [
+  { key: "", label: "Any ticket", min: 0, max: Infinity },
+  { key: "under-10k", label: "Under $10k", min: 0, max: 1_000_000 },
+  { key: "10k-100k", label: "$10k – $100k", min: 1_000_000, max: 10_000_000 },
+  { key: "100k-1m", label: "$100k – $1M", min: 10_000_000, max: 100_000_000 },
+  { key: "1m-10m", label: "$1M – $10M", min: 100_000_000, max: 1_000_000_000 },
+  { key: "10m-plus", label: "$10M+", min: 1_000_000_000, max: Infinity },
+] as const;
+
+export function ticketBucketByKey(key: string): typeof TICKET_BUCKETS[number] {
+  return TICKET_BUCKETS.find((b) => b.key === key) ?? TICKET_BUCKETS[0];
+}
+
+/** Investor type — drives "show me what I'm eligible for" filter. */
+export type InvestorType = "" | "retail" | "wholesale" | "sophisticated" | "smsf" | "siv" | "family_office";
+
+export const INVESTOR_TYPES: { value: InvestorType; label: string }[] = [
+  { value: "", label: "Any investor type" },
+  { value: "retail", label: "Retail (PDS path)" },
+  { value: "wholesale", label: "Wholesale (s708 / sophisticated)" },
+  { value: "smsf", label: "SMSF trustee" },
+  { value: "siv", label: "SIV-complying only" },
+  { value: "family_office", label: "Family office / institutional" },
+];
+
+/** Test whether a listing matches an investor-type filter. The logic
+ *  is intentionally permissive — when the listing doesn't carry the
+ *  flag we assume "yes" rather than filter it out. The filter exists
+ *  to *narrow* obvious mismatches (e.g. wholesale-only when retail
+ *  is selected), not to gate everything strictly. */
+export function listingMatchesInvestorType(
+  l: Pick<InvestmentListing, "key_metrics" | "siv_complying">,
+  investorType: InvestorType,
+): boolean {
+  if (!investorType) return true;
+  const km = (l.key_metrics ?? {}) as Record<string, unknown>;
+  const wholesaleOnly = km["wholesale_only"] === true || km["s708_required"] === true || km["accredited_only"] === true;
+  const retailOpen = km["open_to_retail"] === true || km["retail_eligible"] === true;
+  switch (investorType) {
+    case "retail":
+      // Block wholesale-only listings. Allow listings that have no flag
+      // (we assume retail-accessible unless explicitly wholesale-only).
+      return !wholesaleOnly || retailOpen;
+    case "wholesale":
+    case "sophisticated":
+      // Pass: wholesale investors qualify for everything they can self-attest.
+      return true;
+    case "smsf":
+      // No structured flag for "SMSF-suitable" today — pass everything.
+      // (Future: gate on smsf_eligible key once seeded.)
+      return true;
+    case "siv":
+      return !!l.siv_complying;
+    case "family_office":
+      // Family office / institutional generally qualify everywhere.
+      return true;
+    default:
+      return true;
+  }
+}
+
+/** Vertical-specific filter shapes — each kind exposes a different
+ *  set of filter dimensions in the drawer. The frontend reads this to
+ *  decide which optional filter rows to render. */
+export interface VerticalFilterSpec {
+  /** True when a vertical-specific yield filter should be shown. */
+  showYield: boolean;
+  /** True when a hectares filter is meaningful (farmland). */
+  showHectares: boolean;
+  /** True when a JORC resource / commodity stage filter is meaningful (mining). */
+  showMiningStage: boolean;
+  /** True when an "ESIC-eligible" toggle is meaningful (startups — gives
+   *  the investor an early-stage innovation company tax break). */
+  showEsicToggle: boolean;
+  /** True when ASX-ticker filter is meaningful (listed securities). */
+  showAsxFilter: boolean;
+  /** True when AUM / MER filters make sense (funds). */
+  showFundMetrics: boolean;
+  /** True when capacity / PPA / IRR filters make sense (project equity, renewables). */
+  showProjectMetrics: boolean;
+  /** True when collectible-specific filters (era / vintage / brand) make sense. */
+  showCollectibleMetrics: boolean;
+}
+
+export function filterSpecForKind(kind: ListingKind | null): VerticalFilterSpec {
+  const k = kind ?? "project_equity";
+  return {
+    showYield: ["for_sale_asset", "fund", "project_equity", "royalty", "listed_security"].includes(k),
+    showHectares: k === "for_sale_asset", // narrowed further by vertical=farmland in UI
+    showMiningStage: k === "project_equity",
+    showEsicToggle: k === "equity_raise",
+    showAsxFilter: k === "listed_security",
+    showFundMetrics: k === "fund",
+    showProjectMetrics: ["project_equity", "equity_raise"].includes(k),
+    showCollectibleMetrics: k === "physical_asset",
+  };
+}
+
+/** Returns true when a listing has any "freshness" signal worth a badge
+ *  (new this week / new this month / closing soon). */
+export type FreshnessSignal = "new_this_week" | "new_this_month" | "closing_soon" | null;
+
+export function freshnessSignal(l: Pick<InvestmentListing, "created_at" | "expires_at">): FreshnessSignal {
+  const now = Date.now();
+  if (l.expires_at) {
+    const expiresIn = new Date(l.expires_at).getTime() - now;
+    if (expiresIn > 0 && expiresIn < 7 * 86400 * 1000) return "closing_soon";
+  }
+  if (l.created_at) {
+    const ageMs = now - new Date(l.created_at).getTime();
+    if (ageMs < 7 * 86400 * 1000) return "new_this_week";
+    if (ageMs < 30 * 86400 * 1000) return "new_this_month";
+  }
+  return null;
+}
+
+/** Returns a price-display string for a listing, picking the right
+ *  prefix for its kind. Falls back to `price_display` when set on the
+ *  row (sellers can override), else formats `asking_price_cents`. */
+export function formatListingPrice(l: Pick<InvestmentListing, "listing_kind" | "vertical" | "price_display" | "asking_price_cents" | "key_metrics">): {
+  label: string;   // "Asking" / "Min investment" / "Raising" / "Market cap"
+  value: string;   // "$2.5M" / "$100k" / "ASX: TLS"
+} | null {
+  const kind = deriveListingKind(l);
+  const meta = listingKindMeta(kind);
+
+  // Listed securities: show the ticker + market cap when available.
+  if (kind === "listed_security") {
+    const km = (l.key_metrics ?? {}) as Record<string, unknown>;
+    const ticker = km["asx_ticker"];
+    if (ticker) return { label: "ASX", value: String(ticker).toUpperCase() };
+    return null;
+  }
+
+  // Sellers can override the auto-formatted price via price_display.
+  if (l.price_display) {
+    return { label: meta.priceLabel, value: l.price_display };
+  }
+
+  // Fund / project equity: prefer min_investment from key_metrics when
+  // it's set and no asking_price was; this is the case for most fund
+  // and project rows whose "price" is really a min-commitment.
+  const km = (l.key_metrics ?? {}) as Record<string, unknown>;
+  const minInvest = km["min_investment_aud"] ?? km["min_commit_aud"] ?? km["min_investment"];
+  if ((kind === "fund" || kind === "project_equity") && minInvest != null && !l.asking_price_cents) {
+    return { label: meta.priceLabel, value: typeof minInvest === "number" ? formatAudCompact(minInvest * 100) : String(minInvest) };
+  }
+
+  if (l.asking_price_cents != null) {
+    return { label: meta.priceLabel, value: formatAudCompact(l.asking_price_cents) };
+  }
+
+  return null;
+}
+
+/** "$2.5M" / "$100k" / "$300" — compact AUD formatter. Input is cents. */
+export function formatAudCompact(cents: number): string {
+  const dollars = cents / 100;
+  if (dollars >= 1_000_000) {
+    const m = dollars / 1_000_000;
+    return `$${m >= 10 ? m.toFixed(0) : m.toFixed(1).replace(/\.0$/, "")}M`;
+  }
+  if (dollars >= 1_000) {
+    return `$${Math.round(dollars / 1_000)}k`;
+  }
+  return `$${Math.round(dollars).toLocaleString("en-AU")}`;
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1405,9 +1405,32 @@ export type InvestListingVertical =
   | 'royalties'
   | 'startup';
 
+/**
+ * Discriminator added 2026-05 (Wave 1 of /invest rebuild). Each kind has a
+ * distinct card variant + filter set + price-label semantic. See
+ * `lib/listing-kind.ts` for the helpers that key off this value.
+ *
+ * `vertical` is the secondary axis (sector / industry); `listing_kind`
+ * answers "what shape of opportunity is this" which the page UX needs to
+ * branch on far more often than the vertical does.
+ */
+export type ListingKind =
+  | 'for_sale_business'   // operating business changing hands (cafes, agencies, franchises)
+  | 'for_sale_asset'      // tangible asset for sale (commercial property, farmland, livestock)
+  | 'equity_raise'        // company raising primary capital (startups, pre-IPO)
+  | 'project_equity'      // project / SPV equity (mining tenements, renewables, infra)
+  | 'royalty'             // royalty stream (mining, IP, music, oil-gas)
+  | 'fund'                // managed fund — PDS / IM / wholesale-only / SIV-complying
+  | 'physical_asset'      // collectible: wine, whisky, watches, cars, art, coins, sports
+  | 'listed_security';    // ASX ticker — "buy via broker", not enquire
+
 export interface InvestmentListing {
   id: number;
   vertical: InvestListingVertical;
+  /** What shape of opportunity. Drives card variant + price-label semantic
+   *  + filter set. May be null on legacy rows; UI falls back to deriving
+   *  from `vertical` via lib/listing-kind#deriveListingKind. */
+  listing_kind?: ListingKind | null;
   title: string;
   slug: string;
   description?: string;

--- a/supabase/migrations/20260725200000_add_listing_kind.sql
+++ b/supabase/migrations/20260725200000_add_listing_kind.sql
@@ -1,0 +1,116 @@
+-- ============================================================================
+-- Migration: 20260725200000_add_listing_kind.sql
+-- Purpose: Introduce a `listing_kind` discriminator on investment_listings.
+--          Today the page treats every row identically — same card, same
+--          "Asking $X" label — but in reality the table holds 7 different
+--          shapes of opportunity (for-sale business vs fund vs equity raise
+--          vs listed-security ASX ticker vs physical collectible …).
+--          Per-kind card variants + per-kind filter sets need a typed
+--          column, not a derived-at-query-time mapping over `vertical`.
+--
+-- Why now: Wave 1 of the /invest rebuild (see plan in PR description).
+--          Without this column the new ListingCard can't pick a layout,
+--          the new filter drawer can't expose ticket-size vs market-cap
+--          vs min-investment correctly, and the 60 collectibles labelled
+--          `vertical='fund'` keep showing up as "Asking $2M min (wholesale
+--          only)" on a fund card with a stock-photo of server racks.
+--
+-- Backfill: deterministic mapping from (vertical, key_metrics, asking_price).
+--           See `CASE` block below for the rules. Idempotent —
+--           re-running won't change any row whose listing_kind was set
+--           explicitly by an admin afterwards because we only update
+--           rows WHERE listing_kind IS NULL.
+--
+-- Rollback (destructive):
+--   ALTER TABLE investment_listings DROP COLUMN IF EXISTS listing_kind;
+--   DROP INDEX IF EXISTS idx_investment_listings_listing_kind;
+--
+-- Risk: low — purely additive. The CHECK constraint allows the 7 known
+--       kinds plus NULL so rows added by older code paths still insert.
+-- ============================================================================
+
+BEGIN;
+
+ALTER TABLE investment_listings
+  ADD COLUMN IF NOT EXISTS listing_kind TEXT;
+
+ALTER TABLE investment_listings
+  DROP CONSTRAINT IF EXISTS investment_listings_listing_kind_check;
+ALTER TABLE investment_listings
+  ADD CONSTRAINT investment_listings_listing_kind_check
+  CHECK (listing_kind IS NULL OR listing_kind IN (
+    'for_sale_business',   -- buy-business, franchise (operating business changing hands)
+    'for_sale_asset',      -- commercial property, farmland, livestock (tangible asset)
+    'equity_raise',        -- startups, pre-IPO (company raising primary capital)
+    'project_equity',      -- mining, renewable energy, infrastructure (project / SPV equity)
+    'royalty',             -- mining/IP/music/oil-gas royalty streams
+    'fund',                -- managed funds (PDS / IM / wholesale)
+    'physical_asset',      -- collectibles: wine, whisky, watches, cars, art, coins, sports
+    'listed_security'      -- ASX tickers (use a broker, not enquire)
+  ));
+
+CREATE INDEX IF NOT EXISTS idx_investment_listings_listing_kind
+  ON investment_listings(listing_kind)
+  WHERE status = 'active';
+
+-- ── Backfill ──────────────────────────────────────────────────────────────
+-- Order matters: the listed_security branch must fire BEFORE the
+-- project_equity branch, since uranium/hydrogen/oil-gas/digital-infra
+-- rows that carry an `asx_ticker` AND have no asking price are equities
+-- being browsed (need ticker-style cards), not project-equity raises.
+UPDATE investment_listings
+SET listing_kind = CASE
+  -- ASX tickers: have a ticker, no asking price → listed security
+  WHEN key_metrics ? 'asx_ticker' AND asking_price_cents IS NULL THEN 'listed_security'
+
+  -- Collectibles misclassified as `vertical='fund'` (singular). The
+  -- 60 rows currently tagged `fund` are wine/whisky/watches/cars/art
+  -- per key_metrics (varietal, cask_type, calibre, engine, artist, ...).
+  -- Reclassify them as physical_asset so the right card + filters apply.
+  WHEN vertical = 'fund' AND (
+    key_metrics ?| ARRAY['varietal','vintage','cask_type','case_size_mm','calibre',
+                         'artist','athlete','engine','model','make','distillery',
+                         'producer','sport','grading','expression','transmission',
+                         'medium','representation','colour','signed']
+  ) THEN 'physical_asset'
+
+  -- Real managed funds — explicit plural vertical OR fund-like keys.
+  -- Some sector-vertical rows (oil-gas, energy) are also actually
+  -- managed funds (Ellerston, K2 etc.) — detected via structure or
+  -- fund-like stage marker.
+  WHEN vertical = 'funds' THEN 'fund'
+  WHEN vertical = 'fund' AND key_metrics ?| ARRAY['aum_billions','min_investment','mer_bps','distribution_yield']
+    THEN 'fund'
+  WHEN (key_metrics->>'structure' = 'managed_fund') OR (key_metrics->>'stage' = 'fund')
+    THEN 'fund'
+
+  -- Royalty streams — explicit royalties vertical OR detected via
+  -- stage/royalty_type inside other verticals (e.g., LNG Net Profits
+  -- Royalty Interest sitting under oil-gas).
+  WHEN vertical = 'royalties' THEN 'royalty'
+  WHEN (key_metrics->>'stage' = 'royalty') OR (key_metrics ? 'royalty_type')
+    THEN 'royalty'
+
+  -- For-sale operating businesses
+  WHEN vertical IN ('buy-business', 'franchise') THEN 'for_sale_business'
+
+  -- Tangible-asset sales (real property + land + livestock)
+  WHEN vertical IN ('commercial_property', 'commercial-property', 'farmland', 'livestock')
+    THEN 'for_sale_asset'
+
+  -- Primary-capital raises (companies selling equity)
+  WHEN vertical IN ('startups', 'startup', 'pre_ipo', 'pre-ipo') THEN 'equity_raise'
+
+  -- Project / SPV equity (mining tenements, renewables, infra). Sector
+  -- verticals without ASX tickers default to project_equity.
+  WHEN vertical IN ('mining', 'renewable-energy', 'energy', 'aquaculture',
+                    'carbon-environmental-markets', 'public-social-infrastructure',
+                    'digital-infrastructure', 'oil-gas', 'uranium', 'hydrogen')
+    THEN 'project_equity'
+
+  -- Fallback: leave NULL for human review (admin can set explicitly).
+  ELSE NULL
+END
+WHERE listing_kind IS NULL;
+
+COMMIT;


### PR DESCRIPTION
## Summary

Wave 1 of a three-wave /invest rebuild. The page promised a marketplace and delivered a confused mix — four redundant category navigation patterns, one card layout for 15 vertical shapes, a 4-field stub filter for a DB carrying 100+ filterable dimensions, a wedge CTA between filters and results, and FIRB badges plastered on every row.

This PR does the data hygiene + kind-aware cards + filter rebuild + hero/IA cleanup + view modes. Waves 2 (saved searches / shortlist / compare / alerts) and 3 (smart-match / advisor opt-in / seller surfaces) follow.

## Data hygiene
Added `listing_kind` discriminator with deterministic SQL backfill (`20260725200000_add_listing_kind.sql`). Reclassified all 159 active listings — none NULL after backfill:

| Kind | Count | Notes |
|---|---:|---|
| `physical_asset` | 60 | wine/whisky/watches/cars/art mislabeled as `vertical='fund'` — now get a collectible-shaped card |
| `listed_security` | 32 | ASX tickers with no asking price — get a ticker badge + "Buy via broker" CTA |
| `project_equity` | 19 | mining / renewable / uranium / hydrogen / digital-infra — "Min commitment" label |
| `fund` | 16 | real managed funds — "Min investment" label, MER/AUM-shaped |
| `for_sale_business` | 15 | buy-business + franchise — classic "Asking $X" |
| `for_sale_asset` | 11 | commercial property + farmland + livestock |
| `equity_raise` | 5 | startups + pre-IPO — "Raising" label |
| `royalty` | 1 | LNG net-profits royalty |

## What changed

**`lib/listing-kind.ts`** — new helpers (`deriveListingKind`, `kindMeta`, `formatListingPrice`, `freshnessSignal`, `filterSpecForKind`, `listingMatchesInvestorType`, `TICKET_BUCKETS`, `INVESTOR_TYPES`).

**`InvestListingCard`** — kind-aware: per-kind icon + accent + price label + CTA verb. Listed securities skip Enquire (external "Buy via broker"). FIRB badge gated to `showFirbBadge` prop (surfaced only when intent country signals foreign-investor lens). New "list" variant for the new list-view mode. Freshness badges (New this week / Closing soon) from `created_at` + `expires_at`.

**`InvestListingsClient`** — full rewrite:
- **Single sticky toolbar** (was 2 stacked) with search + filters button + sort + view-mode toggle
- **Kind segmented control** as primary navigation (per-kind counts, zero-count disabled, multi-select)
- **Category chips** as secondary narrow (sector dimension)
- **Slide-over filter drawer** with universal filters (location, ticket size, investor type, FIRB/SIV/wholesale toggles, freshness, featured-only) plus kind-conditional filters (Min yield % when kind exposes yield; ESIC-eligible for equity raises). Escape closes; body scroll locked
- **Three view modes**: Grid (cards), List (horizontal denser), Table (sortable spreadsheet). View-mode preserved across filter changes via `?view=`
- **Search**: Enter commits, Escape clears. The old onBlur-fires-URL bug that committed partial queries is gone
- Searches now match ticker / brand / commodity via `key_metrics` text indexing
- Active-filter chip row with one-click clear per chip

**`app/invest/page.tsx`** — layout overhaul:
- Hero collapsed from 40% of fold to ~15% — H1 + 1-sentence sub + 3 trust pills (live count + FIRB count + SIV count)
- Deleted "Active listings by vertical" chip strip (duplicate of tab bar with raw DB labels; was showing 4 verticals while tab bar showed 12)
- Deleted "Energy & commodity sector hubs" row (overlapped with mining category)
- `GetMatchedEmbed` moved BELOW results as recovery prompt ("Not sure?")
- General Advice Warning + Advertiser Disclosure moved to a collapsed details band at the page bottom (mandatory copy preserved verbatim)
- Single category-card discovery grid (was 3 sections)
- Supply-side CTAs compressed to a 3-card row

**`Icon.tsx`** — added store, gem, grid, list, table, map, bookmark-check.

## Test plan
- [x] `tsc --noEmit` clean (pre-existing `.next/types/validator.ts` noise unrelated)
- [x] `eslint` clean on every touched file
- [x] `vitest run` — 5714/5714 pass
- [x] `next build` succeeds — `/invest` route built; only env-var noise in local build (no `NEXT_PUBLIC_SUPABASE_URL` locally — production is fine)
- [x] Migration applied to remote DB via Supabase MCP (verified: 0 NULL `listing_kind` rows)
- [ ] Visual smoke on the Vercel preview once deployed
- [ ] Confirm: pre-existing `/invest?category=…` deep links still work (yes — category is still URL-backed)

## What's NOT in this PR (coming in Waves 2 & 3)

**Wave 2** — power features
- "Save this search" button → `saved_searches` table (which already exists with `email_frequency`, `last_alerted_at`) → daily cron diffs new listings
- Shortlist / bookmark per-listing → `user_bookmarks`
- Compare 2-4 listings side-by-side → `user_saved_comparisons`
- Email alerts when saved-search matches change

**Wave 3** — cross-feature glue
- Smart-match score per card from logged-in investor profile
- "X advisors can assess this" badge on cards → `listing_advisor_opt_ins`
- Claim-your-listing badge on unclaimed funds → `listing_claims`
- Seller "My listings" surfaces from `listing_owner_accounts`

https://claude.ai/code/session_019Rvnw5P7FXjNMRxiKkPFPh

---
_Generated by [Claude Code](https://claude.ai/code/session_019Rvnw5P7FXjNMRxiKkPFPh)_