### PR TITLE
perf(feature-flags): cross-worker L2 cache to stop build-time fetch storm

### DIFF
--- a/lib/feature-flags.ts
+++ b/lib/feature-flags.ts
@@ -22,6 +22,8 @@
  * a flag in the admin UI propagates within one cron cycle.
  */
 
+import { unstable_cache } from "next/cache";
+// eslint-disable-next-line no-restricted-imports -- feature_flags is service-role-only by design (no anon SELECT policy); admin client is the correct read path per CLAUDE.md § "Two Supabase clients" → "Tables with service_role-only policies"
 import { createAdminClient } from "@/lib/supabase/admin";
 import { logger } from "@/lib/logger";
 
@@ -137,7 +139,73 @@ export function evaluateFlag(
 }
 
 /**
- * Read a flag row from the DB, with 30-second in-process cache.
+ * Inner Supabase fetch — the part wrapped by Next.js `unstable_cache` for
+ * cross-worker deduplication. Always returns `FlagRow | null` (never
+ * throws) so cache entries are stable even on timeout / network failure.
+ *
+ * Telemetry (`last_evaluated_at` update) stays OUTSIDE this function so it
+ * fires from the live caller, not from a cached-result replay — otherwise
+ * the cron's "actively-used vs dormant" signal would only update on the
+ * first call per cache lifetime.
+ */
+async function fetchFlagRow(flagKey: string): Promise<FlagRow | null> {
+  if (isPlaceholderSupabase()) return null;
+  try {
+    const supabase = createAdminClient();
+    const { data, error } = await supabase
+      .from("feature_flags")
+      .select("flag_key, enabled, rollout_pct, allowlist, denylist, segments, archived_at")
+      .eq("flag_key", flagKey)
+      .is("archived_at", null)
+      .abortSignal(AbortSignal.timeout(FETCH_TIMEOUT_MS))
+      .maybeSingle();
+    if (error) {
+      log.warn("feature_flags fetch failed", {
+        flag: flagKey,
+        error: error.message,
+      });
+      return null;
+    }
+    return (data as FlagRow | null) || null;
+  } catch (err) {
+    log.warn("feature_flags threw", {
+      flag: flagKey,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}
+
+/**
+ * L2 cross-worker cache (Next.js `unstable_cache`). Critical during
+ * static export: the build spawns ~29 worker processes, each with its
+ * own L1 (in-process) cache. Without L2, every worker independently
+ * fetches every layout-level flag (`chatbot_widget`, `report_button`,
+ * `push_notifications`, `newsletter_exit_intent`) — 29 × 4 = 116 calls
+ * for the first wave alone, plus refetches every 25s as L1 entries
+ * expire. Cross-Atlantic latency (Supabase eu-west-1 ↔ Vercel iad1)
+ * then turns that into a fetch storm that exceeds the 60s static-page
+ * generation timeout and fails the build.
+ *
+ * `unstable_cache` shares one entry per cacheKey across all workers via
+ * the `.next/cache/fetch-cache` directory. 60s revalidate balances
+ * worker dedup (fast) with admin-UI flag-flip propagation (~1 min).
+ *
+ * Runtime impact is also positive: serverless functions warming up
+ * read from the shared cache instead of each calling Supabase.
+ */
+const cachedFetchFlagRow = unstable_cache(
+  fetchFlagRow,
+  ["feature-flag-row-v1"],
+  { revalidate: 60, tags: ["feature-flags"] },
+);
+
+/**
+ * Read a flag row from the DB, with two-layer caching:
+ *  - L1: per-process Map (30s TTL, fastest, used by serverless hot paths)
+ *  - L2: Next.js unstable_cache (cross-worker, ~60s TTL, kills build-time
+ *    fetch storms)
+ *
  * Fail-open: DB errors return null → evaluateFlag() returns false.
  */
 export async function loadFlag(flagKey: string): Promise<FlagRow | null> {
@@ -153,56 +221,48 @@ export async function loadFlag(flagKey: string): Promise<FlagRow | null> {
     return null;
   }
 
+  // L2 fetch. fetchFlagRow already swallows errors and returns null,
+  // so the unstable_cache entry is always stable (null or row, never
+  // a thrown exception). On a true Supabase outage L2 caches null
+  // for 60s — matching the prior negative-cache intent at scale.
+  //
+  // Falls back to the raw fetcher when unstable_cache throws (E469 in
+  // vitest — no Next.js incremental-cache context) so unit tests and
+  // any other environment without a Next request context still work.
+  let row: FlagRow | null;
   try {
-    const supabase = createAdminClient();
-    const { data, error } = await supabase
-      .from("feature_flags")
-      .select("flag_key, enabled, rollout_pct, allowlist, denylist, segments, archived_at")
-      .eq("flag_key", flagKey)
-      .is("archived_at", null)
-      .abortSignal(AbortSignal.timeout(FETCH_TIMEOUT_MS))
-      .maybeSingle();
-    if (error) {
-      log.warn("feature_flags fetch failed", {
-        flag: flagKey,
-        error: error.message,
-      });
-      // Short negative-cache so a transient Supabase blip doesn't
-      // bury every flag in the 30s positive cache, but repeated
-      // reads within one render don't each pay the timeout.
-      cache.set(flagKey, { row: null, at: now - CACHE_TTL_MS + NEGATIVE_CACHE_TTL_MS });
-      return null;
-    }
-    const row = (data as FlagRow | null) || null;
-    cache.set(flagKey, { row, at: now });
-    // FF-04: fire-and-forget — lets the expiry cron tell an actively-used
-    // disabled flag from a truly dormant one without blocking the caller.
-    if (row) {
-      void supabase
-        .from("feature_flags")
-        .update({ last_evaluated_at: new Date().toISOString() })
-        .eq("flag_key", flagKey)
-        .then(({ error: writeErr }) => {
-          if (writeErr) {
-            log.warn("feature_flags last_evaluated_at update failed", {
-              flag: flagKey,
-              error: writeErr.message,
-            });
-          }
-        });
-    }
-    return row;
-  } catch (err) {
-    log.warn("feature_flags threw", {
-      flag: flagKey,
-      err: err instanceof Error ? err.message : String(err),
-    });
-    // Same short negative-cache window on thrown errors (timeout,
-    // DNS failure, network) so the next read in this render returns
-    // immediately instead of waiting another FETCH_TIMEOUT_MS.
+    row = await cachedFetchFlagRow(flagKey);
+  } catch {
+    row = await fetchFlagRow(flagKey);
+  }
+
+  if (row === null) {
+    // Short negative-cache in L1 so repeated reads within one render
+    // don't each pay the L2 (or worse, a fresh Supabase) round-trip
+    // after a 60s revalidate window expires. Matches the original
+    // 5s negative-cache TTL.
     cache.set(flagKey, { row: null, at: now - CACHE_TTL_MS + NEGATIVE_CACHE_TTL_MS });
     return null;
   }
+
+  cache.set(flagKey, { row, at: now });
+  // FF-04: fire-and-forget — lets the expiry cron tell an actively-used
+  // disabled flag from a truly dormant one without blocking the caller.
+  // Stays outside the L2 cache so it fires once per L1 miss (≈ once per
+  // 30s per worker) rather than only on the first call per L2 lifetime.
+  void createAdminClient()
+    .from("feature_flags")
+    .update({ last_evaluated_at: new Date().toISOString() })
+    .eq("flag_key", flagKey)
+    .then(({ error: writeErr }) => {
+      if (writeErr) {
+        log.warn("feature_flags last_evaluated_at update failed", {
+          flag: flagKey,
+          error: writeErr.message,
+        });
+      }
+    });
+  return row;
 }
 
 export async function isFlagEnabled(


### PR DESCRIPTION
## Root cause this fixes

Production builds have been failing intermittently because static export hits the 4 layout-level flags (\`chatbot_widget\`, \`report_button\`, \`push_notifications\`, \`newsletter_exit_intent\`) from every prerendered page, and Next.js spawns ~29 worker processes that each maintain an independent L1 in-process cache. Each worker × each flag = independent Supabase round-trip from Vercel iad1 (US East) to Supabase eu-west-1 (~100ms cross-Atlantic) + the 3s timeout when the connection pool exhausts.

Symptoms in recent build logs:
- Hundreds of \`feature_flags fetch failed — TimeoutError\` lines
- 3 broker pages (\`/brokers/full-service/shaw-and-partners\`, \`morgans-financial\`, \`ord-minnett\`) failing prerender past the 60s page-generation timeout
- Cascading deploy ERRORs for the last several main pushes

## What changed

Wrap the inner Supabase fetch with Next.js \`unstable_cache\` (L2). Shares one entry per (flag, cacheKey) across all workers via the \`.next/cache/fetch-cache\` directory. Reduces build-time Supabase calls from O(workers × flags × retries) → O(flags). 60s revalidate keeps admin-UI flag flips propagating in ~1 minute.

L1 (per-process Map, 30s TTL) stays — it's the fastest path for hot runtime serverless paths within a single worker. L2 is purely additive.

## Other refactors in this commit

- **Split read from telemetry.** \`fetchFlagRow()\` is the pure read (cached by L2). \`last_evaluated_at\` update stays in \`loadFlag()\` outside the cache, so the FF-04 cron's "actively-used vs dormant" signal still fires once per L1 miss (≈ once per 30s per worker) instead of only on the first call per L2 lifetime.
- **Fail-open wrapper around the \`unstable_cache\` call** so vitest / any env without an active Next.js incremental-cache context (throws E469) falls through to the raw fetcher. Existing 20 unit tests pass unchanged.
- **Justified \`eslint-disable\`** on the \`createAdminClient\` import — the \`feature_flags\` table is service-role-only by design (no anon SELECT policy), so admin client is the correct read path per CLAUDE.md § "Two Supabase clients" → "Tables with service_role-only policies". Same warning was pre-existing but blocked lint-staged on any edit.

## Tier classification

**Tier B** — pure lib change, no schema, no API surface, no auth. Behaviour preserved at runtime (L1 cache, fail-open, telemetry firing semantics) with new L2 cache layer added.

## Test plan

- [x] \`npx vitest run __tests__/lib/feature-flags.test.ts\` — 20/20 pass (existing suite, no changes needed)
- [x] \`NODE_OPTIONS=\"--max-old-space-size=5120\" npx tsc --noEmit\` — clean
- [x] \`npx eslint --max-warnings 0 lib/feature-flags.ts\` — clean
- [ ] After this lands + a deploy succeeds, watch the build log for the prior \`feature_flags fetch failed\` flood — should be near-zero (only first hit per flag per L2 revalidate window)
- [ ] Confirm a flag flip in \`/admin/automation/flags\` is visible on the live site within ~60s

## Doesn't fix (separate work)

- Cross-Atlantic latency itself — proper fix is migrating Supabase to a US region (~30min planned downtime, separate maintenance window)
- The 3 broker pages may still time out individually if their own Supabase queries are slow — staticPageGenerationTimeout was bumped 60s→180s in #938 which should cover them

🤖 Generated with [Claude Code](https://claude.com/claude-code)