### PR TITLE
feat(z22+bb07): Z-22+BB-07 — redundancy hub + ETP tax calculator [audit remediation]

### DIFF
--- a/app/redundancy/page.tsx
+++ b/app/redundancy/page.tsx
@@ -1,0 +1,46 @@
+import type { Metadata } from "next";
+import { SITE_URL, CURRENT_YEAR } from "@/lib/seo";
+import HubPage from "@/components/HubPage";
+import HubNewsletterCapture from "@/components/HubNewsletterCapture";
+import LeadMagnetCapture from "@/components/LeadMagnetCapture";
+import HubExitIntent from "@/components/HubExitIntent";
+import { getLeadMagnetForHub } from "@/lib/lead-magnets";
+import { redundancyHubConfig } from "@/lib/hub-configs/redundancy";
+
+export const revalidate = 3600;
+
+export const metadata: Metadata = {
+  title: `Redundancy Hub (${CURRENT_YEAR}) — ETP Tax, Super Strategy & Financial Rebuild`,
+  description: redundancyHubConfig.metaDescription,
+  alternates: { canonical: `${SITE_URL}/redundancy` },
+  openGraph: {
+    title: `Redundancy Hub (${CURRENT_YEAR}) — ETP Tax & Financial Rebuild`,
+    description: redundancyHubConfig.metaDescription,
+    url: `${SITE_URL}/redundancy`,
+  },
+};
+
+export default function RedundancyHubPage() {
+  const leadMagnet = getLeadMagnetForHub("redundancy");
+
+  return (
+    <>
+      <HubPage
+        config={redundancyHubConfig}
+        newsletterCapture={
+          <HubNewsletterCapture
+            segmentSlug="redundancy-hub"
+            hubTitle="Redundancy"
+            leadMagnetTitle="Free Redundancy Financial Action Checklist"
+          />
+        }
+      >
+        {leadMagnet && <LeadMagnetCapture magnet={leadMagnet} />}
+      </HubPage>
+      <HubExitIntent
+        segmentSlug="redundancy-hub"
+        hubName="Redundancy"
+      />
+    </>
+  );
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -25,7 +25,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const supabase = hasSupabase ? await createClient() : null;
 
   // Static pages with tiered priorities
-  const highPriority = new Set(["/compare", "/quiz", "/reviews", "/deals", "/share-trading", "/crypto", "/savings", "/super", "/cfd", "/term-deposits", "/robo-advisors", "/versus", "/how-to", "/invest", "/foreign-investment", "/global-investing", "/etfs", "/insurance", "/tax", "/property", "/grants", "/grants/rd-tax-incentive", "/smsf/setup", "/smsf/crypto", "/smsf/property", "/sell-business", "/sell-business/valuation", "/dividends", "/dividends/franking-credits", "/negative-gearing", "/lump-sum-investing", "/lump-sum-investing/redundancy", "/lump-sum-investing/inheritance", "/halal-investing", "/learn", "/first-home-buyer"]);
+  const highPriority = new Set(["/compare", "/quiz", "/reviews", "/deals", "/share-trading", "/crypto", "/savings", "/super", "/cfd", "/term-deposits", "/robo-advisors", "/versus", "/how-to", "/invest", "/foreign-investment", "/global-investing", "/etfs", "/insurance", "/tax", "/property", "/grants", "/grants/rd-tax-incentive", "/smsf/setup", "/smsf/crypto", "/smsf/property", "/sell-business", "/sell-business/valuation", "/dividends", "/dividends/franking-credits", "/negative-gearing", "/lump-sum-investing", "/lump-sum-investing/redundancy", "/lump-sum-investing/inheritance", "/halal-investing", "/learn", "/first-home-buyer", "/redundancy"]);
   const medPriority = new Set(["/calculators", "/articles", "/scenarios", "/switch", "/stories", "/benchmark", "/health-scores", "/alerts", "/whats-new", "/costs", "/fee-impact", "/compound-interest-calculator", "/dividend-reinvestment-calculator", "/fire-calculator", "/property-vs-shares-calculator", "/super-contributions-calculator", "/tco-calculator", "/invest/mining", "/invest/buy-business", "/invest/farmland", "/invest/commercial-property", "/invest/renewable-energy", "/invest/startups", "/compare/non-residents", "/compare/money-transfer", "/grants/emdg", "/grants/industry-growth-program", "/grants/eligibility-quiz", "/smsf/investment-strategy", "/smsf/checklist", "/sell-business/checklist", "/visa-investment", "/dividends/calculator", "/negative-gearing/calculator", "/lump-sum-investing/calculator",
     "/questions", ...QUESTIONS.map((q) => `/questions/${q.slug}`)]);
   // Everything else (about, how-we-earn, privacy, methodology, terms, etc.) → 0.4
@@ -110,6 +110,8 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     "/tools", "/tools/should-i-switch", "/tools/visa-investment-calculator", "/tools/withholding-tax-calculator",
     "/tools/alternative-returns", "/tools/smsf-checker", "/tools/currency-converter",
     "/tools/fhss-calculator",
+    "/tools/etp-calculator",
+    "/redundancy",
     "/pricing",
     "/firb-fee-estimator", "/non-resident-dividend-calculator", "/non-resident-cgt-checker",
     "/franking-credits-calculator", "/chess-lookup",

--- a/app/tools/ToolsClient.tsx
+++ b/app/tools/ToolsClient.tsx
@@ -270,6 +270,18 @@ const TOOLS: Tool[] = [
     url: "/tools/fhss-calculator",
     internal: true,
   },
+  {
+    slug: "etp-calculator",
+    name: "ETP Tax Calculator",
+    category: "Tax",
+    rating: 5,
+    description:
+      "Calculate the tax on your Employment Termination Payment (ETP) from genuine redundancy. Shows tax-free threshold, concessional ETP rate (17% or 32%), net payout, and saving vs your marginal rate.",
+    pros: ["Tax-free threshold", "17%/32% ETP rates", "Marginal rate comparison"],
+    pricing: "Free tool",
+    url: "/tools/etp-calculator",
+    internal: true,
+  },
 ];
 
 /* ─── Config ─── */

--- a/app/tools/etp-calculator/ETPCalculatorClient.tsx
+++ b/app/tools/etp-calculator/ETPCalculatorClient.tsx
@@ -10,7 +10,7 @@ const TAX_FREE_BASE = 12_524;
 const TAX_FREE_PER_YEAR = 6_264;
 const ETP_CAP = 245_000;
 
-// Preservation age in AU is 60 for those born after 30 June 1964.
+// Preservation age in AU is 60 for those born after 30 June 1964. // dated-ok — fixed legislative threshold, set in superannuation law
 // For simplicity: "at or above 60" → 17%, "under 60" → 32%.
 const ETP_RATE_UNDER_60 = 0.32;
 const ETP_RATE_AT_OR_ABOVE_60 = 0.17;

--- a/app/tools/etp-calculator/ETPCalculatorClient.tsx
+++ b/app/tools/etp-calculator/ETPCalculatorClient.tsx
@@ -1,0 +1,332 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import Link from "next/link";
+import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
+
+// ─── ETP tax constants (FY2025-26) ───────────────────────────────────────────
+
+const TAX_FREE_BASE = 12_524;
+const TAX_FREE_PER_YEAR = 6_264;
+const ETP_CAP = 245_000;
+
+// Preservation age in AU is 60 for those born after 30 June 1964.
+// For simplicity: "at or above 60" → 17%, "under 60" → 32%.
+const ETP_RATE_UNDER_60 = 0.32;
+const ETP_RATE_AT_OR_ABOVE_60 = 0.17;
+const ETP_ABOVE_CAP_RATE = 0.47;
+
+// Medicare levy
+const MEDICARE = 0.02;
+
+/** FY2025-26 marginal rates (excl. Medicare). */
+function marginalRate(income: number): number {
+  if (income <= 18_200) return 0;
+  if (income <= 45_000) return 0.19;
+  if (income <= 135_000) return 0.325;
+  if (income <= 190_000) return 0.37;
+  return 0.45;
+}
+
+interface ETPResult {
+  taxFreeComponent: number;
+  taxableETP: number;
+  etpWithinCap: number;
+  etpAboveCap: number;
+  taxOnETPWithinCap: number;
+  taxOnETPAboveCap: number;
+  totalTaxOnETP: number;
+  netRedundancyPayout: number;
+  effectiveTaxRateOnETP: number;
+}
+
+function calcETP(
+  totalPayout: number,
+  yearsOfService: number,
+  atOrAbove60: boolean,
+): ETPResult {
+  const taxFreeComponent = Math.min(
+    TAX_FREE_BASE + TAX_FREE_PER_YEAR * Math.floor(yearsOfService),
+    totalPayout,
+  );
+  const taxableETP = Math.max(0, totalPayout - taxFreeComponent);
+
+  const etpWithinCap = Math.min(taxableETP, ETP_CAP);
+  const etpAboveCap = Math.max(0, taxableETP - ETP_CAP);
+
+  const concessionalRate = atOrAbove60
+    ? ETP_RATE_AT_OR_ABOVE_60
+    : ETP_RATE_UNDER_60;
+
+  const taxOnETPWithinCap = etpWithinCap * concessionalRate;
+  const taxOnETPAboveCap = etpAboveCap * ETP_ABOVE_CAP_RATE;
+  const totalTaxOnETP = taxOnETPWithinCap + taxOnETPAboveCap;
+
+  const netRedundancyPayout = totalPayout - totalTaxOnETP;
+  const effectiveTaxRateOnETP =
+    taxableETP > 0 ? totalTaxOnETP / taxableETP : 0;
+
+  return {
+    taxFreeComponent,
+    taxableETP,
+    etpWithinCap,
+    etpAboveCap,
+    taxOnETPWithinCap,
+    taxOnETPAboveCap,
+    totalTaxOnETP,
+    netRedundancyPayout,
+    effectiveTaxRateOnETP,
+  };
+}
+
+function fmt(n: number) {
+  return n.toLocaleString("en-AU", { style: "currency", currency: "AUD", maximumFractionDigits: 0 });
+}
+
+function pct(n: number) {
+  return (n * 100).toFixed(1) + "%";
+}
+
+export default function ETPCalculatorClient() {
+  const [totalPayout, setTotalPayout] = useState(150_000);
+  const [yearsOfService, setYearsOfService] = useState(8);
+  const [atOrAbove60, setAtOrAbove60] = useState(false);
+  const [annualIncome, setAnnualIncome] = useState(90_000);
+
+  const result = useMemo(
+    () => calcETP(totalPayout, yearsOfService, atOrAbove60),
+    [totalPayout, yearsOfService, atOrAbove60],
+  );
+
+  const margRate = marginalRate(annualIncome) + MEDICARE;
+
+  // What the taxable ETP would have cost at marginal rate (hypothetical)
+  const marginalTaxEquivalent = result.taxableETP * margRate;
+  const etpTaxSaving = Math.max(0, marginalTaxEquivalent - result.totalTaxOnETP);
+
+  return (
+    <main className="max-w-2xl mx-auto px-4 py-8">
+      <h1 className="text-2xl font-bold text-gray-900 mb-2">
+        ETP Tax Calculator
+      </h1>
+      <p className="text-gray-600 mb-8 text-sm">
+        FY2025–26 rates · Genuine redundancy only · Unused leave is taxed
+        separately as ordinary income
+      </p>
+
+      {/* Inputs */}
+      <section className="bg-white border border-gray-200 rounded-xl p-6 mb-6 space-y-5">
+        <h2 className="font-semibold text-gray-800 text-lg">Your redundancy details</h2>
+
+        <div>
+          <label htmlFor="etp-total-payout" className="block text-sm font-medium text-gray-700 mb-1">
+            Total redundancy payout (excl. leave)
+          </label>
+          <div className="relative">
+            <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 text-sm">$</span>
+            <input
+              id="etp-total-payout"
+              type="number"
+              min={0}
+              max={2_000_000}
+              step={1000}
+              value={totalPayout}
+              onChange={(e) => setTotalPayout(Math.max(0, Number(e.target.value)))}
+              className="w-full border border-gray-300 rounded-lg pl-7 pr-4 py-2.5 text-sm focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500"
+            />
+          </div>
+          <p className="text-xs text-gray-500 mt-1">
+            Genuine redundancy payment only — not unused annual or long-service leave
+          </p>
+        </div>
+
+        <div>
+          <label htmlFor="etp-years" className="block text-sm font-medium text-gray-700 mb-1">
+            Completed years of service
+          </label>
+          <input
+            id="etp-years"
+            type="number"
+            min={0}
+            max={50}
+            step={1}
+            value={yearsOfService}
+            onChange={(e) => setYearsOfService(Math.max(0, Number(e.target.value)))}
+            className="w-full border border-gray-300 rounded-lg px-4 py-2.5 text-sm focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500"
+          />
+          <p className="text-xs text-gray-500 mt-1">
+            Whole years only — partial years do not count toward the tax-free threshold
+          </p>
+        </div>
+
+        <div>
+          <label htmlFor="etp-annual-income" className="block text-sm font-medium text-gray-700 mb-1">
+            Annual salary (before this year&apos;s redundancy)
+          </label>
+          <div className="relative">
+            <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 text-sm">$</span>
+            <input
+              id="etp-annual-income"
+              type="number"
+              min={0}
+              max={2_000_000}
+              step={1000}
+              value={annualIncome}
+              onChange={(e) => setAnnualIncome(Math.max(0, Number(e.target.value)))}
+              className="w-full border border-gray-300 rounded-lg pl-7 pr-4 py-2.5 text-sm focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500"
+            />
+          </div>
+          <p className="text-xs text-gray-500 mt-1">
+            Used to estimate your marginal rate and the ETP tax saving vs ordinary income
+          </p>
+        </div>
+
+        <div>
+          <span className="block text-sm font-medium text-gray-700 mb-2">
+            Your age at time of payment
+          </span>
+          <div className="flex gap-4">
+            {[false, true].map((val) => (
+              <label key={String(val)} className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="radio"
+                  name="etp-age"
+                  checked={atOrAbove60 === val}
+                  onChange={() => setAtOrAbove60(val)}
+                  className="accent-emerald-600"
+                />
+                <span className="text-sm text-gray-700">
+                  {val ? "60 or over" : "Under 60"}
+                </span>
+              </label>
+            ))}
+          </div>
+          <p className="text-xs text-gray-500 mt-1">
+            Determines ETP concessional rate: 17% (60+) or 32% (under 60)
+          </p>
+        </div>
+      </section>
+
+      {/* Results */}
+      <section className="bg-emerald-50 border border-emerald-200 rounded-xl p-6 mb-6">
+        <h2 className="font-semibold text-emerald-900 text-lg mb-5">Estimated ETP breakdown</h2>
+
+        <div className="space-y-3">
+          <Row label="Total redundancy payout" value={fmt(totalPayout)} />
+          <Row
+            label={`Tax-free component ($12,524 + $6,264 × ${Math.floor(yearsOfService)} yrs)`}
+            value={fmt(result.taxFreeComponent)}
+            highlight
+          />
+          <Row label="Taxable ETP" value={fmt(result.taxableETP)} />
+
+          {result.etpAboveCap > 0 && (
+            <>
+              <Row
+                label={`ETP within cap (${atOrAbove60 ? "17%" : "32%"})`}
+                value={fmt(result.etpWithinCap)}
+              />
+              <Row
+                label="ETP above cap (taxed at 47%)"
+                value={fmt(result.etpAboveCap)}
+                warn
+              />
+            </>
+          )}
+
+          <div className="border-t border-emerald-200 pt-3 mt-2 space-y-2">
+            <Row label="Tax on ETP" value={fmt(result.totalTaxOnETP)} />
+            <Row
+              label="Net redundancy payout (after ETP tax)"
+              value={fmt(result.netRedundancyPayout)}
+              bold
+            />
+            <Row
+              label="Effective ETP tax rate"
+              value={pct(result.effectiveTaxRateOnETP)}
+            />
+          </div>
+
+          {etpTaxSaving > 0 && (
+            <div className="mt-4 bg-emerald-100 rounded-lg px-4 py-3">
+              <p className="text-sm text-emerald-800 font-medium">
+                ETP saves you {fmt(etpTaxSaving)} vs your {pct(margRate)} marginal rate
+              </p>
+              <p className="text-xs text-emerald-700 mt-0.5">
+                That&apos;s the benefit of the concessional ETP rate over ordinary income tax
+              </p>
+            </div>
+          )}
+        </div>
+      </section>
+
+      {/* Unused leave note */}
+      <div className="bg-amber-50 border border-amber-200 rounded-xl p-4 mb-6">
+        <p className="text-sm text-amber-800 font-medium mb-1">⚠️ Unused leave is taxed separately</p>
+        <p className="text-sm text-amber-700">
+          Annual leave and long service leave payouts are ordinary income — taxed at your marginal rate,
+          not the ETP concessional rates. They will be on a separate line of your payment summary.
+        </p>
+      </div>
+
+      {/* CTA strip */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-8">
+        <Link
+          href="/find/tax-accountant"
+          className="flex flex-col items-start bg-white border border-gray-200 rounded-xl p-4 hover:border-emerald-400 transition-colors"
+        >
+          <span className="text-xs font-medium text-emerald-700 mb-1">Get professional advice</span>
+          <span className="font-semibold text-gray-900 text-sm">Find a tax accountant →</span>
+          <span className="text-xs text-gray-500 mt-0.5">Before 30 June can save thousands</span>
+        </Link>
+        <Link
+          href="/redundancy"
+          className="flex flex-col items-start bg-white border border-gray-200 rounded-xl p-4 hover:border-emerald-400 transition-colors"
+        >
+          <span className="text-xs font-medium text-emerald-700 mb-1">Full guide</span>
+          <span className="font-semibold text-gray-900 text-sm">Redundancy Hub →</span>
+          <span className="text-xs text-gray-500 mt-0.5">ETP, super strategy, rebuild plan</span>
+        </Link>
+      </div>
+
+      <p className="text-xs text-gray-400 leading-relaxed">{GENERAL_ADVICE_WARNING}</p>
+    </main>
+  );
+}
+
+function Row({
+  label,
+  value,
+  highlight,
+  bold,
+  warn,
+}: {
+  label: string;
+  value: string;
+  highlight?: boolean;
+  bold?: boolean;
+  warn?: boolean;
+}) {
+  return (
+    <div className="flex items-start justify-between gap-4">
+      <span
+        className={`text-sm ${
+          highlight
+            ? "text-emerald-700 font-medium"
+            : warn
+              ? "text-amber-700"
+              : "text-gray-700"
+        }`}
+      >
+        {label}
+      </span>
+      <span
+        className={`text-sm tabular-nums whitespace-nowrap ${
+          bold ? "font-bold text-gray-900" : highlight ? "text-emerald-700 font-medium" : warn ? "text-amber-700" : "text-gray-900"
+        }`}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}

--- a/app/tools/etp-calculator/page.tsx
+++ b/app/tools/etp-calculator/page.tsx
@@ -1,0 +1,70 @@
+import type { Metadata } from "next";
+import { Suspense } from "react";
+import { CURRENT_YEAR, breadcrumbJsonLd, SITE_URL } from "@/lib/seo";
+import { calculatorJsonLd, faqJsonLd } from "@/lib/schema-markup";
+import ETPCalculatorClient from "./ETPCalculatorClient";
+
+export const revalidate = 3600;
+
+export const metadata: Metadata = {
+  title: `ETP Calculator (${CURRENT_YEAR}) — Employment Termination Payment Tax Estimator`,
+  description:
+    "Calculate the tax on your genuine redundancy Employment Termination Payment (ETP). Shows tax-free threshold, concessional ETP rate (17% or 32%), and how much you keep vs leaving at your marginal rate.",
+  alternates: { canonical: `${SITE_URL}/tools/etp-calculator` },
+  openGraph: {
+    title: `ETP Tax Calculator (${CURRENT_YEAR})`,
+    description:
+      "Estimate tax on your redundancy ETP — tax-free threshold, 17%/32% concessional rate, and net payout.",
+    url: `${SITE_URL}/tools/etp-calculator`,
+  },
+};
+
+const breadcrumbLd = breadcrumbJsonLd([
+  { name: "Home", url: "/" },
+  { name: "Tools", url: "/tools" },
+  { name: "ETP Calculator", url: "/tools/etp-calculator" },
+]);
+
+const calcLd = calculatorJsonLd({
+  name: "Employment Termination Payment (ETP) Tax Calculator",
+  description:
+    "Calculate the tax on your genuine redundancy ETP — including the tax-free threshold, concessional ETP tax rate, and net payout after tax.",
+  path: "/tools/etp-calculator",
+});
+
+const faqLd = faqJsonLd([
+  {
+    q: "What is the ETP tax-free threshold for genuine redundancy?",
+    a: "For FY2025-26 the tax-free threshold is $12,524 base plus $6,264 for each completed year of service. Only whole years count — partial years do not increase the threshold.",
+  },
+  {
+    q: "What tax rate applies to the taxable ETP component?",
+    a: "For a Life Benefit ETP (genuine redundancy): 32% if you are under age 60, or 17% if you are 60 or over. These concessional rates apply up to the ETP cap ($245,000 for FY2025-26). Any amount above the cap is taxed at 47%.",
+  },
+  {
+    q: "Is unused annual leave included in the ETP?",
+    a: "No. Unused annual leave and long service leave payouts are separate from the ETP and are taxed as ordinary income at your marginal rate, not the concessional ETP rates.",
+  },
+]);
+
+export default function ETPCalculatorPage() {
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(calcLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }}
+      />
+      <Suspense>
+        <ETPCalculatorClient />
+      </Suspense>
+    </>
+  );
+}

--- a/lib/hub-configs/redundancy.ts
+++ b/lib/hub-configs/redundancy.ts
@@ -1,0 +1,207 @@
+import { CURRENT_YEAR } from "@/lib/seo";
+import type { HubConfig } from "@/lib/verticals";
+
+export const redundancyHubConfig: HubConfig = {
+  slug: "redundancy",
+  title: `Redundancy Hub (${CURRENT_YEAR}) — ETP Tax, Super Strategy & Financial Rebuild`,
+  metaDescription:
+    "Made redundant? Understand your genuine redundancy tax-free threshold, ETP tax rates, when to top up super, and how to rebuild your income over 12 months. Australia's redundancy financial guide.",
+  audiences: ["founder"],
+  complianceKey: "general_advice",
+
+  hero: {
+    headline: "Redundancy Hub",
+    subhead:
+      "Genuine redundancy payments receive a tax-free threshold and a concessional ETP tax rate. The decisions you make in the first 30–90 days determine how much you keep. Here's the roadmap — including when to speak to a tax agent before 30 June.",
+    stats: [
+      {
+        label: "Genuine redundancy tax-free base (FY2025-26)",
+        value: "$12,524",
+        dataAsOf: "2025-07-01",
+        stalesAt: "2026-07-01",
+        source:
+          "https://www.ato.gov.au/individuals-and-families/jobs-and-employment-types/working-as-an-employee/redundancy-and-early-retirement",
+      },
+      {
+        label: "Additional per year of service",
+        value: "$6,264",
+        dataAsOf: "2025-07-01",
+        stalesAt: "2026-07-01",
+        source:
+          "https://www.ato.gov.au/individuals-and-families/jobs-and-employment-types/working-as-an-employee/redundancy-and-early-retirement",
+      },
+      {
+        label: "ETP life benefit cap",
+        value: "$245,000",
+        dataAsOf: "2025-07-01",
+        stalesAt: "2026-07-01",
+        source: "https://www.ato.gov.au/individuals-and-families/jobs-and-employment-types/working-as-an-employee/employment-termination-payments",
+      },
+    ],
+    primaryCta: {
+      label: "ETP Tax Calculator",
+      href: "/tools/etp-calculator",
+      lever: "lead_routing",
+    },
+    secondaryCta: {
+      label: "Find a Tax Accountant",
+      href: "/find/tax-accountant",
+      lever: "lead_routing",
+    },
+  },
+
+  serviceGrid: [
+    {
+      title: "ETP Tax Rules",
+      icon: "shield",
+      description:
+        "Your genuine redundancy payment has a tax-free threshold ($12,524 + $6,264/year of service). The rest is a Life Benefit ETP taxed at 32% (under 60) or 17% (60+). ATO caps this at $245,000.",
+      href: "https://www.ato.gov.au/individuals-and-families/jobs-and-employment-types/working-as-an-employee/employment-termination-payments",
+      cta: "ATO ETP Guide",
+    },
+    {
+      title: "Super Carry-Forward",
+      icon: "trending-up",
+      description:
+        "If your Total Super Balance is under $500k you can make up to 5 years of unused concessional contributions in a single year (carry-forward rule). Redundancy is often the only time this makes financial sense.",
+      href: "https://www.ato.gov.au/individuals-and-families/super-for-individuals-and-families/super/growing-and-keeping-track-of-your-super/contribute-to-your-super/bring-forward-and-carry-forward-contributions",
+      cta: "ATO Carry-Forward",
+    },
+    {
+      title: "Leave Payouts",
+      icon: "calendar",
+      description:
+        "Unused annual and long service leave are NOT part of the ETP — they're taxed as ordinary income at your marginal rate. They're separate from any genuine redundancy payment and paid by your employer.",
+      href: "https://www.ato.gov.au/individuals-and-families/jobs-and-employment-types/working-as-an-employee/redundancy-and-early-retirement",
+      cta: "ATO Leave Guide",
+    },
+    {
+      title: "Cash Buffer First",
+      icon: "home",
+      description:
+        "3–6 months expenses in an offset account or HISA before any investment decision. Average job search time in Australia is 3.2 months for professionals; plan for 6. Don't invest what you may need.",
+      href: "/savings",
+      cta: "Compare Savings Accounts",
+    },
+    {
+      title: "Centrelink Waiting Period",
+      icon: "users",
+      description:
+        "JobSeeker has an Income Maintenance Period — any payout over the Centrelink-free area is counted as income, delaying your first payment by weeks. Plan your cash flow before applying.",
+      href: "https://www.servicesaustralia.gov.au/income-maintenance-period",
+      cta: "Services Australia",
+    },
+    {
+      title: "12-Month Financial Rebuild",
+      icon: "bar-chart",
+      description:
+        "Month 1: cash buffer + tax advice. Month 2–3: update super, review insurances. Month 4–6: invest surplus strategically. Month 7–12: normalise income, review plan. Redundancy is a reset, not a setback.",
+      href: "/lump-sum-investing/redundancy",
+      cta: "Full Rebuild Guide",
+    },
+  ],
+
+  deepDives: [
+    {
+      title: "ETP vs Redundancy Payment: What's the Difference?",
+      excerpt:
+        "Genuine redundancy, invalidity, early retirement — the ATO treats them differently. Your payslip matters for choosing the right tax treatment.",
+      href: "/lump-sum-investing/redundancy",
+      readingTimeMinutes: 7,
+    },
+    {
+      title: "Super Carry-Forward: The Redundancy Supercharge",
+      excerpt:
+        "Up to 5 years of unused concessional cap in one hit — how to calculate your available headroom, which accounts to use, and the 30 June timing trap.",
+      href: "/super",
+      readingTimeMinutes: 9,
+    },
+    {
+      title: "Tax Minimisation in the Redundancy Year",
+      excerpt:
+        "Timing the financial year cut-off, maximising deductions, income averaging strategies, and when a tax agent pays for itself many times over.",
+      href: "/tax",
+      readingTimeMinutes: 8,
+    },
+  ],
+
+  calculators: [
+    { slug: "etp-calculator", label: "ETP Tax Calculator" },
+    { slug: "savings-calculator", label: "Savings Buffer Calculator" },
+  ],
+
+  quizzes: [
+    {
+      slug: "redundancy/quiz",
+      label: "What should I do with my redundancy payout?",
+      routesTo: "general",
+    },
+  ],
+
+  leadMagnets: [
+    {
+      slug: "redundancy-financial-checklist",
+      title: "Redundancy Financial Action Checklist",
+      format: "pdf",
+      listKey: "redundancy-hub",
+    },
+  ],
+
+  newsletter: {
+    listKey: "redundancy-hub",
+    cadence: "weekly",
+  },
+
+  leadQueue: { kind: "general", topic: "redundancy" },
+
+  relatedHubs: ["super", "tax", "lump-sum-investing", "insurance"],
+
+  articleFilters: {
+    category: "redundancy",
+    tags: ["etp", "termination-payment", "super", "tax"],
+  },
+
+  primaryKeywords: [
+    "redundancy payment australia",
+    "etp tax australia",
+    "employment termination payment",
+    "genuine redundancy tax free",
+    "what to do with redundancy payout",
+    "redundancy super contribution",
+  ],
+
+  schemaTypes: ["FAQPage", "WebPage", "FinancialService"],
+
+  faqs: [
+    {
+      question: "Is my redundancy payment tax-free?",
+      answer:
+        "Part of it may be. Genuine redundancy payments receive a tax-free threshold: $12,524 base + $6,264 per completed year of service (FY2025-26 figures). Any amount above the tax-free threshold is a Life Benefit ETP taxed at 32% if you are under preservation age (60), or 17% if you are at or above 60. These rates apply up to the ETP cap ($245,000). Unused leave payouts (annual leave, long service leave) are separate and taxed at ordinary income tax rates.",
+    },
+    {
+      question: "What is an ETP (Employment Termination Payment)?",
+      answer:
+        "An ETP is a lump-sum payment made when your employment is terminated — including redundancy, dismissal, resignation, invalidity, or early retirement schemes. The ATO distinguishes between Life Benefit ETPs (paid while alive — which covers redundancy) and Death Benefit ETPs. For genuine redundancy, the ETP tax rules give a lower tax rate on the taxable component compared to ordinary income tax.",
+    },
+    {
+      question: "What should I do first with my redundancy payout?",
+      answer:
+        "Before any investment decision: (1) Establish a 3–6 month cash buffer in a high-interest savings account or mortgage offset. The average professional job search takes 3–4 months; build for 6 to avoid forced investment decisions. (2) See a tax agent before 30 June — if you receive your payout near year-end, timing decisions around the financial year cut-off can save thousands. (3) Review whether the super carry-forward rule applies to your situation (TSB under $500k + unused concessional cap in prior years).",
+    },
+    {
+      question: "Can I put my redundancy payout into super?",
+      answer:
+        "Not directly — ETPs cannot be rolled into super (ATO rules since 2012). However, if you receive the payout as cash and your Total Super Balance is under $500,000, you may be able to make a personal concessional contribution using the carry-forward rule — claiming up to 5 years of unused concessional cap ($30,000/year in FY2025-26). This is separate from the ETP itself and must be done before 30 June.",
+    },
+    {
+      question: "How long does it take to find a job after redundancy?",
+      answer:
+        "Australian Bureau of Statistics data shows the median job-search duration for retrenched workers is around 10–13 weeks, with professional roles often taking longer. Budget for 6 months when planning your cash buffer. If you receive JobSeeker, note there is an Income Maintenance Period where your payout may delay the start of your benefit by several weeks.",
+    },
+    {
+      question: "Is unused leave taxed differently from my redundancy payout?",
+      answer:
+        "Yes — unused annual leave and long service leave payouts are not part of the ETP or genuine redundancy tax-free calculation. They are treated as ordinary employment income and taxed at your marginal rate (with a withholding component). They appear separately on your payment summary and are not subject to the ETP cap or concessional tax rates.",
+    },
+  ],
+};

--- a/lib/lead-magnets.ts
+++ b/lib/lead-magnets.ts
@@ -139,6 +139,16 @@ export const LEAD_MAGNETS: LeadMagnet[] = [
     downloadUrl: "/downloads/first-home-buyer-guide.pdf",
     coverIcon: "home",
   },
+  {
+    slug: "redundancy-financial-checklist",
+    hubSlug: "redundancy",
+    title: "Redundancy Financial Action Checklist",
+    description:
+      "30-day, 90-day and 12-month roadmap: ETP tax decisions, super carry-forward timing, cash buffer sizing, Centrelink income maintenance period, and when to see a tax agent.",
+    segmentSlug: "redundancy-hub",
+    downloadUrl: "/downloads/redundancy-financial-checklist.pdf",
+    coverIcon: "shield-check",
+  },
 ];
 
 export function getLeadMagnetForHub(hubSlug: string): LeadMagnet | undefined {


### PR DESCRIPTION
## Summary

Ships the redundancy revenue moment — the fastest recurring affiliate CTA (tax accountant) and an ETP calculator covering the $80–300K lump-sum landing.

- **`lib/hub-configs/redundancy.ts`** — full HubConfig: 3 hero stats (tax-free base, per-year amount, ETP cap), 6 service cards (ETP rules, super carry-forward, leave payouts, cash buffer, Centrelink, 12-month rebuild), 3 deep-dives, 2 calculators, 6 FAQs
- **`app/redundancy/page.tsx`** — RSC hub at `/redundancy` using HubPage HOC; `revalidate=3600`; canonical metadata; newsletter + lead magnet + exit-intent wired
- **`app/tools/etp-calculator/page.tsx`** — RSC, JSON-LD (BreadcrumbList + CalculatorSchema + FAQPage), `revalidate=3600`
- **`app/tools/etp-calculator/ETPCalculatorClient.tsx`** — fully client-side: FY2025-26 tax constants, tax-free threshold maths ($12,524 base + $6,264/year), ETP cap ($245k), concessional rates (17%/32%), marginal-rate comparison, unused-leave amber warning
- **`lib/lead-magnets.ts`** — `redundancy-financial-checklist` entry
- **`app/tools/ToolsClient.tsx`** — ETP calculator listing (Tax category)
- **`app/sitemap.ts`** — `/redundancy` + `/tools/etp-calculator` added (high-priority set + static URLs)

## Gates

- `check-dated-strings.mjs` ✅
- `check-jsonld-coverage.mjs` ✅ (all public routes)
- `audit:rate-limits --strict` ✅ 100%
- No schema migrations, no DB writes, no auth changes

## Supersedes

_None._

Refs: #221
Queue: Z-22+BB-07 — DEFAULTS.md slot 33

---
_Generated by [Claude Code](https://claude.ai/code/session_01GgF3Gi5oEfBspBDiX4X4Nx)_