### PR TITLE
fix(compliance): approval gate on country-rule-alert publishing (§5 #11)

### DIFF
--- a/__tests__/api/admin-country-rule-alerts.test.ts
+++ b/__tests__/api/admin-country-rule-alerts.test.ts
@@ -246,6 +246,9 @@ describe("POST /api/admin/country-rule-alerts — validation", () => {
         alert_key: "uk-new",
         country_code: "uk",
         severity: "warning",
+        // Approval gate (§5 #11): created as an inactive draft even though the
+        // payload requested active:true — publishing is a deliberate PATCH.
+        active: false,
       }),
     );
     expect(auditInsert).toHaveBeenCalledWith(

--- a/app/api/admin/country-rule-alerts/route.ts
+++ b/app/api/admin/country-rule-alerts/route.ts
@@ -99,7 +99,10 @@ export const POST = withValidatedBody(CreateSchema, async (_req, body) => {
     cta_label: body.cta_label ?? null,
     stales_at: body.stales_at,
     display_order: body.display_order,
-    active: body.active,
+    // Approval gate (audit §5 #11): new alerts are created as inactive drafts
+    // so a mistake is never instantly public. Publishing is a deliberate,
+    // separately audit-logged step — PATCH active:true to go live.
+    active: false,
   };
   const { data, error } = await supabase
     .from("country_rule_alerts")
@@ -117,7 +120,11 @@ export const POST = withValidatedBody(CreateSchema, async (_req, body) => {
     entity_type: "country_rule_alerts",
     entity_id: String(data.id),
     admin_email: guard.email,
-    details: { country_code: body.country_code, alert_key: body.alert_key },
+    details: {
+      country_code: body.country_code,
+      alert_key: body.alert_key,
+      created_as_draft: true,
+    },
   });
 
   return NextResponse.json(data, { status: 201 });


### PR DESCRIPTION
Closes new-features audit §5 flag #11 (country-rule alerts).

Country-rule alerts were created active:true → instantly public, so an editor mistake was immediately live. New rows are now created as inactive drafts regardless of the requested flag; publishing is a deliberate, separately audit-logged PATCH active:true. Create test strengthened to assert the draft default (17/17 pass).

Note: the regulatory_alerts editor (AD-20) creates via a server action, not this API route — flagged in the queue for the same treatment.

Tier C (compliance/admin) — your merge.

Generated with Claude Code