### PR TITLE
feat: public API v1 — advisors + fee-index endpoints (deepen the data API)

### DIFF
--- a/__tests__/api/v1-advisors-slug.test.ts
+++ b/__tests__/api/v1-advisors-slug.test.ts
@@ -1,0 +1,297 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const mockServerFrom = vi.fn();
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({ from: mockServerFrom })),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn() })),
+}));
+
+vi.mock("@/lib/html-escape", () => ({
+  escapeHtml: vi.fn((s: string) => s),
+}));
+
+const mockValidateApiKey = vi.fn();
+const mockLogApiRequest = vi.fn();
+vi.mock("@/lib/api-auth", () => ({
+  validateApiKey: (...args: unknown[]) => mockValidateApiKey(...args),
+  logApiRequest: (...args: unknown[]) => mockLogApiRequest(...args),
+  API_CORS_HEADERS: {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET, OPTIONS",
+    "Access-Control-Allow-Headers": "Authorization, Content-Type",
+  },
+}));
+
+import { GET, OPTIONS } from "@/app/api/v1/advisors/[slug]/route";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+const VALID_KEY = { id: "key-1", name: "Test", key_prefix: "ica_test" };
+const SLUG = "jane-smith-cfp";
+
+function makeValidAuth() {
+  return { valid: true, apiKey: VALID_KEY };
+}
+
+function makeInvalidAuth(msg = "Invalid API key") {
+  return { valid: false, error: msg };
+}
+
+function makeAdvisor(overrides = {}) {
+  return {
+    id: 42,
+    slug: SLUG,
+    name: "Jane Smith",
+    firm_name: "Smith Financial",
+    type: "financial_planner",
+    specialties: ["retirement"],
+    rating: 4.8,
+    review_count: 5,
+    verified: true,
+    status: "active",
+    updated_at: "2026-05-01T08:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeReview() {
+  return {
+    id: 1,
+    rating: 5,
+    headline: "Excellent advice",
+    body: "Jane helped us structure our SMSF.",
+    reviewer_name: "Michael T.",
+    created_at: "2026-04-10T09:00:00Z",
+  };
+}
+
+function makeGet(slug = SLUG): NextRequest {
+  const url = `http://localhost/api/v1/advisors/${slug}`;
+  return new NextRequest(url, { headers: { Authorization: "Bearer ica_testkey123" } });
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("OPTIONS /api/v1/advisors/[slug]", () => {
+  it("returns 204 with CORS headers", async () => {
+    const res = await OPTIONS();
+    expect(res.status).toBe(204);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+  });
+});
+
+describe("GET /api/v1/advisors/[slug] — auth", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 401 when API key missing", async () => {
+    mockValidateApiKey.mockResolvedValue(makeInvalidAuth("No API key"));
+    const res = await GET(makeGet(), { params: Promise.resolve({ slug: SLUG }) });
+    expect(res.status).toBe(401);
+    const data = await res.json();
+    expect(data.error).toBe("No API key");
+  });
+
+  it("returns 401 when API key invalid", async () => {
+    mockValidateApiKey.mockResolvedValue(makeInvalidAuth("Invalid key"));
+    const res = await GET(makeGet(), { params: Promise.resolve({ slug: SLUG }) });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("GET /api/v1/advisors/[slug] — validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockValidateApiKey.mockResolvedValue(makeValidAuth());
+  });
+
+  it("returns 400 for invalid slug format (uppercase)", async () => {
+    const res = await GET(makeGet("Jane-Smith"), {
+      params: Promise.resolve({ slug: "Jane-Smith" }),
+    });
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/invalid.*slug/i);
+  });
+
+  it("returns 400 for invalid slug with special chars", async () => {
+    const res = await GET(makeGet("jane_smith"), {
+      params: Promise.resolve({ slug: "jane_smith" }),
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /api/v1/advisors/[slug] — success", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockValidateApiKey.mockResolvedValue(makeValidAuth());
+  });
+
+  it("returns advisor profile with reviews", async () => {
+    const advisor = makeAdvisor();
+    const reviews = [makeReview()];
+    let callCount = 0;
+    mockServerFrom.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        // professionals table
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          single: vi.fn(() => Promise.resolve({ data: advisor, error: null })),
+        };
+      }
+      // professional_reviews table
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        order: vi.fn().mockReturnThis(),
+        limit: vi.fn(() => Promise.resolve({ data: reviews, error: null })),
+      };
+    });
+
+    const res = await GET(makeGet(), { params: Promise.resolve({ slug: SLUG }) });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.name).toBe("Jane Smith");
+    expect(body.data.reviews).toHaveLength(1);
+    expect(body.data.reviews[0].headline).toBe("Excellent advice");
+  });
+
+  it("strips private/PII fields from advisor response", async () => {
+    const advisor = {
+      ...makeAdvisor(),
+      email: "jane@smith.com",
+      phone: "0412345678",
+      stripe_customer_id: "cus_secret",
+      admin_notes: "hidden",
+      credit_balance_cents: 5000,
+    };
+    let callCount = 0;
+    mockServerFrom.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          single: vi.fn(() => Promise.resolve({ data: advisor, error: null })),
+        };
+      }
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        order: vi.fn().mockReturnThis(),
+        limit: vi.fn(() => Promise.resolve({ data: [], error: null })),
+      };
+    });
+
+    const res = await GET(makeGet(), { params: Promise.resolve({ slug: SLUG }) });
+    const body = await res.json();
+    expect(body.data.email).toBeUndefined();
+    expect(body.data.phone).toBeUndefined();
+    expect(body.data.stripe_customer_id).toBeUndefined();
+    expect(body.data.admin_notes).toBeUndefined();
+    expect(body.data.credit_balance_cents).toBeUndefined();
+  });
+
+  it("returns 404 when advisor not found", async () => {
+    mockServerFrom.mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn(() =>
+        Promise.resolve({ data: null, error: { message: "not found" } }),
+      ),
+    });
+    const res = await GET(makeGet(), { params: Promise.resolve({ slug: SLUG }) });
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toMatch(/not found/i);
+  });
+
+  it("includes Cache-Control header on success", async () => {
+    let callCount = 0;
+    mockServerFrom.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          single: vi.fn(() => Promise.resolve({ data: makeAdvisor(), error: null })),
+        };
+      }
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        order: vi.fn().mockReturnThis(),
+        limit: vi.fn(() => Promise.resolve({ data: [], error: null })),
+      };
+    });
+
+    const res = await GET(makeGet(), { params: Promise.resolve({ slug: SLUG }) });
+    expect(res.headers.get("Cache-Control")).toContain("max-age=3600");
+  });
+
+  it("logs successful request with apiKeyId", async () => {
+    let callCount = 0;
+    mockServerFrom.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          single: vi.fn(() => Promise.resolve({ data: makeAdvisor(), error: null })),
+        };
+      }
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        order: vi.fn().mockReturnThis(),
+        limit: vi.fn(() => Promise.resolve({ data: [], error: null })),
+      };
+    });
+
+    await GET(makeGet(), { params: Promise.resolve({ slug: SLUG }) });
+    expect(mockLogApiRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ statusCode: 200, apiKeyId: "key-1" }),
+    );
+  });
+
+  it("returns 500 on unexpected throw", async () => {
+    mockServerFrom.mockImplementation(() => {
+      throw new Error("boom");
+    });
+    const res = await GET(makeGet(), { params: Promise.resolve({ slug: SLUG }) });
+    expect(res.status).toBe(500);
+  });
+
+  it("returns empty reviews array when none exist", async () => {
+    let callCount = 0;
+    mockServerFrom.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          single: vi.fn(() => Promise.resolve({ data: makeAdvisor(), error: null })),
+        };
+      }
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        order: vi.fn().mockReturnThis(),
+        limit: vi.fn(() => Promise.resolve({ data: null, error: null })),
+      };
+    });
+
+    const res = await GET(makeGet(), { params: Promise.resolve({ slug: SLUG }) });
+    const body = await res.json();
+    expect(body.data.reviews).toEqual([]);
+  });
+});

--- a/__tests__/api/v1-advisors.test.ts
+++ b/__tests__/api/v1-advisors.test.ts
@@ -1,0 +1,317 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const { mockServerFrom } = vi.hoisted(() => ({ mockServerFrom: vi.fn() }));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn().mockResolvedValue({ from: mockServerFrom }),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn() })),
+}));
+
+vi.mock("@/lib/html-escape", () => ({
+  escapeHtml: vi.fn((s: string) => s),
+}));
+
+const mockValidateApiKey = vi.fn();
+const mockLogApiRequest = vi.fn();
+vi.mock("@/lib/api-auth", () => ({
+  validateApiKey: (...args: unknown[]) => mockValidateApiKey(...args),
+  logApiRequest: (...args: unknown[]) => mockLogApiRequest(...args),
+  API_CORS_HEADERS: {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET, OPTIONS",
+    "Access-Control-Allow-Headers": "Authorization, Content-Type",
+  },
+}));
+
+import { GET, OPTIONS } from "@/app/api/v1/advisors/route";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+const VALID_KEY = { id: "key-1", name: "Test", key_prefix: "ica_test" };
+
+function makeValidAuth() {
+  return { valid: true, apiKey: VALID_KEY };
+}
+
+function makeInvalidAuth(msg = "Invalid API key") {
+  return { valid: false, error: msg };
+}
+
+function makeAdvisor(overrides = {}) {
+  return {
+    id: 42,
+    slug: "jane-smith-cfp",
+    name: "Jane Smith",
+    firm_name: "Smith Financial",
+    type: "financial_planner",
+    specialties: ["retirement", "smsf"],
+    location_state: "NSW",
+    location_display: "Sydney, NSW",
+    afsl_number: "123456",
+    rating: 4.8,
+    review_count: 24,
+    verified: true,
+    status: "active",
+    updated_at: "2026-05-01T08:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeAdvisorsBuilder(
+  rows: unknown[] = [],
+  error: unknown = null,
+  count = rows.length,
+) {
+  const builder = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    range: vi.fn(() => Promise.resolve({ data: rows, count, error })),
+  };
+  return builder;
+}
+
+function makeGet(params: Record<string, string> = {}): NextRequest {
+  const sp = new URLSearchParams(params).toString();
+  const url = `http://localhost/api/v1/advisors${sp ? `?${sp}` : ""}`;
+  return new NextRequest(url, {
+    headers: { Authorization: "Bearer ica_testkey123" },
+  });
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("OPTIONS /api/v1/advisors", () => {
+  it("returns 204 with CORS headers", async () => {
+    const res = await OPTIONS();
+    expect(res.status).toBe(204);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+  });
+});
+
+describe("GET /api/v1/advisors — auth", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 401 when API key missing", async () => {
+    mockValidateApiKey.mockResolvedValue(makeInvalidAuth("No API key"));
+    const res = await GET(makeGet());
+    expect(res.status).toBe(401);
+    const data = await res.json();
+    expect(data.error).toBe("No API key");
+  });
+
+  it("returns 401 when API key invalid", async () => {
+    mockValidateApiKey.mockResolvedValue(makeInvalidAuth("Invalid or inactive API key"));
+    const res = await GET(makeGet());
+    expect(res.status).toBe(401);
+  });
+
+  it("logs failed auth requests", async () => {
+    mockValidateApiKey.mockResolvedValue(makeInvalidAuth());
+    await GET(makeGet());
+    expect(mockLogApiRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ statusCode: 401, endpoint: "/api/v1/advisors" }),
+    );
+  });
+});
+
+describe("GET /api/v1/advisors — success", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockValidateApiKey.mockResolvedValue(makeValidAuth());
+  });
+
+  it("returns advisor list with meta", async () => {
+    const advisor = makeAdvisor();
+    mockServerFrom.mockReturnValue(makeAdvisorsBuilder([advisor], null, 1));
+
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].name).toBe("Jane Smith");
+    expect(body.meta.total).toBe(1);
+    expect(body.meta.limit).toBe(20);
+    expect(body.meta.offset).toBe(0);
+  });
+
+  it("strips private/PII fields from advisor rows", async () => {
+    const advisor = {
+      ...makeAdvisor(),
+      email: "jane@smith.com",
+      phone: "0412345678",
+      stripe_customer_id: "cus_secret",
+      admin_notes: "internal only",
+      credit_balance_cents: 10000,
+      total_leads: 55,
+    };
+    mockServerFrom.mockReturnValue(makeAdvisorsBuilder([advisor], null, 1));
+
+    const res = await GET(makeGet());
+    const body = await res.json();
+    expect(body.data[0].email).toBeUndefined();
+    expect(body.data[0].phone).toBeUndefined();
+    expect(body.data[0].stripe_customer_id).toBeUndefined();
+    expect(body.data[0].admin_notes).toBeUndefined();
+    expect(body.data[0].credit_balance_cents).toBeUndefined();
+    expect(body.data[0].total_leads).toBeUndefined();
+  });
+
+  it("exposes allowed public fields", async () => {
+    const advisor = makeAdvisor({
+      afsl_number: "123456",
+      rating: 4.8,
+      verified: true,
+      accepts_new_clients: true,
+    });
+    mockServerFrom.mockReturnValue(makeAdvisorsBuilder([advisor], null, 1));
+
+    const res = await GET(makeGet());
+    const body = await res.json();
+    const row = body.data[0];
+    expect(row.afsl_number).toBe("123456");
+    expect(row.rating).toBe(4.8);
+    expect(row.verified).toBe(true);
+    expect(row.accepts_new_clients).toBe(true);
+  });
+
+  it("respects limit query param (max 100)", async () => {
+    const builder = makeAdvisorsBuilder([], null, 0);
+    mockServerFrom.mockReturnValue(builder);
+
+    await GET(makeGet({ limit: "5" }));
+    expect(builder.range).toHaveBeenCalledWith(0, 4);
+  });
+
+  it("clamps limit to 100 even if 200 requested", async () => {
+    const builder = makeAdvisorsBuilder([], null, 0);
+    mockServerFrom.mockReturnValue(builder);
+
+    await GET(makeGet({ limit: "200" }));
+    expect(builder.range).toHaveBeenCalledWith(0, 99);
+  });
+
+  it("defaults limit to 20 when invalid", async () => {
+    const builder = makeAdvisorsBuilder([], null, 0);
+    mockServerFrom.mockReturnValue(builder);
+
+    await GET(makeGet({ limit: "abc" }));
+    expect(builder.range).toHaveBeenCalledWith(0, 19);
+  });
+
+  it("respects offset query param", async () => {
+    const builder = makeAdvisorsBuilder([], null, 100);
+    mockServerFrom.mockReturnValue(builder);
+
+    await GET(makeGet({ offset: "20" }));
+    expect(builder.range).toHaveBeenCalledWith(20, 39);
+  });
+
+  it("filters by type", async () => {
+    const builder = makeAdvisorsBuilder([], null, 0);
+    mockServerFrom.mockReturnValue(builder);
+
+    await GET(makeGet({ type: "financial_planner" }));
+    expect(builder.eq).toHaveBeenCalledWith("type", "financial_planner");
+  });
+
+  it("filters by location_state", async () => {
+    const builder = makeAdvisorsBuilder([], null, 0);
+    mockServerFrom.mockReturnValue(builder);
+
+    await GET(makeGet({ location_state: "NSW" }));
+    expect(builder.eq).toHaveBeenCalledWith("location_state", "NSW");
+  });
+
+  it("filters verified=true", async () => {
+    const builder = makeAdvisorsBuilder([], null, 0);
+    mockServerFrom.mockReturnValue(builder);
+
+    await GET(makeGet({ verified: "true" }));
+    expect(builder.eq).toHaveBeenCalledWith("verified", true);
+  });
+
+  it("filters verified=false", async () => {
+    const builder = makeAdvisorsBuilder([], null, 0);
+    mockServerFrom.mockReturnValue(builder);
+
+    await GET(makeGet({ verified: "false" }));
+    expect(builder.eq).toHaveBeenCalledWith("verified", false);
+  });
+
+  it("filters accepts_new_clients=true", async () => {
+    const builder = makeAdvisorsBuilder([], null, 0);
+    mockServerFrom.mockReturnValue(builder);
+
+    await GET(makeGet({ accepts_new_clients: "true" }));
+    expect(builder.eq).toHaveBeenCalledWith("accepts_new_clients", true);
+  });
+
+  it("filters accepts_new_clients=false", async () => {
+    const builder = makeAdvisorsBuilder([], null, 0);
+    mockServerFrom.mockReturnValue(builder);
+
+    await GET(makeGet({ accepts_new_clients: "false" }));
+    expect(builder.eq).toHaveBeenCalledWith("accepts_new_clients", false);
+  });
+
+  it("returns 500 on DB error", async () => {
+    const builder = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      range: vi.fn(() =>
+        Promise.resolve({ data: null, count: null, error: { message: "DB error" } }),
+      ),
+    };
+    mockServerFrom.mockReturnValue(builder);
+
+    const res = await GET(makeGet());
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data.error).toMatch(/advisor/i);
+  });
+
+  it("returns 500 on unexpected throw", async () => {
+    mockServerFrom.mockImplementation(() => {
+      throw new Error("boom");
+    });
+
+    const res = await GET(makeGet());
+    expect(res.status).toBe(500);
+  });
+
+  it("logs successful requests with apiKeyId", async () => {
+    mockServerFrom.mockReturnValue(makeAdvisorsBuilder([makeAdvisor()], null, 1));
+
+    await GET(makeGet());
+    expect(mockLogApiRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ statusCode: 200, apiKeyId: "key-1" }),
+    );
+  });
+
+  it("includes Cache-Control header on success", async () => {
+    mockServerFrom.mockReturnValue(makeAdvisorsBuilder([], null, 0));
+
+    const res = await GET(makeGet());
+    expect(res.headers.get("Cache-Control")).toContain("max-age=3600");
+  });
+
+  it("computes meta.updated_at from most recent advisor", async () => {
+    const advisors = [
+      makeAdvisor({ updated_at: "2026-01-01T00:00:00Z" }),
+      makeAdvisor({ name: "Bob Jones", updated_at: "2026-04-01T00:00:00Z" }),
+    ];
+    mockServerFrom.mockReturnValue(makeAdvisorsBuilder(advisors, null, 2));
+
+    const res = await GET(makeGet());
+    const body = await res.json();
+    expect(body.meta.updated_at).toBe("2026-04-01T00:00:00Z");
+  });
+});

--- a/__tests__/api/v1-fee-index.test.ts
+++ b/__tests__/api/v1-fee-index.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const mockReadFeeIndex = vi.fn();
+const mockComputeTrend = vi.fn();
+
+vi.mock("@/lib/fee-index", () => ({
+  readFeeIndex: (...args: unknown[]) => mockReadFeeIndex(...args),
+  computeTrend: (...args: unknown[]) => mockComputeTrend(...args),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn() })),
+}));
+
+const mockValidateApiKey = vi.fn();
+const mockLogApiRequest = vi.fn();
+vi.mock("@/lib/api-auth", () => ({
+  validateApiKey: (...args: unknown[]) => mockValidateApiKey(...args),
+  logApiRequest: (...args: unknown[]) => mockLogApiRequest(...args),
+  API_CORS_HEADERS: {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET, OPTIONS",
+    "Access-Control-Allow-Headers": "Authorization, Content-Type",
+  },
+}));
+
+import { GET, OPTIONS } from "@/app/api/v1/fee-index/route";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+const VALID_KEY = { id: "key-3", name: "Test", key_prefix: "ica_test" };
+
+function makeValidAuth() {
+  return { valid: true, apiKey: VALID_KEY };
+}
+
+function makeInvalidAuth(msg = "Invalid API key") {
+  return { valid: false, error: msg };
+}
+
+function makeSnapshot(period = "2026-05-24", overrides = {}) {
+  return {
+    period,
+    computed_at: `${period}T02:15:00Z`,
+    broker_count: 22,
+    asx_fee_sample: 20,
+    us_fee_sample: 18,
+    fx_spread_sample: 19,
+    avg_asx_fee: 8.5,
+    avg_us_fee: 1.2,
+    avg_fx_spread: 0.55,
+    median_asx_fee: 9.5,
+    median_us_fee: 0.0,
+    median_fx_spread: 0.6,
+    source: "cron",
+    ...overrides,
+  };
+}
+
+function makeTrend() {
+  return {
+    quarter: {
+      avgAsxFee: { previous: 9.0, change: -0.5, changePct: -5.56 },
+      avgUsFee: { previous: 1.3, change: -0.1, changePct: -7.69 },
+      avgFxSpread: { previous: 0.57, change: -0.02, changePct: -3.51 },
+    },
+    year: null,
+  };
+}
+
+function makeGet(params: Record<string, string> = {}): NextRequest {
+  const sp = new URLSearchParams(params).toString();
+  const url = `http://localhost/api/v1/fee-index${sp ? `?${sp}` : ""}`;
+  return new NextRequest(url, {
+    headers: { Authorization: "Bearer ica_testkey123" },
+  });
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("OPTIONS /api/v1/fee-index", () => {
+  it("returns 204 with CORS headers", async () => {
+    const res = await OPTIONS();
+    expect(res.status).toBe(204);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+  });
+});
+
+describe("GET /api/v1/fee-index — auth", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 401 when API key missing", async () => {
+    mockValidateApiKey.mockResolvedValue(makeInvalidAuth("No API key"));
+    const res = await GET(makeGet());
+    expect(res.status).toBe(401);
+    const data = await res.json();
+    expect(data.error).toBe("No API key");
+  });
+
+  it("returns 401 when API key invalid", async () => {
+    mockValidateApiKey.mockResolvedValue(makeInvalidAuth("Invalid or inactive API key"));
+    const res = await GET(makeGet());
+    expect(res.status).toBe(401);
+  });
+
+  it("logs failed auth requests", async () => {
+    mockValidateApiKey.mockResolvedValue(makeInvalidAuth());
+    await GET(makeGet());
+    expect(mockLogApiRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ statusCode: 401, endpoint: "/api/v1/fee-index" }),
+    );
+  });
+});
+
+describe("GET /api/v1/fee-index — success", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockValidateApiKey.mockResolvedValue(makeValidAuth());
+  });
+
+  it("returns latest snapshot, trend, and history", async () => {
+    const latest = makeSnapshot();
+    const history = [latest, makeSnapshot("2026-05-23")];
+    mockReadFeeIndex.mockResolvedValue({ latest, history });
+    mockComputeTrend.mockReturnValue(makeTrend());
+
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.latest).toMatchObject({ period: "2026-05-24", avg_asx_fee: 8.5 });
+    expect(body.data.trend).not.toBeNull();
+    expect(body.data.trend.quarter).not.toBeNull();
+    expect(body.data.history.length).toBeGreaterThan(0);
+  });
+
+  it("returns null trend when latest is null", async () => {
+    mockReadFeeIndex.mockResolvedValue({ latest: null, history: [] });
+
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.latest).toBeNull();
+    expect(body.data.trend).toBeNull();
+    expect(body.data.history).toEqual([]);
+  });
+
+  it("respects history param", async () => {
+    const history = Array.from({ length: 10 }, (_, i) =>
+      makeSnapshot(`2026-05-${String(24 - i).padStart(2, "0")}`),
+    );
+    const latest = history[0]!;
+    mockReadFeeIndex.mockResolvedValue({ latest, history });
+    mockComputeTrend.mockReturnValue(null);
+
+    const res = await GET(makeGet({ history: "5" }));
+    const body = await res.json();
+    expect(body.data.history).toHaveLength(5);
+    expect(body.meta.history_days).toBe(5);
+  });
+
+  it("returns empty history when history=0", async () => {
+    const latest = makeSnapshot();
+    const history = [latest, makeSnapshot("2026-05-23")];
+    mockReadFeeIndex.mockResolvedValue({ latest, history });
+    mockComputeTrend.mockReturnValue(makeTrend());
+
+    const res = await GET(makeGet({ history: "0" }));
+    const body = await res.json();
+    expect(body.data.history).toEqual([]);
+    expect(body.meta.history_days).toBe(0);
+  });
+
+  it("clamps history to 400", async () => {
+    const latest = makeSnapshot();
+    mockReadFeeIndex.mockResolvedValue({ latest, history: [latest] });
+    mockComputeTrend.mockReturnValue(null);
+
+    // Should not throw even with a huge history param
+    const res = await GET(makeGet({ history: "999" }));
+    expect(res.status).toBe(200);
+    // Verify readFeeIndex was called (clamped to max 400 internally)
+    expect(mockReadFeeIndex).toHaveBeenCalledWith(400);
+  });
+
+  it("includes meta.updated_at from latest.computed_at", async () => {
+    const latest = makeSnapshot();
+    mockReadFeeIndex.mockResolvedValue({ latest, history: [latest] });
+    mockComputeTrend.mockReturnValue(null);
+
+    const res = await GET(makeGet());
+    const body = await res.json();
+    expect(body.meta.updated_at).toBe("2026-05-24T02:15:00Z");
+  });
+
+  it("sets meta.updated_at to null when no latest snapshot", async () => {
+    mockReadFeeIndex.mockResolvedValue({ latest: null, history: [] });
+
+    const res = await GET(makeGet());
+    const body = await res.json();
+    expect(body.meta.updated_at).toBeNull();
+  });
+
+  it("includes Cache-Control header on success", async () => {
+    mockReadFeeIndex.mockResolvedValue({ latest: null, history: [] });
+
+    const res = await GET(makeGet());
+    expect(res.headers.get("Cache-Control")).toContain("max-age=3600");
+  });
+
+  it("logs successful request with apiKeyId", async () => {
+    mockReadFeeIndex.mockResolvedValue({ latest: null, history: [] });
+
+    await GET(makeGet());
+    expect(mockLogApiRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ statusCode: 200, apiKeyId: "key-3" }),
+    );
+  });
+
+  it("returns 500 on unexpected throw", async () => {
+    mockReadFeeIndex.mockImplementation(() => {
+      throw new Error("DB exploded");
+    });
+
+    const res = await GET(makeGet());
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toMatch(/internal server error/i);
+  });
+
+  it("defaults history to 90 when not provided", async () => {
+    mockReadFeeIndex.mockResolvedValue({ latest: null, history: [] });
+
+    await GET(makeGet());
+    // The route calls readFeeIndex(Math.max(90, 400)) = readFeeIndex(400) to
+    // ensure enough history for trend calc, then trims to the requested 90.
+    expect(mockReadFeeIndex).toHaveBeenCalledWith(400);
+  });
+});

--- a/app/api-docs/page.tsx
+++ b/app/api-docs/page.tsx
@@ -6,12 +6,12 @@ export const revalidate = 86400;
 export const metadata = {
   title: "API Documentation | Invest.com.au",
   description:
-    "API documentation for financial planners and developers. Access Australian broker fee data, comparisons, and fee change history via a RESTful JSON API.",
+    "API documentation for financial planners and developers. Access Australian broker and advisor data, fee comparisons, and the AU brokerage fee index via a RESTful JSON API.",
   alternates: { canonical: "/api-docs" },
   openGraph: {
     title: "API Documentation | Invest.com.au",
     description:
-      "Access Australian broker data via our REST API. Built for financial planners, advisors, and fintech developers.",
+      "Access Australian broker and advisor data via our REST API. Built for financial planners, advisors, and fintech developers.",
   },
 };
 
@@ -99,12 +99,13 @@ export default function ApiDocsPage() {
 
           {/* Header */}
           <h1 className="text-2xl md:text-4xl font-extrabold mb-3">
-            Broker Data API
+            Financial Data API
           </h1>
           <p className="text-lg text-slate-600 mb-8 leading-relaxed max-w-2xl">
-            Access verified Australian broker fee data, comparisons, and fee
-            change history via a RESTful JSON API. Built for financial planners,
-            advisors, and fintech developers.
+            Access verified Australian broker fee data, advisor directory
+            information, the AU brokerage fee index, and fee change history via
+            a RESTful JSON API. Built for financial planners, advisors, and
+            fintech developers.
           </p>
 
           {/* Getting Started */}
@@ -344,6 +345,106 @@ export default function ApiDocsPage() {
                 </div>
               </EndpointCard>
 
+              {/* List Advisors */}
+              <EndpointCard
+                method="GET"
+                path="/api/v1/advisors"
+                auth={true}
+                description="List active financial advisors and professionals. Returns public profile fields only — no PII, no billing data. Supports filtering and pagination."
+              >
+                <div>
+                  <h4 className="text-xs font-semibold uppercase text-slate-400 mb-2">
+                    Query Parameters
+                  </h4>
+                  <div className="text-sm space-y-1 text-slate-600">
+                    <p>
+                      <code className="text-xs bg-slate-100 px-1 py-0.5 rounded">
+                        type
+                      </code>{" "}
+                      &mdash; financial_planner, smsf_accountant,
+                      property_advisor, tax_agent, mortgage_broker,
+                      wealth_manager, etc.
+                    </p>
+                    <p>
+                      <code className="text-xs bg-slate-100 px-1 py-0.5 rounded">
+                        location_state
+                      </code>{" "}
+                      &mdash; NSW, VIC, QLD, WA, SA, TAS, ACT, NT
+                    </p>
+                    <p>
+                      <code className="text-xs bg-slate-100 px-1 py-0.5 rounded">
+                        verified
+                      </code>{" "}
+                      &mdash; true / false
+                    </p>
+                    <p>
+                      <code className="text-xs bg-slate-100 px-1 py-0.5 rounded">
+                        accepts_new_clients
+                      </code>{" "}
+                      &mdash; true / false
+                    </p>
+                    <p>
+                      <code className="text-xs bg-slate-100 px-1 py-0.5 rounded">
+                        limit
+                      </code>{" "}
+                      &mdash; Results per page (default 20, max 100)
+                    </p>
+                    <p>
+                      <code className="text-xs bg-slate-100 px-1 py-0.5 rounded">
+                        offset
+                      </code>{" "}
+                      &mdash; Pagination offset (default 0)
+                    </p>
+                  </div>
+                </div>
+              </EndpointCard>
+
+              {/* Single Advisor */}
+              <EndpointCard
+                method="GET"
+                path="/api/v1/advisors/:slug"
+                auth={true}
+                description="Get a single advisor's full public profile by slug. Includes qualifications, education, FAQs, services metadata, and the last 10 approved reviews."
+              >
+                <div>
+                  <h4 className="text-xs font-semibold uppercase text-slate-400 mb-2">
+                    Path Parameters
+                  </h4>
+                  <p className="text-sm text-slate-600">
+                    <code className="text-xs bg-slate-100 px-1 py-0.5 rounded">
+                      slug
+                    </code>{" "}
+                    &mdash; The advisor&apos;s URL slug (e.g.
+                    &quot;jane-smith-cfp&quot;)
+                  </p>
+                </div>
+              </EndpointCard>
+
+              {/* Fee Index */}
+              <EndpointCard
+                method="GET"
+                path="/api/v1/fee-index"
+                auth={true}
+                description="AU brokerage fee index: market-wide average and median ASX per-trade fee, US share fee, and FX spread across all tracked active brokers. Updated daily. Includes QoQ and YoY trend deltas. Factual aggregate data — not financial advice."
+              >
+                <div>
+                  <h4 className="text-xs font-semibold uppercase text-slate-400 mb-2">
+                    Query Parameters
+                  </h4>
+                  <p className="text-sm text-slate-600">
+                    <code className="text-xs bg-slate-100 px-1 py-0.5 rounded">
+                      history
+                    </code>{" "}
+                    &mdash; Number of prior daily snapshots to include (default
+                    90, max 400). Pass{" "}
+                    <code className="text-xs bg-slate-100 px-1 py-0.5 rounded">
+                      0
+                    </code>{" "}
+                    for latest snapshot only.
+                  </p>
+                </div>
+              </EndpointCard>
+
               {/* Request API Key */}
               <EndpointCard
                 method="POST"
@@ -418,7 +519,19 @@ curl -H "Authorization: Bearer ica_your_key_here" \\
 
 # Compare brokers
 curl -H "Authorization: Bearer ica_your_key_here" \\
-  "https://invest.com.au/api/v1/compare?slugs=stake,selfwealth,commsec"`}
+  "https://invest.com.au/api/v1/compare?slugs=stake,selfwealth,commsec"
+
+# List verified financial planners in NSW
+curl -H "Authorization: Bearer ica_your_key_here" \\
+  "https://invest.com.au/api/v1/advisors?type=financial_planner&location_state=NSW&verified=true"
+
+# Get a single advisor profile (includes reviews, FAQs)
+curl -H "Authorization: Bearer ica_your_key_here" \\
+  "https://invest.com.au/api/v1/advisors/jane-smith-cfp"
+
+# Get the current AU brokerage fee index with 30-day history
+curl -H "Authorization: Bearer ica_your_key_here" \\
+  "https://invest.com.au/api/v1/fee-index?history=30"`}
                 </CodeBlock>
               </div>
 
@@ -440,11 +553,22 @@ async function getBrokers() {
   return data;
 }
 
-async function compareBrokers(slugs) {
-  const res = await fetch(\`\${BASE}/compare?slugs=\${slugs.join(",")}\`, {
+async function getAdvisors(type, state) {
+  const res = await fetch(
+    \`\${BASE}/advisors?type=\${type}&location_state=\${state}&verified=true\`,
+    { headers: { Authorization: \`Bearer \${API_KEY}\` } }
+  );
+  return (await res.json()).data;
+}
+
+async function getFeeIndex() {
+  const res = await fetch(\`\${BASE}/fee-index?history=90\`, {
     headers: { Authorization: \`Bearer \${API_KEY}\` },
   });
-  return (await res.json()).data;
+  const { data } = await res.json();
+  const { latest, trend } = data;
+  console.log(\`Avg ASX fee: $\${latest.avg_asx_fee}\`); // console-allow: code-example
+  return { latest, trend };
 }`}
                 </CodeBlock>
               </div>
@@ -471,10 +595,22 @@ data = response.json()
 for broker in data["data"]:
     print(f"{broker['name']}: ASX fee {broker['asx_fee']}")
 
-# Get a single broker with fee history
-broker = requests.get(f"{BASE}/brokers/commsec", headers=HEADERS).json()
-for change in broker["data"]["fee_changelog"]:
-    print(f"{change['field_name']}: {change['old_value']} -> {change['new_value']}")`}
+# List SMSF accountants in Victoria
+advisors = requests.get(
+    f"{BASE}/advisors",
+    headers=HEADERS,
+    params={"type": "smsf_accountant", "location_state": "VIC", "verified": "true"}
+).json()
+for adv in advisors["data"]:
+    print(f"{adv['name']} — {adv['firm_name']} — rating {adv['rating']}")
+
+# Get the latest AU brokerage fee index
+fee = requests.get(f"{BASE}/fee-index", headers=HEADERS).json()
+latest = fee["data"]["latest"]
+print(f"Market avg ASX fee: ${latest['avg_asx_fee']}")
+trend = fee["data"]["trend"]
+if trend and trend["quarter"]:
+    print(f"QoQ change: {trend['quarter']['avgAsxFee']['changePct']}%")`}
                 </CodeBlock>
               </div>
             </div>
@@ -553,11 +689,17 @@ for change in broker["data"]["fee_changelog"]:
               Available Data Fields
             </h2>
             <p className="text-sm text-slate-600 mb-3">
-              The API exposes only public, non-sensitive broker data. Sensitive
+              The API exposes only public, non-sensitive data. Sensitive
               commercial fields (affiliate URLs, commission rates, CPA values,
-              sponsorship details) are never included in API responses.
+              sponsorship details, advisor billing data, PII) are never included
+              in API responses.
             </p>
-            <div className="overflow-x-auto">
+
+            {/* Broker fields */}
+            <h3 className="text-sm font-semibold text-slate-800 mt-6 mb-2">
+              Broker fields ({"/api/v1/brokers"})
+            </h3>
+            <div className="overflow-x-auto mb-6">
               <table className="w-full text-sm border border-slate-200 rounded-xl overflow-hidden">
                 <thead>
                   <tr className="bg-slate-50">
@@ -593,6 +735,115 @@ for change in broker["data"]["fee_changelog"]:
                     ["year_founded", "number", "Year the broker was founded"],
                     ["fee_verified_date", "string", "When fees were last verified"],
                     ["fee_changelog", "array", "Last 10 fee changes (single broker only)"],
+                  ].map(([field, type, desc]) => (
+                    <tr key={field} className="border-b border-slate-100">
+                      <td className="px-4 py-2">
+                        <code className="text-xs bg-slate-100 px-1 py-0.5 rounded">
+                          {field}
+                        </code>
+                      </td>
+                      <td className="px-4 py-2 text-xs">{type}</td>
+                      <td className="px-4 py-2">{desc}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            {/* Advisor fields */}
+            <h3 className="text-sm font-semibold text-slate-800 mt-6 mb-2">
+              Advisor fields ({"/api/v1/advisors"})
+            </h3>
+            <div className="overflow-x-auto mb-6">
+              <table className="w-full text-sm border border-slate-200 rounded-xl overflow-hidden">
+                <thead>
+                  <tr className="bg-slate-50">
+                    <th className="text-left px-4 py-2 font-semibold text-slate-700 border-b border-slate-200">
+                      Field
+                    </th>
+                    <th className="text-left px-4 py-2 font-semibold text-slate-700 border-b border-slate-200">
+                      Type
+                    </th>
+                    <th className="text-left px-4 py-2 font-semibold text-slate-700 border-b border-slate-200">
+                      Description
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="text-slate-600">
+                  {[
+                    ["slug", "string", "URL-safe identifier"],
+                    ["name", "string", "Advisor display name"],
+                    ["firm_name", "string", "Firm or practice name"],
+                    ["type", "string", "Professional type (financial_planner, smsf_accountant, etc.)"],
+                    ["specialties", "array", "List of specialty areas"],
+                    ["location_state", "string", "Australian state code"],
+                    ["location_display", "string", "Human-readable location"],
+                    ["afsl_number", "string", "AFSL licence number (if applicable)"],
+                    ["bio", "string", "Public professional biography"],
+                    ["website", "string", "Public website URL"],
+                    ["fee_description", "string", "Fee structure description"],
+                    ["hourly_rate_cents", "number", "Hourly rate in cents (AUD)"],
+                    ["flat_fee_cents", "number", "Flat engagement fee in cents (AUD)"],
+                    ["aum_percentage", "number", "AUM-based fee percentage"],
+                    ["initial_consultation_free", "boolean", "Whether first meeting is free"],
+                    ["rating", "number", "Aggregate review rating (0-5)"],
+                    ["review_count", "number", "Number of approved reviews"],
+                    ["verified", "boolean", "Whether AFSL / credentials are verified"],
+                    ["accepts_new_clients", "boolean", "Currently accepting new clients"],
+                    ["availability_status", "string", "open | waitlist | closed"],
+                    ["languages", "array", "Languages spoken (single-advisor endpoint)"],
+                    ["qualifications", "array", "Professional qualifications (single-advisor endpoint)"],
+                    ["education", "array", "Education history (single-advisor endpoint)"],
+                    ["faqs", "array", "Public FAQ items (single-advisor endpoint)"],
+                    ["reviews", "array", "Last 10 approved reviews (single-advisor endpoint)"],
+                  ].map(([field, type, desc]) => (
+                    <tr key={field} className="border-b border-slate-100">
+                      <td className="px-4 py-2">
+                        <code className="text-xs bg-slate-100 px-1 py-0.5 rounded">
+                          {field}
+                        </code>
+                      </td>
+                      <td className="px-4 py-2 text-xs">{type}</td>
+                      <td className="px-4 py-2">{desc}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            {/* Fee index fields */}
+            <h3 className="text-sm font-semibold text-slate-800 mt-6 mb-2">
+              Fee Index fields ({"/api/v1/fee-index"})
+            </h3>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm border border-slate-200 rounded-xl overflow-hidden">
+                <thead>
+                  <tr className="bg-slate-50">
+                    <th className="text-left px-4 py-2 font-semibold text-slate-700 border-b border-slate-200">
+                      Field
+                    </th>
+                    <th className="text-left px-4 py-2 font-semibold text-slate-700 border-b border-slate-200">
+                      Type
+                    </th>
+                    <th className="text-left px-4 py-2 font-semibold text-slate-700 border-b border-slate-200">
+                      Description
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="text-slate-600">
+                  {[
+                    ["period", "string", "UTC calendar day this snapshot covers (YYYY-MM-DD)"],
+                    ["computed_at", "string", "When this snapshot was computed"],
+                    ["broker_count", "number", "Distinct active brokers that contributed data"],
+                    ["avg_asx_fee", "number", "Mean ASX per-trade fee across tracked brokers (AUD)"],
+                    ["median_asx_fee", "number", "Median ASX per-trade fee"],
+                    ["avg_us_fee", "number", "Mean US share per-trade fee (AUD)"],
+                    ["median_us_fee", "number", "Median US share per-trade fee"],
+                    ["avg_fx_spread", "number", "Mean FX spread markup (%)"],
+                    ["median_fx_spread", "number", "Median FX spread markup (%)"],
+                    ["trend.quarter", "object", "QoQ deltas vs ~90 days prior (change, changePct per metric)"],
+                    ["trend.year", "object", "YoY deltas vs ~365 days prior (null if < 1 year of history)"],
+                    ["history", "array", "Prior daily snapshots, DESC by period"],
                   ].map(([field, type, desc]) => (
                     <tr key={field} className="border-b border-slate-100">
                       <td className="px-4 py-2">

--- a/app/api-docs/page.tsx
+++ b/app/api-docs/page.tsx
@@ -607,7 +607,7 @@ for adv in advisors["data"]:
 # Get the latest AU brokerage fee index
 fee = requests.get(f"{BASE}/fee-index", headers=HEADERS).json()
 latest = fee["data"]["latest"]
-print(f"Market avg ASX fee: ${latest['avg_asx_fee']}")
+print(f"Market avg ASX fee: \${latest['avg_asx_fee']}")
 trend = fee["data"]["trend"]
 if trend and trend["quarter"]:
     print(f"QoQ change: {trend['quarter']['avgAsxFee']['changePct']}%")`}

--- a/app/api/v1/advisors/[slug]/route.ts
+++ b/app/api/v1/advisors/[slug]/route.ts
@@ -1,0 +1,253 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { logger } from "@/lib/logger";
+import { validateApiKey, logApiRequest, API_CORS_HEADERS } from "@/lib/api-auth";
+import { escapeHtml } from "@/lib/html-escape";
+
+export const runtime = "nodejs";
+// Per-key auth gating — see /api/v1/brokers/route.ts for the same reasoning.
+export const dynamic = "force-dynamic";
+
+const log = logger("api-v1-advisor-slug");
+
+/**
+ * Public fields for a single advisor profile.
+ * Superset of the list route fields — adds FAQs, education, testimonials,
+ * intro video, and the ideal-client description that the profile page renders.
+ * Still excludes PII (email, phone) and all billing/admin/internal fields.
+ */
+const PUBLIC_FIELDS = [
+  "id",
+  "slug",
+  "name",
+  "firm_name",
+  "type",
+  "specialties",
+  "location_state",
+  "location_suburb",
+  "location_display",
+  "location_postcode",
+  "afsl_number",
+  "acn",
+  "abn",
+  "bio",
+  "photo_url",
+  "website",
+  "linkedin_url",
+  "fee_structure",
+  "fee_description",
+  "hourly_rate_cents",
+  "flat_fee_cents",
+  "aum_percentage",
+  "initial_consultation_free",
+  "min_investment_cents",
+  "min_client_balance_cents",
+  "rating",
+  "review_count",
+  "verified",
+  "status",
+  "languages",
+  "service_areas",
+  "meeting_types",
+  "qualifications",
+  "years_experience",
+  "memberships",
+  "education",
+  "faqs",
+  "ideal_client",
+  "accepting_new_clients",
+  "accepts_new_clients",
+  "availability_status",
+  "accepts_international_clients",
+  "international_tax_specialist",
+  "firb_specialist",
+  "migration_agent",
+  "intro_video_url",
+  "intro_video_poster_url",
+  "offer_text",
+  "offer_active",
+  // Stockbroker firm fields
+  "firm_type",
+  "minimum_investment_cents",
+  "fee_model",
+  "service_tiers",
+  "research_offering",
+  "year_founded",
+  "office_states",
+  "aum_aud_billions",
+  "updated_at",
+  "created_at",
+] as const;
+
+/**
+ * Sanitize an advisor row: keep only public fields, escape string values.
+ */
+function sanitizeAdvisor(row: Record<string, unknown>): Record<string, unknown> {
+  const clean: Record<string, unknown> = {};
+  for (const field of PUBLIC_FIELDS) {
+    if (field in row) {
+      const val = row[field];
+      clean[field] = typeof val === "string" ? escapeHtml(val) : val;
+    }
+  }
+  return clean;
+}
+
+/**
+ * OPTIONS /api/v1/advisors/[slug] — CORS preflight
+ */
+export function OPTIONS() {
+  return new NextResponse(null, {
+    status: 204,
+    headers: API_CORS_HEADERS,
+  });
+}
+
+/**
+ * GET /api/v1/advisors/[slug]
+ *
+ * Returns a single advisor's full public profile by slug.
+ * Includes recent professional reviews (last 10, approved only).
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  const start = Date.now();
+  const { slug } = await params;
+
+  // ── Auth ──
+  const auth = await validateApiKey(request);
+  if (!auth.valid) {
+    const elapsed = Date.now() - start;
+    logApiRequest({
+      apiKeyId: null,
+      endpoint: `/api/v1/advisors/${slug}`,
+      method: "GET",
+      statusCode: 401,
+      responseTimeMs: elapsed,
+      ipAddress:
+        request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+        "unknown",
+      userAgent: request.headers.get("user-agent") || "unknown",
+    });
+    return NextResponse.json(
+      { error: auth.error },
+      { status: 401, headers: API_CORS_HEADERS },
+    );
+  }
+
+  // Validate slug format
+  if (!slug || !/^[a-z0-9-]+$/.test(slug)) {
+    return NextResponse.json(
+      { error: "Invalid advisor slug" },
+      { status: 400, headers: API_CORS_HEADERS },
+    );
+  }
+
+  try {
+    // professionals + professional_reviews are both covered by anon RLS
+    // policies for active/approved rows — the server client (not admin) suffices.
+    const supabase = await createClient();
+
+    // Fetch advisor
+    const { data: advisor, error: advisorError } = await supabase
+      .from("professionals")
+      .select(PUBLIC_FIELDS.join(","))
+      .eq("slug", slug)
+      .eq("status", "active")
+      .single();
+
+    if (advisorError || !advisor) {
+      const elapsed = Date.now() - start;
+      logApiRequest({
+        apiKeyId: auth.apiKey?.id || null,
+        endpoint: `/api/v1/advisors/${slug}`,
+        method: "GET",
+        statusCode: 404,
+        responseTimeMs: elapsed,
+        ipAddress:
+          request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+          "unknown",
+        userAgent: request.headers.get("user-agent") || "unknown",
+      });
+      return NextResponse.json(
+        { error: "Advisor not found" },
+        { status: 404, headers: API_CORS_HEADERS },
+      );
+    }
+
+    // Fetch recent approved reviews (public — shown on the profile page)
+    const { data: reviews } = await supabase
+      .from("professional_reviews")
+      .select(
+        "id, rating, headline, body, reviewer_name, created_at",
+      )
+      .eq("professional_id", (advisor as Record<string, unknown>).id)
+      .eq("status", "approved")
+      .order("created_at", { ascending: false })
+      .limit(10);
+
+    // Sanitize
+    const sanitized = sanitizeAdvisor(advisor as unknown as Record<string, unknown>);
+
+    // Sanitize reviews — only safe public fields, escape strings
+    const sanitizedReviews = (reviews || []).map((r) => ({
+      id: r.id,
+      rating: r.rating,
+      headline: typeof r.headline === "string" ? escapeHtml(r.headline) : r.headline,
+      body: typeof r.body === "string" ? escapeHtml(r.body) : r.body,
+      reviewer_name: typeof r.reviewer_name === "string" ? escapeHtml(r.reviewer_name) : r.reviewer_name,
+      created_at: r.created_at,
+    }));
+
+    const elapsed = Date.now() - start;
+
+    logApiRequest({
+      apiKeyId: auth.apiKey?.id || null,
+      endpoint: `/api/v1/advisors/${slug}`,
+      method: "GET",
+      statusCode: 200,
+      responseTimeMs: elapsed,
+      ipAddress:
+        request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+        "unknown",
+      userAgent: request.headers.get("user-agent") || "unknown",
+    });
+
+    return NextResponse.json(
+      {
+        data: {
+          ...sanitized,
+          reviews: sanitizedReviews,
+        },
+      },
+      {
+        status: 200,
+        headers: {
+          ...API_CORS_HEADERS,
+          "Cache-Control": "private, max-age=3600",
+        },
+      },
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "Unknown error";
+    log.error("Unexpected error in GET /api/v1/advisors/[slug]", { error: msg });
+    const elapsed = Date.now() - start;
+    logApiRequest({
+      apiKeyId: auth.apiKey?.id || null,
+      endpoint: `/api/v1/advisors/${slug}`,
+      method: "GET",
+      statusCode: 500,
+      responseTimeMs: elapsed,
+      ipAddress:
+        request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+        "unknown",
+      userAgent: request.headers.get("user-agent") || "unknown",
+    });
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500, headers: API_CORS_HEADERS },
+    );
+  }
+}

--- a/app/api/v1/advisors/[slug]/route.ts
+++ b/app/api/v1/advisors/[slug]/route.ts
@@ -183,7 +183,7 @@ export async function GET(
       .select(
         "id, rating, headline, body, reviewer_name, created_at",
       )
-      .eq("professional_id", (advisor as Record<string, unknown>).id)
+      .eq("professional_id", (advisor as unknown as Record<string, unknown>).id)
       .eq("status", "approved")
       .order("created_at", { ascending: false })
       .limit(10);

--- a/app/api/v1/advisors/route.ts
+++ b/app/api/v1/advisors/route.ts
@@ -1,0 +1,268 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { logger } from "@/lib/logger";
+import { validateApiKey, logApiRequest, API_CORS_HEADERS } from "@/lib/api-auth";
+import { escapeHtml } from "@/lib/html-escape";
+
+export const runtime = "nodejs";
+// Per-key auth gating — see /api/v1/brokers/route.ts for the same reasoning.
+export const dynamic = "force-dynamic";
+
+const log = logger("api-v1-advisors");
+
+/**
+ * Fields safe to expose via the public API.
+ * Matches what /advisor/[slug] already renders publicly.
+ * Excludes PII (email, phone), billing/payment (stripe_customer_id,
+ * credit_balance_cents, etc.), admin fields (admin_notes, admin_tags,
+ * health_status), and lead/billing counters (total_leads, etc.).
+ */
+const PUBLIC_FIELDS = [
+  "id",
+  "slug",
+  "name",
+  "firm_name",
+  "type",
+  "specialties",
+  "location_state",
+  "location_suburb",
+  "location_display",
+  "afsl_number",
+  "bio",
+  "photo_url",
+  "website",
+  "fee_structure",
+  "fee_description",
+  "hourly_rate_cents",
+  "flat_fee_cents",
+  "aum_percentage",
+  "initial_consultation_free",
+  "min_investment_cents",
+  "rating",
+  "review_count",
+  "verified",
+  "status",
+  "languages",
+  "service_areas",
+  "meeting_types",
+  "qualifications",
+  "years_experience",
+  "memberships",
+  "accepting_new_clients",
+  "accepts_new_clients",
+  "availability_status",
+  "ideal_client",
+  "accepts_international_clients",
+  "international_tax_specialist",
+  "firb_specialist",
+  "migration_agent",
+  // Stockbroker firm fields
+  "firm_type",
+  "minimum_investment_cents",
+  "fee_model",
+  "year_founded",
+  "office_states",
+  "aum_aud_billions",
+  "updated_at",
+  "created_at",
+] as const;
+
+/**
+ * Sanitize an advisor row: keep only public fields, escape string values.
+ */
+function sanitizeAdvisor(row: Record<string, unknown>): Record<string, unknown> {
+  const clean: Record<string, unknown> = {};
+  for (const field of PUBLIC_FIELDS) {
+    if (field in row) {
+      const val = row[field];
+      clean[field] = typeof val === "string" ? escapeHtml(val) : val;
+    }
+  }
+  return clean;
+}
+
+/**
+ * OPTIONS /api/v1/advisors — CORS preflight
+ */
+export function OPTIONS() {
+  return new NextResponse(null, {
+    status: 204,
+    headers: API_CORS_HEADERS,
+  });
+}
+
+/**
+ * GET /api/v1/advisors
+ *
+ * Returns active advisors/professionals with public fields only.
+ *
+ * Query params:
+ *   ?type=financial_planner       — filter by professional type
+ *   ?location_state=NSW           — filter by state
+ *   ?verified=true                — filter verified advisors
+ *   ?accepts_new_clients=true     — filter by new-client availability
+ *   ?limit=20                     — max results (default 20, max 100)
+ *   ?offset=0                     — pagination offset
+ *
+ * Response: { data: Advisor[], meta: { total, limit, offset, updated_at } }
+ */
+export async function GET(request: NextRequest) {
+  const start = Date.now();
+
+  // ── Auth ──
+  const auth = await validateApiKey(request);
+  if (!auth.valid) {
+    const elapsed = Date.now() - start;
+    logApiRequest({
+      apiKeyId: null,
+      endpoint: "/api/v1/advisors",
+      method: "GET",
+      statusCode: 401,
+      responseTimeMs: elapsed,
+      ipAddress:
+        request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+        "unknown",
+      userAgent: request.headers.get("user-agent") || "unknown",
+    });
+    return NextResponse.json(
+      { error: auth.error },
+      { status: 401, headers: API_CORS_HEADERS },
+    );
+  }
+
+  try {
+    const params = request.nextUrl.searchParams;
+
+    // Parse pagination
+    let limit = Math.min(parseInt(params.get("limit") || "20", 10) || 20, 100);
+    if (limit < 1) limit = 20;
+    let offset = parseInt(params.get("offset") || "0", 10) || 0;
+    if (offset < 0) offset = 0;
+
+    // professionals table has anon SELECT policy for active rows covered
+    // by the public RLS policy — createClient (not admin) is correct here,
+    // matching how the public /advisors page fetches.
+    const supabase = await createClient();
+
+    let query = supabase
+      .from("professionals")
+      .select(PUBLIC_FIELDS.join(","), { count: "exact" })
+      .eq("status", "active")
+      .order("rating", { ascending: false })
+      .order("name", { ascending: true });
+
+    // Apply filters
+    const type = params.get("type");
+    if (type) {
+      query = query.eq("type", type);
+    }
+
+    const locationState = params.get("location_state");
+    if (locationState) {
+      query = query.eq("location_state", locationState);
+    }
+
+    const verified = params.get("verified");
+    if (verified === "true") {
+      query = query.eq("verified", true);
+    } else if (verified === "false") {
+      query = query.eq("verified", false);
+    }
+
+    const acceptsNew = params.get("accepts_new_clients");
+    if (acceptsNew === "true") {
+      query = query.eq("accepts_new_clients", true);
+    } else if (acceptsNew === "false") {
+      query = query.eq("accepts_new_clients", false);
+    }
+
+    // Apply pagination
+    query = query.range(offset, offset + limit - 1);
+
+    const { data: advisors, count, error } = await query;
+
+    if (error) {
+      log.error("Failed to fetch advisors", { error: error.message });
+      const elapsed = Date.now() - start;
+      logApiRequest({
+        apiKeyId: auth.apiKey?.id || null,
+        endpoint: "/api/v1/advisors",
+        method: "GET",
+        statusCode: 500,
+        responseTimeMs: elapsed,
+        ipAddress:
+          request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+          "unknown",
+        userAgent: request.headers.get("user-agent") || "unknown",
+      });
+      return NextResponse.json(
+        { error: "Failed to fetch advisors" },
+        { status: 500, headers: API_CORS_HEADERS },
+      );
+    }
+
+    // Sanitize each advisor row
+    const sanitized = (advisors || []).map((a) =>
+      sanitizeAdvisor(a as unknown as Record<string, unknown>),
+    );
+
+    // Most recent updated_at across returned rows
+    const latestUpdate =
+      sanitized.reduce((latest: string, a) => {
+        const u = (a.updated_at as string) || "";
+        return u > latest ? u : latest;
+      }, "") || new Date().toISOString();
+
+    const elapsed = Date.now() - start;
+
+    logApiRequest({
+      apiKeyId: auth.apiKey?.id || null,
+      endpoint: "/api/v1/advisors",
+      method: "GET",
+      statusCode: 200,
+      responseTimeMs: elapsed,
+      ipAddress:
+        request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+        "unknown",
+      userAgent: request.headers.get("user-agent") || "unknown",
+    });
+
+    return NextResponse.json(
+      {
+        data: sanitized,
+        meta: {
+          total: count ?? sanitized.length,
+          limit,
+          offset,
+          updated_at: latestUpdate,
+        },
+      },
+      {
+        status: 200,
+        headers: {
+          ...API_CORS_HEADERS,
+          "Cache-Control": "private, max-age=3600",
+        },
+      },
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "Unknown error";
+    log.error("Unexpected error in GET /api/v1/advisors", { error: msg });
+    const elapsed = Date.now() - start;
+    logApiRequest({
+      apiKeyId: auth.apiKey?.id || null,
+      endpoint: "/api/v1/advisors",
+      method: "GET",
+      statusCode: 500,
+      responseTimeMs: elapsed,
+      ipAddress:
+        request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+        "unknown",
+      userAgent: request.headers.get("user-agent") || "unknown",
+    });
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500, headers: API_CORS_HEADERS },
+    );
+  }
+}

--- a/app/api/v1/docs/route.ts
+++ b/app/api/v1/docs/route.ts
@@ -21,7 +21,7 @@ export function OPTIONS() {
  */
 export function GET() {
   const docs = {
-    name: "Invest.com.au Broker API",
+    name: "Invest.com.au Financial Data API",
     version: "1.0",
     base_url: "https://invest.com.au/api/v1",
     authentication: {
@@ -222,6 +222,166 @@ export function GET() {
           rate_limits: { per_minute: 30, per_day: 1000 },
           message:
             "Save this API key securely. It will not be shown again.",
+        },
+      },
+      {
+        path: "/api/v1/advisors",
+        method: "GET",
+        auth_required: true,
+        description:
+          "List active financial advisors and professionals. Returns public profile fields only — no PII, no billing data. Supports filtering and pagination.",
+        parameters: [
+          {
+            name: "type",
+            type: "string",
+            required: false,
+            description:
+              "Filter by professional type: financial_planner, smsf_accountant, property_advisor, tax_agent, mortgage_broker, wealth_manager, etc.",
+          },
+          {
+            name: "location_state",
+            type: "string",
+            required: false,
+            description: "Filter by Australian state code: NSW, VIC, QLD, WA, SA, TAS, ACT, NT",
+          },
+          {
+            name: "verified",
+            type: "boolean",
+            required: false,
+            description: "Filter verified advisors (true/false)",
+          },
+          {
+            name: "accepts_new_clients",
+            type: "boolean",
+            required: false,
+            description: "Filter by new-client availability (true/false)",
+          },
+          {
+            name: "limit",
+            type: "integer",
+            required: false,
+            description: "Results per page (default: 20, max: 100)",
+          },
+          {
+            name: "offset",
+            type: "integer",
+            required: false,
+            description: "Pagination offset (default: 0)",
+          },
+        ],
+        example_request: "GET /api/v1/advisors?type=financial_planner&location_state=NSW&verified=true&limit=10",
+        example_response: {
+          data: [
+            {
+              id: 42,
+              slug: "jane-smith-cfp",
+              name: "Jane Smith",
+              firm_name: "Smith Financial",
+              type: "financial_planner",
+              specialties: ["retirement", "smsf"],
+              location_state: "NSW",
+              location_display: "Sydney, NSW",
+              afsl_number: "123456",
+              rating: 4.8,
+              review_count: 24,
+              verified: true,
+              hourly_rate_cents: 35000,
+              initial_consultation_free: true,
+              accepts_new_clients: true,
+            },
+          ],
+          meta: {
+            total: 120,
+            limit: 10,
+            offset: 0,
+            updated_at: "2026-05-01T08:00:00Z",
+          },
+        },
+      },
+      {
+        path: "/api/v1/advisors/:slug",
+        method: "GET",
+        auth_required: true,
+        description:
+          "Get a single advisor's full public profile by slug. Includes approved reviews (last 10), qualifications, education, FAQs, and services metadata.",
+        parameters: [
+          {
+            name: "slug",
+            type: "string",
+            required: true,
+            in: "path",
+            description: "The advisor's URL slug (e.g. 'jane-smith-cfp')",
+          },
+        ],
+        example_request: "GET /api/v1/advisors/jane-smith-cfp",
+        example_response: {
+          data: {
+            id: 42,
+            slug: "jane-smith-cfp",
+            name: "Jane Smith",
+            type: "financial_planner",
+            rating: 4.8,
+            verified: true,
+            faqs: [{ q: "Do you offer a free initial meeting?", a: "Yes, 30 minutes at no cost." }],
+            reviews: [
+              {
+                id: 1,
+                rating: 5,
+                headline: "Excellent advice",
+                body: "Jane helped us structure our SMSF effectively.",
+                reviewer_name: "Michael T.",
+                created_at: "2026-04-10T09:00:00Z",
+              },
+            ],
+          },
+        },
+      },
+      {
+        path: "/api/v1/fee-index",
+        method: "GET",
+        auth_required: true,
+        description:
+          "AU brokerage fee index: market-wide average and median ASX per-trade fee, US share fee, and FX spread, with QoQ and YoY trend deltas. Updated daily. This is factual aggregate data — not financial advice.",
+        parameters: [
+          {
+            name: "history",
+            type: "integer",
+            required: false,
+            description:
+              "Number of prior daily snapshots to include in the history array (default: 90, max: 400). Pass 0 to return the latest snapshot only.",
+          },
+        ],
+        example_request: "GET /api/v1/fee-index?history=30",
+        example_response: {
+          data: {
+            latest: {
+              period: "2026-05-24",
+              computed_at: "2026-05-24T02:15:00Z",
+              broker_count: 22,
+              asx_fee_sample: 20,
+              avg_asx_fee: 8.50,
+              median_asx_fee: 9.50,
+              avg_us_fee: 1.20,
+              median_us_fee: 0.00,
+              avg_fx_spread: 0.55,
+              median_fx_spread: 0.60,
+            },
+            trend: {
+              quarter: {
+                avgAsxFee: { previous: 9.00, change: -0.50, changePct: -5.56 },
+                avgUsFee: { previous: 1.30, change: -0.10, changePct: -7.69 },
+                avgFxSpread: { previous: 0.57, change: -0.02, changePct: -3.51 },
+              },
+              year: null,
+            },
+            history: [
+              { period: "2026-05-23", avg_asx_fee: 8.60, median_asx_fee: 9.50 },
+            ],
+          },
+          meta: {
+            updated_at: "2026-05-24T02:15:00Z",
+            history_days: 30,
+          },
         },
       },
       {

--- a/app/api/v1/fee-index/route.ts
+++ b/app/api/v1/fee-index/route.ts
@@ -1,0 +1,147 @@
+import { NextRequest, NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
+import { validateApiKey, logApiRequest, API_CORS_HEADERS } from "@/lib/api-auth";
+import { readFeeIndex, computeTrend } from "@/lib/fee-index";
+
+export const runtime = "nodejs";
+// Per-key auth gating — see /api/v1/brokers/route.ts for the same reasoning.
+export const dynamic = "force-dynamic";
+
+const log = logger("api-v1-fee-index");
+
+/**
+ * OPTIONS /api/v1/fee-index — CORS preflight
+ */
+export function OPTIONS() {
+  return new NextResponse(null, {
+    status: 204,
+    headers: API_CORS_HEADERS,
+  });
+}
+
+/**
+ * GET /api/v1/fee-index
+ *
+ * Returns the AU brokerage fee index: market-wide average and median ASX
+ * per-trade fee, US share fee, and FX spread, with QoQ and YoY trend deltas.
+ *
+ * The underlying data is computed daily by the fee-index cron job from
+ * `broker_price_snapshots`, stored in `fee_index_snapshots`, and read back
+ * here. It is FACTUAL aggregate data — not financial advice.
+ *
+ * Query params:
+ *   ?history=90   — number of prior daily snapshots to include in
+ *                   the `history` array (default 90, max 400).
+ *                   Pass 0 to return latest-only with no history.
+ *
+ * Response:
+ *   {
+ *     data: {
+ *       latest: FeeIndexSnapshot | null,
+ *       trend: FeeIndexTrend | null,
+ *       history: FeeIndexSnapshot[]   // DESC by period
+ *     },
+ *     meta: { updated_at, history_days }
+ *   }
+ */
+export async function GET(request: NextRequest) {
+  const start = Date.now();
+
+  // ── Auth ──
+  const auth = await validateApiKey(request);
+  if (!auth.valid) {
+    const elapsed = Date.now() - start;
+    logApiRequest({
+      apiKeyId: null,
+      endpoint: "/api/v1/fee-index",
+      method: "GET",
+      statusCode: 401,
+      responseTimeMs: elapsed,
+      ipAddress:
+        request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+        "unknown",
+      userAgent: request.headers.get("user-agent") || "unknown",
+    });
+    return NextResponse.json(
+      { error: auth.error },
+      { status: 401, headers: API_CORS_HEADERS },
+    );
+  }
+
+  try {
+    const params = request.nextUrl.searchParams;
+
+    // history param: number of daily rows to return (0–400)
+    let historyDays = parseInt(params.get("history") || "90", 10);
+    if (!Number.isFinite(historyDays) || historyDays < 0) historyDays = 90;
+    if (historyDays > 400) historyDays = 400;
+
+    // readFeeIndex uses the admin client — fee_index_snapshots has no
+    // anon RLS policy (service-role only, per lib/fee-index.ts comment).
+    const { latest, history } = await readFeeIndex(
+      // fetch enough history for trend calc (need ≥ 365 rows to get YoY)
+      // but respect the caller's requested limit for the response body.
+      Math.max(historyDays, 400),
+    );
+
+    const trend = latest ? computeTrend(latest, history) : null;
+
+    // Trim the history array to what the caller asked for
+    const trimmedHistory = historyDays === 0 ? [] : history.slice(0, historyDays);
+
+    const elapsed = Date.now() - start;
+
+    logApiRequest({
+      apiKeyId: auth.apiKey?.id || null,
+      endpoint: "/api/v1/fee-index",
+      method: "GET",
+      statusCode: 200,
+      responseTimeMs: elapsed,
+      ipAddress:
+        request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+        "unknown",
+      userAgent: request.headers.get("user-agent") || "unknown",
+    });
+
+    return NextResponse.json(
+      {
+        data: {
+          latest,
+          trend,
+          history: trimmedHistory,
+        },
+        meta: {
+          updated_at: latest?.computed_at ?? null,
+          history_days: trimmedHistory.length,
+        },
+      },
+      {
+        status: 200,
+        headers: {
+          ...API_CORS_HEADERS,
+          // Fee-index is updated once daily by cron; 1-hour private cache is fine.
+          "Cache-Control": "private, max-age=3600",
+        },
+      },
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "Unknown error";
+    log.error("Unexpected error in GET /api/v1/fee-index", { error: msg });
+    const elapsed = Date.now() - start;
+    logApiRequest({
+      apiKeyId: auth.apiKey?.id || null,
+      endpoint: "/api/v1/fee-index",
+      method: "GET",
+      statusCode: 500,
+      responseTimeMs: elapsed,
+      ipAddress:
+        request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+        "unknown",
+      userAgent: request.headers.get("user-agent") || "unknown",
+    });
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500, headers: API_CORS_HEADERS },
+    );
+  }
+}

--- a/supabase/migrations/20260802_api_v1_advisors_fee_index_endpoints.sql
+++ b/supabase/migrations/20260802_api_v1_advisors_fee_index_endpoints.sql
@@ -1,0 +1,43 @@
+-- Migration: register /api/v1/advisors and /api/v1/fee-index in the API key
+-- allowed_endpoints column.
+--
+-- Context: the allowed_endpoints column is an informational/admin ACL field.
+-- The validateApiKey() flow (lib/api-auth.ts) does not enforce it at
+-- request-time — it is used by the admin UI to communicate per-key grants.
+-- Routes validate auth only; endpoint access is not gated on this field.
+--
+-- This migration:
+--   1. Updates the column DEFAULT so new keys include the new endpoints.
+--   2. Backfills existing active keys to include the new endpoints (opt-in
+--      expansion — existing keys retain all previously granted endpoints).
+--
+-- Rollback strategy: revert the DEFAULT and remove the new endpoint strings
+-- from existing rows with an UPDATE using array_remove().
+
+-- 1. Update column default to include all v1 endpoints
+ALTER TABLE api_keys
+  ALTER COLUMN allowed_endpoints
+    SET DEFAULT '{
+      "/api/v1/brokers",
+      "/api/v1/brokers/:slug",
+      "/api/v1/compare",
+      "/api/v1/advisors",
+      "/api/v1/advisors/:slug",
+      "/api/v1/fee-index"
+    }';
+
+-- 2. Backfill existing active keys — append new endpoints if not already present
+UPDATE api_keys
+SET
+  allowed_endpoints = (
+    SELECT array_agg(DISTINCT ep ORDER BY ep)
+    FROM unnest(
+      allowed_endpoints || ARRAY[
+        '/api/v1/advisors',
+        '/api/v1/advisors/:slug',
+        '/api/v1/fee-index'
+      ]
+    ) AS ep
+  ),
+  updated_at = NOW()
+WHERE is_active = true;


### PR DESCRIPTION
Deepens the public REST API (which exposed brokers only) to also cover **advisors** and the **brokerage fee index**, reusing the existing key-auth + per-key rate-limiting + `api_request_log` exactly.

- `GET /api/v1/advisors` (paginated, filters: type/state/verified/accepts-new) and `GET /api/v1/advisors/[slug]` (incl. faqs/qualifications + last-10 approved reviews) — **public allowlisted fields only** (no email/phone/billing/internal counters); reads via the existing anon SELECT policy like the public pages.
- `GET /api/v1/fee-index` — latest + QoQ/YoY trend + history, reusing `lib/fee-index.ts`.
- Migration adds the three endpoints to the `allowed_endpoints` default + backfills existing keys (informational ACL).
- `/api/v1/docs` (machine-readable) + `/api-docs` (human) updated.

**Fixes on verification:** a Supabase row cast had to go through `unknown` (tsc), and a Python docs sample's literal `${latest[...]}` was being parsed as a JS template interpolation — escaped the `$`.

**Verified:** `tsc` clean · **49 tests passing** (3 files) · eslint clean · rate-limit `--strict` 100%. Factual-data only (AFSL-safe).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUfSRE2Teb6VhEXFP6RpS9)_