### PR TITLE
test(sponsor + disclosure): coverage for compliance-critical components

### DIFF
--- a/__tests__/components/CompactDisclosure.test.tsx
+++ b/__tests__/components/CompactDisclosure.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, userEvent } from "./setup";
+import CompactDisclosure from "@/components/CompactDisclosure";
+
+/**
+ * CompactDisclosure renders the full compliance copy chain
+ * (General Advice / Affiliate / Crypto / Regulatory / AFSL) as a
+ * sequence of disclosable sections. The contract that matters is:
+ *
+ *   - All 5 headings render
+ *   - Only ONE section opens at a time
+ *   - Re-clicking the open section closes it
+ *   - aria-expanded reflects the open state
+ */
+describe("CompactDisclosure", () => {
+  it("renders all 5 section headings", () => {
+    render(<CompactDisclosure />);
+    expect(
+      screen.getByRole("button", { name: /General Advice Warning/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Affiliate Disclosure/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Crypto Warning/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Regulatory Note/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /AFSL Status/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("starts with every section closed (no body paragraphs rendered)", () => {
+    const { container } = render(<CompactDisclosure />);
+    expect(container.querySelectorAll("p")).toHaveLength(0);
+  });
+
+  it("expands a section when its header is clicked", async () => {
+    const user = userEvent.setup();
+    render(<CompactDisclosure />);
+    const header = screen.getByRole("button", { name: /General Advice Warning/ });
+    expect(header).toHaveAttribute("aria-expanded", "false");
+    await user.click(header);
+    expect(header).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("collapses an open section when its header is clicked again", async () => {
+    const user = userEvent.setup();
+    render(<CompactDisclosure />);
+    const header = screen.getByRole("button", { name: /Affiliate Disclosure/ });
+    await user.click(header);
+    expect(header).toHaveAttribute("aria-expanded", "true");
+    await user.click(header);
+    expect(header).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("only allows one section open at a time", async () => {
+    const user = userEvent.setup();
+    render(<CompactDisclosure />);
+    const first = screen.getByRole("button", { name: /General Advice Warning/ });
+    const second = screen.getByRole("button", { name: /Affiliate Disclosure/ });
+    await user.click(first);
+    expect(first).toHaveAttribute("aria-expanded", "true");
+    await user.click(second);
+    expect(first).toHaveAttribute("aria-expanded", "false");
+    expect(second).toHaveAttribute("aria-expanded", "true");
+  });
+});

--- a/__tests__/components/SponsorBadge.test.tsx
+++ b/__tests__/components/SponsorBadge.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "./setup";
+import SponsorBadge from "@/components/SponsorBadge";
+import type { Broker } from "@/lib/types";
+
+/**
+ * Sponsor disclosure pin — the visible "Sponsored / Promoted"
+ * surface on every broker card. Regressions here = ASIC compliance
+ * exposure (the disclosure suffix has to render alongside the tier
+ * label).
+ */
+
+function makeBroker(tier: Broker["sponsorship_tier"]): Broker {
+  // Cast to Broker — we only exercise the sponsorship_tier branch
+  // in this file. Rest of Broker isn't read by SponsorBadge.
+  return { sponsorship_tier: tier } as unknown as Broker;
+}
+
+describe("SponsorBadge", () => {
+  it("renders nothing when sponsorship_tier is null/undefined", () => {
+    const { container: nullC } = render(
+      <SponsorBadge broker={makeBroker(null)} />,
+    );
+    expect(nullC).toBeEmptyDOMElement();
+    const { container: undefC } = render(
+      <SponsorBadge broker={makeBroker(undefined)} />,
+    );
+    expect(undefC).toBeEmptyDOMElement();
+  });
+
+  it("renders Featured Partner + Sponsored disclosure for featured_partner tier", () => {
+    render(<SponsorBadge broker={makeBroker("featured_partner")} />);
+    expect(screen.getByText("Featured Partner")).toBeInTheDocument();
+    expect(screen.getByText(/Sponsored/)).toBeInTheDocument();
+  });
+
+  it("renders Editor's Pick + Promoted disclosure for editors_pick tier", () => {
+    render(<SponsorBadge broker={makeBroker("editors_pick")} />);
+    expect(screen.getByText(/Editor.s Pick/)).toBeInTheDocument();
+    expect(screen.getByText(/Promoted/)).toBeInTheDocument();
+  });
+
+  it("renders Deal of the Month + Sponsored disclosure for deal_of_month tier", () => {
+    render(<SponsorBadge broker={makeBroker("deal_of_month")} />);
+    expect(screen.getByText("Deal of the Month")).toBeInTheDocument();
+    expect(screen.getByText(/Sponsored/)).toBeInTheDocument();
+  });
+
+  it("renders nothing for an unknown tier (defensive — TS would reject this at compile time)", () => {
+    const { container } = render(
+      <SponsorBadge
+        broker={
+          { sponsorship_tier: "made_up_tier" } as unknown as Broker
+        }
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("always renders the disclosure suffix alongside the label (ASIC compliance contract)", () => {
+    // Every tier must surface a "Sponsored" or "Promoted" disclosure
+    // immediately next to its label. Regressing this is a compliance
+    // exposure — the user has to know the placement is paid.
+    for (const tier of ["featured_partner", "editors_pick", "deal_of_month"] as const) {
+      const { container } = render(<SponsorBadge broker={makeBroker(tier)} />);
+      const text = container.textContent ?? "";
+      expect(text).toMatch(/Sponsored|Promoted/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Two compliance-critical components had no test coverage.

**SponsorBadge** (6 tests) — the visible "Sponsored / Promoted" pin on every broker card. ASIC compliance contract: every paid placement must render the disclosure suffix alongside the tier label.
- 3 tier variants (featured_partner / editors_pick / deal_of_month) each render the right label + disclosure
- Null/undefined sponsorship_tier → renders nothing
- Unknown tier → renders nothing (defensive)
- Compliance contract test: every tier surfaces `Sponsored|Promoted`

**CompactDisclosure** (5 tests) — accordion for the full compliance copy chain (General Advice / Affiliate / Crypto / Regulatory / AFSL).
- All 5 sections render
- Starts fully collapsed
- Click toggles `aria-expanded`
- Click open section → collapses
- Only one section open at a time

11 tests across 2 files. No component changes.

## Independent

No conflicts with any in-flight PR.

https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk)_