### PR TITLE
feat: advisor private notes on accepted briefs (B3 CRM)

### DIFF
--- a/app/advisor-portal/briefs/BriefsInboxClient.tsx
+++ b/app/advisor-portal/briefs/BriefsInboxClient.tsx
@@ -17,6 +17,8 @@ interface AcceptedBrief {
   contact_email: string | null;
   contact_phone: string | null;
   accepted_by_team_id: number | null;
+  latest_note: string | null;
+  latest_note_at: string | null;
 }
 
 interface InboxData {
@@ -40,6 +42,8 @@ export default function BriefsInboxClient() {
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
   const [statusBusy, setStatusBusy] = useState<string | null>(null);
+  const [noteDrafts, setNoteDrafts] = useState<Record<string, string>>({});
+  const [noteBusy, setNoteBusy] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     try {
@@ -89,6 +93,31 @@ export default function BriefsInboxClient() {
       await load();
     } finally {
       setStatusBusy(null);
+    }
+  }
+
+  // Saves a private note against the brief. The status route records the note
+  // on the brief's event log; we re-send the current tracker_status (unchanged)
+  // so the note attaches without altering the pipeline stage.
+  async function saveNote(slug: string, currentStatus: string) {
+    setNoteBusy(slug);
+    try {
+      await fetch(`/api/briefs/${slug}/status`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          tracker_status: currentStatus,
+          note: noteDrafts[slug] ?? "",
+        }),
+      });
+      setNoteDrafts((d) => {
+        const next = { ...d };
+        delete next[slug];
+        return next;
+      });
+      await load();
+    } finally {
+      setNoteBusy(null);
     }
   }
 
@@ -235,6 +264,44 @@ export default function BriefsInboxClient() {
                   <span className="text-xs text-slate-400">
                     Update status as you progress.
                   </span>
+                </div>
+                <div className="mt-3 border-t border-slate-100 pt-3">
+                  <label
+                    htmlFor={`note-${b.slug}`}
+                    className="block text-xs font-semibold text-slate-500 mb-1"
+                  >
+                    Private note
+                  </label>
+                  <textarea
+                    id={`note-${b.slug}`}
+                    rows={2}
+                    maxLength={2000}
+                    value={noteDrafts[b.slug] ?? b.latest_note ?? ""}
+                    onChange={(e) =>
+                      setNoteDrafts((d) => ({ ...d, [b.slug]: e.target.value }))
+                    }
+                    placeholder="Add a private note (only you can see this)…"
+                    className="w-full text-xs border border-slate-200 rounded-md px-2 py-1.5 focus:outline-none focus:border-amber-400 focus:ring-1 focus:ring-amber-300"
+                  />
+                  <div className="flex items-center justify-between mt-1.5">
+                    <span className="text-xs text-slate-400">
+                      {b.latest_note_at
+                        ? `Last note ${new Date(b.latest_note_at).toLocaleDateString()}`
+                        : "Notes are private to you."}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => saveNote(b.slug, b.tracker_status)}
+                      disabled={
+                        noteBusy === b.slug ||
+                        (noteDrafts[b.slug] ?? b.latest_note ?? "") ===
+                          (b.latest_note ?? "")
+                      }
+                      className="text-xs font-bold text-amber-700 hover:text-amber-600 disabled:text-slate-300"
+                    >
+                      {noteBusy === b.slug ? "Saving…" : "Save note"}
+                    </button>
+                  </div>
                 </div>
               </article>
             ))}

--- a/app/api/briefs/inbox/route.ts
+++ b/app/api/briefs/inbox/route.ts
@@ -104,9 +104,36 @@ export async function GET(request: NextRequest) {
       .order("accepted_at", { ascending: false })
       .limit(50);
 
+    // Attach the most recent advisor note per accepted brief. Notes live in
+    // brief_tracker_events.payload.note (written by updateTrackerStatus). We
+    // only query events for briefs this advisor already owns (acceptedRaw is
+    // scoped by accepted_by_professional_id), so no cross-advisor leak.
+    const acceptedIds = (acceptedRaw ?? []).map((b) => b.id as number);
+    const latestNote = new Map<number, { note: string; at: string }>();
+    if (acceptedIds.length > 0) {
+      const { data: events } = await admin
+        .from("brief_tracker_events")
+        .select("brief_id, payload, created_at")
+        .in("brief_id", acceptedIds)
+        .eq("event_type", "status_changed")
+        .order("created_at", { ascending: false });
+      for (const e of events ?? []) {
+        const briefId = e.brief_id as number;
+        const note = (e.payload as { note?: string | null } | null)?.note;
+        if (note && !latestNote.has(briefId)) {
+          latestNote.set(briefId, { note, at: e.created_at as string });
+        }
+      }
+    }
+    const accepted = (acceptedRaw ?? []).map((b) => ({
+      ...b,
+      latest_note: latestNote.get(b.id as number)?.note ?? null,
+      latest_note_at: latestNote.get(b.id as number)?.at ?? null,
+    }));
+
     return NextResponse.json({
       available,
-      accepted: acceptedRaw ?? [],
+      accepted,
       teamIds,
     });
   } catch (err) {


### PR DESCRIPTION
## Summary — Build-Everything B3 (advisor lead-management, lean lane)

Completes the advisor lead-management CRM on the briefs inbox. The pipeline stages (`new → contacted → call_booked → proposal_sent → won/lost`), status-update API, and an event-log audit trail (`brief_tracker_events`) already shipped — the one missing piece was **private notes**:

- **Inbox UI** (`app/advisor-portal/briefs/BriefsInboxClient.tsx`) — each accepted brief now has a private-note textarea + "Save note" (disabled until changed). Saving re-sends the *current* stage so the note attaches without altering the pipeline.
- **Inbox API** (`app/api/briefs/inbox/route.ts`) — returns `latest_note` / `latest_note_at` per accepted brief, read back from `brief_tracker_events.payload.note` (one batched query, scoped to briefs the advisor already owns — no cross-advisor read).

No migration: the status route + schema already accept an optional `note`, and the event log already stores it. B2B advisor tooling only — no consumer advice, no reg risk.

## Validation
tsc clean · eslint clean · JSON-LD + rate-limit gates pass · full vitest suite green (10,196) · coverage 64.61% (≥ floor). Verified in a linked worktree with the real toolchain.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUfSRE2Teb6VhEXFP6RpS9)_