### PR TITLE
fix(seo): emit JSON-LD on /just life-event hub

### DIFF
--- a/app/just/page.tsx
+++ b/app/just/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { CURRENT_YEAR, SITE_NAME, SITE_URL } from "@/lib/seo";
+import { absoluteUrl, breadcrumbJsonLd, CURRENT_YEAR, SITE_NAME, SITE_URL } from "@/lib/seo";
+import { itemListJsonLd } from "@/lib/schema-markup";
 
 export const revalidate = 86400;
 
@@ -61,8 +62,32 @@ const EVENTS = [
 ];
 
 export default function JustPage() {
+  const breadcrumbLd = breadcrumbJsonLd([
+    { name: "Home", url: absoluteUrl("/") },
+    { name: "Life events", url: absoluteUrl("/just") },
+  ]);
+
+  const itemListLd = itemListJsonLd(
+    "Life Event Financial Checklists",
+    EVENTS.map((e, i) => ({
+      position: i + 1,
+      name: e.label,
+      url: `/just/${e.slug}`,
+      description: e.description,
+    })),
+  );
+
   return (
-    <div className="container-custom max-w-3xl py-10">
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(itemListLd) }}
+      />
+      <div className="container-custom max-w-3xl py-10">
       <header className="mb-10">
         <p className="text-xs font-bold uppercase tracking-wider text-emerald-600 mb-2">
           Life event guides · {CURRENT_YEAR}
@@ -93,6 +118,7 @@ export default function JustPage() {
         These guides provide general financial information only and do not constitute personal financial advice.
         Always consult a licensed financial adviser or tax agent for advice tailored to your situation.
       </p>
-    </div>
+      </div>
+    </>
   );
 }


### PR DESCRIPTION
## What

Adds JSON-LD structured data to `app/just/page.tsx` (the "moment-of-money" life-event hub linking the 8 `/just/[event]` guides):

- `BreadcrumbList` — Home › Life events
- `ItemList` — the 8 life-event guides

Both via the canonical helpers (`breadcrumbJsonLd` from `lib/seo.ts`, `itemListJsonLd` from `lib/schema-markup.ts`), mirroring the `/just/[event]` detail pages.

## Why

`/just` (added in #1020) shipped with no structured data. It is the **only** route flagged by `scripts/check-jsonld-coverage.mjs`, so the **required** `Lint · Type-check · Test · Build` gate has been failing on `main` and therefore on **every open PR** (e.g. #1043). This is a focused, separate fix so it doesn't pollute unrelated feature diffs.

## Verification (local)

- `node scripts/check-jsonld-coverage.mjs` → ✅ All public routes emit JSON-LD (was: 1 missing)
- `npx tsc --noEmit` → clean (0 source errors)
- pre-commit (eslint) + pre-push (tsc + rate-limit audit + changed tests) → passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)