### PR TITLE
feat(directory): URL-first filter state on /advisors (Session 7)

### DIFF
--- a/__tests__/components/AdvisorsClient.test.tsx
+++ b/__tests__/components/AdvisorsClient.test.tsx
@@ -1,24 +1,33 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { fireEvent } from "@testing-library/react";
-import { render, screen } from "./setup";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
 import AdvisorsClient from "@/app/advisors/AdvisorsClient";
 import type { Professional } from "@/lib/types";
 
-// next/navigation is referenced at module scope inside the mock factory, so the
-// shared mocks must be created via vi.hoisted (the factory is hoisted above
-// const declarations).
-const { mockReplace, mockSearchParams } = vi.hoisted(() => ({
+// Self-contained next/navigation mock (the URL-first assertions need a
+// seedable searchParams + an observable router.replace, so we can't lean on
+// the shared component-test setup whose mock returns fixed values). Hoisted so
+// the factory can reference the spies — see CLAUDE.md vi.mock note.
+const { mockReplace, paramsRef } = vi.hoisted(() => ({
   mockReplace: vi.fn(),
-  mockSearchParams: new URLSearchParams(),
+  paramsRef: { current: new URLSearchParams() },
 }));
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ replace: mockReplace, push: vi.fn(), prefetch: vi.fn() }),
-  useSearchParams: () => mockSearchParams,
+  usePathname: () => "/advisors",
+  useSearchParams: () => paramsRef.current,
 }));
 
 // GetMatchedEmbed pulls in heavy data-fetching children irrelevant to the filters.
 vi.mock("@/components/get-matched/GetMatchedEmbed", () => ({ default: () => null }));
+vi.mock("@/lib/tracking", async (importOriginal) => ({
+  ...(await importOriginal() as Record<string, unknown>),
+  trackEvent: vi.fn(),
+}));
+vi.mock("@/lib/hooks/useAdvisorShortlist", () => ({
+  useAdvisorShortlist: () => ({ toggle: vi.fn(), has: () => false, count: 0, max: 3 }),
+}));
 
 function pro(overrides: Partial<Professional> = {}): Professional {
   return {
@@ -34,7 +43,7 @@ function pro(overrides: Partial<Professional> = {}): Professional {
     created_at: "2026-01-01T00:00:00Z",
     updated_at: "2026-01-01T00:00:00Z",
     ...overrides,
-  };
+  } as Professional;
 }
 
 const professionals: Professional[] = [
@@ -54,6 +63,7 @@ const professionals: Professional[] = [
 describe("AdvisorsClient — directory primitives wiring", () => {
   beforeEach(() => {
     mockReplace.mockClear();
+    paramsRef.current = new URLSearchParams();
   });
 
   it("renders the Advisor Type options through the FacetGroup primitive", () => {
@@ -61,30 +71,31 @@ describe("AdvisorsClient — directory primitives wiring", () => {
     expect(screen.getByText("Advisor Type")).toBeInTheDocument();
     // FacetGroup labels are pluralised ("Financial Planners"); anchor to avoid
     // matching compound types like "Energy Financial Planners".
-    expect(
-      screen.getByRole("checkbox", { name: /^Financial Planners/ }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("checkbox", { name: /^SMSF Accountants/ }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole("checkbox", { name: /^Financial Planners/ })).toBeInTheDocument();
+    expect(screen.getByRole("checkbox", { name: /^SMSF Accountants/ })).toBeInTheDocument();
   });
 
   it("renders the Minimum rating RangeSlider (single-handle)", () => {
     render(<AdvisorsClient professionals={professionals} />);
     expect(screen.getByText("Minimum rating")).toBeInTheDocument();
-    const sliders = screen.getAllByRole("slider");
-    expect(sliders.length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByRole("slider").length).toBeGreaterThanOrEqual(1);
   });
 
-  it("surfaces an active-filter chip when a type facet is toggled on", () => {
+  it("toggling a type facet writes the matching URL param (URL-first)", () => {
     render(<AdvisorsClient professionals={professionals} />);
-    expect(screen.queryByText(/Filtering:/i)).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole("checkbox", { name: /^Financial Planners/ }));
+    expect(mockReplace).toHaveBeenCalled();
+    expect(mockReplace.mock.calls.at(-1)?.[0]).toContain("type=financial_planner");
+  });
+
+  it("renders an active-filter chip strip derived from the URL", () => {
+    paramsRef.current = new URLSearchParams("type=financial_planner");
+    render(<AdvisorsClient professionals={professionals} />);
     // The shared FilterChips strip renders its "Filtering:" prefix once a chip exists.
     expect(screen.getByText(/Filtering:/i)).toBeInTheDocument();
   });
 
-  it("renders no FilterChips strip when nothing is filtered", () => {
+  it("renders no FilterChips strip when the URL has no filters", () => {
     render(<AdvisorsClient professionals={professionals} />);
     expect(screen.queryByText(/Filtering:/i)).not.toBeInTheDocument();
   });

--- a/__tests__/lib/hooks-useDirectoryParams.test.tsx
+++ b/__tests__/lib/hooks-useDirectoryParams.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+const { mockReplace, paramsRef } = vi.hoisted(() => ({
+  mockReplace: vi.fn(),
+  paramsRef: { current: new URLSearchParams() },
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: mockReplace, push: vi.fn(), prefetch: vi.fn() }),
+  usePathname: () => "/advisors",
+  useSearchParams: () => paramsRef.current,
+}));
+
+import { useDirectoryParams } from "@/lib/hooks/useDirectoryParams";
+
+describe("useDirectoryParams", () => {
+  beforeEach(() => {
+    mockReplace.mockClear();
+    paramsRef.current = new URLSearchParams();
+  });
+
+  it("sets a param and replaces the URL on the current path", () => {
+    const { result } = renderHook(() => useDirectoryParams());
+    result.current.setParams({ state: "NSW" });
+    expect(mockReplace).toHaveBeenCalledWith("/advisors?state=NSW", { scroll: false });
+  });
+
+  it("deletes a param when the value is empty", () => {
+    paramsRef.current = new URLSearchParams("state=NSW&sort=name");
+    const { result } = renderHook(() => useDirectoryParams());
+    result.current.setParams({ state: "" });
+    expect(mockReplace).toHaveBeenCalledWith("/advisors?sort=name", { scroll: false });
+  });
+
+  it("preserves unrelated existing params", () => {
+    paramsRef.current = new URLSearchParams("utm=x");
+    const { result } = renderHook(() => useDirectoryParams());
+    result.current.setParams({ type: "financial_planner" });
+    const url = mockReplace.mock.calls.at(-1)?.[0] as string;
+    expect(url).toContain("utm=x");
+    expect(url).toContain("type=financial_planner");
+  });
+
+  it("drops the query string entirely when no params remain", () => {
+    paramsRef.current = new URLSearchParams("state=NSW");
+    const { result } = renderHook(() => useDirectoryParams());
+    result.current.setParams({ state: "" });
+    expect(mockReplace).toHaveBeenCalledWith("/advisors", { scroll: false });
+  });
+
+  it("clears only the given keys", () => {
+    paramsRef.current = new URLSearchParams("state=NSW&sort=name&utm=x");
+    const { result } = renderHook(() => useDirectoryParams());
+    result.current.clearParams(["state", "sort"]);
+    expect(mockReplace.mock.calls.at(-1)?.[0]).toBe("/advisors?utm=x");
+  });
+
+  it("clearParams() with no args removes the whole query string", () => {
+    paramsRef.current = new URLSearchParams("state=NSW&sort=name");
+    const { result } = renderHook(() => useDirectoryParams());
+    result.current.clearParams();
+    expect(mockReplace).toHaveBeenCalledWith("/advisors", { scroll: false });
+  });
+});

--- a/app/advisors/AdvisorsClient.tsx
+++ b/app/advisors/AdvisorsClient.tsx
@@ -1,9 +1,6 @@
 "use client";
 
-/* eslint-disable react-hooks/set-state-in-effect */
-
 import { useState, useMemo, useEffect, useCallback, useRef } from "react";
-import { useSearchParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import Image from "next/image";
 import GetMatchedEmbed from "@/components/get-matched/GetMatchedEmbed";
@@ -18,7 +15,7 @@ import { ADVISOR_SPECIALTY_CATEGORIES } from "@/lib/advisor-specialties";
 import TabBar from "@/components/directory/TabBar";
 import SearchInput from "@/components/directory/SearchInput";
 import SortDropdown from "@/components/directory/SortDropdown";
-import { resolveDirectoryFilters } from "./filter-params";
+import { useDirectoryParams } from "@/lib/hooks/useDirectoryParams";
 import FilterPanel from "@/components/directory/FilterPanel";
 import FacetGroup from "@/components/directory/FacetGroup";
 import RangeSlider from "@/components/directory/RangeSlider";
@@ -208,8 +205,7 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
   /** PR queue #12.5 — visitor's resolved intent country. When set, every advisor card renders an EligibilityBadge based on country_eligibility. */
   intentCountry?: import("@/lib/intent-context").IntentCountryCode | null;
 }) {
-  const searchParams = useSearchParams();
-  const router = useRouter();
+  const { params: searchParams, setParams, clearParams } = useDirectoryParams();
   const trackedRef = useRef(false);
 
   useEffect(() => {
@@ -224,34 +220,96 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
     }, '/advisors');
   }, [professionals.length, firms.length, expertTeams.length, initialType, initialState]);
 
-  const [providerType, setProviderType] = useState<ProviderType>("all");
-  const [typeFilters, setTypeFilters] = useState<Set<ProfessionalType>>(() => {
-    if (initialType) return new Set([initialType]);
-    return new Set();
-  });
-  const toggleType = (key: ProfessionalType | "all") => {
-    if (key === "all") {
-      setTypeFilters(new Set());
-    } else {
-      setTypeFilters(prev => {
-        const next = new Set(prev);
-        if (next.has(key)) next.delete(key); else next.add(key);
-        return next;
-      });
-    }
-  };
-  const [stateFilter, setStateFilter] = useState<string>(initialState || "all");
-  const [specialtyFilters, setSpecialtyFilters] = useState<string[]>([]);
+  // ── URL-first filter state (the URL is the single source of truth, mirroring
+  //    InvestListingsClient). Route-scoped pages seed type/state from the route
+  //    when the corresponding param is absent. ──
+  const providerType: ProviderType = (() => {
+    const pt = searchParams.get("provider_type");
+    return pt === "individual" || pt === "firm" || pt === "team" ? pt : "all";
+  })();
+
+  const typeParam = searchParams.get("type") ?? "";
+  const typeFilters = useMemo<Set<ProfessionalType>>(() => {
+    const fromUrl = typeParam
+      .split(",")
+      .filter((k) => TYPE_FILTERS.some((f) => f.key === k)) as ProfessionalType[];
+    if (fromUrl.length) return new Set(fromUrl);
+    return new Set(initialType ? [initialType] : []);
+  }, [typeParam, initialType]);
+
+  const stateParam = searchParams.get("state");
+  const stateFilter =
+    stateParam && (AU_STATES as readonly string[]).includes(stateParam)
+      ? stateParam
+      : initialState || "all";
+
+  const specialtyParam = searchParams.get("specialty") ?? "";
+  const specialtyFilters = useMemo(
+    () => specialtyParam.split(",").map((s) => s.trim()).filter(Boolean),
+    [specialtyParam],
+  );
+
+  const languageFilter = searchParams.get("language") || "all";
+
+  const sortParam = searchParams.get("sort");
+  const sortBy: SortKey = SORT_OPTIONS.some((o) => o.value === sortParam)
+    ? (sortParam as SortKey)
+    : "rating";
+
+  const setProviderType = useCallback(
+    (v: ProviderType) => setParams({ provider_type: v === "all" ? "" : v }),
+    [setParams],
+  );
+  const setTypeFilters = useCallback(
+    (next: Set<ProfessionalType>) => setParams({ type: Array.from(next).join(",") }),
+    [setParams],
+  );
+  const toggleType = useCallback(
+    (key: ProfessionalType) => {
+      const next = new Set(typeFilters);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      setTypeFilters(next);
+    },
+    [typeFilters, setTypeFilters],
+  );
+  const setStateFilter = useCallback(
+    (v: string) => setParams({ state: v === "all" ? "" : v }),
+    [setParams],
+  );
+  const setSpecialtyFilters = useCallback(
+    (next: string[]) => setParams({ specialty: next.join(",") }),
+    [setParams],
+  );
+  const toggleSpecialty = useCallback(
+    (s: string) =>
+      setSpecialtyFilters(
+        specialtyFilters.includes(s)
+          ? specialtyFilters.filter((x) => x !== s)
+          : [...specialtyFilters, s],
+      ),
+    [specialtyFilters, setSpecialtyFilters],
+  );
+  const setLanguageFilter = useCallback(
+    (v: string) => setParams({ language: v === "all" ? "" : v }),
+    [setParams],
+  );
+  const setSortBy = useCallback(
+    (v: SortKey) => setParams({ sort: v === "rating" ? "" : v }),
+    [setParams],
+  );
+
+  // ── Purely-local UI state (never persisted to the URL) ──
   const [feeFilter, setFeeFilter] = useState<string>("all");
   const [firmFilter, setFirmFilter] = useState<string>("all");
   const [minRating, setMinRating] = useState<number>(0);
   const [verifiedOnly, setVerifiedOnly] = useState(false);
   const [internationalOnly, setInternationalOnly] = useState(false);
-  const [languageFilter, setLanguageFilter] = useState<string>("all");
   const [acceptingOnly, setAcceptingOnly] = useState(false);
   const [videoOnly, setVideoOnly] = useState(false);
-  const [search, setSearch] = useState("");
-  const [sortBy, setSortBy] = useState<SortKey>("rating");
+  const initialQuery = searchParams.get("q") ?? "";
+  const [search, setSearch] = useState(initialQuery);
+  useEffect(() => { setSearch(initialQuery); }, [initialQuery]);
   const [page, setPage] = useState(1);
   const [filtersOpen, setFiltersOpen] = useState(false);
 
@@ -302,15 +360,6 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
 
   const isLocationActive = userLat !== null && userLng !== null;
 
-  // When location is selected from search
-  useEffect(() => {
-    if (locationSearch) {
-      setUserLat(locationSearch.latitude);
-      setUserLng(locationSearch.longitude);
-      setSortBy("distance");
-    }
-  }, [locationSearch]);
-
   // Fetch nearby advisors when location/radius changes
   useEffect(() => {
     if (!isLocationActive) { setNearbyResults(null); return; }
@@ -331,49 +380,6 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
       .catch(() => setNearbyLoading(false));
     return () => controller.abort();
   }, [userLat, userLng, radius, typeFilters, feeFilter, specialtyFilters, isLocationActive]);
-
-  useEffect(() => {
-    const resolved = resolveDirectoryFilters(searchParams, {
-      routeScoped: Boolean(initialType || initialState),
-      validType: v => TYPE_FILTERS.some(f => f.key === v),
-    });
-    if (resolved.providerType) setProviderType(resolved.providerType);
-    if (resolved.specialties) setSpecialtyFilters(resolved.specialties);
-    if (resolved.types) setTypeFilters(new Set(resolved.types));
-    if (resolved.state) setStateFilter(resolved.state);
-    if (resolved.sort) setSortBy(resolved.sort as SortKey);
-    if (resolved.search) setSearch(resolved.search);
-    if (resolved.language) setLanguageFilter(resolved.language);
-  }, [searchParams, initialType, initialState]);
-
-  const initialRenderRef = useRef(true);
-
-  const updateURL = useCallback(() => {
-    const params = new URLSearchParams();
-    if (providerType !== "all") params.set("provider_type", providerType);
-    if (typeFilters.size > 0) params.set("type", Array.from(typeFilters).join(","));
-    if (stateFilter !== "all") params.set("state", stateFilter);
-    if (specialtyFilters.length) params.set("specialty", specialtyFilters.join(","));
-    if (languageFilter !== "all") params.set("language", languageFilter);
-    if (sortBy !== "rating") params.set("sort", sortBy);
-    if (search) params.set("q", search);
-    const qs = params.toString();
-    const newPath = `/advisors${qs ? `?${qs}` : ""}`;
-    // Skip if URL hasn't changed (prevents initial load re-render cycle)
-    const currentQs = searchParams.toString();
-    if (qs === currentQs) return;
-    router.replace(newPath, { scroll: false });
-  }, [providerType, typeFilters, stateFilter, specialtyFilters, languageFilter, sortBy, search, router, searchParams]);
-
-  useEffect(() => {
-    // Skip the very first render to prevent immediate router.replace on page load
-    if (initialRenderRef.current) {
-      initialRenderRef.current = false;
-      return;
-    }
-    const t = setTimeout(updateURL, 300);
-    return () => clearTimeout(t);
-  }, [updateURL]);
 
   useEffect(() => { setPage(1); }, [providerType, typeFilters, stateFilter, specialtyFilters, feeFilter, firmFilter, minRating, verifiedOnly, internationalOnly, languageFilter, acceptingOnly, videoOnly, search, sortBy, nearbyResults]);
 
@@ -570,15 +576,13 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
     ? `Browse verified ${activeTypeLabel.toLowerCase()} across Australia. Filter by location, fees, and specialties.`
     : pageDescription || "Browse verified Australian financial professionals. Filter by location, type, fees, and specialties.";
 
-  const toggleSpecialty = (s: string) => setSpecialtyFilters(prev => prev.includes(s) ? prev.filter(x => x !== s) : [...prev, s]);
-  const clearAll = () => {
-    setProviderType("all");
-    setTypeFilters(new Set()); setStateFilter("all"); setSpecialtyFilters([]); setFeeFilter("all");
-    setFirmFilter("all"); setMinRating(0);
-    setVerifiedOnly(false); setInternationalOnly(false); setSearch(""); setSortBy("rating");
-    setLanguageFilter("all"); setAcceptingOnly(false); setVideoOnly(false);
+  const clearAll = useCallback(() => {
+    clearParams(["provider_type", "type", "state", "specialty", "language", "sort", "q"]);
+    setFeeFilter("all"); setFirmFilter("all"); setMinRating(0);
+    setVerifiedOnly(false); setInternationalOnly(false); setSearch("");
+    setAcceptingOnly(false); setVideoOnly(false);
     setLocationSearch(null); setUserLat(null); setUserLng(null); setRadius(25);
-  };
+  }, [clearParams]);
 
   const allLanguages = useMemo(() => {
     const present = new Set<string>();
@@ -713,6 +717,7 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
             id="advisors-search"
             value={search}
             onChange={setSearch}
+            onSubmit={(q) => setParams({ q: q.trim() })}
             placeholder="Search name, firm, team, specialty, suburb..."
             ariaLabel="Search advisors"
           />
@@ -744,7 +749,11 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
               </label>
               <div className="grid grid-cols-1 md:grid-cols-3 gap-2">
                 <div className="md:col-span-2">
-                  <LocationSearch selected={locationSearch} onSelect={(p) => { setLocationSearch(p); if (!p) { setUserLat(null); setUserLng(null); } }} />
+                  <LocationSearch selected={locationSearch} onSelect={(p) => {
+                    setLocationSearch(p);
+                    if (p) { setUserLat(p.latitude); setUserLng(p.longitude); setSortBy("distance"); }
+                    else { setUserLat(null); setUserLng(null); }
+                  }} />
                 </div>
                 <div className="flex items-center gap-2">
                   <select value={radius} onChange={e => setRadius(Number(e.target.value))} className="flex-1 px-3 py-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-amber-500/30" disabled={!isLocationActive}>

--- a/lib/hooks/useDirectoryParams.ts
+++ b/lib/hooks/useDirectoryParams.ts
@@ -1,0 +1,74 @@
+"use client";
+
+import { useCallback } from "react";
+import {
+  usePathname,
+  useRouter,
+  useSearchParams,
+  type ReadonlyURLSearchParams,
+} from "next/navigation";
+
+export interface UseDirectoryParams {
+  /** The current, read-only query params. Derive filter state from this. */
+  params: ReadonlyURLSearchParams;
+  /**
+   * Set or delete params, then `router.replace` the current path with the
+   * updated query string. A falsy value deletes the key. Writes are
+   * immediate (no debounce) and never push a new history entry, so the
+   * Back button steps through real navigations rather than keystrokes.
+   */
+  setParams: (updates: Record<string, string>) => void;
+  /**
+   * Delete the given keys (preserving any others). With no argument the
+   * whole query string is dropped.
+   */
+  clearParams: (keys?: string[]) => void;
+}
+
+/**
+ * URL-first state for directory pages — the shared mechanism behind the
+ * `/invest` and `/advisors` filter chrome. The URL query string is the
+ * single source of truth: components derive their filter state from
+ * `params` and mutate it through `setParams` / `clearParams`, which keeps
+ * Back/Forward, deep-linking, and share-able URLs working for free.
+ */
+export function useDirectoryParams(): UseDirectoryParams {
+  const router = useRouter();
+  const pathname = usePathname();
+  const params = useSearchParams();
+
+  const replaceWith = useCallback(
+    (next: URLSearchParams) => {
+      const qs = next.toString();
+      router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+    },
+    [router, pathname],
+  );
+
+  const setParams = useCallback(
+    (updates: Record<string, string>) => {
+      const next = new URLSearchParams(params.toString());
+      for (const [key, value] of Object.entries(updates)) {
+        if (value) next.set(key, value);
+        else next.delete(key);
+      }
+      replaceWith(next);
+    },
+    [params, replaceWith],
+  );
+
+  const clearParams = useCallback(
+    (keys?: string[]) => {
+      if (!keys) {
+        replaceWith(new URLSearchParams());
+        return;
+      }
+      const next = new URLSearchParams(params.toString());
+      for (const key of keys) next.delete(key);
+      replaceWith(next);
+    },
+    [params, replaceWith],
+  );
+
+  return { params, setParams, clearParams };
+}


### PR DESCRIPTION
## Summary

Phase 2 **Session 7** of the directory-UX unification. Migrates `app/advisors/AdvisorsClient.tsx` off its local-state + 300ms-debounced URL sync to the **URL-first** model already used by `components/InvestListingsClient.tsx`.

- **New `lib/hooks/useDirectoryParams.ts`** — a URL-first state hook (`{ params, setParams, clearParams }`). The query string is the single source of truth; writes go through `router.replace(..., { scroll: false })` immediately (no debounce) and never push history entries.
- **`AdvisorsClient`** now derives `provider_type`, `type`, `state`, `specialty`, `language` and `sort` directly from `searchParams` and writes them immediately. This removes the fragile write-then-read-back round trip (the old `updateURL` + `initialRenderRef` + `resolveDirectoryFilters` effect), so Back/Forward and shareable/deep-link URLs behave correctly.
- Route-scoped pages (`/advisors/[type]`, `/advisors/[type]/[state]`) keep their seed from the route props when the matching param is absent.
- The 5b filter primitives (`FilterPanel`/`FacetGroup`/`RangeSlider`/`FilterChips`) and the SM-01 grouped-specialty accordion are unchanged. Search keeps live client-side filtering; `q` is persisted on submit. Purely-local UI state (fee/firm/rating/verified/international/accepting/video/geo/radius/page) stays local — it was never URL-backed.

## Tests

- New `__tests__/lib/hooks-useDirectoryParams.test.tsx` (6 cases: set/delete/preserve/clear semantics).
- Updated `__tests__/components/AdvisorsClient.test.tsx` to the URL-first model — toggling a facet asserts the URL write; the chip strip is asserted from a seeded URL (mirrors the `/invest` test pattern, self-contained mocks).

## Incidental fix

The pre-push `tsc --noEmit` gate was already red on main from recently-merged D-stream test PRs (referrals accept/decline session mocks inferred `Promise<number>`, two team-route mocks couldn't take a spread). Repaired in a separate commit — test-only, no production change — so the type-check gate is green.

https://claude.ai/code/session_015enFkJWudM188AhdMhn8A2

---
_Generated by [Claude Code](https://claude.ai/code/session_015enFkJWudM188AhdMhn8A2)_