### PR TITLE
test(cookie-banner): add coverage for getCookiePreferences() — privacy state read path

### DIFF
--- a/__tests__/components/CookieBanner.test.tsx
+++ b/__tests__/components/CookieBanner.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { getCookiePreferences } from "@/components/CookieBanner";
+
+/**
+ * getCookiePreferences() is the read path the rest of the app uses
+ * to decide whether to load analytics scripts and affiliate redirect
+ * cookies. The behaviour matters:
+ *
+ *   1. Default to deny-by-default (essential only) when nothing is
+ *      stored — privacy-first default.
+ *   2. Honour the modern `cookie-preferences` JSON blob when present.
+ *   3. Fall back to the legacy `cookie-consent: accepted|declined`
+ *      flag for users who set their preferences before the granular
+ *      UI shipped.
+ *   4. Survive corrupt localStorage without throwing.
+ */
+describe("getCookiePreferences", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("returns deny-by-default when localStorage is empty", () => {
+    expect(getCookiePreferences()).toEqual({
+      essential: true,
+      analytics: false,
+      affiliate: false,
+    });
+  });
+
+  it("parses the modern cookie-preferences JSON blob", () => {
+    localStorage.setItem(
+      "cookie-preferences",
+      JSON.stringify({ essential: true, analytics: true, affiliate: false }),
+    );
+    expect(getCookiePreferences()).toEqual({
+      essential: true,
+      analytics: true,
+      affiliate: false,
+    });
+  });
+
+  it("falls back to legacy 'accepted' = all on, when only the legacy flag exists", () => {
+    localStorage.setItem("cookie-consent", "accepted");
+    expect(getCookiePreferences()).toEqual({
+      essential: true,
+      analytics: true,
+      affiliate: true,
+    });
+  });
+
+  it("falls back to legacy 'declined' = deny-by-default, when only the legacy flag exists", () => {
+    localStorage.setItem("cookie-consent", "declined");
+    expect(getCookiePreferences()).toEqual({
+      essential: true,
+      analytics: false,
+      affiliate: false,
+    });
+  });
+
+  it("prefers the modern blob over the legacy flag when both are present", () => {
+    localStorage.setItem("cookie-consent", "accepted");
+    localStorage.setItem(
+      "cookie-preferences",
+      JSON.stringify({ essential: true, analytics: false, affiliate: true }),
+    );
+    expect(getCookiePreferences()).toEqual({
+      essential: true,
+      analytics: false,
+      affiliate: true,
+    });
+  });
+
+  it("returns the deny-by-default state when the stored blob is corrupt JSON", () => {
+    localStorage.setItem("cookie-preferences", "{not-json");
+    expect(getCookiePreferences()).toEqual({
+      essential: true,
+      analytics: false,
+      affiliate: false,
+    });
+  });
+
+  it("returns the deny-by-default state when localStorage throws (Safari private mode etc)", () => {
+    const original = Storage.prototype.getItem;
+    Storage.prototype.getItem = () => {
+      throw new Error("simulated SecurityError");
+    };
+    try {
+      expect(getCookiePreferences()).toEqual({
+        essential: true,
+        analytics: false,
+        affiliate: false,
+      });
+    } finally {
+      Storage.prototype.getItem = original;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`CookieBanner.tsx` exports `getCookiePreferences()` as the source-of-truth utility the rest of the app uses to decide whether to load analytics scripts and affiliate redirect cookies. **The function was untested** despite being privacy-critical — a regression silently flips analytics/affiliate consent for every user.

## 7 tests added

- Deny-by-default when localStorage is empty (privacy-first default)
- Parses the modern `cookie-preferences` JSON blob
- Falls back to legacy `cookie-consent: accepted` → all-on
- Falls back to legacy `cookie-consent: declined` → deny default
- Prefers modern blob over legacy flag when both present
- Returns deny default on corrupt JSON
- Returns deny default when `localStorage.getItem` throws (Safari private mode etc)

## What's intentionally NOT tested

The component itself (visibility + animation + 1s setTimeout-driven mount delay) is not tested here. That setTimeout makes component tests flaky in CI. Coverage of the pure read path closes the highest-value gap.

## Independent

No component change. No conflicts with any in-flight PR.

https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk)_