### PR TITLE
test(d): add unit tests for quotes/[slug] + get-matched/plans routes

### DIFF
--- a/__tests__/api/get-matched-plans-checklist.test.ts
+++ b/__tests__/api/get-matched-plans-checklist.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockIsAllowed, mockGetPlanById, mockToggleChecklistItem, mockUpdatePlan } = vi.hoisted(() => ({
+  mockIsAllowed: vi.fn(),
+  mockGetPlanById: vi.fn(),
+  mockToggleChecklistItem: vi.fn(),
+  mockUpdatePlan: vi.fn(),
+}));
+
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: mockIsAllowed,
+  ipKey: vi.fn(() => "ip:1.2.3.4"),
+}));
+
+vi.mock("@/lib/getmatched/action-plans", () => ({
+  getPlanById: mockGetPlanById,
+  toggleChecklistItem: mockToggleChecklistItem,
+  updatePlan: mockUpdatePlan,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import { POST } from "@/app/api/get-matched/plans/[id]/checklist/route";
+
+function makeReq(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/get-matched/plans/5/checklist", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function ctx(id = "5") {
+  return { params: Promise.resolve({ id }) };
+}
+
+describe("POST /api/get-matched/plans/[id]/checklist", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowed.mockResolvedValue(true);
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    mockIsAllowed.mockResolvedValueOnce(false);
+    const res = await POST(makeReq({ index: 0 }), ctx());
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 400 for a non-numeric plan id", async () => {
+    const res = await POST(makeReq({ index: 0 }), ctx("abc"));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid plan id." });
+  });
+
+  it("returns 400 on invalid JSON body", async () => {
+    const req = new NextRequest("http://localhost/api/get-matched/plans/5/checklist", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{bad",
+    });
+    const res = await POST(req, ctx());
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when zod fails (negative index)", async () => {
+    const res = await POST(makeReq({ index: -1 }), ctx());
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when the plan is not found", async () => {
+    mockGetPlanById.mockResolvedValueOnce(null);
+    const res = await POST(makeReq({ index: 0 }), ctx());
+    expect(res.status).toBe(404);
+  });
+
+  it("toggles the checklist item and returns the updated checklist", async () => {
+    mockGetPlanById.mockResolvedValueOnce({ id: 5, checklist: [{ label: "a", done: false }] });
+    const next = [{ label: "a", done: true }];
+    mockToggleChecklistItem.mockReturnValueOnce(next);
+    mockUpdatePlan.mockResolvedValueOnce({ id: 5, checklist: next });
+    const res = await POST(makeReq({ index: 0 }), ctx());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ checklist: next });
+    expect(mockUpdatePlan).toHaveBeenCalledWith({ id: 5, checklist: next });
+  });
+
+  it("returns 500 when updatePlan throws", async () => {
+    mockGetPlanById.mockResolvedValueOnce({ id: 5, checklist: [] });
+    mockToggleChecklistItem.mockReturnValueOnce([]);
+    mockUpdatePlan.mockRejectedValueOnce(new Error("boom"));
+    const res = await POST(makeReq({ index: 0 }), ctx());
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: "Failed to update checklist." });
+  });
+});

--- a/__tests__/api/get-matched-plans-claim.test.ts
+++ b/__tests__/api/get-matched-plans-claim.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockIsAllowed, mockGetUser, mockClaimPlanForUser, mockLogEvent } = vi.hoisted(() => ({
+  mockIsAllowed: vi.fn(),
+  mockGetUser: vi.fn(),
+  mockClaimPlanForUser: vi.fn(),
+  mockLogEvent: vi.fn(),
+}));
+
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: mockIsAllowed,
+  ipKey: vi.fn(() => "ip:1.2.3.4"),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({ auth: { getUser: mockGetUser } })),
+}));
+
+vi.mock("@/lib/getmatched/action-plans", () => ({
+  claimPlanForUser: mockClaimPlanForUser,
+}));
+
+vi.mock("@/lib/getmatched/events", () => ({
+  logEvent: mockLogEvent,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import { POST } from "@/app/api/get-matched/plans/[id]/claim/route";
+
+const USER = { id: "user-uuid-1", email: "alice@example.com" };
+
+function makeReq(): NextRequest {
+  return new NextRequest("http://localhost/api/get-matched/plans/5/claim", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function ctx(id = "5") {
+  return { params: Promise.resolve({ id }) };
+}
+
+describe("POST /api/get-matched/plans/[id]/claim", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowed.mockResolvedValue(true);
+    mockGetUser.mockResolvedValue({ data: { user: USER } });
+    mockLogEvent.mockResolvedValue(undefined);
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    mockIsAllowed.mockResolvedValueOnce(false);
+    const res = await POST(makeReq(), ctx());
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: null } });
+    const res = await POST(makeReq(), ctx());
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "Sign in required." });
+  });
+
+  it("returns 400 for a non-numeric plan id", async () => {
+    const res = await POST(makeReq(), ctx("abc"));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid plan id." });
+  });
+
+  it("claims the plan, logs an event, and returns it", async () => {
+    const plan = { id: 5, session_id: "sess-1", auth_user_id: USER.id, status: "claimed" };
+    mockClaimPlanForUser.mockResolvedValueOnce(plan);
+    const res = await POST(makeReq(), ctx());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true, plan });
+    expect(mockClaimPlanForUser).toHaveBeenCalledWith({
+      planId: 5,
+      authUserId: USER.id,
+      email: USER.email,
+    });
+    expect(mockLogEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ eventType: "account_created", sessionId: "sess-1" }),
+    );
+  });
+
+  it("returns 500 when claimPlanForUser throws", async () => {
+    mockClaimPlanForUser.mockRejectedValueOnce(new Error("boom"));
+    const res = await POST(makeReq(), ctx());
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: "Failed to claim plan." });
+  });
+});

--- a/__tests__/api/get-matched-plans-save.test.ts
+++ b/__tests__/api/get-matched-plans-save.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockIsAllowed, mockGetPlanById, mockUpdatePlan, mockLogEvent } = vi.hoisted(() => ({
+  mockIsAllowed: vi.fn(),
+  mockGetPlanById: vi.fn(),
+  mockUpdatePlan: vi.fn(),
+  mockLogEvent: vi.fn(),
+}));
+
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: mockIsAllowed,
+  ipKey: vi.fn(() => "ip:1.2.3.4"),
+}));
+
+vi.mock("@/lib/getmatched/action-plans", () => ({
+  getPlanById: mockGetPlanById,
+  updatePlan: mockUpdatePlan,
+}));
+
+vi.mock("@/lib/getmatched/events", () => ({
+  logEvent: mockLogEvent,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import { POST } from "@/app/api/get-matched/plans/[id]/save/route";
+
+function makeReq(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/get-matched/plans/5/save", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function ctx(id = "5") {
+  return { params: Promise.resolve({ id }) };
+}
+
+const VALID = { email: "alice@example.com" };
+
+describe("POST /api/get-matched/plans/[id]/save", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowed.mockResolvedValue(true);
+    mockLogEvent.mockResolvedValue(undefined);
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    mockIsAllowed.mockResolvedValueOnce(false);
+    const res = await POST(makeReq(VALID), ctx());
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 400 for a non-numeric plan id", async () => {
+    const res = await POST(makeReq(VALID), ctx("abc"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 on invalid JSON body", async () => {
+    const req = new NextRequest("http://localhost/api/get-matched/plans/5/save", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{bad",
+    });
+    const res = await POST(req, ctx());
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when zod fails (invalid email)", async () => {
+    const res = await POST(makeReq({ email: "nope" }), ctx());
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when plan not found", async () => {
+    mockGetPlanById.mockResolvedValueOnce(null);
+    const res = await POST(makeReq(VALID), ctx());
+    expect(res.status).toBe(404);
+  });
+
+  it("saves the plan and returns share token + view url", async () => {
+    mockGetPlanById.mockResolvedValueOnce({ id: 5, session_id: "sess-1", auth_user_id: null, status: "new" });
+    mockUpdatePlan.mockResolvedValueOnce({ id: 5, share_token: "tok-abc" });
+    const res = await POST(makeReq(VALID), ctx());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      success: true,
+      share_token: "tok-abc",
+      view_url: "/plans/tok-abc",
+    });
+    expect(mockUpdatePlan).toHaveBeenCalledWith({
+      id: 5,
+      email: "alice@example.com",
+      status: "saved",
+    });
+    expect(mockLogEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ eventType: "plan_saved" }),
+    );
+  });
+
+  it("preserves a converted status instead of overwriting to saved", async () => {
+    mockGetPlanById.mockResolvedValueOnce({ id: 5, session_id: "sess-1", auth_user_id: null, status: "converted" });
+    mockUpdatePlan.mockResolvedValueOnce({ id: 5, share_token: "tok-x" });
+    const res = await POST(makeReq(VALID), ctx());
+    expect(res.status).toBe(200);
+    expect(mockUpdatePlan).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "converted" }),
+    );
+  });
+
+  it("returns 500 when updatePlan throws", async () => {
+    mockGetPlanById.mockResolvedValueOnce({ id: 5, session_id: "s", auth_user_id: null, status: "new" });
+    mockUpdatePlan.mockRejectedValueOnce(new Error("boom"));
+    const res = await POST(makeReq(VALID), ctx());
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: "Failed to save plan." });
+  });
+});

--- a/__tests__/api/get-matched-plans-to-brief.test.ts
+++ b/__tests__/api/get-matched-plans-to-brief.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const {
+  mockIsAllowed,
+  mockFrom,
+  mockIsValidEmail,
+  mockIsDisposableEmail,
+  mockGetPlanById,
+  mockLinkBriefToPlan,
+  mockUpdatePlan,
+  mockGetEnabledIntents,
+  mockResolveActionPlan,
+  mockScanBrief,
+  mockGetAcceptCost,
+  mockLogEvent,
+} = vi.hoisted(() => ({
+  mockIsAllowed: vi.fn(),
+  mockFrom: vi.fn(),
+  mockIsValidEmail: vi.fn(),
+  mockIsDisposableEmail: vi.fn(),
+  mockGetPlanById: vi.fn(),
+  mockLinkBriefToPlan: vi.fn(),
+  mockUpdatePlan: vi.fn(),
+  mockGetEnabledIntents: vi.fn(),
+  mockResolveActionPlan: vi.fn(),
+  mockScanBrief: vi.fn(),
+  mockGetAcceptCost: vi.fn(),
+  mockLogEvent: vi.fn(),
+}));
+
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: mockIsAllowed,
+  ipKey: vi.fn(() => "ip:1.2.3.4"),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+vi.mock("@/lib/validate-email", () => ({
+  isValidEmail: mockIsValidEmail,
+  isDisposableEmail: mockIsDisposableEmail,
+}));
+
+vi.mock("@/lib/getmatched/action-plans", () => ({
+  getPlanById: mockGetPlanById,
+  linkBriefToPlan: mockLinkBriefToPlan,
+  updatePlan: mockUpdatePlan,
+}));
+
+vi.mock("@/lib/getmatched/intents", () => ({
+  getEnabledIntents: mockGetEnabledIntents,
+}));
+
+vi.mock("@/lib/getmatched/engine", () => ({
+  resolveActionPlan: mockResolveActionPlan,
+}));
+
+vi.mock("@/lib/briefs/risk-flags", () => ({
+  scanBrief: mockScanBrief,
+}));
+
+vi.mock("@/lib/briefs/credits", () => ({
+  getAcceptCost: mockGetAcceptCost,
+}));
+
+vi.mock("@/lib/getmatched/events", () => ({
+  logEvent: mockLogEvent,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import { POST } from "@/app/api/get-matched/plans/[id]/to-brief/route";
+
+function makeReq(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/get-matched/plans/5/to-brief", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function ctx(id = "5") {
+  return { params: Promise.resolve({ id }) };
+}
+
+const VALID = {
+  contact_name: "Alice Investor",
+  contact_email: "alice@example.com",
+  routing_mode: "smart_match",
+  consent_share: true,
+};
+
+const PLAN = {
+  id: 5,
+  session_id: "sess-1",
+  auth_user_id: null,
+  goal: "Buy a property",
+  answers: { intent: "smsf_property", notes: "hi" },
+  intent_slug: "smsf_property",
+  budget_band: "10k_25k",
+  location_state: "NSW",
+};
+
+const RESOLVED = {
+  route: "individual",
+  recommendedBriefTemplate: "smsf_property",
+  template: { headline: "SMSF property brief" },
+};
+
+// .from("advisor_auctions").insert().select().single()
+function insertBriefChain(result: { data: unknown; error: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  chain.insert = vi.fn(() => chain);
+  chain.select = vi.fn(() => chain);
+  chain.single = vi.fn(() => Promise.resolve(result));
+  return chain;
+}
+
+// .from("brief_tracker_events").insert() — terminal resolves
+function trackerInsertChain() {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  chain.insert = vi.fn(() => Promise.resolve({ error: null }));
+  return chain;
+}
+
+describe("POST /api/get-matched/plans/[id]/to-brief", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowed.mockResolvedValue(true);
+    mockIsValidEmail.mockReturnValue(true);
+    mockIsDisposableEmail.mockReturnValue(false);
+    mockGetPlanById.mockResolvedValue(PLAN);
+    mockGetEnabledIntents.mockResolvedValue([
+      { slug: "smsf_property", default_brief_template: "smsf_property" },
+    ]);
+    mockResolveActionPlan.mockResolvedValue(RESOLVED);
+    mockScanBrief.mockResolvedValue({ severity: "none", flags: [], reviewStatus: "clear" });
+    mockGetAcceptCost.mockResolvedValue(3);
+    mockLinkBriefToPlan.mockResolvedValue(undefined);
+    mockUpdatePlan.mockResolvedValue(undefined);
+    mockLogEvent.mockResolvedValue(undefined);
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    mockIsAllowed.mockResolvedValueOnce(false);
+    const res = await POST(makeReq(VALID), ctx());
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 400 for a non-numeric plan id", async () => {
+    const res = await POST(makeReq(VALID), ctx("abc"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 on invalid JSON body", async () => {
+    const req = new NextRequest("http://localhost/api/get-matched/plans/5/to-brief", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{bad",
+    });
+    const res = await POST(req, ctx());
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when zod fails (missing consent)", async () => {
+    const res = await POST(makeReq({ ...VALID, consent_share: false }), ctx());
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for an invalid/disposable email", async () => {
+    mockIsDisposableEmail.mockReturnValueOnce(true);
+    const res = await POST(makeReq(VALID), ctx());
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Please use a real email address." });
+  });
+
+  it("returns 404 when the plan is not found", async () => {
+    mockGetPlanById.mockResolvedValueOnce(null);
+    const res = await POST(makeReq(VALID), ctx());
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 when risk scan blocks the brief", async () => {
+    mockScanBrief.mockResolvedValueOnce({ severity: "block", flags: ["weapons"], reviewStatus: "blocked" });
+    const res = await POST(makeReq(VALID), ctx());
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toContain("can't accept briefs");
+  });
+
+  it("creates the brief and returns success", async () => {
+    mockFrom
+      .mockReturnValueOnce(insertBriefChain({ data: { id: 77, slug: "buy-a-property-xyz" }, error: null }))
+      .mockReturnValueOnce(trackerInsertChain());
+    const res = await POST(makeReq(VALID), ctx());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      success: true,
+      brief_id: 77,
+      brief_slug: "buy-a-property-xyz",
+      risk_review_status: "clear",
+    });
+    expect(mockLinkBriefToPlan).toHaveBeenCalledWith(5, 77);
+    expect(mockLogEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ eventType: "brief_submitted" }),
+    );
+  });
+
+  it("logs a second tracker event when there are risk flags", async () => {
+    mockScanBrief.mockResolvedValueOnce({ severity: "warn", flags: ["leverage"], reviewStatus: "review" });
+    const briefChain = insertBriefChain({ data: { id: 78, slug: "s" }, error: null });
+    const tracker1 = trackerInsertChain();
+    const tracker2 = trackerInsertChain();
+    mockFrom
+      .mockReturnValueOnce(briefChain)
+      .mockReturnValueOnce(tracker1)
+      .mockReturnValueOnce(tracker2);
+    const res = await POST(makeReq(VALID), ctx());
+    expect(res.status).toBe(200);
+    // created + risk_flagged tracker inserts => brief_tracker_events used twice
+    expect(tracker1.insert).toHaveBeenCalled();
+    expect(tracker2.insert).toHaveBeenCalled();
+  });
+
+  it("returns 500 when the brief insert errors", async () => {
+    mockFrom.mockReturnValueOnce(insertBriefChain({ data: null, error: { message: "boom" } }));
+    const res = await POST(makeReq(VALID), ctx());
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: "Failed to create brief." });
+  });
+
+  it("returns 500 on unexpected error", async () => {
+    mockResolveActionPlan.mockRejectedValueOnce(new Error("engine down"));
+    const res = await POST(makeReq(VALID), ctx());
+    expect(res.status).toBe(500);
+  });
+});

--- a/__tests__/api/quotes-accept.test.ts
+++ b/__tests__/api/quotes-accept.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockFrom, mockIsRateLimited, mockSendAccepted } = vi.hoisted(() => ({
+  mockFrom: vi.fn(),
+  mockIsRateLimited: vi.fn(),
+  mockSendAccepted: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  isRateLimited: mockIsRateLimited,
+}));
+
+vi.mock("@/lib/quote-emails", () => ({
+  sendAdvisorBidAcceptedEmail: mockSendAccepted,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import { POST } from "@/app/api/quotes/[slug]/accept/route";
+
+const SLUG = "find-an-adviser-abc";
+
+function makeReq(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/quotes/" + SLUG + "/accept", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "x-forwarded-for": "1.2.3.4" },
+    body: JSON.stringify(body),
+  });
+}
+
+function ctx() {
+  return { params: Promise.resolve({ slug: SLUG }) };
+}
+
+const VALID = { bid_id: 5, contact_email: "owner@example.com" };
+
+const AUCTION = {
+  id: 11,
+  contact_email: "owner@example.com",
+  contact_name: "Owner",
+  status: "open",
+  slug: SLUG,
+};
+
+const BID = { id: 5, advisor_id: 9, bid_amount: 100, auction_id: 11, status: "active" };
+
+// .from("advisor_auctions").select().eq().eq().eq().maybeSingle()
+function auctionSelectChain(result: { data: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  chain.select = vi.fn(() => chain);
+  chain.eq = vi.fn(() => chain);
+  chain.maybeSingle = vi.fn(() => Promise.resolve(result));
+  return chain;
+}
+
+// .from("advisor_auction_bids").select().eq().eq().maybeSingle()
+function bidSelectChain(result: { data: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  chain.select = vi.fn(() => chain);
+  chain.eq = vi.fn(() => chain);
+  chain.maybeSingle = vi.fn(() => Promise.resolve(result));
+  return chain;
+}
+
+// .update().eq() — terminal eq resolves
+function winnerUpdateChain(result: { error: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  chain.update = vi.fn(() => chain);
+  chain.eq = vi.fn(() => Promise.resolve(result));
+  return chain;
+}
+
+// .update().eq().eq().neq() — generic resolving chain
+function multiUpdateChain() {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  chain.update = vi.fn(() => chain);
+  chain.eq = vi.fn(() => chain);
+  chain.neq = vi.fn(() => Promise.resolve({ error: null }));
+  return chain;
+}
+
+function awardUpdateChain() {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  chain.update = vi.fn(() => chain);
+  chain.eq = vi.fn(() => Promise.resolve({ error: null }));
+  return chain;
+}
+
+function advisorSelectChain(result: { data: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  chain.select = vi.fn(() => chain);
+  chain.eq = vi.fn(() => chain);
+  chain.maybeSingle = vi.fn(() => Promise.resolve(result));
+  return chain;
+}
+
+describe("POST /api/quotes/[slug]/accept", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsRateLimited.mockResolvedValue(false);
+    mockSendAccepted.mockResolvedValue(undefined);
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    mockIsRateLimited.mockResolvedValueOnce(true);
+    const res = await POST(makeReq(VALID), ctx());
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 400 on invalid JSON body", async () => {
+    const req = new NextRequest("http://localhost/api/quotes/" + SLUG + "/accept", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{not json",
+    });
+    const res = await POST(req, ctx());
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when zod validation fails", async () => {
+    const res = await POST(makeReq({ bid_id: -1, contact_email: "x" }), ctx());
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when the job is not found", async () => {
+    mockFrom.mockReturnValueOnce(auctionSelectChain({ data: null }));
+    const res = await POST(makeReq(VALID), ctx());
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when contact email does not match", async () => {
+    mockFrom.mockReturnValueOnce(auctionSelectChain({ data: AUCTION }));
+    const res = await POST(makeReq({ ...VALID, contact_email: "other@example.com" }), ctx());
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 when the job is no longer open", async () => {
+    mockFrom.mockReturnValueOnce(auctionSelectChain({ data: { ...AUCTION, status: "awarded" } }));
+    const res = await POST(makeReq(VALID), ctx());
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "This job is no longer open." });
+  });
+
+  it("returns 404 when the bid is not found", async () => {
+    mockFrom
+      .mockReturnValueOnce(auctionSelectChain({ data: AUCTION }))
+      .mockReturnValueOnce(bidSelectChain({ data: null }));
+    const res = await POST(makeReq(VALID), ctx());
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "Bid not found." });
+  });
+
+  it("returns 500 when marking the winner fails", async () => {
+    mockFrom
+      .mockReturnValueOnce(auctionSelectChain({ data: AUCTION }))
+      .mockReturnValueOnce(bidSelectChain({ data: BID }))
+      .mockReturnValueOnce(winnerUpdateChain({ error: { message: "boom" } }));
+    const res = await POST(makeReq(VALID), ctx());
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: "Failed to accept bid." });
+  });
+
+  it("awards the bid, emails the advisor, and returns success", async () => {
+    mockFrom
+      .mockReturnValueOnce(auctionSelectChain({ data: AUCTION }))
+      .mockReturnValueOnce(bidSelectChain({ data: BID }))
+      .mockReturnValueOnce(winnerUpdateChain({ error: null }))
+      .mockReturnValueOnce(multiUpdateChain())
+      .mockReturnValueOnce(awardUpdateChain())
+      .mockReturnValueOnce(advisorSelectChain({ data: { name: "Jane Doe", email: "jane@adv.com", type: "financial_adviser" } }));
+    const res = await POST(makeReq(VALID), ctx());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true, winning_bid_id: 5 });
+    expect(mockSendAccepted).toHaveBeenCalledOnce();
+  });
+
+  it("succeeds without sending email when advisor has no email", async () => {
+    mockFrom
+      .mockReturnValueOnce(auctionSelectChain({ data: AUCTION }))
+      .mockReturnValueOnce(bidSelectChain({ data: BID }))
+      .mockReturnValueOnce(winnerUpdateChain({ error: null }))
+      .mockReturnValueOnce(multiUpdateChain())
+      .mockReturnValueOnce(awardUpdateChain())
+      .mockReturnValueOnce(advisorSelectChain({ data: null }));
+    const res = await POST(makeReq(VALID), ctx());
+    expect(res.status).toBe(200);
+    expect(mockSendAccepted).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 when an unexpected error is thrown", async () => {
+    mockFrom.mockImplementationOnce(() => {
+      throw new Error("db down");
+    });
+    const res = await POST(makeReq(VALID), ctx());
+    expect(res.status).toBe(500);
+  });
+});

--- a/__tests__/api/quotes-qa.test.ts
+++ b/__tests__/api/quotes-qa.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockFrom, mockGetUser, mockIsRateLimited } = vi.hoisted(() => ({
+  mockFrom: vi.fn(),
+  mockGetUser: vi.fn(),
+  mockIsRateLimited: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({ auth: { getUser: mockGetUser } })),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  isRateLimited: mockIsRateLimited,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import { GET, POST } from "@/app/api/quotes/[slug]/qa/route";
+
+const SLUG = "find-an-adviser-abc";
+
+function makeReq(body?: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/quotes/" + SLUG + "/qa", {
+    method: body === undefined ? "GET" : "POST",
+    headers: { "Content-Type": "application/json", "x-forwarded-for": "1.2.3.4" },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+function ctx() {
+  return { params: Promise.resolve({ slug: SLUG }) };
+}
+
+// .from("advisor_auctions").select().eq().eq().eq().maybeSingle()
+function auctionChain(result: { data: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  chain.select = vi.fn(() => chain);
+  chain.eq = vi.fn(() => chain);
+  chain.maybeSingle = vi.fn(() => Promise.resolve(result));
+  return chain;
+}
+
+// GET qa: .select().eq().eq().order() — terminal order resolves
+function qaSelectChain(result: { data: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  chain.select = vi.fn(() => chain);
+  chain.eq = vi.fn(() => chain);
+  chain.order = vi.fn(() => Promise.resolve(result));
+  return chain;
+}
+
+// advisor lookup: .select().eq().eq().maybeSingle()
+function proChain(result: { data: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  chain.select = vi.fn(() => chain);
+  chain.eq = vi.fn(() => chain);
+  chain.maybeSingle = vi.fn(() => Promise.resolve(result));
+  return chain;
+}
+
+// insert: .insert().select().single()
+function insertChain(result: { data: unknown; error: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  chain.insert = vi.fn(() => chain);
+  chain.select = vi.fn(() => chain);
+  chain.single = vi.fn(() => Promise.resolve(result));
+  return chain;
+}
+
+const AUCTION = { id: 11, contact_email: "owner@example.com", contact_name: "Owner" };
+
+describe("GET /api/quotes/[slug]/qa", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsRateLimited.mockResolvedValue(false);
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    mockIsRateLimited.mockResolvedValueOnce(true);
+    const res = await GET(makeReq(), ctx());
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 404 when job not found", async () => {
+    mockFrom.mockReturnValueOnce(auctionChain({ data: null }));
+    const res = await GET(makeReq(), ctx());
+    expect(res.status).toBe(404);
+  });
+
+  it("returns the Q&A list", async () => {
+    const rows = [{ id: 1, body: "hi", is_question: true }];
+    mockFrom
+      .mockReturnValueOnce(auctionChain({ data: { id: 11 } }))
+      .mockReturnValueOnce(qaSelectChain({ data: rows }));
+    const res = await GET(makeReq(), ctx());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ qa: rows });
+  });
+
+  it("returns empty array when qa data is null", async () => {
+    mockFrom
+      .mockReturnValueOnce(auctionChain({ data: { id: 11 } }))
+      .mockReturnValueOnce(qaSelectChain({ data: null }));
+    const res = await GET(makeReq(), ctx());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ qa: [] });
+  });
+
+  it("returns 500 on unexpected error", async () => {
+    mockFrom.mockImplementationOnce(() => {
+      throw new Error("boom");
+    });
+    const res = await GET(makeReq(), ctx());
+    expect(res.status).toBe(500);
+  });
+});
+
+describe("POST /api/quotes/[slug]/qa", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsRateLimited.mockResolvedValue(false);
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    mockIsRateLimited.mockResolvedValueOnce(true);
+    const res = await POST(makeReq({ body: "hello there" }), ctx());
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 400 on invalid JSON body", async () => {
+    const req = new NextRequest("http://localhost/api/quotes/" + SLUG + "/qa", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{bad",
+    });
+    const res = await POST(req, ctx());
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when zod fails (body too short)", async () => {
+    const res = await POST(makeReq({ body: "ab" }), ctx());
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when job not found", async () => {
+    mockFrom.mockReturnValueOnce(auctionChain({ data: null }));
+    const res = await POST(makeReq({ body: "hello there" }), ctx());
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 401 when neither advisor nor owner auth matches", async () => {
+    mockFrom.mockReturnValueOnce(auctionChain({ data: AUCTION }));
+    const res = await POST(makeReq({ body: "hello there", contact_email: "wrong@example.com" }), ctx());
+    expect(res.status).toBe(401);
+  });
+
+  it("posts as the job owner when contact_email matches", async () => {
+    const chain = insertChain({ data: { id: 99 }, error: null });
+    mockFrom
+      .mockReturnValueOnce(auctionChain({ data: AUCTION }))
+      .mockReturnValueOnce(chain);
+    const res = await POST(makeReq({ body: "owner question", contact_email: "owner@example.com" }), ctx());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true, id: 99 });
+    const insertArg = chain.insert.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(insertArg.advisor_id).toBeNull();
+    expect(insertArg.author_email).toBe("owner@example.com");
+  });
+
+  it("posts as an authenticated advisor", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: { email: "jane@adv.com" } } });
+    const chain = insertChain({ data: { id: 100 }, error: null });
+    mockFrom
+      .mockReturnValueOnce(auctionChain({ data: AUCTION }))
+      .mockReturnValueOnce(proChain({ data: { id: 7, name: "Jane Adviser" } }))
+      .mockReturnValueOnce(chain);
+    const res = await POST(makeReq({ body: "advisor answer" }), ctx());
+    expect(res.status).toBe(200);
+    const insertArg = chain.insert.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(insertArg.advisor_id).toBe(7);
+  });
+
+  it("returns 500 when the insert errors", async () => {
+    mockFrom
+      .mockReturnValueOnce(auctionChain({ data: AUCTION }))
+      .mockReturnValueOnce(insertChain({ data: null, error: { message: "boom" } }));
+    const res = await POST(makeReq({ body: "owner question", contact_email: "owner@example.com" }), ctx());
+    expect(res.status).toBe(500);
+  });
+});

--- a/__tests__/api/quotes-reopen.test.ts
+++ b/__tests__/api/quotes-reopen.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockFrom, mockIsRateLimited } = vi.hoisted(() => ({
+  mockFrom: vi.fn(),
+  mockIsRateLimited: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  isRateLimited: mockIsRateLimited,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import { POST } from "@/app/api/quotes/[slug]/reopen/route";
+
+const SLUG = "find-an-adviser-abc";
+
+function makeReq(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/quotes/" + SLUG + "/reopen", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "x-forwarded-for": "1.2.3.4" },
+    body: JSON.stringify(body),
+  });
+}
+
+function ctx() {
+  return { params: Promise.resolve({ slug: SLUG }) };
+}
+
+const VALID = { contact_email: "owner@example.com" };
+
+const AUCTION = {
+  id: 11,
+  slug: SLUG,
+  status: "expired",
+  contact_email: "owner@example.com",
+  ends_at: "2026-01-01T00:00:00.000Z",
+  reopened_count: 0,
+  winning_bid_id: null,
+};
+
+function auctionChain(result: { data: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  chain.select = vi.fn(() => chain);
+  chain.eq = vi.fn(() => chain);
+  chain.maybeSingle = vi.fn(() => Promise.resolve(result));
+  return chain;
+}
+
+function updateChain(result: { error: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  chain.update = vi.fn(() => chain);
+  chain.eq = vi.fn(() => Promise.resolve(result));
+  return chain;
+}
+
+describe("POST /api/quotes/[slug]/reopen", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsRateLimited.mockResolvedValue(false);
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    mockIsRateLimited.mockResolvedValueOnce(true);
+    const res = await POST(makeReq(VALID), ctx());
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 400 on invalid JSON body", async () => {
+    const req = new NextRequest("http://localhost/api/quotes/" + SLUG + "/reopen", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{bad",
+    });
+    const res = await POST(req, ctx());
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when zod fails (invalid email)", async () => {
+    const res = await POST(makeReq({ contact_email: "nope" }), ctx());
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when job not found", async () => {
+    mockFrom.mockReturnValueOnce(auctionChain({ data: null }));
+    const res = await POST(makeReq(VALID), ctx());
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when email does not match", async () => {
+    mockFrom.mockReturnValueOnce(auctionChain({ data: AUCTION }));
+    const res = await POST(makeReq({ contact_email: "other@example.com" }), ctx());
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 when the job has an accepted quote", async () => {
+    mockFrom.mockReturnValueOnce(auctionChain({ data: { ...AUCTION, winning_bid_id: 3 } }));
+    const res = await POST(makeReq(VALID), ctx());
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Cannot re-open a job with an accepted quote." });
+  });
+
+  it("returns 400 when the re-open limit is reached", async () => {
+    mockFrom.mockReturnValueOnce(auctionChain({ data: { ...AUCTION, reopened_count: 2 } }));
+    const res = await POST(makeReq(VALID), ctx());
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toContain("re-open limit");
+  });
+
+  it("reopens the job and returns the new end date", async () => {
+    const chain = updateChain({ error: null });
+    mockFrom
+      .mockReturnValueOnce(auctionChain({ data: AUCTION }))
+      .mockReturnValueOnce(chain);
+    const res = await POST(makeReq(VALID), ctx());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.success).toBe(true);
+    expect(json.reopened_count).toBe(1);
+    expect(typeof json.ends_at).toBe("string");
+    const updateArg = chain.update.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(updateArg.status).toBe("open");
+    expect(updateArg.reopened_count).toBe(1);
+  });
+
+  it("returns 500 when the update errors", async () => {
+    mockFrom
+      .mockReturnValueOnce(auctionChain({ data: AUCTION }))
+      .mockReturnValueOnce(updateChain({ error: { message: "boom" } }));
+    const res = await POST(makeReq(VALID), ctx());
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 500 on unexpected error", async () => {
+    mockFrom.mockImplementationOnce(() => {
+      throw new Error("db down");
+    });
+    const res = await POST(makeReq(VALID), ctx());
+    expect(res.status).toBe(500);
+  });
+});

--- a/__tests__/api/quotes-review.test.ts
+++ b/__tests__/api/quotes-review.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { createHmac } from "crypto";
+
+const { mockFrom, mockIsRateLimited } = vi.hoisted(() => ({
+  mockFrom: vi.fn(),
+  mockIsRateLimited: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  isRateLimited: mockIsRateLimited,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import { POST } from "@/app/api/quotes/[slug]/review/route";
+
+const SLUG = "find-an-adviser-abc";
+const SECRET = "test-cron-secret";
+const EMAIL = "owner@example.com";
+const AUCTION_ID = 11;
+
+function expectedToken(auctionId: number, email: string): string {
+  return createHmac("sha256", SECRET)
+    .update(`${auctionId}|${email.toLowerCase()}`)
+    .digest("hex")
+    .slice(0, 32);
+}
+
+const GOOD_TOKEN = expectedToken(AUCTION_ID, EMAIL);
+
+function makeReq(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/quotes/" + SLUG + "/review", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "x-forwarded-for": "1.2.3.4" },
+    body: JSON.stringify(body),
+  });
+}
+
+function ctx() {
+  return { params: Promise.resolve({ slug: SLUG }) };
+}
+
+function validBody(overrides: Record<string, unknown> = {}) {
+  return { token: GOOD_TOKEN, reviewer_email: EMAIL, rating: 5, body: "Great service", ...overrides };
+}
+
+const AUCTION = { id: AUCTION_ID, contact_email: EMAIL, winning_bid_id: 22 };
+
+// .from("advisor_auctions").select().eq().eq().maybeSingle()
+function auctionChain(result: { data: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  chain.select = vi.fn(() => chain);
+  chain.eq = vi.fn(() => chain);
+  chain.maybeSingle = vi.fn(() => Promise.resolve(result));
+  return chain;
+}
+
+// .from("advisor_auction_bids").select().eq().maybeSingle()
+function bidChain(result: { data: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  chain.select = vi.fn(() => chain);
+  chain.eq = vi.fn(() => chain);
+  chain.maybeSingle = vi.fn(() => Promise.resolve(result));
+  return chain;
+}
+
+// .from("quote_reviews").insert() — terminal insert resolves
+function insertChain(result: { error: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  chain.insert = vi.fn(() => Promise.resolve(result));
+  return chain;
+}
+
+describe("POST /api/quotes/[slug]/review", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsRateLimited.mockResolvedValue(false);
+    vi.stubEnv("CRON_SECRET", SECRET);
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    mockIsRateLimited.mockResolvedValueOnce(true);
+    const res = await POST(makeReq(validBody()), ctx());
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 400 on invalid JSON body", async () => {
+    const req = new NextRequest("http://localhost/api/quotes/" + SLUG + "/review", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{bad",
+    });
+    const res = await POST(req, ctx());
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when zod fails (rating out of range)", async () => {
+    const res = await POST(makeReq(validBody({ rating: 9 })), ctx());
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when job not found", async () => {
+    mockFrom.mockReturnValueOnce(auctionChain({ data: null }));
+    const res = await POST(makeReq(validBody()), ctx());
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 when there is no accepted quote", async () => {
+    mockFrom.mockReturnValueOnce(auctionChain({ data: { ...AUCTION, winning_bid_id: null } }));
+    const res = await POST(makeReq(validBody()), ctx());
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "No accepted quote on this job." });
+  });
+
+  it("returns 403 when reviewer email does not match", async () => {
+    mockFrom.mockReturnValueOnce(auctionChain({ data: AUCTION }));
+    const res = await POST(makeReq(validBody({ reviewer_email: "other@example.com" })), ctx());
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 403 when the token is invalid", async () => {
+    mockFrom.mockReturnValueOnce(auctionChain({ data: AUCTION }));
+    const res = await POST(makeReq(validBody({ token: "x".repeat(32) })), ctx());
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "Invalid or expired review link." });
+  });
+
+  it("returns 404 when the winning bid is not found", async () => {
+    mockFrom
+      .mockReturnValueOnce(auctionChain({ data: AUCTION }))
+      .mockReturnValueOnce(bidChain({ data: null }));
+    const res = await POST(makeReq(validBody()), ctx());
+    expect(res.status).toBe(404);
+  });
+
+  it("inserts the review and returns success", async () => {
+    const chain = insertChain({ error: null });
+    mockFrom
+      .mockReturnValueOnce(auctionChain({ data: AUCTION }))
+      .mockReturnValueOnce(bidChain({ data: { advisor_id: 9 } }))
+      .mockReturnValueOnce(chain);
+    const res = await POST(makeReq(validBody()), ctx());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true });
+    const insertArg = chain.insert.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(insertArg).toMatchObject({ auction_id: AUCTION_ID, advisor_id: 9, rating: 5, verified: true });
+  });
+
+  it("returns 409 on duplicate review (unique violation)", async () => {
+    mockFrom
+      .mockReturnValueOnce(auctionChain({ data: AUCTION }))
+      .mockReturnValueOnce(bidChain({ data: { advisor_id: 9 } }))
+      .mockReturnValueOnce(insertChain({ error: { code: "23505", message: "dup" } }));
+    const res = await POST(makeReq(validBody()), ctx());
+    expect(res.status).toBe(409);
+  });
+
+  it("returns 500 when the insert errors for another reason", async () => {
+    mockFrom
+      .mockReturnValueOnce(auctionChain({ data: AUCTION }))
+      .mockReturnValueOnce(bidChain({ data: { advisor_id: 9 } }))
+      .mockReturnValueOnce(insertChain({ error: { code: "55000", message: "boom" } }));
+    const res = await POST(makeReq(validBody()), ctx());
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 500 on unexpected error", async () => {
+    mockFrom.mockImplementationOnce(() => {
+      throw new Error("db down");
+    });
+    const res = await POST(makeReq(validBody()), ctx());
+    expect(res.status).toBe(500);
+  });
+});


### PR DESCRIPTION
## Summary
Unit tests for `quotes/[slug]` (accept/qa/reopen/review) + `get-matched/plans/[id]` (checklist/claim/save/to-brief). 77 tests: rate-limit, auth (owner/advisor/token), zod, happy, 404, conflict/state branches, 500.

## Queue item
D-COV pre-launch coverage push. Moves M02 (57→200).

## Supersedes
_None._

## Test plan
- [x] vitest 77/77 local
- [ ] CI green