### PR TITLE
test: cover ServiceWorkerRegistrar gating

### DIFF
--- a/__tests__/components/ServiceWorkerRegistrar.test.tsx
+++ b/__tests__/components/ServiceWorkerRegistrar.test.tsx
@@ -1,0 +1,102 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
+import { render } from "./setup";
+import ServiceWorkerRegistrar from "@/components/ServiceWorkerRegistrar";
+
+type SWGlobal = {
+  serviceWorker?: { register: ReturnType<typeof vi.fn> };
+};
+
+const registerMock = vi.fn().mockResolvedValue(undefined);
+
+function setHostname(hostname: string) {
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: { ...window.location, hostname },
+  });
+}
+
+function installSwOnNavigator() {
+  (navigator as unknown as SWGlobal).serviceWorker = {
+    register: registerMock,
+  };
+}
+
+function removeSwFromNavigator() {
+  delete (navigator as unknown as SWGlobal).serviceWorker;
+}
+
+beforeEach(() => {
+  registerMock.mockClear();
+  registerMock.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  removeSwFromNavigator();
+  vi.unstubAllEnvs();
+  setHostname("localhost");
+});
+
+describe("ServiceWorkerRegistrar", () => {
+  it("returns null and renders nothing in the DOM", () => {
+    const { container } = render(<ServiceWorkerRegistrar />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("does NOT register when navigator.serviceWorker is unsupported", () => {
+    removeSwFromNavigator();
+    setHostname("invest.com.au");
+    render(<ServiceWorkerRegistrar />);
+    expect(registerMock).not.toHaveBeenCalled();
+  });
+
+  it("skips registration on localhost by default", () => {
+    installSwOnNavigator();
+    setHostname("localhost");
+    vi.stubEnv("NEXT_PUBLIC_ENABLE_SW_LOCAL", "");
+    render(<ServiceWorkerRegistrar />);
+    expect(registerMock).not.toHaveBeenCalled();
+  });
+
+  it("skips registration on 127.0.0.1 by default", () => {
+    installSwOnNavigator();
+    setHostname("127.0.0.1");
+    vi.stubEnv("NEXT_PUBLIC_ENABLE_SW_LOCAL", "");
+    render(<ServiceWorkerRegistrar />);
+    expect(registerMock).not.toHaveBeenCalled();
+  });
+
+  it("registers on localhost when NEXT_PUBLIC_ENABLE_SW_LOCAL=1", () => {
+    installSwOnNavigator();
+    setHostname("localhost");
+    vi.stubEnv("NEXT_PUBLIC_ENABLE_SW_LOCAL", "1");
+    // readyState in jsdom is "complete" — register fires immediately.
+    render(<ServiceWorkerRegistrar />);
+    expect(registerMock).toHaveBeenCalledTimes(1);
+    expect(registerMock).toHaveBeenCalledWith("/sw.js", { scope: "/" });
+  });
+
+  it("registers on production hostnames", () => {
+    installSwOnNavigator();
+    setHostname("invest.com.au");
+    render(<ServiceWorkerRegistrar />);
+    expect(registerMock).toHaveBeenCalledTimes(1);
+    expect(registerMock).toHaveBeenCalledWith("/sw.js", { scope: "/" });
+  });
+
+  it("swallows a register() rejection without throwing", async () => {
+    installSwOnNavigator();
+    setHostname("invest.com.au");
+    registerMock.mockRejectedValueOnce(new Error("boom"));
+    expect(() => render(<ServiceWorkerRegistrar />)).not.toThrow();
+    // Flush microtasks so the .catch() runs.
+    await Promise.resolve();
+    expect(registerMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- 7 unit tests for `components/ServiceWorkerRegistrar.tsx`.
- Coverage: null DOM render, no-op when `navigator.serviceWorker` is unsupported, dev-skip on `localhost` / `127.0.0.1` by default, the `NEXT_PUBLIC_ENABLE_SW_LOCAL=1` override path, the production `register("/sw.js", { scope: "/" })` call, and graceful swallow of a `register()` rejection.

## Test plan
- [x] `npx vitest run __tests__/components/ServiceWorkerRegistrar.test.tsx` → 7/7 passing locally.

https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1hmsLvnHGtCTcwuAW5ynk)_