### PR TITLE
test(d): add unit tests for referrals/fixed-quotes/notifications routes

### DIFF
--- a/__tests__/api/fixed-quotes-accept.test.ts
+++ b/__tests__/api/fixed-quotes-accept.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { isAllowedMock, ipKeyMock, acceptQuoteMock } = vi.hoisted(() => ({
+  isAllowedMock: vi.fn(() => Promise.resolve(true)),
+  ipKeyMock: vi.fn(() => "ip:1.2.3.4"),
+  acceptQuoteMock: vi.fn(),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+vi.mock("@/lib/rate-limit-db", () => ({ isAllowed: isAllowedMock, ipKey: ipKeyMock }));
+vi.mock("@/lib/expert-teams/fixed-quotes", () => ({ acceptQuote: acceptQuoteMock }));
+
+import { POST } from "@/app/api/fixed-quotes/[token]/accept/route";
+
+const VALID_TOKEN = "a".repeat(32);
+
+function req(): NextRequest {
+  return new NextRequest("http://localhost/api/fixed-quotes/x/accept", {
+    method: "POST",
+    headers: { "x-forwarded-for": "1.2.3.4" },
+  });
+}
+const ctx = (token: string) => ({ params: Promise.resolve({ token }) });
+
+describe("POST /api/fixed-quotes/[token]/accept", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isAllowedMock.mockResolvedValue(true);
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    isAllowedMock.mockResolvedValueOnce(false);
+    const res = await POST(req(), ctx(VALID_TOKEN));
+    expect(res.status).toBe(429);
+    expect(acceptQuoteMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a token that is too short", async () => {
+    const res = await POST(req(), ctx("short"));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid token." });
+    expect(acceptQuoteMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a token that is too long", async () => {
+    const res = await POST(req(), ctx("z".repeat(81)));
+    expect(res.status).toBe(400);
+  });
+
+  it("accepts the quote and returns success", async () => {
+    acceptQuoteMock.mockResolvedValueOnce({ id: 9, brief_id: 3 });
+    const res = await POST(req(), ctx(VALID_TOKEN));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true });
+    expect(acceptQuoteMock).toHaveBeenCalledWith(VALID_TOKEN);
+  });
+
+  it("returns 409 when the quote is no longer acceptable", async () => {
+    acceptQuoteMock.mockResolvedValueOnce(null);
+    const res = await POST(req(), ctx(VALID_TOKEN));
+    expect(res.status).toBe(409);
+    expect((await res.json()).error).toContain("no longer acceptable");
+  });
+
+  it("returns 500 when acceptQuote throws", async () => {
+    acceptQuoteMock.mockRejectedValueOnce(new Error("db down"));
+    const res = await POST(req(), ctx(VALID_TOKEN));
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: "Failed to accept." });
+  });
+});

--- a/__tests__/api/fixed-quotes-decline.test.ts
+++ b/__tests__/api/fixed-quotes-decline.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { isAllowedMock, ipKeyMock, declineQuoteMock } = vi.hoisted(() => ({
+  isAllowedMock: vi.fn(() => Promise.resolve(true)),
+  ipKeyMock: vi.fn(() => "ip:1.2.3.4"),
+  declineQuoteMock: vi.fn(),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+vi.mock("@/lib/rate-limit-db", () => ({ isAllowed: isAllowedMock, ipKey: ipKeyMock }));
+vi.mock("@/lib/expert-teams/fixed-quotes", () => ({ declineQuote: declineQuoteMock }));
+
+import { POST } from "@/app/api/fixed-quotes/[token]/decline/route";
+
+const VALID_TOKEN = "b".repeat(32);
+
+function req(body?: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/fixed-quotes/x/decline", {
+    method: "POST",
+    headers: { "x-forwarded-for": "1.2.3.4", "Content-Type": "application/json" },
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  });
+}
+const ctx = (token: string) => ({ params: Promise.resolve({ token }) });
+
+describe("POST /api/fixed-quotes/[token]/decline", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isAllowedMock.mockResolvedValue(true);
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    isAllowedMock.mockResolvedValueOnce(false);
+    const res = await POST(req({ reason: "x" }), ctx(VALID_TOKEN));
+    expect(res.status).toBe(429);
+    expect(declineQuoteMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for an invalid (too short) token", async () => {
+    const res = await POST(req({ reason: "x" }), ctx("short"));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid token." });
+    expect(declineQuoteMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a token that is too long", async () => {
+    const res = await POST(req({ reason: "x" }), ctx("z".repeat(81)));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when the body fails zod validation", async () => {
+    const res = await POST(req({ reason: "x".repeat(501) }), ctx(VALID_TOKEN));
+    expect(res.status).toBe(400);
+    expect(declineQuoteMock).not.toHaveBeenCalled();
+  });
+
+  it("declines with a reason and returns success", async () => {
+    declineQuoteMock.mockResolvedValueOnce({ id: 9, brief_id: 3 });
+    const res = await POST(req({ reason: "too expensive" }), ctx(VALID_TOKEN));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true });
+    expect(declineQuoteMock).toHaveBeenCalledWith(VALID_TOKEN, "too expensive");
+  });
+
+  it("treats a missing/unparseable body as a null reason", async () => {
+    declineQuoteMock.mockResolvedValueOnce({ id: 9, brief_id: 3 });
+    const res = await POST(req(), ctx(VALID_TOKEN));
+    expect(res.status).toBe(200);
+    expect(declineQuoteMock).toHaveBeenCalledWith(VALID_TOKEN, null);
+  });
+
+  it("returns 409 when the quote is no longer declinable", async () => {
+    declineQuoteMock.mockResolvedValueOnce(null);
+    const res = await POST(req({ reason: "x" }), ctx(VALID_TOKEN));
+    expect(res.status).toBe(409);
+    expect((await res.json()).error).toContain("no longer declinable");
+  });
+
+  it("returns 500 when declineQuote throws", async () => {
+    declineQuoteMock.mockRejectedValueOnce(new Error("db down"));
+    const res = await POST(req({ reason: "x" }), ctx(VALID_TOKEN));
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: "Failed to decline." });
+  });
+});

--- a/__tests__/api/notifications-read.test.ts
+++ b/__tests__/api/notifications-read.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { isAllowedMock, ipKeyMock, getUserMock, markReadMock } = vi.hoisted(() => ({
+  isAllowedMock: vi.fn(() => Promise.resolve(true)),
+  ipKeyMock: vi.fn(() => "ip:1.2.3.4"),
+  getUserMock: vi.fn(),
+  markReadMock: vi.fn(),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+vi.mock("@/lib/rate-limit-db", () => ({ isAllowed: isAllowedMock, ipKey: ipKeyMock }));
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({ auth: { getUser: getUserMock } })),
+}));
+vi.mock("@/lib/notifications", () => ({ markRead: markReadMock }));
+
+import { POST } from "@/app/api/notifications/[id]/read/route";
+
+const USER = { id: "user-uuid-1" };
+
+function req(): NextRequest {
+  return new NextRequest("http://localhost/api/notifications/7/read", {
+    method: "POST",
+    headers: { "x-forwarded-for": "1.2.3.4" },
+  });
+}
+const ctx = (id: string) => ({ params: Promise.resolve({ id }) });
+
+describe("POST /api/notifications/[id]/read", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isAllowedMock.mockResolvedValue(true);
+    getUserMock.mockResolvedValue({ data: { user: USER } });
+    markReadMock.mockResolvedValue(undefined);
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    isAllowedMock.mockResolvedValueOnce(false);
+    const res = await POST(req(), ctx("7"));
+    expect(res.status).toBe(429);
+    expect(getUserMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    getUserMock.mockResolvedValueOnce({ data: { user: null } });
+    const res = await POST(req(), ctx("7"));
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "Unauthorized" });
+    expect(markReadMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a non-numeric id", async () => {
+    const res = await POST(req(), ctx("abc"));
+    expect(res.status).toBe(400);
+    expect(markReadMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a non-positive id", async () => {
+    const res = await POST(req(), ctx("0"));
+    expect(res.status).toBe(400);
+  });
+
+  it("marks the notification read scoped to the user", async () => {
+    const res = await POST(req(), ctx("7"));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(markReadMock).toHaveBeenCalledWith(USER.id, 7);
+  });
+
+  it("returns 500 when markRead throws", async () => {
+    markReadMock.mockRejectedValueOnce(new Error("db down"));
+    const res = await POST(req(), ctx("7"));
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: "internal" });
+  });
+});

--- a/__tests__/api/referrals-accept.test.ts
+++ b/__tests__/api/referrals-accept.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Mocks (all fns via vi.hoisted so the vi.mock factories can reference them) ──
+const {
+  isAllowedMock,
+  ipKeyMock,
+  requireAdvisorSessionMock,
+  acceptReferralMock,
+  ReferralError,
+} = vi.hoisted(() => {
+  class ReferralError extends Error {
+    constructor(public code: string, message?: string) {
+      super(message ?? code);
+      this.name = "ReferralError";
+    }
+  }
+  return {
+    isAllowedMock: vi.fn(() => Promise.resolve(true)),
+    ipKeyMock: vi.fn(() => "ip:1.2.3.4"),
+    requireAdvisorSessionMock: vi.fn(() => Promise.resolve(42)),
+    acceptReferralMock: vi.fn(),
+    ReferralError,
+  };
+});
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+vi.mock("@/lib/rate-limit-db", () => ({ isAllowed: isAllowedMock, ipKey: ipKeyMock }));
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: requireAdvisorSessionMock,
+}));
+vi.mock("@/lib/team-brief-referrals", () => ({
+  acceptReferral: acceptReferralMock,
+  ReferralError,
+}));
+
+import { POST } from "@/app/api/referrals/[id]/accept/route";
+
+function req(): NextRequest {
+  return new NextRequest("http://localhost/api/referrals/5/accept", {
+    method: "POST",
+    headers: { "x-forwarded-for": "1.2.3.4" },
+  });
+}
+const ctx = (id: string) => ({ params: Promise.resolve({ id }) });
+
+describe("POST /api/referrals/[id]/accept", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isAllowedMock.mockResolvedValue(true);
+    requireAdvisorSessionMock.mockResolvedValue(42);
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    isAllowedMock.mockResolvedValueOnce(false);
+    const res = await POST(req(), ctx("5"));
+    expect(res.status).toBe(429);
+    expect(requireAdvisorSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when there is no advisor session", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(null);
+    const res = await POST(req(), ctx("5"));
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "Sign in required." });
+  });
+
+  it("returns 400 for a non-numeric id", async () => {
+    const res = await POST(req(), ctx("abc"));
+    expect(res.status).toBe(400);
+    expect(acceptReferralMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a non-positive id", async () => {
+    const res = await POST(req(), ctx("0"));
+    expect(res.status).toBe(400);
+  });
+
+  it("accepts the referral and returns it", async () => {
+    const referral = { id: 5, status: "accepted" };
+    acceptReferralMock.mockResolvedValueOnce(referral);
+    const res = await POST(req(), ctx("5"));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ referral });
+    expect(acceptReferralMock).toHaveBeenCalledWith(5, 42);
+  });
+
+  it("maps referral_not_found to 404", async () => {
+    acceptReferralMock.mockRejectedValueOnce(new ReferralError("referral_not_found"));
+    const res = await POST(req(), ctx("5"));
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "referral_not_found" });
+  });
+
+  it("maps not_team_member to 403", async () => {
+    acceptReferralMock.mockRejectedValueOnce(new ReferralError("not_team_member"));
+    const res = await POST(req(), ctx("5"));
+    expect(res.status).toBe(403);
+  });
+
+  it("maps referral_not_pending to 409", async () => {
+    acceptReferralMock.mockRejectedValueOnce(new ReferralError("referral_not_pending"));
+    const res = await POST(req(), ctx("5"));
+    expect(res.status).toBe(409);
+  });
+
+  it("maps brief_already_accepted to 409", async () => {
+    acceptReferralMock.mockRejectedValueOnce(new ReferralError("brief_already_accepted"));
+    const res = await POST(req(), ctx("5"));
+    expect(res.status).toBe(409);
+  });
+
+  it("maps an unknown ReferralError code to 500", async () => {
+    acceptReferralMock.mockRejectedValueOnce(new ReferralError("weird"));
+    const res = await POST(req(), ctx("5"));
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: "weird" });
+  });
+
+  it("returns 500 when a non-ReferralError is thrown", async () => {
+    acceptReferralMock.mockRejectedValueOnce(new Error("db down"));
+    const res = await POST(req(), ctx("5"));
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: "Failed to accept referral." });
+  });
+});

--- a/__tests__/api/referrals-decline.test.ts
+++ b/__tests__/api/referrals-decline.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const {
+  isAllowedMock,
+  ipKeyMock,
+  requireAdvisorSessionMock,
+  declineReferralMock,
+  ReferralError,
+} = vi.hoisted(() => {
+  class ReferralError extends Error {
+    constructor(public code: string, message?: string) {
+      super(message ?? code);
+      this.name = "ReferralError";
+    }
+  }
+  return {
+    isAllowedMock: vi.fn(() => Promise.resolve(true)),
+    ipKeyMock: vi.fn(() => "ip:1.2.3.4"),
+    requireAdvisorSessionMock: vi.fn(() => Promise.resolve(42)),
+    declineReferralMock: vi.fn(),
+    ReferralError,
+  };
+});
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+vi.mock("@/lib/rate-limit-db", () => ({ isAllowed: isAllowedMock, ipKey: ipKeyMock }));
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: requireAdvisorSessionMock,
+}));
+vi.mock("@/lib/team-brief-referrals", () => ({
+  declineReferral: declineReferralMock,
+  ReferralError,
+}));
+
+import { POST } from "@/app/api/referrals/[id]/decline/route";
+
+function req(): NextRequest {
+  return new NextRequest("http://localhost/api/referrals/5/decline", {
+    method: "POST",
+    headers: { "x-forwarded-for": "1.2.3.4" },
+  });
+}
+const ctx = (id: string) => ({ params: Promise.resolve({ id }) });
+
+describe("POST /api/referrals/[id]/decline", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isAllowedMock.mockResolvedValue(true);
+    requireAdvisorSessionMock.mockResolvedValue(42);
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    isAllowedMock.mockResolvedValueOnce(false);
+    const res = await POST(req(), ctx("5"));
+    expect(res.status).toBe(429);
+    expect(requireAdvisorSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when there is no advisor session", async () => {
+    requireAdvisorSessionMock.mockResolvedValueOnce(null);
+    const res = await POST(req(), ctx("5"));
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "Sign in required." });
+  });
+
+  it("returns 400 for a non-numeric id", async () => {
+    const res = await POST(req(), ctx("nope"));
+    expect(res.status).toBe(400);
+    expect(declineReferralMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a non-positive id", async () => {
+    const res = await POST(req(), ctx("-3"));
+    expect(res.status).toBe(400);
+  });
+
+  it("declines the referral and returns it", async () => {
+    const referral = { id: 5, status: "declined" };
+    declineReferralMock.mockResolvedValueOnce(referral);
+    const res = await POST(req(), ctx("5"));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ referral });
+    expect(declineReferralMock).toHaveBeenCalledWith(5, 42);
+  });
+
+  it("maps referral_not_found to 404", async () => {
+    declineReferralMock.mockRejectedValueOnce(new ReferralError("referral_not_found"));
+    const res = await POST(req(), ctx("5"));
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "referral_not_found" });
+  });
+
+  it("maps not_team_member to 403", async () => {
+    declineReferralMock.mockRejectedValueOnce(new ReferralError("not_team_member"));
+    const res = await POST(req(), ctx("5"));
+    expect(res.status).toBe(403);
+  });
+
+  it("maps referral_not_pending to 409", async () => {
+    declineReferralMock.mockRejectedValueOnce(new ReferralError("referral_not_pending"));
+    const res = await POST(req(), ctx("5"));
+    expect(res.status).toBe(409);
+  });
+
+  it("maps an unknown ReferralError code to 500", async () => {
+    declineReferralMock.mockRejectedValueOnce(new ReferralError("weird"));
+    const res = await POST(req(), ctx("5"));
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: "weird" });
+  });
+
+  it("returns 500 when a non-ReferralError is thrown", async () => {
+    declineReferralMock.mockRejectedValueOnce(new Error("db down"));
+    const res = await POST(req(), ctx("5"));
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: "Failed to decline referral." });
+  });
+});


### PR DESCRIPTION
## Summary
Unit tests for 5 untested routes: `referrals/[id]/accept`+`decline`, `fixed-quotes/[token]/accept`+`decline`, `notifications/[id]/read`. 41 tests: rate-limit, auth/token gating, zod, happy, ReferralError mapping (404/403/409/500), null-return 409, 500.

## Queue item
D-COV pre-launch coverage push. Moves M02 (57→200).

## Supersedes
_None._

## Test plan
- [x] vitest 41/41 local
- [ ] CI green