### PR TITLE
feat: verified-advisor badges on forum posts (deepen)

### DIFF
--- a/__tests__/lib/forum-author-badges.test.ts
+++ b/__tests__/lib/forum-author-badges.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * Tests for lib/forum-author-badges.ts — resolveAdvisorBadges().
+ *
+ * The helper does a cross-user SELECT on the `professionals` table via the
+ * admin client (service-role; documented exception in CLAUDE.md). These tests
+ * mock that client to cover:
+ *   - empty input → short-circuit, no DB call
+ *   - active + verified professionals → returned in the map
+ *   - professionals with NULL auth_user_id → omitted
+ *   - non-active or non-verified professionals → omitted by the query filter
+ *   - DB error → empty map returned (fail-safe, non-critical path)
+ *   - thrown exception → empty map returned
+ */
+
+/* ── hoisted mocks (must be before imports) ─────────────────────────── */
+
+const {
+  mockFrom,
+  mockSelect,
+  mockIn,
+  mockEq,
+  mockQueryResult,
+  mockThrow,
+} = vi.hoisted(() => {
+  const mockQueryResult = { data: null as unknown, error: null as unknown };
+  const mockThrow = { active: false };
+
+  const mockEq = vi.fn();
+  const mockIn = vi.fn();
+  const mockSelect = vi.fn();
+  const mockFrom = vi.fn();
+
+  // Wire the fluent chain: from() → select() → in() → eq() → eq()
+  // The second .eq() call returns the terminal promise.
+  mockEq.mockImplementation(() => {
+    // Track call count; second eq() resolves the query.
+    const callCount = mockEq.mock.calls.length;
+    if (callCount >= 2) {
+      if (mockThrow.active) {
+        mockThrow.active = false;
+        throw new Error("simulated DB throw inside eq()");
+      }
+      return Promise.resolve(mockQueryResult);
+    }
+    return { eq: mockEq };
+  });
+
+  mockIn.mockReturnValue({ eq: mockEq });
+  mockSelect.mockReturnValue({ in: mockIn });
+  mockFrom.mockReturnValue({ select: mockSelect });
+
+  return { mockFrom, mockSelect, mockIn, mockEq, mockQueryResult, mockThrow };
+});
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({ from: mockFrom }),
+}));
+
+import { resolveAdvisorBadges } from "@/lib/forum-author-badges";
+
+/* ── helpers ─────────────────────────────────────────────────────────── */
+
+function resetChain() {
+  mockEq.mockReset();
+  mockIn.mockReset();
+  mockSelect.mockReset();
+  mockFrom.mockReset();
+
+  mockEq.mockImplementation(() => {
+    const callCount = mockEq.mock.calls.length;
+    if (callCount >= 2) {
+      if (mockThrow.active) {
+        mockThrow.active = false;
+        throw new Error("simulated DB throw");
+      }
+      return Promise.resolve(mockQueryResult);
+    }
+    return { eq: mockEq };
+  });
+  mockIn.mockReturnValue({ eq: mockEq });
+  mockSelect.mockReturnValue({ in: mockIn });
+  mockFrom.mockReturnValue({ select: mockSelect });
+}
+
+/* ── tests ───────────────────────────────────────────────────────────── */
+
+describe("resolveAdvisorBadges", () => {
+  beforeEach(() => {
+    resetChain();
+    mockQueryResult.data = null;
+    mockQueryResult.error = null;
+    mockThrow.active = false;
+  });
+
+  it("returns an empty map immediately for an empty input, without hitting the DB", async () => {
+    const result = await resolveAdvisorBadges([]);
+    expect(result.size).toBe(0);
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  it("returns verified active professionals in the map", async () => {
+    mockQueryResult.data = [
+      {
+        auth_user_id: "uid-advisor-1",
+        slug: "jane-financial-planner",
+        type: "financial_planner",
+      },
+      {
+        auth_user_id: "uid-advisor-2",
+        slug: "bob-tax-agent",
+        type: "tax_agent",
+      },
+    ];
+    mockQueryResult.error = null;
+
+    const result = await resolveAdvisorBadges(["uid-advisor-1", "uid-advisor-2", "uid-regular-user"]);
+
+    expect(result.size).toBe(2);
+    expect(result.get("uid-advisor-1")).toEqual({
+      slug: "jane-financial-planner",
+      type: "financial_planner",
+    });
+    expect(result.get("uid-advisor-2")).toEqual({
+      slug: "bob-tax-agent",
+      type: "tax_agent",
+    });
+    // Regular forum user is not in the map
+    expect(result.has("uid-regular-user")).toBe(false);
+  });
+
+  it("omits rows with a NULL auth_user_id", async () => {
+    mockQueryResult.data = [
+      { auth_user_id: null, slug: "orphan-advisor", type: "financial_planner" },
+      { auth_user_id: "uid-good", slug: "good-advisor", type: "mortgage_broker" },
+    ];
+    mockQueryResult.error = null;
+
+    const result = await resolveAdvisorBadges(["uid-good"]);
+    expect(result.size).toBe(1);
+    expect(result.has("uid-good")).toBe(true);
+  });
+
+  it("returns an empty map when the DB returns an error", async () => {
+    mockQueryResult.data = null;
+    mockQueryResult.error = { message: "DB error", code: "PGRST999" };
+
+    const result = await resolveAdvisorBadges(["uid-someone"]);
+    expect(result.size).toBe(0);
+  });
+
+  it("returns an empty map when the DB returns null data", async () => {
+    mockQueryResult.data = null;
+    mockQueryResult.error = null;
+
+    const result = await resolveAdvisorBadges(["uid-someone"]);
+    expect(result.size).toBe(0);
+  });
+
+  it("returns an empty map when an exception is thrown (fail-safe)", async () => {
+    // Force eq() to throw on the second call (the DB resolution point).
+    mockThrow.active = true;
+
+    const result = await resolveAdvisorBadges(["uid-boom"]);
+    expect(result.size).toBe(0);
+  });
+
+  it("queries professionals using the correct columns and filters", async () => {
+    mockQueryResult.data = [];
+    mockQueryResult.error = null;
+
+    await resolveAdvisorBadges(["uid-a", "uid-b"]);
+
+    expect(mockFrom).toHaveBeenCalledWith("professionals");
+    expect(mockSelect).toHaveBeenCalledWith("auth_user_id, slug, type");
+    expect(mockIn).toHaveBeenCalledWith("auth_user_id", ["uid-a", "uid-b"]);
+    // eq() called twice: status='active' and verified=true
+    expect(mockEq).toHaveBeenCalledWith("status", "active");
+    expect(mockEq).toHaveBeenCalledWith("verified", true);
+  });
+});

--- a/app/community/[category]/[threadId]/page.tsx
+++ b/app/community/[category]/[threadId]/page.tsx
@@ -1,6 +1,7 @@
 import { createClient } from "@/lib/supabase/server";
 import { absoluteUrl, breadcrumbJsonLd } from "@/lib/seo";
 import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
+import { resolveAdvisorBadges } from "@/lib/forum-author-badges";
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import Icon from "@/components/Icon";
@@ -192,20 +193,14 @@ export default async function ThreadPage({
     }
   }
 
-  // Overlay verified advisor data where professionals have linked their auth account
+  // Overlay verified advisor data where professionals have linked their auth account.
+  // Uses the dedicated cross-user helper which holds the admin client behind the
+  // documented service-role exception (see lib/forum-author-badges.ts for rationale).
   const authorIdList = Array.from(authorIds);
-  const { data: linkedProfessionals } = await supabase
-    .from("professionals")
-    .select("auth_user_id, slug, type")
-    .in("auth_user_id", authorIdList)
-    .eq("status", "active");
-
-  if (linkedProfessionals) {
-    for (const pro of linkedProfessionals) {
-      const uid = pro.auth_user_id as string;
-      if (profileMap[uid]) {
-        profileMap[uid].verified_advisor = { slug: pro.slug as string, type: pro.type as string };
-      }
+  const advisorBadges = await resolveAdvisorBadges(authorIdList);
+  for (const [uid, badge] of advisorBadges) {
+    if (profileMap[uid]) {
+      profileMap[uid].verified_advisor = badge;
     }
   }
 

--- a/lib/forum-author-badges.ts
+++ b/lib/forum-author-badges.ts
@@ -1,0 +1,82 @@
+/**
+ * Forum author badge resolution — verified-advisor attribution.
+ *
+ * Given a set of forum author user-IDs (from `forum_threads.author_id` or
+ * `forum_posts.author_id`), returns a map of which authors hold an active
+ * verified-professional profile on the site, along with their public slug
+ * and professional type.
+ *
+ * This is ATTRIBUTION ONLY — factual ("does this forum account belong to an
+ * advisor in our directory?"). It is NOT a financial-advice intake or
+ * endorsement surface. Any render site that uses this helper MUST display
+ * the `GENERAL_ADVICE_WARNING` from `lib/compliance.ts` alongside attributed
+ * posts (see `app/community/[category]/[threadId]/page.tsx`).
+ *
+ * Why admin client?
+ * The `professionals` table's RLS allows an advisor to read their own row
+ * (auth_user_id = auth.uid()) but does NOT grant anonymous/public SELECT on
+ * all rows by user-id list. This lookup is a cross-user query — we receive
+ * an arbitrary set of forum author user-IDs and need to resolve any that
+ * happen to be advisors. That falls squarely in the documented service-role-
+ * legitimate exception in CLAUDE.md under "lib/* helpers doing cross-user
+ * queries that can't be scoped to auth.uid()".
+ */
+
+// eslint-disable-next-line no-restricted-imports -- Cross-user query: resolves forum author user-IDs against professionals table to provide factual attribution. The per-row RLS policy (auth_user_id = auth.uid()) cannot be used for an arbitrary batch of forum author IDs. Documented service-role-legitimate exception per CLAUDE.md "Two Supabase clients".
+import { createAdminClient } from "@/lib/supabase/admin";
+
+/** Public attribution shape returned for a verified-advisor forum author. */
+export interface AdvisorBadgeInfo {
+  /** Public slug — used to link to /advisor/[slug]. */
+  slug: string;
+  /** ProfessionalType value — used to render the human-readable badge label. */
+  type: string;
+}
+
+/**
+ * Resolve which of the given forum author user-IDs belong to a verified,
+ * active professional on the site.
+ *
+ * Returns a `Map<userId, AdvisorBadgeInfo>`. Authors that are NOT verified
+ * professionals are omitted from the map.
+ *
+ * Errors are swallowed and an empty map is returned — badge display is
+ * non-critical and a DB failure must not break the forum thread page.
+ *
+ * @param authorIds  Deduplicated list of `auth.users.id` values from a
+ *                   thread + its posts.
+ */
+export async function resolveAdvisorBadges(
+  authorIds: string[],
+): Promise<Map<string, AdvisorBadgeInfo>> {
+  if (authorIds.length === 0) return new Map();
+
+  try {
+    const admin = createAdminClient();
+
+    const { data, error } = await admin
+      .from("professionals")
+      .select("auth_user_id, slug, type")
+      .in("auth_user_id", authorIds)
+      .eq("status", "active")
+      .eq("verified", true);
+
+    if (error) {
+      // Non-critical — return empty map rather than throwing.
+      return new Map();
+    }
+
+    const result = new Map<string, AdvisorBadgeInfo>();
+    for (const row of data ?? []) {
+      if (row.auth_user_id) {
+        result.set(row.auth_user_id, {
+          slug: row.slug,
+          type: row.type,
+        });
+      }
+    }
+    return result;
+  } catch {
+    return new Map();
+  }
+}


### PR DESCRIPTION
Deepens the community forum with **verified-advisor attribution** (trust layer) — factual attribution only, no new advice surface (the forum's public/indexed status is unchanged; the QQ-08-gated "ask an advisor" intake is untouched).

- New `lib/forum-author-badges.ts` → `resolveAdvisorBadges(authorIds)` maps forum author user-ids to verified professionals (`status = 'active'` **and** `verified = true`), via the service-role client (documented cross-user exception). Fails safe to an empty map.
- `app/community/[category]/[threadId]/page.tsx` now uses the helper instead of an inline cross-user query that only checked `status = 'active'` — so **only fully-verified advisors get the badge** (strictly narrower than before). The `VerifiedAdvisorBadge` component + the `GENERAL_ADVICE_WARNING` footer were already in place.

**Verified:** `tsc` clean · **7 tests** (empty-input, verified-only mapping, null-author skip, error/throw → empty map, columns/filters) pass · eslint clean. (Recovered by SHA + re-verified, given the push-ref issue.)

Attribution + disclaimer only — AFSL-safe.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUfSRE2Teb6VhEXFP6RpS9)_