### PR TITLE
test(d): add unit tests for pros/* API routes

### DIFF
--- a/__tests__/api/pros-billing-auto-recharge.test.ts
+++ b/__tests__/api/pros-billing-auto-recharge.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockIsAllowed, mockRequireAdvisorSession, mockFrom, mockGetPack } =
+  vi.hoisted(() => ({
+    mockIsAllowed: vi.fn(),
+    mockRequireAdvisorSession: vi.fn(),
+    mockFrom: vi.fn(),
+    mockGetPack: vi.fn(),
+  }));
+
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: mockIsAllowed,
+  ipKey: vi.fn(() => "ip:test"),
+}));
+
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: mockRequireAdvisorSession,
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+vi.mock("@/lib/advisor-credit-packs", () => ({
+  getPack: mockGetPack,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import { POST } from "@/app/api/pros/billing/auto-recharge/route";
+
+const VALID_BODY = {
+  enabled: true,
+  threshold_credits: 10,
+  pack_slug: "marketplace_50",
+};
+
+function makeReq(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/pros/billing/auto-recharge", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+// from().update().eq() — terminal eq() resolves.
+function makeUpdateChain(result: { error: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  chain.update = vi.fn(() => chain);
+  chain.eq = vi.fn(() => Promise.resolve(result));
+  return chain;
+}
+
+const MARKETPLACE_PACK = { slug: "marketplace_50", isCredit: true };
+
+describe("POST /api/pros/billing/auto-recharge", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowed.mockResolvedValue(true);
+    mockRequireAdvisorSession.mockResolvedValue(42);
+    mockGetPack.mockReturnValue(MARKETPLACE_PACK);
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    mockIsAllowed.mockResolvedValueOnce(false);
+    const res = await POST(makeReq(VALID_BODY));
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 401 when not an advisor session", async () => {
+    mockRequireAdvisorSession.mockResolvedValueOnce(null);
+    const res = await POST(makeReq(VALID_BODY));
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "Sign in required." });
+  });
+
+  it("returns 400 on invalid JSON body", async () => {
+    const req = new NextRequest("http://localhost/api/pros/billing/auto-recharge", {
+      method: "POST",
+      body: "not json",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when zod validation fails", async () => {
+    const res = await POST(makeReq({ enabled: true, threshold_credits: 0, pack_slug: "" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when the pack is not a marketplace credit pack", async () => {
+    mockGetPack.mockReturnValueOnce({ slug: "starter", isCredit: true });
+    const res = await POST(makeReq({ ...VALID_BODY, pack_slug: "starter" }));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Pack must be a marketplace credit pack." });
+  });
+
+  it("returns 400 when getPack returns null", async () => {
+    mockGetPack.mockReturnValueOnce(null);
+    const res = await POST(makeReq({ ...VALID_BODY, pack_slug: "marketplace_nope" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("saves settings and returns success", async () => {
+    const chain = makeUpdateChain({ error: null });
+    mockFrom.mockReturnValueOnce(chain);
+    const res = await POST(makeReq(VALID_BODY));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true });
+    expect(mockFrom).toHaveBeenCalledWith("professionals");
+    expect(chain.eq).toHaveBeenCalledWith("id", 42);
+    const updateArg = chain.update.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(updateArg).toMatchObject({
+      auto_recharge_enabled: true,
+      auto_recharge_threshold_credits: 10,
+      auto_recharge_pack_slug: "marketplace_50",
+    });
+  });
+
+  it("returns 500 when the update errors", async () => {
+    mockFrom.mockReturnValueOnce(makeUpdateChain({ error: { message: "boom" } }));
+    const res = await POST(makeReq(VALID_BODY));
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: "Could not save." });
+  });
+});

--- a/__tests__/api/pros-billing-portal.test.ts
+++ b/__tests__/api/pros-billing-portal.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockIsAllowed, mockRequireAdvisorSession, mockCreateBillingPortalUrl } =
+  vi.hoisted(() => ({
+    mockIsAllowed: vi.fn(),
+    mockRequireAdvisorSession: vi.fn(),
+    mockCreateBillingPortalUrl: vi.fn(),
+  }));
+
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: mockIsAllowed,
+  ipKey: vi.fn(() => "ip:test"),
+}));
+
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: mockRequireAdvisorSession,
+}));
+
+vi.mock("@/lib/pro-subscription/billing", () => ({
+  createBillingPortalUrl: mockCreateBillingPortalUrl,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import { POST } from "@/app/api/pros/billing/portal/route";
+
+function makeReq(): NextRequest {
+  return new NextRequest("http://localhost/api/pros/billing/portal", { method: "POST" });
+}
+
+describe("POST /api/pros/billing/portal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowed.mockResolvedValue(true);
+    mockRequireAdvisorSession.mockResolvedValue(42);
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    mockIsAllowed.mockResolvedValueOnce(false);
+    const res = await POST(makeReq());
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 401 when not an advisor session", async () => {
+    mockRequireAdvisorSession.mockResolvedValueOnce(null);
+    const res = await POST(makeReq());
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "Sign in required." });
+  });
+
+  it("returns the portal url on success", async () => {
+    mockCreateBillingPortalUrl.mockResolvedValueOnce({ url: "https://stripe.test/portal" });
+    const res = await POST(makeReq());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ url: "https://stripe.test/portal" });
+    expect(mockCreateBillingPortalUrl).toHaveBeenCalledWith(42);
+  });
+
+  it("returns 404 when the pro has no billing account yet", async () => {
+    mockCreateBillingPortalUrl.mockResolvedValueOnce({
+      unavailable: true,
+      reason: "No billing account for this pro",
+    });
+    const res = await POST(makeReq());
+    expect(res.status).toBe(404);
+    expect((await res.json()).error).toMatch(/subscribe first/i);
+  });
+
+  it("returns 503 when Stripe billing is unconfigured", async () => {
+    mockCreateBillingPortalUrl.mockResolvedValueOnce({
+      unavailable: true,
+      reason: "Stripe not configured",
+    });
+    const res = await POST(makeReq());
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: "Subscription billing is not configured." });
+  });
+
+  it("returns 500 when createBillingPortalUrl throws", async () => {
+    mockCreateBillingPortalUrl.mockRejectedValueOnce(new Error("boom"));
+    const res = await POST(makeReq());
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: "Could not open billing portal." });
+  });
+});

--- a/__tests__/api/pros-billing-subscribe.test.ts
+++ b/__tests__/api/pros-billing-subscribe.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const {
+  mockIsAllowed,
+  mockRequireAdvisorSession,
+  mockCreateCheckoutSession,
+  mockCheckStripeEnv,
+} = vi.hoisted(() => ({
+  mockIsAllowed: vi.fn(),
+  mockRequireAdvisorSession: vi.fn(),
+  mockCreateCheckoutSession: vi.fn(),
+  mockCheckStripeEnv: vi.fn(),
+}));
+
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: mockIsAllowed,
+  ipKey: vi.fn(() => "ip:test"),
+}));
+
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: mockRequireAdvisorSession,
+}));
+
+vi.mock("@/lib/pro-subscription/billing", () => ({
+  createCheckoutSession: mockCreateCheckoutSession,
+}));
+
+vi.mock("@/lib/stripe-env-check", () => ({
+  checkStripeEnv: mockCheckStripeEnv,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import { POST } from "@/app/api/pros/billing/subscribe/route";
+
+function makeReq(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/pros/billing/subscribe", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/pros/billing/subscribe", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowed.mockResolvedValue(true);
+    mockRequireAdvisorSession.mockResolvedValue(42);
+    mockCheckStripeEnv.mockReturnValue({ ok: true, missing: [] });
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    mockIsAllowed.mockResolvedValueOnce(false);
+    const res = await POST(makeReq({ tier: "starter" }));
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 401 when not an advisor session", async () => {
+    mockRequireAdvisorSession.mockResolvedValueOnce(null);
+    const res = await POST(makeReq({ tier: "starter" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 on invalid JSON body", async () => {
+    const req = new NextRequest("http://localhost/api/pros/billing/subscribe", {
+      method: "POST",
+      body: "not json",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when tier is not a valid enum", async () => {
+    const res = await POST(makeReq({ tier: "platinum" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 503 with missing env vars when Stripe price ids are unset", async () => {
+    mockCheckStripeEnv.mockReturnValueOnce({
+      ok: false,
+      missing: ["STRIPE_PRICE_ID_STARTER"],
+    });
+    const res = await POST(makeReq({ tier: "starter" }));
+    expect(res.status).toBe(503);
+    expect(await res.json()).toMatchObject({
+      error: "Subscription billing is not configured.",
+      missing: ["STRIPE_PRICE_ID_STARTER"],
+    });
+    expect(mockCheckStripeEnv).toHaveBeenCalledWith({ required: ["STRIPE_PRICE_ID_STARTER"] });
+  });
+
+  it("returns the checkout url on success", async () => {
+    mockCreateCheckoutSession.mockResolvedValueOnce({ url: "https://stripe.test/checkout" });
+    const res = await POST(makeReq({ tier: "growth" }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ url: "https://stripe.test/checkout" });
+    expect(mockCreateCheckoutSession).toHaveBeenCalledWith({
+      professionalId: 42,
+      tier: "growth",
+    });
+  });
+
+  it("returns 503 when checkout session is unavailable", async () => {
+    mockCreateCheckoutSession.mockResolvedValueOnce({ unavailable: true });
+    const res = await POST(makeReq({ tier: "scale" }));
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: "Subscription billing is not configured." });
+  });
+
+  it("returns 500 when createCheckoutSession throws", async () => {
+    mockCreateCheckoutSession.mockRejectedValueOnce(new Error("boom"));
+    const res = await POST(makeReq({ tier: "starter" }));
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: "Could not start checkout." });
+  });
+});

--- a/__tests__/api/pros-connect-onboarding.test.ts
+++ b/__tests__/api/pros-connect-onboarding.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const {
+  mockIsAllowed,
+  mockGetUser,
+  mockFrom,
+  mockCreateConnectOnboardingLink,
+} = vi.hoisted(() => ({
+  mockIsAllowed: vi.fn(),
+  mockGetUser: vi.fn(),
+  mockFrom: vi.fn(),
+  mockCreateConnectOnboardingLink: vi.fn(),
+}));
+
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: mockIsAllowed,
+  ipKey: vi.fn(() => "ip:test"),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({ auth: { getUser: mockGetUser } })),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+vi.mock("@/lib/stripe-connect", () => ({
+  createConnectOnboardingLink: mockCreateConnectOnboardingLink,
+}));
+
+vi.mock("@/lib/seo", () => ({ SITE_URL: "https://invest.test" }));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import { POST } from "@/app/api/pros/connect/onboarding/route";
+
+const USER = { id: "user-uuid-1", email: "pro@example.com" };
+
+function makeReq(): NextRequest {
+  return new NextRequest("http://localhost/api/pros/connect/onboarding", { method: "POST" });
+}
+
+// from().select().or().in().maybeSingle() — terminal maybeSingle().
+function makeLookupChain(result: { data: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  chain.select = vi.fn(() => chain);
+  chain.or = vi.fn(() => chain);
+  chain.in = vi.fn(() => chain);
+  chain.maybeSingle = vi.fn(() => Promise.resolve(result));
+  return chain;
+}
+
+describe("POST /api/pros/connect/onboarding", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowed.mockResolvedValue(true);
+    mockGetUser.mockResolvedValue({ data: { user: USER } });
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    mockIsAllowed.mockResolvedValueOnce(false);
+    const res = await POST(makeReq());
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: null } });
+    const res = await POST(makeReq());
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "Auth required." });
+  });
+
+  it("returns 404 when no matching pro is found", async () => {
+    mockFrom.mockReturnValueOnce(makeLookupChain({ data: null }));
+    const res = await POST(makeReq());
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "Pro not found." });
+  });
+
+  it("returns the onboarding url on success", async () => {
+    mockFrom.mockReturnValueOnce(makeLookupChain({ data: { id: 7, email: "pro@example.com" } }));
+    mockCreateConnectOnboardingLink.mockResolvedValueOnce({ url: "https://stripe.test/onboard" });
+    const res = await POST(makeReq());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ url: "https://stripe.test/onboard" });
+    expect(mockCreateConnectOnboardingLink).toHaveBeenCalledWith(
+      expect.objectContaining({ professionalId: 7, email: "pro@example.com" }),
+    );
+  });
+
+  it("returns 503 when Stripe secret is missing", async () => {
+    mockFrom.mockReturnValueOnce(makeLookupChain({ data: { id: 7, email: "pro@example.com" } }));
+    mockCreateConnectOnboardingLink.mockResolvedValueOnce({ url: null, unavailable: "no_secret" });
+    const res = await POST(makeReq());
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: "Stripe Connect not configured." });
+  });
+
+  it("returns 502 when the link could not be created", async () => {
+    mockFrom.mockReturnValueOnce(makeLookupChain({ data: { id: 7, email: "pro@example.com" } }));
+    mockCreateConnectOnboardingLink.mockResolvedValueOnce({
+      url: null,
+      detail: "stripe down",
+    });
+    const res = await POST(makeReq());
+    expect(res.status).toBe(502);
+    expect(await res.json()).toEqual({ error: "stripe down" });
+  });
+});

--- a/__tests__/api/pros-connect-refresh.test.ts
+++ b/__tests__/api/pros-connect-refresh.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const {
+  mockIsAllowed,
+  mockGetUser,
+  mockFrom,
+  mockRefreshConnectAccountStatus,
+} = vi.hoisted(() => ({
+  mockIsAllowed: vi.fn(),
+  mockGetUser: vi.fn(),
+  mockFrom: vi.fn(),
+  mockRefreshConnectAccountStatus: vi.fn(),
+}));
+
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: mockIsAllowed,
+  ipKey: vi.fn(() => "ip:test"),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({ auth: { getUser: mockGetUser } })),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+vi.mock("@/lib/stripe-connect", () => ({
+  refreshConnectAccountStatus: mockRefreshConnectAccountStatus,
+}));
+
+import { POST } from "@/app/api/pros/connect/refresh/route";
+
+const USER = { id: "user-uuid-1", email: "pro@example.com" };
+
+function makeReq(): NextRequest {
+  return new NextRequest("http://localhost/api/pros/connect/refresh", { method: "POST" });
+}
+
+// from().select().or().maybeSingle() — terminal maybeSingle().
+function makeLookupChain(result: { data: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  chain.select = vi.fn(() => chain);
+  chain.or = vi.fn(() => chain);
+  chain.maybeSingle = vi.fn(() => Promise.resolve(result));
+  return chain;
+}
+
+describe("POST /api/pros/connect/refresh", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowed.mockResolvedValue(true);
+    mockGetUser.mockResolvedValue({ data: { user: USER } });
+    mockRefreshConnectAccountStatus.mockResolvedValue(undefined);
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    mockIsAllowed.mockResolvedValueOnce(false);
+    const res = await POST(makeReq());
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: null } });
+    const res = await POST(makeReq());
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "Auth required." });
+  });
+
+  it("returns 404 when the pro has no Connect account", async () => {
+    mockFrom.mockReturnValueOnce(makeLookupChain({ data: { id: 7, stripe_connect_account_id: null } }));
+    const res = await POST(makeReq());
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "No Connect account." });
+  });
+
+  it("returns 404 when the pro row is missing entirely", async () => {
+    mockFrom.mockReturnValueOnce(makeLookupChain({ data: null }));
+    const res = await POST(makeReq());
+    expect(res.status).toBe(404);
+  });
+
+  it("refreshes the account status and returns ok", async () => {
+    mockFrom.mockReturnValueOnce(
+      makeLookupChain({ data: { id: 7, stripe_connect_account_id: "acct_123" } }),
+    );
+    const res = await POST(makeReq());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(mockRefreshConnectAccountStatus).toHaveBeenCalledWith("acct_123");
+  });
+});

--- a/__tests__/api/pros-join-upload.test.ts
+++ b/__tests__/api/pros-join-upload.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockIsAllowed, mockUpload, mockStorageFrom } = vi.hoisted(() => ({
+  mockIsAllowed: vi.fn(),
+  mockUpload: vi.fn(),
+  mockStorageFrom: vi.fn(),
+}));
+
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: mockIsAllowed,
+  ipKey: vi.fn(() => "ip:test"),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({
+    storage: { from: mockStorageFrom },
+  })),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import { POST } from "@/app/api/pros/join/upload/route";
+
+function makeReqWithForm(form: FormData): NextRequest {
+  return new NextRequest("http://localhost/api/pros/join/upload", {
+    method: "POST",
+    body: form,
+  });
+}
+
+function makeFile(opts: { type: string; size: number; name?: string }): File {
+  const blob = new Blob([new Uint8Array(opts.size)], { type: opts.type });
+  return new File([blob], opts.name ?? "doc", { type: opts.type });
+}
+
+describe("POST /api/pros/join/upload", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowed.mockResolvedValue(true);
+    mockStorageFrom.mockReturnValue({ upload: mockUpload });
+    mockUpload.mockResolvedValue({ error: null });
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    mockIsAllowed.mockResolvedValueOnce(false);
+    const form = new FormData();
+    form.set("file", makeFile({ type: "application/pdf", size: 100 }));
+    const res = await POST(makeReqWithForm(form));
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 400 when no file is provided", async () => {
+    const res = await POST(makeReqWithForm(new FormData()));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "No file provided" });
+  });
+
+  it("returns 400 for an unsupported MIME type", async () => {
+    const form = new FormData();
+    form.set("file", makeFile({ type: "text/plain", size: 100 }));
+    const res = await POST(makeReqWithForm(form));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/Unsupported file type/);
+  });
+
+  it("returns 400 when the file exceeds the size cap", async () => {
+    const form = new FormData();
+    form.set("file", makeFile({ type: "image/png", size: 11 * 1024 * 1024 }));
+    const res = await POST(makeReqWithForm(form));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/too large/i);
+  });
+
+  it("uploads the file and returns the storage path", async () => {
+    const form = new FormData();
+    form.set("file", makeFile({ type: "application/pdf", size: 1024 }));
+    const res = await POST(makeReqWithForm(form));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.storage_path).toMatch(/^pending\/.*\.pdf$/);
+    expect(mockStorageFrom).toHaveBeenCalledWith("pro-verification-docs");
+    expect(mockUpload).toHaveBeenCalledOnce();
+  });
+
+  it("returns 500 when the storage upload errors", async () => {
+    mockUpload.mockResolvedValueOnce({ error: { message: "denied" } });
+    const form = new FormData();
+    form.set("file", makeFile({ type: "image/webp", size: 1024 }));
+    const res = await POST(makeReqWithForm(form));
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: "Upload failed" });
+  });
+});

--- a/__tests__/api/pros-join.test.ts
+++ b/__tests__/api/pros-join.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockIsAllowed, mockFrom, mockSendWelcomePro } = vi.hoisted(() => ({
+  mockIsAllowed: vi.fn(),
+  mockFrom: vi.fn(),
+  mockSendWelcomePro: vi.fn(),
+}));
+
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: mockIsAllowed,
+  ipKey: vi.fn(() => "ip:test"),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+vi.mock("@/lib/pro-onboarding-emails", () => ({
+  sendWelcomePro: mockSendWelcomePro,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import { POST } from "@/app/api/pros/join/route";
+
+const VALID_BODY = {
+  kind: "individual",
+  specialties: ["financial_planner"],
+  name: "Jane Pro",
+  email: "jane@example.com",
+  verification_doc_path: "pending/123-abc.pdf",
+  payout_bsb: "062-000",
+  payout_account_last4: "1234",
+  agreed_to_terms: true,
+};
+
+function makeReq(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/pros/join", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+// from().select().eq().maybeSingle() — dedupe + slug-clash lookups.
+function makeLookupChain(result: { data: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  chain.select = vi.fn(() => chain);
+  chain.eq = vi.fn(() => chain);
+  chain.maybeSingle = vi.fn(() => Promise.resolve(result));
+  return chain;
+}
+
+// from().insert().select().single()
+function makeInsertChain(result: { data: unknown; error: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  chain.insert = vi.fn(() => chain);
+  chain.select = vi.fn(() => chain);
+  chain.single = vi.fn(() => Promise.resolve(result));
+  return chain;
+}
+
+describe("POST /api/pros/join", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowed.mockResolvedValue(true);
+    mockSendWelcomePro.mockResolvedValue(true);
+  });
+
+  it("returns 400 when zod validation fails (missing terms agreement)", async () => {
+    const { agreed_to_terms: _omit, ...bad } = VALID_BODY;
+    const res = await POST(makeReq(bad));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ code: "validation_error" });
+  });
+
+  it("returns 400 on a malformed BSB", async () => {
+    const res = await POST(makeReq({ ...VALID_BODY, payout_bsb: "12" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    mockIsAllowed.mockResolvedValueOnce(false);
+    const res = await POST(makeReq(VALID_BODY));
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 409 when an application already exists for the email", async () => {
+    mockFrom.mockReturnValueOnce(
+      makeLookupChain({ data: { id: 1, verification_status: "pending" } }),
+    );
+    const res = await POST(makeReq(VALID_BODY));
+    expect(res.status).toBe(409);
+  });
+
+  it("inserts a pending professional and returns ok", async () => {
+    // 1: dedupe lookup (no existing), 2: slug-clash lookup (none), 3: insert.
+    mockFrom
+      .mockReturnValueOnce(makeLookupChain({ data: null }))
+      .mockReturnValueOnce(makeLookupChain({ data: null }))
+      .mockReturnValueOnce(makeInsertChain({ data: { id: 99, slug: "jane-pro" }, error: null }));
+    const res = await POST(makeReq(VALID_BODY));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toMatchObject({ ok: true, professional_id: 99, slug: "jane-pro" });
+    expect(json.starter_credits_granted_on_approval).toBeGreaterThan(0);
+    expect(mockSendWelcomePro).toHaveBeenCalledWith("jane@example.com", "Jane Pro");
+  });
+
+  it("still returns ok when the welcome email throws", async () => {
+    mockFrom
+      .mockReturnValueOnce(makeLookupChain({ data: null }))
+      .mockReturnValueOnce(makeLookupChain({ data: null }))
+      .mockReturnValueOnce(makeInsertChain({ data: { id: 99, slug: "jane-pro" }, error: null }));
+    mockSendWelcomePro.mockRejectedValueOnce(new Error("smtp down"));
+    const res = await POST(makeReq(VALID_BODY));
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 500 when the insert errors", async () => {
+    mockFrom
+      .mockReturnValueOnce(makeLookupChain({ data: null }))
+      .mockReturnValueOnce(makeLookupChain({ data: null }))
+      .mockReturnValueOnce(makeInsertChain({ data: null, error: { message: "boom" } }));
+    const res = await POST(makeReq(VALID_BODY));
+    expect(res.status).toBe(500);
+  });
+});

--- a/__tests__/api/pros-pricing-tier.test.ts
+++ b/__tests__/api/pros-pricing-tier.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockIsAllowed, mockGetUser, mockFrom } = vi.hoisted(() => ({
+  mockIsAllowed: vi.fn(),
+  mockGetUser: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: mockIsAllowed,
+  ipKey: vi.fn(() => "ip:test"),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({ auth: { getUser: mockGetUser } })),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import { POST } from "@/app/api/pros/pricing-tier/route";
+
+const USER = { id: "user-uuid-1", email: "pro@example.com" };
+
+const VALID_BODY = { professional_id: 7, tier: "success_only" };
+
+function makeReq(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/pros/pricing-tier", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+// from().select().eq().or().maybeSingle() — ownership lookup.
+function makeOwnerChain(result: { data: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  chain.select = vi.fn(() => chain);
+  chain.eq = vi.fn(() => chain);
+  chain.or = vi.fn(() => chain);
+  chain.maybeSingle = vi.fn(() => Promise.resolve(result));
+  return chain;
+}
+
+// from().update().eq() — terminal eq().
+function makeUpdateChain(result: { error: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  chain.update = vi.fn(() => chain);
+  chain.eq = vi.fn(() => Promise.resolve(result));
+  return chain;
+}
+
+describe("POST /api/pros/pricing-tier", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowed.mockResolvedValue(true);
+    mockGetUser.mockResolvedValue({ data: { user: USER } });
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    mockIsAllowed.mockResolvedValueOnce(false);
+    const res = await POST(makeReq(VALID_BODY));
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 400 on invalid JSON body", async () => {
+    const req = new NextRequest("http://localhost/api/pros/pricing-tier", {
+      method: "POST",
+      body: "not json",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when zod validation fails", async () => {
+    const res = await POST(makeReq({ professional_id: -1, tier: "gold" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: null } });
+    const res = await POST(makeReq(VALID_BODY));
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "Auth required." });
+  });
+
+  it("returns 404 when the user does not own the professional row", async () => {
+    mockFrom.mockReturnValueOnce(makeOwnerChain({ data: null }));
+    const res = await POST(makeReq(VALID_BODY));
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "Not found." });
+  });
+
+  it("updates the tier and returns ok", async () => {
+    mockFrom.mockReturnValueOnce(makeOwnerChain({ data: { id: 7 } }));
+    const updateChain = makeUpdateChain({ error: null });
+    mockFrom.mockReturnValueOnce(updateChain);
+    const res = await POST(makeReq(VALID_BODY));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, tier: "success_only" });
+    expect(updateChain.eq).toHaveBeenCalledWith("id", 7);
+    const updateArg = updateChain.update.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(updateArg).toEqual({ pricing_tier: "success_only" });
+  });
+
+  it("returns 500 when the update errors", async () => {
+    mockFrom.mockReturnValueOnce(makeOwnerChain({ data: { id: 7 } }));
+    mockFrom.mockReturnValueOnce(makeUpdateChain({ error: { message: "boom" } }));
+    const res = await POST(makeReq(VALID_BODY));
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: "Update failed." });
+  });
+});

--- a/__tests__/api/pros-slug-availability.test.ts
+++ b/__tests__/api/pros-slug-availability.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockIsAllowed, mockFrom, mockListAvailabilityForPro } = vi.hoisted(() => ({
+  mockIsAllowed: vi.fn(),
+  mockFrom: vi.fn(),
+  mockListAvailabilityForPro: vi.fn(),
+}));
+
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: mockIsAllowed,
+  ipKey: vi.fn(() => "ip:test"),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+vi.mock("@/lib/consultations", () => ({
+  listAvailabilityForPro: mockListAvailabilityForPro,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import { GET } from "@/app/api/pros/[slug]/availability/route";
+
+function makeReq(): NextRequest {
+  return new NextRequest("http://localhost/api/pros/jane-pro/availability");
+}
+
+function makeCtx(slug: string) {
+  return { params: Promise.resolve({ slug }) };
+}
+
+// from().select().eq().in().maybeSingle() — pro lookup.
+function makeLookupChain(result: { data: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  chain.select = vi.fn(() => chain);
+  chain.eq = vi.fn(() => chain);
+  chain.in = vi.fn(() => chain);
+  chain.maybeSingle = vi.fn(() => Promise.resolve(result));
+  return chain;
+}
+
+describe("GET /api/pros/[slug]/availability", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowed.mockResolvedValue(true);
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    mockIsAllowed.mockResolvedValueOnce(false);
+    const res = await GET(makeReq(), makeCtx("jane-pro"));
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 400 for an empty slug", async () => {
+    const res = await GET(makeReq(), makeCtx(""));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid slug." });
+  });
+
+  it("returns 400 for an overlong slug", async () => {
+    const res = await GET(makeReq(), makeCtx("x".repeat(201)));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when the pro is not found", async () => {
+    mockFrom.mockReturnValueOnce(makeLookupChain({ data: null }));
+    const res = await GET(makeReq(), makeCtx("jane-pro"));
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "Pro not found." });
+  });
+
+  it("returns the professional and slots on success", async () => {
+    mockFrom.mockReturnValueOnce(
+      makeLookupChain({ data: { id: 7, name: "Jane Pro", slug: "jane-pro" } }),
+    );
+    const slots = [{ id: 1, start: "2026-06-01T10:00:00Z" }];
+    mockListAvailabilityForPro.mockResolvedValueOnce(slots);
+    const res = await GET(makeReq(), makeCtx("jane-pro"));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      professional: { id: 7, name: "Jane Pro", slug: "jane-pro" },
+      slots,
+    });
+    expect(mockListAvailabilityForPro).toHaveBeenCalledWith(7);
+  });
+
+  it("returns 500 when listAvailabilityForPro throws", async () => {
+    mockFrom.mockReturnValueOnce(
+      makeLookupChain({ data: { id: 7, name: "Jane Pro", slug: "jane-pro" } }),
+    );
+    mockListAvailabilityForPro.mockRejectedValueOnce(new Error("boom"));
+    const res = await GET(makeReq(), makeCtx("jane-pro"));
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: "Failed to list availability." });
+  });
+});


### PR DESCRIPTION
## Summary
Adds vitest unit tests for 9 previously-untested `app/api/pros/*` routes (billing auto-recharge/portal/subscribe, Stripe Connect onboarding/refresh, join, join/upload, pricing-tier, availability). 59 tests covering rate-limit, auth, validation, happy + error paths. Stripe kept out of scope by mocking the routes' own billing/connect lib imports.

## Queue item
D-COV (pre-launch coverage push) — untested API routes surfaced 2026-05-20. Moves M02 (API routes with tests, 57→200).

## Supersedes
_None._

## Test plan
- [x] `vitest run __tests__/api/pros-*.test.ts` → 59/59 pass locally
- [ ] CI green