### PR TITLE
perf(images): LCP priority hints + avatar preconnects (Audit PR 4/7)

### DIFF
--- a/app/advisors/AdvisorsClient.tsx
+++ b/app/advisors/AdvisorsClient.tsx
@@ -1205,7 +1205,7 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
                             width={80}
                             height={80}
                             className="w-full h-full object-cover"
-                            priority={index < 3}
+                            priority={index === 0}
                             placeholder="blur"
                             blurDataURL="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI4IiBoZWlnaHQ9IjgiPjxyZWN0IHdpZHRoPSI4IiBoZWlnaHQ9IjgiIGZpbGw9IiNlMmU4ZjAiLz48L3N2Zz4="
                           />

--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -412,7 +412,11 @@ export default async function ArticlesPage({
           <>
             <div className="grid grid-cols-2 md:grid-cols-2 lg:grid-cols-3 gap-2.5 md:gap-6">
               {flatFiltered.map((article, idx) => (
-                <ArticleCard key={article.id} article={article} priority={idx < 3} />
+                // Only the single LCP candidate (first card) gets
+                // `priority`. Marking 3 cards as priority was an
+                // anti-pattern — splits the network budget and DELAYS
+                // the real LCP image.
+                <ArticleCard key={article.id} article={article} priority={idx === 0} />
               ))}
             </div>
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -141,9 +141,17 @@ export default async function RootLayout({
       {/* Inline script adds .js-ready immediately so CSS animations only run when JS is available.
           Without this, hero-fade-up starts at opacity:0 and stays invisible until JS loads. */}
       <head>
-        {/* Preconnect to external APIs for faster initial requests */}
+        {/* Preconnect to external APIs for faster initial requests.
+            ui-avatars + randomuser back avatar fallbacks across
+            advisor listings (/find-advisor, /advisors) where the
+            avatar is the LCP candidate — preconnect saves ~100-300 ms
+            of connection setup on cold visits. */}
         <link rel="preconnect" href="https://guggzyqceattncjwvgyc.supabase.co" />
         <link rel="dns-prefetch" href="https://guggzyqceattncjwvgyc.supabase.co" />
+        <link rel="preconnect" href="https://ui-avatars.com" crossOrigin="anonymous" />
+        <link rel="dns-prefetch" href="https://ui-avatars.com" />
+        <link rel="preconnect" href="https://randomuser.me" crossOrigin="anonymous" />
+        <link rel="dns-prefetch" href="https://randomuser.me" />
         <link rel="manifest" href="/manifest.json" />
         <link rel="alternate" type="application/rss+xml" title="Invest.com.au Articles" href="/feed.xml" />
         <script dangerouslySetInnerHTML={{ __html: "document.documentElement.classList.add('js-ready')" }} />

--- a/components/BrokerCard.tsx
+++ b/components/BrokerCard.tsx
@@ -21,6 +21,7 @@ export default memo(function BrokerCard({
   onToggleSelect,
   selectionDisabled,
   intentCountry = null,
+  priority = false,
 }: {
   broker: Broker;
   badge?: string;
@@ -33,6 +34,10 @@ export default memo(function BrokerCard({
    *  country_eligibility column. Caller is responsible for resolving
    *  the cookie (server) or hook value (client). */
   intentCountry?: IntentCountryCode | null;
+  /** When true, the broker logo loads with Next/Image `priority` (eager
+   *  + fetchPriority="high"). Set on the top row of comparison/listing
+   *  surfaces where the logo is the LCP candidate. */
+  priority?: boolean;
 }) {
   const isSponsoredBroker = isSponsored(broker);
   const isShareOrCFD = broker.platform_type === 'share_broker' || broker.platform_type === 'cfd_forex';
@@ -74,7 +79,7 @@ export default memo(function BrokerCard({
       <div className="p-3">
         {/* Row 1: Logo + Name + Rating + CTA */}
         <div className="flex items-center gap-2.5 mb-2">
-          <BrokerLogo broker={broker} size="md" />
+          <BrokerLogo broker={broker} size="md" priority={priority} />
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-1.5 flex-wrap">
               <a href={`/broker/${broker.slug}`} className="font-bold text-sm text-slate-900 hover:text-slate-700 transition-colors truncate">

--- a/components/VerticalBrokerTable.tsx
+++ b/components/VerticalBrokerTable.tsx
@@ -295,6 +295,9 @@ export default function VerticalBrokerTable({ brokers, slug, color }: Props) {
               broker={broker}
               badge={i === 0 && !query ? "Top Pick" : undefined}
               context="compare"
+              // Top card on the mobile vertical table is the LCP
+              // candidate (above the fold on /share-trading et al.)
+              priority={i === 0 && !query}
             />
           ))
         )}

--- a/components/VerticalPillarPage.tsx
+++ b/components/VerticalPillarPage.tsx
@@ -318,7 +318,10 @@ export default function VerticalPillarPage({
               </div>
               <div className="flex flex-col sm:flex-row sm:items-center gap-4">
                 <div className="flex items-center gap-3 flex-1">
-                  <BrokerLogo broker={topPick} size="lg" />
+                  {/* Top Pick is the LCP candidate on every vertical
+                      pillar page — set `priority` so Next/Image fetches
+                      it eagerly and avoids the lazy-load delay. */}
+                  <BrokerLogo broker={topPick} size="lg" priority />
                   <div>
                     <h3 className="text-xl font-bold">
                       <Link


### PR DESCRIPTION
Four concrete LCP wins from the images audit:

## Changes

### 1. Top-Pick BrokerLogo gets `priority` on every vertical pillar + best/[slug] page
`components/VerticalPillarPage.tsx:321` — `<BrokerLogo broker={topPick} size="lg" />` → adds `priority`. The Top-Pick logo is the LCP candidate on all 5 vertical pillars + 43 best/[slug] pages. Component already accepted the prop; call site just wasn't passing it. **Est. 200-600 ms LCP improvement per page.**

### 2. New `priority` prop on `<BrokerCard>` + applied on mobile table top card
`components/BrokerCard.tsx` — added optional `priority` prop that forwards to inner `<BrokerLogo>`. `components/VerticalBrokerTable.tsx:292` now passes it only on the first card when no search query is active. Other call sites unchanged (default `false`).

### 3. Fix `priority={idx < 3}` anti-pattern on list cards
- `app/articles/page.tsx:415` — `priority={idx < 3}` → `priority={idx === 0}`
- `app/advisors/AdvisorsClient.tsx:1208` — `priority={index < 3}` → `priority={index === 0}`

Marking 3 cards as priority was actively harmful — split the network budget across 3 images and DELAYED the real single LCP image. **Est. 100-400 ms LCP improvement on /articles and /advisors.**

### 4. Preconnect for avatar hosts
`app/layout.tsx` — added `<link rel="preconnect">` (with `crossOrigin="anonymous"`) + `<link rel="dns-prefetch">` for both `ui-avatars.com` and `randomuser.me`. Both back avatar fallbacks across advisor listings where the avatar is the LCP candidate. **Est. 100-300 ms LCP saving on cold visits.**

## What the audit recommended that I did NOT apply (with reason)

- `components/BrokerLogo.tsx` — audit said drop `use client`. **Kept** — uses `useState(imgError)` + `onError` for image-failure fallback (requires client).
- `components/MobileBottomNav.tsx` — audit said drop `use client`. **Kept** — uses `useState`, `useEffect`, and `usePathname` (all client-only).

## Tier classification

**Tier B** — additive props + 4 priority-hint changes + preconnect tags. No behavior changes.

## Test plan

- [x] `NODE_OPTIONS="--max-old-space-size=5120" npx tsc --noEmit` — clean
- [x] `npx eslint --max-warnings 0` on all 6 touched files — clean
- [ ] After deploy: run Lighthouse on `/share-trading`, `/best/etfs`, `/articles`, `/advisors` — expect LCP improvement on each
- [ ] Verify no visual regressions on broker logos / advisor avatars / article cards

## Audit reports this PR implements

Agent 3 (images/Lighthouse) — TL;DR items 1, 3, 5 + section B (next/image misuse).

🤖 Generated with [Claude Code](https://claude.com/claude-code)