### PR TITLE
fix(admin): server-side fetch for ab-tests + affiliate-dashboard (repair RLS-tightening break)

### DIFF
--- a/app/admin/ab-tests/page.tsx
+++ b/app/admin/ab-tests/page.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState } from "react";
 import AdminShell from "@/components/AdminShell";
-import { createClient } from "@/lib/supabase/client";
 import { useToast } from "@/components/Toast";
 import TableSkeleton from "@/components/TableSkeleton";
 
@@ -110,7 +109,6 @@ function normalCDF(x: number): number {
 }
 
 export default function ABTestsPage() {
-  const supabase = createClient();
   const { toast } = useToast();
   const [tests, setTests] = useState<ABTest[]>([]);
   const [loading, setLoading] = useState(true);
@@ -127,19 +125,21 @@ export default function ABTestsPage() {
 
   useEffect(() => {
     fetchTests();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   async function fetchTests() {
     setLoading(true);
-    const { data, error } = await supabase
-      .from("site_ab_tests")
-      .select("*")
-      .order("created_at", { ascending: false });
-
-    if (error) {
-      toast("Error loading A/B tests: " + error.message, "error");
-    } else {
-      setTests((data as ABTest[]) || []);
+    try {
+      const res = await fetch("/api/admin/ab-tests");
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        toast("Error loading A/B tests: " + (body.error || res.statusText), "error");
+      } else {
+        setTests((body.tests as ABTest[]) || []);
+      }
+    } catch (e) {
+      toast("Error loading A/B tests: " + (e instanceof Error ? e.message : "network error"), "error");
     }
     setLoading(false);
   }
@@ -162,18 +162,17 @@ export default function ABTestsPage() {
     }
 
     setSaving(true);
-    const { error } = await supabase.from("site_ab_tests").insert({
+    const error = await postUpdate("POST", {
       name: formName.trim(),
       test_type: formType,
       page: formPage,
       variant_a: variantA,
       variant_b: variantB,
       traffic_split: formSplit,
-      status: "draft",
     });
 
     if (error) {
-      toast("Error creating test: " + error.message, "error");
+      toast("Error creating test: " + error, "error");
     } else {
       toast("A/B test created", "success");
       setShowForm(false);
@@ -198,13 +197,10 @@ export default function ABTestsPage() {
       updateData.end_date = new Date().toISOString();
     }
 
-    const { error } = await supabase
-      .from("site_ab_tests")
-      .update(updateData)
-      .eq("id", testId);
+    const error = await postUpdate("PATCH", { id: testId, ...updateData });
 
     if (error) {
-      toast("Error updating status: " + error.message, "error");
+      toast("Error updating status: " + error, "error");
     } else {
       toast(`Test ${newStatus}`, "success");
       fetchTests();
@@ -214,23 +210,46 @@ export default function ABTestsPage() {
 
   async function declareWinner(testId: number, winner: "a" | "b") {
     setSaving(true);
-    const { error } = await supabase
-      .from("site_ab_tests")
-      .update({
-        winner,
-        status: "completed",
-        end_date: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-      })
-      .eq("id", testId);
+    const error = await postUpdate("PATCH", {
+      id: testId,
+      winner,
+      status: "completed",
+      end_date: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    });
 
     if (error) {
-      toast("Error declaring winner: " + error.message, "error");
+      toast("Error declaring winner: " + error, "error");
     } else {
       toast(`Variant ${winner.toUpperCase()} declared winner`, "success");
       fetchTests();
     }
     setSaving(false);
+  }
+
+  /**
+   * POST/PATCH a body to /api/admin/ab-tests. Returns null on success or an
+   * error string to surface in a toast — mirroring the previous supabase
+   * `{ error }` flow so the call sites read the same.
+   */
+  async function postUpdate(
+    method: "POST" | "PATCH",
+    payload: Record<string, unknown>,
+  ): Promise<string | null> {
+    try {
+      const res = await fetch("/api/admin/ab-tests", {
+        method,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        return body.error || res.statusText || "Request failed";
+      }
+      return null;
+    } catch (e) {
+      return e instanceof Error ? e.message : "network error";
+    }
   }
 
   return (

--- a/app/admin/affiliate-dashboard/page.tsx
+++ b/app/admin/affiliate-dashboard/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState, useEffect, useMemo } from "react";
-import { createClient } from "@/lib/supabase/client";
 import Icon from "@/components/Icon";
 
 type Period = "7d" | "30d" | "90d" | "all";
@@ -47,18 +46,23 @@ export default function AffiliateDashboardPage() {
   useEffect(() => {
     const load = async () => {
       setLoading(true);
-      const supabase = createClient();
-      const since = period === "all" ? "2020-01-01" : new Date(Date.now() - (period === "7d" ? 7 : period === "30d" ? 30 : 90) * 86400000).toISOString();
-
-      const [clicksRes, signupsRes, reportsRes] = await Promise.all([
-        supabase.from("affiliate_clicks").select("broker_slug, broker_name, created_at").gte("created_at", since).order("created_at", { ascending: false }).limit(5000),
-        supabase.from("broker_signups").select("id, broker_slug, click_id, signup_date, revenue_cents, status, source, external_ref, utm_source, utm_campaign").gte("signup_date", since).order("signup_date", { ascending: false }),
-        supabase.from("affiliate_monthly_reports").select("*").order("month", { ascending: false }).limit(50),
-      ]);
-
-      setClicks(clicksRes.data || []);
-      setSignups(signupsRes.data || []);
-      setMonthlyReports(reportsRes.data || []);
+      try {
+        const res = await fetch(`/api/admin/affiliate-dashboard?period=${period}`);
+        const body = await res.json().catch(() => ({}));
+        if (res.ok) {
+          setClicks(body.clicks || []);
+          setSignups(body.signups || []);
+          setMonthlyReports(body.monthlyReports || []);
+        } else {
+          setClicks([]);
+          setSignups([]);
+          setMonthlyReports([]);
+        }
+      } catch {
+        setClicks([]);
+        setSignups([]);
+        setMonthlyReports([]);
+      }
       setLoading(false);
     };
     load();

--- a/app/api/admin/ab-tests/route.ts
+++ b/app/api/admin/ab-tests/route.ts
@@ -1,0 +1,144 @@
+/**
+ * /api/admin/ab-tests — admin-only list / create / update for site A/B tests.
+ *
+ *   GET   — list every test, newest-first.
+ *   POST  — create a draft test
+ *           { name, test_type, page, variant_a, variant_b, traffic_split }
+ *   PATCH — update one test by id
+ *           { id, status?, winner?, start_date?, end_date?, updated_at? }
+ *
+ * The admin A/B test page previously wrote site_ab_tests via the public anon
+ * browser client. The 20260521_buildfix_rls_overopen.sql migration tightens
+ * site_ab_tests to anon-SELECT (running rows only) + service_role ALL, so
+ * those writes are now denied at the database. This route moves them to the
+ * proven service-role pattern behind the standard ADMIN_EMAILS guard.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+import { requireAdmin } from "@/lib/require-admin";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+
+const log = logger("api:admin:ab-tests");
+
+export const runtime = "nodejs";
+
+const VariantSchema = z.record(z.string(), z.string());
+
+const CreateBody = z.object({
+  name: z.string().min(1),
+  test_type: z.string().min(1),
+  page: z.string().min(1),
+  variant_a: VariantSchema,
+  variant_b: VariantSchema,
+  traffic_split: z.number(),
+});
+
+// Mirror the exact set of fields the page mutates: updateStatus() sends
+// status + updated_at (+ optional start_date / end_date) and declareWinner()
+// sends winner + status + end_date + updated_at. The client builds the update
+// object today; the route validates the allowed keys and applies them.
+const PatchBody = z.object({
+  id: z.number().int().positive(),
+  status: z.string().optional(),
+  winner: z.enum(["a", "b"]).optional(),
+  start_date: z.string().optional(),
+  end_date: z.string().optional(),
+  updated_at: z.string().optional(),
+});
+
+export async function GET() {
+  const guard = await requireAdmin();
+  if (!guard.ok) return guard.response;
+
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("site_ab_tests")
+    .select("*")
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    log.error("ab-tests list failed", { error: error.message });
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  return NextResponse.json({ tests: data || [] });
+}
+
+export async function POST(req: NextRequest) {
+  const guard = await requireAdmin();
+  if (!guard.ok) return guard.response;
+
+  const raw = await req.json().catch(() => null);
+  if (raw === null) {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+  const parsed = CreateBody.safeParse(raw);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.issues[0]?.message ?? "Invalid body." },
+      { status: 400 },
+    );
+  }
+  const { name, test_type, page, variant_a, variant_b, traffic_split } =
+    parsed.data;
+
+  const supabase = createAdminClient();
+  const { error } = await supabase.from("site_ab_tests").insert({
+    name: name.trim(),
+    test_type,
+    page,
+    variant_a,
+    variant_b,
+    traffic_split,
+    status: "draft",
+  });
+
+  if (error) {
+    log.error("ab-test create failed", { error: error.message });
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  return NextResponse.json({ ok: true });
+}
+
+export async function PATCH(req: NextRequest) {
+  const guard = await requireAdmin();
+  if (!guard.ok) return guard.response;
+
+  const raw = await req.json().catch(() => null);
+  if (raw === null) {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+  const parsed = PatchBody.safeParse(raw);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.issues[0]?.message ?? "Invalid body." },
+      { status: 400 },
+    );
+  }
+  const { id, ...fields } = parsed.data;
+
+  const update: Record<string, unknown> = {};
+  if (fields.status !== undefined) update.status = fields.status;
+  if (fields.winner !== undefined) update.winner = fields.winner;
+  if (fields.start_date !== undefined) update.start_date = fields.start_date;
+  if (fields.end_date !== undefined) update.end_date = fields.end_date;
+  if (fields.updated_at !== undefined) update.updated_at = fields.updated_at;
+
+  if (Object.keys(update).length === 0) {
+    return NextResponse.json({ error: "no_updates" }, { status: 400 });
+  }
+
+  const supabase = createAdminClient();
+  const { error } = await supabase
+    .from("site_ab_tests")
+    .update(update)
+    .eq("id", id);
+
+  if (error) {
+    log.error("ab-test update failed", { id, error: error.message });
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/admin/affiliate-dashboard/route.ts
+++ b/app/api/admin/affiliate-dashboard/route.ts
@@ -1,0 +1,88 @@
+/**
+ * /api/admin/affiliate-dashboard — admin-only read of affiliate performance
+ * data (clicks, signups, monthly reports) for the admin dashboard page.
+ *
+ *   GET ?period=7d|30d|90d|all
+ *     → { clicks, signups, monthlyReports }
+ *
+ * affiliate_monthly_reports holds revenue / CPA / EPC data. The
+ * 20260521_buildfix_rls_overopen.sql migration restricts it to service_role,
+ * so the dashboard's previous anon-client read is now denied at the database.
+ * This route reads all three datasets via the service-role client behind the
+ * standard ADMIN_EMAILS guard, preserving the exact selects / filters /
+ * ordering / limits the page relied on so its useMemo aggregation is unchanged.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+
+import { requireAdmin } from "@/lib/require-admin";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+
+const log = logger("api:admin:affiliate-dashboard");
+
+export const runtime = "nodejs";
+
+type Period = "7d" | "30d" | "90d" | "all";
+
+function resolvePeriod(raw: string | null): Period {
+  return raw === "7d" || raw === "30d" || raw === "90d" || raw === "all"
+    ? raw
+    : "30d";
+}
+
+export async function GET(req: NextRequest) {
+  const guard = await requireAdmin();
+  if (!guard.ok) return guard.response;
+
+  const period = resolvePeriod(new URL(req.url).searchParams.get("period"));
+  // Identical `since` computation to the page's previous client-side logic.
+  const since =
+    period === "all"
+      ? "2020-01-01"
+      : new Date(
+          Date.now() -
+            (period === "7d" ? 7 : period === "30d" ? 30 : 90) * 86400000,
+        ).toISOString();
+
+  const supabase = createAdminClient();
+
+  const [clicksRes, signupsRes, reportsRes] = await Promise.all([
+    supabase
+      .from("affiliate_clicks")
+      .select("broker_slug, broker_name, created_at")
+      .gte("created_at", since)
+      .order("created_at", { ascending: false })
+      .limit(5000),
+    supabase
+      .from("broker_signups")
+      .select(
+        "id, broker_slug, click_id, signup_date, revenue_cents, status, source, external_ref, utm_source, utm_campaign",
+      )
+      .gte("signup_date", since)
+      .order("signup_date", { ascending: false }),
+    supabase
+      .from("affiliate_monthly_reports")
+      .select("*")
+      .order("month", { ascending: false })
+      .limit(50),
+  ]);
+
+  if (clicksRes.error || signupsRes.error || reportsRes.error) {
+    log.error("affiliate-dashboard read failed", {
+      clicks: clicksRes.error?.message,
+      signups: signupsRes.error?.message,
+      reports: reportsRes.error?.message,
+    });
+    return NextResponse.json(
+      { error: "Failed to load affiliate data." },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({
+    clicks: clicksRes.data || [],
+    signups: signupsRes.data || [],
+    monthlyReports: reportsRes.data || [],
+  });
+}


### PR DESCRIPTION
## Hotfix: repair admin pages broken by the over-open-RLS migration

`supabase/migrations/20260521_buildfix_rls_overopen.sql` already landed on `main` and correctly tightened 6 over-open tables (e.g. `affiliate_monthly_reports` was world-**writable** revenue data; `site_ab_tests` was anon-writable). But two admin pages still read those tables via the **anon browser client**, so they're broken on `main` right now. This moves them to the codebase's proven server-side service-role pattern.

**Changes (4 files, no migration — it's already on main):**
- `app/api/admin/ab-tests/route.ts` (new) — GET/POST/PATCH, `requireAdmin()` guard on every method, Zod-validated bodies, `createAdminClient()`.
- `app/api/admin/affiliate-dashboard/route.ts` (new) — GET `?period=`, same guard, returns clicks/signups/monthlyReports with the page's exact selects/filters/limits.
- `app/admin/ab-tests/page.tsx`, `app/admin/affiliate-dashboard/page.tsx` — fetch the new routes instead of the anon client.

**Verified:** `tsc --noEmit` clean; full suite 12,808 passing; all route methods gated by `requireAdmin`; no schema/RLS changes.

Supersedes the stale #1133 branch (which was 161 commits behind and bundled unrelated drift). Closes the C4/C5/C6 admin-page gap.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUfSRE2Teb6VhEXFP6RpS9)_