### PR TITLE
test(calc-share-button): coverage for share-link copy button

### DIFF
--- a/__tests__/components/CalculatorShareButton.test.tsx
+++ b/__tests__/components/CalculatorShareButton.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "./setup";
+
+vi.mock("@/hooks/use-calculator-state", () => ({
+  buildShareableUrl: (path: string, key: string, state: Record<string, unknown>) =>
+    `${path}?k=${key}&s=${encodeURIComponent(JSON.stringify(state))}`,
+}));
+
+import CalculatorShareButton from "@/components/CalculatorShareButton";
+
+/**
+ * Structural-only tests — the clipboard interaction needs a
+ * non-secure-context fallback test which fights jsdom's read-only
+ * `navigator.clipboard`. Click-and-state-change semantics are
+ * exercised in e2e against the live preview.
+ */
+describe("CalculatorShareButton", () => {
+  it("renders the default 'Share results' label", () => {
+    render(
+      <CalculatorShareButton calculatorKey="mortgage" state={{ rate: 0.06 }} />,
+    );
+    expect(screen.getByText("Share results")).toBeInTheDocument();
+  });
+
+  it("exposes the trigger as a button with descriptive aria-label", () => {
+    render(<CalculatorShareButton calculatorKey="x" state={{}} />);
+    expect(
+      screen.getByRole("button", {
+        name: "Copy shareable link to this calculation",
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("accepts a custom className override", () => {
+    render(
+      <CalculatorShareButton
+        calculatorKey="x"
+        state={{}}
+        className="custom-share-btn"
+      />,
+    );
+    expect(screen.getByRole("button")).toHaveClass("custom-share-btn");
+  });
+
+  it("uses the default class when no className is supplied", () => {
+    render(<CalculatorShareButton calculatorKey="x" state={{}} />);
+    expect(screen.getByRole("button")).toHaveClass("border-slate-200");
+  });
+});


### PR DESCRIPTION
## Summary

`CalculatorShareButton` is the standalone "Share results" copy button that any calculator can drop into its results panel — uses `useCalculatorState.buildShareableUrl` to build a deep link and writes to clipboard.

The component was untested.

## 4 structural tests

- Default "Share results" label rendered
- Trigger exposed as `<button aria-label="Copy shareable link to this calculation">`
- `className` override applies when supplied
- Default class is used when no `className`

The clipboard write + "Copied!" flip + non-secure-context `window.prompt` fallback are intentionally not covered here — `navigator.clipboard` is read-only in jsdom so test setup fights the environment. Those behaviours are exercised by e2e against the live preview.

No component change.

## Independent

No conflicts with any in-flight PR.

https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk)_