### PR TITLE
feat: white-label widget suite + partner attribution (deepen embed product)

### DIFF
--- a/__tests__/api/widget-advisors.test.ts
+++ b/__tests__/api/widget-advisors.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+const mockFrom = vi.fn();
+vi.mock("@/lib/supabase/static", () => ({
+  createStaticClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+import { GET, OPTIONS } from "@/app/api/widget/advisors/route";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeChain(data: unknown[] = []) {
+  const c: Record<string, unknown> = {};
+  const methods = ["select", "eq", "order", "limit"];
+  for (const m of methods) c[m] = vi.fn(() => c);
+  c.then = (resolve: (v: { data: unknown[]; error: null }) => unknown) =>
+    Promise.resolve(resolve({ data, error: null }));
+  return c;
+}
+
+function makeReq(params: Record<string, string> = {}): NextRequest {
+  const url = new URL("http://localhost/api/widget/advisors");
+  for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
+  return new NextRequest(url.toString());
+}
+
+const ADVISOR = {
+  id: 1,
+  slug: "alice-smith",
+  name: "Alice Smith",
+  firm_name: "Smith Financial",
+  type: "financial-planner",
+  location_state: "NSW",
+  location_suburb: "Sydney",
+  location_display: "Sydney, NSW",
+  photo_url: null,
+  fee_structure: "fee-for-service",
+  initial_consultation_free: true,
+  rating: 4.7,
+  review_count: 42,
+  verified: true,
+  offer_text: "Free first session",
+  offer_active: true,
+};
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("GET /api/widget/advisors", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://abc.supabase.co";
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "anon-key";
+  });
+
+  it("returns 200 application/javascript with CORS headers", async () => {
+    mockFrom.mockReturnValue(makeChain([ADVISOR]));
+    const res = await GET(makeReq());
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toMatch(/application\/javascript/);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(res.headers.get("Access-Control-Allow-Methods")).toContain("GET");
+    expect(res.headers.get("Cross-Origin-Resource-Policy")).toBe("cross-origin");
+    expect(res.headers.get("Vary")).toBe("Origin");
+    expect(res.headers.get("Cache-Control")).toMatch(/public/);
+  });
+
+  it("sets 1h public Cache-Control", async () => {
+    mockFrom.mockReturnValue(makeChain([ADVISOR]));
+    const res = await GET(makeReq());
+    const cc = res.headers.get("Cache-Control") ?? "";
+    expect(cc).toMatch(/max-age=3600/);
+    expect(cc).toMatch(/s-maxage=3600/);
+  });
+
+  it("embeds advisor data as JSON in JS payload", async () => {
+    mockFrom.mockReturnValue(makeChain([ADVISOR]));
+    const res = await GET(makeReq());
+    const body = await res.text();
+    expect(body).toContain("Alice Smith");
+    expect(body).toContain("alice-smith");
+    expect(body).toContain("ADVISORS");
+  });
+
+  it("includes Shadow DOM setup in the JS", async () => {
+    mockFrom.mockReturnValue(makeChain([ADVISOR]));
+    const res = await GET(makeReq());
+    const body = await res.text();
+    expect(body).toContain("attachShadow");
+    expect(body).toContain("data-invest-advisors-widget");
+  });
+
+  it("includes general-advice disclaimer", async () => {
+    mockFrom.mockReturnValue(makeChain([ADVISOR]));
+    const res = await GET(makeReq());
+    const body = await res.text();
+    expect(body).toContain("General information only");
+    expect(body).toContain("Not financial advice");
+    expect(body).toContain("DISCLAIMER");
+  });
+
+  it("includes a link back to invest.com.au", async () => {
+    mockFrom.mockReturnValue(makeChain([ADVISOR]));
+    const res = await GET(makeReq());
+    const body = await res.text();
+    expect(body).toContain("invest.com.au");
+  });
+
+  it("filters by type when ?type= provided", async () => {
+    const chain = makeChain([ADVISOR]);
+    mockFrom.mockReturnValue(chain);
+    await GET(makeReq({ type: "financial-planner" }));
+    const eqCalls = (chain.eq as ReturnType<typeof vi.fn>).mock.calls;
+    expect(eqCalls.some((c) => c[0] === "type" && c[1] === "financial-planner")).toBe(true);
+  });
+
+  it("filters by state when ?state= provided", async () => {
+    const chain = makeChain([ADVISOR]);
+    mockFrom.mockReturnValue(chain);
+    await GET(makeReq({ state: "NSW" }));
+    const eqCalls = (chain.eq as ReturnType<typeof vi.fn>).mock.calls;
+    expect(eqCalls.some((c) => c[0] === "location_state" && c[1] === "NSW")).toBe(true);
+  });
+
+  it("does not add type filter when ?type= is absent", async () => {
+    const chain = makeChain([ADVISOR]);
+    mockFrom.mockReturnValue(chain);
+    await GET(makeReq());
+    const eqCalls = (chain.eq as ReturnType<typeof vi.fn>).mock.calls;
+    expect(eqCalls.some((c) => c[0] === "type")).toBe(false);
+  });
+
+  it("clamps limit to 10 when ?limit=20", async () => {
+    const chain = makeChain([ADVISOR]);
+    mockFrom.mockReturnValue(chain);
+    await GET(makeReq({ limit: "20" }));
+    expect((chain.limit as ReturnType<typeof vi.fn>).mock.calls[0]?.[0]).toBe(10);
+  });
+
+  it("clamps limit to 1 when ?limit=0", async () => {
+    const chain = makeChain([ADVISOR]);
+    mockFrom.mockReturnValue(chain);
+    await GET(makeReq({ limit: "0" }));
+    expect((chain.limit as ReturnType<typeof vi.fn>).mock.calls[0]?.[0]).toBe(1);
+  });
+
+  it("uses default limit 5 when ?limit= is absent", async () => {
+    const chain = makeChain([ADVISOR]);
+    mockFrom.mockReturnValue(chain);
+    await GET(makeReq());
+    expect((chain.limit as ReturnType<typeof vi.fn>).mock.calls[0]?.[0]).toBe(5);
+  });
+
+  it("dark theme when ?theme=dark", async () => {
+    mockFrom.mockReturnValue(makeChain([ADVISOR]));
+    const res = await GET(makeReq({ theme: "dark" }));
+    const body = await res.text();
+    expect(body).toContain('"dark"');
+  });
+
+  it("handles empty advisor result gracefully", async () => {
+    mockFrom.mockReturnValue(makeChain([]));
+    const res = await GET(makeReq());
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain("ADVISORS = []");
+  });
+
+  // ─── Partner ref tests ────────────────────────────────────────────────────
+
+  it("threads ?ref= partner ID through outbound links when provided", async () => {
+    mockFrom.mockReturnValue(makeChain([ADVISOR]));
+    const res = await GET(makeReq({ ref: "moneymag" }));
+    const body = await res.text();
+    expect(body).toContain("ref=moneymag");
+    expect(body).toContain("source=advisor-widget");
+    expect(body).toContain("REF_PARAM");
+  });
+
+  it("uses default widget ref when ?ref= is absent", async () => {
+    mockFrom.mockReturnValue(makeChain([ADVISOR]));
+    const res = await GET(makeReq());
+    const body = await res.text();
+    expect(body).toContain("ref=widget");
+    expect(body).toContain("source=advisor-embed");
+  });
+
+  it("URL-encodes the partner ref value", async () => {
+    mockFrom.mockReturnValue(makeChain([ADVISOR]));
+    const res = await GET(makeReq({ ref: "my partner" }));
+    const body = await res.text();
+    // The raw space should be encoded
+    expect(body).toContain("my%20partner");
+  });
+
+  it("queries only active professionals", async () => {
+    const chain = makeChain([ADVISOR]);
+    mockFrom.mockReturnValue(chain);
+    await GET(makeReq());
+    const eqCalls = (chain.eq as ReturnType<typeof vi.fn>).mock.calls;
+    expect(eqCalls.some((c) => c[0] === "status" && c[1] === "active")).toBe(true);
+  });
+});
+
+describe("OPTIONS /api/widget/advisors", () => {
+  it("returns 204 with CORS headers for preflight", () => {
+    const res = OPTIONS();
+    expect(res.status).toBe(204);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(res.headers.get("Access-Control-Allow-Methods")).toContain("GET");
+    expect(res.headers.get("Access-Control-Max-Age")).toBe("86400");
+    expect(res.headers.get("Vary")).toBe("Origin");
+  });
+});

--- a/__tests__/api/widget-fee-index.test.ts
+++ b/__tests__/api/widget-fee-index.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+const mockFrom = vi.fn();
+vi.mock("@/lib/supabase/static", () => ({
+  createStaticClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+import { GET, OPTIONS } from "@/app/api/widget/fee-index/route";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeChain(data: unknown[] = []) {
+  const c: Record<string, unknown> = {};
+  const methods = ["select", "eq", "order", "limit", "not"];
+  for (const m of methods) c[m] = vi.fn(() => c);
+  c.then = (resolve: (v: { data: unknown[]; error: null }) => unknown) =>
+    Promise.resolve(resolve({ data, error: null }));
+  return c;
+}
+
+function makeReq(params: Record<string, string> = {}): NextRequest {
+  const url = new URL("http://localhost/api/widget/fee-index");
+  for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
+  return new NextRequest(url.toString());
+}
+
+const BROKER = {
+  name: "Stake",
+  slug: "stake",
+  asx_fee: "$3.00",
+  asx_fee_value: 3.0,
+  us_fee: "$0.00",
+  us_fee_value: 0.0,
+  fx_rate: "0.6%",
+  rating: 4.5,
+  logo_url: null,
+  color: "#7c3aed",
+  icon: "S",
+};
+
+const BROKER_B = {
+  name: "CommSec",
+  slug: "commsec",
+  asx_fee: "$9.95",
+  asx_fee_value: 9.95,
+  us_fee: "$19.95",
+  us_fee_value: 19.95,
+  fx_rate: "0.7%",
+  rating: 4.2,
+  logo_url: null,
+  color: "#000000",
+  icon: "C",
+};
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("GET /api/widget/fee-index", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://abc.supabase.co";
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "anon-key";
+  });
+
+  it("returns 200 application/javascript with CORS headers", async () => {
+    mockFrom.mockReturnValue(makeChain([BROKER]));
+    const res = await GET(makeReq());
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toMatch(/application\/javascript/);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(res.headers.get("Access-Control-Allow-Methods")).toContain("GET");
+    expect(res.headers.get("Cross-Origin-Resource-Policy")).toBe("cross-origin");
+    expect(res.headers.get("Vary")).toBe("Origin");
+  });
+
+  it("sets 1h public Cache-Control", async () => {
+    mockFrom.mockReturnValue(makeChain([BROKER]));
+    const res = await GET(makeReq());
+    const cc = res.headers.get("Cache-Control") ?? "";
+    expect(cc).toMatch(/public/);
+    expect(cc).toMatch(/max-age=3600/);
+    expect(cc).toMatch(/s-maxage=3600/);
+  });
+
+  it("embeds broker data as JSON in JS payload", async () => {
+    mockFrom.mockReturnValue(makeChain([BROKER]));
+    const res = await GET(makeReq());
+    const body = await res.text();
+    expect(body).toContain("Stake");
+    expect(body).toContain("stake");
+    expect(body).toContain("BROKERS");
+  });
+
+  it("includes Shadow DOM setup", async () => {
+    mockFrom.mockReturnValue(makeChain([BROKER]));
+    const res = await GET(makeReq());
+    const body = await res.text();
+    expect(body).toContain("attachShadow");
+    expect(body).toContain("data-invest-fee-index-widget");
+  });
+
+  it("includes factual fee data disclaimer", async () => {
+    mockFrom.mockReturnValue(makeChain([BROKER]));
+    const res = await GET(makeReq());
+    const body = await res.text();
+    expect(body).toContain("General information only");
+    expect(body).toContain("DISCLAIMER");
+  });
+
+  it("defaults to ASX market", async () => {
+    mockFrom.mockReturnValue(makeChain([BROKER]));
+    const res = await GET(makeReq());
+    const body = await res.text();
+    expect(body).toContain('"asx"');
+  });
+
+  it("sets US market when ?market=us", async () => {
+    mockFrom.mockReturnValue(makeChain([BROKER]));
+    const res = await GET(makeReq({ market: "us" }));
+    const body = await res.text();
+    expect(body).toContain('"us"');
+  });
+
+  it("ignores invalid market param and falls back to asx", async () => {
+    mockFrom.mockReturnValue(makeChain([BROKER]));
+    const res = await GET(makeReq({ market: "crypto" }));
+    const body = await res.text();
+    expect(body).toContain('"asx"');
+  });
+
+  it("dark theme when ?theme=dark", async () => {
+    mockFrom.mockReturnValue(makeChain([BROKER]));
+    const res = await GET(makeReq({ theme: "dark" }));
+    const body = await res.text();
+    expect(body).toContain('"dark"');
+  });
+
+  it("uses rating sort when ?sort=rating (ascending:false)", async () => {
+    const chain = makeChain([BROKER]);
+    mockFrom.mockReturnValue(chain);
+    await GET(makeReq({ sort: "rating" }));
+    const orderCalls = (chain.order as ReturnType<typeof vi.fn>).mock.calls;
+    expect(orderCalls.some((c) => c[0] === "rating")).toBe(true);
+  });
+
+  it("uses asx_fee_value sort by default", async () => {
+    const chain = makeChain([BROKER]);
+    mockFrom.mockReturnValue(chain);
+    await GET(makeReq());
+    const orderCalls = (chain.order as ReturnType<typeof vi.fn>).mock.calls;
+    expect(orderCalls.some((c) => c[0] === "asx_fee_value")).toBe(true);
+  });
+
+  it("uses us_fee_value sort when ?sort=us_fee", async () => {
+    const chain = makeChain([BROKER]);
+    mockFrom.mockReturnValue(chain);
+    await GET(makeReq({ sort: "us_fee" }));
+    const orderCalls = (chain.order as ReturnType<typeof vi.fn>).mock.calls;
+    expect(orderCalls.some((c) => c[0] === "us_fee_value")).toBe(true);
+  });
+
+  it("clamps limit to 20 when ?limit=50", async () => {
+    const chain = makeChain([BROKER]);
+    mockFrom.mockReturnValue(chain);
+    await GET(makeReq({ limit: "50" }));
+    expect((chain.limit as ReturnType<typeof vi.fn>).mock.calls[0]?.[0]).toBe(20);
+  });
+
+  it("uses default limit 10 when absent", async () => {
+    const chain = makeChain([BROKER]);
+    mockFrom.mockReturnValue(chain);
+    await GET(makeReq());
+    expect((chain.limit as ReturnType<typeof vi.fn>).mock.calls[0]?.[0]).toBe(10);
+  });
+
+  it("handles empty broker result gracefully", async () => {
+    mockFrom.mockReturnValue(makeChain([]));
+    const res = await GET(makeReq());
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain("BROKERS = []");
+  });
+
+  it("includes both broker names in payload when two brokers provided", async () => {
+    mockFrom.mockReturnValue(makeChain([BROKER, BROKER_B]));
+    const res = await GET(makeReq());
+    const body = await res.text();
+    expect(body).toContain("Stake");
+    expect(body).toContain("CommSec");
+  });
+
+  it("queries only non-crypto active brokers", async () => {
+    const chain = makeChain([BROKER]);
+    mockFrom.mockReturnValue(chain);
+    await GET(makeReq());
+    const eqCalls = (chain.eq as ReturnType<typeof vi.fn>).mock.calls;
+    expect(eqCalls.some((c) => c[0] === "status" && c[1] === "active")).toBe(true);
+    expect(eqCalls.some((c) => c[0] === "is_crypto" && c[1] === false)).toBe(true);
+  });
+
+  it("includes a link to invest.com.au/fee-index", async () => {
+    mockFrom.mockReturnValue(makeChain([BROKER]));
+    const res = await GET(makeReq());
+    const body = await res.text();
+    expect(body).toContain("fee-index");
+  });
+
+  // ─── Partner ref tests ────────────────────────────────────────────────────
+
+  it("threads ?ref= partner ID through outbound links when provided", async () => {
+    mockFrom.mockReturnValue(makeChain([BROKER]));
+    const res = await GET(makeReq({ ref: "finblog" }));
+    const body = await res.text();
+    expect(body).toContain("ref=finblog");
+    expect(body).toContain("source=fee-index-widget");
+    expect(body).toContain("REF_PARAM");
+  });
+
+  it("uses default widget ref when ?ref= is absent", async () => {
+    mockFrom.mockReturnValue(makeChain([BROKER]));
+    const res = await GET(makeReq());
+    const body = await res.text();
+    expect(body).toContain("ref=widget");
+    expect(body).toContain("source=fee-index-embed");
+  });
+
+  it("URL-encodes the partner ref value", async () => {
+    mockFrom.mockReturnValue(makeChain([BROKER]));
+    const res = await GET(makeReq({ ref: "fin blog" }));
+    const body = await res.text();
+    expect(body).toContain("fin%20blog");
+  });
+});
+
+describe("OPTIONS /api/widget/fee-index", () => {
+  it("returns 204 with CORS headers for preflight", () => {
+    const res = OPTIONS();
+    expect(res.status).toBe(204);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(res.headers.get("Access-Control-Allow-Methods")).toContain("GET");
+    expect(res.headers.get("Access-Control-Max-Age")).toBe("86400");
+    expect(res.headers.get("Vary")).toBe("Origin");
+  });
+});

--- a/__tests__/api/widget-health-scores.test.ts
+++ b/__tests__/api/widget-health-scores.test.ts
@@ -143,7 +143,10 @@ describe("GET /api/widget/health-scores", () => {
     // AU HQ(5) + 13yr(15 since 2013 = ≥10yr) + rating(8) = 28 → Caution
     // The safety_label in the serialised JSON should be "Caution" not "Strong".
     // We parse the BROKERS JSON blob from the body to assert the label precisely.
-    const match = body.match(/var BROKERS = (\[.*?\]);/s);
+    // Use indexOf/substring to avoid the dotAll /s flag (only valid for es2018+)
+    const prefix = "var BROKERS = ";
+    const start = body.indexOf(prefix);
+    const match = start !== -1 ? [null, body.substring(start + prefix.length, body.indexOf(";\n", start + prefix.length))] : null;
     expect(match).toBeTruthy();
     if (match) {
       const brokers = JSON.parse(match[1]) as { safety_label: string }[];

--- a/__tests__/api/widget-health-scores.test.ts
+++ b/__tests__/api/widget-health-scores.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+const mockFrom = vi.fn();
+vi.mock("@/lib/supabase/static", () => ({
+  createStaticClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+// CURRENT_YEAR must be hoisted so the mock factory can reference it before
+// the module is loaded. Using vi.hoisted to avoid the vi.mock hoisting trap.
+const { mockCurrentYear } = vi.hoisted(() => ({ mockCurrentYear: { value: 2026 } }));
+
+vi.mock("@/lib/seo", () => ({
+  get CURRENT_YEAR() {
+    return mockCurrentYear.value;
+  },
+  absoluteUrl: (p: string) => `https://invest.com.au${p}`,
+  breadcrumbJsonLd: () => ({}),
+  SITE_NAME: "invest.com.au",
+}));
+
+import { GET, OPTIONS } from "@/app/api/widget/health-scores/route";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeChain(data: unknown[] = []) {
+  const c: Record<string, unknown> = {};
+  const methods = ["select", "eq", "order", "limit", "in"];
+  for (const m of methods) c[m] = vi.fn(() => c);
+  c.then = (resolve: (v: { data: unknown[]; error: null }) => unknown) =>
+    Promise.resolve(resolve({ data, error: null }));
+  return c;
+}
+
+function makeReq(params: Record<string, string> = {}): NextRequest {
+  const url = new URL("http://localhost/api/widget/health-scores");
+  for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
+  return new NextRequest(url.toString());
+}
+
+const BROKER = {
+  name: "Stake",
+  slug: "stake",
+  rating: 4.7,
+  regulated_by: "ASIC — AFSL 509799",
+  year_founded: 2017,
+  headquarters: "Sydney, Australia",
+  chess_sponsored: true,
+  is_crypto: false,
+  platform_type: "share_broker",
+  logo_url: null,
+  color: "#7c3aed",
+  icon: "S",
+};
+
+const BROKER_CRYPTO = {
+  name: "CoinSpot",
+  slug: "coinspot",
+  rating: 4.2,
+  regulated_by: "AUSTRAC",
+  year_founded: 2013,
+  headquarters: "Melbourne, Australia",
+  chess_sponsored: false,
+  is_crypto: true,
+  platform_type: "crypto_exchange",
+  logo_url: null,
+  color: "#f59e0b",
+  icon: "CS",
+};
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("GET /api/widget/health-scores", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCurrentYear.value = 2026;
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://abc.supabase.co";
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "anon-key";
+  });
+
+  it("returns 200 application/javascript with CORS headers", async () => {
+    mockFrom.mockReturnValue(makeChain([BROKER]));
+    const res = await GET(makeReq());
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toMatch(/application\/javascript/);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(res.headers.get("Access-Control-Allow-Methods")).toContain("GET");
+    expect(res.headers.get("Cross-Origin-Resource-Policy")).toBe("cross-origin");
+    expect(res.headers.get("Vary")).toBe("Origin");
+  });
+
+  it("sets 24h public Cache-Control", async () => {
+    mockFrom.mockReturnValue(makeChain([BROKER]));
+    const res = await GET(makeReq());
+    const cc = res.headers.get("Cache-Control") ?? "";
+    expect(cc).toMatch(/public/);
+    expect(cc).toMatch(/max-age=86400/);
+    expect(cc).toMatch(/s-maxage=86400/);
+  });
+
+  it("embeds scored broker data in the JS payload", async () => {
+    mockFrom.mockReturnValue(makeChain([BROKER]));
+    const res = await GET(makeReq());
+    const body = await res.text();
+    expect(body).toContain("Stake");
+    expect(body).toContain("stake");
+    expect(body).toContain("BROKERS");
+    expect(body).toContain("safety_score");
+    expect(body).toContain("safety_label");
+  });
+
+  it("includes Shadow DOM setup", async () => {
+    mockFrom.mockReturnValue(makeChain([BROKER]));
+    const res = await GET(makeReq());
+    const body = await res.text();
+    expect(body).toContain("attachShadow");
+    expect(body).toContain("data-invest-health-widget");
+  });
+
+  it("includes general-advice disclaimer", async () => {
+    mockFrom.mockReturnValue(makeChain([BROKER]));
+    const res = await GET(makeReq());
+    const body = await res.text();
+    expect(body).toContain("General information only");
+    expect(body).toContain("DISCLAIMER");
+  });
+
+  it("computes Strong label for well-regulated CHESS broker (Stake: ASIC+AFSL+CHESS+AU HQ+9yr+4.7 = ≥80)", async () => {
+    mockFrom.mockReturnValue(makeChain([BROKER]));
+    const res = await GET(makeReq());
+    const body = await res.text();
+    // Stake with ASIC(25)+AFSL(10)+CHESS(20)+AU HQ(5)+9yr(10)+rating(10) = 80 → Strong
+    expect(body).toContain("Strong");
+  });
+
+  it("computes lower score for crypto broker without ASIC/AFSL/CHESS", async () => {
+    mockFrom.mockReturnValue(makeChain([BROKER_CRYPTO]));
+    const res = await GET(makeReq());
+    const body = await res.text();
+    // CoinSpot: AUSTRAC does not contain "asic"/"afsl", no CHESS.
+    // AU HQ(5) + 13yr(15 since 2013 = ≥10yr) + rating(8) = 28 → Caution
+    // The safety_label in the serialised JSON should be "Caution" not "Strong".
+    // We parse the BROKERS JSON blob from the body to assert the label precisely.
+    const match = body.match(/var BROKERS = (\[.*?\]);/s);
+    expect(match).toBeTruthy();
+    if (match) {
+      const brokers = JSON.parse(match[1]) as { safety_label: string }[];
+      expect(brokers[0]?.safety_label).not.toBe("Strong");
+    }
+  });
+
+  it("calls .in() with slugs when ?brokers= provided", async () => {
+    const chain = makeChain([BROKER]);
+    mockFrom.mockReturnValue(chain);
+    await GET(makeReq({ brokers: "stake,commsec" }));
+    expect((chain.in as ReturnType<typeof vi.fn>).mock.calls[0]).toEqual([
+      "slug", ["stake", "commsec"],
+    ]);
+  });
+
+  it("does not call .in() when no brokers param", async () => {
+    const chain = makeChain([BROKER]);
+    mockFrom.mockReturnValue(chain);
+    await GET(makeReq());
+    expect((chain.in as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
+  });
+
+  it("clamps limit to 10 when ?limit=15", async () => {
+    const chain = makeChain([BROKER]);
+    mockFrom.mockReturnValue(chain);
+    await GET(makeReq({ limit: "15" }));
+    expect((chain.limit as ReturnType<typeof vi.fn>).mock.calls[0]?.[0]).toBe(10);
+  });
+
+  it("uses default limit 5 when absent", async () => {
+    const chain = makeChain([BROKER]);
+    mockFrom.mockReturnValue(chain);
+    await GET(makeReq());
+    expect((chain.limit as ReturnType<typeof vi.fn>).mock.calls[0]?.[0]).toBe(5);
+  });
+
+  it("dark theme when ?theme=dark", async () => {
+    mockFrom.mockReturnValue(makeChain([BROKER]));
+    const res = await GET(makeReq({ theme: "dark" }));
+    const body = await res.text();
+    expect(body).toContain('"dark"');
+  });
+
+  it("handles empty broker result gracefully", async () => {
+    mockFrom.mockReturnValue(makeChain([]));
+    const res = await GET(makeReq());
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain("BROKERS = []");
+  });
+
+  it("queries only active brokers via anon client", async () => {
+    const chain = makeChain([BROKER]);
+    mockFrom.mockReturnValue(chain);
+    await GET(makeReq());
+    const eqCalls = (chain.eq as ReturnType<typeof vi.fn>).mock.calls;
+    expect(eqCalls.some((c) => c[0] === "status" && c[1] === "active")).toBe(true);
+  });
+
+  it("includes a link to invest.com.au/health-scores", async () => {
+    mockFrom.mockReturnValue(makeChain([BROKER]));
+    const res = await GET(makeReq());
+    const body = await res.text();
+    expect(body).toContain("health-scores");
+  });
+
+  // ─── Score-breakdown fields ───────────────────────────────────────────────
+
+  it("embeds score_breakdown with expected keys", async () => {
+    mockFrom.mockReturnValue(makeChain([BROKER]));
+    const res = await GET(makeReq());
+    const body = await res.text();
+    expect(body).toContain("score_breakdown");
+    expect(body).toContain('"asic"');
+    expect(body).toContain('"afsl"');
+    expect(body).toContain('"chess"');
+  });
+
+  // ─── Partner ref tests ────────────────────────────────────────────────────
+
+  it("threads ?ref= partner ID through outbound links when provided", async () => {
+    mockFrom.mockReturnValue(makeChain([BROKER]));
+    const res = await GET(makeReq({ ref: "finweekly" }));
+    const body = await res.text();
+    expect(body).toContain("ref=finweekly");
+    expect(body).toContain("source=health-scores-widget");
+    expect(body).toContain("REF_PARAM");
+  });
+
+  it("uses default widget ref when ?ref= is absent", async () => {
+    mockFrom.mockReturnValue(makeChain([BROKER]));
+    const res = await GET(makeReq());
+    const body = await res.text();
+    expect(body).toContain("ref=widget");
+    expect(body).toContain("source=health-scores-embed");
+  });
+
+  it("URL-encodes the partner ref value", async () => {
+    mockFrom.mockReturnValue(makeChain([BROKER]));
+    const res = await GET(makeReq({ ref: "fin weekly" }));
+    const body = await res.text();
+    expect(body).toContain("fin%20weekly");
+  });
+});
+
+describe("OPTIONS /api/widget/health-scores", () => {
+  it("returns 204 with CORS headers for preflight", () => {
+    const res = OPTIONS();
+    expect(res.status).toBe(204);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(res.headers.get("Access-Control-Allow-Methods")).toContain("GET");
+    expect(res.headers.get("Access-Control-Max-Age")).toBe("86400");
+    expect(res.headers.get("Vary")).toBe("Origin");
+  });
+});

--- a/__tests__/api/widget-health-scores.test.ts
+++ b/__tests__/api/widget-health-scores.test.ts
@@ -146,10 +146,10 @@ describe("GET /api/widget/health-scores", () => {
     // Use indexOf/substring to avoid the dotAll /s flag (only valid for es2018+)
     const prefix = "var BROKERS = ";
     const start = body.indexOf(prefix);
-    const match = start !== -1 ? [null, body.substring(start + prefix.length, body.indexOf(";\n", start + prefix.length))] : null;
-    expect(match).toBeTruthy();
-    if (match) {
-      const brokers = JSON.parse(match[1]) as { safety_label: string }[];
+    expect(start).toBeGreaterThan(-1);
+    if (start !== -1) {
+      const jsonStr = body.substring(start + prefix.length, body.indexOf(";\n", start + prefix.length));
+      const brokers = JSON.parse(jsonStr) as { safety_label: string }[];
       expect(brokers[0]?.safety_label).not.toBe("Strong");
     }
   });

--- a/__tests__/api/widget-ref-param.test.ts
+++ b/__tests__/api/widget-ref-param.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Tests for the ?ref=<partnerId> attribution parameter threaded through
+ * all widget routes (/api/widget, /api/widget/calculator,
+ * /api/widget/advisors, /api/widget/fee-index, /api/widget/health-scores).
+ *
+ * This file focuses specifically on the ref-param contract so the
+ * individual widget test files stay focused on their own widget logic.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+// All five routes share the same static client, so one mock factory is enough.
+
+const mockFrom = vi.fn();
+vi.mock("@/lib/supabase/static", () => ({
+  createStaticClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+const { mockCurrentYear } = vi.hoisted(() => ({ mockCurrentYear: { value: 2026 } }));
+vi.mock("@/lib/seo", () => ({
+  get CURRENT_YEAR() {
+    return mockCurrentYear.value;
+  },
+  absoluteUrl: (p: string) => `https://invest.com.au${p}`,
+  breadcrumbJsonLd: () => ({}),
+  SITE_NAME: "invest.com.au",
+}));
+
+import { GET as getBrokerWidget } from "@/app/api/widget/route";
+import { GET as getCalcWidget } from "@/app/api/widget/calculator/route";
+import { GET as getAdvisorsWidget } from "@/app/api/widget/advisors/route";
+import { GET as getFeeIndexWidget } from "@/app/api/widget/fee-index/route";
+import { GET as getHealthWidget } from "@/app/api/widget/health-scores/route";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeChain(data: unknown[] = []) {
+  const c: Record<string, unknown> = {};
+  const methods = ["select", "eq", "order", "limit", "in", "not"];
+  for (const m of methods) c[m] = vi.fn(() => c);
+  c.then = (resolve: (v: { data: unknown[]; error: null }) => unknown) =>
+    Promise.resolve(resolve({ data, error: null }));
+  return c;
+}
+
+function makeReq(base: string, params: Record<string, string> = {}): NextRequest {
+  const url = new URL(`http://localhost${base}`);
+  for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
+  return new NextRequest(url.toString());
+}
+
+const BROKER_ROW = {
+  name: "Stake", slug: "stake", asx_fee: "$3", us_fee: "$0", fx_rate: "0.6%",
+  rating: 4.5, chess_sponsored: true, platform_type: "share_broker", logo_url: null,
+  color: "#7c3aed", icon: "S", deal: null, deal_text: null,
+  asx_fee_value: 3, us_fee_value: 0, affiliate_url: null,
+};
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockCurrentYear.value = 2026;
+  process.env.NEXT_PUBLIC_SUPABASE_URL = "https://abc.supabase.co";
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "anon-key";
+});
+
+// ── /api/widget ───────────────────────────────────────────────────────────────
+
+describe("/api/widget ?ref= threading", () => {
+  it("embeds partner ref in REF_PARAM variable", async () => {
+    mockFrom.mockReturnValue(makeChain([BROKER_ROW]));
+    const res = await getBrokerWidget(makeReq("/api/widget", { ref: "partnerA" }));
+    const body = await res.text();
+    expect(body).toContain("REF_PARAM");
+    expect(body).toContain("ref=partnerA");
+    expect(body).toContain("source=widget");
+  });
+
+  it("falls back to ref=widget&source=embed when ?ref= absent", async () => {
+    mockFrom.mockReturnValue(makeChain([BROKER_ROW]));
+    const res = await getBrokerWidget(makeReq("/api/widget"));
+    const body = await res.text();
+    expect(body).toContain("ref=widget");
+    expect(body).toContain("source=embed");
+  });
+
+  it("URL-encodes partner ref with special characters", async () => {
+    mockFrom.mockReturnValue(makeChain([BROKER_ROW]));
+    const res = await getBrokerWidget(makeReq("/api/widget", { ref: "partner x&y" }));
+    const body = await res.text();
+    expect(body).toContain("partner%20x%26y");
+  });
+
+  it("outbound /go/ links contain the REF_PARAM variable (not a hardcoded ref)", async () => {
+    mockFrom.mockReturnValue(makeChain([BROKER_ROW]));
+    const res = await getBrokerWidget(makeReq("/api/widget", { ref: "pubX" }));
+    const body = await res.text();
+    // The link construction uses REF_PARAM not a hardcoded string
+    expect(body).toContain('"/go/" + esc(b.slug) + "?" + REF_PARAM');
+  });
+
+  it("footer link contains the REF_PARAM variable", async () => {
+    mockFrom.mockReturnValue(makeChain([BROKER_ROW]));
+    const res = await getBrokerWidget(makeReq("/api/widget", { ref: "pubX" }));
+    const body = await res.text();
+    expect(body).toContain('BASE + "?" + REF_PARAM');
+  });
+});
+
+// ── /api/widget/calculator ────────────────────────────────────────────────────
+
+describe("/api/widget/calculator ?ref= threading", () => {
+  const calcChain = () => {
+    const chain = makeChain([{ ...BROKER_ROW, asx_fee_value: 3, us_fee_value: 0, fx_rate: 0.6, affiliate_url: null }]);
+    return chain;
+  };
+
+  it("embeds partner ref in REF_PARAM variable", async () => {
+    mockFrom.mockReturnValue(calcChain());
+    const res = await getCalcWidget(makeReq("/api/widget/calculator", { ref: "calcPub" }));
+    const body = await res.text();
+    expect(body).toContain("REF_PARAM");
+    expect(body).toContain("ref=calcPub");
+    expect(body).toContain("source=calc-widget");
+  });
+
+  it("falls back to ref=widget&source=calc-embed when ?ref= absent", async () => {
+    mockFrom.mockReturnValue(calcChain());
+    const res = await getCalcWidget(makeReq("/api/widget/calculator"));
+    const body = await res.text();
+    expect(body).toContain("ref=widget");
+    expect(body).toContain("source=calc-embed");
+  });
+
+  it("full-calculator link uses REF_PARAM variable", async () => {
+    mockFrom.mockReturnValue(calcChain());
+    const res = await getCalcWidget(makeReq("/api/widget/calculator", { ref: "cP" }));
+    const body = await res.text();
+    expect(body).toContain("trade-cost-calculator?");
+    expect(body).toContain("REF_PARAM");
+  });
+
+  it("footer link uses REF_PARAM variable", async () => {
+    mockFrom.mockReturnValue(calcChain());
+    const res = await getCalcWidget(makeReq("/api/widget/calculator", { ref: "cP" }));
+    const body = await res.text();
+    expect(body).toContain('BASE + "?" + REF_PARAM');
+  });
+
+  it("outbound /go/ link uses REF_PARAM variable", async () => {
+    mockFrom.mockReturnValue(calcChain());
+    const res = await getCalcWidget(makeReq("/api/widget/calculator", { ref: "cP" }));
+    const body = await res.text();
+    expect(body).toContain('"/go/" + esc(r.broker.slug) + "?" + REF_PARAM');
+  });
+});
+
+// ── /api/widget/advisors ──────────────────────────────────────────────────────
+
+describe("/api/widget/advisors ?ref= threading", () => {
+  const ADVISOR = { id: 1, slug: "alice", name: "Alice", firm_name: "Smith", type: "financial-planner",
+    location_state: "NSW", location_suburb: "Sydney", location_display: "Sydney NSW",
+    photo_url: null, fee_structure: "fee-for-service", initial_consultation_free: true,
+    rating: 4.7, review_count: 10, verified: true, offer_text: null, offer_active: false };
+
+  it("embeds partner ref in REF_PARAM when ?ref= provided", async () => {
+    mockFrom.mockReturnValue(makeChain([ADVISOR]));
+    const res = await getAdvisorsWidget(makeReq("/api/widget/advisors", { ref: "advPub" }));
+    const body = await res.text();
+    expect(body).toContain("ref=advPub");
+    expect(body).toContain("source=advisor-widget");
+  });
+
+  it("uses default attribution when ?ref= absent", async () => {
+    mockFrom.mockReturnValue(makeChain([ADVISOR]));
+    const res = await getAdvisorsWidget(makeReq("/api/widget/advisors"));
+    const body = await res.text();
+    expect(body).toContain("ref=widget");
+    expect(body).toContain("source=advisor-embed");
+  });
+});
+
+// ── /api/widget/fee-index ─────────────────────────────────────────────────────
+
+describe("/api/widget/fee-index ?ref= threading", () => {
+  const FI_BROKER = { ...BROKER_ROW, asx_fee: "$3", asx_fee_value: 3 };
+
+  it("embeds partner ref in REF_PARAM when ?ref= provided", async () => {
+    mockFrom.mockReturnValue(makeChain([FI_BROKER]));
+    const res = await getFeeIndexWidget(makeReq("/api/widget/fee-index", { ref: "fiPub" }));
+    const body = await res.text();
+    expect(body).toContain("ref=fiPub");
+    expect(body).toContain("source=fee-index-widget");
+  });
+
+  it("uses default attribution when ?ref= absent", async () => {
+    mockFrom.mockReturnValue(makeChain([FI_BROKER]));
+    const res = await getFeeIndexWidget(makeReq("/api/widget/fee-index"));
+    const body = await res.text();
+    expect(body).toContain("ref=widget");
+    expect(body).toContain("source=fee-index-embed");
+  });
+});
+
+// ── /api/widget/health-scores ─────────────────────────────────────────────────
+
+describe("/api/widget/health-scores ?ref= threading", () => {
+  const HS_BROKER = { ...BROKER_ROW, regulated_by: "ASIC — AFSL 509799",
+    year_founded: 2017, headquarters: "Sydney, Australia",
+    chess_sponsored: true, is_crypto: false, platform_type: "share_broker" };
+
+  it("embeds partner ref in REF_PARAM when ?ref= provided", async () => {
+    mockFrom.mockReturnValue(makeChain([HS_BROKER]));
+    const res = await getHealthWidget(makeReq("/api/widget/health-scores", { ref: "hsPub" }));
+    const body = await res.text();
+    expect(body).toContain("ref=hsPub");
+    expect(body).toContain("source=health-scores-widget");
+  });
+
+  it("uses default attribution when ?ref= absent", async () => {
+    mockFrom.mockReturnValue(makeChain([HS_BROKER]));
+    const res = await getHealthWidget(makeReq("/api/widget/health-scores"));
+    const body = await res.text();
+    expect(body).toContain("ref=widget");
+    expect(body).toContain("source=health-scores-embed");
+  });
+});

--- a/app/api/widget/advisors/route.ts
+++ b/app/api/widget/advisors/route.ts
@@ -1,0 +1,260 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createStaticClient } from "@/lib/supabase/static";
+
+export const runtime = "nodejs";
+// 1h ISR cache — advisor data refreshes infrequently.
+export const revalidate = 3600;
+
+/**
+ * GET /api/widget/advisors — Returns self-contained JavaScript that renders
+ * an embeddable financial-advisor directory widget inside a Shadow DOM.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * PUBLIC-BY-DESIGN ENDPOINT — CORS contract (mirrors /api/widget):
+ *   • `Access-Control-Allow-Origin: *` is INTENTIONAL — embed feature.
+ *   • Must NEVER read user-context data. No cookies, no auth, no per-user
+ *     state. Only public, active-advisor columns are returned.
+ *   • Uses the anon-key client so Postgres RLS enforces active-only reads.
+ *     Do NOT swap to createAdminClient().
+ *   • Cache-Control allows public CDN caching — responses are not
+ *     personalised.
+ * ─────────────────────────────────────────────────────────────────────────
+ *
+ * AFSL compliance: this widget presents factual directory information
+ * (advisor names, types, locations, ratings). It does NOT constitute
+ * financial product advice or a referral/personal recommendation.
+ * The general-advice disclaimer is included in the rendered output.
+ *
+ * Query params:
+ *   ?type=financial-planner|mortgage-broker|...   — filter by advisor type
+ *   ?state=NSW|VIC|QLD|...                        — filter by AU state
+ *   ?limit=5                                      — max advisors (default 5, max 10)
+ *   ?theme=light|dark                             — colour theme (default: light)
+ *   ?ref=<partnerId>                              — partner attribution; appended to
+ *                                                   all outbound invest.com.au links
+ */
+export async function GET(request: NextRequest) {
+  const params = request.nextUrl.searchParams;
+  const typeFilter = params.get("type") || "";
+  const stateFilter = params.get("state") || "";
+  const theme = params.get("theme") === "dark" ? "dark" : "light";
+  const parsedLimit = parseInt(params.get("limit") ?? "", 10);
+  const limit = Number.isNaN(parsedLimit)
+    ? 5
+    : Math.min(Math.max(parsedLimit, 1), 10);
+  // Partner attribution: threaded through all outbound links to invest.com.au.
+  // No storage, no new tables — purely a query-param passthrough for affiliate
+  // attribution on the destination page.
+  const ref = params.get("ref") || "";
+
+  const supabase = createStaticClient();
+
+  let query = supabase
+    .from("professionals")
+    .select(
+      "id, slug, name, firm_name, type, location_state, location_suburb, location_display, photo_url, fee_structure, initial_consultation_free, rating, review_count, verified, offer_text, offer_active",
+    )
+    .eq("status", "active")
+    .order("rating", { ascending: false })
+    .limit(limit);
+
+  if (typeFilter) {
+    query = query.eq("type", typeFilter);
+  }
+  if (stateFilter) {
+    query = query.eq("location_state", stateFilter);
+  }
+
+  const { data: advisors } = await query;
+  const rows = advisors || [];
+
+  const advisorsJson = JSON.stringify(rows);
+
+  // Build the ref query param string for outbound links.
+  // If a partnerId was provided, it takes priority; otherwise fall back
+  // to the default widget attribution signal so analytics can distinguish
+  // traffic from widget embeds.
+  const refParam = ref
+    ? `ref=${encodeURIComponent(ref)}&source=advisor-widget`
+    : "ref=widget&source=advisor-embed";
+
+  const DISCLAIMER =
+    "General information only. Does not take into account your personal situation. " +
+    "Not financial advice. Consider seeking professional advice before making any financial decision.";
+
+  const js = `
+(function() {
+  "use strict";
+  if (typeof document === "undefined") return;
+
+  var ADVISORS = ${advisorsJson};
+  var THEME = ${JSON.stringify(theme)};
+  var DISCLAIMER = ${JSON.stringify(DISCLAIMER)};
+  var REF_PARAM = ${JSON.stringify(refParam)};
+  var BASE = "https://invest.com.au";
+
+  // Find the script tag that loaded us (last matching script on page)
+  var scripts = document.querySelectorAll("script[src*='/api/widget/advisors']");
+  var currentScript = scripts[scripts.length - 1];
+  if (!currentScript) return;
+
+  // Create host element + shadow DOM for style isolation
+  var host = document.createElement("div");
+  host.setAttribute("data-invest-advisors-widget", "true");
+  currentScript.parentNode.insertBefore(host, currentScript.nextSibling);
+
+  var shadow = host.attachShadow({ mode: "open" });
+
+  // ─── Theme tokens ──────────────────────────────────────────────
+  var isDark = THEME === "dark";
+  var bg       = isDark ? "#1e293b" : "#ffffff";
+  var border   = isDark ? "#334155" : "#e2e8f0";
+  var text     = isDark ? "#f1f5f9" : "#0f172a";
+  var textMuted= isDark ? "#94a3b8" : "#64748b";
+  var rowHover = isDark ? "#334155" : "#f8fafc";
+  var accent   = "#059669";
+  var ctaBg    = "#059669";
+  var ctaText  = "#ffffff";
+  var badgeBg  = isDark ? "#064e3b" : "#ecfdf5";
+  var badgeBorder = isDark ? "#10b981" : "#a7f3d0";
+
+  // ─── Styles ────────────────────────────────────────────────────
+  var styles = document.createElement("style");
+  styles.textContent = [
+    ":host { all: initial; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; display: block; }",
+    ".iaw { background:" + bg + "; border:1px solid " + border + "; border-radius:12px; overflow:hidden; max-width:720px; font-size:13px; color:" + text + "; }",
+    ".iaw-header { padding:12px 16px; font-weight:700; font-size:15px; border-bottom:1px solid " + border + "; display:flex; align-items:center; justify-content:space-between; }",
+    ".iaw-card { display:flex; align-items:flex-start; gap:12px; padding:12px 16px; border-bottom:1px solid " + border + "; transition:background .15s; }",
+    ".iaw-card:hover { background:" + rowHover + "; }",
+    ".iaw-card:last-child { border-bottom:none; }",
+    ".iaw-avatar { width:40px; height:40px; border-radius:50%; flex-shrink:0; overflow:hidden; background:" + accent + "20; display:flex; align-items:center; justify-content:center; font-weight:700; font-size:14px; color:" + accent + "; }",
+    ".iaw-avatar img { width:100%; height:100%; object-fit:cover; }",
+    ".iaw-body { flex:1; min-width:0; }",
+    ".iaw-name { font-weight:700; font-size:13px; display:flex; align-items:center; gap:5px; flex-wrap:wrap; }",
+    ".iaw-firm { font-size:11px; color:" + textMuted + "; margin-top:1px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }",
+    ".iaw-meta { display:flex; flex-wrap:wrap; gap:6px; margin-top:5px; }",
+    ".iaw-pill { font-size:10px; padding:2px 7px; border-radius:100px; background:" + (isDark ? "#334155" : "#f1f5f9") + "; color:" + textMuted + "; white-space:nowrap; }",
+    ".iaw-pill.free { background:" + badgeBg + "; color:" + accent + "; border:1px solid " + badgeBorder + "; }",
+    ".iaw-verified { display:inline-block; width:14px; height:14px; background:" + accent + "; border-radius:50%; color:#fff; font-size:9px; text-align:center; line-height:14px; flex-shrink:0; }",
+    ".iaw-rating { font-size:11px; font-weight:700; color:" + accent + "; }",
+    ".iaw-offer { font-size:11px; color:" + textMuted + "; margin-top:4px; font-style:italic; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }",
+    ".iaw-cta { display:inline-block; padding:5px 12px; background:" + ctaBg + "; color:" + ctaText + "; border-radius:6px; text-decoration:none; font-weight:600; font-size:11px; white-space:nowrap; transition:opacity .15s; align-self:center; flex-shrink:0; }",
+    ".iaw-cta:hover { opacity:.88; }",
+    ".iaw-disclaimer { padding:8px 16px; font-size:10px; color:" + textMuted + "; border-top:1px solid " + border + "; line-height:1.5; }",
+    ".iaw-footer { padding:8px 16px; text-align:center; font-size:11px; color:" + textMuted + "; border-top:1px solid " + border + "; }",
+    ".iaw-footer a { color:" + accent + "; text-decoration:none; font-weight:600; }",
+    ".iaw-footer a:hover { text-decoration:underline; }",
+    ".iaw-empty { padding:24px 16px; text-align:center; font-size:13px; color:" + textMuted + "; }",
+    "@media (max-width:480px) { .iaw-card { gap:8px; } .iaw-cta { padding:4px 8px; font-size:10px; } }",
+  ].join("\\n");
+  shadow.appendChild(styles);
+
+  // ─── Helpers ───────────────────────────────────────────────────
+  function esc(s) {
+    if (!s) return "";
+    var d = document.createElement("div");
+    d.appendChild(document.createTextNode(String(s)));
+    return d.innerHTML;
+  }
+
+  function fmtType(t) {
+    if (!t) return "";
+    return t.replace(/-/g, " ").replace(/\\b\\w/g, function(c) { return c.toUpperCase(); });
+  }
+
+  // ─── Render ────────────────────────────────────────────────────
+  var container = document.createElement("div");
+  container.className = "iaw";
+
+  container.innerHTML =
+    '<div class="iaw-header">' +
+      '<span>Financial Advisors</span>' +
+      '<a href="' + BASE + '/advisors?' + REF_PARAM + '" target="_blank" style="font-size:11px;font-weight:400;color:' + textMuted + ';text-decoration:none;">Browse all &rarr;</a>' +
+    '</div>';
+
+  if (ADVISORS.length === 0) {
+    container.innerHTML += '<div class="iaw-empty">No advisors found matching your filters.</div>';
+  } else {
+    for (var i = 0; i < ADVISORS.length; i++) {
+      var a = ADVISORS[i];
+      var profileUrl = BASE + "/advisors/" + esc(a.slug) + "?" + REF_PARAM;
+
+      var avatarHtml = a.photo_url
+        ? '<div class="iaw-avatar"><img src="' + esc(a.photo_url) + '" alt="' + esc(a.name) + '"></div>'
+        : '<div class="iaw-avatar">' + esc((a.name || "A").charAt(0)) + '</div>';
+
+      var verifiedHtml = a.verified
+        ? '<span class="iaw-verified" title="Verified advisor">&#10003;</span>'
+        : "";
+
+      var ratingHtml = a.rating
+        ? '<span class="iaw-rating">&#9733; ' + parseFloat(a.rating).toFixed(1) + '</span>' +
+          (a.review_count ? '<span style="font-size:10px;color:' + textMuted + '"> (' + a.review_count + ')</span>' : "")
+        : "";
+
+      var typePill = a.type
+        ? '<span class="iaw-pill">' + esc(fmtType(a.type)) + '</span>'
+        : "";
+      var statePill = a.location_state
+        ? '<span class="iaw-pill">' + esc(a.location_state) + '</span>'
+        : "";
+      var freePill = a.initial_consultation_free
+        ? '<span class="iaw-pill free">Free consult</span>'
+        : "";
+      var feePill = a.fee_structure
+        ? '<span class="iaw-pill">' + esc(fmtType(a.fee_structure)) + '</span>'
+        : "";
+
+      var offerHtml = a.offer_active && a.offer_text
+        ? '<div class="iaw-offer">Offer: ' + esc(a.offer_text) + '</div>'
+        : "";
+
+      container.innerHTML +=
+        '<div class="iaw-card">' +
+          avatarHtml +
+          '<div class="iaw-body">' +
+            '<div class="iaw-name">' + esc(a.name) + verifiedHtml + (ratingHtml ? ' <span style="margin-left:2px;">' + ratingHtml + '</span>' : '') + '</div>' +
+            (a.firm_name ? '<div class="iaw-firm">' + esc(a.firm_name) + '</div>' : '') +
+            '<div class="iaw-meta">' + typePill + statePill + feePill + freePill + '</div>' +
+            offerHtml +
+          '</div>' +
+          '<a class="iaw-cta" href="' + profileUrl + '" target="_blank" rel="noopener noreferrer">View &rarr;</a>' +
+        '</div>';
+    }
+  }
+
+  container.innerHTML += '<div class="iaw-disclaimer">' + esc(DISCLAIMER) + '</div>';
+  container.innerHTML += '<div class="iaw-footer">Powered by <a href="' + BASE + '/advisors?' + REF_PARAM + '" target="_blank">invest.com.au</a></div>';
+
+  shadow.appendChild(container);
+})();
+`;
+
+  return new NextResponse(js.trim(), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/javascript; charset=utf-8",
+      "Cache-Control": "public, max-age=3600, s-maxage=3600",
+      // Public-by-design: see header comment. Mirrors /api/widget CORS policy.
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, OPTIONS",
+      "Cross-Origin-Resource-Policy": "cross-origin",
+      Vary: "Origin",
+    },
+  });
+}
+
+/**
+ * CORS pre-flight. Mirrors /api/widget OPTIONS handler.
+ */
+export function OPTIONS() {
+  return new NextResponse(null, {
+    status: 204,
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, OPTIONS",
+      "Access-Control-Max-Age": "86400",
+      Vary: "Origin",
+    },
+  });
+}

--- a/app/api/widget/calculator/route.ts
+++ b/app/api/widget/calculator/route.ts
@@ -30,6 +30,8 @@ export const revalidate = 3600;
  *   ?theme=light|dark      — colour theme (default: light)
  *   ?limit=5               — max brokers to show (default: 5, max: 10)
  *   ?amount=5000           — default trade amount pre-filled (default: 5000)
+ *   ?ref=<partnerId>       — partner attribution; appended to all outbound
+ *                            invest.com.au links (no storage, query-param only)
  */
 export async function GET(request: NextRequest) {
   const params = request.nextUrl.searchParams;
@@ -43,6 +45,8 @@ export async function GET(request: NextRequest) {
   const defaultAmount = Number.isNaN(parsedAmount)
     ? 5000
     : Math.min(Math.max(parsedAmount, 1), 1_000_000);
+  // Partner attribution — see /api/widget for the same pattern.
+  const ref = params.get("ref") || "";
 
   // Anon-key client: RLS enforces active-only broker rows. See header comment.
   const supabase = createStaticClient();
@@ -70,6 +74,12 @@ export async function GET(request: NextRequest) {
 
   const brokersJson = JSON.stringify(rows);
 
+  // Ref param string for outbound links. Partner ID takes priority; falls
+  // back to the generic calculator-widget attribution signal.
+  const refParam = ref
+    ? `ref=${encodeURIComponent(ref)}&source=calc-widget`
+    : "ref=widget&source=calc-embed";
+
   // General-advice disclaimer text — keep in sync with
   // lib/compliance.ts GENERAL_ADVICE_WARNING.
   const DISCLAIMER =
@@ -86,6 +96,7 @@ export async function GET(request: NextRequest) {
   var DEFAULT_AMOUNT = ${JSON.stringify(defaultAmount)};
   var THEME = ${JSON.stringify(theme)};
   var DISCLAIMER = ${JSON.stringify(DISCLAIMER)};
+  var REF_PARAM = ${JSON.stringify(refParam)};
   var BASE = "https://invest.com.au";
 
   // Find the script tag that loaded us (last matching script on page)
@@ -218,7 +229,7 @@ export async function GET(request: NextRequest) {
     container.innerHTML =
       '<div class="icw-header">' +
         '<span>Brokerage Fee Calculator</span>' +
-        '<a href="' + BASE + '/trade-cost-calculator?ref=widget" target="_blank" style="font-size:11px;font-weight:400;color:' + textMuted + ';text-decoration:none;">Full calculator &rarr;</a>' +
+        '<a href="' + BASE + '/trade-cost-calculator?' + REF_PARAM + '" target="_blank" style="font-size:11px;font-weight:400;color:' + textMuted + ';text-decoration:none;">Full calculator &rarr;</a>' +
       '</div>';
 
     // Controls
@@ -253,8 +264,8 @@ export async function GET(request: NextRequest) {
 
       var badge = isCheapest ? '<span class="icw-badge">Cheapest</span>' : '';
       var link = r.broker.affiliate_url
-        ? esc(r.broker.affiliate_url) + (r.broker.affiliate_url.includes("?") ? "&" : "?") + "ref=widget&source=calc-embed"
-        : BASE + "/go/" + esc(r.broker.slug) + "?ref=widget&source=calc-embed";
+        ? esc(r.broker.affiliate_url) + (r.broker.affiliate_url.includes("?") ? "&" : "?") + REF_PARAM
+        : BASE + "/go/" + esc(r.broker.slug) + "?" + REF_PARAM;
 
       container.innerHTML +=
         '<div class="icw-row' + (isCheapest ? " cheapest" : "") + '">' +
@@ -280,7 +291,7 @@ export async function GET(request: NextRequest) {
     container.innerHTML += '<div class="icw-disclaimer">' + esc(DISCLAIMER) + '</div>';
 
     // Footer
-    container.innerHTML += '<div class="icw-footer">Powered by <a href="' + BASE + '?ref=calc-widget" target="_blank">invest.com.au</a></div>';
+    container.innerHTML += '<div class="icw-footer">Powered by <a href="' + BASE + "?" + REF_PARAM + '" target="_blank">invest.com.au</a></div>';
 
     // Swap in
     while (shadow.firstChild && shadow.firstChild !== styles) shadow.removeChild(shadow.firstChild);

--- a/app/api/widget/fee-index/route.ts
+++ b/app/api/widget/fee-index/route.ts
@@ -1,0 +1,267 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createStaticClient } from "@/lib/supabase/static";
+
+export const runtime = "nodejs";
+// 1h ISR cache — fee data changes at most daily via the fee cron.
+export const revalidate = 3600;
+
+/**
+ * GET /api/widget/fee-index — Returns self-contained JavaScript that renders
+ * an embeddable AU brokerage-fee-index table widget inside a Shadow DOM.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * PUBLIC-BY-DESIGN ENDPOINT — CORS contract (mirrors /api/widget):
+ *   • `Access-Control-Allow-Origin: *` is INTENTIONAL — embed feature.
+ *   • Must NEVER read user-context data. No cookies, no auth, no per-user
+ *     state. The data here is the same as on the public broker pages.
+ *   • Uses the anon-key client so Postgres RLS enforces active-only reads.
+ *     Do NOT swap to createAdminClient().
+ *   • Cache-Control allows public CDN caching — responses are not
+ *     personalised.
+ * ─────────────────────────────────────────────────────────────────────────
+ *
+ * AFSL compliance: this widget presents factual aggregate brokerage-fee
+ * data (ASX per-trade fees, US share fees, FX spreads) from publicly
+ * disclosed broker fee schedules. It is NOT financial advice.
+ * The general-advice disclaimer is included in the rendered output.
+ *
+ * "Fee index" here means the market-wide view — a sortable table of per-
+ * broker fees so visitors can compare the AU brokerage fee landscape at a
+ * glance. This mirrors the information on the /fee-index public page.
+ *
+ * Query params:
+ *   ?market=asx|us          — which market's fees to highlight (default: asx)
+ *   ?sort=asx_fee|us_fee|rating — sort column (default: asx_fee ascending)
+ *   ?theme=light|dark        — colour theme (default: light)
+ *   ?limit=10                — max brokers (default: 10, max: 20)
+ *   ?ref=<partnerId>         — partner attribution; appended to all outbound
+ *                              invest.com.au links
+ */
+export async function GET(request: NextRequest) {
+  const params = request.nextUrl.searchParams;
+  const market = params.get("market") === "us" ? "us" : "asx";
+  const rawSort = params.get("sort") || "";
+  const sort: "asx_fee" | "us_fee" | "rating" = ["asx_fee", "us_fee", "rating"].includes(rawSort)
+    ? (rawSort as "asx_fee" | "us_fee" | "rating")
+    : "asx_fee";
+  const theme = params.get("theme") === "dark" ? "dark" : "light";
+  const parsedLimit = parseInt(params.get("limit") ?? "", 10);
+  const limit = Number.isNaN(parsedLimit)
+    ? 10
+    : Math.min(Math.max(parsedLimit, 1), 20);
+  const ref = params.get("ref") || "";
+
+  const supabase = createStaticClient();
+
+  // Determine Supabase ordering. For fees we want ascending (cheapest first);
+  // for rating we want descending (highest first).
+  const isRatingSort = sort === "rating";
+
+  const { data: brokers } = await supabase
+    .from("brokers")
+    .select(
+      "name, slug, asx_fee, asx_fee_value, us_fee, us_fee_value, fx_rate, rating, logo_url, color, icon",
+    )
+    .eq("status", "active")
+    .eq("is_crypto", false)
+    .order(isRatingSort ? "rating" : sort === "us_fee" ? "us_fee_value" : "asx_fee_value", {
+      ascending: !isRatingSort,
+      nullsFirst: false,
+    })
+    .limit(limit);
+
+  const rows = (brokers || []) as {
+    name: string;
+    slug: string;
+    asx_fee: string | null;
+    asx_fee_value: number | null;
+    us_fee: string | null;
+    us_fee_value: number | null;
+    fx_rate: string | null;
+    rating: number | null;
+    logo_url: string | null;
+    color: string | null;
+    icon: string | null;
+  }[];
+
+  const brokersJson = JSON.stringify(rows);
+
+  // Ref param string for outbound links.
+  const refParam = ref
+    ? `ref=${encodeURIComponent(ref)}&source=fee-index-widget`
+    : "ref=widget&source=fee-index-embed";
+
+  const DISCLAIMER =
+    "General information only. Fee data sourced from publicly disclosed broker schedules. " +
+    "Not financial advice. Always verify current fees directly with the provider before trading.";
+
+  const js = `
+(function() {
+  "use strict";
+  if (typeof document === "undefined") return;
+
+  var BROKERS = ${brokersJson};
+  var MARKET = ${JSON.stringify(market)};
+  var THEME = ${JSON.stringify(theme)};
+  var DISCLAIMER = ${JSON.stringify(DISCLAIMER)};
+  var REF_PARAM = ${JSON.stringify(refParam)};
+  var BASE = "https://invest.com.au";
+
+  // Find the script tag that loaded us (last matching script on page)
+  var scripts = document.querySelectorAll("script[src*='/api/widget/fee-index']");
+  var currentScript = scripts[scripts.length - 1];
+  if (!currentScript) return;
+
+  // Create host element + shadow DOM for style isolation
+  var host = document.createElement("div");
+  host.setAttribute("data-invest-fee-index-widget", "true");
+  currentScript.parentNode.insertBefore(host, currentScript.nextSibling);
+
+  var shadow = host.attachShadow({ mode: "open" });
+
+  // ─── Theme tokens ──────────────────────────────────────────────
+  var isDark = THEME === "dark";
+  var bg       = isDark ? "#1e293b" : "#ffffff";
+  var bgInput  = isDark ? "#0f172a" : "#f8fafc";
+  var border   = isDark ? "#334155" : "#e2e8f0";
+  var text     = isDark ? "#f1f5f9" : "#0f172a";
+  var textMuted= isDark ? "#94a3b8" : "#64748b";
+  var rowHover = isDark ? "#334155" : "#f8fafc";
+  var accent   = "#059669";
+  var ctaBg    = "#059669";
+  var ctaText  = "#ffffff";
+  var cheapestBg = isDark ? "#064e3b" : "#ecfdf5";
+  var cheapestBorder = isDark ? "#10b981" : "#a7f3d0";
+
+  // ─── Styles ────────────────────────────────────────────────────
+  var styles = document.createElement("style");
+  styles.textContent = [
+    ":host { all: initial; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; display: block; }",
+    ".ifi { background:" + bg + "; border:1px solid " + border + "; border-radius:12px; overflow:hidden; max-width:720px; font-size:13px; color:" + text + "; }",
+    ".ifi-header { padding:12px 16px; font-weight:700; font-size:15px; border-bottom:1px solid " + border + "; display:flex; align-items:center; justify-content:space-between; }",
+    ".ifi-thead { display:grid; grid-template-columns:1fr 90px 90px 70px 90px; padding:7px 16px; background:" + bgInput + "; border-bottom:1px solid " + border + "; font-size:10px; font-weight:700; text-transform:uppercase; letter-spacing:.05em; color:" + textMuted + "; }",
+    ".ifi-row { display:grid; grid-template-columns:1fr 90px 90px 70px 90px; align-items:center; padding:9px 16px; border-bottom:1px solid " + border + "; transition:background .15s; }",
+    ".ifi-row:hover { background:" + rowHover + "; }",
+    ".ifi-row:last-child { border-bottom:none; }",
+    ".ifi-row.cheapest { background:" + cheapestBg + "; border-left:3px solid " + accent + "; }",
+    ".ifi-name { font-weight:600; display:flex; align-items:center; gap:7px; font-size:13px; }",
+    ".ifi-logo { width:24px; height:24px; border-radius:5px; display:flex; align-items:center; justify-content:center; font-weight:700; font-size:10px; flex-shrink:0; overflow:hidden; }",
+    ".ifi-logo img { width:100%; height:100%; object-fit:contain; }",
+    ".ifi-badge { font-size:9px; font-weight:700; text-transform:uppercase; color:" + accent + "; background:" + cheapestBg + "; border:1px solid " + cheapestBorder + "; border-radius:4px; padding:1px 5px; }",
+    ".ifi-fee { font-variant-numeric:tabular-nums; font-weight:600; font-size:12px; }",
+    ".ifi-fee.highlight { color:" + accent + "; }",
+    ".ifi-rating { color:" + accent + "; font-weight:700; font-size:12px; }",
+    ".ifi-cta { display:inline-block; padding:4px 10px; background:" + ctaBg + "; color:" + ctaText + "; border-radius:6px; text-decoration:none; font-weight:600; font-size:11px; text-align:center; transition:opacity .15s; white-space:nowrap; }",
+    ".ifi-cta:hover { opacity:.88; }",
+    ".ifi-disclaimer { padding:8px 16px; font-size:10px; color:" + textMuted + "; border-top:1px solid " + border + "; line-height:1.5; }",
+    ".ifi-footer { padding:8px 16px; text-align:center; font-size:11px; color:" + textMuted + "; border-top:1px solid " + border + "; }",
+    ".ifi-footer a { color:" + accent + "; text-decoration:none; font-weight:600; }",
+    ".ifi-footer a:hover { text-decoration:underline; }",
+    ".ifi-empty { padding:24px 16px; text-align:center; font-size:13px; color:" + textMuted + "; }",
+    /* Responsive: hide less-critical columns on small widths */
+    "@media (max-width:500px) { .ifi-thead { grid-template-columns:1fr 80px 60px; } .ifi-row { grid-template-columns:1fr 80px 60px; } .ifi-hide-sm { display:none; } }",
+  ].join("\\n");
+  shadow.appendChild(styles);
+
+  // ─── Helpers ───────────────────────────────────────────────────
+  function esc(s) {
+    if (!s) return "";
+    var d = document.createElement("div");
+    d.appendChild(document.createTextNode(String(s)));
+    return d.innerHTML;
+  }
+
+  // ─── Build container ───────────────────────────────────────────
+  var container = document.createElement("div");
+  container.className = "ifi";
+
+  var marketLabel = MARKET === "us" ? "US Shares" : "ASX Shares";
+  container.innerHTML =
+    '<div class="ifi-header">' +
+      '<span>AU Brokerage Fee Index — ' + marketLabel + '</span>' +
+      '<a href="' + BASE + '/fee-index?' + REF_PARAM + '" target="_blank" style="font-size:11px;font-weight:400;color:' + textMuted + ';text-decoration:none;">Full index &rarr;</a>' +
+    '</div>';
+
+  if (BROKERS.length === 0) {
+    container.innerHTML += '<div class="ifi-empty">No fee data available.</div>';
+  } else {
+    // Column headers
+    container.innerHTML +=
+      '<div class="ifi-thead">' +
+        '<div>Broker</div>' +
+        '<div>ASX Fee</div>' +
+        '<div class="ifi-hide-sm">US Fee</div>' +
+        '<div class="ifi-hide-sm">Rating</div>' +
+        '<div></div>' +
+      '</div>';
+
+    // Find cheapest broker for primary market
+    var cheapestIdx = -1;
+    var cheapestVal = Infinity;
+    for (var i = 0; i < BROKERS.length; i++) {
+      var fv = MARKET === "us" ? BROKERS[i].us_fee_value : BROKERS[i].asx_fee_value;
+      if (fv !== null && fv !== undefined && fv < cheapestVal) {
+        cheapestVal = fv;
+        cheapestIdx = i;
+      }
+    }
+
+    for (var j = 0; j < BROKERS.length; j++) {
+      var b = BROKERS[j];
+      var isCheapest = (j === cheapestIdx);
+
+      var logoHtml = b.logo_url
+        ? '<div class="ifi-logo" style="background:#fff;border:1px solid ' + border + '"><img src="' + esc(b.logo_url) + '" alt="' + esc(b.name) + '"></div>'
+        : '<div class="ifi-logo" style="background:' + esc(b.color || "#059669") + '20;color:' + esc(b.color || "#059669") + '">' + esc((b.icon || b.name.charAt(0))) + '</div>';
+
+      var badge = isCheapest ? ' <span class="ifi-badge">Cheapest</span>' : "";
+      var link = BASE + "/go/" + esc(b.slug) + "?" + REF_PARAM;
+      var asxClass = MARKET === "asx" ? ' highlight' : "";
+      var usClass  = MARKET === "us"  ? ' highlight' : "";
+
+      container.innerHTML +=
+        '<div class="ifi-row' + (isCheapest ? " cheapest" : "") + '">' +
+          '<div class="ifi-name">' + logoHtml + esc(b.name) + badge + '</div>' +
+          '<div><span class="ifi-fee' + asxClass + '">' + esc(b.asx_fee || "N/A") + '</span></div>' +
+          '<div class="ifi-hide-sm"><span class="ifi-fee' + usClass + '">' + esc(b.us_fee || "N/A") + '</span></div>' +
+          '<div class="ifi-hide-sm"><span class="ifi-rating">' + (b.rating ? parseFloat(b.rating).toFixed(1) : "N/A") + '</span></div>' +
+          '<div><a class="ifi-cta" href="' + link + '" target="_blank" rel="noopener noreferrer nofollow sponsored">Visit &rarr;</a></div>' +
+        '</div>';
+    }
+  }
+
+  container.innerHTML += '<div class="ifi-disclaimer">' + esc(DISCLAIMER) + '</div>';
+  container.innerHTML += '<div class="ifi-footer">Powered by <a href="' + BASE + '/fee-index?' + REF_PARAM + '" target="_blank">invest.com.au</a></div>';
+
+  shadow.appendChild(container);
+})();
+`;
+
+  return new NextResponse(js.trim(), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/javascript; charset=utf-8",
+      "Cache-Control": "public, max-age=3600, s-maxage=3600",
+      // Public-by-design: see header comment. Mirrors /api/widget CORS policy.
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, OPTIONS",
+      "Cross-Origin-Resource-Policy": "cross-origin",
+      Vary: "Origin",
+    },
+  });
+}
+
+/**
+ * CORS pre-flight. Mirrors /api/widget OPTIONS handler.
+ */
+export function OPTIONS() {
+  return new NextResponse(null, {
+    status: 204,
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, OPTIONS",
+      "Access-Control-Max-Age": "86400",
+      Vary: "Origin",
+    },
+  });
+}

--- a/app/api/widget/health-scores/route.ts
+++ b/app/api/widget/health-scores/route.ts
@@ -1,0 +1,321 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createStaticClient } from "@/lib/supabase/static";
+import { CURRENT_YEAR } from "@/lib/seo";
+
+export const runtime = "nodejs";
+// 24h ISR cache — health score inputs (ASIC regulation, years operating)
+// are stable; the cron snapshot runs daily.
+export const revalidate = 86400;
+
+/**
+ * GET /api/widget/health-scores — Returns self-contained JavaScript that
+ * renders an embeddable broker health-score widget inside a Shadow DOM.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * PUBLIC-BY-DESIGN ENDPOINT — CORS contract (mirrors /api/widget):
+ *   • `Access-Control-Allow-Origin: *` is INTENTIONAL — embed feature.
+ *   • Must NEVER read user-context data. No cookies, no auth, no per-user
+ *     state. Only public, active-broker columns are read.
+ *   • Uses the anon-key client so Postgres RLS enforces active-only reads.
+ *     Do NOT swap to createAdminClient(). The broker_health_scores table is
+ *     service-role only (no anon policy); we compute scores from the public
+ *     `brokers` table instead, mirroring the /api/broker-health logic.
+ *   • Cache-Control allows public CDN caching — responses are not
+ *     personalised.
+ * ─────────────────────────────────────────────────────────────────────────
+ *
+ * AFSL compliance: scores are computed from factual, publicly disclosed
+ * regulatory attributes (ASIC status, AFSL, CHESS, years operating, rating).
+ * They are NOT financial advice and do NOT constitute a personal
+ * recommendation. The general-advice disclaimer is included.
+ *
+ * Scoring mirrors /api/broker-health (calculateSafetyScore):
+ *   ASIC regulated +25, holds AFSL +10, CHESS sponsored +20,
+ *   international regulator +5, years operating (up to +20),
+ *   editorial rating (up to +10), AU HQ (up to +5).
+ *
+ * Query params:
+ *   ?brokers=stake,commsec   — comma-separated slugs (optional filter)
+ *   ?limit=5                 — max brokers (default: 5, max: 10)
+ *   ?theme=light|dark        — colour theme (default: light)
+ *   ?ref=<partnerId>         — partner attribution; appended to all outbound
+ *                              invest.com.au links
+ */
+export async function GET(request: NextRequest) {
+  const params = request.nextUrl.searchParams;
+  const brokerSlugs = params.get("brokers")?.split(",").filter(Boolean) ?? [];
+  const theme = params.get("theme") === "dark" ? "dark" : "light";
+  const parsedLimit = parseInt(params.get("limit") ?? "", 10);
+  const limit = Number.isNaN(parsedLimit)
+    ? 5
+    : Math.min(Math.max(parsedLimit, 1), 10);
+  const ref = params.get("ref") || "";
+
+  const supabase = createStaticClient();
+
+  let query = supabase
+    .from("brokers")
+    .select(
+      "name, slug, rating, regulated_by, year_founded, headquarters, chess_sponsored, is_crypto, platform_type, logo_url, color, icon",
+    )
+    .eq("status", "active")
+    .order("rating", { ascending: false })
+    .limit(limit);
+
+  if (brokerSlugs.length > 0) {
+    query = query.in("slug", brokerSlugs);
+  }
+
+  const { data: brokers } = await query;
+  const rows = (brokers || []) as {
+    name: string;
+    slug: string;
+    rating: number | null;
+    regulated_by: string | null;
+    year_founded: number | null;
+    headquarters: string | null;
+    chess_sponsored: boolean | null;
+    is_crypto: boolean | null;
+    platform_type: string | null;
+    logo_url: string | null;
+    color: string | null;
+    icon: string | null;
+  }[];
+
+  // Compute health scores server-side, embedding results in the JS payload.
+  // Mirrors /api/broker-health calculateSafetyScore so the widget shows the
+  // same scores as the broker-health detail page.
+  const currentYear = CURRENT_YEAR;
+
+  interface ScoreResult {
+    name: string;
+    slug: string;
+    logo_url: string | null;
+    color: string | null;
+    icon: string | null;
+    safety_score: number;
+    safety_label: string;
+    score_breakdown: { asic: number; afsl: number; chess: number; years: number; rating: number };
+  }
+
+  const scored: ScoreResult[] = rows.map((b) => {
+    let score = 0;
+    const regLower = (b.regulated_by || "").toLowerCase();
+
+    const asic = regLower.includes("asic") ? 25 : 0;
+    const afsl = regLower.includes("afsl") || regLower.includes("afs licence") ? 10 : 0;
+    const intlReg =
+      regLower.includes("fca") || regLower.includes("sec") || regLower.includes("mas") ? 5 : 0;
+    const chess = b.chess_sponsored ? 20 : 0;
+
+    let yearsPoints = 0;
+    if (b.year_founded) {
+      const yearsOp = currentYear - b.year_founded;
+      if (yearsOp >= 20) yearsPoints = 20;
+      else if (yearsOp >= 10) yearsPoints = 15;
+      else if (yearsOp >= 5) yearsPoints = 10;
+      else if (yearsOp >= 2) yearsPoints = 5;
+    }
+
+    let ratingPoints = 0;
+    if (b.rating) {
+      if (b.rating >= 4.5) ratingPoints = 10;
+      else if (b.rating >= 4.0) ratingPoints = 8;
+      else if (b.rating >= 3.5) ratingPoints = 5;
+      else if (b.rating >= 3.0) ratingPoints = 3;
+    }
+
+    const typePoints = b.platform_type === "share_broker" ? 5 : 0;
+    const hqLower = (b.headquarters || "").toLowerCase();
+    let hqPoints = 0;
+    if (hqLower.includes("australia") || hqLower.includes("sydney") || hqLower.includes("melbourne"))
+      hqPoints = 5;
+    else if (hqLower.includes("uk") || hqLower.includes("london") || hqLower.includes("united states"))
+      hqPoints = 4;
+    else if (hqLower.includes("singapore") || hqLower.includes("hong kong"))
+      hqPoints = 3;
+
+    score = Math.min(asic + afsl + intlReg + chess + yearsPoints + ratingPoints + typePoints + hqPoints, 100);
+    const label = score >= 80 ? "Strong" : score >= 50 ? "Moderate" : "Caution";
+
+    return {
+      name: b.name,
+      slug: b.slug,
+      logo_url: b.logo_url,
+      color: b.color,
+      icon: b.icon,
+      safety_score: score,
+      safety_label: label,
+      score_breakdown: { asic, afsl, chess, years: yearsPoints, rating: ratingPoints },
+    };
+  });
+
+  const scoredJson = JSON.stringify(scored);
+
+  // Ref param string for outbound links.
+  const refParam = ref
+    ? `ref=${encodeURIComponent(ref)}&source=health-scores-widget`
+    : "ref=widget&source=health-scores-embed";
+
+  const DISCLAIMER =
+    "General information only. Health scores are computed from publicly disclosed regulatory " +
+    "attributes and are not a personal recommendation. Not financial advice.";
+
+  const js = `
+(function() {
+  "use strict";
+  if (typeof document === "undefined") return;
+
+  var BROKERS = ${scoredJson};
+  var THEME = ${JSON.stringify(theme)};
+  var DISCLAIMER = ${JSON.stringify(DISCLAIMER)};
+  var REF_PARAM = ${JSON.stringify(refParam)};
+  var BASE = "https://invest.com.au";
+
+  // Find the script tag that loaded us (last matching script on page)
+  var scripts = document.querySelectorAll("script[src*='/api/widget/health-scores']");
+  var currentScript = scripts[scripts.length - 1];
+  if (!currentScript) return;
+
+  // Create host element + shadow DOM for style isolation
+  var host = document.createElement("div");
+  host.setAttribute("data-invest-health-widget", "true");
+  currentScript.parentNode.insertBefore(host, currentScript.nextSibling);
+
+  var shadow = host.attachShadow({ mode: "open" });
+
+  // ─── Theme tokens ──────────────────────────────────────────────
+  var isDark = THEME === "dark";
+  var bg       = isDark ? "#1e293b" : "#ffffff";
+  var bgInput  = isDark ? "#0f172a" : "#f8fafc";
+  var border   = isDark ? "#334155" : "#e2e8f0";
+  var text     = isDark ? "#f1f5f9" : "#0f172a";
+  var textMuted= isDark ? "#94a3b8" : "#64748b";
+  var rowHover = isDark ? "#334155" : "#f8fafc";
+  var accent   = "#059669";
+  var ctaBg    = "#059669";
+  var ctaText  = "#ffffff";
+  var strongBg = isDark ? "#064e3b" : "#ecfdf5";
+  var strongBorder = isDark ? "#10b981" : "#a7f3d0";
+  var cautionBg = isDark ? "#431407" : "#fff7ed";
+  var cautionBorder = isDark ? "#f97316" : "#fed7aa";
+  var cautionText = isDark ? "#fb923c" : "#c2410c";
+  var moderateBg = isDark ? "#1e3a5f" : "#eff6ff";
+  var moderateBorder = isDark ? "#3b82f6" : "#bfdbfe";
+  var moderateText = isDark ? "#60a5fa" : "#1d4ed8";
+
+  // ─── Styles ────────────────────────────────────────────────────
+  var styles = document.createElement("style");
+  styles.textContent = [
+    ":host { all: initial; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; display: block; }",
+    ".ihw { background:" + bg + "; border:1px solid " + border + "; border-radius:12px; overflow:hidden; max-width:720px; font-size:13px; color:" + text + "; }",
+    ".ihw-header { padding:12px 16px; font-weight:700; font-size:15px; border-bottom:1px solid " + border + "; display:flex; align-items:center; justify-content:space-between; }",
+    ".ihw-row { display:grid; grid-template-columns:1fr 70px 90px 90px; align-items:center; padding:10px 16px; border-bottom:1px solid " + border + "; transition:background .15s; }",
+    ".ihw-row:hover { background:" + rowHover + "; }",
+    ".ihw-row:last-child { border-bottom:none; }",
+    ".ihw-thead { display:grid; grid-template-columns:1fr 70px 90px 90px; padding:7px 16px; background:" + bgInput + "; border-bottom:1px solid " + border + "; font-size:10px; font-weight:700; text-transform:uppercase; letter-spacing:.05em; color:" + textMuted + "; }",
+    ".ihw-name { font-weight:600; display:flex; align-items:center; gap:7px; font-size:13px; }",
+    ".ihw-logo { width:24px; height:24px; border-radius:5px; display:flex; align-items:center; justify-content:center; font-weight:700; font-size:10px; flex-shrink:0; overflow:hidden; }",
+    ".ihw-logo img { width:100%; height:100%; object-fit:contain; }",
+    ".ihw-score { font-weight:700; font-size:14px; font-variant-numeric:tabular-nums; }",
+    ".ihw-bar-wrap { height:6px; background:" + (isDark ? "#334155" : "#f1f5f9") + "; border-radius:3px; overflow:hidden; }",
+    ".ihw-bar { height:100%; border-radius:3px; transition:width .4s ease; background:" + accent + "; }",
+    ".ihw-label { display:inline-block; padding:2px 8px; border-radius:100px; font-size:10px; font-weight:700; }",
+    ".ihw-label.strong { background:" + strongBg + "; color:" + accent + "; border:1px solid " + strongBorder + "; }",
+    ".ihw-label.moderate { background:" + moderateBg + "; color:" + moderateText + "; border:1px solid " + moderateBorder + "; }",
+    ".ihw-label.caution { background:" + cautionBg + "; color:" + cautionText + "; border:1px solid " + cautionBorder + "; }",
+    ".ihw-cta { display:inline-block; padding:4px 10px; background:" + ctaBg + "; color:" + ctaText + "; border-radius:6px; text-decoration:none; font-weight:600; font-size:11px; text-align:center; transition:opacity .15s; white-space:nowrap; }",
+    ".ihw-cta:hover { opacity:.88; }",
+    ".ihw-disclaimer { padding:8px 16px; font-size:10px; color:" + textMuted + "; border-top:1px solid " + border + "; line-height:1.5; }",
+    ".ihw-footer { padding:8px 16px; text-align:center; font-size:11px; color:" + textMuted + "; border-top:1px solid " + border + "; }",
+    ".ihw-footer a { color:" + accent + "; text-decoration:none; font-weight:600; }",
+    ".ihw-footer a:hover { text-decoration:underline; }",
+    ".ihw-empty { padding:24px 16px; text-align:center; font-size:13px; color:" + textMuted + "; }",
+    "@media (max-width:480px) { .ihw-row { grid-template-columns:1fr 60px 70px; } .ihw-thead { grid-template-columns:1fr 60px 70px; } .ihw-hide-sm { display:none; } }",
+  ].join("\\n");
+  shadow.appendChild(styles);
+
+  // ─── Helpers ───────────────────────────────────────────────────
+  function esc(s) {
+    if (!s) return "";
+    var d = document.createElement("div");
+    d.appendChild(document.createTextNode(String(s)));
+    return d.innerHTML;
+  }
+
+  // ─── Build container ───────────────────────────────────────────
+  var container = document.createElement("div");
+  container.className = "ihw";
+
+  container.innerHTML =
+    '<div class="ihw-header">' +
+      '<span>Broker Health Scores</span>' +
+      '<a href="' + BASE + '/health-scores?' + REF_PARAM + '" target="_blank" style="font-size:11px;font-weight:400;color:' + textMuted + ';text-decoration:none;">Full scores &rarr;</a>' +
+    '</div>';
+
+  if (BROKERS.length === 0) {
+    container.innerHTML += '<div class="ihw-empty">No broker data available.</div>';
+  } else {
+    container.innerHTML +=
+      '<div class="ihw-thead">' +
+        '<div>Broker</div>' +
+        '<div style="text-align:center">Score</div>' +
+        '<div class="ihw-hide-sm">Bar</div>' +
+        '<div style="text-align:center">Rating</div>' +
+      '</div>';
+
+    for (var i = 0; i < BROKERS.length; i++) {
+      var b = BROKERS[i];
+      var barWidth = Math.max(b.safety_score, 2);
+      var labelClass = b.safety_label === "Strong" ? "strong" : b.safety_label === "Moderate" ? "moderate" : "caution";
+      var link = BASE + "/health-scores/" + esc(b.slug) + "?" + REF_PARAM;
+
+      var logoHtml = b.logo_url
+        ? '<div class="ihw-logo" style="background:#fff;border:1px solid ' + border + '"><img src="' + esc(b.logo_url) + '" alt="' + esc(b.name) + '"></div>'
+        : '<div class="ihw-logo" style="background:' + esc(b.color || "#059669") + '20;color:' + esc(b.color || "#059669") + '">' + esc((b.icon || b.name.charAt(0))) + '</div>';
+
+      container.innerHTML +=
+        '<div class="ihw-row">' +
+          '<div class="ihw-name">' + logoHtml + '<a href="' + link + '" target="_blank" style="color:inherit;text-decoration:none;">' + esc(b.name) + '</a></div>' +
+          '<div style="text-align:center"><span class="ihw-score">' + b.safety_score + '</span><span style="font-size:10px;color:' + textMuted + '">/100</span></div>' +
+          '<div class="ihw-hide-sm"><div style="display:flex;align-items:center;gap:6px;"><div class="ihw-bar-wrap" style="flex:1"><div class="ihw-bar" style="width:' + barWidth + '%"></div></div><span class="ihw-label ' + labelClass + '">' + esc(b.safety_label) + '</span></div></div>' +
+          '<div style="text-align:center"><a class="ihw-cta" href="' + link + '" target="_blank" rel="noopener noreferrer">Details</a></div>' +
+        '</div>';
+    }
+  }
+
+  container.innerHTML += '<div class="ihw-disclaimer">' + esc(DISCLAIMER) + '</div>';
+  container.innerHTML += '<div class="ihw-footer">Powered by <a href="' + BASE + '/health-scores?' + REF_PARAM + '" target="_blank">invest.com.au</a></div>';
+
+  shadow.appendChild(container);
+})();
+`;
+
+  return new NextResponse(js.trim(), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/javascript; charset=utf-8",
+      "Cache-Control": "public, max-age=86400, s-maxage=86400",
+      // Public-by-design: see header comment. Mirrors /api/widget CORS policy.
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, OPTIONS",
+      "Cross-Origin-Resource-Policy": "cross-origin",
+      Vary: "Origin",
+    },
+  });
+}
+
+/**
+ * CORS pre-flight. Mirrors /api/widget OPTIONS handler.
+ */
+export function OPTIONS() {
+  return new NextResponse(null, {
+    status: 204,
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, OPTIONS",
+      "Access-Control-Max-Age": "86400",
+      Vary: "Origin",
+    },
+  });
+}

--- a/app/api/widget/route.ts
+++ b/app/api/widget/route.ts
@@ -35,6 +35,8 @@ export const revalidate = 3600;
  *   ?type=table|compact      — widget layout (default: table)
  *   ?theme=light|dark        — colour theme (default: light)
  *   ?limit=5                 — max brokers to show (default: 5, max: 10)
+ *   ?ref=<partnerId>         — partner attribution; appended to all outbound
+ *                              invest.com.au links (no storage, query-param only)
  */
 export async function GET(request: NextRequest) {
   const params = request.nextUrl.searchParams;
@@ -42,6 +44,10 @@ export async function GET(request: NextRequest) {
   const widgetType = params.get("type") === "compact" ? "compact" : "table";
   const theme = params.get("theme") === "dark" ? "dark" : "light";
   const limit = Math.min(Math.max(parseInt(params.get("limit") || "5", 10) || 5, 1), 10);
+  // Partner attribution: threaded through all outbound links to invest.com.au.
+  // No storage, no new tables — purely a query-param passthrough so the
+  // destination page can attribute traffic back to the embedding partner.
+  const ref = params.get("ref") || "";
 
   // FIN_NOTEBOOK #16 — curated content filter. `?widget=` picks a
   // pre-defined audience (cheapest-brokers, us-shares, top-crypto,
@@ -95,6 +101,12 @@ export async function GET(request: NextRequest) {
   // Serialise broker data into the JS payload
   const brokersJson = JSON.stringify(rows);
 
+  // Ref param string for outbound links. Partner ID takes priority; falls
+  // back to the generic widget attribution signal.
+  const refParam = ref
+    ? `ref=${encodeURIComponent(ref)}&source=widget`
+    : "ref=widget&source=embed";
+
   const js = `
 (function() {
   "use strict";
@@ -104,6 +116,7 @@ export async function GET(request: NextRequest) {
   var TYPE = ${JSON.stringify(widgetType)};
   var THEME = ${JSON.stringify(theme)};
   var WIDGET_HEADING = ${JSON.stringify(widgetHeading)};
+  var REF_PARAM = ${JSON.stringify(refParam)};
   var BASE = "https://invest.com.au";
 
   // Find the script tag that loaded us (last script on page)
@@ -167,7 +180,7 @@ export async function GET(request: NextRequest) {
       var logoHtml = b.logo_url
         ? '<div class="icw-logo" style="background:#fff;border:1px solid ' + border + '"><img src="' + esc(b.logo_url) + '" alt="' + esc(b.name) + '"></div>'
         : '<div class="icw-logo" style="background:' + esc(b.color) + '20;color:' + esc(b.color) + '">' + esc((b.icon || b.name.charAt(0))) + '</div>';
-      var link = BASE + "/go/" + esc(b.slug) + "?ref=widget&source=embed";
+      var link = BASE + "/go/" + esc(b.slug) + "?" + REF_PARAM;
       container.innerHTML += '<div class="icw-card">' +
         logoHtml +
         '<div class="icw-info">' +
@@ -186,7 +199,7 @@ export async function GET(request: NextRequest) {
       var logoHtml = b.logo_url
         ? '<div class="icw-logo" style="background:#fff;border:1px solid ' + border + '"><img src="' + esc(b.logo_url) + '" alt="' + esc(b.name) + '"></div>'
         : '<div class="icw-logo" style="background:' + esc(b.color) + '20;color:' + esc(b.color) + '">' + esc((b.icon || b.name.charAt(0))) + '</div>';
-      var link = BASE + "/go/" + esc(b.slug) + "?ref=widget&source=embed";
+      var link = BASE + "/go/" + esc(b.slug) + "?" + REF_PARAM;
       container.innerHTML += '<div class="icw-row">' +
         '<div class="icw-name">' + logoHtml + esc(b.name) + '</div>' +
         '<div>' + esc(b.asx_fee || "N/A") + '</div>' +
@@ -197,7 +210,7 @@ export async function GET(request: NextRequest) {
     });
   }
 
-  container.innerHTML += '<div class="icw-footer">Powered by <a href="' + BASE + '?ref=widget" target="_blank">invest.com.au</a></div>';
+  container.innerHTML += '<div class="icw-footer">Powered by <a href="' + BASE + "?" + REF_PARAM + '" target="_blank">invest.com.au</a></div>';
   shadow.appendChild(container);
 
   function esc(s) {

--- a/app/embed/EmbedBuilder.tsx
+++ b/app/embed/EmbedBuilder.tsx
@@ -2,7 +2,14 @@
 
 import { useState, useMemo, useEffect, useRef } from "react";
 
-import { WIDGET_CATALOGUE, CALCULATOR_WIDGET_CATALOGUE } from "@/lib/widget/types";
+import {
+  WIDGET_CATALOGUE,
+  CALCULATOR_WIDGET_CATALOGUE,
+  SUITE_WIDGET_CATALOGUE,
+  AU_STATES,
+  ADVISOR_TYPES,
+  type WidgetKind,
+} from "@/lib/widget/types";
 
 const POPULAR_BROKERS = [
   { slug: "stake", name: "Stake" },
@@ -17,11 +24,13 @@ const POPULAR_BROKERS = [
   { slug: "webull", name: "Webull" },
 ];
 
-type BuilderTab = "broker" | "calculator";
-
 export default function EmbedBuilder() {
   // ─── Tab ─────────────────────────────────────────────────────────────────
-  const [tab, setTab] = useState<BuilderTab>("broker");
+  const [tab, setTab] = useState<WidgetKind>("broker");
+
+  // ─── Shared partner ref ──────────────────────────────────────────────────
+  // Applied across all widget types so a publisher can set it once.
+  const [partnerRef, setPartnerRef] = useState("");
 
   // ─── Broker widget state ─────────────────────────────────────────────────
   const [selectedSlugs, setSelectedSlugs] = useState<string[]>([]);
@@ -36,6 +45,23 @@ export default function EmbedBuilder() {
   const [calcLimit, setCalcLimit] = useState(5);
   const [calcAmount, setCalcAmount] = useState(5000);
 
+  // ─── Advisor widget state ────────────────────────────────────────────────
+  const [advisorType, setAdvisorType] = useState("");
+  const [advisorState, setAdvisorState] = useState("");
+  const [advisorTheme, setAdvisorTheme] = useState<"light" | "dark">("light");
+  const [advisorLimit, setAdvisorLimit] = useState(5);
+
+  // ─── Fee-index widget state ──────────────────────────────────────────────
+  const [feeMarket, setFeeMarket] = useState<"asx" | "us">("asx");
+  const [feeSort, setFeeSort] = useState<"asx_fee" | "us_fee" | "rating">("asx_fee");
+  const [feeTheme, setFeeTheme] = useState<"light" | "dark">("light");
+  const [feeLimit, setFeeLimit] = useState(10);
+
+  // ─── Health-scores widget state ──────────────────────────────────────────
+  const [healthSlugs, setHealthSlugs] = useState<string[]>([]);
+  const [healthTheme, setHealthTheme] = useState<"light" | "dark">("light");
+  const [healthLimit, setHealthLimit] = useState(5);
+
   const [copied, setCopied] = useState(false);
   const previewRef = useRef<HTMLDivElement>(null);
 
@@ -47,9 +73,10 @@ export default function EmbedBuilder() {
     if (widgetType !== "table") params.set("type", widgetType);
     if (brokerTheme !== "light") params.set("theme", brokerTheme);
     if (limit !== 5) params.set("limit", String(limit));
+    if (partnerRef.trim()) params.set("ref", partnerRef.trim());
     const qs = params.toString();
     return `https://invest.com.au/api/widget${qs ? `?${qs}` : ""}`;
-  }, [selectedSlugs, widgetType, brokerTheme, limit, widgetCatalogueSlug]);
+  }, [selectedSlugs, widgetType, brokerTheme, limit, widgetCatalogueSlug, partnerRef]);
 
   const calcEmbedUrl = useMemo(() => {
     const params = new URLSearchParams();
@@ -57,15 +84,63 @@ export default function EmbedBuilder() {
     if (calcTheme !== "light") params.set("theme", calcTheme);
     if (calcLimit !== 5) params.set("limit", String(calcLimit));
     if (calcAmount !== 5000) params.set("amount", String(calcAmount));
+    if (partnerRef.trim()) params.set("ref", partnerRef.trim());
     const qs = params.toString();
     return `https://invest.com.au/api/widget/calculator${qs ? `?${qs}` : ""}`;
-  }, [calcMarket, calcTheme, calcLimit, calcAmount]);
+  }, [calcMarket, calcTheme, calcLimit, calcAmount, partnerRef]);
 
-  const activeUrl = tab === "broker" ? brokerEmbedUrl : calcEmbedUrl;
+  const advisorEmbedUrl = useMemo(() => {
+    const params = new URLSearchParams();
+    if (advisorType) params.set("type", advisorType);
+    if (advisorState) params.set("state", advisorState);
+    if (advisorTheme !== "light") params.set("theme", advisorTheme);
+    if (advisorLimit !== 5) params.set("limit", String(advisorLimit));
+    if (partnerRef.trim()) params.set("ref", partnerRef.trim());
+    const qs = params.toString();
+    return `https://invest.com.au/api/widget/advisors${qs ? `?${qs}` : ""}`;
+  }, [advisorType, advisorState, advisorTheme, advisorLimit, partnerRef]);
+
+  const feeIndexEmbedUrl = useMemo(() => {
+    const params = new URLSearchParams();
+    if (feeMarket !== "asx") params.set("market", feeMarket);
+    if (feeSort !== "asx_fee") params.set("sort", feeSort);
+    if (feeTheme !== "light") params.set("theme", feeTheme);
+    if (feeLimit !== 10) params.set("limit", String(feeLimit));
+    if (partnerRef.trim()) params.set("ref", partnerRef.trim());
+    const qs = params.toString();
+    return `https://invest.com.au/api/widget/fee-index${qs ? `?${qs}` : ""}`;
+  }, [feeMarket, feeSort, feeTheme, feeLimit, partnerRef]);
+
+  const healthEmbedUrl = useMemo(() => {
+    const params = new URLSearchParams();
+    if (healthSlugs.length > 0) params.set("brokers", healthSlugs.join(","));
+    if (healthTheme !== "light") params.set("theme", healthTheme);
+    if (healthLimit !== 5) params.set("limit", String(healthLimit));
+    if (partnerRef.trim()) params.set("ref", partnerRef.trim());
+    const qs = params.toString();
+    return `https://invest.com.au/api/widget/health-scores${qs ? `?${qs}` : ""}`;
+  }, [healthSlugs, healthTheme, healthLimit, partnerRef]);
+
+  const activeUrl = useMemo(() => {
+    switch (tab) {
+      case "broker": return brokerEmbedUrl;
+      case "calculator": return calcEmbedUrl;
+      case "advisors": return advisorEmbedUrl;
+      case "fee-index": return feeIndexEmbedUrl;
+      case "health-scores": return healthEmbedUrl;
+    }
+  }, [tab, brokerEmbedUrl, calcEmbedUrl, advisorEmbedUrl, feeIndexEmbedUrl, healthEmbedUrl]);
+
   const snippet = `<script src="${activeUrl}"></script>`;
 
   function toggleBroker(slug: string) {
     setSelectedSlugs((prev) =>
+      prev.includes(slug) ? prev.filter((s) => s !== slug) : [...prev, slug]
+    );
+  }
+
+  function toggleHealthBroker(slug: string) {
+    setHealthSlugs((prev) =>
       prev.includes(slug) ? prev.filter((s) => s !== slug) : [...prev, slug]
     );
   }
@@ -125,32 +200,33 @@ export default function EmbedBuilder() {
     };
   }, [snippet]);
 
-  const activeTheme = tab === "broker" ? brokerTheme : calcTheme;
+  const activeTheme = ((): "light" | "dark" => {
+    switch (tab) {
+      case "broker": return brokerTheme;
+      case "calculator": return calcTheme;
+      case "advisors": return advisorTheme;
+      case "fee-index": return feeTheme;
+      case "health-scores": return healthTheme;
+    }
+  })();
 
   return (
     <div className="border border-slate-200 rounded-xl overflow-hidden">
-      {/* Tab bar */}
-      <div className="flex border-b border-slate-200">
-        <button
-          onClick={() => setTab("broker")}
-          className={`flex-1 py-3 text-xs font-bold uppercase tracking-wider transition-colors ${
-            tab === "broker"
-              ? "bg-white text-emerald-700 border-b-2 border-emerald-600"
-              : "bg-slate-50 text-slate-500 hover:text-slate-700"
-          }`}
-        >
-          Broker Comparison
-        </button>
-        <button
-          onClick={() => setTab("calculator")}
-          className={`flex-1 py-3 text-xs font-bold uppercase tracking-wider transition-colors ${
-            tab === "calculator"
-              ? "bg-white text-emerald-700 border-b-2 border-emerald-600"
-              : "bg-slate-50 text-slate-500 hover:text-slate-700"
-          }`}
-        >
-          Fee Calculator
-        </button>
+      {/* Tab bar — 5 widget types */}
+      <div className="flex overflow-x-auto border-b border-slate-200 scrollbar-none">
+        {SUITE_WIDGET_CATALOGUE.map((w) => (
+          <button
+            key={w.kind}
+            onClick={() => setTab(w.kind)}
+            className={`flex-shrink-0 px-4 py-3 text-xs font-bold uppercase tracking-wider transition-colors whitespace-nowrap ${
+              tab === w.kind
+                ? "bg-white text-emerald-700 border-b-2 border-emerald-600"
+                : "bg-slate-50 text-slate-500 hover:text-slate-700"
+            }`}
+          >
+            {w.label}
+          </button>
+        ))}
       </div>
 
       <div className="p-5 md:p-6 space-y-5">
@@ -324,6 +400,202 @@ export default function EmbedBuilder() {
             </p>
           </>
         )}
+
+        {/* ── ADVISOR WIDGET CONTROLS ── */}
+        {tab === "advisors" && (
+          <>
+            <div className="grid sm:grid-cols-2 gap-4">
+              <div>
+                <label className="block text-xs font-bold uppercase tracking-wider text-slate-500 mb-2">Advisor Type (optional)</label>
+                <select
+                  value={advisorType}
+                  onChange={(e) => setAdvisorType(e.target.value)}
+                  className="w-full border border-slate-200 rounded-lg py-2 px-3 text-sm"
+                >
+                  <option value="">All types</option>
+                  {ADVISOR_TYPES.map((t) => (
+                    <option key={t} value={t}>{t.replace(/-/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())}</option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className="block text-xs font-bold uppercase tracking-wider text-slate-500 mb-2">State (optional)</label>
+                <select
+                  value={advisorState}
+                  onChange={(e) => setAdvisorState(e.target.value)}
+                  className="w-full border border-slate-200 rounded-lg py-2 px-3 text-sm"
+                >
+                  <option value="">All states</option>
+                  {AU_STATES.map((s) => (
+                    <option key={s} value={s}>{s}</option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className="block text-xs font-bold uppercase tracking-wider text-slate-500 mb-2">Theme</label>
+                <select
+                  value={advisorTheme}
+                  onChange={(e) => setAdvisorTheme(e.target.value as "light" | "dark")}
+                  className="w-full border border-slate-200 rounded-lg py-2 px-3 text-sm"
+                >
+                  <option value="light">Light</option>
+                  <option value="dark">Dark</option>
+                </select>
+              </div>
+              <div>
+                <label className="block text-xs font-bold uppercase tracking-wider text-slate-500 mb-2">Max Advisors</label>
+                <select
+                  value={advisorLimit}
+                  onChange={(e) => setAdvisorLimit(parseInt(e.target.value, 10))}
+                  className="w-full border border-slate-200 rounded-lg py-2 px-3 text-sm"
+                >
+                  {[3, 5, 8, 10].map((n) => (
+                    <option key={n} value={n}>{n}</option>
+                  ))}
+                </select>
+              </div>
+            </div>
+            <p className="text-[11px] text-slate-500">
+              Displays public advisor profiles — no personal data. General-advice disclaimer included automatically.
+            </p>
+          </>
+        )}
+
+        {/* ── FEE-INDEX WIDGET CONTROLS ── */}
+        {tab === "fee-index" && (
+          <>
+            <div className="grid sm:grid-cols-2 gap-4">
+              <div>
+                <label className="block text-xs font-bold uppercase tracking-wider text-slate-500 mb-2">Market</label>
+                <select
+                  value={feeMarket}
+                  onChange={(e) => setFeeMarket(e.target.value as "asx" | "us")}
+                  className="w-full border border-slate-200 rounded-lg py-2 px-3 text-sm"
+                >
+                  <option value="asx">ASX (Australian shares)</option>
+                  <option value="us">US shares</option>
+                </select>
+              </div>
+              <div>
+                <label className="block text-xs font-bold uppercase tracking-wider text-slate-500 mb-2">Sort by</label>
+                <select
+                  value={feeSort}
+                  onChange={(e) => setFeeSort(e.target.value as "asx_fee" | "us_fee" | "rating")}
+                  className="w-full border border-slate-200 rounded-lg py-2 px-3 text-sm"
+                >
+                  <option value="asx_fee">ASX fee (cheapest first)</option>
+                  <option value="us_fee">US fee (cheapest first)</option>
+                  <option value="rating">Editorial rating</option>
+                </select>
+              </div>
+              <div>
+                <label className="block text-xs font-bold uppercase tracking-wider text-slate-500 mb-2">Theme</label>
+                <select
+                  value={feeTheme}
+                  onChange={(e) => setFeeTheme(e.target.value as "light" | "dark")}
+                  className="w-full border border-slate-200 rounded-lg py-2 px-3 text-sm"
+                >
+                  <option value="light">Light</option>
+                  <option value="dark">Dark</option>
+                </select>
+              </div>
+              <div>
+                <label className="block text-xs font-bold uppercase tracking-wider text-slate-500 mb-2">Max Brokers</label>
+                <select
+                  value={feeLimit}
+                  onChange={(e) => setFeeLimit(parseInt(e.target.value, 10))}
+                  className="w-full border border-slate-200 rounded-lg py-2 px-3 text-sm"
+                >
+                  {[5, 10, 15, 20].map((n) => (
+                    <option key={n} value={n}>{n}</option>
+                  ))}
+                </select>
+              </div>
+            </div>
+            <p className="text-[11px] text-slate-500">
+              Displays factual, publicly disclosed broker fee schedules. Not financial advice.
+            </p>
+          </>
+        )}
+
+        {/* ── HEALTH-SCORES WIDGET CONTROLS ── */}
+        {tab === "health-scores" && (
+          <>
+            {/* Broker selection */}
+            <div>
+              <label className="block text-xs font-bold uppercase tracking-wider text-slate-500 mb-2">
+                Select Brokers (optional — leave blank for top by rating)
+              </label>
+              <div className="flex flex-wrap gap-2">
+                {POPULAR_BROKERS.map((b) => {
+                  const active = healthSlugs.includes(b.slug);
+                  return (
+                    <button
+                      key={b.slug}
+                      onClick={() => toggleHealthBroker(b.slug)}
+                      className={`px-3 py-1.5 rounded-lg text-xs font-medium border transition-all ${
+                        active
+                          ? "bg-emerald-50 border-emerald-300 text-emerald-700"
+                          : "bg-white border-slate-200 text-slate-600 hover:border-slate-300"
+                      }`}
+                    >
+                      {active && <span className="mr-1">&#10003;</span>}
+                      {b.name}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            <div className="grid sm:grid-cols-2 gap-4">
+              <div>
+                <label className="block text-xs font-bold uppercase tracking-wider text-slate-500 mb-2">Theme</label>
+                <select
+                  value={healthTheme}
+                  onChange={(e) => setHealthTheme(e.target.value as "light" | "dark")}
+                  className="w-full border border-slate-200 rounded-lg py-2 px-3 text-sm"
+                >
+                  <option value="light">Light</option>
+                  <option value="dark">Dark</option>
+                </select>
+              </div>
+              <div>
+                <label className="block text-xs font-bold uppercase tracking-wider text-slate-500 mb-2">Max Brokers</label>
+                <select
+                  value={healthLimit}
+                  onChange={(e) => setHealthLimit(parseInt(e.target.value, 10))}
+                  className="w-full border border-slate-200 rounded-lg py-2 px-3 text-sm"
+                >
+                  {[3, 5, 8, 10].map((n) => (
+                    <option key={n} value={n}>{n}</option>
+                  ))}
+                </select>
+              </div>
+            </div>
+            <p className="text-[11px] text-slate-500">
+              Scores are computed from factual regulatory attributes — not a personal recommendation.
+              General-advice disclaimer is included automatically.
+            </p>
+          </>
+        )}
+
+        {/* ── Shared partner ref ── */}
+        <div>
+          <label className="block text-xs font-bold uppercase tracking-wider text-slate-500 mb-2">
+            Partner ID <span className="text-slate-400 font-normal lowercase">(optional — adds ?ref= to outbound links)</span>
+          </label>
+          <input
+            type="text"
+            value={partnerRef}
+            onChange={(e) => setPartnerRef(e.target.value)}
+            placeholder="e.g. moneymag, yoursite"
+            className="w-full border border-slate-200 rounded-lg py-2 px-3 text-sm placeholder:text-slate-400"
+            maxLength={64}
+          />
+          <p className="mt-1 text-[11px] text-slate-500">
+            Your ID is appended to all outbound invest.com.au links for affiliate attribution. No data is stored by the widget.
+          </p>
+        </div>
 
         {/* Code output — shared */}
         <div>

--- a/app/embed/page.tsx
+++ b/app/embed/page.tsx
@@ -3,20 +3,23 @@ import Link from "next/link";
 import { absoluteUrl, breadcrumbJsonLd, SITE_NAME } from "@/lib/seo";
 import Icon from "@/components/Icon";
 import EmbedBuilder from "./EmbedBuilder";
+import { SUITE_WIDGET_CATALOGUE } from "@/lib/widget/types";
 
 export const revalidate = 3600;
 
 export const metadata: Metadata = {
-  title: `Embed Broker & Calculator Widgets — ${SITE_NAME}`,
-  description: `Add free, self-contained broker comparison or interactive brokerage fee calculator widgets to your website. Multiple styles, dark/light themes, and always up-to-date data from ${SITE_NAME}.`,
+  title: `Embed Financial Widgets — ${SITE_NAME}`,
+  description: `Add free, self-contained broker comparison, fee calculator, advisor directory, fee index, or broker health-score widgets to your website. Multiple styles, dark/light themes, and always up-to-date data from ${SITE_NAME}.`,
   openGraph: {
-    title: "Embed Broker & Calculator Widgets",
+    title: "Embed Financial Widgets",
     description:
-      "Drop a live broker comparison table or interactive fee calculator onto any website with a single script tag.",
+      "Drop live broker comparison, fee calculator, advisor directory, fee index, or health-score widgets onto any website with a single script tag.",
   },
   twitter: { card: "summary_large_image" },
   alternates: { canonical: "/embed" },
 };
+
+// ─── Static snippet sets (used in the documentation section) ─────────────────
 
 const BROKER_SNIPPETS = [
   {
@@ -38,6 +41,11 @@ const BROKER_SNIPPETS = [
     title: "Dark Theme",
     description: "Matches dark-mode sites. Works with both table and compact layouts.",
     code: `<script src="https://invest.com.au/api/widget?theme=dark&limit=5"></script>`,
+  },
+  {
+    title: "With Partner Attribution",
+    description: "Append ?ref= to carry your partner ID through to invest.com.au for attribution.",
+    code: `<script src="https://invest.com.au/api/widget?ref=yourpartnerId"></script>`,
   },
 ];
 
@@ -64,10 +72,130 @@ const CALC_SNIPPETS = [
   },
 ];
 
+const ADVISOR_SNIPPETS = [
+  {
+    title: "Default — All Advisors",
+    description: "Top-rated financial advisors across Australia.",
+    code: `<script src="https://invest.com.au/api/widget/advisors"></script>`,
+  },
+  {
+    title: "Financial Planners in NSW",
+    description: "Filtered by type and state — ideal for regional content.",
+    code: `<script src="https://invest.com.au/api/widget/advisors?type=financial-planner&state=NSW"></script>`,
+  },
+  {
+    title: "Dark Theme",
+    description: "Advisor cards styled for dark-mode sites.",
+    code: `<script src="https://invest.com.au/api/widget/advisors?theme=dark&limit=3"></script>`,
+  },
+  {
+    title: "With Partner Attribution",
+    description: "Thread your partner ID through to invest.com.au profile links.",
+    code: `<script src="https://invest.com.au/api/widget/advisors?ref=yourpartnerId"></script>`,
+  },
+];
+
+const FEE_INDEX_SNIPPETS = [
+  {
+    title: "Default — ASX Fee Index",
+    description: "All active brokers sorted by ASX per-trade fee, cheapest first.",
+    code: `<script src="https://invest.com.au/api/widget/fee-index"></script>`,
+  },
+  {
+    title: "US Share Fee Index",
+    description: "Sorted by US share fee, cheapest first.",
+    code: `<script src="https://invest.com.au/api/widget/fee-index?market=us&sort=us_fee"></script>`,
+  },
+  {
+    title: "Top-Rated, Limited to 5",
+    description: "Sorted by editorial rating rather than fee.",
+    code: `<script src="https://invest.com.au/api/widget/fee-index?sort=rating&limit=5"></script>`,
+  },
+  {
+    title: "Dark Theme",
+    description: "Fee index table styled for dark-mode sites.",
+    code: `<script src="https://invest.com.au/api/widget/fee-index?theme=dark"></script>`,
+  },
+];
+
+const HEALTH_SNIPPETS = [
+  {
+    title: "Default — Top 5 Health Scores",
+    description: "Top brokers with safety scores computed from regulatory attributes.",
+    code: `<script src="https://invest.com.au/api/widget/health-scores"></script>`,
+  },
+  {
+    title: "Specific Brokers",
+    description: "Show health scores for a chosen set of brokers.",
+    code: `<script src="https://invest.com.au/api/widget/health-scores?brokers=stake,commsec,cmc-markets"></script>`,
+  },
+  {
+    title: "Dark Theme",
+    description: "Health scores styled for dark-mode sites.",
+    code: `<script src="https://invest.com.au/api/widget/health-scores?theme=dark&limit=3"></script>`,
+  },
+  {
+    title: "With Partner Attribution",
+    description: "Thread your partner ID through to invest.com.au health-score detail pages.",
+    code: `<script src="https://invest.com.au/api/widget/health-scores?ref=yourpartnerId"></script>`,
+  },
+];
+
+function SnippetBlock({ snippet }: { snippet: { title: string; description: string; code: string } }) {
+  return (
+    <div className="border border-slate-200 rounded-xl overflow-hidden">
+      <div className="px-5 py-3 bg-slate-50 border-b border-slate-200">
+        <h3 className="font-bold text-sm text-slate-900">{snippet.title}</h3>
+        <p className="text-xs text-slate-500 mt-0.5">{snippet.description}</p>
+      </div>
+      <div className="px-5 py-4 bg-slate-900">
+        <code className="text-xs text-emerald-400 font-mono break-all select-all">{snippet.code}</code>
+      </div>
+    </div>
+  );
+}
+
+function ParamsTable({ rows }: {
+  rows: { param: string; values: string; def: string; desc: string }[];
+}) {
+  return (
+    <div className="bg-white border border-slate-200 rounded-xl overflow-hidden mb-12">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="bg-slate-50 border-b border-slate-200 text-left">
+            <th className="px-5 py-3 font-bold text-slate-700">Parameter</th>
+            <th className="px-5 py-3 font-bold text-slate-700">Values</th>
+            <th className="px-5 py-3 font-bold text-slate-700 hidden sm:table-cell">Default</th>
+            <th className="px-5 py-3 font-bold text-slate-700">Description</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-100">
+          {rows.map((row) => (
+            <tr key={row.param}>
+              <td className="px-5 py-3 font-mono text-xs text-emerald-700">{row.param}</td>
+              <td className="px-5 py-3 text-xs text-slate-600">{row.values}</td>
+              <td className="px-5 py-3 text-xs text-slate-400 hidden sm:table-cell">{row.def}</td>
+              <td className="px-5 py-3 text-xs text-slate-600">{row.desc}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// Common ?ref= row shared across all parameter tables.
+const REF_PARAM_ROW = {
+  param: "ref",
+  values: "any string",
+  def: "(none)",
+  desc: "Partner ID appended to all outbound invest.com.au links for affiliate attribution. No data stored.",
+};
+
 export default function EmbedPage() {
   const breadcrumbLd = breadcrumbJsonLd([
     { name: "Home", url: absoluteUrl("/") },
-    { name: "Embed Widget" },
+    { name: "Embed Widgets" },
   ]);
 
   return (
@@ -92,13 +220,28 @@ export default function EmbedPage() {
           </div>
 
           <h1 className="text-2xl sm:text-3xl md:text-4xl font-extrabold leading-tight tracking-tight text-slate-900 mb-3">
-            Embed Broker & Calculator Widgets
+            Embed Financial Widgets
           </h1>
           <p className="text-sm md:text-base text-slate-600 leading-relaxed max-w-2xl">
-            Add a live broker comparison table or an interactive brokerage fee calculator to your
-            blog, forum, or financial website. Both widgets render inside a Shadow DOM so they never
-            conflict with your styles. Data stays fresh automatically.
+            Add live financial widgets to your blog, forum, or financial website with a single
+            script tag. Choose from {SUITE_WIDGET_CATALOGUE.length} widget types — broker
+            comparison, fee calculator, advisor directory, fee index, and health scores. All
+            render inside a Shadow DOM so they never conflict with your styles, and data stays
+            fresh automatically.
           </p>
+
+          {/* Widget suite overview pills */}
+          <div className="flex flex-wrap gap-2 mt-5">
+            {SUITE_WIDGET_CATALOGUE.map((w) => (
+              <span
+                key={w.kind}
+                className="inline-flex items-center gap-1.5 px-3 py-1 bg-slate-100 rounded-full text-xs font-medium text-slate-700"
+              >
+                <span className="w-1.5 h-1.5 rounded-full bg-emerald-500 flex-shrink-0" />
+                {w.label}
+              </span>
+            ))}
+          </div>
         </div>
       </section>
 
@@ -107,9 +250,9 @@ export default function EmbedPage() {
         <h2 className="text-lg md:text-xl font-extrabold text-slate-900 mb-6">How It Works</h2>
         <div className="grid sm:grid-cols-3 gap-4 mb-10">
           {[
-            { icon: "code", title: "1. Copy snippet", desc: "Grab the script tag below or use the builder." },
-            { icon: "layout", title: "2. Paste anywhere", desc: "Drop it into your HTML. No dependencies needed." },
-            { icon: "refresh-cw", title: "3. Always current", desc: "Fees and ratings update automatically from our database." },
+            { icon: "code", title: "1. Copy snippet", desc: "Grab the script tag below or use the builder to configure your widget." },
+            { icon: "layout", title: "2. Paste anywhere", desc: "Drop it into your HTML. No dependencies, no bundlers, no iframes needed." },
+            { icon: "refresh-cw", title: "3. Always current", desc: "Fees, ratings, and data update automatically from our database." },
           ].map((step) => (
             <div key={step.title} className="bg-white border border-slate-200 rounded-xl p-5">
               <Icon name={step.icon} size={20} className="text-emerald-600 mb-2" />
@@ -119,104 +262,105 @@ export default function EmbedPage() {
           ))}
         </div>
 
-        {/* ── Broker Widget Snippets ── */}
+        {/* Partner Attribution callout */}
+        <div className="bg-emerald-50 border border-emerald-200 rounded-xl p-5 mb-12">
+          <h3 className="font-bold text-sm text-emerald-900 mb-1">Partner Attribution</h3>
+          <p className="text-xs text-emerald-800 leading-relaxed">
+            Add <code className="font-mono bg-emerald-100 px-1 rounded">?ref=yourpartnerId</code> to
+            any widget URL and that ID is threaded through every outbound link back to invest.com.au
+            — so clicks originating from your embed are attributed correctly. No new tables are
+            created; attribution is purely query-param based.
+          </p>
+        </div>
+
+        {/* ── Broker Widget ── */}
         <h2 className="text-lg md:text-xl font-extrabold text-slate-900 mb-1">Broker Comparison Widget</h2>
         <p className="text-sm text-slate-500 mb-5">
           Shows a live table or compact card layout comparing broker fees, ratings, and links.
         </p>
-        <div className="space-y-6 mb-12">
-          {BROKER_SNIPPETS.map((snippet) => (
-            <div key={snippet.title} className="border border-slate-200 rounded-xl overflow-hidden">
-              <div className="px-5 py-3 bg-slate-50 border-b border-slate-200">
-                <h3 className="font-bold text-sm text-slate-900">{snippet.title}</h3>
-                <p className="text-xs text-slate-500 mt-0.5">{snippet.description}</p>
-              </div>
-              <div className="px-5 py-4 bg-slate-900">
-                <code className="text-xs text-emerald-400 font-mono break-all select-all">{snippet.code}</code>
-              </div>
-            </div>
-          ))}
+        <div className="space-y-6 mb-8">
+          {BROKER_SNIPPETS.map((s) => <SnippetBlock key={s.title} snippet={s} />)}
         </div>
-
-        {/* Broker params reference */}
         <h3 className="text-base font-extrabold text-slate-900 mb-4">Broker Widget Parameters</h3>
-        <div className="bg-white border border-slate-200 rounded-xl overflow-hidden mb-12">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="bg-slate-50 border-b border-slate-200 text-left">
-                <th className="px-5 py-3 font-bold text-slate-700">Parameter</th>
-                <th className="px-5 py-3 font-bold text-slate-700">Values</th>
-                <th className="px-5 py-3 font-bold text-slate-700 hidden sm:table-cell">Default</th>
-                <th className="px-5 py-3 font-bold text-slate-700">Description</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-slate-100">
-              {[
-                { param: "brokers", values: "slug,slug,...", def: "(all)", desc: "Comma-separated broker slugs to include." },
-                { param: "type", values: "table | compact", def: "table", desc: "Widget layout style." },
-                { param: "theme", values: "light | dark", def: "light", desc: "Colour theme." },
-                { param: "limit", values: "1–10", def: "5", desc: "Maximum brokers displayed." },
-              ].map((row) => (
-                <tr key={row.param}>
-                  <td className="px-5 py-3 font-mono text-xs text-emerald-700">{row.param}</td>
-                  <td className="px-5 py-3 text-xs text-slate-600">{row.values}</td>
-                  <td className="px-5 py-3 text-xs text-slate-400 hidden sm:table-cell">{row.def}</td>
-                  <td className="px-5 py-3 text-xs text-slate-600">{row.desc}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+        <ParamsTable rows={[
+          { param: "brokers", values: "slug,slug,...", def: "(all)", desc: "Comma-separated broker slugs to include." },
+          { param: "type", values: "table | compact", def: "table", desc: "Widget layout style." },
+          { param: "theme", values: "light | dark", def: "light", desc: "Colour theme." },
+          { param: "limit", values: "1–10", def: "5", desc: "Maximum brokers displayed." },
+          { param: "widget", values: "cheapest-brokers | us-shares | top-crypto | savings-rates | term-deposits", def: "(none)", desc: "Curated content filter." },
+          REF_PARAM_ROW,
+        ]} />
 
-        {/* ── Calculator Widget Snippets ── */}
+        {/* ── Calculator Widget ── */}
         <h2 className="text-lg md:text-xl font-extrabold text-slate-900 mb-1">Fee Calculator Widget</h2>
         <p className="text-sm text-slate-500 mb-5">
           An interactive trade-cost calculator — visitors can adjust the trade amount and market.
           Includes the general-advice disclaimer. Powered by live broker fee data.
         </p>
-        <div className="space-y-6 mb-12">
-          {CALC_SNIPPETS.map((snippet) => (
-            <div key={snippet.title} className="border border-slate-200 rounded-xl overflow-hidden">
-              <div className="px-5 py-3 bg-slate-50 border-b border-slate-200">
-                <h3 className="font-bold text-sm text-slate-900">{snippet.title}</h3>
-                <p className="text-xs text-slate-500 mt-0.5">{snippet.description}</p>
-              </div>
-              <div className="px-5 py-4 bg-slate-900">
-                <code className="text-xs text-emerald-400 font-mono break-all select-all">{snippet.code}</code>
-              </div>
-            </div>
-          ))}
+        <div className="space-y-6 mb-8">
+          {CALC_SNIPPETS.map((s) => <SnippetBlock key={s.title} snippet={s} />)}
         </div>
-
-        {/* Calculator params reference */}
         <h3 className="text-base font-extrabold text-slate-900 mb-4">Calculator Widget Parameters</h3>
-        <div className="bg-white border border-slate-200 rounded-xl overflow-hidden mb-12">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="bg-slate-50 border-b border-slate-200 text-left">
-                <th className="px-5 py-3 font-bold text-slate-700">Parameter</th>
-                <th className="px-5 py-3 font-bold text-slate-700">Values</th>
-                <th className="px-5 py-3 font-bold text-slate-700 hidden sm:table-cell">Default</th>
-                <th className="px-5 py-3 font-bold text-slate-700">Description</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-slate-100">
-              {[
-                { param: "market", values: "asx | us", def: "asx", desc: "Which market's fees to show by default." },
-                { param: "theme", values: "light | dark", def: "light", desc: "Colour theme." },
-                { param: "limit", values: "1–10", def: "5", desc: "Maximum brokers displayed." },
-                { param: "amount", values: "1–1000000", def: "5000", desc: "Default trade amount pre-filled (AUD). Visitors can change it." },
-              ].map((row) => (
-                <tr key={row.param}>
-                  <td className="px-5 py-3 font-mono text-xs text-emerald-700">{row.param}</td>
-                  <td className="px-5 py-3 text-xs text-slate-600">{row.values}</td>
-                  <td className="px-5 py-3 text-xs text-slate-400 hidden sm:table-cell">{row.def}</td>
-                  <td className="px-5 py-3 text-xs text-slate-600">{row.desc}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+        <ParamsTable rows={[
+          { param: "market", values: "asx | us", def: "asx", desc: "Which market's fees to show by default." },
+          { param: "theme", values: "light | dark", def: "light", desc: "Colour theme." },
+          { param: "limit", values: "1–10", def: "5", desc: "Maximum brokers displayed." },
+          { param: "amount", values: "1–1000000", def: "5000", desc: "Default trade amount pre-filled (AUD). Visitors can change it." },
+          REF_PARAM_ROW,
+        ]} />
+
+        {/* ── Advisor Directory Widget ── */}
+        <h2 className="text-lg md:text-xl font-extrabold text-slate-900 mb-1">Advisor Directory Widget</h2>
+        <p className="text-sm text-slate-500 mb-5">
+          An embeddable directory of financial advisors with optional type and state filters.
+          Includes the general-advice disclaimer. Powered by live advisor data.
+        </p>
+        <div className="space-y-6 mb-8">
+          {ADVISOR_SNIPPETS.map((s) => <SnippetBlock key={s.title} snippet={s} />)}
         </div>
+        <h3 className="text-base font-extrabold text-slate-900 mb-4">Advisor Widget Parameters</h3>
+        <ParamsTable rows={[
+          { param: "type", values: "financial-planner | mortgage-broker | accountant | investment-advisor | insurance-broker | smsf-advisor", def: "(all)", desc: "Filter by advisor type." },
+          { param: "state", values: "NSW | VIC | QLD | SA | WA | TAS | ACT | NT", def: "(all)", desc: "Filter by Australian state." },
+          { param: "theme", values: "light | dark", def: "light", desc: "Colour theme." },
+          { param: "limit", values: "1–10", def: "5", desc: "Maximum advisors displayed." },
+          REF_PARAM_ROW,
+        ]} />
+
+        {/* ── Fee Index Widget ── */}
+        <h2 className="text-lg md:text-xl font-extrabold text-slate-900 mb-1">Fee Index Table Widget</h2>
+        <p className="text-sm text-slate-500 mb-5">
+          A sortable table of AU brokerage fees — ASX and US share costs across all active brokers.
+          Factual aggregate data sourced from publicly disclosed fee schedules.
+        </p>
+        <div className="space-y-6 mb-8">
+          {FEE_INDEX_SNIPPETS.map((s) => <SnippetBlock key={s.title} snippet={s} />)}
+        </div>
+        <h3 className="text-base font-extrabold text-slate-900 mb-4">Fee Index Widget Parameters</h3>
+        <ParamsTable rows={[
+          { param: "market", values: "asx | us", def: "asx", desc: "Which market to highlight in the table." },
+          { param: "sort", values: "asx_fee | us_fee | rating", def: "asx_fee", desc: "Sort column. Fee sorts ascending (cheapest first); rating descending." },
+          { param: "theme", values: "light | dark", def: "light", desc: "Colour theme." },
+          { param: "limit", values: "1–20", def: "10", desc: "Maximum brokers displayed." },
+          REF_PARAM_ROW,
+        ]} />
+
+        {/* ── Health Scores Widget ── */}
+        <h2 className="text-lg md:text-xl font-extrabold text-slate-900 mb-1">Broker Health Score Widget</h2>
+        <p className="text-sm text-slate-500 mb-5">
+          Safety scores (0–100) computed from publicly disclosed regulatory attributes — ASIC
+          status, AFSL, CHESS sponsorship, years operating, and editorial rating. Not financial advice.
+        </p>
+        <div className="space-y-6 mb-8">
+          {HEALTH_SNIPPETS.map((s) => <SnippetBlock key={s.title} snippet={s} />)}
+        </div>
+        <h3 className="text-base font-extrabold text-slate-900 mb-4">Health Score Widget Parameters</h3>
+        <ParamsTable rows={[
+          { param: "brokers", values: "slug,slug,...", def: "(top by rating)", desc: "Comma-separated broker slugs to include." },
+          { param: "theme", values: "light | dark", def: "light", desc: "Colour theme." },
+          { param: "limit", values: "1–10", def: "5", desc: "Maximum brokers displayed." },
+          REF_PARAM_ROW,
+        ]} />
 
         {/* Interactive Builder */}
         <h2 className="text-lg md:text-xl font-extrabold text-slate-900 mb-4">Get Your Embed Code</h2>

--- a/lib/widget/types.ts
+++ b/lib/widget/types.ts
@@ -13,7 +13,24 @@
  * Calculator widgets are served by the separate /api/widget/calculator
  * route (same Shadow DOM / CORS / ISR approach), configured via
  * CALCULATOR_WIDGET_CATALOGUE below.
+ *
+ * Suite routes (same Shadow DOM / CORS / ISR approach):
+ *   /api/widget/advisors      — advisor directory widget
+ *   /api/widget/fee-index     — AU brokerage fee index table
+ *   /api/widget/health-scores — broker health score comparison
+ *
+ * All suite routes support an optional `?ref=<partnerId>` query param that
+ * is threaded through to outbound invest.com.au links for partner attribution.
+ * No new DB tables are created; the param is appended to href strings only.
  */
+
+/** Widget kind discriminant — used in the EmbedBuilder tab/dropdown. */
+export type WidgetKind =
+  | "broker"
+  | "calculator"
+  | "advisors"
+  | "fee-index"
+  | "health-scores";
 
 export type WidgetFilter = "all" | "asx" | "us" | "crypto" | "savings" | "term-deposits";
 
@@ -124,3 +141,102 @@ const CALC_BY_SLUG = new Map(CALCULATOR_WIDGET_CATALOGUE.map((p) => [p.slug, p])
 export function getCalcWidgetPreset(slug: string): CalcWidgetPreset | undefined {
   return CALC_BY_SLUG.get(slug);
 }
+
+// ─── Advisor Widget types ─────────────────────────────────────────────────────
+
+/** Supported AU states for the advisor directory widget filter. */
+export const AU_STATES = ["NSW", "VIC", "QLD", "SA", "WA", "TAS", "ACT", "NT"] as const;
+export type AuState = (typeof AU_STATES)[number];
+
+/** Supported professional types for the advisor directory widget filter. */
+export const ADVISOR_TYPES = [
+  "financial-planner",
+  "mortgage-broker",
+  "accountant",
+  "investment-advisor",
+  "insurance-broker",
+  "smsf-advisor",
+] as const;
+export type AdvisorType = (typeof ADVISOR_TYPES)[number];
+
+// ─── Fee-Index Widget types ───────────────────────────────────────────────────
+
+/** Supported sort columns for the fee-index widget. */
+export type FeeIndexSortColumn = "asx_fee" | "us_fee" | "rating";
+
+// ─── Suite widget metadata (used by EmbedBuilder) ────────────────────────────
+
+/**
+ * Metadata record for each widget in the suite, used to drive the
+ * EmbedBuilder tab/dropdown and documentation snippets.
+ */
+export interface SuiteWidgetMeta {
+  kind: WidgetKind;
+  label: string;
+  description: string;
+  apiPath: string;
+  /** Example query-param snippets shown in the embed docs. */
+  snippets: { title: string; description: string; params: string }[];
+}
+
+export const SUITE_WIDGET_CATALOGUE: ReadonlyArray<SuiteWidgetMeta> = [
+  {
+    kind: "broker",
+    label: "Broker Comparison",
+    description: "Live broker comparison table or compact card layout.",
+    apiPath: "/api/widget",
+    snippets: [
+      { title: "Top 5 brokers (default)", description: "Top-rated active brokers.", params: "" },
+      { title: "Cheapest ASX brokers", description: "Sorted by ASX per-trade fee.", params: "?widget=cheapest-brokers" },
+      { title: "US shares", description: "Brokers with US share access.", params: "?widget=us-shares" },
+      { title: "Dark theme, compact", description: "Compact card layout for dark-mode sidebars.", params: "?type=compact&theme=dark&limit=3" },
+    ],
+  },
+  {
+    kind: "calculator",
+    label: "Fee Calculator",
+    description: "Interactive trade-cost calculator — visitors can adjust the trade amount.",
+    apiPath: "/api/widget/calculator",
+    snippets: [
+      { title: "ASX fee calculator", description: "Default ASX brokerage comparison.", params: "" },
+      { title: "US shares (with FX)", description: "True per-trade cost for US shares including FX margin.", params: "?market=us" },
+      { title: "Large trade ($25k)", description: "Pre-fills $25k to show % brokerage sting.", params: "?amount=25000" },
+    ],
+  },
+  {
+    kind: "advisors",
+    label: "Advisor Directory",
+    description: "Embeddable financial-advisor directory with optional type/state filter.",
+    apiPath: "/api/widget/advisors",
+    snippets: [
+      { title: "All advisors (default)", description: "Top-rated active advisors.", params: "" },
+      { title: "Financial planners in NSW", description: "Filtered by type and state.", params: "?type=financial-planner&state=NSW" },
+      { title: "Dark theme", description: "Advisor cards styled for dark-mode sites.", params: "?theme=dark" },
+      { title: "With partner ref", description: "Partner attribution threaded through outbound links.", params: "?ref=yourpartnerId" },
+    ],
+  },
+  {
+    kind: "fee-index",
+    label: "Fee Index Table",
+    description: "AU brokerage fee index — sortable table of ASX and US share fees.",
+    apiPath: "/api/widget/fee-index",
+    snippets: [
+      { title: "ASX fee index (default)", description: "All active brokers sorted by ASX fee.", params: "" },
+      { title: "US share fee index", description: "Sorted by US share fee.", params: "?market=us&sort=us_fee" },
+      { title: "Top-rated, limited to 5", description: "Sorted by editorial rating.", params: "?sort=rating&limit=5" },
+      { title: "Dark theme", description: "Fee index styled for dark-mode sites.", params: "?theme=dark" },
+    ],
+  },
+  {
+    kind: "health-scores",
+    label: "Health Scores",
+    description: "Broker health / safety scores computed from regulatory attributes.",
+    apiPath: "/api/widget/health-scores",
+    snippets: [
+      { title: "Top 5 health scores (default)", description: "Top brokers with safety scores.", params: "" },
+      { title: "Specific brokers", description: "Health scores for chosen brokers.", params: "?brokers=stake,commsec,cmc-markets" },
+      { title: "Dark theme", description: "Health scores styled for dark-mode sites.", params: "?theme=dark" },
+      { title: "With partner ref", description: "Partner attribution threaded through links.", params: "?ref=yourpartnerId" },
+    ],
+  },
+];


### PR DESCRIPTION
Deepens the embeddable-widget product (broker comparison + fee calculator) into a **white-label suite + partner attribution**.

- Three new self-contained widgets (same Shadow-DOM / CORS `*` / ISR / anon-key-only / general-advice-disclaimer pattern): `/api/widget/advisors` (directory, filter by type/state), `/api/widget/fee-index` (fee table, sortable), `/api/widget/health-scores` (broker safety scores, computed from public broker columns).
- **Partner attribution:** an optional `?ref=<partnerId>` threaded consistently across all 5 widget routes (3 new + the 2 existing, now parameterised) — appended to every outbound link, query-param only, no new tables.
- `EmbedBuilder` is now a 5-tab builder with a shared Partner ID field; `/embed` docs + snippets expanded for all five.

**Verified:** `tsc` clean · **77 widget tests** (advisors/fee-index/health-scores + ref-param threading) pass · eslint clean · rate-limit `--strict` pass. (Health-scores widget uses the anon `brokers` table — never the service-role `broker_health_scores` — so no RLS bypass.) Recovered the full 3-commit range by SHA (the pushed branch ref was stale again).

Factual data only (AFSL-safe).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUfSRE2Teb6VhEXFP6RpS9)_