### PR TITLE
fix(seo): add JSON-LD to /just life-events index page

### DIFF
--- a/app/just/page.tsx
+++ b/app/just/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { CURRENT_YEAR, SITE_NAME, SITE_URL } from "@/lib/seo";
+import { absoluteUrl, breadcrumbJsonLd, CURRENT_YEAR, SITE_NAME, SITE_URL } from "@/lib/seo";
 
 export const revalidate = 86400;
 
@@ -61,8 +61,34 @@ const EVENTS = [
 ];
 
 export default function JustPage() {
+  const breadcrumbLd = breadcrumbJsonLd([
+    { name: "Home", url: absoluteUrl("/") },
+    { name: "Life events", url: absoluteUrl("/just") },
+  ]);
+
+  const itemListLd = {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name: `Life Event Financial Checklists (${CURRENT_YEAR})`,
+    itemListElement: EVENTS.map((e, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      name: e.label,
+      url: absoluteUrl(`/just/${e.slug}`),
+    })),
+  };
+
   return (
-    <div className="container-custom max-w-3xl py-10">
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(itemListLd) }}
+      />
+      <div className="container-custom max-w-3xl py-10">
       <header className="mb-10">
         <p className="text-xs font-bold uppercase tracking-wider text-emerald-600 mb-2">
           Life event guides · {CURRENT_YEAR}
@@ -93,6 +119,7 @@ export default function JustPage() {
         These guides provide general financial information only and do not constitute personal financial advice.
         Always consult a licensed financial adviser or tax agent for advice tailored to your situation.
       </p>
-    </div>
+      </div>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
Adds BreadcrumbList + ItemList JSON-LD to the `/just` life-events index page.

## Why
The `/just` index page (added in #1020) shipped with no JSON-LD, which trips `scripts/check-jsonld-coverage.mjs`. That gate runs as a step inside the `Lint · Type-check · Test · Build` job, so it now **fails CI on every PR branched after #1020 merged** (~02:34 UTC today) — not just this one. This unblocks the queue.

## Tier
**A** — page UI + JSON-LD only. No schema, API, payment, or migration. Mirrors the existing `/just/[event]` JSON-LD pattern.

## Files
- `app/just/page.tsx` — `breadcrumbJsonLd(...)` + an `ItemList` of the 8 life-event pages, rendered as two `<script type="application/ld+json">` blocks

## Supersedes
_None._

## Test plan
- [x] `node scripts/check-jsonld-coverage.mjs` → "✅ All public routes emit JSON-LD" (was: 1 missing)
- [x] type-check: clean (pre-push hook)
- [x] eslint: clean (`--max-warnings 0`)
- [ ] CI: pending

---
_Generated by Claude Code (pre-launch-wave loop)._

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoQo5uaQJAvncRTu1JYuDV)_