### PR TITLE
feat: embeddable trust/health score badges + API field (deepen ratings)

### DIFF
--- a/__tests__/api/v1-advisors.test.ts
+++ b/__tests__/api/v1-advisors.test.ts
@@ -315,3 +315,147 @@ describe("GET /api/v1/advisors — success", () => {
     expect(body.meta.updated_at).toBe("2026-04-01T00:00:00Z");
   });
 });
+
+// ── Trust Score field tests ────────────────────────────────────────────────────
+
+describe("GET /api/v1/advisors — trust_score field", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockValidateApiKey.mockResolvedValue(makeValidAuth());
+  });
+
+  /**
+   * Advisor with high credential signals — should score in Good or Strong band.
+   */
+  const CREDENTIALED_ADVISOR = {
+    ...makeAdvisor({
+      verified: true,
+      afsl_number: "123456",
+      rating: 4.8,
+      review_count: 15,
+      years_experience: 12,
+      created_at: new Date(Date.now() - 12 * 365 * 24 * 60 * 60 * 1000).toISOString(),
+      bio: "Experienced financial planner specialising in SMSF and retirement planning with 12 years in the industry.",
+      photo_url: "https://cdn.example.com/photo.jpg",
+      qualifications: [{ name: "CFP" }],
+      education: [{ degree: "BComm" }],
+      memberships: [{ name: "FPA" }],
+      fee_structure: "Hourly",
+      fee_description: null,
+      linkedin_url: "https://linkedin.com/in/jane",
+      website: null,
+      languages: ["English"],
+    }),
+    // Extra scoring fields fetched from DB but not in PUBLIC_FIELDS output
+    verified_at: new Date(Date.now() - 60 * 24 * 60 * 60 * 1000).toISOString(), // 60 days ago
+    registration_number: "AR-789",
+    education: [{ degree: "BComm" }],
+  };
+
+  /**
+   * Advisor with minimal credentials — should score in Limited or Moderate band.
+   */
+  const SPARSE_ADVISOR = {
+    ...makeAdvisor({
+      verified: false,
+      afsl_number: null,
+      rating: null,
+      review_count: 0,
+      years_experience: null,
+      created_at: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString(), // 30 days
+      bio: null,
+      photo_url: null,
+      qualifications: null,
+      education: null,
+      memberships: null,
+      fee_structure: null,
+      fee_description: null,
+      linkedin_url: null,
+      website: null,
+      languages: null,
+    }),
+    verified_at: null,
+    registration_number: null,
+    education: null,
+  };
+
+  it("exposes trust_score field on each advisor row", async () => {
+    mockServerFrom.mockReturnValue(makeAdvisorsBuilder([CREDENTIALED_ADVISOR], null, 1));
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const row = body.data[0];
+    expect(row.trust_score).toBeDefined();
+    expect(typeof row.trust_score.overall).toBe("number");
+    expect(typeof row.trust_score.label).toBe("string");
+    expect(typeof row.trust_score.methodology_url).toBe("string");
+  });
+
+  it("trust_score.overall is an integer in [0, 100]", async () => {
+    mockServerFrom.mockReturnValue(makeAdvisorsBuilder([CREDENTIALED_ADVISOR], null, 1));
+    const res = await GET(makeGet());
+    const body = await res.json();
+    const { overall } = body.data[0].trust_score;
+    expect(Number.isInteger(overall)).toBe(true);
+    expect(overall).toBeGreaterThanOrEqual(0);
+    expect(overall).toBeLessThanOrEqual(100);
+  });
+
+  it("trust_score.label is one of the defined bands", async () => {
+    mockServerFrom.mockReturnValue(makeAdvisorsBuilder([CREDENTIALED_ADVISOR], null, 1));
+    const res = await GET(makeGet());
+    const body = await res.json();
+    const { label } = body.data[0].trust_score;
+    expect(["Strong", "Good", "Moderate", "Limited"]).toContain(label);
+  });
+
+  it("trust_score.methodology_url points to the published methodology page", async () => {
+    mockServerFrom.mockReturnValue(makeAdvisorsBuilder([CREDENTIALED_ADVISOR], null, 1));
+    const res = await GET(makeGet());
+    const body = await res.json();
+    expect(body.data[0].trust_score.methodology_url).toBe(
+      "https://invest.com.au/advisor/trust-score-methodology",
+    );
+  });
+
+  it("credentialed advisor scores higher than sparse advisor", async () => {
+    mockServerFrom.mockReturnValue(
+      makeAdvisorsBuilder([CREDENTIALED_ADVISOR, SPARSE_ADVISOR], null, 2),
+    );
+    const res = await GET(makeGet());
+    const body = await res.json();
+    const [credentialed, sparse] = body.data;
+    expect(credentialed.trust_score.overall).toBeGreaterThan(sparse.trust_score.overall);
+  });
+
+  it("sparse advisor with no signals still gets a trust_score object", async () => {
+    mockServerFrom.mockReturnValue(makeAdvisorsBuilder([SPARSE_ADVISOR], null, 1));
+    const res = await GET(makeGet());
+    const body = await res.json();
+    const { trust_score } = body.data[0];
+    expect(trust_score).toBeDefined();
+    expect(trust_score.overall).toBeGreaterThanOrEqual(0);
+    expect(trust_score.overall).toBeLessThanOrEqual(100);
+    // Sparse advisor should be Limited or Moderate
+    expect(["Limited", "Moderate"]).toContain(trust_score.label);
+  });
+
+  it("trust_score does NOT expose private scoring-only fields (verified_at, registration_number, education raw)", async () => {
+    mockServerFrom.mockReturnValue(makeAdvisorsBuilder([CREDENTIALED_ADVISOR], null, 1));
+    const res = await GET(makeGet());
+    const body = await res.json();
+    const row = body.data[0];
+    // These fields are inputs to the scorer only — they must NOT appear on the public row
+    expect(row.verified_at).toBeUndefined();
+    expect(row.registration_number).toBeUndefined();
+    // trust_score should be nested object, not a raw field
+    expect(typeof row.trust_score).toBe("object");
+  });
+
+  it("trust_score is present even on empty advisor list (no rows = no trust_score calls)", async () => {
+    mockServerFrom.mockReturnValue(makeAdvisorsBuilder([], null, 0));
+    const res = await GET(makeGet());
+    const body = await res.json();
+    expect(body.data).toHaveLength(0);
+  });
+});

--- a/__tests__/api/widget-badge.test.ts
+++ b/__tests__/api/widget-badge.test.ts
@@ -314,7 +314,7 @@ describe("GET /api/widget/badge — broker badge", () => {
     mockFrom.mockReturnValue(makeSingleChain(BROKER_ROW));
     const res = await GET(makeReq({ type: "broker", slug: "stake" }));
     const body = await res.text();
-    expect(body).toContain("health-scores/methodology");
+    expect(body).toContain('"methodologyUrl":"https://invest.com.au/health-scores"');
     expect(body).toContain("methodology");
   });
 
@@ -325,7 +325,7 @@ describe("GET /api/widget/badge — broker badge", () => {
     expect(body).toContain("Broker Health Score");
   });
 
-  it("embeds correct score for Stake (ASIC+AFSL+CHESS+AU+9yr+rating = 80 → Strong)", async () => {
+  it("embeds correct score for Stake (ASIC+AFSL+CHESS+AU+9yr+rating+share_broker = 85 → Strong)", async () => {
     mockFrom.mockReturnValue(makeSingleChain(BROKER_ROW));
     const res = await GET(makeReq({ type: "broker", slug: "stake" }));
     const body = await res.text();
@@ -337,8 +337,8 @@ describe("GET /api/widget/badge — broker badge", () => {
       body.indexOf(";\n", start + badgePrefix.length),
     );
     const badge = JSON.parse(jsonStr) as { score: number; label: string; scoreType: string };
-    // Stake: ASIC(25)+AFSL(10)+CHESS(20)+AU HQ(5)+9yr(10)+rating(10) = 80 → Strong
-    expect(badge.score).toBe(80);
+    // Stake: ASIC(25)+AFSL(10)+CHESS(20)+AU HQ(5)+9yr(10)+rating(10)+share_broker(5) = 85 → Strong
+    expect(badge.score).toBe(85);
     expect(badge.label).toBe("Strong");
     expect(badge.scoreType).toBe("Broker Health Score");
   });

--- a/__tests__/api/widget-badge.test.ts
+++ b/__tests__/api/widget-badge.test.ts
@@ -1,0 +1,390 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+const { mockFrom } = vi.hoisted(() => ({ mockFrom: vi.fn() }));
+
+vi.mock("@/lib/supabase/static", () => ({
+  createStaticClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+const { mockCurrentYear } = vi.hoisted(() => ({ mockCurrentYear: { value: 2026 } }));
+
+vi.mock("@/lib/seo", () => ({
+  get CURRENT_YEAR() {
+    return mockCurrentYear.value;
+  },
+  absoluteUrl: (p: string) => `https://invest.com.au${p}`,
+  breadcrumbJsonLd: () => ({}),
+  SITE_NAME: "invest.com.au",
+}));
+
+import { GET, OPTIONS } from "@/app/api/widget/badge/route";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Build a Supabase chain mock that returns a single row via `.single()`.
+ * All chained methods return `this` except `single()` which resolves with
+ * `{ data, error }`.
+ */
+function makeSingleChain(data: unknown, error: unknown = null) {
+  const c: Record<string, unknown> = {};
+  const methods = ["select", "eq", "order", "limit", "in"];
+  for (const m of methods) c[m] = vi.fn(() => c);
+  c.single = vi.fn(() => Promise.resolve({ data, error }));
+  return c;
+}
+
+function makeReq(params: Record<string, string> = {}): NextRequest {
+  const url = new URL("http://localhost/api/widget/badge");
+  for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
+  return new NextRequest(url.toString());
+}
+
+const ADVISOR_ROW = {
+  name: "Jane Smith CFP",
+  slug: "jane-smith-cfp",
+  type: "financial_planner",
+  photo_url: null,
+  bio: "Experienced financial planner with 15 years in wealth management.",
+  verified: true,
+  afsl_number: "123456",
+  registration_number: "AR-789",
+  verified_at: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString(), // 30 days ago
+  created_at: new Date(Date.now() - 5 * 365 * 24 * 60 * 60 * 1000).toISOString(), // 5 yrs ago
+  years_experience: 15,
+  qualifications: [{ name: "CFP" }],
+  education: [{ degree: "BComm" }],
+  memberships: [{ name: "FPA" }],
+  fee_structure: "Hourly",
+  fee_description: null,
+  linkedin_url: "https://linkedin.com/in/janesmith",
+  website: null,
+  languages: ["English"],
+  rating: 4.8,
+  review_count: 12,
+  location_display: "Sydney, NSW",
+  status: "active",
+};
+
+const BROKER_ROW = {
+  name: "Stake",
+  slug: "stake",
+  rating: 4.7,
+  regulated_by: "ASIC — AFSL 509799",
+  year_founded: 2017,
+  headquarters: "Sydney, Australia",
+  chess_sponsored: true,
+  is_crypto: false,
+  platform_type: "share_broker",
+  logo_url: null,
+  color: "#7c3aed",
+  icon: "S",
+  status: "active",
+};
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("GET /api/widget/badge — validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCurrentYear.value = 2026;
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://abc.supabase.co";
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "anon-key";
+  });
+
+  it("returns 400 JS comment when ?type= is missing", async () => {
+    const res = await GET(makeReq({ slug: "jane-smith-cfp" }));
+    expect(res.status).toBe(400);
+    const body = await res.text();
+    expect(body).toContain('?type=');
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+  });
+
+  it("returns 400 JS comment when ?type= is invalid", async () => {
+    const res = await GET(makeReq({ type: "advisor-comparison", slug: "someone" }));
+    expect(res.status).toBe(400);
+    const body = await res.text();
+    expect(body).toContain('?type=');
+  });
+
+  it("returns 400 JS comment when ?slug= is missing", async () => {
+    const res = await GET(makeReq({ type: "advisor" }));
+    expect(res.status).toBe(400);
+    const body = await res.text();
+    expect(body).toContain('?slug=');
+  });
+
+  it("returns 404 when advisor slug not found", async () => {
+    const chain = makeSingleChain(null);
+    mockFrom.mockReturnValue(chain);
+    const res = await GET(makeReq({ type: "advisor", slug: "nobody" }));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 when broker slug not found", async () => {
+    const chain = makeSingleChain(null);
+    mockFrom.mockReturnValue(chain);
+    const res = await GET(makeReq({ type: "broker", slug: "nobody" }));
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("GET /api/widget/badge — advisor badge", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCurrentYear.value = 2026;
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://abc.supabase.co";
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "anon-key";
+  });
+
+  it("returns 200 application/javascript with CORS headers", async () => {
+    mockFrom.mockReturnValue(makeSingleChain(ADVISOR_ROW));
+    const res = await GET(makeReq({ type: "advisor", slug: "jane-smith-cfp" }));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toMatch(/application\/javascript/);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(res.headers.get("Access-Control-Allow-Methods")).toContain("GET");
+    expect(res.headers.get("Cross-Origin-Resource-Policy")).toBe("cross-origin");
+    expect(res.headers.get("Vary")).toBe("Origin");
+  });
+
+  it("sets 1h public Cache-Control", async () => {
+    mockFrom.mockReturnValue(makeSingleChain(ADVISOR_ROW));
+    const res = await GET(makeReq({ type: "advisor", slug: "jane-smith-cfp" }));
+    const cc = res.headers.get("Cache-Control") ?? "";
+    expect(cc).toMatch(/public/);
+    expect(cc).toMatch(/max-age=3600/);
+    expect(cc).toMatch(/s-maxage=3600/);
+  });
+
+  it("embeds advisor name and slug in JS payload", async () => {
+    mockFrom.mockReturnValue(makeSingleChain(ADVISOR_ROW));
+    const res = await GET(makeReq({ type: "advisor", slug: "jane-smith-cfp" }));
+    const body = await res.text();
+    expect(body).toContain("Jane Smith CFP");
+    expect(body).toContain("jane-smith-cfp");
+  });
+
+  it("includes Shadow DOM setup", async () => {
+    mockFrom.mockReturnValue(makeSingleChain(ADVISOR_ROW));
+    const res = await GET(makeReq({ type: "advisor", slug: "jane-smith-cfp" }));
+    const body = await res.text();
+    expect(body).toContain("attachShadow");
+    expect(body).toContain("data-invest-badge-advisor");
+  });
+
+  it("includes the general-advice disclaimer", async () => {
+    mockFrom.mockReturnValue(makeSingleChain(ADVISOR_ROW));
+    const res = await GET(makeReq({ type: "advisor", slug: "jane-smith-cfp" }));
+    const body = await res.text();
+    expect(body).toContain("General information only");
+    expect(body).toContain("DISCLAIMER");
+  });
+
+  it("includes methodology link for advisor", async () => {
+    mockFrom.mockReturnValue(makeSingleChain(ADVISOR_ROW));
+    const res = await GET(makeReq({ type: "advisor", slug: "jane-smith-cfp" }));
+    const body = await res.text();
+    expect(body).toContain("trust-score-methodology");
+    expect(body).toContain("methodology");
+  });
+
+  it("includes Advisor Trust Score type label", async () => {
+    mockFrom.mockReturnValue(makeSingleChain(ADVISOR_ROW));
+    const res = await GET(makeReq({ type: "advisor", slug: "jane-smith-cfp" }));
+    const body = await res.text();
+    expect(body).toContain("Advisor Trust Score");
+  });
+
+  it("embeds a numeric score in the badge data", async () => {
+    mockFrom.mockReturnValue(makeSingleChain(ADVISOR_ROW));
+    const res = await GET(makeReq({ type: "advisor", slug: "jane-smith-cfp" }));
+    const body = await res.text();
+    // The score is embedded in the BADGE object
+    const badgePrefix = "var BADGE = ";
+    const start = body.indexOf(badgePrefix);
+    expect(start).toBeGreaterThan(-1);
+    // Extract the JSON and verify the score is a valid integer in [0, 100]
+    const jsonStr = body.substring(
+      start + badgePrefix.length,
+      body.indexOf(";\n", start + badgePrefix.length),
+    );
+    const badge = JSON.parse(jsonStr) as { score: number; label: string };
+    expect(badge.score).toBeGreaterThanOrEqual(0);
+    expect(badge.score).toBeLessThanOrEqual(100);
+    expect(typeof badge.label).toBe("string");
+    // For a well-credentialed advisor (verified + AFSL + 15yr experience), expect a Good/Strong score
+    expect(["Strong", "Good", "Moderate", "Limited"]).toContain(badge.label);
+  });
+
+  it("does NOT compare entities or include ranking/award language", async () => {
+    mockFrom.mockReturnValue(makeSingleChain(ADVISOR_ROW));
+    const res = await GET(makeReq({ type: "advisor", slug: "jane-smith-cfp" }));
+    const body = await res.text();
+    // No cross-entity comparison language
+    expect(body.toLowerCase()).not.toContain("best advisor");
+    expect(body.toLowerCase()).not.toContain("top advisor");
+    expect(body.toLowerCase()).not.toContain("award");
+    expect(body.toLowerCase()).not.toContain("ranked");
+  });
+
+  it("profiles link back to the advisor's profile page", async () => {
+    mockFrom.mockReturnValue(makeSingleChain(ADVISOR_ROW));
+    const res = await GET(makeReq({ type: "advisor", slug: "jane-smith-cfp" }));
+    const body = await res.text();
+    expect(body).toContain("/advisor/jane-smith-cfp");
+  });
+
+  it("threads ?ref= partner ID through outbound links", async () => {
+    mockFrom.mockReturnValue(makeSingleChain(ADVISOR_ROW));
+    const res = await GET(makeReq({ type: "advisor", slug: "jane-smith-cfp", ref: "finweekly" }));
+    const body = await res.text();
+    expect(body).toContain("ref=finweekly");
+    expect(body).toContain("source=badge-advisor");
+  });
+
+  it("uses default widget ref when ?ref= is absent", async () => {
+    mockFrom.mockReturnValue(makeSingleChain(ADVISOR_ROW));
+    const res = await GET(makeReq({ type: "advisor", slug: "jane-smith-cfp" }));
+    const body = await res.text();
+    expect(body).toContain("ref=widget");
+    expect(body).toContain("source=badge-advisor");
+  });
+
+  it("applies dark theme when ?theme=dark", async () => {
+    mockFrom.mockReturnValue(makeSingleChain(ADVISOR_ROW));
+    const res = await GET(makeReq({ type: "advisor", slug: "jane-smith-cfp", theme: "dark" }));
+    const body = await res.text();
+    expect(body).toContain('"dark"');
+  });
+
+  it("queries only active professionals via anon client", async () => {
+    const chain = makeSingleChain(ADVISOR_ROW);
+    mockFrom.mockReturnValue(chain);
+    await GET(makeReq({ type: "advisor", slug: "jane-smith-cfp" }));
+    const eqCalls = (chain.eq as ReturnType<typeof vi.fn>).mock.calls;
+    expect(eqCalls.some((c) => c[0] === "status" && c[1] === "active")).toBe(true);
+    expect(eqCalls.some((c) => c[0] === "slug" && c[1] === "jane-smith-cfp")).toBe(true);
+  });
+});
+
+describe("GET /api/widget/badge — broker badge", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCurrentYear.value = 2026;
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://abc.supabase.co";
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "anon-key";
+  });
+
+  it("returns 200 application/javascript with CORS headers", async () => {
+    mockFrom.mockReturnValue(makeSingleChain(BROKER_ROW));
+    const res = await GET(makeReq({ type: "broker", slug: "stake" }));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toMatch(/application\/javascript/);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+  });
+
+  it("embeds broker name in JS payload", async () => {
+    mockFrom.mockReturnValue(makeSingleChain(BROKER_ROW));
+    const res = await GET(makeReq({ type: "broker", slug: "stake" }));
+    const body = await res.text();
+    expect(body).toContain("Stake");
+    expect(body).toContain("stake");
+  });
+
+  it("includes Shadow DOM setup with broker attribute", async () => {
+    mockFrom.mockReturnValue(makeSingleChain(BROKER_ROW));
+    const res = await GET(makeReq({ type: "broker", slug: "stake" }));
+    const body = await res.text();
+    expect(body).toContain("attachShadow");
+    expect(body).toContain("data-invest-badge-broker");
+  });
+
+  it("includes the general-advice disclaimer", async () => {
+    mockFrom.mockReturnValue(makeSingleChain(BROKER_ROW));
+    const res = await GET(makeReq({ type: "broker", slug: "stake" }));
+    const body = await res.text();
+    expect(body).toContain("General information only");
+  });
+
+  it("includes methodology link for broker health score", async () => {
+    mockFrom.mockReturnValue(makeSingleChain(BROKER_ROW));
+    const res = await GET(makeReq({ type: "broker", slug: "stake" }));
+    const body = await res.text();
+    expect(body).toContain("health-scores/methodology");
+    expect(body).toContain("methodology");
+  });
+
+  it("includes Broker Health Score type label", async () => {
+    mockFrom.mockReturnValue(makeSingleChain(BROKER_ROW));
+    const res = await GET(makeReq({ type: "broker", slug: "stake" }));
+    const body = await res.text();
+    expect(body).toContain("Broker Health Score");
+  });
+
+  it("embeds correct score for Stake (ASIC+AFSL+CHESS+AU+9yr+rating = 80 → Strong)", async () => {
+    mockFrom.mockReturnValue(makeSingleChain(BROKER_ROW));
+    const res = await GET(makeReq({ type: "broker", slug: "stake" }));
+    const body = await res.text();
+    const badgePrefix = "var BADGE = ";
+    const start = body.indexOf(badgePrefix);
+    expect(start).toBeGreaterThan(-1);
+    const jsonStr = body.substring(
+      start + badgePrefix.length,
+      body.indexOf(";\n", start + badgePrefix.length),
+    );
+    const badge = JSON.parse(jsonStr) as { score: number; label: string; scoreType: string };
+    // Stake: ASIC(25)+AFSL(10)+CHESS(20)+AU HQ(5)+9yr(10)+rating(10) = 80 → Strong
+    expect(badge.score).toBe(80);
+    expect(badge.label).toBe("Strong");
+    expect(badge.scoreType).toBe("Broker Health Score");
+  });
+
+  it("broker profile links to health-scores detail page", async () => {
+    mockFrom.mockReturnValue(makeSingleChain(BROKER_ROW));
+    const res = await GET(makeReq({ type: "broker", slug: "stake" }));
+    const body = await res.text();
+    expect(body).toContain("/health-scores/stake");
+  });
+
+  it("threads ?ref= partner ID through outbound links for broker", async () => {
+    mockFrom.mockReturnValue(makeSingleChain(BROKER_ROW));
+    const res = await GET(makeReq({ type: "broker", slug: "stake", ref: "finmag" }));
+    const body = await res.text();
+    expect(body).toContain("ref=finmag");
+    expect(body).toContain("source=badge-broker");
+  });
+
+  it("does NOT compare this broker to any other broker", async () => {
+    mockFrom.mockReturnValue(makeSingleChain(BROKER_ROW));
+    const res = await GET(makeReq({ type: "broker", slug: "stake" }));
+    const body = await res.text();
+    expect(body.toLowerCase()).not.toContain("best broker");
+    expect(body.toLowerCase()).not.toContain("top broker");
+    expect(body.toLowerCase()).not.toContain("award");
+    expect(body.toLowerCase()).not.toContain("ranked");
+  });
+
+  it("queries only active brokers via anon client", async () => {
+    const chain = makeSingleChain(BROKER_ROW);
+    mockFrom.mockReturnValue(chain);
+    await GET(makeReq({ type: "broker", slug: "stake" }));
+    const eqCalls = (chain.eq as ReturnType<typeof vi.fn>).mock.calls;
+    expect(eqCalls.some((c) => c[0] === "status" && c[1] === "active")).toBe(true);
+    expect(eqCalls.some((c) => c[0] === "slug" && c[1] === "stake")).toBe(true);
+  });
+});
+
+describe("OPTIONS /api/widget/badge", () => {
+  it("returns 204 with CORS headers for preflight", () => {
+    const res = OPTIONS();
+    expect(res.status).toBe(204);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(res.headers.get("Access-Control-Allow-Methods")).toContain("GET");
+    expect(res.headers.get("Access-Control-Max-Age")).toBe("86400");
+    expect(res.headers.get("Vary")).toBe("Origin");
+  });
+});

--- a/app/api/v1/advisors/route.ts
+++ b/app/api/v1/advisors/route.ts
@@ -3,6 +3,7 @@ import { createClient } from "@/lib/supabase/server";
 import { logger } from "@/lib/logger";
 import { validateApiKey, logApiRequest, API_CORS_HEADERS } from "@/lib/api-auth";
 import { escapeHtml } from "@/lib/html-escape";
+import { computeAdvisorTrustScore, type AdvisorTrustScoreInput } from "@/lib/advisor-trust-score";
 
 export const runtime = "nodejs";
 // Per-key auth gating — see /api/v1/brokers/route.ts for the same reasoning.
@@ -16,6 +17,11 @@ const log = logger("api-v1-advisors");
  * Excludes PII (email, phone), billing/payment (stripe_customer_id,
  * credit_balance_cents, etc.), admin fields (admin_notes, admin_tags,
  * health_status), and lead/billing counters (total_leads, etc.).
+ *
+ * Note: verified_at, registration_number, education are also fetched because
+ * they are inputs to the Trust Score computation. They are not exposed in the
+ * sanitized output (they remain scoring-only inputs), but the trust_score
+ * field is exposed.
  */
 const PUBLIC_FIELDS = [
   "id",
@@ -68,6 +74,17 @@ const PUBLIC_FIELDS = [
 ] as const;
 
 /**
+ * Additional fields fetched from DB solely for Trust Score computation.
+ * These are NOT included in the sanitized output row — only the computed
+ * trust_score object is surfaced.
+ */
+const TRUST_SCORE_EXTRA_FIELDS = [
+  "verified_at",
+  "registration_number",
+  "education",
+] as const;
+
+/**
  * Sanitize an advisor row: keep only public fields, escape string values.
  */
 function sanitizeAdvisor(row: Record<string, unknown>): Record<string, unknown> {
@@ -79,6 +96,53 @@ function sanitizeAdvisor(row: Record<string, unknown>): Record<string, unknown> 
     }
   }
   return clean;
+}
+
+/**
+ * Append the Advisor Trust Score to an already-sanitized advisor row.
+ *
+ * The raw DB row (before sanitization) is passed in so the scorer can read
+ * fields that are NOT in the public output (e.g. verified_at, education).
+ *
+ * AFSL NOTE: The score is factual, single-entity only. It does NOT compare
+ * this advisor to any other — it is not a ranking, award, or "best" label.
+ * Methodology link: /advisor/trust-score-methodology.
+ */
+function withTrustScore(
+  sanitized: Record<string, unknown>,
+  rawRow: Record<string, unknown>,
+): Record<string, unknown> {
+  const input: AdvisorTrustScoreInput = {
+    verified: rawRow.verified as boolean | null,
+    afsl_number: rawRow.afsl_number as string | null,
+    registration_number: rawRow.registration_number as string | null,
+    verified_at: rawRow.verified_at as string | null,
+    created_at: rawRow.created_at as string | null,
+    years_experience: rawRow.years_experience as number | null,
+    bio: rawRow.bio as string | null,
+    photo_url: rawRow.photo_url as string | null,
+    qualifications: rawRow.qualifications as unknown[] | null,
+    education: rawRow.education as unknown[] | null,
+    memberships: rawRow.memberships as unknown[] | null,
+    fee_structure: rawRow.fee_structure as string | null,
+    fee_description: rawRow.fee_description as string | null,
+    linkedin_url: rawRow.linkedin_url as string | null,
+    website: rawRow.website as string | null,
+    languages: rawRow.languages as unknown[] | null,
+    rating: rawRow.rating as number | null,
+    review_count: rawRow.review_count as number | null,
+  };
+
+  const result = computeAdvisorTrustScore(input);
+
+  return {
+    ...sanitized,
+    trust_score: {
+      overall: result.overall,
+      label: result.label,
+      methodology_url: "https://invest.com.au/advisor/trust-score-methodology",
+    },
+  };
 }
 
 /**
@@ -144,9 +208,12 @@ export async function GET(request: NextRequest) {
     // matching how the public /advisors page fetches.
     const supabase = await createClient();
 
+    // Fetch public fields + extra fields needed for trust-score computation.
+    const SELECT_FIELDS = [...PUBLIC_FIELDS, ...TRUST_SCORE_EXTRA_FIELDS].join(",");
+
     let query = supabase
       .from("professionals")
-      .select(PUBLIC_FIELDS.join(","), { count: "exact" })
+      .select(SELECT_FIELDS, { count: "exact" })
       .eq("status", "active")
       .order("rating", { ascending: false })
       .order("name", { ascending: true });
@@ -201,10 +268,13 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    // Sanitize each advisor row
-    const sanitized = (advisors || []).map((a) =>
-      sanitizeAdvisor(a as unknown as Record<string, unknown>),
-    );
+    // Sanitize each advisor row and append the computed Trust Score.
+    // The raw row (including scoring-only fields) is passed to withTrustScore
+    // before sanitization strips them from the output.
+    const sanitized = (advisors || []).map((a) => {
+      const raw = a as unknown as Record<string, unknown>;
+      return withTrustScore(sanitizeAdvisor(raw), raw);
+    });
 
     // Most recent updated_at across returned rows
     const latestUpdate =

--- a/app/api/widget/badge/route.ts
+++ b/app/api/widget/badge/route.ts
@@ -1,0 +1,453 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createStaticClient } from "@/lib/supabase/static";
+import { computeAdvisorTrustScore } from "@/lib/advisor-trust-score";
+import { CURRENT_YEAR } from "@/lib/seo";
+
+export const runtime = "nodejs";
+// 1h ISR — advisor profiles refresh hourly; broker health scores are stable daily.
+export const revalidate = 3600;
+
+/**
+ * GET /api/widget/badge — Returns self-contained JavaScript that renders an
+ * embeddable score badge inside a Shadow DOM for a SINGLE named entity.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * PUBLIC-BY-DESIGN ENDPOINT — CORS contract (mirrors /api/widget):
+ *   • `Access-Control-Allow-Origin: *` is INTENTIONAL — embed feature.
+ *   • Must NEVER read user-context data. No cookies, no auth, no per-user
+ *     state. Only public columns are read.
+ *   • Uses the anon-key client so Postgres RLS enforces active-only reads.
+ *     Do NOT swap to createAdminClient().
+ *   • Cache-Control allows public CDN caching — responses are not
+ *     personalised.
+ * ─────────────────────────────────────────────────────────────────────────
+ *
+ * AFSL COMPLIANCE NOTE:
+ *   This badge surfaces a SINGLE entity's OWN factual, already-computed,
+ *   already-public score. It does NOT compare entities against each other,
+ *   does NOT rank, award, or imply "best" status. It is a factual composite
+ *   of objective, publicly-checkable data points for THAT entity alone.
+ *   The general-advice disclaimer is always included.
+ *   A methodology link (/advisor/trust-score-methodology or
+ *   /health-scores/methodology) is included so consumers can audit the
+ *   scoring algorithm.
+ *
+ * Query params:
+ *   ?type=advisor|broker  — which score to display (required)
+ *   ?slug=<slug>          — entity slug (required)
+ *   ?theme=light|dark     — colour theme (default: light)
+ *   ?ref=<partnerId>      — partner attribution; appended to all outbound links
+ */
+export async function GET(request: NextRequest) {
+  const params = request.nextUrl.searchParams;
+  const type = params.get("type");
+  const slug = params.get("slug")?.trim() ?? "";
+  const theme = params.get("theme") === "dark" ? "dark" : "light";
+  const ref = params.get("ref") || "";
+
+  // ── Validate required params ────────────────────────────────────────────
+  if (type !== "advisor" && type !== "broker") {
+    return new NextResponse(
+      `/* invest.com.au score badge: missing or invalid ?type= param (must be "advisor" or "broker") */`,
+      {
+        status: 400,
+        headers: {
+          "Content-Type": "application/javascript; charset=utf-8",
+          "Access-Control-Allow-Origin": "*",
+        },
+      },
+    );
+  }
+
+  if (!slug) {
+    return new NextResponse(
+      `/* invest.com.au score badge: missing ?slug= param */`,
+      {
+        status: 400,
+        headers: {
+          "Content-Type": "application/javascript; charset=utf-8",
+          "Access-Control-Allow-Origin": "*",
+        },
+      },
+    );
+  }
+
+  const supabase = createStaticClient();
+
+  // ── Fetch entity data ───────────────────────────────────────────────────
+
+  if (type === "advisor") {
+    const { data: row } = await supabase
+      .from("professionals")
+      .select(
+        "name, slug, type, photo_url, bio, verified, afsl_number, registration_number, verified_at, created_at, years_experience, qualifications, education, memberships, fee_structure, fee_description, linkedin_url, website, languages, rating, review_count, location_display, status",
+      )
+      .eq("slug", slug)
+      .eq("status", "active")
+      .single();
+
+    if (!row) {
+      return new NextResponse(
+        `/* invest.com.au score badge: advisor "${slug}" not found or inactive */`,
+        {
+          status: 404,
+          headers: {
+            "Content-Type": "application/javascript; charset=utf-8",
+            "Access-Control-Allow-Origin": "*",
+          },
+        },
+      );
+    }
+
+    const advisor = row as {
+      name: string;
+      slug: string;
+      type: string | null;
+      photo_url: string | null;
+      bio: string | null;
+      verified: boolean | null;
+      afsl_number: string | null;
+      registration_number: string | null;
+      verified_at: string | null;
+      created_at: string | null;
+      years_experience: number | null;
+      qualifications: unknown[] | null;
+      education: unknown[] | null;
+      memberships: unknown[] | null;
+      fee_structure: string | null;
+      fee_description: string | null;
+      linkedin_url: string | null;
+      website: string | null;
+      languages: unknown[] | null;
+      rating: number | null;
+      review_count: number | null;
+      location_display: string | null;
+    };
+
+    const scoreResult = computeAdvisorTrustScore(advisor);
+
+    const refParam = ref
+      ? `ref=${encodeURIComponent(ref)}&source=badge-advisor`
+      : "ref=widget&source=badge-advisor";
+
+    const badgeData = {
+      name: advisor.name,
+      slug: advisor.slug,
+      photo_url: advisor.photo_url,
+      location_display: advisor.location_display,
+      score: scoreResult.overall,
+      label: scoreResult.label,
+      labelColor: scoreResult.labelColor,
+      scoreType: "Advisor Trust Score",
+      profileUrl: `https://invest.com.au/advisor/${advisor.slug}`,
+      methodologyUrl: "https://invest.com.au/advisor/trust-score-methodology",
+    };
+
+    const js = buildBadgeJs({
+      badgeData,
+      theme,
+      refParam,
+      widgetAttr: "data-invest-badge-advisor",
+      disclaimerPrefix: "Advisor Trust Scores",
+    });
+
+    return new NextResponse(js, {
+      status: 200,
+      headers: {
+        "Content-Type": "application/javascript; charset=utf-8",
+        "Cache-Control": "public, max-age=3600, s-maxage=3600",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET, OPTIONS",
+        "Cross-Origin-Resource-Policy": "cross-origin",
+        Vary: "Origin",
+      },
+    });
+  }
+
+  // ── Broker badge ─────────────────────────────────────────────────────────
+
+  const { data: brokerRow } = await supabase
+    .from("brokers")
+    .select(
+      "name, slug, rating, regulated_by, year_founded, headquarters, chess_sponsored, is_crypto, platform_type, logo_url, color, icon, status",
+    )
+    .eq("slug", slug)
+    .eq("status", "active")
+    .single();
+
+  if (!brokerRow) {
+    return new NextResponse(
+      `/* invest.com.au score badge: broker "${slug}" not found or inactive */`,
+      {
+        status: 404,
+        headers: {
+          "Content-Type": "application/javascript; charset=utf-8",
+          "Access-Control-Allow-Origin": "*",
+        },
+      },
+    );
+  }
+
+  const broker = brokerRow as {
+    name: string;
+    slug: string;
+    rating: number | null;
+    regulated_by: string | null;
+    year_founded: number | null;
+    headquarters: string | null;
+    chess_sponsored: boolean | null;
+    is_crypto: boolean | null;
+    platform_type: string | null;
+    logo_url: string | null;
+    color: string | null;
+    icon: string | null;
+  };
+
+  // Compute broker health score — same algorithm as /api/widget/health-scores
+  // and /api/broker-health calculateSafetyScore.
+  const currentYear = CURRENT_YEAR;
+  let score = 0;
+  const regLower = (broker.regulated_by || "").toLowerCase();
+
+  const asic = regLower.includes("asic") ? 25 : 0;
+  const afsl = regLower.includes("afsl") || regLower.includes("afs licence") ? 10 : 0;
+  const intlReg =
+    regLower.includes("fca") || regLower.includes("sec") || regLower.includes("mas") ? 5 : 0;
+  const chess = broker.chess_sponsored ? 20 : 0;
+
+  let yearsPoints = 0;
+  if (broker.year_founded) {
+    const yearsOp = currentYear - broker.year_founded;
+    if (yearsOp >= 20) yearsPoints = 20;
+    else if (yearsOp >= 10) yearsPoints = 15;
+    else if (yearsOp >= 5) yearsPoints = 10;
+    else if (yearsOp >= 2) yearsPoints = 5;
+  }
+
+  let ratingPoints = 0;
+  if (broker.rating) {
+    if (broker.rating >= 4.5) ratingPoints = 10;
+    else if (broker.rating >= 4.0) ratingPoints = 8;
+    else if (broker.rating >= 3.5) ratingPoints = 5;
+    else if (broker.rating >= 3.0) ratingPoints = 3;
+  }
+
+  const typePoints = broker.platform_type === "share_broker" ? 5 : 0;
+  const hqLower = (broker.headquarters || "").toLowerCase();
+  let hqPoints = 0;
+  if (
+    hqLower.includes("australia") ||
+    hqLower.includes("sydney") ||
+    hqLower.includes("melbourne")
+  )
+    hqPoints = 5;
+  else if (
+    hqLower.includes("uk") ||
+    hqLower.includes("london") ||
+    hqLower.includes("united states")
+  )
+    hqPoints = 4;
+  else if (hqLower.includes("singapore") || hqLower.includes("hong kong")) hqPoints = 3;
+
+  score = Math.min(asic + afsl + intlReg + chess + yearsPoints + ratingPoints + typePoints + hqPoints, 100);
+  const brokerLabel = score >= 80 ? "Strong" : score >= 50 ? "Moderate" : "Caution";
+  const brokerLabelColor =
+    score >= 80 ? "text-emerald-600" : score >= 50 ? "text-blue-600" : "text-amber-600";
+
+  const refParam = ref
+    ? `ref=${encodeURIComponent(ref)}&source=badge-broker`
+    : "ref=widget&source=badge-broker";
+
+  const badgeData = {
+    name: broker.name,
+    slug: broker.slug,
+    photo_url: broker.logo_url,
+    location_display: broker.headquarters,
+    score,
+    label: brokerLabel,
+    labelColor: brokerLabelColor,
+    scoreType: "Broker Health Score",
+    profileUrl: `https://invest.com.au/health-scores/${broker.slug}`,
+    methodologyUrl: "https://invest.com.au/health-scores/methodology",
+  };
+
+  const js = buildBadgeJs({
+    badgeData,
+    theme,
+    refParam,
+    widgetAttr: "data-invest-badge-broker",
+    disclaimerPrefix: "Broker Health Scores",
+  });
+
+  return new NextResponse(js, {
+    status: 200,
+    headers: {
+      "Content-Type": "application/javascript; charset=utf-8",
+      "Cache-Control": "public, max-age=3600, s-maxage=3600",
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, OPTIONS",
+      "Cross-Origin-Resource-Policy": "cross-origin",
+      Vary: "Origin",
+    },
+  });
+}
+
+// ── Badge JS builder ─────────────────────────────────────────────────────────
+
+interface BadgePayload {
+  name: string;
+  slug: string;
+  photo_url: string | null;
+  location_display: string | null;
+  score: number;
+  label: string;
+  labelColor: string;
+  scoreType: string;
+  profileUrl: string;
+  methodologyUrl: string;
+}
+
+function buildBadgeJs(opts: {
+  badgeData: BadgePayload;
+  theme: "light" | "dark";
+  refParam: string;
+  widgetAttr: string;
+  disclaimerPrefix: string;
+}): string {
+  const { badgeData, theme, refParam, widgetAttr, disclaimerPrefix } = opts;
+
+  const DISCLAIMER =
+    `General information only. ${disclaimerPrefix} are computed from factual, publicly disclosed ` +
+    `attributes and are not a personal recommendation or financial advice. ` +
+    `See the methodology link for full scoring details.`;
+
+  return `
+(function() {
+  "use strict";
+  if (typeof document === "undefined") return;
+
+  var BADGE = ${JSON.stringify(badgeData)};
+  var THEME = ${JSON.stringify(theme)};
+  var DISCLAIMER = ${JSON.stringify(DISCLAIMER)};
+  var REF_PARAM = ${JSON.stringify(refParam)};
+  var BASE = "https://invest.com.au";
+
+  // Find the script tag that loaded us
+  var scripts = document.querySelectorAll("script[src*='/api/widget/badge']");
+  var currentScript = scripts[scripts.length - 1];
+  if (!currentScript) return;
+
+  // Create host element + shadow DOM for style isolation
+  var host = document.createElement("div");
+  host.setAttribute(${JSON.stringify(widgetAttr)}, "true");
+  currentScript.parentNode.insertBefore(host, currentScript.nextSibling);
+
+  var shadow = host.attachShadow({ mode: "open" });
+
+  // ─── Theme tokens ──────────────────────────────────────────────
+  var isDark = THEME === "dark";
+  var bg       = isDark ? "#1e293b" : "#ffffff";
+  var border   = isDark ? "#334155" : "#e2e8f0";
+  var text     = isDark ? "#f1f5f9" : "#0f172a";
+  var textMuted= isDark ? "#94a3b8" : "#64748b";
+  var accent   = "#059669";
+  var trackBg  = isDark ? "#334155" : "#f1f5f9";
+
+  // Score band colours
+  var score = BADGE.score;
+  var gaugeColor = score >= 80 ? "#059669" : score >= 50 ? "#3b82f6" : "#f59e0b";
+
+  // ─── Styles ────────────────────────────────────────────────────
+  var styles = document.createElement("style");
+  styles.textContent = [
+    ":host { all: initial; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; display: block; }",
+    ".ibw { background:" + bg + "; border:1px solid " + border + "; border-radius:12px; overflow:hidden; max-width:320px; font-size:13px; color:" + text + "; }",
+    ".ibw-body { padding:16px; }",
+    ".ibw-name { font-weight:700; font-size:14px; line-height:1.3; margin-bottom:2px; }",
+    ".ibw-location { font-size:11px; color:" + textMuted + "; margin-bottom:12px; }",
+    ".ibw-score-row { display:flex; align-items:center; gap:10px; margin-bottom:10px; }",
+    ".ibw-gauge { position:relative; width:56px; height:56px; flex-shrink:0; }",
+    ".ibw-gauge svg { width:100%; height:100%; transform:rotate(-90deg); }",
+    ".ibw-gauge-track { fill:none; stroke:" + trackBg + "; stroke-width:7; }",
+    ".ibw-gauge-fill { fill:none; stroke:" + gaugeColor + "; stroke-width:7; stroke-linecap:round; transition:stroke-dashoffset .5s ease; }",
+    ".ibw-gauge-text { position:absolute; inset:0; display:flex; flex-direction:column; align-items:center; justify-content:center; }",
+    ".ibw-gauge-num { font-weight:800; font-size:14px; line-height:1; color:" + gaugeColor + "; }",
+    ".ibw-gauge-denom { font-size:8px; color:" + textMuted + "; }",
+    ".ibw-score-meta { flex:1; min-width:0; }",
+    ".ibw-score-type { font-size:10px; font-weight:700; text-transform:uppercase; letter-spacing:.05em; color:" + textMuted + "; margin-bottom:3px; }",
+    ".ibw-label { font-size:13px; font-weight:700; color:" + gaugeColor + "; margin-bottom:4px; }",
+    ".ibw-methodology { font-size:10px; color:" + textMuted + "; }",
+    ".ibw-methodology a { color:" + accent + "; text-decoration:none; }",
+    ".ibw-methodology a:hover { text-decoration:underline; }",
+    ".ibw-cta { display:block; width:100%; text-align:center; padding:8px 12px; background:" + accent + "; color:#fff; border-radius:8px; text-decoration:none; font-weight:700; font-size:12px; margin-top:4px; transition:opacity .15s; box-sizing:border-box; }",
+    ".ibw-cta:hover { opacity:.88; }",
+    ".ibw-disclaimer { padding:8px 12px 10px; font-size:10px; color:" + textMuted + "; border-top:1px solid " + border + "; line-height:1.5; }",
+    ".ibw-footer { padding:6px 12px 8px; text-align:center; font-size:10px; color:" + textMuted + "; }",
+    ".ibw-footer a { color:" + accent + "; text-decoration:none; font-weight:600; }",
+    ".ibw-footer a:hover { text-decoration:underline; }",
+  ].join("\\n");
+  shadow.appendChild(styles);
+
+  // ─── Helpers ───────────────────────────────────────────────────
+  function esc(s) {
+    if (!s) return "";
+    var d = document.createElement("div");
+    d.appendChild(document.createTextNode(String(s)));
+    return d.innerHTML;
+  }
+
+  // Gauge circumference for r=22
+  var r = 22;
+  var circ = 2 * Math.PI * r;
+  var filled = Math.max(0, Math.min(1, score / 100)) * circ;
+  var dashOffset = circ - filled;
+
+  // ─── Build container ───────────────────────────────────────────
+  var container = document.createElement("div");
+  container.className = "ibw";
+
+  var profileLink = esc(BADGE.profileUrl) + "?" + REF_PARAM;
+  var methLink = esc(BADGE.methodologyUrl) + "?" + REF_PARAM;
+
+  container.innerHTML =
+    '<div class="ibw-body">' +
+      '<div class="ibw-name"><a href="' + profileLink + '" target="_blank" style="color:inherit;text-decoration:none;">' + esc(BADGE.name) + '</a></div>' +
+      (BADGE.location_display ? '<div class="ibw-location">' + esc(BADGE.location_display) + '</div>' : '') +
+      '<div class="ibw-score-row">' +
+        '<div class="ibw-gauge">' +
+          '<svg viewBox="0 0 56 56" xmlns="http://www.w3.org/2000/svg">' +
+            '<circle class="ibw-gauge-track" cx="28" cy="28" r="' + r + '" />' +
+            '<circle class="ibw-gauge-fill" cx="28" cy="28" r="' + r + '" stroke-dasharray="' + circ.toFixed(2) + '" stroke-dashoffset="' + dashOffset.toFixed(2) + '" />' +
+          '</svg>' +
+          '<div class="ibw-gauge-text"><span class="ibw-gauge-num">' + score + '</span><span class="ibw-gauge-denom">/100</span></div>' +
+        '</div>' +
+        '<div class="ibw-score-meta">' +
+          '<div class="ibw-score-type">' + esc(BADGE.scoreType) + '</div>' +
+          '<div class="ibw-label">' + esc(BADGE.label) + '</div>' +
+          '<div class="ibw-methodology">Score explained: <a href="' + methLink + '" target="_blank" rel="noopener noreferrer">methodology &rarr;</a></div>' +
+        '</div>' +
+      '</div>' +
+      '<a class="ibw-cta" href="' + profileLink + '" target="_blank" rel="noopener noreferrer">View full profile</a>' +
+    '</div>' +
+    '<div class="ibw-disclaimer">' + esc(DISCLAIMER) + '</div>' +
+    '<div class="ibw-footer">Powered by <a href="' + BASE + '/embed?' + REF_PARAM + '" target="_blank">invest.com.au</a></div>';
+
+  shadow.appendChild(container);
+})();
+`.trim();
+}
+
+/**
+ * CORS pre-flight. Mirrors /api/widget OPTIONS handler.
+ */
+export function OPTIONS() {
+  return new NextResponse(null, {
+    status: 204,
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, OPTIONS",
+      "Access-Control-Max-Age": "86400",
+      Vary: "Origin",
+    },
+  });
+}

--- a/app/api/widget/badge/route.ts
+++ b/app/api/widget/badge/route.ts
@@ -29,7 +29,7 @@ export const revalidate = 3600;
  *   of objective, publicly-checkable data points for THAT entity alone.
  *   The general-advice disclaimer is always included.
  *   A methodology link (/advisor/trust-score-methodology or
- *   /health-scores/methodology) is included so consumers can audit the
+ *   /health-scores) is included so consumers can audit the
  *   scoring algorithm.
  *
  * Query params:
@@ -268,7 +268,7 @@ export async function GET(request: NextRequest) {
     labelColor: brokerLabelColor,
     scoreType: "Broker Health Score",
     profileUrl: `https://invest.com.au/health-scores/${broker.slug}`,
-    methodologyUrl: "https://invest.com.au/health-scores/methodology",
+    methodologyUrl: "https://invest.com.au/health-scores",
   };
 
   const js = buildBadgeJs({

--- a/app/embed/EmbedBuilder.tsx
+++ b/app/embed/EmbedBuilder.tsx
@@ -62,6 +62,11 @@ export default function EmbedBuilder() {
   const [healthTheme, setHealthTheme] = useState<"light" | "dark">("light");
   const [healthLimit, setHealthLimit] = useState(5);
 
+  // ─── Badge widget state ───────────────────────────────────────────────────
+  const [badgeType, setBadgeType] = useState<"advisor" | "broker">("advisor");
+  const [badgeSlug, setBadgeSlug] = useState("");
+  const [badgeTheme, setBadgeTheme] = useState<"light" | "dark">("light");
+
   const [copied, setCopied] = useState(false);
   const previewRef = useRef<HTMLDivElement>(null);
 
@@ -121,6 +126,16 @@ export default function EmbedBuilder() {
     return `https://invest.com.au/api/widget/health-scores${qs ? `?${qs}` : ""}`;
   }, [healthSlugs, healthTheme, healthLimit, partnerRef]);
 
+  const badgeEmbedUrl = useMemo(() => {
+    const params = new URLSearchParams();
+    params.set("type", badgeType);
+    if (badgeSlug.trim()) params.set("slug", badgeSlug.trim());
+    if (badgeTheme !== "light") params.set("theme", badgeTheme);
+    if (partnerRef.trim()) params.set("ref", partnerRef.trim());
+    const qs = params.toString();
+    return `https://invest.com.au/api/widget/badge${qs ? `?${qs}` : ""}`;
+  }, [badgeType, badgeSlug, badgeTheme, partnerRef]);
+
   const activeUrl = useMemo(() => {
     switch (tab) {
       case "broker": return brokerEmbedUrl;
@@ -128,8 +143,9 @@ export default function EmbedBuilder() {
       case "advisors": return advisorEmbedUrl;
       case "fee-index": return feeIndexEmbedUrl;
       case "health-scores": return healthEmbedUrl;
+      case "badge": return badgeEmbedUrl;
     }
-  }, [tab, brokerEmbedUrl, calcEmbedUrl, advisorEmbedUrl, feeIndexEmbedUrl, healthEmbedUrl]);
+  }, [tab, brokerEmbedUrl, calcEmbedUrl, advisorEmbedUrl, feeIndexEmbedUrl, healthEmbedUrl, badgeEmbedUrl]);
 
   const snippet = `<script src="${activeUrl}"></script>`;
 
@@ -207,6 +223,7 @@ export default function EmbedBuilder() {
       case "advisors": return advisorTheme;
       case "fee-index": return feeTheme;
       case "health-scores": return healthTheme;
+      case "badge": return badgeTheme;
     }
   })();
 
@@ -575,6 +592,62 @@ export default function EmbedBuilder() {
             <p className="text-[11px] text-slate-500">
               Scores are computed from factual regulatory attributes — not a personal recommendation.
               General-advice disclaimer is included automatically.
+            </p>
+          </>
+        )}
+
+        {/* ── BADGE WIDGET CONTROLS ── */}
+        {tab === "badge" && (
+          <>
+            <div className="bg-amber-50 border border-amber-200 rounded-xl p-4 text-xs text-amber-900 leading-relaxed">
+              <strong>Single-entity badge only.</strong> This widget shows one advisor&apos;s or broker&apos;s
+              own factual score. It does not compare entities, rank, or imply &ldquo;best&rdquo; status.
+              A methodology link is always included on the badge.
+            </div>
+            <div className="grid sm:grid-cols-2 gap-4">
+              <div>
+                <label className="block text-xs font-bold uppercase tracking-wider text-slate-500 mb-2">Score Type</label>
+                <select
+                  value={badgeType}
+                  onChange={(e) => setBadgeType(e.target.value as "advisor" | "broker")}
+                  className="w-full border border-slate-200 rounded-lg py-2 px-3 text-sm"
+                >
+                  <option value="advisor">Advisor Trust Score</option>
+                  <option value="broker">Broker Health Score</option>
+                </select>
+              </div>
+              <div>
+                <label className="block text-xs font-bold uppercase tracking-wider text-slate-500 mb-2">
+                  {badgeType === "advisor" ? "Advisor Slug" : "Broker Slug"}
+                </label>
+                <input
+                  type="text"
+                  value={badgeSlug}
+                  onChange={(e) => setBadgeSlug(e.target.value)}
+                  placeholder={badgeType === "advisor" ? "e.g. jane-smith-cfp" : "e.g. stake"}
+                  className="w-full border border-slate-200 rounded-lg py-2 px-3 text-sm placeholder:text-slate-400"
+                  maxLength={128}
+                />
+                <p className="mt-1 text-[11px] text-slate-500">
+                  Find the slug in the URL of the {badgeType === "advisor" ? "advisor profile" : "broker profile"} page.
+                </p>
+              </div>
+              <div>
+                <label className="block text-xs font-bold uppercase tracking-wider text-slate-500 mb-2">Theme</label>
+                <select
+                  value={badgeTheme}
+                  onChange={(e) => setBadgeTheme(e.target.value as "light" | "dark")}
+                  className="w-full border border-slate-200 rounded-lg py-2 px-3 text-sm"
+                >
+                  <option value="light">Light</option>
+                  <option value="dark">Dark</option>
+                </select>
+              </div>
+            </div>
+            <p className="text-[11px] text-slate-500">
+              Renders a compact gauge badge (320px max-width) inside a Shadow DOM.
+              Includes the general-advice disclaimer and a link to the scoring methodology.
+              Not a recommendation or personal advice.
             </p>
           </>
         )}

--- a/app/embed/page.tsx
+++ b/app/embed/page.tsx
@@ -141,6 +141,31 @@ const HEALTH_SNIPPETS = [
   },
 ];
 
+const BADGE_SNIPPETS = [
+  {
+    title: "Advisor Trust Score badge",
+    description:
+      "Compact gauge badge showing a single advisor's Trust Score (0–100), label, and methodology link. Not a ranking.",
+    code: `<script src="https://invest.com.au/api/widget/badge?type=advisor&slug=jane-smith-cfp"></script>`,
+  },
+  {
+    title: "Broker Health Score badge",
+    description:
+      "Compact gauge badge showing a single broker's Health Score (0–100), label, and methodology link.",
+    code: `<script src="https://invest.com.au/api/widget/badge?type=broker&slug=stake"></script>`,
+  },
+  {
+    title: "Dark Theme advisor badge",
+    description: "Advisor Trust Score badge styled for dark-mode pages.",
+    code: `<script src="https://invest.com.au/api/widget/badge?type=advisor&slug=jane-smith-cfp&theme=dark"></script>`,
+  },
+  {
+    title: "With Partner Attribution",
+    description: "Thread your partner ID through to invest.com.au profile and methodology links.",
+    code: `<script src="https://invest.com.au/api/widget/badge?type=advisor&slug=jane-smith-cfp&ref=yourpartnerId"></script>`,
+  },
+];
+
 function SnippetBlock({ snippet }: { snippet: { title: string; description: string; code: string } }) {
   return (
     <div className="border border-slate-200 rounded-xl overflow-hidden">
@@ -359,6 +384,30 @@ export default function EmbedPage() {
           { param: "brokers", values: "slug,slug,...", def: "(top by rating)", desc: "Comma-separated broker slugs to include." },
           { param: "theme", values: "light | dark", def: "light", desc: "Colour theme." },
           { param: "limit", values: "1–10", def: "5", desc: "Maximum brokers displayed." },
+          REF_PARAM_ROW,
+        ]} />
+
+        {/* ── Score Badge Widget ── */}
+        <h2 className="text-lg md:text-xl font-extrabold text-slate-900 mb-1">Score Badge Widget</h2>
+        <p className="text-sm text-slate-500 mb-5">
+          A compact, embeddable badge showing a <strong>single entity&apos;s own factual score</strong> — either
+          an Advisor Trust Score or a Broker Health Score. Includes a gauge (0–100), a band label
+          (e.g. &ldquo;Good&rdquo; or &ldquo;Strong&rdquo;), and a link to the published scoring methodology.
+          Not a ranking, award, or comparison. General-advice disclaimer is always included.
+        </p>
+        <div className="bg-amber-50 border border-amber-200 rounded-xl p-4 mb-6 text-xs text-amber-900 leading-relaxed">
+          <strong>Compliance note:</strong> The badge surfaces a single entity&apos;s own score only.
+          It does not compare entities, rank them, or use &ldquo;best&rdquo; or &ldquo;award&rdquo; language.
+          The badge always links to the methodology page so visitors can audit the scoring algorithm.
+        </div>
+        <div className="space-y-6 mb-8">
+          {BADGE_SNIPPETS.map((s) => <SnippetBlock key={s.title} snippet={s} />)}
+        </div>
+        <h3 className="text-base font-extrabold text-slate-900 mb-4">Score Badge Parameters</h3>
+        <ParamsTable rows={[
+          { param: "type", values: "advisor | broker", def: "(required)", desc: "Which score to display — advisor Trust Score or broker Health Score." },
+          { param: "slug", values: "entity slug", def: "(required)", desc: "Slug of the advisor or broker (found in their profile URL)." },
+          { param: "theme", values: "light | dark", def: "light", desc: "Colour theme." },
           REF_PARAM_ROW,
         ]} />
 

--- a/lib/openapi-spec.ts
+++ b/lib/openapi-spec.ts
@@ -240,6 +240,35 @@ export function buildOpenApiSpec(): OpenApiSpec {
             },
           ],
         },
+        AdvisorTrustScore: {
+          type: "object",
+          description:
+            "Factual composite score for a single advisor, computed from publicly disclosed credential " +
+            "and review signals. NOT a ranking or personal recommendation. " +
+            "See methodology_url for full scoring details.",
+          required: ["overall", "label", "methodology_url"],
+          properties: {
+            overall: {
+              type: "integer",
+              minimum: 0,
+              maximum: 100,
+              description: "Overall Trust Score, 0–100.",
+              example: 74,
+            },
+            label: {
+              type: "string",
+              enum: ["Strong", "Good", "Moderate", "Limited"],
+              description: "Human-readable band label corresponding to the overall score.",
+              example: "Good",
+            },
+            methodology_url: {
+              type: "string",
+              format: "uri",
+              description: "Link to the published scoring methodology.",
+              example: "https://invest.com.au/advisor/trust-score-methodology",
+            },
+          },
+        },
         Advisor: {
           type: "object",
           properties: {
@@ -262,6 +291,13 @@ export function buildOpenApiSpec(): OpenApiSpec {
             hourly_rate_cents: { type: "integer", nullable: true },
             initial_consultation_free: { type: "boolean" },
             updated_at: { type: "string", format: "date-time" },
+            trust_score: {
+              allOf: [{ $ref: "#/components/schemas/AdvisorTrustScore" }],
+              description:
+                "Computed Advisor Trust Score for this advisor. " +
+                "Factual single-entity score only — not a comparison, ranking, or award. " +
+                "See methodology_url for the published scoring algorithm.",
+            },
           },
         },
         HealthScore: {

--- a/lib/widget/types.ts
+++ b/lib/widget/types.ts
@@ -18,6 +18,7 @@
  *   /api/widget/advisors      — advisor directory widget
  *   /api/widget/fee-index     — AU brokerage fee index table
  *   /api/widget/health-scores — broker health score comparison
+ *   /api/widget/badge         — single-entity score badge (advisor trust or broker health)
  *
  * All suite routes support an optional `?ref=<partnerId>` query param that
  * is threaded through to outbound invest.com.au links for partner attribution.
@@ -30,7 +31,8 @@ export type WidgetKind =
   | "calculator"
   | "advisors"
   | "fee-index"
-  | "health-scores";
+  | "health-scores"
+  | "badge";
 
 export type WidgetFilter = "all" | "asx" | "us" | "crypto" | "savings" | "term-deposits";
 
@@ -237,6 +239,35 @@ export const SUITE_WIDGET_CATALOGUE: ReadonlyArray<SuiteWidgetMeta> = [
       { title: "Specific brokers", description: "Health scores for chosen brokers.", params: "?brokers=stake,commsec,cmc-markets" },
       { title: "Dark theme", description: "Health scores styled for dark-mode sites.", params: "?theme=dark" },
       { title: "With partner ref", description: "Partner attribution threaded through links.", params: "?ref=yourpartnerId" },
+    ],
+  },
+  {
+    kind: "badge",
+    label: "Score Badge",
+    description:
+      "Single-entity score badge — shows an advisor's Trust Score or a broker's Health Score with a methodology link. Not a ranking or comparison.",
+    apiPath: "/api/widget/badge",
+    snippets: [
+      {
+        title: "Advisor Trust Score badge",
+        description: "Embeds a single advisor's Trust Score with gauge, label, and methodology link.",
+        params: "?type=advisor&slug=jane-smith-cfp",
+      },
+      {
+        title: "Broker Health Score badge",
+        description: "Embeds a single broker's Health Score with gauge, label, and methodology link.",
+        params: "?type=broker&slug=stake",
+      },
+      {
+        title: "Dark theme advisor badge",
+        description: "Advisor badge styled for dark-mode pages.",
+        params: "?type=advisor&slug=jane-smith-cfp&theme=dark",
+      },
+      {
+        title: "With partner ref",
+        description: "Partner attribution threaded through outbound links.",
+        params: "?type=advisor&slug=jane-smith-cfp&ref=yourpartnerId",
+      },
     ],
   },
 ];


### PR DESCRIPTION
Round-3 deepening (4 of 10). Surfaces our **existing factual quality scores** (broker Health Score, Advisor Trust Score) as an embeddable badge + a public-API field, with a methodology link.

- **`/api/widget/badge`** — embeddable single-entity score badge (`?type=advisor|broker&slug=…`), following the existing widget conventions exactly (Shadow DOM, CORS `*`, anon-key, ISR, `?ref=` attribution, general-advice disclaimer). Added to `EmbedBuilder` + `/embed` docs.
- **v1 API** — `trust_score { overall, label, methodology_url }` added to `/api/v1/advisors` (mirrors the broker health-score exposure); `lib/openapi-spec.ts` updated with the `AdvisorTrustScore` schema.

**Compliance:** strictly the AFSL-safe slice — a single entity's own factual, already-public composite. **No** awards / "best of" / rankings / cross-entity comparison (those need legal methodology sign-off and are intentionally out of scope).

**Fixes on verification:** (1) the broker score test expected 80 but the canonical algorithm (matched exactly by the badge — incl. `+5 share_broker`) yields **85** for Stake; the existing canonical test only asserted "≥80/Strong" so never caught it — corrected to 85. (2) the broker methodology link pointed at a non-existent `/health-scores/methodology` — repointed to the existing `/health-scores` page (which has the Methodology section).

**Verified:** `tsc` clean · **61 tests** (badge advisor/broker, validation, disclaimer-present, no-cross-entity-language, `?ref=` threading + 8 new trust_score API tests) pass · eslint clean · rate-limit `--strict` pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUfSRE2Teb6VhEXFP6RpS9)_