### PR TITLE
feat(first-home-buyer): savings-account match on the FHB hub

### DIFF
--- a/__tests__/api/referrals-accept.test.ts
+++ b/__tests__/api/referrals-accept.test.ts
@@ -18,7 +18,7 @@ const {
   return {
     isAllowedMock: vi.fn(() => Promise.resolve(true)),
     ipKeyMock: vi.fn(() => "ip:1.2.3.4"),
-    requireAdvisorSessionMock: vi.fn(() => Promise.resolve(42)),
+    requireAdvisorSessionMock: vi.fn<() => Promise<number | null>>(() => Promise.resolve(42)),
     acceptReferralMock: vi.fn(),
     ReferralError,
   };

--- a/__tests__/api/referrals-decline.test.ts
+++ b/__tests__/api/referrals-decline.test.ts
@@ -17,7 +17,7 @@ const {
   return {
     isAllowedMock: vi.fn(() => Promise.resolve(true)),
     ipKeyMock: vi.fn(() => "ip:1.2.3.4"),
-    requireAdvisorSessionMock: vi.fn(() => Promise.resolve(42)),
+    requireAdvisorSessionMock: vi.fn<() => Promise<number | null>>(() => Promise.resolve(42)),
     declineReferralMock: vi.fn(),
     ReferralError,
   };

--- a/__tests__/api/teams-briefs-claim.test.ts
+++ b/__tests__/api/teams-briefs-claim.test.ts
@@ -19,7 +19,7 @@ vi.mock("@/lib/require-advisor-session", () => ({
 }));
 
 const resolveSquadRouteContextMock = vi.fn();
-const listOtherActiveMembersMock = vi.fn(async () => []);
+const listOtherActiveMembersMock = vi.fn(async (..._args: unknown[]) => []);
 vi.mock("@/lib/team-brief-routes", () => ({
   resolveSquadRouteContext: (...args: unknown[]) => resolveSquadRouteContextMock(...args),
   listOtherActiveMembers: (...args: unknown[]) => listOtherActiveMembersMock(...args),

--- a/__tests__/api/teams-decisions.test.ts
+++ b/__tests__/api/teams-decisions.test.ts
@@ -17,7 +17,7 @@ vi.mock("@/lib/require-advisor-session", () => ({
 }));
 
 const recordDecisionMock = vi.fn();
-const clearDecisionMock = vi.fn(async () => undefined);
+const clearDecisionMock = vi.fn(async (..._args: unknown[]) => undefined);
 vi.mock("@/lib/team-brief-decisions", () => ({
   recordDecision: (...args: unknown[]) => recordDecisionMock(...args),
   clearDecision: (...args: unknown[]) => clearDecisionMock(...args),

--- a/__tests__/components/FhbSavingsMatch.test.tsx
+++ b/__tests__/components/FhbSavingsMatch.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "./setup";
+import FhbSavingsMatch from "@/components/first-home-buyer/FhbSavingsMatch";
+import { firstHomeBuyerSavingsUrl } from "@/lib/first-home-buyer/savings-match";
+
+describe("FhbSavingsMatch", () => {
+  it("links to the attributed high-interest-savings directory", () => {
+    render(<FhbSavingsMatch />);
+    const link = screen.getByRole("link", {
+      name: /compare all high-interest savings accounts/i,
+    });
+    expect(link).toHaveAttribute("href", firstHomeBuyerSavingsUrl());
+  });
+
+  it("explains the FHSS-vs-cash deposit split and the $250k guarantee", () => {
+    render(<FhbSavingsMatch />);
+    expect(screen.getByText(/FHSS scheme/i)).toBeInTheDocument();
+    expect(screen.getByText(/\$250,000/)).toBeInTheDocument();
+  });
+
+  it("carries the general advice warning", () => {
+    render(<FhbSavingsMatch />);
+    expect(screen.getByText(/general advice warning/i)).toBeInTheDocument();
+  });
+});

--- a/__tests__/lib/first-home-buyer/savings-match.test.ts
+++ b/__tests__/lib/first-home-buyer/savings-match.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import {
+  FHB_SAVINGS_CATEGORY_SLUG,
+  FHB_SAVINGS_REF,
+  firstHomeBuyerSavingsUrl,
+} from "@/lib/first-home-buyer/savings-match";
+import { getCategoryBySlug } from "@/lib/best-broker-categories";
+
+describe("first-home-buyer savings match", () => {
+  it("targets a best-page category that actually exists", () => {
+    // Drift guard: a renamed/removed slug would 404 the hub's "Compare all"
+    // link, the exact failure mode the broker-handoff lever was built to kill.
+    expect(getCategoryBySlug(FHB_SAVINGS_CATEGORY_SLUG)).toBeDefined();
+  });
+
+  it("targets a category scoped to savings accounts", () => {
+    const category = getCategoryBySlug(FHB_SAVINGS_CATEGORY_SLUG)!;
+    // The category filters to savings_account products — confirm the match
+    // routes deposit-savers at flexible-access savings (not term deposits).
+    expect(category.filter({ platform_type: "savings_account" } as never)).toBe(
+      true,
+    );
+    expect(category.filter({ platform_type: "term_deposit" } as never)).toBe(
+      false,
+    );
+  });
+
+  it("deep-links to the high-interest-savings directory with attribution", () => {
+    expect(firstHomeBuyerSavingsUrl()).toBe(
+      "/best/high-interest-savings?ref=first-home-buyer",
+    );
+  });
+
+  it("encodes a ref the directory can round-trip back", () => {
+    const url = new URL(firstHomeBuyerSavingsUrl(), "https://invest.com.au");
+    expect(url.pathname).toBe(`/best/${FHB_SAVINGS_CATEGORY_SLUG}`);
+    expect(url.searchParams.get("ref")).toBe(FHB_SAVINGS_REF);
+  });
+});

--- a/app/first-home-buyer/page.tsx
+++ b/app/first-home-buyer/page.tsx
@@ -4,6 +4,8 @@ import HubPage from "@/components/HubPage";
 import HubNewsletterCapture from "@/components/HubNewsletterCapture";
 import LeadMagnetCapture from "@/components/LeadMagnetCapture";
 import HubExitIntent from "@/components/HubExitIntent";
+import FhbSavingsMatch from "@/components/first-home-buyer/FhbSavingsMatch";
+import ArticleBrokerTable from "@/components/ArticleBrokerTable";
 import { getLeadMagnetForHub } from "@/lib/lead-magnets";
 import { firstHomeBuyerHubConfig } from "@/lib/hub-configs/first-home-buyer";
 
@@ -35,6 +37,14 @@ export default function FirstHomeBuyerPage() {
           />
         }
       >
+        <FhbSavingsMatch />
+        <div className="container-custom max-w-4xl">
+          <ArticleBrokerTable
+            vertical="savings"
+            maxBrokers={4}
+            heading="High-interest savings accounts for your deposit"
+          />
+        </div>
         {leadMagnet && <LeadMagnetCapture magnet={leadMagnet} />}
       </HubPage>
       <HubExitIntent

--- a/components/first-home-buyer/FhbSavingsMatch.tsx
+++ b/components/first-home-buyer/FhbSavingsMatch.tsx
@@ -1,0 +1,49 @@
+import Link from "next/link";
+import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
+import { firstHomeBuyerSavingsUrl } from "@/lib/first-home-buyer/savings-match";
+
+/**
+ * <FhbSavingsMatch> — First Home Buyer savings-match framing (W3.19 lever).
+ *
+ * Presentational only: explains where the cash portion of a deposit should
+ * sit (high-interest savings out of super) vs the FHSS portion (inside super),
+ * and links to the curated high-interest-savings directory. The ranked account
+ * list itself is rendered by <ArticleBrokerTable vertical="savings"> alongside
+ * this block in the page, so this component stays sync + trivially testable.
+ */
+export default function FhbSavingsMatch() {
+  return (
+    <section
+      className="container-custom max-w-4xl py-8"
+      data-testid="fhb-savings-match"
+      aria-labelledby="fhb-savings-match-heading"
+    >
+      <h2
+        id="fhb-savings-match-heading"
+        className="text-xl md:text-2xl font-extrabold text-slate-900 mb-2"
+      >
+        Where to keep your deposit while you save
+      </h2>
+      <p className="text-sm text-slate-600 leading-relaxed mb-3 max-w-2xl">
+        Most first home buyers split their deposit: up to{" "}
+        <strong>$50,000 inside super via the FHSS scheme</strong> (taxed at just
+        15% going in), and the rest in cash. The cash portion belongs in a
+        high-interest savings account — not a transaction account earning near
+        0%. Every account below is from an ADI-authorised bank, so your balance
+        is covered by the{" "}
+        <strong>Australian Government deposit guarantee up to $250,000</strong>.
+      </p>
+      <Link
+        href={firstHomeBuyerSavingsUrl()}
+        className="inline-flex items-center gap-1 text-sm font-semibold text-violet-600 hover:text-violet-800 transition-colors"
+        data-lever="lead_routing"
+      >
+        Compare all high-interest savings accounts &rarr;
+      </Link>
+      <p className="text-[11px] text-slate-400 leading-relaxed mt-4">
+        <strong className="text-slate-500">General advice warning.</strong>{" "}
+        {GENERAL_ADVICE_WARNING}
+      </p>
+    </section>
+  );
+}

--- a/lib/first-home-buyer/savings-match.ts
+++ b/lib/first-home-buyer/savings-match.ts
@@ -1,0 +1,25 @@
+/**
+ * First Home Buyer → high-interest savings handoff (W3.19 lever).
+ *
+ * Routes the First Home Buyer hub into the curated high-interest savings
+ * directory so the cash portion of a deposit (the part that doesn't go into
+ * super via FHSS) lands on ranked, FCS-guaranteed accounts instead of being
+ * left in a low-rate transaction account.
+ */
+
+/**
+ * Canonical best-page slug for the savings match. MUST stay in sync with a
+ * real category in `lib/best-broker-categories.ts` — a test asserts this so a
+ * renamed slug can't silently 404 the hub's "Compare all" link (the failure
+ * mode the broker-handoff lever was built to kill).
+ */
+export const FHB_SAVINGS_CATEGORY_SLUG = "high-interest-savings";
+
+/** Attribution tag so savings clicks from the FHB hub are distinguishable. */
+export const FHB_SAVINGS_REF = "first-home-buyer";
+
+/** Pre-attributed high-interest-savings directory URL for the FHB hub. */
+export function firstHomeBuyerSavingsUrl(): string {
+  const params = new URLSearchParams({ ref: FHB_SAVINGS_REF });
+  return `/best/${FHB_SAVINGS_CATEGORY_SLUG}?${params.toString()}`;
+}


### PR DESCRIPTION
## Summary
W3.19 savings-account match lever: the First Home Buyer hub now routes users to high-interest savings for the **cash portion** of their deposit (the part that doesn't go into super via FHSS). Adds a framing section (FHSS-vs-cash split + the $250k FCS deposit guarantee), the curated savings rail (`ArticleBrokerTable vertical="savings"`), and a drift-guarded deep-link to `/best/high-interest-savings`.

## Why
W3.19 (FHB end-to-end journey) shipped the hub + FHSS calc (#895), eligibility quiz (#919), state-grants calc (#1035) and mortgage-broker handoff (#1041). The savings-account match was the next remaining lever — the hub had **no** savings CTA at all, so deposit-savers had no route to a high-interest account. This is the deposit-accumulation monetization lever (savings affiliate links).

Also repairs four **pre-existing** test-only type errors that left `main`'s `tsc --noEmit` red (so the Type-check CI job + the pre-push hook were blocked for every PR). They landed via admin-merged D-COV coverage PRs (CI-bypassed): zero-param `vi.fn()` impls can't be spread into `(...args)` forwarder wrappers (empty-tuple `Parameters`), and a `number`-only `requireAdvisorSession` mock rejected its `null` path.

## Tier
**B** — additive page UI + new `lib/` helper + tests; the test-typing fixes are Tier A (tests). No schema, webhook, cron, Stripe, or admin surface. The FHB hub is `complianceKey: general_advice` (not AFSL-gated); a general-advice warning is rendered in-section.

## Files
- `lib/first-home-buyer/savings-match.ts` — `firstHomeBuyerSavingsUrl()` + `FHB_SAVINGS_CATEGORY_SLUG` (drift-guarded against `lib/best-broker-categories.ts`)
- `components/first-home-buyer/FhbSavingsMatch.tsx` — sync presentational framing section
- `app/first-home-buyer/page.tsx` — renders the section + `ArticleBrokerTable vertical="savings"` in the hub `children` slot
- `__tests__/lib/first-home-buyer/savings-match.test.ts` — 4 tests (slug-exists drift guard, savings_account scoping, URL + attribution round-trip)
- `__tests__/components/FhbSavingsMatch.test.tsx` — 3 tests (link href, FHSS/$250k copy, general-advice warning)
- `__tests__/api/{referrals-accept,referrals-decline,teams-briefs-claim,teams-decisions}.test.ts` — 4 one-line main-green type fixes

## Supersedes
_None._

## Test plan
- [x] vitest local: 7 new + 39 in the 4 repaired files all passing
- [x] type-check: `tsc --noEmit` clean (was red on main before this PR)
- [x] eslint: clean (`--max-warnings 0`)
- [x] pre-push hook: type-check + rate-limit audit + changed tests passed
- [ ] CI: pending
- [ ] Visual: open `/first-home-buyer` → "Where to keep your deposit" section renders, "Compare all high-interest savings accounts" lands on `/best/high-interest-savings?ref=first-home-buyer`, and the savings rail shows ranked accounts

---
_Generated by Claude Code (pre-launch-wave loop)._

---
_Generated by [Claude Code](https://claude.ai/code/session_01DurrV2qonksG6guDBwF8jH)_