### PR TITLE
test(loading + social-proof): coverage for 3 more untested chrome components

### DIFF
--- a/__tests__/components/SocialProofBar.test.tsx
+++ b/__tests__/components/SocialProofBar.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "./setup";
+import SocialProofBar from "@/components/SocialProofBar";
+
+describe("SocialProofBar", () => {
+  it("exposes the trust-signals region via role=status + aria-label", () => {
+    render(<SocialProofBar />);
+    expect(
+      screen.getByRole("status", { name: "Trust signals" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders all three trust claims", () => {
+    render(<SocialProofBar />);
+    expect(screen.getByText(/70\+ ASIC-regulated platforms/)).toBeInTheDocument();
+    expect(screen.getByText(/Independent ratings/)).toBeInTheDocument();
+    expect(screen.getByText(/Fees verified daily/)).toBeInTheDocument();
+  });
+
+  it("renders the 'no pay-to-play' phrasing as part of the independent-ratings line", () => {
+    render(<SocialProofBar />);
+    expect(
+      screen.getByText(/Independent ratings — no pay-to-play/),
+    ).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/loading-skeletons.test.tsx
+++ b/__tests__/components/loading-skeletons.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * Loading-skeleton presentation tests — both the generic
+ * RouteLoadingSkeleton and the more specific ComparisonTableSkeleton
+ * render under route-segment loading boundaries on hundreds of pages.
+ * Coverage here pins the contracts that matter:
+ *
+ *  - role + aria-busy + aria-live on the live region so screen readers
+ *    announce the busy state without reading every pulsing rectangle
+ *  - bar counts on the table skeleton (5 column heads, 4 row stubs)
+ *    so a future "tidy this up" change can't silently drop rows or
+ *    flip column count
+ */
+import { describe, it, expect } from "vitest";
+import { render } from "./setup";
+import RouteLoadingSkeleton from "@/components/RouteLoadingSkeleton";
+import ComparisonTableSkeleton from "@/components/ComparisonTableSkeleton";
+
+describe("RouteLoadingSkeleton", () => {
+  it("exposes the live region with aria-live=polite and aria-busy=true", () => {
+    const { container } = render(<RouteLoadingSkeleton />);
+    const region = container.querySelector("[aria-live]");
+    expect(region).not.toBeNull();
+    expect(region).toHaveAttribute("aria-live", "polite");
+    expect(region).toHaveAttribute("aria-busy", "true");
+  });
+
+  it("renders 6 pulsing placeholder bars", () => {
+    const { container } = render(<RouteLoadingSkeleton />);
+    expect(container.querySelectorAll(".animate-pulse")).toHaveLength(6);
+  });
+});
+
+describe("ComparisonTableSkeleton", () => {
+  it("renders a heading bar + 5 column-head bars + 4 row stubs", () => {
+    const { container } = render(<ComparisonTableSkeleton />);
+    // 5 column-head bars in the header row
+    const header = container.querySelector(".bg-slate-50");
+    expect(header).not.toBeNull();
+    expect(header!.querySelectorAll(".bg-slate-200")).toHaveLength(5);
+    // 4 row stubs
+    expect(container.querySelectorAll(".border-t")).toHaveLength(4);
+  });
+
+  it("uses the animate-pulse class on the wrapper", () => {
+    const { container } = render(<ComparisonTableSkeleton />);
+    expect(container.firstElementChild).toHaveClass("animate-pulse");
+  });
+});


### PR DESCRIPTION
## Summary

Three more presentation components had no test coverage. All three are mounted on hundreds of pages, so a regression flips an SR contract or silently drops trust claims across the site.

| Component | What's pinned |
|-----------|---------------|
| `RouteLoadingSkeleton` | `aria-live="polite"` + `aria-busy="true"` on live region, 6 pulse bars |
| `ComparisonTableSkeleton` | 5 column-head bars + 4 row stubs + outer `animate-pulse` |
| `SocialProofBar` | `role="status"` + `aria-label="Trust signals"` + 3 trust-claim strings |

7 unit tests across 2 files. No component changes.

## Independent

No conflicts with any in-flight PR. Pure test additions.

https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk)_