### PR TITLE
chore(quality-dashboard): wire 4 of the 7 null collector slots

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -124,6 +124,12 @@ jobs:
         env:
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          # Powers M07/M08 — Supabase advisors counts via Management API.
+          # Both secrets already exist (added 2026-04-19); they just weren't
+          # passed through to this step previously, so collectAdvisorCounts
+          # returned -1 and the metrics stayed null.
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}
           LIGHTHOUSE_TOP5: ${{ steps.lh.outputs.lighthouse }}
           GITHUB_SHA: ${{ github.sha }}
         run: npx tsx scripts/collect-quality-metrics.ts > /tmp/snapshot.json

--- a/app/account/calendar/page.tsx
+++ b/app/account/calendar/page.tsx
@@ -296,7 +296,7 @@ export default async function CalendarPage() {
           <div className="bg-blue-50 rounded-xl border border-blue-200 p-4">
             <h3 className="font-semibold text-blue-900 text-sm mb-2">Find a tax accountant</h3>
             <p className="text-xs text-blue-700 mb-3">
-              A good accountant typically saves 3–5× their fee by catching deductions you'd miss.
+              A good accountant typically saves 3–5× their fee by catching deductions you&rsquo;d miss.
             </p>
             <Link
               href="/find/tax-accountant"

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -192,7 +192,7 @@ export default function PricingPage() {
             What do Australian financial advisors charge?
           </h1>
           <p className="text-slate-300 max-w-2xl">
-            Typical fee ranges for financial planners, mortgage brokers, accountants, buyer's agents
+            Typical fee ranges for financial planners, mortgage brokers, accountants, buyer&rsquo;s agents
             and SMSF specialists — so you know what to expect before you book a consultation.
           </p>
         </div>

--- a/scripts/collect-quality-metrics.ts
+++ b/scripts/collect-quality-metrics.ts
@@ -134,24 +134,17 @@ async function collectFromSupabase(
   });
   const out: Record<string, number> = {};
 
-  // M04 RLS tables with policies — count distinct tablename in pg_policies
-  const { data: policyData } = await sb
-    .rpc("get_table_count_by_property", { property: "rls_policy" })
-    .single();
-  if (policyData) {
-    out.M04_rls_tables_with_policies =
-      (policyData as { count?: number }).count ?? 0;
+  // M04 RLS tables with policies — calls a SECURITY DEFINER RPC that wraps
+  // `SELECT COUNT(DISTINCT tablename) FROM pg_policies WHERE schemaname='public'`.
+  // Prior implementation tried `sb.from("pg_policies")` directly; PostgREST
+  // doesn't expose Postgres system views so that always returned null. The
+  // RPC migration is `supabase/migrations/20260519000000_metric_rls_tables_with_policies.sql`.
+  const { data: rlsCount } = await sb.rpc(
+    "metric_rls_tables_with_policies" as never,
+  );
+  if (typeof rlsCount === "number") {
+    out.M04_rls_tables_with_policies = rlsCount;
   }
-
-  // Fallback: when the helper RPC isn't available, query directly via REST.
-  // Keep RPC path above so a future Phase-3 RPC can short-circuit. For now
-  // we use direct queries via the JS client.
-
-  // RLS tables with policies — distinct count
-  const { count: rlsCount } = await sb
-    .from("pg_policies" as never)
-    .select("tablename", { count: "exact", head: true });
-  if (rlsCount != null) out.M04_rls_tables_with_policies = rlsCount;
 
   // M09 cron success rate (7d)
   const sevenDays = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
@@ -191,12 +184,36 @@ async function collectFromSupabase(
 async function collectAdvisorCounts(
   ctx: CollectorContext,
 ): Promise<{ M07: number; M08: number }> {
-  // The Supabase advisor count is reachable via the management API; in CI
-  // we proxy through a small admin route so the SUPABASE_ACCESS_TOKEN isn't
-  // shared with all jobs. For now, emit baseline + log a warning so the
-  // dashboard renders — replaceable when /api/admin/supabase-advisors lands.
+  // Calls the Supabase Management API directly. Requires SUPABASE_ACCESS_TOKEN
+  // + SUPABASE_PROJECT_ID env vars (set in the code-quality.yml workflow from
+  // GitHub Actions secrets of the same name). When either is missing the
+  // collector skips this metric pair instead of crashing the whole run —
+  // M07/M08 stay null but the rest of the dashboard still updates.
   void ctx;
-  return { M07: -1, M08: -1 };
+  const token = envOr("SUPABASE_ACCESS_TOKEN");
+  const projectId = envOr("SUPABASE_PROJECT_ID");
+  if (!token || !projectId) {
+    return { M07: -1, M08: -1 };
+  }
+  async function countAdvisors(kind: "security" | "performance"): Promise<number> {
+    const res = await fetch(
+      `https://api.supabase.com/v1/projects/${projectId}/advisors?type=${kind}`,
+      { headers: { Authorization: `Bearer ${token}` } },
+    );
+    if (!res.ok) return -1;
+    const body = (await res.json()) as { lints?: unknown[] } | unknown[];
+    if (Array.isArray(body)) return body.length;
+    return Array.isArray(body.lints) ? body.lints.length : -1;
+  }
+  try {
+    const [M07, M08] = await Promise.all([
+      countAdvisors("security"),
+      countAdvisors("performance"),
+    ]);
+    return { M07, M08 };
+  } catch {
+    return { M07: -1, M08: -1 };
+  }
 }
 
 function collectFromCoverageJson(): Record<string, number> {
@@ -285,8 +302,11 @@ function collectFromGrep(): Record<string, number> {
       .trim();
     void inTypes;
     // We don't have a precise live count without DB access from CI; emit the
-    // CREATE TABLE count and let the snapshot delta show the trend.
-    out.M05_migration_drift_create_tables = parseInt(sql, 10) || 0;
+    // CREATE TABLE count and let the snapshot delta show the trend. Key
+    // matches the id in `.quality-targets.yml` (`M05_migration_drift`) so
+    // the dashboard picks it up — previously emitted under a `_create_tables`
+    // suffix that no target row matched, leaving M05 perpetually null.
+    out.M05_migration_drift = parseInt(sql, 10) || 0;
   } catch {
     /* noop */
   }

--- a/supabase/migrations/20260519000000_metric_rls_tables_with_policies.sql
+++ b/supabase/migrations/20260519000000_metric_rls_tables_with_policies.sql
@@ -1,0 +1,26 @@
+-- Powers M04_rls_tables_with_policies on the weekly code-quality dashboard.
+--
+-- Why: pg_policies is a Postgres system view; PostgREST doesn't expose it
+-- by default, so the prior collector's direct `sb.from("pg_policies")` call
+-- returned 0 rows and the metric stayed null. A SECURITY DEFINER function
+-- with EXECUTE granted to service_role lets the CI collector read the
+-- count without exposing the underlying view to authenticated/anon.
+--
+-- Returns: integer count of DISTINCT (schemaname, tablename) pairs with at
+-- least one row in pg_policies, filtered to the `public` schema.
+--
+-- Rollback: DROP FUNCTION IF EXISTS public.metric_rls_tables_with_policies();
+
+CREATE OR REPLACE FUNCTION public.metric_rls_tables_with_policies()
+RETURNS integer
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+  SELECT COUNT(DISTINCT tablename)::integer
+  FROM pg_policies
+  WHERE schemaname = 'public';
+$$;
+
+REVOKE ALL ON FUNCTION public.metric_rls_tables_with_policies() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.metric_rls_tables_with_policies() TO service_role;


### PR DESCRIPTION
## Why this exists

The `/admin/code-quality` dashboard has been showing **F (0.24)** — not because the codebase is bad, but because **7 of the 12 metrics return null** on the weekly Sunday 23:00 UTC run, so the weighted score includes zeros for half the inputs.

I'd been told the root cause was missing GitHub Actions secrets. It isn't — `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` were added on 2026-05-08 (11 days ago) and the workflow correctly maps them. The collector itself has three independent bugs.

## Fixes in this PR

### 1. `M05_migration_drift` — key-name mismatch (1 line)

Collector emitted as `M05_migration_drift_create_tables`; `.quality-targets.yml` looks for `M05_migration_drift`. The mismatch meant the snapshot writer silently dropped the value as "unknown id" and the dashboard showed null forever. Renamed the output key.

### 2. `M07_supabase_security_advisors` + `M08_supabase_perf_advisors` — was a stub

`collectAdvisorCounts()` had `return { M07: -1, M08: -1 }` with a TODO comment ("replaceable when `/api/admin/supabase-advisors` lands"). Replaced with a direct call to the Supabase Management API (`https://api.supabase.com/v1/projects/{ref}/advisors?type=security|performance`) using `SUPABASE_ACCESS_TOKEN` + `SUPABASE_PROJECT_ID` (both secrets already exist; just weren't passed to the collect step before). Falls through silently if either env var is missing — keeps the rest of the dashboard updating instead of crashing the whole run.

Also updated `.github/workflows/code-quality.yml` to pass both secrets to the collect step.

### 3. `M04_rls_tables_with_policies` — wrong query approach

Prior collector did `sb.from("pg_policies").select("tablename", { count: "exact", head: true })` — but `pg_policies` is a Postgres system view that PostgREST doesn't expose, so this always returned null. Added a `SECURITY DEFINER` RPC:

```sql
CREATE OR REPLACE FUNCTION public.metric_rls_tables_with_policies()
RETURNS integer
LANGUAGE sql SECURITY DEFINER
SET search_path = pg_catalog, public
AS $$
  SELECT COUNT(DISTINCT tablename)::integer FROM pg_policies WHERE schemaname = 'public';
$$;
REVOKE ALL ON FUNCTION public.metric_rls_tables_with_policies() FROM PUBLIC;
GRANT EXECUTE ON FUNCTION public.metric_rls_tables_with_policies() TO service_role;
```

Migration `supabase/migrations/20260519000000_metric_rls_tables_with_policies.sql` is already applied to live via Supabase MCP — so this PR landing on main + the migration file replaying on fresh envs are both safe (idempotent `CREATE OR REPLACE`). Collector now calls `sb.rpc("metric_rls_tables_with_policies")` instead.

## Still null after this PR (separate follow-ups)

- **M01 × 3 (test coverage)** — workflow runs `npm run test:coverage` but `coverage-summary.json` isn't present at collect time. Needs Actions log forensics; likely the coverage step crashes silently or writes to a different path.
- **M11 (Lighthouse top-5 mobile)** — actually shipped 0 (real value, not null), because the LH step `continue-on-error`s when the build is slow on the runner. Separate problem.

## Side fixes

- `app/pricing/page.tsx` + `app/account/calendar/page.tsx` — 2 pre-existing `react/no-unescaped-entities` warnings (`'` → `&rsquo;`) that lint-staged blocks on every PR that merges main. Same fix is already on PRs #906 and #877 (waiting for merge); proactively re-applied here so this PR isn't blocked.

## Tier classification

**Tier C** — touches new migration (idempotent RPC) + GitHub Actions workflow env block. No code-path / runtime behaviour changes; collector runs Sundays only.

## Test plan

- [x] `NODE_OPTIONS="--max-old-space-size=5120" npx tsc --noEmit` (via pre-push hook) — clean
- [x] `npx eslint --max-warnings 0` (via lint-staged) — clean
- [x] Migration applied to live via Supabase MCP — confirmed `success: true`
- [ ] Manually trigger the workflow (`gh workflow run code-quality.yml`) to verify the snapshot now has values for M04 / M05 / M07 / M08 instead of null
- [ ] After Sunday's run, confirm `docs/audits/metrics-latest.json` reflects the populated metrics + dashboard grade improves