### PR TITLE
feat: complete rate/fee alerts product — thresholds, auth API, cron, Pro feed (deepen)

### DIFF
--- a/__tests__/api/account-alerts.test.ts
+++ b/__tests__/api/account-alerts.test.ts
@@ -1,0 +1,359 @@
+/**
+ * Tests for /api/account/alerts (GET / POST / DELETE).
+ *
+ * Covers:
+ *   - Auth gate: 401 when not signed in
+ *   - POST: valid body creates subscription; invalid body returns 400
+ *   - POST: broker_fee requires broker_slug; loan_rate requires lender_slug
+ *   - POST: DB error returns 500
+ *   - GET: returns items for the current user
+ *   - DELETE: removes own subscription; 401 when not signed in
+ */
+
+import { beforeEach, afterEach, describe, it, expect, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const { mockGetUser, mockFrom } = vi.hoisted(() => ({
+  mockGetUser: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+// Use mockImplementation (not mockResolvedValue) so the implementation
+// survives vi.clearAllMocks(), which only clears call history + queued
+// once-returns, not the base implementation set via mockImplementation.
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn().mockImplementation(() =>
+    Promise.resolve({
+      auth: { getUser: mockGetUser },
+      from: (...args: unknown[]) => mockFrom(...args),
+    }),
+  ),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+// ── Import after mocks ────────────────────────────────────────────────────────
+
+import { GET, POST, DELETE } from "@/app/api/account/alerts/route";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+const VALID_UUID = "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11";
+
+function makeRequest(method: string, body?: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/account/alerts", {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+}
+
+const SIGNED_OUT = { data: { user: null } };
+const SIGNED_IN = {
+  data: { user: { id: "user-123", email: "u@example.com" } },
+};
+
+// clearAllMocks clears call history + once-queued returns but preserves
+// persistent mockImplementation/mockResolvedValue set in the vi.mock factory.
+beforeEach(() => vi.clearAllMocks());
+
+// ── GET ────────────────────────────────────────────────────────────────────────
+
+describe("GET /api/account/alerts", () => {
+  it("returns 401 when not signed in", async () => {
+    mockGetUser.mockResolvedValueOnce(SIGNED_OUT);
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
+  it("returns items for the current user", async () => {
+    mockGetUser.mockResolvedValueOnce(SIGNED_IN);
+    const items = [
+      {
+        id: VALID_UUID,
+        metric_kind: "savings_rate",
+        product_kind: "savings_account",
+        threshold_bps: 500,
+        direction: "above",
+        frequency: "instant",
+        broker_slug: null,
+        lender_slug: null,
+        verified: true,
+        last_notified_at: null,
+        last_fired_value_bps: null,
+        notification_count: 0,
+        created_at: "2026-05-01T00:00:00Z",
+      },
+    ];
+    // Build: from().select().eq().order() → resolves
+    const chain: Record<string, unknown> = {};
+    chain.select = vi.fn(() => chain);
+    chain.eq = vi.fn(() => chain);
+    chain.order = vi.fn(() => Promise.resolve({ data: items, error: null }));
+    mockFrom.mockReturnValueOnce(chain);
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { items: unknown[] };
+    expect(body.items).toHaveLength(1);
+  });
+
+  it("returns 500 when the DB query errors", async () => {
+    mockGetUser.mockResolvedValueOnce(SIGNED_IN);
+    const chain: Record<string, unknown> = {};
+    chain.select = vi.fn(() => chain);
+    chain.eq = vi.fn(() => chain);
+    chain.order = vi.fn(() =>
+      Promise.resolve({ data: null, error: { message: "db_error" } }),
+    );
+    mockFrom.mockReturnValueOnce(chain);
+
+    const res = await GET();
+    expect(res.status).toBe(500);
+  });
+});
+
+// ── POST ───────────────────────────────────────────────────────────────────────
+
+describe("POST /api/account/alerts", () => {
+  it("returns 401 when not signed in", async () => {
+    mockGetUser.mockResolvedValueOnce(SIGNED_OUT);
+    const res = await POST(
+      makeRequest("POST", {
+        metric_kind: "savings_rate",
+        threshold_pct: 5.25,
+      }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for missing metric_kind", async () => {
+    // withValidatedBody returns 400 before the handler runs — no getUser call.
+    const res = await POST(makeRequest("POST", { threshold_pct: 5.25 }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for invalid metric_kind", async () => {
+    // withValidatedBody returns 400 before the handler runs — no getUser call.
+    const res = await POST(
+      makeRequest("POST", {
+        metric_kind: "unknown_kind",
+        threshold_pct: 5.25,
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for threshold_pct out of range", async () => {
+    // withValidatedBody returns 400 before the handler runs — no getUser call.
+    const res = await POST(
+      makeRequest("POST", {
+        metric_kind: "savings_rate",
+        threshold_pct: 150,
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for broker_fee without broker_slug", async () => {
+    mockGetUser.mockResolvedValueOnce(SIGNED_IN);
+    const res = await POST(
+      makeRequest("POST", { metric_kind: "broker_fee", threshold_pct: 9.99 }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for loan_rate without lender_slug", async () => {
+    mockGetUser.mockResolvedValueOnce(SIGNED_IN);
+    const res = await POST(
+      makeRequest("POST", { metric_kind: "loan_rate", threshold_pct: 6.0 }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("creates a savings_rate alert successfully", async () => {
+    mockGetUser.mockResolvedValueOnce(SIGNED_IN);
+    const insertedItem = {
+      id: VALID_UUID,
+      metric_kind: "savings_rate",
+      threshold_bps: 525,
+      direction: "above",
+      frequency: "instant",
+    };
+    // Chain: from().insert({...}).select("...").single()
+    const singleMock = vi.fn(() =>
+      Promise.resolve({ data: insertedItem, error: null }),
+    );
+    const selectMock = vi.fn(() => ({ single: singleMock }));
+    const insertMock = vi.fn(() => ({ select: selectMock }));
+    mockFrom.mockReturnValueOnce({ insert: insertMock });
+
+    const res = await POST(
+      makeRequest("POST", {
+        metric_kind: "savings_rate",
+        threshold_pct: 5.25,
+        direction: "above",
+        frequency: "instant",
+      }),
+    );
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { item: { threshold_bps: number } };
+    expect(body.item.threshold_bps).toBe(525);
+    expect(insertMock).toHaveBeenCalledTimes(1);
+    const insertArgs = insertMock.mock.calls[0] as unknown as [Record<string, unknown>];
+    expect(insertArgs[0].threshold_bps).toBe(525);
+    expect(insertArgs[0].verified).toBe(true);
+    expect(insertArgs[0].user_id).toBe("user-123");
+  });
+
+  it("creates a broker_fee alert with broker_slug", async () => {
+    mockGetUser.mockResolvedValueOnce(SIGNED_IN);
+    const singleMock = vi.fn(() =>
+      Promise.resolve({
+        data: {
+          id: VALID_UUID,
+          metric_kind: "broker_fee",
+          threshold_bps: 999,
+          direction: "below",
+          frequency: "daily",
+        },
+        error: null,
+      }),
+    );
+    const selectMock = vi.fn(() => ({ single: singleMock }));
+    const insertMock = vi.fn(() => ({ select: selectMock }));
+    mockFrom.mockReturnValueOnce({ insert: insertMock });
+
+    const res = await POST(
+      makeRequest("POST", {
+        metric_kind: "broker_fee",
+        threshold_pct: 9.99,
+        direction: "below",
+        frequency: "daily",
+        broker_slug: "commsec",
+      }),
+    );
+    expect(res.status).toBe(201);
+    const insertArgs = insertMock.mock.calls[0] as unknown as [Record<string, unknown>];
+    expect(insertArgs[0].broker_slug).toBe("commsec");
+    expect(insertArgs[0].metric_kind).toBe("broker_fee");
+  });
+
+  it("creates a loan_rate alert with lender_slug", async () => {
+    mockGetUser.mockResolvedValueOnce(SIGNED_IN);
+    const singleMock = vi.fn(() =>
+      Promise.resolve({
+        data: {
+          id: VALID_UUID,
+          metric_kind: "loan_rate",
+          threshold_bps: 620,
+          direction: "below",
+          frequency: "instant",
+        },
+        error: null,
+      }),
+    );
+    const selectMock = vi.fn(() => ({ single: singleMock }));
+    const insertMock = vi.fn(() => ({ select: selectMock }));
+    mockFrom.mockReturnValueOnce({ insert: insertMock });
+
+    const res = await POST(
+      makeRequest("POST", {
+        metric_kind: "loan_rate",
+        threshold_pct: 6.2,
+        direction: "below",
+        frequency: "instant",
+        lender_slug: "commonwealth-bank",
+      }),
+    );
+    expect(res.status).toBe(201);
+    const insertArgs = insertMock.mock.calls[0] as unknown as [Record<string, unknown>];
+    expect(insertArgs[0].lender_slug).toBe("commonwealth-bank");
+  });
+
+  it("returns 500 when the DB insert fails", async () => {
+    mockGetUser.mockResolvedValueOnce(SIGNED_IN);
+    const singleMock = vi.fn(() =>
+      Promise.resolve({ data: null, error: { message: "db_err" } }),
+    );
+    const selectMock = vi.fn(() => ({ single: singleMock }));
+    const insertMock = vi.fn(() => ({ select: selectMock }));
+    mockFrom.mockReturnValueOnce({ insert: insertMock });
+
+    const res = await POST(
+      makeRequest("POST", { metric_kind: "savings_rate", threshold_pct: 5.0 }),
+    );
+    expect(res.status).toBe(500);
+  });
+});
+
+// ── DELETE ─────────────────────────────────────────────────────────────────────
+
+describe("DELETE /api/account/alerts", () => {
+  it("returns 401 when not signed in", async () => {
+    mockGetUser.mockResolvedValueOnce(SIGNED_OUT);
+    const res = await DELETE(makeRequest("DELETE", { id: VALID_UUID }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for missing id", async () => {
+    // withValidatedBody returns 400 before the handler runs — no getUser call.
+    const res = await DELETE(makeRequest("DELETE", {}));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for non-UUID id", async () => {
+    // withValidatedBody returns 400 before the handler runs — no getUser call.
+    const res = await DELETE(makeRequest("DELETE", { id: "not-a-uuid" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("deletes own subscription successfully", async () => {
+    mockGetUser.mockResolvedValueOnce(SIGNED_IN);
+
+    // Chain: from().delete().eq(id).eq(user_id) → last eq resolves
+    let eqCallCount = 0;
+    const chain: Record<string, unknown> = {};
+    chain.delete = vi.fn(() => chain);
+    chain.eq = vi.fn((..._args: unknown[]) => {
+      eqCallCount++;
+      if (eqCallCount >= 2) {
+        return Promise.resolve({ error: null });
+      }
+      return chain;
+    });
+    mockFrom.mockReturnValueOnce(chain);
+
+    const res = await DELETE(makeRequest("DELETE", { id: VALID_UUID }));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { success: boolean };
+    expect(body.success).toBe(true);
+  });
+
+  it("returns 500 when the DB delete fails", async () => {
+    mockGetUser.mockResolvedValueOnce(SIGNED_IN);
+
+    let eqCallCount = 0;
+    const chain: Record<string, unknown> = {};
+    chain.delete = vi.fn(() => chain);
+    chain.eq = vi.fn((..._args: unknown[]) => {
+      eqCallCount++;
+      if (eqCallCount >= 2) {
+        return Promise.resolve({ error: { message: "db_err" } });
+      }
+      return chain;
+    });
+    mockFrom.mockReturnValueOnce(chain);
+
+    const res = await DELETE(makeRequest("DELETE", { id: VALID_UUID }));
+    expect(res.status).toBe(500);
+  });
+});

--- a/__tests__/api/account-alerts.test.ts
+++ b/__tests__/api/account-alerts.test.ts
@@ -10,7 +10,7 @@
  *   - DELETE: removes own subscription; 401 when not signed in
  */
 
-import { beforeEach, afterEach, describe, it, expect, vi } from "vitest";
+import { beforeEach, describe, it, expect, vi } from "vitest";
 import { NextRequest } from "next/server";
 
 // ── Mocks ──────────────────────────────────────────────────────────────────────

--- a/__tests__/lib/alert-thresholds.test.ts
+++ b/__tests__/lib/alert-thresholds.test.ts
@@ -98,15 +98,9 @@ describe("evaluateThreshold — direction:below", () => {
 
 describe("evaluateThreshold — cooldown", () => {
   it("suppresses within the instant (24h) cooldown window", () => {
-    // Fired 12 hours ago.
-    const sub = makeSub({
-      last_notified_at: new Date(NOW_MS - 12 * HOUR_MS).toISOString(),
-      last_fired_value_bps: 520,
-    });
-    // last_fired_value_bps=520 means it previously fired above 500.
-    // Re-arm check: for "above", re-arm when last_fired <= (threshold - hysteresis).
-    // 520 > 500 - 10 = 490 → has NOT re-armed → hysteresis suppresses first.
-    // Let's use a sub where last_fired_value_bps is low enough to pass hysteresis.
+    // Fired 12 hours ago, with last_fired_value_bps low enough to clear the
+    // re-arm/hysteresis gate (for "above", re-arm when last_fired <= threshold - hysteresis,
+    // i.e. <= 500 - 10 = 490) so the cooldown window is what's under test.
     const subReArmed = makeSub({
       last_notified_at: new Date(NOW_MS - 12 * HOUR_MS).toISOString(),
       last_fired_value_bps: 480, // below threshold - hysteresis (490) → re-armed

--- a/__tests__/lib/alert-thresholds.test.ts
+++ b/__tests__/lib/alert-thresholds.test.ts
@@ -1,0 +1,313 @@
+/**
+ * Tests for lib/alert-thresholds.ts
+ *
+ * Covers:
+ *   - evaluateThreshold: crossed / not-crossed (both directions)
+ *   - Hysteresis dead-band prevents re-fire
+ *   - Cooldown window suppresses within-window fires
+ *   - Interaction: cooldown wins over hysteresis once re-armed
+ *   - Edge cases: exactly-at-threshold, hysteresis boundary, zero threshold
+ *   - metricKindLabel and metricKindPath sanity checks
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  evaluateThreshold,
+  metricKindLabel,
+  metricKindPath,
+  DEFAULT_HYSTERESIS_BPS,
+  type AlertSubscription,
+} from "@/lib/alert-thresholds";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+const WEEK_MS = 7 * DAY_MS;
+
+/** Reference "now" used across tests (a fixed point in time). */
+const NOW_MS = new Date("2026-05-25T12:00:00Z").getTime();
+
+/** Build a minimal fresh subscription (never fired). */
+function makeSub(
+  overrides: Partial<AlertSubscription> = {},
+): AlertSubscription {
+  return {
+    id: "test-sub",
+    metric_kind: "savings_rate",
+    threshold_bps: 500, // 5.00%
+    direction: "above",
+    frequency: "instant",
+    last_notified_at: null,
+    last_fired_value_bps: null,
+    ...overrides,
+  };
+}
+
+// ── Basic crossing ─────────────────────────────────────────────────────────────
+
+describe("evaluateThreshold — direction:above", () => {
+  it("fires when current >= threshold (never fired before)", () => {
+    const result = evaluateThreshold(makeSub(), 500, NOW_MS);
+    expect(result.crossed).toBe(true);
+    expect(result.shouldFire).toBe(true);
+    expect(result.suppressReason).toBeUndefined();
+  });
+
+  it("fires when current strictly above threshold", () => {
+    const result = evaluateThreshold(makeSub(), 550, NOW_MS);
+    expect(result.shouldFire).toBe(true);
+  });
+
+  it("does NOT fire when current < threshold", () => {
+    const result = evaluateThreshold(makeSub(), 499, NOW_MS);
+    expect(result.crossed).toBe(false);
+    expect(result.shouldFire).toBe(false);
+    expect(result.suppressReason).toBe("not_crossed");
+  });
+
+  it("does NOT fire when current is exactly 1 bps below threshold", () => {
+    const result = evaluateThreshold(makeSub(), 499, NOW_MS);
+    expect(result.shouldFire).toBe(false);
+  });
+});
+
+describe("evaluateThreshold — direction:below", () => {
+  it("fires when current <= threshold (never fired before)", () => {
+    const sub = makeSub({ direction: "below", threshold_bps: 500 });
+    const result = evaluateThreshold(sub, 500, NOW_MS);
+    expect(result.crossed).toBe(true);
+    expect(result.shouldFire).toBe(true);
+  });
+
+  it("fires when current strictly below threshold", () => {
+    const sub = makeSub({ direction: "below", threshold_bps: 500 });
+    const result = evaluateThreshold(sub, 450, NOW_MS);
+    expect(result.shouldFire).toBe(true);
+  });
+
+  it("does NOT fire when current > threshold", () => {
+    const sub = makeSub({ direction: "below", threshold_bps: 500 });
+    const result = evaluateThreshold(sub, 501, NOW_MS);
+    expect(result.crossed).toBe(false);
+    expect(result.shouldFire).toBe(false);
+  });
+});
+
+// ── Cooldown window ────────────────────────────────────────────────────────────
+
+describe("evaluateThreshold — cooldown", () => {
+  it("suppresses within the instant (24h) cooldown window", () => {
+    // Fired 12 hours ago.
+    const sub = makeSub({
+      last_notified_at: new Date(NOW_MS - 12 * HOUR_MS).toISOString(),
+      last_fired_value_bps: 520,
+    });
+    // last_fired_value_bps=520 means it previously fired above 500.
+    // Re-arm check: for "above", re-arm when last_fired <= (threshold - hysteresis).
+    // 520 > 500 - 10 = 490 → has NOT re-armed → hysteresis suppresses first.
+    // Let's use a sub where last_fired_value_bps is low enough to pass hysteresis.
+    const subReArmed = makeSub({
+      last_notified_at: new Date(NOW_MS - 12 * HOUR_MS).toISOString(),
+      last_fired_value_bps: 480, // below threshold - hysteresis (490) → re-armed
+    });
+    const result = evaluateThreshold(subReArmed, 510, NOW_MS);
+    expect(result.crossed).toBe(true);
+    expect(result.shouldFire).toBe(false);
+    expect(result.suppressReason).toBe("cooldown");
+  });
+
+  it("fires after the instant cooldown window has elapsed", () => {
+    const sub = makeSub({
+      last_notified_at: new Date(NOW_MS - 25 * HOUR_MS).toISOString(),
+      last_fired_value_bps: 480, // re-armed
+    });
+    const result = evaluateThreshold(sub, 510, NOW_MS);
+    expect(result.shouldFire).toBe(true);
+  });
+
+  it("respects the weekly cooldown window", () => {
+    const sub = makeSub({
+      frequency: "weekly",
+      last_notified_at: new Date(NOW_MS - 3 * DAY_MS).toISOString(),
+      last_fired_value_bps: 480,
+    });
+    const result = evaluateThreshold(sub, 510, NOW_MS);
+    expect(result.shouldFire).toBe(false);
+    expect(result.suppressReason).toBe("cooldown");
+  });
+
+  it("fires after the weekly cooldown window has elapsed", () => {
+    const sub = makeSub({
+      frequency: "weekly",
+      last_notified_at: new Date(NOW_MS - (WEEK_MS + HOUR_MS)).toISOString(),
+      last_fired_value_bps: 480,
+    });
+    const result = evaluateThreshold(sub, 510, NOW_MS);
+    expect(result.shouldFire).toBe(true);
+  });
+
+  it("respects the daily cooldown window", () => {
+    const sub = makeSub({
+      frequency: "daily",
+      last_notified_at: new Date(NOW_MS - 12 * HOUR_MS).toISOString(),
+      last_fired_value_bps: 480,
+    });
+    const result = evaluateThreshold(sub, 510, NOW_MS);
+    expect(result.shouldFire).toBe(false);
+    expect(result.suppressReason).toBe("cooldown");
+  });
+});
+
+// ── Hysteresis ─────────────────────────────────────────────────────────────────
+
+describe("evaluateThreshold — hysteresis", () => {
+  it("suppresses re-fire when value hasn't moved beyond hysteresis band (above)", () => {
+    // Fired with value = 520. Threshold = 500. hysteresis = 10.
+    // Re-arm threshold = 500 - 10 = 490. last_fired = 520 > 490 → not re-armed.
+    const sub = makeSub({
+      last_notified_at: new Date(NOW_MS - 2 * DAY_MS).toISOString(),
+      last_fired_value_bps: 520,
+    });
+    const result = evaluateThreshold(sub, 510, NOW_MS);
+    expect(result.crossed).toBe(true);
+    expect(result.shouldFire).toBe(false);
+    expect(result.suppressReason).toBe("hysteresis");
+  });
+
+  it("allows re-fire once value has dipped below re-arm threshold (above)", () => {
+    // last_fired = 489. threshold = 500. Re-arm = 490. 489 <= 490 → re-armed.
+    const sub = makeSub({
+      last_notified_at: new Date(NOW_MS - 2 * DAY_MS).toISOString(),
+      last_fired_value_bps: 489,
+    });
+    const result = evaluateThreshold(sub, 510, NOW_MS);
+    expect(result.shouldFire).toBe(true);
+  });
+
+  it("exactly at re-arm boundary (above): re-armed", () => {
+    // last_fired = 490 = threshold - hysteresis. Should re-arm.
+    const sub = makeSub({
+      last_notified_at: new Date(NOW_MS - 2 * DAY_MS).toISOString(),
+      last_fired_value_bps: 490,
+    });
+    const result = evaluateThreshold(sub, 510, NOW_MS);
+    expect(result.shouldFire).toBe(true);
+  });
+
+  it("suppresses re-fire when value hasn't risen above re-arm threshold (below)", () => {
+    // direction=below, threshold=500, hysteresis=10. Re-arm = 500 + 10 = 510.
+    // last_fired = 490. 490 < 510 → not re-armed.
+    const sub = makeSub({
+      direction: "below",
+      threshold_bps: 500,
+      last_notified_at: new Date(NOW_MS - 2 * DAY_MS).toISOString(),
+      last_fired_value_bps: 490,
+    });
+    const result = evaluateThreshold(sub, 480, NOW_MS);
+    expect(result.crossed).toBe(true);
+    expect(result.shouldFire).toBe(false);
+    expect(result.suppressReason).toBe("hysteresis");
+  });
+
+  it("allows re-fire for below direction once value rises above re-arm threshold", () => {
+    // last_fired = 511. Re-arm = 510. 511 >= 510 → re-armed.
+    const sub = makeSub({
+      direction: "below",
+      threshold_bps: 500,
+      last_notified_at: new Date(NOW_MS - 2 * DAY_MS).toISOString(),
+      last_fired_value_bps: 511,
+    });
+    const result = evaluateThreshold(sub, 480, NOW_MS);
+    expect(result.shouldFire).toBe(true);
+  });
+
+  it("respects a custom hysteresis band", () => {
+    // Custom hysteresis = 50 bps. threshold=500. Re-arm threshold = 500 - 50 = 450.
+    // last_fired=445 → 445 <= 450 → re-armed → should fire.
+    const subReArmed = makeSub({
+      last_notified_at: new Date(NOW_MS - 2 * DAY_MS).toISOString(),
+      last_fired_value_bps: 445,
+    });
+    const resultReArmed = evaluateThreshold(subReArmed, 510, NOW_MS, 50);
+    expect(resultReArmed.shouldFire).toBe(true);
+
+    // last_fired=455 → 455 > 450 → NOT re-armed → hysteresis blocks.
+    const subNotReArmed = makeSub({
+      last_notified_at: new Date(NOW_MS - 2 * DAY_MS).toISOString(),
+      last_fired_value_bps: 455,
+    });
+    const resultNotReArmed = evaluateThreshold(subNotReArmed, 510, NOW_MS, 50);
+    expect(resultNotReArmed.shouldFire).toBe(false);
+    expect(resultNotReArmed.suppressReason).toBe("hysteresis");
+  });
+
+  it("first-fire (last_fired_value_bps=null) skips hysteresis check", () => {
+    // No previous fire — hysteresis state is null.
+    const sub = makeSub({ last_fired_value_bps: null, last_notified_at: null });
+    const result = evaluateThreshold(sub, 550, NOW_MS);
+    expect(result.shouldFire).toBe(true);
+  });
+});
+
+// ── DEFAULT_HYSTERESIS_BPS constant ───────────────────────────────────────────
+
+describe("DEFAULT_HYSTERESIS_BPS", () => {
+  it("is 10", () => {
+    expect(DEFAULT_HYSTERESIS_BPS).toBe(10);
+  });
+});
+
+// ── Edge cases ─────────────────────────────────────────────────────────────────
+
+describe("evaluateThreshold — edge cases", () => {
+  it("handles zero threshold (above): fires when current >= 0", () => {
+    const sub = makeSub({ threshold_bps: 0 });
+    const result = evaluateThreshold(sub, 0, NOW_MS);
+    expect(result.shouldFire).toBe(true);
+  });
+
+  it("handles very large current value (above direction)", () => {
+    const sub = makeSub({ threshold_bps: 500 });
+    const result = evaluateThreshold(sub, 999999, NOW_MS);
+    expect(result.shouldFire).toBe(true);
+  });
+
+  it("handles null last_notified_at with null last_fired_value_bps (pristine sub)", () => {
+    const sub = makeSub({
+      last_notified_at: null,
+      last_fired_value_bps: null,
+    });
+    const result = evaluateThreshold(sub, 600, NOW_MS);
+    expect(result.shouldFire).toBe(true);
+  });
+
+  it("uses default NOW_MS when nowMs param is omitted", () => {
+    // Just verify it doesn't throw and returns a boolean.
+    const sub = makeSub();
+    const result = evaluateThreshold(sub, 600);
+    expect(typeof result.shouldFire).toBe("boolean");
+  });
+});
+
+// ── metricKindLabel ────────────────────────────────────────────────────────────
+
+describe("metricKindLabel", () => {
+  it("returns human-readable labels for all known kinds", () => {
+    expect(metricKindLabel("savings_rate")).toBe("savings account rate");
+    expect(metricKindLabel("term_deposit")).toBe("term deposit rate");
+    expect(metricKindLabel("loan_rate")).toBe("investment loan rate");
+    expect(metricKindLabel("broker_fee")).toBe("brokerage fee");
+  });
+});
+
+// ── metricKindPath ─────────────────────────────────────────────────────────────
+
+describe("metricKindPath", () => {
+  it("returns correct paths for all known kinds", () => {
+    expect(metricKindPath("savings_rate")).toBe("/savings");
+    expect(metricKindPath("term_deposit")).toBe("/term-deposits");
+    expect(metricKindPath("loan_rate")).toBe("/investment-loans");
+    expect(metricKindPath("broker_fee")).toBe("/");
+  });
+});

--- a/app/account/alerts/AlertsClient.tsx
+++ b/app/account/alerts/AlertsClient.tsx
@@ -4,16 +4,24 @@ import { useState } from "react";
 import Link from "next/link";
 import Icon from "@/components/Icon";
 
-interface AlertRow {
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+export type MetricKind = "savings_rate" | "term_deposit" | "loan_rate" | "broker_fee";
+
+export interface AlertRow {
   id: string;
+  metric_kind: string | null;
   product_kind: string;
   threshold_bps: number;
+  direction: string;
   frequency: string;
+  broker_slug: string | null;
+  lender_slug: string | null;
   verified: boolean;
   last_notified_at: string | null;
   notification_count: number;
   created_at: string | null;
-  unsubscribe_token: string;
+  unsubscribe_token?: string;
 }
 
 interface Props {
@@ -21,9 +29,20 @@ interface Props {
   userEmail: string;
 }
 
-const STAGE_LABELS: Record<string, string> = {
-  savings_account: "Savings Account",
-  term_deposit: "Term Deposit",
+// ── Labels ─────────────────────────────────────────────────────────────────────
+
+const METRIC_LABELS: Record<string, string> = {
+  savings_rate: "Savings Account Rate",
+  term_deposit: "Term Deposit Rate",
+  loan_rate: "Investment Loan Rate",
+  broker_fee: "Brokerage Fee",
+  // legacy product_kind values
+  savings_account: "Savings Account Rate",
+};
+
+const DIRECTION_LABELS: Record<string, string> = {
+  above: "rises above",
+  below: "drops below",
 };
 
 const FREQUENCY_LABELS: Record<string, string> = {
@@ -32,21 +51,264 @@ const FREQUENCY_LABELS: Record<string, string> = {
   weekly: "Weekly digest",
 };
 
+// ── Create form ────────────────────────────────────────────────────────────────
+
+interface CreateFormState {
+  metric_kind: MetricKind;
+  threshold_pct: string;
+  direction: "above" | "below";
+  frequency: "instant" | "daily" | "weekly";
+  broker_slug: string;
+  lender_slug: string;
+}
+
+const DEFAULT_FORM: CreateFormState = {
+  metric_kind: "savings_rate",
+  threshold_pct: "",
+  direction: "above",
+  frequency: "instant",
+  broker_slug: "",
+  lender_slug: "",
+};
+
+function CreateAlertForm({
+  onCreated,
+}: {
+  onCreated: (alert: AlertRow) => void;
+}) {
+  const [form, setForm] = useState<CreateFormState>(DEFAULT_FORM);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    const pct = parseFloat(form.threshold_pct);
+    if (isNaN(pct) || pct <= 0 || pct > 100) {
+      setError("Please enter a valid threshold (0–100%).");
+      return;
+    }
+    setSaving(true);
+    try {
+      const body: Record<string, unknown> = {
+        metric_kind: form.metric_kind,
+        threshold_pct: pct,
+        direction: form.direction,
+        frequency: form.frequency,
+      };
+      if (form.metric_kind === "broker_fee" && form.broker_slug) {
+        body.broker_slug = form.broker_slug;
+      }
+      if (form.metric_kind === "loan_rate" && form.lender_slug) {
+        body.lender_slug = form.lender_slug;
+      }
+      const res = await fetch("/api/account/alerts", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (res.ok) {
+        const data = (await res.json()) as { item: AlertRow };
+        onCreated(data.item);
+        setForm(DEFAULT_FORM);
+      } else {
+        const data = (await res.json()) as { error?: string };
+        setError(data.error ?? "Failed to create alert.");
+      }
+    } catch {
+      setError("Failed to create alert. Please try again.");
+    }
+    setSaving(false);
+  };
+
+  const showBrokerSlug = form.metric_kind === "broker_fee";
+  const showLenderSlug = form.metric_kind === "loan_rate";
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="rounded-xl border border-violet-200 bg-violet-50/40 p-4"
+    >
+      <p className="text-xs font-semibold text-violet-800 mb-3">New Alert</p>
+      {error && (
+        <div className="mb-3 rounded-lg bg-red-50 border border-red-200 px-3 py-2 text-xs text-red-700">
+          {error}
+        </div>
+      )}
+      <div className="grid gap-3 sm:grid-cols-2">
+        {/* Metric kind */}
+        <div>
+          <label className="block text-xs font-medium text-slate-700 mb-1">
+            Alert type
+          </label>
+          <select
+            value={form.metric_kind}
+            onChange={(e) =>
+              setForm((f) => ({
+                ...f,
+                metric_kind: e.target.value as MetricKind,
+              }))
+            }
+            className="w-full rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-xs text-slate-900 focus:border-violet-400 focus:outline-none focus:ring-1 focus:ring-violet-300"
+          >
+            <option value="savings_rate">Savings Account Rate</option>
+            <option value="term_deposit">Term Deposit Rate</option>
+            <option value="loan_rate">Investment Loan Rate</option>
+            <option value="broker_fee">Brokerage Fee</option>
+          </select>
+        </div>
+
+        {/* Direction */}
+        <div>
+          <label className="block text-xs font-medium text-slate-700 mb-1">
+            Trigger when rate
+          </label>
+          <select
+            value={form.direction}
+            onChange={(e) =>
+              setForm((f) => ({
+                ...f,
+                direction: e.target.value as "above" | "below",
+              }))
+            }
+            className="w-full rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-xs text-slate-900 focus:border-violet-400 focus:outline-none focus:ring-1 focus:ring-violet-300"
+          >
+            <option value="above">Rises above threshold</option>
+            <option value="below">Drops below threshold</option>
+          </select>
+        </div>
+
+        {/* Threshold */}
+        <div>
+          <label className="block text-xs font-medium text-slate-700 mb-1">
+            Threshold (%)
+          </label>
+          <input
+            type="number"
+            min="0"
+            max="100"
+            step="0.01"
+            placeholder={
+              form.metric_kind === "broker_fee" ? "e.g. 9.99" : "e.g. 5.25"
+            }
+            value={form.threshold_pct}
+            onChange={(e) =>
+              setForm((f) => ({ ...f, threshold_pct: e.target.value }))
+            }
+            className="w-full rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-xs text-slate-900 focus:border-violet-400 focus:outline-none focus:ring-1 focus:ring-violet-300"
+            required
+          />
+        </div>
+
+        {/* Frequency */}
+        <div>
+          <label className="block text-xs font-medium text-slate-700 mb-1">
+            Notification frequency
+          </label>
+          <select
+            value={form.frequency}
+            onChange={(e) =>
+              setForm((f) => ({
+                ...f,
+                frequency: e.target.value as "instant" | "daily" | "weekly",
+              }))
+            }
+            className="w-full rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-xs text-slate-900 focus:border-violet-400 focus:outline-none focus:ring-1 focus:ring-violet-300"
+          >
+            <option value="instant">Instant (within 24h)</option>
+            <option value="daily">Daily digest</option>
+            <option value="weekly">Weekly digest</option>
+          </select>
+        </div>
+
+        {/* Broker slug — only for broker_fee */}
+        {showBrokerSlug && (
+          <div className="sm:col-span-2">
+            <label className="block text-xs font-medium text-slate-700 mb-1">
+              Broker slug (optional — leave blank to watch all)
+            </label>
+            <input
+              type="text"
+              placeholder="e.g. commsec"
+              value={form.broker_slug}
+              onChange={(e) =>
+                setForm((f) => ({ ...f, broker_slug: e.target.value }))
+              }
+              className="w-full rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-xs text-slate-900 focus:border-violet-400 focus:outline-none focus:ring-1 focus:ring-violet-300"
+            />
+          </div>
+        )}
+
+        {/* Lender slug — only for loan_rate */}
+        {showLenderSlug && (
+          <div className="sm:col-span-2">
+            <label className="block text-xs font-medium text-slate-700 mb-1">
+              Lender slug (optional — leave blank to watch best rate)
+            </label>
+            <input
+              type="text"
+              placeholder="e.g. commonwealth-bank"
+              value={form.lender_slug}
+              onChange={(e) =>
+                setForm((f) => ({ ...f, lender_slug: e.target.value }))
+              }
+              className="w-full rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-xs text-slate-900 focus:border-violet-400 focus:outline-none focus:ring-1 focus:ring-violet-300"
+            />
+          </div>
+        )}
+      </div>
+
+      <div className="mt-3 flex items-center justify-between gap-3">
+        <p className="text-[0.65rem] text-slate-400">
+          Factual rate/fee data alerts only — not financial advice.
+        </p>
+        <button
+          type="submit"
+          disabled={saving}
+          className="inline-flex items-center gap-1.5 rounded-lg bg-violet-700 px-4 py-1.5 text-xs font-semibold text-white hover:bg-violet-800 transition-colors disabled:opacity-50"
+        >
+          {saving ? "Saving…" : "Create alert"}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+// ── Main component ─────────────────────────────────────────────────────────────
+
 export default function AlertsClient({ alerts: initial, userEmail }: Props) {
-  const [alerts, setAlerts] = useState(initial);
+  const [alerts, setAlerts] = useState<AlertRow[]>(initial);
   const [removing, setRemoving] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [showCreate, setShowCreate] = useState(false);
 
   const handleRemove = async (alert: AlertRow) => {
     setRemoving(alert.id);
     setError(null);
     try {
-      const res = await fetch(
-        `/api/rate-alerts?unsubscribe=${alert.unsubscribe_token}`,
-        { method: "GET" },
-      );
+      // Prefer the authenticated DELETE endpoint for user-owned rows.
+      const res = await fetch("/api/account/alerts", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id: alert.id }),
+      });
       if (res.ok) {
         setAlerts((prev) => prev.filter((a) => a.id !== alert.id));
+      } else if (res.status === 401 || res.status === 404) {
+        // Fallback: legacy email-only subscriptions use the unsubscribe token path.
+        if (alert.unsubscribe_token) {
+          const fallback = await fetch(
+            `/api/rate-alerts?unsubscribe=${alert.unsubscribe_token}`,
+            { method: "GET" },
+          );
+          if (fallback.ok) {
+            setAlerts((prev) => prev.filter((a) => a.id !== alert.id));
+          } else {
+            setError("Failed to remove alert. Please try again.");
+          }
+        } else {
+          setError("Failed to remove alert. Please try again.");
+        }
       } else {
         setError("Failed to remove alert. Please try again.");
       }
@@ -56,102 +318,132 @@ export default function AlertsClient({ alerts: initial, userEmail }: Props) {
     setRemoving(null);
   };
 
-  if (alerts.length === 0) {
-    return (
-      <div className="rounded-2xl border border-slate-200 bg-white p-8 text-center">
-        <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-2xl bg-amber-50">
-          <Icon name="bell" size={24} className="text-amber-500" />
-        </div>
-        <p className="text-sm font-semibold text-slate-900">No alerts yet</p>
-        <p className="mt-1 text-xs text-slate-500">
-          Set up a rate alert and we&apos;ll email you when an Australian savings
-          account or term deposit crosses your target rate.
-        </p>
-        <Link
-          href="/rate-alerts"
-          className="mt-4 inline-block rounded-lg bg-slate-900 px-4 py-2 text-xs font-semibold text-white hover:bg-slate-700 transition-colors"
-        >
-          Set up an alert
-        </Link>
-      </div>
-    );
-  }
+  const handleCreated = (alert: AlertRow) => {
+    setAlerts((prev) => [alert, ...prev]);
+    setShowCreate(false);
+  };
 
   return (
-    <div className="space-y-3">
+    <div className="space-y-4">
       {error && (
         <div className="rounded-lg bg-red-50 border border-red-200 px-4 py-3 text-xs text-red-700">
           {error}
         </div>
       )}
 
-      <p className="text-xs text-slate-500">
-        Alerts sent to <strong>{userEmail}</strong>
-      </p>
+      {/* Create form toggle */}
+      {showCreate ? (
+        <CreateAlertForm onCreated={handleCreated} />
+      ) : (
+        <button
+          type="button"
+          onClick={() => setShowCreate(true)}
+          className="inline-flex items-center gap-1.5 rounded-lg border border-violet-200 bg-violet-50 px-3 py-1.5 text-xs font-semibold text-violet-700 hover:bg-violet-100 transition-colors"
+        >
+          <Icon name="bell" size={14} />
+          + New alert
+        </button>
+      )}
 
-      {alerts.map((alert) => {
-        const thresholdPct = (alert.threshold_bps / 100).toFixed(2);
-        const productLabel = STAGE_LABELS[alert.product_kind] ?? alert.product_kind;
-        const freqLabel = FREQUENCY_LABELS[alert.frequency] ?? alert.frequency;
-
-        return (
-          <div
-            key={alert.id}
-            className="flex items-start justify-between gap-4 rounded-xl border border-slate-200 bg-white p-4"
-          >
-            <div className="flex items-start gap-3">
-              <div className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-amber-50">
-                <Icon name="bell" size={18} className="text-amber-500" />
-              </div>
-              <div>
-                <p className="text-sm font-semibold text-slate-900">
-                  {productLabel} &ge;{thresholdPct}% p.a.
-                </p>
-                <p className="mt-0.5 text-xs text-slate-500">{freqLabel}</p>
-                <div className="mt-1.5 flex flex-wrap items-center gap-2">
-                  {alert.verified ? (
-                    <span className="inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2 py-0.5 text-[0.65rem] font-semibold text-emerald-700">
-                      <Icon name="check-circle" size={11} />
-                      Verified
-                    </span>
-                  ) : (
-                    <span className="inline-flex items-center gap-1 rounded-full bg-amber-50 px-2 py-0.5 text-[0.65rem] font-semibold text-amber-700">
-                      <Icon name="clock" size={11} />
-                      Awaiting verification
-                    </span>
-                  )}
-                  {alert.notification_count > 0 && (
-                    <span className="text-[0.65rem] text-slate-400">
-                      {alert.notification_count} alert{alert.notification_count !== 1 ? "s" : ""} sent
-                    </span>
-                  )}
-                  {alert.last_notified_at && (
-                    <span className="text-[0.65rem] text-slate-400">
-                      Last: {new Date(alert.last_notified_at).toLocaleDateString("en-AU")}
-                    </span>
-                  )}
-                </div>
-              </div>
-            </div>
-
-            <button
-              type="button"
-              disabled={removing === alert.id}
-              onClick={() => handleRemove(alert)}
-              className="shrink-0 rounded-lg border border-slate-200 px-3 py-1.5 text-xs text-slate-500 hover:border-red-200 hover:text-red-600 transition-colors disabled:opacity-40"
-            >
-              {removing === alert.id ? "Removing…" : "Remove"}
-            </button>
+      {alerts.length === 0 ? (
+        <div className="rounded-2xl border border-slate-200 bg-white p-8 text-center">
+          <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-2xl bg-amber-50">
+            <Icon name="bell" size={24} className="text-amber-500" />
           </div>
-        );
-      })}
+          <p className="text-sm font-semibold text-slate-900">No alerts yet</p>
+          <p className="mt-1 text-xs text-slate-500">
+            Set up an alert and we&apos;ll notify you when a savings rate, term
+            deposit, loan rate, or brokerage fee crosses your threshold.
+          </p>
+        </div>
+      ) : (
+        <>
+          <p className="text-xs text-slate-500">
+            Alerts sent to <strong>{userEmail}</strong>
+          </p>
 
-      <div className="pt-2">
+          <div className="space-y-3">
+            {alerts.map((alert) => {
+              const metricLabel =
+                METRIC_LABELS[alert.metric_kind ?? alert.product_kind] ??
+                (alert.metric_kind ?? alert.product_kind);
+              const dirLabel = DIRECTION_LABELS[alert.direction] ?? alert.direction;
+              const freqLabel = FREQUENCY_LABELS[alert.frequency] ?? alert.frequency;
+              const thresholdPct = (alert.threshold_bps / 100).toFixed(2);
+              const isFee = alert.metric_kind === "broker_fee";
+
+              return (
+                <div
+                  key={alert.id}
+                  className="flex items-start justify-between gap-4 rounded-xl border border-slate-200 bg-white p-4"
+                >
+                  <div className="flex items-start gap-3">
+                    <div className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-amber-50">
+                      <Icon name="bell" size={18} className="text-amber-500" />
+                    </div>
+                    <div>
+                      <p className="text-sm font-semibold text-slate-900">
+                        {metricLabel} {dirLabel}{" "}
+                        {isFee ? `$${thresholdPct}` : `${thresholdPct}% p.a.`}
+                      </p>
+                      <p className="mt-0.5 text-xs text-slate-500">{freqLabel}</p>
+                      {(alert.broker_slug || alert.lender_slug) && (
+                        <p className="mt-0.5 text-xs text-slate-400">
+                          {alert.broker_slug && `Broker: ${alert.broker_slug}`}
+                          {alert.lender_slug && `Lender: ${alert.lender_slug}`}
+                        </p>
+                      )}
+                      <div className="mt-1.5 flex flex-wrap items-center gap-2">
+                        {alert.verified ? (
+                          <span className="inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2 py-0.5 text-[0.65rem] font-semibold text-emerald-700">
+                            <Icon name="check-circle" size={11} />
+                            Active
+                          </span>
+                        ) : (
+                          <span className="inline-flex items-center gap-1 rounded-full bg-amber-50 px-2 py-0.5 text-[0.65rem] font-semibold text-amber-700">
+                            <Icon name="clock" size={11} />
+                            Awaiting verification
+                          </span>
+                        )}
+                        {alert.notification_count > 0 && (
+                          <span className="text-[0.65rem] text-slate-400">
+                            {alert.notification_count} alert
+                            {alert.notification_count !== 1 ? "s" : ""} sent
+                          </span>
+                        )}
+                        {alert.last_notified_at && (
+                          <span className="text-[0.65rem] text-slate-400">
+                            Last:{" "}
+                            {new Date(alert.last_notified_at).toLocaleDateString(
+                              "en-AU",
+                            )}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+
+                  <button
+                    type="button"
+                    disabled={removing === alert.id}
+                    onClick={() => handleRemove(alert)}
+                    className="shrink-0 rounded-lg border border-slate-200 px-3 py-1.5 text-xs text-slate-500 hover:border-red-200 hover:text-red-600 transition-colors disabled:opacity-40"
+                  >
+                    {removing === alert.id ? "Removing…" : "Remove"}
+                  </button>
+                </div>
+              );
+            })}
+          </div>
+        </>
+      )}
+
+      <div className="pt-1">
         <Link
           href="/rate-alerts"
-          className="text-xs font-medium text-slate-700 hover:text-slate-900"
+          className="text-xs font-medium text-slate-500 hover:text-slate-700"
         >
-          + Add another alert
+          Set up email-only alerts →
         </Link>
       </div>
     </div>

--- a/app/account/alerts/page.tsx
+++ b/app/account/alerts/page.tsx
@@ -29,9 +29,9 @@ export default async function AccountAlertsPage() {
   const { data: rows } = await admin
     .from("rate_alert_subscriptions")
     .select(
-      "id, product_kind, threshold_bps, frequency, verified, last_notified_at, notification_count, created_at, unsubscribe_token",
+      "id, metric_kind, product_kind, threshold_bps, direction, frequency, broker_slug, lender_slug, verified, last_notified_at, notification_count, created_at, unsubscribe_token",
     )
-    .eq("email", email.toLowerCase())
+    .or(`user_id.eq.${user.id},email.eq.${email.toLowerCase()}`)
     .order("created_at", { ascending: false });
 
   const alerts = rows ?? [];

--- a/app/api/account/alerts/route.ts
+++ b/app/api/account/alerts/route.ts
@@ -1,0 +1,190 @@
+/**
+ * /api/account/alerts — authenticated CRUD for rate/fee alert subscriptions.
+ *
+ * GET    — list the current user's alert subscriptions
+ * POST   — create a new subscription (auto-verified for signed-in users)
+ * DELETE — remove a subscription by id
+ *
+ * Auth: all methods require a valid Supabase session (401 otherwise).
+ * RLS: the authenticated policy on rate_alert_subscriptions gates on
+ *      user_id = auth.uid(), so the DB enforces ownership too.
+ *
+ * Metric kinds:
+ *   savings_rate  → savings_rate_snapshots
+ *   term_deposit  → savings_rate_snapshots (product_kind='term_deposit')
+ *   loan_rate     → investment_loan_rates
+ *   broker_fee    → brokers.asx_fee_value / us_fee_value
+ *
+ * AFSL: factual threshold comparisons on public data only.
+ * No advice, no ranking, no prediction.
+ */
+
+import { randomBytes } from "crypto";
+
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+import { createClient } from "@/lib/supabase/server";
+import { withValidatedBody } from "@/lib/validation/withValidatedBody";
+import { logger } from "@/lib/logger";
+
+const log = logger("api:account:alerts");
+
+export const runtime = "nodejs";
+
+const METRIC_KINDS = ["savings_rate", "term_deposit", "loan_rate", "broker_fee"] as const;
+
+const CreateBody = z.object({
+  metric_kind: z.enum(METRIC_KINDS),
+  /** Threshold as a percentage (e.g. 5.25). Converted to basis points on insert. */
+  threshold_pct: z.number().min(0).max(100),
+  /** "above" fires when current ≥ threshold; "below" when current ≤ threshold. */
+  direction: z.enum(["above", "below"]).default("above"),
+  frequency: z.enum(["instant", "daily", "weekly"]).default("instant"),
+  /** Required for broker_fee subscriptions. */
+  broker_slug: z.string().max(100).optional().nullable(),
+  /** Required for loan_rate subscriptions. */
+  lender_slug: z.string().max(100).optional().nullable(),
+  /** Optional JSON filter bag for future refinement (min_balance etc.). */
+  product_filters: z.record(z.string(), z.unknown()).optional(),
+});
+
+const DeleteBody = z.object({
+  id: z.string().uuid(),
+});
+
+// ── GET ────────────────────────────────────────────────────────────────────────
+
+export async function GET() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+
+  const { data, error } = await supabase
+    .from("rate_alert_subscriptions")
+    .select(
+      "id, metric_kind, product_kind, threshold_bps, direction, frequency, broker_slug, lender_slug, verified, last_notified_at, last_fired_value_bps, notification_count, created_at",
+    )
+    .eq("user_id", user.id)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    log.warn("alerts GET failed", { userId: user.id, error: error.message });
+    return NextResponse.json({ error: "fetch_failed" }, { status: 500 });
+  }
+
+  return NextResponse.json({ items: data ?? [] });
+}
+
+// ── POST ───────────────────────────────────────────────────────────────────────
+
+export const POST = withValidatedBody(CreateBody, async (_req: NextRequest, body) => {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+
+  const email = user.email ?? "";
+  if (!email) {
+    return NextResponse.json({ error: "user_email_missing" }, { status: 400 });
+  }
+
+  // Validate context-required fields.
+  if (body.metric_kind === "broker_fee" && !body.broker_slug) {
+    return NextResponse.json(
+      { error: "broker_slug required for broker_fee alerts" },
+      { status: 400 },
+    );
+  }
+  if (body.metric_kind === "loan_rate" && !body.lender_slug) {
+    return NextResponse.json(
+      { error: "lender_slug required for loan_rate alerts" },
+      { status: 400 },
+    );
+  }
+
+  const thresholdBps = Math.round(body.threshold_pct * 100);
+
+  // Map metric_kind to legacy product_kind for backward compat with the
+  // existing cron which still reads product_kind.
+  const legacyProductKind =
+    body.metric_kind === "savings_rate"
+      ? "savings_account"
+      : body.metric_kind === "term_deposit"
+      ? "term_deposit"
+      : "other";
+
+  // Signed-in users skip double-opt-in — their session is already verified.
+  const unsubscribeToken = randomBytes(24).toString("hex");
+  const verifyToken = randomBytes(24).toString("hex");
+
+  const { data: inserted, error: insertErr } = await supabase
+    .from("rate_alert_subscriptions")
+    .insert({
+      user_id: user.id,
+      email: email.toLowerCase(),
+      metric_kind: body.metric_kind,
+      product_kind: legacyProductKind,
+      threshold_bps: thresholdBps,
+      direction: body.direction,
+      frequency: body.frequency,
+      broker_slug: body.broker_slug ?? null,
+      lender_slug: body.lender_slug ?? null,
+      product_filters: body.product_filters ?? {},
+      verified: true, // signed-in users are auto-verified
+      verify_token: verifyToken,
+      unsubscribe_token: unsubscribeToken,
+      last_notified_at: null,
+      notification_count: 0,
+    })
+    .select("id, metric_kind, threshold_bps, direction, frequency")
+    .single();
+
+  if (insertErr) {
+    log.warn("alerts POST insert failed", {
+      userId: user.id,
+      err: insertErr.message,
+    });
+    return NextResponse.json({ error: "insert_failed" }, { status: 500 });
+  }
+
+  log.info("alert created", {
+    userId: user.id,
+    alertId: inserted?.id,
+    metricKind: body.metric_kind,
+    thresholdBps,
+    direction: body.direction,
+  });
+
+  return NextResponse.json({ item: inserted }, { status: 201 });
+});
+
+// ── DELETE ─────────────────────────────────────────────────────────────────────
+
+export const DELETE = withValidatedBody(DeleteBody, async (_req: NextRequest, body) => {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+
+  const { error } = await supabase
+    .from("rate_alert_subscriptions")
+    .delete()
+    .eq("id", body.id)
+    .eq("user_id", user.id); // ownership enforced at both app + RLS layers
+
+  if (error) {
+    log.warn("alerts DELETE failed", {
+      userId: user.id,
+      alertId: body.id,
+      err: error.message,
+    });
+    return NextResponse.json({ error: "delete_failed" }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+});

--- a/app/api/cron/rate-alerts/route.ts
+++ b/app/api/cron/rate-alerts/route.ts
@@ -3,64 +3,98 @@ import { NextRequest, NextResponse } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { requireCronAuth } from "@/lib/cron-auth";
 import { sendEmail } from "@/lib/resend";
+import { notifyUser } from "@/lib/notifications";
 import { getSiteUrl } from "@/lib/url";
 import { logger } from "@/lib/logger";
+import {
+  evaluateThreshold,
+  metricKindLabel,
+  metricKindPath,
+  type AlertSubscription,
+  type MetricKind,
+} from "@/lib/alert-thresholds";
 
 export const runtime = "nodejs";
-export const maxDuration = 60;
+export const maxDuration = 120;
 
 const log = logger("cron:rate-alerts");
 
-// FIN_NOTEBOOK Revenue #4: scan public.rate_alert_subscriptions for
-// verified subscribers whose threshold has been crossed by the current
-// best-rate snapshot, and send a notification.
+// FIN_NOTEBOOK Revenue #4: evaluate all rate_alert_subscriptions against
+// current market data and dispatch email + in-app notifications when
+// a threshold is crossed.
 //
-// Data flow:
-//   1. Pull the best (highest rate_bps) snapshot per product_kind from
-//      savings_rate_snapshots — that's the headline rate the alert is
-//      compared against.
-//   2. For each verified subscription, check whether the best rate for
-//      its product_kind meets-or-exceeds the threshold.
-//   3. Anti-spam: skip if last_notified_at is within 24h (instant) or
-//      the matching frequency window (daily / weekly).
-//   4. Dispatch via sendEmail (suppression-aware) and stamp
-//      last_notified_at + bump notification_count.
+// Metric sources:
+//   savings_rate / term_deposit → savings_rate_snapshots (best per product_kind)
+//   loan_rate                   → investment_loan_rates (per lender_slug or best)
+//   broker_fee                  → brokers.asx_fee_value (per broker_slug)
 //
-// Failure modes:
-//   - Empty snapshots → no-op heartbeat (logs count, returns
-//     awaiting_rate_snapshot_ingestion status).
-//   - Send failure for one subscriber → log + continue (don't block
-//     other dispatches).
-
-interface SnapshotRow {
-  product_kind: string;
-  rate_bps: number;
-  captured_at: string;
-}
+// Idempotent:
+//   - Records last_notified_at + last_fired_value_bps on fire.
+//   - lib/alert-thresholds.ts enforces cooldown + hysteresis before fire.
+//   - notifyUser() deduplicates in-app notifications via email_delivery_key.
 
 interface SubscriptionRow {
   id: string;
+  user_id: string | null;
   email: string;
+  metric_kind: string | null;
   product_kind: string;
   threshold_bps: number;
+  direction: string;
   frequency: string;
+  broker_slug: string | null;
+  lender_slug: string | null;
   last_notified_at: string | null;
+  last_fired_value_bps: number | null;
   notification_count: number;
 }
 
-function minMillisBetweenSends(frequency: string): number {
-  switch (frequency) {
-    case "daily":
-      return 24 * 60 * 60 * 1000;
-    case "weekly":
-      return 7 * 24 * 60 * 60 * 1000;
-    case "instant":
-    default:
-      // "instant" still rate-limits to once per 24h per user — the alert
-      // is about a rate crossing the threshold, not the rate changing
-      // by a cent every minute.
-      return 24 * 60 * 60 * 1000;
+// ── Market-data snapshot types ────────────────────────────────────────────────
+
+interface SavingsSnapshot {
+  product_kind: string;
+  rate_bps: number;
+}
+
+interface LoanRateRow {
+  lender_slug: string;
+  rate_pct: number; // percentage — convert to bps (* 100)
+}
+
+interface BrokerFeeRow {
+  slug: string;
+  asx_fee_value: number | null;
+}
+
+// ── Resolve current market value for a subscription ───────────────────────────
+
+function resolveCurrentValue(
+  sub: SubscriptionRow,
+  bestSavingsByKind: Map<string, number>,
+  loanRatesBySlug: Map<string, number>,
+  brokerFeesBySlug: Map<string, number>,
+): number | null {
+  const kind = (sub.metric_kind ?? sub.product_kind) as MetricKind | string;
+
+  if (kind === "savings_rate" || kind === "savings_account") {
+    return bestSavingsByKind.get("savings_account") ?? null;
   }
+  if (kind === "term_deposit") {
+    return bestSavingsByKind.get("term_deposit") ?? null;
+  }
+  if (kind === "loan_rate") {
+    if (sub.lender_slug) {
+      return loanRatesBySlug.get(sub.lender_slug) ?? null;
+    }
+    // No specific lender — use the best (lowest) rate available.
+    if (loanRatesBySlug.size === 0) return null;
+    return Math.min(...loanRatesBySlug.values());
+  }
+  if (kind === "broker_fee") {
+    if (!sub.broker_slug) return null;
+    return brokerFeesBySlug.get(sub.broker_slug) ?? null;
+  }
+  return null;
 }
 
 export async function GET(req: NextRequest) {
@@ -69,127 +103,211 @@ export async function GET(req: NextRequest) {
 
   const supabase = createAdminClient();
   const startedAt = new Date().toISOString();
+  const siteUrl = getSiteUrl();
+  const nowMs = Date.now();
 
-  // Pull the most-recent snapshot per (broker_id, product_kind) and
-  // pick the headline (highest rate_bps) per product_kind.
-  const { data: snapshots, error: snapErr } = await supabase
-    .from("savings_rate_snapshots")
-    .select("product_kind, rate_bps, captured_at")
-    .order("captured_at", { ascending: false })
-    .limit(500);
+  // ── 1. Load market data ────────────────────────────────────────────────────
 
-  if (snapErr) {
-    log.error("snapshot query failed", { err: snapErr.message });
-    return NextResponse.json({ error: snapErr.message }, { status: 500 });
+  const [savingsRes, loansRes, brokersRes] = await Promise.all([
+    supabase
+      .from("savings_rate_snapshots")
+      .select("product_kind, rate_bps, captured_at")
+      .order("captured_at", { ascending: false })
+      .limit(500),
+    supabase
+      .from("investment_loan_rates")
+      .select("lender_slug, rate_pct"),
+    supabase
+      .from("brokers")
+      .select("slug, asx_fee_value")
+      .eq("status", "active"),
+  ]);
+
+  if (savingsRes.error) {
+    log.error("savings snapshots query failed", { err: savingsRes.error.message });
+    return NextResponse.json({ error: savingsRes.error.message }, { status: 500 });
   }
 
-  const bestByKind = new Map<string, SnapshotRow>();
-  for (const snap of (snapshots ?? []) as SnapshotRow[]) {
-    const current = bestByKind.get(snap.product_kind);
-    if (!current || snap.rate_bps > current.rate_bps) {
-      bestByKind.set(snap.product_kind, snap);
+  // Build best (highest rate_bps) per product_kind for savings/td.
+  const bestSavingsByKind = new Map<string, number>();
+  for (const snap of (savingsRes.data ?? []) as SavingsSnapshot[]) {
+    const current = bestSavingsByKind.get(snap.product_kind);
+    if (current === undefined || snap.rate_bps > current) {
+      bestSavingsByKind.set(snap.product_kind, snap.rate_bps);
     }
   }
 
+  // Loan rates: rate_pct → bps.
+  const loanRatesBySlug = new Map<string, number>();
+  for (const row of (loansRes.data ?? []) as LoanRateRow[]) {
+    loanRatesBySlug.set(row.lender_slug, Math.round(row.rate_pct * 100));
+  }
+
+  // Broker fees: asx_fee_value is in cents; treat cents as bps units for
+  // comparison (1 cent = 1 bps unit). Threshold set by user in same unit.
+  const brokerFeesBySlug = new Map<string, number>();
+  for (const row of (brokersRes.data ?? []) as BrokerFeeRow[]) {
+    if (row.asx_fee_value !== null) {
+      brokerFeesBySlug.set(row.slug, Math.round(row.asx_fee_value));
+    }
+  }
+
+  // ── 2. Load verified subscriptions ────────────────────────────────────────
+
   const { data: subs, error: subsErr } = await supabase
     .from("rate_alert_subscriptions")
-    .select("id, email, product_kind, threshold_bps, frequency, last_notified_at, notification_count")
+    .select(
+      "id, user_id, email, metric_kind, product_kind, threshold_bps, direction, frequency, broker_slug, lender_slug, last_notified_at, last_fired_value_bps, notification_count",
+    )
     .eq("verified", true);
 
   if (subsErr) {
-    log.error("verified subscriptions query failed", { err: subsErr.message });
+    log.error("subscriptions query failed", { err: subsErr.message });
     return NextResponse.json({ error: subsErr.message }, { status: 500 });
   }
 
   const verified = subs?.length ?? 0;
-  if (bestByKind.size === 0) {
-    log.info("rate-alerts cron heartbeat — no snapshots yet", { verified });
-    return NextResponse.json({
-      startedAt,
-      verifiedSubscriptions: verified,
-      notified: 0,
-      status: "awaiting_rate_snapshot_ingestion",
-    });
+
+  if (verified === 0) {
+    log.info("rate-alerts cron heartbeat — no verified subscriptions", { verified });
+    return NextResponse.json({ startedAt, verified, notified: 0, status: "no_subscriptions" });
   }
 
-  const now = Date.now();
-  const siteUrl = getSiteUrl();
+  // ── 3. Evaluate thresholds and dispatch ───────────────────────────────────
+
   let notified = 0;
-  let skippedAntiSpam = 0;
-  let skippedBelowThreshold = 0;
+  let skippedNoData = 0;
+  let skippedNotCrossed = 0;
+  let skippedCooldown = 0;
+  let skippedHysteresis = 0;
   const failures: { id: string; err: string }[] = [];
 
-  for (const sub of (subs ?? []) as SubscriptionRow[]) {
-    const best = bestByKind.get(sub.product_kind);
-    if (!best) {
-      skippedBelowThreshold++;
+  for (const rawSub of (subs ?? []) as SubscriptionRow[]) {
+    const currentValue = resolveCurrentValue(
+      rawSub,
+      bestSavingsByKind,
+      loanRatesBySlug,
+      brokerFeesBySlug,
+    );
+
+    if (currentValue === null) {
+      skippedNoData++;
       continue;
     }
-    if (best.rate_bps < sub.threshold_bps) {
-      skippedBelowThreshold++;
+
+    const alertSub: AlertSubscription = {
+      id: rawSub.id,
+      metric_kind: (rawSub.metric_kind ?? rawSub.product_kind) as MetricKind,
+      threshold_bps: rawSub.threshold_bps,
+      direction: (rawSub.direction ?? "above") as "above" | "below",
+      frequency: (rawSub.frequency ?? "instant") as AlertSubscription["frequency"],
+      last_notified_at: rawSub.last_notified_at,
+      last_fired_value_bps: rawSub.last_fired_value_bps,
+    };
+
+    const result = evaluateThreshold(alertSub, currentValue, nowMs);
+
+    if (!result.shouldFire) {
+      if (result.suppressReason === "not_crossed") skippedNotCrossed++;
+      else if (result.suppressReason === "cooldown") skippedCooldown++;
+      else if (result.suppressReason === "hysteresis") skippedHysteresis++;
       continue;
     }
 
-    if (sub.last_notified_at) {
-      const lastMs = new Date(sub.last_notified_at).getTime();
-      if (now - lastMs < minMillisBetweenSends(sub.frequency)) {
-        skippedAntiSpam++;
-        continue;
-      }
-    }
+    const kind = alertSub.metric_kind;
+    const label = metricKindLabel(kind);
+    const path = metricKindPath(kind);
+    const valuePct = (currentValue / 100).toFixed(2);
+    const thresholdPct = (rawSub.threshold_bps / 100).toFixed(2);
+    const directionText = alertSub.direction === "above" ? "crossed above" : "dropped below";
+    const valueDisplay =
+      kind === "broker_fee"
+        ? `$${valuePct} (ASX fee)`
+        : `${valuePct}% p.a.`;
 
-    const productLabel = sub.product_kind === "savings_account" ? "savings account" : "term deposit";
-    const ratePct = (best.rate_bps / 100).toFixed(2);
-    const thresholdPct = (sub.threshold_bps / 100).toFixed(2);
-
-    const result = await sendEmail({
-      to: sub.email,
-      subject: `Rate alert: ${productLabel} now at ${ratePct}% p.a.`,
-      html: `
-        <div style="font-family:Arial,sans-serif;max-width:500px;margin:0 auto;color:#334155">
-          <div style="background:#0f172a;padding:20px 24px;border-radius:12px 12px 0 0">
-            <h1 style="color:white;margin:0;font-size:18px">Rate Alert</h1>
-          </div>
-          <div style="background:#f8fafc;padding:24px;border:1px solid #e2e8f0;border-top:none;border-radius:0 0 12px 12px">
-            <p style="font-size:15px;margin-top:0">An Australian ${productLabel} just crossed your <strong>${thresholdPct}%</strong> target.</p>
-            <p style="font-size:14px;color:#64748b">Current headline rate: <strong>${ratePct}% p.a.</strong></p>
-            <div style="text-align:center;margin:20px 0">
-              <a href="${siteUrl}/${sub.product_kind === "savings_account" ? "savings" : "term-deposits"}"
-                 style="display:inline-block;padding:12px 32px;background:#0f172a;color:white;text-decoration:none;border-radius:8px;font-size:14px;font-weight:600">
-                Compare ${productLabel}s &rarr;
-              </a>
-            </div>
-            <p style="font-size:12px;color:#94a3b8">Heads-up: bonus / intro rates may apply. Always check the fine print before switching.</p>
-          </div>
+    const emailHtml = `
+      <div style="font-family:Arial,sans-serif;max-width:500px;margin:0 auto;color:#334155">
+        <div style="background:#0f172a;padding:20px 24px;border-radius:12px 12px 0 0">
+          <h1 style="color:white;margin:0;font-size:18px">Rate Alert</h1>
         </div>
-      `,
+        <div style="background:#f8fafc;padding:24px;border:1px solid #e2e8f0;border-top:none;border-radius:0 0 12px 12px">
+          <p style="font-size:15px;margin-top:0">
+            The <strong>${label}</strong> just ${directionText} your
+            <strong>${kind === "broker_fee" ? `$${thresholdPct}` : `${thresholdPct}%`}</strong> threshold.
+          </p>
+          <p style="font-size:14px;color:#64748b">
+            Current value: <strong>${valueDisplay}</strong>
+          </p>
+          <div style="text-align:center;margin:20px 0">
+            <a href="${siteUrl}${path}"
+               style="display:inline-block;padding:12px 32px;background:#0f172a;color:white;text-decoration:none;border-radius:8px;font-size:14px;font-weight:600">
+              Compare now &rarr;
+            </a>
+          </div>
+          <p style="font-size:12px;color:#94a3b8">
+            This is a factual market data alert — not personal financial advice.
+            Rates and fees may vary. Always read the product disclosure statement.
+          </p>
+        </div>
+      </div>
+    `;
+
+    const emailResult = await sendEmail({
+      to: rawSub.email,
+      subject: `Alert: ${label} ${directionText} ${kind === "broker_fee" ? `$${thresholdPct}` : `${thresholdPct}%`}`,
+      html: emailHtml,
     });
 
-    if (!result.ok) {
-      failures.push({ id: sub.id, err: result.error ?? "unknown" });
-      continue;
+    if (!emailResult.ok) {
+      failures.push({ id: rawSub.id, err: emailResult.error ?? "unknown" });
     }
 
+    // Always stamp the row (even if email failed) so we don't immediately retry.
     await supabase
       .from("rate_alert_subscriptions")
       .update({
         last_notified_at: new Date().toISOString(),
-        notification_count: sub.notification_count + 1,
+        last_fired_value_bps: currentValue,
+        notification_count: (rawSub.notification_count ?? 0) + 1,
         updated_at: new Date().toISOString(),
       })
-      .eq("id", sub.id);
+      .eq("id", rawSub.id);
+
+    // Write in-app notification for user-linked subscriptions.
+    if (rawSub.user_id) {
+      // Dedup key: one in-app notification per subscription per calendar day.
+      const dayKey = Math.floor(nowMs / 86_400_000);
+      await notifyUser({
+        userId: rawSub.user_id,
+        type: "fee_change",
+        title: `${label.charAt(0).toUpperCase() + label.slice(1)} alert`,
+        body: `${label.charAt(0).toUpperCase() + label.slice(1)} (${valueDisplay}) ${directionText} your ${kind === "broker_fee" ? `$${thresholdPct}` : `${thresholdPct}%`} threshold.`,
+        linkUrl: path,
+        emailDeliveryKey: `rate_alert:${rawSub.id}:${dayKey}`,
+      });
+    }
 
     notified++;
   }
 
-  log.info("rate-alerts cron complete", { verified, notified, skippedAntiSpam, skippedBelowThreshold, failures: failures.length });
+  log.info("rate-alerts cron complete", {
+    verified,
+    notified,
+    skippedNoData,
+    skippedNotCrossed,
+    skippedCooldown,
+    skippedHysteresis,
+    failures: failures.length,
+  });
 
   return NextResponse.json({
     startedAt,
     verifiedSubscriptions: verified,
     notified,
-    skippedAntiSpam,
-    skippedBelowThreshold,
+    skippedNoData,
+    skippedNotCrossed,
+    skippedCooldown,
+    skippedHysteresis,
     failures: failures.length,
   });
 }

--- a/app/pro/dashboard/page.tsx
+++ b/app/pro/dashboard/page.tsx
@@ -9,6 +9,7 @@ import { absoluteUrl, breadcrumbJsonLd, SITE_NAME } from "@/lib/seo";
 import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
 import { getCurrentPricesBatch } from "@/lib/holdings/value";
 import { listBookmarks } from "@/lib/bookmarks";
+import { metricKindLabel, metricKindPath } from "@/lib/alert-thresholds";
 
 export const dynamic = "force-dynamic";
 
@@ -166,6 +167,20 @@ interface HoldingForValue {
   cost_basis_per_share_cents: number | null;
 }
 
+interface AlertFeedRow {
+  id: string;
+  metric_kind: string | null;
+  product_kind: string;
+  threshold_bps: number;
+  direction: string;
+  last_notified_at: string | null;
+  last_fired_value_bps: number | null;
+  notification_count: number;
+  broker_slug: string | null;
+  lender_slug: string | null;
+  verified: boolean;
+}
+
 /**
  * Assembles the dashboard summary data from pre-fetched rows.
  * Exported so tests can exercise the logic without JSX rendering.
@@ -300,11 +315,16 @@ export default async function ProDashboardPage() {
       .eq("status", "active"),
   ]);
 
-  // rate_alert_subscriptions — service-role required (email-keyed, no auth RLS policy)
+  // rate_alert_subscriptions — fetch full rows for the alert feed section.
+  // User-owned (user_id match) + legacy email-keyed rows.
   const alertsRes = await admin
     .from("rate_alert_subscriptions")
-    .select("last_notified_at")
-    .eq("email", email.toLowerCase());
+    .select(
+      "id, metric_kind, product_kind, threshold_bps, direction, last_notified_at, last_fired_value_bps, notification_count, broker_slug, lender_slug, verified",
+    )
+    .or(`user_id.eq.${userId},email.eq.${email.toLowerCase()}`)
+    .order("last_notified_at", { ascending: false, nullsFirst: false })
+    .limit(20);
 
   // Bookmarks — uses listBookmarks which already uses admin client internally
   const bookmarks = await listBookmarks(userId);
@@ -330,12 +350,14 @@ export default async function ProDashboardPage() {
 
   const priceMap = await getCurrentPricesBatch(pricePairs);
 
+  const alertRows = (alertsRes.data ?? []) as AlertFeedRow[];
+
   const summary = assembleDashboardSummary({
     holdings,
     priceMap,
     manualBalanceTotalCents,
     goalBalanceCents,
-    alerts: (alertsRes.data ?? []) as { last_notified_at: string | null }[],
+    alerts: alertRows.map((a) => ({ last_notified_at: a.last_notified_at })),
     watchlistCount: watchlistRes.count ?? 0,
     savedScenariosCount: savedScenariosRes.count ?? 0,
     activeDealsCount: activeDealsRes.count ?? 0,
@@ -485,6 +507,100 @@ export default async function ProDashboardPage() {
         />
 
       </div>
+
+      {/* Alert feed — triggered alerts + active monitoring */}
+      {alertRows.length > 0 && (
+        <section className="mt-10 pt-8 border-t border-slate-100">
+          <div className="flex items-baseline justify-between mb-4 gap-2 flex-wrap">
+            <h2 className="text-sm font-semibold uppercase tracking-wider text-slate-500">
+              Rate &amp; Fee Alerts
+            </h2>
+            <Link
+              href="/account/alerts"
+              className="text-xs font-medium text-violet-700 hover:text-violet-900"
+            >
+              Manage alerts →
+            </Link>
+          </div>
+
+          <div className="space-y-2">
+            {alertRows.map((alert) => {
+              const kind = (alert.metric_kind ?? alert.product_kind) as Parameters<typeof metricKindLabel>[0];
+              const label = metricKindLabel(kind);
+              const path = metricKindPath(kind);
+              const thresholdPct = (alert.threshold_bps / 100).toFixed(2);
+              const isFee = kind === "broker_fee";
+              const hasFired = alert.last_notified_at !== null;
+              const directionText = alert.direction === "above" ? "≥" : "≤";
+              const firedValuePct =
+                alert.last_fired_value_bps !== null
+                  ? (alert.last_fired_value_bps / 100).toFixed(2)
+                  : null;
+
+              return (
+                <Link
+                  key={alert.id}
+                  href={path}
+                  className="flex items-start justify-between gap-3 rounded-xl border border-slate-200 bg-white px-4 py-3 hover:border-violet-300 hover:shadow-sm transition-all"
+                >
+                  <div className="flex items-start gap-3">
+                    <div
+                      className={`mt-0.5 h-8 w-8 shrink-0 flex items-center justify-center rounded-xl ${
+                        hasFired ? "bg-amber-50" : "bg-slate-50"
+                      }`}
+                    >
+                      <svg
+                        className={`w-4 h-4 ${hasFired ? "text-amber-500" : "text-slate-400"}`}
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={1.8}
+                          d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"
+                        />
+                      </svg>
+                    </div>
+                    <div>
+                      <p className="text-sm font-medium text-slate-900">
+                        {label}{" "}
+                        <span className="text-slate-500">
+                          {directionText} {isFee ? `$${thresholdPct}` : `${thresholdPct}%`}
+                        </span>
+                      </p>
+                      {hasFired ? (
+                        <p className="mt-0.5 text-xs text-amber-700 font-medium">
+                          Fired
+                          {firedValuePct && (
+                            <>
+                              {" "}at{" "}
+                              {isFee ? `$${firedValuePct}` : `${firedValuePct}%`}
+                            </>
+                          )}
+                          {" "}·{" "}
+                          {new Date(alert.last_notified_at!).toLocaleDateString("en-AU")}
+                          {alert.notification_count > 1 && (
+                            <> · {alert.notification_count}×</>
+                          )}
+                        </p>
+                      ) : (
+                        <p className="mt-0.5 text-xs text-slate-400">
+                          Monitoring — threshold not yet reached
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                  <span className="shrink-0 text-[0.65rem] font-semibold text-violet-700 mt-0.5">
+                    Compare →
+                  </span>
+                </Link>
+              );
+            })}
+          </div>
+        </section>
+      )}
 
       {/* Quick links to Pro tools */}
       <section className="mt-10 pt-8 border-t border-slate-100">

--- a/lib/alert-thresholds.ts
+++ b/lib/alert-thresholds.ts
@@ -1,0 +1,178 @@
+/**
+ * Alert threshold evaluation — pure, side-effect-free, fully tested.
+ *
+ * Given a subscription and a current metric value, decide whether an
+ * alert should fire. Hysteresis prevents re-fire spam when the metric
+ * hovers around the threshold.
+ *
+ * Supported metric kinds (mirrors rate_alert_subscriptions.metric_kind):
+ *   - savings_rate   : savings_rate_snapshots.rate_bps
+ *   - term_deposit   : savings_rate_snapshots.rate_bps (product_kind='term_deposit')
+ *   - loan_rate      : investment_loan_rates.rate_pct × 100 (converted to bps)
+ *   - broker_fee     : brokers.asx_fee_value or us_fee_value (cents or bps)
+ *
+ * Direction semantics:
+ *   - "above": alert when currentValue ≥ threshold  (e.g. savings rate rises)
+ *   - "below": alert when currentValue ≤ threshold  (e.g. loan rate falls)
+ *
+ * Hysteresis (hysteresisBps default = 10bps = 0.10%):
+ *   Once an alert fires, the metric must move (hysteresisBps) beyond the
+ *   threshold in the "good" direction before re-arming. This prevents
+ *   re-fire spam when the metric oscillates at the boundary. The caller
+ *   controls re-arm state via lastFiredValue.
+ *
+ * AFSL: factual comparison of public market data against user-defined
+ * threshold. No personalised advice, no investment recommendation. The
+ * email copy must remain in the factual/heads-up lane — see cron.
+ */
+
+export type AlertDirection = "above" | "below";
+
+export type MetricKind =
+  | "savings_rate"
+  | "term_deposit"
+  | "loan_rate"
+  | "broker_fee";
+
+export interface AlertSubscription {
+  id: string;
+  metric_kind: MetricKind;
+  /** Value the metric must cross to fire. Same unit as currentValue (bps). */
+  threshold_bps: number;
+  /** "above": fire when currentValue ≥ threshold. "below": fire when currentValue ≤ threshold. */
+  direction: AlertDirection;
+  /** Timestamp of last notification, or null if never fired. */
+  last_notified_at: string | null;
+  /** Value at which the last notification was fired, or null. */
+  last_fired_value_bps: number | null;
+  /** Anti-spam frequency window. */
+  frequency: "instant" | "daily" | "weekly";
+}
+
+export interface ThresholdResult {
+  /** Whether the threshold is currently crossed (direction-aware). */
+  crossed: boolean;
+  /**
+   * Whether an alert should actually be sent:
+   *   - threshold must be crossed
+   *   - must not be within the frequency cooldown window
+   *   - must not be within the hysteresis dead-band after last fire
+   */
+  shouldFire: boolean;
+  /** Reason the alert was suppressed (when shouldFire is false). */
+  suppressReason?: "not_crossed" | "cooldown" | "hysteresis";
+}
+
+/** Default hysteresis band: 10 basis points (0.10%). */
+export const DEFAULT_HYSTERESIS_BPS = 10;
+
+/** Cooldown windows in milliseconds. */
+const COOLDOWN_MS: Record<AlertSubscription["frequency"], number> = {
+  instant: 24 * 60 * 60 * 1000,   // 24 h (even "instant" is once-per-day)
+  daily: 24 * 60 * 60 * 1000,
+  weekly: 7 * 24 * 60 * 60 * 1000,
+};
+
+/**
+ * Evaluate whether an alert should fire.
+ *
+ * @param sub          The subscription row.
+ * @param currentValue Current metric value in basis points.
+ * @param nowMs        Current time as milliseconds-since-epoch (injectable for testing).
+ * @param hysteresisBps Hysteresis band in basis points (default 10).
+ */
+export function evaluateThreshold(
+  sub: AlertSubscription,
+  currentValue: number,
+  nowMs: number = Date.now(),
+  hysteresisBps: number = DEFAULT_HYSTERESIS_BPS,
+): ThresholdResult {
+  // 1. Check if threshold is crossed.
+  const crossed =
+    sub.direction === "above"
+      ? currentValue >= sub.threshold_bps
+      : currentValue <= sub.threshold_bps;
+
+  if (!crossed) {
+    return { crossed: false, shouldFire: false, suppressReason: "not_crossed" };
+  }
+
+  // 2. Hysteresis dead-band check.
+  // If the alert fired previously and the value has not moved sufficiently
+  // away from the threshold + come back, suppress to prevent re-fire spam.
+  if (sub.last_fired_value_bps !== null) {
+    const reArmThreshold =
+      sub.direction === "above"
+        ? // "above" alert: re-arm when value drops below (threshold - hysteresisBps)
+          sub.threshold_bps - hysteresisBps
+        : // "below" alert: re-arm when value rises above (threshold + hysteresisBps)
+          sub.threshold_bps + hysteresisBps;
+
+    const hasReArmed =
+      sub.direction === "above"
+        ? sub.last_fired_value_bps <= reArmThreshold
+        : sub.last_fired_value_bps >= reArmThreshold;
+
+    if (!hasReArmed) {
+      // Still in the hysteresis band since last fire.
+      return { crossed: true, shouldFire: false, suppressReason: "hysteresis" };
+    }
+  }
+
+  // 3. Cooldown window check.
+  if (sub.last_notified_at !== null) {
+    const lastMs = new Date(sub.last_notified_at).getTime();
+    const cooldownMs = COOLDOWN_MS[sub.frequency] ?? COOLDOWN_MS.instant;
+    if (nowMs - lastMs < cooldownMs) {
+      return { crossed: true, shouldFire: false, suppressReason: "cooldown" };
+    }
+  }
+
+  return { crossed: true, shouldFire: true };
+}
+
+/**
+ * Minimum milliseconds that must elapse between sends for a given frequency.
+ * Exported for use by the cron route.
+ */
+export function minMillisBetweenSends(
+  frequency: AlertSubscription["frequency"],
+): number {
+  return COOLDOWN_MS[frequency] ?? COOLDOWN_MS.instant;
+}
+
+/**
+ * Human-readable label for a metric kind.
+ */
+export function metricKindLabel(kind: MetricKind): string {
+  switch (kind) {
+    case "savings_rate":
+      return "savings account rate";
+    case "term_deposit":
+      return "term deposit rate";
+    case "loan_rate":
+      return "investment loan rate";
+    case "broker_fee":
+      return "brokerage fee";
+    default:
+      return kind;
+  }
+}
+
+/**
+ * URL path to compare the product after the alert fires.
+ */
+export function metricKindPath(kind: MetricKind): string {
+  switch (kind) {
+    case "savings_rate":
+      return "/savings";
+    case "term_deposit":
+      return "/term-deposits";
+    case "loan_rate":
+      return "/investment-loans";
+    case "broker_fee":
+      return "/";
+    default:
+      return "/";
+  }
+}

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -14326,47 +14326,65 @@ export type Database = {
       }
       rate_alert_subscriptions: {
         Row: {
+          broker_slug: string | null
           created_at: string
+          direction: string
           email: string
           frequency: string
           id: string
+          last_fired_value_bps: number | null
           last_notified_at: string | null
+          lender_slug: string | null
+          metric_kind: string | null
           notification_count: number
           product_filters: Json
           product_kind: string
           threshold_bps: number
           unsubscribe_token: string
           updated_at: string
+          user_id: string | null
           verified: boolean
           verify_token: string
         }
         Insert: {
+          broker_slug?: string | null
           created_at?: string
+          direction?: string
           email: string
           frequency?: string
           id?: string
+          last_fired_value_bps?: number | null
           last_notified_at?: string | null
+          lender_slug?: string | null
+          metric_kind?: string | null
           notification_count?: number
           product_filters?: Json
           product_kind: string
           threshold_bps: number
           unsubscribe_token: string
           updated_at?: string
+          user_id?: string | null
           verified?: boolean
           verify_token: string
         }
         Update: {
+          broker_slug?: string | null
           created_at?: string
+          direction?: string
           email?: string
           frequency?: string
           id?: string
+          last_fired_value_bps?: number | null
           last_notified_at?: string | null
+          lender_slug?: string | null
+          metric_kind?: string | null
           notification_count?: number
           product_filters?: Json
           product_kind?: string
           threshold_bps?: number
           unsubscribe_token?: string
           updated_at?: string
+          user_id?: string | null
           verified?: boolean
           verify_token?: string
         }

--- a/supabase/migrations/20260825020000_rate_alert_subscriptions_v2.sql
+++ b/supabase/migrations/20260825020000_rate_alert_subscriptions_v2.sql
@@ -1,0 +1,105 @@
+-- Migration: rate_alert_subscriptions v2
+--
+-- Extends the existing rate_alert_subscriptions table to support:
+--   - user_id (uuid, nullable): links the subscription to an auth.users row
+--     when created by a signed-in user. Null = legacy email-only subscription.
+--   - metric_kind: broadens the product scope beyond savings/term-deposit to
+--     include 'loan_rate' (investment_loan_rates) and 'broker_fee' (brokers).
+--   - direction: 'above' (rate/fee rose past threshold) or 'below' (fell below).
+--   - broker_slug (nullable): for broker_fee subscriptions; identifies which broker.
+--   - lender_slug (nullable): for loan_rate subscriptions; identifies which lender.
+--   - last_fired_value_bps (nullable): hysteresis state — the bps value at which
+--     the last notification fired; used by lib/alert-thresholds.ts to suppress
+--     re-fire spam when the metric hovers near the boundary.
+--
+-- The product_kind constraint is widened (metric_kind subsumes it);
+-- product_kind is kept for backward compatibility with the existing cron
+-- but metric_kind takes precedence when non-null.
+--
+-- Rollback strategy:
+--   ALTER TABLE public.rate_alert_subscriptions
+--     DROP COLUMN IF EXISTS user_id,
+--     DROP COLUMN IF EXISTS metric_kind,
+--     DROP COLUMN IF EXISTS direction,
+--     DROP COLUMN IF EXISTS broker_slug,
+--     DROP COLUMN IF EXISTS lender_slug,
+--     DROP COLUMN IF EXISTS last_fired_value_bps;
+--   DROP INDEX IF EXISTS idx_rate_alert_user_id;
+--   DROP INDEX IF EXISTS idx_rate_alert_user_metric;
+
+BEGIN;
+
+-- ── New columns ────────────────────────────────────────────────────────────────
+
+ALTER TABLE public.rate_alert_subscriptions
+  ADD COLUMN IF NOT EXISTS user_id           uuid         REFERENCES auth.users(id) ON DELETE CASCADE,
+  ADD COLUMN IF NOT EXISTS metric_kind       text,
+  ADD COLUMN IF NOT EXISTS direction         text         NOT NULL DEFAULT 'above',
+  ADD COLUMN IF NOT EXISTS broker_slug       text,
+  ADD COLUMN IF NOT EXISTS lender_slug       text,
+  ADD COLUMN IF NOT EXISTS last_fired_value_bps integer;
+
+-- ── Constraints ────────────────────────────────────────────────────────────────
+
+-- metric_kind may be null (legacy rows) or one of the four supported kinds.
+ALTER TABLE public.rate_alert_subscriptions
+  DROP CONSTRAINT IF EXISTS rate_alert_metric_kind_check;
+ALTER TABLE public.rate_alert_subscriptions
+  ADD CONSTRAINT rate_alert_metric_kind_check CHECK (
+    metric_kind IS NULL OR
+    metric_kind IN ('savings_rate', 'term_deposit', 'loan_rate', 'broker_fee')
+  );
+
+ALTER TABLE public.rate_alert_subscriptions
+  DROP CONSTRAINT IF EXISTS rate_alert_direction_check;
+ALTER TABLE public.rate_alert_subscriptions
+  ADD CONSTRAINT rate_alert_direction_check CHECK (
+    direction IN ('above', 'below')
+  );
+
+-- Widen threshold_bps to accommodate broker fees (may be very small bps)
+-- and loan rates (up to ~2500 bps = 25%). Drop and recreate.
+ALTER TABLE public.rate_alert_subscriptions
+  DROP CONSTRAINT IF EXISTS rate_alert_threshold_bps_range;
+ALTER TABLE public.rate_alert_subscriptions
+  ADD CONSTRAINT rate_alert_threshold_bps_range CHECK (
+    threshold_bps BETWEEN 0 AND 10000
+  );
+
+-- ── Indexes ────────────────────────────────────────────────────────────────────
+
+CREATE INDEX IF NOT EXISTS idx_rate_alert_user_id
+  ON public.rate_alert_subscriptions (user_id)
+  WHERE user_id IS NOT NULL;
+
+-- Supports fast lookup of all subscriptions for a user × metric kind
+CREATE INDEX IF NOT EXISTS idx_rate_alert_user_metric
+  ON public.rate_alert_subscriptions (user_id, metric_kind)
+  WHERE user_id IS NOT NULL AND metric_kind IS NOT NULL;
+
+-- ── RLS: add authenticated-user policy ────────────────────────────────────────
+
+-- Signed-in users can select, insert, update, delete their own rows.
+DROP POLICY IF EXISTS "Users own their rate_alert_subscriptions"
+  ON public.rate_alert_subscriptions;
+CREATE POLICY "Users own their rate_alert_subscriptions"
+  ON public.rate_alert_subscriptions
+  AS PERMISSIVE
+  FOR ALL
+  TO authenticated
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());
+
+COMMENT ON COLUMN public.rate_alert_subscriptions.user_id IS
+  'auth.users FK — present when the subscription was created by a signed-in user. '
+  'Null for legacy email-only (pre-v2) subscriptions.';
+
+COMMENT ON COLUMN public.rate_alert_subscriptions.metric_kind IS
+  'Discriminates the metric source: savings_rate | term_deposit | loan_rate | broker_fee. '
+  'Null on legacy rows — product_kind is used instead.';
+
+COMMENT ON COLUMN public.rate_alert_subscriptions.last_fired_value_bps IS
+  'Hysteresis state: the metric value (bps) at which the last notification fired. '
+  'Used by lib/alert-thresholds.ts evaluateThreshold() to prevent re-fire spam.';
+
+COMMIT;


### PR DESCRIPTION
Round-3 deepening (5 of 10). Completes the rate/fee **alerts product** (a top backlog item, ~30% before) — now backed by the fresh data pipelines (#1232). Factual alerts on factual public data (AFSL-safe).

- `lib/alert-thresholds.ts` — pure `evaluateThreshold(sub, value, now, hysteresisBps)` → `{crossed, shouldFire, suppressReason}`; hysteresis dead-band (default 10 bps) + cooldown windows (instant/daily 24h, weekly 7d) prevent re-fire spam across all four metric kinds.
- Migration `…rate_alert_subscriptions_v2.sql` — idempotent `ADD COLUMN IF NOT EXISTS` (`user_id` FK, `metric_kind`, `direction`, broker/lender slug, hysteresis state) + an authenticated-user RLS policy; existing rows stay valid (safe defaults).
- `/api/account/alerts` — auth-gated CRUD, Zod via `withValidatedBody`, context validation (broker_fee→broker_slug, loan_rate→lender_slug), ownership at app + RLS layers; consumer UI in `account/alerts`.
- `rate-alerts` cron rewritten to evaluate all four kinds against live data, dedup via `last_fired_value_bps` + a daily notification key, writing the `user_notifications` inbox; `requireCronAuth` first (confirmed). A new alert feed on `/pro/dashboard`.

**Recovery note:** the agent branched off the *original* data-pipelines commit, so I cherry-picked **only** the alerts commit onto current main (which has #1232) to avoid re-applying it. Fixed two unused-var lint warnings in tests.

**Verified:** `tsc` clean · **44 tests** (26 threshold lib incl. hysteresis/cooldown edges + 18 auth/validation/CRUD) pass · eslint clean · rate-limit `--strict` pass.

**Tier C** (cron + migration + auth route) — announcing; proceeding unless STOP.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUfSRE2Teb6VhEXFP6RpS9)_