### PR TITLE
feat: Investor Pro command center — personal dashboard (deepen)

### DIFF
--- a/__tests__/api/pro-dashboard-gate.test.ts
+++ b/__tests__/api/pro-dashboard-gate.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Pro gate tests for /pro/dashboard.
+ *
+ * Covers the Pro gate logic (getSubscription → isPro) and the
+ * summary-assembly helper (assembleDashboardSummary) exercised by the
+ * page server component — without rendering JSX.
+ *
+ * Pattern mirrors __tests__/api/pro-insights-gate.test.ts:
+ *   vi.hoisted for shared mock fns, vi.mock at top, imports after.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterAll } from "vitest";
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+const { mockGetUser } = vi.hoisted(() => ({
+  mockGetUser: vi.fn(),
+}));
+
+// Subscription mock data — mutated per test.
+let subData: { status: string } | null = null;
+
+const mockServerFrom = vi.fn((table: string) => {
+  const chain: Record<string, unknown> = {};
+  chain.select = vi.fn(() => chain);
+  chain.eq = vi.fn(() => chain);
+  chain.in = vi.fn(() => chain);
+  chain.order = vi.fn(() => chain);
+  chain.limit = vi.fn(() => chain);
+  chain.gte = vi.fn(() => chain);
+  chain.not = vi.fn(() => chain);
+  chain.maybeSingle = vi.fn(async () => {
+    if (table === "subscriptions") return { data: subData, error: null };
+    return { data: null, error: null };
+  });
+  chain.single = vi.fn(async () => ({ data: null, error: null }));
+  return chain;
+});
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({
+    auth: { getUser: mockGetUser },
+    from: mockServerFrom,
+  })),
+}));
+
+// Admin client mock — used by rate_alert_subscriptions fetch
+const mockAdminFrom = vi.fn((_table: string) => {
+  const chain: Record<string, unknown> = {};
+  chain.select = vi.fn(() => chain);
+  chain.eq = vi.fn(() => chain);
+  chain.order = vi.fn(() => chain);
+  chain.limit = vi.fn().mockResolvedValue({ data: [], error: null });
+  return chain;
+});
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+
+// Minimal SEO stubs
+vi.mock("@/lib/seo", () => ({
+  absoluteUrl: (p: string) => `https://invest.com.au${p}`,
+  breadcrumbJsonLd: vi.fn(() => ({ "@context": "https://schema.org" })),
+  SITE_NAME: "Invest.com.au",
+  SITE_URL: "https://invest.com.au",
+  CURRENT_YEAR: 2026,
+}));
+
+// Stub getCurrentPricesBatch — not under test here
+vi.mock("@/lib/holdings/value", () => ({
+  getCurrentPricesBatch: vi.fn(async () => new Map()),
+  keyOf: (ticker: string, exchange: string) => `${ticker}|${exchange}`,
+}));
+
+// Stub listBookmarks — not under test here
+vi.mock("@/lib/bookmarks", () => ({
+  listBookmarks: vi.fn(async () => []),
+}));
+
+// ─── Imports (after mocks) ───────────────────────────────────────────────────
+
+import { getSubscription } from "@/lib/server/get-subscription";
+import { assembleDashboardSummary } from "@/app/pro/dashboard/page";
+
+// ─── Pro gate: getSubscription behaviour ────────────────────────────────────
+
+describe("Pro gate — getSubscription (dashboard)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    subData = null;
+  });
+
+  afterAll(() => vi.restoreAllMocks());
+
+  it("returns isPro=false for a signed-out user", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: null } });
+    const { isPro, user } = await getSubscription();
+    expect(isPro).toBe(false);
+    expect(user).toBeNull();
+  });
+
+  it("returns isPro=false for signed-in user with no subscription", async () => {
+    mockGetUser.mockResolvedValueOnce({
+      data: { user: { id: "u-1" } },
+    });
+    subData = null;
+    const { isPro } = await getSubscription();
+    expect(isPro).toBe(false);
+  });
+
+  it("returns isPro=true for status=active", async () => {
+    mockGetUser.mockResolvedValueOnce({
+      data: { user: { id: "u-2" } },
+    });
+    subData = { status: "active" };
+    const { isPro } = await getSubscription();
+    expect(isPro).toBe(true);
+  });
+
+  it("returns isPro=true for status=trialing", async () => {
+    mockGetUser.mockResolvedValueOnce({
+      data: { user: { id: "u-3" } },
+    });
+    subData = { status: "trialing" };
+    const { isPro } = await getSubscription();
+    expect(isPro).toBe(true);
+  });
+
+  it("returns isPro=false for status=past_due", async () => {
+    mockGetUser.mockResolvedValueOnce({
+      data: { user: { id: "u-4" } },
+    });
+    subData = { status: "past_due" };
+    const { isPro } = await getSubscription();
+    expect(isPro).toBe(false);
+  });
+});
+
+// ─── upgradeHref derivation ──────────────────────────────────────────────────
+
+describe("Pro dashboard — upgradeHref derivation", () => {
+  it("points to /account/upgrade for a signed-in non-Pro user", () => {
+    const user = { id: "u1" };
+    const upgradeHref = user ? "/account/upgrade" : "/auth/login?next=/pro/dashboard";
+    expect(upgradeHref).toBe("/account/upgrade");
+  });
+
+  it("points to login for a signed-out visitor", () => {
+    const user = null;
+    const upgradeHref = user ? "/account/upgrade" : "/auth/login?next=/pro/dashboard";
+    expect(upgradeHref).toBe("/auth/login?next=/pro/dashboard");
+  });
+});
+
+// ─── assembleDashboardSummary ────────────────────────────────────────────────
+
+describe("assembleDashboardSummary", () => {
+  const emptyParams = {
+    holdings: [] as { ticker: string | null; exchange: string | null; shares: number | null; cost_basis_per_share_cents: number | null }[],
+    priceMap: new Map<string, { priceCents: number } | null>(),
+    manualBalanceTotalCents: 0,
+    goalBalanceCents: 0,
+    alerts: [] as { last_notified_at: string | null }[],
+    watchlistCount: 0,
+    savedScenariosCount: 0,
+    activeDealsCount: 0,
+    bookmarksCount: 0,
+  };
+
+  it("returns zeroed summary for all-empty input", () => {
+    const summary = assembleDashboardSummary(emptyParams);
+    expect(summary.portfolioValueCents).toBe(0);
+    expect(summary.pricedHoldingsCount).toBe(0);
+    expect(summary.netWorthCents).toBe(0);
+    expect(summary.alertsCount).toBe(0);
+    expect(summary.watchlistCount).toBe(0);
+    expect(summary.savedScenariosCount).toBe(0);
+    expect(summary.activeDealsCount).toBe(0);
+    expect(summary.bookmarksCount).toBe(0);
+    expect(summary.hasActiveAlerts).toBe(false);
+  });
+
+  it("calculates portfolio value from priced holdings", () => {
+    const priceMap = new Map<string, { priceCents: number } | null>([
+      ["CBA|ASX", { priceCents: 10000 }], // $100.00
+      ["BHP|ASX", { priceCents: 5000 }],  // $50.00
+    ]);
+    const summary = assembleDashboardSummary({
+      ...emptyParams,
+      holdings: [
+        { ticker: "CBA", exchange: "ASX", shares: 10, cost_basis_per_share_cents: 9000 },
+        { ticker: "BHP", exchange: "ASX", shares: 5, cost_basis_per_share_cents: 4500 },
+      ],
+      priceMap,
+    });
+    // 10 * 10000 + 5 * 5000 = 125000
+    expect(summary.portfolioValueCents).toBe(125000);
+    expect(summary.holdingsCount).toBe(2);
+    expect(summary.pricedHoldingsCount).toBe(2);
+  });
+
+  it("skips holdings with no price in the priceMap", () => {
+    const summary = assembleDashboardSummary({
+      ...emptyParams,
+      holdings: [
+        { ticker: "XYZ", exchange: "ASX", shares: 100, cost_basis_per_share_cents: 500 },
+      ],
+      priceMap: new Map(), // no prices
+    });
+    expect(summary.portfolioValueCents).toBe(0);
+    expect(summary.holdingsCount).toBe(1);
+    expect(summary.pricedHoldingsCount).toBe(0);
+  });
+
+  it("sums netWorthCents from all three sources", () => {
+    const priceMap = new Map<string, { priceCents: number } | null>([["ABC|ASX", { priceCents: 1000 }]]);
+    const summary = assembleDashboardSummary({
+      ...emptyParams,
+      holdings: [{ ticker: "ABC", exchange: "ASX", shares: 2, cost_basis_per_share_cents: 800 }],
+      priceMap,
+      manualBalanceTotalCents: 50000,
+      goalBalanceCents: 30000,
+    });
+    // 2 * 1000 + 50000 + 30000 = 82000
+    expect(summary.netWorthCents).toBe(82000);
+  });
+
+  it("reflects alert count and hasActiveAlerts correctly", () => {
+    const summary = assembleDashboardSummary({
+      ...emptyParams,
+      alerts: [
+        { last_notified_at: null },
+        { last_notified_at: "2026-05-01T00:00:00Z" },
+        { last_notified_at: null },
+      ],
+    });
+    expect(summary.alertsCount).toBe(3);
+    expect(summary.hasActiveAlerts).toBe(true);
+  });
+
+  it("hasActiveAlerts is false when no alert has fired", () => {
+    const summary = assembleDashboardSummary({
+      ...emptyParams,
+      alerts: [
+        { last_notified_at: null },
+        { last_notified_at: null },
+      ],
+    });
+    expect(summary.hasActiveAlerts).toBe(false);
+  });
+
+  it("carries through watchlist, saved scenarios, deals and bookmarks counts", () => {
+    const summary = assembleDashboardSummary({
+      ...emptyParams,
+      watchlistCount: 4,
+      savedScenariosCount: 7,
+      activeDealsCount: 2,
+      bookmarksCount: 13,
+    });
+    expect(summary.watchlistCount).toBe(4);
+    expect(summary.savedScenariosCount).toBe(7);
+    expect(summary.activeDealsCount).toBe(2);
+    expect(summary.bookmarksCount).toBe(13);
+  });
+
+  it("ignores holdings with null ticker or exchange", () => {
+    const summary = assembleDashboardSummary({
+      ...emptyParams,
+      holdings: [
+        { ticker: null, exchange: "ASX", shares: 10, cost_basis_per_share_cents: 500 },
+        { ticker: "ABC", exchange: null, shares: 10, cost_basis_per_share_cents: 500 },
+      ],
+      priceMap: new Map<string, { priceCents: number } | null>([["ABC|ASX", { priceCents: 1000 }]]),
+    });
+    // Neither holding can be priced — ticker/exchange both required
+    expect(summary.portfolioValueCents).toBe(0);
+    // holdingsCount still reflects all rows
+    expect(summary.holdingsCount).toBe(2);
+  });
+});

--- a/app/pro/ProPageClient.tsx
+++ b/app/pro/ProPageClient.tsx
@@ -179,6 +179,17 @@ export default function ProPageClient() {
   // Pro member hub links shown only when the user already holds an active Pro subscription.
   const PRO_HUB_LINKS = [
     {
+      href: "/pro/dashboard",
+      icon: (
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+        </svg>
+      ),
+      title: "My Dashboard",
+      description: "Portfolio, net worth, alerts, watchlist, and deals — your personal overview",
+      badge: "NEW",
+    },
+    {
       href: "/pro/insights",
       icon: (
         <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -187,7 +198,7 @@ export default function ProPageClient() {
       ),
       title: "Insights Dashboard",
       description: "Full fee comparison, health-score movers, loan rate movements",
-      badge: "NEW",
+      badge: null,
     },
     {
       href: "/pro/research",
@@ -234,7 +245,7 @@ export default function ProPageClient() {
                 PRO MEMBER HUB
               </div>
             </div>
-            <div className="grid sm:grid-cols-3 gap-3">
+            <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-3">
               {PRO_HUB_LINKS.map((link) => (
                 <Link
                   key={link.href}

--- a/app/pro/dashboard/page.tsx
+++ b/app/pro/dashboard/page.tsx
@@ -237,7 +237,7 @@ export default async function ProDashboardPage() {
     ? "/account/upgrade"
     : "/auth/login?next=/pro/dashboard";
 
-  if (!isPro) {
+  if (!isPro || !user) {
     return (
       <div className="mx-auto max-w-2xl px-4 py-12">
         <script

--- a/app/pro/dashboard/page.tsx
+++ b/app/pro/dashboard/page.tsx
@@ -1,0 +1,518 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/server";
+// eslint-disable-next-line no-restricted-imports -- rate_alert_subscriptions has no anon/auth RLS policy; service-role required for cross-user reads
+import { createAdminClient } from "@/lib/supabase/admin";
+import { getSubscription } from "@/lib/server/get-subscription";
+import ProPaywall from "@/components/ProPaywall";
+import { absoluteUrl, breadcrumbJsonLd, SITE_NAME } from "@/lib/seo";
+import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
+import { getCurrentPricesBatch } from "@/lib/holdings/value";
+import { listBookmarks } from "@/lib/bookmarks";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: `My Dashboard — ${SITE_NAME}`,
+  description:
+    "Your personal Investor Pro command center — portfolio, net worth, alerts, watchlist, saved scenarios, and deals in one view.",
+  robots: { index: false, follow: false },
+  alternates: { canonical: "/pro/dashboard" },
+};
+
+// ─── Formatting helpers ────────────────────────────────────────────────────
+
+function fmtAUD(cents: number): string {
+  if (cents === 0) return "$0";
+  return new Intl.NumberFormat("en-AU", {
+    style: "currency",
+    currency: "AUD",
+    maximumFractionDigits: 0,
+  }).format(cents / 100);
+}
+
+// ─── Summary card ──────────────────────────────────────────────────────────
+
+function SummaryCard({
+  href,
+  icon,
+  title,
+  value,
+  sub,
+  ctaLabel,
+}: {
+  href: string;
+  icon: React.ReactNode;
+  title: string;
+  value: string;
+  sub?: string;
+  ctaLabel: string;
+}) {
+  return (
+    <Link
+      href={href}
+      className="group flex flex-col gap-3 rounded-xl border border-slate-200 bg-white p-5 hover:border-violet-300 hover:shadow-sm transition-all"
+    >
+      <div className="flex items-center justify-between gap-2">
+        <div className="w-9 h-9 bg-violet-50 text-violet-600 rounded-xl flex items-center justify-center shrink-0 group-hover:bg-violet-100 transition-colors">
+          {icon}
+        </div>
+        <span className="text-xs font-semibold text-violet-700 group-hover:text-violet-900 transition-colors">
+          {ctaLabel} →
+        </span>
+      </div>
+      <div>
+        <p className="text-xs font-semibold uppercase tracking-wider text-slate-500 mb-0.5">
+          {title}
+        </p>
+        <p className="text-2xl font-extrabold text-slate-900 tabular-nums leading-tight">
+          {value}
+        </p>
+        {sub && (
+          <p className="mt-0.5 text-xs text-slate-500 leading-relaxed">{sub}</p>
+        )}
+      </div>
+    </Link>
+  );
+}
+
+// ─── Icons ─────────────────────────────────────────────────────────────────
+
+function PortfolioIcon() {
+  return (
+    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" />
+    </svg>
+  );
+}
+
+function NetWorthIcon() {
+  return (
+    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+    </svg>
+  );
+}
+
+function AlertIcon() {
+  return (
+    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
+    </svg>
+  );
+}
+
+function WatchlistIcon() {
+  return (
+    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
+    </svg>
+  );
+}
+
+function ScenariosIcon() {
+  return (
+    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+    </svg>
+  );
+}
+
+function DealsIcon() {
+  return (
+    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z" />
+    </svg>
+  );
+}
+
+function BookmarksIcon() {
+  return (
+    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
+    </svg>
+  );
+}
+
+// ─── Data assembly helpers (importable for tests) ──────────────────────────
+
+export interface DashboardSummary {
+  /** Portfolio value in cents, from priced holdings */
+  portfolioValueCents: number;
+  /** Count of holdings tracked */
+  holdingsCount: number;
+  /** Number of holdings for which a price was found */
+  pricedHoldingsCount: number;
+  /** Total net-worth estimate in cents */
+  netWorthCents: number;
+  /** Number of active rate/fee alerts */
+  alertsCount: number;
+  /** Whether any alert has been notified (last_notified_at is non-null) */
+  hasActiveAlerts: boolean;
+  /** Watchlist item count */
+  watchlistCount: number;
+  /** Saved comparisons count */
+  savedScenariosCount: number;
+  /** Active pro deals count */
+  activeDealsCount: number;
+  /** Saved bookmarks count */
+  bookmarksCount: number;
+}
+
+interface HoldingForValue {
+  ticker: string | null;
+  exchange: string | null;
+  shares: number | null;
+  cost_basis_per_share_cents: number | null;
+}
+
+/**
+ * Assembles the dashboard summary data from pre-fetched rows.
+ * Exported so tests can exercise the logic without JSX rendering.
+ */
+export function assembleDashboardSummary(params: {
+  holdings: HoldingForValue[];
+  /** Map keyed by "TICKER|EXCHANGE". Value is null when price not available. */
+  priceMap: Map<string, { priceCents: number } | null>;
+  manualBalanceTotalCents: number;
+  goalBalanceCents: number;
+  alerts: { last_notified_at: string | null }[];
+  watchlistCount: number;
+  savedScenariosCount: number;
+  activeDealsCount: number;
+  bookmarksCount: number;
+}): DashboardSummary {
+  const {
+    holdings,
+    priceMap,
+    manualBalanceTotalCents,
+    goalBalanceCents,
+    alerts,
+    watchlistCount,
+    savedScenariosCount,
+    activeDealsCount,
+    bookmarksCount,
+  } = params;
+
+  let portfolioValueCents = 0;
+  let pricedCount = 0;
+  for (const h of holdings) {
+    if (!h.ticker || !h.exchange || !h.shares) continue;
+    const price = priceMap.get(`${h.ticker}|${h.exchange}`);
+    if (price?.priceCents != null) {
+      portfolioValueCents += Math.round(h.shares * price.priceCents);
+      pricedCount++;
+    }
+  }
+
+  const netWorthCents = portfolioValueCents + goalBalanceCents + manualBalanceTotalCents;
+  const hasActiveAlerts = alerts.some((a) => a.last_notified_at != null);
+
+  return {
+    portfolioValueCents,
+    holdingsCount: holdings.length,
+    pricedHoldingsCount: pricedCount,
+    netWorthCents,
+    alertsCount: alerts.length,
+    hasActiveAlerts,
+    watchlistCount,
+    savedScenariosCount,
+    activeDealsCount,
+    bookmarksCount,
+  };
+}
+
+// ─── Page ──────────────────────────────────────────────────────────────────
+
+export default async function ProDashboardPage() {
+  const { user, isPro } = await getSubscription();
+
+  const breadcrumbLd = breadcrumbJsonLd([
+    { name: "Home", url: absoluteUrl("/") },
+    { name: "Pro", url: absoluteUrl("/pro") },
+    { name: "My Dashboard" },
+  ]);
+
+  const upgradeHref = user
+    ? "/account/upgrade"
+    : "/auth/login?next=/pro/dashboard";
+
+  if (!isPro) {
+    return (
+      <div className="mx-auto max-w-2xl px-4 py-12">
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
+        />
+        <ProPaywall
+          title="Pro Dashboard"
+          description="Your personal command center — portfolio value, net worth, fee & rate alerts, watchlist, saved scenarios, and exclusive Pro deals all in one place."
+          ctaLabel={user ? "Upgrade to Pro" : "Sign in & subscribe"}
+          ctaHref={upgradeHref}
+          bullets={[
+            "Portfolio & net-worth totals pulled from your holdings",
+            "Active fee/rate alert count at a glance",
+            "Watchlist, saved comparisons, and bookmarks summary",
+          ]}
+        />
+      </div>
+    );
+  }
+
+  // ── Data fetching (Pro subscribers only reach here) ──────────────────────
+
+  const supabase = await createClient();
+  const admin = createAdminClient();
+
+  const userId = user.id;
+  const email = user.email ?? "";
+
+  const [
+    holdingsRes,
+    manualBalancesRes,
+    goalsRes,
+    watchlistRes,
+    savedScenariosRes,
+    activeDealsRes,
+  ] = await Promise.all([
+    supabase
+      .from("investor_holdings")
+      .select("ticker, exchange, shares, cost_basis_per_share_cents")
+      .eq("auth_user_id", userId),
+    supabase
+      .from("manual_balances")
+      .select("amount_cents"),
+    supabase
+      .from("investor_goals")
+      .select("current_balance_cents")
+      .eq("auth_user_id", userId),
+    supabase
+      .from("user_watchlist_items")
+      .select("id", { count: "exact", head: true })
+      .eq("user_id", userId),
+    supabase
+      .from("user_saved_comparisons")
+      .select("id", { count: "exact", head: true })
+      .eq("user_id", userId),
+    supabase
+      .from("pro_deals")
+      .select("id", { count: "exact", head: true })
+      .eq("status", "active"),
+  ]);
+
+  // rate_alert_subscriptions — service-role required (email-keyed, no auth RLS policy)
+  const alertsRes = await admin
+    .from("rate_alert_subscriptions")
+    .select("last_notified_at")
+    .eq("email", email.toLowerCase());
+
+  // Bookmarks — uses listBookmarks which already uses admin client internally
+  const bookmarks = await listBookmarks(userId);
+
+  const holdings = (holdingsRes.data ?? []) as HoldingForValue[];
+  const manualBalanceTotalCents = (manualBalancesRes.data ?? []).reduce(
+    (acc: number, b: { amount_cents: number }) => acc + (b.amount_cents ?? 0),
+    0,
+  );
+  const goalBalanceCents = (goalsRes.data ?? []).reduce(
+    (acc: number, g: { current_balance_cents: number }) =>
+      acc + (g.current_balance_cents ?? 0),
+    0,
+  );
+
+  // Fetch current prices for holdings in one batch
+  const pricePairs = holdings
+    .filter(
+      (h): h is HoldingForValue & { ticker: string; exchange: string } =>
+        typeof h.ticker === "string" && typeof h.exchange === "string",
+    )
+    .map((h) => ({ ticker: h.ticker, exchange: h.exchange }));
+
+  const priceMap = await getCurrentPricesBatch(pricePairs);
+
+  const summary = assembleDashboardSummary({
+    holdings,
+    priceMap,
+    manualBalanceTotalCents,
+    goalBalanceCents,
+    alerts: (alertsRes.data ?? []) as { last_notified_at: string | null }[],
+    watchlistCount: watchlistRes.count ?? 0,
+    savedScenariosCount: savedScenariosRes.count ?? 0,
+    activeDealsCount: activeDealsRes.count ?? 0,
+    bookmarksCount: bookmarks.length,
+  });
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-10 md:py-14">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
+      />
+
+      {/* Breadcrumb */}
+      <nav aria-label="Breadcrumb" className="mb-6 text-xs text-slate-500">
+        <Link href="/" className="hover:text-slate-900">Home</Link>
+        <span className="mx-1.5" aria-hidden="true">/</span>
+        <Link href="/pro" className="hover:text-slate-900">Pro</Link>
+        <span className="mx-1.5" aria-hidden="true">/</span>
+        <span className="text-slate-700">My Dashboard</span>
+      </nav>
+
+      {/* Header */}
+      <header className="mb-8">
+        <div className="inline-flex items-center gap-1.5 px-2.5 py-0.5 bg-amber-100 text-amber-700 text-xs font-bold rounded-full mb-3">
+          <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
+            <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+          </svg>
+          INVESTOR PRO · MY DASHBOARD
+        </div>
+        <h1 className="text-3xl font-bold text-slate-900">My Dashboard</h1>
+        <p className="mt-2 text-base text-slate-600 max-w-2xl">
+          Your personal investing overview — aggregated from your holdings,
+          alerts, watchlist, and saved work. General information only.
+        </p>
+      </header>
+
+      {/* Summary cards grid */}
+      <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
+
+        {/* Portfolio */}
+        <SummaryCard
+          href="/account/holdings"
+          icon={<PortfolioIcon />}
+          title="Investment portfolio"
+          value={
+            summary.holdingsCount === 0
+              ? "No holdings"
+              : fmtAUD(summary.portfolioValueCents)
+          }
+          sub={
+            summary.holdingsCount === 0
+              ? "Add your first holding to see your portfolio value"
+              : `${summary.pricedHoldingsCount} of ${summary.holdingsCount} holding${summary.holdingsCount === 1 ? "" : "s"} priced`
+          }
+          ctaLabel="Manage holdings"
+        />
+
+        {/* Net worth */}
+        <SummaryCard
+          href="/account/net-worth"
+          icon={<NetWorthIcon />}
+          title="Estimated net worth"
+          value={
+            summary.netWorthCents === 0
+              ? "Add data"
+              : fmtAUD(summary.netWorthCents)
+          }
+          sub="Holdings + goals + manual balances"
+          ctaLabel="View breakdown"
+        />
+
+        {/* Rate & fee alerts */}
+        <SummaryCard
+          href="/account/alerts"
+          icon={<AlertIcon />}
+          title="Rate & fee alerts"
+          value={
+            summary.alertsCount === 0
+              ? "None set"
+              : `${summary.alertsCount} alert${summary.alertsCount === 1 ? "" : "s"}`
+          }
+          sub={
+            summary.alertsCount === 0
+              ? "Set alerts to be notified when rates change"
+              : summary.hasActiveAlerts
+              ? "At least one alert has fired"
+              : "Monitoring — no change yet"
+          }
+          ctaLabel="Manage alerts"
+        />
+
+        {/* Watchlist */}
+        <SummaryCard
+          href="/account/watchlist"
+          icon={<WatchlistIcon />}
+          title="Watchlist"
+          value={
+            summary.watchlistCount === 0
+              ? "Empty"
+              : `${summary.watchlistCount} item${summary.watchlistCount === 1 ? "" : "s"}`
+          }
+          sub="Brokers and products you are tracking"
+          ctaLabel="View watchlist"
+        />
+
+        {/* Saved comparisons */}
+        <SummaryCard
+          href="/account/saved"
+          icon={<ScenariosIcon />}
+          title="Saved comparisons"
+          value={
+            summary.savedScenariosCount === 0
+              ? "None saved"
+              : `${summary.savedScenariosCount} scenario${summary.savedScenariosCount === 1 ? "" : "s"}`
+          }
+          sub="Broker comparisons and calculator snapshots"
+          ctaLabel="View saved"
+        />
+
+        {/* Pro deals */}
+        <SummaryCard
+          href="/pro/deals"
+          icon={<DealsIcon />}
+          title="Exclusive deals"
+          value={
+            summary.activeDealsCount === 0
+              ? "Check back soon"
+              : `${summary.activeDealsCount} deal${summary.activeDealsCount === 1 ? "" : "s"} live`
+          }
+          sub="Sign-up bonuses and reduced fees — Pro only"
+          ctaLabel="Browse deals"
+        />
+
+        {/* Bookmarks */}
+        <SummaryCard
+          href="/account/bookmarks"
+          icon={<BookmarksIcon />}
+          title="Reading list"
+          value={
+            summary.bookmarksCount === 0
+              ? "Empty"
+              : `${summary.bookmarksCount} saved`
+          }
+          sub="Articles, brokers, and advisors you have bookmarked"
+          ctaLabel="View bookmarks"
+        />
+
+      </div>
+
+      {/* Quick links to Pro tools */}
+      <section className="mt-10 pt-8 border-t border-slate-100">
+        <h2 className="text-sm font-semibold uppercase tracking-wider text-slate-500 mb-4">
+          Pro tools
+        </h2>
+        <div className="flex flex-wrap gap-3">
+          {[
+            { href: "/pro/insights", label: "Insights Dashboard" },
+            { href: "/pro/research", label: "Premium Research" },
+            { href: "/pro/deals", label: "Exclusive Deals" },
+          ].map((link) => (
+            <Link
+              key={link.href}
+              href={link.href}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-slate-200 bg-white text-sm font-medium text-slate-700 hover:border-violet-300 hover:text-violet-700 transition-colors"
+            >
+              {link.label}
+            </Link>
+          ))}
+        </div>
+      </section>
+
+      <footer className="mt-10 pt-6 border-t border-slate-100">
+        <p className="text-xs text-slate-400 leading-relaxed">
+          {GENERAL_ADVICE_WARNING}
+        </p>
+      </footer>
+    </div>
+  );
+}


### PR DESCRIPTION
Deepens Investor Pro with a **command center** — one Pro-gated page aggregating the member's *personal* surfaces (distinct from the `/pro/insights` market-data dashboard). Factual aggregation of the user's own data; no advice.

- New `app/pro/dashboard/page.tsx` (RSC, Pro-gated, `noindex`): 7 summary cards (portfolio value, net worth across holdings+goals+manual balances, active fee/rate alert count, watchlist, saved comparisons, deals, bookmarks), each linking to its full surface. Non-Pro → the same paywall pattern as `/pro/insights`.
- A pure `assembleDashboardSummary()` helper (tested) computing the totals from existing data helpers — **reuses** existing queries, doesn't rebuild them.
- Adds a "Dashboard" card to the Pro Member Hub in `ProPageClient.tsx`.

**Fix on verification:** the Pro gate now narrows `user` non-null (`!isPro || !user`) — resolves a tsc null-access + handles signed-out explicitly.

**Verified:** `tsc` clean · **15 tests** (gate states + summary assembly) pass · eslint clean. Admin client used only for the email-keyed `rate_alert_subscriptions` (documented exception). AFSL-safe.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUfSRE2Teb6VhEXFP6RpS9)_