### PR TITLE
test: cover RouteLoadingSkeleton + ComparisonTableSkeleton

### DIFF
--- a/__tests__/components/ComparisonTableSkeleton.test.tsx
+++ b/__tests__/components/ComparisonTableSkeleton.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { render } from "./setup";
+import ComparisonTableSkeleton from "@/components/ComparisonTableSkeleton";
+
+describe("ComparisonTableSkeleton", () => {
+  it("renders a header strip with 5 column placeholders", () => {
+    const { container } = render(<ComparisonTableSkeleton />);
+    // First "row" inside the bordered card is the header strip.
+    const headerStrip = container.querySelector(".bg-slate-50");
+    expect(headerStrip).not.toBeNull();
+    expect(headerStrip?.querySelectorAll("div")).toHaveLength(5);
+  });
+
+  it("renders 4 row placeholders below the header", () => {
+    const { container } = render(<ComparisonTableSkeleton />);
+    // Each row sits inside a border-t-100 div.
+    const rows = container.querySelectorAll(".border-t");
+    expect(rows).toHaveLength(4);
+  });
+
+  it("animates the placeholder with .animate-pulse on the outer wrapper", () => {
+    const { container } = render(<ComparisonTableSkeleton />);
+    expect(container.firstElementChild?.className).toContain("animate-pulse");
+  });
+});

--- a/__tests__/components/RouteLoadingSkeleton.test.tsx
+++ b/__tests__/components/RouteLoadingSkeleton.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { render } from "./setup";
+import RouteLoadingSkeleton from "@/components/RouteLoadingSkeleton";
+
+describe("RouteLoadingSkeleton", () => {
+  it("renders six placeholder bars", () => {
+    const { container } = render(<RouteLoadingSkeleton />);
+    // 1 title + 4 line bars + 1 big block (h-40) = 6 total
+    const bars = container.querySelectorAll(".animate-pulse");
+    expect(bars).toHaveLength(6);
+  });
+
+  it("exposes the loading state to assistive tech via aria-live and aria-busy", () => {
+    const { container } = render(<RouteLoadingSkeleton />);
+    const region = container.querySelector("[aria-live]");
+    expect(region).not.toBeNull();
+    expect(region).toHaveAttribute("aria-live", "polite");
+    expect(region).toHaveAttribute("aria-busy", "true");
+  });
+
+  it("centres the skeleton vertically with min-h-[60vh]", () => {
+    const { container } = render(<RouteLoadingSkeleton />);
+    expect(container.firstElementChild?.className).toContain("min-h-[60vh]");
+  });
+});


### PR DESCRIPTION
## Summary
- 6 unit tests across two new test files for the small loading placeholders.

| Component | Tests | Covers |
|---|---|---|
| `RouteLoadingSkeleton` | 3 | 6 placeholder bars, `aria-live="polite"` + `aria-busy="true"`, 60vh min height |
| `ComparisonTableSkeleton` | 3 | 5-column header strip, 4 row placeholders, `animate-pulse` wrapper |

## Test plan
- [x] `npx vitest run __tests__/components/RouteLoadingSkeleton.test.tsx __tests__/components/ComparisonTableSkeleton.test.tsx` → 6/6 passing locally.

https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk)_