### PR TITLE
test(companion-strip): coverage for /best cross-vertical launchpad

### DIFF
--- a/__tests__/components/CompanionLinksStrip.test.tsx
+++ b/__tests__/components/CompanionLinksStrip.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "./setup";
+import CompanionLinksStrip from "@/components/CompanionLinksStrip";
+
+const LINKS = [
+  {
+    label: "SMSF Accountants",
+    sub: "Set up + lodgement specialists",
+    href: "/advisors/smsf-accountants",
+  },
+  {
+    label: "Super Funds",
+    sub: "Compare 50+ providers",
+    href: "/super",
+  },
+  {
+    label: "Property Investment Loans",
+    sub: "Mortgage broker comparison",
+    href: "/compare/mortgages",
+  },
+];
+
+describe("CompanionLinksStrip", () => {
+  it("renders nothing when links is empty", () => {
+    const { container } = render(<CompanionLinksStrip links={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("uses the default 'People also lined up' heading", () => {
+    render(<CompanionLinksStrip links={LINKS} />);
+    expect(screen.getByText("People also lined up")).toBeInTheDocument();
+  });
+
+  it("accepts a custom heading", () => {
+    render(<CompanionLinksStrip links={LINKS} heading="Adjacent services" />);
+    expect(screen.getByText("Adjacent services")).toBeInTheDocument();
+  });
+
+  it("exposes the section via aria-labelledby pointing to the heading", () => {
+    render(<CompanionLinksStrip links={LINKS} />);
+    const section = screen.getByRole("region", { name: "People also lined up" });
+    expect(section).toBeInTheDocument();
+    expect(section).toHaveAttribute("aria-labelledby", "companion-strip-heading");
+  });
+
+  it("renders one Link per item with correct href + label + sub", () => {
+    render(<CompanionLinksStrip links={LINKS} />);
+    expect(
+      screen.getByRole("link", { name: /SMSF Accountants/ }),
+    ).toHaveAttribute("href", "/advisors/smsf-accountants");
+    expect(
+      screen.getByText("Set up + lodgement specialists"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Super Funds/ }),
+    ).toHaveAttribute("href", "/super");
+    expect(
+      screen.getByText("Compare 50+ providers"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the expected number of links", () => {
+    render(<CompanionLinksStrip links={LINKS} />);
+    expect(screen.getAllByRole("link")).toHaveLength(3);
+  });
+});


### PR DESCRIPTION
## Summary

`CompanionLinksStrip` renders at the bottom of `/best/[slug]` pages as a 2-3 destination cross-vertical launchpad — surfaces specialist advisors, sibling vertical pillars, and tools that readers commonly stack with the current category (e.g. SMSF broker → SMSF accountant + super pillar).

The component was untested.

## 6 tests

- Empty links → renders nothing
- Default "People also lined up" heading
- Custom heading override
- `aria-labelledby` points to the heading
- Per-link `<Link>` with correct href + label + sub
- Renders the right number of links

No component change.

## Independent

No conflicts with any in-flight PR.

https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk)_