### PR TITLE
feat(directory): extract <EmptyState> primitive

### DIFF
--- a/__tests__/components/directory/EmptyState.test.tsx
+++ b/__tests__/components/directory/EmptyState.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, userEvent } from "../setup";
+import EmptyState from "@/components/directory/EmptyState";
+
+describe("EmptyState", () => {
+  it("renders the title", () => {
+    render(<EmptyState title="No advisors found" />);
+    expect(screen.getByText("No advisors found")).toBeInTheDocument();
+  });
+
+  it("renders the body when supplied", () => {
+    render(
+      <EmptyState
+        title="No advisors found"
+        body="Try removing some filters."
+      />,
+    );
+    expect(screen.getByText("Try removing some filters.")).toBeInTheDocument();
+  });
+
+  it("exposes the result region via aria-label", () => {
+    render(<EmptyState title="x" />);
+    expect(screen.getByRole("region", { name: "No results" })).toBeInTheDocument();
+  });
+
+  it("renders suggestions as buttons and fires onClick on each", async () => {
+    const user = userEvent.setup();
+    const a = vi.fn();
+    const b = vi.fn();
+    render(
+      <EmptyState
+        title="x"
+        suggestions={[
+          { label: "Remove SIV filter (+12)", onClick: a },
+          { label: "Expand radius (+48)", onClick: b },
+        ]}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: /Remove SIV filter/ }));
+    expect(a).toHaveBeenCalled();
+    await user.click(screen.getByRole("button", { name: /Expand radius/ }));
+    expect(b).toHaveBeenCalled();
+  });
+
+  it("does not render a suggestions list when none supplied", () => {
+    render(<EmptyState title="x" />);
+    expect(screen.queryByRole("list")).not.toBeInTheDocument();
+  });
+
+  it("renders children below suggestions for custom actions", () => {
+    render(
+      <EmptyState
+        title="x"
+        suggestions={[{ label: "y", onClick: () => {} }]}
+      >
+        <div data-testid="custom-action">Set alert</div>
+      </EmptyState>,
+    );
+    expect(screen.getByTestId("custom-action")).toBeInTheDocument();
+  });
+});

--- a/components/directory/EmptyState.tsx
+++ b/components/directory/EmptyState.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import type { ReactNode } from "react";
+import Icon from "@/components/Icon";
+
+/**
+ * Canonical empty-state for directory pages.
+ *
+ * Renders a centered message + optional smart-suggestion list when
+ * filtering returns zero results. The suggestions are the difference
+ * between a frustrating dead-end and a productive recovery — they
+ * give users a concrete next click instead of just "no results, try
+ * something else".
+ *
+ * Three slots:
+ *   1. `icon` (optional) — defaults to the search icon
+ *   2. `title` — short headline ("No advisors found", "No
+ *      opportunities match your filters")
+ *   3. `body` — one-sentence explanation ("Try removing some filters
+ *      or expanding the radius.")
+ *   4. `suggestions` (optional) — array of one-click recovery
+ *      actions ("Remove the SIV filter (+12 results)", "Expand to
+ *      'Any distance' (+48 results)"). Each suggestion has a label
+ *      and an onClick; the count delta is part of the label
+ *      because rendering it separately required a tighter layout
+ *      contract we don't need yet.
+ *   5. `children` (optional) — slot for a custom action, e.g. an
+ *      alert-capture email form. Renders below suggestions.
+ *
+ * Use inline (inside the result feed where listings would be) rather
+ * than as a modal — empty-state modals interrupt flow and aren't
+ * needed for filter-induced empties.
+ */
+export interface EmptyStateSuggestion {
+  label: string;
+  onClick: () => void;
+}
+
+export interface EmptyStateProps {
+  title: string;
+  body?: string;
+  icon?: string;
+  suggestions?: ReadonlyArray<EmptyStateSuggestion>;
+  /** Optional custom slot (e.g. alert-capture form). Renders below suggestions. */
+  children?: ReactNode;
+  className?: string;
+}
+
+export default function EmptyState({
+  title,
+  body,
+  icon = "search",
+  suggestions,
+  children,
+  className = "",
+}: EmptyStateProps) {
+  return (
+    <div
+      role="region"
+      aria-label="No results"
+      className={`bg-white border border-slate-200 rounded-2xl text-center py-10 px-5 ${className}`}
+    >
+      <Icon
+        name={icon}
+        size={32}
+        className="text-slate-300 mx-auto mb-3"
+        aria-hidden
+      />
+      <p className="text-sm font-bold text-slate-700 mb-1">{title}</p>
+      {body && (
+        <p className="text-xs text-slate-500 mb-3 max-w-md mx-auto leading-relaxed">
+          {body}
+        </p>
+      )}
+      {suggestions && suggestions.length > 0 && (
+        <ul className="flex flex-wrap items-center justify-center gap-2 mb-3">
+          {suggestions.map((s, i) => (
+            <li key={i}>
+              <button
+                type="button"
+                onClick={s.onClick}
+                className="px-3 py-1.5 text-xs font-semibold bg-amber-50 border border-amber-200 text-amber-800 rounded-full hover:bg-amber-100 transition-colors"
+              >
+                {s.label}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Final Phase 2 Session 5.5 primitive: `<EmptyState>` — canonical empty-state for directory pages with optional smart-suggestion recovery actions.

```tsx
<EmptyState
  title="No advisors found"
  body="Try removing some filters or expanding the radius."
  suggestions={[
    { label: "Remove SIV filter (+12 results)", onClick: clearSiv },
    { label: "Expand to Any distance (+48)", onClick: expandRadius },
  ]}
>
  <AlertCapture />  {/* optional custom action slot */}
</EmptyState>
```

Smart suggestions give users a concrete recovery click instead of a dead-end "no results, try something else" — the difference between frustrating empty state and productive empty state.

- 6 unit tests
- Pure presentation, no state of its own
- `role="region" aria-label="No results"` for SR navigation
- Independent — fully new file, no conflict with any in-flight PR
- Consumer migration queued for follow-up (current `/advisors` no-results card + `/invest` empty branch each hand-roll their own version)

https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk)_