### PR TITLE
feat: guided cross-border investing journey for expats (deepen foreign-investment)

### DIFF
--- a/__tests__/lib/expat-journey.test.ts
+++ b/__tests__/lib/expat-journey.test.ts
@@ -1,0 +1,279 @@
+import { describe, it, expect } from "vitest";
+import { buildExpatJourney, getJourneyStep } from "@/lib/expat-journey";
+import {
+  UK_CONFIG,
+  US_CONFIG,
+  NZ_CONFIG,
+  CN_CONFIG,
+  SA_CONFIG,
+} from "@/lib/foreign-investment-country-data";
+
+// ─── buildExpatJourney ──────────────────────────────────────────────────────
+
+describe("buildExpatJourney — invariants", () => {
+  it("always includes an eligibility step as step 1", () => {
+    const journey = buildExpatJourney(UK_CONFIG);
+    const step = journey.steps[0];
+    expect(step).toBeDefined();
+    expect(step!.id).toBe("eligibility");
+    expect(step!.stepNumber).toBe(1);
+  });
+
+  it("always includes a handoff step as the last step", () => {
+    const journey = buildExpatJourney(UK_CONFIG);
+    const last = journey.steps[journey.steps.length - 1];
+    expect(last).toBeDefined();
+    expect(last!.id).toBe("handoff");
+  });
+
+  it("step numbers are sequential from 1 with no gaps", () => {
+    const journey = buildExpatJourney(UK_CONFIG);
+    journey.steps.forEach((step, idx) => {
+      expect(step.stepNumber).toBe(idx + 1);
+    });
+  });
+
+  it("always returns at least 3 steps (eligibility, firb, handoff minimum)", () => {
+    // SA has fewer optional sections but should still have >= 3 steps
+    const journey = buildExpatJourney(SA_CONFIG);
+    expect(journey.steps.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("always includes a firb step", () => {
+    const journey = buildExpatJourney(UK_CONFIG);
+    const firbStep = journey.steps.find((s) => s.id === "firb");
+    expect(firbStep).toBeDefined();
+  });
+
+  it("always includes a tax step", () => {
+    const journey = buildExpatJourney(UK_CONFIG);
+    const taxStep = journey.steps.find((s) => s.id === "tax");
+    expect(taxStep).toBeDefined();
+  });
+});
+
+// ─── UK — full-featured journey ─────────────────────────────────────────────
+
+describe("buildExpatJourney — UK config (full featured)", () => {
+  const journey = buildExpatJourney(UK_CONFIG);
+
+  it("correctly identifies the country", () => {
+    expect(journey.code).toBe("uk");
+    expect(journey.countryName).toBe("United Kingdom");
+    expect(journey.countryShort).toBe("UK");
+    expect(journey.flag).toBe("🇬🇧");
+    expect(journey.currency).toBe("GBP");
+  });
+
+  it("includes a pension step for UK (QROPS)", () => {
+    const pensionStep = journey.steps.find((s) => s.id === "pension");
+    expect(pensionStep).toBeDefined();
+    expect(pensionStep!.heading).toContain("QROPS");
+    // Should have a critical callout about high-stakes nature
+    expect(pensionStep!.calloutVariant).toBe("critical");
+  });
+
+  it("includes an fx step for UK (GBP corridor)", () => {
+    const fxStep = journey.steps.find((s) => s.id === "fx");
+    expect(fxStep).toBeDefined();
+    expect(fxStep!.heading).toContain("GBP");
+  });
+
+  it("includes a migration step for UK", () => {
+    const migStep = journey.steps.find((s) => s.id === "migration");
+    expect(migStep).toBeDefined();
+  });
+
+  it("eligibility step mentions DTA and 15% dividend rate for UK", () => {
+    const step = journey.steps.find((s) => s.id === "eligibility");
+    expect(step).toBeDefined();
+    const allText = step!.bullets.join(" ");
+    expect(allText).toContain("Double Tax Agreement");
+    expect(allText).toContain("15%");
+  });
+
+  it("FIRB step mentions the established-dwelling ban", () => {
+    const step = journey.steps.find((s) => s.id === "firb");
+    expect(step).toBeDefined();
+    expect(step!.calloutTitle).toContain("Established Dwelling Ban");
+    expect(step!.calloutVariant).toBe("critical");
+  });
+
+  it("handoff step links to all three advisor pages", () => {
+    const step = journey.steps.find((s) => s.id === "handoff");
+    expect(step).toBeDefined();
+    const hrefs = step!.links.map((l) => l.href);
+    expect(hrefs).toContain("/advisors/firb-specialists");
+    expect(hrefs).toContain("/advisors/international-tax-specialists");
+    expect(hrefs).toContain("/advisors/migration-agents");
+  });
+
+  it("handoff step mentions pension specialists for UK (QROPS)", () => {
+    const step = journey.steps.find((s) => s.id === "handoff");
+    expect(step).toBeDefined();
+    const bulletText = step!.bullets.join(" ");
+    expect(bulletText).toContain("Pension transfer specialists");
+  });
+
+  it("tax step includes DTA rows and HMRC reporting bullets", () => {
+    const step = journey.steps.find((s) => s.id === "tax");
+    expect(step).toBeDefined();
+    const allText = step!.bullets.join(" ");
+    expect(allText).toContain("WHT");
+    expect(allText).toContain("UK reporting");
+  });
+});
+
+// ─── US — critical warning, FBAR/FATCA, no pension ──────────────────────────
+
+describe("buildExpatJourney — US config", () => {
+  const journey = buildExpatJourney(US_CONFIG);
+
+  it("eligibility step has critical callout for US worldwide tax", () => {
+    const step = journey.steps.find((s) => s.id === "eligibility");
+    expect(step).toBeDefined();
+    expect(step!.calloutVariant).toBe("critical");
+    expect(step!.calloutTitle).toContain("US Citizens");
+  });
+
+  it("includes a reporting step for FBAR/FATCA", () => {
+    const step = journey.steps.find((s) => s.id === "reporting");
+    expect(step).toBeDefined();
+    const text = step!.bullets.join(" ");
+    expect(text).toContain("FBAR");
+  });
+
+  it("tax step notes US reporting obligations", () => {
+    const step = journey.steps.find((s) => s.id === "tax");
+    expect(step).toBeDefined();
+    // US has reportingObligations — tax step callout should surface it
+    expect(step!.calloutTitle).toBeDefined();
+    // The callout title comes from reportingObligations.title (e.g. "FBAR, FATCA, and US reporting...")
+    expect(step!.calloutTitle!.toLowerCase()).toContain("reporting");
+  });
+
+  it("includes investment-options step for US (PFIC-aware choices)", () => {
+    const step = journey.steps.find((s) => s.id === "investment-options");
+    expect(step).toBeDefined();
+  });
+});
+
+// ─── NZ — no FIRB required ──────────────────────────────────────────────────
+
+describe("buildExpatJourney — NZ config (trans-Tasman)", () => {
+  const journey = buildExpatJourney(NZ_CONFIG);
+
+  it("FIRB step has warn (not critical) callout for NZ", () => {
+    const step = journey.steps.find((s) => s.id === "firb");
+    expect(step).toBeDefined();
+    // NZ callout says "No FIRB Required" — variant should be warn
+    expect(step!.calloutVariant).toBe("warn");
+    expect(step!.calloutTitle).toContain("No FIRB");
+  });
+
+  it("eligibility step does not say FIRB is required", () => {
+    const step = journey.steps.find((s) => s.id === "eligibility");
+    expect(step).toBeDefined();
+    const text = step!.bullets.join(" ");
+    // NZ citizens don't require FIRB
+    expect(text).toContain("do not need FIRB");
+  });
+
+  it("includes a pension step for NZ (KiwiSaver portability)", () => {
+    const step = journey.steps.find((s) => s.id === "pension");
+    expect(step).toBeDefined();
+  });
+});
+
+// ─── CN — capital controls ───────────────────────────────────────────────────
+
+describe("buildExpatJourney — CN config", () => {
+  const journey = buildExpatJourney(CN_CONFIG);
+
+  it("eligibility step has critical callout for capital controls", () => {
+    const step = journey.steps.find((s) => s.id === "eligibility");
+    expect(step).toBeDefined();
+    expect(step!.calloutVariant).toBe("critical");
+    expect(step!.calloutTitle).toContain("Capital Outflow");
+  });
+
+  it("FX step mentions SAFE compliance", () => {
+    const fxStep = journey.steps.find((s) => s.id === "fx");
+    // CN has an fxCorridor config
+    expect(fxStep).toBeDefined();
+  });
+});
+
+// ─── SA — no DTA ─────────────────────────────────────────────────────────────
+
+describe("buildExpatJourney — SA config (no DTA)", () => {
+  const journey = buildExpatJourney(SA_CONFIG);
+
+  it("eligibility step mentions no DTA for SA", () => {
+    const step = journey.steps.find((s) => s.id === "eligibility");
+    expect(step).toBeDefined();
+    const text = step!.bullets.join(" ");
+    expect(text).toContain("does not have a Double Tax Agreement");
+  });
+
+  it("tax step summary mentions no DTA", () => {
+    const step = journey.steps.find((s) => s.id === "tax");
+    expect(step).toBeDefined();
+    expect(step!.summary).toContain("does not have a Double Tax Agreement");
+  });
+});
+
+// ─── getJourneyStep ──────────────────────────────────────────────────────────
+
+describe("getJourneyStep", () => {
+  it("returns the step matching the given id", () => {
+    const journey = buildExpatJourney(UK_CONFIG);
+    const step = getJourneyStep(journey, "tax");
+    expect(step).toBeDefined();
+    expect(step!.id).toBe("tax");
+  });
+
+  it("returns undefined for an unknown id", () => {
+    const journey = buildExpatJourney(UK_CONFIG);
+    const step = getJourneyStep(journey, "nonexistent-step");
+    expect(step).toBeUndefined();
+  });
+});
+
+// ─── Data integrity — no fabricated URLs ────────────────────────────────────
+
+describe("buildExpatJourney — link integrity", () => {
+  const KNOWN_PREFIXES = [
+    "/foreign-investment",
+    "/advisors",
+    "/compare",
+    "/non-resident",
+    "/visa-investment",
+    "/cgt-calculator",
+    "/invest",
+    "/foreign-investment/send-money-australia",
+    "/foreign-investment/siv",
+    "/foreign-investment/super",
+    "/foreign-investment/shares",
+    "/foreign-investment/tax",
+    "/find-advisor",
+  ];
+
+  for (const code of ["uk", "us", "nz", "cn", "sa"] as const) {
+    const configs = { uk: UK_CONFIG, us: US_CONFIG, nz: NZ_CONFIG, cn: CN_CONFIG, sa: SA_CONFIG };
+    it(`all links in ${code.toUpperCase()} journey start with a known prefix`, () => {
+      const journey = buildExpatJourney(configs[code]);
+      for (const step of journey.steps) {
+        for (const link of step.links) {
+          const isKnown = KNOWN_PREFIXES.some((prefix) =>
+            link.href.startsWith(prefix),
+          );
+          expect(
+            isKnown,
+            `Unexpected link href in step "${step.id}": ${link.href}`,
+          ).toBe(true);
+        }
+      }
+    });
+  }
+});

--- a/app/foreign-investment/journey/[country]/page.tsx
+++ b/app/foreign-investment/journey/[country]/page.tsx
@@ -1,0 +1,402 @@
+/**
+ * /foreign-investment/journey/[country]
+ *
+ * Guided cross-border investing journey — sequences the existing country-data
+ * (FIRB rules, DTA rates, FX corridor, pension transfer, migration pathways)
+ * into an ordered step-by-step path, ending with an advisor handoff.
+ *
+ * Country-parameterised so each of the 12 hub countries gets a canonical
+ * journey URL:
+ *   /foreign-investment/journey/united-kingdom
+ *   /foreign-investment/journey/united-states
+ *   … etc.
+ *
+ * All data is sourced from COUNTRY_CONFIGS (lib/foreign-investment-country-data.ts)
+ * via buildExpatJourney (lib/expat-journey.ts). No new data is fabricated.
+ *
+ * Compliance:
+ *   - General information only — GENERAL_ADVICE_WARNING rendered in full
+ *   - FOREIGN_INVESTOR_GENERAL_DISCLAIMER at the foot
+ *   - Advisor CTAs are flat-fee referral (no personal advice or product rec)
+ *   - No performance claims or product rankings
+ */
+
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import type { Metadata } from "next";
+import { breadcrumbJsonLd, SITE_URL, absoluteUrl, CURRENT_YEAR } from "@/lib/seo";
+import {
+  GENERAL_ADVICE_WARNING,
+  FOREIGN_INVESTOR_GENERAL_DISCLAIMER,
+} from "@/lib/compliance";
+import {
+  getCountryConfig,
+  COUNTRY_CONFIGS,
+} from "@/lib/foreign-investment-country-data";
+import { intentCountryFromSlug } from "@/lib/intent-context";
+import { buildExpatJourney, type JourneyStep } from "@/lib/expat-journey";
+import ForeignInvestmentNav from "../../ForeignInvestmentNav";
+import RememberCountry from "@/components/foreign-investment/RememberCountry";
+
+// ─── Static params ───────────────────────────────────────────────────────────
+
+export function generateStaticParams() {
+  return Object.values(COUNTRY_CONFIGS)
+    .filter(Boolean)
+    .map((c) => ({ country: c!.slug }));
+}
+
+// ─── Metadata ────────────────────────────────────────────────────────────────
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ country: string }>;
+}): Promise<Metadata> {
+  const { country } = await params;
+  const code = intentCountryFromSlug(country);
+  if (!code) return { title: "Guide Not Found" };
+  const config = getCountryConfig(code);
+  if (!config) return { title: "Guide Not Found" };
+
+  const title = `${config.adjective} Investor Journey: Step-by-Step Guide to Investing in Australia (${CURRENT_YEAR})`;
+  const description = `Guided cross-border investing journey for ${config.adjective} residents. Covers FIRB eligibility, property rules, investment options, DTA tax rates, FX, ${config.retirementTransfer ? "pension transfer, " : ""}${config.migration ? "visa pathways, " : ""}and advisor referral. General information only.`;
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title: `${config.adjective} Investor Journey — Investing in Australia ${CURRENT_YEAR}`,
+      description: `Step-by-step guide: FIRB, tax, FX, and advisor handoff for ${config.adjective} investors.`,
+      url: `${SITE_URL}/foreign-investment/journey/${config.slug}`,
+      images: [
+        {
+          url: `/api/og?title=${encodeURIComponent(`${config.flag} Cross-Border Investing Journey: ${config.countryShort} → Australia`)}&sub=${encodeURIComponent(`FIRB · Tax · FX · Advisors · ${CURRENT_YEAR}`)}`,
+          width: 1200,
+          height: 630,
+        },
+      ],
+    },
+    twitter: { card: "summary_large_image" },
+    alternates: {
+      canonical: `${SITE_URL}/foreign-investment/journey/${config.slug}`,
+    },
+  };
+}
+
+export const revalidate = 86400;
+
+// ─── JSON-LD ──────────────────────────────────────────────────────────────────
+
+function buildHowToJsonLd(
+  config: ReturnType<typeof getCountryConfig>,
+  steps: ReadonlyArray<JourneyStep>,
+) {
+  if (!config) return null;
+  return {
+    "@context": "https://schema.org",
+    "@type": "HowTo",
+    name: `How to invest in Australia as a ${config.adjective} resident — ${CURRENT_YEAR} guide`,
+    description: `Step-by-step guide covering FIRB eligibility, tax obligations, investment options, FX, and finding a specialist advisor.`,
+    url: absoluteUrl(`/foreign-investment/journey/${config.slug}`),
+    image: `/api/og?title=${encodeURIComponent(`${config.adjective} Cross-Border Investing Journey`)}&sub=${encodeURIComponent("FIRB · Tax · FX · Advisors")}`,
+    step: steps.map((s) => ({
+      "@type": "HowToStep",
+      name: s.railLabel,
+      text: s.summary,
+      url: absoluteUrl(
+        `/foreign-investment/journey/${config.slug}#${s.id}`,
+      ),
+    })),
+  };
+}
+
+// ─── UI components ────────────────────────────────────────────────────────────
+
+function CalloutBox({
+  title,
+  body,
+  variant = "warn",
+}: {
+  title: string;
+  body: string;
+  variant?: "warn" | "critical";
+}) {
+  const styles =
+    variant === "critical"
+      ? "bg-red-50 border-red-200 text-red-900"
+      : "bg-amber-50 border-amber-200 text-amber-900";
+  const labelStyle =
+    variant === "critical" ? "text-red-700" : "text-amber-700";
+
+  return (
+    <div className={`rounded-xl border p-4 mt-4 ${styles}`}>
+      <p className={`text-xs font-bold uppercase tracking-wide mb-1 ${labelStyle}`}>
+        {variant === "critical" ? "Important" : "Note"}
+      </p>
+      <p className="text-xs font-semibold mb-1">{title}</p>
+      <p
+        className="text-xs leading-relaxed"
+        dangerouslySetInnerHTML={{
+          __html: body.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>"),
+        }}
+      />
+    </div>
+  );
+}
+
+function StepCard({ step }: { step: JourneyStep }) {
+  return (
+    <section
+      id={step.id}
+      className="bg-white rounded-2xl border border-slate-200 shadow-sm overflow-hidden scroll-mt-24"
+    >
+      {/* Step header */}
+      <div className="px-6 py-4 bg-slate-50 border-b border-slate-200 flex items-center gap-3">
+        <span className="inline-flex items-center justify-center w-7 h-7 rounded-full bg-amber-500 text-white text-xs font-extrabold shrink-0">
+          {step.stepNumber}
+        </span>
+        <h2 className="font-extrabold text-slate-900 text-sm md:text-base leading-tight">
+          {step.heading}
+        </h2>
+      </div>
+
+      <div className="px-6 py-5 space-y-4">
+        {/* Summary */}
+        <p className="text-sm text-slate-600 leading-relaxed">{step.summary}</p>
+
+        {/* Callout */}
+        {step.calloutTitle && (
+          <CalloutBox
+            title={step.calloutTitle}
+            body={step.calloutBody ?? ""}
+            variant={step.calloutVariant}
+          />
+        )}
+
+        {/* Bullets */}
+        {step.bullets.length > 0 && (
+          <ul className="space-y-2.5">
+            {step.bullets.map((bullet, i) => (
+              <li key={i} className="flex gap-2.5 text-xs text-slate-700 leading-relaxed">
+                <span className="text-amber-500 font-bold mt-0.5 shrink-0">—</span>
+                <span
+                  dangerouslySetInnerHTML={{
+                    __html: bullet.replace(
+                      /\*\*(.+?)\*\*/g,
+                      "<strong>$1</strong>",
+                    ),
+                  }}
+                />
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {/* Links */}
+        {step.links.length > 0 && (
+          <div className="flex flex-wrap gap-2 pt-2">
+            {step.links.map((link) =>
+              link.primary ? (
+                <Link
+                  key={link.href}
+                  href={link.href}
+                  className="inline-flex items-center gap-1.5 bg-amber-500 hover:bg-amber-400 text-slate-900 font-bold text-xs px-4 py-2 rounded-lg transition-colors"
+                >
+                  {link.label}
+                </Link>
+              ) : (
+                <Link
+                  key={link.href}
+                  href={link.href}
+                  className="inline-flex items-center gap-1.5 border border-slate-300 hover:bg-slate-50 text-slate-700 font-semibold text-xs px-4 py-2 rounded-lg transition-colors"
+                >
+                  {link.label}
+                </Link>
+              ),
+            )}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export default async function ExpatJourneyPage({
+  params,
+}: {
+  params: Promise<{ country: string }>;
+}) {
+  const { country } = await params;
+  const code = intentCountryFromSlug(country);
+  if (!code) notFound();
+  const config = getCountryConfig(code);
+  if (!config) notFound();
+
+  const journey = buildExpatJourney(config);
+
+  const breadcrumb = breadcrumbJsonLd([
+    { name: "Home", url: SITE_URL },
+    { name: "Foreign Investment", url: `${SITE_URL}/foreign-investment` },
+    {
+      name: config.countryName,
+      url: `${SITE_URL}/foreign-investment/${config.slug}`,
+    },
+    {
+      name: "Journey",
+      url: `${SITE_URL}/foreign-investment/journey/${config.slug}`,
+    },
+  ]);
+
+  const howToLd = buildHowToJsonLd(config, journey.steps);
+
+  return (
+    <div className="bg-white min-h-screen">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
+      />
+      {howToLd && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(howToLd) }}
+        />
+      )}
+
+      {/* Persist country intent cookie for cross-navigation continuity */}
+      <RememberCountry code={code} />
+
+      <ForeignInvestmentNav current="" />
+
+      {/* ── Hero ──────────────────────────────────────────────────────── */}
+      <section className="relative bg-white border-b border-slate-100 py-8 md:py-12">
+        <div className="container-custom">
+          {/* Breadcrumb */}
+          <nav className="text-xs text-slate-500 mb-5 flex items-center gap-1.5 flex-wrap">
+            <Link href="/" className="hover:text-slate-900">
+              Home
+            </Link>
+            <span>/</span>
+            <Link href="/foreign-investment" className="hover:text-slate-900">
+              Foreign Investment
+            </Link>
+            <span>/</span>
+            <Link
+              href={`/foreign-investment/${config.slug}`}
+              className="hover:text-slate-900"
+            >
+              {config.countryName}
+            </Link>
+            <span>/</span>
+            <span className="text-slate-900 font-medium">Journey</span>
+          </nav>
+
+          <div className="max-w-2xl">
+            <div className="inline-flex items-center gap-2 px-3 py-1 bg-slate-100 border border-slate-200 rounded-full text-xs font-semibold text-slate-600 mb-4">
+              <span className="text-base">{config.flag}</span>
+              {config.countryName} · Cross-Border Investing Journey · {CURRENT_YEAR}
+            </div>
+
+            <h1 className="text-2xl sm:text-3xl md:text-4xl font-extrabold leading-[1.1] mb-3 tracking-tight text-slate-900">
+              {config.adjective} investor{" "}
+              <span className="text-amber-600">step-by-step journey</span>
+            </h1>
+            <p className="text-sm md:text-base text-slate-600 leading-relaxed mb-6">
+              This guide sequences the key decisions for a {config.adjective}{" "}
+              resident investing in Australia — from understanding your
+              eligibility and FIRB obligations through to tax, FX, and finding
+              the right specialist. General information only — not financial
+              advice.
+            </p>
+
+            {/* General advice warning — above the fold */}
+            <div className="bg-slate-50 border border-slate-200 rounded-xl p-4">
+              <p className="text-xs text-slate-500 leading-relaxed">
+                {GENERAL_ADVICE_WARNING}
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Progress rail + steps ─────────────────────────────────────── */}
+      <div className="container-custom py-10 md:py-14">
+        <div className="flex flex-col lg:flex-row gap-8 items-start">
+          {/* Sticky progress rail (desktop) */}
+          <aside className="hidden lg:block sticky top-24 w-52 shrink-0">
+            <p className="text-[0.65rem] font-bold uppercase tracking-widest text-slate-400 mb-3">
+              Your journey
+            </p>
+            <nav className="space-y-1">
+              {journey.steps.map((s) => (
+                <a
+                  key={s.id}
+                  href={`#${s.id}`}
+                  className="flex items-center gap-2.5 px-3 py-2 rounded-lg text-xs font-semibold text-slate-600 hover:bg-slate-50 hover:text-amber-700 transition-colors group"
+                >
+                  <span className="w-5 h-5 rounded-full bg-slate-100 group-hover:bg-amber-100 text-slate-500 group-hover:text-amber-700 text-[0.6rem] font-extrabold flex items-center justify-center shrink-0 transition-colors">
+                    {s.stepNumber}
+                  </span>
+                  {s.railLabel}
+                </a>
+              ))}
+            </nav>
+
+            {/* Country guide link */}
+            <div className="mt-6 p-3 bg-amber-50 border border-amber-200 rounded-xl">
+              <p className="text-[0.65rem] font-bold uppercase tracking-wide text-amber-700 mb-1">
+                Full country guide
+              </p>
+              <Link
+                href={`/foreign-investment/${config.slug}`}
+                className="text-xs font-semibold text-amber-700 hover:text-amber-800"
+              >
+                {config.flag} {config.countryName} investing hub →
+              </Link>
+            </div>
+          </aside>
+
+          {/* Steps */}
+          <div className="flex-1 min-w-0 space-y-6">
+            {journey.steps.map((step) => (
+              <StepCard key={step.id} step={step} />
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* ── Related journeys ──────────────────────────────────────────── */}
+      <section className="py-10 bg-slate-50 border-t border-slate-100">
+        <div className="container-custom">
+          <p className="text-xs font-bold uppercase tracking-wider text-slate-400 mb-4">
+            Other country journeys
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {Object.values(COUNTRY_CONFIGS)
+              .filter((c) => c && c.code !== config.code)
+              .map((c) => (
+                <Link
+                  key={c!.slug}
+                  href={`/foreign-investment/journey/${c!.slug}`}
+                  className="px-3 py-1.5 bg-white border border-slate-200 hover:border-amber-300 text-xs font-semibold text-slate-700 hover:text-amber-700 rounded-lg transition-colors"
+                >
+                  {c!.flag} {c!.countryShort}
+                </Link>
+              ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── Compliance footer ─────────────────────────────────────────── */}
+      <section className="py-6 bg-white border-t border-slate-200">
+        <div className="container-custom">
+          <p className="text-xs text-slate-400 leading-relaxed">
+            {FOREIGN_INVESTOR_GENERAL_DISCLAIMER}
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/foreign-investment/journey/[country]/page.tsx
+++ b/app/foreign-investment/journey/[country]/page.tsx
@@ -38,6 +38,14 @@ import { buildExpatJourney, type JourneyStep } from "@/lib/expat-journey";
 import ForeignInvestmentNav from "../../ForeignInvestmentNav";
 import RememberCountry from "@/components/foreign-investment/RememberCountry";
 
+// ─── Bold-markdown renderer (safe: returns JSX, never innerHTML) ─────────────
+
+function renderBold(text: string) {
+  return text
+    .split(/\*\*(.+?)\*\*/g)
+    .map((part, i) => (i % 2 === 1 ? <strong key={i}>{part}</strong> : part));
+}
+
 // ─── Static params ───────────────────────────────────────────────────────────
 
 export function generateStaticParams() {
@@ -135,12 +143,7 @@ function CalloutBox({
         {variant === "critical" ? "Important" : "Note"}
       </p>
       <p className="text-xs font-semibold mb-1">{title}</p>
-      <p
-        className="text-xs leading-relaxed"
-        dangerouslySetInnerHTML={{
-          __html: body.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>"),
-        }}
-      />
+      <p className="text-xs leading-relaxed">{renderBold(body)}</p>
     </div>
   );
 }
@@ -180,14 +183,7 @@ function StepCard({ step }: { step: JourneyStep }) {
             {step.bullets.map((bullet, i) => (
               <li key={i} className="flex gap-2.5 text-xs text-slate-700 leading-relaxed">
                 <span className="text-amber-500 font-bold mt-0.5 shrink-0">—</span>
-                <span
-                  dangerouslySetInnerHTML={{
-                    __html: bullet.replace(
-                      /\*\*(.+?)\*\*/g,
-                      "<strong>$1</strong>",
-                    ),
-                  }}
-                />
+                <span>{renderBold(bullet)}</span>
               </li>
             ))}
           </ul>

--- a/app/foreign-investment/journey/page.tsx
+++ b/app/foreign-investment/journey/page.tsx
@@ -1,0 +1,198 @@
+/**
+ * /foreign-investment/journey
+ *
+ * Landing page for the guided cross-border investing journey. If the user
+ * has an intent country cookie set, we redirect them directly to their
+ * country-specific journey. Otherwise, we show a country picker.
+ *
+ * This is a dynamic route (reads cookies) — no `export const revalidate`.
+ */
+
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import type { Metadata } from "next";
+import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
+import { COUNTRY_CONFIGS } from "@/lib/foreign-investment-country-data";
+import { getIntentCountry } from "@/lib/intent-context-server";
+import { intentCountryMeta } from "@/lib/intent-context";
+import ForeignInvestmentNav from "../ForeignInvestmentNav";
+
+export const metadata: Metadata = {
+  title: `Cross-Border Investing Journey — Step-by-Step Guide for Foreign Investors (${CURRENT_YEAR})`,
+  description:
+    "Guided step-by-step investing journey for migrants, expats, and non-residents. Select your country to get a personalised path covering FIRB, tax, FX, and advisor handoff.",
+  openGraph: {
+    title: `Cross-Border Investing Journey — Foreign Investor Guide ${CURRENT_YEAR}`,
+    description:
+      "Country-specific step-by-step guide: FIRB eligibility, DTA tax rates, investment options, FX, pension transfer, and specialist advisor referral.",
+    url: `${SITE_URL}/foreign-investment/journey`,
+  },
+  twitter: { card: "summary_large_image" },
+  alternates: { canonical: `${SITE_URL}/foreign-investment/journey` },
+};
+
+export default async function JourneyIndexPage() {
+  // If we have an intent country, redirect straight to the journey for it
+  const code = await getIntentCountry();
+  if (code) {
+    const meta = intentCountryMeta(code);
+    redirect(`/foreign-investment/journey/${meta.slug}`);
+  }
+
+  const breadcrumb = breadcrumbJsonLd([
+    { name: "Home", url: SITE_URL },
+    { name: "Foreign Investment", url: `${SITE_URL}/foreign-investment` },
+    { name: "Journey", url: `${SITE_URL}/foreign-investment/journey` },
+  ]);
+
+  const countries = Object.values(COUNTRY_CONFIGS).filter(Boolean);
+
+  return (
+    <div className="bg-white min-h-screen">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
+      />
+
+      <ForeignInvestmentNav current="" />
+
+      {/* ── Hero ────────────────────────────────────────────────────── */}
+      <section className="relative bg-white border-b border-slate-100 py-10 md:py-16">
+        <div className="container-custom">
+          <nav className="text-xs text-slate-500 mb-5 flex items-center gap-1.5 flex-wrap">
+            <Link href="/" className="hover:text-slate-900">
+              Home
+            </Link>
+            <span>/</span>
+            <Link href="/foreign-investment" className="hover:text-slate-900">
+              Foreign Investment
+            </Link>
+            <span>/</span>
+            <span className="text-slate-900 font-medium">Journey</span>
+          </nav>
+
+          <div className="max-w-2xl">
+            <div className="inline-flex items-center gap-2 px-3 py-1 bg-slate-100 border border-slate-200 rounded-full text-xs font-semibold text-slate-600 mb-4">
+              <span className="w-1.5 h-1.5 bg-amber-500 rounded-full" />
+              Cross-Border Investing · Guided Journey · {CURRENT_YEAR}
+            </div>
+
+            <h1 className="text-2xl sm:text-3xl md:text-4xl font-extrabold leading-[1.1] mb-3 tracking-tight text-slate-900">
+              Your{" "}
+              <span className="text-amber-600">cross-border investing</span>{" "}
+              journey
+            </h1>
+            <p className="text-sm md:text-base text-slate-600 leading-relaxed">
+              Select your home country to get a personalised, step-by-step
+              guide covering FIRB eligibility, investment options, tax
+              obligations, FX, and finding a specialist advisor. General
+              information only — not financial or legal advice.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Country picker ────────────────────────────────────────────── */}
+      <section className="py-12 md:py-16">
+        <div className="container-custom">
+          <h2 className="text-base font-extrabold text-slate-900 mb-6">
+            Select your home country
+          </h2>
+
+          <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {countries.map((c) => (
+              <Link
+                key={c!.slug}
+                href={`/foreign-investment/journey/${c!.slug}`}
+                className="group flex items-start gap-4 p-5 bg-white border border-slate-200 hover:border-amber-300 hover:shadow-md rounded-2xl transition-all"
+              >
+                <span className="text-3xl shrink-0 mt-0.5">{c!.flag}</span>
+                <div className="min-w-0">
+                  <p className="font-extrabold text-sm text-slate-900 group-hover:text-amber-700 transition-colors mb-1">
+                    {c!.countryName}
+                  </p>
+                  <p className="text-xs text-slate-500 leading-relaxed line-clamp-2">
+                    {c!.hero.paragraph.slice(0, 120)}
+                    {c!.hero.paragraph.length > 120 ? "…" : ""}
+                  </p>
+                  <span className="mt-2 inline-flex items-center gap-1 text-xs font-bold text-amber-600 group-hover:text-amber-700">
+                    Start journey →
+                  </span>
+                </div>
+              </Link>
+            ))}
+          </div>
+
+          <p className="mt-8 text-xs text-slate-400">
+            Your country not listed?{" "}
+            <Link
+              href="/foreign-investment"
+              className="text-amber-600 hover:text-amber-700 font-semibold"
+            >
+              View the general foreign investment hub
+            </Link>{" "}
+            for DTA rates and rules for all countries.
+          </p>
+        </div>
+      </section>
+
+      {/* ── What the journey covers ───────────────────────────────────── */}
+      <section className="py-12 bg-slate-50 border-t border-slate-100">
+        <div className="container-custom">
+          <h2 className="text-sm font-extrabold text-slate-900 mb-6 uppercase tracking-wide">
+            What each journey covers
+          </h2>
+          <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {[
+              {
+                n: "01",
+                title: "Eligibility",
+                body: "Tax residency status, DTA coverage, and whether FIRB applies to you.",
+              },
+              {
+                n: "02",
+                title: "FIRB & Property",
+                body: "What you can buy, the established-dwelling ban, and how FIRB approval works.",
+              },
+              {
+                n: "03",
+                title: "Investment Options",
+                body: "What is open and what is restricted — shares, property, super, crypto, savings.",
+              },
+              {
+                n: "04",
+                title: "Tax",
+                body: "DTA withholding rates, CGT treatment, and your home-country reporting obligations.",
+              },
+              {
+                n: "05",
+                title: "FX & Moving Money",
+                body: "How to transfer money efficiently — specialist FX vs bank rates.",
+              },
+              {
+                n: "06",
+                title: "Advisor Handoff",
+                body: "FIRB specialists, international tax accountants, and migration agents — when you need each.",
+              },
+            ].map((item) => (
+              <div
+                key={item.n}
+                className="bg-white rounded-xl border border-slate-200 p-4"
+              >
+                <span className="text-[0.65rem] font-extrabold text-slate-400 uppercase tracking-widest">
+                  Step {item.n}
+                </span>
+                <p className="font-extrabold text-sm text-slate-900 mt-1 mb-1.5">
+                  {item.title}
+                </p>
+                <p className="text-xs text-slate-500 leading-relaxed">
+                  {item.body}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/lib/expat-journey.ts
+++ b/lib/expat-journey.ts
@@ -1,0 +1,595 @@
+/**
+ * Expat Journey — builds an ordered, country-aware step list for the
+ * `/foreign-investment/[country]/journey` guided page.
+ *
+ * Strategy: assemble EXISTING data from CountryConfig (the single source
+ * of truth) into an ordered step sequence. No new data is fabricated.
+ * Each step surfaces the relevant country-config facts + links to the
+ * existing calculators/pages/advisor surfaces.
+ *
+ * Step ordering is intentionally fixed for UX consistency:
+ *   1. Eligibility / residency signal — "Can I invest?"
+ *   2. FIRB — property and business thresholds
+ *   3. Investment options — what's open/blocked for this country
+ *   4. Tax — DTA rates, withholding, home-country reporting
+ *   5. FX / moving money — corridor options
+ *   6. Pension / super transfer — if applicable (UK QROPS, NZ KiwiSaver, etc.)
+ *   7. Reporting obligations — FBAR/FATCA, SAFE controls, etc. if applicable
+ *   8. Visa / migration — if user is considering permanent move
+ *   9. Advisor handoff — FIRB specialists + international tax + migration agents
+ *
+ * Steps are skipped (omitted) when the country config has no relevant data
+ * for that topic — the list is honest, not padded.
+ *
+ * Everything here is factual and general in nature (AFSL general-advice
+ * licence). No personal recommendations, no product placement, no fabricated
+ * tax rates. All copy either quotes config data or links to the relevant
+ * page/calculator for the user to verify.
+ *
+ * Tests: __tests__/lib/expat-journey.test.ts
+ */
+
+import type { CountryConfig } from "./foreign-investment-country-data";
+import type { IntentCountryCode } from "./intent-context";
+import { intentCountryMeta } from "./intent-context";
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+/**
+ * A single step in the cross-border investing journey.
+ * id is stable — used as URL anchors on the journey page.
+ */
+export interface JourneyStep {
+  /** Stable anchor id, e.g. "eligibility", "firb", "tax". */
+  id: string;
+  /** Step number (1-based) for display. */
+  stepNumber: number;
+  /** Short title shown in the progress rail. */
+  railLabel: string;
+  /** Full section heading. */
+  heading: string;
+  /** 1–2 sentence summary surfaced in the step card. */
+  summary: string;
+  /**
+   * Factual bullet points extracted from the country config.
+   * Each bullet may contain **bold** markdown (rendered client-side).
+   */
+  bullets: ReadonlyArray<string>;
+  /**
+   * Links to existing pages / calculators. Every link is a pre-existing
+   * route — no fabricated URLs.
+   */
+  links: ReadonlyArray<{ label: string; href: string; primary?: boolean }>;
+  /**
+   * Optional amber/red callout heading — surfaces critical warnings
+   * from the config (e.g. US worldwide-tax, CN capital controls, UK QROPS risk).
+   */
+  calloutTitle?: string;
+  /** Body text for the callout. May contain **bold** markdown. */
+  calloutBody?: string;
+  /** "warn" (amber) or "critical" (red) — drives visual variant. Defaults to "warn". */
+  calloutVariant?: "warn" | "critical";
+}
+
+export interface ExpatJourney {
+  /** Two-letter country code. */
+  code: IntentCountryCode;
+  /** Canonical country name, e.g. "United Kingdom". */
+  countryName: string;
+  /** Short label, e.g. "UK", "US". */
+  countryShort: string;
+  /** Emoji flag. */
+  flag: string;
+  /** ISO 4217 currency. */
+  currency: string;
+  /** Ordered journey steps — always >= 2 (eligibility + handoff are always present). */
+  steps: ReadonlyArray<JourneyStep>;
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/** Capitalise first letter — used when adjective starts a sentence. */
+function ucFirst(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+/** Primary DTA dividend rate from the first row of the DTA table, or "30%" fallback. */
+function dividendWht(config: CountryConfig): string {
+  const row = config.dta.rows.find((r) =>
+    r.type.toLowerCase().includes("unfranked"),
+  );
+  return row?.withTreaty ?? "30%";
+}
+
+/** True when property.banHeadline is set (established dwelling ban active). */
+function hasBan(config: CountryConfig): boolean {
+  return Boolean(config.property.banHeadline);
+}
+
+/**
+ * True for all countries except NZ (SCV 444 / trans-Tasman exemption).
+ * NZ is the only case where FIRB is not required. We infer from the
+ * criticalWarning text rather than adding a new config field.
+ */
+function requiresFirb(config: CountryConfig): boolean {
+  // NZ critical warning explicitly says "No FIRB Required"
+  const warn = config.criticalWarning?.title ?? "";
+  return !warn.toLowerCase().includes("no firb");
+}
+
+// ─── Step builders ──────────────────────────────────────────────────────────
+
+function buildEligibilityStep(
+  config: CountryConfig,
+  n: number,
+): JourneyStep {
+  const meta = intentCountryMeta(config.code);
+  const hasDta = meta.hasDta;
+  const firb = requiresFirb(config);
+
+  const bullets: string[] = [
+    `**Tax residency**: Your obligations depend on whether you are a tax resident of ${config.countryName}, Australia, or both. The country page has a two-audience breakdown.`,
+    `**DTA status**: ${hasDta ? `${config.countryShort} and Australia have a Double Tax Agreement — reduced withholding rates apply (e.g. dividends at ${dividendWht(config)} rather than 30%).` : `${config.countryShort} does not have a Double Tax Agreement with Australia. Standard ATO withholding rates apply (30% on unfranked dividends).`}`,
+    firb
+      ? `**FIRB**: ${ucFirst(config.adjective)} residents generally need Foreign Investment Review Board (FIRB) approval to purchase Australian property. See Step 2.`
+      : `**FIRB**: ${config.countryShort} citizens under the Trans-Tasman arrangement do not need FIRB approval for Australian property — one of the key advantages. See Step 2 for details.`,
+  ];
+
+  // Audience bullets from the first audience card (the inbound investor)
+  const inboundCard = config.audiences.cards[0];
+  if (inboundCard) {
+    bullets.push(
+      ...inboundCard.bullets.map((b) => `**${config.adjective} resident**: ${b}`),
+    );
+  }
+
+  return {
+    id: "eligibility",
+    stepNumber: n,
+    railLabel: "Eligibility",
+    heading: `Step ${n}: Who can invest — residency and eligibility`,
+    summary: `Before investing, establish your tax residency status and whether the ${config.countryShort}–Australia Double Tax Agreement applies to you. This determines withholding rates, reporting obligations, and FIRB requirements.`,
+    bullets,
+    links: [
+      {
+        label: `${config.countryShort}–Australia investing guide`,
+        href: `/foreign-investment/${config.slug}`,
+        primary: true,
+      },
+      {
+        label: "Non-resident tax guide",
+        href: "/foreign-investment/tax",
+      },
+    ],
+    ...(config.criticalWarning
+      ? {
+          calloutTitle: config.criticalWarning.title,
+          calloutBody: config.criticalWarning.body,
+          calloutVariant: "critical" as const,
+        }
+      : {}),
+  };
+}
+
+function buildFirbStep(config: CountryConfig, n: number): JourneyStep {
+  const firb = requiresFirb(config);
+  const ban = hasBan(config);
+
+  const bullets: string[] = [];
+
+  // Property tiles — open vs blocked
+  for (const tile of config.property.tiles) {
+    const icon = tile.state === "open" ? "Open" : "Blocked";
+    bullets.push(`**${tile.label}** (${icon}): ${tile.note}`);
+  }
+
+  // Country-side reminders
+  bullets.push(...config.property.countrySideReminders);
+
+  const links = [
+    ...config.property.ctaLinks.map((l) => ({
+      label: l.label,
+      href: l.href,
+      primary: l.primary,
+    })),
+    {
+      label: "FIRB application guide",
+      href: "/foreign-investment/guides/firb-application-guide",
+    },
+    {
+      label: "FIRB specialists",
+      href: "/advisors/firb-specialists",
+    },
+  ];
+
+  let callout: Pick<JourneyStep, "calloutTitle" | "calloutBody" | "calloutVariant"> = {};
+  if (!firb) {
+    callout = {
+      calloutTitle: `${config.countryShort} citizens: No FIRB required`,
+      calloutBody: config.criticalWarning?.body ?? "NZ citizens under the Trans-Tasman arrangement do not need FIRB approval for most Australian property purchases.",
+      calloutVariant: "warn",
+    };
+  } else if (ban && config.property.banHeadline) {
+    callout = {
+      calloutTitle: config.property.banHeadline,
+      calloutBody: config.property.banDetail ?? "The established dwelling ban is active. New dwellings and commercial property remain available.",
+      calloutVariant: "critical",
+    };
+  }
+
+  return {
+    id: "firb",
+    stepNumber: n,
+    railLabel: "FIRB & Property",
+    heading: `Step ${n}: FIRB rules and Australian property`,
+    summary: firb
+      ? `FIRB approval is required for ${config.adjective} residents purchasing most Australian property. The 2025–2027 established dwelling ban limits options — but new dwellings, off-the-plan, and commercial property remain open.`
+      : `${config.countryShort} citizens under the Trans-Tasman arrangement do not need FIRB approval — a significant advantage over most other nationalities. Foreign-buyer stamp duty surcharges may still apply in some states.`,
+    bullets,
+    links,
+    ...callout,
+  };
+}
+
+function buildInvestmentOptionsStep(
+  config: CountryConfig,
+  n: number,
+): JourneyStep | null {
+  // Use investmentOptions if present, otherwise synthesise from paths-to-shares
+  const items = config.investmentOptions?.items;
+  const paths = config.pathsToShares?.cards;
+
+  if (!items && !paths) return null;
+
+  const bullets: string[] = [];
+
+  if (items) {
+    for (const item of items) {
+      const icon = item.state === "open" ? "Open" : "Blocked";
+      bullets.push(`**${item.label}** (${icon}): ${item.body}`);
+    }
+  } else if (paths) {
+    for (const path of paths) {
+      bullets.push(`**${path.title}**: ${path.body}`);
+    }
+  }
+
+  const links: Array<{ label: string; href: string; primary?: boolean }> = [];
+  if (config.investmentOptions) {
+    links.push({
+      label: "Compare non-resident brokers",
+      href: "/compare/non-residents",
+      primary: true,
+    });
+  } else if (config.pathsToShares?.ctaLinks) {
+    links.push(
+      ...config.pathsToShares.ctaLinks.map((l) => ({
+        label: l.label,
+        href: l.href,
+        primary: l.primary,
+      })),
+    );
+  }
+  links.push({ label: "ASX shares for non-residents", href: "/foreign-investment/shares" });
+
+  return {
+    id: "investment-options",
+    stepNumber: n,
+    railLabel: "Investment Options",
+    heading: `Step ${n}: What ${config.adjective} investors can access`,
+    summary: `The investment options available to you depend on your tax residency and visa status. Here is what is open and what is restricted for ${config.adjective} residents.`,
+    bullets,
+    links,
+  };
+}
+
+function buildTaxStep(config: CountryConfig, n: number): JourneyStep {
+  const meta = intentCountryMeta(config.code);
+  const hasDta = meta.hasDta;
+
+  const bullets: string[] = [];
+
+  // DTA rows — top 4 most relevant
+  const taxRows = config.dta.rows.slice(0, 4);
+  for (const row of taxRows) {
+    bullets.push(
+      `**${row.type}**: ${hasDta ? row.withTreaty : row.noTreaty} AU WHT. ${row.countrySideNote}`,
+    );
+  }
+
+  // Country reporting obligations
+  if (config.dta.countryReporting.length > 0) {
+    bullets.push(
+      ...config.dta.countryReporting.map(
+        (r) => `**${config.countryShort} reporting**: ${r}`,
+      ),
+    );
+  }
+
+  const links: JourneyStep["links"] = [
+    {
+      label: config.dta.ctaLabel,
+      href: config.dta.ctaHref,
+      primary: true,
+    },
+    {
+      label: "Non-resident CGT checker",
+      href: "/non-resident-cgt-checker",
+    },
+    {
+      label: "Non-resident dividend calculator",
+      href: "/non-resident-dividend-calculator",
+    },
+    {
+      label: "DTA search table",
+      href: "/foreign-investment#dta",
+    },
+  ];
+
+  // FBAR/FATCA or other reporting obligations
+  let callout: Pick<JourneyStep, "calloutTitle" | "calloutBody" | "calloutVariant"> = {};
+  if (config.reportingObligations) {
+    callout = {
+      calloutTitle: `${config.reportingObligations.title}`,
+      calloutBody: config.reportingObligations.sub,
+      calloutVariant: "critical",
+    };
+  }
+
+  return {
+    id: "tax",
+    stepNumber: n,
+    railLabel: "Tax",
+    heading: `Step ${n}: Tax — withholding rates and ${config.countryShort}-side reporting`,
+    summary: hasDta
+      ? `The ${config.countryShort}–Australia Double Tax Agreement reduces withholding rates on investment income. You still need to report Australian income in ${config.countryName} — ${config.dta.countryReportingHeading} covers the key obligations.`
+      : `${config.countryName} does not have a Double Tax Agreement with Australia. Standard ATO withholding rates apply. Australian income should be declared in ${config.countryName} as required by local tax law.`,
+    bullets,
+    links,
+    ...callout,
+  };
+}
+
+function buildFxStep(
+  config: CountryConfig,
+  n: number,
+): JourneyStep | null {
+  if (!config.fxCorridor) return null;
+
+  const fx = config.fxCorridor;
+  const bullets = fx.options.map(
+    (opt) =>
+      `**${opt.name}** (${opt.badge}): ${opt.cost} — ${opt.speed}. ${opt.note}`,
+  );
+
+  return {
+    id: "fx",
+    stepNumber: n,
+    railLabel: "Moving Money",
+    heading: `Step ${n}: Moving money — ${fx.eyebrow}`,
+    summary: fx.sub,
+    bullets,
+    links: [
+      {
+        label: fx.ctaLabel,
+        href: fx.ctaHref,
+        primary: true,
+      },
+      {
+        label: "Send money to Australia guide",
+        href: "/foreign-investment/send-money-australia",
+      },
+    ],
+    calloutTitle: "FX costs compound",
+    calloutBody:
+      "On a large transfer, the difference between a high-street bank and a specialist FX provider can be thousands of dollars. Compare before you transfer.",
+    calloutVariant: "warn",
+  };
+}
+
+function buildPensionStep(
+  config: CountryConfig,
+  n: number,
+): JourneyStep | null {
+  if (!config.retirementTransfer) return null;
+
+  const ret = config.retirementTransfer;
+  const bullets: string[] = [];
+
+  for (const acc of ret.accordions) {
+    bullets.push(`**${acc.summary}**:`);
+    bullets.push(...acc.bullets);
+  }
+
+  if (ret.callout) {
+    bullets.push(ret.callout);
+  }
+
+  return {
+    id: "pension",
+    stepNumber: n,
+    railLabel: "Pension / Super",
+    heading: `Step ${n}: ${ret.title}`,
+    summary: ret.sub,
+    bullets,
+    links: ret.ctaLinks.map((l) => ({
+      label: l.label,
+      href: l.href,
+      primary: l.primary,
+    })),
+    calloutTitle: "High-stakes decision",
+    calloutBody:
+      "Pension transfers across borders carry significant tax risk on both sides. Do not self-direct — engage a specialist before making any transfer.",
+    calloutVariant: "critical",
+  };
+}
+
+function buildReportingStep(
+  config: CountryConfig,
+  n: number,
+): JourneyStep | null {
+  if (!config.reportingObligations) return null;
+
+  const rep = config.reportingObligations;
+  const bullets: string[] = [];
+
+  for (const card of rep.cards) {
+    bullets.push(`**${card.title}**:`);
+    bullets.push(...card.bullets);
+  }
+
+  return {
+    id: "reporting",
+    stepNumber: n,
+    railLabel: "Reporting",
+    heading: `Step ${n}: ${rep.title}`,
+    summary: rep.sub,
+    bullets,
+    links: [
+      {
+        label: "Find a cross-border tax specialist",
+        href: "/advisors/international-tax-specialists",
+        primary: true,
+      },
+    ],
+    calloutTitle: "Compliance obligations",
+    calloutBody:
+      "Failing to comply with cross-border reporting requirements can result in significant penalties. Seek specialist advice.",
+    calloutVariant: "critical",
+  };
+}
+
+function buildMigrationStep(
+  config: CountryConfig,
+  n: number,
+): JourneyStep | null {
+  if (!config.migration) return null;
+
+  const mig = config.migration;
+  const bullets = mig.pathways.map(
+    (p) => `**${p.name}**: ${p.note}`,
+  );
+
+  return {
+    id: "migration",
+    stepNumber: n,
+    railLabel: "Migration",
+    heading: `Step ${n}: ${mig.title}`,
+    summary: mig.sub,
+    bullets,
+    links: [
+      {
+        label: mig.ctaLink.label,
+        href: mig.ctaLink.href,
+        primary: true,
+      },
+      {
+        label: "Visa and investment pathways",
+        href: "/visa-investment",
+      },
+    ],
+  };
+}
+
+function buildHandoffStep(config: CountryConfig, n: number): JourneyStep {
+  // Use advisorAnchor if configured, otherwise build from defaults
+  const anchor = config.advisorAnchor;
+
+  const bullets = [
+    "**FIRB specialists** — licensed to advise on FIRB applications, foreign acquisition obligations, and structuring property purchases as a non-resident.",
+    "**International tax specialists** — handle dual-country reporting, DTA positions, non-resident CGT, withholding tax refund claims, and home-country filing.",
+    "**Migration agents** — registered to advise on visa pathways, permanent residency options, and how migration status affects your investment and tax position.",
+    ...(config.retirementTransfer
+      ? [
+          `**Pension transfer specialists** — essential for ${config.countryShort}–Australia pension transfers; the risks are high and advisors need specialist cross-border pension experience.`,
+        ]
+      : []),
+  ];
+
+  return {
+    id: "handoff",
+    stepNumber: n,
+    railLabel: "Next Steps",
+    heading: `Step ${n}: Next steps — finding the right specialist`,
+    summary:
+      anchor?.body ??
+      `Cross-border investing from ${config.countryName} touches multiple specialist disciplines. The right advisor depends on your primary question: property, tax, pension transfer, or migration.`,
+    bullets,
+    links: [
+      {
+        label: "FIRB specialists",
+        href: "/advisors/firb-specialists",
+        primary: true,
+      },
+      {
+        label: "International tax specialists",
+        href: "/advisors/international-tax-specialists",
+      },
+      {
+        label: "Migration agents",
+        href: "/advisors/migration-agents",
+      },
+    ],
+  };
+}
+
+// ─── Public API ─────────────────────────────────────────────────────────────
+
+/**
+ * Build the ordered ExpatJourney from a CountryConfig.
+ *
+ * Omits any step for which no config data exists (e.g. no pension
+ * transfer section → no pension step). The steps array is always
+ * non-empty — eligibility + handoff are always present.
+ *
+ * @param config — from getCountryConfig() or COUNTRY_CONFIGS[code]
+ * @returns ExpatJourney with ordered steps
+ */
+export function buildExpatJourney(config: CountryConfig): ExpatJourney {
+  const meta = intentCountryMeta(config.code);
+
+  // Ordered candidates — null entries are filtered out below.
+  const candidates: (JourneyStep | null)[] = [];
+
+  // Counter increments as each non-null step is accepted.
+  let n = 1;
+
+  function accept(step: JourneyStep | null): void {
+    if (!step) return;
+    // Renumber based on actual accepted position
+    candidates.push({ ...step, stepNumber: n++ });
+  }
+
+  accept(buildEligibilityStep(config, n));
+  accept(buildFirbStep(config, n));
+  accept(buildInvestmentOptionsStep(config, n));
+  accept(buildTaxStep(config, n));
+  accept(buildFxStep(config, n));
+  accept(buildPensionStep(config, n));
+  accept(buildReportingStep(config, n));
+  accept(buildMigrationStep(config, n));
+  accept(buildHandoffStep(config, n));
+
+  const steps = candidates.filter((s): s is JourneyStep => s !== null);
+
+  return {
+    code: config.code,
+    countryName: config.countryName,
+    countryShort: config.countryShort,
+    flag: meta.flag,
+    currency: meta.currency,
+    steps,
+  };
+}
+
+/**
+ * Return a single step by its stable id, or undefined if not present.
+ * Useful for rendering a specific step in isolation (e.g. a step-level
+ * server component that fetches only what it needs).
+ */
+export function getJourneyStep(
+  journey: ExpatJourney,
+  id: string,
+): JourneyStep | undefined {
+  return journey.steps.find((s) => s.id === id);
+}


### PR DESCRIPTION
Deepens the foreign-investment / country-mode area into a **guided cross-border investing journey** for migrants/expats — sequencing the *existing* country data into an ordered, factual step-by-step path ending in an advisor handoff. No new datasets; single source of truth is `COUNTRY_CONFIGS`.

- `lib/expat-journey.ts` — pure `buildExpatJourney(config)` assembling ordered steps from existing data: eligibility/DTA/FIRB → property → investment options → tax (non-resident CGT/dividends) → FX → pension/super → reporting → migration → **advisor handoff** (links the existing FIRB/migration specialist directories). Steps with no data are omitted; eligibility is always first, handoff always last.
- `app/foreign-investment/journey/[country]/page.tsx` — RSC (ISR 24h, `generateStaticParams` for all 12 hub countries), progress rail + step cards, country-aware via the intent cookie, HowTo + breadcrumb JSON-LD, `GENERAL_ADVICE_WARNING` + `FOREIGN_INVESTOR_GENERAL_DISCLAIMER`.
- `app/foreign-investment/journey/page.tsx` — country picker that redirects to the saved intent-country journey.

**Fix on verification:** the agent rendered `**bold**` config copy via `dangerouslySetInnerHTML` (tripped `invest/no-unsafe-inner-html`) — replaced with a safe JSX `renderBold` helper (no innerHTML).

**Verified:** `tsc` clean · **33 tests** (per-country invariants, step ordering, link-integrity — no fabricated URLs) pass · eslint clean · jsonld gate pass. Factual + flat-fee referral (AFSL-safe). Recovered + re-verified by SHA.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUfSRE2Teb6VhEXFP6RpS9)_