### PR TITLE
fix(f): allowlist parseMoney + formatAud in duplicate-function gate [audit remediation]

### DIFF
--- a/scripts/check-duplicate-functions.mjs
+++ b/scripts/check-duplicate-functions.mjs
@@ -215,6 +215,25 @@ const ALLOWED_NAMES = new Set([
   "rankBrokers",
   "rankAdvisors",
   "scoreAdvisor",
+
+  // components/FeeImpactVisualiser.tsx: formatAud(n: number) — takes dollars, returns
+  // compact chart-label strings ($100k, $1.50M). Used in SVG chart axis/tooltip labels
+  // where space is constrained.
+  // lib/first-home-buyer/state-grants.ts: formatAud(cents: number) — takes cents,
+  // returns full Intl.NumberFormat AUD string ($1,200). Used for state-grant amounts.
+  // Different units (dollars vs cents) and output format (compact vs full). Swapping
+  // would produce wrong monetary values in both contexts. (Resolved FP — iter 517.)
+  "formatAud",
+
+  // app/investment-income-tax-calculator/InvestmentIncomeTaxClient.tsx: parseMoney(value)
+  // — strips everything except digits and the decimal point, returns 0 for invalid or
+  // negative input. Designed for tax-calculator form fields where amounts must be ≥ 0.
+  // lib/holdings/csv-import/_utils.ts: parseMoney(raw) — strips currency symbols,
+  // letters, commas, and whitespace; preserves the minus sign; returns NaN for empty
+  // strings. Designed for CSV import rows where negative amounts are valid.
+  // Different invalid-input sentinel (0 vs NaN), different sign handling, different
+  // domains (UI form vs CSV importer). (Surfaced by scout fire 2026-05-25 — F-DISC-20260525-01.)
+  "parseMoney",
 ]);
 
 const EXPORT_PATTERNS = [


### PR DESCRIPTION
## Summary

Two lib/ export names flagged by `audit:duplicate-functions` are genuine false-positives that need allowlist entries, not consolidation.

**parseMoney** (F-DISC-20260525-01 — surfaced by scout fire 2026-05-25):
- `app/investment-income-tax-calculator/InvestmentIncomeTaxClient.tsx` strips all non-digit/dot chars and returns `0` for invalid or negative inputs — form-field semantics where tax amounts must be ≥ 0.
- `lib/holdings/csv-import/_utils.ts` preserves the minus sign and returns `NaN` for empty strings — CSV-import semantics where negative amounts (e.g. negative P&L) are valid.
- Different invalid-input sentinel (`0` vs `NaN`), different sign handling, different domains; not substitutable.

**formatAud** (F-DISC-20260522-01 — resolved false-positive in iter 517, allowlist commit was missed):
- `components/FeeImpactVisualiser.tsx` takes **dollars**, emits compact chart-axis labels (`$100k`, `$1.50M`).
- `lib/first-home-buyer/state-grants.ts` takes **cents**, emits full `Intl.NumberFormat` AUD strings (`$1,200`).
- Different units and output format; swapping would produce wrong monetary values in both contexts.

## Verified callers / context

Both implementations are narrow-scope local helpers (`function` without `export`). Neither is imported by callers outside its own file, so this is a pure gate fix — no call sites modified.

`node scripts/check-duplicate-functions.mjs` exits 0 after this change.

## Supersedes

_None._

## Idempotency / safety claim

Allowlist additions are additive — removing a name re-exposes the gate finding, adding a name suppresses it. No source code changed; CI cannot regress.

## Rollback

Revert this commit to re-expose both findings in the gate.

Refs: #214
Audit: docs/audits/codebase-health-2026-04-24.md
Queue: docs/audits/REMEDIATION_QUEUE.md — F-DISC-20260525-01

---
_Generated by [Claude Code](https://claude.ai/code/session_01MVuCdLr3vTqzbUpt8XdB3E)_