### PR TITLE
test(d): add unit tests for hooks + posthog + pro-intake libs

### DIFF
--- a/__tests__/lib/hooks/useComparisonCart.test.ts
+++ b/__tests__/lib/hooks/useComparisonCart.test.ts
@@ -1,0 +1,227 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+// ── useShortlist mock (composed dependency, NOT the module under test) ─────────
+// useComparisonCart is the unit under test; it composes useShortlist, which in
+// turn depends on useUser + fetch + Supabase. Mock the composed hook with a
+// small stateful fake so we exercise the cart's broker-delegation path.
+
+const shortlistState: { slugs: string[] } = { slugs: [] };
+const shortlistMock = {
+  add: vi.fn((slug: string) => {
+    if (!shortlistState.slugs.includes(slug)) shortlistState.slugs.push(slug);
+  }),
+  remove: vi.fn((slug: string) => {
+    shortlistState.slugs = shortlistState.slugs.filter((s) => s !== slug);
+  }),
+};
+
+vi.mock("@/lib/hooks/useShortlist", () => ({
+  useShortlist: () => ({ ...shortlistMock, slugs: shortlistState.slugs }),
+}));
+
+import {
+  useComparisonCart,
+  CART_MAX_TOTAL,
+} from "@/lib/hooks/useComparisonCart";
+
+const NON_BROKER_KEY = "invest_cart_non_broker";
+
+// ── localStorage stub ─────────────────────────────────────────────────────────
+
+const store: Record<string, string> = {};
+const localStorageMock = {
+  getItem: vi.fn((key: string) => store[key] ?? null),
+  setItem: vi.fn((key: string, val: string) => {
+    store[key] = val;
+  }),
+  removeItem: vi.fn((key: string) => {
+    delete store[key];
+  }),
+  clear: vi.fn(() => {
+    Object.keys(store).forEach((k) => delete store[k]);
+  }),
+};
+
+beforeEach(() => {
+  shortlistState.slugs = [];
+  delete store[NON_BROKER_KEY];
+  localStorageMock.clear();
+  vi.clearAllMocks();
+  Object.defineProperty(window, "localStorage", {
+    value: localStorageMock,
+    writable: true,
+    configurable: true,
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useComparisonCart", () => {
+  it("exposes a max-total of 6", () => {
+    expect(CART_MAX_TOTAL).toBe(6);
+  });
+
+  it("starts empty", () => {
+    const { result } = renderHook(() => useComparisonCart());
+    expect(result.current.items).toEqual([]);
+    expect(result.current.count).toBe(0);
+    expect(result.current.isFull).toBe(false);
+  });
+
+  it("hydrates non-broker items from localStorage", () => {
+    store[NON_BROKER_KEY] = JSON.stringify([
+      { kind: "etf", ref: "VAS", addedAt: "2026-01-01T00:00:00Z" },
+    ]);
+    const { result } = renderHook(() => useComparisonCart());
+    expect(result.current.items).toEqual([
+      { kind: "etf", ref: "VAS", addedAt: "2026-01-01T00:00:00Z" },
+    ]);
+    expect(result.current.count).toBe(1);
+  });
+
+  it("filters out malformed / broker-kind entries when hydrating", () => {
+    store[NON_BROKER_KEY] = JSON.stringify([
+      { kind: "etf", ref: "VAS", addedAt: "2026-01-01T00:00:00Z" }, // valid
+      { kind: "broker", ref: "x", addedAt: "2026-01-01T00:00:00Z" }, // wrong layer
+      { kind: "etf", ref: 5, addedAt: "2026-01-01T00:00:00Z" }, // bad ref
+      { kind: "etf", ref: "Y" }, // missing addedAt
+      "garbage",
+      null,
+    ]);
+    const { result } = renderHook(() => useComparisonCart());
+    expect(result.current.items).toEqual([
+      { kind: "etf", ref: "VAS", addedAt: "2026-01-01T00:00:00Z" },
+    ]);
+  });
+
+  it("treats malformed JSON / non-array as empty", () => {
+    store[NON_BROKER_KEY] = "not json";
+    const { result } = renderHook(() => useComparisonCart());
+    expect(result.current.items).toEqual([]);
+  });
+
+  it("adds a non-broker item, stamps addedAt, and persists", () => {
+    const { result } = renderHook(() => useComparisonCart());
+    let res!: { ok: boolean; reason?: string };
+    act(() => {
+      res = result.current.add({ kind: "etf", ref: "VAS", label: "Vanguard" });
+    });
+    expect(res.ok).toBe(true);
+    expect(result.current.items).toHaveLength(1);
+    const item = result.current.items[0]!;
+    expect(item.kind).toBe("etf");
+    expect(item.ref).toBe("VAS");
+    expect(item.label).toBe("Vanguard");
+    expect(typeof item.addedAt).toBe("string");
+    expect(Number.isNaN(Date.parse(item.addedAt))).toBe(false);
+    expect(JSON.parse(store[NON_BROKER_KEY]!)).toHaveLength(1);
+  });
+
+  it("add is idempotent for an item already present", () => {
+    const { result } = renderHook(() => useComparisonCart());
+    act(() => {
+      result.current.add({ kind: "etf", ref: "VAS" });
+    });
+    let res!: { ok: boolean };
+    act(() => {
+      res = result.current.add({ kind: "etf", ref: "VAS" });
+    });
+    expect(res.ok).toBe(true);
+    expect(result.current.items).toHaveLength(1);
+  });
+
+  it("delegates broker adds to the shortlist hook", () => {
+    const { result } = renderHook(() => useComparisonCart());
+    let res!: { ok: boolean };
+    act(() => {
+      res = result.current.add({ kind: "broker", ref: "stake" });
+    });
+    expect(res.ok).toBe(true);
+    expect(shortlistMock.add).toHaveBeenCalledWith("stake");
+    // broker items are not written to the non-broker localStorage layer
+    expect(store[NON_BROKER_KEY]).toBeUndefined();
+  });
+
+  it("composes broker shortlist + non-broker layer in the unified view", () => {
+    shortlistState.slugs = ["stake", "pearler"];
+    store[NON_BROKER_KEY] = JSON.stringify([
+      { kind: "advisor", ref: "jane", addedAt: "2026-01-01T00:00:00Z" },
+    ]);
+    const { result } = renderHook(() => useComparisonCart());
+    expect(result.current.count).toBe(3);
+    const kinds = result.current.items.map((i) => i.kind);
+    expect(kinds).toEqual(["broker", "broker", "advisor"]);
+    const brokerItem = result.current.items.find((i) => i.kind === "broker")!;
+    expect(brokerItem.addedAt).toBe("1970-01-01T00:00:00Z");
+  });
+
+  it("has() matches on both kind and ref", () => {
+    store[NON_BROKER_KEY] = JSON.stringify([
+      { kind: "etf", ref: "VAS", addedAt: "2026-01-01T00:00:00Z" },
+    ]);
+    shortlistState.slugs = ["stake"];
+    const { result } = renderHook(() => useComparisonCart());
+    expect(result.current.has({ kind: "etf", ref: "VAS" })).toBe(true);
+    expect(result.current.has({ kind: "broker", ref: "stake" })).toBe(true);
+    expect(result.current.has({ kind: "advisor", ref: "VAS" })).toBe(false);
+    expect(result.current.has({ kind: "etf", ref: "nope" })).toBe(false);
+  });
+
+  it("rejects an add once the cart is full", () => {
+    store[NON_BROKER_KEY] = JSON.stringify(
+      Array.from({ length: CART_MAX_TOTAL }, (_, i) => ({
+        kind: "etf",
+        ref: `etf-${i}`,
+        addedAt: "2026-01-01T00:00:00Z",
+      })),
+    );
+    const { result } = renderHook(() => useComparisonCart());
+    expect(result.current.isFull).toBe(true);
+    let res!: { ok: boolean; reason?: string };
+    act(() => {
+      res = result.current.add({ kind: "etf", ref: "overflow" });
+    });
+    expect(res.ok).toBe(false);
+    expect(res.reason).toContain("full");
+    expect(result.current.count).toBe(CART_MAX_TOTAL);
+  });
+
+  it("removes a non-broker item and persists", () => {
+    store[NON_BROKER_KEY] = JSON.stringify([
+      { kind: "etf", ref: "VAS", addedAt: "2026-01-01T00:00:00Z" },
+      { kind: "advisor", ref: "jane", addedAt: "2026-01-02T00:00:00Z" },
+    ]);
+    const { result } = renderHook(() => useComparisonCart());
+    act(() => result.current.remove({ kind: "etf", ref: "VAS" }));
+    expect(result.current.items).toEqual([
+      { kind: "advisor", ref: "jane", addedAt: "2026-01-02T00:00:00Z" },
+    ]);
+    expect(JSON.parse(store[NON_BROKER_KEY]!)).toHaveLength(1);
+  });
+
+  it("delegates broker removes to the shortlist hook", () => {
+    shortlistState.slugs = ["stake"];
+    const { result } = renderHook(() => useComparisonCart());
+    act(() => result.current.remove({ kind: "broker", ref: "stake" }));
+    expect(shortlistMock.remove).toHaveBeenCalledWith("stake");
+  });
+
+  it("clear() empties only the non-broker layer, leaving broker shortlist intact", () => {
+    shortlistState.slugs = ["stake"];
+    store[NON_BROKER_KEY] = JSON.stringify([
+      { kind: "etf", ref: "VAS", addedAt: "2026-01-01T00:00:00Z" },
+    ]);
+    const { result } = renderHook(() => useComparisonCart());
+    act(() => result.current.clear());
+    // non-broker gone, broker remains
+    expect(result.current.items.map((i) => i.kind)).toEqual(["broker"]);
+    expect(JSON.parse(store[NON_BROKER_KEY]!)).toEqual([]);
+    expect(shortlistMock.remove).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/lib/hooks/useListingShortlist.test.ts
+++ b/__tests__/lib/hooks/useListingShortlist.test.ts
@@ -1,0 +1,151 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+import { useListingShortlist } from "@/lib/hooks/useListingShortlist";
+
+const STORAGE_KEY = "invest_listing_shortlist_v1";
+
+// ── localStorage stub ─────────────────────────────────────────────────────────
+
+const store: Record<string, string> = {};
+const localStorageMock = {
+  getItem: vi.fn((key: string) => store[key] ?? null),
+  setItem: vi.fn((key: string, val: string) => {
+    store[key] = val;
+  }),
+  removeItem: vi.fn((key: string) => {
+    delete store[key];
+  }),
+  clear: vi.fn(() => {
+    Object.keys(store).forEach((k) => delete store[k]);
+  }),
+};
+
+beforeEach(() => {
+  localStorageMock.clear();
+  vi.clearAllMocks();
+  Object.defineProperty(window, "localStorage", {
+    value: localStorageMock,
+    writable: true,
+    configurable: true,
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useListingShortlist", () => {
+  it("starts empty when nothing is stored", () => {
+    const { result } = renderHook(() => useListingShortlist());
+    expect(result.current.slugs).toEqual([]);
+    expect(result.current.count).toBe(0);
+    expect(result.current.max).toBe(4);
+  });
+
+  it("hydrates from localStorage on mount", () => {
+    store[STORAGE_KEY] = JSON.stringify(["a", "b"]);
+    const { result } = renderHook(() => useListingShortlist());
+    expect(result.current.slugs).toEqual(["a", "b"]);
+    expect(result.current.count).toBe(2);
+  });
+
+  it("ignores non-string entries when hydrating", () => {
+    store[STORAGE_KEY] = JSON.stringify(["a", 5, null, "b", { x: 1 }]);
+    const { result } = renderHook(() => useListingShortlist());
+    expect(result.current.slugs).toEqual(["a", "b"]);
+  });
+
+  it("treats malformed JSON as empty", () => {
+    store[STORAGE_KEY] = "{not valid json";
+    const { result } = renderHook(() => useListingShortlist());
+    expect(result.current.slugs).toEqual([]);
+  });
+
+  it("treats a non-array stored value as empty", () => {
+    store[STORAGE_KEY] = JSON.stringify({ foo: "bar" });
+    const { result } = renderHook(() => useListingShortlist());
+    expect(result.current.slugs).toEqual([]);
+  });
+
+  it("toggle adds a slug and persists it", () => {
+    const { result } = renderHook(() => useListingShortlist());
+    act(() => result.current.toggle("broker-x"));
+    expect(result.current.slugs).toEqual(["broker-x"]);
+    expect(result.current.count).toBe(1);
+    expect(JSON.parse(store[STORAGE_KEY]!)).toEqual(["broker-x"]);
+  });
+
+  it("toggle removes a slug that is already present", () => {
+    const { result } = renderHook(() => useListingShortlist());
+    act(() => result.current.toggle("broker-x"));
+    act(() => result.current.toggle("broker-x"));
+    expect(result.current.slugs).toEqual([]);
+    expect(JSON.parse(store[STORAGE_KEY]!)).toEqual([]);
+  });
+
+  it("has() reflects membership", () => {
+    const { result } = renderHook(() => useListingShortlist());
+    expect(result.current.has("broker-x")).toBe(false);
+    act(() => result.current.toggle("broker-x"));
+    expect(result.current.has("broker-x")).toBe(true);
+  });
+
+  it("enforces the MAX_SHORTLIST cap of 4", () => {
+    const { result } = renderHook(() => useListingShortlist());
+    act(() => {
+      result.current.toggle("a");
+    });
+    act(() => result.current.toggle("b"));
+    act(() => result.current.toggle("c"));
+    act(() => result.current.toggle("d"));
+    act(() => result.current.toggle("e"));
+    expect(result.current.count).toBe(4);
+    expect(result.current.slugs).toEqual(["a", "b", "c", "d"]);
+    expect(result.current.has("e")).toBe(false);
+  });
+
+  it("can still remove an item once at the cap", () => {
+    const { result } = renderHook(() => useListingShortlist());
+    act(() => result.current.toggle("a"));
+    act(() => result.current.toggle("b"));
+    act(() => result.current.toggle("c"));
+    act(() => result.current.toggle("d"));
+    act(() => result.current.toggle("b")); // remove
+    expect(result.current.slugs).toEqual(["a", "c", "d"]);
+    // now a new add succeeds
+    act(() => result.current.toggle("e"));
+    expect(result.current.slugs).toEqual(["a", "c", "d", "e"]);
+  });
+
+  it("clear() empties the shortlist and persists empty", () => {
+    const { result } = renderHook(() => useListingShortlist());
+    act(() => result.current.toggle("a"));
+    act(() => result.current.toggle("b"));
+    act(() => result.current.clear());
+    expect(result.current.slugs).toEqual([]);
+    expect(result.current.count).toBe(0);
+    expect(JSON.parse(store[STORAGE_KEY]!)).toEqual([]);
+  });
+
+  it("dispatches a CustomEvent so other instances stay in sync", () => {
+    const { result: a } = renderHook(() => useListingShortlist());
+    const { result: b } = renderHook(() => useListingShortlist());
+    act(() => a.current.toggle("shared-slug"));
+    // the second hook listens for the change event and updates
+    expect(b.current.slugs).toEqual(["shared-slug"]);
+  });
+
+  it("silently ignores a localStorage write failure", () => {
+    localStorageMock.setItem.mockImplementationOnce(() => {
+      throw new Error("quota");
+    });
+    const { result } = renderHook(() => useListingShortlist());
+    expect(() => act(() => result.current.toggle("a"))).not.toThrow();
+    // state still updates even though persistence threw
+    expect(result.current.slugs).toEqual(["a"]);
+  });
+});

--- a/__tests__/lib/posthog/events.test.ts
+++ b/__tests__/lib/posthog/events.test.ts
@@ -1,0 +1,144 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+import { trackEvent, getDistinctId } from "@/lib/posthog/events";
+
+type PostHogStub = {
+  capture: ReturnType<typeof vi.fn>;
+  get_distinct_id?: ReturnType<typeof vi.fn>;
+};
+
+function setPosthog(stub: PostHogStub | undefined): void {
+  (window as unknown as { posthog?: PostHogStub }).posthog = stub;
+}
+
+let capture: ReturnType<typeof vi.fn>;
+let getId: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  capture = vi.fn();
+  getId = vi.fn(() => "distinct-123");
+  setPosthog({ capture, get_distinct_id: getId });
+});
+
+afterEach(() => {
+  setPosthog(undefined);
+  vi.restoreAllMocks();
+});
+
+describe("trackEvent", () => {
+  it("forwards the event name and props to posthog.capture", () => {
+    const props = {
+      quiz_type: "advisor_match" as const,
+      source_page: "/quiz",
+    };
+    trackEvent("quiz_started", props);
+    expect(capture).toHaveBeenCalledTimes(1);
+    expect(capture).toHaveBeenCalledWith("quiz_started", props);
+  });
+
+  it("passes the props object through unchanged (same reference, full shape)", () => {
+    const props = {
+      quiz_type: "diy_broker" as const,
+      time_taken_seconds: 42,
+      selected_advisor_type: "smsf",
+      budget_range: "100k-250k",
+      risk_profile: "balanced",
+      top_match_slug: "jane-doe",
+      match_count: 3,
+      country: "hong_kong",
+    };
+    trackEvent("quiz_completed", props);
+    const [name, sent] = capture.mock.calls[0]!;
+    expect(name).toBe("quiz_completed");
+    expect(sent).toBe(props);
+    expect(sent).toEqual(props);
+  });
+
+  it("supports null-valued optional dimensions (e.g. domestic track)", () => {
+    trackEvent("quiz_completed", {
+      quiz_type: "advisor_match",
+      time_taken_seconds: 10,
+      selected_advisor_type: null,
+      budget_range: null,
+      risk_profile: null,
+      top_match_slug: null,
+      match_count: 0,
+      country: null,
+    });
+    expect(capture.mock.calls[0]![1]).toMatchObject({ country: null });
+  });
+
+  it("does nothing when posthog is not attached to window", () => {
+    setPosthog(undefined);
+    expect(() =>
+      trackEvent("advisor_viewed", {
+        advisor_id: 1,
+        advisor_name: "Jane",
+        advisor_type: "planner",
+        firm: null,
+        city: null,
+      }),
+    ).not.toThrow();
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it("captures each of the documented event names", () => {
+    trackEvent("advisor_contacted", {
+      advisor_id: 1,
+      contact_method: "email",
+      source_section: "profile",
+    });
+    trackEvent("lead_submitted", {
+      lead_source: "quiz",
+      source_page: "/quiz",
+      advisor_match_count: 2,
+      quiz_completed: true,
+      utm_source: "google",
+      utm_campaign: "spring",
+    });
+    trackEvent("advisor_response", {
+      lead_id: 9,
+      advisor_id: 1,
+      response_time_minutes: 30,
+      lead_source: "quiz",
+    });
+    trackEvent("lead_outcome", {
+      lead_id: 9,
+      advisor_id: 1,
+      outcome: "converted",
+      lead_source: "quiz",
+    });
+    const names = capture.mock.calls.map((c) => c[0]);
+    expect(names).toEqual([
+      "advisor_contacted",
+      "lead_submitted",
+      "advisor_response",
+      "lead_outcome",
+    ]);
+  });
+});
+
+describe("getDistinctId", () => {
+  it("returns the distinct id from posthog", () => {
+    expect(getDistinctId()).toBe("distinct-123");
+    expect(getId).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns null when posthog is not present", () => {
+    setPosthog(undefined);
+    expect(getDistinctId()).toBeNull();
+  });
+
+  it("returns null when get_distinct_id is missing on the client", () => {
+    setPosthog({ capture: vi.fn() });
+    expect(getDistinctId()).toBeNull();
+  });
+
+  it("returns null when get_distinct_id yields undefined", () => {
+    setPosthog({ capture: vi.fn(), get_distinct_id: vi.fn(() => undefined as unknown as string) });
+    expect(getDistinctId()).toBeNull();
+  });
+});

--- a/__tests__/lib/pro-intake/templates.test.ts
+++ b/__tests__/lib/pro-intake/templates.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  INTAKE_TEMPLATES,
+  getTemplatesForCategory,
+  type IntakeTemplate,
+} from "@/lib/pro-intake/templates";
+
+const VALID_KINDS = new Set(["text", "number", "select", "phone", "email"]);
+
+describe("INTAKE_TEMPLATES (static invariants)", () => {
+  it("ships a non-empty list", () => {
+    expect(INTAKE_TEMPLATES.length).toBeGreaterThan(0);
+  });
+
+  it("has unique slugs", () => {
+    const slugs = INTAKE_TEMPLATES.map((t) => t.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+
+  it("every template has a title, blurb, and at least one match key", () => {
+    for (const t of INTAKE_TEMPLATES) {
+      expect(t.title.length).toBeGreaterThan(0);
+      expect(t.blurb.length).toBeGreaterThan(0);
+      expect(t.match.length).toBeGreaterThan(0);
+      expect(t.match.every((m) => typeof m === "string" && m.length > 0)).toBe(
+        true,
+      );
+    }
+  });
+
+  it("every template has 4-5 questions (per the doc'd pack size)", () => {
+    for (const t of INTAKE_TEMPLATES) {
+      expect(t.questions.length).toBeGreaterThanOrEqual(4);
+      expect(t.questions.length).toBeLessThanOrEqual(5);
+    }
+  });
+
+  it("every question has a prompt and a valid kind", () => {
+    for (const t of INTAKE_TEMPLATES) {
+      for (const q of t.questions) {
+        expect(q.prompt.length).toBeGreaterThan(0);
+        expect(VALID_KINDS.has(q.kind)).toBe(true);
+        expect(typeof q.required).toBe("boolean");
+      }
+    }
+  });
+
+  it("select questions carry a non-empty options array; non-select questions carry none", () => {
+    for (const t of INTAKE_TEMPLATES) {
+      for (const q of t.questions) {
+        if (q.kind === "select") {
+          expect(Array.isArray(q.options)).toBe(true);
+          expect(q.options!.length).toBeGreaterThan(0);
+          expect(q.options!.every((o) => typeof o === "string" && o.length > 0)).toBe(
+            true,
+          );
+        } else {
+          expect(q.options).toBeUndefined();
+        }
+      }
+    }
+  });
+
+  it("does not repeat option labels within a single question", () => {
+    for (const t of INTAKE_TEMPLATES) {
+      for (const q of t.questions) {
+        if (q.options) {
+          expect(new Set(q.options).size).toBe(q.options.length);
+        }
+      }
+    }
+  });
+});
+
+describe("getTemplatesForCategory", () => {
+  it("returns all templates when category is null/undefined/empty", () => {
+    expect(getTemplatesForCategory(null)).toEqual(INTAKE_TEMPLATES);
+    expect(getTemplatesForCategory(undefined)).toEqual(INTAKE_TEMPLATES);
+    expect(getTemplatesForCategory("")).toEqual(INTAKE_TEMPLATES);
+  });
+
+  it("returns every template even when there is no match (fallback)", () => {
+    const out = getTemplatesForCategory("totally-unknown-category");
+    expect(out).toEqual(INTAKE_TEMPLATES);
+    expect(out.length).toBe(INTAKE_TEMPLATES.length);
+  });
+
+  it("surfaces the matching template first, then the rest", () => {
+    const out = getTemplatesForCategory("business_acquisition");
+    expect(out[0]!.slug).toBe("sme_acquisition_starter");
+    // still returns the full set, no duplicates, no drops
+    expect(out.length).toBe(INTAKE_TEMPLATES.length);
+    expect(new Set(out.map((t) => t.slug)).size).toBe(INTAKE_TEMPLATES.length);
+  });
+
+  it("matches case-insensitively", () => {
+    const lower = getTemplatesForCategory("smsf_property");
+    const upper = getTemplatesForCategory("SMSF_PROPERTY");
+    const mixed = getTemplatesForCategory("Smsf_Property");
+    expect(lower[0]!.slug).toBe("smsf_property_starter");
+    expect(upper[0]!.slug).toBe("smsf_property_starter");
+    expect(mixed[0]!.slug).toBe("smsf_property_starter");
+  });
+
+  it("matches on any key within a template's match array", () => {
+    // smsf_property_starter lists several aliases
+    for (const alias of [
+      "smsf_property",
+      "smsf_strategy",
+      "smsf_accounting",
+      "smsf_accountant",
+    ]) {
+      expect(getTemplatesForCategory(alias)[0]!.slug).toBe(
+        "smsf_property_starter",
+      );
+    }
+  });
+
+  it("can surface multiple templates first when several share a match", () => {
+    // No category matches two templates in current data, but assert the
+    // ordering contract holds: matched come before unmatched.
+    const out = getTemplatesForCategory("cross_border_tax");
+    const matched: IntakeTemplate[] = INTAKE_TEMPLATES.filter((t) =>
+      t.match.includes("cross_border_tax"),
+    );
+    expect(out.slice(0, matched.length).map((t) => t.slug)).toEqual(
+      matched.map((t) => t.slug),
+    );
+  });
+
+  it("does not mutate the source array", () => {
+    const before = [...INTAKE_TEMPLATES];
+    getTemplatesForCategory("business_acquisition");
+    expect(INTAKE_TEMPLATES).toEqual(before);
+  });
+});


### PR DESCRIPTION
## Summary
Direct unit tests for untested lib modules. 50 tests: `hooks/useComparisonCart` + `hooks/useListingShortlist` (jsdom renderHook — hydrate/add/remove/cap/clear/cross-instance sync), `posthog/events` (trackEvent/getDistinctId across all branches), `pro-intake/templates` (selection logic + data invariants).

## Queue item
D-COV pre-launch coverage push (lib coverage → M01).

## Supersedes
_None._

## Test plan
- [x] vitest 50/50 local
- [ ] CI green