### PR TITLE
fix(security): wire portal-gate isolation to business portal (§5 #14)

### DIFF
--- a/app/business-portal/layout.tsx
+++ b/app/business-portal/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { requireBusinessSession } from "@/lib/require-business-session";
+import { enforcePortalKind } from "@/lib/portal-gate";
 
 export const dynamic = "force-dynamic";
 
@@ -12,17 +13,22 @@ export const metadata: Metadata = {
 
 /**
  * Gate every /business-portal/* route on:
- *   1. Authenticated user (else → /account/login)
- *   2. Active or pending business_accounts row (else → /account/upgrade/business)
- *
- * Per-portal active-kind enforcement (the "strict separation" workspace
- * promise) lands in a separate PR; for now, just check membership here.
+ *   1. Workspace-kind isolation (enforcePortalKind) — a multi-kind user must
+ *      deliberately switch into the business workspace; this prevents reaching
+ *      the business portal while active in another kind (audit §5 #14).
+ *   2. Authenticated user (else → /account/login)
+ *   3. Active or pending business_accounts row (else → /account/upgrade/business)
  */
 export default async function BusinessPortalLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  // Workspace-isolation gate (matches the advisor portal). Redirects an
+  // unauthenticated user to login and a user not in the business workspace to
+  // the chooser, before any business data is loaded.
+  await enforcePortalKind("business_owner");
+
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) {


### PR DESCRIPTION
Closes new-features audit §5 flag #14 (business portal).

enforcePortalKind workspace isolation was only wired to the advisor portal; the business portal had an explicit 'lands in a separate PR' TODO and relied on per-route membership checks alone, so a multi-kind user could reach /business-portal without the deliberate workspace-switch guard. Adds enforcePortalKind('business_owner') to the layout (mirrors advisor), before any business data loads; requireBusinessSession retained as defence-in-depth.

Surfaced for separate decisions (in the green-loop queue): firm portal routes via advisor+is_firm_admin (no separate kind yet — product call); broker portal layout is a client component needing a server-wrapper refactor.

Tier C (portal/auth) — your merge.

Generated with Claude Code