### PR TITLE
feat: broker health-score history + trend sparklines (deepen)

### DIFF
--- a/__tests__/api/cron-snapshot-health-scores.test.ts
+++ b/__tests__/api/cron-snapshot-health-scores.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, type MockInstance } from "vitest";
 import { NextRequest, NextResponse } from "next/server";
 
 /* ─── Hoisted mocks (vi.mock is hoisted; use vi.hoisted for shared fns) ────── */
@@ -6,14 +6,22 @@ import { NextRequest, NextResponse } from "next/server";
 const { mockAdminFrom, mockRequireCronAuth, mockWrapCronHandler } =
   vi.hoisted(() => ({
     mockAdminFrom: vi.fn(),
-    mockRequireCronAuth: vi.fn(() => null), // null = authorised
+    // Typed to return NextResponse | null so .mockReturnValue accepts both
+    // the null (authorised) and NextResponse (rejected) cases.
+    mockRequireCronAuth: vi.fn(
+      (): NextResponse | null => null,
+    ),
     mockWrapCronHandler: vi.fn(
       (
         _name: string,
         handler: (req: NextRequest) => Promise<Response>,
       ) => handler,
     ),
-  }));
+  })) as {
+    mockAdminFrom: MockInstance;
+    mockRequireCronAuth: MockInstance<() => NextResponse | null>;
+    mockWrapCronHandler: MockInstance;
+  };
 
 vi.mock("@/lib/supabase/admin", () => ({
   createAdminClient: () => ({ from: mockAdminFrom }),

--- a/__tests__/api/cron-snapshot-health-scores.test.ts
+++ b/__tests__/api/cron-snapshot-health-scores.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+/* ─── Hoisted mocks (vi.mock is hoisted; use vi.hoisted for shared fns) ────── */
+
+const { mockAdminFrom, mockRequireCronAuth, mockWrapCronHandler } =
+  vi.hoisted(() => ({
+    mockAdminFrom: vi.fn(),
+    mockRequireCronAuth: vi.fn(() => null), // null = authorised
+    mockWrapCronHandler: vi.fn(
+      (
+        _name: string,
+        handler: (req: NextRequest) => Promise<Response>,
+      ) => handler,
+    ),
+  }));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({ from: mockAdminFrom }),
+}));
+
+vi.mock("@/lib/cron-auth", () => ({
+  requireCronAuth: mockRequireCronAuth,
+}));
+
+vi.mock("@/lib/cron-run-log", () => ({
+  wrapCronHandler: mockWrapCronHandler,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+import { GET } from "@/app/api/cron/snapshot-health-scores/route";
+
+/* ─── Helpers ────────────────────────────────────────────────────────────────── */
+
+function makeRequest(): NextRequest {
+  return new NextRequest("http://localhost/api/cron/snapshot-health-scores", {
+    headers: { Authorization: "Bearer test-cron-secret" },
+  });
+}
+
+function makeHealthScores() {
+  return [
+    {
+      broker_slug: "commsec",
+      overall_score: 88,
+      regulatory_score: 90,
+      client_money_score: 85,
+      financial_stability_score: 88,
+      platform_reliability_score: 82,
+      insurance_score: 80,
+    },
+    {
+      broker_slug: "stake",
+      overall_score: 72,
+      regulatory_score: 75,
+      client_money_score: 70,
+      financial_stability_score: 68,
+      platform_reliability_score: 78,
+      insurance_score: 65,
+    },
+  ];
+}
+
+/* Builds a Supabase-like chainable builder for the health_scores SELECT */
+function makeSelectBuilder(data: unknown, error: unknown = null) {
+  return {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    single: vi.fn(() => Promise.resolve({ data, error })),
+    // For non-single selects the chain resolves directly
+    then: (resolve: (v: unknown) => void) =>
+      Promise.resolve({ data, error }).then(resolve),
+  };
+}
+
+/* Builds a builder that records inserts */
+function makeInsertCapture(insertError: unknown = null) {
+  const inserted: unknown[] = [];
+  return {
+    inserted,
+    builder: {
+      select: vi.fn().mockReturnThis(),
+      insert: vi.fn((row: unknown) => {
+        inserted.push(row);
+        return Promise.resolve({ error: insertError });
+      }),
+    },
+  };
+}
+
+/* ─── Tests ─────────────────────────────────────────────────────────────────── */
+
+describe("GET /api/cron/snapshot-health-scores", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireCronAuth.mockReturnValue(null); // authorised by default
+  });
+
+  it("returns 401 when requireCronAuth rejects", async () => {
+    const unauthorisedResponse = new Response(null, { status: 401 });
+    mockRequireCronAuth.mockReturnValue(unauthorisedResponse);
+    // Since wrapCronHandler is mocked to call through, GET is the handler itself.
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 500 when fetching broker_health_scores fails", async () => {
+    mockAdminFrom.mockReturnValue(
+      makeSelectBuilder(null, { message: "db error" }),
+    );
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error).toMatch(/db error/i);
+  });
+
+  it("inserts one history row per broker and returns counts", async () => {
+    const scores = makeHealthScores();
+    const { inserted, builder: insertBuilder } = makeInsertCapture();
+
+    // First call: SELECT from broker_health_scores
+    // Subsequent calls: INSERT into broker_health_score_history
+    let callCount = 0;
+    mockAdminFrom.mockImplementation((table: string) => {
+      if (table === "broker_health_scores") {
+        callCount++;
+        return makeSelectBuilder(scores);
+      }
+      // broker_health_score_history — use insert builder
+      return insertBuilder;
+    });
+
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.total).toBe(2);
+    expect(body.succeeded).toBe(2);
+    expect(body.failed).toBe(0);
+
+    expect(inserted).toHaveLength(2);
+    const first = inserted[0] as Record<string, unknown>;
+    expect(first.broker_slug).toBe("commsec");
+    expect(first.overall_score).toBe(88);
+    expect(typeof first.captured_at).toBe("string");
+  });
+
+  it("counts insert failures without throwing", async () => {
+    const scores = makeHealthScores();
+    const { inserted, builder: insertBuilder } = makeInsertCapture({
+      message: "constraint violation",
+    });
+
+    mockAdminFrom.mockImplementation((table: string) => {
+      if (table === "broker_health_scores") return makeSelectBuilder(scores);
+      return insertBuilder;
+    });
+
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.failed).toBe(2);
+    expect(body.succeeded).toBe(0);
+    expect(inserted).toHaveLength(2); // still attempted both
+  });
+
+  it("handles empty broker_health_scores gracefully", async () => {
+    mockAdminFrom.mockReturnValue(makeSelectBuilder([]));
+    const res = await GET(makeRequest());
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.total).toBe(0);
+    expect(body.succeeded).toBe(0);
+  });
+
+  it("handles null data from broker_health_scores gracefully (treats as empty)", async () => {
+    mockAdminFrom.mockReturnValue(makeSelectBuilder(null));
+    const res = await GET(makeRequest());
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.total).toBe(0);
+  });
+
+  it("all captured_at timestamps share the same ISO string within a single run", async () => {
+    const scores = makeHealthScores();
+    const insertedRows: Array<Record<string, unknown>> = [];
+    mockAdminFrom.mockImplementation((table: string) => {
+      if (table === "broker_health_scores") return makeSelectBuilder(scores);
+      return {
+        insert: (row: Record<string, unknown>) => {
+          insertedRows.push(row);
+          return Promise.resolve({ error: null });
+        },
+      };
+    });
+
+    await GET(makeRequest());
+    expect(insertedRows).toHaveLength(2);
+    // All rows in a single cron run should share the same captured_at
+    expect(insertedRows[0]?.captured_at).toBe(insertedRows[1]?.captured_at);
+  });
+});

--- a/__tests__/api/cron-snapshot-health-scores.test.ts
+++ b/__tests__/api/cron-snapshot-health-scores.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { NextRequest } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 
 /* ─── Hoisted mocks (vi.mock is hoisted; use vi.hoisted for shared fns) ────── */
 
@@ -107,7 +107,10 @@ describe("GET /api/cron/snapshot-health-scores", () => {
   });
 
   it("returns 401 when requireCronAuth rejects", async () => {
-    const unauthorisedResponse = new Response(null, { status: 401 });
+    const unauthorisedResponse = NextResponse.json(
+      { error: "Unauthorized" },
+      { status: 401 },
+    );
     mockRequireCronAuth.mockReturnValue(unauthorisedResponse);
     // Since wrapCronHandler is mocked to call through, GET is the handler itself.
     const res = await GET(makeRequest());

--- a/__tests__/api/cron-snapshot-health-scores.test.ts
+++ b/__tests__/api/cron-snapshot-health-scores.test.ts
@@ -161,6 +161,9 @@ describe("GET /api/cron/snapshot-health-scores", () => {
     expect(body.succeeded).toBe(2);
     expect(body.failed).toBe(0);
 
+    // broker_health_scores is read exactly once per run
+    expect(callCount).toBe(1);
+
     expect(inserted).toHaveLength(2);
     const first = inserted[0] as Record<string, unknown>;
     expect(first.broker_slug).toBe("commsec");

--- a/__tests__/lib/health-score-trends.test.ts
+++ b/__tests__/lib/health-score-trends.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from "vitest";
+import {
+  summariseTrend,
+  normaliseSparklinePoints,
+  formatDelta,
+  type HealthScoreHistoryRow,
+} from "@/lib/health-score-trends";
+
+/* ─── Fixtures ─────────────────────────────────────────────────────────────── */
+
+function makeRow(
+  overall_score: number,
+  captured_at: string,
+): HealthScoreHistoryRow {
+  return {
+    captured_at,
+    overall_score,
+    regulatory_score: null,
+    client_money_score: null,
+    financial_stability_score: null,
+    platform_reliability_score: null,
+    insurance_score: null,
+  };
+}
+
+const flat = [
+  makeRow(72, "2026-01-01T00:00:00Z"),
+  makeRow(72, "2026-02-01T00:00:00Z"),
+  makeRow(72, "2026-03-01T00:00:00Z"),
+];
+
+const rising = [
+  makeRow(60, "2026-01-01T00:00:00Z"),
+  makeRow(70, "2026-02-01T00:00:00Z"),
+  makeRow(80, "2026-03-01T00:00:00Z"),
+];
+
+const falling = [
+  makeRow(85, "2026-01-01T00:00:00Z"),
+  makeRow(75, "2026-02-01T00:00:00Z"),
+  makeRow(60, "2026-03-01T00:00:00Z"),
+];
+
+/* Deliberately out of chronological order to test internal sort */
+const outOfOrder = [
+  makeRow(80, "2026-03-01T00:00:00Z"),
+  makeRow(60, "2026-01-01T00:00:00Z"),
+  makeRow(70, "2026-02-01T00:00:00Z"),
+];
+
+/* ─── summariseTrend ───────────────────────────────────────────────────────── */
+
+describe("summariseTrend", () => {
+  it("returns null for an empty array", () => {
+    expect(summariseTrend([])).toBeNull();
+  });
+
+  it("returns a flat summary for a single-row series", () => {
+    const result = summariseTrend([makeRow(70, "2026-01-01T00:00:00Z")]);
+    expect(result).not.toBeNull();
+    expect(result!.direction).toBe("flat");
+    expect(result!.delta).toBe(0);
+    expect(result!.count).toBe(1);
+  });
+
+  it("identifies rising trend", () => {
+    const result = summariseTrend(rising);
+    expect(result!.direction).toBe("up");
+    expect(result!.delta).toBeCloseTo(20);
+    expect(result!.latest).toBe(80);
+    expect(result!.earliest).toBe(60);
+  });
+
+  it("identifies falling trend", () => {
+    const result = summariseTrend(falling);
+    expect(result!.direction).toBe("down");
+    expect(result!.delta).toBeCloseTo(-25);
+  });
+
+  it("returns flat when delta is within ±1", () => {
+    const nearFlat = [
+      makeRow(72, "2026-01-01T00:00:00Z"),
+      makeRow(72.5, "2026-02-01T00:00:00Z"),
+    ];
+    expect(summariseTrend(nearFlat)!.direction).toBe("flat");
+  });
+
+  it("returns flat for an array with equal scores", () => {
+    expect(summariseTrend(flat)!.direction).toBe("flat");
+  });
+
+  it("sorts rows by captured_at before comparing first and last", () => {
+    const result = summariseTrend(outOfOrder);
+    expect(result!.earliest).toBe(60);
+    expect(result!.latest).toBe(80);
+    expect(result!.direction).toBe("up");
+  });
+
+  it("returns the correct count", () => {
+    expect(summariseTrend(rising)!.count).toBe(3);
+    expect(summariseTrend(flat)!.count).toBe(3);
+  });
+});
+
+/* ─── normaliseSparklinePoints ─────────────────────────────────────────────── */
+
+describe("normaliseSparklinePoints", () => {
+  it("returns empty array for empty input", () => {
+    expect(normaliseSparklinePoints([])).toEqual([]);
+  });
+
+  it("returns 0.5 for all points when all scores are equal (flat-line guard)", () => {
+    const points = normaliseSparklinePoints(flat);
+    expect(points).toHaveLength(3);
+    expect(points.every((p) => p === 0.5)).toBe(true);
+  });
+
+  it("min maps to 0 and max maps to 1", () => {
+    const points = normaliseSparklinePoints(rising);
+    expect(Math.min(...points)).toBeCloseTo(0);
+    expect(Math.max(...points)).toBeCloseTo(1);
+  });
+
+  it("intermediate values are proportional", () => {
+    // rising: 60→70→80  → normalised: 0, 0.5, 1
+    const points = normaliseSparklinePoints(rising);
+    expect(points[0]).toBeCloseTo(0);
+    expect(points[1]).toBeCloseTo(0.5);
+    expect(points[2]).toBeCloseTo(1);
+  });
+
+  it("sorts out-of-order rows before normalising", () => {
+    // outOfOrder: 60 (Jan), 70 (Feb), 80 (Mar) after sort
+    const points = normaliseSparklinePoints(outOfOrder);
+    expect(points[0]).toBeCloseTo(0);
+    expect(points[2]).toBeCloseTo(1);
+  });
+
+  it("handles a single row — returns a single 0.5", () => {
+    const points = normaliseSparklinePoints([makeRow(75, "2026-01-01T00:00:00Z")]);
+    expect(points).toHaveLength(1);
+    expect(points[0]).toBe(0.5);
+  });
+});
+
+/* ─── formatDelta ──────────────────────────────────────────────────────────── */
+
+describe("formatDelta", () => {
+  it("formats positive deltas with a + prefix", () => {
+    expect(formatDelta(5)).toBe("+5.0");
+    expect(formatDelta(0.25)).toBe("+0.3");
+  });
+
+  it("formats negative deltas with a minus sign (U+2212)", () => {
+    const result = formatDelta(-3.5);
+    expect(result).toContain("3.5");
+    expect(result.startsWith("−")).toBe(true); // U+2212, not hyphen
+  });
+
+  it("formats zero as +0.0", () => {
+    expect(formatDelta(0)).toBe("+0.0");
+  });
+
+  it("rounds to 1 decimal place", () => {
+    expect(formatDelta(10.15)).toBe("+10.2");
+    expect(formatDelta(-2.04)).toBe("−2.0");
+  });
+});

--- a/app/api/cron/snapshot-health-scores/route.ts
+++ b/app/api/cron/snapshot-health-scores/route.ts
@@ -1,0 +1,85 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireCronAuth } from "@/lib/cron-auth";
+import { wrapCronHandler } from "@/lib/cron-run-log";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+
+const log = logger("cron-snapshot-health-scores");
+
+export const runtime = "nodejs";
+export const maxDuration = 60;
+
+/**
+ * Cron: health-score snapshot.
+ *
+ * Runs daily (see lib/cron-groups.ts — daily-6 group alongside check-fees).
+ * Copies the current broker_health_scores rows into the append-only
+ * broker_health_score_history table so the /health-scores/[slug] detail
+ * page can render an overall_score sparkline over time.
+ *
+ * Uses service-role (createAdminClient) because cron routes are a
+ * legitimate service_role caller per the admin-client scope documented
+ * in CLAUDE.md.
+ */
+async function handler(req: NextRequest): Promise<NextResponse> {
+  const unauth = requireCronAuth(req);
+  if (unauth) return unauth;
+
+  const supabase = createAdminClient();
+
+  const { data: scores, error: fetchErr } = await supabase
+    .from("broker_health_scores")
+    .select(
+      "broker_slug, overall_score, regulatory_score, client_money_score, financial_stability_score, platform_reliability_score, insurance_score",
+    );
+
+  if (fetchErr) {
+    log.error("failed to fetch broker_health_scores", {
+      error: fetchErr.message,
+    });
+    return NextResponse.json(
+      { ok: false, error: fetchErr.message },
+      { status: 500 },
+    );
+  }
+
+  const rows = scores ?? [];
+  const now = new Date().toISOString();
+  let succeeded = 0;
+  let failed = 0;
+
+  for (const s of rows) {
+    const { error: insertErr } = await supabase
+      .from("broker_health_score_history")
+      .insert({
+        broker_slug: s.broker_slug,
+        overall_score: s.overall_score,
+        regulatory_score: s.regulatory_score ?? null,
+        client_money_score: s.client_money_score ?? null,
+        financial_stability_score: s.financial_stability_score ?? null,
+        platform_reliability_score: s.platform_reliability_score ?? null,
+        insurance_score: s.insurance_score ?? null,
+        captured_at: now,
+      });
+
+    if (insertErr) {
+      log.error("failed to insert health score history row", {
+        broker_slug: s.broker_slug,
+        error: insertErr.message,
+      });
+      failed++;
+    } else {
+      succeeded++;
+    }
+  }
+
+  log.info("health-score snapshot complete", {
+    total: rows.length,
+    succeeded,
+    failed,
+  });
+
+  return NextResponse.json({ ok: true, total: rows.length, succeeded, failed });
+}
+
+export const GET = wrapCronHandler("snapshot-health-scores", handler);

--- a/app/health-scores/[slug]/page.tsx
+++ b/app/health-scores/[slug]/page.tsx
@@ -4,7 +4,12 @@ import type { Metadata } from "next";
 import { createClient } from "@/lib/supabase/server";
 import { createStaticClient } from "@/lib/supabase/static";
 import { absoluteUrl, breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
-import type { Broker, BrokerHealthScore } from "@/lib/types";
+import type { Broker, BrokerHealthScore, BrokerHealthScoreHistory } from "@/lib/types";
+import {
+  summariseTrend,
+  normaliseSparklinePoints,
+  formatDelta,
+} from "@/lib/health-score-trends";
 
 export const revalidate = 3600;
 
@@ -112,6 +117,70 @@ function ScoreGauge({ score, size = 120 }: { score: number; size?: number }) {
   );
 }
 
+/* ─── SVG sparkline (server-renderable, no client deps) ─── */
+
+function ScoreSparkline({
+  history,
+  width = 200,
+  height = 48,
+}: {
+  history: readonly BrokerHealthScoreHistory[];
+  width?: number;
+  height?: number;
+}) {
+  const points = normaliseSparklinePoints(history);
+  if (points.length < 2) return null;
+
+  const pad = 4;
+  const plotW = width - pad * 2;
+  const plotH = height - pad * 2;
+
+  const coords = points.map((y, i) => {
+    const x = pad + (i / (points.length - 1)) * plotW;
+    // y=0 is bottom, SVG y=0 is top → invert
+    const svgY = pad + (1 - y) * plotH;
+    return `${x},${svgY}`;
+  });
+
+  const polyline = coords.join(" ");
+  const summary = summariseTrend(history);
+  const trendColor =
+    !summary || summary.direction === "flat"
+      ? "#94a3b8"
+      : summary.direction === "up"
+        ? "#22c55e"
+        : "#ef4444";
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      role="img"
+      aria-label="Overall score trend"
+      className="overflow-visible"
+    >
+      <polyline
+        points={polyline}
+        fill="none"
+        stroke={trendColor}
+        strokeWidth="2"
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
+      {/* Dot at the most recent point */}
+      {(() => {
+        const lastCoord = coords[coords.length - 1];
+        if (!lastCoord) return null;
+        const parts = lastCoord.split(",");
+        const cx = Number(parts[0] ?? "0");
+        const cy = Number(parts[1] ?? "0");
+        return <circle cx={cx} cy={cy} r="3" fill={trendColor} />;
+      })()}
+    </svg>
+  );
+}
+
 /* ─── Rating label helper ─── */
 
 function ratingLabel(score: number): string {
@@ -211,23 +280,34 @@ export default async function HealthScoreDetailPage({
   const { slug } = await params;
   const supabase = await createClient();
 
-  const [{ data: score }, { data: broker }] = await Promise.all([
-    supabase
-      .from("broker_health_scores")
-      .select("*")
-      .eq("broker_slug", slug)
-      .single(),
-    supabase
-      .from("brokers")
-      .select("id, name, slug, color, icon, logo_url, rating, status")
-      .eq("slug", slug)
-      .single(),
-  ]);
+  const [{ data: score }, { data: broker }, { data: historyRows }] =
+    await Promise.all([
+      supabase
+        .from("broker_health_scores")
+        .select("*")
+        .eq("broker_slug", slug)
+        .single(),
+      supabase
+        .from("brokers")
+        .select("id, name, slug, color, icon, logo_url, rating, status")
+        .eq("slug", slug)
+        .single(),
+      supabase
+        .from("broker_health_score_history")
+        .select(
+          "id, broker_slug, overall_score, regulatory_score, client_money_score, financial_stability_score, platform_reliability_score, insurance_score, captured_at",
+        )
+        .eq("broker_slug", slug)
+        .order("captured_at", { ascending: true })
+        .limit(90),
+    ]);
 
   if (!score || !broker) notFound();
 
   const typedScore = score as BrokerHealthScore;
   const typedBroker = broker as Broker;
+  const history = (historyRows ?? []) as BrokerHealthScoreHistory[];
+  const trendSummary = summariseTrend(history);
 
   /* ─── JSON-LD ─── */
 
@@ -329,6 +409,27 @@ export default async function HealthScoreDetailPage({
                 <p className="text-xs text-slate-400 mt-1">
                   Last reviewed: {lastReviewed}
                 </p>
+              )}
+
+              {/* ── Trend sparkline ── */}
+              {history.length >= 2 && trendSummary && (
+                <div className="mt-3 flex items-center gap-3">
+                  <ScoreSparkline history={history} width={120} height={36} />
+                  <span
+                    className={`text-xs font-semibold tabular-nums ${
+                      trendSummary.direction === "up"
+                        ? "text-emerald-600"
+                        : trendSummary.direction === "down"
+                          ? "text-red-500"
+                          : "text-slate-400"
+                    }`}
+                  >
+                    {formatDelta(trendSummary.delta)} pts
+                  </span>
+                  <span className="text-xs text-slate-400">
+                    over {trendSummary.count} snapshots
+                  </span>
+                </div>
               )}
             </div>
           </div>
@@ -450,6 +551,73 @@ export default async function HealthScoreDetailPage({
             </table>
           </div>
         </section>
+
+        {/* Score history table */}
+        {history.length >= 2 && (
+          <section>
+            <h2 className="text-lg font-bold text-slate-900 mb-3">
+              Score History
+            </h2>
+            <div className="bg-white border border-slate-200 rounded-2xl overflow-hidden">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="bg-slate-50 border-b border-slate-200">
+                    <th className="text-left px-4 py-3 text-xs font-semibold text-slate-600">
+                      Date
+                    </th>
+                    <th className="text-right px-4 py-3 text-xs font-semibold text-slate-600">
+                      Overall
+                    </th>
+                    <th className="text-right px-4 py-3 text-xs font-semibold text-slate-600 hidden sm:table-cell">
+                      Regulatory
+                    </th>
+                    <th className="text-right px-4 py-3 text-xs font-semibold text-slate-600 hidden md:table-cell">
+                      Client Money
+                    </th>
+                    <th className="text-right px-4 py-3 text-xs font-semibold text-slate-600 hidden md:table-cell">
+                      Stability
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {[...history]
+                    .sort(
+                      (a, b) =>
+                        new Date(b.captured_at).getTime() -
+                        new Date(a.captured_at).getTime(),
+                    )
+                    .slice(0, 20)
+                    .map((h, i) => (
+                      <tr
+                        key={h.id}
+                        className={`border-b border-slate-50 ${i % 2 === 1 ? "bg-slate-50/50" : ""}`}
+                      >
+                        <td className="px-4 py-2.5 text-slate-500 text-xs tabular-nums">
+                          {new Date(h.captured_at).toLocaleDateString("en-AU", {
+                            day: "numeric",
+                            month: "short",
+                            year: "numeric",
+                          })}
+                        </td>
+                        <td className="px-4 py-2.5 text-right font-semibold text-slate-900 tabular-nums">
+                          {h.overall_score}
+                        </td>
+                        <td className="px-4 py-2.5 text-right text-slate-600 tabular-nums hidden sm:table-cell">
+                          {h.regulatory_score ?? "—"}
+                        </td>
+                        <td className="px-4 py-2.5 text-right text-slate-600 tabular-nums hidden md:table-cell">
+                          {h.client_money_score ?? "—"}
+                        </td>
+                        <td className="px-4 py-2.5 text-right text-slate-600 tabular-nums hidden md:table-cell">
+                          {h.financial_stability_score ?? "—"}
+                        </td>
+                      </tr>
+                    ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        )}
 
         {/* Methodology */}
         <section>

--- a/lib/cron-groups.ts
+++ b/lib/cron-groups.ts
@@ -79,7 +79,7 @@ export const CRON_GROUPS: Record<string, readonly string[]> = {
     "/api/cron/review-sentiment-refresh",
     "/api/cron/versus-editorial-backfill",
   ],
-  "daily-6": ["/api/cron/check-fees", "/api/cron/tmd-audit", "/api/cron/refresh-loan-rates"],
+  "daily-6": ["/api/cron/check-fees", "/api/cron/tmd-audit", "/api/cron/refresh-loan-rates", "/api/cron/snapshot-health-scores"],
   "daily-7": [
     "/api/cron/portfolio-alerts",
     "/api/cron/price-drop-alerts",

--- a/lib/health-score-trends.ts
+++ b/lib/health-score-trends.ts
@@ -1,0 +1,111 @@
+/**
+ * lib/health-score-trends.ts
+ *
+ * Pure helpers for broker health-score trend analysis.
+ *
+ * These functions are intentionally free of Supabase / Next.js dependencies
+ * so they can be exercised in fast unit tests.  Data fetching lives in the
+ * page server component; this module only transforms the result.
+ */
+
+export interface HealthScoreHistoryRow {
+  captured_at: string;
+  overall_score: number;
+  regulatory_score?: number | null;
+  client_money_score?: number | null;
+  financial_stability_score?: number | null;
+  platform_reliability_score?: number | null;
+  insurance_score?: number | null;
+}
+
+/** Direction of change derived from the first vs last data point. */
+export type TrendDirection = "up" | "down" | "flat";
+
+export interface TrendSummary {
+  /** overall_score of the most recent snapshot */
+  latest: number;
+  /** overall_score of the oldest snapshot in the series */
+  earliest: number;
+  /** Point delta: latest − earliest (positive = up, negative = down) */
+  delta: number;
+  /** Human-readable direction */
+  direction: TrendDirection;
+  /** Number of snapshots in the series */
+  count: number;
+}
+
+/**
+ * Summarises the trend from an array of history rows.
+ *
+ * Rows may be in any order — the function sorts by captured_at ascending
+ * internally so callers don't have to guarantee ordering.
+ *
+ * Returns `null` when there are no rows (nothing to summarise).
+ *
+ * The "flat" band is ±1 point to absorb floating-point rounding in the
+ * weighted-average calculation done by the admin tooling.
+ */
+export function summariseTrend(
+  history: readonly HealthScoreHistoryRow[],
+): TrendSummary | null {
+  if (history.length === 0) return null;
+
+  const sorted = [...history].sort(
+    (a, b) =>
+      new Date(a.captured_at).getTime() - new Date(b.captured_at).getTime(),
+  );
+
+  const first = sorted[0];
+  const last = sorted[sorted.length - 1];
+
+  // noUncheckedIndexedAccess guard
+  if (!first || !last) return null;
+
+  const earliest = Number(first.overall_score);
+  const latest = Number(last.overall_score);
+  const delta = latest - earliest;
+
+  let direction: TrendDirection;
+  if (delta > 1) direction = "up";
+  else if (delta < -1) direction = "down";
+  else direction = "flat";
+
+  return { latest, earliest, delta, direction, count: sorted.length };
+}
+
+/**
+ * Normalises a series of overall_score values to the [0, 1] range
+ * for SVG sparkline rendering.
+ *
+ * - Returns an empty array for an empty input.
+ * - When all values are identical the midpoint (0.5) is returned for every
+ *   point so the sparkline renders as a flat centred line rather than
+ *   degenerate zeroes.
+ */
+export function normaliseSparklinePoints(
+  history: readonly HealthScoreHistoryRow[],
+): number[] {
+  if (history.length === 0) return [];
+
+  const sorted = [...history].sort(
+    (a, b) =>
+      new Date(a.captured_at).getTime() - new Date(b.captured_at).getTime(),
+  );
+
+  const scores = sorted.map((r) => Number(r.overall_score));
+  const min = Math.min(...scores);
+  const max = Math.max(...scores);
+
+  if (min === max) return scores.map(() => 0.5);
+
+  return scores.map((s) => (s - min) / (max - min));
+}
+
+/**
+ * Formats a trend delta as a human-readable string, e.g. "+3.0" or "−2.5".
+ * Uses a proper minus sign (U+2212) for negative deltas.
+ */
+export function formatDelta(delta: number): string {
+  const abs = Math.abs(delta).toFixed(1);
+  return delta >= 0 ? `+${abs}` : `−${abs}`;
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -584,6 +584,20 @@ export interface BrokerHealthScore {
   updated_at: string;
 }
 
+// ─── Health score history (time-series for sparkline) ───
+
+export interface BrokerHealthScoreHistory {
+  id: number;
+  broker_slug: string;
+  overall_score: number;
+  regulatory_score: number | null;
+  client_money_score: number | null;
+  financial_stability_score: number | null;
+  platform_reliability_score: number | null;
+  insurance_score: number | null;
+  captured_at: string;
+}
+
 // ─── Feature 9: Regulatory & Tax Change Alerts ───
 
 export interface RegulatoryAlert {

--- a/supabase/migrations/20260802010000_broker_health_score_history.sql
+++ b/supabase/migrations/20260802010000_broker_health_score_history.sql
@@ -1,0 +1,73 @@
+-- Migration: 20260802010000_broker_health_score_history.sql
+--
+-- Creates broker_health_score_history — an append-only time-series table that
+-- snapshots the five health-score dimensions whenever the cron
+-- /api/cron/snapshot-health-scores fires. The data powers the trend sparkline
+-- on the /health-scores/[slug] detail page.
+--
+-- Idempotency: CREATE TABLE IF NOT EXISTS; DROP/CREATE POLICY pairs; IF NOT EXISTS indexes.
+--
+-- Rollback:
+--   DROP TABLE IF EXISTS public.broker_health_score_history;
+--   (RLS policies, indexes, and the initial seed are dropped with the table.)
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.broker_health_score_history (
+  id                          bigint       GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  broker_slug                 text         NOT NULL,
+  overall_score               numeric      NOT NULL,
+  regulatory_score            numeric,
+  client_money_score          numeric,
+  financial_stability_score   numeric,
+  platform_reliability_score  numeric,
+  insurance_score             numeric,
+  captured_at                 timestamptz  NOT NULL DEFAULT now()
+);
+
+-- Public read (same access level as broker_health_scores — factual/informational data
+-- displayed on the public detail page).
+ALTER TABLE public.broker_health_score_history ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.broker_health_score_history FORCE  ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "anon can read health score history" ON public.broker_health_score_history;
+CREATE POLICY "anon can read health score history"
+  ON public.broker_health_score_history
+  FOR SELECT TO anon, authenticated
+  USING (true);
+
+-- Writes are service_role only (cron uses admin client).
+DROP POLICY IF EXISTS "service_role full access" ON public.broker_health_score_history;
+CREATE POLICY "service_role full access"
+  ON public.broker_health_score_history
+  FOR ALL TO service_role
+  USING (true) WITH CHECK (true);
+
+CREATE INDEX IF NOT EXISTS idx_bhsh_slug_captured
+  ON public.broker_health_score_history (broker_slug, captured_at DESC);
+
+-- Seed an initial snapshot from current broker_health_scores so the sparkline
+-- has at least one data point before the cron fires for the first time.
+-- ON CONFLICT is not needed here because we are inserting into the history table
+-- (append-only), not upsert.  The SELECT guard prevents duplicate seeds on
+-- re-run (idempotent: only inserts if no rows exist yet for each slug).
+INSERT INTO public.broker_health_score_history
+  (broker_slug, overall_score, regulatory_score, client_money_score,
+   financial_stability_score, platform_reliability_score, insurance_score,
+   captured_at)
+SELECT
+  bhs.broker_slug,
+  bhs.overall_score,
+  bhs.regulatory_score,
+  bhs.client_money_score,
+  bhs.financial_stability_score,
+  bhs.platform_reliability_score,
+  bhs.insurance_score,
+  COALESCE(bhs.updated_at, now())
+FROM public.broker_health_scores bhs
+WHERE NOT EXISTS (
+  SELECT 1 FROM public.broker_health_score_history h
+  WHERE h.broker_slug = bhs.broker_slug
+);
+
+COMMIT;


### PR DESCRIPTION
Deepens broker health scores from a static snapshot into a **tracked data asset with history + trends**.

- New `broker_health_score_history` table (5 dimensions + overall + `captured_at`; RLS ENABLE+FORCE, anon SELECT for public trend display, service-role write; indexed; idempotent + seeded from current scores).
- New `snapshot-health-scores` cron (`requireCronAuth` first, bulk-inserts a snapshot per run with a shared `captured_at`, `wrapCronHandler`, registered in `lib/cron-groups.ts`).
- `lib/health-score-trends.ts` — pure helpers (`summariseTrend`, `normaliseSparklinePoints`, `formatDelta`).
- The detail page now shows a trend delta badge + an SVG sparkline (same dependency-free approach as `ScoreGauge`) + a "Score History" table.

**Fix on verification:** an unused test counter is now a real assertion (source table read exactly once per run).

**Verified:** `tsc` clean · **25 tests** (18 trend-helper + 7 cron) pass · eslint clean · rate-limit `--strict` pass. Append-only, factual data (AFSL-safe).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUfSRE2Teb6VhEXFP6RpS9)_