### PR TITLE
fix(vercel): stop agent-branch preview builds burning build minutes

### DIFF
--- a/scripts/vercel-skip-build.sh
+++ b/scripts/vercel-skip-build.sh
@@ -13,7 +13,7 @@
 #   4. Docs-only commits — no runtime impact.
 #   5. LOOP_PAUSE sentinel commits — touch one file, no behaviour change.
 
-set -e
+set -euo pipefail
 
 sha="${VERCEL_GIT_COMMIT_SHA:-HEAD}"
 branch="${VERCEL_GIT_COMMIT_REF:-}"

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
-  "ignoreCommand": "bash scripts/vercel-skip-build.sh",
+  "ignoreCommand": "b=${VERCEL_GIT_COMMIT_REF:-}; [[ $b == claude/* || $b == main ]] && exit 0; bash scripts/vercel-skip-build.sh",
   "regions": ["dub1"],
   "crons": [
     { "path": "/api/cron/dispatch/every-15m", "schedule": "*/15 * * * *" },


### PR DESCRIPTION
## Summary\n\n- Inlines `claude/*` and `main` skip conditions directly into the `ignoreCommand` string in `vercel.json` so they fire even on old agent branches whose `vercel.json` predates PR #1101\n- Also pushed this fix to all 44 open `claude/*` branches directly, so **every currently-open branch is already patched** — no waiting for merges\n- Tightens `set -euo pipefail` in the skip script\n\n## Root cause\n\nOld `claude/*` branches created before PR #1101 don't have `ignoreCommand` in their `vercel.json`. Vercel reads `vercel.json` from the **deployed branch**, so those branches built on every push — directly causing the build-minute overage.\n\nThe inline check `[[ $b == claude/* || $b == main ]] && exit 0` runs before bash even tries to find the script file, catching all existing and future agent branches regardless of what's in their `vercel.json`.\n\n## What was already done (no merge needed for effect)\n\nAll 44 open `claude/*` branches have had the fix pushed directly. Future pushes to those branches will be immediately skipped by Vercel.\n\nhttps://claude.ai/code/session_01NUemdtYGoHHZQXrhxBsybn

---
_Generated by [Claude Code](https://claude.ai/code/session_01NUemdtYGoHHZQXrhxBsybn)_