### PR TITLE
feat(bb02+bb03): BB-02 + BB-03 — salary-sacrifice optimiser + CGT calculator [audit remediation]

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -118,6 +118,8 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     "/just/retired", "/just/inherited", "/just/made-redundant",
     "/just/got-married", "/just/had-a-baby", "/just/bought-a-house",
     "/just/sold-a-business", "/just/started-investing",
+    "/tools/salary-sacrifice-optimiser",
+    "/tools/cgt-calculator",
     "/redundancy",
     "/pricing",
     "/firb-fee-estimator", "/non-resident-dividend-calculator", "/non-resident-cgt-checker",

--- a/app/tools/cgt-calculator/CGTCalculatorClient.tsx
+++ b/app/tools/cgt-calculator/CGTCalculatorClient.tsx
@@ -1,0 +1,348 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import Link from "next/link";
+import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
+
+// ─── FY2025-26 tax rates ──────────────────────────────────────────────────────
+
+function incomeTax(gross: number): number {
+  if (gross <= 18_200) return 0;
+  if (gross <= 45_000) return (gross - 18_200) * 0.19;
+  if (gross <= 135_000) return 5_092 + (gross - 45_000) * 0.325;
+  if (gross <= 190_000) return 29_467 + (gross - 135_000) * 0.37;
+  return 51_667 + (gross - 190_000) * 0.45;
+}
+
+function medicare(gross: number): number {
+  if (gross <= 26_000) return 0;
+  if (gross <= 32_500) return (gross - 26_000) * 0.1;
+  return gross * 0.02;
+}
+
+const INCOME_PRESETS = [
+  { label: "Under $45k", value: 40_000 },
+  { label: "$45k–$135k", value: 90_000 },
+  { label: "$135k–$190k", value: 160_000 },
+  { label: "Over $190k", value: 220_000 },
+];
+
+function fmt(n: number): string {
+  return new Intl.NumberFormat("en-AU", {
+    style: "currency",
+    currency: "AUD",
+    maximumFractionDigits: 0,
+  }).format(n);
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export default function CGTCalculatorClient() {
+  const [purchasePrice, setPurchasePrice] = useState("50000");
+  const [salePrice, setSalePrice] = useState("80000");
+  const [purchaseCosts, setPurchaseCosts] = useState("1000");
+  const [saleCosts, setSaleCosts] = useState("500");
+  const [heldOver12Months, setHeldOver12Months] = useState(true);
+  const [annualIncome, setAnnualIncome] = useState(90_000);
+  const [assetType, setAssetType] = useState<"shares" | "property" | "crypto" | "other">("shares");
+
+  const r = useMemo(() => {
+    const purchase = parseFloat(purchasePrice.replace(/,/g, "")) || 0;
+    const sale = parseFloat(salePrice.replace(/,/g, "")) || 0;
+    const pCosts = parseFloat(purchaseCosts.replace(/,/g, "")) || 0;
+    const sCosts = parseFloat(saleCosts.replace(/,/g, "")) || 0;
+
+    const costBase = purchase + pCosts;
+    const proceeds = sale - sCosts;
+    const grossGain = proceeds - costBase;
+    const isLoss = grossGain < 0;
+
+    const discountApplies = heldOver12Months && !isLoss;
+    const discountedGain = discountApplies ? grossGain * 0.5 : grossGain;
+    const taxableGain = Math.max(0, discountedGain);
+
+    const taxWithoutGain = incomeTax(annualIncome) + medicare(annualIncome);
+    const taxWithGain = incomeTax(annualIncome + taxableGain) + medicare(annualIncome + taxableGain);
+    const cgtOwed = Math.max(0, taxWithGain - taxWithoutGain);
+
+    const effectiveRate = taxableGain > 0 ? cgtOwed / grossGain : 0;
+    const netProfit = grossGain - cgtOwed;
+
+    return {
+      costBase, proceeds, grossGain, isLoss,
+      discountApplies, discountedGain, taxableGain,
+      cgtOwed, effectiveRate, netProfit,
+    };
+  }, [purchasePrice, salePrice, purchaseCosts, saleCosts, heldOver12Months, annualIncome]);
+
+  const showResults = r.proceeds > 0 && r.costBase > 0;
+
+  return (
+    <div className="space-y-6">
+      {/* Inputs */}
+      <div className="bg-white rounded-2xl border border-slate-200 p-6 space-y-5">
+        <h2 className="text-base font-bold text-slate-900">Asset details</h2>
+
+        {/* Asset type */}
+        <div>
+          <label className="block text-sm font-semibold text-slate-700 mb-2">Asset type</label>
+          <div className="grid grid-cols-4 gap-1.5">
+            {(["shares", "property", "crypto", "other"] as const).map((t) => (
+              <button
+                key={t}
+                onClick={() => setAssetType(t)}
+                className={`py-2 text-xs font-semibold rounded-lg capitalize transition-all ${
+                  assetType === t
+                    ? "bg-emerald-600 text-white"
+                    : "bg-slate-100 text-slate-600 hover:bg-slate-200"
+                }`}
+              >
+                {t}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm font-semibold text-slate-700 mb-1.5">Purchase price</label>
+            <div className="relative">
+              <span className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 text-sm">$</span>
+              <input
+                type="number" min={0} step={1000}
+                value={purchasePrice}
+                onChange={(e) => setPurchasePrice(e.target.value)}
+                className="w-full pl-8 pr-3 py-2.5 border border-slate-200 rounded-xl text-sm text-slate-900 font-medium focus:outline-none focus:ring-2 focus:ring-emerald-500"
+              />
+            </div>
+          </div>
+          <div>
+            <label className="block text-sm font-semibold text-slate-700 mb-1.5">Sale price</label>
+            <div className="relative">
+              <span className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 text-sm">$</span>
+              <input
+                type="number" min={0} step={1000}
+                value={salePrice}
+                onChange={(e) => setSalePrice(e.target.value)}
+                className="w-full pl-8 pr-3 py-2.5 border border-slate-200 rounded-xl text-sm text-slate-900 font-medium focus:outline-none focus:ring-2 focus:ring-emerald-500"
+              />
+            </div>
+          </div>
+          <div>
+            <label className="block text-sm font-semibold text-slate-700 mb-1.5">
+              Purchase costs
+              <span className="text-slate-400 font-normal ml-1">(stamp duty, brokerage)</span>
+            </label>
+            <div className="relative">
+              <span className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 text-sm">$</span>
+              <input
+                type="number" min={0} step={100}
+                value={purchaseCosts}
+                onChange={(e) => setPurchaseCosts(e.target.value)}
+                className="w-full pl-8 pr-3 py-2.5 border border-slate-200 rounded-xl text-sm text-slate-900 font-medium focus:outline-none focus:ring-2 focus:ring-emerald-500"
+              />
+            </div>
+          </div>
+          <div>
+            <label className="block text-sm font-semibold text-slate-700 mb-1.5">
+              Sale costs
+              <span className="text-slate-400 font-normal ml-1">(agent fees, brokerage)</span>
+            </label>
+            <div className="relative">
+              <span className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 text-sm">$</span>
+              <input
+                type="number" min={0} step={100}
+                value={saleCosts}
+                onChange={(e) => setSaleCosts(e.target.value)}
+                className="w-full pl-8 pr-3 py-2.5 border border-slate-200 rounded-xl text-sm text-slate-900 font-medium focus:outline-none focus:ring-2 focus:ring-emerald-500"
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* Holding period */}
+        <label className="flex items-center gap-3 cursor-pointer select-none">
+          <input
+            type="checkbox"
+            checked={heldOver12Months}
+            onChange={(e) => setHeldOver12Months(e.target.checked)}
+            className="w-4 h-4 accent-emerald-600"
+          />
+          <span className="text-sm text-slate-700">
+            Held more than 12 months (eligible for 50% CGT discount)
+          </span>
+        </label>
+
+        {/* Income */}
+        <div>
+          <label className="block text-sm font-semibold text-slate-700 mb-2">
+            Your other annual income (for marginal rate)
+          </label>
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-1.5">
+            {INCOME_PRESETS.map((p) => (
+              <button
+                key={p.value}
+                onClick={() => setAnnualIncome(p.value)}
+                className={`py-2 text-xs font-semibold rounded-lg transition-all ${
+                  annualIncome === p.value
+                    ? "bg-emerald-600 text-white"
+                    : "bg-slate-100 text-slate-600 hover:bg-slate-200"
+                }`}
+              >
+                {p.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Results */}
+      {showResults && (
+        <div className="space-y-4">
+          {r.isLoss ? (
+            <div className="bg-slate-50 border border-slate-200 rounded-xl p-4 text-sm text-slate-700">
+              <strong>Capital loss:</strong> This asset returned a loss of {fmt(-r.grossGain)}. Capital losses can
+              be carried forward indefinitely and offset against future capital gains (not ordinary income).
+            </div>
+          ) : (
+            <>
+              {/* Key numbers */}
+              <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+                <div className="bg-slate-50 rounded-xl p-4">
+                  <div className="text-2xl font-extrabold text-slate-900">{fmt(r.grossGain)}</div>
+                  <div className="text-xs font-semibold text-slate-500 mt-0.5">Gross capital gain</div>
+                </div>
+                {r.discountApplies && (
+                  <div className="bg-emerald-50 rounded-xl p-4">
+                    <div className="text-2xl font-extrabold text-emerald-700">{fmt(r.taxableGain)}</div>
+                    <div className="text-xs font-semibold text-slate-500 mt-0.5">After 50% CGT discount</div>
+                  </div>
+                )}
+                <div className="bg-rose-50 rounded-xl p-4">
+                  <div className="text-2xl font-extrabold text-rose-700">{fmt(r.cgtOwed)}</div>
+                  <div className="text-xs font-semibold text-slate-500 mt-0.5">
+                    CGT owed (effective {(r.effectiveRate * 100).toFixed(1)}%)
+                  </div>
+                </div>
+              </div>
+
+              {/* Breakdown */}
+              <div className="bg-white border border-slate-200 rounded-2xl p-5 space-y-2.5 text-sm">
+                <h3 className="font-bold text-slate-900">Calculation breakdown</h3>
+                <Row label="Cost base (purchase + costs)" value={fmt(r.costBase)} />
+                <Row label="Proceeds (sale − costs)" value={fmt(r.proceeds)} />
+                <Row label="Gross capital gain" value={fmt(r.grossGain)} bold />
+                {r.discountApplies && (
+                  <Row label="50% CGT discount (held >12 months)" value={`−${fmt(r.grossGain * 0.5)}`} green />
+                )}
+                <Row label="Taxable gain" value={fmt(r.taxableGain)} bold />
+                <Row label="CGT owed at marginal rate" value={fmt(r.cgtOwed)} />
+                <div className="border-t border-slate-100 pt-2.5">
+                  <Row label="Net profit after CGT" value={fmt(r.netProfit)} bold green />
+                </div>
+              </div>
+
+              {/* Comparison: with vs without discount */}
+              {r.grossGain > 0 && (
+                <div className="bg-white border border-slate-200 rounded-2xl p-5 text-sm">
+                  <h3 className="font-bold text-slate-900 mb-3">Discount impact</h3>
+                  <div className="grid grid-cols-2 gap-3">
+                    <div className="bg-slate-50 rounded-xl p-3 text-center">
+                      <div className="text-xs text-slate-500 mb-1">Tax WITHOUT 12-month hold</div>
+                      <div className="text-lg font-extrabold text-slate-900">
+                        {fmt(
+                          Math.max(
+                            0,
+                            incomeTax(annualIncome + r.grossGain) +
+                              medicare(annualIncome + r.grossGain) -
+                              incomeTax(annualIncome) -
+                              medicare(annualIncome)
+                          )
+                        )}
+                      </div>
+                    </div>
+                    <div className="bg-emerald-50 rounded-xl p-3 text-center">
+                      <div className="text-xs text-slate-500 mb-1">Tax WITH 12-month hold</div>
+                      <div className="text-lg font-extrabold text-emerald-700">{fmt(r.cgtOwed)}</div>
+                    </div>
+                  </div>
+                  {!heldOver12Months && r.grossGain > 0 && (
+                    <p className="text-xs text-amber-700 mt-2 bg-amber-50 rounded-lg p-2">
+                      Holding until 12 months would save{" "}
+                      {fmt(
+                        Math.max(
+                          0,
+                          incomeTax(annualIncome + r.grossGain) +
+                            medicare(annualIncome + r.grossGain) -
+                            incomeTax(annualIncome) -
+                            medicare(annualIncome)
+                        ) - r.cgtOwed
+                      )}{" "}
+                      in CGT on this asset.
+                    </p>
+                  )}
+                </div>
+              )}
+
+              {assetType === "property" && (
+                <div className="bg-blue-50 border border-blue-200 rounded-xl p-4 text-sm text-blue-800">
+                  <strong>Property note:</strong> Main residence may be fully or partially exempt (6-year rule for former
+                  main residence rented out). Depreciation deductions claimed may reduce your cost base. A tax agent
+                  can work out the exact CGT position for investment properties.
+                </div>
+              )}
+
+              {assetType === "crypto" && (
+                <div className="bg-blue-50 border border-blue-200 rounded-xl p-4 text-sm text-blue-800">
+                  <strong>Crypto note:</strong> The ATO treats cryptocurrency as property, not currency. CGT applies on
+                  every disposal (sale, swap, or spending). Cost base tracking methods include FIFO, LIFO, or
+                  specific identification — confirm with a crypto-specialist tax agent.
+                </div>
+              )}
+            </>
+          )}
+
+          {/* CTA */}
+          <div className="bg-emerald-50 border border-emerald-200 rounded-2xl p-5">
+            <p className="text-sm font-semibold text-emerald-900 mb-1">
+              Minimise CGT with professional advice
+            </p>
+            <p className="text-xs text-emerald-700 mb-3">
+              Tax loss harvesting, asset location, main residence exemptions, and the 6-year rule can all
+              reduce your CGT bill significantly.
+            </p>
+            <Link
+              href="/advisors/tax-agents"
+              className="inline-block bg-emerald-600 text-white text-sm font-semibold px-4 py-2 rounded-lg hover:bg-emerald-700 transition-colors"
+            >
+              Find a Tax Agent
+            </Link>
+          </div>
+        </div>
+      )}
+
+      <p className="text-xs text-slate-400 leading-relaxed">{GENERAL_ADVICE_WARNING}</p>
+    </div>
+  );
+}
+
+function Row({
+  label,
+  value,
+  green,
+  bold,
+}: {
+  label: string;
+  value: string;
+  green?: boolean;
+  bold?: boolean;
+}) {
+  return (
+    <div className="flex justify-between">
+      <span className="text-slate-600">{label}</span>
+      <span className={[bold ? "font-bold" : "font-semibold", green ? "text-emerald-700" : "text-slate-900"].join(" ")}>
+        {value}
+      </span>
+    </div>
+  );
+}

--- a/app/tools/cgt-calculator/page.tsx
+++ b/app/tools/cgt-calculator/page.tsx
@@ -1,0 +1,119 @@
+import type { Metadata } from "next";
+import { Suspense } from "react";
+import { CURRENT_YEAR, breadcrumbJsonLd, SITE_URL } from "@/lib/seo";
+import { calculatorJsonLd, faqJsonLd } from "@/lib/schema-markup";
+import CGTCalculatorClient from "./CGTCalculatorClient";
+
+export const revalidate = 3600;
+
+export const metadata: Metadata = {
+  title: `CGT Calculator (${CURRENT_YEAR}) — Capital Gains Tax Estimator Australia`,
+  description:
+    "Calculate capital gains tax on shares, property, crypto, or other assets. Includes 50% CGT discount for assets held over 12 months, FY2025-26 marginal rates, and net profit after tax.",
+  alternates: { canonical: `${SITE_URL}/tools/cgt-calculator` },
+  openGraph: {
+    title: `CGT Calculator (${CURRENT_YEAR}) — Capital Gains Tax Australia`,
+    description:
+      "Enter your purchase price, sale price, and holding period. The calculator applies the 50% CGT discount and your marginal tax rate to estimate CGT owed.",
+    url: `${SITE_URL}/tools/cgt-calculator`,
+  },
+};
+
+const breadcrumbLd = breadcrumbJsonLd([
+  { name: "Home", url: "/" },
+  { name: "Tools", url: "/tools" },
+  { name: "CGT Calculator", url: "/tools/cgt-calculator" },
+]);
+
+const calcLd = calculatorJsonLd({
+  name: "Capital Gains Tax Calculator",
+  description:
+    "Estimate CGT on shares, property, cryptocurrency, or other assets. Includes 50% discount for assets held over 12 months, purchase and sale costs, and FY2025-26 marginal tax rates.",
+  path: "/tools/cgt-calculator",
+});
+
+const faqLd = faqJsonLd([
+  {
+    q: "How is capital gains tax calculated in Australia?",
+    a: "Your capital gain equals the proceeds (sale price minus sale costs) minus the cost base (purchase price plus purchase costs). If you held the asset for more than 12 months, you can apply a 50% discount to the gain before adding it to your taxable income for the year. The gain is then taxed at your marginal income tax rate — not a separate CGT rate.",
+  },
+  {
+    q: "What is the 50% CGT discount?",
+    a: "Australian resident individuals and trusts can apply a 50% discount to capital gains on assets held for more than 12 months. This effectively halves the tax owed — for example, a $30,000 gain after a 12-month hold is only taxed as a $15,000 gain. Companies and superannuation funds cannot access the 50% discount (super funds get a one-third discount).",
+  },
+  {
+    q: "What's included in the cost base?",
+    a: "The cost base includes the original purchase price plus incidental costs: stamp duty, legal fees, and brokerage on purchase. For property, you may also include capital improvement costs (not repairs). For investment properties, you must reduce the cost base by depreciation deductions you've already claimed.",
+  },
+  {
+    q: "Can I offset a capital loss against a capital gain?",
+    a: "Yes. Capital losses must first be offset against capital gains in the same year before the 50% discount is applied. Remaining losses carry forward indefinitely and can offset future gains. Capital losses cannot be offset against ordinary income such as salary.",
+  },
+  {
+    q: "Do I pay CGT on crypto in Australia?",
+    a: "Yes. The ATO treats cryptocurrency as a capital asset, not currency. Every disposal — selling, swapping, spending, or gifting — is a CGT event. The 50% discount applies if you held the crypto for more than 12 months. The ATO can access exchange data, so all crypto gains should be reported.",
+  },
+  {
+    q: "When is my main residence CGT-free?",
+    a: "Your main residence is fully CGT-exempt if you owned and lived in it the entire time, and the land is under 2 hectares. A partial exemption applies if you rented part of it or used it for income. The 6-year rule allows you to treat a former main residence as your main residence for up to 6 years while it is rented, preserving the exemption if you have no other main residence.",
+  },
+]);
+
+export default function CGTCalculatorPage() {
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(calcLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }}
+      />
+
+      <div className="container-custom max-w-2xl py-8">
+        <nav className="text-sm text-slate-400 mb-6 flex gap-1.5 flex-wrap">
+          <a href="/" className="hover:text-slate-600">Home</a>
+          <span>›</span>
+          <a href="/tools" className="hover:text-slate-600">Tools</a>
+          <span>›</span>
+          <span className="text-slate-600">CGT Calculator</span>
+        </nav>
+
+        <header className="mb-8">
+          <p className="text-xs font-bold uppercase tracking-wider text-emerald-600 mb-2">Calculator · FY2025-26</p>
+          <h1 className="text-3xl font-extrabold text-slate-900 mb-2">
+            Capital Gains Tax Calculator
+          </h1>
+          <p className="text-slate-500 text-base">
+            Estimate CGT on shares, property, crypto, or other assets. Enter your purchase and sale details
+            to see the 50% CGT discount impact and your tax owed.
+          </p>
+        </header>
+
+        <Suspense>
+          <CGTCalculatorClient />
+        </Suspense>
+
+        {/* FAQ */}
+        <section className="mt-12">
+          <h2 className="text-xl font-bold text-slate-900 mb-4">
+            Frequently asked questions
+          </h2>
+          <div className="space-y-5">
+            {faqLd.mainEntity.map((faq: { name: string; acceptedAnswer: { text: string } }) => (
+              <div key={faq.name}>
+                <h3 className="text-sm font-bold text-slate-900 mb-1">{faq.name}</h3>
+                <p className="text-sm text-slate-600 leading-relaxed">{faq.acceptedAnswer.text}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+      </div>
+    </>
+  );
+}

--- a/app/tools/cgt-calculator/page.tsx
+++ b/app/tools/cgt-calculator/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { Suspense } from "react";
 import { CURRENT_YEAR, breadcrumbJsonLd, SITE_URL } from "@/lib/seo";
-import { calculatorJsonLd, faqJsonLd } from "@/lib/schema-markup";
+import { calculatorJsonLd, faqJsonLd, type FaqItem } from "@/lib/schema-markup";
 import CGTCalculatorClient from "./CGTCalculatorClient";
 
 export const revalidate = 3600;
@@ -32,7 +32,7 @@ const calcLd = calculatorJsonLd({
   path: "/tools/cgt-calculator",
 });
 
-const faqLd = faqJsonLd([
+const FAQS: FaqItem[] = [
   {
     q: "How is capital gains tax calculated in Australia?",
     a: "Your capital gain equals the proceeds (sale price minus sale costs) minus the cost base (purchase price plus purchase costs). If you held the asset for more than 12 months, you can apply a 50% discount to the gain before adding it to your taxable income for the year. The gain is then taxed at your marginal income tax rate — not a separate CGT rate.",
@@ -57,7 +57,9 @@ const faqLd = faqJsonLd([
     q: "When is my main residence CGT-free?",
     a: "Your main residence is fully CGT-exempt if you owned and lived in it the entire time, and the land is under 2 hectares. A partial exemption applies if you rented part of it or used it for income. The 6-year rule allows you to treat a former main residence as your main residence for up to 6 years while it is rented, preserving the exemption if you have no other main residence.",
   },
-]);
+];
+
+const faqLd = faqJsonLd(FAQS);
 
 export default function CGTCalculatorPage() {
   return (
@@ -105,10 +107,10 @@ export default function CGTCalculatorPage() {
             Frequently asked questions
           </h2>
           <div className="space-y-5">
-            {faqLd.mainEntity.map((faq: { name: string; acceptedAnswer: { text: string } }) => (
-              <div key={faq.name}>
-                <h3 className="text-sm font-bold text-slate-900 mb-1">{faq.name}</h3>
-                <p className="text-sm text-slate-600 leading-relaxed">{faq.acceptedAnswer.text}</p>
+            {FAQS.map((faq) => (
+              <div key={faq.q}>
+                <h3 className="text-sm font-bold text-slate-900 mb-1">{faq.q}</h3>
+                <p className="text-sm text-slate-600 leading-relaxed">{faq.a}</p>
               </div>
             ))}
           </div>

--- a/app/tools/salary-sacrifice-optimiser/SalarySacrificeOptimiserClient.tsx
+++ b/app/tools/salary-sacrifice-optimiser/SalarySacrificeOptimiserClient.tsx
@@ -1,0 +1,292 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import Link from "next/link";
+import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
+
+// ─── FY2025-26 tax constants ──────────────────────────────────────────────────
+
+const SG_RATE = 0.115;
+const CONCESSIONAL_CAP = 30_000;
+const DIV293_THRESHOLD = 250_000;
+
+function incomeTax(gross: number): number {
+  if (gross <= 18_200) return 0;
+  if (gross <= 45_000) return (gross - 18_200) * 0.19;
+  if (gross <= 135_000) return 5_092 + (gross - 45_000) * 0.325;
+  if (gross <= 190_000) return 29_467 + (gross - 135_000) * 0.37;
+  return 51_667 + (gross - 190_000) * 0.45;
+}
+
+function medicare(gross: number): number {
+  if (gross <= 26_000) return 0;
+  if (gross <= 32_500) return (gross - 26_000) * 0.1;
+  return gross * 0.02;
+}
+
+function marginalRateOf(gross: number): number {
+  if (gross <= 18_200) return 0;
+  if (gross <= 45_000) return 0.19;
+  if (gross <= 135_000) return 0.325;
+  if (gross <= 190_000) return 0.37;
+  return 0.45;
+}
+
+function totalTax(gross: number): number {
+  return incomeTax(gross) + medicare(gross);
+}
+
+function fmt(n: number): string {
+  return new Intl.NumberFormat("en-AU", {
+    style: "currency",
+    currency: "AUD",
+    maximumFractionDigits: 0,
+  }).format(n);
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export default function SalarySacrificeOptimiserClient() {
+  const [grossSalary, setGrossSalary] = useState("100000");
+  const [sacrificeAmount, setSacrificeAmount] = useState("10000");
+  const [includeEmployerSg, setIncludeEmployerSg] = useState(true);
+
+  const r = useMemo(() => {
+    const gross = parseFloat(grossSalary.replace(/,/g, "")) || 0;
+    const rawSacrifice = parseFloat(sacrificeAmount.replace(/,/g, "")) || 0;
+    const employerSg = includeEmployerSg ? Math.round(gross * SG_RATE) : 0;
+
+    // Cap enforcement
+    const maxSacrifice = Math.max(0, CONCESSIONAL_CAP - employerSg);
+    const sacrifice = Math.min(rawSacrifice, maxSacrifice);
+    const capExceeded = rawSacrifice > maxSacrifice;
+    const totalConcessional = employerSg + sacrifice;
+    const capRoom = Math.max(0, CONCESSIONAL_CAP - totalConcessional);
+
+    const taxableBefore = gross;
+    const taxableAfter = gross - sacrifice;
+
+    const taxBefore = totalTax(taxableBefore);
+    const taxAfter = totalTax(taxableAfter);
+
+    const takehomeBefore = gross - taxBefore;
+    const takehomeAfter = taxableAfter - taxAfter;
+
+    const incomeTaxSaving = taxBefore - taxAfter;
+    const superTaxRate = gross + sacrifice > DIV293_THRESHOLD ? 0.30 : 0.15;
+    const superTax = sacrifice * superTaxRate;
+    const netGain = incomeTaxSaving - superTax; // pure dollar benefit
+
+    const margRate = marginalRateOf(gross);
+    const div293 = gross + sacrifice > DIV293_THRESHOLD;
+
+    return {
+      gross, sacrifice, rawSacrifice, employerSg, capExceeded,
+      totalConcessional, capRoom, taxBefore, taxAfter,
+      takehomeBefore, takehomeAfter,
+      takehomeDelta: takehomeAfter - takehomeBefore, // negative = less take-home
+      incomeTaxSaving, superTax, superTaxRate, netGain,
+      margRate, div293,
+    };
+  }, [grossSalary, sacrificeAmount, includeEmployerSg]);
+
+  const showResults = r.gross > 0 && r.rawSacrifice > 0;
+
+  return (
+    <div className="space-y-6">
+      {/* Inputs */}
+      <div className="bg-white rounded-2xl border border-slate-200 p-6 space-y-5">
+        <h2 className="text-base font-bold text-slate-900">Your details (FY2025-26)</h2>
+
+        <div>
+          <label className="block text-sm font-semibold text-slate-700 mb-1.5">
+            Gross annual salary
+          </label>
+          <div className="relative">
+            <span className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 font-medium text-sm">$</span>
+            <input
+              type="number"
+              min={0}
+              step={5000}
+              value={grossSalary}
+              onChange={(e) => setGrossSalary(e.target.value)}
+              className="w-full pl-8 pr-4 py-3 border border-slate-200 rounded-xl text-slate-900 font-medium focus:outline-none focus:ring-2 focus:ring-emerald-500"
+              placeholder="100000"
+            />
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-sm font-semibold text-slate-700 mb-1.5">
+            Annual salary sacrifice (pre-tax)
+          </label>
+          <div className="relative">
+            <span className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 font-medium text-sm">$</span>
+            <input
+              type="number"
+              min={0}
+              step={500}
+              value={sacrificeAmount}
+              onChange={(e) => setSacrificeAmount(e.target.value)}
+              className="w-full pl-8 pr-4 py-3 border border-slate-200 rounded-xl text-slate-900 font-medium focus:outline-none focus:ring-2 focus:ring-emerald-500"
+              placeholder="10000"
+            />
+          </div>
+        </div>
+
+        <label className="flex items-start gap-3 cursor-pointer select-none">
+          <input
+            type="checkbox"
+            checked={includeEmployerSg}
+            onChange={(e) => setIncludeEmployerSg(e.target.checked)}
+            className="w-4 h-4 mt-0.5 accent-emerald-600 shrink-0"
+          />
+          <span className="text-sm text-slate-700">
+            Count employer SG ({(SG_RATE * 100).toFixed(1)}% = {fmt(r.employerSg)}/yr) toward the{" "}
+            {fmt(CONCESSIONAL_CAP)} concessional cap
+          </span>
+        </label>
+      </div>
+
+      {/* Cap warning */}
+      {r.capExceeded && (
+        <div className="bg-amber-50 border border-amber-200 rounded-xl p-4 text-sm text-amber-800">
+          <strong>Concessional cap capped at {fmt(CONCESSIONAL_CAP)}.</strong> Your requested sacrifice of{" "}
+          {fmt(r.rawSacrifice)} plus employer SG of {fmt(r.employerSg)} would exceed the limit. Results use the
+          maximum effective sacrifice of {fmt(r.sacrifice)}.
+        </div>
+      )}
+
+      {/* Results */}
+      {showResults && (
+        <div className="space-y-4">
+          {/* Headline cards */}
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <div className="bg-emerald-50 rounded-xl p-4">
+              <div className="text-2xl font-extrabold text-emerald-700">{fmt(r.incomeTaxSaving)}</div>
+              <div className="text-xs font-semibold text-slate-600 mt-0.5">Income tax saving / yr</div>
+            </div>
+            <div className="bg-slate-50 rounded-xl p-4">
+              <div className="text-2xl font-extrabold text-slate-700">{fmt(r.superTax)}</div>
+              <div className="text-xs font-semibold text-slate-600 mt-0.5">
+                Super contributions tax ({(r.superTaxRate * 100).toFixed(0)}%)
+              </div>
+            </div>
+            <div className={`rounded-xl p-4 ${r.netGain >= 0 ? "bg-emerald-50" : "bg-rose-50"}`}>
+              <div className={`text-2xl font-extrabold ${r.netGain >= 0 ? "text-emerald-700" : "text-rose-700"}`}>
+                {fmt(r.netGain)}
+              </div>
+              <div className="text-xs font-semibold text-slate-600 mt-0.5">Net annual tax advantage</div>
+            </div>
+          </div>
+
+          {/* Before vs after */}
+          <div className="bg-white border border-slate-200 rounded-2xl overflow-hidden">
+            <div className="grid grid-cols-3 text-xs font-bold uppercase tracking-wider text-slate-500 bg-slate-50 px-4 py-3 border-b border-slate-100">
+              <div>Item</div>
+              <div className="text-right">Before sacrifice</div>
+              <div className="text-right">After sacrifice</div>
+            </div>
+            {([
+              ["Taxable income", r.gross, r.gross - r.sacrifice],
+              ["Income tax + Medicare", r.taxBefore, r.taxAfter],
+              ["Take-home pay", r.takehomeBefore, r.takehomeAfter],
+              ["Super (employer SG)", r.employerSg, r.employerSg],
+              ["Super (sacrifice, gross)", 0, r.sacrifice],
+            ] as [string, number, number][]).map(([label, before, after]) => (
+              <div
+                key={label}
+                className="grid grid-cols-3 text-sm border-b border-slate-50 last:border-0 px-4 py-3"
+              >
+                <div className="text-slate-600">{label}</div>
+                <div className="text-right font-semibold text-slate-900">{fmt(before)}</div>
+                <div className={`text-right font-semibold ${after !== before ? "text-emerald-700" : "text-slate-900"}`}>
+                  {fmt(after)}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Summary breakdown */}
+          <div className="bg-white border border-slate-200 rounded-2xl p-5 space-y-2.5 text-sm">
+            <h3 className="font-bold text-slate-900 mb-1">How the saving works</h3>
+            <Row label="You sacrifice (gross, pre-tax)" value={fmt(r.sacrifice)} />
+            <Row label="Your take-home decreases by" value={fmt(-r.takehomeDelta)} dim />
+            <Row label="Income tax you save" value={fmt(r.incomeTaxSaving)} green />
+            <Row label={`Super contributions tax (${(r.superTaxRate * 100).toFixed(0)}%)`} value={`−${fmt(r.superTax)}`} dim />
+            <div className="border-t border-slate-100 pt-2.5">
+              <Row label="Net annual advantage" value={fmt(r.netGain)} bold green={r.netGain >= 0} />
+            </div>
+            <div className="pt-1 space-y-1.5 text-xs text-slate-500">
+              <div className="flex justify-between">
+                <span>Your marginal rate</span>
+                <span className="font-medium">{(r.margRate * 100).toFixed(0)}%</span>
+              </div>
+              <div className="flex justify-between">
+                <span>Concessional cap remaining</span>
+                <span className={`font-medium ${r.capRoom === 0 ? "text-amber-600" : ""}`}>
+                  {r.capRoom === 0 ? "Cap reached" : fmt(r.capRoom)}
+                </span>
+              </div>
+            </div>
+          </div>
+
+          {r.div293 && (
+            <div className="bg-blue-50 border border-blue-200 rounded-xl p-4 text-sm text-blue-800">
+              <strong>Division 293 applies.</strong> Your income + sacrifice exceeds {fmt(DIV293_THRESHOLD)}, so your
+              super contributions are taxed at 30% (not 15%). Salary sacrifice still saves you{" "}
+              {fmt(r.netGain)} per year, but the advantage per dollar is smaller.
+            </div>
+          )}
+
+          {/* CTA */}
+          <div className="bg-emerald-50 border border-emerald-200 rounded-2xl p-5">
+            <p className="text-sm font-semibold text-emerald-900 mb-1">
+              Maximise your concessional contributions strategy
+            </p>
+            <p className="text-xs text-emerald-700 mb-3">
+              A financial adviser can combine salary sacrifice with carry-forward unused cap, personal deductible
+              contributions, and spouse contributions for your situation.
+            </p>
+            <Link
+              href="/advisors/financial-planners"
+              className="inline-block bg-emerald-600 text-white text-sm font-semibold px-4 py-2 rounded-lg hover:bg-emerald-700 transition-colors"
+            >
+              Find a Financial Adviser
+            </Link>
+          </div>
+        </div>
+      )}
+
+      <p className="text-xs text-slate-400 leading-relaxed">{GENERAL_ADVICE_WARNING}</p>
+    </div>
+  );
+}
+
+function Row({
+  label,
+  value,
+  dim,
+  green,
+  bold,
+}: {
+  label: string;
+  value: string;
+  dim?: boolean;
+  green?: boolean;
+  bold?: boolean;
+}) {
+  return (
+    <div className="flex justify-between">
+      <span className={dim ? "text-slate-400" : "text-slate-600"}>{label}</span>
+      <span
+        className={[
+          bold ? "font-bold" : "font-semibold",
+          green ? "text-emerald-700" : dim ? "text-slate-400" : "text-slate-900",
+        ].join(" ")}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}

--- a/app/tools/salary-sacrifice-optimiser/page.tsx
+++ b/app/tools/salary-sacrifice-optimiser/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { Suspense } from "react";
 import { CURRENT_YEAR, breadcrumbJsonLd, SITE_URL } from "@/lib/seo";
-import { calculatorJsonLd, faqJsonLd } from "@/lib/schema-markup";
+import { calculatorJsonLd, faqJsonLd, type FaqItem } from "@/lib/schema-markup";
 import SalarySacrificeOptimiserClient from "./SalarySacrificeOptimiserClient";
 
 export const revalidate = 3600;
@@ -32,7 +32,7 @@ const calcLd = calculatorJsonLd({
   path: "/tools/salary-sacrifice-optimiser",
 });
 
-const faqLd = faqJsonLd([
+const FAQS: FaqItem[] = [
   {
     q: "How does salary sacrifice into super reduce my tax?",
     a: "Salary sacrifice redirects part of your pre-tax salary into super before income tax is applied. That amount is taxed at 15% inside super rather than at your marginal rate (19%, 32.5%, 37%, or 45% + Medicare). The difference is your tax saving. For example, at a 37% marginal rate, a $10,000 sacrifice saves $2,200 per year in income tax (37% less 15% = 22% saving).",
@@ -53,7 +53,9 @@ const faqLd = faqJsonLd([
     q: "Can I use carry-forward unused cap to sacrifice more than $30,000?",
     a: "Yes, if your total super balance was under $500,000 at 30 June last year, you can carry forward up to 5 years of unused concessional cap. This allows a one-off sacrifice larger than $30,000 in a single year. The calculator shows the standard $30,000 annual cap; a financial adviser can model your carry-forward entitlement.",
   },
-]);
+];
+
+const faqLd = faqJsonLd(FAQS);
 
 export default function SalarySacrificeOptimiserPage() {
   return (
@@ -101,10 +103,10 @@ export default function SalarySacrificeOptimiserPage() {
             Frequently asked questions
           </h2>
           <div className="space-y-5">
-            {faqLd.mainEntity.map((faq: { name: string; acceptedAnswer: { text: string } }) => (
-              <div key={faq.name}>
-                <h3 className="text-sm font-bold text-slate-900 mb-1">{faq.name}</h3>
-                <p className="text-sm text-slate-600 leading-relaxed">{faq.acceptedAnswer.text}</p>
+            {FAQS.map((faq) => (
+              <div key={faq.q}>
+                <h3 className="text-sm font-bold text-slate-900 mb-1">{faq.q}</h3>
+                <p className="text-sm text-slate-600 leading-relaxed">{faq.a}</p>
               </div>
             ))}
           </div>

--- a/app/tools/salary-sacrifice-optimiser/page.tsx
+++ b/app/tools/salary-sacrifice-optimiser/page.tsx
@@ -1,0 +1,115 @@
+import type { Metadata } from "next";
+import { Suspense } from "react";
+import { CURRENT_YEAR, breadcrumbJsonLd, SITE_URL } from "@/lib/seo";
+import { calculatorJsonLd, faqJsonLd } from "@/lib/schema-markup";
+import SalarySacrificeOptimiserClient from "./SalarySacrificeOptimiserClient";
+
+export const revalidate = 3600;
+
+export const metadata: Metadata = {
+  title: `Salary Sacrifice Optimiser (${CURRENT_YEAR}) — Calculate Your Super Tax Saving`,
+  description:
+    "Calculate the real dollar benefit of salary sacrificing into super. Shows income tax saving, 15% contributions tax, Division 293 impact, and net annual advantage. FY2025-26 Australian tax rates.",
+  alternates: { canonical: `${SITE_URL}/tools/salary-sacrifice-optimiser` },
+  openGraph: {
+    title: `Salary Sacrifice Optimiser (${CURRENT_YEAR})`,
+    description:
+      "How much will salary sacrifice actually save you? Enter your salary and sacrifice amount for a before/after comparison using FY2025-26 tax rates.",
+    url: `${SITE_URL}/tools/salary-sacrifice-optimiser`,
+  },
+};
+
+const breadcrumbLd = breadcrumbJsonLd([
+  { name: "Home", url: "/" },
+  { name: "Tools", url: "/tools" },
+  { name: "Salary Sacrifice Optimiser", url: "/tools/salary-sacrifice-optimiser" },
+]);
+
+const calcLd = calculatorJsonLd({
+  name: "Salary Sacrifice Optimiser",
+  description:
+    "Calculate the tax benefit of salary sacrificing into superannuation. Shows income tax saving, contributions tax (15% or 30% for Division 293), and net annual advantage using FY2025-26 Australian tax rates.",
+  path: "/tools/salary-sacrifice-optimiser",
+});
+
+const faqLd = faqJsonLd([
+  {
+    q: "How does salary sacrifice into super reduce my tax?",
+    a: "Salary sacrifice redirects part of your pre-tax salary into super before income tax is applied. That amount is taxed at 15% inside super rather than at your marginal rate (19%, 32.5%, 37%, or 45% + Medicare). The difference is your tax saving. For example, at a 37% marginal rate, a $10,000 sacrifice saves $2,200 per year in income tax (37% less 15% = 22% saving).",
+  },
+  {
+    q: "What is the concessional contributions cap?",
+    a: "The concessional (before-tax) cap is $30,000 per financial year in FY2025-26. It includes your employer's Superannuation Guarantee (11.5% in FY2025-26) and any salary sacrifice amounts. Excess concessional contributions are included in your taxable income and taxed at your marginal rate, with an interest charge from the ATO.",
+  },
+  {
+    q: "What is Division 293 tax?",
+    a: "Division 293 is an extra 15% tax on concessional contributions for people with income above $250,000 (income plus concessional contributions combined). It brings the effective tax rate on super contributions to 30%. Salary sacrifice is still worthwhile at the 45% or 47% marginal rates — you save 15-17 cents per dollar — but the advantage is smaller than for middle-income earners.",
+  },
+  {
+    q: "Does salary sacrifice reduce my take-home pay by the full sacrifice amount?",
+    a: "No. Your take-home pay falls by less than the sacrifice amount because you save income tax on the sacrifice. For example, at a 32.5% marginal rate, sacrificing $10,000 only costs you $6,750 in take-home pay — the remaining $3,250 was income tax you would have paid anyway. The employer then pays the 15% contributions tax from the super fund, so the fund receives $8,500 net.",
+  },
+  {
+    q: "Can I use carry-forward unused cap to sacrifice more than $30,000?",
+    a: "Yes, if your total super balance was under $500,000 at 30 June last year, you can carry forward up to 5 years of unused concessional cap. This allows a one-off sacrifice larger than $30,000 in a single year. The calculator shows the standard $30,000 annual cap; a financial adviser can model your carry-forward entitlement.",
+  },
+]);
+
+export default function SalarySacrificeOptimiserPage() {
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(calcLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }}
+      />
+
+      <div className="container-custom max-w-2xl py-8">
+        <nav className="text-sm text-slate-400 mb-6 flex gap-1.5 flex-wrap">
+          <a href="/" className="hover:text-slate-600">Home</a>
+          <span>›</span>
+          <a href="/tools" className="hover:text-slate-600">Tools</a>
+          <span>›</span>
+          <span className="text-slate-600">Salary Sacrifice Optimiser</span>
+        </nav>
+
+        <header className="mb-8">
+          <p className="text-xs font-bold uppercase tracking-wider text-emerald-600 mb-2">Calculator · FY2025-26</p>
+          <h1 className="text-3xl font-extrabold text-slate-900 mb-2">
+            Salary Sacrifice Optimiser
+          </h1>
+          <p className="text-slate-500 text-base">
+            See exactly how much you save (and keep) when you redirect pre-tax salary into super.
+            Uses FY2025-26 tax rates including Division 293 for high earners.
+          </p>
+        </header>
+
+        <Suspense>
+          <SalarySacrificeOptimiserClient />
+        </Suspense>
+
+        {/* FAQ */}
+        <section className="mt-12">
+          <h2 className="text-xl font-bold text-slate-900 mb-4">
+            Frequently asked questions
+          </h2>
+          <div className="space-y-5">
+            {faqLd.mainEntity.map((faq: { name: string; acceptedAnswer: { text: string } }) => (
+              <div key={faq.name}>
+                <h3 className="text-sm font-bold text-slate-900 mb-1">{faq.name}</h3>
+                <p className="text-sm text-slate-600 leading-relaxed">{faq.acceptedAnswer.text}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

Co-ships BB-02 (salary-sacrifice optimiser) and BB-03 (CGT calculator) from the BB calculator-farm stream.

**BB-02: `/tools/salary-sacrifice-optimiser`** (new page)
- Full quantitative calculator, distinct from the existing `/tools/salary-sacrifice` decision tree (which only answers yes/no)
- FY2025-26 tax brackets (19/32.5/37/45%) + Medicare
- Computes income tax saving, 15% contributions tax (30% for Division 293 above $250k), net annual advantage, take-home before/after comparison
- Concessional cap enforcement ($30k): auto-caps sacrifice at cap − employer SG, with amber warning
- Division 293 detection with contextual callout
- CTA → `/advisors/financial-planners`

**BB-03: `/tools/cgt-calculator`** (new page)
- Full purchase→sale flow, distinct from `/cgt-calculator` which only takes a pre-computed gain amount
- Inputs: purchase price, sale price, purchase/sale costs (stamp duty, brokerage), 12-month hold toggle, income preset (for marginal rate), asset type (shares/property/crypto/other)
- Applies 50% CGT discount for 12-month hold
- Shows gross gain, taxable gain, CGT owed (using stacked marginal rate on income + gain), effective rate, net profit
- Side-by-side discount impact: tax with vs without 12-month hold, plus "holding until 12 months saves $X" callout
- Asset-specific contextual notes (property: 6-year rule / main residence; crypto: ATO treatment / FIFO)
- CTA → `/advisors/tax-agents`

**Both pages:** `GENERAL_ADVICE_WARNING` footer, breadcrumb JSON-LD, `calculatorJsonLd` + `faqJsonLd` structured data, `revalidate = 3600`, `<Suspense>` wrapper for client components.

**`app/sitemap.ts`:** +2 entries (`/tools/salary-sacrifice-optimiser`, `/tools/cgt-calculator`).

## Supersedes

_None._

## Tracking

Closes BB-02 (salary-sacrifice optimiser) and BB-03 (CGT calculator).
DEFAULTS.md priority slot 45.
Audit ref: `docs/audits/codebase-health-2026-04-24.md`

https://claude.ai/code/session_01XETmsxQD8TcVEw5vM3D41N

---
_Generated by [Claude Code](https://claude.ai/code/session_01XETmsxQD8TcVEw5vM3D41N)_