### PR TITLE
fix(a11y): drop role=menu from 4 navigation dropdowns

### DIFF
--- a/__tests__/components/LocationFlagButton.test.tsx
+++ b/__tests__/components/LocationFlagButton.test.tsx
@@ -185,14 +185,14 @@ describe("LocationFlagButton", () => {
     it("dispatches open the popover from elsewhere on the page", async () => {
       render(<LocationFlagButton />);
       // Popover starts closed
-      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("country-popover")).not.toBeInTheDocument();
 
       act(() => {
         window.dispatchEvent(new CustomEvent("country-mode:open-selector"));
       });
 
       // Popover is now open
-      expect(await screen.findByRole("menu")).toBeInTheDocument();
+      expect(await screen.findByTestId("country-popover")).toBeInTheDocument();
     });
   });
 

--- a/components/WorkspaceSwitcher.tsx
+++ b/components/WorkspaceSwitcher.tsx
@@ -133,7 +133,6 @@ export default function WorkspaceSwitcher() {
 
       {open && (
         <div
-          role="menu"
           aria-label="Switch workspace"
           className="absolute right-0 mt-2 w-64 rounded-xl border border-slate-200 bg-white shadow-lg z-50 overflow-hidden"
         >

--- a/components/layout/AccountButton.tsx
+++ b/components/layout/AccountButton.tsx
@@ -26,6 +26,7 @@ export default function AccountButton() {
   // (user_metadata isn't kept in sync — display_name lives in our profile table)
   useEffect(() => {
     if (!user) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: clear stale name on sign-out
       setProfileName(null);
       return;
     }
@@ -138,10 +139,7 @@ export default function AccountButton() {
       </button>
 
       {open && (
-        <div
-          className="absolute right-0 top-full mt-2 w-64 bg-white rounded-2xl border border-slate-200 shadow-xl shadow-slate-200/60 overflow-hidden z-50"
-          role="menu"
-        >
+        <div className="absolute right-0 top-full mt-2 w-64 bg-white rounded-2xl border border-slate-200 shadow-xl shadow-slate-200/60 overflow-hidden z-50">
           {/* Profile header */}
           <div className="px-4 py-3 border-b border-slate-100 bg-slate-50/50">
             <p className="text-sm font-bold text-slate-900 truncate">{displayName}</p>

--- a/components/layout/LocationFlagButton.tsx
+++ b/components/layout/LocationFlagButton.tsx
@@ -231,10 +231,7 @@ export default function LocationFlagButton() {
       </button>
 
       {open && (
-        <div
-          role="menu"
-          className="absolute right-0 top-full mt-2 z-[60] w-[360px] bg-white rounded-2xl border border-slate-200 shadow-xl shadow-slate-200/60 overflow-hidden"
-        >
+        <div className="absolute right-0 top-full mt-2 z-[60] w-[360px] bg-white rounded-2xl border border-slate-200 shadow-xl shadow-slate-200/60 overflow-hidden">
           <div className="p-4">
             {popoverState === "suggested" && supported ? (
               <>

--- a/components/layout/LocationFlagButton.tsx
+++ b/components/layout/LocationFlagButton.tsx
@@ -231,7 +231,10 @@ export default function LocationFlagButton() {
       </button>
 
       {open && (
-        <div className="absolute right-0 top-full mt-2 z-[60] w-[360px] bg-white rounded-2xl border border-slate-200 shadow-xl shadow-slate-200/60 overflow-hidden">
+        <div
+          data-testid="country-popover"
+          className="absolute right-0 top-full mt-2 z-[60] w-[360px] bg-white rounded-2xl border border-slate-200 shadow-xl shadow-slate-200/60 overflow-hidden"
+        >
           <div className="p-4">
             {popoverState === "suggested" && supported ? (
               <>

--- a/components/layout/Navigation.tsx
+++ b/components/layout/Navigation.tsx
@@ -206,10 +206,7 @@ function MegaMenuDropdown({
       </button>
 
       {open && (
-        <div
-          className={`absolute left-0 top-full pt-2 z-50 ${menuWidth}`}
-          role="menu"
-        >
+        <div className={`absolute left-0 top-full pt-2 z-50 ${menuWidth}`}>
           <div className="bg-white rounded-2xl border border-slate-200 shadow-xl shadow-slate-200/60 overflow-hidden">
             {children}
           </div>


### PR DESCRIPTION
## Summary

Removes `role="menu"` from 4 navigation dropdowns in the shared header chrome. Per ARIA APG, that role is for application menus (File→Open) and requires `role="menuitem"` descendants — these are nav dropdowns with `<Link>` elements, so axe-core's `aria-required-children` (critical impact) fires on every page.

This has been failing the `Accessibility (axe-core)` CI gate on every PR — confirmed on #948 (pure docs) and #952 (the QW PR that just merged). Both PRs failed a11y identically because the violation is in shared chrome, not in any PR's diff.

## Changes

| File | Change |
|------|--------|
| `components/layout/Navigation.tsx:209-211` | Drop `role="menu"` from MegaMenuDropdown popover div |
| `components/layout/AccountButton.tsx:141-144` | Drop `role="menu"` from account dropdown div |
| `components/WorkspaceSwitcher.tsx:134-138` | Drop `role="menu"`, keep `aria-label="Switch workspace"` |
| `components/layout/LocationFlagButton.tsx:233-236` | Drop `role="menu"` from country selector |

Plus one unrelated pre-existing lint warning suppressed in `AccountButton.tsx:29` with line-scoped disable + reason (intentional state clear on sign-out, same pattern as `AdvisorsClient.tsx`).

## Why dropping (not adding `role="menuitem"`)

Adding `role="menuitem"` to all the `<Link>` descendants would change keyboard semantics (arrow keys would move focus, Enter would activate, no Tab navigation). That's the wrong UX for nav dropdowns — users expect Tab/Shift-Tab through links. The disclosure pattern (`aria-expanded` on the trigger + plain links inside) is what these are already implementing functionally; just removing the misleading role aligns ARIA with behaviour.

## Test plan

- [x] `npx eslint <4 files> --max-warnings 0` clean
- [x] Pre-push hook (type-check + tests) passes
- [ ] CI green — specifically `Accessibility (axe-core on key routes)` should pass on this PR for the first time since the role was introduced
- [ ] Smoke: open each dropdown, confirm Tab/Shift-Tab navigates through links normally, Escape closes (all existing behaviour, just verifying no regression)

https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk)_