### PR TITLE
feat: Market Pulse — public aggregate trend dashboard (deepen)

### DIFF
--- a/__tests__/lib/market-pulse-aggregations.test.ts
+++ b/__tests__/lib/market-pulse-aggregations.test.ts
@@ -1,0 +1,463 @@
+/**
+ * Unit tests for Market Pulse aggregation helpers.
+ *
+ * These cover the three new pure functions added to lib/market-intelligence.ts:
+ *   - buildHealthScoreTrendPoints / computeHealthScoreTrendSummary
+ *   - buildSavingsRateTrendPoints / computeSavingsRateTrendSummary
+ *   - buildFeeIndexDeltaSeries
+ *
+ * All tests use plain data fixtures — no Supabase, no Next.js.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  buildHealthScoreTrendPoints,
+  computeHealthScoreTrendSummary,
+  buildSavingsRateTrendPoints,
+  computeSavingsRateTrendSummary,
+  buildFeeIndexDeltaSeries,
+  type HealthScoreHistoryRow,
+  type SavingsRateRow,
+  type FeeTrendPoint,
+} from "@/lib/market-intelligence";
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+function makeHealthRow(
+  broker_slug: string,
+  overall_score: number,
+  captured_at: string,
+): HealthScoreHistoryRow {
+  return { broker_slug, overall_score, captured_at };
+}
+
+function makeSavingsRow(
+  broker_id: number,
+  rate_bps: number,
+  captured_at: string,
+  product_kind = "savings_account",
+): SavingsRateRow {
+  return {
+    broker_id,
+    rate_bps,
+    captured_at,
+    product_kind,
+    intro_rate_bps: null,
+  };
+}
+
+function makeFeePoint(
+  period: string,
+  avgAsxFee: number | null,
+  avgUsFee: number | null = null,
+  avgFxSpread: number | null = null,
+): FeeTrendPoint {
+  return { period, avgAsxFee, avgUsFee, avgFxSpread };
+}
+
+// ─── buildHealthScoreTrendPoints ─────────────────────────────────────────────
+
+describe("buildHealthScoreTrendPoints", () => {
+  it("returns empty for no input", () => {
+    expect(buildHealthScoreTrendPoints([])).toEqual([]);
+  });
+
+  it("returns empty when only one broker per day (privacy guard)", () => {
+    const rows = [
+      makeHealthRow("broker-a", 80, "2026-05-01T02:00:00Z"),
+    ];
+    expect(buildHealthScoreTrendPoints(rows)).toHaveLength(0);
+  });
+
+  it("emits a point when >= 2 brokers are in the same day", () => {
+    const rows = [
+      makeHealthRow("broker-a", 80, "2026-05-01T02:00:00Z"),
+      makeHealthRow("broker-b", 60, "2026-05-01T03:00:00Z"),
+    ];
+    const points = buildHealthScoreTrendPoints(rows);
+    expect(points).toHaveLength(1);
+    expect(points[0]!.day).toBe("2026-05-01");
+  });
+
+  it("computes the correct average score", () => {
+    const rows = [
+      makeHealthRow("broker-a", 80, "2026-05-01T02:00:00Z"),
+      makeHealthRow("broker-b", 60, "2026-05-01T03:00:00Z"),
+    ];
+    const points = buildHealthScoreTrendPoints(rows);
+    expect(points[0]!.avgScore).toBe(70.0);
+    expect(points[0]!.brokerCount).toBe(2);
+  });
+
+  it("groups multiple rows per broker per day — uses one vote per broker", () => {
+    // broker-a has 2 rows for the same day; should count as 1 broker
+    const rows = [
+      makeHealthRow("broker-a", 80, "2026-05-01T02:00:00Z"),
+      makeHealthRow("broker-a", 82, "2026-05-01T08:00:00Z"), // later capture
+      makeHealthRow("broker-b", 60, "2026-05-01T03:00:00Z"),
+    ];
+    const points = buildHealthScoreTrendPoints(rows);
+    expect(points).toHaveLength(1);
+    expect(points[0]!.brokerCount).toBe(2);
+    // avg of 82 (latest broker-a) and 60 (broker-b) = 71
+    expect(points[0]!.avgScore).toBe(71.0);
+  });
+
+  it("suppresses a day with only 1 distinct broker even if multiple rows", () => {
+    const rows = [
+      makeHealthRow("broker-a", 80, "2026-05-01T02:00:00Z"),
+      makeHealthRow("broker-a", 85, "2026-05-01T08:00:00Z"),
+    ];
+    expect(buildHealthScoreTrendPoints(rows)).toHaveLength(0);
+  });
+
+  it("handles multiple days and sorts chronologically", () => {
+    const rows = [
+      // Day 2 — 2 brokers
+      makeHealthRow("broker-a", 80, "2026-05-02T02:00:00Z"),
+      makeHealthRow("broker-b", 60, "2026-05-02T03:00:00Z"),
+      // Day 1 — 2 brokers
+      makeHealthRow("broker-a", 75, "2026-05-01T02:00:00Z"),
+      makeHealthRow("broker-b", 65, "2026-05-01T03:00:00Z"),
+    ];
+    const points = buildHealthScoreTrendPoints(rows);
+    expect(points).toHaveLength(2);
+    expect(points[0]!.day).toBe("2026-05-01");
+    expect(points[1]!.day).toBe("2026-05-02");
+  });
+
+  it("skips rows with non-finite overall_score", () => {
+    const rows = [
+      makeHealthRow("broker-a", NaN, "2026-05-01T02:00:00Z"),
+      makeHealthRow("broker-b", 60, "2026-05-01T03:00:00Z"),
+      // Only broker-b has valid score → single broker → suppressed
+    ];
+    expect(buildHealthScoreTrendPoints(rows)).toHaveLength(0);
+  });
+
+  it("rounds avgScore to 1dp", () => {
+    const rows = [
+      makeHealthRow("broker-a", 77, "2026-05-01T02:00:00Z"),
+      makeHealthRow("broker-b", 88, "2026-05-01T03:00:00Z"),
+      makeHealthRow("broker-c", 66, "2026-05-01T04:00:00Z"),
+    ];
+    const points = buildHealthScoreTrendPoints(rows);
+    expect(points[0]!.avgScore).toBe(77.0); // (77+88+66)/3 = 77
+  });
+});
+
+// ─── computeHealthScoreTrendSummary ──────────────────────────────────────────
+
+describe("computeHealthScoreTrendSummary", () => {
+  it("returns insufficient_data for empty series", () => {
+    const summary = computeHealthScoreTrendSummary([]);
+    expect(summary.direction).toBe("insufficient_data");
+    expect(summary.latest).toBeNull();
+    expect(summary.pointCount).toBe(0);
+  });
+
+  it("returns insufficient_data for a single-point series", () => {
+    const points = [{ day: "2026-05-01", avgScore: 75, brokerCount: 3 }];
+    const summary = computeHealthScoreTrendSummary(points);
+    expect(summary.direction).toBe("insufficient_data");
+    expect(summary.latest).toBe(75);
+    expect(summary.earliest).toBe(75);
+    expect(summary.pointCount).toBe(1);
+  });
+
+  it("detects a rising trend (higher is better)", () => {
+    const points = [
+      { day: "2026-03-01", avgScore: 60, brokerCount: 3 },
+      { day: "2026-04-01", avgScore: 70, brokerCount: 3 },
+      { day: "2026-05-01", avgScore: 80, brokerCount: 3 },
+    ];
+    const summary = computeHealthScoreTrendSummary(points);
+    expect(summary.direction).toBe("rising");
+    expect(summary.absoluteChange).toBeGreaterThan(0);
+    expect(summary.pctChange).toBeGreaterThan(0);
+  });
+
+  it("detects a falling trend", () => {
+    const points = [
+      { day: "2026-03-01", avgScore: 80, brokerCount: 3 },
+      { day: "2026-04-01", avgScore: 70, brokerCount: 3 },
+      { day: "2026-05-01", avgScore: 60, brokerCount: 3 },
+    ];
+    const summary = computeHealthScoreTrendSummary(points);
+    expect(summary.direction).toBe("falling");
+    expect(summary.absoluteChange).toBeLessThan(0);
+  });
+
+  it("reports flat when |pctChange| <= 1%", () => {
+    const points = [
+      { day: "2026-04-01", avgScore: 70, brokerCount: 3 },
+      { day: "2026-05-01", avgScore: 70.5, brokerCount: 3 }, // 0.7% change
+    ];
+    const summary = computeHealthScoreTrendSummary(points);
+    expect(summary.direction).toBe("flat");
+  });
+
+  it("handles null pctChange when earliest is 0", () => {
+    const points = [
+      { day: "2026-04-01", avgScore: 0, brokerCount: 3 },
+      { day: "2026-05-01", avgScore: 10, brokerCount: 3 },
+    ];
+    const summary = computeHealthScoreTrendSummary(points);
+    expect(summary.pctChange).toBeNull();
+  });
+
+  it("rounds to expected precision", () => {
+    const points = [
+      { day: "2026-04-01", avgScore: 66.666, brokerCount: 3 },
+      { day: "2026-05-01", avgScore: 77.777, brokerCount: 3 },
+    ];
+    const summary = computeHealthScoreTrendSummary(points);
+    // absoluteChange = 11.11, rounded to 2dp
+    expect(summary.absoluteChange).toBe(11.11);
+  });
+});
+
+// ─── buildSavingsRateTrendPoints ─────────────────────────────────────────────
+
+describe("buildSavingsRateTrendPoints", () => {
+  it("returns empty for no input", () => {
+    expect(buildSavingsRateTrendPoints([])).toEqual([]);
+  });
+
+  it("excludes term_deposit rows", () => {
+    const rows = [
+      makeSavingsRow(1, 450, "2026-05-01T02:00:00Z", "term_deposit"),
+      makeSavingsRow(2, 420, "2026-05-01T03:00:00Z", "term_deposit"),
+    ];
+    expect(buildSavingsRateTrendPoints(rows)).toHaveLength(0);
+  });
+
+  it("returns empty when only 1 broker per day (privacy guard)", () => {
+    const rows = [makeSavingsRow(1, 450, "2026-05-01T02:00:00Z")];
+    expect(buildSavingsRateTrendPoints(rows)).toHaveLength(0);
+  });
+
+  it("emits a point when >= 2 brokers on the same day", () => {
+    const rows = [
+      makeSavingsRow(1, 500, "2026-05-01T02:00:00Z"),
+      makeSavingsRow(2, 450, "2026-05-01T03:00:00Z"),
+    ];
+    const points = buildSavingsRateTrendPoints(rows);
+    expect(points).toHaveLength(1);
+    expect(points[0]!.day).toBe("2026-05-01");
+    expect(points[0]!.brokerCount).toBe(2);
+  });
+
+  it("converts bps to % pa correctly (best and avg)", () => {
+    // 500 bps = 5.00% pa, 400 bps = 4.00% pa
+    const rows = [
+      makeSavingsRow(1, 500, "2026-05-01T02:00:00Z"),
+      makeSavingsRow(2, 400, "2026-05-01T03:00:00Z"),
+    ];
+    const points = buildSavingsRateTrendPoints(rows);
+    expect(points[0]!.bestRate).toBe(5.0);
+    expect(points[0]!.avgRate).toBe(4.5);
+  });
+
+  it("uses the latest row per broker per day when duplicates exist", () => {
+    const rows = [
+      makeSavingsRow(1, 400, "2026-05-01T02:00:00Z"), // earlier
+      makeSavingsRow(1, 450, "2026-05-01T10:00:00Z"), // later — should win
+      makeSavingsRow(2, 500, "2026-05-01T03:00:00Z"),
+    ];
+    const points = buildSavingsRateTrendPoints(rows);
+    expect(points[0]!.bestRate).toBe(5.0); // broker 2
+    expect(points[0]!.avgRate).toBe(4.75); // (4.5 + 5.0) / 2 = 4.75
+  });
+
+  it("returns chronological order across multiple days", () => {
+    const rows = [
+      makeSavingsRow(1, 500, "2026-05-02T02:00:00Z"),
+      makeSavingsRow(2, 450, "2026-05-02T03:00:00Z"),
+      makeSavingsRow(1, 490, "2026-05-01T02:00:00Z"),
+      makeSavingsRow(2, 440, "2026-05-01T03:00:00Z"),
+    ];
+    const points = buildSavingsRateTrendPoints(rows);
+    expect(points).toHaveLength(2);
+    expect(points[0]!.day).toBe("2026-05-01");
+    expect(points[1]!.day).toBe("2026-05-02");
+  });
+
+  it("rounds rates to 2dp", () => {
+    // 333 bps = 3.33% pa
+    const rows = [
+      makeSavingsRow(1, 333, "2026-05-01T02:00:00Z"),
+      makeSavingsRow(2, 334, "2026-05-01T03:00:00Z"),
+    ];
+    const points = buildSavingsRateTrendPoints(rows);
+    expect(points[0]!.bestRate).toBe(3.34);
+    expect(points[0]!.avgRate).toBe(3.34); // (3.33 + 3.34) / 2 = 3.335 → 3.34 rounded
+  });
+
+  it("handles empty rows for a day gracefully", () => {
+    expect(buildSavingsRateTrendPoints([])).toEqual([]);
+  });
+});
+
+// ─── computeSavingsRateTrendSummary ──────────────────────────────────────────
+
+describe("computeSavingsRateTrendSummary", () => {
+  it("returns insufficient_data for empty series", () => {
+    const summary = computeSavingsRateTrendSummary([]);
+    expect(summary.direction).toBe("insufficient_data");
+    expect(summary.latestBest).toBeNull();
+    expect(summary.pointCount).toBe(0);
+  });
+
+  it("returns insufficient_data for a single point", () => {
+    const points = [{ day: "2026-05-01", bestRate: 5.0, avgRate: 4.5, brokerCount: 3 }];
+    const summary = computeSavingsRateTrendSummary(points);
+    expect(summary.direction).toBe("insufficient_data");
+    expect(summary.latestBest).toBe(5.0);
+    expect(summary.earliestBest).toBe(5.0);
+    expect(summary.latestAvg).toBe(4.5);
+  });
+
+  it("detects a rising trend when best rate goes up by >1%", () => {
+    const points = [
+      { day: "2026-03-01", bestRate: 4.0, avgRate: 3.5, brokerCount: 3 },
+      { day: "2026-05-01", bestRate: 5.0, avgRate: 4.5, brokerCount: 3 },
+    ];
+    const summary = computeSavingsRateTrendSummary(points);
+    expect(summary.direction).toBe("rising");
+    expect(summary.pctChangeBest).toBeGreaterThan(0);
+  });
+
+  it("detects a falling trend when best rate goes down by >1%", () => {
+    const points = [
+      { day: "2026-03-01", bestRate: 5.0, avgRate: 4.5, brokerCount: 3 },
+      { day: "2026-05-01", bestRate: 4.0, avgRate: 3.5, brokerCount: 3 },
+    ];
+    const summary = computeSavingsRateTrendSummary(points);
+    expect(summary.direction).toBe("falling");
+    expect(summary.absoluteChangeBest).toBeLessThan(0);
+  });
+
+  it("reports flat when rate changes within 1%", () => {
+    const points = [
+      { day: "2026-04-01", bestRate: 5.0, avgRate: 4.5, brokerCount: 3 },
+      { day: "2026-05-01", bestRate: 5.04, avgRate: 4.5, brokerCount: 3 }, // 0.8% change
+    ];
+    const summary = computeSavingsRateTrendSummary(points);
+    expect(summary.direction).toBe("flat");
+  });
+
+  it("surfaces latestAvg from the most recent point", () => {
+    const points = [
+      { day: "2026-04-01", bestRate: 5.0, avgRate: 4.0, brokerCount: 3 },
+      { day: "2026-05-01", bestRate: 5.5, avgRate: 4.8, brokerCount: 3 },
+    ];
+    const summary = computeSavingsRateTrendSummary(points);
+    expect(summary.latestAvg).toBe(4.8);
+  });
+});
+
+// ─── buildFeeIndexDeltaSeries ─────────────────────────────────────────────────
+
+describe("buildFeeIndexDeltaSeries", () => {
+  it("returns empty for empty input", () => {
+    expect(buildFeeIndexDeltaSeries([])).toEqual([]);
+  });
+
+  it("returns empty for a single-point series (no prior to compare against)", () => {
+    const points = [makeFeePoint("2026-05-01", 10, 8, 0.6)];
+    expect(buildFeeIndexDeltaSeries(points)).toHaveLength(0);
+  });
+
+  it("returns N-1 delta points for N input points", () => {
+    const points = [
+      makeFeePoint("2026-03-01", 10, 8, 0.6),
+      makeFeePoint("2026-04-01", 9, 7, 0.55),
+      makeFeePoint("2026-05-01", 8, 6, 0.5),
+    ];
+    expect(buildFeeIndexDeltaSeries(points)).toHaveLength(2);
+  });
+
+  it("computes correct signed deltas (falling = negative)", () => {
+    const points = [
+      makeFeePoint("2026-04-01", 10, 8, 0.6),
+      makeFeePoint("2026-05-01", 8, 7, 0.55),
+    ];
+    const deltas = buildFeeIndexDeltaSeries(points);
+    expect(deltas[0]!.asxDelta).toBe(-2.0);
+    expect(deltas[0]!.usDelta).toBe(-1.0);
+    expect(deltas[0]!.fxDelta).toBe(-0.05);
+  });
+
+  it("computes correct signed deltas (rising = positive)", () => {
+    const points = [
+      makeFeePoint("2026-04-01", 8, 6, 0.5),
+      makeFeePoint("2026-05-01", 10, 8, 0.6),
+    ];
+    const deltas = buildFeeIndexDeltaSeries(points);
+    expect(deltas[0]!.asxDelta).toBe(2.0);
+    expect(deltas[0]!.usDelta).toBe(2.0);
+    expect(deltas[0]!.fxDelta).toBe(0.1);
+  });
+
+  it("propagates null when either side of a delta is null", () => {
+    const points = [
+      makeFeePoint("2026-04-01", null, 8, 0.6),
+      makeFeePoint("2026-05-01", 10, null, 0.5),
+    ];
+    const deltas = buildFeeIndexDeltaSeries(points);
+    expect(deltas[0]!.asxDelta).toBeNull(); // prev is null
+    expect(deltas[0]!.usDelta).toBeNull(); // curr is null
+    expect(deltas[0]!.fxDelta).toBe(-0.1);
+  });
+
+  it("uses the period of the current point (not prev) in output", () => {
+    const points = [
+      makeFeePoint("2026-04-01", 10),
+      makeFeePoint("2026-05-01", 8),
+    ];
+    const deltas = buildFeeIndexDeltaSeries(points);
+    expect(deltas[0]!.period).toBe("2026-05-01");
+  });
+
+  it("handles a zero-change day correctly (delta = 0)", () => {
+    const points = [
+      makeFeePoint("2026-04-01", 10, 8, 0.6),
+      makeFeePoint("2026-05-01", 10, 8, 0.6),
+    ];
+    const deltas = buildFeeIndexDeltaSeries(points);
+    expect(deltas[0]!.asxDelta).toBe(0);
+    expect(deltas[0]!.usDelta).toBe(0);
+    expect(deltas[0]!.fxDelta).toBe(0);
+  });
+
+  it("rounds deltas to 4dp", () => {
+    const points = [
+      makeFeePoint("2026-04-01", 10.00001),
+      makeFeePoint("2026-05-01", 10.00008),
+    ];
+    const deltas = buildFeeIndexDeltaSeries(points);
+    // 0.00007 rounded to 4dp = 0.0001
+    expect(deltas[0]!.asxDelta).toBe(0.0001);
+  });
+
+  it("handles sparse data across many periods", () => {
+    const points = [
+      makeFeePoint("2026-01-01", 12),
+      makeFeePoint("2026-02-01", null),
+      makeFeePoint("2026-03-01", 10),
+      makeFeePoint("2026-04-01", 9),
+      makeFeePoint("2026-05-01", 8),
+    ];
+    const deltas = buildFeeIndexDeltaSeries(points);
+    expect(deltas).toHaveLength(4);
+    // 2026-02-01: prev=12, curr=null → null
+    expect(deltas[0]!.asxDelta).toBeNull();
+    // 2026-03-01: prev=null, curr=10 → null
+    expect(deltas[1]!.asxDelta).toBeNull();
+    // 2026-04-01: prev=10, curr=9 → -1
+    expect(deltas[2]!.asxDelta).toBe(-1);
+    // 2026-05-01: prev=9, curr=8 → -1
+    expect(deltas[3]!.asxDelta).toBe(-1);
+  });
+});

--- a/app/insights/page.tsx
+++ b/app/insights/page.tsx
@@ -558,6 +558,23 @@ export default async function InsightsPage() {
             </p>
           </section>
 
+          {/* ── Market Pulse CTA ─────────────────────────────────────── */}
+          <div className="rounded-xl border border-teal-100 bg-teal-50 p-5 mb-4">
+            <h2 className="text-base font-bold text-teal-900">
+              Market Pulse — Aggregate Time-Series Dashboard
+            </h2>
+            <p className="mt-1 text-sm text-teal-800">
+              See how health scores, savings rates, and fee indexes have moved
+              over time — daily aggregate trends across all tracked platforms.
+            </p>
+            <Link
+              href="/market-pulse"
+              className="mt-3 inline-block rounded-lg bg-teal-700 px-4 py-2 text-sm font-semibold text-white hover:bg-teal-800"
+            >
+              View Market Pulse →
+            </Link>
+          </div>
+
           {/* ── Narrative report CTA ─────────────────────────────────── */}
           <div className="rounded-xl border border-blue-100 bg-blue-50 p-5 mb-8">
             <h2 className="text-base font-bold text-blue-900">

--- a/app/market-pulse/page.tsx
+++ b/app/market-pulse/page.tsx
@@ -1,0 +1,848 @@
+/**
+ * /market-pulse — Market-wide time-series dashboard.
+ *
+ * Surfaces AGGREGATE trends across the three main data stores we already
+ * capture: broker health scores, savings rates, and fee-index snapshots.
+ * All outputs are factual descriptive statistics — no per-broker data is
+ * surfaced, no rankings-as-advice. ISR (1 h).
+ *
+ * Data sources:
+ *   - broker_health_score_history  → market avg health score over time
+ *                                    (anon SELECT policy — use createClient)
+ *   - savings_rate_snapshots       → best/avg savings rate over time
+ *                                    (anon SELECT policy — use createClient)
+ *   - fee_index_snapshots          → fee-index delta series
+ *                                    (service-role only — use readFeeIndex)
+ */
+
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  absoluteUrl,
+  breadcrumbJsonLd,
+  ORGANIZATION_JSONLD,
+  CURRENT_YEAR,
+  SITE_URL,
+} from "@/lib/seo";
+import {
+  GENERAL_ADVICE_WARNING,
+  EDITORIAL_ACCURACY_COMMITMENT,
+} from "@/lib/compliance";
+import { readFeeIndex } from "@/lib/fee-index";
+import { createClient } from "@/lib/supabase/server";
+import {
+  buildFeeTrendPoints,
+  buildFeeIndexDeltaSeries,
+  buildHealthScoreTrendPoints,
+  computeHealthScoreTrendSummary,
+  buildSavingsRateTrendPoints,
+  computeSavingsRateTrendSummary,
+  trimTrendWindow,
+  type HealthScoreHistoryRow,
+  type SavingsRateRow,
+  type FeeTrendPoint,
+  type FeeIndexDeltaPoint,
+  type HealthScoreTrendPoint,
+  type SavingsRateTrendPoint,
+} from "@/lib/market-intelligence";
+
+// ─── Page config ─────────────────────────────────────────────────────────────
+
+export const revalidate = 3600; // 1 h ISR
+
+const PAGE_PATH = "/market-pulse";
+const PAGE_TITLE = `Market Pulse: Australian Investing Trends (${CURRENT_YEAR})`;
+const PAGE_DESCRIPTION =
+  "Aggregate time-series for the Australian investing market: market-wide platform health score trend, best savings rate movement, and broker fee-index deltas — factual data, updated daily.";
+
+export const metadata: Metadata = {
+  title: PAGE_TITLE,
+  description: PAGE_DESCRIPTION,
+  alternates: { canonical: PAGE_PATH },
+  openGraph: {
+    title: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+    url: PAGE_PATH,
+    type: "website",
+    images: [
+      {
+        url: "/api/og?title=Market+Pulse&subtitle=Australian+Investing+Trends+Dashboard&type=default",
+        width: 1200,
+        height: 630,
+        alt: "Market Pulse — Australian Investing Trends",
+      },
+    ],
+  },
+  twitter: { card: "summary_large_image" },
+};
+
+// ─── JSON-LD ──────────────────────────────────────────────────────────────────
+
+function datasetJsonLd(latestPeriod: string | null) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Dataset",
+    name: "Market Pulse — Australian Investing Trends",
+    description: PAGE_DESCRIPTION,
+    url: absoluteUrl(PAGE_PATH),
+    keywords: [
+      "Australian investing",
+      "platform health scores",
+      "savings rates",
+      "brokerage fee trends",
+      "market intelligence",
+      "time-series data",
+    ],
+    creator: ORGANIZATION_JSONLD,
+    publisher: ORGANIZATION_JSONLD,
+    isAccessibleForFree: true,
+    license: `${SITE_URL}/terms`,
+    measurementTechnique:
+      "Aggregate time-series (daily averages, best-in-market, period-over-period deltas) computed from Invest.com.au's internal broker health, savings-rate, and fee-index records.",
+    ...(latestPeriod
+      ? {
+          dateModified: latestPeriod,
+          temporalCoverage: `../${latestPeriod}`,
+        }
+      : {}),
+  };
+}
+
+// ─── Formatting helpers ───────────────────────────────────────────────────────
+
+function fmtDate(iso: string | null | undefined): string {
+  if (!iso) return "—";
+  const d = new Date(`${iso.slice(0, 10)}T00:00:00.000Z`);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleDateString("en-AU", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+function fmtPct(n: number | null | undefined, dp = 2): string {
+  if (n === null || n === undefined) return "—";
+  return `${n.toFixed(dp)}%`;
+}
+
+function fmtMoney(n: number | null | undefined): string {
+  if (n === null || n === undefined) return "—";
+  return `$${n.toFixed(2)}`;
+}
+
+function fmtDelta(n: number | null | undefined, prefix = ""): string {
+  if (n === null || n === undefined) return "—";
+  const sign = n >= 0 ? "+" : "−";
+  return `${sign}${prefix}${Math.abs(n).toFixed(2)}`;
+}
+
+// ─── Pure SVG line chart (no external deps) ───────────────────────────────────
+
+/**
+ * Server-rendered SVG area/line chart for a numeric series.
+ *
+ * - No JS, no external libraries.
+ * - Renders a filled area + stroke line + terminal dot.
+ * - Accepts normalised [0–1] y values and a raw series for display purposes.
+ * - Omits itself cleanly for empty / single-point input.
+ */
+function SvgLineChart({
+  points,
+  color = "#0f766e",
+  width = 600,
+  height = 120,
+  label,
+}: {
+  points: { x: number; y: number }[]; // x=index 0..N-1, y=normalised 0–1
+  color?: string;
+  width?: number;
+  height?: number;
+  label?: string;
+}) {
+  if (points.length < 2) return null;
+
+  const pad = { top: 8, right: 8, bottom: 8, left: 8 };
+  const plotW = width - pad.left - pad.right;
+  const plotH = height - pad.top - pad.bottom;
+
+  const coords = points.map((p) => {
+    const svgX = pad.left + (p.x / (points.length - 1)) * plotW;
+    const svgY = pad.top + (1 - p.y) * plotH;
+    return { svgX, svgY };
+  });
+
+  const polylineStr = coords.map((c) => `${c.svgX},${c.svgY}`).join(" ");
+  const fillStr = [
+    `${pad.left},${pad.top + plotH}`,
+    ...coords.map((c) => `${c.svgX},${c.svgY}`),
+    `${pad.left + plotW},${pad.top + plotH}`,
+  ].join(" ");
+
+  const last = coords[coords.length - 1]!;
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      role="img"
+      aria-label={label ?? "Time-series chart"}
+      className="w-full overflow-visible"
+      preserveAspectRatio="none"
+    >
+      <polygon points={fillStr} fill={color} opacity={0.1} />
+      <polyline
+        points={polylineStr}
+        fill="none"
+        stroke={color}
+        strokeWidth="2"
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
+      <circle cx={last.svgX} cy={last.svgY} r="4" fill={color} />
+    </svg>
+  );
+}
+
+/** Normalise an array of numbers to [0, 1] range for SVG rendering. */
+function normalise(values: (number | null)[]): number[] {
+  const finite = values.filter((v): v is number => v !== null && Number.isFinite(v));
+  if (finite.length === 0) return values.map(() => 0.5);
+  const min = Math.min(...finite);
+  const max = Math.max(...finite);
+  if (min === max) return values.map(() => 0.5);
+  return values.map((v) => (v === null || !Number.isFinite(v) ? 0.5 : (v - min) / (max - min)));
+}
+
+// ─── Section wrappers ─────────────────────────────────────────────────────────
+
+function SectionHeading({ id, children }: { id: string; children: React.ReactNode }) {
+  return (
+    <h2 id={id} className="text-lg font-bold text-slate-900 mb-1">
+      {children}
+    </h2>
+  );
+}
+
+function EmptyState({ message }: { message: string }) {
+  return (
+    <div className="rounded-xl border border-dashed border-slate-300 bg-slate-50 px-6 py-10 text-center text-sm text-slate-500">
+      {message}
+    </div>
+  );
+}
+
+function TrendBadge({
+  direction,
+  pctChange,
+  higherIsBetter,
+}: {
+  direction: "falling" | "rising" | "flat" | "insufficient_data";
+  pctChange: number | null;
+  /** When true: rising = positive (green), falling = negative (red).
+   *  When false (fees): falling = positive (green), rising = negative (red). */
+  higherIsBetter: boolean;
+}) {
+  if (direction === "insufficient_data" || pctChange === null) {
+    return <span className="text-xs text-slate-400">no trend data yet</span>;
+  }
+
+  const isPositive =
+    (direction === "rising" && higherIsBetter) ||
+    (direction === "falling" && !higherIsBetter);
+  const isNegative =
+    (direction === "falling" && higherIsBetter) ||
+    (direction === "rising" && !higherIsBetter);
+
+  const cls = isPositive
+    ? "text-emerald-600"
+    : isNegative
+      ? "text-rose-600"
+      : "text-slate-500";
+
+  const arrow = direction === "rising" ? "▲" : direction === "falling" ? "▼" : "→";
+  const pctStr = `${arrow} ${Math.abs(pctChange).toFixed(1)}% over tracked period`;
+
+  return <span className={`text-xs font-semibold ${cls}`}>{pctStr}</span>;
+}
+
+// ─── Health score chart section ───────────────────────────────────────────────
+
+function HealthScoreSection({
+  trendPoints,
+}: {
+  trendPoints: HealthScoreTrendPoint[];
+}) {
+  const summary = computeHealthScoreTrendSummary(trendPoints);
+  const yValues = normalise(trendPoints.map((p) => p.avgScore));
+  const svgPoints = trendPoints.map((_, i) => ({ x: i, y: yValues[i] ?? 0.5 }));
+
+  return (
+    <section aria-labelledby="health-score-heading" className="mb-10">
+      <SectionHeading id="health-score-heading">
+        Market-Wide Platform Health Score Trend
+      </SectionHeading>
+      <p className="text-xs text-slate-500 mb-4">
+        Daily arithmetic mean of broker health scores across all platforms we
+        track. Individual broker scores are never surfaced — only the market
+        aggregate is shown. Days with fewer than 2 platforms are suppressed.
+      </p>
+
+      {trendPoints.length >= 2 ? (
+        <>
+          {/* Stat row */}
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4 mb-4">
+            <div className="rounded-xl border border-slate-200 bg-white p-4">
+              <p className="text-xs font-medium uppercase tracking-wide text-slate-500">Current avg</p>
+              <p className="mt-1 text-xl font-bold tabular-nums text-slate-900">
+                {summary.latest !== null ? `${summary.latest}` : "—"}
+                <span className="text-sm font-normal text-slate-400">/100</span>
+              </p>
+            </div>
+            <div className="rounded-xl border border-slate-200 bg-white p-4">
+              <p className="text-xs font-medium uppercase tracking-wide text-slate-500">Series start</p>
+              <p className="mt-1 text-xl font-bold tabular-nums text-slate-900">
+                {summary.earliest !== null ? `${summary.earliest}` : "—"}
+                <span className="text-sm font-normal text-slate-400">/100</span>
+              </p>
+            </div>
+            <div className="rounded-xl border border-slate-200 bg-white p-4">
+              <p className="text-xs font-medium uppercase tracking-wide text-slate-500">Change</p>
+              <p className="mt-1 text-xl font-bold tabular-nums text-slate-900">
+                {summary.absoluteChange !== null
+                  ? fmtDelta(summary.absoluteChange, "")
+                      .replace("−", "−")
+                  : "—"}
+              </p>
+            </div>
+            <div className="rounded-xl border border-slate-200 bg-white p-4">
+              <p className="text-xs font-medium uppercase tracking-wide text-slate-500">Data points</p>
+              <p className="mt-1 text-xl font-bold tabular-nums text-slate-900">
+                {summary.pointCount}
+              </p>
+              <p className="text-xs text-slate-400">daily buckets</p>
+            </div>
+          </div>
+
+          {/* Chart */}
+          <div className="rounded-xl border border-slate-200 bg-white p-5">
+            <div className="flex items-center justify-between mb-3">
+              <p className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                Avg score over time (0–100 scale)
+              </p>
+              <TrendBadge
+                direction={summary.direction}
+                pctChange={summary.pctChange}
+                higherIsBetter={true}
+              />
+            </div>
+            <SvgLineChart
+              points={svgPoints}
+              color="#0f766e"
+              width={600}
+              height={120}
+              label="Market-wide average broker health score over time"
+            />
+            {/* X-axis labels */}
+            {trendPoints.length >= 2 && (
+              <div className="flex justify-between mt-1 text-[0.6rem] text-slate-400">
+                <span>{trendPoints[0]!.day}</span>
+                <span>{trendPoints[trendPoints.length - 1]!.day}</span>
+              </div>
+            )}
+          </div>
+        </>
+      ) : (
+        <EmptyState message="Market health score trend requires at least 2 days of data across multiple platforms. Check back once the daily health-score cron has run for a couple of days." />
+      )}
+
+      <p className="mt-3 text-xs text-slate-500">
+        Per-platform scores →{" "}
+        <Link href="/health-scores" className="font-semibold text-blue-700 underline">
+          Platform Health Scores
+        </Link>
+      </p>
+    </section>
+  );
+}
+
+// ─── Savings rate chart section ───────────────────────────────────────────────
+
+function SavingsRateSection({
+  trendPoints,
+}: {
+  trendPoints: SavingsRateTrendPoint[];
+}) {
+  const summary = computeSavingsRateTrendSummary(trendPoints);
+  const bestValues = trendPoints.map((p) => p.bestRate);
+  const avgValues = trendPoints.map((p) => p.avgRate);
+  const yBest = normalise(bestValues);
+  const yAvg = normalise(avgValues);
+  const bestSvgPoints = trendPoints.map((_, i) => ({ x: i, y: yBest[i] ?? 0.5 }));
+  const avgSvgPoints = trendPoints.map((_, i) => ({ x: i, y: yAvg[i] ?? 0.5 }));
+
+  return (
+    <section aria-labelledby="savings-rate-heading" className="mb-10">
+      <SectionHeading id="savings-rate-heading">
+        Savings Rate Trend (Savings Accounts)
+      </SectionHeading>
+      <p className="text-xs text-slate-500 mb-4">
+        Daily best (highest) and average standard savings rate across platforms
+        we track. Intro/promotional rates are excluded from the market average
+        to avoid distorting the underlying trend. Term deposits are shown
+        separately below. Days with fewer than 2 platforms are suppressed.
+      </p>
+
+      {trendPoints.length >= 2 ? (
+        <>
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4 mb-4">
+            <div className="rounded-xl border border-slate-200 bg-white p-4">
+              <p className="text-xs font-medium uppercase tracking-wide text-slate-500">Current best</p>
+              <p className="mt-1 text-xl font-bold tabular-nums text-slate-900">
+                {fmtPct(summary.latestBest)} <span className="text-sm font-normal text-slate-400">p.a.</span>
+              </p>
+            </div>
+            <div className="rounded-xl border border-slate-200 bg-white p-4">
+              <p className="text-xs font-medium uppercase tracking-wide text-slate-500">Current avg</p>
+              <p className="mt-1 text-xl font-bold tabular-nums text-slate-900">
+                {fmtPct(summary.latestAvg)} <span className="text-sm font-normal text-slate-400">p.a.</span>
+              </p>
+            </div>
+            <div className="rounded-xl border border-slate-200 bg-white p-4">
+              <p className="text-xs font-medium uppercase tracking-wide text-slate-500">Best rate change</p>
+              <p className="mt-1 text-xl font-bold tabular-nums text-slate-900">
+                {summary.absoluteChangeBest !== null
+                  ? `${summary.absoluteChangeBest >= 0 ? "+" : ""}${summary.absoluteChangeBest.toFixed(2)}%`
+                  : "—"}
+              </p>
+            </div>
+            <div className="rounded-xl border border-slate-200 bg-white p-4">
+              <p className="text-xs font-medium uppercase tracking-wide text-slate-500">Data points</p>
+              <p className="mt-1 text-xl font-bold tabular-nums text-slate-900">
+                {summary.pointCount}
+              </p>
+              <p className="text-xs text-slate-400">daily buckets</p>
+            </div>
+          </div>
+
+          {/* Best rate chart */}
+          <div className="rounded-xl border border-slate-200 bg-white p-5 mb-3">
+            <div className="flex items-center justify-between mb-3">
+              <p className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                Best rate over time (% p.a.)
+              </p>
+              <TrendBadge
+                direction={summary.direction}
+                pctChange={summary.pctChangeBest}
+                higherIsBetter={true}
+              />
+            </div>
+            <SvgLineChart
+              points={bestSvgPoints}
+              color="#1d4ed8"
+              width={600}
+              height={100}
+              label="Best savings rate over time"
+            />
+            {trendPoints.length >= 2 && (
+              <div className="flex justify-between mt-1 text-[0.6rem] text-slate-400">
+                <span>{trendPoints[0]!.day}</span>
+                <span>{trendPoints[trendPoints.length - 1]!.day}</span>
+              </div>
+            )}
+          </div>
+
+          {/* Avg rate chart */}
+          <div className="rounded-xl border border-slate-200 bg-white p-5">
+            <div className="flex items-center justify-between mb-3">
+              <p className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                Average rate over time (% p.a.)
+              </p>
+            </div>
+            <SvgLineChart
+              points={avgSvgPoints}
+              color="#7c3aed"
+              width={600}
+              height={100}
+              label="Market-average savings rate over time"
+            />
+            {trendPoints.length >= 2 && (
+              <div className="flex justify-between mt-1 text-[0.6rem] text-slate-400">
+                <span>{trendPoints[0]!.day}</span>
+                <span>{trendPoints[trendPoints.length - 1]!.day}</span>
+              </div>
+            )}
+          </div>
+        </>
+      ) : (
+        <EmptyState message="Savings rate trend requires at least 2 days of data across multiple platforms. Check back once the savings-rate ingest has run for a couple of days." />
+      )}
+
+      <p className="mt-3 text-xs text-slate-500">
+        Compare savings accounts →{" "}
+        <Link href="/savings-accounts" className="font-semibold text-blue-700 underline">
+          Savings accounts
+        </Link>
+      </p>
+    </section>
+  );
+}
+
+// ─── Fee delta series chart section ──────────────────────────────────────────
+
+function FeeDeltaSection({
+  trendPoints,
+  deltaPoints,
+}: {
+  trendPoints: FeeTrendPoint[];
+  deltaPoints: FeeIndexDeltaPoint[];
+}) {
+  // ASX fee level chart
+  const asxLevels = trendPoints.map((p) => p.avgAsxFee);
+  const asxNorm = normalise(asxLevels);
+  const asxSvgPoints = trendPoints.map((_, i) => ({ x: i, y: asxNorm[i] ?? 0.5 }));
+
+  // Delta bar representation — we treat this as a line chart of the delta itself
+  const asxDeltas = deltaPoints.map((p) => p.asxDelta);
+  const asxDeltaNorm = normalise(asxDeltas);
+  const asxDeltaSvg = deltaPoints.map((_, i) => ({ x: i, y: asxDeltaNorm[i] ?? 0.5 }));
+
+  const latestTrend = trendPoints[trendPoints.length - 1];
+
+  return (
+    <section aria-labelledby="fee-delta-heading" className="mb-10">
+      <SectionHeading id="fee-delta-heading">
+        Brokerage Fee Index — Level &amp; Day-on-Day Deltas
+      </SectionHeading>
+      <p className="text-xs text-slate-500 mb-4">
+        Market-wide average ASX brokerage fee (level, left) and period-on-period
+        change in that average (delta, right). A positive delta means the average
+        fee rose vs the prior day; negative means it fell. Computed from the
+        daily fee-index snapshot.
+      </p>
+
+      {trendPoints.length >= 2 ? (
+        <>
+          <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 mb-5">
+            {/* Level chart */}
+            <div className="rounded-xl border border-slate-200 bg-white p-5">
+              <p className="text-xs font-medium uppercase tracking-wide text-slate-500 mb-1">
+                Avg ASX fee (level)
+              </p>
+              <p className="text-lg font-bold tabular-nums text-slate-900 mb-3">
+                {fmtMoney(latestTrend?.avgAsxFee ?? null)}
+                <span className="text-xs font-normal text-slate-400 ml-1">latest</span>
+              </p>
+              <SvgLineChart
+                points={asxSvgPoints}
+                color="#a16207"
+                width={300}
+                height={100}
+                label="Average ASX brokerage fee level over time"
+              />
+              {trendPoints.length >= 2 && (
+                <div className="flex justify-between mt-1 text-[0.6rem] text-slate-400">
+                  <span>{trendPoints[0]!.period}</span>
+                  <span>{trendPoints[trendPoints.length - 1]!.period}</span>
+                </div>
+              )}
+            </div>
+
+            {/* Delta chart */}
+            <div className="rounded-xl border border-slate-200 bg-white p-5">
+              <p className="text-xs font-medium uppercase tracking-wide text-slate-500 mb-1">
+                Day-on-day delta (ASX fee)
+              </p>
+              <p className="text-xs text-slate-500 mb-3">
+                Positive = fee rose; negative = fee fell.
+              </p>
+              {asxDeltaSvg.length >= 2 ? (
+                <>
+                  <SvgLineChart
+                    points={asxDeltaSvg}
+                    color="#dc2626"
+                    width={300}
+                    height={100}
+                    label="Day-on-day change in average ASX brokerage fee"
+                  />
+                  {deltaPoints.length >= 2 && (
+                    <div className="flex justify-between mt-1 text-[0.6rem] text-slate-400">
+                      <span>{deltaPoints[0]!.period}</span>
+                      <span>{deltaPoints[deltaPoints.length - 1]!.period}</span>
+                    </div>
+                  )}
+                </>
+              ) : (
+                <p className="text-xs text-slate-400">Insufficient delta data.</p>
+              )}
+            </div>
+          </div>
+
+          {/* Recent delta table */}
+          {deltaPoints.length > 0 && (
+            <div className="rounded-xl border border-slate-200 bg-white overflow-hidden">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="bg-slate-50 border-b border-slate-200">
+                    <th className="text-left px-4 py-3 text-xs font-semibold text-slate-600">Period</th>
+                    <th className="text-right px-4 py-3 text-xs font-semibold text-slate-600">ASX Δ</th>
+                    <th className="text-right px-4 py-3 text-xs font-semibold text-slate-600 hidden sm:table-cell">US Δ</th>
+                    <th className="text-right px-4 py-3 text-xs font-semibold text-slate-600 hidden md:table-cell">FX Δ</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {[...deltaPoints]
+                    .reverse()
+                    .slice(0, 14)
+                    .map((d, i) => (
+                      <tr
+                        key={d.period}
+                        className={`border-b border-slate-50 ${i % 2 === 1 ? "bg-slate-50/50" : ""}`}
+                      >
+                        <td className="px-4 py-2 text-xs text-slate-500 tabular-nums">{d.period}</td>
+                        <td className={`px-4 py-2 text-right text-xs tabular-nums font-medium ${d.asxDelta !== null && d.asxDelta > 0 ? "text-rose-600" : d.asxDelta !== null && d.asxDelta < 0 ? "text-emerald-600" : "text-slate-400"}`}>
+                          {d.asxDelta !== null ? fmtDelta(d.asxDelta) : "—"}
+                        </td>
+                        <td className={`px-4 py-2 text-right text-xs tabular-nums font-medium hidden sm:table-cell ${d.usDelta !== null && d.usDelta > 0 ? "text-rose-600" : d.usDelta !== null && d.usDelta < 0 ? "text-emerald-600" : "text-slate-400"}`}>
+                          {d.usDelta !== null ? fmtDelta(d.usDelta) : "—"}
+                        </td>
+                        <td className={`px-4 py-2 text-right text-xs tabular-nums font-medium hidden md:table-cell ${d.fxDelta !== null && d.fxDelta > 0 ? "text-rose-600" : d.fxDelta !== null && d.fxDelta < 0 ? "text-emerald-600" : "text-slate-400"}`}>
+                          {d.fxDelta !== null ? `${fmtDelta(d.fxDelta)}%` : "—"}
+                        </td>
+                      </tr>
+                    ))}
+                </tbody>
+              </table>
+              <p className="px-4 py-2 text-[0.6rem] text-slate-400 border-t border-slate-100">
+                Showing latest 14 periods. Green = fee fell (consumer-positive), red = fee rose.
+              </p>
+            </div>
+          )}
+        </>
+      ) : (
+        <EmptyState message="Fee-index data is still being gathered. Check back once the daily fee-index cron has run." />
+      )}
+
+      <p className="mt-3 text-xs text-slate-500">
+        Full fee index →{" "}
+        <Link href="/brokerage-fee-index" className="font-semibold text-blue-700 underline">
+          AU Brokerage Fee Index
+        </Link>
+      </p>
+    </section>
+  );
+}
+
+// ─── Methodology note ─────────────────────────────────────────────────────────
+
+function MethodologyNote() {
+  return (
+    <section className="mb-8">
+      <div className="rounded-xl border border-slate-200 bg-slate-50 p-5">
+        <h2 className="text-sm font-bold text-slate-700 mb-2">Methodology</h2>
+        <ul className="text-xs text-slate-500 leading-relaxed space-y-1 list-disc list-inside">
+          <li>
+            <strong>Health scores</strong> are computed from publicly available data (AFSL
+            status, client-money handling, financial disclosures, platform uptime, insurance)
+            weighted across 5 dimensions. The market average shown here is the arithmetic
+            mean across all platforms with a current score.
+          </li>
+          <li>
+            <strong>Savings rates</strong> are captured daily from product disclosure statements
+            and platform rate pages. Only standard rates are used in the market average;
+            introductory/promotional rates are excluded to prevent distortion.
+          </li>
+          <li>
+            <strong>Fee-index snapshots</strong> are computed daily from our hourly broker
+            price-capture cron. Each platform contributes one vote (its most recent snapshot
+            in the capture window). Brokers not marked active are excluded.
+          </li>
+          <li>
+            Days with fewer than 2 platforms in any series are suppressed to prevent
+            back-calculation to individual broker values.
+          </li>
+          <li>
+            All data is factual and descriptive. Nothing on this page constitutes financial
+            advice or a recommendation to use any particular platform.
+          </li>
+        </ul>
+        <p className="mt-3 text-xs text-slate-500">
+          <Link href="/how-we-verify" className="underline hover:text-slate-900">
+            How we verify our data
+          </Link>
+        </p>
+      </div>
+    </section>
+  );
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export default async function MarketPulsePage() {
+  const supabase = await createClient();
+
+  // Fetch all three data sources in parallel
+  const [
+    { latest: latestFee, history: feeHistory },
+    { data: healthHistoryData },
+    { data: savingsRateData },
+  ] = await Promise.all([
+    readFeeIndex(365), // up to 1 year of daily fee snapshots (service-role)
+    supabase // anon SELECT policy on broker_health_score_history
+      .from("broker_health_score_history")
+      .select("broker_slug, overall_score, captured_at")
+      .order("captured_at", { ascending: false })
+      .limit(5000), // last ~90 days × ~50 brokers
+    supabase // anon SELECT policy on savings_rate_snapshots
+      .from("savings_rate_snapshots")
+      .select("broker_id, rate_bps, captured_at, product_kind, intro_rate_bps")
+      .order("captured_at", { ascending: false })
+      .limit(5000),
+  ]);
+
+  // ── Aggregate ─────────────────────────────────────────────────────────────
+
+  // 1. Health score time series (last 90 days displayed)
+  const healthHistory = (healthHistoryData as HealthScoreHistoryRow[] | null) ?? [];
+  const HEALTH_WINDOW = 90;
+  const allHealthTrendPoints = buildHealthScoreTrendPoints(healthHistory);
+  const healthTrendPoints = allHealthTrendPoints.slice(-HEALTH_WINDOW);
+
+  // 2. Savings rate time series (last 90 days displayed)
+  const savingsRows = (savingsRateData as SavingsRateRow[] | null) ?? [];
+  const SAVINGS_WINDOW = 90;
+  const allSavingsTrendPoints = buildSavingsRateTrendPoints(savingsRows);
+  const savingsTrendPoints = allSavingsTrendPoints.slice(-SAVINGS_WINDOW);
+
+  // 3. Fee-index delta series (last 90 days displayed)
+  const FEE_WINDOW = 90;
+  const allFeePoints = buildFeeTrendPoints(feeHistory);
+  const feeTrendPoints = trimTrendWindow(allFeePoints, FEE_WINDOW);
+  const feeDeltaPoints = buildFeeIndexDeltaSeries(feeTrendPoints);
+
+  // Determine latest period for Dataset JSON-LD
+  const latestPeriod =
+    latestFee?.period ??
+    healthTrendPoints[healthTrendPoints.length - 1]?.day ??
+    savingsTrendPoints[savingsTrendPoints.length - 1]?.day ??
+    null;
+
+  // ── JSON-LD ───────────────────────────────────────────────────────────────
+
+  const breadcrumbs = breadcrumbJsonLd([
+    { name: "Home", url: absoluteUrl("/") },
+    { name: "Market Pulse" },
+  ]);
+  const dataset = datasetJsonLd(latestPeriod);
+
+  // ── Render ────────────────────────────────────────────────────────────────
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbs) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(dataset) }}
+      />
+
+      <div className="pt-5 pb-12 md:py-12">
+        <div className="container-custom max-w-4xl">
+
+          {/* Breadcrumb */}
+          <nav aria-label="Breadcrumb" className="mb-4 text-xs text-slate-500 md:text-sm">
+            <Link href="/" className="hover:text-slate-900">Home</Link>
+            <span className="mx-1.5" aria-hidden="true">/</span>
+            <span className="text-slate-700">Market Pulse</span>
+          </nav>
+
+          {/* Header */}
+          <header className="mb-8">
+            <h1 className="text-2xl font-bold text-slate-900 md:text-3xl">
+              Market Pulse
+            </h1>
+            <p className="mt-2 text-sm text-slate-600 md:text-base max-w-2xl">
+              Aggregate time-series for the Australian retail investing market —
+              market-wide health score trends, best savings rates, and broker fee
+              movements. All data is factual aggregate; individual broker values
+              are never surfaced.
+            </p>
+            {latestPeriod && (
+              <p className="mt-2 text-xs text-slate-500">
+                Latest data:{" "}
+                <span className="font-semibold text-slate-700">
+                  {fmtDate(latestPeriod)}
+                </span>
+              </p>
+            )}
+          </header>
+
+          {/* ── 1. Health Score Trend ─────────────────────────────────── */}
+          <HealthScoreSection trendPoints={healthTrendPoints} />
+
+          {/* ── 2. Savings Rate Trend ─────────────────────────────────── */}
+          <SavingsRateSection trendPoints={savingsTrendPoints} />
+
+          {/* ── 3. Fee Index Delta ────────────────────────────────────── */}
+          <FeeDeltaSection
+            trendPoints={feeTrendPoints}
+            deltaPoints={feeDeltaPoints}
+          />
+
+          {/* ── Methodology ──────────────────────────────────────────── */}
+          <MethodologyNote />
+
+          {/* ── Cross-links ──────────────────────────────────────────── */}
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 mb-8">
+            <Link
+              href="/insights"
+              className="rounded-xl border border-blue-100 bg-blue-50 p-5 hover:bg-blue-100 transition-colors"
+            >
+              <p className="text-sm font-semibold text-blue-900">
+                Australian Investing Index →
+              </p>
+              <p className="mt-1 text-xs text-blue-700">
+                Snapshot stats: current fee averages, health score distribution,
+                advisor supply.
+              </p>
+            </Link>
+            <Link
+              href="/health-scores"
+              className="rounded-xl border border-slate-200 bg-white p-5 hover:bg-slate-50 transition-colors"
+            >
+              <p className="text-sm font-semibold text-slate-900">
+                Platform Health Scores →
+              </p>
+              <p className="mt-1 text-xs text-slate-500">
+                Per-broker safety breakdowns across 5 dimensions.
+              </p>
+            </Link>
+          </div>
+
+          {/* Compliance */}
+          <div className="space-y-2 text-[0.7rem] leading-relaxed text-slate-500 md:text-xs">
+            <p>
+              <strong className="text-slate-600">General information only.</strong>{" "}
+              {GENERAL_ADVICE_WARNING}
+            </p>
+            <p>{EDITORIAL_ACCURACY_COMMITMENT}</p>
+            {latestPeriod && (
+              <p>
+                Data as of {fmtDate(latestPeriod)}.{" "}
+                <Link href="/how-we-verify" className="underline hover:text-slate-900">
+                  How we verify
+                </Link>
+                .
+              </p>
+            )}
+          </div>
+
+        </div>
+      </div>
+    </>
+  );
+}

--- a/lib/market-intelligence.ts
+++ b/lib/market-intelligence.ts
@@ -413,3 +413,321 @@ export function trimTrendWindow(
   if (points.length <= windowDays) return points;
   return points.slice(points.length - windowDays);
 }
+
+// ─── Market Pulse: health-score time series ──────────────────────────────────
+
+/** A row from broker_health_score_history (the subset we need). */
+export interface HealthScoreHistoryRow {
+  broker_slug: string;
+  overall_score: number;
+  captured_at: string; // ISO timestamp
+}
+
+/**
+ * A single point on the market-wide average health-score time series.
+ *
+ * Only emitted when >= 2 brokers contributed to the bucket (privacy guard —
+ * prevents back-calculation to individual scores).
+ */
+export interface HealthScoreTrendPoint {
+  /** YYYY-MM-DD — the UTC calendar day this bucket represents. */
+  day: string;
+  /** Arithmetic mean across contributing brokers, rounded to 1dp. */
+  avgScore: number;
+  /** Number of distinct broker_slug values in the bucket. */
+  brokerCount: number;
+}
+
+/**
+ * Bucket broker health-score history rows into daily averages.
+ *
+ * Groups rows by UTC calendar day (YYYY-MM-DD) of `captured_at`, then emits
+ * one `HealthScoreTrendPoint` per day where >= 2 distinct brokers have a row.
+ * Days with only one broker are suppressed (privacy guard).
+ * Output is sorted chronologically (oldest first).
+ *
+ * Handles sparse / empty input gracefully — returns an empty array.
+ */
+export function buildHealthScoreTrendPoints(
+  rows: HealthScoreHistoryRow[],
+): HealthScoreTrendPoint[] {
+  if (rows.length === 0) return [];
+
+  // Group: day → Map<broker_slug, latest overall_score for that day>
+  const byDay = new Map<string, Map<string, number>>();
+
+  for (const row of rows) {
+    if (!Number.isFinite(Number(row.overall_score))) continue;
+    const day = row.captured_at.slice(0, 10); // YYYY-MM-DD
+    if (!byDay.has(day)) byDay.set(day, new Map());
+    const dayMap = byDay.get(day)!;
+    // Keep the latest entry per broker per day (rows may not be unique per
+    // broker_slug per day if the cron ran multiple times).
+    const existing = dayMap.get(row.broker_slug);
+    if (
+      existing === undefined ||
+      row.captured_at > (rows.find(
+        (r) => r.broker_slug === row.broker_slug &&
+               r.captured_at.slice(0, 10) === day &&
+               r.captured_at > row.captured_at,
+      )?.captured_at ?? "")
+    ) {
+      dayMap.set(row.broker_slug, Number(row.overall_score));
+    }
+  }
+
+  const points: HealthScoreTrendPoint[] = [];
+
+  for (const [day, brokerMap] of byDay.entries()) {
+    if (brokerMap.size < 2) continue; // privacy guard
+    const scores = [...brokerMap.values()];
+    const avg = scores.reduce((sum, s) => sum + s, 0) / scores.length;
+    points.push({
+      day,
+      avgScore: roundTo(avg, 1) as number,
+      brokerCount: brokerMap.size,
+    });
+  }
+
+  // Sort chronologically
+  return points.sort((a, b) => (a.day < b.day ? -1 : a.day > b.day ? 1 : 0));
+}
+
+/**
+ * Direction of movement for the market-wide health score.
+ * Mirrors the FeeTrendSummary's TrendDirection for consistency.
+ */
+export interface HealthScoreTrendSummary {
+  /** Average score at the most recent data point, or null if no data. */
+  latest: number | null;
+  /** Average score at the earliest data point, or null if < 2 points. */
+  earliest: number | null;
+  /** Signed absolute change (latest − earliest). */
+  absoluteChange: number | null;
+  /** Signed percentage change. */
+  pctChange: number | null;
+  direction: TrendDirection;
+  pointCount: number;
+}
+
+/**
+ * Summarise the direction of the market-wide health-score trend from a
+ * chronological series of daily average points.
+ *
+ * "Flat" = |pctChange| <= 1 % (mirrors fee-trend convention).
+ * Returns direction "insufficient_data" when fewer than 2 points exist.
+ */
+export function computeHealthScoreTrendSummary(
+  points: HealthScoreTrendPoint[],
+): HealthScoreTrendSummary {
+  if (points.length === 0) {
+    return { latest: null, earliest: null, absoluteChange: null, pctChange: null, direction: "insufficient_data", pointCount: 0 };
+  }
+  if (points.length === 1) {
+    return { latest: points[0]!.avgScore, earliest: points[0]!.avgScore, absoluteChange: null, pctChange: null, direction: "insufficient_data", pointCount: 1 };
+  }
+
+  const earliest = points[0]!.avgScore;
+  const latest = points[points.length - 1]!.avgScore;
+  const absoluteChange = roundTo(latest - earliest, 2);
+  const pctChange = earliest === 0 ? null : roundTo(((latest - earliest) / earliest) * 100, 1);
+
+  let direction: TrendDirection = "flat";
+  if (pctChange !== null) {
+    if (pctChange < -1) direction = "falling";
+    else if (pctChange > 1) direction = "rising";
+  }
+
+  return {
+    latest: roundTo(latest, 1) as number,
+    earliest: roundTo(earliest, 1) as number,
+    absoluteChange,
+    pctChange,
+    direction,
+    pointCount: points.length,
+  };
+}
+
+// ─── Market Pulse: savings-rate time series ──────────────────────────────────
+
+/** A row from savings_rate_snapshots (the subset we need). */
+export interface SavingsRateRow {
+  rate_bps: number;
+  captured_at: string; // ISO timestamp
+  product_kind: string; // "savings_account" | "term_deposit"
+  broker_id: number;
+  intro_rate_bps: number | null;
+}
+
+/**
+ * A single point on the market-wide savings-rate time series.
+ *
+ * Only emitted when >= 2 distinct broker_ids contributed.
+ */
+export interface SavingsRateTrendPoint {
+  /** YYYY-MM-DD */
+  day: string;
+  /**
+   * Best (highest) standard rate across contributing brokers, in % pa (bps ÷ 100).
+   * Rounded to 2dp.
+   */
+  bestRate: number;
+  /**
+   * Arithmetic mean standard rate across contributing brokers, in % pa.
+   * Rounded to 2dp.
+   */
+  avgRate: number;
+  /** Number of distinct broker_ids that contributed. */
+  brokerCount: number;
+}
+
+/**
+ * Bucket savings-rate snapshot rows into daily best/average values.
+ *
+ * - Only "savings_account" rows are included (term deposits have term-specific
+ *   rates that skew market-wide comparisons — they are a separate product type).
+ * - Groups by UTC calendar day. Within each day, uses the latest snapshot per
+ *   broker (an append-only table may have multiple rows per broker per day).
+ * - Days with < 2 distinct brokers are suppressed (privacy guard).
+ * - `rate_bps` is the standard rate; intro rates are intentionally excluded
+ *   from market averages (they are promotional and time-limited).
+ * - Output is sorted chronologically (oldest first).
+ */
+export function buildSavingsRateTrendPoints(
+  rows: SavingsRateRow[],
+): SavingsRateTrendPoint[] {
+  if (rows.length === 0) return [];
+
+  // Group: day → Map<broker_id, latest rate_bps for that day>
+  const byDay = new Map<string, Map<number, { rate_bps: number; captured_at: string }>>();
+
+  for (const row of rows) {
+    if (row.product_kind !== "savings_account") continue;
+    if (!Number.isFinite(Number(row.rate_bps))) continue;
+
+    const day = row.captured_at.slice(0, 10);
+    if (!byDay.has(day)) byDay.set(day, new Map());
+    const dayMap = byDay.get(day)!;
+
+    const existing = dayMap.get(row.broker_id);
+    // Keep the latest captured_at row per broker per day
+    if (!existing || row.captured_at > existing.captured_at) {
+      dayMap.set(row.broker_id, { rate_bps: Number(row.rate_bps), captured_at: row.captured_at });
+    }
+  }
+
+  const points: SavingsRateTrendPoint[] = [];
+
+  for (const [day, brokerMap] of byDay.entries()) {
+    if (brokerMap.size < 2) continue; // privacy guard
+    const rates = [...brokerMap.values()].map((v) => v.rate_bps / 100); // bps → % pa
+    const best = Math.max(...rates);
+    const avg = rates.reduce((sum, r) => sum + r, 0) / rates.length;
+    points.push({
+      day,
+      bestRate: (roundTo(best, 2) as number),
+      avgRate: (roundTo(avg, 2) as number),
+      brokerCount: brokerMap.size,
+    });
+  }
+
+  return points.sort((a, b) => (a.day < b.day ? -1 : a.day > b.day ? 1 : 0));
+}
+
+/**
+ * Compute a trend summary for the savings-rate series (best rate direction).
+ *
+ * "Flat" = |pctChange| <= 1 %. Returns "insufficient_data" for < 2 points.
+ */
+export interface SavingsRateTrendSummary {
+  latestBest: number | null;
+  earliestBest: number | null;
+  latestAvg: number | null;
+  absoluteChangeBest: number | null;
+  pctChangeBest: number | null;
+  direction: TrendDirection;
+  pointCount: number;
+}
+
+export function computeSavingsRateTrendSummary(
+  points: SavingsRateTrendPoint[],
+): SavingsRateTrendSummary {
+  if (points.length === 0) {
+    return { latestBest: null, earliestBest: null, latestAvg: null, absoluteChangeBest: null, pctChangeBest: null, direction: "insufficient_data", pointCount: 0 };
+  }
+  if (points.length === 1) {
+    return { latestBest: points[0]!.bestRate, earliestBest: points[0]!.bestRate, latestAvg: points[0]!.avgRate, absoluteChangeBest: null, pctChangeBest: null, direction: "insufficient_data", pointCount: 1 };
+  }
+
+  const earliest = points[0]!.bestRate;
+  const latest = points[points.length - 1]!.bestRate;
+  const latestAvg = points[points.length - 1]!.avgRate;
+  const absoluteChangeBest = roundTo(latest - earliest, 2);
+  const pctChangeBest = earliest === 0 ? null : roundTo(((latest - earliest) / earliest) * 100, 1);
+
+  let direction: TrendDirection = "flat";
+  if (pctChangeBest !== null) {
+    if (pctChangeBest < -1) direction = "falling";
+    else if (pctChangeBest > 1) direction = "rising";
+  }
+
+  return {
+    latestBest: roundTo(latest, 2) as number,
+    earliestBest: roundTo(earliest, 2) as number,
+    latestAvg: roundTo(latestAvg, 2) as number,
+    absoluteChangeBest,
+    pctChangeBest,
+    direction,
+    pointCount: points.length,
+  };
+}
+
+// ─── Market Pulse: fee-index delta series ────────────────────────────────────
+
+/**
+ * A single point on the fee-index period-over-period delta series.
+ * Each point is the signed change vs the prior period in the series.
+ */
+export interface FeeIndexDeltaPoint {
+  /** YYYY-MM-DD */
+  period: string;
+  /** Signed delta vs prior period for avg ASX fee, or null. */
+  asxDelta: number | null;
+  /** Signed delta vs prior period for avg US fee, or null. */
+  usDelta: number | null;
+  /** Signed delta vs prior period for avg FX spread, or null. */
+  fxDelta: number | null;
+}
+
+/**
+ * Convert a chronological series of fee trend points into a period-over-period
+ * delta series.
+ *
+ * The first point has no prior, so it is omitted. Output length is
+ * `points.length - 1` for a non-empty input (0 for empty or single-point).
+ * Null values propagate: if either side of a delta is null, the delta is null.
+ */
+export function buildFeeIndexDeltaSeries(
+  points: FeeTrendPoint[],
+): FeeIndexDeltaPoint[] {
+  if (points.length < 2) return [];
+
+  const deltas: FeeIndexDeltaPoint[] = [];
+  for (let i = 1; i < points.length; i++) {
+    const prev = points[i - 1]!;
+    const curr = points[i]!;
+
+    const diff = (a: number | null, b: number | null): number | null => {
+      if (a === null || b === null) return null;
+      return roundTo(b - a, 4);
+    };
+
+    deltas.push({
+      period: curr.period,
+      asxDelta: diff(prev.avgAsxFee, curr.avgAsxFee),
+      usDelta: diff(prev.avgUsFee, curr.avgUsFee),
+      fxDelta: diff(prev.avgFxSpread, curr.avgFxSpread),
+    });
+  }
+  return deltas;
+}


### PR DESCRIPTION
Round-4 deepening (2 of 10). A public **"Market Pulse"** dashboard surfacing aggregate time-series we already store but only showed per-broker. Factual aggregate data (AFSL-safe; no advice, no rankings-as-advice).

- `lib/market-intelligence.ts` — 6 new pure, tested helpers: market-wide **health-score trend** (with a <2-broker privacy guard), best+avg **savings-rate trend** (savings accounts, bps→% pa), and **fee-index delta series** (period-over-period, null-safe).
- `app/market-pulse/page.tsx` — new public page (ISR 1h; `Dataset` + breadcrumb JSON-LD): three dependency-free SVG trend sections (reusing the existing `/health-scores` sparkline approach), honest empty states, methodology note, `GENERAL_ADVICE_WARNING` + editorial-accuracy. Linked from `/insights`. Does **not** duplicate the per-broker `/health-scores` view.
- Client choice follows CLAUDE.md doctrine: `createClient()` for `broker_health_score_history` + `savings_rate_snapshots` (anon SELECT), `readFeeIndex()` (admin) for the service-role `fee_index_snapshots`.

**Verified:** `tsc` clean · **41 tests** (trend direction, bucketing, privacy guard, sparse/single-point, bps→% conversion, null propagation) pass · eslint clean · jsonld gate green.

**Note:** series show honest empty states until the `snapshot-health-scores` / `refresh-savings-rates` crons have ≥2 days × ≥2 platforms of history (fee-index is available immediately).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUfSRE2Teb6VhEXFP6RpS9)_