### PR TITLE
feat: advisor lead-quality peer benchmark (B5)

### DIFF
--- a/__tests__/lib/advisor/lead-benchmark.test.ts
+++ b/__tests__/lib/advisor/lead-benchmark.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeLeadBenchmark,
+  MIN_PEERS,
+  MIN_PEER_LEADS,
+} from "@/lib/advisor/lead-benchmark";
+
+function statuses(counts: {
+  new?: number;
+  contacted?: number;
+  converted?: number;
+  lost?: number;
+}): string[] {
+  const out: string[] = [];
+  for (const [status, n] of Object.entries(counts)) {
+    for (let i = 0; i < (n ?? 0); i++) out.push(status);
+  }
+  return out;
+}
+
+describe("computeLeadBenchmark", () => {
+  it("is unavailable (no_type) when the advisor has no type", () => {
+    const r = computeLeadBenchmark({
+      advisorType: null,
+      peerCount: 50,
+      peerLeadStatuses: statuses({ converted: 100 }),
+      windowDays: 90,
+    });
+    expect(r).toEqual({ available: false, reason: "no_type" });
+  });
+
+  it("is unavailable (insufficient_peers) below the peer floor", () => {
+    const r = computeLeadBenchmark({
+      advisorType: "financial_planner",
+      peerCount: MIN_PEERS - 1,
+      peerLeadStatuses: statuses({ converted: 100 }),
+      windowDays: 90,
+    });
+    expect(r.available).toBe(false);
+    expect(r.reason).toBe("insufficient_peers");
+    expect(r.peer_count).toBe(MIN_PEERS - 1);
+    // Privacy: no rates leak when gated.
+    expect(r.peer_accept_rate_pct).toBeUndefined();
+  });
+
+  it("is unavailable (insufficient_data) below the lead-sample floor", () => {
+    const r = computeLeadBenchmark({
+      advisorType: "financial_planner",
+      peerCount: 10,
+      peerLeadStatuses: statuses({ contacted: MIN_PEER_LEADS - 1 }),
+      windowDays: 90,
+    });
+    expect(r.available).toBe(false);
+    expect(r.reason).toBe("insufficient_data");
+    expect(r.peer_accept_rate_pct).toBeUndefined();
+  });
+
+  it("returns aggregate accept + conversion rates when above both floors", () => {
+    // 100 leads: 50 converted, 30 contacted, 20 lost.
+    // accepted = contacted + converted = 80 → 80.0%; converted = 50 → 50.0%.
+    const r = computeLeadBenchmark({
+      advisorType: "mortgage_broker",
+      peerCount: 12,
+      peerLeadStatuses: statuses({ converted: 50, contacted: 30, lost: 20 }),
+      windowDays: 90,
+    });
+    expect(r.available).toBe(true);
+    expect(r.advisor_type).toBe("mortgage_broker");
+    expect(r.peer_count).toBe(12);
+    expect(r.peer_accept_rate_pct).toBe(80);
+    expect(r.peer_conversion_rate_pct).toBe(50);
+    expect(r.window_days).toBe(90);
+  });
+
+  it("rounds rates to one decimal place", () => {
+    // 33 converted of 99 total = 33.33% → 33.3
+    const r = computeLeadBenchmark({
+      advisorType: "accountant",
+      peerCount: 8,
+      peerLeadStatuses: statuses({ converted: 33, lost: 66 }),
+      windowDays: 90,
+    });
+    expect(r.peer_conversion_rate_pct).toBe(33.3);
+  });
+});

--- a/app/advisor-portal/AnalyticsTab.tsx
+++ b/app/advisor-portal/AnalyticsTab.tsx
@@ -1,7 +1,17 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import Icon from "@/components/Icon";
 import type { Advisor, Stats, Lead, ProfileCompleteness, ViewType } from "./types";
+
+interface LeadBenchmark {
+  available: boolean;
+  advisor_type?: string;
+  peer_count?: number;
+  window_days?: number;
+  peer_accept_rate_pct?: number;
+  peer_conversion_rate_pct?: number;
+}
 
 function formatResponseTime(minutes: number | null): string {
   if (minutes === null) return "—";
@@ -20,6 +30,24 @@ type Props = {
 };
 
 export default function AnalyticsTab({ stats, advisor, leads, profileCompleteness, onNavigate }: Props) {
+  const [benchmark, setBenchmark] = useState<LeadBenchmark | null>(null);
+  useEffect(() => {
+    let active = true;
+    fetch("/api/advisor-portal/lead-quality-benchmark")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => {
+        if (active && d) setBenchmark(d as LeadBenchmark);
+      })
+      .catch(() => {});
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const myAccept = stats?.acceptRate ?? 0;
+  const acceptAhead =
+    benchmark?.available && myAccept >= (benchmark.peer_accept_rate_pct ?? 0);
+
   return (
     <div className="space-y-4 md:space-y-6">
       <div>
@@ -123,6 +151,44 @@ export default function AnalyticsTab({ stats, advisor, leads, profileCompletenes
             })()}
           </div>
         </div>
+        {benchmark?.available && (
+          <div className="mt-3 pt-3 border-t border-slate-100">
+            <p className="text-[0.6rem] font-medium text-slate-400 uppercase tracking-wide mb-2">
+              vs other {benchmark.advisor_type?.replace(/_/g, " ")}s · last{" "}
+              {benchmark.window_days} days · {benchmark.peer_count} peers
+            </p>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="bg-slate-50 rounded-xl p-3 text-center">
+                <p className="text-sm font-bold text-slate-900">
+                  {myAccept}%{" "}
+                  <span className="text-slate-400 font-normal">vs</span>{" "}
+                  {benchmark.peer_accept_rate_pct}%
+                </p>
+                <p className="text-[0.6rem] text-slate-500 mt-1">
+                  Your accept rate vs peers
+                </p>
+                <p
+                  className={`text-[0.55rem] mt-0.5 font-medium ${acceptAhead ? "text-emerald-600" : "text-amber-600"}`}
+                >
+                  {acceptAhead ? "Above peer average" : "Below peer average"}
+                </p>
+              </div>
+              <div className="bg-slate-50 rounded-xl p-3 text-center">
+                <p className="text-sm font-bold text-slate-900">
+                  {stats?.conversionRate ?? "0"}%{" "}
+                  <span className="text-slate-400 font-normal">vs</span>{" "}
+                  {benchmark.peer_conversion_rate_pct}%
+                </p>
+                <p className="text-[0.6rem] text-slate-500 mt-1">
+                  Your conversion vs peers
+                </p>
+                <p className="text-[0.55rem] text-slate-400 mt-0.5">
+                  Same-type advisors only
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
       </div>
 
       {/* Response time */}

--- a/app/api/advisor-portal/lead-quality-benchmark/route.ts
+++ b/app/api/advisor-portal/lead-quality-benchmark/route.ts
@@ -1,0 +1,95 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { createAdminClient } from "@/lib/supabase/admin";
+import { requireAdvisorSession } from "@/lib/require-advisor-session";
+import { isAllowed, ipKey } from "@/lib/rate-limit-db";
+import { logger } from "@/lib/logger";
+import { computeLeadBenchmark } from "@/lib/advisor/lead-benchmark";
+
+export const runtime = "nodejs";
+
+const log = logger("advisor:lead-benchmark");
+
+const WINDOW_DAYS = 90;
+
+/**
+ * GET /api/advisor-portal/lead-quality-benchmark
+ *
+ * Returns the same-type peer-group lead-quality aggregate (accept + conversion
+ * rate) so the authed advisor can benchmark themselves. Aggregate-only and
+ * gated by MIN_PEERS / MIN_PEER_LEADS (see lib/advisor/lead-benchmark.ts) — no
+ * individual competitor's data is exposed. Service-role is required: this is a
+ * cross-advisor aggregate that can't be scoped to the caller's auth.uid().
+ */
+export async function GET(request: NextRequest) {
+  try {
+    if (
+      !(await isAllowed("lead_quality_benchmark", ipKey(request), {
+        max: 30,
+        refillPerSec: 0.5,
+      }))
+    ) {
+      return NextResponse.json({ error: "Too many requests." }, { status: 429 });
+    }
+
+    const advisorId = await requireAdvisorSession(request);
+    if (!advisorId) {
+      return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+    }
+
+    const admin = createAdminClient();
+    const { data: me } = await admin
+      .from("professionals")
+      .select("id, type")
+      .eq("id", advisorId)
+      .maybeSingle();
+
+    const advisorType = (me?.type as string | null) ?? null;
+    if (!advisorType) {
+      return NextResponse.json(computeLeadBenchmark({
+        advisorType: null,
+        peerCount: 0,
+        peerLeadStatuses: [],
+        windowDays: WINDOW_DAYS,
+      }));
+    }
+
+    // Same-type active peers, excluding the caller.
+    const { data: peers } = await admin
+      .from("professionals")
+      .select("id")
+      .eq("type", advisorType)
+      .eq("status", "active")
+      .neq("id", advisorId);
+    const peerIds = (peers ?? []).map((p) => p.id as number);
+
+    let peerLeadStatuses: string[] = [];
+    if (peerIds.length > 0) {
+      const since = new Date(Date.now() - WINDOW_DAYS * 86400_000).toISOString();
+      const { data: peerLeads } = await admin
+        .from("professional_leads")
+        .select("status")
+        .in("professional_id", peerIds)
+        .gte("created_at", since)
+        .limit(20000);
+      peerLeadStatuses = (peerLeads ?? []).map((l) => l.status as string);
+    }
+
+    return NextResponse.json(
+      computeLeadBenchmark({
+        advisorType,
+        peerCount: peerIds.length,
+        peerLeadStatuses,
+        windowDays: WINDOW_DAYS,
+      }),
+    );
+  } catch (err) {
+    log.error("benchmark error", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json(
+      { error: "Failed to load benchmark." },
+      { status: 500 },
+    );
+  }
+}

--- a/lib/advisor/lead-benchmark.ts
+++ b/lib/advisor/lead-benchmark.ts
@@ -1,0 +1,71 @@
+/**
+ * Lead-quality peer benchmark (B5).
+ *
+ * Computes an advisor's same-type peer-group lead-quality aggregate so the
+ * advisor can benchmark their own accept/conversion rates. PRIVACY: this only
+ * ever returns aggregates, and is gated behind a minimum peer count AND a
+ * minimum total-lead sample so no individual competitor's data can be inferred.
+ * The pure computation lives here so it can be unit-tested without a DB.
+ */
+
+/** Minimum distinct same-type peers before any benchmark is returned. */
+export const MIN_PEERS = 5;
+/** Minimum total peer leads in the window before a benchmark is returned. */
+export const MIN_PEER_LEADS = 30;
+
+export type LeadBenchmarkReason =
+  | "no_type"
+  | "insufficient_peers"
+  | "insufficient_data";
+
+export interface LeadBenchmark {
+  available: boolean;
+  reason?: LeadBenchmarkReason;
+  window_days?: number;
+  advisor_type?: string;
+  peer_count?: number;
+  peer_accept_rate_pct?: number;
+  peer_conversion_rate_pct?: number;
+}
+
+function rate(part: number, whole: number): number {
+  return whole > 0 ? Math.round((part / whole) * 1000) / 10 : 0;
+}
+
+/**
+ * Build the benchmark from a peer set's lead statuses. `peerLeadStatuses` is
+ * the flat list of `professional_leads.status` across all same-type peers in
+ * the window — never grouped by advisor, so no per-peer figure is exposed.
+ */
+export function computeLeadBenchmark(params: {
+  advisorType: string | null;
+  peerCount: number;
+  peerLeadStatuses: string[];
+  windowDays: number;
+}): LeadBenchmark {
+  const { advisorType, peerCount, peerLeadStatuses, windowDays } = params;
+
+  if (!advisorType) return { available: false, reason: "no_type" };
+  if (peerCount < MIN_PEERS) {
+    return { available: false, reason: "insufficient_peers", peer_count: peerCount };
+  }
+
+  const total = peerLeadStatuses.length;
+  if (total < MIN_PEER_LEADS) {
+    return { available: false, reason: "insufficient_data", peer_count: peerCount };
+  }
+
+  const accepted = peerLeadStatuses.filter(
+    (s) => s === "contacted" || s === "converted",
+  ).length;
+  const converted = peerLeadStatuses.filter((s) => s === "converted").length;
+
+  return {
+    available: true,
+    window_days: windowDays,
+    advisor_type: advisorType,
+    peer_count: peerCount,
+    peer_accept_rate_pct: rate(accepted, total),
+    peer_conversion_rate_pct: rate(converted, total),
+  };
+}


### PR DESCRIPTION
## Summary — Build-Everything B5 (B2B analytics, lean lane)

Adds a peer benchmark to the advisor analytics tab so an advisor can see their **accept + conversion rates vs same-type peers** — completing the "lead-quality benchmark" item. The individual metrics + funnel already existed; the missing piece was the peer comparison.

- **`lib/advisor/lead-benchmark.ts`** — pure, unit-tested gating + rate math.
- **`GET /api/advisor-portal/lead-quality-benchmark`** — resolves same-type active peers and returns **aggregate-only** accept/conversion rates, computed from `professional_leads`. Rate-limited.
- **`AnalyticsTab.tsx`** — fetches the benchmark and renders a "vs peers" card in the Lead Performance section (only when available).

## Privacy
The endpoint returns **only aggregates** (rates + a peer count), never per-advisor figures, and is gated behind `MIN_PEERS = 5` **and** `MIN_PEER_LEADS = 30` — below either floor it returns `{ available: false }` so no individual competitor's performance can be inferred. Service-role is used because this is a cross-advisor aggregate that can't be scoped to `auth.uid()` (mirrors the existing `marketplace-analytics` category benchmark). No migration.

## Validation
tsc clean · eslint clean · JSON-LD + rate-limit gates pass · full vitest suite green (10,201, incl. new benchmark tests) · coverage 64.59% (≥ floor).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUfSRE2Teb6VhEXFP6RpS9)_