### PR TITLE
fix(c): C-DISC-20260522-01/02 — replace createAdminClient with server client in brokers + community routes [audit remediation]

### DIFF
--- a/__tests__/api/community-categories.test.ts
+++ b/__tests__/api/community-categories.test.ts
@@ -2,10 +2,10 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // ── Mocks ──────────────────────────────────────────────────────────────────────
 
-const mockAdminFrom = vi.fn();
+const { mockServerFrom } = vi.hoisted(() => ({ mockServerFrom: vi.fn() }));
 
-vi.mock("@/lib/supabase/admin", () => ({
-  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn().mockResolvedValue({ from: mockServerFrom }),
 }));
 
 vi.mock("@/lib/logger", () => ({
@@ -47,7 +47,7 @@ describe("GET /api/community/categories", () => {
   beforeEach(() => vi.clearAllMocks());
 
   it("returns empty list when no categories", async () => {
-    mockAdminFrom.mockReturnValue(makeCategoriesBuilder([]));
+    mockServerFrom.mockReturnValue(makeCategoriesBuilder([]));
     const res = await GET();
     expect(res.status).toBe(200);
     const data = await res.json();
@@ -56,7 +56,7 @@ describe("GET /api/community/categories", () => {
 
   it("returns list of active categories", async () => {
     const cats = [makeCategory({ slug: "investing" }), makeCategory({ slug: "super", sort_order: 2 })];
-    mockAdminFrom.mockReturnValue(makeCategoriesBuilder(cats));
+    mockServerFrom.mockReturnValue(makeCategoriesBuilder(cats));
     const res = await GET();
     expect(res.status).toBe(200);
     const data = await res.json();
@@ -66,20 +66,20 @@ describe("GET /api/community/categories", () => {
 
   it("filters by status=active", async () => {
     const builder = makeCategoriesBuilder([]);
-    mockAdminFrom.mockReturnValue(builder);
+    mockServerFrom.mockReturnValue(builder);
     await GET();
     expect(builder.eq).toHaveBeenCalledWith("status", "active");
   });
 
   it("orders by sort_order ascending", async () => {
     const builder = makeCategoriesBuilder([]);
-    mockAdminFrom.mockReturnValue(builder);
+    mockServerFrom.mockReturnValue(builder);
     await GET();
     expect(builder.order).toHaveBeenCalledWith("sort_order", { ascending: true });
   });
 
   it("returns 500 on DB error", async () => {
-    mockAdminFrom.mockReturnValue(makeCategoriesBuilder([], { message: "DB error" }));
+    mockServerFrom.mockReturnValue(makeCategoriesBuilder([], { message: "DB error" }));
     const res = await GET();
     expect(res.status).toBe(500);
     const data = await res.json();
@@ -87,7 +87,7 @@ describe("GET /api/community/categories", () => {
   });
 
   it("returns 500 on unexpected throw", async () => {
-    mockAdminFrom.mockImplementation(() => { throw new Error("boom"); });
+    mockServerFrom.mockImplementation(() => { throw new Error("boom"); });
     const res = await GET();
     expect(res.status).toBe(500);
   });

--- a/__tests__/api/v1-brokers.test.ts
+++ b/__tests__/api/v1-brokers.test.ts
@@ -3,10 +3,10 @@ import { NextRequest } from "next/server";
 
 // ── Mocks ──────────────────────────────────────────────────────────────────────
 
-const mockAdminFrom = vi.fn();
+const { mockServerFrom } = vi.hoisted(() => ({ mockServerFrom: vi.fn() }));
 
-vi.mock("@/lib/supabase/admin", () => ({
-  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn().mockResolvedValue({ from: mockServerFrom }),
 }));
 
 vi.mock("@/lib/logger", () => ({
@@ -120,7 +120,7 @@ describe("GET /api/v1/brokers — success", () => {
 
   it("returns broker list with meta", async () => {
     const broker = makeBroker();
-    mockAdminFrom.mockReturnValue(makeBrokersBuilder([broker], null, 1));
+    mockServerFrom.mockReturnValue(makeBrokersBuilder([broker], null, 1));
 
     const res = await GET(makeGet());
     expect(res.status).toBe(200);
@@ -134,7 +134,7 @@ describe("GET /api/v1/brokers — success", () => {
 
   it("strips private fields from broker rows", async () => {
     const broker = { ...makeBroker(), stripe_customer_id: "cus_secret", internal_notes: "hidden" };
-    mockAdminFrom.mockReturnValue(makeBrokersBuilder([broker], null, 1));
+    mockServerFrom.mockReturnValue(makeBrokersBuilder([broker], null, 1));
 
     const res = await GET(makeGet());
     const body = await res.json();
@@ -144,7 +144,7 @@ describe("GET /api/v1/brokers — success", () => {
 
   it("respects limit query param (max 100)", async () => {
     const builder = makeBrokersBuilder([], null, 0);
-    mockAdminFrom.mockReturnValue(builder);
+    mockServerFrom.mockReturnValue(builder);
 
     await GET(makeGet({ limit: "5" }));
     expect(builder.range).toHaveBeenCalledWith(0, 4);
@@ -152,7 +152,7 @@ describe("GET /api/v1/brokers — success", () => {
 
   it("clamps limit to 100 even if 200 requested", async () => {
     const builder = makeBrokersBuilder([], null, 0);
-    mockAdminFrom.mockReturnValue(builder);
+    mockServerFrom.mockReturnValue(builder);
 
     await GET(makeGet({ limit: "200" }));
     expect(builder.range).toHaveBeenCalledWith(0, 99);
@@ -160,7 +160,7 @@ describe("GET /api/v1/brokers — success", () => {
 
   it("defaults limit to 20 when invalid", async () => {
     const builder = makeBrokersBuilder([], null, 0);
-    mockAdminFrom.mockReturnValue(builder);
+    mockServerFrom.mockReturnValue(builder);
 
     await GET(makeGet({ limit: "abc" }));
     expect(builder.range).toHaveBeenCalledWith(0, 19);
@@ -168,7 +168,7 @@ describe("GET /api/v1/brokers — success", () => {
 
   it("respects offset query param", async () => {
     const builder = makeBrokersBuilder([], null, 100);
-    mockAdminFrom.mockReturnValue(builder);
+    mockServerFrom.mockReturnValue(builder);
 
     await GET(makeGet({ offset: "20" }));
     expect(builder.range).toHaveBeenCalledWith(20, 39);
@@ -176,7 +176,7 @@ describe("GET /api/v1/brokers — success", () => {
 
   it("filters by platform_type", async () => {
     const builder = makeBrokersBuilder([], null, 0);
-    mockAdminFrom.mockReturnValue(builder);
+    mockServerFrom.mockReturnValue(builder);
 
     await GET(makeGet({ platform_type: "share_broker" }));
     expect(builder.eq).toHaveBeenCalledWith("platform_type", "share_broker");
@@ -184,7 +184,7 @@ describe("GET /api/v1/brokers — success", () => {
 
   it("filters chess_sponsored=true", async () => {
     const builder = makeBrokersBuilder([], null, 0);
-    mockAdminFrom.mockReturnValue(builder);
+    mockServerFrom.mockReturnValue(builder);
 
     await GET(makeGet({ chess_sponsored: "true" }));
     expect(builder.eq).toHaveBeenCalledWith("chess_sponsored", true);
@@ -192,7 +192,7 @@ describe("GET /api/v1/brokers — success", () => {
 
   it("filters chess_sponsored=false", async () => {
     const builder = makeBrokersBuilder([], null, 0);
-    mockAdminFrom.mockReturnValue(builder);
+    mockServerFrom.mockReturnValue(builder);
 
     await GET(makeGet({ chess_sponsored: "false" }));
     expect(builder.eq).toHaveBeenCalledWith("chess_sponsored", false);
@@ -200,7 +200,7 @@ describe("GET /api/v1/brokers — success", () => {
 
   it("filters smsf_support=true", async () => {
     const builder = makeBrokersBuilder([], null, 0);
-    mockAdminFrom.mockReturnValue(builder);
+    mockServerFrom.mockReturnValue(builder);
 
     await GET(makeGet({ smsf_support: "true" }));
     expect(builder.eq).toHaveBeenCalledWith("smsf_support", true);
@@ -208,7 +208,7 @@ describe("GET /api/v1/brokers — success", () => {
 
   it("filters is_crypto=true", async () => {
     const builder = makeBrokersBuilder([], null, 0);
-    mockAdminFrom.mockReturnValue(builder);
+    mockServerFrom.mockReturnValue(builder);
 
     await GET(makeGet({ is_crypto: "true" }));
     expect(builder.eq).toHaveBeenCalledWith("is_crypto", true);
@@ -221,7 +221,7 @@ describe("GET /api/v1/brokers — success", () => {
       order: vi.fn().mockReturnThis(),
       range: vi.fn(() => Promise.resolve({ data: null, count: null, error: { message: "DB error" } })),
     };
-    mockAdminFrom.mockReturnValue(builder);
+    mockServerFrom.mockReturnValue(builder);
 
     const res = await GET(makeGet());
     expect(res.status).toBe(500);
@@ -230,14 +230,14 @@ describe("GET /api/v1/brokers — success", () => {
   });
 
   it("returns 500 on unexpected throw", async () => {
-    mockAdminFrom.mockImplementation(() => { throw new Error("boom"); });
+    mockServerFrom.mockImplementation(() => { throw new Error("boom"); });
 
     const res = await GET(makeGet());
     expect(res.status).toBe(500);
   });
 
   it("logs successful requests with apiKeyId", async () => {
-    mockAdminFrom.mockReturnValue(makeBrokersBuilder([makeBroker()], null, 1));
+    mockServerFrom.mockReturnValue(makeBrokersBuilder([makeBroker()], null, 1));
 
     await GET(makeGet());
     expect(mockLogApiRequest).toHaveBeenCalledWith(
@@ -246,7 +246,7 @@ describe("GET /api/v1/brokers — success", () => {
   });
 
   it("includes Cache-Control header on success", async () => {
-    mockAdminFrom.mockReturnValue(makeBrokersBuilder([], null, 0));
+    mockServerFrom.mockReturnValue(makeBrokersBuilder([], null, 0));
 
     const res = await GET(makeGet());
     expect(res.headers.get("Cache-Control")).toContain("max-age=3600");
@@ -257,7 +257,7 @@ describe("GET /api/v1/brokers — success", () => {
       makeBroker({ updated_at: "2026-01-01T00:00:00Z" }),
       makeBroker({ name: "SelfWealth", updated_at: "2026-04-01T00:00:00Z" }),
     ];
-    mockAdminFrom.mockReturnValue(makeBrokersBuilder(brokers, null, 2));
+    mockServerFrom.mockReturnValue(makeBrokersBuilder(brokers, null, 2));
 
     const res = await GET(makeGet());
     const body = await res.json();

--- a/app/api/community/categories/route.ts
+++ b/app/api/community/categories/route.ts
@@ -1,4 +1,4 @@
-import { createAdminClient } from "@/lib/supabase/admin";
+import { createClient } from "@/lib/supabase/server";
 import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 
@@ -6,7 +6,7 @@ const log = logger("community:categories");
 
 export async function GET() {
   try {
-    const supabase = createAdminClient();
+    const supabase = await createClient();
 
     const { data, error } = await supabase
       .from("forum_categories")

--- a/app/api/v1/brokers/route.ts
+++ b/app/api/v1/brokers/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createAdminClient } from "@/lib/supabase/admin";
+import { createClient } from "@/lib/supabase/server";
 import { logger } from "@/lib/logger";
 import { validateApiKey, logApiRequest, API_CORS_HEADERS } from "@/lib/api-auth";
 import { escapeHtml } from "@/lib/html-escape";
@@ -124,7 +124,7 @@ export async function GET(request: NextRequest) {
     let offset = parseInt(params.get("offset") || "0", 10) || 0;
     if (offset < 0) offset = 0;
 
-    const supabase = createAdminClient();
+    const supabase = await createClient();
 
     // Build query — select only public fields
     let query = supabase


### PR DESCRIPTION
## Summary

Removes two illegitimate uses of `createAdminClient()` (service-role bypass) from routes that only need anon-level reads — exactly the pattern flagged in CLAUDE.md's admin.ts scope contract.

- **`app/api/v1/brokers/route.ts`** (`C-DISC-20260522-01`): Was using admin client to read `brokers WHERE status='active'`. The `001_initial.sql` migration has a `"Public read for active brokers"` anon SELECT policy — no bypass needed.
- **`app/api/community/categories/route.ts`** (`C-DISC-20260522-02`): Was using admin client to read `forum_categories WHERE status='active'`. `20260429_o_iter6_rls_forum.sql` has a `"public read"` policy granting `TO anon, authenticated` — no bypass needed.

Both routes now use `await createClient()` from `lib/supabase/server`. In each case (API-key-auth and public-read route respectively), no user session cookie is present, so the client operates as anon — which the existing RLS policies correctly gate.

Test mocks updated from `createAdminClient` → `createClient` (async, `vi.hoisted()` to avoid TDZ hoisting bug).

## Supersedes

_None._

## Test plan

- [x] 26 existing tests pass (`npm test -- community-categories.test.ts v1-brokers.test.ts`)
- [x] Lint clean
- [x] RLS policies verified in migrations before making change

Refs: #216
Audit: `docs/audits/codebase-health-2026-04-24.md` §admin.ts scope
Queue: C-DISC-20260522-01 + C-DISC-20260522-02

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jcr5Q3tz9g2NxnefzYYqB4)_