### PR TITLE
fix(reliability): auto-retry failed outbound webhook deliveries (§5 #17)

### DIFF
--- a/__tests__/lib/outbound-webhooks-retry.test.ts
+++ b/__tests__/lib/outbound-webhooks-retry.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/logger", () => ({
+  logger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}));
+
+let deliveriesData: unknown[] = [];
+let endpointRow: Record<string, unknown> | null = null;
+
+function makeChain() {
+  const c: Record<string, unknown> = {};
+  for (const m of ["select", "gte", "order", "eq", "update", "insert"]) c[m] = vi.fn(() => c);
+  // Endpoint lookup terminates in .maybeSingle()
+  c.maybeSingle = () => Promise.resolve({ data: endpointRow, error: null });
+  // Deliveries fetch terminates in .order() then await → chain.then
+  c.then = (resolve: (v: { data: unknown; error: unknown }) => unknown) =>
+    Promise.resolve(resolve({ data: deliveriesData, error: null }));
+  return c;
+}
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({
+    from: () => makeChain(),
+    rpc: () => ({ single: () => Promise.resolve({ data: null, error: null }) }),
+  }),
+}));
+
+import { retryFailedOutboundWebhooks } from "@/lib/outbound-webhooks";
+
+describe("retryFailedOutboundWebhooks", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    endpointRow = {
+      id: 1,
+      url: "https://sub.example/hook",
+      signing_secret: "whsec_test",
+      owner_kind: "professional",
+      owner_id: "p1",
+      event_subscriptions: ["brief.accepted"],
+      enabled: true,
+    };
+    // Retried delivery fails again — we only assert it was re-attempted.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: false, status: 503, text: async () => "down" })),
+    );
+  });
+
+  it("retries latest-failed groups, skips succeeded + over-cap", async () => {
+    deliveriesData = [
+      // group A (endpoint 1): single failure → retry
+      { endpoint_id: 1, event_type: "brief.accepted", payload: { a: 1 }, response_status: 500, delivered_at: "2026-05-20T01:00:00Z" },
+      // group B (endpoint 2): failed then succeeded → skip
+      { endpoint_id: 2, event_type: "brief.done", payload: { b: 2 }, response_status: 500, delivered_at: "2026-05-20T01:00:00Z" },
+      { endpoint_id: 2, event_type: "brief.done", payload: { b: 2 }, response_status: 200, delivered_at: "2026-05-20T02:00:00Z" },
+      // group C (endpoint 3): 5 failures → at cap → skip
+      ...Array.from({ length: 5 }, (_, i) => ({
+        endpoint_id: 3,
+        event_type: "x",
+        payload: { c: 3 },
+        response_status: 500,
+        delivered_at: `2026-05-20T0${i}:30:00Z`,
+      })),
+    ];
+
+    const stats = await retryFailedOutboundWebhooks();
+    expect(stats.groups).toBe(3);
+    expect(stats.retried).toBe(1);
+    expect(stats.skipped_succeeded).toBe(1);
+    expect(stats.skipped_max_attempts).toBe(1);
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns zeroed stats when there are no recent deliveries", async () => {
+    deliveriesData = [];
+    const stats = await retryFailedOutboundWebhooks();
+    expect(stats).toEqual({
+      groups: 0,
+      retried: 0,
+      skipped_succeeded: 0,
+      skipped_max_attempts: 0,
+      skipped_endpoint_gone: 0,
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/app/api/cron/retry-outbound-webhooks/route.ts
+++ b/app/api/cron/retry-outbound-webhooks/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireCronAuth } from "@/lib/cron-auth";
+import { wrapCronHandler } from "@/lib/cron-run-log";
+import { retryFailedOutboundWebhooks } from "@/lib/outbound-webhooks";
+import { logger } from "@/lib/logger";
+
+const log = logger("cron-retry-outbound-webhooks");
+
+export const runtime = "nodejs";
+export const maxDuration = 60;
+
+/**
+ * Cron: re-attempt recently-failed OUTBOUND webhook deliveries (audit §5 #17).
+ *
+ * Outbound deliveries were admin-replay-only, so a downed subscriber endpoint
+ * silently dropped events. This re-delivers failures from the last 24h that
+ * have no later success and are under the per-event attempt cap. Runs every
+ * 30m (effective backoff = the interval); the cap prevents infinite retries.
+ */
+async function handler(req: NextRequest): Promise<NextResponse> {
+  const unauth = requireCronAuth(req);
+  if (unauth) return unauth;
+
+  const stats = await retryFailedOutboundWebhooks();
+  log.info("retry-outbound-webhooks completed", stats);
+  return NextResponse.json({ ok: true, ...stats });
+}
+
+export const GET = wrapCronHandler("retry-outbound-webhooks", handler);

--- a/lib/cron-groups.ts
+++ b/lib/cron-groups.ts
@@ -34,7 +34,7 @@ export const CRON_GROUPS: Record<string, readonly string[]> = {
     "/api/cron/lead-sla-check",
     "/api/cron/editorial-auto-publish",
   ],
-  "every-30m": ["/api/cron/heartbeat", "/api/cron/retry-webhooks", "/api/cron/auction-close"],
+  "every-30m": ["/api/cron/heartbeat", "/api/cron/retry-webhooks", "/api/cron/retry-outbound-webhooks", "/api/cron/auction-close"],
   "every-6h": ["/api/admin/run-migration"],
 
   "daily-0": ["/api/cron/auto-publish"],

--- a/lib/outbound-webhooks/index.ts
+++ b/lib/outbound-webhooks/index.ts
@@ -194,3 +194,109 @@ async function deliverWithLogging(
     });
   }
 }
+
+const RETRY_WINDOW_MS = 24 * 60 * 60 * 1000;
+const MAX_DELIVERY_ATTEMPTS = 5;
+
+function isDeliveryOk(status: number | null): boolean {
+  return status !== null && status >= 200 && status < 300;
+}
+
+/**
+ * Auto-retry recently-failed outbound deliveries (audit §5 #17). Without this
+ * a downed subscriber endpoint silently drops events until an admin manually
+ * replays. Groups deliveries in the last 24h by (endpoint, event, payload);
+ * for any group whose latest attempt failed and that is under the attempt cap,
+ * re-signs with a fresh timestamp and re-delivers (logging a new attempt).
+ * Effective spacing = the cron interval; the attempt cap stops infinite retries.
+ * Migration-free — attempts are counted from the existing deliveries rows.
+ */
+export async function retryFailedOutboundWebhooks(): Promise<{
+  groups: number;
+  retried: number;
+  skipped_succeeded: number;
+  skipped_max_attempts: number;
+  skipped_endpoint_gone: number;
+}> {
+  const admin = createAdminClient();
+  const since = new Date(Date.now() - RETRY_WINDOW_MS).toISOString();
+  const { data: deliveries } = await admin
+    .from("outbound_webhook_deliveries")
+    .select("endpoint_id, event_type, payload, response_status, delivered_at")
+    .gte("delivered_at", since)
+    .order("delivered_at", { ascending: true });
+
+  const stats = {
+    groups: 0,
+    retried: 0,
+    skipped_succeeded: 0,
+    skipped_max_attempts: 0,
+    skipped_endpoint_gone: 0,
+  };
+  if (!deliveries || deliveries.length === 0) return stats;
+
+  // Group by endpoint+event+payload. Rows are ascending by time, so the last
+  // row seen per key is the latest attempt.
+  interface Group {
+    endpoint_id: number;
+    event_type: string;
+    payload: Record<string, unknown>;
+    attempts: number;
+    latestOk: boolean;
+  }
+  const groups = new Map<string, Group>();
+  for (const d of deliveries as Array<{
+    endpoint_id: number;
+    event_type: string;
+    payload: Record<string, unknown>;
+    response_status: number | null;
+  }>) {
+    const key = `${d.endpoint_id}|${d.event_type}|${JSON.stringify(d.payload)}`;
+    const g = groups.get(key) ?? {
+      endpoint_id: d.endpoint_id,
+      event_type: d.event_type,
+      payload: d.payload,
+      attempts: 0,
+      latestOk: false,
+    };
+    g.attempts += 1;
+    g.latestOk = isDeliveryOk(d.response_status);
+    groups.set(key, g);
+  }
+  stats.groups = groups.size;
+
+  for (const g of groups.values()) {
+    if (g.latestOk) {
+      stats.skipped_succeeded += 1;
+      continue;
+    }
+    if (g.attempts >= MAX_DELIVERY_ATTEMPTS) {
+      stats.skipped_max_attempts += 1;
+      continue;
+    }
+    const { data: ep } = await admin
+      .from("outbound_webhook_endpoints")
+      .select("*")
+      .eq("id", g.endpoint_id)
+      .eq("enabled", true)
+      .maybeSingle();
+    if (!ep) {
+      stats.skipped_endpoint_gone += 1;
+      continue;
+    }
+    const ts = Math.floor(Date.now() / 1000);
+    const body = JSON.stringify({ event: g.event_type, ts, data: g.payload });
+    const signature = signPayload(ts, body, (ep as WebhookEndpoint).signing_secret);
+    await deliverWithLogging(
+      ep as WebhookEndpoint,
+      g.event_type,
+      body,
+      signature,
+      ts,
+      g.payload,
+    );
+    stats.retried += 1;
+  }
+
+  return stats;
+}


### PR DESCRIPTION
Closes new-features audit §5 flag #17 (P2).

Outbound webhook deliveries were admin-replay-only, so a downed subscriber endpoint silently dropped events. Adds retryFailedOutboundWebhooks() — groups deliveries from the last 24h by (endpoint, event, payload); for any group whose latest attempt failed and is under a 5-attempt cap, re-signs with a fresh timestamp and re-delivers (logging a new attempt). New every-30m cron drives it. Migration-free (attempts counted from existing rows). Unit tests cover retry/skip-succeeded/skip-cap. requireCronAuth on the route.

Tier C (cron + webhook lib) — your merge.

Generated with Claude Code