### PR TITLE
test(disc): admin/advisor-kyc + admin/article-comments route coverage (19 cases)

### DIFF
--- a/__tests__/api/admin-advisor-kyc.test.ts
+++ b/__tests__/api/admin-advisor-kyc.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Hoisted mocks ─────────────────────────────────────────────────────────────
+
+const {
+  mockRequireAdmin,
+  mockListPendingKyc,
+  mockListKycDocuments,
+  mockVerifyKyc,
+  mockRejectKyc,
+  mockAdminFrom,
+} = vi.hoisted(() => ({
+  mockRequireAdmin: vi.fn(),
+  mockListPendingKyc: vi.fn(),
+  mockListKycDocuments: vi.fn(),
+  mockVerifyKyc: vi.fn(),
+  mockRejectKyc: vi.fn(),
+  mockAdminFrom: vi.fn(),
+}));
+
+vi.mock("@/lib/require-admin", () => ({
+  requireAdmin: () => mockRequireAdmin(),
+}));
+
+vi.mock("@/lib/advisor-kyc", () => ({
+  listPendingKyc: () => mockListPendingKyc(),
+  listKycDocuments: (id: number) => mockListKycDocuments(id),
+  verifyKyc: (opts: unknown) => mockVerifyKyc(opts),
+  rejectKyc: (opts: unknown) => mockRejectKyc(opts),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+
+import { GET, PATCH } from "@/app/api/admin/advisor-kyc/route";
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const ADMIN_GUARD = { ok: true as const, email: "admin@invest.com.au", response: undefined };
+const UNAUTH_GUARD = {
+  ok: false as const,
+  email: "",
+  response: new Response(JSON.stringify({ error: "Unauthorised" }), { status: 401 }),
+};
+
+const KYC_DOC = {
+  id: 1,
+  professional_id: 42,
+  document_type: "afsl_certificate",
+  storage_path: "advisor-kyc/42/cert.pdf",
+  status: "submitted",
+};
+
+function makeAuditChain() {
+  const insert = vi.fn().mockResolvedValue({ error: null });
+  mockAdminFrom.mockReturnValue({ insert });
+  return { insert };
+}
+
+// ── GET tests ─────────────────────────────────────────────────────────────────
+
+describe("GET /api/admin/advisor-kyc", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdmin.mockResolvedValue(ADMIN_GUARD);
+    mockListPendingKyc.mockResolvedValue([KYC_DOC]);
+  });
+
+  it("returns 401 when not admin", async () => {
+    mockRequireAdmin.mockResolvedValue(UNAUTH_GUARD);
+    const req = new NextRequest("http://localhost/api/admin/advisor-kyc");
+    const res = await GET(req);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns all pending docs when no professional_id param", async () => {
+    const req = new NextRequest("http://localhost/api/admin/advisor-kyc");
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.items).toHaveLength(1);
+    expect(json.items[0].id).toBe(1);
+    expect(mockListPendingKyc).toHaveBeenCalledOnce();
+    expect(mockListKycDocuments).not.toHaveBeenCalled();
+  });
+
+  it("returns docs for specific professional_id", async () => {
+    mockListKycDocuments.mockResolvedValue([KYC_DOC]);
+    const req = new NextRequest(
+      "http://localhost/api/admin/advisor-kyc?professional_id=42",
+    );
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.items).toHaveLength(1);
+    expect(mockListKycDocuments).toHaveBeenCalledWith(42);
+    expect(mockListPendingKyc).not.toHaveBeenCalled();
+  });
+});
+
+// ── PATCH tests ───────────────────────────────────────────────────────────────
+
+function makePatch(body: Record<string, unknown>): NextRequest {
+  return new NextRequest("http://localhost/api/admin/advisor-kyc", {
+    method: "PATCH",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("PATCH /api/admin/advisor-kyc", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdmin.mockResolvedValue(ADMIN_GUARD);
+    mockVerifyKyc.mockResolvedValue(true);
+    mockRejectKyc.mockResolvedValue(true);
+    makeAuditChain();
+  });
+
+  it("returns 401 when not admin", async () => {
+    mockRequireAdmin.mockResolvedValue(UNAUTH_GUARD);
+    const res = await PATCH(makePatch({ id: 1, action: "verify" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when id is missing", async () => {
+    const res = await PATCH(makePatch({ action: "verify" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when action is missing", async () => {
+    const res = await PATCH(makePatch({ id: 1 }));
+    expect(res.status).toBe(400);
+  });
+
+  it("verifies a KYC document and inserts audit log", async () => {
+    const { insert } = makeAuditChain();
+    const res = await PATCH(makePatch({ id: 1, action: "verify", notes: "Looks good" }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+    expect(mockVerifyKyc).toHaveBeenCalledWith({
+      id: 1,
+      verifiedBy: "admin@invest.com.au",
+      notes: "Looks good",
+    });
+    expect(insert).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "advisor_kyc:verified" }),
+    );
+  });
+
+  it("returns 400 when reject reason is too short", async () => {
+    const res = await PATCH(makePatch({ id: 1, action: "reject", reason: "no" }));
+    expect(res.status).toBe(400);
+    expect(mockRejectKyc).not.toHaveBeenCalled();
+  });
+
+  it("rejects a KYC document and inserts audit log", async () => {
+    const { insert } = makeAuditChain();
+    const res = await PATCH(
+      makePatch({ id: 1, action: "reject", reason: "Document unclear" }),
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+    expect(mockRejectKyc).toHaveBeenCalledWith({
+      id: 1,
+      verifiedBy: "admin@invest.com.au",
+      reason: "Document unclear",
+    });
+    expect(insert).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "advisor_kyc:rejected" }),
+    );
+  });
+
+  it("returns 400 for unknown action", async () => {
+    const res = await PATCH(makePatch({ id: 1, action: "approve" }));
+    expect(res.status).toBe(400);
+  });
+});

--- a/__tests__/api/admin-article-comments.test.ts
+++ b/__tests__/api/admin-article-comments.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Hoisted mocks ─────────────────────────────────────────────────────────────
+
+const {
+  mockRequireAdmin,
+  mockListPendingComments,
+  mockSetCommentStatus,
+  mockAdminFrom,
+} = vi.hoisted(() => ({
+  mockRequireAdmin: vi.fn(),
+  mockListPendingComments: vi.fn(),
+  mockSetCommentStatus: vi.fn(),
+  mockAdminFrom: vi.fn(),
+}));
+
+vi.mock("@/lib/require-admin", () => ({
+  requireAdmin: () => mockRequireAdmin(),
+}));
+
+vi.mock("@/lib/article-comments", () => ({
+  listPendingComments: () => mockListPendingComments(),
+  setCommentStatus: (opts: unknown) => mockSetCommentStatus(opts),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+
+import { GET, PATCH } from "@/app/api/admin/article-comments/route";
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const ADMIN_GUARD = { ok: true as const, email: "admin@invest.com.au", response: undefined };
+const UNAUTH_GUARD = {
+  ok: false as const,
+  email: "",
+  response: new Response(JSON.stringify({ error: "Unauthorised" }), { status: 401 }),
+};
+
+const PENDING_COMMENT = {
+  id: 7,
+  article_slug: "best-brokers-2026",
+  author_name: "Jane Doe",
+  body: "Great review!",
+  status: "pending",
+  created_at: "2026-05-24T00:00:00Z",
+};
+
+function makeAuditChain() {
+  const insert = vi.fn().mockResolvedValue({ error: null });
+  mockAdminFrom.mockReturnValue({ insert });
+  return { insert };
+}
+
+// ── GET tests ─────────────────────────────────────────────────────────────────
+
+describe("GET /api/admin/article-comments", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdmin.mockResolvedValue(ADMIN_GUARD);
+    mockListPendingComments.mockResolvedValue([PENDING_COMMENT]);
+  });
+
+  it("returns 401 when not admin", async () => {
+    mockRequireAdmin.mockResolvedValue(UNAUTH_GUARD);
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
+  it("returns pending comments list", async () => {
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.items).toHaveLength(1);
+    expect(json.items[0].id).toBe(7);
+    expect(mockListPendingComments).toHaveBeenCalledOnce();
+  });
+});
+
+// ── PATCH tests ───────────────────────────────────────────────────────────────
+
+function makePatch(body: Record<string, unknown>): NextRequest {
+  return new NextRequest("http://localhost/api/admin/article-comments", {
+    method: "PATCH",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("PATCH /api/admin/article-comments", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdmin.mockResolvedValue(ADMIN_GUARD);
+    mockSetCommentStatus.mockResolvedValue(true);
+    makeAuditChain();
+  });
+
+  it("returns 401 when not admin", async () => {
+    mockRequireAdmin.mockResolvedValue(UNAUTH_GUARD);
+    const res = await PATCH(makePatch({ id: 7, action: "publish" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when id is missing", async () => {
+    const res = await PATCH(makePatch({ action: "publish" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when action is missing", async () => {
+    const res = await PATCH(makePatch({ id: 7 }));
+    expect(res.status).toBe(400);
+  });
+
+  it("publishes a comment and returns published status", async () => {
+    const { insert } = makeAuditChain();
+    const res = await PATCH(makePatch({ id: 7, action: "publish" }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+    expect(json.status).toBe("published");
+    expect(mockSetCommentStatus).toHaveBeenCalledWith({
+      id: 7,
+      status: "published",
+      moderatorEmail: "admin@invest.com.au",
+    });
+    expect(insert).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "article_comment:publish" }),
+    );
+  });
+
+  it("rejects a comment and returns rejected status", async () => {
+    makeAuditChain();
+    const res = await PATCH(makePatch({ id: 7, action: "reject" }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.status).toBe("rejected");
+    expect(mockSetCommentStatus).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "rejected" }),
+    );
+  });
+
+  it("removes a comment and returns removed status", async () => {
+    makeAuditChain();
+    const res = await PATCH(makePatch({ id: 7, action: "remove" }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.status).toBe("removed");
+  });
+
+  it("returns 500 when setCommentStatus returns false", async () => {
+    mockSetCommentStatus.mockResolvedValue(false);
+    const res = await PATCH(makePatch({ id: 7, action: "publish" }));
+    expect(res.status).toBe(500);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds 19 vitest cases across 2 test files for zero-coverage admin routes
- Continues the DISC-20260524 discovery batch (follows #1182, #1183, #1184, #1185)

## What's tested

**`admin/advisor-kyc` (10 cases):** GET all-pending docs (no param), GET by `professional_id`, PATCH 401 guard, 400 missing id/action, verify action + audit-log insert, reject with short reason → 400, reject with valid reason + audit-log insert, unknown action → 400.

**`admin/article-comments` (9 cases):** GET 401 guard, GET pending-list returns items, PATCH 401 guard, 400 missing id/action, publish → `{ ok, status: "published" }` + audit insert, reject → `{ status: "rejected" }`, remove → `{ status: "removed" }`, `setCommentStatus` returns false → 500.

## Mock notes

- Both routes use `requireAdmin` + `createAdminClient` — same pattern as other admin tests
- `advisor-kyc` lib functions (`listPendingKyc`, `listKycDocuments`, `verifyKyc`, `rejectKyc`) fully mocked at module level via `vi.hoisted()`
- `article-comments` lib functions (`listPendingComments`, `setCommentStatus`) similarly mocked
- Audit log insert via `db.from("admin_audit_log").insert()` verified on write-path tests

## Supersedes

_None._

## Tier

**Tier A** — tests only, no production code changes.

https://claude.ai/code/session_01RihnUTi1q7CLXfVCYfWVW8

---
_Generated by [Claude Code](https://claude.ai/code/session_01RihnUTi1q7CLXfVCYfWVW8)_