### PR TITLE
feat(first-home-buyer): mortgage-broker handoff with FHB-specialty filter

### DIFF
--- a/__tests__/app/advisors-filter-params.test.ts
+++ b/__tests__/app/advisors-filter-params.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { resolveDirectoryFilters } from "@/app/advisors/filter-params";
+import {
+  FHB_MORTGAGE_BROKER_SPECIALTY,
+  firstHomeBuyerBrokerDirectoryUrl,
+} from "@/lib/first-home-buyer/broker-handoff";
+
+const validType = (k: string) =>
+  ["mortgage_broker", "financial_planner", "buyers_agent"].includes(k);
+
+function parse(qs: string, routeScoped: boolean) {
+  return resolveDirectoryFilters(new URLSearchParams(qs), {
+    routeScoped,
+    validType,
+  });
+}
+
+describe("resolveDirectoryFilters", () => {
+  it("returns an empty object for no params", () => {
+    expect(parse("", false)).toEqual({});
+  });
+
+  it("reads a valid provider_type", () => {
+    expect(parse("provider_type=firm", false).providerType).toBe("firm");
+    expect(parse("provider_type=bogus", false).providerType).toBeUndefined();
+  });
+
+  it("honours the specialty param even when route-scoped", () => {
+    // The route fixes the type (e.g. /advisors/mortgage-brokers), but
+    // specialty is orthogonal — it must still pre-select the filter.
+    const result = parse("specialty=First Home Buyers", true);
+    expect(result.specialties).toEqual(["First Home Buyers"]);
+  });
+
+  it("splits, trims and drops empty specialty values", () => {
+    expect(parse("specialty=First Home Buyers,, Refinancing ", false).specialties).toEqual([
+      "First Home Buyers",
+      "Refinancing",
+    ]);
+    expect(parse("specialty=", false).specialties).toBeUndefined();
+  });
+
+  it("ignores type/state params when route-scoped", () => {
+    const result = parse("type=financial_planner&state=NSW&sort=name", true);
+    expect(result.types).toBeUndefined();
+    expect(result.state).toBeUndefined();
+    expect(result.sort).toBeUndefined();
+  });
+
+  it("reads type/state/sort/q/language when not route-scoped", () => {
+    const result = parse(
+      "type=mortgage_broker,buyers_agent&state=VIC&sort=name&q=smith&language=Mandarin",
+      false,
+    );
+    expect(result.types).toEqual(["mortgage_broker", "buyers_agent"]);
+    expect(result.state).toBe("VIC");
+    expect(result.sort).toBe("name");
+    expect(result.search).toBe("smith");
+    expect(result.language).toBe("Mandarin");
+  });
+
+  it("filters out unknown type keys and ignores invalid states", () => {
+    expect(parse("type=not_a_type", false).types).toBeUndefined();
+    expect(parse("type=mortgage_broker,not_a_type", false).types).toEqual([
+      "mortgage_broker",
+    ]);
+    expect(parse("state=ZZ", false).state).toBeUndefined();
+  });
+
+  it("resolves the First Home Buyer broker deep-link to the FHB specialty", () => {
+    const qs = firstHomeBuyerBrokerDirectoryUrl().split("?")[1] ?? "";
+    const result = resolveDirectoryFilters(new URLSearchParams(qs), {
+      routeScoped: true,
+      validType,
+    });
+    expect(result.specialties).toEqual([FHB_MORTGAGE_BROKER_SPECIALTY]);
+  });
+});

--- a/__tests__/lib/first-home-buyer/broker-handoff.test.ts
+++ b/__tests__/lib/first-home-buyer/broker-handoff.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import {
+  FHB_MORTGAGE_BROKER_SPECIALTY,
+  firstHomeBuyerBrokerDirectoryUrl,
+} from "@/lib/first-home-buyer/broker-handoff";
+import { SPECIALTIES_BY_TYPE } from "@/lib/advisor-specialties";
+
+describe("first-home-buyer broker handoff", () => {
+  it("uses a specialty that actually exists for mortgage brokers", () => {
+    // Drift guard: the directory filters with an exact specialties.includes()
+    // check, so this label must stay in the real mortgage_broker specialty set.
+    expect(SPECIALTIES_BY_TYPE.mortgage_broker).toContain(
+      FHB_MORTGAGE_BROKER_SPECIALTY,
+    );
+  });
+
+  it("deep-links to the mortgage-broker directory pre-filtered to FHB specialists", () => {
+    expect(firstHomeBuyerBrokerDirectoryUrl()).toBe(
+      "/advisors/mortgage-brokers?specialty=First+Home+Buyers",
+    );
+  });
+
+  it("encodes a specialty value the directory can round-trip back", () => {
+    const url = new URL(
+      firstHomeBuyerBrokerDirectoryUrl(),
+      "https://invest.com.au",
+    );
+    expect(url.pathname).toBe("/advisors/mortgage-brokers");
+    expect(url.searchParams.get("specialty")).toBe(
+      FHB_MORTGAGE_BROKER_SPECIALTY,
+    );
+  });
+});

--- a/app/advisors/AdvisorsClient.tsx
+++ b/app/advisors/AdvisorsClient.tsx
@@ -18,6 +18,7 @@ import { ADVISOR_SPECIALTY_CATEGORIES } from "@/lib/advisor-specialties";
 import TabBar from "@/components/directory/TabBar";
 import SearchInput from "@/components/directory/SearchInput";
 import SortDropdown from "@/components/directory/SortDropdown";
+import { resolveDirectoryFilters } from "./filter-params";
 
 export interface ExpertTeamCard {
   id: number;
@@ -322,25 +323,17 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
   }, [userLat, userLng, radius, typeFilters, feeFilter, specialtyFilters, isLocationActive]);
 
   useEffect(() => {
-    const pt = searchParams.get("provider_type");
-    if (pt === "individual" || pt === "firm" || pt === "team") setProviderType(pt);
-
-    if (initialType || initialState) return;
-    const t = searchParams.get("type");
-    const s = searchParams.get("state");
-    const sp = searchParams.get("specialty");
-    const sort = searchParams.get("sort");
-    const q = searchParams.get("q");
-    const lang = searchParams.get("language");
-    if (t) {
-      const types = t.split(",").filter(v => TYPE_FILTERS.some(f => f.key === v)) as ProfessionalType[];
-      if (types.length > 0) setTypeFilters(new Set(types));
-    }
-    if (s && AU_STATES.includes(s as typeof AU_STATES[number])) setStateFilter(s);
-    if (sp) setSpecialtyFilters(sp.split(","));
-    if (sort) setSortBy(sort as SortKey);
-    if (q) setSearch(q);
-    if (lang) setLanguageFilter(lang);
+    const resolved = resolveDirectoryFilters(searchParams, {
+      routeScoped: Boolean(initialType || initialState),
+      validType: v => TYPE_FILTERS.some(f => f.key === v),
+    });
+    if (resolved.providerType) setProviderType(resolved.providerType);
+    if (resolved.specialties) setSpecialtyFilters(resolved.specialties);
+    if (resolved.types) setTypeFilters(new Set(resolved.types));
+    if (resolved.state) setStateFilter(resolved.state);
+    if (resolved.sort) setSortBy(resolved.sort as SortKey);
+    if (resolved.search) setSearch(resolved.search);
+    if (resolved.language) setLanguageFilter(resolved.language);
   }, [searchParams, initialType, initialState]);
 
   const initialRenderRef = useRef(true);

--- a/app/advisors/filter-params.ts
+++ b/app/advisors/filter-params.ts
@@ -1,0 +1,71 @@
+import { AU_STATES } from "@/lib/types";
+import type { ProfessionalType } from "@/lib/types";
+
+export type ProviderTypeParam = "individual" | "firm" | "team";
+
+export interface ResolvedDirectoryFilters {
+  providerType?: ProviderTypeParam;
+  types?: ProfessionalType[];
+  state?: string;
+  specialties?: string[];
+  sort?: string;
+  search?: string;
+  language?: string;
+}
+
+interface ResolveOptions {
+  /**
+   * True when the page already fixes the professional type via its route
+   * (e.g. /advisors/mortgage-brokers). The URL `type`/`state` params must
+   * not override the route-derived type, so they are ignored in that case.
+   */
+  routeScoped: boolean;
+  /** Predicate validating a `type` param value against the known filter keys. */
+  validType: (key: string) => boolean;
+}
+
+/**
+ * Resolve directory filter state from URL query params.
+ *
+ * `specialty` is orthogonal to the route-derived professional type, so it is
+ * honoured even on route-scoped pages — this is what lets the First Home Buyer
+ * hub deep-link into /advisors/mortgage-brokers?specialty=First Home Buyers and
+ * have the FHB specialist filter pre-selected.
+ */
+export function resolveDirectoryFilters(
+  params: { get(name: string): string | null },
+  { routeScoped, validType }: ResolveOptions,
+): ResolvedDirectoryFilters {
+  const result: ResolvedDirectoryFilters = {};
+
+  const pt = params.get("provider_type");
+  if (pt === "individual" || pt === "firm" || pt === "team") result.providerType = pt;
+
+  const sp = params.get("specialty");
+  if (sp) {
+    const specialties = sp.split(",").map((s) => s.trim()).filter(Boolean);
+    if (specialties.length) result.specialties = specialties;
+  }
+
+  if (routeScoped) return result;
+
+  const t = params.get("type");
+  if (t) {
+    const types = t.split(",").filter(validType) as ProfessionalType[];
+    if (types.length) result.types = types;
+  }
+
+  const s = params.get("state");
+  if (s && (AU_STATES as readonly string[]).includes(s)) result.state = s;
+
+  const sort = params.get("sort");
+  if (sort) result.sort = sort;
+
+  const q = params.get("q");
+  if (q) result.search = q;
+
+  const lang = params.get("language");
+  if (lang) result.language = lang;
+
+  return result;
+}

--- a/lib/first-home-buyer/broker-handoff.ts
+++ b/lib/first-home-buyer/broker-handoff.ts
@@ -1,0 +1,22 @@
+/**
+ * First Home Buyer → mortgage-broker directory handoff (W3.19 lever).
+ *
+ * Deep-links the First Home Buyer hub into the mortgage-broker directory
+ * pre-filtered to FHB specialists, so the hub's "Find a Mortgage Broker"
+ * CTA lands users on a curated shortlist instead of the unfiltered list.
+ */
+
+/**
+ * Canonical specialty label. MUST match the value stored in
+ * `professionals.specialties` and listed under `mortgage_broker` in
+ * `lib/advisor-specialties.ts` — the directory filters with an exact
+ * `specialties.includes(...)` check, so any drift silently empties the list.
+ * A test asserts this stays in sync.
+ */
+export const FHB_MORTGAGE_BROKER_SPECIALTY = "First Home Buyers";
+
+/** Pre-filtered mortgage-broker directory URL for First Home Buyer specialists. */
+export function firstHomeBuyerBrokerDirectoryUrl(): string {
+  const params = new URLSearchParams({ specialty: FHB_MORTGAGE_BROKER_SPECIALTY });
+  return `/advisors/mortgage-brokers?${params.toString()}`;
+}

--- a/lib/hub-configs/first-home-buyer.ts
+++ b/lib/hub-configs/first-home-buyer.ts
@@ -1,5 +1,6 @@
 import { CURRENT_YEAR } from "@/lib/seo";
 import type { HubConfig } from "@/lib/verticals";
+import { firstHomeBuyerBrokerDirectoryUrl } from "@/lib/first-home-buyer/broker-handoff";
 
 /**
  * Hub config for /first-home-buyer — consumed by the <HubPage> HOC.
@@ -42,7 +43,7 @@ export const firstHomeBuyerHubConfig: HubConfig = {
     ],
     primaryCta: {
       label: "Find a Mortgage Broker",
-      href: "/find/mortgage-broker",
+      href: firstHomeBuyerBrokerDirectoryUrl(),
       lever: "lead_routing",
     },
     secondaryCta: {
@@ -90,7 +91,7 @@ export const firstHomeBuyerHubConfig: HubConfig = {
       icon: "briefcase",
       description:
         "A specialist first home buyer broker compares 30+ lenders including those using LMI waivers, 95% LVR products, and guarantor loans. Free service — paid by the lender.",
-      href: "/find/mortgage-broker/sydney",
+      href: firstHomeBuyerBrokerDirectoryUrl(),
       cta: "Find a Broker",
     },
     {
@@ -98,7 +99,7 @@ export const firstHomeBuyerHubConfig: HubConfig = {
       icon: "lock",
       description:
         "Waiting for FHSS release takes 20+ business days. A deposit bond (from $100) covers the 10% deposit at exchange while your ATO release processes.",
-      href: "/find/mortgage-broker",
+      href: firstHomeBuyerBrokerDirectoryUrl(),
       cta: "Talk to a Broker",
     },
   ],


### PR DESCRIPTION
## Summary
Wires the First Home Buyer hub's mortgage-broker CTAs to a pre-filtered `/advisors/mortgage-brokers?specialty=First Home Buyers` deep-link, and fixes the directory so a `specialty` deep-link actually pre-selects on type-scoped routes.

## Why
W3.19 (FHB end-to-end journey) shipped the hub + FHSS calc (#895) and eligibility quiz (#919); the state-grants lever is in flight (#1035). This is the mortgage-broker handoff lever — the hub's primary monetization CTA (lead routing). Two hub CTAs pointed at `/find/mortgage-broker`, which has **no route** (only `/find/[advisor-type]/[city]`) and 404'd. The directory already *wrote* `specialty` to the URL but never *read* it back on type-scoped pages (the param-resolution effect early-returned before reading specialty whenever the route fixed the type), so a `?specialty=` deep-link silently dropped.

## Tier
**B** — additive page UI + new lib/helper module + tests. No schema, no webhook/cron/Stripe/admin surface. RLS N/A. (`AdvisorsClient` is a content directory component, not an AFSL-gated page.)

## Files
- `lib/first-home-buyer/broker-handoff.ts` — `FHB_MORTGAGE_BROKER_SPECIALTY` + `firstHomeBuyerBrokerDirectoryUrl()` (canonical specialty label kept in sync with the real `mortgage_broker` specialty data via a drift-guard test)
- `app/advisors/filter-params.ts` — pure, tested `resolveDirectoryFilters()`; `specialty` is now orthogonal to the route-derived type so the deep-link pre-selects
- `app/advisors/AdvisorsClient.tsx` — uses the helper in the URL-param effect (faithful refactor + the specialty fix)
- `lib/hub-configs/first-home-buyer.ts` — hub primary CTA + "Mortgage Brokers" card + "Deposit Bond" card now deep-link to the FHB-filtered directory (repairs two dead `/find/mortgage-broker` links)
- `__tests__/app/advisors-filter-params.test.ts` — 8 tests
- `__tests__/lib/first-home-buyer/broker-handoff.test.ts` — 3 tests (incl. specialty-data drift guard + round-trip)

## Supersedes
_None._

## Test plan
- [x] vitest local: 11/11 passing (both new files)
- [x] type-check: clean (`tsc --noEmit`, exit 0)
- [x] eslint: clean (`--max-warnings 0`)
- [x] pre-push hook: type-check + rate-limit audit passed
- [ ] CI: pending
- [ ] Visual: open `/first-home-buyer` → "Find a Mortgage Broker" / "Find a Broker" / "Talk to a Broker" CTAs land on `/advisors/mortgage-brokers` with the "First Home Buyers" specialty chip pre-selected and the list narrowed to FHB specialists

---
_Generated by Claude Code (pre-launch-wave loop)._

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoQo5uaQJAvncRTu1JYuDV)_