### PR TITLE
test(related-content-grid): coverage for KK-02 article cross-link grid

### DIFF
--- a/__tests__/components/RelatedContentGrid.test.tsx
+++ b/__tests__/components/RelatedContentGrid.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "./setup";
+import RelatedContentGrid from "@/components/RelatedContentGrid";
+
+const ITEMS = [
+  {
+    id: 1,
+    href: "/article/best-share-trading-platforms-australia",
+    title: "Best share trading platforms Australia 2026",
+    badgeText: "Guide",
+    badgeClass: "bg-blue-100 text-blue-700",
+    meta: "5 min read",
+  },
+  {
+    id: 2,
+    href: "/article/how-to-buy-us-stocks",
+    title: "How to buy US stocks from Australia",
+    meta: "8 min read",
+  },
+  {
+    id: 3,
+    href: "/article/sponsor-feature",
+    title: "Sponsored deep-dive on crypto",
+    badgeText: "Sponsored",
+  },
+];
+
+describe("RelatedContentGrid", () => {
+  it("renders nothing when items is empty", () => {
+    const { container } = render(<RelatedContentGrid items={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("uses the default 'Related Content' heading", () => {
+    render(<RelatedContentGrid items={ITEMS} />);
+    expect(screen.getByText("Related Content")).toBeInTheDocument();
+  });
+
+  it("accepts a custom heading", () => {
+    render(<RelatedContentGrid items={ITEMS} heading="Read next" />);
+    expect(screen.getByText("Read next")).toBeInTheDocument();
+  });
+
+  it("renders one Link per item with correct href + title", () => {
+    render(<RelatedContentGrid items={ITEMS} />);
+    expect(
+      screen.getByRole("link", {
+        name: /Best share trading platforms Australia 2026/,
+      }),
+    ).toHaveAttribute("href", "/article/best-share-trading-platforms-australia");
+    expect(
+      screen.getByRole("link", { name: /How to buy US stocks/ }),
+    ).toHaveAttribute("href", "/article/how-to-buy-us-stocks");
+  });
+
+  it("renders optional badge text when supplied", () => {
+    render(<RelatedContentGrid items={ITEMS} />);
+    expect(screen.getByText("Guide")).toBeInTheDocument();
+    expect(screen.getByText("Sponsored")).toBeInTheDocument();
+  });
+
+  it("omits the badge entirely for items without badgeText", () => {
+    render(<RelatedContentGrid items={[ITEMS[1]]} />);
+    expect(screen.queryByText(/Guide|Sponsored/)).not.toBeInTheDocument();
+  });
+
+  it("renders optional meta footer line when supplied", () => {
+    render(<RelatedContentGrid items={ITEMS} />);
+    expect(screen.getByText("5 min read")).toBeInTheDocument();
+    expect(screen.getByText("8 min read")).toBeInTheDocument();
+  });
+
+  it("omits the meta footer for items without it", () => {
+    render(<RelatedContentGrid items={[ITEMS[2]]} />);
+    expect(screen.queryByText(/min read/)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

`RelatedContentGrid` is the reusable bottom-of-article internal-link grid (KK-02). Renders a responsive 1→3 column grid; each card optionally has a category badge + meta footer (read time, sponsor attribution). Heavily used across article + research pages — a regression silently drops internal-link coverage which hurts crawl + topical authority.

The component was untested.

## 8 tests

- Empty items → renders nothing
- Default "Related Content" heading
- Custom heading override
- Per-item `<Link>` with correct href + title
- Optional badge text renders when supplied
- Badge omitted for items without `badgeText`
- Optional `meta` footer renders when supplied
- Meta footer omitted for items without it

No component change.

## Independent

No conflicts with any in-flight PR.

https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk)_