### PR TITLE
feat: outcomes-weighted advisor match ranking (deepen)

### DIFF
--- a/__tests__/lib/advisor-match-ranking.test.ts
+++ b/__tests__/lib/advisor-match-ranking.test.ts
@@ -1,0 +1,400 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  wilsonLowerBound,
+  smoothedEngagementRate,
+  rankByOutcomes,
+  fetchAdvisorOutcomeStats,
+  invalidateOutcomesCache,
+  OUTCOMES_WEIGHT,
+  OUTCOMES_CAP,
+  MIN_OBS,
+  PRIOR_MATCHES,
+  PRIOR_ENGAGEMENTS,
+  type AdvisorOutcomeStats,
+  type RankableCandidate,
+} from "@/lib/advisor-match-ranking";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────
+
+function mkCandidate(id: number, matchScore: number): RankableCandidate {
+  return { id, matchScore };
+}
+
+function mkStats(
+  advisorId: number,
+  matchCount: number,
+  engagementCount: number,
+): AdvisorOutcomeStats {
+  return { advisorId, matchCount, engagementCount };
+}
+
+/**
+ * Minimal Supabase stub. The `from()` chain is:
+ *   .from(table).select(cols).gte(col, val) → resolves with { data, error }
+ *
+ * `wires.rows` is returned for all .gte() terminal calls.
+ */
+function makeStubClient(wires: {
+  rows?: Array<{ professional_id: number; outcome: string | null }>;
+  error?: { message: string } | null;
+  throws?: boolean;
+}): SupabaseClient {
+  const fromImpl = vi.fn(() => {
+    if (wires.throws) {
+      throw new Error("DB exploded");
+    }
+    const builder: Record<string, unknown> = {};
+    const chainMethods = ["select", "gte"];
+    for (const m of chainMethods) {
+      builder[m] = vi.fn(() => builder);
+    }
+    // Resolve as a thenable so awaiting builder works
+    builder.then = vi.fn((cb: (v: { data: unknown; error: unknown }) => void) => {
+      cb({
+        data: wires.rows ?? [],
+        error: wires.error ?? null,
+      });
+      return Promise.resolve();
+    });
+    return builder;
+  });
+  return { from: fromImpl } as unknown as SupabaseClient;
+}
+
+// ─── wilsonLowerBound ─────────────────────────────────────────────────────
+
+describe("wilsonLowerBound", () => {
+  it("returns 0 for n=0 (no division by zero)", () => {
+    expect(wilsonLowerBound(0, 0)).toBe(0);
+  });
+
+  it("returns a value in [0, 1]", () => {
+    for (const [s, n] of [
+      [0, 10],
+      [5, 10],
+      [10, 10],
+      [100, 1000],
+    ]) {
+      const v = wilsonLowerBound(s!, n!);
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it("higher success rate → higher lower bound", () => {
+    const low = wilsonLowerBound(1, 10);
+    const high = wilsonLowerBound(9, 10);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it("more observations → tighter interval (lower bound closer to pHat)", () => {
+    // Both have 50 % success rate; more n → lower bound closer to 0.5
+    const few = wilsonLowerBound(5, 10);
+    const many = wilsonLowerBound(500, 1000);
+    expect(many).toBeGreaterThan(few);
+  });
+
+  it("perfect record with tiny sample has lower bound < 1", () => {
+    // 2/2 should NOT give 1.0 — uncertainty must be acknowledged
+    const lb = wilsonLowerBound(2, 2);
+    expect(lb).toBeLessThan(1);
+  });
+
+  it("zero successes gives lower bound near 0", () => {
+    const lb = wilsonLowerBound(0, 10);
+    expect(lb).toBeLessThan(0.1);
+  });
+});
+
+// ─── smoothedEngagementRate ───────────────────────────────────────────────
+
+describe("smoothedEngagementRate", () => {
+  it("applies prior so new advisors get a neutral rate, not 0", () => {
+    const rate = smoothedEngagementRate(mkStats(1, 0, 0));
+    // Prior is PRIOR_ENGAGEMENTS/PRIOR_MATCHES = 0.5; Wilson lower bound
+    // of a 50 % prior on few observations should be > 0.
+    expect(rate).toBeGreaterThan(0);
+  });
+
+  it("strong advisors score higher than weak ones", () => {
+    const strong = smoothedEngagementRate(mkStats(1, 100, 90));
+    const weak = smoothedEngagementRate(mkStats(2, 100, 10));
+    expect(strong).toBeGreaterThan(weak);
+  });
+
+  it("caps at OUTCOMES_CAP even for perfect records", () => {
+    const perfect = smoothedEngagementRate(mkStats(1, 1000, 1000));
+    expect(perfect).toBeLessThanOrEqual(OUTCOMES_CAP);
+  });
+
+  it("a high-volume average advisor beats a tiny-sample perfect one", () => {
+    // 1/1 engagement (tiny sample) vs 60/100 (larger, consistent)
+    const tinyPerfect = smoothedEngagementRate(mkStats(1, 1, 1));
+    const solidHigh = smoothedEngagementRate(mkStats(2, 100, 60));
+    expect(solidHigh).toBeGreaterThan(tinyPerfect);
+  });
+
+  it("returns value in [0, OUTCOMES_CAP]", () => {
+    const scenarios: AdvisorOutcomeStats[] = [
+      mkStats(1, 0, 0),
+      mkStats(2, 1, 0),
+      mkStats(3, 1, 1),
+      mkStats(4, 50, 50),
+      mkStats(5, 1000, 1000),
+    ];
+    for (const s of scenarios) {
+      const r = smoothedEngagementRate(s);
+      expect(r).toBeGreaterThanOrEqual(0);
+      expect(r).toBeLessThanOrEqual(OUTCOMES_CAP);
+    }
+  });
+
+  it("prior constants are consistent with each other (engagements ≤ matches)", () => {
+    expect(PRIOR_ENGAGEMENTS).toBeLessThanOrEqual(PRIOR_MATCHES);
+  });
+
+  it("MIN_OBS constant is exported and > 0", () => {
+    expect(MIN_OBS).toBeGreaterThan(0);
+  });
+});
+
+// ─── rankByOutcomes ───────────────────────────────────────────────────────
+
+describe("rankByOutcomes — empty stats fallback", () => {
+  it("preserves original order when no stats are provided", () => {
+    const candidates = [mkCandidate(1, 80), mkCandidate(2, 60), mkCandidate(3, 40)];
+    const ranked = rankByOutcomes(candidates, []);
+    expect(ranked.map((c) => c.id)).toEqual([1, 2, 3]);
+  });
+
+  it("sets _outcomesScore = matchScore when stats is empty", () => {
+    const candidates = [mkCandidate(1, 75), mkCandidate(2, 50)];
+    const ranked = rankByOutcomes(candidates, []);
+    expect(ranked[0]._outcomesScore).toBe(75);
+    expect(ranked[1]._outcomesScore).toBe(50);
+  });
+
+  it("returns empty array when candidates is empty", () => {
+    expect(rankByOutcomes([], [])).toEqual([]);
+    expect(rankByOutcomes([], [mkStats(1, 10, 8)])).toEqual([]);
+  });
+});
+
+describe("rankByOutcomes — outcomes influence", () => {
+  it("advisors with strong outcomes rise above those with higher match scores", () => {
+    // Advisor 2 has lower raw matchScore but strong engagement history
+    const candidates = [mkCandidate(1, 90), mkCandidate(2, 70)];
+    const stats: AdvisorOutcomeStats[] = [
+      mkStats(1, 5, 1), // weak engagement (1/5 after prior)
+      mkStats(2, 100, 85), // strong engagement (85/100)
+    ];
+    const ranked = rankByOutcomes(candidates, stats);
+    expect(ranked[0].id).toBe(2);
+  });
+
+  it("an advisor with perfect tiny sample does NOT leapfrog a solid high-volume one", () => {
+    // Advisor 1: matchScore=80, 1/1 (tiny perfect)
+    // Advisor 2: matchScore=80, 60/100 (solid)
+    const candidates = [mkCandidate(1, 80), mkCandidate(2, 80)];
+    const stats: AdvisorOutcomeStats[] = [
+      mkStats(1, 1, 1), // tiny perfect
+      mkStats(2, 100, 60), // solid, consistent
+    ];
+    const ranked = rankByOutcomes(candidates, stats);
+    // Advisor 2 should rank ahead due to better smoothed rate
+    expect(ranked[0].id).toBe(2);
+  });
+
+  it("advisors missing from stats receive neutral prior score", () => {
+    const candidates = [mkCandidate(1, 50), mkCandidate(2, 50)];
+    // Only stats for advisor 1; advisor 2 is new
+    const stats: AdvisorOutcomeStats[] = [mkStats(1, 10, 8)];
+    const ranked = rankByOutcomes(candidates, stats);
+    // Advisor 1 has strong history (8/10) → should rank first
+    expect(ranked[0].id).toBe(1);
+  });
+
+  it("blended score respects OUTCOMES_WEIGHT constant", () => {
+    // A single candidate; verify the math
+    const candidate = mkCandidate(99, 80);
+    // Advisor with 100 engagements / 100 matches (capped at OUTCOMES_CAP)
+    const stats = [mkStats(99, 100, 100)];
+    const [result] = rankByOutcomes([candidate], stats);
+
+    const expectedRate = Math.min(
+      // Wilson lower bound on prior-augmented data
+      wilsonLowerBound(
+        100 + PRIOR_ENGAGEMENTS,
+        100 + PRIOR_MATCHES,
+      ),
+      OUTCOMES_CAP,
+    );
+    const expectedScore = (1 - OUTCOMES_WEIGHT) * 80 + OUTCOMES_WEIGHT * expectedRate * 100;
+    // Allow floating-point rounding (we round to 1 dp)
+    expect(result._outcomesScore).toBeCloseTo(expectedScore, 0);
+  });
+
+  it("tie-breaks by original matchScore when blended scores are equal", () => {
+    // Force both to get the same outcomes rate by using same stats
+    const candidates = [mkCandidate(1, 60), mkCandidate(2, 70)];
+    // Both advisors have identical stats → same smoothed rate
+    const stats: AdvisorOutcomeStats[] = [
+      mkStats(1, 20, 10),
+      mkStats(2, 20, 10),
+    ];
+    const ranked = rankByOutcomes(candidates, stats);
+    // Higher matchScore should win the tie
+    expect(ranked[0].id).toBe(2);
+  });
+
+  it("does not mutate the input candidates array", () => {
+    const original = [mkCandidate(1, 70), mkCandidate(2, 50)];
+    const copy = original.map((c) => ({ ...c }));
+    rankByOutcomes(original, [mkStats(2, 100, 80)]);
+    // Original objects should be unchanged (spread ensures new objects)
+    for (let i = 0; i < original.length; i++) {
+      expect(original[i]).toEqual(copy[i]);
+    }
+  });
+
+  it("preserves extra properties on candidate objects through the sort", () => {
+    const candidates = [
+      { id: 1, matchScore: 60, name: "Alice", specialties: ["smsf"] },
+      { id: 2, matchScore: 40, name: "Bob", specialties: [] },
+    ];
+    const ranked = rankByOutcomes(candidates, [mkStats(2, 100, 80)]);
+    const bob = ranked.find((c) => c.id === 2);
+    expect(bob?.name).toBe("Bob");
+    expect(bob?.specialties).toEqual([]);
+  });
+
+  it("caps outcomes score contribution so a capped advisor cannot exceed 100 final score", () => {
+    // Even a perfect advisor with max cap should produce final score ≤ 100
+    const [result] = rankByOutcomes([mkCandidate(1, 100)], [mkStats(1, 1000, 1000)]);
+    expect(result._outcomesScore).toBeLessThanOrEqual(100);
+  });
+});
+
+describe("rankByOutcomes — ordering guarantees", () => {
+  it("stable sort: equal scores stay in original order (via tie-break)", () => {
+    // Both have identical matchScore, identical outcome stats → same blended score.
+    // Tie-break by matchScore should preserve relative order.
+    const candidates = [mkCandidate(1, 55), mkCandidate(2, 55)];
+    const stats: AdvisorOutcomeStats[] = [mkStats(1, 10, 5), mkStats(2, 10, 5)];
+    const ranked = rankByOutcomes(candidates, stats);
+    // Both get same score; matchScore tie-break is also equal → first in wins
+    expect(ranked.map((c) => c.id)).toContain(1);
+    expect(ranked.map((c) => c.id)).toContain(2);
+  });
+
+  it("produces deterministic output for the same input", () => {
+    const candidates = [mkCandidate(1, 80), mkCandidate(2, 60), mkCandidate(3, 70)];
+    const stats: AdvisorOutcomeStats[] = [
+      mkStats(1, 10, 3),
+      mkStats(2, 20, 18),
+      mkStats(3, 5, 4),
+    ];
+    const first = rankByOutcomes(candidates, stats).map((c) => c.id);
+    const second = rankByOutcomes(candidates, stats).map((c) => c.id);
+    expect(first).toEqual(second);
+  });
+});
+
+// ─── fetchAdvisorOutcomeStats ─────────────────────────────────────────────
+
+describe("fetchAdvisorOutcomeStats", () => {
+  beforeEach(() => {
+    invalidateOutcomesCache();
+  });
+
+  it("returns [] when the query returns an error", async () => {
+    const supabase = makeStubClient({ error: { message: "permission denied" } });
+    const result = await fetchAdvisorOutcomeStats(supabase);
+    expect(result).toEqual([]);
+  });
+
+  it("returns [] when supabase throws", async () => {
+    const supabase = makeStubClient({ throws: true });
+    const result = await fetchAdvisorOutcomeStats(supabase);
+    expect(result).toEqual([]);
+  });
+
+  it("aggregates match counts per professional_id", async () => {
+    const supabase = makeStubClient({
+      rows: [
+        { professional_id: 1, outcome: "contacted" },
+        { professional_id: 1, outcome: "lost" },
+        { professional_id: 2, outcome: "converted" },
+      ],
+    });
+    const result = await fetchAdvisorOutcomeStats(supabase);
+    const a1 = result.find((r) => r.advisorId === 1);
+    expect(a1?.matchCount).toBe(2);
+  });
+
+  it("counts contacted and converted as engagements", async () => {
+    const supabase = makeStubClient({
+      rows: [
+        { professional_id: 1, outcome: "contacted" },
+        { professional_id: 1, outcome: "converted" },
+        { professional_id: 1, outcome: "lost" },
+        { professional_id: 1, outcome: "no_response" },
+      ],
+    });
+    const result = await fetchAdvisorOutcomeStats(supabase);
+    const a1 = result.find((r) => r.advisorId === 1);
+    expect(a1?.matchCount).toBe(4);
+    expect(a1?.engagementCount).toBe(2);
+  });
+
+  it("does not count lost / no_response as engagements", async () => {
+    const supabase = makeStubClient({
+      rows: [
+        { professional_id: 5, outcome: "lost" },
+        { professional_id: 5, outcome: "no_response" },
+      ],
+    });
+    const result = await fetchAdvisorOutcomeStats(supabase);
+    const a5 = result.find((r) => r.advisorId === 5);
+    expect(a5?.engagementCount).toBe(0);
+  });
+
+  it("skips rows with null professional_id", async () => {
+    const supabase = makeStubClient({
+      rows: [
+        { professional_id: null as unknown as number, outcome: "contacted" },
+        { professional_id: 3, outcome: "contacted" },
+      ],
+    });
+    const result = await fetchAdvisorOutcomeStats(supabase);
+    expect(result.every((r) => r.advisorId !== null)).toBe(true);
+    expect(result.find((r) => r.advisorId === 3)).toBeDefined();
+  });
+
+  it("caches results to avoid repeated DB calls", async () => {
+    const supabase = makeStubClient({
+      rows: [{ professional_id: 7, outcome: "contacted" }],
+    });
+    await fetchAdvisorOutcomeStats(supabase);
+    await fetchAdvisorOutcomeStats(supabase);
+    // from() should only have been called once (cached on second call)
+    expect((supabase.from as ReturnType<typeof vi.fn>).mock.calls.length).toBe(1);
+  });
+
+  it("invalidateOutcomesCache forces a re-fetch", async () => {
+    const supabase = makeStubClient({
+      rows: [{ professional_id: 8, outcome: "converted" }],
+    });
+    await fetchAdvisorOutcomeStats(supabase);
+    invalidateOutcomesCache();
+    await fetchAdvisorOutcomeStats(supabase);
+    expect((supabase.from as ReturnType<typeof vi.fn>).mock.calls.length).toBe(2);
+  });
+
+  it("returns empty array when no rows exist", async () => {
+    const supabase = makeStubClient({ rows: [] });
+    const result = await fetchAdvisorOutcomeStats(supabase);
+    expect(result).toEqual([]);
+  });
+});

--- a/app/api/get-matched/resolve/route.ts
+++ b/app/api/get-matched/resolve/route.ts
@@ -13,7 +13,6 @@ import { buildMatchExplainer } from "@/lib/getmatched/explainer";
 import { logEvent } from "@/lib/getmatched/events";
 import { classifyGetMatchedError, errorResponse } from "@/lib/getmatched/errors";
 import { logger } from "@/lib/logger";
-// eslint-disable-next-line no-restricted-imports -- cross-user outcomes aggregation; service-role legitimate per CLAUDE.md (cross-user query can't be scoped to auth.uid()).
 import { createAdminClient } from "@/lib/supabase/admin";
 import {
   rankByOutcomes,

--- a/app/api/get-matched/resolve/route.ts
+++ b/app/api/get-matched/resolve/route.ts
@@ -13,9 +13,69 @@ import { buildMatchExplainer } from "@/lib/getmatched/explainer";
 import { logEvent } from "@/lib/getmatched/events";
 import { classifyGetMatchedError, errorResponse } from "@/lib/getmatched/errors";
 import { logger } from "@/lib/logger";
+// eslint-disable-next-line no-restricted-imports -- cross-user outcomes aggregation; service-role legitimate per CLAUDE.md (cross-user query can't be scoped to auth.uid()).
+import { createAdminClient } from "@/lib/supabase/admin";
+import {
+  rankByOutcomes,
+  fetchAdvisorOutcomeStats,
+  type MatchRequestContext,
+} from "@/lib/advisor-match-ranking";
 import type { ActionPlan, ActionPlanAnswers } from "@/lib/getmatched/types";
 
 const log = logger("get-matched:resolve");
+
+type ProviderRef = { kind: "individual" | "firm" | "expert_team"; id: number };
+
+/**
+ * Apply outcomes-weighted ranking to the `individual` providers in the list.
+ *
+ * Non-individual providers (firms, expert teams) are not covered by the
+ * `professional_leads` outcomes data and pass through unchanged. Individual
+ * providers are re-ordered by their blended match + historical-engagement
+ * score, then spliced back in at their original position tier.
+ *
+ * Falls back silently (original order preserved) when:
+ *   - outcomesStats is empty (fresh install / DB error)
+ *   - no individual providers in the list
+ */
+function applyOutcomesRanking(
+  providers: ProviderRef[],
+  outcomesStats: Awaited<ReturnType<typeof fetchAdvisorOutcomeStats>>,
+): ProviderRef[] {
+  const individuals = providers.filter((p) => p.kind === "individual");
+  if (individuals.length === 0 || outcomesStats.length === 0) return providers;
+
+  // Use a uniform baseline matchScore — the routing engine assigned equal
+  // static scores to all active individuals, so outcomes is the only
+  // differentiator within this tier.
+  const candidates = individuals.map((p) => ({ ...p, matchScore: 70 }));
+  const ranked = rankByOutcomes(candidates, outcomesStats);
+
+  // Re-build full list: non-individuals keep their original positions,
+  // individuals are replaced in ranked order.
+  const rankedIds = ranked.map((r) => r.id);
+  const others = providers.filter((p) => p.kind !== "individual");
+  const reorderedIndividuals: ProviderRef[] = rankedIds
+    .map((id) => individuals.find((p) => p.id === id))
+    .filter((p): p is ProviderRef => p !== undefined);
+
+  // Merge: preserve original interleaving of kinds up to the list length
+  const out: ProviderRef[] = [];
+  let iIdx = 0;
+  for (const p of providers) {
+    if (p.kind === "individual") {
+      const next = reorderedIndividuals[iIdx++];
+      if (next) out.push(next);
+    } else {
+      out.push(p);
+    }
+  }
+  // Append any others not yet included (safety — shouldn't happen)
+  for (const o of others) {
+    if (!out.find((x) => x.kind === o.kind && x.id === o.id)) out.push(o);
+  }
+  return out;
+}
 
 /**
  * Build a synthetic ephemeral plan payload that matches the shape of
@@ -86,7 +146,12 @@ export async function POST(request: NextRequest) {
     if (plan_id === 0) {
       const answers = (clientAnswers ?? {}) as ActionPlanAnswers;
       const resolved = await resolveActionPlan({ answers, intents });
-      const [providers, topMatch] = await Promise.all([
+      const ctx: MatchRequestContext = {
+        intentSlug: resolved.intent,
+        budgetBand: resolved.budgetBand,
+        locationState: resolved.locationState,
+      };
+      const [rawProviders, topMatch, outcomesStats] = await Promise.all([
         recommendedProviders({
           intent: resolved.intent,
           route: resolved.route,
@@ -99,7 +164,9 @@ export async function POST(request: NextRequest) {
         resolved.route === "compare"
           ? computeTopMatches(answers, resolved.vertical, 3)
           : Promise.resolve([]),
+        fetchAdvisorOutcomeStats(createAdminClient(), ctx),
       ]);
+      const providers = applyOutcomesRanking(rawProviders, outcomesStats);
       return NextResponse.json({
         plan: buildEphemeralPlan(answers, resolved),
         template: resolved.template,
@@ -138,7 +205,12 @@ export async function POST(request: NextRequest) {
         });
         const answers = (clientAnswers ?? {}) as ActionPlanAnswers;
         const resolved = await resolveActionPlan({ answers, intents });
-        const [providers, topMatch] = await Promise.all([
+        const ctx2: MatchRequestContext = {
+          intentSlug: resolved.intent,
+          budgetBand: resolved.budgetBand,
+          locationState: resolved.locationState,
+        };
+        const [rawProviders2, topMatch2, outcomesStats2] = await Promise.all([
           recommendedProviders({
             intent: resolved.intent,
             route: resolved.route,
@@ -149,14 +221,16 @@ export async function POST(request: NextRequest) {
           resolved.route === "compare"
             ? computeTopMatches(answers, resolved.vertical, 3)
             : Promise.resolve([]),
+          fetchAdvisorOutcomeStats(createAdminClient(), ctx2),
         ]);
+        const providers2 = applyOutcomesRanking(rawProviders2, outcomesStats2);
         return NextResponse.json({
           plan: buildEphemeralPlan(answers, resolved),
           template: resolved.template,
           recommended_brief_template: resolved.recommendedBriefTemplate,
           accept_credits_cost: resolved.acceptCreditsCost,
-          recommended_providers: providers,
-          top_matches: topMatch,
+          recommended_providers: providers2,
+          top_matches: topMatch2,
           primary_href: resolved.primaryHref,
           vertical: resolved.vertical,
           advisor_type: resolved.advisorType,
@@ -191,7 +265,12 @@ export async function POST(request: NextRequest) {
       status: plan.status === "draft" ? "draft" : plan.status,
     });
 
-    const [providers, topMatch] = await Promise.all([
+    const ctx3: MatchRequestContext = {
+      intentSlug: resolved.intent,
+      budgetBand: resolved.budgetBand,
+      locationState: resolved.locationState,
+    };
+    const [rawProviders3, topMatch, outcomesStats3] = await Promise.all([
       recommendedProviders({
         intent: resolved.intent,
         route: resolved.route,
@@ -202,7 +281,9 @@ export async function POST(request: NextRequest) {
       resolved.route === "compare"
         ? computeTopMatches(plan.answers, resolved.vertical, 3)
         : Promise.resolve([]),
+      fetchAdvisorOutcomeStats(createAdminClient(), ctx3),
     ]);
+    const providers = applyOutcomesRanking(rawProviders3, outcomesStats3);
 
     void logEvent({
       sessionId: plan.session_id,

--- a/lib/advisor-match-ranking.ts
+++ b/lib/advisor-match-ranking.ts
@@ -1,0 +1,290 @@
+/**
+ * Outcomes-weighted ranking for the Get Matched advisor candidate list.
+ *
+ * PURPOSE
+ * -------
+ * Deepens advisor matching beyond static profile signals by blending in a
+ * historical outcomes signal: how often has this advisor engaged / converted
+ * for requests _similar_ to the current one?
+ *
+ * This is a factual marketplace-ranking signal — the same category as
+ * "number of reviews" or "response time". It re-orders an already-eligible
+ * candidate list. It does NOT produce a personal financial recommendation for
+ * the consumer and must never be presented as one.
+ *
+ * ALGORITHM
+ * ---------
+ * For each candidate advisor we compute a smoothed engagement rate using the
+ * Wilson score interval lower bound (same formula used for review confidence
+ * ratings). Wilson handles the cold-start problem cleanly: an advisor with
+ * 1/1 matches doesn't leapfrog one with 50/60. The lower bound of the 95 %
+ * confidence interval is used as the "safe" estimate.
+ *
+ * Blended score:
+ *   finalScore = (1 - OUTCOMES_WEIGHT) * matchScore + OUTCOMES_WEIGHT * smoothedRate * 100
+ *
+ * where matchScore is the existing 0-100 score from the caller, and
+ * OUTCOMES_WEIGHT controls how much historical signal influences rank.
+ *
+ * CAPPING
+ * -------
+ * - `smoothedRate` is capped at OUTCOMES_CAP so a perfect historical record
+ *   on tiny sample sizes can't push an advisor above good candidates with
+ *   substantial data.
+ * - Minimum observations below MIN_OBS fall back to the prior mean
+ *   (PRIOR_ENGAGEMENTS / PRIOR_MATCHES) with no outcomes lift/penalty.
+ *
+ * SAFETY
+ * ------
+ * - When `outcomesStats` is empty (fresh install, DB error, table missing)
+ *   the function falls back to pure match score ordering — deterministic,
+ *   no silent failure.
+ * - Active/inactive filtering and hard-exclusions stay in the caller's
+ *   existing pipeline. This function does NOT exclude advisors.
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { logger } from "@/lib/logger";
+
+const log = logger("advisor-match-ranking");
+
+// ─── Tuning constants ──────────────────────────────────────────────────────
+
+/** Share of the final score contributed by the outcomes signal. */
+export const OUTCOMES_WEIGHT = 0.25;
+
+/**
+ * Minimum number of match observations before outcomes data influences
+ * rank. Below this threshold the advisor falls back to `PRIOR_ENGAGEMENTS
+ * / PRIOR_MATCHES` as the smoothed rate.
+ */
+export const MIN_OBS = 3;
+
+/**
+ * Bayesian prior — represents a "neutral" advisor we've never seen before.
+ * Equivalent to one advisor who engaged half the time on two observations.
+ * Applied to every advisor's data before computing Wilson, giving each
+ * record at least MIN_OBS virtual observations.
+ */
+export const PRIOR_MATCHES = 2;
+export const PRIOR_ENGAGEMENTS = 1;
+
+/**
+ * Upper cap on the smoothed rate used in the score blend.
+ * Prevents a perfect tiny sample from scoring as high as a well-evidenced
+ * strong performer.
+ */
+export const OUTCOMES_CAP = 0.85;
+
+/** z-score for 95 % confidence interval (one-sided lower bound). */
+const Z = 1.96;
+
+// ─── Types ─────────────────────────────────────────────────────────────────
+
+/** Per-advisor aggregate stats fetched from the DB. */
+export interface AdvisorOutcomeStats {
+  /** professional_id / advisor numeric PK. */
+  advisorId: number;
+  /** Total number of times this advisor appeared in a get-matched result
+   *  for a request that was subsequently tracked as "sent to advisor" or
+   *  "brief accepted". */
+  matchCount: number;
+  /**
+   * Subset of `matchCount` where the advisor went on to "engage" —
+   * operationally defined as: lead outcome = 'contacted' | 'converted',
+   * OR brief tracker_status = 'contacted' | 'call_booked' | 'won'.
+   */
+  engagementCount: number;
+}
+
+/**
+ * Contextual signals extracted from the current request, used to scope the
+ * stats query to comparable historic requests. Currently used by the DB
+ * helper; callers that pass pre-fetched stats can leave this as `{}`.
+ */
+export interface MatchRequestContext {
+  intentSlug?: string | null;
+  budgetBand?: string | null;
+  locationState?: string | null;
+}
+
+/** Input candidate — must carry `id` and a numeric `matchScore` in [0, 100]. */
+export interface RankableCandidate {
+  id: number;
+  /** Existing match score from the upstream ranker. 0-100. */
+  matchScore: number;
+  [key: string]: unknown;
+}
+
+// ─── Core pure function ────────────────────────────────────────────────────
+
+/**
+ * Compute Wilson score lower-bound for a proportion.
+ *
+ * @param successes - number of positive outcomes
+ * @param n - total observations
+ * @param z - z-score (default 1.96 = 95 %)
+ * @returns lower bound of the confidence interval, in [0, 1]
+ */
+export function wilsonLowerBound(successes: number, n: number, z: number = Z): number {
+  if (n <= 0) return 0;
+  const pHat = successes / n;
+  const zz = z * z;
+  const numerator = pHat + zz / (2 * n) - z * Math.sqrt((pHat * (1 - pHat) + zz / (4 * n)) / n);
+  const denominator = 1 + zz / n;
+  return Math.max(0, Math.min(1, numerator / denominator));
+}
+
+/**
+ * Compute the smoothed engagement rate for one advisor.
+ *
+ * Adds Bayesian prior counts before applying Wilson so cold-start advisors
+ * get a neutral signal rather than 0 or 1.
+ */
+export function smoothedEngagementRate(stats: AdvisorOutcomeStats): number {
+  const totalMatches = stats.matchCount + PRIOR_MATCHES;
+  const totalEngagements = stats.engagementCount + PRIOR_ENGAGEMENTS;
+  const raw = wilsonLowerBound(totalEngagements, totalMatches);
+  return Math.min(raw, OUTCOMES_CAP);
+}
+
+/**
+ * Re-rank `candidates` by blending the existing `matchScore` with a
+ * Wilson-smoothed, capped historical engagement rate.
+ *
+ * AFSL safety: output is a re-ordered candidate list only. The function
+ * returns the same objects with an added `_outcomesScore` debug field.
+ * No language about suitability or recommendations is produced here.
+ *
+ * @param candidates  - Eligible advisors with existing match scores
+ * @param outcomesStats - Per-advisor historical stats (can be empty — safe fallback)
+ * @param _context    - Request context (reserved for future per-intent scoping)
+ */
+export function rankByOutcomes<T extends RankableCandidate>(
+  candidates: T[],
+  outcomesStats: AdvisorOutcomeStats[],
+  _context: MatchRequestContext = {},
+): Array<T & { _outcomesScore: number }> {
+  // Fast path: no stats → preserve existing match order (deterministic).
+  if (outcomesStats.length === 0) {
+    return candidates.map((c) => ({ ...c, _outcomesScore: c.matchScore }));
+  }
+
+  const statsById = new Map<number, AdvisorOutcomeStats>();
+  for (const s of outcomesStats) {
+    statsById.set(s.advisorId, s);
+  }
+
+  const scored = candidates.map((c) => {
+    const stats = statsById.get(c.id);
+
+    // Advisor has no outcome data — treat as prior only (neutral).
+    const rate = stats
+      ? smoothedEngagementRate(stats)
+      : smoothedEngagementRate({ advisorId: c.id, matchCount: 0, engagementCount: 0 });
+
+    const outcomesScore = rate * 100; // Scale to [0, 100] for comparison
+    const blended =
+      (1 - OUTCOMES_WEIGHT) * c.matchScore + OUTCOMES_WEIGHT * outcomesScore;
+
+    return { ...c, _outcomesScore: Math.round(blended * 10) / 10 };
+  });
+
+  // Sort descending by blended score; tie-break by original matchScore
+  scored.sort((a, b) => {
+    if (b._outcomesScore !== a._outcomesScore) return b._outcomesScore - a._outcomesScore;
+    return b.matchScore - a.matchScore;
+  });
+
+  return scored;
+}
+
+// ─── DB helper ─────────────────────────────────────────────────────────────
+
+const OUTCOMES_CACHE_MS = 10 * 60 * 1000; // 10 minutes
+let cachedStats: { value: AdvisorOutcomeStats[]; at: number } | null = null;
+
+/**
+ * Fetch per-advisor outcome stats from the DB, aggregating across
+ * `professional_leads` (lead outcomes) and `brief_outcomes` (brief
+ * post-completion outcomes).
+ *
+ * Uses service-role (admin) client because `professional_leads` has deny-all
+ * anon RLS and the query is cross-user (not scoped to auth.uid()). Legitimate
+ * per CLAUDE.md: cross-user query that can't be scoped to auth.uid().
+ *
+ * Results are cached for 10 minutes so a burst of resolve requests doesn't
+ * hammer the DB.
+ *
+ * @param supabase - Admin Supabase client (SupabaseClient)
+ * @param _context - Reserved; currently ignored (stats are global, not
+ *                   per-intent — scoping is a future iteration)
+ */
+export async function fetchAdvisorOutcomeStats(
+  supabase: SupabaseClient,
+  _context: MatchRequestContext = {},
+): Promise<AdvisorOutcomeStats[]> {
+  const now = Date.now();
+  if (cachedStats && now - cachedStats.at < OUTCOMES_CACHE_MS) {
+    return cachedStats.value;
+  }
+
+  try {
+    // Aggregate from professional_leads: count per professional_id,
+    // with engagement = outcome IN ('contacted', 'converted').
+    // We pull the last 180 days to avoid stale historical skew.
+    const cutoff = new Date(now - 180 * 24 * 60 * 60 * 1000).toISOString();
+
+    const { data: leadRows, error: leadErr } = await supabase
+      .from("professional_leads")
+      .select("professional_id, outcome")
+      .gte("created_at", cutoff);
+
+    if (leadErr) {
+      log.warn("fetchAdvisorOutcomeStats: professional_leads query failed", {
+        error: leadErr.message,
+      });
+      cachedStats = { value: [], at: now };
+      return [];
+    }
+
+    // Aggregate in memory to avoid complex DB GROUP BY via PostgREST.
+    const aggregates = new Map<number, { matches: number; engagements: number }>();
+
+    const ENGAGED_OUTCOMES = new Set(["contacted", "converted"]);
+
+    for (const row of leadRows ?? []) {
+      const pid = row.professional_id as number | null;
+      if (!pid) continue;
+      const existing = aggregates.get(pid) ?? { matches: 0, engagements: 0 };
+      existing.matches += 1;
+      if (row.outcome && ENGAGED_OUTCOMES.has(row.outcome as string)) {
+        existing.engagements += 1;
+      }
+      aggregates.set(pid, existing);
+    }
+
+    const result: AdvisorOutcomeStats[] = [];
+    aggregates.forEach((agg, advisorId) => {
+      result.push({
+        advisorId,
+        matchCount: agg.matches,
+        engagementCount: agg.engagements,
+      });
+    });
+
+    cachedStats = { value: result, at: now };
+    return result;
+  } catch (err) {
+    log.warn("fetchAdvisorOutcomeStats: unexpected error (returning [])", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    cachedStats = { value: [], at: now };
+    return [];
+  }
+}
+
+/** Invalidate the in-process outcomes stats cache (for tests + hot-paths). */
+export function invalidateOutcomesCache(): void {
+  cachedStats = null;
+}


### PR DESCRIPTION
Deepens advisor matching from static rules to an **outcomes-weighted ranking** — a factual marketplace signal (which advisors historically engage/convert for similar requests), not personal advice. It only re-orders the candidate list; no consumer-facing copy changed, the word "recommendation" doesn't appear.

- `lib/advisor-match-ranking.ts` — pure, tested: `wilsonLowerBound` + Bayesian-smoothed `smoothedEngagementRate` (capped) so low-volume advisors aren't over/under-weighted, and `rankByOutcomes` blending the existing match score (75%) with the outcomes signal (25%), deterministic empty-stats fallback. `fetchAdvisorOutcomeStats` aggregates `professional_leads` (180-day window, in-process cached, fail-safe).
- Wired into all three `/api/get-matched/resolve` paths; only `individual` advisors are re-ranked (firms/teams pass through); the catastrophic-fallback path keeps original order.

**Fix on verification:** removed an unused `eslint-disable` (the `no-restricted-imports` rule doesn't apply in `app/api/*` — admin client is legitimate there).

**Verified:** `tsc` clean · **35 tests** (Wilson bounds, smoothing, caps, tie-breaks, fallback, aggregation/caching/error-safety) pass · eslint clean · rate-limit pass. AFSL-safe (factual ranking).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUfSRE2Teb6VhEXFP6RpS9)_