### PR TITLE
test(disc): apply/[id]/applications/fee-index route coverage (27 cases)

### DIFF
--- a/__tests__/api/careers-jobs-apply.test.ts
+++ b/__tests__/api/careers-jobs-apply.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createChainableBuilder, makeRequest } from "@/__tests__/helpers";
+import { NextRequest } from "next/server";
+
+// ── Hoisted mocks ─────────────────────────────────────────────────────────────
+
+const { mockIsRateLimited, mockServerFrom } = vi.hoisted(() => ({
+  mockIsRateLimited: vi.fn().mockResolvedValue(false),
+  mockServerFrom: vi.fn(),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  isRateLimited: (...a: unknown[]) => mockIsRateLimited(...a),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(() => Promise.resolve({ from: mockServerFrom })),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+import { POST } from "@/app/api/careers/jobs/apply/route";
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const VALID_JOB_ID = "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11";
+
+const VALID_BODY = {
+  job_id: VALID_JOB_ID,
+  applicant_name: "Jane Smith",
+  applicant_email: "jane@example.com",
+  message: "I am very interested in this position and have five years of relevant experience.",
+};
+
+const ACTIVE_JOB = { id: VALID_JOB_ID, status: "active" };
+
+// ── Mock setup helper ─────────────────────────────────────────────────────────
+
+function setupMocks({
+  job = ACTIVE_JOB as { id: string; status: string } | null,
+  jobError = null as { message: string } | null,
+  insertError = null as { message: string } | null,
+} = {}) {
+  mockServerFrom.mockImplementation((table: string) => {
+    const b = createChainableBuilder(table);
+    if (table === "job_posts") {
+      b.maybeSingle = vi.fn().mockResolvedValue({ data: jobError ? null : job, error: jobError });
+    } else if (table === "job_applications") {
+      b.then = vi.fn((cb: (v: unknown) => void) => {
+        cb({ data: null, error: insertError });
+        return Promise.resolve();
+      });
+    }
+    return b;
+  });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("POST /api/careers/jobs/apply", () => {
+  function makePost(body: Record<string, unknown>): NextRequest {
+    return makeRequest("/api/careers/jobs/apply", body);
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsRateLimited.mockResolvedValue(false);
+    setupMocks();
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    mockIsRateLimited.mockResolvedValueOnce(true);
+    expect((await POST(makePost(VALID_BODY))).status).toBe(429);
+  });
+
+  it("returns 400 for invalid UUID job_id", async () => {
+    expect((await POST(makePost({ ...VALID_BODY, job_id: "not-a-uuid" }))).status).toBe(400);
+  });
+
+  it("returns 400 when required fields are missing", async () => {
+    expect((await POST(makePost({ job_id: VALID_JOB_ID }))).status).toBe(400);
+  });
+
+  it("returns 400 for invalid email", async () => {
+    expect((await POST(makePost({ ...VALID_BODY, applicant_email: "not-an-email" }))).status).toBe(400);
+  });
+
+  it("returns 400 when message is too short", async () => {
+    expect((await POST(makePost({ ...VALID_BODY, message: "Short" }))).status).toBe(400);
+  });
+
+  it("returns 500 on DB error looking up job", async () => {
+    setupMocks({ jobError: { message: "connection refused" } });
+    expect((await POST(makePost(VALID_BODY))).status).toBe(500);
+  });
+
+  it("returns 404 when job is not found or not active", async () => {
+    setupMocks({ job: null });
+    expect((await POST(makePost(VALID_BODY))).status).toBe(404);
+  });
+
+  it("returns 500 on insert error", async () => {
+    setupMocks({ insertError: { message: "constraint violation" } });
+    expect((await POST(makePost(VALID_BODY))).status).toBe(500);
+  });
+
+  it("returns 200 with ok:true on successful submission", async () => {
+    const res = await POST(makePost(VALID_BODY));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+  });
+});

--- a/__tests__/api/cron-fee-index.test.ts
+++ b/__tests__/api/cron-fee-index.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Hoisted mocks ─────────────────────────────────────────────────────────────
+
+const {
+  mockRequireCronAuth,
+  mockReadRecentBrokerSnapshots,
+  mockComputeFeeIndex,
+  mockUpsertFeeIndexSnapshot,
+  mockUtcDay,
+} = vi.hoisted(() => ({
+  mockRequireCronAuth: vi.fn().mockReturnValue(null),
+  mockReadRecentBrokerSnapshots: vi.fn().mockResolvedValue([]),
+  mockComputeFeeIndex: vi.fn(),
+  mockUpsertFeeIndexSnapshot: vi.fn().mockResolvedValue({ ok: true }),
+  mockUtcDay: vi.fn().mockReturnValue("2026-05-24"),
+}));
+
+vi.mock("@/lib/cron-run-log", () => ({
+  wrapCronHandler: (_name: string, h: unknown) => h,
+}));
+
+vi.mock("@/lib/cron-auth", () => ({
+  requireCronAuth: (...a: unknown[]) => mockRequireCronAuth(...a),
+}));
+
+vi.mock("@/lib/fee-index", () => ({
+  readRecentBrokerSnapshots: (...a: unknown[]) => mockReadRecentBrokerSnapshots(...a),
+  computeFeeIndex: (...a: unknown[]) => mockComputeFeeIndex(...a),
+  upsertFeeIndexSnapshot: (...a: unknown[]) => mockUpsertFeeIndexSnapshot(...a),
+  utcDay: (...a: unknown[]) => mockUtcDay(...a),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+import { GET } from "@/app/api/cron/fee-index/route";
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const COMPUTATION_ZERO = {
+  period: "2026-05-24",
+  brokerCount: 0,
+  asxFee: { mean: null, median: null, sample: 0 },
+  usFee: { mean: null, median: null, sample: 0 },
+  fxSpread: { mean: null, median: null, sample: 0 },
+};
+
+const COMPUTATION_WITH_BROKERS = {
+  period: "2026-05-24",
+  brokerCount: 3,
+  asxFee: { mean: 9.5, median: 9.95, sample: 3 },
+  usFee: { mean: 0, median: 0, sample: 3 },
+  fxSpread: { mean: 0.006, median: 0.006, sample: 3 },
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeGet(): NextRequest {
+  return new NextRequest("http://localhost/api/cron/fee-index", {
+    method: "GET",
+    headers: { Authorization: "Bearer test-cron-secret" },
+  });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("GET /api/cron/fee-index", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireCronAuth.mockReturnValue(null);
+    mockReadRecentBrokerSnapshots.mockResolvedValue([]);
+    mockComputeFeeIndex.mockReturnValue(COMPUTATION_WITH_BROKERS);
+    mockUpsertFeeIndexSnapshot.mockResolvedValue({ ok: true });
+    mockUtcDay.mockReturnValue("2026-05-24");
+  });
+
+  it("returns 401 when cron auth fails", async () => {
+    const { NextResponse } = await import("next/server");
+    mockRequireCronAuth.mockReturnValueOnce(
+      NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    );
+    expect((await GET(makeGet())).status).toBe(401);
+  });
+
+  it("returns 200 with persisted:false when no broker snapshots exist", async () => {
+    mockComputeFeeIndex.mockReturnValueOnce(COMPUTATION_ZERO);
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+    expect(json.brokerCount).toBe(0);
+    expect(json.persisted).toBe(false);
+    expect(mockUpsertFeeIndexSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 when upsert fails", async () => {
+    mockUpsertFeeIndexSnapshot.mockResolvedValueOnce({
+      ok: false,
+      error: "unique constraint violation",
+    });
+    const res = await GET(makeGet());
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.ok).toBe(false);
+  });
+
+  it("returns 200 with broker stats on success", async () => {
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+    expect(json.persisted).toBe(true);
+    expect(json.brokerCount).toBe(3);
+    expect(json.period).toBe("2026-05-24");
+  });
+});

--- a/__tests__/api/firm-portal-job-id.test.ts
+++ b/__tests__/api/firm-portal-job-id.test.ts
@@ -1,0 +1,283 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { makeRequest, createChainableBuilder } from "@/__tests__/helpers";
+
+// ── Hoisted mocks ─────────────────────────────────────────────────────────────
+
+const { mockIsRateLimited, mockGetUser, mockAdminFrom } = vi.hoisted(() => ({
+  mockIsRateLimited: vi.fn().mockResolvedValue(false),
+  mockGetUser: vi.fn().mockResolvedValue({ data: { user: { id: "user-1" } } }),
+  mockAdminFrom: vi.fn(),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  isRateLimited: (...a: unknown[]) => mockIsRateLimited(...a),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(() =>
+    Promise.resolve({ auth: { getUser: mockGetUser } }),
+  ),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+import { PATCH, DELETE } from "@/app/api/firm-portal/jobs/[id]/route";
+import { GET as GET_APPS } from "@/app/api/firm-portal/jobs/[id]/applications/route";
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const FIRM_PRO = {
+  firm_id: "firm-1",
+  is_firm_admin: true,
+  status: "active",
+};
+
+const OWNED_JOB = { id: "job-uuid-1" };
+
+const UPDATED_JOB = {
+  id: "job-uuid-1",
+  title: "Updated Advisor",
+  location: "Brisbane QLD",
+  type: "full_time",
+  description: "Updated description that is long enough.",
+  status: "active",
+  updated_at: "2026-05-24T00:00:00Z",
+};
+
+const APPLICATIONS = [
+  {
+    id: 1,
+    applicant_name: "Bob Jones",
+    applicant_email: "bob@example.com",
+    message: "Interested.",
+    created_at: "2026-05-24T00:00:00Z",
+  },
+];
+
+// ── Mock setup helper ─────────────────────────────────────────────────────────
+
+function setupMocks({
+  firmPro = FIRM_PRO as Record<string, unknown> | null,
+  ownsJob = true,
+  updatedJob = UPDATED_JOB as unknown,
+  updateError = null as { message: string } | null,
+  archiveError = null as { message: string } | null,
+  applications = APPLICATIONS as unknown[],
+  appsError = null as { message: string } | null,
+} = {}) {
+  mockAdminFrom.mockImplementation((table: string) => {
+    const b = createChainableBuilder(table);
+
+    if (table === "professionals") {
+      b.maybeSingle = vi.fn().mockResolvedValue({ data: firmPro, error: null });
+    } else if (table === "job_posts") {
+      // ownership check (assertOwnership) → maybeSingle
+      b.maybeSingle = vi.fn().mockResolvedValue({
+        data: ownsJob ? OWNED_JOB : null,
+        error: null,
+      });
+      // PATCH update → single
+      b.single = vi.fn().mockResolvedValue({
+        data: updateError ? null : updatedJob,
+        error: updateError,
+      });
+      // DELETE archive → awaited chain (then)
+      b.then = vi.fn((cb: (v: unknown) => void) => {
+        cb({ data: null, error: archiveError });
+        return Promise.resolve();
+      });
+    } else if (table === "job_applications") {
+      b.then = vi.fn((cb: (v: unknown) => void) => {
+        cb({ data: appsError ? null : applications, error: appsError });
+        return Promise.resolve();
+      });
+    }
+
+    return b;
+  });
+}
+
+// ── Route context helper ──────────────────────────────────────────────────────
+
+function makeCtx(id = "job-uuid-1") {
+  return { params: Promise.resolve({ id }) };
+}
+
+// ── PATCH /api/firm-portal/jobs/[id] ─────────────────────────────────────────
+
+describe("PATCH /api/firm-portal/jobs/[id]", () => {
+  const VALID_PATCH = { title: "Updated Advisor" };
+
+  function makePatch(body: Record<string, unknown>): NextRequest {
+    return makeRequest("/api/firm-portal/jobs/job-uuid-1", body, { method: "PATCH" });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsRateLimited.mockResolvedValue(false);
+    mockGetUser.mockResolvedValue({ data: { user: { id: "user-1" } } });
+    setupMocks();
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    mockIsRateLimited.mockResolvedValueOnce(true);
+    expect((await PATCH(makePatch(VALID_PATCH), makeCtx())).status).toBe(429);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: null } });
+    expect((await PATCH(makePatch(VALID_PATCH), makeCtx())).status).toBe(401);
+  });
+
+  it("returns 403 when caller is not a firm admin", async () => {
+    setupMocks({ firmPro: null });
+    expect((await PATCH(makePatch(VALID_PATCH), makeCtx())).status).toBe(403);
+  });
+
+  it("returns 404 when job is not owned by the firm", async () => {
+    setupMocks({ ownsJob: false });
+    expect((await PATCH(makePatch(VALID_PATCH), makeCtx())).status).toBe(404);
+  });
+
+  it("returns 400 for invalid employment type", async () => {
+    const res = await PATCH(makePatch({ type: "gig_economy" }), makeCtx());
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 500 on DB update error", async () => {
+    setupMocks({ updateError: { message: "constraint violation" } });
+    expect((await PATCH(makePatch(VALID_PATCH), makeCtx())).status).toBe(500);
+  });
+
+  it("returns 200 with updated job on success", async () => {
+    const res = await PATCH(makePatch(VALID_PATCH), makeCtx());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.job).toBeDefined();
+    expect(json.job.id).toBe("job-uuid-1");
+  });
+});
+
+// ── DELETE /api/firm-portal/jobs/[id] ────────────────────────────────────────
+
+describe("DELETE /api/firm-portal/jobs/[id]", () => {
+  function makeDelete(): NextRequest {
+    return new NextRequest("http://localhost/api/firm-portal/jobs/job-uuid-1", {
+      method: "DELETE",
+      headers: { "x-forwarded-for": "5.6.7.8" },
+    });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsRateLimited.mockResolvedValue(false);
+    mockGetUser.mockResolvedValue({ data: { user: { id: "user-1" } } });
+    setupMocks();
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    mockIsRateLimited.mockResolvedValueOnce(true);
+    expect((await DELETE(makeDelete(), makeCtx())).status).toBe(429);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: null } });
+    expect((await DELETE(makeDelete(), makeCtx())).status).toBe(401);
+  });
+
+  it("returns 403 when caller is not a firm admin", async () => {
+    setupMocks({ firmPro: null });
+    expect((await DELETE(makeDelete(), makeCtx())).status).toBe(403);
+  });
+
+  it("returns 404 when job is not owned by the firm", async () => {
+    setupMocks({ ownsJob: false });
+    expect((await DELETE(makeDelete(), makeCtx())).status).toBe(404);
+  });
+
+  it("returns 500 on DB archive error", async () => {
+    setupMocks({ archiveError: { message: "write failed" } });
+    expect((await DELETE(makeDelete(), makeCtx())).status).toBe(500);
+  });
+
+  it("returns 200 with ok:true on successful archive", async () => {
+    const res = await DELETE(makeDelete(), makeCtx());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+  });
+});
+
+// ── GET /api/firm-portal/jobs/[id]/applications ───────────────────────────────
+
+describe("GET /api/firm-portal/jobs/[id]/applications", () => {
+  function makeGet(): NextRequest {
+    return new NextRequest(
+      "http://localhost/api/firm-portal/jobs/job-uuid-1/applications",
+      {
+        method: "GET",
+        headers: { "x-forwarded-for": "5.6.7.8" },
+      },
+    );
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsRateLimited.mockResolvedValue(false);
+    mockGetUser.mockResolvedValue({ data: { user: { id: "user-1" } } });
+    setupMocks();
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    mockIsRateLimited.mockResolvedValueOnce(true);
+    expect((await GET_APPS(makeGet(), makeCtx())).status).toBe(429);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: null } });
+    expect((await GET_APPS(makeGet(), makeCtx())).status).toBe(401);
+  });
+
+  it("returns 403 when caller is not a firm admin", async () => {
+    setupMocks({ firmPro: null });
+    expect((await GET_APPS(makeGet(), makeCtx())).status).toBe(403);
+  });
+
+  it("returns 404 when job is not owned by the firm", async () => {
+    setupMocks({ ownsJob: false });
+    expect((await GET_APPS(makeGet(), makeCtx())).status).toBe(404);
+  });
+
+  it("returns 500 on DB error fetching applications", async () => {
+    setupMocks({ appsError: { message: "connection refused" } });
+    expect((await GET_APPS(makeGet(), makeCtx())).status).toBe(500);
+  });
+
+  it("returns 200 with applications list on success", async () => {
+    const res = await GET_APPS(makeGet(), makeCtx());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.applications).toHaveLength(1);
+    expect(json.applications[0]?.applicant_name).toBe("Bob Jones");
+  });
+
+  it("returns 200 with empty array when no applications", async () => {
+    setupMocks({ applications: [] });
+    const res = await GET_APPS(makeGet(), makeCtx());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.applications).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds 27 vitest cases across 3 test files for the remaining zero-coverage routes from #1170 (merged 2026-05-23)
- Builds on #1182 which covers `careers/jobs` and `firm-portal/jobs` (GET+POST)

## What's tested

**`careers/jobs/apply` POST (9 cases):** 429 rate-limit, 400 Zod validation (invalid UUID, missing fields, bad email, short message), 500 job lookup DB error, 404 job not found/inactive, 500 insert error, 200 success.

**`firm-portal/jobs/[id]` PATCH (7 cases):** 429, 401 unauth, 403 not firm admin, 404 job not owned by firm, 400 invalid employment type, 500 DB update error, 200 success with updated job object.

**`firm-portal/jobs/[id]` DELETE (6 cases):** 429, 401, 403, 404 not owned, 500 archive DB error, 200 success with `ok:true`.

**`firm-portal/jobs/[id]/applications` GET (7 cases):** 429, 401, 403, 404 job not owned, 500 DB error, 200 with application list, 200 empty array.

**`cron/fee-index` GET (4 cases):** 401 cron auth failure, 200 zero-brokers (upsert skipped, `persisted:false`), 500 upsert failure, 200 success with broker count and fee stats.

## Mock notes

- Dynamic `[id]` route context: `{ params: Promise.resolve({ id }) }` matching `await ctx.params`
- Multi-table `mockAdminFrom` routes `professionals` → `maybeSingle` (firm admin resolution), `job_posts` → `maybeSingle` (ownership) + `single` (PATCH update) + `then` (DELETE archive), `job_applications` → `then` (list)
- `cron/fee-index` mocks `@/lib/fee-index` module functions directly; `wrapCronHandler` unwrapped to the raw handler

## Tier

**Tier A** — tests only, no production code changes.

https://claude.ai/code/session_01Fe25wL5VQrhTeHCxm1YgRV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fe25wL5VQrhTeHCxm1YgRV)_