### PR TITLE
feat(z27): Z-27 — /tax-return hub (seasonal accountant lead gen) [audit remediation]

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1029,5 +1029,13 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     priority: 0.65,
   }));
 
-  return [...staticPages, ...localizedPages, ...bestPages, ...bestForPages, ...commodityPages, ...stockDetailPages, ...transferGuidePages, ...costPages, ...brokerPages, ...articlePages, ...scenarioPages, ...authorPages, ...reviewerPages, ...alertPages, ...reportPages, ...versusPages, ...howToPages, ...expertArticlePages, ...advisorPages, ...advisorTypePages, ...advisorStatePages, ...advisorCityPages, ...advisorLocationPages, ...investingCityPages, ...glossaryPages, ...firmPages, ...propertyListingPages, ...suburbGuidePages, ...propertyHubPages, ...newHubPages, newsletterArchivePage, ...newsletterEditionPages, ...investStaticPages, ...investCategoryPages, ...investSubcategoryPages, ...investListingPages, ...stockbrokerFirmPages, ...quoteJobPages, ...quoteCategoryStatePages, marketplaceHubPage, ...marketplaceIntentPages, ...marketplaceIntentStatePages, testimonialsPage, ...grantsIndustryPages, ...grantsStateProgramPages, investingForIndexPage, ...investingForPages];
+  // ── Z-27: /tax-return hub (seasonal June–October) ──
+  const taxReturnHubPage = {
+    url: `${baseUrl}/tax-return`,
+    lastModified: new Date(),
+    changeFrequency: "weekly" as const,
+    priority: 0.82,
+  };
+
+  return [...staticPages, ...localizedPages, ...bestPages, ...bestForPages, ...commodityPages, ...stockDetailPages, ...transferGuidePages, ...costPages, ...brokerPages, ...articlePages, ...scenarioPages, ...authorPages, ...reviewerPages, ...alertPages, ...reportPages, ...versusPages, ...howToPages, ...expertArticlePages, ...advisorPages, ...advisorTypePages, ...advisorStatePages, ...advisorCityPages, ...advisorLocationPages, ...investingCityPages, ...glossaryPages, ...firmPages, ...propertyListingPages, ...suburbGuidePages, ...propertyHubPages, ...newHubPages, newsletterArchivePage, ...newsletterEditionPages, ...investStaticPages, ...investCategoryPages, ...investSubcategoryPages, ...investListingPages, ...stockbrokerFirmPages, ...quoteJobPages, ...quoteCategoryStatePages, marketplaceHubPage, ...marketplaceIntentPages, ...marketplaceIntentStatePages, testimonialsPage, ...grantsIndustryPages, ...grantsStateProgramPages, investingForIndexPage, ...investingForPages, taxReturnHubPage];
 }

--- a/app/tax-return/page.tsx
+++ b/app/tax-return/page.tsx
@@ -1,0 +1,98 @@
+import type { Metadata } from "next";
+import { SITE_URL, CURRENT_YEAR } from "@/lib/seo";
+import HubPage from "@/components/HubPage";
+import HubNewsletterCapture from "@/components/HubNewsletterCapture";
+import { taxReturnHubConfig } from "@/lib/hub-configs/tax-return";
+import Link from "next/link";
+
+export const revalidate = 3600;
+
+export const metadata: Metadata = {
+  title: taxReturnHubConfig.title,
+  description: taxReturnHubConfig.metaDescription,
+  alternates: { canonical: `${SITE_URL}/tax-return` },
+  openGraph: {
+    title: `Tax Return Hub (${CURRENT_YEAR}) — Deductions, Agents & Investment Income`,
+    description: taxReturnHubConfig.metaDescription,
+    url: `${SITE_URL}/tax-return`,
+  },
+};
+
+export default function TaxReturnPage() {
+  return (
+    <HubPage
+      config={taxReturnHubConfig}
+      newsletterCapture={
+        <HubNewsletterCapture
+          segmentSlug="tax-return-hub"
+          hubTitle="Tax Return"
+        />
+      }
+    >
+      {/* Key dates callout */}
+      <section className="py-10 border-t border-slate-200 bg-amber-50">
+        <div className="container-custom max-w-6xl">
+          <h2 className="text-xl font-bold text-slate-900 mb-4">
+            FY2025-26 key dates
+          </h2>
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            {[
+              {
+                date: "1 Jul 2025",
+                label: "FY2025-26 opens",
+                note: "ATO opens myTax for current-year lodgements",
+              },
+              {
+                date: "31 Oct 2025",
+                label: "Individual deadline",
+                note: "Lodgement due for individuals without a tax agent",
+              },
+              {
+                date: "15 May 2026",
+                label: "Tax agent deadline",
+                note: "Extended deadline for clients of registered tax agents",
+              },
+            ].map(({ date, label, note }) => (
+              <div
+                key={date}
+                className="bg-white border border-amber-200 rounded-xl p-4"
+              >
+                <p className="text-base font-bold text-amber-700 mb-1">{date}</p>
+                <p className="text-sm font-semibold text-slate-900">{label}</p>
+                <p className="text-xs text-slate-500 mt-1">{note}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Quick-access topic links */}
+      <section className="py-10 border-t border-slate-200">
+        <div className="container-custom max-w-6xl">
+          <h2 className="text-xl font-bold text-slate-900 mb-4">
+            Tax topics by investor type
+          </h2>
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+            {[
+              { label: "Shares & ETFs", href: "/tax/capital-gains", badge: "CGT + franking" },
+              { label: "Property Investors", href: "/negative-gearing", badge: "Rental deductions" },
+              { label: "Crypto", href: "/tax/crypto", badge: "ATO rules" },
+              { label: "SMSF Trustees", href: "/smsf", badge: "15% fund tax" },
+              { label: "Freelancers / ABN", href: "/investing-for/freelancer", badge: "Sole trader tax" },
+              { label: "Tax Agent Guide", href: "/advisor-guides/tax-agent-vs-accountant", badge: "DIY vs agent" },
+            ].map(({ label, href, badge }) => (
+              <Link
+                key={href}
+                href={href}
+                className="flex flex-col gap-1 p-4 bg-white border border-slate-200 rounded-xl hover:border-amber-300 hover:shadow-sm transition-all"
+              >
+                <span className="text-sm font-semibold text-slate-900">{label}</span>
+                <span className="text-xs text-slate-500">{badge}</span>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </section>
+    </HubPage>
+  );
+}

--- a/lib/hub-configs/tax-return.ts
+++ b/lib/hub-configs/tax-return.ts
@@ -1,0 +1,205 @@
+import { CURRENT_YEAR } from "@/lib/seo";
+import type { HubConfig } from "@/lib/verticals";
+
+export const taxReturnHubConfig: HubConfig = {
+  slug: "tax-return",
+  title: `Tax Return Hub Australia (${CURRENT_YEAR}) — Deductions, Lodgement & Accountants`,
+  metaDescription:
+    "Australia's tax return hub: work-related deductions, investment income, rental property claims, the 67¢/hr WFH rate, and when a tax agent pays for itself. Independent guides updated for FY2025-26.",
+  audiences: ["founder"],
+  complianceKey: "general_advice",
+
+  hero: {
+    headline: "Tax Return Hub",
+    subhead:
+      "The Australian tax year runs 1 July to 30 June. Individual lodgement is due 31 October; a registered tax agent extends your deadline to 15 May. This hub covers every major deduction category, investment income claims, and when to pay for professional help — with real numbers, not generalities.",
+    stats: [
+      {
+        label: "Average Australian tax refund",
+        value: "$2,817",
+        dataAsOf: "2023-07-01",
+        stalesAt: "2026-07-01",
+        source:
+          "https://www.ato.gov.au/about-ato/research-and-statistics/in-detail/taxation-statistics/taxation-statistics-2022-23/",
+      },
+      {
+        label: "WFH fixed rate (cents per hour)",
+        value: "67¢",
+        dataAsOf: "2023-07-01",
+        stalesAt: "2026-07-01",
+        source:
+          "https://www.ato.gov.au/individuals-and-families/income-deductions-offsets-and-records/deductions-you-can-claim/working-from-home-expenses",
+      },
+      {
+        label: "Individual lodgement deadline",
+        value: "31 Oct",
+        dataAsOf: "2025-07-01",
+        stalesAt: "2026-07-01",
+        source:
+          "https://www.ato.gov.au/individuals-and-families/lodging-your-tax-return/when-to-lodge",
+      },
+    ],
+    primaryCta: {
+      label: "Find a Tax Accountant",
+      href: "/advisors/tax-accountants",
+      lever: "lead_routing",
+    },
+    secondaryCta: {
+      label: "Tax Optimiser",
+      href: "/tax-optimizer",
+      lever: "lead_routing",
+    },
+  },
+
+  serviceGrid: [
+    {
+      title: "Work-Related Deductions",
+      icon: "briefcase",
+      description:
+        "Claim uniforms, tools, professional memberships, self-education (if work-related), and home office costs. Must be directly related to earning your income — not reimbursed by your employer and you need records.",
+      href: "/tax",
+      cta: "Deductions Guide",
+    },
+    {
+      title: "Working From Home",
+      icon: "home",
+      description:
+        "The ATO's revised fixed rate is 67¢ per work-from-home hour, covering electricity, gas, internet, phone, and stationery. Keep a diary for 4 weeks to justify your full-year claim. Depreciation on equipment claimed separately.",
+      href: "/tax",
+      cta: "WFH Methods Explained",
+    },
+    {
+      title: "Investment Income",
+      icon: "trending-up",
+      description:
+        "Dividends (including franking credits), interest, managed fund distributions, and CGT events from share or property sales all belong in your return. Brokerage statements and CHESS holdings reports make it manageable.",
+      href: "/tax/capital-gains",
+      cta: "Investment Tax Guide",
+    },
+    {
+      title: "Rental Property",
+      icon: "building-2",
+      description:
+        "Claim interest on investment loans, rates, agent fees, repairs, and depreciation. Negative gearing losses reduce your taxable income. The ATO's Rental Properties guide is updated each financial year — use the current edition.",
+      href: "/negative-gearing",
+      cta: "Rental Deductions Guide",
+    },
+    {
+      title: "Cryptocurrency",
+      icon: "database",
+      description:
+        "Every disposal of crypto is a CGT event — selling, trading one coin for another, and using crypto to buy goods. The ATO receives data from Australian exchanges. Proper records from day one make lodgement straightforward.",
+      href: "/tax/crypto",
+      cta: "Crypto Tax Guide",
+    },
+    {
+      title: "Tax Agents & Lodgement",
+      icon: "file-text",
+      description:
+        "A registered tax agent extends your lodgement deadline from 31 October to 15 May. For investors with multiple income sources, CGT events, or rental properties, their fee is typically tax-deductible and saves more than it costs.",
+      href: "/advisor-guides/tax-agent-vs-accountant",
+      cta: "Agent vs DIY",
+    },
+  ],
+
+  deepDives: [
+    {
+      title: `Work-Related Deductions Checklist — FY${CURRENT_YEAR}`,
+      excerpt:
+        "From home office to car to uniforms — what the ATO requires for each deduction category, how much you can claim without receipts ($300 threshold), and which deductions are commonly missed.",
+      href: "/tax",
+      readingTimeMinutes: 8,
+    },
+    {
+      title: "CGT and Your Tax Return: Shares, Property & Crypto",
+      excerpt:
+        "When to report capital gains, how the 50% discount applies after 12 months, tax-loss harvesting before 30 June, and how to handle CGT events from ETF distributions.",
+      href: "/tax/capital-gains",
+      readingTimeMinutes: 10,
+    },
+    {
+      title: "Negative Gearing and Your Tax Return",
+      excerpt:
+        "How rental property losses reduce your taxable income, what the ATO classifies as allowable deductions vs capital costs, and the depreciation schedule rules that change in 2025.",
+      href: "/negative-gearing",
+      readingTimeMinutes: 7,
+    },
+    {
+      title: "When Does a Tax Agent Pay for Itself?",
+      excerpt:
+        "Average accountant fee vs average refund uplift — how to calculate whether professional lodgement is worth the cost for your situation, and what to look for in a tax specialist for investors.",
+      href: "/advisor-guides/tax-agent-vs-accountant",
+      readingTimeMinutes: 5,
+    },
+  ],
+
+  calculators: [
+    { slug: "withholding-tax-calculator", label: "Withholding Tax Calculator" },
+  ],
+
+  newsletter: {
+    listKey: "tax-return-hub",
+    cadence: "monthly",
+  },
+
+  leadQueue: { kind: "general", topic: "tax" },
+
+  relatedHubs: ["tax", "negative-gearing", "crypto", "redundancy"],
+
+  articleFilters: {
+    category: "tax",
+    tags: [
+      "tax-return",
+      "deductions",
+      "work-from-home",
+      "negative-gearing",
+      "cgt",
+      "rental-property",
+    ],
+  },
+
+  primaryKeywords: [
+    "tax return australia",
+    "tax deductions australia",
+    "work from home tax deduction australia",
+    "investment property tax deductions",
+    "how to lodge tax return australia",
+    "tax agent australia",
+    "capital gains tax return",
+  ],
+
+  schemaTypes: ["FAQPage", "WebPage", "FinancialService"],
+
+  faqs: [
+    {
+      question: "When is the tax return lodgement deadline in Australia?",
+      answer:
+        "For individuals lodging their own tax return via myTax, the deadline is 31 October each year. If you engage a registered tax agent, your deadline automatically extends to 15 May the following year — but you must be registered with the agent before 31 October. Penalties for late lodgement start at $330 per 28-day period (up to $1,650).",
+    },
+    {
+      question: "What work-related deductions can I claim without receipts?",
+      answer:
+        "The ATO allows claims of up to $300 in work-related expenses without receipts — but you must still be able to show how you calculated the amount, and the expenses must be genuine work costs. Above $300, receipts or bank statements are required. Note: the $300 is a receipt threshold, not a deduction cap — you can claim more with evidence.",
+    },
+    {
+      question: "How do I claim working from home expenses?",
+      answer:
+        "There are two methods: (1) Fixed rate — 67 cents per work-from-home hour, covering running costs including electricity, internet, and phone. You need a diary or timesheet for at least 4 representative weeks. (2) Actual cost — calculate the real cost of each expense based on your work use percentage. The fixed rate is simpler; actual cost can produce a larger claim for high electricity users. You cannot claim occupancy expenses (rent or mortgage interest) unless your home is a place of business.",
+    },
+    {
+      question: "Do I need to declare dividend income on my tax return?",
+      answer:
+        "Yes — all Australian dividend income, including franking credits, must be declared. Your broker or the company's share registry will send you a dividend statement. The ATO pre-fills this data from exchange reports, but you should check it's complete before lodging. Franking credits reduce the tax you owe — if your tax rate is lower than 30%, the excess franking credit may be refunded to you.",
+    },
+    {
+      question: "How are capital gains taxed in Australia?",
+      answer:
+        "Capital gains from selling assets are included in your assessable income and taxed at your marginal rate. If you held the asset for more than 12 months, you receive a 50% CGT discount — only half the gain is taxable. Capital losses can only be used to offset capital gains (not other income). CGT events from shares, property, ETFs, and cryptocurrency all need to be reported in the relevant financial year's return.",
+    },
+    {
+      question: "Is it worth using a tax agent for an investor's return?",
+      answer:
+        "Generally yes, if you have investment income, rental properties, CGT events, or work-related deductions above $300. The average ATO refund is around $2,800; a tax agent's fee is typically $200–$600 for an individual return. Their fee is tax-deductible (claimable the following year), and they often identify deductions that reduce your tax liability by more than their fee. For simple income-only returns with no investments, myTax is straightforward and free.",
+    },
+  ],
+};


### PR DESCRIPTION
## Summary

Z-27 from the audit remediation queue — `/tax-return` top-level hub, targeting the June–October Australian tax return season. Primary monetisation: accountant lead generation.

### Hub config (`lib/hub-configs/tax-return.ts`)

- **3 hero stats:** average $2,817 refund (ATO 2022-23), 67¢/hr WFH fixed rate, 31 Oct individual deadline — all dated with `dataAsOf`/`stalesAt`/`source`
- **6 service cards:** WFH expenses, work-related deductions, investment income, rental property, cryptocurrency, tax agents & lodgement
- **4 deep-dives:** deductions checklist, CGT + tax return, negative gearing + tax return, when a tax agent pays for itself
- **Calculator:** withholding-tax-calculator
- **6 FAQs:** lodgement deadline, $300 receipt threshold, WFH methods, dividend income declaration, CGT rates, agent value
- **Lead queue:** `general/tax` → accountant routing
- **Newsletter:** `tax-return-hub` cadence monthly
- **Related hubs:** tax, negative-gearing, crypto, redundancy

### Page (`app/tax-return/page.tsx`)

- HubPage HOC (W-12 pattern)
- FY2025-26 key-dates callout strip (amber) — 1 Jul / 31 Oct / 15 May
- Investor-type quick-access grid (shares/ETFs, property, crypto, SMSF, freelancers, agent guide)
- `revalidate = 3600`

### Sitemap

- `/tax-return` at priority 0.82, `changeFrequency: "weekly"` (seasonal)

## Supersedes

_None._

## Audit ref

`docs/audits/REMEDIATION_QUEUE.md` slot 49 — Z-27.

https://claude.ai/code/session_01XETmsxQD8TcVEw5vM3D41N

---
_Generated by [Claude Code](https://claude.ai/code/session_01XETmsxQD8TcVEw5vM3D41N)_