### PR TITLE
feat: Advisor Trust Score — extend ratings to advisors (deepen)

### DIFF
--- a/__tests__/lib/advisor-trust-score.test.ts
+++ b/__tests__/lib/advisor-trust-score.test.ts
@@ -1,0 +1,631 @@
+/**
+ * __tests__/lib/advisor-trust-score.test.ts
+ *
+ * Unit tests for the Advisor Trust Score scorer.
+ *
+ * Covers:
+ *   - Each dimension in isolation (happy path + edge cases)
+ *   - Weighting / overall calculation
+ *   - Edge cases: no reviews, brand-new advisor, missing fields,
+ *     fully-populated advisor, all-zeros, all-maxed
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  computeAdvisorTrustScore,
+  trustScoreLabel,
+  trustScoreLabelColor,
+  WEIGHT_VERIFICATION,
+  WEIGHT_TRACK_RECORD,
+  WEIGHT_TRANSPARENCY,
+  WEIGHT_CLIENT_FEEDBACK,
+  type AdvisorTrustScoreInput,
+} from "@/lib/advisor-trust-score";
+
+/* ─── Helpers ─────────────────────────────────────────────────────────────── */
+
+/**
+ * Returns an ISO-8601 date N years ago from a fixed reference date.
+ * Uses millisecond arithmetic so fractional years work correctly
+ * (setFullYear truncates floats, so yearsAgo(0.2) would give 1 year with that approach).
+ */
+function yearsAgo(n: number): string {
+  const REF_MS = new Date("2026-05-25T00:00:00Z").getTime();
+  return new Date(REF_MS - n * 365.25 * 24 * 60 * 60 * 1000).toISOString();
+}
+
+/** Minimal valid input with no positive signals. */
+const BLANK: AdvisorTrustScoreInput = {
+  verified: null,
+  afsl_number: null,
+  registration_number: null,
+  verified_at: null,
+  created_at: null,
+  years_experience: null,
+  bio: null,
+  photo_url: null,
+  qualifications: null,
+  education: null,
+  memberships: null,
+  fee_structure: null,
+  fee_description: null,
+  linkedin_url: null,
+  website: null,
+  languages: null,
+  rating: null,
+  review_count: null,
+};
+
+/** Fully-populated "gold standard" advisor. */
+const GOLD: AdvisorTrustScoreInput = {
+  verified: true,
+  afsl_number: "123456",
+  registration_number: "1234567",
+  verified_at: new Date("2026-03-01T00:00:00Z").toISOString(), // within 12 months of 2026-05-25
+  created_at: yearsAgo(15),
+  years_experience: 20,
+  bio: "I have more than 20 years helping clients achieve financial independence.",
+  photo_url: "https://example.com/photo.jpg",
+  qualifications: ["CFP", "CPA"],
+  education: [{ institution: "UNSW", degree: "B.Comm" }],
+  memberships: ["FPA", "CFA Institute"],
+  fee_structure: "fee_only",
+  fee_description: "Flat annual retainer from $2,000",
+  linkedin_url: "https://linkedin.com/in/example",
+  website: "https://example.com",
+  languages: ["English", "Mandarin"],
+  rating: 5.0,
+  review_count: 30,
+};
+
+/* ─── Weight constants ─────────────────────────────────────────────────────── */
+
+describe("weight constants", () => {
+  it("weights sum to 1.0", () => {
+    const total =
+      WEIGHT_VERIFICATION +
+      WEIGHT_TRACK_RECORD +
+      WEIGHT_TRANSPARENCY +
+      WEIGHT_CLIENT_FEEDBACK;
+    expect(total).toBeCloseTo(1.0);
+  });
+});
+
+/* ─── trustScoreLabel ──────────────────────────────────────────────────────── */
+
+describe("trustScoreLabel", () => {
+  it("returns Strong for 80+", () => {
+    expect(trustScoreLabel(80)).toBe("Strong");
+    expect(trustScoreLabel(100)).toBe("Strong");
+  });
+  it("returns Good for 65–79", () => {
+    expect(trustScoreLabel(65)).toBe("Good");
+    expect(trustScoreLabel(79)).toBe("Good");
+  });
+  it("returns Moderate for 50–64", () => {
+    expect(trustScoreLabel(50)).toBe("Moderate");
+    expect(trustScoreLabel(64)).toBe("Moderate");
+  });
+  it("returns Limited below 50", () => {
+    expect(trustScoreLabel(0)).toBe("Limited");
+    expect(trustScoreLabel(49)).toBe("Limited");
+  });
+});
+
+/* ─── trustScoreLabelColor ────────────────────────────────────────────────── */
+
+describe("trustScoreLabelColor", () => {
+  it("returns emerald for 65+", () => {
+    expect(trustScoreLabelColor(65)).toContain("emerald");
+    expect(trustScoreLabelColor(80)).toContain("emerald");
+  });
+  it("returns amber for 50–64", () => {
+    expect(trustScoreLabelColor(50)).toContain("amber");
+  });
+  it("returns slate for below 50", () => {
+    expect(trustScoreLabelColor(40)).toContain("slate");
+  });
+});
+
+/* ─── Verification dimension ───────────────────────────────────────────────── */
+
+describe("verification dimension", () => {
+  it("blank profile → 0", () => {
+    const result = computeAdvisorTrustScore(BLANK);
+    const dim = result.dimensions.find((d) => d.key === "verification")!;
+    expect(dim.score).toBe(0);
+  });
+
+  it("verified only → 50 pts", () => {
+    const result = computeAdvisorTrustScore({ ...BLANK, verified: true });
+    const dim = result.dimensions.find((d) => d.key === "verification")!;
+    expect(dim.score).toBe(50);
+  });
+
+  it("AFSL present → +30 pts (on top of verified)", () => {
+    const result = computeAdvisorTrustScore({
+      ...BLANK,
+      verified: true,
+      afsl_number: "123456",
+    });
+    const dim = result.dimensions.find((d) => d.key === "verification")!;
+    expect(dim.score).toBe(80);
+  });
+
+  it("registration number → +10 pts more", () => {
+    const result = computeAdvisorTrustScore({
+      ...BLANK,
+      verified: true,
+      afsl_number: "123456",
+      registration_number: "AR-001",
+    });
+    const dim = result.dimensions.find((d) => d.key === "verification")!;
+    expect(dim.score).toBe(90);
+  });
+
+  it("freshness bonus: verified within 12 months → +10 pts on top", () => {
+    const result = computeAdvisorTrustScore({
+      ...BLANK,
+      verified: true,
+      verified_at: new Date("2026-03-01T00:00:00Z").toISOString(),
+    });
+    const dim = result.dimensions.find((d) => d.key === "verification")!;
+    // 50 (verified) + 10 (freshness) = 60
+    expect(dim.score).toBe(60);
+  });
+
+  it("freshness bonus: verified > 12 months ago → no bonus", () => {
+    const result = computeAdvisorTrustScore({
+      ...BLANK,
+      verified: true,
+      verified_at: yearsAgo(2),
+    });
+    const dim = result.dimensions.find((d) => d.key === "verification")!;
+    expect(dim.score).toBe(50); // no freshness bonus
+  });
+
+  it("AFSL with whitespace-only value → not counted", () => {
+    const result = computeAdvisorTrustScore({ ...BLANK, afsl_number: "   " });
+    const dim = result.dimensions.find((d) => d.key === "verification")!;
+    expect(dim.score).toBe(0);
+  });
+
+  it("full gold advisor → 100 (capped)", () => {
+    const result = computeAdvisorTrustScore(GOLD);
+    const dim = result.dimensions.find((d) => d.key === "verification")!;
+    expect(dim.score).toBe(100);
+  });
+
+  it("weight is WEIGHT_VERIFICATION", () => {
+    const result = computeAdvisorTrustScore(BLANK);
+    const dim = result.dimensions.find((d) => d.key === "verification")!;
+    expect(dim.weight).toBe(WEIGHT_VERIFICATION);
+  });
+});
+
+/* ─── Track Record dimension ───────────────────────────────────────────────── */
+
+describe("track_record dimension", () => {
+  it("blank input → 10 (floor)", () => {
+    const result = computeAdvisorTrustScore(BLANK);
+    const dim = result.dimensions.find((d) => d.key === "track_record")!;
+    expect(dim.score).toBe(10);
+  });
+
+  it("brand-new advisor (created_at < 1 year ago) → 10", () => {
+    const result = computeAdvisorTrustScore({
+      ...BLANK,
+      created_at: yearsAgo(0.2), // ~2-3 months
+    });
+    const dim = result.dimensions.find((d) => d.key === "track_record")!;
+    expect(dim.score).toBe(10);
+  });
+
+  it("1–2 years tenure → 25", () => {
+    const result = computeAdvisorTrustScore({
+      ...BLANK,
+      created_at: yearsAgo(1.5),
+    });
+    const dim = result.dimensions.find((d) => d.key === "track_record")!;
+    expect(dim.score).toBe(25);
+  });
+
+  it("3–4 years tenure → 40", () => {
+    const result = computeAdvisorTrustScore({
+      ...BLANK,
+      created_at: yearsAgo(3.5),
+    });
+    const dim = result.dimensions.find((d) => d.key === "track_record")!;
+    expect(dim.score).toBe(40);
+  });
+
+  it("5–6 years tenure → 55", () => {
+    const result = computeAdvisorTrustScore({
+      ...BLANK,
+      created_at: yearsAgo(5.5),
+    });
+    const dim = result.dimensions.find((d) => d.key === "track_record")!;
+    expect(dim.score).toBe(55);
+  });
+
+  it("7–9 years tenure → 70", () => {
+    const result = computeAdvisorTrustScore({
+      ...BLANK,
+      created_at: yearsAgo(8),
+    });
+    const dim = result.dimensions.find((d) => d.key === "track_record")!;
+    expect(dim.score).toBe(70);
+  });
+
+  it("10–14 years tenure → 85", () => {
+    const result = computeAdvisorTrustScore({
+      ...BLANK,
+      created_at: yearsAgo(12),
+    });
+    const dim = result.dimensions.find((d) => d.key === "track_record")!;
+    expect(dim.score).toBe(85);
+  });
+
+  it("15+ years tenure → 100", () => {
+    const result = computeAdvisorTrustScore({
+      ...BLANK,
+      created_at: yearsAgo(20),
+    });
+    const dim = result.dimensions.find((d) => d.key === "track_record")!;
+    expect(dim.score).toBe(100);
+  });
+
+  it("self-reported years_experience used when created_at is null", () => {
+    const result = computeAdvisorTrustScore({
+      ...BLANK,
+      years_experience: 12,
+    });
+    const dim = result.dimensions.find((d) => d.key === "track_record")!;
+    expect(dim.score).toBe(85);
+  });
+
+  it("picks max of tenure vs years_experience", () => {
+    // platform tenure = 3 years → score 40
+    // self-reported = 15 years → score 100
+    // should use 15 years → 100
+    const result = computeAdvisorTrustScore({
+      ...BLANK,
+      created_at: yearsAgo(3),
+      years_experience: 15,
+    });
+    const dim = result.dimensions.find((d) => d.key === "track_record")!;
+    expect(dim.score).toBe(100);
+  });
+
+  it("weight is WEIGHT_TRACK_RECORD", () => {
+    const result = computeAdvisorTrustScore(BLANK);
+    const dim = result.dimensions.find((d) => d.key === "track_record")!;
+    expect(dim.weight).toBe(WEIGHT_TRACK_RECORD);
+  });
+});
+
+/* ─── Transparency dimension ───────────────────────────────────────────────── */
+
+describe("transparency dimension", () => {
+  it("blank input → 0", () => {
+    const result = computeAdvisorTrustScore(BLANK);
+    const dim = result.dimensions.find((d) => d.key === "transparency")!;
+    expect(dim.score).toBe(0);
+  });
+
+  it("bio under 30 chars → not counted", () => {
+    const result = computeAdvisorTrustScore({ ...BLANK, bio: "Short bio." });
+    const dim = result.dimensions.find((d) => d.key === "transparency")!;
+    expect(dim.score).toBe(0);
+  });
+
+  it("bio 30+ chars → 20 pts", () => {
+    const result = computeAdvisorTrustScore({
+      ...BLANK,
+      bio: "This is a long enough bio that should count for points.",
+    });
+    const dim = result.dimensions.find((d) => d.key === "transparency")!;
+    expect(dim.score).toBe(20);
+  });
+
+  it("photo → 15 pts", () => {
+    const result = computeAdvisorTrustScore({
+      ...BLANK,
+      photo_url: "https://example.com/photo.jpg",
+    });
+    const dim = result.dimensions.find((d) => d.key === "transparency")!;
+    expect(dim.score).toBe(15);
+  });
+
+  it("qualifications array → 15 pts", () => {
+    const result = computeAdvisorTrustScore({
+      ...BLANK,
+      qualifications: ["CFP"],
+    });
+    const dim = result.dimensions.find((d) => d.key === "transparency")!;
+    expect(dim.score).toBe(15);
+  });
+
+  it("empty qualifications array → 0", () => {
+    const result = computeAdvisorTrustScore({ ...BLANK, qualifications: [] });
+    const dim = result.dimensions.find((d) => d.key === "transparency")!;
+    expect(dim.score).toBe(0);
+  });
+
+  it("fee_description alone → 15 pts", () => {
+    const result = computeAdvisorTrustScore({
+      ...BLANK,
+      fee_description: "Fixed annual fee from $2,000",
+    });
+    const dim = result.dimensions.find((d) => d.key === "transparency")!;
+    expect(dim.score).toBe(15);
+  });
+
+  it("linkedin_url → online presence (+10 pts)", () => {
+    const result = computeAdvisorTrustScore({
+      ...BLANK,
+      linkedin_url: "https://linkedin.com/in/test",
+    });
+    const dim = result.dimensions.find((d) => d.key === "transparency")!;
+    expect(dim.score).toBe(10);
+  });
+
+  it("languages with only 1 entry → not counted (need >1)", () => {
+    const result = computeAdvisorTrustScore({
+      ...BLANK,
+      languages: ["English"],
+    });
+    const dim = result.dimensions.find((d) => d.key === "transparency")!;
+    expect(dim.score).toBe(0);
+  });
+
+  it("2+ languages → 5 pts", () => {
+    const result = computeAdvisorTrustScore({
+      ...BLANK,
+      languages: ["English", "Mandarin"],
+    });
+    const dim = result.dimensions.find((d) => d.key === "transparency")!;
+    expect(dim.score).toBe(5);
+  });
+
+  it("gold advisor → 100 (capped)", () => {
+    const result = computeAdvisorTrustScore(GOLD);
+    const dim = result.dimensions.find((d) => d.key === "transparency")!;
+    expect(dim.score).toBe(100);
+  });
+
+  it("weight is WEIGHT_TRANSPARENCY", () => {
+    const result = computeAdvisorTrustScore(BLANK);
+    const dim = result.dimensions.find((d) => d.key === "transparency")!;
+    expect(dim.weight).toBe(WEIGHT_TRANSPARENCY);
+  });
+});
+
+/* ─── Client Feedback dimension ────────────────────────────────────────────── */
+
+describe("client_feedback dimension", () => {
+  it("no reviews → 0", () => {
+    const result = computeAdvisorTrustScore(BLANK);
+    const dim = result.dimensions.find((d) => d.key === "client_feedback")!;
+    expect(dim.score).toBe(0);
+  });
+
+  it("0 reviews via explicit zero → 0", () => {
+    const result = computeAdvisorTrustScore({
+      ...BLANK,
+      review_count: 0,
+      rating: 5.0,
+    });
+    const dim = result.dimensions.find((d) => d.key === "client_feedback")!;
+    expect(dim.score).toBe(0);
+  });
+
+  it("1 review, 5.0 rating → (20 + 100) / 2 = 60", () => {
+    const result = computeAdvisorTrustScore({
+      ...BLANK,
+      review_count: 1,
+      rating: 5.0,
+    });
+    const dim = result.dimensions.find((d) => d.key === "client_feedback")!;
+    expect(dim.score).toBe(60);
+  });
+
+  it("1 review, 3.0 rating → (20 + 0) / 2 = 10", () => {
+    const result = computeAdvisorTrustScore({
+      ...BLANK,
+      review_count: 1,
+      rating: 3.0,
+    });
+    const dim = result.dimensions.find((d) => d.key === "client_feedback")!;
+    expect(dim.score).toBe(10);
+  });
+
+  it("rating below 3.0 → quality sub-score 0", () => {
+    const result = computeAdvisorTrustScore({
+      ...BLANK,
+      review_count: 5,
+      rating: 2.0,
+    });
+    const dim = result.dimensions.find((d) => d.key === "client_feedback")!;
+    // volume: 60, quality: 0 → avg 30
+    expect(dim.score).toBe(30);
+  });
+
+  it("5 reviews, 4.0 rating → expected combined", () => {
+    // volume 5 → 60; quality: (4.0 - 3.0)/2.0 * 100 = 50 → avg = 55
+    const result = computeAdvisorTrustScore({
+      ...BLANK,
+      review_count: 5,
+      rating: 4.0,
+    });
+    const dim = result.dimensions.find((d) => d.key === "client_feedback")!;
+    expect(dim.score).toBe(55);
+  });
+
+  it("10 reviews, 4.5 rating → expected combined", () => {
+    // volume 10 → 80; quality: (4.5 - 3.0)/2.0 * 100 = 75 → avg = 77 (rounded from 77.5)
+    const result = computeAdvisorTrustScore({
+      ...BLANK,
+      review_count: 10,
+      rating: 4.5,
+    });
+    const dim = result.dimensions.find((d) => d.key === "client_feedback")!;
+    expect(dim.score).toBe(78); // Math.round((80 + 75) / 2) = 78 (JS rounds 77.5 to 78)
+  });
+
+  it("20+ reviews, 5.0 → 100", () => {
+    const result = computeAdvisorTrustScore({
+      ...BLANK,
+      review_count: 25,
+      rating: 5.0,
+    });
+    const dim = result.dimensions.find((d) => d.key === "client_feedback")!;
+    expect(dim.score).toBe(100);
+  });
+
+  it("weight is WEIGHT_CLIENT_FEEDBACK", () => {
+    const result = computeAdvisorTrustScore(BLANK);
+    const dim = result.dimensions.find((d) => d.key === "client_feedback")!;
+    expect(dim.weight).toBe(WEIGHT_CLIENT_FEEDBACK);
+  });
+});
+
+/* ─── Overall computation ───────────────────────────────────────────────────── */
+
+describe("computeAdvisorTrustScore — overall", () => {
+  it("blank input → low overall score", () => {
+    const result = computeAdvisorTrustScore(BLANK);
+    // Only non-zero signal is track_record floor (10pts × 0.25 = 2.5)
+    expect(result.overall).toBeLessThan(10);
+  });
+
+  it("gold advisor → overall ≥ 90", () => {
+    const result = computeAdvisorTrustScore(GOLD);
+    expect(result.overall).toBeGreaterThanOrEqual(90);
+  });
+
+  it("overall is rounded integer in [0, 100]", () => {
+    for (const input of [BLANK, GOLD]) {
+      const result = computeAdvisorTrustScore(input);
+      expect(result.overall).toBeGreaterThanOrEqual(0);
+      expect(result.overall).toBeLessThanOrEqual(100);
+      expect(Number.isInteger(result.overall)).toBe(true);
+    }
+  });
+
+  it("returns exactly 4 dimensions", () => {
+    const result = computeAdvisorTrustScore(BLANK);
+    expect(result.dimensions).toHaveLength(4);
+  });
+
+  it("overall equals weighted sum of dimension scores", () => {
+    const result = computeAdvisorTrustScore(GOLD);
+    const manual = Math.round(
+      result.dimensions.reduce((sum, d) => sum + d.score * d.weight, 0),
+    );
+    expect(result.overall).toBe(manual);
+  });
+
+  it("label matches overall score band", () => {
+    const strong = computeAdvisorTrustScore(GOLD);
+    expect(strong.label).toBe("Strong");
+
+    const blank = computeAdvisorTrustScore(BLANK);
+    expect(blank.label).toBe("Limited");
+  });
+
+  it("computedAt defaults to a recent ISO string", () => {
+    const before = Date.now();
+    const result = computeAdvisorTrustScore(BLANK);
+    const after = Date.now();
+    const ts = new Date(result.computedAt).getTime();
+    expect(ts).toBeGreaterThanOrEqual(before);
+    expect(ts).toBeLessThanOrEqual(after);
+  });
+
+  it("accepts an explicit computedAt value", () => {
+    const ts = "2026-01-01T00:00:00Z";
+    const result = computeAdvisorTrustScore(BLANK, ts);
+    expect(result.computedAt).toBe(ts);
+  });
+});
+
+/* ─── Edge cases ────────────────────────────────────────────────────────────── */
+
+describe("edge cases", () => {
+  it("review_count as null treated as 0", () => {
+    const result = computeAdvisorTrustScore({
+      ...BLANK,
+      review_count: null,
+      rating: 4.8,
+    });
+    const dim = result.dimensions.find((d) => d.key === "client_feedback")!;
+    expect(dim.score).toBe(0);
+  });
+
+  it("years_experience of 0 is ignored", () => {
+    const result = computeAdvisorTrustScore({ ...BLANK, years_experience: 0 });
+    const dim = result.dimensions.find((d) => d.key === "track_record")!;
+    // created_at null + years_experience 0 → null → floor 10
+    expect(dim.score).toBe(10);
+  });
+
+  it("brand-new advisor with no reviews, no AFSL, no bio produces a low but non-zero score", () => {
+    const result = computeAdvisorTrustScore({
+      ...BLANK,
+      created_at: new Date().toISOString(),
+    });
+    // track_record floor gives 10 pts × 0.25 = 2.5 → rounds to ~3
+    expect(result.overall).toBeGreaterThan(0);
+    expect(result.overall).toBeLessThan(10);
+  });
+
+  it("advisor with only a photo and bio still returns a valid result", () => {
+    const result = computeAdvisorTrustScore({
+      ...BLANK,
+      photo_url: "https://cdn.example.com/photo.jpg",
+      bio: "Twenty years of experience helping clients reach their financial goals.",
+    });
+    expect(result.overall).toBeGreaterThan(0);
+    expect(result.dimensions).toHaveLength(4);
+  });
+
+  it("rating exactly at the 3.0 floor → quality sub-score 0", () => {
+    const result = computeAdvisorTrustScore({
+      ...BLANK,
+      review_count: 10,
+      rating: 3.0,
+    });
+    const dim = result.dimensions.find((d) => d.key === "client_feedback")!;
+    // volume 10 → 80, quality → 0, avg → 40
+    expect(dim.score).toBe(40);
+  });
+
+  it("rating above 5.0 is clamped to 100 quality", () => {
+    // Should not be possible in practice, but guard against bad data
+    const result = computeAdvisorTrustScore({
+      ...BLANK,
+      review_count: 20,
+      rating: 6.0, // data anomaly
+    });
+    const dim = result.dimensions.find((d) => d.key === "client_feedback")!;
+    // quality clamped to 100, volume 100 → avg 100
+    expect(dim.score).toBe(100);
+  });
+
+  it("rationale strings are non-empty for every dimension", () => {
+    const result = computeAdvisorTrustScore(BLANK);
+    for (const d of result.dimensions) {
+      expect(typeof d.rationale).toBe("string");
+      expect(d.rationale.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("description strings are non-empty for every dimension", () => {
+    const result = computeAdvisorTrustScore(GOLD);
+    for (const d of result.dimensions) {
+      expect(typeof d.description).toBe("string");
+      expect(d.description.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/app/advisor/[slug]/components/AdvisorTrustScoreSection.tsx
+++ b/app/advisor/[slug]/components/AdvisorTrustScoreSection.tsx
@@ -1,0 +1,256 @@
+/**
+ * AdvisorTrustScoreSection
+ *
+ * Server-renderable (RSC) section that displays the Advisor Trust Score
+ * on a professional's public profile page. Pure SVG + HTML — no client deps.
+ *
+ * Displays:
+ *   - Overall score gauge (SVG, same approach as broker ScoreGauge)
+ *   - Per-dimension score bars with rationales
+ *   - Short methodology blurb with link to full methodology page
+ *   - GENERAL_ADVICE_WARNING from lib/compliance
+ *
+ * AFSL safety: the section is clearly labelled as factual/informational,
+ * contains the general advice warning, and links to the full methodology.
+ * It does not rank advisors against each other on this page.
+ */
+
+import Link from "next/link";
+import type { AdvisorTrustScore } from "@/lib/advisor-trust-score";
+
+/* ─── SVG Gauge ─── */
+
+function TrustScoreGauge({
+  score,
+  size = 112,
+}: {
+  score: number;
+  size?: number;
+}) {
+  const r = (size - 14) / 2;
+  const circumference = 2 * Math.PI * r;
+  const progress = (score / 100) * circumference;
+  const gaugeColor =
+    score >= 80 ? "#10b981" : score >= 50 ? "#f59e0b" : "#94a3b8";
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox={`0 0 ${size} ${size}`}
+      role="img"
+      aria-label={`Advisor Trust Score: ${score} out of 100`}
+      className="shrink-0"
+    >
+      {/* Track */}
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={r}
+        fill="none"
+        stroke="#e2e8f0"
+        strokeWidth="9"
+      />
+      {/* Progress arc */}
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={r}
+        fill="none"
+        stroke={gaugeColor}
+        strokeWidth="9"
+        strokeLinecap="round"
+        strokeDasharray={`${progress} ${circumference}`}
+        transform={`rotate(-90 ${size / 2} ${size / 2})`}
+      />
+      {/* Score number */}
+      <text
+        x={size / 2}
+        y={size / 2 - 4}
+        textAnchor="middle"
+        dominantBaseline="middle"
+        fontSize="22"
+        fontWeight="800"
+        fill="#0f172a"
+      >
+        {score}
+      </text>
+      {/* /100 label */}
+      <text
+        x={size / 2}
+        y={size / 2 + 16}
+        textAnchor="middle"
+        fontSize="9"
+        fontWeight="500"
+        fill="#94a3b8"
+      >
+        / 100
+      </text>
+    </svg>
+  );
+}
+
+/* ─── Bar colour helpers ─── */
+
+function barColor(score: number): string {
+  if (score >= 80) return "bg-emerald-500";
+  if (score >= 50) return "bg-amber-400";
+  return "bg-slate-300";
+}
+
+function labelColor(score: number): string {
+  if (score >= 80) return "text-emerald-600";
+  if (score >= 50) return "text-amber-600";
+  return "text-slate-400";
+}
+
+/* ─── Component ─── */
+
+export default function AdvisorTrustScoreSection({
+  trustScore,
+  advisorName,
+  generalAdviceWarning,
+}: {
+  trustScore: AdvisorTrustScore;
+  advisorName: string;
+  generalAdviceWarning: string;
+}) {
+  return (
+    <section
+      aria-labelledby="trust-score-heading"
+      className="bg-white border border-slate-200 rounded-2xl overflow-hidden"
+    >
+      {/* Section header */}
+      <div className="flex items-center gap-3 px-5 py-4 border-b border-slate-100 bg-slate-50/60">
+        {/* Shield icon */}
+        <span
+          className="inline-flex items-center justify-center w-8 h-8 rounded-lg bg-slate-100 shrink-0"
+          aria-hidden="true"
+        >
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="#475569"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+          </svg>
+        </span>
+        <div>
+          <h2
+            id="trust-score-heading"
+            className="text-sm font-bold text-slate-800"
+          >
+            Trust Score
+          </h2>
+          <p className="text-xs text-slate-400 leading-tight">
+            Factual credential &amp; compliance signals &mdash; not a recommendation
+          </p>
+        </div>
+      </div>
+
+      {/* Score summary row */}
+      <div className="flex flex-col sm:flex-row items-center sm:items-start gap-5 px-5 py-5 border-b border-slate-100">
+        <TrustScoreGauge score={trustScore.overall} size={112} />
+        <div className="flex-1 text-center sm:text-left">
+          <p className="text-xs text-slate-400 mb-0.5">Overall Trust Score</p>
+          <p
+            className={`text-2xl font-extrabold mb-1 ${labelColor(trustScore.overall)}`}
+          >
+            {trustScore.label}
+          </p>
+          <p className="text-xs text-slate-500 leading-relaxed max-w-sm">
+            This score for{" "}
+            <strong className="text-slate-700">{advisorName}</strong> is
+            computed from four factual dimensions: credential verification,
+            platform tenure, profile transparency, and client review record.
+          </p>
+          <p className="mt-2 text-xs">
+            <Link
+              href="/advisor/trust-score-methodology"
+              className="text-slate-500 hover:text-slate-700 underline underline-offset-2"
+            >
+              How is this score calculated?
+            </Link>
+          </p>
+        </div>
+      </div>
+
+      {/* Dimension breakdown */}
+      <div className="px-5 py-5 space-y-4">
+        {trustScore.dimensions.map((dim) => (
+          <div key={dim.key}>
+            <div className="flex items-center justify-between mb-1">
+              <div>
+                <span className="text-xs font-semibold text-slate-700">
+                  {dim.label}
+                </span>
+                <span className="ml-1.5 text-xs text-slate-400">
+                  ({(dim.weight * 100).toFixed(0)}% weight)
+                </span>
+              </div>
+              <span
+                className={`text-xs font-bold tabular-nums ${labelColor(dim.score)}`}
+              >
+                {dim.score}
+                <span className="text-slate-300 font-normal">/100</span>
+              </span>
+            </div>
+            {/* Progress bar */}
+            <div className="h-2 bg-slate-100 rounded-full overflow-hidden mb-1.5">
+              <div
+                className={`h-full rounded-full ${barColor(dim.score)}`}
+                style={{ width: `${dim.score}%` }}
+                role="presentation"
+              />
+            </div>
+            {/* Dimension description */}
+            <p className="text-xs text-slate-400 leading-relaxed">
+              {dim.description}
+            </p>
+            {/* Rationale */}
+            {dim.rationale && (
+              <p className="text-xs text-slate-500 mt-0.5 italic">
+                {dim.rationale}
+              </p>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {/* Methodology note + compliance warning */}
+      <div className="px-5 pb-5 space-y-3">
+        {/* Methodology link */}
+        <div className="bg-slate-50 border border-slate-100 rounded-xl px-4 py-3">
+          <p className="text-xs font-semibold text-slate-600 mb-0.5">
+            Methodology
+          </p>
+          <p className="text-xs text-slate-500 leading-relaxed">
+            The Trust Score is a factual composite of four dimensions:
+            Verification &amp; Registration ({(trustScore.dimensions[0]?.weight ?? 0.30) * 100}%),
+            Track Record ({(trustScore.dimensions[1]?.weight ?? 0.25) * 100}%),
+            Profile Transparency ({(trustScore.dimensions[2]?.weight ?? 0.25) * 100}%),
+            and Client Feedback ({(trustScore.dimensions[3]?.weight ?? 0.20) * 100}%).
+            Scores are computed on-read from current profile data.{" "}
+            <Link
+              href="/advisor/trust-score-methodology"
+              className="underline hover:text-slate-700"
+            >
+              Full methodology &rarr;
+            </Link>
+          </p>
+        </div>
+
+        {/* General advice warning */}
+        <p className="text-[11px] text-slate-400 leading-relaxed">
+          <strong className="font-semibold">General Advice Warning:</strong>{" "}
+          {generalAdviceWarning}
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/app/advisor/[slug]/page.tsx
+++ b/app/advisor/[slug]/page.tsx
@@ -15,6 +15,9 @@ import {
   getProviderOutcomeBadge,
   getPublicTestimonials,
 } from "@/lib/outcomes/profile-display";
+import { computeAdvisorTrustScore } from "@/lib/advisor-trust-score";
+import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
+import AdvisorTrustScoreSection from "./components/AdvisorTrustScoreSection";
 
 export const revalidate = 1800;
 
@@ -286,6 +289,28 @@ export default async function AdvisorProfilePage({ params }: { params: Promise<{
     return "Contact for pricing";
   }
 
+  // ── Advisor Trust Score (computed on-read from existing profile data) ──
+  const trustScore = computeAdvisorTrustScore({
+    verified: pro.verified,
+    afsl_number: pro.afsl_number,
+    registration_number: pro.registration_number,
+    verified_at: pro.verified_at,
+    created_at: pro.created_at,
+    years_experience: pro.years_experience,
+    bio: pro.bio,
+    photo_url: pro.photo_url,
+    qualifications: pro.qualifications as unknown[] | null,
+    education: pro.education as unknown[] | null,
+    memberships: pro.memberships as unknown[] | null,
+    fee_structure: pro.fee_structure,
+    fee_description: pro.fee_description,
+    linkedin_url: pro.linkedin_url,
+    website: pro.website,
+    languages: pro.languages as unknown[] | null,
+    rating: pro.rating,
+    review_count: pro.review_count,
+  });
+
   return (
     <>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }} />
@@ -467,6 +492,15 @@ export default async function AdvisorProfilePage({ params }: { params: Promise<{
 
         </div>
       )}
+
+      {/* ── Advisor Trust Score section ── */}
+      <div className="container-custom max-w-4xl mt-6">
+        <AdvisorTrustScoreSection
+          trustScore={trustScore}
+          advisorName={pro.name}
+          generalAdviceWarning={GENERAL_ADVICE_WARNING}
+        />
+      </div>
 
       {/* Outcome-flywheel badge + verified testimonials — fetched in
           parallel above. Renders below the main profile so it

--- a/app/advisor/trust-score-methodology/page.tsx
+++ b/app/advisor/trust-score-methodology/page.tsx
@@ -149,7 +149,7 @@ export default function TrustScoreMethodologyPage() {
             The Trust Score is a{" "}
             <strong>factual composite of credential and compliance signals</strong>{" "}
             drawn from publicly available and platform-verifiable data. It is not a
-            recommendation, personal advice, or a "best advisor" ranking. It is a
+            recommendation, personal advice, or a &ldquo;best advisor&rdquo; ranking. It is a
             transparency tool to help consumers understand an advisor&rsquo;s verifiable standing.
           </p>
         </div>

--- a/app/advisor/trust-score-methodology/page.tsx
+++ b/app/advisor/trust-score-methodology/page.tsx
@@ -1,0 +1,499 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { breadcrumbJsonLd, absoluteUrl, CURRENT_YEAR, SITE_NAME } from "@/lib/seo";
+import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
+import {
+  WEIGHT_VERIFICATION,
+  WEIGHT_TRACK_RECORD,
+  WEIGHT_TRANSPARENCY,
+  WEIGHT_CLIENT_FEEDBACK,
+} from "@/lib/advisor-trust-score";
+
+export const revalidate = 86400;
+
+export const metadata: Metadata = {
+  title: `Advisor Trust Score Methodology — How We Calculate It (${CURRENT_YEAR})`,
+  description:
+    "Full methodology for the Invest.com.au Advisor Trust Score: what data we use, " +
+    "how each of the four dimensions is scored, and how the overall score is calculated. " +
+    "Factual credential signals only — not a recommendation.",
+  alternates: { canonical: "/advisor/trust-score-methodology" },
+  openGraph: {
+    title: "Advisor Trust Score Methodology",
+    description:
+      "How Invest.com.au computes the Advisor Trust Score from factual credential and " +
+      "compliance signals. Four dimensions, named-constant weights, fully transparent.",
+    url: "/advisor/trust-score-methodology",
+  },
+};
+
+const DIMENSIONS = [
+  {
+    key: "verification",
+    label: "Verification & Registration",
+    weight: WEIGHT_VERIFICATION,
+    color: "bg-blue-500",
+    signals: [
+      { signal: "Profile verified by Invest.com.au editorial team", pts: 50 },
+      { signal: "AFSL number present on profile", pts: 30 },
+      { signal: "Registration number present (AR, Credit Rep, MARN, etc.)", pts: 10 },
+      { signal: "Verification is current (within the past 12 months)", pts: 10 },
+    ],
+    notes:
+      "Verification is cross-checked against ASIC Professional Registers. " +
+      "An AFSL number alone does not guarantee the licence is current — verification " +
+      "additionally confirms the status is active at the time of review.",
+  },
+  {
+    key: "track_record",
+    label: "Track Record",
+    weight: WEIGHT_TRACK_RECORD,
+    color: "bg-violet-500",
+    bands: [
+      { years: "15+ years", score: 100 },
+      { years: "10–14 years", score: 85 },
+      { years: "7–9 years", score: 70 },
+      { years: "5–6 years", score: 55 },
+      { years: "3–4 years", score: 40 },
+      { years: "1–2 years", score: 25 },
+      { years: "< 1 year or no data", score: 10 },
+    ],
+    notes:
+      "The higher of two signals is used: (a) self-reported years of professional experience, " +
+      "or (b) time since the advisor joined the Invest.com.au platform. " +
+      "This dimension reflects observable tenure only — it does not imply investment performance, " +
+      "suitability, or quality of advice.",
+  },
+  {
+    key: "transparency",
+    label: "Profile Transparency",
+    weight: WEIGHT_TRANSPARENCY,
+    color: "bg-teal-500",
+    signals: [
+      { signal: "Biography (30+ characters)", pts: 20 },
+      { signal: "Profile photo", pts: 15 },
+      { signal: "Qualifications list", pts: 15 },
+      { signal: "Fee structure or fee description", pts: 15 },
+      { signal: "Education history", pts: 10 },
+      { signal: "Professional memberships", pts: 10 },
+      { signal: "Online presence (LinkedIn or website)", pts: 10 },
+      { signal: "Multiple languages spoken", pts: 5 },
+    ],
+    notes:
+      "Points are awarded for each field the advisor has populated. " +
+      "Maximum 100 (all fields complete). This dimension measures disclosure, " +
+      "not the content of the disclosure.",
+  },
+  {
+    key: "client_feedback",
+    label: "Client Feedback",
+    weight: WEIGHT_CLIENT_FEEDBACK,
+    color: "bg-amber-500",
+    feedbackNote: true,
+    notes:
+      "The score is the average of two equal-weight sub-scores: " +
+      "(1) Volume — how many approved reviews the advisor has collected; " +
+      "(2) Quality — how the average star rating maps to a 0–100 scale. " +
+      "For the quality sub-score the range [3.0 stars, 5.0 stars] is mapped " +
+      "linearly to [0, 100]; a rating below 3.0 receives 0 quality points. " +
+      "Reviews are moderated by the Invest.com.au team and are not editable by the advisor.",
+  },
+] as const;
+
+const VOLUME_BANDS = [
+  { reviews: "20+", score: 100 },
+  { reviews: "10–19", score: 80 },
+  { reviews: "5–9", score: 60 },
+  { reviews: "2–4", score: 40 },
+  { reviews: "1", score: 20 },
+  { reviews: "0", score: 0 },
+] as const;
+
+export default function TrustScoreMethodologyPage() {
+  const breadcrumbLd = breadcrumbJsonLd([
+    { name: "Home", url: absoluteUrl("/") },
+    { name: "Find an Advisor", url: absoluteUrl("/advisors") },
+    { name: "Trust Score Methodology" },
+  ]);
+
+  return (
+    <div className="bg-white min-h-screen">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
+      />
+
+      {/* ── Hero ── */}
+      <section className="bg-white border-b border-slate-100">
+        <div className="container-custom py-6 md:py-8 max-w-4xl">
+          {/* Breadcrumbs */}
+          <nav
+            className="text-xs text-slate-400 mb-4 flex items-center gap-1.5"
+            aria-label="Breadcrumb"
+          >
+            <Link href="/" className="hover:text-slate-600">
+              Home
+            </Link>
+            <span aria-hidden="true">/</span>
+            <Link href="/advisors" className="hover:text-slate-600">
+              Find an Advisor
+            </Link>
+            <span aria-hidden="true">/</span>
+            <span className="text-slate-600">Trust Score Methodology</span>
+          </nav>
+
+          <h1 className="text-2xl md:text-3xl font-extrabold text-slate-900 mb-2">
+            Advisor Trust Score — Methodology
+          </h1>
+          <p className="text-slate-600 max-w-2xl leading-relaxed">
+            The Trust Score is a{" "}
+            <strong>factual composite of credential and compliance signals</strong>{" "}
+            drawn from publicly available and platform-verifiable data. It is not a
+            recommendation, personal advice, or a "best advisor" ranking. It is a
+            transparency tool to help consumers understand an advisor&rsquo;s verifiable standing.
+          </p>
+        </div>
+      </section>
+
+      {/* ── Content ── */}
+      <div className="container-custom py-8 max-w-4xl space-y-10">
+
+        {/* Weight summary */}
+        <section>
+          <h2 className="text-xl font-extrabold text-slate-900 mb-4">
+            Four Dimensions, Named-Constant Weights
+          </h2>
+          <p className="text-sm text-slate-600 mb-5 leading-relaxed">
+            The overall score (0–100) is a weighted average of four dimension scores.
+            Weights are fixed constants in the source code and are published here for
+            full transparency.
+          </p>
+          <div className="bg-white border border-slate-200 rounded-2xl overflow-hidden">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="bg-slate-50 border-b border-slate-200">
+                  <th className="text-left px-4 py-3 text-xs font-semibold text-slate-600">
+                    Dimension
+                  </th>
+                  <th className="text-right px-4 py-3 text-xs font-semibold text-slate-600">
+                    Weight
+                  </th>
+                  <th className="text-right px-4 py-3 text-xs font-semibold text-slate-600">
+                    Max Contribution
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {DIMENSIONS.map((d, i) => (
+                  <tr
+                    key={d.key}
+                    className={`border-b border-slate-50 ${i % 2 === 1 ? "bg-slate-50/50" : ""}`}
+                  >
+                    <td className="px-4 py-3">
+                      <div className="flex items-center gap-2">
+                        <span className={`inline-block w-2 h-2 rounded-full ${d.color}`} />
+                        <span className="font-medium text-slate-800">{d.label}</span>
+                      </div>
+                    </td>
+                    <td className="px-4 py-3 text-right font-semibold text-slate-700">
+                      {(d.weight * 100).toFixed(0)}%
+                    </td>
+                    <td className="px-4 py-3 text-right text-slate-500">
+                      {(100 * d.weight).toFixed(0)} pts
+                    </td>
+                  </tr>
+                ))}
+                <tr className="border-t-2 border-slate-200 bg-slate-50">
+                  <td className="px-4 py-3 font-bold text-slate-900">Total</td>
+                  <td className="px-4 py-3 text-right font-extrabold text-slate-900">100%</td>
+                  <td className="px-4 py-3 text-right font-extrabold text-slate-900">100 pts</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* Dimension detail */}
+        {DIMENSIONS.map((d) => (
+          <section key={d.key}>
+            <div className="flex items-center gap-3 mb-3">
+              <span className={`inline-block w-3 h-3 rounded-full ${d.color}`} />
+              <h2 className="text-lg font-extrabold text-slate-900">
+                {d.label}{" "}
+                <span className="text-sm font-normal text-slate-400">
+                  ({(d.weight * 100).toFixed(0)}% weight)
+                </span>
+              </h2>
+            </div>
+
+            {"signals" in d && d.signals && (
+              <div className="bg-white border border-slate-200 rounded-xl overflow-hidden mb-3">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="bg-slate-50 border-b border-slate-200">
+                      <th className="text-left px-4 py-2.5 text-xs font-semibold text-slate-600">
+                        Signal
+                      </th>
+                      <th className="text-right px-4 py-2.5 text-xs font-semibold text-slate-600">
+                        Points
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {d.signals.map((s, i) => (
+                      <tr
+                        key={s.signal}
+                        className={`border-b border-slate-50 ${i % 2 === 1 ? "bg-slate-50/40" : ""}`}
+                      >
+                        <td className="px-4 py-2.5 text-slate-700">{s.signal}</td>
+                        <td className="px-4 py-2.5 text-right font-semibold text-slate-800">
+                          +{s.pts}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+
+            {"bands" in d && d.bands && (
+              <div className="bg-white border border-slate-200 rounded-xl overflow-hidden mb-3">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="bg-slate-50 border-b border-slate-200">
+                      <th className="text-left px-4 py-2.5 text-xs font-semibold text-slate-600">
+                        Tenure / Experience
+                      </th>
+                      <th className="text-right px-4 py-2.5 text-xs font-semibold text-slate-600">
+                        Dimension Score
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {d.bands.map((b, i) => (
+                      <tr
+                        key={b.years}
+                        className={`border-b border-slate-50 ${i % 2 === 1 ? "bg-slate-50/40" : ""}`}
+                      >
+                        <td className="px-4 py-2.5 text-slate-700">{b.years}</td>
+                        <td className="px-4 py-2.5 text-right font-semibold text-slate-800">
+                          {b.score}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+
+            {"feedbackNote" in d && d.feedbackNote && (
+              <div className="grid sm:grid-cols-2 gap-4 mb-3">
+                {/* Volume */}
+                <div className="bg-white border border-slate-200 rounded-xl overflow-hidden">
+                  <div className="bg-slate-50 border-b border-slate-200 px-4 py-2.5">
+                    <p className="text-xs font-semibold text-slate-600">
+                      Sub-score A — Volume (50% of dimension)
+                    </p>
+                  </div>
+                  <table className="w-full text-sm">
+                    <tbody>
+                      {VOLUME_BANDS.map((vb, i) => (
+                        <tr
+                          key={vb.reviews}
+                          className={`border-b border-slate-50 ${i % 2 === 1 ? "bg-slate-50/40" : ""}`}
+                        >
+                          <td className="px-4 py-2 text-slate-700">
+                            {vb.reviews} reviews
+                          </td>
+                          <td className="px-4 py-2 text-right font-semibold text-slate-800">
+                            {vb.score}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+                {/* Quality */}
+                <div className="bg-white border border-slate-200 rounded-xl overflow-hidden">
+                  <div className="bg-slate-50 border-b border-slate-200 px-4 py-2.5">
+                    <p className="text-xs font-semibold text-slate-600">
+                      Sub-score B — Quality (50% of dimension)
+                    </p>
+                  </div>
+                  <div className="px-4 py-3 space-y-2 text-sm text-slate-600">
+                    <p>
+                      Linear mapping of the average star rating to 0–100:
+                    </p>
+                    <p className="font-mono text-xs bg-slate-50 rounded px-3 py-2 border border-slate-100">
+                      quality = (rating − 3.0) ÷ 2.0 × 100
+                    </p>
+                    <ul className="text-xs space-y-1 text-slate-500">
+                      <li>5.0 stars → 100 pts</li>
+                      <li>4.0 stars → 50 pts</li>
+                      <li>3.0 stars → 0 pts</li>
+                      <li>&lt; 3.0 stars → 0 pts (floor)</li>
+                    </ul>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            <p className="text-xs text-slate-500 leading-relaxed bg-slate-50 border border-slate-100 rounded-lg px-4 py-3">
+              {d.notes}
+            </p>
+          </section>
+        ))}
+
+        {/* Score bands */}
+        <section>
+          <h2 className="text-lg font-extrabold text-slate-900 mb-3">
+            Score Bands &amp; Labels
+          </h2>
+          <div className="bg-white border border-slate-200 rounded-xl overflow-hidden">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="bg-slate-50 border-b border-slate-200">
+                  <th className="text-left px-4 py-2.5 text-xs font-semibold text-slate-600">
+                    Overall Score
+                  </th>
+                  <th className="text-left px-4 py-2.5 text-xs font-semibold text-slate-600">
+                    Label
+                  </th>
+                  <th className="text-left px-4 py-2.5 text-xs font-semibold text-slate-600 hidden sm:table-cell">
+                    Interpretation
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {[
+                  { range: "80–100", label: "Strong", interp: "Verified, AFSL confirmed, high transparency, active client feedback." },
+                  { range: "65–79", label: "Good", interp: "Most credential signals present; minor gaps in transparency or feedback." },
+                  { range: "50–64", label: "Moderate", interp: "Some credential signals present; profile may be incomplete or newly joined." },
+                  { range: "0–49", label: "Limited", interp: "Few verifiable credential signals on file at this time." },
+                ].map((row, i) => (
+                  <tr
+                    key={row.range}
+                    className={`border-b border-slate-50 ${i % 2 === 1 ? "bg-slate-50/40" : ""}`}
+                  >
+                    <td className="px-4 py-3 font-semibold tabular-nums text-slate-800">
+                      {row.range}
+                    </td>
+                    <td className="px-4 py-3 font-semibold text-slate-800">
+                      {row.label}
+                    </td>
+                    <td className="px-4 py-3 text-xs text-slate-500 hidden sm:table-cell">
+                      {row.interp}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* What the score is not */}
+        <section>
+          <h2 className="text-lg font-extrabold text-slate-900 mb-3">
+            What the Trust Score Is — and Is Not
+          </h2>
+          <div className="bg-white border border-slate-200 rounded-xl p-5 space-y-4 text-sm text-slate-600 leading-relaxed">
+            <p>
+              <strong className="text-slate-800">What it IS:</strong> a factual composite
+              score based on objectively checkable signals — whether an advisor is verified,
+              whether they hold an AFSL, how long they have been on the platform, how much
+              information they have disclosed on their profile, and what their independently
+              moderated review record looks like.
+            </p>
+            <p>
+              <strong className="text-slate-800">What it IS NOT:</strong>
+            </p>
+            <ul className="list-disc list-inside space-y-1.5 text-slate-500">
+              <li>
+                Not a recommendation to use any particular advisor.
+              </li>
+              <li>
+                Not a statement about investment performance, returns, or suitability for
+                your specific circumstances.
+              </li>
+              <li>
+                Not personal financial advice under the{" "}
+                <em>Corporations Act 2001</em> (Cth).
+              </li>
+              <li>
+                Not a ranking designed to steer consumers toward any advisor. Two advisors
+                with the same score are equal — the score does not establish precedence
+                within a band.
+              </li>
+              <li>
+                Not a guarantee that the advisor&rsquo;s AFSL is currently active —
+                licence status can change. Use the{" "}
+                <a
+                  href="https://connectonline.asic.gov.au/RegistrySearch/faces/landing/SearchRegisters.jspx"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline hover:text-slate-800"
+                >
+                  ASIC Professional Registers
+                </a>{" "}
+                to verify current status.
+              </li>
+            </ul>
+          </div>
+        </section>
+
+        {/* Data freshness */}
+        <section>
+          <h2 className="text-lg font-extrabold text-slate-900 mb-3">
+            Data Freshness
+          </h2>
+          <div className="bg-white border border-slate-200 rounded-xl p-5 text-sm text-slate-600 leading-relaxed">
+            <p>
+              The Trust Score is computed on-read directly from the advisor&rsquo;s live profile
+              data each time the page is loaded (with ISR caching at 30-minute intervals).
+              There is no separate scoring pipeline or database table — the score always
+              reflects the current state of the profile.
+            </p>
+            <p className="mt-2">
+              Advisors can improve their score by completing their profile, obtaining
+              verification, and inviting clients to leave reviews through the advisor portal.
+            </p>
+          </div>
+        </section>
+
+        {/* General advice warning */}
+        <section>
+          <div className="bg-amber-50 border border-amber-200 rounded-xl p-5 text-xs text-amber-900 leading-relaxed">
+            <p className="font-semibold mb-1">General Advice Warning</p>
+            <p>{GENERAL_ADVICE_WARNING}</p>
+          </div>
+        </section>
+
+        {/* Attribution */}
+        <section className="text-xs text-slate-400 space-y-1">
+          <p>
+            Published by {SITE_NAME} &middot; Last updated {CURRENT_YEAR}.
+          </p>
+          <p>
+            Questions about the methodology?{" "}
+            <a
+              href="mailto:corrections@invest.com.au"
+              className="underline hover:text-slate-600"
+            >
+              corrections@invest.com.au
+            </a>
+          </p>
+        </section>
+
+        {/* Back link */}
+        <div className="text-sm">
+          <Link
+            href="/advisors"
+            className="text-slate-500 hover:text-slate-700 hover:underline"
+          >
+            &larr; Back to find an advisor
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lib/advisor-trust-score.ts
+++ b/lib/advisor-trust-score.ts
@@ -1,0 +1,469 @@
+/**
+ * lib/advisor-trust-score.ts
+ *
+ * Advisor Trust Score — a public-facing, methodology-transparent composite
+ * score computed from factual credential and compliance signals on a
+ * professional's profile.
+ *
+ * PURPOSE: Help consumers quickly understand an advisor's verifiable standing.
+ *   This is NOT a recommendation, personal advice, or a "best advisor" ranking.
+ *   It is a factual composite of objective, publicly-checkable data points.
+ *   See /advisor/trust-score-methodology for the full published methodology.
+ *
+ * AFSL SAFETY NOTE: The score is based entirely on factual credential signals
+ *   (AFSL/registration status, verified flag, tenure, profile completeness,
+ *   and review volume/rating). It does not express an opinion on suitability,
+ *   performance, returns, or quality of advice. Under RG 234 / RG 256 the
+ *   site holds no AFSL and must not give personal advice or imply comparative
+ *   superiority between advisors for the purposes of investment decisions.
+ *
+ * DESIGN: Pure function (no I/O). Input is a subset of the `professionals`
+ *   row plus a review aggregate. Output is a fully-typed result with per-
+ *   dimension sub-scores, labels, and an overall 0–100 score.
+ */
+
+/* ─── Named weight constants ─── */
+
+/** Weight for the Verification & Registration dimension (0–1). */
+export const WEIGHT_VERIFICATION = 0.30;
+/** Weight for the Track Record (tenure) dimension (0–1). */
+export const WEIGHT_TRACK_RECORD = 0.25;
+/** Weight for the Profile Transparency dimension (0–1). */
+export const WEIGHT_TRANSPARENCY = 0.25;
+/** Weight for the Client Feedback dimension (0–1). */
+export const WEIGHT_CLIENT_FEEDBACK = 0.20;
+
+// Sanity check: weights must sum to 1.0 (tested)
+// 0.30 + 0.25 + 0.25 + 0.20 = 1.00
+
+/* ─── Dimension keys ─── */
+
+export type TrustDimensionKey =
+  | "verification"
+  | "track_record"
+  | "transparency"
+  | "client_feedback";
+
+/* ─── Public types ─── */
+
+export interface TrustDimension {
+  key: TrustDimensionKey;
+  label: string;
+  /** 0–100 sub-score for this dimension. */
+  score: number;
+  /** 0–1 weight applied to this dimension in the overall calculation. */
+  weight: number;
+  /** One-sentence plain-English explanation of what drove this score. */
+  rationale: string;
+  /** Markdown-safe description of what this dimension measures (shown in UI). */
+  description: string;
+}
+
+export interface AdvisorTrustScore {
+  /** Overall Trust Score, 0–100, rounded to nearest integer. */
+  overall: number;
+  /** Human-readable label corresponding to the overall score band. */
+  label: string;
+  /** CSS colour token for the label/gauge (tailwind class fragment). */
+  labelColor: string;
+  /** Per-dimension breakdown. */
+  dimensions: TrustDimension[];
+  /**
+   * ISO-8601 timestamp at which the score was computed.
+   * Set by the caller (page server component) so tests can stay pure.
+   */
+  computedAt: string;
+}
+
+/* ─── Input shape ─── */
+
+/**
+ * Subset of the `professionals` row that the scorer needs.
+ * All fields that could be missing must be typed as `| null | undefined`.
+ */
+export interface AdvisorTrustScoreInput {
+  // Verification & Registration
+  verified: boolean | null | undefined;
+  afsl_number: string | null | undefined;
+  registration_number: string | null | undefined;
+  verified_at: string | null | undefined;
+
+  // Track Record (tenure proxy: created_at is the join date)
+  created_at: string | null | undefined;
+  years_experience: number | null | undefined;
+
+  // Profile Transparency (completeness signals)
+  bio: string | null | undefined;
+  photo_url: string | null | undefined;
+  qualifications: unknown[] | null | undefined;
+  education: unknown[] | null | undefined;
+  memberships: unknown[] | null | undefined;
+  fee_structure: string | null | undefined;
+  fee_description: string | null | undefined;
+  linkedin_url: string | null | undefined;
+  website: string | null | undefined;
+  languages: unknown[] | null | undefined;
+
+  // Client Feedback
+  rating: number | null | undefined;
+  review_count: number | null | undefined;
+}
+
+/* ─── Verification dimension ─── */
+
+/**
+ * Dimension 1 — Verification & Registration (weight 30%)
+ *
+ * Signals:
+ *   - Verified flag (confirmed by editorial or ASIC check)   +50 pts
+ *   - AFSL number present on profile                         +30 pts
+ *   - Registration number present (AR, ACR, MARN, etc.)      +10 pts
+ *   - Verified within last 12 months (freshness bonus)       +10 pts
+ *
+ * Max = 100. No signal = 0.
+ */
+function scoreVerification(input: AdvisorTrustScoreInput): TrustDimension {
+  let score = 0;
+  const signals: string[] = [];
+
+  if (input.verified) {
+    score += 50;
+    signals.push("profile verified");
+  }
+  if (input.afsl_number && input.afsl_number.trim().length > 0) {
+    score += 30;
+    signals.push(`AFSL ${input.afsl_number.trim()} on file`);
+  }
+  if (input.registration_number && input.registration_number.trim().length > 0) {
+    score += 10;
+    signals.push("registration number on file");
+  }
+  // Freshness: verified within the past 12 months
+  if (input.verified && input.verified_at) {
+    const twelveMonthsAgo = Date.now() - 365 * 24 * 60 * 60 * 1000;
+    const verifiedAt = new Date(input.verified_at).getTime();
+    if (!isNaN(verifiedAt) && verifiedAt >= twelveMonthsAgo) {
+      score += 10;
+      signals.push("verified within past 12 months");
+    }
+  }
+
+  const rationale =
+    signals.length > 0
+      ? `Score based on: ${signals.join(", ")}.`
+      : "No credential verification signals found on this profile.";
+
+  return {
+    key: "verification",
+    label: "Verification & Registration",
+    score: Math.min(score, 100),
+    weight: WEIGHT_VERIFICATION,
+    rationale,
+    description:
+      "Checks whether the advisor has been independently verified by the Invest.com.au editorial team, " +
+      "holds an Australian Financial Services Licence (AFSL) number, or carries a relevant registration " +
+      "number (e.g. Authorised Representative, Credit Representative, or MARN). " +
+      "Verification is cross-checked against ASIC Professional Registers.",
+  };
+}
+
+/* ─── Track Record dimension ─── */
+
+/**
+ * Dimension 2 — Track Record (weight 25%)
+ *
+ * Signals (using the higher of: self-reported years_experience, or
+ * platform tenure derived from created_at):
+ *
+ *   ≥ 15 years → 100
+ *   ≥ 10 years → 85
+ *   ≥  7 years → 70
+ *   ≥  5 years → 55
+ *   ≥  3 years → 40
+ *   ≥  1 year  → 25
+ *   < 1 year / no data → 10
+ */
+function scoreTrackRecord(input: AdvisorTrustScoreInput): TrustDimension {
+  // Derive platform tenure in years from created_at
+  let tenureYears: number | null = null;
+  if (input.created_at) {
+    const createdMs = new Date(input.created_at).getTime();
+    if (!isNaN(createdMs)) {
+      tenureYears = (Date.now() - createdMs) / (365.25 * 24 * 60 * 60 * 1000);
+    }
+  }
+
+  // Use the higher of self-reported experience vs platform tenure
+  const selfReported =
+    typeof input.years_experience === "number" && input.years_experience > 0
+      ? input.years_experience
+      : null;
+
+  const effectiveYears: number | null =
+    selfReported != null && tenureYears != null
+      ? Math.max(selfReported, tenureYears)
+      : (selfReported ?? tenureYears);
+
+  let score: number;
+  let rationale: string;
+
+  if (effectiveYears == null) {
+    score = 10;
+    rationale = "No tenure or experience data available.";
+  } else if (effectiveYears >= 15) {
+    score = 100;
+    rationale = `15+ years of experience or platform tenure (${effectiveYears.toFixed(1)} yrs).`;
+  } else if (effectiveYears >= 10) {
+    score = 85;
+    rationale = `10–14 years of experience or platform tenure (${effectiveYears.toFixed(1)} yrs).`;
+  } else if (effectiveYears >= 7) {
+    score = 70;
+    rationale = `7–9 years of experience or platform tenure (${effectiveYears.toFixed(1)} yrs).`;
+  } else if (effectiveYears >= 5) {
+    score = 55;
+    rationale = `5–6 years of experience or platform tenure (${effectiveYears.toFixed(1)} yrs).`;
+  } else if (effectiveYears >= 3) {
+    score = 40;
+    rationale = `3–4 years of experience or platform tenure (${effectiveYears.toFixed(1)} yrs).`;
+  } else if (effectiveYears >= 1) {
+    score = 25;
+    rationale = `1–2 years of experience or platform tenure (${effectiveYears.toFixed(1)} yrs).`;
+  } else {
+    score = 10;
+    rationale = `Less than 1 year on the platform or limited experience data.`;
+  }
+
+  return {
+    key: "track_record",
+    label: "Track Record",
+    score,
+    weight: WEIGHT_TRACK_RECORD,
+    rationale,
+    description:
+      "Reflects the advisor's verified tenure on the Invest.com.au platform and/or their self-reported " +
+      "years of professional experience. Longer track records provide more observable data for consumers. " +
+      "The higher of the two signals is used. This is a tenure signal only — it does not imply performance.",
+  };
+}
+
+/* ─── Transparency dimension ─── */
+
+/**
+ * Dimension 3 — Profile Transparency (weight 25%)
+ *
+ * Points awarded for each populated transparency field:
+ *   bio (long-form text)         20 pts
+ *   photo                        15 pts
+ *   qualifications list          15 pts
+ *   fee structure / description  15 pts
+ *   education history            10 pts
+ *   memberships                  10 pts
+ *   online presence (linked in or website) 10 pts
+ *   languages                     5 pts
+ *
+ * Max = 100.
+ */
+function scoreTransparency(input: AdvisorTrustScoreInput): TrustDimension {
+  const checks: Array<{ label: string; pts: number; present: boolean }> = [
+    {
+      label: "bio",
+      pts: 20,
+      present:
+        typeof input.bio === "string" && input.bio.trim().length > 30,
+    },
+    {
+      label: "photo",
+      pts: 15,
+      present:
+        typeof input.photo_url === "string" && input.photo_url.trim().length > 0,
+    },
+    {
+      label: "qualifications",
+      pts: 15,
+      present: Array.isArray(input.qualifications) && input.qualifications.length > 0,
+    },
+    {
+      label: "fee structure",
+      pts: 15,
+      present:
+        (typeof input.fee_structure === "string" &&
+          input.fee_structure.trim().length > 0) ||
+        (typeof input.fee_description === "string" &&
+          input.fee_description.trim().length > 0),
+    },
+    {
+      label: "education",
+      pts: 10,
+      present: Array.isArray(input.education) && input.education.length > 0,
+    },
+    {
+      label: "professional memberships",
+      pts: 10,
+      present: Array.isArray(input.memberships) && input.memberships.length > 0,
+    },
+    {
+      label: "online presence",
+      pts: 10,
+      present:
+        (typeof input.linkedin_url === "string" &&
+          input.linkedin_url.trim().length > 0) ||
+        (typeof input.website === "string" && input.website.trim().length > 0),
+    },
+    {
+      label: "languages",
+      pts: 5,
+      present: Array.isArray(input.languages) && input.languages.length > 1,
+    },
+  ];
+
+  const earned = checks
+    .filter((c) => c.present)
+    .map((c) => c.label);
+  const score = checks.reduce((sum, c) => (c.present ? sum + c.pts : sum), 0);
+
+  const rationale =
+    earned.length > 0
+      ? `Present: ${earned.join(", ")}.`
+      : "No transparency fields populated.";
+
+  return {
+    key: "transparency",
+    label: "Profile Transparency",
+    score: Math.min(score, 100),
+    weight: WEIGHT_TRANSPARENCY,
+    rationale,
+    description:
+      "Measures how much factual information the advisor has published on their public profile: " +
+      "biography, photo, qualifications, fee structure, education history, professional memberships, " +
+      "online presence (LinkedIn / website), and languages spoken. " +
+      "More disclosure lets consumers make better-informed decisions.",
+  };
+}
+
+/* ─── Client Feedback dimension ─── */
+
+/**
+ * Dimension 4 — Client Feedback (weight 20%)
+ *
+ * Combined volume × quality signal to avoid gaming via a few hand-picked reviews.
+ *
+ * Volume score (50% of dimension):
+ *   ≥ 20 reviews → 100
+ *   ≥ 10 reviews →  80
+ *   ≥  5 reviews →  60
+ *   ≥  2 reviews →  40
+ *   ≥  1 review  →  20
+ *   0 reviews    →   0
+ *
+ * Quality score (50% of dimension):
+ *   Maps the star rating (0–5) linearly onto 0–100 but only from the range
+ *   [3.0, 5.0] so that < 3.0 yields 0 and = 5.0 yields 100.
+ *   Rationale: on this platform ratings below 3.0 are practically impossible
+ *   (clients who had genuinely bad experiences tend to leave no review, so
+ *   sub-3.0 averages are statistically significant).
+ *
+ * No reviews → both halves = 0.
+ */
+function scoreClientFeedback(input: AdvisorTrustScoreInput): TrustDimension {
+  const count = typeof input.review_count === "number" ? input.review_count : 0;
+  const rating = typeof input.rating === "number" ? input.rating : null;
+
+  // Volume sub-score
+  let volumeScore: number;
+  if (count >= 20) volumeScore = 100;
+  else if (count >= 10) volumeScore = 80;
+  else if (count >= 5) volumeScore = 60;
+  else if (count >= 2) volumeScore = 40;
+  else if (count >= 1) volumeScore = 20;
+  else volumeScore = 0;
+
+  // Quality sub-score
+  let qualityScore: number;
+  if (rating == null || count === 0) {
+    qualityScore = 0;
+  } else {
+    // Linear map [3.0, 5.0] → [0, 100], clamp to [0, 100]
+    qualityScore = Math.max(0, Math.min(100, ((rating - 3.0) / 2.0) * 100));
+  }
+
+  const score = Math.round((volumeScore + qualityScore) / 2);
+
+  let rationale: string;
+  if (count === 0) {
+    rationale = "No reviews on this profile yet.";
+  } else {
+    rationale = `${count} review${count === 1 ? "" : "s"}, ${rating != null ? `${rating.toFixed(1)}/5.0 average rating` : "no rating"}.`;
+  }
+
+  return {
+    key: "client_feedback",
+    label: "Client Feedback",
+    score,
+    weight: WEIGHT_CLIENT_FEEDBACK,
+    rationale,
+    description:
+      "Combines the number of approved client reviews (volume signal) with the average star rating " +
+      "(quality signal). Both components carry equal weight within this dimension. " +
+      "Reviews are moderated before publication and are not editable by the advisor.",
+  };
+}
+
+/* ─── Label helpers ─── */
+
+/**
+ * Returns a human-readable label for the given overall score.
+ * Bands mirror the broker health-score convention.
+ */
+export function trustScoreLabel(score: number): string {
+  if (score >= 80) return "Strong";
+  if (score >= 65) return "Good";
+  if (score >= 50) return "Moderate";
+  return "Limited";
+}
+
+/**
+ * Returns the Tailwind text-colour class for the given score band.
+ */
+export function trustScoreLabelColor(score: number): string {
+  if (score >= 80) return "text-emerald-600";
+  if (score >= 65) return "text-emerald-600";
+  if (score >= 50) return "text-amber-600";
+  return "text-slate-500";
+}
+
+/* ─── Main export ─── */
+
+/**
+ * Compute the Advisor Trust Score from a professionals row + review aggregate.
+ *
+ * Pure function — no I/O, no side effects.
+ *
+ * @param input  Subset of the `professionals` DB row (typed as
+ *               `AdvisorTrustScoreInput` — callers may pass the full row).
+ * @param computedAt  ISO-8601 timestamp for the computation time.
+ *                    Defaults to `new Date().toISOString()` when omitted.
+ */
+export function computeAdvisorTrustScore(
+  input: AdvisorTrustScoreInput,
+  computedAt?: string,
+): AdvisorTrustScore {
+  const dimensions: TrustDimension[] = [
+    scoreVerification(input),
+    scoreTrackRecord(input),
+    scoreTransparency(input),
+    scoreClientFeedback(input),
+  ];
+
+  // Weighted average — weights already sum to 1.0
+  const overall = Math.round(
+    dimensions.reduce((sum, d) => sum + d.score * d.weight, 0),
+  );
+
+  return {
+    overall,
+    label: trustScoreLabel(overall),
+    labelColor: trustScoreLabelColor(overall),
+    dimensions,
+    computedAt: computedAt ?? new Date().toISOString(),
+  };
+}


### PR DESCRIPTION
Extends the proprietary "Trust & Safety" rating concept (broker-only until now) to **advisors** — a methodology-transparent **Advisor Trust Score** from factual credential/compliance signals. AFSL-safe: factual composite + transparent methodology, explicitly *not* a recommendation or "best advisor" ranking (no advisor-vs-advisor comparison).

- `lib/advisor-trust-score.ts` — pure, tested scorer over four weighted dimensions (Verification & Registration 30%, Track Record 25%, Profile Transparency 25%, Client Feedback 20%), named-constant weights, computed **on-read** from existing `professionals` columns (no new table/cron).
- Advisor profile (`app/advisor/[slug]`) renders a Trust Score section: SVG gauge (broker `ScoreGauge` pattern) + per-dimension bars with rationale + a methodology link + `GENERAL_ADVICE_WARNING`.
- Full methodology page at `/advisor/trust-score-methodology` (signal tables, score bands, "what this is / is not", ASIC register link).

**Fix on verification:** escaped quotes in the methodology copy.

**Verified:** `tsc` clean · **65 unit tests** (every dimension + edge cases: no reviews, new advisor, missing fields, rating clamps, weight sum) pass · eslint clean · jsonld gate pass. Factual only (AFSL-safe); distinct from the internal `advisor-health` portal tool.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUfSRE2Teb6VhEXFP6RpS9)_