### PR TITLE
feat(routing): phase 5 session 14 — plural slug 301s for super + savings

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -140,6 +140,37 @@ const nextConfig: NextConfig = {
         destination: "/compare",
         permanent: true,
       },
+
+      // ── Directory-UX plan Phase 5 Session 14 — plural slug 301s.
+      // The user-locked decision (docs/plans/DIRECTORY_UX_UNIFICATION.md Q5)
+      // settles on "Plural directories + /find-* funnels". We keep the
+      // canonical singular routes (/super, /savings, /insurance) since
+      // they exist with content and SEO equity; these redirects catch
+      // the plural forms that external links / search results commonly
+      // use ("super funds Australia", "savings accounts comparison"
+      // etc.) so a user typing the plural never hits a 404. The
+      // canonical singular keeps its place; only the plural surface
+      // 301s to it.
+      {
+        source: "/super-funds",
+        destination: "/super",
+        permanent: true,
+      },
+      {
+        source: "/super-funds/:slug*",
+        destination: "/super/:slug*",
+        permanent: true,
+      },
+      {
+        source: "/savings-accounts",
+        destination: "/savings",
+        permanent: true,
+      },
+      {
+        source: "/savings-accounts/:slug*",
+        destination: "/savings/:slug*",
+        permanent: true,
+      },
       {
         source: "/brokers/:slug*",
         destination: "/broker/:slug*",


### PR DESCRIPTION
## Summary

Phase 5 Session 14 of the directory UX unification plan: add 301 redirects for the plural-slug forms of `/super` and `/savings` so external links and search results never hit a 404.

```
/super-funds        → /super         (permanent)
/super-funds/:slug  → /super/:slug   (permanent)
/savings-accounts        → /savings        (permanent)
/savings-accounts/:slug  → /savings/:slug  (permanent)
```

## Why these specifically

Per the user-locked Q5 decision (`docs/plans/DIRECTORY_UX_UNIFICATION.md`): **plural directories + `/find-*` funnels**. The canonical routes already exist as singular (`/super`, `/savings`) with SEO equity and existing content. The plural forms are what users naturally type ("super funds Australia", "savings accounts comparison" etc.).

Matches the existing `/brokers → /compare` pattern from `next.config.ts:138-141` — redirect plural to canonical singular, don't duplicate routes.

`/insurance`, `/etfs`, `/advisors`, `/brokers` are already in their canonical forms (`/insurance`/`/etfs`/`/advisors` are real routes; `/brokers` already 301s to `/compare`).

## Independence

Doesn't conflict with any in-flight PR — only touches `next.config.ts`.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint --max-warnings 0` clean
- [x] Pre-push hook passes
- [ ] CI green
- [ ] After merge: visit `/super-funds` → 301 to `/super`; `/savings-accounts` → 301 to `/savings`

https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk)_