### PR TITLE
feat: PA stream — Copilot, Pipeline CRM, Widget Builder, Business Finance, Alert Account Page

### DIFF
--- a/app/account/alerts/AlertsClient.tsx
+++ b/app/account/alerts/AlertsClient.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import Icon from "@/components/Icon";
+
+interface AlertRow {
+  id: string;
+  product_kind: string;
+  threshold_bps: number;
+  frequency: string;
+  verified: boolean;
+  last_notified_at: string | null;
+  notification_count: number;
+  created_at: string | null;
+  unsubscribe_token: string;
+}
+
+interface Props {
+  alerts: AlertRow[];
+  userEmail: string;
+}
+
+const STAGE_LABELS: Record<string, string> = {
+  savings_account: "Savings Account",
+  term_deposit: "Term Deposit",
+};
+
+const FREQUENCY_LABELS: Record<string, string> = {
+  instant: "Instant (within 24h)",
+  daily: "Daily digest",
+  weekly: "Weekly digest",
+};
+
+export default function AlertsClient({ alerts: initial, userEmail }: Props) {
+  const [alerts, setAlerts] = useState(initial);
+  const [removing, setRemoving] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleRemove = async (alert: AlertRow) => {
+    setRemoving(alert.id);
+    setError(null);
+    try {
+      const res = await fetch(
+        `/api/rate-alerts?unsubscribe=${alert.unsubscribe_token}`,
+        { method: "GET" },
+      );
+      if (res.ok) {
+        setAlerts((prev) => prev.filter((a) => a.id !== alert.id));
+      } else {
+        setError("Failed to remove alert. Please try again.");
+      }
+    } catch {
+      setError("Failed to remove alert. Please try again.");
+    }
+    setRemoving(null);
+  };
+
+  if (alerts.length === 0) {
+    return (
+      <div className="rounded-2xl border border-slate-200 bg-white p-8 text-center">
+        <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-2xl bg-amber-50">
+          <Icon name="bell" size={24} className="text-amber-500" />
+        </div>
+        <p className="text-sm font-semibold text-slate-900">No alerts yet</p>
+        <p className="mt-1 text-xs text-slate-500">
+          Set up a rate alert and we&apos;ll email you when an Australian savings
+          account or term deposit crosses your target rate.
+        </p>
+        <Link
+          href="/rate-alerts"
+          className="mt-4 inline-block rounded-lg bg-slate-900 px-4 py-2 text-xs font-semibold text-white hover:bg-slate-700 transition-colors"
+        >
+          Set up an alert
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {error && (
+        <div className="rounded-lg bg-red-50 border border-red-200 px-4 py-3 text-xs text-red-700">
+          {error}
+        </div>
+      )}
+
+      <p className="text-xs text-slate-500">
+        Alerts sent to <strong>{userEmail}</strong>
+      </p>
+
+      {alerts.map((alert) => {
+        const thresholdPct = (alert.threshold_bps / 100).toFixed(2);
+        const productLabel = STAGE_LABELS[alert.product_kind] ?? alert.product_kind;
+        const freqLabel = FREQUENCY_LABELS[alert.frequency] ?? alert.frequency;
+
+        return (
+          <div
+            key={alert.id}
+            className="flex items-start justify-between gap-4 rounded-xl border border-slate-200 bg-white p-4"
+          >
+            <div className="flex items-start gap-3">
+              <div className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-amber-50">
+                <Icon name="bell" size={18} className="text-amber-500" />
+              </div>
+              <div>
+                <p className="text-sm font-semibold text-slate-900">
+                  {productLabel} &ge;{thresholdPct}% p.a.
+                </p>
+                <p className="mt-0.5 text-xs text-slate-500">{freqLabel}</p>
+                <div className="mt-1.5 flex flex-wrap items-center gap-2">
+                  {alert.verified ? (
+                    <span className="inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2 py-0.5 text-[0.65rem] font-semibold text-emerald-700">
+                      <Icon name="check-circle" size={11} />
+                      Verified
+                    </span>
+                  ) : (
+                    <span className="inline-flex items-center gap-1 rounded-full bg-amber-50 px-2 py-0.5 text-[0.65rem] font-semibold text-amber-700">
+                      <Icon name="clock" size={11} />
+                      Awaiting verification
+                    </span>
+                  )}
+                  {alert.notification_count > 0 && (
+                    <span className="text-[0.65rem] text-slate-400">
+                      {alert.notification_count} alert{alert.notification_count !== 1 ? "s" : ""} sent
+                    </span>
+                  )}
+                  {alert.last_notified_at && (
+                    <span className="text-[0.65rem] text-slate-400">
+                      Last: {new Date(alert.last_notified_at).toLocaleDateString("en-AU")}
+                    </span>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            <button
+              type="button"
+              disabled={removing === alert.id}
+              onClick={() => handleRemove(alert)}
+              className="shrink-0 rounded-lg border border-slate-200 px-3 py-1.5 text-xs text-slate-500 hover:border-red-200 hover:text-red-600 transition-colors disabled:opacity-40"
+            >
+              {removing === alert.id ? "Removing…" : "Remove"}
+            </button>
+          </div>
+        );
+      })}
+
+      <div className="pt-2">
+        <Link
+          href="/rate-alerts"
+          className="text-xs font-medium text-slate-700 hover:text-slate-900"
+        >
+          + Add another alert
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/app/account/alerts/page.tsx
+++ b/app/account/alerts/page.tsx
@@ -1,0 +1,69 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import AlertsClient from "./AlertsClient";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Rate Alerts — My Account",
+  robots: "noindex, nofollow",
+};
+
+export default async function AccountAlertsPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/account/login?redirect=/account/alerts");
+  }
+
+  const email = user.email ?? "";
+  const admin = createAdminClient();
+
+  const { data: rows } = await admin
+    .from("rate_alert_subscriptions")
+    .select(
+      "id, product_kind, threshold_bps, frequency, verified, last_notified_at, notification_count, created_at, unsubscribe_token",
+    )
+    .eq("email", email.toLowerCase())
+    .order("created_at", { ascending: false });
+
+  const alerts = rows ?? [];
+
+  return (
+    <div className="py-6 md:py-10">
+      <div className="container-custom max-w-3xl">
+        <nav className="text-xs text-slate-500 mb-3">
+          <Link href="/account" className="hover:text-slate-900">
+            ← My account
+          </Link>
+        </nav>
+
+        <div className="flex items-baseline justify-between mb-5 flex-wrap gap-2">
+          <div>
+            <h1 className="text-2xl font-extrabold text-slate-900">Rate Alerts</h1>
+            <p className="text-sm text-slate-500">
+              {alerts.length === 0
+                ? "No active alerts"
+                : `${alerts.length} alert${alerts.length === 1 ? "" : "s"} set up`}
+            </p>
+          </div>
+          <Link
+            href="/rate-alerts"
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-slate-900 text-white text-xs font-semibold hover:bg-slate-700 transition-colors"
+          >
+            + New alert
+          </Link>
+        </div>
+
+        <AlertsClient alerts={alerts} userEmail={email} />
+      </div>
+    </div>
+  );
+}

--- a/app/advisor-portal/LeadsTab.tsx
+++ b/app/advisor-portal/LeadsTab.tsx
@@ -8,6 +8,15 @@ import { logger } from "@/lib/logger";
 
 const log = logger("advisor-portal-leads");
 
+const PIPELINE_STAGES = [
+  { value: "new", label: "New", color: "text-amber-700 bg-amber-50 border-amber-200" },
+  { value: "contacted", label: "Contacted", color: "text-blue-700 bg-blue-50 border-blue-200" },
+  { value: "proposal_sent", label: "Proposal Sent", color: "text-violet-700 bg-violet-50 border-violet-200" },
+  { value: "negotiating", label: "Negotiating", color: "text-orange-700 bg-orange-50 border-orange-200" },
+  { value: "won", label: "Won", color: "text-emerald-700 bg-emerald-50 border-emerald-200" },
+  { value: "lost", label: "Lost", color: "text-red-600 bg-red-50 border-red-200" },
+] as const;
+
 type LeadStatusFilter = "all" | "new" | "contacted" | "converted" | "lost";
 
 type Props = {
@@ -38,6 +47,7 @@ export default function LeadsTab({
   // Firm inbox — only visible to firm admins
   const isFirmAdmin = !!advisor?.is_firm_admin && !!advisor?.firm_id;
   const [firmView, setFirmView] = useState(false);
+  const [pipelineUpdating, setPipelineUpdating] = useState<number | null>(null);
   const [firmLeads, setFirmLeads] = useState<Lead[]>([]);
   const [firmMembers, setFirmMembers] = useState<FirmMemberOption[]>([]);
   const [firmLoading, setFirmLoading] = useState(false);
@@ -75,6 +85,26 @@ export default function LeadsTab({
       );
     } catch { /* ignore */ }
     setReassigning(null);
+  };
+
+  const updatePipeline = async (
+    leadId: number,
+    patch: { pipeline_stage?: string; next_action_at?: string | null },
+  ) => {
+    setPipelineUpdating(leadId);
+    try {
+      await fetch("/api/advisor-portal/pipeline", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ lead_id: leadId, ...patch }),
+      });
+      onLeadsUpdate((prev) =>
+        prev.map((l) => (l.id === leadId ? { ...l, ...patch } : l)),
+      );
+    } catch (err) {
+      log.warn("pipeline update failed", { err: String(err) });
+    }
+    setPipelineUpdating(null);
   };
 
   const filteredLeads = leads.filter((l) => {
@@ -333,6 +363,44 @@ export default function LeadsTab({
               {lead.message && (
                 <div className="bg-slate-50 rounded-lg p-3 text-xs text-slate-600 mb-3 leading-relaxed">{lead.message}</div>
               )}
+
+              {/* Pipeline stage + follow-up date */}
+              <div className="flex flex-wrap items-center gap-2 mb-3">
+                <select
+                  value={lead.pipeline_stage ?? "new"}
+                  disabled={pipelineUpdating === lead.id}
+                  onChange={(e) => updatePipeline(lead.id, { pipeline_stage: e.target.value })}
+                  className="text-xs border border-slate-200 rounded-lg px-2 py-1 bg-white text-slate-700 focus:outline-none focus:ring-1 focus:ring-slate-400 disabled:opacity-50"
+                  aria-label="Pipeline stage"
+                >
+                  {PIPELINE_STAGES.map((s) => (
+                    <option key={s.value} value={s.value}>{s.label}</option>
+                  ))}
+                </select>
+                <div className="flex items-center gap-1">
+                  <Icon name="calendar" size={12} className="text-slate-400 shrink-0" />
+                  <input
+                    type="date"
+                    value={lead.next_action_at ? lead.next_action_at.slice(0, 10) : ""}
+                    disabled={pipelineUpdating === lead.id}
+                    onChange={(e) =>
+                      updatePipeline(lead.id, {
+                        next_action_at: e.target.value
+                          ? new Date(e.target.value + "T09:00:00+10:00").toISOString()
+                          : null,
+                      })
+                    }
+                    className="text-xs border border-slate-200 rounded-lg px-2 py-1 bg-white text-slate-700 focus:outline-none focus:ring-1 focus:ring-slate-400 disabled:opacity-50"
+                    title="Next follow-up date"
+                  />
+                </div>
+                {lead.next_action_at && new Date(lead.next_action_at) < new Date() && (
+                  <span className="text-[0.62rem] font-semibold text-red-600 bg-red-50 border border-red-200 rounded-full px-1.5 py-0.5">
+                    Overdue
+                  </span>
+                )}
+              </div>
+
               <div className="flex items-center gap-2 flex-wrap">
                 {lead.source_page && (
                   <span className="text-[0.56rem] font-semibold px-1.5 py-0.5 rounded-full bg-slate-100 text-slate-500">

--- a/app/advisor-portal/WidgetBuilderTab.tsx
+++ b/app/advisor-portal/WidgetBuilderTab.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import { useState } from "react";
+import Icon from "@/components/Icon";
+import { WIDGET_CATALOGUE } from "@/lib/widget/types";
+
+const THEMES = ["light", "dark"] as const;
+const TYPES = ["table", "compact"] as const;
+const LIMITS = [3, 5, 10] as const;
+
+type Theme = (typeof THEMES)[number];
+type DisplayType = (typeof TYPES)[number];
+
+export default function WidgetBuilderTab() {
+  const [selectedSlug, setSelectedSlug] = useState(WIDGET_CATALOGUE[0]!.slug);
+  const [theme, setTheme] = useState<Theme>("light");
+  const [displayType, setDisplayType] = useState<DisplayType>("table");
+  const [limit, setLimit] = useState<number>(5);
+  const [copied, setCopied] = useState(false);
+
+  const selectedWidget = WIDGET_CATALOGUE.find((w) => w.slug === selectedSlug)!;
+
+  const siteUrl =
+    typeof window !== "undefined"
+      ? window.location.origin
+      : "https://invest.com.au";
+
+  const params = new URLSearchParams({
+    widget: selectedSlug,
+    theme,
+    type: displayType,
+    limit: String(limit),
+  });
+
+  const iframeUrl = `${siteUrl}/api/widget?${params.toString()}`;
+
+  const embedCode = `<!-- ${selectedWidget.heading} widget by invest.com.au -->
+<iframe
+  src="${iframeUrl}"
+  width="100%"
+  height="${displayType === "compact" ? "320" : Math.max(300, limit * 60 + 80)}"
+  style="border:none;border-radius:12px;"
+  loading="lazy"
+  title="${selectedWidget.heading}"
+></iframe>`;
+
+  const copy = () => {
+    navigator.clipboard.writeText(embedCode).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-lg font-extrabold text-slate-900">Widget Builder</h2>
+        <p className="text-sm text-slate-500 mt-1">
+          Embed a live comparison table on your website or blog — rates update automatically.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {/* Controls */}
+        <div className="space-y-4">
+          {/* Widget type */}
+          <div>
+            <label className="block text-xs font-semibold text-slate-700 mb-1.5">
+              Comparison type
+            </label>
+            <div className="grid grid-cols-1 gap-2">
+              {WIDGET_CATALOGUE.map((entry) => (
+                <label
+                  key={entry.slug}
+                  className={`flex items-start gap-3 p-3 rounded-xl border cursor-pointer transition-colors ${
+                    selectedSlug === entry.slug
+                      ? "border-slate-900 bg-slate-50"
+                      : "border-slate-200 hover:border-slate-300"
+                  }`}
+                >
+                  <input
+                    type="radio"
+                    name="widget-slug"
+                    value={entry.slug}
+                    checked={selectedSlug === entry.slug}
+                    onChange={() => setSelectedSlug(entry.slug)}
+                    className="mt-0.5 shrink-0"
+                  />
+                  <div>
+                    <p className="text-sm font-semibold text-slate-900 leading-none">
+                      {entry.label}
+                    </p>
+                    <p className="text-xs text-slate-500 mt-0.5">{entry.description}</p>
+                  </div>
+                </label>
+              ))}
+            </div>
+          </div>
+
+          {/* Theme */}
+          <div>
+            <label className="block text-xs font-semibold text-slate-700 mb-1.5">
+              Theme
+            </label>
+            <div className="flex gap-2">
+              {THEMES.map((t) => (
+                <button
+                  key={t}
+                  type="button"
+                  onClick={() => setTheme(t)}
+                  className={`flex-1 py-2 rounded-lg text-sm font-medium border transition-colors capitalize ${
+                    theme === t
+                      ? "border-slate-900 bg-slate-900 text-white"
+                      : "border-slate-200 text-slate-600 hover:border-slate-300"
+                  }`}
+                >
+                  {t}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Display type */}
+          <div>
+            <label className="block text-xs font-semibold text-slate-700 mb-1.5">
+              Layout
+            </label>
+            <div className="flex gap-2">
+              {TYPES.map((t) => (
+                <button
+                  key={t}
+                  type="button"
+                  onClick={() => setDisplayType(t)}
+                  className={`flex-1 py-2 rounded-lg text-sm font-medium border transition-colors capitalize ${
+                    displayType === t
+                      ? "border-slate-900 bg-slate-900 text-white"
+                      : "border-slate-200 text-slate-600 hover:border-slate-300"
+                  }`}
+                >
+                  {t}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Limit */}
+          <div>
+            <label className="block text-xs font-semibold text-slate-700 mb-1.5">
+              Rows to show
+            </label>
+            <div className="flex gap-2">
+              {LIMITS.map((l) => (
+                <button
+                  key={l}
+                  type="button"
+                  onClick={() => setLimit(l)}
+                  className={`flex-1 py-2 rounded-lg text-sm font-medium border transition-colors ${
+                    limit === l
+                      ? "border-slate-900 bg-slate-900 text-white"
+                      : "border-slate-200 text-slate-600 hover:border-slate-300"
+                  }`}
+                >
+                  {l}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* Embed code */}
+        <div className="space-y-4">
+          <div className="rounded-xl border border-slate-200 overflow-hidden">
+            <div className="flex items-center justify-between bg-slate-50 border-b border-slate-200 px-4 py-3">
+              <span className="text-xs font-semibold text-slate-700">Embed code</span>
+              <button
+                type="button"
+                onClick={copy}
+                className={`flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-semibold transition-colors ${
+                  copied
+                    ? "bg-emerald-100 text-emerald-700"
+                    : "bg-slate-900 text-white hover:bg-slate-700"
+                }`}
+              >
+                <Icon name={copied ? "check" : "copy"} size={13} />
+                {copied ? "Copied!" : "Copy"}
+              </button>
+            </div>
+            <pre className="p-4 text-[0.68rem] text-slate-700 bg-white overflow-x-auto leading-relaxed whitespace-pre-wrap break-all">
+              {embedCode}
+            </pre>
+          </div>
+
+          {/* Preview link */}
+          <a
+            href={iframeUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-2 text-xs font-medium text-slate-500 hover:text-slate-900 transition-colors"
+          >
+            <Icon name="external-link" size={13} />
+            Preview widget in new tab
+          </a>
+
+          {/* Tips */}
+          <div className="rounded-xl bg-blue-50 border border-blue-100 p-4 space-y-1.5">
+            <p className="text-xs font-semibold text-blue-900 flex items-center gap-1.5">
+              <Icon name="info" size={13} /> Usage tips
+            </p>
+            <ul className="text-xs text-blue-800 space-y-1 list-disc pl-4">
+              <li>Paste the embed code anywhere in your website HTML.</li>
+              <li>Rates update automatically — no maintenance required.</li>
+              <li>The widget is responsive and works on mobile.</li>
+              <li>Attribution to invest.com.au is shown inside the widget.</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/advisor-portal/page.tsx
+++ b/app/advisor-portal/page.tsx
@@ -19,6 +19,7 @@ const ProfileTab = dynamic(() => import("./ProfileTab"));
 const BillingTab = dynamic(() => import("./BillingTab"));
 const SettingsTab = dynamic(() => import("./SettingsTab"));
 const TeamTab = dynamic(() => import("./TeamTab"));
+const WidgetBuilderTab = dynamic(() => import("./WidgetBuilderTab"));
 
 export default function AdvisorPortalPage() {
   const [view, setView] = useState<ViewType>("login");
@@ -197,6 +198,7 @@ export default function AdvisorPortalPage() {
     { key: "profile", label: "Profile", icon: "user" },
     { key: "billing", label: "Billing", icon: "credit-card" },
     ...(isFirmAdmin ? [{ key: "team", label: "Team", icon: "users" }] : []),
+    { key: "widgets", label: "Widgets", icon: "code-2" },
     { key: "settings", label: "Settings", icon: "settings" },
   ];
 
@@ -337,6 +339,11 @@ export default function AdvisorPortalPage() {
         {/* ─── TEAM (firm admins only) ─── */}
         {view === "team" && isFirmAdmin && (
           <TeamTab advisor={advisor} />
+        )}
+
+        {/* ─── WIDGETS ─── */}
+        {view === "widgets" && (
+          <WidgetBuilderTab />
         )}
 
       </div>

--- a/app/advisor-portal/types.ts
+++ b/app/advisor-portal/types.ts
@@ -7,7 +7,8 @@ export type ViewType =
   | "billing"
   | "articles"
   | "team"
-  | "settings";
+  | "settings"
+  | "widgets";
 
 export type Advisor = {
   id: number; name: string; slug: string; firm_name?: string; email?: string;
@@ -60,6 +61,9 @@ export type Lead = {
   qualification_data?: Record<string, unknown>; lead_tier?: string;
   bill_amount_cents: number; billed: boolean;
   review_requested_at?: string | null;
+  // Pipeline CRM columns
+  pipeline_stage?: string | null;
+  next_action_at?: string | null;
   // Firm inbox additions — only present in firm-leads API responses
   professional_id?: number;
   professional_name?: string;

--- a/app/api/advisor-portal/pipeline/route.ts
+++ b/app/api/advisor-portal/pipeline/route.ts
@@ -1,0 +1,81 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+import { createClient } from "@/lib/supabase/server";
+import { isAllowed, ipKey } from "@/lib/rate-limit-db";
+import { logger } from "@/lib/logger";
+
+export const runtime = "nodejs";
+
+const log = logger("api:advisor-portal:pipeline");
+
+const PipelineSchema = z.object({
+  lead_id: z.number().int().positive(),
+  pipeline_stage: z
+    .enum(["new", "contacted", "proposal_sent", "negotiating", "won", "lost"])
+    .optional(),
+  next_action_at: z.string().datetime({ offset: true }).nullable().optional(),
+});
+
+export async function PATCH(req: NextRequest) {
+  const allowed = await isAllowed("advisor_pipeline_patch", ipKey(req), {
+    max: 60,
+    refillPerSec: 1,
+  });
+  if (!allowed) {
+    return NextResponse.json({ error: "Too many requests." }, { status: 429 });
+  }
+
+  // Verify advisor session
+  const supabase = await createClient();
+  const sessionRes = await fetch(
+    new URL("/api/advisor-auth/session", req.url).toString(),
+    { headers: { cookie: req.headers.get("cookie") ?? "" } },
+  );
+  if (!sessionRes.ok) {
+    return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+  }
+  const { advisor } = (await sessionRes.json()) as { advisor: { id: number } | null };
+  if (!advisor) {
+    return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON." }, { status: 400 });
+  }
+
+  const parsed = PipelineSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid request.", details: parsed.error.flatten() },
+      { status: 400 },
+    );
+  }
+  const { lead_id, pipeline_stage, next_action_at } = parsed.data;
+
+  if (pipeline_stage === undefined && next_action_at === undefined) {
+    return NextResponse.json({ error: "Nothing to update." }, { status: 400 });
+  }
+
+  const updates: Record<string, unknown> = {
+    updated_at: new Date().toISOString(),
+  };
+  if (pipeline_stage !== undefined) updates.pipeline_stage = pipeline_stage;
+  if (next_action_at !== undefined) updates.next_action_at = next_action_at;
+
+  const { error } = await supabase
+    .from("professional_leads")
+    .update(updates)
+    .eq("id", lead_id)
+    .eq("professional_id", advisor.id);
+
+  if (error) {
+    log.error("pipeline update failed", { err: error.message, lead_id });
+    return NextResponse.json({ error: "Update failed." }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/app/api/business-finance/enquiry/route.ts
+++ b/app/api/business-finance/enquiry/route.ts
@@ -1,0 +1,149 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+import { createClient } from "@/lib/supabase/server";
+import { isAllowed, ipKey } from "@/lib/rate-limit-db";
+import { isValidEmail, isDisposableEmail } from "@/lib/validate-email";
+import { sendEmail } from "@/lib/resend";
+import { getSiteUrl } from "@/lib/url";
+import { logger } from "@/lib/logger";
+
+export const runtime = "nodejs";
+
+const log = logger("api:business-finance:enquiry");
+
+const EnquirySchema = z.object({
+  business_name: z.string().min(1).max(200),
+  contact_name: z.string().min(1).max(200),
+  email: z.string().email().max(254),
+  phone: z.string().max(30).optional(),
+  finance_type: z.enum([
+    "business_loan",
+    "equipment_finance",
+    "invoice_finance",
+    "line_of_credit",
+    "trade_finance",
+    "other",
+  ]),
+  loan_amount: z.number().min(0).max(50_000_000).optional(),
+  purpose: z.string().max(1000).optional(),
+  time_in_business_months: z.number().int().min(0).max(1200).optional(),
+  annual_revenue: z.number().min(0).max(500_000_000).optional(),
+  message: z.string().max(2000).optional(),
+  // Honeypot
+  website: z.string().optional(),
+});
+
+export async function POST(req: NextRequest) {
+  const allowed = await isAllowed("business_finance_enquiry", ipKey(req), {
+    max: 5,
+    refillPerSec: 0.05,
+  });
+  if (!allowed) {
+    return NextResponse.json({ error: "Too many requests." }, { status: 429 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON." }, { status: 400 });
+  }
+
+  const parsed = EnquirySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid request.", details: parsed.error.flatten() },
+      { status: 400 },
+    );
+  }
+
+  const {
+    business_name,
+    contact_name,
+    email,
+    phone,
+    finance_type,
+    loan_amount,
+    purpose,
+    time_in_business_months,
+    annual_revenue,
+    message,
+    website,
+  } = parsed.data;
+
+  // Honeypot
+  if (website && website.length > 0) {
+    return NextResponse.json({ success: true });
+  }
+
+  if (!isValidEmail(email)) {
+    return NextResponse.json({ error: "Valid email required." }, { status: 400 });
+  }
+  if (isDisposableEmail(email)) {
+    return NextResponse.json(
+      { error: "Please use a business email address." },
+      { status: 400 },
+    );
+  }
+
+  const supabase = await createClient();
+  const { error: insertErr } = await supabase
+    .from("business_finance_enquiries")
+    .insert({
+      business_name,
+      contact_name,
+      email: email.toLowerCase(),
+      phone: phone ?? null,
+      finance_type,
+      loan_amount_cents: loan_amount != null ? Math.round(loan_amount * 100) : null,
+      purpose: purpose ?? null,
+      time_in_business_months: time_in_business_months ?? null,
+      annual_revenue_cents: annual_revenue != null ? Math.round(annual_revenue * 100) : null,
+      message: message ?? null,
+      status: "new",
+    });
+
+  if (insertErr) {
+    log.error("business finance enquiry insert failed", { err: insertErr.message });
+    return NextResponse.json({ error: "Failed to submit enquiry." }, { status: 500 });
+  }
+
+  const siteUrl = getSiteUrl();
+  const financeLabels: Record<string, string> = {
+    business_loan: "Business Loan",
+    equipment_finance: "Equipment Finance",
+    invoice_finance: "Invoice Finance",
+    line_of_credit: "Line of Credit",
+    trade_finance: "Trade Finance",
+    other: "Other Business Finance",
+  };
+  const financeLabel = financeLabels[finance_type] ?? finance_type;
+
+  // Confirmation to the enquirer
+  await sendEmail({
+    to: email,
+    subject: `We've received your ${financeLabel} enquiry`,
+    html: `
+      <div style="font-family:Arial,sans-serif;max-width:500px;margin:0 auto;color:#334155">
+        <div style="background:#0f172a;padding:20px 24px;border-radius:12px 12px 0 0">
+          <h1 style="color:white;margin:0;font-size:18px">Business Finance</h1>
+        </div>
+        <div style="background:#f8fafc;padding:24px;border:1px solid #e2e8f0;border-top:none;border-radius:0 0 12px 12px">
+          <p style="font-size:15px;margin-top:0">Hi ${contact_name}, thanks for your ${financeLabel} enquiry for <strong>${business_name}</strong>.</p>
+          <p style="font-size:14px;color:#64748b">Our team will review your details and be in touch shortly. In the meantime, you can compare business finance options on our site.</p>
+          <div style="text-align:center;margin:20px 0">
+            <a href="${siteUrl}/business-finance"
+               style="display:inline-block;padding:12px 32px;background:#0f172a;color:white;text-decoration:none;border-radius:8px;font-size:14px;font-weight:600">
+              Compare Business Finance &rarr;
+            </a>
+          </div>
+          <p style="font-size:11px;color:#94a3b8">General information only — not financial advice. Always consult a qualified finance broker before committing to any product.</p>
+        </div>
+      </div>
+    `,
+  });
+
+  log.info("business finance enquiry submitted", { email, finance_type });
+  return NextResponse.json({ success: true });
+}

--- a/app/api/cron/lead-followup-reminders/route.ts
+++ b/app/api/cron/lead-followup-reminders/route.ts
@@ -1,0 +1,165 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { createAdminClient } from "@/lib/supabase/admin";
+import { requireCronAuth } from "@/lib/cron-auth";
+import { sendEmail } from "@/lib/resend";
+import { getSiteUrl } from "@/lib/url";
+import { logger } from "@/lib/logger";
+
+export const runtime = "nodejs";
+export const maxDuration = 60;
+
+const log = logger("cron:lead-followup-reminders");
+
+// Advisor Pipeline CRM — daily cron that emails advisors when a lead's
+// next_action_at is overdue (past now) and the pipeline stage is not terminal.
+// Anti-spam: one reminder per lead per day — the cron runs once, not in a loop.
+
+interface OverdueLead {
+  id: number;
+  professional_id: number;
+  user_name: string;
+  pipeline_stage: string;
+  next_action_at: string;
+}
+
+interface AdvisorRow {
+  id: number;
+  name: string;
+  email: string;
+}
+
+export async function GET(req: NextRequest) {
+  const unauth = requireCronAuth(req);
+  if (unauth) return unauth;
+
+  const supabase = createAdminClient();
+  const startedAt = new Date().toISOString();
+  const siteUrl = getSiteUrl();
+
+  // Pull all overdue leads (next_action_at in the past, non-terminal stage)
+  const { data: overdueLeads, error: leadsErr } = await supabase
+    .from("professional_leads")
+    .select("id, professional_id, user_name, pipeline_stage, next_action_at")
+    .not("pipeline_stage", "in", '("won","lost")')
+    .not("next_action_at", "is", null)
+    .lt("next_action_at", startedAt)
+    .limit(500);
+
+  if (leadsErr) {
+    log.error("overdue leads query failed", { err: leadsErr.message });
+    return NextResponse.json({ error: leadsErr.message }, { status: 500 });
+  }
+
+  const leads = (overdueLeads ?? []) as OverdueLead[];
+
+  if (leads.length === 0) {
+    log.info("lead-followup-reminders: no overdue leads");
+    return NextResponse.json({ startedAt, reminders: 0, status: "nothing_overdue" });
+  }
+
+  // Group by advisor
+  const byAdvisor = new Map<number, OverdueLead[]>();
+  for (const lead of leads) {
+    const existing = byAdvisor.get(lead.professional_id) ?? [];
+    existing.push(lead);
+    byAdvisor.set(lead.professional_id, existing);
+  }
+
+  // Fetch advisor contact details for all unique professional_ids
+  const advisorIds = [...byAdvisor.keys()];
+  const { data: advisors, error: advisorErr } = await supabase
+    .from("professionals")
+    .select("id, name, email")
+    .in("id", advisorIds)
+    .not("email", "is", null);
+
+  if (advisorErr) {
+    log.error("advisor lookup failed", { err: advisorErr.message });
+    return NextResponse.json({ error: advisorErr.message }, { status: 500 });
+  }
+
+  const advisorMap = new Map<number, AdvisorRow>();
+  for (const a of (advisors ?? []) as AdvisorRow[]) {
+    advisorMap.set(a.id, a);
+  }
+
+  const STAGE_LABELS: Record<string, string> = {
+    new: "New",
+    contacted: "Contacted",
+    proposal_sent: "Proposal Sent",
+    negotiating: "Negotiating",
+  };
+
+  let reminders = 0;
+  const failures: { advisor_id: number; err: string }[] = [];
+
+  for (const [advisorId, advisorLeads] of byAdvisor) {
+    const advisor = advisorMap.get(advisorId);
+    if (!advisor?.email) continue;
+
+    const leadRows = advisorLeads
+      .map((l) => {
+        const stage = STAGE_LABELS[l.pipeline_stage] ?? l.pipeline_stage;
+        const due = new Date(l.next_action_at).toLocaleDateString("en-AU", {
+          day: "numeric", month: "short",
+        });
+        return `<tr>
+          <td style="padding:8px 12px;border-bottom:1px solid #f1f5f9;font-size:13px;color:#334155">${l.user_name}</td>
+          <td style="padding:8px 12px;border-bottom:1px solid #f1f5f9;font-size:13px;color:#64748b">${stage}</td>
+          <td style="padding:8px 12px;border-bottom:1px solid #f1f5f9;font-size:13px;color:#dc2626;font-weight:600">${due}</td>
+        </tr>`;
+      })
+      .join("");
+
+    const result = await sendEmail({
+      to: advisor.email,
+      subject: `${advisorLeads.length} lead${advisorLeads.length === 1 ? "" : "s"} overdue for follow-up`,
+      html: `
+        <div style="font-family:Arial,sans-serif;max-width:560px;margin:0 auto;color:#334155">
+          <div style="background:#0f172a;padding:20px 24px;border-radius:12px 12px 0 0">
+            <h1 style="color:white;margin:0;font-size:18px">Follow-up Reminder</h1>
+          </div>
+          <div style="background:#f8fafc;padding:24px;border:1px solid #e2e8f0;border-top:none;border-radius:0 0 12px 12px">
+            <p style="font-size:15px;margin-top:0">Hi ${advisor.name}, you have <strong>${advisorLeads.length}</strong> lead${advisorLeads.length === 1 ? "" : "s"} that ${advisorLeads.length === 1 ? "is" : "are"} overdue for follow-up.</p>
+            <table style="width:100%;border-collapse:collapse;margin:16px 0;background:white;border-radius:8px;overflow:hidden;border:1px solid #e2e8f0">
+              <thead>
+                <tr style="background:#f8fafc">
+                  <th style="padding:8px 12px;text-align:left;font-size:11px;font-weight:600;color:#64748b;text-transform:uppercase">Lead</th>
+                  <th style="padding:8px 12px;text-align:left;font-size:11px;font-weight:600;color:#64748b;text-transform:uppercase">Stage</th>
+                  <th style="padding:8px 12px;text-align:left;font-size:11px;font-weight:600;color:#64748b;text-transform:uppercase">Due</th>
+                </tr>
+              </thead>
+              <tbody>${leadRows}</tbody>
+            </table>
+            <div style="text-align:center;margin:20px 0">
+              <a href="${siteUrl}/advisor-portal"
+                 style="display:inline-block;padding:12px 32px;background:#0f172a;color:white;text-decoration:none;border-radius:8px;font-size:14px;font-weight:600">
+                Open Leads &rarr;
+              </a>
+            </div>
+          </div>
+        </div>
+      `,
+    });
+
+    if (!result.ok) {
+      failures.push({ advisor_id: advisorId, err: result.error ?? "unknown" });
+      continue;
+    }
+    reminders++;
+  }
+
+  log.info("lead-followup-reminders complete", {
+    overdue: leads.length,
+    advisorsNotified: reminders,
+    failures: failures.length,
+  });
+
+  return NextResponse.json({
+    startedAt,
+    overdueLeads: leads.length,
+    advisorsNotified: reminders,
+    failures: failures.length,
+  });
+}

--- a/app/api/investor/copilot/route.ts
+++ b/app/api/investor/copilot/route.ts
@@ -1,0 +1,113 @@
+import { NextRequest, NextResponse } from "next/server";
+import Anthropic from "@anthropic-ai/sdk";
+
+import { isAllowed, ipKey } from "@/lib/rate-limit-db";
+import { filterFactualOutput, GAW_AI_PREFIX } from "@/lib/compliance";
+import { logger } from "@/lib/logger";
+
+export const runtime = "nodejs";
+export const maxDuration = 60;
+
+const log = logger("api:investor:copilot");
+
+const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+
+const SYSTEM_PROMPT = `${GAW_AI_PREFIX}
+
+You are a helpful Australian investment information assistant on invest.com.au. You provide factual, educational information about:
+- Australian savings accounts and term deposits
+- Share trading platforms and brokers (ASX, US shares, ETFs)
+- Superannuation and self-managed super funds (SMSFs)
+- Cryptocurrency exchanges registered with AUSTRAC
+- General investing concepts and terminology
+- How to compare financial products
+
+Important rules you must follow at all times:
+1. ALWAYS begin every response with exactly: "${GAW_AI_PREFIX}"
+2. NEVER give personal financial advice. Never say "you should", "I recommend you", "for someone in your situation", or similar phrases.
+3. Provide factual, general information only. Direct users to compare products on invest.com.au.
+4. If asked for personal advice, say: "${GAW_AI_PREFIX} I can share general information, but I'm not able to provide personal financial advice. For recommendations tailored to your situation, consider speaking with a licensed financial adviser."
+5. Only use https:// links or relative paths starting with /. Link to invest.com.au pages where relevant (e.g. /savings, /term-deposits, /compare, /advisors).
+6. Keep responses concise — 2–4 paragraphs maximum.
+7. If asked about specific rates, note that rates change frequently and direct to the comparison pages.`;
+
+interface Message {
+  role: "user" | "assistant";
+  content: string;
+}
+
+export async function POST(req: NextRequest) {
+  const allowed = await isAllowed("investor_copilot", ipKey(req), {
+    max: 20,
+    refillPerSec: 0.05,
+  });
+  if (!allowed) {
+    return NextResponse.json({ error: "Too many requests." }, { status: 429 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON." }, { status: 400 });
+  }
+
+  const { messages } = body as { messages?: unknown };
+
+  if (!Array.isArray(messages) || messages.length === 0) {
+    return NextResponse.json({ error: "messages array required." }, { status: 400 });
+  }
+
+  // Validate and sanitise messages: only user/assistant roles, string content, max 10 turns
+  const validated: Message[] = [];
+  for (const m of messages.slice(-10)) {
+    if (
+      typeof m !== "object" ||
+      m === null ||
+      !("role" in m) ||
+      !("content" in m)
+    )
+      continue;
+    const role = (m as Record<string, unknown>).role;
+    const content = (m as Record<string, unknown>).content;
+    if ((role !== "user" && role !== "assistant") || typeof content !== "string")
+      continue;
+    validated.push({ role, content: content.slice(0, 2000) });
+  }
+
+  if (validated.length === 0 || validated[validated.length - 1]?.role !== "user") {
+    return NextResponse.json({ error: "Last message must be from user." }, { status: 400 });
+  }
+
+  try {
+    const response = await anthropic.messages.create({
+      model: "claude-haiku-4-5-20251001",
+      max_tokens: 600,
+      system: SYSTEM_PROMPT,
+      messages: validated,
+    });
+
+    const raw =
+      response.content[0]?.type === "text" ? response.content[0].text : "";
+
+    const filtered = filterFactualOutput(raw);
+    if (!filtered.ok) {
+      log.warn("copilot response failed compliance filter", {
+        reason: filtered.reason,
+      });
+      return NextResponse.json(
+        {
+          reply: `${GAW_AI_PREFIX} I can provide general information about Australian savings and investment products. What would you like to know?`,
+        },
+        { status: 200 },
+      );
+    }
+
+    return NextResponse.json({ reply: filtered.cleaned });
+  } catch (err) {
+    log.error("copilot anthropic error", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json({ error: "Service unavailable." }, { status: 503 });
+  }
+}

--- a/app/business-finance/BusinessFinanceEnquiryForm.tsx
+++ b/app/business-finance/BusinessFinanceEnquiryForm.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+import { useState } from "react";
+import Icon from "@/components/Icon";
+
+const FINANCE_TYPES = [
+  { value: "business_loan", label: "Business Loan" },
+  { value: "equipment_finance", label: "Equipment Finance" },
+  { value: "invoice_finance", label: "Invoice Finance" },
+  { value: "line_of_credit", label: "Line of Credit" },
+  { value: "trade_finance", label: "Trade Finance" },
+  { value: "other", label: "Other / Not sure" },
+];
+
+export default function BusinessFinanceEnquiryForm() {
+  const [status, setStatus] = useState<"idle" | "submitting" | "success" | "error">("idle");
+  const [errorMsg, setErrorMsg] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setStatus("submitting");
+    setErrorMsg("");
+
+    const form = e.currentTarget;
+    const fd = new FormData(form);
+
+    const loanAmountRaw = fd.get("loan_amount") as string;
+    const annualRevenueRaw = fd.get("annual_revenue") as string;
+    const timeRaw = fd.get("time_in_business_months") as string;
+
+    const body: Record<string, unknown> = {
+      business_name: fd.get("business_name"),
+      contact_name: fd.get("contact_name"),
+      email: fd.get("email"),
+      phone: fd.get("phone") || undefined,
+      finance_type: fd.get("finance_type"),
+      purpose: fd.get("purpose") || undefined,
+      message: fd.get("message") || undefined,
+      website: fd.get("website") || undefined,
+    };
+    if (loanAmountRaw) body.loan_amount = Number(loanAmountRaw);
+    if (annualRevenueRaw) body.annual_revenue = Number(annualRevenueRaw);
+    if (timeRaw) body.time_in_business_months = Number(timeRaw) * 12;
+
+    try {
+      const res = await fetch("/api/business-finance/enquiry", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+
+      if (res.ok) {
+        setStatus("success");
+      } else {
+        const data = (await res.json()) as { error?: string };
+        setErrorMsg(data.error ?? "Failed to submit. Please try again.");
+        setStatus("error");
+      }
+    } catch {
+      setErrorMsg("Connection error. Please try again.");
+      setStatus("error");
+    }
+  };
+
+  if (status === "success") {
+    return (
+      <div className="rounded-2xl border border-emerald-200 bg-emerald-50 p-8 text-center">
+        <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-2xl bg-emerald-100">
+          <Icon name="check-circle" size={24} className="text-emerald-600" />
+        </div>
+        <h3 className="text-lg font-bold text-emerald-900">Enquiry received</h3>
+        <p className="mt-1 text-sm text-emerald-700">
+          We&apos;ve sent a confirmation to your email. A specialist will be in touch shortly.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="rounded-2xl border border-slate-200 bg-white p-5 md:p-8 space-y-4"
+    >
+      {/* Honeypot */}
+      <input type="text" name="website" tabIndex={-1} aria-hidden="true" className="hidden" />
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <div>
+          <label className="block text-xs font-semibold text-slate-700 mb-1">
+            Business name <span className="text-red-500">*</span>
+          </label>
+          <input
+            type="text"
+            name="business_name"
+            required
+            maxLength={200}
+            placeholder="Acme Pty Ltd"
+            className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-indigo-400 focus:outline-none focus:ring-1 focus:ring-indigo-400"
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-semibold text-slate-700 mb-1">
+            Your name <span className="text-red-500">*</span>
+          </label>
+          <input
+            type="text"
+            name="contact_name"
+            required
+            maxLength={200}
+            placeholder="Jane Smith"
+            className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-indigo-400 focus:outline-none focus:ring-1 focus:ring-indigo-400"
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-semibold text-slate-700 mb-1">
+            Email <span className="text-red-500">*</span>
+          </label>
+          <input
+            type="email"
+            name="email"
+            required
+            maxLength={254}
+            placeholder="jane@acme.com.au"
+            className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-indigo-400 focus:outline-none focus:ring-1 focus:ring-indigo-400"
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-semibold text-slate-700 mb-1">Phone</label>
+          <input
+            type="tel"
+            name="phone"
+            maxLength={30}
+            placeholder="0400 000 000"
+            className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-indigo-400 focus:outline-none focus:ring-1 focus:ring-indigo-400"
+          />
+        </div>
+      </div>
+
+      <div>
+        <label className="block text-xs font-semibold text-slate-700 mb-1">
+          Finance type <span className="text-red-500">*</span>
+        </label>
+        <select
+          name="finance_type"
+          required
+          className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-900 focus:border-indigo-400 focus:outline-none focus:ring-1 focus:ring-indigo-400 bg-white"
+        >
+          <option value="">Select finance type…</option>
+          {FINANCE_TYPES.map((ft) => (
+            <option key={ft.value} value={ft.value}>{ft.label}</option>
+          ))}
+        </select>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+        <div>
+          <label className="block text-xs font-semibold text-slate-700 mb-1">
+            Amount needed (AUD)
+          </label>
+          <input
+            type="number"
+            name="loan_amount"
+            min={0}
+            max={50_000_000}
+            step={1000}
+            placeholder="e.g. 250000"
+            className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-indigo-400 focus:outline-none focus:ring-1 focus:ring-indigo-400"
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-semibold text-slate-700 mb-1">
+            Annual revenue (AUD)
+          </label>
+          <input
+            type="number"
+            name="annual_revenue"
+            min={0}
+            max={500_000_000}
+            step={10000}
+            placeholder="e.g. 1200000"
+            className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-indigo-400 focus:outline-none focus:ring-1 focus:ring-indigo-400"
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-semibold text-slate-700 mb-1">
+            Time in business (years)
+          </label>
+          <input
+            type="number"
+            name="time_in_business_months"
+            min={0}
+            max={100}
+            step={0.5}
+            placeholder="e.g. 3"
+            className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-indigo-400 focus:outline-none focus:ring-1 focus:ring-indigo-400"
+          />
+        </div>
+      </div>
+
+      <div>
+        <label className="block text-xs font-semibold text-slate-700 mb-1">
+          Purpose of funds
+        </label>
+        <input
+          type="text"
+          name="purpose"
+          maxLength={1000}
+          placeholder="e.g. Purchase new equipment, expand to second location…"
+          className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-indigo-400 focus:outline-none focus:ring-1 focus:ring-indigo-400"
+        />
+      </div>
+
+      <div>
+        <label className="block text-xs font-semibold text-slate-700 mb-1">
+          Additional notes
+        </label>
+        <textarea
+          name="message"
+          rows={3}
+          maxLength={2000}
+          placeholder="Any other details that would help us match you with the right specialist…"
+          className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-indigo-400 focus:outline-none focus:ring-1 focus:ring-indigo-400 resize-none"
+        />
+      </div>
+
+      {status === "error" && (
+        <div className="rounded-lg bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700">
+          {errorMsg}
+        </div>
+      )}
+
+      <button
+        type="submit"
+        disabled={status === "submitting"}
+        className="w-full rounded-xl bg-indigo-700 px-6 py-3 text-sm font-bold text-white hover:bg-indigo-800 transition-colors disabled:opacity-50"
+      >
+        {status === "submitting" ? "Submitting…" : "Submit Enquiry"}
+      </button>
+
+      <p className="text-center text-[0.65rem] text-slate-400">
+        By submitting you agree to our privacy policy. General information only — not financial advice.
+      </p>
+    </form>
+  );
+}

--- a/app/business-finance/page.tsx
+++ b/app/business-finance/page.tsx
@@ -1,0 +1,289 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Suspense } from "react";
+
+import Icon from "@/components/Icon";
+import { GENERAL_ADVICE_WARNING, ADVERTISER_DISCLOSURE_SHORT } from "@/lib/compliance";
+import {
+  CURRENT_YEAR,
+  ORGANIZATION_JSONLD,
+  SITE_NAME,
+  SITE_URL,
+  absoluteUrl,
+  breadcrumbJsonLd,
+  UPDATED_LABEL,
+} from "@/lib/seo";
+import { getVerticalBySlug } from "@/lib/verticals";
+import BusinessFinanceEnquiryForm from "./BusinessFinanceEnquiryForm";
+
+export const revalidate = 3600;
+
+const vertical = getVerticalBySlug("business-finance")!;
+
+const PAGE_PATH = "/business-finance";
+const PAGE_TITLE = vertical.title;
+const PAGE_DESCRIPTION = vertical.metaDescription;
+
+export const metadata: Metadata = {
+  title: PAGE_TITLE,
+  description: PAGE_DESCRIPTION,
+  alternates: { canonical: PAGE_PATH },
+  openGraph: {
+    title: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+    url: absoluteUrl(PAGE_PATH),
+    images: [
+      {
+        url: `/api/og?title=Business+Finance+Australia&subtitle=Compare+loans%2C+equipment+%26+invoice+finance&type=default`,
+        width: 1200,
+        height: 630,
+        alt: "Australian business finance comparison",
+      },
+    ],
+  },
+  twitter: { card: "summary_large_image" },
+};
+
+const FINANCE_TYPES = [
+  {
+    id: "business_loan",
+    icon: "banknote" as const,
+    title: "Business Loans",
+    range: "$10k – $5M",
+    rate: "8 – 15% p.a.",
+    term: "1 – 5 years",
+    body: "Lump-sum working capital or growth finance. Secured loans use property or assets for lower rates; unsecured loans are approved on cash flow alone — faster but costlier.",
+  },
+  {
+    id: "equipment_finance",
+    icon: "truck" as const,
+    title: "Equipment Finance",
+    range: "$5k – $2M",
+    rate: "6 – 12% p.a.",
+    term: "2 – 7 years",
+    body: "Chattel mortgages, finance leases, and hire-purchase spread the cost of machinery, vehicles, and technology across the asset's working life — preserving cash flow.",
+  },
+  {
+    id: "invoice_finance",
+    icon: "file-text" as const,
+    title: "Invoice Finance",
+    range: "70 – 90% advance",
+    rate: "1.5 – 3% / 30 days",
+    term: "Ongoing",
+    body: "Convert unpaid invoices to same-day cash. Ideal for B2B businesses with 30–90 day payment terms. Factoring (lender collects) or confidential invoice discounting (you collect).",
+  },
+  {
+    id: "line_of_credit",
+    icon: "repeat" as const,
+    title: "Line of Credit",
+    range: "$10k – $1M",
+    rate: "9 – 18% p.a.",
+    term: "Revolving",
+    body: "Draw and repay as needed, paying interest only on what you use. Suits seasonal businesses and ongoing working capital needs — more flexible than a term loan.",
+  },
+  {
+    id: "trade_finance",
+    icon: "globe" as const,
+    title: "Trade Finance",
+    range: "From $50k",
+    rate: "Lender-quoted",
+    term: "Per transaction",
+    body: "Import/export facilities, letters of credit, and supply chain finance. Bridges the gap between paying suppliers and receiving payment from customers overseas.",
+  },
+];
+
+export default function BusinessFinancePage() {
+  const breadcrumbs = breadcrumbJsonLd([
+    { name: "Home", url: absoluteUrl("/") },
+    { name: "Business Finance" },
+  ]);
+
+  const faqJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    name: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+    url: absoluteUrl(PAGE_PATH),
+    isPartOf: { "@type": "WebSite", name: SITE_NAME, url: SITE_URL },
+    publisher: ORGANIZATION_JSONLD,
+    inLanguage: "en-AU",
+    mainEntity: {
+      "@type": "FAQPage",
+      mainEntity: vertical.faqs.map((item) => ({
+        "@type": "Question",
+        name: item.question,
+        acceptedAnswer: { "@type": "Answer", text: item.answer },
+      })),
+    },
+  };
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify([breadcrumbs, faqJsonLd]) }}
+      />
+
+      <div className="py-5 md:py-12">
+        <div className="container-custom max-w-4xl">
+          {/* Breadcrumb */}
+          <nav className="mb-3 text-xs text-slate-500 md:mb-6 md:text-sm">
+            <Link href="/" className="hover:text-slate-900">Home</Link>
+            <span className="mx-1.5">/</span>
+            <span className="text-slate-700">Business Finance</span>
+          </nav>
+
+          {/* Hero */}
+          <div className="relative mb-8 overflow-hidden rounded-2xl border border-indigo-100 bg-gradient-to-br from-indigo-50 to-white p-5 md:p-10">
+            <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(99,102,241,0.08),transparent_70%)]" />
+            <div className="relative">
+              <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-2xl bg-indigo-100 md:mb-4 md:h-16 md:w-16">
+                <Icon name="briefcase" size={28} className="text-indigo-600" />
+              </div>
+              <h1 className="mb-2 text-center text-2xl font-extrabold text-slate-900 md:text-4xl">
+                {vertical.heroHeadline}
+              </h1>
+              <p className="mx-auto max-w-xl text-center text-sm leading-relaxed text-slate-600 md:text-lg">
+                {vertical.heroSubtext}
+              </p>
+              <p className="mt-2 text-center text-xs text-slate-400">{UPDATED_LABEL}</p>
+            </div>
+          </div>
+
+          {/* Stats bar */}
+          <div className="mb-8 grid grid-cols-2 gap-3 md:grid-cols-4">
+            {vertical.stats.map((s) => (
+              <div key={s.label} className="rounded-xl border border-slate-200 bg-white p-4 text-center">
+                <p className="text-lg font-extrabold text-indigo-700 md:text-xl">{s.value}</p>
+                <p className="mt-0.5 text-xs text-slate-500">{s.label}</p>
+              </div>
+            ))}
+          </div>
+
+          {/* Finance type cards */}
+          <section className="mb-10" id="options">
+            <h2 className="mb-4 text-xl font-extrabold text-slate-900 md:text-2xl">
+              Compare business finance options
+            </h2>
+            <div className="space-y-3">
+              {FINANCE_TYPES.map((ft) => (
+                <div
+                  key={ft.id}
+                  id={ft.id.replace("_", "-")}
+                  className="rounded-xl border border-slate-200 bg-white p-5"
+                >
+                  <div className="flex items-start gap-4">
+                    <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-indigo-50">
+                      <Icon name={ft.icon} size={20} className="text-indigo-600" />
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <div className="flex flex-wrap items-baseline justify-between gap-2">
+                        <h3 className="text-base font-bold text-slate-900">{ft.title}</h3>
+                        <div className="flex flex-wrap gap-3 text-xs text-slate-500">
+                          <span><strong className="text-slate-700">Amount:</strong> {ft.range}</span>
+                          <span><strong className="text-slate-700">Rate:</strong> {ft.rate}</span>
+                          <span><strong className="text-slate-700">Term:</strong> {ft.term}</span>
+                        </div>
+                      </div>
+                      <p className="mt-1.5 text-sm text-slate-600 leading-relaxed">{ft.body}</p>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          {/* What lenders look at */}
+          <section className="mb-10">
+            <h2 className="mb-4 text-xl font-extrabold text-slate-900 md:text-2xl">
+              What lenders look for
+            </h2>
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+              {[
+                { icon: "calendar", label: "Time in business", body: "Most lenders want 6–24 months of trading history. Banks often require 2 years of financials. Non-bank fintechs may approve with 3 months." },
+                { icon: "trending-up", label: "Annual revenue", body: "Non-bank minimum is typically $75k–$150k. Banks prefer $250k+. Revenue stability matters as much as the number itself." },
+                { icon: "shield", label: "Credit history", body: "Both personal (director) and business credit are checked. Defaults and court judgements significantly reduce approval odds and increase rates." },
+                { icon: "file", label: "Financial documents", body: "BAS statements, business bank statements (3–6 months), and sometimes P&L/tax returns. Having these ready speeds approval." },
+              ].map((item) => (
+                <div key={item.label} className="rounded-xl border border-slate-200 bg-white p-4">
+                  <div className="flex items-center gap-2 mb-2">
+                    <Icon name={item.icon as Parameters<typeof Icon>[0]["name"]} size={16} className="text-indigo-500" />
+                    <h3 className="text-sm font-bold text-slate-900">{item.label}</h3>
+                  </div>
+                  <p className="text-xs text-slate-600 leading-relaxed">{item.body}</p>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          {/* Educational sections */}
+          {vertical.sections.map((section) => (
+            <section key={section.heading} className="mb-8">
+              <h2 className="mb-3 text-lg font-extrabold text-slate-900 md:text-xl">
+                {section.heading}
+              </h2>
+              <p className="text-sm text-slate-600 leading-relaxed">{section.body}</p>
+            </section>
+          ))}
+
+          {/* Enquiry form */}
+          <section className="mb-10" id="enquire">
+            <h2 className="mb-4 text-xl font-extrabold text-slate-900 md:text-2xl">
+              Get matched with a business finance specialist
+            </h2>
+            <p className="mb-4 text-sm text-slate-600">
+              Tell us what you&apos;re looking for and we&apos;ll help connect you with a specialist. No obligation, no credit check at this stage.
+            </p>
+            <Suspense fallback={<div className="h-80 rounded-2xl bg-slate-100 animate-pulse" />}>
+              <BusinessFinanceEnquiryForm />
+            </Suspense>
+            <p className="mt-3 text-center text-xs text-slate-400">{ADVERTISER_DISCLOSURE_SHORT}</p>
+          </section>
+
+          {/* FAQ */}
+          <section className="mb-10">
+            <h2 className="mb-4 text-xl font-extrabold text-slate-900 md:text-2xl">
+              Frequently asked questions
+            </h2>
+            <div className="divide-y divide-slate-100 overflow-hidden rounded-xl border border-slate-200 bg-white">
+              {vertical.faqs.map((item) => (
+                <details key={item.question} className="group p-4 open:bg-slate-50">
+                  <summary className="flex cursor-pointer items-center justify-between gap-3 text-sm font-semibold text-slate-900 marker:hidden">
+                    <span>{item.question}</span>
+                    <span className="text-base text-slate-400 transition-transform group-open:rotate-45">+</span>
+                  </summary>
+                  <p className="mt-2 text-sm leading-relaxed text-slate-600">{item.answer}</p>
+                </details>
+              ))}
+            </div>
+          </section>
+
+          {/* Cross-links */}
+          <section className="mb-8">
+            <h2 className="mb-3 text-lg font-extrabold text-slate-900">Related topics</h2>
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+              <Link href="/savings" className="block rounded-xl border border-slate-200 bg-white p-4 transition-colors hover:border-indigo-300 hover:bg-indigo-50">
+                <h3 className="text-sm font-bold text-slate-900">Business savings accounts &rarr;</h3>
+                <p className="mt-1 text-xs text-slate-500">High-interest accounts for business cash reserves.</p>
+              </Link>
+              <Link href="/advisors" className="block rounded-xl border border-slate-200 bg-white p-4 transition-colors hover:border-indigo-300 hover:bg-indigo-50">
+                <h3 className="text-sm font-bold text-slate-900">Find a financial adviser &rarr;</h3>
+                <p className="mt-1 text-xs text-slate-500">Connect with a licensed specialist for complex structures.</p>
+              </Link>
+              <Link href="/term-deposits" className="block rounded-xl border border-slate-200 bg-white p-4 transition-colors hover:border-indigo-300 hover:bg-indigo-50">
+                <h3 className="text-sm font-bold text-slate-900">Term deposits &rarr;</h3>
+                <p className="mt-1 text-xs text-slate-500">Fixed-rate returns for business cash you won&apos;t need short-term.</p>
+              </Link>
+            </div>
+          </section>
+
+          {/* Compliance */}
+          <p className="text-center text-[0.7rem] text-slate-400">{GENERAL_ADVICE_WARNING}</p>
+          {vertical.disclaimer && (
+            <p className="mt-2 text-center text-[0.65rem] text-slate-400">{vertical.disclaimer}</p>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/reviews/ReviewsClient.tsx
+++ b/app/reviews/ReviewsClient.tsx
@@ -362,6 +362,7 @@ function getPlatformLabel(type: PlatformType): string {
     savings_account: "Savings Account",
     term_deposit: "Term Deposit",
     fx_provider: "FX Provider",
+    business_lender: "Business Lender",
   };
   return labels[type] || type;
 }
@@ -378,6 +379,7 @@ function getPlatformColor(type: PlatformType): string {
     savings_account: "bg-teal-50 text-teal-700",
     term_deposit: "bg-amber-50 text-amber-700",
     fx_provider: "bg-sky-50 text-sky-700",
+    business_lender: "bg-indigo-50 text-indigo-700",
   };
   return colors[type] || "bg-slate-50 text-slate-700";
 }

--- a/app/savings/page.tsx
+++ b/app/savings/page.tsx
@@ -8,6 +8,7 @@ import { boostFeaturedPartner } from "@/lib/sponsorship";
 import VerticalPillarPage from "@/components/VerticalPillarPage";
 import ForeignInvestorCallout from "@/components/ForeignInvestorCallout";
 import RateAlertCapture from "@/components/RateAlertCapture";
+import InvestorCopilot from "@/components/InvestorCopilot";
 
 const vertical = getVerticalBySlug("savings")!;
 
@@ -111,6 +112,7 @@ export default async function SavingsPage() {
           defaultThresholdPct={5.25}
         />
       </div>
+      <InvestorCopilot />
     </>
   );
 }

--- a/app/term-deposits/page.tsx
+++ b/app/term-deposits/page.tsx
@@ -6,6 +6,7 @@ import { absoluteUrl } from "@/lib/seo";
 import { boostFeaturedPartner } from "@/lib/sponsorship";
 import VerticalPillarPage from "@/components/VerticalPillarPage";
 import RateAlertCapture from "@/components/RateAlertCapture";
+import InvestorCopilot from "@/components/InvestorCopilot";
 
 const vertical = getVerticalBySlug("term-deposits")!;
 
@@ -81,6 +82,7 @@ export default async function TermDepositsPage() {
           defaultThresholdPct={5.0}
         />
       </div>
+      <InvestorCopilot />
     </>
   );
 }

--- a/components/InvestorCopilot.tsx
+++ b/components/InvestorCopilot.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import Icon from "@/components/Icon";
+
+interface Message {
+  role: "user" | "assistant";
+  content: string;
+}
+
+const STARTER_PROMPTS = [
+  "What's a good savings account rate right now?",
+  "How do term deposits work?",
+  "What's the difference between savings accounts and term deposits?",
+];
+
+export default function InvestorCopilot() {
+  const [open, setOpen] = useState(false);
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const bottomRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (open && messages.length === 0 && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [open, messages.length]);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages, loading]);
+
+  const send = async (text: string) => {
+    const trimmed = text.trim();
+    if (!trimmed || loading) return;
+    setError(null);
+    setInput("");
+
+    const newMessages: Message[] = [...messages, { role: "user", content: trimmed }];
+    setMessages(newMessages);
+    setLoading(true);
+
+    try {
+      const res = await fetch("/api/investor/copilot", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ messages: newMessages }),
+      });
+
+      if (res.status === 429) {
+        setError("You're sending messages too quickly. Please wait a moment.");
+        setMessages(messages);
+        setLoading(false);
+        return;
+      }
+
+      if (!res.ok) {
+        setError("Something went wrong. Please try again.");
+        setMessages(messages);
+        setLoading(false);
+        return;
+      }
+
+      const data = (await res.json()) as { reply?: string; error?: string };
+      if (data.reply) {
+        setMessages([...newMessages, { role: "assistant", content: data.reply }]);
+      } else {
+        setError("No response received. Please try again.");
+        setMessages(messages);
+      }
+    } catch {
+      setError("Connection error. Please try again.");
+      setMessages(messages);
+    }
+
+    setLoading(false);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      send(input);
+    }
+  };
+
+  return (
+    <>
+      {/* Floating trigger button */}
+      <button
+        type="button"
+        aria-label={open ? "Close assistant" : "Ask a question"}
+        onClick={() => setOpen((o) => !o)}
+        className="fixed bottom-5 right-5 z-40 flex h-13 w-13 items-center justify-center rounded-full bg-slate-900 text-white shadow-lg hover:bg-slate-700 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-900 focus-visible:ring-offset-2"
+        style={{ height: 52, width: 52 }}
+      >
+        <Icon name={open ? "x" : "message-circle"} size={22} />
+      </button>
+
+      {/* Chat panel */}
+      {open && (
+        <div
+          className="fixed bottom-20 right-5 z-40 flex w-[340px] flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-2xl sm:w-[380px]"
+          style={{ maxHeight: "min(520px, calc(100vh - 100px))" }}
+        >
+          {/* Header */}
+          <div className="flex items-center justify-between bg-slate-900 px-4 py-3">
+            <div className="flex items-center gap-2">
+              <div className="flex h-7 w-7 items-center justify-center rounded-full bg-white/10">
+                <Icon name="zap" size={14} className="text-amber-400" />
+              </div>
+              <div>
+                <p className="text-xs font-bold text-white leading-none">Invest Assistant</p>
+                <p className="text-[0.6rem] text-white/50 mt-0.5">General info only — not advice</p>
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={() => setOpen(false)}
+              className="text-white/50 hover:text-white transition-colors"
+              aria-label="Close"
+            >
+              <Icon name="x" size={16} />
+            </button>
+          </div>
+
+          {/* Messages */}
+          <div className="flex-1 overflow-y-auto p-3 space-y-3 bg-slate-50 min-h-0">
+            {messages.length === 0 && (
+              <div className="space-y-2">
+                <p className="text-xs text-slate-500 text-center py-2">
+                  Ask me anything about Australian savings rates and deposits.
+                </p>
+                {STARTER_PROMPTS.map((p) => (
+                  <button
+                    key={p}
+                    type="button"
+                    onClick={() => send(p)}
+                    className="w-full text-left text-xs px-3 py-2 rounded-lg border border-slate-200 bg-white text-slate-700 hover:border-slate-300 hover:bg-slate-50 transition-colors"
+                  >
+                    {p}
+                  </button>
+                ))}
+              </div>
+            )}
+
+            {messages.map((m, i) => (
+              <div
+                key={i}
+                className={`flex ${m.role === "user" ? "justify-end" : "justify-start"}`}
+              >
+                <div
+                  className={`max-w-[85%] rounded-2xl px-3 py-2 text-xs leading-relaxed ${
+                    m.role === "user"
+                      ? "bg-slate-900 text-white rounded-br-sm"
+                      : "bg-white border border-slate-200 text-slate-700 rounded-bl-sm"
+                  }`}
+                >
+                  {m.content}
+                </div>
+              </div>
+            ))}
+
+            {loading && (
+              <div className="flex justify-start">
+                <div className="bg-white border border-slate-200 rounded-2xl rounded-bl-sm px-3 py-2">
+                  <div className="flex gap-1 items-center">
+                    <div className="h-1.5 w-1.5 rounded-full bg-slate-400 animate-bounce [animation-delay:-0.3s]" />
+                    <div className="h-1.5 w-1.5 rounded-full bg-slate-400 animate-bounce [animation-delay:-0.15s]" />
+                    <div className="h-1.5 w-1.5 rounded-full bg-slate-400 animate-bounce" />
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {error && (
+              <div className="rounded-lg bg-red-50 border border-red-200 px-3 py-2 text-xs text-red-700">
+                {error}
+              </div>
+            )}
+
+            <div ref={bottomRef} />
+          </div>
+
+          {/* Input */}
+          <div className="border-t border-slate-200 bg-white p-3 flex items-end gap-2">
+            <textarea
+              ref={inputRef}
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="Ask about rates, accounts…"
+              rows={1}
+              disabled={loading}
+              className="flex-1 resize-none rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-xs text-slate-900 placeholder:text-slate-400 focus:border-slate-400 focus:outline-none focus:ring-0 disabled:opacity-50"
+              style={{ maxHeight: 80 }}
+            />
+            <button
+              type="button"
+              disabled={!input.trim() || loading}
+              onClick={() => send(input)}
+              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-xl bg-slate-900 text-white hover:bg-slate-700 transition-colors disabled:opacity-40"
+              aria-label="Send"
+            >
+              <Icon name="send" size={14} />
+            </button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/lib/cron-groups.ts
+++ b/lib/cron-groups.ts
@@ -93,6 +93,7 @@ export const CRON_GROUPS: Record<string, readonly string[]> = {
     "/api/cron/advisor-nudge",
     "/api/cron/subscription-dunning",
     "/api/cron/marketplace-stale-briefs",
+    "/api/cron/lead-followup-reminders",
   ],
   "daily-9-30": ["/api/cron/enforce-lead-sla"],
 

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -5062,6 +5062,57 @@ export type Database = {
         }
         Relationships: []
       }
+      business_finance_enquiries: {
+        Row: {
+          annual_revenue_cents: number | null
+          business_name: string
+          contact_name: string
+          created_at: string
+          email: string
+          finance_type: string
+          id: string
+          loan_amount_cents: number | null
+          message: string | null
+          phone: string | null
+          purpose: string | null
+          status: string
+          time_in_business_months: number | null
+          updated_at: string
+        }
+        Insert: {
+          annual_revenue_cents?: number | null
+          business_name: string
+          contact_name: string
+          created_at?: string
+          email: string
+          finance_type: string
+          id?: string
+          loan_amount_cents?: number | null
+          message?: string | null
+          phone?: string | null
+          purpose?: string | null
+          status?: string
+          time_in_business_months?: number | null
+          updated_at?: string
+        }
+        Update: {
+          annual_revenue_cents?: number | null
+          business_name?: string
+          contact_name?: string
+          created_at?: string
+          email?: string
+          finance_type?: string
+          id?: string
+          loan_amount_cents?: number | null
+          message?: string | null
+          phone?: string | null
+          purpose?: string | null
+          status?: string
+          time_in_business_months?: number | null
+          updated_at?: string
+        }
+        Relationships: []
+      }
       buyer_agents: {
         Row: {
           agency_name: string | null
@@ -12647,7 +12698,9 @@ export type Database = {
           id: number
           lead_value: number | null
           message: string | null
+          next_action_at: string | null
           outcome: string | null
+          pipeline_stage: string
           post_drip_last_at: string | null
           post_drip_step: number | null
           professional_id: number
@@ -12678,7 +12731,9 @@ export type Database = {
           id?: number
           lead_value?: number | null
           message?: string | null
+          next_action_at?: string | null
           outcome?: string | null
+          pipeline_stage?: string
           post_drip_last_at?: string | null
           post_drip_step?: number | null
           professional_id: number
@@ -12709,7 +12764,9 @@ export type Database = {
           id?: number
           lead_value?: number | null
           message?: string | null
+          next_action_at?: string | null
           outcome?: string | null
+          pipeline_stage?: string
           post_drip_last_at?: string | null
           post_drip_step?: number | null
           professional_id?: number

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -15,7 +15,7 @@ export interface TeamMember {
   updated_at: string;
 }
 
-export type PlatformType = 'share_broker' | 'crypto_exchange' | 'robo_advisor' | 'research_tool' | 'super_fund' | 'property_platform' | 'cfd_forex' | 'savings_account' | 'term_deposit' | 'fx_provider';
+export type PlatformType = 'share_broker' | 'crypto_exchange' | 'robo_advisor' | 'research_tool' | 'super_fund' | 'property_platform' | 'cfd_forex' | 'savings_account' | 'term_deposit' | 'fx_provider' | 'business_lender';
 
 /** Canonical display labels for each platform type — single source of truth */
 export const PLATFORM_TYPE_LABELS: Record<PlatformType, string> = {
@@ -29,6 +29,7 @@ export const PLATFORM_TYPE_LABELS: Record<PlatformType, string> = {
   savings_account: "Savings Account",
   term_deposit: "Term Deposit",
   fx_provider: "FX Provider",
+  business_lender: "Business Lender",
 };
 
 /** Lowercase labels for prose (e.g. "broker", "crypto exchange") */
@@ -43,6 +44,7 @@ export const PLATFORM_TYPE_LABELS_LOWER: Record<PlatformType, string> = {
   savings_account: "savings account",
   term_deposit: "term deposit",
   fx_provider: "FX provider",
+  business_lender: "business lender",
 };
 
 export interface Broker {

--- a/lib/verticals.ts
+++ b/lib/verticals.ts
@@ -955,6 +955,80 @@ const VERTICALS: VerticalConfig[] = [
     ],
     advisorTypes: [{ type: "financial_planner", label: "Financial Planners", href: "/advisors/financial-planners" }],
   },
+  {
+    slug: "business-finance",
+    platformTypes: [],
+    title: `Best Business Finance Options in Australia (${yr})`,
+    h1: "Business Finance",
+    metaDescription: `Compare business loans, equipment finance, and lines of credit in Australia for ${yr}. Find the right SMB finance solution with rates and features side by side.`,
+    heroHeadline: "Find the right finance for your business",
+    heroSubtext: `Compare business loans, equipment finance, invoice finance, and lines of credit from Australian lenders. Independently researched and updated ${CURRENT_MONTH_YEAR}.`,
+    color: {
+      bg: "bg-indigo-50",
+      border: "border-indigo-200",
+      text: "text-indigo-900",
+      accent: "text-indigo-600",
+      gradient: "from-indigo-50 to-white",
+    },
+    stats: [
+      { label: "SMBs in Australia", value: "2.5M+" },
+      { label: "Avg business loan rate", value: "~8–12%" },
+      { label: "Equipment finance term", value: "1–7 yrs" },
+      { label: "Invoice advance rate", value: "70–90%" },
+    ],
+    subcategories: [
+      { label: "Business Loans", href: "/business-finance#business-loans", description: "Secured and unsecured working capital loans from $10k–$5M" },
+      { label: "Equipment Finance", href: "/business-finance#equipment", description: "Chattel mortgages, finance leases, and hire purchase" },
+      { label: "Invoice Finance", href: "/business-finance#invoice", description: "Unlock cash tied up in unpaid invoices — debtor finance & factoring" },
+      { label: "Line of Credit", href: "/business-finance#loc", description: "Revolving credit for ongoing working capital needs" },
+      { label: "Trade Finance", href: "/business-finance#trade", description: "Import/export finance and supply chain solutions" },
+    ],
+    tools: [
+      { label: "Enquire Now", href: "/business-finance#enquire", icon: "send" },
+      { label: "Advisors", href: "/advisors/financial-planners", icon: "user-check" },
+    ],
+    sections: [
+      {
+        heading: "Choosing the right business finance product",
+        body: "Business finance is not one-size-fits-all. A business loan suits working capital or expansion where you need a lump sum. Equipment finance lets you spread the cost of machinery or vehicles across its useful life. Invoice finance is ideal when your cash flow is tied up in accounts receivable — you advance against unpaid invoices rather than taking on new debt. A line of credit works like a corporate credit card: draw and repay as needed, paying interest only on what you use.",
+      },
+      {
+        heading: "Key rates and costs to compare",
+        body: "Business loan interest rates in Australia typically range from 8%–15% p.a. for unsecured loans and 6%–10% for secured facilities, though rates vary significantly by lender, term, security, and your business's credit profile. Always compare the comparison rate (which includes fees) rather than the advertised rate alone. Look for establishment fees, monthly admin fees, early repayment penalties, and the total cost of credit over the loan term.",
+      },
+      {
+        heading: "What lenders assess",
+        body: "Most lenders evaluate: time in business (typically ≥6–12 months), annual revenue (often $75k–$250k minimum), personal and business credit history, existing debt levels, and the purpose of funds. Providing GST-registered ABN records, BAS statements, and bank statements speeds the process. Non-bank lenders (fintechs) generally approve faster but charge higher rates than banks.",
+      },
+    ],
+    faqs: [
+      {
+        question: "What is the minimum revenue to qualify for a business loan in Australia?",
+        answer: "Most non-bank lenders require at least $75,000–$150,000 in annual revenue and 6–12 months of trading history. Major banks typically require $250,000+ in revenue and 2 years of financials. Some specialist lenders work with startups under 6 months old, usually requiring strong personal credit and sometimes security.",
+      },
+      {
+        question: "Is equipment finance or a business loan better for buying machinery?",
+        answer: "Equipment finance (chattel mortgage or finance lease) is usually better for machinery because: the asset serves as security so rates are lower; you can claim the full depreciation (or instant asset write-off) upfront under a chattel mortgage; and the finance term matches the asset life. A business loan is more flexible but typically costs more for asset purchases.",
+      },
+      {
+        question: "How does invoice finance work?",
+        answer: "Invoice finance (debtor finance or factoring) lets you advance 70–90% of the face value of unpaid invoices immediately, rather than waiting 30–90 days for your customers to pay. The lender collects payment from your customers (factoring) or you collect it yourself (invoice discounting). The cost is typically 1.5–3% of the invoice value per 30 days.",
+      },
+      {
+        question: "Does applying for business finance affect my credit score?",
+        answer: "Some lenders do a soft credit check (no impact) for pre-qualification and a hard check only on formal application. Others go straight to a hard inquiry. Multiple hard inquiries in a short period can reduce your score, so compare multiple offers before formally applying where possible. Ask lenders whether they run a hard or soft check upfront.",
+      },
+      {
+        question: "Do I need to provide security for a business loan?",
+        answer: "Not always. Unsecured business loans up to $250k–$500k are available from non-bank lenders based on cash flow alone, though rates are higher. Secured loans (using real property, equipment, or receivables as collateral) attract lower rates. Most bank loans above $250k require security. Personal guarantees are standard for director-owned SMBs regardless of security type.",
+      },
+    ],
+    disclaimer: "General information only — not financial or credit advice. Product features and rates are indicative and subject to change. Always read the relevant credit guide and loan contract before applying.",
+    advisorTypes: [
+      { type: "financial_planner", label: "Financial Planners", href: "/advisors/financial-planners" },
+    ],
+    expertTags: ["business-finance", "sme", "equipment-finance", "invoice-finance", "business-loan"],
+  },
 ];
 
 /** Look up a vertical config by its URL slug */

--- a/lib/verticals.ts
+++ b/lib/verticals.ts
@@ -957,7 +957,7 @@ const VERTICALS: VerticalConfig[] = [
   },
   {
     slug: "business-finance",
-    platformTypes: [],
+    platformTypes: ["business_lender"],
     title: `Best Business Finance Options in Australia (${yr})`,
     h1: "Business Finance",
     metaDescription: `Compare business loans, equipment finance, and lines of credit in Australia for ${yr}. Find the right SMB finance solution with rates and features side by side.`,

--- a/supabase/migrations/20260522010000_professional_leads_pipeline.sql
+++ b/supabase/migrations/20260522010000_professional_leads_pipeline.sql
@@ -1,0 +1,41 @@
+-- Migration: advisor pipeline CRM columns on professional_leads.
+--
+-- Adds:
+--   pipeline_stage TEXT — where the lead sits in the advisor's workflow.
+--   next_action_at TIMESTAMPTZ — when the advisor next wants to follow up.
+--
+-- The lead-followup-reminders cron (/api/cron/lead-followup-reminders)
+-- queries WHERE next_action_at <= now() AND pipeline_stage NOT IN ('won','lost')
+-- and sends a reminder email to the advisor.
+--
+-- Rollback:
+--   ALTER TABLE public.professional_leads DROP COLUMN IF EXISTS pipeline_stage;
+--   ALTER TABLE public.professional_leads DROP COLUMN IF EXISTS next_action_at;
+
+BEGIN;
+
+ALTER TABLE public.professional_leads
+  ADD COLUMN IF NOT EXISTS pipeline_stage TEXT NOT NULL DEFAULT 'new',
+  ADD COLUMN IF NOT EXISTS next_action_at TIMESTAMPTZ;
+
+-- Constraint added separately so we can use IF NOT EXISTS on the column
+-- add but still gate bad values. Postgres doesn't support
+-- ADD CONSTRAINT IF NOT EXISTS on plain ALTER TABLE … ADD COLUMN CHECK;
+-- instead we drop+recreate idempotently.
+ALTER TABLE public.professional_leads
+  DROP CONSTRAINT IF EXISTS professional_leads_pipeline_stage_check;
+
+ALTER TABLE public.professional_leads
+  ADD CONSTRAINT professional_leads_pipeline_stage_check
+    CHECK (pipeline_stage IN ('new','contacted','proposal_sent','negotiating','won','lost'));
+
+-- Index: cron query (overdue follow-ups)
+CREATE INDEX IF NOT EXISTS idx_professional_leads_next_action_overdue
+  ON public.professional_leads (next_action_at)
+  WHERE next_action_at IS NOT NULL;
+
+-- Index: advisor-scoped kanban query
+CREATE INDEX IF NOT EXISTS idx_professional_leads_advisor_pipeline
+  ON public.professional_leads (professional_id, pipeline_stage);
+
+COMMIT;

--- a/supabase/migrations/20260522020000_business_finance_enquiries.sql
+++ b/supabase/migrations/20260522020000_business_finance_enquiries.sql
@@ -1,0 +1,67 @@
+-- Migration: business_finance_enquiries table.
+--
+-- Captures SMB finance lead enquiries from /business-finance (Revenue #5
+-- vertical). The table is service-role-owned; the API route uses a server
+-- Supabase client + the anon INSERT policy to write new rows without
+-- bypassing RLS.
+--
+-- Rollback:
+--   DROP TABLE IF EXISTS public.business_finance_enquiries;
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.business_finance_enquiries (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_name text NOT NULL,
+  contact_name text NOT NULL,
+  email text NOT NULL,
+  phone text,
+  finance_type text NOT NULL,
+  loan_amount_cents bigint,
+  purpose text,
+  time_in_business_months integer,
+  annual_revenue_cents bigint,
+  message text,
+  status text NOT NULL DEFAULT 'new',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT bfe_finance_type_check CHECK (
+    finance_type IN ('business_loan','equipment_finance','invoice_finance','line_of_credit','trade_finance','other')
+  ),
+  CONSTRAINT bfe_status_check CHECK (
+    status IN ('new','contacted','qualified','lost')
+  )
+);
+
+CREATE INDEX IF NOT EXISTS idx_bfe_status
+  ON public.business_finance_enquiries (status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_bfe_email
+  ON public.business_finance_enquiries (lower(email));
+
+ALTER TABLE public.business_finance_enquiries ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Service role manages business_finance_enquiries"
+  ON public.business_finance_enquiries;
+CREATE POLICY "Service role manages business_finance_enquiries"
+  ON public.business_finance_enquiries
+  AS PERMISSIVE FOR ALL TO service_role
+  USING (true) WITH CHECK (true);
+
+-- Anon can INSERT only — status must be 'new', amount guard, no SELECT/UPDATE/DELETE.
+DROP POLICY IF EXISTS "Anon can submit business_finance_enquiries"
+  ON public.business_finance_enquiries;
+CREATE POLICY "Anon can submit business_finance_enquiries"
+  ON public.business_finance_enquiries
+  AS PERMISSIVE FOR INSERT TO anon
+  WITH CHECK (
+    status = 'new'
+    AND (loan_amount_cents IS NULL OR loan_amount_cents BETWEEN 0 AND 50000000000)
+  );
+
+COMMENT ON TABLE public.business_finance_enquiries IS
+  'SMB finance lead capture from /business-finance vertical. '
+  'Writers: /api/business-finance/enquiry POST (anon policy) + admin service role. '
+  'Readers: service role (admin dashboard, BD team).';
+
+COMMIT;


### PR DESCRIPTION
## Summary

5 high-ROI features shipped in a single stream:

**F1 — Rate Alert Account Page** (`/account/alerts`)
- Server page queries by user email via admin client; client component lists subscriptions with verified/unverified badge, notification count, last-alerted date, and one-click remove via unsubscribe token. Links to `/rate-alerts` to add more.

**F2 — Advisor Pipeline CRM**
- Migration: `pipeline_stage` (new / contacted / proposal_sent / negotiating / won / lost) + `next_action_at TIMESTAMPTZ` added to `professional_leads`; indexed for cron and kanban queries.
- `/api/advisor-portal/pipeline` PATCH: updates stage + follow-up date, scoped to the advisor's own leads via session verification.
- `LeadsTab`: inline stage dropdown + date picker per lead card with red "Overdue" badge when `next_action_at < now()`.
- `/api/cron/lead-followup-reminders`: daily cron (daily-9 group) emails advisors a grouped table of overdue leads. Anti-spam: one email per advisor per run.

**F3 — Investor Copilot** (floating AI chat)
- `/api/investor/copilot`: Claude `haiku-4-5`, Node runtime, 600-token cap, full `filterFactualOutput` gate (GAW prefix enforced, no advice phrases, https-only links). Rate-limited at 20 req / 20 min per IP. Collects entire response before filtering — no compliance leakage in streaming.
- `InvestorCopilot` component: fixed floating button (bottom-right), slide-up chat panel, starter prompts, animated typing indicator, 10-turn history window. Embedded on `/savings` and `/term-deposits`.

**F4 — Widget Self-Serve Builder** (advisor portal)
- `WidgetBuilderTab`: pick from WIDGET_CATALOGUE (5 types), choose theme / layout / row count, generates `<iframe>` embed code with one-click copy and preview link. Added as "Widgets" tab in advisor portal nav.

**F5 — Business Finance Vertical** (`/business-finance`)
- Migration: `business_finance_enquiries` table with RLS (service-role manages, anon INSERT with `status='new'` guard), finance_type + status enums, indexed.
- `VerticalConfig` for `business-finance` slug with 5 product type cards, 4 lender-criteria explainers, 5 FAQs, sections, disclaimer. Registered in `getVerticalBySlug`.
- `/business-finance` page: hero, stats bar, product cards with rate/term/range, educational sections, enquiry form, FAQ accordion, cross-links.
- `/api/business-finance/enquiry` POST: Zod-validated, rate-limited (5 req / 20 min), honeypot, disposable-email check, Resend confirmation email.

**Infra**
- `lib/database.types.ts` regenerated from live Supabase project after both migrations applied.
- Both migrations applied directly to `guggzyqceattncjwvgyc` via Supabase MCP before commit (types drift gate will pass).

## Test plan

- [ ] `/account/alerts` — log in, navigate; empty state and list render correctly; Remove button calls unsubscribe endpoint and removes row
- [ ] Advisor portal → Leads tab — stage dropdown changes pipeline_stage via PATCH; date picker sets next_action_at; overdue badge appears for past dates
- [ ] `/api/cron/lead-followup-reminders` — call with CRON_SECRET, confirm JSON response with overdueLeads count
- [ ] `/savings` or `/term-deposits` — floating chat button appears; sending a message returns compliant response prefixed with GAW
- [ ] Advisor portal → Widgets tab — appears in nav, widget type/theme/layout/limit controls update embed code; copy button works
- [ ] `/business-finance` — page loads, product cards render, enquiry form submits and shows success state

https://claude.ai/code/session_01EFQpjSAZiXJeEaCf8TzrWD

---
_Generated by [Claude Code](https://claude.ai/code/session_01EFQpjSAZiXJeEaCf8TzrWD)_