### PR TITLE
feat: embeddable fee-calculator widget (deepen the embed product)

### DIFF
--- a/__tests__/api/widget-calculator.test.ts
+++ b/__tests__/api/widget-calculator.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+const mockFrom = vi.fn();
+vi.mock("@/lib/supabase/static", () => ({
+  createStaticClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+import { GET, OPTIONS } from "@/app/api/widget/calculator/route";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeChain(data: unknown[] = []) {
+  const c: Record<string, unknown> = {};
+  const methods = ["select", "eq", "order", "limit", "not"];
+  for (const m of methods) c[m] = vi.fn(() => c);
+  c.then = (resolve: (v: { data: unknown[]; error: null }) => unknown) =>
+    Promise.resolve(resolve({ data, error: null }));
+  return c;
+}
+
+function makeReq(params: Record<string, string> = {}): NextRequest {
+  const url = new URL("http://localhost/api/widget/calculator");
+  for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
+  return new NextRequest(url.toString());
+}
+
+const BROKER = {
+  name: "Stake",
+  slug: "stake",
+  asx_fee_value: 3,
+  us_fee_value: 0,
+  fx_rate: 0.6,
+  logo_url: null,
+  color: "#7c3aed",
+  icon: "S",
+  affiliate_url: "https://stake.com.au?ref=invest",
+};
+
+const BROKER_B = {
+  name: "CommSec",
+  slug: "commsec",
+  asx_fee_value: 9.5,
+  us_fee_value: 19.95,
+  fx_rate: 0.7,
+  logo_url: null,
+  color: "#000000",
+  icon: "C",
+  affiliate_url: null,
+};
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("GET /api/widget/calculator", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://abc.supabase.co";
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "anon-key";
+  });
+
+  it("returns 200 application/javascript with CORS headers", async () => {
+    mockFrom.mockReturnValue(makeChain([BROKER]));
+    const res = await GET(makeReq());
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toMatch(/application\/javascript/);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(res.headers.get("Access-Control-Allow-Methods")).toContain("GET");
+    expect(res.headers.get("Cross-Origin-Resource-Policy")).toBe("cross-origin");
+    expect(res.headers.get("Vary")).toBe("Origin");
+  });
+
+  it("sets 1h public Cache-Control for CDN caching", async () => {
+    mockFrom.mockReturnValue(makeChain([BROKER]));
+    const res = await GET(makeReq());
+    const cc = res.headers.get("Cache-Control") ?? "";
+    expect(cc).toMatch(/public/);
+    expect(cc).toMatch(/max-age=3600/);
+    expect(cc).toMatch(/s-maxage=3600/);
+  });
+
+  it("embeds broker data as JSON in the JS payload", async () => {
+    mockFrom.mockReturnValue(makeChain([BROKER]));
+    const res = await GET(makeReq());
+    const body = await res.text();
+    expect(body).toContain("Stake");
+    expect(body).toContain("stake");
+    expect(body).toContain("BROKERS");
+  });
+
+  it("includes the general-advice disclaimer text", async () => {
+    mockFrom.mockReturnValue(makeChain([BROKER]));
+    const res = await GET(makeReq());
+    const body = await res.text();
+    expect(body).toContain("General information only");
+    expect(body).toContain("Not financial advice");
+    expect(body).toContain("DISCLAIMER");
+  });
+
+  it("defaults to ASX market", async () => {
+    mockFrom.mockReturnValue(makeChain([BROKER]));
+    const res = await GET(makeReq());
+    const body = await res.text();
+    expect(body).toContain('"asx"');
+  });
+
+  it("sets US market when ?market=us", async () => {
+    mockFrom.mockReturnValue(makeChain([BROKER]));
+    const res = await GET(makeReq({ market: "us" }));
+    const body = await res.text();
+    expect(body).toContain('"us"');
+  });
+
+  it("ignores invalid market param and falls back to asx", async () => {
+    mockFrom.mockReturnValue(makeChain([BROKER]));
+    const res = await GET(makeReq({ market: "crypto" }));
+    const body = await res.text();
+    expect(body).toContain('"asx"');
+  });
+
+  it("sets dark theme when ?theme=dark", async () => {
+    mockFrom.mockReturnValue(makeChain([BROKER]));
+    const res = await GET(makeReq({ theme: "dark" }));
+    const body = await res.text();
+    expect(body).toContain('"dark"');
+  });
+
+  it("defaults to light theme", async () => {
+    mockFrom.mockReturnValue(makeChain([BROKER]));
+    const res = await GET(makeReq());
+    const body = await res.text();
+    expect(body).toContain('"light"');
+  });
+
+  it("clamps limit to 10 when ?limit=99", async () => {
+    const chain = makeChain([BROKER]);
+    mockFrom.mockReturnValue(chain);
+    await GET(makeReq({ limit: "99" }));
+    expect((chain.limit as ReturnType<typeof vi.fn>).mock.calls[0]?.[0]).toBe(10);
+  });
+
+  it("clamps limit to 1 when ?limit=0", async () => {
+    const chain = makeChain([BROKER]);
+    mockFrom.mockReturnValue(chain);
+    await GET(makeReq({ limit: "0" }));
+    expect((chain.limit as ReturnType<typeof vi.fn>).mock.calls[0]?.[0]).toBe(1);
+  });
+
+  it("applies default amount 5000 when ?amount= is absent", async () => {
+    mockFrom.mockReturnValue(makeChain([BROKER]));
+    const res = await GET(makeReq());
+    const body = await res.text();
+    expect(body).toContain("DEFAULT_AMOUNT");
+    expect(body).toContain("5000");
+  });
+
+  it("accepts custom ?amount= value", async () => {
+    mockFrom.mockReturnValue(makeChain([BROKER]));
+    const res = await GET(makeReq({ amount: "25000" }));
+    const body = await res.text();
+    expect(body).toContain("25000");
+  });
+
+  it("caps ?amount= at 1000000", async () => {
+    mockFrom.mockReturnValue(makeChain([BROKER]));
+    const res = await GET(makeReq({ amount: "9999999" }));
+    const body = await res.text();
+    // 9999999 should not appear; 1000000 (the cap) should
+    expect(body).toContain("1000000");
+    expect(body).not.toContain("9999999");
+  });
+
+  it("handles empty broker result without throwing", async () => {
+    mockFrom.mockReturnValue(makeChain([]));
+    const res = await GET(makeReq());
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain("BROKERS = []");
+  });
+
+  it("queries only non-crypto active brokers", async () => {
+    const chain = makeChain([BROKER]);
+    mockFrom.mockReturnValue(chain);
+    await GET(makeReq());
+    const eqCalls = (chain.eq as ReturnType<typeof vi.fn>).mock.calls;
+    expect(eqCalls.some((c) => c[0] === "status" && c[1] === "active")).toBe(true);
+    expect(eqCalls.some((c) => c[0] === "is_crypto" && c[1] === false)).toBe(true);
+  });
+
+  it("includes calc logic (computeResults) and Shadow DOM setup in the JS", async () => {
+    mockFrom.mockReturnValue(makeChain([BROKER]));
+    const res = await GET(makeReq());
+    const body = await res.text();
+    expect(body).toContain("attachShadow");
+    expect(body).toContain("computeResults");
+    expect(body).toContain("totalCost");
+  });
+
+  it("includes a link back to invest.com.au in the JS payload", async () => {
+    mockFrom.mockReturnValue(makeChain([BROKER]));
+    const res = await GET(makeReq());
+    const body = await res.text();
+    expect(body).toContain("invest.com.au");
+  });
+
+  it("renders sorted cheapest-first logic in JS (references totalCost sort)", async () => {
+    mockFrom.mockReturnValue(makeChain([BROKER, BROKER_B]));
+    const res = await GET(makeReq());
+    const body = await res.text();
+    // The sort comparator is embedded in the JS
+    expect(body).toContain("totalCost");
+    // Both brokers are embedded
+    expect(body).toContain("CommSec");
+  });
+
+  it("uses the affiliate_url when present in broker data", async () => {
+    mockFrom.mockReturnValue(makeChain([BROKER]));
+    const res = await GET(makeReq());
+    const body = await res.text();
+    // The JS references affiliate_url to build the CTA link
+    expect(body).toContain("affiliate_url");
+  });
+});
+
+describe("OPTIONS /api/widget/calculator", () => {
+  it("returns 204 with CORS headers for preflight", () => {
+    const res = OPTIONS();
+    expect(res.status).toBe(204);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(res.headers.get("Access-Control-Allow-Methods")).toContain("GET");
+    expect(res.headers.get("Access-Control-Max-Age")).toBe("86400");
+    expect(res.headers.get("Vary")).toBe("Origin");
+  });
+});

--- a/app/api/widget/calculator/route.ts
+++ b/app/api/widget/calculator/route.ts
@@ -35,11 +35,14 @@ export async function GET(request: NextRequest) {
   const params = request.nextUrl.searchParams;
   const market = params.get("market") === "us" ? "us" : "asx";
   const theme = params.get("theme") === "dark" ? "dark" : "light";
-  const limit = Math.min(Math.max(parseInt(params.get("limit") || "5", 10) || 5, 1), 10);
-  const defaultAmount = Math.min(
-    Math.max(parseFloat(params.get("amount") || "5000") || 5000, 1),
-    1_000_000,
-  );
+  const parsedLimit = parseInt(params.get("limit") ?? "", 10);
+  const limit = Number.isNaN(parsedLimit)
+    ? 5
+    : Math.min(Math.max(parsedLimit, 1), 10);
+  const parsedAmount = parseFloat(params.get("amount") ?? "");
+  const defaultAmount = Number.isNaN(parsedAmount)
+    ? 5000
+    : Math.min(Math.max(parsedAmount, 1), 1_000_000);
 
   // Anon-key client: RLS enforces active-only broker rows. See header comment.
   const supabase = createStaticClient();

--- a/app/api/widget/calculator/route.ts
+++ b/app/api/widget/calculator/route.ts
@@ -1,0 +1,339 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createStaticClient } from "@/lib/supabase/static";
+
+export const runtime = "nodejs";
+// 1h ISR cache — broker fee data changes at most daily via the fee cron.
+export const revalidate = 3600;
+
+/**
+ * GET /api/widget/calculator — Returns self-contained JavaScript that renders
+ * an interactive brokerage-fee / trade-cost calculator inside a Shadow DOM.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * PUBLIC-BY-DESIGN ENDPOINT — CORS contract (mirrors /api/widget):
+ *   • `Access-Control-Allow-Origin: *` is INTENTIONAL — embed feature.
+ *   • Must NEVER read user-context data (no cookies, no auth, no per-user
+ *     state). Fee data here is identical to the public broker pages.
+ *   • Uses the anon-key client so Postgres RLS enforces active-only reads.
+ *     Do NOT swap to createAdminClient().
+ *   • Cache-Control allows public CDN caching — responses are not
+ *     personalised.
+ * ─────────────────────────────────────────────────────────────────────────
+ *
+ * AFSL compliance: this widget performs factual arithmetic on publicly
+ * disclosed broker fee schedules. It does NOT constitute financial product
+ * advice. The rendered widget includes the site's general-advice disclaimer
+ * (lib/compliance.ts GENERAL_ADVICE_WARNING) so consumers are aware.
+ *
+ * Query params:
+ *   ?market=asx|us         — which fee column to show (default: asx)
+ *   ?theme=light|dark      — colour theme (default: light)
+ *   ?limit=5               — max brokers to show (default: 5, max: 10)
+ *   ?amount=5000           — default trade amount pre-filled (default: 5000)
+ */
+export async function GET(request: NextRequest) {
+  const params = request.nextUrl.searchParams;
+  const market = params.get("market") === "us" ? "us" : "asx";
+  const theme = params.get("theme") === "dark" ? "dark" : "light";
+  const limit = Math.min(Math.max(parseInt(params.get("limit") || "5", 10) || 5, 1), 10);
+  const defaultAmount = Math.min(
+    Math.max(parseFloat(params.get("amount") || "5000") || 5000, 1),
+    1_000_000,
+  );
+
+  // Anon-key client: RLS enforces active-only broker rows. See header comment.
+  const supabase = createStaticClient();
+  const { data: brokers } = await supabase
+    .from("brokers")
+    .select(
+      "name, slug, asx_fee_value, us_fee_value, fx_rate, logo_url, color, icon, affiliate_url",
+    )
+    .eq("status", "active")
+    .eq("is_crypto", false)
+    .order("rating", { ascending: false })
+    .limit(limit);
+
+  const rows = (brokers || []) as {
+    name: string;
+    slug: string;
+    asx_fee_value: number | null;
+    us_fee_value: number | null;
+    fx_rate: number | null;
+    logo_url: string | null;
+    color: string | null;
+    icon: string | null;
+    affiliate_url: string | null;
+  }[];
+
+  const brokersJson = JSON.stringify(rows);
+
+  // General-advice disclaimer text — keep in sync with
+  // lib/compliance.ts GENERAL_ADVICE_WARNING.
+  const DISCLAIMER =
+    "General information only. Does not take into account your personal situation. " +
+    "Not financial advice. Consider the PDS and TMD before making any investment decision.";
+
+  const js = `
+(function() {
+  "use strict";
+  if (typeof document === "undefined") return;
+
+  var BROKERS = ${brokersJson};
+  var DEFAULT_MARKET = ${JSON.stringify(market)};
+  var DEFAULT_AMOUNT = ${JSON.stringify(defaultAmount)};
+  var THEME = ${JSON.stringify(theme)};
+  var DISCLAIMER = ${JSON.stringify(DISCLAIMER)};
+  var BASE = "https://invest.com.au";
+
+  // Find the script tag that loaded us (last matching script on page)
+  var scripts = document.querySelectorAll("script[src*='/api/widget/calculator']");
+  var currentScript = scripts[scripts.length - 1];
+  if (!currentScript) return;
+
+  // Create host element + shadow DOM for style isolation
+  var host = document.createElement("div");
+  host.setAttribute("data-invest-calc-widget", "true");
+  currentScript.parentNode.insertBefore(host, currentScript.nextSibling);
+
+  var shadow = host.attachShadow({ mode: "open" });
+
+  // ─── Theme tokens ──────────────────────────────────────────────
+  var isDark = THEME === "dark";
+  var bg      = isDark ? "#1e293b" : "#ffffff";
+  var bgInput = isDark ? "#0f172a" : "#f8fafc";
+  var border  = isDark ? "#334155" : "#e2e8f0";
+  var text    = isDark ? "#f1f5f9" : "#0f172a";
+  var textMuted = isDark ? "#94a3b8" : "#64748b";
+  var rowHover  = isDark ? "#334155" : "#f8fafc";
+  var accent    = "#059669";
+  var accentBg  = "#059669";
+  var accentText = "#ffffff";
+  var cheapestBg = isDark ? "#064e3b" : "#ecfdf5";
+  var cheapestBorder = isDark ? "#10b981" : "#a7f3d0";
+  var barBg      = isDark ? "#334155" : "#f1f5f9";
+
+  // ─── Styles ────────────────────────────────────────────────────
+  var styles = document.createElement("style");
+  styles.textContent = [
+    ":host { all: initial; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; display: block; }",
+    ".icw { background:" + bg + "; border:1px solid " + border + "; border-radius:12px; overflow:hidden; max-width:720px; font-size:13px; color:" + text + "; }",
+    ".icw-header { padding:12px 16px; font-weight:700; font-size:15px; border-bottom:1px solid " + border + "; display:flex; align-items:center; justify-content:space-between; }",
+    ".icw-controls { padding:10px 16px; border-bottom:1px solid " + border + "; display:flex; gap:8px; align-items:center; flex-wrap:wrap; background:" + bgInput + "; }",
+    ".icw-label { font-size:11px; font-weight:600; color:" + textMuted + "; text-transform:uppercase; letter-spacing:.05em; margin-right:4px; }",
+    ".icw-input { padding:5px 10px; border:1px solid " + border + "; border-radius:6px; background:" + bg + "; color:" + text + "; font-size:13px; font-weight:600; width:110px; outline:none; }",
+    ".icw-input:focus { border-color:" + accent + "; box-shadow:0 0 0 2px " + accent + "33; }",
+    ".icw-btn { padding:5px 12px; border:1px solid " + border + "; border-radius:6px; background:" + bg + "; color:" + textMuted + "; font-size:12px; font-weight:600; cursor:pointer; transition:all .15s; }",
+    ".icw-btn.active { background:" + accent + "; color:#fff; border-color:" + accent + "; }",
+    ".icw-btn:hover:not(.active) { border-color:" + accent + "; color:" + accent + "; }",
+    ".icw-row { display:grid; grid-template-columns:1fr 80px 90px 90px; align-items:center; padding:9px 16px; border-bottom:1px solid " + border + "; transition:background .15s; }",
+    ".icw-row:hover { background:" + rowHover + "; }",
+    ".icw-row:last-child { border-bottom:none; }",
+    ".icw-row.cheapest { background:" + cheapestBg + "; border-left:3px solid " + accent + "; }",
+    ".icw-name { font-weight:600; display:flex; align-items:center; gap:7px; font-size:13px; }",
+    ".icw-logo { width:24px; height:24px; border-radius:5px; display:flex; align-items:center; justify-content:center; font-weight:700; font-size:10px; flex-shrink:0; overflow:hidden; }",
+    ".icw-logo img { width:100%; height:100%; object-fit:contain; }",
+    ".icw-badge { font-size:9px; font-weight:700; text-transform:uppercase; color:" + accent + "; background:" + cheapestBg + "; border:1px solid " + cheapestBorder + "; border-radius:4px; padding:1px 5px; margin-left:4px; }",
+    ".icw-bar-wrap { height:6px; background:" + barBg + "; border-radius:3px; overflow:hidden; }",
+    ".icw-bar { height:100%; border-radius:3px; transition:width .4s ease; }",
+    ".icw-bar.cheapest { background:" + accent + "; }",
+    ".icw-bar.rest { background:#f59e0b; }",
+    ".icw-cost { font-weight:700; font-size:13px; font-variant-numeric:tabular-nums; }",
+    ".icw-pct { font-size:11px; color:" + textMuted + "; font-variant-numeric:tabular-nums; }",
+    ".icw-cta { display:inline-block; padding:4px 11px; background:" + accentBg + "; color:" + accentText + "; border-radius:6px; text-decoration:none; font-weight:600; font-size:11px; text-align:center; transition:opacity .15s; white-space:nowrap; }",
+    ".icw-cta:hover { opacity:.88; }",
+    ".icw-summary { padding:8px 16px; background:" + bgInput + "; border-top:1px solid " + border + "; font-size:12px; color:" + textMuted + "; text-align:center; }",
+    ".icw-summary strong { color:" + text + "; }",
+    ".icw-footer { padding:8px 16px; text-align:center; font-size:10px; color:" + textMuted + "; border-top:1px solid " + border + "; }",
+    ".icw-footer a { color:" + accent + "; text-decoration:none; font-weight:600; }",
+    ".icw-disclaimer { padding:8px 16px; font-size:10px; color:" + textMuted + "; border-top:1px solid " + border + "; line-height:1.5; }",
+    /* Header column row */
+    ".icw-thead { display:grid; grid-template-columns:1fr 80px 90px 90px; padding:7px 16px; background:" + bgInput + "; border-bottom:1px solid " + border + "; font-size:10px; font-weight:700; text-transform:uppercase; letter-spacing:.05em; color:" + textMuted + "; }",
+    /* Responsive: collapse cost bar col on narrow widths */
+    "@media (max-width:480px) { .icw-row { grid-template-columns:1fr 90px 80px; } .icw-thead { grid-template-columns:1fr 90px 80px; } .icw-col-bar { display:none; } }",
+  ].join("\\n");
+  shadow.appendChild(styles);
+
+  // ─── State ─────────────────────────────────────────────────────
+  var currentMarket = DEFAULT_MARKET;
+  var currentAmount = DEFAULT_AMOUNT;
+
+  // ─── Calc logic (mirrors TradeCostCalculator.tsx) ──────────────
+  function computeResults(amount) {
+    var results = [];
+    for (var i = 0; i < BROKERS.length; i++) {
+      var b = BROKERS[i];
+      if (currentMarket === "asx") {
+        var brokerage = b.asx_fee_value;
+        if (brokerage === null || brokerage === undefined || brokerage >= 999) continue;
+        results.push({
+          broker: b,
+          brokerage: brokerage,
+          fxCost: 0,
+          totalCost: brokerage,
+          pctOfTrade: amount > 0 ? (brokerage / amount) * 100 : 0,
+        });
+      } else {
+        var brok2 = b.us_fee_value;
+        if (brok2 === null || brok2 === undefined || brok2 >= 999) continue;
+        var fxCost = amount * ((b.fx_rate || 0) / 100);
+        var total = brok2 + fxCost;
+        results.push({
+          broker: b,
+          brokerage: brok2,
+          fxCost: fxCost,
+          totalCost: total,
+          pctOfTrade: amount > 0 ? (total / amount) * 100 : 0,
+        });
+      }
+    }
+    results.sort(function(a, b) { return a.totalCost - b.totalCost; });
+    return results;
+  }
+
+  function fmt(n) {
+    return "$" + n.toFixed(2);
+  }
+
+  function esc(s) {
+    if (!s) return "";
+    var d = document.createElement("div");
+    d.appendChild(document.createTextNode(String(s)));
+    return d.innerHTML;
+  }
+
+  // ─── Render ────────────────────────────────────────────────────
+  function render() {
+    var amount = parseFloat(String(currentAmount)) || 0;
+    var results = computeResults(amount);
+    var cheapestCost = results.length > 0 ? results[0].totalCost : 0;
+    var mostExpensiveCost = results.length > 0 ? results[results.length - 1].totalCost : 1;
+
+    var container = document.createElement("div");
+    container.className = "icw";
+
+    // Header
+    container.innerHTML =
+      '<div class="icw-header">' +
+        '<span>Brokerage Fee Calculator</span>' +
+        '<a href="' + BASE + '/trade-cost-calculator?ref=widget" target="_blank" style="font-size:11px;font-weight:400;color:' + textMuted + ';text-decoration:none;">Full calculator &rarr;</a>' +
+      '</div>';
+
+    // Controls
+    var marketBtnASX = '<button class="icw-btn' + (currentMarket === "asx" ? " active" : "") + '" data-market="asx">ASX</button>';
+    var marketBtnUS  = '<button class="icw-btn' + (currentMarket === "us"  ? " active" : "") + '" data-market="us">US</button>';
+    container.innerHTML +=
+      '<div class="icw-controls">' +
+        '<span class="icw-label">Amount</span>' +
+        '<input class="icw-input" type="number" value="' + esc(String(currentAmount)) + '" min="1" step="500" aria-label="Trade amount in AUD" />' +
+        '<span style="font-size:12px;color:' + textMuted + '">AUD</span>' +
+        '<span style="margin-left:4px;">' + marketBtnASX + marketBtnUS + '</span>' +
+      '</div>';
+
+    // Column headers
+    container.innerHTML +=
+      '<div class="icw-thead">' +
+        '<div>Broker</div>' +
+        '<div style="text-align:right">Total</div>' +
+        '<div style="text-align:right">% of trade</div>' +
+        '<div class="icw-col-bar"></div>' +
+      '</div>';
+
+    // Result rows
+    for (var i = 0; i < results.length; i++) {
+      var r = results[i];
+      var isCheapest = (i === 0);
+      var barWidth = mostExpensiveCost > 0 ? Math.max((r.totalCost / mostExpensiveCost) * 100, 2) : 2;
+
+      var logoHtml = r.broker.logo_url
+        ? '<div class="icw-logo" style="background:#fff;border:1px solid ' + border + '"><img src="' + esc(r.broker.logo_url) + '" alt="' + esc(r.broker.name) + '"></div>'
+        : '<div class="icw-logo" style="background:' + esc(r.broker.color || "#059669") + '20;color:' + esc(r.broker.color || "#059669") + '">' + esc((r.broker.icon || r.broker.name.charAt(0))) + '</div>';
+
+      var badge = isCheapest ? '<span class="icw-badge">Cheapest</span>' : '';
+      var link = r.broker.affiliate_url
+        ? esc(r.broker.affiliate_url) + (r.broker.affiliate_url.includes("?") ? "&" : "?") + "ref=widget&source=calc-embed"
+        : BASE + "/go/" + esc(r.broker.slug) + "?ref=widget&source=calc-embed";
+
+      container.innerHTML +=
+        '<div class="icw-row' + (isCheapest ? " cheapest" : "") + '">' +
+          '<div class="icw-name">' + logoHtml + esc(r.broker.name) + badge + '</div>' +
+          '<div style="text-align:right"><span class="icw-cost">' + fmt(r.totalCost) + '</span></div>' +
+          '<div style="text-align:right"><span class="icw-pct">' + r.pctOfTrade.toFixed(2) + '%</span></div>' +
+          '<div class="icw-col-bar"><div class="icw-bar-wrap"><div class="icw-bar ' + (isCheapest ? "cheapest" : "rest") + '" style="width:' + barWidth.toFixed(1) + '%"></div></div></div>' +
+        '</div>';
+    }
+
+    if (results.length === 0) {
+      container.innerHTML += '<div style="padding:20px;text-align:center;color:' + textMuted + ';font-size:13px;">No brokers found for ' + (currentMarket === "asx" ? "ASX" : "US") + ' trades.</div>';
+    }
+
+    // Savings summary
+    if (results.length >= 2) {
+      var saving = results[results.length - 1].totalCost - results[0].totalCost;
+      container.innerHTML +=
+        '<div class="icw-summary">Cheapest saves <strong>' + fmt(saving) + '</strong> per trade vs. most expensive</div>';
+    }
+
+    // Disclaimer — AFSL-required general advice warning
+    container.innerHTML += '<div class="icw-disclaimer">' + esc(DISCLAIMER) + '</div>';
+
+    // Footer
+    container.innerHTML += '<div class="icw-footer">Powered by <a href="' + BASE + '?ref=calc-widget" target="_blank">invest.com.au</a></div>';
+
+    // Swap in
+    while (shadow.firstChild && shadow.firstChild !== styles) shadow.removeChild(shadow.firstChild);
+    // Remove everything except styles node, then append
+    var existing = shadow.querySelector(".icw");
+    if (existing) shadow.removeChild(existing);
+    shadow.appendChild(container);
+
+    // Wire up controls
+    var input = shadow.querySelector(".icw-input");
+    if (input) {
+      input.addEventListener("input", function(e) {
+        var val = parseFloat(e.target.value);
+        if (Number.isFinite(val) && val > 0) {
+          currentAmount = val;
+          render();
+        }
+      });
+    }
+    shadow.querySelectorAll("[data-market]").forEach(function(btn) {
+      btn.addEventListener("click", function() {
+        currentMarket = btn.getAttribute("data-market");
+        render();
+      });
+    });
+  }
+
+  render();
+})();
+`;
+
+  return new NextResponse(js.trim(), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/javascript; charset=utf-8",
+      "Cache-Control": "public, max-age=3600, s-maxage=3600",
+      // Public-by-design: see header comment. Mirrors /api/widget CORS policy.
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, OPTIONS",
+      "Cross-Origin-Resource-Policy": "cross-origin",
+      Vary: "Origin",
+    },
+  });
+}
+
+/**
+ * CORS pre-flight. Mirrors /api/widget OPTIONS handler.
+ */
+export function OPTIONS() {
+  return new NextResponse(null, {
+    status: 204,
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, OPTIONS",
+      "Access-Control-Max-Age": "86400",
+      Vary: "Origin",
+    },
+  });
+}

--- a/app/embed/EmbedBuilder.tsx
+++ b/app/embed/EmbedBuilder.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useMemo, useEffect, useRef } from "react";
 
-import { WIDGET_CATALOGUE } from "@/lib/widget/types";
+import { WIDGET_CATALOGUE, CALCULATOR_WIDGET_CATALOGUE } from "@/lib/widget/types";
 
 const POPULAR_BROKERS = [
   { slug: "stake", name: "Stake" },
@@ -17,27 +17,52 @@ const POPULAR_BROKERS = [
   { slug: "webull", name: "Webull" },
 ];
 
+type BuilderTab = "broker" | "calculator";
+
 export default function EmbedBuilder() {
+  // ─── Tab ─────────────────────────────────────────────────────────────────
+  const [tab, setTab] = useState<BuilderTab>("broker");
+
+  // ─── Broker widget state ─────────────────────────────────────────────────
   const [selectedSlugs, setSelectedSlugs] = useState<string[]>([]);
   const [widgetType, setWidgetType] = useState<"table" | "compact">("table");
-  const [theme, setTheme] = useState<"light" | "dark">("light");
+  const [brokerTheme, setBrokerTheme] = useState<"light" | "dark">("light");
   const [limit, setLimit] = useState(5);
   const [widgetCatalogueSlug, setWidgetCatalogueSlug] = useState<string>("");
+
+  // ─── Calculator widget state ─────────────────────────────────────────────
+  const [calcMarket, setCalcMarket] = useState<"asx" | "us">("asx");
+  const [calcTheme, setCalcTheme] = useState<"light" | "dark">("light");
+  const [calcLimit, setCalcLimit] = useState(5);
+  const [calcAmount, setCalcAmount] = useState(5000);
+
   const [copied, setCopied] = useState(false);
   const previewRef = useRef<HTMLDivElement>(null);
 
-  const embedUrl = useMemo(() => {
+  // ─── Snippet generation ──────────────────────────────────────────────────
+  const brokerEmbedUrl = useMemo(() => {
     const params = new URLSearchParams();
     if (widgetCatalogueSlug) params.set("widget", widgetCatalogueSlug);
     if (selectedSlugs.length > 0) params.set("brokers", selectedSlugs.join(","));
     if (widgetType !== "table") params.set("type", widgetType);
-    if (theme !== "light") params.set("theme", theme);
+    if (brokerTheme !== "light") params.set("theme", brokerTheme);
     if (limit !== 5) params.set("limit", String(limit));
     const qs = params.toString();
     return `https://invest.com.au/api/widget${qs ? `?${qs}` : ""}`;
-  }, [selectedSlugs, widgetType, theme, limit, widgetCatalogueSlug]);
+  }, [selectedSlugs, widgetType, brokerTheme, limit, widgetCatalogueSlug]);
 
-  const snippet = `<script src="${embedUrl}"></script>`;
+  const calcEmbedUrl = useMemo(() => {
+    const params = new URLSearchParams();
+    if (calcMarket !== "asx") params.set("market", calcMarket);
+    if (calcTheme !== "light") params.set("theme", calcTheme);
+    if (calcLimit !== 5) params.set("limit", String(calcLimit));
+    if (calcAmount !== 5000) params.set("amount", String(calcAmount));
+    const qs = params.toString();
+    return `https://invest.com.au/api/widget/calculator${qs ? `?${qs}` : ""}`;
+  }, [calcMarket, calcTheme, calcLimit, calcAmount]);
+
+  const activeUrl = tab === "broker" ? brokerEmbedUrl : calcEmbedUrl;
+  const snippet = `<script src="${activeUrl}"></script>`;
 
   function toggleBroker(slug: string) {
     setSelectedSlugs((prev) =>
@@ -100,94 +125,207 @@ export default function EmbedBuilder() {
     };
   }, [snippet]);
 
+  const activeTheme = tab === "broker" ? brokerTheme : calcTheme;
+
   return (
     <div className="border border-slate-200 rounded-xl overflow-hidden">
+      {/* Tab bar */}
+      <div className="flex border-b border-slate-200">
+        <button
+          onClick={() => setTab("broker")}
+          className={`flex-1 py-3 text-xs font-bold uppercase tracking-wider transition-colors ${
+            tab === "broker"
+              ? "bg-white text-emerald-700 border-b-2 border-emerald-600"
+              : "bg-slate-50 text-slate-500 hover:text-slate-700"
+          }`}
+        >
+          Broker Comparison
+        </button>
+        <button
+          onClick={() => setTab("calculator")}
+          className={`flex-1 py-3 text-xs font-bold uppercase tracking-wider transition-colors ${
+            tab === "calculator"
+              ? "bg-white text-emerald-700 border-b-2 border-emerald-600"
+              : "bg-slate-50 text-slate-500 hover:text-slate-700"
+          }`}
+        >
+          Fee Calculator
+        </button>
+      </div>
+
       <div className="p-5 md:p-6 space-y-5">
-        {/* Curated widget filter */}
-        <div>
-          <label className="block text-xs font-bold uppercase tracking-wider text-slate-500 mb-2">
-            Widget type
-          </label>
-          <select
-            value={widgetCatalogueSlug}
-            onChange={(e) => setWidgetCatalogueSlug(e.target.value)}
-            className="w-full border border-slate-200 rounded-lg py-2 px-3 text-sm"
-          >
-            <option value="">Top brokers (default)</option>
-            {WIDGET_CATALOGUE.map((w) => (
-              <option key={w.slug} value={w.slug}>{w.label}</option>
-            ))}
-          </select>
-          <p className="mt-1 text-[11px] text-slate-500">
-            Pick a curated list (e.g. crypto exchanges) or leave default for top-rated overall.
-          </p>
-        </div>
+        {/* ── BROKER WIDGET CONTROLS ── */}
+        {tab === "broker" && (
+          <>
+            {/* Curated widget filter */}
+            <div>
+              <label className="block text-xs font-bold uppercase tracking-wider text-slate-500 mb-2">
+                Widget type
+              </label>
+              <select
+                value={widgetCatalogueSlug}
+                onChange={(e) => setWidgetCatalogueSlug(e.target.value)}
+                className="w-full border border-slate-200 rounded-lg py-2 px-3 text-sm"
+              >
+                <option value="">Top brokers (default)</option>
+                {WIDGET_CATALOGUE.map((w) => (
+                  <option key={w.slug} value={w.slug}>{w.label}</option>
+                ))}
+              </select>
+              <p className="mt-1 text-[11px] text-slate-500">
+                Pick a curated list (e.g. crypto exchanges) or leave default for top-rated overall.
+              </p>
+            </div>
 
-        {/* Broker selection */}
-        <div>
-          <label className="block text-xs font-bold uppercase tracking-wider text-slate-500 mb-2">
-            Select Brokers (optional)
-          </label>
-          <div className="flex flex-wrap gap-2">
-            {POPULAR_BROKERS.map((b) => {
-              const active = selectedSlugs.includes(b.slug);
-              return (
-                <button
-                  key={b.slug}
-                  onClick={() => toggleBroker(b.slug)}
-                  className={`px-3 py-1.5 rounded-lg text-xs font-medium border transition-all ${
-                    active
-                      ? "bg-emerald-50 border-emerald-300 text-emerald-700"
-                      : "bg-white border-slate-200 text-slate-600 hover:border-slate-300"
-                  }`}
+            {/* Broker selection */}
+            <div>
+              <label className="block text-xs font-bold uppercase tracking-wider text-slate-500 mb-2">
+                Select Brokers (optional)
+              </label>
+              <div className="flex flex-wrap gap-2">
+                {POPULAR_BROKERS.map((b) => {
+                  const active = selectedSlugs.includes(b.slug);
+                  return (
+                    <button
+                      key={b.slug}
+                      onClick={() => toggleBroker(b.slug)}
+                      className={`px-3 py-1.5 rounded-lg text-xs font-medium border transition-all ${
+                        active
+                          ? "bg-emerald-50 border-emerald-300 text-emerald-700"
+                          : "bg-white border-slate-200 text-slate-600 hover:border-slate-300"
+                      }`}
+                    >
+                      {active && <span className="mr-1">&#10003;</span>}
+                      {b.name}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            {/* Layout + Theme */}
+            <div className="grid sm:grid-cols-3 gap-4">
+              <div>
+                <label className="block text-xs font-bold uppercase tracking-wider text-slate-500 mb-2">Layout</label>
+                <select
+                  value={widgetType}
+                  onChange={(e) => setWidgetType(e.target.value as "table" | "compact")}
+                  className="w-full border border-slate-200 rounded-lg py-2 px-3 text-sm"
                 >
-                  {active && <span className="mr-1">&#10003;</span>}
-                  {b.name}
-                </button>
-              );
-            })}
-          </div>
-        </div>
+                  <option value="table">Table</option>
+                  <option value="compact">Compact Cards</option>
+                </select>
+              </div>
+              <div>
+                <label className="block text-xs font-bold uppercase tracking-wider text-slate-500 mb-2">Theme</label>
+                <select
+                  value={brokerTheme}
+                  onChange={(e) => setBrokerTheme(e.target.value as "light" | "dark")}
+                  className="w-full border border-slate-200 rounded-lg py-2 px-3 text-sm"
+                >
+                  <option value="light">Light</option>
+                  <option value="dark">Dark</option>
+                </select>
+              </div>
+              <div>
+                <label className="block text-xs font-bold uppercase tracking-wider text-slate-500 mb-2">Max Brokers</label>
+                <select
+                  value={limit}
+                  onChange={(e) => setLimit(parseInt(e.target.value, 10))}
+                  className="w-full border border-slate-200 rounded-lg py-2 px-3 text-sm"
+                >
+                  {[3, 5, 8, 10].map((n) => (
+                    <option key={n} value={n}>{n}</option>
+                  ))}
+                </select>
+              </div>
+            </div>
+          </>
+        )}
 
-        {/* Layout + Theme */}
-        <div className="grid sm:grid-cols-3 gap-4">
-          <div>
-            <label className="block text-xs font-bold uppercase tracking-wider text-slate-500 mb-2">Layout</label>
-            <select
-              value={widgetType}
-              onChange={(e) => setWidgetType(e.target.value as "table" | "compact")}
-              className="w-full border border-slate-200 rounded-lg py-2 px-3 text-sm"
-            >
-              <option value="table">Table</option>
-              <option value="compact">Compact Cards</option>
-            </select>
-          </div>
-          <div>
-            <label className="block text-xs font-bold uppercase tracking-wider text-slate-500 mb-2">Theme</label>
-            <select
-              value={theme}
-              onChange={(e) => setTheme(e.target.value as "light" | "dark")}
-              className="w-full border border-slate-200 rounded-lg py-2 px-3 text-sm"
-            >
-              <option value="light">Light</option>
-              <option value="dark">Dark</option>
-            </select>
-          </div>
-          <div>
-            <label className="block text-xs font-bold uppercase tracking-wider text-slate-500 mb-2">Max Brokers</label>
-            <select
-              value={limit}
-              onChange={(e) => setLimit(parseInt(e.target.value, 10))}
-              className="w-full border border-slate-200 rounded-lg py-2 px-3 text-sm"
-            >
-              {[3, 5, 8, 10].map((n) => (
-                <option key={n} value={n}>{n}</option>
-              ))}
-            </select>
-          </div>
-        </div>
+        {/* ── CALCULATOR WIDGET CONTROLS ── */}
+        {tab === "calculator" && (
+          <>
+            {/* Preset picker */}
+            <div>
+              <label className="block text-xs font-bold uppercase tracking-wider text-slate-500 mb-2">
+                Preset
+              </label>
+              <div className="grid sm:grid-cols-3 gap-3">
+                {CALCULATOR_WIDGET_CATALOGUE.map((preset) => (
+                  <button
+                    key={preset.slug}
+                    onClick={() => {
+                      setCalcMarket(preset.market);
+                      setCalcAmount(preset.amount);
+                    }}
+                    className="text-left border border-slate-200 rounded-lg p-3 hover:border-emerald-300 hover:bg-emerald-50/40 transition-all"
+                  >
+                    <p className="text-xs font-bold text-slate-800 mb-0.5">{preset.label}</p>
+                    <p className="text-[11px] text-slate-500 leading-snug">{preset.snippetHint}</p>
+                  </button>
+                ))}
+              </div>
+            </div>
 
-        {/* Code output */}
+            {/* Market + Amount + Theme + Limit */}
+            <div className="grid sm:grid-cols-2 gap-4">
+              <div>
+                <label className="block text-xs font-bold uppercase tracking-wider text-slate-500 mb-2">Market</label>
+                <select
+                  value={calcMarket}
+                  onChange={(e) => setCalcMarket(e.target.value as "asx" | "us")}
+                  className="w-full border border-slate-200 rounded-lg py-2 px-3 text-sm"
+                >
+                  <option value="asx">ASX (Australian shares)</option>
+                  <option value="us">US shares (includes FX cost)</option>
+                </select>
+              </div>
+              <div>
+                <label className="block text-xs font-bold uppercase tracking-wider text-slate-500 mb-2">Default Amount (AUD)</label>
+                <select
+                  value={calcAmount}
+                  onChange={(e) => setCalcAmount(parseInt(e.target.value, 10))}
+                  className="w-full border border-slate-200 rounded-lg py-2 px-3 text-sm"
+                >
+                  {[500, 1000, 2000, 5000, 10000, 25000, 50000].map((n) => (
+                    <option key={n} value={n}>${n.toLocaleString()}</option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className="block text-xs font-bold uppercase tracking-wider text-slate-500 mb-2">Theme</label>
+                <select
+                  value={calcTheme}
+                  onChange={(e) => setCalcTheme(e.target.value as "light" | "dark")}
+                  className="w-full border border-slate-200 rounded-lg py-2 px-3 text-sm"
+                >
+                  <option value="light">Light</option>
+                  <option value="dark">Dark</option>
+                </select>
+              </div>
+              <div>
+                <label className="block text-xs font-bold uppercase tracking-wider text-slate-500 mb-2">Max Brokers</label>
+                <select
+                  value={calcLimit}
+                  onChange={(e) => setCalcLimit(parseInt(e.target.value, 10))}
+                  className="w-full border border-slate-200 rounded-lg py-2 px-3 text-sm"
+                >
+                  {[3, 5, 8, 10].map((n) => (
+                    <option key={n} value={n}>{n}</option>
+                  ))}
+                </select>
+              </div>
+            </div>
+
+            <p className="text-[11px] text-slate-500">
+              The calculator is interactive — visitors can change the trade amount and market directly in the widget.
+              General-advice disclaimer is included automatically.
+            </p>
+          </>
+        )}
+
+        {/* Code output — shared */}
         <div>
           <label className="block text-xs font-bold uppercase tracking-wider text-slate-500 mb-2">Your Embed Code</label>
           <div className="relative">
@@ -203,13 +341,13 @@ export default function EmbedBuilder() {
           </div>
         </div>
 
-        {/* Live Preview */}
+        {/* Live Preview — shared */}
         <div>
           <label className="block text-xs font-bold uppercase tracking-wider text-slate-500 mb-2">Live Preview</label>
           <div
             ref={previewRef}
             className={`rounded-lg border border-slate-200 overflow-hidden min-h-50 ${
-              theme === "dark" ? "bg-slate-800" : "bg-white"
+              activeTheme === "dark" ? "bg-slate-800" : "bg-white"
             }`}
           />
         </div>

--- a/app/embed/page.tsx
+++ b/app/embed/page.tsx
@@ -1,24 +1,24 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { absoluteUrl, breadcrumbJsonLd, CURRENT_YEAR, SITE_NAME } from "@/lib/seo";
+import { absoluteUrl, breadcrumbJsonLd, SITE_NAME } from "@/lib/seo";
 import Icon from "@/components/Icon";
 import EmbedBuilder from "./EmbedBuilder";
 
 export const revalidate = 3600;
 
 export const metadata: Metadata = {
-  title: `Embed Broker Comparison Widget — ${SITE_NAME}`,
-  description: `Add a free, self-contained broker comparison widget to your website. Multiple styles, dark/light themes, and always up-to-date data from ${SITE_NAME}.`,
+  title: `Embed Broker & Calculator Widgets — ${SITE_NAME}`,
+  description: `Add free, self-contained broker comparison or interactive brokerage fee calculator widgets to your website. Multiple styles, dark/light themes, and always up-to-date data from ${SITE_NAME}.`,
   openGraph: {
-    title: "Embed Broker Comparison Widget",
+    title: "Embed Broker & Calculator Widgets",
     description:
-      "Drop a live broker comparison table onto any website with a single script tag.",
+      "Drop a live broker comparison table or interactive fee calculator onto any website with a single script tag.",
   },
   twitter: { card: "summary_large_image" },
   alternates: { canonical: "/embed" },
 };
 
-const SNIPPETS = [
+const BROKER_SNIPPETS = [
   {
     title: "Default — Table (Top 5)",
     description: "Shows a sortable table of the top 5 rated brokers with ASX/US fees and ratings.",
@@ -41,6 +41,29 @@ const SNIPPETS = [
   },
 ];
 
+const CALC_SNIPPETS = [
+  {
+    title: "Default — ASX Fee Calculator",
+    description: "Interactive brokerage fee comparison for ASX trades — visitors can adjust the trade amount.",
+    code: `<script src="https://invest.com.au/api/widget/calculator"></script>`,
+  },
+  {
+    title: "US Shares (with FX cost)",
+    description: "Shows the true per-trade cost for US shares including FX margin.",
+    code: `<script src="https://invest.com.au/api/widget/calculator?market=us"></script>`,
+  },
+  {
+    title: "Large Trade ($25k default)",
+    description: "Pre-fills $25,000 to show where percentage-based brokerage stings.",
+    code: `<script src="https://invest.com.au/api/widget/calculator?amount=25000"></script>`,
+  },
+  {
+    title: "Dark Theme Calculator",
+    description: "Interactive fee calculator styled for dark-mode sites.",
+    code: `<script src="https://invest.com.au/api/widget/calculator?theme=dark"></script>`,
+  },
+];
+
 export default function EmbedPage() {
   const breadcrumbLd = breadcrumbJsonLd([
     { name: "Home", url: absoluteUrl("/") },
@@ -60,7 +83,7 @@ export default function EmbedPage() {
           <nav className="text-xs text-slate-500 mb-5 flex items-center gap-1.5">
             <Link href="/" className="hover:text-slate-900">Home</Link>
             <span className="text-slate-300">/</span>
-            <span className="text-slate-900 font-medium">Embed Widget</span>
+            <span className="text-slate-900 font-medium">Embed Widgets</span>
           </nav>
 
           <div className="inline-flex items-center gap-2 px-3 py-1 bg-emerald-50 rounded-full text-xs font-semibold text-emerald-700 mb-4">
@@ -69,12 +92,12 @@ export default function EmbedPage() {
           </div>
 
           <h1 className="text-2xl sm:text-3xl md:text-4xl font-extrabold leading-tight tracking-tight text-slate-900 mb-3">
-            Embed a Broker Comparison Widget
+            Embed Broker & Calculator Widgets
           </h1>
           <p className="text-sm md:text-base text-slate-600 leading-relaxed max-w-2xl">
-            Add a live, self-contained comparison table to your blog, forum, or financial website.
-            The widget renders inside a Shadow DOM so it never conflicts with your styles.
-            Data stays fresh automatically.
+            Add a live broker comparison table or an interactive brokerage fee calculator to your
+            blog, forum, or financial website. Both widgets render inside a Shadow DOM so they never
+            conflict with your styles. Data stays fresh automatically.
           </p>
         </div>
       </section>
@@ -96,10 +119,13 @@ export default function EmbedPage() {
           ))}
         </div>
 
-        {/* Snippet Examples */}
-        <h2 className="text-lg md:text-xl font-extrabold text-slate-900 mb-4">Embed Examples</h2>
+        {/* ── Broker Widget Snippets ── */}
+        <h2 className="text-lg md:text-xl font-extrabold text-slate-900 mb-1">Broker Comparison Widget</h2>
+        <p className="text-sm text-slate-500 mb-5">
+          Shows a live table or compact card layout comparing broker fees, ratings, and links.
+        </p>
         <div className="space-y-6 mb-12">
-          {SNIPPETS.map((snippet) => (
+          {BROKER_SNIPPETS.map((snippet) => (
             <div key={snippet.title} className="border border-slate-200 rounded-xl overflow-hidden">
               <div className="px-5 py-3 bg-slate-50 border-b border-slate-200">
                 <h3 className="font-bold text-sm text-slate-900">{snippet.title}</h3>
@@ -112,8 +138,8 @@ export default function EmbedPage() {
           ))}
         </div>
 
-        {/* Query Params Reference */}
-        <h2 className="text-lg md:text-xl font-extrabold text-slate-900 mb-4">Customisation Options</h2>
+        {/* Broker params reference */}
+        <h3 className="text-base font-extrabold text-slate-900 mb-4">Broker Widget Parameters</h3>
         <div className="bg-white border border-slate-200 rounded-xl overflow-hidden mb-12">
           <table className="w-full text-sm">
             <thead>
@@ -129,7 +155,57 @@ export default function EmbedPage() {
                 { param: "brokers", values: "slug,slug,...", def: "(all)", desc: "Comma-separated broker slugs to include." },
                 { param: "type", values: "table | compact", def: "table", desc: "Widget layout style." },
                 { param: "theme", values: "light | dark", def: "light", desc: "Colour theme." },
-                { param: "limit", values: "1-10", def: "5", desc: "Maximum brokers displayed." },
+                { param: "limit", values: "1–10", def: "5", desc: "Maximum brokers displayed." },
+              ].map((row) => (
+                <tr key={row.param}>
+                  <td className="px-5 py-3 font-mono text-xs text-emerald-700">{row.param}</td>
+                  <td className="px-5 py-3 text-xs text-slate-600">{row.values}</td>
+                  <td className="px-5 py-3 text-xs text-slate-400 hidden sm:table-cell">{row.def}</td>
+                  <td className="px-5 py-3 text-xs text-slate-600">{row.desc}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {/* ── Calculator Widget Snippets ── */}
+        <h2 className="text-lg md:text-xl font-extrabold text-slate-900 mb-1">Fee Calculator Widget</h2>
+        <p className="text-sm text-slate-500 mb-5">
+          An interactive trade-cost calculator — visitors can adjust the trade amount and market.
+          Includes the general-advice disclaimer. Powered by live broker fee data.
+        </p>
+        <div className="space-y-6 mb-12">
+          {CALC_SNIPPETS.map((snippet) => (
+            <div key={snippet.title} className="border border-slate-200 rounded-xl overflow-hidden">
+              <div className="px-5 py-3 bg-slate-50 border-b border-slate-200">
+                <h3 className="font-bold text-sm text-slate-900">{snippet.title}</h3>
+                <p className="text-xs text-slate-500 mt-0.5">{snippet.description}</p>
+              </div>
+              <div className="px-5 py-4 bg-slate-900">
+                <code className="text-xs text-emerald-400 font-mono break-all select-all">{snippet.code}</code>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Calculator params reference */}
+        <h3 className="text-base font-extrabold text-slate-900 mb-4">Calculator Widget Parameters</h3>
+        <div className="bg-white border border-slate-200 rounded-xl overflow-hidden mb-12">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="bg-slate-50 border-b border-slate-200 text-left">
+                <th className="px-5 py-3 font-bold text-slate-700">Parameter</th>
+                <th className="px-5 py-3 font-bold text-slate-700">Values</th>
+                <th className="px-5 py-3 font-bold text-slate-700 hidden sm:table-cell">Default</th>
+                <th className="px-5 py-3 font-bold text-slate-700">Description</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100">
+              {[
+                { param: "market", values: "asx | us", def: "asx", desc: "Which market's fees to show by default." },
+                { param: "theme", values: "light | dark", def: "light", desc: "Colour theme." },
+                { param: "limit", values: "1–10", def: "5", desc: "Maximum brokers displayed." },
+                { param: "amount", values: "1–1000000", def: "5000", desc: "Default trade amount pre-filled (AUD). Visitors can change it." },
               ].map((row) => (
                 <tr key={row.param}>
                   <td className="px-5 py-3 font-mono text-xs text-emerald-700">{row.param}</td>

--- a/lib/widget/types.ts
+++ b/lib/widget/types.ts
@@ -9,6 +9,10 @@
  * `?widget=` is OPTIONAL — when omitted, the route falls back to the
  * existing behaviour (top brokers by rating, optionally filtered by
  * `?brokers=`).
+ *
+ * Calculator widgets are served by the separate /api/widget/calculator
+ * route (same Shadow DOM / CORS / ISR approach), configured via
+ * CALCULATOR_WIDGET_CATALOGUE below.
  */
 
 export type WidgetFilter = "all" | "asx" | "us" | "crypto" | "savings" | "term-deposits";
@@ -68,4 +72,55 @@ export function getWidgetCatalogueEntry(slug: string): WidgetCatalogueEntry | un
 
 export function listWidgetSlugs(): string[] {
   return WIDGET_CATALOGUE.map((w) => w.slug);
+}
+
+// ─── Calculator Widget types ──────────────────────────────────────────────────
+
+/**
+ * A calculator widget preset — a suggested configuration for the
+ * /api/widget/calculator embed that publishers can copy as-is.
+ */
+export interface CalcWidgetPreset {
+  slug: string;
+  label: string;
+  description: string;
+  /** Default market shown in the rendered widget. */
+  market: "asx" | "us";
+  /** Default trade amount pre-filled in the widget input. */
+  amount: number;
+  /** Human-readable snippet hint shown in the embed builder. */
+  snippetHint: string;
+}
+
+export const CALCULATOR_WIDGET_CATALOGUE: ReadonlyArray<CalcWidgetPreset> = [
+  {
+    slug: "asx-fees",
+    label: "ASX Brokerage Comparison",
+    description: "Live per-trade cost across every major AU broker — ASX shares.",
+    market: "asx",
+    amount: 5000,
+    snippetHint: "Ideal for articles about ASX investing, stock brokers, or cost comparisons.",
+  },
+  {
+    slug: "us-fees",
+    label: "US Share Cost Comparison",
+    description: "True per-trade cost including FX margin for US shares.",
+    market: "us",
+    amount: 5000,
+    snippetHint: "Ideal for articles about US investing, international shares, or FX costs.",
+  },
+  {
+    slug: "large-trade",
+    label: "Large Trade Cost ($25k)",
+    description: "Shows how percentage-based brokerage stings on larger trades.",
+    market: "asx",
+    amount: 25000,
+    snippetHint: "Ideal for articles about high-value trades, ETFs, or wholesale investing.",
+  },
+];
+
+const CALC_BY_SLUG = new Map(CALCULATOR_WIDGET_CATALOGUE.map((p) => [p.slug, p]));
+
+export function getCalcWidgetPreset(slug: string): CalcWidgetPreset | undefined {
+  return CALC_BY_SLUG.get(slug);
 }


### PR DESCRIPTION
Deepens the existing publisher-embeddable widget product (which covered broker comparison only) to also serve an **embeddable fee/trade-cost calculator** — a distribution + backlink play, factual-calculation only (AFSL-safe, carries the general-advice disclaimer).

- New `GET /api/widget/calculator` — self-contained interactive calculator served into a Shadow DOM, same CORS `*` / ISR / theming pattern as `/api/widget`; reuses the trade-cost calc logic + broker fee data (no new deps, no admin client). Params: `market`, `theme`, `limit`, `amount`.
- `app/embed/EmbedBuilder.tsx` is now a two-tab builder (Broker Comparison / Fee Calculator) with live preview + snippet copy; `/embed` docs updated.
- `lib/widget/types.ts` gains a small calculator-preset catalogue.

**Fix on verification:** the param clamp used `parseInt() || default`, so `?limit=0` / `?amount=0` wrongly fell back to the default instead of clamping to the min — corrected to default only when absent/NaN, else clamp.

**Verified:** `tsc` clean · `widget-calculator` tests **21 passing** · eslint clean · rate-limit `--strict` pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUfSRE2Teb6VhEXFP6RpS9)_