### PR TITLE
fix(infra): drop invalid _regions_note property from vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,5 @@
 {
   "ignoreCommand": "bash scripts/vercel-skip-build.sh",
-  "_regions_note": "Pin serverless + ISR functions to Dublin so they're co-located with Supabase eu-west-1. Cross-region RTT drops from ~80ms (iad1 ↔ eu-west-1) to ~5ms (dub1 ↔ eu-west-1) — every server-rendered page benefits. AU end-users still hit Vercel's Sydney CDN POP for cached/ISR pages, so only the rare uncached SSR pays the extra ~50ms first-byte vs iad1.",
   "regions": ["dub1"],
   "crons": [
     { "path": "/api/cron/dispatch/every-15m", "schedule": "*/15 * * * *" },


### PR DESCRIPTION
## Summary

- Vercel's `vercel.json` schema validator rejects unknown properties; the `_regions_note` documentation comment introduced in bc2ff8b ("perf(infra): tier-S caching + Vercel region wins (Audit PR 1/7)") is failing schema validation on every preview deploy since.
- This blocks the Vercel preview status on every open PR (every PR opened after bc2ff8b shows `Deployment failed: should NOT have additional property '_regions_note'`).
- Rationale for the `regions: ["dub1"]` pin is preserved in the commit message so it isn't lost.

## Test plan

- [ ] CI green
- [ ] Preview deploy succeeds (status check goes from ❌ to ✅)
- [ ] After merge, open PRs' Vercel checks turn green on next event

https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk)_