### PR TITLE
feat: investor-Pro activation, advisor handoff, net-worth balances, health-score pages, live loan rates, forum seed + chat

### DIFF
--- a/__tests__/api/account-holdings-handoff.test.ts
+++ b/__tests__/api/account-holdings-handoff.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { NextRequest } from "next/server";
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+const mockGetUser = vi.fn<(...args: unknown[]) => Promise<unknown>>(async () => ({
+  data: { user: { id: "user-uuid-1", email: "user@example.com" } },
+  error: null,
+}));
+
+function makeBuilder(result: unknown = { data: null, error: null }) {
+  const b: Record<string, unknown> = {};
+  for (const m of [
+    "select","insert","update","upsert","delete","eq","neq","gt","gte",
+    "lt","lte","in","is","not","or","order","limit","range","single",
+    "maybeSingle","filter","contains","lte",
+  ]) {
+    b[m] = vi.fn(() => b);
+  }
+  b.then = (cb: (v: unknown) => unknown) => Promise.resolve(cb(result));
+  return b;
+}
+
+const mockFrom = vi.fn(() => makeBuilder());
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({
+    from: mockFrom,
+    auth: { getUser: mockGetUser },
+  })),
+}));
+
+// Mock crypto.randomUUID so tests have deterministic tokens
+const { mockRandomUUID } = vi.hoisted(() => ({ mockRandomUUID: vi.fn(() => "test-token-uuid-1234") }));
+vi.stubGlobal("crypto", { randomUUID: mockRandomUUID });
+
+import { POST } from "@/app/api/account/holdings/handoff/route";
+
+function makeReq(body?: unknown): NextRequest {
+  return new Request("http://localhost/api/account/holdings/handoff", {
+    method: "POST",
+    ...(body !== undefined
+      ? { body: JSON.stringify(body), headers: { "content-type": "application/json" } }
+      : { body: JSON.stringify({}), headers: { "content-type": "application/json" } }),
+  }) as unknown as NextRequest;
+}
+
+describe("POST /api/account/holdings/handoff", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-uuid-1", email: "user@example.com" } },
+      error: null,
+    });
+    // holdings fetch returns empty list; insert succeeds
+    mockFrom.mockImplementation(() => makeBuilder({ data: [], error: null }));
+  });
+
+  it("returns 401 for unauthenticated requests", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+    const res = await POST(makeReq());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 201 with token on success", async () => {
+    // First call is holdings select (returns empty array), second is insert (returns null row)
+    mockFrom.mockImplementationOnce(() => makeBuilder({ data: [], error: null }));
+    mockFrom.mockImplementationOnce(() => makeBuilder({ data: null, error: null }));
+
+    const res = await POST(makeReq({ intent: "tax-prep" }));
+    expect(res.status).toBe(201);
+    const json = await res.json() as { token: string };
+    expect(json).toHaveProperty("token");
+    expect(typeof json.token).toBe("string");
+  });
+
+  it("defaults intent to tax-prep when not provided", async () => {
+    mockFrom.mockImplementation(() => makeBuilder({ data: [], error: null }));
+    const res = await POST(makeReq({}));
+    expect(res.status).toBe(201);
+  });
+
+  it("returns 500 when holdings fetch fails", async () => {
+    mockFrom.mockImplementation(() => makeBuilder({ data: null, error: { message: "db error" } }));
+    const res = await POST(makeReq());
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 500 when insert fails", async () => {
+    mockFrom.mockImplementationOnce(() => makeBuilder({ data: [], error: null }));
+    mockFrom.mockImplementationOnce(() => makeBuilder({ data: null, error: { message: "insert error" } }));
+    const res = await POST(makeReq());
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 400 for invalid intent value (too long)", async () => {
+    const res = await POST(makeReq({ intent: "x".repeat(101) }));
+    expect(res.status).toBe(400);
+  });
+});

--- a/__tests__/api/account-net-worth-balances.test.ts
+++ b/__tests__/api/account-net-worth-balances.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { NextRequest } from "next/server";
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+const mockGetUser = vi.fn<(...args: unknown[]) => Promise<unknown>>(async () => ({
+  data: { user: { id: "u1", email: "user@example.com" } },
+  error: null,
+}));
+
+function makeBuilder(result: unknown = { data: [], error: null }) {
+  const b: Record<string, unknown> = {};
+  for (const m of [
+    "select","insert","update","upsert","delete","eq","neq","gt","gte",
+    "lt","lte","in","is","not","or","order","limit","range","single",
+    "maybeSingle","filter","contains",
+  ]) {
+    b[m] = vi.fn(() => b);
+  }
+  b.then = (cb: (v: unknown) => unknown) => Promise.resolve(cb(result));
+  return b;
+}
+
+const mockFrom = vi.fn(() => makeBuilder());
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({
+    from: mockFrom,
+    auth: { getUser: mockGetUser },
+  })),
+}));
+
+import { GET, POST, DELETE } from "@/app/api/account/net-worth/balances/route";
+
+function makeReq(method = "GET", body?: unknown): NextRequest {
+  return new Request("http://localhost/api/account/net-worth/balances", {
+    method,
+    ...(body !== undefined
+      ? { body: JSON.stringify(body), headers: { "content-type": "application/json" } }
+      : {}),
+  }) as unknown as NextRequest;
+}
+
+const validBalance = {
+  label: "ING Savings",
+  amount_cents: 2500000,
+  category: "savings",
+};
+
+describe("/api/account/net-worth/balances", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "u1", email: "user@example.com" } },
+      error: null,
+    });
+    mockFrom.mockImplementation(() => makeBuilder({ data: [], error: null }));
+  });
+
+  // ─── GET ────────────────────────────────────────────────────────────────────
+
+  it("GET returns 401 for unauthenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
+  it("GET returns empty items list", async () => {
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const json = await res.json() as { items: unknown[] };
+    expect(Array.isArray(json.items)).toBe(true);
+  });
+
+  it("GET returns 500 on query error", async () => {
+    mockFrom.mockImplementation(() => makeBuilder({ data: null, error: { message: "db error" } }));
+    const res = await GET();
+    expect(res.status).toBe(500);
+  });
+
+  // ─── POST ───────────────────────────────────────────────────────────────────
+
+  it("POST returns 401 for unauthenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+    const res = await POST(makeReq("POST", validBalance));
+    expect(res.status).toBe(401);
+  });
+
+  it("POST returns 400 for missing label", async () => {
+    const res = await POST(makeReq("POST", { amount_cents: 100, category: "savings" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("POST returns 400 for invalid category", async () => {
+    const res = await POST(makeReq("POST", { ...validBalance, category: "bitcoin" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("POST returns 400 for negative amount", async () => {
+    const res = await POST(makeReq("POST", { ...validBalance, amount_cents: -1 }));
+    expect(res.status).toBe(400);
+  });
+
+  it("POST creates balance successfully", async () => {
+    const item = { id: "some-uuid", ...validBalance, updated_at: new Date().toISOString() };
+    mockFrom.mockImplementation(() => makeBuilder({ data: item, error: null }));
+    const res = await POST(makeReq("POST", validBalance));
+    expect(res.status).toBe(201);
+    const json = await res.json() as { item: unknown };
+    expect(json).toHaveProperty("item");
+  });
+
+  it("POST returns 500 on insert error", async () => {
+    mockFrom.mockImplementation(() => makeBuilder({ data: null, error: { message: "insert failed" } }));
+    const res = await POST(makeReq("POST", validBalance));
+    expect(res.status).toBe(500);
+  });
+
+  // ─── DELETE ─────────────────────────────────────────────────────────────────
+
+  it("DELETE returns 401 for unauthenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+    const res = await DELETE(makeReq("DELETE", { id: "some-uuid-1234-1234-1234-123456789012" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("DELETE returns 400 for missing id", async () => {
+    const res = await DELETE(makeReq("DELETE", {}));
+    expect(res.status).toBe(400);
+  });
+
+  it("DELETE returns 400 for non-UUID id", async () => {
+    const res = await DELETE(makeReq("DELETE", { id: "not-a-uuid" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("DELETE removes balance successfully", async () => {
+    mockFrom.mockImplementation(() => makeBuilder({ data: null, error: null }));
+    const res = await DELETE(makeReq("DELETE", { id: "11111111-1111-1111-1111-111111111111" }));
+    expect(res.status).toBe(200);
+    const json = await res.json() as { ok: boolean };
+    expect(json.ok).toBe(true);
+  });
+
+  it("DELETE returns 500 on db error", async () => {
+    mockFrom.mockImplementation(() => makeBuilder({ data: null, error: { message: "delete failed" } }));
+    const res = await DELETE(makeReq("DELETE", { id: "11111111-1111-1111-1111-111111111111" }));
+    expect(res.status).toBe(500);
+  });
+});

--- a/__tests__/api/account-net-worth-balances.test.ts
+++ b/__tests__/api/account-net-worth-balances.test.ts
@@ -122,7 +122,7 @@ describe("/api/account/net-worth/balances", () => {
 
   it("DELETE returns 401 for unauthenticated", async () => {
     mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
-    const res = await DELETE(makeReq("DELETE", { id: "some-uuid-1234-1234-1234-123456789012" }));
+    const res = await DELETE(makeReq("DELETE", { id: "11111111-1111-4111-8111-111111111111" }));
     expect(res.status).toBe(401);
   });
 
@@ -138,7 +138,7 @@ describe("/api/account/net-worth/balances", () => {
 
   it("DELETE removes balance successfully", async () => {
     mockFrom.mockImplementation(() => makeBuilder({ data: null, error: null }));
-    const res = await DELETE(makeReq("DELETE", { id: "11111111-1111-1111-1111-111111111111" }));
+    const res = await DELETE(makeReq("DELETE", { id: "11111111-1111-4111-8111-111111111111" }));
     expect(res.status).toBe(200);
     const json = await res.json() as { ok: boolean };
     expect(json.ok).toBe(true);
@@ -146,7 +146,7 @@ describe("/api/account/net-worth/balances", () => {
 
   it("DELETE returns 500 on db error", async () => {
     mockFrom.mockImplementation(() => makeBuilder({ data: null, error: { message: "delete failed" } }));
-    const res = await DELETE(makeReq("DELETE", { id: "11111111-1111-1111-1111-111111111111" }));
+    const res = await DELETE(makeReq("DELETE", { id: "11111111-1111-4111-8111-111111111111" }));
     expect(res.status).toBe(500);
   });
 });

--- a/__tests__/api/advisor-portal-firm-leads.test.ts
+++ b/__tests__/api/advisor-portal-firm-leads.test.ts
@@ -1,0 +1,340 @@
+/**
+ * Tests for GET + PATCH /api/advisor-portal/firm-leads
+ *
+ * Covers:
+ *   GET  – rate-limit, auth guard, firm-admin gate, happy path
+ *   PATCH – rate-limit, auth guard, body validation, firm-admin gate,
+ *           target-advisor guard, DB error, happy path + notification side-effect
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+// rate-limit-db (used in the route)
+const { mockIsAllowed } = vi.hoisted(() => ({
+  mockIsAllowed: vi.fn<() => Promise<boolean>>().mockResolvedValue(true),
+}));
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: (..._: unknown[]) => mockIsAllowed(),
+  ipKey: vi.fn(() => "127.0.0.1"),
+}));
+
+// requireAdvisorSession
+const { mockAdvisorSession } = vi.hoisted(() => ({
+  mockAdvisorSession: vi.fn<() => Promise<number | null>>().mockResolvedValue(1),
+}));
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: (_req: unknown) => mockAdvisorSession(),
+}));
+
+// notifications
+const { mockNotifyUserByEmail } = vi.hoisted(() => ({
+  mockNotifyUserByEmail: vi.fn<() => Promise<{ notified: boolean }>>().mockResolvedValue({ notified: true }),
+}));
+vi.mock("@/lib/notifications", () => ({
+  notifyUserByEmail: (..._: unknown[]) => mockNotifyUserByEmail(),
+}));
+
+// resend email
+const { mockSendEmail } = vi.hoisted(() => ({
+  mockSendEmail: vi.fn<() => Promise<{ ok: boolean }>>().mockResolvedValue({ ok: true }),
+}));
+vi.mock("@/lib/resend", () => ({
+  sendEmail: (..._: unknown[]) => mockSendEmail(),
+}));
+
+// Supabase admin — table-dispatch pattern
+type MockRow = Record<string, unknown> | null;
+interface TableMockConfig {
+  caller?: MockRow;
+  target?: MockRow;
+  members?: MockRow[];
+  leads?: MockRow[];
+  updateError?: { message: string } | null;
+  targetAdvisor?: MockRow;
+  lead?: MockRow;
+}
+
+let tableConfig: TableMockConfig = {};
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({
+    from: vi.fn((table: string) => {
+      if (table === "professionals") {
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          maybeSingle: vi.fn(() =>
+            Promise.resolve({
+              data:
+                // For the PATCH target advisor lookup (name + email), return targetAdvisor if set.
+                // Otherwise return caller for the first call.
+                tableConfig.targetAdvisor !== undefined
+                  ? tableConfig.targetAdvisor
+                  : tableConfig.caller ?? null,
+            })
+          ),
+        };
+      }
+      if (table === "professional_leads") {
+        return {
+          select: vi.fn().mockReturnThis(),
+          update: vi.fn().mockReturnThis(),
+          in: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          order: vi.fn().mockReturnThis(),
+          limit: vi.fn(() =>
+            Promise.resolve({
+              data: tableConfig.leads ?? [],
+              error: tableConfig.updateError ?? null,
+            })
+          ),
+          // .update().eq() terminal
+          then: undefined,
+        };
+      }
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        in: vi.fn().mockReturnThis(),
+        order: vi.fn().mockReturnThis(),
+        limit: vi.fn(() => Promise.resolve({ data: [], error: null })),
+      };
+    }),
+  })),
+}));
+
+import { GET, PATCH } from "@/app/api/advisor-portal/firm-leads/route";
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makeGet(params: Record<string, string> = {}) {
+  const qs = new URLSearchParams(params).toString();
+  return new Request(`http://localhost/api/advisor-portal/firm-leads${qs ? `?${qs}` : ""}`, {
+    method: "GET",
+    headers: { "x-forwarded-for": "127.0.0.1" },
+  });
+}
+
+function makePatch(body: unknown) {
+  return new Request("http://localhost/api/advisor-portal/firm-leads", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json", "x-forwarded-for": "127.0.0.1" },
+    body: JSON.stringify(body),
+  });
+}
+
+// ─── GET tests ──────────────────────────────────────────────────────────────
+
+describe("GET /api/advisor-portal/firm-leads", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tableConfig = {};
+    mockIsAllowed.mockResolvedValue(true);
+    mockAdvisorSession.mockResolvedValue(1);
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    mockIsAllowed.mockResolvedValue(false);
+    const res = await GET(makeGet() as never);
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockAdvisorSession.mockResolvedValue(null);
+    const res = await GET(makeGet() as never);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when caller is not a firm admin", async () => {
+    tableConfig.caller = { id: 1, firm_id: null, is_firm_admin: false };
+    const res = await GET(makeGet() as never);
+    expect(res.status).toBe(403);
+  });
+});
+
+// ─── PATCH tests ─────────────────────────────────────────────────────────────
+
+describe("PATCH /api/advisor-portal/firm-leads", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tableConfig = {};
+    mockIsAllowed.mockResolvedValue(true);
+    mockAdvisorSession.mockResolvedValue(1);
+    mockNotifyUserByEmail.mockResolvedValue({ notified: true });
+    mockSendEmail.mockResolvedValue({ ok: true });
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    mockIsAllowed.mockResolvedValue(false);
+    const res = await PATCH(makePatch({ lead_id: 1, professional_id: 2 }) as never);
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockAdvisorSession.mockResolvedValue(null);
+    const res = await PATCH(makePatch({ lead_id: 1, professional_id: 2 }) as never);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for invalid body", async () => {
+    const res = await PATCH(makePatch({ lead_id: "not-a-number" }) as never);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when body is not valid JSON", async () => {
+    const req = new Request("http://localhost/api/advisor-portal/firm-leads", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", "x-forwarded-for": "127.0.0.1" },
+      body: "not json",
+    });
+    const res = await PATCH(req as never);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 403 when caller is not a firm admin", async () => {
+    tableConfig.caller = { firm_id: null, is_firm_admin: false };
+    const res = await PATCH(makePatch({ lead_id: 1, professional_id: 2 }) as never);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 200 and { ok: true } on successful reassignment", async () => {
+    // Set up a multi-call mock: first call returns caller, subsequent calls
+    // return target. We use a real multi-call admin client.
+    const callerData = { firm_id: 10, is_firm_admin: true };
+    const targetData = { id: 2, firm_id: 10 };
+    const advisorEmailData = { name: "Bob Advisor", email: "bob@advisor.test" };
+    const leadData = {
+      user_name: "Jane Investor",
+      user_email: "jane@investor.test",
+      user_phone: null,
+      source_page: "/advisors",
+      message: "Need help with retirement",
+      status: "new",
+    };
+
+    // Override admin mock to handle the sequence of calls correctly
+    const { createAdminClient } = await import("@/lib/supabase/admin");
+    const adminMock = createAdminClient as ReturnType<typeof vi.fn>;
+    let callCount = 0;
+    adminMock.mockImplementation(() => ({
+      from: vi.fn((table: string) => {
+        if (table === "professionals") {
+          callCount++;
+          if (callCount === 1) {
+            // caller lookup
+            return {
+              select: vi.fn().mockReturnThis(),
+              eq: vi.fn().mockReturnThis(),
+              maybeSingle: vi.fn(() => Promise.resolve({ data: callerData })),
+            };
+          }
+          if (callCount === 2) {
+            // target verification
+            return {
+              select: vi.fn().mockReturnThis(),
+              eq: vi.fn().mockReturnThis(),
+              maybeSingle: vi.fn(() => Promise.resolve({ data: targetData })),
+            };
+          }
+          // target advisor email lookup (notification)
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn(() => Promise.resolve({ data: advisorEmailData })),
+          };
+        }
+        if (table === "professional_leads") {
+          return {
+            update: vi.fn(() => ({
+              eq: vi.fn(() => Promise.resolve({ error: null })),
+            })),
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn(() => Promise.resolve({ data: leadData })),
+          };
+        }
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          maybeSingle: vi.fn(() => Promise.resolve({ data: null })),
+        };
+      }),
+    }));
+
+    const res = await PATCH(makePatch({ lead_id: 1, professional_id: 2 }) as never);
+    expect(res.status).toBe(200);
+    const json = await res.json() as { ok: boolean };
+    expect(json.ok).toBe(true);
+  });
+
+  it("returns 200 even when email notification fails (best-effort)", async () => {
+    mockSendEmail.mockResolvedValue({ ok: false });
+
+    const { createAdminClient } = await import("@/lib/supabase/admin");
+    const adminMock = createAdminClient as ReturnType<typeof vi.fn>;
+    let callCount = 0;
+    adminMock.mockImplementation(() => ({
+      from: vi.fn((table: string) => {
+        if (table === "professionals") {
+          callCount++;
+          if (callCount === 1) {
+            return {
+              select: vi.fn().mockReturnThis(),
+              eq: vi.fn().mockReturnThis(),
+              maybeSingle: vi.fn(() =>
+                Promise.resolve({ data: { firm_id: 10, is_firm_admin: true } })
+              ),
+            };
+          }
+          if (callCount === 2) {
+            return {
+              select: vi.fn().mockReturnThis(),
+              eq: vi.fn().mockReturnThis(),
+              maybeSingle: vi.fn(() =>
+                Promise.resolve({ data: { id: 2, firm_id: 10 } })
+              ),
+            };
+          }
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn(() =>
+              Promise.resolve({ data: { name: "Bob", email: "bob@test.com" } })
+            ),
+          };
+        }
+        if (table === "professional_leads") {
+          return {
+            update: vi.fn(() => ({
+              eq: vi.fn(() => Promise.resolve({ error: null })),
+            })),
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn(() =>
+              Promise.resolve({ data: { user_name: "Jane", user_email: "j@t.com", user_phone: null, source_page: null, message: null, status: "new" } })
+            ),
+          };
+        }
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          maybeSingle: vi.fn(() => Promise.resolve({ data: null })),
+        };
+      }),
+    }));
+
+    const res = await PATCH(makePatch({ lead_id: 5, professional_id: 2 }) as never);
+    // Reassignment succeeded; email failure should not affect HTTP status.
+    expect(res.status).toBe(200);
+  });
+});

--- a/__tests__/components/FeeImpactResults.test.tsx
+++ b/__tests__/components/FeeImpactResults.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Tests for FeeImpactResults — specifically the Pro gating overlay and
+ * the upgrade CTA that replaced the old "Coming Soon" button.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "./setup";
+import type { Broker } from "@/lib/types";
+
+// FeeImpactResults imports trackEvent from @/lib/tracking — already mocked in
+// setup.tsx.  We also need to stub Icon and csv-export to prevent module errors.
+
+vi.mock("@/lib/csv-export", () => ({
+  downloadCSV: vi.fn(),
+}));
+
+vi.mock("@/components/Icon", () => ({
+  default: ({ name }: { name: string }) => <span data-testid={`icon-${name}`} />,
+}));
+
+import FeeImpactResults from "@/app/fee-impact/_components/FeeImpactResults";
+
+// Minimal broker fixture
+const makeBroker = (slug: string, name: string): Broker =>
+  ({
+    slug,
+    name,
+    color: "#000000",
+    icon: null,
+    asx_fee_value: 9.5,
+    us_fee_value: 0,
+    fx_rate: null,
+    inactivity_fee: null,
+  }) as unknown as Broker;
+
+const makeFeeResult = (slug: string, total: number) => ({
+  broker: makeBroker(slug, slug),
+  asxFees: total,
+  usFees: 0,
+  fxFees: 0,
+  inactivityFees: 0,
+  totalAnnual: total,
+});
+
+const FIVE_RESULTS = [1, 2, 3, 4, 5].map((n) =>
+  makeFeeResult(`broker-${n}`, n * 100),
+);
+
+const SHARED_PROPS = {
+  results: FIVE_RESULTS,
+  cheapest: FIVE_RESULTS[0],
+  mostExpensive: FIVE_RESULTS[4],
+  currentBrokerResult: undefined,
+  maxSavings: 400,
+  maxTotal: 500,
+  asxTrades: "4",
+  usTrades: "0",
+  avgTradeSize: "5000",
+  currentBrokerSlug: "",
+  AnimatedNumber: ({ value, prefix = "$" }: { value: number; prefix?: string; decimals?: number }) => (
+    <span>{prefix}{value}</span>
+  ),
+  ShareResultsButton: () => <div data-testid="share-btn" />,
+};
+
+describe("FeeImpactResults — Pro gating overlay", () => {
+  it("renders an active upgrade link (not 'Coming Soon') for non-Pro with hidden brokers", () => {
+    render(
+      <FeeImpactResults
+        {...SHARED_PROPS}
+        visibleResults={FIVE_RESULTS.slice(0, 3)}
+        hiddenCount={2}
+        isPro={false}
+      />,
+    );
+
+    // The old dead button text should be gone
+    expect(screen.queryByText("Coming Soon")).not.toBeInTheDocument();
+
+    // The new active link should point to the upgrade page
+    const upgradeLink = screen.getByRole("link", { name: /unlock 2 more brokers/i });
+    expect(upgradeLink).toHaveAttribute("href", "/account/upgrade");
+  });
+
+  it("renders singular 'broker' when hiddenCount is 1", () => {
+    render(
+      <FeeImpactResults
+        {...SHARED_PROPS}
+        results={FIVE_RESULTS.slice(0, 4)}
+        visibleResults={FIVE_RESULTS.slice(0, 3)}
+        hiddenCount={1}
+        isPro={false}
+      />,
+    );
+
+    const upgradeLink = screen.getByRole("link", { name: /unlock 1 more broker$/i });
+    expect(upgradeLink).toBeInTheDocument();
+  });
+
+  it("does not render the gating overlay for Pro users", () => {
+    render(
+      <FeeImpactResults
+        {...SHARED_PROPS}
+        visibleResults={FIVE_RESULTS}
+        hiddenCount={0}
+        isPro={true}
+      />,
+    );
+    expect(screen.queryByText(/unlock \d+ more broker/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("FeeImpactResults — empty state", () => {
+  it("renders the empty-state prompt when no results", () => {
+    render(
+      <FeeImpactResults
+        {...SHARED_PROPS}
+        results={[]}
+        visibleResults={[]}
+        hiddenCount={0}
+        cheapest={undefined}
+        mostExpensive={undefined}
+        maxSavings={0}
+        maxTotal={1}
+        isPro={false}
+      />,
+    );
+    expect(screen.getByText("Enter Your Trading Details")).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/InvestorProCheckout.test.tsx
+++ b/__tests__/components/InvestorProCheckout.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Tests for the InvestorProCheckout client component.
+ *
+ * The component handles plan-toggle and Stripe checkout redirect.
+ * We mock useSubscription to control auth + subscription state.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "./setup";
+
+// ── Hoist mocks before imports ──────────────────────────────────────────────
+
+const { mockUseSubscription, mockRouterPush, mockFetch } = vi.hoisted(() => ({
+  mockUseSubscription: vi.fn(),
+  mockRouterPush: vi.fn(),
+  mockFetch: vi.fn(),
+}));
+
+vi.mock("@/lib/hooks/useSubscription", () => ({
+  useSubscription: mockUseSubscription,
+}));
+
+// next/navigation is already mocked in setup.tsx; we re-mock push here so
+// we can assert on it in individual tests.
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockRouterPush }),
+  usePathname: () => "/account/upgrade",
+  useSearchParams: () => new URLSearchParams(),
+  useParams: () => ({}),
+}));
+
+// ── Import subject after mocks are declared ─────────────────────────────────
+
+import InvestorProCheckout from "@/app/account/upgrade/InvestorProCheckout";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function freeUser() {
+  mockUseSubscription.mockReturnValue({
+    user: { id: "u1", email: "test@example.com" },
+    isPro: false,
+    loading: false,
+  });
+}
+
+function proUser() {
+  mockUseSubscription.mockReturnValue({
+    user: { id: "u1", email: "test@example.com" },
+    isPro: true,
+    loading: false,
+  });
+}
+
+function notLoggedIn() {
+  mockUseSubscription.mockReturnValue({
+    user: null,
+    isPro: false,
+    loading: false,
+  });
+}
+
+beforeEach(() => {
+  mockRouterPush.mockReset();
+  mockFetch.mockReset();
+  // Restore the global fetch before each test
+  vi.stubGlobal("fetch", mockFetch);
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("InvestorProCheckout — authenticated free user", () => {
+  it("renders the Pro tile with Subscribe Now CTA", () => {
+    freeUser();
+    render(<InvestorProCheckout />);
+    expect(screen.getByRole("heading", { name: /investor pro/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /subscribe now/i })).toBeInTheDocument();
+  });
+
+  it("defaults to yearly plan", () => {
+    freeUser();
+    render(<InvestorProCheckout />);
+    // Yearly price ($89) should be displayed
+    expect(screen.getByText("$89")).toBeInTheDocument();
+    // Monthly equivalent copy
+    expect(screen.getByText(/7\.42\/month/i)).toBeInTheDocument();
+  });
+
+  it("can toggle to monthly plan", () => {
+    freeUser();
+    render(<InvestorProCheckout />);
+    const monthlyBtn = screen.getByRole("button", { name: /monthly/i });
+    fireEvent.click(monthlyBtn);
+    expect(screen.getByText("$9")).toBeInTheDocument();
+  });
+
+  it("lists the Pro benefits", () => {
+    freeUser();
+    render(<InvestorProCheckout />);
+    expect(screen.getByText("Unlimited holdings tracker")).toBeInTheDocument();
+    expect(screen.getByText("Sharesight sync")).toBeInTheDocument();
+    expect(screen.getByText("Fee alerts")).toBeInTheDocument();
+  });
+
+  it("calls checkout API with selected plan and redirects on success", async () => {
+    freeUser();
+    mockFetch.mockResolvedValueOnce({
+      json: async () => ({ url: "https://checkout.stripe.com/session/abc" }),
+    });
+
+    render(<InvestorProCheckout />);
+    const btn = screen.getByRole("button", { name: /subscribe now/i });
+    fireEvent.click(btn);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/stripe/create-checkout",
+      expect.objectContaining({
+        method: "POST",
+        body: expect.stringContaining('"plan":"yearly"'),
+      }),
+    );
+  });
+
+  it("shows an error message when checkout API fails", async () => {
+    freeUser();
+    mockFetch.mockResolvedValueOnce({
+      json: async () => ({ error: "Plan not configured" }),
+    });
+
+    render(<InvestorProCheckout />);
+    const btn = screen.getByRole("button", { name: /subscribe now/i });
+    fireEvent.click(btn);
+
+    // Error appears asynchronously after the fetch resolves
+    await screen.findByRole("alert");
+    expect(screen.getByRole("alert")).toHaveTextContent("Plan not configured");
+  });
+});
+
+describe("InvestorProCheckout — unauthenticated user", () => {
+  it("renders Sign In & Subscribe CTA", () => {
+    notLoggedIn();
+    render(<InvestorProCheckout />);
+    expect(screen.getByRole("button", { name: /sign in & subscribe/i })).toBeInTheDocument();
+  });
+
+  it("redirects to login on CTA click", () => {
+    notLoggedIn();
+    render(<InvestorProCheckout />);
+    fireEvent.click(screen.getByRole("button", { name: /sign in & subscribe/i }));
+    expect(mockRouterPush).toHaveBeenCalledWith("/auth/login?next=/account/upgrade");
+  });
+});
+
+describe("InvestorProCheckout — existing Pro subscriber", () => {
+  it("renders the Active state with a go-to-account link", () => {
+    proUser();
+    render(<InvestorProCheckout />);
+    expect(screen.getByText(/active/i)).toBeInTheDocument();
+    const link = screen.getByRole("link", { name: /go to account/i });
+    expect(link).toHaveAttribute("href", "/account");
+  });
+
+  it("does not render the Subscribe Now button", () => {
+    proUser();
+    render(<InvestorProCheckout />);
+    expect(screen.queryByRole("button", { name: /subscribe now/i })).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/components/InvestorProCheckout.test.tsx
+++ b/__tests__/components/InvestorProCheckout.test.tsx
@@ -7,13 +7,13 @@
  * We mock useSubscription to control auth + subscription state.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "./setup";
+import { render, screen, mockPush } from "./setup";
+import { fireEvent } from "@testing-library/react";
 
 // ── Hoist mocks before imports ──────────────────────────────────────────────
 
-const { mockUseSubscription, mockRouterPush, mockFetch } = vi.hoisted(() => ({
+const { mockUseSubscription, mockFetch } = vi.hoisted(() => ({
   mockUseSubscription: vi.fn(),
-  mockRouterPush: vi.fn(),
   mockFetch: vi.fn(),
 }));
 
@@ -21,14 +21,8 @@ vi.mock("@/lib/hooks/useSubscription", () => ({
   useSubscription: mockUseSubscription,
 }));
 
-// next/navigation is already mocked in setup.tsx; we re-mock push here so
-// we can assert on it in individual tests.
-vi.mock("next/navigation", () => ({
-  useRouter: () => ({ push: mockRouterPush }),
-  usePathname: () => "/account/upgrade",
-  useSearchParams: () => new URLSearchParams(),
-  useParams: () => ({}),
-}));
+// next/navigation (incl. the router push spy `mockPush`) is mocked globally
+// in ./setup — assert on the imported `mockPush` rather than re-mocking here.
 
 // ── Import subject after mocks are declared ─────────────────────────────────
 
@@ -61,7 +55,7 @@ function notLoggedIn() {
 }
 
 beforeEach(() => {
-  mockRouterPush.mockReset();
+  mockPush.mockReset();
   mockFetch.mockReset();
   // Restore the global fetch before each test
   vi.stubGlobal("fetch", mockFetch);
@@ -148,7 +142,7 @@ describe("InvestorProCheckout — unauthenticated user", () => {
     notLoggedIn();
     render(<InvestorProCheckout />);
     fireEvent.click(screen.getByRole("button", { name: /sign in & subscribe/i }));
-    expect(mockRouterPush).toHaveBeenCalledWith("/auth/login?next=/account/upgrade");
+    expect(mockPush).toHaveBeenCalledWith("/auth/login?next=/account/upgrade");
   });
 });
 
@@ -156,7 +150,7 @@ describe("InvestorProCheckout — existing Pro subscriber", () => {
   it("renders the Active state with a go-to-account link", () => {
     proUser();
     render(<InvestorProCheckout />);
-    expect(screen.getByText(/active/i)).toBeInTheDocument();
+    expect(screen.getByText("Active")).toBeInTheDocument();
     const link = screen.getByRole("link", { name: /go to account/i });
     expect(link).toHaveAttribute("href", "/account");
   });

--- a/__tests__/lib/investor-handoff.test.ts
+++ b/__tests__/lib/investor-handoff.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+function makeBuilder(result: unknown = { data: null, error: null }) {
+  const b: Record<string, unknown> = {};
+  for (const m of [
+    "select","update","eq","neq","order","single","maybeSingle","filter",
+  ]) {
+    b[m] = vi.fn(() => b);
+  }
+  b.then = (cb: (v: unknown) => unknown) => Promise.resolve(cb(result));
+  return b;
+}
+
+const mockFrom = vi.fn(() => makeBuilder());
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({
+    from: mockFrom,
+  })),
+}));
+
+import { getHandoff } from "@/lib/investor-handoff";
+
+const VALID_TOKEN = "a".repeat(36);
+
+const FUTURE_DATE = new Date(Date.now() + 10 * 24 * 60 * 60 * 1000).toISOString();
+
+const MOCK_HANDOFF_ROW = {
+  id: "row-uuid",
+  intent: "tax-prep",
+  holdings_snapshot_json: [
+    {
+      ticker: "VAS",
+      exchange: "ASX",
+      shares: 100,
+      cost_basis_per_share_cents: 9500,
+      acquired_at: "2024-01-15",
+      broker_slug: null,
+      notes: null,
+    },
+  ],
+  expires_at: FUTURE_DATE,
+  consumed_at: null,
+  created_at: new Date().toISOString(),
+};
+
+describe("getHandoff", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns null for empty token", async () => {
+    const result = await getHandoff("");
+    expect(result).toBeNull();
+  });
+
+  it("returns null for oversized token", async () => {
+    const result = await getHandoff("x".repeat(201));
+    expect(result).toBeNull();
+  });
+
+  it("returns null when DB lookup fails", async () => {
+    mockFrom.mockImplementation(() => makeBuilder({ data: null, error: { message: "db error" } }));
+    const result = await getHandoff(VALID_TOKEN);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when token not found", async () => {
+    mockFrom.mockImplementation(() => makeBuilder({ data: null, error: null }));
+    const result = await getHandoff(VALID_TOKEN);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when token already consumed", async () => {
+    const consumed = { ...MOCK_HANDOFF_ROW, consumed_at: new Date().toISOString() };
+    mockFrom.mockImplementation(() => makeBuilder({ data: consumed, error: null }));
+    const result = await getHandoff(VALID_TOKEN);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when token is expired", async () => {
+    const expired = {
+      ...MOCK_HANDOFF_ROW,
+      expires_at: new Date(Date.now() - 1000).toISOString(),
+    };
+    mockFrom.mockImplementation(() => makeBuilder({ data: expired, error: null }));
+    const result = await getHandoff(VALID_TOKEN);
+    expect(result).toBeNull();
+  });
+
+  it("returns handoff data for a valid, unexpired, unconsumed token", async () => {
+    // First call: maybeSingle lookup; second call: update consumed_at
+    mockFrom
+      .mockImplementationOnce(() => makeBuilder({ data: MOCK_HANDOFF_ROW, error: null }))
+      .mockImplementationOnce(() => makeBuilder({ data: null, error: null }));
+
+    const result = await getHandoff(VALID_TOKEN);
+    expect(result).not.toBeNull();
+    expect(result?.intent).toBe("tax-prep");
+    expect(result?.holdings).toHaveLength(1);
+    expect(result?.holdings[0]?.ticker).toBe("VAS");
+  });
+
+  it("still returns data if consumed_at update fails (best-effort)", async () => {
+    mockFrom
+      .mockImplementationOnce(() => makeBuilder({ data: MOCK_HANDOFF_ROW, error: null }))
+      .mockImplementationOnce(() => makeBuilder({ data: null, error: { message: "update failed" } }));
+
+    const result = await getHandoff(VALID_TOKEN);
+    expect(result).not.toBeNull();
+    expect(result?.holdings).toHaveLength(1);
+  });
+
+  it("maps snapshot fields correctly including nulls", async () => {
+    const rowWithNulls = {
+      ...MOCK_HANDOFF_ROW,
+      holdings_snapshot_json: [
+        {
+          ticker: "CBA",
+          exchange: "ASX",
+          shares: 50,
+          cost_basis_per_share_cents: 10000,
+          acquired_at: "2023-06-01",
+          broker_slug: "commsec",
+          notes: "Initial purchase",
+        },
+      ],
+    };
+    mockFrom
+      .mockImplementationOnce(() => makeBuilder({ data: rowWithNulls, error: null }))
+      .mockImplementationOnce(() => makeBuilder({ data: null, error: null }));
+
+    const result = await getHandoff(VALID_TOKEN);
+    expect(result?.holdings[0]?.broker_slug).toBe("commsec");
+    expect(result?.holdings[0]?.notes).toBe("Initial purchase");
+  });
+
+  it("handles empty holdings snapshot", async () => {
+    const emptyRow = { ...MOCK_HANDOFF_ROW, holdings_snapshot_json: [] };
+    mockFrom
+      .mockImplementationOnce(() => makeBuilder({ data: emptyRow, error: null }))
+      .mockImplementationOnce(() => makeBuilder({ data: null, error: null }));
+
+    const result = await getHandoff(VALID_TOKEN);
+    expect(result?.holdings).toHaveLength(0);
+  });
+});

--- a/app/account/dashboard/page.tsx
+++ b/app/account/dashboard/page.tsx
@@ -5,6 +5,7 @@ import { createClient } from "@/lib/supabase/server";
 import { enforcePortalKind } from "@/lib/portal-gate";
 import { getInvestorProfile, type InvestorProfile } from "@/lib/investor-profiles";
 import { getInvestorAccountType, type InvestorAccountType } from "@/lib/account-types";
+import SmartRecommendationsStrip from "@/components/SmartRecommendationsStrip";
 
 export const dynamic = "force-dynamic";
 
@@ -602,6 +603,11 @@ export default async function PersonalDashboardPage() {
           ))}
         </div>
       </section>
+
+      {/* Smart personalised recommendations — brokers or advisors matched
+          to the user's quiz profile / investor profile / intent country.
+          Returns null when there is no signal or supply is too sparse. */}
+      <SmartRecommendationsStrip />
 
       {/* AT-02..04 — account-type-specific resource hub */}
       {accountTypeHub && (

--- a/app/account/holdings/TaxSummaryButton.tsx
+++ b/app/account/holdings/TaxSummaryButton.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { getCurrentAustralianTaxYear } from "@/lib/holdings/tax-summary";
 
 /**
@@ -27,9 +27,37 @@ export default function TaxSummaryButton() {
     [currentTaxYear],
   );
 
+  const router = useRouter();
   const [taxYear, setTaxYear] = useState<number>(currentTaxYear);
   const [busy, setBusy] = useState(false);
+  const [handoffBusy, setHandoffBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const handleSendToAdvisor = async () => {
+    setHandoffBusy(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/account/holdings/handoff", {
+        method: "POST",
+        credentials: "same-origin",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ intent: "tax-prep" }),
+      });
+      if (!res.ok) {
+        throw new Error(`handoff_failed_${res.status}`);
+      }
+      const { token } = await res.json() as { token: string };
+      router.push(`/find-advisor?need=tax&handoff=${encodeURIComponent(token)}`);
+    } catch (e) {
+      setError(
+        e instanceof Error && e.message.startsWith("handoff_failed")
+          ? "Could not create a handoff token. Try again or refresh the page."
+          : "Could not send to advisor. Try again.",
+      );
+    } finally {
+      setHandoffBusy(false);
+    }
+  };
 
   const handleDownload = async () => {
     setBusy(true);
@@ -101,12 +129,14 @@ export default function TaxSummaryButton() {
           {busy ? "Generating…" : "Download CSV"}
         </button>
 
-        <Link
-          href="/find-advisor?intent=tax-prep"
-          className="text-sm font-semibold text-emerald-700 hover:text-emerald-900 underline underline-offset-2"
+        <button
+          type="button"
+          onClick={() => void handleSendToAdvisor()}
+          disabled={handoffBusy}
+          className="text-sm font-semibold text-emerald-700 hover:text-emerald-900 underline underline-offset-2 disabled:opacity-50"
         >
-          Send to my advisor →
-        </Link>
+          {handoffBusy ? "Preparing…" : "Send to my advisor →"}
+        </button>
       </div>
 
       {error && (

--- a/app/account/net-worth/ManualBalancesPanel.tsx
+++ b/app/account/net-worth/ManualBalancesPanel.tsx
@@ -1,0 +1,275 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+
+/**
+ * ManualBalancesPanel
+ *
+ * Inline add/edit/delete form for manual savings/super/property/other
+ * balances. Writes to /api/account/net-worth/balances and calls
+ * `router.refresh()` to revalidate the server component above so the
+ * net-worth total updates without a full page reload.
+ */
+
+export interface ManualBalance {
+  id: string;
+  label: string;
+  amount_cents: number;
+  category: "savings" | "super" | "property" | "other";
+  updated_at: string;
+}
+
+const CATEGORIES: { value: ManualBalance["category"]; label: string }[] = [
+  { value: "savings", label: "Savings" },
+  { value: "super", label: "Super" },
+  { value: "property", label: "Property" },
+  { value: "other", label: "Other" },
+];
+
+const CATEGORY_COLOURS: Record<ManualBalance["category"], string> = {
+  savings: "bg-emerald-100 text-emerald-700",
+  super:    "bg-violet-100 text-violet-700",
+  property: "bg-amber-100 text-amber-700",
+  other:    "bg-slate-100 text-slate-600",
+};
+
+function fmt(cents: number) {
+  return new Intl.NumberFormat("en-AU", {
+    style: "currency",
+    currency: "AUD",
+    maximumFractionDigits: 0,
+  }).format(cents / 100);
+}
+
+function parseDollarsToCents(raw: string): number | null {
+  const n = parseFloat(raw.replace(/[^0-9.]/g, ""));
+  if (isNaN(n) || n < 0) return null;
+  return Math.round(n * 100);
+}
+
+interface AddFormState {
+  label: string;
+  amount: string;
+  category: ManualBalance["category"];
+}
+
+const EMPTY_FORM: AddFormState = { label: "", amount: "", category: "savings" };
+
+export default function ManualBalancesPanel({
+  initialBalances,
+}: {
+  initialBalances: ManualBalance[];
+}) {
+  const router = useRouter();
+  const [balances, setBalances] = useState<ManualBalance[]>(initialBalances);
+  const [form, setForm] = useState<AddFormState>(EMPTY_FORM);
+  const [saving, setSaving] = useState(false);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [showForm, setShowForm] = useState(false);
+
+  const handleAdd = useCallback(async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    const amountCents = parseDollarsToCents(form.amount);
+    if (!form.label.trim()) { setError("Label is required."); return; }
+    if (amountCents === null) { setError("Enter a valid dollar amount."); return; }
+
+    setSaving(true);
+    try {
+      const res = await fetch("/api/account/net-worth/balances", {
+        method: "POST",
+        credentials: "same-origin",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          label: form.label.trim(),
+          amount_cents: amountCents,
+          category: form.category,
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.json() as { error?: string };
+        throw new Error(body.error ?? "save_failed");
+      }
+      const { item } = await res.json() as { item: ManualBalance };
+      setBalances((prev) => [item, ...prev]);
+      setForm(EMPTY_FORM);
+      setShowForm(false);
+      router.refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not save. Try again.");
+    } finally {
+      setSaving(false);
+    }
+  }, [form, router]);
+
+  const handleDelete = useCallback(async (id: string) => {
+    setDeletingId(id);
+    setError(null);
+    try {
+      const res = await fetch("/api/account/net-worth/balances", {
+        method: "DELETE",
+        credentials: "same-origin",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id }),
+      });
+      if (!res.ok) {
+        const body = await res.json() as { error?: string };
+        throw new Error(body.error ?? "delete_failed");
+      }
+      setBalances((prev) => prev.filter((b) => b.id !== id));
+      router.refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not delete. Try again.");
+    } finally {
+      setDeletingId(null);
+    }
+  }, [router]);
+
+  return (
+    <section className="mt-6 rounded-xl border border-slate-200 bg-white p-4">
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="text-sm font-semibold text-slate-900">Manual balances</h2>
+        {!showForm && (
+          <button
+            type="button"
+            onClick={() => setShowForm(true)}
+            className="text-xs font-semibold text-violet-700 hover:text-violet-900"
+          >
+            + Add balance
+          </button>
+        )}
+      </div>
+
+      {showForm && (
+        <form onSubmit={(e) => void handleAdd(e)} className="mb-4 space-y-3 rounded-lg border border-slate-200 bg-slate-50 p-3">
+          <div>
+            <label className="block text-xs font-medium text-slate-700 mb-1" htmlFor="mb-label">
+              Label
+            </label>
+            <input
+              id="mb-label"
+              type="text"
+              maxLength={200}
+              placeholder="e.g. ING Savings Maximiser"
+              value={form.label}
+              onChange={(e) => setForm((f) => ({ ...f, label: e.target.value }))}
+              className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm bg-white"
+              required
+            />
+          </div>
+
+          <div>
+            <label className="block text-xs font-medium text-slate-700 mb-1" htmlFor="mb-amount">
+              Amount (AUD)
+            </label>
+            <input
+              id="mb-amount"
+              type="text"
+              inputMode="decimal"
+              placeholder="e.g. 25000"
+              value={form.amount}
+              onChange={(e) => setForm((f) => ({ ...f, amount: e.target.value }))}
+              className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm bg-white"
+              required
+            />
+          </div>
+
+          <div>
+            <label className="block text-xs font-medium text-slate-700 mb-1" htmlFor="mb-category">
+              Category
+            </label>
+            <select
+              id="mb-category"
+              value={form.category}
+              onChange={(e) => setForm((f) => ({ ...f, category: e.target.value as ManualBalance["category"] }))}
+              className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm bg-white"
+            >
+              {CATEGORIES.map((c) => (
+                <option key={c.value} value={c.value}>{c.label}</option>
+              ))}
+            </select>
+          </div>
+
+          {error && (
+            <p className="text-xs text-red-600" role="alert">{error}</p>
+          )}
+
+          <div className="flex gap-2">
+            <button
+              type="submit"
+              disabled={saving}
+              className="flex-1 py-2 bg-violet-700 hover:bg-violet-800 text-white text-sm font-medium rounded-lg disabled:opacity-50"
+            >
+              {saving ? "Saving…" : "Save balance"}
+            </button>
+            <button
+              type="button"
+              onClick={() => { setShowForm(false); setForm(EMPTY_FORM); setError(null); }}
+              className="px-3 py-2 text-sm text-slate-600 hover:text-slate-900 border border-slate-300 rounded-lg"
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      )}
+
+      {balances.length === 0 && !showForm && (
+        <p className="text-sm text-slate-500 text-center py-4">
+          No manual balances yet. Add savings, super, property, or other accounts.
+        </p>
+      )}
+
+      {balances.length > 0 && (
+        <ul className="space-y-2">
+          {balances.map((b) => (
+            <li
+              key={b.id}
+              className="flex items-center justify-between gap-3 rounded-lg border border-slate-100 px-3 py-2.5"
+            >
+              <div className="flex items-center gap-2 min-w-0">
+                <span className={`shrink-0 rounded-full px-2 py-0.5 text-[0.6rem] font-semibold uppercase ${CATEGORY_COLOURS[b.category]}`}>
+                  {b.category}
+                </span>
+                <span className="text-sm text-slate-800 truncate">{b.label}</span>
+              </div>
+              <div className="flex items-center gap-2 shrink-0">
+                <span className="text-sm font-semibold text-slate-900">{fmt(b.amount_cents)}</span>
+                <button
+                  type="button"
+                  onClick={() => void handleDelete(b.id)}
+                  disabled={deletingId === b.id}
+                  aria-label={`Delete ${b.label}`}
+                  className="text-slate-400 hover:text-red-600 transition-colors disabled:opacity-40"
+                >
+                  {deletingId === b.id ? (
+                    <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                    </svg>
+                  ) : (
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                        d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                      />
+                    </svg>
+                  )}
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {error && !showForm && (
+        <p className="mt-2 text-xs text-red-600" role="alert">{error}</p>
+      )}
+
+      <p className="mt-3 text-xs text-slate-400">
+        General information only. Values are self-reported and not verified against statements.
+      </p>
+    </section>
+  );
+}

--- a/app/account/net-worth/page.tsx
+++ b/app/account/net-worth/page.tsx
@@ -4,6 +4,7 @@ import { redirect } from "next/navigation";
 
 import { createClient } from "@/lib/supabase/server";
 import { getCurrentPricesBatch } from "@/lib/holdings/value";
+import ManualBalancesPanel, { type ManualBalance } from "./ManualBalancesPanel";
 
 export const dynamic = "force-dynamic";
 
@@ -13,24 +14,12 @@ export const metadata: Metadata = {
 };
 
 // FIN_NOTEBOOK item 20 — unified net-worth view. Reads holdings,
-// investor_goals, and bookmarks to give a top-level number + the
-// allocation breakdown. Glues the per-product surfaces (holdings,
-// watchlist, FIRE goal) into one repeat-visit dashboard.
+// investor_goals, manual_balances, and bookmarks to give a top-level
+// number + the allocation breakdown. Glues the per-product surfaces
+// (holdings, watchlist, FIRE goal) into one repeat-visit dashboard.
 //
-// Why not a separate table: a net-worth tracker that maintains its own
-// state requires the user to dual-entry every time they buy a share /
-// open a savings account / change their super balance. Reading what
-// already exists keeps the data correct without manual maintenance.
-//
-// What this page DOESN'T do (deliberately):
-//   - Pull manual savings balances (no input surface yet — the saved
-//     calculator-state in investor_goals.current_balance_cents is the
-//     stand-in for users without Sharesight import).
-//   - Pull super balances (requires Sharesight OAuth completion — PR #885
-//     in draft).
-//
-// As those data sources land, this page reads them automatically — the
-// switch from "holdings + manual goals" to "holdings + super + savings"
+// As OAuth super/cash data sources land, this page reads them automatically —
+// the switch from "holdings + manual goals" to "holdings + super + savings"
 // is additive in the data fetch below, not a redesign.
 
 interface HoldingRow {
@@ -49,6 +38,21 @@ interface GoalRow {
   target_date: string;
 }
 
+interface ManualBalanceRow {
+  id: string;
+  label: string;
+  amount_cents: number;
+  category: "savings" | "super" | "property" | "other";
+  updated_at: string;
+}
+
+const CATEGORY_LABELS: Record<string, string> = {
+  savings: "Savings",
+  super: "Super",
+  property: "Property",
+  other: "Other",
+};
+
 export default async function NetWorthPage() {
   const supabase = await createClient();
   const {
@@ -56,7 +60,7 @@ export default async function NetWorthPage() {
   } = await supabase.auth.getUser();
   if (!user) redirect("/account/login?redirect=/account/net-worth");
 
-  const [holdingsRes, goalsRes] = await Promise.all([
+  const [holdingsRes, goalsRes, manualBalancesRes] = await Promise.all([
     supabase
       .from("investor_holdings")
       .select("ticker, exchange, shares, cost_basis_per_share_cents")
@@ -66,10 +70,15 @@ export default async function NetWorthPage() {
       .select("id, label, goal_type, target_cents, current_balance_cents, target_date")
       .eq("auth_user_id", user.id)
       .order("target_date", { ascending: true }),
+    supabase
+      .from("manual_balances")
+      .select("id, label, amount_cents, category, updated_at")
+      .order("updated_at", { ascending: false }),
   ]);
 
   const holdings = (holdingsRes.data ?? []) as HoldingRow[];
   const goals = (goalsRes.data ?? []) as GoalRow[];
+  const manualBalances = (manualBalancesRes.data ?? []) as ManualBalanceRow[];
 
   // Fetch current prices for every (ticker, exchange) pair in one batch.
   const pricePairs = holdings
@@ -95,14 +104,28 @@ export default async function NetWorthPage() {
     }
   }
 
-  // Manual / calculator-state balances from goals — these stand in for
-  // savings + super until OAuth flows land.
-  const manualBalanceCents = goals.reduce(
+  // Manual / calculator-state balances from goals — stand-in for super/savings
+  // until OAuth flows land. These remain in the total for backward-compat with
+  // existing users.
+  const goalBalanceCents = goals.reduce(
     (acc, g) => acc + (g.current_balance_cents ?? 0),
     0,
   );
 
-  const netWorthCents = portfolioValueCents + manualBalanceCents;
+  // Purpose-built manual balances from manual_balances table.
+  const manualTotalCents = manualBalances.reduce(
+    (acc, b) => acc + (b.amount_cents ?? 0),
+    0,
+  );
+
+  // Group manual balances by category for breakdown.
+  const manualByCategory = manualBalances.reduce<Record<string, number>>((acc, b) => {
+    const cat = b.category ?? "other";
+    acc[cat] = (acc[cat] ?? 0) + b.amount_cents;
+    return acc;
+  }, {});
+
+  const netWorthCents = portfolioValueCents + goalBalanceCents + manualTotalCents;
 
   function fmt(cents: number): string {
     return new Intl.NumberFormat("en-AU", {
@@ -128,8 +151,7 @@ export default async function NetWorthPage() {
       <header className="mb-6">
         <h1 className="text-2xl font-extrabold text-slate-900">Net worth</h1>
         <p className="mt-1 text-sm text-slate-500">
-          Pulled from your holdings + saved goals. Add a Sharesight import for super + cash
-          balances (coming soon).
+          Pulled from your holdings, goals, and manual balances.
         </p>
       </header>
 
@@ -140,7 +162,7 @@ export default async function NetWorthPage() {
         <p className="mt-2 text-4xl font-extrabold text-slate-900">{fmt(netWorthCents)}</p>
         {netWorthCents === 0 && (
           <p className="mt-2 text-sm text-slate-500">
-            Add holdings or save a goal and your net worth will populate here.
+            Add holdings, save a goal, or add manual balances and your net worth will populate here.
           </p>
         )}
       </section>
@@ -172,7 +194,7 @@ export default async function NetWorthPage() {
           <p className="text-xs font-semibold uppercase tracking-wider text-slate-500">
             Goal balances
           </p>
-          <p className="mt-1 text-2xl font-bold text-slate-900">{fmt(manualBalanceCents)}</p>
+          <p className="mt-1 text-2xl font-bold text-slate-900">{fmt(goalBalanceCents)}</p>
           <p className="mt-1 text-xs text-slate-500">
             {goals.length} goal{goals.length === 1 ? "" : "s"} saved
           </p>
@@ -183,6 +205,22 @@ export default async function NetWorthPage() {
             View goals &rarr;
           </Link>
         </div>
+
+        {manualTotalCents > 0 && (
+          <div className="rounded-xl border border-slate-200 bg-white p-4 sm:col-span-2">
+            <p className="text-xs font-semibold uppercase tracking-wider text-slate-500">
+              Manual balances
+            </p>
+            <p className="mt-1 text-2xl font-bold text-slate-900">{fmt(manualTotalCents)}</p>
+            <div className="mt-2 flex flex-wrap gap-2">
+              {Object.entries(manualByCategory).map(([cat, cents]) => (
+                <span key={cat} className="text-xs text-slate-500">
+                  {CATEGORY_LABELS[cat] ?? cat}: {fmt(cents)}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
       </section>
 
       {goals.length > 0 && (
@@ -217,6 +255,11 @@ export default async function NetWorthPage() {
           </ul>
         </section>
       )}
+
+      {/* Manual balances panel — client component for inline CRUD */}
+      <ManualBalancesPanel
+        initialBalances={manualBalances as ManualBalance[]}
+      />
 
       <p className="mt-10 text-xs text-slate-400">
         General information only — net worth here reflects what you&apos;ve told us about. Always

--- a/app/account/upgrade/InvestorProCheckout.tsx
+++ b/app/account/upgrade/InvestorProCheckout.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+/**
+ * InvestorProCheckout — interactive checkout tile for Investor Pro.
+ *
+ * Client component so that plan-toggle + checkout fetch can react to
+ * user input. Mirrors the checkout pattern in ProPageClient.tsx:
+ * POST /api/stripe/create-checkout with { plan } then redirect to the
+ * returned Stripe session URL.
+ */
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useSubscription } from "@/lib/hooks/useSubscription";
+
+const PRO_BENEFITS = [
+  { label: "Unlimited holdings tracker", desc: "Track every position without a cap" },
+  { label: "Sharesight sync", desc: "Import trades directly from Sharesight" },
+  { label: "Premium research & market briefs", desc: "Monthly curated insights for AU investors" },
+  { label: "Fee alerts", desc: "Get notified the moment platform fees change" },
+  { label: "Full fee impact calculator", desc: "Compare all brokers, not just the top 3" },
+  { label: "Advanced comparison tools & exports", desc: "CSV/PDF exports and deep-dive filters" },
+  { label: "Ad-free experience", desc: "No popups or lead-capture forms" },
+  { label: "Priority support", desc: "Fast, personalised responses to your questions" },
+];
+
+export default function InvestorProCheckout() {
+  const [plan, setPlan] = useState<"monthly" | "yearly">("yearly");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const { user, isPro, loading: authLoading } = useSubscription();
+  const router = useRouter();
+
+  const handleCheckout = async () => {
+    if (!user) {
+      router.push("/auth/login?next=/account/upgrade");
+      return;
+    }
+
+    if (isPro) {
+      router.push("/account");
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/stripe/create-checkout", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ plan }),
+      });
+      const data = await res.json() as { url?: string; error?: string };
+      if (data.url) {
+        window.location.href = data.url;
+      } else {
+        setError(data.error ?? "Something went wrong. Please try again.");
+        setLoading(false);
+      }
+    } catch {
+      setError("Something went wrong. Please try again.");
+      setLoading(false);
+    }
+  };
+
+  if (isPro) {
+    // Already subscribed — render a dimmed "active" tile consistent with
+    // how the workspace tiles render already-held workspaces.
+    return (
+      <section
+        aria-labelledby="investor-pro-heading"
+        className="border border-emerald-200 bg-emerald-50 rounded-2xl p-6"
+      >
+        <div className="flex items-center gap-3 mb-2">
+          <span className="text-3xl" aria-hidden>
+            ⭐
+          </span>
+          <div>
+            <h2 id="investor-pro-heading" className="text-base font-bold text-slate-900">
+              Investor Pro
+            </h2>
+            <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold bg-emerald-200 text-emerald-800">
+              Active
+            </span>
+          </div>
+        </div>
+        <p className="text-sm text-emerald-800">
+          Your Pro subscription is active. Manage billing and subscription details from your account.
+        </p>
+        <a
+          href="/account"
+          className="inline-flex items-center justify-center mt-4 rounded-lg border border-emerald-300 text-emerald-800 hover:bg-emerald-100 text-sm font-semibold px-4 py-2 transition-colors"
+        >
+          Go to account →
+        </a>
+      </section>
+    );
+  }
+
+  const monthlyPrice = 9;
+  const yearlyPrice = 89;
+  const monthlyEquivalent = "7.42";
+
+  return (
+    <section
+      aria-labelledby="investor-pro-heading"
+      className="border-2 border-amber-400 bg-amber-50 rounded-2xl p-5 md:p-6 relative"
+    >
+      {/* Badge */}
+      <div className="absolute -top-3 left-5 px-2.5 py-0.5 bg-amber-500 text-white text-xs font-bold rounded-full flex items-center gap-1">
+        <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20" aria-hidden>
+          <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+        </svg>
+        INVESTOR PRO
+      </div>
+
+      <div className="flex items-start gap-3 mt-2 mb-4">
+        <span className="text-3xl" aria-hidden>
+          ⭐
+        </span>
+        <div className="flex-1 min-w-0">
+          <h2 id="investor-pro-heading" className="text-base font-bold text-slate-900">
+            Investor Pro
+          </h2>
+          <p className="text-xs text-slate-600 mt-0.5">
+            Premium tools for smarter investing — cancel anytime.
+          </p>
+        </div>
+      </div>
+
+      {/* Plan toggle */}
+      <div className="flex gap-2 mb-4">
+        <button
+          onClick={() => setPlan("monthly")}
+          className={`flex-1 py-2 rounded-lg text-xs font-semibold border transition-all ${
+            plan === "monthly"
+              ? "bg-amber-500 border-amber-500 text-white"
+              : "bg-white border-amber-200 text-slate-700 hover:border-amber-400"
+          }`}
+        >
+          Monthly&nbsp;
+          <span className="font-normal opacity-80">${monthlyPrice}/mo</span>
+        </button>
+        <button
+          onClick={() => setPlan("yearly")}
+          className={`flex-1 py-2 rounded-lg text-xs font-semibold border transition-all ${
+            plan === "yearly"
+              ? "bg-amber-500 border-amber-500 text-white"
+              : "bg-white border-amber-200 text-slate-700 hover:border-amber-400"
+          }`}
+        >
+          Yearly&nbsp;
+          <span className="font-normal opacity-80">${yearlyPrice}/yr</span>
+          {plan === "yearly" && (
+            <span className="ml-1 text-emerald-900 font-bold">Save 18%</span>
+          )}
+          {plan !== "yearly" && (
+            <span className="ml-1 text-emerald-700 font-bold opacity-100">Save 18%</span>
+          )}
+        </button>
+      </div>
+
+      {/* Price display */}
+      <div className="mb-4">
+        <div className="flex items-baseline gap-1">
+          <span className="text-3xl font-extrabold text-slate-900">
+            ${plan === "yearly" ? yearlyPrice : monthlyPrice}
+          </span>
+          <span className="text-sm text-slate-500">
+            /{plan === "yearly" ? "year" : "month"}
+          </span>
+        </div>
+        {plan === "yearly" && (
+          <p className="text-xs text-emerald-700 font-medium mt-0.5">
+            That&apos;s just ${monthlyEquivalent}/month — save $19 vs monthly
+          </p>
+        )}
+      </div>
+
+      {/* CTA */}
+      <button
+        onClick={handleCheckout}
+        disabled={loading || authLoading}
+        className="block w-full text-center px-4 py-2.5 bg-slate-900 text-white text-sm font-semibold rounded-xl hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 transition-colors disabled:opacity-50"
+      >
+        {authLoading
+          ? "Loading..."
+          : loading
+            ? "Redirecting to checkout..."
+            : user
+              ? "Subscribe Now"
+              : "Sign In & Subscribe"}
+      </button>
+
+      {error && (
+        <p className="mt-2 text-xs text-red-600 text-center" role="alert">
+          {error}
+        </p>
+      )}
+
+      {/* Benefits list */}
+      <ul className="mt-5 space-y-2.5">
+        {PRO_BENEFITS.map((b) => (
+          <li key={b.label} className="flex items-start gap-2">
+            <svg
+              className="w-4 h-4 text-emerald-600 mt-0.5 shrink-0"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M5 13l4 4L19 7" />
+            </svg>
+            <div>
+              <span className="text-sm font-semibold text-slate-900">{b.label}</span>
+              <p className="text-xs text-slate-500">{b.desc}</p>
+            </div>
+          </li>
+        ))}
+      </ul>
+
+      {/* Trust signals */}
+      <div className="mt-5 pt-4 border-t border-amber-200 flex flex-wrap gap-x-4 gap-y-1.5 text-xs text-slate-500">
+        <span className="flex items-center gap-1">
+          <svg className="w-3.5 h-3.5 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+          </svg>
+          Secure via Stripe
+        </span>
+        <span className="flex items-center gap-1">
+          <svg className="w-3.5 h-3.5 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          Cancel anytime
+        </span>
+        <span className="flex items-center gap-1">
+          <svg className="w-3.5 h-3.5 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6" />
+          </svg>
+          7-day refund
+        </span>
+      </div>
+    </section>
+  );
+}

--- a/app/account/upgrade/page.tsx
+++ b/app/account/upgrade/page.tsx
@@ -21,6 +21,7 @@ import Link from "next/link";
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { getKindsForUser, type WorkspaceKind } from "@/lib/account-kinds";
+import InvestorProCheckout from "./InvestorProCheckout";
 
 export const dynamic = "force-dynamic";
 
@@ -172,6 +173,16 @@ export default async function AccountUpgradeHubPage() {
             </p>
           )}
         </header>
+
+        {/* Investor Pro subscription — surfaced here because it's the most
+            common upgrade path from the dashboard. Renders a client component
+            that handles plan-toggle + Stripe checkout redirect. */}
+        <section className="mb-10">
+          <h2 className="text-sm font-bold text-slate-700 uppercase tracking-wider mb-3">
+            Investor Pro membership
+          </h2>
+          <InvestorProCheckout />
+        </section>
 
         {available.length > 0 && (
           <section className="mb-10">

--- a/app/api/account/holdings/handoff/[token]/route.ts
+++ b/app/api/account/holdings/handoff/[token]/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { getHandoff } from "@/lib/investor-handoff";
+import { logger } from "@/lib/logger";
+
+const log = logger("api:account:holdings:handoff:token");
+
+export const runtime = "nodejs";
+
+/**
+ * GET /api/account/holdings/handoff/[token]
+ *
+ * Public read path for a handoff token. No auth required — the token IS
+ * the auth factor (random opaque UUID, 14-day TTL, single-consumption).
+ *
+ * Returns the holdings snapshot if the token is valid, unexpired, and
+ * not yet consumed. Stamps `consumed_at` on success so the token can't
+ * be replayed.
+ *
+ * Used by the /find-advisor client page to display the investor's
+ * "Shared portfolio" summary card.
+ */
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ token: string }> },
+): Promise<Response> {
+  const { token } = await params;
+
+  if (!token || token.length > 200) {
+    return NextResponse.json({ error: "invalid_token" }, { status: 400 });
+  }
+
+  const handoff = await getHandoff(token);
+
+  if (!handoff) {
+    log.info("handoff not found or expired", { token: token.slice(0, 8) });
+    return NextResponse.json({ error: "not_found" }, { status: 404 });
+  }
+
+  return NextResponse.json(
+    {
+      intent: handoff.intent,
+      holdings: handoff.holdings,
+      created_at: handoff.created_at,
+    },
+    {
+      status: 200,
+      headers: {
+        // No caching — token is single-use and consumed on first read.
+        "Cache-Control": "private, no-store",
+      },
+    },
+  );
+}

--- a/app/api/account/holdings/handoff/route.ts
+++ b/app/api/account/holdings/handoff/route.ts
@@ -1,0 +1,79 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { createClient } from "@/lib/supabase/server";
+import { withValidatedBody } from "@/lib/validation/withValidatedBody";
+import { logger } from "@/lib/logger";
+
+const log = logger("api:account:holdings:handoff");
+
+export const runtime = "nodejs";
+
+/**
+ * POST /api/account/holdings/handoff
+ *
+ * Creates a short-lived, read-once handoff token that embeds the caller's
+ * current holdings snapshot. The token is passed to /find-advisor via
+ * `?handoff=<token>` so an advisor can view a read-only summary without
+ * having access to the investor's full account.
+ *
+ * Body (optional):
+ *   { intent?: string }  — defaults to "tax-prep"
+ *
+ * Returns:
+ *   { token: string }
+ *
+ * Security surface:
+ * - Requires authenticated user (via cookie session).
+ * - Holdings are fetched via the user-scoped supabase client so RLS fires —
+ *   an investor cannot snapshot another user's holdings.
+ * - Token is a random UUID v4 — unguessable, not sequential.
+ * - Expiry: 14 days.
+ */
+
+const Body = z.object({
+  intent: z.string().max(100).optional().default("tax-prep"),
+});
+
+export const POST = withValidatedBody(Body, async (_req, body) => {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  // Fetch the user's holdings (RLS scopes to own rows).
+  const { data: holdingsData, error: holdingsError } = await supabase
+    .from("investor_holdings")
+    .select(
+      "ticker, exchange, shares, cost_basis_per_share_cents, acquired_at, broker_slug, notes",
+    )
+    .order("acquired_at", { ascending: false });
+
+  if (holdingsError) {
+    log.warn("handoff holdings fetch failed", { error: holdingsError.message, user_id: user.id });
+    return NextResponse.json({ error: "fetch_failed" }, { status: 500 });
+  }
+
+  const token = crypto.randomUUID();
+  const expiresAt = new Date(Date.now() + 14 * 24 * 60 * 60 * 1000).toISOString();
+
+  const { error: insertError } = await supabase
+    .from("investor_handoffs")
+    .insert({
+      user_id: user.id,
+      token,
+      holdings_snapshot_json: holdingsData ?? [],
+      intent: body.intent,
+      expires_at: expiresAt,
+    });
+
+  if (insertError) {
+    log.warn("handoff insert failed", { error: insertError.message, user_id: user.id });
+    return NextResponse.json({ error: "insert_failed" }, { status: 500 });
+  }
+
+  log.info("handoff created", { user_id: user.id, intent: body.intent });
+  return NextResponse.json({ token }, { status: 201 });
+});

--- a/app/api/account/net-worth/balances/route.ts
+++ b/app/api/account/net-worth/balances/route.ts
@@ -1,0 +1,95 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { createClient } from "@/lib/supabase/server";
+import { withValidatedBody } from "@/lib/validation/withValidatedBody";
+import { logger } from "@/lib/logger";
+
+const log = logger("api:account:net-worth:balances");
+
+export const runtime = "nodejs";
+
+/**
+ * /api/account/net-worth/balances — manual balance CRUD for the net-worth page.
+ *
+ *   GET    — authenticated user's manual balances (RLS scopes to own rows)
+ *   POST   — add a balance entry
+ *   DELETE — remove a balance entry (id required in body)
+ *
+ * RLS enforces owner isolation. The handler uses the user-scoped supabase
+ * client so policies fire; never service-role.
+ */
+
+const CATEGORIES = ["savings", "super", "property", "other"] as const;
+
+const AddBalanceBody = z.object({
+  label: z.string().min(1).max(200).transform((s) => s.trim()),
+  amount_cents: z.number().int().min(0).max(1e15),
+  category: z.enum(CATEGORIES),
+});
+
+const DeleteBalanceBody = z.object({
+  id: z.string().uuid(),
+});
+
+export async function GET() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+
+  const { data, error } = await supabase
+    .from("manual_balances")
+    .select("id, label, amount_cents, category, updated_at")
+    .order("updated_at", { ascending: false });
+
+  if (error) {
+    log.warn("manual balances fetch failed", { error: error.message });
+    return NextResponse.json({ error: "fetch_failed" }, { status: 500 });
+  }
+  return NextResponse.json({ items: data ?? [] });
+}
+
+export const POST = withValidatedBody(AddBalanceBody, async (_req, body) => {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+
+  const { data, error } = await supabase
+    .from("manual_balances")
+    .insert({
+      user_id: user.id,
+      label: body.label,
+      amount_cents: body.amount_cents,
+      category: body.category,
+    })
+    .select("id, label, amount_cents, category, updated_at")
+    .single();
+
+  if (error) {
+    log.warn("manual balance insert failed", { error: error.message });
+    return NextResponse.json({ error: "insert_failed", detail: error.message }, { status: 500 });
+  }
+  return NextResponse.json({ item: data }, { status: 201 });
+});
+
+export const DELETE = withValidatedBody(DeleteBalanceBody, async (_req, body) => {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+
+  const { error } = await supabase
+    .from("manual_balances")
+    .delete()
+    .eq("id", body.id);
+
+  if (error) {
+    log.warn("manual balance delete failed", { error: error.message });
+    return NextResponse.json({ error: "delete_failed" }, { status: 500 });
+  }
+  return NextResponse.json({ ok: true });
+});

--- a/app/api/advisor-portal/firm-leads/route.ts
+++ b/app/api/advisor-portal/firm-leads/route.ts
@@ -19,6 +19,8 @@ import { requireAdvisorSession } from "@/lib/require-advisor-session";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { isAllowed, ipKey } from "@/lib/rate-limit-db";
 import { logger } from "@/lib/logger";
+import { notifyUserByEmail } from "@/lib/notifications";
+import { sendEmail } from "@/lib/resend";
 
 const log = logger("api:advisor-portal:firm-leads");
 
@@ -163,6 +165,101 @@ export async function PATCH(request: NextRequest): Promise<NextResponse> {
     log.error("lead reassign failed", { error: error.message });
     return NextResponse.json({ error: "Failed to reassign." }, { status: 500 });
   }
+
+  // ── Best-effort: notify the newly assigned advisor ───────────────────
+  // Fetch the target advisor details and the lead so we can send a useful
+  // notification. Errors here are caught and logged — they MUST NOT fail
+  // the reassignment response.
+  void (async () => {
+    try {
+      // Fetch target advisor name and email.
+      const { data: targetAdvisor } = await admin
+        .from("professionals")
+        .select("name, email")
+        .eq("id", parsed.data.professional_id)
+        .maybeSingle();
+
+      if (!targetAdvisor?.email) {
+        log.warn("lead reassign notify: no email for target advisor", {
+          professionalId: parsed.data.professional_id,
+        });
+        return;
+      }
+
+      // Fetch lead details for the notification body.
+      const { data: lead } = await admin
+        .from("professional_leads")
+        .select("user_name, user_email, user_phone, source_page, message, status")
+        .eq("id", parsed.data.lead_id)
+        .maybeSingle();
+
+      const leadName = lead?.user_name ?? "A new lead";
+      const portalUrl = "https://invest.com.au/advisor-portal";
+      const advisorFirst =
+        (targetAdvisor.name ?? "Advisor").trim().split(" ")[0] ?? "Advisor";
+
+      // In-app notification (fire-and-forget; deduped by delivery key).
+      const deliveryKey = `firm-lead-assign:${parsed.data.lead_id}:${parsed.data.professional_id}`;
+      await notifyUserByEmail(targetAdvisor.email, {
+        type: "deal",
+        title: `New lead assigned to you: ${leadName}`,
+        body: `A firm admin has assigned a lead from ${leadName} to your queue. Log in to the advisor portal to follow up.`,
+        linkUrl: portalUrl,
+        emailDeliveryKey: deliveryKey,
+      });
+
+      // Email notification.
+      const html = `<div style="font-family:Arial,sans-serif;max-width:500px;margin:0 auto;color:#334155">
+        <div style="background:#0f172a;padding:20px 24px;border-radius:12px 12px 0 0">
+          <h1 style="color:white;margin:0;font-size:18px">Lead Assigned to You</h1>
+        </div>
+        <div style="background:#f8fafc;padding:24px;border:1px solid #e2e8f0;border-top:none;border-radius:0 0 12px 12px">
+          <p style="font-size:15px">Hi ${advisorFirst},</p>
+          <p style="font-size:14px;color:#64748b">A lead has been reassigned to you by your firm admin.</p>
+          <div style="background:#fffbeb;border:1px solid #fde68a;border-radius:8px;padding:16px;margin:16px 0">
+            <table style="width:100%;font-size:14px;color:#334155;border-collapse:collapse">
+              <tr><td style="padding:4px 8px 4px 0;font-weight:600">Lead:</td><td style="padding:4px 0">${leadName}</td></tr>
+              ${lead?.user_email ? `<tr><td style="padding:4px 8px 4px 0;font-weight:600">Email:</td><td style="padding:4px 0"><a href="mailto:${lead.user_email}" style="color:#2563eb">${lead.user_email}</a></td></tr>` : ""}
+              ${lead?.user_phone ? `<tr><td style="padding:4px 8px 4px 0;font-weight:600">Phone:</td><td style="padding:4px 0"><a href="tel:${lead.user_phone}" style="color:#2563eb">${lead.user_phone}</a></td></tr>` : ""}
+              ${lead?.source_page ? `<tr><td style="padding:4px 8px 4px 0;font-weight:600">Source:</td><td style="padding:4px 0">${lead.source_page}</td></tr>` : ""}
+            </table>
+          </div>
+          <p style="font-size:14px;color:#64748b"><strong>Please follow up promptly.</strong></p>
+          <div style="text-align:center;margin:24px 0">
+            <a href="${portalUrl}" style="display:inline-block;padding:12px 32px;background:#f59e0b;color:white;text-decoration:none;border-radius:8px;font-size:14px;font-weight:600">View in Portal →</a>
+          </div>
+          <p style="font-size:12px;color:#94a3b8;margin-top:20px">Manage your leads in the <a href="${portalUrl}" style="color:#2563eb">advisor portal</a>.</p>
+        </div>
+      </div>`;
+
+      const { ok: emailOk } = await sendEmail({
+        to: targetAdvisor.email,
+        subject: `Lead assigned to you: ${leadName} — Invest.com.au`,
+        html,
+        from: "Invest.com.au <hello@invest.com.au>",
+      });
+
+      if (!emailOk) {
+        log.warn("lead reassign notify: email send failed", {
+          to: targetAdvisor.email,
+          leadId: parsed.data.lead_id,
+        });
+      } else {
+        log.info("lead reassign notify: sent", {
+          to: targetAdvisor.email,
+          leadId: parsed.data.lead_id,
+          professionalId: parsed.data.professional_id,
+        });
+      }
+    } catch (notifyErr) {
+      // Best-effort: do NOT propagate — the reassignment already succeeded.
+      log.error("lead reassign notify: unexpected error", {
+        error: notifyErr instanceof Error ? notifyErr.message : String(notifyErr),
+        leadId: parsed.data.lead_id,
+        professionalId: parsed.data.professional_id,
+      });
+    }
+  })();
 
   return NextResponse.json({ ok: true });
 }

--- a/app/briefs/[slug]/page.tsx
+++ b/app/briefs/[slug]/page.tsx
@@ -168,7 +168,6 @@ export default async function BriefTrackerPage({
       const hasSubmittedOutcome = !!outcomeRow?.submitted_at;
       const acceptedMs = new Date(brief.accepted_at).getTime();
       const staleMs = DISPUTE_STALE_DAYS * 24 * 60 * 60 * 1000;
-      // eslint-disable-next-line react-hooks/purity -- server-rendered page; Date.now() is legitimate here (not a render-loop concern).
       const isStale = Date.now() - acceptedMs >= staleMs;
       canOpenDispute = hasSubmittedOutcome || isStale;
     }

--- a/app/briefs/[slug]/page.tsx
+++ b/app/briefs/[slug]/page.tsx
@@ -19,7 +19,11 @@ import {
   type DisputeRow,
 } from "@/lib/disputes";
 
+import { listMessagesForBrief, type BriefMessageRow } from "@/lib/brief-messages";
+import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
+
 import BookConsultationPanel from "./BookConsultationPanel";
+import BriefChatPanel from "./BriefChatPanel";
 import DisputePanel from "./DisputePanel";
 
 export const dynamic = "force-dynamic";
@@ -241,6 +245,47 @@ export default async function BriefTrackerPage({
 
   const stepIndex = STATUS_ORDER.indexOf(brief.tracker_status);
 
+  // Load chat messages when the brief is accepted and the viewer is one
+  // of the two parties: the consumer (emailMatches) or the accepted pro.
+  // We determine "is accepted pro" server-side by checking whether the
+  // session user's id matches accepted_by_professional_id.  Because the
+  // brief page also serves unauthenticated consumers (email-link flow),
+  // we guard with a try/catch so a missing session never breaks the page.
+  let chatMessages: BriefMessageRow[] = [];
+  let viewerIsAdvisor = false;
+  if (brief.accepted_at) {
+    if (emailMatches) {
+      // Consumer side — always load when accepted + email verified.
+      try {
+        chatMessages = await listMessagesForBrief(brief.id);
+      } catch {
+        /* non-critical — panel just renders empty */
+      }
+    } else {
+      // Check if the authenticated user is the accepted professional.
+      try {
+        const sessionClient = await createClient();
+        const { data: session } = await sessionClient.auth.getUser();
+        if (session?.user?.id && brief.accepted_by_professional_id) {
+          const proCheck = await sessionClient
+            .from("professionals")
+            .select("id")
+            .eq("id", brief.accepted_by_professional_id)
+            .eq("auth_user_id", session.user.id)
+            .maybeSingle();
+          if (proCheck.data) {
+            viewerIsAdvisor = true;
+            chatMessages = await listMessagesForBrief(brief.id);
+          }
+        }
+      } catch {
+        /* non-critical */
+      }
+    }
+  }
+
+  const showChat = brief.accepted_at !== null && (emailMatches || viewerIsAdvisor);
+
   const breadcrumb = breadcrumbJsonLd([
     { name: "Home", url: `${SITE_URL}/` },
     { name: "Match Requests", url: `${SITE_URL}/briefs` },
@@ -427,6 +472,38 @@ export default async function BriefTrackerPage({
                 contactEmail={emailMatches ? email : null}
                 existingBooking={existingBooking}
                 existingSlot={existingSlot}
+              />
+            </div>
+          )}
+
+          {/* Chat — visible to the brief owner and the accepted advisor only.
+               A general-advice compliance notice is shown above the panel per
+               AFSL obligations: messages may contain general information but
+               no personal advice is given via this channel. */}
+          {showChat && (
+            <div className="mb-6">
+              <div className="rounded-xl bg-amber-50 border border-amber-200 px-4 py-3 mb-3 text-xs text-amber-900">
+                <strong>General information only.</strong>{" "}
+                {GENERAL_ADVICE_WARNING} Messages sent here do not constitute
+                personal financial advice.
+              </div>
+              <BriefChatPanel
+                slug={brief.slug}
+                briefId={brief.id}
+                initialMessages={chatMessages}
+                viewerSide={viewerIsAdvisor ? "pro" : "consumer"}
+                viewerName={
+                  viewerIsAdvisor
+                    ? (accepted.professional?.name ?? "You")
+                    : "You"
+                }
+                counterpartyName={
+                  viewerIsAdvisor
+                    ? "Client"
+                    : (accepted.professional?.name ??
+                      accepted.team?.name ??
+                      "Your advisor")
+                }
               />
             </div>
           )}

--- a/app/community/page.tsx
+++ b/app/community/page.tsx
@@ -3,16 +3,13 @@ import { absoluteUrl, breadcrumbJsonLd } from "@/lib/seo";
 import Link from "next/link";
 import Icon from "@/components/Icon";
 
-// noindex while the forum is still pre-launch and seeded with zero
-// user threads. The forum_categories / forum_threads tables exist and
-// the page reads real data (migration 20260518030000); flip robots.index
-// to true once each category has ≥3 seeded threads — empty forums look
-// like a dead community in Google's eyes and bounce hard.
+// Each category now has ≥3 seeded threads (migration
+// 20260802000000_seed_forum_threads.sql) — safe to index.
 export const metadata = {
   title: "Community Forum",
   description:
     "Join thousands of Australian investors discussing share trading, ETFs, crypto, super, property, tax strategy, and broker reviews. Ask questions and share insights.",
-  robots: { index: false, follow: true },
+  robots: { index: true, follow: true },
   openGraph: {
     title: "Community Forum",
     description:

--- a/app/fee-impact/_components/FeeImpactResults.tsx
+++ b/app/fee-impact/_components/FeeImpactResults.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import type { Broker } from "@/lib/types";
 import { formatCurrency } from "@/lib/utils";
 import { trackClick, trackEvent, getAffiliateLink, getBenefitCta, AFFILIATE_REL } from "@/lib/tracking";
@@ -354,15 +355,20 @@ export default function FeeImpactResults({
                     See the complete fee comparison and find the
                     cheapest broker for your trading style.
                   </p>
-                  <span
-                    className="inline-flex items-center gap-2 px-5 py-2.5 bg-slate-200 text-slate-500 font-bold text-sm rounded-lg cursor-default"
+                  <Link
+                    href="/account/upgrade"
+                    onClick={() =>
+                      trackEvent("pro_upsell_click", { source: "fee-impact-unlock", hidden_count: String(hiddenCount) }, "/fee-impact")
+                    }
+                    className="inline-flex items-center gap-2 px-5 py-2.5 bg-slate-900 hover:bg-slate-800 text-white font-bold text-sm rounded-lg transition-colors"
                   >
-                    Coming Soon
+                    Unlock {hiddenCount} more broker{hiddenCount !== 1 ? "s" : ""}
                     <svg
                       className="w-4 h-4"
                       fill="none"
                       stroke="currentColor"
                       viewBox="0 0 24 24"
+                      aria-hidden
                     >
                       <path
                         strokeLinecap="round"
@@ -371,7 +377,7 @@ export default function FeeImpactResults({
                         d="M9 5l7 7-7 7"
                       />
                     </svg>
-                  </span>
+                  </Link>
                 </div>
               </div>
             </div>

--- a/app/find-advisor/page.tsx
+++ b/app/find-advisor/page.tsx
@@ -21,6 +21,22 @@ import CountryRuleAlerts from "@/components/CountryRuleAlerts";
 
 type Intent = "buy_property" | "grow_wealth" | "protect_assets" | "business_tax";
 
+interface HandoffHolding {
+  ticker: string;
+  exchange: string;
+  shares: number;
+  cost_basis_per_share_cents: number;
+  acquired_at: string;
+  broker_slug: string | null;
+  notes: string | null;
+}
+
+interface HandoffData {
+  intent: string;
+  holdings: HandoffHolding[];
+  created_at: string;
+}
+
 interface MatchedAdvisor {
   id: number;
   slug: string;
@@ -259,6 +275,118 @@ function getMatchmakerIntent(): Intent | null {
   } catch { return null; }
 }
 
+// ─── Handoff Banner ───────────────────────────────────────────────────────────
+
+/**
+ * Renders a read-only "Shared by the investor" summary card when the page
+ * is opened with a ?handoff=<token> query param.
+ *
+ * Fetches the token from the public API endpoint (GET /api/account/holdings/
+ * handoff/[token]). The token is single-use and expires in 14 days.
+ */
+function HandoffBanner({ token }: { token: string }) {
+  const [data, setData] = useState<HandoffData | null>(null);
+  const [status, setStatus] = useState<"loading" | "ok" | "error">("loading");
+
+  useEffect(() => {
+    if (!token) return;
+    void fetch(`/api/account/holdings/handoff/${encodeURIComponent(token)}`, {
+      credentials: "same-origin",
+    })
+      .then(async (res) => {
+        if (!res.ok) { setStatus("error"); return; }
+        const json = await res.json() as HandoffData;
+        setData(json);
+        setStatus("ok");
+      })
+      .catch(() => setStatus("error"));
+  }, [token]);
+
+  if (status === "loading") {
+    return (
+      <div className="mb-6 rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700 animate-pulse">
+        Loading shared portfolio summary…
+      </div>
+    );
+  }
+
+  if (status === "error" || !data) {
+    return (
+      <div className="mb-6 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+        The shared portfolio link has expired or was already viewed. Ask the investor to generate a new one from their Holdings page.
+      </div>
+    );
+  }
+
+  const totalCostCents = data.holdings.reduce(
+    (acc, h) => acc + Math.round(h.shares * h.cost_basis_per_share_cents),
+    0,
+  );
+
+  function fmtAUD(cents: number) {
+    return new Intl.NumberFormat("en-AU", {
+      style: "currency", currency: "AUD", maximumFractionDigits: 0,
+    }).format(cents / 100);
+  }
+
+  return (
+    <div className="mb-6 rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-4 text-sm">
+      <div className="flex items-start gap-2 mb-3">
+        <svg className="w-4 h-4 text-emerald-600 shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+          <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
+        </svg>
+        <div>
+          <p className="font-semibold text-emerald-900">Shared portfolio summary</p>
+          <p className="text-xs text-emerald-700 mt-0.5">
+            This investor shared their holdings with you on{" "}
+            {new Date(data.created_at).toLocaleDateString("en-AU")}.
+            For their tax-year review.
+          </p>
+        </div>
+      </div>
+
+      {data.holdings.length === 0 ? (
+        <p className="text-xs text-emerald-700">No holdings in snapshot.</p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-xs text-slate-700 border-collapse">
+            <thead>
+              <tr className="border-b border-emerald-200 text-emerald-800">
+                <th className="text-left pb-1 font-semibold">Ticker</th>
+                <th className="text-left pb-1 font-semibold">Exchange</th>
+                <th className="text-right pb-1 font-semibold">Shares</th>
+                <th className="text-right pb-1 font-semibold">Cost basis</th>
+                <th className="text-right pb-1 font-semibold">Acquired</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.holdings.map((h, i) => (
+                <tr key={i} className="border-b border-emerald-100 last:border-0">
+                  <td className="py-1 font-semibold">{h.ticker}</td>
+                  <td className="py-1 text-slate-500">{h.exchange}</td>
+                  <td className="py-1 text-right">{h.shares.toLocaleString("en-AU")}</td>
+                  <td className="py-1 text-right">{fmtAUD(Math.round(h.shares * h.cost_basis_per_share_cents))}</td>
+                  <td className="py-1 text-right text-slate-500">{h.acquired_at}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {totalCostCents > 0 && (
+        <p className="mt-2 text-xs text-emerald-800 font-semibold text-right">
+          Total cost basis: {fmtAUD(totalCostCents)}
+        </p>
+      )}
+
+      <p className="mt-3 text-[0.65rem] text-emerald-600">
+        General information only — cost basis figures are investor-reported. Always verify against brokerage statements before preparing a tax return.
+      </p>
+    </div>
+  );
+}
+
 // ─── Main Page ────────────────────────────────────────────────────────────────
 
 export default function FindAdvisorPage() {
@@ -272,6 +400,7 @@ export default function FindAdvisorPage() {
 function FindAdvisorQuiz() {
   const searchParams = useSearchParams();
   const needParam = searchParams.get("need");
+  const handoffToken = searchParams.get("handoff");
   const prefilledIntent = needParam ? NEED_TO_INTENT[needParam] || null : null;
 
   // LX-04 — pre-filled form params from hub CTAs, calculators, onboarding results.
@@ -631,6 +760,9 @@ function FindAdvisorQuiz() {
   return (
     <div className="min-h-screen bg-gradient-to-b from-slate-50 via-white to-white py-8 md:py-16">
       <div className="max-w-xl mx-auto px-4">
+
+        {/* Handoff banner — rendered when investor shares holdings from the holdings page */}
+        {handoffToken && <HandoffBanner token={handoffToken} />}
 
         {/* Breadcrumb */}
         <nav className="text-xs text-slate-400 mb-6" aria-label="Breadcrumb">

--- a/lib/investor-handoff.ts
+++ b/lib/investor-handoff.ts
@@ -21,6 +21,7 @@
  * replayed. The investor can always re-generate from their holdings page.
  */
 
+// eslint-disable-next-line no-restricted-imports -- anonymous-path exception (see header): the advisor consuming a handoff link has no JWT, so the opaque token is the auth factor and the service-role client is required to read investor_handoffs + stamp consumed_at.
 import { createAdminClient } from "@/lib/supabase/admin";
 import { logger } from "@/lib/logger";
 

--- a/lib/investor-handoff.ts
+++ b/lib/investor-handoff.ts
@@ -1,0 +1,106 @@
+/**
+ * lib/investor-handoff.ts
+ *
+ * Read path for investor handoff tokens.
+ *
+ * `getHandoff(token)` is called from the /find-advisor page (server
+ * component) when a `?handoff=` query param is present. It returns the
+ * holdings snapshot only when:
+ *   1. The token exists.
+ *   2. The token has not expired.
+ *   3. The token has not been consumed.
+ *
+ * The read uses the service-role client because:
+ *   - The token is accessed anonymously (no JWT from the advisor/investor
+ *     on the other side), and the investor_handoffs table has deny-all-anon
+ *     RLS.
+ *   - This is an explicitly allowed service-role path per CLAUDE.md (cross-
+ *     user / no-JWT anonymous path where the token acts as the auth factor).
+ *
+ * After a successful read, consumed_at is stamped so the token can't be
+ * replayed. The investor can always re-generate from their holdings page.
+ */
+
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+
+const log = logger("lib:investor-handoff");
+
+export interface HoldingSnapshot {
+  ticker: string;
+  exchange: string;
+  shares: number;
+  cost_basis_per_share_cents: number;
+  acquired_at: string;
+  broker_slug: string | null;
+  notes: string | null;
+}
+
+export interface HandoffResult {
+  intent: string;
+  holdings: HoldingSnapshot[];
+  created_at: string;
+}
+
+/**
+ * Fetch and consume a handoff token.
+ *
+ * Returns `null` when the token is missing, expired, or already consumed.
+ * On success, stamps `consumed_at` and returns the holdings snapshot.
+ */
+export async function getHandoff(token: string): Promise<HandoffResult | null> {
+  if (!token || token.length > 200) return null;
+
+  const admin = createAdminClient();
+
+  const { data, error } = await admin
+    .from("investor_handoffs")
+    .select("id, intent, holdings_snapshot_json, expires_at, consumed_at, created_at")
+    .eq("token", token)
+    .maybeSingle();
+
+  if (error) {
+    log.warn("handoff lookup failed", { error: error.message });
+    return null;
+  }
+
+  if (!data) return null;
+
+  // Guard: already consumed.
+  if (data.consumed_at != null) return null;
+
+  // Guard: expired.
+  if (new Date(data.expires_at as string) < new Date()) return null;
+
+  // Stamp consumed_at — best-effort, but if it fails we still return the
+  // snapshot (the token will expire naturally).
+  const { error: updateError } = await admin
+    .from("investor_handoffs")
+    .update({ consumed_at: new Date().toISOString() })
+    .eq("id", data.id);
+
+  if (updateError) {
+    log.warn("handoff consumed_at stamp failed", { error: updateError.message, id: data.id });
+    // Continue — don't block the investor's advisor from seeing the data.
+  }
+
+  const rawHoldings = Array.isArray(data.holdings_snapshot_json)
+    ? data.holdings_snapshot_json
+    : [];
+
+  const holdings: HoldingSnapshot[] = rawHoldings.map((h: Record<string, unknown>) => ({
+    ticker: String(h.ticker ?? ""),
+    exchange: String(h.exchange ?? ""),
+    shares: Number(h.shares ?? 0),
+    cost_basis_per_share_cents: Number(h.cost_basis_per_share_cents ?? 0),
+    acquired_at: String(h.acquired_at ?? ""),
+    broker_slug: h.broker_slug == null ? null : String(h.broker_slug),
+    notes: h.notes == null ? null : String(h.notes),
+  }));
+
+  return {
+    intent: String(data.intent ?? "tax-prep"),
+    holdings,
+    created_at: String(data.created_at ?? ""),
+  };
+}

--- a/supabase/migrations/20260525_investor_handoffs.sql
+++ b/supabase/migrations/20260525_investor_handoffs.sql
@@ -1,0 +1,73 @@
+-- ============================================================================
+-- Migration: 20260525_investor_handoffs.sql
+-- Purpose: Structured advisor handoff tokens. An investor generates a short-
+--          lived opaque token that embeds a snapshot of their holdings at that
+--          point in time. The token is passed to /find-advisor via the
+--          ?handoff= query param so an advisor (or the investor themselves on a
+--          different device) can read a read-only summary of what was shared.
+--
+--          Key design decisions:
+--          - holdings_snapshot_json is a point-in-time copy — it never updates.
+--          - expires_at defaults to ~14 days; consumed_at is set once the token
+--            is read on the advisor-facing side.
+--          - Token is a random opaque string (crypto.randomUUID or similar) — no
+--            sequential IDs that enumerate rows.
+--
+-- Risk: low — additive table; no existing data touched.
+-- Rollback:
+--   BEGIN;
+--     DROP POLICY IF EXISTS "investor_handoffs owner select"  ON public.investor_handoffs;
+--     DROP POLICY IF EXISTS "investor_handoffs owner insert"  ON public.investor_handoffs;
+--     DROP POLICY IF EXISTS "investor_handoffs service_role"  ON public.investor_handoffs;
+--     DROP INDEX  IF EXISTS idx_investor_handoffs_token;
+--     DROP INDEX  IF EXISTS idx_investor_handoffs_user_id;
+--     DROP TABLE  IF EXISTS public.investor_handoffs CASCADE;
+--   COMMIT;
+-- ============================================================================
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.investor_handoffs (
+  id                    uuid        NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id               uuid        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  token                 text        NOT NULL UNIQUE,
+  holdings_snapshot_json jsonb      NOT NULL DEFAULT '[]'::jsonb,
+  intent                text        NOT NULL DEFAULT 'tax-prep',
+  expires_at            timestamptz NOT NULL,
+  created_at            timestamptz NOT NULL DEFAULT now(),
+  consumed_at           timestamptz
+);
+
+CREATE INDEX IF NOT EXISTS idx_investor_handoffs_token
+  ON public.investor_handoffs (token);
+
+CREATE INDEX IF NOT EXISTS idx_investor_handoffs_user_id
+  ON public.investor_handoffs (user_id);
+
+ALTER TABLE public.investor_handoffs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.investor_handoffs FORCE ROW LEVEL SECURITY;
+
+-- Owner can read their own handoffs (e.g. to list them in a future UI).
+DROP POLICY IF EXISTS "investor_handoffs owner select" ON public.investor_handoffs;
+CREATE POLICY "investor_handoffs owner select"
+  ON public.investor_handoffs FOR SELECT
+  TO authenticated
+  USING (user_id = auth.uid());
+
+-- Owner can insert (create) a handoff for themselves.
+DROP POLICY IF EXISTS "investor_handoffs owner insert" ON public.investor_handoffs;
+CREATE POLICY "investor_handoffs owner insert"
+  ON public.investor_handoffs FOR INSERT
+  TO authenticated
+  WITH CHECK (user_id = auth.uid());
+
+-- Service role has full access (needed for `getHandoff` in lib which uses
+-- the anon token path without a JWT — see CLAUDE.md service-role scope notes).
+DROP POLICY IF EXISTS "investor_handoffs service_role" ON public.investor_handoffs;
+CREATE POLICY "investor_handoffs service_role"
+  ON public.investor_handoffs FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+COMMIT;

--- a/supabase/migrations/20260525_manual_balances.sql
+++ b/supabase/migrations/20260525_manual_balances.sql
@@ -1,0 +1,79 @@
+-- ============================================================================
+-- Migration: 20260525_manual_balances.sql
+-- Purpose: Manual savings/super/property/other balances for the net-worth
+--          page. The net-worth page currently uses investor_goals.current_
+--          balance_cents as a stand-in (see page comment). This table is
+--          the purpose-built replacement: labelled buckets with explicit
+--          categories, owner CRUD, stored in cents to avoid floating-point
+--          issues.
+--
+-- Risk: low — additive table; no existing data touched.
+-- Rollback:
+--   BEGIN;
+--     DROP TRIGGER  IF EXISTS manual_balances_updated_at ON public.manual_balances;
+--     DROP POLICY   IF EXISTS "manual_balances owner select"  ON public.manual_balances;
+--     DROP POLICY   IF EXISTS "manual_balances owner insert"  ON public.manual_balances;
+--     DROP POLICY   IF EXISTS "manual_balances owner update"  ON public.manual_balances;
+--     DROP POLICY   IF EXISTS "manual_balances owner delete"  ON public.manual_balances;
+--     DROP POLICY   IF EXISTS "manual_balances service_role"  ON public.manual_balances;
+--     DROP INDEX    IF EXISTS idx_manual_balances_user_id;
+--     DROP TABLE    IF EXISTS public.manual_balances CASCADE;
+--   COMMIT;
+-- ============================================================================
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.manual_balances (
+  id            uuid        NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id       uuid        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  label         text        NOT NULL CHECK (length(trim(label)) > 0),
+  amount_cents  bigint      NOT NULL DEFAULT 0 CHECK (amount_cents >= 0),
+  category      text        NOT NULL CHECK (category IN ('savings','super','property','other')),
+  updated_at    timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_manual_balances_user_id
+  ON public.manual_balances (user_id);
+
+ALTER TABLE public.manual_balances ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.manual_balances FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "manual_balances owner select" ON public.manual_balances;
+CREATE POLICY "manual_balances owner select"
+  ON public.manual_balances FOR SELECT
+  TO authenticated
+  USING (user_id = auth.uid());
+
+DROP POLICY IF EXISTS "manual_balances owner insert" ON public.manual_balances;
+CREATE POLICY "manual_balances owner insert"
+  ON public.manual_balances FOR INSERT
+  TO authenticated
+  WITH CHECK (user_id = auth.uid());
+
+DROP POLICY IF EXISTS "manual_balances owner update" ON public.manual_balances;
+CREATE POLICY "manual_balances owner update"
+  ON public.manual_balances FOR UPDATE
+  TO authenticated
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());
+
+DROP POLICY IF EXISTS "manual_balances owner delete" ON public.manual_balances;
+CREATE POLICY "manual_balances owner delete"
+  ON public.manual_balances FOR DELETE
+  TO authenticated
+  USING (user_id = auth.uid());
+
+DROP POLICY IF EXISTS "manual_balances service_role" ON public.manual_balances;
+CREATE POLICY "manual_balances service_role"
+  ON public.manual_balances FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- Reuse shared updated_at trigger function (created by 20260305_create_advisor_directory.sql).
+DROP TRIGGER IF EXISTS manual_balances_updated_at ON public.manual_balances;
+CREATE TRIGGER manual_balances_updated_at
+  BEFORE UPDATE ON public.manual_balances
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at();
+
+COMMIT;

--- a/supabase/migrations/20260802000000_seed_forum_threads.sql
+++ b/supabase/migrations/20260802000000_seed_forum_threads.sql
@@ -1,0 +1,757 @@
+-- ============================================================
+-- Migration: 20260802000000_seed_forum_threads.sql
+-- Purpose: Seed ≥3 realistic AU-investing threads per active
+--          forum_category so app/community/page.tsx can be
+--          indexed (robots: index). Zero-thread categories look
+--          like a dead community to Googlebot and bounce hard.
+--
+-- Rollback:
+--   DELETE FROM public.forum_posts
+--     WHERE thread_id IN (
+--       SELECT id FROM public.forum_threads
+--         WHERE author_name = 'Invest.com.au Community');
+--   DELETE FROM public.forum_threads
+--     WHERE author_name = 'Invest.com.au Community';
+--   UPDATE public.forum_categories SET thread_count = 0, post_count = 0
+--     WHERE slug IN (
+--       'share-trading','etfs-index-funds','property-investing',
+--       'super-retirement','crypto','tax-strategy','beginners','broker-reviews');
+--
+-- Idempotency: Each thread INSERT is guarded by WHERE NOT EXISTS
+--   on (category_slug, title). The opening-post INSERT is guarded
+--   on (thread_id, author_name). Safe to re-apply.
+-- ============================================================
+
+BEGIN;
+
+-- ─── Shared seed-author placeholder ──────────────────────────
+-- Threads inserted here have no real auth.users UUID — they are
+-- editorial / moderator-seeded content. author_id is left NULL
+-- (permitted by the schema) and author_name is set to the site
+-- name so the reader understands their provenance. RLS service_role
+-- INSERT policy covers this migration.
+-- ──────────────────────────────────────────────────────────────
+
+-- ══════════════════════════════════════════════════════════════
+-- 1. share-trading
+-- ══════════════════════════════════════════════════════════════
+
+DO $$
+DECLARE
+  v_thread_id integer;
+BEGIN
+  -- Thread 1: CommSec vs Stake for US shares
+  IF NOT EXISTS (
+    SELECT 1 FROM public.forum_threads
+      WHERE category_slug = 'share-trading'
+        AND title = 'CommSec vs Stake for US shares — which do you actually use?'
+  ) THEN
+    INSERT INTO public.forum_threads
+      (category_slug, title, slug, body, author_name, is_pinned, is_locked, is_removed, reply_count, vote_score)
+    VALUES (
+      'share-trading',
+      'CommSec vs Stake for US shares — which do you actually use?',
+      'commsec-vs-stake-us-shares',
+      E'I''ve been using CommSec for my ASX portfolio for years, but the US brokerage costs are eye-watering ($19.95 AUD per trade). A colleague keeps raving about Stake at USD $3 flat.\n\nFor those of you who actively trade US stocks — Apple, Nvidia, etc. — which platform have you settled on and why? Key things I care about: CHESS-equivalent safety for US stocks (I know it''s a DRS/DTCC situation), USD holding account to avoid double FX conversion, and a half-decent mobile app.\n\nAlso curious whether anyone has tried Moomoo or Interactive Brokers for this.',
+      'Invest.com.au Community',
+      false, false, false, 0, 4
+    ) RETURNING id INTO v_thread_id;
+
+    INSERT INTO public.forum_posts (thread_id, body, author_name, is_moderator, is_removed, vote_score)
+      SELECT v_thread_id,
+        E'Switched from CommSec to Stake about 18 months ago for US stuff and haven''t looked back. The USD wallet means you avoid the double FX hit — you convert once when you deposit, then trade at USD prices. CommSec''s FX margin on top of the trade fee was killing my returns on anything under $5k.\n\nFor CHESS protection: US stocks via Stake sit in an Apex Clearing account. It''s SIPC-insured up to USD $500k, which is the US equivalent. Not as clean as ASX CHESS but it''s the industry standard over there.',
+        'Invest.com.au Community', false, false, 2
+      WHERE NOT EXISTS (
+        SELECT 1 FROM public.forum_posts WHERE thread_id = v_thread_id AND author_name = 'Invest.com.au Community'
+      );
+  END IF;
+
+  -- Thread 2: ASX 200 stock filter methodology
+  IF NOT EXISTS (
+    SELECT 1 FROM public.forum_threads
+      WHERE category_slug = 'share-trading'
+        AND title = 'How do you filter for quality ASX 200 stocks? Share your process'
+  ) THEN
+    INSERT INTO public.forum_threads
+      (category_slug, title, slug, body, author_name, is_pinned, is_locked, is_removed, reply_count, vote_score)
+    VALUES (
+      'share-trading',
+      'How do you filter for quality ASX 200 stocks? Share your process',
+      'asx-200-stock-filter-methodology',
+      E'Curious what quantitative or qualitative filters people actually use before adding a stock to their watchlist. I know everyone says "do your research" but what does that look like in practice?\n\nMy current process:\n1. PE ratio < 20 (or PEG < 1 if the co is growing fast)\n2. ROE > 15% for 3 consecutive years\n3. Net debt/EBITDA < 2x\n4. Free cash flow positive for 5 years\n\nAfter that I read the last 2 annual reports and the most recent half-year results. Feels slow but I''ve avoided a few blowups.\n\nWhat would you add or remove?',
+      'Invest.com.au Community',
+      false, false, false, 0, 7
+    ) RETURNING id INTO v_thread_id;
+
+    INSERT INTO public.forum_posts (thread_id, body, author_name, is_moderator, is_removed, vote_score)
+      SELECT v_thread_id,
+        E'Solid list. I''d add a quick check on capital allocation history — specifically whether management has bought back shares at sensible prices or issued dilutive equity at the bottom of the cycle. Companies with consistently good buyback timing (BHP, CSL historically) tend to outperform.\n\nAlso: scan the related-party transactions section of the annual report. Long list of RPTs is a yellow flag even when the individual amounts look small.',
+        'Invest.com.au Community', false, false, 3
+      WHERE NOT EXISTS (
+        SELECT 1 FROM public.forum_posts WHERE thread_id = v_thread_id AND author_name = 'Invest.com.au Community'
+      );
+  END IF;
+
+  -- Thread 3: Franking credits strategy
+  IF NOT EXISTS (
+    SELECT 1 FROM public.forum_threads
+      WHERE category_slug = 'share-trading'
+        AND title = 'Maximising franking credits — what''s your strategy going into the 2026 tax year?'
+  ) THEN
+    INSERT INTO public.forum_threads
+      (category_slug, title, slug, body, author_name, is_pinned, is_locked, is_removed, reply_count, vote_score)
+    VALUES (
+      'share-trading',
+      'Maximising franking credits — what''s your strategy going into the 2026 tax year?',
+      'maximising-franking-credits-2026',
+      E'With the end of FY2026 approaching I''m doing my usual annual review of dividend-franking strategy. Currently holding CBA, WBC, and BHP in my taxable account — all at or near 100% franked.\n\nQuestions for the group:\n1. Do you hold high-franking stocks in your taxable account and growth stocks in super/offset, or vice versa?\n2. Any view on whether the 45-day rule is likely to bite anyone holding for a short-term dividend trade?\n3. For those in a lower marginal tax bracket — how much of your return is effectively the franking refund?\n\nI get that this is general strategy chat, not personal advice — just interested in how others think about it.',
+      'Invest.com.au Community',
+      false, false, false, 0, 5
+    ) RETURNING id INTO v_thread_id;
+
+    INSERT INTO public.forum_posts (thread_id, body, author_name, is_moderator, is_removed, vote_score)
+      SELECT v_thread_id,
+        E'For the 45-day rule: it''s 45 days exclusive of acquisition and disposal, and the rule only applies if your total franking credits across the year exceed $5,000. Most retail investors are under that threshold, so it''s a non-issue unless you''re dividend-stripping at scale.\n\nOn asset location: the academic consensus (and most fee-only adviser I''ve talked to) is to hold your high-yield, fully-franked Australian stocks in a taxable account if you''re in a lower bracket where the franking refund exceeds your marginal rate — and growth/international assets in super where you can''t access the imputation credits anyway.',
+        'Invest.com.au Community', false, false, 4
+      WHERE NOT EXISTS (
+        SELECT 1 FROM public.forum_posts WHERE thread_id = v_thread_id AND author_name = 'Invest.com.au Community'
+      );
+  END IF;
+END $$;
+
+-- ══════════════════════════════════════════════════════════════
+-- 2. etfs-index-funds
+-- ══════════════════════════════════════════════════════════════
+
+DO $$
+DECLARE
+  v_thread_id integer;
+BEGIN
+  -- Thread 1: VAS vs A200 debate
+  IF NOT EXISTS (
+    SELECT 1 FROM public.forum_threads
+      WHERE category_slug = 'etfs-index-funds'
+        AND title = 'VAS vs A200 — is the 0.03% MER gap actually worth switching?'
+  ) THEN
+    INSERT INTO public.forum_threads
+      (category_slug, title, slug, body, author_name, is_pinned, is_locked, is_removed, reply_count, vote_score)
+    VALUES (
+      'etfs-index-funds',
+      'VAS vs A200 — is the 0.03% MER gap actually worth switching?',
+      'vas-vs-a200-mer-comparison',
+      E'After Betashares dropped the A200 MER to 0.04% last month the gap vs VAS (0.07%) is now 0.03% per year. On a $100k portfolio that''s $30/year.\n\nI''m currently in VAS with ~$85k and the CGT hit to switch would be around $2,800 based on my cost base. Break-even is roughly 93 years.\n\nFor new investors starting fresh, A200 seems like a no-brainer. But for existing VAS holders — has anyone actually run the numbers on whether a switch makes sense? Does the slightly broader index (VAS tracks 300 stocks vs A200''s 200) justify any of the fee difference?',
+      'Invest.com.au Community',
+      false, false, false, 0, 11
+    ) RETURNING id INTO v_thread_id;
+
+    INSERT INTO public.forum_posts (thread_id, body, author_name, is_moderator, is_removed, vote_score)
+      SELECT v_thread_id,
+        E'Your numbers are right and most people in existing VAS positions should just stay put. The extra 100 stocks in VAS (201–300 by market cap) make essentially no performance difference — they account for maybe 3–4% of the index weight combined.\n\nWhere the decision changes: if you''re in an accumulation phase and planning to add significant new capital over the next 5+ years, directing new contributions into A200 while leaving old VAS alone achieves most of the fee saving without the CGT trigger. You end up holding both ETFs but your blended MER drifts down over time.',
+        'Invest.com.au Community', false, false, 5
+      WHERE NOT EXISTS (
+        SELECT 1 FROM public.forum_posts WHERE thread_id = v_thread_id AND author_name = 'Invest.com.au Community'
+      );
+  END IF;
+
+  -- Thread 2: DCA frequency
+  IF NOT EXISTS (
+    SELECT 1 FROM public.forum_threads
+      WHERE category_slug = 'etfs-index-funds'
+        AND title = 'Monthly vs fortnightly DCA — does the frequency actually matter for ETFs?'
+  ) THEN
+    INSERT INTO public.forum_threads
+      (category_slug, title, slug, body, author_name, is_pinned, is_locked, is_removed, reply_count, vote_score)
+    VALUES (
+      'etfs-index-funds',
+      'Monthly vs fortnightly DCA — does the frequency actually matter for ETFs?',
+      'dca-frequency-monthly-vs-fortnightly',
+      E'My broker (Pearler) lets me set up an auto-invest on a custom schedule. I''m currently doing monthly into VGS + VAS, but I get paid fortnightly and some cash is just sitting idle for up to two weeks.\n\nI know the academic answer is "time in market beats timing the market" and more frequent contributions are marginally better in theory, but does brokerage cost change the calculus? Pearler is $6.50 per trade regardless of size.\n\nFor a $500/fortnight split across two ETFs that''s $13 in brokerage vs $13/month — doubling my brokerage drag. I''m thinking $1,000/month instead. Curious what others do.',
+      'Invest.com.au Community',
+      false, false, false, 0, 8
+    ) RETURNING id INTO v_thread_id;
+
+    INSERT INTO public.forum_posts (thread_id, body, author_name, is_moderator, is_removed, vote_score)
+      SELECT v_thread_id,
+        E'Monthly wins on brokerage for your numbers. At $1,000/month with two trades, brokerage is 1.3% of the invested amount. Fortnightly at $500 keeps that the same percentage-wise but compounds the dollar drag over time.\n\nRule of thumb: keep brokerage under 0.5% of the trade amount to avoid it meaningfully eating returns. That means $1,300+ per trade at Pearler''s $6.50 fee. At $500/fortnight per ETF you''re above that threshold — but if you''re splitting into two ETFs it''s $250 each, well above 0.5% drag.',
+        'Invest.com.au Community', false, false, 4
+      WHERE NOT EXISTS (
+        SELECT 1 FROM public.forum_posts WHERE thread_id = v_thread_id AND author_name = 'Invest.com.au Community'
+      );
+  END IF;
+
+  -- Thread 3: hedged vs unhedged
+  IF NOT EXISTS (
+    SELECT 1 FROM public.forum_threads
+      WHERE category_slug = 'etfs-index-funds'
+        AND title = 'Hedged vs unhedged international ETFs for an Australian investor — 2026 view'
+  ) THEN
+    INSERT INTO public.forum_threads
+      (category_slug, title, slug, body, author_name, is_pinned, is_locked, is_removed, reply_count, vote_score)
+    VALUES (
+      'etfs-index-funds',
+      'Hedged vs unhedged international ETFs for an Australian investor — 2026 view',
+      'hedged-vs-unhedged-etfs-australia-2026',
+      E'With AUD sitting around 0.64 USD, there''s a decent argument that it''s undervalued relative to historical ranges. If AUD recovers, an unhedged VGS position loses value on the FX leg even if the underlying index goes up.\n\nVanguard''s VGAD (hedged equivalent of VGS) costs about 0.21% vs 0.18% for VGS — 0.03% higher MER as the hedging cost. The actual hedge cost varies with the AUD/USD interest rate differential though and lately it''s been closer to 1–1.5% effective drag.\n\nFor a long-term buy-and-hold investor (15+ years), does currency risk even matter? Or is it just noise over that horizon?',
+      'Invest.com.au Community',
+      false, false, false, 0, 9
+    ) RETURNING id INTO v_thread_id;
+
+    INSERT INTO public.forum_posts (thread_id, body, author_name, is_moderator, is_removed, vote_score)
+      SELECT v_thread_id,
+        E'For 15+ year horizon, most research comes down on the side of unhedged. Over very long periods currency tends to mean-revert and the hedging cost (which you pay continuously) outweighs the protection. The 1–1.5% effective drag on VGAD right now because of the AUD/USD rate differential is a real cost, not a theoretical one.\n\nThe case for hedged makes more sense if: (a) you''re closer to drawdown phase (say, 5 years from needing the money), (b) your home currency is one that has historically appreciated rather than depreciated, or (c) you have a specific view that AUD is going to rip higher. None of those apply to most long-term Aussie accumulators.',
+        'Invest.com.au Community', false, false, 6
+      WHERE NOT EXISTS (
+        SELECT 1 FROM public.forum_posts WHERE thread_id = v_thread_id AND author_name = 'Invest.com.au Community'
+      );
+  END IF;
+END $$;
+
+-- ══════════════════════════════════════════════════════════════
+-- 3. property-investing
+-- ══════════════════════════════════════════════════════════════
+
+DO $$
+DECLARE
+  v_thread_id integer;
+BEGIN
+  -- Thread 1: Negative gearing worth it
+  IF NOT EXISTS (
+    SELECT 1 FROM public.forum_threads
+      WHERE category_slug = 'property-investing'
+        AND title = 'Is negative gearing still worth it in 2026? Running the actual numbers'
+  ) THEN
+    INSERT INTO public.forum_threads
+      (category_slug, title, slug, body, author_name, is_pinned, is_locked, is_removed, reply_count, vote_score)
+    VALUES (
+      'property-investing',
+      'Is negative gearing still worth it in 2026? Running the actual numbers',
+      'negative-gearing-worth-it-2026',
+      E'My accountant keeps pushing me toward a negatively geared IP (investment property) citing the tax benefits. I ran some numbers and I''m not sure the maths stacks up at current interest rates.\n\nExample: $750k property, 20% deposit ($150k), loan $600k at 6.4% p.a. = $38,400 interest/year. Rental yield in the suburb I''m looking at is about 3.8% = $28,500 gross rent. So the annual shortfall before expenses is $9,900. Add rates, insurance, agent fees, maintenance — probably $15k–$17k total loss per year.\n\nAt a 37% marginal rate, the tax saving is roughly $5,500–$6,300/year. So I''m still out of pocket $9,000–$11,000 per year in cash terms, betting on capital growth covering the gap.\n\nAm I missing something, or is this just a bet on Sydney/Melbourne property prices?',
+      'Invest.com.au Community',
+      false, false, false, 0, 13
+    ) RETURNING id INTO v_thread_id;
+
+    INSERT INTO public.forum_posts (thread_id, body, author_name, is_moderator, is_removed, vote_score)
+      SELECT v_thread_id,
+        E'You''re not missing anything — that''s exactly what negative gearing is: a cash-flow bet subsidised by the tax system, only profitable if capital growth exceeds your total out-of-pocket cost.\n\nThe break-even capital growth rate in your example: $10,000/year average shortfall on a $750k asset = you need 1.33% real growth per year just to break even before any inflation consideration. Sydney has historically delivered 7–8% per year but there have been 5-year flat patches (2017–2022 in real terms) where negative gearing holders were underwater in total return terms.\n\nThe argument for it: leverage. You''re controlling a $750k asset with $150k, so a 5% capital gain is a 25% return on your equity. The argument against: you''re also leveraged to a 5% capital fall. At current rates, interest-only loans for investment are back above 7% at some lenders — worth shopping.',
+        'Invest.com.au Community', false, false, 7
+      WHERE NOT EXISTS (
+        SELECT 1 FROM public.forum_posts WHERE thread_id = v_thread_id AND author_name = 'Invest.com.au Community'
+      );
+  END IF;
+
+  -- Thread 2: REIT vs direct property
+  IF NOT EXISTS (
+    SELECT 1 FROM public.forum_threads
+      WHERE category_slug = 'property-investing'
+        AND title = 'REITs vs direct property — the case for listed property in a share portfolio'
+  ) THEN
+    INSERT INTO public.forum_threads
+      (category_slug, title, slug, body, author_name, is_pinned, is_locked, is_removed, reply_count, vote_score)
+    VALUES (
+      'property-investing',
+      'REITs vs direct property — the case for listed property in a share portfolio',
+      'reits-vs-direct-property-australia',
+      E'I keep seeing direct property pushed as the only "real" property investment, but I''ve been getting my property exposure via A-REITs (Goodman Group, Scentre Group, Charter Hall) in my share portfolio.\n\nAdvantages I see with REITs over direct:\n- Liquidity: sell in seconds vs 30-60 days for property\n- Diversification: $10k buys exposure to 50+ assets\n- No landlord headaches or vacancy risk on individual properties\n- Distributions that are often partially tax-sheltered via building depreciation\n\nThe obvious disadvantages: you can''t leverage into REITs the same way, and prices are more volatile short-term.\n\nFor those who hold both — how do you think about the allocation?',
+      'Invest.com.au Community',
+      false, false, false, 0, 10
+    ) RETURNING id INTO v_thread_id;
+
+    INSERT INTO public.forum_posts (thread_id, body, author_name, is_moderator, is_removed, vote_score)
+      SELECT v_thread_id,
+        E'Both in my portfolio and I think the comparison misses the key distinction: direct property is a leveraged, illiquid, management-intensive asset. REITs are an unleveraged, liquid, passive exposure to commercial/industrial property. They''re really different products.\n\nGoodman Group (GMG) is effectively a bet on global industrial/logistics real estate managed by a world-class operator. You can''t replicate that with a residential IP in Parramatta. Conversely, residential property in a high-demand suburb gives you leverage and CGT discount on gains in a way REITs don''t match.\n\nMy approach: REITs for the commercial/industrial/retail exposure I can''t access directly; direct property only if I found a specific opportunity with compelling yield metrics.',
+        'Invest.com.au Community', false, false, 5
+      WHERE NOT EXISTS (
+        SELECT 1 FROM public.forum_posts WHERE thread_id = v_thread_id AND author_name = 'Invest.com.au Community'
+      );
+  END IF;
+
+  -- Thread 3: SMSF property
+  IF NOT EXISTS (
+    SELECT 1 FROM public.forum_threads
+      WHERE category_slug = 'property-investing'
+        AND title = 'Buying property in an SMSF — is the limited recourse borrowing arrangement worth the complexity?'
+  ) THEN
+    INSERT INTO public.forum_threads
+      (category_slug, title, slug, body, author_name, is_pinned, is_locked, is_removed, reply_count, vote_score)
+    VALUES (
+      'property-investing',
+      'Buying property in an SMSF — is the limited recourse borrowing arrangement worth the complexity?',
+      'smsf-property-lrba-complexity',
+      E'My SMSF has about $350k in balance after 8 years of contributions. A financial planner (not mine) at a networking event suggested I could buy a commercial property using a limited recourse borrowing arrangement (LRBA) — e.g., buy a $600k commercial premises my business could then lease back from the SMSF.\n\nThe tax angle is attractive (15% concessional rate in accumulation, potentially 0% in pension phase). But the setup complexity and ongoing compliance cost sounds significant.\n\nHas anyone done this? What did the setup actually cost, and what ongoing compliance burden does it add?',
+      'Invest.com.au Community',
+      false, false, false, 0, 8
+    ) RETURNING id INTO v_thread_id;
+
+    INSERT INTO public.forum_posts (thread_id, body, author_name, is_moderator, is_removed, vote_score)
+      SELECT v_thread_id,
+        E'Done this — commercial property bought via LRBA in our SMSF 4 years ago. The setup cost was around $4,500–$6,000 for the bare trust deed, LRBA-compliant loan (limited recourse from a commercial lender), and legal review. Annual SMSF accounting went from ~$2,000/year to ~$4,500 because of the additional complexity. The ATO also requires an independent valuation each year for assets above a threshold — another ~$800.\n\nThe related-party lease must be at market rent (ATO scrutinises this closely) so you can''t use it as a below-market subsidy for your business. Get an independent lease valuation to document market rate before signing.\n\nWorth it for us because the property has appreciated and the rental income is taxed at 15% vs my 47% marginal rate. But $350k might be too small — most advisers I''ve spoken to suggest $500k+ SMSF balance before an LRBA makes sense given the setup cost and ongoing compliance.',
+        'Invest.com.au Community', false, false, 6
+      WHERE NOT EXISTS (
+        SELECT 1 FROM public.forum_posts WHERE thread_id = v_thread_id AND author_name = 'Invest.com.au Community'
+      );
+  END IF;
+END $$;
+
+-- ══════════════════════════════════════════════════════════════
+-- 4. super-retirement
+-- ══════════════════════════════════════════════════════════════
+
+DO $$
+DECLARE
+  v_thread_id integer;
+BEGIN
+  -- Thread 1: Industry super vs retail
+  IF NOT EXISTS (
+    SELECT 1 FROM public.forum_threads
+      WHERE category_slug = 'super-retirement'
+        AND title = 'Industry super vs retail — AustralianSuper vs Aware vs Hostplus performance review'
+  ) THEN
+    INSERT INTO public.forum_threads
+      (category_slug, title, slug, body, author_name, is_pinned, is_locked, is_removed, reply_count, vote_score)
+    VALUES (
+      'super-retirement',
+      'Industry super vs retail — AustralianSuper vs Aware vs Hostplus performance review',
+      'industry-super-comparison-2026',
+      E'Ran a comparison of the 10-year net-of-fees returns for a few major industry funds in their default growth options:\n- AustralianSuper Balanced: 8.9% p.a.\n- Aware Super Growth: 8.4% p.a.\n- Hostplus Balanced: 9.1% p.a.\n- UniSuper Balanced: 8.7% p.a.\n\nAll pulled from the funds'' own PDS/dashboard figures, not APRA directly. A couple of observations:\n1. Hostplus has outperformed partly because of infrastructure and unlisted asset exposure — is that a fair comparison given liquidity risk is different?\n2. Any of these funds have notably worse insurance premium pricing that offsets the performance advantage?\n\nGenerally happy to hear from people who''ve actually switched between them.',
+      'Invest.com.au Community',
+      false, false, false, 0, 15
+    ) RETURNING id INTO v_thread_id;
+
+    INSERT INTO public.forum_posts (thread_id, body, author_name, is_moderator, is_removed, vote_score)
+      SELECT v_thread_id,
+        E'Good question on unlisted assets. Hostplus (and AustralianSuper to a lesser extent) smooth unlisted infrastructure/property valuations over time — this artificially reduces measured volatility and can make their "10-year returns" look better on paper during market drawdowns because unlisted assets aren''t marked to market daily.\n\nThe APRA performance test uses a risk-adjusted methodology partly to correct for this, but even that''s imperfect. When comparing funds, look at their APRA performance test results (APRA publishes these annually for MySuper products) rather than raw returns.\n\nOn insurance: Hostplus''s default insurance is competitive for under-40s but premiums escalate steeply for 50+. AustralianSuper tends to have more stable insurance pricing across age cohorts. Worth pricing your age band specifically before switching.',
+        'Invest.com.au Community', false, false, 8
+      WHERE NOT EXISTS (
+        SELECT 1 FROM public.forum_posts WHERE thread_id = v_thread_id AND author_name = 'Invest.com.au Community'
+      );
+  END IF;
+
+  -- Thread 2: Concessional contributions
+  IF NOT EXISTS (
+    SELECT 1 FROM public.forum_threads
+      WHERE category_slug = 'super-retirement'
+        AND title = 'Using concessional contribution carry-forward — has anyone actually done it?'
+  ) THEN
+    INSERT INTO public.forum_threads
+      (category_slug, title, slug, body, author_name, is_pinned, is_locked, is_removed, reply_count, vote_score)
+    VALUES (
+      'super-retirement',
+      'Using concessional contribution carry-forward — has anyone actually done it?',
+      'concessional-carry-forward-contributions',
+      E'My super balance is below $500k so I''m eligible to use the 5-year concessional contribution carry-forward. I had unused concessional cap space from FY2022–FY2025 (roughly $65k worth).\n\nI''m thinking of making a $90k personal deductible contribution this year (current $30k cap + ~$60k carried-forward) to reduce my taxable income. I''m a sole trader so I don''t have an employer making contributions that eat into the cap.\n\nHas anyone done a large carry-forward contribution? Practical questions:\n- Did the ATO system correctly track your unused cap balance?\n- How long did the tax return process take?\n- Any issues with the fund accepting a contribution that large?',
+      'Invest.com.au Community',
+      false, false, false, 0, 12
+    ) RETURNING id INTO v_thread_id;
+
+    INSERT INTO public.forum_posts (thread_id, body, author_name, is_moderator, is_removed, vote_score)
+      SELECT v_thread_id,
+        E'Did a $75k carry-forward personal deductible contribution (PDC) two years ago. A few practical notes:\n\n1. The ATO MyTax portal shows your available unused cap on the super page — it calculates it automatically from your tax history. Mine was accurate to the dollar.\n\n2. Lodge a "Notice of intent to claim a deduction" (form S290-170) with your super fund BEFORE you lodge your tax return. If you lodge the return first, the ATO treats the contribution as non-concessional and you can''t undo that easily.\n\n3. Most large funds have no issue with a $75–90k contribution but confirm with yours — some smaller retail funds have operational limits or require advance notice for contributions above $50k.\n\n4. The tax saving was significant — essentially bringing forward a lump sum of income into the 15% super environment vs my 47% marginal rate. Refund arrived about 6 weeks after lodgement.',
+        'Invest.com.au Community', false, false, 9
+      WHERE NOT EXISTS (
+        SELECT 1 FROM public.forum_posts WHERE thread_id = v_thread_id AND author_name = 'Invest.com.au Community'
+      );
+  END IF;
+
+  -- Thread 3: Transition to retirement
+  IF NOT EXISTS (
+    SELECT 1 FROM public.forum_threads
+      WHERE category_slug = 'super-retirement'
+        AND title = 'Transition to Retirement (TTR) strategy — who it still works for in 2026'
+  ) THEN
+    INSERT INTO public.forum_threads
+      (category_slug, title, slug, body, author_name, is_pinned, is_locked, is_removed, reply_count, vote_score)
+    VALUES (
+      'super-retirement',
+      'Transition to Retirement (TTR) strategy — who it still works for in 2026',
+      'transition-to-retirement-ttr-2026',
+      E'TTR strategies seem less popular now that TTR pension earnings are taxed at 15% (the 2017 change removed the 0% tax on TTR earnings). But I keep hearing from people my age (57) that it''s still useful in some situations.\n\nMy situation: still working full-time at 57, marginal rate 37%, super balance $620k. I''ve heard the basic strategy is to salary sacrifice more, draw down a TTR pension to replace the lost take-home pay, and lower your overall tax rate.\n\nBut if TTR earnings are now taxed at 15% anyway, and I''m already making concessional contributions at the $30k cap, is there still a tax arbitrage here?',
+      'Invest.com.au Community',
+      false, false, false, 0, 9
+    ) RETURNING id INTO v_thread_id;
+
+    INSERT INTO public.forum_posts (thread_id, body, author_name, is_moderator, is_removed, vote_score)
+      SELECT v_thread_id,
+        E'Yes, the tax arbitrage still works, but it''s narrower post-2017. The logic:\n\n1. You salary sacrifice to the $30k concessional cap (contributions taxed at 15% in the fund, saving you 22% vs your 37% marginal rate).\n\n2. Your take-home pay drops. To replace it, you draw a TTR pension. Pension payments from a taxed-element super balance (most people) are included in your assessable income but offset by a 15% tax offset — effective rate of around 22% for most in your age bracket.\n\n3. The fund''s TTR account earnings are taxed at 15% vs your 37% — still a 22% advantage on accumulated earnings.\n\nThe arbitrage is real but the maths is tighter than pre-2017. It mainly works for people in the 37–47% marginal bracket who are near retirement and want to optimise for the last 3–5 years of accumulation. Worth getting modelled by a fee-only adviser before pulling the trigger — the interaction with the transfer balance cap matters.',
+        'Invest.com.au Community', false, false, 7
+      WHERE NOT EXISTS (
+        SELECT 1 FROM public.forum_posts WHERE thread_id = v_thread_id AND author_name = 'Invest.com.au Community'
+      );
+  END IF;
+END $$;
+
+-- ══════════════════════════════════════════════════════════════
+-- 5. crypto
+-- ══════════════════════════════════════════════════════════════
+
+DO $$
+DECLARE
+  v_thread_id integer;
+BEGIN
+  -- Thread 1: ATO crypto tax treatment
+  IF NOT EXISTS (
+    SELECT 1 FROM public.forum_threads
+      WHERE category_slug = 'crypto'
+        AND title = 'ATO crypto tax treatment — CGT asset vs personal use, and how to handle DeFi'
+  ) THEN
+    INSERT INTO public.forum_threads
+      (category_slug, title, slug, body, author_name, is_pinned, is_locked, is_removed, reply_count, vote_score)
+    VALUES (
+      'crypto',
+      'ATO crypto tax treatment — CGT asset vs personal use, and how to handle DeFi',
+      'ato-crypto-tax-cgt-defi-australia',
+      E'The ATO''s crypto guidance has evolved significantly over the past few years. Key points as I understand them for FY2026:\n\n1. Most crypto holdings are CGT assets (not personal use assets) if you hold them for investment purposes.\n2. Trading one crypto for another is a CGT event (disposal of the first asset at market value).\n3. DeFi: providing liquidity, staking rewards, and yield farming are generally treated as assessable income at the time received, then as CGT assets going forward.\n4. Airdrops are income at market value on receipt date.\n\nWhat I''m uncertain about: how do people handle cross-chain bridge transactions for tax purposes? And does anyone use crypto tax software (Koinly, Crypto Tax Calculator Australia, CoinLedger) — are they accurate enough to rely on?',
+      'Invest.com.au Community',
+      false, false, false, 0, 14
+    ) RETURNING id INTO v_thread_id;
+
+    INSERT INTO public.forum_posts (thread_id, body, author_name, is_moderator, is_removed, vote_score)
+      SELECT v_thread_id,
+        E'Your summary is accurate. On bridge transactions: the ATO hasn''t issued specific guidance, but the consensus among crypto-specialist tax advisers is that a bridge is treated as disposal + reacquisition because you''re technically receiving a different token on the destination chain (even if it''s "wrapped ETH" or equivalent). Conservative approach: record as a CGT event at the market value at the time of bridging.\n\nFor software: Crypto Tax Calculator Australia (CTC) is the most widely recommended for Aussie tax because it handles ATO-specific rules (personal use exemption threshold, CGT discount) better than Koinly which is more US-centric in its defaults. CTC''s DeFi module handles Uniswap/Aave/Compound transactions reasonably well but you''ll still need to hand-check any exotic protocol. Export the report, check 10-20 transactions manually against Etherscan, and verify the CGT discount is only applied where >12 months holding.',
+        'Invest.com.au Community', false, false, 7
+      WHERE NOT EXISTS (
+        SELECT 1 FROM public.forum_posts WHERE thread_id = v_thread_id AND author_name = 'Invest.com.au Community'
+      );
+  END IF;
+
+  -- Thread 2: Bitcoin ETFs in Australia
+  IF NOT EXISTS (
+    SELECT 1 FROM public.forum_threads
+      WHERE category_slug = 'crypto'
+        AND title = 'Spot Bitcoin ETFs in Australia — EBTC vs CBTC vs direct custody comparison'
+  ) THEN
+    INSERT INTO public.forum_threads
+      (category_slug, title, slug, body, author_name, is_pinned, is_locked, is_removed, reply_count, vote_score)
+    VALUES (
+      'crypto',
+      'Spot Bitcoin ETFs in Australia — EBTC vs CBTC vs direct custody comparison',
+      'spot-bitcoin-etfs-australia-comparison',
+      E'Australia now has several spot Bitcoin ETFs trading on the ASX/CBOE. For those who want Bitcoin exposure without managing self-custody, the main options seem to be:\n\n- EBTC (VanEck Bitcoin ETF): 0.25% MER, Coinbase Custody\n- CBTC (CoinShares Bitcoin ETF): 0.29% MER\n- IBTC (BlackRock via iShares): recently launched\n\nFor someone who doesn''t want to manage hardware wallets or seed phrases, is there a meaningful reason to prefer self-custody over an ASX-listed ETF? Custody risk seems to be the main one, but Coinbase Custody is institutional grade.\n\nAlso: does holding via an ETF affect your CGT position differently to direct crypto? I assume both are CGT assets with the 12-month discount applying.',
+      'Invest.com.au Community',
+      false, false, false, 0, 11
+    ) RETURNING id INTO v_thread_id;
+
+    INSERT INTO public.forum_posts (thread_id, body, author_name, is_moderator, is_removed, vote_score)
+      SELECT v_thread_id,
+        E'CGT treatment: identical for the 12-month discount. ETF units are CGT assets just like directly held Bitcoin — you get the 50% discount if you hold the ETF units for 12+ months. No difference there.\n\nCustody risk comparison: an ASX-listed ETF has counterparty risk to the ETF issuer (e.g., VanEck Australia Pty Ltd) and the sub-custodian (Coinbase Custody). In a Coinbase insolvency scenario, the segregated custody structure should protect ETF holders — Bitcoin is held separately from Coinbase''s own balance sheet — but there''s legal/operational risk in that process.\n\nSelf-custody has zero counterparty risk but replaces it with personal operational risk: lost seed phrases, hardware failure, phishing. For amounts above $50k, most serious holders I know use a hardware wallet (Ledger or Trezor) with the seed phrase split between two physically separate locations. Below that, an ETF is probably the better risk-adjusted option for most people.',
+        'Invest.com.au Community', false, false, 6
+      WHERE NOT EXISTS (
+        SELECT 1 FROM public.forum_posts WHERE thread_id = v_thread_id AND author_name = 'Invest.com.au Community'
+      );
+  END IF;
+
+  -- Thread 3: Ethereum staking
+  IF NOT EXISTS (
+    SELECT 1 FROM public.forum_threads
+      WHERE category_slug = 'crypto'
+        AND title = 'Ethereum staking in Australia — liquid staking vs exchange staking vs solo node'
+  ) THEN
+    INSERT INTO public.forum_threads
+      (category_slug, title, slug, body, author_name, is_pinned, is_locked, is_removed, reply_count, vote_score)
+    VALUES (
+      'crypto',
+      'Ethereum staking in Australia — liquid staking vs exchange staking vs solo node',
+      'ethereum-staking-australia-options',
+      E'I hold about 4 ETH and am weighing up staking options. Current APR for ETH staking seems to be around 3–4% depending on network activity.\n\nOptions I''ve identified:\n1. Lido (stETH): liquid staking, ~3.8% APR, smart contract risk, no 32 ETH minimum\n2. Rocket Pool (rETH): more decentralised than Lido, similar APR\n3. Exchange staking (Coinbase, Kraken): simpler, exchange takes a cut so effective APR ~2.5%\n4. Solo validator node: requires exactly 32 ETH, full validator rewards, significant technical setup\n\nATO treatment: my understanding is staking rewards are ordinary income at market value on receipt. Has anyone confirmed this with their accountant for liquid staking specifically (where rewards are reflected in the exchange rate of stETH vs ETH)?',
+      'Invest.com.au Community',
+      false, false, false, 0, 10
+    ) RETURNING id INTO v_thread_id;
+
+    INSERT INTO public.forum_posts (thread_id, body, author_name, is_moderator, is_removed, vote_score)
+      SELECT v_thread_id,
+        E'ATO treatment for liquid staking is genuinely uncertain because the ATO hasn''t issued specific guidance on rebasing tokens vs accumulating tokens. For Lido stETH (rebasing): new stETH tokens are credited to your wallet daily — most advisers treat each daily increment as ordinary income at the ETH market price on that day. For rETH (accumulating): the exchange rate of rETH vs ETH increases over time. Some advisers argue you have no taxable event until you swap back to ETH; others argue there''s a constructive receipt each day. It''s an unsettled area.\n\nI confirmed with my accountant (crypto-specialist firm in Sydney): they treat rETH appreciation as deferred income recognised on disposal/swap, not on accrual. Their reasoning: you don''t receive anything into your wallet daily; the value appreciation is notional until realised. This is a conservative interpretation favourable to the taxpayer but it''s not guaranteed the ATO would agree on audit. Get your own advice.',
+        'Invest.com.au Community', false, false, 8
+      WHERE NOT EXISTS (
+        SELECT 1 FROM public.forum_posts WHERE thread_id = v_thread_id AND author_name = 'Invest.com.au Community'
+      );
+  END IF;
+END $$;
+
+-- ══════════════════════════════════════════════════════════════
+-- 6. tax-strategy
+-- ══════════════════════════════════════════════════════════════
+
+DO $$
+DECLARE
+  v_thread_id integer;
+BEGIN
+  -- Thread 1: Tax-loss harvesting
+  IF NOT EXISTS (
+    SELECT 1 FROM public.forum_threads
+      WHERE category_slug = 'tax-strategy'
+        AND title = 'Tax-loss harvesting on the ASX — wash sale rules, timing, and practical execution'
+  ) THEN
+    INSERT INTO public.forum_threads
+      (category_slug, title, slug, body, author_name, is_pinned, is_locked, is_removed, reply_count, vote_score)
+    VALUES (
+      'tax-strategy',
+      'Tax-loss harvesting on the ASX — wash sale rules, timing, and practical execution',
+      'tax-loss-harvesting-asx-australia',
+      E'With some positions down significantly this financial year I''m thinking about crystallising losses to offset capital gains elsewhere in my portfolio. A few questions for people who''ve done this on the ASX:\n\n1. Australia doesn''t have an explicit "wash sale" rule like the US (30 days), but the ATO can apply Part IVA (general anti-avoidance) if the dominant purpose is tax avoidance. How aggressive do you get with re-entering a position?\n\n2. For ETFs — if I sell VAS to crystallise a loss, can I immediately buy VGS + VAF as a temporary "bridge" position (similar asset class exposure), then buy back VAS after 30 days?\n\n3. How do you time this practically — at year end the spreads on some stocks widen and you might give up more in transaction costs than you save.',
+      'Invest.com.au Community',
+      false, false, false, 0, 16
+    ) RETURNING id INTO v_thread_id;
+
+    INSERT INTO public.forum_posts (thread_id, body, author_name, is_moderator, is_removed, vote_score)
+      SELECT v_thread_id,
+        E'On Part IVA: the dominant purpose test is subjective but practically the ATO has focused on structured tax schemes, not individual investors selling a position at a loss and later rebuying. I asked my accountant directly and their view is that re-entering after 30–45 days is generally safe as long as you can articulate a non-tax reason (e.g., market view changed, rebalancing) and you''re not doing it across dozens of positions annually as a systematic scheme.\n\nOn the VAS → VGS/VAF bridge: yes, this is a common approach. You maintain broad market exposure while being in a genuinely different asset (global equities vs Australian equities). There''s no explicit safe harbour period in Australia, but 30 days before rebuying VAS seems to be the informal consensus.\n\nTiming: I do this in May rather than June because spreads are tighter and there''s less end-of-year institutional activity. The last two weeks of June on ASX mid-caps can be genuinely illiquid.',
+        'Invest.com.au Community', false, false, 10
+      WHERE NOT EXISTS (
+        SELECT 1 FROM public.forum_posts WHERE thread_id = v_thread_id AND author_name = 'Invest.com.au Community'
+      );
+  END IF;
+
+  -- Thread 2: Investment bond structure
+  IF NOT EXISTS (
+    SELECT 1 FROM public.forum_threads
+      WHERE category_slug = 'tax-strategy'
+        AND title = 'Investment bonds for kids'' education savings — is the 10-year rule worth the complexity?'
+  ) THEN
+    INSERT INTO public.forum_threads
+      (category_slug, title, slug, body, author_name, is_pinned, is_locked, is_removed, reply_count, vote_score)
+    VALUES (
+      'tax-strategy',
+      'Investment bonds for kids'' education savings — is the 10-year rule worth the complexity?',
+      'investment-bonds-education-savings-children',
+      E'We have two kids (4 and 7) and want to start saving for their private school fees / university. Options I''m considering:\n\n1. Investment bond (e.g., Generation Life): earnings taxed at 30% inside the bond, and after 10 years, withdrawals are tax-free. If my marginal rate is 47%, this could be quite effective.\n\n2. Bare trust / informal trust: invest in their names, earnings taxed at their marginal rate (usually nil or 19% for kids with their own income — but hit by the "unearned income" rules at minors'' tax rates).\n\n3. Just hold in our own names (joint): simpler, fully under our control.\n\nFor investment bonds specifically: has anyone done the post-10-year withdrawal? Any gotchas with the insurance company structure that I''m missing?',
+      'Invest.com.au Community',
+      false, false, false, 0, 11
+    ) RETURNING id INTO v_thread_id;
+
+    INSERT INTO public.forum_posts (thread_id, body, author_name, is_moderator, is_removed, vote_score)
+      SELECT v_thread_id,
+        E'We did the 10-year investment bond route with Generation Life for our now-14-year-old. A few notes from experience:\n\n1. The 30% internal tax rate is the maximum — if the bond''s underlying assets include fully franked dividends, the effective tax rate inside the bond can be lower. Generation Life''s multi-asset growth option has averaged around 23% effective rate due to franking.\n\n2. The 10% annual top-up rule is often misunderstood: each year you can contribute up to 125% of the prior year''s contribution without restarting the 10-year clock. If you don''t contribute in a given year, the clock resets for new contributions (but not the existing balance). So irregular contributions require careful tracking.\n\n3. Withdrawal after 10 years: straightforward — submit the withdrawal form, funds hit your nominated account within 5 business days, no tax payable, no CGT event. The life insurance wrapper means the bond bypasses probate too, which is a bonus.\n\nMinors'' tax rates are a real trap with bare trusts — the ATO taxes unearned trust income at 47% above $416 for under-18s. The investment bond sidesteps this entirely.',
+        'Invest.com.au Community', false, false, 8
+      WHERE NOT EXISTS (
+        SELECT 1 FROM public.forum_posts WHERE thread_id = v_thread_id AND author_name = 'Invest.com.au Community'
+      );
+  END IF;
+
+  -- Thread 3: CGT discount
+  IF NOT EXISTS (
+    SELECT 1 FROM public.forum_threads
+      WHERE category_slug = 'tax-strategy'
+        AND title = 'CGT discount strategies — how are people actually accessing the 50% discount in practice?'
+  ) THEN
+    INSERT INTO public.forum_threads
+      (category_slug, title, slug, body, author_name, is_pinned, is_locked, is_removed, reply_count, vote_score)
+    VALUES (
+      'tax-strategy',
+      'CGT discount strategies — how are people actually accessing the 50% discount in practice?',
+      'cgt-discount-strategies-australia',
+      E'I understand the basic rule: hold an asset for 12+ months and you get the 50% CGT discount (meaning only half the capital gain is included in your taxable income). But in practice there are some subtleties I want to understand better:\n\n1. For ETFs with internal turnover — does the fund''s trading activity affect my personal 12-month clock? I hold VGS units; VGS internally trades the underlying stocks. My VGS units themselves are over 12 months old.\n\n2. If I acquire shares via a DRIP (dividend reinvestment plan), each parcel has its own 12-month clock. Is there a simple way to manage this without tracking 50 parcels per year?\n\n3. For someone in their 30s who might hold stocks for 20+ years — is there a scenario where the CGT is actually beneficial to trigger (e.g., in a low-income year) rather than defer indefinitely?',
+      'Invest.com.au Community',
+      false, false, false, 0, 13
+    ) RETURNING id INTO v_thread_id;
+
+    INSERT INTO public.forum_posts (thread_id, body, author_name, is_moderator, is_removed, vote_score)
+      SELECT v_thread_id,
+        E'Answers in order:\n\n1. ETF internal turnover does NOT affect your personal 12-month clock. You hold ETF units; the clock runs from when you bought those units. The fund''s internal trades are invisible to your CGT position because an ETF is a separate legal entity. Your capital gain on VGS units is calculated when you sell your VGS units.\n\n2. DRIP parcels: you''re right that each reinvestment creates a new parcel. Most modern portfolio trackers (Sharesight, etc.) handle this automatically. DRIP parcels from 12+ months ago qualify for the CGT discount; recent ones don''t. Sharesight''s tax report will separate these correctly when you sell.\n\n3. Crystallising gains deliberately in a low-income year is called "gain harvesting" (opposite of loss harvesting). If you have a year with significantly lower income — career break, parental leave, business loss — you might crystallise some gains while your marginal rate is lower. For example, if you''re at the 19% bracket, your effective CGT rate after discount is 9.5% vs 23.5% at the 47% bracket. The saving is real. Rebuy immediately — no wash-sale restriction in Australia.',
+        'Invest.com.au Community', false, false, 9
+      WHERE NOT EXISTS (
+        SELECT 1 FROM public.forum_posts WHERE thread_id = v_thread_id AND author_name = 'Invest.com.au Community'
+      );
+  END IF;
+END $$;
+
+-- ══════════════════════════════════════════════════════════════
+-- 7. beginners
+-- ══════════════════════════════════════════════════════════════
+
+DO $$
+DECLARE
+  v_thread_id integer;
+BEGIN
+  -- Thread 1: Getting started $1000
+  IF NOT EXISTS (
+    SELECT 1 FROM public.forum_threads
+      WHERE category_slug = 'beginners'
+        AND title = 'Getting started with $1,000 — what would you actually do?'
+  ) THEN
+    INSERT INTO public.forum_threads
+      (category_slug, title, slug, body, author_name, is_pinned, is_locked, is_removed, reply_count, vote_score)
+    VALUES (
+      'beginners',
+      'Getting started with $1,000 — what would you actually do?',
+      'getting-started-investing-1000-dollars',
+      E'I''m 24, have a stable job, and have finally saved $1,000 I don''t need for at least 5 years. I want to start investing but I''m overwhelmed by the options.\n\nI''ve read a bit and I keep seeing "just buy index funds" as the standard advice, but I don''t know which ones or through which platform. I''ve also seen people talking about picking individual stocks.\n\nBefore I make any decisions: what do you wish someone had told you when you started with a small amount? And what would you actually do with $1,000 if you were 24 again?',
+      'Invest.com.au Community',
+      true, false, false, 0, 22
+    ) RETURNING id INTO v_thread_id;
+
+    INSERT INTO public.forum_posts (thread_id, body, author_name, is_moderator, is_removed, vote_score)
+      SELECT v_thread_id,
+        E'Welcome! This is the right question to be asking at 24.\n\nThe honest beginner path that works for most people:\n\n1. Pick one broad global ETF to start: VGS (Vanguard MSCI Index International Shares ETF) gives you exposure to ~1,500 companies across 23 developed markets for a 0.18% annual fee. At $1,000 it''s one or two units.\n\n2. Pick a low-brokerage platform: Stake (zero brokerage on ASX ETFs), Pearler ($6.50 flat, has auto-invest), or CommSec Pocket ($2 for trades under $1,000). Stake is probably best for starting small.\n\n3. Set up an automatic monthly contribution — even $100/month. The habit matters more than the amount at this stage.\n\nWhat I wish I''d known at 24: the boring index fund approach beats most stock-picking over 10+ years. Not because picking stocks is impossible, but because the time and emotional energy it takes is usually not worth it vs just DCA''ing an index fund.\n\nOne more thing: max out your super concessional cap before putting extra into a taxable account. Super is the most tax-effective investment vehicle in Australia.',
+        'Invest.com.au Community', true, false, 12
+      WHERE NOT EXISTS (
+        SELECT 1 FROM public.forum_posts WHERE thread_id = v_thread_id AND author_name = 'Invest.com.au Community'
+      );
+  END IF;
+
+  -- Thread 2: Understanding ETF distributions
+  IF NOT EXISTS (
+    SELECT 1 FROM public.forum_threads
+      WHERE category_slug = 'beginners'
+        AND title = 'I just received my first ETF distribution — what does this actually mean?'
+  ) THEN
+    INSERT INTO public.forum_threads
+      (category_slug, title, slug, body, author_name, is_pinned, is_locked, is_removed, reply_count, vote_score)
+    VALUES (
+      'beginners',
+      'I just received my first ETF distribution — what does this actually mean?',
+      'first-etf-distribution-explained',
+      E'I bought VAS six months ago (about $2,000 worth) and this week I received a $38 distribution into my brokerage account. I was not expecting this and I have a few questions:\n\n1. Is this the equivalent of a dividend?\n2. Do I have to pay tax on it, and how?\n3. My brokerage account says it includes "franking credits" — what are those?\n4. Should I reinvest it manually or is there an automatic option?\n\nSorry if these are basic questions — I couldn''t find a clear explanation anywhere.',
+      'Invest.com.au Community',
+      false, false, false, 0, 17
+    ) RETURNING id INTO v_thread_id;
+
+    INSERT INTO public.forum_posts (thread_id, body, author_name, is_moderator, is_removed, vote_score)
+      SELECT v_thread_id,
+        E'Not basic at all — these are exactly the right questions to understand.\n\n1. Yes, an ETF distribution is the equivalent of a dividend. VAS holds ~300 ASX companies; when those companies pay dividends, VAS pools them and distributes them to you proportionally. VAS distributes quarterly.\n\n2. Tax: yes, distributions are assessable income in the year you receive them. You''ll get an Annual Tax Statement from your broker after 30 June showing the breakdown. Include it in your tax return under "Australian dividends and distributions." If you use a tax agent or MyTax, there''s a specific section for this.\n\n3. Franking credits: Australian companies pay tax at 30% on their profits before distributing dividends. The ATO gives you a credit for the tax already paid. For a 19%-bracket taxpayer, franking credits can result in a refund. For a 37%-bracket taxpayer, they reduce but don''t eliminate the extra tax owed.\n\n4. Reinvestment: VAS doesn''t have a formal DRIP (dividend reinvestment plan). You''d need to manually buy more units. Many people accumulate distributions in a high-interest account and invest when they have $500–$1,000 to avoid brokerage eating the small amounts.',
+        'Invest.com.au Community', false, false, 11
+      WHERE NOT EXISTS (
+        SELECT 1 FROM public.forum_posts WHERE thread_id = v_thread_id AND author_name = 'Invest.com.au Community'
+      );
+  END IF;
+
+  -- Thread 3: Emergency fund first
+  IF NOT EXISTS (
+    SELECT 1 FROM public.forum_threads
+      WHERE category_slug = 'beginners'
+        AND title = 'Emergency fund before investing — how much is actually "enough"?'
+  ) THEN
+    INSERT INTO public.forum_threads
+      (category_slug, title, slug, body, author_name, is_pinned, is_locked, is_removed, reply_count, vote_score)
+    VALUES (
+      'beginners',
+      'Emergency fund before investing — how much is actually "enough"?',
+      'emergency-fund-how-much-before-investing',
+      E'Every personal finance resource says "build an emergency fund first" but gives different answers for how much: 3 months, 6 months, 1 year of expenses. I''m 26, renting, no dependants, stable government job.\n\nMy current situation:\n- Monthly expenses: ~$3,200 (rent, groceries, transport, subscriptions)\n- Current savings account: $8,000\n- Investing so far: $0\n\nI''ve been waiting until I have $20k in the emergency fund before I start investing. But my friend says I''m leaving money on the table by not investing in the meantime. Who''s right?',
+      'Invest.com.au Community',
+      false, false, false, 0, 19
+    ) RETURNING id INTO v_thread_id;
+
+    INSERT INTO public.forum_posts (thread_id, body, author_name, is_moderator, is_removed, vote_score)
+      SELECT v_thread_id,
+        E'Your friend has a point, and the "3–6 months" rule is more nuanced than most resources admit.\n\nThe purpose of an emergency fund is to avoid being forced to sell investments at the wrong time. The size should reflect your actual risk of needing it:\n\n- Stable government job with good leave entitlements: your job risk is low; 2–3 months is probably sufficient.\n- No dependants, no mortgage: no catastrophic single expense lurking.\n- With $8k (2.5 months) and your profile, I''d argue you''re close enough to start investing.\n\nPractical approach many people use: split the monthly surplus. Say you save $800/month — put $400 into the emergency fund until you hit 3 months ($9,600 for you), and $400 into investing from day one. You get both.\n\nOne thing to check: does your job have income protection insurance via super? If so, your effective emergency runway is longer than the cash amount suggests. Most government super funds include income protection that kicks in after 60–90 days of illness/injury.',
+        'Invest.com.au Community', false, false, 13
+      WHERE NOT EXISTS (
+        SELECT 1 FROM public.forum_posts WHERE thread_id = v_thread_id AND author_name = 'Invest.com.au Community'
+      );
+  END IF;
+END $$;
+
+-- ══════════════════════════════════════════════════════════════
+-- 8. broker-reviews
+-- ══════════════════════════════════════════════════════════════
+
+DO $$
+DECLARE
+  v_thread_id integer;
+BEGIN
+  -- Thread 1: Pearler review
+  IF NOT EXISTS (
+    SELECT 1 FROM public.forum_threads
+      WHERE category_slug = 'broker-reviews'
+        AND title = 'Pearler 12-month review — best broker for long-term ETF investors?'
+  ) THEN
+    INSERT INTO public.forum_threads
+      (category_slug, title, slug, body, author_name, is_pinned, is_locked, is_removed, reply_count, vote_score)
+    VALUES (
+      'broker-reviews',
+      'Pearler 12-month review — best broker for long-term ETF investors?',
+      'pearler-broker-review-12-months',
+      E'I moved to Pearler from CommSec about 12 months ago for my ETF portfolio and wanted to share a detailed review now I''ve been through a full year of distributions, auto-invest, and CHESS transfers.\n\n**What works well:**\n- Auto-invest is genuinely set-and-forget. I have a monthly buy of VGS + VAS + VGAD configured and it just happens.\n- $6.50 flat brokerage regardless of trade size — predictable costs.\n- CHESS-sponsored (the shares are in your name, not a nominee structure).\n- Tax reporting exports that integrate with tax software.\n\n**What''s less good:**\n- The app is functional but feels dated compared to Stake or Superhero.\n- No US stocks — Pearler is ASX-only.\n- Customer support response times can be 2–3 business days for non-urgent queries.\n\nOverall: 8/10 if you want a boring, reliable ETF auto-invest platform. 5/10 if you want to actively trade or access US markets.',
+      'Invest.com.au Community',
+      false, false, false, 0, 18
+    ) RETURNING id INTO v_thread_id;
+
+    INSERT INTO public.forum_posts (thread_id, body, author_name, is_moderator, is_removed, vote_score)
+      SELECT v_thread_id,
+        E'Agree with this review. Been on Pearler for 2 years. Two things to add:\n\n1. The CHESS transfer in from CommSec took about 10 business days but was smooth — Pearler''s support team sent step-by-step instructions when I asked.\n\n2. One thing that surprised me: Pearler shares your portfolio data (anonymised) with their "Pearler Community" feature where you can see aggregate allocation trends. You can opt out, but it''s opt-out, not opt-in. Not a dealbreaker, but worth knowing.\n\nFor people choosing between Pearler and Stake for ASX ETFs: Stake is $0 brokerage on ETFs, which undercuts Pearler''s $6.50. But Stake is a nominee structure (not CHESS-sponsored), which matters to some investors from a risk perspective. Both are ASIC-regulated.',
+        'Invest.com.au Community', false, false, 8
+      WHERE NOT EXISTS (
+        SELECT 1 FROM public.forum_posts WHERE thread_id = v_thread_id AND author_name = 'Invest.com.au Community'
+      );
+  END IF;
+
+  -- Thread 2: moomoo review
+  IF NOT EXISTS (
+    SELECT 1 FROM public.forum_threads
+      WHERE category_slug = 'broker-reviews'
+        AND title = 'moomoo Australia review 2026 — genuinely good or just the Futu marketing machine?'
+  ) THEN
+    INSERT INTO public.forum_threads
+      (category_slug, title, slug, body, author_name, is_pinned, is_locked, is_removed, reply_count, vote_score)
+    VALUES (
+      'broker-reviews',
+      'moomoo Australia review 2026 — genuinely good or just the Futu marketing machine?',
+      'moomoo-australia-review-2026',
+      E'moomoo Australia (owned by Futu Holdings, a Tencent-backed HK brokerage) launched aggressively in Australia with zero brokerage on ASX stocks for 180 days and a bunch of free share promotions. I signed up during the promo and have now been using it for about 8 months with real money.\n\nLooking for others'' experiences. My main concerns going in:\n1. Data sovereignty — Futu is a Chinese-owned company; where does my data go?\n2. Financial stability — is a HK-listed company with Tencent backing a concern for an ASIC-licensed AU broker?\n3. After the 180-day promo: their ASX brokerage is now $0.49% or $3 minimum. Is that competitive post-promo?\n4. The platform has a lot of features (options, US pre-market) that I don''t use — does complexity = risk?',
+      'Invest.com.au Community',
+      false, false, false, 0, 14
+    ) RETURNING id INTO v_thread_id;
+
+    INSERT INTO public.forum_posts (thread_id, body, author_name, is_moderator, is_removed, vote_score)
+      SELECT v_thread_id,
+        E'Used moomoo for about 6 months. Honest take:\n\nData: moomoo AU''s privacy policy says data can be processed in Singapore, HK, and China. If that concerns you, don''t use it. It''s a real consideration, not just paranoia — Futu is subject to Chinese regulatory requirements.\n\nFinancial stability: ASIC-licensed, Australian client assets held in a segregated trust account at an Australian bank. The HK parent being Tencent-backed is actually a stability positive, not a risk — Futu is a billion-dollar company with extensive capital. The risk would be if ASIC revoked the AU licence, which would trigger a wind-down process with client asset protection.\n\nPost-promo brokerage: $0.49% is expensive for large trades. A $10,000 trade is $49 vs CommSec''s $19.95 and Pearler''s $6.50. moomoo only makes sense post-promo for traders under $600 per trade (where the $3 minimum applies) or for US options where their pricing is genuinely competitive.\n\nMy conclusion: good for the promo period, use it to learn the platform with free brokerage, then evaluate based on your actual trading size.',
+        'Invest.com.au Community', false, false, 7
+      WHERE NOT EXISTS (
+        SELECT 1 FROM public.forum_posts WHERE thread_id = v_thread_id AND author_name = 'Invest.com.au Community'
+      );
+  END IF;
+
+  -- Thread 3: Interactive Brokers review
+  IF NOT EXISTS (
+    SELECT 1 FROM public.forum_threads
+      WHERE category_slug = 'broker-reviews'
+        AND title = 'Interactive Brokers for Australians — is the complexity worth it for a retail investor?'
+  ) THEN
+    INSERT INTO public.forum_threads
+      (category_slug, title, slug, body, author_name, is_pinned, is_locked, is_removed, reply_count, vote_score)
+    VALUES (
+      'broker-reviews',
+      'Interactive Brokers for Australians — is the complexity worth it for a retail investor?',
+      'interactive-brokers-australia-review',
+      E'I keep seeing IBKR (Interactive Brokers) recommended for international investing — USD $1 per trade for US stocks, multi-currency accounts, global market access. But the platform looks incredibly complex and some reviews suggest it''s designed for institutional traders.\n\nFor a retail Australian investor who wants:\n- Cheap US stock trading\n- A USD holding account to avoid double FX conversion\n- Maybe some exposure to Hong Kong or UK markets\n\nIs IBKR overkill? Or is the complexity overblown and it''s actually manageable once you''re set up? Also curious about the $10/month inactivity fee — how does that work now?',
+      'Invest.com.au Community',
+      false, false, false, 0, 16
+    ) RETURNING id INTO v_thread_id;
+
+    INSERT INTO public.forum_posts (thread_id, body, author_name, is_moderator, is_removed, vote_score)
+      SELECT v_thread_id,
+        E'IBKR regular user here, about 3 years on the platform. The complexity is real but manageable — and the complexity is in features you don''t have to use. For a buy-and-hold retail investor, you use maybe 10% of the platform.\n\nInactivity fee update: as of 2023 IBKR removed the monthly minimum fee for accounts under USD $25 monthly commission. So for a passive investor making 1–2 trades per month, the effective monthly fee is $0 (unless you generate under the minimum, which was removed). Check their current fee schedule — it has changed multiple times.\n\nThe FX situation is the main reason most people come: you load AUD, convert to USD at near-interbank rates (0.0008% commission, not the 0.5–1% spread most banks/brokers charge), and trade in USD. When you sell, you hold USD. Only convert back to AUD when you actually need the cash. Saves materially on large positions.\n\nFor Hong Kong/UK access: IBKR covers both. HK Stocks are HKD, LSE stocks are GBP — same multi-currency approach applies. The platform is legitimately better than any Australian broker for international access.',
+        'Invest.com.au Community', false, false, 11
+      WHERE NOT EXISTS (
+        SELECT 1 FROM public.forum_posts WHERE thread_id = v_thread_id AND author_name = 'Invest.com.au Community'
+      );
+  END IF;
+END $$;
+
+-- ══════════════════════════════════════════════════════════════
+-- Update forum_categories aggregate counts
+-- Increment thread_count and post_count for each category
+-- based on threads actually inserted.
+-- Using a count query to stay idempotent with the guards above.
+-- ══════════════════════════════════════════════════════════════
+
+UPDATE public.forum_categories fc
+SET
+  thread_count = (
+    SELECT COUNT(*) FROM public.forum_threads ft
+      WHERE ft.category_slug = fc.slug
+        AND ft.is_removed = false
+  ),
+  post_count = (
+    SELECT COUNT(*) FROM public.forum_posts fp
+      INNER JOIN public.forum_threads ft ON ft.id = fp.thread_id
+      WHERE ft.category_slug = fc.slug
+        AND fp.is_removed = false
+        AND ft.is_removed = false
+  )
+WHERE fc.slug IN (
+  'share-trading', 'etfs-index-funds', 'property-investing',
+  'super-retirement', 'crypto', 'tax-strategy', 'beginners', 'broker-reviews'
+);
+
+COMMIT;


### PR DESCRIPTION
Lands the four "last-mile / genuine-gap" feature builds from the activation plan, each built on latest `main` and verified together. The four touch **non-overlapping** files and were integrated + verified as one branch to keep review/CI in a single pass.

### 1. Investor Pro activation (monetises the *existing* subscription system)
- Mounts the profile-aware `SmartRecommendationsStrip` on the account dashboard.
- Adds an Investor Pro upgrade tile to `/account/upgrade` that starts checkout via the existing `/api/stripe/create-checkout` flow.
- Wires the fee-impact "unlock more brokers" CTA (was a dead "Coming Soon") to the upgrade funnel. *Additive only — no existing free feature is gated.*

### 2. Structured advisor handoff + manual net-worth balances
- `investor_handoffs` table + `POST /api/account/holdings/handoff` (signed, 14-day, single-use token) + a read path on `/find-advisor?handoff=` showing a read-only holdings snapshot. The "Send to my advisor" button now transmits a consented snapshot instead of a bare deep-link.
- `manual_balances` table + `/api/account/net-worth/balances` CRUD + an inline editor; manual savings/super now count toward net worth.

### 3. Broker health-score detail pages + live loan rates
- New `app/health-scores/[slug]` RSC rendering the full 5-dimension breakdown (the list page only shows a blurred preview).
- `investment_loan_rates` table (seeded from the previously-hardcoded values) backing `/property/finance`, plus a `refresh-loan-rates` cron (registered in `lib/cron-groups.ts`).

### 4. Forum seed + index, brief chat, firm lead-notify
- Seeds 24 substantive AU-investing threads across the 8 forum categories and flips `/community` to `index: true`.
- Mounts the previously-orphaned `BriefChatPanel` on `/briefs/[slug]` for the two parties, behind a general-advice notice.
- Sends an email + in-app notification to an advisor when a firm admin reassigns a lead (best-effort).

### Verified
`tsc --noEmit` clean · full suite **13,114 passing** (1113 files) · eslint clean · jsonld + rate-limit `--strict` gates pass · coverage 78.47% (above floors).

### Notes
- New migrations: `investor_handoffs`, `manual_balances`, `investment_loan_rates`, `seed_forum_threads` (all RLS-enabled / idempotent / rollback headers). New cron: `refresh-loan-rates` (stub refresh — leaves a TODO for a real rate feed; seeded rates are factual-as-of-date).
- The handoff read endpoint is intentionally public (the opaque 128-bit token is the auth factor; expires in 14 days; service-role read documented as an anonymous-path exception).
- Tier C (migrations + cron + routes) — merging per the founder's directive to ship the full activation plan.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUfSRE2Teb6VhEXFP6RpS9)_