### PR TITLE
feat(expat): country-vs-country compare + DASP calculator + persona router (deepen)

### DIFF
--- a/__tests__/lib/country-compare.test.ts
+++ b/__tests__/lib/country-compare.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Unit tests for lib/country-compare.ts
+ *
+ * Validates:
+ *  - Pair integrity (both countries present, no missing data)
+ *  - Deduplication (no a-vs-b / b-vs-a duplicates)
+ *  - Canonical ordering (alphabetical by countryShort)
+ *  - parsePairSlug: valid, reverse, invalid inputs
+ *  - buildCountryComparison: row count, warnings, flags
+ *  - allComparePairs: C(12,2) = 66 unique pairs
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  allComparePairs,
+  parsePairSlug,
+  buildCountryComparison,
+} from "@/lib/country-compare";
+import {
+  COUNTRY_CONFIGS,
+  UK_CONFIG,
+  US_CONFIG,
+  NZ_CONFIG,
+  SA_CONFIG,
+} from "@/lib/foreign-investment-country-data";
+import type { IntentCountryCode } from "@/lib/intent-context";
+
+// ─── allComparePairs ─────────────────────────────────────────────────────────
+
+describe("allComparePairs", () => {
+  it("returns exactly C(n,2) pairs for n hub countries", () => {
+    const n = Object.keys(COUNTRY_CONFIGS).length;
+    const expected = (n * (n - 1)) / 2;
+    const pairs = allComparePairs();
+    expect(pairs.length).toBe(expected);
+  });
+
+  it("returns 66 pairs for the 12 hub countries", () => {
+    expect(allComparePairs().length).toBe(66);
+  });
+
+  it("has no duplicate pair slugs", () => {
+    const pairs = allComparePairs();
+    const slugs = pairs.map((p) => p.pair);
+    const unique = new Set(slugs);
+    expect(unique.size).toBe(slugs.length);
+  });
+
+  it("canonical slug is always a-vs-b, never b-vs-a (alphabetical by countryShort)", () => {
+    const pairs = allComparePairs();
+    for (const p of pairs) {
+      const cfgA = COUNTRY_CONFIGS[p.codeA];
+      const cfgB = COUNTRY_CONFIGS[p.codeB];
+      expect(cfgA).toBeDefined();
+      expect(cfgB).toBeDefined();
+      // A must be <= B by countryShort
+      const cmp = cfgA!.countryShort.localeCompare(cfgB!.countryShort);
+      expect(cmp).toBeLessThanOrEqual(0);
+    }
+  });
+
+  it("every pair slug starts with slugA and ends with slugB", () => {
+    const pairs = allComparePairs();
+    for (const p of pairs) {
+      const cfgA = COUNTRY_CONFIGS[p.codeA];
+      const cfgB = COUNTRY_CONFIGS[p.codeB];
+      expect(p.pair).toBe(`${cfgA!.slug}-vs-${cfgB!.slug}`);
+    }
+  });
+
+  it("every code in the pairs is a key in COUNTRY_CONFIGS", () => {
+    const validCodes = new Set(Object.keys(COUNTRY_CONFIGS) as IntentCountryCode[]);
+    const pairs = allComparePairs();
+    for (const p of pairs) {
+      expect(validCodes.has(p.codeA)).toBe(true);
+      expect(validCodes.has(p.codeB)).toBe(true);
+    }
+  });
+
+  it("no pair has the same country on both sides", () => {
+    const pairs = allComparePairs();
+    for (const p of pairs) {
+      expect(p.codeA).not.toBe(p.codeB);
+    }
+  });
+});
+
+// ─── parsePairSlug ───────────────────────────────────────────────────────────
+
+describe("parsePairSlug", () => {
+  it("parses a canonical slug without reversed flag", () => {
+    // UK = "UK", US = "US" — UK < US alphabetically → uk-vs-us is canonical
+    const result = parsePairSlug("united-kingdom-vs-united-states");
+    expect(result).not.toBeNull();
+    expect(result!.reversed).toBe(false);
+    expect(result!.canonicalSlug).toBe("united-kingdom-vs-united-states");
+  });
+
+  it("parses a reversed slug and sets reversed=true with the correct canonicalSlug", () => {
+    // us before uk in reversed order
+    const result = parsePairSlug("united-states-vs-united-kingdom");
+    expect(result).not.toBeNull();
+    expect(result!.reversed).toBe(true);
+    expect(result!.canonicalSlug).toBe("united-kingdom-vs-united-states");
+  });
+
+  it("returns null for an unrecognised country slug on the left", () => {
+    expect(parsePairSlug("atlantis-vs-united-kingdom")).toBeNull();
+  });
+
+  it("returns null for an unrecognised country slug on the right", () => {
+    expect(parsePairSlug("united-kingdom-vs-narnia")).toBeNull();
+  });
+
+  it("returns null when there is no -vs- separator", () => {
+    expect(parsePairSlug("united-kingdom-united-states")).toBeNull();
+  });
+
+  it("returns null for an empty string", () => {
+    expect(parsePairSlug("")).toBeNull();
+  });
+
+  it("returns the correct cfgA/cfgB for NZ-vs-UK (NZ comes before UK alphabetically)", () => {
+    // NZ = "NZ", UK = "UK" — NZ < UK → new-zealand-vs-united-kingdom
+    const result = parsePairSlug("new-zealand-vs-united-kingdom");
+    expect(result).not.toBeNull();
+    expect(result!.reversed).toBe(false);
+    expect(result!.cfgA.code).toBe("nz");
+    expect(result!.cfgB.code).toBe("uk");
+  });
+});
+
+// ─── buildCountryComparison ──────────────────────────────────────────────────
+
+describe("buildCountryComparison", () => {
+  it("produces a non-empty rows array", () => {
+    const c = buildCountryComparison(UK_CONFIG, US_CONFIG);
+    expect(c.rows.length).toBeGreaterThan(0);
+  });
+
+  it("includes all expected dimensions", () => {
+    const c = buildCountryComparison(UK_CONFIG, US_CONFIG);
+    const dimensions = c.rows.map((r) => r.dimension);
+    expect(dimensions.some((d) => d.toLowerCase().includes("dta"))).toBe(true);
+    expect(dimensions.some((d) => d.toLowerCase().includes("dividend"))).toBe(true);
+    expect(dimensions.some((d) => d.toLowerCase().includes("firb"))).toBe(true);
+    expect(dimensions.some((d) => d.toLowerCase().includes("pension"))).toBe(true);
+    expect(dimensions.some((d) => d.toLowerCase().includes("migration"))).toBe(true);
+  });
+
+  it("sets bothHaveDta=true for UK vs US (both have DTA)", () => {
+    const c = buildCountryComparison(UK_CONFIG, US_CONFIG);
+    expect(c.bothHaveDta).toBe(true);
+  });
+
+  it("sets bothHaveDta=false when one country has no DTA (SA has no DTA)", () => {
+    const c = buildCountryComparison(UK_CONFIG, SA_CONFIG);
+    expect(c.bothHaveDta).toBe(false);
+  });
+
+  it("canonical ordering: A is alphabetically first by countryShort", () => {
+    // UK < US
+    const c1 = buildCountryComparison(UK_CONFIG, US_CONFIG);
+    const c2 = buildCountryComparison(US_CONFIG, UK_CONFIG);
+    expect(c1.countryA.code).toBe("uk");
+    expect(c2.countryA.code).toBe("uk"); // same — canonical regardless of input order
+    expect(c1.pairSlug).toBe(c2.pairSlug);
+  });
+
+  it("pairSlug matches slug format", () => {
+    const c = buildCountryComparison(UK_CONFIG, US_CONFIG);
+    expect(c.pairSlug).toBe("united-kingdom-vs-united-states");
+  });
+
+  it("warns about US critical warning (FATCA/worldwide tax)", () => {
+    const c = buildCountryComparison(UK_CONFIG, US_CONFIG);
+    // US has a criticalWarning about worldwide taxation
+    expect(c.warnings.some((w) => w.country === "US")).toBe(true);
+  });
+
+  it("surfaces no warnings for a pair without criticalWarnings (NZ-UK)", () => {
+    // Neither NZ nor UK have criticalWarning set
+    const c = buildCountryComparison(NZ_CONFIG, UK_CONFIG);
+    // NZ has "No FIRB Required" critical warning
+    // UK has no criticalWarning
+    // So warnings will have 1 entry (NZ)
+    const nzWarnings = c.warnings.filter((w) => w.country === "NZ");
+    expect(nzWarnings.length).toBeLessThanOrEqual(1);
+  });
+
+  it("NZ-vs-UK FIRB row reflects NZ Trans-Tasman exemption", () => {
+    const c = buildCountryComparison(NZ_CONFIG, UK_CONFIG);
+    const firbRow = c.rows.find((r) =>
+      r.dimension.toLowerCase().includes("firb approval"),
+    );
+    expect(firbRow).toBeDefined();
+    // The NZ or UK side should reflect the trans-tasman note
+    const hasTransTasman =
+      firbRow!.valueA.toLowerCase().includes("trans") ||
+      firbRow!.valueB.toLowerCase().includes("trans");
+    expect(hasTransTasman).toBe(true);
+  });
+
+  it("hasPensionTransfer is true when one country has retirementTransfer", () => {
+    // UK has retirementTransfer (QROPS); SA likely does not
+    const c = buildCountryComparison(UK_CONFIG, SA_CONFIG);
+    // UK has QROPS section
+    expect(typeof c.hasPensionTransfer).toBe("boolean");
+    if (UK_CONFIG.retirementTransfer ?? SA_CONFIG.retirementTransfer) {
+      expect(c.hasPensionTransfer).toBe(true);
+    }
+  });
+
+  it("every row has non-empty valueA and valueB", () => {
+    const c = buildCountryComparison(UK_CONFIG, US_CONFIG);
+    for (const row of c.rows) {
+      expect(row.valueA.length).toBeGreaterThan(0);
+      expect(row.valueB.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("dividend row shows DTA-reduced rate for DTA countries", () => {
+    const c = buildCountryComparison(UK_CONFIG, US_CONFIG);
+    const divRow = c.rows.find((r) =>
+      r.dimension.toLowerCase().includes("unfranked dividend"),
+    );
+    expect(divRow).toBeDefined();
+    // Both have DTA; UK rate is 15%, US is also 15%
+    expect(divRow!.valueA).toContain("15%");
+    expect(divRow!.valueB).toContain("15%");
+  });
+
+  it("dividend row shows 30% for non-DTA country (SA)", () => {
+    const c = buildCountryComparison(UK_CONFIG, SA_CONFIG);
+    const divRow = c.rows.find((r) =>
+      r.dimension.toLowerCase().includes("unfranked dividend"),
+    );
+    expect(divRow).toBeDefined();
+    // SA has no DTA → 30%
+    const saVal =
+      c.countryA.code === "sa" ? divRow!.valueA : divRow!.valueB;
+    expect(saVal).toContain("30%");
+  });
+});

--- a/app/foreign-investment/FIPersonaRouter.tsx
+++ b/app/foreign-investment/FIPersonaRouter.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+/**
+ * FIPersonaRouter — "What brings you here?" three-choice selector on the
+ * Foreign Investment hub.
+ *
+ * Three journeys map to high-intent expat/foreign-investor needs:
+ *   1. Moving to Australia    → /foreign-investment/journey (country picker)
+ *   2. Leaving Australia      → /foreign-investment/super (DASP + super guide)
+ *   3. Non-resident investor  → existing hub content (#find-your-situation)
+ *
+ * This is a routing/UX helper, not a financial-advice tool. All copy is
+ * factual and directional — linking to the appropriate guide page.
+ *
+ * AFSL: no product recommendations, no personal advice.
+ */
+
+import { useState } from "react";
+import Link from "next/link";
+
+interface Journey {
+  id: string;
+  emoji: string;
+  label: string;
+  description: string;
+  ctaLabel: string;
+  ctaHref: string;
+  secondaryLinks: { label: string; href: string }[];
+  keyPoints: string[];
+}
+
+const JOURNEYS: Journey[] = [
+  {
+    id: "moving-to-au",
+    emoji: "✈️",
+    label: "Moving to Australia",
+    description:
+      "You're planning to migrate or are in the process of moving to Australia.",
+    ctaLabel: "Start the migration investing journey",
+    ctaHref: "/foreign-investment/journey",
+    secondaryLinks: [
+      { label: "Tax on arrival — rebasing & residency", href: "/foreign-investment/tax" },
+      { label: "Pension / super transfer options", href: "/foreign-investment/super" },
+      { label: "FIRB & property as a new resident", href: "/foreign-investment/property" },
+    ],
+    keyPoints: [
+      "Tax residency starts on your first day physically in Australia",
+      "Foreign assets have a deemed acquisition at market value on residency start date — important for CGT",
+      "Overseas pension transfers have country-specific rules (QROPS for UK; KiwiSaver for NZ)",
+      "Once you hold PR, FIRB approval is no longer required for property",
+    ],
+  },
+  {
+    id: "leaving-au",
+    emoji: "🛫",
+    label: "Leaving Australia",
+    description:
+      "You're departing Australia and need to manage your super, tax position, and assets.",
+    ctaLabel: "Super & DASP guide for departing residents",
+    ctaHref: "/foreign-investment/super",
+    secondaryLinks: [
+      { label: "DASP calculator (estimate your super payout)", href: "/tools/dasp-calculator" },
+      { label: "Selling AU investments before you leave", href: "/foreign-investment/tax" },
+      { label: "Non-resident CGT after departure", href: "/foreign-investment/tax" },
+    ],
+    keyPoints: [
+      "Temp visa holders can claim super via DASP — but 35% (or 65% for WHM) is withheld by the ATO",
+      "Australian citizens and PR holders cannot access super via DASP — it stays until preservation age",
+      "Departing can trigger a change in tax residency — losing the CGT 50% discount and tax-free threshold",
+      "Selling AU property as a non-resident has different CGT rules — no main-residence exemption",
+    ],
+  },
+  {
+    id: "non-resident-investor",
+    emoji: "🌏",
+    label: "Non-Resident Investor",
+    description:
+      "You live overseas and want to invest in Australian shares, property, or other assets.",
+    ctaLabel: "Browse country-specific investing guides",
+    ctaHref: "/foreign-investment/journey",
+    secondaryLinks: [
+      { label: "Withholding tax calculator", href: "/tools/withholding-tax-calculator" },
+      { label: "Compare countries — tax & FIRB", href: "/foreign-investment/compare" },
+      { label: "Brokers that accept non-residents", href: "/foreign-investment/shares" },
+    ],
+    keyPoints: [
+      "Non-residents are taxed on Australian-sourced income — withholding tax applies automatically",
+      "A Double Tax Agreement (DTA) between your country and Australia may reduce withholding rates",
+      "FIRB approval required for property — established dwelling ban active until March 2027",
+      "No tax-free threshold for non-residents — tax applies from the first dollar",
+    ],
+  },
+];
+
+export default function FIPersonaRouter() {
+  const [selected, setSelected] = useState<string | null>(null);
+
+  const active = JOURNEYS.find((j) => j.id === selected);
+
+  return (
+    <div>
+      {/* Journey cards */}
+      <div className="grid sm:grid-cols-3 gap-4 mb-6">
+        {JOURNEYS.map((j) => (
+          <button
+            key={j.id}
+            type="button"
+            onClick={() => setSelected(selected === j.id ? null : j.id)}
+            className={`text-left rounded-2xl border-2 p-5 transition-all focus:outline-none focus:ring-2 focus:ring-amber-400/50 ${
+              selected === j.id
+                ? "border-amber-500 bg-amber-50 shadow-lg shadow-amber-500/10"
+                : "border-slate-200 bg-white hover:border-slate-300 hover:shadow"
+            }`}
+          >
+            <div className="text-3xl mb-2">{j.emoji}</div>
+            <h3
+              className={`text-sm font-extrabold mb-1 ${
+                selected === j.id ? "text-amber-800" : "text-slate-900"
+              }`}
+            >
+              {j.label}
+            </h3>
+            <p className="text-xs text-slate-500 leading-snug">
+              {j.description}
+            </p>
+            <div
+              className={`mt-2 text-xs font-bold transition-colors ${
+                selected === j.id ? "text-amber-600" : "text-slate-400"
+              }`}
+            >
+              {selected === j.id ? "Selected ✓" : "Select →"}
+            </div>
+          </button>
+        ))}
+      </div>
+
+      {/* Expanded journey detail */}
+      {active && (
+        <div className="bg-white rounded-2xl border-2 border-amber-300 shadow-lg p-6 animate-fade-in">
+          <div className="flex items-start gap-4 mb-5">
+            <div className="text-3xl">{active.emoji}</div>
+            <div>
+              <h3 className="text-base font-extrabold text-slate-900 mb-0.5">
+                {active.label}
+              </h3>
+              <p className="text-sm text-slate-600">{active.description}</p>
+            </div>
+          </div>
+
+          <div className="grid md:grid-cols-2 gap-6">
+            {/* Key points */}
+            <div>
+              <p className="text-xs font-bold uppercase tracking-wider text-amber-700 mb-3">
+                Key things to know
+              </p>
+              <ul className="space-y-2">
+                {active.keyPoints.map((point, i) => (
+                  <li
+                    key={i}
+                    className="flex items-start gap-2 text-xs text-slate-700"
+                  >
+                    <span className="text-amber-500 font-bold mt-0.5 shrink-0">
+                      →
+                    </span>
+                    {point}
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            {/* CTA + secondary links */}
+            <div>
+              <p className="text-xs font-bold uppercase tracking-wider text-slate-500 mb-3">
+                Where to go next
+              </p>
+              <Link
+                href={active.ctaHref}
+                className="block w-full text-center px-5 py-3 bg-amber-500 hover:bg-amber-400 text-slate-900 font-extrabold rounded-xl text-sm transition-colors shadow mb-4"
+              >
+                {active.ctaLabel} →
+              </Link>
+              <div className="space-y-2">
+                {active.secondaryLinks.map((link) => (
+                  <Link
+                    key={link.href}
+                    href={link.href}
+                    className="flex items-center justify-between bg-slate-50 hover:bg-amber-50 border border-slate-200 hover:border-amber-300 rounded-xl px-4 py-2.5 transition-all group"
+                  >
+                    <span className="text-xs font-semibold text-slate-700 group-hover:text-amber-800">
+                      {link.label}
+                    </span>
+                    <span className="text-amber-500 font-bold text-base">&rarr;</span>
+                  </Link>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/foreign-investment/compare/[pair]/page.tsx
+++ b/app/foreign-investment/compare/[pair]/page.tsx
@@ -1,0 +1,569 @@
+/**
+ * /foreign-investment/compare/[pair]
+ *
+ * Country-vs-country comparison pages for the foreign-investment section.
+ * Example: /foreign-investment/compare/united-kingdom-vs-united-states
+ *
+ * SSG via generateStaticParams — 66 unique pairs from 12 hub countries.
+ * All content is factual (sourced from COUNTRY_CONFIGS). Compliance:
+ * GENERAL_ADVICE_WARNING + FOREIGN_INVESTOR_GENERAL_DISCLAIMER.
+ *
+ * Structured data: Article + ItemList (comparison rows) + BreadcrumbList.
+ */
+
+import { notFound, redirect } from "next/navigation";
+import Link from "next/link";
+import type { Metadata } from "next";
+import {
+  breadcrumbJsonLd,
+  absoluteUrl,
+  CURRENT_YEAR,
+  SITE_NAME,
+} from "@/lib/seo";
+import {
+  GENERAL_ADVICE_WARNING,
+  FOREIGN_INVESTOR_GENERAL_DISCLAIMER,
+  DTA_DISCLAIMER,
+  FIRB_DISCLAIMER,
+  WITHHOLDING_TAX_NOTE,
+} from "@/lib/compliance";
+import {
+  allComparePairs,
+  parsePairSlug,
+  buildCountryComparison,
+} from "@/lib/country-compare";
+import { COUNTRY_CONFIGS } from "@/lib/foreign-investment-country-data";
+import ForeignInvestmentNav from "../../ForeignInvestmentNav";
+
+// ─── Static Params ───────────────────────────────────────────────────────────
+
+export async function generateStaticParams(): Promise<{ pair: string }[]> {
+  return allComparePairs().map((p) => ({ pair: p.pair }));
+}
+
+// ─── Metadata ────────────────────────────────────────────────────────────────
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ pair: string }>;
+}): Promise<Metadata> {
+  const { pair } = await params;
+  const parsed = parsePairSlug(pair);
+  if (!parsed) return {};
+
+  const { cfgA, cfgB } = parsed;
+  const title = `${cfgA.countryName} vs ${cfgB.countryName} Investing in Australia — Tax, FIRB & Rules (${CURRENT_YEAR})`;
+  const description = `Structured comparison: ${cfgA.countryShort} vs ${cfgB.countryName} withholding tax rates, FIRB rules, FX corridors, pension transfer eligibility, and migration pathways for investors in Australia. Updated March ${CURRENT_YEAR}.`;
+
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: absoluteUrl(`/foreign-investment/compare/${cfgA.slug}-vs-${cfgB.slug}`),
+    },
+    openGraph: {
+      title: `${cfgA.countryShort} vs ${cfgB.countryShort} — Investing in Australia (${CURRENT_YEAR})`,
+      description,
+      url: absoluteUrl(`/foreign-investment/compare/${cfgA.slug}-vs-${cfgB.slug}`),
+    },
+    twitter: { card: "summary_large_image" },
+  };
+}
+
+// ─── Page ────────────────────────────────────────────────────────────────────
+
+export const revalidate = 86400; // 24h — no real-time data
+
+export default async function ComparePairPage({
+  params,
+}: {
+  params: Promise<{ pair: string }>;
+}) {
+  const { pair } = await params;
+  const parsed = parsePairSlug(pair);
+
+  if (!parsed) notFound();
+
+  // Redirect reverse-order slugs to canonical
+  if (parsed.reversed) {
+    redirect(`/foreign-investment/compare/${parsed.canonicalSlug}`);
+  }
+
+  const { cfgA, cfgB } = parsed;
+  const comparison = buildCountryComparison(cfgA, cfgB);
+
+  // ── JSON-LD ────────────────────────────────────────────────────────────────
+
+  const breadcrumbLd = breadcrumbJsonLd([
+    { name: "Home", url: absoluteUrl("/") },
+    { name: "Foreign Investment", url: absoluteUrl("/foreign-investment") },
+    {
+      name: "Compare Countries",
+      url: absoluteUrl("/foreign-investment/compare"),
+    },
+    {
+      name: `${cfgA.countryShort} vs ${cfgB.countryShort}`,
+      url: absoluteUrl(`/foreign-investment/compare/${comparison.pairSlug}`),
+    },
+  ]);
+
+  const articleLd = {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    headline: `${cfgA.countryName} vs ${cfgB.countryName} — Investing in Australia Comparison`,
+    description: `Factual comparison of investment rules for ${cfgA.countryName} and ${cfgB.countryName} residents investing in Australia.`,
+    url: absoluteUrl(`/foreign-investment/compare/${comparison.pairSlug}`),
+    publisher: {
+      "@type": "Organization",
+      name: SITE_NAME,
+      url: absoluteUrl("/"),
+    },
+    dateModified: "2026-03-01",
+    about: [
+      { "@type": "Country", name: cfgA.countryName },
+      { "@type": "Country", name: cfgB.countryName },
+    ],
+  };
+
+  const itemListLd = {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name: `${cfgA.countryShort} vs ${cfgB.countryShort} — Key Investment Rule Differences`,
+    description: `Comparison of ${comparison.rows.length} key dimensions affecting ${cfgA.countryName} and ${cfgB.countryName} investors in Australia.`,
+    numberOfItems: comparison.rows.length,
+    itemListElement: comparison.rows.map((row, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      name: row.dimension,
+      description: `${cfgA.countryShort}: ${row.valueA} | ${cfgB.countryShort}: ${row.valueB}`,
+    })),
+  };
+
+  return (
+    <div className="bg-white min-h-screen">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(itemListLd) }}
+      />
+
+      <ForeignInvestmentNav current="" />
+
+      {/* ── Hero ──────────────────────────────────────────────────────── */}
+      <section className="relative bg-white border-b border-slate-100 py-8 md:py-12">
+        <div className="container-custom">
+          <nav className="text-xs text-slate-500 mb-5 flex items-center gap-1.5 flex-wrap">
+            <Link href="/" className="hover:text-slate-900">
+              Home
+            </Link>
+            <span className="text-slate-300">/</span>
+            <Link href="/foreign-investment" className="hover:text-slate-900">
+              Foreign Investment
+            </Link>
+            <span className="text-slate-300">/</span>
+            <Link
+              href="/foreign-investment/compare"
+              className="hover:text-slate-900"
+            >
+              Compare Countries
+            </Link>
+            <span className="text-slate-300">/</span>
+            <span className="text-slate-900 font-medium">
+              {cfgA.countryShort} vs {cfgB.countryShort}
+            </span>
+          </nav>
+
+          <div className="inline-flex items-center gap-2 px-3 py-1 bg-slate-100 border border-slate-200 rounded-full text-xs font-semibold text-slate-600 mb-4">
+            <span className="w-1.5 h-1.5 bg-amber-500 rounded-full" />
+            Country Comparison · Updated March {CURRENT_YEAR}
+          </div>
+
+          <h1 className="text-2xl sm:text-3xl md:text-4xl font-extrabold leading-[1.1] mb-3 tracking-tight text-slate-900">
+            <span className="mr-2">{cfgA.flag}</span>
+            {cfgA.countryName}{" "}
+            <span className="text-slate-400 font-semibold text-2xl">vs</span>{" "}
+            <span className="mr-2">{cfgB.flag}</span>
+            {cfgB.countryName}
+            <span className="block text-amber-600 mt-1">
+              Investing in Australia
+            </span>
+          </h1>
+          <p className="text-sm md:text-base text-slate-600 leading-relaxed max-w-2xl mb-2">
+            Factual comparison of the key structural differences for{" "}
+            {cfgA.countryName} and {cfgB.countryName} residents investing in
+            Australia — withholding tax rates, FIRB rules, FX corridors,
+            pension transfers, and migration pathways.
+          </p>
+          <p className="text-xs text-slate-400 leading-relaxed">
+            {GENERAL_ADVICE_WARNING}
+          </p>
+        </div>
+      </section>
+
+      {/* ── Country header cards ─────────────────────────────────────── */}
+      <section className="bg-slate-50 border-b border-slate-100 py-6">
+        <div className="container-custom">
+          <div className="grid md:grid-cols-2 gap-4">
+            {[comparison.countryA, comparison.countryB].map((c) => (
+              <div
+                key={c.code}
+                className="bg-white border border-slate-200 rounded-2xl p-5 flex items-start gap-4"
+              >
+                <span className="text-4xl shrink-0">{c.flag}</span>
+                <div>
+                  <h2 className="text-base font-extrabold text-slate-900 mb-1">
+                    {c.name}
+                  </h2>
+                  <div className="flex flex-wrap gap-2 mb-2">
+                    <span
+                      className={`text-[0.65rem] font-bold px-2 py-0.5 rounded-full ${
+                        c.hasDta
+                          ? "bg-green-100 text-green-700"
+                          : "bg-red-100 text-red-700"
+                      }`}
+                    >
+                      {c.hasDta ? "DTA with AU" : "No DTA"}
+                    </span>
+                    <span className="text-[0.65rem] font-bold px-2 py-0.5 rounded-full bg-slate-100 text-slate-600">
+                      {c.currency}
+                    </span>
+                  </div>
+                  <Link
+                    href={`/foreign-investment/${c.slug}`}
+                    className="text-xs font-bold text-amber-600 hover:text-amber-700"
+                  >
+                    Full {c.short} investor guide →
+                  </Link>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── Critical Warnings ────────────────────────────────────────── */}
+      {comparison.warnings.length > 0 && (
+        <section className="py-6 bg-red-50 border-b border-red-100">
+          <div className="container-custom space-y-3">
+            {comparison.warnings.map((w, i) => (
+              <div
+                key={i}
+                className="bg-white border border-red-200 rounded-xl p-4"
+              >
+                <p className="text-xs font-extrabold text-red-700 mb-1">
+                  {w.country}: {w.title}
+                </p>
+                <p className="text-xs text-slate-600 leading-relaxed">
+                  {w.body}
+                </p>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* ── Comparison Table ─────────────────────────────────────────── */}
+      <section className="py-10 md:py-14">
+        <div className="container-custom">
+          <h2 className="text-xl font-extrabold text-slate-900 mb-2">
+            Key structural differences
+          </h2>
+          <p className="text-sm text-slate-500 mb-6">
+            Factual comparison across {comparison.rows.length} dimensions.
+            Rates sourced from ATO/Treasury as at March {CURRENT_YEAR}.
+          </p>
+
+          {/* Desktop table */}
+          <div className="hidden md:block overflow-x-auto rounded-2xl border border-slate-200">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="bg-slate-50 border-b border-slate-200">
+                  <th className="text-left px-5 py-3.5 text-xs font-bold text-slate-500 uppercase tracking-wide w-1/3">
+                    Dimension
+                  </th>
+                  <th className="text-left px-5 py-3.5 text-xs font-bold text-slate-700 uppercase tracking-wide w-[30%]">
+                    <span className="mr-1">{cfgA.flag}</span> {cfgA.countryShort}
+                  </th>
+                  <th className="text-left px-5 py-3.5 text-xs font-bold text-slate-700 uppercase tracking-wide w-[30%]">
+                    <span className="mr-1">{cfgB.flag}</span> {cfgB.countryShort}
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {comparison.rows.map((row, i) => (
+                  <tr
+                    key={i}
+                    className={`border-b border-slate-100 last:border-0 ${
+                      i % 2 === 0 ? "bg-white" : "bg-slate-50/50"
+                    }`}
+                  >
+                    <td className="px-5 py-4 align-top">
+                      <p className="font-semibold text-slate-900 text-xs">
+                        {row.dimension}
+                      </p>
+                      {row.note && (
+                        <p className="text-[0.65rem] text-slate-400 leading-snug mt-1">
+                          {row.note}
+                        </p>
+                      )}
+                    </td>
+                    <td className="px-5 py-4 align-top">
+                      <p className="text-xs text-slate-700 leading-relaxed">
+                        {row.valueA}
+                      </p>
+                    </td>
+                    <td className="px-5 py-4 align-top">
+                      <p className="text-xs text-slate-700 leading-relaxed">
+                        {row.valueB}
+                      </p>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Mobile stack */}
+          <div className="md:hidden space-y-4">
+            {comparison.rows.map((row, i) => (
+              <div
+                key={i}
+                className="bg-white border border-slate-200 rounded-xl p-4"
+              >
+                <p className="text-xs font-bold text-slate-500 uppercase tracking-wide mb-2">
+                  {row.dimension}
+                </p>
+                <div className="grid grid-cols-2 gap-3">
+                  <div className="bg-slate-50 rounded-lg p-3">
+                    <p className="text-[0.65rem] font-bold text-slate-400 mb-1">
+                      {cfgA.flag} {cfgA.countryShort}
+                    </p>
+                    <p className="text-xs text-slate-700 leading-relaxed">
+                      {row.valueA}
+                    </p>
+                  </div>
+                  <div className="bg-amber-50 rounded-lg p-3">
+                    <p className="text-[0.65rem] font-bold text-slate-400 mb-1">
+                      {cfgB.flag} {cfgB.countryShort}
+                    </p>
+                    <p className="text-xs text-slate-700 leading-relaxed">
+                      {row.valueB}
+                    </p>
+                  </div>
+                </div>
+                {row.note && (
+                  <p className="text-[0.65rem] text-slate-400 leading-snug mt-2">
+                    {row.note}
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── Pension Transfer callout (if relevant) ──────────────────── */}
+      {comparison.hasPensionTransfer && (
+        <section className="py-8 bg-amber-50 border-y border-amber-200">
+          <div className="container-custom max-w-3xl">
+            <h3 className="text-base font-extrabold text-amber-900 mb-2">
+              Pension / super transfer — high-stakes decision
+            </h3>
+            <p className="text-sm text-amber-800 leading-relaxed mb-4">
+              {cfgA.retirementTransfer || cfgB.retirementTransfer
+                ? `One or both of these countries has a specific pathway for transferring pension funds to Australian super. These transfers carry significant tax risk on both sides — do not self-direct.`
+                : ""}
+            </p>
+            <div className="flex flex-wrap gap-3">
+              {cfgA.retirementTransfer && (
+                <Link
+                  href={`/foreign-investment/${cfgA.slug}#retirement`}
+                  className="text-xs font-bold text-amber-700 hover:text-amber-900 underline underline-offset-2"
+                >
+                  {cfgA.countryShort} pension transfer guide →
+                </Link>
+              )}
+              {cfgB.retirementTransfer && (
+                <Link
+                  href={`/foreign-investment/${cfgB.slug}#retirement`}
+                  className="text-xs font-bold text-amber-700 hover:text-amber-900 underline underline-offset-2"
+                >
+                  {cfgB.countryShort} pension transfer guide →
+                </Link>
+              )}
+              <Link
+                href="/advisors/international-tax-specialists"
+                className="text-xs font-bold text-amber-700 hover:text-amber-900 underline underline-offset-2"
+              >
+                Find a pension transfer specialist →
+              </Link>
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* ── Links to full individual guides ─────────────────────────── */}
+      <section className="py-10 md:py-14 bg-slate-50 border-t border-slate-100">
+        <div className="container-custom">
+          <h2 className="text-base font-extrabold text-slate-900 mb-6">
+            Full country guides
+          </h2>
+          <div className="grid md:grid-cols-2 gap-4">
+            {[cfgA, cfgB].map((cfg) => (
+              <Link
+                key={cfg.code}
+                href={`/foreign-investment/${cfg.slug}`}
+                className="group flex items-start gap-4 p-5 bg-white border border-slate-200 hover:border-amber-300 hover:shadow-md rounded-2xl transition-all"
+              >
+                <span className="text-3xl shrink-0">{cfg.flag}</span>
+                <div className="min-w-0">
+                  <p className="font-extrabold text-sm text-slate-900 group-hover:text-amber-700 transition-colors mb-1">
+                    {cfg.countryName} — Full Investor Guide
+                  </p>
+                  <p className="text-xs text-slate-500 leading-relaxed line-clamp-2">
+                    {cfg.metadata.description.slice(0, 100)}
+                    {cfg.metadata.description.length > 100 ? "…" : ""}
+                  </p>
+                  <span className="mt-2 inline-flex items-center gap-1 text-xs font-bold text-amber-600 group-hover:text-amber-700">
+                    Full guide →
+                  </span>
+                </div>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── Other comparisons ───────────────────────────────────────── */}
+      <section className="py-8 border-t border-slate-100">
+        <div className="container-custom">
+          <p className="text-xs font-bold uppercase tracking-wide text-slate-500 mb-3">
+            Also compare
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {[cfgA, cfgB].map((cfg) => {
+              // suggest comparisons against this country and the other 2 hub countries
+              const otherCodes = (
+                Object.keys(COUNTRY_CONFIGS) as (keyof typeof COUNTRY_CONFIGS)[]
+              )
+                .filter(
+                  (c) => c !== cfgA.code && c !== cfgB.code,
+                )
+                .slice(0, 5);
+              return otherCodes.map((otherCode) => {
+                const otherCfg = COUNTRY_CONFIGS[otherCode];
+                if (!otherCfg) return null;
+                const [a, b] =
+                  cfg.countryShort.localeCompare(otherCfg.countryShort) <= 0
+                    ? [cfg, otherCfg]
+                    : [otherCfg, cfg];
+                const slug = `${a.slug}-vs-${b.slug}`;
+                return (
+                  <Link
+                    key={`${cfg.code}-${otherCode}`}
+                    href={`/foreign-investment/compare/${slug}`}
+                    className="inline-flex items-center gap-1 px-3 py-1.5 bg-white border border-slate-200 hover:border-amber-300 hover:bg-amber-50 text-xs font-semibold text-slate-700 hover:text-amber-700 rounded-lg transition-colors"
+                  >
+                    <span>{cfg.flag}</span>
+                    <span className="text-slate-400">vs</span>
+                    <span>{otherCfg.flag}</span>
+                    {cfg.countryShort} vs {otherCfg.countryShort}
+                  </Link>
+                );
+              });
+            })}
+          </div>
+        </div>
+      </section>
+
+      {/* ── Advisor CTA ──────────────────────────────────────────────── */}
+      <section className="py-10 bg-gradient-to-br from-slate-900 to-slate-800">
+        <div className="container-custom">
+          <div className="grid md:grid-cols-2 gap-8 items-center">
+            <div>
+              <h2 className="text-lg md:text-xl font-extrabold text-white mb-2">
+                Need help with your specific situation?
+              </h2>
+              <p className="text-slate-300 text-sm leading-relaxed">
+                Country rules are one layer — your personal tax residency
+                status, visa type, and investment structure determine the
+                actual treatment. A cross-border specialist can work through
+                both sides.
+              </p>
+            </div>
+            <div className="flex flex-col sm:flex-row gap-3">
+              <Link
+                href="/advisors/international-tax-specialists"
+                className="px-5 py-2.5 bg-amber-500 hover:bg-amber-400 text-white font-bold rounded-xl text-sm text-center transition-colors shadow-lg"
+              >
+                Find an International Tax Specialist
+              </Link>
+              <Link
+                href="/advisors/firb-specialists"
+                className="px-5 py-2.5 border border-slate-600 hover:border-slate-400 text-slate-300 hover:text-white font-semibold rounded-xl text-sm text-center transition-colors"
+              >
+                Find an FIRB Specialist
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Tools ────────────────────────────────────────────────────── */}
+      <section className="py-8 border-t border-slate-100">
+        <div className="container-custom">
+          <p className="text-xs font-bold uppercase tracking-wide text-slate-500 mb-3">
+            Relevant calculators
+          </p>
+          <div className="flex flex-wrap gap-3">
+            <Link
+              href="/tools/withholding-tax-calculator"
+              className="text-xs font-semibold text-amber-600 hover:text-amber-700"
+            >
+              Withholding Tax Calculator →
+            </Link>
+            <Link
+              href="/tools/dasp-calculator"
+              className="text-xs font-semibold text-amber-600 hover:text-amber-700"
+            >
+              DASP Calculator (departing super) →
+            </Link>
+            <Link
+              href="/tools/cgt-calculator"
+              className="text-xs font-semibold text-amber-600 hover:text-amber-700"
+            >
+              CGT Calculator →
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Disclaimers ──────────────────────────────────────────────── */}
+      <section className="py-6 bg-slate-50 border-t border-slate-200">
+        <div className="container-custom space-y-2">
+          <p className="text-xs text-slate-400 leading-relaxed">
+            {FOREIGN_INVESTOR_GENERAL_DISCLAIMER}
+          </p>
+          <p className="text-xs text-slate-400 leading-relaxed">
+            {DTA_DISCLAIMER}
+          </p>
+          <p className="text-xs text-slate-400 leading-relaxed">
+            {FIRB_DISCLAIMER}
+          </p>
+          <p className="text-xs text-slate-400 leading-relaxed">
+            {WITHHOLDING_TAX_NOTE}
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+}
+

--- a/app/foreign-investment/compare/page.tsx
+++ b/app/foreign-investment/compare/page.tsx
@@ -1,0 +1,189 @@
+/**
+ * /foreign-investment/compare
+ *
+ * Index page listing all available country-vs-country comparison pairs.
+ * Serves as an SEO hub and internal-link source for the 66 pair pages.
+ */
+
+import Link from "next/link";
+import type { Metadata } from "next";
+import { breadcrumbJsonLd, absoluteUrl, CURRENT_YEAR } from "@/lib/seo";
+import { FOREIGN_INVESTOR_GENERAL_DISCLAIMER } from "@/lib/compliance";
+import { COUNTRY_CONFIGS } from "@/lib/foreign-investment-country-data";
+import { allComparePairs } from "@/lib/country-compare";
+import { intentCountryMeta } from "@/lib/intent-context";
+import type { IntentCountryCode } from "@/lib/intent-context";
+import ForeignInvestmentNav from "../ForeignInvestmentNav";
+
+export const revalidate = 86400;
+
+export const metadata: Metadata = {
+  title: `Compare Countries for Investing in Australia (${CURRENT_YEAR}) — Side-by-Side Tax & FIRB Rules`,
+  description:
+    "Compare any two countries side-by-side: withholding tax rates, FIRB rules, FX corridors, pension-transfer eligibility, and migration pathways. All 66 pairs from 12 hub countries.",
+  alternates: { canonical: absoluteUrl("/foreign-investment/compare") },
+  openGraph: {
+    title: `Compare Countries — Investing in Australia (${CURRENT_YEAR})`,
+    description:
+      "Side-by-side: DTA status, withholding tax, FIRB rules, FX, pension transfer, and migration pathways for UK, US, China, India, Singapore, and more.",
+    url: absoluteUrl("/foreign-investment/compare"),
+  },
+};
+
+export default function CompareIndexPage() {
+  const pairs = allComparePairs();
+  const codes = Object.keys(COUNTRY_CONFIGS) as IntentCountryCode[];
+
+  const breadcrumbLd = breadcrumbJsonLd([
+    { name: "Home", url: absoluteUrl("/") },
+    { name: "Foreign Investment", url: absoluteUrl("/foreign-investment") },
+    { name: "Compare Countries", url: absoluteUrl("/foreign-investment/compare") },
+  ]);
+
+  return (
+    <div className="bg-white min-h-screen">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
+      />
+
+      <ForeignInvestmentNav current="" />
+
+      {/* ── Hero ──────────────────────────────────────────────────────── */}
+      <section className="relative bg-white border-b border-slate-100 py-8 md:py-12">
+        <div className="container-custom">
+          <nav className="text-xs text-slate-500 mb-5 flex items-center gap-1.5 flex-wrap">
+            <Link href="/" className="hover:text-slate-900">Home</Link>
+            <span className="text-slate-300">/</span>
+            <Link href="/foreign-investment" className="hover:text-slate-900">Foreign Investment</Link>
+            <span className="text-slate-300">/</span>
+            <span className="text-slate-900 font-medium">Compare Countries</span>
+          </nav>
+
+          <div className="inline-flex items-center gap-2 px-3 py-1 bg-slate-100 border border-slate-200 rounded-full text-xs font-semibold text-slate-600 mb-4">
+            <span className="w-1.5 h-1.5 bg-amber-500 rounded-full" />
+            {pairs.length} pairs · {codes.length} hub countries · Updated March {CURRENT_YEAR}
+          </div>
+
+          <h1 className="text-2xl sm:text-3xl md:text-4xl font-extrabold leading-[1.1] mb-3 tracking-tight text-slate-900">
+            Compare countries for{" "}
+            <span className="text-amber-600">investing in Australia</span>
+          </h1>
+          <p className="text-sm md:text-base text-slate-600 leading-relaxed max-w-2xl">
+            Side-by-side comparison of DTA status, withholding tax rates, FIRB
+            rules, FX corridor availability, pension-transfer eligibility, and
+            migration pathways. General information only — not financial advice.
+          </p>
+        </div>
+      </section>
+
+      {/* ── Country grid for quick-jump ──────────────────────────────── */}
+      <section className="py-10">
+        <div className="container-custom">
+          <h2 className="text-base font-extrabold text-slate-900 mb-2">
+            Select two countries to compare
+          </h2>
+          <p className="text-sm text-slate-500 mb-6">
+            Pick any two of the {codes.length} hub countries below to see
+            their comparison page.
+          </p>
+
+          <div className="grid sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
+            {codes.map((code) => {
+              const cfg = COUNTRY_CONFIGS[code];
+              if (!cfg) return null;
+              const meta = intentCountryMeta(code);
+              return (
+                <div
+                  key={code}
+                  className="bg-white border border-slate-200 rounded-xl p-4"
+                >
+                  <div className="flex items-center gap-3 mb-3">
+                    <span className="text-2xl">{cfg.flag}</span>
+                    <div>
+                      <p className="font-bold text-sm text-slate-900">{cfg.countryName}</p>
+                      <span
+                        className={`text-[0.6rem] font-bold px-1.5 py-0.5 rounded-full ${
+                          meta.hasDta
+                            ? "bg-green-100 text-green-700"
+                            : "bg-slate-100 text-slate-500"
+                        }`}
+                      >
+                        {meta.hasDta ? "DTA" : "No DTA"}
+                      </span>
+                    </div>
+                  </div>
+                  <div className="flex flex-wrap gap-1.5">
+                    {codes
+                      .filter((c) => c !== code)
+                      .slice(0, 5)
+                      .map((otherCode) => {
+                        const otherCfg = COUNTRY_CONFIGS[otherCode];
+                        if (!otherCfg) return null;
+                        const [a, b] =
+                          cfg.countryShort.localeCompare(otherCfg.countryShort) <= 0
+                            ? [cfg, otherCfg]
+                            : [otherCfg, cfg];
+                        return (
+                          <Link
+                            key={otherCode}
+                            href={`/foreign-investment/compare/${a.slug}-vs-${b.slug}`}
+                            className="inline-flex items-center gap-1 text-[0.65rem] font-semibold text-slate-600 hover:text-amber-700 bg-slate-50 hover:bg-amber-50 border border-slate-200 hover:border-amber-300 rounded-md px-2 py-1 transition-colors"
+                          >
+                            <span>vs {otherCfg.flag}</span>
+                            <span>{otherCfg.countryShort}</span>
+                          </Link>
+                        );
+                      })}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+
+      {/* ── All pairs A-Z ────────────────────────────────────────────── */}
+      <section className="py-10 bg-slate-50 border-t border-slate-100">
+        <div className="container-custom">
+          <h2 className="text-base font-extrabold text-slate-900 mb-2">
+            All {pairs.length} comparison pairs
+          </h2>
+          <p className="text-sm text-slate-500 mb-6">
+            Every unique country pair from our {codes.length} hub countries.
+          </p>
+          <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-3">
+            {pairs.map(({ pair, codeA, codeB }) => {
+              const cfgA = COUNTRY_CONFIGS[codeA];
+              const cfgB = COUNTRY_CONFIGS[codeB];
+              if (!cfgA || !cfgB) return null;
+              return (
+                <Link
+                  key={pair}
+                  href={`/foreign-investment/compare/${pair}`}
+                  className="group flex items-center gap-3 bg-white hover:bg-amber-50 border border-slate-200 hover:border-amber-300 rounded-xl px-4 py-3 transition-all"
+                >
+                  <span className="text-lg">{cfgA.flag}</span>
+                  <span className="text-[0.65rem] font-bold text-slate-400">vs</span>
+                  <span className="text-lg">{cfgB.flag}</span>
+                  <span className="text-xs font-semibold text-slate-700 group-hover:text-amber-700 transition-colors">
+                    {cfgA.countryShort} vs {cfgB.countryShort}
+                  </span>
+                </Link>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+
+      {/* ── Disclaimer ──────────────────────────────────────────────── */}
+      <section className="py-6 bg-white border-t border-slate-200">
+        <div className="container-custom">
+          <p className="text-xs text-slate-400 leading-relaxed">
+            {FOREIGN_INVESTOR_GENERAL_DISCLAIMER}
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/foreign-investment/page.tsx
+++ b/app/foreign-investment/page.tsx
@@ -12,6 +12,7 @@ import { getDtaCountries, getDefaultWHT } from "@/lib/fi-data-server";
 import { FOREIGN_INVESTOR_GENERAL_DISCLAIMER, DTA_DISCLAIMER } from "@/lib/compliance";
 import type { Broker } from "@/lib/types";
 import PersonaSelector from "./PersonaSelector";
+import FIPersonaRouter from "./FIPersonaRouter";
 import DTASearchTable from "./DTASearchTable";
 import ForeignInvestmentNav from "./ForeignInvestmentNav";
 import WHTCalculator from "./WHTCalculator";
@@ -236,13 +237,25 @@ export default async function ForeignInvestmentHubPage() {
         </div>
       </section>
 
-      {/* ── Persona Selector ────────────────────────────────────────── */}
-      <section id="find-your-situation" className="py-12 md:py-16 bg-slate-50">
+      {/* ── Journey Persona Router ───────────────────────────────────── */}
+      <section id="find-your-situation" className="py-12 md:py-16 bg-white border-b border-slate-100">
         <div className="container-custom">
           <SectionHeading
-            eyebrow="Find your situation"
-            title="What best describes you?"
-            sub="Select your situation to see the rules, key considerations, and next steps that apply specifically to you."
+            eyebrow="Where are you in your journey?"
+            title="What brings you here?"
+            sub="Select your situation to see the guides, tools, and next steps that apply to you. General information only — not financial advice."
+          />
+          <FIPersonaRouter />
+        </div>
+      </section>
+
+      {/* ── Detailed Persona Selector ────────────────────────────────── */}
+      <section className="py-12 md:py-16 bg-slate-50">
+        <div className="container-custom">
+          <SectionHeading
+            eyebrow="Investor type"
+            title="What best describes your investor status?"
+            sub="Select your visa and residency status to see the specific rules, key considerations, and recommended specialists."
           />
           <PersonaSelector personas={FOREIGN_INVESTOR_PERSONAS} />
         </div>

--- a/app/tools/dasp-calculator/DaspCalculatorClient.tsx
+++ b/app/tools/dasp-calculator/DaspCalculatorClient.tsx
@@ -1,0 +1,394 @@
+"use client";
+
+/**
+ * DASP Calculator Client Component.
+ *
+ * Interactive form that drives computeDasp() from lib/calculators/dasp.ts.
+ * Factual tax arithmetic only — headline withholding estimate, not personal
+ * tax advice. DASP_WARNING + GENERAL_ADVICE_WARNING surfaced prominently.
+ *
+ * Inputs:
+ *   - Taxed element (most accumulation-fund balances)
+ *   - Untaxed element (some public-sector/defined-benefit funds — optional)
+ *   - Tax-free component (non-concessional contributions — optional)
+ *   - Working Holiday Maker toggle (subclass 417/462)
+ *
+ * Outputs (live-calculated):
+ *   - Gross balance
+ *   - Tax withheld (breakdown by component)
+ *   - Net payment
+ *   - Effective rate
+ */
+
+import { useState, useMemo } from "react";
+import Link from "next/link";
+import {
+  computeDasp,
+  DASP_TAXED_ELEMENT_RATE,
+  DASP_UNTAXED_ELEMENT_RATE,
+  DASP_WHM_RATE,
+} from "@/lib/calculators/dasp";
+import {
+  DASP_WARNING,
+  GENERAL_ADVICE_WARNING,
+} from "@/lib/compliance";
+
+function fmt(n: number): string {
+  return new Intl.NumberFormat("en-AU", {
+    style: "currency",
+    currency: "AUD",
+    maximumFractionDigits: 0,
+  }).format(n);
+}
+
+function pct(n: number): string {
+  return `${(n * 100).toFixed(1)}%`;
+}
+
+interface NumericInputProps {
+  label: string;
+  id: string;
+  value: string;
+  onChange: (v: string) => void;
+  hint?: string;
+}
+
+function NumericInput({ label, id, value, onChange, hint }: NumericInputProps) {
+  return (
+    <div>
+      <label
+        htmlFor={id}
+        className="block text-xs font-bold text-slate-700 mb-1"
+      >
+        {label}
+      </label>
+      {hint && (
+        <p className="text-[0.65rem] text-slate-400 mb-1.5 leading-snug">
+          {hint}
+        </p>
+      )}
+      <div className="relative">
+        <span className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 text-sm font-semibold">
+          $
+        </span>
+        <input
+          id={id}
+          type="number"
+          min="0"
+          step="100"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder="0"
+          className="w-full pl-7 pr-4 py-2.5 border border-slate-200 rounded-xl text-sm text-slate-900 focus:outline-none focus:ring-2 focus:ring-amber-400/50 focus:border-amber-400 bg-white"
+        />
+      </div>
+    </div>
+  );
+}
+
+export default function DaspCalculatorClient() {
+  const [taxed, setTaxed] = useState("50000");
+  const [untaxed, setUntaxed] = useState("");
+  const [taxFree, setTaxFree] = useState("");
+  const [isWhm, setIsWhm] = useState(false);
+  const [showAdvanced, setShowAdvanced] = useState(false);
+
+  const result = useMemo(() => {
+    return computeDasp({
+      taxedElement: parseFloat(taxed) || 0,
+      untaxedElement: parseFloat(untaxed) || 0,
+      taxFreeComponent: parseFloat(taxFree) || 0,
+      isWorkingHolidayMaker: isWhm,
+    });
+  }, [taxed, untaxed, taxFree, isWhm]);
+
+  const hasBalance = result.grossBalance > 0;
+
+  return (
+    <div className="container-custom max-w-3xl py-10 md:py-14">
+      {/* Header */}
+      <div className="mb-8">
+        <div className="inline-flex items-center gap-2 px-3 py-1 bg-slate-100 border border-slate-200 rounded-full text-xs font-semibold text-slate-600 mb-4">
+          <span className="w-1.5 h-1.5 bg-amber-500 rounded-full" />
+          ATO rates · Updated 2026
+        </div>
+        <h1 className="text-2xl sm:text-3xl font-extrabold text-slate-900 mb-2 leading-tight">
+          DASP Calculator
+          <span className="block text-amber-600">
+            Departing Australia Superannuation Payment
+          </span>
+        </h1>
+        <p className="text-sm text-slate-600 leading-relaxed">
+          Estimate the withholding tax deducted from your super when you leave
+          Australia. Shows the taxed, untaxed, and tax-free components plus the
+          net cash you receive. Factual arithmetic only — not personal tax advice.
+        </p>
+      </div>
+
+      {/* DASP Warning */}
+      <div className="bg-red-50 border border-red-200 rounded-xl p-4 mb-6">
+        <p className="text-xs font-extrabold text-red-700 mb-1">
+          High withholding rates — read before you proceed
+        </p>
+        <p className="text-xs text-red-700 leading-relaxed">{DASP_WARNING}</p>
+      </div>
+
+      <div className="grid md:grid-cols-[1fr_1fr] gap-8 items-start">
+        {/* ── Inputs ────────────────────────────────────────────────── */}
+        <div className="space-y-5">
+          <div className="bg-white border border-slate-200 rounded-2xl p-5 space-y-4">
+            <h2 className="text-sm font-extrabold text-slate-900">
+              Your super balance
+            </h2>
+
+            <NumericInput
+              label="Taxed element ($)"
+              id="taxed"
+              value={taxed}
+              onChange={setTaxed}
+              hint="For most accumulation funds (employer SG + salary sacrifice + fund earnings), this is your entire account balance."
+            />
+
+            {/* WHM toggle */}
+            <div>
+              <label className="flex items-start gap-3 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={isWhm}
+                  onChange={(e) => setIsWhm(e.target.checked)}
+                  className="mt-0.5 w-4 h-4 rounded border-slate-300 text-amber-500 focus:ring-amber-400"
+                />
+                <div>
+                  <span className="text-xs font-bold text-slate-800 block">
+                    Working Holiday Maker (subclass 417 or 462)
+                  </span>
+                  <span className="text-[0.65rem] text-slate-400 leading-snug">
+                    WHM DASP withholding is {(DASP_WHM_RATE * 100).toFixed(0)}% on the
+                    entire taxable component — significantly higher than the standard{" "}
+                    {(DASP_TAXED_ELEMENT_RATE * 100).toFixed(0)}%.
+                  </span>
+                </div>
+              </label>
+            </div>
+
+            {/* Advanced toggle */}
+            <button
+              type="button"
+              onClick={() => setShowAdvanced(!showAdvanced)}
+              className="text-xs font-semibold text-amber-600 hover:text-amber-700"
+            >
+              {showAdvanced ? "Hide" : "Show"} advanced components (untaxed /
+              tax-free)
+            </button>
+
+            {showAdvanced && (
+              <div className="space-y-4 pt-2 border-t border-slate-100">
+                <NumericInput
+                  label="Untaxed element ($)"
+                  id="untaxed"
+                  value={untaxed}
+                  onChange={setUntaxed}
+                  hint={`Applies to some public-sector or defined-benefit funds. Standard rate: ${(DASP_UNTAXED_ELEMENT_RATE * 100).toFixed(0)}% (or ${(DASP_WHM_RATE * 100).toFixed(0)}% for WHM). If unsure, leave blank.`}
+                />
+                <NumericInput
+                  label="Tax-free component ($)"
+                  id="taxFree"
+                  value={taxFree}
+                  onChange={setTaxFree}
+                  hint="Non-concessional (after-tax) contributions. Taxed at 0% — this amount passes through untouched."
+                />
+              </div>
+            )}
+          </div>
+
+          {/* Rate reference */}
+          <div className="bg-slate-50 border border-slate-200 rounded-xl p-4">
+            <p className="text-[0.65rem] font-extrabold text-slate-500 uppercase tracking-wide mb-2">
+              ATO DASP withholding rates (on or after 1 July 2017)
+            </p>
+            <table className="w-full text-xs">
+              <thead>
+                <tr className="border-b border-slate-200">
+                  <th className="text-left pb-1 font-semibold text-slate-500">Component</th>
+                  <th className="text-right pb-1 font-semibold text-slate-500">Standard</th>
+                  <th className="text-right pb-1 font-semibold text-amber-600">WHM</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100">
+                <tr>
+                  <td className="py-1.5 text-slate-700">Tax-free component</td>
+                  <td className="py-1.5 text-right text-slate-700">0%</td>
+                  <td className="py-1.5 text-right text-amber-700">0%</td>
+                </tr>
+                <tr>
+                  <td className="py-1.5 text-slate-700">Taxed element</td>
+                  <td className="py-1.5 text-right text-slate-700">{(DASP_TAXED_ELEMENT_RATE * 100).toFixed(0)}%</td>
+                  <td className="py-1.5 text-right font-bold text-amber-700">{(DASP_WHM_RATE * 100).toFixed(0)}%</td>
+                </tr>
+                <tr>
+                  <td className="py-1.5 text-slate-700">Untaxed element</td>
+                  <td className="py-1.5 text-right text-slate-700">{(DASP_UNTAXED_ELEMENT_RATE * 100).toFixed(0)}%</td>
+                  <td className="py-1.5 text-right font-bold text-amber-700">{(DASP_WHM_RATE * 100).toFixed(0)}%</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        {/* ── Results ───────────────────────────────────────────────── */}
+        <div>
+          <div
+            className={`bg-white border rounded-2xl p-5 transition-all ${
+              hasBalance ? "border-amber-200 shadow-md shadow-amber-500/5" : "border-slate-200"
+            }`}
+          >
+            <h2 className="text-sm font-extrabold text-slate-900 mb-4">
+              Estimated result
+            </h2>
+
+            {!hasBalance ? (
+              <p className="text-sm text-slate-400 text-center py-8">
+                Enter your super balance above to see the estimate.
+              </p>
+            ) : (
+              <div className="space-y-3">
+                {/* Net payment — the headline number */}
+                <div className="bg-amber-50 border border-amber-200 rounded-xl p-4 text-center mb-2">
+                  <p className="text-[0.65rem] font-bold text-amber-600 uppercase tracking-wide mb-1">
+                    Estimated net DASP payment
+                  </p>
+                  <p className="text-3xl font-extrabold text-amber-700">
+                    {fmt(result.netPayment)}
+                  </p>
+                  <p className="text-xs text-amber-600 mt-1">
+                    after {pct(result.effectiveRate)} effective withholding
+                  </p>
+                </div>
+
+                {/* Breakdown table */}
+                <div className="space-y-2">
+                  <div className="flex justify-between text-xs py-1.5 border-b border-slate-100">
+                    <span className="text-slate-500">Gross super balance</span>
+                    <span className="font-semibold text-slate-900">{fmt(result.grossBalance)}</span>
+                  </div>
+                  {result.taxFreeComponent > 0 && (
+                    <div className="flex justify-between text-xs py-1.5 border-b border-slate-100">
+                      <span className="text-slate-500">Tax-free component (0% WHT)</span>
+                      <span className="font-semibold text-green-700">{fmt(result.taxFreeComponent)}</span>
+                    </div>
+                  )}
+                  <div className="flex justify-between text-xs py-1.5 border-b border-slate-100">
+                    <span className="text-slate-500">Taxable component</span>
+                    <span className="font-semibold text-slate-900">{fmt(result.taxableComponent)}</span>
+                  </div>
+                  {result.taxOnTaxedElement > 0 && (
+                    <div className="flex justify-between text-xs py-1.5 border-b border-slate-100">
+                      <span className="text-slate-500">
+                        Tax on taxed element ({isWhm ? (DASP_WHM_RATE * 100).toFixed(0) : (DASP_TAXED_ELEMENT_RATE * 100).toFixed(0)}%)
+                      </span>
+                      <span className="font-semibold text-red-600">−{fmt(result.taxOnTaxedElement)}</span>
+                    </div>
+                  )}
+                  {result.taxOnUntaxedElement > 0 && (
+                    <div className="flex justify-between text-xs py-1.5 border-b border-slate-100">
+                      <span className="text-slate-500">
+                        Tax on untaxed element ({isWhm ? (DASP_WHM_RATE * 100).toFixed(0) : (DASP_UNTAXED_ELEMENT_RATE * 100).toFixed(0)}%)
+                      </span>
+                      <span className="font-semibold text-red-600">−{fmt(result.taxOnUntaxedElement)}</span>
+                    </div>
+                  )}
+                  <div className="flex justify-between text-xs py-1.5 border-b border-slate-100">
+                    <span className="font-bold text-slate-700">Total DASP withholding tax</span>
+                    <span className="font-extrabold text-red-600">−{fmt(result.totalTax)}</span>
+                  </div>
+                  <div className="flex justify-between text-sm py-2 mt-1">
+                    <span className="font-extrabold text-slate-900">Net payment to you</span>
+                    <span className="font-extrabold text-amber-700">{fmt(result.netPayment)}</span>
+                  </div>
+                </div>
+
+                {/* WHM callout */}
+                {result.isWorkingHolidayMaker && (
+                  <div className="bg-red-50 border border-red-200 rounded-lg p-3 mt-2">
+                    <p className="text-xs text-red-700 font-semibold">
+                      WHM rate applied — 65% on the entire taxable component.
+                      The government cannot reduce this rate; it is fixed by statute.
+                    </p>
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+
+          {/* Next steps */}
+          {hasBalance && (
+            <div className="mt-4 bg-slate-50 border border-slate-200 rounded-xl p-4 space-y-2">
+              <p className="text-xs font-bold text-slate-700">Next steps</p>
+              <ul className="space-y-1.5 text-xs text-slate-600">
+                <li>
+                  <span className="text-slate-400 mr-1">→</span>
+                  Check your fund for the component breakdown (contact your
+                  super fund if unsure)
+                </li>
+                <li>
+                  <span className="text-slate-400 mr-1">→</span>
+                  Apply via the{" "}
+                  <a
+                    href="https://www.ato.gov.au/individuals-and-families/super-for-individuals-and-families/super/leaving-australia-super/dasp-online-application"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-amber-600 hover:underline font-semibold"
+                  >
+                    ATO DASP portal
+                  </a>{" "}
+                  after your visa has ceased and you have departed Australia
+                </li>
+                <li>
+                  <span className="text-slate-400 mr-1">→</span>
+                  Most funds process claims in 28 days once the ATO has
+                  validated your visa status
+                </li>
+              </ul>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Disclaimer */}
+      <div className="mt-8 pt-6 border-t border-slate-200">
+        <p className="text-xs text-slate-400 leading-relaxed">
+          {GENERAL_ADVICE_WARNING}
+        </p>
+        <p className="text-xs text-slate-400 leading-relaxed mt-2">
+          This calculator is an estimate based on ATO published rates (current
+          for DASP payments on or after 1 July 2017). It does not model
+          low-income offsets, proportioning rules, or fund-specific fees.
+          Actual withholding may differ. Verify with your super fund and the
+          ATO before relying on this figure.
+        </p>
+      </div>
+
+      {/* Related tools */}
+      <div className="mt-6 flex flex-wrap gap-3">
+        <Link
+          href="/tools/withholding-tax-calculator"
+          className="text-xs font-semibold text-amber-600 hover:text-amber-700"
+        >
+          Withholding Tax Calculator →
+        </Link>
+        <Link
+          href="/foreign-investment/super"
+          className="text-xs font-semibold text-amber-600 hover:text-amber-700"
+        >
+          Super & DASP guide →
+        </Link>
+        <Link
+          href="/advisors/international-tax-specialists"
+          className="text-xs font-semibold text-amber-600 hover:text-amber-700"
+        >
+          Find a tax specialist →
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/app/tools/dasp-calculator/page.tsx
+++ b/app/tools/dasp-calculator/page.tsx
@@ -14,7 +14,6 @@
 import type { Metadata } from "next";
 import { Suspense } from "react";
 import { absoluteUrl, breadcrumbJsonLd, CURRENT_YEAR, SITE_NAME } from "@/lib/seo";
-import { DASP_WARNING, GENERAL_ADVICE_WARNING } from "@/lib/compliance";
 import { faqJsonLd, type FaqItem } from "@/lib/schema-markup";
 import DaspCalculatorClient from "./DaspCalculatorClient";
 

--- a/app/tools/dasp-calculator/page.tsx
+++ b/app/tools/dasp-calculator/page.tsx
@@ -1,0 +1,138 @@
+/**
+ * /tools/dasp-calculator
+ *
+ * DASP (Departing Australia Superannuation Payment) Calculator page.
+ *
+ * Displays the interactive DaspCalculatorClient with full JSON-LD markup
+ * (SoftwareApplication + FAQPage + BreadcrumbList) and compliance footers.
+ *
+ * AFSL safety: factual withholding estimate only. DASP_WARNING +
+ * GENERAL_ADVICE_WARNING surfaced inside the client component. No
+ * personal advice, no product recommendations.
+ */
+
+import type { Metadata } from "next";
+import { Suspense } from "react";
+import { absoluteUrl, breadcrumbJsonLd, CURRENT_YEAR, SITE_NAME } from "@/lib/seo";
+import { DASP_WARNING, GENERAL_ADVICE_WARNING } from "@/lib/compliance";
+import { faqJsonLd, type FaqItem } from "@/lib/schema-markup";
+import DaspCalculatorClient from "./DaspCalculatorClient";
+
+export const revalidate = 3600;
+
+export const metadata: Metadata = {
+  title: `DASP Calculator — Departing Australia Superannuation Payment (${CURRENT_YEAR})`,
+  description:
+    "Calculate the tax withheld on your Departing Australia Superannuation Payment (DASP). Shows 35% standard rate vs 65% Working Holiday Maker rate, plus component breakdown (taxed, untaxed, tax-free). ATO rates.",
+  alternates: { canonical: absoluteUrl("/tools/dasp-calculator") },
+  openGraph: {
+    title: `DASP Calculator — Departing Australia Super Tax (${CURRENT_YEAR})`,
+    description:
+      "Estimate net DASP payment after ATO withholding. 35% standard / 65% WHM. Free and instant.",
+    url: absoluteUrl("/tools/dasp-calculator"),
+  },
+  twitter: { card: "summary_large_image" },
+};
+
+const softwareLd = {
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  name: `DASP Calculator — ${SITE_NAME}`,
+  description:
+    "Estimate the Australian withholding tax on a Departing Australia Superannuation Payment (DASP) for temporary visa holders and Working Holiday Makers.",
+  url: absoluteUrl("/tools/dasp-calculator"),
+  applicationCategory: "FinanceApplication",
+  operatingSystem: "Any",
+  offers: { "@type": "Offer", price: "0", priceCurrency: "AUD" },
+};
+
+const breadcrumbLd = breadcrumbJsonLd([
+  { name: "Home", url: absoluteUrl("/") },
+  { name: "Tools", url: absoluteUrl("/tools") },
+  { name: "DASP Calculator", url: absoluteUrl("/tools/dasp-calculator") },
+]);
+
+const FAQS: FaqItem[] = [
+  {
+    q: "What is DASP?",
+    a: "DASP stands for Departing Australia Superannuation Payment. It allows temporary visa holders who have permanently left Australia to claim their accumulated superannuation. You apply through the ATO's DASP portal after your visa has ceased.",
+  },
+  {
+    q: "What is the DASP withholding rate?",
+    a: "For most temporary visa holders, the DASP withholding rate is 35% on the taxed element and 45% on the untaxed element. The tax-free component is taxed at 0%. Working Holiday Makers (subclass 417 and 462) face a higher rate of 65% on the entire taxable component (both taxed and untaxed elements).",
+  },
+  {
+    q: "How does the WHM DASP rate differ?",
+    a: "Working Holiday Makers (visa subclass 417 or 462) pay a flat 65% DASP withholding rate on their entire taxable component — compared to the 35%/45% split for standard temporary residents. This rate applies if you held a WHM visa at any time, even if your final visa is a different subclass.",
+  },
+  {
+    q: "What is the tax-free component of super?",
+    a: "The tax-free component is the portion of your super made from non-concessional (after-tax) contributions. This component is not taxed on DASP withdrawal — you receive it in full. Most accumulation fund balances consist primarily of the taxed element (employer SG contributions + concessional contributions + fund earnings).",
+  },
+  {
+    q: "When can I apply for DASP?",
+    a: "You can apply for DASP via the ATO's online portal once: (1) your visa has ceased (either expired or cancelled), and (2) you have departed Australia. Most funds process claims within 28 days once the ATO has confirmed your visa status. You cannot apply while still holding an active temporary visa in Australia.",
+  },
+  {
+    q: "Does the calculator account for my exact super fund balance breakdown?",
+    a: "The calculator uses the component amounts you enter. If you are unsure of your taxed/untaxed/tax-free split, contact your super fund — they are required to provide this information. For most retail accumulation funds, the entire balance is in the taxed element.",
+  },
+];
+
+const faqLd = faqJsonLd(FAQS);
+
+function Loading() {
+  return (
+    <div className="py-12 animate-pulse container-custom max-w-3xl">
+      <div className="h-6 w-64 bg-slate-100 rounded mb-4" />
+      <div className="h-48 bg-slate-100 rounded-2xl mb-6" />
+      <div className="h-80 bg-slate-100 rounded-xl" />
+    </div>
+  );
+}
+
+export default function DaspCalculatorPage() {
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(softwareLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }}
+      />
+      <Suspense fallback={<Loading />}>
+        <DaspCalculatorClient />
+      </Suspense>
+
+      {/* FAQ section (for SEO + accessibility — answers the structured-data above) */}
+      <section className="py-10 bg-slate-50 border-t border-slate-100">
+        <div className="container-custom max-w-3xl">
+          <h2 className="text-base font-extrabold text-slate-900 mb-6">
+            Frequently asked questions
+          </h2>
+          <div className="space-y-4">
+            {FAQS.map((faq, i) => (
+              <div
+                key={i}
+                className="bg-white border border-slate-200 rounded-xl p-4"
+              >
+                <p className="text-sm font-bold text-slate-900 mb-1.5">
+                  {faq.q}
+                </p>
+                <p className="text-xs text-slate-600 leading-relaxed">
+                  {faq.a}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/lib/country-compare.ts
+++ b/lib/country-compare.ts
@@ -1,0 +1,375 @@
+/**
+ * Country-vs-Country comparison engine for the /foreign-investment/compare/[pair] pages.
+ *
+ * Extracts a structured set of "comparison dimensions" from two CountryConfig
+ * objects — DTA/withholding rates, FIRB thresholds, residency signals, FX
+ * corridor availability, pension-transfer eligibility, migration pathways, and
+ * key critical warnings. Drives the SSG pair pages.
+ *
+ * AFSL safety: all data is factual (sourced from COUNTRY_CONFIGS which is
+ * verified against ATO/Treasury March 2026). No personal recommendations, no
+ * ranking of which country is "better". Callers MUST display
+ * GENERAL_ADVICE_WARNING + FOREIGN_INVESTOR_GENERAL_DISCLAIMER.
+ *
+ * Pair slug format: "<slug-a>-vs-<slug-b>" (always alphabetically sorted by
+ * country short name to prevent a-vs-b / b-vs-a duplication).
+ *
+ * Tests: __tests__/lib/country-compare.test.ts
+ */
+
+import type { CountryConfig } from "./foreign-investment-country-data";
+import { COUNTRY_CONFIGS } from "./foreign-investment-country-data";
+import { intentCountryMeta } from "./intent-context";
+import type { IntentCountryCode } from "./intent-context";
+
+// ─── Public Types ────────────────────────────────────────────────────────────
+
+export interface CompareRow {
+  /** Short dimension label shown in the table header column. */
+  dimension: string;
+  /** Value for country A. */
+  valueA: string;
+  /** Value for country B. */
+  valueB: string;
+  /**
+   * Optional note (displayed in a collapse / tooltip) giving additional
+   * context for the row. Factual only.
+   */
+  note?: string;
+}
+
+export interface CountryComparison {
+  /** Slug used in the URL, e.g. "uk-vs-us". */
+  pairSlug: string;
+  countryA: {
+    code: IntentCountryCode;
+    name: string;
+    short: string;
+    flag: string;
+    currency: string;
+    slug: string;
+    hasDta: boolean;
+  };
+  countryB: {
+    code: IntentCountryCode;
+    name: string;
+    short: string;
+    flag: string;
+    currency: string;
+    slug: string;
+    hasDta: boolean;
+  };
+  /** Main comparison table rows — DTA, tax, FIRB, FX, pension, migration. */
+  rows: ReadonlyArray<CompareRow>;
+  /**
+   * Critical warnings from either country's config that must be surfaced
+   * prominently (e.g. US FATCA, CN capital controls).
+   */
+  warnings: ReadonlyArray<{ country: string; title: string; body: string }>;
+  /** True when at least one country has a `retirementTransfer` section. */
+  hasPensionTransfer: boolean;
+  /** True when at least one country has an `fxCorridor` section. */
+  hasFxCorridor: boolean;
+  /** True when both countries have a DTA with Australia. */
+  bothHaveDta: boolean;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Extract the unfranked dividend WHT rate from the first relevant DTA row. */
+function dividendRate(config: CountryConfig, hasDta: boolean): string {
+  const row = config.dta.rows.find((r) =>
+    r.type.toLowerCase().includes("unfranked"),
+  );
+  if (!row) return hasDta ? "15%*" : "30%";
+  return hasDta ? row.withTreaty : row.noTreaty;
+}
+
+/** Extract the interest WHT rate. */
+function interestRate(config: CountryConfig, hasDta: boolean): string {
+  const row = config.dta.rows.find((r) =>
+    r.type.toLowerCase().includes("interest"),
+  );
+  if (!row) return "10%";
+  return hasDta ? row.withTreaty : row.noTreaty;
+}
+
+/** Extract the royalties WHT rate. */
+function royaltiesRate(config: CountryConfig, hasDta: boolean): string {
+  const row = config.dta.rows.find((r) =>
+    r.type.toLowerCase().includes("royalt"),
+  );
+  if (!row) return hasDta ? "5%–10%*" : "30%";
+  return hasDta ? row.withTreaty : row.noTreaty;
+}
+
+/** Whether FIRB is required (heuristic: NZ doesn't need it). */
+function firbRequired(config: CountryConfig): string {
+  const warn = config.criticalWarning?.title ?? "";
+  if (warn.toLowerCase().includes("no firb")) return "No (Trans-Tasman exemption)";
+  return "Yes — FIRB approval required";
+}
+
+/** Established dwelling ban status. */
+function dwellingBan(config: CountryConfig): string {
+  return config.property.banHeadline
+    ? "Banned until 31 March 2027"
+    : "No ban (NZ Trans-Tasman exemption applies)";
+}
+
+/** FX corridor availability label. */
+function fxLabel(config: CountryConfig): string {
+  if (!config.fxCorridor) return "Not specifically covered";
+  return config.fxCorridor.eyebrow || `${config.currencySymbol} → AUD corridor available`;
+}
+
+/** Pension transfer availability label. */
+function pensionLabel(config: CountryConfig): string {
+  if (!config.retirementTransfer) return "No specific AU pension-transfer pathway";
+  return config.retirementTransfer.title.slice(0, 80);
+}
+
+/** Migration pathways label — count + first pathway. */
+function migrationLabel(config: CountryConfig): string {
+  if (!config.migration) return "Standard visa pathways — see AHC website";
+  const count = config.migration.pathways.length;
+  const first = config.migration.pathways[0];
+  return first
+    ? `${count} pathway${count !== 1 ? "s" : ""} — inc. ${first.name}`
+    : `${count} pathway${count !== 1 ? "s" : ""}`;
+}
+
+/** Reporting obligations label (FBAR/FATCA, SAFE controls, etc.). */
+function reportingLabel(config: CountryConfig): string {
+  if (!config.reportingObligations) return "Standard ATO non-resident reporting";
+  return config.reportingObligations.title;
+}
+
+// ─── Core Builder ─────────────────────────────────────────────────────────────
+
+/**
+ * Build a `CountryComparison` from two `CountryConfig` objects.
+ *
+ * Country order is normalised: A is whichever comes first alphabetically by
+ * `countryShort` so a-vs-b and b-vs-a produce identical output.
+ */
+export function buildCountryComparison(
+  cfgX: CountryConfig,
+  cfgY: CountryConfig,
+): CountryComparison {
+  // Canonical order: alphabetical by short name
+  const [cfgA, cfgB] =
+    cfgX.countryShort.localeCompare(cfgY.countryShort) <= 0
+      ? [cfgX, cfgY]
+      : [cfgY, cfgX];
+
+  const metaA = intentCountryMeta(cfgA.code);
+  const metaB = intentCountryMeta(cfgB.code);
+  const dtaA = metaA.hasDta;
+  const dtaB = metaB.hasDta;
+
+  const rows: CompareRow[] = [
+    {
+      dimension: "Double Tax Agreement (DTA) with Australia",
+      valueA: dtaA ? `Yes — ${cfgA.dta.title.slice(0, 60)}` : "No DTA",
+      valueB: dtaB ? `Yes — ${cfgB.dta.title.slice(0, 60)}` : "No DTA",
+      note:
+        "A DTA reduces Australian withholding tax on dividends, interest, and royalties. Without a DTA, standard ATO rates apply (30% unfranked dividends, 30% royalties).",
+    },
+    {
+      dimension: "Unfranked dividend withholding tax (AU)",
+      valueA: dividendRate(cfgA, dtaA),
+      valueB: dividendRate(cfgB, dtaB),
+      note:
+        "Fully franked dividends carry an attached imputation credit and are generally 0% WHT regardless of DTA. Rate shown is for unfranked dividends.",
+    },
+    {
+      dimension: "Interest withholding tax (AU)",
+      valueA: interestRate(cfgA, dtaA),
+      valueB: interestRate(cfgB, dtaB),
+      note:
+        "Standard ATO rate for non-residents on Australian interest income is 10%. Some DTAs keep this at 10%; others may vary.",
+    },
+    {
+      dimension: "Royalties withholding tax (AU)",
+      valueA: royaltiesRate(cfgA, dtaA),
+      valueB: royaltiesRate(cfgB, dtaB),
+      note:
+        "Without a DTA, royalties are taxed at 30% in Australia. DTA rates are typically 5%–10%. Applies to intellectual property and licensing income sourced in Australia.",
+    },
+    {
+      dimension: "FIRB approval required for AU property",
+      valueA: firbRequired(cfgA),
+      valueB: firbRequired(cfgB),
+      note:
+        "FIRB (Foreign Investment Review Board) approval is generally required for non-residents purchasing Australian property. NZ citizens under the Trans-Tasman arrangement are exempt.",
+    },
+    {
+      dimension: "Established dwelling ban (2025–2027)",
+      valueA: dwellingBan(cfgA),
+      valueB: dwellingBan(cfgB),
+      note:
+        "The Australian Government banned foreign persons from purchasing existing (established) dwellings from 1 April 2025 to 31 March 2027. New dwellings, off-the-plan, and commercial property remain available.",
+    },
+    {
+      dimension: "FX corridor to AUD",
+      valueA: fxLabel(cfgA),
+      valueB: fxLabel(cfgB),
+      note:
+        "FX corridors vary by volume and competitive pressure. Specialist FX providers typically offer 2–4% better rates than retail bank wire transfers for large sums.",
+    },
+    {
+      dimension: "Pension / super transfer pathway",
+      valueA: pensionLabel(cfgA),
+      valueB: pensionLabel(cfgB),
+      note:
+        "Overseas pension transfers to Australian super are generally restricted. UK has a specific QROPS pathway; NZ has a KiwiSaver-to-super exemption. Most other countries have no direct transfer pathway — lump-sum withdrawal and re-contribution rules apply.",
+    },
+    {
+      dimension: "AU migration pathways",
+      valueA: migrationLabel(cfgA),
+      valueB: migrationLabel(cfgB),
+      note:
+        "Visa pathway availability affects tax residency timing, FIRB exemption eligibility, and super access. Permanent residency removes FIRB requirements.",
+    },
+    {
+      dimension: "Cross-border reporting obligations",
+      valueA: reportingLabel(cfgA),
+      valueB: reportingLabel(cfgB),
+      note:
+        "Reporting obligations vary significantly. US persons face FBAR/FATCA; Chinese residents face SAFE controls. All non-residents must report Australian income in their home country per local tax law.",
+    },
+  ];
+
+  // Surface critical warnings from both configs
+  const warnings: { country: string; title: string; body: string }[] = [];
+  if (cfgA.criticalWarning) {
+    warnings.push({
+      country: cfgA.countryShort,
+      title: cfgA.criticalWarning.title,
+      body: cfgA.criticalWarning.body,
+    });
+  }
+  if (cfgB.criticalWarning) {
+    warnings.push({
+      country: cfgB.countryShort,
+      title: cfgB.criticalWarning.title,
+      body: cfgB.criticalWarning.body,
+    });
+  }
+
+  const pairSlug = `${cfgA.slug}-vs-${cfgB.slug}`;
+
+  return {
+    pairSlug,
+    countryA: {
+      code: cfgA.code,
+      name: cfgA.countryName,
+      short: cfgA.countryShort,
+      flag: cfgA.flag,
+      currency: cfgA.currency,
+      slug: cfgA.slug,
+      hasDta: dtaA,
+    },
+    countryB: {
+      code: cfgB.code,
+      name: cfgB.countryName,
+      short: cfgB.countryShort,
+      flag: cfgB.flag,
+      currency: cfgB.currency,
+      slug: cfgB.slug,
+      hasDta: dtaB,
+    },
+    rows,
+    warnings,
+    hasPensionTransfer: Boolean(cfgA.retirementTransfer ?? cfgB.retirementTransfer),
+    hasFxCorridor: Boolean(cfgA.fxCorridor ?? cfgB.fxCorridor),
+    bothHaveDta: dtaA && dtaB,
+  };
+}
+
+// ─── Static Params ─────────────────────────────────────────────────────────
+
+/**
+ * All deduplicated country pairs for `generateStaticParams`.
+ *
+ * Pairs are canonical (A before B alphabetically by countryShort), so
+ * uk-vs-us is generated but NOT us-vs-uk. The route handler canonicalises
+ * any reverse-order slug via redirect.
+ *
+ * With 12 hub countries: C(12,2) = 66 unique pairs.
+ */
+export function allComparePairs(): ReadonlyArray<{
+  pair: string;
+  codeA: IntentCountryCode;
+  codeB: IntentCountryCode;
+}> {
+  const codes = Object.keys(COUNTRY_CONFIGS) as IntentCountryCode[];
+  const pairs: { pair: string; codeA: IntentCountryCode; codeB: IntentCountryCode }[] = [];
+
+  for (let i = 0; i < codes.length; i++) {
+    for (let j = i + 1; j < codes.length; j++) {
+      const codeX = codes[i]!;
+      const codeY = codes[j]!;
+      const cfgX = COUNTRY_CONFIGS[codeX];
+      const cfgY = COUNTRY_CONFIGS[codeY];
+      if (!cfgX || !cfgY) continue;
+
+      // Normalise: A = alphabetically-first short name
+      const [cfgA, cfgB] =
+        cfgX.countryShort.localeCompare(cfgY.countryShort) <= 0
+          ? [cfgX, cfgY]
+          : [cfgY, cfgX];
+
+      const codeA = cfgA.code;
+      const codeB = cfgB.code;
+
+      pairs.push({
+        pair: `${cfgA.slug}-vs-${cfgB.slug}`,
+        codeA,
+        codeB,
+      });
+    }
+  }
+
+  return pairs;
+}
+
+/**
+ * Parse a `[pair]` slug into the two CountryConfig objects.
+ *
+ * Handles canonical and reverse-order slugs — callers should redirect to
+ * canonical if `reversed` is true.
+ *
+ * Returns null if either country slug is unrecognised.
+ */
+export function parsePairSlug(pairSlug: string): {
+  cfgA: CountryConfig;
+  cfgB: CountryConfig;
+  reversed: boolean;
+  canonicalSlug: string;
+} | null {
+  const vsIdx = pairSlug.lastIndexOf("-vs-");
+  if (vsIdx === -1) return null;
+
+  const slugX = pairSlug.slice(0, vsIdx);
+  const slugY = pairSlug.slice(vsIdx + 4);
+
+  // Build slug → code map from COUNTRY_CONFIGS
+  const configs = Object.values(COUNTRY_CONFIGS).filter(Boolean) as CountryConfig[];
+  const cfgX = configs.find((c) => c.slug === slugX);
+  const cfgY = configs.find((c) => c.slug === slugY);
+
+  if (!cfgX || !cfgY) return null;
+
+  // Canonical order
+  const [cfgA, cfgB] =
+    cfgX.countryShort.localeCompare(cfgY.countryShort) <= 0
+      ? [cfgX, cfgY]
+      : [cfgY, cfgX];
+
+  const canonicalSlug = `${cfgA.slug}-vs-${cfgB.slug}`;
+  const reversed = pairSlug !== canonicalSlug;
+
+  return { cfgA, cfgB, reversed, canonicalSlug };
+}


### PR DESCRIPTION
Round-3 deepening (6 of 10). Deepens the expat/foreign-investment area with country-vs-country comparison + a DASP calculator + a persona router. Factual + flat-fee referral; disclaimers on every surface (AFSL-safe).

- `lib/country-compare.ts` — pure engine extracting 10 structured dimensions (DTA status, dividend/interest/royalty WHT, FIRB requirement, established-dwelling ban, FX corridor, pension transfer, migration, reporting) from two `CountryConfig`s; `allComparePairs()` generates the 66 canonical deduplicated C(12,2) pairs (alphabetical ordering so a-vs-b == b-vs-a); `parsePairSlug` handles reverse-order slugs.
- `/foreign-investment/compare/[pair]` (SSG) + index hub — comparison table/card-stack, critical-warning band (e.g. US FATCA), pension callout, Article + ItemList + breadcrumb JSON-LD, full FI disclaimers.
- `/tools/dasp-calculator` — interactive DASP withholding calc reusing the **existing** `lib/calculators/dasp.ts` (35%/45%/65% components + WHM), `SoftwareApplication` + FAQPage JSON-LD, `DASP_WARNING`.
- `FIPersonaRouter` on the FI hub ("moving to AU" / "leaving AU" / "non-resident investor").

**Fix on verification:** removed a dead compliance import in the DASP page (both warnings render in the client — confirmed lines 133/360 — so user-facing compliance is intact).

**Verified:** `tsc` clean · **40 tests** (27 compare: pair count/dedup/ordering, dimensions, DTA flags, FIRB NZ exemption, warnings; + 13 existing DASP calc) pass · eslint clean · jsonld gate green. Compare pages are build-time only (zero DB/RLS surface).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUfSRE2Teb6VhEXFP6RpS9)_