### PR TITLE
feat(directory): extract <FilterChips> primitive

### DIFF
--- a/__tests__/components/directory/FilterChips.test.tsx
+++ b/__tests__/components/directory/FilterChips.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, userEvent } from "../setup";
+import FilterChips from "@/components/directory/FilterChips";
+
+describe("FilterChips", () => {
+  it("renders nothing when chips is empty", () => {
+    const { container } = render(<FilterChips chips={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders one button per chip with the supplied label", () => {
+    render(
+      <FilterChips
+        chips={[
+          { label: "Mining", onClear: () => {} },
+          { label: "NSW", onClear: () => {} },
+        ]}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /Mining/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /NSW/ })).toBeInTheDocument();
+  });
+
+  it("fires the per-chip onClear when its button is clicked", async () => {
+    const user = userEvent.setup();
+    const a = vi.fn();
+    const b = vi.fn();
+    render(
+      <FilterChips
+        chips={[
+          { label: "Mining", onClear: a },
+          { label: "NSW", onClear: b },
+        ]}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: /Remove Mining filter/ }));
+    expect(a).toHaveBeenCalled();
+    expect(b).not.toHaveBeenCalled();
+  });
+
+  it("uses the default 'Filtering:' prefix", () => {
+    render(<FilterChips chips={[{ label: "X", onClear: () => {} }]} />);
+    expect(screen.getByText("Filtering:")).toBeInTheDocument();
+  });
+
+  it("accepts a custom prefix", () => {
+    render(
+      <FilterChips
+        chips={[{ label: "X", onClear: () => {} }]}
+        prefix="Refining by:"
+      />,
+    );
+    expect(screen.getByText("Refining by:")).toBeInTheDocument();
+  });
+
+  it("hides 'Clear all' when onClearAll is not supplied", () => {
+    render(<FilterChips chips={[{ label: "X", onClear: () => {} }]} />);
+    expect(screen.queryByRole("button", { name: /Clear all/ })).not.toBeInTheDocument();
+  });
+
+  it("renders 'Clear all' button when onClearAll is supplied", async () => {
+    const user = userEvent.setup();
+    const onClearAll = vi.fn();
+    render(
+      <FilterChips
+        chips={[{ label: "X", onClear: () => {} }]}
+        onClearAll={onClearAll}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: /Clear all/ }));
+    expect(onClearAll).toHaveBeenCalled();
+  });
+
+  it("exposes the region via aria-label", () => {
+    render(<FilterChips chips={[{ label: "X", onClear: () => {} }]} />);
+    expect(
+      screen.getByRole("region", { name: "Active filters" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/components/directory/FilterChips.tsx
+++ b/components/directory/FilterChips.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+/**
+ * Canonical active-filter chip strip for directory pages.
+ *
+ * Renders a "Filtering: <chips>" row with one removable chip per
+ * active filter and a "Clear all" affordance at the end. Useful as
+ * a persistent affordance in toolbars where the filter panel is
+ * not always visible — users see what's narrowing the result set
+ * and can dismiss individual filters with one click.
+ *
+ * Each chip is `{ label, onClear }`:
+ *   - `label` is rendered as visible text + sr-only "Remove {label}
+ *     filter" so screen readers get the action context
+ *   - `onClear` fires on click; the consumer is responsible for
+ *     mutating the underlying filter state
+ *
+ * Renders nothing when `chips.length === 0` so consumers can mount
+ * unconditionally.
+ *
+ * Accessibility
+ * -------------
+ *  - role="region" + aria-label="Active filters" so SR users can
+ *    navigate to the chip strip as a landmark
+ *  - Each chip is a <button> with both visible × glyph
+ *    (aria-hidden) and sr-only "Remove {label} filter" — clearest
+ *    screen-reader announcement we can give without redesigning
+ *    the visual chip
+ */
+export interface FilterChip {
+  /** Visible label, e.g. "Mining", "NSW", "FIRB-eligible". */
+  label: string;
+  /** Fires when the user clicks the × button. */
+  onClear: () => void;
+}
+
+export interface FilterChipsProps {
+  chips: ReadonlyArray<FilterChip>;
+  /** Fires when the user clicks "Clear all". Optional — hidden if not supplied. */
+  onClearAll?: () => void;
+  /** Heading rendered before the chips (default "Filtering:"). */
+  prefix?: string;
+  className?: string;
+}
+
+export default function FilterChips({
+  chips,
+  onClearAll,
+  prefix = "Filtering:",
+  className = "",
+}: FilterChipsProps) {
+  if (chips.length === 0) return null;
+  return (
+    <div
+      role="region"
+      aria-label="Active filters"
+      className={`flex flex-wrap items-center gap-1.5 ${className}`}
+    >
+      <span className="text-[10px] font-semibold uppercase tracking-wide text-slate-500">
+        {prefix}
+      </span>
+      {chips.map((c) => (
+        <button
+          key={c.label}
+          type="button"
+          onClick={c.onClear}
+          className="inline-flex items-center gap-1 rounded-full bg-amber-50 border border-amber-200 px-2 py-0.5 text-[11px] font-semibold text-amber-900 hover:bg-amber-100"
+        >
+          {c.label}
+          <span className="text-amber-600" aria-hidden="true">
+            ×
+          </span>
+          <span className="sr-only">Remove {c.label} filter</span>
+        </button>
+      ))}
+      {onClearAll && (
+        <button
+          type="button"
+          onClick={onClearAll}
+          className="text-[11px] font-bold text-slate-500 hover:text-slate-700 underline underline-offset-2 ml-1"
+        >
+          Clear all
+        </button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Another Phase 2 primitive: `<FilterChips>` — the "Filtering: chip · chip · chip — Clear all" strip lifted out of `InvestListingsClient.tsx`. Pure presentation, fully independent.

```tsx
<FilterChips
  chips={[
    { label: "Mining", onClear: () => clearKind("mining") },
    { label: "NSW", onClear: () => clearState() },
    { label: "FIRB-eligible", onClear: () => clearFirbOnly() },
  ]}
  onClearAll={clearAllFilters}
/>
```

`/advisors` currently has no equivalent — every filter has to be cleared by re-opening the filter panel. After a consumer migration (follow-up PR), `/advisors` gains the same persistent affordance.

- 8 unit tests
- `role="region" aria-label="Active filters"` landmark
- Each chip is a `<button>` with visible × glyph (aria-hidden) + sr-only "Remove {label} filter" for screen readers
- Renders nothing when chips is empty so consumers can mount unconditionally
- Independent — fully new file, no conflicts

https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk)_