### PR TITLE
feat(advisor-billing): premium 1.75× lead pricing for cross-border specialties

### DIFF
--- a/__tests__/lib/advisor-billing.test.ts
+++ b/__tests__/lib/advisor-billing.test.ts
@@ -154,6 +154,8 @@ import {
   DEFAULT_TOPUP_CENTS,
   ARTICLE_STANDARD_PRICE_CENTS,
   ARTICLE_FEATURED_PRICE_CENTS,
+  CROSS_BORDER_LEAD_MULTIPLIER,
+  getLeadPriceCents,
 } from "@/lib/advisor-billing";
 
 // ─── Tests ───────────────────────────────────────────────────────────
@@ -449,5 +451,39 @@ describe("handleInvoicePaymentFailed", () => {
     const bu = updateCalls.find((c) => c.table === "advisor_billing");
     expect(bu?.payload.status).toBe("payment_failed");
     expect(bu?.keyVal).toBe(9);
+  });
+});
+
+describe("getLeadPriceCents (cross-border premium)", () => {
+  it("exports the 1.75× multiplier constant", () => {
+    expect(CROSS_BORDER_LEAD_MULTIPLIER).toBe(1.75);
+  });
+
+  it("returns the default for empty specialties", () => {
+    expect(getLeadPriceCents([])).toBe(DEFAULT_LEAD_PRICE_CENTS);
+    expect(getLeadPriceCents([])).toBe(3900);
+  });
+
+  it("returns the default for a non-cross-border specialty", () => {
+    expect(getLeadPriceCents(["SMSF Setup"])).toBe(DEFAULT_LEAD_PRICE_CENTS);
+  });
+
+  it("returns the premium for a single cross-border specialty", () => {
+    expect(getLeadPriceCents(["UK Pension Transfer"])).toBe(6825);
+    expect(getLeadPriceCents(["FATCA-Aware US Expat Planning"])).toBe(6825);
+    expect(getLeadPriceCents(["DASP Processing"])).toBe(6825);
+    expect(getLeadPriceCents(["FIRB Property (Non-Resident)"])).toBe(6825);
+  });
+
+  it("returns the premium when a mix includes any cross-border specialty (cross-border wins)", () => {
+    expect(
+      getLeadPriceCents(["SMSF Setup", "UK Pension Transfer", "Crypto Tax"]),
+    ).toBe(6825);
+  });
+
+  it("computed premium matches DEFAULT × multiplier rounded to nearest cent", () => {
+    expect(getLeadPriceCents(["DASP Processing"])).toBe(
+      Math.round(DEFAULT_LEAD_PRICE_CENTS * CROSS_BORDER_LEAD_MULTIPLIER),
+    );
   });
 });

--- a/lib/advisor-billing-multipliers.ts
+++ b/lib/advisor-billing-multipliers.ts
@@ -20,17 +20,17 @@
  * advisor's `specialties` array.
  */
 
+import { CROSS_BORDER_SPECIALTIES } from "@/lib/advisor-specialties";
+
 /**
  * The 4 cross-border specialties that justify premium pricing
  * (ASIC RG 246-friendly: pricing reflects effort + risk profile +
  * regulatory complexity, not personal advice quality).
+ *
+ * Re-exported from `@/lib/advisor-specialties` so the taxonomy and the
+ * pricing layer can never drift apart — change one place, both update.
  */
-export const CROSS_BORDER_SPECIALTIES: ReadonlyArray<string> = [
-  "UK Pension Transfer",
-  "FATCA-Aware US Expat Planning",
-  "DASP Processing",
-  "FIRB Property (Non-Resident)",
-];
+export { CROSS_BORDER_SPECIALTIES };
 
 /**
  * Multiplier applied on top of base + tier multipliers when the

--- a/lib/advisor-billing.ts
+++ b/lib/advisor-billing.ts
@@ -1,6 +1,8 @@
 import { getStripe } from "@/lib/stripe";
+// eslint-disable-next-line no-restricted-imports -- advisor_billing writes/reads are performed by Stripe webhooks and admin-triggered flows that run without a user JWT; admin client is the documented exception per CLAUDE.md §"Two Supabase clients".
 import { createAdminClient } from "@/lib/supabase/admin";
 import { logger } from "@/lib/logger";
+import { CROSS_BORDER_SPECIALTIES } from "@/lib/advisor-specialties";
 
 const log = logger("advisor-billing");
 
@@ -10,6 +12,34 @@ export const FREE_LEAD_LIMIT = 3; // 3 free leads to prove value
 export const DEFAULT_TOPUP_CENTS = 15000; // A$150 credit top-up (~4 leads)
 export const ARTICLE_STANDARD_PRICE_CENTS = 19900; // A$199 standard article
 export const ARTICLE_FEATURED_PRICE_CENTS = 39900; // A$399 featured article
+
+/**
+ * Cross-border leads (UK pension transfer, FATCA US expat, DASP, FIRB
+ * non-resident property) realise 5–15× the LTV of a domestic share-broker
+ * lead — fees across pension transfer + non-resident mortgage + FX +
+ * FIRB lawyer + ongoing planner + recurring tax stack to $5–20k over
+ * ~18 months. 1.75× is a conservative slice of that asymmetry that
+ * leaves the advisor with most of the margin (see FIN_NOTEBOOK
+ * 2026-05-01 decision, backlog item #24 Phase A).
+ */
+export const CROSS_BORDER_LEAD_MULTIPLIER = 1.75;
+
+/**
+ * Returns the per-lead price in cents for a lead with the given
+ * specialty tags. If any specialty is in the cross-border set sourced
+ * from `lib/advisor-specialties.ts`, applies the
+ * `CROSS_BORDER_LEAD_MULTIPLIER`; otherwise returns the flat default.
+ *
+ * Pure — no DB / Stripe / cookies. Callers that don't have specialty
+ * context should keep using `DEFAULT_LEAD_PRICE_CENTS` directly.
+ */
+export function getLeadPriceCents(specialties: readonly string[]): number {
+  if (specialties.length === 0) return DEFAULT_LEAD_PRICE_CENTS;
+  const crossBorderSet = new Set<string>(CROSS_BORDER_SPECIALTIES);
+  const hasCrossBorder = specialties.some((s) => crossBorderSet.has(s));
+  if (!hasCrossBorder) return DEFAULT_LEAD_PRICE_CENTS;
+  return Math.round(DEFAULT_LEAD_PRICE_CENTS * CROSS_BORDER_LEAD_MULTIPLIER);
+}
 
 /**
  * Get or create a Stripe customer for a professional advisor.

--- a/lib/advisor-specialties.ts
+++ b/lib/advisor-specialties.ts
@@ -1,6 +1,25 @@
 import type { ProfessionalType } from "@/lib/types";
 
 // ═══════════════════════════════════════════════
+// Cross-border specialty set (single source of truth)
+// ═══════════════════════════════════════════════
+//
+// Listed here at module top so downstream pricing/routing modules
+// (`lib/advisor-billing.ts`, `lib/advisor-billing-multipliers.ts`,
+// country-page CTA filters, etc.) can import the canonical list without
+// duplicating the strings. Keep IN SYNC with the "Cross-border & expat"
+// category below — the category spreads this constant.
+
+export const CROSS_BORDER_SPECIALTY_CATEGORY = "Cross-border & expat";
+
+export const CROSS_BORDER_SPECIALTIES: readonly string[] = [
+  "UK Pension Transfer",
+  "FATCA-Aware US Expat Planning",
+  "DASP Processing",
+  "FIRB Property (Non-Resident)",
+];
+
+// ═══════════════════════════════════════════════
 // Specialty Taxonomy
 // ═══════════════════════════════════════════════
 
@@ -128,13 +147,8 @@ export const ADVISOR_SPECIALTY_CATEGORIES: {
     //   • Departing temp visa holders claiming DASP super refunds
     //   • Non-residents buying AU property where FIRB rules + AU credit
     //     history + tax treatment all interact
-    category: "Cross-border & expat",
-    specialties: [
-      "UK Pension Transfer",
-      "FATCA-Aware US Expat Planning",
-      "DASP Processing",
-      "FIRB Property (Non-Resident)",
-    ],
+    category: CROSS_BORDER_SPECIALTY_CATEGORY,
+    specialties: [...CROSS_BORDER_SPECIALTIES],
   },
   {
     // SM-02: Cultural + faith-based routing (added 2026-05-18). Advisors who


### PR DESCRIPTION
## Summary

Closes the second half of FIN_NOTEBOOK backlog #24 Phase A. Pairs with the specialty-routed CTAs PR.

Cross-border leads (UK pension transfer, FATCA US expat, FIRB property non-resident, DASP processing) carry **5–15× the realised LTV** of domestic share-broker leads — UK arrivals consume ~$5–20k of professional fees in 18 months across pension transfer + non-resident mortgage + FX + FIRB lawyer + ongoing planner + tax. They should not price at the flat $39/lead.

## What changed

- **`lib/advisor-billing.ts`** — adds `CROSS_BORDER_LEAD_MULTIPLIER = 1.75` and a pure `getLeadPriceCents(specialties: readonly string[])` helper that returns **6825 cents** ($68.25) when any specialty is in the cross-border set, else **3900 cents** ($39).
- **`lib/advisor-specialties.ts`** — extracts `CROSS_BORDER_SPECIALTIES` as the canonical single-source-of-truth list at module top. The existing "Cross-border & expat" category entry spreads from this constant so taxonomy and pricing can never drift apart.
- **`lib/advisor-billing-multipliers.ts`** — drops its inline duplicate of the 4 cross-border specialty strings and re-exports the canonical list from `advisor-specialties.ts` instead.

## Why this shape

`grep -r DEFAULT_LEAD_PRICE_CENTS` found only the export and the test import — no production call sites use the flat default. Other pricing sites use the per-advisor `lead_price_cents` column from the `professionals` table, which already has no specialty context. The new helper is **standalone**, ready for the matcher / billing layer to call when it wires lead-specialty inference into pricing decisions.

`lib/advisor-billing-multipliers.ts` already had a `CROSS_BORDER_PRICE_MULTIPLIER` + `crossBorderLeadMultiplier()` used by `app/api/advisor-enquiry/route.ts`; both pieces now read the same shared specialty list, which prevents the silent drift that would happen if someone added a new cross-border specialty to one file but not the other.

## Tier classification

**Tier B** — pure lib helper + test, no routes touched, no DB changes. The existing multiplier logic in `advisor-billing-multipliers.ts` is unchanged behaviourally.

## Test plan

- [x] `npx vitest run __tests__/lib/advisor-billing.test.ts` — 20/20 passing (was 14, +6 new)
- [x] Sibling regressions: `advisor-billing-multipliers.test.ts` 22/22, `advisor-specialties.test.ts` 12/12
- [x] `NODE_OPTIONS="--max-old-space-size=5120" npx tsc --noEmit` — clean
- [x] `npx eslint --max-warnings 0` — clean
- [ ] First production call site to use `getLeadPriceCents()` should land in a follow-up PR (likely in the `/api/advisor-enquiry` flow or the marketplace pricing surface — wire-up is intentionally out of scope here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)