### PR TITLE
perf(infra): tier-S caching + Vercel region wins (Audit PR 1/7)

### DIFF
--- a/app/api/afsl/[number]/route.ts
+++ b/app/api/afsl/[number]/route.ts
@@ -16,7 +16,12 @@ import { getAfslLicensee, normaliseAfslNumber } from "@/lib/afsl-register";
 import { isAllowed, ipKey } from "@/lib/rate-limit-db";
 
 export const runtime = "nodejs";
-export const dynamic = "force-dynamic";
+// 1h ISR cache. Data is the public AFSL register — same response for all
+// callers, safe to CDN-cache. Previously `dynamic = "force-dynamic"`
+// silently nullified the `s-maxage=86400` header set at the bottom of
+// the file. Rate-limit still applies on cache misses (function invocations);
+// the cache absorbs the bulk of repeat lookups.
+export const revalidate = 3600;
 
 type Params = { params: Promise<{ number: string }> };
 

--- a/app/api/og/advisor/route.tsx
+++ b/app/api/og/advisor/route.tsx
@@ -258,6 +258,10 @@ export async function GET(request: NextRequest) {
     {
       width: 1200,
       height: 630,
+      headers: {
+        "Cache-Control":
+          "public, max-age=86400, s-maxage=2592000, stale-while-revalidate=86400",
+      },
     }
   );
 }

--- a/app/api/og/broker/route.tsx
+++ b/app/api/og/broker/route.tsx
@@ -237,6 +237,10 @@ export async function GET(request: NextRequest) {
     {
       width: 1200,
       height: 630,
+      headers: {
+        "Cache-Control":
+          "public, max-age=86400, s-maxage=2592000, stale-while-revalidate=86400",
+      },
     }
   );
 }

--- a/app/api/og/how-to/route.tsx
+++ b/app/api/og/how-to/route.tsx
@@ -202,6 +202,10 @@ export async function GET(request: NextRequest) {
     {
       width: 1200,
       height: 630,
+      headers: {
+        "Cache-Control":
+          "public, max-age=86400, s-maxage=2592000, stale-while-revalidate=86400",
+      },
     }
   );
 }

--- a/app/api/og/route.tsx
+++ b/app/api/og/route.tsx
@@ -124,6 +124,15 @@ export async function GET(request: NextRequest) {
     {
       width: 1200,
       height: 630,
+      headers: {
+        // Crawlers (Google, Twitter, Facebook, LinkedIn, Slack) hit OG
+        // routes on every link share. PNG render = font load + JSX → PNG
+        // encode, which is the slowest thing this app does at runtime.
+        // 24h browser + 30d shared (CDN) means a popular link shared 1k
+        // times triggers ~1 actual render instead of 1k.
+        "Cache-Control":
+          "public, max-age=86400, s-maxage=2592000, stale-while-revalidate=86400",
+      },
     }
   );
 }

--- a/app/api/og/versus/route.tsx
+++ b/app/api/og/versus/route.tsx
@@ -318,6 +318,10 @@ export async function GET(request: NextRequest) {
     {
       width: 1200,
       height: 630,
+      headers: {
+        "Cache-Control":
+          "public, max-age=86400, s-maxage=2592000, stale-while-revalidate=86400",
+      },
     }
   );
 }

--- a/app/api/og/vertical/route.tsx
+++ b/app/api/og/vertical/route.tsx
@@ -256,6 +256,10 @@ export async function GET(request: NextRequest) {
     {
       width: 1200,
       height: 630,
+      headers: {
+        "Cache-Control":
+          "public, max-age=86400, s-maxage=2592000, stale-while-revalidate=86400",
+      },
     }
   );
 }

--- a/app/api/v1/brokers/[slug]/route.ts
+++ b/app/api/v1/brokers/[slug]/route.ts
@@ -5,6 +5,8 @@ import { validateApiKey, logApiRequest, API_CORS_HEADERS } from "@/lib/api-auth"
 import { escapeHtml } from "@/lib/html-escape";
 
 export const runtime = "nodejs";
+// Per-key auth gating — see /api/v1/brokers/route.ts for the same reasoning.
+// Browser-level cache only via `Cache-Control: private` below.
 export const dynamic = "force-dynamic";
 
 const log = logger("api-v1-broker-slug");
@@ -198,7 +200,7 @@ export async function GET(
         status: 200,
         headers: {
           ...API_CORS_HEADERS,
-          "Cache-Control": "public, max-age=3600",
+          "Cache-Control": "private, max-age=3600",
         },
       },
     );

--- a/app/api/v1/brokers/route.ts
+++ b/app/api/v1/brokers/route.ts
@@ -5,6 +5,10 @@ import { validateApiKey, logApiRequest, API_CORS_HEADERS } from "@/lib/api-auth"
 import { escapeHtml } from "@/lib/html-escape";
 
 export const runtime = "nodejs";
+// Keep force-dynamic: per-API-key allowed_endpoints + rate limits mean
+// CDN sharing across keys would bypass access control. The Cache-Control
+// header below uses `private` so each consumer's browser caches their
+// own copy for 1h, but Vercel's shared edge cache doesn't.
 export const dynamic = "force-dynamic";
 
 const log = logger("api-v1-brokers");
@@ -222,7 +226,7 @@ export async function GET(request: NextRequest) {
         status: 200,
         headers: {
           ...API_CORS_HEADERS,
-          "Cache-Control": "public, max-age=3600",
+          "Cache-Control": "private, max-age=3600",
         },
       },
     );

--- a/app/api/v1/compare/route.ts
+++ b/app/api/v1/compare/route.ts
@@ -208,7 +208,7 @@ export async function GET(request: NextRequest) {
         status: 200,
         headers: {
           ...API_CORS_HEADERS,
-          "Cache-Control": "public, max-age=3600",
+          "Cache-Control": "private, max-age=3600",
         },
       },
     );

--- a/app/api/widget/route.ts
+++ b/app/api/widget/route.ts
@@ -3,7 +3,11 @@ import { createStaticClient } from "@/lib/supabase/static";
 import { getWidgetCatalogueEntry } from "@/lib/widget/types";
 
 export const runtime = "nodejs";
-export const dynamic = "force-dynamic";
+// 1h ISR cache. Previously `dynamic = "force-dynamic"` which silently
+// nullified the `Cache-Control: max-age=3600` header below — every
+// partner embed re-rendered the widget on every page view. Vercel
+// now serves the same JS payload from the CDN edge for 1h.
+export const revalidate = 3600;
 
 /**
  * GET /api/widget — Returns self-contained JavaScript that renders an

--- a/app/feed.xml/route.ts
+++ b/app/feed.xml/route.ts
@@ -2,6 +2,10 @@ import { createClient } from "@/lib/supabase/server";
 
 const SITE_URL = "https://invest.com.au";
 
+// 1h ISR — articles publish at most a few per day; aggressive caching is fine.
+// Pairs with the Cache-Control header on the response below.
+export const revalidate = 3600;
+
 export async function GET() {
   const supabase = await createClient();
   const { data: articles } = await supabase
@@ -60,7 +64,8 @@ export async function GET() {
   return new Response(xml, {
     headers: {
       "Content-Type": "application/xml; charset=utf-8",
-      "Cache-Control": "public, max-age=3600, s-maxage=3600",
+      "Cache-Control":
+        "public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400",
     },
   });
 }

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,5 +1,10 @@
 import type { MetadataRoute } from "next";
 
+// Pure constant generation — no DB, no request state. Pin static so
+// Next.js bakes the output at build time instead of re-running the
+// function on every crawler hit.
+export const dynamic = "force-static";
+
 export default function robots(): MetadataRoute.Robots {
   const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://invest.com.au";
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -32,7 +32,9 @@ const nextConfig: NextConfig = {
     formats: ["image/avif", "image/webp"],
     deviceSizes: [640, 750, 828, 1080, 1200, 1920],
     imageSizes: [16, 32, 48, 64, 96, 128, 256],
-    minimumCacheTTL: 86400,
+    // Image URLs are content-keyed via `?url=&w=&q=` — collisions impossible.
+    // 30d (was 24h) cuts repeat transform credits + bandwidth significantly.
+    minimumCacheTTL: 2592000,
     remotePatterns: [
       {
         protocol: "https",

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,7 @@
 {
   "ignoreCommand": "bash scripts/vercel-skip-build.sh",
+  "_regions_note": "Pin serverless + ISR functions to Dublin so they're co-located with Supabase eu-west-1. Cross-region RTT drops from ~80ms (iad1 ↔ eu-west-1) to ~5ms (dub1 ↔ eu-west-1) — every server-rendered page benefits. AU end-users still hit Vercel's Sydney CDN POP for cached/ISR pages, so only the rare uncached SSR pays the extra ~50ms first-byte vs iad1.",
+  "regions": ["dub1"],
   "crons": [
     { "path": "/api/cron/dispatch/every-15m", "schedule": "*/15 * * * *" },
     { "path": "/api/cron/dispatch/every-30m", "schedule": "0,30 * * * *" },


### PR DESCRIPTION
First of the 4-agent perf-audit follow-up PRs. Pure config / cache-header changes — zero behaviour changes for users beyond faster responses.

## Changes

### 1. `vercel.json` — pin functions to Dublin (`dub1`)
Co-locates Vercel serverless + ISR functions with Supabase eu-west-1. **Cross-region RTT drops from ~80ms (iad1 ↔ eu-west-1) to ~5ms (dub1 ↔ eu-west-1)** for every server-rendered page. Builds also run in `dub1` now — should eliminate the cross-Atlantic fetch storms that were failing prerender on broker pages.

AU end-users still hit Vercel's Sydney CDN POP for cached pages; only the rare uncached SSR pays ~50ms more first-byte vs `iad1`.

### 2. `next.config.ts` — image cache TTL 24h → 30d
Image URLs are content-keyed via `?url=&w=&q=`; collisions impossible. Cuts repeat transform credits + bandwidth.

### 3. Drop `force-dynamic` on 2 truly-public routes
- `app/api/widget/route.ts` — embeddable JS, no auth. Now 1h ISR.
- `app/api/afsl/[number]/route.ts` — public AFSL lookup, rate-limited but not access-gated. Now 1h ISR.

Both previously had `Cache-Control` headers silently nullified by `force-dynamic`'s implicit `no-store`.

### 4. Three v1 auth-gated routes — `private` cache instead of `public`
Per-key `allowed_endpoints` + rate limits mean CDN sharing across keys would bypass access control. The old `public, max-age=3600` was a bug (one consumer could get another's cached response). Now `private, max-age=3600` — each consumer's browser caches their own copy, CDN doesn't share:
- `app/api/v1/brokers/route.ts`
- `app/api/v1/brokers/[slug]/route.ts`
- `app/api/v1/compare/route.ts`

### 5. Six OG image routes — add Cache-Control
Social crawlers (Google, Twitter, FB, LinkedIn, Slack) currently re-render the PNG on every hit (font load + JSX → PNG = slowest runtime path). Adding `public, max-age=86400, s-maxage=2592000, stale-while-revalidate=86400` to every `ImageResponse`. **1000 daily shares → ~1 actual render**:
- `app/api/og/{,broker,advisor,versus,how-to,vertical}/route.tsx`

### 6. `app/robots.ts` — `dynamic = "force-static"`
Pure constant generation; was re-rendering on every crawler hit.

### 7. `app/feed.xml/route.ts` — add ISR + SWR
Articles publish ~few/day. Added `revalidate = 3600` + `stale-while-revalidate=86400` to the response header.

## Tier classification

**Tier B** — touches `vercel.json` (deploy config) + multiple `app/api/*` routes. Cron schedule unchanged. No schema, no migrations.

## Test plan

- [x] `npx eslint --max-warnings 0` clean on every touched file
- [x] `npx vitest run __tests__/api/widget.test.ts __tests__/api/afsl-lookup.test.ts` — 22/22 pass
- [x] `python3 -m json.tool vercel.json` — valid JSON
- [x] Pre-push hook (`tsc --noEmit` + rate-limit audit + changed-file tests) — all green
- [ ] After deploy: verify `invest-com-au.vercel.app` still serves; new build should run in `dub1` (visible in build logs) and complete faster than recent iad1 builds
- [ ] After deploy: verify OG image cache headers via `curl -I https://invest-com-au.vercel.app/api/og?title=test`
- [ ] After deploy: verify `/api/widget?widget=cheapest-brokers` returns `Cache-Control: public, max-age=3600` and serves edge-cached on second hit

## Audit reports this PR implements

From the 4-agent perf audit findings (4 agents, ~3000 words each):
- Agent 4 (caching/CDN/edge/region) — items A, B, D, E, F
- Agent 3 (images) — section H gap (image cache TTL)

Remaining audit work will land as PRs 2-7 over this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)