### PR TITLE
feat(directory): extract <CompareBar> primitive

### DIFF
--- a/__tests__/components/directory/CompareBar.test.tsx
+++ b/__tests__/components/directory/CompareBar.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "../setup";
+import CompareBar from "@/components/directory/CompareBar";
+
+describe("CompareBar", () => {
+  it("renders nothing when count is 0", () => {
+    const { container } = render(
+      <CompareBar count={0} max={4} noun="advisor" compareHref="/x" />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows 'save 1 more to compare' when count is 1", () => {
+    render(<CompareBar count={1} max={4} noun="advisor" compareHref="/x" />);
+    expect(screen.getByText(/1 advisor saved/)).toBeInTheDocument();
+    expect(screen.getByText(/save 1 more to compare/)).toBeInTheDocument();
+  });
+
+  it("shows the Compare CTA when count is 2 or more", () => {
+    render(<CompareBar count={3} max={4} noun="advisor" compareHref="/advisors/compare" />);
+    const cta = screen.getByRole("link", { name: /Compare 3/ });
+    expect(cta).toHaveAttribute("href", "/advisors/compare");
+  });
+
+  it("pluralises the noun correctly", () => {
+    render(<CompareBar count={2} max={4} noun="listing" compareHref="/x" />);
+    expect(screen.getByText(/2 listings saved/)).toBeInTheDocument();
+  });
+
+  it("hides View Saved when viewHref is not supplied", () => {
+    render(<CompareBar count={1} max={4} noun="advisor" compareHref="/x" />);
+    expect(screen.queryByRole("link", { name: /View saved/ })).not.toBeInTheDocument();
+  });
+
+  it("renders View Saved link when viewHref is supplied", () => {
+    render(
+      <CompareBar
+        count={2}
+        max={4}
+        noun="advisor"
+        compareHref="/x"
+        viewHref="/shortlist/advisors"
+      />,
+    );
+    expect(screen.getByRole("link", { name: /View saved/ })).toHaveAttribute(
+      "href",
+      "/shortlist/advisors",
+    );
+  });
+
+  it("exposes the comparison shortlist via aria-label", () => {
+    render(<CompareBar count={1} max={4} noun="x" compareHref="/x" />);
+    expect(
+      screen.getByRole("region", { name: "Comparison shortlist" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/components/directory/CompareBar.tsx
+++ b/components/directory/CompareBar.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import Link from "next/link";
+
+/**
+ * Canonical sticky shortlist + compare bar for directory pages.
+ *
+ * Renders only when the shortlist has ≥1 item. Tone:
+ *   1 item   → "1 saved — save N more to compare" (no compare CTA)
+ *   2-max    → "N saved · Compare N →" (action-ready)
+ *   at max   → same as above; toggle on an unsaved tile becomes a
+ *              no-op silently (the hook caps internally)
+ *
+ * Visual style aligns with the site's slate/amber palette — the
+ * shortlist bar on /advisors used to be bg-violet-600 which broke
+ * the design system (recolored in QW6 of the directory UX plan).
+ * This primitive bakes in the slate-900 + amber-500 pairing so
+ * future consumers don't drift.
+ */
+export interface CompareBarProps {
+  count: number;
+  max: number;
+  /** Singular noun for "N <noun> saved". E.g. "advisor", "listing". */
+  noun: string;
+  /** Where the "Compare N" CTA lands. */
+  compareHref: string;
+  /** Where "View saved" lands (typically a list page like /shortlist/advisors). */
+  viewHref?: string;
+  className?: string;
+}
+
+export default function CompareBar({
+  count,
+  max,
+  noun,
+  compareHref,
+  viewHref,
+  className = "",
+}: CompareBarProps) {
+  if (count <= 0) return null;
+  const plural = count === 1 ? "" : "s";
+  return (
+    <div className={`sticky top-16 z-30 mb-3 ${className}`}>
+      <div
+        role="region"
+        aria-label="Comparison shortlist"
+        className="bg-slate-900 text-white rounded-xl px-4 py-2.5 flex items-center justify-between shadow-lg shadow-slate-300"
+      >
+        <span className="text-sm font-semibold">
+          {count} {noun}
+          {plural} saved
+          {count === 1 && (
+            <span className="text-slate-300 font-normal">
+              {" "}
+              — save 1 more to compare
+            </span>
+          )}
+        </span>
+        <div className="flex items-center gap-2">
+          {viewHref && (
+            <Link
+              href={viewHref}
+              className="px-3 py-1.5 text-slate-300 text-xs font-semibold hover:text-white transition-colors"
+            >
+              View saved
+            </Link>
+          )}
+          {count >= 2 ? (
+            <Link
+              href={compareHref}
+              className="px-3 py-1.5 bg-amber-500 text-white text-xs font-bold rounded-lg hover:bg-amber-400 transition-colors"
+            >
+              Compare {count} &rarr;
+            </Link>
+          ) : (
+            <span className="text-xs text-slate-400">
+              {max - count} more to compare
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Phase 3 primitive: `<CompareBar>` — the canonical sticky shortlist + compare bar for directory pages. Pure presentation, no state of its own — consumers wire their existing shortlist hook to the props.

## Component

`components/directory/CompareBar.tsx`

```tsx
<CompareBar
  count={shortlistCount}
  max={shortlistMax}
  noun="advisor"            // singular; auto-pluralised
  compareHref="/advisors/compare"
  viewHref="/shortlist/advisors"
/>
```

- **Visual**: slate-900 surface + amber-500 Compare CTA. Matches the site palette; replaces the off-palette `bg-violet-600` bar that QW6 of the directory UX plan already recolored on `/advisors`.
- **Renders nothing when count ≤ 0** so consumers can wire it unconditionally.
- **Pluralises noun** automatically — `1 advisor` / `2 advisors`, `1 listing` / `2 listings`.
- **Tiered messaging**: "save 1 more to compare" hint when count===1, action-ready Compare CTA when count≥2.
- **A11y**: `role="region"` + `aria-label="Comparison shortlist"` so screen readers can navigate to it as a landmark.

## What this PR does NOT do

Investigated extracting a generic `useShortlist<T>` hook to back this primitive, but `lib/hooks/useShortlist.ts` is already in use as a **broker-specific** hook with its own contract (different storage key, server sync via `/api/sync-shortlist`, max=8). Refactoring it to generic shape needs coordination with that consumer. Deferred to a future PR; for now `<CompareBar>` works as a pure UI consumer that any shortlist hook can drive.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint <touched> --max-warnings 0` clean
- [x] 7 unit tests pass
- [x] Pre-push hook passes
- [ ] CI green

https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk)_