### PR TITLE
fix(compliance): gate startup capital-raising behind a default-OFF flag

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -109,3 +109,13 @@ LISTING_OWNER_COOKIE_SECRET=your_listing_owner_cookie_secret_here
 
 # ── Logging (optional) ──────────────────────────────────
 # LOG_LEVEL=warn
+
+# ── Compliance gates (default OFF) ──────────────────────
+# Flows that need authorisation BEYOND the planned general-advice AFSL
+# (see docs/strategy/REGULATORY-AVOID-LIST.md). Leave UNSET in every
+# environment until founder + legal sign-off. See lib/compliance-gates.ts.
+#
+# Startup capital-raising (open rounds, share data-room materials) is CSF
+# intermediary territory. Only set to the literal string "true" once the
+# CSF intermediary authorisation is held.
+# STARTUP_RAISES_ENABLED=true

--- a/__tests__/api/startup-data-room-grant.test.ts
+++ b/__tests__/api/startup-data-room-grant.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { NextRequest } from "next/server";
 
 // ─── Hoisted mocks ────────────────────────────────────────────────────────────
@@ -105,9 +105,16 @@ function setupServerFrom({
 describe("POST /api/startups/data-room/grant", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Capital-raising is gated OFF by default; these tests cover the
+    // post-gate grant logic, so enable the flag for the suite.
+    vi.stubEnv("STARTUP_RAISES_ENABLED", "true");
     mockRequireStartupSession.mockResolvedValue(STARTUP_ID);
     mockGetUser.mockResolvedValue({ data: { user: { id: GRANTED_BY_USER_ID } } });
     setupServerFrom();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it("returns 401 when no startup session", async () => {

--- a/__tests__/api/startup-raise-gate.test.ts
+++ b/__tests__/api/startup-raise-gate.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { NextRequest } from "next/server";
+
+const { mockGetUser, mockRequireStartupSession } = vi.hoisted(() => ({
+  mockGetUser: vi.fn(),
+  mockRequireStartupSession: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({
+    auth: { getUser: mockGetUser },
+    from: vi.fn(),
+  })),
+}));
+vi.mock("@/lib/supabase/admin", () => ({ createAdminClient: vi.fn() }));
+vi.mock("@/lib/require-startup-session", () => ({
+  requireStartupSession: mockRequireStartupSession,
+}));
+
+import { POST as roundPOST } from "@/app/api/startups/round/route";
+import { POST as grantPOST } from "@/app/api/startups/data-room/grant/route";
+
+function makeReq(body: unknown): NextRequest {
+  return new Request("http://localhost/x", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  }) as unknown as NextRequest;
+}
+
+const validPricedRound = {
+  instrument: "priced_equity",
+  target_aud_cents: 100_000_000,
+  min_ticket_aud_cents: 1_000_000,
+  valuation_cap_aud_cents: 500_000_000,
+  wholesale_only: true,
+};
+
+const validGrant = {
+  file_id: "11111111-1111-1111-1111-111111111111",
+  inquiry_id: "22222222-2222-2222-2222-222222222222",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetUser.mockResolvedValue({ data: { user: { id: "u1" } } });
+  mockRequireStartupSession.mockResolvedValue("startup-1");
+});
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("startup capital-raising compliance gate", () => {
+  describe("round creation", () => {
+    it("returns 403 when raises are disabled (env unset)", async () => {
+      vi.stubEnv("STARTUP_RAISES_ENABLED", "");
+      const res = await roundPOST(makeReq(validPricedRound));
+      expect(res.status).toBe(403);
+      const json = (await res.json()) as { error: string };
+      expect(json.error).toMatch(/temporarily unavailable/i);
+    });
+
+    it("still returns 401 when unauthenticated (auth precedes the gate)", async () => {
+      vi.stubEnv("STARTUP_RAISES_ENABLED", "true");
+      mockGetUser.mockResolvedValueOnce({ data: { user: null } });
+      const res = await roundPOST(makeReq(validPricedRound));
+      expect(res.status).toBe(401);
+    });
+
+    it("rejects retail (non-wholesale) rounds even when enabled", async () => {
+      vi.stubEnv("STARTUP_RAISES_ENABLED", "true");
+      const res = await roundPOST(
+        makeReq({ ...validPricedRound, wholesale_only: false }),
+      );
+      expect(res.status).toBe(403);
+      const json = (await res.json()) as { error: string };
+      expect(json.error).toMatch(/wholesale/i);
+    });
+  });
+
+  describe("data-room grant", () => {
+    it("returns 403 when raises are disabled (env unset)", async () => {
+      vi.stubEnv("STARTUP_RAISES_ENABLED", "");
+      const res = await grantPOST(makeReq(validGrant));
+      expect(res.status).toBe(403);
+      const json = (await res.json()) as { error: string };
+      expect(json.error).toMatch(/temporarily unavailable/i);
+    });
+
+    it("returns 401 when there is no startup session", async () => {
+      mockRequireStartupSession.mockResolvedValueOnce(null);
+      const res = await grantPOST(makeReq(validGrant));
+      expect(res.status).toBe(401);
+    });
+  });
+});

--- a/__tests__/api/startup-round.test.ts
+++ b/__tests__/api/startup-round.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { NextRequest } from "next/server";
 
 // ─── Hoisted mocks ────────────────────────────────────────────────────────────
@@ -66,6 +66,9 @@ function makeServerFromMock(
 describe("POST /api/startups/round", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Capital-raising is gated OFF by default; these tests cover the
+    // post-gate business logic, so enable the flag for the suite.
+    vi.stubEnv("STARTUP_RAISES_ENABLED", "true");
     mockGetUser.mockResolvedValue({ data: { user: { id: "uid-1" } } });
     // Active profile, no open round (success default)
     mockServerFrom.mockImplementation(makeServerFromMock({ id: "sp-1", status: "active" }, null));
@@ -75,6 +78,10 @@ describe("POST /api/startups/round", () => {
       select: vi.fn().mockReturnThis(),
       single: vi.fn().mockResolvedValue({ data: { id: "round-1" }, error: null }),
     });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it("returns 401 when unauthenticated", async () => {

--- a/__tests__/lib/compliance-gates.test.ts
+++ b/__tests__/lib/compliance-gates.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { startupRaisesEnabled } from "@/lib/compliance-gates";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("startupRaisesEnabled", () => {
+  it("is false when the env var is unset", () => {
+    vi.stubEnv("STARTUP_RAISES_ENABLED", "");
+    expect(startupRaisesEnabled()).toBe(false);
+  });
+
+  it("is false for any value other than 'true'", () => {
+    vi.stubEnv("STARTUP_RAISES_ENABLED", "1");
+    expect(startupRaisesEnabled()).toBe(false);
+    vi.stubEnv("STARTUP_RAISES_ENABLED", "yes");
+    expect(startupRaisesEnabled()).toBe(false);
+    vi.stubEnv("STARTUP_RAISES_ENABLED", "TRUE");
+    expect(startupRaisesEnabled()).toBe(false);
+  });
+
+  it("is true only when exactly 'true'", () => {
+    vi.stubEnv("STARTUP_RAISES_ENABLED", "true");
+    expect(startupRaisesEnabled()).toBe(true);
+  });
+});

--- a/app/api/startups/data-room/grant/route.ts
+++ b/app/api/startups/data-room/grant/route.ts
@@ -3,6 +3,10 @@ import { z } from "zod";
 import { createClient } from "@/lib/supabase/server";
 import { requireStartupSession } from "@/lib/require-startup-session";
 import { logger } from "@/lib/logger";
+import {
+  startupRaisesEnabled,
+  STARTUP_RAISES_DISABLED_MESSAGE,
+} from "@/lib/compliance-gates";
 
 const log = logger("startups-data-room-grant");
 
@@ -14,6 +18,13 @@ const GrantSchema = z.object({
 export async function POST(request: NextRequest): Promise<NextResponse> {
   const startupId = await requireStartupSession(request);
   if (!startupId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  if (!startupRaisesEnabled()) {
+    return NextResponse.json(
+      { error: STARTUP_RAISES_DISABLED_MESSAGE },
+      { status: 403 },
+    );
+  }
 
   let body: unknown;
   try {

--- a/app/api/startups/round/route.ts
+++ b/app/api/startups/round/route.ts
@@ -3,6 +3,10 @@ import { z } from "zod";
 import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { logger } from "@/lib/logger";
+import {
+  startupRaisesEnabled,
+  STARTUP_RAISES_DISABLED_MESSAGE,
+} from "@/lib/compliance-gates";
 
 const log = logger("startups-round");
 
@@ -41,6 +45,13 @@ export async function POST(request: NextRequest) {
     const { data: { user } } = await supabase.auth.getUser();
     if (!user) return NextResponse.json({ error: "Unauthorised" }, { status: 401 });
 
+    if (!startupRaisesEnabled()) {
+      return NextResponse.json(
+        { error: STARTUP_RAISES_DISABLED_MESSAGE },
+        { status: 403 },
+      );
+    }
+
     const body: unknown = await request.json();
     const parsed = BaseRoundSchema.safeParse(body);
     if (!parsed.success) {
@@ -50,6 +61,16 @@ export async function POST(request: NextRequest) {
 
     const fieldError = validateInstrumentFields(parsed.data);
     if (fieldError) return NextResponse.json({ error: fieldError }, { status: 400 });
+
+    // Defence-in-depth: only wholesale-investor (s708) rounds are ever
+    // permitted under the planned licence; reject retail rounds server-side
+    // regardless of the client payload.
+    if (!parsed.data.wholesale_only) {
+      return NextResponse.json(
+        { error: "Only wholesale-investor (s708) rounds are permitted." },
+        { status: 403 },
+      );
+    }
 
     // Resolve startup profile via RLS-aware client
     const { data: profile } = await supabase

--- a/lib/compliance-gates.ts
+++ b/lib/compliance-gates.ts
@@ -1,0 +1,25 @@
+/**
+ * Default-OFF gates for flows that need regulatory authorisation BEYOND the
+ * planned general-advice AFSL (see docs/strategy/REGULATORY-AVOID-LIST.md).
+ *
+ * These are intentionally env-var driven, NOT admin-toggleable feature flags
+ * (`lib/feature-flags.ts`): flipping one of these on is a deliberate
+ * infrastructure change that must follow founder + legal sign-off, and must
+ * not be reachable from an admin toggle UI. Unset (the default) means OFF.
+ */
+
+/**
+ * Startup capital-raising — opening rounds, sharing data-room materials,
+ * matching investors to offers — is crowd-sourced-funding (CSF) intermediary
+ * territory (RG 261/262). It requires a CSF intermediary authorisation the
+ * entity does not hold. OFF until that authorisation is granted.
+ *
+ * Set `STARTUP_RAISES_ENABLED=true` to re-enable (founder + legal sign-off
+ * required).
+ */
+export function startupRaisesEnabled(): boolean {
+  return process.env.STARTUP_RAISES_ENABLED === "true";
+}
+
+export const STARTUP_RAISES_DISABLED_MESSAGE =
+  "Capital-raising features are temporarily unavailable pending regulatory authorisation.";


### PR DESCRIPTION
## What

The startup capital-raising flow was **live and open**: opening a round (`POST /api/startups/round`) and granting data-room access (`POST /api/startups/data-room/grant`) facilitate crowd-sourced funding / investor-to-offer matching — **CSF intermediary territory (RG 261/262)**, an authorisation the entity does not hold and which is on `docs/strategy/REGULATORY-AVOID-LIST.md`. There was no server-side compliance gate, and `wholesale_only` was a caller-controlled flag with nothing preventing a retail round.

## Fix

- New `lib/compliance-gates.ts` → `startupRaisesEnabled()`, reading `STARTUP_RAISES_ENABLED` (default **OFF**). Deliberately **env-driven, not an admin-toggleable feature flag** — flipping it on is an infra change gated on founder + legal sign-off, not reachable from an admin UI.
- Both raise endpoints return `403` with a "temporarily unavailable pending regulatory authorisation" message when disabled.
- **Defence-in-depth:** the round route now rejects non-wholesale (`wholesale_only === false`) rounds server-side regardless of payload.
- Documented the flag in `.env.local.example`.

## Notes

- The sibling concern (`tax-optimizer` / `portfolio-xray`) needed **no change** — both API routes already return `410 Gone` (already disabled pre-AFSL); the pages were deliberately left as client-side factual calculators.
- The existing `startup-round` / `data-room-grant` suites now run with the flag enabled (they cover the post-gate business logic).

## Verified

`tsc --noEmit` clean; **94 startup tests pass** (9 files, incl. the new gate tests); eslint clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUfSRE2Teb6VhEXFP6RpS9)_