### PR TITLE
test(non-resident-banner): coverage for foreign-investor diversion banner

### DIFF
--- a/__tests__/components/NonResidentFilterBanner.test.tsx
+++ b/__tests__/components/NonResidentFilterBanner.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, userEvent } from "./setup";
+import NonResidentFilterBanner from "@/components/NonResidentFilterBanner";
+
+describe("NonResidentFilterBanner", () => {
+  it("renders nothing when nonResidentCount is 0", () => {
+    const { container } = render(
+      <NonResidentFilterBanner total={50} nonResidentCount={0} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders headline with count comparison when data is present", () => {
+    render(<NonResidentFilterBanner total={50} nonResidentCount={12} />);
+    expect(
+      screen.getByText(/12 of 50 platforms accept non-residents/),
+    ).toBeInTheDocument();
+  });
+
+  it("links to /foreign-investment/shares for the default 'shares' vertical", () => {
+    render(<NonResidentFilterBanner total={50} nonResidentCount={12} />);
+    expect(
+      screen.getByRole("link", { name: /non-resident friendly platforms/ }),
+    ).toHaveAttribute("href", "/foreign-investment/shares");
+  });
+
+  it("links to /foreign-investment/crypto when vertical='crypto'", () => {
+    render(
+      <NonResidentFilterBanner
+        total={50}
+        nonResidentCount={12}
+        vertical="crypto"
+      />,
+    );
+    expect(
+      screen.getByRole("link", { name: /non-resident friendly platforms/ }),
+    ).toHaveAttribute("href", "/foreign-investment/crypto");
+  });
+
+  it("links to /foreign-investment/savings when vertical='savings'", () => {
+    render(
+      <NonResidentFilterBanner
+        total={50}
+        nonResidentCount={12}
+        vertical="savings"
+      />,
+    );
+    expect(
+      screen.getByRole("link", { name: /non-resident friendly platforms/ }),
+    ).toHaveAttribute("href", "/foreign-investment/savings");
+  });
+
+  it("aliases 'cfd' vertical to /foreign-investment/shares (no dedicated CFD guide yet)", () => {
+    render(
+      <NonResidentFilterBanner
+        total={50}
+        nonResidentCount={12}
+        vertical="cfd"
+      />,
+    );
+    expect(
+      screen.getByRole("link", { name: /non-resident friendly platforms/ }),
+    ).toHaveAttribute("href", "/foreign-investment/shares");
+  });
+
+  it("dismiss button removes the banner from the DOM", async () => {
+    const user = userEvent.setup();
+    render(<NonResidentFilterBanner total={50} nonResidentCount={12} />);
+    expect(screen.getByText(/non-residents/)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Dismiss" }));
+    expect(screen.queryByText(/non-residents/)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

`NonResidentFilterBanner` appears on `compare/*` pages, telling overseas visitors how many of the listed brokers accept non-residents and CTA-ing into the foreign-investment vertical guide. Critical conversion surface for the international funnel — the component was untested.

## 7 tests

- `nonResidentCount=0` → renders nothing
- Headline shows "N of M platforms accept non-residents"
- Default `vertical="shares"` → `/foreign-investment/shares`
- `vertical="crypto"` → `/foreign-investment/crypto`
- `vertical="savings"` → `/foreign-investment/savings`
- `vertical="cfd"` → aliases to `/shares` (no dedicated CFD guide yet)
- Dismiss × button removes the banner from the DOM

No component change.

## Independent

No conflicts with any in-flight PR.

https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk)_