### PR TITLE
feat(quiz): concierge wealth-stack — super + savings + robo matching (deepen)

### DIFF
--- a/__tests__/lib/quiz-scoring-wealth-stack.test.ts
+++ b/__tests__/lib/quiz-scoring-wealth-stack.test.ts
@@ -1,0 +1,471 @@
+/**
+ * Tests for the wealth-stack per-vertical scoring extension to lib/quiz-scoring.ts.
+ *
+ * Covers:
+ *   - scoreVertical() for super_fund, savings_account, robo_advisor
+ *   - Per-vertical scoring signals (risk band, amount, horizon)
+ *   - Ranking and tiebreaker consistency
+ *   - buildStackResults() — multi-vertical orchestration
+ *   - Edge cases: no products, no inputs, single product
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  scoreVertical,
+  buildStackResults,
+  type QuizWeights,
+  type StackQuizInputs,
+  type VerticalScoredResult,
+} from "@/lib/quiz-scoring";
+import type { Broker } from "@/lib/types";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeBroker(
+  overrides: Partial<Broker> & { slug: string; name: string }
+): Broker {
+  return {
+    id: 1,
+    color: "#000",
+    chess_sponsored: false,
+    smsf_support: false,
+    is_crypto: false,
+    platform_type: "super_fund",
+    deal: false,
+    editors_pick: false,
+    status: "active",
+    created_at: "2024-01-01",
+    updated_at: "2024-01-01",
+    rating: 4.0,
+    ...overrides,
+  } as Broker;
+}
+
+function makeWeights(overrides: Partial<QuizWeights> = {}): QuizWeights {
+  return {
+    beginner: 5,
+    low_fee: 5,
+    us_shares: 5,
+    smsf: 5,
+    crypto: 5,
+    advanced: 5,
+    property: 5,
+    robo: 5,
+    ...overrides,
+  };
+}
+
+// ─── scoreVertical — super_fund ───────────────────────────────────────────────
+
+describe("scoreVertical — super_fund", () => {
+  const superBrokerA = makeBroker({
+    slug: "australian-super",
+    name: "AustralianSuper",
+    platform_type: "super_fund",
+    rating: 4.5,
+  });
+  const superBrokerB = makeBroker({
+    slug: "hostplus",
+    name: "Hostplus",
+    platform_type: "super_fund",
+    rating: 4.0,
+  });
+
+  const brokers = [superBrokerA, superBrokerB];
+  const weights: Record<string, QuizWeights> = {
+    "australian-super": makeWeights({ robo: 7, smsf: 5, low_fee: 8 }),
+    hostplus: makeWeights({ robo: 6, smsf: 6, low_fee: 9 }),
+  };
+
+  it("returns results for super_fund kind", () => {
+    const results = scoreVertical("super_fund", brokers, weights, {});
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.every(r => r.kind === "super_fund")).toBe(true);
+  });
+
+  it("returns at most `limit` results (default 3)", () => {
+    const results = scoreVertical("super_fund", brokers, weights, {});
+    expect(results.length).toBeLessThanOrEqual(3);
+  });
+
+  it("respects explicit limit parameter", () => {
+    const results = scoreVertical("super_fund", brokers, weights, {}, 1);
+    expect(results).toHaveLength(1);
+  });
+
+  it("applies LARGE amount bonus so larger portfolios rank higher-quality products", () => {
+    const inputsSmall: StackQuizInputs = { amount: "small" };
+    const inputsLarge: StackQuizInputs = { amount: "large" };
+    const resultsSmall = scoreVertical("super_fund", brokers, weights, inputsSmall, 1);
+    const resultsLarge = scoreVertical("super_fund", brokers, weights, inputsLarge, 1);
+    // Large amount adds a bonus so the top score should be higher
+    expect(resultsLarge[0]!.total).toBeGreaterThan(resultsSmall[0]!.total);
+  });
+
+  it("growth risk band boosts advanced+us_shares dimension weights", () => {
+    const advancedBroker = makeBroker({
+      slug: "advanced-super",
+      name: "Advanced Super",
+      platform_type: "super_fund",
+      rating: 4.0,
+    });
+    const conservativeBroker = makeBroker({
+      slug: "conservative-super",
+      name: "Conservative Super",
+      platform_type: "super_fund",
+      rating: 4.0,
+    });
+    const testWeights: Record<string, QuizWeights> = {
+      "advanced-super": makeWeights({ advanced: 10, us_shares: 10, robo: 5, smsf: 5 }),
+      "conservative-super": makeWeights({ advanced: 2, us_shares: 2, robo: 5, smsf: 5 }),
+    };
+    const results = scoreVertical(
+      "super_fund",
+      [advancedBroker, conservativeBroker],
+      testWeights,
+      { riskBand: "growth" },
+    );
+    // Growth risk band should reward advanced+us_shares — advanced-super should rank first
+    expect(results[0]!.slug).toBe("advanced-super");
+  });
+
+  it("conservative risk band boosts low_fee dimension", () => {
+    const lowFeeBroker = makeBroker({
+      slug: "low-fee-super",
+      name: "Low Fee Super",
+      platform_type: "super_fund",
+      rating: 4.0,
+    });
+    const highFeeBroker = makeBroker({
+      slug: "high-fee-super",
+      name: "High Fee Super",
+      platform_type: "super_fund",
+      rating: 4.0,
+    });
+    const testWeights: Record<string, QuizWeights> = {
+      "low-fee-super": makeWeights({ low_fee: 10, smsf: 3, robo: 5 }),
+      "high-fee-super": makeWeights({ low_fee: 2, smsf: 3, robo: 5 }),
+    };
+    const results = scoreVertical(
+      "super_fund",
+      [lowFeeBroker, highFeeBroker],
+      testWeights,
+      { riskBand: "conservative" },
+    );
+    expect(results[0]!.slug).toBe("low-fee-super");
+  });
+
+  it("returns empty array when brokers list is empty", () => {
+    const results = scoreVertical("super_fund", [], {}, {});
+    expect(results).toHaveLength(0);
+  });
+
+  it("returns empty array when weights map is empty (no matching slugs)", () => {
+    const results = scoreVertical("super_fund", brokers, {}, {});
+    // No weights entries → empty scored list
+    expect(results).toHaveLength(0);
+  });
+
+  it("attaches the broker object to each result", () => {
+    const results = scoreVertical("super_fund", brokers, weights, {});
+    for (const r of results) {
+      if (r.broker) {
+        expect(["australian-super", "hostplus"]).toContain(r.broker.slug);
+      }
+    }
+  });
+
+  it("sorts results by total score DESC", () => {
+    const results = scoreVertical("super_fund", brokers, weights, { amount: "large" });
+    for (let i = 0; i < results.length - 1; i++) {
+      expect(results[i]!.total).toBeGreaterThanOrEqual(results[i + 1]!.total);
+    }
+  });
+
+  it("uses rating as tiebreaker when scores are equal", () => {
+    const brokerHigh = makeBroker({ slug: "high-rating", name: "High Rating", platform_type: "super_fund", rating: 4.8 });
+    const brokerLow  = makeBroker({ slug: "low-rating",  name: "Low Rating",  platform_type: "super_fund", rating: 3.5 });
+    const equalWeights: Record<string, QuizWeights> = {
+      "high-rating": makeWeights({ robo: 5, smsf: 5 }),
+      "low-rating":  makeWeights({ robo: 5, smsf: 5 }),
+    };
+    const results = scoreVertical("super_fund", [brokerHigh, brokerLow], equalWeights, {});
+    // Equal base scores — rating nudge: high-rating gets 1 + (4.8 - 4) * 0.1 = 1.08 multiplier
+    expect(results[0]!.slug).toBe("high-rating");
+  });
+});
+
+// ─── scoreVertical — robo_advisor ────────────────────────────────────────────
+
+describe("scoreVertical — robo_advisor", () => {
+  const stockspot = makeBroker({
+    slug: "stockspot",
+    name: "Stockspot",
+    platform_type: "robo_advisor",
+    rating: 4.6,
+  });
+  const raiz = makeBroker({
+    slug: "raiz",
+    name: "Raiz",
+    platform_type: "robo_advisor",
+    rating: 4.0,
+  });
+
+  const brokers = [stockspot, raiz];
+  const weights: Record<string, QuizWeights> = {
+    stockspot: makeWeights({ robo: 10, beginner: 7, low_fee: 5 }),
+    raiz:      makeWeights({ robo: 9,  beginner: 9, low_fee: 7 }),
+  };
+
+  it("returns results for robo_advisor kind", () => {
+    const results = scoreVertical("robo_advisor", brokers, weights, {});
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.every(r => r.kind === "robo_advisor")).toBe(true);
+  });
+
+  it("conservative risk band gives robo a large bonus (conservative → highest robo bonus)", () => {
+    const resultsConservative = scoreVertical("robo_advisor", brokers, weights, { riskBand: "conservative" });
+    const resultsGrowth       = scoreVertical("robo_advisor", brokers, weights, { riskBand: "growth" });
+    // Conservative has robo bonus = 5, growth has robo bonus = 3
+    // Conservative should produce higher totals
+    expect(resultsConservative[0]!.total).toBeGreaterThan(resultsGrowth[0]!.total);
+  });
+
+  it("robo score is based primarily on robo weight (1.5× coefficient)", () => {
+    const highRoboBroker = makeBroker({ slug: "high-robo", name: "High Robo", platform_type: "robo_advisor", rating: 4.0 });
+    const lowRoboBroker  = makeBroker({ slug: "low-robo",  name: "Low Robo",  platform_type: "robo_advisor", rating: 4.0 });
+    const testWeights: Record<string, QuizWeights> = {
+      "high-robo": makeWeights({ robo: 10, beginner: 5 }),
+      "low-robo":  makeWeights({ robo: 3,  beginner: 5 }),
+    };
+    const results = scoreVertical("robo_advisor", [highRoboBroker, lowRoboBroker], testWeights, {});
+    expect(results[0]!.slug).toBe("high-robo");
+  });
+
+  it("returns empty array for empty broker list", () => {
+    const results = scoreVertical("robo_advisor", [], {}, {});
+    expect(results).toHaveLength(0);
+  });
+});
+
+// ─── scoreVertical — savings_account ─────────────────────────────────────────
+
+describe("scoreVertical — savings_account", () => {
+  const ubank = makeBroker({
+    slug: "ubank",
+    name: "UBank",
+    platform_type: "savings_account",
+    rating: 4.3,
+  });
+  const macquarie = makeBroker({
+    slug: "macquarie-savings",
+    name: "Macquarie Savings",
+    platform_type: "savings_account",
+    rating: 4.5,
+  });
+
+  const brokers = [ubank, macquarie];
+  const weights: Record<string, QuizWeights> = {
+    ubank:              makeWeights({ low_fee: 9, smsf: 4, beginner: 8 }),
+    "macquarie-savings": makeWeights({ low_fee: 8, smsf: 6, beginner: 6 }),
+  };
+
+  it("returns results for savings_account kind", () => {
+    const results = scoreVertical("savings_account", brokers, weights, {});
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.every(r => r.kind === "savings_account")).toBe(true);
+  });
+
+  it("short horizon boosts low_fee weight heavily for savings", () => {
+    const lowFeeBroker  = makeBroker({ slug: "low-fee-sav",  name: "Low Fee Savings",  platform_type: "savings_account", rating: 4.0 });
+    const highFeeBroker = makeBroker({ slug: "high-fee-sav", name: "High Fee Savings", platform_type: "savings_account", rating: 4.0 });
+    const testWeights: Record<string, QuizWeights> = {
+      "low-fee-sav":  makeWeights({ low_fee: 10, smsf: 3 }),
+      "high-fee-sav": makeWeights({ low_fee: 2,  smsf: 3 }),
+    };
+    const results = scoreVertical(
+      "savings_account",
+      [lowFeeBroker, highFeeBroker],
+      testWeights,
+      { horizon: "short" },
+    );
+    expect(results[0]!.slug).toBe("low-fee-sav");
+  });
+
+  it("returns empty array for empty broker list", () => {
+    const results = scoreVertical("savings_account", [], {}, {});
+    expect(results).toHaveLength(0);
+  });
+
+  it("amount multiplier scales all savings scores", () => {
+    const resultsSmall = scoreVertical("savings_account", brokers, weights, { amount: "small" });
+    const resultsWhale = scoreVertical("savings_account", brokers, weights, { amount: "whale" });
+    // Whale multiplier (1.2) > small (0.9)
+    expect(resultsWhale[0]!.total).toBeGreaterThan(resultsSmall[0]!.total);
+  });
+});
+
+// ─── buildStackResults ────────────────────────────────────────────────────────
+
+describe("buildStackResults", () => {
+  const superBroker = makeBroker({
+    slug: "aware-super",
+    name: "Aware Super",
+    platform_type: "super_fund",
+    rating: 4.5,
+  });
+  const savingsBroker = makeBroker({
+    slug: "ing-savings",
+    name: "ING Savings",
+    platform_type: "savings_account",
+    rating: 4.2,
+  });
+  const roboBroker = makeBroker({
+    slug: "stockspot",
+    name: "Stockspot",
+    platform_type: "robo_advisor",
+    rating: 4.6,
+  });
+
+  const superWeights: Record<string, QuizWeights> = {
+    "aware-super": makeWeights({ robo: 7, smsf: 7 }),
+  };
+  const savingsWeights: Record<string, QuizWeights> = {
+    "ing-savings": makeWeights({ low_fee: 9 }),
+  };
+  const roboWeights: Record<string, QuizWeights> = {
+    stockspot: makeWeights({ robo: 10 }),
+  };
+
+  it("returns results for all three kinds when all slices are provided", () => {
+    const stack = buildStackResults({
+      inputs: { amount: "medium", riskBand: "balanced" },
+      perKind: {
+        super_fund:     { brokers: [superBroker],   weights: superWeights },
+        savings_account: { brokers: [savingsBroker], weights: savingsWeights },
+        robo_advisor:   { brokers: [roboBroker],     weights: roboWeights },
+      },
+    });
+    expect(stack.super_fund).toBeDefined();
+    expect(stack.savings_account).toBeDefined();
+    expect(stack.robo_advisor).toBeDefined();
+  });
+
+  it("omits kinds with no brokers", () => {
+    const stack = buildStackResults({
+      inputs: { amount: "medium" },
+      perKind: {
+        super_fund: { brokers: [superBroker], weights: superWeights },
+        // savings_account and robo_advisor not supplied
+      },
+    });
+    expect(stack.super_fund).toBeDefined();
+    expect(stack.savings_account).toBeUndefined();
+    expect(stack.robo_advisor).toBeUndefined();
+  });
+
+  it("returns empty object when no perKind slices are provided", () => {
+    const stack = buildStackResults({ inputs: {}, perKind: {} });
+    expect(Object.keys(stack)).toHaveLength(0);
+  });
+
+  it("respects the limit parameter per vertical", () => {
+    const superBrokerB = makeBroker({ slug: "hostplus", name: "Hostplus", platform_type: "super_fund", rating: 4.0 });
+    const stack = buildStackResults({
+      inputs: {},
+      perKind: {
+        super_fund: {
+          brokers: [superBroker, superBrokerB],
+          weights: {
+            ...superWeights,
+            hostplus: makeWeights({ robo: 6, smsf: 6 }),
+          },
+        },
+      },
+      limit: 1,
+    });
+    expect(stack.super_fund!.length).toBe(1);
+  });
+
+  it("each result carries the correct kind label", () => {
+    const stack = buildStackResults({
+      inputs: {},
+      perKind: {
+        super_fund:      { brokers: [superBroker],   weights: superWeights },
+        savings_account: { brokers: [savingsBroker], weights: savingsWeights },
+        robo_advisor:    { brokers: [roboBroker],    weights: roboWeights },
+      },
+    });
+    expect(stack.super_fund!.every((r: VerticalScoredResult) => r.kind === "super_fund")).toBe(true);
+    expect(stack.savings_account!.every((r: VerticalScoredResult) => r.kind === "savings_account")).toBe(true);
+    expect(stack.robo_advisor!.every((r: VerticalScoredResult) => r.kind === "robo_advisor")).toBe(true);
+  });
+
+  it("works with no inputs (undefined fields are graceful no-ops)", () => {
+    // Should not throw — all bonuses default to 0
+    expect(() =>
+      buildStackResults({
+        inputs: {},
+        perKind: {
+          super_fund: { brokers: [superBroker], weights: superWeights },
+        },
+      })
+    ).not.toThrow();
+  });
+
+  it("returns the top-scoring product in each vertical", () => {
+    const weakSuper = makeBroker({ slug: "weak-super", name: "Weak Super", platform_type: "super_fund", rating: 3.5 });
+    const stack = buildStackResults({
+      inputs: { riskBand: "growth", amount: "large" },
+      perKind: {
+        super_fund: {
+          brokers: [superBroker, weakSuper],
+          weights: {
+            "aware-super": makeWeights({ robo: 10, smsf: 10 }),
+            "weak-super":  makeWeights({ robo: 2,  smsf: 2  }),
+          },
+        },
+      },
+      limit: 1,
+    });
+    expect(stack.super_fund![0]!.slug).toBe("aware-super");
+  });
+});
+
+// ─── Cross-vertical scoring symmetry ─────────────────────────────────────────
+
+describe("scoreVertical — cross-vertical symmetry", () => {
+  it("whale amount scores higher than small amount across all verticals", () => {
+    // The amount multiplier (whale=1.2 vs small=0.9) means whale-portfolio users
+    // always score the same products higher. For super, there's also an additional
+    // amount bonus, so the ratio is even larger — we just verify whale > small.
+    for (const kind of ["super_fund", "savings_account", "robo_advisor"] as const) {
+      const broker = makeBroker({ slug: "test", name: "Test", platform_type: kind });
+      const weights = { test: makeWeights({ robo: 10, smsf: 10, low_fee: 10, beginner: 10 }) };
+
+      const smallResult = scoreVertical(kind, [broker], weights, { amount: "small" });
+      const whaleResult = scoreVertical(kind, [broker], weights, { amount: "whale" });
+
+      expect(whaleResult[0]!.total).toBeGreaterThan(smallResult[0]!.total);
+    }
+  });
+
+  it("all three verticals return VerticalScoredResult shape (slug, total, kind)", () => {
+    const kinds: Array<"super_fund" | "savings_account" | "robo_advisor"> = [
+      "super_fund",
+      "savings_account",
+      "robo_advisor",
+    ];
+    for (const kind of kinds) {
+      const broker = makeBroker({ slug: "b", name: "B", platform_type: kind });
+      const weights = { b: makeWeights({ robo: 8, low_fee: 6, smsf: 5, beginner: 5 }) };
+      const results = scoreVertical(kind, [broker], weights, {});
+      const r = results[0];
+      if (r) {
+        expect(typeof r.slug).toBe("string");
+        expect(typeof r.total).toBe("number");
+        expect(r.kind).toBe(kind);
+      }
+    }
+  });
+});

--- a/app/quiz/_components/QuizResultsScreen.tsx
+++ b/app/quiz/_components/QuizResultsScreen.tsx
@@ -17,6 +17,7 @@ import QuizNextBestActions from "./QuizNextBestActions";
 import QuizPrimaryActionHero from "./QuizPrimaryActionHero";
 import QuizInlineEmailCapture from "./QuizInlineEmailCapture";
 import { resolveBestOutcome } from "@/lib/quiz-outcome";
+import type { VerticalScoredResult, StackQuizInputs } from "@/lib/quiz-scoring";
 
 interface ScoredResult {
   slug: string;
@@ -39,6 +40,10 @@ interface Props {
       the win first, then get nudged to capture (warm conversion). */
   onEmailCaptureSubmit: (email: string, name: string) => Promise<void> | void;
   emailCaptureStatus: "idle" | "loading" | "submitted" | "error";
+  /** Wealth-stack per-vertical results (populated when stack questions answered). */
+  stackResults?: Partial<Record<"super_fund" | "savings_account" | "robo_advisor", VerticalScoredResult[]>>;
+  /** Stack inputs used to build the vertical results — for rendering context labels. */
+  stackInputs?: StackQuizInputs;
 }
 
 export default function QuizResultsScreen({
@@ -54,6 +59,8 @@ export default function QuizResultsScreen({
   getMatchReasons,
   onEmailCaptureSubmit,
   emailCaptureStatus,
+  stackResults,
+  stackInputs,
 }: Props) {
   const topMatch = results[0];
   const runnerUps = results.slice(1);
@@ -198,6 +205,14 @@ export default function QuizResultsScreen({
             Now sits below the top match so the user sees the answer first, then
             the broader "broker + super + savings + tax" framing. */}
         <ThreadCardsStrip answers={unifiedAnswers} />
+
+        {/* Wealth-stack vertical picks — only shown when the quiz gathered
+            stack signals (risk band, super/savings interest). Each card is a
+            factual criteria match presented with the general-advice disclaimer.
+            NOT personal advice — factual matching based on stated criteria. */}
+        {stackResults && Object.keys(stackResults).length > 0 && (
+          <WealthStackStrip stackResults={stackResults} stackInputs={stackInputs} />
+        )}
 
         {/* Quick Comparison Table — only for outcomes that surface broker results */}
         {showBrokerResults && <QuizComparisonTable allResults={allResults} />}
@@ -431,5 +446,158 @@ export default function QuizResultsScreen({
         />
       </div>
     </div>
+  );
+}
+
+// ─── WealthStackStrip ─────────────────────────────────────────────────────
+// Renders the matched super, savings, and robo picks as a factual stack
+// below the main broker results. Each card includes the general-advice
+// disclaimer and a referral CTA to the product's review / comparison page.
+//
+// AFSL compliance: presented as "products that match your stated criteria"
+// (factual) not "the right product for you" (personal advice). The disclaimer
+// is unconditionally visible on every card.
+
+const VERTICAL_META: Record<
+  "super_fund" | "savings_account" | "robo_advisor",
+  { label: string; icon: string; colorClass: string; reviewBase: string; comparisonHref: string; description: string }
+> = {
+  super_fund: {
+    label: "Super fund",
+    icon: "landmark",
+    colorClass: "bg-blue-50 text-blue-700 border-blue-200",
+    reviewBase: "/broker",
+    comparisonHref: "/super",
+    description: "Where your compulsory retirement contributions grow. Matched to your risk band and balance.",
+  },
+  savings_account: {
+    label: "Savings account",
+    icon: "piggy-bank",
+    colorClass: "bg-emerald-50 text-emerald-700 border-emerald-200",
+    reviewBase: "/broker",
+    comparisonHref: "/savings",
+    description: "High-interest account for cash you'll need within 1–5 years. Matched to your time horizon.",
+  },
+  robo_advisor: {
+    label: "Robo-advisor",
+    icon: "cpu",
+    colorClass: "bg-violet-50 text-violet-700 border-violet-200",
+    reviewBase: "/broker",
+    comparisonHref: "/robo-advisors",
+    description: "Automated, diversified portfolio. Rebalances itself — matched to your risk tolerance.",
+  },
+};
+
+interface WealthStackStripProps {
+  stackResults: Partial<Record<"super_fund" | "savings_account" | "robo_advisor", VerticalScoredResult[]>>;
+  stackInputs?: StackQuizInputs;
+}
+
+function WealthStackStrip({ stackResults }: WealthStackStripProps) {
+  const entries = (Object.entries(stackResults) as [
+    "super_fund" | "savings_account" | "robo_advisor",
+    VerticalScoredResult[]
+  ][]).filter(([, items]) => items.length > 0);
+
+  if (entries.length === 0) return null;
+
+  return (
+    <section
+      aria-labelledby="wealth-stack-heading"
+      className="mb-4 md:mb-6 result-card-in result-card-in-delay-2"
+    >
+      <div className="text-center mb-3 md:mb-4">
+        <p className="text-[0.58rem] md:text-[0.62rem] font-bold uppercase tracking-wider text-violet-600 mb-1">
+          Your wealth stack
+        </p>
+        <h2
+          id="wealth-stack-heading"
+          className="text-base md:text-xl font-extrabold text-slate-900"
+        >
+          Beyond the broker — your full stack
+        </h2>
+        <p className="text-[0.69rem] md:text-sm text-slate-500 mt-1">
+          Based on your risk profile and preferences. General information only — not personal advice.
+        </p>
+      </div>
+
+      <div className="space-y-2.5 md:space-y-3">
+        {entries.map(([kind, items]) => {
+          const meta = VERTICAL_META[kind];
+          const top = items[0];
+          if (!top?.broker) return null;
+
+          return (
+            <div
+              key={kind}
+              className="bg-white border border-slate-200 rounded-xl p-3.5 md:p-4"
+            >
+              {/* Header row */}
+              <div className="flex items-start gap-3 mb-2">
+                <div className={`w-9 h-9 rounded-lg flex items-center justify-center shrink-0 border ${meta.colorClass}`}>
+                  <Icon name={meta.icon} size={18} />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <p className="text-[0.58rem] md:text-[0.62rem] font-bold uppercase tracking-wider text-slate-400 mb-0.5">
+                    {meta.label}
+                  </p>
+                  <h3 className="text-sm md:text-base font-bold text-slate-900 leading-tight">
+                    {top.broker.name}
+                  </h3>
+                  {top.broker.tagline && (
+                    <p className="text-[0.65rem] md:text-xs text-slate-500 mt-0.5">{top.broker.tagline}</p>
+                  )}
+                </div>
+                {top.broker.rating && (
+                  <div className="shrink-0 text-right">
+                    <span className="text-xs font-bold text-amber-600">{top.broker.rating.toFixed(1)}</span>
+                    <span className="text-[0.62rem] text-slate-400">/5</span>
+                  </div>
+                )}
+              </div>
+
+              {/* Description */}
+              <p className="text-[0.65rem] md:text-xs text-slate-500 mb-2.5 leading-relaxed">
+                {meta.description}
+              </p>
+
+              {/* Disclaimer — always visible per AFSL compliance */}
+              <p className="text-[0.58rem] md:text-[0.62rem] text-amber-700 bg-amber-50 border border-amber-200 rounded-lg px-2 py-1 mb-2.5 leading-relaxed">
+                <strong>General information only.</strong> This match is based on your stated criteria — not personal financial advice. Read the PDS/TMD before opening an account.
+              </p>
+
+              {/* CTAs */}
+              <div className="flex flex-wrap gap-2">
+                <Link
+                  href={`${meta.reviewBase}/${top.broker.slug}`}
+                  onClick={() => trackEvent("quiz_stack_review_click", { kind, slug: top.slug }, "/quiz")}
+                  className="text-[0.65rem] md:text-xs font-semibold text-slate-600 hover:text-slate-900 underline-offset-2 hover:underline"
+                >
+                  Read full review
+                </Link>
+                <Link
+                  href={meta.comparisonHref}
+                  onClick={() => trackEvent("quiz_stack_compare_click", { kind }, "/quiz")}
+                  className="text-[0.65rem] md:text-xs font-semibold text-slate-500 hover:text-slate-700"
+                >
+                  Compare all →
+                </Link>
+                {top.broker.affiliate_url && (
+                  <a
+                    href={top.broker.affiliate_url}
+                    target="_blank"
+                    rel="noopener noreferrer sponsored"
+                    onClick={() => trackEvent("quiz_stack_cta_click", { kind, slug: top.slug }, "/quiz")}
+                    className="ml-auto px-3 py-1.5 bg-violet-600 text-white text-[0.65rem] md:text-xs font-bold rounded-lg hover:bg-violet-700 transition-colors"
+                  >
+                    {top.broker.benefit_cta ?? top.broker.cta_text ?? "Visit site"} →
+                  </a>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </section>
   );
 }

--- a/app/quiz/_components/QuizResultsScreen.tsx
+++ b/app/quiz/_components/QuizResultsScreen.tsx
@@ -104,12 +104,12 @@ export default function QuizResultsScreen({
             >
               Retake Quiz
             </button>
-            <a
+            <Link
               href="/compare"
               className="px-5 py-2.5 border border-slate-300 text-slate-700 text-sm font-semibold rounded-lg hover:bg-slate-50 transition-colors"
             >
               Browse All Platforms
-            </a>
+            </Link>
           </div>
         </div>
       </div>

--- a/app/quiz/page.tsx
+++ b/app/quiz/page.tsx
@@ -6,7 +6,7 @@ import { trackEvent } from "@/lib/tracking";
 import { trackEvent as phTrack } from "@/lib/posthog/events";
 import { storeQualificationData } from "@/lib/qualification-store";
 import { getPlacementWinners, type PlacementWinner } from "@/lib/sponsorship";
-import { scoreQuizResults, type WeightKey, type QuizWeights, type AmountKey } from "@/lib/quiz-scoring";
+import { scoreQuizResults, type WeightKey, type QuizWeights, type AmountKey, buildStackResults, type StackQuizInputs, type VerticalScoredResult } from "@/lib/quiz-scoring";
 import { intentCountryFromSlug, quizKeyForIntentCode } from "@/lib/intent-context";
 
 import QuizQuestionScreen from "./_components/QuizQuestionScreen";
@@ -15,7 +15,7 @@ import QuizResultsScreen from "./_components/QuizResultsScreen";
 import AdvisorResultsScreen from "./_components/AdvisorResultsScreen";
 
 /* ─── Types ─── */
-type QuestionId = "location" | "goal" | "mode" | "experience" | "complexity" | "amount" | "priority" | "advisor_type" | "property_sub" | "investor_country" | "visa_status" | "investor_goal_intl";
+type QuestionId = "location" | "goal" | "mode" | "experience" | "complexity" | "amount" | "priority" | "advisor_type" | "property_sub" | "investor_country" | "visa_status" | "investor_goal_intl" | "stack_risk" | "stack_super" | "stack_savings";
 type QuizTrack = "diy" | "advisor" | "international";
 // "email-gate" phase removed — capture is now inline in the results screen
 // so users see the value before being asked. Was a 20-40% drop-off tax.
@@ -34,6 +34,10 @@ interface UnifiedAnswers {
   investor_country?: string;
   visa_status?: string;
   investor_goal_intl?: string;
+  // Wealth-stack questions (optional, appended to DIY track)
+  stack_risk?: string;
+  stack_super?: string;
+  stack_savings?: string;
 }
 
 interface QuizWeight {
@@ -173,6 +177,32 @@ const UNIFIED_QUESTIONS: Record<QuestionId, { text: string; options: { key: stri
       { key: "property-super", label: "Use super for property (SMSF)", sub: "Self-managed super fund property strategy" },
     ],
   },
+  // ─── Wealth-stack supplementary questions (DIY track only) ───────────
+  // Three quick optional questions appended after `priority` for DIY users.
+  // They feed the vertical scoring engine (super, savings, robo) without
+  // extending the main quiz flow for advisor/international users.
+  stack_risk: {
+    text: "How would you describe your risk tolerance?",
+    options: [
+      { key: "conservative", label: "Conservative",   sub: "I prefer stability — lower returns are fine to avoid big swings", emoji: "🛡️" },
+      { key: "balanced",     label: "Balanced",       sub: "Comfortable with some ups and downs over the medium term",        emoji: "⚖️" },
+      { key: "growth",       label: "Growth",         sub: "Happy to ride volatility for higher long-term returns",           emoji: "🚀" },
+    ],
+  },
+  stack_super: {
+    text: "Do you want a super fund recommendation in your results?",
+    options: [
+      { key: "super_yes",    label: "Yes — show me a top fund",       sub: "We'll match a super fund to your risk profile and balance",   emoji: "🏦" },
+      { key: "super_no",     label: "Not right now",                  sub: "Skip super — focus on investing platforms",                  emoji: "➡️" },
+    ],
+  },
+  stack_savings: {
+    text: "Want a high-interest savings account in your stack?",
+    options: [
+      { key: "savings_yes",  label: "Yes — park my cash somewhere smart", sub: "Match a high-rate savings account to your time horizon",    emoji: "💰" },
+      { key: "savings_no",   label: "Not needed",                         sub: "Skip savings — I'm happy with my current setup",            emoji: "➡️" },
+    ],
+  },
 };
 
 /* ─── Navigation logic ─── */
@@ -220,9 +250,21 @@ function getNextId(id: QuestionId, a: UnifiedAnswers): QuestionId | null {
     case "amount":
       return track === "advisor" ? "advisor_type" : "priority";
     case "priority":
+      if (a.goal === "property") return "property_sub";
+      // DIY track: optional wealth-stack questions for relevant goals
+      if (shouldShowStackQuestions(a)) return "stack_risk";
+      return null;
     case "advisor_type":
       return a.goal === "property" ? "property_sub" : null;
     case "property_sub":
+      // After property sub, offer stack questions for REITs/super paths
+      if (a.property_sub !== "physical" && shouldShowStackQuestions(a)) return "stack_risk";
+      return null;
+    case "stack_risk":
+      return "stack_super";
+    case "stack_super":
+      return "stack_savings";
+    case "stack_savings":
       return null;
     // International-only questions that shouldn't appear on domestic track
     case "investor_country":
@@ -232,11 +274,24 @@ function getNextId(id: QuestionId, a: UnifiedAnswers): QuestionId | null {
   }
 }
 
+/**
+ * Decide whether to show the supplementary wealth-stack questions.
+ * Only shown on the DIY track for goals where a multi-product stack
+ * adds genuine value (not crypto-only, not active trading).
+ */
+function shouldShowStackQuestions(a: UnifiedAnswers): boolean {
+  if (a.mode === "help") return false; // advisor path
+  const stackGoals = ["grow", "income", "automate", "property", "super", "property-reit", "property-super"];
+  return a.goal ? stackGoals.includes(a.goal) : false;
+}
+
 function getTotalSteps(a: UnifiedAnswers): number {
   if (isInternational(a)) return 6; // location + country + visa + goal + amount + advisor_type
   const skipMode = a.goal === "help" || a.goal === "home";
   const hasPropertySub = a.goal === "property";
-  return 1 + (skipMode ? 4 : 5) + (hasPropertySub ? 1 : 0); // +1 for location
+  const hasStackQuestions = shouldShowStackQuestions(a) && a.mode !== "help";
+  const stackExtra = hasStackQuestions ? 3 : 0; // stack_risk + stack_super + stack_savings
+  return 1 + (skipMode ? 4 : 5) + (hasPropertySub ? 1 : 0) + stackExtra; // +1 for location
 }
 
 function inferAdvisorType(a: UnifiedAnswers): string {
@@ -424,6 +479,8 @@ export default function QuizPage() {
   const [brokers, setBrokers] = useState<Broker[]>([]);
   const [weights, setWeights] = useState<Record<string, QuizWeights>>(fallbackScores);
   const [quizCampaignWinners, setQuizCampaignWinners] = useState<PlacementWinner[]>([]);
+  // Wealth-stack per-vertical scored results (populated after DIY results phase)
+  const [stackResults, setStackResults] = useState<Partial<Record<"super_fund" | "savings_account" | "robo_advisor", VerticalScoredResult[]>>>({});
 
   const mountedRef = useRef(true);
   const questionHeadingRef = useRef<HTMLHeadingElement>(null);
@@ -534,6 +591,84 @@ export default function QuizPage() {
   }, [scoringAnswers, weights, brokers, quizCampaignWinners, answers.amount, answers.goal]);
 
   const hasCryptoResult = useMemo(() => results.some(r => r.broker?.is_crypto), [results]);
+
+  // Build wealth-stack vertical inputs from quiz answers
+  const stackInputs = useMemo((): StackQuizInputs => {
+    const riskMap: Record<string, StackQuizInputs["riskBand"]> = {
+      conservative: "conservative",
+      balanced: "balanced",
+      growth: "growth",
+    };
+    const horizonMap: Record<string, StackQuizInputs["horizon"]> = {
+      small: "short",
+      medium: "mid",
+      large: "long",
+      xlarge: "long",
+      whale: "long",
+    };
+    return {
+      amount: answers.amount as AmountKey | undefined,
+      riskBand: answers.stack_risk ? riskMap[answers.stack_risk] : undefined,
+      horizon: answers.amount ? horizonMap[answers.amount] : undefined,
+      superInterest: answers.stack_super === "super_yes" || answers.goal === "super",
+      roboInterest: answers.goal === "automate",
+      savingsInterest: answers.stack_savings === "savings_yes",
+      goal: answers.goal,
+    };
+  }, [answers]);
+
+  // Compute wealth-stack vertical results (memoised)
+  useEffect(() => {
+    if (phase !== "diy-results" && phase !== "analyzing") return;
+    const superInterest = stackInputs.superInterest ?? false;
+    const savingsInterest = stackInputs.savingsInterest ?? false;
+    const roboInterest = stackInputs.roboInterest ?? (answers.goal === "automate");
+
+    // Build per-kind slices from the same broker + weights data
+    const perKind: Parameters<typeof buildStackResults>[0]["perKind"] = {};
+
+    if (superInterest || answers.goal === "super" || answers.goal === "grow") {
+      const superBrokers = brokers.filter(b => b.platform_type === "super_fund");
+      if (superBrokers.length > 0) {
+        const superWeights: Record<string, QuizWeights> = {};
+        for (const b of superBrokers) {
+          superWeights[b.slug] = weights[b.slug] ?? fallbackScores[b.slug] ?? {
+            beginner: 5, low_fee: 5, us_shares: 0, smsf: 7, crypto: 0, advanced: 3, property: 3, robo: 7,
+          };
+        }
+        perKind["super_fund"] = { brokers: superBrokers, weights: superWeights };
+      }
+    }
+
+    if (savingsInterest || answers.amount === "small" || answers.goal === "property") {
+      const savingsBrokers = brokers.filter(b => b.platform_type === "savings_account" || b.platform_type === "term_deposit");
+      if (savingsBrokers.length > 0) {
+        const savingsWeights: Record<string, QuizWeights> = {};
+        for (const b of savingsBrokers) {
+          savingsWeights[b.slug] = weights[b.slug] ?? fallbackScores[b.slug] ?? {
+            beginner: 6, low_fee: 8, us_shares: 0, smsf: 3, crypto: 0, advanced: 2, property: 0, robo: 3,
+          };
+        }
+        perKind["savings_account"] = { brokers: savingsBrokers, weights: savingsWeights };
+      }
+    }
+
+    if (roboInterest || answers.goal === "automate") {
+      const roboBrokers = brokers.filter(b => b.platform_type === "robo_advisor");
+      if (roboBrokers.length > 0) {
+        const roboWeights: Record<string, QuizWeights> = {};
+        for (const b of roboBrokers) {
+          roboWeights[b.slug] = weights[b.slug] ?? fallbackScores[b.slug] ?? {
+            beginner: 8, low_fee: 6, us_shares: 3, smsf: 3, crypto: 0, advanced: 2, property: 2, robo: 9,
+          };
+        }
+        perKind["robo_advisor"] = { brokers: roboBrokers, weights: roboWeights };
+      }
+    }
+
+    const built = buildStackResults({ inputs: stackInputs, perKind, limit: 1 });
+    setStackResults(built);
+  }, [phase, stackInputs, brokers, weights, answers.goal, answers.amount, answers.stack_super, answers.stack_savings]);
 
   // Track completion + persist results
   useEffect(() => {
@@ -782,6 +917,8 @@ export default function QuizPage() {
         getMatchReasons={getMatchReasons}
         onEmailCaptureSubmit={handleInlineEmailSubmit}
         emailCaptureStatus={emailCaptureStatus}
+        stackResults={stackResults}
+        stackInputs={stackInputs}
       />
     );
   }

--- a/app/quiz/page.tsx
+++ b/app/quiz/page.tsx
@@ -701,7 +701,7 @@ export default function QuizPage() {
         });
       } catch { /* quota exceeded */ }
     }
-  }, [phase, brokers.length, results, scoringAnswers, answers.advisor_type, answers.amount, answers.experience]);
+  }, [phase, brokers.length, results, scoringAnswers, answers.advisor_type, answers.amount, answers.experience, answers.investor_country]);
 
   /* ─── Handlers ─── */
 

--- a/lib/quiz-scoring.ts
+++ b/lib/quiz-scoring.ts
@@ -5,6 +5,202 @@ export type WeightKey = "beginner" | "low_fee" | "us_shares" | "smsf" | "crypto"
 export type QuizWeights = Record<WeightKey, number>;
 export type AmountKey = "small" | "medium" | "large" | "xlarge" | "whale";
 
+// ─── Wealth-Stack Per-Vertical Scoring ──────────────────────────────────────
+//
+// The main quiz collects wealth-stack signals (super preference, savings
+// horizon, robo interest) in addition to the broker-matching questions.
+// These signals feed `scoreVertical()` which ranks products within a
+// single vertical (super, savings, robo) using factual, criteria-based
+// matching — not personal advice.
+//
+// Design contract: every scored item returns a `VerticalScoredResult`
+// that mirrors `ScoredResult` shape so consumers can treat all verticals
+// uniformly. The matching is purely criteria-driven (balance thresholds,
+// fee bands, declared risk band) — no opinion on what the user *should*
+// do, only what products best match their stated criteria.
+
+/** Inputs captured by the extended quiz for wealth-stack matching. */
+export interface StackQuizInputs {
+  /** Amount key from the quiz amount question (re-used across verticals). */
+  amount?: AmountKey;
+  /** Risk band: the user's declared comfort with volatility. */
+  riskBand?: "conservative" | "balanced" | "growth";
+  /** Time horizon for savings / super contributions. */
+  horizon?: "short" | "mid" | "long";
+  /** Whether the user expressed interest in super optimisation. */
+  superInterest?: boolean;
+  /** Whether the user expressed interest in automated / robo investing. */
+  roboInterest?: boolean;
+  /** Whether the user expressed interest in a high-interest savings account. */
+  savingsInterest?: boolean;
+  /** Primary goal from the main quiz (passed through for kind-ordering). */
+  goal?: string;
+}
+
+/** Factual scoring profile for a super fund, savings account, or robo product. */
+export interface VerticalScoredResult {
+  slug: string;
+  total: number;
+  broker?: Broker;
+  /** The kind that was scored. */
+  kind: "super_fund" | "savings_account" | "robo_advisor";
+}
+
+// ---------------------------------------------------------------------------
+// Per-vertical answer → weight maps.
+// These map the new quiz signals to numeric score contributions.
+// Keeping them separate from ANSWER_WEIGHT_MAP avoids polluting the
+// broker-matching logic with vertical-specific keys.
+// ---------------------------------------------------------------------------
+
+/** Risk band → super-fund score bonuses per category. */
+const SUPER_RISK_BONUS: Record<"conservative" | "balanced" | "growth", Partial<QuizWeights>> = {
+  conservative: { smsf: 2, low_fee: 3 },
+  balanced: { beginner: 1, low_fee: 2, property: 1 },
+  growth: { advanced: 2, us_shares: 2 },
+};
+
+/** Amount band → super-fund base score contribution. */
+const SUPER_AMOUNT_BONUS: Record<AmountKey, number> = {
+  small: 0,
+  medium: 2,
+  large: 4,
+  xlarge: 5,
+  whale: 5,
+};
+
+/** Risk band → robo-advisor score bonuses per category. */
+const ROBO_RISK_BONUS: Record<"conservative" | "balanced" | "growth", Partial<QuizWeights>> = {
+  conservative: { robo: 5, low_fee: 3 },
+  balanced: { robo: 4, beginner: 2 },
+  growth: { robo: 3, advanced: 1 },
+};
+
+/** Horizon → savings emphasis: shorter = higher reward for low-fee / safety. */
+const SAVINGS_HORIZON_BONUS: Record<"short" | "mid" | "long", Partial<QuizWeights>> = {
+  short: { low_fee: 5, smsf: 2 },
+  mid: { low_fee: 3, beginner: 2 },
+  long: { low_fee: 2, property: 1 },
+};
+
+/**
+ * Score a single vertical's products given the user's stack quiz inputs.
+ *
+ * Works the same way as `scoreQuizResults` — sums weight contributions
+ * from the user's answers and applies an amount multiplier — but uses
+ * vertical-specific signal maps rather than the generic ANSWER_WEIGHT_MAP.
+ *
+ * AFSL compliance: returns factual criteria matches, presented as
+ * "products that match your stated criteria" — not "the right product
+ * for you". The calling UI must include the general-advice disclaimer.
+ *
+ * @param kind          Which vertical to score.
+ * @param brokers       All products with `platform_type === kind`.
+ * @param weights       Per-slug QuizWeights (same shape as broker quiz).
+ * @param inputs        User's stack quiz inputs.
+ * @param limit         Max results to return (default 3).
+ */
+export function scoreVertical(
+  kind: "super_fund" | "savings_account" | "robo_advisor",
+  brokers: Broker[],
+  weights: Record<string, QuizWeights>,
+  inputs: StackQuizInputs,
+  limit = 3,
+): VerticalScoredResult[] {
+  const multiplier = inputs.amount ? (AMOUNT_MULTIPLIER[inputs.amount] ?? 1.0) : 1.0;
+
+  const scored = Object.entries(weights).map(([slug, scores]) => {
+    let total = 0;
+
+    if (kind === "super_fund") {
+      // Base score from the robo + smsf dimensions (super funds score well on these)
+      total += scores.robo + scores.smsf;
+      // Risk-band bonus
+      if (inputs.riskBand) {
+        const bonus = SUPER_RISK_BONUS[inputs.riskBand];
+        for (const [k, v] of Object.entries(bonus)) {
+          total += scores[k as WeightKey] * (v / 10);
+        }
+      }
+      // Amount bonus — larger balances reward more sophisticated options
+      if (inputs.amount) {
+        total += SUPER_AMOUNT_BONUS[inputs.amount];
+      }
+    } else if (kind === "robo_advisor") {
+      // Base score from the robo + beginner dimensions
+      total += scores.robo * 1.5 + scores.beginner;
+      // Risk-band bonus
+      if (inputs.riskBand) {
+        const bonus = ROBO_RISK_BONUS[inputs.riskBand];
+        for (const [k, v] of Object.entries(bonus)) {
+          total += scores[k as WeightKey] * (v / 10);
+        }
+      }
+    } else {
+      // savings_account: reward low-fee + safety; penalise SMSF-heavy (wrong vertical)
+      total += scores.low_fee * 2 + scores.smsf;
+      // Horizon bonus
+      if (inputs.horizon) {
+        const bonus = SAVINGS_HORIZON_BONUS[inputs.horizon];
+        for (const [k, v] of Object.entries(bonus)) {
+          total += scores[k as WeightKey] * (v / 10);
+        }
+      }
+    }
+
+    // Apply amount multiplier
+    total *= multiplier;
+
+    // Rating nudge (same formula as broker scoring for consistency)
+    const broker = brokers.find((b) => b.slug === slug);
+    if (broker?.rating) total *= 1 + (broker.rating - 4) * 0.1;
+
+    return { slug, total, broker: broker ?? undefined, kind };
+  });
+
+  // Sort by total DESC, then rating DESC, then name ASC (consistent tiebreaker)
+  const sorted = (scored as VerticalScoredResult[]).sort(
+    (a, b) =>
+      b.total - a.total ||
+      (b.broker?.rating ?? 0) - (a.broker?.rating ?? 0) ||
+      (a.broker?.name ?? "").localeCompare(b.broker?.name ?? "")
+  );
+
+  return sorted.slice(0, limit);
+}
+
+/**
+ * Build per-vertical scored results for the wealth-stack display.
+ *
+ * Returns a map of kind → top results. Kinds with no products (empty
+ * brokers array) are omitted rather than returning empty arrays.
+ *
+ * AFSL: purely factual — maps stated criteria to product attributes.
+ * The calling UI is responsible for the general-advice disclaimer.
+ */
+export function buildStackResults(opts: {
+  inputs: StackQuizInputs;
+  perKind: Partial<Record<
+    "super_fund" | "savings_account" | "robo_advisor",
+    { brokers: Broker[]; weights: Record<string, QuizWeights> }
+  >>;
+  limit?: number;
+}): Partial<Record<"super_fund" | "savings_account" | "robo_advisor", VerticalScoredResult[]>> {
+  const result: Partial<Record<"super_fund" | "savings_account" | "robo_advisor", VerticalScoredResult[]>> = {};
+
+  const kinds = (["super_fund", "savings_account", "robo_advisor"] as const);
+  for (const kind of kinds) {
+    const slice = opts.perKind[kind];
+    if (!slice || slice.brokers.length === 0) continue;
+    const scored = scoreVertical(kind, slice.brokers, slice.weights, opts.inputs, opts.limit ?? 3);
+    if (scored.length > 0) {
+      result[kind] = scored;
+    }
+  }
+
+  return result;
+}
+
 export interface ScoredResult {
   slug: string;
   total: number;


### PR DESCRIPTION
Round-3 deepening (7 of 10). Completes the **concierge wealth-stack builder** (a top backlog item, ~70% before): extends the quiz/concierge beyond broker+advisor matching to also match **super, savings, and robo-advisor** options into one "stack". AFSL-safe: factual criteria-based matching + general guidance + referral — every stack card carries a non-dismissable general-advice disclaimer; never "the right product for you".

- `lib/quiz-scoring.ts` — adds `scoreVertical()` + `buildStackResults()` reusing the existing `QuizWeights`/matching shape, with per-vertical factual signal maps (super fund / robo / savings) + amount-tier and risk-band bonuses.
- `app/quiz/page.tsx` — 3 supplementary end-of-flow questions (risk band, super/savings opt-in) gated to eligible DIY goals; the advisor/international tracks are unaffected.
- `QuizResultsScreen` — a `WealthStackStrip` rendering one card per matched vertical (rating, review CTA, compare link, referral CTA + disclaimer).

**Fixes on verification:** `<a>`→`<Link>` for the `/compare` nav, and a `useEffect` missing-dep (`investor_country`).

**Verified:** `tsc` clean · **51 tests** (28 new wealth-stack scoring across all 3 verticals + edges; 23 existing quiz-scoring green) pass · eslint clean.

**Note:** the branch inherits 2 stale `cron-rate-alerts.test.ts` assertions from #1235's cron rewrite (maxDuration 60→120; status now `no_subscriptions`) — not code bugs; I'm correcting that stale test in the push-delivery PR (which owns that cron).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUfSRE2Teb6VhEXFP6RpS9)_