### PR TITLE
fix(security): drop orphan sharesight_connections plaintext-token table (§5 #2) [Tier E — founder apply]

### DIFF
--- a/.driftallowlist
+++ b/.driftallowlist
@@ -74,4 +74,5 @@ spatial_ref_sys
 # intentionally omitted here — the gate will fail loudly if they slip out of the migration set.
 investor_oauth_connections  # PR #893 — OAuth provider connections; remove when its migration lands
 afsl_register               # created in Supabase dashboard (ASIC AFSL register import 2026-05-19); remove when backfill migration lands
-sharesight_connections      # W2.11 Sharesight OAuth — dashboard-created table for token storage; remove when its backfill migration lands
+# sharesight_connections removed — orphan plaintext-token table dropped via
+# 20260729_drop_orphan_sharesight_connections.sql (audit §5 #2).

--- a/supabase/migrations/20260729_drop_orphan_sharesight_connections.sql
+++ b/supabase/migrations/20260729_drop_orphan_sharesight_connections.sql
@@ -1,0 +1,28 @@
+-- Drop the orphan `sharesight_connections` table (new-features audit §5 flag #2).
+--
+-- BACKGROUND:
+--   This table was created directly in the Supabase dashboard for the W2.11
+--   Sharesight OAuth feature (token storage) and was never defined by a repo
+--   migration. The feature shipped using a different storage path; the table
+--   is now an orphan that holds plaintext OAuth tokens. As of this audit it has
+--   0 rows and ZERO code references (only a stale entry in lib/database.types.ts
+--   and .driftallowlist). A plaintext-token table with no owner is a standing
+--   security liability on an AFSL platform.
+--
+--   Tracked in the decision log as the "drop orphan plaintext-token table" item.
+--   Listed on .driftallowlist:77 — removed in the same change as this migration.
+--
+-- IDEMPOTENT: IF EXISTS guard makes re-running safe.
+-- FORWARD-ONLY: applied to live via Supabase MCP / dashboard by the founder
+--   (Tier E — irreversible drop), then regenerate lib/database.types.ts to
+--   clear the type entry.
+--
+-- ROLLBACK STRATEGY:
+--   There is no in-repo CREATE for this table (it was dashboard-created), so a
+--   true rollback would mean re-creating it from the dashboard. This is
+--   intentional: the table is unused (0 rows) and storing plaintext OAuth
+--   tokens, so its removal is the desired end state. Risk: none — no code reads
+--   or writes it. If Sharesight OAuth token persistence is later needed, add a
+--   purpose-built, encrypted, RLS-protected table via a fresh migration.
+
+DROP TABLE IF EXISTS public.sharesight_connections;


### PR DESCRIPTION
Closes new-features audit §5 flag #2 (P0) — **pending founder apply**.

The dashboard-created `sharesight_connections` table stores **plaintext OAuth tokens**, has **0 rows** and **zero code references** (only a stale `lib/database.types.ts` entry + `.driftallowlist:77`). Adds an idempotent forward-only `DROP TABLE IF EXISTS` migration and removes the allowlist entry.

**⚠️ Tier E (irreversible) — do NOT auto-merge.** Founder action:
1. Apply `20260729_drop_orphan_sharesight_connections.sql` to live via Supabase MCP/dashboard.
2. Regenerate `lib/database.types.ts` to clear the type entry.
3. Then merge this PR.

Note: the "Supabase/Database types drift" checks may flag a transient mismatch until step 2 is done — expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)