### PR TITLE
feat(directory): phase 2 session 6 — extract <TabBar> and <ResultCount>

### DIFF
--- a/__tests__/components/directory/ResultCount.test.tsx
+++ b/__tests__/components/directory/ResultCount.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "../setup";
+import ResultCount from "@/components/directory/ResultCount";
+
+describe("ResultCount — single-line mode", () => {
+  it("renders total + default noun 'listings'", () => {
+    const { container } = render(<ResultCount total={42} />);
+    expect(container.textContent).toContain("42");
+    expect(container.textContent).toContain("listings");
+  });
+
+  it("uses a custom noun when supplied", () => {
+    const { container } = render(<ResultCount total={3} noun="advisors" />);
+    expect(container.textContent).toContain("3");
+    expect(container.textContent).toContain("advisors");
+  });
+
+  it("wraps in an aria-live=polite region for screen readers", () => {
+    const { container } = render(<ResultCount total={1} />);
+    expect(container.firstElementChild).toHaveAttribute("aria-live", "polite");
+  });
+});
+
+describe("ResultCount — pill mode", () => {
+  it("renders one pill per entry with count + label", () => {
+    render(
+      <ResultCount
+        total={159}
+        pills={[
+          { tone: "live", count: 159, label: "live opportunities" },
+          { tone: "info", count: 84, label: "FIRB-eligible", icon: "globe" },
+          { tone: "good", count: 6, label: "SIV-complying", icon: "shield-check" },
+        ]}
+      />,
+    );
+    expect(screen.getByText(/159/)).toBeInTheDocument();
+    expect(screen.getByText(/live opportunities/)).toBeInTheDocument();
+    expect(screen.getByText(/84/)).toBeInTheDocument();
+    expect(screen.getByText(/FIRB-eligible/)).toBeInTheDocument();
+    expect(screen.getByText(/6/)).toBeInTheDocument();
+    expect(screen.getByText(/SIV-complying/)).toBeInTheDocument();
+  });
+
+  it("still wraps in aria-live=polite when in pill mode", () => {
+    const { container } = render(
+      <ResultCount
+        total={1}
+        pills={[{ tone: "neutral", count: 1, label: "x" }]}
+      />,
+    );
+    expect(container.firstElementChild).toHaveAttribute("aria-live", "polite");
+  });
+});

--- a/__tests__/components/directory/TabBar.test.tsx
+++ b/__tests__/components/directory/TabBar.test.tsx
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, userEvent } from "../setup";
+import TabBar from "@/components/directory/TabBar";
+
+const TABS = [
+  { id: "all", label: "All", count: 10 },
+  { id: "active", label: "Active", count: 6 },
+  { id: "closed", label: "Closed", count: 4 },
+  { id: "empty", label: "Empty", count: 0 },
+];
+
+describe("TabBar — segmented variant", () => {
+  it("renders all tabs with role tablist/tab semantics", () => {
+    render(
+      <TabBar
+        tabs={TABS}
+        value="all"
+        onChange={() => {}}
+        ariaLabel="Status"
+        variant="segmented"
+        zeroCountBehavior="show"
+      />,
+    );
+    expect(screen.getByRole("tablist", { name: "Status" })).toBeInTheDocument();
+    expect(screen.getAllByRole("tab")).toHaveLength(4);
+  });
+
+  it("marks the active tab with aria-selected", () => {
+    render(
+      <TabBar
+        tabs={TABS}
+        value="active"
+        onChange={() => {}}
+        ariaLabel="Status"
+        variant="segmented"
+        zeroCountBehavior="show"
+      />,
+    );
+    expect(screen.getByRole("tab", { name: /Active/ })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+
+  it("fires onChange with the tab id when a tab is clicked", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <TabBar
+        tabs={TABS}
+        value="all"
+        onChange={onChange}
+        ariaLabel="Status"
+        variant="segmented"
+        zeroCountBehavior="show"
+      />,
+    );
+    await user.click(screen.getByRole("tab", { name: /Active/ }));
+    expect(onChange).toHaveBeenCalledWith("active");
+  });
+});
+
+describe("TabBar — zero-count behaviour", () => {
+  it("hides zero-count tabs by default", () => {
+    render(
+      <TabBar
+        tabs={TABS}
+        value="all"
+        onChange={() => {}}
+        ariaLabel="Status"
+        variant="segmented"
+      />,
+    );
+    expect(screen.queryByRole("tab", { name: /Empty/ })).not.toBeInTheDocument();
+    expect(screen.getAllByRole("tab")).toHaveLength(3);
+  });
+
+  it("disables zero-count tabs when behaviour is 'disable'", () => {
+    render(
+      <TabBar
+        tabs={TABS}
+        value="all"
+        onChange={() => {}}
+        ariaLabel="Status"
+        variant="segmented"
+        zeroCountBehavior="disable"
+      />,
+    );
+    const emptyTab = screen.getByRole("tab", { name: /Empty/ });
+    expect(emptyTab).toBeDisabled();
+  });
+
+  it("shows zero-count tabs as enabled when behaviour is 'show'", () => {
+    render(
+      <TabBar
+        tabs={TABS}
+        value="all"
+        onChange={() => {}}
+        ariaLabel="Status"
+        variant="segmented"
+        zeroCountBehavior="show"
+      />,
+    );
+    const emptyTab = screen.getByRole("tab", { name: /Empty/ });
+    expect(emptyTab).not.toBeDisabled();
+  });
+
+  it("respects alwaysShow — never hides that tab even with count=0", () => {
+    const tabs = [
+      { id: "all", label: "All", count: 0 },
+      { id: "x", label: "X", count: 5 },
+    ];
+    render(
+      <TabBar
+        tabs={tabs}
+        value="all"
+        onChange={() => {}}
+        ariaLabel="Status"
+        variant="segmented"
+        alwaysShow="all"
+      />,
+    );
+    expect(screen.getByRole("tab", { name: /All/ })).toBeInTheDocument();
+  });
+});
+
+describe("TabBar — chip variant", () => {
+  it("renders chip-style tabs with tablist semantics", () => {
+    render(
+      <TabBar
+        tabs={TABS}
+        value="all"
+        onChange={() => {}}
+        ariaLabel="Category"
+        variant="chip"
+        zeroCountBehavior="show"
+      />,
+    );
+    expect(screen.getByRole("tablist", { name: "Category" })).toBeInTheDocument();
+    expect(screen.getAllByRole("tab")).toHaveLength(4);
+  });
+});
+
+describe("TabBar — empty universe", () => {
+  it("renders nothing when every tab is filtered out", () => {
+    const tabs = [{ id: "x", label: "X", count: 0 }];
+    const { container } = render(
+      <TabBar
+        tabs={tabs}
+        value="x"
+        onChange={() => {}}
+        ariaLabel="Empty"
+        variant="segmented"
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/app/advisors/AdvisorsClient.tsx
+++ b/app/advisors/AdvisorsClient.tsx
@@ -15,6 +15,7 @@ import VerifiedBadge from "@/components/VerifiedBadge";
 import { trackEvent } from "@/lib/tracking";
 import { useAdvisorShortlist } from "@/lib/hooks/useAdvisorShortlist";
 import { ADVISOR_SPECIALTY_CATEGORIES } from "@/lib/advisor-specialties";
+import TabBar from "@/components/directory/TabBar";
 
 export interface ExpertTeamCard {
   id: number;
@@ -659,37 +660,20 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
             Hidden when sub-pages call AdvisorsClient with no firms/teams
             (e.g. /advisors/financial-planners). */}
         {(firms.length > 0 || expertTeams.length > 0) && (
-          <div
-            role="tablist"
-            aria-label="Provider type"
-            className="flex items-center gap-1 p-1 bg-slate-100 rounded-xl mb-3 md:mb-4 overflow-x-auto"
-          >
-            {(["all", "individual", "firm", "team"] as const)
-              .filter(pt => pt === "all" || providerTypeCounts[pt] > 0)
-              .map(pt => {
-                const label = pt === "all" ? "All" : PROVIDER_TYPE_LABELS[pt];
-                const count = providerTypeCounts[pt];
-                const active = providerType === pt;
-                return (
-                  <button
-                    key={pt}
-                    role="tab"
-                    aria-selected={active}
-                    onClick={() => setProviderType(pt)}
-                    className={`flex items-center gap-1.5 px-3 md:px-4 py-1.5 md:py-2 text-xs md:text-sm font-semibold rounded-lg transition-all whitespace-nowrap ${
-                      active
-                        ? "bg-white text-slate-900 shadow-sm"
-                        : "text-slate-600 hover:bg-white/60"
-                    }`}
-                  >
-                    {label}
-                    <span className={`text-[0.6rem] md:text-[0.65rem] font-bold px-1.5 py-0.5 rounded ${active ? "bg-amber-100 text-amber-700" : "bg-slate-200 text-slate-500"}`}>
-                      {count}
-                    </span>
-                  </button>
-                );
-              })}
-          </div>
+          <TabBar
+            ariaLabel="Provider type"
+            variant="segmented"
+            value={providerType}
+            onChange={(id) => setProviderType(id as ProviderType)}
+            alwaysShow="all"
+            className="mb-3 md:mb-4"
+            tabs={[
+              { id: "all", label: "All", count: providerTypeCounts.all },
+              { id: "individual", label: PROVIDER_TYPE_LABELS.individual, count: providerTypeCounts.individual },
+              { id: "firm", label: PROVIDER_TYPE_LABELS.firm, count: providerTypeCounts.firm },
+              { id: "team", label: PROVIDER_TYPE_LABELS.team, count: providerTypeCounts.team },
+            ]}
+          />
         )}
 
         {/* Search + Filter bar */}

--- a/components/InvestListingsClient.tsx
+++ b/components/InvestListingsClient.tsx
@@ -21,6 +21,7 @@ import InvestListingCard from "@/components/InvestListingCard";
 import ListingCompareBar from "@/components/invest/ListingCompareBar";
 import SaveSearchButton from "@/components/invest/SaveSearchButton";
 import Icon from "@/components/Icon";
+import TabBar from "@/components/directory/TabBar";
 
 // ─── Props ───────────────────────────────────────────────────────────
 export interface InvestListingsClientProps {
@@ -580,41 +581,20 @@ export default function InvestListingsClient({
           )}
 
           {/* Row 3: category chips (secondary narrow by sector) */}
-          {!lockedCategory && (() => {
-            const visibleTabs = tabs.filter(tab => tab.slug === "all" || (categoryCounts[tab.slug] ?? 0) > 0);
-            if (visibleTabs.length <= 1) return null;
-            return (
-              <div className="overflow-x-auto scrollbar-hide -mx-1 px-1">
-                <div className="flex items-center gap-1.5 min-w-max">
-                  {visibleTabs.map((tab) => {
-                    const isActive = tab.slug === activeCategory;
-                    const count = categoryCounts[tab.slug] ?? 0;
-                    const isAll = tab.slug === "all";
-                    return (
-                      <button
-                        key={tab.slug}
-                        type="button"
-                        onClick={() => setParams({ category: tab.slug === "all" ? "" : tab.slug, sub: "" })}
-                        aria-pressed={isActive}
-                        className={`whitespace-nowrap rounded-full px-3 py-1 text-[0.7rem] font-medium transition-all inline-flex items-center gap-1 ${
-                          isActive
-                            ? "bg-slate-100 text-slate-900 ring-1 ring-slate-300"
-                            : "text-slate-500 hover:bg-slate-50"
-                        }`}
-                      >
-                        {tab.label}
-                        {!isAll && (
-                          <span className="text-[0.55rem] font-bold tabular-nums text-slate-400">
-                            {count}
-                          </span>
-                        )}
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
-            );
-          })()}
+          {!lockedCategory && (
+            <TabBar
+              ariaLabel="Category"
+              variant="chip"
+              value={activeCategory}
+              onChange={(id) => setParams({ category: id === "all" ? "" : id, sub: "" })}
+              alwaysShow="all"
+              tabs={tabs.map((tab) => ({
+                id: tab.slug,
+                label: tab.label,
+                count: tab.slug === "all" ? undefined : (categoryCounts[tab.slug] ?? 0),
+              }))}
+            />
+          )}
 
           {/* Active-filter chips */}
           {activeChips.length > 0 && (

--- a/components/directory/ResultCount.tsx
+++ b/components/directory/ResultCount.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import type { ReactNode } from "react";
+import Icon from "@/components/Icon";
+
+/**
+ * Canonical result-count display for directory pages.
+ *
+ * Two display modes:
+ *
+ *   1. Single-line: "{n} listings found"
+ *   2. Pill mode: a row of stat pills — total + optional secondary
+ *      facts ("84 FIRB-eligible", "6 SIV-complying"). Used on
+ *      /invest hero where multiple counts add useful context.
+ *
+ * Single-line mode (the simpler case) is the default — pass
+ * `pills={[...]}` to enable pill mode.
+ *
+ * Live region
+ * -----------
+ * The result count is wrapped in `aria-live="polite"` so screen
+ * readers announce result-set changes when filters narrow. Avoid
+ * `aria-live="assertive"` — filter changes shouldn't interrupt the
+ * user's flow.
+ */
+export interface ResultPill {
+  /** Tone — drives background + text colour. */
+  tone: "neutral" | "live" | "info" | "good" | "warn";
+  /** Numeric count rendered in bold. */
+  count: number;
+  /** Singular/plural label after the count. */
+  label: string;
+  /** Optional icon name. */
+  icon?: string;
+}
+
+export interface ResultCountProps {
+  /** Total result count — rendered as the primary number. */
+  total: number;
+  /** Singular/plural noun shown after the count when no pills supplied. */
+  noun?: string;
+  /** Optional stat pills row (overrides the single-line "{n} found" output). */
+  pills?: ReadonlyArray<ResultPill>;
+  className?: string;
+  /** Optional trailing content (e.g. an inline "view all" link). */
+  children?: ReactNode;
+}
+
+const PILL_TONES: Record<ResultPill["tone"], string> = {
+  neutral: "bg-white border-slate-200 text-slate-700",
+  live: "bg-white border-emerald-200 text-emerald-700",
+  info: "bg-white border-blue-200 text-blue-700",
+  good: "bg-white border-emerald-200 text-emerald-700",
+  warn: "bg-white border-amber-200 text-amber-700",
+};
+
+export default function ResultCount({
+  total,
+  noun = "listings",
+  pills,
+  className = "",
+  children,
+}: ResultCountProps) {
+  if (pills && pills.length > 0) {
+    return (
+      <div
+        aria-live="polite"
+        className={`flex items-center gap-2 flex-wrap ${className}`}
+      >
+        {pills.map((p, idx) => (
+          <span
+            key={idx}
+            className={`inline-flex items-center gap-1.5 px-3 py-1 border rounded-full text-[0.65rem] md:text-xs font-semibold shadow-sm ${PILL_TONES[p.tone]}`}
+          >
+            {p.tone === "live" && !p.icon && (
+              <span
+                aria-hidden
+                className="w-1.5 h-1.5 bg-emerald-500 rounded-full animate-pulse"
+              />
+            )}
+            {p.icon && <Icon name={p.icon} size={11} aria-hidden />}
+            <span className="font-bold">{p.count}</span> {p.label}
+          </span>
+        ))}
+        {children}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      aria-live="polite"
+      className={`text-sm text-slate-600 ${className}`}
+    >
+      <span className="font-bold text-slate-900">{total}</span> {noun}
+      {total !== 1 ? "" : ""}
+      {children}
+    </div>
+  );
+}

--- a/components/directory/TabBar.tsx
+++ b/components/directory/TabBar.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import Icon from "@/components/Icon";
+
+/**
+ * Canonical tab-bar primitive for directory pages.
+ *
+ * Supports two visual variants today:
+ *
+ *   - "segmented"  — pill segmented control on a slate-100 background.
+ *                    Active tab has a white surface + shadow. Used for
+ *                    the /advisors provider-type bar.
+ *   - "chip"       — standalone borderless pills. Active tab gets a
+ *                    slate-100 fill + ring. Used for /invest
+ *                    category sub-row.
+ *
+ * Per-tab visual customization (per-kind accent colours on the /invest
+ * kind row) is intentionally NOT supported by this primitive — that
+ * row has 8+ unique accent palettes that don't generalise. Keep it as
+ * a bespoke render until the design system formalises a kind colour
+ * scale.
+ *
+ * Zero-count behaviour
+ * --------------------
+ * By default, tabs with count===0 are HIDDEN (so users never see
+ * dead-end "Expert Teams 0" affordances). Pass
+ * zeroCountBehavior="disable" to grey them out, or "show" to render
+ * normally (when zero is informative — e.g. "All categories with no
+ * results yet").
+ *
+ * The `alwaysShow` id (typically "all") is exempt from zero-count
+ * filtering — even when the universe is empty, the "All" tab should
+ * still be there to anchor the bar.
+ *
+ * Accessibility
+ * -------------
+ *  - role="tablist" on the wrapper with the supplied ariaLabel
+ *  - role="tab" + aria-selected on each tab
+ *  - Wrapper is horizontally scrollable on overflow (whitespace-nowrap)
+ *    with scrollbar-hide so mobile users don't see the native scrollbar.
+ */
+export interface TabBarItem<T extends string = string> {
+  id: T;
+  label: string;
+  count?: number;
+  /** Icon name from the lucide icon set; rendered to the left of the label. */
+  icon?: string;
+}
+
+export interface TabBarProps<T extends string = string> {
+  tabs: ReadonlyArray<TabBarItem<T>>;
+  value: T;
+  onChange: (id: T) => void;
+  ariaLabel: string;
+  variant: "segmented" | "chip";
+  /** Default: "hide". */
+  zeroCountBehavior?: "hide" | "disable" | "show";
+  /** Tab id that should never be filtered out by zero-count rules. */
+  alwaysShow?: T;
+  className?: string;
+}
+
+export default function TabBar<T extends string = string>({
+  tabs,
+  value,
+  onChange,
+  ariaLabel,
+  variant,
+  zeroCountBehavior = "hide",
+  alwaysShow,
+  className = "",
+}: TabBarProps<T>) {
+  const visible = tabs.filter((t) => {
+    if (alwaysShow && t.id === alwaysShow) return true;
+    if (typeof t.count !== "number") return true;
+    if (t.count > 0) return true;
+    return zeroCountBehavior !== "hide";
+  });
+
+  if (visible.length === 0) return null;
+
+  if (variant === "segmented") {
+    return (
+      <div
+        role="tablist"
+        aria-label={ariaLabel}
+        className={`flex items-center gap-1 p-1 bg-slate-100 rounded-xl overflow-x-auto scrollbar-hide ${className}`}
+      >
+        {visible.map((t) => (
+          <SegmentedTab
+            key={t.id}
+            tab={t}
+            active={t.id === value}
+            disabled={zeroCountBehavior === "disable" && t.count === 0 && t.id !== alwaysShow}
+            onClick={() => onChange(t.id)}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  // chip
+  return (
+    <div
+      role="tablist"
+      aria-label={ariaLabel}
+      className={`overflow-x-auto scrollbar-hide -mx-1 px-1 ${className}`}
+    >
+      <div className="flex items-center gap-1.5 min-w-max">
+        {visible.map((t) => (
+          <ChipTab
+            key={t.id}
+            tab={t}
+            active={t.id === value}
+            isAll={alwaysShow !== undefined && t.id === alwaysShow}
+            disabled={zeroCountBehavior === "disable" && t.count === 0 && t.id !== alwaysShow}
+            onClick={() => onChange(t.id)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+interface InternalTabProps<T extends string = string> {
+  tab: TabBarItem<T>;
+  active: boolean;
+  disabled: boolean;
+  onClick: () => void;
+}
+
+function SegmentedTab<T extends string = string>({
+  tab,
+  active,
+  disabled,
+  onClick,
+}: InternalTabProps<T>) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      disabled={disabled}
+      onClick={onClick}
+      className={`flex items-center gap-1.5 px-3 md:px-4 py-1.5 md:py-2 text-xs md:text-sm font-semibold rounded-lg transition-all whitespace-nowrap ${
+        active
+          ? "bg-white text-slate-900 shadow-sm"
+          : disabled
+            ? "text-slate-300 cursor-not-allowed"
+            : "text-slate-600 hover:bg-white/60"
+      }`}
+    >
+      {tab.icon && <Icon name={tab.icon} size={12} aria-hidden />}
+      {tab.label}
+      {typeof tab.count === "number" && (
+        <span
+          className={`text-[0.6rem] md:text-[0.65rem] font-bold px-1.5 py-0.5 rounded ${
+            active ? "bg-amber-100 text-amber-700" : "bg-slate-200 text-slate-500"
+          }`}
+        >
+          {tab.count}
+        </span>
+      )}
+    </button>
+  );
+}
+
+function ChipTab<T extends string = string>({
+  tab,
+  active,
+  isAll,
+  disabled,
+  onClick,
+}: InternalTabProps<T> & { isAll: boolean }) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      disabled={disabled}
+      onClick={onClick}
+      className={`whitespace-nowrap rounded-full px-3 py-1 text-[0.7rem] font-medium transition-all inline-flex items-center gap-1 ${
+        active
+          ? "bg-slate-100 text-slate-900 ring-1 ring-slate-300"
+          : disabled
+            ? "text-slate-300 cursor-not-allowed"
+            : "text-slate-500 hover:bg-slate-50"
+      }`}
+    >
+      {tab.icon && <Icon name={tab.icon} size={11} aria-hidden />}
+      {tab.label}
+      {!isAll && typeof tab.count === "number" && (
+        <span
+          className={`text-[0.55rem] font-bold tabular-nums ${
+            disabled ? "text-slate-300" : "text-slate-400"
+          }`}
+        >
+          {tab.count}
+        </span>
+      )}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary

Phase 2 Session 6: extract `<TabBar>` (segmented + chip variants) and `<ResultCount>` (single-line + pill mode) primitives. Migrates `/advisors` provider-type bar and `/invest` category chip row.

## Primitives

### `<TabBar>`
- Variants: `segmented` (slate-100 wrapper, white surface for active) and `chip` (standalone pills)
- `zeroCountBehavior: "hide" | "disable" | "show"` — default `hide`
- `alwaysShow` id — never filtered out by zero-count rules
- ARIA: `role="tablist"` + `aria-selected` on each tab
- 9 unit tests

### `<ResultCount>`
- Single-line mode: `{total} listings`
- Pill mode: row of stat chips (`live | info | good | warn | neutral` tones)
- Always wrapped in `aria-live="polite"` so filter-change announcements reach SR users
- 5 unit tests

## Consumer migrations

- `app/advisors/AdvisorsClient.tsx` — provider-type bar now renders via `<TabBar variant="segmented" alwaysShow="all" />`
- `components/InvestListingsClient.tsx` — category chip row now renders via `<TabBar variant="chip" alwaysShow="all" />`

## Intentionally NOT migrated

- **`/invest` kind tabs (Row 2)** — 8+ per-kind accent palettes that don't generalise. Kept bespoke until the design system formalises a kind colour scale.
- **Hero stat pills** — `<ResultCount>` exports a pill mode but `/invest` hero pills sit beside title chrome and `/advisors` count sits inside the search row. Migrating those needs a wider hero-layout refactor queued for Session 7+.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint <all touched> --max-warnings 0` clean
- [x] 14 new unit tests pass
- [x] Pre-push hook (type-check + rate-limit audit + changed-file tests) passes
- [ ] CI green
- [ ] Manual: `/advisors` provider tabs still work (All / Individuals / Firms / Expert Teams), zero-count tabs hidden
- [ ] Manual: `/invest` category chips still work, no behaviour change

## Independence from sibling PRs

This branches from `main` and overlaps only with `#955` (Phase 2 Session 4) on the import lines of the two consumer client components. Either order of merge is fine — git auto-merge handles the imports.

https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk)_