### PR TITLE
test(d): add unit tests for account-docs/listings/saved routes

### DIFF
--- a/__tests__/api/account-documents-id.test.ts
+++ b/__tests__/api/account-documents-id.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockGetUser, mockFrom, mockStorageFrom, mockStorageRemove } = vi.hoisted(() => ({
+  mockGetUser: vi.fn(),
+  mockFrom: vi.fn(),
+  mockStorageFrom: vi.fn(),
+  mockStorageRemove: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({
+    auth: { getUser: mockGetUser },
+    from: mockFrom,
+    storage: { from: mockStorageFrom },
+  })),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import { DELETE } from "@/app/api/account/documents/[id]/route";
+
+const USER = { id: "user-uuid-1", email: "alice@example.com" };
+const DOC_ID = "doc-uuid-1";
+
+function makeReq(): NextRequest {
+  return new NextRequest(`http://localhost/api/account/documents/${DOC_ID}`, { method: "DELETE" });
+}
+
+const ctx = (id: string) => ({ params: Promise.resolve({ id }) });
+
+// fetch chain: from().select().eq().maybeSingle()
+function makeFetchChain(result: { data: unknown; error: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  chain.select = vi.fn(() => chain);
+  chain.eq = vi.fn(() => chain);
+  chain.maybeSingle = vi.fn(() => Promise.resolve(result));
+  return chain;
+}
+
+// db delete chain: from().delete().eq() — terminal .eq()
+function makeDeleteChain(result: { error: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  chain.delete = vi.fn(() => chain);
+  chain.eq = vi.fn(() => Promise.resolve(result));
+  return chain;
+}
+
+describe("DELETE /api/account/documents/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockStorageFrom.mockReturnValue({ remove: mockStorageRemove });
+    mockStorageRemove.mockResolvedValue({ error: null });
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: null } });
+    const res = await DELETE(makeReq(), ctx(DOC_ID));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 500 when the metadata fetch errors", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    mockFrom.mockReturnValueOnce(makeFetchChain({ data: null, error: { message: "boom" } }));
+    const res = await DELETE(makeReq(), ctx(DOC_ID));
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 404 when the document does not exist (or not owned)", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    mockFrom.mockReturnValueOnce(makeFetchChain({ data: null, error: null }));
+    const res = await DELETE(makeReq(), ctx(DOC_ID));
+    expect(res.status).toBe(404);
+  });
+
+  it("deletes storage file and DB row, returns ok", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    mockFrom
+      .mockReturnValueOnce(makeFetchChain({ data: { id: DOC_ID, file_path: "u/d/f.pdf" }, error: null }))
+      .mockReturnValueOnce(makeDeleteChain({ error: null }));
+    const res = await DELETE(makeReq(), ctx(DOC_ID));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(mockStorageRemove).toHaveBeenCalledWith(["u/d/f.pdf"]);
+  });
+
+  it("proceeds with DB delete even when storage removal fails", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    mockStorageRemove.mockResolvedValueOnce({ error: { message: "storage gone" } });
+    const dbChain = makeDeleteChain({ error: null });
+    mockFrom
+      .mockReturnValueOnce(makeFetchChain({ data: { id: DOC_ID, file_path: "u/d/f.pdf" }, error: null }))
+      .mockReturnValueOnce(dbChain);
+    const res = await DELETE(makeReq(), ctx(DOC_ID));
+    expect(res.status).toBe(200);
+    expect(dbChain.delete).toHaveBeenCalled();
+  });
+
+  it("returns 500 when the DB delete errors", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    mockFrom
+      .mockReturnValueOnce(makeFetchChain({ data: { id: DOC_ID, file_path: "u/d/f.pdf" }, error: null }))
+      .mockReturnValueOnce(makeDeleteChain({ error: { message: "boom" } }));
+    const res = await DELETE(makeReq(), ctx(DOC_ID));
+    expect(res.status).toBe(500);
+  });
+});

--- a/__tests__/api/account-documents-upload.test.ts
+++ b/__tests__/api/account-documents-upload.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockGetUser, mockFrom, mockStorageFrom, mockStorageUpload, mockStorageRemove, mockIsAllowed } =
+  vi.hoisted(() => ({
+    mockGetUser: vi.fn(),
+    mockFrom: vi.fn(),
+    mockStorageFrom: vi.fn(),
+    mockStorageUpload: vi.fn(),
+    mockStorageRemove: vi.fn(),
+    mockIsAllowed: vi.fn(),
+  }));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({
+    auth: { getUser: mockGetUser },
+    from: mockFrom,
+    storage: { from: mockStorageFrom },
+  })),
+}));
+
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: mockIsAllowed,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import { POST } from "@/app/api/account/documents/upload/route";
+
+const USER = { id: "user-uuid-1", email: "alice@example.com" };
+
+// POST insert chain: from().insert().select().single()
+function makeInsertChain(result: { data: unknown; error: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  chain.insert = vi.fn(() => chain);
+  chain.select = vi.fn(() => chain);
+  chain.single = vi.fn(() => Promise.resolve(result));
+  return chain;
+}
+
+function makeFile(content: string, type: string, name = "statement.pdf"): File {
+  return new File([content], name, { type });
+}
+
+function makeReq(form: FormData): NextRequest {
+  return new NextRequest("http://localhost/api/account/documents/upload", {
+    method: "POST",
+    body: form,
+  });
+}
+
+function buildForm(opts: {
+  file?: File | string;
+  document_type?: string;
+  description?: string;
+}): FormData {
+  const form = new FormData();
+  if (opts.file !== undefined) {
+    if (typeof opts.file === "string") form.set("file", opts.file);
+    else form.set("file", opts.file);
+  }
+  if (opts.document_type !== undefined) form.set("document_type", opts.document_type);
+  if (opts.description !== undefined) form.set("description", opts.description);
+  return form;
+}
+
+describe("POST /api/account/documents/upload", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowed.mockResolvedValue(true);
+    mockStorageFrom.mockReturnValue({ upload: mockStorageUpload, remove: mockStorageRemove });
+    mockStorageUpload.mockResolvedValue({ error: null });
+    mockStorageRemove.mockResolvedValue({ error: null });
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: null } });
+    const res = await POST(makeReq(buildForm({ file: makeFile("pdf", "application/pdf"), document_type: "tax_return" })));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 429 when the rate limit is exceeded", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    mockIsAllowed.mockResolvedValueOnce(false);
+    const res = await POST(makeReq(buildForm({ file: makeFile("pdf", "application/pdf"), document_type: "tax_return" })));
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 400 when no file is provided", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    const res = await POST(makeReq(buildForm({ document_type: "tax_return" })));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "No file provided" });
+  });
+
+  it("returns 400 for an invalid document_type", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    const res = await POST(
+      makeReq(buildForm({ file: makeFile("pdf", "application/pdf"), document_type: "passport" })),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when the description is too long", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    const res = await POST(
+      makeReq(
+        buildForm({
+          file: makeFile("pdf", "application/pdf"),
+          document_type: "tax_return",
+          description: "x".repeat(501),
+        }),
+      ),
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Description too long (max 500 chars)" });
+  });
+
+  it("returns 400 for an unsupported mime type", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    const res = await POST(
+      makeReq(buildForm({ file: makeFile("doc", "application/msword", "x.doc"), document_type: "tax_return" })),
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ error: expect.stringContaining("Unsupported file type") });
+  });
+
+  it("returns 400 when the file exceeds the size limit", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    // Report an oversized size without allocating 20+ MB. We stub formData()
+    // directly because a real multipart round-trip reconstructs the File from
+    // its (small) byte content, discarding a `size` override.
+    const big = makeFile("x", "application/pdf", "big.pdf");
+    Object.defineProperty(big, "size", { value: 21 * 1024 * 1024, configurable: true });
+    const form = new FormData();
+    form.set("file", big);
+    form.set("document_type", "tax_return");
+    const req = makeReq(form);
+    vi.spyOn(req, "formData").mockResolvedValue(form);
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "File too large. Maximum size is 20 MB." });
+  });
+
+  it("returns 500 when the storage upload fails", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    mockStorageUpload.mockResolvedValueOnce({ error: { message: "storage down" } });
+    const res = await POST(
+      makeReq(buildForm({ file: makeFile("pdf", "application/pdf"), document_type: "tax_return" })),
+    );
+    expect(res.status).toBe(500);
+  });
+
+  it("cleans up storage and returns 500 when the DB insert fails", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    mockFrom.mockReturnValueOnce(makeInsertChain({ data: null, error: { message: "db down" } }));
+    const res = await POST(
+      makeReq(buildForm({ file: makeFile("pdf", "application/pdf"), document_type: "tax_return" })),
+    );
+    expect(res.status).toBe(500);
+    expect(mockStorageRemove).toHaveBeenCalled();
+  });
+
+  it("uploads the file, inserts metadata, and returns 201 with the id", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    const chain = makeInsertChain({ data: { id: "new-doc-id" }, error: null });
+    mockFrom.mockReturnValueOnce(chain);
+    const res = await POST(
+      makeReq(
+        buildForm({
+          file: makeFile("pdf-content", "image/png", "scan.png"),
+          document_type: "super_statement",
+          description: "Q1 super",
+        }),
+      ),
+    );
+    expect(res.status).toBe(201);
+    expect(await res.json()).toEqual({ id: "new-doc-id" });
+    expect(mockStorageUpload).toHaveBeenCalledOnce();
+    const insertArg = chain.insert.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(insertArg).toMatchObject({
+      user_id: USER.id,
+      document_type: "super_statement",
+      mime_type: "image/png",
+      description: "Q1 super",
+    });
+  });
+
+  it("returns 400 when the multipart body cannot be parsed", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    const req = new NextRequest("http://localhost/api/account/documents/upload", {
+      method: "POST",
+      headers: { "Content-Type": "multipart/form-data; boundary=----x" },
+      body: "not actually multipart",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid multipart body" });
+  });
+});

--- a/__tests__/api/intake-questions-id.test.ts
+++ b/__tests__/api/intake-questions-id.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const {
+  mockIsAllowed,
+  mockIpKey,
+  mockRequireAdvisorSession,
+  mockGetQuestionById,
+  mockIsOwner,
+  mockRemoveQuestion,
+  mockUpsertQuestion,
+  IntakeError,
+} = vi.hoisted(() => {
+  class IntakeErrorCls extends Error {
+    status: number;
+    constructor(message: string, status: number) {
+      super(message);
+      this.name = "IntakeError";
+      this.status = status;
+    }
+  }
+  return {
+    mockIsAllowed: vi.fn(),
+    mockIpKey: vi.fn(() => "ip:1.2.3.4"),
+    mockRequireAdvisorSession: vi.fn(),
+    mockGetQuestionById: vi.fn(),
+    mockIsOwner: vi.fn(),
+    mockRemoveQuestion: vi.fn(),
+    mockUpsertQuestion: vi.fn(),
+    IntakeError: IntakeErrorCls,
+  };
+});
+
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: mockIsAllowed,
+  ipKey: mockIpKey,
+}));
+
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: mockRequireAdvisorSession,
+}));
+
+vi.mock("@/lib/pro-intake", () => ({
+  IntakeError,
+  getQuestionById: mockGetQuestionById,
+  isOwner: mockIsOwner,
+  removeQuestion: mockRemoveQuestion,
+  upsertQuestion: mockUpsertQuestion,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import { PATCH, DELETE } from "@/app/api/intake/questions/[id]/route";
+
+const ADVISOR_ID = 42;
+const EXISTING = {
+  id: 5,
+  owner_kind: "professional" as const,
+  professional_id: ADVISOR_ID,
+  team_id: null,
+  prompt: "Old prompt",
+  kind: "text" as const,
+  options: [],
+  required: true,
+  sort_order: 0,
+  enabled: true,
+};
+
+const VALID_BODY = {
+  prompt: "What is your time horizon?",
+  kind: "text",
+  options: [],
+  required: true,
+  sort_order: 1,
+  enabled: true,
+};
+
+function makeReq(method: string, body?: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/intake/questions/5", {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+const ctx = (id: string) => ({ params: Promise.resolve({ id }) });
+
+describe("PATCH /api/intake/questions/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowed.mockResolvedValue(true);
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockIsAllowed.mockResolvedValueOnce(false);
+    const res = await PATCH(makeReq("PATCH", VALID_BODY), ctx("5"));
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 401 when no advisor session", async () => {
+    mockRequireAdvisorSession.mockResolvedValueOnce(null);
+    const res = await PATCH(makeReq("PATCH", VALID_BODY), ctx("5"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for an invalid id", async () => {
+    mockRequireAdvisorSession.mockResolvedValueOnce(ADVISOR_ID);
+    const res = await PATCH(makeReq("PATCH", VALID_BODY), ctx("abc"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when the question does not exist", async () => {
+    mockRequireAdvisorSession.mockResolvedValueOnce(ADVISOR_ID);
+    mockGetQuestionById.mockResolvedValueOnce(null);
+    const res = await PATCH(makeReq("PATCH", VALID_BODY), ctx("5"));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when the advisor does not own the question", async () => {
+    mockRequireAdvisorSession.mockResolvedValueOnce(ADVISOR_ID);
+    mockGetQuestionById.mockResolvedValueOnce(EXISTING);
+    mockIsOwner.mockResolvedValueOnce(false);
+    const res = await PATCH(makeReq("PATCH", VALID_BODY), ctx("5"));
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 for invalid JSON", async () => {
+    mockRequireAdvisorSession.mockResolvedValueOnce(ADVISOR_ID);
+    mockGetQuestionById.mockResolvedValueOnce(EXISTING);
+    mockIsOwner.mockResolvedValueOnce(true);
+    const req = new NextRequest("http://localhost/api/intake/questions/5", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: "{bad",
+    });
+    const res = await PATCH(req, ctx("5"));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid JSON body." });
+  });
+
+  it("returns 400 for a body that fails validation", async () => {
+    mockRequireAdvisorSession.mockResolvedValueOnce(ADVISOR_ID);
+    mockGetQuestionById.mockResolvedValueOnce(EXISTING);
+    mockIsOwner.mockResolvedValueOnce(true);
+    const res = await PATCH(makeReq("PATCH", { prompt: "no" }), ctx("5"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 500 when the team owner id is missing", async () => {
+    mockRequireAdvisorSession.mockResolvedValueOnce(ADVISOR_ID);
+    mockGetQuestionById.mockResolvedValueOnce({
+      ...EXISTING,
+      owner_kind: "team",
+      professional_id: null,
+      team_id: null,
+    });
+    mockIsOwner.mockResolvedValueOnce(true);
+    const res = await PATCH(makeReq("PATCH", VALID_BODY), ctx("5"));
+    expect(res.status).toBe(500);
+  });
+
+  it("updates the question and returns it", async () => {
+    mockRequireAdvisorSession.mockResolvedValueOnce(ADVISOR_ID);
+    mockGetQuestionById.mockResolvedValueOnce(EXISTING);
+    mockIsOwner.mockResolvedValueOnce(true);
+    const updated = { ...EXISTING, prompt: VALID_BODY.prompt };
+    mockUpsertQuestion.mockResolvedValueOnce(updated);
+    const res = await PATCH(makeReq("PATCH", VALID_BODY), ctx("5"));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ question: updated });
+    expect(mockUpsertQuestion).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 5, owner_id: ADVISOR_ID, acting_professional_id: ADVISOR_ID }),
+    );
+  });
+
+  it("maps IntakeError to its status", async () => {
+    mockRequireAdvisorSession.mockResolvedValueOnce(ADVISOR_ID);
+    mockGetQuestionById.mockResolvedValueOnce(EXISTING);
+    mockIsOwner.mockResolvedValueOnce(true);
+    mockUpsertQuestion.mockRejectedValueOnce(new IntakeError("Limit reached", 409));
+    const res = await PATCH(makeReq("PATCH", VALID_BODY), ctx("5"));
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({ error: "Limit reached" });
+  });
+
+  it("returns 500 on an unexpected error", async () => {
+    mockRequireAdvisorSession.mockResolvedValueOnce(ADVISOR_ID);
+    mockGetQuestionById.mockResolvedValueOnce(EXISTING);
+    mockIsOwner.mockResolvedValueOnce(true);
+    mockUpsertQuestion.mockRejectedValueOnce(new Error("db down"));
+    const res = await PATCH(makeReq("PATCH", VALID_BODY), ctx("5"));
+    expect(res.status).toBe(500);
+  });
+});
+
+describe("DELETE /api/intake/questions/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowed.mockResolvedValue(true);
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockIsAllowed.mockResolvedValueOnce(false);
+    const res = await DELETE(makeReq("DELETE"), ctx("5"));
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 401 when no advisor session", async () => {
+    mockRequireAdvisorSession.mockResolvedValueOnce(null);
+    const res = await DELETE(makeReq("DELETE"), ctx("5"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for an invalid id", async () => {
+    mockRequireAdvisorSession.mockResolvedValueOnce(ADVISOR_ID);
+    const res = await DELETE(makeReq("DELETE"), ctx("0"));
+    expect(res.status).toBe(400);
+  });
+
+  it("removes the question and returns ok", async () => {
+    mockRequireAdvisorSession.mockResolvedValueOnce(ADVISOR_ID);
+    mockRemoveQuestion.mockResolvedValueOnce(undefined);
+    const res = await DELETE(makeReq("DELETE"), ctx("5"));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(mockRemoveQuestion).toHaveBeenCalledWith(5, ADVISOR_ID);
+  });
+
+  it("maps IntakeError to its status", async () => {
+    mockRequireAdvisorSession.mockResolvedValueOnce(ADVISOR_ID);
+    mockRemoveQuestion.mockRejectedValueOnce(new IntakeError("Not authorised.", 403));
+    const res = await DELETE(makeReq("DELETE"), ctx("5"));
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 500 on an unexpected error", async () => {
+    mockRequireAdvisorSession.mockResolvedValueOnce(ADVISOR_ID);
+    mockRemoveQuestion.mockRejectedValueOnce(new Error("db down"));
+    const res = await DELETE(makeReq("DELETE"), ctx("5"));
+    expect(res.status).toBe(500);
+  });
+});

--- a/__tests__/api/listings-owner-flow-id.test.ts
+++ b/__tests__/api/listings-owner-flow-id.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockGetUser, mockIsAllowed, mockIpKey, mockAdminFrom, mockRowToListing } = vi.hoisted(() => ({
+  mockGetUser: vi.fn(),
+  mockIsAllowed: vi.fn(),
+  mockIpKey: vi.fn(() => "ip:1.2.3.4"),
+  mockAdminFrom: vi.fn(),
+  mockRowToListing: vi.fn((row: { id: string }) => ({ id: row.id, mapped: true })),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({
+    auth: { getUser: mockGetUser },
+  })),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: mockIsAllowed,
+  ipKey: mockIpKey,
+}));
+
+vi.mock("@/lib/listings/types", () => ({
+  LISTING_KINDS: ["property", "business", "syndicate", "asset_other"],
+  rowToListing: mockRowToListing,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import { PATCH } from "@/app/api/listings/owner-flow/[id]/route";
+
+const USER = { id: "owner-uuid-1", email: "alice@example.com" };
+const LISTING_ID = "list-uuid-1";
+
+function makeReq(body?: unknown): NextRequest {
+  return new NextRequest(`http://localhost/api/listings/owner-flow/${LISTING_ID}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+const ctx = (id: string) => ({ params: Promise.resolve({ id }) });
+
+// fetch chain: from().select().eq().maybeSingle()
+function makeFetchChain(result: { data: unknown; error: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  chain.select = vi.fn(() => chain);
+  chain.eq = vi.fn(() => chain);
+  chain.maybeSingle = vi.fn(() => Promise.resolve(result));
+  return chain;
+}
+
+// update chain: from().update().eq().select().single()
+function makeUpdateChain(result: { data: unknown; error: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  chain.update = vi.fn(() => chain);
+  chain.eq = vi.fn(() => chain);
+  chain.select = vi.fn(() => chain);
+  chain.single = vi.fn(() => Promise.resolve(result));
+  return chain;
+}
+
+const DRAFT = { id: LISTING_ID, owner_user_id: USER.id, status: "draft" };
+
+describe("PATCH /api/listings/owner-flow/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowed.mockResolvedValue(true);
+    mockRowToListing.mockImplementation((row: { id: string }) => ({ id: row.id, mapped: true }));
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockIsAllowed.mockResolvedValueOnce(false);
+    const res = await PATCH(makeReq({ title: "New title" }), ctx(LISTING_ID));
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 400 for invalid JSON", async () => {
+    const req = new NextRequest(`http://localhost/api/listings/owner-flow/${LISTING_ID}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: "{bad",
+    });
+    const res = await PATCH(req, ctx(LISTING_ID));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid JSON body" });
+  });
+
+  it("returns 400 for a body that fails validation", async () => {
+    const res = await PATCH(makeReq({ title: "no" }), ctx(LISTING_ID));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for an unknown (strict) field", async () => {
+    const res = await PATCH(makeReq({ bogus: true }), ctx(LISTING_ID));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: null } });
+    const res = await PATCH(makeReq({ title: "New title" }), ctx(LISTING_ID));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 500 when the fetch errors", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    mockAdminFrom.mockReturnValueOnce(makeFetchChain({ data: null, error: { message: "boom" } }));
+    const res = await PATCH(makeReq({ title: "New title" }), ctx(LISTING_ID));
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 404 when the listing is not found", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    mockAdminFrom.mockReturnValueOnce(makeFetchChain({ data: null, error: null }));
+    const res = await PATCH(makeReq({ title: "New title" }), ctx(LISTING_ID));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when the caller is not the owner", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    mockAdminFrom.mockReturnValueOnce(
+      makeFetchChain({ data: { ...DRAFT, owner_user_id: "someone-else" }, error: null }),
+    );
+    const res = await PATCH(makeReq({ title: "New title" }), ctx(LISTING_ID));
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 409 when the listing is not a draft", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    mockAdminFrom.mockReturnValueOnce(
+      makeFetchChain({ data: { ...DRAFT, status: "approved" }, error: null }),
+    );
+    const res = await PATCH(makeReq({ title: "New title" }), ctx(LISTING_ID));
+    expect(res.status).toBe(409);
+  });
+
+  it("returns 400 when no updatable fields are provided", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    mockAdminFrom.mockReturnValueOnce(makeFetchChain({ data: DRAFT, error: null }));
+    const res = await PATCH(makeReq({}), ctx(LISTING_ID));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "No fields to update." });
+  });
+
+  it("returns 500 when the update errors", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    mockAdminFrom
+      .mockReturnValueOnce(makeFetchChain({ data: DRAFT, error: null }))
+      .mockReturnValueOnce(makeUpdateChain({ data: null, error: { message: "boom" } }));
+    const res = await PATCH(makeReq({ title: "New title" }), ctx(LISTING_ID));
+    expect(res.status).toBe(500);
+  });
+
+  it("updates the draft and returns the mapped listing", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    const updatedRow = { ...DRAFT, title: "New title" };
+    const updateChain = makeUpdateChain({ data: updatedRow, error: null });
+    mockAdminFrom
+      .mockReturnValueOnce(makeFetchChain({ data: DRAFT, error: null }))
+      .mockReturnValueOnce(updateChain);
+    const res = await PATCH(
+      makeReq({ title: "  New title  ", currency: "aud", asking_price_cents: 1000 }),
+      ctx(LISTING_ID),
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, listing: { id: LISTING_ID, mapped: true } });
+    const updateArg = updateChain.update.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(updateArg.title).toBe("New title");
+    expect(updateArg.currency).toBe("AUD");
+    expect(updateArg.asking_price_cents).toBe(1000);
+    expect(updateArg.updated_at).toEqual(expect.any(String));
+  });
+});

--- a/__tests__/api/listings-owner-flow-submit.test.ts
+++ b/__tests__/api/listings-owner-flow-submit.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockGetUser, mockIsAllowed, mockIpKey, mockSubmit } = vi.hoisted(() => ({
+  mockGetUser: vi.fn(),
+  mockIsAllowed: vi.fn(),
+  mockIpKey: vi.fn(() => "ip:1.2.3.4"),
+  mockSubmit: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({
+    auth: { getUser: mockGetUser },
+  })),
+}));
+
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: mockIsAllowed,
+  ipKey: mockIpKey,
+}));
+
+vi.mock("@/lib/listings/moderate", () => ({
+  submitListingForReview: mockSubmit,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import { POST } from "@/app/api/listings/owner-flow/[id]/submit/route";
+
+const USER = { id: "user-uuid-1", email: "alice@example.com" };
+const LISTING_ID = "list-uuid-1";
+
+function makeReq(body?: unknown): NextRequest {
+  const init: { method: string; headers: Record<string, string>; body?: string } = {
+    method: "POST",
+    headers: {},
+  };
+  if (body !== undefined) {
+    init.headers["Content-Type"] = "application/json";
+    init.body = JSON.stringify(body);
+  }
+  return new NextRequest(`http://localhost/api/listings/owner-flow/${LISTING_ID}/submit`, init);
+}
+
+const ctx = (id: string) => ({ params: Promise.resolve({ id }) });
+
+describe("POST /api/listings/owner-flow/[id]/submit", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowed.mockResolvedValue(true);
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockIsAllowed.mockResolvedValueOnce(false);
+    const res = await POST(makeReq(), ctx(LISTING_ID));
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 400 when a non-empty body is sent", async () => {
+    const payload = JSON.stringify({ status: "approved" });
+    const req = new NextRequest(`http://localhost/api/listings/owner-flow/${LISTING_ID}/submit`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "content-length": String(payload.length) },
+      body: payload,
+    });
+    const res = await POST(req, ctx(LISTING_ID));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Submit takes no body fields." });
+  });
+
+  it("returns 400 for invalid JSON", async () => {
+    const req = new NextRequest(`http://localhost/api/listings/owner-flow/${LISTING_ID}/submit`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "content-length": "5" },
+      body: "{bad",
+    });
+    const res = await POST(req, ctx(LISTING_ID));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid JSON body" });
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: null } });
+    const res = await POST(makeReq(), ctx(LISTING_ID));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when the listing is not found", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    mockSubmit.mockResolvedValueOnce({ ok: false, error: "not_found" });
+    const res = await POST(makeReq(), ctx(LISTING_ID));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when forbidden", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    mockSubmit.mockResolvedValueOnce({ ok: false, error: "forbidden" });
+    const res = await POST(makeReq(), ctx(LISTING_ID));
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 409 for a bad lifecycle transition", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    mockSubmit.mockResolvedValueOnce({ ok: false, error: "cannot_submit_from_approved" });
+    const res = await POST(makeReq(), ctx(LISTING_ID));
+    expect(res.status).toBe(409);
+  });
+
+  it("returns 500 for an unexpected failure", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    mockSubmit.mockResolvedValueOnce({ ok: false, error: "db exploded" });
+    const res = await POST(makeReq(), ctx(LISTING_ID));
+    expect(res.status).toBe(500);
+  });
+
+  it("submits successfully and returns status", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    mockSubmit.mockResolvedValueOnce({
+      ok: true,
+      noOp: false,
+      listing: { status: "pending_review" },
+    });
+    const res = await POST(makeReq(), ctx(LISTING_ID));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, noOp: false, status: "pending_review" });
+    expect(mockSubmit).toHaveBeenCalledWith(LISTING_ID, USER.id);
+  });
+
+  it("is idempotent — returns noOp:true for already-pending", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    mockSubmit.mockResolvedValueOnce({
+      ok: true,
+      noOp: true,
+      listing: { status: "pending_review" },
+    });
+    const res = await POST(makeReq(), ctx(LISTING_ID));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ noOp: true });
+  });
+});

--- a/__tests__/api/saved-searches-id.test.ts
+++ b/__tests__/api/saved-searches-id.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockGetUser, mockIsAllowed, mockIpKey, mockUpdate, mockRemove } = vi.hoisted(() => ({
+  mockGetUser: vi.fn(),
+  mockIsAllowed: vi.fn(),
+  mockIpKey: vi.fn(() => "ip:1.2.3.4"),
+  mockUpdate: vi.fn(),
+  mockRemove: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({
+    auth: { getUser: mockGetUser },
+  })),
+}));
+
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: mockIsAllowed,
+  ipKey: mockIpKey,
+}));
+
+vi.mock("@/lib/saved-searches", () => ({
+  update: mockUpdate,
+  remove: mockRemove,
+  EMAIL_FREQUENCIES: ["off", "daily", "weekly"] as const,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import { PATCH, DELETE } from "@/app/api/saved-searches/[id]/route";
+
+const USER = { id: "user-uuid-1", email: "alice@example.com" };
+
+function makeReq(method: string, body?: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/saved-searches/1", {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+const ctx = (id: string) => ({ params: Promise.resolve({ id }) });
+
+describe("PATCH /api/saved-searches/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowed.mockResolvedValue(true);
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockIsAllowed.mockResolvedValueOnce(false);
+    const res = await PATCH(makeReq("PATCH", { label: "x" }), ctx("1"));
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: null } });
+    const res = await PATCH(makeReq("PATCH", { label: "x" }), ctx("1"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for an invalid id", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    const res = await PATCH(makeReq("PATCH", { label: "x" }), ctx("abc"));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid id" });
+  });
+
+  it("returns 400 for invalid JSON", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    const req = new NextRequest("http://localhost/api/saved-searches/1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: "{not json",
+    });
+    const res = await PATCH(req, ctx("1"));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid JSON body" });
+  });
+
+  it("returns 400 with validation_error for a bad body", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    const res = await PATCH(makeReq("PATCH", { email_frequency: "hourly" }), ctx("1"));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ code: "validation_error" });
+  });
+
+  it("returns 404 when the row is missing or not owned", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    mockUpdate.mockResolvedValueOnce(null);
+    const res = await PATCH(makeReq("PATCH", { label: "Renamed" }), ctx("1"));
+    expect(res.status).toBe(404);
+  });
+
+  it("updates and returns the saved search", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    const row = { id: 1, label: "Renamed" };
+    mockUpdate.mockResolvedValueOnce(row);
+    const res = await PATCH(makeReq("PATCH", { label: "Renamed" }), ctx("1"));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ saved_search: row });
+    expect(mockUpdate).toHaveBeenCalledWith(1, USER.id, { label: "Renamed" });
+  });
+});
+
+describe("DELETE /api/saved-searches/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowed.mockResolvedValue(true);
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockIsAllowed.mockResolvedValueOnce(false);
+    const res = await DELETE(makeReq("DELETE"), ctx("1"));
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: null } });
+    const res = await DELETE(makeReq("DELETE"), ctx("1"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for an invalid id", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    const res = await DELETE(makeReq("DELETE"), ctx("0"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 500 when remove fails", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    mockRemove.mockResolvedValueOnce(false);
+    const res = await DELETE(makeReq("DELETE"), ctx("3"));
+    expect(res.status).toBe(500);
+  });
+
+  it("deletes and returns success", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: USER } });
+    mockRemove.mockResolvedValueOnce(true);
+    const res = await DELETE(makeReq("DELETE"), ctx("3"));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true });
+    expect(mockRemove).toHaveBeenCalledWith(3, USER.id);
+  });
+});


### PR DESCRIPTION
## Summary
Unit tests for 6 untested routes: `account/documents/[id]` (DELETE) + `account/documents/upload` (multipart POST: size/type/mime rejection + storage-cleanup-on-DB-failure), `intake/questions/[id]`, `listings/owner-flow/[id]` + `/submit`, `saved-searches/[id]`. 68 tests: rate-limit, auth/ownership, zod, happy, 404/409, IntakeError mapping, 500. (listings/[id] + saved-comparisons/[id] already covered — not duplicated.)

## Queue item
D-COV pre-launch coverage push. Moves M02 (57→200).

## Supersedes
_None._

## Test plan
- [x] vitest 68/68 local
- [ ] CI green