### PR TITLE
test(d): add unit tests for briefs/* API routes

### DIFF
--- a/__tests__/api/briefs-inbox.test.ts
+++ b/__tests__/api/briefs-inbox.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockIsAllowed, mockRequireAdvisorSession, mockMask } = vi.hoisted(() => ({
+  mockIsAllowed: vi.fn(),
+  mockRequireAdvisorSession: vi.fn(),
+  mockMask: vi.fn((row: unknown) => ({ masked: true, ...(row as object) })),
+}));
+
+const mockFrom = vi.fn();
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: mockIsAllowed,
+  ipKey: vi.fn(() => "1.2.3.4"),
+}));
+
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: mockRequireAdvisorSession,
+}));
+
+vi.mock("@/lib/briefs/mask", () => ({
+  maskBriefForProvider: mockMask,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import { GET } from "@/app/api/briefs/inbox/route";
+
+function makeReq(): NextRequest {
+  return new NextRequest("http://localhost/api/briefs/inbox", { method: "GET" });
+}
+
+// Generic thenable chain — every chain method returns the chain; the chain
+// itself is awaitable and resolves to `result`. Lets us drive every terminal
+// call (.order().limit(), .maybeSingle()) without knowing the exact tail.
+function makeChain(result: { data: unknown; error?: unknown }) {
+  const chain: Record<string, unknown> = {};
+  const methods = [
+    "select", "eq", "in", "is", "or", "order", "limit", "maybeSingle", "single",
+  ];
+  for (const m of methods) chain[m] = vi.fn(() => chain);
+  (chain as { then: unknown }).then = (resolve: (v: unknown) => unknown) =>
+    resolve(result);
+  return chain;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIsAllowed.mockResolvedValue(true);
+  mockRequireAdvisorSession.mockResolvedValue(42);
+  mockMask.mockImplementation((row: unknown) => ({ masked: true, ...(row as object) }));
+});
+
+describe("GET /api/briefs/inbox", () => {
+  it("429 when rate-limited", async () => {
+    mockIsAllowed.mockResolvedValue(false);
+    const res = await GET(makeReq());
+    expect(res.status).toBe(429);
+  });
+
+  it("401 when no advisor session", async () => {
+    mockRequireAdvisorSession.mockResolvedValue(null);
+    const res = await GET(makeReq());
+    expect(res.status).toBe(401);
+  });
+
+  it("happy path returns available + accepted buckets", async () => {
+    const openBrief = {
+      slug: "b1",
+      routing_mode: "broadcast",
+      provider_preference: "any",
+      flow_type: "accept",
+      status: "open",
+    };
+    // Calls in order: expert_team_members, professionals, advisor_auctions(open),
+    // advisor_auctions(accepted).
+    mockFrom
+      .mockReturnValueOnce(makeChain({ data: [{ team_id: 7 }] }))
+      .mockReturnValueOnce(makeChain({ data: { type: "accountant", firm_id: null } }))
+      .mockReturnValueOnce(makeChain({ data: [openBrief] }))
+      .mockReturnValueOnce(makeChain({ data: [{ id: 1, slug: "acc1" }] }));
+
+    const res = await GET(makeReq());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.available).toHaveLength(1);
+    expect(json.available[0].masked).toBe(true);
+    expect(json.accepted).toHaveLength(1);
+    expect(json.teamIds).toEqual([7]);
+  });
+
+  it("filters out direct-targeted briefs not aimed at the caller", async () => {
+    const directBrief = {
+      slug: "d1",
+      routing_mode: "direct",
+      target_professional_id: 999,
+      target_team_id: null,
+      target_firm_id: null,
+    };
+    mockFrom
+      .mockReturnValueOnce(makeChain({ data: [] }))
+      .mockReturnValueOnce(makeChain({ data: { type: null, firm_id: null } }))
+      .mockReturnValueOnce(makeChain({ data: [directBrief] }))
+      .mockReturnValueOnce(makeChain({ data: [] }));
+
+    const res = await GET(makeReq());
+    const json = await res.json();
+    expect(json.available).toHaveLength(0);
+  });
+
+  it("500 when a query throws", async () => {
+    mockFrom.mockImplementation(() => {
+      throw new Error("db down");
+    });
+    const res = await GET(makeReq());
+    expect(res.status).toBe(500);
+  });
+});

--- a/__tests__/api/briefs-preview.test.ts
+++ b/__tests__/api/briefs-preview.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockIsAllowed, mockRequireAdvisorSession, mockMask, mockGetAcceptCost } =
+  vi.hoisted(() => ({
+    mockIsAllowed: vi.fn(),
+    mockRequireAdvisorSession: vi.fn(),
+    mockMask: vi.fn(),
+    mockGetAcceptCost: vi.fn(),
+  }));
+
+const mockFrom = vi.fn();
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: mockIsAllowed,
+  ipKey: vi.fn(() => "1.2.3.4"),
+}));
+
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: mockRequireAdvisorSession,
+}));
+
+vi.mock("@/lib/briefs/mask", () => ({
+  maskBriefForProvider: mockMask,
+}));
+
+vi.mock("@/lib/briefs/credits", () => ({
+  getAcceptCost: mockGetAcceptCost,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import { GET } from "@/app/api/briefs/[slug]/preview/route";
+
+function makeReq(): NextRequest {
+  return new NextRequest("http://localhost/api/briefs/b1/preview", { method: "GET" });
+}
+const ctx = { params: Promise.resolve({ slug: "b1" }) };
+
+function makeChain(result: { data: unknown; error?: unknown }) {
+  const chain: Record<string, unknown> = {};
+  for (const m of ["select", "eq", "maybeSingle"]) chain[m] = vi.fn(() => chain);
+  (chain as { then: unknown }).then = (resolve: (v: unknown) => unknown) =>
+    resolve(result);
+  return chain;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIsAllowed.mockResolvedValue(true);
+  mockRequireAdvisorSession.mockResolvedValue(42);
+  mockMask.mockImplementation((row: { slug: string }) => ({
+    slug: row.slug,
+    brief_template: "tax",
+    provider_preference: "individual",
+    accept_credits_cost: 5,
+  }));
+});
+
+describe("GET /api/briefs/[slug]/preview", () => {
+  it("429 when rate-limited", async () => {
+    mockIsAllowed.mockResolvedValue(false);
+    const res = await GET(makeReq(), ctx);
+    expect(res.status).toBe(429);
+  });
+
+  it("401 when no advisor session", async () => {
+    mockRequireAdvisorSession.mockResolvedValue(null);
+    const res = await GET(makeReq(), ctx);
+    expect(res.status).toBe(401);
+  });
+
+  it("404 when brief not found", async () => {
+    mockFrom.mockReturnValue(makeChain({ data: null }));
+    const res = await GET(makeReq(), ctx);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns held stub when risk review not cleared", async () => {
+    mockFrom.mockReturnValue(
+      makeChain({ data: { slug: "b1", status: "open", risk_review_status: "pending" } }),
+    );
+    const res = await GET(makeReq(), ctx);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.held_for_review).toBe(true);
+    expect(mockMask).not.toHaveBeenCalled();
+  });
+
+  it("happy path returns masked brief", async () => {
+    mockFrom.mockReturnValue(
+      makeChain({ data: { slug: "b1", risk_review_status: "clear" } }),
+    );
+    const res = await GET(makeReq(), ctx);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.masked).toBe(true);
+    expect(json.brief.slug).toBe("b1");
+  });
+
+  it("computes live accept cost when not stamped", async () => {
+    mockMask.mockReturnValue({
+      slug: "b1",
+      brief_template: "tax",
+      provider_preference: "firm",
+      accept_credits_cost: null,
+    });
+    mockGetAcceptCost.mockResolvedValue(9);
+    mockFrom.mockReturnValue(
+      makeChain({ data: { slug: "b1", risk_review_status: "approved" } }),
+    );
+    const res = await GET(makeReq(), ctx);
+    const json = await res.json();
+    expect(mockGetAcceptCost).toHaveBeenCalledWith({
+      briefTemplate: "tax",
+      providerKind: "firm",
+    });
+    expect(json.brief.accept_credits_cost).toBe(9);
+  });
+
+  it("500 when query throws", async () => {
+    mockFrom.mockImplementation(() => {
+      throw new Error("boom");
+    });
+    const res = await GET(makeReq(), ctx);
+    expect(res.status).toBe(500);
+  });
+});

--- a/__tests__/api/briefs-shortlist-id.test.ts
+++ b/__tests__/api/briefs-shortlist-id.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockIsAllowed, mockGetUser, mockRemoveFromShortlist, mockUpdateNote } =
+  vi.hoisted(() => ({
+    mockIsAllowed: vi.fn(),
+    mockGetUser: vi.fn(),
+    mockRemoveFromShortlist: vi.fn(),
+    mockUpdateNote: vi.fn(),
+  }));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({ auth: { getUser: mockGetUser } })),
+}));
+
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: mockIsAllowed,
+  ipKey: vi.fn(() => "1.2.3.4"),
+}));
+
+vi.mock("@/lib/brief-shortlist", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/brief-shortlist")>(
+    "@/lib/brief-shortlist",
+  );
+  return {
+    ...actual,
+    removeFromShortlist: mockRemoveFromShortlist,
+    updateNote: mockUpdateNote,
+  };
+});
+
+import { DELETE, PATCH } from "@/app/api/briefs/[slug]/shortlist/[id]/route";
+import { ShortlistError } from "@/lib/brief-shortlist";
+
+const USER = { id: "user-1", email: "owner@example.com" };
+const ctx = { params: Promise.resolve({ slug: "b1", id: "55" }) };
+
+function makeReq(method: string, body?: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/briefs/b1/shortlist/55", {
+    method,
+    headers: body === undefined ? undefined : { "Content-Type": "application/json" },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIsAllowed.mockResolvedValue(true);
+  mockGetUser.mockResolvedValue({ data: { user: USER } });
+});
+
+describe("DELETE /api/briefs/[slug]/shortlist/[id]", () => {
+  it("429 when rate-limited", async () => {
+    mockIsAllowed.mockResolvedValue(false);
+    const res = await DELETE(makeReq("DELETE"), ctx);
+    expect(res.status).toBe(429);
+  });
+
+  it("401 when no email", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    const res = await DELETE(makeReq("DELETE"), ctx);
+    expect(res.status).toBe(401);
+  });
+
+  it("happy path removes shortlist item", async () => {
+    mockRemoveFromShortlist.mockResolvedValue(undefined);
+    const res = await DELETE(makeReq("DELETE"), ctx);
+    expect(res.status).toBe(200);
+    expect(mockRemoveFromShortlist).toHaveBeenCalledWith(55, USER.email);
+  });
+
+  it("404 on not_found ShortlistError", async () => {
+    mockRemoveFromShortlist.mockRejectedValue(new ShortlistError("not_found"));
+    const res = await DELETE(makeReq("DELETE"), ctx);
+    expect(res.status).toBe(404);
+  });
+
+  it("403 on not_owner ShortlistError", async () => {
+    mockRemoveFromShortlist.mockRejectedValue(new ShortlistError("not_owner"));
+    const res = await DELETE(makeReq("DELETE"), ctx);
+    expect(res.status).toBe(403);
+  });
+
+  it("500 on unexpected error", async () => {
+    mockRemoveFromShortlist.mockRejectedValue(new Error("boom"));
+    const res = await DELETE(makeReq("DELETE"), ctx);
+    expect(res.status).toBe(500);
+  });
+});
+
+describe("PATCH /api/briefs/[slug]/shortlist/[id]", () => {
+  it("429 when rate-limited", async () => {
+    mockIsAllowed.mockResolvedValue(false);
+    const res = await PATCH(makeReq("PATCH", { note: "hi" }), ctx);
+    expect(res.status).toBe(429);
+  });
+
+  it("401 when no email", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    const res = await PATCH(makeReq("PATCH", { note: "hi" }), ctx);
+    expect(res.status).toBe(401);
+  });
+
+  it("400 on invalid JSON", async () => {
+    const req = new NextRequest("http://localhost/api/briefs/b1/shortlist/55", {
+      method: "PATCH",
+      body: "{bad",
+    });
+    const res = await PATCH(req, ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("400 on schema rejection (note too long)", async () => {
+    const res = await PATCH(makeReq("PATCH", { note: "x".repeat(1001) }), ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("happy path updates note", async () => {
+    mockUpdateNote.mockResolvedValue(undefined);
+    const res = await PATCH(makeReq("PATCH", { note: "updated" }), ctx);
+    expect(res.status).toBe(200);
+    expect(mockUpdateNote).toHaveBeenCalledWith({
+      shortlistId: 55,
+      note: "updated",
+      ownerEmail: USER.email,
+    });
+  });
+
+  it("accepts null note", async () => {
+    mockUpdateNote.mockResolvedValue(undefined);
+    const res = await PATCH(makeReq("PATCH", { note: null }), ctx);
+    expect(res.status).toBe(200);
+  });
+
+  it("404 on not_found ShortlistError", async () => {
+    mockUpdateNote.mockRejectedValue(new ShortlistError("not_found"));
+    const res = await PATCH(makeReq("PATCH", { note: "x" }), ctx);
+    expect(res.status).toBe(404);
+  });
+
+  it("500 on unexpected error", async () => {
+    mockUpdateNote.mockRejectedValue(new Error("boom"));
+    const res = await PATCH(makeReq("PATCH", { note: "x" }), ctx);
+    expect(res.status).toBe(500);
+  });
+});

--- a/__tests__/api/briefs-shortlist.test.ts
+++ b/__tests__/api/briefs-shortlist.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockIsAllowed, mockGetUser, mockAddToShortlist } = vi.hoisted(() => ({
+  mockIsAllowed: vi.fn(),
+  mockGetUser: vi.fn(),
+  mockAddToShortlist: vi.fn(),
+}));
+
+const mockFrom = vi.fn();
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({ auth: { getUser: mockGetUser } })),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: mockIsAllowed,
+  ipKey: vi.fn(() => "1.2.3.4"),
+}));
+
+vi.mock("@/lib/brief-shortlist", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/brief-shortlist")>(
+    "@/lib/brief-shortlist",
+  );
+  return { ...actual, addToShortlist: mockAddToShortlist };
+});
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import { POST } from "@/app/api/briefs/[slug]/shortlist/route";
+import { ShortlistError } from "@/lib/brief-shortlist";
+
+const USER = { id: "user-1", email: "owner@example.com" };
+const VALID = { provider_kind: "professional", provider_id: 7, note: "great" };
+
+function makeReq(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/briefs/b1/shortlist", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+const ctx = { params: Promise.resolve({ slug: "b1" }) };
+
+function makeBriefChain(result: { data: unknown }) {
+  const chain: Record<string, unknown> = {};
+  for (const m of ["select", "eq", "maybeSingle"]) chain[m] = vi.fn(() => chain);
+  (chain as { then: unknown }).then = (resolve: (v: unknown) => unknown) =>
+    resolve(result);
+  return chain;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIsAllowed.mockResolvedValue(true);
+  mockGetUser.mockResolvedValue({ data: { user: USER } });
+});
+
+describe("POST /api/briefs/[slug]/shortlist", () => {
+  it("429 when rate-limited", async () => {
+    mockIsAllowed.mockResolvedValue(false);
+    const res = await POST(makeReq(VALID), ctx);
+    expect(res.status).toBe(429);
+  });
+
+  it("400 on invalid JSON", async () => {
+    const req = new NextRequest("http://localhost/api/briefs/b1/shortlist", {
+      method: "POST",
+      body: "not-json",
+    });
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("400 on schema rejection", async () => {
+    const res = await POST(makeReq({ provider_kind: "alien", provider_id: -1 }), ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("401 when not authenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    const res = await POST(makeReq(VALID), ctx);
+    expect(res.status).toBe(401);
+  });
+
+  it("404 when brief not found", async () => {
+    mockFrom.mockReturnValue(makeBriefChain({ data: null }));
+    const res = await POST(makeReq(VALID), ctx);
+    expect(res.status).toBe(404);
+  });
+
+  it("403 when caller does not own the brief", async () => {
+    mockFrom.mockReturnValue(
+      makeBriefChain({ data: { id: 1, contact_email: "other@example.com" } }),
+    );
+    const res = await POST(makeReq(VALID), ctx);
+    expect(res.status).toBe(403);
+  });
+
+  it("happy path adds to shortlist", async () => {
+    mockFrom.mockReturnValue(
+      makeBriefChain({ data: { id: 1, contact_email: USER.email } }),
+    );
+    mockAddToShortlist.mockResolvedValue({ id: 99 });
+    const res = await POST(makeReq(VALID), ctx);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+    expect(json.shortlist).toEqual({ id: 99 });
+  });
+
+  it("422 on limit_reached ShortlistError", async () => {
+    mockFrom.mockReturnValue(
+      makeBriefChain({ data: { id: 1, contact_email: USER.email } }),
+    );
+    mockAddToShortlist.mockRejectedValue(new ShortlistError("limit_reached"));
+    const res = await POST(makeReq(VALID), ctx);
+    expect(res.status).toBe(422);
+  });
+
+  it("409 on duplicate ShortlistError", async () => {
+    mockFrom.mockReturnValue(
+      makeBriefChain({ data: { id: 1, contact_email: USER.email } }),
+    );
+    mockAddToShortlist.mockRejectedValue(new ShortlistError("duplicate"));
+    const res = await POST(makeReq(VALID), ctx);
+    expect(res.status).toBe(409);
+  });
+
+  it("500 on unexpected error", async () => {
+    mockFrom.mockReturnValue(
+      makeBriefChain({ data: { id: 1, contact_email: USER.email } }),
+    );
+    mockAddToShortlist.mockRejectedValue(new Error("kaboom"));
+    const res = await POST(makeReq(VALID), ctx);
+    expect(res.status).toBe(500);
+  });
+});

--- a/__tests__/api/briefs-status.test.ts
+++ b/__tests__/api/briefs-status.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockIsAllowed, mockRequireAdvisorSession, mockUpdateTrackerStatus } =
+  vi.hoisted(() => ({
+    mockIsAllowed: vi.fn(),
+    mockRequireAdvisorSession: vi.fn(),
+    mockUpdateTrackerStatus: vi.fn(),
+  }));
+
+const mockFrom = vi.fn();
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: mockIsAllowed,
+  ipKey: vi.fn(() => "1.2.3.4"),
+}));
+
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: mockRequireAdvisorSession,
+}));
+
+vi.mock("@/lib/briefs/credits", () => ({
+  updateTrackerStatus: mockUpdateTrackerStatus,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import { POST } from "@/app/api/briefs/[slug]/status/route";
+
+const VALID = { tracker_status: "contacted", note: "called them" };
+
+function makeReq(body: unknown, raw = false): NextRequest {
+  return new NextRequest("http://localhost/api/briefs/b1/status", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: raw ? (body as string) : JSON.stringify(body),
+  });
+}
+const ctx = { params: Promise.resolve({ slug: "b1" }) };
+
+function makeBriefChain(result: { data: unknown }) {
+  const chain: Record<string, unknown> = {};
+  for (const m of ["select", "eq", "maybeSingle"]) chain[m] = vi.fn(() => chain);
+  (chain as { then: unknown }).then = (resolve: (v: unknown) => unknown) =>
+    resolve(result);
+  return chain;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIsAllowed.mockResolvedValue(true);
+  mockRequireAdvisorSession.mockResolvedValue(42);
+});
+
+describe("POST /api/briefs/[slug]/status", () => {
+  it("429 when rate-limited", async () => {
+    mockIsAllowed.mockResolvedValue(false);
+    const res = await POST(makeReq(VALID), ctx);
+    expect(res.status).toBe(429);
+  });
+
+  it("401 when no advisor session", async () => {
+    mockRequireAdvisorSession.mockResolvedValue(null);
+    const res = await POST(makeReq(VALID), ctx);
+    expect(res.status).toBe(401);
+  });
+
+  it("400 on invalid JSON", async () => {
+    const res = await POST(makeReq("not-json", true), ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("400 on schema rejection", async () => {
+    const res = await POST(makeReq({ tracker_status: "bogus" }), ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("404 when brief not found", async () => {
+    mockFrom.mockReturnValue(makeBriefChain({ data: null }));
+    const res = await POST(makeReq(VALID), ctx);
+    expect(res.status).toBe(404);
+  });
+
+  it("happy path updates tracker status", async () => {
+    mockFrom.mockReturnValue(
+      makeBriefChain({ data: { id: 1, accepted_by_professional_id: 42 } }),
+    );
+    mockUpdateTrackerStatus.mockResolvedValue({ ok: true });
+    const res = await POST(makeReq(VALID), ctx);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.success).toBe(true);
+    expect(mockUpdateTrackerStatus).toHaveBeenCalledWith({
+      briefId: 1,
+      professionalId: 42,
+      newStatus: "contacted",
+      note: "called them",
+    });
+  });
+
+  it("403 when updateTrackerStatus rejects", async () => {
+    mockFrom.mockReturnValue(
+      makeBriefChain({ data: { id: 1, accepted_by_professional_id: 99 } }),
+    );
+    mockUpdateTrackerStatus.mockResolvedValue({ ok: false, reason: "not yours" });
+    const res = await POST(makeReq(VALID), ctx);
+    expect(res.status).toBe(403);
+  });
+
+  it("500 when query throws", async () => {
+    mockFrom.mockImplementation(() => {
+      throw new Error("db");
+    });
+    const res = await POST(makeReq(VALID), ctx);
+    expect(res.status).toBe(500);
+  });
+});

--- a/__tests__/api/briefs-withdraw.test.ts
+++ b/__tests__/api/briefs-withdraw.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockIsAllowed } = vi.hoisted(() => ({ mockIsAllowed: vi.fn() }));
+
+const mockFrom = vi.fn();
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: mockIsAllowed,
+  ipKey: vi.fn(() => "1.2.3.4"),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import { POST } from "@/app/api/briefs/[slug]/withdraw/route";
+
+const VALID = { contact_email: "owner@example.com" };
+
+function makeReq(body: unknown, raw = false): NextRequest {
+  return new NextRequest("http://localhost/api/briefs/b1/withdraw", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: raw ? (body as string) : JSON.stringify(body),
+  });
+}
+const ctx = { params: Promise.resolve({ slug: "b1" }) };
+
+// A chain that is awaitable and whose methods all return the chain.
+function makeChain(result: { data?: unknown; error?: unknown }) {
+  const chain: Record<string, unknown> = {};
+  for (const m of ["select", "eq", "maybeSingle", "update", "insert"]) {
+    chain[m] = vi.fn(() => chain);
+  }
+  (chain as { then: unknown }).then = (resolve: (v: unknown) => unknown) =>
+    resolve(result);
+  return chain;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIsAllowed.mockResolvedValue(true);
+});
+
+describe("POST /api/briefs/[slug]/withdraw", () => {
+  it("429 when rate-limited", async () => {
+    mockIsAllowed.mockResolvedValue(false);
+    const res = await POST(makeReq(VALID), ctx);
+    expect(res.status).toBe(429);
+  });
+
+  it("400 on invalid JSON", async () => {
+    const res = await POST(makeReq("nope", true), ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("400 on schema rejection (bad email)", async () => {
+    const res = await POST(makeReq({ contact_email: "not-an-email" }), ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("404 when brief not found", async () => {
+    mockFrom.mockReturnValue(makeChain({ data: null }));
+    const res = await POST(makeReq(VALID), ctx);
+    expect(res.status).toBe(404);
+  });
+
+  it("403 when email does not match", async () => {
+    mockFrom.mockReturnValue(
+      makeChain({ data: { id: 1, contact_email: "other@example.com", status: "open" } }),
+    );
+    const res = await POST(makeReq(VALID), ctx);
+    expect(res.status).toBe(403);
+  });
+
+  it("400 when brief already closed", async () => {
+    mockFrom.mockReturnValue(
+      makeChain({ data: { id: 1, contact_email: VALID.contact_email, status: "closed" } }),
+    );
+    const res = await POST(makeReq(VALID), ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("happy path withdraws the brief", async () => {
+    // 1st from: select brief; 2nd: update; 3rd: insert tracker event.
+    mockFrom
+      .mockReturnValueOnce(
+        makeChain({ data: { id: 1, contact_email: VALID.contact_email, status: "open" } }),
+      )
+      .mockReturnValueOnce(makeChain({ error: null }))
+      .mockReturnValueOnce(makeChain({ error: null }));
+    const res = await POST(makeReq(VALID), ctx);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.success).toBe(true);
+    expect(mockFrom).toHaveBeenCalledWith("advisor_auctions");
+    expect(mockFrom).toHaveBeenCalledWith("brief_tracker_events");
+  });
+
+  it("matches email case-insensitively", async () => {
+    mockFrom
+      .mockReturnValueOnce(
+        makeChain({ data: { id: 1, contact_email: "Owner@Example.com", status: "open" } }),
+      )
+      .mockReturnValueOnce(makeChain({ error: null }))
+      .mockReturnValueOnce(makeChain({ error: null }));
+    const res = await POST(makeReq({ contact_email: "Owner@Example.com" }), ctx);
+    expect(res.status).toBe(200);
+  });
+
+  it("500 when query throws", async () => {
+    mockFrom.mockImplementation(() => {
+      throw new Error("db");
+    });
+    const res = await POST(makeReq(VALID), ctx);
+    expect(res.status).toBe(500);
+  });
+});


### PR DESCRIPTION
## Summary
Adds vitest unit tests for 6 previously-untested `app/api/briefs/*` routes (inbox, preview, shortlist add/remove, status, withdraw). 53 tests covering rate-limit (429), auth gating (401/403), not-found (404), happy paths, DB-error (500), zod rejection (400), plus ShortlistError mapping (422/409). Admin + server clients mocked per CLAUDE.md.

## Queue item
D-COV (pre-launch coverage push) — untested API routes surfaced 2026-05-20. Moves M02 (API routes with tests, 57→200).

## Supersedes
_None._

## Test plan
- [x] `vitest run __tests__/api/briefs-*.test.ts` → 53/53 pass locally
- [ ] CI green