### PR TITLE
test: cover four small disclaimer/heading components

### DIFF
--- a/__tests__/components/CompactDisclaimerLine.test.tsx
+++ b/__tests__/components/CompactDisclaimerLine.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "./setup";
+import CompactDisclaimerLine from "@/components/CompactDisclaimerLine";
+
+describe("CompactDisclaimerLine", () => {
+  it("renders the info-icon link pointing at /how-we-earn", () => {
+    render(<CompactDisclaimerLine />);
+    const link = screen.getByRole("link", {
+      name: "Important disclaimers",
+    });
+    expect(link).toHaveAttribute("href", "/how-we-earn");
+  });
+
+  it("light variant applies slate text classes", () => {
+    const { container } = render(<CompactDisclaimerLine />);
+    expect(container.querySelector("p")?.className).toContain("text-slate-400");
+  });
+
+  it("dark variant applies white text classes", () => {
+    const { container } = render(<CompactDisclaimerLine variant="dark" />);
+    expect(container.querySelector("p")?.className).toContain("text-white/50");
+  });
+
+  it("uses the dark-variant link colour", () => {
+    render(<CompactDisclaimerLine variant="dark" />);
+    const link = screen.getByRole("link", {
+      name: "Important disclaimers",
+    });
+    expect(link.className).toContain("text-white/60");
+  });
+
+  it("marks the inline svg icon aria-hidden", () => {
+    const { container } = render(<CompactDisclaimerLine />);
+    expect(container.querySelector("svg")).toHaveAttribute(
+      "aria-hidden",
+      "true",
+    );
+  });
+});

--- a/__tests__/components/PropertyDisclaimer.test.tsx
+++ b/__tests__/components/PropertyDisclaimer.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "./setup";
+import PropertyDisclaimer from "@/components/PropertyDisclaimer";
+
+describe("PropertyDisclaimer", () => {
+  it("renders the info-icon link pointing at /terms", () => {
+    render(<PropertyDisclaimer />);
+    const link = screen.getByRole("link", {
+      name: "Important disclaimers",
+    });
+    expect(link).toHaveAttribute("href", "/terms");
+  });
+
+  it("renders the compliance copy alongside the icon link", () => {
+    const { container } = render(<PropertyDisclaimer />);
+    // The disclaimer text is whatever PROPERTY_DISCLAIMER_SHORT resolves to.
+    // We don't assert the exact wording (that would couple the test to
+    // compliance copy), but we do assert the surrounding paragraph
+    // contains some non-trivial body text after the icon link.
+    const p = container.querySelector("p");
+    expect(p).not.toBeNull();
+    expect(p?.textContent?.length ?? 0).toBeGreaterThan(20);
+  });
+
+  it("marks the inline svg icon aria-hidden", () => {
+    const { container } = render(<PropertyDisclaimer />);
+    expect(container.querySelector("svg")).toHaveAttribute(
+      "aria-hidden",
+      "true",
+    );
+  });
+});

--- a/__tests__/components/RiskWarningInline.test.tsx
+++ b/__tests__/components/RiskWarningInline.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { render } from "./setup";
+import RiskWarningInline from "@/components/RiskWarningInline";
+
+describe("RiskWarningInline", () => {
+  it("renders a paragraph with non-trivial copy", () => {
+    const { container } = render(<RiskWarningInline />);
+    const p = container.querySelector("p");
+    expect(p).not.toBeNull();
+    expect(p?.textContent?.length ?? 0).toBeGreaterThan(10);
+  });
+
+  it("default (light) variant uses slate text", () => {
+    const { container } = render(<RiskWarningInline />);
+    expect(container.querySelector("p")?.className).toContain(
+      "text-slate-400",
+    );
+  });
+
+  it("dark variant uses white text", () => {
+    const { container } = render(<RiskWarningInline variant="dark" />);
+    expect(container.querySelector("p")?.className).toContain(
+      "text-white/60",
+    );
+  });
+});

--- a/__tests__/components/SectionHeading.test.tsx
+++ b/__tests__/components/SectionHeading.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "./setup";
+import SectionHeading from "@/components/SectionHeading";
+
+describe("SectionHeading", () => {
+  it("renders eyebrow + title", () => {
+    render(<SectionHeading eyebrow="OUR PICKS" title="The Top Brokers" />);
+    expect(screen.getByText("OUR PICKS")).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "The Top Brokers" }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render the sub paragraph when sub is undefined", () => {
+    const { container } = render(
+      <SectionHeading eyebrow="x" title="y" />,
+    );
+    // Only the eyebrow <p> exists; no sub <p>.
+    expect(container.querySelectorAll("p")).toHaveLength(1);
+  });
+
+  it("renders the sub paragraph when provided", () => {
+    render(
+      <SectionHeading eyebrow="x" title="y" sub="A descriptive sub copy" />,
+    );
+    expect(
+      screen.getByText("A descriptive sub copy"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders title as an h2 (correct section semantics)", () => {
+    render(<SectionHeading eyebrow="x" title="Section Title" />);
+    const heading = screen.getByRole("heading", { name: "Section Title" });
+    expect(heading.tagName).toBe("H2");
+  });
+});


### PR DESCRIPTION
## Summary
Four focused test files for the small pure-presentation primitives that were untested.

| Component | Tests | Covers |
|---|---|---|
| `SectionHeading` | 4 | eyebrow render, h2 semantics, optional sub paragraph |
| `PropertyDisclaimer` | 3 | `/terms` info-icon link, non-trivial body copy, `aria-hidden` svg |
| `CompactDisclaimerLine` | 5 | `/how-we-earn` link, light/dark text classes + link colour, `aria-hidden` svg |
| `RiskWarningInline` | 3 | body copy render, light/dark text classes |

Total: **15 new tests, 4 new files, no production-code changes**.

## Test plan
- [x] `npx vitest run __tests__/components/SectionHeading.test.tsx __tests__/components/PropertyDisclaimer.test.tsx __tests__/components/CompactDisclaimerLine.test.tsx __tests__/components/RiskWarningInline.test.tsx` → 15/15 passing locally.

https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk)_