### PR TITLE
feat(em): rate-alerts public landing — opt-in surface for the high-intent email list

### DIFF
--- a/__tests__/components/RateAlertSignupForm.test.tsx
+++ b/__tests__/components/RateAlertSignupForm.test.tsx
@@ -1,0 +1,227 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "./setup";
+import userEvent from "@testing-library/user-event";
+import * as nextNavigation from "next/navigation";
+
+// Per-test control over `useSearchParams()` so we can simulate the
+// verify/unsubscribe round-trip. The global mock from `setup.tsx` returns
+// an empty `URLSearchParams` for every test; we use `vi.spyOn` here so we
+// can return a populated one for the token-state tests without rebuilding
+// the entire next/navigation mock.
+import RateAlertSignupForm from "@/app/rate-alerts/RateAlertSignupForm";
+
+function mockFetchOk(payload: Record<string, unknown> = { success: true }) {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(payload),
+  });
+}
+
+function mockFetchError(status: number, error?: string) {
+  return vi.fn().mockResolvedValue({
+    ok: false,
+    status,
+    json: () => Promise.resolve({ error: error ?? "Server error" }),
+  });
+}
+
+function mockFetchNetworkError() {
+  return vi.fn().mockRejectedValue(new TypeError("Failed to fetch"));
+}
+
+describe("RateAlertSignupForm", () => {
+  let originalFetch: typeof globalThis.fetch;
+  let searchParamsSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    searchParamsSpy = vi.spyOn(nextNavigation, "useSearchParams");
+    // Default: empty params, matching the setup.tsx mock. Individual
+    // tests override via `searchParamsSpy.mockReturnValue(...)`.
+    searchParamsSpy.mockReturnValue(
+      new URLSearchParams() as ReturnType<typeof nextNavigation.useSearchParams>,
+    );
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    searchParamsSpy.mockRestore();
+  });
+
+  it("renders the form with default product/frequency and threshold filled", () => {
+    render(<RateAlertSignupForm />);
+    expect(screen.getByTestId("rate-alert-form")).toBeInTheDocument();
+    expect(screen.getByTestId("rate-alert-email")).toBeInTheDocument();
+    expect(screen.getByTestId("rate-alert-threshold")).toHaveValue(5.25);
+    // Default product = savings_account, default frequency = instant.
+    expect(
+      screen.getByTestId("rate-alert-kind-savings_account"),
+    ).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByTestId("rate-alert-freq-instant")).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+  });
+
+  it("rejects an invalid email before hitting the network", async () => {
+    const fetchSpy = mockFetchOk();
+    globalThis.fetch = fetchSpy;
+    const user = userEvent.setup();
+    render(<RateAlertSignupForm />);
+
+    await user.type(screen.getByTestId("rate-alert-email"), "not-an-email");
+    await user.click(screen.getByTestId("rate-alert-submit"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("rate-alert-error")).toHaveTextContent(
+        /valid email/i,
+      );
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects an out-of-range threshold before hitting the network", async () => {
+    const fetchSpy = mockFetchOk();
+    globalThis.fetch = fetchSpy;
+    const user = userEvent.setup();
+    render(<RateAlertSignupForm />);
+
+    await user.type(screen.getByTestId("rate-alert-email"), "finn@example.com");
+    const threshold = screen.getByTestId("rate-alert-threshold");
+    await user.clear(threshold);
+    await user.type(threshold, "120");
+    await user.click(screen.getByTestId("rate-alert-submit"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("rate-alert-error")).toHaveTextContent(
+        /target rate/i,
+      );
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("POSTs the canonical payload shape to /api/rate-alerts", async () => {
+    const fetchSpy = mockFetchOk();
+    globalThis.fetch = fetchSpy;
+    const user = userEvent.setup();
+    render(<RateAlertSignupForm />);
+
+    await user.type(screen.getByTestId("rate-alert-email"), "finn@example.com");
+    await user.click(screen.getByTestId("rate-alert-kind-term_deposit"));
+    await user.click(screen.getByTestId("rate-alert-freq-weekly"));
+    await user.click(screen.getByTestId("rate-alert-submit"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("rate-alert-success")).toBeInTheDocument();
+    });
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    const [url, opts] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/api/rate-alerts");
+    expect(opts.method).toBe("POST");
+    const body = JSON.parse(opts.body as string) as Record<string, unknown>;
+    expect(body).toMatchObject({
+      email: "finn@example.com",
+      product_kind: "term_deposit",
+      threshold_pct: 5.25,
+      frequency: "weekly",
+    });
+    // Honeypot stays empty for a real user.
+    expect(body.website).toBe("");
+  });
+
+  it("shows the success state with the submitted email after a 200", async () => {
+    globalThis.fetch = mockFetchOk();
+    const user = userEvent.setup();
+    render(<RateAlertSignupForm />);
+
+    await user.type(screen.getByTestId("rate-alert-email"), "watcher@example.com");
+    await user.click(screen.getByTestId("rate-alert-submit"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("rate-alert-success")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("rate-alert-success")).toHaveTextContent(
+      "watcher@example.com",
+    );
+  });
+
+  it("surfaces the server error message on a non-2xx response", async () => {
+    globalThis.fetch = mockFetchError(429, "Too many requests.");
+    const user = userEvent.setup();
+    render(<RateAlertSignupForm />);
+
+    await user.type(screen.getByTestId("rate-alert-email"), "finn@example.com");
+    await user.click(screen.getByTestId("rate-alert-submit"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("rate-alert-error")).toHaveTextContent(
+        /too many/i,
+      );
+    });
+  });
+
+  it("falls back to a network-error message on a thrown fetch", async () => {
+    globalThis.fetch = mockFetchNetworkError();
+    const user = userEvent.setup();
+    render(<RateAlertSignupForm />);
+
+    await user.type(screen.getByTestId("rate-alert-email"), "finn@example.com");
+    await user.click(screen.getByTestId("rate-alert-submit"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("rate-alert-error")).toBeInTheDocument();
+    });
+  });
+
+  it("renders the verified state when ?verify=… returns action=verified", async () => {
+    searchParamsSpy.mockReturnValue(
+      new URLSearchParams(
+        "verify=abc123",
+      ) as ReturnType<typeof nextNavigation.useSearchParams>,
+    );
+    globalThis.fetch = mockFetchOk({ success: true, action: "verified" });
+    render(<RateAlertSignupForm />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("rate-alert-verified")).toBeInTheDocument();
+    });
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "/api/rate-alerts?verify=abc123",
+      expect.objectContaining({ signal: expect.anything() }),
+    );
+  });
+
+  it("renders the unsubscribed state when ?unsubscribe=… returns action=unsubscribed", async () => {
+    searchParamsSpy.mockReturnValue(
+      new URLSearchParams(
+        "unsubscribe=xyz789",
+      ) as ReturnType<typeof nextNavigation.useSearchParams>,
+    );
+    globalThis.fetch = mockFetchOk({ success: true, action: "unsubscribed" });
+    render(<RateAlertSignupForm />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("rate-alert-unsubscribed")).toBeInTheDocument();
+    });
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "/api/rate-alerts?unsubscribe=xyz789",
+      expect.objectContaining({ signal: expect.anything() }),
+    );
+  });
+
+  it("renders a token-error state when the verify request returns no action", async () => {
+    searchParamsSpy.mockReturnValue(
+      new URLSearchParams(
+        "verify=expired",
+      ) as ReturnType<typeof nextNavigation.useSearchParams>,
+    );
+    globalThis.fetch = mockFetchOk({ error: "Verification failed." });
+    render(<RateAlertSignupForm />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("rate-alert-token-error")).toBeInTheDocument();
+    });
+  });
+});

--- a/app/rate-alerts/RateAlertSignupForm.tsx
+++ b/app/rate-alerts/RateAlertSignupForm.tsx
@@ -1,0 +1,344 @@
+"use client";
+
+import { useEffect, useState, type FormEvent } from "react";
+import { useSearchParams } from "next/navigation";
+
+// FIN_NOTEBOOK Revenue #4 — public landing-page form. POSTs to the existing
+// `/api/rate-alerts` endpoint (see app/api/rate-alerts/route.ts for the
+// canonical payload shape). Token-driven verify/unsubscribe links from the
+// confirmation email also land back here (via ?verify=… or ?unsubscribe=…),
+// so the component also surfaces those success states.
+
+type ProductKind = "savings_account" | "term_deposit";
+type Frequency = "instant" | "daily" | "weekly";
+type FormStatus = "idle" | "sending" | "done" | "error";
+
+const PRODUCT_LABELS: Record<ProductKind, string> = {
+  savings_account: "Savings account",
+  term_deposit: "Term deposit",
+};
+
+const FREQUENCY_LABELS: Record<Frequency, string> = {
+  instant: "Instant",
+  daily: "Daily digest",
+  weekly: "Weekly digest",
+};
+
+export default function RateAlertSignupForm() {
+  const searchParams = useSearchParams();
+
+  const [email, setEmail] = useState("");
+  const [productKind, setProductKind] = useState<ProductKind>("savings_account");
+  const [thresholdPct, setThresholdPct] = useState("5.25");
+  const [frequency, setFrequency] = useState<Frequency>("instant");
+  // Honeypot — bots fill this, real users never see it. Submit-side checks
+  // are handled server-side (route.ts silently 200s on a non-empty value).
+  const [website, setWebsite] = useState("");
+
+  const [status, setStatus] = useState<FormStatus>("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  // Token states — separate from the form so a verify/unsubscribe round-trip
+  // doesn't reset a half-filled form.
+  const [tokenStatus, setTokenStatus] = useState<
+    "idle" | "verifying" | "verified" | "unsubscribed" | "token_error"
+  >("idle");
+
+  // Depend on the string values (stable) rather than the searchParams
+  // object reference — Next.js returns a new ReadonlyURLSearchParams
+  // instance on each render of pages with `useSearchParams`, which would
+  // otherwise refire this effect indefinitely.
+  const verifyToken = searchParams.get("verify");
+  const unsubToken = searchParams.get("unsubscribe");
+
+  useEffect(() => {
+    if (!verifyToken && !unsubToken) return;
+
+    const ctrl = new AbortController();
+    setTokenStatus("verifying");
+
+    const url = verifyToken
+      ? `/api/rate-alerts?verify=${encodeURIComponent(verifyToken)}`
+      : `/api/rate-alerts?unsubscribe=${encodeURIComponent(unsubToken!)}`;
+
+    fetch(url, { signal: ctrl.signal })
+      .then((res) => res.json().catch(() => ({})))
+      .then((data: { action?: string; error?: string }) => {
+        if (data.action === "verified") {
+          setTokenStatus("verified");
+        } else if (data.action === "unsubscribed") {
+          setTokenStatus("unsubscribed");
+        } else {
+          setTokenStatus("token_error");
+        }
+      })
+      .catch((err: unknown) => {
+        if (err instanceof Error && err.name === "AbortError") return;
+        setTokenStatus("token_error");
+      });
+
+    return () => ctrl.abort();
+  }, [verifyToken, unsubToken]);
+
+  async function submit(e: FormEvent) {
+    e.preventDefault();
+    setError(null);
+
+    const pct = Number.parseFloat(thresholdPct);
+    if (!email || !email.includes("@")) {
+      setError("Please enter a valid email address.");
+      return;
+    }
+    if (!Number.isFinite(pct) || pct <= 0 || pct > 50) {
+      setError("Enter a target rate between 0% and 50%.");
+      return;
+    }
+
+    setStatus("sending");
+    try {
+      const res = await fetch("/api/rate-alerts", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email,
+          product_kind: productKind,
+          threshold_pct: pct,
+          frequency,
+          website,
+        }),
+      });
+      const data = (await res.json().catch(() => ({}))) as { error?: string };
+      if (!res.ok) {
+        throw new Error(data.error || `Request failed (HTTP ${res.status}).`);
+      }
+      setStatus("done");
+    } catch (err) {
+      setStatus("error");
+      setError(err instanceof Error ? err.message : "Network error.");
+    }
+  }
+
+  // ── Token-driven states first (verify / unsubscribe round-trip). ──
+  if (tokenStatus === "verifying") {
+    return (
+      <div
+        data-testid="rate-alert-token-pending"
+        role="status"
+        aria-live="polite"
+        className="rounded-2xl border border-slate-200 bg-white p-6 text-center text-sm text-slate-600 shadow-sm"
+      >
+        Checking your link…
+      </div>
+    );
+  }
+  if (tokenStatus === "verified") {
+    return (
+      <div
+        data-testid="rate-alert-verified"
+        role="status"
+        aria-live="polite"
+        className="rounded-2xl border border-emerald-200 bg-emerald-50 p-6 text-center shadow-sm"
+      >
+        <h2 className="text-base font-bold text-emerald-900">
+          You&apos;re subscribed
+        </h2>
+        <p className="mt-1 text-sm text-emerald-800">
+          We&apos;ll email you the moment an Australian rate beats your
+          threshold.
+        </p>
+      </div>
+    );
+  }
+  if (tokenStatus === "unsubscribed") {
+    return (
+      <div
+        data-testid="rate-alert-unsubscribed"
+        role="status"
+        aria-live="polite"
+        className="rounded-2xl border border-slate-200 bg-slate-50 p-6 text-center shadow-sm"
+      >
+        <h2 className="text-base font-bold text-slate-900">Unsubscribed</h2>
+        <p className="mt-1 text-sm text-slate-600">
+          You&apos;ve been removed from rate alerts. You can resubscribe at any
+          time below.
+        </p>
+      </div>
+    );
+  }
+  if (tokenStatus === "token_error") {
+    return (
+      <div
+        data-testid="rate-alert-token-error"
+        role="alert"
+        className="rounded-2xl border border-amber-200 bg-amber-50 p-6 text-center text-sm text-amber-900 shadow-sm"
+      >
+        That link looks expired or already used. You can re-subscribe below.
+      </div>
+    );
+  }
+
+  if (status === "done") {
+    return (
+      <div
+        data-testid="rate-alert-success"
+        role="status"
+        aria-live="polite"
+        className="rounded-2xl border border-emerald-200 bg-emerald-50 p-6 text-center shadow-sm"
+      >
+        <h2 className="text-base font-bold text-emerald-900">
+          Check your inbox
+        </h2>
+        <p className="mt-1 text-sm text-emerald-800">
+          We&apos;ve sent a confirmation link to{" "}
+          <strong className="break-all">{email}</strong>. Click it to activate
+          your alert.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <form
+      data-testid="rate-alert-form"
+      onSubmit={submit}
+      // noValidate so our own (consistent, accessible) error messages run
+      // instead of the browser's locale-dependent native popups.
+      noValidate
+      className="rounded-2xl bg-slate-900 p-5 text-white shadow-lg md:p-8"
+    >
+      <h2 className="text-lg font-bold md:text-xl">
+        Set up your rate alert — free
+      </h2>
+      <p className="mt-1 text-sm text-slate-300">
+        Double opt-in. One email per match, max one per day. Unsubscribe in one
+        click.
+      </p>
+
+      {/* Honeypot — visually hidden, off-screen, no tab stop. */}
+      <label
+        aria-hidden="true"
+        className="absolute -left-[9999px] top-auto h-px w-px overflow-hidden"
+      >
+        Website
+        <input
+          type="text"
+          name="website"
+          tabIndex={-1}
+          autoComplete="off"
+          value={website}
+          onChange={(e) => setWebsite(e.target.value)}
+        />
+      </label>
+
+      <div className="mt-5 grid gap-4">
+        <label className="block text-sm">
+          <span className="mb-1.5 block text-xs font-semibold text-slate-300">
+            Email address
+          </span>
+          <input
+            data-testid="rate-alert-email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="you@example.com"
+            required
+            autoComplete="email"
+            className="w-full rounded-lg border border-white/20 bg-white/10 px-3 py-2.5 text-sm text-white placeholder:text-slate-500 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400"
+          />
+        </label>
+
+        <fieldset>
+          <legend className="mb-1.5 block text-xs font-semibold text-slate-300">
+            Product
+          </legend>
+          <div className="grid grid-cols-2 gap-2">
+            {(Object.keys(PRODUCT_LABELS) as ProductKind[]).map((kind) => (
+              <button
+                key={kind}
+                type="button"
+                data-testid={`rate-alert-kind-${kind}`}
+                aria-pressed={productKind === kind}
+                onClick={() => setProductKind(kind)}
+                className={`rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
+                  productKind === kind
+                    ? "bg-amber-500 text-white"
+                    : "bg-white/10 text-slate-300 hover:bg-white/15"
+                }`}
+              >
+                {PRODUCT_LABELS[kind]}
+              </button>
+            ))}
+          </div>
+        </fieldset>
+
+        <label className="block text-sm">
+          <span className="mb-1.5 block text-xs font-semibold text-slate-300">
+            Notify me when the headline rate reaches
+          </span>
+          <div className="relative">
+            <input
+              data-testid="rate-alert-threshold"
+              type="number"
+              inputMode="decimal"
+              step="0.05"
+              min="0"
+              max="50"
+              value={thresholdPct}
+              onChange={(e) => setThresholdPct(e.target.value)}
+              placeholder="5.25"
+              required
+              aria-label="Target rate in per cent per annum"
+              className="w-full rounded-lg border border-white/20 bg-white/10 px-3 py-2.5 pr-16 text-sm text-white placeholder:text-slate-500 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400"
+            />
+            <span className="pointer-events-none absolute inset-y-0 right-3 flex items-center text-xs text-slate-400">
+              % p.a.
+            </span>
+          </div>
+        </label>
+
+        <fieldset>
+          <legend className="mb-1.5 block text-xs font-semibold text-slate-300">
+            Frequency
+          </legend>
+          <div className="grid grid-cols-3 gap-2">
+            {(Object.keys(FREQUENCY_LABELS) as Frequency[]).map((f) => (
+              <button
+                key={f}
+                type="button"
+                data-testid={`rate-alert-freq-${f}`}
+                aria-pressed={frequency === f}
+                onClick={() => setFrequency(f)}
+                className={`rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
+                  frequency === f
+                    ? "bg-amber-500 text-white"
+                    : "bg-white/10 text-slate-300 hover:bg-white/15"
+                }`}
+              >
+                {FREQUENCY_LABELS[f]}
+              </button>
+            ))}
+          </div>
+        </fieldset>
+      </div>
+
+      <button
+        data-testid="rate-alert-submit"
+        type="submit"
+        disabled={status === "sending"}
+        className="mt-6 w-full rounded-lg bg-amber-500 px-5 py-3 text-sm font-semibold text-white transition-colors hover:bg-amber-600 disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {status === "sending" ? "Setting your alert…" : "Alert me"}
+      </button>
+
+      {error && (
+        <p
+          data-testid="rate-alert-error"
+          role="alert"
+          className="mt-3 text-sm text-amber-200"
+        >
+          {error}
+        </p>
+      )}
+    </form>
+  );
+}

--- a/app/rate-alerts/page.tsx
+++ b/app/rate-alerts/page.tsx
@@ -1,0 +1,338 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Suspense } from "react";
+
+import Icon from "@/components/Icon";
+import {
+  ADVERTISER_DISCLOSURE_SHORT,
+  GENERAL_ADVICE_WARNING,
+} from "@/lib/compliance";
+import {
+  CURRENT_YEAR,
+  ORGANIZATION_JSONLD,
+  SITE_NAME,
+  SITE_URL,
+  UPDATED_LABEL,
+  absoluteUrl,
+  breadcrumbJsonLd,
+} from "@/lib/seo";
+
+import RateAlertSignupForm from "./RateAlertSignupForm";
+
+// FIN_NOTEBOOK Revenue #4 — public landing page for the rate-alerts
+// opt-in list. The /api/rate-alerts POST endpoint, double-opt-in
+// verification flow, suppression list, and notification cron all already
+// exist; this page is the missing public driver into them.
+//
+// Server component with ISR — the copy is stable, the form below is the
+// only interactive surface and lives in a separate client component
+// (RateAlertSignupForm) wrapped in Suspense so the verify/unsubscribe
+// useSearchParams() call doesn't force the whole page client-side.
+
+export const revalidate = 3600;
+
+const PAGE_PATH = "/rate-alerts";
+const PAGE_TITLE = `Australian Savings & Term-Deposit Rate Alerts (${CURRENT_YEAR})`;
+const PAGE_DESCRIPTION =
+  "Free email alerts the moment an Australian savings account or term deposit beats your target rate. Double opt-in, unsubscribe in one click.";
+
+export const metadata: Metadata = {
+  title: PAGE_TITLE,
+  description: PAGE_DESCRIPTION,
+  alternates: { canonical: PAGE_PATH },
+  openGraph: {
+    title: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+    url: absoluteUrl(PAGE_PATH),
+    images: [
+      {
+        url: "/api/og?title=Australian+Rate+Alerts&subtitle=Email+me+when+savings+rates+beat+my+target&type=default",
+        width: 1200,
+        height: 630,
+        alt: "Australian savings and term-deposit rate alerts",
+      },
+    ],
+  },
+  twitter: { card: "summary_large_image" },
+};
+
+const HOW_IT_WORKS = [
+  {
+    icon: "target" as const,
+    title: "Pick your target rate",
+    body: "Tell us the savings or term-deposit rate you want to beat — e.g. 5.25% p.a. — and how often you'd like to hear from us.",
+  },
+  {
+    icon: "bell" as const,
+    title: "We watch the market",
+    body: "We monitor headline rates across the major Australian banks and challenger brands every day. No tracker apps, no logins, no spreadsheets.",
+  },
+  {
+    icon: "mail" as const,
+    title: "Email when it lands",
+    body: "The moment the headline rate crosses your threshold, we email you with the product, the rate, and a link to compare. One match per day, max.",
+  },
+];
+
+const FAQ_ITEMS = [
+  {
+    question: "Which products do you track?",
+    answer:
+      "Australian high-interest savings accounts and term deposits. We compare the headline (advertised) rate per product — bonus and intro rates may apply, always check the provider's fine print before switching.",
+  },
+  {
+    question: "How often will I get emailed?",
+    answer:
+      "It depends on the frequency you pick. \"Instant\" sends within 24 hours of a match, capped at one email per day. \"Daily\" and \"weekly\" digests batch matches into a single send. We will never spam you and we will never share your email.",
+  },
+  {
+    question: "Is this financial advice?",
+    answer:
+      "No. Rate alerts are factual information — the rate has crossed the threshold you set. We do not assess suitability, recommend a product as right for you, or provide personal financial advice. Always read the provider's PDS and TMD before opening an account.",
+  },
+  {
+    question: "How do I unsubscribe?",
+    answer:
+      "Every alert email contains a one-click unsubscribe link. You can also paste the link from any past email — the token-based unsubscribe works without a login. We honour the request immediately and delete the subscription row.",
+  },
+  {
+    question: "How is my email used?",
+    answer:
+      "Only to send you the alerts you've asked for. We do not on-sell email addresses, we do not run third-party ad pixels on the confirmation flow, and verified subscribers never receive marketing emails by default. See our privacy policy for the full data-processor list.",
+  },
+];
+
+export default function RateAlertsPage() {
+  const breadcrumbs = breadcrumbJsonLd([
+    { name: "Home", url: absoluteUrl("/") },
+    { name: "Rate Alerts" },
+  ]);
+
+  const webPageJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    name: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+    url: absoluteUrl(PAGE_PATH),
+    isPartOf: { "@type": "WebSite", name: SITE_NAME, url: SITE_URL },
+    publisher: ORGANIZATION_JSONLD,
+    inLanguage: "en-AU",
+    primaryImageOfPage: {
+      "@type": "ImageObject",
+      url: `${SITE_URL}/api/og?title=Australian+Rate+Alerts&subtitle=Email+me+when+savings+rates+beat+my+target&type=default`,
+    },
+    mainEntity: {
+      "@type": "FAQPage",
+      mainEntity: FAQ_ITEMS.map((item) => ({
+        "@type": "Question",
+        name: item.question,
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: item.answer,
+        },
+      })),
+    },
+  };
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify([breadcrumbs, webPageJsonLd]),
+        }}
+      />
+
+      <div className="py-5 md:py-12">
+        <div className="container-custom max-w-3xl">
+          {/* Breadcrumb */}
+          <nav className="mb-3 text-xs text-slate-500 md:mb-6 md:text-sm">
+            <Link href="/" className="hover:text-slate-900">
+              Home
+            </Link>
+            <span className="mx-1.5 md:mx-2">/</span>
+            <span className="text-slate-700">Rate Alerts</span>
+          </nav>
+
+          {/* Hero */}
+          <div className="relative mb-6 overflow-hidden rounded-2xl border border-slate-200 bg-white p-5 text-center md:mb-10 md:p-10">
+            <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(245,158,11,0.1),transparent_70%)]" />
+            <div className="relative">
+              <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-2xl bg-amber-50 md:mb-4 md:h-16 md:w-16">
+                <Icon name="bell" size={24} className="text-amber-500 md:hidden" />
+                <Icon
+                  name="bell"
+                  size={32}
+                  className="hidden text-amber-500 md:block"
+                />
+              </div>
+              <h1 className="mb-2 text-xl font-extrabold text-slate-900 md:mb-3 md:text-4xl">
+                Get alerted when Aussie savings rates beat your target
+              </h1>
+              <p className="mx-auto max-w-lg text-sm leading-relaxed text-slate-600 md:text-lg">
+                Set a target rate for a high-interest savings account or term
+                deposit. We&apos;ll email you the moment an Australian bank
+                pushes its headline rate above it. {UPDATED_LABEL}.
+              </p>
+            </div>
+          </div>
+
+          {/* Sign-up form (client component, Suspense-wrapped for
+              useSearchParams()). */}
+          <div className="mb-8 md:mb-12">
+            <Suspense
+              fallback={
+                <div
+                  aria-hidden="true"
+                  className="h-[420px] rounded-2xl bg-slate-100"
+                />
+              }
+            >
+              <RateAlertSignupForm />
+            </Suspense>
+            <p className="mt-3 text-center text-xs text-slate-400">
+              {ADVERTISER_DISCLOSURE_SHORT}
+            </p>
+          </div>
+
+          {/* How it works */}
+          <section className="mb-8 md:mb-12">
+            <h2 className="mb-3 text-lg font-extrabold text-slate-900 md:mb-5 md:text-2xl">
+              How it works
+            </h2>
+            <ol className="grid grid-cols-1 gap-3 md:grid-cols-3">
+              {HOW_IT_WORKS.map((step, i) => (
+                <li
+                  key={step.title}
+                  className="rounded-xl border border-slate-200 bg-white p-4"
+                >
+                  <div className="mb-2 flex items-center gap-2">
+                    <span className="flex h-6 w-6 items-center justify-center rounded-full bg-slate-900 text-[0.65rem] font-bold text-white">
+                      {i + 1}
+                    </span>
+                    <Icon
+                      name={step.icon}
+                      size={18}
+                      className="text-amber-500"
+                    />
+                  </div>
+                  <h3 className="text-sm font-bold text-slate-900">
+                    {step.title}
+                  </h3>
+                  <p className="mt-1 text-xs text-slate-500">{step.body}</p>
+                </li>
+              ))}
+            </ol>
+          </section>
+
+          {/* Why bother */}
+          <section className="mb-8 md:mb-12">
+            <h2 className="mb-3 text-lg font-extrabold text-slate-900 md:mb-5 md:text-2xl">
+              Why bother?
+            </h2>
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+              <div className="rounded-xl border border-slate-200 bg-white p-4">
+                <Icon
+                  name="zap"
+                  size={20}
+                  className="mb-2 text-slate-600"
+                />
+                <h3 className="text-sm font-bold text-slate-900">
+                  Be first when rates move
+                </h3>
+                <p className="mt-1 text-xs text-slate-500">
+                  Headline savings and term-deposit rates change in lockstep
+                  with the RBA cash rate — and during competitive pushes by
+                  challenger banks. Our alert lands the day the rate goes live,
+                  not weeks later.
+                </p>
+              </div>
+              <div className="rounded-xl border border-slate-200 bg-white p-4">
+                <Icon
+                  name="shield"
+                  size={20}
+                  className="mb-2 text-slate-600"
+                />
+                <h3 className="text-sm font-bold text-slate-900">
+                  Independent, free, no broker logins
+                </h3>
+                <p className="mt-1 text-xs text-slate-500">
+                  We&apos;re an editorial comparison site, not a deposit
+                  aggregator. Setting up an alert never asks for your bank
+                  password or any personal financial information beyond your
+                  email.
+                </p>
+              </div>
+            </div>
+          </section>
+
+          {/* FAQ */}
+          <section className="mb-8 md:mb-12">
+            <h2 className="mb-3 text-lg font-extrabold text-slate-900 md:mb-5 md:text-2xl">
+              Frequently asked questions
+            </h2>
+            <div className="divide-y divide-slate-100 overflow-hidden rounded-xl border border-slate-200 bg-white">
+              {FAQ_ITEMS.map((item) => (
+                <details
+                  key={item.question}
+                  className="group p-4 open:bg-slate-50"
+                >
+                  <summary className="flex cursor-pointer items-center justify-between gap-3 text-sm font-semibold text-slate-900 marker:hidden">
+                    <span>{item.question}</span>
+                    <span
+                      aria-hidden="true"
+                      className="text-base text-slate-400 transition-transform group-open:rotate-45"
+                    >
+                      +
+                    </span>
+                  </summary>
+                  <p className="mt-2 text-sm leading-relaxed text-slate-600">
+                    {item.answer}
+                  </p>
+                </details>
+              ))}
+            </div>
+          </section>
+
+          {/* Cross-links to the verticals that drive the same intent */}
+          <section className="mb-8 md:mb-12">
+            <h2 className="mb-3 text-lg font-extrabold text-slate-900 md:mb-5 md:text-2xl">
+              Compare while you wait
+            </h2>
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+              <Link
+                href="/savings"
+                className="block rounded-xl border border-slate-200 bg-white p-4 transition-colors hover:border-amber-300 hover:bg-amber-50"
+              >
+                <h3 className="text-sm font-bold text-slate-900">
+                  Best savings accounts &rarr;
+                </h3>
+                <p className="mt-1 text-xs text-slate-500">
+                  Side-by-side rates, bonus conditions, and accessibility for
+                  the major and challenger banks.
+                </p>
+              </Link>
+              <Link
+                href="/term-deposits"
+                className="block rounded-xl border border-slate-200 bg-white p-4 transition-colors hover:border-amber-300 hover:bg-amber-50"
+              >
+                <h3 className="text-sm font-bold text-slate-900">
+                  Best term deposits &rarr;
+                </h3>
+                <p className="mt-1 text-xs text-slate-500">
+                  Compare 3-, 6-, 12-month and longer terms by headline rate
+                  and minimum deposit.
+                </p>
+              </Link>
+            </div>
+          </section>
+
+          {/* Compliance footer */}
+          <p className="text-center text-[0.7rem] text-slate-400">
+            {GENERAL_ADVICE_WARNING}
+          </p>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -26,7 +26,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   // Static pages with tiered priorities
   const highPriority = new Set(["/compare", "/quiz", "/reviews", "/deals", "/share-trading", "/crypto", "/savings", "/super", "/cfd", "/term-deposits", "/robo-advisors", "/versus", "/how-to", "/invest", "/foreign-investment", "/global-investing", "/etfs", "/insurance", "/tax", "/property", "/grants", "/grants/rd-tax-incentive", "/smsf/setup", "/smsf/crypto", "/smsf/property", "/sell-business", "/sell-business/valuation", "/dividends", "/dividends/franking-credits", "/negative-gearing", "/lump-sum-investing", "/lump-sum-investing/redundancy", "/lump-sum-investing/inheritance", "/halal-investing", "/learn", "/first-home-buyer"]);
-  const medPriority = new Set(["/calculators", "/articles", "/scenarios", "/switch", "/stories", "/benchmark", "/health-scores", "/alerts", "/whats-new", "/costs", "/fee-impact", "/compound-interest-calculator", "/dividend-reinvestment-calculator", "/fire-calculator", "/property-vs-shares-calculator", "/super-contributions-calculator", "/tco-calculator", "/invest/mining", "/invest/buy-business", "/invest/farmland", "/invest/commercial-property", "/invest/renewable-energy", "/invest/startups", "/compare/non-residents", "/compare/money-transfer", "/grants/emdg", "/grants/industry-growth-program", "/grants/eligibility-quiz", "/smsf/investment-strategy", "/smsf/checklist", "/sell-business/checklist", "/visa-investment", "/dividends/calculator", "/negative-gearing/calculator", "/lump-sum-investing/calculator",
+  const medPriority = new Set(["/calculators", "/articles", "/scenarios", "/switch", "/stories", "/benchmark", "/health-scores", "/alerts", "/whats-new", "/costs", "/fee-impact", "/fee-alerts", "/rate-alerts", "/compound-interest-calculator", "/dividend-reinvestment-calculator", "/fire-calculator", "/property-vs-shares-calculator", "/super-contributions-calculator", "/tco-calculator", "/invest/mining", "/invest/buy-business", "/invest/farmland", "/invest/commercial-property", "/invest/renewable-energy", "/invest/startups", "/compare/non-residents", "/compare/money-transfer", "/grants/emdg", "/grants/industry-growth-program", "/grants/eligibility-quiz", "/smsf/investment-strategy", "/smsf/checklist", "/sell-business/checklist", "/visa-investment", "/dividends/calculator", "/negative-gearing/calculator", "/lump-sum-investing/calculator",
     "/questions", ...QUESTIONS.map((q) => `/questions/${q.slug}`)]);
   // Everything else (about, how-we-earn, privacy, methodology, terms, etc.) → 0.4
 
@@ -74,7 +74,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     "/privacy/data-collection", "/privacy/data-rights",
     "/methodology", "/how-we-verify", "/terms", "/switch", "/editorial-policy", "/benchmark",
     "/billing-policy",
-    "/health-scores", "/alerts", "/whats-new", "/costs", "/fee-impact", "/fee-alerts", "/score",
+    "/health-scores", "/alerts", "/whats-new", "/costs", "/fee-impact", "/fee-alerts", "/rate-alerts", "/score",
     "/glossary", "/complaints", "/contact", "/advisors", "/find-advisor", "/find-advisor/life-event", "/community",
     "/community/share-trading", "/community/etfs-index-funds", "/community/crypto",
     "/community/super-retirement", "/community/property", "/community/tax-strategy",


### PR DESCRIPTION
## Summary

Ships the public-facing driver for the existing `/api/rate-alerts` endpoint (FIN_NOTEBOOK ship-now item #4 — "Rate alerts → high-intent email list", smallest build of the backlog, previously 30% built).

The backend (`app/api/rate-alerts/route.ts`, `app/api/cron/rate-alerts/route.ts`) already existed; what was missing was a public page driving signups. This adds it.

## What changed

- **`app/rate-alerts/page.tsx`** — ISR server component (`revalidate = 3600`). Hero + 3-step "how it works" + "why bother" + 5-question FAQ + cross-links to `/savings` & `/term-deposits`. Full `generateMetadata`, BreadcrumbList + WebPage JSON-LD (with FAQPage `mainEntity` inlined).
- **`app/rate-alerts/RateAlertSignupForm.tsx`** — client component. POSTs to `/api/rate-alerts` with the exact zod-validated payload shape: `{ email, product_kind, threshold_pct, frequency, website }`. Handles success / error states and the `?verify=`/`?unsubscribe=` token round-trip.
- **`__tests__/components/RateAlertSignupForm.test.tsx`** — 10 jsdom tests (render, email/threshold validation, payload shape, success/error, verify/unsubscribe round-trip).
- **`app/sitemap.ts`** — adds `/rate-alerts` to the static list under `medPriority` (also moves `/fee-alerts` into the same bucket — it was missing a priority slot).

## Compliance + helpers

- Disclaimer copy sourced from `lib/compliance.ts` (`GENERAL_ADVICE_WARNING`, `ADVERTISER_DISCLOSURE_SHORT`) — no hardcoded disclosures.
- SEO helpers from `lib/seo.ts` (`absoluteUrl`, `breadcrumbJsonLd`, `ORGANIZATION_JSONLD`, `CURRENT_YEAR`, `UPDATED_LABEL`, `SITE_URL`, `SITE_NAME`).
- Form uses `noValidate` so our consistent/accessible error UX runs in place of locale-dependent native browser popups (also makes the validation testable in jsdom).
- The `useEffect` for the verify/unsubscribe round-trip depends on the string token values, not the `searchParams` object reference, because Next.js returns a new `ReadonlyURLSearchParams` instance per render.

## Tier classification

**Tier B** — additive page + sitemap. No schema, no admin, no cron, no auth surface.

## Test plan

- [x] `npx vitest run __tests__/components/RateAlertSignupForm.test.tsx` — 10/10 pass
- [x] Regression: `__tests__/api/rate-alerts.test.ts` 12/12, `__tests__/lib/sitemap.test.ts` 7/7
- [x] `NODE_OPTIONS="--max-old-space-size=5120" npx tsc --noEmit` — clean
- [x] `npx eslint --max-warnings 0` — clean
- [ ] Visit `/rate-alerts` on preview, submit the form, confirm the verify email round-trip works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)