### PR TITLE
test(d): add unit tests for listings/* + bookings/* API routes

### DIFF
--- a/__tests__/api/bookings-cancel.test.ts
+++ b/__tests__/api/bookings-cancel.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { ConsultationError } = vi.hoisted(() => {
+  class ConsultationError extends Error {
+    code: string;
+    status: number;
+    constructor(code: string, message: string, status: number) {
+      super(message);
+      this.code = code;
+      this.status = status;
+    }
+  }
+  return { ConsultationError };
+});
+
+const {
+  mockIsAllowed,
+  mockRequireAdvisorSession,
+  mockGetUser,
+  mockGetBooking,
+  mockGetSlot,
+  mockCancelBooking,
+  mockAdminInsert,
+  mockAdminFrom,
+} = vi.hoisted(() => {
+  const mockAdminInsert = vi.fn();
+  return {
+    mockIsAllowed: vi.fn(),
+    mockRequireAdvisorSession: vi.fn(),
+    mockGetUser: vi.fn(),
+    mockGetBooking: vi.fn(),
+    mockGetSlot: vi.fn(),
+    mockCancelBooking: vi.fn(),
+    mockAdminInsert,
+    mockAdminFrom: vi.fn(() => ({ insert: mockAdminInsert })),
+  };
+});
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({ auth: { getUser: mockGetUser } })),
+}));
+
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: mockRequireAdvisorSession,
+}));
+
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: mockIsAllowed,
+  ipKey: vi.fn(() => "ip:1.2.3.4"),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+vi.mock("@/lib/consultations", () => ({
+  ConsultationError,
+  getBooking: mockGetBooking,
+  getSlot: mockGetSlot,
+  cancelBooking: mockCancelBooking,
+}));
+
+import { POST } from "@/app/api/bookings/[id]/cancel/route";
+
+const BOOKING = {
+  id: 7,
+  slot_id: 11,
+  brief_id: 99,
+  consumer_email: "consumer@example.com",
+};
+const SLOT = { id: 11, professional_id: "pro-1", start_at: "x", end_at: "y" };
+
+function makeReq(body?: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/bookings/7/cancel", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+const ctx = (id = "7") => ({ params: Promise.resolve({ id }) });
+
+describe("POST /api/bookings/[id]/cancel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowed.mockResolvedValue(true);
+    mockRequireAdvisorSession.mockResolvedValue(null);
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    mockAdminInsert.mockResolvedValue({ error: null });
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockIsAllowed.mockResolvedValueOnce(false);
+    const res = await POST(makeReq({}), ctx());
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 400 on a non-numeric booking id", async () => {
+    const res = await POST(makeReq({}), ctx("abc"));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid booking id." });
+  });
+
+  it("returns 400 on a malformed body (bad email)", async () => {
+    const res = await POST(makeReq({ contact_email: "not-an-email" }), ctx());
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when the booking is not found", async () => {
+    mockGetBooking.mockResolvedValueOnce(null);
+    const res = await POST(makeReq({}), ctx());
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "Booking not found." });
+  });
+
+  it("returns 404 when the slot is not found", async () => {
+    mockGetBooking.mockResolvedValueOnce(BOOKING);
+    mockGetSlot.mockResolvedValueOnce(null);
+    const res = await POST(makeReq({}), ctx());
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "Slot not found." });
+  });
+
+  it("returns 403 when no party can be authorised", async () => {
+    mockGetBooking.mockResolvedValueOnce(BOOKING);
+    mockGetSlot.mockResolvedValueOnce(SLOT);
+    const res = await POST(makeReq({ contact_email: "stranger@example.com" }), ctx());
+    expect(res.status).toBe(403);
+  });
+
+  it("cancels as the professional when their session matches the slot", async () => {
+    mockRequireAdvisorSession.mockResolvedValueOnce("pro-1");
+    mockGetBooking.mockResolvedValueOnce(BOOKING);
+    mockGetSlot.mockResolvedValueOnce(SLOT);
+    mockCancelBooking.mockResolvedValueOnce({ ...BOOKING, status: "cancelled" });
+    const res = await POST(makeReq({}), ctx());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ success: true });
+    expect(mockCancelBooking).toHaveBeenCalledWith(7, "professional");
+  });
+
+  it("cancels as the consumer via matching contact_email", async () => {
+    mockGetBooking.mockResolvedValueOnce(BOOKING);
+    mockGetSlot.mockResolvedValueOnce(SLOT);
+    mockCancelBooking.mockResolvedValueOnce({ ...BOOKING, status: "cancelled" });
+    const res = await POST(makeReq({ contact_email: "Consumer@Example.com" }), ctx());
+    expect(res.status).toBe(200);
+    expect(mockCancelBooking).toHaveBeenCalledWith(7, "consumer");
+  });
+
+  it("cancels as the consumer via a matching signed-in session", async () => {
+    mockGetBooking.mockResolvedValueOnce(BOOKING);
+    mockGetSlot.mockResolvedValueOnce(SLOT);
+    mockGetUser.mockResolvedValueOnce({ data: { user: { email: "consumer@example.com" } } });
+    mockCancelBooking.mockResolvedValueOnce({ ...BOOKING, status: "cancelled" });
+    const res = await POST(makeReq(), ctx());
+    expect(res.status).toBe(200);
+    expect(mockCancelBooking).toHaveBeenCalledWith(7, "consumer");
+  });
+
+  it("still succeeds when the tracker-event insert throws (best effort)", async () => {
+    mockGetBooking.mockResolvedValueOnce(BOOKING);
+    mockGetSlot.mockResolvedValueOnce(SLOT);
+    mockCancelBooking.mockResolvedValueOnce({ ...BOOKING, status: "cancelled" });
+    mockAdminInsert.mockRejectedValueOnce(new Error("insert boom"));
+    const res = await POST(makeReq({ contact_email: "consumer@example.com" }), ctx());
+    expect(res.status).toBe(200);
+  });
+
+  it("maps a ConsultationError to its status + code", async () => {
+    mockGetBooking.mockResolvedValueOnce(BOOKING);
+    mockGetSlot.mockResolvedValueOnce(SLOT);
+    mockCancelBooking.mockRejectedValueOnce(
+      new ConsultationError("booking_not_found", "gone", 409),
+    );
+    const res = await POST(makeReq({ contact_email: "consumer@example.com" }), ctx());
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({ error: "gone", code: "booking_not_found" });
+  });
+
+  it("returns 500 on an unexpected error", async () => {
+    mockGetBooking.mockRejectedValueOnce(new Error("kaboom"));
+    const res = await POST(makeReq({}), ctx());
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: "Failed to cancel booking." });
+  });
+});

--- a/__tests__/api/bookings-confirm.test.ts
+++ b/__tests__/api/bookings-confirm.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { ConsultationError } = vi.hoisted(() => {
+  class ConsultationError extends Error {
+    code: string;
+    status: number;
+    constructor(code: string, message: string, status: number) {
+      super(message);
+      this.code = code;
+      this.status = status;
+    }
+  }
+  return { ConsultationError };
+});
+
+const {
+  mockIsAllowed,
+  mockRequireAdvisorSession,
+  mockGetBooking,
+  mockGetSlot,
+  mockConfirmBooking,
+  mockSendEmail,
+  mockAdminFrom,
+} = vi.hoisted(() => ({
+  mockIsAllowed: vi.fn(),
+  mockRequireAdvisorSession: vi.fn(),
+  mockGetBooking: vi.fn(),
+  mockGetSlot: vi.fn(),
+  mockConfirmBooking: vi.fn(),
+  mockSendEmail: vi.fn(),
+  mockAdminFrom: vi.fn(),
+}));
+
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: mockRequireAdvisorSession,
+}));
+
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: mockIsAllowed,
+  ipKey: vi.fn(() => "ip:1.2.3.4"),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+vi.mock("@/lib/consultations", () => ({
+  ConsultationError,
+  getBooking: mockGetBooking,
+  getSlot: mockGetSlot,
+  confirmBooking: mockConfirmBooking,
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+
+vi.mock("@/lib/marketplace-emails", () => ({
+  sendConsumerConsultationConfirmed: mockSendEmail,
+}));
+
+import { POST } from "@/app/api/bookings/[id]/confirm/route";
+
+const BOOKING = {
+  id: 7,
+  slot_id: 11,
+  brief_id: 99,
+  consumer_email: "consumer@example.com",
+  meet_url: null,
+};
+const SLOT = { id: 11, professional_id: "pro-1", start_at: "x", end_at: "y" };
+
+function makeReq(body?: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/bookings/7/confirm", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+const ctx = (id = "7") => ({ params: Promise.resolve({ id }) });
+
+// admin.from().select().eq().maybeSingle()
+function makeMaybeSingleChain(result: { data: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  chain.select = vi.fn(() => chain);
+  chain.eq = vi.fn(() => chain);
+  chain.maybeSingle = vi.fn(() => Promise.resolve(result));
+  return chain;
+}
+
+describe("POST /api/bookings/[id]/confirm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowed.mockResolvedValue(true);
+    mockRequireAdvisorSession.mockResolvedValue("pro-1");
+    mockSendEmail.mockResolvedValue(undefined);
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockIsAllowed.mockResolvedValueOnce(false);
+    const res = await POST(makeReq({}), ctx());
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 401 when there is no advisor session", async () => {
+    mockRequireAdvisorSession.mockResolvedValueOnce(null);
+    const res = await POST(makeReq({}), ctx());
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "Sign in required." });
+  });
+
+  it("returns 400 on a non-numeric booking id", async () => {
+    const res = await POST(makeReq({}), ctx("nope"));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid booking id." });
+  });
+
+  it("returns 400 on a malformed body (bad meet_url)", async () => {
+    const res = await POST(makeReq({ meet_url: "not a url" }), ctx());
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when the booking is not found", async () => {
+    mockGetBooking.mockResolvedValueOnce(null);
+    const res = await POST(makeReq({}), ctx());
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "Booking not found." });
+  });
+
+  it("returns 404 when the slot is not found", async () => {
+    mockGetBooking.mockResolvedValueOnce(BOOKING);
+    mockGetSlot.mockResolvedValueOnce(null);
+    const res = await POST(makeReq({}), ctx());
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "Slot not found." });
+  });
+
+  it("returns 403 when the slot belongs to another professional", async () => {
+    mockGetBooking.mockResolvedValueOnce(BOOKING);
+    mockGetSlot.mockResolvedValueOnce({ ...SLOT, professional_id: "someone-else" });
+    const res = await POST(makeReq({}), ctx());
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "Not your booking." });
+  });
+
+  it("happy path: confirms the booking and returns it", async () => {
+    mockGetBooking.mockResolvedValueOnce(BOOKING);
+    mockGetSlot.mockResolvedValueOnce(SLOT);
+    const confirmed = { ...BOOKING, status: "confirmed", meet_url: "https://meet.example.com/x" };
+    mockConfirmBooking.mockResolvedValueOnce(confirmed);
+    // brief lookup returns no slug -> skips email branch
+    mockAdminFrom.mockReturnValue(makeMaybeSingleChain({ data: null }));
+    const res = await POST(makeReq({ meet_url: "https://meet.example.com/x" }), ctx());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ success: true });
+    expect(mockConfirmBooking).toHaveBeenCalledWith(7, { meetUrl: "https://meet.example.com/x" });
+  });
+
+  it("passes meetUrl null when no meet_url is supplied", async () => {
+    mockGetBooking.mockResolvedValueOnce(BOOKING);
+    mockGetSlot.mockResolvedValueOnce(SLOT);
+    mockConfirmBooking.mockResolvedValueOnce({ ...BOOKING, status: "confirmed" });
+    mockAdminFrom.mockReturnValue(makeMaybeSingleChain({ data: null }));
+    const res = await POST(makeReq({}), ctx());
+    expect(res.status).toBe(200);
+    expect(mockConfirmBooking).toHaveBeenCalledWith(7, { meetUrl: null });
+  });
+
+  it("sends the consumer email when the brief has a slug (best effort)", async () => {
+    mockGetBooking.mockResolvedValueOnce(BOOKING);
+    mockGetSlot.mockResolvedValueOnce(SLOT);
+    mockConfirmBooking.mockResolvedValueOnce({ ...BOOKING, status: "confirmed", meet_url: null });
+    mockAdminFrom
+      .mockReturnValueOnce(makeMaybeSingleChain({ data: { slug: "my-brief", job_title: "Job", contact_name: "Bob" } }))
+      .mockReturnValueOnce(makeMaybeSingleChain({ data: { name: "Pro Name" } }));
+    const res = await POST(makeReq({}), ctx());
+    expect(res.status).toBe(200);
+    // email dispatch is fire-and-forget; let the microtask flush
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockSendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ consumerEmail: "consumer@example.com", briefSlug: "my-brief" }),
+    );
+  });
+
+  it("maps a ConsultationError to its status + code", async () => {
+    mockGetBooking.mockResolvedValueOnce(BOOKING);
+    mockGetSlot.mockResolvedValueOnce(SLOT);
+    mockConfirmBooking.mockRejectedValueOnce(
+      new ConsultationError("slot_not_open", "already confirmed", 409),
+    );
+    const res = await POST(makeReq({}), ctx());
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({ error: "already confirmed", code: "slot_not_open" });
+  });
+
+  it("returns 500 on an unexpected error", async () => {
+    mockGetBooking.mockRejectedValueOnce(new Error("kaboom"));
+    const res = await POST(makeReq({}), ctx());
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: "Failed to confirm booking." });
+  });
+});

--- a/__tests__/api/listings-by-slugs.test.ts
+++ b/__tests__/api/listings-by-slugs.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockIsAllowed, mockIpKey } = vi.hoisted(() => ({
+  mockIsAllowed: vi.fn(),
+  mockIpKey: vi.fn(() => "ip:1.2.3.4"),
+}));
+const mockFrom = vi.fn();
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({ from: mockFrom })),
+}));
+
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: mockIsAllowed,
+  ipKey: mockIpKey,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import { GET } from "@/app/api/listings/by-slugs/route";
+
+function makeReq(slugs?: string): NextRequest {
+  const url = slugs === undefined
+    ? "http://localhost/api/listings/by-slugs"
+    : `http://localhost/api/listings/by-slugs?slugs=${encodeURIComponent(slugs)}`;
+  return new NextRequest(url, { method: "GET" });
+}
+
+// from().select().in().eq() — eq() resolves the query.
+function makeSelectChain(result: { data: unknown; error: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  chain.select = vi.fn(() => chain);
+  chain.in = vi.fn(() => chain);
+  chain.eq = vi.fn(() => Promise.resolve(result));
+  return chain;
+}
+
+describe("GET /api/listings/by-slugs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowed.mockResolvedValue(true);
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockIsAllowed.mockResolvedValueOnce(false);
+    const res = await GET(makeReq("a,b"));
+    expect(res.status).toBe(429);
+    expect(await res.json()).toEqual({ error: "Rate limited" });
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  it("returns an empty list when no slugs are provided", async () => {
+    const res = await GET(makeReq());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ listings: [] });
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  it("returns an empty list when slugs param is blank/whitespace", async () => {
+    const res = await GET(makeReq(" , , "));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ listings: [] });
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  it("fetches active listings filtered to the requested slugs", async () => {
+    const rows = [{ id: 1, slug: "foo" }, { id: 2, slug: "bar" }];
+    const chain = makeSelectChain({ data: rows, error: null });
+    mockFrom.mockReturnValueOnce(chain);
+    const res = await GET(makeReq("foo,bar"));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ listings: rows });
+    expect(mockFrom).toHaveBeenCalledWith("investment_listings");
+    expect(chain.in).toHaveBeenCalledWith("slug", ["foo", "bar"]);
+    expect(chain.eq).toHaveBeenCalledWith("status", "active");
+  });
+
+  it("caps the number of slugs at 4", async () => {
+    const chain = makeSelectChain({ data: [], error: null });
+    mockFrom.mockReturnValueOnce(chain);
+    await GET(makeReq("a,b,c,d,e,f"));
+    expect(chain.in).toHaveBeenCalledWith("slug", ["a", "b", "c", "d"]);
+  });
+
+  it("returns an empty list (200) when the query errors", async () => {
+    mockFrom.mockReturnValueOnce(makeSelectChain({ data: null, error: { message: "boom" } }));
+    const res = await GET(makeReq("foo"));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ listings: [] });
+  });
+
+  it("returns an empty list (200) when the data is null but no error", async () => {
+    mockFrom.mockReturnValueOnce(makeSelectChain({ data: null, error: null }));
+    const res = await GET(makeReq("foo"));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ listings: [] });
+  });
+
+  it("swallows a thrown client error and returns an empty list (200)", async () => {
+    mockFrom.mockImplementationOnce(() => {
+      throw new Error("client blew up");
+    });
+    const res = await GET(makeReq("foo"));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ listings: [] });
+  });
+});

--- a/__tests__/api/listings-claim.test.ts
+++ b/__tests__/api/listings-claim.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockGetUser = vi.fn();
+const mockServerFrom = vi.fn();
+const mockAdminFrom = vi.fn();
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({
+    auth: { getUser: mockGetUser },
+    from: mockServerFrom,
+  })),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import { POST } from "@/app/api/listings/my-listings/claim/route";
+
+const USER = { id: "user-uuid-1", email: "owner@example.com" };
+
+const VALID_BODY = { listing_id: 42, listing_table: "investment_listings" };
+
+function makeReq(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/listings/my-listings/claim", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+// admin.from(table).select().eq().maybeSingle()
+function makeListingChain(result: { data: unknown; error: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  chain.select = vi.fn(() => chain);
+  chain.eq = vi.fn(() => chain);
+  chain.maybeSingle = vi.fn(() => Promise.resolve(result));
+  return chain;
+}
+
+// admin.from(table).upsert() resolves directly
+function makeUpsertChain(result: { error: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  chain.upsert = vi.fn(() => Promise.resolve(result));
+  return chain;
+}
+
+describe("POST /api/listings/my-listings/claim", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("rejects an invalid body via the validation wrapper (400)", async () => {
+    const res = await POST(makeReq({ listing_id: 1, listing_table: "nope" }));
+    expect(res.status).toBe(400);
+    expect(mockGetUser).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-positive listing_id (400)", async () => {
+    const res = await POST(makeReq({ listing_id: 0, listing_table: "investment_listings" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: null } });
+    const res = await POST(makeReq(VALID_BODY));
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "unauthorized" });
+  });
+
+  it("returns 401 when the user has no email", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: { id: "x", email: null } } });
+    const res = await POST(makeReq(VALID_BODY));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when the listing is missing", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    mockAdminFrom.mockReturnValueOnce(makeListingChain({ data: null, error: null }));
+    const res = await POST(makeReq(VALID_BODY));
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "listing_not_found" });
+  });
+
+  it("returns 404 when the listing lookup errors", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    mockAdminFrom.mockReturnValueOnce(makeListingChain({ data: null, error: { message: "db" } }));
+    const res = await POST(makeReq(VALID_BODY));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when the listing email does not match the user", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    mockAdminFrom.mockReturnValueOnce(
+      makeListingChain({ data: { id: 42, contact_email: "other@example.com", slug: "s" }, error: null }),
+    );
+    const res = await POST(makeReq(VALID_BODY));
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "email_mismatch" });
+  });
+
+  it("returns 403 when the listing has no contact email", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    mockAdminFrom.mockReturnValueOnce(
+      makeListingChain({ data: { id: 42, contact_email: "", slug: "s" }, error: null }),
+    );
+    const res = await POST(makeReq(VALID_BODY));
+    expect(res.status).toBe(403);
+  });
+
+  it("happy path: upserts claim + owner account and returns ok", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    const listingChain = makeListingChain({
+      data: { id: 42, contact_email: "OWNER@example.com", slug: "my-slug", title: "My Listing" },
+      error: null,
+    });
+    const claimChain = makeUpsertChain({ error: null });
+    const accountChain = makeUpsertChain({ error: null });
+    mockAdminFrom
+      .mockReturnValueOnce(listingChain) // listing lookup
+      .mockReturnValueOnce(claimChain) // listing_claims
+      .mockReturnValueOnce(accountChain); // listing_owner_accounts
+
+    const res = await POST(makeReq(VALID_BODY));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      ok: true,
+      listing: { id: 42, table: "investment_listings", title: "My Listing" },
+    });
+    expect(mockAdminFrom).toHaveBeenNthCalledWith(2, "listing_claims");
+    expect(mockAdminFrom).toHaveBeenNthCalledWith(3, "listing_owner_accounts");
+    const claimArgs = claimChain.upsert.mock.calls[0] as unknown as [Record<string, unknown>, unknown];
+    expect(claimArgs[0]).toMatchObject({
+      auth_user_id: USER.id,
+      claim_type: "listing",
+      target_slug: "my-slug",
+      status: "verified",
+    });
+  });
+
+  it("uses property_listing claim_type for property_listings table", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    const listingChain = makeListingChain({
+      data: { id: 42, contact_email: "owner@example.com", slug: "prop-slug" },
+      error: null,
+    });
+    const claimChain = makeUpsertChain({ error: null });
+    const accountChain = makeUpsertChain({ error: null });
+    mockAdminFrom
+      .mockReturnValueOnce(listingChain)
+      .mockReturnValueOnce(claimChain)
+      .mockReturnValueOnce(accountChain);
+
+    const res = await POST(makeReq({ listing_id: 42, listing_table: "property_listings" }));
+    expect(res.status).toBe(200);
+    const claimArgs = claimChain.upsert.mock.calls[0] as unknown as [Record<string, unknown>, unknown];
+    expect(claimArgs[0]).toMatchObject({ claim_type: "property_listing" });
+  });
+
+  it("returns 500 when the claim upsert fails", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    const listingChain = makeListingChain({
+      data: { id: 42, contact_email: "owner@example.com", slug: "s" },
+      error: null,
+    });
+    mockAdminFrom
+      .mockReturnValueOnce(listingChain)
+      .mockReturnValueOnce(makeUpsertChain({ error: { message: "claim boom" } }));
+    const res = await POST(makeReq(VALID_BODY));
+    expect(res.status).toBe(500);
+    expect(await res.json()).toMatchObject({ error: "claim_insert_failed", detail: "claim boom" });
+  });
+
+  it("still returns ok when only the owner-account upsert fails (best effort)", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    const listingChain = makeListingChain({
+      data: { id: 42, contact_email: "owner@example.com", slug: "s", title: "T" },
+      error: null,
+    });
+    mockAdminFrom
+      .mockReturnValueOnce(listingChain)
+      .mockReturnValueOnce(makeUpsertChain({ error: null }))
+      .mockReturnValueOnce(makeUpsertChain({ error: { message: "account boom" } }));
+    const res = await POST(makeReq(VALID_BODY));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ ok: true });
+  });
+});

--- a/__tests__/api/listings-verify.test.ts
+++ b/__tests__/api/listings-verify.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockIsRateLimited, mockIsValidEmail, mockSignCookie, mockAdminFrom } = vi.hoisted(() => ({
+  mockIsRateLimited: vi.fn(),
+  mockIsValidEmail: vi.fn(),
+  mockSignCookie: vi.fn(),
+  mockAdminFrom: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  isRateLimited: mockIsRateLimited,
+}));
+
+vi.mock("@/lib/validate-email", () => ({
+  isValidEmail: mockIsValidEmail,
+}));
+
+vi.mock("@/lib/listing-owner-cookie", () => ({
+  signListingOwnerCookie: mockSignCookie,
+  LISTING_OWNER_COOKIE_NAME: "listing_owner_verified",
+  LISTING_OWNER_COOKIE_MAX_AGE_S: 3600,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import { POST } from "@/app/api/listings/my-listings/verify/route";
+
+function makeReq(body: unknown, opts?: { raw?: string }): NextRequest {
+  return new NextRequest("http://localhost/api/listings/my-listings/verify", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "x-forwarded-for": "9.9.9.9" },
+    body: opts?.raw ?? JSON.stringify(body),
+  });
+}
+
+// from("email_otps").select().eq().is().order().limit().maybeSingle()
+function makeOtpSelectChain(result: { data: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  chain.select = vi.fn(() => chain);
+  chain.eq = vi.fn(() => chain);
+  chain.is = vi.fn(() => chain);
+  chain.order = vi.fn(() => chain);
+  chain.limit = vi.fn(() => chain);
+  chain.maybeSingle = vi.fn(() => Promise.resolve(result));
+  return chain;
+}
+
+// from("email_otps").update().eq() resolves
+function makeOtpUpdateChain() {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  chain.update = vi.fn(() => chain);
+  chain.eq = vi.fn(() => Promise.resolve({ error: null }));
+  return chain;
+}
+
+const future = () => new Date(Date.now() + 60_000).toISOString();
+const past = () => new Date(Date.now() - 60_000).toISOString();
+
+describe("POST /api/listings/my-listings/verify", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsRateLimited.mockResolvedValue(false);
+    mockIsValidEmail.mockReturnValue(true);
+    mockSignCookie.mockReturnValue("signed-cookie-value");
+  });
+
+  it("returns 429 on the per-IP burst cap", async () => {
+    mockIsRateLimited.mockResolvedValueOnce(true);
+    const res = await POST(makeReq({ email: "a@b.com", code: "123456" }));
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 429 on the per-IP cumulative cap", async () => {
+    mockIsRateLimited.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    const res = await POST(makeReq({ email: "a@b.com", code: "123456" }));
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 429 on the per-email cap", async () => {
+    mockIsRateLimited
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+    const res = await POST(makeReq({ email: "a@b.com", code: "123456" }));
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 400 on invalid JSON", async () => {
+    const res = await POST(makeReq(null, { raw: "{not json" }));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid request" });
+  });
+
+  it("returns 400 on a body that fails the schema", async () => {
+    const res = await POST(makeReq({ email: "a@b.com" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 on an invalid email address", async () => {
+    mockIsValidEmail.mockReturnValueOnce(false);
+    const res = await POST(makeReq({ email: "bad", code: "123456" }));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Please enter a valid email address." });
+  });
+
+  it("returns 400 when the code is empty after trimming", async () => {
+    const res = await POST(makeReq({ email: "a@b.com", code: "   " }));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Code is required." });
+  });
+
+  it("returns 400 when no active OTP is found", async () => {
+    mockAdminFrom.mockReturnValueOnce(makeOtpSelectChain({ data: null }));
+    const res = await POST(makeReq({ email: "a@b.com", code: "123456" }));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "No active code found. Please request a new one." });
+  });
+
+  it("returns 400 when the OTP is expired", async () => {
+    mockAdminFrom.mockReturnValueOnce(
+      makeOtpSelectChain({ data: { id: 1, code: "123456", expires_at: past(), used_at: null } }),
+    );
+    const res = await POST(makeReq({ email: "a@b.com", code: "123456" }));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Code has expired. Please request a new one." });
+  });
+
+  it("returns 400 when the code length differs", async () => {
+    mockAdminFrom.mockReturnValueOnce(
+      makeOtpSelectChain({ data: { id: 1, code: "123456", expires_at: future(), used_at: null } }),
+    );
+    const res = await POST(makeReq({ email: "a@b.com", code: "999" }));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Incorrect code. Please try again." });
+  });
+
+  it("returns 400 when the code is wrong (same length)", async () => {
+    mockAdminFrom.mockReturnValueOnce(
+      makeOtpSelectChain({ data: { id: 1, code: "123456", expires_at: future(), used_at: null } }),
+    );
+    const res = await POST(makeReq({ email: "a@b.com", code: "654321" }));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Incorrect code. Please try again." });
+  });
+
+  it("happy path: marks OTP used, signs cookie, returns 200 with Set-Cookie", async () => {
+    mockAdminFrom
+      .mockReturnValueOnce(
+        makeOtpSelectChain({ data: { id: 5, code: "123456", expires_at: future(), used_at: null } }),
+      )
+      .mockReturnValueOnce(makeOtpUpdateChain());
+    const res = await POST(makeReq({ email: "Owner@Example.com", code: "123456" }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, verified: true });
+    expect(mockSignCookie).toHaveBeenCalledWith("owner@example.com");
+    expect(res.cookies.get("listing_owner_verified")?.value).toBe("signed-cookie-value");
+  });
+
+  it("returns 503 when cookie signing throws (misconfiguration)", async () => {
+    mockAdminFrom
+      .mockReturnValueOnce(
+        makeOtpSelectChain({ data: { id: 5, code: "123456", expires_at: future(), used_at: null } }),
+      )
+      .mockReturnValueOnce(makeOtpUpdateChain());
+    mockSignCookie.mockImplementationOnce(() => {
+      throw new Error("no secret");
+    });
+    const res = await POST(makeReq({ email: "a@b.com", code: "123456" }));
+    expect(res.status).toBe(503);
+  });
+});


### PR DESCRIPTION
## Summary
Adds vitest unit tests for 5 previously-untested routes: `listings/by-slugs`, `listings/my-listings/claim`+`verify`, `bookings/[id]/cancel`+`confirm`. 57 tests covering rate-limit, auth, zod, happy + not-found + error branches, and ConsultationError mapping.

## Queue item
D-COV (pre-launch coverage push). Moves M02 (API routes with tests, 57→200).

## Supersedes
_None._

## Test plan
- [x] `vitest run __tests__/api/listings-*.test.ts __tests__/api/bookings-*.test.ts` → 57/57 pass locally
- [ ] CI green