### PR TITLE
fix(lint): unblock CI by clearing ETFScreenerClient lint failures

### DIFF
--- a/app/etfs/screener/ETFScreenerClient.tsx
+++ b/app/etfs/screener/ETFScreenerClient.tsx
@@ -35,6 +35,11 @@ function formatAUM(millions: number): string {
     : `$${millions}M`;
 }
 
+function SortIcon({ col, sortKey, sortDir }: { col: SortKey; sortKey: SortKey; sortDir: SortDir }) {
+  if (sortKey !== col) return <span className="text-slate-400 ml-1">↕</span>;
+  return <span className="text-amber-600 ml-1">{sortDir === "asc" ? "↑" : "↓"}</span>;
+}
+
 function assetClassBadge(cls: ETFAssetClass): string {
   const colors: Record<ETFAssetClass, string> = {
     "australian-shares": "bg-amber-100 text-amber-800",
@@ -77,7 +82,7 @@ export default function ETFScreenerClient() {
   const [search, setSearch] = useState("");
 
   const filtered = useMemo(() => {
-    let results = ETF_DATA.filter((etf) => {
+    const results = ETF_DATA.filter((etf) => {
       if (assetClass !== "all" && etf.assetClass !== assetClass) return false;
       if (provider !== "all" && etf.provider !== provider) return false;
       if (etf.mer > maxMER) return false;
@@ -108,11 +113,6 @@ export default function ETFScreenerClient() {
       setSortKey(key);
       setSortDir(key === "ticker" ? "asc" : "desc");
     }
-  }
-
-  function SortIcon({ col }: { col: SortKey }) {
-    if (sortKey !== col) return <span className="text-slate-400 ml-1">↕</span>;
-    return <span className="text-amber-600 ml-1">{sortDir === "asc" ? "↑" : "↓"}</span>;
   }
 
   return (
@@ -218,7 +218,7 @@ export default function ETFScreenerClient() {
                     className="text-left py-3 px-4 text-xs font-bold cursor-pointer select-none"
                     onClick={() => toggleSort("ticker")}
                   >
-                    Ticker <SortIcon col="ticker" />
+                    Ticker <SortIcon col="ticker" sortKey={sortKey} sortDir={sortDir} />
                   </th>
                   <th className="text-left py-3 px-4 text-xs font-bold">Name</th>
                   <th className="text-left py-3 px-4 text-xs font-bold hidden sm:table-cell">Category</th>
@@ -226,19 +226,19 @@ export default function ETFScreenerClient() {
                     className="text-right py-3 px-4 text-xs font-bold cursor-pointer select-none"
                     onClick={() => toggleSort("mer")}
                   >
-                    MER <SortIcon col="mer" />
+                    MER <SortIcon col="mer" sortKey={sortKey} sortDir={sortDir} />
                   </th>
                   <th
                     className="text-right py-3 px-4 text-xs font-bold cursor-pointer select-none"
                     onClick={() => toggleSort("aumMillions")}
                   >
-                    AUM <SortIcon col="aumMillions" />
+                    AUM <SortIcon col="aumMillions" sortKey={sortKey} sortDir={sortDir} />
                   </th>
                   <th
                     className="text-right py-3 px-4 text-xs font-bold cursor-pointer select-none"
                     onClick={() => toggleSort("distributionYield")}
                   >
-                    Yield <SortIcon col="distributionYield" />
+                    Yield <SortIcon col="distributionYield" sortKey={sortKey} sortDir={sortDir} />
                   </th>
                   <th className="text-center py-3 px-4 text-xs font-bold">Franking</th>
                   <th className="py-3 px-4"></th>


### PR DESCRIPTION
## Summary

- `app/etfs/screener/ETFScreenerClient.tsx:80` had `let results = ETF_DATA.filter(...)` that is mutated (`.sort()`) but never reassigned — `prefer-const` fires as an **error**, failing `npm run lint` on every PR.
- The same file's inline `SortIcon` component triggers four `react-hooks/static-components` warnings; lint-staged's `--max-warnings 0` rule turned those into commit blockers.
- Both issues were introduced by #931 (ETF screener feature) and have been failing the `Lint · Type-check · Test · Build` CI job on main ever since.

## Changes

1. `let results` → `const results` (single character change at line 80).
2. Extracted `SortIcon` from inside `ETFScreenerClient` to a top-level component above it, threading `sortKey` and `sortDir` through props. No behavioural change — same render output.

## Test plan

- [x] `npx eslint app/etfs/screener/ETFScreenerClient.tsx --max-warnings 0` → 0 errors, 0 warnings
- [x] Pre-push hook (type-check + rate-limit audit + changed-file tests) passes
- [ ] CI green on this PR
- [ ] After merge, the same lint check turns green on PRs #948 and #950

https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk)_