### PR TITLE
feat(directory): extract <PostcodeAutocomplete> primitive

### DIFF
--- a/__tests__/components/directory/PostcodeAutocomplete.test.tsx
+++ b/__tests__/components/directory/PostcodeAutocomplete.test.tsx
@@ -50,7 +50,7 @@ describe("PostcodeAutocomplete", () => {
         debounceMs={0}
       />,
     );
-    await user.type(screen.getByRole("textbox"), "Sy");
+    await user.type(screen.getByRole("combobox"), "Sy");
     await waitFor(() => {
       expect(search).toHaveBeenCalled();
     });
@@ -70,7 +70,7 @@ describe("PostcodeAutocomplete", () => {
         debounceMs={0}
       />,
     );
-    await user.type(screen.getByRole("textbox"), "S");
+    await user.type(screen.getByRole("combobox"), "S");
     // Wait long enough that any debounced call would have fired
     await new Promise((r) => setTimeout(r, 50));
     expect(search).not.toHaveBeenCalled();
@@ -87,7 +87,7 @@ describe("PostcodeAutocomplete", () => {
         debounceMs={0}
       />,
     );
-    await user.type(screen.getByRole("textbox"), "Sy");
+    await user.type(screen.getByRole("combobox"), "Sy");
     const option = await screen.findByRole("option", { name: /Sydney, NSW/ });
     await user.click(option);
     expect(onSelect).toHaveBeenCalledWith(MOCK_HITS[0]);
@@ -106,7 +106,7 @@ describe("PostcodeAutocomplete", () => {
     );
     await user.click(screen.getByLabelText("Clear location"));
     expect(onSelect).toHaveBeenCalledWith(null);
-    expect(screen.getByRole("textbox")).toHaveValue("");
+    expect(screen.getByRole("combobox")).toHaveValue("");
   });
 
   it("Escape closes the dropdown", async () => {
@@ -119,7 +119,7 @@ describe("PostcodeAutocomplete", () => {
         debounceMs={0}
       />,
     );
-    await user.type(screen.getByRole("textbox"), "Sy");
+    await user.type(screen.getByRole("combobox"), "Sy");
     await screen.findByRole("listbox");
     await user.keyboard("{Escape}");
     expect(screen.queryByRole("listbox")).not.toBeInTheDocument();

--- a/__tests__/components/directory/PostcodeAutocomplete.test.tsx
+++ b/__tests__/components/directory/PostcodeAutocomplete.test.tsx
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, userEvent, waitFor } from "../setup";
+import PostcodeAutocomplete, {
+  type PostcodeResult,
+} from "@/components/directory/PostcodeAutocomplete";
+
+const MOCK_HITS: PostcodeResult[] = [
+  { postcode: "2000", locality: "Sydney", state: "NSW", latitude: -33.86, longitude: 151.21 },
+  { postcode: "2010", locality: "Surry Hills", state: "NSW", latitude: -33.88, longitude: 151.21 },
+];
+
+function makeSearch(hits: PostcodeResult[] = MOCK_HITS) {
+  return vi.fn().mockResolvedValue(hits);
+}
+
+describe("PostcodeAutocomplete", () => {
+  it("renders the input with the supplied placeholder + ariaLabel", () => {
+    render(
+      <PostcodeAutocomplete
+        selected={null}
+        onSelect={() => {}}
+        search={makeSearch()}
+        placeholder="Where in Australia?"
+        ariaLabel="Search location"
+      />,
+    );
+    const input = screen.getByLabelText("Search location");
+    expect(input).toHaveAttribute("placeholder", "Where in Australia?");
+  });
+
+  it("hydrates the input from a pre-selected result", () => {
+    render(
+      <PostcodeAutocomplete
+        selected={MOCK_HITS[0]}
+        onSelect={() => {}}
+        search={makeSearch()}
+      />,
+    );
+    expect(screen.getByDisplayValue(/Sydney, NSW/)).toBeInTheDocument();
+  });
+
+  it("fires search and shows results when user types ≥ 2 chars", async () => {
+    const user = userEvent.setup();
+    const search = makeSearch();
+    render(
+      <PostcodeAutocomplete
+        selected={null}
+        onSelect={() => {}}
+        search={search}
+        debounceMs={0}
+      />,
+    );
+    await user.type(screen.getByRole("textbox"), "Sy");
+    await waitFor(() => {
+      expect(search).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(screen.getByRole("option", { name: /Sydney, NSW/ })).toBeInTheDocument();
+    });
+  });
+
+  it("does NOT search for queries shorter than 2 chars", async () => {
+    const user = userEvent.setup();
+    const search = makeSearch();
+    render(
+      <PostcodeAutocomplete
+        selected={null}
+        onSelect={() => {}}
+        search={search}
+        debounceMs={0}
+      />,
+    );
+    await user.type(screen.getByRole("textbox"), "S");
+    // Wait long enough that any debounced call would have fired
+    await new Promise((r) => setTimeout(r, 50));
+    expect(search).not.toHaveBeenCalled();
+  });
+
+  it("selecting an option fires onSelect with the full result + closes the listbox", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(
+      <PostcodeAutocomplete
+        selected={null}
+        onSelect={onSelect}
+        search={makeSearch()}
+        debounceMs={0}
+      />,
+    );
+    await user.type(screen.getByRole("textbox"), "Sy");
+    const option = await screen.findByRole("option", { name: /Sydney, NSW/ });
+    await user.click(option);
+    expect(onSelect).toHaveBeenCalledWith(MOCK_HITS[0]);
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("clear button fires onSelect(null) and empties the input", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(
+      <PostcodeAutocomplete
+        selected={MOCK_HITS[0]}
+        onSelect={onSelect}
+        search={makeSearch()}
+      />,
+    );
+    await user.click(screen.getByLabelText("Clear location"));
+    expect(onSelect).toHaveBeenCalledWith(null);
+    expect(screen.getByRole("textbox")).toHaveValue("");
+  });
+
+  it("Escape closes the dropdown", async () => {
+    const user = userEvent.setup();
+    render(
+      <PostcodeAutocomplete
+        selected={null}
+        onSelect={() => {}}
+        search={makeSearch()}
+        debounceMs={0}
+      />,
+    );
+    await user.type(screen.getByRole("textbox"), "Sy");
+    await screen.findByRole("listbox");
+    await user.keyboard("{Escape}");
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+});

--- a/components/directory/PostcodeAutocomplete.tsx
+++ b/components/directory/PostcodeAutocomplete.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import Icon from "@/components/Icon";
+
+/**
+ * Controlled postcode + suburb autocomplete primitive.
+ *
+ * Renders an <input> with a search icon, a clear-X when populated,
+ * and a results dropdown that opens on focus + character entry.
+ * Closes on outside click and Escape. Selection commits via
+ * `onSelect`; `onSelect(null)` is also sent when the user clears the
+ * input (so consumers can drop any derived geo state).
+ *
+ * The search function is a prop so this works for both
+ * /api/advisor-search/postcodes (current) and
+ * /api/invest-search/postcodes (future Phase 4) without coupling.
+ *
+ * Debounce
+ * --------
+ * Keystrokes are debounced by `debounceMs` (default 200ms). The
+ * existing /advisors LocationSearch used 250ms — close enough to
+ * not be a behavioural regression when /advisors migrates.
+ *
+ * Generic result shape
+ * --------------------
+ * Result objects need at minimum `{ postcode, locality, state }`
+ * for the visible label. Additional fields (lat/lng, etc.) flow
+ * through `onSelect` to the consumer untouched.
+ */
+export interface PostcodeResult {
+  postcode: string;
+  locality: string;
+  state: string;
+  latitude: number;
+  longitude: number;
+}
+
+export interface PostcodeAutocompleteProps {
+  selected: PostcodeResult | null;
+  onSelect: (next: PostcodeResult | null) => void;
+  /**
+   * Fetches up to ~5 candidate results for the supplied query.
+   * Must handle its own debounce / cancellation if expensive —
+   * this primitive's debounce is just a keystroke smoother.
+   */
+  search: (query: string, signal: AbortSignal) => Promise<PostcodeResult[]>;
+  placeholder?: string;
+  ariaLabel?: string;
+  debounceMs?: number;
+  className?: string;
+}
+
+export default function PostcodeAutocomplete({
+  selected,
+  onSelect,
+  search,
+  placeholder = "Postcode or suburb...",
+  ariaLabel = "Search postcode or suburb",
+  debounceMs = 200,
+  className = "",
+}: PostcodeAutocompleteProps) {
+  const [query, setQuery] = useState(
+    selected ? `${selected.locality}, ${selected.state}` : "",
+  );
+  const [results, setResults] = useState<PostcodeResult[]>([]);
+  const [open, setOpen] = useState(false);
+  const timeout = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const wrapRef = useRef<HTMLDivElement>(null);
+
+  // Click outside to close
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, []);
+
+  // Cleanup any pending debounce on unmount
+  useEffect(() => () => {
+    if (timeout.current) clearTimeout(timeout.current);
+  }, []);
+
+  const onChange = (next: string) => {
+    setQuery(next);
+    if (timeout.current) clearTimeout(timeout.current);
+    if (next.trim().length < 2) {
+      setResults([]);
+      setOpen(false);
+      return;
+    }
+    const controller = new AbortController();
+    timeout.current = setTimeout(async () => {
+      try {
+        const hits = await search(next.trim(), controller.signal);
+        setResults(hits);
+        setOpen(hits.length > 0);
+      } catch {
+        /* user kept typing or unmount — drop silently */
+      }
+    }, debounceMs);
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Escape") {
+      setOpen(false);
+    }
+  };
+
+  const choose = (r: PostcodeResult) => {
+    setQuery(`${r.locality}, ${r.state} ${r.postcode}`);
+    setResults([]);
+    setOpen(false);
+    onSelect(r);
+  };
+
+  const clear = () => {
+    setQuery("");
+    setResults([]);
+    setOpen(false);
+    onSelect(null);
+  };
+
+  return (
+    <div ref={wrapRef} className={`relative ${className}`}>
+      <Icon
+        name="map-pin"
+        size={14}
+        className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 pointer-events-none"
+        aria-hidden
+      />
+      <input
+        type="text"
+        role="combobox"
+        value={query}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={onKeyDown}
+        onFocus={() => results.length > 0 && setOpen(true)}
+        placeholder={placeholder}
+        aria-label={ariaLabel}
+        aria-autocomplete="list"
+        aria-expanded={open}
+        aria-controls="postcode-autocomplete-listbox"
+        className="w-full pl-9 pr-9 py-2 text-sm border border-slate-200 rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-amber-400 focus:border-amber-400"
+      />
+      {query && (
+        <button
+          type="button"
+          onClick={clear}
+          aria-label="Clear location"
+          className="absolute right-2.5 top-1/2 -translate-y-1/2 w-5 h-5 rounded-full bg-slate-100 hover:bg-slate-200 text-slate-500 flex items-center justify-center text-[11px] font-bold"
+        >
+          ×
+        </button>
+      )}
+      {open && results.length > 0 && (
+        <ul
+          id="postcode-autocomplete-listbox"
+          role="listbox"
+          aria-label="Location suggestions"
+          className="absolute z-20 mt-1 w-full bg-white border border-slate-200 rounded-lg shadow-lg max-h-64 overflow-y-auto"
+        >
+          {results.map((r) => (
+            <li key={`${r.postcode}-${r.locality}-${r.state}`}>
+              <button
+                type="button"
+                role="option"
+                aria-selected={
+                  selected?.postcode === r.postcode &&
+                  selected?.locality === r.locality
+                }
+                onClick={() => choose(r)}
+                className="w-full text-left px-3 py-2 text-sm hover:bg-amber-50 transition-colors flex items-center justify-between gap-2"
+              >
+                <span className="truncate">
+                  {r.locality}, {r.state}
+                </span>
+                <span className="text-xs text-slate-500 tabular-nums shrink-0">
+                  {r.postcode}
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Last major plan-mentioned primitive: `<PostcodeAutocomplete>`. Controlled postcode + suburb input with debounced autocomplete dropdown, ARIA combobox semantics, click-outside-to-close, Escape-to-close, clear-X.

```tsx
<PostcodeAutocomplete
  selected={locationSearch}
  onSelect={(p) => {
    setLocationSearch(p);
    if (!p) { setUserLat(null); setUserLng(null); }
  }}
  search={async (q, signal) => {
    const res = await fetch(`/api/advisor-search/postcodes?q=${q}`, { signal });
    return res.ok ? (await res.json()).results : [];
  }}
/>
```

## Why this is generic

The fetch function is a prop so this works for both `/api/advisor-search/postcodes` (current /advisors consumer) and `/api/invest-search/postcodes` (future Phase 4 map view) without coupling.

## Behaviour

- Debounced keystrokes (default 200ms, configurable)
- Skip search for queries < 2 chars (matches existing AdvisorsClient.LocationSearch contract)
- Click outside closes the dropdown
- Escape closes
- Clear-X fires `onSelect(null)` so consumers drop derived geo state

## Accessibility

- `role="combobox"` + `aria-autocomplete="list"` + `aria-expanded` + `aria-controls` on the input
- `role="listbox"` with `id` + `aria-label` on the dropdown
- Each option is a `<button>` with `role="option"` + `aria-selected`

## Test plan

- [x] 7 unit tests pass — search trigger threshold, debounce, selection commit, clear, Escape close
- [x] `npx eslint --max-warnings 0` clean (including jsx-a11y rules)
- [x] Pre-push hook passes
- [ ] CI green

## Follow-up

Consumer migration for `AdvisorsClient.LocationSearch` — same endpoint signature so the swap is mechanical.

https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk)_