### PR TITLE
test(jargon-tooltip): coverage for plain-English term overlay

### DIFF
--- a/__tests__/components/JargonTooltip.test.tsx
+++ b/__tests__/components/JargonTooltip.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { fireEvent } from "@testing-library/react";
+import { render, screen } from "./setup";
+import JargonTooltip from "@/components/JargonTooltip";
+
+describe("JargonTooltip", () => {
+  it("renders the term verbatim when no glossary definition exists", () => {
+    render(<JargonTooltip term="NOT_A_REAL_TERM" />);
+    expect(screen.getByText("NOT_A_REAL_TERM")).toBeInTheDocument();
+    // No tooltip arrow / dotted underline when there's no definition.
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
+  it("renders children instead of the term when both are supplied (no-def branch)", () => {
+    render(
+      <JargonTooltip term="NOT_A_REAL_TERM">Custom Label</JargonTooltip>,
+    );
+    expect(screen.getByText("Custom Label")).toBeInTheDocument();
+    expect(screen.queryByText("NOT_A_REAL_TERM")).not.toBeInTheDocument();
+  });
+
+  it("renders the term with the ⓘ icon when the term IS in the glossary (e.g. 'ASX')", () => {
+    const { container } = render(<JargonTooltip term="ASX" />);
+    expect(screen.getByText("ASX")).toBeInTheDocument();
+    // The component wraps the term in a span with an SVG icon when
+    // a definition exists.
+    expect(container.querySelector("svg")).not.toBeNull();
+  });
+
+  it("hover opens the tooltip with the glossary definition", () => {
+    render(<JargonTooltip term="ASX" />);
+    const wrapper = screen.getByText("ASX").parentElement?.parentElement;
+    expect(wrapper).not.toBeNull();
+    fireEvent.mouseEnter(wrapper!);
+    expect(screen.getByRole("tooltip")).toBeInTheDocument();
+  });
+
+  it("mouseLeave closes the tooltip", () => {
+    render(<JargonTooltip term="ASX" />);
+    const wrapper = screen.getByText("ASX").parentElement?.parentElement;
+    fireEvent.mouseEnter(wrapper!);
+    expect(screen.getByRole("tooltip")).toBeInTheDocument();
+    fireEvent.mouseLeave(wrapper!);
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/components/JargonTooltip.test.tsx
+++ b/__tests__/components/JargonTooltip.test.tsx
@@ -29,7 +29,7 @@ describe("JargonTooltip", () => {
 
   it("hover opens the tooltip with the glossary definition", () => {
     render(<JargonTooltip term="ASX" />);
-    const wrapper = screen.getByText("ASX").parentElement?.parentElement;
+    const wrapper = screen.getByText("ASX").parentElement;
     expect(wrapper).not.toBeNull();
     fireEvent.mouseEnter(wrapper!);
     expect(screen.getByRole("tooltip")).toBeInTheDocument();
@@ -37,7 +37,7 @@ describe("JargonTooltip", () => {
 
   it("mouseLeave closes the tooltip", () => {
     render(<JargonTooltip term="ASX" />);
-    const wrapper = screen.getByText("ASX").parentElement?.parentElement;
+    const wrapper = screen.getByText("ASX").parentElement;
     fireEvent.mouseEnter(wrapper!);
     expect(screen.getByRole("tooltip")).toBeInTheDocument();
     fireEvent.mouseLeave(wrapper!);


### PR DESCRIPTION
## Summary

`JargonTooltip` wraps any financial term and shows a plain-English tooltip from `GLOSSARY` on hover (desktop) or tap (mobile). Used heavily across calculators + comparison tables — critical for non-pro users to understand financial jargon without leaving the page.

The component was untested.

## 5 tests

- Unknown term → renders plain text (no icon, no tooltip)
- Unknown term + children → renders children instead
- Known glossary term (e.g. "ASX") renders with ⓘ icon
- `mouseEnter` opens tooltip with `role="tooltip"`
- `mouseLeave` closes the tooltip

Two commits — the second fixes a `parentElement` traversal bug in the hover tests after the initial push. All 5 pass on the final commit.

## Independent

No conflicts with any in-flight PR.

https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk)_