### PR TITLE
feat(dd): DD-04 — real-time advisor bidding auction model [audit remediation]

### DIFF
--- a/app/api/cron/auction-close/route.ts
+++ b/app/api/cron/auction-close/route.ts
@@ -1,0 +1,219 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { requireCronAuth } from "@/lib/cron-auth";
+import { logger } from "@/lib/logger";
+import { sendEmail } from "@/lib/resend";
+import { SITE_URL } from "@/lib/seo";
+
+export const runtime = "nodejs";
+export const maxDuration = 60;
+
+const log = logger("cron-auction-close");
+
+const FROM = "Invest.com.au <hello@invest.com.au>";
+
+function emailWrap(title: string, body: string): string {
+  return `<div style="font-family:Arial,sans-serif;max-width:520px;margin:0 auto;color:#334155"><div style="background:#0f172a;padding:20px 24px;border-radius:12px 12px 0 0"><h1 style="color:white;margin:0;font-size:18px">${title}</h1></div><div style="background:#f8fafc;padding:24px;border:1px solid #e2e8f0;border-top:none;border-radius:0 0 12px 12px">${body}</div></div>`;
+}
+
+function btn(href: string, label: string): string {
+  return `<div style="text-align:center;margin:24px 0"><a href="${href}" style="display:inline-block;padding:12px 32px;background:#f59e0b;color:white;text-decoration:none;border-radius:8px;font-size:14px;font-weight:600">${label}</a></div>`;
+}
+
+async function sendAuctionWonEmail(
+  advisorEmail: string,
+  advisorName: string,
+  consumerName: string,
+  consumerEmail: string,
+  consumerPhone: string | null,
+  leadType: string,
+  location: string | null,
+  bidAmountCents: number,
+): Promise<void> {
+  const portalUrl = `${SITE_URL}/advisor-portal/auctions`;
+  const displayLead = leadType.replace(/_/g, " ");
+  const displayLocation = location ?? "Remote / Australia-wide";
+  const bidDisplay = `$${(bidAmountCents / 100).toFixed(2)}`;
+
+  await sendEmail({
+    from: FROM,
+    to: advisorEmail,
+    subject: `You won the auction — ${displayLead} lead in ${displayLocation}`,
+    html: emailWrap(
+      "You Won the Auction!",
+      `<p style="font-size:15px">Hi ${advisorName.split(" ")[0]},</p>
+      <p style="font-size:14px;color:#64748b">Congratulations! Your bid of <strong>${bidDisplay}</strong> won the <strong>${displayLead}</strong> lead in <strong>${displayLocation}</strong>.</p>
+      <div style="background:#fffbeb;border:1px solid #fde68a;border-radius:8px;padding:16px;margin:16px 0">
+        <p style="font-size:13px;font-weight:700;color:#0f172a;margin:0 0 10px 0">Client contact details:</p>
+        <table style="width:100%;font-size:14px;color:#334155;border-collapse:collapse">
+          <tr><td style="padding:4px 8px 4px 0;font-weight:600">Name:</td><td>${consumerName}</td></tr>
+          <tr><td style="padding:4px 8px 4px 0;font-weight:600">Email:</td><td><a href="mailto:${consumerEmail}" style="color:#2563eb">${consumerEmail}</a></td></tr>
+          ${consumerPhone ? `<tr><td style="padding:4px 8px 4px 0;font-weight:600">Phone:</td><td><a href="tel:${consumerPhone}" style="color:#2563eb">${consumerPhone}</a></td></tr>` : ""}
+        </table>
+      </div>
+      <p style="font-size:14px;color:#64748b"><strong>Please reach out within 24 hours.</strong> Quick follow-up improves your rating on Invest.com.au.</p>
+      ${btn(`mailto:${consumerEmail}?subject=Your%20enquiry%20on%20Invest.com.au`, `Email ${consumerName.split(" ")[0]} Now →`)}
+      <p style="font-size:12px;color:#94a3b8;margin-top:20px">Manage your leads in the <a href="${portalUrl}" style="color:#2563eb">advisor portal</a>.</p>`,
+    ),
+  });
+}
+
+async function sendConsumerAuctionMatchedEmail(
+  consumerEmail: string,
+  consumerName: string,
+  advisorName: string,
+  leadType: string,
+  location: string | null,
+): Promise<void> {
+  const displayLead = leadType.replace(/_/g, " ");
+  const displayLocation = location ?? "Australia-wide";
+  const findUrl = `${SITE_URL}/find`;
+
+  await sendEmail({
+    from: FROM,
+    to: consumerEmail,
+    subject: `An advisor has been matched to your ${displayLead} enquiry`,
+    html: emailWrap(
+      "Your Advisor Match is Ready",
+      `<p style="font-size:15px">Hi ${consumerName.split(" ")[0]},</p>
+      <p style="font-size:14px;color:#64748b">A qualified advisor has been matched to your <strong>${displayLead}</strong> enquiry in <strong>${displayLocation}</strong>.</p>
+      <div style="background:#f0fdf4;border:1px solid #bbf7d0;border-radius:8px;padding:16px;margin:16px 0">
+        <p style="font-size:14px;font-weight:700;color:#0f172a;margin:0 0 4px 0">${advisorName}</p>
+        <p style="font-size:13px;color:#64748b;margin:0">Matched advisor for your ${displayLead} needs</p>
+      </div>
+      <p style="font-size:14px;color:#64748b">They will reach out to you directly within 24 hours. Please keep an eye on your inbox (including spam folder).</p>
+      ${btn(findUrl, "Browse More Advisors →")}
+      <p style="font-size:12px;color:#94a3b8;margin-top:20px">This is not financial advice. <a href="${SITE_URL}/privacy" style="color:#94a3b8">Privacy Policy</a></p>`,
+    ),
+  });
+}
+
+/**
+ * GET /api/cron/auction-close
+ *
+ * Closes expired advisor auctions (status='open', ends_at < NOW(), flow_type='auction').
+ * Awards to the highest active bid; sends winner + consumer match emails.
+ * No-bid auctions are marked 'expired'.
+ *
+ * Registered in cron-groups.ts under 'every-30m' — runs every 30 minutes.
+ * Max 60s runtime handles up to ~200 expiring auctions in a single fire.
+ */
+export async function GET(req: NextRequest) {
+  const unauth = requireCronAuth(req);
+  if (unauth) return unauth;
+
+  const admin = createAdminClient();
+  const now = new Date().toISOString();
+
+  const { data: expired, error: fetchErr } = await admin
+    .from("advisor_auctions")
+    .select("id, lead_type, location, contact_name, contact_email, contact_phone, slug")
+    .eq("status", "open")
+    .eq("flow_type", "auction")
+    .lt("ends_at", now)
+    .limit(200);
+
+  if (fetchErr) {
+    log.error("Failed to fetch expired auctions", { error: fetchErr.message });
+    return NextResponse.json({ error: "fetch_failed" }, { status: 500 });
+  }
+
+  let awarded = 0;
+  let expired_count = 0;
+  let errors = 0;
+
+  for (const auction of expired ?? []) {
+    try {
+      const { data: bids } = await admin
+        .from("advisor_auction_bids")
+        .select("id, advisor_id, bid_amount")
+        .eq("auction_id", auction.id)
+        .eq("status", "active")
+        .order("bid_amount", { ascending: false })
+        .limit(50);
+
+      if (!bids || bids.length === 0) {
+        await admin
+          .from("advisor_auctions")
+          .update({ status: "expired" })
+          .eq("id", auction.id);
+        expired_count++;
+        log.info("Auction expired (no bids)", { auctionId: auction.id });
+        continue;
+      }
+
+      const winner = bids[0];
+      const loserIds = bids.slice(1).map((b: { id: number }) => b.id);
+
+      // Award auction to highest bidder
+      await admin
+        .from("advisor_auctions")
+        .update({ status: "awarded" })
+        .eq("id", auction.id);
+
+      await admin
+        .from("advisor_auction_bids")
+        .update({ status: "accepted" })
+        .eq("id", winner.id);
+
+      if (loserIds.length > 0) {
+        await admin
+          .from("advisor_auction_bids")
+          .update({ status: "expired" })
+          .in("id", loserIds);
+      }
+
+      // Fetch advisor details for winner notification
+      const { data: advisor } = await admin
+        .from("professionals")
+        .select("name, email")
+        .eq("id", winner.advisor_id)
+        .single();
+
+      if (advisor?.email && auction.contact_email) {
+        await Promise.allSettled([
+          sendAuctionWonEmail(
+            advisor.email,
+            advisor.name,
+            auction.contact_name ?? "the client",
+            auction.contact_email,
+            auction.contact_phone ?? null,
+            auction.lead_type,
+            auction.location,
+            winner.bid_amount,
+          ),
+          sendConsumerAuctionMatchedEmail(
+            auction.contact_email,
+            auction.contact_name ?? "there",
+            advisor.name,
+            auction.lead_type,
+            auction.location,
+          ),
+        ]);
+      }
+
+      awarded++;
+      log.info("Auction awarded", {
+        auctionId: auction.id,
+        winnerAdvisorId: winner.advisor_id,
+        bidAmountCents: winner.bid_amount,
+        totalBids: bids.length,
+      });
+    } catch (err) {
+      errors++;
+      log.error("Failed to close auction", {
+        auctionId: auction.id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  log.info("Auction close complete", {
+    processed: (expired ?? []).length,
+    awarded,
+    expired: expired_count,
+    errors,
+  });
+
+  return NextResponse.json({ awarded, expired: expired_count, errors });
+}

--- a/app/api/submit-lead/route.ts
+++ b/app/api/submit-lead/route.ts
@@ -731,6 +731,29 @@ export async function POST(request: NextRequest) {
       utm_source: (utm as UtmParams).utm_source ?? null,
       utm_campaign: (utm as UtmParams).utm_campaign ?? null,
     });
+
+    // Hot-lead auction trigger (DD-04): fire a 1-hour bidding window for
+    // high-intent lead types that have a phone number supplied. Non-blocking.
+    const AUCTION_ELIGIBLE_NEEDS = ["planning", "smsf", "estate", "wealth", "tax"];
+    const hasPhone = typeof user_phone === "string" && user_phone.trim().length > 6;
+    if (hasPhone && AUCTION_ELIGIBLE_NEEDS.includes(need)) {
+      const origin = process.env.VERCEL_PROJECT_PRODUCTION_URL
+        ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
+        : "http://localhost:3000";
+      fetch(`${origin}/api/advisor-auction`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-internal-secret": process.env.INTERNAL_API_SECRET ?? "",
+        },
+        body: JSON.stringify({
+          lead_id: lead.id,
+          lead_type: need,
+          location: userState,
+          budget_range: user_intent?.budget ?? null,
+        }),
+      }).catch(() => null);
+    }
   }
 
   return NextResponse.json({

--- a/lib/cron-groups.ts
+++ b/lib/cron-groups.ts
@@ -34,7 +34,7 @@ export const CRON_GROUPS: Record<string, readonly string[]> = {
     "/api/cron/lead-sla-check",
     "/api/cron/editorial-auto-publish",
   ],
-  "every-30m": ["/api/cron/heartbeat", "/api/cron/retry-webhooks"],
+  "every-30m": ["/api/cron/heartbeat", "/api/cron/retry-webhooks", "/api/cron/auction-close"],
   "every-6h": ["/api/admin/run-migration"],
 
   "daily-0": ["/api/cron/auto-publish"],


### PR DESCRIPTION
## DD-04 — Real-time advisor bidding auction model

Completes the DD marketplace stream. The auction infrastructure (tables, bid API, advisor-portal UI) was built in DD-01..DD-03, but auctions never resolved — no close cron existed, and hot-lead submission never opened a bidding window.

## Changes

- **`app/api/cron/auction-close/route.ts`** (new, 219 LOC): runs every 30 min via the `every-30m` dispatch group. For each expired open auction (`status='open'`, `ends_at < NOW()`, `flow_type='auction'`): awards to highest active bid (`'accepted'`), marks auction `'awarded'`, expires remaining bids. Sends advisor winner email (client contact details revealed) + consumer matched email. Zero-bid auctions → `'expired'`. Per-auction error isolation; handles 200 auctions per fire.
- **`lib/cron-groups.ts`**: adds `/api/cron/auction-close` to `every-30m` — no new Vercel cron slot consumed.
- **`app/api/submit-lead/route.ts`**: hot-lead auction trigger. When a lead for `planning / smsf / estate / wealth / tax` includes a phone number, fires a non-blocking POST to `/api/advisor-auction` (already guarded by `x-internal-secret`) to open a 1-hour bidding window. Fire-and-forget — does not affect lead response latency.

## Supersedes

_None._

## Tier C announcement

DD stream — announce + merge unless STOP.

Refs: #218
Audit: `docs/audits/codebase-health-2026-04-24.md` §marketplace
Queue: `docs/audits/REMEDIATION_QUEUE.md` DD-04

---
_Generated by [Claude Code](https://claude.ai/code/session_01118go8Tiu11UKhow4zBBCN)_