### PR TITLE
fix(compliance): AFSL-expiry monitor fails loud when lookup unconfigured (§5 #4)

### DIFF
--- a/__tests__/api/cron-afsl-expiry-monitor.test.ts
+++ b/__tests__/api/cron-afsl-expiry-monitor.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockError, mockInfo } = vi.hoisted(() => ({
+  mockError: vi.fn(),
+  mockInfo: vi.fn(),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: () => ({ info: mockInfo, warn: vi.fn(), error: mockError, debug: vi.fn() }),
+}));
+vi.mock("@/lib/cron-run-log", () => ({
+  wrapCronHandler: (_n: string, h: unknown) => h,
+}));
+vi.mock("@/lib/cron-auth", () => ({ requireCronAuth: vi.fn(() => null) }));
+vi.mock("@/lib/admin", () => ({ ADMIN_EMAIL: "admin@example.com" }));
+vi.mock("@/lib/url", () => ({ getSiteUrl: () => "https://invest.com.au" }));
+
+const mockLookupAfsl = vi.fn();
+vi.mock("@/lib/advisor-application-resolver", () => ({
+  lookupAfsl: (...a: unknown[]) => mockLookupAfsl(...a),
+}));
+
+// Per-from() result queue; every chain method returns the chain, and the
+// chain is thenable so `await chain` resolves the next queued result no
+// matter which method is last in the call.
+interface Res { data?: unknown; error?: { message: string } | null }
+const fromQueue: Res[] = [];
+let fromIdx = 0;
+function makeChain() {
+  const res = fromQueue[fromIdx++] ?? { data: null };
+  const c: Record<string, unknown> = {};
+  for (const m of ["select", "eq", "not", "update", "limit", "insert"]) {
+    c[m] = vi.fn(() => c);
+  }
+  c.then = (resolve: (v: { data: unknown; error: unknown }) => unknown) =>
+    Promise.resolve(resolve({ data: res.data ?? null, error: res.error ?? null }));
+  return c;
+}
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({ from: () => makeChain() }),
+}));
+
+import { GET } from "@/app/api/cron/afsl-expiry-monitor/route";
+
+function makeReq(): NextRequest {
+  return new Request("http://localhost/api/cron/afsl-expiry-monitor") as unknown as NextRequest;
+}
+
+const advisor = { id: 1, name: "Jane", email: "jane@x.com", afsl_number: "123456", type: "planner", status: "active" };
+
+describe("GET /api/cron/afsl-expiry-monitor", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fromQueue.length = 0;
+    fromIdx = 0;
+    delete process.env.RESEND_API_KEY; // keep sendEmail a no-op (no real fetch)
+  });
+
+  it("fails loud (inert=true + log.error) when no lookup runs", async () => {
+    fromQueue.push({ data: [advisor] }); // professionals fetch
+    mockLookupAfsl.mockResolvedValue({ performed: false });
+    const res = await GET(makeReq());
+    const json = (await res.json()) as { ok: boolean; inert: boolean; skipped_no_lookup: number };
+    expect(json.ok).toBe(true);
+    expect(json.inert).toBe(true);
+    expect(json.skipped_no_lookup).toBe(1);
+    expect(mockError).toHaveBeenCalledWith(
+      expect.stringContaining("INERT"),
+      expect.any(Object),
+    );
+  });
+
+  it("is not inert when lookups run and licence is current", async () => {
+    fromQueue.push({ data: [advisor] });
+    mockLookupAfsl.mockResolvedValue({ performed: true, status: "current" });
+    const res = await GET(makeReq());
+    const json = (await res.json()) as { inert: boolean; still_current: number };
+    expect(json.inert).toBe(false);
+    expect(json.still_current).toBe(1);
+    expect(mockError).not.toHaveBeenCalled();
+  });
+});

--- a/app/api/cron/afsl-expiry-monitor/route.ts
+++ b/app/api/cron/afsl-expiry-monitor/route.ts
@@ -112,8 +112,25 @@ async function handler(req: NextRequest) {
     }
   }
 
-  log.info("AFSL expiry monitor completed", stats);
-  return NextResponse.json({ ok: true, ...stats });
+  // Fail loud: if there were advisers to check but no lookup ran, the AFSL
+  // provider is unconfigured (AFSL_LOOKUP_URL unset) and this weekly ASIC
+  // check is silently inert — an advisor could retain "active" status after a
+  // licence cancellation/suspension. Alert ops instead of a clean no-op.
+  const inert = stats.scanned > 0 && stats.lookups_run === 0;
+  if (inert) {
+    log.error(
+      "afsl-expiry-monitor INERT — AFSL_LOOKUP_URL not configured; no adviser licences were re-checked against the ASIC register",
+      { scanned: stats.scanned, skipped_no_lookup: stats.skipped_no_lookup },
+    );
+    sendEmail(
+      ADMIN_EMAIL,
+      "⚠️ AFSL expiry monitor inert — no ASIC checks ran",
+      `<p>The weekly AFSL expiry monitor scanned ${stats.scanned} active adviser(s) but performed <strong>0</strong> ASIC register lookups because no AFSL lookup provider is configured (<code>AFSL_LOOKUP_URL</code> unset). Adviser licences are <strong>not</strong> being re-checked, so a ceased/suspended AFSL would go undetected. Set <code>AFSL_LOOKUP_URL</code> in production to enable enforcement.</p>`,
+    );
+  }
+
+  log.info("AFSL expiry monitor completed", { inert, ...stats });
+  return NextResponse.json({ ok: true, inert, ...stats });
 }
 
 function sendEmail(to: string | null, subject: string, html: string): void {


### PR DESCRIPTION
Closes new-features audit §5 flag #4 (P0) — code part.

When AFSL_LOOKUP_URL is unset, the weekly ASIC re-check silently no-ops (lookupAfsl performed:false) and still returns ok:true — an advisor could keep 'active' status after a licence cancellation. Now: if advisers were scanned but zero lookups ran, the cron log.errors + emails the admin that the monitor is INERT and returns inert:true. New route test covers inert + healthy paths.

**Founder action (Tier D):** confirm AFSL_LOOKUP_URL is set in prod to enable real enforcement.

Tier C (cron) — for your merge. Both crons retain requireCronAuth.

Generated with Claude Code