### PR TITLE
test(d): add unit tests for teams/* API routes

### DIFF
--- a/__tests__/api/teams-briefs-bulk.test.ts
+++ b/__tests__/api/teams-briefs-bulk.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+const isAllowedMock = vi.fn<() => Promise<boolean>>();
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: (..._args: unknown[]) => isAllowedMock(),
+  ipKey: () => "test-ip",
+}));
+
+const requireAdvisorSessionMock = vi.fn<() => Promise<number | null>>();
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: () => requireAdvisorSessionMock(),
+}));
+
+const runBulkActionMock = vi.fn();
+vi.mock("@/lib/squad-bulk-actions", () => ({
+  MAX_BULK: 50,
+  runBulkAction: (...args: unknown[]) => runBulkActionMock(...args),
+}));
+
+// Admin client returns a fresh thenable per .from() call; each terminal
+// maybeSingle() pulls the next queued result.
+const maybeSingleResults: Array<{ data: unknown }> = [];
+function pushResult(data: unknown) {
+  maybeSingleResults.push({ data });
+}
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => {
+    const chain: Record<string, unknown> = {};
+    const fn = () => chain;
+    chain.select = fn;
+    chain.eq = fn;
+    chain.in = fn;
+    chain.maybeSingle = () =>
+      Promise.resolve(maybeSingleResults.shift() ?? { data: null });
+    return { from: () => chain };
+  }),
+}));
+
+import { POST } from "@/app/api/teams/[slug]/briefs/bulk/route";
+
+function ctx() {
+  return { params: Promise.resolve({ slug: "alpha-squad" }) };
+}
+
+function postReq(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/teams/alpha-squad/briefs/bulk", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const VALID = { action: "claim", brief_ids: [1, 2, 3] };
+
+describe("POST /api/teams/[slug]/briefs/bulk", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    maybeSingleResults.length = 0;
+    isAllowedMock.mockResolvedValue(true);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(null);
+    expect((await POST(postReq(VALID), ctx())).status).toBe(401);
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    isAllowedMock.mockResolvedValueOnce(false);
+    expect((await POST(postReq(VALID), ctx())).status).toBe(429);
+  });
+
+  it("returns 400 on invalid body", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    expect((await POST(postReq({ action: "nope", brief_ids: [] }), ctx())).status).toBe(400);
+  });
+
+  it("returns 404 when team not found", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    pushResult(null); // team lookup
+    expect((await POST(postReq(VALID), ctx())).status).toBe(404);
+  });
+
+  it("returns 403 when caller is not an active member", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    pushResult({ id: 5 }); // team
+    pushResult(null); // member
+    expect((await POST(postReq(VALID), ctx())).status).toBe(403);
+  });
+
+  it("returns 400 when refer is missing to_team_id", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    pushResult({ id: 5 });
+    pushResult({ id: 9 });
+    const res = await POST(postReq({ action: "refer", brief_ids: [1] }), ctx());
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 200 when all briefs succeed", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    pushResult({ id: 5 });
+    pushResult({ id: 9 });
+    runBulkActionMock.mockResolvedValueOnce({
+      results: [{ briefId: 1, ok: true }],
+      summary: { total: 1, ok: 1, failed: 0 },
+    });
+    const res = await POST(postReq(VALID), ctx());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ summary: { failed: 0 } });
+  });
+
+  it("returns 207 on partial success", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    pushResult({ id: 5 });
+    pushResult({ id: 9 });
+    runBulkActionMock.mockResolvedValueOnce({
+      results: [],
+      summary: { total: 2, ok: 1, failed: 1 },
+    });
+    expect((await POST(postReq(VALID), ctx())).status).toBe(207);
+  });
+
+  it("returns 422 when all briefs fail", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    pushResult({ id: 5 });
+    pushResult({ id: 9 });
+    runBulkActionMock.mockResolvedValueOnce({
+      results: [],
+      summary: { total: 2, ok: 0, failed: 2 },
+    });
+    expect((await POST(postReq(VALID), ctx())).status).toBe(422);
+  });
+
+  it("returns 500 when runBulkAction throws", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    pushResult({ id: 5 });
+    pushResult({ id: 9 });
+    runBulkActionMock.mockRejectedValueOnce(new Error("boom"));
+    expect((await POST(postReq(VALID), ctx())).status).toBe(500);
+  });
+});

--- a/__tests__/api/teams-briefs-claim.test.ts
+++ b/__tests__/api/teams-briefs-claim.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+const isAllowedMock = vi.fn<() => Promise<boolean>>();
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: (..._args: unknown[]) => isAllowedMock(),
+  ipKey: () => "test-ip",
+}));
+
+const requireAdvisorSessionMock = vi.fn<() => Promise<number | null>>();
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: () => requireAdvisorSessionMock(),
+}));
+
+const resolveSquadRouteContextMock = vi.fn();
+const listOtherActiveMembersMock = vi.fn(async () => []);
+vi.mock("@/lib/team-brief-routes", () => ({
+  resolveSquadRouteContext: (...args: unknown[]) => resolveSquadRouteContextMock(...args),
+  listOtherActiveMembers: (...args: unknown[]) => listOtherActiveMembersMock(...args),
+}));
+
+const claimBriefForMemberMock = vi.fn();
+vi.mock("@/lib/team-brief-assignments", () => ({
+  claimBriefForMember: (...args: unknown[]) => claimBriefForMemberMock(...args),
+}));
+
+vi.mock("@/lib/marketplace-squad-emails", () => ({
+  sendSquadClaimNotification: vi.fn(async () => undefined),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({ maybeSingle: vi.fn(async () => ({ data: { name: "Bob" } })) })),
+      })),
+    })),
+  })),
+}));
+
+import { POST } from "@/app/api/teams/[slug]/briefs/[briefId]/claim/route";
+
+const ROUTE = {
+  teamId: 5,
+  teamSlug: "alpha-squad",
+  teamName: "Alpha Squad",
+  briefId: 42,
+  briefSlug: "brief-42",
+  briefTitle: "Tax help",
+};
+
+function ctx(slug = "alpha-squad", briefId = "42") {
+  return { params: Promise.resolve({ slug, briefId }) };
+}
+
+function postReq(body: unknown = {}): NextRequest {
+  return new NextRequest("http://localhost/api/teams/alpha-squad/briefs/42/claim", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("POST /api/teams/[slug]/briefs/[briefId]/claim", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isAllowedMock.mockResolvedValue(true);
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    isAllowedMock.mockResolvedValueOnce(false);
+    const res = await POST(postReq(), ctx());
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(null);
+    const res = await POST(postReq(), ctx());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 on invalid body", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    const res = await POST(postReq({ notes: 123 }), ctx());
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when route context cannot be resolved", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    resolveSquadRouteContextMock.mockResolvedValueOnce(null);
+    const res = await POST(postReq(), ctx());
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 409 when another member already claimed", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    resolveSquadRouteContextMock.mockResolvedValueOnce(ROUTE);
+    claimBriefForMemberMock.mockResolvedValueOnce({ ok: false, reason: "already_claimed" });
+    const res = await POST(postReq(), ctx());
+    expect(res.status).toBe(409);
+  });
+
+  it("claims the brief and returns success", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    resolveSquadRouteContextMock.mockResolvedValueOnce(ROUTE);
+    claimBriefForMemberMock.mockResolvedValueOnce({ ok: true, created: true, row: { id: 9 } });
+    const res = await POST(postReq({ notes: "mine" }), ctx());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ success: true, created: true, assignment: { id: 9 } });
+  });
+
+  it("returns 500 when the claim helper throws", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    resolveSquadRouteContextMock.mockResolvedValueOnce(ROUTE);
+    claimBriefForMemberMock.mockRejectedValueOnce(new Error("boom"));
+    const res = await POST(postReq(), ctx());
+    expect(res.status).toBe(500);
+  });
+});

--- a/__tests__/api/teams-briefs-complete.test.ts
+++ b/__tests__/api/teams-briefs-complete.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+const isAllowedMock = vi.fn<() => Promise<boolean>>();
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: (..._args: unknown[]) => isAllowedMock(),
+  ipKey: () => "test-ip",
+}));
+
+const requireAdvisorSessionMock = vi.fn<() => Promise<number | null>>();
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: () => requireAdvisorSessionMock(),
+}));
+
+const resolveSquadRouteContextMock = vi.fn();
+vi.mock("@/lib/team-brief-routes", () => ({
+  resolveSquadRouteContext: (...args: unknown[]) => resolveSquadRouteContextMock(...args),
+}));
+
+const completeBriefAssignmentMock = vi.fn();
+vi.mock("@/lib/team-brief-assignments", () => ({
+  completeBriefAssignment: (...args: unknown[]) => completeBriefAssignmentMock(...args),
+}));
+
+import { POST } from "@/app/api/teams/[slug]/briefs/[briefId]/complete/route";
+
+const ROUTE = { teamId: 5, briefId: 42, briefSlug: "b", briefTitle: "T", teamSlug: "a", teamName: "A" };
+
+function ctx() {
+  return { params: Promise.resolve({ slug: "alpha-squad", briefId: "42" }) };
+}
+
+function postReq(body: unknown = {}): NextRequest {
+  return new NextRequest("http://localhost/api/teams/alpha-squad/briefs/42/complete", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("POST /api/teams/[slug]/briefs/[briefId]/complete", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isAllowedMock.mockResolvedValue(true);
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    isAllowedMock.mockResolvedValueOnce(false);
+    expect((await POST(postReq(), ctx())).status).toBe(429);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(null);
+    expect((await POST(postReq(), ctx())).status).toBe(401);
+  });
+
+  it("returns 400 on invalid body", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    expect((await POST(postReq({ note: 5 }), ctx())).status).toBe(400);
+  });
+
+  it("returns 404 when route context cannot be resolved", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    resolveSquadRouteContextMock.mockResolvedValueOnce(null);
+    expect((await POST(postReq(), ctx())).status).toBe(404);
+  });
+
+  it("returns 409 when no claim exists", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    resolveSquadRouteContextMock.mockResolvedValueOnce(ROUTE);
+    completeBriefAssignmentMock.mockResolvedValueOnce(null);
+    expect((await POST(postReq(), ctx())).status).toBe(409);
+  });
+
+  it("completes the assignment and returns success", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    resolveSquadRouteContextMock.mockResolvedValueOnce(ROUTE);
+    completeBriefAssignmentMock.mockResolvedValueOnce({ id: 9, status: "completed" });
+    const res = await POST(postReq(), ctx());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ success: true, assignment: { id: 9 } });
+  });
+
+  it("returns 500 when the helper throws", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    resolveSquadRouteContextMock.mockResolvedValueOnce(ROUTE);
+    completeBriefAssignmentMock.mockRejectedValueOnce(new Error("boom"));
+    expect((await POST(postReq(), ctx())).status).toBe(500);
+  });
+});

--- a/__tests__/api/teams-briefs-handoff.test.ts
+++ b/__tests__/api/teams-briefs-handoff.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+const isAllowedMock = vi.fn<() => Promise<boolean>>();
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: (..._args: unknown[]) => isAllowedMock(),
+  ipKey: () => "test-ip",
+}));
+
+const requireAdvisorSessionMock = vi.fn<() => Promise<number | null>>();
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: () => requireAdvisorSessionMock(),
+}));
+
+const resolveSquadRouteContextMock = vi.fn();
+vi.mock("@/lib/team-brief-routes", () => ({
+  resolveSquadRouteContext: (...args: unknown[]) => resolveSquadRouteContextMock(...args),
+}));
+
+const handoffBriefAssignmentMock = vi.fn();
+vi.mock("@/lib/team-brief-assignments", () => ({
+  handoffBriefAssignment: (...args: unknown[]) => handoffBriefAssignmentMock(...args),
+}));
+
+// Admin client used only for the to_professional_id membership check.
+const memberMaybeSingleMock = vi.fn(async () => ({ data: { id: 3, status: "active" } }));
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          eq: vi.fn(() => ({ maybeSingle: () => memberMaybeSingleMock() })),
+        })),
+      })),
+    })),
+  })),
+}));
+
+import { POST } from "@/app/api/teams/[slug]/briefs/[briefId]/handoff/route";
+
+const ROUTE = { teamId: 5, briefId: 42, briefSlug: "b", briefTitle: "T", teamSlug: "a", teamName: "A" };
+
+function ctx() {
+  return { params: Promise.resolve({ slug: "alpha-squad", briefId: "42" }) };
+}
+
+function postReq(body: unknown = {}): NextRequest {
+  return new NextRequest("http://localhost/api/teams/alpha-squad/briefs/42/handoff", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("POST /api/teams/[slug]/briefs/[briefId]/handoff", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isAllowedMock.mockResolvedValue(true);
+    memberMaybeSingleMock.mockResolvedValue({ data: { id: 3, status: "active" } });
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    isAllowedMock.mockResolvedValueOnce(false);
+    expect((await POST(postReq(), ctx())).status).toBe(429);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(null);
+    expect((await POST(postReq(), ctx())).status).toBe(401);
+  });
+
+  it("returns 400 on invalid body", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    expect((await POST(postReq({ to_professional_id: -1 }), ctx())).status).toBe(400);
+  });
+
+  it("returns 404 when route context cannot be resolved", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    resolveSquadRouteContextMock.mockResolvedValueOnce(null);
+    expect((await POST(postReq(), ctx())).status).toBe(404);
+  });
+
+  it("returns 400 when handoff target is not an active member", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    resolveSquadRouteContextMock.mockResolvedValueOnce(ROUTE);
+    memberMaybeSingleMock.mockResolvedValueOnce({ data: { id: 3, status: "invited" } });
+    const res = await POST(postReq({ to_professional_id: 7 }), ctx());
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 409 when caller has no active claim", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    resolveSquadRouteContextMock.mockResolvedValueOnce(ROUTE);
+    handoffBriefAssignmentMock.mockResolvedValueOnce(null);
+    expect((await POST(postReq(), ctx())).status).toBe(409);
+  });
+
+  it("hands off the brief and returns from/to rows", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    resolveSquadRouteContextMock.mockResolvedValueOnce(ROUTE);
+    handoffBriefAssignmentMock.mockResolvedValueOnce({
+      fromRow: { id: 1, status: "handed_off" },
+      toRow: { id: 2, status: "claimed" },
+    });
+    const res = await POST(postReq({ to_professional_id: 7, note: "yours now" }), ctx());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ success: true, from: { id: 1 }, to: { id: 2 } });
+  });
+
+  it("returns 500 when the helper throws", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    resolveSquadRouteContextMock.mockResolvedValueOnce(ROUTE);
+    handoffBriefAssignmentMock.mockRejectedValueOnce(new Error("boom"));
+    expect((await POST(postReq(), ctx())).status).toBe(500);
+  });
+});

--- a/__tests__/api/teams-briefs-release.test.ts
+++ b/__tests__/api/teams-briefs-release.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+const isAllowedMock = vi.fn<() => Promise<boolean>>();
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: (..._args: unknown[]) => isAllowedMock(),
+  ipKey: () => "test-ip",
+}));
+
+const requireAdvisorSessionMock = vi.fn<() => Promise<number | null>>();
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: () => requireAdvisorSessionMock(),
+}));
+
+const resolveSquadRouteContextMock = vi.fn();
+vi.mock("@/lib/team-brief-routes", () => ({
+  resolveSquadRouteContext: (...args: unknown[]) => resolveSquadRouteContextMock(...args),
+}));
+
+const releaseBriefAssignmentMock = vi.fn();
+vi.mock("@/lib/team-brief-assignments", () => ({
+  releaseBriefAssignment: (...args: unknown[]) => releaseBriefAssignmentMock(...args),
+}));
+
+import { POST } from "@/app/api/teams/[slug]/briefs/[briefId]/release/route";
+
+const ROUTE = { teamId: 5, briefId: 42, briefSlug: "b", briefTitle: "T", teamSlug: "a", teamName: "A" };
+
+function ctx() {
+  return { params: Promise.resolve({ slug: "alpha-squad", briefId: "42" }) };
+}
+
+function postReq(body: unknown = {}): NextRequest {
+  return new NextRequest("http://localhost/api/teams/alpha-squad/briefs/42/release", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("POST /api/teams/[slug]/briefs/[briefId]/release", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isAllowedMock.mockResolvedValue(true);
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    isAllowedMock.mockResolvedValueOnce(false);
+    expect((await POST(postReq(), ctx())).status).toBe(429);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(null);
+    expect((await POST(postReq(), ctx())).status).toBe(401);
+  });
+
+  it("returns 400 on invalid body", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    expect((await POST(postReq({ note: 5 }), ctx())).status).toBe(400);
+  });
+
+  it("returns 404 when route context cannot be resolved", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    resolveSquadRouteContextMock.mockResolvedValueOnce(null);
+    expect((await POST(postReq(), ctx())).status).toBe(404);
+  });
+
+  it("returns 409 when no claim exists", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    resolveSquadRouteContextMock.mockResolvedValueOnce(ROUTE);
+    releaseBriefAssignmentMock.mockResolvedValueOnce(null);
+    expect((await POST(postReq(), ctx())).status).toBe(409);
+  });
+
+  it("releases the assignment and returns success", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    resolveSquadRouteContextMock.mockResolvedValueOnce(ROUTE);
+    releaseBriefAssignmentMock.mockResolvedValueOnce({ id: 9, status: "released" });
+    const res = await POST(postReq(), ctx());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ success: true, assignment: { id: 9 } });
+  });
+
+  it("returns 500 when the helper throws", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    resolveSquadRouteContextMock.mockResolvedValueOnce(ROUTE);
+    releaseBriefAssignmentMock.mockRejectedValueOnce(new Error("boom"));
+    expect((await POST(postReq(), ctx())).status).toBe(500);
+  });
+});

--- a/__tests__/api/teams-decisions.test.ts
+++ b/__tests__/api/teams-decisions.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+const isAllowedMock = vi.fn<() => Promise<boolean>>();
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: (..._args: unknown[]) => isAllowedMock(),
+  ipKey: () => "test-ip",
+}));
+
+const requireAdvisorSessionMock = vi.fn<() => Promise<number | null>>();
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: () => requireAdvisorSessionMock(),
+}));
+
+const recordDecisionMock = vi.fn();
+const clearDecisionMock = vi.fn(async () => undefined);
+vi.mock("@/lib/team-brief-decisions", () => ({
+  recordDecision: (...args: unknown[]) => recordDecisionMock(...args),
+  clearDecision: (...args: unknown[]) => clearDecisionMock(...args),
+}));
+
+const maybeSingleResults: Array<{ data: unknown }> = [];
+function pushResult(data: unknown) {
+  maybeSingleResults.push({ data });
+}
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => {
+    const chain: Record<string, unknown> = {};
+    const fn = () => chain;
+    chain.select = fn;
+    chain.eq = fn;
+    chain.maybeSingle = () =>
+      Promise.resolve(maybeSingleResults.shift() ?? { data: null });
+    return { from: () => chain };
+  }),
+}));
+
+import { POST, DELETE } from "@/app/api/teams/[slug]/decisions/route";
+
+function ctx() {
+  return { params: Promise.resolve({ slug: "alpha-squad" }) };
+}
+
+function makeReq(method: string, body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/teams/alpha-squad/decisions", {
+    method,
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const VALID_POST = { briefId: 42, decision: "not_for_us", reason: "out of scope" };
+
+describe("POST /api/teams/[slug]/decisions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    maybeSingleResults.length = 0;
+    isAllowedMock.mockResolvedValue(true);
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    isAllowedMock.mockResolvedValueOnce(false);
+    expect((await POST(makeReq("POST", VALID_POST), ctx())).status).toBe(429);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(null);
+    expect((await POST(makeReq("POST", VALID_POST), ctx())).status).toBe(401);
+  });
+
+  it("returns 400 on invalid body", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    expect((await POST(makeReq("POST", { briefId: 1, decision: "maybe" }), ctx())).status).toBe(400);
+  });
+
+  it("returns 404 when team not found", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    pushResult(null);
+    expect((await POST(makeReq("POST", VALID_POST), ctx())).status).toBe(404);
+  });
+
+  it("returns 403 when not an active member", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    pushResult({ id: 5 });
+    pushResult(null);
+    expect((await POST(makeReq("POST", VALID_POST), ctx())).status).toBe(403);
+  });
+
+  it("records the decision and returns it", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    pushResult({ id: 5 });
+    pushResult({ id: 9 });
+    recordDecisionMock.mockResolvedValueOnce({ id: 1, decision: "not_for_us" });
+    const res = await POST(makeReq("POST", VALID_POST), ctx());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ decision: { id: 1 } });
+  });
+
+  it("returns 500 when recordDecision throws", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    pushResult({ id: 5 });
+    pushResult({ id: 9 });
+    recordDecisionMock.mockRejectedValueOnce(new Error("boom"));
+    expect((await POST(makeReq("POST", VALID_POST), ctx())).status).toBe(500);
+  });
+});
+
+describe("DELETE /api/teams/[slug]/decisions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    maybeSingleResults.length = 0;
+    isAllowedMock.mockResolvedValue(true);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(null);
+    expect((await DELETE(makeReq("DELETE", { briefId: 1 }), ctx())).status).toBe(401);
+  });
+
+  it("returns 400 on invalid body", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    expect((await DELETE(makeReq("DELETE", { briefId: -1 }), ctx())).status).toBe(400);
+  });
+
+  it("returns 403 when not an active member", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    pushResult({ id: 5 });
+    pushResult(null);
+    expect((await DELETE(makeReq("DELETE", { briefId: 1 }), ctx())).status).toBe(403);
+  });
+
+  it("clears the decision and returns ok", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    pushResult({ id: 5 });
+    pushResult({ id: 9 });
+    const res = await DELETE(makeReq("DELETE", { briefId: 1 }), ctx());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(clearDecisionMock).toHaveBeenCalled();
+  });
+});

--- a/__tests__/api/teams-ops-settings.test.ts
+++ b/__tests__/api/teams-ops-settings.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+const isAllowedMock = vi.fn<() => Promise<boolean>>();
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: (..._args: unknown[]) => isAllowedMock(),
+  ipKey: () => "test-ip",
+}));
+
+const requireAdvisorSessionMock = vi.fn<() => Promise<number | null>>();
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: () => requireAdvisorSessionMock(),
+}));
+
+// Queued results, consumed in route order:
+//   1. team lookup (maybeSingle)
+//   2. membership lookup (maybeSingle)
+//   3. (round_robin only) active-members .in() lookup -> awaited chain
+//   4. update().eq() -> awaited chain ({ error })
+const maybeSingleResults: Array<{ data: unknown }> = [];
+const inResults: Array<{ data: unknown }> = [];
+const updateResults: Array<{ error: unknown }> = [];
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => {
+    function makeChain() {
+      const chain: Record<string, unknown> = {};
+      const self = () => chain;
+      chain.select = self;
+      chain.eq = self;
+      chain.maybeSingle = () =>
+        Promise.resolve(maybeSingleResults.shift() ?? { data: null });
+      // .in() is terminal (awaited) for the active-members validation.
+      chain.in = () => Promise.resolve(inResults.shift() ?? { data: [] });
+      return chain;
+    }
+    return {
+      from: () => {
+        const chain = makeChain() as Record<string, unknown>;
+        // update().eq() is terminal returning { error }.
+        chain.update = () => ({
+          eq: () => Promise.resolve(updateResults.shift() ?? { error: null }),
+        });
+        return chain;
+      },
+    };
+  }),
+}));
+
+import { PATCH } from "@/app/api/teams/[slug]/ops-settings/route";
+
+function ctx() {
+  return { params: Promise.resolve({ slug: "alpha-squad" }) };
+}
+
+function patchReq(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/teams/alpha-squad/ops-settings", {
+    method: "PATCH",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("PATCH /api/teams/[slug]/ops-settings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    maybeSingleResults.length = 0;
+    inResults.length = 0;
+    updateResults.length = 0;
+    isAllowedMock.mockResolvedValue(true);
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    isAllowedMock.mockResolvedValueOnce(false);
+    expect((await PATCH(patchReq({ auto_claim_mode: "manual" }), ctx())).status).toBe(429);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(null);
+    expect((await PATCH(patchReq({ auto_claim_mode: "manual" }), ctx())).status).toBe(401);
+  });
+
+  it("returns 400 on invalid body", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    expect((await PATCH(patchReq({ auto_claim_mode: "chaos" }), ctx())).status).toBe(400);
+  });
+
+  it("returns 404 when team not found", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    maybeSingleResults.push({ data: null });
+    expect((await PATCH(patchReq({ auto_claim_mode: "manual" }), ctx())).status).toBe(404);
+  });
+
+  it("returns 403 when not an active member", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    maybeSingleResults.push({ data: { id: 5 } });
+    maybeSingleResults.push({ data: null });
+    expect((await PATCH(patchReq({ auto_claim_mode: "manual" }), ctx())).status).toBe(403);
+  });
+
+  it("returns 400 when round_robin members are not active", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    maybeSingleResults.push({ data: { id: 5 } });
+    maybeSingleResults.push({ data: { id: 9 } });
+    inResults.push({ data: [{ professional_id: 7 }] }); // 8 is missing
+    const res = await PATCH(
+      patchReq({ auto_claim_mode: "round_robin", auto_claim_member_ids: [7, 8] }),
+      ctx(),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns ok with no-op when no updatable fields supplied", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    maybeSingleResults.push({ data: { id: 5 } });
+    maybeSingleResults.push({ data: { id: 9 } });
+    const res = await PATCH(patchReq({}), ctx());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it("updates specialty_tags and returns ok", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    maybeSingleResults.push({ data: { id: 5 } });
+    maybeSingleResults.push({ data: { id: 9 } });
+    updateResults.push({ error: null });
+    const res = await PATCH(patchReq({ specialty_tags: ["tax", "smsf"] }), ctx());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it("returns 500 when the update errors", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    maybeSingleResults.push({ data: { id: 5 } });
+    maybeSingleResults.push({ data: { id: 9 } });
+    updateResults.push({ error: { message: "boom" } });
+    const res = await PATCH(patchReq({ specialty_tags: ["tax"] }), ctx());
+    expect(res.status).toBe(500);
+  });
+});

--- a/__tests__/api/teams-quotes.test.ts
+++ b/__tests__/api/teams-quotes.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+const isAllowedMock = vi.fn<() => Promise<boolean>>();
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: (..._args: unknown[]) => isAllowedMock(),
+  ipKey: () => "test-ip",
+}));
+
+const requireAdvisorSessionMock = vi.fn<() => Promise<number | null>>();
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: () => requireAdvisorSessionMock(),
+}));
+
+const createFixedQuoteMock = vi.fn();
+vi.mock("@/lib/expert-teams/fixed-quotes", () => ({
+  createFixedQuote: (...args: unknown[]) => createFixedQuoteMock(...args),
+}));
+
+vi.mock("@/lib/resend", () => ({ sendEmail: vi.fn(async () => undefined) }));
+vi.mock("@/lib/seo", () => ({ SITE_URL: "https://invest.com.au" }));
+
+const maybeSingleResults: Array<{ data: unknown }> = [];
+function pushResult(data: unknown) {
+  maybeSingleResults.push({ data });
+}
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => {
+    const chain: Record<string, unknown> = {};
+    const fn = () => chain;
+    chain.select = fn;
+    chain.eq = fn;
+    chain.maybeSingle = () =>
+      Promise.resolve(maybeSingleResults.shift() ?? { data: null });
+    return { from: () => chain };
+  }),
+}));
+
+import { POST } from "@/app/api/teams/[slug]/quotes/route";
+
+function ctx() {
+  return { params: Promise.resolve({ slug: "alpha-squad" }) };
+}
+
+function postReq(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/teams/alpha-squad/quotes", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const VALID = {
+  brief_id: 42,
+  amount_cents: 250000,
+  scope_items: [{ label: "Tax return", estimated_hours: 4 }],
+};
+
+const TEAM = { id: 5, name: "Alpha Squad" };
+const BRIEF = {
+  id: 42,
+  slug: "brief-42",
+  job_title: "Tax help",
+  contact_email: "client@example.com",
+  contact_name: "Client",
+  status: "open",
+  accepted_by_team_id: 5,
+};
+
+describe("POST /api/teams/[slug]/quotes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    maybeSingleResults.length = 0;
+    isAllowedMock.mockResolvedValue(true);
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    isAllowedMock.mockResolvedValueOnce(false);
+    expect((await POST(postReq(VALID), ctx())).status).toBe(429);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(null);
+    expect((await POST(postReq(VALID), ctx())).status).toBe(401);
+  });
+
+  it("returns 400 on invalid body", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    expect((await POST(postReq({ brief_id: 0, amount_cents: -1, scope_items: [] }), ctx())).status).toBe(400);
+  });
+
+  it("returns 404 when team not found", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    pushResult(null);
+    expect((await POST(postReq(VALID), ctx())).status).toBe(404);
+  });
+
+  it("returns 403 when not an active member", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    pushResult(TEAM);
+    pushResult(null);
+    expect((await POST(postReq(VALID), ctx())).status).toBe(403);
+  });
+
+  it("returns 404 when brief not accepted by this team", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    pushResult(TEAM);
+    pushResult({ id: 9 });
+    pushResult({ ...BRIEF, accepted_by_team_id: 999 });
+    expect((await POST(postReq(VALID), ctx())).status).toBe(404);
+  });
+
+  it("returns 409 when brief is not open", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    pushResult(TEAM);
+    pushResult({ id: 9 });
+    pushResult({ ...BRIEF, status: "closed" });
+    expect((await POST(postReq(VALID), ctx())).status).toBe(409);
+  });
+
+  it("returns 409 when quote creation is blocked", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    pushResult(TEAM);
+    pushResult({ id: 9 });
+    pushResult(BRIEF);
+    createFixedQuoteMock.mockResolvedValueOnce(null);
+    expect((await POST(postReq(VALID), ctx())).status).toBe(409);
+  });
+
+  it("creates a quote and returns the token", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    pushResult(TEAM);
+    pushResult({ id: 9 });
+    pushResult(BRIEF);
+    createFixedQuoteMock.mockResolvedValueOnce({
+      id: 77,
+      review_token: "tok_abc",
+      amount_cents: 250000,
+      expires_at: "2026-06-01T00:00:00Z",
+    });
+    const res = await POST(postReq(VALID), ctx());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ quote_id: 77, review_token: "tok_abc" });
+  });
+
+  it("returns 500 when createFixedQuote throws", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    pushResult(TEAM);
+    pushResult({ id: 9 });
+    pushResult(BRIEF);
+    createFixedQuoteMock.mockRejectedValueOnce(new Error("boom"));
+    expect((await POST(postReq(VALID), ctx())).status).toBe(500);
+  });
+});

--- a/__tests__/api/teams-referrals.test.ts
+++ b/__tests__/api/teams-referrals.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+const isAllowedMock = vi.fn<() => Promise<boolean>>();
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: (..._args: unknown[]) => isAllowedMock(),
+  ipKey: () => "test-ip",
+}));
+
+const requireAdvisorSessionMock = vi.fn<() => Promise<number | null>>();
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: () => requireAdvisorSessionMock(),
+}));
+
+// Use a real ReferralError so `instanceof` in the route works. The class
+// must be created inside vi.hoisted so it exists when the hoisted vi.mock
+// factory runs (see CLAUDE.md vi.mock hoisting note).
+const { ReferralError, createReferralMock } = vi.hoisted(() => {
+  class ReferralError extends Error {
+    constructor(
+      public code: string,
+      message?: string,
+    ) {
+      super(message ?? code);
+      this.name = "ReferralError";
+    }
+  }
+  return { ReferralError, createReferralMock: vi.fn() };
+});
+vi.mock("@/lib/team-brief-referrals", () => ({
+  ReferralError,
+  createReferral: (...args: unknown[]) => createReferralMock(...args),
+}));
+
+vi.mock("@/lib/marketplace-squad-emails", () => ({
+  sendReferralReceivedEmail: vi.fn(async () => undefined),
+}));
+
+// from-team lookup returns { data, error }.
+const teamResults: Array<{ data: unknown; error: unknown }> = [];
+function pushTeam(data: unknown, error: unknown = null) {
+  teamResults.push({ data, error });
+}
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => {
+    const chain: Record<string, unknown> = {};
+    const fn = () => chain;
+    chain.select = fn;
+    chain.eq = fn;
+    chain.maybeSingle = () =>
+      Promise.resolve(teamResults.shift() ?? { data: null, error: null });
+    return { from: () => chain };
+  }),
+}));
+
+import { POST } from "@/app/api/teams/[slug]/referrals/route";
+
+function ctx() {
+  return { params: Promise.resolve({ slug: "alpha-squad" }) };
+}
+
+function postReq(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/teams/alpha-squad/referrals", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const VALID = { briefId: 42, toTeamId: 9, note: "good fit for you" };
+const FROM_TEAM = { id: 5, name: "Alpha Squad", verification_status: "verified" };
+
+describe("POST /api/teams/[slug]/referrals", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    teamResults.length = 0;
+    isAllowedMock.mockResolvedValue(true);
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    isAllowedMock.mockResolvedValueOnce(false);
+    expect((await POST(postReq(VALID), ctx())).status).toBe(429);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(null);
+    expect((await POST(postReq(VALID), ctx())).status).toBe(401);
+  });
+
+  it("returns 500 when the team lookup errors", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    pushTeam(null, { message: "boom" });
+    expect((await POST(postReq(VALID), ctx())).status).toBe(500);
+  });
+
+  it("returns 404 when from-team not found", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    pushTeam(null);
+    expect((await POST(postReq(VALID), ctx())).status).toBe(404);
+  });
+
+  it("returns 400 on invalid body", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    pushTeam(FROM_TEAM);
+    expect((await POST(postReq({ briefId: 0, toTeamId: 0 }), ctx())).status).toBe(400);
+  });
+
+  it("creates a referral and returns 201", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    pushTeam(FROM_TEAM);
+    createReferralMock.mockResolvedValueOnce({ id: 11, status: "pending" });
+    const res = await POST(postReq(VALID), ctx());
+    expect(res.status).toBe(201);
+    expect(await res.json()).toMatchObject({ referral: { id: 11 } });
+  });
+
+  it("maps ReferralError(not_team_member) to 403", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    pushTeam(FROM_TEAM);
+    createReferralMock.mockRejectedValueOnce(new ReferralError("not_team_member"));
+    const res = await POST(postReq(VALID), ctx());
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "not_team_member" });
+  });
+
+  it("maps ReferralError(duplicate_referral) to 409", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    pushTeam(FROM_TEAM);
+    createReferralMock.mockRejectedValueOnce(new ReferralError("duplicate_referral"));
+    expect((await POST(postReq(VALID), ctx())).status).toBe(409);
+  });
+
+  it("maps ReferralError(self_referral_not_allowed) to 400", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    pushTeam(FROM_TEAM);
+    createReferralMock.mockRejectedValueOnce(new ReferralError("self_referral_not_allowed"));
+    expect((await POST(postReq(VALID), ctx())).status).toBe(400);
+  });
+
+  it("returns 500 on a non-ReferralError throw", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(1);
+    pushTeam(FROM_TEAM);
+    createReferralMock.mockRejectedValueOnce(new Error("boom"));
+    expect((await POST(postReq(VALID), ctx())).status).toBe(500);
+  });
+});


### PR DESCRIPTION
## Summary
Adds vitest unit tests for 9 previously-untested `app/api/teams/*` routes (brief claim/complete/handoff/release, bulk actions, decisions, ops-settings, quotes, referrals). 79 tests covering rate-limit (429), auth/membership/ownership gating (401/403), not-found (404), zod rejection (400), conflict states (409/422), happy paths, and helper/DB error (500). Helper libs mocked so tests target route logic.

## Queue item
D-COV (pre-launch coverage push) — untested API routes surfaced 2026-05-20. Moves M02 (API routes with tests, 57→200).

## Supersedes
_None._

## Test plan
- [x] `vitest run __tests__/api/teams-*.test.ts` → 79/79 pass locally
- [ ] CI green