### PR TITLE
docs(claude.md): document directory primitives + banner tokens

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,10 @@ npm run test:watch                 # watch mode
 | Schema.org JSON-LD builders                  | `lib/schema-markup.ts`                                    |
 | Structured logging                           | `lib/logger.ts` (never `console.*`)                       |
 | DB-backed rate limiting                      | `lib/rate-limit.ts`                                       |
+| Directory-page primitives (search, sort, tabs, filter panel, facet group, range slider, compare bar, empty state, filter chips, postcode autocomplete, result count, banner stack) | `components/directory/*` (see `docs/plans/DIRECTORY_UX_UNIFICATION.md`) |
+| Country-aware banner stack (pill + rule alerts + recommendation) | `<DirectoryBanners surface="invest \| advisors \| compare" />` from `components/foreign-investment/DirectoryBanners.tsx` |
+| Country-recommendation copy lookup           | `lib/page-recommendations.ts` (add a row here, don't edit the recommendation component) |
+| Banner visual tokens (colours / radius / spacing) | `components/foreign-investment/banner-tokens.ts`     |
 
 Reaching for a hardcoded disclaimer, a new affiliate URL builder, or a fresh JSON-LD object usually means you missed an existing helper — search `lib/` first.
 


### PR DESCRIPTION
## Summary

Documentation-only: add the new directory primitives + banner system to the "Single sources of truth — don't duplicate" table in `CLAUDE.md` so future agents and contributors find the existing components instead of hand-rolling fresh implementations.

Four new table rows:

| Concern | Module |
|---------|--------|
| Directory-page primitives | `components/directory/*` |
| Country-aware banner stack | `<DirectoryBanners />` |
| Country-recommendation copy lookup | `lib/page-recommendations.ts` |
| Banner visual tokens | `components/foreign-investment/banner-tokens.ts` |

Cross-references `docs/plans/DIRECTORY_UX_UNIFICATION.md` as the canonical spec.

## Independent

Pure documentation change, no code change, no conflicts with any in-flight PR.

https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk)_