### PR TITLE
fix(f): use logger in ai-chat route + de-shadow formatAud helper

### DIFF
--- a/app/api/admin/ai-chat/route.ts
+++ b/app/api/admin/ai-chat/route.ts
@@ -12,9 +12,12 @@ import {
 } from "@/lib/ai-cost-caps";
 import { sendCap80Alert } from "@/lib/ai-cost-alerts";
 import { filterFactualOutput } from "@/lib/compliance";
+import { logger } from "@/lib/logger";
 
 export const runtime = "nodejs";
 export const maxDuration = 120;
+
+const log = logger("api:admin:ai-chat");
 
 const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
 
@@ -803,13 +806,10 @@ export async function POST(req: NextRequest) {
               if (finalText.trim().length > 0) {
                 const filterResult = filterFactualOutput(finalText);
                 if (!filterResult.ok) {
-                  console.warn(
-                    "[ai-chat] factual_filter_rejected",
-                    JSON.stringify({
-                      reason: filterResult.reason,
-                      spans: filterResult.rejectedSpans.map((s) => s.rule),
-                    }),
-                  );
+                  log.warn("[ai-chat] factual_filter_rejected", {
+                    reason: filterResult.reason,
+                    spans: filterResult.rejectedSpans.map((s) => s.rule),
+                  });
                   send({
                     type: "filter_warning",
                     reason: filterResult.reason,

--- a/app/non-resident-dividend-calculator/NonResidentDividendClient.tsx
+++ b/app/non-resident-dividend-calculator/NonResidentDividendClient.tsx
@@ -50,7 +50,7 @@ const COUNTRIES: { code: string; label: string; unfrankedWht: number }[] = [
   { code: "OTHER", label: "Other / no DTA", unfrankedWht: 30 },
 ];
 
-function formatAud(value: number): string {
+function formatAudDollars(value: number): string {
   return value.toLocaleString("en-AU", {
     style: "currency",
     currency: "AUD",
@@ -232,7 +232,7 @@ export default function NonResidentDividendClient() {
                 Net cash dividend received
               </p>
               <p className="text-3xl md:text-4xl font-extrabold text-green-900">
-                {formatAud(calc.netCash)}
+                {formatAudDollars(calc.netCash)}
               </p>
               <p className="text-xs text-green-800 mt-2">
                 Effective Australian withholding rate:{" "}
@@ -246,7 +246,7 @@ export default function NonResidentDividendClient() {
                   <tr>
                     <td className="px-4 py-2 text-slate-600">Gross dividend</td>
                     <td className="px-4 py-2 text-right font-bold text-slate-900">
-                      {formatAud(dividendNum)}
+                      {formatAudDollars(dividendNum)}
                     </td>
                   </tr>
                   <tr>
@@ -254,7 +254,7 @@ export default function NonResidentDividendClient() {
                       Franked portion ({frankingPct}%) — 0% WHT
                     </td>
                     <td className="px-4 py-2 text-right font-bold text-slate-900">
-                      {formatAud(calc.frankedPortion)}
+                      {formatAudDollars(calc.frankedPortion)}
                     </td>
                   </tr>
                   <tr>
@@ -262,7 +262,7 @@ export default function NonResidentDividendClient() {
                       Unfranked portion ({100 - frankingPct}%)
                     </td>
                     <td className="px-4 py-2 text-right font-bold text-slate-900">
-                      {formatAud(calc.unfrankedPortion)}
+                      {formatAudDollars(calc.unfrankedPortion)}
                     </td>
                   </tr>
                   <tr>
@@ -270,7 +270,7 @@ export default function NonResidentDividendClient() {
                       WHT on unfranked ({country.unfrankedWht}%)
                     </td>
                     <td className="px-4 py-2 text-right font-bold text-rose-700">
-                      -{formatAud(calc.unfrankedWht)}
+                      -{formatAudDollars(calc.unfrankedWht)}
                     </td>
                   </tr>
                   <tr className="bg-green-50">
@@ -278,7 +278,7 @@ export default function NonResidentDividendClient() {
                       Net cash to you
                     </td>
                     <td className="px-4 py-2 text-right font-extrabold text-green-800">
-                      {formatAud(calc.netCash)}
+                      {formatAudDollars(calc.netCash)}
                     </td>
                   </tr>
                 </tbody>

--- a/app/tools/alternative-returns/AlternativeReturnsClient.tsx
+++ b/app/tools/alternative-returns/AlternativeReturnsClient.tsx
@@ -82,7 +82,7 @@ function compoundValue(principal: number, rate: number, years: number): number {
   return principal * Math.pow(1 + rate, years);
 }
 
-function formatAud(value: number): string {
+function formatAudAbbrev(value: number): string {
   if (value >= 10_000_000) return `A$${(value / 1_000_000).toFixed(1)}M`;
   if (value >= 1_000_000) return `A$${(value / 1_000_000).toFixed(2)}M`;
   if (value >= 1_000) return `A$${(value / 1_000).toFixed(0)}k`;
@@ -231,13 +231,13 @@ export default function AlternativeReturnsClient() {
               Estimated current value — {selectedAsset.shortLabel}
             </p>
             <p className="text-3xl md:text-5xl font-extrabold mb-2 tracking-tight">
-              {formatAud(selectedResult.currentValue)}
+              {formatAudAbbrev(selectedResult.currentValue)}
             </p>
             <p className="text-sm text-slate-300">
-              {formatAud(principal)} invested in {yearNum}
+              {formatAudAbbrev(principal)} invested in {yearNum}
               {totalGrowth >= 0 ? (
                 <>
-                  {" "}grew by <strong className="text-emerald-300">{formatAud(totalGrowth)}</strong>
+                  {" "}grew by <strong className="text-emerald-300">{formatAudAbbrev(totalGrowth)}</strong>
                   {" "}({((totalGrowth / Math.max(principal, 1)) * 100).toFixed(0)}% total)
                 </>
               ) : (
@@ -252,7 +252,7 @@ export default function AlternativeReturnsClient() {
             Side-by-side comparison
           </h2>
           <p className="text-xs text-slate-500 mb-5">
-            Same {formatAud(principal)} purchase in {yearNum} across all five
+            Same {formatAudAbbrev(principal)} purchase in {yearNum} across all five
             asset classes, using historical annualised returns.
           </p>
 
@@ -276,7 +276,7 @@ export default function AlternativeReturnsClient() {
                     </p>
                   </div>
                   <p className="text-base md:text-lg font-extrabold text-slate-900 shrink-0">
-                    {formatAud(currentValue)}
+                    {formatAudAbbrev(currentValue)}
                   </p>
                 </div>
                 <div className="h-3 bg-slate-100 rounded-full overflow-hidden">

--- a/app/tools/visa-investment-calculator/VisaCalculatorClient.tsx
+++ b/app/tools/visa-investment-calculator/VisaCalculatorClient.tsx
@@ -128,7 +128,7 @@ const VISA_PATHWAYS: VisaPathway[] = [
   },
 ];
 
-function formatAud(value: number): string {
+function formatAudAbbrev(value: number): string {
   if (value === 0) return "Nil";
   if (value >= 1_000_000) return `A$${(value / 1_000_000).toFixed(value >= 10_000_000 ? 0 : 1)}M`;
   return `A$${(value / 1_000).toFixed(0)}k`;
@@ -225,7 +225,7 @@ export default function VisaCalculatorClient() {
             />
           </div>
           <p className="text-xs text-slate-600 mt-3">
-            With <strong>{formatAud(budgetNum)}</strong>, you may qualify for:
+            With <strong>{formatAudAbbrev(budgetNum)}</strong>, you may qualify for:
           </p>
           <div className="flex flex-wrap gap-2 mt-2">
             {affordable.length === 0 ? (
@@ -310,7 +310,7 @@ export default function VisaCalculatorClient() {
                       Min investment
                     </dt>
                     <dd className="font-extrabold text-slate-900">
-                      {formatAud(v.minInvestmentAud)}
+                      {formatAudAbbrev(v.minInvestmentAud)}
                     </dd>
                   </div>
                   <div className="bg-slate-50 rounded-lg px-2.5 py-1.5">

--- a/app/tools/withholding-tax-calculator/WithholdingTaxClient.tsx
+++ b/app/tools/withholding-tax-calculator/WithholdingTaxClient.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import Icon from "@/components/Icon";
+import { formatAud } from "@/lib/first-home-buyer/state-grants";
 
 interface CountryOption {
   code: string;
@@ -52,13 +53,6 @@ function toNumber(value: number | string | null | undefined): number | null {
   return Number.isFinite(n) ? n : null;
 }
 
-function formatAud(cents: number): string {
-  return (cents / 100).toLocaleString("en-AU", {
-    style: "currency",
-    currency: "AUD",
-    maximumFractionDigits: 0,
-  });
-}
 
 export default function WithholdingTaxClient() {
   const [countries, setCountries] = useState<CountryOption[]>([]);


### PR DESCRIPTION
## Summary
Two scout-surfaced cleanups:
1. **Logger drift** — `app/api/admin/ai-chat/route.ts` had a raw `console.warn` (flagged by `audit:console-calls`). Replaced with `logger("api:admin:ai-chat").warn(...)`, preserving message + args.
2. **`formatAud` shadow** — `audit:duplicate-functions` flagged 4 local redefinitions of the lib `formatAud` export. False-friend: only the withholding-tax calculator's local matched the lib semantics (cents → /100, 0dp) — that one now imports the lib helper. The other three are genuinely different (dollars/2dp, M-k abbreviation, "Nil" handling) and were renamed (`formatAudDollars`, `formatAudAbbrev`) to stop shadowing rather than wrongly importing (which would have introduced a 100× bug).

Both `audit:console-calls` and `audit:duplicate-functions` report clean post-change.

## Queue item
F-DISC-20260520-01 — surfaced by scout fire 2026-05-20. See docs/audits/REMEDIATION_QUEUE.md

## Supersedes
_None._

## Test plan
- [x] `npm run audit:console-calls` → clean
- [x] `npm run audit:duplicate-functions` → clean
- [ ] CI green
