### PR TITLE
perf(edge): geo route → edge runtime + cohort-stats cache headers (Audit PR 5/7)

### DIFF
--- a/app/api/cohort-stats/route.ts
+++ b/app/api/cohort-stats/route.ts
@@ -47,12 +47,23 @@ export async function GET(request: Request) {
 
   if (totalCount < MIN_COHORT) {
     // Not enough data — return illustrative flag
-    return NextResponse.json({
-      cohort_label: buildCohortLabel(experience, range, interest),
-      total_count: totalCount,
-      sufficient_data: false,
-      broker_distribution: [],
-    });
+    return NextResponse.json(
+      {
+        cohort_label: buildCohortLabel(experience, range, interest),
+        total_count: totalCount,
+        sufficient_data: false,
+        broker_distribution: [],
+      },
+      {
+        headers: {
+          // Same edge cache strategy as the sufficient-data path —
+          // insufficient-data cohorts only flip when respondents
+          // cross the MIN_COHORT threshold, which is slow.
+          "Cache-Control":
+            "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400",
+        },
+      },
+    );
   }
 
   // Aggregate broker distribution
@@ -86,12 +97,24 @@ export async function GET(request: Request) {
     .sort((a, b) => b.count - a.count)
     .slice(0, 5);
 
-  return NextResponse.json({
-    cohort_label: buildCohortLabel(experience, range, interest),
-    total_count: totalCount,
-    sufficient_data: true,
-    broker_distribution: distribution,
-  });
+  return NextResponse.json(
+    {
+      cohort_label: buildCohortLabel(experience, range, interest),
+      total_count: totalCount,
+      sufficient_data: true,
+      broker_distribution: distribution,
+    },
+    {
+      headers: {
+        // Aggregate query over a slow-changing dataset (new quiz
+        // respondents trickle in). 1h edge cache is safe; SWR keeps
+        // it warm during refresh. Audit flagged this as the one
+        // edge-runtime route shipping without any Cache-Control.
+        "Cache-Control":
+          "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400",
+      },
+    },
+  );
 }
 
 function buildCohortLabel(

--- a/app/api/geo/route.ts
+++ b/app/api/geo/route.ts
@@ -10,6 +10,12 @@ import { headers } from "next/headers";
  * flag indicator in the top nav. Cached aggressively at the edge
  * because the value only changes per IP, not per session.
  */
+// Edge runtime — this route only reads the `x-vercel-ip-country`
+// header and returns JSON. No Node.js APIs needed. Edge functions
+// execute in 18+ regions worldwide, giving sub-50ms TTFB globally
+// instead of paying a round-trip to the function region (dub1 today).
+export const runtime = "edge";
+
 export async function GET() {
   const hdrs = await headers();
   const country = hdrs.get("x-vercel-ip-country") ?? null;


### PR DESCRIPTION
Two small Tier B wins from the caching/CDN audit. Defers larger Tier B items to focused follow-up PRs.

## Changes

1. **`app/api/geo/route.ts` → edge runtime** — Reads only the `x-vercel-ip-country` header and returns JSON. Zero Node APIs. Now executes in 18+ Vercel edge POPs worldwide instead of round-tripping to the function region (dub1 today). Sub-50ms TTFB globally for the flag indicator in the top nav.
2. **`app/api/cohort-stats/route.ts` — add `Cache-Control` on both response paths** — already on edge runtime but shipped without any cache headers. Aggregate over a slow-changing dataset; 5min browser / 1h edge / 24h SWR is safe.

## Deferred (with reasons)

- **Lighthouse hard-fail re-enable** — premature without post-fix LH measurements. PRs 1-4 just shipped; tightening thresholds now would flag noise as regressions.
- **More edge migrations** (`/api/afsl/[number]`, etc.) — each needs dependency-chain verification. One at a time in their own PRs.
- **Font subset** (~80 kB savings) — needs glyphhanger tooling.
- **Favicon compression** (192 kB savings on 2 files) — needs image tooling.
- **Avatar placeholder elimination** — worth its own refactor PR.

## Test plan

- [x] `NODE_OPTIONS="--max-old-space-size=5120" npx tsc --noEmit` — clean
- [x] `npx eslint --max-warnings 0` on both files — clean
- [ ] After deploy: `curl -I https://invest-com-au.vercel.app/api/geo` — should show `x-vercel-cache: HIT` on second hit and the edge POP region in `x-vercel-id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)