### PR TITLE
test(disc): 4 test files for uncovered admin/cron/notif routes (iter 555)

### DIFF
--- a/__tests__/api/admin-content-calendar.test.ts
+++ b/__tests__/api/admin-content-calendar.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+import { createChainableBuilder } from "@/__tests__/helpers";
+
+// ── Hoisted mocks ─────────────────────────────────────────────────────────────
+
+const { mockRequireCronAuth, mockAdminFrom } = vi.hoisted(() => ({
+  mockRequireCronAuth: vi.fn(),
+  mockAdminFrom: vi.fn(),
+}));
+
+vi.mock("@/lib/cron-auth", () => ({
+  requireCronAuth: (req: NextRequest) => mockRequireCronAuth(req),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+
+import { GET, POST, PATCH, DELETE } from "@/app/api/admin/content/calendar/route";
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const CALENDAR_ITEMS = [
+  { id: 1, title: "Best Brokers 2026", status: "planned", target_publish_date: "2026-06-01" },
+];
+
+// ── Setup helpers ─────────────────────────────────────────────────────────────
+
+function setupMocks(data: unknown = CALENDAR_ITEMS, error: unknown = null) {
+  mockRequireCronAuth.mockReturnValue(null); // null = auth passed
+  mockAdminFrom.mockImplementation((table: string) => {
+    const b = createChainableBuilder(table);
+    b.then = vi.fn((cb: (v: unknown) => void) => {
+      cb({ data, error });
+      return Promise.resolve();
+    });
+    b.single = vi.fn().mockResolvedValue({ data: Array.isArray(data) ? data[0] ?? null : data, error });
+    b.maybeSingle = vi.fn().mockResolvedValue({ data: Array.isArray(data) ? data[0] ?? null : data, error });
+    return b;
+  });
+}
+
+function makeGet(params: Record<string, string> = {}): NextRequest {
+  const url = new URL("http://localhost/api/admin/content/calendar");
+  for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
+  return new NextRequest(url, {
+    method: "GET",
+    headers: { Authorization: "Bearer test-secret" },
+  });
+}
+
+function makePost(body: Record<string, unknown>): NextRequest {
+  return new NextRequest("http://localhost/api/admin/content/calendar", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json", Authorization: "Bearer test-secret" },
+  });
+}
+
+function makePatch(body: Record<string, unknown>): NextRequest {
+  return new NextRequest("http://localhost/api/admin/content/calendar", {
+    method: "PATCH",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json", Authorization: "Bearer test-secret" },
+  });
+}
+
+function makeDelete(body: Record<string, unknown>): NextRequest {
+  return new NextRequest("http://localhost/api/admin/content/calendar", {
+    method: "DELETE",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json", Authorization: "Bearer test-secret" },
+  });
+}
+
+// ── GET tests ─────────────────────────────────────────────────────────────────
+
+describe("GET /api/admin/content/calendar", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupMocks();
+  });
+
+  it("returns 401 when cron auth fails", async () => {
+    mockRequireCronAuth.mockReturnValueOnce(
+      NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    );
+    expect((await GET(makeGet())).status).toBe(401);
+  });
+
+  it("returns calendar items", async () => {
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.items).toBeDefined();
+  });
+
+  it("filters by status when provided", async () => {
+    await GET(makeGet({ status: "planned" }));
+    // eq("status", "planned") was called on the builder
+    expect(mockAdminFrom).toHaveBeenCalledWith("content_calendar");
+  });
+
+  it("returns 500 on DB error", async () => {
+    setupMocks(null, { message: "DB error" });
+    const res = await GET(makeGet());
+    expect(res.status).toBe(500);
+  });
+});
+
+// ── POST tests ────────────────────────────────────────────────────────────────
+
+describe("POST /api/admin/content/calendar", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupMocks(CALENDAR_ITEMS[0]);
+  });
+
+  it("returns 401 when cron auth fails", async () => {
+    mockRequireCronAuth.mockReturnValueOnce(
+      NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    );
+    expect((await POST(makePost({ title: "Test Article" }))).status).toBe(401);
+  });
+
+  it("returns 400 when title is missing", async () => {
+    const res = await POST(makePost({ category: "brokers" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("creates a calendar item and returns 201", async () => {
+    const res = await POST(makePost({ title: "Best Brokers 2026" }));
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    expect(json.item).toBeDefined();
+  });
+});
+
+// ── PATCH tests ───────────────────────────────────────────────────────────────
+
+describe("PATCH /api/admin/content/calendar", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupMocks(CALENDAR_ITEMS[0]);
+  });
+
+  it("returns 401 when cron auth fails", async () => {
+    mockRequireCronAuth.mockReturnValueOnce(
+      NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    );
+    expect((await PATCH(makePatch({ id: 1, status: "draft_ready" }))).status).toBe(401);
+  });
+
+  it("returns 400 when id is missing", async () => {
+    const res = await PATCH(makePatch({ status: "draft_ready" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("updates the calendar item", async () => {
+    const res = await PATCH(makePatch({ id: 1, status: "draft_ready" }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.item).toBeDefined();
+  });
+});
+
+// ── DELETE tests ──────────────────────────────────────────────────────────────
+
+describe("DELETE /api/admin/content/calendar", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupMocks(null);
+  });
+
+  it("returns 401 when cron auth fails", async () => {
+    mockRequireCronAuth.mockReturnValueOnce(
+      NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    );
+    expect((await DELETE(makeDelete({ id: 1 }))).status).toBe(401);
+  });
+
+  it("returns 400 when id is missing", async () => {
+    const res = await DELETE(makeDelete({ title: "foo" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("deletes the calendar item", async () => {
+    const res = await DELETE(makeDelete({ id: 1 }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.success).toBe(true);
+  });
+});

--- a/__tests__/api/admin-revalidate.test.ts
+++ b/__tests__/api/admin-revalidate.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+// ── Hoisted mocks ─────────────────────────────────────────────────────────────
+
+const { mockRequireCronAuth, mockRevalidateTag } = vi.hoisted(() => ({
+  mockRequireCronAuth: vi.fn(),
+  mockRevalidateTag: vi.fn(),
+}));
+
+vi.mock("@/lib/cron-auth", () => ({
+  requireCronAuth: (req: NextRequest) => mockRequireCronAuth(req),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidateTag: (...a: unknown[]) => mockRevalidateTag(...a),
+}));
+
+import { POST } from "@/app/api/admin/revalidate/route";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makePost(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/admin/revalidate", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${process.env.CRON_SECRET || "test-secret"}`,
+    },
+  });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("POST /api/admin/revalidate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireCronAuth.mockReturnValue(null); // null = auth passed
+  });
+
+  it("returns 401 when cron auth fails", async () => {
+    mockRequireCronAuth.mockReturnValueOnce(
+      NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    );
+    expect((await POST(makePost({ tags: ["brokers"] }))).status).toBe(401);
+  });
+
+  it("returns 400 when body is invalid JSON", async () => {
+    const req = new NextRequest("http://localhost/api/admin/revalidate", {
+      method: "POST",
+      body: "not-json",
+      headers: { "Content-Type": "application/json" },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when tags array is missing", async () => {
+    const res = await POST(makePost({ notTags: "foo" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when tags array is empty", async () => {
+    const res = await POST(makePost({ tags: [] }));
+    expect(res.status).toBe(400);
+  });
+
+  it("revalidates each tag and returns them in response", async () => {
+    const res = await POST(makePost({ tags: ["brokers", "articles"] }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.revalidated).toEqual(["brokers", "articles"]);
+    expect(json.timestamp).toBeTruthy();
+    expect(mockRevalidateTag).toHaveBeenCalledWith("brokers", { expire: 0 });
+    expect(mockRevalidateTag).toHaveBeenCalledWith("articles", { expire: 0 });
+  });
+});

--- a/__tests__/api/cron-retry-outbound-webhooks.test.ts
+++ b/__tests__/api/cron-retry-outbound-webhooks.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+// ── Hoisted mocks ─────────────────────────────────────────────────────────────
+
+const { mockRequireCronAuth, mockRetryFailedOutboundWebhooks } = vi.hoisted(() => ({
+  mockRequireCronAuth: vi.fn(),
+  mockRetryFailedOutboundWebhooks: vi.fn().mockResolvedValue({ retried: 3, failed: 0 }),
+}));
+
+vi.mock("@/lib/cron-auth", () => ({
+  requireCronAuth: (req: NextRequest) => mockRequireCronAuth(req),
+}));
+
+vi.mock("@/lib/cron-run-log", () => ({
+  wrapCronHandler: (_name: string, h: (req: NextRequest) => Promise<NextResponse>) => h,
+}));
+
+vi.mock("@/lib/outbound-webhooks", () => ({
+  retryFailedOutboundWebhooks: (...a: unknown[]) => mockRetryFailedOutboundWebhooks(...a),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+import { GET } from "@/app/api/cron/retry-outbound-webhooks/route";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeGet(): NextRequest {
+  return new NextRequest("http://localhost/api/cron/retry-outbound-webhooks", {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${process.env.CRON_SECRET || "test-secret"}`,
+    },
+  });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("GET /api/cron/retry-outbound-webhooks", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireCronAuth.mockReturnValue(null);
+    mockRetryFailedOutboundWebhooks.mockResolvedValue({ retried: 3, failed: 0 });
+  });
+
+  it("returns 401 when cron auth fails", async () => {
+    mockRequireCronAuth.mockReturnValueOnce(
+      NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    );
+    expect((await GET(makeGet())).status).toBe(401);
+  });
+
+  it("retries failed webhooks and returns stats", async () => {
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+    expect(json.retried).toBe(3);
+    expect(json.failed).toBe(0);
+    expect(mockRetryFailedOutboundWebhooks).toHaveBeenCalled();
+  });
+
+  it("returns stats even when no webhooks needed retry", async () => {
+    mockRetryFailedOutboundWebhooks.mockResolvedValueOnce({ retried: 0, failed: 0 });
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+    expect(json.retried).toBe(0);
+  });
+});

--- a/__tests__/api/notifications-read-all.test.ts
+++ b/__tests__/api/notifications-read-all.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Hoisted mocks ─────────────────────────────────────────────────────────────
+
+const {
+  mockIsAllowed,
+  mockIpKey,
+  mockGetUser,
+  mockMarkAllRead,
+} = vi.hoisted(() => ({
+  mockIsAllowed: vi.fn().mockResolvedValue(true),
+  mockIpKey: vi.fn().mockReturnValue("ip:1.2.3.4"),
+  mockGetUser: vi.fn().mockResolvedValue({ data: { user: { id: "user-uuid-1" } } }),
+  mockMarkAllRead: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: (...a: unknown[]) => mockIsAllowed(...a),
+  ipKey: (req: NextRequest) => mockIpKey(req),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(() => ({
+    auth: { getUser: () => mockGetUser() },
+  })),
+}));
+
+vi.mock("@/lib/notifications", () => ({
+  markAllRead: (...a: unknown[]) => mockMarkAllRead(...a),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+import { POST } from "@/app/api/notifications/read-all/route";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makePost(): NextRequest {
+  return new NextRequest("http://localhost/api/notifications/read-all", {
+    method: "POST",
+    headers: { "x-forwarded-for": "1.2.3.4" },
+  });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("POST /api/notifications/read-all", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowed.mockResolvedValue(true);
+    mockGetUser.mockResolvedValue({ data: { user: { id: "user-uuid-1" } } });
+    mockMarkAllRead.mockResolvedValue(undefined);
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockIsAllowed.mockResolvedValueOnce(false);
+    const res = await POST(makePost());
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 401 when user is not authenticated", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: null } });
+    const res = await POST(makePost());
+    expect(res.status).toBe(401);
+  });
+
+  it("marks all notifications as read and returns ok", async () => {
+    const res = await POST(makePost());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+    expect(mockMarkAllRead).toHaveBeenCalledWith("user-uuid-1");
+  });
+
+  it("returns 500 when markAllRead throws", async () => {
+    mockMarkAllRead.mockRejectedValueOnce(new Error("DB error"));
+    const res = await POST(makePost());
+    expect(res.status).toBe(500);
+  });
+});


### PR DESCRIPTION
## Summary

- `admin/content/calendar` — GET/POST/PATCH/DELETE with cron auth guards + error paths (11 cases)
- `admin/revalidate` — POST with cron auth + tag revalidation (5 cases)
- `notifications/read-all` — rate-limit/auth/mark-all-read/500 (4 cases)
- `cron/retry-outbound-webhooks` — cron auth/success/zero-retry (3 cases)

**23 new test cases** across 4 route files with zero prior coverage per `git ls-files __tests__/api/` cross-reference (DISC-20260524, iter 555).

`admin-advisor-kyc` and `admin-article-comments` omitted — already added in PR #1186 (iter 554) by concurrent session.

Tier A — additive tests only, no production code changes.

## Test plan

- [ ] `Lint · Type-check · Test · Build` CI green
- [ ] All 4 test files pass locally

https://claude.ai/code/session_01Fe25wL5VQrhTeHCxm1YgRV