### PR TITLE
fix(account-button): stop the loading skeleton hanging forever + unblock prod build

### DIFF
--- a/__tests__/lib/hooks-useUser.test.tsx
+++ b/__tests__/lib/hooks-useUser.test.tsx
@@ -62,6 +62,28 @@ describe("useUser", () => {
     expect(result.current.user).toBeNull();
   });
 
+  it("falls back to logged-out after the timeout when getUser never settles", async () => {
+    vi.useFakeTimers();
+    try {
+      // A promise that neither resolves nor rejects — simulates the
+      // TLS / fetch deadlock case where supabase.auth.getUser() hangs
+      // forever. Without the timeout fallback, `loading` would stay
+      // true and AccountButton would sit on its skeleton indefinitely.
+      getUserImpl = () => new Promise<{ data: { user: unknown } }>(() => {});
+      const { result } = renderHook(() => useUser());
+      expect(result.current.loading).toBe(true);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5500);
+      });
+
+      expect(result.current.loading).toBe(false);
+      expect(result.current.user).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("upgrades state when onAuthStateChange fires", async () => {
     const { result } = renderHook(() => useUser());
     await waitFor(() => expect(result.current.loading).toBe(false));

--- a/lib/hooks/useUser.ts
+++ b/lib/hooks/useUser.ts
@@ -4,6 +4,15 @@ import { useEffect, useState } from "react";
 import { createClient } from "@/lib/supabase/client";
 import type { User } from "@supabase/supabase-js";
 
+// supabase.auth.getUser() has been observed to neither resolve nor reject
+// when the auth service is unreachable (TLS / fetch deadlock at the edge).
+// .catch() alone doesn't help — a promise that never settles never rejects,
+// so `loading` would stay true and AccountButton + every downstream
+// auth-gated UI stays pinned in its loading skeleton forever. Cap the
+// initial call: well above typical ~200ms response, short enough that the
+// user sees an actionable Sign In control rather than a stuck skeleton.
+const INITIAL_GET_USER_TIMEOUT_MS = 5000;
+
 export function useUser() {
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
@@ -12,32 +21,29 @@ export function useUser() {
     const supabase = createClient();
     let cancelled = false;
 
-    // Get initial user.
-    //
-    // The previous version had no .catch() — if supabase.auth.getUser()
-    // rejected (network failure, auth service down), `loading` would stay
-    // true forever and every component downstream (AccountButton, shortlist,
-    // compare CTAs, subscription checks) would sit in its loading skeleton
-    // indefinitely. This blocked the whole authenticated UI on a single
-    // transient failure.
+    const fallbackTimer = setTimeout(() => {
+      if (cancelled) return;
+      // Treat as logged-out on timeout; onAuthStateChange below still
+      // upgrades state if a real session resolves later.
+      setUser(null);
+      setLoading(false);
+    }, INITIAL_GET_USER_TIMEOUT_MS);
+
     supabase.auth
       .getUser()
       .then(({ data }) => {
         if (cancelled) return;
+        clearTimeout(fallbackTimer);
         setUser(data.user);
         setLoading(false);
       })
       .catch(() => {
         if (cancelled) return;
-        // Treat as logged-out rather than hanging the UI forever. The
-        // onAuthStateChange subscription below will still upgrade state
-        // if the user actually has a valid session once the service is
-        // reachable again.
+        clearTimeout(fallbackTimer);
         setUser(null);
         setLoading(false);
       });
 
-    // Listen for auth changes
     const {
       data: { subscription },
     } = supabase.auth.onAuthStateChange((_event, session) => {
@@ -47,6 +53,7 @@ export function useUser() {
 
     return () => {
       cancelled = true;
+      clearTimeout(fallbackTimer);
       subscription.unsubscribe();
     };
   }, []);

--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,13 @@ const bundleAnalyzer = withBundleAnalyzer({
 });
 
 const nextConfig: NextConfig = {
+  // Default is 60s. Bumped because the Supabase project sits in eu-west-1
+  // while Vercel builds run in iad1 (US East) — every prerender query pays
+  // ~80-100ms of cross-region latency, and the parallel fan-out during
+  // static export occasionally pushes the slowest broker / advisor pages
+  // past 60s. 180s leaves headroom without masking a genuinely-broken
+  // page (Next.js still retries 3 times before failing).
+  staticPageGenerationTimeout: 180,
   experimental: {
     // Reduce aggressive prefetching — only prefetch on hover, not on viewport
     optimisticClientCache: false,


### PR DESCRIPTION
## What and why

Two narrowly-scoped fixes for two separate problems that surfaced in the same session:

### 1. `lib/hooks/useUser.ts` — skeleton can't hang forever

The AccountButton skeleton was getting stuck for logged-in users on the live site. Root cause: `supabase.auth.getUser()` was occasionally neither resolving nor rejecting (TLS / fetch deadlock at the edge). The existing `.catch()` covers rejections, but a promise that never settles also never rejects — so `loading` stayed `true` forever and every auth-gated client component (AccountButton, shortlist CTAs, compare gates, paywalls) sat on its skeleton with no way out. That matches the user-reported "skeleton stuck + tap does nothing" symptom.

Fix: time-box the initial call at 5s. If it doesn't settle, treat as logged-out (the user sees Sign In / Sign Up). If a real session resolves later, `onAuthStateChange` still upgrades state — no functional regression for slow-but-eventual responses, just a brief Sign-In flash in the worst case.

### 2. `next.config.ts` — bump `staticPageGenerationTimeout` to 180s

The most recent production deploy for `main@681079a` failed at the export phase: `/brokers/full-service/{shaw-and-partners,morgans-financial,ord-minnett}` each hit Next.js's default 60s per-page cap on all 3 retry attempts. Cross-region latency from `iad1` build runners → `eu-west-1` Supabase project (~80-100ms × hundreds of parallel queries during static export) pushes the slowest pages past the 60s ceiling.

Bumping to 180s (3× default) leaves headroom without masking a genuinely broken page — Next.js still retries 3 times before failing, so a hung query still surfaces, just with breathing room. Pure config change; no runtime behaviour change for any request-time path.

## What this is NOT

- This is **not** a fix for the underlying cross-region Supabase latency or the layout-feature-flag fetch storm. That's the proper long-term fix and needs a separate change (de-dupe the 4 layout `isFlagEnabled` reads across prerender workers, ideally migrate Supabase closer to the build region).
- The webhook is **not** broken — Vercel is receiving every push from main; recent production builds were failing in state `ERROR`, not missing. A prior session diagnosed it incorrectly as a webhook outage.

## Test plan

- [x] `npx vitest run __tests__/lib/hooks-useUser.test.tsx` — 7/7 pass, including new `falls back to logged-out after the timeout when getUser never settles` test
- [x] `tsc --noEmit` clean
- [x] `eslint --max-warnings 0` on touched files clean
- [x] Pre-push hook (tsc + rate-limit audit + test:changed) passed on push
- [ ] After merge: confirm production build completes (the 3 broker pages should no longer time out)
- [ ] After merge: confirm logged-in users see their account avatar within ≤5s, never a stuck skeleton

---
_Generated by [Claude Code](https://claude.ai/code/session_01U2oorjGt5XQ6u4xt4sJCE2)_