### PR TITLE
test(verified-client + fees-freshness): coverage for review + freshness badges

### DIFF
--- a/__tests__/components/FeesFreshnessIndicator.test.tsx
+++ b/__tests__/components/FeesFreshnessIndicator.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "./setup";
+import { FeesFreshnessIndicator } from "@/components/FeesFreshnessIndicator";
+
+describe("FeesFreshnessIndicator", () => {
+  it("renders nothing when lastChecked is null", () => {
+    const { container } = render(<FeesFreshnessIndicator lastChecked={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders 'N min ago' label for recent times", () => {
+    const fiveMinAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+    render(<FeesFreshnessIndicator lastChecked={fiveMinAgo} />);
+    expect(screen.getByText(/Fees checked 5 min ago/)).toBeInTheDocument();
+  });
+
+  it("renders 'N hours ago' for sub-day times", () => {
+    const threeHoursAgo = new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString();
+    render(<FeesFreshnessIndicator lastChecked={threeHoursAgo} />);
+    expect(screen.getByText(/Fees checked 3 hours ago/)).toBeInTheDocument();
+  });
+
+  it("renders 'yesterday' for exactly 1 day", () => {
+    const oneDayAgo = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString();
+    render(<FeesFreshnessIndicator lastChecked={oneDayAgo} />);
+    expect(screen.getByText(/Fees checked yesterday/)).toBeInTheDocument();
+  });
+
+  it("renders 'N days ago' for 2+ days", () => {
+    const fiveDaysAgo = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString();
+    render(<FeesFreshnessIndicator lastChecked={fiveDaysAgo} />);
+    expect(screen.getByText(/Fees checked 5 days ago/)).toBeInTheDocument();
+  });
+
+  it("uses emerald dot for <24h", () => {
+    const recent = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+    const { container } = render(<FeesFreshnessIndicator lastChecked={recent} />);
+    expect(container.querySelector(".bg-emerald-500")).not.toBeNull();
+  });
+
+  it("uses amber dot for 24h–72h", () => {
+    const thirtyHoursAgo = new Date(Date.now() - 30 * 60 * 60 * 1000).toISOString();
+    const { container } = render(<FeesFreshnessIndicator lastChecked={thirtyHoursAgo} />);
+    expect(container.querySelector(".bg-amber-500")).not.toBeNull();
+  });
+
+  it("uses red dot for 72h+ (stale)", () => {
+    const fourDaysAgo = new Date(Date.now() - 4 * 24 * 60 * 60 * 1000).toISOString();
+    const { container } = render(<FeesFreshnessIndicator lastChecked={fourDaysAgo} />);
+    expect(container.querySelector(".bg-red-500")).not.toBeNull();
+  });
+
+  it("renders inline variant without the pill background", () => {
+    const recent = new Date().toISOString();
+    const { container } = render(
+      <FeesFreshnessIndicator lastChecked={recent} variant="inline" />,
+    );
+    // The badge variant wraps in a rounded-full pill with border; inline doesn't.
+    expect(container.querySelector(".rounded-full.border")).toBeNull();
+  });
+});

--- a/__tests__/components/VerifiedClientBadge.test.tsx
+++ b/__tests__/components/VerifiedClientBadge.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "./setup";
+import VerifiedClientBadge from "@/components/VerifiedClientBadge";
+
+describe("VerifiedClientBadge", () => {
+  it("renders nothing when isVerified is false", () => {
+    const { container } = render(<VerifiedClientBadge isVerified={false} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders the Verified Client badge when isVerified=true", () => {
+    render(<VerifiedClientBadge isVerified />);
+    expect(screen.getByText("Verified Client")).toBeInTheDocument();
+  });
+
+  it("uses base aria-label when verifiedVia is omitted", () => {
+    render(<VerifiedClientBadge isVerified />);
+    expect(screen.getByLabelText("Verified Client")).toBeInTheDocument();
+  });
+
+  it("appends the verifiedVia source to the aria-label, with underscores → spaces", () => {
+    render(
+      <VerifiedClientBadge isVerified verifiedVia="advisor_enquiry" />,
+    );
+    expect(
+      screen.getByLabelText("Verified Client (advisor enquiry)"),
+    ).toBeInTheDocument();
+  });
+
+  it("attaches the tooltip text via title attribute for hover discovery", () => {
+    render(<VerifiedClientBadge isVerified />);
+    const badge = screen.getByText("Verified Client").closest("span");
+    expect(badge?.getAttribute("title")).toContain(
+      "This reviewer used an enquiry",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Two more untested badge components that feed user-facing trust + freshness signals on broker/advisor cards.

**VerifiedClientBadge** (5 tests)
- `isVerified=false` → renders nothing
- `isVerified=true` → "Verified Client" pill
- aria-label with and without `verifiedVia` source
- Tooltip text via `title` attribute

**FeesFreshnessIndicator** (9 tests)
- `lastChecked=null` → renders nothing
- "N min ago" / "N hours ago" / "yesterday" / "N days ago" labels
- Colour transitions: emerald (<24h), amber (24-72h), red (72h+)
- Inline variant has no pill chrome

14 tests across 2 files. No component changes.

## Independent

No conflicts with any in-flight PR.

https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk)_