### PR TITLE
feat: cross-border expat planner — interactive checklist (deepen)

### DIFF
--- a/__tests__/lib/expat-plan.test.ts
+++ b/__tests__/lib/expat-plan.test.ts
@@ -104,10 +104,8 @@ describe("buildExpatPlan — structural invariants", () => {
 // ─── buildExpatPlan — UK full-featured ──────────────────────────────────────
 
 describe("buildExpatPlan — UK (full-featured config)", () => {
-  let plan: ExpatPlan;
-
   // Build once for the suite — avoids re-running the full build per test
-  plan = buildExpatPlan(UK_CONFIG);
+  const plan: ExpatPlan = buildExpatPlan(UK_CONFIG);
 
   it("includes a firb item", () => {
     const item = plan.items.find((i) => i.id === "firb");

--- a/__tests__/lib/expat-plan.test.ts
+++ b/__tests__/lib/expat-plan.test.ts
@@ -1,0 +1,551 @@
+/**
+ * Tests for lib/expat-plan.ts
+ *
+ * Coverage:
+ *   - buildExpatPlan: structural invariants, country-specific features,
+ *     fxSummary / pensionSummary enrichment, data integrity
+ *   - computeCompletion: zero, partial, full, edge cases
+ *   - getPlanItem: hit and miss
+ *   - planProgressKey: stable key format
+ *   - parseProgress: valid, malformed, null, type-coercion attacks
+ *   - toggleItemDone: add, remove, idempotent
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  buildExpatPlan,
+  computeCompletion,
+  getPlanItem,
+  planProgressKey,
+  parseProgress,
+  toggleItemDone,
+  type ExpatPlan,
+  type ExpatPlanProgress,
+} from "@/lib/expat-plan";
+import {
+  UK_CONFIG,
+  US_CONFIG,
+  NZ_CONFIG,
+  CN_CONFIG,
+  SA_CONFIG,
+} from "@/lib/foreign-investment-country-data";
+
+// ─── buildExpatPlan — invariants ─────────────────────────────────────────────
+
+describe("buildExpatPlan — structural invariants", () => {
+  it("returns at least 2 items (eligibility + handoff) for every country", () => {
+    for (const config of [UK_CONFIG, US_CONFIG, NZ_CONFIG, CN_CONFIG, SA_CONFIG]) {
+      const plan = buildExpatPlan(config);
+      expect(plan.items.length).toBeGreaterThanOrEqual(2);
+    }
+  });
+
+  it("first item is always eligibility", () => {
+    const plan = buildExpatPlan(UK_CONFIG);
+    expect(plan.items[0]).toBeDefined();
+    expect(plan.items[0]!.id).toBe("eligibility");
+    expect(plan.items[0]!.stepNumber).toBe(1);
+  });
+
+  it("last item is always handoff", () => {
+    const plan = buildExpatPlan(UK_CONFIG);
+    const last = plan.items[plan.items.length - 1];
+    expect(last).toBeDefined();
+    expect(last!.id).toBe("handoff");
+  });
+
+  it("step numbers are sequential from 1 with no gaps", () => {
+    const plan = buildExpatPlan(UK_CONFIG);
+    plan.items.forEach((item, idx) => {
+      expect(item.stepNumber).toBe(idx + 1);
+    });
+  });
+
+  it("item ids are unique within a plan", () => {
+    const plan = buildExpatPlan(UK_CONFIG);
+    const ids = plan.items.map((i) => i.id);
+    const uniqueIds = new Set(ids);
+    expect(uniqueIds.size).toBe(ids.length);
+  });
+
+  it("every item has a non-empty heading, summary, and railLabel", () => {
+    const plan = buildExpatPlan(UK_CONFIG);
+    for (const item of plan.items) {
+      expect(item.heading.length).toBeGreaterThan(0);
+      expect(item.summary.length).toBeGreaterThan(0);
+      expect(item.railLabel.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("every item has a category from the known set", () => {
+    const VALID_CATEGORIES = new Set(["setup", "compliance", "financial", "action"]);
+    const plan = buildExpatPlan(UK_CONFIG);
+    for (const item of plan.items) {
+      expect(VALID_CATEGORIES.has(item.category)).toBe(true);
+    }
+  });
+
+  it("builtAt is a valid ISO 8601 timestamp", () => {
+    const plan = buildExpatPlan(UK_CONFIG);
+    expect(() => new Date(plan.builtAt)).not.toThrow();
+    expect(new Date(plan.builtAt).getTime()).toBeGreaterThan(0);
+  });
+
+  it("sets code, countryName, countryShort, flag, currency from config", () => {
+    const plan = buildExpatPlan(UK_CONFIG);
+    expect(plan.code).toBe("uk");
+    expect(plan.countryName).toBe("United Kingdom");
+    expect(plan.countryShort).toBe("UK");
+    expect(plan.flag).toBe("🇬🇧");
+    expect(plan.currency).toBe("GBP");
+  });
+});
+
+// ─── buildExpatPlan — UK full-featured ──────────────────────────────────────
+
+describe("buildExpatPlan — UK (full-featured config)", () => {
+  let plan: ExpatPlan;
+
+  // Build once for the suite — avoids re-running the full build per test
+  plan = buildExpatPlan(UK_CONFIG);
+
+  it("includes a firb item", () => {
+    const item = plan.items.find((i) => i.id === "firb");
+    expect(item).toBeDefined();
+    expect(item!.category).toBe("compliance");
+  });
+
+  it("includes a tax item", () => {
+    const item = plan.items.find((i) => i.id === "tax");
+    expect(item).toBeDefined();
+    expect(item!.category).toBe("compliance");
+  });
+
+  it("includes a pension item for UK (QROPS)", () => {
+    const item = plan.items.find((i) => i.id === "pension");
+    expect(item).toBeDefined();
+    expect(item!.category).toBe("financial");
+    // Pension item should have a critical callout
+    expect(item!.calloutVariant).toBe("critical");
+  });
+
+  it("includes an fx item for UK (GBP corridor)", () => {
+    const item = plan.items.find((i) => i.id === "fx");
+    expect(item).toBeDefined();
+    expect(item!.category).toBe("financial");
+  });
+
+  it("includes a migration item", () => {
+    const item = plan.items.find((i) => i.id === "migration");
+    expect(item).toBeDefined();
+    expect(item!.category).toBe("setup");
+  });
+
+  it("fxSummary is populated with UK GBP→AUD corridor data", () => {
+    expect(plan.fxSummary).toBeDefined();
+    expect(plan.fxSummary!.eyebrow).toContain("GBP");
+    expect(plan.fxSummary!.bestOptionLabel.length).toBeGreaterThan(0);
+    expect(plan.fxSummary!.bestOptionCost.length).toBeGreaterThan(0);
+    expect(plan.fxSummary!.ctaHref.length).toBeGreaterThan(0);
+  });
+
+  it("pensionSummary is populated with QROPS data", () => {
+    expect(plan.pensionSummary).toBeDefined();
+    expect(plan.pensionSummary!.title).toContain("QROPS");
+    expect(plan.pensionSummary!.keyRules.length).toBeGreaterThan(0);
+    // callout should mention risk
+    expect(plan.pensionSummary!.callout).toBeDefined();
+  });
+
+  it("fx item detail bullets include corridor options and key insight", () => {
+    const item = plan.items.find((i) => i.id === "fx");
+    expect(item).toBeDefined();
+    const allDetail = item!.detail.join(" ");
+    // Should have corridor label
+    expect(allDetail).toContain("GBP");
+    // Should mention at least one option
+    expect(allDetail.toLowerCase()).toMatch(/cost|margin/i);
+  });
+
+  it("pension item detail bullets include key QROPS rules", () => {
+    const item = plan.items.find((i) => i.id === "pension");
+    expect(item).toBeDefined();
+    const allDetail = item!.detail.join(" ");
+    // Should reference the pension transfer overview
+    expect(allDetail.length).toBeGreaterThan(50);
+  });
+
+  it("handoff item category is 'action'", () => {
+    const item = plan.items.find((i) => i.id === "handoff");
+    expect(item).toBeDefined();
+    expect(item!.category).toBe("action");
+  });
+});
+
+// ─── buildExpatPlan — US (FBAR/FATCA, no pension) ───────────────────────────
+
+describe("buildExpatPlan — US config", () => {
+  const plan = buildExpatPlan(US_CONFIG);
+
+  it("includes a reporting item for FBAR/FATCA", () => {
+    const item = plan.items.find((i) => i.id === "reporting");
+    expect(item).toBeDefined();
+    expect(item!.category).toBe("compliance");
+  });
+
+  it("reporting item detail mentions FBAR", () => {
+    const item = plan.items.find((i) => i.id === "reporting");
+    expect(item).toBeDefined();
+    const text = item!.detail.join(" ");
+    expect(text).toContain("FBAR");
+  });
+
+  it("does NOT have a pensionSummary (US has no retirementTransfer config)", () => {
+    expect(plan.pensionSummary).toBeUndefined();
+  });
+
+  it("eligibility item has a critical callout for US worldwide tax", () => {
+    const item = plan.items.find((i) => i.id === "eligibility");
+    expect(item).toBeDefined();
+    expect(item!.calloutVariant).toBe("critical");
+  });
+
+  it("has an fxSummary for USD→AUD", () => {
+    expect(plan.fxSummary).toBeDefined();
+  });
+});
+
+// ─── buildExpatPlan — NZ (no FIRB) ──────────────────────────────────────────
+
+describe("buildExpatPlan — NZ config (Trans-Tasman)", () => {
+  const plan = buildExpatPlan(NZ_CONFIG);
+
+  it("FIRB item has warn callout (not critical) for NZ", () => {
+    const item = plan.items.find((i) => i.id === "firb");
+    expect(item).toBeDefined();
+    expect(item!.calloutVariant).toBe("warn");
+  });
+
+  it("includes a pension item for NZ (KiwiSaver)", () => {
+    const item = plan.items.find((i) => i.id === "pension");
+    expect(item).toBeDefined();
+    expect(plan.pensionSummary).toBeDefined();
+  });
+
+  it("plan code is 'nz'", () => {
+    expect(plan.code).toBe("nz");
+  });
+});
+
+// ─── buildExpatPlan — CN (capital controls) ──────────────────────────────────
+
+describe("buildExpatPlan — CN config", () => {
+  const plan = buildExpatPlan(CN_CONFIG);
+
+  it("eligibility item has critical callout for capital controls", () => {
+    const item = plan.items.find((i) => i.id === "eligibility");
+    expect(item).toBeDefined();
+    expect(item!.calloutVariant).toBe("critical");
+  });
+
+  it("has an fxSummary", () => {
+    expect(plan.fxSummary).toBeDefined();
+  });
+});
+
+// ─── buildExpatPlan — SA (no DTA) ────────────────────────────────────────────
+
+describe("buildExpatPlan — SA config (no DTA)", () => {
+  const plan = buildExpatPlan(SA_CONFIG);
+
+  it("plan has at least 3 items", () => {
+    expect(plan.items.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("eligibility detail mentions no DTA", () => {
+    const item = plan.items.find((i) => i.id === "eligibility");
+    expect(item).toBeDefined();
+    const text = item!.detail.join(" ");
+    expect(text).toContain("Double Tax Agreement");
+  });
+});
+
+// ─── buildExpatPlan — data integrity ─────────────────────────────────────────
+
+describe("buildExpatPlan — link integrity", () => {
+  const KNOWN_PREFIXES = [
+    "/foreign-investment",
+    "/advisors",
+    "/compare",
+    "/non-resident",
+    "/visa-investment",
+    "/cgt-calculator",
+    "/invest",
+    "/find-advisor",
+    "/login",
+  ];
+
+  for (const code of ["uk", "us", "nz", "cn", "sa"] as const) {
+    const configs = {
+      uk: UK_CONFIG,
+      us: US_CONFIG,
+      nz: NZ_CONFIG,
+      cn: CN_CONFIG,
+      sa: SA_CONFIG,
+    };
+    it(`all links in ${code.toUpperCase()} plan start with a known prefix`, () => {
+      const plan = buildExpatPlan(configs[code]);
+      for (const item of plan.items) {
+        for (const link of item.links) {
+          const isKnown = KNOWN_PREFIXES.some((prefix) =>
+            link.href.startsWith(prefix),
+          );
+          expect(
+            isKnown,
+            `Unexpected link href in item "${item.id}": ${link.href}`,
+          ).toBe(true);
+        }
+      }
+    });
+  }
+});
+
+// ─── computeCompletion ───────────────────────────────────────────────────────
+
+describe("computeCompletion", () => {
+  const plan = buildExpatPlan(UK_CONFIG);
+  const allIds = plan.items.map((i) => i.id);
+
+  it("returns 0% and not complete when no items done", () => {
+    const result = computeCompletion(plan, []);
+    expect(result.doneCount).toBe(0);
+    expect(result.totalCount).toBe(plan.items.length);
+    expect(result.percent).toBe(0);
+    expect(result.complete).toBe(false);
+  });
+
+  it("returns 100% and complete when all items done", () => {
+    const result = computeCompletion(plan, allIds);
+    expect(result.doneCount).toBe(plan.items.length);
+    expect(result.percent).toBe(100);
+    expect(result.complete).toBe(true);
+  });
+
+  it("correctly calculates partial completion", () => {
+    // Mark exactly half done (rounded)
+    const halfIds = allIds.slice(0, Math.floor(allIds.length / 2));
+    const result = computeCompletion(plan, halfIds);
+    expect(result.doneCount).toBe(halfIds.length);
+    expect(result.percent).toBeGreaterThan(0);
+    expect(result.percent).toBeLessThan(100);
+    expect(result.complete).toBe(false);
+  });
+
+  it("ignores unknown ids not in the plan", () => {
+    const result = computeCompletion(plan, ["totally-unknown-id"]);
+    expect(result.doneCount).toBe(0);
+    expect(result.percent).toBe(0);
+  });
+
+  it("handles duplicate done ids gracefully (deduplication via Set)", () => {
+    const firstId = allIds[0]!;
+    const result = computeCompletion(plan, [firstId, firstId, firstId]);
+    expect(result.doneCount).toBe(1);
+  });
+
+  it("percent is always an integer (Math.round)", () => {
+    for (let i = 0; i < allIds.length; i++) {
+      const result = computeCompletion(plan, allIds.slice(0, i));
+      expect(result.percent).toBe(Math.round(result.percent));
+      expect(Number.isInteger(result.percent)).toBe(true);
+    }
+  });
+
+  it("handles an empty plan (zero total) without divide-by-zero", () => {
+    const emptyPlan: ExpatPlan = {
+      code: "uk",
+      countryName: "United Kingdom",
+      countryShort: "UK",
+      flag: "🇬🇧",
+      currency: "GBP",
+      items: [],
+      builtAt: new Date().toISOString(),
+    };
+    const result = computeCompletion(emptyPlan, []);
+    expect(result.percent).toBe(0);
+    expect(result.complete).toBe(false);
+    expect(result.totalCount).toBe(0);
+    expect(result.doneCount).toBe(0);
+  });
+});
+
+// ─── getPlanItem ──────────────────────────────────────────────────────────────
+
+describe("getPlanItem", () => {
+  const plan = buildExpatPlan(UK_CONFIG);
+
+  it("returns the item matching the given id", () => {
+    const item = getPlanItem(plan, "tax");
+    expect(item).toBeDefined();
+    expect(item!.id).toBe("tax");
+  });
+
+  it("returns undefined for an unknown id", () => {
+    const item = getPlanItem(plan, "nonexistent-id");
+    expect(item).toBeUndefined();
+  });
+
+  it("returns the eligibility item by id", () => {
+    const item = getPlanItem(plan, "eligibility");
+    expect(item).toBeDefined();
+    expect(item!.stepNumber).toBe(1);
+  });
+});
+
+// ─── planProgressKey ─────────────────────────────────────────────────────────
+
+describe("planProgressKey", () => {
+  it("returns the expected key format for known codes", () => {
+    expect(planProgressKey("uk")).toBe("expat_plan_progress_uk");
+    expect(planProgressKey("us")).toBe("expat_plan_progress_us");
+    expect(planProgressKey("nz")).toBe("expat_plan_progress_nz");
+    expect(planProgressKey("cn")).toBe("expat_plan_progress_cn");
+  });
+
+  it("keys are unique per country code", () => {
+    const codes = ["uk", "us", "nz", "cn", "in", "jp", "sg", "hk", "kr", "my", "ae", "sa"] as const;
+    const keys = codes.map(planProgressKey);
+    const uniqueKeys = new Set(keys);
+    expect(uniqueKeys.size).toBe(codes.length);
+  });
+});
+
+// ─── parseProgress ───────────────────────────────────────────────────────────
+
+describe("parseProgress", () => {
+  it("returns empty progress for null input", () => {
+    const result = parseProgress(null);
+    expect(result.doneIds).toEqual([]);
+  });
+
+  it("returns empty progress for undefined input", () => {
+    const result = parseProgress(undefined);
+    expect(result.doneIds).toEqual([]);
+  });
+
+  it("returns empty progress for empty string", () => {
+    const result = parseProgress("");
+    expect(result.doneIds).toEqual([]);
+  });
+
+  it("parses a valid progress JSON string", () => {
+    const progress: ExpatPlanProgress = {
+      doneIds: ["eligibility", "firb"],
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    };
+    const result = parseProgress(JSON.stringify(progress));
+    expect(result.doneIds).toEqual(["eligibility", "firb"]);
+    expect(result.updatedAt).toBe("2026-01-01T00:00:00.000Z");
+  });
+
+  it("handles malformed JSON without throwing", () => {
+    expect(() => parseProgress("{invalid json")).not.toThrow();
+    const result = parseProgress("{invalid json");
+    expect(result.doneIds).toEqual([]);
+  });
+
+  it("handles an object without doneIds array gracefully", () => {
+    const result = parseProgress(JSON.stringify({ something: "else" }));
+    expect(result.doneIds).toEqual([]);
+  });
+
+  it("filters out non-string doneIds", () => {
+    const raw = JSON.stringify({
+      doneIds: ["eligibility", 42, null, "firb", true],
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    });
+    const result = parseProgress(raw);
+    expect(result.doneIds).toEqual(["eligibility", "firb"]);
+  });
+
+  it("filters out empty-string doneIds", () => {
+    const raw = JSON.stringify({
+      doneIds: ["eligibility", "", "firb"],
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    });
+    const result = parseProgress(raw);
+    expect(result.doneIds).toEqual(["eligibility", "firb"]);
+  });
+
+  it("filters out excessively long doneIds (>= 64 chars)", () => {
+    const longId = "a".repeat(65);
+    const raw = JSON.stringify({
+      doneIds: ["eligibility", longId, "firb"],
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    });
+    const result = parseProgress(raw);
+    expect(result.doneIds).not.toContain(longId);
+    expect(result.doneIds).toContain("eligibility");
+    expect(result.doneIds).toContain("firb");
+  });
+
+  it("handles a primitive JSON value (string, number) without throwing", () => {
+    expect(() => parseProgress('"just a string"')).not.toThrow();
+    expect(() => parseProgress("42")).not.toThrow();
+    expect(parseProgress('"just a string"').doneIds).toEqual([]);
+  });
+
+  it("falls back updatedAt to epoch for missing field", () => {
+    const raw = JSON.stringify({ doneIds: ["eligibility"] });
+    const result = parseProgress(raw);
+    expect(result.updatedAt).toBe(new Date(0).toISOString());
+  });
+});
+
+// ─── toggleItemDone ──────────────────────────────────────────────────────────
+
+describe("toggleItemDone", () => {
+  const baseProgress: ExpatPlanProgress = {
+    doneIds: ["eligibility"],
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+
+  it("adds an item to doneIds when done=true", () => {
+    const result = toggleItemDone(baseProgress, "firb", true);
+    expect(result.doneIds).toContain("firb");
+    expect(result.doneIds).toContain("eligibility");
+  });
+
+  it("removes an item from doneIds when done=false", () => {
+    const result = toggleItemDone(baseProgress, "eligibility", false);
+    expect(result.doneIds).not.toContain("eligibility");
+  });
+
+  it("is idempotent — adding an already-done item does not duplicate", () => {
+    const result = toggleItemDone(baseProgress, "eligibility", true);
+    expect(result.doneIds.filter((id) => id === "eligibility").length).toBe(1);
+  });
+
+  it("is idempotent — removing a not-done item is safe", () => {
+    const result = toggleItemDone(baseProgress, "nonexistent", false);
+    expect(result.doneIds).toEqual(baseProgress.doneIds);
+  });
+
+  it("does not mutate the original progress object", () => {
+    const original = { doneIds: ["eligibility"], updatedAt: "2026-01-01T00:00:00.000Z" };
+    toggleItemDone(original, "firb", true);
+    expect(original.doneIds).toEqual(["eligibility"]);
+  });
+
+  it("sets updatedAt to a date later than the original", () => {
+    const before = new Date(baseProgress.updatedAt).getTime();
+    const result = toggleItemDone(baseProgress, "firb", true);
+    const after = new Date(result.updatedAt).getTime();
+    expect(after).toBeGreaterThanOrEqual(before);
+  });
+
+  it("returns a new object (does not return the same reference)", () => {
+    const result = toggleItemDone(baseProgress, "firb", true);
+    expect(result).not.toBe(baseProgress);
+  });
+});

--- a/app/api/expat-plan/route.ts
+++ b/app/api/expat-plan/route.ts
@@ -1,0 +1,205 @@
+/**
+ * /api/expat-plan — read & write the signed-in user's expat plan progress.
+ *
+ * Progress is stored in `user_calculator_state` under the key
+ * `expat_plan_progress_{countryCode}` (e.g. "expat_plan_progress_uk").
+ * This reuses the existing RLS-enabled table and upsert pattern from
+ * /api/calculator-state, keeping the data model simple and the auth
+ * surface consistent.
+ *
+ * Anonymous users use localStorage only (handled entirely client-side).
+ * This route is only called for signed-in users.
+ *
+ * GET  ?country=uk   → { progress: ExpatPlanProgress | null }
+ * POST body: { country: string, doneIds: string[] }
+ *      → { ok: true }
+ *
+ * Response codes:
+ *   401 = no session
+ *   400 = invalid body / unknown country code
+ *   429 = rate limited
+ *   500 = DB write failed
+ *   503 = connection error
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { createClient } from "@/lib/supabase/server";
+import { logger } from "@/lib/logger";
+import { isRateLimited } from "@/lib/rate-limit";
+import { isKnownIntentCountry, type IntentCountryCode } from "@/lib/intent-context";
+import { planProgressKey, type ExpatPlanProgress } from "@/lib/expat-plan";
+import type { CalculatorStateMap } from "@/lib/calculator-state";
+import type { Json } from "@/lib/database.types";
+
+const log = logger("expat-plan-api");
+
+const WriteSchema = z.object({
+  country: z.string().min(2).max(4),
+  doneIds: z.array(z.string().min(1).max(64)).max(20),
+});
+
+export async function GET(request: NextRequest) {
+  try {
+    const country = request.nextUrl.searchParams.get("country");
+
+    if (!country || !isKnownIntentCountry(country)) {
+      return NextResponse.json(
+        { error: "Unknown country code" },
+        { status: 400 },
+      );
+    }
+
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json(
+        { error: "Session expired. Please sign in again." },
+        { status: 401 },
+      );
+    }
+
+    const { data, error } = await supabase
+      .from("user_calculator_state")
+      .select("state")
+      .eq("user_id", user.id)
+      .maybeSingle();
+
+    if (error) {
+      log.warn("expat-plan GET failed", {
+        userId: user.id,
+        error: error.message,
+      });
+      return NextResponse.json(
+        { error: "Something went wrong. Try again in a moment." },
+        { status: 500 },
+      );
+    }
+
+    const stateMap =
+      ((data as { state?: unknown } | null)?.state as CalculatorStateMap) ?? {};
+
+    const key = planProgressKey(country as IntentCountryCode);
+    const entry = stateMap[key];
+
+    let progress: ExpatPlanProgress | null = null;
+    if (entry?.data) {
+      const raw = entry.data as { doneIds?: unknown; updatedAt?: unknown };
+      const doneIds = Array.isArray(raw.doneIds)
+        ? (raw.doneIds as unknown[]).filter(
+            (id): id is string => typeof id === "string",
+          )
+        : [];
+      const updatedAt =
+        typeof raw.updatedAt === "string"
+          ? raw.updatedAt
+          : new Date(0).toISOString();
+      progress = { doneIds, updatedAt };
+    }
+
+    return NextResponse.json({ progress });
+  } catch (err) {
+    log.error("expat-plan GET threw", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json(
+      { error: "Connection issue. Please try again." },
+      { status: 503 },
+    );
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json(
+        { error: "Session expired. Please sign in again." },
+        { status: 401 },
+      );
+    }
+
+    // 120/min per user — plan progress saves are lightweight but called on
+    // every toggle; protects against autosave storms.
+    if (await isRateLimited(`expat-plan:${user.id}`, 120, 1)) {
+      return NextResponse.json({ error: "Slow down a moment." }, { status: 429 });
+    }
+
+    const json = await request.json().catch(() => null);
+    const parsed = WriteSchema.safeParse(json);
+    if (!parsed.success) {
+      return NextResponse.json({ error: "Invalid body" }, { status: 400 });
+    }
+
+    const { country, doneIds } = parsed.data;
+
+    if (!isKnownIntentCountry(country)) {
+      return NextResponse.json(
+        { error: "Unknown country code" },
+        { status: 400 },
+      );
+    }
+
+    const key = planProgressKey(country as IntentCountryCode);
+
+    // Read-merge-write — same pattern as /api/calculator-state
+    const { data: existing } = await supabase
+      .from("user_calculator_state")
+      .select("state")
+      .eq("user_id", user.id)
+      .maybeSingle();
+
+    const current =
+      ((existing as { state?: unknown } | null)?.state as CalculatorStateMap) ??
+      {};
+
+    const merged: CalculatorStateMap = {
+      ...current,
+      [key]: {
+        source: "expat-plan",
+        data: { doneIds, updatedAt: new Date().toISOString() },
+        captured_at: new Date().toISOString(),
+      },
+    };
+
+    const { error: upsertError } = await supabase
+      .from("user_calculator_state")
+      .upsert(
+        {
+          user_id: user.id,
+          state: merged as unknown as Json,
+          updated_at: new Date().toISOString(),
+        },
+        { onConflict: "user_id" },
+      );
+
+    if (upsertError) {
+      log.warn("expat-plan POST upsert failed", {
+        userId: user.id,
+        country,
+        error: upsertError.message,
+      });
+      return NextResponse.json(
+        { error: "Save failed. Please try again." },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    log.error("expat-plan POST threw", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json(
+      { error: "Connection issue. Please try again." },
+      { status: 503 },
+    );
+  }
+}

--- a/app/foreign-investment/journey/[country]/page.tsx
+++ b/app/foreign-investment/journey/[country]/page.tsx
@@ -317,6 +317,27 @@ export default async function ExpatJourneyPage({
         </div>
       </section>
 
+      {/* ── Planner CTA strip ─────────────────────────────────────────── */}
+      <div className="container-custom pt-6 pb-0">
+        <div className="bg-emerald-50 border border-emerald-200 rounded-2xl px-5 py-4 flex flex-col sm:flex-row items-start sm:items-center gap-3 justify-between">
+          <div>
+            <p className="text-sm font-extrabold text-emerald-900 leading-tight">
+              Ready to track your progress?
+            </p>
+            <p className="text-xs text-emerald-700 mt-0.5">
+              Open the interactive planner — tick off steps as you go. Progress
+              saves to your browser (or account if signed in).
+            </p>
+          </div>
+          <Link
+            href={`/foreign-investment/journey/${config.slug}/plan`}
+            className="inline-flex items-center gap-1.5 bg-emerald-600 hover:bg-emerald-500 text-white font-bold text-xs px-4 py-2 rounded-lg transition-colors shrink-0"
+          >
+            Open Planner
+          </Link>
+        </div>
+      </div>
+
       {/* ── Progress rail + steps ─────────────────────────────────────── */}
       <div className="container-custom py-10 md:py-14">
         <div className="flex flex-col lg:flex-row gap-8 items-start">
@@ -340,8 +361,21 @@ export default async function ExpatJourneyPage({
               ))}
             </nav>
 
+            {/* Track progress — planner link */}
+            <div className="mt-6 p-3 bg-emerald-50 border border-emerald-200 rounded-xl">
+              <p className="text-[0.65rem] font-bold uppercase tracking-wide text-emerald-700 mb-1">
+                Track your progress
+              </p>
+              <Link
+                href={`/foreign-investment/journey/${config.slug}/plan`}
+                className="text-xs font-semibold text-emerald-700 hover:text-emerald-800"
+              >
+                Open interactive planner →
+              </Link>
+            </div>
+
             {/* Country guide link */}
-            <div className="mt-6 p-3 bg-amber-50 border border-amber-200 rounded-xl">
+            <div className="mt-3 p-3 bg-amber-50 border border-amber-200 rounded-xl">
               <p className="text-[0.65rem] font-bold uppercase tracking-wide text-amber-700 mb-1">
                 Full country guide
               </p>

--- a/app/foreign-investment/journey/[country]/plan/page.tsx
+++ b/app/foreign-investment/journey/[country]/plan/page.tsx
@@ -1,0 +1,339 @@
+/**
+ * /foreign-investment/journey/[country]/plan
+ *
+ * Personalized cross-border planner — turns the guided journey steps into
+ * an interactive checklist with persisted progress.
+ *
+ * Architecture:
+ *   • Server component: builds the ExpatPlan, fetches user session,
+ *     renders the static shell + metadata + JSON-LD.
+ *   • Client component (ExpatPlanClient): owns interactive checkbox state,
+ *     localStorage persistence (anon) and DB sync (signed-in).
+ *
+ * Country-parameterised — same URLs as the journey:
+ *   /foreign-investment/journey/united-kingdom/plan
+ *   /foreign-investment/journey/united-states/plan
+ *   … etc.
+ *
+ * All data is from COUNTRY_CONFIGS via buildExpatPlan. No new data is
+ * fabricated.
+ *
+ * Compliance:
+ *   - GENERAL_ADVICE_WARNING rendered above the fold
+ *   - FOREIGN_INVESTOR_GENERAL_DISCLAIMER at the foot
+ *   - No personal advice, no product rankings, no performance claims
+ *   - Advisor CTAs are flat-fee referral only
+ */
+
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import type { Metadata } from "next";
+import { createClient } from "@/lib/supabase/server";
+import { breadcrumbJsonLd, SITE_URL, absoluteUrl, CURRENT_YEAR } from "@/lib/seo";
+import {
+  GENERAL_ADVICE_WARNING,
+  FOREIGN_INVESTOR_GENERAL_DISCLAIMER,
+} from "@/lib/compliance";
+import {
+  getCountryConfig,
+  COUNTRY_CONFIGS,
+} from "@/lib/foreign-investment-country-data";
+import { intentCountryFromSlug } from "@/lib/intent-context";
+import { buildExpatPlan } from "@/lib/expat-plan";
+import ForeignInvestmentNav from "../../../ForeignInvestmentNav";
+import RememberCountry from "@/components/foreign-investment/RememberCountry";
+import ExpatPlanClient from "@/components/foreign-investment/ExpatPlanClient";
+
+// ─── Static params ────────────────────────────────────────────────────────────
+
+export function generateStaticParams() {
+  return Object.values(COUNTRY_CONFIGS)
+    .filter(Boolean)
+    .map((c) => ({ country: c!.slug }));
+}
+
+// ─── Metadata ─────────────────────────────────────────────────────────────────
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ country: string }>;
+}): Promise<Metadata> {
+  const { country } = await params;
+  const code = intentCountryFromSlug(country);
+  if (!code) return { title: "Plan Not Found" };
+  const config = getCountryConfig(code);
+  if (!config) return { title: "Plan Not Found" };
+
+  const title = `${config.adjective} Investor Planner: Track Your Cross-Border Investing Steps (${CURRENT_YEAR})`;
+  const description = `Personalised checklist for ${config.adjective} residents investing in Australia. Track FIRB, tax, FX${config.retirementTransfer ? ", pension transfer" : ""}${config.migration ? ", migration" : ""} and specialist advisor steps. Save progress across sessions. General information only.`;
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title: `${config.adjective} Investor Planner — ${config.flag} Track Your AU Investing Journey (${CURRENT_YEAR})`,
+      description: `Checklist planner: FIRB, tax, FX, and advisor steps for ${config.adjective} residents investing in Australia.`,
+      url: `${SITE_URL}/foreign-investment/journey/${config.slug}/plan`,
+      images: [
+        {
+          url: `/api/og?title=${encodeURIComponent(`${config.flag} Cross-Border Investing Planner: ${config.countryShort} → Australia`)}&sub=${encodeURIComponent(`Track FIRB · Tax · FX · Advisors · ${CURRENT_YEAR}`)}`,
+          width: 1200,
+          height: 630,
+        },
+      ],
+    },
+    twitter: { card: "summary_large_image" },
+    alternates: {
+      canonical: `${SITE_URL}/foreign-investment/journey/${config.slug}/plan`,
+    },
+  };
+}
+
+export const revalidate = 86400;
+
+// ─── JSON-LD ──────────────────────────────────────────────────────────────────
+
+function buildChecklistJsonLd(
+  config: ReturnType<typeof getCountryConfig>,
+  itemCount: number,
+) {
+  if (!config) return null;
+  return {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name: `${config.adjective} Investor Cross-Border Planner — ${CURRENT_YEAR}`,
+    description: `A ${itemCount}-step checklist for ${config.adjective} residents investing in Australia. Covers FIRB eligibility, tax obligations, FX, and specialist advisor referral.`,
+    url: absoluteUrl(`/foreign-investment/journey/${config.slug}/plan`),
+    numberOfItems: itemCount,
+  };
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export default async function ExpatPlanPage({
+  params,
+}: {
+  params: Promise<{ country: string }>;
+}) {
+  const { country } = await params;
+  const code = intentCountryFromSlug(country);
+  if (!code) notFound();
+  const config = getCountryConfig(code);
+  if (!config) notFound();
+
+  const plan = buildExpatPlan(config);
+
+  // Check session for DB persistence enablement
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  const isSignedIn = Boolean(user);
+
+  const breadcrumb = breadcrumbJsonLd([
+    { name: "Home", url: SITE_URL },
+    { name: "Foreign Investment", url: `${SITE_URL}/foreign-investment` },
+    {
+      name: config.countryName,
+      url: `${SITE_URL}/foreign-investment/${config.slug}`,
+    },
+    {
+      name: "Journey",
+      url: `${SITE_URL}/foreign-investment/journey/${config.slug}`,
+    },
+    {
+      name: "Planner",
+      url: `${SITE_URL}/foreign-investment/journey/${config.slug}/plan`,
+    },
+  ]);
+
+  const checklistLd = buildChecklistJsonLd(config, plan.items.length);
+
+  return (
+    <div className="bg-white min-h-screen">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
+      />
+      {checklistLd && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(checklistLd) }}
+        />
+      )}
+
+      <RememberCountry code={code} />
+
+      <ForeignInvestmentNav current="" />
+
+      {/* ── Hero ──────────────────────────────────────────────────────── */}
+      <section className="relative bg-white border-b border-slate-100 py-8 md:py-12">
+        <div className="container-custom">
+          {/* Breadcrumb */}
+          <nav className="text-xs text-slate-500 mb-5 flex items-center gap-1.5 flex-wrap">
+            <Link href="/" className="hover:text-slate-900">
+              Home
+            </Link>
+            <span>/</span>
+            <Link href="/foreign-investment" className="hover:text-slate-900">
+              Foreign Investment
+            </Link>
+            <span>/</span>
+            <Link
+              href={`/foreign-investment/${config.slug}`}
+              className="hover:text-slate-900"
+            >
+              {config.countryName}
+            </Link>
+            <span>/</span>
+            <Link
+              href={`/foreign-investment/journey/${config.slug}`}
+              className="hover:text-slate-900"
+            >
+              Journey
+            </Link>
+            <span>/</span>
+            <span className="text-slate-900 font-medium">Planner</span>
+          </nav>
+
+          <div className="max-w-2xl">
+            <div className="inline-flex items-center gap-2 px-3 py-1 bg-slate-100 border border-slate-200 rounded-full text-xs font-semibold text-slate-600 mb-4">
+              <span className="text-base">{config.flag}</span>
+              {config.countryName} · Cross-Border Investing Planner · {CURRENT_YEAR}
+            </div>
+
+            <h1 className="text-2xl sm:text-3xl md:text-4xl font-extrabold leading-[1.1] mb-3 tracking-tight text-slate-900">
+              {config.adjective} investor{" "}
+              <span className="text-amber-600">personalised planner</span>
+            </h1>
+            <p className="text-sm md:text-base text-slate-600 leading-relaxed mb-5">
+              Tick off each step as you research and act. Your progress is saved{" "}
+              {isSignedIn ? "to your account" : "in this browser"}. Use the
+              guided{" "}
+              <Link
+                href={`/foreign-investment/journey/${config.slug}`}
+                className="text-amber-700 font-semibold hover:text-amber-800 underline underline-offset-2"
+              >
+                Journey page
+              </Link>{" "}
+              for full detail on each step. General information only — not
+              financial advice.
+            </p>
+
+            {/* General advice warning */}
+            <div className="bg-slate-50 border border-slate-200 rounded-xl p-4 mb-4">
+              <p className="text-xs text-slate-500 leading-relaxed">
+                {GENERAL_ADVICE_WARNING}
+              </p>
+            </div>
+
+            {/* Signed-out DB-sync nudge */}
+            {!isSignedIn && (
+              <div className="flex items-center gap-3 px-4 py-3 bg-amber-50 border border-amber-200 rounded-xl">
+                <p className="text-xs text-amber-800 leading-relaxed flex-1">
+                  <strong>Save across devices:</strong> sign in to sync your
+                  progress to your account.
+                </p>
+                <Link
+                  href="/login"
+                  className="text-xs font-bold text-amber-800 hover:text-amber-900 shrink-0 underline"
+                >
+                  Sign in
+                </Link>
+              </div>
+            )}
+          </div>
+        </div>
+      </section>
+
+      {/* ── Planner ────────────────────────────────────────────────────── */}
+      <div className="container-custom py-10 md:py-14">
+        <div className="flex flex-col lg:flex-row gap-8 items-start">
+          {/* Sticky sidebar (desktop) */}
+          <aside className="hidden lg:block sticky top-24 w-52 shrink-0">
+            <p className="text-[0.65rem] font-bold uppercase tracking-widest text-slate-400 mb-3">
+              Planner steps
+            </p>
+            <nav className="space-y-1">
+              {plan.items.map((item) => (
+                <a
+                  key={item.id}
+                  href={`#${item.id}`}
+                  className="flex items-center gap-2.5 px-3 py-2 rounded-lg text-xs font-semibold text-slate-600 hover:bg-slate-50 hover:text-amber-700 transition-colors group"
+                >
+                  <span className="w-5 h-5 rounded-full bg-slate-100 group-hover:bg-amber-100 text-slate-500 group-hover:text-amber-700 text-[0.6rem] font-extrabold flex items-center justify-center shrink-0 transition-colors">
+                    {item.stepNumber}
+                  </span>
+                  {item.railLabel}
+                </a>
+              ))}
+            </nav>
+
+            {/* Back to journey */}
+            <div className="mt-6 p-3 bg-amber-50 border border-amber-200 rounded-xl">
+              <p className="text-[0.65rem] font-bold uppercase tracking-wide text-amber-700 mb-1">
+                Step-by-step guide
+              </p>
+              <Link
+                href={`/foreign-investment/journey/${config.slug}`}
+                className="text-xs font-semibold text-amber-700 hover:text-amber-800"
+              >
+                {config.flag} Journey page →
+              </Link>
+            </div>
+
+            {/* Country hub */}
+            <div className="mt-3 p-3 bg-slate-50 border border-slate-200 rounded-xl">
+              <p className="text-[0.65rem] font-bold uppercase tracking-wide text-slate-500 mb-1">
+                Full country guide
+              </p>
+              <Link
+                href={`/foreign-investment/${config.slug}`}
+                className="text-xs font-semibold text-slate-600 hover:text-slate-900"
+              >
+                {config.flag} {config.countryName} investing hub →
+              </Link>
+            </div>
+          </aside>
+
+          {/* Interactive planner */}
+          <div className="flex-1 min-w-0">
+            <ExpatPlanClient plan={plan} isSignedIn={isSignedIn} />
+          </div>
+        </div>
+      </div>
+
+      {/* ── Other country planners ────────────────────────────────────── */}
+      <section className="py-10 bg-slate-50 border-t border-slate-100">
+        <div className="container-custom">
+          <p className="text-xs font-bold uppercase tracking-wider text-slate-400 mb-4">
+            Other country planners
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {Object.values(COUNTRY_CONFIGS)
+              .filter((c) => c && c.code !== config.code)
+              .map((c) => (
+                <Link
+                  key={c!.slug}
+                  href={`/foreign-investment/journey/${c!.slug}/plan`}
+                  className="px-3 py-1.5 bg-white border border-slate-200 hover:border-amber-300 text-xs font-semibold text-slate-700 hover:text-amber-700 rounded-lg transition-colors"
+                >
+                  {c!.flag} {c!.countryShort}
+                </Link>
+              ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── Compliance footer ─────────────────────────────────────────── */}
+      <section className="py-6 bg-white border-t border-slate-200">
+        <div className="container-custom">
+          <p className="text-xs text-slate-400 leading-relaxed">
+            {FOREIGN_INVESTOR_GENERAL_DISCLAIMER}
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/components/foreign-investment/ExpatPlanClient.tsx
+++ b/components/foreign-investment/ExpatPlanClient.tsx
@@ -1,0 +1,538 @@
+"use client";
+
+/**
+ * ExpatPlanClient — interactive checklist for the cross-border planner.
+ *
+ * Persistence strategy (mirrors the calculator-state pattern):
+ *   • Anonymous:  localStorage only — key `expat_plan_progress_{code}`.
+ *   • Signed-in:  localStorage for instant paint, then sync to DB via
+ *                 /api/expat-plan. DB is the source of truth on reload.
+ *
+ * The component is deliberately thin:
+ *   • It receives the pre-built ExpatPlan from the server component.
+ *   • It owns only the interactive state (which items are checked, saving
+ *     status, hydration flag).
+ *   • All plan structure / completion math is delegated back to the pure
+ *     helpers in lib/expat-plan.ts.
+ *
+ * No personal recommendations are made — items map 1:1 to the neutral
+ * journey steps that already exist. The planner only adds checkboxes.
+ */
+
+import { useEffect, useRef, useState, useCallback } from "react";
+import Link from "next/link";
+import type { ExpatPlan, PlanItem, PlanCompletion } from "@/lib/expat-plan";
+import {
+  computeCompletion,
+  planProgressKey,
+  parseProgress,
+  toggleItemDone,
+  type ExpatPlanProgress,
+} from "@/lib/expat-plan";
+
+// ─── Bold-markdown renderer ──────────────────────────────────────────────────
+
+function renderBold(text: string) {
+  return text
+    .split(/\*\*(.+?)\*\*/g)
+    .map((part, i) => (i % 2 === 1 ? <strong key={i}>{part}</strong> : part));
+}
+
+// ─── Category badge ──────────────────────────────────────────────────────────
+
+const CATEGORY_LABELS: Record<string, string> = {
+  setup: "Setup",
+  compliance: "Compliance",
+  financial: "Financial",
+  action: "Action",
+};
+
+const CATEGORY_STYLES: Record<string, string> = {
+  setup: "bg-blue-100 text-blue-700",
+  compliance: "bg-red-100 text-red-700",
+  financial: "bg-amber-100 text-amber-700",
+  action: "bg-emerald-100 text-emerald-700",
+};
+
+function CategoryBadge({ category }: { category: string }) {
+  return (
+    <span
+      className={`inline-flex items-center px-2 py-0.5 rounded-full text-[0.6rem] font-bold uppercase tracking-wide ${CATEGORY_STYLES[category] ?? "bg-slate-100 text-slate-600"}`}
+    >
+      {CATEGORY_LABELS[category] ?? category}
+    </span>
+  );
+}
+
+// ─── Completion bar ──────────────────────────────────────────────────────────
+
+function CompletionBar({
+  completion,
+  countryName,
+}: {
+  completion: PlanCompletion;
+  countryName: string;
+}) {
+  return (
+    <div className="bg-white border border-slate-200 rounded-2xl p-5 shadow-sm mb-6">
+      <div className="flex items-center justify-between mb-3">
+        <div>
+          <p className="text-sm font-extrabold text-slate-900">
+            {countryName} plan progress
+          </p>
+          <p className="text-xs text-slate-500 mt-0.5">
+            {completion.doneCount} of {completion.totalCount} steps completed
+          </p>
+        </div>
+        <div className="text-right">
+          <span
+            className={`text-2xl font-extrabold tabular-nums ${completion.complete ? "text-emerald-600" : "text-amber-600"}`}
+          >
+            {completion.percent}%
+          </span>
+        </div>
+      </div>
+      <div className="relative h-3 bg-slate-100 rounded-full overflow-hidden">
+        <div
+          className={`absolute inset-y-0 left-0 rounded-full transition-all duration-500 ${completion.complete ? "bg-emerald-500" : "bg-amber-500"}`}
+          style={{ width: `${completion.percent}%` }}
+          aria-valuenow={completion.percent}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          role="progressbar"
+          aria-label={`${completion.percent}% of ${countryName} plan completed`}
+        />
+      </div>
+      {completion.complete && (
+        <p className="text-xs font-semibold text-emerald-700 mt-2">
+          All steps reviewed — consider booking a specialist to act on your
+          plan.
+        </p>
+      )}
+    </div>
+  );
+}
+
+// ─── Plan item card ──────────────────────────────────────────────────────────
+
+function PlanItemCard({
+  item,
+  done,
+  onToggle,
+}: {
+  item: PlanItem;
+  done: boolean;
+  onToggle: (id: string, done: boolean) => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+
+  const calloutStyles =
+    item.calloutVariant === "critical"
+      ? "bg-red-50 border-red-200 text-red-900"
+      : "bg-amber-50 border-amber-200 text-amber-900";
+  const calloutLabel =
+    item.calloutVariant === "critical" ? "text-red-700" : "text-amber-700";
+
+  return (
+    <div
+      className={`bg-white rounded-2xl border shadow-sm overflow-hidden transition-all ${
+        done ? "border-emerald-300 opacity-80" : "border-slate-200"
+      }`}
+    >
+      {/* Header row */}
+      <div className="px-5 py-4 flex items-start gap-3">
+        {/* Checkbox */}
+        <button
+          type="button"
+          onClick={() => onToggle(item.id, !done)}
+          aria-label={done ? `Mark "${item.railLabel}" as not done` : `Mark "${item.railLabel}" as done`}
+          className={`mt-0.5 flex-shrink-0 w-5 h-5 rounded border-2 flex items-center justify-center transition-colors ${
+            done
+              ? "border-emerald-500 bg-emerald-500 text-white"
+              : "border-slate-300 hover:border-amber-400 bg-white"
+          }`}
+        >
+          {done && (
+            <svg
+              className="w-3 h-3"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={3}
+                d="M5 13l4 4L19 7"
+              />
+            </svg>
+          )}
+        </button>
+
+        {/* Step number + content */}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1 flex-wrap">
+            <span className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-amber-500 text-white text-[0.6rem] font-extrabold shrink-0">
+              {item.stepNumber}
+            </span>
+            <CategoryBadge category={item.category} />
+            {done && (
+              <span className="text-[0.6rem] font-bold uppercase tracking-wide text-emerald-600">
+                Done
+              </span>
+            )}
+          </div>
+          <h3
+            className={`font-extrabold text-sm leading-tight ${
+              done ? "line-through text-slate-400" : "text-slate-900"
+            }`}
+          >
+            {item.heading}
+          </h3>
+          <p className="text-xs text-slate-500 mt-1 leading-relaxed">
+            {item.summary}
+          </p>
+        </div>
+      </div>
+
+      {/* Expand/collapse toggle */}
+      <div className="px-5 pb-3 flex items-center gap-3">
+        <button
+          type="button"
+          onClick={() => setExpanded((prev) => !prev)}
+          className="text-xs font-semibold text-slate-500 hover:text-amber-700 flex items-center gap-1 transition-colors"
+          aria-expanded={expanded}
+        >
+          {expanded ? "Hide detail" : "See detail"}
+          <svg
+            className={`w-3 h-3 transition-transform ${expanded ? "rotate-180" : ""}`}
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M19 9l-7 7-7-7"
+            />
+          </svg>
+        </button>
+      </div>
+
+      {/* Expanded detail */}
+      {expanded && (
+        <div className="px-5 pb-5 border-t border-slate-100 space-y-3 pt-3">
+          {/* Callout */}
+          {item.calloutTitle && (
+            <div className={`rounded-xl border p-3 ${calloutStyles}`}>
+              <p className={`text-[0.6rem] font-bold uppercase tracking-wide mb-1 ${calloutLabel}`}>
+                {item.calloutVariant === "critical" ? "Important" : "Note"}
+              </p>
+              <p className="text-xs font-semibold mb-1">{item.calloutTitle}</p>
+              {item.calloutBody && (
+                <p className="text-xs leading-relaxed">
+                  {renderBold(item.calloutBody)}
+                </p>
+              )}
+            </div>
+          )}
+
+          {/* Detail bullets */}
+          {item.detail.length > 0 && (
+            <ul className="space-y-2">
+              {item.detail.map((bullet, i) => (
+                <li
+                  key={i}
+                  className="flex gap-2 text-xs text-slate-700 leading-relaxed"
+                >
+                  <span className="text-amber-500 font-bold mt-0.5 shrink-0">
+                    —
+                  </span>
+                  <span>{renderBold(bullet)}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {/* Links */}
+          {item.links.length > 0 && (
+            <div className="flex flex-wrap gap-2 pt-1">
+              {item.links.map((link) =>
+                link.primary ? (
+                  <Link
+                    key={link.href}
+                    href={link.href}
+                    className="inline-flex items-center gap-1 bg-amber-500 hover:bg-amber-400 text-slate-900 font-bold text-xs px-3 py-1.5 rounded-lg transition-colors"
+                  >
+                    {link.label}
+                  </Link>
+                ) : (
+                  <Link
+                    key={link.href}
+                    href={link.href}
+                    className="inline-flex items-center gap-1 border border-slate-300 hover:bg-slate-50 text-slate-700 font-semibold text-xs px-3 py-1.5 rounded-lg transition-colors"
+                  >
+                    {link.label}
+                  </Link>
+                ),
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Save status indicator ────────────────────────────────────────────────────
+
+type SaveStatus = "idle" | "saving" | "saved" | "error";
+
+function SaveStatusBadge({ status }: { status: SaveStatus }) {
+  if (status === "idle") return null;
+  const styles: Record<SaveStatus, string> = {
+    idle: "",
+    saving: "text-slate-400",
+    saved: "text-emerald-600",
+    error: "text-red-500",
+  };
+  const labels: Record<SaveStatus, string> = {
+    idle: "",
+    saving: "Saving…",
+    saved: "Saved",
+    error: "Save failed — will retry",
+  };
+  return (
+    <span className={`text-xs font-semibold ${styles[status]}`}>
+      {labels[status]}
+    </span>
+  );
+}
+
+// ─── Main component ──────────────────────────────────────────────────────────
+
+interface ExpatPlanClientProps {
+  plan: ExpatPlan;
+  /** True when user is signed in — enables DB sync. */
+  isSignedIn: boolean;
+}
+
+const SAVE_DEBOUNCE_MS = 1200;
+
+export default function ExpatPlanClient({
+  plan,
+  isSignedIn,
+}: ExpatPlanClientProps) {
+  const storageKey = planProgressKey(plan.code);
+
+  // Lazy initializer reads localStorage on first render — avoids synchronous
+  // setState in effect (which triggers cascading renders). The initializer
+  // runs once at mount on the client, so it is safe to read localStorage here.
+  const [progress, setProgress] = useState<ExpatPlanProgress>(() => {
+    if (typeof window === "undefined") {
+      return { doneIds: [], updatedAt: new Date(0).toISOString() };
+    }
+    return parseProgress(localStorage.getItem(planProgressKey(plan.code)));
+  });
+  // hydrated is always true since the lazy useState initializer already ran synchronously.
+  const [saveStatus, setSaveStatus] = useState<SaveStatus>("idle");
+
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // ─── DB sync for signed-in users ─────────────────────────────────────────
+  // Only fetches from the DB; state is already seeded from localStorage above.
+
+  useEffect(() => {
+    if (!isSignedIn) return;
+
+    void fetch(`/api/expat-plan?country=${plan.code}`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data: { progress?: ExpatPlanProgress | null } | null) => {
+        const dbProgress = data?.progress;
+        if (!dbProgress) return;
+
+        // Last-write-wins by updatedAt — reconcile DB with local state
+        setProgress((local) => {
+          const localTs = new Date(local.updatedAt).getTime();
+          const dbTs = new Date(dbProgress.updatedAt).getTime();
+          return dbTs > localTs ? dbProgress : local;
+        });
+      })
+      .catch(() => {
+        // DB fetch failed — localStorage state is fine
+      });
+  }, [plan.code, isSignedIn]);
+
+  // ─── Persist progress ──────────────────────────────────────────────────────
+
+  const persistProgress = useCallback(
+    (updated: ExpatPlanProgress) => {
+      // Always write to localStorage
+      try {
+        localStorage.setItem(storageKey, JSON.stringify(updated));
+      } catch {
+        // Quota / private-mode — silent
+      }
+
+      // For signed-in users, debounce DB write
+      if (!isSignedIn) {
+        setSaveStatus("idle");
+        return;
+      }
+
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+      setSaveStatus("saving");
+
+      saveTimerRef.current = setTimeout(() => {
+        void fetch("/api/expat-plan", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            country: plan.code,
+            doneIds: updated.doneIds,
+          }),
+        })
+          .then((r) => {
+            setSaveStatus(r.ok ? "saved" : "error");
+            if (r.ok) {
+              setTimeout(() => setSaveStatus("idle"), 2000);
+            }
+          })
+          .catch(() => {
+            setSaveStatus("error");
+          });
+      }, SAVE_DEBOUNCE_MS);
+    },
+    [plan.code, isSignedIn, storageKey],
+  );
+
+  // ─── Toggle handler ────────────────────────────────────────────────────────
+
+  const handleToggle = useCallback(
+    (itemId: string, done: boolean) => {
+      setProgress((prev) => {
+        const updated = toggleItemDone(prev, itemId, done);
+        persistProgress(updated);
+        return updated;
+      });
+    },
+    [persistProgress],
+  );
+
+  // ─── Computed completion ───────────────────────────────────────────────────
+
+  const completion = computeCompletion(plan, progress.doneIds);
+
+  // ─── Reset handler ─────────────────────────────────────────────────────────
+
+  const handleReset = useCallback(() => {
+    const reset: ExpatPlanProgress = {
+      doneIds: [],
+      updatedAt: new Date().toISOString(),
+    };
+    setProgress(reset);
+    persistProgress(reset);
+  }, [persistProgress]);
+
+  // ─── Render ────────────────────────────────────────────────────────────────
+
+  return (
+    <div>
+      {/* Completion bar */}
+      <CompletionBar completion={completion} countryName={plan.countryName} />
+
+      {/* Save status + reset */}
+      <div className="flex items-center justify-between mb-4">
+        <SaveStatusBadge status={saveStatus} />
+        {completion.doneCount > 0 && (
+          <button
+            type="button"
+            onClick={handleReset}
+            className="text-xs text-slate-400 hover:text-red-500 font-semibold transition-colors"
+          >
+            Reset progress
+          </button>
+        )}
+      </div>
+
+      {/* Checklist */}
+      <div className="space-y-3">
+        {plan.items.map((item) => (
+          <PlanItemCard
+            key={item.id}
+            item={item}
+            done={progress.doneIds.includes(item.id)}
+            onToggle={handleToggle}
+          />
+        ))}
+      </div>
+
+      {/* FX summary callout (when present) */}
+      {plan.fxSummary && (
+        <div className="mt-6 bg-amber-50 border border-amber-200 rounded-2xl p-5">
+          <p className="text-[0.65rem] font-bold uppercase tracking-wider text-amber-700 mb-1">
+            {plan.fxSummary.eyebrow}
+          </p>
+          <p className="text-sm font-extrabold text-slate-900 mb-1">
+            {plan.fxSummary.title}
+          </p>
+          <p className="text-xs text-slate-600 mb-3">{plan.fxSummary.sub}</p>
+          <p className="text-xs text-slate-700 mb-3">
+            <strong>Best option:</strong> {plan.fxSummary.bestOptionLabel} —{" "}
+            {plan.fxSummary.bestOptionCost}
+          </p>
+          <Link
+            href={plan.fxSummary.ctaHref}
+            className="inline-flex items-center gap-1.5 bg-amber-500 hover:bg-amber-400 text-slate-900 font-bold text-xs px-4 py-2 rounded-lg transition-colors"
+          >
+            {plan.fxSummary.ctaLabel}
+          </Link>
+        </div>
+      )}
+
+      {/* Pension summary callout (when present) */}
+      {plan.pensionSummary && (
+        <div className="mt-4 bg-red-50 border border-red-200 rounded-2xl p-5">
+          <p className="text-[0.65rem] font-bold uppercase tracking-wider text-red-700 mb-1">
+            Pension / Super Transfer
+          </p>
+          <p className="text-sm font-extrabold text-slate-900 mb-1">
+            {plan.pensionSummary.title}
+          </p>
+          <p className="text-xs text-slate-600 mb-3">
+            {plan.pensionSummary.sub}
+          </p>
+          {plan.pensionSummary.callout && (
+            <p className="text-xs font-semibold text-red-800 mb-3">
+              {renderBold(plan.pensionSummary.callout)}
+            </p>
+          )}
+          {plan.pensionSummary.keyRules.length > 0 && (
+            <ul className="space-y-1.5">
+              {plan.pensionSummary.keyRules.map((rule, i) => (
+                <li key={i} className="flex gap-2 text-xs text-red-900">
+                  <span className="font-bold shrink-0">—</span>
+                  <span>{renderBold(rule)}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+
+      {/* Anonymous sign-in nudge */}
+      {!isSignedIn && completion.doneCount > 0 && (
+        <div className="mt-6 bg-slate-50 border border-slate-200 rounded-2xl p-5">
+          <p className="text-xs font-semibold text-slate-700 mb-1">
+            Your progress is saved locally in this browser only.
+          </p>
+          <p className="text-xs text-slate-500">
+            Sign in to save your plan across devices and pick up where you left
+            off.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lib/expat-plan.ts
+++ b/lib/expat-plan.ts
@@ -1,0 +1,407 @@
+/**
+ * Expat Plan — transforms a built ExpatJourney into a trackable checklist plan.
+ *
+ * Design intent:
+ *   • Each JourneyStep becomes a PlanItem with a stable `id` (matches the
+ *     step's own `id`), the step's heading/summary, and an optional array
+ *     of `detail` bullets drawn from the step's bullets/links for deeper
+ *     in-plan context (particularly FX-corridor options and pension rules
+ *     where config supplies richer data).
+ *   • Progress state (`done` per item) is held externally (in
+ *     localStorage for anonymous users, and via /api/expat-plan for
+ *     signed-in users). This module only computes the plan structure and
+ *     completion math — it never reads or writes persistence.
+ *   • `buildExpatPlan` is a PURE function — same input always gives same
+ *     output. Designed for fast test iteration.
+ *   • `computeCompletion` is intentionally separate from the build step
+ *     so the client component can call it any time progress changes
+ *     without rebuilding the full plan.
+ *
+ * FX / pension deepening:
+ *   Where the country config supplies fxCorridor or retirementTransfer
+ *   data the plan surfaces an enriched `detail` list on those items —
+ *   specifically the FX option costs/speeds and the pension key rules —
+ *   so the planner view is genuinely richer than the static journey page
+ *   without fabricating any data.
+ *
+ * Compliance:
+ *   All copy is factual / general in nature. No personal recommendations,
+ *   no product rankings, no fabricated rules. AFSL general-advice scope.
+ *
+ * Tests: __tests__/lib/expat-plan.test.ts
+ */
+
+import type { CountryConfig } from "./foreign-investment-country-data";
+import type { IntentCountryCode } from "./intent-context";
+import { intentCountryMeta } from "./intent-context";
+import { buildExpatJourney, type ExpatJourney, type JourneyStep } from "./expat-journey";
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+/**
+ * A single checklist item in the cross-border plan.
+ * `id` mirrors the journey step id — stable across rebuilds.
+ */
+export interface PlanItem {
+  /** Stable id matching the source JourneyStep id (e.g. "eligibility", "firb"). */
+  id: string;
+  /** Step number (1-based, same as journey). */
+  stepNumber: number;
+  /** Short label for the progress rail and checklist header. */
+  railLabel: string;
+  /** Full heading (same as journey heading). */
+  heading: string;
+  /** 1–2 sentence summary of what this item covers. */
+  summary: string;
+  /**
+   * Enriched detail bullets surfaced from the step's factual data.
+   * May include FX option specifics, pension key rules, or reporting
+   * obligation bullets depending on what the country config supplies.
+   * Always drawn from existing config — never fabricated.
+   */
+  detail: ReadonlyArray<string>;
+  /** Links to existing calculators/pages for this step. */
+  links: ReadonlyArray<{ label: string; href: string; primary?: boolean }>;
+  /** Optional callout (critical/warn) from the source step. */
+  calloutTitle?: string;
+  calloutBody?: string;
+  calloutVariant?: "warn" | "critical";
+  /**
+   * Category used for visual grouping in the planner UI.
+   * Derived from step id — "setup", "compliance", "financial", "action".
+   */
+  category: PlanItemCategory;
+}
+
+export type PlanItemCategory = "setup" | "compliance" | "financial" | "action";
+
+/** The full plan for one country. */
+export interface ExpatPlan {
+  /** Two-letter intent code. */
+  code: IntentCountryCode;
+  /** Canonical country name. */
+  countryName: string;
+  /** Short label (e.g. "UK"). */
+  countryShort: string;
+  /** Emoji flag. */
+  flag: string;
+  /** ISO 4217 home currency. */
+  currency: string;
+  /** Ordered checklist items. Length always >= 2 (eligibility + handoff). */
+  items: ReadonlyArray<PlanItem>;
+  /**
+   * ISO 8601 date when the plan was last built.
+   * Used by the client to detect stale cached plans.
+   */
+  builtAt: string;
+  /**
+   * Extra FX detail surfaced when fxCorridor is present in the config.
+   * Allows the plan to show repatriation context without cluttering the
+   * PlanItem bullet list.
+   */
+  fxSummary?: FxSummary;
+  /**
+   * Extra pension detail surfaced when retirementTransfer is present.
+   * Structured so the planner can render it as a highlighted callout.
+   */
+  pensionSummary?: PensionSummary;
+}
+
+/** Structured FX corridor summary derived from CountryConfig.fxCorridor. */
+export interface FxSummary {
+  eyebrow: string;
+  title: string;
+  sub: string;
+  /** Best option name + cost (cheapest by badge/name). */
+  bestOptionLabel: string;
+  bestOptionCost: string;
+  /** Link to compare page. */
+  ctaLabel: string;
+  ctaHref: string;
+}
+
+/** Structured pension summary derived from CountryConfig.retirementTransfer. */
+export interface PensionSummary {
+  title: string;
+  sub: string;
+  /** High-risk callout text (from config.retirementTransfer.callout). */
+  callout?: string;
+  /** Key rule bullet points from the first accordion. */
+  keyRules: ReadonlyArray<string>;
+}
+
+/** Persisted progress for one country's plan. Stored externally (localStorage / DB). */
+export interface ExpatPlanProgress {
+  /** Which item ids have been marked done. */
+  doneIds: ReadonlyArray<string>;
+  /** ISO 8601 last-updated timestamp. */
+  updatedAt: string;
+}
+
+/** Completion result. */
+export interface PlanCompletion {
+  /** Number of items marked done. */
+  doneCount: number;
+  /** Total number of items. */
+  totalCount: number;
+  /** Percentage 0–100 (integer). */
+  percent: number;
+  /** True when every item is done. */
+  complete: boolean;
+}
+
+// ─── Category mapping ────────────────────────────────────────────────────────
+
+const CATEGORY_BY_STEP_ID: Record<string, PlanItemCategory> = {
+  eligibility: "setup",
+  firb: "compliance",
+  "investment-options": "financial",
+  tax: "compliance",
+  fx: "financial",
+  pension: "financial",
+  reporting: "compliance",
+  migration: "setup",
+  handoff: "action",
+};
+
+function categoryFor(stepId: string): PlanItemCategory {
+  return CATEGORY_BY_STEP_ID[stepId] ?? "action";
+}
+
+// ─── Detail enrichment ───────────────────────────────────────────────────────
+
+/**
+ * Build enriched detail bullets for a PlanItem.
+ *
+ * For most steps this mirrors the journey step bullets (already factual).
+ * For "fx" and "pension" we overlay structured config data to give the
+ * planner view richer context than the journey's narrative summary.
+ */
+function buildDetailBullets(
+  step: JourneyStep,
+  config: CountryConfig,
+): ReadonlyArray<string> {
+  // FX step — lead with corridor-specific cost options
+  if (step.id === "fx" && config.fxCorridor) {
+    const fx = config.fxCorridor;
+    const optionBullets = fx.options.map(
+      (opt) =>
+        `**${opt.name}** [${opt.badge}]: ${opt.cost} — ${opt.speed}. ${opt.note}`,
+    );
+    return [
+      `**Corridor**: ${fx.eyebrow}`,
+      ...optionBullets,
+      `**Key insight**: ${fx.sub}`,
+    ];
+  }
+
+  // Pension step — lead with critical rules from the first accordion
+  if (step.id === "pension" && config.retirementTransfer) {
+    const ret = config.retirementTransfer;
+    const firstAccordion = ret.accordions[0];
+    const ruleBullets = firstAccordion ? firstAccordion.bullets.slice(0, 4) : [];
+    const detail: string[] = [
+      `**What this covers**: ${ret.sub}`,
+      ...ruleBullets,
+    ];
+    if (ret.callout) {
+      detail.push(`**Warning**: ${ret.callout}`);
+    }
+    return detail;
+  }
+
+  // Reporting step — surface key obligation bullets
+  if (step.id === "reporting" && config.reportingObligations) {
+    const rep = config.reportingObligations;
+    const detail: string[] = [`**Overview**: ${rep.sub}`];
+    for (const card of rep.cards) {
+      detail.push(`**${card.title}**:`);
+      detail.push(...card.bullets.slice(0, 2));
+    }
+    return detail;
+  }
+
+  // Default — use the step's own bullets (already factual, max 6 to avoid
+  // repetition with the journey page)
+  return step.bullets.slice(0, 6);
+}
+
+// ─── FX / pension summary builders ──────────────────────────────────────────
+
+function buildFxSummary(config: CountryConfig): FxSummary | undefined {
+  if (!config.fxCorridor) return undefined;
+  const fx = config.fxCorridor;
+
+  // Find the "Recommended" or cheapest badge option as the headline
+  const best =
+    fx.options.find((o) => o.badgeAccent === "emerald") ?? fx.options[0];
+
+  if (!best) return undefined;
+
+  return {
+    eyebrow: fx.eyebrow,
+    title: fx.title,
+    sub: fx.sub,
+    bestOptionLabel: best.name,
+    bestOptionCost: best.cost,
+    ctaLabel: fx.ctaLabel,
+    ctaHref: fx.ctaHref,
+  };
+}
+
+function buildPensionSummary(config: CountryConfig): PensionSummary | undefined {
+  if (!config.retirementTransfer) return undefined;
+  const ret = config.retirementTransfer;
+
+  const firstAccordion = ret.accordions[0];
+  const keyRules: ReadonlyArray<string> = firstAccordion
+    ? firstAccordion.bullets
+    : [];
+
+  return {
+    title: ret.title,
+    sub: ret.sub,
+    callout: ret.callout,
+    keyRules,
+  };
+}
+
+// ─── Plan item builder ───────────────────────────────────────────────────────
+
+function buildPlanItem(step: JourneyStep, config: CountryConfig): PlanItem {
+  return {
+    id: step.id,
+    stepNumber: step.stepNumber,
+    railLabel: step.railLabel,
+    heading: step.heading,
+    summary: step.summary,
+    detail: buildDetailBullets(step, config),
+    links: step.links,
+    calloutTitle: step.calloutTitle,
+    calloutBody: step.calloutBody,
+    calloutVariant: step.calloutVariant,
+    category: categoryFor(step.id),
+  };
+}
+
+// ─── Public API ─────────────────────────────────────────────────────────────
+
+/**
+ * Build an ExpatPlan from a CountryConfig.
+ *
+ * Internally calls `buildExpatJourney` to get the ordered step list, then
+ * converts each step into a PlanItem with enriched detail. Overlays
+ * fxSummary and pensionSummary when the config supports them.
+ *
+ * @param config — from COUNTRY_CONFIGS[code] or getCountryConfig(code)
+ * @returns ExpatPlan with ordered checklist items
+ */
+export function buildExpatPlan(config: CountryConfig): ExpatPlan {
+  const journey: ExpatJourney = buildExpatJourney(config);
+  const meta = intentCountryMeta(config.code);
+
+  const items = journey.steps.map((step) => buildPlanItem(step, config));
+
+  return {
+    code: config.code,
+    countryName: config.countryName,
+    countryShort: config.countryShort,
+    flag: meta.flag,
+    currency: meta.currency,
+    items,
+    builtAt: new Date().toISOString(),
+    fxSummary: buildFxSummary(config),
+    pensionSummary: buildPensionSummary(config),
+  };
+}
+
+/**
+ * Compute completion stats for a plan given a set of done item ids.
+ *
+ * @param plan — the ExpatPlan (or just an items array)
+ * @param doneIds — set of item ids the user has marked done
+ * @returns PlanCompletion with doneCount, totalCount, percent, complete
+ */
+export function computeCompletion(
+  plan: Pick<ExpatPlan, "items">,
+  doneIds: ReadonlyArray<string>,
+): PlanCompletion {
+  const totalCount = plan.items.length;
+  const doneSet = new Set(doneIds);
+  const doneCount = plan.items.filter((item) => doneSet.has(item.id)).length;
+  const percent =
+    totalCount === 0 ? 0 : Math.round((doneCount / totalCount) * 100);
+  return {
+    doneCount,
+    totalCount,
+    percent,
+    complete: doneCount === totalCount && totalCount > 0,
+  };
+}
+
+/**
+ * Return a single plan item by its stable id, or undefined if not present.
+ */
+export function getPlanItem(
+  plan: ExpatPlan,
+  id: string,
+): PlanItem | undefined {
+  return plan.items.find((item) => item.id === id);
+}
+
+/**
+ * Produce the localStorage / DB storage key for a country's plan progress.
+ * Format: "expat_plan_progress_uk", "expat_plan_progress_us", etc.
+ * The key is stable — do not change without a migration.
+ */
+export function planProgressKey(code: IntentCountryCode): string {
+  return `expat_plan_progress_${code}`;
+}
+
+/**
+ * Parse persisted progress JSON, returning an empty progress object on any
+ * parse failure. Safe to call with untrusted input (localStorage values, etc.).
+ */
+export function parseProgress(raw: string | null | undefined): ExpatPlanProgress {
+  if (!raw) return { doneIds: [], updatedAt: new Date(0).toISOString() };
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      !Array.isArray((parsed as { doneIds?: unknown }).doneIds)
+    ) {
+      return { doneIds: [], updatedAt: new Date(0).toISOString() };
+    }
+    const p = parsed as { doneIds: unknown[]; updatedAt?: unknown };
+    const doneIds = p.doneIds
+      .filter((id): id is string => typeof id === "string")
+      .filter((id) => id.length > 0 && id.length < 64);
+    const updatedAt =
+      typeof p.updatedAt === "string" ? p.updatedAt : new Date(0).toISOString();
+    return { doneIds, updatedAt };
+  } catch {
+    return { doneIds: [], updatedAt: new Date(0).toISOString() };
+  }
+}
+
+/**
+ * Toggle a done state for one item, returning new progress.
+ * Pure — does not write anywhere.
+ */
+export function toggleItemDone(
+  progress: ExpatPlanProgress,
+  itemId: string,
+  done: boolean,
+): ExpatPlanProgress {
+  const current = new Set(progress.doneIds);
+  if (done) {
+    current.add(itemId);
+  } else {
+    current.delete(itemId);
+  }
+  return {
+    doneIds: Array.from(current),
+    updatedAt: new Date().toISOString(),
+  };
+}


### PR DESCRIPTION
Deepens the foreign-investment expat journey into a **personalized cross-border planner** — an interactive, progress-tracked checklist built on top of the existing guided journey (additive; reuses `buildExpatJourney`). Factual + flat-fee referral (AFSL-safe; disclaimers present).

- `lib/expat-plan.ts` — pure, tested: `buildExpatPlan()` turns journey steps into trackable checklist items, with completion math, FX-corridor + pension detail enrichment from existing config, and hardened `parseProgress` (malformed-JSON / oversized-id resistant).
- `app/api/expat-plan/route.ts` — GET/POST persisting progress in the existing `user_calculator_state` table (key `expat_plan_progress_{code}`), same read-merge-write pattern as `/api/calculator-state` (RLS via server client, rate-limited). **No migration.**
- `/foreign-investment/journey/[country]/plan` (page + `ExpatPlanClient`) — interactive checklist with completion bar, category badges, per-item detail; localStorage for anon + debounced DB write-through for signed-in. The journey page gains an "Open Planner" CTA.

**Fix on verification:** `let`→`const` in a test block.

**Verified:** `tsc` clean · **66 tests** (structural invariants across UK/US/NZ/CN/SA, completion math, link integrity, parse-attack vectors) pass · eslint clean · rate-limit + jsonld gates pass. Built on the existing journey; no fabricated rules.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUfSRE2Teb6VhEXFP6RpS9)_