### PR TITLE
feat(nf): noindex 4 empty listing verticals + remove from sitemap (§4-vert)

### DIFF
--- a/app/invest/insurance-linked-securities/listings/page.tsx
+++ b/app/invest/insurance-linked-securities/listings/page.tsx
@@ -18,6 +18,9 @@ export async function generateMetadata(): Promise<Metadata> {
     description:
       "Browse Australian insurance-linked securities (ILS) investment opportunities for wholesale investors. Catastrophe bonds, sidecars, collateralised reinsurance and ILW structures. Non-correlated alternative yield.",
     alternates: { canonical: `${SITE_URL}/invest/insurance-linked-securities/listings` },
+    // No live listings yet — de-indexed until supply threshold is met.
+    // Remove when countListingsByVertical("insurance-linked-securities") > 0 in prod.
+    robots: { index: false, follow: false },
     openGraph: {
       title: `Insurance-Linked Securities Investment Opportunities — ${countLabel}Active Listings`,
       url: `${SITE_URL}/invest/insurance-linked-securities/listings`,

--- a/app/invest/litigation-funding/listings/page.tsx
+++ b/app/invest/litigation-funding/listings/page.tsx
@@ -18,6 +18,9 @@ export async function generateMetadata(): Promise<Metadata> {
     description:
       "Browse Australian litigation funding investment opportunities for wholesale investors. Class actions, commercial disputes and international arbitration funding. Compare expected returns, case portfolios and funding structures.",
     alternates: { canonical: `${SITE_URL}/invest/litigation-funding/listings` },
+    // No live listings yet — de-indexed until supply threshold is met.
+    // Remove when countListingsByVertical("litigation-funding") > 0 in prod.
+    robots: { index: false, follow: false },
     openGraph: {
       title: `Litigation Funding Investment Opportunities — ${countLabel}Active Listings`,
       url: `${SITE_URL}/invest/litigation-funding/listings`,

--- a/app/invest/royalties/listings/page.tsx
+++ b/app/invest/royalties/listings/page.tsx
@@ -18,6 +18,9 @@ export async function generateMetadata(): Promise<Metadata> {
     description:
       "Browse Australian royalty and intellectual property investment opportunities. Mining royalties, music catalogue royalties, patent royalties, film residuals and pharmaceutical royalties available for investment.",
     alternates: { canonical: `${SITE_URL}/invest/royalties/listings` },
+    // No live listings yet — de-indexed until supply threshold is met.
+    // Remove when countListingsByVertical("royalties") > 0 in prod.
+    robots: { index: false, follow: false },
     openGraph: {
       title: `Royalty & IP Investment Opportunities Australia — ${countLabel}Active Listings`,
       url: `${SITE_URL}/invest/royalties/listings`,

--- a/app/invest/venture-capital/listings/page.tsx
+++ b/app/invest/venture-capital/listings/page.tsx
@@ -18,6 +18,9 @@ export async function generateMetadata(): Promise<Metadata> {
     description:
       "Browse Australian venture capital investment opportunities for wholesale investors. Early-stage, Series A/B and growth equity fund mandates. Compare VC fund structures, sector focus and minimum commitments.",
     alternates: { canonical: `${SITE_URL}/invest/venture-capital/listings` },
+    // No live listings yet — de-indexed until supply threshold is met.
+    // Remove when countListingsByVertical("venture-capital") > 0 in prod.
+    robots: { index: false, follow: false },
     openGraph: {
       title: `Venture Capital Investment Opportunities — ${countLabel}Active Listings`,
       url: `${SITE_URL}/invest/venture-capital/listings`,

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -62,15 +62,15 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     "/invest/private-credit/listings", "/invest/infrastructure/listings",
     "/invest/digital-infrastructure/listings",
     "/invest/public-social-infrastructure/listings",
-    // carbon/aquaculture/livestock /listings de-indexed pending compliance
-    // review (s708 / MIS classification) — guide hubs stay, listing pages omitted.
-    "/invest/royalties/listings",
+    // carbon/aquaculture/livestock/royalties/VC/litigation-funding/ILS /listings
+    // de-indexed (no live listings yet — thin pages hurt crawl budget).
+    // Guide hubs stay; listing pages omitted until supply threshold is met.
     "/invest/aquaculture",
     "/invest/livestock",
     "/invest/private-equity/listings",
-    "/invest/venture-capital", "/invest/venture-capital/listings",
-    "/invest/litigation-funding", "/invest/litigation-funding/listings",
-    "/invest/insurance-linked-securities", "/invest/insurance-linked-securities/listings",
+    "/invest/venture-capital",
+    "/invest/litigation-funding",
+    "/invest/insurance-linked-securities",
     "/foreign-investment/united-states", "/foreign-investment/japan", "/foreign-investment/india",
     "/foreign-investment/malaysia", "/foreign-investment/new-zealand", "/foreign-investment/south-korea",
     "/foreign-investment/saudi-arabia",


### PR DESCRIPTION
## Summary

Closes the §4-vert completeness item from the new-features audit (2026-05-20). Four listing pages were indexed-but-empty, diluting crawl budget and generating thin-page signals in GSC:

- `/invest/venture-capital/listings`
- `/invest/litigation-funding/listings`
- `/invest/insurance-linked-securities/listings`
- `/invest/royalties/listings`

**Changes:**
- Added `robots: { index: false, follow: false }` to all 4 `generateMetadata()` functions with a comment directing when to re-enable (when `countListingsByVertical()` > 0 in prod)
- Removed the 4 `/listings` paths from `app/sitemap.ts` (guide hub pages remain)

**Pattern:** Matches the fix already applied to carbon/aquaculture/livestock in PR #1062.

**Re-enabling:** Delete the `robots` block and add the listing path back to `app/sitemap.ts` when the first live listing appears for that vertical.

## Tier

**Tier A** — content/SEO metadata only. No logic, no auth, no DB, no API changes.

## Supersedes

_None._

Refs: §4-vert (`docs/audits/NEW-FEATURES-GREEN-QUEUE.md`)
Audit: `docs/audits/2026-05-20-new-features-audit.md` §5 completeness
Queue: NF §4-vert

---
_Generated by [Claude Code](https://claude.ai/code/session_01BHCLvS4HDCVq2S1vUwXEpN)_