### PR TITLE
test(market-ticker): coverage for scrolling ticker + compliance footnote

### DIFF
--- a/__tests__/components/MarketTicker.test.tsx
+++ b/__tests__/components/MarketTicker.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "./setup";
+import MarketTicker from "@/components/MarketTicker";
+
+/**
+ * MarketTicker renders 6 hardcoded market tickers (ASX 200, BTC/AUD,
+ * AUD/USD, ETH/AUD, Gold/AUD, S&P 500), duplicated for seamless
+ * marquee scroll. The hardcoded values are placeholders (intentionally
+ * "Indicative only. Not financial advice." per the compliance
+ * footnote) but the structure + compliance label need to render
+ * predictably.
+ */
+describe("MarketTicker", () => {
+  it("exposes the ticker as a keyboard-focusable region with aria-label", () => {
+    render(<MarketTicker />);
+    const region = screen.getByLabelText(/Market ticker/);
+    expect(region).toBeInTheDocument();
+    expect(region).toHaveAttribute("tabIndex", "0");
+  });
+
+  it("renders the compliance footnote 'Indicative only. Not financial advice.'", () => {
+    render(<MarketTicker />);
+    expect(
+      screen.getByText("Indicative only. Not financial advice."),
+    ).toBeInTheDocument();
+  });
+
+  it("includes all 6 ticker labels (each appearing twice — duplicated for marquee loop)", () => {
+    render(<MarketTicker />);
+    for (const label of [
+      "ASX 200",
+      "BTC/AUD",
+      "AUD/USD",
+      "ETH/AUD",
+      "Gold/AUD",
+      "S&P 500",
+    ]) {
+      // Each appears twice (duplicated for seamless loop) — at least one match.
+      expect(screen.getAllByText(label).length).toBeGreaterThanOrEqual(2);
+    }
+  });
+
+  it("uses amber accent for up trends and red for down trends", () => {
+    const { container } = render(<MarketTicker />);
+    // Up tickers have text-amber-400; down tickers have text-red-400.
+    expect(container.querySelectorAll(".text-amber-400").length).toBeGreaterThan(0);
+    expect(container.querySelectorAll(".text-red-400").length).toBeGreaterThan(0);
+  });
+
+  it("respects prefers-reduced-motion via motion-reduce class", () => {
+    const { container } = render(<MarketTicker />);
+    expect(container.querySelector(".motion-reduce\\:animate-none")).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

`MarketTicker` renders 6 hardcoded market tickers (ASX 200, BTC/AUD, AUD/USD, ETH/AUD, Gold/AUD, S&P 500), duplicated for seamless marquee scroll. The values are placeholders ("Indicative only. Not financial advice." footnote) but the structure + a11y + compliance label need to render predictably.

The component was untested.

## 5 tests

- Region exposed via `aria-label="Market ticker"` + `tabIndex=0` for keyboard-focus pause
- Compliance footnote "Indicative only. Not financial advice." always rendered
- All 6 labels present (each appearing ≥2 times — duplicated for seamless loop)
- Up-trend tickers use `text-amber-400`, down-trend use `text-red-400`
- `prefers-reduced-motion` respected via `motion-reduce:animate-none`

No component change.

## Independent

No conflicts with any in-flight PR.

https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk)_