### PR TITLE
feat(scenario): v2 — comparison presets, delta view, property/CGT dimension (deepen)

### DIFF
--- a/__tests__/lib/scenario-presets.test.ts
+++ b/__tests__/lib/scenario-presets.test.ts
@@ -1,0 +1,579 @@
+/**
+ * Tests for scenario-presets registry and scenario-delta calculations.
+ *
+ * Coverage:
+ *   1. Preset integrity — slugs unique, inputs valid, a/b labels distinct.
+ *   2. computeScenarioDelta — absolute delta, % delta, size indicators.
+ *   3. Neutral framing — "larger/smaller/equal", never "better/worse".
+ *   4. computeScenario property/CGT dimension — new 4th engine dimension.
+ *   5. Composition parity — property CGT result matches computeCgt standalone.
+ *   6. PRESET_SLUGS / getPreset / allPresetMeta helpers.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import {
+  SCENARIO_PRESETS,
+  PRESET_SLUGS,
+  getPreset,
+  allPresetMeta,
+} from "@/lib/scenario-presets";
+
+import { computeScenarioDelta } from "@/lib/scenario-delta";
+
+import { computeScenario, type ScenarioInput } from "@/lib/scenario-engine";
+
+import { computeCgt } from "@/lib/calculators/cgt";
+
+// ─── Preset registry integrity ────────────────────────────────────────────────
+
+describe("SCENARIO_PRESETS — registry integrity", () => {
+  it("contains at least 1 preset", () => {
+    expect(SCENARIO_PRESETS.length).toBeGreaterThan(0);
+  });
+
+  it("all slugs are unique", () => {
+    const slugs = SCENARIO_PRESETS.map((p) => p.slug);
+    const unique = new Set(slugs);
+    expect(unique.size).toBe(slugs.length);
+  });
+
+  it("all slugs are non-empty kebab-case strings", () => {
+    for (const p of SCENARIO_PRESETS) {
+      expect(p.slug).toMatch(/^[a-z][a-z0-9-]+$/);
+    }
+  });
+
+  it("all presets have non-empty title, summary, a.label, b.label", () => {
+    for (const p of SCENARIO_PRESETS) {
+      expect(p.title.length).toBeGreaterThan(0);
+      expect(p.summary.length).toBeGreaterThan(0);
+      expect(p.a.label.length).toBeGreaterThan(0);
+      expect(p.b.label.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("all preset a/b labels are distinct", () => {
+    for (const p of SCENARIO_PRESETS) {
+      expect(p.a.label).not.toBe(p.b.label);
+    }
+  });
+
+  it("all preset inputs have required ScenarioInput fields", () => {
+    for (const p of SCENARIO_PRESETS) {
+      for (const side of [p.a, p.b]) {
+        const inp = side.inputs;
+        expect(typeof inp.currentAge).toBe("number");
+        expect(typeof inp.retirementAge).toBe("number");
+        expect(typeof inp.annualSalary).toBe("number");
+        expect(typeof inp.currentSuperBalance).toBe("number");
+        expect(inp.retirementAge).toBeGreaterThan(inp.currentAge);
+      }
+    }
+  });
+
+  it("all preset inputs produce valid ScenarioResult without throwing", () => {
+    for (const p of SCENARIO_PRESETS) {
+      expect(() => computeScenario(p.a.inputs)).not.toThrow();
+      expect(() => computeScenario(p.b.inputs)).not.toThrow();
+    }
+  });
+
+  it("all preset results have positive projected super at retirement", () => {
+    for (const p of SCENARIO_PRESETS) {
+      const ra = computeScenario(p.a.inputs);
+      const rb = computeScenario(p.b.inputs);
+      expect(ra.retirement.projectedSuperAtRetirement).toBeGreaterThan(0);
+      expect(rb.retirement.projectedSuperAtRetirement).toBeGreaterThan(0);
+    }
+  });
+
+  it("highlights is a non-empty array for every preset", () => {
+    for (const p of SCENARIO_PRESETS) {
+      expect(Array.isArray(p.highlights)).toBe(true);
+      expect(p.highlights.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ─── PRESET_SLUGS helper ─────────────────────────────────────────────────────
+
+describe("PRESET_SLUGS", () => {
+  it("contains the same slugs as SCENARIO_PRESETS in the same order", () => {
+    expect(PRESET_SLUGS).toEqual(SCENARIO_PRESETS.map((p) => p.slug));
+  });
+});
+
+// ─── getPreset helper ────────────────────────────────────────────────────────
+
+describe("getPreset", () => {
+  it("returns the correct preset for a known slug", () => {
+    const first = SCENARIO_PRESETS[0];
+    if (!first) return;
+    const found = getPreset(first.slug);
+    expect(found).toBeDefined();
+    expect(found?.slug).toBe(first.slug);
+    expect(found?.title).toBe(first.title);
+  });
+
+  it("returns undefined for an unknown slug", () => {
+    expect(getPreset("this-slug-does-not-exist")).toBeUndefined();
+  });
+
+  it("returns undefined for empty string", () => {
+    expect(getPreset("")).toBeUndefined();
+  });
+});
+
+// ─── allPresetMeta helper ─────────────────────────────────────────────────────
+
+describe("allPresetMeta", () => {
+  it("returns an array the same length as SCENARIO_PRESETS", () => {
+    expect(allPresetMeta()).toHaveLength(SCENARIO_PRESETS.length);
+  });
+
+  it("each entry has slug, title, summary", () => {
+    for (const m of allPresetMeta()) {
+      expect(typeof m.slug).toBe("string");
+      expect(typeof m.title).toBe("string");
+      expect(typeof m.summary).toBe("string");
+    }
+  });
+
+  it("does not include inputs (only meta fields)", () => {
+    for (const m of allPresetMeta()) {
+      expect((m as Record<string, unknown>)["a"]).toBeUndefined();
+      expect((m as Record<string, unknown>)["b"]).toBeUndefined();
+    }
+  });
+});
+
+// ─── computeScenarioDelta — delta math ───────────────────────────────────────
+
+describe("computeScenarioDelta — delta math", () => {
+  const baseInput: ScenarioInput = {
+    currentAge: 35,
+    retirementAge: 67,
+    annualSalary: 100_000,
+    currentSuperBalance: 150_000,
+    extraConcessionalContribs: 0,
+    expectedReturnPct: 7,
+  };
+
+  const highSacrificeInput: ScenarioInput = {
+    ...baseInput,
+    extraConcessionalContribs: 18_500,
+  };
+
+  it("returns an array of delta rows", () => {
+    const rA = computeScenario(highSacrificeInput);
+    const rB = computeScenario(baseInput);
+    const deltas = computeScenarioDelta(rA, rB);
+    expect(Array.isArray(deltas)).toBe(true);
+    expect(deltas.length).toBeGreaterThan(0);
+  });
+
+  it("absoluteDelta = valueA − valueB for each row", () => {
+    const rA = computeScenario(highSacrificeInput);
+    const rB = computeScenario(baseInput);
+    const deltas = computeScenarioDelta(rA, rB);
+    for (const d of deltas) {
+      expect(d.absoluteDelta).toBeCloseTo(d.valueA - d.valueB, 5);
+    }
+  });
+
+  it("pctDelta = (A − B) / |B| × 100 when B ≠ 0", () => {
+    const rA = computeScenario(highSacrificeInput);
+    const rB = computeScenario(baseInput);
+    const deltas = computeScenarioDelta(rA, rB);
+    for (const d of deltas) {
+      if (d.valueB !== 0 && d.pctDelta !== null) {
+        expect(d.pctDelta).toBeCloseTo(
+          ((d.valueA - d.valueB) / Math.abs(d.valueB)) * 100,
+          5,
+        );
+      }
+    }
+  });
+
+  it("pctDelta is null when valueB is 0", () => {
+    const rA = computeScenario(baseInput);
+    const rB = computeScenario(baseInput);
+    // Both identical → some rows will have 0 delta but not necessarily 0 valueB.
+    // Force a case with valueB = 0: no investment income.
+    const deltas = computeScenarioDelta(rA, rB);
+    const zeroValueBRows = deltas.filter((d) => d.valueB === 0);
+    for (const d of zeroValueBRows) {
+      expect(d.pctDelta).toBeNull();
+    }
+  });
+
+  it("sizeA is 'larger' when valueA > valueB", () => {
+    const rA = computeScenario(highSacrificeInput);
+    const rB = computeScenario(baseInput);
+    const deltas = computeScenarioDelta(rA, rB);
+    const superRow = deltas.find((d) => d.metric === "Projected super at retirement");
+    expect(superRow).toBeDefined();
+    // High sacrifice → larger projected super
+    expect(superRow?.sizeA).toBe("larger");
+  });
+
+  it("sizeA is 'smaller' when valueA < valueB", () => {
+    const rA = computeScenario(baseInput);
+    const rB = computeScenario(highSacrificeInput);
+    const deltas = computeScenarioDelta(rA, rB);
+    const superRow = deltas.find((d) => d.metric === "Projected super at retirement");
+    expect(superRow).toBeDefined();
+    expect(superRow?.sizeA).toBe("smaller");
+  });
+
+  it("sizeA is 'equal' when A and B are identical", () => {
+    const r = computeScenario(baseInput);
+    const deltas = computeScenarioDelta(r, r);
+    for (const d of deltas) {
+      // All deltas should be 0 / equal when comparing a scenario to itself
+      expect(d.sizeA).toBe("equal");
+      expect(d.absoluteDelta).toBeCloseTo(0, 5);
+    }
+  });
+
+  it("every DeltaRow has all required fields", () => {
+    const rA = computeScenario(highSacrificeInput);
+    const rB = computeScenario(baseInput);
+    const deltas = computeScenarioDelta(rA, rB);
+    for (const d of deltas) {
+      expect(typeof d.metric).toBe("string");
+      expect(d.metric.length).toBeGreaterThan(0);
+      expect(["retirement", "super", "investmentTax", "property"]).toContain(d.category);
+      expect(typeof d.valueA).toBe("number");
+      expect(typeof d.valueB).toBe("number");
+      expect(typeof d.absoluteDelta).toBe("number");
+      expect(["currency", "years", "percentage", "boolean"]).toContain(d.format);
+      expect(["larger", "smaller", "equal"]).toContain(d.sizeA);
+    }
+  });
+
+  it("includes retirement, super, and investmentTax categories by default", () => {
+    const r = computeScenario(baseInput);
+    const deltas = computeScenarioDelta(r, r);
+    const cats = new Set(deltas.map((d) => d.category));
+    expect(cats.has("retirement")).toBe(true);
+    expect(cats.has("super")).toBe(true);
+    expect(cats.has("investmentTax")).toBe(true);
+  });
+
+  it("does NOT include property category when neither side has a property", () => {
+    const r = computeScenario(baseInput);
+    const deltas = computeScenarioDelta(r, r);
+    const propRows = deltas.filter((d) => d.category === "property");
+    expect(propRows).toHaveLength(0);
+  });
+
+  it("includes property category when side A has a property", () => {
+    const rA = computeScenario({ ...baseInput, propertyPurchasePrice: 800_000 });
+    const rB = computeScenario(baseInput);
+    const deltas = computeScenarioDelta(rA, rB);
+    const propRows = deltas.filter((d) => d.category === "property");
+    expect(propRows.length).toBeGreaterThan(0);
+  });
+});
+
+// ─── computeScenario — property/CGT dimension ────────────────────────────────
+
+describe("computeScenario — property/CGT dimension", () => {
+  const baseInput: ScenarioInput = {
+    currentAge: 35,
+    retirementAge: 67,
+    annualSalary: 100_000,
+    currentSuperBalance: 150_000,
+  };
+
+  it("property.hasProperty is false when no propertyPurchasePrice provided", () => {
+    const r = computeScenario(baseInput);
+    expect(r.property.hasProperty).toBe(false);
+    expect(r.property.purchasePrice).toBe(0);
+    expect(r.property.projectedPropertyValue).toBe(0);
+    expect(r.property.grossGain).toBe(0);
+  });
+
+  it("property.hasProperty is false when propertyPurchasePrice is 0", () => {
+    const r = computeScenario({ ...baseInput, propertyPurchasePrice: 0 });
+    expect(r.property.hasProperty).toBe(false);
+  });
+
+  it("property.hasProperty is true when propertyPurchasePrice > 0", () => {
+    const r = computeScenario({ ...baseInput, propertyPurchasePrice: 500_000 });
+    expect(r.property.hasProperty).toBe(true);
+    expect(r.property.purchasePrice).toBe(500_000);
+  });
+
+  it("projectedPropertyValue grows by compound growth over years to retirement", () => {
+    const purchase = 600_000;
+    const growthPct = 4;
+    const years = 67 - 35; // 32 years
+    const expected = purchase * Math.pow(1 + growthPct / 100, years);
+
+    const r = computeScenario({
+      ...baseInput,
+      propertyPurchasePrice: purchase,
+      propertyGrowthRatePct: growthPct,
+    });
+
+    expect(r.property.projectedPropertyValue).toBeCloseTo(expected, -2);
+  });
+
+  it("grossGain = projectedPropertyValue − purchasePrice", () => {
+    const r = computeScenario({ ...baseInput, propertyPurchasePrice: 700_000 });
+    expect(r.property.grossGain).toBeCloseTo(
+      r.property.projectedPropertyValue - r.property.purchasePrice,
+      5,
+    );
+  });
+
+  it("grossGain is 0 when growth rate is 0", () => {
+    const r = computeScenario({
+      ...baseInput,
+      propertyPurchasePrice: 500_000,
+      propertyGrowthRatePct: 0,
+    });
+    expect(r.property.grossGain).toBeCloseTo(0, 5);
+  });
+
+  it("netEquityAfterCgt = projectedPropertyValue − cgt.taxWithDiscount", () => {
+    const r = computeScenario({ ...baseInput, propertyPurchasePrice: 800_000 });
+    expect(r.property.netEquityAfterCgt).toBeCloseTo(
+      r.property.projectedPropertyValue - r.property.cgt.taxWithDiscount,
+      5,
+    );
+  });
+
+  it("estimatedAnnualRentalIncome = purchasePrice × rentalYieldPct / 100", () => {
+    const r = computeScenario({
+      ...baseInput,
+      propertyPurchasePrice: 600_000,
+      propertyRentalYieldPct: 3.5,
+    });
+    expect(r.property.estimatedAnnualRentalIncome).toBeCloseTo(600_000 * 0.035, 2);
+  });
+
+  it("estimatedAnnualHoldingCosts = purchasePrice × holdingCostsPct / 100", () => {
+    const r = computeScenario({
+      ...baseInput,
+      propertyPurchasePrice: 600_000,
+      propertyHoldingCostsPct: 2,
+    });
+    expect(r.property.estimatedAnnualHoldingCosts).toBeCloseTo(600_000 * 0.02, 2);
+  });
+
+  it("defaults growthRatePct to 4 when propertyPurchasePrice > 0 and not specified", () => {
+    const r = computeScenario({ ...baseInput, propertyPurchasePrice: 500_000 });
+    expect(r.property.growthRatePct).toBe(4);
+  });
+
+  it("defaults growthRatePct to 0 when propertyPurchasePrice is 0", () => {
+    const r = computeScenario(baseInput);
+    expect(r.property.growthRatePct).toBe(0);
+  });
+});
+
+// ─── Composition parity: property CGT = standalone computeCgt ────────────────
+
+describe("composition parity — property CGT matches computeCgt standalone", () => {
+  it("engine cgt.taxWithDiscount matches standalone computeCgt for the same gain and marginal rate", () => {
+    const purchase = 700_000;
+    const growthPct = 4;
+    const years = 67 - 35;
+    const salary = 100_000;
+
+    const r = computeScenario({
+      currentAge: 35,
+      retirementAge: 67,
+      annualSalary: salary,
+      currentSuperBalance: 150_000,
+      propertyPurchasePrice: purchase,
+      propertyGrowthRatePct: growthPct,
+      propertyHeld12Months: true,
+    });
+
+    const projectedValue = purchase * Math.pow(1 + growthPct / 100, years);
+    const grossGain = projectedValue - purchase;
+
+    // Marginal rate at $100k salary using marginalRateIncludingMedicare logic:
+    // $100k is in the $45k–$120k bracket → 32.5% + 2% Medicare = 34.5%
+    const marginalRate = 0.345;
+
+    const standalone = computeCgt({
+      gain: grossGain,
+      marginalRate,
+      held12Months: true,
+      holder: "individual",
+    });
+
+    expect(r.property.cgt.taxWithDiscount).toBeCloseTo(standalone.taxWithDiscount, 0);
+    expect(r.property.cgt.discountedGain).toBeCloseTo(standalone.discountedGain, 0);
+    expect(r.property.cgt.taxSaved).toBeCloseTo(standalone.taxSaved, 0);
+  });
+
+  it("taxWithDiscount < taxWithoutDiscount when held12Months = true", () => {
+    const r = computeScenario({
+      currentAge: 35,
+      retirementAge: 67,
+      annualSalary: 100_000,
+      currentSuperBalance: 150_000,
+      propertyPurchasePrice: 800_000,
+      propertyHeld12Months: true,
+    });
+    expect(r.property.cgt.taxWithDiscount).toBeLessThan(
+      r.property.cgt.taxWithoutDiscount,
+    );
+  });
+
+  it("taxWithDiscount equals taxWithoutDiscount when held12Months = false", () => {
+    const r = computeScenario({
+      currentAge: 35,
+      retirementAge: 67,
+      annualSalary: 100_000,
+      currentSuperBalance: 150_000,
+      propertyPurchasePrice: 800_000,
+      propertyHeld12Months: false,
+    });
+    expect(r.property.cgt.taxWithDiscount).toBeCloseTo(
+      r.property.cgt.taxWithoutDiscount,
+      5,
+    );
+  });
+
+  it("prior engine outputs are unchanged by adding property inputs", () => {
+    const base: ScenarioInput = {
+      currentAge: 35,
+      retirementAge: 67,
+      annualSalary: 100_000,
+      currentSuperBalance: 150_000,
+    };
+    const withProp: ScenarioInput = { ...base, propertyPurchasePrice: 600_000 };
+
+    const rBase = computeScenario(base);
+    const rWith = computeScenario(withProp);
+
+    // Property input must not affect retirement, super, or investmentTax
+    expect(rWith.retirement.projectedSuperAtRetirement).toBeCloseTo(
+      rBase.retirement.projectedSuperAtRetirement,
+      5,
+    );
+    expect(rWith.superContributions.totalSuperTax).toBeCloseTo(
+      rBase.superContributions.totalSuperTax,
+      5,
+    );
+    expect(rWith.investmentTax.taxOnInvestmentIncome).toBeCloseTo(
+      rBase.investmentTax.taxOnInvestmentIncome,
+      5,
+    );
+  });
+});
+
+// ─── Preset: salary-sacrifice-vs-etf specific checks ─────────────────────────
+
+describe("preset: salary-sacrifice-vs-etf", () => {
+  it("exists in the registry", () => {
+    expect(getPreset("salary-sacrifice-vs-etf")).toBeDefined();
+  });
+
+  it("scenario A (salary sacrifice) has higher projected super than scenario B", () => {
+    const p = getPreset("salary-sacrifice-vs-etf");
+    if (!p) return;
+    const rA = computeScenario(p.a.inputs);
+    const rB = computeScenario(p.b.inputs);
+    // Salary sacrifice grows super faster — A should project higher super
+    expect(rA.retirement.projectedSuperAtRetirement).toBeGreaterThan(
+      rB.retirement.projectedSuperAtRetirement,
+    );
+  });
+
+  it("scenario A has a positive tax saving on extra contribs", () => {
+    const p = getPreset("salary-sacrifice-vs-etf");
+    if (!p) return;
+    const rA = computeScenario(p.a.inputs);
+    expect(rA.superContributions.taxSavingOnExtraContribs).toBeGreaterThan(0);
+  });
+
+  it("scenario B has positive investment tax (due to franked dividends)", () => {
+    const p = getPreset("salary-sacrifice-vs-etf");
+    if (!p) return;
+    const rB = computeScenario(p.b.inputs);
+    expect(rB.investmentTax.taxOnInvestmentIncome).toBeGreaterThan(0);
+  });
+});
+
+// ─── Preset: max-concessional-vs-moderate specific checks ────────────────────
+
+describe("preset: max-concessional-vs-moderate", () => {
+  it("exists in the registry", () => {
+    expect(getPreset("max-concessional-vs-moderate")).toBeDefined();
+  });
+
+  it("scenario A (max sacrifice) has higher projected super", () => {
+    const p = getPreset("max-concessional-vs-moderate");
+    if (!p) return;
+    const rA = computeScenario(p.a.inputs);
+    const rB = computeScenario(p.b.inputs);
+    expect(rA.retirement.projectedSuperAtRetirement).toBeGreaterThan(
+      rB.retirement.projectedSuperAtRetirement,
+    );
+  });
+
+  it("scenario A tax saving is greater than scenario B tax saving", () => {
+    const p = getPreset("max-concessional-vs-moderate");
+    if (!p) return;
+    const rA = computeScenario(p.a.inputs);
+    const rB = computeScenario(p.b.inputs);
+    expect(rA.superContributions.taxSavingOnExtraContribs).toBeGreaterThan(
+      rB.superContributions.taxSavingOnExtraContribs,
+    );
+  });
+});
+
+// ─── Preset: early-retirement-vs-standard specific checks ────────────────────
+
+describe("preset: early-retirement-vs-standard", () => {
+  it("exists in the registry", () => {
+    expect(getPreset("early-retirement-vs-standard")).toBeDefined();
+  });
+
+  it("standard retirement (B) projects larger super than early (A)", () => {
+    const p = getPreset("early-retirement-vs-standard");
+    if (!p) return;
+    const rA = computeScenario(p.a.inputs);
+    const rB = computeScenario(p.b.inputs);
+    // B has 7 more years of accumulation → larger super
+    expect(rB.retirement.projectedSuperAtRetirement).toBeGreaterThan(
+      rA.retirement.projectedSuperAtRetirement,
+    );
+  });
+
+  it("both yearsToRetirement values differ by 7", () => {
+    const p = getPreset("early-retirement-vs-standard");
+    if (!p) return;
+    const rA = computeScenario(p.a.inputs);
+    const rB = computeScenario(p.b.inputs);
+    expect(rB.retirement.yearsToRetirement - rA.retirement.yearsToRetirement).toBe(7);
+  });
+});
+
+// ─── Preset: smsf-vs-industry-super specific checks ─────────────────────────
+
+describe("preset: smsf-vs-industry-super", () => {
+  it("exists in the registry", () => {
+    expect(getPreset("smsf-vs-industry-super")).toBeDefined();
+  });
+
+  it("industry super (B, higher effective return) projects larger super", () => {
+    const p = getPreset("smsf-vs-industry-super");
+    if (!p) return;
+    const rA = computeScenario(p.a.inputs);
+    const rB = computeScenario(p.b.inputs);
+    // B has a higher effective return rate → larger projected super
+    expect(rB.retirement.projectedSuperAtRetirement).toBeGreaterThan(
+      rA.retirement.projectedSuperAtRetirement,
+    );
+  });
+});

--- a/app/scenarios/compare/[preset]/PresetCompareClient.tsx
+++ b/app/scenarios/compare/[preset]/PresetCompareClient.tsx
@@ -1,0 +1,453 @@
+"use client";
+
+/**
+ * PresetCompareClient — interactive delta view for a scenario comparison preset.
+ *
+ * Displays two pre-computed scenarios (A and B) side-by-side with:
+ *   - Per-metric absolute delta (A − B) and percentage delta.
+ *   - Neutral "larger / smaller / equal" size indicator (NOT "better/worse").
+ *   - Property / CGT dimension when the preset includes property inputs.
+ *
+ * AFSL compliance: GENERAL_ADVICE_WARNING is shown prominently.
+ * No personalised recommendations are produced.
+ */
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
+import { formatCurrency } from "@/lib/utils";
+import { computeScenario } from "@/lib/scenario-engine";
+import { computeScenarioDelta, type DeltaRow } from "@/lib/scenario-delta";
+import { allPresetMeta, type ScenarioPreset } from "@/lib/scenario-presets";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function formatValue(value: number, format: DeltaRow["format"]): string {
+  switch (format) {
+    case "currency":
+      return formatCurrency(value);
+    case "years":
+      return `${Math.round(value)} yrs`;
+    case "percentage":
+      return `${value.toFixed(1)}%`;
+    case "boolean":
+      return value ? "Yes" : "No";
+    default:
+      return String(value);
+  }
+}
+
+function formatDelta(delta: number, pct: number | null, format: DeltaRow["format"]): string {
+  const sign = delta > 0 ? "+" : "";
+  const absFormatted =
+    format === "currency"
+      ? formatCurrency(Math.abs(delta))
+      : format === "years"
+        ? `${Math.abs(Math.round(delta))} yrs`
+        : format === "percentage"
+          ? `${Math.abs(delta).toFixed(1)}%`
+          : String(Math.abs(delta));
+
+  const pctStr = pct !== null ? ` (${sign}${pct.toFixed(1)}%)` : "";
+  return `${sign}${absFormatted}${pctStr}`;
+}
+
+// ─── Category labels ──────────────────────────────────────────────────────────
+
+const CATEGORY_LABELS: Record<DeltaRow["category"], string> = {
+  retirement: "Retirement Projection",
+  super: "Super Contributions",
+  investmentTax: "Investment Income Tax",
+  property: "Property / CGT Projection",
+};
+
+// ─── Size indicator badge ─────────────────────────────────────────────────────
+
+function SizeBadge({ size }: { size: DeltaRow["sizeA"] }) {
+  if (size === "equal") {
+    return (
+      <span className="inline-block text-[0.6rem] font-bold uppercase tracking-wide bg-slate-100 text-slate-500 px-1.5 py-0.5 rounded">
+        Equal
+      </span>
+    );
+  }
+  return (
+    <span
+      className={`inline-block text-[0.6rem] font-bold uppercase tracking-wide px-1.5 py-0.5 rounded ${
+        size === "larger"
+          ? "bg-sky-50 text-sky-700"
+          : "bg-orange-50 text-orange-700"
+      }`}
+    >
+      A {size}
+    </span>
+  );
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+export default function PresetCompareClient({
+  preset,
+}: {
+  preset: ScenarioPreset;
+}) {
+  const [activeCategory, setActiveCategory] = useState<DeltaRow["category"] | "all">("all");
+
+  const resultA = useMemo(() => computeScenario(preset.a.inputs), [preset.a.inputs]);
+  const resultB = useMemo(() => computeScenario(preset.b.inputs), [preset.b.inputs]);
+  const deltas = useMemo(() => computeScenarioDelta(resultA, resultB), [resultA, resultB]);
+
+  const categories = useMemo(
+    () =>
+      [...new Set(deltas.map((d) => d.category))].filter(
+        (c): c is DeltaRow["category"] => true,
+      ),
+    [deltas],
+  );
+
+  const visibleDeltas =
+    activeCategory === "all"
+      ? deltas
+      : deltas.filter((d) => d.category === activeCategory);
+
+  const otherPresets = useMemo(
+    () => allPresetMeta().filter((p) => p.slug !== preset.slug),
+    [preset.slug],
+  );
+
+  return (
+    <div className="py-0">
+      {/* ── Hero ─────────────────────────────────────────────────────── */}
+      <div className="bg-gradient-to-br from-violet-700 via-violet-800 to-violet-900 text-white py-8 md:py-14 px-4">
+        <div className="container-custom max-w-4xl text-center">
+          <p className="text-xs font-bold uppercase tracking-widest text-violet-300 mb-2">
+            Scenario Comparison
+          </p>
+          <h1 className="text-xl md:text-3xl font-extrabold mb-3">
+            {preset.title}
+          </h1>
+          <p className="text-sm md:text-base text-violet-100 max-w-2xl mx-auto leading-relaxed">
+            {preset.summary}
+          </p>
+          <p className="text-[0.7rem] text-violet-300 mt-3 max-w-xl mx-auto">
+            General information only — not personal advice. See disclaimer below.
+          </p>
+        </div>
+      </div>
+
+      <div className="container-custom max-w-5xl py-6 md:py-10 space-y-6">
+        {/* ── Scenario summary cards ───────────────────────────────────── */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {[
+            { label: preset.a.label, desc: preset.a.description, result: resultA, id: "scenario-a" },
+            { label: preset.b.label, desc: preset.b.description, result: resultB, id: "scenario-b" },
+          ].map(({ label, desc, result, id }) => (
+            <div
+              key={id}
+              id={id}
+              className="bg-white border border-slate-200 rounded-2xl p-5 space-y-3"
+            >
+              <div>
+                <p className="text-sm font-extrabold text-violet-700">{label}</p>
+                <p className="text-xs text-slate-500 mt-0.5 leading-snug">{desc}</p>
+              </div>
+              <div className="grid grid-cols-2 gap-2">
+                <div className="bg-slate-50 rounded-xl p-3 text-center">
+                  <p className="text-[0.6rem] text-slate-500 font-semibold uppercase tracking-wide">
+                    Super at retirement
+                  </p>
+                  <p className="text-sm font-black text-violet-700 mt-0.5">
+                    {formatCurrency(result.retirement.projectedSuperAtRetirement)}
+                  </p>
+                </div>
+                <div className="bg-slate-50 rounded-xl p-3 text-center">
+                  <p className="text-[0.6rem] text-slate-500 font-semibold uppercase tracking-wide">
+                    Drawdown years
+                  </p>
+                  <p className="text-sm font-black text-slate-800 mt-0.5">
+                    {result.retirement.drawdownYears} yrs
+                  </p>
+                </div>
+                <div className="bg-slate-50 rounded-xl p-3 text-center">
+                  <p className="text-[0.6rem] text-slate-500 font-semibold uppercase tracking-wide">
+                    Super tax saving p.a.
+                  </p>
+                  <p className="text-sm font-black text-emerald-700 mt-0.5">
+                    {formatCurrency(result.superContributions.taxSavingOnExtraContribs)}
+                  </p>
+                </div>
+                <div className="bg-slate-50 rounded-xl p-3 text-center">
+                  <p className="text-[0.6rem] text-slate-500 font-semibold uppercase tracking-wide">
+                    Investment tax p.a.
+                  </p>
+                  <p className="text-sm font-black text-amber-700 mt-0.5">
+                    {formatCurrency(result.investmentTax.taxOnInvestmentIncome)}
+                  </p>
+                </div>
+                {result.property.hasProperty && (
+                  <>
+                    <div className="bg-sky-50 rounded-xl p-3 text-center col-span-2">
+                      <p className="text-[0.6rem] text-slate-500 font-semibold uppercase tracking-wide">
+                        Property value at retirement
+                      </p>
+                      <p className="text-sm font-black text-sky-700 mt-0.5">
+                        {formatCurrency(result.property.projectedPropertyValue)}
+                      </p>
+                    </div>
+                    <div className="bg-sky-50 rounded-xl p-3 text-center">
+                      <p className="text-[0.6rem] text-slate-500 font-semibold uppercase tracking-wide">
+                        CGT (with discount)
+                      </p>
+                      <p className="text-sm font-black text-orange-700 mt-0.5">
+                        {formatCurrency(result.property.cgt.taxWithDiscount)}
+                      </p>
+                    </div>
+                    <div className="bg-sky-50 rounded-xl p-3 text-center">
+                      <p className="text-[0.6rem] text-slate-500 font-semibold uppercase tracking-wide">
+                        Net equity after CGT
+                      </p>
+                      <p className="text-sm font-black text-sky-800 mt-0.5">
+                        {formatCurrency(result.property.netEquityAfterCgt)}
+                      </p>
+                    </div>
+                  </>
+                )}
+              </div>
+              {result.retirement.isOnTrack ? (
+                <p className="text-xs text-emerald-600 font-semibold">
+                  Projected to meet 4% rule target
+                </p>
+              ) : (
+                <p className="text-xs text-amber-600 font-semibold">
+                  Projected gap: {formatCurrency(Math.abs(result.retirement.gapToTarget))}
+                </p>
+              )}
+            </div>
+          ))}
+        </div>
+
+        {/* ── Category filter ────────────────────────────────────────────── */}
+        <div className="flex flex-wrap gap-2">
+          <button
+            onClick={() => setActiveCategory("all")}
+            className={`text-xs font-semibold px-3 py-1.5 rounded-lg transition-all ${
+              activeCategory === "all"
+                ? "bg-violet-600 text-white"
+                : "bg-slate-100 text-slate-600 hover:bg-slate-200"
+            }`}
+          >
+            All metrics
+          </button>
+          {categories.map((cat) => (
+            <button
+              key={cat}
+              onClick={() => setActiveCategory(cat)}
+              className={`text-xs font-semibold px-3 py-1.5 rounded-lg transition-all ${
+                activeCategory === cat
+                  ? "bg-violet-600 text-white"
+                  : "bg-slate-100 text-slate-600 hover:bg-slate-200"
+              }`}
+            >
+              {CATEGORY_LABELS[cat]}
+            </button>
+          ))}
+        </div>
+
+        {/* ── Delta table ───────────────────────────────────────────────── */}
+        <div className="bg-white border border-slate-200 rounded-2xl overflow-hidden">
+          {/* Table header */}
+          <div className="grid grid-cols-[2fr_1fr_1fr_1fr_1fr] bg-violet-600 text-white text-[0.65rem] font-bold">
+            <div className="px-4 py-3">Metric</div>
+            <div className="px-3 py-3 text-right border-l border-violet-500">
+              {preset.a.label.split(" ")[0]}
+            </div>
+            <div className="px-3 py-3 text-right border-l border-violet-500">
+              {preset.b.label.split(" ")[0]}
+            </div>
+            <div className="px-3 py-3 text-right border-l border-violet-500">
+              A − B (delta)
+            </div>
+            <div className="px-3 py-3 text-center border-l border-violet-500">
+              Size (A vs B)
+            </div>
+          </div>
+
+          {/* Category grouping */}
+          {(activeCategory === "all" ? categories : [activeCategory]).map((cat) => {
+            const catRows = visibleDeltas.filter((d) => d.category === cat);
+            if (catRows.length === 0) return null;
+            return (
+              <div key={cat}>
+                <div className="px-4 py-2 bg-slate-50 border-b border-slate-100">
+                  <p className="text-[0.6rem] font-bold text-slate-600 uppercase tracking-widest">
+                    {CATEGORY_LABELS[cat]}
+                  </p>
+                </div>
+                {catRows.map((d, i) => (
+                  <div
+                    key={d.metric}
+                    className={`grid grid-cols-[2fr_1fr_1fr_1fr_1fr] text-xs border-b border-slate-100 last:border-b-0 ${
+                      i % 2 === 0 ? "bg-white" : "bg-slate-50/40"
+                    }`}
+                  >
+                    {/* Metric name */}
+                    <div className="px-4 py-2.5 text-slate-600 font-medium">
+                      {d.metric}
+                    </div>
+
+                    {/* Value A */}
+                    <div className="px-3 py-2.5 text-right font-semibold text-slate-800 border-l border-slate-100">
+                      {formatValue(d.valueA, d.format)}
+                    </div>
+
+                    {/* Value B */}
+                    <div className="px-3 py-2.5 text-right font-semibold text-slate-800 border-l border-slate-100">
+                      {formatValue(d.valueB, d.format)}
+                    </div>
+
+                    {/* Delta */}
+                    <div
+                      className={`px-3 py-2.5 text-right font-semibold border-l border-slate-100 ${
+                        Math.abs(d.absoluteDelta) < 0.005
+                          ? "text-slate-400"
+                          : d.absoluteDelta > 0
+                            ? "text-sky-700"
+                            : "text-orange-700"
+                      }`}
+                    >
+                      {Math.abs(d.absoluteDelta) < 0.005
+                        ? "—"
+                        : formatDelta(d.absoluteDelta, d.pctDelta, d.format)}
+                    </div>
+
+                    {/* Size indicator */}
+                    <div className="px-3 py-2.5 text-center border-l border-slate-100">
+                      <SizeBadge size={d.sizeA} />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            );
+          })}
+        </div>
+
+        {/* ── Highlights callout ────────────────────────────────────────── */}
+        {preset.highlights.length > 0 && (
+          <div className="bg-violet-50 border border-violet-200 rounded-2xl p-4">
+            <p className="text-xs font-bold text-violet-800 mb-1">
+              Key metrics illustrated by this comparison
+            </p>
+            <div className="flex flex-wrap gap-1.5 mt-1">
+              {preset.highlights.map((h) => (
+                <span
+                  key={h}
+                  className="text-[0.65rem] font-semibold bg-violet-100 text-violet-700 px-2.5 py-0.5 rounded-full"
+                >
+                  {h}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* ── Other presets ─────────────────────────────────────────────── */}
+        {otherPresets.length > 0 && (
+          <div>
+            <p className="text-xs font-bold text-slate-700 mb-2">
+              Other scenario comparisons
+            </p>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+              {otherPresets.map((p) => (
+                <Link
+                  key={p.slug}
+                  href={`/scenarios/compare/${p.slug}`}
+                  className="flex items-start gap-2 bg-white border border-slate-200 rounded-xl p-4 hover:border-violet-300 hover:shadow-sm transition-all group"
+                >
+                  <div className="flex-1 min-w-0">
+                    <p className="text-xs font-bold text-slate-800 group-hover:text-violet-700 transition-colors leading-snug">
+                      {p.title}
+                    </p>
+                    <p className="text-[0.65rem] text-slate-400 mt-0.5 line-clamp-2 leading-snug">
+                      {p.summary.slice(0, 100)}…
+                    </p>
+                  </div>
+                  <span className="text-slate-300 group-hover:text-violet-400 transition-colors shrink-0 mt-0.5">
+                    →
+                  </span>
+                </Link>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* ── CTA: open in full planner ──────────────────────────────────── */}
+        <div className="bg-violet-50 border border-violet-200 rounded-2xl p-5 text-center">
+          <p className="text-sm font-bold text-violet-800 mb-1">
+            Customise these numbers for your situation
+          </p>
+          <p className="text-xs text-violet-600 mb-3">
+            Open the full Scenario Planner, enter your own salary, super balance,
+            and investment details, and save up to 3 personal scenarios to compare.
+          </p>
+          <Link
+            href="/scenarios/plan"
+            className="inline-block px-5 py-2.5 bg-violet-600 text-white text-sm font-bold rounded-xl hover:bg-violet-700 transition-all"
+          >
+            Open Scenario Planner →
+          </Link>
+        </div>
+
+        {/* ── General advice warning ─────────────────────────────────────── */}
+        <div className="p-4 bg-slate-50 border border-slate-200 rounded-xl">
+          <p className="text-[0.65rem] text-slate-500 leading-relaxed">
+            {GENERAL_ADVICE_WARNING}
+          </p>
+          <p className="text-[0.65rem] text-slate-400 mt-2 leading-relaxed">
+            Projections use FY2026 tax rates and the nominal rates stated in each
+            scenario assumption. Actual outcomes depend on investment returns,
+            future tax-law changes, your personal circumstances, and factors not
+            modelled here (Age Pension, LITO, HELP/HECS, mortgage costs, stamp
+            duty, depreciation, vacancy rates). Contribution caps quoted are for
+            FY2026 — verify with the ATO before acting. The size indicator
+            (&quot;larger&quot; / &quot;smaller&quot;) is factual and neutral — it is not advice
+            about which scenario is preferable for your situation.
+          </p>
+        </div>
+
+        {/* ── Cross-links ────────────────────────────────────────────────── */}
+        <div className="flex flex-wrap gap-2">
+          <Link
+            href="/scenarios/plan"
+            className="text-xs px-3 py-1.5 bg-slate-100 text-slate-700 font-semibold rounded-lg hover:bg-slate-200"
+          >
+            Scenario Planner →
+          </Link>
+          <Link
+            href="/retirement-calculator"
+            className="text-xs px-3 py-1.5 bg-slate-100 text-slate-700 font-semibold rounded-lg hover:bg-slate-200"
+          >
+            Retirement Calculator →
+          </Link>
+          <Link
+            href="/super-contributions-calculator"
+            className="text-xs px-3 py-1.5 bg-slate-100 text-slate-700 font-semibold rounded-lg hover:bg-slate-200"
+          >
+            Super Contributions Calculator →
+          </Link>
+          <Link
+            href="/cgt-calculator"
+            className="text-xs px-3 py-1.5 bg-slate-100 text-slate-700 font-semibold rounded-lg hover:bg-slate-200"
+          >
+            CGT Calculator →
+          </Link>
+          <Link
+            href="/find-advisor"
+            className="text-xs px-3 py-1.5 bg-slate-100 text-slate-700 font-semibold rounded-lg hover:bg-slate-200"
+          >
+            Find an Adviser →
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/scenarios/compare/[preset]/page.tsx
+++ b/app/scenarios/compare/[preset]/page.tsx
@@ -1,0 +1,140 @@
+/**
+ * /scenarios/compare/[preset] — shareable comparison preset page.
+ *
+ * Server component: statically generated at build time for every preset slug.
+ * Hands off to `PresetCompareClient` for the interactive delta view.
+ *
+ * SEO: Article + ItemList JSON-LD + BreadcrumbList.
+ * AFSL: GENERAL_ADVICE_WARNING is displayed by the client component.
+ */
+
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { absoluteUrl, breadcrumbJsonLd, SITE_NAME } from "@/lib/seo";
+import { itemListJsonLd } from "@/lib/schema-markup";
+import { getPreset, PRESET_SLUGS, allPresetMeta } from "@/lib/scenario-presets";
+import PresetCompareClient from "./PresetCompareClient";
+
+// ─── SSG: build all preset pages at compile time ──────────────────────────────
+
+export async function generateStaticParams() {
+  return PRESET_SLUGS.map((slug) => ({ preset: slug }));
+}
+
+// ─── Metadata ─────────────────────────────────────────────────────────────────
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ preset: string }>;
+}): Promise<Metadata> {
+  const { preset: slug } = await params;
+  const p = getPreset(slug);
+  if (!p) return {};
+
+  const description = `${p.summary.slice(0, 150)}… General information only — not personal advice.`;
+
+  return {
+    title: `${p.title} — Scenario Comparison`,
+    description,
+    alternates: { canonical: `/scenarios/compare/${slug}` },
+    openGraph: {
+      title: `${p.title} — ${SITE_NAME}`,
+      description,
+      images: [
+        {
+          url: `/api/og?title=${encodeURIComponent(p.title)}&subtitle=Scenario+Comparison&type=tool`,
+          width: 1200,
+          height: 630,
+        },
+      ],
+    },
+    robots: "index, follow",
+  };
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export default async function PresetComparePage({
+  params,
+}: {
+  params: Promise<{ preset: string }>;
+}) {
+  const { preset: slug } = await params;
+  const preset = getPreset(slug);
+  if (!preset) notFound();
+
+  // BreadcrumbList JSON-LD
+  const bcLd = breadcrumbJsonLd([
+    { name: "Home", url: absoluteUrl("/") },
+    { name: "Scenarios", url: absoluteUrl("/scenarios") },
+    { name: "Compare Presets", url: absoluteUrl("/scenarios/compare") },
+    { name: preset.title },
+  ]);
+
+  // Article JSON-LD — describes this comparison page as editorial content
+  const articleLd = {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    headline: preset.title,
+    description: preset.summary.slice(0, 300),
+    url: absoluteUrl(`/scenarios/compare/${slug}`),
+    publisher: {
+      "@type": "Organization",
+      name: SITE_NAME,
+      url: absoluteUrl("/"),
+    },
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": absoluteUrl(`/scenarios/compare/${slug}`),
+    },
+  };
+
+  // ItemList JSON-LD — the two scenarios being compared
+  const itemListLd = itemListJsonLd(preset.title, [
+    {
+      position: 1,
+      name: preset.a.label,
+      url: `/scenarios/compare/${slug}#scenario-a`,
+      description: preset.a.description,
+    },
+    {
+      position: 2,
+      name: preset.b.label,
+      url: `/scenarios/compare/${slug}#scenario-b`,
+      description: preset.b.description,
+    },
+  ]);
+
+  // ItemList of ALL presets for sitelinks / related-content discovery
+  const allPresetsLd = itemListJsonLd("Scenario Comparison Presets", [
+    ...allPresetMeta().map((p, i) => ({
+      position: i + 1,
+      name: p.title,
+      url: `/scenarios/compare/${p.slug}`,
+      description: p.summary.slice(0, 120),
+    })),
+  ]);
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(bcLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(itemListLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(allPresetsLd) }}
+      />
+      <PresetCompareClient preset={preset} />
+    </>
+  );
+}

--- a/app/scenarios/plan/ScenarioPlannerClient.tsx
+++ b/app/scenarios/plan/ScenarioPlannerClient.tsx
@@ -3,10 +3,11 @@
 /**
  * Scenario Planner — client component.
  *
- * Composes retirement, super-contributions, and investment-income-tax
- * projections into one unified view. Save up to 3 named scenarios to
- * `user_calculator_state` (key: "scenario_planner") and compare two
- * side-by-side.
+ * Composes retirement, super-contributions, investment-income-tax, and
+ * property/CGT projections into one unified view. Save up to 3 named
+ * scenarios to `user_calculator_state` (key: "scenario_planner") and
+ * compare two side-by-side with per-metric delta (absolute + %) and
+ * a neutral "larger/smaller" size indicator.
  *
  * AFSL compliance: all outputs are factual projections with
  * GENERAL_ADVICE_WARNING displayed prominently. No personalised
@@ -26,6 +27,7 @@ import {
   type ScenarioResult,
   type ScenarioPlannerSnapshot,
 } from "@/lib/scenario-engine";
+import { computeScenarioDelta, type DeltaRow } from "@/lib/scenario-delta";
 
 // ─── nanoid-lite (no dependency needed) ──────────────────────────────────────
 function nanoid(): string {
@@ -51,6 +53,11 @@ const DEFAULT_INPUTS: Required<ScenarioInput> = {
   frankingPct: 100,
   annualCapitalGain: 0,
   capitalGainDiscountEligible: false,
+  propertyPurchasePrice: 0,
+  propertyGrowthRatePct: 0,
+  propertyRentalYieldPct: 3,
+  propertyHoldingCostsPct: 1.5,
+  propertyHeld12Months: true,
 };
 
 // ─── Max saved scenarios ──────────────────────────────────────────────────────
@@ -428,7 +435,36 @@ function ResultsPanel({ result }: { result: ScenarioResult }) {
   );
 }
 
-// ─── Compare panel ────────────────────────────────────────────────────────────
+// ─── Compare panel (richer delta view) ───────────────────────────────────────
+
+function formatDeltaValue(value: number, format: DeltaRow["format"]): string {
+  switch (format) {
+    case "currency":
+      return formatCurrency(value);
+    case "years":
+      return `${Math.round(value)} yrs`;
+    case "percentage":
+      return `${value.toFixed(1)}%`;
+    default:
+      return String(value);
+  }
+}
+
+function formatDeltaDisplay(row: DeltaRow): string {
+  if (Math.abs(row.absoluteDelta) < 0.005) return "—";
+  const sign = row.absoluteDelta > 0 ? "+" : "";
+  const absStr = formatDeltaValue(Math.abs(row.absoluteDelta), row.format);
+  const pctStr =
+    row.pctDelta !== null ? ` (${sign}${row.pctDelta.toFixed(1)}%)` : "";
+  return `${sign}${absStr}${pctStr}`;
+}
+
+const CATEGORY_LABELS: Record<DeltaRow["category"], string> = {
+  retirement: "Retirement",
+  super: "Super Contributions",
+  investmentTax: "Investment Tax",
+  property: "Property / CGT",
+};
 
 function ComparePanel({
   a,
@@ -437,116 +473,100 @@ function ComparePanel({
   a: { label: string; result: ScenarioResult };
   b: { label: string; result: ScenarioResult };
 }) {
-  type Row = { label: string; va: string; vb: string; better?: "a" | "b" | "tie" };
-
-  const rows: Row[] = [
-    {
-      label: "Projected super at retirement",
-      va: formatCurrency(a.result.retirement.projectedSuperAtRetirement),
-      vb: formatCurrency(b.result.retirement.projectedSuperAtRetirement),
-      better:
-        a.result.retirement.projectedSuperAtRetirement >
-        b.result.retirement.projectedSuperAtRetirement
-          ? "a"
-          : a.result.retirement.projectedSuperAtRetirement <
-              b.result.retirement.projectedSuperAtRetirement
-            ? "b"
-            : "tie",
-    },
-    {
-      label: "4% rule target",
-      va: formatCurrency(a.result.retirement.targetBalance4PctRule),
-      vb: formatCurrency(b.result.retirement.targetBalance4PctRule),
-    },
-    {
-      label: "Gap to target",
-      va: formatCurrency(Math.abs(a.result.retirement.gapToTarget)),
-      vb: formatCurrency(Math.abs(b.result.retirement.gapToTarget)),
-      better:
-        a.result.retirement.gapToTarget <= b.result.retirement.gapToTarget
-          ? "a"
-          : "b",
-    },
-    {
-      label: "On track",
-      va: a.result.retirement.isOnTrack ? "Yes" : "No",
-      vb: b.result.retirement.isOnTrack ? "Yes" : "No",
-    },
-    {
-      label: "Drawdown years",
-      va: String(a.result.retirement.drawdownYears),
-      vb: String(b.result.retirement.drawdownYears),
-      better:
-        a.result.retirement.drawdownYears > b.result.retirement.drawdownYears
-          ? "a"
-          : a.result.retirement.drawdownYears <
-              b.result.retirement.drawdownYears
-            ? "b"
-            : "tie",
-    },
-    {
-      label: "Super tax saving p.a.",
-      va: formatCurrency(a.result.superContributions.taxSavingOnExtraContribs),
-      vb: formatCurrency(b.result.superContributions.taxSavingOnExtraContribs),
-      better:
-        a.result.superContributions.taxSavingOnExtraContribs >
-        b.result.superContributions.taxSavingOnExtraContribs
-          ? "a"
-          : a.result.superContributions.taxSavingOnExtraContribs <
-              b.result.superContributions.taxSavingOnExtraContribs
-            ? "b"
-            : "tie",
-    },
-    {
-      label: "Investment tax p.a.",
-      va: formatCurrency(a.result.investmentTax.taxOnInvestmentIncome),
-      vb: formatCurrency(b.result.investmentTax.taxOnInvestmentIncome),
-      better:
-        a.result.investmentTax.taxOnInvestmentIncome <
-        b.result.investmentTax.taxOnInvestmentIncome
-          ? "a"
-          : a.result.investmentTax.taxOnInvestmentIncome >
-              b.result.investmentTax.taxOnInvestmentIncome
-            ? "b"
-            : "tie",
-    },
-  ];
+  const deltas = computeScenarioDelta(a.result, b.result);
+  const categories = [...new Set(deltas.map((d) => d.category))] as DeltaRow["category"][];
 
   return (
-    <div className="bg-white border border-slate-200 rounded-2xl overflow-hidden">
-      <div className="grid grid-cols-3 bg-violet-600 text-white text-xs font-bold">
-        <div className="px-4 py-3">Metric</div>
-        <div className="px-4 py-3 text-center border-l border-violet-500">
-          {a.label}
-        </div>
-        <div className="px-4 py-3 text-center border-l border-violet-500">
-          {b.label}
-        </div>
-      </div>
-      {rows.map((row, i) => (
-        <div
-          key={i}
-          className={`grid grid-cols-3 text-xs border-b border-slate-100 last:border-b-0 ${i % 2 === 0 ? "bg-white" : "bg-slate-50/60"}`}
-        >
-          <div className="px-4 py-2.5 text-slate-600 font-medium">
-            {row.label}
-          </div>
+    <div className="space-y-3">
+      {categories.map((cat) => {
+        const catRows = deltas.filter((d) => d.category === cat);
+        return (
           <div
-            className={`px-4 py-2.5 text-center font-semibold border-l border-slate-100 ${
-              row.better === "a" ? "text-emerald-700 bg-emerald-50/60" : "text-slate-800"
-            }`}
+            key={cat}
+            className="bg-white border border-slate-200 rounded-2xl overflow-hidden"
           >
-            {row.va}
+            {/* Category header */}
+            <div className="grid grid-cols-[2fr_1fr_1fr_1fr_auto] bg-violet-600 text-white text-[0.65rem] font-bold">
+              <div className="px-4 py-2.5">{CATEGORY_LABELS[cat]}</div>
+              <div className="px-3 py-2.5 text-right border-l border-violet-500 truncate max-w-[7rem]">
+                {a.label}
+              </div>
+              <div className="px-3 py-2.5 text-right border-l border-violet-500 truncate max-w-[7rem]">
+                {b.label}
+              </div>
+              <div className="px-3 py-2.5 text-right border-l border-violet-500">
+                A − B
+              </div>
+              <div className="px-3 py-2.5 text-center border-l border-violet-500">
+                Size
+              </div>
+            </div>
+
+            {/* Rows */}
+            {catRows.map((row, i) => (
+              <div
+                key={row.metric}
+                className={`grid grid-cols-[2fr_1fr_1fr_1fr_auto] text-xs border-b border-slate-100 last:border-b-0 ${
+                  i % 2 === 0 ? "bg-white" : "bg-slate-50/50"
+                }`}
+              >
+                {/* Metric */}
+                <div className="px-4 py-2 text-slate-600 font-medium">
+                  {row.metric}
+                </div>
+
+                {/* A value */}
+                <div className="px-3 py-2 text-right font-semibold text-slate-800 border-l border-slate-100">
+                  {formatDeltaValue(row.valueA, row.format)}
+                </div>
+
+                {/* B value */}
+                <div className="px-3 py-2 text-right font-semibold text-slate-800 border-l border-slate-100">
+                  {formatDeltaValue(row.valueB, row.format)}
+                </div>
+
+                {/* Delta */}
+                <div
+                  className={`px-3 py-2 text-right font-semibold border-l border-slate-100 text-[0.65rem] ${
+                    Math.abs(row.absoluteDelta) < 0.005
+                      ? "text-slate-400"
+                      : row.absoluteDelta > 0
+                        ? "text-sky-700"
+                        : "text-orange-700"
+                  }`}
+                >
+                  {formatDeltaDisplay(row)}
+                </div>
+
+                {/* Neutral size indicator */}
+                <div className="px-3 py-2 text-center border-l border-slate-100">
+                  {row.sizeA === "equal" ? (
+                    <span className="inline-block text-[0.55rem] font-bold uppercase tracking-wide bg-slate-100 text-slate-500 px-1.5 py-0.5 rounded">
+                      =
+                    </span>
+                  ) : (
+                    <span
+                      className={`inline-block text-[0.55rem] font-bold uppercase tracking-wide px-1.5 py-0.5 rounded ${
+                        row.sizeA === "larger"
+                          ? "bg-sky-50 text-sky-700"
+                          : "bg-orange-50 text-orange-700"
+                      }`}
+                    >
+                      A {row.sizeA}
+                    </span>
+                  )}
+                </div>
+              </div>
+            ))}
           </div>
-          <div
-            className={`px-4 py-2.5 text-center font-semibold border-l border-slate-100 ${
-              row.better === "b" ? "text-emerald-700 bg-emerald-50/60" : "text-slate-800"
-            }`}
-          >
-            {row.vb}
-          </div>
-        </div>
-      ))}
+        );
+      })}
+
+      <p className="text-[0.6rem] text-slate-400 leading-relaxed">
+        Size indicator (&quot;A larger&quot; / &quot;A smaller&quot;) is factual — it reflects the
+        numerical relationship between the two projections, not a recommendation
+        about which scenario is preferable.
+      </p>
     </div>
   );
 }
@@ -1199,6 +1219,12 @@ export default function ScenarioPlannerClient() {
             className="text-xs px-3 py-1.5 bg-slate-100 text-slate-700 font-semibold rounded-lg hover:bg-slate-200"
           >
             Find an Adviser →
+          </Link>
+          <Link
+            href="/scenarios/compare/salary-sacrifice-vs-etf"
+            className="text-xs px-3 py-1.5 bg-violet-100 text-violet-700 font-semibold rounded-lg hover:bg-violet-200"
+          >
+            Preset: Salary Sacrifice vs ETF →
           </Link>
         </div>
       </div>

--- a/lib/scenario-delta.ts
+++ b/lib/scenario-delta.ts
@@ -1,0 +1,238 @@
+/**
+ * Scenario delta calculations — richer compare view.
+ *
+ * Computes per-metric absolute and percentage deltas between two
+ * `ScenarioResult` objects without any "better/worse" framing.
+ * Uses neutral size language: "larger" / "smaller" / "equal".
+ *
+ * AFSL scope
+ * ----------
+ * Delta labels are factual and neutral. "Larger" means numerically
+ * greater; it is NOT a recommendation. Callers MUST display
+ * `GENERAL_ADVICE_WARNING` from `lib/compliance.ts` alongside any
+ * comparison.
+ *
+ * Design
+ * ------
+ * - Pure function; no I/O, no state.
+ * - Each `DeltaRow` carries raw numbers so rendering code can apply
+ *   its own formatting (currency, percentage, integer).
+ * - The `sizeA` / `sizeB` indicator is always from A's perspective:
+ *     "larger" means A > B; "smaller" means A < B; "equal" means equal.
+ */
+
+import { type ScenarioResult } from "@/lib/scenario-engine";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type DeltaSize = "larger" | "smaller" | "equal";
+
+export interface DeltaRow {
+  /** Human-readable metric name (matches the compare table rows). */
+  metric: string;
+  /** Category grouping for collapsible sections. */
+  category: "retirement" | "super" | "investmentTax" | "property";
+  /** Raw numeric value for scenario A (before formatting). */
+  valueA: number;
+  /** Raw numeric value for scenario B (before formatting). */
+  valueB: number;
+  /** Absolute difference: valueA − valueB. Negative means A < B. */
+  absoluteDelta: number;
+  /**
+   * Percentage delta relative to B: ((A − B) / |B|) × 100.
+   * `null` when B is 0 (division by zero guard).
+   */
+  pctDelta: number | null;
+  /**
+   * Neutral size indicator from A's perspective.
+   * "larger" → A numerically greater; "smaller" → A numerically less; "equal" → identical.
+   */
+  sizeA: DeltaSize;
+  /** Format hint for the rendering layer. */
+  format: "currency" | "years" | "percentage" | "boolean";
+}
+
+// ─── Helper ───────────────────────────────────────────────────────────────────
+
+function row(
+  metric: string,
+  category: DeltaRow["category"],
+  valueA: number,
+  valueB: number,
+  format: DeltaRow["format"],
+): DeltaRow {
+  const absoluteDelta = valueA - valueB;
+  const pctDelta = valueB !== 0 ? (absoluteDelta / Math.abs(valueB)) * 100 : null;
+  const sizeA: DeltaSize =
+    Math.abs(absoluteDelta) < 0.005
+      ? "equal"
+      : absoluteDelta > 0
+        ? "larger"
+        : "smaller";
+  return { metric, category, valueA, valueB, absoluteDelta, pctDelta, sizeA, format };
+}
+
+// ─── Main export ──────────────────────────────────────────────────────────────
+
+/**
+ * Compute per-metric deltas between two scenario results.
+ *
+ * Returns an array of `DeltaRow` objects — one per key metric.
+ * The list is ordered for display: retirement first, then super,
+ * then investment tax, then property (if either side has one).
+ *
+ * Pure function. No I/O, no state.
+ */
+export function computeScenarioDelta(
+  a: ScenarioResult,
+  b: ScenarioResult,
+): DeltaRow[] {
+  const rows: DeltaRow[] = [
+    // ── Retirement ──────────────────────────────────────────────────
+    row(
+      "Projected super at retirement",
+      "retirement",
+      a.retirement.projectedSuperAtRetirement,
+      b.retirement.projectedSuperAtRetirement,
+      "currency",
+    ),
+    row(
+      "4% rule target",
+      "retirement",
+      a.retirement.targetBalance4PctRule,
+      b.retirement.targetBalance4PctRule,
+      "currency",
+    ),
+    row(
+      "Gap to target (absolute)",
+      "retirement",
+      Math.abs(a.retirement.gapToTarget),
+      Math.abs(b.retirement.gapToTarget),
+      "currency",
+    ),
+    row(
+      "Drawdown years",
+      "retirement",
+      a.retirement.drawdownYears,
+      b.retirement.drawdownYears,
+      "years",
+    ),
+    row(
+      "Years to retirement",
+      "retirement",
+      a.retirement.yearsToRetirement,
+      b.retirement.yearsToRetirement,
+      "years",
+    ),
+    row(
+      "Annual employer SG",
+      "retirement",
+      a.retirement.annualEmployerContrib,
+      b.retirement.annualEmployerContrib,
+      "currency",
+    ),
+
+    // ── Super contributions ──────────────────────────────────────────
+    row(
+      "Total concessional contributions p.a.",
+      "super",
+      a.superContributions.totalConcessional,
+      b.superContributions.totalConcessional,
+      "currency",
+    ),
+    row(
+      "Super tax p.a.",
+      "super",
+      a.superContributions.totalSuperTax,
+      b.superContributions.totalSuperTax,
+      "currency",
+    ),
+    row(
+      "Tax saving vs taking as income p.a.",
+      "super",
+      a.superContributions.taxSavingOnExtraContribs,
+      b.superContributions.taxSavingOnExtraContribs,
+      "currency",
+    ),
+    row(
+      "Net concessional in super p.a.",
+      "super",
+      a.superContributions.netConcessionalInSuper,
+      b.superContributions.netConcessionalInSuper,
+      "currency",
+    ),
+
+    // ── Investment tax ────────────────────────────────────────────────
+    row(
+      "Tax on investment income p.a.",
+      "investmentTax",
+      a.investmentTax.taxOnInvestmentIncome,
+      b.investmentTax.taxOnInvestmentIncome,
+      "currency",
+    ),
+    row(
+      "Net investment income after tax p.a.",
+      "investmentTax",
+      a.investmentTax.netInvestmentIncome,
+      b.investmentTax.netInvestmentIncome,
+      "currency",
+    ),
+    row(
+      "Effective rate on investment income",
+      "investmentTax",
+      a.investmentTax.effectiveRateOnInvestmentIncome,
+      b.investmentTax.effectiveRateOnInvestmentIncome,
+      "percentage",
+    ),
+  ];
+
+  // ── Property (include when either side has a property) ────────────
+  if (a.property.hasProperty || b.property.hasProperty) {
+    rows.push(
+      row(
+        "Projected property value at retirement",
+        "property",
+        a.property.projectedPropertyValue,
+        b.property.projectedPropertyValue,
+        "currency",
+      ),
+      row(
+        "Gross capital gain on sale",
+        "property",
+        a.property.grossGain,
+        b.property.grossGain,
+        "currency",
+      ),
+      row(
+        "CGT payable (with discount)",
+        "property",
+        a.property.cgt.taxWithDiscount,
+        b.property.cgt.taxWithDiscount,
+        "currency",
+      ),
+      row(
+        "Net equity after estimated CGT",
+        "property",
+        a.property.netEquityAfterCgt,
+        b.property.netEquityAfterCgt,
+        "currency",
+      ),
+      row(
+        "Estimated annual rental income",
+        "property",
+        a.property.estimatedAnnualRentalIncome,
+        b.property.estimatedAnnualRentalIncome,
+        "currency",
+      ),
+      row(
+        "Estimated annual holding costs",
+        "property",
+        a.property.estimatedAnnualHoldingCosts,
+        b.property.estimatedAnnualHoldingCosts,
+        "currency",
+      ),
+    );
+  }
+
+  return rows;
+}

--- a/lib/scenario-engine.ts
+++ b/lib/scenario-engine.ts
@@ -1,9 +1,10 @@
 /**
  * Scenario Planning Engine — pure, composed projection model.
  *
- * Chains the retirement projection, super-contributions tax logic, and
- * investment-income-tax estimator into a single typed result so the planner
- * page can drive all three from one input form without duplicating any formulas.
+ * Chains the retirement projection, super-contributions tax logic,
+ * investment-income-tax estimator, and property/CGT projection into a single
+ * typed result so the planner page can drive all four from one input form
+ * without duplicating any formulas.
  *
  * Design decisions
  * ----------------
@@ -11,6 +12,7 @@
  *   Trivially testable and sharable between server (RSC) and client.
  * - Calls the EXISTING pure helpers:
  *     `computeInvestmentIncomeTax`  (lib/calculators/investment-income-tax.ts)
+ *     `computeCgt`                  (lib/calculators/cgt.ts)
  *   Retirement and super-contributions maths are extracted verbatim from the
  *   existing inline component maths (RetirementCalculatorClient.tsx,
  *   SuperContributionsClient.tsx) into this module so they can be tested
@@ -31,6 +33,7 @@
  */
 
 import { computeInvestmentIncomeTax } from "@/lib/calculators/investment-income-tax";
+import { computeCgt, type CgtResult } from "@/lib/calculators/cgt";
 
 // ─── FY2026 super constants (keep in sync with SuperContributionsClient.tsx) ──
 export const CONCESSIONAL_CAP = 30_000;
@@ -101,6 +104,36 @@ export interface ScenarioInput {
   annualCapitalGain?: number;
   /** Whether the capital-gain assets were held > 12 months (CGT discount eligible). Defaults to false. */
   capitalGainDiscountEligible?: boolean;
+
+  // ── Property / CGT projection (optional) ─────────────────────────────────
+  /**
+   * Purchase price of an investment property (AUD). When provided (> 0),
+   * `computeScenario` projects the property value at retirement and
+   * estimates the CGT liability on a hypothetical sale using `computeCgt`.
+   * Defaults to 0 (no property dimension modelled).
+   */
+  propertyPurchasePrice?: number;
+  /**
+   * Expected annual property price growth rate as a percentage (e.g. 4 for 4%).
+   * Defaults to 4 when `propertyPurchasePrice` > 0.
+   */
+  propertyGrowthRatePct?: number;
+  /**
+   * Annual gross rental yield as a percentage of purchase price (e.g. 3 for 3%).
+   * Used to estimate gross rental income each year. Defaults to 3.
+   */
+  propertyRentalYieldPct?: number;
+  /**
+   * Annual property holding costs as a percentage of purchase price
+   * (rates, insurance, maintenance — not including mortgage, interest, or depreciation).
+   * Defaults to 1.5%.
+   */
+  propertyHoldingCostsPct?: number;
+  /**
+   * Whether the property qualifies for the 50% individual CGT discount on sale.
+   * True when held > 12 months. Defaults to true when a purchase price is set.
+   */
+  propertyHeld12Months?: boolean;
 }
 
 // ─── Sub-result types ──────────────────────────────────────────────────────────
@@ -151,6 +184,59 @@ export interface SuperContributionsSummary {
   nonConcessionalExcess: number;
 }
 
+// ─── Property projection ──────────────────────────────────────────────────────
+
+/**
+ * Optional property / CGT dimension.
+ *
+ * Factual projection only — models a single investment property held from now
+ * to the retirement age, then sold. Uses `computeCgt` (lib/calculators/cgt.ts)
+ * for the CGT estimate so the result is identical to the standalone CGT calc.
+ *
+ * This is a general-information model. It does NOT model:
+ *   - mortgage / interest deductibility
+ *   - depreciation schedules
+ *   - stamp duty / transaction costs
+ *   - land tax
+ *   - negative gearing or carry-forward losses
+ *   - PPOR main-residence exemption
+ * Callers MUST display `GENERAL_ADVICE_WARNING`.
+ */
+export interface PropertyProjection {
+  /** Whether a property was provided (false when purchasePrice = 0). */
+  hasProperty: boolean;
+  /** Original purchase price echoed back (AUD). */
+  purchasePrice: number;
+  /** Projected property value at retirement age (AUD). */
+  projectedPropertyValue: number;
+  /** Gross capital gain on a hypothetical sale at retirement (AUD). */
+  grossGain: number;
+  /** CGT result — includes taxWithDiscount, taxSaved, effectiveRateWithDiscount. */
+  cgt: CgtResult;
+  /**
+   * Estimated annual gross rental income (purchasePrice × rentalYieldPct / 100).
+   * This is gross — tenancy vacancies, agent fees, and repair costs are not
+   * deducted. For general-information purposes only.
+   */
+  estimatedAnnualRentalIncome: number;
+  /**
+   * Estimated annual holding costs (purchasePrice × holdingCostsPct / 100).
+   * Covers rates, insurance, and basic maintenance — not mortgage repayments.
+   */
+  estimatedAnnualHoldingCosts: number;
+  /**
+   * Net equity at retirement AFTER the estimated CGT liability:
+   * projectedPropertyValue − cgt.taxWithDiscount.
+   */
+  netEquityAfterCgt: number;
+  /** Growth rate p.a. used for the projection (%). */
+  growthRatePct: number;
+  /** Rental yield p.a. used (%). */
+  rentalYieldPct: number;
+  /** Holding costs p.a. used (%). */
+  holdingCostsPct: number;
+}
+
 /** Annual investment-income tax estimate — thin wrapper re-exporting the existing result. */
 export type InvestmentTaxSummary = {
   /** Total tax attributable to investment income (marginal, net of franking offsets). */
@@ -178,6 +264,11 @@ export interface ScenarioResult {
   superContributions: SuperContributionsSummary;
   /** Annual investment income tax estimate. */
   investmentTax: InvestmentTaxSummary;
+  /**
+   * Property / CGT projection. Present when `inputs.propertyPurchasePrice > 0`;
+   * `hasProperty` is false otherwise.
+   */
+  property: PropertyProjection;
   /**
    * Scenario label — optional name for display and compare UX.
    * Set by the caller; `computeScenario` does not generate one.
@@ -341,6 +432,7 @@ export function computeSuperContributions(
  *   1. `computeSuperContributions` — contribution tax and caps.
  *   2. `computeRetirementProjection` — balance at retirement + drawdown.
  *   3. `computeInvestmentIncomeTax` — annual investment income tax.
+ *   4. `computeCgt` — property CGT on hypothetical sale at retirement (optional).
  *
  * Pure function. No I/O, no state. Safe to call on every render.
  *
@@ -355,6 +447,7 @@ export function computeSuperContributions(
  */
 export function computeScenario(raw: ScenarioInput): ScenarioResult {
   // ── Resolve defaults ──────────────────────────────────────────────
+  const rawPropertyPrice = Math.max(0, raw.propertyPurchasePrice ?? 0);
   const inputs: Required<ScenarioInput> = {
     currentAge: Math.max(18, Math.min(75, Math.round(raw.currentAge))),
     retirementAge: Math.max(raw.currentAge + 1, Math.min(85, Math.round(raw.retirementAge))),
@@ -373,6 +466,11 @@ export function computeScenario(raw: ScenarioInput): ScenarioResult {
     frankingPct: raw.frankingPct ?? 100,
     annualCapitalGain: Math.max(0, raw.annualCapitalGain ?? 0),
     capitalGainDiscountEligible: raw.capitalGainDiscountEligible ?? false,
+    propertyPurchasePrice: rawPropertyPrice,
+    propertyGrowthRatePct: raw.propertyGrowthRatePct ?? (rawPropertyPrice > 0 ? 4 : 0),
+    propertyRentalYieldPct: raw.propertyRentalYieldPct ?? 3,
+    propertyHoldingCostsPct: raw.propertyHoldingCostsPct ?? 1.5,
+    propertyHeld12Months: raw.propertyHeld12Months ?? true,
   };
 
   // ── 1. Super contributions ────────────────────────────────────────
@@ -427,11 +525,74 @@ export function computeScenario(raw: ScenarioInput): ScenarioResult {
     totalAssessableIncome: rawTax.totalAssessableIncome,
   };
 
+  // ── 4. Property / CGT projection ──────────────────────────────────
+  const hasProperty = inputs.propertyPurchasePrice > 0;
+  let property: PropertyProjection;
+
+  if (hasProperty) {
+    const yearsToRetirement = Math.max(0, inputs.retirementAge - inputs.currentAge);
+    const growthFraction = inputs.propertyGrowthRatePct / 100;
+    const projectedPropertyValue =
+      inputs.propertyPurchasePrice * Math.pow(1 + growthFraction, yearsToRetirement);
+    const grossGain = Math.max(0, projectedPropertyValue - inputs.propertyPurchasePrice);
+
+    // Use the marginal rate on the combined income + CGT gain to match the
+    // investment-income-tax model's bracket-progression approach. For the CGT
+    // calc we use the simple marginalRateIncludingMedicare helper (same as the
+    // super contributions saving — consistent across the engine).
+    const marginalRate = marginalRateIncludingMedicare(inputs.annualSalary);
+
+    const cgt = computeCgt({
+      gain: grossGain,
+      marginalRate,
+      held12Months: inputs.propertyHeld12Months,
+      holder: "individual",
+    });
+
+    const estimatedAnnualRentalIncome =
+      (inputs.propertyPurchasePrice * inputs.propertyRentalYieldPct) / 100;
+    const estimatedAnnualHoldingCosts =
+      (inputs.propertyPurchasePrice * inputs.propertyHoldingCostsPct) / 100;
+    const netEquityAfterCgt = projectedPropertyValue - cgt.taxWithDiscount;
+
+    property = {
+      hasProperty: true,
+      purchasePrice: inputs.propertyPurchasePrice,
+      projectedPropertyValue,
+      grossGain,
+      cgt,
+      estimatedAnnualRentalIncome,
+      estimatedAnnualHoldingCosts,
+      netEquityAfterCgt,
+      growthRatePct: inputs.propertyGrowthRatePct,
+      rentalYieldPct: inputs.propertyRentalYieldPct,
+      holdingCostsPct: inputs.propertyHoldingCostsPct,
+    };
+  } else {
+    // No property — return a zeroed-out placeholder so callers can
+    // unconditionally access result.property without null-checks.
+    const zeroCgt = computeCgt({ gain: 0, marginalRate: 0, held12Months: true });
+    property = {
+      hasProperty: false,
+      purchasePrice: 0,
+      projectedPropertyValue: 0,
+      grossGain: 0,
+      cgt: zeroCgt,
+      estimatedAnnualRentalIncome: 0,
+      estimatedAnnualHoldingCosts: 0,
+      netEquityAfterCgt: 0,
+      growthRatePct: 0,
+      rentalYieldPct: 0,
+      holdingCostsPct: 0,
+    };
+  }
+
   return {
     inputs,
     retirement,
     superContributions,
     investmentTax,
+    property,
   };
 }
 

--- a/lib/scenario-presets.ts
+++ b/lib/scenario-presets.ts
@@ -1,0 +1,310 @@
+/**
+ * Scenario comparison presets — curated decision pairs.
+ *
+ * Each preset defines two named `ScenarioInput` objects that represent
+ * the two sides of a common financial decision. Presets are used to:
+ *
+ *   1. Pre-populate the Scenario Planner compare tab via a shareable URL
+ *      `/scenarios/compare/[preset]` (SSG).
+ *   2. Drive JSON-LD structured data (ItemList + Article breadcrumb) for SEO.
+ *
+ * Design rules
+ * ------------
+ * - Only model decisions fully supported by the existing `computeScenario`
+ *   calc logic. Do NOT introduce new financial assumptions here.
+ * - Inputs are realistic Australian baseline values (FY2026) illustrating
+ *   the decision, not optimal advice. Every preset page MUST display
+ *   `GENERAL_ADVICE_WARNING` from `lib/compliance.ts`.
+ * - Preset slugs are stable once published (they become canonical URLs).
+ * - The `description` field is factual and neutral — no "better" framing.
+ *
+ * AFSL scope
+ * ----------
+ * Factual projections only. The preset page shows what each path
+ * *projects* given the stated assumptions, not which path is
+ * *recommended*. No personalised recommendation is produced.
+ *
+ * FY2026 assumptions used across presets
+ * ---------------------------------------
+ *   SG rate        11.5% (DEFAULT_SG_RATE)
+ *   Return         7% nominal p.a. (balanced-growth super / diversified ETF)
+ *   Inflation      3% p.a.
+ *   Concessional cap  $30,000
+ */
+
+import { type ScenarioInput, DEFAULT_SG_RATE } from "@/lib/scenario-engine";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface ScenarioPresetSide {
+  /** Short label for this side, e.g. "Salary sacrifice" */
+  label: string;
+  /** One-sentence factual description of what this side models. */
+  description: string;
+  /** Input values for `computeScenario`. */
+  inputs: ScenarioInput;
+}
+
+export interface ScenarioPreset {
+  /** URL slug — stable, used as the dynamic route segment. */
+  slug: string;
+  /** H1 / page title. */
+  title: string;
+  /**
+   * One-paragraph factual explanation of the decision being compared.
+   * Must be neutral — no advice framing.
+   */
+  summary: string;
+  /** The two sides of the comparison. */
+  a: ScenarioPresetSide;
+  b: ScenarioPresetSide;
+  /**
+   * Comma-separated list of key metrics this preset illustrates.
+   * Used for meta description and JSON-LD keywords.
+   */
+  highlights: string[];
+}
+
+// ─── Preset registry ─────────────────────────────────────────────────────────
+
+/**
+ * All published presets. Slugs must be unique and stable after first deploy.
+ *
+ * Add new rows here only when the underlying calc logic can fully model the
+ * decision being illustrated. Remove by setting `published: false` — never
+ * delete (URLs become 404s).
+ */
+export const SCENARIO_PRESETS: readonly ScenarioPreset[] = [
+  // ── 1. Salary sacrifice vs ETF outside super ───────────────────────────────
+  {
+    slug: "salary-sacrifice-vs-etf",
+    title: "Salary Sacrifice into Super vs ETF Outside Super",
+    summary:
+      "Salary sacrifice directs pre-tax dollars into super at 15% contributions tax, " +
+      "potentially saving income tax compared with investing the same net-of-tax amount " +
+      "in an ETF outside super. This projection compares the super balance at retirement " +
+      "under each path, using identical age, salary, and return assumptions. " +
+      "It does not account for the Age Pension, or for any restriction on early super " +
+      "access before preservation age.",
+    a: {
+      label: "Salary sacrifice ($10k p.a.)",
+      description:
+        "Redirects $10,000 p.a. of pre-tax salary into super as extra concessional contributions " +
+        "on top of employer SG. No outside-super ETF investment modelled here.",
+      inputs: {
+        currentAge: 35,
+        retirementAge: 67,
+        annualSalary: 100_000,
+        employerSgRate: DEFAULT_SG_RATE,
+        currentSuperBalance: 150_000,
+        extraConcessionalContribs: 10_000,
+        expectedReturnPct: 7,
+        inflationRatePct: 3,
+        desiredRetirementIncome: 60_000,
+      },
+    },
+    b: {
+      label: "No salary sacrifice (invest after-tax)",
+      description:
+        "No extra concessional contributions. The after-tax equivalent (~$6,550 at 34.5% marginal rate) " +
+        "is modelled as annual franked dividends in a diversified ETF paying a 3.5% gross yield, " +
+        "capturing the tax drag on dividends outside super.",
+      inputs: {
+        currentAge: 35,
+        retirementAge: 67,
+        annualSalary: 100_000,
+        employerSgRate: DEFAULT_SG_RATE,
+        currentSuperBalance: 150_000,
+        extraConcessionalContribs: 0,
+        expectedReturnPct: 7,
+        inflationRatePct: 3,
+        desiredRetirementIncome: 60_000,
+        // ~$6,550 after-tax invest equivalent modelled as franked ETF dividends
+        annualFrankedDividends: 6_550,
+        frankingPct: 70,
+      },
+    },
+    highlights: [
+      "projected super at retirement",
+      "super tax saving p.a.",
+      "investment tax p.a.",
+      "drawdown years",
+    ],
+  },
+
+  // ── 2. SMSF vs industry/retail super (higher fees) ────────────────────────
+  {
+    slug: "smsf-vs-industry-super",
+    title: "SMSF vs Industry Super — Retirement Projection",
+    summary:
+      "A self-managed super fund (SMSF) gives direct investment control but carries " +
+      "fixed operating costs (auditor, ASIC levy, accountant) that can erode smaller " +
+      "balances. This projection models the net effect on retirement balance by " +
+      "representing SMSF costs as a reduction in the effective annual return, compared " +
+      "with an industry super fund with lower fees and the same gross return assumption. " +
+      "SMSF setup, trustee obligations, and borrowing rules are not modelled here.",
+    a: {
+      label: "SMSF (est. $3,000 fixed costs p.a.)",
+      description:
+        "SMSF with estimated $3,000 annual fixed costs deducted from fund growth, " +
+        "modelled as a 0.5–0.6% drag on a $500k balance (effective return 6.4%).",
+      inputs: {
+        currentAge: 45,
+        retirementAge: 67,
+        annualSalary: 120_000,
+        employerSgRate: DEFAULT_SG_RATE,
+        currentSuperBalance: 500_000,
+        extraConcessionalContribs: 5_000,
+        expectedReturnPct: 6.4, // 7% gross − ~0.6% fixed cost drag on $500k
+        inflationRatePct: 3,
+        desiredRetirementIncome: 80_000,
+      },
+    },
+    b: {
+      label: "Industry/retail super (lower fees)",
+      description:
+        "Diversified industry super fund with 0.5% total fee, modelled as 6.65% net return " +
+        "(7% gross − 0.35% MER/admin).",
+      inputs: {
+        currentAge: 45,
+        retirementAge: 67,
+        annualSalary: 120_000,
+        employerSgRate: DEFAULT_SG_RATE,
+        currentSuperBalance: 500_000,
+        extraConcessionalContribs: 5_000,
+        expectedReturnPct: 6.65, // 7% gross − 0.35% fees
+        inflationRatePct: 3,
+        desiredRetirementIncome: 80_000,
+      },
+    },
+    highlights: [
+      "projected super at retirement",
+      "drawdown years",
+      "gap to target",
+      "effective return assumption",
+    ],
+  },
+
+  // ── 3. Max concessional contributions vs moderate contributions ───────────
+  {
+    slug: "max-concessional-vs-moderate",
+    title: "Maximising Concessional Cap vs Moderate Salary Sacrifice",
+    summary:
+      "The FY2026 concessional cap is $30,000 (employer SG + salary sacrifice + personal " +
+      "deductible contributions). Maximising the cap accelerates super growth and captures the " +
+      "largest possible tax saving at the marginal rate, but reduces take-home pay. This " +
+      "projection compares a cap-maximisation strategy with a moderate $5,000 top-up, " +
+      "assuming the same gross salary and return.",
+    a: {
+      label: "Max concessional cap (~$18,500 salary sacrifice)",
+      description:
+        "Salary sacrifice up to the $30k concessional cap after accounting for 11.5% employer SG. " +
+        "At $100k salary: SG = $11,500; sacrifice = $18,500 to hit $30k.",
+      inputs: {
+        currentAge: 35,
+        retirementAge: 67,
+        annualSalary: 100_000,
+        employerSgRate: DEFAULT_SG_RATE,
+        currentSuperBalance: 150_000,
+        extraConcessionalContribs: 18_500, // 30k − 11.5k SG
+        expectedReturnPct: 7,
+        inflationRatePct: 3,
+        desiredRetirementIncome: 60_000,
+      },
+    },
+    b: {
+      label: "Moderate salary sacrifice ($5,000 p.a.)",
+      description:
+        "A common starting point — salary sacrificing $5,000 p.a. on top of employer SG, " +
+        "leaving the remaining cap headroom unused.",
+      inputs: {
+        currentAge: 35,
+        retirementAge: 67,
+        annualSalary: 100_000,
+        employerSgRate: DEFAULT_SG_RATE,
+        currentSuperBalance: 150_000,
+        extraConcessionalContribs: 5_000,
+        expectedReturnPct: 7,
+        inflationRatePct: 3,
+        desiredRetirementIncome: 60_000,
+      },
+    },
+    highlights: [
+      "projected super at retirement",
+      "super tax saving p.a.",
+      "gap to target",
+      "drawdown years",
+    ],
+  },
+
+  // ── 4. Early retirement vs standard preservation age ─────────────────────
+  {
+    slug: "early-retirement-vs-standard",
+    title: "Early Retirement at 60 vs Standard Retirement at 67",
+    summary:
+      "Retiring 7 years earlier reduces the accumulation phase, shortens the compounding " +
+      "runway, and extends the drawdown period. This projection compares the same individual " +
+      "retiring at 60 vs 67, with identical contributions and return assumptions. " +
+      "Access to super preservation age (60 for those born after 1 July 1964), the Age " +
+      "Pension eligibility age (67), and Centrelink means testing are not modelled.",
+    a: {
+      label: "Retire at 60 (early)",
+      description:
+        "Accumulates super for 25 years (age 35 → 60), then draws down over a " +
+        "potentially longer retirement horizon.",
+      inputs: {
+        currentAge: 35,
+        retirementAge: 60,
+        annualSalary: 100_000,
+        employerSgRate: DEFAULT_SG_RATE,
+        currentSuperBalance: 150_000,
+        extraConcessionalContribs: 10_000,
+        expectedReturnPct: 7,
+        inflationRatePct: 3,
+        desiredRetirementIncome: 65_000,
+      },
+    },
+    b: {
+      label: "Retire at 67 (standard Age Pension age)",
+      description:
+        "Seven additional years of accumulation and compounding before drawing down.",
+      inputs: {
+        currentAge: 35,
+        retirementAge: 67,
+        annualSalary: 100_000,
+        employerSgRate: DEFAULT_SG_RATE,
+        currentSuperBalance: 150_000,
+        extraConcessionalContribs: 10_000,
+        expectedReturnPct: 7,
+        inflationRatePct: 3,
+        desiredRetirementIncome: 65_000,
+      },
+    },
+    highlights: [
+      "projected super at retirement",
+      "drawdown years",
+      "gap to target",
+      "years to retire",
+    ],
+  },
+] as const;
+
+// ─── Lookup helpers ───────────────────────────────────────────────────────────
+
+/** All published preset slugs — used for `generateStaticParams`. */
+export const PRESET_SLUGS: string[] = SCENARIO_PRESETS.map((p) => p.slug);
+
+/**
+ * Find a preset by slug. Returns `undefined` for unknown slugs
+ * (callers should `notFound()` in that case).
+ */
+export function getPreset(slug: string): ScenarioPreset | undefined {
+  return SCENARIO_PRESETS.find((p) => p.slug === slug);
+}
+
+/**
+ * All preset slugs and titles — for the index page or ItemList JSON-LD.
+ */
+export function allPresetMeta(): Array<{ slug: string; title: string; summary: string }> {
+  return SCENARIO_PRESETS.map(({ slug, title, summary }) => ({ slug, title, summary }));
+}


### PR DESCRIPTION
Round-3 deepening (3 of 10). Deepens the scenario-planning engine (which already had save + a basic compare). Factual projections + `GENERAL_ADVICE_WARNING` everywhere; neutral framing (AFSL-safe).

- `lib/scenario-presets.ts` — curated comparison presets (e.g. salary-sacrifice vs ETF, SMSF vs robo) that pre-populate two scenarios.
- `app/scenarios/compare/[preset]` — SSG shareable comparison pages (`generateStaticParams`, Article + ItemList + breadcrumb JSON-LD) with an interactive category-grouped delta table.
- `lib/scenario-delta.ts` — pure `computeScenarioDelta`: per-metric absolute + % delta with a **neutral** larger/smaller indicator (no "better" / advice framing).
- `computeScenario` gains an optional property/CGT dimension (composes the existing `computeCgt`; additive — doesn't affect the retirement/super/tax outputs, parity-tested). The plan page's compare panel now uses the richer delta table.

**Verified:** `tsc` clean · **101 tests** (47 existing + 54 new: preset integrity, delta math, property dimension, composition parity with `computeCgt`) pass · eslint clean · jsonld gate green. Property model is marginal-rate scope (no mortgage/depreciation/stamp-duty) — documented in JSDoc + the on-page warning.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUfSRE2Teb6VhEXFP6RpS9)_