### PR TITLE
feat(sitemap): split into sitemap index (8 shards) for scale (deepen)

### DIFF
--- a/__tests__/lib/sitemap.test.ts
+++ b/__tests__/lib/sitemap.test.ts
@@ -1,12 +1,14 @@
 /**
- * Tests for `app/sitemap.ts` — verify that the new marketplace + testimonials
- * pages are emitted and that noindex `/account/refer` is *not*.
+ * Tests for `app/sitemap.ts` — verifies the sharded sitemap index structure.
  *
- * The sitemap module touches Supabase for several dynamic page groups, so
- * we stub the server client with a builder that returns empty data for
- * every table. The marketplace pages are derived from `getEnabledIntents()`
- * and `AUSTRALIAN_STATES`, both of which we mock to a fixed set so the
- * URL count is deterministic.
+ * The sitemap uses Next.js's `generateSitemaps()` + `sitemap({ id })` pattern,
+ * which produces a sitemap index at /sitemap.xml and individual shards at
+ * /sitemap/[id].xml. Each shard is tested independently; the union of all
+ * shards is checked for correctness (no dupes, no forbidden paths).
+ *
+ * Supabase is stubbed with a chain that returns empty data for every table
+ * so tests run without a live DB. Intent list and AUSTRALIAN_STATES are fixed
+ * so URL counts are deterministic.
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -15,14 +17,8 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("@/lib/supabase/server", () => ({
   createClient: vi.fn(async () => {
-    // Make the *chain* thenable (so `await client.from(...).select(...)`
-    // resolves), but DON'T make the top-level client object thenable —
-    // otherwise `Promise.resolve(client)` unwraps it via Promise's
-    // thenable-assimilation rule and `await createClient()` returns the
-    // chain payload (`{ data: [], error: null }`) instead of the client.
-    // That bug bit on every PR with NEXT_PUBLIC_SUPABASE_ANON_KEY set:
-    // `supabase.from is not a function` because `supabase` was actually
-    // `{ data, error }`.
+    // Make the chain thenable but NOT the top-level client object — avoids
+    // Promise thenable-assimilation swallowing the client itself.
     const makeChain = (): unknown => {
       const builder: Record<string, unknown> = {};
       const methods = [
@@ -75,87 +71,270 @@ vi.mock("@/lib/getmatched/intents", () => ({
   getEnabledIntents: vi.fn(() => Promise.resolve(TEST_INTENTS)),
 }));
 
-// Other helpers used inside sitemap pull from local arrays; nothing to mock.
-
 vi.mock("@/lib/glossary", () => ({
   GLOSSARY_ENTRIES: [],
 }));
 
-import sitemap from "@/app/sitemap";
+import sitemap, { generateSitemaps } from "@/app/sitemap";
 import { AUSTRALIAN_STATES } from "@/lib/seo/best-pages";
 
-describe("app/sitemap.ts — marketplace + testimonials", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Build every shard and return the flat union of all URLs. */
+async function getAllUrls(): Promise<string[]> {
+  const shardIds = generateSitemaps().map((s) => s.id);
+  const shards = await Promise.all(shardIds.map((id) => sitemap({ id })));
+  return shards.flat().map((e) => e.url);
+}
+
+/** Build a single shard and return its URLs. */
+async function getShardUrls(id: number): Promise<string[]> {
+  const entries = await sitemap({ id });
+  return entries.map((e) => e.url);
+}
+
+// ── generateSitemaps structure ────────────────────────────────────────────────
+
+describe("generateSitemaps()", () => {
+  it("returns 8 shards (ids 0–7)", () => {
+    const shards = generateSitemaps();
+    expect(shards).toHaveLength(8);
+    expect(shards.map((s) => s.id)).toEqual([0, 1, 2, 3, 4, 5, 6, 7]);
+  });
+});
+
+// ── Per-shard non-empty checks ────────────────────────────────────────────────
+
+describe("each shard is non-empty", () => {
+  for (let id = 0; id <= 7; id++) {
+    it(`shard ${id} emits at least 1 URL`, async () => {
+      const urls = await getShardUrls(id);
+      expect(urls.length).toBeGreaterThan(0);
+    });
+  }
+});
+
+// ── Category coverage ─────────────────────────────────────────────────────────
+
+describe("shard 0 — static pages", () => {
+  it("contains the homepage", async () => {
+    const urls = await getShardUrls(0);
+    expect(urls).toContain("https://invest.com.au");
   });
 
+  it("contains key high-priority hubs", async () => {
+    const urls = new Set(await getShardUrls(0));
+    for (const path of ["/compare", "/versus", "/quiz", "/etfs", "/insurance", "/tax"]) {
+      expect(urls.has(`https://invest.com.au${path}`)).toBe(true);
+    }
+  });
+
+  it("does NOT duplicate the homepage (empty string → /)", async () => {
+    const urls = await getShardUrls(0);
+    const homepageUrls = urls.filter((u) => u === "https://invest.com.au");
+    expect(homepageUrls.length).toBe(1);
+  });
+});
+
+describe("shard 1 — localized pages", () => {
+  it("contains canonical /foreign-investment", async () => {
+    const urls = await getShardUrls(1);
+    expect(urls).toContain("https://invest.com.au/foreign-investment");
+  });
+
+  it("contains zh and ko locale variants", async () => {
+    const urls = new Set(await getShardUrls(1));
+    expect(urls.has("https://invest.com.au/zh/foreign-investment")).toBe(true);
+    expect(urls.has("https://invest.com.au/ko/foreign-investment")).toBe(true);
+  });
+
+  it("contains ar locale variant for UAE", async () => {
+    const urls = new Set(await getShardUrls(1));
+    expect(urls.has("https://invest.com.au/ar/foreign-investment/united-arab-emirates")).toBe(true);
+  });
+});
+
+describe("shard 2 — brokers, best, versus, invest-categories", () => {
+  it("contains the /best hub", async () => {
+    const urls = await getShardUrls(2);
+    expect(urls).toContain("https://invest.com.au/best");
+  });
+
+  it("contains the /best-for hub", async () => {
+    const urls = await getShardUrls(2);
+    expect(urls).toContain("https://invest.com.au/best-for");
+  });
+
+  it("does NOT contain /invest hub (that lives in shard 0)", async () => {
+    // Static invest pages are in shard 0; shard 2 only has category/subcategory/listing pages
+    const urls = new Set(await getShardUrls(2));
+    expect(urls.has("https://invest.com.au/invest")).toBe(false);
+  });
+});
+
+describe("shard 3 — articles, scenarios, reports, alerts", () => {
+  it("returns an array (empty with mocked DB)", async () => {
+    const urls = await getShardUrls(3);
+    // With empty DB stub, article/scenario/etc. pages return empty arrays
+    expect(Array.isArray(urls)).toBe(true);
+  });
+});
+
+describe("shard 4 — advisors", () => {
+  it("contains advisor type pages", async () => {
+    const urls = new Set(await getShardUrls(4));
+    expect(urls.has("https://invest.com.au/advisors/financial-planners")).toBe(true);
+    expect(urls.has("https://invest.com.au/advisors/smsf-accountants")).toBe(true);
+  });
+
+  it("contains advisor type × state pages", async () => {
+    const urls = new Set(await getShardUrls(4));
+    expect(urls.has("https://invest.com.au/advisors/financial-planners/nsw")).toBe(true);
+  });
+
+  it("contains advisor type × city pages", async () => {
+    const urls = new Set(await getShardUrls(4));
+    expect(urls.has("https://invest.com.au/advisors/financial-planners/sydney")).toBe(true);
+  });
+
+  it("contains find-advisor location pages", async () => {
+    const urls = new Set(await getShardUrls(4));
+    expect(urls.has("https://invest.com.au/find-advisor/sydney")).toBe(true);
+    expect(urls.has("https://invest.com.au/find-advisor/sydney-financial-planner")).toBe(true);
+  });
+});
+
+describe("shard 5 — glossary, how-to, marketplace", () => {
   it("includes the /marketplace hub", async () => {
-    const entries = await sitemap();
-    const urls = entries.map((e) => e.url);
+    const urls = await getShardUrls(5);
     expect(urls).toContain("https://invest.com.au/marketplace");
   });
 
   it("includes /marketplace/[intent] for every enabled intent", async () => {
-    const entries = await sitemap();
-    const urls = new Set(entries.map((e) => e.url));
+    const urls = new Set(await getShardUrls(5));
     for (const intent of TEST_INTENTS) {
-      expect(urls.has(`https://invest.com.au/marketplace/${intent.slug}`)).toBe(
-        true,
-      );
+      expect(urls.has(`https://invest.com.au/marketplace/${intent.slug}`)).toBe(true);
     }
   });
 
   it("includes /marketplace/[intent]/[state] for every (intent × state) combo", async () => {
-    const entries = await sitemap();
-    const urls = new Set(entries.map((e) => e.url));
+    const urls = new Set(await getShardUrls(5));
     for (const intent of TEST_INTENTS) {
       for (const state of AUSTRALIAN_STATES) {
         expect(
-          urls.has(
-            `https://invest.com.au/marketplace/${intent.slug}/${state.slug}`,
-          ),
+          urls.has(`https://invest.com.au/marketplace/${intent.slug}/${state.slug}`),
         ).toBe(true);
       }
     }
   });
 
-  it("includes /testimonials", async () => {
-    const entries = await sitemap();
-    const urls = entries.map((e) => e.url);
+  it("emits correct marketplace URL count", async () => {
+    const urls = await getShardUrls(5);
+    const marketplaceCount = urls.filter((u) => u.includes("/marketplace")).length;
+    const expected =
+      1 + TEST_INTENTS.length + TEST_INTENTS.length * AUSTRALIAN_STATES.length;
+    expect(marketplaceCount).toBe(expected);
+  });
+});
+
+describe("shard 6 — property, suburb, investing-cities", () => {
+  it("contains property hub pages", async () => {
+    const urls = new Set(await getShardUrls(6));
+    expect(urls.has("https://invest.com.au/property")).toBe(true);
+    expect(urls.has("https://invest.com.au/property/listings")).toBe(true);
+    expect(urls.has("https://invest.com.au/property/suburbs")).toBe(true);
+  });
+
+  it("contains /investing hub", async () => {
+    const urls = await getShardUrls(6);
+    expect(urls).toContain("https://invest.com.au/investing");
+  });
+});
+
+describe("shard 7 — misc (quotes, newsletter, grants, events, afsl)", () => {
+  it("contains quote category×state pages", async () => {
+    const urls = new Set(await getShardUrls(7));
+    expect(urls.has("https://invest.com.au/quotes/by/financial_planner/nsw")).toBe(true);
+  });
+
+  it("contains /newsletter archive page", async () => {
+    const urls = await getShardUrls(7);
+    expect(urls).toContain("https://invest.com.au/newsletter");
+  });
+
+  it("contains grants industry pages", async () => {
+    const urls = new Set(await getShardUrls(7));
+    expect(urls.has("https://invest.com.au/grants/tech")).toBe(true);
+  });
+
+  it("contains /investing-for hub and occupation pages", async () => {
+    const urls = new Set(await getShardUrls(7));
+    expect(urls.has("https://invest.com.au/investing-for")).toBe(true);
+    expect(urls.has("https://invest.com.au/investing-for/doctor")).toBe(true);
+  });
+});
+
+// ── Cross-shard union checks ───────────────────────────────────────────────────
+
+describe("union of all shards", () => {
+  it("includes /marketplace", async () => {
+    const urls = await getAllUrls();
+    expect(urls).toContain("https://invest.com.au/marketplace");
+  });
+
+  it("includes /testimonials (shard 0)", async () => {
+    const urls = await getAllUrls();
     expect(urls).toContain("https://invest.com.au/testimonials");
   });
 
+  it("includes /feed (shard 0)", async () => {
+    const urls = await getAllUrls();
+    expect(urls).toContain("https://invest.com.au/feed");
+  });
+
+  it("includes /tax-return (shard 0)", async () => {
+    const urls = await getAllUrls();
+    expect(urls).toContain("https://invest.com.au/tax-return");
+  });
+
   it("does NOT include any /account/* paths (noindex)", async () => {
-    const entries = await sitemap();
-    const accountUrls = entries
-      .map((e) => e.url)
-      .filter((u) => u.includes("/account/"));
+    const urls = await getAllUrls();
+    const accountUrls = urls.filter((u) => u.includes("/account/"));
     expect(accountUrls).toEqual([]);
   });
 
   it("does NOT include any /admin/* paths", async () => {
-    const entries = await sitemap();
-    const adminUrls = entries
-      .map((e) => e.url)
-      .filter((u) => u.includes("/admin/") || u.endsWith("/admin"));
+    const urls = await getAllUrls();
+    const adminUrls = urls.filter((u) => u.includes("/admin/") || u.endsWith("/admin"));
     expect(adminUrls).toEqual([]);
   });
 
-  it("emits ~140 new marketplace + testimonials URLs", async () => {
-    const entries = await sitemap();
-    const urls = entries.map((e) => e.url);
-    const marketplaceCount = urls.filter((u) =>
-      u.includes("/marketplace"),
-    ).length;
-    const testimonialsCount = urls.filter((u) =>
-      u.endsWith("/testimonials"),
-    ).length;
-    // 1 hub + 17 intent + (17 × 8 states) = 154 marketplace + 1 testimonials = 155.
-    const expectedMarketplace =
-      1 + TEST_INTENTS.length + TEST_INTENTS.length * AUSTRALIAN_STATES.length;
-    expect(marketplaceCount).toBe(expectedMarketplace);
-    expect(testimonialsCount).toBe(1);
-    // Total new ≥ 140 per the task target.
-    expect(marketplaceCount + testimonialsCount).toBeGreaterThanOrEqual(140);
+  it("has no duplicate URLs across shards", async () => {
+    const urls = await getAllUrls();
+    const urlSet = new Set(urls);
+    // Build a map of URL → count for a helpful failure message
+    const dupeMap: Record<string, number> = {};
+    for (const url of urls) {
+      dupeMap[url] = (dupeMap[url] ?? 0) + 1;
+    }
+    const dupes = Object.entries(dupeMap)
+      .filter(([, count]) => count > 1)
+      .map(([url]) => url);
+    expect(dupes).toEqual([]);
+    expect(urls.length).toBe(urlSet.size);
+  });
+
+  it("covers all expected category shards (0-7 all return entries or empty for DB-driven)", async () => {
+    const shardIds = generateSitemaps().map((s) => s.id);
+    const results = await Promise.all(
+      shardIds.map(async (id) => ({ id, count: (await sitemap({ id })).length })),
+    );
+    // Shards with purely static content must be non-empty
+    const staticShards = [0, 1, 4, 5, 6, 7];
+    for (const { id, count } of results) {
+      if (staticShards.includes(id)) {
+        expect(count, `shard ${id} should be non-empty`).toBeGreaterThan(0);
+      }
+    }
   });
 });

--- a/__tests__/lib/sitemap.test.ts
+++ b/__tests__/lib/sitemap.test.ts
@@ -11,7 +11,7 @@
  * so URL counts are deterministic.
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 // ── Mocks ────────────────────────────────────────────────────────────────────
 
@@ -106,7 +106,12 @@ describe("generateSitemaps()", () => {
 // ── Per-shard non-empty checks ────────────────────────────────────────────────
 
 describe("each shard is non-empty", () => {
-  for (let id = 0; id <= 7; id++) {
+  // DB-driven shards (2, 3) can be legitimately empty under the empty-DB test mock
+  // (shard 3 is purely articles/scenarios/reports/alerts). Their functions are
+  // validated by the union + category tests below; here we assert the statically
+  // seeded shards always emit URLs. Matches `staticShards` in the coverage test.
+  const staticShards = [0, 1, 4, 5, 6, 7];
+  for (const id of staticShards) {
     it(`shard ${id} emits at least 1 URL`, async () => {
       const urls = await getShardUrls(id);
       expect(urls.length).toBeGreaterThan(0);
@@ -320,7 +325,7 @@ describe("union of all shards", () => {
     const dupes = Object.entries(dupeMap)
       .filter(([, count]) => count > 1)
       .map(([url]) => url);
-    expect(dupes).toEqual([]);
+    expect(dupes, `duplicate URLs across shards: ${JSON.stringify(dupes)}`).toEqual([]);
     expect(urls.length).toBe(urlSet.size);
   });
 

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -16,25 +16,61 @@ import { BCP47_TAG } from "@/lib/i18n/locales";
 import { AUSTRALIAN_STATES } from "@/lib/seo/best-pages";
 import { getEnabledIntents } from "@/lib/getmatched/intents";
 
-// Regenerate sitemap at most once per day — avoids per-request DB queries
+// Regenerate each shard at most once per day — avoids per-request DB queries
 export const revalidate = 86400;
 
-export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://invest.com.au";
-  const hasSupabase = !!(process.env.NEXT_PUBLIC_SUPABASE_URL && process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY);
-  const supabase = hasSupabase ? await createClient() : null;
+// ─── Shard IDs ────────────────────────────────────────────────────────────────
+// 0  static pages
+// 1  localized / hreflang pages
+// 2  brokers + best/best-for + versus + cost scenarios
+// 3  articles + scenarios + reports + alerts
+// 4  advisors (profiles, type×state, type×city, find-advisor)
+// 5  glossary + how-to + invest-categories + marketplace
+// 6  property + suburb guides + investing-cities
+// 7  misc (authors, reviewers, quotes, newsletter, grants, investingFor, events, afsl, feed)
+// ─────────────────────────────────────────────────────────────────────────────
 
-  // Static pages with tiered priorities
+export function generateSitemaps() {
+  return [
+    { id: 0 },
+    { id: 1 },
+    { id: 2 },
+    { id: 3 },
+    { id: 4 },
+    { id: 5 },
+    { id: 6 },
+    { id: 7 },
+  ];
+}
+
+// ─── Shared helpers ───────────────────────────────────────────────────────────
+
+function baseUrl(): string {
+  return process.env.NEXT_PUBLIC_SITE_URL || "https://invest.com.au";
+}
+
+async function getSupabase() {
+  const hasSupabase = !!(
+    process.env.NEXT_PUBLIC_SUPABASE_URL &&
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  );
+  return hasSupabase ? await createClient() : null;
+}
+
+// ─── Shard builders ───────────────────────────────────────────────────────────
+
+async function buildShard0(): Promise<MetadataRoute.Sitemap> {
+  const base = baseUrl();
   const highPriority = new Set(["/compare", "/quiz", "/reviews", "/deals", "/share-trading", "/crypto", "/savings", "/super", "/cfd", "/term-deposits", "/robo-advisors", "/versus", "/how-to", "/invest", "/foreign-investment", "/global-investing", "/etfs", "/insurance", "/tax", "/property", "/grants", "/grants/rd-tax-incentive", "/smsf/setup", "/smsf/crypto", "/smsf/property", "/sell-business", "/sell-business/valuation", "/dividends", "/dividends/franking-credits", "/negative-gearing", "/lump-sum-investing", "/lump-sum-investing/redundancy", "/lump-sum-investing/inheritance", "/halal-investing", "/learn", "/first-home-buyer", "/redundancy", "/inheritance"]);
   const medPriority = new Set(["/calculators", "/articles", "/scenarios", "/switch", "/stories", "/benchmark", "/health-scores", "/alerts", "/whats-new", "/costs", "/fee-impact", "/fee-alerts", "/rate-alerts", "/compound-interest-calculator", "/dividend-reinvestment-calculator", "/fire-calculator", "/property-vs-shares-calculator", "/super-contributions-calculator", "/tco-calculator", "/invest/mining", "/invest/buy-business", "/invest/farmland", "/invest/commercial-property", "/invest/renewable-energy", "/invest/startups", "/compare/non-residents", "/compare/money-transfer", "/grants/emdg", "/grants/industry-growth-program", "/grants/eligibility-quiz", "/smsf/investment-strategy", "/smsf/checklist", "/sell-business/checklist", "/visa-investment", "/dividends/calculator", "/negative-gearing/calculator", "/lump-sum-investing/calculator",
     "/wealth-stack", "/startup/grants", "/lic-screener", "/tools/subscription-audit",
     "/questions", ...QUESTIONS.map((q) => `/questions/${q.slug}`)]);
-  // Everything else (about, how-we-earn, privacy, methodology, terms, etc.) → 0.4
 
-  const staticPages = [
+  const staticPaths = [
     "", "/compare", "/versus", "/reviews", "/calculators",
     "/term-deposits", "/robo-advisors", "/property-platforms", "/research-tools",
     "/invest", "/invest/funds",
+    "/invest/listings", "/invest/alternatives/platforms", "/invest/alternatives/guides",
     // Browse-Opportunities (intent: opportunity) — IA refactor 2026-05-07.
     // The 4 Compare-tagged slugs (forex, managed-funds, dividend-investing,
     // ipos) are 301-redirected via next.config.ts and intentionally absent
@@ -55,19 +91,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     "/invest/ipo-calendar", "/invest/commodities",
     "/smsf", "/smsf/auditors",
     "/research",
-    "/invest/buy-business/listings", "/invest/mining/listings",
-    "/invest/farmland/listings", "/invest/commercial-property/listings",
-    "/invest/franchise/listings", "/invest/renewable-energy/listings",
-    "/invest/startups/listings", "/invest/alternatives/listings",
-    "/invest/private-credit/listings", "/invest/infrastructure/listings",
-    "/invest/digital-infrastructure/listings",
-    "/invest/public-social-infrastructure/listings",
-    // carbon/aquaculture/livestock/royalties/VC/litigation-funding/ILS /listings
-    // de-indexed (no live listings yet — thin pages hurt crawl budget).
-    // Guide hubs stay; listing pages omitted until supply threshold is met.
+    // /invest/X/listings pages are generated programmatically in shard 2 via
+    // getOpportunityCategories() — do NOT hardcode them here to avoid duplication.
+    // These non-opportunity invest paths (aquaculture, livestock, etc.) are
+    // guide-only and have no /listings subdirectory.
     "/invest/aquaculture",
     "/invest/livestock",
-    "/invest/private-equity/listings",
     "/invest/venture-capital",
     "/invest/litigation-funding",
     "/invest/insurance-linked-securities",
@@ -104,8 +133,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     "/advisor-guides/tax-agent-vs-accountant",
     "/advisor-guides/mortgage-broker-vs-bank",
     "/advisor-guides/buyers-agent-vs-diy",
-    
-    "/portfolio-calculator",
+
     "/advisor-apply", "/switching-calculator", "/savings-calculator",
     "/quick-audit", "/portfolio-xray", "/tax-optimizer", "/fee-simulator",
     "/trade-cost-calculator", "/us-share-costs-calculator", "/cgt-calculator",
@@ -124,7 +152,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     "/tools/salary-sacrifice-optimiser",
     "/tools/cgt-calculator",
     "/tools/subscription-audit",
-    "/lic-screener",
     "/startup/grants",
     "/wealth-stack",
     "/redundancy",
@@ -156,8 +183,8 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     "/learn",
     // Global investing hub (outbound — AU residents → world)
     "/global-investing",
-    // Foreign investment hub — hreflang-aware entries generated in localizedPages below.
-    // Non-localised sub-pages remain here; UAE is also in localizedPages (ar variant).
+    // Foreign investment hub — hreflang-aware entries generated in shard 1.
+    // Non-localised sub-pages remain here; UAE is also in shard 1 (ar variant).
     "/foreign-investment/super",
     "/foreign-investment/shares", "/foreign-investment/energy",
     "/foreign-investment/savings", "/foreign-investment/cfd",
@@ -180,10 +207,10 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     // Property sub-pages
     "/property/finance",
     // Additional public pages
-    "/tools", "/rates", "/properties", "/pro",
+    "/rates", "/properties", "/pro",
     "/advertise", "/advertise/packages", "/advertise/featured-placement", "/advertiser-terms", "/accessibility",
     "/fsg", "/legal", "/developer-terms", "/consultations",
-    "/courses", "/reports", "/portfolio", "/portfolio-calculator",
+    "/courses", "/reports", "/portfolio",
     "/advisor-signup",
     "/quotes", "/quotes/post", "/quotes/recent-wins",
     "/press",
@@ -192,7 +219,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     "/advisor-guides/how-to-choose-real-estate-agent",
     // Calculators
     "/mortgage-calculator", "/retirement-calculator", "/smsf-calculator",
-    "/debt-calculator", "/property-yield-calculator", "/fee-impact",
+    "/debt-calculator", "/property-yield-calculator",
     "/compound-interest-calculator", "/dividend-reinvestment-calculator",
     "/fire-calculator", "/property-vs-shares-calculator",
     "/super-contributions-calculator", "/tco-calculator",
@@ -206,12 +233,81 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     "/advisors/leaderboard", "/advisors/compare",
     // Content tools
     "/switch-scripts",
-  ].map((path) => ({
-    url: `${baseUrl}${path}`,
+    // New hub pages (static portions)
+    "/etfs", "/etfs/asx-200", "/etfs/us-exposure", "/etfs/dividends",
+    "/etfs/screener",
+    "/etfs/vas", "/etfs/a200", "/etfs/ivv", "/etfs/ndq", "/etfs/vgs",
+    "/etfs/vts", "/etfs/vhy", "/etfs/stw", "/etfs/ioz", "/etfs/ethi",
+    "/etfs/vgad", "/etfs/hack", "/etfs/vaf", "/etfs/iwld",
+    "/etfs/vs/vas-vs-a200", "/etfs/vs/vas-vs-stw", "/etfs/vs/ioz-vs-vas",
+    "/etfs/vs/ivv-vs-vts", "/etfs/vs/ndq-vs-ivv", "/etfs/vs/vgs-vs-ivv",
+    "/etfs/vs/vhy-vs-hvst", "/etfs/vs/vhy-vs-vas",
+    "/insurance", "/insurance/life", "/insurance/income-protection",
+    "/insurance/health", "/insurance/home-contents",
+    "/tax", "/tax/capital-gains", "/tax/franking-credits",
+    "/tax/negative-gearing", "/tax/crypto",
+    "/fee-tracker",
+    "/super/smsf",
+    "/advisors/international-tax-specialists",
+    "/advisors/firb-specialists",
+    "/advisors/migration-agents",
+    "/brokers/full-service",
+    // Testimonials, feed, tax-return hub
+    "/testimonials",
+    "/feed",
+    "/tax-return",
+  ];
+
+  return staticPaths.map((path) => ({
+    url: `${base}${path}`,
     lastModified: new Date(),
     changeFrequency: (path === "" || highPriority.has(path) ? "weekly" : "monthly") as "weekly" | "monthly",
     priority: path === "" ? 1.0 : highPriority.has(path) ? 0.9 : medPriority.has(path) ? 0.7 : 0.4,
   }));
+}
+
+async function buildShard1(): Promise<MetadataRoute.Sitemap> {
+  const base = baseUrl();
+
+  const LOCALE_GROUPS: Array<{
+    canonical: string;
+    canonicalPriority: number;
+    localePaths: Partial<Record<"zh" | "ko" | "ar", string>>;
+  }> = [
+    { canonical: "/foreign-investment",           canonicalPriority: 0.9, localePaths: { zh: "/zh/foreign-investment",           ko: "/ko/foreign-investment"           } },
+    { canonical: "/foreign-investment/siv",        canonicalPriority: 0.7, localePaths: { zh: "/zh/foreign-investment/siv",        ko: "/ko/foreign-investment/siv"        } },
+    { canonical: "/foreign-investment/property",   canonicalPriority: 0.7, localePaths: { zh: "/zh/foreign-investment/property",   ko: "/ko/foreign-investment/property"   } },
+    { canonical: "/foreign-investment/tax",        canonicalPriority: 0.7, localePaths: { zh: "/zh/foreign-investment/tax",        ko: "/ko/foreign-investment/tax"        } },
+    { canonical: "/foreign-investment/united-arab-emirates", canonicalPriority: 0.7, localePaths: { ar: "/ar/foreign-investment/united-arab-emirates" } },
+  ];
+
+  return LOCALE_GROUPS.flatMap(
+    ({ canonical, canonicalPriority, localePaths }) => {
+      const languages: Record<string, string> = {
+        [BCP47_TAG.en]: `${base}${canonical}`,
+        "x-default": `${base}${canonical}`,
+      };
+      for (const [locale, localePath] of Object.entries(localePaths) as [keyof typeof BCP47_TAG, string][]) {
+        languages[BCP47_TAG[locale]] = `${base}${localePath}`;
+      }
+      const alternates = { languages };
+      return [
+        { url: `${base}${canonical}`, lastModified: new Date(), changeFrequency: "weekly" as const, priority: canonicalPriority, alternates },
+        ...Object.values(localePaths).map((localePath) => ({
+          url: `${base}${localePath}`,
+          lastModified: new Date(),
+          changeFrequency: "weekly" as const,
+          priority: Math.min(canonicalPriority, 0.7) as number,
+          alternates,
+        })),
+      ];
+    },
+  );
+}
+
+async function buildShard2(): Promise<MetadataRoute.Sitemap> {
+  const base = baseUrl();
+  const supabase = await getSupabase();
 
   // Dynamic broker pages
   const { data: brokers } = supabase
@@ -219,57 +315,24 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     : { data: null };
 
   const brokerPages = (brokers || []).map((b) => ({
-    url: `${baseUrl}/broker/${b.slug}`,
+    url: `${base}/broker/${b.slug}`,
     lastModified: b.updated_at ? new Date(b.updated_at) : new Date(),
     changeFrequency: "weekly" as const,
     priority: 0.7,
   }));
 
-  // Dynamic article pages — only published. Without this filter,
-  // drafts (status='draft') and archived (status='archived') articles
-  // leak into the sitemap and get crawled by Google. Every other
-  // dynamic source on this file (brokers, professionals, scenarios,
-  // alerts, reports, advisor_articles) already filters by its
-  // status column; this query was the lone exception (P0-4 in
-  // docs/audits/2026-04-26-comprehensive-audit.md §8.1).
-  const { data: articles } = supabase
-    ? await supabase
-        .from("articles")
-        .select("slug, updated_at")
-        .eq("status", "published")
-    : { data: null };
-
-  const articlePages = (articles || []).map((a) => ({
-    url: `${baseUrl}/article/${a.slug}`,
-    lastModified: a.updated_at ? new Date(a.updated_at) : new Date(),
-    changeFrequency: "monthly" as const,
-    priority: 0.6,
-  }));
-
-  // Dynamic scenario pages
-  const { data: scenarios } = supabase
-    ? await supabase.from("scenarios").select("slug, updated_at")
-    : { data: null };
-
-  const scenarioPages = (scenarios || []).map((s) => ({
-    url: `${baseUrl}/scenario/${s.slug}`,
-    lastModified: s.updated_at ? new Date(s.updated_at) : new Date(),
-    changeFrequency: "monthly" as const,
-    priority: 0.6,
-  }));
-
   // Best Broker for X hub pages
   const bestPages = [
-    { url: `${baseUrl}/best`, lastModified: new Date(), changeFrequency: "weekly" as const, priority: 0.9 },
+    { url: `${base}/best`, lastModified: new Date(), changeFrequency: "weekly" as const, priority: 0.9 },
     ...getAllCategorySlugs().map((slug) => ({
-      url: `${baseUrl}/best/${slug}`,
+      url: `${base}/best/${slug}`,
       lastModified: new Date(),
       changeFrequency: "weekly" as const,
       priority: 0.8,
     })),
   ];
 
-  // Dynamic /best-for/[slug] scenarios (from best_for_scenarios)
+  // Dynamic /best-for/[slug] scenarios
   const { data: bestForScenarios } = supabase
     ? await supabase
         .from("best_for_scenarios")
@@ -277,121 +340,18 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
         .eq("status", "active")
     : { data: null };
   const bestForPages = [
-    { url: `${baseUrl}/best-for`, lastModified: new Date(), changeFrequency: "weekly" as const, priority: 0.85 },
+    { url: `${base}/best-for`, lastModified: new Date(), changeFrequency: "weekly" as const, priority: 0.85 },
     ...(bestForScenarios || []).map((s: { slug: string; updated_at: string | null }) => ({
-      url: `${baseUrl}/best-for/${s.slug}`,
+      url: `${base}/best-for/${s.slug}`,
       lastModified: s.updated_at ? new Date(s.updated_at) : new Date(),
       changeFrequency: "weekly" as const,
       priority: 0.75,
     })),
   ];
 
-  // Dynamic commodity sector stocks + ETFs pages
-  const { data: commoditySectors } = supabase
-    ? await supabase
-        .from("commodity_sectors")
-        .select("slug")
-        .eq("status", "active")
-    : { data: null };
-  const commodityPages = (commoditySectors || []).flatMap(
-    (s: { slug: string }) => [
-      {
-        url: `${baseUrl}/invest/${s.slug}/stocks`,
-        lastModified: new Date(),
-        changeFrequency: "weekly" as const,
-        priority: 0.7,
-      },
-      {
-        url: `${baseUrl}/invest/${s.slug}/etfs`,
-        lastModified: new Date(),
-        changeFrequency: "weekly" as const,
-        priority: 0.7,
-      },
-    ],
-  );
-
-  // Individual stock detail pages
-  const { data: commodityStocks } = supabase
-    ? await supabase
-        .from("commodity_stocks")
-        .select("sector_slug, ticker")
-        .eq("status", "active")
-    : { data: null };
-  const stockDetailPages = (commodityStocks || []).map(
-    (s: { sector_slug: string; ticker: string }) => ({
-      url: `${baseUrl}/invest/${s.sector_slug}/stocks/${s.ticker.toLowerCase()}`,
-      lastModified: new Date(),
-      changeFrequency: "weekly" as const,
-      priority: 0.6,
-    }),
-  );
-
-  // Broker transfer guides
-  const { data: transferGuides } = supabase
-    ? await supabase
-        .from("broker_transfer_guides")
-        .select("broker_slug, updated_at")
-    : { data: null };
-  const transferGuidePages = [
-    { url: `${baseUrl}/how-to/transfer-from`, lastModified: new Date(), changeFrequency: "weekly" as const, priority: 0.8 },
-    ...(transferGuides || []).map(
-      (g: { broker_slug: string; updated_at: string | null }) => ({
-        url: `${baseUrl}/how-to/transfer-from/${g.broker_slug}`,
-        lastModified: g.updated_at ? new Date(g.updated_at) : new Date(),
-        changeFrequency: "monthly" as const,
-        priority: 0.7,
-      }),
-    ),
-  ];
-
-  // Dynamic team member pages (authors + reviewers)
-  const { data: teamMembers } = supabase
-    ? await supabase.from("team_members").select("slug, role, updated_at").eq("status", "active")
-    : { data: null };
-
-  const authorPages = (teamMembers || []).map((m) => ({
-    url: `${baseUrl}/authors/${m.slug}`,
-    lastModified: m.updated_at ? new Date(m.updated_at) : new Date(),
-    changeFrequency: "monthly" as const,
-    priority: 0.4,
-  }));
-
-  const reviewerPages = (teamMembers || [])
-    .filter((m) => m.role === "expert_reviewer" || m.role === "editor")
-    .map((m) => ({
-      url: `${baseUrl}/reviewers/${m.slug}`,
-      lastModified: m.updated_at ? new Date(m.updated_at) : new Date(),
-      changeFrequency: "monthly" as const,
-      priority: 0.4,
-    }));
-
-  // Dynamic regulatory alert pages
-  const { data: alerts } = supabase
-    ? await supabase.from("regulatory_alerts").select("slug, updated_at").eq("status", "published")
-    : { data: null };
-
-  const alertPages = (alerts || []).map((a) => ({
-    url: `${baseUrl}/alerts/${a.slug}`,
-    lastModified: a.updated_at ? new Date(a.updated_at) : new Date(),
-    changeFrequency: "monthly" as const,
-    priority: 0.6,
-  }));
-
-  // Dynamic quarterly report pages
-  const { data: reports } = supabase
-    ? await supabase.from("quarterly_reports").select("slug, updated_at").eq("status", "published")
-    : { data: null };
-
-  const reportPages = (reports || []).map((r) => ({
-    url: `${baseUrl}/reports/${r.slug}`,
-    lastModified: r.updated_at ? new Date(r.updated_at) : new Date(),
-    changeFrequency: "monthly" as const,
-    priority: 0.6,
-  }));
-
   // Cost scenario pages
   const costPages = getAllCostScenarioSlugs().map((slug) => ({
-    url: `${baseUrl}/costs/${slug}`,
+    url: `${base}/costs/${slug}`,
     lastModified: new Date(),
     changeFrequency: "weekly" as const,
     priority: 0.7,
@@ -528,10 +488,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     "axitrader-vs-pepperstone", "activtrades-vs-pepperstone",
   ];
 
-  // Programmatic versus pairs — generated from live broker inventory so
-  // new brokers automatically enter SEO coverage. Curated pairs are
-  // merged in too so any hand-picked pair (e.g. one we have editorial
-  // for) is guaranteed to ship.
+  // Programmatic versus pairs — generated from live broker inventory
   let generatedPairSlugs: string[] = [];
   let editorialSlugs: string[] = [];
   if (supabase) {
@@ -540,10 +497,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
         .from("brokers")
         .select("slug, name, rating, platform_type")
         .eq("status", "active"),
-      // Every row in versus_editorials is a page that definitely has
-      // content — guarantee those are in the sitemap even if the
-      // generator happens not to surface them (platform-type drift,
-      // deactivated broker, etc).
       supabase.from("versus_editorials").select("slug"),
     ]);
     const versusRows = versusRowsRes.data;
@@ -566,14 +519,204 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     const hasEditorial = editorialSlugSet.has(pair);
     const isHandCurated = versusPopularPairs.includes(pair);
     return {
-      url: `${baseUrl}/versus/${pair}`,
+      url: `${base}/versus/${pair}`,
       lastModified: new Date(),
       changeFrequency: "weekly" as const,
-      // Pages with real editorial content ship at 0.9; curated-but-no-
-      // editorial pairs at 0.8; auto-generated pairs at 0.6.
       priority: hasEditorial ? 0.9 : isHandCurated ? 0.8 : 0.6,
     };
   });
+
+  // Dynamic commodity sector stocks + ETFs pages
+  const { data: commoditySectors } = supabase
+    ? await supabase
+        .from("commodity_sectors")
+        .select("slug")
+        .eq("status", "active")
+    : { data: null };
+  const commodityPages = (commoditySectors || []).flatMap(
+    (s: { slug: string }) => [
+      {
+        url: `${base}/invest/${s.slug}/stocks`,
+        lastModified: new Date(),
+        changeFrequency: "weekly" as const,
+        priority: 0.7,
+      },
+      {
+        url: `${base}/invest/${s.slug}/etfs`,
+        lastModified: new Date(),
+        changeFrequency: "weekly" as const,
+        priority: 0.7,
+      },
+    ],
+  );
+
+  // Individual stock detail pages
+  const { data: commodityStocks } = supabase
+    ? await supabase
+        .from("commodity_stocks")
+        .select("sector_slug, ticker")
+        .eq("status", "active")
+    : { data: null };
+  const stockDetailPages = (commodityStocks || []).map(
+    (s: { sector_slug: string; ticker: string }) => ({
+      url: `${base}/invest/${s.sector_slug}/stocks/${s.ticker.toLowerCase()}`,
+      lastModified: new Date(),
+      changeFrequency: "weekly" as const,
+      priority: 0.6,
+    }),
+  );
+
+  // Broker transfer guides
+  const { data: transferGuides } = supabase
+    ? await supabase
+        .from("broker_transfer_guides")
+        .select("broker_slug, updated_at")
+    : { data: null };
+  const transferGuidePages = [
+    { url: `${base}/how-to/transfer-from`, lastModified: new Date(), changeFrequency: "weekly" as const, priority: 0.8 },
+    ...(transferGuides || []).map(
+      (g: { broker_slug: string; updated_at: string | null }) => ({
+        url: `${base}/how-to/transfer-from/${g.broker_slug}`,
+        lastModified: g.updated_at ? new Date(g.updated_at) : new Date(),
+        changeFrequency: "monthly" as const,
+        priority: 0.7,
+      }),
+    ),
+  ];
+
+  // Full-service stockbroker firm detail pages
+  const { data: stockbrokerFirms } = supabase
+    ? await supabase
+        .from("professionals")
+        .select("slug, updated_at")
+        .in("type", ["stockbroker_firm", "private_wealth_manager"])
+        .eq("status", "active")
+    : { data: null };
+  const stockbrokerFirmPages = (stockbrokerFirms || []).map((f) => ({
+    url: `${base}/brokers/full-service/${f.slug}`,
+    lastModified: f.updated_at ? new Date(f.updated_at) : new Date(),
+    changeFrequency: "weekly" as const,
+    priority: 0.7,
+  }));
+
+  // Category listing pages — /invest/{slug}/listings for all opportunity categories.
+  // Static invest hub pages (/invest, /invest/listings, /invest/alternatives, etc.) live in shard 0.
+  const investCategoryPages = getOpportunityCategories().map((c) => c.slug).map((slug) => ({
+    url: `${base}/invest/${slug}/listings`,
+    lastModified: new Date(),
+    changeFrequency: "weekly" as const,
+    priority: 0.8,
+  }));
+
+  // Sub-category listing pages
+  const investSubcategoryPages = getAllSubcategorySlugs().map(({ category, subcategory }) => ({
+    url: `${base}/invest/${category}/listings/${subcategory}`,
+    lastModified: new Date(),
+    changeFrequency: "weekly" as const,
+    priority: 0.7,
+  }));
+
+  // Individual investment listing detail pages
+  const { data: investListings } = supabase
+    ? await supabase.from("investment_listings").select("slug, vertical, sub_category, updated_at").eq("status", "active")
+    : { data: null };
+
+  const investListingPages = (investListings || []).map((l) => ({
+    url: `${base}${listingUrl(l as { vertical: InvestListingVertical; sub_category?: string; slug: string })}`,
+    lastModified: l.updated_at ? new Date(l.updated_at) : new Date(),
+    changeFrequency: "weekly" as const,
+    priority: 0.6,
+  }));
+
+  return [
+    ...brokerPages,
+    ...bestPages,
+    ...bestForPages,
+    ...costPages,
+    ...versusPages,
+    ...commodityPages,
+    ...stockDetailPages,
+    ...transferGuidePages,
+    ...stockbrokerFirmPages,
+    ...investCategoryPages,
+    ...investSubcategoryPages,
+    ...investListingPages,
+  ];
+}
+
+async function buildShard3(): Promise<MetadataRoute.Sitemap> {
+  const base = baseUrl();
+  const supabase = await getSupabase();
+
+  // Dynamic article pages — only published
+  const { data: articles } = supabase
+    ? await supabase
+        .from("articles")
+        .select("slug, updated_at")
+        .eq("status", "published")
+    : { data: null };
+
+  const articlePages = (articles || []).map((a) => ({
+    url: `${base}/article/${a.slug}`,
+    lastModified: a.updated_at ? new Date(a.updated_at) : new Date(),
+    changeFrequency: "monthly" as const,
+    priority: 0.6,
+  }));
+
+  // Dynamic scenario pages
+  const { data: scenarios } = supabase
+    ? await supabase.from("scenarios").select("slug, updated_at")
+    : { data: null };
+
+  const scenarioPages = (scenarios || []).map((s) => ({
+    url: `${base}/scenario/${s.slug}`,
+    lastModified: s.updated_at ? new Date(s.updated_at) : new Date(),
+    changeFrequency: "monthly" as const,
+    priority: 0.6,
+  }));
+
+  // Dynamic regulatory alert pages
+  const { data: alerts } = supabase
+    ? await supabase.from("regulatory_alerts").select("slug, updated_at").eq("status", "published")
+    : { data: null };
+
+  const alertPages = (alerts || []).map((a) => ({
+    url: `${base}/alerts/${a.slug}`,
+    lastModified: a.updated_at ? new Date(a.updated_at) : new Date(),
+    changeFrequency: "monthly" as const,
+    priority: 0.6,
+  }));
+
+  // Dynamic quarterly report pages
+  const { data: reports } = supabase
+    ? await supabase.from("quarterly_reports").select("slug, updated_at").eq("status", "published")
+    : { data: null };
+
+  const reportPages = (reports || []).map((r) => ({
+    url: `${base}/reports/${r.slug}`,
+    lastModified: r.updated_at ? new Date(r.updated_at) : new Date(),
+    changeFrequency: "monthly" as const,
+    priority: 0.6,
+  }));
+
+  // Expert articles (advisor-authored)
+  const { data: expertArticleSlugs } = supabase
+    ? await supabase.from("advisor_articles").select("slug, published_at").eq("status", "published")
+    : { data: null };
+
+  const expertArticlePages = (expertArticleSlugs || []).map((a) => ({
+    url: `${base}/expert/${a.slug}`,
+    lastModified: a.published_at ? new Date(a.published_at) : new Date(),
+    changeFrequency: "monthly" as const,
+    priority: 0.6,
+  }));
+
+  return [...articlePages, ...scenarioPages, ...alertPages, ...reportPages, ...expertArticlePages];
+}
+
+async function buildShard4(): Promise<MetadataRoute.Sitemap> {
+  const base = baseUrl();
+  const supabase = await getSupabase();
 
   // Dynamic advisor profile pages
   const { data: professionals } = supabase
@@ -581,15 +724,13 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     : { data: null };
 
   const advisorPages = (professionals || []).map((p) => ({
-    url: `${baseUrl}/advisor/${p.slug}`,
+    url: `${base}/advisor/${p.slug}`,
     lastModified: p.updated_at ? new Date(p.updated_at) : new Date(),
     changeFrequency: "weekly" as const,
     priority: 0.7,
   }));
 
-  // Programmatic /find/[advisor-type]/[city] pages — DB-driven, same source as
-  // generateStaticParams in app/find/[advisor-type]/[city]/page.tsx.
-  // Deduplicates by type×city slug combination, capped at 2000 entries.
+  // Programmatic /find/[advisor-type]/[city] pages
   const { data: findAdvisorRows } = supabase
     ? await supabase
         .from("professionals")
@@ -606,16 +747,16 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       const key = `${typeSlug}:${citySlug}`;
       if (findAdvisorSeen.has(key)) return [];
       findAdvisorSeen.add(key);
-      return [{ url: `${baseUrl}/find/${typeSlug}/${citySlug}`, lastModified: new Date(), changeFrequency: "weekly" as const, priority: 0.65 }];
+      return [{ url: `${base}/find/${typeSlug}/${citySlug}`, lastModified: new Date(), changeFrequency: "weekly" as const, priority: 0.65 }];
     })
     .slice(0, 2000);
 
-  // Programmatic advisor type + state pages
+  // Advisor type + state pages
   const advisorTypes = ["smsf-accountants", "financial-planners", "property-advisors", "tax-agents", "mortgage-brokers", "estate-planners", "insurance-brokers", "buyers-agents", "real-estate-agents", "wealth-managers", "aged-care-advisors", "crypto-advisors", "debt-counsellors"];
   const states = ["nsw", "vic", "qld", "wa", "sa", "tas", "act", "nt"];
 
   const advisorTypePages = advisorTypes.map((type) => ({
-    url: `${baseUrl}/advisors/${type}`,
+    url: `${base}/advisors/${type}`,
     lastModified: new Date(),
     changeFrequency: "weekly" as const,
     priority: 0.8,
@@ -623,18 +764,18 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   const advisorStatePages = advisorTypes.flatMap((type) =>
     states.map((state) => ({
-      url: `${baseUrl}/advisors/${type}/${state}`,
+      url: `${base}/advisors/${type}/${state}`,
       lastModified: new Date(),
       changeFrequency: "weekly" as const,
       priority: 0.6,
     }))
   );
 
-  // Advisor type + city pages (e.g. /advisors/financial-planners/sydney)
+  // Advisor type + city pages
   const advisorCities = ["sydney", "melbourne", "brisbane", "perth", "adelaide", "gold-coast", "canberra", "hobart", "darwin", "newcastle", "wollongong", "geelong", "sunshine-coast", "townsville", "cairns", "toowoomba", "ballarat", "bendigo", "launceston", "central-coast"];
   const advisorCityPages = advisorTypes.flatMap((type) =>
     advisorCities.map((city) => ({
-      url: `${baseUrl}/advisors/${type}/${city}`,
+      url: `${base}/advisors/${type}/${city}`,
       lastModified: new Date(),
       changeFrequency: "weekly" as const,
       priority: 0.6,
@@ -647,89 +788,38 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     "newcastle", "wollongong", "geelong", "sunshine-coast", "townsville", "cairns", "toowoomba",
     "ballarat", "bendigo", "launceston", "central-coast",
     // City + type combos (high search volume)
-    // Financial planners — all major cities
     "sydney-financial-planner", "melbourne-financial-planner", "brisbane-financial-planner",
     "perth-financial-planner", "adelaide-financial-planner", "canberra-financial-planner",
     "gold-coast-financial-planner", "hobart-financial-planner", "darwin-financial-planner",
     "newcastle-financial-planner", "wollongong-financial-planner", "geelong-financial-planner",
     "sunshine-coast-financial-planner", "townsville-financial-planner",
-    // SMSF accountants — major cities
     "sydney-smsf", "melbourne-smsf", "brisbane-smsf",
     "perth-smsf", "adelaide-smsf", "canberra-smsf", "gold-coast-smsf",
-    // Tax agents — major cities
     "sydney-tax-agent", "melbourne-tax-agent", "brisbane-tax-agent",
     "perth-tax-agent", "adelaide-tax-agent", "canberra-tax-agent",
-    // Mortgage brokers — all major cities
     "sydney-mortgage-broker", "melbourne-mortgage-broker", "brisbane-mortgage-broker",
     "perth-mortgage-broker", "gold-coast-mortgage-broker", "adelaide-mortgage-broker",
     "canberra-mortgage-broker", "hobart-mortgage-broker", "newcastle-mortgage-broker",
     "wollongong-mortgage-broker", "geelong-mortgage-broker", "sunshine-coast-mortgage-broker",
-    // Property & buyers agents
     "sydney-property-advisor", "melbourne-property-advisor", "brisbane-property-advisor",
     "perth-property-advisor", "adelaide-property-advisor",
     "sydney-buyers-agent", "melbourne-buyers-agent", "brisbane-buyers-agent",
     "perth-buyers-agent", "gold-coast-buyers-agent", "adelaide-buyers-agent",
     "canberra-buyers-agent", "newcastle-buyers-agent", "sunshine-coast-buyers-agent",
-    // Accountants
     "sydney-accountant", "melbourne-accountant", "brisbane-accountant",
     "perth-accountant", "adelaide-accountant",
-    // Wealth managers
     "sydney-wealth-manager", "melbourne-wealth-manager", "brisbane-wealth-manager",
     "perth-wealth-manager",
-    // Estate planners
     "sydney-estate-planner", "melbourne-estate-planner", "brisbane-estate-planner",
-    // Insurance brokers
     "sydney-insurance-broker", "melbourne-insurance-broker", "brisbane-insurance-broker",
-    // Real estate agents
     "sydney-real-estate-agent", "melbourne-real-estate-agent", "brisbane-real-estate-agent",
     "perth-real-estate-agent", "gold-coast-real-estate-agent",
   ];
   const advisorLocationPages = advisorLocationSlugs.map(slug => ({
-    url: `${baseUrl}/find-advisor/${slug}`,
+    url: `${base}/find-advisor/${slug}`,
     lastModified: new Date(),
     changeFrequency: "weekly" as const,
     priority: 0.7,
-  }));
-
-  // How-to guide pages
-  const howToPages = getAllGuideSlugs().map((slug) => ({
-    url: `${baseUrl}/how-to/${slug}`,
-    lastModified: new Date(),
-    changeFrequency: "weekly" as const,
-    priority: 0.7,
-  }));
-
-  // Expert articles (advisor-authored)
-  const { data: expertArticleSlugs } = supabase
-    ? await supabase.from("advisor_articles").select("slug, published_at").eq("status", "published")
-    : { data: null };
-
-  const expertArticlePages = (expertArticleSlugs || []).map((a) => ({
-    url: `${baseUrl}/expert/${a.slug}`,
-    lastModified: a.published_at ? new Date(a.published_at) : new Date(),
-    changeFrequency: "monthly" as const,
-    priority: 0.6,
-  }));
-
-  // City / location investing pages
-  const investingCityPages = [
-    { url: `${baseUrl}/investing`, lastModified: new Date(), changeFrequency: "weekly" as const, priority: 0.7 },
-    ...getAllCitySlugs().map((slug) => ({
-      url: `${baseUrl}/investing/${slug}`,
-      lastModified: new Date(),
-      changeFrequency: "weekly" as const,
-      priority: 0.7,
-    })),
-  ];
-
-  // Individual glossary term pages — full live set (203), so all term pages
-  // are discoverable. Server-only import keeps the client bundle lean.
-  const { FULL_GLOSSARY_ENTRIES: GLOSSARY_ENTRIES } = await import("@/lib/glossary-extended");
-  const glossaryPages = GLOSSARY_ENTRIES.map((entry) => ({
-    url: `${baseUrl}/glossary/${entry.slug}`,
-    lastModified: new Date(),
-    changeFrequency: "monthly" as const,
-    priority: 0.4,
   }));
 
   // Advisor firm pages
@@ -737,47 +827,86 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     ? await supabase.from("advisor_firms").select("slug").eq("status", "active")
     : { data: null };
   const firmPages = (firms || []).map((f) => ({
-    url: `${baseUrl}/firm/${f.slug}`,
+    url: `${base}/firm/${f.slug}`,
     lastModified: new Date(),
     changeFrequency: "weekly" as const,
     priority: 0.6,
   }));
+
+  return [
+    ...advisorPages,
+    ...findAdvisorCityPages,
+    ...advisorTypePages,
+    ...advisorStatePages,
+    ...advisorCityPages,
+    ...advisorLocationPages,
+    ...firmPages,
+  ];
+}
+
+async function buildShard5(): Promise<MetadataRoute.Sitemap> {
+  const base = baseUrl();
+
+  // Individual glossary term pages
+  const { FULL_GLOSSARY_ENTRIES: GLOSSARY_ENTRIES } = await import("@/lib/glossary-extended");
+  const glossaryPages = GLOSSARY_ENTRIES.map((entry) => ({
+    url: `${base}/glossary/${entry.slug}`,
+    lastModified: new Date(),
+    changeFrequency: "monthly" as const,
+    priority: 0.4,
+  }));
+
+  // How-to guide pages
+  const howToPages = getAllGuideSlugs().map((slug) => ({
+    url: `${base}/how-to/${slug}`,
+    lastModified: new Date(),
+    changeFrequency: "weekly" as const,
+    priority: 0.7,
+  }));
+
+  // ── /marketplace hub + intent + intent×state pages ──
+  const enabledIntents = await getEnabledIntents();
+  const marketplaceHubPage = {
+    url: `${base}/marketplace`,
+    lastModified: new Date(),
+    changeFrequency: "weekly" as const,
+    priority: 0.85,
+  };
+  const marketplaceIntentPages = enabledIntents.map((i) => ({
+    url: `${base}/marketplace/${i.slug}`,
+    lastModified: new Date(),
+    changeFrequency: "weekly" as const,
+    priority: 0.8,
+  }));
+  const marketplaceIntentStatePages = enabledIntents.flatMap((i) =>
+    AUSTRALIAN_STATES.map((s) => ({
+      url: `${base}/marketplace/${i.slug}/${s.slug}`,
+      lastModified: new Date(),
+      changeFrequency: "weekly" as const,
+      priority: 0.6,
+    })),
+  );
+
+  return [
+    ...glossaryPages,
+    ...howToPages,
+    marketplaceHubPage,
+    ...marketplaceIntentPages,
+    ...marketplaceIntentStatePages,
+  ];
+}
+
+async function buildShard6(): Promise<MetadataRoute.Sitemap> {
+  const base = baseUrl();
+  const supabase = await getSupabase();
 
   // Property listing pages
   const { data: propertyListings } = supabase
     ? await supabase.from("property_listings").select("slug, updated_at").in("status", ["active", "coming_soon"])
     : { data: null };
   const propertyListingPages = (propertyListings || []).map((l) => ({
-    url: `${baseUrl}/property/listings/${l.slug}`,
+    url: `${base}/property/listings/${l.slug}`,
     lastModified: l.updated_at ? new Date(l.updated_at) : new Date(),
-    changeFrequency: "weekly" as const,
-    priority: 0.7,
-  }));
-
-  // ── Investment Marketplace pages ──
-  const investStaticPages = [
-    { url: `${baseUrl}/invest`, lastModified: new Date(), changeFrequency: "weekly" as const, priority: 0.9 },
-    { url: `${baseUrl}/invest/listings`, lastModified: new Date(), changeFrequency: "weekly" as const, priority: 0.9 },
-    { url: `${baseUrl}/invest/alternatives`, lastModified: new Date(), changeFrequency: "weekly" as const, priority: 0.8 },
-    { url: `${baseUrl}/invest/alternatives/platforms`, lastModified: new Date(), changeFrequency: "monthly" as const, priority: 0.7 },
-    { url: `${baseUrl}/invest/alternatives/guides`, lastModified: new Date(), changeFrequency: "monthly" as const, priority: 0.7 },
-  ];
-
-  // Category listing pages: /invest/{category}/listings
-  // Only emit /invest/<slug>/listings URLs for opportunity-tagged categories.
-  // The 12 demoted categories (4 Compare-redirected + 8 Guide) don't have
-  // /listings subdirectories and would emit dead URLs.
-  const investCategoryPages = getOpportunityCategories().map((c) => c.slug).map((slug) => ({
-    url: `${baseUrl}/invest/${slug}/listings`,
-    lastModified: new Date(),
-    changeFrequency: "weekly" as const,
-    priority: 0.8,
-  }));
-
-  // Sub-category listing pages: /invest/{category}/listings/{subcategory}
-  const investSubcategoryPages = getAllSubcategorySlugs().map(({ category, subcategory }) => ({
-    url: `${baseUrl}/invest/${category}/listings/${subcategory}`,
-    lastModified: new Date(),
     changeFrequency: "weekly" as const,
     priority: 0.7,
   }));
@@ -788,15 +917,15 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     : { data: null };
 
   const suburbGuidePages = (suburbSlugs || []).map((s) => ({
-    url: `${baseUrl}/property/suburbs/${s.slug}`,
+    url: `${base}/property/suburbs/${s.slug}`,
     lastModified: new Date(),
     changeFrequency: "monthly" as const,
     priority: 0.6,
   }));
 
-  // AA-05: /[suburb]/property-investing programmatic pages (top-level URL, higher SEO priority)
+  // AA-05: /[suburb]/property-investing programmatic pages
   const suburbInvestingPages = (suburbSlugs || []).map((s) => ({
-    url: `${baseUrl}/${s.slug}/property-investing`,
+    url: `${base}/${s.slug}/property-investing`,
     lastModified: new Date(),
     changeFrequency: "monthly" as const,
     priority: 0.7,
@@ -804,83 +933,57 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   // Property static hub pages
   const propertyHubPages = [
-    { url: `${baseUrl}/property`, priority: 0.8 },
-    { url: `${baseUrl}/property/listings`, priority: 0.8 },
-    { url: `${baseUrl}/property/suburbs`, priority: 0.7 },
-    { url: `${baseUrl}/property/buyer-agents`, priority: 0.7 },
-    { url: `${baseUrl}/property/foreign-investment`, priority: 0.8 },
+    { url: `${base}/property`, priority: 0.8 },
+    { url: `${base}/property/listings`, priority: 0.8 },
+    { url: `${base}/property/suburbs`, priority: 0.7 },
+    { url: `${base}/property/buyer-agents`, priority: 0.7 },
+    { url: `${base}/property/foreign-investment`, priority: 0.8 },
   ].map((p) => ({ ...p, lastModified: new Date(), changeFrequency: "weekly" as const }));
 
-  // New hubs: ETF, Insurance, Tax, Fee Tracker, Advisor Specialists
-  const newHubPages = [
-    // ETF Hub
-    { url: `${baseUrl}/etfs`, priority: 0.9 },
-    { url: `${baseUrl}/etfs/asx-200`, priority: 0.85 },
-    { url: `${baseUrl}/etfs/us-exposure`, priority: 0.85 },
-    { url: `${baseUrl}/etfs/dividends`, priority: 0.85 },
-    // ETF screener + ticker pages (AA-04 + BB-09)
-    { url: `${baseUrl}/etfs/screener`, priority: 0.88 },
-    { url: `${baseUrl}/etfs/vas`, priority: 0.85 },
-    { url: `${baseUrl}/etfs/a200`, priority: 0.85 },
-    { url: `${baseUrl}/etfs/ivv`, priority: 0.85 },
-    { url: `${baseUrl}/etfs/ndq`, priority: 0.85 },
-    { url: `${baseUrl}/etfs/vgs`, priority: 0.85 },
-    { url: `${baseUrl}/etfs/vts`, priority: 0.82 },
-    { url: `${baseUrl}/etfs/vhy`, priority: 0.82 },
-    { url: `${baseUrl}/etfs/stw`, priority: 0.80 },
-    { url: `${baseUrl}/etfs/ioz`, priority: 0.80 },
-    { url: `${baseUrl}/etfs/ethi`, priority: 0.78 },
-    { url: `${baseUrl}/etfs/vgad`, priority: 0.78 },
-    { url: `${baseUrl}/etfs/hack`, priority: 0.75 },
-    { url: `${baseUrl}/etfs/vaf`, priority: 0.75 },
-    { url: `${baseUrl}/etfs/iwld`, priority: 0.75 },
-    // ETF vs pages
-    { url: `${baseUrl}/etfs/vs/vas-vs-a200`, priority: 0.8 },
-    { url: `${baseUrl}/etfs/vs/vas-vs-stw`, priority: 0.75 },
-    { url: `${baseUrl}/etfs/vs/ioz-vs-vas`, priority: 0.75 },
-    { url: `${baseUrl}/etfs/vs/ivv-vs-vts`, priority: 0.75 },
-    { url: `${baseUrl}/etfs/vs/ndq-vs-ivv`, priority: 0.8 },
-    { url: `${baseUrl}/etfs/vs/vgs-vs-ivv`, priority: 0.75 },
-    { url: `${baseUrl}/etfs/vs/vhy-vs-hvst`, priority: 0.75 },
-    { url: `${baseUrl}/etfs/vs/vhy-vs-vas`, priority: 0.75 },
-    // Insurance Hub
-    { url: `${baseUrl}/insurance`, priority: 0.9 },
-    { url: `${baseUrl}/insurance/life`, priority: 0.85 },
-    { url: `${baseUrl}/insurance/income-protection`, priority: 0.85 },
-    { url: `${baseUrl}/insurance/health`, priority: 0.85 },
-    { url: `${baseUrl}/insurance/home-contents`, priority: 0.8 },
-    // Tax Strategy Hub
-    { url: `${baseUrl}/tax`, priority: 0.9 },
-    { url: `${baseUrl}/tax/capital-gains`, priority: 0.85 },
-    { url: `${baseUrl}/tax/franking-credits`, priority: 0.85 },
-    { url: `${baseUrl}/tax/negative-gearing`, priority: 0.85 },
-    { url: `${baseUrl}/tax/crypto`, priority: 0.85 },
-    // Fee Tracker
-    { url: `${baseUrl}/fee-tracker`, priority: 0.85 },
-    // Super sub-pages
-    { url: `${baseUrl}/super/smsf`, priority: 0.85 },
-    // Advisor Specialists
-    { url: `${baseUrl}/advisors/international-tax-specialists`, priority: 0.85 },
-    { url: `${baseUrl}/advisors/firb-specialists`, priority: 0.8 },
-    { url: `${baseUrl}/advisors/migration-agents`, priority: 0.8 },
-    // Full-service stockbrokers vertical
-    { url: `${baseUrl}/brokers/full-service`, priority: 0.85 },
-  ].map((p) => ({ ...p, lastModified: new Date(), changeFrequency: "weekly" as const }));
+  // City / location investing pages
+  const investingCityPages = [
+    { url: `${base}/investing`, lastModified: new Date(), changeFrequency: "weekly" as const, priority: 0.7 },
+    ...getAllCitySlugs().map((slug) => ({
+      url: `${base}/investing/${slug}`,
+      lastModified: new Date(),
+      changeFrequency: "weekly" as const,
+      priority: 0.7,
+    })),
+  ];
 
-  // Full-service stockbroker firm detail pages
-  const { data: stockbrokerFirms } = supabase
-    ? await supabase
-        .from("professionals")
-        .select("slug, updated_at")
-        .in("type", ["stockbroker_firm", "private_wealth_manager"])
-        .eq("status", "active")
+  return [
+    ...propertyListingPages,
+    ...suburbGuidePages,
+    ...suburbInvestingPages,
+    ...propertyHubPages,
+    ...investingCityPages,
+  ];
+}
+
+async function buildShard7(): Promise<MetadataRoute.Sitemap> {
+  const base = baseUrl();
+  const supabase = await getSupabase();
+
+  // Dynamic team member pages (authors + reviewers)
+  const { data: teamMembers } = supabase
+    ? await supabase.from("team_members").select("slug, role, updated_at").eq("status", "active")
     : { data: null };
-  const stockbrokerFirmPages = (stockbrokerFirms || []).map((f) => ({
-    url: `${baseUrl}/brokers/full-service/${f.slug}`,
-    lastModified: f.updated_at ? new Date(f.updated_at) : new Date(),
-    changeFrequency: "weekly" as const,
-    priority: 0.7,
+
+  const authorPages = (teamMembers || []).map((m) => ({
+    url: `${base}/authors/${m.slug}`,
+    lastModified: m.updated_at ? new Date(m.updated_at) : new Date(),
+    changeFrequency: "monthly" as const,
+    priority: 0.4,
   }));
+
+  const reviewerPages = (teamMembers || [])
+    .filter((m) => m.role === "expert_reviewer" || m.role === "editor")
+    .map((m) => ({
+      url: `${base}/reviewers/${m.slug}`,
+      lastModified: m.updated_at ? new Date(m.updated_at) : new Date(),
+      changeFrequency: "monthly" as const,
+      priority: 0.4,
+    }));
 
   // Newsletter archive & edition pages
   const { data: newsletterEditions } = supabase
@@ -891,32 +994,20 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     : { data: null };
 
   const newsletterArchivePage = {
-    url: `${baseUrl}/newsletter`,
+    url: `${base}/newsletter`,
     lastModified: new Date(),
     changeFrequency: "weekly" as const,
     priority: 0.6,
   };
 
   const newsletterEditionPages = (newsletterEditions || []).map((e) => ({
-    url: `${baseUrl}/newsletter/${e.edition_date}`,
+    url: `${base}/newsletter/${e.edition_date}`,
     lastModified: e.created_at ? new Date(e.created_at) : new Date(),
     changeFrequency: "monthly" as const,
     priority: 0.5,
   }));
 
-  // Individual investment listing detail pages
-  const { data: investListings } = supabase
-    ? await supabase.from("investment_listings").select("slug, vertical, sub_category, updated_at").eq("status", "active")
-    : { data: null };
-
-  const investListingPages = (investListings || []).map((l) => ({
-    url: `${baseUrl}${listingUrl(l as { vertical: InvestListingVertical; sub_category?: string; slug: string })}`,
-    lastModified: l.updated_at ? new Date(l.updated_at) : new Date(),
-    changeFrequency: "weekly" as const,
-    priority: 0.6,
-  }));
-
-  // Public quote request pages (open jobs only — expired/closed drop off on next sitemap regen)
+  // Public quote request pages
   const { data: publicJobs } = supabase
     ? await supabase
         .from("advisor_auctions")
@@ -927,13 +1018,13 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     : { data: null };
 
   const quoteJobPages = (publicJobs || []).map((j) => ({
-    url: `${baseUrl}/quotes/${j.slug}`,
+    url: `${base}/quotes/${j.slug}`,
     lastModified: j.created_at ? new Date(j.created_at) : new Date(),
     changeFrequency: "hourly" as const,
     priority: 0.6,
   }));
 
-  // Category × location landing pages — long-tail SEO surface
+  // Category × location landing pages
   const QUOTE_TYPES = [
     "smsf_accountant", "financial_planner", "property_advisor", "tax_agent",
     "mortgage_broker", "estate_planner", "insurance_broker", "buyers_agent",
@@ -943,98 +1034,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const QUOTE_STATES = ["nsw", "vic", "qld", "wa", "sa", "tas", "act", "nt"];
   const quoteCategoryStatePages = QUOTE_TYPES.flatMap((t) =>
     QUOTE_STATES.map((s) => ({
-      url: `${baseUrl}/quotes/by/${t}/${s}`,
+      url: `${base}/quotes/by/${t}/${s}`,
       lastModified: new Date(),
       changeFrequency: "weekly" as const,
       priority: 0.5,
     })),
   );
-
-  // Locale-aware pages — each group links canonical ↔ locale alternates via hreflang.
-  // These replace the previously bare static-path entries for the same URLs.
-  // x-default always points to the canonical (en-AU) path.
-  const LOCALE_GROUPS: Array<{
-    canonical: string;
-    canonicalPriority: number;
-    localePaths: Partial<Record<"zh" | "ko" | "ar", string>>;
-  }> = [
-    { canonical: "/foreign-investment",           canonicalPriority: 0.9, localePaths: { zh: "/zh/foreign-investment",           ko: "/ko/foreign-investment"           } },
-    { canonical: "/foreign-investment/siv",        canonicalPriority: 0.7, localePaths: { zh: "/zh/foreign-investment/siv",        ko: "/ko/foreign-investment/siv"        } },
-    { canonical: "/foreign-investment/property",   canonicalPriority: 0.7, localePaths: { zh: "/zh/foreign-investment/property",   ko: "/ko/foreign-investment/property"   } },
-    { canonical: "/foreign-investment/tax",        canonicalPriority: 0.7, localePaths: { zh: "/zh/foreign-investment/tax",        ko: "/ko/foreign-investment/tax"        } },
-    { canonical: "/foreign-investment/united-arab-emirates", canonicalPriority: 0.7, localePaths: { ar: "/ar/foreign-investment/united-arab-emirates" } },
-  ];
-
-  const localizedPages: MetadataRoute.Sitemap = LOCALE_GROUPS.flatMap(
-    ({ canonical, canonicalPriority, localePaths }) => {
-      const languages: Record<string, string> = {
-        [BCP47_TAG.en]: `${baseUrl}${canonical}`,
-        "x-default": `${baseUrl}${canonical}`,
-      };
-      for (const [locale, localePath] of Object.entries(localePaths) as [keyof typeof BCP47_TAG, string][]) {
-        languages[BCP47_TAG[locale]] = `${baseUrl}${localePath}`;
-      }
-      const alternates = { languages };
-      return [
-        { url: `${baseUrl}${canonical}`, lastModified: new Date(), changeFrequency: "weekly" as const, priority: canonicalPriority, alternates },
-        ...Object.values(localePaths).map((localePath) => ({
-          url: `${baseUrl}${localePath}`,
-          lastModified: new Date(),
-          changeFrequency: "weekly" as const,
-          priority: Math.min(canonicalPriority, 0.7) as number,
-          alternates,
-        })),
-      ];
-    },
-  );
-
-  // ── /marketplace hub + intent + intent×state pages ──
-  // Programmatic SEO surface — 1 hub + N intents + (N × 8 states) leaf
-  // pages. Intents come from the admin-tunable taxonomy; if the DB is
-  // unreachable, `getEnabledIntents()` falls back to the code-defined
-  // list so the sitemap stays populated. Routes:
-  //   /marketplace                     (hub)
-  //   /marketplace/[intent]            (per intent)
-  //   /marketplace/[intent]/[state]    (per intent × state)
-  // /account/refer and other /account/* paths are noindex — not emitted
-  // here; robots.ts already disallows /account/.
-  const enabledIntents = await getEnabledIntents();
-  const marketplaceHubPage = {
-    url: `${baseUrl}/marketplace`,
-    lastModified: new Date(),
-    changeFrequency: "weekly" as const,
-    priority: 0.85,
-  };
-  const marketplaceIntentPages = enabledIntents.map((i) => ({
-    url: `${baseUrl}/marketplace/${i.slug}`,
-    lastModified: new Date(),
-    changeFrequency: "weekly" as const,
-    priority: 0.8,
-  }));
-  const marketplaceIntentStatePages = enabledIntents.flatMap((i) =>
-    AUSTRALIAN_STATES.map((s) => ({
-      url: `${baseUrl}/marketplace/${i.slug}/${s.slug}`,
-      lastModified: new Date(),
-      changeFrequency: "weekly" as const,
-      priority: 0.6,
-    })),
-  );
-
-  // ── /testimonials — single static page ──
-  const testimonialsPage = {
-    url: `${baseUrl}/testimonials`,
-    lastModified: new Date(),
-    changeFrequency: "monthly" as const,
-    priority: 0.5,
-  };
-
-  // ── /feed — public advisor insights feed ──
-  const feedPage = {
-    url: `${baseUrl}/feed`,
-    lastModified: new Date(),
-    changeFrequency: "monthly" as const,
-    priority: 0.6,
-  };
 
   // ── AA-02: /grants/[industry] programmatic pages ──
   const grantsIndustrySlugs = [
@@ -1042,7 +1047,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     "mining", "healthcare", "export", "creative", "defence",
   ];
   const grantsIndustryPages = grantsIndustrySlugs.map((slug) => ({
-    url: `${baseUrl}/grants/${slug}`,
+    url: `${base}/grants/${slug}`,
     lastModified: new Date(),
     changeFrequency: "monthly" as const,
     priority: 0.6,
@@ -1063,7 +1068,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     ["nt", "nt-business-innovation"],
   ];
   const grantsStateProgramPages = grantsStatePrograms.map(([state, program]) => ({
-    url: `${baseUrl}/grants/${state}/${program}`,
+    url: `${base}/grants/${state}/${program}`,
     lastModified: new Date(),
     changeFrequency: "monthly" as const,
     priority: 0.6,
@@ -1079,25 +1084,17 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     "freelancer", "contractor", "sports-professional",
   ];
   const investingForIndexPage = {
-    url: `${baseUrl}/investing-for`,
+    url: `${base}/investing-for`,
     lastModified: new Date(),
     changeFrequency: "monthly" as const,
     priority: 0.75,
   };
   const investingForPages = investingForSlugs.map((slug) => ({
-    url: `${baseUrl}/investing-for/${slug}`,
+    url: `${base}/investing-for/${slug}`,
     lastModified: new Date(),
     changeFrequency: "monthly" as const,
     priority: 0.65,
   }));
-
-  // ── Z-27: /tax-return hub (seasonal June–October) ──
-  const taxReturnHubPage = {
-    url: `${baseUrl}/tax-return`,
-    lastModified: new Date(),
-    changeFrequency: "weekly" as const,
-    priority: 0.82,
-  };
 
   // ── CPD events — /events/[id] detail pages ──
   const { data: publishedEvents } = supabase
@@ -1108,18 +1105,13 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
         .gte("starts_at", new Date().toISOString())
     : { data: null };
   const eventDetailPages = (publishedEvents || []).map((ev: { id: number; updated_at: string | null }) => ({
-    url: `${baseUrl}/events/${ev.id}`,
+    url: `${base}/events/${ev.id}`,
     lastModified: ev.updated_at ? new Date(ev.updated_at) : new Date(),
     changeFrequency: "weekly" as const,
     priority: 0.65,
   }));
 
   // ── CO-03: /afsl/[number] — dynamic AFSL licensee SEO pages ──
-  // The afsl_register table is populated pre-launch via admin CSV upload
-  // or post-launch via weekly cron. Currently empty; query is future-ready
-  // so new entries surface in the sitemap automatically after upload.
-  // Only index current/suspended licensees — cancelled/ceased pages carry
-  // lower SEO value and are still served (dynamicParams=true) but omitted here.
   const { data: afslLicensees } = supabase
     ? await supabase
         .from("afsl_register")
@@ -1127,11 +1119,44 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
         .in("status", ["current", "suspended"])
     : { data: null };
   const afslPages = (afslLicensees || []).map((l: { afsl_number: string; last_verified_at: string | null }) => ({
-    url: `${baseUrl}/afsl/${l.afsl_number}`,
+    url: `${base}/afsl/${l.afsl_number}`,
     lastModified: l.last_verified_at ? new Date(l.last_verified_at) : new Date(),
     changeFrequency: "monthly" as const,
     priority: 0.5,
   }));
 
-  return [...staticPages, ...localizedPages, ...bestPages, ...bestForPages, ...commodityPages, ...stockDetailPages, ...transferGuidePages, ...costPages, ...brokerPages, ...articlePages, ...scenarioPages, ...authorPages, ...reviewerPages, ...alertPages, ...reportPages, ...versusPages, ...howToPages, ...expertArticlePages, ...advisorPages, ...findAdvisorCityPages, ...advisorTypePages, ...advisorStatePages, ...advisorCityPages, ...advisorLocationPages, ...investingCityPages, ...glossaryPages, ...firmPages, ...propertyListingPages, ...suburbGuidePages, ...suburbInvestingPages, ...propertyHubPages, ...newHubPages, newsletterArchivePage, ...newsletterEditionPages, ...investStaticPages, ...investCategoryPages, ...investSubcategoryPages, ...investListingPages, ...stockbrokerFirmPages, ...quoteJobPages, ...quoteCategoryStatePages, marketplaceHubPage, ...marketplaceIntentPages, ...marketplaceIntentStatePages, testimonialsPage, ...grantsIndustryPages, ...grantsStateProgramPages, investingForIndexPage, ...investingForPages, taxReturnHubPage, ...afslPages, feedPage, ...eventDetailPages];
+  return [
+    ...authorPages,
+    ...reviewerPages,
+    newsletterArchivePage,
+    ...newsletterEditionPages,
+    ...quoteJobPages,
+    ...quoteCategoryStatePages,
+    ...grantsIndustryPages,
+    ...grantsStateProgramPages,
+    investingForIndexPage,
+    ...investingForPages,
+    ...eventDetailPages,
+    ...afslPages,
+  ];
+}
+
+// ─── Main export ──────────────────────────────────────────────────────────────
+// Next.js calls `sitemap({ id })` for each ID returned by `generateSitemaps`.
+// It automatically builds a sitemap index at `/sitemap.xml` that references
+// each shard at `/sitemap/0.xml`, `/sitemap/1.xml`, … `/sitemap/7.xml`.
+// robots.ts already points to `/sitemap.xml` so no change is needed there.
+
+export default async function sitemap({ id }: { id: number }): Promise<MetadataRoute.Sitemap> {
+  switch (id) {
+    case 0: return buildShard0();
+    case 1: return buildShard1();
+    case 2: return buildShard2();
+    case 3: return buildShard3();
+    case 4: return buildShard4();
+    case 5: return buildShard5();
+    case 6: return buildShard6();
+    case 7: return buildShard7();
+    default: return [];
+  }
 }

--- a/lib/best-broker-categories.ts
+++ b/lib/best-broker-categories.ts
@@ -2630,5 +2630,7 @@ export function getAllCategories(): BestBrokerCategory[] {
 }
 
 export function getAllCategorySlugs(): string[] {
-  return categories.map((c) => c.slug);
+  // Dedupe: two category entries can share a slug (one canonical /best/[slug] page),
+  // so the routable slug set must be unique (no duplicate sitemap URLs / static params).
+  return [...new Set(categories.map((c) => c.slug))];
 }


### PR DESCRIPTION
Round-4 deepening (1 of 10). Splits the monolithic ~1,137-line `app/sitemap.ts` into a **sitemap index** before it hits Google's 50k-URL / 10MB single-file caps. Pure infra.

- `app/sitemap.ts` now exports `generateSitemaps()` (8 shards by segment: static, locale/hreflang, brokers+best+versus+invest, articles/scenarios/reports/alerts, advisors, glossary+how-to+marketplace, property, authors+misc) + `sitemap({ id })`. Next 14 auto-builds the index at `/sitemap.xml` → `/sitemap/[id].xml`; `robots.ts` reference unchanged.
- **Every URL preserved** (no adds/drops); fixed 4 pre-existing within-list duplicates.

**Fixes on verification (the agent's own tests were red):**
- A real **cross-shard duplicate** — `/best/options-trading` was emitted twice because `getAllCategorySlugs()` returned the slug twice (two category entries in `lib/best-broker-categories.ts` share it). Fixed at the root: the function now returns a **unique** slug set (also protects `/best/[slug]` `generateStaticParams`).
- The "each shard non-empty" test wrongly required the **purely DB-driven shard 3** (articles/scenarios/…) to be non-empty under the empty-DB mock — aligned it with the suite's own `staticShards` set; added a duplicate-revealing assertion message.

**Verified:** `tsc` clean · **39 sitemap tests** (shard structure, per-shard coverage, no cross-shard dupes, URL preservation) pass · eslint clean.

**Flag for you (content decision, not done here):** two category entries in `best-broker-categories.ts` (lines ~2110 + ~2496) share slug `options-trading` — only one can own `/best/options-trading`; worth deciding which (or renaming one) so the other isn't orphaned.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUfSRE2Teb6VhEXFP6RpS9)_