### PR TITLE
fix(db): clear stale sharesight_connections from generated types

### DIFF
--- a/.driftallowlist
+++ b/.driftallowlist
@@ -72,7 +72,8 @@ spatial_ref_sys
 # Founder dashboard PRs (#891–#893) added these tables without migrations; pending Stream A backfill.
 # brief_promo_codes + brief_promo_redemptions get their migration in this PR (#899) and so are
 # intentionally omitted here — the gate will fail loudly if they slip out of the migration set.
-investor_oauth_connections  # PR #893 — OAuth provider connections; remove when its migration lands
-afsl_register               # created in Supabase dashboard (ASIC AFSL register import 2026-05-19); remove when backfill migration lands
+# investor_oauth_connections + afsl_register removed 2026-05-21 — their migrations
+# have since landed (drift gate confirmed both are no longer drifted).
 # sharesight_connections removed — orphan plaintext-token table dropped via
-# 20260729_drop_orphan_sharesight_connections.sql (audit §5 #2).
+# 20260729_drop_orphan_sharesight_connections.sql (audit §5 #2); its stale type
+# entry in lib/database.types.ts cleared here (the 7d7570db fix had regressed).

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -15043,42 +15043,6 @@ export type Database = {
         }
         Relationships: []
       }
-      sharesight_connections: {
-        Row: {
-          access_token: string
-          api_base_url: string
-          auth_user_id: string
-          created_at: string
-          expires_at_s: number
-          last_import_error: string | null
-          last_imported_at: string | null
-          refresh_token: string
-          updated_at: string
-        }
-        Insert: {
-          access_token: string
-          api_base_url: string
-          auth_user_id: string
-          created_at?: string
-          expires_at_s: number
-          last_import_error?: string | null
-          last_imported_at?: string | null
-          refresh_token: string
-          updated_at?: string
-        }
-        Update: {
-          access_token?: string
-          api_base_url?: string
-          auth_user_id?: string
-          created_at?: string
-          expires_at_s?: number
-          last_import_error?: string | null
-          last_imported_at?: string | null
-          refresh_token?: string
-          updated_at?: string
-        }
-        Relationships: []
-      }
       site_ab_tests: {
         Row: {
           clicks_a: number | null


### PR DESCRIPTION
## Why

The database-types drift gate fails on **every** PR right now (it's path-skipped on `main` pushes, so it slipped through unnoticed). `lib/database.types.ts` still declares the `sharesight_connections` table, but that table was dropped in prod via migration `20260729_drop_orphan_sharesight_connections.sql` (audit §5 #2 — an orphan plaintext-token table, 0 rows, 0 code references).

An earlier fix (`7d7570db`, per `REMEDIATION_QUEUE.md`) removed the type entry but it **regressed** back onto main.

## What

- Remove the stale `sharesight_connections` block from `lib/database.types.ts` (36 lines). Equivalent to regenerating via `npm run db:types`, which can't run here without prod credentials. Verified safe: **zero code references**, no foreign-key relationships point at it.
- Drop two `.driftallowlist` entries the gate flagged as no longer drifted (`investor_oauth_connections`, `afsl_register` — their migrations have since landed).

## Verification

`node scripts/check-database-types-drift.mjs` → **exit 0**, "no drifted tables" (342 type tables, 343 migration tables, 17 allow-listed). eslint parse clean on commit.

Unblocks the drift gate for all open PRs, including #1148.

🤖 Generated with [Claude Code](https://claude.com/claude-code)