### PR TITLE
feat(dd): DD-01 — tiered advisor listings (Pro + Featured sort) [audit remediation]

### DIFF
--- a/app/advisors/AdvisorsClient.tsx
+++ b/app/advisors/AdvisorsClient.tsx
@@ -445,12 +445,15 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
       case "fee_low": result.sort((a, b) => (a.hourly_rate_cents || a.flat_fee_cents || 999999) - (b.hourly_rate_cents || b.flat_fee_cents || 999999)); break;
       case "fee_high": result.sort((a, b) => (b.hourly_rate_cents || b.flat_fee_cents || 0) - (a.hourly_rate_cents || a.flat_fee_cents || 0)); break;
     }
-    // Featured advisors always appear first within the chosen sort
+    // Tier sort: Featured (gold/featured_until) → Pro → Free
     const now = new Date();
     result.sort((a, b) => {
-      const aFeatured = a.featured_until && new Date(a.featured_until) > now ? 1 : 0;
-      const bFeatured = b.featured_until && new Date(b.featured_until) > now ? 1 : 0;
-      return bFeatured - aFeatured;
+      const tierScore = (p: typeof a) => {
+        if (p.featured_until && new Date(p.featured_until) > now) return 2;
+        if (p.advisor_tier === "pro") return 1;
+        return 0;
+      };
+      return tierScore(b) - tierScore(a);
     });
     return result;
   }, [professionals, nearbyResults, isLocationActive, typeFilters, stateFilter, specialtyFilters, feeFilter, firmFilter, minRating, verifiedOnly, internationalOnly, languageFilter, acceptingOnly, videoOnly, search, sortBy]);
@@ -1179,10 +1182,13 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
 
               const pro = item.pro;
               const isFeatured = !!(pro.featured_until && new Date(pro.featured_until) > new Date());
+              const isProTier = !isFeatured && pro.advisor_tier === "pro";
               return (
                 <Link key={item.key} href={`/advisor/${pro.slug}`} className={`group block bg-white rounded-2xl transition-all duration-200 overflow-hidden ${
                   isFeatured
                     ? "shadow-md shadow-amber-50 hover:shadow-xl hover:shadow-amber-100/50 hover:-translate-y-0.5 ring-1 ring-amber-200/80 border border-amber-200"
+                    : isProTier
+                    ? "shadow-sm border border-violet-100 hover:shadow-md hover:shadow-violet-50 hover:-translate-y-0.5 hover:border-violet-200"
                     : "shadow-sm border border-slate-100 hover:shadow-md hover:shadow-slate-100 hover:-translate-y-0.5 hover:border-slate-200"
                 }`}>
                   {isFeatured && (
@@ -1241,6 +1247,12 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
                               <span className="shrink-0 text-[0.58rem] font-bold px-1.5 py-0.5 rounded-full bg-amber-500 text-white flex items-center gap-0.5 shadow-sm">
                                 <Icon name="star" size={9} />
                                 Featured
+                              </span>
+                            )}
+                            {isProTier && (
+                              <span className="shrink-0 text-[0.58rem] font-bold px-1.5 py-0.5 rounded-full bg-violet-600 text-white flex items-center gap-0.5 shadow-sm">
+                                <Icon name="zap" size={9} />
+                                Pro
                               </span>
                             )}
                             {pro.avg_response_minutes != null && pro.avg_response_minutes <= 120 && (

--- a/app/find/[advisor-type]/[city]/page.tsx
+++ b/app/find/[advisor-type]/[city]/page.tsx
@@ -119,6 +119,7 @@ interface AdvisorRow {
   fee_model: string | null;
   initial_consultation_free: boolean | null;
   is_sponsored: boolean;
+  advisor_tier: string | null;
 }
 
 async function getAdvisors(dbType: string, city: string): Promise<AdvisorRow[]> {
@@ -126,7 +127,7 @@ async function getAdvisors(dbType: string, city: string): Promise<AdvisorRow[]> 
   const { data, error } = await supabase
     .from("professionals")
     .select(
-      "id, name, slug, type, location_suburb, location_state, rating, review_count, verified, photo_url, bio, fee_model, initial_consultation_free, is_sponsored"
+      "id, name, slug, type, location_suburb, location_state, rating, review_count, verified, photo_url, bio, fee_model, initial_consultation_free, is_sponsored, advisor_tier"
     )
     .eq("status", "active")
     .eq("type", dbType)
@@ -192,6 +193,11 @@ function AdvisorCard({ advisor }: { advisor: AdvisorRow }) {
             {advisor.is_sponsored && (
               <span className="ml-2 text-xs bg-blue-50 text-blue-600 px-1.5 py-0.5 rounded font-medium">
                 Featured
+              </span>
+            )}
+            {!advisor.is_sponsored && advisor.advisor_tier === "pro" && (
+              <span className="ml-2 text-xs bg-violet-50 text-violet-700 px-1.5 py-0.5 rounded font-medium">
+                Pro
               </span>
             )}
           </div>

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1106,6 +1106,8 @@ export interface Professional {
   meta_title?: string;
   meta_description?: string;
   featured_until?: string;
+  /** "free" | "pro" | "gold". Drives Pro/Featured badge on listing cards. */
+  advisor_tier?: string | null;
   // Billing fields
   credit_balance_cents?: number;
   lifetime_credit_cents?: number;


### PR DESCRIPTION
## Summary

DD-01 — tiered advisor listings (Free / Pro / Featured). Closes the first item in the DD (marketplace mechanics) stream.

**What changed:**

- `lib/types.ts` — add `advisor_tier?: string | null` to `Professional` interface (the column already exists on `professionals` in the DB; set by the Stripe subscription webhook in `lib/stripe-webhook/handlers/customer-subscription.ts`).
- `app/advisors/AdvisorsClient.tsx` — sort order upgraded from binary featured/not-featured to three tiers: **Featured** (gold/featured_until) → **Pro** (`advisor_tier === "pro"`) → **Free**. Pro-tier advisors get a violet "Pro" badge and subtle violet card border. No change to the existing amber Featured treatment.
- `app/find/[advisor-type]/[city]/page.tsx` — `advisor_tier` added to the Supabase select; Pro-tier advisors get a violet "Pro" badge alongside the existing Verified badge.

**No schema migration** — `professionals.advisor_tier` has existed since the original advisor-billing migrations. The Stripe subscription webhook already sets it to `"pro"` on subscription activation.

**Rollback:** `git revert 137680e` — no DB changes.

## Test plan

- [ ] CI `Lint · Type-check · Test · Build` green (no new TS errors — `advisor_tier` is now in the type)
- [ ] CI `Stripe webhook idempotency gate` green (no new webhook handlers added)
- [ ] Verify: an advisor with `advisor_tier = "pro"` in the DB gets the violet badge + violet card border on `/advisors`
- [ ] Verify: featured sort order correct (gold advisors still at top)

## Supersedes

_None._

https://claude.ai/code/session_01GgF3Gi5oEfBspBDiX4X4Nx

---
_Generated by [Claude Code](https://claude.ai/code/session_01GgF3Gi5oEfBspBDiX4X4Nx)_