### PR TITLE
feat: API data platform — savings, robo-advisors, health-scores, OpenAPI 3.1 (deepen)

### DIFF
--- a/__tests__/api/v1-docs.test.ts
+++ b/__tests__/api/v1-docs.test.ts
@@ -14,7 +14,7 @@ describe("/api/v1/docs", () => {
     const res = await GET();
     expect(res.status).toBe(200);
     const json = await res.json();
-    expect(json).toHaveProperty("name", "Invest.com.au Broker API");
+    expect(json).toHaveProperty("name", "Invest.com.au Financial Data API");
     expect(json).toHaveProperty("version", "1.0");
     expect(json).toHaveProperty("endpoints");
     expect(Array.isArray(json.endpoints)).toBe(true);

--- a/__tests__/api/v1-health-scores-history.test.ts
+++ b/__tests__/api/v1-health-scores-history.test.ts
@@ -1,0 +1,292 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const { mockServerFrom } = vi.hoisted(() => ({ mockServerFrom: vi.fn() }));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn().mockResolvedValue({ from: mockServerFrom }),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn() })),
+}));
+
+vi.mock("@/lib/html-escape", () => ({
+  escapeHtml: vi.fn((s: string) => s),
+}));
+
+const mockValidateApiKey = vi.fn();
+const mockLogApiRequest = vi.fn();
+vi.mock("@/lib/api-auth", () => ({
+  validateApiKey: (...args: unknown[]) => mockValidateApiKey(...args),
+  logApiRequest: (...args: unknown[]) => mockLogApiRequest(...args),
+  API_CORS_HEADERS: {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET, OPTIONS",
+    "Access-Control-Allow-Headers": "Authorization, Content-Type",
+  },
+}));
+
+import { GET, OPTIONS } from "@/app/api/v1/health-scores/history/route";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+const VALID_KEY = { id: "key-hs-history", name: "Test", key_prefix: "ica_test" };
+
+function makeValidAuth() {
+  return { valid: true, apiKey: VALID_KEY };
+}
+
+function makeInvalidAuth(msg = "Invalid API key") {
+  return { valid: false, error: msg };
+}
+
+function makeHistoryEntry(overrides: Record<string, unknown> = {}) {
+  return {
+    broker_slug: "stake",
+    overall_score: 82.5,
+    regulatory_score: 90,
+    client_money_score: 85,
+    financial_stability_score: 78,
+    platform_reliability_score: 79,
+    insurance_score: 80,
+    captured_at: "2026-05-24T02:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeHistoryBuilder(
+  rows: unknown[] = [],
+  error: unknown = null,
+  count = rows.length,
+) {
+  return {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    gte: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    range: vi.fn(() => Promise.resolve({ data: rows, count, error })),
+  };
+}
+
+function makeGet(params: Record<string, string> = {}): NextRequest {
+  const sp = new URLSearchParams(params).toString();
+  const url = `http://localhost/api/v1/health-scores/history${sp ? `?${sp}` : ""}`;
+  return new NextRequest(url, {
+    headers: { Authorization: "Bearer ica_testkey123" },
+  });
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("OPTIONS /api/v1/health-scores/history", () => {
+  it("returns 204 with CORS headers", async () => {
+    const res = await OPTIONS();
+    expect(res.status).toBe(204);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+  });
+});
+
+describe("GET /api/v1/health-scores/history — auth", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 401 when API key missing", async () => {
+    mockValidateApiKey.mockResolvedValue(makeInvalidAuth("No API key"));
+    const res = await GET(makeGet({ broker_slug: "stake" }));
+    expect(res.status).toBe(401);
+    const data = await res.json();
+    expect(data.error).toBe("No API key");
+  });
+
+  it("returns 401 when API key invalid", async () => {
+    mockValidateApiKey.mockResolvedValue(makeInvalidAuth());
+    const res = await GET(makeGet({ broker_slug: "stake" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("logs failed auth requests", async () => {
+    mockValidateApiKey.mockResolvedValue(makeInvalidAuth());
+    await GET(makeGet({ broker_slug: "stake" }));
+    expect(mockLogApiRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        statusCode: 401,
+        endpoint: "/api/v1/health-scores/history",
+      }),
+    );
+  });
+});
+
+describe("GET /api/v1/health-scores/history — validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockValidateApiKey.mockResolvedValue(makeValidAuth());
+  });
+
+  it("returns 400 when broker_slug is missing", async () => {
+    const res = await GET(makeGet());
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/broker_slug/i);
+  });
+
+  it("returns 400 when broker_slug has invalid chars (uppercase)", async () => {
+    const res = await GET(makeGet({ broker_slug: "STAKE" }));
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /api/v1/health-scores/history — success", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockValidateApiKey.mockResolvedValue(makeValidAuth());
+  });
+
+  it("returns history for a broker", async () => {
+    const entry = makeHistoryEntry();
+    mockServerFrom.mockReturnValue(makeHistoryBuilder([entry], null, 1));
+
+    const res = await GET(makeGet({ broker_slug: "stake" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].broker_slug).toBe("stake");
+    expect(body.data[0].overall_score).toBe(82.5);
+    expect(body.meta.broker_slug).toBe("stake");
+    expect(body.meta.disclaimer).toBeTruthy();
+  });
+
+  it("strips private fields (id not in PUBLIC_FIELDS)", async () => {
+    const entry = { ...makeHistoryEntry(), id: 999, secret_field: "hidden" };
+    mockServerFrom.mockReturnValue(makeHistoryBuilder([entry], null, 1));
+
+    const res = await GET(makeGet({ broker_slug: "stake" }));
+    const body = await res.json();
+    expect(body.data[0].id).toBeUndefined();
+    expect(body.data[0].secret_field).toBeUndefined();
+  });
+
+  it("filters by broker_slug", async () => {
+    const builder = makeHistoryBuilder([], null, 0);
+    mockServerFrom.mockReturnValue(builder);
+
+    await GET(makeGet({ broker_slug: "stake" }));
+    expect(builder.eq).toHaveBeenCalledWith("broker_slug", "stake");
+  });
+
+  it("applies days filter via gte on captured_at", async () => {
+    const builder = makeHistoryBuilder([], null, 0);
+    mockServerFrom.mockReturnValue(builder);
+
+    await GET(makeGet({ broker_slug: "stake", days: "30" }));
+    expect(builder.gte).toHaveBeenCalled();
+    // The argument is an ISO date string for ~30 days ago
+    const gteCall = builder.gte.mock.calls[0];
+    expect(gteCall?.[0]).toBe("captured_at");
+    expect(typeof gteCall?.[1]).toBe("string");
+  });
+
+  it("defaults days to 90 when not provided", async () => {
+    const builder = makeHistoryBuilder([], null, 0);
+    mockServerFrom.mockReturnValue(builder);
+
+    await GET(makeGet({ broker_slug: "stake" }));
+    const body = (await builder.range.mock.results[0]?.value) as unknown;
+    void body;
+    // Indirectly validated by checking gte was called with a date ~90 days ago
+    expect(builder.gte).toHaveBeenCalled();
+  });
+
+  it("clamps days to 400", async () => {
+    const builder = makeHistoryBuilder([], null, 0);
+    mockServerFrom.mockReturnValue(builder);
+
+    const res = await GET(makeGet({ broker_slug: "stake", days: "999" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.meta.days).toBe(400);
+  });
+
+  it("respects limit query param (max 400)", async () => {
+    const builder = makeHistoryBuilder([], null, 0);
+    mockServerFrom.mockReturnValue(builder);
+
+    await GET(makeGet({ broker_slug: "stake", limit: "50" }));
+    expect(builder.range).toHaveBeenCalledWith(0, 49);
+  });
+
+  it("clamps limit to 400", async () => {
+    const builder = makeHistoryBuilder([], null, 0);
+    mockServerFrom.mockReturnValue(builder);
+
+    await GET(makeGet({ broker_slug: "stake", limit: "1000" }));
+    expect(builder.range).toHaveBeenCalledWith(0, 399);
+  });
+
+  it("respects offset query param", async () => {
+    const builder = makeHistoryBuilder([], null, 100);
+    mockServerFrom.mockReturnValue(builder);
+
+    await GET(makeGet({ broker_slug: "stake", offset: "50" }));
+    expect(builder.range).toHaveBeenCalledWith(50, 149);
+  });
+
+  it("returns 500 on DB error", async () => {
+    const errorBuilder = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      gte: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      range: vi.fn(() =>
+        Promise.resolve({
+          data: null,
+          count: null,
+          error: { message: "DB error" },
+        }),
+      ),
+    };
+    mockServerFrom.mockReturnValue(errorBuilder);
+
+    const res = await GET(makeGet({ broker_slug: "stake" }));
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data.error).toMatch(/health score/i);
+  });
+
+  it("returns 500 on unexpected throw", async () => {
+    mockServerFrom.mockImplementation(() => {
+      throw new Error("boom");
+    });
+
+    const res = await GET(makeGet({ broker_slug: "stake" }));
+    expect(res.status).toBe(500);
+  });
+
+  it("logs successful requests with apiKeyId", async () => {
+    mockServerFrom.mockReturnValue(
+      makeHistoryBuilder([makeHistoryEntry()], null, 1),
+    );
+
+    await GET(makeGet({ broker_slug: "stake" }));
+    expect(mockLogApiRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ statusCode: 200, apiKeyId: "key-hs-history" }),
+    );
+  });
+
+  it("includes Cache-Control header on success", async () => {
+    mockServerFrom.mockReturnValue(makeHistoryBuilder([], null, 0));
+
+    const res = await GET(makeGet({ broker_slug: "stake" }));
+    expect(res.headers.get("Cache-Control")).toContain("max-age=3600");
+  });
+
+  it("reports meta.updated_at from first entry captured_at", async () => {
+    const entry = makeHistoryEntry({ captured_at: "2026-05-24T02:00:00Z" });
+    mockServerFrom.mockReturnValue(makeHistoryBuilder([entry], null, 1));
+
+    const res = await GET(makeGet({ broker_slug: "stake" }));
+    const body = await res.json();
+    expect(body.meta.updated_at).toBe("2026-05-24T02:00:00Z");
+  });
+});

--- a/__tests__/api/v1-health-scores.test.ts
+++ b/__tests__/api/v1-health-scores.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const { mockServerFrom } = vi.hoisted(() => ({ mockServerFrom: vi.fn() }));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn().mockResolvedValue({ from: mockServerFrom }),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn() })),
+}));
+
+vi.mock("@/lib/html-escape", () => ({
+  escapeHtml: vi.fn((s: string) => s),
+}));
+
+const mockValidateApiKey = vi.fn();
+const mockLogApiRequest = vi.fn();
+vi.mock("@/lib/api-auth", () => ({
+  validateApiKey: (...args: unknown[]) => mockValidateApiKey(...args),
+  logApiRequest: (...args: unknown[]) => mockLogApiRequest(...args),
+  API_CORS_HEADERS: {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET, OPTIONS",
+    "Access-Control-Allow-Headers": "Authorization, Content-Type",
+  },
+}));
+
+import { GET, OPTIONS } from "@/app/api/v1/health-scores/route";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+const VALID_KEY = { id: "key-hs", name: "Test", key_prefix: "ica_test" };
+
+function makeValidAuth() {
+  return { valid: true, apiKey: VALID_KEY };
+}
+
+function makeInvalidAuth(msg = "Invalid API key") {
+  return { valid: false, error: msg };
+}
+
+function makeScore(overrides: Record<string, unknown> = {}) {
+  return {
+    broker_slug: "stake",
+    afsl_number: "123456",
+    afsl_status: "active",
+    overall_score: 82.5,
+    regulatory_score: 90,
+    regulatory_notes: "AFSL active, no breaches on record",
+    financial_stability_score: 78,
+    financial_stability_notes: "Adequate capital buffer",
+    client_money_score: 85,
+    client_money_notes: "Segregated trust accounts confirmed",
+    insurance_score: 80,
+    insurance_notes: "PI insurance current",
+    platform_reliability_score: 79,
+    platform_reliability_notes: "Two minor outages in past 12 months",
+    last_reviewed_at: "2026-05-01T00:00:00Z",
+    updated_at: "2026-05-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeScoresBuilder(
+  rows: unknown[] = [],
+  error: unknown = null,
+  count = rows.length,
+) {
+  return {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    gte: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    range: vi.fn(() => Promise.resolve({ data: rows, count, error })),
+  };
+}
+
+function makeGet(params: Record<string, string> = {}): NextRequest {
+  const sp = new URLSearchParams(params).toString();
+  const url = `http://localhost/api/v1/health-scores${sp ? `?${sp}` : ""}`;
+  return new NextRequest(url, {
+    headers: { Authorization: "Bearer ica_testkey123" },
+  });
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("OPTIONS /api/v1/health-scores", () => {
+  it("returns 204 with CORS headers", async () => {
+    const res = await OPTIONS();
+    expect(res.status).toBe(204);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+  });
+});
+
+describe("GET /api/v1/health-scores — auth", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 401 when API key missing", async () => {
+    mockValidateApiKey.mockResolvedValue(makeInvalidAuth("No API key"));
+    const res = await GET(makeGet());
+    expect(res.status).toBe(401);
+    const data = await res.json();
+    expect(data.error).toBe("No API key");
+  });
+
+  it("returns 401 when API key invalid", async () => {
+    mockValidateApiKey.mockResolvedValue(makeInvalidAuth());
+    const res = await GET(makeGet());
+    expect(res.status).toBe(401);
+  });
+
+  it("logs failed auth requests", async () => {
+    mockValidateApiKey.mockResolvedValue(makeInvalidAuth());
+    await GET(makeGet());
+    expect(mockLogApiRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        statusCode: 401,
+        endpoint: "/api/v1/health-scores",
+      }),
+    );
+  });
+});
+
+describe("GET /api/v1/health-scores — success", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockValidateApiKey.mockResolvedValue(makeValidAuth());
+  });
+
+  it("returns health scores with meta", async () => {
+    const score = makeScore();
+    mockServerFrom.mockReturnValue(makeScoresBuilder([score], null, 1));
+
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].broker_slug).toBe("stake");
+    expect(body.data[0].overall_score).toBe(82.5);
+    expect(body.meta.total).toBe(1);
+    expect(body.meta.disclaimer).toBeTruthy();
+  });
+
+  it("strips private fields (id column not in PUBLIC_FIELDS)", async () => {
+    const score = { ...makeScore(), id: 999, secret_field: "hidden" };
+    mockServerFrom.mockReturnValue(makeScoresBuilder([score], null, 1));
+
+    const res = await GET(makeGet());
+    const body = await res.json();
+    // id is not in PUBLIC_FIELDS for health scores
+    expect(body.data[0].id).toBeUndefined();
+    expect(body.data[0].secret_field).toBeUndefined();
+  });
+
+  it("filters by broker_slug when provided", async () => {
+    const builder = makeScoresBuilder([], null, 0);
+    mockServerFrom.mockReturnValue(builder);
+
+    await GET(makeGet({ broker_slug: "stake" }));
+    expect(builder.eq).toHaveBeenCalledWith("broker_slug", "stake");
+  });
+
+  it("applies min_score filter", async () => {
+    const builder = makeScoresBuilder([], null, 0);
+    mockServerFrom.mockReturnValue(builder);
+
+    await GET(makeGet({ min_score: "70" }));
+    expect(builder.gte).toHaveBeenCalledWith("overall_score", 70);
+  });
+
+  it("ignores non-numeric min_score", async () => {
+    const builder = makeScoresBuilder([], null, 0);
+    mockServerFrom.mockReturnValue(builder);
+
+    await GET(makeGet({ min_score: "invalid" }));
+    // Should not call gte with NaN
+    expect(builder.gte).not.toHaveBeenCalled();
+  });
+
+  it("respects limit query param (max 100)", async () => {
+    const builder = makeScoresBuilder([], null, 0);
+    mockServerFrom.mockReturnValue(builder);
+
+    await GET(makeGet({ limit: "5" }));
+    expect(builder.range).toHaveBeenCalledWith(0, 4);
+  });
+
+  it("clamps limit to 100 when 200 requested", async () => {
+    const builder = makeScoresBuilder([], null, 0);
+    mockServerFrom.mockReturnValue(builder);
+
+    await GET(makeGet({ limit: "200" }));
+    expect(builder.range).toHaveBeenCalledWith(0, 99);
+  });
+
+  it("respects offset query param", async () => {
+    const builder = makeScoresBuilder([], null, 100);
+    mockServerFrom.mockReturnValue(builder);
+
+    await GET(makeGet({ offset: "20" }));
+    expect(builder.range).toHaveBeenCalledWith(20, 39);
+  });
+
+  it("returns 500 on DB error", async () => {
+    const errorBuilder = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      gte: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      range: vi.fn(() =>
+        Promise.resolve({
+          data: null,
+          count: null,
+          error: { message: "DB error" },
+        }),
+      ),
+    };
+    mockServerFrom.mockReturnValue(errorBuilder);
+
+    const res = await GET(makeGet());
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data.error).toMatch(/health score/i);
+  });
+
+  it("returns 500 on unexpected throw", async () => {
+    mockServerFrom.mockImplementation(() => {
+      throw new Error("boom");
+    });
+
+    const res = await GET(makeGet());
+    expect(res.status).toBe(500);
+  });
+
+  it("logs successful requests with apiKeyId", async () => {
+    mockServerFrom.mockReturnValue(makeScoresBuilder([makeScore()], null, 1));
+
+    await GET(makeGet());
+    expect(mockLogApiRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ statusCode: 200, apiKeyId: "key-hs" }),
+    );
+  });
+
+  it("includes Cache-Control header on success", async () => {
+    mockServerFrom.mockReturnValue(makeScoresBuilder([], null, 0));
+
+    const res = await GET(makeGet());
+    expect(res.headers.get("Cache-Control")).toContain("max-age=3600");
+  });
+
+  it("computes meta.updated_at from most recent score", async () => {
+    const scores = [
+      makeScore({ broker_slug: "stake", updated_at: "2026-01-01T00:00:00Z" }),
+      makeScore({ broker_slug: "commsec", updated_at: "2026-04-01T00:00:00Z" }),
+    ];
+    mockServerFrom.mockReturnValue(makeScoresBuilder(scores, null, 2));
+
+    const res = await GET(makeGet());
+    const body = await res.json();
+    expect(body.meta.updated_at).toBe("2026-04-01T00:00:00Z");
+  });
+});

--- a/__tests__/api/v1-openapi.test.ts
+++ b/__tests__/api/v1-openapi.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("@/lib/api-auth", () => ({
+  API_CORS_HEADERS: {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET, OPTIONS",
+    "Access-Control-Allow-Headers": "Authorization, Content-Type",
+  },
+}));
+
+import { GET, OPTIONS } from "@/app/api/v1/openapi.json/route";
+import { buildOpenApiSpec } from "@/lib/openapi-spec";
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("OPTIONS /api/v1/openapi.json", () => {
+  it("returns 204 with CORS headers", async () => {
+    const res = await OPTIONS();
+    expect(res.status).toBe(204);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+  });
+});
+
+describe("GET /api/v1/openapi.json — structural validity", () => {
+  it("returns 200 with Content-Type application/json", async () => {
+    const res = await GET();
+    expect(res.status).toBe(200);
+  });
+
+  it("returns a valid OpenAPI 3.1 document", async () => {
+    const res = await GET();
+    const spec = await res.json();
+
+    // Core required OpenAPI 3.1 fields
+    expect(spec.openapi).toBe("3.1.0");
+    expect(spec.info).toMatchObject({
+      title: expect.any(String),
+      version: expect.any(String),
+    });
+    expect(Array.isArray(spec.servers)).toBe(true);
+    expect(spec.servers.length).toBeGreaterThan(0);
+    expect(spec.paths).toBeDefined();
+    expect(typeof spec.paths).toBe("object");
+  });
+
+  it("includes all required v1 endpoint paths", async () => {
+    const res = await GET();
+    const spec = await res.json();
+    const paths = Object.keys(spec.paths as Record<string, unknown>);
+
+    // Existing endpoints
+    expect(paths).toContain("/brokers");
+    expect(paths).toContain("/brokers/{slug}");
+    expect(paths).toContain("/compare");
+    expect(paths).toContain("/advisors");
+    expect(paths).toContain("/advisors/{slug}");
+    expect(paths).toContain("/fee-index");
+    expect(paths).toContain("/api-keys");
+    expect(paths).toContain("/docs");
+    expect(paths).toContain("/openapi.json");
+
+    // New endpoints
+    expect(paths).toContain("/savings");
+    expect(paths).toContain("/savings/{slug}");
+    expect(paths).toContain("/robo-advisors");
+    expect(paths).toContain("/robo-advisors/{slug}");
+    expect(paths).toContain("/health-scores");
+    expect(paths).toContain("/health-scores/history");
+  });
+
+  it("every GET path has at least a 200 response defined", async () => {
+    const res = await GET();
+    const spec = await res.json();
+
+    for (const [path, pathItem] of Object.entries(
+      spec.paths as Record<string, Record<string, unknown>>,
+    )) {
+      const getOp = pathItem.get as Record<string, unknown> | undefined;
+      if (getOp) {
+        const responses = getOp.responses as Record<string, unknown>;
+        expect(
+          responses["200"],
+          `GET ${path} must have a 200 response`,
+        ).toBeDefined();
+      }
+    }
+  });
+
+  it("every path with a GET operation has an operationId", async () => {
+    const res = await GET();
+    const spec = await res.json();
+
+    for (const [path, pathItem] of Object.entries(
+      spec.paths as Record<string, Record<string, unknown>>,
+    )) {
+      const getOp = pathItem.get as Record<string, unknown> | undefined;
+      if (getOp) {
+        expect(
+          getOp.operationId,
+          `GET ${path} must have an operationId`,
+        ).toBeDefined();
+        expect(typeof getOp.operationId).toBe("string");
+      }
+    }
+  });
+
+  it("has security schemes defined in components", async () => {
+    const res = await GET();
+    const spec = await res.json();
+    const components = spec.components as Record<string, unknown>;
+    expect(components.securitySchemes).toBeDefined();
+    const schemes = components.securitySchemes as Record<string, unknown>;
+    expect(schemes.BearerAuth).toBeDefined();
+  });
+
+  it("has required schemas in components", async () => {
+    const res = await GET();
+    const spec = await res.json();
+    const schemas = (spec.components as Record<string, unknown>)
+      .schemas as Record<string, unknown>;
+
+    // Core schemas
+    expect(schemas.ErrorResponse).toBeDefined();
+    expect(schemas.Broker).toBeDefined();
+    expect(schemas.BrokerDetail).toBeDefined();
+    expect(schemas.Advisor).toBeDefined();
+    expect(schemas.FeeIndexSnapshot).toBeDefined();
+
+    // New schemas
+    expect(schemas.SavingsPlatform).toBeDefined();
+    expect(schemas.SavingsRate).toBeDefined();
+    expect(schemas.RoboAdvisor).toBeDefined();
+    expect(schemas.RoboAdvisorDetail).toBeDefined();
+    expect(schemas.HealthScore).toBeDefined();
+    expect(schemas.HealthScoreHistoryEntry).toBeDefined();
+  });
+
+  it("has a server URL pointing to invest.com.au", async () => {
+    const res = await GET();
+    const spec = await res.json();
+    const servers = spec.servers as { url: string }[];
+    const hasInvestServer = servers.some((s) =>
+      s.url.includes("invest.com.au"),
+    );
+    expect(hasInvestServer).toBe(true);
+  });
+
+  it("includes Cache-Control public header", async () => {
+    const res = await GET();
+    expect(res.headers.get("Cache-Control")).toContain("public");
+    expect(res.headers.get("Cache-Control")).toContain("max-age=86400");
+  });
+
+  it("health-scores/history path requires broker_slug param", async () => {
+    const res = await GET();
+    const spec = await res.json();
+    const historyPath = (spec.paths as Record<string, unknown>)[
+      "/health-scores/history"
+    ] as Record<string, unknown>;
+    const getOp = historyPath.get as Record<string, unknown>;
+    const params = getOp.parameters as {
+      name: string;
+      required?: boolean;
+    }[];
+
+    const brokerSlugParam = params.find((p) => p.name === "broker_slug");
+    expect(brokerSlugParam).toBeDefined();
+    expect(brokerSlugParam?.required).toBe(true);
+  });
+
+  it("savings endpoint documents rate_bps field", async () => {
+    const res = await GET();
+    const spec = await res.json();
+    const schemas = (spec.components as Record<string, unknown>)
+      .schemas as Record<string, unknown>;
+    const savingsRate = schemas.SavingsRate as Record<string, unknown>;
+    const properties = savingsRate.properties as Record<
+      string,
+      Record<string, unknown>
+    >;
+
+    expect(properties.rate_bps).toBeDefined();
+    expect(properties.rate_bps.description).toMatch(/basis points/i);
+  });
+});
+
+describe("buildOpenApiSpec() unit tests", () => {
+  it("returns a deterministic spec on multiple calls", () => {
+    const spec1 = buildOpenApiSpec();
+    const spec2 = buildOpenApiSpec();
+    expect(JSON.stringify(spec1)).toBe(JSON.stringify(spec2));
+  });
+
+  it("spec openapi field is exactly '3.1.0'", () => {
+    const spec = buildOpenApiSpec();
+    expect(spec.openapi).toBe("3.1.0");
+  });
+
+  it("all paths use /api/v1 prefix-relative paths (no full URL)", () => {
+    const spec = buildOpenApiSpec();
+    // Paths should be relative (start with /), not absolute URLs
+    for (const path of Object.keys(spec.paths)) {
+      expect(path).toMatch(/^\//);
+      // Should NOT be a full URL
+      expect(path).not.toMatch(/^https?:\/\//);
+    }
+  });
+});

--- a/__tests__/api/v1-robo-advisors-slug.test.ts
+++ b/__tests__/api/v1-robo-advisors-slug.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const { mockServerFrom } = vi.hoisted(() => ({ mockServerFrom: vi.fn() }));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn().mockResolvedValue({ from: mockServerFrom }),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn() })),
+}));
+
+vi.mock("@/lib/html-escape", () => ({
+  escapeHtml: vi.fn((s: string) => s),
+}));
+
+const mockValidateApiKey = vi.fn();
+const mockLogApiRequest = vi.fn();
+vi.mock("@/lib/api-auth", () => ({
+  validateApiKey: (...args: unknown[]) => mockValidateApiKey(...args),
+  logApiRequest: (...args: unknown[]) => mockLogApiRequest(...args),
+  API_CORS_HEADERS: {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET, OPTIONS",
+    "Access-Control-Allow-Headers": "Authorization, Content-Type",
+  },
+}));
+
+import { GET, OPTIONS } from "@/app/api/v1/robo-advisors/[slug]/route";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+const VALID_KEY = {
+  id: "key-robo-slug",
+  name: "Test",
+  key_prefix: "ica_test",
+};
+
+function makeValidAuth() {
+  return { valid: true, apiKey: VALID_KEY };
+}
+
+function makeInvalidAuth(msg = "Invalid API key") {
+  return { valid: false, error: msg };
+}
+
+function makeRobo(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 20,
+    name: "Stockspot",
+    slug: "stockspot",
+    platform_type: "robo_advisor",
+    rating: 4.7,
+    review_content: "Top robo-advisor for long-term investors.",
+    fee_source_url: "https://stockspot.com.au/fees",
+    smsf_support: true,
+    status: "active",
+    updated_at: "2026-04-28T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeChangelogEntry(overrides: Record<string, unknown> = {}) {
+  return {
+    field_name: "min_deposit",
+    old_value: "1000",
+    new_value: "2000",
+    change_type: "update",
+    changed_at: "2026-03-10T09:00:00Z",
+    source: "fee_page_check",
+    ...overrides,
+  };
+}
+
+function makeSingleRoboBuilder(row: unknown | null, error: unknown = null) {
+  return {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    single: vi.fn(() => Promise.resolve({ data: row, error })),
+  };
+}
+
+function makeChangelogBuilder(rows: unknown[] = []) {
+  return {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    limit: vi.fn(() => Promise.resolve({ data: rows, error: null })),
+  };
+}
+
+function makeGet(
+  slug: string,
+): { req: NextRequest; routeParams: Promise<{ slug: string }> } {
+  const url = `http://localhost/api/v1/robo-advisors/${slug}`;
+  return {
+    req: new NextRequest(url, {
+      headers: { Authorization: "Bearer ica_testkey123" },
+    }),
+    routeParams: Promise.resolve({ slug }),
+  };
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("OPTIONS /api/v1/robo-advisors/[slug]", () => {
+  it("returns 204 with CORS headers", async () => {
+    const res = await OPTIONS();
+    expect(res.status).toBe(204);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+  });
+});
+
+describe("GET /api/v1/robo-advisors/[slug] — auth", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 401 when API key invalid", async () => {
+    mockValidateApiKey.mockResolvedValue(makeInvalidAuth());
+    const { req, routeParams } = makeGet("stockspot");
+    const res = await GET(req, { params: routeParams });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("GET /api/v1/robo-advisors/[slug] — validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockValidateApiKey.mockResolvedValue({ valid: true, apiKey: VALID_KEY });
+  });
+
+  it("returns 400 for slug with uppercase letters", async () => {
+    const { req, routeParams } = makeGet("STOCKSPOT");
+    const res = await GET(req, { params: routeParams });
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/slug/i);
+  });
+
+  it("returns 400 for empty slug", async () => {
+    const { req, routeParams } = makeGet("");
+    const res = await GET(req, { params: routeParams });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /api/v1/robo-advisors/[slug] — success", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockValidateApiKey.mockResolvedValue(makeValidAuth());
+  });
+
+  it("returns robo data with fee_changelog", async () => {
+    const robo = makeRobo();
+    const entry = makeChangelogEntry();
+    mockServerFrom.mockImplementation((table: string) => {
+      if (table === "brokers") return makeSingleRoboBuilder(robo);
+      if (table === "broker_data_changes")
+        return makeChangelogBuilder([entry]);
+      throw new Error(`unexpected table: ${table}`);
+    });
+
+    const { req, routeParams } = makeGet("stockspot");
+    const res = await GET(req, { params: routeParams });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.name).toBe("Stockspot");
+    expect(body.data.fee_changelog).toHaveLength(1);
+    expect(body.data.fee_changelog[0].field_name).toBe("min_deposit");
+  });
+
+  it("returns 404 when robo-advisor not found", async () => {
+    mockServerFrom.mockImplementation((table: string) => {
+      if (table === "brokers")
+        return makeSingleRoboBuilder(null, { message: "no rows" });
+      throw new Error(`unexpected table: ${table}`);
+    });
+
+    const { req, routeParams } = makeGet("nonexistent");
+    const res = await GET(req, { params: routeParams });
+    expect(res.status).toBe(404);
+    const data = await res.json();
+    expect(data.error).toMatch(/not found/i);
+  });
+
+  it("strips private fields from robo row", async () => {
+    const robo = {
+      ...makeRobo(),
+      affiliate_url: "https://secret.example.com",
+      commission_cents: 500,
+    };
+    mockServerFrom.mockImplementation((table: string) => {
+      if (table === "brokers") return makeSingleRoboBuilder(robo);
+      if (table === "broker_data_changes") return makeChangelogBuilder([]);
+      throw new Error(`unexpected table: ${table}`);
+    });
+
+    const { req, routeParams } = makeGet("stockspot");
+    const res = await GET(req, { params: routeParams });
+    const body = await res.json();
+    expect(body.data.affiliate_url).toBeUndefined();
+    expect(body.data.commission_cents).toBeUndefined();
+  });
+
+  it("includes review_content in detail response", async () => {
+    const robo = makeRobo();
+    mockServerFrom.mockImplementation((table: string) => {
+      if (table === "brokers") return makeSingleRoboBuilder(robo);
+      if (table === "broker_data_changes") return makeChangelogBuilder([]);
+      throw new Error(`unexpected table: ${table}`);
+    });
+
+    const { req, routeParams } = makeGet("stockspot");
+    const res = await GET(req, { params: routeParams });
+    const body = await res.json();
+    expect(body.data.review_content).toBe("Top robo-advisor for long-term investors.");
+  });
+
+  it("includes Cache-Control header on success", async () => {
+    mockServerFrom.mockImplementation((table: string) => {
+      if (table === "brokers") return makeSingleRoboBuilder(makeRobo());
+      if (table === "broker_data_changes") return makeChangelogBuilder([]);
+      throw new Error(`unexpected table: ${table}`);
+    });
+
+    const { req, routeParams } = makeGet("stockspot");
+    const res = await GET(req, { params: routeParams });
+    expect(res.headers.get("Cache-Control")).toContain("max-age=3600");
+  });
+
+  it("returns 500 on unexpected throw", async () => {
+    mockServerFrom.mockImplementation(() => {
+      throw new Error("DB exploded");
+    });
+
+    const { req, routeParams } = makeGet("stockspot");
+    const res = await GET(req, { params: routeParams });
+    expect(res.status).toBe(500);
+  });
+
+  it("logs successful request with apiKeyId", async () => {
+    mockServerFrom.mockImplementation((table: string) => {
+      if (table === "brokers") return makeSingleRoboBuilder(makeRobo());
+      if (table === "broker_data_changes") return makeChangelogBuilder([]);
+      throw new Error(`unexpected table: ${table}`);
+    });
+
+    const { req, routeParams } = makeGet("stockspot");
+    await GET(req, { params: routeParams });
+    expect(mockLogApiRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        statusCode: 200,
+        apiKeyId: "key-robo-slug",
+      }),
+    );
+  });
+
+  it("returns 401 and logs failed requests", async () => {
+    mockValidateApiKey.mockResolvedValue(makeInvalidAuth());
+    const { req, routeParams } = makeGet("stockspot");
+    await GET(req, { params: routeParams });
+    expect(mockLogApiRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ statusCode: 401 }),
+    );
+  });
+});

--- a/__tests__/api/v1-robo-advisors.test.ts
+++ b/__tests__/api/v1-robo-advisors.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const { mockServerFrom } = vi.hoisted(() => ({ mockServerFrom: vi.fn() }));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn().mockResolvedValue({ from: mockServerFrom }),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn() })),
+}));
+
+vi.mock("@/lib/html-escape", () => ({
+  escapeHtml: vi.fn((s: string) => s),
+}));
+
+const mockValidateApiKey = vi.fn();
+const mockLogApiRequest = vi.fn();
+vi.mock("@/lib/api-auth", () => ({
+  validateApiKey: (...args: unknown[]) => mockValidateApiKey(...args),
+  logApiRequest: (...args: unknown[]) => mockLogApiRequest(...args),
+  API_CORS_HEADERS: {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET, OPTIONS",
+    "Access-Control-Allow-Headers": "Authorization, Content-Type",
+  },
+}));
+
+import { GET, OPTIONS } from "@/app/api/v1/robo-advisors/route";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+const VALID_KEY = { id: "key-robo", name: "Test", key_prefix: "ica_test" };
+
+function makeValidAuth() {
+  return { valid: true, apiKey: VALID_KEY };
+}
+
+function makeInvalidAuth(msg = "Invalid API key") {
+  return { valid: false, error: msg };
+}
+
+function makeRobo(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 20,
+    name: "Stockspot",
+    slug: "stockspot",
+    platform_type: "robo_advisor",
+    rating: 4.7,
+    min_deposit: "$2,000",
+    status: "active",
+    updated_at: "2026-04-28T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeRobosBuilder(
+  rows: unknown[] = [],
+  error: unknown = null,
+  count = rows.length,
+) {
+  return {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    range: vi.fn(() => Promise.resolve({ data: rows, count, error })),
+  };
+}
+
+function makeGet(params: Record<string, string> = {}): NextRequest {
+  const sp = new URLSearchParams(params).toString();
+  const url = `http://localhost/api/v1/robo-advisors${sp ? `?${sp}` : ""}`;
+  return new NextRequest(url, {
+    headers: { Authorization: "Bearer ica_testkey123" },
+  });
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("OPTIONS /api/v1/robo-advisors", () => {
+  it("returns 204 with CORS headers", async () => {
+    const res = await OPTIONS();
+    expect(res.status).toBe(204);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+  });
+});
+
+describe("GET /api/v1/robo-advisors — auth", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 401 when API key missing", async () => {
+    mockValidateApiKey.mockResolvedValue(makeInvalidAuth("No API key"));
+    const res = await GET(makeGet());
+    expect(res.status).toBe(401);
+    const data = await res.json();
+    expect(data.error).toBe("No API key");
+  });
+
+  it("returns 401 when API key invalid", async () => {
+    mockValidateApiKey.mockResolvedValue(makeInvalidAuth());
+    const res = await GET(makeGet());
+    expect(res.status).toBe(401);
+  });
+
+  it("logs failed auth requests", async () => {
+    mockValidateApiKey.mockResolvedValue(makeInvalidAuth());
+    await GET(makeGet());
+    expect(mockLogApiRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        statusCode: 401,
+        endpoint: "/api/v1/robo-advisors",
+      }),
+    );
+  });
+});
+
+describe("GET /api/v1/robo-advisors — success", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockValidateApiKey.mockResolvedValue(makeValidAuth());
+  });
+
+  it("returns robo list with meta", async () => {
+    const robo = makeRobo();
+    mockServerFrom.mockReturnValue(makeRobosBuilder([robo], null, 1));
+
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].name).toBe("Stockspot");
+    expect(body.meta.total).toBe(1);
+    expect(body.meta.limit).toBe(20);
+    expect(body.meta.offset).toBe(0);
+  });
+
+  it("strips private fields", async () => {
+    const robo = {
+      ...makeRobo(),
+      affiliate_url: "https://secret.example.com",
+      commission_cents: 500,
+    };
+    mockServerFrom.mockReturnValue(makeRobosBuilder([robo], null, 1));
+
+    const res = await GET(makeGet());
+    const body = await res.json();
+    expect(body.data[0].affiliate_url).toBeUndefined();
+    expect(body.data[0].commission_cents).toBeUndefined();
+  });
+
+  it("respects limit query param (max 100)", async () => {
+    const builder = makeRobosBuilder([], null, 0);
+    mockServerFrom.mockReturnValue(builder);
+
+    await GET(makeGet({ limit: "5" }));
+    expect(builder.range).toHaveBeenCalledWith(0, 4);
+  });
+
+  it("clamps limit to 100 even if 200 requested", async () => {
+    const builder = makeRobosBuilder([], null, 0);
+    mockServerFrom.mockReturnValue(builder);
+
+    await GET(makeGet({ limit: "200" }));
+    expect(builder.range).toHaveBeenCalledWith(0, 99);
+  });
+
+  it("defaults limit to 20 when invalid", async () => {
+    const builder = makeRobosBuilder([], null, 0);
+    mockServerFrom.mockReturnValue(builder);
+
+    await GET(makeGet({ limit: "abc" }));
+    expect(builder.range).toHaveBeenCalledWith(0, 19);
+  });
+
+  it("respects offset query param", async () => {
+    const builder = makeRobosBuilder([], null, 100);
+    mockServerFrom.mockReturnValue(builder);
+
+    await GET(makeGet({ offset: "20" }));
+    expect(builder.range).toHaveBeenCalledWith(20, 39);
+  });
+
+  it("filters smsf_support=true", async () => {
+    const builder = makeRobosBuilder([], null, 0);
+    mockServerFrom.mockReturnValue(builder);
+
+    await GET(makeGet({ smsf_support: "true" }));
+    expect(builder.eq).toHaveBeenCalledWith("smsf_support", true);
+  });
+
+  it("filters smsf_support=false", async () => {
+    const builder = makeRobosBuilder([], null, 0);
+    mockServerFrom.mockReturnValue(builder);
+
+    await GET(makeGet({ smsf_support: "false" }));
+    expect(builder.eq).toHaveBeenCalledWith("smsf_support", false);
+  });
+
+  it("returns 500 on DB error", async () => {
+    const errorBuilder = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      range: vi.fn(() =>
+        Promise.resolve({
+          data: null,
+          count: null,
+          error: { message: "DB error" },
+        }),
+      ),
+    };
+    mockServerFrom.mockReturnValue(errorBuilder);
+
+    const res = await GET(makeGet());
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data.error).toMatch(/robo-advisor/i);
+  });
+
+  it("returns 500 on unexpected throw", async () => {
+    mockServerFrom.mockImplementation(() => {
+      throw new Error("boom");
+    });
+
+    const res = await GET(makeGet());
+    expect(res.status).toBe(500);
+  });
+
+  it("logs successful requests with apiKeyId", async () => {
+    mockServerFrom.mockReturnValue(makeRobosBuilder([makeRobo()], null, 1));
+
+    await GET(makeGet());
+    expect(mockLogApiRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ statusCode: 200, apiKeyId: "key-robo" }),
+    );
+  });
+
+  it("includes Cache-Control header on success", async () => {
+    mockServerFrom.mockReturnValue(makeRobosBuilder([], null, 0));
+
+    const res = await GET(makeGet());
+    expect(res.headers.get("Cache-Control")).toContain("max-age=3600");
+  });
+
+  it("computes meta.updated_at from most recent robo row", async () => {
+    const robos = [
+      makeRobo({ updated_at: "2026-01-01T00:00:00Z" }),
+      makeRobo({ name: "Raiz", slug: "raiz", updated_at: "2026-04-01T00:00:00Z" }),
+    ];
+    mockServerFrom.mockReturnValue(makeRobosBuilder(robos, null, 2));
+
+    const res = await GET(makeGet());
+    const body = await res.json();
+    expect(body.meta.updated_at).toBe("2026-04-01T00:00:00Z");
+  });
+});

--- a/__tests__/api/v1-savings-slug.test.ts
+++ b/__tests__/api/v1-savings-slug.test.ts
@@ -35,10 +35,6 @@ import { GET, OPTIONS } from "@/app/api/v1/savings/[slug]/route";
 
 const VALID_KEY = { id: "key-savings-slug", name: "Test", key_prefix: "ica_test" };
 
-function makeValidAuth() {
-  return { valid: true, apiKey: VALID_KEY };
-}
-
 function makeInvalidAuth(msg = "Invalid API key") {
   return { valid: false, error: msg };
 }

--- a/__tests__/api/v1-savings-slug.test.ts
+++ b/__tests__/api/v1-savings-slug.test.ts
@@ -1,0 +1,271 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const { mockServerFrom } = vi.hoisted(() => ({ mockServerFrom: vi.fn() }));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn().mockResolvedValue({ from: mockServerFrom }),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn() })),
+}));
+
+vi.mock("@/lib/html-escape", () => ({
+  escapeHtml: vi.fn((s: string) => s),
+}));
+
+const mockValidateApiKey = vi.fn();
+const mockLogApiRequest = vi.fn();
+vi.mock("@/lib/api-auth", () => ({
+  validateApiKey: (...args: unknown[]) => mockValidateApiKey(...args),
+  logApiRequest: (...args: unknown[]) => mockLogApiRequest(...args),
+  API_CORS_HEADERS: {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET, OPTIONS",
+    "Access-Control-Allow-Headers": "Authorization, Content-Type",
+  },
+}));
+
+import { GET, OPTIONS } from "@/app/api/v1/savings/[slug]/route";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+const VALID_KEY = { id: "key-savings-slug", name: "Test", key_prefix: "ica_test" };
+
+function makeValidAuth() {
+  return { valid: true, apiKey: VALID_KEY };
+}
+
+function makeInvalidAuth(msg = "Invalid API key") {
+  return { valid: false, error: msg };
+}
+
+function makePlatform(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 5,
+    name: "ING Savings Maximiser",
+    slug: "ing-savings-maximiser",
+    platform_type: "savings",
+    rating: 4.6,
+    review_content: "ING is a top savings pick.",
+    status: "active",
+    updated_at: "2026-05-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeRate(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "uuid-1",
+    broker_id: 5,
+    product_kind: "savings_account",
+    rate_bps: 550,
+    intro_rate_bps: null,
+    intro_term_months: null,
+    min_balance_cents: 0,
+    max_balance_cents: null,
+    term_months: null,
+    captured_at: "2026-05-20T02:00:00Z",
+    notes: "Requires monthly deposit",
+    ...overrides,
+  };
+}
+
+/**
+ * Makes a builder for single-row brokers query (.single() terminates the chain).
+ */
+function makeSinglePlatformBuilder(
+  row: unknown | null,
+  error: unknown = null,
+) {
+  return {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    in: vi.fn().mockReturnThis(),
+    single: vi.fn(() => Promise.resolve({ data: row, error })),
+  };
+}
+
+function makeRatesBuilder(rows: unknown[] = []) {
+  return {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    limit: vi.fn(() => Promise.resolve({ data: rows, error: null })),
+  };
+}
+
+function makeGet(
+  slug: string,
+  params: Record<string, string> = {},
+): { req: NextRequest; routeParams: Promise<{ slug: string }> } {
+  const sp = new URLSearchParams(params).toString();
+  const url = `http://localhost/api/v1/savings/${slug}${sp ? `?${sp}` : ""}`;
+  return {
+    req: new NextRequest(url, {
+      headers: { Authorization: "Bearer ica_testkey123" },
+    }),
+    routeParams: Promise.resolve({ slug }),
+  };
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("OPTIONS /api/v1/savings/[slug]", () => {
+  it("returns 204 with CORS headers", async () => {
+    const res = await OPTIONS();
+    expect(res.status).toBe(204);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+  });
+});
+
+describe("GET /api/v1/savings/[slug] — auth", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 401 when API key invalid", async () => {
+    mockValidateApiKey.mockResolvedValue(makeInvalidAuth());
+    const { req, routeParams } = makeGet("ing-savings-maximiser");
+    const res = await GET(req, { params: routeParams });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("GET /api/v1/savings/[slug] — validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockValidateApiKey.mockResolvedValue({ valid: true, apiKey: VALID_KEY });
+  });
+
+  it("returns 400 for invalid slug (capitals)", async () => {
+    const { req, routeParams } = makeGet("ING-SAVINGS");
+    const res = await GET(req, { params: routeParams });
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/slug/i);
+  });
+
+  it("returns 400 for empty slug", async () => {
+    const { req, routeParams } = makeGet("");
+    const res = await GET(req, { params: routeParams });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /api/v1/savings/[slug] — success", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockValidateApiKey.mockResolvedValue({ valid: true, apiKey: VALID_KEY });
+  });
+
+  it("returns platform data with rates_by_kind", async () => {
+    const platform = makePlatform();
+    const rate = makeRate();
+    mockServerFrom.mockImplementation((table: string) => {
+      if (table === "brokers") return makeSinglePlatformBuilder(platform);
+      if (table === "savings_rate_snapshots") return makeRatesBuilder([rate]);
+      throw new Error(`unexpected table: ${table}`);
+    });
+
+    const { req, routeParams } = makeGet("ing-savings-maximiser");
+    const res = await GET(req, { params: routeParams });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.name).toBe("ING Savings Maximiser");
+    expect(body.data.rates_by_kind).toBeDefined();
+    expect(body.data.rates_by_kind.savings_account).toHaveLength(1);
+    expect(body.data.rate_note).toBeTruthy();
+  });
+
+  it("returns 404 when platform not found", async () => {
+    mockServerFrom.mockImplementation((table: string) => {
+      if (table === "brokers")
+        return makeSinglePlatformBuilder(null, { message: "no rows" });
+      throw new Error(`unexpected table: ${table}`);
+    });
+
+    const { req, routeParams } = makeGet("nonexistent-slug");
+    const res = await GET(req, { params: routeParams });
+    expect(res.status).toBe(404);
+    const data = await res.json();
+    expect(data.error).toMatch(/not found/i);
+  });
+
+  it("groups rate history by product_kind", async () => {
+    const platform = makePlatform();
+    const savingsRate = makeRate({ product_kind: "savings_account" });
+    const tdRate = makeRate({ product_kind: "term_deposit", term_months: 12 });
+    mockServerFrom.mockImplementation((table: string) => {
+      if (table === "brokers") return makeSinglePlatformBuilder(platform);
+      if (table === "savings_rate_snapshots")
+        return makeRatesBuilder([savingsRate, tdRate]);
+      throw new Error(`unexpected table: ${table}`);
+    });
+
+    const { req, routeParams } = makeGet("ing-savings-maximiser");
+    const res = await GET(req, { params: routeParams });
+    const body = await res.json();
+    expect(body.data.rates_by_kind.savings_account).toHaveLength(1);
+    expect(body.data.rates_by_kind.term_deposit).toHaveLength(1);
+  });
+
+  it("strips private fields", async () => {
+    const platform = {
+      ...makePlatform(),
+      affiliate_url: "https://secret.example.com",
+      commission_cents: 1200,
+    };
+    mockServerFrom.mockImplementation((table: string) => {
+      if (table === "brokers") return makeSinglePlatformBuilder(platform);
+      if (table === "savings_rate_snapshots") return makeRatesBuilder([]);
+      throw new Error(`unexpected table: ${table}`);
+    });
+
+    const { req, routeParams } = makeGet("ing-savings-maximiser");
+    const res = await GET(req, { params: routeParams });
+    const body = await res.json();
+    expect(body.data.affiliate_url).toBeUndefined();
+    expect(body.data.commission_cents).toBeUndefined();
+  });
+
+  it("includes Cache-Control header on success", async () => {
+    mockServerFrom.mockImplementation((table: string) => {
+      if (table === "brokers") return makeSinglePlatformBuilder(makePlatform());
+      if (table === "savings_rate_snapshots") return makeRatesBuilder([]);
+      throw new Error(`unexpected table: ${table}`);
+    });
+
+    const { req, routeParams } = makeGet("ing-savings-maximiser");
+    const res = await GET(req, { params: routeParams });
+    expect(res.headers.get("Cache-Control")).toContain("max-age=3600");
+  });
+
+  it("returns 500 on unexpected throw", async () => {
+    mockServerFrom.mockImplementation(() => {
+      throw new Error("DB exploded");
+    });
+
+    const { req, routeParams } = makeGet("ing-savings-maximiser");
+    const res = await GET(req, { params: routeParams });
+    expect(res.status).toBe(500);
+  });
+
+  it("logs successful request with apiKeyId", async () => {
+    mockServerFrom.mockImplementation((table: string) => {
+      if (table === "brokers") return makeSinglePlatformBuilder(makePlatform());
+      if (table === "savings_rate_snapshots") return makeRatesBuilder([]);
+      throw new Error(`unexpected table: ${table}`);
+    });
+
+    const { req, routeParams } = makeGet("ing-savings-maximiser");
+    await GET(req, { params: routeParams });
+    expect(mockLogApiRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        statusCode: 200,
+        apiKeyId: "key-savings-slug",
+      }),
+    );
+  });
+});

--- a/__tests__/api/v1-savings.test.ts
+++ b/__tests__/api/v1-savings.test.ts
@@ -1,0 +1,393 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const { mockServerFrom } = vi.hoisted(() => ({ mockServerFrom: vi.fn() }));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn().mockResolvedValue({ from: mockServerFrom }),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn() })),
+}));
+
+vi.mock("@/lib/html-escape", () => ({
+  escapeHtml: vi.fn((s: string) => s),
+}));
+
+const mockValidateApiKey = vi.fn();
+const mockLogApiRequest = vi.fn();
+vi.mock("@/lib/api-auth", () => ({
+  validateApiKey: (...args: unknown[]) => mockValidateApiKey(...args),
+  logApiRequest: (...args: unknown[]) => mockLogApiRequest(...args),
+  API_CORS_HEADERS: {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET, OPTIONS",
+    "Access-Control-Allow-Headers": "Authorization, Content-Type",
+  },
+}));
+
+import { GET, OPTIONS } from "@/app/api/v1/savings/route";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+const VALID_KEY = { id: "key-savings", name: "Test", key_prefix: "ica_test" };
+
+function makeValidAuth() {
+  return { valid: true, apiKey: VALID_KEY };
+}
+
+function makeInvalidAuth(msg = "Invalid API key") {
+  return { valid: false, error: msg };
+}
+
+function makePlatform(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 5,
+    name: "ING Savings Maximiser",
+    slug: "ing-savings-maximiser",
+    platform_type: "savings",
+    rating: 4.6,
+    status: "active",
+    updated_at: "2026-05-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeRate(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "uuid-1",
+    broker_id: 5,
+    product_kind: "savings_account",
+    rate_bps: 550,
+    intro_rate_bps: null,
+    intro_term_months: null,
+    min_balance_cents: 0,
+    max_balance_cents: null,
+    term_months: null,
+    captured_at: "2026-05-20T02:00:00Z",
+    notes: "Requires monthly deposit",
+    ...overrides,
+  };
+}
+
+/**
+ * Makes a chainable builder for the brokers table query.
+ * Ends with .range() returning a promise.
+ */
+function makePlatformsBuilder(
+  rows: unknown[] = [],
+  error: unknown = null,
+  count = rows.length,
+) {
+  const builder = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    in: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    range: vi.fn(() => Promise.resolve({ data: rows, count, error })),
+  };
+  return builder;
+}
+
+/**
+ * Makes a builder for the savings_rate_snapshots table query.
+ *
+ * The route calls:
+ *   .select(...).in(...).order(...)  — terminal when no product_kind filter
+ *   .select(...).in(...).order(...).eq(...)  — terminal when product_kind filter set
+ *
+ * Both order() and eq() need to resolve as Promises (awaited directly on the
+ * query builder), while also being chainable when eq() is appended after order().
+ */
+function makeRatesBuilder(rows: unknown[] = [], error: unknown = null) {
+  const resolved = Promise.resolve({ data: rows, error });
+  // A thenable object: calling .then() on it behaves like a resolved promise,
+  // but it also exposes .eq() for the chained-filter case.
+  const thenableResult = {
+    then: resolved.then.bind(resolved),
+    catch: resolved.catch.bind(resolved),
+    finally: resolved.finally.bind(resolved),
+    eq: vi.fn(() => Promise.resolve({ data: rows, error })),
+  };
+  return {
+    select: vi.fn().mockReturnThis(),
+    in: vi.fn().mockReturnThis(),
+    order: vi.fn(() => thenableResult),
+    // Expose thenableResult so tests can spy on .eq
+    _thenableResult: thenableResult,
+  };
+}
+
+function makeGet(params: Record<string, string> = {}): NextRequest {
+  const sp = new URLSearchParams(params).toString();
+  const url = `http://localhost/api/v1/savings${sp ? `?${sp}` : ""}`;
+  return new NextRequest(url, {
+    headers: { Authorization: "Bearer ica_testkey123" },
+  });
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("OPTIONS /api/v1/savings", () => {
+  it("returns 204 with CORS headers", async () => {
+    const res = await OPTIONS();
+    expect(res.status).toBe(204);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+  });
+});
+
+describe("GET /api/v1/savings — auth", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 401 when API key missing", async () => {
+    mockValidateApiKey.mockResolvedValue(makeInvalidAuth("No API key"));
+    const res = await GET(makeGet());
+    expect(res.status).toBe(401);
+    const data = await res.json();
+    expect(data.error).toBe("No API key");
+  });
+
+  it("returns 401 when API key invalid", async () => {
+    mockValidateApiKey.mockResolvedValue(makeInvalidAuth());
+    const res = await GET(makeGet());
+    expect(res.status).toBe(401);
+  });
+
+  it("logs failed auth requests", async () => {
+    mockValidateApiKey.mockResolvedValue(makeInvalidAuth());
+    await GET(makeGet());
+    expect(mockLogApiRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ statusCode: 401, endpoint: "/api/v1/savings" }),
+    );
+  });
+});
+
+describe("GET /api/v1/savings — success", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockValidateApiKey.mockResolvedValue(makeValidAuth());
+  });
+
+  it("returns platform list with rates and meta", async () => {
+    const platform = makePlatform();
+    const rate = makeRate();
+    mockServerFrom.mockImplementation((table: string) => {
+      if (table === "brokers") return makePlatformsBuilder([platform], null, 1);
+      if (table === "savings_rate_snapshots") return makeRatesBuilder([rate]);
+      throw new Error(`unexpected table: ${table}`);
+    });
+
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].name).toBe("ING Savings Maximiser");
+    expect(body.data[0].latest_rates).toHaveLength(1);
+    expect(body.data[0].latest_rates[0].rate_bps).toBe(550);
+    expect(body.meta.total).toBe(1);
+    expect(body.meta.limit).toBe(20);
+    expect(body.meta.offset).toBe(0);
+    expect(body.meta.rate_note).toBeTruthy();
+  });
+
+  it("strips private fields (e.g. affiliate_url)", async () => {
+    const platform = {
+      ...makePlatform(),
+      affiliate_url: "https://secret.example.com",
+      commission_cents: 1200,
+    };
+    mockServerFrom.mockImplementation((table: string) => {
+      if (table === "brokers") return makePlatformsBuilder([platform], null, 1);
+      if (table === "savings_rate_snapshots") return makeRatesBuilder([]);
+      throw new Error(`unexpected table: ${table}`);
+    });
+
+    const res = await GET(makeGet());
+    const body = await res.json();
+    expect(body.data[0].affiliate_url).toBeUndefined();
+    expect(body.data[0].commission_cents).toBeUndefined();
+  });
+
+  it("respects limit query param", async () => {
+    const platformsBuilder = makePlatformsBuilder([], null, 0);
+    mockServerFrom.mockImplementation((table: string) => {
+      if (table === "brokers") return platformsBuilder;
+      if (table === "savings_rate_snapshots") return makeRatesBuilder([]);
+      throw new Error(`unexpected table: ${table}`);
+    });
+
+    await GET(makeGet({ limit: "5" }));
+    expect(platformsBuilder.range).toHaveBeenCalledWith(0, 4);
+  });
+
+  it("clamps limit to 100 even if 200 requested", async () => {
+    const platformsBuilder = makePlatformsBuilder([], null, 0);
+    mockServerFrom.mockImplementation((table: string) => {
+      if (table === "brokers") return platformsBuilder;
+      if (table === "savings_rate_snapshots") return makeRatesBuilder([]);
+      throw new Error(`unexpected table: ${table}`);
+    });
+
+    await GET(makeGet({ limit: "200" }));
+    expect(platformsBuilder.range).toHaveBeenCalledWith(0, 99);
+  });
+
+  it("defaults limit to 20 when invalid", async () => {
+    const platformsBuilder = makePlatformsBuilder([], null, 0);
+    mockServerFrom.mockImplementation((table: string) => {
+      if (table === "brokers") return platformsBuilder;
+      if (table === "savings_rate_snapshots") return makeRatesBuilder([]);
+      throw new Error(`unexpected table: ${table}`);
+    });
+
+    await GET(makeGet({ limit: "abc" }));
+    expect(platformsBuilder.range).toHaveBeenCalledWith(0, 19);
+  });
+
+  it("respects offset query param", async () => {
+    const platformsBuilder = makePlatformsBuilder([], null, 100);
+    mockServerFrom.mockImplementation((table: string) => {
+      if (table === "brokers") return platformsBuilder;
+      if (table === "savings_rate_snapshots") return makeRatesBuilder([]);
+      throw new Error(`unexpected table: ${table}`);
+    });
+
+    await GET(makeGet({ offset: "20" }));
+    expect(platformsBuilder.range).toHaveBeenCalledWith(20, 39);
+  });
+
+  it("filters rates by product_kind when specified", async () => {
+    const platform = makePlatform();
+    const ratesBuilder = makeRatesBuilder([]);
+    mockServerFrom.mockImplementation((table: string) => {
+      if (table === "brokers") return makePlatformsBuilder([platform], null, 1);
+      if (table === "savings_rate_snapshots") return ratesBuilder;
+      throw new Error(`unexpected table: ${table}`);
+    });
+
+    await GET(makeGet({ product_kind: "savings_account" }));
+    // The eq() is called on the thenable returned by order()
+    expect(ratesBuilder._thenableResult.eq).toHaveBeenCalledWith(
+      "product_kind",
+      "savings_account",
+    );
+  });
+
+  it("excludes platforms with no matching rates when product_kind filter is set", async () => {
+    const platform = makePlatform();
+    // No rates returned for this kind
+    const ratesBuilder = makeRatesBuilder([]);
+    mockServerFrom.mockImplementation((table: string) => {
+      if (table === "brokers") return makePlatformsBuilder([platform], null, 1);
+      if (table === "savings_rate_snapshots") return ratesBuilder;
+      throw new Error(`unexpected table: ${table}`);
+    });
+
+    const res = await GET(makeGet({ product_kind: "term_deposit" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // Platform has no term_deposit rates → filtered out
+    expect(body.data).toHaveLength(0);
+  });
+
+  it("includes platform when product_kind filter matches", async () => {
+    const platform = makePlatform();
+    const rate = makeRate({ product_kind: "term_deposit" });
+    // Override the eq() mock to return the rate
+    const ratesBuilder = makeRatesBuilder([rate]);
+    // Make the .eq() on the thenable return the rate
+    ratesBuilder._thenableResult.eq.mockResolvedValue({
+      data: [rate],
+      error: null,
+    });
+    mockServerFrom.mockImplementation((table: string) => {
+      if (table === "brokers") return makePlatformsBuilder([platform], null, 1);
+      if (table === "savings_rate_snapshots") return ratesBuilder;
+      throw new Error(`unexpected table: ${table}`);
+    });
+
+    const res = await GET(makeGet({ product_kind: "term_deposit" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toHaveLength(1);
+  });
+
+  it("returns 500 on DB error fetching platforms", async () => {
+    const errorBuilder = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      in: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      range: vi.fn(() =>
+        Promise.resolve({
+          data: null,
+          count: null,
+          error: { message: "DB error" },
+        }),
+      ),
+    };
+    mockServerFrom.mockImplementation((table: string) => {
+      if (table === "brokers") return errorBuilder;
+      if (table === "savings_rate_snapshots") return makeRatesBuilder([]);
+      throw new Error(`unexpected table: ${table}`);
+    });
+
+    const res = await GET(makeGet());
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data.error).toMatch(/savings/i);
+  });
+
+  it("returns 500 on unexpected throw", async () => {
+    mockServerFrom.mockImplementation(() => {
+      throw new Error("boom");
+    });
+
+    const res = await GET(makeGet());
+    expect(res.status).toBe(500);
+  });
+
+  it("logs successful requests with apiKeyId", async () => {
+    mockServerFrom.mockImplementation((table: string) => {
+      if (table === "brokers") return makePlatformsBuilder([makePlatform()], null, 1);
+      if (table === "savings_rate_snapshots") return makeRatesBuilder([]);
+      throw new Error(`unexpected table: ${table}`);
+    });
+
+    await GET(makeGet());
+    expect(mockLogApiRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ statusCode: 200, apiKeyId: "key-savings" }),
+    );
+  });
+
+  it("includes Cache-Control header on success", async () => {
+    mockServerFrom.mockImplementation((table: string) => {
+      if (table === "brokers") return makePlatformsBuilder([], null, 0);
+      if (table === "savings_rate_snapshots") return makeRatesBuilder([]);
+      throw new Error(`unexpected table: ${table}`);
+    });
+
+    const res = await GET(makeGet());
+    expect(res.headers.get("Cache-Control")).toContain("max-age=3600");
+  });
+
+  it("deduplicates rates per (broker_id, product_kind)", async () => {
+    const platform = makePlatform();
+    // Two rows with same broker_id + product_kind — only first should appear
+    const rate1 = makeRate({ id: "uuid-1", captured_at: "2026-05-20T00:00:00Z" });
+    const rate2 = makeRate({ id: "uuid-2", captured_at: "2026-05-19T00:00:00Z" });
+    mockServerFrom.mockImplementation((table: string) => {
+      if (table === "brokers") return makePlatformsBuilder([platform], null, 1);
+      if (table === "savings_rate_snapshots")
+        return makeRatesBuilder([rate1, rate2]);
+      throw new Error(`unexpected table: ${table}`);
+    });
+
+    const res = await GET(makeGet());
+    const body = await res.json();
+    expect(body.data[0].latest_rates).toHaveLength(1);
+  });
+});

--- a/app/api-docs/page.tsx
+++ b/app/api-docs/page.tsx
@@ -445,6 +445,206 @@ export default function ApiDocsPage() {
                 </div>
               </EndpointCard>
 
+              {/* Savings */}
+              <EndpointCard
+                method="GET"
+                path="/api/v1/savings"
+                auth={true}
+                description="List savings account and term deposit platforms with the latest rate snapshot for each. Rate fields use basis points (bps): 525 bps = 5.25% p.a. Includes government-guaranteed ADI data."
+              >
+                <div>
+                  <h4 className="text-xs font-semibold uppercase text-slate-400 mb-2">
+                    Query Parameters
+                  </h4>
+                  <div className="text-sm space-y-1 text-slate-600">
+                    <p>
+                      <code className="text-xs bg-slate-100 px-1 py-0.5 rounded">
+                        product_kind
+                      </code>{" "}
+                      &mdash; savings_account | term_deposit
+                    </p>
+                    <p>
+                      <code className="text-xs bg-slate-100 px-1 py-0.5 rounded">
+                        limit
+                      </code>{" "}
+                      &mdash; Results per page (default 20, max 100)
+                    </p>
+                    <p>
+                      <code className="text-xs bg-slate-100 px-1 py-0.5 rounded">
+                        offset
+                      </code>{" "}
+                      &mdash; Pagination offset (default 0)
+                    </p>
+                  </div>
+                </div>
+              </EndpointCard>
+
+              {/* Single Savings Platform */}
+              <EndpointCard
+                method="GET"
+                path="/api/v1/savings/:slug"
+                auth={true}
+                description="Get a single savings platform's full public profile by slug. Includes all current rate snapshots and rate history (last 30 per product_kind)."
+              >
+                <div>
+                  <h4 className="text-xs font-semibold uppercase text-slate-400 mb-2">
+                    Path Parameters
+                  </h4>
+                  <p className="text-sm text-slate-600">
+                    <code className="text-xs bg-slate-100 px-1 py-0.5 rounded">
+                      slug
+                    </code>{" "}
+                    &mdash; The platform&apos;s URL slug (e.g.
+                    &quot;ing-savings-maximiser&quot;)
+                  </p>
+                </div>
+              </EndpointCard>
+
+              {/* Robo-Advisors */}
+              <EndpointCard
+                method="GET"
+                path="/api/v1/robo-advisors"
+                auth={true}
+                description="List active robo-advisor platforms (Stockspot, InvestSMART, Raiz, Spaceship, Six Park, etc.). Automated investment services backed by ASIC-regulated platforms."
+              >
+                <div>
+                  <h4 className="text-xs font-semibold uppercase text-slate-400 mb-2">
+                    Query Parameters
+                  </h4>
+                  <div className="text-sm space-y-1 text-slate-600">
+                    <p>
+                      <code className="text-xs bg-slate-100 px-1 py-0.5 rounded">
+                        smsf_support
+                      </code>{" "}
+                      &mdash; true / false
+                    </p>
+                    <p>
+                      <code className="text-xs bg-slate-100 px-1 py-0.5 rounded">
+                        limit
+                      </code>{" "}
+                      &mdash; Results per page (default 20, max 100)
+                    </p>
+                    <p>
+                      <code className="text-xs bg-slate-100 px-1 py-0.5 rounded">
+                        offset
+                      </code>{" "}
+                      &mdash; Pagination offset (default 0)
+                    </p>
+                  </div>
+                </div>
+              </EndpointCard>
+
+              {/* Single Robo-Advisor */}
+              <EndpointCard
+                method="GET"
+                path="/api/v1/robo-advisors/:slug"
+                auth={true}
+                description="Get a single robo-advisor's full public profile by slug. Includes fee changelog (last 10 changes)."
+              >
+                <div>
+                  <h4 className="text-xs font-semibold uppercase text-slate-400 mb-2">
+                    Path Parameters
+                  </h4>
+                  <p className="text-sm text-slate-600">
+                    <code className="text-xs bg-slate-100 px-1 py-0.5 rounded">
+                      slug
+                    </code>{" "}
+                    &mdash; The robo-advisor&apos;s URL slug (e.g.
+                    &quot;stockspot&quot;, &quot;raiz&quot;)
+                  </p>
+                </div>
+              </EndpointCard>
+
+              {/* Health Scores */}
+              <EndpointCard
+                method="GET"
+                path="/api/v1/health-scores"
+                auth={true}
+                description="Current broker health scores across five dimensions: regulatory, financial stability, client money, insurance, and platform reliability. Scores 0–100. Informational data — not financial advice."
+              >
+                <div>
+                  <h4 className="text-xs font-semibold uppercase text-slate-400 mb-2">
+                    Query Parameters
+                  </h4>
+                  <div className="text-sm space-y-1 text-slate-600">
+                    <p>
+                      <code className="text-xs bg-slate-100 px-1 py-0.5 rounded">
+                        broker_slug
+                      </code>{" "}
+                      &mdash; Filter to a specific broker by slug
+                    </p>
+                    <p>
+                      <code className="text-xs bg-slate-100 px-1 py-0.5 rounded">
+                        min_score
+                      </code>{" "}
+                      &mdash; Only return brokers with overall_score &ge; this
+                      value
+                    </p>
+                    <p>
+                      <code className="text-xs bg-slate-100 px-1 py-0.5 rounded">
+                        limit
+                      </code>{" "}
+                      &mdash; Results per page (default 20, max 100)
+                    </p>
+                    <p>
+                      <code className="text-xs bg-slate-100 px-1 py-0.5 rounded">
+                        offset
+                      </code>{" "}
+                      &mdash; Pagination offset (default 0)
+                    </p>
+                  </div>
+                </div>
+              </EndpointCard>
+
+              {/* Health Score History */}
+              <EndpointCard
+                method="GET"
+                path="/api/v1/health-scores/history"
+                auth={true}
+                description="Time-series history of broker health scores (append-only snapshot table, populated by cron). broker_slug is required. Returns scores DESC by captured_at."
+              >
+                <div>
+                  <h4 className="text-xs font-semibold uppercase text-slate-400 mb-2">
+                    Query Parameters
+                  </h4>
+                  <div className="text-sm space-y-1 text-slate-600">
+                    <p>
+                      <code className="text-xs bg-slate-100 px-1 py-0.5 rounded">
+                        broker_slug
+                      </code>{" "}
+                      <span className="text-red-500 text-xs">required</span>{" "}
+                      &mdash; Broker slug (e.g. &quot;stake&quot;)
+                    </p>
+                    <p>
+                      <code className="text-xs bg-slate-100 px-1 py-0.5 rounded">
+                        days
+                      </code>{" "}
+                      &mdash; Days of history (default 90, max 400)
+                    </p>
+                    <p>
+                      <code className="text-xs bg-slate-100 px-1 py-0.5 rounded">
+                        limit
+                      </code>{" "}
+                      &mdash; Max rows (default 100, max 400)
+                    </p>
+                    <p>
+                      <code className="text-xs bg-slate-100 px-1 py-0.5 rounded">
+                        offset
+                      </code>{" "}
+                      &mdash; Pagination offset (default 0)
+                    </p>
+                  </div>
+                </div>
+              </EndpointCard>
+
+              {/* OpenAPI */}
+              <EndpointCard
+                method="GET"
+                path="/api/v1/openapi.json"
+                auth={false}
+                description="Returns a valid OpenAPI 3.1 specification describing every v1 endpoint, parameters, schemas, and security requirements. Suitable for client SDK generation via openapi-generator or similar tools."
+              />
+
               {/* Request API Key */}
               <EndpointCard
                 method="POST"

--- a/app/api/v1/docs/route.ts
+++ b/app/api/v1/docs/route.ts
@@ -18,6 +18,8 @@ export function OPTIONS() {
  *
  * Public API documentation endpoint. No authentication required.
  * Returns a JSON description of all available endpoints.
+ *
+ * For a machine-readable OpenAPI 3.1 specification, see GET /api/v1/openapi.json.
  */
 export function GET() {
   const docs = {
@@ -383,6 +385,279 @@ export function GET() {
             history_days: 30,
           },
         },
+      },
+      {
+        path: "/api/v1/savings",
+        method: "GET",
+        auth_required: true,
+        description:
+          "List savings account and term deposit platforms with the latest rate snapshot for each. Rate fields use basis points (bps): 525 bps = 5.25% p.a.",
+        parameters: [
+          {
+            name: "product_kind",
+            type: "string",
+            required: false,
+            description: "Filter by kind: savings_account | term_deposit",
+          },
+          {
+            name: "limit",
+            type: "integer",
+            required: false,
+            description: "Results per page (default: 20, max: 100)",
+          },
+          {
+            name: "offset",
+            type: "integer",
+            required: false,
+            description: "Pagination offset (default: 0)",
+          },
+        ],
+        example_request: "GET /api/v1/savings?product_kind=savings_account&limit=10",
+        example_response: {
+          data: [
+            {
+              id: 5,
+              name: "ING Savings Maximiser",
+              slug: "ing-savings-maximiser",
+              platform_type: "savings",
+              rating: 4.6,
+              latest_rates: [
+                {
+                  product_kind: "savings_account",
+                  rate_bps: 550,
+                  intro_rate_bps: null,
+                  min_balance_cents: 0,
+                  captured_at: "2026-05-24T02:00:00Z",
+                  notes: "Requires $1,000+ deposit per month to earn bonus rate",
+                },
+              ],
+            },
+          ],
+          meta: {
+            total: 8,
+            limit: 10,
+            offset: 0,
+            updated_at: "2026-05-24T02:00:00Z",
+            rate_note: "rate_bps: integer basis points — 525 bps = 5.25% p.a. Intro rates are time-limited bonus rates.",
+          },
+        },
+      },
+      {
+        path: "/api/v1/savings/:slug",
+        method: "GET",
+        auth_required: true,
+        description:
+          "Get a single savings platform's full public profile by slug. Includes all current rate snapshots and rate history (last 30 per product_kind).",
+        parameters: [
+          {
+            name: "slug",
+            type: "string",
+            required: true,
+            in: "path",
+            description: "The platform's URL slug (e.g. 'ing-savings-maximiser')",
+          },
+        ],
+        example_request: "GET /api/v1/savings/ing-savings-maximiser",
+        example_response: {
+          data: {
+            id: 5,
+            name: "ING Savings Maximiser",
+            slug: "ing-savings-maximiser",
+            rates_by_kind: {
+              savings_account: [
+                {
+                  rate_bps: 550,
+                  captured_at: "2026-05-24T02:00:00Z",
+                  notes: "Requires $1,000+ deposit per month",
+                },
+              ],
+            },
+          },
+        },
+      },
+      {
+        path: "/api/v1/robo-advisors",
+        method: "GET",
+        auth_required: true,
+        description:
+          "List active robo-advisor platforms (Stockspot, InvestSMART, Raiz, Spaceship, Six Park, etc.). Returns public profile data.",
+        parameters: [
+          {
+            name: "smsf_support",
+            type: "boolean",
+            required: false,
+            description: "Filter by SMSF support (true/false)",
+          },
+          {
+            name: "limit",
+            type: "integer",
+            required: false,
+            description: "Results per page (default: 20, max: 100)",
+          },
+          {
+            name: "offset",
+            type: "integer",
+            required: false,
+            description: "Pagination offset (default: 0)",
+          },
+        ],
+        example_request: "GET /api/v1/robo-advisors?limit=10",
+        example_response: {
+          data: [
+            {
+              id: 20,
+              name: "Stockspot",
+              slug: "stockspot",
+              platform_type: "robo_advisor",
+              rating: 4.7,
+              min_deposit: "$2,000",
+              regulated_by: "ASIC",
+            },
+          ],
+          meta: { total: 8, limit: 10, offset: 0, updated_at: "2026-05-24T00:00:00Z" },
+        },
+      },
+      {
+        path: "/api/v1/robo-advisors/:slug",
+        method: "GET",
+        auth_required: true,
+        description:
+          "Get a single robo-advisor's full public profile by slug. Includes fee changelog (last 10 changes).",
+        parameters: [
+          {
+            name: "slug",
+            type: "string",
+            required: true,
+            in: "path",
+            description: "The robo-advisor's URL slug (e.g. 'stockspot')",
+          },
+        ],
+        example_request: "GET /api/v1/robo-advisors/stockspot",
+        example_response: {
+          data: {
+            id: 20,
+            name: "Stockspot",
+            slug: "stockspot",
+            platform_type: "robo_advisor",
+            rating: 4.7,
+            fee_changelog: [],
+          },
+        },
+      },
+      {
+        path: "/api/v1/health-scores",
+        method: "GET",
+        auth_required: true,
+        description:
+          "Current broker health scores across five dimensions: regulatory, financial stability, client money, insurance, platform reliability. Scores are 0–100. Informational data — not financial advice.",
+        parameters: [
+          {
+            name: "broker_slug",
+            type: "string",
+            required: false,
+            description: "Filter to a specific broker by slug",
+          },
+          {
+            name: "min_score",
+            type: "number",
+            required: false,
+            description: "Only return brokers with overall_score >= this value",
+          },
+          {
+            name: "limit",
+            type: "integer",
+            required: false,
+            description: "Results per page (default: 20, max: 100)",
+          },
+          {
+            name: "offset",
+            type: "integer",
+            required: false,
+            description: "Pagination offset (default: 0)",
+          },
+        ],
+        example_request: "GET /api/v1/health-scores?min_score=70",
+        example_response: {
+          data: [
+            {
+              broker_slug: "stake",
+              overall_score: 82.5,
+              regulatory_score: 90,
+              financial_stability_score: 78,
+              client_money_score: 85,
+              insurance_score: 80,
+              platform_reliability_score: 79,
+              last_reviewed_at: "2026-05-01T00:00:00Z",
+            },
+          ],
+          meta: {
+            total: 15,
+            limit: 20,
+            offset: 0,
+            updated_at: "2026-05-01T00:00:00Z",
+            disclaimer: "Health scores are informational only. Not financial advice.",
+          },
+        },
+      },
+      {
+        path: "/api/v1/health-scores/history",
+        method: "GET",
+        auth_required: true,
+        description:
+          "Time-series history of broker health scores from broker_health_score_history (populated by snapshot cron). broker_slug is required. Returns scores DESC by captured_at.",
+        parameters: [
+          {
+            name: "broker_slug",
+            type: "string",
+            required: true,
+            description: "Broker slug (e.g. 'stake'). Required.",
+          },
+          {
+            name: "days",
+            type: "integer",
+            required: false,
+            description: "Days of history (default: 90, max: 400)",
+          },
+          {
+            name: "limit",
+            type: "integer",
+            required: false,
+            description: "Max rows (default: 100, max: 400)",
+          },
+          {
+            name: "offset",
+            type: "integer",
+            required: false,
+            description: "Pagination offset (default: 0)",
+          },
+        ],
+        example_request: "GET /api/v1/health-scores/history?broker_slug=stake&days=30",
+        example_response: {
+          data: [
+            {
+              broker_slug: "stake",
+              overall_score: 82.5,
+              regulatory_score: 90,
+              captured_at: "2026-05-24T02:00:00Z",
+            },
+          ],
+          meta: {
+            broker_slug: "stake",
+            total: 30,
+            limit: 100,
+            offset: 0,
+            days: 30,
+            updated_at: "2026-05-24T02:00:00Z",
+          },
+        },
+      },
+      {
+        path: "/api/v1/openapi.json",
+        method: "GET",
+        auth_required: false,
+        description:
+          "Returns a valid OpenAPI 3.1 specification describing every v1 endpoint, parameters, schemas, and security. Suitable for client SDK generation. Generated from lib/openapi-spec.ts.",
+        example_request: "GET /api/v1/openapi.json",
       },
       {
         path: "/api/v1/docs",

--- a/app/api/v1/health-scores/history/route.ts
+++ b/app/api/v1/health-scores/history/route.ts
@@ -1,0 +1,226 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { logger } from "@/lib/logger";
+import { validateApiKey, logApiRequest, API_CORS_HEADERS } from "@/lib/api-auth";
+import { escapeHtml } from "@/lib/html-escape";
+
+export const runtime = "nodejs";
+// Per-key auth gating — see /api/v1/brokers/route.ts for the same reasoning.
+export const dynamic = "force-dynamic";
+
+const log = logger("api-v1-health-scores-history");
+
+/**
+ * Public fields from broker_health_score_history.
+ * Append-only snapshot table — each row is a historical point-in-time record.
+ */
+const PUBLIC_FIELDS = [
+  "broker_slug",
+  "overall_score",
+  "regulatory_score",
+  "client_money_score",
+  "financial_stability_score",
+  "platform_reliability_score",
+  "insurance_score",
+  "captured_at",
+] as const;
+
+/**
+ * Sanitize a history row.
+ */
+function sanitizeHistory(
+  row: Record<string, unknown>,
+): Record<string, unknown> {
+  const clean: Record<string, unknown> = {};
+  for (const field of PUBLIC_FIELDS) {
+    if (field in row) {
+      const val = row[field];
+      clean[field] = typeof val === "string" ? escapeHtml(val) : val;
+    }
+  }
+  return clean;
+}
+
+/**
+ * OPTIONS /api/v1/health-scores/history — CORS preflight
+ */
+export function OPTIONS() {
+  return new NextResponse(null, {
+    status: 204,
+    headers: API_CORS_HEADERS,
+  });
+}
+
+/**
+ * GET /api/v1/health-scores/history
+ *
+ * Returns the time-series history of broker health scores from
+ * broker_health_score_history. This append-only table is populated by the
+ * /api/cron/snapshot-health-scores cron job.
+ *
+ * Scores are numeric 0–100. This is factual/informational data — not financial
+ * advice or a recommendation to use or avoid any broker.
+ *
+ * Query params:
+ *   ?broker_slug=stake    — required: filter to a specific broker's history
+ *   ?days=90              — how many days of history to return (default 90, max 400)
+ *   ?limit=100            — max rows (default 100, max 400)
+ *   ?offset=0             — pagination offset
+ *
+ * Response: { data: HealthScoreHistory[], meta: { broker_slug, total, limit, offset, updated_at } }
+ */
+export async function GET(request: NextRequest) {
+  const start = Date.now();
+
+  // ── Auth ──
+  const auth = await validateApiKey(request);
+  if (!auth.valid) {
+    const elapsed = Date.now() - start;
+    logApiRequest({
+      apiKeyId: null,
+      endpoint: "/api/v1/health-scores/history",
+      method: "GET",
+      statusCode: 401,
+      responseTimeMs: elapsed,
+      ipAddress:
+        request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+        "unknown",
+      userAgent: request.headers.get("user-agent") || "unknown",
+    });
+    return NextResponse.json(
+      { error: auth.error },
+      { status: 401, headers: API_CORS_HEADERS },
+    );
+  }
+
+  try {
+    const params = request.nextUrl.searchParams;
+
+    // broker_slug is required — without it the response would be enormous
+    const brokerSlug = params.get("broker_slug");
+    if (!brokerSlug || !/^[a-z0-9-]+$/.test(brokerSlug)) {
+      return NextResponse.json(
+        {
+          error:
+            "broker_slug query parameter is required (e.g. ?broker_slug=stake)",
+        },
+        { status: 400, headers: API_CORS_HEADERS },
+      );
+    }
+
+    // Parse days param (controls the captured_at cutoff)
+    let days = parseInt(params.get("days") || "90", 10);
+    if (!Number.isFinite(days) || days < 1) days = 90;
+    if (days > 400) days = 400;
+
+    // Parse pagination
+    let limit = Math.min(parseInt(params.get("limit") || "100", 10) || 100, 400);
+    if (limit < 1) limit = 100;
+    let offset = parseInt(params.get("offset") || "0", 10) || 0;
+    if (offset < 0) offset = 0;
+
+    const supabase = await createClient();
+
+    // Compute the cutoff timestamp
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - days);
+
+    // broker_health_score_history has anon SELECT policy — createClient suffices.
+    const { data: history, count, error } = await supabase
+      .from("broker_health_score_history")
+      .select(PUBLIC_FIELDS.join(","), { count: "exact" })
+      .eq("broker_slug", brokerSlug)
+      .gte("captured_at", cutoff.toISOString())
+      .order("captured_at", { ascending: false })
+      .range(offset, offset + limit - 1);
+
+    if (error) {
+      log.error("Failed to fetch health score history", {
+        error: error.message,
+      });
+      const elapsed = Date.now() - start;
+      logApiRequest({
+        apiKeyId: auth.apiKey?.id || null,
+        endpoint: "/api/v1/health-scores/history",
+        method: "GET",
+        statusCode: 500,
+        responseTimeMs: elapsed,
+        ipAddress:
+          request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+          "unknown",
+        userAgent: request.headers.get("user-agent") || "unknown",
+      });
+      return NextResponse.json(
+        { error: "Failed to fetch health score history" },
+        { status: 500, headers: API_CORS_HEADERS },
+      );
+    }
+
+    const sanitized = (history || []).map((h) =>
+      sanitizeHistory(h as unknown as Record<string, unknown>),
+    );
+
+    const latestCapture =
+      sanitized.length > 0
+        ? (sanitized[0]?.captured_at as string)
+        : null;
+
+    const elapsed = Date.now() - start;
+
+    logApiRequest({
+      apiKeyId: auth.apiKey?.id || null,
+      endpoint: "/api/v1/health-scores/history",
+      method: "GET",
+      statusCode: 200,
+      responseTimeMs: elapsed,
+      ipAddress:
+        request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+        "unknown",
+      userAgent: request.headers.get("user-agent") || "unknown",
+    });
+
+    return NextResponse.json(
+      {
+        data: sanitized,
+        meta: {
+          broker_slug: brokerSlug,
+          total: count ?? sanitized.length,
+          limit,
+          offset,
+          days,
+          updated_at: latestCapture ?? new Date().toISOString(),
+          disclaimer:
+            "Health score history is informational only. It reflects publicly available regulatory and operational data. This is not financial advice.",
+        },
+      },
+      {
+        status: 200,
+        headers: {
+          ...API_CORS_HEADERS,
+          "Cache-Control": "private, max-age=3600",
+        },
+      },
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "Unknown error";
+    log.error("Unexpected error in GET /api/v1/health-scores/history", {
+      error: msg,
+    });
+    const elapsed = Date.now() - start;
+    logApiRequest({
+      apiKeyId: auth.apiKey?.id || null,
+      endpoint: "/api/v1/health-scores/history",
+      method: "GET",
+      statusCode: 500,
+      responseTimeMs: elapsed,
+      ipAddress:
+        request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+        "unknown",
+      userAgent: request.headers.get("user-agent") || "unknown",
+    });
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500, headers: API_CORS_HEADERS },
+    );
+  }
+}

--- a/app/api/v1/health-scores/route.ts
+++ b/app/api/v1/health-scores/route.ts
@@ -1,0 +1,224 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { logger } from "@/lib/logger";
+import { validateApiKey, logApiRequest, API_CORS_HEADERS } from "@/lib/api-auth";
+import { escapeHtml } from "@/lib/html-escape";
+
+export const runtime = "nodejs";
+// Per-key auth gating — see /api/v1/brokers/route.ts for the same reasoning.
+export const dynamic = "force-dynamic";
+
+const log = logger("api-v1-health-scores");
+
+/**
+ * Public fields from broker_health_scores.
+ * Excludes: id (internal), created_at (non-informative for consumers).
+ * The notes fields are factual regulatory/operational data — safe to expose
+ * under the existing general-advice AFSL since this is informational only.
+ */
+const PUBLIC_FIELDS = [
+  "broker_slug",
+  "afsl_number",
+  "afsl_status",
+  "overall_score",
+  "regulatory_score",
+  "regulatory_notes",
+  "financial_stability_score",
+  "financial_stability_notes",
+  "client_money_score",
+  "client_money_notes",
+  "insurance_score",
+  "insurance_notes",
+  "platform_reliability_score",
+  "platform_reliability_notes",
+  "last_reviewed_at",
+  "updated_at",
+] as const;
+
+/**
+ * Sanitize a health score row.
+ */
+function sanitizeScore(row: Record<string, unknown>): Record<string, unknown> {
+  const clean: Record<string, unknown> = {};
+  for (const field of PUBLIC_FIELDS) {
+    if (field in row) {
+      const val = row[field];
+      clean[field] = typeof val === "string" ? escapeHtml(val) : val;
+    }
+  }
+  return clean;
+}
+
+/**
+ * OPTIONS /api/v1/health-scores — CORS preflight
+ */
+export function OPTIONS() {
+  return new NextResponse(null, {
+    status: 204,
+    headers: API_CORS_HEADERS,
+  });
+}
+
+/**
+ * GET /api/v1/health-scores
+ *
+ * Returns current broker health scores. Each row reflects the latest
+ * health assessment across five dimensions: regulatory, financial stability,
+ * client money, insurance, and platform reliability.
+ *
+ * Scores are numeric 0–100. This is factual/informational data — not financial
+ * advice or a recommendation to use or avoid any broker.
+ *
+ * Query params:
+ *   ?broker_slug=stake        — filter to a specific broker
+ *   ?min_score=70             — only return brokers with overall_score >= this
+ *   ?limit=20                 — max results (default 20, max 100)
+ *   ?offset=0                 — pagination offset
+ *
+ * Response: { data: HealthScore[], meta: { total, limit, offset, updated_at } }
+ */
+export async function GET(request: NextRequest) {
+  const start = Date.now();
+
+  // ── Auth ──
+  const auth = await validateApiKey(request);
+  if (!auth.valid) {
+    const elapsed = Date.now() - start;
+    logApiRequest({
+      apiKeyId: null,
+      endpoint: "/api/v1/health-scores",
+      method: "GET",
+      statusCode: 401,
+      responseTimeMs: elapsed,
+      ipAddress:
+        request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+        "unknown",
+      userAgent: request.headers.get("user-agent") || "unknown",
+    });
+    return NextResponse.json(
+      { error: auth.error },
+      { status: 401, headers: API_CORS_HEADERS },
+    );
+  }
+
+  try {
+    const params = request.nextUrl.searchParams;
+
+    // Parse pagination
+    let limit = Math.min(parseInt(params.get("limit") || "20", 10) || 20, 100);
+    if (limit < 1) limit = 20;
+    let offset = parseInt(params.get("offset") || "0", 10) || 0;
+    if (offset < 0) offset = 0;
+
+    const supabase = await createClient();
+
+    // broker_health_scores has anon SELECT policy — createClient suffices.
+    let query = supabase
+      .from("broker_health_scores")
+      .select(PUBLIC_FIELDS.join(","), { count: "exact" })
+      .order("overall_score", { ascending: false })
+      .order("broker_slug", { ascending: true });
+
+    // Optional filters
+    const brokerSlug = params.get("broker_slug");
+    if (brokerSlug) {
+      query = query.eq("broker_slug", brokerSlug);
+    }
+
+    const minScoreParam = params.get("min_score");
+    if (minScoreParam) {
+      const minScore = parseFloat(minScoreParam);
+      if (Number.isFinite(minScore)) {
+        query = query.gte("overall_score", minScore);
+      }
+    }
+
+    query = query.range(offset, offset + limit - 1);
+
+    const { data: scores, count, error } = await query;
+
+    if (error) {
+      log.error("Failed to fetch health scores", { error: error.message });
+      const elapsed = Date.now() - start;
+      logApiRequest({
+        apiKeyId: auth.apiKey?.id || null,
+        endpoint: "/api/v1/health-scores",
+        method: "GET",
+        statusCode: 500,
+        responseTimeMs: elapsed,
+        ipAddress:
+          request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+          "unknown",
+        userAgent: request.headers.get("user-agent") || "unknown",
+      });
+      return NextResponse.json(
+        { error: "Failed to fetch health scores" },
+        { status: 500, headers: API_CORS_HEADERS },
+      );
+    }
+
+    const sanitized = (scores || []).map((s) =>
+      sanitizeScore(s as unknown as Record<string, unknown>),
+    );
+
+    const latestUpdate =
+      sanitized.reduce((latest: string, s) => {
+        const u = (s.updated_at as string) || "";
+        return u > latest ? u : latest;
+      }, "") || new Date().toISOString();
+
+    const elapsed = Date.now() - start;
+
+    logApiRequest({
+      apiKeyId: auth.apiKey?.id || null,
+      endpoint: "/api/v1/health-scores",
+      method: "GET",
+      statusCode: 200,
+      responseTimeMs: elapsed,
+      ipAddress:
+        request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+        "unknown",
+      userAgent: request.headers.get("user-agent") || "unknown",
+    });
+
+    return NextResponse.json(
+      {
+        data: sanitized,
+        meta: {
+          total: count ?? sanitized.length,
+          limit,
+          offset,
+          updated_at: latestUpdate,
+          disclaimer:
+            "Health scores are informational only. They reflect publicly available regulatory and operational data. This is not financial advice.",
+        },
+      },
+      {
+        status: 200,
+        headers: {
+          ...API_CORS_HEADERS,
+          "Cache-Control": "private, max-age=3600",
+        },
+      },
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "Unknown error";
+    log.error("Unexpected error in GET /api/v1/health-scores", { error: msg });
+    const elapsed = Date.now() - start;
+    logApiRequest({
+      apiKeyId: auth.apiKey?.id || null,
+      endpoint: "/api/v1/health-scores",
+      method: "GET",
+      statusCode: 500,
+      responseTimeMs: elapsed,
+      ipAddress:
+        request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+        "unknown",
+      userAgent: request.headers.get("user-agent") || "unknown",
+    });
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500, headers: API_CORS_HEADERS },
+    );
+  }
+}

--- a/app/api/v1/openapi.json/route.ts
+++ b/app/api/v1/openapi.json/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+import { API_CORS_HEADERS } from "@/lib/api-auth";
+import { buildOpenApiSpec } from "@/lib/openapi-spec";
+
+export const runtime = "nodejs";
+// OpenAPI spec is static content — allow CDN caching for 24h.
+// No per-key auth state is involved.
+export const dynamic = "force-static";
+
+/**
+ * OPTIONS /api/v1/openapi.json — CORS preflight
+ */
+export function OPTIONS() {
+  return new NextResponse(null, {
+    status: 204,
+    headers: API_CORS_HEADERS,
+  });
+}
+
+/**
+ * GET /api/v1/openapi.json
+ *
+ * Returns a valid OpenAPI 3.1 document describing every v1 endpoint,
+ * their parameters, schemas, and security requirements.
+ *
+ * No authentication required — this is a public discovery endpoint.
+ * The spec is generated from lib/openapi-spec.ts, the single source of truth.
+ */
+export function GET() {
+  const spec = buildOpenApiSpec();
+
+  return NextResponse.json(spec, {
+    status: 200,
+    headers: {
+      ...API_CORS_HEADERS,
+      // Publicly cacheable — spec only changes on deploy.
+      "Cache-Control": "public, max-age=86400, stale-while-revalidate=3600",
+      "Content-Type": "application/json",
+    },
+  });
+}

--- a/app/api/v1/robo-advisors/[slug]/route.ts
+++ b/app/api/v1/robo-advisors/[slug]/route.ts
@@ -1,0 +1,237 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { logger } from "@/lib/logger";
+import { validateApiKey, logApiRequest, API_CORS_HEADERS } from "@/lib/api-auth";
+import { escapeHtml } from "@/lib/html-escape";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const log = logger("api-v1-robo-advisor-slug");
+
+/**
+ * Public fields for a single robo-advisor detail response.
+ * Includes review_content and fee_source_url for the detail view.
+ */
+const PUBLIC_FIELDS = [
+  "id",
+  "name",
+  "slug",
+  "tagline",
+  "platform_type",
+  "rating",
+  "min_deposit",
+  "regulated_by",
+  "year_founded",
+  "headquarters",
+  "fee_verified_date",
+  "status",
+  "pros",
+  "cons",
+  "deal",
+  "deal_text",
+  "editors_pick",
+  "icon",
+  "color",
+  "review_content",
+  "fee_source_url",
+  "smsf_support",
+  "updated_at",
+] as const;
+
+function sanitizePlatform(
+  row: Record<string, unknown>,
+): Record<string, unknown> {
+  const clean: Record<string, unknown> = {};
+  for (const field of PUBLIC_FIELDS) {
+    if (field in row) {
+      const val = row[field];
+      clean[field] = typeof val === "string" ? escapeHtml(val) : val;
+    }
+  }
+  return clean;
+}
+
+/**
+ * Sanitize a fee changelog entry.
+ */
+function sanitizeChangelogEntry(
+  entry: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    field_name:
+      typeof entry.field_name === "string"
+        ? escapeHtml(entry.field_name)
+        : entry.field_name,
+    old_value:
+      typeof entry.old_value === "string"
+        ? escapeHtml(entry.old_value)
+        : entry.old_value,
+    new_value:
+      typeof entry.new_value === "string"
+        ? escapeHtml(entry.new_value)
+        : entry.new_value,
+    change_type:
+      typeof entry.change_type === "string"
+        ? escapeHtml(entry.change_type)
+        : entry.change_type,
+    changed_at: entry.changed_at,
+    source:
+      typeof entry.source === "string"
+        ? escapeHtml(entry.source)
+        : entry.source,
+  };
+}
+
+/**
+ * OPTIONS /api/v1/robo-advisors/[slug] — CORS preflight
+ */
+export function OPTIONS() {
+  return new NextResponse(null, {
+    status: 204,
+    headers: API_CORS_HEADERS,
+  });
+}
+
+/**
+ * GET /api/v1/robo-advisors/[slug]
+ *
+ * Returns a single robo-advisor's full public profile by slug.
+ * Includes fee_changelog (last 10 changes) from broker_data_changes.
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  const start = Date.now();
+  const { slug } = await params;
+
+  // ── Auth ──
+  const auth = await validateApiKey(request);
+  if (!auth.valid) {
+    const elapsed = Date.now() - start;
+    logApiRequest({
+      apiKeyId: null,
+      endpoint: `/api/v1/robo-advisors/${slug}`,
+      method: "GET",
+      statusCode: 401,
+      responseTimeMs: elapsed,
+      ipAddress:
+        request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+        "unknown",
+      userAgent: request.headers.get("user-agent") || "unknown",
+    });
+    return NextResponse.json(
+      { error: auth.error },
+      { status: 401, headers: API_CORS_HEADERS },
+    );
+  }
+
+  // Validate slug format
+  if (!slug || !/^[a-z0-9-]+$/.test(slug)) {
+    return NextResponse.json(
+      { error: "Invalid robo-advisor slug" },
+      { status: 400, headers: API_CORS_HEADERS },
+    );
+  }
+
+  try {
+    const supabase = await createClient();
+
+    // Fetch the robo-advisor platform
+    const { data: platform, error: platformError } = await supabase
+      .from("brokers")
+      .select(PUBLIC_FIELDS.join(","))
+      .eq("slug", slug)
+      .eq("status", "active")
+      .eq("platform_type", "robo_advisor")
+      .single();
+
+    if (platformError || !platform) {
+      const elapsed = Date.now() - start;
+      logApiRequest({
+        apiKeyId: auth.apiKey?.id || null,
+        endpoint: `/api/v1/robo-advisors/${slug}`,
+        method: "GET",
+        statusCode: 404,
+        responseTimeMs: elapsed,
+        ipAddress:
+          request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+          "unknown",
+        userAgent: request.headers.get("user-agent") || "unknown",
+      });
+      return NextResponse.json(
+        { error: "Robo-advisor not found" },
+        { status: 404, headers: API_CORS_HEADERS },
+      );
+    }
+
+    // Fetch fee changelog (last 10 changes)
+    const { data: changelog } = await supabase
+      .from("broker_data_changes")
+      .select(
+        "field_name, old_value, new_value, change_type, changed_at, source",
+      )
+      .eq("broker_slug", slug)
+      .order("changed_at", { ascending: false })
+      .limit(10);
+
+    const sanitized = sanitizePlatform(
+      platform as unknown as Record<string, unknown>,
+    );
+    const sanitizedChangelog = (changelog || []).map((entry) =>
+      sanitizeChangelogEntry(entry as Record<string, unknown>),
+    );
+
+    const elapsed = Date.now() - start;
+
+    logApiRequest({
+      apiKeyId: auth.apiKey?.id || null,
+      endpoint: `/api/v1/robo-advisors/${slug}`,
+      method: "GET",
+      statusCode: 200,
+      responseTimeMs: elapsed,
+      ipAddress:
+        request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+        "unknown",
+      userAgent: request.headers.get("user-agent") || "unknown",
+    });
+
+    return NextResponse.json(
+      {
+        data: {
+          ...sanitized,
+          fee_changelog: sanitizedChangelog,
+        },
+      },
+      {
+        status: 200,
+        headers: {
+          ...API_CORS_HEADERS,
+          "Cache-Control": "private, max-age=3600",
+        },
+      },
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "Unknown error";
+    log.error("Unexpected error in GET /api/v1/robo-advisors/[slug]", {
+      error: msg,
+    });
+    const elapsed = Date.now() - start;
+    logApiRequest({
+      apiKeyId: auth.apiKey?.id || null,
+      endpoint: `/api/v1/robo-advisors/${slug}`,
+      method: "GET",
+      statusCode: 500,
+      responseTimeMs: elapsed,
+      ipAddress:
+        request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+        "unknown",
+      userAgent: request.headers.get("user-agent") || "unknown",
+    });
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500, headers: API_CORS_HEADERS },
+    );
+  }
+}

--- a/app/api/v1/robo-advisors/route.ts
+++ b/app/api/v1/robo-advisors/route.ts
@@ -1,0 +1,218 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { logger } from "@/lib/logger";
+import { validateApiKey, logApiRequest, API_CORS_HEADERS } from "@/lib/api-auth";
+import { escapeHtml } from "@/lib/html-escape";
+
+export const runtime = "nodejs";
+// Per-key auth gating — see /api/v1/brokers/route.ts for the same reasoning.
+export const dynamic = "force-dynamic";
+
+const log = logger("api-v1-robo-advisors");
+
+/**
+ * Public fields for robo-advisor platform rows.
+ * Excludes: affiliate_url, commission fields, internal admin data.
+ */
+const PUBLIC_FIELDS = [
+  "id",
+  "name",
+  "slug",
+  "tagline",
+  "platform_type",
+  "rating",
+  "min_deposit",
+  "regulated_by",
+  "year_founded",
+  "headquarters",
+  "fee_verified_date",
+  "status",
+  "pros",
+  "cons",
+  "deal",
+  "deal_text",
+  "editors_pick",
+  "icon",
+  "color",
+  "updated_at",
+] as const;
+
+/**
+ * Sanitize a robo-advisor row: keep only public fields, escape strings.
+ */
+function sanitizePlatform(
+  row: Record<string, unknown>,
+): Record<string, unknown> {
+  const clean: Record<string, unknown> = {};
+  for (const field of PUBLIC_FIELDS) {
+    if (field in row) {
+      const val = row[field];
+      clean[field] = typeof val === "string" ? escapeHtml(val) : val;
+    }
+  }
+  return clean;
+}
+
+/**
+ * OPTIONS /api/v1/robo-advisors — CORS preflight
+ */
+export function OPTIONS() {
+  return new NextResponse(null, {
+    status: 204,
+    headers: API_CORS_HEADERS,
+  });
+}
+
+/**
+ * GET /api/v1/robo-advisors
+ *
+ * Returns active robo-advisor platforms (platform_type = 'robo_advisor').
+ * Robo-advisors are automated investment services backed by real brokers/platforms
+ * in the brokers table (Raiz, Stockspot, Spaceship, InvestSMART, Six Park, etc.).
+ *
+ * Query params:
+ *   ?smsf_support=true   — filter by SMSF support (true/false)
+ *   ?limit=20            — max results (default 20, max 100)
+ *   ?offset=0            — pagination offset
+ *
+ * Response: { data: RoboAdvisor[], meta: { total, limit, offset, updated_at } }
+ */
+export async function GET(request: NextRequest) {
+  const start = Date.now();
+
+  // ── Auth ──
+  const auth = await validateApiKey(request);
+  if (!auth.valid) {
+    const elapsed = Date.now() - start;
+    logApiRequest({
+      apiKeyId: null,
+      endpoint: "/api/v1/robo-advisors",
+      method: "GET",
+      statusCode: 401,
+      responseTimeMs: elapsed,
+      ipAddress:
+        request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+        "unknown",
+      userAgent: request.headers.get("user-agent") || "unknown",
+    });
+    return NextResponse.json(
+      { error: auth.error },
+      { status: 401, headers: API_CORS_HEADERS },
+    );
+  }
+
+  try {
+    const params = request.nextUrl.searchParams;
+
+    // Parse pagination
+    let limit = Math.min(parseInt(params.get("limit") || "20", 10) || 20, 100);
+    if (limit < 1) limit = 20;
+    let offset = parseInt(params.get("offset") || "0", 10) || 0;
+    if (offset < 0) offset = 0;
+
+    const supabase = await createClient();
+
+    let query = supabase
+      .from("brokers")
+      .select(PUBLIC_FIELDS.join(","), { count: "exact" })
+      .eq("status", "active")
+      .eq("platform_type", "robo_advisor")
+      .order("rating", { ascending: false })
+      .order("name", { ascending: true });
+
+    // Optional SMSF filter
+    const smsfSupport = params.get("smsf_support");
+    if (smsfSupport === "true") {
+      query = query.eq("smsf_support", true);
+    } else if (smsfSupport === "false") {
+      query = query.eq("smsf_support", false);
+    }
+
+    // Apply pagination
+    query = query.range(offset, offset + limit - 1);
+
+    const { data: platforms, count, error } = await query;
+
+    if (error) {
+      log.error("Failed to fetch robo-advisors", { error: error.message });
+      const elapsed = Date.now() - start;
+      logApiRequest({
+        apiKeyId: auth.apiKey?.id || null,
+        endpoint: "/api/v1/robo-advisors",
+        method: "GET",
+        statusCode: 500,
+        responseTimeMs: elapsed,
+        ipAddress:
+          request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+          "unknown",
+        userAgent: request.headers.get("user-agent") || "unknown",
+      });
+      return NextResponse.json(
+        { error: "Failed to fetch robo-advisors" },
+        { status: 500, headers: API_CORS_HEADERS },
+      );
+    }
+
+    const sanitized = (platforms || []).map((p) =>
+      sanitizePlatform(p as unknown as Record<string, unknown>),
+    );
+
+    const latestUpdate =
+      sanitized.reduce((latest: string, p) => {
+        const u = (p.updated_at as string) || "";
+        return u > latest ? u : latest;
+      }, "") || new Date().toISOString();
+
+    const elapsed = Date.now() - start;
+
+    logApiRequest({
+      apiKeyId: auth.apiKey?.id || null,
+      endpoint: "/api/v1/robo-advisors",
+      method: "GET",
+      statusCode: 200,
+      responseTimeMs: elapsed,
+      ipAddress:
+        request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+        "unknown",
+      userAgent: request.headers.get("user-agent") || "unknown",
+    });
+
+    return NextResponse.json(
+      {
+        data: sanitized,
+        meta: {
+          total: count ?? sanitized.length,
+          limit,
+          offset,
+          updated_at: latestUpdate,
+        },
+      },
+      {
+        status: 200,
+        headers: {
+          ...API_CORS_HEADERS,
+          "Cache-Control": "private, max-age=3600",
+        },
+      },
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "Unknown error";
+    log.error("Unexpected error in GET /api/v1/robo-advisors", { error: msg });
+    const elapsed = Date.now() - start;
+    logApiRequest({
+      apiKeyId: auth.apiKey?.id || null,
+      endpoint: "/api/v1/robo-advisors",
+      method: "GET",
+      statusCode: 500,
+      responseTimeMs: elapsed,
+      ipAddress:
+        request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+        "unknown",
+      userAgent: request.headers.get("user-agent") || "unknown",
+    });
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500, headers: API_CORS_HEADERS },
+    );
+  }
+}

--- a/app/api/v1/savings/[slug]/route.ts
+++ b/app/api/v1/savings/[slug]/route.ts
@@ -1,0 +1,230 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { logger } from "@/lib/logger";
+import { validateApiKey, logApiRequest, API_CORS_HEADERS } from "@/lib/api-auth";
+import { escapeHtml } from "@/lib/html-escape";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const log = logger("api-v1-savings-slug");
+
+/**
+ * Public fields for a single savings platform detail response.
+ * Includes additional review/content fields beyond the list endpoint.
+ */
+const PUBLIC_FIELDS = [
+  "id",
+  "name",
+  "slug",
+  "tagline",
+  "platform_type",
+  "rating",
+  "min_deposit",
+  "regulated_by",
+  "year_founded",
+  "headquarters",
+  "fee_verified_date",
+  "status",
+  "pros",
+  "cons",
+  "deal",
+  "deal_text",
+  "editors_pick",
+  "icon",
+  "color",
+  "review_content",
+  "updated_at",
+] as const;
+
+function sanitizePlatform(
+  row: Record<string, unknown>,
+): Record<string, unknown> {
+  const clean: Record<string, unknown> = {};
+  for (const field of PUBLIC_FIELDS) {
+    if (field in row) {
+      const val = row[field];
+      clean[field] = typeof val === "string" ? escapeHtml(val) : val;
+    }
+  }
+  return clean;
+}
+
+function sanitizeRate(row: Record<string, unknown>): Record<string, unknown> {
+  return {
+    id: row.id,
+    product_kind: row.product_kind,
+    rate_bps: row.rate_bps,
+    intro_rate_bps: row.intro_rate_bps,
+    intro_term_months: row.intro_term_months,
+    min_balance_cents: row.min_balance_cents,
+    max_balance_cents: row.max_balance_cents,
+    term_months: row.term_months,
+    captured_at: row.captured_at,
+    notes:
+      typeof row.notes === "string" ? escapeHtml(row.notes) : row.notes,
+  };
+}
+
+/**
+ * OPTIONS /api/v1/savings/[slug] — CORS preflight
+ */
+export function OPTIONS() {
+  return new NextResponse(null, {
+    status: 204,
+    headers: API_CORS_HEADERS,
+  });
+}
+
+/**
+ * GET /api/v1/savings/[slug]
+ *
+ * Returns a single savings platform's full public profile by slug.
+ * Includes all current rate snapshots and rate history (last 30 per product_kind).
+ *
+ * Rate fields use basis points (bps): 525 bps = 5.25% p.a.
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  const start = Date.now();
+  const { slug } = await params;
+
+  // ── Auth ──
+  const auth = await validateApiKey(request);
+  if (!auth.valid) {
+    const elapsed = Date.now() - start;
+    logApiRequest({
+      apiKeyId: null,
+      endpoint: `/api/v1/savings/${slug}`,
+      method: "GET",
+      statusCode: 401,
+      responseTimeMs: elapsed,
+      ipAddress:
+        request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+        "unknown",
+      userAgent: request.headers.get("user-agent") || "unknown",
+    });
+    return NextResponse.json(
+      { error: auth.error },
+      { status: 401, headers: API_CORS_HEADERS },
+    );
+  }
+
+  // Validate slug format
+  if (!slug || !/^[a-z0-9-]+$/.test(slug)) {
+    return NextResponse.json(
+      { error: "Invalid savings platform slug" },
+      { status: 400, headers: API_CORS_HEADERS },
+    );
+  }
+
+  try {
+    const supabase = await createClient();
+
+    // Fetch the savings platform
+    const { data: platform, error: platformError } = await supabase
+      .from("brokers")
+      .select(PUBLIC_FIELDS.join(","))
+      .eq("slug", slug)
+      .eq("status", "active")
+      .in("platform_type", ["savings", "term_deposit"])
+      .single();
+
+    if (platformError || !platform) {
+      const elapsed = Date.now() - start;
+      logApiRequest({
+        apiKeyId: auth.apiKey?.id || null,
+        endpoint: `/api/v1/savings/${slug}`,
+        method: "GET",
+        statusCode: 404,
+        responseTimeMs: elapsed,
+        ipAddress:
+          request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+          "unknown",
+        userAgent: request.headers.get("user-agent") || "unknown",
+      });
+      return NextResponse.json(
+        { error: "Savings platform not found" },
+        { status: 404, headers: API_CORS_HEADERS },
+      );
+    }
+
+    const platformRow = platform as unknown as Record<string, unknown>;
+
+    // Fetch rate history (last 30 snapshots per product_kind, most recent first)
+    const { data: rates } = await supabase
+      .from("savings_rate_snapshots")
+      .select(
+        "id, broker_id, product_kind, rate_bps, intro_rate_bps, intro_term_months, min_balance_cents, max_balance_cents, term_months, captured_at, notes",
+      )
+      .eq("broker_id", platformRow.id as number)
+      .order("captured_at", { ascending: false })
+      .limit(60); // 30 per kind × 2 kinds max
+
+    // Group by product_kind, take last 30 per kind
+    const ratesByKind: Record<string, Record<string, unknown>[]> = {};
+    for (const rate of rates || []) {
+      const r = rate as Record<string, unknown>;
+      const kind = r.product_kind as string;
+      if (!ratesByKind[kind]) ratesByKind[kind] = [];
+      if ((ratesByKind[kind]?.length ?? 0) < 30) {
+        ratesByKind[kind]!.push(sanitizeRate(r));
+      }
+    }
+
+    const sanitized = sanitizePlatform(platformRow);
+
+    const elapsed = Date.now() - start;
+
+    logApiRequest({
+      apiKeyId: auth.apiKey?.id || null,
+      endpoint: `/api/v1/savings/${slug}`,
+      method: "GET",
+      statusCode: 200,
+      responseTimeMs: elapsed,
+      ipAddress:
+        request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+        "unknown",
+      userAgent: request.headers.get("user-agent") || "unknown",
+    });
+
+    return NextResponse.json(
+      {
+        data: {
+          ...sanitized,
+          rates_by_kind: ratesByKind,
+          rate_note:
+            "rate_bps: integer basis points — 525 bps = 5.25% p.a. Intro rates are time-limited bonus rates.",
+        },
+      },
+      {
+        status: 200,
+        headers: {
+          ...API_CORS_HEADERS,
+          "Cache-Control": "private, max-age=3600",
+        },
+      },
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "Unknown error";
+    log.error("Unexpected error in GET /api/v1/savings/[slug]", { error: msg });
+    const elapsed = Date.now() - start;
+    logApiRequest({
+      apiKeyId: auth.apiKey?.id || null,
+      endpoint: `/api/v1/savings/${slug}`,
+      method: "GET",
+      statusCode: 500,
+      responseTimeMs: elapsed,
+      ipAddress:
+        request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+        "unknown",
+      userAgent: request.headers.get("user-agent") || "unknown",
+    });
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500, headers: API_CORS_HEADERS },
+    );
+  }
+}

--- a/app/api/v1/savings/route.ts
+++ b/app/api/v1/savings/route.ts
@@ -177,10 +177,10 @@ export async function GET(request: NextRequest) {
     const filteredKind = validKinds.find((k) => k === productKindFilter) ?? null;
 
     const platformIds = platformRows
-      .map((p) => (p as Record<string, unknown>).id as number)
+      .map((p) => (p as unknown as Record<string, unknown>).id as number)
       .filter(Boolean);
 
-    let ratesMap: Record<number, Record<string, unknown>[]> = {};
+    const ratesMap: Record<number, Record<string, unknown>[]> = {};
 
     if (platformIds.length > 0) {
       let ratesQuery = supabase
@@ -225,7 +225,7 @@ export async function GET(request: NextRequest) {
 
     const latestUpdate =
       sanitized.reduce((latest: string, p) => {
-        const u = (p.updated_at as string) || "";
+        const u = ((p as Record<string, unknown>).updated_at as string) || "";
         return u > latest ? u : latest;
       }, "") || new Date().toISOString();
 

--- a/app/api/v1/savings/route.ts
+++ b/app/api/v1/savings/route.ts
@@ -1,0 +1,286 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { logger } from "@/lib/logger";
+import { validateApiKey, logApiRequest, API_CORS_HEADERS } from "@/lib/api-auth";
+import { escapeHtml } from "@/lib/html-escape";
+
+export const runtime = "nodejs";
+// Per-key auth gating — see /api/v1/brokers/route.ts for the same reasoning.
+export const dynamic = "force-dynamic";
+
+const log = logger("api-v1-savings");
+
+/**
+ * Public fields safe to expose for savings/term-deposit platform rows.
+ * Excludes: affiliate_url, commission fields, internal admin data.
+ */
+const PUBLIC_FIELDS = [
+  "id",
+  "name",
+  "slug",
+  "tagline",
+  "platform_type",
+  "rating",
+  "min_deposit",
+  "regulated_by",
+  "year_founded",
+  "headquarters",
+  "fee_verified_date",
+  "status",
+  "pros",
+  "cons",
+  "deal",
+  "deal_text",
+  "editors_pick",
+  "icon",
+  "color",
+  "updated_at",
+] as const;
+
+/**
+ * Sanitize a savings platform row: keep only public fields, escape strings.
+ */
+function sanitizePlatform(
+  row: Record<string, unknown>,
+): Record<string, unknown> {
+  const clean: Record<string, unknown> = {};
+  for (const field of PUBLIC_FIELDS) {
+    if (field in row) {
+      const val = row[field];
+      clean[field] = typeof val === "string" ? escapeHtml(val) : val;
+    }
+  }
+  return clean;
+}
+
+/**
+ * Sanitize a rate snapshot row.
+ */
+function sanitizeRate(row: Record<string, unknown>): Record<string, unknown> {
+  return {
+    id: row.id,
+    product_kind: row.product_kind,
+    rate_bps: row.rate_bps,
+    intro_rate_bps: row.intro_rate_bps,
+    intro_term_months: row.intro_term_months,
+    min_balance_cents: row.min_balance_cents,
+    max_balance_cents: row.max_balance_cents,
+    term_months: row.term_months,
+    captured_at: row.captured_at,
+    notes:
+      typeof row.notes === "string" ? escapeHtml(row.notes) : row.notes,
+  };
+}
+
+/**
+ * OPTIONS /api/v1/savings — CORS preflight
+ */
+export function OPTIONS() {
+  return new NextResponse(null, {
+    status: 204,
+    headers: API_CORS_HEADERS,
+  });
+}
+
+/**
+ * GET /api/v1/savings
+ *
+ * Returns active savings account and term deposit platforms with the latest
+ * rate snapshot for each (joined from savings_rate_snapshots).
+ *
+ * Query params:
+ *   ?product_kind=savings_account   — filter by kind: savings_account | term_deposit
+ *   ?limit=20                       — max results (default 20, max 100)
+ *   ?offset=0                       — pagination offset
+ *
+ * Response: { data: SavingsPlatform[], meta: { total, limit, offset, updated_at } }
+ *
+ * Rate fields use basis points (bps): 525 bps = 5.25% p.a.
+ */
+export async function GET(request: NextRequest) {
+  const start = Date.now();
+
+  // ── Auth ──
+  const auth = await validateApiKey(request);
+  if (!auth.valid) {
+    const elapsed = Date.now() - start;
+    logApiRequest({
+      apiKeyId: null,
+      endpoint: "/api/v1/savings",
+      method: "GET",
+      statusCode: 401,
+      responseTimeMs: elapsed,
+      ipAddress:
+        request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+        "unknown",
+      userAgent: request.headers.get("user-agent") || "unknown",
+    });
+    return NextResponse.json(
+      { error: auth.error },
+      { status: 401, headers: API_CORS_HEADERS },
+    );
+  }
+
+  try {
+    const params = request.nextUrl.searchParams;
+
+    // Parse pagination
+    let limit = Math.min(parseInt(params.get("limit") || "20", 10) || 20, 100);
+    if (limit < 1) limit = 20;
+    let offset = parseInt(params.get("offset") || "0", 10) || 0;
+    if (offset < 0) offset = 0;
+
+    const supabase = await createClient();
+
+    // Build query — brokers with savings/term_deposit platform types.
+    // platform_type can be either 'savings' (the original CHECK constraint value)
+    // or matched via product_kind filter on savings_rate_snapshots.
+    let query = supabase
+      .from("brokers")
+      .select(PUBLIC_FIELDS.join(","), { count: "exact" })
+      .eq("status", "active")
+      .in("platform_type", ["savings", "term_deposit"])
+      .order("rating", { ascending: false })
+      .order("name", { ascending: true });
+
+    // Apply pagination
+    query = query.range(offset, offset + limit - 1);
+
+    const { data: platforms, count, error } = await query;
+
+    if (error) {
+      log.error("Failed to fetch savings platforms", { error: error.message });
+      const elapsed = Date.now() - start;
+      logApiRequest({
+        apiKeyId: auth.apiKey?.id || null,
+        endpoint: "/api/v1/savings",
+        method: "GET",
+        statusCode: 500,
+        responseTimeMs: elapsed,
+        ipAddress:
+          request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+          "unknown",
+        userAgent: request.headers.get("user-agent") || "unknown",
+      });
+      return NextResponse.json(
+        { error: "Failed to fetch savings platforms" },
+        { status: 500, headers: API_CORS_HEADERS },
+      );
+    }
+
+    const platformRows = platforms || [];
+
+    // For each platform, fetch the latest rate snapshots from savings_rate_snapshots.
+    // Apply product_kind filter if requested.
+    const productKindFilter = params.get("product_kind");
+    const validKinds = ["savings_account", "term_deposit"] as const;
+    const filteredKind = validKinds.find((k) => k === productKindFilter) ?? null;
+
+    const platformIds = platformRows
+      .map((p) => (p as Record<string, unknown>).id as number)
+      .filter(Boolean);
+
+    let ratesMap: Record<number, Record<string, unknown>[]> = {};
+
+    if (platformIds.length > 0) {
+      let ratesQuery = supabase
+        .from("savings_rate_snapshots")
+        .select(
+          "id, broker_id, product_kind, rate_bps, intro_rate_bps, intro_term_months, min_balance_cents, max_balance_cents, term_months, captured_at, notes",
+        )
+        .in("broker_id", platformIds)
+        .order("captured_at", { ascending: false });
+
+      if (filteredKind) {
+        ratesQuery = ratesQuery.eq("product_kind", filteredKind);
+      }
+
+      const { data: rates } = await ratesQuery;
+
+      // Group latest rate per (broker_id, product_kind) — take first per group
+      const seen = new Set<string>();
+      for (const rate of rates || []) {
+        const r = rate as Record<string, unknown>;
+        const key = `${r.broker_id as string}-${r.product_kind as string}`;
+        if (!seen.has(key)) {
+          seen.add(key);
+          const bid = r.broker_id as number;
+          if (!ratesMap[bid]) ratesMap[bid] = [];
+          ratesMap[bid]!.push(sanitizeRate(r));
+        }
+      }
+    }
+
+    // If product_kind filter is specified and a platform has no matching rate,
+    // exclude it from results (matches user intent).
+    const sanitized = platformRows
+      .map((p) => {
+        const row = p as unknown as Record<string, unknown>;
+        const clean = sanitizePlatform(row);
+        const pid = row.id as number;
+        const latest_rates = ratesMap[pid] ?? [];
+        return { ...clean, latest_rates };
+      })
+      .filter((p) => !filteredKind || (p.latest_rates as unknown[]).length > 0);
+
+    const latestUpdate =
+      sanitized.reduce((latest: string, p) => {
+        const u = (p.updated_at as string) || "";
+        return u > latest ? u : latest;
+      }, "") || new Date().toISOString();
+
+    const elapsed = Date.now() - start;
+
+    logApiRequest({
+      apiKeyId: auth.apiKey?.id || null,
+      endpoint: "/api/v1/savings",
+      method: "GET",
+      statusCode: 200,
+      responseTimeMs: elapsed,
+      ipAddress:
+        request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+        "unknown",
+      userAgent: request.headers.get("user-agent") || "unknown",
+    });
+
+    return NextResponse.json(
+      {
+        data: sanitized,
+        meta: {
+          total: filteredKind ? sanitized.length : (count ?? sanitized.length),
+          limit,
+          offset,
+          updated_at: latestUpdate,
+          rate_note:
+            "rate_bps: integer basis points — 525 bps = 5.25% p.a. Intro rates are time-limited bonus rates.",
+        },
+      },
+      {
+        status: 200,
+        headers: {
+          ...API_CORS_HEADERS,
+          "Cache-Control": "private, max-age=3600",
+        },
+      },
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "Unknown error";
+    log.error("Unexpected error in GET /api/v1/savings", { error: msg });
+    const elapsed = Date.now() - start;
+    logApiRequest({
+      apiKeyId: auth.apiKey?.id || null,
+      endpoint: "/api/v1/savings",
+      method: "GET",
+      statusCode: 500,
+      responseTimeMs: elapsed,
+      ipAddress:
+        request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+        "unknown",
+      userAgent: request.headers.get("user-agent") || "unknown",
+    });
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500, headers: API_CORS_HEADERS },
+    );
+  }
+}

--- a/lib/openapi-spec.ts
+++ b/lib/openapi-spec.ts
@@ -1,0 +1,1302 @@
+/**
+ * OpenAPI 3.1 specification for the Invest.com.au Financial Data API (v1).
+ *
+ * This module is the single source of truth for the spec — both the
+ * GET /api/v1/openapi.json route and any tooling that generates client SDKs
+ * should consume this module rather than maintaining separate copies.
+ *
+ * Kept in a lib module (not inline in the route) so it can be imported by
+ * tests to validate structural correctness without an HTTP round-trip.
+ */
+
+export type OpenApiSpec = {
+  openapi: string;
+  info: Record<string, unknown>;
+  servers: { url: string; description: string }[];
+  security: Record<string, unknown>[];
+  components: Record<string, unknown>;
+  paths: Record<string, unknown>;
+};
+
+export function buildOpenApiSpec(): OpenApiSpec {
+  return {
+    openapi: "3.1.0",
+    info: {
+      title: "Invest.com.au Financial Data API",
+      version: "1.0.0",
+      description:
+        "RESTful JSON API for verified Australian broker, robo-advisor, savings, advisor, and health-score data. Built for financial planners, advisors, and fintech developers. All data is factual and informational — not financial advice.",
+      contact: {
+        name: "API Support",
+        email: "api@invest.com.au",
+        url: "https://invest.com.au/api-docs",
+      },
+      license: {
+        name: "Commercial — contact us for licensing terms",
+        url: "https://invest.com.au/contact",
+      },
+    },
+    servers: [
+      {
+        url: "https://invest.com.au/api/v1",
+        description: "Production",
+      },
+    ],
+    security: [{ BearerAuth: [] }],
+    components: {
+      securitySchemes: {
+        BearerAuth: {
+          type: "http",
+          scheme: "bearer",
+          bearerFormat: "ica_<hex>",
+          description:
+            "API key in `ica_<32-hex>` format. Obtain via POST /api/v1/api-keys.",
+        },
+      },
+      schemas: {
+        ErrorResponse: {
+          type: "object",
+          required: ["error"],
+          properties: {
+            error: { type: "string", example: "Invalid API key" },
+          },
+        },
+        PaginationMeta: {
+          type: "object",
+          required: ["total", "limit", "offset"],
+          properties: {
+            total: {
+              type: "integer",
+              description: "Total number of matching records",
+            },
+            limit: { type: "integer", example: 20 },
+            offset: { type: "integer", example: 0 },
+            updated_at: {
+              type: "string",
+              format: "date-time",
+              description: "ISO 8601 timestamp of the most recently updated record",
+            },
+          },
+        },
+        Broker: {
+          type: "object",
+          properties: {
+            id: { type: "integer" },
+            name: { type: "string", example: "Stake" },
+            slug: { type: "string", example: "stake" },
+            tagline: { type: "string" },
+            asx_fee: { type: "string", example: "$3.00" },
+            asx_fee_value: { type: "number", example: 3.0 },
+            us_fee: { type: "string", example: "$0" },
+            us_fee_value: { type: "number", example: 0 },
+            fx_rate: { type: "number", example: 0.6 },
+            chess_sponsored: { type: "boolean" },
+            smsf_support: { type: "boolean" },
+            is_crypto: { type: "boolean" },
+            platform_type: {
+              type: "string",
+              enum: [
+                "share_broker",
+                "crypto_exchange",
+                "cfd_forex",
+                "multi_asset",
+                "robo_advisor",
+                "savings",
+              ],
+            },
+            rating: { type: "number", example: 4.5 },
+            inactivity_fee: { type: "string" },
+            min_deposit: { type: "string" },
+            regulated_by: { type: "string", example: "ASIC" },
+            year_founded: { type: "integer", example: 2017 },
+            headquarters: { type: "string", example: "Sydney, NSW" },
+            fee_verified_date: { type: "string", format: "date" },
+            status: { type: "string", enum: ["active", "inactive"] },
+            updated_at: { type: "string", format: "date-time" },
+          },
+        },
+        BrokerDetail: {
+          allOf: [
+            { $ref: "#/components/schemas/Broker" },
+            {
+              type: "object",
+              properties: {
+                review_content: { type: "string" },
+                fee_source_url: { type: "string", format: "uri" },
+                fee_changelog: {
+                  type: "array",
+                  items: { $ref: "#/components/schemas/FeeChangelogEntry" },
+                  description: "Last 10 fee changes",
+                },
+              },
+            },
+          ],
+        },
+        FeeChangelogEntry: {
+          type: "object",
+          properties: {
+            field_name: { type: "string", example: "asx_fee_value" },
+            old_value: { type: "string" },
+            new_value: { type: "string" },
+            change_type: {
+              type: "string",
+              enum: ["update", "create", "delete"],
+            },
+            changed_at: { type: "string", format: "date-time" },
+            source: { type: "string" },
+          },
+        },
+        SavingsPlatform: {
+          type: "object",
+          properties: {
+            id: { type: "integer" },
+            name: { type: "string", example: "ING Savings Maximiser" },
+            slug: { type: "string", example: "ing-savings-maximiser" },
+            platform_type: {
+              type: "string",
+              enum: ["savings", "term_deposit"],
+            },
+            rating: { type: "number" },
+            regulated_by: { type: "string", example: "APRA" },
+            updated_at: { type: "string", format: "date-time" },
+            latest_rates: {
+              type: "array",
+              items: { $ref: "#/components/schemas/SavingsRate" },
+            },
+          },
+        },
+        SavingsRate: {
+          type: "object",
+          properties: {
+            id: { type: "string", format: "uuid" },
+            product_kind: {
+              type: "string",
+              enum: ["savings_account", "term_deposit"],
+            },
+            rate_bps: {
+              type: "integer",
+              description: "Interest rate in basis points (525 = 5.25% p.a.)",
+              example: 525,
+            },
+            intro_rate_bps: {
+              type: "integer",
+              nullable: true,
+              description: "Introductory/bonus rate in basis points",
+            },
+            intro_term_months: {
+              type: "integer",
+              nullable: true,
+              description: "Duration of intro rate in months",
+            },
+            min_balance_cents: {
+              type: "integer",
+              description: "Minimum balance for this rate tier (AUD cents)",
+            },
+            max_balance_cents: {
+              type: "integer",
+              nullable: true,
+              description: "Maximum balance for this rate tier (AUD cents), null if uncapped",
+            },
+            term_months: {
+              type: "integer",
+              nullable: true,
+              description: "Term length in months (term deposits only)",
+            },
+            captured_at: { type: "string", format: "date-time" },
+            notes: {
+              type: "string",
+              description: "Rate conditions, bonus eligibility requirements, etc.",
+            },
+          },
+        },
+        RoboAdvisor: {
+          type: "object",
+          properties: {
+            id: { type: "integer" },
+            name: { type: "string", example: "Stockspot" },
+            slug: { type: "string", example: "stockspot" },
+            platform_type: { type: "string", enum: ["robo_advisor"] },
+            rating: { type: "number" },
+            min_deposit: { type: "string" },
+            smsf_support: { type: "boolean" },
+            regulated_by: { type: "string", example: "ASIC" },
+            updated_at: { type: "string", format: "date-time" },
+          },
+        },
+        RoboAdvisorDetail: {
+          allOf: [
+            { $ref: "#/components/schemas/RoboAdvisor" },
+            {
+              type: "object",
+              properties: {
+                review_content: { type: "string" },
+                fee_source_url: { type: "string", format: "uri" },
+                fee_changelog: {
+                  type: "array",
+                  items: { $ref: "#/components/schemas/FeeChangelogEntry" },
+                  description: "Last 10 fee changes",
+                },
+              },
+            },
+          ],
+        },
+        Advisor: {
+          type: "object",
+          properties: {
+            id: { type: "integer" },
+            slug: { type: "string" },
+            name: { type: "string" },
+            firm_name: { type: "string" },
+            type: { type: "string", example: "financial_planner" },
+            specialties: { type: "array", items: { type: "string" } },
+            location_state: {
+              type: "string",
+              enum: ["NSW", "VIC", "QLD", "WA", "SA", "TAS", "ACT", "NT"],
+            },
+            location_display: { type: "string" },
+            afsl_number: { type: "string" },
+            rating: { type: "number" },
+            review_count: { type: "integer" },
+            verified: { type: "boolean" },
+            accepts_new_clients: { type: "boolean" },
+            hourly_rate_cents: { type: "integer", nullable: true },
+            initial_consultation_free: { type: "boolean" },
+            updated_at: { type: "string", format: "date-time" },
+          },
+        },
+        HealthScore: {
+          type: "object",
+          properties: {
+            broker_slug: { type: "string", example: "stake" },
+            afsl_number: { type: "string" },
+            afsl_status: {
+              type: "string",
+              enum: ["active", "suspended", "cancelled", "unknown"],
+            },
+            overall_score: {
+              type: "number",
+              minimum: 0,
+              maximum: 100,
+              description: "Composite health score 0–100",
+            },
+            regulatory_score: { type: "number", nullable: true },
+            regulatory_notes: { type: "string", nullable: true },
+            financial_stability_score: { type: "number", nullable: true },
+            financial_stability_notes: { type: "string", nullable: true },
+            client_money_score: { type: "number", nullable: true },
+            client_money_notes: { type: "string", nullable: true },
+            insurance_score: { type: "number", nullable: true },
+            insurance_notes: { type: "string", nullable: true },
+            platform_reliability_score: { type: "number", nullable: true },
+            platform_reliability_notes: { type: "string", nullable: true },
+            last_reviewed_at: {
+              type: "string",
+              format: "date-time",
+              nullable: true,
+            },
+            updated_at: { type: "string", format: "date-time" },
+          },
+        },
+        HealthScoreHistoryEntry: {
+          type: "object",
+          properties: {
+            broker_slug: { type: "string" },
+            overall_score: { type: "number" },
+            regulatory_score: { type: "number", nullable: true },
+            client_money_score: { type: "number", nullable: true },
+            financial_stability_score: { type: "number", nullable: true },
+            platform_reliability_score: { type: "number", nullable: true },
+            insurance_score: { type: "number", nullable: true },
+            captured_at: { type: "string", format: "date-time" },
+          },
+        },
+        FeeIndexSnapshot: {
+          type: "object",
+          properties: {
+            period: {
+              type: "string",
+              format: "date",
+              description: "UTC calendar day (YYYY-MM-DD)",
+            },
+            computed_at: { type: "string", format: "date-time" },
+            broker_count: { type: "integer" },
+            asx_fee_sample: { type: "integer" },
+            avg_asx_fee: { type: "number" },
+            median_asx_fee: { type: "number" },
+            avg_us_fee: { type: "number" },
+            median_us_fee: { type: "number" },
+            avg_fx_spread: { type: "number" },
+            median_fx_spread: { type: "number" },
+          },
+        },
+        FeeIndexTrend: {
+          type: "object",
+          nullable: true,
+          properties: {
+            quarter: {
+              type: "object",
+              nullable: true,
+              properties: {
+                avgAsxFee: { $ref: "#/components/schemas/TrendDelta" },
+                avgUsFee: { $ref: "#/components/schemas/TrendDelta" },
+                avgFxSpread: { $ref: "#/components/schemas/TrendDelta" },
+              },
+            },
+            year: {
+              type: "object",
+              nullable: true,
+              properties: {
+                avgAsxFee: { $ref: "#/components/schemas/TrendDelta" },
+                avgUsFee: { $ref: "#/components/schemas/TrendDelta" },
+                avgFxSpread: { $ref: "#/components/schemas/TrendDelta" },
+              },
+            },
+          },
+        },
+        TrendDelta: {
+          type: "object",
+          properties: {
+            previous: { type: "number" },
+            change: { type: "number" },
+            changePct: { type: "number" },
+          },
+        },
+      },
+    },
+    paths: {
+      "/brokers": {
+        get: {
+          operationId: "listBrokers",
+          summary: "List active brokers",
+          description:
+            "Returns all active brokers with public fields. Supports filtering by platform type, CHESS sponsorship, SMSF support. Paginated.",
+          tags: ["Brokers"],
+          parameters: [
+            {
+              name: "platform_type",
+              in: "query",
+              schema: {
+                type: "string",
+                enum: [
+                  "share_broker",
+                  "crypto_exchange",
+                  "cfd_forex",
+                  "multi_asset",
+                  "robo_advisor",
+                  "savings",
+                ],
+              },
+              description: "Filter by platform category",
+            },
+            {
+              name: "chess_sponsored",
+              in: "query",
+              schema: { type: "boolean" },
+              description: "Filter by CHESS sponsorship",
+            },
+            {
+              name: "smsf_support",
+              in: "query",
+              schema: { type: "boolean" },
+              description: "Filter by SMSF support",
+            },
+            {
+              name: "is_crypto",
+              in: "query",
+              schema: { type: "boolean" },
+              description: "Filter crypto exchanges",
+            },
+            {
+              name: "limit",
+              in: "query",
+              schema: { type: "integer", default: 20, minimum: 1, maximum: 100 },
+              description: "Results per page",
+            },
+            {
+              name: "offset",
+              in: "query",
+              schema: { type: "integer", default: 0, minimum: 0 },
+              description: "Pagination offset",
+            },
+          ],
+          responses: {
+            "200": {
+              description: "List of brokers",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      data: {
+                        type: "array",
+                        items: { $ref: "#/components/schemas/Broker" },
+                      },
+                      meta: { $ref: "#/components/schemas/PaginationMeta" },
+                    },
+                  },
+                },
+              },
+            },
+            "401": {
+              description: "Unauthorized",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "500": {
+              description: "Internal server error",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+          },
+        },
+      },
+      "/brokers/{slug}": {
+        get: {
+          operationId: "getBroker",
+          summary: "Get a single broker by slug",
+          description:
+            "Returns a broker's full public profile. Includes the last 10 fee changes.",
+          tags: ["Brokers"],
+          parameters: [
+            {
+              name: "slug",
+              in: "path",
+              required: true,
+              schema: { type: "string", example: "stake" },
+              description: "Broker URL slug",
+            },
+          ],
+          responses: {
+            "200": {
+              description: "Broker detail",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      data: { $ref: "#/components/schemas/BrokerDetail" },
+                    },
+                  },
+                },
+              },
+            },
+            "401": {
+              description: "Unauthorized",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "404": {
+              description: "Broker not found",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+          },
+        },
+      },
+      "/compare": {
+        get: {
+          operationId: "compareBrokers",
+          summary: "Compare up to 5 brokers side-by-side",
+          description:
+            "Returns broker data for the requested slugs in the same order. Maximum 5 brokers.",
+          tags: ["Brokers"],
+          parameters: [
+            {
+              name: "slugs",
+              in: "query",
+              required: true,
+              schema: { type: "string", example: "stake,selfwealth,commsec" },
+              description:
+                "Comma-separated broker slugs (max 5). Example: stake,selfwealth,commsec",
+            },
+          ],
+          responses: {
+            "200": {
+              description: "Comparison data",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      data: {
+                        type: "array",
+                        items: { $ref: "#/components/schemas/Broker" },
+                      },
+                      meta: {
+                        type: "object",
+                        properties: {
+                          requested: {
+                            type: "array",
+                            items: { type: "string" },
+                          },
+                          found: { type: "integer" },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            "400": {
+              description: "Bad request",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "401": {
+              description: "Unauthorized",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+          },
+        },
+      },
+      "/savings": {
+        get: {
+          operationId: "listSavings",
+          summary: "List savings accounts and term deposit platforms",
+          description:
+            "Returns savings account and term deposit platforms with the latest rate snapshots. Rate fields use basis points (bps): 525 bps = 5.25% p.a.",
+          tags: ["Savings & Term Deposits"],
+          parameters: [
+            {
+              name: "product_kind",
+              in: "query",
+              schema: {
+                type: "string",
+                enum: ["savings_account", "term_deposit"],
+              },
+              description: "Filter by product kind",
+            },
+            {
+              name: "limit",
+              in: "query",
+              schema: { type: "integer", default: 20, minimum: 1, maximum: 100 },
+              description: "Results per page",
+            },
+            {
+              name: "offset",
+              in: "query",
+              schema: { type: "integer", default: 0, minimum: 0 },
+              description: "Pagination offset",
+            },
+          ],
+          responses: {
+            "200": {
+              description: "List of savings platforms with rates",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      data: {
+                        type: "array",
+                        items: { $ref: "#/components/schemas/SavingsPlatform" },
+                      },
+                      meta: { $ref: "#/components/schemas/PaginationMeta" },
+                    },
+                  },
+                },
+              },
+            },
+            "401": {
+              description: "Unauthorized",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+          },
+        },
+      },
+      "/savings/{slug}": {
+        get: {
+          operationId: "getSavingsPlatform",
+          summary: "Get a single savings platform by slug",
+          description:
+            "Returns a savings platform's full public profile. Includes all current rate snapshots and rate history (last 30 per product_kind).",
+          tags: ["Savings & Term Deposits"],
+          parameters: [
+            {
+              name: "slug",
+              in: "path",
+              required: true,
+              schema: { type: "string", example: "ing-savings-maximiser" },
+              description: "Platform URL slug",
+            },
+          ],
+          responses: {
+            "200": {
+              description: "Savings platform detail",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      data: {
+                        allOf: [
+                          { $ref: "#/components/schemas/SavingsPlatform" },
+                          {
+                            type: "object",
+                            properties: {
+                              rates_by_kind: {
+                                type: "object",
+                                additionalProperties: {
+                                  type: "array",
+                                  items: {
+                                    $ref: "#/components/schemas/SavingsRate",
+                                  },
+                                },
+                                description:
+                                  "Rate history keyed by product_kind",
+                              },
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            "401": {
+              description: "Unauthorized",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "404": {
+              description: "Platform not found",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+          },
+        },
+      },
+      "/robo-advisors": {
+        get: {
+          operationId: "listRoboAdvisors",
+          summary: "List robo-advisor platforms",
+          description:
+            "Returns active robo-advisor platforms (automated investment services). Includes platforms like Stockspot, InvestSMART, Raiz, Spaceship, Six Park.",
+          tags: ["Robo-Advisors"],
+          parameters: [
+            {
+              name: "smsf_support",
+              in: "query",
+              schema: { type: "boolean" },
+              description: "Filter by SMSF support",
+            },
+            {
+              name: "limit",
+              in: "query",
+              schema: { type: "integer", default: 20, minimum: 1, maximum: 100 },
+              description: "Results per page",
+            },
+            {
+              name: "offset",
+              in: "query",
+              schema: { type: "integer", default: 0, minimum: 0 },
+              description: "Pagination offset",
+            },
+          ],
+          responses: {
+            "200": {
+              description: "List of robo-advisor platforms",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      data: {
+                        type: "array",
+                        items: { $ref: "#/components/schemas/RoboAdvisor" },
+                      },
+                      meta: { $ref: "#/components/schemas/PaginationMeta" },
+                    },
+                  },
+                },
+              },
+            },
+            "401": {
+              description: "Unauthorized",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+          },
+        },
+      },
+      "/robo-advisors/{slug}": {
+        get: {
+          operationId: "getRoboAdvisor",
+          summary: "Get a single robo-advisor by slug",
+          description:
+            "Returns a robo-advisor's full public profile. Includes fee changelog (last 10 changes).",
+          tags: ["Robo-Advisors"],
+          parameters: [
+            {
+              name: "slug",
+              in: "path",
+              required: true,
+              schema: { type: "string", example: "stockspot" },
+              description: "Robo-advisor URL slug",
+            },
+          ],
+          responses: {
+            "200": {
+              description: "Robo-advisor detail",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      data: { $ref: "#/components/schemas/RoboAdvisorDetail" },
+                    },
+                  },
+                },
+              },
+            },
+            "401": {
+              description: "Unauthorized",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "404": {
+              description: "Robo-advisor not found",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+          },
+        },
+      },
+      "/advisors": {
+        get: {
+          operationId: "listAdvisors",
+          summary: "List active financial advisors and professionals",
+          description:
+            "Returns active advisors with public profile fields. No PII, no billing data. Supports filtering and pagination.",
+          tags: ["Advisors"],
+          parameters: [
+            {
+              name: "type",
+              in: "query",
+              schema: { type: "string", example: "financial_planner" },
+              description:
+                "Professional type: financial_planner, smsf_accountant, property_advisor, tax_agent, mortgage_broker, wealth_manager, etc.",
+            },
+            {
+              name: "location_state",
+              in: "query",
+              schema: {
+                type: "string",
+                enum: ["NSW", "VIC", "QLD", "WA", "SA", "TAS", "ACT", "NT"],
+              },
+              description: "Filter by Australian state",
+            },
+            {
+              name: "verified",
+              in: "query",
+              schema: { type: "boolean" },
+              description: "Filter to verified advisors",
+            },
+            {
+              name: "accepts_new_clients",
+              in: "query",
+              schema: { type: "boolean" },
+              description: "Filter by new-client availability",
+            },
+            {
+              name: "limit",
+              in: "query",
+              schema: { type: "integer", default: 20, minimum: 1, maximum: 100 },
+              description: "Results per page",
+            },
+            {
+              name: "offset",
+              in: "query",
+              schema: { type: "integer", default: 0, minimum: 0 },
+              description: "Pagination offset",
+            },
+          ],
+          responses: {
+            "200": {
+              description: "List of advisors",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      data: {
+                        type: "array",
+                        items: { $ref: "#/components/schemas/Advisor" },
+                      },
+                      meta: { $ref: "#/components/schemas/PaginationMeta" },
+                    },
+                  },
+                },
+              },
+            },
+            "401": {
+              description: "Unauthorized",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+          },
+        },
+      },
+      "/advisors/{slug}": {
+        get: {
+          operationId: "getAdvisor",
+          summary: "Get a single advisor by slug",
+          description:
+            "Returns an advisor's full public profile. Includes qualifications, FAQs, and last 10 approved reviews.",
+          tags: ["Advisors"],
+          parameters: [
+            {
+              name: "slug",
+              in: "path",
+              required: true,
+              schema: { type: "string", example: "jane-smith-cfp" },
+              description: "Advisor URL slug",
+            },
+          ],
+          responses: {
+            "200": {
+              description: "Advisor detail",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      data: { $ref: "#/components/schemas/Advisor" },
+                    },
+                  },
+                },
+              },
+            },
+            "401": {
+              description: "Unauthorized",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "404": {
+              description: "Advisor not found",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+          },
+        },
+      },
+      "/fee-index": {
+        get: {
+          operationId: "getFeeIndex",
+          summary: "AU brokerage fee index",
+          description:
+            "Market-wide average and median ASX per-trade fee, US share fee, and FX spread across all tracked active brokers. Updated daily. Includes QoQ and YoY trend deltas. Factual aggregate data — not financial advice.",
+          tags: ["Market Data"],
+          parameters: [
+            {
+              name: "history",
+              in: "query",
+              schema: {
+                type: "integer",
+                default: 90,
+                minimum: 0,
+                maximum: 400,
+              },
+              description:
+                "Number of prior daily snapshots to include. Pass 0 for latest only.",
+            },
+          ],
+          responses: {
+            "200": {
+              description: "Fee index snapshot and history",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      data: {
+                        type: "object",
+                        properties: {
+                          latest: {
+                            $ref: "#/components/schemas/FeeIndexSnapshot",
+                            nullable: true,
+                          },
+                          trend: {
+                            $ref: "#/components/schemas/FeeIndexTrend",
+                          },
+                          history: {
+                            type: "array",
+                            items: {
+                              $ref: "#/components/schemas/FeeIndexSnapshot",
+                            },
+                          },
+                        },
+                      },
+                      meta: {
+                        type: "object",
+                        properties: {
+                          updated_at: {
+                            type: "string",
+                            format: "date-time",
+                            nullable: true,
+                          },
+                          history_days: { type: "integer" },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            "401": {
+              description: "Unauthorized",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+          },
+        },
+      },
+      "/health-scores": {
+        get: {
+          operationId: "listHealthScores",
+          summary: "List current broker health scores",
+          description:
+            "Returns current broker health scores across five dimensions: regulatory, financial stability, client money, insurance, and platform reliability. Scores are 0–100. This is informational data — not financial advice.",
+          tags: ["Health Scores"],
+          parameters: [
+            {
+              name: "broker_slug",
+              in: "query",
+              schema: { type: "string" },
+              description: "Filter to a specific broker by slug",
+            },
+            {
+              name: "min_score",
+              in: "query",
+              schema: { type: "number", minimum: 0, maximum: 100 },
+              description:
+                "Only return brokers with overall_score >= this value",
+            },
+            {
+              name: "limit",
+              in: "query",
+              schema: { type: "integer", default: 20, minimum: 1, maximum: 100 },
+              description: "Results per page",
+            },
+            {
+              name: "offset",
+              in: "query",
+              schema: { type: "integer", default: 0, minimum: 0 },
+              description: "Pagination offset",
+            },
+          ],
+          responses: {
+            "200": {
+              description: "List of broker health scores",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      data: {
+                        type: "array",
+                        items: { $ref: "#/components/schemas/HealthScore" },
+                      },
+                      meta: {
+                        allOf: [
+                          { $ref: "#/components/schemas/PaginationMeta" },
+                          {
+                            type: "object",
+                            properties: {
+                              disclaimer: { type: "string" },
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            "401": {
+              description: "Unauthorized",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+          },
+        },
+      },
+      "/health-scores/history": {
+        get: {
+          operationId: "getHealthScoreHistory",
+          summary: "Broker health score time-series history",
+          description:
+            "Returns the historical time-series of health scores for a specific broker from broker_health_score_history. Populated by the snapshot cron job. broker_slug is required.",
+          tags: ["Health Scores"],
+          parameters: [
+            {
+              name: "broker_slug",
+              in: "query",
+              required: true,
+              schema: { type: "string", example: "stake" },
+              description: "Broker slug to fetch history for",
+            },
+            {
+              name: "days",
+              in: "query",
+              schema: {
+                type: "integer",
+                default: 90,
+                minimum: 1,
+                maximum: 400,
+              },
+              description: "Number of days of history to return",
+            },
+            {
+              name: "limit",
+              in: "query",
+              schema: {
+                type: "integer",
+                default: 100,
+                minimum: 1,
+                maximum: 400,
+              },
+              description: "Max rows per page",
+            },
+            {
+              name: "offset",
+              in: "query",
+              schema: { type: "integer", default: 0, minimum: 0 },
+              description: "Pagination offset",
+            },
+          ],
+          responses: {
+            "200": {
+              description: "Health score history",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      data: {
+                        type: "array",
+                        items: {
+                          $ref: "#/components/schemas/HealthScoreHistoryEntry",
+                        },
+                      },
+                      meta: {
+                        type: "object",
+                        properties: {
+                          broker_slug: { type: "string" },
+                          total: { type: "integer" },
+                          limit: { type: "integer" },
+                          offset: { type: "integer" },
+                          days: { type: "integer" },
+                          updated_at: { type: "string", format: "date-time" },
+                          disclaimer: { type: "string" },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            "400": {
+              description: "broker_slug required",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "401": {
+              description: "Unauthorized",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+          },
+        },
+      },
+      "/api-keys": {
+        post: {
+          operationId: "createApiKey",
+          summary: "Request a new API key",
+          description:
+            "Request a new API key. The plain-text key is returned once and cannot be retrieved again. Maximum 3 keys per email.",
+          tags: ["Authentication"],
+          security: [],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  required: ["email", "name"],
+                  properties: {
+                    email: {
+                      type: "string",
+                      format: "email",
+                      description: "Your email address",
+                    },
+                    name: {
+                      type: "string",
+                      description: "A label for this API key",
+                    },
+                    company_name: {
+                      type: "string",
+                      description: "Your company or practice name",
+                    },
+                    use_case: {
+                      type: "string",
+                      description: "Brief description of intended use",
+                    },
+                  },
+                },
+              },
+            },
+          },
+          responses: {
+            "201": {
+              description: "API key created",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      api_key: {
+                        type: "string",
+                        description:
+                          "Plain-text API key — shown once, save securely",
+                      },
+                      key_prefix: { type: "string" },
+                      tier: {
+                        type: "string",
+                        enum: ["free", "basic", "pro", "enterprise"],
+                      },
+                      rate_limits: {
+                        type: "object",
+                        properties: {
+                          per_minute: { type: "integer" },
+                          per_day: { type: "integer" },
+                        },
+                      },
+                      message: { type: "string" },
+                    },
+                  },
+                },
+              },
+            },
+            "400": {
+              description: "Bad request",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "429": {
+              description: "Too many API keys for this email",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+          },
+        },
+      },
+      "/docs": {
+        get: {
+          operationId: "getDocs",
+          summary: "API documentation (JSON)",
+          description:
+            "Returns the API's human-readable documentation as a JSON object. No authentication required.",
+          tags: ["Meta"],
+          security: [],
+          responses: {
+            "200": {
+              description: "API docs",
+              content: {
+                "application/json": {
+                  schema: { type: "object" },
+                },
+              },
+            },
+          },
+        },
+      },
+      "/openapi.json": {
+        get: {
+          operationId: "getOpenApiSpec",
+          summary: "OpenAPI 3.1 specification",
+          description:
+            "Returns the full OpenAPI 3.1 specification for this API. No authentication required.",
+          tags: ["Meta"],
+          security: [],
+          responses: {
+            "200": {
+              description: "OpenAPI spec",
+              content: {
+                "application/json": {
+                  schema: { type: "object" },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+}

--- a/supabase/migrations/20260825000000_api_v1_platform_endpoints.sql
+++ b/supabase/migrations/20260825000000_api_v1_platform_endpoints.sql
@@ -1,0 +1,61 @@
+-- Migration: register new v1 endpoints in the API key allowed_endpoints column.
+--
+-- New endpoints added in this migration:
+--   /api/v1/savings             — savings account + term deposit list
+--   /api/v1/savings/:slug       — single savings platform detail
+--   /api/v1/robo-advisors       — robo-advisor list
+--   /api/v1/robo-advisors/:slug — single robo-advisor detail
+--   /api/v1/health-scores       — current broker health scores
+--   /api/v1/health-scores/history — health score time-series
+--   /api/v1/openapi.json        — OpenAPI 3.1 spec (public, but registered for completeness)
+--
+-- Context: the allowed_endpoints column is an informational/admin ACL field.
+-- The validateApiKey() flow (lib/api-auth.ts) does not enforce it at
+-- request-time — it is used by the admin UI to communicate per-key grants.
+--
+-- This migration:
+--   1. Updates the column DEFAULT so new keys include all new endpoints.
+--   2. Backfills existing active keys (opt-in expansion — no endpoint is removed).
+--
+-- Rollback strategy:
+--   ALTER TABLE api_keys ALTER COLUMN allowed_endpoints SET DEFAULT '{...previous...}';
+--   UPDATE api_keys SET allowed_endpoints = array_remove(allowed_endpoints, '/api/v1/savings'), ...;
+
+-- 1. Update column default to include all v1 endpoints
+ALTER TABLE api_keys
+  ALTER COLUMN allowed_endpoints
+    SET DEFAULT '{
+      "/api/v1/brokers",
+      "/api/v1/brokers/:slug",
+      "/api/v1/compare",
+      "/api/v1/advisors",
+      "/api/v1/advisors/:slug",
+      "/api/v1/fee-index",
+      "/api/v1/savings",
+      "/api/v1/savings/:slug",
+      "/api/v1/robo-advisors",
+      "/api/v1/robo-advisors/:slug",
+      "/api/v1/health-scores",
+      "/api/v1/health-scores/history",
+      "/api/v1/openapi.json"
+    }';
+
+-- 2. Backfill existing active keys — append new endpoints if not already present
+UPDATE api_keys
+SET
+  allowed_endpoints = (
+    SELECT array_agg(DISTINCT ep ORDER BY ep)
+    FROM unnest(
+      allowed_endpoints || ARRAY[
+        '/api/v1/savings',
+        '/api/v1/savings/:slug',
+        '/api/v1/robo-advisors',
+        '/api/v1/robo-advisors/:slug',
+        '/api/v1/health-scores',
+        '/api/v1/health-scores/history',
+        '/api/v1/openapi.json'
+      ]
+    ) AS ep
+  ),
+  updated_at = NOW()
+WHERE is_active = true;


### PR DESCRIPTION
Deepens the public REST API (brokers/advisors/fee-index) into a **fuller data platform**, mirroring the existing v1 auth/metering/logging exactly.

- **New vertical endpoints:** `/api/v1/savings` (+ `[slug]`, with rate snapshots) and `/api/v1/robo-advisors` (+ `[slug]`). (Super funds + ETFs skipped — no structured tables back them today; noted in the report.)
- **Time-series:** `/api/v1/health-scores` (current) + `/api/v1/health-scores/history` (from `broker_health_score_history`).
- **`/api/v1/openapi.json`** — a valid OpenAPI 3.1 doc generated from a single `lib/openapi-spec.ts` source describing all 15 paths.
- Migration backfills the 7 new endpoints into existing keys' `allowed_endpoints`; `/api/v1/docs` + `/api-docs` updated.

**Fixes on verification:** two TS errors in the savings route (a Supabase cast through `unknown`, and a safe `updated_at` access), a `let`→`const`, and an unused test helper.

**Verified:** `tsc` clean · **112 tests** (8 files) pass · eslint clean · rate-limit `--strict` 100%. Factual data only (AFSL-safe).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUfSRE2Teb6VhEXFP6RpS9)_