### PR TITLE
feat(directory): phase 1 — banner stack unification

### DIFF
--- a/__tests__/lib/page-recommendations.test.ts
+++ b/__tests__/lib/page-recommendations.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { buildPageRecommendation } from "@/lib/page-recommendations";
+
+describe("buildPageRecommendation", () => {
+  it("strips the 'investors' suffix from labels in titles", () => {
+    const rec = buildPageRecommendation("advisors", "UK investors", true);
+    expect(rec).not.toBeNull();
+    expect(rec!.title).toBe("Cross-border tax accountants for UK clients");
+    expect(rec!.title).not.toMatch(/investors/);
+  });
+
+  it("returns the high-friction invest variant when isHighFriction is true", () => {
+    const rec = buildPageRecommendation("invest", "UK investors", true);
+    expect(rec).not.toBeNull();
+    expect(rec!.title).toContain("FIRB-eligible new properties");
+    expect(rec!.title).toContain("UK");
+    expect(rec!.body).toContain("2025–2027 ban");
+    expect(rec!.href).toBe("/invest?firb=eligible");
+    expect(rec!.cta).toBe("FIRB-eligible only");
+  });
+
+  it("returns the low-friction invest variant when isHighFriction is false", () => {
+    const rec = buildPageRecommendation("invest", "NZ investors", false);
+    expect(rec).not.toBeNull();
+    expect(rec!.title).toContain("New properties and FIRB-eligible listings");
+    expect(rec!.body).toContain("trans-Tasman");
+    // Same CTA target — low-friction users still benefit from the FIRB-eligible filter.
+    expect(rec!.href).toBe("/invest?firb=eligible");
+  });
+
+  it("returns the compare surface CTA pointing to /compare/non-residents", () => {
+    const rec = buildPageRecommendation("compare", "US investors", true);
+    expect(rec).not.toBeNull();
+    expect(rec!.href).toBe("/compare/non-residents");
+    expect(rec!.cta).toBe("Non-resident brokers");
+  });
+
+  it("returns the advisors surface CTA pointing to international tax specialists", () => {
+    const rec = buildPageRecommendation("advisors", "SG investors", true);
+    expect(rec).not.toBeNull();
+    expect(rec!.href).toBe("/advisors/international-tax-specialists");
+    expect(rec!.cta).toBe("Specialist advisors");
+  });
+
+  it("handles labels without the 'investors' suffix gracefully", () => {
+    const rec = buildPageRecommendation("advisors", "Singapore", true);
+    expect(rec).not.toBeNull();
+    expect(rec!.title).toBe("Cross-border tax accountants for Singapore clients");
+  });
+});

--- a/app/advisors/page.tsx
+++ b/app/advisors/page.tsx
@@ -5,9 +5,7 @@ import type { Professional, AdvisorFirm } from "@/lib/types";
 import type { Metadata } from "next";
 import AdvisorsClient, { type ExpertTeamCard } from "./AdvisorsClient";
 import HomeToolsStrip from "@/components/HomeToolsStrip";
-import IntentCountryBadge from "@/components/foreign-investment/IntentCountryBadge";
-import IntentCountryRecommendation from "@/components/foreign-investment/IntentCountryRecommendation";
-import CountryRuleAlerts from "@/components/CountryRuleAlerts";
+import DirectoryBanners from "@/components/foreign-investment/DirectoryBanners";
 import { absoluteUrl, breadcrumbJsonLd, CURRENT_YEAR } from "@/lib/seo";
 import { logger } from "@/lib/logger";
 
@@ -110,9 +108,7 @@ export default function AdvisorsPage() {
     <>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }} />
       <div className="container-custom pt-4">
-        <IntentCountryBadge />
-        <IntentCountryRecommendation surface="advisors" />
-        <CountryRuleAlerts />
+        <DirectoryBanners surface="advisors" />
       </div>
       <Suspense fallback={<AdvisorsLoading />}>
         <AdvisorsData />

--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -7,8 +7,7 @@ import GetMatchedEmbed from "@/components/get-matched/GetMatchedEmbed";
 import { absoluteUrl, UPDATED_LABEL } from "@/lib/seo";
 import ComplianceFooter from "@/components/ComplianceFooter";
 import HomeToolsStrip from "@/components/HomeToolsStrip";
-import IntentCountryBadge from "@/components/foreign-investment/IntentCountryBadge";
-import IntentCountryRecommendation from "@/components/foreign-investment/IntentCountryRecommendation";
+import DirectoryBanners from "@/components/foreign-investment/DirectoryBanners";
 
 export const metadata = {
   title: "Compare Investing Platforms — Fees & Features",
@@ -156,8 +155,7 @@ export default function ComparePage() {
       </div>
       {/* Server-rendered H1 for crawlers that don't execute client JS — streams immediately */}
       <div className="container-custom pt-5 md:pt-10">
-        <div className="mb-3"><IntentCountryBadge /></div>
-        <IntentCountryRecommendation surface="compare" />
+        <DirectoryBanners surface="compare" />
         <h1 className="text-3xl md:text-4xl font-extrabold text-slate-900 tracking-tight">
           Compare Australian Investment Platforms
         </h1>

--- a/app/invest/page.tsx
+++ b/app/invest/page.tsx
@@ -22,9 +22,7 @@ import GetMatchedEmbed from "@/components/get-matched/GetMatchedEmbed";
 import { loadInvestPageContext } from "@/lib/listing-page-context";
 import { computeMatchScore } from "@/lib/listing-match";
 import HomeToolsStrip from "@/components/HomeToolsStrip";
-import IntentCountryBadge from "@/components/foreign-investment/IntentCountryBadge";
-import IntentCountryRecommendation from "@/components/foreign-investment/IntentCountryRecommendation";
-import CountryRuleAlerts from "@/components/CountryRuleAlerts";
+import DirectoryBanners from "@/components/foreign-investment/DirectoryBanners";
 import ScrollReveal from "@/components/ScrollReveal";
 import Icon from "@/components/Icon";
 
@@ -218,11 +216,7 @@ export default async function InvestMarketplacePage() {
           <span className="text-slate-700">Opportunities</span>
         </nav>
 
-        <div className="mb-2">
-          <IntentCountryBadge />
-        </div>
-        <CountryRuleAlerts />
-        <IntentCountryRecommendation surface="invest" />
+        <DirectoryBanners surface="invest" />
 
         <h1 className="text-2xl md:text-4xl font-extrabold mb-2 text-slate-900 tracking-tight">
           Australian Investment Opportunities

--- a/components/foreign-investment/DirectoryBanners.tsx
+++ b/components/foreign-investment/DirectoryBanners.tsx
@@ -1,0 +1,47 @@
+import IntentCountryBadge from "./IntentCountryBadge";
+import IntentCountryRecommendation from "./IntentCountryRecommendation";
+import CountryRuleAlerts from "../CountryRuleAlerts";
+import type { RecommendationSurface } from "@/lib/page-recommendations";
+
+/**
+ * Canonical country-aware banner stack for directory pages.
+ *
+ * Renders three pieces in fixed order on every directory that
+ * adapts to the visitor's intent country (UK/US/NZ/etc.):
+ *
+ *   1. IntentCountryBadge — "Browsing as <country> investors" pill
+ *      with Hub / Clear actions. Server-side; reads the
+ *      iv_intent_country cookie.
+ *   2. CountryRuleAlerts — high-impact rule notifications
+ *      (dwelling ban, visa changes, FIRB tweaks). Client-side;
+ *      fetches /api/country-rule-alerts on mount.
+ *   3. IntentCountryRecommendation — advisory CTA card
+ *      ("Cross-border tax accountants for UK clients" etc.).
+ *      Server-side; copy comes from
+ *      `lib/page-recommendations.ts`.
+ *
+ * Renders nothing when the user has no intent country set — most
+ * visitors. So adding this to a page is safe even before country
+ * mode is fully wired.
+ *
+ * Order is deliberate: pill (passive context) → rule alerts
+ * (urgent / time-bound) → recommendation (advisory next step).
+ * Reordering produces a different cognitive load and was settled
+ * in the directory-UX unification plan
+ * (docs/plans/DIRECTORY_UX_UNIFICATION.md, decision Q6).
+ */
+export default function DirectoryBanners({
+  surface,
+}: {
+  surface: RecommendationSurface;
+}) {
+  return (
+    <>
+      <div className="mb-2">
+        <IntentCountryBadge />
+      </div>
+      <CountryRuleAlerts />
+      <IntentCountryRecommendation surface={surface} />
+    </>
+  );
+}

--- a/components/foreign-investment/IntentCountryBadge.tsx
+++ b/components/foreign-investment/IntentCountryBadge.tsx
@@ -2,6 +2,13 @@ import Link from "next/link";
 import { intentCountryMeta } from "@/lib/intent-context";
 import { getIntentCountry } from "@/lib/intent-context-server";
 import ClearIntentCountryButton from "./ClearIntentCountryButton";
+import {
+  BADGE_BG,
+  BADGE_BORDER,
+  BADGE_DIVIDER,
+  BADGE_LINK_HOVER,
+  BADGE_TEXT,
+} from "./banner-tokens";
 
 /**
  * Reads the iv_intent_country cookie and renders a small badge
@@ -25,25 +32,27 @@ export default async function IntentCountryBadge({
 
   return (
     <div
-      className={`inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-amber-50 border border-amber-200 text-xs font-semibold text-amber-900 ${className}`}
+      className={`inline-flex items-center gap-2 px-3 py-1.5 rounded-full ${BADGE_BG} border ${BADGE_BORDER} text-xs font-semibold ${BADGE_TEXT} ${className}`}
     >
       <span aria-hidden className="text-sm leading-none">
         {meta.flag}
       </span>
       <span>Browsing as {meta.label}</span>
-      <span aria-hidden className="text-amber-300">
+      <span aria-hidden className={BADGE_DIVIDER}>
         ·
       </span>
       <Link
         href={`/foreign-investment/${meta.slug}`}
-        className="underline decoration-dotted hover:text-amber-700"
+        className={`underline decoration-dotted ${BADGE_LINK_HOVER}`}
       >
         Hub
       </Link>
-      <span aria-hidden className="text-amber-300">
+      <span aria-hidden className={BADGE_DIVIDER}>
         ·
       </span>
-      <ClearIntentCountryButton className="underline decoration-dotted hover:text-amber-700 cursor-pointer disabled:opacity-50">
+      <ClearIntentCountryButton
+        className={`underline decoration-dotted ${BADGE_LINK_HOVER} cursor-pointer disabled:opacity-50`}
+      >
         Clear
       </ClearIntentCountryButton>
     </div>

--- a/components/foreign-investment/IntentCountryRecommendation.tsx
+++ b/components/foreign-investment/IntentCountryRecommendation.tsx
@@ -1,19 +1,10 @@
 import { intentCountryMeta } from "@/lib/intent-context";
 import { getIntentCountry } from "@/lib/intent-context-server";
+import {
+  buildPageRecommendation,
+  type RecommendationSurface,
+} from "@/lib/page-recommendations";
 import IntentCountryRecommendationCard from "./IntentCountryRecommendationCard";
-
-type SurfaceKind = "compare" | "advisors" | "invest";
-
-interface Recommendation {
-  /** Headline for the country-specific CTA card. */
-  title: string;
-  /** One-line explanation of why this is being recommended. */
-  body: string;
-  /** Where the primary CTA lands. Pre-filtered URL where possible. */
-  href: string;
-  /** Primary CTA label. */
-  cta: string;
-}
 
 /**
  * Country-aware contextual CTA card.
@@ -25,13 +16,17 @@ interface Recommendation {
  * because that's the strict subset of brokers that work for non-AU
  * residents.
  *
+ * Copy lives in `lib/page-recommendations.ts` (single source of truth
+ * per surface). Adding a new surface means adding a row there, not
+ * editing this component.
+ *
  * Renders nothing when no country is set (most users) so the standard
  * page experience is unchanged.
  */
 export default async function IntentCountryRecommendation({
   surface,
 }: {
-  surface: SurfaceKind;
+  surface: RecommendationSurface;
 }) {
   const code = await getIntentCountry();
   if (!code) return null;
@@ -41,7 +36,7 @@ export default async function IntentCountryRecommendation({
   const meta = intentCountryMeta(code);
   const isHighFriction = code !== "nz";
 
-  const rec = buildRecommendation(surface, code, meta.label, isHighFriction);
+  const rec = buildPageRecommendation(surface, meta.label, isHighFriction);
   if (!rec) return null;
 
   return (
@@ -54,47 +49,4 @@ export default async function IntentCountryRecommendation({
       cta={rec.cta}
     />
   );
-}
-
-function buildRecommendation(
-  surface: SurfaceKind,
-  code: string,
-  label: string,
-  isHighFriction: boolean,
-): Recommendation | null {
-  switch (surface) {
-    case "compare":
-      return {
-        title: `Show only brokers that accept ${label.replace(" investors", "")} residents`,
-        body: `Most retail Australian brokers don't onboard non-residents. The non-resident comparison is the right filter — it pre-filters to platforms that explicitly accept overseas applicants.`,
-        href: "/compare/non-residents",
-        cta: "Non-resident brokers",
-      };
-    case "advisors":
-      return {
-        title: `Cross-border tax accountants for ${label.replace(" investors", "")} clients`,
-        body: `International tax specialists handle UK/AU dual reporting, FIRB property advice, QROPS pension transfers and treaty positions — the four areas where DIY most often goes wrong.`,
-        href: "/advisors/international-tax-specialists",
-        cta: "Specialist advisors",
-      };
-    case "invest":
-      if (!isHighFriction) {
-        return {
-          title: `New properties and FIRB-eligible listings for ${label.replace(" investors", "")}`,
-          body: `Even with the trans-Tasman framework, FIRB rules still apply on most direct property purchases. Pre-filter to FIRB-eligible listings to skip the items you can't buy.`,
-          href: "/invest?firb=eligible",
-          cta: "FIRB-eligible only",
-        };
-      }
-      return {
-        title: `FIRB-eligible new properties — what ${label.replace(" investors", "")} can actually buy`,
-        body: `The 2025–2027 ban blocks foreign buyers from established Australian dwellings. New dwellings, off-the-plan and commercial property remain open with FIRB approval. Pre-filter to those.`,
-        href: "/invest?firb=eligible",
-        cta: "FIRB-eligible only",
-      };
-    default:
-      // Exhaustiveness — should never hit at runtime.
-      return null;
-  }
-  void code;
 }

--- a/components/foreign-investment/IntentCountryRecommendationCard.tsx
+++ b/components/foreign-investment/IntentCountryRecommendationCard.tsx
@@ -2,6 +2,15 @@
 
 import { useState, useTransition } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import {
+  BANNER_PADDING,
+  BANNER_RADIUS,
+  RECOMMENDATION_APPLIED_BG,
+  RECOMMENDATION_BG,
+  RECOMMENDATION_BORDER,
+  RECOMMENDATION_CTA_BG,
+  RECOMMENDATION_CTA_HOVER,
+} from "./banner-tokens";
 
 interface Props {
   flag: string;
@@ -70,7 +79,7 @@ export default function IntentCountryRecommendationCard({
       }`}
       aria-hidden={applied}
     >
-      <div className="bg-amber-50 border border-amber-200 rounded-2xl p-4 md:p-5">
+      <div className={`${RECOMMENDATION_BG} border ${RECOMMENDATION_BORDER} ${BANNER_RADIUS} ${BANNER_PADDING}`}>
         <div className="flex items-start justify-between gap-4 flex-wrap">
           <div className="flex items-start gap-3">
             <span aria-hidden className="text-2xl leading-none mt-0.5">
@@ -90,8 +99,8 @@ export default function IntentCountryRecommendationCard({
             disabled={applied}
             className={`shrink-0 px-4 py-2 font-bold text-sm rounded-lg transition-all duration-300 ease-out ${
               applied
-                ? "bg-emerald-500 text-white scale-105"
-                : "bg-amber-500 hover:bg-amber-400 text-slate-900"
+                ? `${RECOMMENDATION_APPLIED_BG} text-white scale-105`
+                : `${RECOMMENDATION_CTA_BG} ${RECOMMENDATION_CTA_HOVER} text-slate-900`
             }`}
             aria-live="polite"
           >

--- a/components/foreign-investment/banner-tokens.ts
+++ b/components/foreign-investment/banner-tokens.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared visual tokens for the country-aware banner stack
+ * (IntentCountryBadge + CountryRuleAlerts + IntentCountryRecommendation).
+ *
+ * Centralising the colour, border, radius and spacing values keeps the
+ * three components visually coherent — they sit one above the other on
+ * /invest, /advisors and /compare so even a one-pixel divergence reads
+ * as a bug. Update tokens here; never inline bg-amber-50 across the
+ * three components.
+ */
+
+export const BANNER_RADIUS = "rounded-2xl";
+export const BANNER_PADDING = "p-4 md:p-5";
+
+// Pill — the small "Browsing as X investors" chip above the cards.
+export const BADGE_BG = "bg-amber-50";
+export const BADGE_BORDER = "border-amber-200";
+export const BADGE_TEXT = "text-amber-900";
+export const BADGE_DIVIDER = "text-amber-300";
+export const BADGE_LINK_HOVER = "hover:text-amber-700";
+
+// Recommendation card — the advisory CTA card (amber tone, advisory copy).
+export const RECOMMENDATION_BG = "bg-amber-50";
+export const RECOMMENDATION_BORDER = "border-amber-200";
+export const RECOMMENDATION_TITLE_TEXT = "text-amber-900";
+export const RECOMMENDATION_BODY_TEXT = "text-amber-800";
+export const RECOMMENDATION_CTA_BG = "bg-amber-500";
+export const RECOMMENDATION_CTA_TEXT = "text-white";
+export const RECOMMENDATION_CTA_HOVER = "hover:bg-amber-400";
+export const RECOMMENDATION_APPLIED_BG = "bg-emerald-500";
+
+// Rule-alert severity palette. Used by CountryRuleAlerts.
+// Info = informational, Warning = action recommended, Urgent = compliance risk.
+export const ALERT_INFO = "border-blue-200 bg-blue-50 text-blue-900";
+export const ALERT_WARNING = "border-amber-200 bg-amber-50 text-amber-900";
+export const ALERT_URGENT = "border-red-200 bg-red-50 text-red-900";

--- a/lib/page-recommendations.ts
+++ b/lib/page-recommendations.ts
@@ -1,0 +1,86 @@
+/**
+ * Page-level recommendation copy for the country-aware
+ * IntentCountryRecommendation card.
+ *
+ * Was previously a hardcoded switch statement inside
+ * components/foreign-investment/IntentCountryRecommendation.tsx — moved
+ * here so:
+ *   1. Adding a new surface (e.g. /brokers) doesn't require editing
+ *      the component, only adding a row to PAGE_RECOMMENDATIONS.
+ *   2. Country-specific copy variants (rare today, expected as we add
+ *      more high-friction countries) attach to the same table.
+ *   3. Tests can hit the lookup without rendering the component.
+ *
+ * Each surface has a base recommendation. Countries can opt into a
+ * softer "low-friction" variant when isHighFriction === false (NZ
+ * today; trans-Tasman is the only such relationship).
+ */
+
+export type RecommendationSurface = "compare" | "advisors" | "invest";
+
+export interface PageRecommendation {
+  /** Headline for the country-specific CTA card. */
+  title: string;
+  /** One-line explanation of why this is being recommended. */
+  body: string;
+  /** Where the primary CTA lands. Pre-filtered URL where possible. */
+  href: string;
+  /** Primary CTA label. */
+  cta: string;
+}
+
+/**
+ * Strip the trailing " investors" suffix from country labels like
+ * "UK investors" → "UK" so it composes naturally inside titles
+ * ("FIRB-eligible — what UK can actually buy").
+ */
+function shortLabel(label: string): string {
+  return label.replace(/ investors$/, "");
+}
+
+const RECOMMENDATION_BUILDERS: Record<
+  RecommendationSurface,
+  (label: string, isHighFriction: boolean) => PageRecommendation
+> = {
+  compare: (label) => ({
+    title: `Show only brokers that accept ${shortLabel(label)} residents`,
+    body: `Most retail Australian brokers don't onboard non-residents. The non-resident comparison is the right filter — it pre-filters to platforms that explicitly accept overseas applicants.`,
+    href: "/compare/non-residents",
+    cta: "Non-resident brokers",
+  }),
+
+  advisors: (label) => ({
+    title: `Cross-border tax accountants for ${shortLabel(label)} clients`,
+    body: `International tax specialists handle UK/AU dual reporting, FIRB property advice, QROPS pension transfers and treaty positions — the four areas where DIY most often goes wrong.`,
+    href: "/advisors/international-tax-specialists",
+    cta: "Specialist advisors",
+  }),
+
+  invest: (label, isHighFriction) => {
+    const short = shortLabel(label);
+    if (!isHighFriction) {
+      return {
+        title: `New properties and FIRB-eligible listings for ${short}`,
+        body: `Even with the trans-Tasman framework, FIRB rules still apply on most direct property purchases. Pre-filter to FIRB-eligible listings to skip the items you can't buy.`,
+        href: "/invest?firb=eligible",
+        cta: "FIRB-eligible only",
+      };
+    }
+    return {
+      title: `FIRB-eligible new properties — what ${short} can actually buy`,
+      body: `The 2025–2027 ban blocks foreign buyers from established Australian dwellings. New dwellings, off-the-plan and commercial property remain open with FIRB approval. Pre-filter to those.`,
+      href: "/invest?firb=eligible",
+      cta: "FIRB-eligible only",
+    };
+  },
+};
+
+export function buildPageRecommendation(
+  surface: RecommendationSurface,
+  label: string,
+  isHighFriction: boolean,
+): PageRecommendation | null {
+  const builder = RECOMMENDATION_BUILDERS[surface];
+  if (!builder) return null;
+  return builder(label, isHighFriction);
+}


### PR DESCRIPTION
## Summary

Phase 1 of the directory UX unification plan (`docs/plans/DIRECTORY_UX_UNIFICATION.md`). Ships Sessions 1–3 in one PR:

| Session | Deliverable |
|---------|-------------|
| **1** | `<DirectoryBanners>` wrapper composing `IntentCountryBadge` + `CountryRuleAlerts` + `IntentCountryRecommendation` in canonical order. Applied to `/invest`, `/advisors`, `/compare`. |
| **2** | Recommendation copy moved from the in-component switch in `IntentCountryRecommendation.tsx` to `lib/page-recommendations.ts`. 6 unit tests pin the surface × friction-level matrix. |
| **3** | Shared `banner-tokens.ts` for amber/emerald colour pairs, border radius, padding, severity palette. Removes inline `bg-amber-50 / border-amber-200` drift across the four banner-family components. |

## Behavioural changes

- **`/advisors`** previously rendered the banner stack as `pill → recommendation → rule alerts`. Now matches `/invest`'s order (`pill → rule alerts → recommendation`) — urgent (rule alert) before advisory (recommendation) per decision Q6 in the plan.
- **`/compare`** now renders `CountryRuleAlerts` (previously omitted). Same alerts API, no new data layer. If a `dwelling-ban` alert is active for the visitor's intent country, it now surfaces on `/compare` too.

## Files

```
 __tests__/lib/page-recommendations.test.ts (new, 6 tests)
 app/advisors/page.tsx                       (uses <DirectoryBanners />)
 app/compare/page.tsx                        (uses <DirectoryBanners />)
 app/invest/page.tsx                         (uses <DirectoryBanners />)
 components/foreign-investment/
   DirectoryBanners.tsx                      (new — server component wrapper)
   banner-tokens.ts                          (new — colour + radius + padding tokens)
   IntentCountryBadge.tsx                    (uses tokens)
   IntentCountryRecommendation.tsx           (uses lib/page-recommendations.ts)
   IntentCountryRecommendationCard.tsx       (uses tokens)
 lib/page-recommendations.ts                 (new — data-layer copy lookup)
```

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint <all-touched> --max-warnings 0` clean
- [x] `npm test -- __tests__/lib/page-recommendations.test.ts` → 6/6 passing
- [x] Pre-push hook passes
- [ ] CI green
- [ ] Manual: set `iv_intent_country=gb` cookie, visit `/invest`, `/advisors`, `/compare` — confirm identical banner stack order on all three, dwelling-ban alert now appears on `/compare` too

## Follow-ups

- Phase 2 (filter primitives) — next PR
- Adding a new surface or country variant now only requires editing `lib/page-recommendations.ts`; component is closed for modification

https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk)_