### PR TITLE
feat(first-home-buyer): add buyers-agent handoff lever

### DIFF
--- a/__tests__/lib/first-home-buyer/buyers-agent-handoff.test.ts
+++ b/__tests__/lib/first-home-buyer/buyers-agent-handoff.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import {
+  FHB_BUYERS_AGENT_SPECIALTY,
+  firstHomeBuyerBuyersAgentUrl,
+} from "@/lib/first-home-buyer/buyers-agent-handoff";
+import { SPECIALTIES_BY_TYPE } from "@/lib/advisor-specialties";
+
+describe("first-home-buyer buyers-agent handoff", () => {
+  it("uses a specialty that actually exists for buyers agents", () => {
+    // Drift guard: the directory filters with an exact specialties.includes()
+    // check, so this label must stay in the real buyers_agent specialty set.
+    expect(SPECIALTIES_BY_TYPE.buyers_agent).toContain(
+      FHB_BUYERS_AGENT_SPECIALTY,
+    );
+  });
+
+  it("deep-links to the buyers-agent directory pre-filtered to FHB specialists", () => {
+    expect(firstHomeBuyerBuyersAgentUrl()).toBe(
+      "/advisors/buyers-agents?specialty=First+Home+Buyers",
+    );
+  });
+
+  it("encodes a specialty value the directory can round-trip back", () => {
+    const url = new URL(
+      firstHomeBuyerBuyersAgentUrl(),
+      "https://invest.com.au",
+    );
+    expect(url.pathname).toBe("/advisors/buyers-agents");
+    expect(url.searchParams.get("specialty")).toBe(
+      FHB_BUYERS_AGENT_SPECIALTY,
+    );
+  });
+});

--- a/app/first-home-buyer/page.tsx
+++ b/app/first-home-buyer/page.tsx
@@ -5,6 +5,7 @@ import HubNewsletterCapture from "@/components/HubNewsletterCapture";
 import LeadMagnetCapture from "@/components/LeadMagnetCapture";
 import HubExitIntent from "@/components/HubExitIntent";
 import FhbSavingsMatch from "@/components/first-home-buyer/FhbSavingsMatch";
+import FhbBuyersAgentHandoff from "@/components/first-home-buyer/FhbBuyersAgentHandoff";
 import ArticleBrokerTable from "@/components/ArticleBrokerTable";
 import { getLeadMagnetForHub } from "@/lib/lead-magnets";
 import { firstHomeBuyerHubConfig } from "@/lib/hub-configs/first-home-buyer";
@@ -45,6 +46,7 @@ export default function FirstHomeBuyerPage() {
             heading="High-interest savings accounts for your deposit"
           />
         </div>
+        <FhbBuyersAgentHandoff />
         {leadMagnet && <LeadMagnetCapture magnet={leadMagnet} />}
       </HubPage>
       <HubExitIntent

--- a/components/first-home-buyer/FhbBuyersAgentHandoff.tsx
+++ b/components/first-home-buyer/FhbBuyersAgentHandoff.tsx
@@ -1,0 +1,47 @@
+import Link from "next/link";
+import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
+import { firstHomeBuyerBuyersAgentUrl } from "@/lib/first-home-buyer/buyers-agent-handoff";
+
+/**
+ * <FhbBuyersAgentHandoff> — First Home Buyer buyers-agent handoff (W3.19 lever).
+ *
+ * Presentational only: closes the FHB funnel on the buy side. Once the deposit
+ * (FHSS + cash savings) and the loan (mortgage broker) are sorted, a buyer's
+ * agent finds, evaluates, and negotiates the actual purchase. Links to the
+ * buyers-agent directory pre-filtered to first-home-buyer specialists.
+ */
+export default function FhbBuyersAgentHandoff() {
+  return (
+    <section
+      className="container-custom max-w-4xl py-8"
+      data-testid="fhb-buyers-agent-handoff"
+      aria-labelledby="fhb-buyers-agent-heading"
+    >
+      <h2
+        id="fhb-buyers-agent-heading"
+        className="text-xl md:text-2xl font-extrabold text-slate-900 mb-2"
+      >
+        Found your deposit and loan? Get help buying the property
+      </h2>
+      <p className="text-sm text-slate-600 leading-relaxed mb-3 max-w-2xl">
+        A <strong>buyer&apos;s agent works only for you</strong> — they search
+        (including off-market listings), run due diligence, and negotiate or bid
+        at auction on your behalf. Selling agents represent the vendor; a buyer&apos;s
+        agent is your advocate. For first home buyers, a good agent often saves
+        more than their fee through a sharper negotiation. The specialists below
+        all handle <strong>first-home purchases</strong>.
+      </p>
+      <Link
+        href={firstHomeBuyerBuyersAgentUrl()}
+        className="inline-flex items-center gap-1 text-sm font-semibold text-violet-600 hover:text-violet-800 transition-colors"
+        data-lever="lead_routing"
+      >
+        Find a first-home-buyer specialist buyer&apos;s agent &rarr;
+      </Link>
+      <p className="text-[11px] text-slate-400 leading-relaxed mt-4">
+        <strong className="text-slate-500">General advice warning.</strong>{" "}
+        {GENERAL_ADVICE_WARNING}
+      </p>
+    </section>
+  );
+}

--- a/lib/first-home-buyer/buyers-agent-handoff.ts
+++ b/lib/first-home-buyer/buyers-agent-handoff.ts
@@ -1,0 +1,25 @@
+/**
+ * First Home Buyer → buyers-agent directory handoff (W3.19 lever).
+ *
+ * Deep-links the First Home Buyer hub into the buyers-agent directory
+ * pre-filtered to FHB specialists, so the hub's "Find a Buyer's Agent" CTA
+ * lands users on a curated shortlist of agents who handle first-home
+ * purchases instead of the unfiltered list. This is the buy-side counterpart
+ * to the mortgage-broker handoff: the broker arranges the loan, the buyer's
+ * agent finds and negotiates the property.
+ */
+
+/**
+ * Canonical specialty label. MUST match the value stored in
+ * `professionals.specialties` and listed under `buyers_agent` in
+ * `lib/advisor-specialties.ts` — the directory filters with an exact
+ * `specialties.includes(...)` check, so any drift silently empties the list.
+ * A test asserts this stays in sync.
+ */
+export const FHB_BUYERS_AGENT_SPECIALTY = "First Home Buyers";
+
+/** Pre-filtered buyers-agent directory URL for First Home Buyer specialists. */
+export function firstHomeBuyerBuyersAgentUrl(): string {
+  const params = new URLSearchParams({ specialty: FHB_BUYERS_AGENT_SPECIALTY });
+  return `/advisors/buyers-agents?${params.toString()}`;
+}

--- a/lib/hub-configs/first-home-buyer.ts
+++ b/lib/hub-configs/first-home-buyer.ts
@@ -1,6 +1,7 @@
 import { CURRENT_YEAR } from "@/lib/seo";
 import type { HubConfig } from "@/lib/verticals";
 import { firstHomeBuyerBrokerDirectoryUrl } from "@/lib/first-home-buyer/broker-handoff";
+import { firstHomeBuyerBuyersAgentUrl } from "@/lib/first-home-buyer/buyers-agent-handoff";
 
 /**
  * Hub config for /first-home-buyer — consumed by the <HubPage> HOC.
@@ -101,6 +102,14 @@ export const firstHomeBuyerHubConfig: HubConfig = {
         "Waiting for FHSS release takes 20+ business days. A deposit bond (from $100) covers the 10% deposit at exchange while your ATO release processes.",
       href: firstHomeBuyerBrokerDirectoryUrl(),
       cta: "Talk to a Broker",
+    },
+    {
+      title: "Buyer's Agents",
+      icon: "search",
+      description:
+        "A buyer's agent works only for you — searching off-market listings, running due diligence, and negotiating the purchase. For first home buyers, a sharp negotiation often saves more than their fee.",
+      href: firstHomeBuyerBuyersAgentUrl(),
+      cta: "Find a Buyer's Agent",
     },
   ],
 


### PR DESCRIPTION
## Summary
Adds the buyers-agent handoff lever to the First Home Buyer hub — the last remaining W3.19 monetization lever.

## Why
Closes the FHB funnel on the buy side: once a user has their deposit (FHSS + cash savings) and loan (mortgage broker) sorted, a buyer's agent finds, evaluates, and negotiates the actual purchase. Mirrors the merged mortgage-broker handoff pattern (#1041).

## Tier
**B** — additive page UI + a small `lib/` helper + tests. No schema, API, webhook, cron, or auth changes.

## Files
- `lib/first-home-buyer/buyers-agent-handoff.ts` — `firstHomeBuyerBuyersAgentUrl()` + canonical `FHB_BUYERS_AGENT_SPECIALTY`, deep-linking `/advisors/buyers-agents?specialty=First Home Buyers`
- `components/first-home-buyer/FhbBuyersAgentHandoff.tsx` — framing section (buy-side CTA + general-advice warning), mirrors `<FhbSavingsMatch>`
- `app/first-home-buyer/page.tsx` — mounts the section below the savings rail
- `lib/hub-configs/first-home-buyer.ts` — adds a "Buyer's Agents" service-grid card
- `__tests__/lib/first-home-buyer/buyers-agent-handoff.test.ts` — 3 tests incl. drift guard against the canonical `buyers_agent` specialty set

## Supersedes
_None._

## Test plan
- [x] vitest local: 3/3 passing (`buyers-agent-handoff.test.ts`)
- [x] type-check: clean (`tsc --noEmit` exit 0)
- [ ] CI: pending
- [ ] Visual: `/first-home-buyer` renders the "Buyer's Agents" card + buy-side section; CTA lands on `/advisors/buyers-agents` with the FHB specialty pre-selected


---
_Generated by [Claude Code](https://claude.ai/code/session_01PMeTAxrguM3bD6SFn3EJZs)_