### PR TITLE
test(d): add unit tests for expert-teams/* API routes

### DIFF
--- a/__tests__/api/expert-teams-id-invite.test.ts
+++ b/__tests__/api/expert-teams-id-invite.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockIsAllowed, mockRequireAdvisorSession, mockGetTeamById, mockInviteMember } = vi.hoisted(
+  () => ({
+    mockIsAllowed: vi.fn(),
+    mockRequireAdvisorSession: vi.fn(),
+    mockGetTeamById: vi.fn(),
+    mockInviteMember: vi.fn(),
+  }),
+);
+
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: mockIsAllowed,
+  ipKey: vi.fn(() => "ip:test"),
+}));
+
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: mockRequireAdvisorSession,
+}));
+
+vi.mock("@/lib/expert-teams", () => ({
+  getTeamById: mockGetTeamById,
+  inviteMember: mockInviteMember,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import { POST } from "@/app/api/expert-teams/[id]/invite/route";
+
+const VALID_BODY = { email: "pro@example.com", name: "Pat", role: "accountant" };
+
+function makeReq(body: unknown, raw = false): NextRequest {
+  return new NextRequest("http://localhost/api/expert-teams/5/invite", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: raw ? (body as string) : JSON.stringify(body),
+  });
+}
+
+function ctx(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+describe("POST /api/expert-teams/[id]/invite", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowed.mockResolvedValue(true);
+    mockRequireAdvisorSession.mockResolvedValue("advisor-1");
+    mockGetTeamById.mockResolvedValue({ id: 5, owner_professional_id: "advisor-1" });
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockIsAllowed.mockResolvedValueOnce(false);
+    const res = await POST(makeReq(VALID_BODY), ctx("5"));
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 401 when not signed in", async () => {
+    mockRequireAdvisorSession.mockResolvedValueOnce(null);
+    const res = await POST(makeReq(VALID_BODY), ctx("5"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 on a non-numeric team id", async () => {
+    const res = await POST(makeReq(VALID_BODY), ctx("abc"));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid team id." });
+  });
+
+  it("returns 404 when the team does not exist", async () => {
+    mockGetTeamById.mockResolvedValueOnce(null);
+    const res = await POST(makeReq(VALID_BODY), ctx("5"));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when the caller is not the team owner", async () => {
+    mockGetTeamById.mockResolvedValueOnce({ id: 5, owner_professional_id: "someone-else" });
+    const res = await POST(makeReq(VALID_BODY), ctx("5"));
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 on invalid JSON body", async () => {
+    const res = await POST(makeReq("{bad", true), ctx("5"));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid JSON body." });
+  });
+
+  it("returns 400 on an invalid email (zod)", async () => {
+    const res = await POST(makeReq({ email: "not-an-email" }), ctx("5"));
+    expect(res.status).toBe(400);
+  });
+
+  it("invites the member on the happy path", async () => {
+    const invitation = { id: 1, email: "pro@example.com" };
+    mockInviteMember.mockResolvedValueOnce(invitation);
+    const res = await POST(makeReq(VALID_BODY), ctx("5"));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ invitation });
+    expect(mockInviteMember).toHaveBeenCalledWith({
+      teamId: 5,
+      invitedByProfessionalId: "advisor-1",
+      email: "pro@example.com",
+      name: "Pat",
+      role: "accountant",
+    });
+  });
+
+  it("maps invitation_already_pending to 409", async () => {
+    mockInviteMember.mockRejectedValueOnce(new Error("invitation_already_pending"));
+    const res = await POST(makeReq(VALID_BODY), ctx("5"));
+    expect(res.status).toBe(409);
+  });
+
+  it("maps already_member to 409", async () => {
+    mockInviteMember.mockRejectedValueOnce(new Error("already_member"));
+    const res = await POST(makeReq(VALID_BODY), ctx("5"));
+    expect(res.status).toBe(409);
+  });
+
+  it("returns 500 on an unmapped error", async () => {
+    mockInviteMember.mockRejectedValueOnce(new Error("boom"));
+    const res = await POST(makeReq(VALID_BODY), ctx("5"));
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: "Failed to invite member." });
+  });
+});

--- a/__tests__/api/expert-teams-id-submit.test.ts
+++ b/__tests__/api/expert-teams-id-submit.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockIsAllowed, mockRequireAdvisorSession, mockSubmitForVerification } = vi.hoisted(() => ({
+  mockIsAllowed: vi.fn(),
+  mockRequireAdvisorSession: vi.fn(),
+  mockSubmitForVerification: vi.fn(),
+}));
+
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: mockIsAllowed,
+  ipKey: vi.fn(() => "ip:test"),
+}));
+
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: mockRequireAdvisorSession,
+}));
+
+vi.mock("@/lib/expert-teams", () => ({
+  submitForVerification: mockSubmitForVerification,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import { POST } from "@/app/api/expert-teams/[id]/submit/route";
+
+function makeReq(): NextRequest {
+  return new NextRequest("http://localhost/api/expert-teams/5/submit", { method: "POST" });
+}
+
+function ctx(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+describe("POST /api/expert-teams/[id]/submit", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowed.mockResolvedValue(true);
+    mockRequireAdvisorSession.mockResolvedValue("advisor-1");
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockIsAllowed.mockResolvedValueOnce(false);
+    const res = await POST(makeReq(), ctx("5"));
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 401 when not signed in", async () => {
+    mockRequireAdvisorSession.mockResolvedValueOnce(null);
+    const res = await POST(makeReq(), ctx("5"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 on a non-numeric team id", async () => {
+    const res = await POST(makeReq(), ctx("xyz"));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid team id." });
+  });
+
+  it("submits for verification on the happy path", async () => {
+    const team = { id: 5, status: "submitted" };
+    mockSubmitForVerification.mockResolvedValueOnce(team);
+    const res = await POST(makeReq(), ctx("5"));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ team });
+    expect(mockSubmitForVerification).toHaveBeenCalledWith(5, "advisor-1");
+  });
+
+  it("maps team_not_found to 404", async () => {
+    mockSubmitForVerification.mockRejectedValueOnce(new Error("team_not_found"));
+    const res = await POST(makeReq(), ctx("5"));
+    expect(res.status).toBe(404);
+  });
+
+  it("maps not_owner to 403", async () => {
+    mockSubmitForVerification.mockRejectedValueOnce(new Error("not_owner"));
+    const res = await POST(makeReq(), ctx("5"));
+    expect(res.status).toBe(403);
+  });
+
+  it("maps incomplete:* to 400 with the missing list", async () => {
+    mockSubmitForVerification.mockRejectedValueOnce(new Error("incomplete:disclosure,members"));
+    const res = await POST(makeReq(), ctx("5"));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: "Team is not ready for verification.",
+      missing: ["disclosure", "members"],
+    });
+  });
+
+  it("returns 500 on an unmapped error", async () => {
+    mockSubmitForVerification.mockRejectedValueOnce(new Error("boom"));
+    const res = await POST(makeReq(), ctx("5"));
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: "Failed to submit team." });
+  });
+});

--- a/__tests__/api/expert-teams-invite-accept.test.ts
+++ b/__tests__/api/expert-teams-invite-accept.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockIsAllowed, mockRequireAdvisorSession, mockAcceptInvitation } = vi.hoisted(() => ({
+  mockIsAllowed: vi.fn(),
+  mockRequireAdvisorSession: vi.fn(),
+  mockAcceptInvitation: vi.fn(),
+}));
+
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: mockIsAllowed,
+  ipKey: vi.fn(() => "ip:test"),
+}));
+
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: mockRequireAdvisorSession,
+}));
+
+vi.mock("@/lib/expert-teams", () => ({
+  acceptInvitation: mockAcceptInvitation,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import { POST } from "@/app/api/expert-teams/invite/accept/route";
+
+const TOKEN = "t".repeat(30);
+
+function makeReq(body: unknown, raw = false): NextRequest {
+  return new NextRequest("http://localhost/api/expert-teams/invite/accept", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: raw ? (body as string) : JSON.stringify(body),
+  });
+}
+
+describe("POST /api/expert-teams/invite/accept", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowed.mockResolvedValue(true);
+    mockRequireAdvisorSession.mockResolvedValue("advisor-1");
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockIsAllowed.mockResolvedValueOnce(false);
+    const res = await POST(makeReq({ token: TOKEN }));
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 401 when not signed in", async () => {
+    mockRequireAdvisorSession.mockResolvedValueOnce(null);
+    const res = await POST(makeReq({ token: TOKEN }));
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "Sign in required." });
+  });
+
+  it("returns 400 on invalid JSON body", async () => {
+    const res = await POST(makeReq("{not json", true));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid JSON body." });
+  });
+
+  it("returns 400 when the token is too short (zod)", async () => {
+    const res = await POST(makeReq({ token: "short" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("accepts the invitation on the happy path", async () => {
+    mockAcceptInvitation.mockResolvedValueOnce({ teamId: 99 });
+    const res = await POST(makeReq({ token: TOKEN }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true, team_id: 99 });
+    expect(mockAcceptInvitation).toHaveBeenCalledWith({
+      token: TOKEN,
+      professionalId: "advisor-1",
+    });
+  });
+
+  it("maps invalid_invitation to 404", async () => {
+    mockAcceptInvitation.mockRejectedValueOnce(new Error("invalid_invitation"));
+    const res = await POST(makeReq({ token: TOKEN }));
+    expect(res.status).toBe(404);
+  });
+
+  it("maps invitation_unavailable to 410", async () => {
+    mockAcceptInvitation.mockRejectedValueOnce(new Error("invitation_unavailable"));
+    const res = await POST(makeReq({ token: TOKEN }));
+    expect(res.status).toBe(410);
+  });
+
+  it("maps invitation_expired to 410", async () => {
+    mockAcceptInvitation.mockRejectedValueOnce(new Error("invitation_expired"));
+    const res = await POST(makeReq({ token: TOKEN }));
+    expect(res.status).toBe(410);
+  });
+
+  it("returns 500 on an unmapped error", async () => {
+    mockAcceptInvitation.mockRejectedValueOnce(new Error("boom"));
+    const res = await POST(makeReq({ token: TOKEN }));
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: "Failed to accept invitation." });
+  });
+});

--- a/__tests__/api/expert-teams-invite-get.test.ts
+++ b/__tests__/api/expert-teams-invite-get.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockIsAllowed, mockGetInvitationByToken, mockMaybeSingle, mockEq, mockFrom } =
+  vi.hoisted(() => {
+    const mockMaybeSingle = vi.fn();
+    const mockEq = vi.fn(() => ({ maybeSingle: mockMaybeSingle }));
+    const mockSelect = vi.fn(() => ({ eq: mockEq }));
+    const mockFrom = vi.fn(() => ({ select: mockSelect }));
+    return {
+      mockIsAllowed: vi.fn(),
+      mockGetInvitationByToken: vi.fn(),
+      mockMaybeSingle,
+      mockEq,
+      mockSelect,
+      mockFrom,
+    };
+  });
+
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: mockIsAllowed,
+  ipKey: vi.fn(() => "ip:test"),
+}));
+
+vi.mock("@/lib/expert-teams", () => ({
+  getInvitationByToken: mockGetInvitationByToken,
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+import { GET } from "@/app/api/expert-teams/invite/route";
+
+function makeReq(token?: string): NextRequest {
+  const url = token
+    ? `http://localhost/api/expert-teams/invite?token=${token}`
+    : "http://localhost/api/expert-teams/invite";
+  return new NextRequest(url, { method: "GET" });
+}
+
+const FUTURE = new Date(Date.now() + 86400000).toISOString();
+const PAST = new Date(Date.now() - 86400000).toISOString();
+
+function invitation(overrides: Record<string, unknown> = {}) {
+  return {
+    email: "pro@example.com",
+    name: "Pat Pro",
+    invited_role: "accountant",
+    status: "pending",
+    expires_at: FUTURE,
+    team_id: 42,
+    ...overrides,
+  };
+}
+
+describe("GET /api/expert-teams/invite", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowed.mockResolvedValue(true);
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockIsAllowed.mockResolvedValueOnce(false);
+    const res = await GET(makeReq("a".repeat(30)));
+    expect(res.status).toBe(429);
+    expect(await res.json()).toEqual({ error: "Too many requests" });
+  });
+
+  it("returns 400 when no token provided", async () => {
+    const res = await GET(makeReq());
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Token required." });
+  });
+
+  it("returns 404 when the invitation is not found", async () => {
+    mockGetInvitationByToken.mockResolvedValueOnce(null);
+    const res = await GET(makeReq("tok"));
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "Invalid invitation." });
+  });
+
+  it("returns 410 when the invitation is not pending", async () => {
+    mockGetInvitationByToken.mockResolvedValueOnce(invitation({ status: "accepted" }));
+    const res = await GET(makeReq("tok"));
+    expect(res.status).toBe(410);
+  });
+
+  it("returns 410 when the invitation has expired", async () => {
+    mockGetInvitationByToken.mockResolvedValueOnce(invitation({ expires_at: PAST }));
+    const res = await GET(makeReq("tok"));
+    expect(res.status).toBe(410);
+    expect(await res.json()).toEqual({ error: "This invitation has expired." });
+  });
+
+  it("returns the invitation and team on the happy path", async () => {
+    mockGetInvitationByToken.mockResolvedValueOnce(invitation());
+    const team = { id: 42, name: "Team A", slug: "team-a", team_category: "tax" };
+    mockMaybeSingle.mockResolvedValueOnce({ data: team, error: null });
+    const res = await GET(makeReq("tok"));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      email: "pro@example.com",
+      name: "Pat Pro",
+      role: "accountant",
+      team,
+    });
+    expect(mockEq).toHaveBeenCalledWith("id", 42);
+  });
+});


### PR DESCRIPTION
## Summary
Adds vitest unit tests for 4 previously-untested `app/api/expert-teams/*` routes (invite GET, invite/accept, [id]/invite, [id]/submit). 34 tests covering rate-limit (429), auth (401/403), zod (400), happy paths, and mapped error codes (404/409/410/500).

## Queue item
D-COV (pre-launch coverage push) — untested API routes. Moves M02 (API routes with tests, 57→200).

## Supersedes
_None._

## Test plan
- [x] `vitest run __tests__/api/expert-teams-*.test.ts` → 34/34 pass locally
- [ ] CI green