### PR TITLE
fix(billing): add supplier ABN to broker tax-invoice PDF (audit §5 #8)

### DIFF
--- a/__tests__/api/broker-portal-invoices-pdf.test.ts
+++ b/__tests__/api/broker-portal-invoices-pdf.test.ts
@@ -117,6 +117,30 @@ describe("GET /api/broker-portal/invoices/[id]/pdf", () => {
     expect(res.headers.get("Content-Type")).toContain("text/html");
   });
 
+  it("renders the supplier (issuer) legal name + ABN — ATO tax-invoice requirement", async () => {
+    const accountChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: { broker_slug: "commsec" } }),
+    };
+    const invoiceChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: baseInvoice, error: null }),
+    };
+    mockAdminFrom
+      .mockReturnValueOnce(accountChain)
+      .mockReturnValueOnce(invoiceChain);
+
+    const { GET } = await import("@/app/api/broker-portal/invoices/[id]/pdf/route");
+    const { COMPANY_LEGAL_NAME, COMPANY_ABN } = await import("@/lib/compliance");
+    const res = await GET(makeReq("42"), makeParams("42"));
+    const body = await res.text();
+    expect(body).toContain("TAX INVOICE");
+    expect(body).toContain(COMPANY_LEGAL_NAME);
+    expect(body).toContain(`ABN ${COMPANY_ABN}`);
+  });
+
   it("sets Content-Disposition with invoice number in filename", async () => {
     const accountChain = {
       select: vi.fn().mockReturnThis(),

--- a/app/api/broker-portal/invoices/[id]/pdf/route.ts
+++ b/app/api/broker-portal/invoices/[id]/pdf/route.ts
@@ -3,6 +3,7 @@ import { createServerClient } from "@supabase/ssr";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { formatDate } from "@/lib/utils";
 import { escapeHtml } from "@/lib/html-escape";
+import { COMPANY_LEGAL_NAME, COMPANY_ABN } from "@/lib/compliance";
 
 export const runtime = "nodejs";
 
@@ -230,6 +231,8 @@ export async function GET(
           Invest.com.au
         </div>
         <div style="font-size:12px;color:#94a3b8;margin-top:4px;">Partner Marketplace</div>
+        <div style="font-size:12px;color:#334155;margin-top:8px;">${escapeHtml(COMPANY_LEGAL_NAME)}</div>
+        <div style="font-size:12px;color:#334155;">ABN ${escapeHtml(COMPANY_ABN)}</div>
       </div>
       <div style="text-align:right;">
         <div style="font-size:24px;font-weight:700;color:#0f172a;letter-spacing:1px;">TAX INVOICE</div>


### PR DESCRIPTION
Closes new-features audit §5 flag #8.

The broker-portal invoice PDF is labelled **TAX INVOICE** and shows the recipient ABN, but omitted the **supplier (issuer) ABN** — an ATO tax-invoice requirement for invoices of \$1,000+.

- Adds the issuer legal name + ABN to the invoice header, sourced from `lib/compliance.ts` (single source of truth — `COMPANY_LEGAL_NAME`, `COMPANY_ABN`).
- Extends the route test to assert both render.

Tier: A/B (additive billing display). Local: targeted vitest (12/12) + eslint clean. Full type-check/tests run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)