### PR TITLE
test(d): add unit tests for decision-trees libs

### DIFF
--- a/__tests__/lib/decision-trees/buy-vs-rent.test.ts
+++ b/__tests__/lib/decision-trees/buy-vs-rent.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from "vitest";
+import {
+  BUY_VS_RENT_TREE,
+  BUY_VS_RENT_START_ID,
+} from "@/lib/decision-trees/buy-vs-rent";
+import type { TreeNode, TreeLeaf, TreeQuestion } from "@/components/DecisionTree";
+
+/**
+ * buy-vs-rent.ts is a static `TreeNode[]` data module (no runtime logic).
+ * These tests assert the structural invariants the DecisionTree renderer
+ * relies on: unique ids, every `next` pointer resolves, every node is
+ * reachable from the start id, every leaf has a valid verdict, and there
+ * are no orphans or dangling references.
+ */
+
+const VALID_VERDICTS = new Set(["buy", "rent", "save", "review"]);
+
+function isLeaf(node: TreeNode): node is TreeLeaf {
+  return "verdict" in node;
+}
+function isQuestion(node: TreeNode): node is TreeQuestion {
+  return "question" in node;
+}
+
+const byId = new Map(BUY_VS_RENT_TREE.map((n) => [n.id, n]));
+
+describe("BUY_VS_RENT_TREE — shape & invariants (static data module)", () => {
+  it("is a non-empty array", () => {
+    expect(Array.isArray(BUY_VS_RENT_TREE)).toBe(true);
+    expect(BUY_VS_RENT_TREE.length).toBeGreaterThan(0);
+  });
+
+  it("exposes a start id that points at an existing node", () => {
+    expect(BUY_VS_RENT_START_ID).toBe("start");
+    expect(byId.has(BUY_VS_RENT_START_ID)).toBe(true);
+  });
+
+  it("every node id is unique and non-empty", () => {
+    const ids = BUY_VS_RENT_TREE.map((n) => n.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    ids.forEach((id) => expect(id.length).toBeGreaterThan(0));
+  });
+
+  it("every node is exactly one of question | leaf (never both, never neither)", () => {
+    BUY_VS_RENT_TREE.forEach((node) => {
+      const leaf = isLeaf(node);
+      const question = isQuestion(node);
+      expect(leaf || question).toBe(true);
+      expect(leaf && question).toBe(false);
+    });
+  });
+
+  it("every question has at least two options, each with label + resolvable next", () => {
+    BUY_VS_RENT_TREE.filter(isQuestion).forEach((q) => {
+      expect(q.question.length).toBeGreaterThan(0);
+      expect(q.options.length).toBeGreaterThanOrEqual(2);
+      q.options.forEach((opt) => {
+        expect(opt.label.length).toBeGreaterThan(0);
+        expect(byId.has(opt.next)).toBe(true);
+      });
+    });
+  });
+
+  it("every leaf has a valid verdict, heading, and detail", () => {
+    const leaves = BUY_VS_RENT_TREE.filter(isLeaf);
+    expect(leaves.length).toBeGreaterThan(0);
+    leaves.forEach((leaf) => {
+      expect(VALID_VERDICTS.has(leaf.verdict)).toBe(true);
+      expect(leaf.heading.length).toBeGreaterThan(0);
+      expect(leaf.detail.length).toBeGreaterThan(0);
+    });
+  });
+
+  it("leaf actions (when present) have a label and a root-relative href", () => {
+    BUY_VS_RENT_TREE.filter(isLeaf)
+      .filter((l): l is TreeLeaf & { action: NonNullable<TreeLeaf["action"]> } =>
+        Boolean(l.action),
+      )
+      .forEach((leaf) => {
+        expect(leaf.action.label.length).toBeGreaterThan(0);
+        expect(leaf.action.href.startsWith("/")).toBe(true);
+      });
+  });
+
+  it("every node is reachable from the start id (no orphans)", () => {
+    const seen = new Set<string>();
+    const stack = [BUY_VS_RENT_START_ID];
+    while (stack.length) {
+      const id = stack.pop()!;
+      if (seen.has(id)) continue;
+      seen.add(id);
+      const node = byId.get(id);
+      if (node && isQuestion(node)) {
+        node.options.forEach((o) => stack.push(o.next));
+      }
+    }
+    const allIds = new Set(BUY_VS_RENT_TREE.map((n) => n.id));
+    expect(seen).toEqual(allIds);
+  });
+
+  it("contains the expected verdict spread (buy / rent / save / review all present)", () => {
+    const verdicts = new Set(BUY_VS_RENT_TREE.filter(isLeaf).map((l) => l.verdict));
+    expect(verdicts).toEqual(new Set(["buy", "rent", "save", "review"]));
+  });
+
+  it("the start node branches to both the renter and the owner paths", () => {
+    const start = byId.get("start");
+    expect(start && isQuestion(start)).toBe(true);
+    const nexts = (start as TreeQuestion).options.map((o) => o.next);
+    expect(nexts).toContain("horizon");
+    expect(nexts).toContain("own-sell");
+  });
+
+  it("the short-horizon renter path lands on a 'rent' verdict", () => {
+    const leaf = byId.get("leaf-rent-short");
+    expect(leaf && isLeaf(leaf) && (leaf as TreeLeaf).verdict).toBe("rent");
+  });
+});

--- a/__tests__/lib/decision-trees/salary-sacrifice.test.ts
+++ b/__tests__/lib/decision-trees/salary-sacrifice.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from "vitest";
+import {
+  SALARY_SACRIFICE_TREE,
+  SALARY_SACRIFICE_START_ID,
+} from "@/lib/decision-trees/salary-sacrifice";
+import type { TreeNode, TreeLeaf, TreeQuestion } from "@/components/DecisionTree";
+
+/**
+ * salary-sacrifice.ts is a static `TreeNode[]` data module (no runtime
+ * logic). These tests assert the structural invariants the DecisionTree
+ * renderer relies on.
+ */
+
+const VALID_VERDICTS = new Set(["buy", "rent", "save", "review"]);
+
+function isLeaf(node: TreeNode): node is TreeLeaf {
+  return "verdict" in node;
+}
+function isQuestion(node: TreeNode): node is TreeQuestion {
+  return "question" in node;
+}
+
+const byId = new Map(SALARY_SACRIFICE_TREE.map((n) => [n.id, n]));
+
+describe("SALARY_SACRIFICE_TREE — shape & invariants (static data module)", () => {
+  it("is a non-empty array", () => {
+    expect(Array.isArray(SALARY_SACRIFICE_TREE)).toBe(true);
+    expect(SALARY_SACRIFICE_TREE.length).toBeGreaterThan(0);
+  });
+
+  it("exposes a start id that points at an existing node", () => {
+    expect(SALARY_SACRIFICE_START_ID).toBe("start");
+    expect(byId.has(SALARY_SACRIFICE_START_ID)).toBe(true);
+  });
+
+  it("every node id is unique and non-empty", () => {
+    const ids = SALARY_SACRIFICE_TREE.map((n) => n.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    ids.forEach((id) => expect(id.length).toBeGreaterThan(0));
+  });
+
+  it("every node is exactly one of question | leaf", () => {
+    SALARY_SACRIFICE_TREE.forEach((node) => {
+      const leaf = isLeaf(node);
+      const question = isQuestion(node);
+      expect(leaf || question).toBe(true);
+      expect(leaf && question).toBe(false);
+    });
+  });
+
+  it("every question has at least two options, each with label + resolvable next", () => {
+    SALARY_SACRIFICE_TREE.filter(isQuestion).forEach((q) => {
+      expect(q.question.length).toBeGreaterThan(0);
+      expect(q.options.length).toBeGreaterThanOrEqual(2);
+      q.options.forEach((opt) => {
+        expect(opt.label.length).toBeGreaterThan(0);
+        expect(byId.has(opt.next)).toBe(true);
+      });
+    });
+  });
+
+  it("every leaf has a valid verdict, heading, and detail", () => {
+    const leaves = SALARY_SACRIFICE_TREE.filter(isLeaf);
+    expect(leaves.length).toBeGreaterThan(0);
+    leaves.forEach((leaf) => {
+      expect(VALID_VERDICTS.has(leaf.verdict)).toBe(true);
+      expect(leaf.heading.length).toBeGreaterThan(0);
+      expect(leaf.detail.length).toBeGreaterThan(0);
+    });
+  });
+
+  it("leaf actions (when present) have a label and a root-relative href", () => {
+    SALARY_SACRIFICE_TREE.filter(isLeaf)
+      .filter((l): l is TreeLeaf & { action: NonNullable<TreeLeaf["action"]> } =>
+        Boolean(l.action),
+      )
+      .forEach((leaf) => {
+        expect(leaf.action.label.length).toBeGreaterThan(0);
+        expect(leaf.action.href.startsWith("/")).toBe(true);
+      });
+  });
+
+  it("every node is reachable from the start id (no orphans)", () => {
+    const seen = new Set<string>();
+    const stack = [SALARY_SACRIFICE_START_ID];
+    while (stack.length) {
+      const id = stack.pop()!;
+      if (seen.has(id)) continue;
+      seen.add(id);
+      const node = byId.get(id);
+      if (node && isQuestion(node)) {
+        node.options.forEach((o) => stack.push(o.next));
+      }
+    }
+    const allIds = new Set(SALARY_SACRIFICE_TREE.map((n) => n.id));
+    expect(seen).toEqual(allIds);
+  });
+
+  it("the start node splits employee vs self-employed", () => {
+    const start = byId.get("start") as TreeQuestion;
+    const nexts = start.options.map((o) => o.next);
+    expect(nexts).toContain("income-range");
+    expect(nexts).toContain("leaf-self-employed");
+  });
+
+  it("the high-income branch routes Div 293 vs high-earner", () => {
+    const capCheckHigh = byId.get("cap-check-high") as TreeQuestion;
+    const nexts = capCheckHigh.options.map((o) => o.next);
+    expect(nexts).toContain("leaf-div293");
+    expect(nexts).toContain("leaf-high-earner");
+  });
+
+  it("clear-winner, high-earner and div293 leaves all carry a 'buy' verdict", () => {
+    (["leaf-clear-winner", "leaf-high-earner", "leaf-div293"] as const).forEach(
+      (id) => {
+        const leaf = byId.get(id) as TreeLeaf;
+        expect(leaf.verdict).toBe("buy");
+      },
+    );
+  });
+
+  it("low-income, near-cap and self-employed leaves are 'review' verdicts", () => {
+    (["leaf-low-income", "leaf-near-cap", "leaf-self-employed"] as const).forEach(
+      (id) => {
+        const leaf = byId.get(id) as TreeLeaf;
+        expect(leaf.verdict).toBe("review");
+      },
+    );
+  });
+});

--- a/__tests__/lib/decision-trees/smsf-setup.test.ts
+++ b/__tests__/lib/decision-trees/smsf-setup.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from "vitest";
+import {
+  SMSF_SETUP_TREE,
+  SMSF_SETUP_START_ID,
+} from "@/lib/decision-trees/smsf-setup";
+import type { TreeNode, TreeLeaf, TreeQuestion } from "@/components/DecisionTree";
+
+/**
+ * smsf-setup.ts is a static `TreeNode[]` data module (no runtime logic).
+ * These tests assert the structural invariants the DecisionTree renderer
+ * relies on, plus that the documented routing (returns-check can loop
+ * back into the shared balance-check question) resolves cleanly.
+ */
+
+const VALID_VERDICTS = new Set(["buy", "rent", "save", "review"]);
+
+function isLeaf(node: TreeNode): node is TreeLeaf {
+  return "verdict" in node;
+}
+function isQuestion(node: TreeNode): node is TreeQuestion {
+  return "question" in node;
+}
+
+const byId = new Map(SMSF_SETUP_TREE.map((n) => [n.id, n]));
+
+describe("SMSF_SETUP_TREE — shape & invariants (static data module)", () => {
+  it("is a non-empty array", () => {
+    expect(Array.isArray(SMSF_SETUP_TREE)).toBe(true);
+    expect(SMSF_SETUP_TREE.length).toBeGreaterThan(0);
+  });
+
+  it("exposes a start id that points at an existing node", () => {
+    expect(SMSF_SETUP_START_ID).toBe("start");
+    expect(byId.has(SMSF_SETUP_START_ID)).toBe(true);
+  });
+
+  it("every node id is unique and non-empty", () => {
+    const ids = SMSF_SETUP_TREE.map((n) => n.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    ids.forEach((id) => expect(id.length).toBeGreaterThan(0));
+  });
+
+  it("every node is exactly one of question | leaf", () => {
+    SMSF_SETUP_TREE.forEach((node) => {
+      const leaf = isLeaf(node);
+      const question = isQuestion(node);
+      expect(leaf || question).toBe(true);
+      expect(leaf && question).toBe(false);
+    });
+  });
+
+  it("every question has at least two options, each with label + resolvable next", () => {
+    SMSF_SETUP_TREE.filter(isQuestion).forEach((q) => {
+      expect(q.question.length).toBeGreaterThan(0);
+      expect(q.options.length).toBeGreaterThanOrEqual(2);
+      q.options.forEach((opt) => {
+        expect(opt.label.length).toBeGreaterThan(0);
+        expect(byId.has(opt.next)).toBe(true);
+      });
+    });
+  });
+
+  it("every leaf has a valid verdict, heading, and detail", () => {
+    const leaves = SMSF_SETUP_TREE.filter(isLeaf);
+    expect(leaves.length).toBeGreaterThan(0);
+    leaves.forEach((leaf) => {
+      expect(VALID_VERDICTS.has(leaf.verdict)).toBe(true);
+      expect(leaf.heading.length).toBeGreaterThan(0);
+      expect(leaf.detail.length).toBeGreaterThan(0);
+    });
+  });
+
+  it("leaf actions (when present) have a label and a root-relative href", () => {
+    SMSF_SETUP_TREE.filter(isLeaf)
+      .filter((l): l is TreeLeaf & { action: NonNullable<TreeLeaf["action"]> } =>
+        Boolean(l.action),
+      )
+      .forEach((leaf) => {
+        expect(leaf.action.label.length).toBeGreaterThan(0);
+        expect(leaf.action.href.startsWith("/")).toBe(true);
+      });
+  });
+
+  it("every node is reachable from the start id (no orphans), tolerating the returns->balance loop", () => {
+    const seen = new Set<string>();
+    const stack = [SMSF_SETUP_START_ID];
+    while (stack.length) {
+      const id = stack.pop()!;
+      if (seen.has(id)) continue; // guard handles the returns-check -> balance-check re-entry
+      seen.add(id);
+      const node = byId.get(id);
+      if (node && isQuestion(node)) {
+        node.options.forEach((o) => stack.push(o.next));
+      }
+    }
+    const allIds = new Set(SMSF_SETUP_TREE.map((n) => n.id));
+    expect(seen).toEqual(allIds);
+  });
+
+  it("the start node offers control, business-property and returns paths", () => {
+    const start = byId.get("start") as TreeQuestion;
+    const nexts = start.options.map((o) => o.next);
+    expect(nexts).toContain("balance-check");
+    expect(nexts).toContain("leaf-business-property");
+    expect(nexts).toContain("returns-check");
+  });
+
+  it("returns-check feeds back into the shared balance-check question (no duplicate balance node)", () => {
+    const returnsCheck = byId.get("returns-check") as TreeQuestion;
+    const nexts = returnsCheck.options.map((o) => o.next);
+    expect(nexts).toContain("balance-check");
+    expect(nexts).toContain("leaf-check-fund-first");
+  });
+
+  it("balance bands map to escalating verdicts: too-small=rent, mid=review, strong=buy", () => {
+    expect((byId.get("leaf-too-small") as TreeLeaf).verdict).toBe("rent");
+    expect((byId.get("leaf-viable-watch-costs") as TreeLeaf).verdict).toBe(
+      "review",
+    );
+    expect((byId.get("leaf-viable-strong") as TreeLeaf).verdict).toBe("buy");
+  });
+
+  it("balance-check has exactly three bands", () => {
+    const balanceCheck = byId.get("balance-check") as TreeQuestion;
+    expect(balanceCheck.options).toHaveLength(3);
+    expect(balanceCheck.options.map((o) => o.next)).toEqual([
+      "leaf-too-small",
+      "leaf-viable-watch-costs",
+      "leaf-viable-strong",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
Unit tests for decision-tree + (gap-filled) lib modules. 35 tests: structural-invariant tests for the 3 static `decision-trees/*` TreeNode graphs (unique ids, every option `next` resolves, reachability/no-orphans, valid verdict enums). The 3 country-mode modules were already fully covered (#616/#618) — not duplicated.

## Queue item
D-COV pre-launch coverage push (lib coverage → M01 line-coverage target).

## Supersedes
_None._

## Test plan
- [x] vitest 35/35 local
- [ ] CI green