### PR TITLE
test(promo-badge): coverage for broker-deal pill + expiry formatting

### DIFF
--- a/__tests__/components/PromoBadge.test.tsx
+++ b/__tests__/components/PromoBadge.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "./setup";
+import PromoBadge from "@/components/PromoBadge";
+import type { Broker } from "@/lib/types";
+
+/**
+ * PromoBadge surfaces a "Promo" pill on every broker card that has an
+ * active deal, with hover-revealed tooltip carrying the deal_text +
+ * formatted expiry. The pill is invisible (renders nothing) when the
+ * broker doesn't have a deal — a regression here either hides every
+ * promo or surfaces a tooltip without the offer text.
+ */
+function makeBroker(over: Partial<Broker>): Broker {
+  return {
+    deal: false,
+    deal_text: undefined,
+    deal_expiry: undefined,
+    ...over,
+  } as unknown as Broker;
+}
+
+describe("PromoBadge", () => {
+  it("renders nothing when broker.deal is false", () => {
+    const { container } = render(
+      <PromoBadge
+        broker={makeBroker({ deal: false, deal_text: "Some offer" })}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when broker.deal_text is empty/null", () => {
+    const { container } = render(
+      <PromoBadge broker={makeBroker({ deal: true, deal_text: undefined })} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders the Promo pill when deal + deal_text are present", () => {
+    render(
+      <PromoBadge
+        broker={makeBroker({
+          deal: true,
+          deal_text: "Get $200 off first year",
+        })}
+      />,
+    );
+    expect(screen.getByText("Promo")).toBeInTheDocument();
+    expect(screen.getByText("Get $200 off first year")).toBeInTheDocument();
+  });
+
+  it("renders the formatted expiry when deal_expiry is supplied", () => {
+    // 15 June 2026 UTC — formatted as "15 Jun" in en-AU short style.
+    render(
+      <PromoBadge
+        broker={makeBroker({
+          deal: true,
+          deal_text: "Offer",
+          deal_expiry: "2026-06-15T00:00:00.000Z",
+        })}
+      />,
+    );
+    expect(screen.getByText(/Expires/)).toBeInTheDocument();
+    expect(screen.getByText(/15 Jun/)).toBeInTheDocument();
+  });
+
+  it("omits the Expires line when deal_expiry is null", () => {
+    render(
+      <PromoBadge
+        broker={makeBroker({
+          deal: true,
+          deal_text: "Offer",
+          deal_expiry: undefined,
+        })}
+      />,
+    );
+    expect(screen.queryByText(/Expires/)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

`PromoBadge` surfaces a "Promo" pill with hover tooltip on every broker card that has an active deal. Critical surface for marketing attribution + ASIC offer-disclosure. The pill renders nothing when the broker doesn't have a deal — a regression here either hides every promo or surfaces a tooltip without offer text.

The component was untested.

## 5 tests

- `deal=false` → renders nothing
- `deal=true` but `deal_text` missing → renders nothing
- Both present → renders "Promo" pill + tooltip carrying `deal_text`
- `deal_expiry` formatted via `toLocaleDateString("en-AU", short)` → "Expires 15 Jun"
- No `deal_expiry` → no "Expires" line

No component change.

## Independent

No conflicts with any in-flight PR.

https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk)_