### PR TITLE
test(d): add unit tests for briefs/[slug] action routes

### DIFF
--- a/__tests__/api/briefs-accept.test.ts
+++ b/__tests__/api/briefs-accept.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const {
+  mockIsAllowed,
+  mockIpKey,
+  mockRequireAdvisorSession,
+  mockAcceptBrief,
+  mockIsProfessionalOnTeam,
+  mockMaybeSingle,
+} = vi.hoisted(() => ({
+  mockIsAllowed: vi.fn(),
+  mockIpKey: vi.fn(() => "ip:1.2.3.4"),
+  mockRequireAdvisorSession: vi.fn(),
+  mockAcceptBrief: vi.fn(),
+  mockIsProfessionalOnTeam: vi.fn(),
+  mockMaybeSingle: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => {
+    const chain: Record<string, unknown> = {};
+    chain.from = vi.fn(() => chain);
+    chain.select = vi.fn(() => chain);
+    chain.eq = vi.fn(() => chain);
+    chain.maybeSingle = mockMaybeSingle;
+    return chain;
+  }),
+}));
+
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: mockIsAllowed,
+  ipKey: mockIpKey,
+}));
+
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: mockRequireAdvisorSession,
+}));
+
+vi.mock("@/lib/briefs/credits", () => ({
+  acceptBrief: mockAcceptBrief,
+}));
+
+vi.mock("@/lib/expert-teams", () => ({
+  isProfessionalOnTeam: mockIsProfessionalOnTeam,
+}));
+
+vi.mock("@/lib/marketplace-emails", () => ({
+  sendConsumerProviderAccepted: vi.fn(async () => undefined),
+}));
+
+vi.mock("@/lib/user-notifications", () => ({
+  enqueueUserNotificationByEmail: vi.fn(async () => true),
+}));
+
+vi.mock("@/lib/pro-affiliate/track", () => ({
+  attributeBriefAccepted: vi.fn(async () => undefined),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import { POST } from "@/app/api/briefs/[slug]/accept/route";
+
+const BRIEF = {
+  id: 42,
+  slug: "abc",
+  job_title: "Tax help",
+  contact_email: "owner@example.com",
+  contact_name: "Owner",
+  contact_phone: "0400",
+};
+
+function makeReq(body: unknown = {}): NextRequest {
+  return new NextRequest("http://localhost/api/briefs/abc/accept", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const ctx = { params: Promise.resolve({ slug: "abc" }) };
+
+describe("POST /api/briefs/[slug]/accept", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowed.mockResolvedValue(true);
+    mockRequireAdvisorSession.mockResolvedValue(7);
+    mockMaybeSingle.mockResolvedValue({ data: BRIEF });
+    mockAcceptBrief.mockResolvedValue({
+      accepted: true,
+      creditsSpent: 1,
+      balanceAfterCents: 5000,
+      brief: { id: 42 },
+    });
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockIsAllowed.mockResolvedValueOnce(false);
+    const res = await POST(makeReq(), ctx);
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 401 when not an advisor", async () => {
+    mockRequireAdvisorSession.mockResolvedValueOnce(null);
+    const res = await POST(makeReq(), ctx);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 on invalid body", async () => {
+    const res = await POST(makeReq({ team_id: -1 }), ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when brief not found", async () => {
+    mockMaybeSingle.mockResolvedValueOnce({ data: null });
+    const res = await POST(makeReq(), ctx);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when team_id supplied but advisor not a member", async () => {
+    mockIsProfessionalOnTeam.mockResolvedValueOnce(false);
+    const res = await POST(makeReq({ team_id: 9 }), ctx);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 409 when already accepted by another provider", async () => {
+    mockAcceptBrief.mockResolvedValueOnce({ accepted: false, reason: "already_accepted" });
+    const res = await POST(makeReq(), ctx);
+    expect(res.status).toBe(409);
+    expect(await res.json()).toMatchObject({ reason: "already_accepted" });
+  });
+
+  it("returns 402 when insufficient credits", async () => {
+    mockAcceptBrief.mockResolvedValueOnce({ accepted: false, reason: "insufficient_credits" });
+    const res = await POST(makeReq(), ctx);
+    expect(res.status).toBe(402);
+  });
+
+  it("maps an unknown reason to 400", async () => {
+    mockAcceptBrief.mockResolvedValueOnce({ accepted: false, reason: "weird" });
+    const res = await POST(makeReq(), ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("accepts the brief on the happy path", async () => {
+    const res = await POST(makeReq(), ctx);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      success: true,
+      credits_spent: 1,
+      balance_after_cents: 5000,
+      contact: { email: "owner@example.com" },
+    });
+  });
+
+  it("accepts on behalf of a team when member", async () => {
+    mockIsProfessionalOnTeam.mockResolvedValueOnce(true);
+    const res = await POST(makeReq({ team_id: 9 }), ctx);
+    expect(res.status).toBe(200);
+    expect(mockAcceptBrief).toHaveBeenCalledWith(
+      expect.objectContaining({ teamId: 9, professionalId: 7 }),
+    );
+  });
+
+  it("returns 500 when acceptBrief throws", async () => {
+    mockAcceptBrief.mockRejectedValueOnce(new Error("boom"));
+    const res = await POST(makeReq(), ctx);
+    expect(res.status).toBe(500);
+  });
+});

--- a/__tests__/api/briefs-book-slot.test.ts
+++ b/__tests__/api/briefs-book-slot.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const {
+  mockIsAllowed,
+  mockIpKey,
+  mockGetUser,
+  mockBookSlot,
+  mockGetSlot,
+  mockMaybeSingle,
+  ConsultationError,
+} = vi.hoisted(() => {
+  class ConsultationError extends Error {
+    readonly code: string;
+    readonly status: number;
+    constructor(code: string, message: string, status: number) {
+      super(message);
+      this.code = code;
+      this.status = status;
+    }
+  }
+  return {
+    mockIsAllowed: vi.fn(),
+    mockIpKey: vi.fn(() => "ip:1.2.3.4"),
+    mockGetUser: vi.fn(),
+    mockBookSlot: vi.fn(),
+    mockGetSlot: vi.fn(),
+    mockMaybeSingle: vi.fn(),
+    ConsultationError,
+  };
+});
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => {
+    const chain: Record<string, unknown> = {};
+    chain.from = vi.fn(() => chain);
+    chain.select = vi.fn(() => chain);
+    chain.eq = vi.fn(() => chain);
+    chain.maybeSingle = mockMaybeSingle;
+    return chain;
+  }),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({ auth: { getUser: mockGetUser } })),
+}));
+
+vi.mock("@/lib/rate-limit-db", () => ({ isAllowed: mockIsAllowed, ipKey: mockIpKey }));
+
+vi.mock("@/lib/consultations", () => ({
+  bookSlot: mockBookSlot,
+  getSlot: mockGetSlot,
+  ConsultationError,
+}));
+
+vi.mock("@/lib/marketplace-emails", () => ({
+  sendProConsultationBooked: vi.fn(async () => undefined),
+  sendConsumerConsultationPending: vi.fn(async () => undefined),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import { POST } from "@/app/api/briefs/[slug]/book-slot/route";
+
+const BRIEF = {
+  id: 42,
+  slug: "abc",
+  job_title: "Tax help",
+  contact_email: "owner@example.com",
+  contact_name: "Owner",
+  accepted_by_professional_id: 7,
+  accepted_by_team_id: null,
+};
+
+function makeReq(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/briefs/abc/book-slot", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const ctx = { params: Promise.resolve({ slug: "abc" }) };
+
+describe("POST /api/briefs/[slug]/book-slot", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowed.mockResolvedValue(true);
+    mockMaybeSingle.mockResolvedValue({ data: BRIEF });
+    mockGetSlot.mockResolvedValue({ id: 5, professional_id: 7, start_at: "x", end_at: "y" });
+    mockBookSlot.mockResolvedValue({
+      booking: { id: 99 },
+      slot: { id: 5, professional_id: 7, start_at: "x", end_at: "y" },
+    });
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockIsAllowed.mockResolvedValueOnce(false);
+    const res = await POST(makeReq({ slot_id: 5 }), ctx);
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 400 on invalid JSON body", async () => {
+    const req = new NextRequest("http://localhost/api/briefs/abc/book-slot", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not json",
+    });
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 on schema validation failure", async () => {
+    const res = await POST(makeReq({ slot_id: -1 }), ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when brief not found", async () => {
+    mockMaybeSingle.mockResolvedValueOnce({ data: null });
+    const res = await POST(makeReq({ slot_id: 5, contact_email: "owner@example.com" }), ctx);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 when brief not yet accepted", async () => {
+    mockMaybeSingle.mockResolvedValueOnce({
+      data: { ...BRIEF, accepted_by_professional_id: null },
+    });
+    const res = await POST(makeReq({ slot_id: 5, contact_email: "owner@example.com" }), ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 403 when contact_email does not match owner", async () => {
+    const res = await POST(makeReq({ slot_id: 5, contact_email: "other@example.com" }), ctx);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 401 when no email and not signed in", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: null } });
+    const res = await POST(makeReq({ slot_id: 5 }), ctx);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when signed-in user does not own the brief", async () => {
+    mockGetUser.mockResolvedValueOnce({
+      data: { user: { id: "u1", email: "other@example.com" } },
+    });
+    const res = await POST(makeReq({ slot_id: 5 }), ctx);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 404 when slot not found", async () => {
+    mockGetSlot.mockResolvedValueOnce(null);
+    const res = await POST(makeReq({ slot_id: 5, contact_email: "owner@example.com" }), ctx);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 when slot belongs to a different pro", async () => {
+    mockGetSlot.mockResolvedValueOnce({ id: 5, professional_id: 999, start_at: "x", end_at: "y" });
+    const res = await POST(makeReq({ slot_id: 5, contact_email: "owner@example.com" }), ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("books via email-as-key on the happy path", async () => {
+    const res = await POST(makeReq({ slot_id: 5, contact_email: "owner@example.com" }), ctx);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ success: true, booking: { id: 99 } });
+  });
+
+  it("books via signed-in owner", async () => {
+    mockGetUser.mockResolvedValueOnce({
+      data: { user: { id: "u1", email: "owner@example.com" } },
+    });
+    const res = await POST(makeReq({ slot_id: 5 }), ctx);
+    expect(res.status).toBe(200);
+    expect(mockBookSlot).toHaveBeenCalledWith(
+      expect.objectContaining({ consumerUserId: "u1" }),
+    );
+  });
+
+  it("maps a ConsultationError to its status/code", async () => {
+    mockBookSlot.mockRejectedValueOnce(new ConsultationError("slot_not_open", "Taken", 409));
+    const res = await POST(makeReq({ slot_id: 5, contact_email: "owner@example.com" }), ctx);
+    expect(res.status).toBe(409);
+    expect(await res.json()).toMatchObject({ code: "slot_not_open" });
+  });
+
+  it("returns 500 on unexpected error", async () => {
+    mockBookSlot.mockRejectedValueOnce(new Error("boom"));
+    const res = await POST(makeReq({ slot_id: 5, contact_email: "owner@example.com" }), ctx);
+    expect(res.status).toBe(500);
+  });
+});

--- a/__tests__/api/briefs-disputes.test.ts
+++ b/__tests__/api/briefs-disputes.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const {
+  mockIsAllowed,
+  mockIpKey,
+  mockGetUser,
+  mockRequireAdvisorSession,
+  mockOpenDispute,
+  mockIsProfessionalOnTeam,
+  mockMaybeSingle,
+  DisputeError,
+} = vi.hoisted(() => {
+  class DisputeError extends Error {
+    constructor(message: string, public readonly status: number) {
+      super(message);
+      this.name = "DisputeError";
+    }
+  }
+  return {
+    mockIsAllowed: vi.fn(),
+    mockIpKey: vi.fn(() => "ip:1.2.3.4"),
+    mockGetUser: vi.fn(),
+    mockRequireAdvisorSession: vi.fn(),
+    mockOpenDispute: vi.fn(),
+    mockIsProfessionalOnTeam: vi.fn(),
+    mockMaybeSingle: vi.fn(),
+    DisputeError,
+  };
+});
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => {
+    const chain: Record<string, unknown> = {};
+    chain.from = vi.fn(() => chain);
+    chain.select = vi.fn(() => chain);
+    chain.eq = vi.fn(() => chain);
+    chain.maybeSingle = mockMaybeSingle;
+    return chain;
+  }),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({ auth: { getUser: mockGetUser } })),
+}));
+
+vi.mock("@/lib/rate-limit-db", () => ({ isAllowed: mockIsAllowed, ipKey: mockIpKey }));
+
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: mockRequireAdvisorSession,
+}));
+
+vi.mock("@/lib/disputes", () => ({
+  openDispute: mockOpenDispute,
+  DisputeError,
+}));
+
+vi.mock("@/lib/expert-teams", () => ({
+  isProfessionalOnTeam: mockIsProfessionalOnTeam,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import { POST } from "@/app/api/briefs/[slug]/disputes/route";
+
+const BRIEF = {
+  id: 42,
+  contact_email: "owner@example.com",
+  accepted_at: "2026-01-01",
+  accepted_by_professional_id: 7,
+  accepted_by_team_id: null,
+};
+
+const REASON = "x".repeat(250);
+
+function makeReq(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/briefs/abc/disputes", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const ctx = { params: Promise.resolve({ slug: "abc" }) };
+
+describe("POST /api/briefs/[slug]/disputes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowed.mockResolvedValue(true);
+    mockMaybeSingle.mockResolvedValue({ data: BRIEF, email: "pro@example.com" });
+    // advisorEmail also calls maybeSingle; default returns BRIEF which has no email,
+    // tests that exercise advisor path override per-call.
+    mockRequireAdvisorSession.mockResolvedValue(null);
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "u1", email: "owner@example.com" } },
+    });
+    mockOpenDispute.mockResolvedValue({ id: 1, status: "open" });
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockIsAllowed.mockResolvedValueOnce(false);
+    const res = await POST(makeReq({ reason: REASON }), ctx);
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 400 on invalid JSON body", async () => {
+    const req = new NextRequest("http://localhost/api/briefs/abc/disputes", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not json",
+    });
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when reason too short", async () => {
+    const res = await POST(makeReq({ reason: "too short" }), ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when brief not found", async () => {
+    mockMaybeSingle.mockResolvedValueOnce({ data: null });
+    const res = await POST(makeReq({ reason: REASON }), ctx);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 401 when caller is neither consumer nor accepted pro", async () => {
+    mockGetUser.mockResolvedValueOnce({
+      data: { user: { id: "u1", email: "stranger@example.com" } },
+    });
+    const res = await POST(makeReq({ reason: REASON }), ctx);
+    expect(res.status).toBe(401);
+  });
+
+  it("opens a dispute as the consumer on the happy path", async () => {
+    const res = await POST(makeReq({ reason: REASON }), ctx);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ dispute: { id: 1, status: "open" } });
+    expect(mockOpenDispute).toHaveBeenCalledWith(
+      expect.objectContaining({ openedByKind: "consumer", briefId: 42 }),
+    );
+  });
+
+  it("opens a dispute as the accepted professional", async () => {
+    mockRequireAdvisorSession.mockResolvedValueOnce(7);
+    // brief lookup, then advisorEmail lookup
+    mockMaybeSingle
+      .mockResolvedValueOnce({ data: BRIEF })
+      .mockResolvedValueOnce({ data: { email: "pro@example.com" } });
+    const res = await POST(makeReq({ reason: REASON }), ctx);
+    expect(res.status).toBe(200);
+    expect(mockOpenDispute).toHaveBeenCalledWith(
+      expect.objectContaining({ openedByKind: "professional" }),
+    );
+  });
+
+  it("maps a DisputeError to its status", async () => {
+    mockOpenDispute.mockRejectedValueOnce(new DisputeError("Already open", 409));
+    const res = await POST(makeReq({ reason: REASON }), ctx);
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({ error: "Already open" });
+  });
+
+  it("returns 500 on unexpected error", async () => {
+    mockOpenDispute.mockRejectedValueOnce(new Error("boom"));
+    const res = await POST(makeReq({ reason: REASON }), ctx);
+    expect(res.status).toBe(500);
+  });
+});

--- a/__tests__/api/briefs-intake-answers.test.ts
+++ b/__tests__/api/briefs-intake-answers.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const {
+  mockIsAllowed,
+  mockIpKey,
+  mockSubmitAnswers,
+  mockMaybeSingle,
+  IntakeError,
+} = vi.hoisted(() => {
+  class IntakeError extends Error {
+    readonly status: number;
+    constructor(message: string, status = 400) {
+      super(message);
+      this.status = status;
+    }
+  }
+  return {
+    mockIsAllowed: vi.fn(),
+    mockIpKey: vi.fn(() => "ip:1.2.3.4"),
+    mockSubmitAnswers: vi.fn(),
+    mockMaybeSingle: vi.fn(),
+    IntakeError,
+  };
+});
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => {
+    const chain: Record<string, unknown> = {};
+    chain.from = vi.fn(() => chain);
+    chain.select = vi.fn(() => chain);
+    chain.eq = vi.fn(() => chain);
+    chain.maybeSingle = mockMaybeSingle;
+    return chain;
+  }),
+}));
+
+vi.mock("@/lib/rate-limit-db", () => ({ isAllowed: mockIsAllowed, ipKey: mockIpKey }));
+
+vi.mock("@/lib/pro-intake", () => ({
+  submitAnswers: mockSubmitAnswers,
+  IntakeError,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import { POST } from "@/app/api/briefs/[slug]/intake-answers/route";
+
+const BRIEF = { id: 42, slug: "abc", contact_email: "owner@example.com" };
+
+const VALID = {
+  email: "owner@example.com",
+  answers: [{ question_id: 1, answer: "yes" }],
+};
+
+function makeReq(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/briefs/abc/intake-answers", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const ctx = { params: Promise.resolve({ slug: "abc" }) };
+
+describe("POST /api/briefs/[slug]/intake-answers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowed.mockResolvedValue(true);
+    mockMaybeSingle.mockResolvedValue({ data: BRIEF });
+    mockSubmitAnswers.mockResolvedValue([{ id: 1, question_id: 1, answer: "yes" }]);
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockIsAllowed.mockResolvedValueOnce(false);
+    const res = await POST(makeReq(VALID), ctx);
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 400 on invalid JSON body", async () => {
+    const req = new NextRequest("http://localhost/api/briefs/abc/intake-answers", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not json",
+    });
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 on schema validation failure", async () => {
+    const res = await POST(makeReq({ email: "owner@example.com", answers: [] }), ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when brief not found", async () => {
+    mockMaybeSingle.mockResolvedValueOnce({ data: null });
+    const res = await POST(makeReq(VALID), ctx);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when email does not match brief owner", async () => {
+    const res = await POST(makeReq({ ...VALID, email: "other@example.com" }), ctx);
+    expect(res.status).toBe(403);
+  });
+
+  it("saves answers on the happy path", async () => {
+    const res = await POST(makeReq(VALID), ctx);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ answers: [{ id: 1, question_id: 1, answer: "yes" }] });
+    expect(mockSubmitAnswers).toHaveBeenCalledWith(
+      expect.objectContaining({ briefId: 42 }),
+    );
+  });
+
+  it("maps an IntakeError to its status", async () => {
+    mockSubmitAnswers.mockRejectedValueOnce(new IntakeError("Unknown question", 422));
+    const res = await POST(makeReq(VALID), ctx);
+    expect(res.status).toBe(422);
+    expect(await res.json()).toEqual({ error: "Unknown question" });
+  });
+
+  it("returns 500 on unexpected error", async () => {
+    mockSubmitAnswers.mockRejectedValueOnce(new Error("boom"));
+    const res = await POST(makeReq(VALID), ctx);
+    expect(res.status).toBe(500);
+  });
+});

--- a/__tests__/api/briefs-messages-mark-read.test.ts
+++ b/__tests__/api/briefs-messages-mark-read.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const {
+  mockIsAllowed,
+  mockIpKey,
+  mockGetUser,
+  mockRequireAdvisorSession,
+  mockMarkRead,
+  mockIsProfessionalOnTeam,
+  mockMaybeSingle,
+  BriefMessageError,
+} = vi.hoisted(() => {
+  class BriefMessageError extends Error {
+    constructor(message: string, public readonly status: number) {
+      super(message);
+      this.name = "BriefMessageError";
+    }
+  }
+  return {
+    mockIsAllowed: vi.fn(),
+    mockIpKey: vi.fn(() => "ip:1.2.3.4"),
+    mockGetUser: vi.fn(),
+    mockRequireAdvisorSession: vi.fn(),
+    mockMarkRead: vi.fn(),
+    mockIsProfessionalOnTeam: vi.fn(),
+    mockMaybeSingle: vi.fn(),
+    BriefMessageError,
+  };
+});
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => {
+    const chain: Record<string, unknown> = {};
+    chain.from = vi.fn(() => chain);
+    chain.select = vi.fn(() => chain);
+    chain.eq = vi.fn(() => chain);
+    chain.maybeSingle = mockMaybeSingle;
+    return chain;
+  }),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({ auth: { getUser: mockGetUser } })),
+}));
+
+vi.mock("@/lib/rate-limit-db", () => ({ isAllowed: mockIsAllowed, ipKey: mockIpKey }));
+
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: mockRequireAdvisorSession,
+}));
+
+vi.mock("@/lib/brief-messages", () => ({
+  markRead: mockMarkRead,
+  BriefMessageError,
+}));
+
+vi.mock("@/lib/expert-teams", () => ({
+  isProfessionalOnTeam: mockIsProfessionalOnTeam,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import { POST } from "@/app/api/briefs/[slug]/messages/mark-read/route";
+
+const BRIEF = {
+  id: 42,
+  contact_email: "owner@example.com",
+  accepted_at: "2026-01-01",
+  accepted_by_professional_id: 7,
+  accepted_by_team_id: null,
+};
+
+function makeReq(body: unknown = {}): NextRequest {
+  return new NextRequest("http://localhost/api/briefs/abc/messages/mark-read", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const ctx = { params: Promise.resolve({ slug: "abc" }) };
+
+describe("POST /api/briefs/[slug]/messages/mark-read", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowed.mockResolvedValue(true);
+    mockMaybeSingle.mockResolvedValue({ data: BRIEF });
+    mockRequireAdvisorSession.mockResolvedValue(null);
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "u1", email: "owner@example.com" } },
+    });
+    mockMarkRead.mockResolvedValue(3);
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockIsAllowed.mockResolvedValueOnce(false);
+    const res = await POST(makeReq(), ctx);
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 404 when brief not found", async () => {
+    mockMaybeSingle.mockResolvedValueOnce({ data: null });
+    const res = await POST(makeReq(), ctx);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns {updated:0} when brief not yet accepted", async () => {
+    mockMaybeSingle.mockResolvedValueOnce({ data: { ...BRIEF, accepted_at: null } });
+    const res = await POST(makeReq(), ctx);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ updated: 0 });
+    expect(mockMarkRead).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when caller resolves to nobody", async () => {
+    mockGetUser.mockResolvedValueOnce({
+      data: { user: { id: "u1", email: "stranger@example.com" } },
+    });
+    const res = await POST(makeReq(), ctx);
+    expect(res.status).toBe(401);
+  });
+
+  it("marks read as the consumer on the happy path", async () => {
+    const res = await POST(makeReq(), ctx);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ updated: 3 });
+    expect(mockMarkRead).toHaveBeenCalledWith({ briefId: 42, asKind: "consumer" });
+  });
+
+  it("marks read as the pro when advisor is the accepted professional", async () => {
+    mockRequireAdvisorSession.mockResolvedValueOnce(7);
+    const res = await POST(makeReq(), ctx);
+    expect(res.status).toBe(200);
+    expect(mockMarkRead).toHaveBeenCalledWith({ briefId: 42, asKind: "pro" });
+  });
+
+  it("tolerates an empty/absent body", async () => {
+    const req = new NextRequest("http://localhost/api/briefs/abc/messages/mark-read", {
+      method: "POST",
+    });
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(200);
+  });
+
+  it("maps a BriefMessageError to its status", async () => {
+    mockMarkRead.mockRejectedValueOnce(new BriefMessageError("Nope", 403));
+    const res = await POST(makeReq(), ctx);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 500 on unexpected error", async () => {
+    mockMarkRead.mockRejectedValueOnce(new Error("boom"));
+    const res = await POST(makeReq(), ctx);
+    expect(res.status).toBe(500);
+  });
+});

--- a/__tests__/api/briefs-messages.test.ts
+++ b/__tests__/api/briefs-messages.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const {
+  mockIsAllowed,
+  mockIpKey,
+  mockGetUser,
+  mockRequireAdvisorSession,
+  mockSendMessage,
+  mockIsProfessionalOnTeam,
+  mockMaybeSingle,
+  BriefMessageError,
+} = vi.hoisted(() => {
+  class BriefMessageError extends Error {
+    constructor(message: string, public readonly status: number) {
+      super(message);
+      this.name = "BriefMessageError";
+    }
+  }
+  return {
+    mockIsAllowed: vi.fn(),
+    mockIpKey: vi.fn(() => "ip:1.2.3.4"),
+    mockGetUser: vi.fn(),
+    mockRequireAdvisorSession: vi.fn(),
+    mockSendMessage: vi.fn(),
+    mockIsProfessionalOnTeam: vi.fn(),
+    mockMaybeSingle: vi.fn(),
+    BriefMessageError,
+  };
+});
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => {
+    const chain: Record<string, unknown> = {};
+    chain.from = vi.fn(() => chain);
+    chain.select = vi.fn(() => chain);
+    chain.eq = vi.fn(() => chain);
+    chain.maybeSingle = mockMaybeSingle;
+    return chain;
+  }),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({ auth: { getUser: mockGetUser } })),
+}));
+
+vi.mock("@/lib/rate-limit-db", () => ({ isAllowed: mockIsAllowed, ipKey: mockIpKey }));
+
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: mockRequireAdvisorSession,
+}));
+
+vi.mock("@/lib/brief-messages", () => ({
+  sendMessage: mockSendMessage,
+  BriefMessageError,
+}));
+
+vi.mock("@/lib/expert-teams", () => ({
+  isProfessionalOnTeam: mockIsProfessionalOnTeam,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import { POST } from "@/app/api/briefs/[slug]/messages/route";
+
+const BRIEF = {
+  id: 42,
+  contact_email: "owner@example.com",
+  accepted_at: "2026-01-01",
+  accepted_by_professional_id: 7,
+  accepted_by_team_id: null,
+};
+
+function makeReq(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/briefs/abc/messages", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const ctx = { params: Promise.resolve({ slug: "abc" }) };
+
+describe("POST /api/briefs/[slug]/messages", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowed.mockResolvedValue(true);
+    mockMaybeSingle.mockResolvedValue({ data: BRIEF });
+    mockRequireAdvisorSession.mockResolvedValue(null);
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "u1", email: "owner@example.com" } },
+    });
+    mockSendMessage.mockResolvedValue({ id: 1, body: "hi" });
+  });
+
+  it("returns 429 when IP rate limited", async () => {
+    mockIsAllowed.mockResolvedValueOnce(false);
+    const res = await POST(makeReq({ body: "hi" }), ctx);
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 400 on invalid JSON body", async () => {
+    const req = new NextRequest("http://localhost/api/briefs/abc/messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not json",
+    });
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 on empty message body", async () => {
+    const res = await POST(makeReq({ body: "" }), ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when brief not found", async () => {
+    mockMaybeSingle.mockResolvedValueOnce({ data: null });
+    const res = await POST(makeReq({ body: "hi" }), ctx);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 409 when brief not yet accepted", async () => {
+    mockMaybeSingle.mockResolvedValueOnce({ data: { ...BRIEF, accepted_at: null } });
+    const res = await POST(makeReq({ body: "hi" }), ctx);
+    expect(res.status).toBe(409);
+  });
+
+  it("returns 401 when sender resolves to nobody", async () => {
+    mockGetUser.mockResolvedValueOnce({
+      data: { user: { id: "u1", email: "stranger@example.com" } },
+    });
+    const res = await POST(makeReq({ body: "hi" }), ctx);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 429 when the per-user throttle trips", async () => {
+    // First isAllowed (IP) true, second (per-user) false.
+    mockIsAllowed.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+    const res = await POST(makeReq({ body: "hi" }), ctx);
+    expect(res.status).toBe(429);
+  });
+
+  it("sends a message as the consumer on the happy path", async () => {
+    const res = await POST(makeReq({ body: "hi" }), ctx);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ message: { id: 1, body: "hi" } });
+    expect(mockSendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ senderKind: "consumer", briefId: 42 }),
+    );
+  });
+
+  it("sends as the accepted professional", async () => {
+    mockRequireAdvisorSession.mockResolvedValueOnce(7);
+    const res = await POST(makeReq({ body: "hi" }), ctx);
+    expect(res.status).toBe(200);
+    expect(mockSendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ senderKind: "professional", senderProfessionalId: 7 }),
+    );
+  });
+
+  it("maps a BriefMessageError to its status", async () => {
+    mockSendMessage.mockRejectedValueOnce(new BriefMessageError("Blocked", 403));
+    const res = await POST(makeReq({ body: "hi" }), ctx);
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "Blocked" });
+  });
+
+  it("returns 500 on unexpected error", async () => {
+    mockSendMessage.mockRejectedValueOnce(new Error("boom"));
+    const res = await POST(makeReq({ body: "hi" }), ctx);
+    expect(res.status).toBe(500);
+  });
+});

--- a/__tests__/api/briefs-payment.test.ts
+++ b/__tests__/api/briefs-payment.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const {
+  mockIsAllowed,
+  mockIpKey,
+  mockGetUser,
+  mockCreatePaymentForBrief,
+  mockMaybeSingle,
+} = vi.hoisted(() => ({
+  mockIsAllowed: vi.fn(),
+  mockIpKey: vi.fn(() => "ip:1.2.3.4"),
+  mockGetUser: vi.fn(),
+  mockCreatePaymentForBrief: vi.fn(),
+  mockMaybeSingle: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => {
+    const chain: Record<string, unknown> = {};
+    chain.from = vi.fn(() => chain);
+    chain.select = vi.fn(() => chain);
+    chain.eq = vi.fn(() => chain);
+    chain.maybeSingle = mockMaybeSingle;
+    return chain;
+  }),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({ auth: { getUser: mockGetUser } })),
+}));
+
+vi.mock("@/lib/rate-limit-db", () => ({ isAllowed: mockIsAllowed, ipKey: mockIpKey }));
+
+vi.mock("@/lib/stripe-connect", () => ({
+  createPaymentForBrief: mockCreatePaymentForBrief,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import { POST } from "@/app/api/briefs/[slug]/payment/route";
+
+const BRIEF = {
+  id: 42,
+  contact_email: "owner@example.com",
+  accepted_by_professional_id: 7,
+  accepted_at: "2026-01-01",
+  status: "accepted",
+};
+
+const VALID = { amount_cents: 50000, description: "Initial advice fee" };
+
+function makeReq(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/briefs/abc/payment", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const ctx = { params: Promise.resolve({ slug: "abc" }) };
+
+describe("POST /api/briefs/[slug]/payment", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowed.mockResolvedValue(true);
+    mockMaybeSingle.mockResolvedValue({ data: BRIEF });
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "u1", email: "owner@example.com" } },
+    });
+    mockCreatePaymentForBrief.mockResolvedValue({
+      clientSecret: "cs_123",
+      paymentId: "pay_1",
+      paymentIntentId: "pi_1",
+    });
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockIsAllowed.mockResolvedValueOnce(false);
+    const res = await POST(makeReq(VALID), ctx);
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 400 on invalid JSON body", async () => {
+    const req = new NextRequest("http://localhost/api/briefs/abc/payment", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not json",
+    });
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 on schema validation failure", async () => {
+    const res = await POST(makeReq({ amount_cents: 1, description: "x" }), ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: null } });
+    const res = await POST(makeReq(VALID), ctx);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when brief not found", async () => {
+    mockMaybeSingle.mockResolvedValueOnce({ data: null });
+    const res = await POST(makeReq(VALID), ctx);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when caller is not the brief owner", async () => {
+    mockGetUser.mockResolvedValueOnce({
+      data: { user: { id: "u1", email: "other@example.com" } },
+    });
+    const res = await POST(makeReq(VALID), ctx);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 409 when brief not yet accepted", async () => {
+    mockMaybeSingle.mockResolvedValueOnce({
+      data: { ...BRIEF, accepted_by_professional_id: null, accepted_at: null },
+    });
+    const res = await POST(makeReq(VALID), ctx);
+    expect(res.status).toBe(409);
+  });
+
+  it("returns 503 when Stripe not configured", async () => {
+    mockCreatePaymentForBrief.mockResolvedValueOnce({ unavailable: "no_secret" });
+    const res = await POST(makeReq(VALID), ctx);
+    expect(res.status).toBe(503);
+  });
+
+  it("returns 409 when the pro has not connected", async () => {
+    mockCreatePaymentForBrief.mockResolvedValueOnce({ unavailable: "pro_not_connected" });
+    const res = await POST(makeReq(VALID), ctx);
+    expect(res.status).toBe(409);
+  });
+
+  it("returns 502 when payment creation fails without a client secret", async () => {
+    mockCreatePaymentForBrief.mockResolvedValueOnce({ clientSecret: null, detail: "card error" });
+    const res = await POST(makeReq(VALID), ctx);
+    expect(res.status).toBe(502);
+    expect(await res.json()).toEqual({ error: "card error" });
+  });
+
+  it("returns the client secret on the happy path", async () => {
+    const res = await POST(makeReq(VALID), ctx);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      client_secret: "cs_123",
+      payment_id: "pay_1",
+      payment_intent_id: "pi_1",
+    });
+    expect(mockCreatePaymentForBrief).toHaveBeenCalledWith(
+      expect.objectContaining({ briefId: 42, professionalId: 7, consumerUserId: "u1" }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Unit tests for 7 untested `briefs/[slug]` action routes (accept, book-slot, disputes, intake-answers, messages, messages/mark-read, payment). 73 tests: rate-limit, auth/ownership, zod, happy, not-found, helper-error mapping (incl. ConsultationError/DisputeError/IntakeError/BriefMessageError), payment 503/502/409 branches.

## Queue item
D-COV pre-launch coverage push. Moves M02 (57→200).

## Supersedes
_None._

## Test plan
- [x] vitest 73/73 local
- [ ] CI green