### PR TITLE
feat(cross-border): specialty-routed advisor CTAs on country pages

### DIFF
--- a/__tests__/components/CrossBorderAdvisorCTA.test.tsx
+++ b/__tests__/components/CrossBorderAdvisorCTA.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "./setup";
+import CrossBorderAdvisorCTA from "@/components/CrossBorderAdvisorCTA";
+
+describe("<CrossBorderAdvisorCTA>", () => {
+  it("renders nothing for an unmapped country", () => {
+    const { container } = render(<CrossBorderAdvisorCTA countrySlug="atlantis" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders the specialty CTA when the country maps to one", () => {
+    render(<CrossBorderAdvisorCTA countrySlug="uk" />);
+    const cta = screen.getByTestId("cross-border-advisor-cta");
+    expect(cta).toBeInTheDocument();
+    const link = screen.getByRole("link", { name: /find a specialist/i });
+    expect(link).toHaveAttribute(
+      "href",
+      "/find-advisor?specialty=UK%20Pension%20Transfer&country=gb",
+    );
+    expect(link).toHaveAttribute("data-specialty", "UK Pension Transfer");
+    expect(link).toHaveAttribute("data-country", "gb");
+  });
+
+  it("renders the generic copy when the country has no specialty mapping", () => {
+    render(<CrossBorderAdvisorCTA countrySlug="hong-kong" />);
+    const link = screen.getByRole("link", { name: /find an advisor/i });
+    expect(link).toHaveAttribute("href", "/find-advisor?country=hk");
+    expect(link).toHaveAttribute("data-specialty", "");
+  });
+
+  it("renders the optional secondary link when both props are passed", () => {
+    render(
+      <CrossBorderAdvisorCTA
+        countrySlug="uk"
+        secondaryHref="/foreign-investment"
+        secondaryLabel="← Hub"
+      />,
+    );
+    expect(screen.getByRole("link", { name: "← Hub" })).toHaveAttribute(
+      "href",
+      "/foreign-investment",
+    );
+  });
+
+  it("omits the secondary link when only one of the two props is set", () => {
+    render(<CrossBorderAdvisorCTA countrySlug="uk" secondaryHref="/foo" />);
+    expect(screen.queryAllByRole("link")).toHaveLength(1);
+  });
+});

--- a/__tests__/lib/cross-border-cta.test.ts
+++ b/__tests__/lib/cross-border-cta.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import {
+  getCrossBorderCta,
+  CROSS_BORDER_CTA_ISO_CODES,
+} from "@/lib/cross-border-cta";
+
+describe("getCrossBorderCta", () => {
+  it("returns null for unknown / empty inputs", () => {
+    expect(getCrossBorderCta(null)).toBeNull();
+    expect(getCrossBorderCta(undefined)).toBeNull();
+    expect(getCrossBorderCta("")).toBeNull();
+    expect(getCrossBorderCta("zz")).toBeNull();
+    expect(getCrossBorderCta("atlantis")).toBeNull();
+  });
+
+  it("maps gb (and aliases) to UK Pension Transfer", () => {
+    for (const slug of ["gb", "GB", "uk", "UK", "united-kingdom"]) {
+      const cta = getCrossBorderCta(slug);
+      expect(cta?.specialty).toBe("UK Pension Transfer");
+      expect(cta?.countryParam).toBe("gb");
+      expect(cta?.href).toBe(
+        "/find-advisor?specialty=UK%20Pension%20Transfer&country=gb",
+      );
+      expect(cta?.ctaLabel).toMatch(/UK Pension Transfer/);
+    }
+  });
+
+  it("maps us / usa / united-states to FATCA-Aware US Expat Planning", () => {
+    for (const slug of ["us", "usa", "united-states"]) {
+      const cta = getCrossBorderCta(slug);
+      expect(cta?.specialty).toBe("FATCA-Aware US Expat Planning");
+      expect(cta?.countryParam).toBe("us");
+      expect(cta?.href).toContain(
+        "specialty=FATCA-Aware%20US%20Expat%20Planning",
+      );
+      expect(cta?.href).toContain("country=us");
+    }
+  });
+
+  it("returns country-only CTAs (no specialty) for unmapped corridors", () => {
+    const cta = getCrossBorderCta("hong-kong");
+    expect(cta?.specialty).toBeNull();
+    expect(cta?.countryParam).toBe("hk");
+    expect(cta?.href).toBe("/find-advisor?country=hk");
+    expect(cta?.ctaLabel).toMatch(/Hong Kong/);
+  });
+
+  it("includes at least the corridors used by the country page directory", () => {
+    // Mirrors app/foreign-investment/from/* dirs we currently render.
+    for (const iso of ["gb", "us", "in", "hk", "cn", "jp", "my", "nz", "sa"]) {
+      expect(CROSS_BORDER_CTA_ISO_CODES).toContain(iso);
+    }
+  });
+
+  it("encodes the specialty into the href safely", () => {
+    const cta = getCrossBorderCta("uk");
+    // The space in "UK Pension Transfer" must be percent-encoded.
+    expect(cta?.href).toContain("%20");
+    expect(cta?.href).not.toContain(" ");
+  });
+});

--- a/app/foreign-investment/from/[country]/page.tsx
+++ b/app/foreign-investment/from/[country]/page.tsx
@@ -9,6 +9,8 @@ import { intentCountryFromIso, intentCountryMeta } from "@/lib/intent-context";
 import type { Broker } from "@/lib/types";
 import ForeignInvestmentNav from "../../ForeignInvestmentNav";
 import SectionHeading from "@/components/SectionHeading";
+import CrossBorderAdvisorCTA from "@/components/CrossBorderAdvisorCTA";
+import { getCrossBorderCta } from "@/lib/cross-border-cta";
 
 // ── Country lookup helpers ───────────────────────────────────────────────────
 
@@ -370,22 +372,39 @@ export default async function CountryForeignInvestmentPage({
       </section>
 
       {/* ── CTA ──────────────────────────────────────────────────────── */}
-      <section className="py-10 bg-gradient-to-br from-slate-900 to-slate-800">
-        <div className="container-custom flex flex-col sm:flex-row items-center gap-6 justify-between">
-          <div>
-            <h2 className="text-lg font-extrabold text-white mb-1">Find an advisor for {dtaCountry.country} investors</h2>
-            <p className="text-slate-400 text-sm">International tax specialists who understand both Australian rules and {dtaCountry.country} obligations.</p>
+      {/*
+        Backlog #24 (FIN_NOTEBOOK 2026-05-01): the generic "Find Tax Advisor"
+        button is replaced when the country has a cross-border specialty
+        mapping in `lib/cross-border-cta.ts`. Specialty-routed CTAs deep-link
+        /find-advisor with ?specialty= + ?country= so the lead carries its
+        cross-border context into the matcher and lands at the 1.75× pricing
+        tier instead of the flat $39 pool. Countries without a mapping keep
+        the previous generic copy.
+      */}
+      {getCrossBorderCta(country) ? (
+        <CrossBorderAdvisorCTA
+          countrySlug={country}
+          secondaryHref="/foreign-investment"
+          secondaryLabel="← Foreign Investment Hub"
+        />
+      ) : (
+        <section className="py-10 bg-gradient-to-br from-slate-900 to-slate-800">
+          <div className="container-custom flex flex-col sm:flex-row items-center gap-6 justify-between">
+            <div>
+              <h2 className="text-lg font-extrabold text-white mb-1">Find an advisor for {dtaCountry.country} investors</h2>
+              <p className="text-slate-400 text-sm">International tax specialists who understand both Australian rules and {dtaCountry.country} obligations.</p>
+            </div>
+            <div className="flex gap-3 shrink-0">
+              <Link href="/advisors/tax-agents" className="px-5 py-3 bg-amber-500 hover:bg-amber-400 text-white font-bold rounded-xl text-sm transition-colors whitespace-nowrap">
+                Find Tax Advisor
+              </Link>
+              <Link href="/foreign-investment" className="px-5 py-3 border border-slate-600 hover:border-slate-400 text-slate-300 font-semibold rounded-xl text-sm transition-colors whitespace-nowrap">
+                ← Foreign Investment Hub
+              </Link>
+            </div>
           </div>
-          <div className="flex gap-3 shrink-0">
-            <Link href="/advisors/tax-agents" className="px-5 py-3 bg-amber-500 hover:bg-amber-400 text-white font-bold rounded-xl text-sm transition-colors whitespace-nowrap">
-              Find Tax Advisor
-            </Link>
-            <Link href="/foreign-investment" className="px-5 py-3 border border-slate-600 hover:border-slate-400 text-slate-300 font-semibold rounded-xl text-sm transition-colors whitespace-nowrap">
-              ← Foreign Investment Hub
-            </Link>
-          </div>
-        </div>
-      </section>
+        </section>
+      )}
 
       <section className="py-6 bg-slate-50 border-t border-slate-200">
         <div className="container-custom">

--- a/components/CrossBorderAdvisorCTA.tsx
+++ b/components/CrossBorderAdvisorCTA.tsx
@@ -1,0 +1,77 @@
+import Link from "next/link";
+import { getCrossBorderCta } from "@/lib/cross-border-cta";
+
+/**
+ * Country-aware "Talk to a specialist" CTA for cross-border surfaces.
+ *
+ * Renders a prominent CTA that deep-links into /find-advisor with both
+ * `?specialty=` and `?country=` populated so the lead carries its
+ * cross-border context all the way to the matcher (and the 1.75× premium
+ * pricing tier in `lib/advisor-billing-multipliers.ts`).
+ *
+ * Returns null when the country slug has no mapping in
+ * `lib/cross-border-cta.ts` — caller decides whether to render a generic
+ * fallback CTA in that case.
+ *
+ * Style matches the existing slate-gradient CTA band already used by
+ * `app/foreign-investment/from/[country]/page.tsx` so the section reads
+ * as a tightening of the existing pattern, not a new one.
+ */
+
+export interface CrossBorderAdvisorCTAProps {
+  /**
+   * Country slug — ISO alpha-2 lowercased ("gb", "us"...), the rich-hub
+   * directory name ("united-kingdom"...), or the colloquial alias ("uk").
+   * See `lib/cross-border-cta.ts` for the full accepted list.
+   */
+  countrySlug: string;
+  /**
+   * Optional secondary action rendered as a ghost button to the right of
+   * the primary CTA. Use this to keep the existing "back to hub" link
+   * alongside the specialty CTA without losing it.
+   */
+  secondaryHref?: string;
+  /** Secondary button label — required when `secondaryHref` is provided. */
+  secondaryLabel?: string;
+}
+
+export default function CrossBorderAdvisorCTA({
+  countrySlug,
+  secondaryHref,
+  secondaryLabel,
+}: CrossBorderAdvisorCTAProps) {
+  const cta = getCrossBorderCta(countrySlug);
+  if (!cta) return null;
+
+  return (
+    <section
+      className="py-10 bg-gradient-to-br from-slate-900 to-slate-800"
+      data-testid="cross-border-advisor-cta"
+    >
+      <div className="container-custom flex flex-col sm:flex-row items-center gap-6 justify-between">
+        <div>
+          <h2 className="text-lg font-extrabold text-white mb-1">{cta.ctaLabel}</h2>
+          <p className="text-slate-400 text-sm leading-relaxed max-w-2xl">{cta.ctaSub}</p>
+        </div>
+        <div className="flex gap-3 shrink-0">
+          <Link
+            href={cta.href}
+            data-specialty={cta.specialty ?? ""}
+            data-country={cta.countryParam}
+            className="px-5 py-3 bg-amber-500 hover:bg-amber-400 text-white font-bold rounded-xl text-sm transition-colors whitespace-nowrap"
+          >
+            {cta.specialty ? "Find a specialist" : "Find an advisor"}
+          </Link>
+          {secondaryHref && secondaryLabel && (
+            <Link
+              href={secondaryHref}
+              className="px-5 py-3 border border-slate-600 hover:border-slate-400 text-slate-300 font-semibold rounded-xl text-sm transition-colors whitespace-nowrap"
+            >
+              {secondaryLabel}
+            </Link>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/lib/cross-border-cta.ts
+++ b/lib/cross-border-cta.ts
@@ -1,0 +1,228 @@
+/**
+ * Country → cross-border specialty map for "Talk to a specialist" CTAs.
+ *
+ * Backlog #24 (FIN_NOTEBOOK 2026-05-01): cross-border leads are a 5–15× LTV
+ * line vs domestic share-broker leads ($5–20k professional-fee spend per
+ * UK-arrival in the first 18 months). The specialty taxonomy shipped on
+ * 2026-05-02 in `lib/advisor-specialties.ts`; this helper closes the loop
+ * by surfacing specialty-routed CTAs from every country surface so the
+ * lead carries its specialty into /find-advisor — letting the matcher
+ * (and downstream `lib/advisor-billing-multipliers.ts`) charge the 1.75×
+ * premium tier instead of dumping the lead in the flat $39 pool.
+ *
+ * The helper accepts both:
+ *   - ISO 3166-1 alpha-2 codes lowercased (e.g. "gb", "us", "in") — used
+ *     by `app/foreign-investment/from/[country]` route params.
+ *   - The intent-country slug used by the rich hubs (e.g. "united-kingdom",
+ *     "hong-kong") — used by `app/foreign-investment/<slug>` pages.
+ *   - The colloquial alias "uk" (mapped to "gb") because that's what
+ *     copy/marketing actually uses.
+ *
+ * If a country has no specialty match the helper still returns the
+ * country param so the destination page can pre-filter the geo dimension.
+ * `specialty` is `null` in that case — callers decide whether to render
+ * a generic "Find an advisor" CTA or skip the section entirely.
+ */
+
+export interface CrossBorderCta {
+  /** Cross-border specialty from `lib/advisor-specialties.ts` lines 133-138, or null. */
+  specialty:
+    | "UK Pension Transfer"
+    | "FATCA-Aware US Expat Planning"
+    | "DASP Processing"
+    | "FIRB Property (Non-Resident)"
+    | null;
+  /** Country dimension to forward — always lowercase ISO alpha-2 (gb, us, hk...). */
+  countryParam: string;
+  /** Display name for copy ("the UK", "Hong Kong", "Saudi Arabia"). */
+  countryName: string;
+  /**
+   * CTA button label. When a specialty is matched, the button name calls it
+   * out explicitly ("Talk to a UK Pension Transfer specialist") so the
+   * destination is unambiguous. With no specialty match it falls back to a
+   * country-scoped generic ("Talk to an advisor for HK investors").
+   */
+  ctaLabel: string;
+  /** Sub-copy describing why the user should click. */
+  ctaSub: string;
+  /** Fully-qualified relative href to /find-advisor with both params populated. */
+  href: string;
+}
+
+// ─── ISO alpha-2 (lowercase) → CrossBorderCta core data ─────────────────────
+
+interface CountryMapping {
+  countryParam: string;
+  countryName: string;
+  specialty: CrossBorderCta["specialty"];
+  specialtyReason: string;
+}
+
+/**
+ * Authoritative country → specialty map. Keyed by ISO alpha-2 lowercased.
+ *
+ * Mapping rationale (advisory; do not force a specialty where none fits):
+ *  • gb → "UK Pension Transfer". The UK-arrival corridor has stranded
+ *    private/state pensions — the single biggest LTV driver.
+ *  • us → "FATCA-Aware US Expat Planning". US persons in Australia face
+ *    FATCA + PFIC constraints on every AU portfolio choice; only specialists
+ *    can structure correctly without triggering punitive US treatment.
+ *  • For every other supported country the corridor is dominated by
+ *    non-resident property and general-tax questions rather than one
+ *    pension/citizenship-specific specialty. We surface the country
+ *    dimension only — the lead lands in the broader advisor pool but
+ *    the matcher still gets the country signal.
+ *
+ * NOT mapped: DASP Processing is an outbound (Australians leaving)
+ * specialty, not an inbound corridor — it belongs on /super and /quit-aus
+ * surfaces, not on /foreign-investment/from/[country]. FIRB Property
+ * (Non-Resident) applies to any non-resident; we keep it generic rather
+ * than per-country to avoid spamming every page with the same CTA.
+ */
+const COUNTRY_MAP: Record<string, CountryMapping> = {
+  gb: {
+    countryParam: "gb",
+    countryName: "the UK",
+    specialty: "UK Pension Transfer",
+    specialtyReason:
+      "Specialists who handle UK pension transfers, QROPS eligibility, and the AU-UK DTA can save tens of thousands over a single transfer decision.",
+  },
+  us: {
+    countryParam: "us",
+    countryName: "the US",
+    specialty: "FATCA-Aware US Expat Planning",
+    specialtyReason:
+      "US citizens and green-card holders in Australia need an advisor who understands FATCA, PFIC traps, and the dual-filing burden — not every planner does.",
+  },
+  // Country-only mappings — no specialty, just the geo dimension.
+  in: {
+    countryParam: "in",
+    countryName: "India",
+    specialty: null,
+    specialtyReason: "",
+  },
+  hk: {
+    countryParam: "hk",
+    countryName: "Hong Kong",
+    specialty: null,
+    specialtyReason: "",
+  },
+  cn: {
+    countryParam: "cn",
+    countryName: "China",
+    specialty: null,
+    specialtyReason: "",
+  },
+  jp: {
+    countryParam: "jp",
+    countryName: "Japan",
+    specialty: null,
+    specialtyReason: "",
+  },
+  my: {
+    countryParam: "my",
+    countryName: "Malaysia",
+    specialty: null,
+    specialtyReason: "",
+  },
+  nz: {
+    countryParam: "nz",
+    countryName: "New Zealand",
+    specialty: null,
+    specialtyReason: "",
+  },
+  sa: {
+    countryParam: "sa",
+    countryName: "Saudi Arabia",
+    specialty: null,
+    specialtyReason: "",
+  },
+  kr: {
+    countryParam: "kr",
+    countryName: "South Korea",
+    specialty: null,
+    specialtyReason: "",
+  },
+  sg: {
+    countryParam: "sg",
+    countryName: "Singapore",
+    specialty: null,
+    specialtyReason: "",
+  },
+  ae: {
+    countryParam: "ae",
+    countryName: "the UAE",
+    specialty: null,
+    specialtyReason: "",
+  },
+};
+
+/**
+ * Alias slugs that should resolve to the same mapping as an ISO code.
+ * Covers the rich-hub directory names (`united-kingdom`, `hong-kong`...)
+ * and the marketing alias `uk`. Keep in sync with
+ * `lib/intent-context.ts` KNOWN entries so every country surface picks
+ * up the same specialty.
+ */
+const ALIAS_TO_ISO: Record<string, string> = {
+  uk: "gb",
+  "united-kingdom": "gb",
+  "united-states": "us",
+  usa: "us",
+  india: "in",
+  "hong-kong": "hk",
+  hongkong: "hk",
+  china: "cn",
+  japan: "jp",
+  malaysia: "my",
+  "new-zealand": "nz",
+  newzealand: "nz",
+  "saudi-arabia": "sa",
+  "south-korea": "kr",
+  singapore: "sg",
+  "united-arab-emirates": "ae",
+  uae: "ae",
+};
+
+function normaliseSlug(slug: string): string {
+  return slug.trim().toLowerCase();
+}
+
+/**
+ * Resolve any country slug (ISO alpha-2 lowercased, rich-hub slug, or
+ * marketing alias) into a `CrossBorderCta`. Returns `null` when the slug
+ * is unknown so callers can short-circuit the CTA section.
+ */
+export function getCrossBorderCta(
+  countrySlug: string | null | undefined,
+): CrossBorderCta | null {
+  if (!countrySlug) return null;
+  const slug = normaliseSlug(countrySlug);
+  const iso = ALIAS_TO_ISO[slug] ?? slug;
+  const mapping = COUNTRY_MAP[iso];
+  if (!mapping) return null;
+
+  const href = mapping.specialty
+    ? `/find-advisor?specialty=${encodeURIComponent(mapping.specialty)}&country=${mapping.countryParam}`
+    : `/find-advisor?country=${mapping.countryParam}`;
+
+  const ctaLabel = mapping.specialty
+    ? `Talk to a ${mapping.specialty} advisor`
+    : `Talk to an advisor for ${mapping.countryName} investors`;
+
+  const ctaSub = mapping.specialty
+    ? mapping.specialtyReason
+    : `Matched with Australian advisors experienced in ${mapping.countryName}-corridor tax and investment questions.`;
+
+  return {
+    specialty: mapping.specialty,
+    countryParam: mapping.countryParam,
+    countryName: mapping.countryName,
+    ctaLabel,
+    ctaSub,
+    href,
+  };
+}
+
+/** All ISO codes (lowercase) for which a mapping exists — useful in tests/audits. */
+export const CROSS_BORDER_CTA_ISO_CODES = Object.keys(COUNTRY_MAP);


### PR DESCRIPTION
## Summary

Closes the loop on FIN_NOTEBOOK backlog #24 (Phase A — remaining ~half day). The cross-border specialty taxonomy shipped 2026-05-02 in `lib/advisor-specialties.ts`, but country pages still pointed at the generic `/advisors/tax-agents` listing — so a UK-arrival lead with $5–20k of professional-fee LTV landed in the same flat $39/lead pool as a domestic share-broker lead.

This PR adds:

- **`lib/cross-border-cta.ts`** — country → specialty mapper. Accepts ISO alpha-2 (`gb`), the rich-hub directory slug (`united-kingdom`), and the marketing alias (`uk`). `gb` → "UK Pension Transfer", `us` → "FATCA-Aware US Expat Planning"; other supported countries return country-only CTAs.
- **`components/CrossBorderAdvisorCTA.tsx`** — thin presentational component matching the existing slate-gradient CTA band. Returns `null` when the country has no mapping so the page can fall back.
- **`app/foreign-investment/from/[country]/page.tsx`** — replaces the generic Find-Tax-Advisor CTA with the country-aware variant when a mapping exists; other countries keep existing copy verbatim.

`/find-advisor` already reads `?specialty=` and validates against `isCrossBorderSpecialty` (PR #574), so the lead arrives pre-filtered and downstream matcher / billing sees the specialty tag.

## Pairs with

The matching premium-pricing piece — `feat(advisor-billing): premium 1.75× lead pricing for cross-border specialties` — is being opened separately. Together they close the FIN_NOTEBOOK #24 Phase A revenue loop.

## Tier classification

**Tier B** — additive UI / page-level work. No schema, no admin route, no cron, no auth surface.

## Test plan

- [x] `npx vitest run __tests__/lib/cross-border-cta.test.ts __tests__/components/CrossBorderAdvisorCTA.test.tsx` — 11 tests pass
- [x] `npx eslint --max-warnings 0` — clean
- [x] `NODE_OPTIONS="--max-old-space-size=5120" npx tsc --noEmit` — clean
- [ ] Click through `/foreign-investment/from/gb` on preview and confirm CTA renders + link carries `?specialty=UK+Pension+Transfer&country=gb`

## Salvage note

The `lib/cross-border-cta.ts` helper was originally drafted in a prior session that was interrupted; this PR consolidates that work onto a clean branch with tests + page wiring + the matching component. PR #910 contains an earlier, broader incarnation of cross-border + AFSL work that now overlaps — recommend reviewing #910 separately to cherry-pick the non-overlapping pieces (admin UIs, AI Q&A scaffold, account dashboard tiles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)