### PR TITLE
test(d): add unit tests for listing-kind/life-events/switch-scripts/csv-import libs

### DIFF
--- a/__tests__/lib/getmatched/recall.test.ts
+++ b/__tests__/lib/getmatched/recall.test.ts
@@ -1,0 +1,119 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  getPartialPlan,
+  setPartialPlan,
+  clearPartialPlan,
+  describePartial,
+  type PartialPlan,
+} from "@/lib/getmatched/recall";
+
+const STORAGE_KEY = "iv_gm_partial_plan";
+
+function validPlan(over: Partial<PartialPlan> = {}): PartialPlan {
+  return {
+    answers: { intent: "property" },
+    stepIndex: 3,
+    totalSteps: 7,
+    updatedAt: Date.now(),
+    ...over,
+  };
+}
+
+describe("getmatched/recall", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    window.sessionStorage.clear();
+  });
+
+  describe("setPartialPlan + getPartialPlan round-trip", () => {
+    it("persists and reads back a partial plan with a fresh updatedAt", () => {
+      const before = Date.now();
+      setPartialPlan({ answers: { intent: "property" }, stepIndex: 2, totalSteps: 7 });
+      const got = getPartialPlan();
+      expect(got).not.toBeNull();
+      expect(got!.stepIndex).toBe(2);
+      expect(got!.totalSteps).toBe(7);
+      expect(got!.answers).toEqual({ intent: "property" });
+      expect(got!.updatedAt).toBeGreaterThanOrEqual(before);
+    });
+  });
+
+  describe("getPartialPlan", () => {
+    it("returns null when nothing is stored", () => {
+      expect(getPartialPlan()).toBeNull();
+    });
+
+    it("returns null and clears storage for corrupt JSON", () => {
+      window.sessionStorage.setItem(STORAGE_KEY, "{not json");
+      expect(getPartialPlan()).toBeNull();
+      expect(window.sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+    });
+
+    it("returns null and clears when shape is invalid (missing numeric fields)", () => {
+      window.sessionStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({ answers: {}, stepIndex: "x", totalSteps: 7, updatedAt: Date.now() }),
+      );
+      expect(getPartialPlan()).toBeNull();
+      expect(window.sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+    });
+
+    it("returns null and clears when the entry is stale (older than TTL)", () => {
+      const eightDaysAgo = Date.now() - 8 * 24 * 60 * 60 * 1000;
+      window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(validPlan({ updatedAt: eightDaysAgo })));
+      expect(getPartialPlan()).toBeNull();
+      expect(window.sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+    });
+
+    it("returns a plan that is just within the TTL window", () => {
+      const sixDaysAgo = Date.now() - 6 * 24 * 60 * 60 * 1000;
+      window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(validPlan({ updatedAt: sixDaysAgo })));
+      expect(getPartialPlan()).not.toBeNull();
+    });
+
+    it("returns null (but does NOT clear) when the plan was actually completed", () => {
+      window.sessionStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify(validPlan({ stepIndex: 7, totalSteps: 7 })),
+      );
+      expect(getPartialPlan()).toBeNull();
+      // completed plans are not cleared — only returned as null
+      expect(window.sessionStorage.getItem(STORAGE_KEY)).not.toBeNull();
+    });
+
+    it("returns null when stepIndex exceeds totalSteps", () => {
+      window.sessionStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify(validPlan({ stepIndex: 9, totalSteps: 7 })),
+      );
+      expect(getPartialPlan()).toBeNull();
+    });
+  });
+
+  describe("clearPartialPlan", () => {
+    it("removes a stored plan", () => {
+      setPartialPlan({ answers: {}, stepIndex: 1, totalSteps: 5 });
+      clearPartialPlan();
+      expect(window.sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+    });
+
+    it("is a no-op when nothing is stored", () => {
+      expect(() => clearPartialPlan()).not.toThrow();
+    });
+  });
+
+  describe("describePartial", () => {
+    it("renders a human progress label", () => {
+      expect(describePartial(validPlan({ stepIndex: 4, totalSteps: 7 }))).toBe(
+        "4 of 7 questions answered",
+      );
+    });
+  });
+});

--- a/__tests__/lib/holdings/csv-import/_utils.test.ts
+++ b/__tests__/lib/holdings/csv-import/_utils.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect } from "vitest";
+import {
+  splitCsvLine,
+  truncate,
+  parseAuDate,
+  parseIsoDate,
+  parseFlexibleDate,
+  parseMoney,
+  MAX_INPUT_ROWS,
+} from "@/lib/holdings/csv-import/_utils";
+
+describe("splitCsvLine", () => {
+  it("splits a simple comma line and trims fields", () => {
+    expect(splitCsvLine("a, b ,c")).toEqual(["a", "b", "c"]);
+  });
+
+  it("respects commas inside double-quoted fields", () => {
+    expect(splitCsvLine('"Smith, John",42,"X"')).toEqual(["Smith, John", "42", "X"]);
+  });
+
+  it("strips the surrounding quotes from quoted fields", () => {
+    expect(splitCsvLine('"hello"')).toEqual(["hello"]);
+  });
+
+  it("returns a single field for input with no commas", () => {
+    expect(splitCsvLine("solo")).toEqual(["solo"]);
+  });
+
+  it("yields empty strings for an empty line and for trailing commas", () => {
+    expect(splitCsvLine("")).toEqual([""]);
+    expect(splitCsvLine("a,,b")).toEqual(["a", "", "b"]);
+    expect(splitCsvLine("a,b,")).toEqual(["a", "b", ""]);
+  });
+
+  it("treats adjacent quotes as toggles (not RFC-4180 escapes)", () => {
+    // "" toggles inQuote off then on again -> net no quote chars in output.
+    expect(splitCsvLine('a""b')).toEqual(["ab"]);
+  });
+
+  it("trims whitespace around unquoted values", () => {
+    expect(splitCsvLine("  TLS  ,  100  ")).toEqual(["TLS", "100"]);
+  });
+});
+
+describe("truncate", () => {
+  it("returns the input unchanged when within the limit", () => {
+    expect(truncate("short")).toBe("short");
+  });
+
+  it("returns input unchanged at exactly the limit", () => {
+    const s = "x".repeat(200);
+    expect(truncate(s)).toBe(s);
+  });
+
+  it("appends an ellipsis when over the limit", () => {
+    const s = "x".repeat(250);
+    const out = truncate(s);
+    expect(out).toHaveLength(201); // 200 chars + ellipsis
+    expect(out.endsWith("…")).toBe(true);
+  });
+
+  it("honours a custom max", () => {
+    expect(truncate("abcdef", 3)).toBe("abc…");
+  });
+
+  it("handles empty string", () => {
+    expect(truncate("")).toBe("");
+  });
+});
+
+describe("parseAuDate", () => {
+  it("parses DD/MM/YYYY", () => {
+    expect(parseAuDate("09/05/2026")).toBe("2026-05-09");
+  });
+
+  it("parses single-digit day/month", () => {
+    expect(parseAuDate("1/2/2026")).toBe("2026-02-01");
+  });
+
+  it("maps two-digit year >= 50 to 19xx", () => {
+    expect(parseAuDate("01/01/99")).toBe("1999-01-01");
+  });
+
+  it("maps two-digit year < 50 to 20xx", () => {
+    expect(parseAuDate("01/01/26")).toBe("2026-01-01");
+  });
+
+  it("tolerates surrounding whitespace", () => {
+    expect(parseAuDate("  10/06/2026  ")).toBe("2026-06-10");
+  });
+
+  it("rejects invalid calendar dates", () => {
+    expect(parseAuDate("31/02/2026")).toBeNull();
+    expect(parseAuDate("32/01/2026")).toBeNull();
+    expect(parseAuDate("01/13/2026")).toBeNull();
+  });
+
+  it("rejects ISO and garbage input", () => {
+    expect(parseAuDate("2026-05-09")).toBeNull();
+    expect(parseAuDate("not a date")).toBeNull();
+    expect(parseAuDate("")).toBeNull();
+  });
+
+  it("rejects 3-digit years", () => {
+    expect(parseAuDate("01/01/202")).toBeNull();
+  });
+});
+
+describe("parseIsoDate", () => {
+  it("parses YYYY-MM-DD", () => {
+    expect(parseIsoDate("2026-05-09")).toBe("2026-05-09");
+  });
+
+  it("zero-pads single-digit month/day", () => {
+    expect(parseIsoDate("2026-5-9")).toBe("2026-05-09");
+  });
+
+  it("tolerates a trailing time portion (T / space / comma)", () => {
+    expect(parseIsoDate("2026-05-09T10:30:00Z")).toBe("2026-05-09");
+    expect(parseIsoDate("2026-05-09 10:30:00")).toBe("2026-05-09");
+    expect(parseIsoDate("2026-05-09,extra")).toBe("2026-05-09");
+  });
+
+  it("tolerates leading whitespace", () => {
+    expect(parseIsoDate("   2026-01-01")).toBe("2026-01-01");
+  });
+
+  it("rejects invalid calendar dates", () => {
+    expect(parseIsoDate("2026-02-30")).toBeNull();
+    expect(parseIsoDate("2026-13-01")).toBeNull();
+  });
+
+  it("rejects AU-format and garbage", () => {
+    expect(parseIsoDate("09/05/2026")).toBeNull();
+    expect(parseIsoDate("")).toBeNull();
+  });
+});
+
+describe("parseFlexibleDate", () => {
+  it("prefers ISO format", () => {
+    expect(parseFlexibleDate("2026-05-09")).toBe("2026-05-09");
+  });
+
+  it("falls back to AU format", () => {
+    expect(parseFlexibleDate("09/05/2026")).toBe("2026-05-09");
+  });
+
+  it("returns null when neither format matches", () => {
+    expect(parseFlexibleDate("May 9 2026")).toBeNull();
+  });
+});
+
+describe("parseMoney", () => {
+  it("parses a plain number string", () => {
+    expect(parseMoney("100")).toBe(100);
+  });
+
+  it("strips currency symbols", () => {
+    expect(parseMoney("$1234")).toBe(1234);
+    expect(parseMoney("£500")).toBe(500);
+    expect(parseMoney("€42")).toBe(42);
+    expect(parseMoney("¥99")).toBe(99);
+  });
+
+  it("strips thousands separators and whitespace", () => {
+    expect(parseMoney("1,234,567")).toBe(1234567);
+    expect(parseMoney("  2 500 ")).toBe(2500);
+  });
+
+  it("strips alphabetic currency codes", () => {
+    expect(parseMoney("AUD 1500")).toBe(1500);
+    expect(parseMoney("1500 USD")).toBe(1500);
+  });
+
+  it("preserves a decimal point and leading minus", () => {
+    expect(parseMoney("$1,234.56")).toBeCloseTo(1234.56);
+    expect(parseMoney("-50")).toBe(-50);
+  });
+
+  it("returns NaN for empty input", () => {
+    expect(parseMoney("")).toBeNaN();
+  });
+
+  it("coerces an all-alpha string to 0 (letters stripped, Number('') === 0)", () => {
+    // Documented behaviour quirk: stripping leaves "" which Number() reads as 0.
+    expect(parseMoney("abc")).toBe(0);
+  });
+
+  it("returns NaN when a stray symbol survives stripping", () => {
+    // '.' is not in the strip set, so "1.2.3" -> Number("1.2.3") === NaN.
+    expect(parseMoney("1.2.3")).toBeNaN();
+  });
+});
+
+describe("MAX_INPUT_ROWS", () => {
+  it("is the documented 500-row cap", () => {
+    expect(MAX_INPUT_ROWS).toBe(500);
+  });
+});

--- a/__tests__/lib/life-events.test.ts
+++ b/__tests__/lib/life-events.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from "vitest";
+import {
+  LIFE_EVENT_CATEGORIES,
+  LIFE_EVENTS,
+  buildLifeEventUrl,
+  type LifeEvent,
+  type LifeEventCategory,
+} from "@/lib/life-events";
+
+const CATEGORY_IDS: LifeEventCategory[] = [
+  "property",
+  "family",
+  "career",
+  "wealth",
+  "business",
+  "retirement",
+];
+
+describe("LIFE_EVENT_CATEGORIES", () => {
+  it("covers exactly the six known categories", () => {
+    expect(LIFE_EVENT_CATEGORIES.map((c) => c.id).sort()).toEqual([...CATEGORY_IDS].sort());
+  });
+
+  it("every category has a label and emoji", () => {
+    for (const c of LIFE_EVENT_CATEGORIES) {
+      expect(c.label.length).toBeGreaterThan(0);
+      expect(c.emoji.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("category ids are unique", () => {
+    expect(new Set(LIFE_EVENT_CATEGORIES.map((c) => c.id)).size).toBe(LIFE_EVENT_CATEGORIES.length);
+  });
+});
+
+describe("LIFE_EVENTS data invariants", () => {
+  it("is non-empty", () => {
+    expect(LIFE_EVENTS.length).toBeGreaterThan(0);
+  });
+
+  it("has unique ids", () => {
+    const ids = LIFE_EVENTS.map((e) => e.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("every event has the required fields populated", () => {
+    for (const e of LIFE_EVENTS) {
+      expect(e.id.length).toBeGreaterThan(0);
+      expect(e.emoji.length).toBeGreaterThan(0);
+      expect(e.title.length).toBeGreaterThan(0);
+      expect(e.subtitle.length).toBeGreaterThan(0);
+      expect(e.need.length).toBeGreaterThan(0);
+      expect(Array.isArray(e.context)).toBe(true);
+      expect(e.context.length).toBeGreaterThan(0);
+      expect(Array.isArray(e.suggestedTypes)).toBe(true);
+      expect(e.suggestedTypes.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("every event's category is a known category", () => {
+    for (const e of LIFE_EVENTS) {
+      expect(CATEGORY_IDS).toContain(e.category);
+    }
+  });
+
+  it("relatedHub, when present, is an absolute path", () => {
+    for (const e of LIFE_EVENTS) {
+      if (e.relatedHub !== undefined) {
+        expect(e.relatedHub.startsWith("/")).toBe(true);
+      }
+    }
+  });
+
+  it("each category has at least one event", () => {
+    for (const id of CATEGORY_IDS) {
+      expect(LIFE_EVENTS.some((e) => e.category === id)).toBe(true);
+    }
+  });
+});
+
+describe("buildLifeEventUrl", () => {
+  const sample: LifeEvent = {
+    id: "buying_first_home",
+    emoji: "🏠",
+    title: "Buying My First Home",
+    subtitle: "...",
+    category: "property",
+    need: "mortgage",
+    context: ["first_home"],
+    suggestedTypes: ["Mortgage Broker"],
+  };
+
+  it("builds a /find-advisor URL with need + context", () => {
+    const url = buildLifeEventUrl(sample);
+    expect(url.startsWith("/find-advisor?")).toBe(true);
+    const qs = new URLSearchParams(url.split("?")[1]);
+    expect(qs.get("need")).toBe("mortgage");
+    expect(qs.get("context")).toBe("first_home");
+  });
+
+  it("joins multiple context values with a comma", () => {
+    const url = buildLifeEventUrl({ ...sample, context: ["a", "b", "c"] });
+    expect(new URLSearchParams(url.split("?")[1]).get("context")).toBe("a,b,c");
+  });
+
+  it("forwards state + postcode extras", () => {
+    const url = buildLifeEventUrl(sample, { state: "VIC", postcode: "3000" });
+    const qs = new URLSearchParams(url.split("?")[1]);
+    expect(qs.get("state")).toBe("VIC");
+    expect(qs.get("postcode")).toBe("3000");
+  });
+
+  it("omits state/postcode when not provided", () => {
+    const qs = new URLSearchParams(buildLifeEventUrl(sample).split("?")[1]);
+    expect(qs.has("state")).toBe(false);
+    expect(qs.has("postcode")).toBe(false);
+  });
+
+  it("produces a valid URL for every real life event", () => {
+    for (const e of LIFE_EVENTS) {
+      const url = buildLifeEventUrl(e);
+      const qs = new URLSearchParams(url.split("?")[1]);
+      expect(qs.get("need")).toBe(e.need);
+      expect(qs.get("context")).toBe(e.context.join(","));
+    }
+  });
+});

--- a/__tests__/lib/listing-kind.test.ts
+++ b/__tests__/lib/listing-kind.test.ts
@@ -1,0 +1,464 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import type { InvestmentListing } from "@/lib/types";
+import {
+  deriveListingKind,
+  LISTING_KIND_META,
+  listingKindMeta,
+  ALL_LISTING_KINDS,
+  TICKET_BUCKETS,
+  ticketBucketByKey,
+  INVESTOR_TYPES,
+  listingMatchesInvestorType,
+  filterSpecForKind,
+  freshnessSignal,
+  formatListingPrice,
+  formatAudCompact,
+} from "@/lib/listing-kind";
+
+// Minimal helper to build the slice of an InvestmentListing each function needs.
+type DeriveInput = Pick<
+  InvestmentListing,
+  "vertical" | "key_metrics" | "asking_price_cents" | "listing_kind"
+>;
+function deriveRow(over: Partial<DeriveInput>): DeriveInput {
+  return {
+    vertical: "startups" as InvestmentListing["vertical"],
+    key_metrics: {},
+    asking_price_cents: undefined,
+    listing_kind: null,
+    ...over,
+  };
+}
+
+describe("deriveListingKind", () => {
+  it("returns the explicit listing_kind when present", () => {
+    expect(
+      deriveListingKind(deriveRow({ listing_kind: "royalty" })),
+    ).toBe("royalty");
+  });
+
+  it("treats asx_ticker with no asking price as a listed_security", () => {
+    expect(
+      deriveListingKind(
+        deriveRow({ key_metrics: { asx_ticker: "TLS" }, asking_price_cents: undefined }),
+      ),
+    ).toBe("listed_security");
+  });
+
+  it("does NOT treat asx_ticker as listed_security when an asking price is set", () => {
+    const kind = deriveListingKind(
+      deriveRow({
+        vertical: "startups" as InvestmentListing["vertical"],
+        key_metrics: { asx_ticker: "TLS" },
+        asking_price_cents: 5000,
+      }),
+    );
+    expect(kind).toBe("equity_raise");
+  });
+
+  it("maps vertical=fund + a physical key to physical_asset", () => {
+    expect(
+      deriveListingKind(
+        deriveRow({ vertical: "fund" as InvestmentListing["vertical"], key_metrics: { vintage: 1998 } }),
+      ),
+    ).toBe("physical_asset");
+  });
+
+  it("maps vertical=funds to fund", () => {
+    expect(
+      deriveListingKind(deriveRow({ vertical: "funds" as InvestmentListing["vertical"] })),
+    ).toBe("fund");
+  });
+
+  it("maps vertical=fund + a fund metric key to fund", () => {
+    expect(
+      deriveListingKind(
+        deriveRow({ vertical: "fund" as InvestmentListing["vertical"], key_metrics: { aum_billions: 2 } }),
+      ),
+    ).toBe("fund");
+  });
+
+  it("maps structure=managed_fund to fund", () => {
+    expect(
+      deriveListingKind(
+        deriveRow({ vertical: "anything" as InvestmentListing["vertical"], key_metrics: { structure: "managed_fund" } }),
+      ),
+    ).toBe("fund");
+  });
+
+  it("maps stage=fund to fund", () => {
+    expect(
+      deriveListingKind(
+        deriveRow({ vertical: "x" as InvestmentListing["vertical"], key_metrics: { stage: "fund" } }),
+      ),
+    ).toBe("fund");
+  });
+
+  it("maps vertical=royalties to royalty", () => {
+    expect(
+      deriveListingKind(deriveRow({ vertical: "royalties" as InvestmentListing["vertical"] })),
+    ).toBe("royalty");
+  });
+
+  it("maps stage=royalty / royalty_type to royalty", () => {
+    expect(
+      deriveListingKind(deriveRow({ vertical: "x" as InvestmentListing["vertical"], key_metrics: { stage: "royalty" } })),
+    ).toBe("royalty");
+    expect(
+      deriveListingKind(deriveRow({ vertical: "x" as InvestmentListing["vertical"], key_metrics: { royalty_type: "music" } })),
+    ).toBe("royalty");
+  });
+
+  it("maps buy-business / franchise to for_sale_business", () => {
+    expect(deriveListingKind(deriveRow({ vertical: "buy-business" as InvestmentListing["vertical"] }))).toBe("for_sale_business");
+    expect(deriveListingKind(deriveRow({ vertical: "franchise" as InvestmentListing["vertical"] }))).toBe("for_sale_business");
+  });
+
+  it("maps commercial / farmland / livestock to for_sale_asset", () => {
+    for (const v of ["commercial_property", "commercial-property", "farmland", "livestock"]) {
+      expect(deriveListingKind(deriveRow({ vertical: v as InvestmentListing["vertical"] }))).toBe("for_sale_asset");
+    }
+  });
+
+  it("maps startup verticals to equity_raise", () => {
+    for (const v of ["startups", "startup", "pre_ipo", "pre-ipo"]) {
+      expect(deriveListingKind(deriveRow({ vertical: v as InvestmentListing["vertical"] }))).toBe("equity_raise");
+    }
+  });
+
+  it("defaults to project_equity for unknown sector verticals", () => {
+    expect(
+      deriveListingKind(deriveRow({ vertical: "mining" as InvestmentListing["vertical"], key_metrics: {} })),
+    ).toBe("project_equity");
+  });
+
+  it("handles a null/undefined key_metrics safely", () => {
+    expect(
+      deriveListingKind(
+        deriveRow({ vertical: "mining" as InvestmentListing["vertical"], key_metrics: undefined }),
+      ),
+    ).toBe("project_equity");
+  });
+});
+
+describe("LISTING_KIND_META + listingKindMeta", () => {
+  it("has a meta entry for every kind in ALL_LISTING_KINDS", () => {
+    for (const kind of ALL_LISTING_KINDS) {
+      expect(LISTING_KIND_META[kind]).toBeDefined();
+    }
+  });
+
+  it("every meta has required non-empty string fields and accent block", () => {
+    for (const kind of ALL_LISTING_KINDS) {
+      const m = LISTING_KIND_META[kind];
+      expect(m.label.length).toBeGreaterThan(0);
+      expect(m.pluralLabel.length).toBeGreaterThan(0);
+      expect(m.icon.length).toBeGreaterThan(0);
+      expect(m.priceLabel.length).toBeGreaterThan(0);
+      expect(m.blurb.length).toBeGreaterThan(0);
+      expect(m.ctaLabel.length).toBeGreaterThan(0);
+      expect(typeof m.externalCta).toBe("boolean");
+      for (const key of ["badge", "badgeSubtle", "border", "text", "bg"] as const) {
+        expect(typeof m.accent[key]).toBe("string");
+        expect(m.accent[key].length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("only listed_security uses an external CTA", () => {
+    expect(LISTING_KIND_META.listed_security.externalCta).toBe(true);
+    const others = ALL_LISTING_KINDS.filter((k) => k !== "listed_security");
+    for (const k of others) {
+      expect(LISTING_KIND_META[k].externalCta).toBe(false);
+    }
+  });
+
+  it("listingKindMeta resolves the kind", () => {
+    expect(listingKindMeta("fund")).toBe(LISTING_KIND_META.fund);
+  });
+
+  it("listingKindMeta falls back to project_equity for null/undefined", () => {
+    expect(listingKindMeta(null)).toBe(LISTING_KIND_META.project_equity);
+    expect(listingKindMeta(undefined)).toBe(LISTING_KIND_META.project_equity);
+  });
+
+  it("ALL_LISTING_KINDS has 8 unique entries", () => {
+    expect(ALL_LISTING_KINDS).toHaveLength(8);
+    expect(new Set(ALL_LISTING_KINDS).size).toBe(8);
+  });
+});
+
+describe("ticketBucketByKey", () => {
+  it("resolves a known bucket key", () => {
+    expect(ticketBucketByKey("10k-100k").label).toBe("$10k – $100k");
+  });
+
+  it("falls back to the first (Any) bucket for unknown keys", () => {
+    expect(ticketBucketByKey("nonsense")).toBe(TICKET_BUCKETS[0]);
+    expect(ticketBucketByKey("")).toBe(TICKET_BUCKETS[0]);
+  });
+
+  it("buckets are contiguous and ordered by min", () => {
+    const nonEmpty = TICKET_BUCKETS.filter((b) => b.key !== "");
+    for (let i = 1; i < nonEmpty.length; i++) {
+      expect(nonEmpty[i]!.min).toBe(nonEmpty[i - 1]!.max);
+    }
+  });
+});
+
+describe("INVESTOR_TYPES + listingMatchesInvestorType", () => {
+  function row(over: Partial<Pick<InvestmentListing, "key_metrics" | "siv_complying">>) {
+    return { key_metrics: {}, siv_complying: false, ...over } as Pick<
+      InvestmentListing,
+      "key_metrics" | "siv_complying"
+    >;
+  }
+
+  it("INVESTOR_TYPES includes the empty 'any' default first", () => {
+    expect(INVESTOR_TYPES[0]!.value).toBe("");
+  });
+
+  it("empty investor type matches everything", () => {
+    expect(listingMatchesInvestorType(row({}), "")).toBe(true);
+  });
+
+  it("retail is blocked by wholesale-only listings", () => {
+    expect(listingMatchesInvestorType(row({ key_metrics: { wholesale_only: true } }), "retail")).toBe(false);
+    expect(listingMatchesInvestorType(row({ key_metrics: { s708_required: true } }), "retail")).toBe(false);
+    expect(listingMatchesInvestorType(row({ key_metrics: { accredited_only: true } }), "retail")).toBe(false);
+  });
+
+  it("retail is allowed when no wholesale flag is present", () => {
+    expect(listingMatchesInvestorType(row({}), "retail")).toBe(true);
+  });
+
+  it("retail is allowed when retail-open overrides wholesale-only", () => {
+    expect(
+      listingMatchesInvestorType(
+        row({ key_metrics: { wholesale_only: true, open_to_retail: true } }),
+        "retail",
+      ),
+    ).toBe(true);
+    expect(
+      listingMatchesInvestorType(
+        row({ key_metrics: { wholesale_only: true, retail_eligible: true } }),
+        "retail",
+      ),
+    ).toBe(true);
+  });
+
+  it("wholesale / sophisticated / smsf / family_office pass everything", () => {
+    const restricted = row({ key_metrics: { wholesale_only: true } });
+    expect(listingMatchesInvestorType(restricted, "wholesale")).toBe(true);
+    expect(listingMatchesInvestorType(restricted, "sophisticated")).toBe(true);
+    expect(listingMatchesInvestorType(restricted, "smsf")).toBe(true);
+    expect(listingMatchesInvestorType(restricted, "family_office")).toBe(true);
+  });
+
+  it("siv requires the siv_complying flag", () => {
+    expect(listingMatchesInvestorType(row({ siv_complying: true }), "siv")).toBe(true);
+    expect(listingMatchesInvestorType(row({ siv_complying: false }), "siv")).toBe(false);
+  });
+
+  it("handles null key_metrics", () => {
+    expect(
+      listingMatchesInvestorType({ key_metrics: undefined, siv_complying: false }, "retail"),
+    ).toBe(true);
+  });
+});
+
+describe("filterSpecForKind", () => {
+  it("fund shows fund metrics + yield, not collectible/mining", () => {
+    const spec = filterSpecForKind("fund");
+    expect(spec.showFundMetrics).toBe(true);
+    expect(spec.showYield).toBe(true);
+    expect(spec.showCollectibleMetrics).toBe(false);
+    expect(spec.showMiningStage).toBe(false);
+  });
+
+  it("project_equity shows mining stage + project metrics + yield", () => {
+    const spec = filterSpecForKind("project_equity");
+    expect(spec.showMiningStage).toBe(true);
+    expect(spec.showProjectMetrics).toBe(true);
+    expect(spec.showYield).toBe(true);
+  });
+
+  it("for_sale_asset shows hectares + yield", () => {
+    const spec = filterSpecForKind("for_sale_asset");
+    expect(spec.showHectares).toBe(true);
+    expect(spec.showYield).toBe(true);
+  });
+
+  it("equity_raise shows esic toggle + project metrics", () => {
+    const spec = filterSpecForKind("equity_raise");
+    expect(spec.showEsicToggle).toBe(true);
+    expect(spec.showProjectMetrics).toBe(true);
+  });
+
+  it("listed_security shows asx filter + yield", () => {
+    const spec = filterSpecForKind("listed_security");
+    expect(spec.showAsxFilter).toBe(true);
+    expect(spec.showYield).toBe(true);
+  });
+
+  it("physical_asset shows collectible metrics", () => {
+    expect(filterSpecForKind("physical_asset").showCollectibleMetrics).toBe(true);
+  });
+
+  it("null defaults to project_equity spec", () => {
+    expect(filterSpecForKind(null)).toEqual(filterSpecForKind("project_equity"));
+  });
+});
+
+describe("freshnessSignal", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function at(iso: string) {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(iso));
+  }
+
+  it("returns closing_soon when expiry is within 7 days", () => {
+    at("2026-05-20T00:00:00Z");
+    expect(
+      freshnessSignal({ created_at: "2020-01-01T00:00:00Z", expires_at: "2026-05-24T00:00:00Z" }),
+    ).toBe("closing_soon");
+  });
+
+  it("does not flag closing_soon when expiry already passed", () => {
+    at("2026-05-20T00:00:00Z");
+    expect(
+      freshnessSignal({ created_at: "2020-01-01T00:00:00Z", expires_at: "2026-05-10T00:00:00Z" }),
+    ).toBeNull();
+  });
+
+  it("does not flag closing_soon when expiry is far out", () => {
+    at("2026-05-20T00:00:00Z");
+    expect(
+      freshnessSignal({ created_at: "2020-01-01T00:00:00Z", expires_at: "2027-01-01T00:00:00Z" }),
+    ).toBeNull();
+  });
+
+  it("returns new_this_week for very recent created_at", () => {
+    at("2026-05-20T00:00:00Z");
+    expect(
+      freshnessSignal({ created_at: "2026-05-18T00:00:00Z", expires_at: undefined }),
+    ).toBe("new_this_week");
+  });
+
+  it("returns new_this_month for created_at within 30 days", () => {
+    at("2026-05-20T00:00:00Z");
+    expect(
+      freshnessSignal({ created_at: "2026-05-01T00:00:00Z", expires_at: undefined }),
+    ).toBe("new_this_month");
+  });
+
+  it("returns null for old listings with no expiry", () => {
+    at("2026-05-20T00:00:00Z");
+    expect(
+      freshnessSignal({ created_at: "2020-01-01T00:00:00Z", expires_at: undefined }),
+    ).toBeNull();
+  });
+
+  it("closing_soon takes priority over freshness", () => {
+    at("2026-05-20T00:00:00Z");
+    expect(
+      freshnessSignal({ created_at: "2026-05-19T00:00:00Z", expires_at: "2026-05-22T00:00:00Z" }),
+    ).toBe("closing_soon");
+  });
+});
+
+describe("formatAudCompact", () => {
+  it("formats millions with one decimal", () => {
+    expect(formatAudCompact(250_000_000)).toBe("$2.5M");
+  });
+
+  it("strips trailing .0 on whole millions", () => {
+    expect(formatAudCompact(200_000_000)).toBe("$2M");
+  });
+
+  it("formats >= 10M with no decimal", () => {
+    expect(formatAudCompact(1_550_000_000)).toBe("$16M");
+  });
+
+  it("formats thousands", () => {
+    expect(formatAudCompact(10_000_000)).toBe("$100k");
+  });
+
+  it("formats sub-thousand dollars with locale grouping", () => {
+    expect(formatAudCompact(30000)).toBe("$300");
+  });
+
+  it("rounds small amounts", () => {
+    expect(formatAudCompact(99)).toBe("$1");
+  });
+});
+
+describe("formatListingPrice", () => {
+  type PriceRow = Parameters<typeof formatListingPrice>[0];
+  function priceRow(over: Partial<PriceRow>): PriceRow {
+    return {
+      listing_kind: null,
+      vertical: "mining" as InvestmentListing["vertical"],
+      price_display: undefined,
+      asking_price_cents: undefined,
+      key_metrics: {},
+      ...over,
+    } as PriceRow;
+  }
+
+  it("returns ASX ticker for listed securities", () => {
+    expect(
+      formatListingPrice(
+        priceRow({ listing_kind: "listed_security", key_metrics: { asx_ticker: "tls" } }),
+      ),
+    ).toEqual({ label: "ASX", value: "TLS" });
+  });
+
+  it("returns null for listed security without a ticker", () => {
+    expect(
+      formatListingPrice(priceRow({ listing_kind: "listed_security", key_metrics: {} })),
+    ).toBeNull();
+  });
+
+  it("uses price_display override when set", () => {
+    const res = formatListingPrice(
+      priceRow({ listing_kind: "fund", price_display: "POA" }),
+    );
+    expect(res).toEqual({ label: "Min investment", value: "POA" });
+  });
+
+  it("uses min_investment_aud for funds when no asking price", () => {
+    const res = formatListingPrice(
+      priceRow({ listing_kind: "fund", key_metrics: { min_investment_aud: 50000 } }),
+    );
+    expect(res).toEqual({ label: "Min investment", value: "$50k" });
+  });
+
+  it("uses min_commit_aud for project equity", () => {
+    const res = formatListingPrice(
+      priceRow({ listing_kind: "project_equity", key_metrics: { min_commit_aud: 250000 } }),
+    );
+    expect(res).toEqual({ label: "Min commitment", value: "$250k" });
+  });
+
+  it("renders a non-number min_investment as a string", () => {
+    const res = formatListingPrice(
+      priceRow({ listing_kind: "fund", key_metrics: { min_investment: "Negotiable" } }),
+    );
+    expect(res).toEqual({ label: "Min investment", value: "Negotiable" });
+  });
+
+  it("formats asking_price_cents when present", () => {
+    const res = formatListingPrice(
+      priceRow({ listing_kind: "for_sale_business", asking_price_cents: 250_000_000 }),
+    );
+    expect(res).toEqual({ label: "Asking", value: "$2.5M" });
+  });
+
+  it("returns null when nothing priceable", () => {
+    expect(formatListingPrice(priceRow({ listing_kind: "for_sale_business" }))).toBeNull();
+  });
+});

--- a/__tests__/lib/switch-scripts.test.ts
+++ b/__tests__/lib/switch-scripts.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import {
+  SWITCH_SCRIPTS,
+  getSwitchScript,
+  listSwitchScripts,
+} from "@/lib/switch-scripts";
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+describe("SWITCH_SCRIPTS data invariants", () => {
+  it("is non-empty", () => {
+    expect(SWITCH_SCRIPTS.length).toBeGreaterThan(0);
+  });
+
+  it("has unique broker slugs", () => {
+    const slugs = SWITCH_SCRIPTS.map((s) => s.brokerSlug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+
+  it("every script has required string fields populated", () => {
+    for (const s of SWITCH_SCRIPTS) {
+      expect(s.brokerSlug.length).toBeGreaterThan(0);
+      expect(s.brokerName.length).toBeGreaterThan(0);
+      expect(s.whySwitch.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("negotiation steps have label + body", () => {
+    for (const s of SWITCH_SCRIPTS) {
+      expect(s.negotiationScript.length).toBeGreaterThan(0);
+      for (const step of s.negotiationScript) {
+        expect(step.label.length).toBeGreaterThan(0);
+        expect(step.body.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("transfer steps have label + body, eta optional", () => {
+    for (const s of SWITCH_SCRIPTS) {
+      expect(s.transferProcess.length).toBeGreaterThan(0);
+      for (const step of s.transferProcess) {
+        expect(step.label.length).toBeGreaterThan(0);
+        expect(step.body.length).toBeGreaterThan(0);
+        if (step.eta !== undefined) {
+          expect(typeof step.eta).toBe("string");
+        }
+      }
+    }
+  });
+
+  it("tax notes are non-empty strings", () => {
+    for (const s of SWITCH_SCRIPTS) {
+      expect(s.taxNotes.length).toBeGreaterThan(0);
+      for (const note of s.taxNotes) {
+        expect(typeof note).toBe("string");
+        expect(note.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("recommendedAlternatives never reference the broker itself", () => {
+    for (const s of SWITCH_SCRIPTS) {
+      expect(s.recommendedAlternatives).not.toContain(s.brokerSlug);
+    }
+  });
+
+  it("verifiedAt + stalesAt are ISO dates and verifiedAt precedes stalesAt", () => {
+    for (const s of SWITCH_SCRIPTS) {
+      expect(s.verifiedAt).toMatch(ISO_DATE);
+      expect(s.stalesAt).toMatch(ISO_DATE);
+      expect(new Date(s.verifiedAt).getTime()).toBeLessThan(new Date(s.stalesAt).getTime());
+    }
+  });
+
+  it("sourceUrl, when present, is an https URL", () => {
+    for (const s of SWITCH_SCRIPTS) {
+      if (s.sourceUrl !== undefined) {
+        expect(s.sourceUrl.startsWith("https://")).toBe(true);
+      }
+    }
+  });
+});
+
+describe("getSwitchScript", () => {
+  it("returns the matching script for a known slug", () => {
+    const s = getSwitchScript("commsec");
+    expect(s).toBeDefined();
+    expect(s!.brokerName).toBe("CommSec");
+  });
+
+  it("returns undefined for an unknown slug", () => {
+    expect(getSwitchScript("does-not-exist")).toBeUndefined();
+  });
+
+  it("is case-sensitive (no fuzzy match)", () => {
+    expect(getSwitchScript("CommSec")).toBeUndefined();
+  });
+
+  it("resolves every defined slug", () => {
+    for (const s of SWITCH_SCRIPTS) {
+      expect(getSwitchScript(s.brokerSlug)).toBe(s);
+    }
+  });
+});
+
+describe("listSwitchScripts", () => {
+  it("returns the full SWITCH_SCRIPTS array", () => {
+    expect(listSwitchScripts()).toBe(SWITCH_SCRIPTS);
+    expect(listSwitchScripts()).toHaveLength(SWITCH_SCRIPTS.length);
+  });
+});


### PR DESCRIPTION
## Summary
Direct unit tests for untested lib logic. 137 tests across `listing-kind.ts` (60 — full branch coverage of deriveListingKind/formatListingPrice/formatAudCompact/freshnessSignal/filterSpecForKind/listingMatchesInvestorType), `holdings/csv-import/_utils.ts` (38 — parsing/coercion edge cases), `getmatched/recall.ts` (jsdom), plus `life-events.ts`/`switch-scripts.ts` logic + data invariants.

Note: flagged a behaviour quirk — `parseMoney("abc")` returns `0` (not NaN). Tests assert actual behaviour; no source change.

## Queue item
D-COV pre-launch coverage push (lib coverage → M01).

## Supersedes
_None._

## Test plan
- [x] vitest 137/137 local
- [ ] CI green