### PR TITLE
feat: widget marketplace gallery on /embed (E1)

### DIFF
--- a/app/embed/WidgetGallery.tsx
+++ b/app/embed/WidgetGallery.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useState } from "react";
+import { WIDGET_CATALOGUE } from "@/lib/widget/types";
+
+const BASE = "https://invest.com.au/api/widget";
+
+function snippetFor(slug: string): string {
+  return `<script src="${BASE}?widget=${slug}"></script>`;
+}
+
+/**
+ * Browsable gallery of the curated `?widget=` catalogue (E1). Each card shows
+ * a ready-made widget and a one-click copy of its embed snippet, so publishers
+ * can discover the available widgets without learning the query-param API.
+ */
+export default function WidgetGallery() {
+  const [copied, setCopied] = useState<string | null>(null);
+
+  async function copy(slug: string) {
+    const snippet = snippetFor(slug);
+    try {
+      await navigator.clipboard.writeText(snippet);
+    } catch {
+      const ta = document.createElement("textarea");
+      ta.value = snippet;
+      document.body.appendChild(ta);
+      ta.select();
+      document.execCommand("copy");
+      document.body.removeChild(ta);
+    }
+    setCopied(slug);
+    setTimeout(() => setCopied((c) => (c === slug ? null : c)), 2000);
+  }
+
+  return (
+    <div className="grid sm:grid-cols-2 gap-4">
+      {WIDGET_CATALOGUE.map((w) => (
+        <div
+          key={w.slug}
+          className="border border-slate-200 rounded-xl overflow-hidden flex flex-col"
+        >
+          <div className="px-5 py-3 bg-slate-50 border-b border-slate-200">
+            <h3 className="font-bold text-sm text-slate-900">{w.label}</h3>
+            <p className="text-xs text-slate-500 mt-0.5">{w.description}</p>
+          </div>
+          <div className="px-5 py-4 bg-slate-900 flex-1">
+            <code className="text-xs text-emerald-400 font-mono break-all select-all">
+              {snippetFor(w.slug)}
+            </code>
+          </div>
+          <button
+            type="button"
+            onClick={() => copy(w.slug)}
+            className="px-5 py-2.5 text-xs font-bold text-emerald-700 hover:bg-emerald-50 border-t border-slate-200 transition-colors"
+          >
+            {copied === w.slug ? "Copied!" : "Copy snippet"}
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/app/embed/page.tsx
+++ b/app/embed/page.tsx
@@ -1,8 +1,9 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { absoluteUrl, breadcrumbJsonLd, CURRENT_YEAR, SITE_NAME } from "@/lib/seo";
+import { absoluteUrl, breadcrumbJsonLd, SITE_NAME } from "@/lib/seo";
 import Icon from "@/components/Icon";
 import EmbedBuilder from "./EmbedBuilder";
+import WidgetGallery from "./WidgetGallery";
 
 export const revalidate = 3600;
 
@@ -94,6 +95,15 @@ export default function EmbedPage() {
               <p className="text-xs text-slate-500 leading-relaxed">{step.desc}</p>
             </div>
           ))}
+        </div>
+
+        {/* Widget Gallery */}
+        <h2 className="text-lg md:text-xl font-extrabold text-slate-900 mb-2">Widget Gallery</h2>
+        <p className="text-sm text-slate-500 mb-4">
+          Ready-made widgets for popular comparisons — copy a snippet and paste it anywhere. Each one stays up to date automatically.
+        </p>
+        <div className="mb-12">
+          <WidgetGallery />
         </div>
 
         {/* Snippet Examples */}


### PR DESCRIPTION
## Summary — Build-Everything E1 (distribution, lean lane)

Turns `/embed` into a browsable **widget marketplace gallery**. The `/api/widget` route already serves 5 curated `?widget=` types (cheapest brokers, US shares, crypto exchanges, savings rates, term deposits) and they're tested — but the embed page never surfaced them; publishers had to know the query-param API. This adds a gallery so they can discover and copy each one.

- **`app/embed/WidgetGallery.tsx`** — maps `WIDGET_CATALOGUE` to cards (label + description + snippet + one-click copy, mirroring `EmbedBuilder`'s clipboard pattern with an `execCommand` fallback).
- **`app/embed/page.tsx`** — renders the gallery in a new "Widget Gallery" section above the existing examples. Also removed an unused `CURRENT_YEAR` import.

No API, data, or migration changes — pure UX over existing infrastructure. (The "WhatsApp/Telegram alerts bot" half of the E1 backlog item is out of scope here.)

## Validation
tsc clean · eslint clean · JSON-LD + rate-limit gates pass · full vitest suite green (10,196) · coverage 64.62% (≥ floor).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUfSRE2Teb6VhEXFP6RpS9)_