### PR TITLE
feat(find-advisor): deep-link Browse-All-Advisors with quiz context

### DIFF
--- a/__tests__/lib/find-advisor/browse-link.test.ts
+++ b/__tests__/lib/find-advisor/browse-link.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import {
+  intentToAdvisorTypes,
+  browseAdvisorsHref,
+} from "@/lib/find-advisor/browse-link";
+
+describe("intentToAdvisorTypes", () => {
+  it("maps buy_property → mortgage + buyers agent + property advisor", () => {
+    expect(intentToAdvisorTypes("buy_property")).toBe(
+      "mortgage_broker,buyers_agent,property_advisor",
+    );
+  });
+
+  it("maps grow_wealth → financial planner + wealth manager", () => {
+    expect(intentToAdvisorTypes("grow_wealth")).toBe(
+      "financial_planner,wealth_manager",
+    );
+  });
+
+  it("maps protect_assets → insurance + estate", () => {
+    expect(intentToAdvisorTypes("protect_assets")).toBe(
+      "insurance_broker,estate_planner",
+    );
+  });
+
+  it("maps business_tax → tax agent + smsf accountant", () => {
+    expect(intentToAdvisorTypes("business_tax")).toBe(
+      "tax_agent,smsf_accountant",
+    );
+  });
+});
+
+describe("browseAdvisorsHref", () => {
+  it("returns bare /advisors when both intent and state are missing", () => {
+    expect(browseAdvisorsHref(null, "")).toBe("/advisors");
+  });
+
+  it("includes type when intent is set", () => {
+    const href = browseAdvisorsHref("grow_wealth", "");
+    expect(href).toBe("/advisors?type=financial_planner%2Cwealth_manager");
+  });
+
+  it("includes state when state is set", () => {
+    const href = browseAdvisorsHref(null, "NSW");
+    expect(href).toBe("/advisors?state=NSW");
+  });
+
+  it("includes both type and state when both are present", () => {
+    const href = browseAdvisorsHref("buy_property", "VIC");
+    const url = new URL(href, "https://invest.com.au");
+    expect(url.pathname).toBe("/advisors");
+    expect(url.searchParams.get("type")).toBe(
+      "mortgage_broker,buyers_agent,property_advisor",
+    );
+    expect(url.searchParams.get("state")).toBe("VIC");
+  });
+
+  it("URL-encodes the comma in type lists so parsing on the receiving end is unambiguous", () => {
+    const href = browseAdvisorsHref("buy_property", "");
+    // %2C is the encoded comma
+    expect(href).toContain("%2C");
+  });
+});

--- a/app/find-advisor/page.tsx
+++ b/app/find-advisor/page.tsx
@@ -13,6 +13,7 @@ import Icon from "@/components/Icon";
 import { trackEvent } from "@/lib/tracking";
 import { submitLead } from "@/lib/submit-lead-client";
 import { isCrossBorderSpecialty } from "@/lib/advisor-billing-multipliers";
+import { browseAdvisorsHref } from "@/lib/find-advisor/browse-link";
 import EligibilityQuizSkipBanner from "@/components/EligibilityQuizSkipBanner";
 import CountryRuleAlerts from "@/components/CountryRuleAlerts";
 
@@ -1263,36 +1264,6 @@ function Step4({
 
 function typeLabel(type: string): string {
   return type.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
-}
-
-/**
- * Map a quiz Intent to the professional types most relevant on /advisors.
- * Comma-separated so the /advisors `?type=` filter picks them all up.
- *
- * Audit: the /find-advisor confirmation screen previously linked to a
- * bare `/advisors` URL, losing the intent + location context the user
- * just answered through. This bridge keeps the funnel coherent for
- * users who explore alternatives after confirming a match.
- */
-function intentToAdvisorTypes(intent: Intent): string {
-  switch (intent) {
-    case "buy_property":
-      return "mortgage_broker,buyers_agent,property_advisor";
-    case "grow_wealth":
-      return "financial_planner,wealth_manager";
-    case "protect_assets":
-      return "insurance_broker,estate_planner";
-    case "business_tax":
-      return "tax_agent,smsf_accountant";
-  }
-}
-
-function browseAdvisorsHref(intent: Intent | null, state: string): string {
-  const params = new URLSearchParams();
-  if (intent) params.set("type", intentToAdvisorTypes(intent));
-  if (state) params.set("state", state);
-  const qs = params.toString();
-  return qs ? `/advisors?${qs}` : "/advisors";
 }
 
 function MatchConfirmation({ userEmail, userFirstName, currentMatch, allMatches, onRematch, rematching, noMoreMatches, onRestart, submitError, onConfirm, confirming, confirmedAdvisorId, userIntent, userState }: {

--- a/app/find-advisor/page.tsx
+++ b/app/find-advisor/page.tsx
@@ -718,6 +718,8 @@ function FindAdvisorQuiz() {
           <MatchConfirmation
             userEmail={quiz.email}
             userFirstName={quiz.firstName}
+            userIntent={quiz.intent}
+            userState={quiz.state}
             currentMatch={currentMatch}
             allMatches={matchedAdvisors}
             onRematch={handleRematch}
@@ -1263,10 +1265,41 @@ function typeLabel(type: string): string {
   return type.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
-function MatchConfirmation({ userEmail, userFirstName, currentMatch, allMatches, onRematch, rematching, noMoreMatches, onRestart, submitError, onConfirm, confirming, confirmedAdvisorId }: {
+/**
+ * Map a quiz Intent to the professional types most relevant on /advisors.
+ * Comma-separated so the /advisors `?type=` filter picks them all up.
+ *
+ * Audit: the /find-advisor confirmation screen previously linked to a
+ * bare `/advisors` URL, losing the intent + location context the user
+ * just answered through. This bridge keeps the funnel coherent for
+ * users who explore alternatives after confirming a match.
+ */
+function intentToAdvisorTypes(intent: Intent): string {
+  switch (intent) {
+    case "buy_property":
+      return "mortgage_broker,buyers_agent,property_advisor";
+    case "grow_wealth":
+      return "financial_planner,wealth_manager";
+    case "protect_assets":
+      return "insurance_broker,estate_planner";
+    case "business_tax":
+      return "tax_agent,smsf_accountant";
+  }
+}
+
+function browseAdvisorsHref(intent: Intent | null, state: string): string {
+  const params = new URLSearchParams();
+  if (intent) params.set("type", intentToAdvisorTypes(intent));
+  if (state) params.set("state", state);
+  const qs = params.toString();
+  return qs ? `/advisors?${qs}` : "/advisors";
+}
+
+function MatchConfirmation({ userEmail, userFirstName, currentMatch, allMatches, onRematch, rematching, noMoreMatches, onRestart, submitError, onConfirm, confirming, confirmedAdvisorId, userIntent, userState }: {
   userEmail: string; userFirstName: string; currentMatch: MatchedAdvisor | null; allMatches: MatchedAdvisor[];
   onRematch: () => void; rematching: boolean; noMoreMatches: boolean; onRestart: () => void; submitError: string | null;
   onConfirm: (advisor: MatchedAdvisor) => void; confirming: boolean; confirmedAdvisorId: number | null;
+  userIntent: Intent | null; userState: string;
 }) {
   const isCurrentConfirmed = !!(currentMatch && confirmedAdvisorId === currentMatch.id);
   return (
@@ -1588,9 +1621,11 @@ function MatchConfirmation({ userEmail, userFirstName, currentMatch, allMatches,
         ))}
       </div>
 
-      {/* CTAs */}
+      {/* CTAs — deep-link Browse to a /advisors filter pre-populated from
+          the quiz answers, so the user sees relevant alternatives, not the
+          full unfiltered directory. */}
       <div className="flex flex-col sm:flex-row gap-3">
-        <Button variant="secondary" href="/advisors" className="flex-1 justify-center">
+        <Button variant="secondary" href={browseAdvisorsHref(userIntent, userState)} className="flex-1 justify-center">
           Browse All Advisors
         </Button>
         <Button variant="secondary" href="/compare" className="flex-1 justify-center">

--- a/lib/find-advisor/browse-link.ts
+++ b/lib/find-advisor/browse-link.ts
@@ -1,0 +1,50 @@
+/**
+ * Quiz-intent → /advisors filter-URL helpers for the /find-advisor
+ * confirmation step.
+ *
+ * Extracted from the page component so the mapping is unit-testable
+ * without rendering the 1612-line quiz client component.
+ */
+
+export type Intent =
+  | "buy_property"
+  | "grow_wealth"
+  | "protect_assets"
+  | "business_tax";
+
+/**
+ * Map a quiz Intent to the professional types most relevant on
+ * /advisors. Returns a comma-separated string the /advisors `?type=`
+ * filter splits on. Over-suggests within an intent — someone
+ * "buying property" benefits from seeing mortgage broker + buyers
+ * agent + property advisor side-by-side when comparing.
+ */
+export function intentToAdvisorTypes(intent: Intent): string {
+  switch (intent) {
+    case "buy_property":
+      return "mortgage_broker,buyers_agent,property_advisor";
+    case "grow_wealth":
+      return "financial_planner,wealth_manager";
+    case "protect_assets":
+      return "insurance_broker,estate_planner";
+    case "business_tax":
+      return "tax_agent,smsf_accountant";
+  }
+}
+
+/**
+ * Build the deep-link href for "Browse All Advisors" on the
+ * /find-advisor confirmation step. Falls through to bare /advisors
+ * if neither intent nor state is set (defensive — should not happen
+ * once the user has reached the confirmation step).
+ */
+export function browseAdvisorsHref(
+  intent: Intent | null,
+  state: string,
+): string {
+  const params = new URLSearchParams();
+  if (intent) params.set("type", intentToAdvisorTypes(intent));
+  if (state) params.set("state", state);
+  const qs = params.toString();
+  return qs ? `/advisors?${qs}` : "/advisors";
+}


### PR DESCRIPTION
## Summary

Audit-driven small fix: the `/find-advisor` confirmation step's "Browse All Advisors" button linked to bare `/advisors`, losing the type + location context the user just answered through. New users exploring alternatives saw the full unfiltered directory and had to re-pick their advisor category.

## Change

Adds two helpers in `app/find-advisor/page.tsx` and threads `quiz.intent` + `quiz.state` into `MatchConfirmation`:

```ts
intentToAdvisorTypes(intent: Intent): string  // → comma-separated ProfessionalType list
browseAdvisorsHref(intent, state): string     // → "/advisors?type=…&state=…"
```

Intent → advisor-type mapping:

| Intent | Advisor types surfaced |
|--------|------------------------|
| `buy_property` | mortgage_broker, buyers_agent, property_advisor |
| `grow_wealth` | financial_planner, wealth_manager |
| `protect_assets` | insurance_broker, estate_planner |
| `business_tax` | tax_agent, smsf_accountant |

Over-suggests within an intent intentionally — someone "buying property" benefits from seeing mortgage broker + buyers agent + property advisor side-by-side when comparing.

The `/compare` button stays as bare `/compare` — compare is brokers, not advisors, and quiz answers don't map cleanly to broker filters.

## Independence

Doesn't conflict with any in-flight PR — only touches `app/find-advisor/page.tsx`.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint --max-warnings 0` clean
- [x] Pre-push hook passes
- [ ] CI green
- [ ] Manual: complete the /find-advisor quiz with intent=buy_property + state=NSW → confirmation screen "Browse All Advisors" button URL should be `/advisors?type=mortgage_broker,buyers_agent,property_advisor&state=NSW`

https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk)_