### PR TITLE
test(glossary-search): coverage for in-page jargon dictionary

### DIFF
--- a/__tests__/components/GlossarySearch.test.tsx
+++ b/__tests__/components/GlossarySearch.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, userEvent } from "./setup";
+import GlossarySearch from "@/components/GlossarySearch";
+
+const ENTRIES = [
+  {
+    term: "ASX",
+    definition: "Australian Securities Exchange — primary stock exchange.",
+    category: "Markets",
+  },
+  {
+    term: "CHESS",
+    definition: "Clearing House Electronic Subregister System.",
+    category: "Custody",
+  },
+  {
+    term: "ETF",
+    definition: "Exchange Traded Fund — basket of securities.",
+  },
+];
+
+describe("GlossarySearch", () => {
+  it("renders the search input with aria-label", () => {
+    render(<GlossarySearch entries={ENTRIES} />);
+    expect(screen.getByLabelText("Search glossary terms")).toBeInTheDocument();
+  });
+
+  it("does NOT render results until query is > 1 character", async () => {
+    const user = userEvent.setup();
+    render(<GlossarySearch entries={ENTRIES} />);
+    const input = screen.getByRole("textbox");
+    await user.type(input, "A");
+    expect(screen.queryByText(/result/)).not.toBeInTheDocument();
+  });
+
+  it("filters by term substring (case-insensitive)", async () => {
+    const user = userEvent.setup();
+    render(<GlossarySearch entries={ENTRIES} />);
+    await user.type(screen.getByRole("textbox"), "asx");
+    expect(screen.getByText("ASX")).toBeInTheDocument();
+    expect(screen.getByText(/1 result/)).toBeInTheDocument();
+  });
+
+  it("filters by definition substring (case-insensitive)", async () => {
+    const user = userEvent.setup();
+    render(<GlossarySearch entries={ENTRIES} />);
+    await user.type(screen.getByRole("textbox"), "fund");
+    expect(screen.getByText("ETF")).toBeInTheDocument();
+  });
+
+  it("shows 'No terms match' empty state for unmatched queries", async () => {
+    const user = userEvent.setup();
+    render(<GlossarySearch entries={ENTRIES} />);
+    await user.type(screen.getByRole("textbox"), "zzzzzzzzz");
+    expect(screen.getByText(/No terms match/)).toBeInTheDocument();
+  });
+
+  it("pluralises 'results' correctly (1 result vs 2 results)", async () => {
+    const user = userEvent.setup();
+    render(<GlossarySearch entries={ENTRIES} />);
+    // "ex" matches "Exchange" in ASX definition + "Exchange Traded Fund" in ETF definition
+    await user.type(screen.getByRole("textbox"), "exchange");
+    expect(screen.getByText(/2 results/)).toBeInTheDocument();
+  });
+
+  it("renders the category pill for entries that have a category", async () => {
+    const user = userEvent.setup();
+    render(<GlossarySearch entries={ENTRIES} />);
+    await user.type(screen.getByRole("textbox"), "asx");
+    expect(screen.getByText("Markets")).toBeInTheDocument();
+  });
+
+  it("omits the category pill for entries without one", async () => {
+    const user = userEvent.setup();
+    render(<GlossarySearch entries={ENTRIES} />);
+    await user.type(screen.getByRole("textbox"), "etf");
+    // ETF entry has no category — Markets / Custody should not appear
+    expect(screen.queryByText("Markets")).not.toBeInTheDocument();
+    expect(screen.queryByText("Custody")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

`GlossarySearch` is the in-page search at the top of `/glossary`. Filters term + definition fields case-insensitively, surfaces a "No terms match" empty state, and renders category pills when present. Untested.

## 8 tests

- Input has `aria-label="Search glossary terms"`
- No results until query > 1 character
- Filters by term substring (case-insensitive)
- Filters by definition substring (case-insensitive)
- "No terms match" empty state for unmatched queries
- Pluralises 'result(s)' correctly (1 vs 2)
- Renders category pill for entries with a category
- Omits category pill for entries without one

No component change.

## Independent

No conflicts with any in-flight PR.

https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk)_