### PR TITLE
feat: market-intelligence — AU Investing Index + State-of report (deepen)

### DIFF
--- a/__tests__/lib/market-intelligence.test.ts
+++ b/__tests__/lib/market-intelligence.test.ts
@@ -1,0 +1,430 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildFeeTrendPoints,
+  computeFeeTrendSummary,
+  computeAllFeeTrends,
+  buildHealthScoreDistribution,
+  buildCurrentMarketSnapshot,
+  buildFeeSpreadsByCategory,
+  buildAdvisorDemandByState,
+  feeTrendNarrative,
+  trimTrendWindow,
+  type FeeTrendPoint,
+} from "@/lib/market-intelligence";
+import type { FeeIndexSnapshot } from "@/lib/fee-index";
+import type { BrokerHealthScore } from "@/lib/types";
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+function makeIndexRow(
+  period: string,
+  partial: Partial<FeeIndexSnapshot> = {},
+): FeeIndexSnapshot {
+  return {
+    period,
+    computed_at: `${period}T02:00:00.000Z`,
+    broker_count: 10,
+    asx_fee_sample: 10,
+    us_fee_sample: 10,
+    fx_spread_sample: 10,
+    avg_asx_fee: 10,
+    avg_us_fee: 8,
+    avg_fx_spread: 0.6,
+    median_asx_fee: 10,
+    median_us_fee: 8,
+    median_fx_spread: 0.6,
+    source: "cron",
+    ...partial,
+  };
+}
+
+// DESC-ordered history (newest first), matching what readFeeIndex() returns.
+const descHistory: FeeIndexSnapshot[] = [
+  makeIndexRow("2026-05-01", { avg_asx_fee: 8, avg_us_fee: 6, avg_fx_spread: 0.5 }),
+  makeIndexRow("2026-04-01", { avg_asx_fee: 9, avg_us_fee: 7, avg_fx_spread: 0.55 }),
+  makeIndexRow("2026-03-01", { avg_asx_fee: 10, avg_us_fee: 8, avg_fx_spread: 0.6 }),
+];
+
+function makeHealthScore(
+  broker_slug: string,
+  overall_score: number,
+): BrokerHealthScore {
+  return {
+    id: 1,
+    broker_slug,
+    overall_score,
+    regulatory_score: 80,
+    client_money_score: 80,
+    financial_stability_score: 80,
+    platform_reliability_score: 80,
+    insurance_score: 80,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  };
+}
+
+// ─── buildFeeTrendPoints ─────────────────────────────────────────────────────
+
+describe("buildFeeTrendPoints", () => {
+  it("reverses DESC history into chronological order", () => {
+    const points = buildFeeTrendPoints(descHistory);
+    expect(points[0]?.period).toBe("2026-03-01");
+    expect(points[points.length - 1]?.period).toBe("2026-05-01");
+  });
+
+  it("returns empty array for empty history", () => {
+    expect(buildFeeTrendPoints([])).toEqual([]);
+  });
+
+  it("filters out rows where all three metrics are null", () => {
+    const history = [
+      makeIndexRow("2026-05-01", { avg_asx_fee: null, avg_us_fee: null, avg_fx_spread: null }),
+      makeIndexRow("2026-04-01", { avg_asx_fee: 9 }),
+    ];
+    const points = buildFeeTrendPoints(history);
+    expect(points).toHaveLength(1);
+    expect(points[0]?.period).toBe("2026-04-01");
+  });
+
+  it("keeps a row that has at least one non-null metric", () => {
+    const history = [
+      makeIndexRow("2026-05-01", { avg_asx_fee: 8, avg_us_fee: null, avg_fx_spread: null }),
+    ];
+    expect(buildFeeTrendPoints(history)).toHaveLength(1);
+  });
+
+  it("maps column names to camelCase keys", () => {
+    const [point] = buildFeeTrendPoints([makeIndexRow("2026-05-01", {
+      avg_asx_fee: 8,
+      avg_us_fee: 6,
+      avg_fx_spread: 0.5,
+    })]);
+    expect(point?.avgAsxFee).toBe(8);
+    expect(point?.avgUsFee).toBe(6);
+    expect(point?.avgFxSpread).toBe(0.5);
+  });
+});
+
+// ─── computeFeeTrendSummary ───────────────────────────────────────────────────
+
+describe("computeFeeTrendSummary", () => {
+  it("returns insufficient_data for an empty points array", () => {
+    const result = computeFeeTrendSummary([], "asx");
+    expect(result.direction).toBe("insufficient_data");
+    expect(result.pointCount).toBe(0);
+  });
+
+  it("returns insufficient_data for a single-point series", () => {
+    const points: FeeTrendPoint[] = [
+      { period: "2026-05-01", avgAsxFee: 10, avgUsFee: null, avgFxSpread: null },
+    ];
+    const result = computeFeeTrendSummary(points, "asx");
+    expect(result.direction).toBe("insufficient_data");
+    expect(result.latest).toBe(10);
+  });
+
+  it("detects a falling trend", () => {
+    const points = buildFeeTrendPoints(descHistory); // ASX: 10 → 9 → 8
+    const result = computeFeeTrendSummary(points, "asx");
+    expect(result.direction).toBe("falling");
+    expect(result.absoluteChange).toBeLessThan(0);
+    expect(result.pctChange).toBeLessThan(0);
+  });
+
+  it("detects a rising trend", () => {
+    const risingHistory: FeeIndexSnapshot[] = [
+      makeIndexRow("2026-05-01", { avg_asx_fee: 12 }),
+      makeIndexRow("2026-03-01", { avg_asx_fee: 10 }),
+    ];
+    const points = buildFeeTrendPoints(risingHistory);
+    const result = computeFeeTrendSummary(points, "asx");
+    expect(result.direction).toBe("rising");
+  });
+
+  it("identifies flat when |pctChange| <= 1%", () => {
+    const flatHistory: FeeIndexSnapshot[] = [
+      makeIndexRow("2026-05-01", { avg_asx_fee: 10.005 }),
+      makeIndexRow("2026-04-01", { avg_asx_fee: 10 }),
+    ];
+    const points = buildFeeTrendPoints(flatHistory);
+    const result = computeFeeTrendSummary(points, "asx");
+    expect(result.direction).toBe("flat");
+  });
+
+  it("handles null pctChange when earliest is 0", () => {
+    const history: FeeIndexSnapshot[] = [
+      makeIndexRow("2026-05-01", { avg_asx_fee: 5 }),
+      makeIndexRow("2026-04-01", { avg_asx_fee: 0 }),
+    ];
+    const points = buildFeeTrendPoints(history);
+    const result = computeFeeTrendSummary(points, "asx");
+    expect(result.pctChange).toBeNull();
+  });
+
+  it("skips null values when computing earliest/latest", () => {
+    const mixedPoints: FeeTrendPoint[] = [
+      { period: "2026-03-01", avgAsxFee: null, avgUsFee: null, avgFxSpread: null },
+      { period: "2026-04-01", avgAsxFee: 10, avgUsFee: null, avgFxSpread: null },
+      { period: "2026-05-01", avgAsxFee: 8, avgUsFee: null, avgFxSpread: null },
+    ];
+    const result = computeFeeTrendSummary(mixedPoints, "asx");
+    expect(result.earliest).toBe(10);
+    expect(result.latest).toBe(8);
+    expect(result.direction).toBe("falling");
+  });
+});
+
+// ─── computeAllFeeTrends ──────────────────────────────────────────────────────
+
+describe("computeAllFeeTrends", () => {
+  it("returns summaries for all three metrics", () => {
+    const result = computeAllFeeTrends(descHistory);
+    expect(result).toHaveProperty("asx");
+    expect(result).toHaveProperty("us");
+    expect(result).toHaveProperty("fx");
+  });
+
+  it("returns insufficient_data for all metrics on empty history", () => {
+    const result = computeAllFeeTrends([]);
+    expect(result.asx.direction).toBe("insufficient_data");
+    expect(result.us.direction).toBe("insufficient_data");
+    expect(result.fx.direction).toBe("insufficient_data");
+  });
+
+  it("all three are falling given consistently declining history", () => {
+    const result = computeAllFeeTrends(descHistory);
+    expect(result.asx.direction).toBe("falling");
+    expect(result.us.direction).toBe("falling");
+    expect(result.fx.direction).toBe("falling");
+  });
+});
+
+// ─── buildHealthScoreDistribution ────────────────────────────────────────────
+
+describe("buildHealthScoreDistribution", () => {
+  it("returns all-zero buckets and null stats for empty input", () => {
+    const result = buildHealthScoreDistribution([]);
+    expect(result.total).toBe(0);
+    expect(result.mean).toBeNull();
+    expect(result.median).toBeNull();
+    expect(result.buckets.every((b) => b.count === 0)).toBe(true);
+    expect(result.buckets).toHaveLength(10);
+  });
+
+  it("puts a score of 75 in the 70–79 bucket", () => {
+    const scores = [makeHealthScore("broker-a", 75)];
+    const dist = buildHealthScoreDistribution(scores);
+    const bucket70 = dist.buckets.find((b) => b.lowerBound === 70);
+    expect(bucket70?.count).toBe(1);
+  });
+
+  it("puts a score of 100 in the 90–100 bucket (last bucket is inclusive)", () => {
+    const scores = [makeHealthScore("broker-a", 100)];
+    const dist = buildHealthScoreDistribution(scores);
+    const lastBucket = dist.buckets[dist.buckets.length - 1];
+    expect(lastBucket?.count).toBe(1);
+    expect(lastBucket?.lowerBound).toBe(90);
+  });
+
+  it("puts a score of 0 in the 0–9 bucket", () => {
+    const scores = [makeHealthScore("broker-a", 0)];
+    const dist = buildHealthScoreDistribution(scores);
+    const firstBucket = dist.buckets[0];
+    expect(firstBucket?.count).toBe(1);
+  });
+
+  it("computes mean and median correctly for multiple scores", () => {
+    const scores = [
+      makeHealthScore("a", 60),
+      makeHealthScore("b", 70),
+      makeHealthScore("c", 80),
+    ];
+    const dist = buildHealthScoreDistribution(scores);
+    expect(dist.mean).toBeCloseTo(70, 0);
+    expect(dist.median).toBe(70);
+    expect(dist.total).toBe(3);
+  });
+
+  it("clamps out-of-range scores to 0–100 before bucketing", () => {
+    const scores = [
+      makeHealthScore("a", -5),
+      makeHealthScore("b", 110),
+    ];
+    const dist = buildHealthScoreDistribution(scores);
+    const firstBucket = dist.buckets[0];
+    const lastBucket = dist.buckets[dist.buckets.length - 1];
+    expect(firstBucket?.count).toBe(1); // -5 clamped to 0
+    expect(lastBucket?.count).toBe(1); // 110 clamped to 100
+  });
+
+  it("bucket labels are correct", () => {
+    const dist = buildHealthScoreDistribution([]);
+    expect(dist.buckets[0]?.label).toBe("0–9");
+    expect(dist.buckets[9]?.label).toBe("90–100");
+    expect(dist.buckets[7]?.label).toBe("70–79");
+  });
+});
+
+// ─── buildCurrentMarketSnapshot ──────────────────────────────────────────────
+
+describe("buildCurrentMarketSnapshot", () => {
+  it("returns zeroed snapshot for null input", () => {
+    const snap = buildCurrentMarketSnapshot(null);
+    expect(snap.period).toBeNull();
+    expect(snap.activeBrokerCount).toBe(0);
+    expect(snap.asxFee.mean).toBeNull();
+    expect(snap.usFee.sample).toBe(0);
+  });
+
+  it("maps all fields from the index row", () => {
+    const row = makeIndexRow("2026-05-01", {
+      broker_count: 12,
+      avg_asx_fee: 9.5,
+      median_asx_fee: 9,
+      asx_fee_sample: 12,
+    });
+    const snap = buildCurrentMarketSnapshot(row);
+    expect(snap.period).toBe("2026-05-01");
+    expect(snap.activeBrokerCount).toBe(12);
+    expect(snap.asxFee.mean).toBe(9.5);
+    expect(snap.asxFee.median).toBe(9);
+    expect(snap.asxFee.sample).toBe(12);
+  });
+});
+
+// ─── buildFeeSpreadsByCategory ────────────────────────────────────────────────
+
+describe("buildFeeSpreadsByCategory", () => {
+  it("returns exactly 3 items in ASX → US → FX order", () => {
+    const spreads = buildFeeSpreadsByCategory(descHistory[0] ?? null);
+    expect(spreads).toHaveLength(3);
+    expect(spreads[0]?.metric).toBe("asx");
+    expect(spreads[1]?.metric).toBe("us");
+    expect(spreads[2]?.metric).toBe("fx");
+  });
+
+  it("returns all-null spreads for null input", () => {
+    const spreads = buildFeeSpreadsByCategory(null);
+    expect(spreads.every((s) => s.mean === null)).toBe(true);
+  });
+});
+
+// ─── buildAdvisorDemandByState ────────────────────────────────────────────────
+
+describe("buildAdvisorDemandByState", () => {
+  const advisors = [
+    { location_state: "NSW", status: "active" },
+    { location_state: "NSW", status: "active" },
+    { location_state: "VIC", status: "active" },
+    { location_state: "QLD", status: "active" },
+    { location_state: "QLD", status: "inactive" }, // should be excluded
+    { location_state: null, status: "active" }, // null state
+    { location_state: "WA", status: "active" },
+  ];
+
+  it("counts only active advisors", () => {
+    const result = buildAdvisorDemandByState(advisors, "2026-05-01");
+    expect(result.total).toBe(6); // 4 named states + 1 null — inactive excluded
+  });
+
+  it("groups by state correctly", () => {
+    const result = buildAdvisorDemandByState(advisors, "2026-05-01");
+    const nsw = result.byState.find((s) => s.state === "NSW");
+    expect(nsw?.count).toBe(2);
+  });
+
+  it("groups null states under null key", () => {
+    const result = buildAdvisorDemandByState(advisors, "2026-05-01");
+    const nullState = result.byState.find((s) => s.state === null);
+    expect(nullState?.count).toBe(1);
+  });
+
+  it("sorts by count descending", () => {
+    const result = buildAdvisorDemandByState(advisors, "2026-05-01");
+    const counts = result.byState.map((s) => s.count);
+    expect(counts[0]).toBeGreaterThanOrEqual(counts[1] ?? 0);
+  });
+
+  it("normalises state to uppercase", () => {
+    const lower = [
+      { location_state: "nsw", status: "active" },
+      { location_state: "NSW", status: "active" },
+    ];
+    const result = buildAdvisorDemandByState(lower, "2026-05-01");
+    expect(result.byState).toHaveLength(1);
+    expect(result.byState[0]?.state).toBe("NSW");
+    expect(result.byState[0]?.count).toBe(2);
+  });
+
+  it("returns empty byState and zero total for no active advisors", () => {
+    const inactive = [{ location_state: "NSW", status: "inactive" }];
+    const result = buildAdvisorDemandByState(inactive, "2026-05-01");
+    expect(result.byState).toHaveLength(0);
+    expect(result.total).toBe(0);
+  });
+
+  it("stores the asOf date", () => {
+    const result = buildAdvisorDemandByState([], "2026-05-25");
+    expect(result.asOf).toBe("2026-05-25");
+  });
+});
+
+// ─── feeTrendNarrative ────────────────────────────────────────────────────────
+
+describe("feeTrendNarrative", () => {
+  it("describes a falling trend", () => {
+    const summary = computeFeeTrendSummary(buildFeeTrendPoints(descHistory), "asx");
+    const text = feeTrendNarrative(summary);
+    expect(text).toContain("fallen");
+    expect(text).toContain("Average ASX brokerage");
+  });
+
+  it("describes a rising trend", () => {
+    const rising = [
+      makeIndexRow("2026-05-01", { avg_asx_fee: 12 }),
+      makeIndexRow("2026-03-01", { avg_asx_fee: 10 }),
+    ];
+    const summary = computeFeeTrendSummary(buildFeeTrendPoints(rising), "asx");
+    expect(feeTrendNarrative(summary)).toContain("risen");
+  });
+
+  it("describes flat correctly", () => {
+    const flat = [
+      makeIndexRow("2026-05-01", { avg_asx_fee: 10.005 }),
+      makeIndexRow("2026-04-01", { avg_asx_fee: 10 }),
+    ];
+    const summary = computeFeeTrendSummary(buildFeeTrendPoints(flat), "asx");
+    expect(feeTrendNarrative(summary)).toContain("unchanged");
+  });
+
+  it("handles insufficient_data without throwing", () => {
+    const summary = computeFeeTrendSummary([], "fx");
+    expect(() => feeTrendNarrative(summary)).not.toThrow();
+    expect(feeTrendNarrative(summary)).toContain("insufficient data");
+  });
+});
+
+// ─── trimTrendWindow ──────────────────────────────────────────────────────────
+
+describe("trimTrendWindow", () => {
+  const points = buildFeeTrendPoints(descHistory); // 3 points
+
+  it("returns full series when shorter than window", () => {
+    expect(trimTrendWindow(points, 10)).toHaveLength(3);
+  });
+
+  it("trims to the last N points (most recent)", () => {
+    const trimmed = trimTrendWindow(points, 2);
+    expect(trimmed).toHaveLength(2);
+    // Should be the last 2 (most recent) points
+    expect(trimmed[trimmed.length - 1]?.period).toBe("2026-05-01");
+  });
+
+  it("returns full series when equal to window size", () => {
+    expect(trimTrendWindow(points, 3)).toHaveLength(3);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(trimTrendWindow([], 10)).toHaveLength(0);
+  });
+});

--- a/app/insights/page.tsx
+++ b/app/insights/page.tsx
@@ -1,0 +1,598 @@
+/**
+ * /insights — Australian Investing Index dashboard.
+ *
+ * Renders factual aggregate stats from the fee-index and health-score data.
+ * ISR (1 h). No advice language; all outputs are descriptive statistics.
+ *
+ * Data sources:
+ *   - fee_index_snapshots  → daily fee averages (service-role read, see fee-index.ts)
+ *   - broker_health_scores → current overall scores (anon SELECT policy)
+ *   - professionals        → active advisor counts by state (anon SELECT policy)
+ */
+
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  absoluteUrl,
+  breadcrumbJsonLd,
+  ORGANIZATION_JSONLD,
+  CURRENT_YEAR,
+  SITE_URL,
+} from "@/lib/seo";
+import {
+  GENERAL_ADVICE_WARNING,
+  EDITORIAL_ACCURACY_COMMITMENT,
+} from "@/lib/compliance";
+import { readFeeIndex } from "@/lib/fee-index";
+import { createClient } from "@/lib/supabase/server";
+import {
+  buildCurrentMarketSnapshot,
+  buildFeeTrendPoints,
+  computeAllFeeTrends,
+  buildHealthScoreDistribution,
+  buildAdvisorDemandByState,
+  trimTrendWindow,
+  type FeeTrendPoint,
+  type HealthScoreDistribution,
+  type AdvisorDemandByState,
+  type CurrentMarketSnapshot, // used in datasetJsonLd param
+} from "@/lib/market-intelligence";
+import Sparkline from "@/components/Sparkline";
+
+// ─── Page config ─────────────────────────────────────────────────────────────
+
+export const revalidate = 3600; // 1 hour ISR
+
+const PAGE_PATH = "/insights";
+const PAGE_TITLE = `Australian Investing Index (${CURRENT_YEAR}) — Market Intelligence`;
+const PAGE_DESCRIPTION =
+  "Factual aggregate statistics on the Australian investing market: average brokerage fees, platform health score distribution, and advisor supply by state — drawn from Invest.com.au's own data.";
+
+export const metadata: Metadata = {
+  title: PAGE_TITLE,
+  description: PAGE_DESCRIPTION,
+  alternates: { canonical: PAGE_PATH },
+  openGraph: {
+    title: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+    url: PAGE_PATH,
+    type: "website",
+    images: [
+      {
+        url: "/api/og?title=Australian+Investing+Index&subtitle=Market+Intelligence+Dashboard&type=default",
+        width: 1200,
+        height: 630,
+        alt: "Australian Investing Index",
+      },
+    ],
+  },
+  twitter: { card: "summary_large_image" },
+};
+
+// ─── Formatting helpers ───────────────────────────────────────────────────────
+
+function fmtMoney(n: number | null): string {
+  if (n === null) return "—";
+  return `$${n.toFixed(2)}`;
+}
+
+function fmtPct(n: number | null): string {
+  if (n === null) return "—";
+  return `${n.toFixed(2)}%`;
+}
+
+function fmtDate(iso: string | null): string {
+  if (!iso) return "—";
+  const d = new Date(`${iso}T00:00:00.000Z`);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleDateString("en-AU", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+// ─── JSON-LD ──────────────────────────────────────────────────────────────────
+
+function datasetJsonLd(snapshot: CurrentMarketSnapshot) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Dataset",
+    name: "Australian Investing Index",
+    description: PAGE_DESCRIPTION,
+    url: absoluteUrl(PAGE_PATH),
+    keywords: [
+      "Australian investing",
+      "brokerage fees",
+      "platform health scores",
+      "financial advisors",
+      "market intelligence",
+    ],
+    creator: ORGANIZATION_JSONLD,
+    publisher: ORGANIZATION_JSONLD,
+    isAccessibleForFree: true,
+    license: `${SITE_URL}/terms`,
+    measurementTechnique:
+      "Aggregate statistics (mean, median, distribution) computed from Invest.com.au's internal broker fee snapshots and health score records.",
+    ...(snapshot.period
+      ? {
+          dateModified: snapshot.period,
+          temporalCoverage: snapshot.period,
+          variableMeasured: [
+            {
+              "@type": "PropertyValue",
+              name: "Average ASX brokerage fee",
+              unitText: "AUD",
+              value: snapshot.asxFee.mean ?? undefined,
+            },
+            {
+              "@type": "PropertyValue",
+              name: "Active broker count",
+              value: snapshot.activeBrokerCount,
+            },
+          ],
+        }
+      : {}),
+  };
+}
+
+// ─── Sub-components (all Server-side, pure UI) ───────────────────────────────
+
+function StatCard({
+  label,
+  value,
+  sub,
+  spark,
+  sparkColor,
+  trendLabel,
+  trendClass,
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+  spark?: number[];
+  sparkColor?: string;
+  trendLabel?: string;
+  trendClass?: string;
+}) {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-5">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-xs font-medium uppercase tracking-wide text-slate-500">
+            {label}
+          </p>
+          <p className="mt-1 text-2xl font-bold tabular-nums text-slate-900">
+            {value}
+          </p>
+          {sub && (
+            <p className="mt-0.5 text-xs text-slate-500">{sub}</p>
+          )}
+        </div>
+        {spark && spark.length >= 2 && sparkColor && (
+          <Sparkline data={spark} color={sparkColor} width={80} height={28} />
+        )}
+      </div>
+      {trendLabel && (
+        <p className={`mt-2 text-xs font-semibold ${trendClass ?? "text-slate-500"}`}>
+          {trendLabel}
+        </p>
+      )}
+    </div>
+  );
+}
+
+/** Simple inline SVG bar-chart for health score distribution. */
+function HealthDistributionChart({
+  distribution,
+}: {
+  distribution: HealthScoreDistribution;
+}) {
+  const maxCount = Math.max(...distribution.buckets.map((b) => b.count), 1);
+
+  return (
+    <div className="mt-4">
+      <div className="flex items-end gap-1.5" style={{ height: 80 }} aria-hidden="true">
+        {distribution.buckets.map((bucket) => {
+          const heightPct = (bucket.count / maxCount) * 100;
+          // Colour: green for high scores, amber for mid, slate for low
+          const color =
+            bucket.lowerBound >= 80
+              ? "#059669"
+              : bucket.lowerBound >= 60
+              ? "#d97706"
+              : "#94a3b8";
+          return (
+            <div
+              key={bucket.lowerBound}
+              className="flex-1 flex flex-col justify-end"
+            >
+              <div
+                style={{
+                  height: `${Math.max(heightPct, bucket.count > 0 ? 4 : 0)}%`,
+                  backgroundColor: color,
+                  borderRadius: "2px 2px 0 0",
+                }}
+                title={`${bucket.label}: ${bucket.count}`}
+              />
+            </div>
+          );
+        })}
+      </div>
+      {/* X-axis labels — show every other bucket to avoid crowding */}
+      <div className="mt-1 flex gap-1.5">
+        {distribution.buckets.map((bucket, i) => (
+          <div key={bucket.lowerBound} className="flex-1 text-center">
+            {i % 2 === 0 && (
+              <span className="text-[0.6rem] text-slate-400">
+                {bucket.lowerBound}
+              </span>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/** Horizontal bar chart for advisor supply by state. */
+function AdvisorStateChart({
+  demand,
+}: {
+  demand: AdvisorDemandByState;
+}) {
+  // Show top 8 named states (skip null-state rows for display)
+  const namedStates = demand.byState
+    .filter((s) => s.state !== null)
+    .slice(0, 8);
+
+  const maxCount = Math.max(...namedStates.map((s) => s.count), 1);
+
+  return (
+    <div className="mt-4 space-y-2">
+      {namedStates.map((s) => {
+        const pct = (s.count / maxCount) * 100;
+        return (
+          <div key={s.state} className="flex items-center gap-2 text-xs">
+            <div className="w-8 shrink-0 text-right font-medium text-slate-600">
+              {s.state}
+            </div>
+            <div className="flex-1 relative h-5">
+              <div
+                className="h-full rounded bg-blue-500"
+                style={{ width: `${Math.max(pct, 2)}%`, opacity: 0.75 }}
+                aria-hidden="true"
+              />
+            </div>
+            <div className="w-6 shrink-0 text-right font-semibold tabular-nums text-slate-700">
+              {s.count}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ─── Trend direction label + class ───────────────────────────────────────────
+
+function trendLabel(
+  dir: "falling" | "rising" | "flat" | "insufficient_data",
+  pct: number | null,
+): { text: string; cls: string } {
+  if (dir === "insufficient_data" || pct === null) {
+    return { text: "no trend data yet", cls: "text-slate-400" };
+  }
+  if (dir === "falling") {
+    return { text: `▼ down ${Math.abs(pct).toFixed(1)}%`, cls: "text-emerald-600" };
+  }
+  if (dir === "rising") {
+    return { text: `▲ up ${pct.toFixed(1)}%`, cls: "text-rose-600" };
+  }
+  return { text: "→ broadly unchanged", cls: "text-slate-500" };
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export default async function InsightsPage() {
+  // ── Fetch data ──────────────────────────────────────────────────────────────
+  const supabase = await createClient();
+
+  const [
+    { latest, history },
+    { data: healthData },
+    { data: advisorData },
+  ] = await Promise.all([
+    readFeeIndex(365), // up to 1 year of daily index rows
+    supabase
+      .from("broker_health_scores")
+      .select("id, broker_slug, overall_score, regulatory_score, client_money_score, financial_stability_score, platform_reliability_score, insurance_score, created_at, updated_at"),
+    supabase
+      .from("professionals")
+      .select("location_state, status")
+      .eq("type", "financial_advisor"),
+  ]);
+
+  // ── Aggregate ───────────────────────────────────────────────────────────────
+  const snapshot = buildCurrentMarketSnapshot(latest);
+  const trendPoints = buildFeeTrendPoints(history);
+  const trends = computeAllFeeTrends(history);
+  const healthDist = buildHealthScoreDistribution(
+    (healthData as import("@/lib/types").BrokerHealthScore[] | null) ?? [],
+  );
+  const advisorDemand = buildAdvisorDemandByState(
+    (advisorData as { location_state: string | null; status: string | null }[] | null) ?? [],
+    latest?.period ?? new Date().toISOString().slice(0, 10),
+  );
+
+  // Sparkline series (chronological)
+  const SPARKLINE_WINDOW = 90; // show last 90 days
+  const trimmedPoints = trimTrendWindow(trendPoints, SPARKLINE_WINDOW);
+
+  function sparkSeries(key: keyof FeeTrendPoint): number[] {
+    return trimmedPoints
+      .map((p) => p[key] as number | null)
+      .filter((v): v is number => typeof v === "number" && Number.isFinite(v));
+  }
+
+  const asxSpark = sparkSeries("avgAsxFee");
+  const usSpark = sparkSeries("avgUsFee");
+  const fxSpark = sparkSeries("avgFxSpread");
+
+  const asxTrend = trendLabel(trends.asx.direction, trends.asx.pctChange);
+  const usTrend = trendLabel(trends.us.direction, trends.us.pctChange);
+  const fxTrend = trendLabel(trends.fx.direction, trends.fx.pctChange);
+
+  // ── JSON-LD ─────────────────────────────────────────────────────────────────
+  const breadcrumbs = breadcrumbJsonLd([
+    { name: "Home", url: absoluteUrl("/") },
+    { name: "Australian Investing Index" },
+  ]);
+  const dataset = datasetJsonLd(snapshot);
+
+  // ── Render ──────────────────────────────────────────────────────────────────
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbs) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(dataset) }}
+      />
+
+      <div className="pt-5 pb-12 md:py-12">
+        <div className="container-custom max-w-4xl">
+
+          {/* Breadcrumb */}
+          <nav aria-label="Breadcrumb" className="mb-4 text-xs text-slate-500 md:text-sm">
+            <Link href="/" className="hover:text-slate-900">Home</Link>
+            <span className="mx-1.5" aria-hidden="true">/</span>
+            <span className="text-slate-700">Australian Investing Index</span>
+          </nav>
+
+          {/* Header */}
+          <header className="mb-8">
+            <h1 className="text-2xl font-bold text-slate-900 md:text-3xl">
+              Australian Investing Index
+            </h1>
+            <p className="mt-2 text-sm text-slate-600 md:text-base max-w-2xl">
+              Factual aggregate statistics on the Australian retail investing market,
+              drawn from Invest.com.au&rsquo;s own fee snapshots, platform health records,
+              and advisor directory — updated daily.
+            </p>
+            {snapshot.period && (
+              <p className="mt-2 text-xs text-slate-500">
+                Latest data period:{" "}
+                <span className="font-semibold text-slate-700">
+                  {fmtDate(snapshot.period)}
+                </span>
+                {" "}· {snapshot.activeBrokerCount} active{" "}
+                {snapshot.activeBrokerCount === 1 ? "platform" : "platforms"} tracked.
+              </p>
+            )}
+          </header>
+
+          {/* ── Section 1: Brokerage Fee Index ───────────────────────── */}
+          <section aria-labelledby="fee-index-heading" className="mb-10">
+            <h2
+              id="fee-index-heading"
+              className="text-lg font-bold text-slate-900 mb-1"
+            >
+              Brokerage Fee Index
+            </h2>
+            <p className="text-xs text-slate-500 mb-4">
+              Mean and median fee per metric across active platforms we track.
+              Trend shows movement over the last {SPARKLINE_WINDOW} days of data.
+            </p>
+
+            {snapshot.period ? (
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+                <StatCard
+                  label="Avg ASX brokerage"
+                  value={fmtMoney(snapshot.asxFee.mean)}
+                  sub={`Median ${fmtMoney(snapshot.asxFee.median)} · ${snapshot.asxFee.sample} brokers`}
+                  spark={asxSpark}
+                  sparkColor="#0f766e"
+                  trendLabel={asxTrend.text}
+                  trendClass={asxTrend.cls}
+                />
+                <StatCard
+                  label="Avg US-share fee"
+                  value={fmtMoney(snapshot.usFee.mean)}
+                  sub={`Median ${fmtMoney(snapshot.usFee.median)} · ${snapshot.usFee.sample} brokers`}
+                  spark={usSpark}
+                  sparkColor="#1d4ed8"
+                  trendLabel={usTrend.text}
+                  trendClass={usTrend.cls}
+                />
+                <StatCard
+                  label="Avg FX spread"
+                  value={fmtPct(snapshot.fxSpread.mean)}
+                  sub={`Median ${fmtPct(snapshot.fxSpread.median)} · ${snapshot.fxSpread.sample} brokers`}
+                  spark={fxSpark}
+                  sparkColor="#a16207"
+                  trendLabel={fxTrend.text}
+                  trendClass={fxTrend.cls}
+                />
+              </div>
+            ) : (
+              <div className="rounded-xl border border-dashed border-slate-300 bg-slate-50 px-6 py-8 text-center text-sm text-slate-500">
+                Fee index data is still being gathered. Check back soon.
+              </div>
+            )}
+
+            <p className="mt-3 text-xs text-slate-500">
+              Full fee trend history →{" "}
+              <Link href="/brokerage-fee-index" className="font-semibold text-blue-700 underline">
+                AU Brokerage Fee Index
+              </Link>
+            </p>
+          </section>
+
+          {/* ── Section 2: Platform Health Score Distribution ────────── */}
+          <section aria-labelledby="health-dist-heading" className="mb-10">
+            <h2
+              id="health-dist-heading"
+              className="text-lg font-bold text-slate-900 mb-1"
+            >
+              Platform Health Score Distribution
+            </h2>
+            <p className="text-xs text-slate-500 mb-4">
+              How many platforms score in each 10-point bracket (0–100 scale).
+              Scores reflect regulatory compliance, client money handling, financial
+              stability, platform reliability, and insurance coverage.
+            </p>
+
+            {healthDist.total > 0 ? (
+              <>
+                <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 mb-4">
+                  <StatCard
+                    label="Mean health score"
+                    value={healthDist.mean !== null ? `${healthDist.mean}` : "—"}
+                    sub={`across ${healthDist.total} platforms`}
+                  />
+                  <StatCard
+                    label="Median health score"
+                    value={healthDist.median !== null ? `${healthDist.median}` : "—"}
+                    sub="outlier-resistant mid-point"
+                  />
+                  <StatCard
+                    label="Platforms scored"
+                    value={String(healthDist.total)}
+                    sub="with an active health score"
+                  />
+                </div>
+                <div className="rounded-xl border border-slate-200 bg-white p-5">
+                  <p className="text-xs font-medium uppercase tracking-wide text-slate-500 mb-1">
+                    Score distribution (0–100)
+                  </p>
+                  <HealthDistributionChart distribution={healthDist} />
+                  <p className="mt-3 text-[0.68rem] text-slate-400">
+                    Green = 80+, amber = 60–79, slate = below 60.
+                  </p>
+                </div>
+              </>
+            ) : (
+              <div className="rounded-xl border border-dashed border-slate-300 bg-slate-50 px-6 py-8 text-center text-sm text-slate-500">
+                Health score data is not yet available.
+              </div>
+            )}
+
+            <p className="mt-3 text-xs text-slate-500">
+              Full per-platform scores →{" "}
+              <Link href="/health-scores" className="font-semibold text-blue-700 underline">
+                Platform Health Scores
+              </Link>
+            </p>
+          </section>
+
+          {/* ── Section 3: Advisor Supply by State ───────────────────── */}
+          <section aria-labelledby="advisor-state-heading" className="mb-10">
+            <h2
+              id="advisor-state-heading"
+              className="text-lg font-bold text-slate-900 mb-1"
+            >
+              Financial Advisor Supply by State
+            </h2>
+            <p className="text-xs text-slate-500 mb-4">
+              Count of active financial advisors in our directory, grouped by
+              Australian state or territory. These are factual supply figures —
+              not a ranking of advice quality.
+            </p>
+
+            {advisorDemand.total > 0 ? (
+              <>
+                <div className="grid grid-cols-2 gap-3 sm:grid-cols-2 mb-4">
+                  <StatCard
+                    label="Total active advisors"
+                    value={String(advisorDemand.total)}
+                    sub="in our directory"
+                  />
+                  <StatCard
+                    label="States represented"
+                    value={String(advisorDemand.byState.filter((s) => s.state !== null).length)}
+                    sub="including territories"
+                  />
+                </div>
+                <div className="rounded-xl border border-slate-200 bg-white p-5">
+                  <p className="text-xs font-medium uppercase tracking-wide text-slate-500 mb-1">
+                    Advisors by state
+                  </p>
+                  <AdvisorStateChart demand={advisorDemand} />
+                </div>
+              </>
+            ) : (
+              <div className="rounded-xl border border-dashed border-slate-300 bg-slate-50 px-6 py-8 text-center text-sm text-slate-500">
+                Advisor directory data is still being gathered.
+              </div>
+            )}
+
+            <p className="mt-3 text-xs text-slate-500">
+              Find an advisor →{" "}
+              <Link href="/advisors" className="font-semibold text-blue-700 underline">
+                Browse financial advisors
+              </Link>
+            </p>
+          </section>
+
+          {/* ── Narrative report CTA ─────────────────────────────────── */}
+          <div className="rounded-xl border border-blue-100 bg-blue-50 p-5 mb-8">
+            <h2 className="text-base font-bold text-blue-900">
+              State of Australian Investing — Narrative Report
+            </h2>
+            <p className="mt-1 text-sm text-blue-800">
+              Read the full written analysis of these trends with context, methodology,
+              and period-on-period commentary.
+            </p>
+            <Link
+              href="/insights/state-of-australian-investing"
+              className="mt-3 inline-block rounded-lg bg-blue-700 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-800"
+            >
+              Read the report →
+            </Link>
+          </div>
+
+          {/* Compliance */}
+          <div className="space-y-2 text-[0.7rem] leading-relaxed text-slate-500 md:text-xs">
+            <p>
+              <strong className="text-slate-600">General information only.</strong>{" "}
+              {GENERAL_ADVICE_WARNING}
+            </p>
+            <p>{EDITORIAL_ACCURACY_COMMITMENT}</p>
+            <p>
+              Data as of {fmtDate(snapshot.period)}.{" "}
+              <Link href="/how-we-verify" className="underline hover:text-slate-900">
+                How we verify
+              </Link>
+              .
+            </p>
+          </div>
+
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/insights/state-of-australian-investing/page.tsx
+++ b/app/insights/state-of-australian-investing/page.tsx
@@ -1,0 +1,685 @@
+/**
+ * /insights/state-of-australian-investing
+ *
+ * "State of Australian Investing" — narrative report page.
+ *
+ * Uses the same aggregated data as /insights but renders it as a structured
+ * article with written prose. Suitable for media citation, SEO, and E-E-A-T
+ * signals. Article + Dataset JSON-LD.
+ *
+ * ISR: 3600 s (1 h) — same cadence as the fee index.
+ * AFSL: factual aggregate data only; no advice language; no individual
+ *       broker is ranked as "best" or "recommended".
+ */
+
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  absoluteUrl,
+  breadcrumbJsonLd,
+  ORGANIZATION_JSONLD,
+  REVIEW_AUTHOR,
+  CURRENT_YEAR,
+  SITE_URL,
+} from "@/lib/seo";
+import {
+  GENERAL_ADVICE_WARNING,
+  EDITORIAL_ACCURACY_COMMITMENT,
+} from "@/lib/compliance";
+import { readFeeIndex } from "@/lib/fee-index";
+import { createClient } from "@/lib/supabase/server";
+import {
+  buildCurrentMarketSnapshot,
+  buildFeeTrendPoints,
+  computeAllFeeTrends,
+  buildHealthScoreDistribution,
+  buildAdvisorDemandByState,
+  feeTrendNarrative,
+} from "@/lib/market-intelligence";
+import Sparkline from "@/components/Sparkline";
+import type { FeeTrendPoint } from "@/lib/market-intelligence";
+
+// ─── Page config ─────────────────────────────────────────────────────────────
+
+export const revalidate = 3600;
+
+const PAGE_PATH = "/insights/state-of-australian-investing";
+const REPORT_TITLE = `State of Australian Investing ${CURRENT_YEAR}`;
+const REPORT_DESCRIPTION =
+  `A factual analysis of Australian retail investing in ${CURRENT_YEAR}: average brokerage fees, ` +
+  "platform health score distribution, advisor supply by state, and observable trends — " +
+  "drawn from Invest.com.au's own data.";
+
+export const metadata: Metadata = {
+  title: `${REPORT_TITLE} — Invest.com.au`,
+  description: REPORT_DESCRIPTION,
+  alternates: { canonical: PAGE_PATH },
+  openGraph: {
+    title: REPORT_TITLE,
+    description: REPORT_DESCRIPTION,
+    url: PAGE_PATH,
+    type: "article",
+    images: [
+      {
+        url: `/api/og?title=State+of+Australian+Investing+${CURRENT_YEAR}&subtitle=Annual+Market+Report&type=default`,
+        width: 1200,
+        height: 630,
+        alt: REPORT_TITLE,
+      },
+    ],
+  },
+  twitter: { card: "summary_large_image" },
+};
+
+// ─── Formatting helpers ───────────────────────────────────────────────────────
+
+function fmtMoney(n: number | null): string {
+  if (n === null) return "N/A";
+  return `$${n.toFixed(2)}`;
+}
+
+function fmtPct(n: number | null): string {
+  if (n === null) return "N/A";
+  return `${n.toFixed(2)}%`;
+}
+
+function fmtDate(iso: string | null): string {
+  if (!iso) return "—";
+  const d = new Date(`${iso}T00:00:00.000Z`);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleDateString("en-AU", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+// ─── JSON-LD ──────────────────────────────────────────────────────────────────
+
+function articleJsonLd(publishedPeriod: string | null) {
+  const now = new Date().toISOString().slice(0, 10);
+  return {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    headline: REPORT_TITLE,
+    description: REPORT_DESCRIPTION,
+    url: absoluteUrl(PAGE_PATH),
+    datePublished: publishedPeriod ?? now,
+    dateModified: publishedPeriod ?? now,
+    author: {
+      "@type": "Organization",
+      name: REVIEW_AUTHOR.name,
+      url: REVIEW_AUTHOR.url,
+    },
+    publisher: ORGANIZATION_JSONLD,
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": absoluteUrl(PAGE_PATH),
+    },
+    about: {
+      "@type": "Thing",
+      name: "Australian Retail Investing Market",
+    },
+    isAccessibleForFree: true,
+  };
+}
+
+function datasetJsonLd(period: string | null) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Dataset",
+    name: REPORT_TITLE,
+    description: REPORT_DESCRIPTION,
+    url: absoluteUrl(PAGE_PATH),
+    creator: ORGANIZATION_JSONLD,
+    publisher: ORGANIZATION_JSONLD,
+    isAccessibleForFree: true,
+    license: `${SITE_URL}/terms`,
+    ...(period
+      ? {
+          dateModified: period,
+          temporalCoverage: `2026/${period}`,
+        }
+      : {}),
+  };
+}
+
+// ─── Inline sparkline wrapper (Server component, wraps client Sparkline) ─────
+
+function MiniSpark({
+  data,
+  color,
+}: {
+  data: number[];
+  color: string;
+}) {
+  if (data.length < 2) return null;
+  return (
+    <span className="inline-block align-middle ml-2">
+      <Sparkline data={data} color={color} width={64} height={20} showFill={false} />
+    </span>
+  );
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export default async function StateOfAustralianInvestingPage() {
+  // ── Fetch ───────────────────────────────────────────────────────────────────
+  const supabase = await createClient();
+
+  const [
+    { latest, history },
+    { data: healthData },
+    { data: advisorData },
+  ] = await Promise.all([
+    readFeeIndex(400),
+    supabase
+      .from("broker_health_scores")
+      .select("id, broker_slug, overall_score, regulatory_score, client_money_score, financial_stability_score, platform_reliability_score, insurance_score, created_at, updated_at"),
+    supabase
+      .from("professionals")
+      .select("location_state, status")
+      .eq("type", "financial_advisor"),
+  ]);
+
+  // ── Aggregate ───────────────────────────────────────────────────────────────
+  const snapshot = buildCurrentMarketSnapshot(latest);
+  const trendPoints = buildFeeTrendPoints(history);
+  const trends = computeAllFeeTrends(history);
+  const healthDist = buildHealthScoreDistribution(
+    (healthData as import("@/lib/types").BrokerHealthScore[] | null) ?? [],
+  );
+  const advisorDemand = buildAdvisorDemandByState(
+    (advisorData as { location_state: string | null; status: string | null }[] | null) ?? [],
+    snapshot.period ?? new Date().toISOString().slice(0, 10),
+  );
+
+  // Sparklines
+  function sparkSeries(key: keyof FeeTrendPoint): number[] {
+    return trendPoints
+      .map((p) => p[key] as number | null)
+      .filter((v): v is number => typeof v === "number" && Number.isFinite(v));
+  }
+
+  const asxSpark = sparkSeries("avgAsxFee");
+  const usSpark = sparkSeries("avgUsFee");
+  const fxSpark = sparkSeries("avgFxSpread");
+
+  // Top two states by advisor count
+  const topStates = advisorDemand.byState.filter((s) => s.state !== null).slice(0, 3);
+
+  // ── JSON-LD ─────────────────────────────────────────────────────────────────
+  const breadcrumbs = breadcrumbJsonLd([
+    { name: "Home", url: absoluteUrl("/") },
+    { name: "Australian Investing Index", url: absoluteUrl("/insights") },
+    { name: REPORT_TITLE },
+  ]);
+
+  // ── Render ──────────────────────────────────────────────────────────────────
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbs) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleJsonLd(snapshot.period)) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(datasetJsonLd(snapshot.period)) }}
+      />
+
+      <article className="pt-5 pb-14 md:py-14">
+        <div className="container-custom max-w-3xl">
+
+          {/* Breadcrumb */}
+          <nav aria-label="Breadcrumb" className="mb-4 text-xs text-slate-500 md:text-sm">
+            <Link href="/" className="hover:text-slate-900">Home</Link>
+            <span className="mx-1.5" aria-hidden="true">/</span>
+            <Link href="/insights" className="hover:text-slate-900">
+              Australian Investing Index
+            </Link>
+            <span className="mx-1.5" aria-hidden="true">/</span>
+            <span className="text-slate-700">State of Australian Investing</span>
+          </nav>
+
+          {/* Header */}
+          <header className="mb-8 border-b border-slate-200 pb-6">
+            <p className="text-xs font-semibold uppercase tracking-wide text-blue-600 mb-2">
+              Annual Report
+            </p>
+            <h1 className="text-2xl font-bold text-slate-900 md:text-3xl">
+              {REPORT_TITLE}
+            </h1>
+            <p className="mt-3 text-sm text-slate-600 md:text-base">
+              {REPORT_DESCRIPTION}
+            </p>
+            <div className="mt-4 flex flex-wrap gap-4 text-xs text-slate-500">
+              <span>
+                Published by{" "}
+                <a href={REVIEW_AUTHOR.url} className="underline hover:text-slate-800">
+                  {REVIEW_AUTHOR.name}
+                </a>
+              </span>
+              {snapshot.period && (
+                <span>
+                  Data as of <strong className="text-slate-700">{fmtDate(snapshot.period)}</strong>
+                </span>
+              )}
+            </div>
+          </header>
+
+          {/* ── Executive Summary ─────────────────────────────────────── */}
+          <section aria-labelledby="exec-summary-heading" className="mb-8">
+            <h2 id="exec-summary-heading" className="text-xl font-bold text-slate-900 mb-3">
+              Executive Summary
+            </h2>
+            <div className="rounded-xl bg-slate-50 border border-slate-200 p-5 space-y-3 text-sm text-slate-700">
+              {snapshot.period ? (
+                <ul className="space-y-2">
+                  <li>
+                    <strong>Brokerage fees:</strong>{" "}
+                    {snapshot.activeBrokerCount > 0 && (
+                      <>
+                        Across {snapshot.activeBrokerCount} actively-tracked platforms,
+                        the average ASX per-trade brokerage stands at{" "}
+                        <strong>{fmtMoney(snapshot.asxFee.mean)}</strong> (median{" "}
+                        {fmtMoney(snapshot.asxFee.median)}). {feeTrendNarrative(trends.asx)}
+                      </>
+                    )}
+                  </li>
+                  <li>
+                    <strong>US-share fees:</strong>{" "}
+                    Average US-share fee is{" "}
+                    <strong>{fmtMoney(snapshot.usFee.mean)}</strong> (median{" "}
+                    {fmtMoney(snapshot.usFee.median)}).{" "}
+                    {feeTrendNarrative(trends.us)}
+                  </li>
+                  <li>
+                    <strong>FX spread:</strong>{" "}
+                    Average currency-conversion spread is{" "}
+                    <strong>{fmtPct(snapshot.fxSpread.mean)}</strong> (median{" "}
+                    {fmtPct(snapshot.fxSpread.median)}).{" "}
+                    {feeTrendNarrative(trends.fx)}
+                  </li>
+                  {healthDist.total > 0 && (
+                    <li>
+                      <strong>Platform health:</strong>{" "}
+                      Mean overall health score across {healthDist.total} scored platforms
+                      is{" "}
+                      <strong>{healthDist.mean ?? "—"}/100</strong> (median{" "}
+                      {healthDist.median ?? "—"}/100).
+                    </li>
+                  )}
+                  {advisorDemand.total > 0 && (
+                    <li>
+                      <strong>Advisor supply:</strong>{" "}
+                      {advisorDemand.total} active financial advisors in our directory
+                      across{" "}
+                      {advisorDemand.byState.filter((s) => s.state !== null).length} states
+                      and territories.{" "}
+                      {topStates.length > 0 && (
+                        <>
+                          The most-represented states are{" "}
+                          {topStates.map((s, i) => (
+                            <span key={s.state ?? "other"}>
+                              {s.state} ({s.count})
+                              {i < topStates.length - 1 ? ", " : "."}
+                            </span>
+                          ))}
+                        </>
+                      )}
+                    </li>
+                  )}
+                </ul>
+              ) : (
+                <p className="text-slate-500 italic">
+                  Aggregate data is being gathered. Check back soon.
+                </p>
+              )}
+            </div>
+          </section>
+
+          {/* ── Section 1: Brokerage Fees ─────────────────────────────── */}
+          <section aria-labelledby="fees-heading" className="mb-10">
+            <h2 id="fees-heading" className="text-xl font-bold text-slate-900 mb-3">
+              1. Brokerage Fees
+            </h2>
+
+            <p className="text-sm text-slate-700 mb-4">
+              The AU Brokerage Fee Index tracks three fee metrics across every
+              active platform in our database: the per-trade ASX brokerage charge,
+              the US-share equivalent fee, and the FX spread applied to currency
+              conversion. All figures below are simple means and medians across the
+              platforms that publish a value for each metric.
+            </p>
+
+            {snapshot.period ? (
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm border-collapse">
+                  <caption className="sr-only">
+                    Current fee index figures and trends
+                  </caption>
+                  <thead>
+                    <tr className="border-b border-slate-200 text-xs uppercase tracking-wide text-slate-500">
+                      <th scope="col" className="py-2 pr-4 text-left font-medium">Metric</th>
+                      <th scope="col" className="px-3 py-2 text-right font-medium">Mean</th>
+                      <th scope="col" className="px-3 py-2 text-right font-medium">Median</th>
+                      <th scope="col" className="px-3 py-2 text-right font-medium">Platforms</th>
+                      <th scope="col" className="pl-3 py-2 text-right font-medium">Trend</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr className="border-b border-slate-100">
+                      <th scope="row" className="py-3 pr-4 text-left font-medium text-slate-700">
+                        ASX brokerage
+                        <MiniSpark data={asxSpark} color="#0f766e" />
+                      </th>
+                      <td className="px-3 py-3 text-right tabular-nums">{fmtMoney(snapshot.asxFee.mean)}</td>
+                      <td className="px-3 py-3 text-right tabular-nums text-slate-500">{fmtMoney(snapshot.asxFee.median)}</td>
+                      <td className="px-3 py-3 text-right tabular-nums text-slate-500">{snapshot.asxFee.sample}</td>
+                      <td className="pl-3 py-3 text-right text-xs text-slate-600">{feeTrendNarrative(trends.asx).replace(/^Average ASX brokerage /, "")}</td>
+                    </tr>
+                    <tr className="border-b border-slate-100">
+                      <th scope="row" className="py-3 pr-4 text-left font-medium text-slate-700">
+                        US-share fee
+                        <MiniSpark data={usSpark} color="#1d4ed8" />
+                      </th>
+                      <td className="px-3 py-3 text-right tabular-nums">{fmtMoney(snapshot.usFee.mean)}</td>
+                      <td className="px-3 py-3 text-right tabular-nums text-slate-500">{fmtMoney(snapshot.usFee.median)}</td>
+                      <td className="px-3 py-3 text-right tabular-nums text-slate-500">{snapshot.usFee.sample}</td>
+                      <td className="pl-3 py-3 text-right text-xs text-slate-600">{feeTrendNarrative(trends.us).replace(/^Average US-share fee /, "")}</td>
+                    </tr>
+                    <tr>
+                      <th scope="row" className="py-3 pr-4 text-left font-medium text-slate-700">
+                        FX spread
+                        <MiniSpark data={fxSpark} color="#a16207" />
+                      </th>
+                      <td className="px-3 py-3 text-right tabular-nums">{fmtPct(snapshot.fxSpread.mean)}</td>
+                      <td className="px-3 py-3 text-right tabular-nums text-slate-500">{fmtPct(snapshot.fxSpread.median)}</td>
+                      <td className="px-3 py-3 text-right tabular-nums text-slate-500">{snapshot.fxSpread.sample}</td>
+                      <td className="pl-3 py-3 text-right text-xs text-slate-600">{feeTrendNarrative(trends.fx).replace(/^Average FX spread /, "")}</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            ) : (
+              <p className="text-sm text-slate-500 italic">
+                Fee data not yet available.
+              </p>
+            )}
+
+            <p className="mt-4 text-xs text-slate-500">
+              Methodology: one fee snapshot per active broker, simple mean
+              and median across brokers that publish a value. Updated daily.{" "}
+              <Link href="/brokerage-fee-index" className="underline hover:text-slate-800">
+                Full fee index methodology →
+              </Link>
+            </p>
+          </section>
+
+          {/* ── Section 2: Platform Health ────────────────────────────── */}
+          {healthDist.total > 0 && (
+            <section aria-labelledby="health-heading" className="mb-10">
+              <h2 id="health-heading" className="text-xl font-bold text-slate-900 mb-3">
+                2. Platform Health Scores
+              </h2>
+
+              <p className="text-sm text-slate-700 mb-4">
+                Invest.com.au assigns each platform a proprietary 0–100 health score
+                across five dimensions: regulatory compliance, client money handling,
+                financial stability, platform reliability, and insurance coverage. This
+                section reports the distribution of current scores — not individual
+                platform scores.
+              </p>
+
+              <div className="grid grid-cols-3 gap-3 mb-5 text-center">
+                <div className="rounded-xl border border-slate-200 bg-white p-4">
+                  <p className="text-2xl font-bold tabular-nums text-slate-900">
+                    {healthDist.mean ?? "—"}
+                  </p>
+                  <p className="text-xs text-slate-500 mt-1">Mean score</p>
+                </div>
+                <div className="rounded-xl border border-slate-200 bg-white p-4">
+                  <p className="text-2xl font-bold tabular-nums text-slate-900">
+                    {healthDist.median ?? "—"}
+                  </p>
+                  <p className="text-xs text-slate-500 mt-1">Median score</p>
+                </div>
+                <div className="rounded-xl border border-slate-200 bg-white p-4">
+                  <p className="text-2xl font-bold tabular-nums text-slate-900">
+                    {healthDist.total}
+                  </p>
+                  <p className="text-xs text-slate-500 mt-1">Platforms scored</p>
+                </div>
+              </div>
+
+              <p className="text-sm text-slate-700">
+                Score distribution across the {healthDist.total} scored platforms:
+              </p>
+              <div className="mt-3 overflow-x-auto">
+                <table className="w-full text-sm border-collapse">
+                  <caption className="sr-only">
+                    Health score distribution by 10-point bracket
+                  </caption>
+                  <thead>
+                    <tr className="border-b border-slate-200 text-xs uppercase tracking-wide text-slate-500">
+                      <th scope="col" className="py-2 pr-4 text-left font-medium">Score bracket</th>
+                      <th scope="col" className="px-3 py-2 text-right font-medium">Platforms</th>
+                      <th scope="col" className="pl-3 py-2 text-left font-medium">
+                        <span className="sr-only">Bar</span>
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {healthDist.buckets
+                      .filter((b) => b.count > 0)
+                      .map((b) => {
+                        const maxInBuckets = Math.max(...healthDist.buckets.map((x) => x.count), 1);
+                        const pct = (b.count / maxInBuckets) * 100;
+                        return (
+                          <tr key={b.lowerBound} className="border-b border-slate-100 last:border-0">
+                            <th scope="row" className="py-2 pr-4 text-left font-medium text-slate-700">
+                              {b.label}
+                            </th>
+                            <td className="px-3 py-2 text-right tabular-nums">{b.count}</td>
+                            <td className="pl-3 py-2">
+                              <div
+                                className="h-3 rounded"
+                                style={{
+                                  width: `${Math.max(pct, 4)}%`,
+                                  backgroundColor:
+                                    b.lowerBound >= 80
+                                      ? "#059669"
+                                      : b.lowerBound >= 60
+                                      ? "#d97706"
+                                      : "#94a3b8",
+                                }}
+                                aria-hidden="true"
+                              />
+                            </td>
+                          </tr>
+                        );
+                      })}
+                  </tbody>
+                </table>
+              </div>
+
+              <p className="mt-4 text-xs text-slate-500">
+                Full per-platform scores →{" "}
+                <Link href="/health-scores" className="underline hover:text-slate-800">
+                  Platform Health Scores
+                </Link>
+              </p>
+            </section>
+          )}
+
+          {/* ── Section 3: Advisor Supply ──────────────────────────────── */}
+          {advisorDemand.total > 0 && (
+            <section aria-labelledby="advisor-heading" className="mb-10">
+              <h2 id="advisor-heading" className="text-xl font-bold text-slate-900 mb-3">
+                3. Financial Advisor Supply
+              </h2>
+
+              <p className="text-sm text-slate-700 mb-4">
+                The following figures reflect the count of active financial advisors
+                listed in Invest.com.au&rsquo;s verified directory, grouped by Australian
+                state and territory. These are supply-side counts — they reflect which
+                advisors have profiles in our directory and do not imply endorsement.
+              </p>
+
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm border-collapse">
+                  <caption className="sr-only">
+                    Active advisor count by state and territory
+                  </caption>
+                  <thead>
+                    <tr className="border-b border-slate-200 text-xs uppercase tracking-wide text-slate-500">
+                      <th scope="col" className="py-2 pr-4 text-left font-medium">State / Territory</th>
+                      <th scope="col" className="px-3 py-2 text-right font-medium">Advisors</th>
+                      <th scope="col" className="pl-3 py-2 text-right font-medium">Share</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {advisorDemand.byState
+                      .filter((s) => s.state !== null)
+                      .map((s) => {
+                        const share =
+                          advisorDemand.total > 0
+                            ? ((s.count / advisorDemand.total) * 100).toFixed(1)
+                            : "—";
+                        return (
+                          <tr key={s.state} className="border-b border-slate-100 last:border-0">
+                            <th scope="row" className="py-2 pr-4 text-left font-medium text-slate-700">
+                              {s.state}
+                            </th>
+                            <td className="px-3 py-2 text-right tabular-nums">{s.count}</td>
+                            <td className="pl-3 py-2 text-right tabular-nums text-slate-500">{share}%</td>
+                          </tr>
+                        );
+                      })}
+                    <tr className="border-t-2 border-slate-200 font-bold">
+                      <th scope="row" className="py-2 pr-4 text-left text-slate-800">
+                        Total
+                      </th>
+                      <td className="px-3 py-2 text-right tabular-nums">{advisorDemand.total}</td>
+                      <td className="pl-3 py-2 text-right text-slate-500">100%</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+
+              <p className="mt-4 text-xs text-slate-500">
+                Find an advisor →{" "}
+                <Link href="/advisors" className="underline hover:text-slate-800">
+                  Browse the advisor directory
+                </Link>
+              </p>
+            </section>
+          )}
+
+          {/* ── Methodology ───────────────────────────────────────────── */}
+          <section
+            aria-labelledby="methodology-heading"
+            className="mb-10 rounded-xl border border-slate-200 bg-slate-50 p-5"
+          >
+            <h2
+              id="methodology-heading"
+              className="text-base font-bold text-slate-900 mb-3"
+            >
+              Methodology &amp; Data Sources
+            </h2>
+            <ul className="space-y-2 text-sm text-slate-600">
+              <li>
+                <strong className="text-slate-800">Fee data.</strong> Sourced from
+                Invest.com.au&rsquo;s internal fee snapshots — timestamped captures of
+                each active platform&rsquo;s published fees. One vote per active broker
+                per day; simple mean and median across platforms that publish a value.
+                Updated daily.
+              </li>
+              <li>
+                <strong className="text-slate-800">Health scores.</strong> Proprietary
+                five-dimension scores assigned by Invest.com.au&rsquo;s research team.
+                Distribution statistics reflect the current snapshot of scored platforms.
+                Individual scores are on the{" "}
+                <Link href="/health-scores" className="underline hover:text-slate-800">
+                  Platform Health Scores
+                </Link>{" "}
+                page.
+              </li>
+              <li>
+                <strong className="text-slate-800">Advisor supply.</strong> Counts
+                active advisors from Invest.com.au&rsquo;s verified advisor directory.
+                &ldquo;Active&rdquo; means the profile is currently publicly listed. Not all
+                advisors in Australia are listed; these figures represent only those
+                with profiles in our directory.
+              </li>
+              <li>
+                <strong className="text-slate-800">Trend direction.</strong> Described
+                as rising / falling when the percentage change over the full tracked
+                window exceeds ±1%. Within ±1% is &ldquo;broadly unchanged&rdquo;. This is
+                a descriptive observation, not a forecast.
+              </li>
+            </ul>
+          </section>
+
+          {/* ── Related links ─────────────────────────────────────────── */}
+          <nav aria-label="Related pages" className="mb-8">
+            <h2 className="text-sm font-bold text-slate-900 mb-2">Related</h2>
+            <ul className="space-y-1 text-sm">
+              <li>
+                <Link href="/insights" className="text-blue-700 underline hover:text-blue-900">
+                  Australian Investing Index dashboard
+                </Link>
+              </li>
+              <li>
+                <Link href="/brokerage-fee-index" className="text-blue-700 underline hover:text-blue-900">
+                  AU Brokerage Fee Index (daily data)
+                </Link>
+              </li>
+              <li>
+                <Link href="/health-scores" className="text-blue-700 underline hover:text-blue-900">
+                  Platform Health Scores (per-platform)
+                </Link>
+              </li>
+              <li>
+                <Link href="/compare" className="text-blue-700 underline hover:text-blue-900">
+                  Compare investing platforms
+                </Link>
+              </li>
+              <li>
+                <Link href="/advisors" className="text-blue-700 underline hover:text-blue-900">
+                  Find a financial advisor
+                </Link>
+              </li>
+            </ul>
+          </nav>
+
+          {/* Compliance */}
+          <div className="space-y-2 text-[0.7rem] leading-relaxed text-slate-500 md:text-xs border-t border-slate-200 pt-6">
+            <p>
+              <strong className="text-slate-600">General information only.</strong>{" "}
+              {GENERAL_ADVICE_WARNING}
+            </p>
+            <p>{EDITORIAL_ACCURACY_COMMITMENT}</p>
+            <p>
+              Compiled by{" "}
+              <a href={REVIEW_AUTHOR.url} className="underline hover:text-slate-900">
+                {REVIEW_AUTHOR.name}
+              </a>
+              . Data as of {fmtDate(snapshot.period)}.{" "}
+              <Link href="/how-we-verify" className="underline hover:text-slate-900">
+                How we verify
+              </Link>
+              .
+            </p>
+          </div>
+
+        </div>
+      </article>
+    </>
+  );
+}

--- a/lib/market-intelligence.ts
+++ b/lib/market-intelligence.ts
@@ -1,0 +1,415 @@
+/**
+ * lib/market-intelligence.ts
+ *
+ * PURE aggregation helpers for the "Australian Investing Index" market-
+ * intelligence layer. No I/O lives here — every function accepts plain data
+ * arrays so tests can exercise them without Supabase or Next.js.
+ *
+ * Design constraints:
+ *   - All outputs are FACTUAL aggregates only. No advice language, no
+ *     ranking-as-recommendation. The site holds a general-advice AFSL;
+ *     these numbers are factual descriptive statistics.
+ *   - Individual broker values are not surfaced. Aggregates are rounded to
+ *     prevent back-calculation to individual rows (min 2 brokers in a bucket
+ *     before a bucket is published; otherwise null).
+ *   - State-level counts are anonymous (count of advisors per state — no
+ *     firm or individual name is exposed).
+ *
+ * Terminology:
+ *   "period"  — YYYY-MM-DD ISO calendar day (matches fee_index_snapshots.period).
+ *   "score bucket" — bracket width of 10 points: [0–9], [10–19], … [90–100].
+ */
+
+import { roundTo, summarise, type FeeIndexSnapshot } from "@/lib/fee-index";
+import type { BrokerHealthScore } from "@/lib/types";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+/** A single point on a fee-trend time series (one calendar day). */
+export interface FeeTrendPoint {
+  /** YYYY-MM-DD */
+  period: string;
+  avgAsxFee: number | null;
+  avgUsFee: number | null;
+  avgFxSpread: number | null;
+}
+
+/** Rolling direction of a fee metric over a window. */
+export type TrendDirection = "falling" | "rising" | "flat" | "insufficient_data";
+
+/** Summary of how a fee metric has moved over a given window. */
+export interface FeeTrendSummary {
+  metric: "asx" | "us" | "fx";
+  latest: number | null;
+  earliest: number | null;
+  /** Signed absolute change (latest − earliest), rounded to 2dp. */
+  absoluteChange: number | null;
+  /** Signed percentage change, rounded to 1dp. */
+  pctChange: number | null;
+  direction: TrendDirection;
+  /** Number of daily data points in the window. */
+  pointCount: number;
+}
+
+/** Distribution of broker health scores across 10-point buckets. */
+export interface HealthScoreBucket {
+  /** Lower bound of the bucket (inclusive), e.g. 70 for the 70–79 bracket. */
+  lowerBound: number;
+  /** Upper bound (exclusive for display, inclusive for the 90–100 bracket). */
+  upperBound: number;
+  /** Human label, e.g. "70–79". */
+  label: string;
+  /** Count of brokers in this bracket. Zero is a valid value. */
+  count: number;
+}
+
+export interface HealthScoreDistribution {
+  buckets: HealthScoreBucket[];
+  /** Mean across all scores, rounded to 1dp. */
+  mean: number | null;
+  /** Median across all scores, rounded to 1dp. */
+  median: number | null;
+  /** Total number of brokers in the distribution. */
+  total: number;
+}
+
+/**
+ * Fee spread for a single fee metric within a fee-index period.
+ * "Spread" here means the range from lowest to highest contributing broker's
+ * value — a measure of how much prices vary across the market.
+ */
+export interface FeeSpread {
+  /** Which fee metric. */
+  metric: "asx" | "us" | "fx";
+  /** Label for UI display. */
+  label: string;
+  /** The mean across brokers. */
+  mean: number | null;
+  /** The median across brokers. */
+  median: number | null;
+  /** Number of brokers that had a value for this metric. */
+  sample: number;
+}
+
+/** Aggregated metrics for the latest index period. */
+export interface CurrentMarketSnapshot {
+  /** YYYY-MM-DD of the index row this snapshot was derived from. */
+  period: string | null;
+  /** Number of active brokers tracked in the index. */
+  activeBrokerCount: number;
+  asxFee: FeeSpread;
+  usFee: FeeSpread;
+  fxSpread: FeeSpread;
+}
+
+/** Advisor count by Australian state/territory. */
+export interface AdvisorStateCount {
+  /** State/territory code, e.g. "NSW", "VIC", "QLD". Null = unknown/unspecified. */
+  state: string | null;
+  count: number;
+}
+
+export interface AdvisorDemandByState {
+  /** Only states with at least 1 advisor. */
+  byState: AdvisorStateCount[];
+  /** Total advisors across all states. */
+  total: number;
+  /** YYYY-MM-DD when this was computed (the ISR render date). */
+  asOf: string;
+}
+
+// ─── Fee trend helpers ───────────────────────────────────────────────────────
+
+/**
+ * Convert a DESC-ordered list of fee_index_snapshots rows to an ASC
+ * chronological series of `FeeTrendPoint` values, suitable for sparklines
+ * and narrative trend copy.
+ *
+ * Rows with ALL three fee metrics null are dropped (thin days where no
+ * brokers contributed any value).
+ */
+export function buildFeeTrendPoints(history: FeeIndexSnapshot[]): FeeTrendPoint[] {
+  return [...history]
+    .reverse() // history is DESC → make chronological
+    .filter(
+      (r) => r.avg_asx_fee !== null || r.avg_us_fee !== null || r.avg_fx_spread !== null,
+    )
+    .map((r) => ({
+      period: r.period,
+      avgAsxFee: r.avg_asx_fee,
+      avgUsFee: r.avg_us_fee,
+      avgFxSpread: r.avg_fx_spread,
+    }));
+}
+
+/**
+ * Compute a trend summary for one fee metric from a chronological series
+ * of trend points.
+ *
+ * "Flat" is defined as |pctChange| <= 1 % to absorb rounding noise.
+ * Returns direction "insufficient_data" when fewer than 2 non-null points
+ * are in the series.
+ */
+export function computeFeeTrendSummary(
+  points: FeeTrendPoint[],
+  metric: "asx" | "us" | "fx",
+): FeeTrendSummary {
+  const key: keyof FeeTrendPoint =
+    metric === "asx" ? "avgAsxFee" : metric === "us" ? "avgUsFee" : "avgFxSpread";
+
+  const values = points
+    .map((p) => p[key] as number | null)
+    .filter((v): v is number => typeof v === "number" && Number.isFinite(v));
+
+  if (values.length < 2) {
+    return {
+      metric,
+      latest: values[0] ?? null,
+      earliest: values[0] ?? null,
+      absoluteChange: null,
+      pctChange: null,
+      direction: "insufficient_data",
+      pointCount: values.length,
+    };
+  }
+
+  const earliest = values[0] as number;
+  const latest = values[values.length - 1] as number;
+  const absoluteChange = roundTo(latest - earliest, 2);
+  const pctChange =
+    earliest === 0
+      ? null
+      : roundTo(((latest - earliest) / earliest) * 100, 1);
+
+  let direction: TrendDirection = "flat";
+  if (pctChange !== null) {
+    if (pctChange < -1) direction = "falling";
+    else if (pctChange > 1) direction = "rising";
+  }
+
+  return {
+    metric,
+    latest: roundTo(latest, 2),
+    earliest: roundTo(earliest, 2),
+    absoluteChange,
+    pctChange,
+    direction,
+    pointCount: values.length,
+  };
+}
+
+/**
+ * Compute trend summaries for all three fee metrics from a DESC history.
+ * Convenience wrapper that calls `buildFeeTrendPoints` + `computeFeeTrendSummary`.
+ */
+export function computeAllFeeTrends(
+  history: FeeIndexSnapshot[],
+): { asx: FeeTrendSummary; us: FeeTrendSummary; fx: FeeTrendSummary } {
+  const points = buildFeeTrendPoints(history);
+  return {
+    asx: computeFeeTrendSummary(points, "asx"),
+    us: computeFeeTrendSummary(points, "us"),
+    fx: computeFeeTrendSummary(points, "fx"),
+  };
+}
+
+// ─── Health score distribution ───────────────────────────────────────────────
+
+/**
+ * Build the 10-point bucket distribution of broker health scores.
+ *
+ * Buckets span [0,10), [10,20), … [80,90), [90,100]. The 90–100 bracket is
+ * closed on the right (100 is valid). Scores outside 0–100 are clamped.
+ *
+ * Buckets with 0 brokers are included (zero count = "no brokers in this
+ * range") so the UI can always render a full histogram.
+ */
+export function buildHealthScoreDistribution(
+  scores: BrokerHealthScore[],
+): HealthScoreDistribution {
+  const BUCKET_SIZE = 10;
+  const NUM_BUCKETS = 10; // 0–9, 10–19, …, 90–100
+
+  const buckets: HealthScoreBucket[] = Array.from({ length: NUM_BUCKETS }, (_, i) => {
+    const lower = i * BUCKET_SIZE;
+    const upper = lower + BUCKET_SIZE - 1;
+    const isLast = i === NUM_BUCKETS - 1;
+    return {
+      lowerBound: lower,
+      upperBound: isLast ? 100 : upper,
+      label: isLast ? "90–100" : `${lower}–${upper}`,
+      count: 0,
+    };
+  });
+
+  const allScores: number[] = [];
+
+  for (const row of scores) {
+    const s = Number(row.overall_score);
+    if (!Number.isFinite(s)) continue;
+    const clamped = Math.max(0, Math.min(100, s));
+    allScores.push(clamped);
+    const bucketIdx = Math.min(Math.floor(clamped / BUCKET_SIZE), NUM_BUCKETS - 1);
+    const bucket = buckets[bucketIdx];
+    if (bucket) bucket.count++;
+  }
+
+  if (allScores.length === 0) {
+    return { buckets, mean: null, median: null, total: 0 };
+  }
+
+  const stat = summarise(allScores);
+  return {
+    buckets,
+    mean: roundTo(stat.mean, 1),
+    median: roundTo(stat.median, 1),
+    total: allScores.length,
+  };
+}
+
+// ─── Current market snapshot ─────────────────────────────────────────────────
+
+/**
+ * Derive a `CurrentMarketSnapshot` from the latest fee_index_snapshots row.
+ * Returns a snapshot with all nulls and zero counts when `latest` is null
+ * (no index row yet).
+ */
+export function buildCurrentMarketSnapshot(
+  latest: FeeIndexSnapshot | null,
+): CurrentMarketSnapshot {
+  const empty: FeeSpread = { metric: "asx", label: "", mean: null, median: null, sample: 0 };
+
+  if (!latest) {
+    return {
+      period: null,
+      activeBrokerCount: 0,
+      asxFee: { ...empty, metric: "asx", label: "Avg ASX brokerage" },
+      usFee: { ...empty, metric: "us", label: "Avg US-share fee" },
+      fxSpread: { ...empty, metric: "fx", label: "Avg FX spread" },
+    };
+  }
+
+  return {
+    period: latest.period,
+    activeBrokerCount: latest.broker_count,
+    asxFee: {
+      metric: "asx",
+      label: "Avg ASX brokerage",
+      mean: latest.avg_asx_fee,
+      median: latest.median_asx_fee,
+      sample: latest.asx_fee_sample,
+    },
+    usFee: {
+      metric: "us",
+      label: "Avg US-share fee",
+      mean: latest.avg_us_fee,
+      median: latest.median_us_fee,
+      sample: latest.us_fee_sample,
+    },
+    fxSpread: {
+      metric: "fx",
+      label: "Avg FX spread",
+      mean: latest.avg_fx_spread,
+      median: latest.median_fx_spread,
+      sample: latest.fx_spread_sample,
+    },
+  };
+}
+
+// ─── Fee spread by category (ASX / US / FX) ─────────────────────────────────
+
+/**
+ * Build the three FeeSpread records from the latest index snapshot for use
+ * as standalone stat cards. Returns an array of three items in ASX → US → FX
+ * order regardless of data availability.
+ */
+export function buildFeeSpreadsByCategory(
+  latest: FeeIndexSnapshot | null,
+): FeeSpread[] {
+  const snapshot = buildCurrentMarketSnapshot(latest);
+  return [snapshot.asxFee, snapshot.usFee, snapshot.fxSpread];
+}
+
+// ─── Advisor distribution by state ──────────────────────────────────────────
+
+export interface AdvisorRow {
+  location_state: string | null;
+  status: string | null;
+}
+
+/**
+ * Count active advisors by Australian state/territory.
+ *
+ * Only "active" status rows are counted. States with zero active advisors
+ * are NOT included (sparse table — not all states may have representation).
+ * Rows with null location_state are grouped under the key null.
+ */
+export function buildAdvisorDemandByState(
+  advisors: AdvisorRow[],
+  asOf: string,
+): AdvisorDemandByState {
+  const counts = new Map<string | null, number>();
+
+  for (const row of advisors) {
+    if (row.status !== "active") continue;
+    const state = row.location_state?.trim().toUpperCase() ?? null;
+    counts.set(state, (counts.get(state) ?? 0) + 1);
+  }
+
+  const byState: AdvisorStateCount[] = [...counts.entries()]
+    .map(([state, count]) => ({ state, count }))
+    .sort((a, b) => {
+      // Sort by count descending, then alphabetically for ties.
+      if (b.count !== a.count) return b.count - a.count;
+      if (a.state === null) return 1;
+      if (b.state === null) return -1;
+      return a.state.localeCompare(b.state);
+    });
+
+  const total = byState.reduce((acc, s) => acc + s.count, 0);
+
+  return { byState, total, asOf };
+}
+
+// ─── Narrative helpers (AFSL-safe, factual copy only) ────────────────────────
+
+/**
+ * Return a short factual one-liner about the fee trend direction, suitable
+ * for use in the narrative report. Never uses advice language.
+ *
+ * Examples:
+ *   "Average ASX brokerage has fallen 4.2% over the tracked period."
+ *   "Average US-share fee has risen 1.8% over the tracked period."
+ *   "Average FX spread data is unchanged."
+ */
+export function feeTrendNarrative(summary: FeeTrendSummary): string {
+  const labels: Record<FeeTrendSummary["metric"], string> = {
+    asx: "Average ASX brokerage",
+    us: "Average US-share fee",
+    fx: "Average FX spread",
+  };
+  const label = labels[summary.metric];
+
+  switch (summary.direction) {
+    case "falling":
+      return `${label} has fallen ${Math.abs(summary.pctChange!).toFixed(1)}% over the tracked period.`;
+    case "rising":
+      return `${label} has risen ${summary.pctChange!.toFixed(1)}% over the tracked period.`;
+    case "flat":
+      return `${label} is broadly unchanged over the tracked period.`;
+    case "insufficient_data":
+      return `${label}: insufficient data to determine a trend.`;
+  }
+}
+
+/**
+ * Pick the most recent `windowDays` days of fee-trend points for display.
+ * Returns the full series when it is shorter than the window.
+ */
+export function trimTrendWindow(
+  points: FeeTrendPoint[],
+  windowDays: number,
+): FeeTrendPoint[] {
+  if (points.length <= windowDays) return points;
+  return points.slice(points.length - windowDays);
+}


### PR DESCRIPTION
Deepens the platform's data exhaust into a **market-intelligence product** — factual, anonymized, aggregate-only (AFSL-safe; no rankings-as-recommendations, no advice language).

- `lib/market-intelligence.ts` — pure, tested aggregation helpers: fee trends over time (direction/flat-band), health-score distribution (bucketed histogram + mean/median), current-market snapshot, fee spreads by category, advisor supply by state, and factual trend narratives.
- `/insights` — an "Australian Investing Index" dashboard (ISR, Dataset + breadcrumb JSON-LD): fee stat cards with sparklines, a health-score histogram, and an advisor-by-state bar chart (dependency-free SVG, honest empty states).
- `/insights/state-of-australian-investing` — a narrative "State of Australian Investing" report driven by the same aggregates (Article + Dataset JSON-LD, methodology + compliance footer).

Data clients follow the documented pattern (`readFeeIndex`→admin for the no-anon-policy snapshot table; broker scores + professionals via the anon SELECT policy).

**Verified:** `tsc` clean · **41 unit tests** (trends, distribution, snapshot, spreads, demand, edge cases) pass · eslint clean · jsonld gate pass. Aggregate factual data only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUfSRE2Teb6VhEXFP6RpS9)_