### PR TITLE
feat(nf): wire autopilot DB toggles to cron routes (audit §5 #16)

### DIFF
--- a/__tests__/api/cron-auto-publish.test.ts
+++ b/__tests__/api/cron-auto-publish.test.ts
@@ -79,6 +79,11 @@ vi.mock("@/lib/cron-auth", () => ({
   requireCronAuth: vi.fn(() => null), // default: auth OK
 }));
 
+vi.mock("@/lib/autopilot", () => ({
+  checkAutopilotGate: vi.fn().mockResolvedValue(null),
+  _resetAutopilotCache: vi.fn(),
+}));
+
 import { GET, runtime, maxDuration } from "@/app/api/cron/auto-publish/route";
 import { requireCronAuth } from "@/lib/cron-auth";
 

--- a/__tests__/api/cron-check-affiliate-links.test.ts
+++ b/__tests__/api/cron-check-affiliate-links.test.ts
@@ -21,6 +21,11 @@ vi.mock("@/lib/supabase/admin", () => ({
   createAdminClient: vi.fn(() => ({ from: mockFrom, rpc: vi.fn(() => makeBuilder()) })),
 }));
 
+vi.mock("@/lib/autopilot", () => ({
+  checkAutopilotGate: vi.fn().mockResolvedValue(null),
+  _resetAutopilotCache: vi.fn(),
+}));
+
 import { GET, runtime, maxDuration } from "@/app/api/cron/check-affiliate-links/route";
 
 const SECRET = "test-cron-secret-1234567890";

--- a/__tests__/api/cron-check-fees-personalized.test.ts
+++ b/__tests__/api/cron-check-fees-personalized.test.ts
@@ -60,6 +60,11 @@ vi.mock("@/lib/email-templates", () => ({
   feeChangeAlertEmail: (rows: Array<{ broker: string }>) => `<p>fee-change-html-for-${rows.map((r) => r.broker).join("-")}</p>`,
 }));
 
+vi.mock("@/lib/autopilot", () => ({
+  checkAutopilotGate: vi.fn().mockResolvedValue(null),
+  _resetAutopilotCache: vi.fn(),
+}));
+
 import { GET } from "@/app/api/cron/check-fees/route";
 
 // Tiny chainable-query builder that yields `data` when awaited.

--- a/__tests__/api/cron-expire-deals.test.ts
+++ b/__tests__/api/cron-expire-deals.test.ts
@@ -35,6 +35,11 @@ vi.mock("@/lib/supabase/admin", () => ({
   })),
 }));
 
+vi.mock("@/lib/autopilot", () => ({
+  checkAutopilotGate: vi.fn().mockResolvedValue(null),
+  _resetAutopilotCache: vi.fn(),
+}));
+
 import { GET, runtime, maxDuration } from "@/app/api/cron/expire-deals/route";
 
 const SECRET = "test-cron-secret-1234567890";

--- a/__tests__/api/cron-low-balance-alerts.test.ts
+++ b/__tests__/api/cron-low-balance-alerts.test.ts
@@ -35,6 +35,11 @@ vi.mock("@/lib/supabase/admin", () => ({
   })),
 }));
 
+vi.mock("@/lib/autopilot", () => ({
+  checkAutopilotGate: vi.fn().mockResolvedValue(null),
+  _resetAutopilotCache: vi.fn(),
+}));
+
 import { GET, runtime, maxDuration } from "@/app/api/cron/low-balance-alerts/route";
 
 const SECRET = "test-cron-secret-1234567890";

--- a/__tests__/api/cron-marketplace-stats.test.ts
+++ b/__tests__/api/cron-marketplace-stats.test.ts
@@ -40,6 +40,11 @@ vi.mock("@/lib/supabase/admin", () => ({
   })),
 }));
 
+vi.mock("@/lib/autopilot", () => ({
+  checkAutopilotGate: vi.fn().mockResolvedValue(null),
+  _resetAutopilotCache: vi.fn(),
+}));
+
 import { GET, runtime, maxDuration } from "@/app/api/cron/marketplace-stats/route";
 
 const SECRET = "test-cron-secret-1234567890";

--- a/__tests__/api/cron-quiz-follow-up.test.ts
+++ b/__tests__/api/cron-quiz-follow-up.test.ts
@@ -30,6 +30,11 @@ vi.mock("@/lib/supabase/admin", () => ({
   createAdminClient: vi.fn(() => ({ from: mockFrom, rpc: vi.fn(() => makeBuilder()) })),
 }));
 
+vi.mock("@/lib/autopilot", () => ({
+  checkAutopilotGate: vi.fn().mockResolvedValue(null),
+  _resetAutopilotCache: vi.fn(),
+}));
+
 import { GET, runtime, maxDuration } from "@/app/api/cron/quiz-follow-up/route";
 
 const SECRET = "test-cron-secret-1234567890";

--- a/__tests__/api/cron-retry-webhooks.test.ts
+++ b/__tests__/api/cron-retry-webhooks.test.ts
@@ -78,6 +78,11 @@ vi.mock("@/lib/cron-auth", () => ({
   requireCronAuth: vi.fn(() => null),
 }));
 
+vi.mock("@/lib/autopilot", () => ({
+  checkAutopilotGate: vi.fn().mockResolvedValue(null),
+  _resetAutopilotCache: vi.fn(),
+}));
+
 import { GET, runtime, maxDuration } from "@/app/api/cron/retry-webhooks/route";
 import { requireCronAuth } from "@/lib/cron-auth";
 

--- a/__tests__/api/cron-weekly-newsletter.test.ts
+++ b/__tests__/api/cron-weekly-newsletter.test.ts
@@ -28,6 +28,11 @@ vi.mock("@/lib/email-templates", () => ({
   weeklyDigestEmail: vi.fn(() => "<html>digest</html>"),
 }));
 
+vi.mock("@/lib/autopilot", () => ({
+  checkAutopilotGate: vi.fn().mockResolvedValue(null),
+  _resetAutopilotCache: vi.fn(),
+}));
+
 import { GET, runtime, maxDuration } from "@/app/api/cron/weekly-newsletter/route";
 
 const SECRET = "test-cron-secret-1234567890";

--- a/__tests__/api/cron-welcome-drip.test.ts
+++ b/__tests__/api/cron-welcome-drip.test.ts
@@ -31,6 +31,11 @@ vi.mock("@/lib/email-templates", () => ({
   checkInEmail: vi.fn(() => "<html>check-in</html>"),
 }));
 
+vi.mock("@/lib/autopilot", () => ({
+  checkAutopilotGate: vi.fn().mockResolvedValue(null),
+  _resetAutopilotCache: vi.fn(),
+}));
+
 import { GET, runtime, maxDuration } from "@/app/api/cron/welcome-drip/route";
 
 const SECRET = "test-cron-secret-1234567890";

--- a/app/api/cron/auto-publish/route.ts
+++ b/app/api/cron/auto-publish/route.ts
@@ -1,6 +1,7 @@
 import { createAdminClient } from "@/lib/supabase/admin";
 import { NextRequest, NextResponse } from "next/server";
 import { requireCronAuth } from "@/lib/cron-auth";
+import { checkAutopilotGate } from "@/lib/autopilot";
 
 export const runtime = "edge";
 export const maxDuration = 30;
@@ -13,6 +14,8 @@ export const maxDuration = 30;
 export async function GET(req: NextRequest) {
   const unauth = requireCronAuth(req);
   if (unauth) return unauth;
+  const gated = await checkAutopilotGate("auto-publish");
+  if (gated) return gated;
 
   const supabase = createAdminClient();
 

--- a/app/api/cron/check-affiliate-links/route.ts
+++ b/app/api/cron/check-affiliate-links/route.ts
@@ -2,6 +2,7 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { NextRequest, NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 import { requireCronAuth } from "@/lib/cron-auth";
+import { checkAutopilotGate } from "@/lib/autopilot";
 
 const log = logger("cron-affiliate");
 
@@ -21,6 +22,8 @@ export const maxDuration = 60;
 export async function GET(req: NextRequest) {
   const unauth = requireCronAuth(req);
   if (unauth) return unauth;
+  const gated = await checkAutopilotGate("check-affiliate-links");
+  if (gated) return gated;
 
   const supabase = createAdminClient();
 

--- a/app/api/cron/check-fees/route.ts
+++ b/app/api/cron/check-fees/route.ts
@@ -4,6 +4,7 @@ import { getAdminEmail } from "@/lib/admin";
 import { feeChangeAlertEmail } from "@/lib/email-templates";
 import { logger } from "@/lib/logger";
 import { requireCronAuth } from "@/lib/cron-auth";
+import { checkAutopilotGate } from "@/lib/autopilot";
 import { buildEmailToUserIdMap, notifyUser } from "@/lib/notifications";
 import { sendEmail } from "@/lib/resend";
 
@@ -36,6 +37,8 @@ function extractFees(text: string): Record<string, string> {
 export async function GET(req: NextRequest) {
   const unauth = requireCronAuth(req);
   if (unauth) return unauth;
+  const gated = await checkAutopilotGate("check-fees");
+  if (gated) return gated;
 
   const supabase = createAdminClient();
 

--- a/app/api/cron/content-staleness/route.ts
+++ b/app/api/cron/content-staleness/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getAdminEmail } from "@/lib/admin";
 import { logger } from "@/lib/logger";
 import { requireCronAuth } from "@/lib/cron-auth";
+import { checkAutopilotGate } from "@/lib/autopilot";
 
 const log = logger("cron-content-staleness");
 
@@ -22,6 +23,8 @@ export const maxDuration = 60;
 export async function GET(req: NextRequest) {
   const unauth = requireCronAuth(req);
   if (unauth) return unauth;
+  const gated = await checkAutopilotGate("content-staleness");
+  if (gated) return gated;
 
   const supabase = createAdminClient();
 

--- a/app/api/cron/expire-deals/route.ts
+++ b/app/api/cron/expire-deals/route.ts
@@ -2,6 +2,7 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { NextRequest, NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 import { requireCronAuth } from "@/lib/cron-auth";
+import { checkAutopilotGate } from "@/lib/autopilot";
 
 const log = logger("cron-deals");
 
@@ -18,6 +19,8 @@ export const maxDuration = 60;
 export async function GET(req: NextRequest) {
   const unauth = requireCronAuth(req);
   if (unauth) return unauth;
+  const gated = await checkAutopilotGate("expire-deals");
+  if (gated) return gated;
 
   const supabase = createAdminClient();
 

--- a/app/api/cron/low-balance-alerts/route.ts
+++ b/app/api/cron/low-balance-alerts/route.ts
@@ -2,6 +2,7 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { NextRequest, NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 import { requireCronAuth } from "@/lib/cron-auth";
+import { checkAutopilotGate } from "@/lib/autopilot";
 
 const log = logger("cron-low-balance");
 
@@ -21,6 +22,8 @@ export const maxDuration = 60;
 export async function GET(req: NextRequest) {
   const unauth = requireCronAuth(req);
   if (unauth) return unauth;
+  const gated = await checkAutopilotGate("low-balance-alerts");
+  if (gated) return gated;
 
   const supabase = createAdminClient();
 

--- a/app/api/cron/marketplace-stats/route.ts
+++ b/app/api/cron/marketplace-stats/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { calculateOptimalBids, applyBidAdjustments } from "@/lib/marketplace/auto-bid";
 import { logger } from "@/lib/logger";
 import { requireCronAuth } from "@/lib/cron-auth";
+import { checkAutopilotGate } from "@/lib/autopilot";
 
 const log = logger("cron-marketplace-stats");
 
@@ -20,6 +21,8 @@ export const maxDuration = 60;
 export async function GET(req: NextRequest) {
   const unauth = requireCronAuth(req);
   if (unauth) return unauth;
+  const gated = await checkAutopilotGate("marketplace-stats");
+  if (gated) return gated;
 
   const supabase = createAdminClient();
 

--- a/app/api/cron/quiz-follow-up/route.ts
+++ b/app/api/cron/quiz-follow-up/route.ts
@@ -7,6 +7,7 @@ import {
 } from "@/lib/email-templates";
 import { logger } from "@/lib/logger";
 import { requireCronAuth } from "@/lib/cron-auth";
+import { checkAutopilotGate } from "@/lib/autopilot";
 
 const log = logger("quiz-followup");
 
@@ -28,6 +29,8 @@ export const maxDuration = 60;
 export async function GET(req: NextRequest) {
   const unauth = requireCronAuth(req);
   if (unauth) return unauth;
+  const gated = await checkAutopilotGate("quiz-follow-up");
+  if (gated) return gated;
 
   const supabase = createAdminClient();
 

--- a/app/api/cron/retry-webhooks/route.ts
+++ b/app/api/cron/retry-webhooks/route.ts
@@ -1,6 +1,7 @@
 import { createAdminClient } from "@/lib/supabase/admin";
 import { NextRequest, NextResponse } from "next/server";
 import { requireCronAuth } from "@/lib/cron-auth";
+import { checkAutopilotGate } from "@/lib/autopilot";
 
 export const runtime = "edge";
 export const maxDuration = 60;
@@ -29,6 +30,8 @@ const BACKOFF_DELAYS_MS = [
 export async function GET(req: NextRequest) {
   const unauth = requireCronAuth(req);
   if (unauth) return unauth;
+  const gated = await checkAutopilotGate("retry-webhooks");
+  if (gated) return gated;
 
   const supabase = createAdminClient();
 

--- a/app/api/cron/weekly-newsletter/route.ts
+++ b/app/api/cron/weekly-newsletter/route.ts
@@ -2,6 +2,7 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { weeklyDigestEmail } from "@/lib/email-templates";
 import { NextRequest, NextResponse } from "next/server";
 import { requireCronAuth } from "@/lib/cron-auth";
+import { checkAutopilotGate } from "@/lib/autopilot";
 
 export const runtime = "edge";
 export const maxDuration = 120;
@@ -22,6 +23,8 @@ export const maxDuration = 120;
 export async function GET(req: NextRequest) {
   const unauth = requireCronAuth(req);
   if (unauth) return unauth;
+  const gated = await checkAutopilotGate("weekly-newsletter");
+  if (gated) return gated;
 
   const resendApiKey = process.env.RESEND_API_KEY;
   if (!resendApiKey) {

--- a/app/api/cron/welcome-drip/route.ts
+++ b/app/api/cron/welcome-drip/route.ts
@@ -7,6 +7,7 @@ import {
   checkInEmail,
 } from "@/lib/email-templates";
 import { requireCronAuth } from "@/lib/cron-auth";
+import { checkAutopilotGate } from "@/lib/autopilot";
 
 export const runtime = "edge";
 export const maxDuration = 60;
@@ -26,6 +27,8 @@ export const maxDuration = 60;
 export async function GET(req: NextRequest) {
   const unauth = requireCronAuth(req);
   if (unauth) return unauth;
+  const gated = await checkAutopilotGate("welcome-drip");
+  if (gated) return gated;
 
   const supabase = createAdminClient();
 

--- a/lib/autopilot.ts
+++ b/lib/autopilot.ts
@@ -1,0 +1,100 @@
+/**
+ * Autopilot gate — reads site_settings to decide whether a cron automation
+ * should execute. The admin UI at /admin/autopilot writes two keys per
+ * automation: "autopilot_enabled" (master switch) and "autopilot_<id>"
+ * (per-automation toggle). Both must be truthy for the automation to run.
+ *
+ * Without this gate the admin toggles were cosmetic — they saved to DB but
+ * the cron routes never read them. Audit §5 item 16 (2026-05-20).
+ *
+ * Usage inside a cron GET handler (after requireCronAuth):
+ *
+ *   const gateResult = await checkAutopilotGate("check-fees");
+ *   if (gateResult) return gateResult;      // returns 503 JSON when disabled
+ *   // … do the work …
+ */
+
+import { NextResponse } from "next/server";
+// eslint-disable-next-line no-restricted-imports -- site_settings is service-role-only (no anon SELECT policy) per CLAUDE.md § "Tables with service_role-only policies"
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+
+const log = logger("autopilot");
+
+const CACHE_TTL_MS = 30_000;
+
+interface CacheEntry {
+  masterEnabled: boolean;
+  perAutomation: Record<string, boolean>;
+  at: number;
+}
+
+let cache: CacheEntry | null = null;
+
+async function loadSettings(): Promise<Pick<CacheEntry, "masterEnabled" | "perAutomation">> {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("site_settings")
+    .select("key, value")
+    .like("key", "autopilot%");
+
+  if (error) {
+    log.warn("autopilot-settings-read-failed (defaulting to enabled)", { err: error.message });
+    return { masterEnabled: true, perAutomation: {} };
+  }
+
+  let masterEnabled = true;
+  const perAutomation: Record<string, boolean> = {};
+
+  for (const row of data ?? []) {
+    if (row.key === "autopilot_enabled") {
+      masterEnabled = (row.value as string) !== "false";
+    } else {
+      const id = (row.key as string).replace("autopilot_", "");
+      perAutomation[id] = (row.value as string) !== "false";
+    }
+  }
+
+  return { masterEnabled, perAutomation };
+}
+
+/**
+ * Call immediately after `requireCronAuth`. Returns a NextResponse (503) if
+ * the automation is disabled via the admin UI, or null if it should run.
+ *
+ * Fail-open: if the DB read fails, the cron proceeds as normal so a Supabase
+ * outage doesn't silence all automations.
+ */
+export async function checkAutopilotGate(id: string): Promise<NextResponse | null> {
+  const now = Date.now();
+
+  if (!cache || now - cache.at > CACHE_TTL_MS) {
+    const settings = await loadSettings();
+    cache = { ...settings, at: now };
+  }
+
+  if (!cache.masterEnabled) {
+    log.info("autopilot-master-disabled", { id });
+    return NextResponse.json(
+      { skipped: true, reason: "autopilot_master_disabled" },
+      { status: 503 },
+    );
+  }
+
+  // Per-automation toggle defaults to enabled when no setting exists
+  const perEnabled = cache.perAutomation[id] ?? true;
+  if (!perEnabled) {
+    log.info("autopilot-automation-disabled", { id });
+    return NextResponse.json(
+      { skipped: true, reason: `autopilot_${id}_disabled` },
+      { status: 503 },
+    );
+  }
+
+  return null;
+}
+
+/** Test-only — reset the in-process cache between test cases. */
+export function _resetAutopilotCache(): void {
+  cache = null;
+}


### PR DESCRIPTION
## Summary

Closes audit §5 item 16 (P2 — Autopilot toggles DB-backed or removed).

The admin UI at `/admin/autopilot` has always saved toggle state to `site_settings` (keys: `autopilot_enabled` master, `autopilot_<id>` per-automation). But the 11 cron routes it controls never **read** those settings — the toggles were cosmetic. Disabling a toggle appeared to work but the cron ran regardless on the next Vercel invocation.

**Changes:**
- New `lib/autopilot.ts` — `checkAutopilotGate(id)` helper reads `site_settings` with a 30-second in-process cache. Checks master switch then per-automation toggle. Returns a 503 `{ skipped: true, reason }` when disabled. Fail-open on DB error (Supabase outage doesn't silence all automations).
- Added `checkAutopilotGate("<id>")` to all 11 cron routes matching the AUTOMATIONS constant in the admin UI, immediately after the existing `requireCronAuth` guard.

**Cron routes updated:** check-fees, expire-deals, marketplace-stats, quiz-follow-up, auto-publish, content-staleness, check-affiliate-links, low-balance-alerts, welcome-drip, weekly-newsletter, retry-webhooks.

**Pattern:** Mirrors `lib/ai-cost-caps.ts` exactly (same cache, same fail-open logic).

## Tier

**Tier B** — touches cron route handlers. 15-minute observation window applies.

## Supersedes

_None._

Refs: audit §5 item 16 (`docs/audits/2026-05-20-new-features-audit.md`)
Queue: NF-16

---
_Generated by [Claude Code](https://claude.ai/code/session_01BHCLvS4HDCVq2S1vUwXEpN)_