### PR TITLE
fix(ci): emit json-summary coverage so M01 metric stops reading null

### DIFF
--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -21,7 +21,7 @@ export default defineConfig({
     ],
     coverage: {
       provider: "v8",
-      reporter: ["text", "text-summary", "lcov"],
+      reporter: ["text", "text-summary", "lcov", "json-summary"],
       include: ["lib/**/*.ts", "lib/**/*.tsx", "app/api/**/*.ts"],
       exclude: [
         "lib/database.types.ts",


### PR DESCRIPTION
## Summary
Fixes the M01 test-coverage metric reading `null` in `docs/audits/metrics-latest.json`. The quality-metrics collector reads `coverage/coverage-summary.json`, but vitest only had `["text","text-summary","lcov"]` reporters — none emit that file. Adds `json-summary`.

Verified locally: `vitest run --coverage` now produces `coverage/coverage-summary.json` with populated lines/branches/functions pct.

## Queue item
D-COV pre-launch coverage push — unblocks M01 metric collection so the coverage waves become measurable.

## Supersedes
_None._

## Test plan
- [x] coverage-summary.json produced locally
- [ ] CI green (code-quality job populates M01 next run)