### PR TITLE
test(d): add unit tests for admin moderation routes

### DIFF
--- a/__tests__/api/admin-briefs-risk.test.ts
+++ b/__tests__/api/admin-briefs-risk.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Tests for POST /api/admin/briefs/[id]/risk.
+ *
+ * Admin-gated risk-review action (approve | reject) on a brief. The route
+ * updates `advisor_auctions`, inserts a `brief_tracker_events` row, and
+ * fires fire-and-forget notification helpers. We mock requireAdmin, the
+ * admin Supabase client, and every notification dependency so we can assert
+ * on auth gating, body validation, and the persisted state change.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockRequireAdmin, mockAdminFrom } = vi.hoisted(() => ({
+  mockRequireAdmin: vi.fn(),
+  mockAdminFrom: vi.fn(),
+}));
+
+vi.mock("@/lib/require-admin", () => ({
+  requireAdmin: () => mockRequireAdmin(),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  })),
+}));
+
+vi.mock("@/lib/briefs/routing", () => ({
+  resolveEligibleProviders: vi.fn(async () => []),
+}));
+vi.mock("@/lib/marketplace-emails", () => ({
+  sendProviderNewMatchRequest: vi.fn(async () => true),
+}));
+vi.mock("@/lib/resend", () => ({ sendEmail: vi.fn(async () => true) }));
+vi.mock("@/lib/seo", () => ({ SITE_URL: "https://invest.com.au" }));
+vi.mock("@/lib/user-notifications", () => ({
+  enqueueUserNotificationByEmail: vi.fn(async () => undefined),
+}));
+
+import { POST } from "@/app/api/admin/briefs/[id]/risk/route";
+
+const ADMIN_OK = {
+  ok: true as const,
+  email: "admin@invest.com.au",
+  userId: "user-1",
+};
+
+function denyGuard(status: number) {
+  return {
+    ok: false as const,
+    response: new Response(JSON.stringify({ error: "denied" }), { status }),
+  };
+}
+
+function makeReq(id: string, body: unknown) {
+  return new NextRequest(`http://localhost/api/admin/briefs/${id}/risk`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const ctx = (id: string) => ({ params: Promise.resolve({ id }) });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRequireAdmin.mockResolvedValue(ADMIN_OK);
+  // Default chainable builder: update().eq().select().maybeSingle() resolves
+  // to a brief row; insert() resolves ok.
+  mockAdminFrom.mockImplementation(() => {
+    const builder: Record<string, unknown> = {};
+    const chain = () => builder;
+    builder.update = vi.fn(chain);
+    builder.eq = vi.fn(chain);
+    builder.select = vi.fn(chain);
+    builder.maybeSingle = vi.fn(async () => ({
+      data: { id: 7, contact_email: null, slug: "s", job_title: "Job" },
+      error: null,
+    }));
+    builder.insert = vi.fn(async () => ({ data: null, error: null }));
+    return builder;
+  });
+});
+
+describe("POST /api/admin/briefs/[id]/risk", () => {
+  it("propagates 401 when admin guard refuses", async () => {
+    mockRequireAdmin.mockResolvedValue(denyGuard(401));
+    const res = await POST(makeReq("7", { action: "approve" }), ctx("7"));
+    expect(res.status).toBe(401);
+    expect(mockAdminFrom).not.toHaveBeenCalled();
+  });
+
+  it("propagates 403 when admin guard forbids", async () => {
+    mockRequireAdmin.mockResolvedValue(denyGuard(403));
+    const res = await POST(makeReq("7", { action: "approve" }), ctx("7"));
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 for a non-numeric brief id", async () => {
+    const res = await POST(makeReq("abc", { action: "approve" }), ctx("abc"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for an invalid JSON body", async () => {
+    const req = new NextRequest("http://localhost/api/admin/briefs/7/risk", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{not json",
+    });
+    const res = await POST(req, ctx("7"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when the action is not approve/reject", async () => {
+    const res = await POST(makeReq("7", { action: "frobnicate" }), ctx("7"));
+    expect(res.status).toBe(400);
+  });
+
+  it("approves: writes approved status and tracker event", async () => {
+    const updateSpy = vi.fn();
+    const insertSpy = vi.fn();
+    mockAdminFrom.mockImplementation((table: string) => {
+      const builder: Record<string, unknown> = {};
+      const chain = () => builder;
+      builder.update = vi.fn((u: unknown) => {
+        updateSpy(table, u);
+        return builder;
+      });
+      builder.eq = vi.fn(chain);
+      builder.select = vi.fn(chain);
+      builder.maybeSingle = vi.fn(async () => ({
+        data: { id: 7, contact_email: null, slug: "s", job_title: "Job" },
+        error: null,
+      }));
+      builder.insert = vi.fn(async (row: unknown) => {
+        insertSpy(table, row);
+        return { data: null, error: null };
+      });
+      return builder;
+    });
+
+    const res = await POST(makeReq("7", { action: "approve" }), ctx("7"));
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ success: true });
+
+    expect(updateSpy).toHaveBeenCalledWith(
+      "advisor_auctions",
+      expect.objectContaining({ risk_review_status: "approved" }),
+    );
+    expect(insertSpy).toHaveBeenCalledWith(
+      "brief_tracker_events",
+      expect.objectContaining({ event_type: "risk_approved", actor_kind: "admin" }),
+    );
+  });
+
+  it("rejects: writes rejected status and closes the brief", async () => {
+    const updateSpy = vi.fn();
+    mockAdminFrom.mockImplementation((table: string) => {
+      const builder: Record<string, unknown> = {};
+      const chain = () => builder;
+      builder.update = vi.fn((u: unknown) => {
+        updateSpy(table, u);
+        return builder;
+      });
+      builder.eq = vi.fn(chain);
+      builder.select = vi.fn(chain);
+      builder.maybeSingle = vi.fn(async () => ({
+        data: { id: 7, contact_email: null, slug: "s", job_title: "Job" },
+        error: null,
+      }));
+      builder.insert = vi.fn(async () => ({ data: null, error: null }));
+      return builder;
+    });
+
+    const res = await POST(
+      makeReq("7", { action: "reject", note: "scam" }),
+      ctx("7"),
+    );
+    expect(res.status).toBe(200);
+    expect(updateSpy).toHaveBeenCalledWith(
+      "advisor_auctions",
+      expect.objectContaining({
+        risk_review_status: "rejected",
+        status: "closed",
+        risk_review_decision_reason: "scam",
+      }),
+    );
+  });
+});

--- a/__tests__/api/admin-disputes-resolve.test.ts
+++ b/__tests__/api/admin-disputes-resolve.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Tests for POST /api/admin/disputes/[id]/resolve.
+ *
+ * Admin-gated dispute resolution. Delegates the status change to the
+ * `setStatus` helper and, on a `resolved_for_consumer` verdict, runs a
+ * refund hook via `loadRefundContext` + `recordLedgerEntry` + `awardCredits`.
+ * Helpers are mocked; a real `DisputeError` class is provided so the route's
+ * `instanceof` branch maps to the carried status code.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const {
+  mockRequireAdmin,
+  mockSetStatus,
+  mockLoadRefundContext,
+  mockRecordLedgerEntry,
+  mockAwardCredits,
+  DisputeError,
+} = vi.hoisted(() => {
+  class DisputeError extends Error {
+    status: number;
+    constructor(message: string, status: number) {
+      super(message);
+      this.name = "DisputeError";
+      this.status = status;
+    }
+  }
+  return {
+    mockRequireAdmin: vi.fn(),
+    mockSetStatus: vi.fn(),
+    mockLoadRefundContext: vi.fn(),
+    mockRecordLedgerEntry: vi.fn(),
+    mockAwardCredits: vi.fn(),
+    DisputeError,
+  };
+});
+
+vi.mock("@/lib/require-admin", () => ({
+  requireAdmin: () => mockRequireAdmin(),
+}));
+
+vi.mock("@/lib/disputes", () => ({
+  DisputeError,
+  setStatus: (...a: unknown[]) => mockSetStatus(...a),
+  loadRefundContext: (...a: unknown[]) => mockLoadRefundContext(...a),
+}));
+
+vi.mock("@/lib/advisor-credit-ledger", () => ({
+  recordLedgerEntry: (...a: unknown[]) => mockRecordLedgerEntry(...a),
+}));
+vi.mock("@/lib/investor-referrals", () => ({
+  awardCredits: (...a: unknown[]) => mockAwardCredits(...a),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  })),
+}));
+
+import { POST } from "@/app/api/admin/disputes/[id]/resolve/route";
+
+const ADMIN_OK = {
+  ok: true as const,
+  email: "admin@invest.com.au",
+  userId: "user-1",
+};
+
+function denyGuard(status: number) {
+  return {
+    ok: false as const,
+    response: new Response(JSON.stringify({ error: "denied" }), { status }),
+  };
+}
+
+function makeReq(id: string, body: unknown) {
+  return new NextRequest(
+    `http://localhost/api/admin/disputes/${id}/resolve`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+const ctx = (id: string) => ({ params: Promise.resolve({ id }) });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRequireAdmin.mockResolvedValue(ADMIN_OK);
+  mockSetStatus.mockResolvedValue({
+    dispute: { id: 5, status: "admin_reviewing" },
+    changed: true,
+  });
+});
+
+describe("POST /api/admin/disputes/[id]/resolve", () => {
+  it("propagates 401 when guard refuses", async () => {
+    mockRequireAdmin.mockResolvedValue(denyGuard(401));
+    const res = await POST(
+      makeReq("5", { status: "admin_reviewing" }),
+      ctx("5"),
+    );
+    expect(res.status).toBe(401);
+    expect(mockSetStatus).not.toHaveBeenCalled();
+  });
+
+  it("propagates 403 when guard forbids", async () => {
+    mockRequireAdmin.mockResolvedValue(denyGuard(403));
+    const res = await POST(
+      makeReq("5", { status: "admin_reviewing" }),
+      ctx("5"),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 for a non-numeric dispute id", async () => {
+    const res = await POST(
+      makeReq("xx", { status: "admin_reviewing" }),
+      ctx("xx"),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for an invalid status value", async () => {
+    const res = await POST(makeReq("5", { status: "nope" }), ctx("5"));
+    expect(res.status).toBe(400);
+    expect(mockSetStatus).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for an invalid JSON body", async () => {
+    const req = new NextRequest(
+      "http://localhost/api/admin/disputes/5/resolve",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{bad",
+      },
+    );
+    const res = await POST(req, ctx("5"));
+    expect(res.status).toBe(400);
+  });
+
+  it("resolves a dispute and returns the updated record", async () => {
+    const res = await POST(
+      makeReq("5", { status: "admin_reviewing", resolution_notes: "ok" }),
+      ctx("5"),
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.dispute).toEqual({ id: 5, status: "admin_reviewing" });
+    expect(json.refund).toBeNull();
+    expect(mockSetStatus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        disputeId: 5,
+        status: "admin_reviewing",
+        resolvedByUserId: "user-1",
+      }),
+    );
+  });
+
+  it("runs the refund hook on resolved_for_consumer", async () => {
+    mockSetStatus.mockResolvedValue({
+      dispute: { id: 5, status: "resolved_for_consumer" },
+      changed: true,
+    });
+    mockLoadRefundContext.mockResolvedValue({
+      acceptedProfessionalId: 12,
+      leadSpendCents: 500,
+      briefId: 99,
+      leadSpendEntryId: 1,
+      consumerReferrerUserId: "ref-1",
+      consumerAuthUserId: "consumer-1",
+    });
+    mockRecordLedgerEntry.mockResolvedValue({ idempotent: false });
+    mockAwardCredits.mockResolvedValue(undefined);
+
+    const res = await POST(
+      makeReq("5", { status: "resolved_for_consumer" }),
+      ctx("5"),
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.refund).toEqual({
+      proRefundCents: 500,
+      referrerCreditsAwarded: true,
+    });
+    expect(mockRecordLedgerEntry).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "lead_dispute_refund" }),
+    );
+  });
+
+  it("maps a DisputeError to its carried status code", async () => {
+    mockSetStatus.mockRejectedValue(new DisputeError("Already closed", 409));
+    const res = await POST(
+      makeReq("5", { status: "withdrawn" }),
+      ctx("5"),
+    );
+    expect(res.status).toBe(409);
+    await expect(res.json()).resolves.toEqual({ error: "Already closed" });
+  });
+
+  it("returns 500 on an unexpected error", async () => {
+    mockSetStatus.mockRejectedValue(new Error("db down"));
+    const res = await POST(
+      makeReq("5", { status: "admin_reviewing" }),
+      ctx("5"),
+    );
+    expect(res.status).toBe(500);
+  });
+});

--- a/__tests__/api/admin-expert-teams-verify.test.ts
+++ b/__tests__/api/admin-expert-teams-verify.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests for POST /api/admin/expert-teams/[id]/verify.
+ *
+ * Admin-gated verify/reject of an expert team. The route looks the team up
+ * via `getTeamById` (404 if missing) then delegates to `adminVerify`.
+ * Both helpers are mocked.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockRequireAdmin, mockGetTeamById, mockAdminVerify } = vi.hoisted(
+  () => ({
+    mockRequireAdmin: vi.fn(),
+    mockGetTeamById: vi.fn(),
+    mockAdminVerify: vi.fn(),
+  }),
+);
+
+vi.mock("@/lib/require-admin", () => ({
+  requireAdmin: () => mockRequireAdmin(),
+}));
+
+vi.mock("@/lib/expert-teams", () => ({
+  getTeamById: (...a: unknown[]) => mockGetTeamById(...a),
+  adminVerify: (...a: unknown[]) => mockAdminVerify(...a),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  })),
+}));
+
+import { POST } from "@/app/api/admin/expert-teams/[id]/verify/route";
+
+const ADMIN_OK = {
+  ok: true as const,
+  email: "admin@invest.com.au",
+  userId: "user-1",
+};
+
+function denyGuard(status: number) {
+  return {
+    ok: false as const,
+    response: new Response(JSON.stringify({ error: "denied" }), { status }),
+  };
+}
+
+function makeReq(id: string, body: unknown) {
+  return new NextRequest(
+    `http://localhost/api/admin/expert-teams/${id}/verify`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+const ctx = (id: string) => ({ params: Promise.resolve({ id }) });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRequireAdmin.mockResolvedValue(ADMIN_OK);
+  mockGetTeamById.mockResolvedValue({ id: 3, name: "Team", status: "pending" });
+  mockAdminVerify.mockResolvedValue({ id: 3, status: "verified" });
+});
+
+describe("POST /api/admin/expert-teams/[id]/verify", () => {
+  it("propagates 401 when guard refuses", async () => {
+    mockRequireAdmin.mockResolvedValue(denyGuard(401));
+    const res = await POST(makeReq("3", { approved: true }), ctx("3"));
+    expect(res.status).toBe(401);
+    expect(mockGetTeamById).not.toHaveBeenCalled();
+  });
+
+  it("propagates 403 when guard forbids", async () => {
+    mockRequireAdmin.mockResolvedValue(denyGuard(403));
+    const res = await POST(makeReq("3", { approved: true }), ctx("3"));
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 for a non-numeric team id", async () => {
+    const res = await POST(makeReq("zz", { approved: true }), ctx("zz"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for an invalid JSON body", async () => {
+    const req = new NextRequest(
+      "http://localhost/api/admin/expert-teams/3/verify",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{bad",
+      },
+    );
+    const res = await POST(req, ctx("3"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when approved is missing", async () => {
+    const res = await POST(makeReq("3", {}), ctx("3"));
+    expect(res.status).toBe(400);
+    expect(mockAdminVerify).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the team does not exist", async () => {
+    mockGetTeamById.mockResolvedValue(null);
+    const res = await POST(makeReq("3", { approved: true }), ctx("3"));
+    expect(res.status).toBe(404);
+    expect(mockAdminVerify).not.toHaveBeenCalled();
+  });
+
+  it("verifies a team and returns the updated record", async () => {
+    const res = await POST(
+      makeReq("3", { approved: true, accepts_briefs: true }),
+      ctx("3"),
+    );
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      team: { id: 3, status: "verified" },
+    });
+    expect(mockAdminVerify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teamId: 3,
+        approved: true,
+        acceptsBriefs: true,
+      }),
+    );
+  });
+
+  it("rejects a team when approved is false", async () => {
+    mockAdminVerify.mockResolvedValue({ id: 3, status: "rejected" });
+    const res = await POST(
+      makeReq("3", { approved: false, rejection_reason: "incomplete" }),
+      ctx("3"),
+    );
+    expect(res.status).toBe(200);
+    expect(mockAdminVerify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        approved: false,
+        rejectionReason: "incomplete",
+      }),
+    );
+  });
+});

--- a/__tests__/api/admin-fin-objection.test.ts
+++ b/__tests__/api/admin-fin-objection.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Tests for POST /api/admin/fin-objection/[id].
+ *
+ * NOT gated by requireAdmin — uses a narrower FIN_OBJECTION_EMAILS allowlist
+ * (admin != Fin). Auth flow: createClient().auth.getUser() then membership
+ * check via getFinObjectionEmails(). On success it stamps fin_objection_at
+ * on a `review_passed` editorial article (404 if no row matches) and writes
+ * an admin_audit_log row.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockGetUser, mockGetFinObjectionEmails, mockAdminFrom } = vi.hoisted(
+  () => ({
+    mockGetUser: vi.fn(),
+    mockGetFinObjectionEmails: vi.fn(),
+    mockAdminFrom: vi.fn(),
+  }),
+);
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({ auth: { getUser: mockGetUser } })),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+
+vi.mock("@/lib/admin", () => ({
+  getFinObjectionEmails: () => mockGetFinObjectionEmails(),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  })),
+}));
+
+import { POST } from "@/app/api/admin/fin-objection/[id]/route";
+
+function makeReq(id: string) {
+  return new NextRequest(`http://localhost/api/admin/fin-objection/${id}`, {
+    method: "POST",
+  });
+}
+
+const ctx = (id: string) => ({ params: Promise.resolve({ id }) });
+
+const FIN = { id: "fin-1", email: "fin@invest.com.au" };
+
+/**
+ * Build an admin client whose `editorial_articles` chain resolves the given
+ * single() result, and whose `admin_audit_log` insert is captured.
+ */
+function setupAdmin(
+  singleResult: { data: unknown; error: { message: string } | null },
+  auditSpy = vi.fn(),
+) {
+  mockAdminFrom.mockImplementation((table: string) => {
+    if (table === "admin_audit_log") {
+      return { insert: vi.fn(async (row: unknown) => auditSpy(row)) };
+    }
+    const builder: Record<string, unknown> = {};
+    const chain = () => builder;
+    builder.update = vi.fn(chain);
+    builder.eq = vi.fn(chain);
+    builder.select = vi.fn(chain);
+    builder.single = vi.fn(async () => singleResult);
+    return builder;
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetUser.mockResolvedValue({ data: { user: FIN }, error: null });
+  mockGetFinObjectionEmails.mockReturnValue(["fin@invest.com.au"]);
+  setupAdmin({
+    data: { id: "10", fin_objection_at: "2026-05-20T00:00:00Z", status: "review_passed" },
+    error: null,
+  });
+});
+
+describe("POST /api/admin/fin-objection/[id]", () => {
+  it("returns 401 when unauthenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+    const res = await POST(makeReq("10"), ctx("10"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when the user is not on the fin-objection allowlist", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "u9", email: "rando@example.com" } },
+      error: null,
+    });
+    const res = await POST(makeReq("10"), ctx("10"));
+    expect(res.status).toBe(403);
+  });
+
+  it("stamps fin_objection_at and writes an audit log row", async () => {
+    const auditSpy = vi.fn();
+    setupAdmin(
+      {
+        data: {
+          id: "10",
+          fin_objection_at: "2026-05-20T00:00:00Z",
+          status: "review_passed",
+        },
+        error: null,
+      },
+      auditSpy,
+    );
+    const res = await POST(makeReq("10"), ctx("10"));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.id).toBe("10");
+    expect(json.fin_objection_at).toBe("2026-05-20T00:00:00Z");
+    expect(auditSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "editorial_article:fin_objection",
+        admin_email: "fin@invest.com.au",
+      }),
+    );
+  });
+
+  it("returns 500 on a DB error", async () => {
+    setupAdmin({ data: null, error: { message: "boom" } });
+    const res = await POST(makeReq("10"), ctx("10"));
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 404 when no review_passed article matches", async () => {
+    setupAdmin({ data: null, error: null });
+    const res = await POST(makeReq("10"), ctx("10"));
+    expect(res.status).toBe(404);
+  });
+});

--- a/__tests__/api/admin-listings-owner-flow-approve.test.ts
+++ b/__tests__/api/admin-listings-owner-flow-approve.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Tests for POST /api/admin/listings/owner-flow/[id]/approve.
+ *
+ * Admin-gated. Delegates to `approveListing` (mocked) which returns either a
+ * ModerationResult or ModerationFailure; the route maps `not_found` -> 404,
+ * other failures -> 500. Writes a best-effort admin_audit_log row.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockRequireAdmin, mockApproveListing, mockAdminFrom } = vi.hoisted(
+  () => ({
+    mockRequireAdmin: vi.fn(),
+    mockApproveListing: vi.fn(),
+    mockAdminFrom: vi.fn(),
+  }),
+);
+
+vi.mock("@/lib/require-admin", () => ({
+  requireAdmin: () => mockRequireAdmin(),
+}));
+
+vi.mock("@/lib/listings/moderate", () => ({
+  approveListing: (...a: unknown[]) => mockApproveListing(...a),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  })),
+}));
+
+import { POST } from "@/app/api/admin/listings/owner-flow/[id]/approve/route";
+
+const ADMIN_OK = {
+  ok: true as const,
+  email: "admin@invest.com.au",
+  userId: "user-1",
+};
+
+function denyGuard(status: number) {
+  return {
+    ok: false as const,
+    response: new Response(JSON.stringify({ error: "denied" }), { status }),
+  };
+}
+
+function makeReq(id: string, body?: unknown) {
+  const init: RequestInit & { headers: Record<string, string> } = {
+    method: "POST",
+    headers: {},
+  };
+  if (body !== undefined) {
+    init.headers["Content-Type"] = "application/json";
+    init.body = JSON.stringify(body);
+  }
+  return new NextRequest(
+    `http://localhost/api/admin/listings/owner-flow/${id}/approve`,
+    init,
+  );
+}
+
+const ctx = (id: string) => ({ params: Promise.resolve({ id }) });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRequireAdmin.mockResolvedValue(ADMIN_OK);
+  mockApproveListing.mockResolvedValue({
+    ok: true,
+    noOp: false,
+    listing: { id: "abc", slug: "my-listing", status: "approved" },
+  });
+  mockAdminFrom.mockReturnValue({ insert: vi.fn(async () => ({ error: null })) });
+});
+
+describe("POST /api/admin/listings/owner-flow/[id]/approve", () => {
+  it("propagates 401 when guard refuses", async () => {
+    mockRequireAdmin.mockResolvedValue(denyGuard(401));
+    const res = await POST(makeReq("abc"), ctx("abc"));
+    expect(res.status).toBe(401);
+    expect(mockApproveListing).not.toHaveBeenCalled();
+  });
+
+  it("propagates 403 when guard forbids", async () => {
+    mockRequireAdmin.mockResolvedValue(denyGuard(403));
+    const res = await POST(makeReq("abc"), ctx("abc"));
+    expect(res.status).toBe(403);
+  });
+
+  it("accepts an explicit empty body", async () => {
+    const res = await POST(makeReq("abc", {}), ctx("abc"));
+    expect(res.status).toBe(200);
+    expect(mockApproveListing).toHaveBeenCalledWith("abc", "user-1");
+  });
+
+  it("approves a listing (no body) and writes an audit row", async () => {
+    const insertSpy = vi.fn(async () => ({ error: null }));
+    mockAdminFrom.mockReturnValue({ insert: insertSpy });
+
+    const res = await POST(makeReq("abc"), ctx("abc"));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual({
+      ok: true,
+      noOp: false,
+      listing: { id: "abc", slug: "my-listing", status: "approved" },
+    });
+    expect(mockApproveListing).toHaveBeenCalledWith("abc", "user-1");
+    expect(insertSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "listing:approved" }),
+    );
+  });
+
+  it("returns 404 when the listing is not found", async () => {
+    mockApproveListing.mockResolvedValue({ ok: false, error: "not_found" });
+    const res = await POST(makeReq("abc"), ctx("abc"));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 500 on a non-not_found failure", async () => {
+    mockApproveListing.mockResolvedValue({ ok: false, error: "db_error" });
+    const res = await POST(makeReq("abc"), ctx("abc"));
+    expect(res.status).toBe(500);
+  });
+
+  it("still returns 200 if the audit log insert throws", async () => {
+    mockAdminFrom.mockReturnValue({
+      insert: vi.fn(async () => {
+        throw new Error("audit down");
+      }),
+    });
+    const res = await POST(makeReq("abc"), ctx("abc"));
+    expect(res.status).toBe(200);
+  });
+});

--- a/__tests__/api/admin-listings-owner-flow-reject.test.ts
+++ b/__tests__/api/admin-listings-owner-flow-reject.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for POST /api/admin/listings/owner-flow/[id]/reject.
+ *
+ * Admin-gated. Requires a non-empty `notes` field (Zod, strict). Delegates to
+ * `rejectListing` (mocked); maps `not_found` -> 404, `notes_required` -> 400,
+ * else 500. Writes a best-effort admin_audit_log row.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockRequireAdmin, mockRejectListing, mockAdminFrom } = vi.hoisted(
+  () => ({
+    mockRequireAdmin: vi.fn(),
+    mockRejectListing: vi.fn(),
+    mockAdminFrom: vi.fn(),
+  }),
+);
+
+vi.mock("@/lib/require-admin", () => ({
+  requireAdmin: () => mockRequireAdmin(),
+}));
+
+vi.mock("@/lib/listings/moderate", () => ({
+  rejectListing: (...a: unknown[]) => mockRejectListing(...a),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  })),
+}));
+
+import { POST } from "@/app/api/admin/listings/owner-flow/[id]/reject/route";
+
+const ADMIN_OK = {
+  ok: true as const,
+  email: "admin@invest.com.au",
+  userId: "user-1",
+};
+
+function denyGuard(status: number) {
+  return {
+    ok: false as const,
+    response: new Response(JSON.stringify({ error: "denied" }), { status }),
+  };
+}
+
+function makeReq(id: string, body: unknown) {
+  return new NextRequest(
+    `http://localhost/api/admin/listings/owner-flow/${id}/reject`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+const ctx = (id: string) => ({ params: Promise.resolve({ id }) });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRequireAdmin.mockResolvedValue(ADMIN_OK);
+  mockRejectListing.mockResolvedValue({
+    ok: true,
+    noOp: false,
+    listing: { id: "abc", slug: "my-listing", status: "rejected" },
+  });
+  mockAdminFrom.mockReturnValue({ insert: vi.fn(async () => ({ error: null })) });
+});
+
+describe("POST /api/admin/listings/owner-flow/[id]/reject", () => {
+  it("propagates 401 when guard refuses", async () => {
+    mockRequireAdmin.mockResolvedValue(denyGuard(401));
+    const res = await POST(makeReq("abc", { notes: "spam" }), ctx("abc"));
+    expect(res.status).toBe(401);
+    expect(mockRejectListing).not.toHaveBeenCalled();
+  });
+
+  it("propagates 403 when guard forbids", async () => {
+    mockRequireAdmin.mockResolvedValue(denyGuard(403));
+    const res = await POST(makeReq("abc", { notes: "spam" }), ctx("abc"));
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 for an invalid JSON body", async () => {
+    const req = new NextRequest(
+      "http://localhost/api/admin/listings/owner-flow/abc/reject",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{bad",
+      },
+    );
+    const res = await POST(req, ctx("abc"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when notes is empty", async () => {
+    const res = await POST(makeReq("abc", { notes: "" }), ctx("abc"));
+    expect(res.status).toBe(400);
+    expect(mockRejectListing).not.toHaveBeenCalled();
+  });
+
+  it("rejects a listing and writes an audit row", async () => {
+    const insertSpy = vi.fn(async () => ({ error: null }));
+    mockAdminFrom.mockReturnValue({ insert: insertSpy });
+
+    const res = await POST(makeReq("abc", { notes: "duplicate" }), ctx("abc"));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+    expect(json.listing.status).toBe("rejected");
+    expect(mockRejectListing).toHaveBeenCalledWith("abc", "user-1", "duplicate");
+    expect(insertSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "listing:rejected" }),
+    );
+  });
+
+  it("returns 404 when the listing is not found", async () => {
+    mockRejectListing.mockResolvedValue({ ok: false, error: "not_found" });
+    const res = await POST(makeReq("abc", { notes: "x" }), ctx("abc"));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 500 on an unexpected helper failure", async () => {
+    mockRejectListing.mockResolvedValue({ ok: false, error: "db_error" });
+    const res = await POST(makeReq("abc", { notes: "x" }), ctx("abc"));
+    expect(res.status).toBe(500);
+  });
+});

--- a/__tests__/api/admin-professionals-approve.test.ts
+++ b/__tests__/api/admin-professionals-approve.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Tests for POST /api/admin/professionals/[id]/approve.
+ *
+ * Body is parsed by withValidatedBody (real wrapper) BEFORE the admin guard
+ * runs, so an invalid body returns 400 first. After validation: requireAdmin
+ * gate -> IP rate limit -> id validation -> fetch professional (404 / 409 if
+ * already verified) -> flip to verified + optional credit grant -> best-effort
+ * pro-approved email.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const {
+  mockRequireAdmin,
+  mockAdminFrom,
+  mockIsAllowed,
+  mockSendProApproved,
+} = vi.hoisted(() => ({
+  mockRequireAdmin: vi.fn(),
+  mockAdminFrom: vi.fn(),
+  mockIsAllowed: vi.fn(),
+  mockSendProApproved: vi.fn(),
+}));
+
+vi.mock("@/lib/require-admin", () => ({
+  requireAdmin: () => mockRequireAdmin(),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: (...a: unknown[]) => mockIsAllowed(...a),
+  ipKey: vi.fn(() => "127.0.0.1"),
+}));
+
+vi.mock("@/lib/pro-onboarding-emails", () => ({
+  sendProApproved: (...a: unknown[]) => mockSendProApproved(...a),
+}));
+
+vi.mock("@/lib/pro-onboarding", () => ({
+  STARTER_FREE_CREDITS: 5,
+  STARTER_CREDIT_CENTS_PER_CREDIT: 100,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  })),
+}));
+
+import { POST } from "@/app/api/admin/professionals/[id]/approve/route";
+
+const ADMIN_OK = {
+  ok: true as const,
+  email: "admin@invest.com.au",
+  userId: "user-1",
+};
+
+function denyGuard(status: number) {
+  return {
+    ok: false as const,
+    response: new Response(JSON.stringify({ error: "denied" }), { status }),
+  };
+}
+
+function makeReq(id: string, body: unknown) {
+  return new NextRequest(
+    `http://localhost/api/admin/professionals/${id}/approve`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+const ctx = (id: string) => ({ params: Promise.resolve({ id }) });
+
+/**
+ * professionals.select().eq().maybeSingle() resolves to `fetchResult`;
+ * professionals.update().eq() resolves to `updateResult`. The update spy
+ * captures the patch object.
+ */
+function setupProfessionals(
+  fetchResult: { data: unknown; error: { message: string } | null },
+  updateResult: { error: { message: string } | null } = { error: null },
+  updateSpy = vi.fn(),
+) {
+  mockAdminFrom.mockImplementation(() => {
+    const builder: Record<string, unknown> = {};
+    builder.select = vi.fn(() => builder);
+    builder.update = vi.fn((patch: unknown) => {
+      updateSpy(patch);
+      // update().eq() is awaited -> return a thenable-ish chain
+      return {
+        eq: vi.fn(async () => updateResult),
+      };
+    });
+    builder.eq = vi.fn(() => builder);
+    builder.maybeSingle = vi.fn(async () => fetchResult);
+    return builder;
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRequireAdmin.mockResolvedValue(ADMIN_OK);
+  mockIsAllowed.mockResolvedValue(true);
+  mockSendProApproved.mockResolvedValue(true);
+  setupProfessionals({
+    data: {
+      id: 42,
+      email: "pro@example.com",
+      name: "Pro",
+      verification_status: "pending",
+      credit_balance_cents: 0,
+    },
+    error: null,
+  });
+});
+
+describe("POST /api/admin/professionals/[id]/approve", () => {
+  it("propagates 401 when guard refuses", async () => {
+    mockRequireAdmin.mockResolvedValue(denyGuard(401));
+    const res = await POST(makeReq("42", {}), ctx("42"));
+    expect(res.status).toBe(401);
+  });
+
+  it("propagates 403 when guard forbids", async () => {
+    mockRequireAdmin.mockResolvedValue(denyGuard(403));
+    const res = await POST(makeReq("42", {}), ctx("42"));
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 for an invalid body (wrong field type)", async () => {
+    const res = await POST(
+      makeReq("42", { grant_starter_credits: "yes" }),
+      ctx("42"),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockIsAllowed.mockResolvedValue(false);
+    const res = await POST(makeReq("42", {}), ctx("42"));
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 400 for a non-numeric id", async () => {
+    const res = await POST(makeReq("xx", {}), ctx("xx"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when the professional is not found", async () => {
+    setupProfessionals({ data: null, error: null });
+    const res = await POST(makeReq("42", {}), ctx("42"));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 409 when already verified", async () => {
+    setupProfessionals({
+      data: { id: 42, verification_status: "verified", credit_balance_cents: 0 },
+      error: null,
+    });
+    const res = await POST(makeReq("42", {}), ctx("42"));
+    expect(res.status).toBe(409);
+  });
+
+  it("returns 500 when the lookup errors", async () => {
+    setupProfessionals({ data: null, error: { message: "boom" } });
+    const res = await POST(makeReq("42", {}), ctx("42"));
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 500 when the update errors", async () => {
+    const updateSpy = vi.fn();
+    setupProfessionals(
+      {
+        data: {
+          id: 42,
+          email: "pro@example.com",
+          name: "Pro",
+          verification_status: "pending",
+          credit_balance_cents: 0,
+        },
+        error: null,
+      },
+      { error: { message: "update failed" } },
+      updateSpy,
+    );
+    const res = await POST(makeReq("42", {}), ctx("42"));
+    expect(res.status).toBe(500);
+  });
+
+  it("approves the pro, flips to verified, and grants starter credits", async () => {
+    const updateSpy = vi.fn();
+    setupProfessionals(
+      {
+        data: {
+          id: 42,
+          email: "pro@example.com",
+          name: "Pro",
+          verification_status: "pending",
+          credit_balance_cents: 0,
+        },
+        error: null,
+      },
+      { error: null },
+      updateSpy,
+    );
+
+    const res = await POST(
+      makeReq("42", { grant_starter_credits: true }),
+      ctx("42"),
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+    expect(json.starter_credits_granted).toBe(5);
+    expect(updateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        verification_status: "verified",
+        accepts_briefs: true,
+        status: "active",
+        credit_balance_cents: 500,
+      }),
+    );
+    expect(mockSendProApproved).toHaveBeenCalled();
+  });
+
+  it("approves without credits when grant_starter_credits is false", async () => {
+    const updateSpy = vi.fn();
+    setupProfessionals(
+      {
+        data: {
+          id: 42,
+          email: "pro@example.com",
+          name: "Pro",
+          verification_status: "pending",
+          credit_balance_cents: 0,
+        },
+        error: null,
+      },
+      { error: null },
+      updateSpy,
+    );
+
+    const res = await POST(
+      makeReq("42", { grant_starter_credits: false }),
+      ctx("42"),
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.starter_credits_granted).toBe(0);
+    expect(updateSpy).toHaveBeenCalledWith(
+      expect.not.objectContaining({ credit_balance_cents: expect.anything() }),
+    );
+  });
+
+  it("still returns 200 when the approval email throws", async () => {
+    mockSendProApproved.mockRejectedValue(new Error("smtp down"));
+    const res = await POST(makeReq("42", {}), ctx("42"));
+    expect(res.status).toBe(200);
+  });
+});

--- a/__tests__/api/admin-professionals-reject.test.ts
+++ b/__tests__/api/admin-professionals-reject.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Tests for POST /api/admin/professionals/[id]/reject.
+ *
+ * Body parsed by withValidatedBody (real wrapper) first — `reason` is
+ * mandatory (min 4 chars). Then requireAdmin -> IP rate limit -> id check ->
+ * fetch (404 / 409 if verified) -> flip to rejected + inactive -> best-effort
+ * pro-rejected email.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const {
+  mockRequireAdmin,
+  mockAdminFrom,
+  mockIsAllowed,
+  mockSendProRejected,
+} = vi.hoisted(() => ({
+  mockRequireAdmin: vi.fn(),
+  mockAdminFrom: vi.fn(),
+  mockIsAllowed: vi.fn(),
+  mockSendProRejected: vi.fn(),
+}));
+
+vi.mock("@/lib/require-admin", () => ({
+  requireAdmin: () => mockRequireAdmin(),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: (...a: unknown[]) => mockIsAllowed(...a),
+  ipKey: vi.fn(() => "127.0.0.1"),
+}));
+
+vi.mock("@/lib/pro-onboarding-emails", () => ({
+  sendProRejected: (...a: unknown[]) => mockSendProRejected(...a),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  })),
+}));
+
+import { POST } from "@/app/api/admin/professionals/[id]/reject/route";
+
+const ADMIN_OK = {
+  ok: true as const,
+  email: "admin@invest.com.au",
+  userId: "user-1",
+};
+
+function denyGuard(status: number) {
+  return {
+    ok: false as const,
+    response: new Response(JSON.stringify({ error: "denied" }), { status }),
+  };
+}
+
+function makeReq(id: string, body: unknown) {
+  return new NextRequest(
+    `http://localhost/api/admin/professionals/${id}/reject`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+const ctx = (id: string) => ({ params: Promise.resolve({ id }) });
+
+function setupProfessionals(
+  fetchResult: { data: unknown; error: { message: string } | null },
+  updateResult: { error: { message: string } | null } = { error: null },
+  updateSpy = vi.fn(),
+) {
+  mockAdminFrom.mockImplementation(() => {
+    const builder: Record<string, unknown> = {};
+    builder.select = vi.fn(() => builder);
+    builder.update = vi.fn((patch: unknown) => {
+      updateSpy(patch);
+      return { eq: vi.fn(async () => updateResult) };
+    });
+    builder.eq = vi.fn(() => builder);
+    builder.maybeSingle = vi.fn(async () => fetchResult);
+    return builder;
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRequireAdmin.mockResolvedValue(ADMIN_OK);
+  mockIsAllowed.mockResolvedValue(true);
+  mockSendProRejected.mockResolvedValue(true);
+  setupProfessionals({
+    data: {
+      id: 42,
+      email: "pro@example.com",
+      name: "Pro",
+      verification_status: "pending",
+    },
+    error: null,
+  });
+});
+
+describe("POST /api/admin/professionals/[id]/reject", () => {
+  it("propagates 401 when guard refuses", async () => {
+    mockRequireAdmin.mockResolvedValue(denyGuard(401));
+    const res = await POST(makeReq("42", { reason: "incomplete docs" }), ctx("42"));
+    expect(res.status).toBe(401);
+  });
+
+  it("propagates 403 when guard forbids", async () => {
+    mockRequireAdmin.mockResolvedValue(denyGuard(403));
+    const res = await POST(makeReq("42", { reason: "incomplete docs" }), ctx("42"));
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 when reason is missing", async () => {
+    const res = await POST(makeReq("42", {}), ctx("42"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when reason is too short", async () => {
+    const res = await POST(makeReq("42", { reason: "no" }), ctx("42"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockIsAllowed.mockResolvedValue(false);
+    const res = await POST(makeReq("42", { reason: "incomplete docs" }), ctx("42"));
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 400 for a non-numeric id", async () => {
+    const res = await POST(makeReq("xx", { reason: "incomplete docs" }), ctx("xx"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when the professional is not found", async () => {
+    setupProfessionals({ data: null, error: null });
+    const res = await POST(makeReq("42", { reason: "incomplete docs" }), ctx("42"));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 409 when the provider is already verified", async () => {
+    setupProfessionals({
+      data: { id: 42, verification_status: "verified" },
+      error: null,
+    });
+    const res = await POST(makeReq("42", { reason: "incomplete docs" }), ctx("42"));
+    expect(res.status).toBe(409);
+  });
+
+  it("returns 500 when the lookup errors", async () => {
+    setupProfessionals({ data: null, error: { message: "boom" } });
+    const res = await POST(makeReq("42", { reason: "incomplete docs" }), ctx("42"));
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 500 when the update errors", async () => {
+    setupProfessionals(
+      {
+        data: { id: 42, email: "pro@example.com", name: "Pro", verification_status: "pending" },
+        error: null,
+      },
+      { error: { message: "update failed" } },
+    );
+    const res = await POST(makeReq("42", { reason: "incomplete docs" }), ctx("42"));
+    expect(res.status).toBe(500);
+  });
+
+  it("rejects the pro, flips to rejected + inactive, and emails them", async () => {
+    const updateSpy = vi.fn();
+    setupProfessionals(
+      {
+        data: { id: 42, email: "pro@example.com", name: "Pro", verification_status: "pending" },
+        error: null,
+      },
+      { error: null },
+      updateSpy,
+    );
+
+    const res = await POST(
+      makeReq("42", { reason: "incomplete documentation" }),
+      ctx("42"),
+    );
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ ok: true });
+    expect(updateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        verification_status: "rejected",
+        accepts_briefs: false,
+        status: "inactive",
+        verification_notes: "incomplete documentation",
+      }),
+    );
+    expect(mockSendProRejected).toHaveBeenCalledWith(
+      "pro@example.com",
+      "Pro",
+      "incomplete documentation",
+    );
+  });
+
+  it("still returns 200 when the rejection email throws", async () => {
+    mockSendProRejected.mockRejectedValue(new Error("smtp down"));
+    const res = await POST(makeReq("42", { reason: "incomplete docs" }), ctx("42"));
+    expect(res.status).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary
Unit tests for 8 admin moderation routes (briefs risk, disputes resolve, expert-teams verify, fin-objection, listings owner-flow approve/reject, professionals approve/reject). 67 tests: admin-auth gating (401/403), happy state-change, zod 400, 404, error 500; DisputeError mapping. (admin/qa already covered — not duplicated.)

## Queue item
D-COV pre-launch coverage push. Moves M02 (57→200).

## Supersedes
_None._

## Test plan
- [x] vitest 67/67 local
- [ ] CI green