### PR TITLE
feat: salvage #964 — principals model + GDPR-wired account deletion (additive)

### DIFF
--- a/__tests__/api/account-delete.test.ts
+++ b/__tests__/api/account-delete.test.ts
@@ -48,6 +48,14 @@ const mockFrom = vi.fn(() => ({
       (chain.filters as { col: string; val: unknown }[]).push({ col, val });
       return chain;
     };
+    chain.is = (col: string, val: unknown) => {
+      (chain.filters as { col: string; val: unknown }[]).push({ col, val });
+      return chain;
+    };
+    chain.not = (col: string, _op: string, val: unknown) => {
+      (chain.filters as { col: string; val: unknown }[]).push({ col, val });
+      return chain;
+    };
     chain.then = (cb: (v: { data: null; error: { message: string } | null }) => void) => {
       updateCalls.push({
         payload,
@@ -210,18 +218,15 @@ describe("/api/account/delete", () => {
       });
       const res = await DELETE(makeReq("DELETE"));
       expect(res.status).toBe(200);
-      expect(updateCalls).toHaveLength(1);
-      expect(updateCalls[0]?.payload.status).toBe("cancelled");
-      expect(updateCalls[0]?.payload.cancelled_at).toEqual(expect.any(String));
+      // The cancel flips the user's scheduled row to cancelled. The GDPR
+      // soft-delete wiring also clears deleted_at markers on the entity
+      // tables, so updateCalls holds the cancel plus those clears.
+      const cancel = updateCalls.find((u) => u.payload.status === "cancelled");
+      expect(cancel).toBeDefined();
+      expect(cancel?.payload.cancelled_at).toEqual(expect.any(String));
       // Scoped to user + scheduled status (can't cancel someone else's)
-      expect(updateCalls[0]?.filters).toContainEqual({
-        col: "user_id",
-        val: "u1",
-      });
-      expect(updateCalls[0]?.filters).toContainEqual({
-        col: "status",
-        val: "scheduled",
-      });
+      expect(cancel?.filters).toContainEqual({ col: "user_id", val: "u1" });
+      expect(cancel?.filters).toContainEqual({ col: "status", val: "scheduled" });
     });
 
     it("returns 500 if the update errors", async () => {

--- a/__tests__/api/cron-hard-delete-expired.test.ts
+++ b/__tests__/api/cron-hard-delete-expired.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach, afterAll } from "vitest";
+import type { NextRequest } from "next/server";
+
+// ─── Mocks ───────────────────────────────────────────────────────────
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+vi.mock("@/lib/cron-run-log", () => ({
+  wrapCronHandler: (_name: string, h: unknown) => h,
+}));
+
+let killSwitchOn = false;
+vi.mock("@/lib/admin/classifier-config", () => ({
+  isFeatureDisabled: vi.fn(async () => killSwitchOn),
+}));
+
+// Use the real SOFT_DELETE_ENTITY_TABLES list so the cron iterates the same
+// 5 tables it would in production.
+vi.mock("@/lib/gdpr-soft-delete", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/gdpr-soft-delete")>();
+  return { SOFT_DELETE_ENTITY_TABLES: actual.SOFT_DELETE_ENTITY_TABLES };
+});
+
+// Per-table select + delete behaviour.
+const selectBehaviour: Record<
+  string,
+  { data: { id: number }[] | null; error: { message: string } | null }
+> = {};
+const deleteBehaviour: Record<
+  string,
+  { count: number | null; error: { message: string } | null }
+> = {};
+const deleteCalls: { table: string; ids: (string | number)[] }[] = [];
+
+const mockFrom = vi.fn((table: string) => ({
+  select: () => ({
+    not: () => ({
+      lt: () => ({
+        limit: async () => selectBehaviour[table] ?? { data: [], error: null },
+      }),
+    }),
+  }),
+  delete: (_opts?: unknown) => ({
+    in: async (_col: string, ids: (string | number)[]) => {
+      deleteCalls.push({ table, ids });
+      return deleteBehaviour[table] ?? { count: 0, error: null };
+    },
+  }),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+vi.mock("@/lib/cron-auth", () => ({
+  requireCronAuth: vi.fn(() => null),
+}));
+
+import { GET, runtime, maxDuration } from "@/app/api/cron/hard-delete-expired/route";
+import { requireCronAuth } from "@/lib/cron-auth";
+
+function makeReq(): NextRequest {
+  return new Request("http://localhost/api/cron/hard-delete-expired") as unknown as NextRequest;
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────
+
+describe("GET /api/cron/hard-delete-expired", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    killSwitchOn = false;
+    for (const k of Object.keys(selectBehaviour)) delete selectBehaviour[k];
+    for (const k of Object.keys(deleteBehaviour)) delete deleteBehaviour[k];
+    deleteCalls.length = 0;
+  });
+
+  afterAll(() => vi.restoreAllMocks());
+
+  it("exports nodejs runtime and maxDuration = 300", () => {
+    expect(runtime).toBe("nodejs");
+    expect(maxDuration).toBe(300);
+  });
+
+  it("auth short-circuits before any DB read", async () => {
+    const unauth = new Response("Unauthorized", { status: 401 });
+    vi.mocked(requireCronAuth).mockReturnValueOnce(unauth as never);
+    const res = await GET(makeReq());
+    expect(res.status).toBe(401);
+    expect(deleteCalls).toHaveLength(0);
+  });
+
+  it("honours the kill switch", async () => {
+    killSwitchOn = true;
+    const res = await GET(makeReq());
+    const json = await res.json();
+    expect(json).toEqual({ ok: true, skipped: "kill_switch_on" });
+    expect(deleteCalls).toHaveLength(0);
+  });
+
+  it("no expired rows → scanned 0, deleted 0, no delete issued", async () => {
+    const res = await GET(makeReq());
+    const json = await res.json();
+    expect(json).toMatchObject({ ok: true, scanned: 0, deleted: 0, failed: 0 });
+    expect(deleteCalls).toHaveLength(0);
+  });
+
+  it("deletes expired redacted rows on a table", async () => {
+    selectBehaviour.professionals = { data: [{ id: 1 }, { id: 2 }], error: null };
+    deleteBehaviour.professionals = { count: 2, error: null };
+
+    const res = await GET(makeReq());
+    const json = await res.json();
+    expect(json).toMatchObject({ ok: true, deleted: 2 });
+    expect(json.scanned).toBeGreaterThanOrEqual(2);
+
+    const proDelete = deleteCalls.find((c) => c.table === "professionals");
+    expect(proDelete?.ids).toEqual([1, 2]);
+  });
+
+  it("one failing table increments failed but does not stop the rest", async () => {
+    selectBehaviour.professionals = { data: null, error: { message: "select boom" } };
+    selectBehaviour.investor_profiles = { data: [{ id: 5 }], error: null };
+    deleteBehaviour.investor_profiles = { count: 1, error: null };
+
+    const res = await GET(makeReq());
+    const json = await res.json();
+    expect(json).toMatchObject({ ok: false, failed: 1, deleted: 1 });
+  });
+});

--- a/__tests__/api/cron-redact-deleted-users.test.ts
+++ b/__tests__/api/cron-redact-deleted-users.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach, afterAll } from "vitest";
+import type { NextRequest } from "next/server";
+
+// ─── Mocks ───────────────────────────────────────────────────────────
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+vi.mock("@/lib/cron-run-log", () => ({
+  wrapCronHandler: (_name: string, h: unknown) => h,
+}));
+
+let killSwitchOn = false;
+vi.mock("@/lib/admin/classifier-config", () => ({
+  isFeatureDisabled: vi.fn(async () => killSwitchOn),
+}));
+
+// Isolate the cron's orchestration from the soft-delete SQL helpers.
+const { mockMark, mockRedact } = vi.hoisted(() => ({
+  mockMark: vi.fn(async () => ({ failedTables: [] as string[] })),
+  mockRedact: vi.fn(async () => ({ failedTables: [] as string[] })),
+}));
+vi.mock("@/lib/gdpr-soft-delete", () => ({
+  markUserEntitiesDeleted: mockMark,
+  redactUserEntities: mockRedact,
+}));
+
+const { mockErase } = vi.hoisted(() => ({
+  mockErase: vi.fn(async () => ({}) as Record<string, number>),
+}));
+vi.mock("@/lib/privacy-data", () => ({
+  eraseUserData: mockErase,
+}));
+
+// account_deletion_requests fetch + status-update mock.
+let candidatesFetch: {
+  data: { id: number; user_id: string; email: string | null }[] | null;
+  error: { message: string; code?: string } | null;
+} = { data: [], error: null };
+
+const statusUpdateCalls: { id: number; payload: Record<string, unknown> }[] = [];
+let statusUpdateError: { message: string } | null = null;
+
+const mockFrom = vi.fn((table: string) => {
+  if (table !== "account_deletion_requests") {
+    throw new Error(`unexpected table ${table}`);
+  }
+  return {
+    // fetch chain: select().eq().lt().is().limit()
+    select: () => ({
+      eq: () => ({
+        lt: () => ({
+          is: () => ({
+            limit: async () => candidatesFetch,
+          }),
+        }),
+      }),
+    }),
+    // status-update chain: update().eq().eq()
+    update: (payload: Record<string, unknown>) => ({
+      eq: (_col: string, id: number) => ({
+        eq: async () => {
+          statusUpdateCalls.push({ id, payload });
+          return { error: statusUpdateError };
+        },
+      }),
+    }),
+  };
+});
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+vi.mock("@/lib/cron-auth", () => ({
+  requireCronAuth: vi.fn(() => null),
+}));
+
+import { GET, runtime, maxDuration } from "@/app/api/cron/redact-deleted-users/route";
+import { requireCronAuth } from "@/lib/cron-auth";
+
+function makeReq(): NextRequest {
+  return new Request("http://localhost/api/cron/redact-deleted-users") as unknown as NextRequest;
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────
+
+describe("GET /api/cron/redact-deleted-users", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    killSwitchOn = false;
+    candidatesFetch = { data: [], error: null };
+    statusUpdateCalls.length = 0;
+    statusUpdateError = null;
+    mockMark.mockResolvedValue({ failedTables: [] });
+    mockRedact.mockResolvedValue({ failedTables: [] });
+    mockErase.mockResolvedValue({});
+  });
+
+  afterAll(() => vi.restoreAllMocks());
+
+  it("exports nodejs runtime and maxDuration = 300", () => {
+    expect(runtime).toBe("nodejs");
+    expect(maxDuration).toBe(300);
+  });
+
+  it("auth short-circuits before any DB read", async () => {
+    const unauth = new Response("Unauthorized", { status: 401 });
+    vi.mocked(requireCronAuth).mockReturnValueOnce(unauth as never);
+    const res = await GET(makeReq());
+    expect(res.status).toBe(401);
+    expect(mockRedact).not.toHaveBeenCalled();
+  });
+
+  it("honours the kill switch", async () => {
+    killSwitchOn = true;
+    const res = await GET(makeReq());
+    const json = await res.json();
+    expect(json).toEqual({ ok: true, skipped: "kill_switch_on" });
+    expect(mockRedact).not.toHaveBeenCalled();
+  });
+
+  it("returns skipped (not 500) when the table is not migrated", async () => {
+    candidatesFetch = { data: null, error: { message: "relation does not exist", code: "42P01" } };
+    const res = await GET(makeReq());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toMatchObject({ ok: true, skipped: "table_not_migrated" });
+  });
+
+  it("returns 500 on a generic fetch error", async () => {
+    candidatesFetch = { data: null, error: { message: "db down" } };
+    const res = await GET(makeReq());
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json).toEqual({ ok: false, error: "fetch_failed" });
+  });
+
+  it("redacts each expired request and marks it purged", async () => {
+    candidatesFetch = {
+      data: [
+        { id: 1, user_id: "u-1", email: "a@example.com" },
+        { id: 2, user_id: "u-2", email: "b@example.com" },
+      ],
+      error: null,
+    };
+    const res = await GET(makeReq());
+    const json = await res.json();
+    expect(json).toMatchObject({ ok: true, scanned: 2, redacted: 2, failed: 0 });
+
+    expect(mockMark).toHaveBeenCalledTimes(2);
+    expect(mockRedact).toHaveBeenCalledTimes(2);
+    // Email-keyed surfaces erased for each request that carries an email.
+    expect(mockErase).toHaveBeenCalledWith(expect.anything(), "a@example.com");
+    expect(mockErase).toHaveBeenCalledWith(expect.anything(), "b@example.com");
+    expect(statusUpdateCalls).toHaveLength(2);
+    expect(statusUpdateCalls[0]?.payload).toMatchObject({ status: "purged" });
+    expect(statusUpdateCalls[0]?.payload.fulfilled_at).toEqual(expect.any(String));
+    expect(statusUpdateCalls[0]?.payload.pii_redacted_at).toEqual(expect.any(String));
+  });
+
+  it("counts a request as failed when the status update errors", async () => {
+    candidatesFetch = { data: [{ id: 9, user_id: "u-9", email: "c@example.com" }], error: null };
+    statusUpdateError = { message: "update boom" };
+    const res = await GET(makeReq());
+    const json = await res.json();
+    expect(json).toMatchObject({ ok: false, scanned: 1, redacted: 0, failed: 1 });
+  });
+});

--- a/__tests__/lib/gdpr-soft-delete.test.ts
+++ b/__tests__/lib/gdpr-soft-delete.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import {
+  SOFT_DELETE_ENTITY_TABLES,
+  PII_REDACTION_MAP,
+  markUserEntitiesDeleted,
+  clearUserEntitiesDeleted,
+  redactUserEntities,
+} from "@/lib/gdpr-soft-delete";
+
+/**
+ * Builds a chainable Supabase mock that records every .from(table) update
+ * call as { table, payload, filters } and resolves each terminal await to the
+ * configured result. The update chain used by the helpers is:
+ *   from(t).update(payload).eq(col,val).is(col,val)          [mark/clear-2nd]
+ *   from(t).update(payload).eq(col,val).not(col,op,val).is()  [clear/redact]
+ * Both `.is(...)` and `.not(...).is(...)` are terminal-awaitable, so every
+ * link returns a thenable that also exposes the next link.
+ */
+interface RecordedCall {
+  table: string;
+  payload: Record<string, unknown>;
+}
+
+function makeClient(opts: {
+  errorTables?: Set<string>;
+}): { client: SupabaseClient; calls: RecordedCall[] } {
+  const calls: RecordedCall[] = [];
+  const errorTables = opts.errorTables ?? new Set<string>();
+
+  const from = vi.fn((table: string) => ({
+    update: (payload: Record<string, unknown>) => {
+      const result = {
+        error: errorTables.has(table) ? { message: "boom" } : null,
+      };
+      // Each filter method returns a thenable that resolves to `result`,
+      // and also exposes the remaining filter methods for further chaining.
+      const makeThenable = (): Record<string, unknown> => {
+        const node: Record<string, unknown> = {
+          then: (resolve: (v: typeof result) => unknown) => {
+            calls.push({ table, payload });
+            return Promise.resolve(result).then(resolve);
+          },
+          eq: () => makeThenable(),
+          is: () => makeThenable(),
+          not: () => makeThenable(),
+        };
+        return node;
+      };
+      return makeThenable();
+    },
+  }));
+
+  return { client: { from } as unknown as SupabaseClient, calls };
+}
+
+describe("gdpr-soft-delete", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("exposes the 5 user-facing entity tables and a PII map for each", () => {
+    expect(SOFT_DELETE_ENTITY_TABLES).toEqual([
+      "professionals",
+      "broker_accounts",
+      "investor_profiles",
+      "business_accounts",
+      "listing_owner_accounts",
+    ]);
+    for (const table of SOFT_DELETE_ENTITY_TABLES) {
+      expect(PII_REDACTION_MAP[table]).toBeDefined();
+    }
+  });
+
+  it("PII map replaces NOT NULL columns with placeholders, nulls the rest", () => {
+    // professionals.name is NOT NULL → placeholder, not null
+    expect(PII_REDACTION_MAP.professionals.name).toBe("Deleted user");
+    expect(PII_REDACTION_MAP.professionals.email).toBeNull();
+    // broker_accounts.email is NOT NULL → must be a non-null placeholder
+    expect(PII_REDACTION_MAP.broker_accounts.email).toMatch(/@/);
+    expect(PII_REDACTION_MAP.broker_accounts.full_name).toBe("Deleted user");
+    // business_accounts.business_name is NOT NULL → placeholder
+    expect(PII_REDACTION_MAP.business_accounts.business_name).toBe("Deleted account");
+  });
+
+  it("markUserEntitiesDeleted writes deleted_at to every entity table", async () => {
+    const { client, calls } = makeClient({});
+    const result = await markUserEntitiesDeleted(client, "u-1", "2026-05-25T00:00:00Z");
+    expect(result.failedTables).toEqual([]);
+    expect(calls).toHaveLength(SOFT_DELETE_ENTITY_TABLES.length);
+    for (const call of calls) {
+      expect(call.payload).toEqual({ deleted_at: "2026-05-25T00:00:00Z" });
+    }
+  });
+
+  it("markUserEntitiesDeleted collects (does not throw on) per-table errors", async () => {
+    const { client } = makeClient({ errorTables: new Set(["broker_accounts"]) });
+    const result = await markUserEntitiesDeleted(client, "u-1");
+    expect(result.failedTables).toEqual(["broker_accounts"]);
+  });
+
+  it("clearUserEntitiesDeleted nulls deleted_at across tables", async () => {
+    const { client, calls } = makeClient({});
+    const result = await clearUserEntitiesDeleted(client, "u-1");
+    expect(result.failedTables).toEqual([]);
+    expect(calls).toHaveLength(SOFT_DELETE_ENTITY_TABLES.length);
+    for (const call of calls) {
+      expect(call.payload).toEqual({ deleted_at: null });
+    }
+  });
+
+  it("redactUserEntities applies the PII map plus pii_redacted_at per table", async () => {
+    const { client, calls } = makeClient({});
+    const result = await redactUserEntities(client, "u-1", "2026-05-25T00:00:00Z");
+    expect(result.failedTables).toEqual([]);
+    expect(calls).toHaveLength(SOFT_DELETE_ENTITY_TABLES.length);
+
+    const proCall = calls.find((c) => c.table === "professionals");
+    expect(proCall?.payload).toMatchObject({
+      name: "Deleted user",
+      email: null,
+      pii_redacted_at: "2026-05-25T00:00:00Z",
+    });
+    const investorCall = calls.find((c) => c.table === "investor_profiles");
+    expect(investorCall?.payload).toEqual({
+      display_name: null,
+      pii_redacted_at: "2026-05-25T00:00:00Z",
+    });
+  });
+});

--- a/__tests__/lib/principals.test.ts
+++ b/__tests__/lib/principals.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockFrom } = vi.hoisted(() => ({ mockFrom: vi.fn() }));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({ from: mockFrom }),
+}));
+
+import { getPrincipalForAuthUser, getPrincipalById } from "@/lib/principals";
+
+function chainMaybeSingle(result: { data: unknown; error: { message: string } | null }) {
+  return {
+    select: vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          maybeSingle: vi.fn().mockResolvedValue(result),
+        }),
+        maybeSingle: vi.fn().mockResolvedValue(result),
+      }),
+    }),
+  };
+}
+
+const SAMPLE_ROW = {
+  id: "p-1",
+  kind: "human",
+  auth_user_id: "u-1",
+  display_name: "Test User",
+  slug: null,
+  status: "active",
+  metadata: { foo: "bar" },
+  created_at: "2026-05-19T00:00:00Z",
+  updated_at: "2026-05-19T00:00:00Z",
+};
+
+describe("principals", () => {
+  beforeEach(() => mockFrom.mockReset());
+
+  describe("getPrincipalForAuthUser", () => {
+    it("maps a row to a Principal object", async () => {
+      mockFrom.mockReturnValue(chainMaybeSingle({ data: SAMPLE_ROW, error: null }));
+      const result = await getPrincipalForAuthUser("u-1");
+      expect(result).toEqual({
+        id: "p-1",
+        kind: "human",
+        authUserId: "u-1",
+        displayName: "Test User",
+        slug: null,
+        status: "active",
+        metadata: { foo: "bar" },
+        createdAt: "2026-05-19T00:00:00Z",
+        updatedAt: "2026-05-19T00:00:00Z",
+      });
+    });
+
+    it("returns null on supabase error", async () => {
+      mockFrom.mockReturnValue(chainMaybeSingle({ data: null, error: { message: "boom" } }));
+      expect(await getPrincipalForAuthUser("u-1")).toBeNull();
+    });
+
+    it("returns null when no row exists", async () => {
+      mockFrom.mockReturnValue(chainMaybeSingle({ data: null, error: null }));
+      expect(await getPrincipalForAuthUser("missing")).toBeNull();
+    });
+
+    it("treats missing metadata as empty object", async () => {
+      mockFrom.mockReturnValue(
+        chainMaybeSingle({ data: { ...SAMPLE_ROW, metadata: null }, error: null }),
+      );
+      const result = await getPrincipalForAuthUser("u-1");
+      expect(result?.metadata).toEqual({});
+    });
+  });
+
+  describe("getPrincipalById", () => {
+    it("maps a row to a Principal", async () => {
+      mockFrom.mockReturnValue(chainMaybeSingle({ data: SAMPLE_ROW, error: null }));
+      const result = await getPrincipalById("p-1");
+      expect(result?.id).toBe("p-1");
+      expect(result?.displayName).toBe("Test User");
+    });
+
+    it("returns null on error", async () => {
+      mockFrom.mockReturnValue(chainMaybeSingle({ data: null, error: { message: "boom" } }));
+      expect(await getPrincipalById("p-1")).toBeNull();
+    });
+
+    it("returns null when no row found", async () => {
+      mockFrom.mockReturnValue(chainMaybeSingle({ data: null, error: null }));
+      expect(await getPrincipalById("missing")).toBeNull();
+    });
+  });
+});

--- a/app/api/account/delete/route.ts
+++ b/app/api/account/delete/route.ts
@@ -4,6 +4,10 @@ import { createClient } from "@/lib/supabase/server";
 import { logger } from "@/lib/logger";
 import { sendEmail } from "@/lib/resend";
 import { isAllowed } from "@/lib/rate-limit-db";
+import {
+  markUserEntitiesDeleted,
+  clearUserEntitiesDeleted,
+} from "@/lib/gdpr-soft-delete";
 
 const log = logger("account-delete");
 
@@ -120,6 +124,26 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Failed to schedule deletion" }, { status: 500 });
   }
 
+  // Soft-delete marker: stamp deleted_at on the user's own entity rows so the
+  // account disappears from soft-delete-aware reads immediately. Uses the
+  // RLS-scoped server client, so it only marks tables where the owner has an
+  // UPDATE policy (investor_profiles, business_accounts,
+  // listing_owner_accounts, professionals). broker_accounts has SELECT-only
+  // owner RLS, and cookie-session advisors have no auth.uid() — those rows are
+  // marked by the redact-deleted-users cron, which re-runs this with the
+  // service-role client before redacting. Best-effort: the
+  // account_deletion_requests row committed above is the authoritative
+  // timeline (the cron keys off scheduled_purge_at, not deleted_at), so a
+  // partial or failed mark here never blocks the eventual purge. PII is
+  // preserved until redaction so a within-grace cancel fully restores it.
+  const { failedTables } = await markUserEntitiesDeleted(supabase, user.id);
+  if (failedTables.length > 0) {
+    log.warn("account-delete soft-delete marker partial failure", {
+      userId: user.id,
+      failedTables,
+    });
+  }
+
   // K-07 (audit 2026-04-26 §7 SEC-07): send a confirmation email so
   // the user has a permanent record of the deadline + a cancel link
   // they can find later. Best-effort — failure to email does not roll
@@ -180,6 +204,19 @@ export async function DELETE(_request: NextRequest) {
   if (error) {
     log.error("account_deletion_requests cancel failed", error);
     return NextResponse.json({ error: "Failed to cancel deletion" }, { status: 500 });
+  }
+
+  // Restore the soft-delete marker set at request time so the cancelled
+  // account becomes fully visible again. Only rows not yet PII-redacted are
+  // touched (within the grace window nothing has been redacted, so this
+  // restores everything). Best-effort — the request status is already
+  // 'cancelled', which is what stops the redaction cron from acting.
+  const { failedTables } = await clearUserEntitiesDeleted(supabase, user.id);
+  if (failedTables.length > 0) {
+    log.warn("account-delete cancel soft-delete restore partial failure", {
+      userId: user.id,
+      failedTables,
+    });
   }
 
   return NextResponse.json({

--- a/app/api/cron/hard-delete-expired/route.ts
+++ b/app/api/cron/hard-delete-expired/route.ts
@@ -1,0 +1,84 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+import { requireCronAuth } from "@/lib/cron-auth";
+import { wrapCronHandler } from "@/lib/cron-run-log";
+import { isFeatureDisabled } from "@/lib/admin/classifier-config";
+import { SOFT_DELETE_ENTITY_TABLES } from "@/lib/gdpr-soft-delete";
+
+const log = logger("cron:hard-delete-expired");
+
+export const runtime = "nodejs";
+export const maxDuration = 300;
+
+/**
+ * Daily cron — hard-delete half of the GDPR / APP account-deletion lifecycle.
+ *
+ * For each soft-delete-aware entity table, hard-deletes rows whose PII was
+ * redacted (pii_redacted_at IS NOT NULL) more than 7 years ago. The redacted
+ * skeleton is retained until then to satisfy the Australian financial-record
+ * retention requirement (per AFSL obligations); earlier deletion would
+ * violate that minimum, later deletion violates GDPR right-to-erasure /
+ * APP 11.
+ *
+ * Works directly on the entity tables (rather than a central principals row)
+ * so this lifecycle is self-contained and does not depend on the principals
+ * registry being present.
+ *
+ * Idempotent — rows past the cutoff are removed in BATCH_SIZE chunks per
+ * table each run; subsequent runs scan only the remainder. Each table has its
+ * own try block so one failure does not stop the rest.
+ */
+
+const BATCH_SIZE = 50;
+const HARD_DELETE_DELAY_MS = 7 * 365 * 24 * 60 * 60 * 1000; // ~7 years
+
+async function handler(req: NextRequest) {
+  const unauth = requireCronAuth(req);
+  if (unauth) return unauth;
+
+  if (await isFeatureDisabled("hard_delete_expired_users")) {
+    return NextResponse.json({ ok: true, skipped: "kill_switch_on" });
+  }
+
+  const supabase = createAdminClient();
+  const cutoff = new Date(Date.now() - HARD_DELETE_DELAY_MS).toISOString();
+  const stats = { scanned: 0, deleted: 0, failed: 0 };
+
+  for (const table of SOFT_DELETE_ENTITY_TABLES) {
+    try {
+      // Select a bounded batch of expired ids first, then delete by id. This
+      // keeps each statement small and lets us report per-run progress.
+      const { data: rows, error: selErr } = await supabase
+        .from(table)
+        .select("id")
+        .not("pii_redacted_at", "is", null)
+        .lt("pii_redacted_at", cutoff)
+        .limit(BATCH_SIZE);
+      if (selErr) throw new Error(selErr.message);
+
+      const ids = ((rows ?? []) as { id: string | number }[]).map((r) => r.id);
+      stats.scanned += ids.length;
+      if (ids.length === 0) continue;
+
+      const { error: delErr, count } = await supabase
+        .from(table)
+        .delete({ count: "exact" })
+        .in("id", ids);
+      if (delErr) throw new Error(delErr.message);
+
+      stats.deleted += count ?? 0;
+    } catch (err) {
+      stats.failed += 1;
+      log.error("hard-delete failed for table", {
+        table,
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  log.info("hard-delete-expired completed", stats);
+  return NextResponse.json({ ok: stats.failed === 0, ...stats });
+}
+
+export const GET = wrapCronHandler("hard-delete-expired", handler);

--- a/app/api/cron/redact-deleted-users/route.ts
+++ b/app/api/cron/redact-deleted-users/route.ts
@@ -1,0 +1,140 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+import { requireCronAuth } from "@/lib/cron-auth";
+import { wrapCronHandler } from "@/lib/cron-run-log";
+import { isFeatureDisabled } from "@/lib/admin/classifier-config";
+import { markUserEntitiesDeleted, redactUserEntities } from "@/lib/gdpr-soft-delete";
+import { eraseUserData } from "@/lib/privacy-data";
+
+const log = logger("cron:redact-deleted-users");
+
+export const runtime = "nodejs";
+export const maxDuration = 300;
+
+/**
+ * Daily cron — redaction half of the GDPR / APP account-deletion lifecycle.
+ *
+ * Drives off main's existing `account_deletion_requests` ledger (populated by
+ * POST /api/account/delete). For every request that has passed its 30-day
+ * grace window and is still 'scheduled' (i.e. the user never cancelled):
+ *
+ *   1. Ensure the user's entity rows are soft-deleted (defensive — the
+ *      endpoint already stamps deleted_at, but re-stamping is idempotent and
+ *      covers requests created before the marker wiring shipped).
+ *   2. Null the PII columns on each entity row and stamp pii_redacted_at,
+ *      retaining a "Deleted user" skeleton for the AFSL 7-year financial-
+ *      record requirement (see lib/gdpr-soft-delete.ts PII_REDACTION_MAP).
+ *   3. Erase / anonymise the user's email-keyed PII surfaces (leads, reviews,
+ *      captures, subscriptions) via the existing lib/privacy-data.ts
+ *      `eraseUserData` config, so the full GDPR loop closes from one place
+ *      rather than two parallel erasure systems.
+ *   4. Mark the request status='purged', fulfilled_at + pii_redacted_at = now
+ *      so it is excluded from subsequent runs.
+ *
+ * The hard-delete cron (/api/cron/hard-delete-expired) removes the redacted
+ * skeleton once the 7-year window elapses.
+ *
+ * Idempotent: the status='scheduled' + scheduled_purge_at filter means a
+ * processed request is skipped on later runs, and redactUserEntities guards
+ * on `pii_redacted_at IS NULL` per row. BATCH_SIZE bounds latency on the
+ * first run after a large soft-delete event.
+ */
+
+const BATCH_SIZE = 100;
+
+interface DeletionRequestRow {
+  id: number;
+  user_id: string;
+  email: string | null;
+}
+
+async function handler(req: NextRequest) {
+  const unauth = requireCronAuth(req);
+  if (unauth) return unauth;
+
+  if (await isFeatureDisabled("redact_deleted_users")) {
+    return NextResponse.json({ ok: true, skipped: "kill_switch_on" });
+  }
+
+  const supabase = createAdminClient();
+  const now = new Date().toISOString();
+
+  const { data: candidates, error } = await supabase
+    .from("account_deletion_requests")
+    .select("id, user_id, email")
+    .eq("status", "scheduled")
+    .lt("scheduled_purge_at", now)
+    .is("pii_redacted_at", null)
+    .limit(BATCH_SIZE);
+
+  if (error) {
+    // Forward-compatible: account_deletion_requests may not be migrated in a
+    // given environment yet (tracked as Blocked A-MISSING-TABLE-1 on main).
+    if (error.message?.includes("does not exist") || error.code === "42P01") {
+      log.warn("account_deletion_requests not migrated — skipping redaction cron", {
+        hint: "Apply 20260427_wave_security_observability.sql to unblock.",
+      });
+      return NextResponse.json({ ok: true, skipped: "table_not_migrated", redacted: 0 });
+    }
+    log.error("candidate fetch failed", { error: error.message });
+    return NextResponse.json({ ok: false, error: "fetch_failed" }, { status: 500 });
+  }
+
+  const requests: DeletionRequestRow[] = (candidates ?? []) as DeletionRequestRow[];
+  const stats = { scanned: requests.length, redacted: 0, failed: 0 };
+
+  for (const request of requests) {
+    try {
+      // Defensive re-stamp so requests created before the endpoint wiring
+      // shipped (no deleted_at) are still picked up by redactUserEntities,
+      // which only touches rows where deleted_at IS NOT NULL.
+      await markUserEntitiesDeleted(supabase, request.user_id, now);
+
+      const { failedTables } = await redactUserEntities(supabase, request.user_id, now);
+      if (failedTables.length > 0) {
+        log.warn("entity redaction partial failure", {
+          requestId: request.id,
+          userId: request.user_id,
+          failedTables,
+        });
+      }
+
+      // Close the email-keyed PII surfaces (leads, reviews, captures,
+      // subscriptions) via the existing privacy-data config so deletion is
+      // complete across both the account-identity tables and the
+      // transactional/marketing tables. Best-effort — eraseUserData swallows
+      // per-surface errors internally.
+      if (request.email) {
+        await eraseUserData(supabase, request.email);
+      }
+
+      const { error: updErr } = await supabase
+        .from("account_deletion_requests")
+        .update({ status: "purged", fulfilled_at: now, pii_redacted_at: now })
+        .eq("id", request.id)
+        .eq("status", "scheduled");
+      if (updErr) {
+        stats.failed += 1;
+        log.warn("deletion request status update failed", {
+          requestId: request.id,
+          err: updErr.message,
+        });
+        continue;
+      }
+
+      stats.redacted += 1;
+    } catch (err) {
+      stats.failed += 1;
+      log.warn("redaction threw", {
+        requestId: request.id,
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  log.info("redact-deleted-users completed", stats);
+  return NextResponse.json({ ok: stats.failed === 0, ...stats });
+}
+
+export const GET = wrapCronHandler("redact-deleted-users", handler);

--- a/lib/cron-groups.ts
+++ b/lib/cron-groups.ts
@@ -53,6 +53,8 @@ export const CRON_GROUPS: Record<string, readonly string[]> = {
     "/api/cron/data-export-monitor",
     "/api/cron/process-data-exports",
     "/api/cron/account-deletion-reminder",
+    "/api/cron/redact-deleted-users",
+    "/api/cron/hard-delete-expired",
   ],
   "daily-3": [
     "/api/cron/referral-payouts",

--- a/lib/gdpr-soft-delete.ts
+++ b/lib/gdpr-soft-delete.ts
@@ -1,0 +1,167 @@
+/**
+ * GDPR / APP soft-delete + redaction helpers.
+ *
+ * Single source of truth for the two-stage account-deletion lifecycle that is
+ * wired into main's existing `account_deletion_requests` flow:
+ *
+ *   1. Request   — POST /api/account/delete upserts an
+ *                  `account_deletion_requests` row (status='scheduled',
+ *                  scheduled_purge_at = now + 30d) AND immediately stamps
+ *                  `deleted_at` on the user's entity rows via
+ *                  `markUserEntitiesDeleted`. PII is preserved during the
+ *                  grace window so an accidental request can be cancelled.
+ *
+ *   2. Cancel    — DELETE /api/account/delete clears `deleted_at` via
+ *                  `clearUserEntitiesDeleted`, fully restoring visibility.
+ *
+ *   3. Redact    — /api/cron/redact-deleted-users runs daily: for requests
+ *                  past their grace window it calls `redactUserEntities`,
+ *                  nulling PII columns (retaining a "Deleted user" skeleton
+ *                  for the AFSL 7-year financial-record requirement) and
+ *                  stamping `pii_redacted_at`.
+ *
+ *   4. Hard-delete — /api/cron/hard-delete-expired removes rows whose
+ *                  `pii_redacted_at` is older than the 7-year retention
+ *                  window.
+ *
+ * Keeping the table list + PII column map here (rather than inlined in each
+ * caller) means adding a 6th account kind only touches this file.
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+/**
+ * The user-facing entity tables that carry per-user PII and were given
+ * `deleted_at` / `pii_redacted_at` columns by
+ * 20260801000800_gdpr_soft_delete.sql. Every table here is keyed by
+ * `auth_user_id`.
+ */
+export const SOFT_DELETE_ENTITY_TABLES = [
+  "professionals",
+  "broker_accounts",
+  "investor_profiles",
+  "business_accounts",
+  "listing_owner_accounts",
+] as const;
+
+export type SoftDeleteEntityTable = (typeof SOFT_DELETE_ENTITY_TABLES)[number];
+
+/**
+ * Per-table PII redaction map. Keys are columns to clear; the value is what
+ * to write — `null` for nullable columns, or a fixed placeholder for NOT NULL
+ * columns (so the financial-record skeleton stays queryable under an
+ * anonymised label). Column names verified against the live schema:
+ *   - professionals:          name (NOT NULL), firm_name, bio, photo_url, phone, email
+ *   - broker_accounts:        full_name (NOT NULL), email (NOT NULL), company_name, phone
+ *   - investor_profiles:      display_name (nullable)
+ *   - business_accounts:      business_name (NOT NULL), legal_name (nullable)
+ *   - listing_owner_accounts: display_name (nullable)
+ */
+export const PII_REDACTION_MAP: Record<
+  SoftDeleteEntityTable,
+  Record<string, string | null>
+> = {
+  professionals: {
+    name: "Deleted user",
+    firm_name: null,
+    bio: null,
+    photo_url: null,
+    phone: null,
+    email: null,
+  },
+  broker_accounts: {
+    full_name: "Deleted user",
+    email: "deleted@privacy.invest.com.au",
+    company_name: null,
+    phone: null,
+  },
+  investor_profiles: {
+    display_name: null,
+  },
+  business_accounts: {
+    business_name: "Deleted account",
+    legal_name: null,
+  },
+  listing_owner_accounts: {
+    display_name: null,
+  },
+};
+
+interface SoftDeleteResult {
+  /** Tables whose update returned an error (best-effort callers log these). */
+  failedTables: string[];
+}
+
+/**
+ * Stamp `deleted_at = now` on every entity row owned by `authUserId` that is
+ * not already soft-deleted. Best-effort and idempotent: tables the user has
+ * no row in simply match nothing, and the `deleted_at IS NULL` guard means a
+ * repeat request does not overwrite the original timestamp. Errors are
+ * collected rather than thrown so a single failing table never blocks the
+ * caller (the request row is the authoritative marker).
+ */
+export async function markUserEntitiesDeleted(
+  supabase: SupabaseClient,
+  authUserId: string,
+  when: string = new Date().toISOString(),
+): Promise<SoftDeleteResult> {
+  const failedTables: string[] = [];
+  for (const table of SOFT_DELETE_ENTITY_TABLES) {
+    const { error } = await supabase
+      .from(table)
+      .update({ deleted_at: when })
+      .eq("auth_user_id", authUserId)
+      .is("deleted_at", null);
+    if (error) failedTables.push(table);
+  }
+  return { failedTables };
+}
+
+/**
+ * Clear `deleted_at` (restore visibility) on every entity row owned by
+ * `authUserId` that was soft-deleted but not yet PII-redacted. Used by the
+ * cancel path so a within-grace cancellation fully restores the account.
+ * Rows that have already been redacted (pii_redacted_at IS NOT NULL) are left
+ * alone — PII is gone and there is nothing to restore.
+ */
+export async function clearUserEntitiesDeleted(
+  supabase: SupabaseClient,
+  authUserId: string,
+): Promise<SoftDeleteResult> {
+  const failedTables: string[] = [];
+  for (const table of SOFT_DELETE_ENTITY_TABLES) {
+    const { error } = await supabase
+      .from(table)
+      .update({ deleted_at: null })
+      .eq("auth_user_id", authUserId)
+      .not("deleted_at", "is", null)
+      .is("pii_redacted_at", null);
+    if (error) failedTables.push(table);
+  }
+  return { failedTables };
+}
+
+/**
+ * Null PII columns and stamp `pii_redacted_at = now` on every entity row
+ * owned by `authUserId` that is soft-deleted and not yet redacted. Idempotent
+ * via the `pii_redacted_at IS NULL` guard. Used by the redact-deleted-users
+ * cron after the grace window has expired.
+ */
+export async function redactUserEntities(
+  supabase: SupabaseClient,
+  authUserId: string,
+  when: string = new Date().toISOString(),
+): Promise<SoftDeleteResult> {
+  const failedTables: string[] = [];
+  for (const table of SOFT_DELETE_ENTITY_TABLES) {
+    const patch = { ...PII_REDACTION_MAP[table], pii_redacted_at: when };
+    const { error } = await supabase
+      .from(table)
+      .update(patch)
+      .eq("auth_user_id", authUserId)
+      .not("deleted_at", "is", null)
+      .is("pii_redacted_at", null);
+    if (error) failedTables.push(table);
+  }
+  return { failedTables };
+}

--- a/lib/principals.ts
+++ b/lib/principals.ts
@@ -1,0 +1,121 @@
+/**
+ * Principal registry helpers (account/identity architecture foundation).
+ *
+ * A "principal" is the unified actor row that represents anyone (or anything)
+ * able to act in the system and leave an audit trail. Today the registry
+ * covers:
+ *
+ *   - kind='human'       — backed by auth.users; one principal per user.
+ *   - kind='partner_org' — commercial-partner metadata rows (sponsors,
+ *                          newsletter sponsors, partner integrations);
+ *                          no auth.users row.
+ *
+ * The abstraction is designed to extend to agents / internal-team /
+ * regulatory representatives in a future session without schema rework.
+ *
+ * This module is purely additive: it reads the `principals` table created by
+ * 20260801000000_principals_table.sql and does not depend on (or modify) the
+ * existing account-kind membership view or the account-kind enum.
+ */
+
+// eslint-disable-next-line no-restricted-imports -- cross-user / service-role-managed reads with no per-user JWT path (see CLAUDE.md § "Two Supabase clients").
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+
+const log = logger("principals");
+
+export type PrincipalKind = "human" | "partner_org";
+export type PrincipalStatus = "active" | "suspended" | "retired" | "pending";
+
+export interface Principal {
+  id: string;
+  kind: PrincipalKind;
+  authUserId: string | null;
+  displayName: string;
+  slug: string | null;
+  status: PrincipalStatus;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface PrincipalRow {
+  id: string;
+  kind: string;
+  auth_user_id: string | null;
+  display_name: string;
+  slug: string | null;
+  status: string;
+  metadata: Record<string, unknown> | null;
+  created_at: string;
+  updated_at: string;
+}
+
+const PRINCIPAL_COLUMNS =
+  "id, kind, auth_user_id, display_name, slug, status, metadata, created_at, updated_at";
+
+function rowToPrincipal(r: PrincipalRow): Principal {
+  return {
+    id: r.id,
+    kind: r.kind as PrincipalKind,
+    authUserId: r.auth_user_id,
+    displayName: r.display_name,
+    slug: r.slug,
+    status: r.status as PrincipalStatus,
+    metadata: r.metadata ?? {},
+    createdAt: r.created_at,
+    updatedAt: r.updated_at,
+  };
+}
+
+/**
+ * Resolve the principal row for an auth.users id. Returns null when the user
+ * has no principal row (e.g. before the human-backfill has run, or when called
+ * for a user that never had one provisioned).
+ */
+export async function getPrincipalForAuthUser(
+  authUserId: string,
+): Promise<Principal | null> {
+  try {
+    const supabase = createAdminClient();
+    const { data, error } = await supabase
+      .from("principals")
+      .select(PRINCIPAL_COLUMNS)
+      .eq("kind", "human")
+      .eq("auth_user_id", authUserId)
+      .maybeSingle();
+    if (error) {
+      log.warn("getPrincipalForAuthUser failed", { authUserId, error: error.message });
+      return null;
+    }
+    return data ? rowToPrincipal(data as PrincipalRow) : null;
+  } catch (err) {
+    log.warn("getPrincipalForAuthUser threw", {
+      authUserId,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}
+
+export async function getPrincipalById(principalId: string): Promise<Principal | null> {
+  try {
+    const supabase = createAdminClient();
+    const { data, error } = await supabase
+      .from("principals")
+      .select(PRINCIPAL_COLUMNS)
+      .eq("id", principalId)
+      .maybeSingle();
+    if (error) {
+      log.warn("getPrincipalById failed", { principalId, error: error.message });
+      return null;
+    }
+    return data ? rowToPrincipal(data as PrincipalRow) : null;
+  } catch (err) {
+    log.warn("getPrincipalById threw", {
+      principalId,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}

--- a/supabase/migrations/20260801000000_principals_table.sql
+++ b/supabase/migrations/20260801000000_principals_table.sql
@@ -1,0 +1,74 @@
+-- ============================================================================
+-- Migration: 20260801000000_principals_table.sql
+-- Purpose: Foundation for a unified identity model. A `principal` is anything
+--          that can ACT in the system and leave an audit trail. Initial scope:
+--          humans (auth.users-backed) for the existing account kinds, and
+--          partner_orgs (no auth.users) for sponsors / commercial-partner
+--          metadata rows. Designed to extend to agent / internal_team /
+--          regulatory_representative kinds in a future migration without
+--          schema rework.
+--
+--          PURELY ADDITIVE: this migration only creates a new table. It does
+--          NOT alter the existing `account_kind_membership` view, the
+--          account-kind enum, or any existing table. Linking entity tables to
+--          principals (a `principal_id` FK + backfill) is intentionally left
+--          to a follow-up so this foundation can ship in isolation.
+-- Risk: low — additive table; no existing data touched.
+-- Rollback:
+--   BEGIN;
+--     DROP TRIGGER IF EXISTS principals_updated_at ON public.principals;
+--     DROP TABLE IF EXISTS public.principals CASCADE;
+--   COMMIT;
+-- ============================================================================
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.principals (
+  id              uuid NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  kind            text NOT NULL CHECK (kind IN ('human','partner_org')),
+  -- NULL for partner_org kind today. Will be NULL for future agent /
+  -- internal_team / regulatory_representative principals where there is no
+  -- corresponding auth.users row. PostgreSQL UNIQUE permits multiple NULL
+  -- values, so the unique constraint below remains correct for those kinds.
+  auth_user_id    uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  display_name    text NOT NULL CHECK (length(display_name) > 0),
+  slug            text UNIQUE,
+  status          text NOT NULL DEFAULT 'active'
+                  CHECK (status IN ('active','suspended','retired','pending')),
+  metadata        jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  updated_at      timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT principals_auth_user_unique UNIQUE (auth_user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_principals_kind ON public.principals (kind);
+CREATE INDEX IF NOT EXISTS idx_principals_status_active
+  ON public.principals (status) WHERE status = 'active';
+
+ALTER TABLE public.principals ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.principals FORCE ROW LEVEL SECURITY;
+
+-- Humans read only their own principal row. Partner_orgs are admin-managed
+-- and never accessed via authenticated session — the service_role policy
+-- below handles all reads on those rows.
+DROP POLICY IF EXISTS "human reads own principal" ON public.principals;
+CREATE POLICY "human reads own principal"
+  ON public.principals FOR SELECT
+  TO authenticated
+  USING (kind = 'human' AND auth_user_id = auth.uid());
+
+DROP POLICY IF EXISTS "service_role full access principals" ON public.principals;
+CREATE POLICY "service_role full access principals"
+  ON public.principals FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- Reuse the shared updated_at trigger function (created by
+-- 20260305_create_advisor_directory.sql and reused across every table).
+DROP TRIGGER IF EXISTS principals_updated_at ON public.principals;
+CREATE TRIGGER principals_updated_at
+  BEFORE UPDATE ON public.principals
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at();
+
+COMMIT;

--- a/supabase/migrations/20260801000800_gdpr_soft_delete.sql
+++ b/supabase/migrations/20260801000800_gdpr_soft_delete.sql
@@ -1,0 +1,115 @@
+-- ============================================================================
+-- Migration: 20260801000800_gdpr_soft_delete.sql
+-- Purpose: Pre-launch GDPR / APP-compliant soft-delete + redaction foundation,
+--          wired into main's EXISTING account-deletion flow
+--          (`account_deletion_requests`, populated by
+--          POST /api/account/delete).
+--
+--          Adds two timestamp columns to each of the 5 user-facing entity
+--          tables:
+--            - deleted_at      → set the moment a user requests deletion
+--                                (soft-delete marker; PII preserved during
+--                                the 30-day grace window so an accidental
+--                                deletion can be cancelled/restored)
+--            - pii_redacted_at → set by the redact-deleted-users cron once
+--                                the account_deletion_requests grace window
+--                                has expired; PII columns are nulled but the
+--                                financial-record skeleton is retained under
+--                                a "Deleted user" placeholder for the AFSL
+--                                7-year retention requirement
+--
+--          A matching `pii_redacted_at` column is added to
+--          `account_deletion_requests` so the cron can record when a
+--          request's PII was redacted (distinct from `fulfilled_at`, which
+--          the existing flow already uses to mark the request closed).
+--
+--          The two crons that consume these columns
+--          (redact-deleted-users + hard-delete-expired) ship in the same
+--          change and are registered in lib/cron-groups.ts under daily-2,
+--          alongside the existing gdpr-retention-purge job.
+--
+--          DELIBERATELY ADDITIVE: this migration does NOT tighten any
+--          existing RLS SELECT policy. #964 attempted to add
+--          `AND deleted_at IS NULL` to per-user read policies, but several
+--          of these tables (professionals, broker_accounts,
+--          listing_owner_accounts) have public marketplace read paths where
+--          a careless predicate change risks a visibility regression.
+--          Callers that must hide soft-deleted rows should filter
+--          `.is("deleted_at", null)` explicitly; tightening the policies is
+--          left to a separate, carefully-scoped migration.
+-- Risk: low — additive columns + partial indexes only. No data touched, no
+--             policy behaviour changed. With zero soft-deleted rows at
+--             apply time it is a no-op until a user requests deletion.
+-- Rollback:
+--   BEGIN;
+--     ALTER TABLE public.account_deletion_requests DROP COLUMN IF EXISTS pii_redacted_at;
+--     ALTER TABLE public.professionals          DROP COLUMN IF EXISTS deleted_at;
+--     ALTER TABLE public.professionals          DROP COLUMN IF EXISTS pii_redacted_at;
+--     ALTER TABLE public.broker_accounts        DROP COLUMN IF EXISTS deleted_at;
+--     ALTER TABLE public.broker_accounts        DROP COLUMN IF EXISTS pii_redacted_at;
+--     ALTER TABLE public.investor_profiles      DROP COLUMN IF EXISTS deleted_at;
+--     ALTER TABLE public.investor_profiles      DROP COLUMN IF EXISTS pii_redacted_at;
+--     ALTER TABLE public.business_accounts      DROP COLUMN IF EXISTS deleted_at;
+--     ALTER TABLE public.business_accounts      DROP COLUMN IF EXISTS pii_redacted_at;
+--     ALTER TABLE public.listing_owner_accounts DROP COLUMN IF EXISTS deleted_at;
+--     ALTER TABLE public.listing_owner_accounts DROP COLUMN IF EXISTS pii_redacted_at;
+--   COMMIT;
+-- ============================================================================
+
+BEGIN;
+
+-- ─── Soft-delete + redaction columns on the 5 entity tables ────────────────
+ALTER TABLE public.professionals
+  ADD COLUMN IF NOT EXISTS deleted_at      timestamptz,
+  ADD COLUMN IF NOT EXISTS pii_redacted_at timestamptz;
+
+ALTER TABLE public.broker_accounts
+  ADD COLUMN IF NOT EXISTS deleted_at      timestamptz,
+  ADD COLUMN IF NOT EXISTS pii_redacted_at timestamptz;
+
+ALTER TABLE public.investor_profiles
+  ADD COLUMN IF NOT EXISTS deleted_at      timestamptz,
+  ADD COLUMN IF NOT EXISTS pii_redacted_at timestamptz;
+
+ALTER TABLE public.business_accounts
+  ADD COLUMN IF NOT EXISTS deleted_at      timestamptz,
+  ADD COLUMN IF NOT EXISTS pii_redacted_at timestamptz;
+
+ALTER TABLE public.listing_owner_accounts
+  ADD COLUMN IF NOT EXISTS deleted_at      timestamptz,
+  ADD COLUMN IF NOT EXISTS pii_redacted_at timestamptz;
+
+-- Cron bookkeeping column on the existing deletion-request ledger.
+ALTER TABLE public.account_deletion_requests
+  ADD COLUMN IF NOT EXISTS pii_redacted_at timestamptz;
+
+COMMENT ON COLUMN public.account_deletion_requests.pii_redacted_at IS
+  'Timestamp when the redact-deleted-users cron nulled PII on the linked '
+  'entity rows after the grace window expired. NULL = not yet redacted.';
+
+-- ─── Partial indexes so the daily crons scan only relevant rows ────────────
+CREATE INDEX IF NOT EXISTS idx_professionals_deleted_at
+  ON public.professionals (deleted_at) WHERE deleted_at IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_broker_accounts_deleted_at
+  ON public.broker_accounts (deleted_at) WHERE deleted_at IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_investor_profiles_deleted_at
+  ON public.investor_profiles (deleted_at) WHERE deleted_at IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_business_accounts_deleted_at
+  ON public.business_accounts (deleted_at) WHERE deleted_at IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_listing_owner_accounts_deleted_at
+  ON public.listing_owner_accounts (deleted_at) WHERE deleted_at IS NOT NULL;
+
+-- Hard-delete cron scans rows already redacted (pii_redacted_at set) whose
+-- retention window has elapsed.
+CREATE INDEX IF NOT EXISTS idx_professionals_pii_redacted_at
+  ON public.professionals (pii_redacted_at) WHERE pii_redacted_at IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_broker_accounts_pii_redacted_at
+  ON public.broker_accounts (pii_redacted_at) WHERE pii_redacted_at IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_investor_profiles_pii_redacted_at
+  ON public.investor_profiles (pii_redacted_at) WHERE pii_redacted_at IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_business_accounts_pii_redacted_at
+  ON public.business_accounts (pii_redacted_at) WHERE pii_redacted_at IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_listing_owner_accounts_pii_redacted_at
+  ON public.listing_owner_accounts (pii_redacted_at) WHERE pii_redacted_at IS NOT NULL;
+
+COMMIT;


### PR DESCRIPTION
Salvages the two genuinely-novel, non-redundant ideas from the (abandoned-as-stale) #964 branch as **purely-additive** changes onto current `main`. Per a deep-dive review, main already shipped #964's account-kinds/portal/workspace foundation + the live `startup` portal, so #964 itself can't merge — but these two pieces are worth keeping. **Touches none of main's account-kind enum, `account_kind_membership` view, portal-gate, or workspace UI.**

**1. `principals` actor model** (commit 1) — new `principals` table (human / partner_org, extensible) + `lib/principals.ts` read helpers + test. Idempotent migration, RLS enabled+FORCE, per-user + service-role policies, rollback header. Skipped #964's destructive view-redefinition.

**2. GDPR deletion, wired end-to-end** (commit 2) — root-caused a real gap: main *schedules* deletions (`account_deletion_requests`) but nothing ever purged at the date. Now: `POST /api/account/delete` stamps `deleted_at` on the user's entity rows (and `DELETE`/cancel clears them); a `redact-deleted-users` cron redacts PII after the 30-day grace (retaining a skeleton for AFSL 7-yr retention); a `hard-delete-expired` cron purges after 7 years. Both crons gate on `requireCronAuth`, registered in `lib/cron-groups.ts`. No RLS tightening (deliberately avoiding the marketplace-visibility regression #964 flagged).

**Verified:** `tsc --noEmit` clean; full suite **12,836 passing** (incl. the 4 new test files + the updated `account-delete` mock); additive-only (no protected files touched).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUfSRE2Teb6VhEXFP6RpS9)_