### PR TITLE
fix(nf): wire autopilot toggles so crons respect site_settings flags (audit §5 #16)

### DIFF
--- a/__tests__/lib/autopilot.test.ts
+++ b/__tests__/lib/autopilot.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const mockFrom = vi.fn();
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+import { isAutomationEnabled } from "@/lib/autopilot";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function mockSettings(rows: { key: string; value: string }[] | null, error?: object) {
+  const inBuilder = {
+    select: vi.fn().mockReturnThis(),
+    in: vi.fn().mockResolvedValue({ data: rows, error: error ?? null }),
+  };
+  mockFrom.mockReturnValue(inBuilder);
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("isAutomationEnabled", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns true when no settings exist (default enabled)", async () => {
+    mockSettings([]);
+    expect(await isAutomationEnabled("check-fees")).toBe(true);
+  });
+
+  it("returns true when both toggles are 'true'", async () => {
+    mockSettings([
+      { key: "autopilot_enabled", value: "true" },
+      { key: "autopilot_check-fees", value: "true" },
+    ]);
+    expect(await isAutomationEnabled("check-fees")).toBe(true);
+  });
+
+  it("returns false when master toggle is 'false'", async () => {
+    mockSettings([{ key: "autopilot_enabled", value: "false" }]);
+    expect(await isAutomationEnabled("check-fees")).toBe(false);
+  });
+
+  it("returns false when per-automation toggle is 'false'", async () => {
+    mockSettings([
+      { key: "autopilot_enabled", value: "true" },
+      { key: "autopilot_expire-deals", value: "false" },
+    ]);
+    expect(await isAutomationEnabled("expire-deals")).toBe(false);
+  });
+
+  it("returns false when only per-automation toggle present and false", async () => {
+    mockSettings([{ key: "autopilot_weekly-newsletter", value: "false" }]);
+    expect(await isAutomationEnabled("weekly-newsletter")).toBe(false);
+  });
+
+  it("returns true (fail-open) on DB error", async () => {
+    mockSettings(null, { message: "connection refused" });
+    expect(await isAutomationEnabled("auto-publish")).toBe(true);
+  });
+
+  it("returns true (fail-open) when DB throws", async () => {
+    mockFrom.mockImplementation(() => {
+      throw new Error("timeout");
+    });
+    expect(await isAutomationEnabled("marketplace-stats")).toBe(true);
+  });
+});

--- a/app/api/cron/auto-publish/route.ts
+++ b/app/api/cron/auto-publish/route.ts
@@ -1,6 +1,7 @@
 import { createAdminClient } from "@/lib/supabase/admin";
 import { NextRequest, NextResponse } from "next/server";
 import { requireCronAuth } from "@/lib/cron-auth";
+import { isAutomationEnabled } from "@/lib/autopilot";
 
 export const runtime = "edge";
 export const maxDuration = 30;
@@ -13,6 +14,10 @@ export const maxDuration = 30;
 export async function GET(req: NextRequest) {
   const unauth = requireCronAuth(req);
   if (unauth) return unauth;
+
+  if (!await isAutomationEnabled("auto-publish")) {
+    return NextResponse.json({ ok: true, message: "autopilot paused — skipping" });
+  }
 
   const supabase = createAdminClient();
 

--- a/app/api/cron/check-affiliate-links/route.ts
+++ b/app/api/cron/check-affiliate-links/route.ts
@@ -2,6 +2,7 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { NextRequest, NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 import { requireCronAuth } from "@/lib/cron-auth";
+import { isAutomationEnabled } from "@/lib/autopilot";
 
 const log = logger("cron-affiliate");
 
@@ -21,6 +22,10 @@ export const maxDuration = 60;
 export async function GET(req: NextRequest) {
   const unauth = requireCronAuth(req);
   if (unauth) return unauth;
+
+  if (!await isAutomationEnabled("check-affiliate-links")) {
+    return NextResponse.json({ ok: true, message: "autopilot paused — skipping" });
+  }
 
   const supabase = createAdminClient();
 

--- a/app/api/cron/check-fees/route.ts
+++ b/app/api/cron/check-fees/route.ts
@@ -4,6 +4,7 @@ import { getAdminEmail } from "@/lib/admin";
 import { feeChangeAlertEmail } from "@/lib/email-templates";
 import { logger } from "@/lib/logger";
 import { requireCronAuth } from "@/lib/cron-auth";
+import { isAutomationEnabled } from "@/lib/autopilot";
 import { buildEmailToUserIdMap, notifyUser } from "@/lib/notifications";
 import { sendEmail } from "@/lib/resend";
 
@@ -36,6 +37,10 @@ function extractFees(text: string): Record<string, string> {
 export async function GET(req: NextRequest) {
   const unauth = requireCronAuth(req);
   if (unauth) return unauth;
+
+  if (!await isAutomationEnabled("check-fees")) {
+    return NextResponse.json({ ok: true, message: "autopilot paused — skipping" });
+  }
 
   const supabase = createAdminClient();
 

--- a/app/api/cron/content-staleness/route.ts
+++ b/app/api/cron/content-staleness/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getAdminEmail } from "@/lib/admin";
 import { logger } from "@/lib/logger";
 import { requireCronAuth } from "@/lib/cron-auth";
+import { isAutomationEnabled } from "@/lib/autopilot";
 
 const log = logger("cron-content-staleness");
 
@@ -22,6 +23,10 @@ export const maxDuration = 60;
 export async function GET(req: NextRequest) {
   const unauth = requireCronAuth(req);
   if (unauth) return unauth;
+
+  if (!await isAutomationEnabled("content-staleness")) {
+    return NextResponse.json({ ok: true, message: "autopilot paused — skipping" });
+  }
 
   const supabase = createAdminClient();
 

--- a/app/api/cron/expire-deals/route.ts
+++ b/app/api/cron/expire-deals/route.ts
@@ -2,6 +2,7 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { NextRequest, NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 import { requireCronAuth } from "@/lib/cron-auth";
+import { isAutomationEnabled } from "@/lib/autopilot";
 
 const log = logger("cron-deals");
 
@@ -18,6 +19,10 @@ export const maxDuration = 60;
 export async function GET(req: NextRequest) {
   const unauth = requireCronAuth(req);
   if (unauth) return unauth;
+
+  if (!await isAutomationEnabled("expire-deals")) {
+    return NextResponse.json({ ok: true, message: "autopilot paused — skipping" });
+  }
 
   const supabase = createAdminClient();
 

--- a/app/api/cron/low-balance-alerts/route.ts
+++ b/app/api/cron/low-balance-alerts/route.ts
@@ -2,6 +2,7 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { NextRequest, NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 import { requireCronAuth } from "@/lib/cron-auth";
+import { isAutomationEnabled } from "@/lib/autopilot";
 
 const log = logger("cron-low-balance");
 
@@ -21,6 +22,10 @@ export const maxDuration = 60;
 export async function GET(req: NextRequest) {
   const unauth = requireCronAuth(req);
   if (unauth) return unauth;
+
+  if (!await isAutomationEnabled("low-balance-alerts")) {
+    return NextResponse.json({ ok: true, message: "autopilot paused — skipping" });
+  }
 
   const supabase = createAdminClient();
 

--- a/app/api/cron/marketplace-stats/route.ts
+++ b/app/api/cron/marketplace-stats/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { calculateOptimalBids, applyBidAdjustments } from "@/lib/marketplace/auto-bid";
 import { logger } from "@/lib/logger";
 import { requireCronAuth } from "@/lib/cron-auth";
+import { isAutomationEnabled } from "@/lib/autopilot";
 
 const log = logger("cron-marketplace-stats");
 
@@ -20,6 +21,10 @@ export const maxDuration = 60;
 export async function GET(req: NextRequest) {
   const unauth = requireCronAuth(req);
   if (unauth) return unauth;
+
+  if (!await isAutomationEnabled("marketplace-stats")) {
+    return NextResponse.json({ ok: true, message: "autopilot paused — skipping" });
+  }
 
   const supabase = createAdminClient();
 

--- a/app/api/cron/quiz-follow-up/route.ts
+++ b/app/api/cron/quiz-follow-up/route.ts
@@ -7,6 +7,7 @@ import {
 } from "@/lib/email-templates";
 import { logger } from "@/lib/logger";
 import { requireCronAuth } from "@/lib/cron-auth";
+import { isAutomationEnabled } from "@/lib/autopilot";
 
 const log = logger("quiz-followup");
 
@@ -28,6 +29,10 @@ export const maxDuration = 60;
 export async function GET(req: NextRequest) {
   const unauth = requireCronAuth(req);
   if (unauth) return unauth;
+
+  if (!await isAutomationEnabled("quiz-follow-up")) {
+    return NextResponse.json({ ok: true, message: "autopilot paused — skipping" });
+  }
 
   const supabase = createAdminClient();
 

--- a/app/api/cron/retry-webhooks/route.ts
+++ b/app/api/cron/retry-webhooks/route.ts
@@ -1,6 +1,7 @@
 import { createAdminClient } from "@/lib/supabase/admin";
 import { NextRequest, NextResponse } from "next/server";
 import { requireCronAuth } from "@/lib/cron-auth";
+import { isAutomationEnabled } from "@/lib/autopilot";
 
 export const runtime = "edge";
 export const maxDuration = 60;
@@ -29,6 +30,10 @@ const BACKOFF_DELAYS_MS = [
 export async function GET(req: NextRequest) {
   const unauth = requireCronAuth(req);
   if (unauth) return unauth;
+
+  if (!await isAutomationEnabled("retry-webhooks")) {
+    return NextResponse.json({ ok: true, message: "autopilot paused — skipping" });
+  }
 
   const supabase = createAdminClient();
 

--- a/app/api/cron/weekly-newsletter/route.ts
+++ b/app/api/cron/weekly-newsletter/route.ts
@@ -2,6 +2,7 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { weeklyDigestEmail } from "@/lib/email-templates";
 import { NextRequest, NextResponse } from "next/server";
 import { requireCronAuth } from "@/lib/cron-auth";
+import { isAutomationEnabled } from "@/lib/autopilot";
 
 export const runtime = "edge";
 export const maxDuration = 120;
@@ -22,6 +23,10 @@ export const maxDuration = 120;
 export async function GET(req: NextRequest) {
   const unauth = requireCronAuth(req);
   if (unauth) return unauth;
+
+  if (!await isAutomationEnabled("weekly-newsletter")) {
+    return NextResponse.json({ ok: true, message: "autopilot paused — skipping" });
+  }
 
   const resendApiKey = process.env.RESEND_API_KEY;
   if (!resendApiKey) {

--- a/app/api/cron/welcome-drip/route.ts
+++ b/app/api/cron/welcome-drip/route.ts
@@ -7,6 +7,7 @@ import {
   checkInEmail,
 } from "@/lib/email-templates";
 import { requireCronAuth } from "@/lib/cron-auth";
+import { isAutomationEnabled } from "@/lib/autopilot";
 
 export const runtime = "edge";
 export const maxDuration = 60;
@@ -26,6 +27,10 @@ export const maxDuration = 60;
 export async function GET(req: NextRequest) {
   const unauth = requireCronAuth(req);
   if (unauth) return unauth;
+
+  if (!await isAutomationEnabled("welcome-drip")) {
+    return NextResponse.json({ ok: true, message: "autopilot paused — skipping" });
+  }
 
   const supabase = createAdminClient();
 

--- a/lib/autopilot.ts
+++ b/lib/autopilot.ts
@@ -1,0 +1,43 @@
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+
+// eslint-disable-next-line no-restricted-imports -- site_settings is service-role-only config
+const log = logger("autopilot");
+
+/**
+ * Returns true when the automation is allowed to run.
+ *
+ * Two checks in one DB round-trip:
+ *   - `autopilot_enabled`        — master kill-switch (default true when absent)
+ *   - `autopilot_${automationId}` — per-automation toggle (default true when absent)
+ *
+ * Fails open on DB errors so a transient Supabase outage doesn't halt
+ * production crons. The setting values are the strings "true" / "false" as
+ * set by the admin autopilot dashboard.
+ */
+export async function isAutomationEnabled(automationId: string): Promise<boolean> {
+  try {
+    const supabase = createAdminClient();
+    const { data: rows } = await supabase
+      .from("site_settings")
+      .select("key, value")
+      .in("key", ["autopilot_enabled", `autopilot_${automationId}`]);
+
+    if (!rows) return true;
+
+    const byKey = Object.fromEntries(
+      rows.map((r) => [r.key as string, r.value as string]),
+    );
+
+    if (byKey["autopilot_enabled"] === "false") return false;
+    if (byKey[`autopilot_${automationId}`] === "false") return false;
+
+    return true;
+  } catch (err) {
+    log.warn("autopilot check failed — failing open", {
+      automationId,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return true;
+  }
+}


### PR DESCRIPTION
## Closing — superseded by #1178

This PR is a duplicate of #1178 (opened by a concurrent loop fire seconds earlier). Both implement the same NF-16 fix: wiring `site_settings` autopilot toggles into the 11 cron routes. PR #1178 has a better implementation (30s in-process cache, LIKE query for all autopilot keys, `NextResponse | null` return type). Closing this one to avoid merge conflicts.

The test file added in this branch (`__tests__/lib/autopilot.test.ts`) uses `isAutomationEnabled` which doesn't exist in #1178's API — no direct cherry-pick. #1178 exports `_resetAutopilotCache()` which enables equivalent tests to be written against `checkAutopilotGate`.

## Supersedes

_None. Superseded by #1178._