### PR TITLE
feat: unified next-action engine + recommendations on 4 surfaces (deepen)

### DIFF
--- a/__tests__/lib/next-action.test.ts
+++ b/__tests__/lib/next-action.test.ts
@@ -1,0 +1,542 @@
+/**
+ * Unit tests for lib/next-action.ts
+ *
+ * Verifies: ranking, cross-vertical routing, signed-out vs profiled,
+ * surface suppression, edge cases, and AFSL-safe framing invariants.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  buildNextActions,
+  PRIO_TAKE_QUIZ,
+  PRIO_GET_MATCHED,
+  PRIO_VERTICAL_GUIDE,
+  PRIO_VERTICAL_CALC,
+  PRIO_COMPARE,
+  PRIO_ADVISOR_REFERRAL,
+  PRIO_LEARN,
+  type NextActionSignals,
+} from "@/lib/next-action";
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const ANON_SIGNALS: NextActionSignals = {
+  profile: null,
+  quizVertical: null,
+  quizCompleted: false,
+  topMatchSlug: null,
+  intentCountry: null,
+  surface: "other",
+};
+
+function signals(overrides: Partial<NextActionSignals>): NextActionSignals {
+  return { ...ANON_SIGNALS, ...overrides };
+}
+
+function profile(
+  overrides: Partial<NonNullable<NextActionSignals["profile"]>> = {},
+): NonNullable<NextActionSignals["profile"]> {
+  return {
+    primaryVertical: null,
+    budgetBand: null,
+    experienceLevel: null,
+    isFhb: false,
+    isPreRetiree: false,
+    isCrossBorder: false,
+    isHnw: false,
+    isBusinessOwner: false,
+    ...overrides,
+  };
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function ids(actions: ReturnType<typeof buildNextActions>) {
+  return actions.map((a) => a.id);
+}
+
+function kinds(actions: ReturnType<typeof buildNextActions>) {
+  return actions.map((a) => a.kind);
+}
+
+function byId(actions: ReturnType<typeof buildNextActions>, id: string) {
+  return actions.find((a) => a.id === id);
+}
+
+// ── Invariant: always non-empty ───────────────────────────────────────────────
+
+describe("buildNextActions invariants", () => {
+  it("always returns at least one action for any signal set", () => {
+    expect(buildNextActions(ANON_SIGNALS).length).toBeGreaterThan(0);
+  });
+
+  it("result is sorted descending by priority", () => {
+    const actions = buildNextActions(ANON_SIGNALS);
+    for (let i = 0; i < actions.length - 1; i++) {
+      expect(actions[i]!.priority).toBeGreaterThanOrEqual(actions[i + 1]!.priority);
+    }
+  });
+
+  it("no duplicate IDs in any result", () => {
+    const actions = buildNextActions(ANON_SIGNALS);
+    const seen = new Set(ids(actions));
+    expect(seen.size).toBe(actions.length);
+  });
+
+  it("every action has non-empty title, description, href, cta", () => {
+    const actions = buildNextActions(ANON_SIGNALS);
+    for (const a of actions) {
+      expect(a.title.length).toBeGreaterThan(0);
+      expect(a.description.length).toBeGreaterThan(0);
+      expect(a.href.startsWith("/")).toBe(true);
+      expect(a.cta.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ── Signed-out visitor (fully anonymous) ──────────────────────────────────────
+
+describe("anonymous / signed-out visitor", () => {
+  it("leads with take-quiz CTA", () => {
+    const actions = buildNextActions(ANON_SIGNALS);
+    expect(actions[0]!.kind).toBe("take-quiz");
+    expect(actions[0]!.priority).toBe(PRIO_TAKE_QUIZ);
+  });
+
+  it("includes learn hub and compare as fallbacks", () => {
+    const ks = kinds(buildNextActions(ANON_SIGNALS));
+    expect(ks).toContain("learn");
+    expect(ks).toContain("compare");
+  });
+
+  it("does NOT show get-matched when quiz is not completed", () => {
+    const ks = kinds(buildNextActions(ANON_SIGNALS));
+    expect(ks).not.toContain("get-matched");
+  });
+});
+
+// ── Quiz completed ────────────────────────────────────────────────────────────
+
+describe("quiz completed — broker vertical", () => {
+  const sig = signals({
+    quizVertical: "trade",
+    quizCompleted: true,
+    topMatchSlug: "moomoo",
+  });
+
+  it("get-matched appears and outranks compare", () => {
+    const actions = buildNextActions(sig);
+    const gm = byId(actions, "get-matched")!;
+    const cp = byId(actions, "compare-platforms");
+    expect(gm).toBeDefined();
+    expect(gm.priority).toBe(PRIO_GET_MATCHED);
+    // get-matched should be higher than compare
+    if (cp) {
+      expect(gm.priority).toBeGreaterThan(cp.priority);
+    }
+  });
+
+  it("take-quiz is suppressed when quiz is completed", () => {
+    expect(ids(buildNextActions(sig))).not.toContain("take-quiz");
+  });
+
+  it("get-matched href deep-links to the top-match broker", () => {
+    const gm = byId(buildNextActions(sig), "get-matched")!;
+    expect(gm.href).toBe("/brokers/moomoo");
+  });
+
+  it("fee-calculator surfaces for broker vertical", () => {
+    expect(ids(buildNextActions(sig))).toContain("fee-calculator");
+  });
+
+  it("set-fee-alert surfaces when quiz is done + topMatchSlug", () => {
+    expect(ids(buildNextActions(sig))).toContain("set-fee-alert");
+  });
+
+  it("set-fee-alert href includes broker slug as query param", () => {
+    const alert = byId(buildNextActions(sig), "set-fee-alert")!;
+    expect(alert.href).toContain("moomoo");
+  });
+});
+
+describe("quiz completed — no topMatchSlug", () => {
+  const sig = signals({ quizVertical: "advisor_match", quizCompleted: true, topMatchSlug: null });
+
+  it("shows find-advisor instead of broker get-matched", () => {
+    const action = byId(buildNextActions(sig), "find-advisor")!;
+    expect(action).toBeDefined();
+    expect(action.kind).toBe("get-matched");
+    expect(action.href).toBe("/advisors");
+  });
+});
+
+// ── Cross-vertical routing: super / SMSF ─────────────────────────────────────
+
+describe("super / SMSF vertical", () => {
+  const sig = signals({
+    profile: profile({ primaryVertical: "super" }),
+    quizVertical: "super",
+    quizCompleted: true,
+    topMatchSlug: null,
+  });
+
+  it("surfaces smsf-guide", () => {
+    expect(ids(buildNextActions(sig))).toContain("smsf-guide");
+  });
+
+  it("surfaces super-calc", () => {
+    expect(ids(buildNextActions(sig))).toContain("super-calc");
+  });
+
+  it("surfaces smsf-advisor referral with boosted priority", () => {
+    const adv = byId(buildNextActions(sig), "smsf-advisor")!;
+    expect(adv).toBeDefined();
+    expect(adv.priority).toBeGreaterThan(PRIO_ADVISOR_REFERRAL);
+  });
+
+  it("smsf vertical maps guide href to /smsf", () => {
+    const guide = byId(buildNextActions(sig), "smsf-guide")!;
+    expect(guide.href).toBe("/smsf");
+  });
+
+  it("pre-retiree retirement-guide is suppressed when already in super vertical", () => {
+    const sigPreRetiree = signals({
+      profile: profile({ primaryVertical: "super", isPreRetiree: true }),
+      quizCompleted: true,
+    });
+    expect(ids(buildNextActions(sigPreRetiree))).not.toContain("retirement-guide");
+  });
+});
+
+describe("smsf vertical (explicit)", () => {
+  it("smsf keyword also routes to smsf-guide", () => {
+    const sig = signals({ quizVertical: "smsf", quizCompleted: false });
+    expect(ids(buildNextActions(sig))).toContain("smsf-guide");
+  });
+});
+
+// ── Cross-vertical routing: property ─────────────────────────────────────────
+
+describe("first-home buyer vertical", () => {
+  const sig = signals({
+    profile: profile({ primaryVertical: "first_home", isFhb: true }),
+    quizVertical: "first_home",
+    quizCompleted: false,
+  });
+
+  it("surfaces fhb-guide", () => {
+    expect(ids(buildNextActions(sig))).toContain("fhb-guide");
+  });
+
+  it("surfaces stamp-duty-calc", () => {
+    expect(ids(buildNextActions(sig))).toContain("stamp-duty-calc");
+  });
+
+  it("surfaces buyers-agent advisor referral", () => {
+    expect(ids(buildNextActions(sig))).toContain("property-advisor");
+  });
+
+  it("fhb-guide href is /first-home-buyer", () => {
+    const guide = byId(buildNextActions(sig), "fhb-guide")!;
+    expect(guide.href).toBe("/first-home-buyer");
+  });
+});
+
+describe("property vertical (non-FHB)", () => {
+  const sig = signals({
+    profile: profile({ primaryVertical: "property", isFhb: false }),
+    quizVertical: "property",
+    quizCompleted: false,
+  });
+
+  it("surfaces property-guide (not fhb-guide)", () => {
+    const all = ids(buildNextActions(sig));
+    expect(all).toContain("property-guide");
+    expect(all).not.toContain("fhb-guide");
+  });
+});
+
+// ── Cross-vertical routing: international / cross-border ─────────────────────
+
+describe("cross-border / international vertical", () => {
+  const sig = signals({
+    profile: profile({ primaryVertical: "international", isCrossBorder: true }),
+    quizVertical: "international",
+    quizCompleted: false,
+    intentCountry: "uk",
+  });
+
+  it("surfaces foreign-investment-hub", () => {
+    expect(ids(buildNextActions(sig))).toContain("foreign-investment-hub");
+  });
+
+  it("surfaces non-resident-compare with boosted priority", () => {
+    const cmp = byId(buildNextActions(sig), "non-resident-compare")!;
+    expect(cmp).toBeDefined();
+    expect(cmp.priority).toBeGreaterThan(PRIO_COMPARE);
+  });
+
+  it("surfaces intl-tax-advisor referral", () => {
+    expect(ids(buildNextActions(sig))).toContain("intl-tax-advisor");
+  });
+
+  it("foreign-investment-hub href includes country slug when intentCountry is set", () => {
+    const hub = byId(buildNextActions(sig), "foreign-investment-hub")!;
+    expect(hub.href).toBe("/foreign-investment/united-kingdom");
+  });
+
+  it("generic foreign-investment href used when no intentCountry", () => {
+    const noCountrySig = signals({
+      profile: profile({ primaryVertical: "international", isCrossBorder: true }),
+      quizVertical: "international",
+      intentCountry: null,
+    });
+    const hub = byId(buildNextActions(noCountrySig), "foreign-investment-hub")!;
+    expect(hub.href).toBe("/foreign-investment");
+  });
+});
+
+// ── Advisor vertical ──────────────────────────────────────────────────────────
+
+describe("advisor vertical", () => {
+  const sig = signals({
+    profile: profile({ primaryVertical: "advisor_match" }),
+    quizVertical: "advisor_match",
+    quizCompleted: false,
+  });
+
+  it("surfaces find-advisor-vertical with boosted priority", () => {
+    const adv = byId(buildNextActions(sig), "find-advisor-vertical")!;
+    expect(adv).toBeDefined();
+    expect(adv.priority).toBeGreaterThan(PRIO_ADVISOR_REFERRAL);
+  });
+
+  it("surfaces wealth-guide", () => {
+    expect(ids(buildNextActions(sig))).toContain("wealth-guide");
+  });
+
+  it("wealth-guide href points to advisor-guides", () => {
+    const guide = byId(buildNextActions(sig), "wealth-guide")!;
+    expect(guide.href).toContain("/advisor-guides/");
+  });
+});
+
+// ── Surface suppression ───────────────────────────────────────────────────────
+
+describe("surface suppression", () => {
+  it("compare surface suppresses compare-platforms action", () => {
+    const sig = signals({
+      quizVertical: "trade",
+      quizCompleted: true,
+      topMatchSlug: "stake",
+      surface: "compare",
+    });
+    const all = ids(buildNextActions(sig));
+    expect(all).not.toContain("compare-platforms");
+    expect(all).not.toContain("compare-fallback");
+  });
+
+  it("learn surface suppresses learn-hub action", () => {
+    const sig = signals({ surface: "learn" });
+    const all = ids(buildNextActions(sig));
+    expect(all).not.toContain("learn-hub");
+  });
+
+  it("advisors surface does not suppress non-advisor next actions", () => {
+    const sig = signals({
+      profile: profile({ primaryVertical: "trade" }),
+      quizVertical: "trade",
+      quizCompleted: true,
+      topMatchSlug: "comsec",
+      surface: "advisors",
+    });
+    // Should still show broker-relevant actions
+    expect(ids(buildNextActions(sig))).toContain("fee-calculator");
+  });
+});
+
+// ── HNW and pre-retiree flags ─────────────────────────────────────────────────
+
+describe("profile flags", () => {
+  it("HNW flag surfaces private-markets action", () => {
+    const sig = signals({ profile: profile({ isHnw: true }) });
+    expect(ids(buildNextActions(sig))).toContain("private-markets");
+  });
+
+  it("pre-retiree flag surfaces retirement-guide for non-super verticals", () => {
+    const sig = signals({
+      profile: profile({ isPreRetiree: true, primaryVertical: "trade" }),
+      quizVertical: "trade",
+    });
+    expect(ids(buildNextActions(sig))).toContain("retirement-guide");
+  });
+
+  it("business-owner profile does not crash (no specific action; general fallbacks)", () => {
+    const sig = signals({ profile: profile({ isBusinessOwner: true }) });
+    expect(() => buildNextActions(sig)).not.toThrow();
+    expect(buildNextActions(sig).length).toBeGreaterThan(0);
+  });
+});
+
+// ── Cross-border upsell without explicit cross-border vertical ────────────────
+
+describe("cross-border upsell (profile flag, non-cross-border vertical)", () => {
+  it("adds non-resident-compare for cross-border flag on broker vertical", () => {
+    const sig = signals({
+      profile: profile({ primaryVertical: "trade", isCrossBorder: true }),
+      quizVertical: "trade",
+      quizCompleted: false,
+    });
+    // Should contain either non-resident-compare or non-resident-compare-secondary
+    const all = ids(buildNextActions(sig));
+    const hasNonResident =
+      all.includes("non-resident-compare") ||
+      all.includes("non-resident-compare-secondary");
+    expect(hasNonResident).toBe(true);
+  });
+});
+
+// ── Intent country country slug mapping ──────────────────────────────────────
+
+describe("country slug mapping", () => {
+  const COUNTRIES: Array<[import("@/lib/intent-context").IntentCountryCode, string]> = [
+    ["uk", "/foreign-investment/united-kingdom"],
+    ["us", "/foreign-investment/united-states"],
+    ["cn", "/foreign-investment/china"],
+    ["in", "/foreign-investment/india"],
+    ["jp", "/foreign-investment/japan"],
+    ["sg", "/foreign-investment/singapore"],
+    ["hk", "/foreign-investment/hong-kong"],
+    ["kr", "/foreign-investment/south-korea"],
+    ["my", "/foreign-investment/malaysia"],
+    ["nz", "/foreign-investment/new-zealand"],
+    ["ae", "/foreign-investment/united-arab-emirates"],
+    ["sa", "/foreign-investment/saudi-arabia"],
+  ];
+
+  it.each(COUNTRIES)(
+    "code '%s' maps hub href to '%s'",
+    (code, expectedHref) => {
+      const sig = signals({
+        profile: profile({ primaryVertical: "international", isCrossBorder: true }),
+        quizVertical: "international",
+        intentCountry: code,
+      });
+      const hub = byId(buildNextActions(sig), "foreign-investment-hub")!;
+      expect(hub.href).toBe(expectedHref);
+    },
+  );
+});
+
+// ── Priority ordering guarantees ──────────────────────────────────────────────
+
+describe("priority ordering", () => {
+  it("take-quiz always ranks highest for anonymous visitor", () => {
+    const actions = buildNextActions(ANON_SIGNALS);
+    expect(actions[0]!.id).toBe("take-quiz");
+  });
+
+  it("get-matched ranks above vertical-guide when quiz done + topMatch", () => {
+    const sig = signals({
+      profile: profile({ primaryVertical: "super" }),
+      quizVertical: "super",
+      quizCompleted: true,
+      topMatchSlug: null, // no specific match for super
+    });
+    const actions = buildNextActions(sig);
+    const gmIdx = actions.findIndex((a) => a.kind === "get-matched");
+    const guideIdx = actions.findIndex((a) => a.kind === "vertical-guide");
+    if (gmIdx !== -1 && guideIdx !== -1) {
+      expect(actions[gmIdx]!.priority).toBeGreaterThanOrEqual(actions[guideIdx]!.priority);
+    }
+  });
+
+  it("vertical-calc ranks below vertical-guide", () => {
+    const sig = signals({ quizVertical: "super", quizCompleted: false });
+    const actions = buildNextActions(sig);
+    const guideIdx = actions.findIndex((a) => a.kind === "vertical-guide");
+    const calcIdx = actions.findIndex((a) => a.kind === "vertical-calc");
+    if (guideIdx !== -1 && calcIdx !== -1) {
+      expect(actions[guideIdx]!.priority).toBeGreaterThanOrEqual(actions[calcIdx]!.priority);
+    }
+  });
+
+  it("advisor-referral ranks above learn and compare fallbacks", () => {
+    const actions = buildNextActions(ANON_SIGNALS);
+    const advIdx = actions.findIndex((a) => a.kind === "advisor-referral");
+    const learnIdx = actions.findIndex((a) => a.kind === "learn");
+    if (advIdx !== -1 && learnIdx !== -1) {
+      expect(actions[advIdx]!.priority).toBeGreaterThan(actions[learnIdx]!.priority);
+    }
+  });
+
+  it("exported priority constants maintain expected relative order", () => {
+    expect(PRIO_TAKE_QUIZ).toBeGreaterThan(PRIO_GET_MATCHED);
+    expect(PRIO_GET_MATCHED).toBeGreaterThan(PRIO_VERTICAL_GUIDE);
+    expect(PRIO_VERTICAL_GUIDE).toBeGreaterThan(PRIO_VERTICAL_CALC);
+    expect(PRIO_VERTICAL_CALC).toBeGreaterThan(PRIO_COMPARE);
+    expect(PRIO_COMPARE).toBeGreaterThan(PRIO_ADVISOR_REFERRAL);
+    expect(PRIO_ADVISOR_REFERRAL).toBeGreaterThan(PRIO_LEARN);
+  });
+});
+
+// ── showAdviceWarning invariant ───────────────────────────────────────────────
+
+describe("showAdviceWarning framing", () => {
+  it("take-quiz action does NOT set showAdviceWarning (navigation, not product CTA)", () => {
+    const actions = buildNextActions(ANON_SIGNALS);
+    const quiz = byId(actions, "take-quiz")!;
+    expect(quiz.showAdviceWarning).toBe(false);
+  });
+
+  it("get-matched DOES set showAdviceWarning", () => {
+    const sig = signals({ quizCompleted: true, topMatchSlug: "stake" });
+    const gm = byId(buildNextActions(sig), "get-matched")!;
+    expect(gm.showAdviceWarning).toBe(true);
+  });
+
+  it("learn-hub does NOT set showAdviceWarning", () => {
+    const actions = buildNextActions(ANON_SIGNALS);
+    const learn = byId(actions, "learn-hub");
+    if (learn) {
+      expect(learn.showAdviceWarning).toBe(false);
+    }
+  });
+
+  it("compare-related actions DO set showAdviceWarning", () => {
+    const sig = signals({ quizVertical: "trade", quizCompleted: true, topMatchSlug: "cmc" });
+    const actions = buildNextActions(sig);
+    const cmp = actions.find((a) => a.kind === "compare");
+    if (cmp) {
+      expect(cmp.showAdviceWarning).toBe(true);
+    }
+  });
+});
+
+// ── Edge cases ────────────────────────────────────────────────────────────────
+
+describe("edge cases", () => {
+  it("does not crash with all-null profile fields", () => {
+    const sig = signals({ profile: profile() });
+    expect(() => buildNextActions(sig)).not.toThrow();
+  });
+
+  it("does not crash with intentCountry set but no profile or quiz", () => {
+    const sig = signals({ intentCountry: "nz" });
+    expect(() => buildNextActions(sig)).not.toThrow();
+  });
+
+  it("handles unknown quiz vertical gracefully (no explicit routing match)", () => {
+    const sig = signals({ quizVertical: "unknown_future_vertical" as string, quizCompleted: false });
+    const actions = buildNextActions(sig);
+    expect(actions.length).toBeGreaterThan(0);
+    // Should still have fallbacks
+    expect(kinds(actions)).toContain("learn");
+  });
+
+  it("quiz completed with no vertical surfaces find-advisor fallback", () => {
+    const sig = signals({ quizCompleted: true, topMatchSlug: null, quizVertical: null });
+    const action = byId(buildNextActions(sig), "find-advisor")!;
+    expect(action).toBeDefined();
+  });
+});

--- a/app/advisors/page.tsx
+++ b/app/advisors/page.tsx
@@ -8,6 +8,7 @@ import HomeToolsStrip from "@/components/HomeToolsStrip";
 import DirectoryBanners from "@/components/foreign-investment/DirectoryBanners";
 import { absoluteUrl, breadcrumbJsonLd, CURRENT_YEAR } from "@/lib/seo";
 import { logger } from "@/lib/logger";
+import NextActions from "@/components/NextActions";
 
 const log = logger("advisors-page");
 
@@ -112,6 +113,10 @@ export default function AdvisorsPage() {
       </div>
       <Suspense fallback={<AdvisorsLoading />}>
         <AdvisorsData />
+      </Suspense>
+      {/* Personalised next-action strip — advisor surface suppresses duplicate advisor CTAs */}
+      <Suspense fallback={null}>
+        <NextActions surface="advisors" />
       </Suspense>
       <HomeToolsStrip />
     </>

--- a/app/article/[slug]/page.tsx
+++ b/app/article/[slug]/page.tsx
@@ -30,6 +30,7 @@ import LinkifiedText from "@/components/LinkifiedText";
 import FloatingRightCTA from "@/components/FloatingRightCTA";
 import { isFlagEnabled } from "@/lib/feature-flags";
 import { pillarPathForCategory, linkDensityForCategory } from "@/lib/keyword-linking";
+import NextActions from "@/components/NextActions";
 
 export const revalidate = 3600; // ISR: revalidate every hour
 
@@ -860,6 +861,10 @@ export default async function ArticlePage({
           </div>
         </div>
       </div>
+      {/* Personalised next-action strip — surfaces after article content */}
+      <Suspense fallback={null}>
+        <NextActions surface="article" />
+      </Suspense>
       <FloatingRightCTA
         href="/compare"
         label="Compare brokers"

--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -8,6 +8,7 @@ import { absoluteUrl, UPDATED_LABEL } from "@/lib/seo";
 import ComplianceFooter from "@/components/ComplianceFooter";
 import HomeToolsStrip from "@/components/HomeToolsStrip";
 import DirectoryBanners from "@/components/foreign-investment/DirectoryBanners";
+import NextActions from "@/components/NextActions";
 
 export const metadata = {
   title: "Compare Investing Platforms — Fees & Features",
@@ -165,6 +166,10 @@ export default function ComparePage() {
       </div>
       <Suspense fallback={<ComparePageSkeleton />}>
         <CompareData />
+      </Suspense>
+      {/* Personalised next-action strip — suppresses compare CTA since the user is already here */}
+      <Suspense fallback={null}>
+        <NextActions surface="compare" />
       </Suspense>
       <HomeToolsStrip />
       <div className="container-custom pb-8">

--- a/app/learn/page.tsx
+++ b/app/learn/page.tsx
@@ -5,6 +5,8 @@ import { createClient } from "@/lib/supabase/server";
 import Icon from "@/components/Icon";
 import NewsletterCta from "./NewsletterCta";
 import { LEARNING_PATHS, sumEstimatedMinutes } from "@/lib/learning-paths";
+import { Suspense } from "react";
+import NextActions from "@/components/NextActions";
 
 export const revalidate = 3600;
 
@@ -215,6 +217,11 @@ export default async function LearnHubPage() {
             <NewsletterCta />
           </div>
         </section>
+
+        {/* Personalised next-action strip — learn surface suppresses duplicate learn hub CTA */}
+        <Suspense fallback={null}>
+          <NextActions surface="learn" />
+        </Suspense>
       </div>
     </>
   );

--- a/components/NextActions.tsx
+++ b/components/NextActions.tsx
@@ -1,0 +1,146 @@
+/**
+ * NextActions — server component that resolves personalisation signals,
+ * calls the `buildNextActions` engine, and renders a compact strip of
+ * "your next step" cards.
+ *
+ * Mounted on high-traffic surfaces that currently lack SmartRecommendationsStrip:
+ *   /compare, /advisors, /learn, article/[slug]
+ *
+ * Returns null when there are no usable signals (fully anonymous visitor
+ * who hasn't taken the quiz or visited a country hub). The existing
+ * SmartRecommendationsStrip continues to own broker/advisor entity cards;
+ * this component owns the action-level navigation strip.
+ *
+ * AFSL: factual "next step" framing only. `showAdviceWarning` items
+ * render the short PDS_CONSIDERATION disclaimer beneath the card.
+ */
+
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/server";
+import { getIntentCountry } from "@/lib/intent-context-server";
+import { getQuizProfile } from "@/lib/quiz-profile";
+import { getInvestorProfile } from "@/lib/investor-profiles";
+import {
+  buildNextActions,
+  type NextAction,
+  type NextActionSignals,
+} from "@/lib/next-action";
+import { PDS_CONSIDERATION } from "@/lib/compliance";
+import { intentCountryMeta } from "@/lib/intent-context";
+
+interface Props {
+  surface: NextActionSignals["surface"];
+  /**
+   * Cap on how many actions to render. Defaults to 3 for strips;
+   * callers that want a more complete list can pass a higher value.
+   */
+  maxItems?: number;
+}
+
+export default async function NextActions({ surface, maxItems = 3 }: Props) {
+  // Resolve all three signal sources in parallel
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  const [quiz, intentCountry, investorProfile] = await Promise.all([
+    getQuizProfile(),
+    getIntentCountry(),
+    user ? getInvestorProfile(user.id) : Promise.resolve(null),
+  ]);
+
+  // Require at least one signal — don't render for fully anonymous visitors
+  // who have no quiz, no country intent, and no signed-in profile.
+  if (!quiz && !intentCountry && !investorProfile) return null;
+
+  const signals: NextActionSignals = {
+    profile: investorProfile,
+    quizVertical: quiz?.vertical ?? null,
+    quizCompleted: !!quiz?.completedAt,
+    topMatchSlug: quiz?.topMatchSlug ?? null,
+    intentCountry:
+      investorProfile?.intentCountrySnapshot ??
+      quiz?.intentCountry ??
+      intentCountry,
+    surface,
+  };
+
+  const actions = buildNextActions(signals).slice(0, maxItems);
+  if (actions.length === 0) return null;
+
+  const countryMeta =
+    signals.intentCountry ? intentCountryMeta(signals.intentCountry) : null;
+
+  const headline = buildHeadline(signals, countryMeta);
+
+  return (
+    <section
+      aria-label="Your next step"
+      className="bg-gradient-to-br from-slate-50 via-white to-emerald-50/40 border-y border-slate-200"
+    >
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 py-5">
+        <p className="text-xs font-semibold uppercase tracking-wider text-emerald-700 mb-1">
+          <span aria-hidden className="mr-1.5">
+            {countryMeta?.flag ?? "→"}
+          </span>
+          Next steps for you
+        </p>
+        <h2 className="text-base sm:text-lg font-semibold text-slate-900 mb-4">
+          {headline}
+        </h2>
+        <ul className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+          {actions.map((action) => (
+            <ActionCard key={action.id} action={action} />
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}
+
+function ActionCard({ action }: { action: NextAction }) {
+  return (
+    <li>
+      <Link
+        href={action.href}
+        className="group flex flex-col h-full bg-white hover:bg-emerald-50/30 border border-slate-200 hover:border-emerald-300 rounded-xl p-4 transition-colors"
+      >
+        <p className="text-sm font-semibold text-slate-900 group-hover:text-emerald-900 mb-1">
+          {action.title}
+        </p>
+        <p className="text-xs text-slate-500 leading-relaxed flex-1 mb-3">
+          {action.description}
+        </p>
+        <span className="inline-flex items-center gap-1 text-xs font-bold text-emerald-700 group-hover:text-emerald-900">
+          {action.cta}
+          <span aria-hidden>&rarr;</span>
+        </span>
+        {action.showAdviceWarning && (
+          <p className="mt-2 text-[0.65rem] text-slate-400 leading-relaxed border-t border-slate-100 pt-2">
+            {PDS_CONSIDERATION}
+          </p>
+        )}
+      </Link>
+    </li>
+  );
+}
+
+function buildHeadline(
+  signals: NextActionSignals,
+  countryMeta: ReturnType<typeof intentCountryMeta> | null,
+): string {
+  if (signals.quizCompleted && countryMeta) {
+    return `Suggested next steps — matched to your quiz + ${countryMeta.label}`;
+  }
+  if (signals.quizCompleted) {
+    return "Suggested next steps based on your quiz answers";
+  }
+  if (countryMeta) {
+    return `Suggested next steps for ${countryMeta.label}`;
+  }
+  if (signals.profile?.primaryVertical) {
+    return "Suggested next steps based on your profile";
+  }
+  return "Suggested next steps";
+}

--- a/lib/next-action.ts
+++ b/lib/next-action.ts
@@ -1,0 +1,531 @@
+/**
+ * Next-action engine — unified personalisation primitive (big-next-action).
+ *
+ * Pure function: given the caller's resolved profile signals, return a ranked
+ * list of `NextAction` items that guide the visitor toward their most
+ * productive next step. No DB calls — callers resolve signals first and pass
+ * them in (allows React `cache()` deduplication at the call site).
+ *
+ * AFSL compliance: every action is a factual "next step" description, not
+ * personalised financial advice. No recommendation to buy, sell, or hold any
+ * specific financial product. Copy that surfaces to the visitor is sourced
+ * from named constants here — never inline-hardcoded in components.
+ *
+ * Vertical routing:
+ *   "super" / "smsf"          → SMSF guide + super calculators
+ *   "property" / "first_home" → FHOG / stamp-duty calculator + buyers-agent CTA
+ *   "international"           → foreign-investment hub + non-resident compare
+ *   broker verticals          → compare + fee calculator + take-quiz
+ *   advisor verticals         → find-advisor + quiz-refinement
+ *   no profile (signed-out)   → take-quiz → get-matched → compare → learn
+ *
+ * Priority constants (PRIO_*) are intentionally exported so tests can assert
+ * relative ordering without relying on magic numbers.
+ */
+
+import type { InvestorProfile } from "./investor-profiles";
+import type { QuizProfile } from "./quiz-profile";
+import type { IntentCountryCode } from "./intent-context";
+
+// ─── Priority tiers ──────────────────────────────────────────────────────────
+// Higher number = shown first. Named so tests are self-documenting.
+
+/** Immediate profile-completion or quiz action — highest value for the user */
+export const PRIO_TAKE_QUIZ = 100;
+/** "Get matched" — strong CTA when quiz is done */
+export const PRIO_GET_MATCHED = 90;
+/** Vertical-specific guide or hub page */
+export const PRIO_VERTICAL_GUIDE = 80;
+/** Vertical-specific calculator */
+export const PRIO_VERTICAL_CALC = 75;
+/** Compare page — always relevant for broker-oriented visitors */
+export const PRIO_COMPARE = 70;
+/** Set a fee alert — relevant after profile shows interest in a specific platform */
+export const PRIO_SET_ALERT = 60;
+/** Advisor referral — always a valid escalation path */
+export const PRIO_ADVISOR_REFERRAL = 50;
+/** General learn hub — useful fallback for any visitor */
+export const PRIO_LEARN = 40;
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type NextActionKind =
+  | "take-quiz"
+  | "get-matched"
+  | "vertical-guide"
+  | "vertical-calc"
+  | "compare"
+  | "set-alert"
+  | "advisor-referral"
+  | "learn";
+
+export interface NextAction {
+  /** Machine-stable identifier for analytics / deduplication */
+  id: string;
+  kind: NextActionKind;
+  /** Priority score — higher renders first */
+  priority: number;
+  /** Short headline (≤ 60 chars) for the action card */
+  title: string;
+  /** One-line factual description of what this step does */
+  description: string;
+  /** URL to send the user to */
+  href: string;
+  /** Primary CTA label */
+  cta: string;
+  /**
+   * When true, the rendering component MUST display `GENERAL_ADVICE_WARNING`
+   * near this action. Reserved for actions adjacent to product or advisor
+   * comparisons. Pure-navigation actions (quiz, learn) don't need it.
+   */
+  showAdviceWarning: boolean;
+}
+
+/**
+ * Resolved signals passed to `buildNextActions`. Callers merge their three
+ * sources (investor_profiles, quiz cookie, intent-country cookie) before
+ * calling — the engine is source-agnostic.
+ */
+export interface NextActionSignals {
+  /**
+   * Merged investor profile (signed-in structured data + quiz cookie).
+   * Null for anonymous visitors who have not taken the quiz.
+   */
+  profile: Pick<
+    InvestorProfile,
+    | "primaryVertical"
+    | "budgetBand"
+    | "experienceLevel"
+    | "isFhb"
+    | "isPreRetiree"
+    | "isCrossBorder"
+    | "isHnw"
+    | "isBusinessOwner"
+  > | null;
+  /**
+   * Inferred vertical from the quiz cookie (may differ from
+   * `profile.primaryVertical` when the profile hasn't been re-synced yet).
+   * Null when no quiz has been taken.
+   */
+  quizVertical: QuizProfile["vertical"] | null;
+  /**
+   * Whether the visitor has a completed quiz (completedAt !== null).
+   * Used to suppress the "take quiz" CTA for users who already finished.
+   */
+  quizCompleted: boolean;
+  /**
+   * Top-match slug from the quiz — when present the "get matched" action
+   * can deep-link to that specific broker/advisor profile.
+   */
+  topMatchSlug: string | null;
+  /**
+   * Intent country from any source. When set, cross-border actions surface
+   * higher and are filtered to the user's country context.
+   */
+  intentCountry: IntentCountryCode | null;
+  /**
+   * The surface the visitor is on — used to suppress redundant actions
+   * (e.g. don't show "Compare platforms" on /compare itself).
+   */
+  surface: "compare" | "advisors" | "learn" | "article" | "other";
+}
+
+// ─── Vertical sets (mirrors SmartRecommendationsStrip categorisation) ────────
+
+const BROKER_VERTICALS = new Set([
+  "trade",
+  "automate",
+  "fees",
+  "tools",
+  "safety",
+  "crypto",
+  "broker_diy",
+]);
+
+const ADVISOR_VERTICALS = new Set([
+  "advisor_match",
+  "complex",
+  "wealth",
+  "international",
+  "first_home",
+]);
+
+const SUPER_VERTICALS = new Set(["super", "smsf"]);
+
+const PROPERTY_VERTICALS = new Set(["property", "first_home"]);
+
+// ─── Engine ──────────────────────────────────────────────────────────────────
+
+/**
+ * Build a ranked `NextAction[]` for the given signal set.
+ *
+ * Guarantees:
+ * - Array is always non-empty (at minimum the quiz CTA or learn hub).
+ * - Items are sorted descending by `priority`.
+ * - No duplicates (each `id` appears at most once).
+ */
+export function buildNextActions(signals: NextActionSignals): NextAction[] {
+  const actions: NextAction[] = [];
+
+  const vertical =
+    signals.profile?.primaryVertical ?? signals.quizVertical ?? null;
+
+  // ── 1. Quiz CTA — suppress when quiz is already completed ────────────────
+  if (!signals.quizCompleted) {
+    actions.push({
+      id: "take-quiz",
+      kind: "take-quiz",
+      priority: PRIO_TAKE_QUIZ,
+      title: "Find the right platform in 60 seconds",
+      description:
+        "Answer a few questions about your goals and we'll show you the platforms that fit.",
+      href: "/quiz",
+      cta: "Take the quiz",
+      showAdviceWarning: false,
+    });
+  }
+
+  // ── 2. Get matched — only when quiz is done and we have a top match ───────
+  if (signals.quizCompleted && signals.topMatchSlug) {
+    actions.push({
+      id: "get-matched",
+      kind: "get-matched",
+      priority: PRIO_GET_MATCHED,
+      title: "Review your top platform match",
+      description:
+        "Your quiz results are ready — see the platform ranked highest for your profile.",
+      href: `/brokers/${signals.topMatchSlug}`,
+      cta: "See your match",
+      showAdviceWarning: true,
+    });
+  } else if (signals.quizCompleted && !signals.topMatchSlug) {
+    // Quiz done but no specific match (advisor vertical) → find-advisor CTA
+    actions.push({
+      id: "find-advisor",
+      kind: "get-matched",
+      priority: PRIO_GET_MATCHED,
+      title: "Browse matched financial advisors",
+      description:
+        "Your quiz identified that professional advice would suit your situation. Browse verified advisors.",
+      href: "/advisors",
+      cta: "Find an advisor",
+      showAdviceWarning: true,
+    });
+  }
+
+  // ── 3. Cross-vertical routing ────────────────────────────────────────────
+
+  if (vertical && SUPER_VERTICALS.has(vertical)) {
+    // Super / SMSF path
+    actions.push({
+      id: "smsf-guide",
+      kind: "vertical-guide",
+      priority: PRIO_VERTICAL_GUIDE,
+      title: "SMSF starter guide",
+      description:
+        "Step-by-step overview of setting up and running a self-managed super fund.",
+      href: "/smsf",
+      cta: "Read the guide",
+      showAdviceWarning: false,
+    });
+    actions.push({
+      id: "super-calc",
+      kind: "vertical-calc",
+      priority: PRIO_VERTICAL_CALC,
+      title: "Super balance projection calculator",
+      description:
+        "Project your super balance at retirement under different contribution scenarios.",
+      href: "/tools/super-calculator",
+      cta: "Open calculator",
+      showAdviceWarning: true,
+    });
+    // Advisor referral for SMSF is high-value
+    actions.push({
+      id: "smsf-advisor",
+      kind: "advisor-referral",
+      priority: PRIO_ADVISOR_REFERRAL + 15,
+      title: "Find an SMSF accountant",
+      description:
+        "Verified SMSF specialists who handle ATO compliance, audits, and investment strategy.",
+      href: "/advisors/smsf-accountants",
+      cta: "Browse SMSF advisors",
+      showAdviceWarning: true,
+    });
+  } else if (vertical && PROPERTY_VERTICALS.has(vertical)) {
+    // Property / first-home buyer path
+    const isFhb = signals.profile?.isFhb ?? vertical === "first_home";
+    if (isFhb) {
+      actions.push({
+        id: "fhb-guide",
+        kind: "vertical-guide",
+        priority: PRIO_VERTICAL_GUIDE,
+        title: "First Home Buyer's guide",
+        description:
+          "FHOG eligibility, stamp-duty concessions, and the HomeGuarantee Scheme — what you can access.",
+        href: "/first-home-buyer",
+        cta: "Read the guide",
+        showAdviceWarning: false,
+      });
+      actions.push({
+        id: "stamp-duty-calc",
+        kind: "vertical-calc",
+        priority: PRIO_VERTICAL_CALC,
+        title: "Stamp duty & LMI calculator",
+        description:
+          "Estimate your upfront costs by state, including stamp duty concessions and LMI.",
+        href: "/tools/stamp-duty-calculator",
+        cta: "Calculate costs",
+        showAdviceWarning: true,
+      });
+    } else {
+      actions.push({
+        id: "property-guide",
+        kind: "vertical-guide",
+        priority: PRIO_VERTICAL_GUIDE,
+        title: "Property investing hub",
+        description:
+          "Negative gearing, depreciation schedules, and suburb research — all in one place.",
+        href: "/property",
+        cta: "Explore property",
+        showAdviceWarning: false,
+      });
+    }
+    actions.push({
+      id: "property-advisor",
+      kind: "advisor-referral",
+      priority: PRIO_ADVISOR_REFERRAL + 10,
+      title: "Find a buyer's agent",
+      description:
+        "Buyer's agents negotiate on your behalf and source off-market deals. Free initial consultation.",
+      href: "/advisors/buyers-agents",
+      cta: "Browse buyer's agents",
+      showAdviceWarning: true,
+    });
+  } else if (vertical && signals.profile?.isCrossBorder) {
+    // Cross-border / international path (takes priority when flag is set)
+    actions.push({
+      id: "foreign-investment-hub",
+      kind: "vertical-guide",
+      priority: PRIO_VERTICAL_GUIDE,
+      title: "Foreign investor hub",
+      description:
+        "FIRB rules, tax-treaty positions, and onboarding requirements for non-resident investors.",
+      href: signals.intentCountry
+        ? `/foreign-investment/${_countrySlug(signals.intentCountry)}`
+        : "/foreign-investment",
+      cta: "Explore the guide",
+      showAdviceWarning: false,
+    });
+    actions.push({
+      id: "non-resident-compare",
+      kind: "compare",
+      priority: PRIO_COMPARE + 10,
+      title: "Platforms that accept non-residents",
+      description:
+        "Most retail Australian brokers do not onboard non-residents. This filtered list shows those that do.",
+      href: "/compare/non-residents",
+      cta: "Non-resident platforms",
+      showAdviceWarning: true,
+    });
+    actions.push({
+      id: "intl-tax-advisor",
+      kind: "advisor-referral",
+      priority: PRIO_ADVISOR_REFERRAL + 12,
+      title: "Find an international tax specialist",
+      description:
+        "Cross-border tax specialists handle dual-reporting, FIRB advice, and treaty positions.",
+      href: "/advisors/international-tax-specialists",
+      cta: "Browse specialists",
+      showAdviceWarning: true,
+    });
+  } else if (vertical && ADVISOR_VERTICALS.has(vertical)) {
+    // Advisor-oriented path
+    actions.push({
+      id: "find-advisor-vertical",
+      kind: "advisor-referral",
+      priority: PRIO_ADVISOR_REFERRAL + 20,
+      title: "Find a verified financial advisor",
+      description:
+        "Browse advisors filtered by specialty — SMSF, wealth management, tax, and more.",
+      href: "/advisors",
+      cta: "Browse advisors",
+      showAdviceWarning: true,
+    });
+    actions.push({
+      id: "wealth-guide",
+      kind: "vertical-guide",
+      priority: PRIO_VERTICAL_GUIDE,
+      title: "How to choose a financial advisor",
+      description:
+        "Fee structures, qualifications to check, and questions to ask before your first meeting.",
+      href: "/advisor-guides/financial-planner",
+      cta: "Read the guide",
+      showAdviceWarning: false,
+    });
+  } else if (vertical && BROKER_VERTICALS.has(vertical)) {
+    // Broker / DIY investing path
+    if (signals.surface !== "compare") {
+      actions.push({
+        id: "compare-platforms",
+        kind: "compare",
+        priority: PRIO_COMPARE,
+        title: "Compare all investing platforms",
+        description:
+          "Side-by-side fees, features, and CHESS sponsorship for 100+ Australian platforms.",
+        href: "/compare",
+        cta: "Compare platforms",
+        showAdviceWarning: true,
+      });
+    }
+
+    actions.push({
+      id: "fee-calculator",
+      kind: "vertical-calc",
+      priority: PRIO_VERTICAL_CALC,
+      title: "Brokerage fee calculator",
+      description:
+        "Enter your trade size and frequency to see the real annual cost difference between platforms.",
+      href: "/tools/brokerage-fee-calculator",
+      cta: "Calculate fees",
+      showAdviceWarning: true,
+    });
+
+    if (signals.quizCompleted && signals.topMatchSlug) {
+      actions.push({
+        id: "set-fee-alert",
+        kind: "set-alert",
+        priority: PRIO_SET_ALERT,
+        title: "Set a fee-change alert",
+        description:
+          "Get notified by email when your top-match platform changes its brokerage fees.",
+        href: `/fee-alerts?broker=${signals.topMatchSlug}`,
+        cta: "Set alert",
+        showAdviceWarning: false,
+      });
+    }
+  }
+
+  // ── 4. Cross-border upsell for signed-in profiles flagged as cross-border ──
+  if (
+    signals.profile?.isCrossBorder &&
+    vertical &&
+    !ADVISOR_VERTICALS.has(vertical) &&
+    !actions.find((a) => a.id === "non-resident-compare")
+  ) {
+    actions.push({
+      id: "non-resident-compare-secondary",
+      kind: "compare",
+      priority: PRIO_COMPARE + 5,
+      title: "Platforms that accept non-residents",
+      description:
+        "Pre-filtered to platforms that explicitly accept overseas applicants.",
+      href: "/compare/non-residents",
+      cta: "Non-resident platforms",
+      showAdviceWarning: true,
+    });
+  }
+
+  // ── 5. HNW upsell — surface private-markets hub ───────────────────────────
+  if (signals.profile?.isHnw) {
+    actions.push({
+      id: "private-markets",
+      kind: "vertical-guide",
+      priority: PRIO_VERTICAL_GUIDE - 5,
+      title: "Private markets & wholesale investing",
+      description:
+        "Eligible investors can access unlisted equity, private credit, and property syndicates.",
+      href: "/private-markets",
+      cta: "Explore options",
+      showAdviceWarning: true,
+    });
+  }
+
+  // ── 6. Pre-retiree upsell ────────────────────────────────────────────────
+  if (signals.profile?.isPreRetiree && !SUPER_VERTICALS.has(vertical ?? "")) {
+    actions.push({
+      id: "retirement-guide",
+      kind: "vertical-guide",
+      priority: PRIO_VERTICAL_GUIDE - 3,
+      title: "Retirement planning overview",
+      description:
+        "Transition-to-retirement, account-based pension phase, and aged-care planning basics.",
+      href: "/super",
+      cta: "Read the guide",
+      showAdviceWarning: false,
+    });
+  }
+
+  // ── 7. General fallbacks (always included to keep the list non-empty) ─────
+  if (!actions.some((a) => a.kind === "advisor-referral")) {
+    actions.push({
+      id: "advisor-referral-fallback",
+      kind: "advisor-referral",
+      priority: PRIO_ADVISOR_REFERRAL,
+      title: "Speak with a financial advisor",
+      description:
+        "A licensed adviser can review your full situation — something a comparison tool can't do.",
+      href: "/advisors",
+      cta: "Find an advisor",
+      showAdviceWarning: true,
+    });
+  }
+
+  if (signals.surface !== "learn" && !actions.some((a) => a.kind === "learn")) {
+    actions.push({
+      id: "learn-hub",
+      kind: "learn",
+      priority: PRIO_LEARN,
+      title: "Structured learning paths",
+      description:
+        "Guided paths from beginner to advanced — investing basics, super, tax, and more.",
+      href: "/learn",
+      cta: "Start learning",
+      showAdviceWarning: false,
+    });
+  }
+
+  if (
+    signals.surface !== "compare" &&
+    !actions.some((a) => a.kind === "compare")
+  ) {
+    actions.push({
+      id: "compare-fallback",
+      kind: "compare",
+      priority: PRIO_COMPARE - 5,
+      title: "Compare investing platforms",
+      description:
+        "Side-by-side fees, features, and CHESS sponsorship for Australian platforms.",
+      href: "/compare",
+      cta: "Compare platforms",
+      showAdviceWarning: true,
+    });
+  }
+
+  // ── Sort descending by priority, then stable by id ────────────────────────
+  actions.sort((a, b) =>
+    b.priority !== a.priority ? b.priority - a.priority : a.id.localeCompare(b.id),
+  );
+
+  return actions;
+}
+
+// ─── Internal helpers ─────────────────────────────────────────────────────────
+
+/** Map intent code → foreign-investment route slug. */
+function _countrySlug(code: IntentCountryCode): string {
+  const MAP: Record<IntentCountryCode, string> = {
+    uk: "united-kingdom",
+    us: "united-states",
+    cn: "china",
+    in: "india",
+    jp: "japan",
+    sg: "singapore",
+    hk: "hong-kong",
+    kr: "south-korea",
+    my: "malaysia",
+    nz: "new-zealand",
+    ae: "united-arab-emirates",
+    sa: "saudi-arabia",
+  };
+  return MAP[code];
+}


### PR DESCRIPTION
Round-3 deepening (9 of 10). Unifies the fragmented personalization (intent cookie + quiz profile + `investor_profiles`) into ONE ranked engine, and mounts recommendations on the high-traffic surfaces that lacked them. AFSL-safe: factual "next step" suggestions, not personal advice.

- `lib/next-action.ts` — pure, tested `buildNextActions(signals)` → ranked `NextAction[]` with named priority constants and **cross-vertical routing** off `primary_vertical` (super → SMSF guide/calcs; property/FHB → FHOG + stamp-duty; international → country FI hub + non-resident compare; advisor/complex → find-advisor; broker verticals → compare/fee-calc/alert; HNW/pre-retiree flags). Surface-aware suppression; `showAdviceWarning` drives `PDS_CONSIDERATION` on product-adjacent CTAs only.
- `components/NextActions.tsx` — thin server component merging the three signal sources, `<Suspense fallback={null}>` (degrades silently for anonymous visitors).
- Mounted on the 4 missing high-traffic surfaces: `/compare`, `/advisors`, `/learn`, `article/[slug]`. The existing 9 `SmartRecommendationsStrip` mounts and `lib/quiz-scoring.ts` are untouched.

**Verified:** `tsc` clean · **65 tests** (ranking, cross-vertical routing, surface suppression, HNW/pre-retiree/cross-border flags, all 12 intent-country mappings, anonymous + edge cases) pass · eslint clean · jsonld gate green. No schema/API changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUfSRE2Teb6VhEXFP6RpS9)_