### PR TITLE
fix(cron): ab-auto-promote circuit-breaker + suburb stub alert (§5 #15,#18)

### DIFF
--- a/__tests__/api/cron-ab-auto-promote.test.ts
+++ b/__tests__/api/cron-ab-auto-promote.test.ts
@@ -161,4 +161,21 @@ describe("GET /api/cron/ab-auto-promote", () => {
     const json = await res.json() as { failed: number };
     expect(json.failed).toBe(1);
   });
+
+  it("circuit-breaker: caps promotions at 5 per run and flags capped", async () => {
+    // 6 tests that all declare a winner — the breaker should stop after 5.
+    const sixWinners = [1, 2, 3, 4, 5, 6].map((id) => makeTest({ id }));
+    dbQueue.push({ data: sixWinners }); // fetch
+    // Each of the 5 promotions consumes an update + an admin_action_log insert.
+    for (let i = 0; i < 5; i++) {
+      dbQueue.push({ data: null }); // update ab_tests
+      dbQueue.push({ data: null }); // insert admin_action_log
+    }
+    mockDecideWinner.mockReturnValue({ winner: "b", reason: "b_wins", pValue: 0.01, zScore: 3, liftPct: 20 });
+    const res = await GET(makeReq());
+    const json = await res.json() as { promoted: number; capped: boolean; scanned: number };
+    expect(json.scanned).toBe(6);
+    expect(json.promoted).toBe(5);
+    expect(json.capped).toBe(true);
+  });
 });

--- a/__tests__/lib/property-suburb-refresh.test.ts
+++ b/__tests__/lib/property-suburb-refresh.test.ts
@@ -41,7 +41,7 @@ vi.mock("@/lib/logger", () => ({
   }),
 }));
 
-import { refreshSuburb } from "@/lib/property-suburb-refresh";
+import { refreshSuburb, selectProvider } from "@/lib/property-suburb-refresh";
 
 const ORIGINAL_ENV = { ...process.env };
 
@@ -59,6 +59,20 @@ beforeEach(() => {
 afterEach(() => {
   for (const k of Object.keys(process.env)) delete process.env[k];
   Object.assign(process.env, ORIGINAL_ENV);
+});
+
+describe("selectProvider — used by the cron to detect an unintended stub", () => {
+  it("returns 'stub' when no provider env var is set", () => {
+    expect(selectProvider()).toBe("stub");
+  });
+  it("returns 'corelogic' when CORELOGIC_API_KEY is set", () => {
+    process.env.CORELOGIC_API_KEY = "token-abc";
+    expect(selectProvider()).toBe("corelogic");
+  });
+  it("returns 'sqm' when only SQM_RESEARCH_API_KEY is set", () => {
+    process.env.SQM_RESEARCH_API_KEY = "sqm-token";
+    expect(selectProvider()).toBe("sqm");
+  });
 });
 
 describe("refreshSuburb — stub provider (no env vars)", () => {

--- a/app/api/cron/ab-auto-promote/route.ts
+++ b/app/api/cron/ab-auto-promote/route.ts
@@ -12,6 +12,14 @@ export const runtime = "nodejs";
 export const maxDuration = 60;
 
 /**
+ * Circuit-breaker: max winners auto-promoted (concluded) in a single run.
+ * Beyond the kill switch, this guards against a miscalculated
+ * confidence/threshold concluding every running test in one nightly pass —
+ * when tripped the cron stops promoting and alerts ops to review manually.
+ */
+const MAX_PROMOTIONS_PER_RUN = 5;
+
+/**
  * Nightly cron that reads every running A/B test, runs a two-
  * proportion z-test on impressions/conversions, and if a significant
  * winner is declared (p < threshold AND min_sample_size reached)
@@ -56,6 +64,7 @@ async function handler(req: NextRequest) {
     insufficient: 0,
     inconclusive: 0,
     failed: 0,
+    capped: false,
   };
 
   for (const test of tests || []) {
@@ -80,6 +89,16 @@ async function handler(req: NextRequest) {
       if (!decision.winner) {
         stats.inconclusive++;
         continue;
+      }
+
+      // Circuit-breaker: stop and alert if too many tests conclude in one run.
+      if (stats.promoted >= MAX_PROMOTIONS_PER_RUN) {
+        stats.capped = true;
+        log.error(
+          "ab-auto-promote circuit breaker tripped — per-run promotion cap reached; remaining tests deferred to next run",
+          { cap: MAX_PROMOTIONS_PER_RUN, promoted: stats.promoted, scanned: stats.scanned },
+        );
+        break;
       }
 
       const nowIso = new Date().toISOString();

--- a/app/api/cron/property-suburb-refresh/route.ts
+++ b/app/api/cron/property-suburb-refresh/route.ts
@@ -3,7 +3,7 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { logger } from "@/lib/logger";
 import { requireCronAuth } from "@/lib/cron-auth";
 import { wrapCronHandler } from "@/lib/cron-run-log";
-import { refreshSuburb } from "@/lib/property-suburb-refresh";
+import { refreshSuburb, selectProvider } from "@/lib/property-suburb-refresh";
 import { isFeatureDisabled } from "@/lib/admin/classifier-config";
 
 const log = logger("cron:property-suburb-refresh");
@@ -34,6 +34,18 @@ async function handler(req: NextRequest) {
   // instantly without a deploy if something is wrong upstream.
   if (await isFeatureDisabled("property_suburb_refresh")) {
     return NextResponse.json({ ok: true, skipped: "kill_switch_on" });
+  }
+
+  // Surface an unintended zero-stub: if no paid provider is configured the
+  // refresh writes empty diffs and would otherwise look like a clean success.
+  // Alert loudly so a missing CORELOGIC_API_KEY / SQM_RESEARCH_API_KEY in prod
+  // doesn't silently freeze suburb data. (A deliberately provider-less env
+  // still no-ops; the alert just makes the state visible to ops.)
+  const provider = selectProvider();
+  if (provider === "stub") {
+    log.error(
+      "property-suburb-refresh running in STUB mode — no data provider configured (CORELOGIC_API_KEY and SQM_RESEARCH_API_KEY both unset); suburb data is not being refreshed",
+    );
   }
 
   const supabase = createAdminClient();
@@ -85,8 +97,8 @@ async function handler(req: NextRequest) {
     }
   }
 
-  log.info("property-suburb-refresh cron completed", stats);
-  return NextResponse.json({ ok: true, ...stats });
+  log.info("property-suburb-refresh cron completed", { provider, ...stats });
+  return NextResponse.json({ ok: true, provider, ...stats });
 }
 
 export const GET = wrapCronHandler("property-suburb-refresh", handler);

--- a/lib/property-suburb-refresh.ts
+++ b/lib/property-suburb-refresh.ts
@@ -27,6 +27,7 @@
  *     200ms pacer between calls. A fresh CoreLogic call is ~300ms.
  */
 
+// eslint-disable-next-line no-restricted-imports -- ops cron writes to suburb_data + property_suburb_refresh_log (non-user-data, refreshed server-side); no anon JWT path. See CLAUDE.md § "Two Supabase clients".
 import { createAdminClient } from "@/lib/supabase/admin";
 import { logger } from "@/lib/logger";
 
@@ -131,7 +132,7 @@ export async function refreshSuburb(
   return { suburbSlug, provider, fieldsChanged };
 }
 
-function selectProvider(): SuburbProvider {
+export function selectProvider(): SuburbProvider {
   if (process.env.CORELOGIC_API_KEY) return "corelogic";
   if (process.env.SQM_RESEARCH_API_KEY) return "sqm";
   return "stub";


### PR DESCRIPTION
Closes new-features audit §5 flags #15 and #18 (P2 reliability).

- #15: ab-auto-promote had no cap beyond the kill switch — a bad confidence/threshold calc could conclude every running A/B test in one nightly pass. Adds MAX_PROMOTIONS_PER_RUN=5; on trip it stops, logs an ops alert, returns capped=true (remaining resume next run).
- #18: property-suburb-refresh silently no-ops to a stub provider when no data-provider env is set. Exports selectProvider() and alerts (log.error) once per run in stub mode + surfaces provider in the response.

Tests: circuit-breaker cap + selectProvider resolution (21/21 local). Both crons retain requireCronAuth. Tier B.

Generated with Claude Code