### PR TITLE
test(disc): admin-afsl-register-upload + admin-qa-id — 16 cases [audit remediation]

### DIFF
--- a/__tests__/api/admin-afsl-register-upload.test.ts
+++ b/__tests__/api/admin-afsl-register-upload.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests for POST /api/admin/afsl-register/upload.
+ *
+ * Admin-only CSV upload that upserts rows into `public.afsl_register`.
+ * Auth: requireAdmin (ADMIN_EMAILS allowlist).
+ * Body: { csv: string } — parses CSV, validates columns, upserts to DB.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const { mockRequireAdmin, mockNormaliseAfslNumber } = vi.hoisted(() => ({
+  mockRequireAdmin: vi.fn(),
+  mockNormaliseAfslNumber: vi.fn((s: string) => s.trim()),
+}));
+
+vi.mock("@/lib/require-admin", () => ({ requireAdmin: () => mockRequireAdmin() }));
+
+vi.mock("@/lib/afsl-register", () => ({
+  normaliseAfslNumber: (s: string) => mockNormaliseAfslNumber(s),
+}));
+
+const mockAdminFrom = vi.fn();
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn() })),
+}));
+
+import { POST } from "@/app/api/admin/afsl-register/upload/route";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+const ADMIN_OK = { ok: true as const, email: "admin@test.com" };
+const ADMIN_UNAUTH = {
+  ok: false as const,
+  response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+};
+
+const VALID_CSV =
+  "afsl_number,licensee_name,status\n" +
+  "123456,Acme Finance,current\n" +
+  "789012,Beta Invest,cancelled";
+
+function makeReq(body?: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/admin/afsl-register/upload", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+}
+
+function makeUpsertBuilder(error: unknown = null, count: number | null = 2) {
+  return { upsert: vi.fn().mockResolvedValue({ error, count }) };
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("POST /api/admin/afsl-register/upload", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdmin.mockResolvedValue(ADMIN_OK);
+    mockNormaliseAfslNumber.mockImplementation((s: string) => s.trim());
+    mockAdminFrom.mockReturnValue(makeUpsertBuilder());
+  });
+
+  it("returns 401 when requireAdmin fails", async () => {
+    mockRequireAdmin.mockResolvedValue(ADMIN_UNAUTH);
+    const res = await POST(makeReq({ csv: VALID_CSV }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when body is invalid JSON", async () => {
+    const req = new NextRequest("http://localhost/api/admin/afsl-register/upload", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not-json{{",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const data = await res.json() as { error: string };
+    expect(data.error).toMatch(/invalid json/i);
+  });
+
+  it("returns 400 when csv field is missing", async () => {
+    const res = await POST(makeReq({ notCsv: "test" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when CSV has only a header row", async () => {
+    const res = await POST(makeReq({ csv: "afsl_number,licensee_name" }));
+    expect(res.status).toBe(400);
+    const data = await res.json() as { error: string };
+    expect(data.error).toMatch(/header row/i);
+  });
+
+  it("returns 400 when CSV is missing required columns", async () => {
+    const res = await POST(makeReq({ csv: "name,status\nAcme,current" }));
+    expect(res.status).toBe(400);
+    const data = await res.json() as { error: string };
+    expect(data.error).toMatch(/missing required columns/i);
+  });
+
+  it("returns 400 when all rows are invalid after parsing", async () => {
+    // normaliseAfslNumber returns "" → row skipped → no valid rows
+    mockNormaliseAfslNumber.mockReturnValue("");
+    const res = await POST(makeReq({ csv: VALID_CSV }));
+    expect(res.status).toBe(400);
+    const data = await res.json() as { error: string };
+    expect(data.error).toMatch(/no valid rows/i);
+  });
+
+  it("returns 500 when upsert fails", async () => {
+    mockAdminFrom.mockReturnValue(makeUpsertBuilder({ message: "DB error" }, null));
+    const res = await POST(makeReq({ csv: VALID_CSV }));
+    expect(res.status).toBe(500);
+    const data = await res.json() as { error: string };
+    expect(data.error).toMatch(/upsert failed/i);
+  });
+
+  it("returns 200 with row count on success", async () => {
+    const res = await POST(makeReq({ csv: VALID_CSV }));
+    expect(res.status).toBe(200);
+    const data = await res.json() as { ok: boolean; rows: number; errors: unknown[] };
+    expect(data.ok).toBe(true);
+    expect(data.rows).toBe(2);
+    expect(Array.isArray(data.errors)).toBe(true);
+  });
+});

--- a/__tests__/api/admin-qa-id.test.ts
+++ b/__tests__/api/admin-qa-id.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Tests for POST /api/admin/qa/[id].
+ *
+ * Admin-only endpoint for managing Q&A questions. Auth: custom ADMIN_EMAILS
+ * check via createClient().auth.getUser(). Supports three actions:
+ * generate_draft (AI draft with cost-cap gate), approve, reject.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const {
+  mockGetUser,
+  mockAdminFrom,
+  mockRespondToMessage,
+  mockPreCheckCaps,
+  mockRecordUsage,
+  mockRevalidatePath,
+} = vi.hoisted(() => ({
+  mockGetUser: vi.fn(),
+  mockAdminFrom: vi.fn(),
+  mockRespondToMessage: vi.fn(),
+  mockPreCheckCaps: vi.fn(),
+  mockRecordUsage: vi.fn(),
+  mockRevalidatePath: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(() => ({ auth: { getUser: () => mockGetUser() } })),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+
+vi.mock("@/lib/admin", () => ({ ADMIN_EMAILS: ["admin@test.com"] }));
+
+vi.mock("@/lib/chatbot", () => ({
+  respondToMessage: (...args: unknown[]) => mockRespondToMessage(...args),
+}));
+
+vi.mock("@/lib/ai-cost-caps", () => ({
+  loadQaCaptureConfig: vi.fn(() => ({})),
+  preCheckCaps: (...args: unknown[]) => mockPreCheckCaps(...args),
+  recordUsage: (...args: unknown[]) => mockRecordUsage(...args),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: (...args: unknown[]) => mockRevalidatePath(...args),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn() })),
+}));
+
+import { POST } from "@/app/api/admin/qa/[id]/route";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+const ADMIN_USER = { id: "user-1", email: "admin@test.com" };
+const MOCK_QUESTION = { id: 1, slug: "what-is-etf", question_text: "What is an ETF?", status: "pending" };
+
+function makeReq(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/admin/qa/1", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeParams(id: string): { params: Promise<{ id: string }> } {
+  return { params: Promise.resolve({ id }) };
+}
+
+/** Builder for .select().eq().maybeSingle() chain. */
+function makeSelectBuilder(data: unknown, error: null | { message: string } = null) {
+  const b = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn().mockResolvedValue({ data, error }),
+    single: vi.fn().mockResolvedValue({ data, error }),
+  };
+  return b;
+}
+
+/** Builder for .update().eq()... chain that resolves to { error }. */
+function makeUpdateBuilder(error: null | { message: string } = null) {
+  const resolve = (r: (v: { error: unknown }) => void) => r({ error });
+  const b = {
+    update: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    then: (r: (v: { error: unknown }) => void) => { resolve(r); return Promise.resolve(); },
+  };
+  return b;
+}
+
+/** Builder for .insert().select().single() chain. */
+function makeInsertSelectBuilder(data: unknown, error: null | { message: string } = null) {
+  const b = {
+    insert: vi.fn().mockReturnThis(),
+    select: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue({ data, error }),
+  };
+  return b;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("POST /api/admin/qa/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUser.mockResolvedValue({ data: { user: ADMIN_USER }, error: null });
+  });
+
+  it("returns 401 when user is not in ADMIN_EMAILS", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "x", email: "random@user.com" } }, error: null });
+    const res = await POST(makeReq({ action: "reject" }), makeParams("1"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when id is not numeric", async () => {
+    // admin passes but id is invalid — no DB call needed
+    const res = await POST(makeReq({ action: "reject" }), makeParams("not-a-number"));
+    expect(res.status).toBe(400);
+    const data = await res.json() as { error: string };
+    expect(data.error).toMatch(/invalid id/i);
+  });
+
+  it("returns 400 when action body is invalid", async () => {
+    mockAdminFrom.mockReturnValue(makeSelectBuilder(MOCK_QUESTION));
+    const res = await POST(makeReq({ action: "unknown_action" }), makeParams("1"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when question is not found", async () => {
+    mockAdminFrom.mockReturnValue(makeSelectBuilder(null));
+    const res = await POST(makeReq({ action: "reject" }), makeParams("1"));
+    expect(res.status).toBe(404);
+    const data = await res.json() as { error: string };
+    expect(data.error).toMatch(/not found/i);
+  });
+
+  it("approve with answer_id returns 200 and calls revalidatePath", async () => {
+    mockAdminFrom
+      .mockReturnValueOnce(makeSelectBuilder(MOCK_QUESTION)) // question fetch
+      .mockReturnValueOnce(makeUpdateBuilder())              // qa_answers update
+      .mockReturnValueOnce(makeUpdateBuilder());             // qa_questions update
+
+    const res = await POST(
+      makeReq({ action: "approve", answer_text: "An ETF is an exchange traded fund.", answer_id: 42 }),
+      makeParams("1"),
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json() as { status: string; slug: string };
+    expect(data.status).toBe("approved");
+    expect(data.slug).toBe("what-is-etf");
+    expect(mockRevalidatePath).toHaveBeenCalledWith("/answers");
+    expect(mockRevalidatePath).toHaveBeenCalledWith("/answers/what-is-etf");
+  });
+
+  it("reject action returns 200 with status=rejected", async () => {
+    mockAdminFrom
+      .mockReturnValueOnce(makeSelectBuilder(MOCK_QUESTION)) // question fetch
+      .mockReturnValueOnce(makeUpdateBuilder());             // qa_questions update
+
+    const res = await POST(
+      makeReq({ action: "reject", moderation_note: "Off-topic" }),
+      makeParams("1"),
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json() as { status: string };
+    expect(data.status).toBe("rejected");
+  });
+
+  it("generate_draft returns 429 when cost cap is reached", async () => {
+    mockAdminFrom.mockReturnValue(makeSelectBuilder(MOCK_QUESTION));
+    mockPreCheckCaps.mockResolvedValue({ allowed: false });
+
+    const res = await POST(makeReq({ action: "generate_draft" }), makeParams("1"));
+    expect(res.status).toBe(429);
+    const data = await res.json() as { error: string };
+    expect(data.error).toMatch(/cost cap/i);
+  });
+
+  it("generate_draft returns 200 with answer on success", async () => {
+    const mockAnswer = { id: 10, answer_text: "An ETF is a basket of securities." };
+
+    mockAdminFrom
+      .mockReturnValueOnce(makeSelectBuilder(MOCK_QUESTION))       // question fetch
+      .mockReturnValueOnce(makeInsertSelectBuilder(mockAnswer));   // qa_answers insert
+
+    mockPreCheckCaps.mockResolvedValue({ allowed: true });
+    mockRespondToMessage.mockResolvedValue({
+      reply: mockAnswer.answer_text,
+      model: "claude-3",
+      tokensIn: 100,
+      tokensOut: 50,
+    });
+
+    const res = await POST(makeReq({ action: "generate_draft" }), makeParams("1"));
+    expect(res.status).toBe(200);
+    const data = await res.json() as { answer_id: number; answer_text: string };
+    expect(data.answer_id).toBe(10);
+    expect(data.answer_text).toBe(mockAnswer.answer_text);
+  });
+});


### PR DESCRIPTION
## Summary

DISC-20260524-07/08 — unit tests for two zero-coverage admin routes.

- `admin-afsl-register-upload` (8 tests): requireAdmin 401, invalid JSON 400, missing `csv` field 400, header-only CSV 400, missing required columns 400, all rows invalid 400, upsert DB error 500, successful upsert 200 with row count.
- `admin-qa-id` (8 tests): ADMIN_EMAILS 401, non-numeric id 400, unknown action 400, question not found 404, approve+answer_id 200 (+ revalidatePath calls), reject 200, generate_draft cost-cap 429, generate_draft success 200 with answer_id + answer_text.

All 16 tests pass locally. TypeScript clean. Lint exit 0.

## Supersedes

_None._

Refs: audit remediation stream DISC-20260524 · codebase-health-2026-04-24.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01RihnUTi1q7CLXfVCYfWVW8)_