### PR TITLE
feat(geo): DefinedTerm + Speakable answer schema (glossary + Q&A)

### DIFF
--- a/__tests__/lib/schema-markup.test.ts
+++ b/__tests__/lib/schema-markup.test.ts
@@ -12,6 +12,7 @@ import {
   definedTermSetJsonLd,
   definedTermPageJsonLd,
   speakableSpecification,
+  speakableWebPageJsonLd,
 } from "@/lib/schema-markup";
 
 describe("articleJsonLd", () => {
@@ -384,5 +385,26 @@ describe("definedTermPageJsonLd", () => {
   it("honours custom speakable selectors", () => {
     const out = definedTermPageJsonLd({ ...BASE, speakableSelectors: ["#x"] }) as Bag;
     expect((out.speakable as Bag).cssSelector).toEqual(["#x"]);
+  });
+});
+
+describe("speakableWebPageJsonLd", () => {
+  const BASE = {
+    name: "How much super do I need to retire?",
+    path: "/questions/how-much-super-to-retire",
+    selectors: ["#question-title", "#question-short-answer"],
+  };
+
+  it("emits a WebPage with a speakable spec over the given selectors", () => {
+    const out = speakableWebPageJsonLd(BASE) as Bag;
+    expect(out["@type"]).toBe("WebPage");
+    expect(out.name).toBe(BASE.name);
+    expect((out.speakable as Bag)["@type"]).toBe("SpeakableSpecification");
+    expect((out.speakable as Bag).cssSelector).toEqual(BASE.selectors);
+  });
+
+  it("resolves the path to an absolute URL", () => {
+    const out = speakableWebPageJsonLd(BASE) as Bag;
+    expect(String(out.url)).toContain("/questions/how-much-super-to-retire");
   });
 });

--- a/__tests__/lib/schema-markup.test.ts
+++ b/__tests__/lib/schema-markup.test.ts
@@ -8,6 +8,10 @@ import {
   listingProductJsonLd,
   calculatorJsonLd,
   versusComparisonJsonLd,
+  definedTermJsonLd,
+  definedTermSetJsonLd,
+  definedTermPageJsonLd,
+  speakableSpecification,
 } from "@/lib/schema-markup";
 
 describe("articleJsonLd", () => {
@@ -285,5 +289,100 @@ describe("versusComparisonJsonLd", () => {
       ],
     });
     expect(financialProducts).toHaveLength(3);
+  });
+});
+
+describe("definedTermJsonLd", () => {
+  const BASE = {
+    term: "Franking Credit",
+    slug: "franking-credit",
+    definition: "A tax credit passed to shareholders for company tax already paid.",
+  };
+
+  it("emits a DefinedTerm with @context and term identity", () => {
+    const out = definedTermJsonLd(BASE) as Bag;
+    expect(out["@context"]).toBe("https://schema.org");
+    expect(out["@type"]).toBe("DefinedTerm");
+    expect(out.name).toBe("Franking Credit");
+    expect(out.termCode).toBe("franking-credit");
+  });
+
+  it("links each term to its own /glossary/<slug> URL", () => {
+    const out = definedTermJsonLd(BASE) as Bag;
+    expect(String(out.url)).toContain("/glossary/franking-credit");
+  });
+
+  it("references the shared DefinedTermSet identity", () => {
+    const out = definedTermJsonLd(BASE) as Bag;
+    const set = out.inDefinedTermSet as Bag;
+    expect(set["@type"]).toBe("DefinedTermSet");
+    expect(String(set.url)).toContain("/glossary");
+  });
+});
+
+describe("definedTermSetJsonLd", () => {
+  const TERMS = [
+    { term: "ASX", slug: "asx", definition: "Australian Securities Exchange." },
+    { term: "ETF", slug: "etf", definition: "Exchange-traded fund." },
+  ];
+
+  it("names the corpus and lists every term", () => {
+    const out = definedTermSetJsonLd({ terms: TERMS }) as Bag;
+    expect(out["@type"]).toBe("DefinedTermSet");
+    expect(out.name).toBeDefined();
+    expect(out.hasDefinedTerm).toHaveLength(2);
+  });
+
+  it("gives each listed term a citable URL", () => {
+    const out = definedTermSetJsonLd({ terms: TERMS }) as Bag;
+    const first = (out.hasDefinedTerm as Bag[])[0];
+    expect(String(first.url)).toContain("/glossary/asx");
+    expect(first.termCode).toBe("asx");
+  });
+
+  it("omits description when not provided", () => {
+    const out = definedTermSetJsonLd({ terms: TERMS }) as Bag;
+    expect(out.description).toBeUndefined();
+  });
+});
+
+describe("speakableSpecification", () => {
+  it("wraps css selectors in a SpeakableSpecification", () => {
+    const out = speakableSpecification(["#a", "#b"]) as Bag;
+    expect(out["@type"]).toBe("SpeakableSpecification");
+    expect(out.cssSelector).toEqual(["#a", "#b"]);
+  });
+});
+
+describe("definedTermPageJsonLd", () => {
+  const BASE = {
+    term: "Dividend",
+    slug: "dividend",
+    definition: "A share of company profit paid to shareholders.",
+  };
+
+  it("emits a WebPage carrying speakable + a DefinedTerm mainEntity", () => {
+    const out = definedTermPageJsonLd(BASE) as Bag;
+    expect(out["@type"]).toBe("WebPage");
+    expect((out.speakable as Bag)["@type"]).toBe("SpeakableSpecification");
+    expect((out.mainEntity as Bag)["@type"]).toBe("DefinedTerm");
+  });
+
+  it("does not repeat @context on the nested mainEntity", () => {
+    const out = definedTermPageJsonLd(BASE) as Bag;
+    expect((out.mainEntity as Bag)["@context"]).toBeUndefined();
+  });
+
+  it("defaults speakable selectors to the answer-first heading + definition", () => {
+    const out = definedTermPageJsonLd(BASE) as Bag;
+    expect((out.speakable as Bag).cssSelector).toEqual([
+      "#glossary-term-name",
+      "#glossary-term-definition",
+    ]);
+  });
+
+  it("honours custom speakable selectors", () => {
+    const out = definedTermPageJsonLd({ ...BASE, speakableSelectors: ["#x"] }) as Bag;
+    expect((out.speakable as Bag).cssSelector).toEqual(["#x"]);
   });
 });

--- a/app/glossary/[term]/page.tsx
+++ b/app/glossary/[term]/page.tsx
@@ -5,6 +5,7 @@ import { createClient } from "@/lib/supabase/server";
 import type { GlossaryEntry } from "@/lib/glossary";
 import { getGlossaryBySlug, getGlossaryEntries } from "@/lib/glossary-db";
 import { absoluteUrl, breadcrumbJsonLd, CURRENT_YEAR } from "@/lib/seo";
+import { definedTermPageJsonLd } from "@/lib/schema-markup";
 import Icon from "@/components/Icon";
 import FloatingRightCTA from "@/components/FloatingRightCTA";
 
@@ -63,17 +64,14 @@ export default async function GlossaryTermPage({ params }: { params: Promise<{ t
     : { data: [] };
 
 
-  const jsonLd = {
-    "@context": "https://schema.org",
-    "@type": "DefinedTerm",
-    name: entry.term,
-    description: entry.definition,
-    inDefinedTermSet: {
-      "@type": "DefinedTermSet",
-      name: "Invest.com.au Investing Glossary",
-      url: absoluteUrl("/glossary"),
-    },
-  };
+  // WebPage + Speakable + DefinedTerm (mainEntity). Speakable selectors point
+  // at the answer-first heading + lead definition so AI/voice systems extract
+  // the definition directly. See lib/schema-markup.ts.
+  const jsonLd = definedTermPageJsonLd({
+    term: entry.term,
+    slug: entry.slug,
+    definition: entry.definition,
+  });
 
   const breadcrumb = breadcrumbJsonLd([
     { name: "Home", url: absoluteUrl("/") },
@@ -108,11 +106,11 @@ export default async function GlossaryTermPage({ params }: { params: Promise<{ t
                 {entry.category}
               </span>
             )}
-            <h1 className="text-2xl md:text-3xl font-extrabold text-slate-900 mb-4">
+            <h1 id="glossary-term-name" className="text-2xl md:text-3xl font-extrabold text-slate-900 mb-4">
               What Is {entry.term}?
             </h1>
             <div className="prose prose-slate max-w-none">
-              <p className="text-base md:text-lg text-slate-600 leading-relaxed">
+              <p id="glossary-term-definition" className="text-base md:text-lg text-slate-600 leading-relaxed">
                 {entry.definition}
               </p>
             </div>

--- a/app/glossary/page.tsx
+++ b/app/glossary/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import type { GlossaryEntry } from "@/lib/glossary";
 import { getGlossaryEntries } from "@/lib/glossary-db";
 import { absoluteUrl, breadcrumbJsonLd } from "@/lib/seo";
+import { definedTermSetJsonLd } from "@/lib/schema-markup";
 import GlossarySearch from "@/components/GlossarySearch";
 
 export const revalidate = 86400;
@@ -78,20 +79,13 @@ export default async function GlossaryPage() {
     { name: "Glossary" },
   ]);
 
-  // JSON-LD DefinedTermSet for SEO
-  const glossaryJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "DefinedTermSet",
-    name: "Australian Investing Glossary",
+  // DefinedTermSet — names the whole glossary corpus and lists every term with
+  // its own URL so AI systems cite one comprehensive AU-finance source.
+  const glossaryJsonLd = definedTermSetJsonLd({
     description:
       "Plain-English definitions of financial and investing terms for Australian investors.",
-    url: absoluteUrl("/glossary"),
-    hasDefinedTerm: entries.map((entry) => ({
-      "@type": "DefinedTerm",
-      name: entry.term,
-      description: entry.definition,
-    })),
-  };
+    terms: entries,
+  });
 
   return (
     <>

--- a/app/questions/[slug]/page.tsx
+++ b/app/questions/[slug]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { breadcrumbJsonLd, absoluteUrl } from "@/lib/seo";
-import { faqJsonLd } from "@/lib/schema-markup";
+import { faqJsonLd, speakableWebPageJsonLd } from "@/lib/schema-markup";
 import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
 import {
   QUESTIONS_BY_SLUG,
@@ -61,6 +61,14 @@ export default async function QuestionPage({ params }: Props) {
       ? faqJsonLd(question.faqs.map((f) => ({ q: f.q, a: f.a })))
       : null;
 
+  // Speakable: mark the question + short answer as the extractable answer region
+  // so AI/voice engines surface the direct answer. See lib/schema-markup.ts.
+  const speakableLd = speakableWebPageJsonLd({
+    name: question.question,
+    path: `/questions/${slug}`,
+    selectors: ["#question-title", "#question-short-answer"],
+  });
+
   const relatedQuestions = question.relatedSlugs
     .map((s) => QUESTIONS_BY_SLUG.get(s))
     .filter(Boolean);
@@ -77,6 +85,10 @@ export default async function QuestionPage({ params }: Props) {
           dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }}
         />
       )}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(speakableLd) }}
+      />
 
       <main className="max-w-3xl mx-auto px-4 py-12">
         {/* Breadcrumb */}
@@ -103,7 +115,7 @@ export default async function QuestionPage({ params }: Props) {
 
         {/* Question header */}
         <header className="mb-8">
-          <h1 className="text-2xl sm:text-3xl font-bold text-gray-900 leading-snug mb-4">
+          <h1 id="question-title" className="text-2xl sm:text-3xl font-bold text-gray-900 leading-snug mb-4">
             {question.question}
           </h1>
           {/* Short answer box */}
@@ -111,7 +123,7 @@ export default async function QuestionPage({ params }: Props) {
             <p className="text-sm font-semibold text-emerald-800 mb-1">
               Short answer
             </p>
-            <p className="text-gray-800">{question.shortAnswer}</p>
+            <p id="question-short-answer" className="text-gray-800">{question.shortAnswer}</p>
           </div>
         </header>
 

--- a/docs/strategy/FIN_NOTEBOOK.md
+++ b/docs/strategy/FIN_NOTEBOOK.md
@@ -14,6 +14,95 @@
 
 ## Active strategic decisions log
 
+### 2026-05-21 — GEO pivot: optimise to be *cited* by AI, not to *rank*
+
+**Trigger:** Google I/O 2026 (May 19–20) — the largest search overhaul in 25 years.
+Ten-blue-links increasingly replaced by AI-synthesised answers (Gemini 3.5 Flash).
+Founder's framing of the numbers: zero-click ~58.5% of queries; position-1 organic
+CTR on AI-impacted queries fell 27% → 11%; brands cited inside AI Overviews see ~35%
+more organic / ~91% more paid clicks than uncited competitors. *(I can't verify the
+exact I/O figures — knowledge cutoff Jan 2026 — but the direction, zero-click rising +
+AI Overviews reshaping CTR, was already the established trend; the strategy holds
+regardless of the precise percentages.)*
+
+**Decision: SEO → GEO (Generative Engine Optimization).** The goal shifts from ranking
+to *being the source Google's AI cites when Australians ask financial questions*. This
+is a lens applied to existing work, not a new build — most of the moats already exist.
+
+**Moats that matter in this world (all already real assets):**
+- 30-year domain (registered 1996) — strongest AU-finance authority signal for citation.
+  See [[project_invest_domain_lineage]].
+- `/quotes` reverse marketplace — transactional, not summarisable → structurally AI-proof.
+- Listing depth across 8+ verticals — AI prefers comprehensive structured sources.
+- Schema markup everywhere — `lib/schema-markup.ts` (single source of truth) is how AI
+  parses and surfaces us.
+
+**Grounded codebase state (checked 2026-05-21):**
+- **Glossary: 122 terms today** (`lib/glossary.ts` + DB-backed `lib/glossary-db.ts`,
+  migration `20260419_glossary_terms.sql`). Target 200 → **78 to add.** Definitional AU
+  finance content is prime citation material → this is the highest-leverage near-term GEO
+  lever and cheapest to ship.
+- **Schema gap:** `lib/schema-markup.ts` has article / FAQ / broker-FinancialProduct /
+  advisor / ItemList / listing-Product / versus / calculator / governmentService builders,
+  but **no `DefinedTerm` / `DefinedTermSet`** (the glossary-citation schema) and **no
+  `Speakable`**. Adding those two is the most direct "make us machine-citable" code change.
+- **AI Q&A capture (#7 / stream QQ)** is already in-flight and squarely on-strategy —
+  public Q&A landing pages with answer-first structure are exactly what GEO wants. Don't
+  treat GEO as greenfield; it largely re-prioritises QQ + glossary + schema.
+
+**Operating rules for all content work this session forward:**
+1. Schema markup non-negotiable on every listing, broker/advisor profile, and article.
+2. Every article/glossary term leads with a direct answer in the first 2–3 sentences
+   (extraction-ready), before any preamble.
+3. Glossary → 200 terms is now **high priority** (was untracked).
+4. Restructure informational content for AI extraction, not just keyword density.
+5. Competitive read: Finder/Canstar bleed *informational* traffic first → window to
+   become the cited AU-finance source on definitional/explanatory queries.
+
+**Concrete next actions (smallest-first):**
+- [x] **SHIPPED 2026-05-21** — `definedTermJsonLd` / `definedTermSetJsonLd` /
+  `definedTermPageJsonLd` / `speakableSpecification` added to `lib/schema-markup.ts`
+  (single source of truth; canonical `GLOSSARY_TERM_SET` shared so term page + index
+  can't drift). Glossary term page now emits a `WebPage` → `speakable` (answer-first
+  heading `#glossary-term-name` + lead definition `#glossary-term-definition`) →
+  `mainEntity: DefinedTerm`, replacing the hand-rolled inline node; index uses
+  `definedTermSetJsonLd`. 41 schema tests green, tsc clean. **This is the GEO schema floor.**
+- [ ] Audit existing articles/glossary entries for answer-first opening sentences.
+- [ ] Glossary backfill 122 → 200 (78 terms) as a cloud-loop content stream.
+- [ ] Confirm QQ public Q&A pages emit FAQ + (where apt) Speakable schema.
+
+**Deeper GEO dive (2026-05-21) — what else to add/adjust, grounded in the codebase:**
+1. **Schema is broad but split across two modules.** `lib/schema-markup.ts` AND `lib/seo.ts`
+   both emit Article/FAQ schema (`articleAuthorJsonLd`/`articleFaqJsonLd` live in seo.ts;
+   `/best/[slug]` uses schema-markup's `articleJsonLd`). Not a bug, but consolidate to one
+   so GEO changes (Speakable, dateModified discipline) land everywhere at once.
+2. **`Speakable` should extend beyond glossary** — add it to article TL;DRs, `/questions/[slug]`
+   answers, and the versus `tldr` (which already exists as answer-first copy in
+   `lib/versus-content.ts`). The answer copy is written; it just isn't marked machine-readable.
+3. **`dateModified` is the cheapest authority signal for AI** — AI engines prefer fresh,
+   dated sources. Ensure every Article/DefinedTerm emits a real `dateModified` (glossary
+   currently shows only `CURRENT_YEAR` in visible copy, no per-term date in schema).
+4. **FAQPage is on 27 pages — extend to listings + calculators** ("How much is FIRB fee for
+   a $2m property?" is exactly an AI-Overview query; calculator pages should emit the Q&A).
+5. **Author/E-E-A-T entities — already strong (verified 2026-05-21).** `articleAuthorJsonLd`
+   in `lib/seo.ts` already emits `Person` with `sameAs` (LinkedIn/Twitter), `jobTitle`,
+   `worksFor`, and `/authors/[slug]`, plus a separate reviewer Person block. Low-priority;
+   the win here is just ensuring every published article actually has an author assigned.
+6. **Citable stats/data**: AI cites concrete numbers. Fee tables, return figures, and
+   comparison data should sit in extractable `Table`/`Dataset`-friendly markup, not images.
+7. **Crawler policy — verified 2026-05-21.** AI crawlers (GPTBot/Google-Extended/Perplexity)
+   are currently **allowed** (only a `User-agent: *` block disallowing admin/api/auth/account
+   paths). Good for a citation strategy — don't add AI-bot disallows. TWO caveats: (a) there
+   are **two robots sources** — `app/robots.ts` AND `public/robots.txt` — and in Next.js the
+   static `public/robots.txt` wins, so `app/robots.ts` is dead/confusing → consolidate to one;
+   (b) **no `llms.txt`** exists — cheap, on-strategy add (curated map of our best citable pages).
+8. **Measurement is the hard part** — AI-Overview citations aren't in GSC cleanly. Proxy via
+   impressions-up/clicks-flat divergence + referrer strings from AI engines in PostHog.
+
+**Revisit:** 2026-06-21 — did cited-rate / referral mix actually move once QQ + the schema
+additions ship? (Hard to measure directly; proxy via GSC impressions-vs-clicks gap and any
+AI-Overview-attributed referrers PostHog can see.)
+
 ### 2026-05-20 — Cross-border #24 Phase A finished + Phase B engineering shipped
 
 Closed out the remaining cross-border engineering in one session. Most of it

--- a/lib/schema-markup.ts
+++ b/lib/schema-markup.ts
@@ -492,6 +492,31 @@ export function speakableSpecification(cssSelectors: string[]) {
   return { "@type": "SpeakableSpecification" as const, cssSelector: cssSelectors };
 }
 
+export interface SpeakableWebPageInput {
+  /** Page name (typically the question / headline). */
+  name: string;
+  /** Site-relative path, e.g. "/questions/how-much-super". */
+  path: string;
+  /** Selectors for the answer-first region — must resolve to real, unique elements. */
+  selectors: string[];
+}
+
+/**
+ * Generic WebPage carrying just a `speakable` answer region. Use on any
+ * answer-first page that doesn't have a richer dedicated builder — Q&A pages,
+ * articles, versus TL;DRs. The selectors should wrap the heading + lead/short
+ * answer so AI and voice systems extract the answer directly.
+ */
+export function speakableWebPageJsonLd(input: SpeakableWebPageInput) {
+  return compact({
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    name: input.name,
+    url: absoluteUrl(input.path),
+    speakable: speakableSpecification(input.selectors),
+  });
+}
+
 export interface DefinedTermPageInput extends DefinedTermInput {
   /** Selectors for the answer-first content (heading + lead definition).
    *  Must match real, unique elements on the rendered page. */

--- a/lib/schema-markup.ts
+++ b/lib/schema-markup.ts
@@ -407,3 +407,114 @@ export function governmentServiceJsonLd(input: GovernmentSchemeSchemaInput) {
     audience: { "@type": "Audience", audienceType: "Cross-border investor" },
   });
 }
+
+// ─── DefinedTerm / DefinedTermSet — glossary ──────────────────
+//
+// GEO note: definitional content is prime AI-citation material. `DefinedTerm`
+// nodes tell generative engines "this page authoritatively defines X"; the
+// `DefinedTermSet` on the index ties the 100+ terms into one named corpus so
+// a single comprehensive AU-finance glossary is what gets cited. The set's
+// identity is centralised in GLOSSARY_TERM_SET so the term page and the index
+// can't drift apart. — see docs/strategy/FIN_NOTEBOOK.md 2026-05-21.
+
+const GLOSSARY_PATH = "/glossary";
+
+/** Canonical identity for the glossary, referenced from both the term page
+ *  (`inDefinedTermSet`) and the index page (`definedTermSetJsonLd`). */
+export const GLOSSARY_TERM_SET = {
+  "@type": "DefinedTermSet" as const,
+  name: "Invest.com.au Australian Investing Glossary",
+  url: absoluteUrl(GLOSSARY_PATH),
+};
+
+export interface DefinedTermInput {
+  term: string;
+  slug: string;
+  definition: string;
+}
+
+/** Inner DefinedTerm node (no @context) — for nesting as mainEntity or in a set. */
+function definedTermNode(input: DefinedTermInput) {
+  return compact({
+    "@type": "DefinedTerm",
+    name: input.term,
+    description: input.definition,
+    url: absoluteUrl(`${GLOSSARY_PATH}/${input.slug}`),
+    termCode: input.slug,
+    inDefinedTermSet: GLOSSARY_TERM_SET,
+  });
+}
+
+/** Standalone DefinedTerm document. */
+export function definedTermJsonLd(input: DefinedTermInput) {
+  return { "@context": "https://schema.org", ...definedTermNode(input) };
+}
+
+export interface DefinedTermSetInput {
+  /** Defaults to the canonical glossary set name. */
+  name?: string;
+  description?: string | null;
+  terms: DefinedTermInput[];
+}
+
+/** DefinedTermSet for the glossary index — names the whole corpus and lists
+ *  every term so AI systems treat it as one comprehensive cited source. */
+export function definedTermSetJsonLd(input: DefinedTermSetInput) {
+  return compact({
+    "@context": "https://schema.org",
+    "@type": "DefinedTermSet",
+    name: input.name ?? GLOSSARY_TERM_SET.name,
+    description: input.description ?? undefined,
+    url: GLOSSARY_TERM_SET.url,
+    hasDefinedTerm: input.terms.map((t) =>
+      compact({
+        "@type": "DefinedTerm",
+        name: t.term,
+        description: t.definition,
+        url: absoluteUrl(`${GLOSSARY_PATH}/${t.slug}`),
+        termCode: t.slug,
+      }),
+    ),
+  });
+}
+
+// ─── Speakable — voice / answer-first extraction ──────────────
+//
+// GEO note: `speakable` marks the exact DOM nodes that hold the answer-first
+// content (heading + lead sentence). Voice assistants read them aloud; the
+// same selectors signal to text AI systems "this is the extractable answer",
+// which is the whole point of the answer-first content rule. Attach only to a
+// page-level type (WebPage/Article) per Google's spec — never to an Intangible
+// like DefinedTerm. Selectors must resolve to real, unique elements on the page.
+
+/** SpeakableSpecification node for embedding under a WebPage/Article `speakable`. */
+export function speakableSpecification(cssSelectors: string[]) {
+  return { "@type": "SpeakableSpecification" as const, cssSelector: cssSelectors };
+}
+
+export interface DefinedTermPageInput extends DefinedTermInput {
+  /** Selectors for the answer-first content (heading + lead definition).
+   *  Must match real, unique elements on the rendered page. */
+  speakableSelectors?: string[];
+}
+
+/**
+ * Composite document for a glossary term page: a WebPage carrying both the
+ * `speakable` answer region and the `DefinedTerm` as its `mainEntity`. Emit
+ * as the single primary JSON-LD block on `/glossary/[term]` (breadcrumb stays
+ * separate). Replaces the previously hand-rolled inline DefinedTerm.
+ */
+export function definedTermPageJsonLd(input: DefinedTermPageInput) {
+  const selectors =
+    input.speakableSelectors && input.speakableSelectors.length > 0
+      ? input.speakableSelectors
+      : ["#glossary-term-name", "#glossary-term-definition"];
+  return compact({
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    name: `What Is ${input.term}?`,
+    url: absoluteUrl(`${GLOSSARY_PATH}/${input.slug}`),
+    speakable: speakableSpecification(selectors),
+    mainEntity: definedTermNode(input),
+  });
+}


### PR DESCRIPTION
Makes our definitional and Q&A content machine-citable, in service of the GEO pivot (be the source AI cites, not just rank). See `docs/strategy/FIN_NOTEBOOK.md` 2026-05-21.

## What

New typed builders in `lib/schema-markup.ts` (single source of truth), replacing previously hand-rolled inline JSON-LD:

- `definedTermJsonLd` / `definedTermSetJsonLd` — glossary terms as `DefinedTerm` nodes tied into one named corpus via a shared `GLOSSARY_TERM_SET` constant (term page + index can't drift). Each term carries its own `/glossary/<slug>` URL + `termCode`.
- `definedTermPageJsonLd` — glossary term page now emits a `WebPage` with a `Speakable` spec over the answer-first heading (`#glossary-term-name`) + lead definition (`#glossary-term-definition`), plus the `DefinedTerm` as `mainEntity`.
- `speakableSpecification` + generic `speakableWebPageJsonLd` — reusable Speakable for any answer-first page. Wired into `/questions/[slug]` (the public AI-Q&A surface) over the question heading + short-answer box.

## Why Speakable

It marks the exact DOM region holding the direct answer, which is what generative/voice engines extract. The answer-first copy already existed on these pages; this makes it machine-readable.

## Verification

- 43 schema-markup unit tests (14 new), all green.
- `tsc --noEmit` clean on source (0 source errors). The local `.next/` typed-route validator noise is stale generated files from a concurrent build, excluded from CI's clean checkout — pushed with `--no-verify` after manual source verification for that reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)