### PR TITLE
fix(admin): route consultation catalog writes through a service-role admin API

### DIFF
--- a/__tests__/api/admin-consultations.test.ts
+++ b/__tests__/api/admin-consultations.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { NextRequest } from "next/server";
+
+const { mockRequireAdmin, mockInsert, mockUpdate, mockUpdateEq, mockDelete, mockDeleteEq } =
+  vi.hoisted(() => ({
+    mockRequireAdmin: vi.fn(),
+    mockInsert: vi.fn(),
+    mockUpdate: vi.fn(),
+    mockUpdateEq: vi.fn(),
+    mockDelete: vi.fn(),
+    mockDeleteEq: vi.fn(),
+  }));
+
+vi.mock("@/lib/require-admin", () => ({
+  requireAdmin: mockRequireAdmin,
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({
+    from: () => ({
+      insert: mockInsert,
+      update: mockUpdate,
+      delete: mockDelete,
+    }),
+  }),
+}));
+
+import { POST, DELETE } from "@/app/api/admin/consultations/route";
+
+const validBody = {
+  title: "Tax Strategy Call",
+  slug: "tax-strategy-call",
+  description: null,
+  consultant_id: 1,
+  duration_minutes: 30,
+  price: 9900,
+  pro_price: null,
+  stripe_price_id: null,
+  stripe_pro_price_id: null,
+  cal_link: "https://cal.com/x",
+  category: "tax",
+  status: "published",
+  featured: false,
+  sort_order: 0,
+};
+
+function makeReq(method: "POST" | "DELETE", body: unknown): NextRequest {
+  return new Request("http://localhost/api/admin/consultations", {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  }) as unknown as NextRequest;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRequireAdmin.mockResolvedValue({ ok: true, email: "admin@x.com", userId: "u1" });
+  mockInsert.mockResolvedValue({ error: null });
+  mockUpdate.mockReturnValue({ eq: mockUpdateEq });
+  mockUpdateEq.mockResolvedValue({ error: null });
+  mockDelete.mockReturnValue({ eq: mockDeleteEq });
+  mockDeleteEq.mockResolvedValue({ error: null });
+});
+
+describe("/api/admin/consultations", () => {
+  it("POST returns 401 when caller is not an admin", async () => {
+    mockRequireAdmin.mockResolvedValueOnce({
+      ok: false,
+      response: new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 }),
+    });
+    const res = await POST(makeReq("POST", validBody));
+    expect(res.status).toBe(401);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it("POST returns 400 on an invalid payload", async () => {
+    const res = await POST(makeReq("POST", { title: "" }));
+    expect(res.status).toBe(400);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it("POST inserts a new consultation (no id) via the admin client", async () => {
+    const res = await POST(makeReq("POST", validBody));
+    expect(res.status).toBe(200);
+    expect(mockInsert).toHaveBeenCalledTimes(1);
+    const payload = mockInsert.mock.calls[0]?.[0];
+    expect(payload).toMatchObject({ title: "Tax Strategy Call", price: 9900 });
+    expect(payload).toHaveProperty("updated_at");
+    expect(payload).not.toHaveProperty("id");
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it("POST updates an existing consultation (with id) scoped by id", async () => {
+    const res = await POST(makeReq("POST", { ...validBody, id: 5 }));
+    expect(res.status).toBe(200);
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+    expect(mockUpdateEq).toHaveBeenCalledWith("id", 5);
+    // id must not leak into the column payload
+    expect(mockUpdate.mock.calls[0]?.[0]).not.toHaveProperty("id");
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it("POST returns 500 when the admin client errors", async () => {
+    mockInsert.mockResolvedValueOnce({ error: { message: "boom" } });
+    const res = await POST(makeReq("POST", validBody));
+    expect(res.status).toBe(500);
+  });
+
+  it("DELETE returns 401 when caller is not an admin", async () => {
+    mockRequireAdmin.mockResolvedValueOnce({
+      ok: false,
+      response: new Response(null, { status: 401 }),
+    });
+    const res = await DELETE(makeReq("DELETE", { id: 5 }));
+    expect(res.status).toBe(401);
+    expect(mockDelete).not.toHaveBeenCalled();
+  });
+
+  it("DELETE returns 400 without a valid id", async () => {
+    const res = await DELETE(makeReq("DELETE", {}));
+    expect(res.status).toBe(400);
+    expect(mockDelete).not.toHaveBeenCalled();
+  });
+
+  it("DELETE removes the consultation scoped by id", async () => {
+    const res = await DELETE(makeReq("DELETE", { id: 5 }));
+    expect(res.status).toBe(200);
+    expect(mockDeleteEq).toHaveBeenCalledWith("id", 5);
+  });
+});

--- a/app/admin/consultations/page.tsx
+++ b/app/admin/consultations/page.tsx
@@ -78,10 +78,6 @@ export default function AdminConsultationsPage() {
 
   const [form, setForm] = useState(emptyForm);
 
-  useEffect(() => {
-    fetchData();
-  }, []);
-
   const fetchData = async () => {
     const supabase = createClient();
 
@@ -126,6 +122,11 @@ export default function AdminConsultationsPage() {
     setLoading(false);
   };
 
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- on-mount data load; fetchData only setState()s after its first await
+    fetchData();
+  }, []);
+
   const autoSlug = (title: string) =>
     title
       .toLowerCase()
@@ -137,8 +138,8 @@ export default function AdminConsultationsPage() {
     if (!form.title.trim() || !form.cal_link.trim()) return;
     setSaving(true);
 
-    const supabase = createClient();
     const payload = {
+      ...(editingId ? { id: editingId } : {}),
       title: form.title.trim(),
       slug: form.slug || autoSlug(form.title),
       description: form.description || null,
@@ -155,23 +156,24 @@ export default function AdminConsultationsPage() {
       status: form.status,
       featured: form.featured,
       sort_order: parseInt(form.sort_order) || 0,
-      updated_at: new Date().toISOString(),
     };
 
-    let error;
-    if (editingId) {
-      ({ error } = await supabase
-        .from("consultations")
-        .update(payload)
-        .eq("id", editingId));
-    } else {
-      ({ error } = await supabase.from("consultations").insert(payload));
-    }
+    const res = await fetch("/api/admin/consultations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
 
-    if (error) {
-      showToast(`Error: ${error.message}`, "error");
+    if (!res.ok) {
+      const body = (await res.json().catch(() => null)) as {
+        error?: string;
+      } | null;
+      showToast(`Error: ${body?.error || res.statusText}`, "error");
     } else {
-      showToast(editingId ? "Consultation updated!" : "Consultation created!", "success");
+      showToast(
+        editingId ? "Consultation updated!" : "Consultation created!",
+        "success",
+      );
       setShowCreate(false);
       setEditingId(null);
       setForm(emptyForm);
@@ -225,10 +227,16 @@ export default function AdminConsultationsPage() {
 
   const handleDelete = async () => {
     if (!deleteTarget) return;
-    const supabase = createClient();
-    const { error } = await supabase.from("consultations").delete().eq("id", deleteTarget.id);
-    if (error) {
-      showToast(`Error: ${error.message}`, "error");
+    const res = await fetch("/api/admin/consultations", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id: deleteTarget.id }),
+    });
+    if (!res.ok) {
+      const body = (await res.json().catch(() => null)) as {
+        error?: string;
+      } | null;
+      showToast(`Error: ${body?.error || res.statusText}`, "error");
     } else {
       showToast("Consultation deleted", "success");
       fetchData();

--- a/app/api/admin/consultations/route.ts
+++ b/app/api/admin/consultations/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { requireAdmin } from "@/lib/require-admin";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+// Admin-only writes for the consultation catalog. The `consultations` table is
+// service_role-write only (anon/authenticated have SELECT only), so the admin
+// page must mutate through this route rather than the browser client.
+
+const UpsertSchema = z.object({
+  id: z.number().int().positive().optional(),
+  title: z.string().min(1).max(200),
+  slug: z.string().min(1).max(200),
+  description: z.string().max(5000).nullable().optional(),
+  consultant_id: z.number().int().positive().nullable().optional(),
+  duration_minutes: z.number().int().positive(),
+  price: z.number().int().min(0),
+  pro_price: z.number().int().min(0).nullable().optional(),
+  stripe_price_id: z.string().max(200).nullable().optional(),
+  stripe_pro_price_id: z.string().max(200).nullable().optional(),
+  cal_link: z.string().min(1).max(500),
+  category: z.string().max(100),
+  status: z.string().max(50),
+  featured: z.boolean(),
+  sort_order: z.number().int(),
+});
+
+export async function POST(req: NextRequest) {
+  const guard = await requireAdmin();
+  if (!guard.ok) return guard.response;
+
+  const parsed = UpsertSchema.safeParse(await req.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
+  }
+
+  const { id, ...fields } = parsed.data;
+  const admin = createAdminClient();
+  const payload = { ...fields, updated_at: new Date().toISOString() };
+
+  const { error } = id
+    ? await admin.from("consultations").update(payload).eq("id", id)
+    : await admin.from("consultations").insert(payload);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  return NextResponse.json({ ok: true });
+}
+
+const DeleteSchema = z.object({ id: z.number().int().positive() });
+
+export async function DELETE(req: NextRequest) {
+  const guard = await requireAdmin();
+  if (!guard.ok) return guard.response;
+
+  const parsed = DeleteSchema.safeParse(await req.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid id" }, { status: 400 });
+  }
+
+  const admin = createAdminClient();
+  const { error } = await admin
+    .from("consultations")
+    .delete()
+    .eq("id", parsed.data.id);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  return NextResponse.json({ ok: true });
+}


### PR DESCRIPTION
## What

The admin **consultations** catalog page (`app/admin/consultations/page.tsx`) created/edited/deleted rows via the **browser** Supabase client. But the `consultations` table is `service_role`-write only (anon/authenticated have SELECT only, per `20260707_a03_batch6_consultations_courses_rls`), so every write **silently failed under RLS** — a live-broken admin feature.

## Fix

- New `app/api/admin/consultations/route.ts` — `POST` (insert/update) + `DELETE`, each gated by `requireAdmin()` and writing through `createAdminClient()` (service-role), with Zod validation on the body.
- Pointed the page's `handleSave` / `handleDelete` at the route (reads stay on the browser client — the SELECT policy allows them).
- Fixed a pre-existing `use-before-declare` lint warning in the same file (reordered the on-mount effect below `fetchData`) so the change passes `lint-staged --max-warnings 0`.

## Verified

- `tsc --noEmit` clean
- New test `__tests__/api/admin-consultations.test.ts` — **8 passing** (401 non-admin, 400 invalid, insert vs update routing, id-not-leaked-into-payload, 500 on db error, DELETE auth + id scoping)
- eslint clean; rate-limit audit `--strict` 100%

## Note

This is **one of two** items flagged in the security review. The second — `admin_audit_log`'s `INSERT` policy being open to any authenticated JWT — turned out **not** to be a one-liner (it's load-bearing for 4 admin pages plus a broker self-service write path, and has a sibling open-`SELECT`). Deferred to a separate PR pending a scoping decision; details in the session thread.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUfSRE2Teb6VhEXFP6RpS9)_