### PR TITLE
fix(ci): bump Playwright webServer timeout 120s → 180s to clear a11y flake

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -99,7 +99,14 @@ export default defineConfig({
             command: "npm run start",
             url: "http://localhost:3000",
             reuseExistingServer: false,
-            timeout: 120_000,
+            // 120s was timing out the Accessibility (axe-core) job
+            // on flaky runs ("Timed out waiting 120000ms from
+            // config.webServer"). The same .next artifact + npm
+            // run start works for E2E in the same workflow, but
+            // a11y races against runner cold-start more often.
+            // 180s gives a safer buffer; a real server crash will
+            // still surface within 3min.
+            timeout: 180_000,
           }
         : undefined,
 });


### PR DESCRIPTION
## Summary

The `Accessibility (axe-core)` CI gate has been failing on multiple PRs (#948, #952 pre-merge, #953, #957, #960, …) with the same error verbatim:

> Timed out waiting 120000ms from config.webServer

This is the Playwright runner waiting for `npm run start` to respond on `http://localhost:3000`. **It is not an a11y violation** — the test never gets to execute. Misdiagnosed earlier as a true a11y failure on #953; the actual cause was infrastructure timing.

## Why this is timing out

The same `.next` artifact + start command works fine for the End-to-end (Playwright) job in the same workflow. The a11y job races against runner cold-start more often (smaller chromium-only Playwright init means the server start is the rate-limit step).

## Fix

Bump `webServer.timeout` in `playwright.config.ts` from 120 000 ms to 180 000 ms. Three minutes is enough buffer for cold runner starts; a real server crash still surfaces within that window.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint --max-warnings 0` clean
- [x] Pre-push hook passes
- [ ] After merge: re-run a11y on a few of the failing PRs to confirm the gate clears

## Independent

One-line config change. No conflict with any in-flight PR.

https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk)_