### PR TITLE
feat(push): RFC 8292 VAPID JWT signing + watchlist push wiring (deepen)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -29,6 +29,16 @@ RESEND_AUDIENCE_ID=your_resend_audience_id_here
 #   alerts@invest.com.au    (alert notifications)
 #   billing@invest.com.au   (billing alerts)
 
+# ── Web Push / VAPID (REQUIRED for browser push notifications) ───
+# Generate with: npx web-push generate-vapid-keys
+# VAPID_PUBLIC_KEY is also set as NEXT_PUBLIC_VAPID_PUBLIC_KEY for the SW.
+VAPID_PUBLIC_KEY=your_vapid_public_key_here
+VAPID_PRIVATE_KEY=your_vapid_private_key_here
+# VAPID_SUBJECT — identifies the push operator (mailto: or https: URL).
+# Defaults to mailto:admin@invest.com.au if unset.
+VAPID_SUBJECT=mailto:admin@invest.com.au
+ADMIN_API_KEY=your_admin_api_key_here
+
 # ── Cron / Internal (REQUIRED for automations) ───────────
 CRON_SECRET=your_cron_secret_here
 INTERNAL_API_KEY=your_internal_api_key_here

--- a/__tests__/api/cron-watchlist-alerts.test.ts
+++ b/__tests__/api/cron-watchlist-alerts.test.ts
@@ -14,6 +14,16 @@ vi.mock("@/lib/cron-auth", () => ({
   requireCronAuth: vi.fn(() => null),
 }));
 
+const dispatchPushMock = vi.fn(async () => ({
+  sent: 1,
+  failed: 0,
+  skipped_no_sub: false,
+  stale_removed: 0,
+}));
+vi.mock("@/lib/push-dispatch", () => ({
+  dispatchPushToUser: (userId: string, payload: unknown) => dispatchPushMock(userId, payload),
+}));
+
 interface SendArgs {
   to: string;
   subject: string;
@@ -140,6 +150,7 @@ describe("cron/watchlist-alerts", () => {
     state.authUsers = [];
     sendEmailMock.mockClear();
     mockListUsers.mockClear();
+    dispatchPushMock.mockClear();
   });
 
   it("returns 500 when RESEND_API_KEY is unset", async () => {
@@ -198,5 +209,65 @@ describe("cron/watchlist-alerts", () => {
     expect(body.sent).toBe(0);
     expect(body.skipped_no_email).toBe(1);
     expect(sendEmailMock).not.toHaveBeenCalled();
+  });
+
+  // ── Push dispatch wiring ──────────────────────────────────────────────────
+
+  it("calls dispatchPushToUser for each successfully emailed user", async () => {
+    const now = new Date();
+    state.prefs = [{ user_id: "u-1", last_digest_window_start: null }];
+    state.items = [{ user_id: "u-1", id: 1, item_type: "broker", item_slug: "commsec", display_name: "CommSec" }];
+    state.brokers = [{ slug: "commsec", name: "CommSec", updated_at: now.toISOString() }];
+    state.authUsers = [{ id: "u-1", email: "alice@x.com", user_metadata: {} }];
+    await GET(makeReq());
+    expect(dispatchPushMock).toHaveBeenCalledOnce();
+    const [userId, payload] = dispatchPushMock.mock.calls[0] as [string, { title: string; body: string; url: string; tag: string }];
+    expect(userId).toBe("u-1");
+    expect(payload.title).toBe("Your watchlist this week");
+    expect(payload.tag).toBe("watchlist_digest:u-1");
+  });
+
+  it("reports push_dispatched count in the response", async () => {
+    const now = new Date();
+    state.prefs = [{ user_id: "u-1", last_digest_window_start: null }];
+    state.items = [{ user_id: "u-1", id: 1, item_type: "broker", item_slug: "commsec", display_name: "CommSec" }];
+    state.brokers = [{ slug: "commsec", name: "CommSec", updated_at: now.toISOString() }];
+    state.authUsers = [{ id: "u-1", email: "alice@x.com", user_metadata: {} }];
+    const res = await GET(makeReq());
+    const body = await res.json();
+    expect(body.push_dispatched).toBe(1);
+  });
+
+  it("does not call dispatchPushToUser for users with no email (skipped before email)", async () => {
+    state.prefs = [{ user_id: "u-1", last_digest_window_start: null }];
+    state.items = [{ user_id: "u-1", id: 1, item_type: "broker", item_slug: "commsec", display_name: "CommSec" }];
+    state.brokers = [{ slug: "commsec", name: "CommSec", updated_at: new Date().toISOString() }];
+    state.authUsers = [{ id: "u-1", email: null, user_metadata: {} }];
+    await GET(makeReq());
+    expect(dispatchPushMock).not.toHaveBeenCalled();
+  });
+
+  it("does not call dispatchPushToUser when digest has no changes", async () => {
+    state.prefs = [{ user_id: "u-1", last_digest_window_start: null }];
+    state.items = [{ user_id: "u-1", id: 1, item_type: "broker", item_slug: "commsec", display_name: "CommSec" }];
+    state.brokers = []; // nothing changed
+    state.authUsers = [{ id: "u-1", email: "alice@x.com", user_metadata: {} }];
+    await GET(makeReq());
+    expect(dispatchPushMock).not.toHaveBeenCalled();
+  });
+
+  it("push dispatch failure does not fail the cron run (fire-and-forget)", async () => {
+    const now = new Date();
+    state.prefs = [{ user_id: "u-1", last_digest_window_start: null }];
+    state.items = [{ user_id: "u-1", id: 1, item_type: "broker", item_slug: "commsec", display_name: "CommSec" }];
+    state.brokers = [{ slug: "commsec", name: "CommSec", updated_at: now.toISOString() }];
+    state.authUsers = [{ id: "u-1", email: "alice@x.com", user_metadata: {} }];
+    // dispatchPushToUser resolves with sent:0 (e.g. VAPID keys unset) — should not throw
+    dispatchPushMock.mockResolvedValueOnce({ sent: 0, failed: 0, skipped_no_sub: true, stale_removed: 0 });
+    const res = await GET(makeReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sent).toBe(1);
+    expect(body.push_dispatched).toBe(0);
   });
 });

--- a/__tests__/api/cron-watchlist-alerts.test.ts
+++ b/__tests__/api/cron-watchlist-alerts.test.ts
@@ -14,7 +14,7 @@ vi.mock("@/lib/cron-auth", () => ({
   requireCronAuth: vi.fn(() => null),
 }));
 
-const dispatchPushMock = vi.fn(async () => ({
+const dispatchPushMock = vi.fn(async (_userId: string, _payload: unknown) => ({
   sent: 1,
   failed: 0,
   skipped_no_sub: false,

--- a/__tests__/api/push-send.test.ts
+++ b/__tests__/api/push-send.test.ts
@@ -7,6 +7,11 @@ vi.mock("@/lib/logger", () => ({
   logger: vi.fn(() => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn() })),
 }));
 
+// Mock the VAPID JWT builder — push-send tests verify request routing, not JWT signing.
+vi.mock("@/lib/vapid-jwt", () => ({
+  buildVapidAuthHeader: vi.fn(async () => "vapid t=mock.jwt.sig, k=mock-pub"),
+}));
+
 const mockAdminFrom = vi.fn();
 vi.mock("@/lib/supabase/admin", () => ({
   createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),

--- a/__tests__/lib/push-dispatch.test.ts
+++ b/__tests__/lib/push-dispatch.test.ts
@@ -25,6 +25,12 @@ vi.mock("@/lib/logger", () => ({
   })),
 }));
 
+// Mock the VAPID JWT builder so push-dispatch tests don't need real key material.
+// The unit under test here is the dispatch loop, not the JWT construction.
+vi.mock("@/lib/vapid-jwt", () => ({
+  buildVapidAuthHeader: vi.fn(async () => "vapid t=mock.jwt.sig, k=mock-pub"),
+}));
+
 const { mockMaybeSingle, mockSubsQuery, mockDeleteIn, mockDeleteBuilder } =
   vi.hoisted(() => ({
     mockMaybeSingle: vi.fn(),
@@ -249,6 +255,16 @@ describe("dispatchPushToUser", () => {
     expect(sent.title).toBe(PAYLOAD.title);
     expect(sent.body).toBe(PAYLOAD.body);
     expect(sent.url).toBe(PAYLOAD.url);
+  });
+
+  it("sets the Authorization header from buildVapidAuthHeader", async () => {
+    setupFrom();
+    const sender = mockSender(201);
+    await dispatchPushToUser(USER_ID, PAYLOAD, sender);
+    const [, init] = sender.mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    // The mock returns "vapid t=mock.jwt.sig, k=mock-pub"
+    expect(headers["Authorization"]).toBe("vapid t=mock.jwt.sig, k=mock-pub");
   });
 
   it("uses custom icon and tag when provided", async () => {

--- a/__tests__/lib/vapid-jwt.test.ts
+++ b/__tests__/lib/vapid-jwt.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Tests for lib/vapid-jwt.ts
+ *
+ * Covers:
+ *   - JWT structure: header + claims + signature (3 dot-separated parts)
+ *   - Header claims: typ=JWT, alg=ES256
+ *   - Payload claims: aud = scheme+host of endpoint, sub = subject, exp = now+12h
+ *   - Signature verifies against the VAPID public key via Web Crypto
+ *   - Custom expiresInSeconds / nowMs are respected
+ *   - VAPID_SUBJECT env var is used when subject option is omitted
+ *   - Default subject fallback ("mailto:admin@invest.com.au") when neither is set
+ *   - buildVapidAuthHeader returns `vapid t=<jwt>, k=<publicKey>`
+ *   - fromBase64Url / toBase64Url round-trips
+ *   - Wrong key length throws a descriptive error
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  buildVapidJwt,
+  buildVapidAuthHeader,
+  toBase64Url,
+  fromBase64Url,
+} from "@/lib/vapid-jwt";
+
+// ── Generate a real P-256 key pair for tests ──────────────────────────────────
+//
+// vitest runs in Node 20+ which exposes globalThis.crypto.subtle.
+// We generate a fresh key pair once per module load — fast (~1ms) and
+// deterministic across test runs in the same process.
+
+async function generateTestKeyPair(): Promise<{
+  privateKeyBase64url: string;
+  publicKeyBase64url: string;
+  publicKeyCryptoKey: CryptoKey;
+}> {
+  const { privateKey, publicKey } = await globalThis.crypto.subtle.generateKey(
+    { name: "ECDSA", namedCurve: "P-256" },
+    true,
+    ["sign", "verify"],
+  );
+
+  // Export private key as JWK to get the raw 32-byte scalar (`d` field).
+  // Using JWK export is simpler and more reliable than parsing PKCS8 bytes.
+  const jwk = await globalThis.crypto.subtle.exportKey("jwk", privateKey);
+  // jwk.d is base64url (no padding) — exactly the format VAPID_PRIVATE_KEY uses.
+  const privateKeyBase64url = jwk.d ?? "";
+
+  // Export public key as raw (65-byte uncompressed point)
+  const rawPublic = new Uint8Array(
+    await globalThis.crypto.subtle.exportKey("raw", publicKey),
+  );
+  const publicKeyBase64url = toBase64Url(rawPublic);
+
+  return { privateKeyBase64url, publicKeyBase64url, publicKeyCryptoKey: publicKey };
+}
+
+// ── Helper: decode JWT part ───────────────────────────────────────────────────
+
+function decodeJwtPart(part: string): Record<string, unknown> {
+  const bytes = fromBase64Url(part);
+  const json = new TextDecoder().decode(bytes);
+  return JSON.parse(json) as Record<string, unknown>;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("toBase64Url / fromBase64Url", () => {
+  it("round-trips arbitrary bytes", () => {
+    const original = Uint8Array.from([0, 1, 127, 128, 255, 62, 63]);
+    const encoded = toBase64Url(original);
+    expect(encoded).not.toContain("+");
+    expect(encoded).not.toContain("/");
+    expect(encoded).not.toContain("=");
+    const decoded = fromBase64Url(encoded);
+    expect(decoded).toEqual(original);
+  });
+
+  it("handles empty bytes", () => {
+    const encoded = toBase64Url(new Uint8Array(0));
+    expect(encoded).toBe("");
+    expect(fromBase64Url(encoded)).toEqual(new Uint8Array(0));
+  });
+
+  it("tolerates base64url input without padding", () => {
+    // "abc" → 3 bytes → 4 base64 chars without padding
+    const bytes = Uint8Array.from([105, 183, 29]);
+    const withPadding = btoa(String.fromCharCode(...bytes));
+    const withoutPadding = withPadding.replace(/=/g, "");
+    const decoded = fromBase64Url(withoutPadding);
+    expect(decoded).toEqual(bytes);
+  });
+});
+
+describe("buildVapidJwt", () => {
+  const endpoint = "https://fcm.googleapis.com/fcm/send/test-token";
+  const subject = "mailto:push@invest.com.au";
+  const nowMs = 1_700_000_000_000; // deterministic fixed time
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns a three-part dot-separated JWT string", async () => {
+    const { privateKeyBase64url } = await generateTestKeyPair();
+    const jwt = await buildVapidJwt({ endpoint, privateKey: privateKeyBase64url, subject, nowMs });
+    const parts = jwt.split(".");
+    expect(parts).toHaveLength(3);
+  });
+
+  it("header contains typ=JWT and alg=ES256", async () => {
+    const { privateKeyBase64url } = await generateTestKeyPair();
+    const jwt = await buildVapidJwt({ endpoint, privateKey: privateKeyBase64url, subject, nowMs });
+    const [headerB64] = jwt.split(".");
+    const header = decodeJwtPart(headerB64 ?? "");
+    expect(header.typ).toBe("JWT");
+    expect(header.alg).toBe("ES256");
+  });
+
+  it("claims contain correct aud (scheme + host only)", async () => {
+    const { privateKeyBase64url } = await generateTestKeyPair();
+    const jwt = await buildVapidJwt({ endpoint, privateKey: privateKeyBase64url, subject, nowMs });
+    const [, claimsB64] = jwt.split(".");
+    const claims = decodeJwtPart(claimsB64 ?? "");
+    expect(claims.aud).toBe("https://fcm.googleapis.com");
+  });
+
+  it("claims contain correct sub", async () => {
+    const { privateKeyBase64url } = await generateTestKeyPair();
+    const jwt = await buildVapidJwt({ endpoint, privateKey: privateKeyBase64url, subject, nowMs });
+    const [, claimsB64] = jwt.split(".");
+    const claims = decodeJwtPart(claimsB64 ?? "");
+    expect(claims.sub).toBe(subject);
+  });
+
+  it("exp = now + 12h by default", async () => {
+    const { privateKeyBase64url } = await generateTestKeyPair();
+    const jwt = await buildVapidJwt({ endpoint, privateKey: privateKeyBase64url, subject, nowMs });
+    const [, claimsB64] = jwt.split(".");
+    const claims = decodeJwtPart(claimsB64 ?? "");
+    const expectedExp = Math.floor(nowMs / 1000) + 12 * 3600;
+    expect(claims.exp).toBe(expectedExp);
+  });
+
+  it("respects custom expiresInSeconds", async () => {
+    const { privateKeyBase64url } = await generateTestKeyPair();
+    const jwt = await buildVapidJwt({
+      endpoint,
+      privateKey: privateKeyBase64url,
+      subject,
+      nowMs,
+      expiresInSeconds: 3600,
+    });
+    const [, claimsB64] = jwt.split(".");
+    const claims = decodeJwtPart(claimsB64 ?? "");
+    const expectedExp = Math.floor(nowMs / 1000) + 3600;
+    expect(claims.exp).toBe(expectedExp);
+  });
+
+  it("uses VAPID_SUBJECT env var when subject option is omitted", async () => {
+    vi.stubEnv("VAPID_SUBJECT", "mailto:env-sub@invest.com.au");
+    const { privateKeyBase64url } = await generateTestKeyPair();
+    const jwt = await buildVapidJwt({ endpoint, privateKey: privateKeyBase64url, nowMs });
+    const [, claimsB64] = jwt.split(".");
+    const claims = decodeJwtPart(claimsB64 ?? "");
+    expect(claims.sub).toBe("mailto:env-sub@invest.com.au");
+  });
+
+  it("falls back to mailto:admin@invest.com.au when VAPID_SUBJECT is unset", async () => {
+    vi.stubEnv("VAPID_SUBJECT", "");
+    const { privateKeyBase64url } = await generateTestKeyPair();
+    const jwt = await buildVapidJwt({ endpoint, privateKey: privateKeyBase64url, nowMs });
+    const [, claimsB64] = jwt.split(".");
+    const claims = decodeJwtPart(claimsB64 ?? "");
+    expect(claims.sub).toBe("mailto:admin@invest.com.au");
+  });
+
+  it("signature verifies against the matching public key via Web Crypto", async () => {
+    const { privateKeyBase64url, publicKeyCryptoKey } = await generateTestKeyPair();
+    const jwt = await buildVapidJwt({ endpoint, privateKey: privateKeyBase64url, subject, nowMs });
+
+    const [headerB64, claimsB64, sigB64] = jwt.split(".");
+    const signingInput = `${headerB64}.${claimsB64}`;
+    const encoder = new TextEncoder();
+    const signingInputBytes = encoder.encode(signingInput);
+
+    // Web Crypto verify — signature is IEEE P1363 (r || s) — same as what
+    // SubtleCrypto.sign returns, so we decode directly.
+    const sigBytes = fromBase64Url(sigB64 ?? "");
+
+    const valid = await globalThis.crypto.subtle.verify(
+      { name: "ECDSA", hash: { name: "SHA-256" } },
+      publicKeyCryptoKey,
+      sigBytes,
+      signingInputBytes,
+    );
+    expect(valid).toBe(true);
+  });
+
+  it("signature does NOT verify against a different public key", async () => {
+    const { privateKeyBase64url } = await generateTestKeyPair();
+    const { publicKeyCryptoKey: otherPublicKey } = await generateTestKeyPair();
+
+    const jwt = await buildVapidJwt({ endpoint, privateKey: privateKeyBase64url, subject, nowMs });
+    const [headerB64, claimsB64, sigB64] = jwt.split(".");
+    const sigBytes = fromBase64Url(sigB64 ?? "");
+    const signingInputBytes = new TextEncoder().encode(`${headerB64}.${claimsB64}`);
+
+    const valid = await globalThis.crypto.subtle.verify(
+      { name: "ECDSA", hash: { name: "SHA-256" } },
+      otherPublicKey,
+      sigBytes,
+      signingInputBytes,
+    );
+    expect(valid).toBe(false);
+  });
+
+  it("throws a descriptive error when key is not 32 bytes", async () => {
+    await expect(
+      buildVapidJwt({
+        endpoint,
+        privateKey: toBase64Url(Uint8Array.from([1, 2, 3])), // only 3 bytes
+        subject,
+        nowMs,
+      }),
+    ).rejects.toThrow(/32 bytes/);
+  });
+
+  it("aud uses the endpoint host for different push services", async () => {
+    const { privateKeyBase64url } = await generateTestKeyPair();
+    const apnsEndpoint = "https://web.push.apple.com/QA/abc123";
+    const jwt = await buildVapidJwt({
+      endpoint: apnsEndpoint,
+      privateKey: privateKeyBase64url,
+      subject,
+      nowMs,
+    });
+    const [, claimsB64] = jwt.split(".");
+    const claims = decodeJwtPart(claimsB64 ?? "");
+    expect(claims.aud).toBe("https://web.push.apple.com");
+  });
+});
+
+describe("buildVapidAuthHeader", () => {
+  const endpoint = "https://fcm.googleapis.com/fcm/send/tok";
+  const subject = "mailto:push@invest.com.au";
+
+  it("returns `vapid t=<jwt>, k=<publicKey>` format", async () => {
+    const { privateKeyBase64url, publicKeyBase64url } = await generateTestKeyPair();
+    const header = await buildVapidAuthHeader(
+      endpoint,
+      privateKeyBase64url,
+      publicKeyBase64url,
+      subject,
+    );
+    expect(header).toMatch(/^vapid t=.+\..+\..+, k=.+$/);
+    const kMatch = header.match(/k=([^,\s]+)/);
+    expect(kMatch?.[1]).toBe(publicKeyBase64url);
+  });
+
+  it("the jwt part alone is a valid 3-part JWT", async () => {
+    const { privateKeyBase64url, publicKeyBase64url } = await generateTestKeyPair();
+    const header = await buildVapidAuthHeader(
+      endpoint,
+      privateKeyBase64url,
+      publicKeyBase64url,
+      subject,
+    );
+    const tMatch = header.match(/t=([^,\s]+)/);
+    const jwt = tMatch?.[1] ?? "";
+    expect(jwt.split(".")).toHaveLength(3);
+  });
+});

--- a/__tests__/lib/vapid-jwt.test.ts
+++ b/__tests__/lib/vapid-jwt.test.ts
@@ -190,7 +190,7 @@ describe("buildVapidJwt", () => {
     const valid = await globalThis.crypto.subtle.verify(
       { name: "ECDSA", hash: { name: "SHA-256" } },
       publicKeyCryptoKey,
-      sigBytes,
+      sigBytes as BufferSource,
       signingInputBytes,
     );
     expect(valid).toBe(true);
@@ -208,7 +208,7 @@ describe("buildVapidJwt", () => {
     const valid = await globalThis.crypto.subtle.verify(
       { name: "ECDSA", hash: { name: "SHA-256" } },
       otherPublicKey,
-      sigBytes,
+      sigBytes as BufferSource,
       signingInputBytes,
     );
     expect(valid).toBe(false);

--- a/app/api/cron/portfolio-alerts/route.ts
+++ b/app/api/cron/portfolio-alerts/route.ts
@@ -17,6 +17,18 @@ export const maxDuration = 30;
  * 3. New deals on their brokers
  *
  * Sends email alerts and creates portfolio_alerts records.
+ *
+ * NOTE — browser push gap:
+ *   user_portfolios stores `email` (the portfolio owner's address) but
+ *   no `user_id` column. The push delivery stack (dispatchPushToUser)
+ *   requires a Supabase auth user UUID, and resolving one from an email
+ *   address on the Edge runtime is deliberately avoided (it would require
+ *   auth.admin.listUsers pagination across potentially many pages).
+ *
+ *   Browser push will be wired here once the table carries a user_id
+ *   column — tracked in FIN_NOTEBOOK. Until then, email is the sole
+ *   delivery channel for portfolio alerts. The rate-alerts and watchlist
+ *   crons already cover push delivery for their own alert types.
  */
 export async function GET(req: Request) {
   const unauth = requireCronAuth(req);

--- a/app/api/cron/watchlist-alerts/route.ts
+++ b/app/api/cron/watchlist-alerts/route.ts
@@ -24,6 +24,7 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { logger } from "@/lib/logger";
 import { requireCronAuth } from "@/lib/cron-auth";
 import { sendEmail } from "@/lib/resend";
+import { dispatchPushToUser } from "@/lib/push-dispatch";
 import {
   collectChangesForUser,
   renderWatchlistDigestHtml,
@@ -139,7 +140,7 @@ export async function GET(req: NextRequest) {
 
   // 3. Per-user: build the digest, send if non-empty, record state.
   const users = await fetchAuthUsers(supabase, userIds);
-  const stats = { sent: 0, skipped_empty: 0, skipped_no_email: 0, failed: 0 };
+  const stats = { sent: 0, skipped_empty: 0, skipped_no_email: 0, failed: 0, push_dispatched: 0 };
 
   for (const pref of optedIn) {
     const items = itemsByUser.get(pref.user_id) ?? [];
@@ -209,6 +210,19 @@ export async function GET(req: NextRequest) {
         userId: pref.user_id,
         error: updateErr.message,
       });
+    }
+
+    // Browser push — fire-and-forget alongside the email.
+    // dispatchPushToUser checks browser_push pref and skips silently when
+    // the user hasn't opted in, so this is always safe to call.
+    const pushResult = await dispatchPushToUser(pref.user_id, {
+      title: "Your watchlist this week",
+      body: `${changes.length} update${changes.length === 1 ? "" : "s"} on your watchlist.`,
+      url: MANAGE_HREF,
+      tag: `watchlist_digest:${pref.user_id}`,
+    });
+    if (pushResult.sent > 0) {
+      stats.push_dispatched += pushResult.sent;
     }
   }
 

--- a/app/api/push/send/route.ts
+++ b/app/api/push/send/route.ts
@@ -26,6 +26,7 @@ export async function POST(request: NextRequest) {
   }
 
   try {
+    // eslint-disable-next-line invest/no-unvalidated-req-json -- admin-gated internal push-send route (ADMIN_API_KEY checked above); fields destructured + validated below
     const body = await request.json();
     const { topic, title, body: notifBody, url, icon } = body as {
       topic: string;

--- a/app/api/push/send/route.ts
+++ b/app/api/push/send/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { logger } from "@/lib/logger";
+import { buildVapidAuthHeader } from "@/lib/vapid-jwt";
 
 const log = logger("push:send");
 
@@ -94,20 +95,25 @@ export async function POST(request: NextRequest) {
       topic,
     });
 
-    // Send notifications via Web Push protocol
-    // Uses VAPID for authentication (RFC 8292)
+    // Send notifications via Web Push protocol (RFC 8292 — ES256 VAPID JWT)
     let sent = 0;
     let failed = 0;
     const staleEndpoints: string[] = [];
 
     const results = await Promise.allSettled(
       subscriptions.map(async (sub) => {
+        // Build a per-endpoint VAPID JWT (aud = scheme+host of the endpoint)
+        const authHeader = await buildVapidAuthHeader(
+          sub.endpoint,
+          vapidPrivate,
+          vapidPublic,
+        );
         const res = await fetch(sub.endpoint, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
             "TTL": "86400",
-            ...(vapidPublic ? { "Authorization": `vapid t=${vapidPublic}` } : {}),
+            Authorization: authHeader,
           },
           body: payload,
         });

--- a/lib/push-dispatch.ts
+++ b/lib/push-dispatch.ts
@@ -31,6 +31,7 @@
 // eslint-disable-next-line no-restricted-imports -- runs from the alert crons (no user JWT), dispatching to a specific user's push_subscriptions rows; service-role required for this cross-user/cron context
 import { createAdminClient } from "@/lib/supabase/admin";
 import { logger } from "@/lib/logger";
+import { buildVapidAuthHeader } from "@/lib/vapid-jwt";
 
 const log = logger("push-dispatch");
 
@@ -152,22 +153,20 @@ export async function dispatchPushToUser(
 
     const results = await Promise.allSettled(
       (subs as PushSubscriptionRow[]).map(async (sub) => {
-        // The /api/push/send route uses a simplified VAPID header construction.
-        // We follow the same approach for consistency — a full RFC 8292
-        // implementation (with JWT + crypto signing) requires the `web-push`
-        // npm package which is not installed. The VAPID public key is sent as
-        // an audience hint; real VAPID signing is a server-side concern that
-        // most push services also accept without the JWT when the endpoint is
-        // from their own infrastructure (FCM, APNS-web).
-        //
-        // TODO: if full RFC 8292 compliance is needed, install `web-push` and
-        // replace the Authorization header construction here. Track in FIN_NOTEBOOK.
+        // RFC 8292 — ES256 JWT signed with the VAPID private key.
+        // buildVapidAuthHeader returns: `vapid t=<jwt>, k=<publicKey>`
+        const authHeader = await buildVapidAuthHeader(
+          sub.endpoint,
+          vapidPrivate,
+          vapidPublic,
+        );
+
         const res = await sender(sub.endpoint, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
             "TTL": "86400",
-            Authorization: `vapid t=${vapidPublic}`,
+            Authorization: authHeader,
           },
           body: payloadJson,
         });

--- a/lib/vapid-jwt.ts
+++ b/lib/vapid-jwt.ts
@@ -1,0 +1,257 @@
+/**
+ * vapid-jwt — RFC 8292 ES256 VAPID JWT builder.
+ *
+ * Builds a signed JSON Web Token for use in the VAPID Authorization header
+ * when sending Web Push notifications. No npm dependency — uses the
+ * Web Crypto API (globalThis.crypto.subtle) available in Node 20+ and the
+ * Edge runtime.
+ *
+ * Usage:
+ *   const jwt = await buildVapidJwt({
+ *     endpoint:    "https://fcm.googleapis.com/fcm/send/…",
+ *     privateKey:  process.env.VAPID_PRIVATE_KEY,   // base64url raw P-256 key
+ *     subject:     process.env.VAPID_SUBJECT ?? "mailto:admin@invest.com.au",
+ *   });
+ *   // jwt is a base64url-encoded signed JWT string
+ *
+ *   // Then set the Authorization header:
+ *   Authorization: `vapid t=${jwt}, k=${VAPID_PUBLIC_KEY}`
+ *
+ * Key format:
+ *   VAPID_PRIVATE_KEY — the 32-byte P-256 private key scalar, base64url-encoded
+ *   (the format produced by tools like `vapid-keygen` or `web-push generate-vapid-keys`).
+ *
+ * References:
+ *   https://datatracker.ietf.org/doc/html/rfc8292
+ *   https://datatracker.ietf.org/doc/html/rfc7519 (JWT)
+ */
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+/**
+ * Encode a Uint8Array as a base64url string (no padding, URL-safe alphabet).
+ */
+export function toBase64Url(bytes: Uint8Array): string {
+  // In Node 20+ Buffer.from + toString is available; in Edge btoa is available.
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i] as number);
+  }
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+}
+
+/**
+ * Decode a base64url string (with or without padding) to a Uint8Array.
+ */
+export function fromBase64Url(input: string): Uint8Array {
+  // Restore standard base64 padding
+  const padded = input.replace(/-/g, "+").replace(/_/g, "/");
+  const padLen = (4 - (padded.length % 4)) % 4;
+  const b64 = padded + "=".repeat(padLen);
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+/**
+ * Convert a base64url-encoded JSON object to a base64url-encoded string.
+ */
+function encodeJwtPart(obj: Record<string, unknown>): string {
+  const json = JSON.stringify(obj);
+  const encoder = new TextEncoder();
+  return toBase64Url(encoder.encode(json));
+}
+
+// ── VAPID JWT builder ──────────────────────────────────────────────────────────
+
+export interface VapidJwtOptions {
+  /** The full push endpoint URL (used to extract aud = scheme + host). */
+  endpoint: string;
+  /**
+   * The raw 32-byte P-256 private key as a base64url string.
+   * Produced by `web-push generate-vapid-keys` or equivalent.
+   */
+  privateKey: string;
+  /**
+   * JWT `sub` claim — must be a mailto: or https: URL identifying the
+   * application server operator. Defaults to the VAPID_SUBJECT env var
+   * or "mailto:admin@invest.com.au" if neither is supplied.
+   */
+  subject?: string;
+  /**
+   * JWT expiry in seconds from now. RFC 8292 requires ≤ 24 h.
+   * Defaults to 12 hours.
+   */
+  expiresInSeconds?: number;
+  /** Inject a custom time source for deterministic tests. */
+  nowMs?: number;
+}
+
+/**
+ * Build a signed RFC 8292 VAPID JWT string (the `t=` part of the header).
+ *
+ * @throws if the private key bytes are not a valid P-256 scalar (i.e. wrong
+ *         key material was stored in VAPID_PRIVATE_KEY).
+ */
+export async function buildVapidJwt(opts: VapidJwtOptions): Promise<string> {
+  const { endpoint, privateKey, expiresInSeconds = 12 * 3600, nowMs = Date.now() } = opts;
+
+  const subject =
+    opts.subject ||
+    process.env.VAPID_SUBJECT ||
+    "mailto:admin@invest.com.au";
+
+  // aud = scheme + host of the push endpoint (RFC 8292 §3.1)
+  const url = new URL(endpoint);
+  const aud = `${url.protocol}//${url.host}`;
+
+  // JWT header
+  const header = encodeJwtPart({ typ: "JWT", alg: "ES256" });
+
+  // JWT claims
+  const nowSec = Math.floor(nowMs / 1000);
+  const claims = encodeJwtPart({
+    aud,
+    exp: nowSec + expiresInSeconds,
+    sub: subject,
+  });
+
+  // Signing input: ASCII(base64url(header) + "." + base64url(payload))
+  const signingInput = `${header}.${claims}`;
+  const encoder = new TextEncoder();
+  const signingInputBytes = encoder.encode(signingInput);
+
+  // Import the raw P-256 private key.
+  // VAPID private keys are 32-byte raw scalars stored as base64url.
+  // Web Crypto requires them wrapped in a JWK (or PKCS8), so we use JWK.
+  const keyBytes = fromBase64Url(privateKey);
+  if (keyBytes.length !== 32) {
+    throw new Error(
+      `VAPID private key must be 32 bytes (got ${keyBytes.length}). ` +
+        "Store the raw P-256 scalar as base64url in VAPID_PRIVATE_KEY.",
+    );
+  }
+
+  // Reconstruct the PKCS8 DER from the raw 32-byte scalar.
+  // Structure: RFC 5915 ECPrivateKey wrapped in PKCS8 PrivateKeyInfo for P-256.
+  // Node 20+ SubtleCrypto accepts PKCS8 without the optional [1] public key context.
+  const pkcs8 = buildEcP256Pkcs8(keyBytes);
+
+  const cryptoKey = await globalThis.crypto.subtle.importKey(
+    "pkcs8",
+    pkcs8,
+    { name: "ECDSA", namedCurve: "P-256" },
+    false,
+    ["sign"],
+  );
+
+  // Sign with ECDSA P-256 + SHA-256 (ES256)
+  // Web Crypto returns the signature in IEEE P1363 format (64 bytes: r || s).
+  const sigDer = await globalThis.crypto.subtle.sign(
+    { name: "ECDSA", hash: { name: "SHA-256" } },
+    cryptoKey,
+    signingInputBytes,
+  );
+
+  const signature = toBase64Url(new Uint8Array(sigDer));
+  return `${signingInput}.${signature}`;
+}
+
+// ── ASN.1 / PKCS8 DER encoding for P-256 private keys ────────────────────────
+//
+// SubtleCrypto.importKey("pkcs8", …) requires a DER-encoded PKCS#8
+// PrivateKeyInfo (RFC 5958). For P-256 the minimal structure is 67 bytes:
+//
+//   30 41                                       SEQUENCE (65 bytes)
+//     02 01 00                                  INTEGER version = 0
+//     30 13                                     SEQUENCE algorithmId (19 bytes)
+//       06 07 2a 86 48 ce 3d 02 01              OID id-ecPublicKey
+//       06 08 2a 86 48 ce 3d 03 01 07           OID secp256r1 (P-256)
+//     04 27                                     OCTET STRING (39 bytes)
+//       30 25                                   SEQUENCE ECPrivateKey (37 bytes)
+//         02 01 01                              INTEGER version = 1
+//         04 20 <32 bytes>                      OCTET STRING privateKey
+//
+// Node 20+ SubtleCrypto accepts this minimal form (the [1] public-key context
+// in the ECPrivateKey is optional). All lengths are computed by tlv() so the
+// function is correct for any 32-byte scalar without hard-coded sizes.
+
+/** Generic DER TLV encoder (handles lengths up to 65535). */
+function tlv(tag: number, value: Uint8Array): Uint8Array {
+  const len = value.length;
+  if (len < 0x80) {
+    return concat([Uint8Array.from([tag, len]), value]);
+  } else if (len < 0x100) {
+    return concat([Uint8Array.from([tag, 0x81, len]), value]);
+  }
+  return concat([
+    Uint8Array.from([tag, 0x82, (len >> 8) & 0xff, len & 0xff]),
+    value,
+  ]);
+}
+
+function buildEcP256Pkcs8(rawKey: Uint8Array): ArrayBuffer {
+  // OID id-ecPublicKey: 1.2.840.10045.2.1
+  const oidEcPublicKey = Uint8Array.from([
+    0x06, 0x07, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02, 0x01,
+  ]);
+  // OID secp256r1 (P-256): 1.2.840.10045.3.1.7
+  const oidP256 = Uint8Array.from([
+    0x06, 0x08, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x03, 0x01, 0x07,
+  ]);
+
+  const algorithmId = tlv(0x30, concat([oidEcPublicKey, oidP256]));
+
+  // RFC 5915 ECPrivateKey (minimal — no public key context):
+  // SEQUENCE { version=1, OCTET STRING(scalar) }
+  const ecPrivateKey = tlv(
+    0x30,
+    concat([
+      tlv(0x02, Uint8Array.from([0x01])), // version = 1
+      tlv(0x04, rawKey), // privateKey scalar
+    ]),
+  );
+
+  // PKCS8 PrivateKeyInfo
+  const pkcs8Body = concat([
+    tlv(0x02, Uint8Array.from([0x00])), // version = 0
+    algorithmId,
+    tlv(0x04, ecPrivateKey), // privateKey OCTET STRING
+  ]);
+
+  return tlv(0x30, pkcs8Body).buffer;
+}
+
+function concat(arrays: Uint8Array[]): Uint8Array {
+  const total = arrays.reduce((n, a) => n + a.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const a of arrays) {
+    out.set(a, offset);
+    offset += a.length;
+  }
+  return out;
+}
+
+/**
+ * Build the full VAPID Authorization header value for a given push endpoint.
+ *
+ * Returns: `vapid t=<jwt>, k=<base64url-public-key>`
+ *
+ * @param endpoint        The push endpoint URL.
+ * @param vapidPrivate    VAPID_PRIVATE_KEY (32-byte P-256 scalar, base64url).
+ * @param vapidPublic     VAPID_PUBLIC_KEY  (65-byte uncompressed P-256 point, base64url).
+ * @param subject         The `sub` claim (mailto: or https: URL).
+ */
+export async function buildVapidAuthHeader(
+  endpoint: string,
+  vapidPrivate: string,
+  vapidPublic: string,
+  subject?: string,
+): Promise<string> {
+  const jwt = await buildVapidJwt({ endpoint, privateKey: vapidPrivate, subject });
+  return `vapid t=${jwt}, k=${vapidPublic}`;
+}

--- a/lib/vapid-jwt.ts
+++ b/lib/vapid-jwt.ts
@@ -222,7 +222,8 @@ function buildEcP256Pkcs8(rawKey: Uint8Array): ArrayBuffer {
     tlv(0x04, ecPrivateKey), // privateKey OCTET STRING
   ]);
 
-  return tlv(0x30, pkcs8Body).buffer;
+  // Freshly-allocated full-size Uint8Array, so .buffer is exactly this data.
+  return tlv(0x30, pkcs8Body).buffer as ArrayBuffer;
 }
 
 function concat(arrays: Uint8Array[]): Uint8Array {


### PR DESCRIPTION
Round-4 deepening (5 of 10). Completes the push-notification delivery stack: a **real RFC 8292 VAPID JWT** (replacing the fake header-hint that fails on non-FCM push servers) + wires the watchlist cron to push. AFSL-safe (factual alerts on the user's own subscriptions).

- `lib/vapid-jwt.ts` — `buildVapidJwt` / `buildVapidAuthHeader`: ES256 (ECDSA P-256) JWT signed via **Web Crypto** (`crypto.subtle`), wrapping the raw 32-byte VAPID private scalar in a minimal PKCS8 DER blob. **No new npm dependency.** `lib/push-dispatch.ts` + `app/api/push/send` now send `Authorization: vapid t=<jwt>, k=<key>`.
- `watchlist-alerts` cron now dispatches push alongside email (respecting `browser_push` + dedupe); `requireCronAuth` intact. `portfolio-alerts` documents the gap (no `user_id` on `user_portfolios` — deferred until the schema adds it).

**Fixes on verification (vitest passed but `tsc --noEmit` failed — strict types it skips):** the production `pkcs8` builder's `.buffer` (`ArrayBufferLike`→`ArrayBuffer`), two `BufferSource` casts in the signature-verify test, and a 0-arity mock that's called with 2 args; plus the documented `req.json` disable on the admin-gated send route.

**Verified:** `tsc` clean · **58 tests** — crucially the JWT tests **verify the signature against the public key** (and reject a wrong key) via Web Crypto, proving the crypto is correct — pass · eslint clean · rate-limit `--strict` pass.

**Tier C** (crons + push). **Flag:** `VAPID_PUBLIC_KEY`/`VAPID_PRIVATE_KEY`/`VAPID_SUBJECT` must be set to activate (skips gracefully if unset).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUfSRE2Teb6VhEXFP6RpS9)_