### PR TITLE
test(d): add unit tests for disputes/switch-intent/webhooks routes

### DIFF
--- a/__tests__/api/advisor-portal-webhooks.test.ts
+++ b/__tests__/api/advisor-portal-webhooks.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockIsAllowed = vi.fn();
+const mockRequireAdvisorSession = vi.fn();
+const mockListEndpoints = vi.fn();
+const mockCreateEndpoint = vi.fn();
+const mockDisableEndpoint = vi.fn();
+const mockAdminMaybeSingle = vi.fn();
+
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: (...args: unknown[]) => mockIsAllowed(...args),
+  ipKey: vi.fn(() => "ip:1.2.3.4"),
+}));
+
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: (...args: unknown[]) => mockRequireAdvisorSession(...args),
+}));
+
+vi.mock("@/lib/outbound-webhooks", () => ({
+  listEndpoints: (...args: unknown[]) => mockListEndpoints(...args),
+  createEndpoint: (...args: unknown[]) => mockCreateEndpoint(...args),
+  disableEndpoint: (...args: unknown[]) => mockDisableEndpoint(...args),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => {
+    const chain: Record<string, unknown> = {};
+    chain.from = vi.fn(() => chain);
+    chain.select = vi.fn(() => chain);
+    chain.eq = vi.fn(() => chain);
+    chain.maybeSingle = vi.fn(() => mockAdminMaybeSingle());
+    return chain;
+  }),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import { GET, POST, DELETE, ALLOWED_EVENTS } from "@/app/api/advisor-portal/webhooks/route";
+
+function makeReq(method: string, body?: unknown, url = "http://localhost/api/advisor-portal/webhooks"): NextRequest {
+  return new NextRequest(url, {
+    method,
+    headers: { "Content-Type": "application/json" },
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  });
+}
+
+function makeRawReq(method: string, raw: string): NextRequest {
+  return new NextRequest("http://localhost/api/advisor-portal/webhooks", {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: raw,
+  });
+}
+
+describe("GET /api/advisor-portal/webhooks", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdvisorSession.mockResolvedValue(42);
+  });
+
+  it("returns 401 when there is no advisor session", async () => {
+    mockRequireAdvisorSession.mockResolvedValueOnce(null);
+    const res = await GET(makeReq("GET"));
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "Sign in required." });
+  });
+
+  it("lists endpoints without exposing the signing secret", async () => {
+    mockListEndpoints.mockResolvedValueOnce([
+      {
+        id: 1,
+        url: "https://hook.example/x",
+        enabled: true,
+        event_subscriptions: ["brief.accepted"],
+        signing_secret: "shh-secret",
+      },
+    ]);
+    const res = await GET(makeReq("GET"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.endpoints[0]).toEqual({
+      id: 1,
+      url: "https://hook.example/x",
+      enabled: true,
+      event_subscriptions: ["brief.accepted"],
+    });
+    expect(JSON.stringify(body)).not.toContain("shh-secret");
+    expect(body.allowedEvents).toEqual(ALLOWED_EVENTS);
+    expect(mockListEndpoints).toHaveBeenCalledWith("professional", "42");
+  });
+});
+
+describe("POST /api/advisor-portal/webhooks", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowed.mockResolvedValue(true);
+    mockRequireAdvisorSession.mockResolvedValue(42);
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockIsAllowed.mockResolvedValueOnce(false);
+    const res = await POST(makeReq("POST", { url: "https://x.example", eventSubscriptions: ["brief.accepted"] }));
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 401 when there is no advisor session", async () => {
+    mockRequireAdvisorSession.mockResolvedValueOnce(null);
+    const res = await POST(makeReq("POST", { url: "https://x.example", eventSubscriptions: ["brief.accepted"] }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for invalid JSON", async () => {
+    const res = await POST(makeRawReq("POST", "{bad"));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid JSON body." });
+  });
+
+  it("returns 400 for a zod-invalid body (bad url)", async () => {
+    const res = await POST(makeReq("POST", { url: "not-a-url", eventSubscriptions: ["brief.accepted"] }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when no events survive the allow-list filter", async () => {
+    const res = await POST(makeReq("POST", { url: "https://x.example", eventSubscriptions: ["bogus.event"] }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toContain("No supported events");
+    expect(mockCreateEndpoint).not.toHaveBeenCalled();
+  });
+
+  it("happy path — creates an endpoint and returns the signing secret once", async () => {
+    mockCreateEndpoint.mockResolvedValueOnce({
+      endpoint: {
+        id: 9,
+        url: "https://x.example",
+        event_subscriptions: ["brief.accepted"],
+        enabled: true,
+      },
+      signingSecret: "whsec_abc",
+    });
+    const res = await POST(
+      makeReq("POST", { url: "https://x.example", eventSubscriptions: ["brief.accepted", "bogus.event"] }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.signingSecret).toBe("whsec_abc");
+    expect(body.endpoint.id).toBe(9);
+    // bogus.event filtered out before reaching createEndpoint
+    expect(mockCreateEndpoint).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ownerKind: "professional",
+        ownerId: "42",
+        eventSubscriptions: ["brief.accepted"],
+      }),
+    );
+  });
+
+  it("returns 500 when createEndpoint throws", async () => {
+    mockCreateEndpoint.mockRejectedValueOnce(new Error("db down"));
+    const res = await POST(makeReq("POST", { url: "https://x.example", eventSubscriptions: ["brief.accepted"] }));
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: "Failed to create endpoint." });
+  });
+});
+
+describe("DELETE /api/advisor-portal/webhooks", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdvisorSession.mockResolvedValue(42);
+  });
+
+  it("returns 401 when there is no advisor session", async () => {
+    mockRequireAdvisorSession.mockResolvedValueOnce(null);
+    const res = await DELETE(makeReq("DELETE", undefined, "http://localhost/api/advisor-portal/webhooks?id=1"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when the id is missing or invalid", async () => {
+    const res = await DELETE(makeReq("DELETE", undefined, "http://localhost/api/advisor-portal/webhooks"));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Missing or invalid id." });
+  });
+
+  it("returns 404 when the endpoint is not owned by the caller", async () => {
+    mockAdminMaybeSingle.mockResolvedValueOnce({ data: null });
+    const res = await DELETE(makeReq("DELETE", undefined, "http://localhost/api/advisor-portal/webhooks?id=5"));
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "Endpoint not found." });
+    expect(mockDisableEndpoint).not.toHaveBeenCalled();
+  });
+
+  it("happy path — disables an owned endpoint", async () => {
+    mockAdminMaybeSingle.mockResolvedValueOnce({ data: { id: 5 } });
+    const res = await DELETE(makeReq("DELETE", undefined, "http://localhost/api/advisor-portal/webhooks?id=5"));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(mockDisableEndpoint).toHaveBeenCalledWith(5);
+  });
+});

--- a/__tests__/api/disputes-messages.test.ts
+++ b/__tests__/api/disputes-messages.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ─── Hoisted mocks ───────────────────────────────────────────────────────────
+
+const { DisputeError } = vi.hoisted(() => {
+  class DisputeError extends Error {
+    constructor(
+      message: string,
+      public readonly status: number,
+    ) {
+      super(message);
+      this.name = "DisputeError";
+    }
+  }
+  return { DisputeError };
+});
+
+const mockIsAllowed = vi.fn();
+const mockGetUser = vi.fn();
+const mockAdminMaybeSingle = vi.fn();
+const mockRequireAdvisorSession = vi.fn();
+const mockIsProfessionalOnTeam = vi.fn();
+const mockAddMessage = vi.fn();
+
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: (...args: unknown[]) => mockIsAllowed(...args),
+  ipKey: vi.fn(() => "ip:1.2.3.4"),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({
+    auth: { getUser: mockGetUser },
+  })),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => {
+    const chain: Record<string, unknown> = {};
+    chain.from = vi.fn(() => chain);
+    chain.select = vi.fn(() => chain);
+    chain.eq = vi.fn(() => chain);
+    chain.maybeSingle = vi.fn(() => mockAdminMaybeSingle());
+    return chain;
+  }),
+}));
+
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: (...args: unknown[]) => mockRequireAdvisorSession(...args),
+}));
+
+vi.mock("@/lib/expert-teams", () => ({
+  isProfessionalOnTeam: (...args: unknown[]) => mockIsProfessionalOnTeam(...args),
+}));
+
+vi.mock("@/lib/disputes", () => ({
+  DisputeError,
+  addMessage: (...args: unknown[]) => mockAddMessage(...args),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import { POST } from "@/app/api/disputes/[id]/messages/route";
+
+function makeReq(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/disputes/5/messages", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeRawReq(raw: string): NextRequest {
+  return new NextRequest("http://localhost/api/disputes/5/messages", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: raw,
+  });
+}
+
+const ctx = (id: string) => ({ params: Promise.resolve({ id }) });
+
+const LOOKUP_CONSUMER = {
+  id: 5,
+  brief_id: 99,
+  advisor_auctions: {
+    contact_email: "consumer@example.com",
+    accepted_by_professional_id: 7,
+    accepted_by_team_id: null,
+  },
+};
+
+describe("POST /api/disputes/[id]/messages", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowed.mockResolvedValue(true);
+    mockRequireAdvisorSession.mockResolvedValue(null);
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+  });
+
+  it("returns 429 when the IP rate limit is exhausted", async () => {
+    mockIsAllowed.mockResolvedValueOnce(false);
+    const res = await POST(makeReq({ body: "hi" }), ctx("5"));
+    expect(res.status).toBe(429);
+    expect(mockAdminMaybeSingle).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a non-numeric dispute id", async () => {
+    const res = await POST(makeReq({ body: "hi" }), ctx("not-a-number"));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid dispute id." });
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    const res = await POST(makeRawReq("{not json"), ctx("5"));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid JSON body." });
+  });
+
+  it("returns 400 for a zod-invalid body (empty message)", async () => {
+    const res = await POST(makeReq({ body: "" }), ctx("5"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when the dispute is not found", async () => {
+    mockAdminMaybeSingle.mockResolvedValueOnce({ data: null });
+    const res = await POST(makeReq({ body: "hi" }), ctx("5"));
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "Dispute not found." });
+  });
+
+  it("returns 401 when the sender cannot be resolved", async () => {
+    mockAdminMaybeSingle.mockResolvedValueOnce({ data: LOOKUP_CONSUMER });
+    // no advisor session, no matching user
+    const res = await POST(makeReq({ body: "hi" }), ctx("5"));
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "Sign in required." });
+  });
+
+  it("returns 429 when the per-user rate limit is exhausted", async () => {
+    mockAdminMaybeSingle.mockResolvedValueOnce({ data: LOOKUP_CONSUMER });
+    mockRequireAdvisorSession.mockResolvedValueOnce(7); // resolves as professional
+    // IP limit ok (first call), per-user limit fails (second call)
+    mockIsAllowed.mockReset();
+    mockIsAllowed.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+    const res = await POST(makeReq({ body: "hi" }), ctx("5"));
+    expect(res.status).toBe(429);
+  });
+
+  it("happy path — professional sender posts a message", async () => {
+    mockAdminMaybeSingle.mockResolvedValueOnce({ data: LOOKUP_CONSUMER });
+    mockRequireAdvisorSession.mockResolvedValueOnce(7);
+    const row = { id: 1, body: "hi" };
+    mockAddMessage.mockResolvedValueOnce(row);
+    const res = await POST(makeReq({ body: "hi" }), ctx("5"));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ message: row });
+    expect(mockAddMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ disputeId: 5, senderKind: "professional", body: "hi" }),
+    );
+  });
+
+  it("happy path — consumer sender (email match) posts a message", async () => {
+    mockAdminMaybeSingle.mockResolvedValueOnce({ data: LOOKUP_CONSUMER });
+    mockRequireAdvisorSession.mockResolvedValueOnce(null);
+    mockGetUser.mockResolvedValueOnce({
+      data: { user: { id: "u1", email: "Consumer@Example.com" } },
+    });
+    const row = { id: 2, body: "thanks" };
+    mockAddMessage.mockResolvedValueOnce(row);
+    const res = await POST(makeReq({ body: "thanks" }), ctx("5"));
+    expect(res.status).toBe(200);
+    expect(mockAddMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ senderKind: "consumer", senderUserId: "u1" }),
+    );
+  });
+
+  it("maps DisputeError to its status code", async () => {
+    mockAdminMaybeSingle.mockResolvedValueOnce({ data: LOOKUP_CONSUMER });
+    mockRequireAdvisorSession.mockResolvedValueOnce(7);
+    mockAddMessage.mockRejectedValueOnce(new DisputeError("Dispute is closed.", 409));
+    const res = await POST(makeReq({ body: "hi" }), ctx("5"));
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({ error: "Dispute is closed." });
+  });
+
+  it("returns 500 on an unexpected error", async () => {
+    mockAdminMaybeSingle.mockResolvedValueOnce({ data: LOOKUP_CONSUMER });
+    mockRequireAdvisorSession.mockResolvedValueOnce(7);
+    mockAddMessage.mockRejectedValueOnce(new Error("db down"));
+    const res = await POST(makeReq({ body: "hi" }), ctx("5"));
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: "Failed to send message." });
+  });
+});

--- a/__tests__/api/switch-intent.test.ts
+++ b/__tests__/api/switch-intent.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockIsAllowed = vi.fn();
+const mockIsValidEmail = vi.fn();
+const mockIsDisposableEmail = vi.fn();
+const mockIsSuppressed = vi.fn();
+const mockSendEmail = vi.fn();
+const mockInsert = vi.fn();
+
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: (...args: unknown[]) => mockIsAllowed(...args),
+  ipKey: vi.fn(() => "ip:1.2.3.4"),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({
+    from: vi.fn(() => ({ insert: (...args: unknown[]) => mockInsert(...args) })),
+  })),
+}));
+
+vi.mock("@/lib/validate-email", () => ({
+  isValidEmail: (...args: unknown[]) => mockIsValidEmail(...args),
+  isDisposableEmail: (...args: unknown[]) => mockIsDisposableEmail(...args),
+}));
+
+vi.mock("@/lib/email-suppression", () => ({
+  isSuppressed: (...args: unknown[]) => mockIsSuppressed(...args),
+}));
+
+vi.mock("@/lib/resend", () => ({
+  sendEmail: (...args: unknown[]) => mockSendEmail(...args),
+}));
+
+vi.mock("@/lib/url", () => ({
+  getSiteUrl: vi.fn(() => "https://invest.com.au"),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import { POST } from "@/app/api/switch-intent/route";
+
+function makeReq(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/switch-intent", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeRawReq(raw: string): NextRequest {
+  return new NextRequest("http://localhost/api/switch-intent", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: raw,
+  });
+}
+
+const VALID = {
+  product_kind: "super_fund",
+  from_provider: "Old Super",
+  to_provider: "New Super",
+  email: "user@example.com",
+  estimated_balance: 50000,
+  reason: "fees",
+  notes: "switch please",
+};
+
+describe("POST /api/switch-intent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowed.mockResolvedValue(true);
+    mockIsValidEmail.mockReturnValue(true);
+    mockIsDisposableEmail.mockReturnValue(false);
+    mockIsSuppressed.mockResolvedValue(false);
+    mockSendEmail.mockResolvedValue(undefined);
+    mockInsert.mockResolvedValue({ error: null });
+  });
+
+  it("returns 400 for invalid JSON", async () => {
+    const res = await POST(makeRawReq("{nope"));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid JSON" });
+  });
+
+  it("returns 400 for a zod-invalid body (bad product_kind)", async () => {
+    const res = await POST(makeReq({ ...VALID, product_kind: "crypto" }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe("Invalid request");
+  });
+
+  it("returns success without inserting when honeypot is filled", async () => {
+    const res = await POST(makeReq({ ...VALID, website: "http://spam" }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true });
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when email fails the secondary validity check", async () => {
+    mockIsValidEmail.mockReturnValueOnce(false);
+    const res = await POST(makeReq(VALID));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Valid email required." });
+  });
+
+  it("returns 400 for a disposable email", async () => {
+    mockIsDisposableEmail.mockReturnValueOnce(true);
+    const res = await POST(makeReq(VALID));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Please use a real email address." });
+  });
+
+  it("silently succeeds (no insert) when the email is suppressed", async () => {
+    mockIsSuppressed.mockResolvedValueOnce(true);
+    const res = await POST(makeReq(VALID));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true });
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it("happy path — inserts the row, lowercases email, sends verify email", async () => {
+    const res = await POST(makeReq({ ...VALID, email: "User@Example.com" }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true });
+    expect(mockInsert).toHaveBeenCalledOnce();
+    const row = mockInsert.mock.calls[0]![0] as Record<string, unknown>;
+    expect(row).toMatchObject({
+      product_kind: "super_fund",
+      email: "user@example.com",
+      estimated_balance_cents: 5000000,
+      reason: "fees",
+    });
+    expect(row.verify_token).toEqual(expect.any(String));
+    expect(row.unsubscribe_token).toEqual(expect.any(String));
+    expect(mockSendEmail).toHaveBeenCalledOnce();
+  });
+
+  it("returns 500 when the insert fails", async () => {
+    mockInsert.mockResolvedValueOnce({ error: { message: "boom" } });
+    const res = await POST(makeReq(VALID));
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: "Failed to submit" });
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
Adds vitest unit tests for 3 previously-untested routes: `disputes/[id]/messages`, `switch-intent`, `advisor-portal/webhooks`. 32 tests covering rate-limit, auth/session gating, zod, happy + error branches, DisputeError mapping, and webhook signing-secret handling. (The cron rotate-featured route was already covered on main — not duplicated.)

## Queue item
D-COV (pre-launch coverage push). Moves M02 (API routes with tests, 57→200).

## Supersedes
_None._

## Test plan
- [x] `vitest run` on the 3 files → 32/32 pass locally
- [ ] CI green