### PR TITLE
feat: switching-as-a-service guided tool (broker/super/savings) (deepen)

### DIFF
--- a/__tests__/lib/switching.test.ts
+++ b/__tests__/lib/switching.test.ts
@@ -1,0 +1,608 @@
+/**
+ * Unit tests for lib/switching — checklist integrity + saving calc.
+ *
+ * Mirrors the test-file naming convention: __tests__/lib/<x>.test.ts
+ * No mocks needed — all functions are pure.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  BROKER_CHECKLIST,
+  SUPER_CHECKLIST,
+  SAVINGS_CHECKLIST,
+  SWITCH_TYPES,
+  getChecklist,
+} from "@/lib/switching/checklist";
+import {
+  parseFee,
+  calcBrokerSaving,
+  calcSuperSaving,
+  calcSavingsSaving,
+} from "@/lib/switching/savings";
+
+// ─── Checklist integrity ──────────────────────────────────────────────────────
+
+describe("BROKER_CHECKLIST", () => {
+  it("has at least 8 steps (minimum viable checklist)", () => {
+    expect(BROKER_CHECKLIST.steps.length).toBeGreaterThanOrEqual(8);
+  });
+
+  it("type is 'broker'", () => {
+    expect(BROKER_CHECKLIST.type).toBe("broker");
+  });
+
+  it("every step has a non-empty heading and body", () => {
+    for (const step of BROKER_CHECKLIST.steps) {
+      expect(step.heading.length).toBeGreaterThan(0);
+      expect(step.body.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("phases are restricted to prepare/open/transfer/close", () => {
+    const allowedPhases = new Set(["prepare", "open", "transfer", "close"]);
+    for (const step of BROKER_CHECKLIST.steps) {
+      expect(allowedPhases.has(step.phase)).toBe(true);
+    }
+  });
+
+  it("steps appear in logical phase order (prepare before open before transfer before close)", () => {
+    const phaseOrder = ["prepare", "open", "transfer", "close"];
+    const stepPhases = BROKER_CHECKLIST.steps.map((s) => s.phase);
+    let lastIdx = -1;
+    for (const phase of stepPhases) {
+      const idx = phaseOrder.indexOf(phase);
+      // Allow same phase to repeat but never go backwards
+      expect(idx).toBeGreaterThanOrEqual(lastIdx);
+      lastIdx = idx;
+    }
+  });
+
+  it("does not contain personal-advice phrases", () => {
+    const forbidden = [
+      "you should",
+      "we recommend",
+      "i recommend",
+      "best for you",
+      "advise you to",
+      "you must invest",
+    ];
+    for (const step of BROKER_CHECKLIST.steps) {
+      const text = (step.heading + " " + step.body).toLowerCase();
+      for (const phrase of forbidden) {
+        expect(text).not.toContain(phrase);
+      }
+    }
+  });
+
+  it("includes a CHESS-related step", () => {
+    const hasCHESS = BROKER_CHECKLIST.steps.some(
+      (s) =>
+        s.body.toLowerCase().includes("chess") ||
+        s.heading.toLowerCase().includes("chess"),
+    );
+    expect(hasCHESS).toBe(true);
+  });
+
+  it("includes a cost-base / CGT record-keeping step", () => {
+    const hasCostBase = BROKER_CHECKLIST.steps.some(
+      (s) =>
+        s.body.toLowerCase().includes("cost base") ||
+        s.body.toLowerCase().includes("cgt"),
+    );
+    expect(hasCostBase).toBe(true);
+  });
+
+  it("includes a step covering the HIN (Holder Identification Number)", () => {
+    const hasHIN = BROKER_CHECKLIST.steps.some(
+      (s) =>
+        s.body.toLowerCase().includes("hin") ||
+        s.heading.toLowerCase().includes("hin"),
+    );
+    expect(hasHIN).toBe(true);
+  });
+});
+
+describe("SUPER_CHECKLIST", () => {
+  it("has at least 8 steps", () => {
+    expect(SUPER_CHECKLIST.steps.length).toBeGreaterThanOrEqual(8);
+  });
+
+  it("type is 'super'", () => {
+    expect(SUPER_CHECKLIST.type).toBe("super");
+  });
+
+  it("every step has a non-empty heading and body", () => {
+    for (const step of SUPER_CHECKLIST.steps) {
+      expect(step.heading.length).toBeGreaterThan(0);
+      expect(step.body.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("phases are restricted to check/rollover/close", () => {
+    const allowedPhases = new Set(["check", "rollover", "close"]);
+    for (const step of SUPER_CHECKLIST.steps) {
+      expect(allowedPhases.has(step.phase)).toBe(true);
+    }
+  });
+
+  it("the FIRST step has a warning about insurance loss (ASIC RG 183 requirement)", () => {
+    const firstStep = SUPER_CHECKLIST.steps[0];
+    expect(firstStep).toBeDefined();
+    expect(firstStep?.warning).toBeDefined();
+    expect(firstStep?.warning?.toLowerCase()).toContain("insurance");
+  });
+
+  it("includes a step about checking insurance before switching", () => {
+    const hasInsuranceStep = SUPER_CHECKLIST.steps.some(
+      (s) =>
+        s.body.toLowerCase().includes("insurance") &&
+        s.phase === "check",
+    );
+    expect(hasInsuranceStep).toBe(true);
+  });
+
+  it("includes a step mentioning myGov rollover", () => {
+    const hasMyGov = SUPER_CHECKLIST.steps.some(
+      (s) => s.body.toLowerCase().includes("mygov"),
+    );
+    expect(hasMyGov).toBe(true);
+  });
+
+  it("includes a beneficiary nomination step", () => {
+    const hasBeneficiary = SUPER_CHECKLIST.steps.some(
+      (s) =>
+        s.body.toLowerCase().includes("beneficiary") ||
+        s.heading.toLowerCase().includes("beneficiary"),
+    );
+    expect(hasBeneficiary).toBe(true);
+  });
+
+  it("includes a lost super search step", () => {
+    const hasLostSuper = SUPER_CHECKLIST.steps.some(
+      (s) =>
+        s.body.toLowerCase().includes("lost") ||
+        s.heading.toLowerCase().includes("lost"),
+    );
+    expect(hasLostSuper).toBe(true);
+  });
+
+  it("does not contain personal-advice phrases", () => {
+    const forbidden = [
+      "you should",
+      "we recommend",
+      "best for you",
+      "advise you to",
+    ];
+    for (const step of SUPER_CHECKLIST.steps) {
+      const text = (step.heading + " " + step.body).toLowerCase();
+      for (const phrase of forbidden) {
+        expect(text).not.toContain(phrase);
+      }
+    }
+  });
+});
+
+describe("SAVINGS_CHECKLIST", () => {
+  it("has at least 8 steps", () => {
+    expect(SAVINGS_CHECKLIST.steps.length).toBeGreaterThanOrEqual(8);
+  });
+
+  it("type is 'savings'", () => {
+    expect(SAVINGS_CHECKLIST.type).toBe("savings");
+  });
+
+  it("every step has a non-empty heading and body", () => {
+    for (const step of SAVINGS_CHECKLIST.steps) {
+      expect(step.heading.length).toBeGreaterThan(0);
+      expect(step.body.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("phases are restricted to prepare/open/migrate/close", () => {
+    const allowedPhases = new Set(["prepare", "open", "migrate", "close"]);
+    for (const step of SAVINGS_CHECKLIST.steps) {
+      expect(allowedPhases.has(step.phase)).toBe(true);
+    }
+  });
+
+  it("includes a step about direct debit migration", () => {
+    const hasDD = SAVINGS_CHECKLIST.steps.some(
+      (s) =>
+        s.body.toLowerCase().includes("direct debit") ||
+        s.heading.toLowerCase().includes("direct debit"),
+    );
+    expect(hasDD).toBe(true);
+  });
+
+  it("includes a step about intro rate expiry", () => {
+    const hasIntro = SAVINGS_CHECKLIST.steps.some(
+      (s) =>
+        s.body.toLowerCase().includes("introductory") ||
+        s.body.toLowerCase().includes("intro"),
+    );
+    expect(hasIntro).toBe(true);
+  });
+
+  it("includes a step about payroll update", () => {
+    const hasPayroll = SAVINGS_CHECKLIST.steps.some(
+      (s) =>
+        s.body.toLowerCase().includes("payroll") ||
+        s.heading.toLowerCase().includes("payroll"),
+    );
+    expect(hasPayroll).toBe(true);
+  });
+
+  it("does not contain personal-advice phrases", () => {
+    const forbidden = ["you should", "we recommend", "best for you"];
+    for (const step of SAVINGS_CHECKLIST.steps) {
+      const text = (step.heading + " " + step.body).toLowerCase();
+      for (const phrase of forbidden) {
+        expect(text).not.toContain(phrase);
+      }
+    }
+  });
+});
+
+// ─── getChecklist helper ──────────────────────────────────────────────────────
+
+describe("getChecklist", () => {
+  it("returns broker checklist for 'broker'", () => {
+    const result = getChecklist("broker");
+    expect(result?.type).toBe("broker");
+  });
+
+  it("returns super checklist for 'super'", () => {
+    const result = getChecklist("super");
+    expect(result?.type).toBe("super");
+  });
+
+  it("returns savings checklist for 'savings'", () => {
+    const result = getChecklist("savings");
+    expect(result?.type).toBe("savings");
+  });
+
+  it("returns null for unknown type", () => {
+    expect(getChecklist("unknown")).toBeNull();
+    expect(getChecklist("")).toBeNull();
+    expect(getChecklist("forex")).toBeNull();
+  });
+});
+
+// ─── SWITCH_TYPES metadata ────────────────────────────────────────────────────
+
+describe("SWITCH_TYPES", () => {
+  it("has exactly 3 entries (broker, super, savings)", () => {
+    expect(SWITCH_TYPES).toHaveLength(3);
+  });
+
+  it("each entry has type, label, icon, tagline, slug", () => {
+    for (const entry of SWITCH_TYPES) {
+      expect(entry.type).toBeTruthy();
+      expect(entry.label).toBeTruthy();
+      expect(entry.icon).toBeTruthy();
+      expect(entry.tagline).toBeTruthy();
+      expect(entry.slug).toBeTruthy();
+    }
+  });
+
+  it("slugs match type values", () => {
+    for (const entry of SWITCH_TYPES) {
+      expect(entry.slug).toBe(entry.type);
+    }
+  });
+});
+
+// ─── parseFee ─────────────────────────────────────────────────────────────────
+
+describe("parseFee", () => {
+  it("parses flat dollar fee", () => {
+    expect(parseFee("$19.95")).toEqual({ flat: 19.95, pct: 0 });
+    expect(parseFee("$0")).toEqual({ flat: 0, pct: 0 });
+    expect(parseFee("$11")).toEqual({ flat: 11, pct: 0 });
+  });
+
+  it("parses percentage fee", () => {
+    const result = parseFee("0.5%");
+    expect(result.flat).toBe(0);
+    expect(result.pct).toBeCloseTo(0.005);
+  });
+
+  it("handles free / $0", () => {
+    expect(parseFee("free")).toEqual({ flat: 0, pct: 0 });
+    expect(parseFee("Free")).toEqual({ flat: 0, pct: 0 });
+    expect(parseFee("$0")).toEqual({ flat: 0, pct: 0 });
+  });
+
+  it("handles null and undefined", () => {
+    expect(parseFee(null)).toEqual({ flat: 0, pct: 0 });
+    expect(parseFee(undefined)).toEqual({ flat: 0, pct: 0 });
+    expect(parseFee("")).toEqual({ flat: 0, pct: 0 });
+  });
+
+  it("handles fee with comma-separated thousand separators", () => {
+    const result = parseFee("$1,000");
+    expect(result.flat).toBe(1000);
+  });
+});
+
+// ─── calcBrokerSaving ─────────────────────────────────────────────────────────
+
+describe("calcBrokerSaving", () => {
+  const baseInputs = {
+    tradesPerYear: 24,
+    avgTradeSize: 2000,
+    usAllocationPct: 0,
+  };
+
+  it("calculates saving from $19.95 to $0 brokerage (24 ASX trades)", () => {
+    const result = calcBrokerSaving({
+      ...baseInputs,
+      currentAsxFee: "$19.95",
+      targetAsxFee: "$0",
+    });
+    // 24 trades × $19.95 = $478.80
+    expect(result.currentAnnualCost).toBeCloseTo(478.8, 1);
+    expect(result.targetAnnualCost).toBe(0);
+    expect(result.annualDifference).toBeCloseTo(478.8, 1);
+  });
+
+  it("positive annualDifference means saving (current costs more than target)", () => {
+    const result = calcBrokerSaving({
+      ...baseInputs,
+      currentAsxFee: "$29.95",
+      targetAsxFee: "$9.50",
+    });
+    expect(result.annualDifference).toBeGreaterThan(0);
+  });
+
+  it("negative annualDifference means target costs more (no saving)", () => {
+    const result = calcBrokerSaving({
+      ...baseInputs,
+      currentAsxFee: "$5",
+      targetAsxFee: "$19.95",
+    });
+    expect(result.annualDifference).toBeLessThan(0);
+  });
+
+  it("projected savings at 1y = annualDifference, at 5y ≈ 5×", () => {
+    const result = calcBrokerSaving({
+      ...baseInputs,
+      currentAsxFee: "$19.95",
+      targetAsxFee: "$0",
+    });
+    const yr1 = result.projectedSavings.find((p) => p.years === 1);
+    const yr5 = result.projectedSavings.find((p) => p.years === 5);
+    expect(yr1).toBeDefined();
+    expect(yr5).toBeDefined();
+    // Projections are individually rounded integers so yr5 ≈ yr1 × 5
+    // Allow ±2 for rounding drift (Math.round(x) * 5 vs Math.round(x * 5))
+    expect(Math.abs(yr5!.saving - yr1!.saving * 5)).toBeLessThanOrEqual(2);
+  });
+
+  it("includes FX cost for US trades", () => {
+    const resultWithUS = calcBrokerSaving({
+      ...baseInputs,
+      currentAsxFee: "$0",
+      targetAsxFee: "$0",
+      currentFxRate: 1.0, // 1% FX
+      targetFxRate: 0.7,  // 0.7% FX
+      usAllocationPct: 50,
+    });
+    // Should show a positive saving due to lower FX on target
+    expect(resultWithUS.annualDifference).toBeGreaterThan(0);
+  });
+
+  it("includes inactivity fee in total cost", () => {
+    const withInactivity = calcBrokerSaving({
+      ...baseInputs,
+      currentAsxFee: "$0",
+      targetAsxFee: "$0",
+      currentInactivityFee: "$50",
+      targetInactivityFee: "$0",
+    });
+    expect(withInactivity.currentAnnualCost).toBe(50);
+    expect(withInactivity.targetAnnualCost).toBe(0);
+    expect(withInactivity.annualDifference).toBe(50);
+  });
+
+  it("zero trades produces zero cost", () => {
+    const result = calcBrokerSaving({
+      ...baseInputs,
+      tradesPerYear: 0,
+      currentAsxFee: "$19.95",
+      targetAsxFee: "$0",
+    });
+    expect(result.currentAnnualCost).toBe(0);
+    expect(result.targetAnnualCost).toBe(0);
+    expect(result.annualDifference).toBe(0);
+  });
+
+  it("percentage fee: higher trade size increases cost proportionally", () => {
+    const smallTrade = calcBrokerSaving({
+      tradesPerYear: 10,
+      avgTradeSize: 1000,
+      usAllocationPct: 0,
+      currentAsxFee: "0.1%",
+      targetAsxFee: "$0",
+    });
+    const largeTrade = calcBrokerSaving({
+      tradesPerYear: 10,
+      avgTradeSize: 10000,
+      usAllocationPct: 0,
+      currentAsxFee: "0.1%",
+      targetAsxFee: "$0",
+    });
+    expect(largeTrade.currentAnnualCost).toBeCloseTo(
+      smallTrade.currentAnnualCost * 10,
+      1,
+    );
+  });
+});
+
+// ─── calcSuperSaving ──────────────────────────────────────────────────────────
+
+describe("calcSuperSaving", () => {
+  it("calculates correct annual saving on $100k balance", () => {
+    const result = calcSuperSaving({
+      balance: 100_000,
+      currentFeeRatePct: 1.5,
+      targetFeeRatePct: 0.5,
+    });
+    // 1.5% × 100k = $1,500; 0.5% × 100k = $500; difference = $1,000
+    expect(result.currentAnnualFee).toBe(1500);
+    expect(result.targetAnnualFee).toBe(500);
+    expect(result.annualDifference).toBe(1000);
+  });
+
+  it("includes fixed admin fee in total", () => {
+    const result = calcSuperSaving({
+      balance: 100_000,
+      currentFeeRatePct: 0.5,
+      targetFeeRatePct: 0.5,
+      currentFixedFeeAud: 200,
+      targetFixedFeeAud: 52,
+    });
+    // Same % fee, but different fixed fees: $200 vs $52
+    expect(result.annualDifference).toBeCloseTo(148, 1);
+  });
+
+  it("positive annualDifference means saving by switching", () => {
+    const result = calcSuperSaving({
+      balance: 50_000,
+      currentFeeRatePct: 1.0,
+      targetFeeRatePct: 0.3,
+    });
+    expect(result.annualDifference).toBeGreaterThan(0);
+  });
+
+  it("negative annualDifference means target is more expensive", () => {
+    const result = calcSuperSaving({
+      balance: 50_000,
+      currentFeeRatePct: 0.3,
+      targetFeeRatePct: 1.5,
+    });
+    expect(result.annualDifference).toBeLessThan(0);
+  });
+
+  it("5-year projection is 5× the annual difference", () => {
+    const result = calcSuperSaving({
+      balance: 100_000,
+      currentFeeRatePct: 1.0,
+      targetFeeRatePct: 0.5,
+    });
+    const yr1 = result.projectedSavings.find((p) => p.years === 1)!;
+    const yr5 = result.projectedSavings.find((p) => p.years === 5)!;
+    expect(yr5.saving).toBe(yr1.saving * 5);
+  });
+
+  it("zero balance produces zero fees", () => {
+    const result = calcSuperSaving({
+      balance: 0,
+      currentFeeRatePct: 1.5,
+      targetFeeRatePct: 0.5,
+    });
+    expect(result.currentAnnualFee).toBe(0);
+    expect(result.targetAnnualFee).toBe(0);
+    expect(result.annualDifference).toBe(0);
+  });
+
+  it("equal fee rates produce zero difference", () => {
+    const result = calcSuperSaving({
+      balance: 200_000,
+      currentFeeRatePct: 0.8,
+      targetFeeRatePct: 0.8,
+    });
+    expect(result.annualDifference).toBe(0);
+  });
+});
+
+// ─── calcSavingsSaving ────────────────────────────────────────────────────────
+
+describe("calcSavingsSaving", () => {
+  it("calculates annual interest gain from 0.5% to 5%", () => {
+    const result = calcSavingsSaving({
+      balance: 50_000,
+      currentRatePct: 0.5,
+      targetRatePct: 5.0,
+    });
+    // 0.5% × $50k = $250; 5% × $50k = $2,500; difference = $2,250
+    expect(result.currentAnnualInterest).toBe(250);
+    expect(result.targetAnnualInterest).toBe(2500);
+    expect(result.annualDifference).toBe(2250);
+  });
+
+  it("monthly fee is annualised (×12)", () => {
+    const result = calcSavingsSaving({
+      balance: 10_000,
+      currentRatePct: 3.0,
+      targetRatePct: 3.0,
+      currentMonthlyFeeAud: 0,
+      targetMonthlyFeeAud: 5,
+    });
+    expect(result.targetAnnualFees).toBe(60);
+    // Same rate but target has fees: net gain is negative
+    expect(result.annualDifference).toBe(-60);
+  });
+
+  it("positive difference means net gain from switching", () => {
+    const result = calcSavingsSaving({
+      balance: 20_000,
+      currentRatePct: 0.1,
+      targetRatePct: 4.5,
+    });
+    expect(result.annualDifference).toBeGreaterThan(0);
+  });
+
+  it("fee offset can reduce the gain from a higher rate", () => {
+    // Higher rate but much higher monthly fee
+    const result = calcSavingsSaving({
+      balance: 1_000,
+      currentRatePct: 0.0,
+      targetRatePct: 5.0,
+      currentMonthlyFeeAud: 0,
+      targetMonthlyFeeAud: 10, // $120/yr fees vs $50 interest gain
+    });
+    expect(result.annualDifference).toBeLessThan(0);
+  });
+
+  it("5-year projection correctly multiplied", () => {
+    const result = calcSavingsSaving({
+      balance: 10_000,
+      currentRatePct: 0.5,
+      targetRatePct: 4.5,
+    });
+    const yr1 = result.projectedSavings.find((p) => p.years === 1)!;
+    const yr5 = result.projectedSavings.find((p) => p.years === 5)!;
+    expect(yr5.saving).toBe(yr1.saving * 5);
+  });
+
+  it("zero balance produces zero difference", () => {
+    const result = calcSavingsSaving({
+      balance: 0,
+      currentRatePct: 0.5,
+      targetRatePct: 5.0,
+    });
+    expect(result.annualDifference).toBe(0);
+  });
+
+  it("equal rates with equal fees produce zero difference", () => {
+    const result = calcSavingsSaving({
+      balance: 50_000,
+      currentRatePct: 4.0,
+      targetRatePct: 4.0,
+      currentMonthlyFeeAud: 0,
+      targetMonthlyFeeAud: 0,
+    });
+    expect(result.annualDifference).toBe(0);
+  });
+
+  it("projects savings for years [1,2,3,5]", () => {
+    const result = calcSavingsSaving({
+      balance: 10_000,
+      currentRatePct: 1.0,
+      targetRatePct: 4.0,
+    });
+    const years = result.projectedSavings.map((p) => p.years);
+    expect(years).toEqual([1, 2, 3, 5]);
+  });
+});

--- a/app/switch/[type]/SwitchTypeClient.tsx
+++ b/app/switch/[type]/SwitchTypeClient.tsx
@@ -1,0 +1,580 @@
+"use client";
+
+/**
+ * Interactive switching tool: checklist progress tracker + cost-of-staying estimate.
+ *
+ * AFSL-safe:
+ *  - No personal recommendation ("switch to X because it's best for you").
+ *  - Only factual process steps and a user-supplied-input cost estimate.
+ *  - GENERAL_ADVICE_WARNING is surfaced on the parent page.
+ */
+
+import { useState, useMemo } from "react";
+import type { SwitchChecklist } from "@/lib/switching";
+import {
+  calcBrokerSaving,
+  calcSuperSaving,
+  calcSavingsSaving,
+} from "@/lib/switching";
+
+interface Props {
+  checklist: SwitchChecklist;
+  switchType: string;
+}
+
+// ─── Phase labels ─────────────────────────────────────────────────────────────
+
+const PHASE_LABELS: Record<string, string> = {
+  // broker
+  prepare: "Prepare",
+  open: "Open new account",
+  transfer: "Transfer holdings",
+  close: "Close old account",
+  // super
+  check: "Pre-switch check",
+  rollover: "Initiate rollover",
+  // savings
+  migrate: "Migrate payments",
+};
+
+// ─── Cost estimate form per type ──────────────────────────────────────────────
+
+function BrokerEstimateForm() {
+  const [currentFee, setCurrentFee] = useState("$19.95");
+  const [targetFee, setTargetFee] = useState("$0");
+  const [trades, setTrades] = useState(24);
+  const [avgSize, setAvgSize] = useState(2000);
+  const [usPct, setUsPct] = useState(0);
+  const [showResult, setShowResult] = useState(false);
+
+  const result = useMemo(
+    () =>
+      showResult
+        ? calcBrokerSaving({
+            currentAsxFee: currentFee,
+            targetAsxFee: targetFee,
+            tradesPerYear: trades,
+            avgTradeSize: avgSize,
+            usAllocationPct: usPct,
+          })
+        : null,
+    [showResult, currentFee, targetFee, trades, avgSize, usPct],
+  );
+
+  return (
+    <div className="bg-white border border-slate-200 rounded-xl p-5 mb-6">
+      <h2 className="text-sm font-bold text-slate-900 mb-4">
+        Cost of staying vs switching estimate
+      </h2>
+      <div className="grid grid-cols-2 gap-3 mb-3">
+        <div>
+          <label className="block text-xs font-semibold text-slate-600 mb-1">
+            Current ASX fee
+          </label>
+          <input
+            className="w-full px-3 py-2 text-sm border border-slate-200 rounded-lg"
+            value={currentFee}
+            onChange={(e) => { setCurrentFee(e.target.value); setShowResult(false); }}
+            placeholder="e.g. $19.95 or 0.5%"
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-semibold text-slate-600 mb-1">
+            Target ASX fee
+          </label>
+          <input
+            className="w-full px-3 py-2 text-sm border border-slate-200 rounded-lg"
+            value={targetFee}
+            onChange={(e) => { setTargetFee(e.target.value); setShowResult(false); }}
+            placeholder="e.g. $0 or $5"
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-semibold text-slate-600 mb-1">
+            Trades per year
+          </label>
+          <input
+            type="number"
+            className="w-full px-3 py-2 text-sm border border-slate-200 rounded-lg"
+            value={trades}
+            onChange={(e) => { setTrades(parseInt(e.target.value) || 0); setShowResult(false); }}
+            min={0}
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-semibold text-slate-600 mb-1">
+            Avg trade size ($)
+          </label>
+          <input
+            type="number"
+            className="w-full px-3 py-2 text-sm border border-slate-200 rounded-lg"
+            value={avgSize}
+            onChange={(e) => { setAvgSize(parseInt(e.target.value) || 0); setShowResult(false); }}
+            min={0}
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-semibold text-slate-600 mb-1">
+            US shares (%)
+          </label>
+          <input
+            type="number"
+            className="w-full px-3 py-2 text-sm border border-slate-200 rounded-lg"
+            value={usPct}
+            onChange={(e) => { setUsPct(Math.min(100, parseInt(e.target.value) || 0)); setShowResult(false); }}
+            min={0}
+            max={100}
+          />
+        </div>
+      </div>
+      <button
+        onClick={() => setShowResult(true)}
+        className="w-full py-2.5 bg-violet-600 text-white text-sm font-bold rounded-xl hover:bg-violet-700 transition-colors"
+      >
+        Calculate savings →
+      </button>
+      {result && <SavingResult annualDiff={result.annualDifference} current={result.currentAnnualCost} target={result.targetAnnualCost} projections={result.projectedSavings} label="brokerage" />}
+      <p className="text-xs text-slate-400 mt-2">
+        Estimate only — based on your inputs. Not a personal recommendation.
+      </p>
+    </div>
+  );
+}
+
+function SuperEstimateForm() {
+  const [balance, setBalance] = useState(80000);
+  const [currentRate, setCurrentRate] = useState(1.2);
+  const [targetRate, setTargetRate] = useState(0.5);
+  const [currentFixed, setCurrentFixed] = useState(78);
+  const [targetFixed, setTargetFixed] = useState(52);
+  const [showResult, setShowResult] = useState(false);
+
+  const result = useMemo(
+    () =>
+      showResult
+        ? calcSuperSaving({
+            balance,
+            currentFeeRatePct: currentRate,
+            targetFeeRatePct: targetRate,
+            currentFixedFeeAud: currentFixed,
+            targetFixedFeeAud: targetFixed,
+          })
+        : null,
+    [showResult, balance, currentRate, targetRate, currentFixed, targetFixed],
+  );
+
+  return (
+    <div className="bg-white border border-slate-200 rounded-xl p-5 mb-6">
+      <h2 className="text-sm font-bold text-slate-900 mb-4">
+        Annual fee saving estimate
+      </h2>
+      <p className="text-xs text-slate-500 mb-3">
+        Enter your super balance and both funds' total annual fee percentages (admin + investment fees, found in each fund's PDS or the ATO YourSuper tool).
+      </p>
+      <div className="grid grid-cols-2 gap-3 mb-3">
+        <div className="col-span-2">
+          <label className="block text-xs font-semibold text-slate-600 mb-1">
+            Super balance ($)
+          </label>
+          <input
+            type="number"
+            className="w-full px-3 py-2 text-sm border border-slate-200 rounded-lg"
+            value={balance}
+            onChange={(e) => { setBalance(parseInt(e.target.value) || 0); setShowResult(false); }}
+            min={0}
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-semibold text-slate-600 mb-1">
+            Current fund fee (% p.a.)
+          </label>
+          <input
+            type="number"
+            step="0.01"
+            className="w-full px-3 py-2 text-sm border border-slate-200 rounded-lg"
+            value={currentRate}
+            onChange={(e) => { setCurrentRate(parseFloat(e.target.value) || 0); setShowResult(false); }}
+            min={0}
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-semibold text-slate-600 mb-1">
+            Target fund fee (% p.a.)
+          </label>
+          <input
+            type="number"
+            step="0.01"
+            className="w-full px-3 py-2 text-sm border border-slate-200 rounded-lg"
+            value={targetRate}
+            onChange={(e) => { setTargetRate(parseFloat(e.target.value) || 0); setShowResult(false); }}
+            min={0}
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-semibold text-slate-600 mb-1">
+            Current fixed fee ($/yr)
+          </label>
+          <input
+            type="number"
+            className="w-full px-3 py-2 text-sm border border-slate-200 rounded-lg"
+            value={currentFixed}
+            onChange={(e) => { setCurrentFixed(parseInt(e.target.value) || 0); setShowResult(false); }}
+            min={0}
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-semibold text-slate-600 mb-1">
+            Target fixed fee ($/yr)
+          </label>
+          <input
+            type="number"
+            className="w-full px-3 py-2 text-sm border border-slate-200 rounded-lg"
+            value={targetFixed}
+            onChange={(e) => { setTargetFixed(parseInt(e.target.value) || 0); setShowResult(false); }}
+            min={0}
+          />
+        </div>
+      </div>
+      <button
+        onClick={() => setShowResult(true)}
+        className="w-full py-2.5 bg-violet-600 text-white text-sm font-bold rounded-xl hover:bg-violet-700 transition-colors"
+      >
+        Calculate fee saving →
+      </button>
+      {result && <SavingResult annualDiff={result.annualDifference} current={result.currentAnnualFee} target={result.targetAnnualFee} projections={result.projectedSavings} label="fees" />}
+      <p className="text-xs text-slate-400 mt-2">
+        Estimate only — flat fee comparison based on your inputs. Does not model investment returns. Not a personal recommendation.
+      </p>
+    </div>
+  );
+}
+
+function SavingsEstimateForm() {
+  const [balance, setBalance] = useState(50000);
+  const [currentRate, setCurrentRate] = useState(0.5);
+  const [targetRate, setTargetRate] = useState(5.0);
+  const [currentFee, setCurrentFee] = useState(0);
+  const [targetFee, setTargetFee] = useState(0);
+  const [showResult, setShowResult] = useState(false);
+
+  const result = useMemo(
+    () =>
+      showResult
+        ? calcSavingsSaving({
+            balance,
+            currentRatePct: currentRate,
+            targetRatePct: targetRate,
+            currentMonthlyFeeAud: currentFee,
+            targetMonthlyFeeAud: targetFee,
+          })
+        : null,
+    [showResult, balance, currentRate, targetRate, currentFee, targetFee],
+  );
+
+  return (
+    <div className="bg-white border border-slate-200 rounded-xl p-5 mb-6">
+      <h2 className="text-sm font-bold text-slate-900 mb-4">
+        Annual interest gain estimate
+      </h2>
+      <p className="text-xs text-slate-500 mb-3">
+        Enter your savings balance and both accounts' ongoing interest rates (not the introductory rate).
+      </p>
+      <div className="grid grid-cols-2 gap-3 mb-3">
+        <div className="col-span-2">
+          <label className="block text-xs font-semibold text-slate-600 mb-1">
+            Savings balance ($)
+          </label>
+          <input
+            type="number"
+            className="w-full px-3 py-2 text-sm border border-slate-200 rounded-lg"
+            value={balance}
+            onChange={(e) => { setBalance(parseInt(e.target.value) || 0); setShowResult(false); }}
+            min={0}
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-semibold text-slate-600 mb-1">
+            Current rate (% p.a., ongoing)
+          </label>
+          <input
+            type="number"
+            step="0.01"
+            className="w-full px-3 py-2 text-sm border border-slate-200 rounded-lg"
+            value={currentRate}
+            onChange={(e) => { setCurrentRate(parseFloat(e.target.value) || 0); setShowResult(false); }}
+            min={0}
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-semibold text-slate-600 mb-1">
+            Target rate (% p.a., ongoing)
+          </label>
+          <input
+            type="number"
+            step="0.01"
+            className="w-full px-3 py-2 text-sm border border-slate-200 rounded-lg"
+            value={targetRate}
+            onChange={(e) => { setTargetRate(parseFloat(e.target.value) || 0); setShowResult(false); }}
+            min={0}
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-semibold text-slate-600 mb-1">
+            Current monthly fee ($)
+          </label>
+          <input
+            type="number"
+            className="w-full px-3 py-2 text-sm border border-slate-200 rounded-lg"
+            value={currentFee}
+            onChange={(e) => { setCurrentFee(parseInt(e.target.value) || 0); setShowResult(false); }}
+            min={0}
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-semibold text-slate-600 mb-1">
+            Target monthly fee ($)
+          </label>
+          <input
+            type="number"
+            className="w-full px-3 py-2 text-sm border border-slate-200 rounded-lg"
+            value={targetFee}
+            onChange={(e) => { setTargetFee(parseInt(e.target.value) || 0); setShowResult(false); }}
+            min={0}
+          />
+        </div>
+      </div>
+      <button
+        onClick={() => setShowResult(true)}
+        className="w-full py-2.5 bg-violet-600 text-white text-sm font-bold rounded-xl hover:bg-violet-700 transition-colors"
+      >
+        Calculate interest gain →
+      </button>
+      {result && (
+        <SavingResult
+          annualDiff={result.annualDifference}
+          current={result.currentAnnualInterest - result.currentAnnualFees}
+          target={result.targetAnnualInterest - result.targetAnnualFees}
+          projections={result.projectedSavings}
+          label="net interest"
+          gainLabel="gain"
+        />
+      )}
+      <p className="text-xs text-slate-400 mt-2">
+        Estimate only — uses simple (non-compounding) interest. Not a personal recommendation.
+      </p>
+    </div>
+  );
+}
+
+// ─── Shared result display ────────────────────────────────────────────────────
+
+interface SavingResultProps {
+  annualDiff: number;
+  current: number;
+  target: number;
+  projections: { years: number; saving: number }[];
+  label: string;
+  gainLabel?: string;
+}
+
+function SavingResult({ annualDiff, current, target, projections, label, gainLabel = "saving" }: SavingResultProps) {
+  const isPositive = annualDiff > 0;
+  return (
+    <div
+      className={`mt-4 rounded-xl p-4 border ${
+        isPositive
+          ? "bg-emerald-50 border-emerald-200"
+          : "bg-slate-50 border-slate-200"
+      }`}
+    >
+      <div className="flex items-baseline gap-2 mb-2">
+        <span
+          className={`text-2xl font-extrabold ${
+            isPositive ? "text-emerald-700" : "text-slate-700"
+          }`}
+        >
+          {isPositive ? "+" : ""}${Math.abs(annualDiff).toLocaleString("en-AU", { maximumFractionDigits: 0 })}
+        </span>
+        <span className="text-sm text-slate-500">
+          estimated annual {isPositive ? gainLabel : "extra cost"} in {label}
+        </span>
+      </div>
+      <div className="flex gap-4 text-xs text-slate-500 mb-3">
+        <span>Current: <strong>${current.toLocaleString("en-AU", { maximumFractionDigits: 0 })}/yr</strong></span>
+        <span>Target: <strong>${target.toLocaleString("en-AU", { maximumFractionDigits: 0 })}/yr</strong></span>
+      </div>
+      {isPositive && (
+        <div className="grid grid-cols-4 gap-2 text-center border-t border-emerald-200 pt-3">
+          {projections.map((p) => (
+            <div key={p.years}>
+              <p className="text-[0.6rem] text-slate-500">{p.years}yr</p>
+              <p className="text-sm font-extrabold text-emerald-700">
+                ${p.saving.toLocaleString("en-AU")}
+              </p>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Checklist with progress tracking ────────────────────────────────────────
+
+function ChecklistSection({ checklist }: { checklist: SwitchChecklist }) {
+  const [checked, setChecked] = useState<Set<number>>(new Set());
+
+  const toggle = (i: number) => {
+    setChecked((prev) => {
+      const next = new Set(prev);
+      if (next.has(i)) next.delete(i);
+      else next.add(i);
+      return next;
+    });
+  };
+
+  const progress =
+    checklist.steps.length > 0
+      ? Math.round((checked.size / checklist.steps.length) * 100)
+      : 0;
+
+  // Group steps by phase
+  const phases: { phase: string; steps: { step: (typeof checklist.steps)[number]; idx: number }[] }[] = [];
+  for (let i = 0; i < checklist.steps.length; i++) {
+    const step = checklist.steps[i]!;
+    const last = phases[phases.length - 1];
+    if (!last || last.phase !== step.phase) {
+      phases.push({ phase: step.phase, steps: [{ step, idx: i }] });
+    } else {
+      last.steps.push({ step, idx: i });
+    }
+  }
+
+  return (
+    <div>
+      {/* Progress bar */}
+      <div className="flex items-center gap-3 mb-4">
+        <div className="flex-1 h-2 bg-slate-100 rounded-full overflow-hidden">
+          <div
+            className="h-full bg-violet-500 rounded-full transition-all duration-300"
+            style={{ width: `${progress}%` }}
+          />
+        </div>
+        <span className="text-xs font-semibold text-slate-500 shrink-0">
+          {checked.size}/{checklist.steps.length} steps
+        </span>
+      </div>
+
+      {/* Steps grouped by phase */}
+      <div className="space-y-6">
+        {phases.map(({ phase, steps }) => (
+          <div key={phase}>
+            <h3 className="text-xs font-bold uppercase tracking-wider text-slate-400 mb-2">
+              {PHASE_LABELS[phase] ?? phase}
+            </h3>
+            <div className="space-y-2">
+              {steps.map(({ step, idx }) => {
+                const done = checked.has(idx);
+                return (
+                  <div
+                    key={idx}
+                    id={`step-${idx + 1}`}
+                    className={`border rounded-xl p-4 transition-all cursor-pointer select-none ${
+                      done
+                        ? "border-violet-200 bg-violet-50 opacity-70"
+                        : "border-slate-200 bg-white hover:border-violet-200"
+                    }`}
+                    onClick={() => toggle(idx)}
+                  >
+                    <div className="flex gap-3 items-start">
+                      <div
+                        className={`w-6 h-6 rounded-full border-2 flex items-center justify-center shrink-0 mt-0.5 transition-all ${
+                          done
+                            ? "bg-violet-600 border-violet-600"
+                            : "border-slate-300"
+                        }`}
+                      >
+                        {done && (
+                          <svg
+                            className="w-3 h-3 text-white"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke="currentColor"
+                            strokeWidth={3}
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              d="M5 13l4 4L19 7"
+                            />
+                          </svg>
+                        )}
+                      </div>
+                      <div className="flex-1">
+                        <p
+                          className={`text-sm font-semibold ${
+                            done ? "line-through text-slate-400" : "text-slate-900"
+                          }`}
+                        >
+                          {step.heading}
+                        </p>
+                        {!done && (
+                          <p className="text-xs text-slate-500 mt-1 leading-relaxed">
+                            {step.body}
+                          </p>
+                        )}
+                        {step.warning && !done && (
+                          <div className="mt-2 flex gap-2 bg-amber-50 border border-amber-200 rounded-lg p-2">
+                            <span className="text-amber-500 shrink-0">⚠️</span>
+                            <p className="text-xs text-amber-800">{step.warning}</p>
+                          </div>
+                        )}
+                        {step.source && !done && (
+                          <p className="text-[0.65rem] text-slate-400 mt-1">
+                            Source: {step.source}
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {progress === 100 && (
+        <div className="mt-6 bg-emerald-50 border border-emerald-200 rounded-xl p-4 text-center">
+          <p className="text-base font-bold text-emerald-800 mb-1">
+            All steps complete!
+          </p>
+          <p className="text-sm text-emerald-600">
+            Your switching checklist is done. Compare providers to find the right destination.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Main export ──────────────────────────────────────────────────────────────
+
+export default function SwitchTypeClient({ checklist, switchType }: Props) {
+  return (
+    <div>
+      {/* Cost estimate form — type specific */}
+      {switchType === "broker" && <BrokerEstimateForm />}
+      {switchType === "super" && <SuperEstimateForm />}
+      {switchType === "savings" && <SavingsEstimateForm />}
+
+      {/* Step-by-step checklist */}
+      <div className="mt-6">
+        <h2 className="text-base font-bold text-slate-900 mb-4">
+          Step-by-step checklist ({checklist.steps.length} steps)
+        </h2>
+        <ChecklistSection checklist={checklist} />
+      </div>
+    </div>
+  );
+}

--- a/app/switch/[type]/SwitchTypeClient.tsx
+++ b/app/switch/[type]/SwitchTypeClient.tsx
@@ -169,7 +169,7 @@ function SuperEstimateForm() {
         Annual fee saving estimate
       </h2>
       <p className="text-xs text-slate-500 mb-3">
-        Enter your super balance and both funds' total annual fee percentages (admin + investment fees, found in each fund's PDS or the ATO YourSuper tool).
+        Enter your super balance and both funds&apos; total annual fee percentages (admin + investment fees, found in each fund&apos;s PDS or the ATO YourSuper tool).
       </p>
       <div className="grid grid-cols-2 gap-3 mb-3">
         <div className="col-span-2">
@@ -277,7 +277,7 @@ function SavingsEstimateForm() {
         Annual interest gain estimate
       </h2>
       <p className="text-xs text-slate-500 mb-3">
-        Enter your savings balance and both accounts' ongoing interest rates (not the introductory rate).
+        Enter your savings balance and both accounts&apos; ongoing interest rates (not the introductory rate).
       </p>
       <div className="grid grid-cols-2 gap-3 mb-3">
         <div className="col-span-2">

--- a/app/switch/[type]/page.tsx
+++ b/app/switch/[type]/page.tsx
@@ -1,0 +1,319 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import type { Metadata } from "next";
+import { absoluteUrl, breadcrumbJsonLd, CURRENT_YEAR, SITE_NAME } from "@/lib/seo";
+import { faqJsonLd, howToJsonLd } from "@/lib/schema-markup";
+import { getChecklist, SWITCH_TYPES } from "@/lib/switching";
+import ComplianceFooter from "@/components/ComplianceFooter";
+import SwitchTypeClient from "./SwitchTypeClient";
+import {
+  GENERAL_ADVICE_WARNING,
+  SUPER_WARNING,
+} from "@/lib/compliance";
+
+export const revalidate = 3600;
+
+// ─── Static params ────────────────────────────────────────────────────────────
+
+export function generateStaticParams() {
+  return SWITCH_TYPES.map((t) => ({ type: t.slug }));
+}
+
+// ─── Metadata ─────────────────────────────────────────────────────────────────
+
+const META: Record<
+  string,
+  { title: string; description: string }
+> = {
+  broker: {
+    title: `How to Switch Share Brokers in Australia — CHESS Transfer Guide (${CURRENT_YEAR}) | ${SITE_NAME}`,
+    description:
+      "Step-by-step guide to transferring your ASX shares to a new broker via CHESS off-market transfer. Covers HIN transfer, cost-base records, US shares, and fees. Estimate your annual saving.",
+  },
+  super: {
+    title: `How to Switch Super Funds in Australia — Rollover Guide (${CURRENT_YEAR}) | ${SITE_NAME}`,
+    description:
+      "Step-by-step guide to rolling over your superannuation via myGov. Covers insurance check, lost super search, beneficiary nomination, and contribution timing. Estimate your annual fee saving.",
+  },
+  savings: {
+    title: `How to Switch Savings Accounts in Australia — Guide (${CURRENT_YEAR}) | ${SITE_NAME}`,
+    description:
+      "Step-by-step guide to switching savings accounts. Covers migrating direct debits and payroll, intro-rate expiry traps, and closing the old account. Estimate your annual interest gain.",
+  },
+};
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ type: string }>;
+}): Promise<Metadata> {
+  const { type } = await params;
+  const meta = META[type];
+  if (!meta) return {};
+  return {
+    title: meta.title,
+    description: meta.description,
+    alternates: { canonical: `/switch/${type}` },
+    openGraph: {
+      title: meta.title,
+      description: meta.description,
+      images: [
+        {
+          url: `/api/og?title=${encodeURIComponent(`Switch ${type.charAt(0).toUpperCase() + type.slice(1)}`)}&subtitle=Step-by-step+guide&type=default`,
+          width: 1200,
+          height: 630,
+        },
+      ],
+    },
+    twitter: { card: "summary_large_image" },
+  };
+}
+
+// ─── FAQ data per type ────────────────────────────────────────────────────────
+
+const FAQS: Record<string, { q: string; a: string }[]> = {
+  broker: [
+    {
+      q: "What is a CHESS transfer (off-market transfer)?",
+      a: "A CHESS transfer — also called an off-market transfer or broker-to-broker transfer — moves your ASX shares from one broker to another without selling them. Your new broker submits the transfer request to ASX CHESS on your behalf. Your HIN (Holder Identification Number) moves from your old broker's sponsorship to your new broker's sponsorship within 3–5 business days.",
+    },
+    {
+      q: "Do I need to sell my shares to switch brokers?",
+      a: "No, if your shares are CHESS-sponsored (indicated by a HIN starting with 'X'). CHESS-sponsored shares can be transferred in-specie (without selling). Custodial/issuer-sponsored shares may require selling first, depending on the new broker's capabilities.",
+    },
+    {
+      q: "How much does a CHESS transfer cost?",
+      a: "Most brokers charge a per-holding CHESS transfer fee, typically around $50–$55 per line of stock. Some brokers charge this on the outgoing side, some on the incoming side. Check both brokers' fee schedules before initiating the transfer.",
+    },
+    {
+      q: "Does a CHESS transfer reset my cost base for CGT?",
+      a: "No. An in-specie CHESS transfer does not trigger a CGT event. Your original acquisition date and cost base are preserved. However, a sell-down and rebuy does trigger a CGT event and creates a new cost base at the rebuy price.",
+    },
+  ],
+  super: [
+    {
+      q: "Will I lose my insurance when I switch super funds?",
+      a: "You may. Insurance inside super often has no medical underwriting, meaning pre-existing conditions may be covered that wouldn't be accepted by a new insurer. When you switch funds, your old insurance stops and you must apply for new cover in the new fund, which may require underwriting. Check your current cover amounts before initiating any rollover.",
+    },
+    {
+      q: "How long does a super rollover take?",
+      a: "Most rollovers initiated via myGov complete within 3–5 business days. The ATO's SuperStream system facilitates the transfer between funds electronically.",
+    },
+    {
+      q: "Can I roll over only part of my super?",
+      a: "Yes. When using myGov's 'Find and transfer super' tool, you can choose to roll over the full balance (which will close the old account) or a partial amount. A partial rollover is useful if you want to retain insurance cover in your old fund while consolidating most of your balance.",
+    },
+    {
+      q: "What happens to lost super when I switch?",
+      a: "You should search for lost or ATO-held super before switching. Use the 'Find and transfer super' tool in myGov to locate any accounts with previous employers. The ATO estimates billions of dollars are held in lost or inactive accounts.",
+    },
+  ],
+  savings: [
+    {
+      q: "What is an introductory savings rate?",
+      a: "An introductory (honeymoon) rate is a higher interest rate offered for the first 3–5 months after opening an account. After the intro period ends, the rate drops to the ongoing (base) rate, which may be significantly lower. Always compare the ongoing rate, not just the intro rate, when evaluating a savings account.",
+    },
+    {
+      q: "How do I move my direct debits to a new savings account?",
+      a: "Log in to your current account's transaction history and list every recurring direct debit. For each biller, update your BSB and account number online or by contacting the biller directly. Some major banks offer an 'account switching service' that automatically redirects direct debits for up to 13 months.",
+    },
+    {
+      q: "How long should I keep the old account open while switching?",
+      a: "Keep your old account open and funded for at least one full calendar month after updating all direct debits. This catches any quarterly or annual payments you may have missed. Transfer the balance only after you're confident all recurring payments have moved.",
+    },
+  ],
+};
+
+// ─── Intro copy per type ──────────────────────────────────────────────────────
+
+const INTROS: Record<string, string> = {
+  broker:
+    "Switching share brokers in Australia is straightforward if your holdings are CHESS-sponsored. The process involves an in-specie off-market CHESS transfer — your shares move without selling. Follow these steps to transfer your portfolio safely.",
+  super:
+    "Rolling over your superannuation is a permanent action. Before starting, check your existing insurance cover — you may lose it permanently when the old fund is closed. Once you've done that check, the rollover itself is quick via myGov.",
+  savings:
+    "Switching savings accounts takes more planning than opening a new account. The critical step is migrating every direct debit and payroll before closing the old account. Follow these steps to switch without missing a payment.",
+};
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export default async function SwitchTypePage({
+  params,
+}: {
+  params: Promise<{ type: string }>;
+}) {
+  const { type } = await params;
+  const checklist = getChecklist(type);
+  if (!checklist) notFound();
+
+  const typeInfo = SWITCH_TYPES.find((t) => t.type === type)!;
+  const faqs = FAQS[type] ?? [];
+
+  // Build HowTo JSON-LD using existing schema-markup builder
+  const howToLd = howToJsonLd({
+    slug: `switch-${type}`,
+    h1: `How to Switch ${typeInfo.label} in Australia`,
+    intro: INTROS[type] ?? "",
+    steps: checklist.steps.map((s) => ({
+      heading: s.heading,
+      body: s.body,
+    })),
+    datePublished: "2026-05-25",
+    dateModified: "2026-05-25",
+  });
+
+  // Patch the HowTo URL to point to /switch/[type] not /how-to/switch-[type]
+  const patchedHowTo = {
+    ...howToLd,
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": absoluteUrl(`/switch/${type}`),
+    },
+    step: howToLd.step?.map(
+      (
+        s: { "@type": string; position: number; name: string; text: string; url: string },
+        i: number,
+      ) => ({
+        ...s,
+        url: absoluteUrl(`/switch/${type}#step-${i + 1}`),
+      }),
+    ),
+  };
+
+  const faqLd = faqJsonLd(faqs);
+
+  const breadcrumbLd = breadcrumbJsonLd([
+    { name: "Home", url: absoluteUrl("/") },
+    { name: "Switch", url: absoluteUrl("/switch") },
+    { name: typeInfo.label },
+  ]);
+
+  const isSuper = type === "super";
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(patchedHowTo) }}
+      />
+      {faqLd && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }}
+        />
+      )}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
+      />
+
+      <div className="py-5 md:py-12">
+        <div className="container-custom max-w-3xl mx-auto">
+          {/* Breadcrumb */}
+          <nav className="text-sm text-slate-500 mb-6" aria-label="Breadcrumb">
+            <Link href="/" className="hover:text-brand">Home</Link>
+            <span className="mx-2">/</span>
+            <Link href="/switch" className="hover:text-brand">Switch</Link>
+            <span className="mx-2">/</span>
+            <span className="text-brand">{typeInfo.label}</span>
+          </nav>
+
+          {/* Hero */}
+          <div className="bg-gradient-to-br from-violet-600 to-violet-800 rounded-2xl p-6 md:p-10 text-white mb-8 relative overflow-hidden">
+            <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(255,255,255,0.08),transparent_60%)]" />
+            <div className="relative">
+              <h1 className="text-2xl md:text-3xl font-extrabold mb-3">
+                How to Switch {typeInfo.label}
+              </h1>
+              <p className="text-sm md:text-base text-violet-100 max-w-xl">
+                {INTROS[type]}
+              </p>
+            </div>
+          </div>
+
+          {/* Super-specific insurance warning — ASIC RG 183 */}
+          {isSuper && (
+            <div className="bg-amber-50 border border-amber-300 rounded-xl p-4 mb-6 flex gap-3">
+              <span className="text-amber-500 text-xl shrink-0 mt-0.5">⚠️</span>
+              <p className="text-sm text-amber-900 leading-relaxed">
+                <strong>Check your insurance before switching super.</strong>{" "}
+                {SUPER_WARNING}
+              </p>
+            </div>
+          )}
+
+          {/* Interactive cost estimate + checklist */}
+          <SwitchTypeClient checklist={checklist} switchType={type} />
+
+          {/* FAQ section */}
+          {faqs.length > 0 && (
+            <section className="mt-12">
+              <h2 className="text-lg font-bold text-slate-900 mb-4">
+                Frequently asked questions
+              </h2>
+              <div className="space-y-4">
+                {faqs.map((f) => (
+                  <details
+                    key={f.q}
+                    className="bg-white border border-slate-200 rounded-xl p-4 group"
+                  >
+                    <summary className="font-semibold text-sm text-slate-900 cursor-pointer list-none flex justify-between items-center gap-2">
+                      {f.q}
+                      <span className="text-slate-400 shrink-0 group-open:rotate-180 transition-transform">▾</span>
+                    </summary>
+                    <p className="mt-3 text-sm text-slate-600 leading-relaxed">
+                      {f.a}
+                    </p>
+                  </details>
+                ))}
+              </div>
+            </section>
+          )}
+
+          {/* Referral CTA */}
+          <div className="mt-10 bg-slate-50 border border-slate-200 rounded-2xl p-6 text-center">
+            <h2 className="text-base font-bold text-slate-900 mb-1">
+              Compare {typeInfo.label}s side by side
+            </h2>
+            <p className="text-sm text-slate-500 mb-4">
+              See factual fee data for every provider before you switch.
+            </p>
+            <div className="flex flex-col sm:flex-row gap-3 justify-center">
+              <Link
+                href={
+                  type === "broker"
+                    ? "/compare"
+                    : type === "super"
+                      ? "/super"
+                      : "/savings"
+                }
+                className="inline-block px-5 py-2.5 bg-violet-600 text-white text-sm font-bold rounded-xl hover:bg-violet-700 transition-colors"
+              >
+                Compare {typeInfo.label}s →
+              </Link>
+              <Link
+                href="/find-advisor"
+                className="inline-block px-5 py-2.5 bg-white border border-slate-200 text-slate-700 text-sm font-semibold rounded-xl hover:border-violet-300 transition-colors"
+              >
+                Find a financial advisor
+              </Link>
+            </div>
+            <p className="text-xs text-slate-400 mt-3">
+              General information only — not financial advice or a personal recommendation.
+            </p>
+          </div>
+
+          {/* Compliance */}
+          <div className="mt-8">
+            <ComplianceFooter variant={isSuper ? "default" : "default"} />
+          </div>
+
+          {/* General advice warning — always present */}
+          <div className="mt-4 text-xs text-slate-400 leading-relaxed border-t border-slate-100 pt-4">
+            {GENERAL_ADVICE_WARNING}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/switch/page.tsx
+++ b/app/switch/page.tsx
@@ -1,21 +1,25 @@
 import { createClient } from "@/lib/supabase/server";
 import type { Broker, BrokerTransferGuide } from "@/lib/types";
 import SwitchClient from "./SwitchClient";
-import { absoluteUrl, breadcrumbJsonLd } from "@/lib/seo";
+import { absoluteUrl, breadcrumbJsonLd, CURRENT_YEAR, SITE_NAME } from "@/lib/seo";
+import { faqJsonLd } from "@/lib/schema-markup";
+import { SWITCH_TYPES } from "@/lib/switching";
+import Link from "next/link";
+import type { Metadata } from "next";
 
 export const revalidate = 3600;
 
-export const metadata = {
-  title: "Platform Switch Planner — Personalised Migration Checklist",
+export const metadata: Metadata = {
+  title: `Switch Broker, Super, or Savings Account — Step-by-Step Guide (${CURRENT_YEAR}) | ${SITE_NAME}`,
   description:
-    "Generate a personalised switching checklist between Australian platforms. See savings, CHESS transfer steps, CGT implications, and a 'nothing missed' migration plan.",
+    "Factual step-by-step guides for switching your share broker (CHESS transfer), superannuation fund (myGov rollover), or savings account (direct debit migration). Estimate your cost of staying vs switching.",
   openGraph: {
-    title: "Platform Switch Planner",
+    title: "Switch Broker, Super, or Savings — ${SITE_NAME}",
     description:
-      "Personalised platform migration checklist with CHESS transfer steps, CGT guidance, and savings calculator.",
+      "Guided switching checklists and cost-of-staying estimates for Australian investors.",
     images: [
       {
-        url: "/api/og?title=Platform+Switch+Planner&subtitle=Personalised+Migration+Checklist&type=default",
+        url: "/api/og?title=Switching+Guide&subtitle=Broker+%7C+Super+%7C+Savings&type=default",
         width: 1200,
         height: 630,
       },
@@ -23,6 +27,12 @@ export const metadata = {
   },
   twitter: { card: "summary_large_image" as const },
   alternates: { canonical: "/switch" },
+};
+
+const TYPE_DESCRIPTIONS: Record<string, string> = {
+  broker: "Transfer your ASX/US shares, HIN, and cost-base records to a new broker. No sell-down required for CHESS-sponsored holdings.",
+  super: "Roll over your super via myGov. Includes a pre-switch insurance check and beneficiary update guide.",
+  savings: "Open a new account first, migrate direct debits and payroll, then close the old one. Covers intro-rate expiry traps.",
 };
 
 export default async function SwitchPage() {
@@ -42,12 +52,94 @@ export default async function SwitchPage() {
     { name: "Switch Platforms" },
   ]);
 
+  const faqLd = faqJsonLd([
+    {
+      q: "Can I transfer my shares to a new broker without selling them?",
+      a: "Yes, if your shares are CHESS-sponsored (you have a HIN starting with 'X'). You can initiate an off-market CHESS transfer through your new broker. The process takes 3–5 business days and your shares stay in your name throughout. Custodial (non-CHESS) holdings may require a sell-down — check with your current broker.",
+    },
+    {
+      q: "Will I lose my super insurance if I switch funds?",
+      a: "You may lose your existing insurance cover when you switch super funds. Insurance inside super often has no medical underwriting, so pre-existing conditions may not be covered by a new fund. Check your current fund's insurance cover (death, TPD, income protection) before initiating any rollover. ASIC's MoneySmart guidance recommends checking this before switching.",
+    },
+    {
+      q: "What is the safest way to roll over superannuation?",
+      a: "The ATO recommends using the 'Find and transfer super' tool in myGov (linked to the ATO). This transfers your balance directly between funds within 3–5 business days and is free. Alternatively, you can complete ATO form NAT 75359 and submit it to your new fund.",
+    },
+    {
+      q: "How do I switch savings accounts without missing a direct debit?",
+      a: "The safest approach is to open the new account first, transfer most (but not all) of your funds, then migrate each direct debit to the new BSB and account number before closing the old account. Keep enough in the old account to cover pending payments for at least two full billing cycles while you complete the migration.",
+    },
+    {
+      q: "How much could I save by switching brokers?",
+      a: "Savings depend on how many trades you make and which platforms you compare. Use the per-type switching guides to enter your specific numbers and see an estimate based on real fee data.",
+    },
+  ]);
+
   return (
     <>
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
       />
+      {faqLd && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }}
+        />
+      )}
+
+      <div className="py-5 md:py-12">
+        <div className="container-custom max-w-3xl mx-auto">
+          {/* Breadcrumb */}
+          <nav className="text-sm text-slate-500 mb-6" aria-label="Breadcrumb">
+            <Link href="/" className="hover:text-brand">Home</Link>
+            <span className="mx-2">/</span>
+            <span className="text-brand">Switch</span>
+          </nav>
+
+          {/* Hero */}
+          <div className="bg-gradient-to-br from-violet-600 to-violet-800 rounded-2xl p-6 md:p-10 text-white mb-8 relative overflow-hidden">
+            <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(255,255,255,0.1),transparent_60%)]" />
+            <div className="relative">
+              <h1 className="text-2xl md:text-4xl font-extrabold mb-3">
+                Switching Guide
+              </h1>
+              <p className="text-sm md:text-base text-violet-100 max-w-xl">
+                Factual step-by-step guides for switching your broker, super fund, or savings account. Enter your numbers to see the cost of staying vs switching.
+              </p>
+            </div>
+          </div>
+
+          {/* Type cards */}
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-10">
+            {SWITCH_TYPES.map((t) => (
+              <Link
+                key={t.type}
+                href={`/switch/${t.slug}`}
+                className="group block bg-white border border-slate-200 rounded-xl p-5 hover:border-violet-300 hover:shadow-sm transition-all"
+              >
+                <div className="w-10 h-10 bg-violet-50 rounded-lg flex items-center justify-center mb-3 group-hover:bg-violet-100 transition-colors">
+                  <span className="text-violet-600 text-lg">
+                    {t.type === "broker" ? "📊" : t.type === "super" ? "🏛️" : "💰"}
+                  </span>
+                </div>
+                <h2 className="text-base font-bold text-slate-900 mb-1">{t.label}</h2>
+                <p className="text-xs text-slate-500 leading-relaxed">{TYPE_DESCRIPTIONS[t.type]}</p>
+                <span className="mt-3 inline-block text-xs font-semibold text-violet-600 group-hover:underline">
+                  View checklist + estimate →
+                </span>
+              </Link>
+            ))}
+          </div>
+
+          {/* Existing broker-to-broker switch planner (preserved) */}
+          <div className="border-t border-slate-200 pt-8 mb-4">
+            <h2 className="text-lg font-bold text-slate-900 mb-1">Broker-to-Broker Switch Planner</h2>
+            <p className="text-sm text-slate-500 mb-5">Select two brokers to get a personalised checklist and savings estimate.</p>
+          </div>
+        </div>
+      </div>
+
       <SwitchClient
         brokers={(brokersRes.data as Broker[]) || []}
         transferGuides={(guidesRes.data as BrokerTransferGuide[]) || []}

--- a/lib/switching/checklist.ts
+++ b/lib/switching/checklist.ts
@@ -1,0 +1,366 @@
+/**
+ * Switching checklist model — pure, tested, AFSL-safe.
+ *
+ * Factual process guidance only. Every step is drawn from publicly available
+ * regulatory/industry sources (ATO, ASIC, MoneySmart, ASX). No personal
+ * recommendation is made about whether the user should switch.
+ *
+ * References
+ * ----------
+ *   Broker (CHESS):   ASIC RG 227 · ASX CHESS Operating Rules
+ *   Super (rollover): ATO SIS Act s238 · ASIC RG 183 · myGov ATO-linked
+ *   Savings:          ASIC MoneySmart · RBA guidance
+ */
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+/** A single step in a switching checklist. */
+export interface SwitchStep {
+  /** Short heading shown as bullet label. */
+  heading: string;
+  /** Full factual description — no personal-advice language. */
+  body: string;
+  /**
+   * Tag for grouping steps in UI (phases vary per type).
+   * broker: "prepare" | "open" | "transfer" | "close"
+   * super:  "check" | "rollover" | "close"
+   * savings:"prepare" | "open" | "migrate" | "close"
+   */
+  phase: string;
+  /**
+   * Optional warning — compliance-sensitive sub-note sourced from
+   * ASIC / ATO official guidance. Only populated where ASIC/ATO
+   * mandates a specific disclosure (e.g. super insurance loss).
+   */
+  warning?: string;
+  /**
+   * Optional source citation shown to the user so they can verify
+   * the factual claim themselves (URL or regulator name + doc title).
+   */
+  source?: string;
+}
+
+export type SwitchType = "broker" | "super" | "savings";
+
+export interface SwitchChecklist {
+  type: SwitchType;
+  /** Short description of what the checklist covers. */
+  description: string;
+  steps: SwitchStep[];
+}
+
+// ─── Broker checklist ─────────────────────────────────────────────────────────
+
+/**
+ * Factual steps for switching share brokers in Australia.
+ *
+ * Covers HIN/SRN transfer vs sell-down, CHESS sponsorship considerations,
+ * in-specie transfer, and cost-base record keeping per ATO requirements.
+ *
+ * Sources: ASX CHESS Operating Rules, ASIC RG 181, ATO CGT record-keeping.
+ */
+export const BROKER_CHECKLIST: SwitchChecklist = {
+  type: "broker",
+  description:
+    "A factual step-by-step process for transferring your share portfolio to a new broker in Australia.",
+  steps: [
+    {
+      heading: "Check your current sponsorship model (CHESS vs custodial)",
+      body:
+        "Log in to your current broker and check whether your holdings are CHESS-sponsored (you have a Holder Identification Number, HIN, starting with 'X') or held in a custodial/issuer-sponsored model (you have a Shareholder Reference Number, SRN, per company). CHESS-sponsored shares can be transferred directly without selling. Custodial shares may need to be sold and repurchased, which has tax and brokerage implications.",
+      phase: "prepare",
+      source: "ASX CHESS Operating Rules, ASIC RG 181",
+    },
+    {
+      heading: "Record your cost base before moving",
+      body:
+        "Download or screenshot your full transaction history from your current broker. Australian tax law requires you to keep records of the original acquisition date and cost for each parcel of shares for Capital Gains Tax (CGT) purposes. An in-specie transfer does not reset your cost base, but records must be retained. A sell-down and rebuy creates a new CGT event.",
+      phase: "prepare",
+      source: "ATO — CGT record-keeping requirements",
+    },
+    {
+      heading: "Confirm the new broker supports in-specie CHESS transfer",
+      body:
+        "Contact or check the new broker's FAQ to confirm they accept off-market CHESS transfers (also called broker-to-broker transfers). Most CHESS-sponsored brokers accept these. Some non-CHESS (custodial) brokers do not accept in-specie transfers and require a sell-down before account opening.",
+      phase: "open",
+    },
+    {
+      heading: "Open and verify your new broker account",
+      body:
+        "Complete the new broker's online application. You will need to provide: photo ID (driver's licence or passport), your Tax File Number (TFN) — voluntary but withholding tax applies if not supplied — and your bank account details for settlement. Identity verification is typically completed within minutes online via digital ID checks.",
+      phase: "open",
+    },
+    {
+      heading: "Initiate the off-market (CHESS) transfer",
+      body:
+        "Log in to your new broker and initiate a 'CHESS transfer' or 'HIN transfer'. You will need to provide your current HIN (from your old broker) and the details of each holding (ASX code and quantity). Your new broker submits the transfer request to ASX CHESS on your behalf. Your old broker will be notified and has 3 business days to respond. There is no need to contact your old broker separately.",
+      phase: "transfer",
+      source: "ASX CHESS Operating Rules §6",
+    },
+    {
+      heading: "Understand transfer fees",
+      body:
+        "Most brokers charge a per-holding CHESS transfer fee (commonly $50–$55 per line of stock). Some charge on the outgoing side, some on the incoming side — check both brokers' fee schedules. ETFs and managed funds held on the CHESS subregister transfer the same way as individual shares.",
+      phase: "transfer",
+    },
+    {
+      heading: "For US/international shares: understand the separate process",
+      body:
+        "US shares held on the CHESS subregister (as CDIs — CHESS Depositary Interests) transfer via the same CHESS mechanism. Shares held via the US DTC (Depository Trust Company) use a different process called ACATS (Automated Customer Account Transfer Service) and are subject to the US broker's transfer rules. Contact both brokers for their specific US transfer process.",
+      phase: "transfer",
+    },
+    {
+      heading: "Wait for transfer to complete (3–5 business days)",
+      body:
+        "ASX CHESS processes the transfer within 3–5 business days. During this period, your shares remain on your current HIN and you retain full ownership. You may not be able to trade the transferred holdings while the transfer is in progress. Check both your old and new broker portals to confirm receipt.",
+      phase: "transfer",
+    },
+    {
+      heading: "Verify all holdings and cost-base records in the new account",
+      body:
+        "After the transfer, log in to your new broker and verify: (1) all holdings appear with correct quantities, (2) the cost-base or 'purchase price' data transferred correctly if the new broker supports it, (3) any dividend reinvestment plan (DRP) enrolments — these do not transfer and must be re-enrolled.",
+      phase: "close",
+    },
+    {
+      heading: "Close your old broker account",
+      body:
+        "Once you have confirmed all holdings have transferred, close your old account. Check: (1) any remaining cash balance — withdraw it before closing, (2) exit fees or account closure fees in the PDS/fee schedule, (3) ongoing subscription or platform fees that may still be charged — cancel any direct debits.",
+      phase: "close",
+    },
+  ],
+};
+
+// ─── Super checklist ──────────────────────────────────────────────────────────
+
+/**
+ * Factual steps for rolling over a superannuation account in Australia.
+ *
+ * Covers rollover via myGov/ATO, insurance implications, contributions timing,
+ * lost super search, and beneficiary nomination.
+ *
+ * Sources: ATO SIS Act, ASIC RG 183, MoneySmart "Changing super funds".
+ *
+ * AFSL note: super switching carries significant insurance loss risk per
+ * ASIC RG 183. The SUPER_WARNING from lib/compliance.ts is surfaced on the page;
+ * this checklist also includes factual warning steps per that guidance.
+ */
+export const SUPER_CHECKLIST: SwitchChecklist = {
+  type: "super",
+  description:
+    "A factual step-by-step process for rolling over your superannuation account in Australia, including insurance and contributions checks.",
+  steps: [
+    {
+      heading: "Check your existing insurance cover before doing anything",
+      body:
+        "Log in to your current super fund's member portal (or call them) and record: (1) death and total and permanent disability (TPD) cover — the insured amount, (2) income protection cover — the monthly benefit and benefit period, (3) premium costs — how much your current fund deducts each month. Insurance inside super often has no medical underwriting, so pre-existing conditions may not be covered by a new fund. Write all of this down before initiating any rollover.",
+      phase: "check",
+      warning:
+        "Switching super funds can result in permanent loss of life insurance, TPD, and income protection cover. Some conditions may not be insurable in a new fund. Check your current cover before rolling over.",
+      source: "ASIC RG 183, MoneySmart 'Changing super funds'",
+    },
+    {
+      heading: "Check whether contributions will land in time",
+      body:
+        "Contact your employer's payroll department and check: (1) when the next Superannuation Guarantee (SG) contribution is due to be paid, (2) whether you can update your nominated fund in time for the next payment. Contributions made to your old fund after you close it may need to be manually transferred. The ATO's SuperStream standard means most contributions reach the new fund within 3 business days of payment.",
+      phase: "check",
+      source: "ATO — SuperStream",
+    },
+    {
+      heading: "Search for lost and multiple super accounts",
+      body:
+        "Before consolidating, use the ATO's 'Find and transfer super' tool (via myGov) to check whether you have other super accounts you've forgotten. Combine all accounts into your chosen fund to avoid duplicate fees. The ATO estimates Australians have billions in lost super — this step costs nothing and takes 5 minutes.",
+      phase: "check",
+      source: "ATO — Find your super (myGov)",
+    },
+    {
+      heading: "Research and choose your new super fund",
+      body:
+        "Compare funds using the ATO's free YourSuper comparison tool (ato.gov.au/yoursuper). Key factors to compare: annual performance (net of fees), total fees (administration + investment fees), investment options, and insurance offerings. The YourSuper tool shows all APRA-regulated funds with standardised data.",
+      phase: "check",
+      source: "ATO — YourSuper comparison tool",
+    },
+    {
+      heading: "Open your new super fund account",
+      body:
+        "Join your chosen fund via their website or member application. You will need: your TFN (required for super by law — unlike brokerage accounts, TFN withholding for super is 47% without one), your personal details, and your bank account details. Choose your investment option(s) — if unsure, most funds offer a 'balanced' or 'MySuper' default option.",
+      phase: "rollover",
+    },
+    {
+      heading: "Initiate the rollover via myGov (ATO-linked)",
+      body:
+        "The easiest and safest way to transfer is via myGov: (1) log in to myGov and select 'ATO', (2) go to 'Super' > 'Find and transfer super', (3) select the amount to roll over — full balance to close the old account, or partial if retaining some in the old fund (e.g. to preserve insurance), (4) confirm. The ATO coordinates the transfer directly with both funds. Most rollovers complete within 3–5 business days.",
+      phase: "rollover",
+      source: "ATO — Roll over super via myGov",
+    },
+    {
+      heading: "Alternative: request rollover via the new fund",
+      body:
+        "If you prefer not to use myGov, complete a 'Request to transfer whole balance of superannuation benefits between funds' form (ATO form NAT 75359) and submit it to your new fund. They will coordinate the transfer with your old fund. This takes 3–5 business days on receipt.",
+      phase: "rollover",
+      source: "ATO form NAT 75359",
+    },
+    {
+      heading: "Update your employer's nominated fund",
+      body:
+        "Provide your employer's payroll department with your new fund's details: fund ABN, fund USI (Unique Superannuation Identifier), your member number, and the fund's bank account details (via SuperStream). Use the ATO's 'Standard Choice Form' (ATO form NAT 13080) if your employer requires a formal document. You have the right to choose your own fund under the Choice of Fund rules (SGA Act s32C).",
+      phase: "rollover",
+      source: "ATO — Standard Choice Form (NAT 13080)",
+    },
+    {
+      heading: "Review and update your beneficiary nomination",
+      body:
+        "Beneficiary nominations do not transfer automatically. Log in to your new fund and complete a binding death benefit nomination if you want a legally binding instruction on who receives your super in the event of death. A non-lapsing binding nomination is the most robust — otherwise nominations lapse every 3 years and the trustee has discretion.",
+      phase: "close",
+    },
+    {
+      heading: "Apply for comparable insurance in your new fund (if needed)",
+      body:
+        "If your new fund offers lower or no default insurance cover, apply for equivalent cover. Do this before closing the old account — you may have a brief window to join without underwriting. Check whether your new fund has a 'voluntary cover' or 'opt-in' process and what the underwriting requirements are.",
+      phase: "close",
+      warning:
+        "New insurance applications in super are subject to the insurer's underwriting. Pre-existing conditions may result in exclusions or higher premiums. Apply for new cover before closing old cover.",
+    },
+    {
+      heading: "Confirm the old account is fully closed",
+      body:
+        "After the rollover completes, verify: (1) the old fund's member portal shows a zero balance, (2) any insurance deductions have stopped, (3) you have received a final statement. If the old fund had an exit fee (less common since the Protecting Your Super reforms), confirm it has been deducted from the transferred amount.",
+      phase: "close",
+      source: "Treasury Laws Amendment (Protecting Your Super Package) Act 2019",
+    },
+  ],
+};
+
+// ─── Savings checklist ────────────────────────────────────────────────────────
+
+/**
+ * Factual steps for switching savings accounts in Australia.
+ *
+ * Covers opening a new account, migrating direct debits and payroll,
+ * intro-rate expiry awareness, and closing the old account.
+ *
+ * Sources: ASIC MoneySmart, APRA, ABA Banking Code of Practice.
+ */
+export const SAVINGS_CHECKLIST: SwitchChecklist = {
+  type: "savings",
+  description:
+    "A factual step-by-step process for switching to a new Australian savings account, including migrating direct debits and payroll.",
+  steps: [
+    {
+      heading: "Note the introductory rate period and ongoing rate",
+      body:
+        "Many high-interest savings accounts advertise an introductory (honeymoon) rate that applies for 3–5 months, after which the ongoing base rate applies — which may be significantly lower. Record both rates and the intro period end date. Compare the ongoing rate, not just the intro rate, when deciding whether to switch.",
+      phase: "prepare",
+    },
+    {
+      heading: "Check for account conditions on the bonus rate",
+      body:
+        "Most bonus savings rates have monthly conditions: e.g. deposit a minimum amount ($1,000–$2,000), make a minimum number of card transactions, or not make any withdrawals in the month. Failing conditions reverts to the base rate, which is often close to 0%. Confirm you can meet these conditions with your spending patterns before switching.",
+      phase: "prepare",
+    },
+    {
+      heading: "Check for exit fees on your current account",
+      body:
+        "Most at-call savings accounts have no exit fee. However, some notice saver accounts, term deposits, or accounts with fee waivers may charge a fee for early closure or have a required notice period (typically 31–90 days). Review your current account's PDS or fee schedule.",
+      phase: "prepare",
+    },
+    {
+      heading: "List all direct debits and automatic payments from the current account",
+      body:
+        "Before opening the new account, log in to your current account's transaction history and list every recurring direct debit or BPAY payment: utilities, subscriptions, insurance, loan repayments, etc. Also note any automatic transfers (e.g. automated savings top-ups). You will need to re-authorise each of these with the new account's BSB and account number.",
+      phase: "prepare",
+    },
+    {
+      heading: "Open the new savings account",
+      body:
+        "Apply online — most accounts are opened in under 10 minutes. You will need: photo ID (passport or driver's licence), your TFN (recommended — otherwise withholding tax applies to interest at the highest marginal rate), and your current bank's BSB and account number for an initial transfer. Identity verification is completed digitally via DVS (Document Verification Service).",
+      phase: "open",
+    },
+    {
+      heading: "Transfer funds to the new account",
+      body:
+        "Once opened, transfer most of your balance to the new account, keeping enough in the old account to cover pending direct debits for at least 1–2 full billing cycles while you migrate them across. Transfers via Osko/PayID (NPP) are available within minutes; standard direct entry (DE) takes 1–3 business days.",
+      phase: "open",
+    },
+    {
+      heading: "Update your payroll to the new account",
+      body:
+        "Submit your new BSB and account number to your employer's payroll department. Most employers require this before the payroll cut-off date for the next pay cycle. Check your employment contract or company HR portal for the process. Allow one full pay cycle buffer before closing the old account.",
+      phase: "migrate",
+    },
+    {
+      heading: "Re-authorise all direct debits with the new account",
+      body:
+        "For each direct debit on your list, contact the biller (or update online) with your new BSB and account number. Alternatively, ask your new bank whether they offer a 'direct debit switching service' — many major banks will automatically redirect direct debits for up to 13 months after you switch (ABA Banking Code initiative). Confirm the service is active before cancelling the old account.",
+      phase: "migrate",
+      source: "ABA Banking Code of Practice — Account switching",
+    },
+    {
+      heading: "Wait one full billing cycle to catch any missed direct debits",
+      body:
+        "After updating all billers, wait at least one full calendar month before closing the old account. This catches any quarterly or annual direct debits you may have missed. Check the old account's transaction history for any new debits and redirect them.",
+      phase: "migrate",
+    },
+    {
+      heading: "Close the old savings account",
+      body:
+        "Transfer any remaining balance to the new account, then contact your old bank (online, via the app, or in branch) to close the account. Request written confirmation of closure. If your old account had interest still accruing (e.g. end-of-month credit), wait for the final interest payment before closing.",
+      phase: "close",
+    },
+    {
+      heading: "Set a calendar reminder for the intro-rate expiry",
+      body:
+        "If your new account has an introductory rate, set a calendar reminder for 2 weeks before the intro period ends. At that point, compare the ongoing rate against other accounts — you may benefit from switching again or negotiating with your bank.",
+      phase: "close",
+    },
+  ],
+};
+
+// ─── Lookup helper ────────────────────────────────────────────────────────────
+
+const CHECKLISTS: Record<SwitchType, SwitchChecklist> = {
+  broker: BROKER_CHECKLIST,
+  super: SUPER_CHECKLIST,
+  savings: SAVINGS_CHECKLIST,
+};
+
+/**
+ * Returns the checklist for a given switch type.
+ * Returns null for unknown types (caller renders 404).
+ */
+export function getChecklist(type: string): SwitchChecklist | null {
+  if (type === "broker" || type === "super" || type === "savings") {
+    return CHECKLISTS[type];
+  }
+  return null;
+}
+
+/** All supported switch types with display metadata. */
+export const SWITCH_TYPES: {
+  type: SwitchType;
+  label: string;
+  icon: string;
+  tagline: string;
+  slug: string;
+}[] = [
+  {
+    type: "broker",
+    label: "Share Broker",
+    icon: "arrow-right-left",
+    tagline: "Transfer your shares, HIN, and cost-base records",
+    slug: "broker",
+  },
+  {
+    type: "super",
+    label: "Super Fund",
+    icon: "building-2",
+    tagline: "Roll over your super and protect your insurance cover",
+    slug: "super",
+  },
+  {
+    type: "savings",
+    label: "Savings Account",
+    icon: "piggy-bank",
+    tagline: "Migrate direct debits, payroll, and earn a better rate",
+    slug: "savings",
+  },
+];

--- a/lib/switching/index.ts
+++ b/lib/switching/index.ts
@@ -1,0 +1,35 @@
+/**
+ * lib/switching — barrel export.
+ *
+ * Switching-as-a-service: factual step-by-step checklists + cost-of-staying
+ * estimates for broker, super, and savings account switching.
+ *
+ * AFSL-safe: factual process guidance + cost estimates only.
+ * No personal recommendation is ever made here.
+ */
+
+export {
+  BROKER_CHECKLIST,
+  SUPER_CHECKLIST,
+  SAVINGS_CHECKLIST,
+  SWITCH_TYPES,
+  getChecklist,
+} from "./checklist";
+
+export type { SwitchStep, SwitchChecklist, SwitchType } from "./checklist";
+
+export {
+  parseFee,
+  calcBrokerSaving,
+  calcSuperSaving,
+  calcSavingsSaving,
+} from "./savings";
+
+export type {
+  BrokerFeeInputs,
+  BrokerSavingResult,
+  SuperFeeInputs,
+  SuperSavingResult,
+  SavingsFeeInputs,
+  SavingsSavingResult,
+} from "./savings";

--- a/lib/switching/savings.ts
+++ b/lib/switching/savings.ts
@@ -1,0 +1,285 @@
+/**
+ * "Cost of staying vs switching" estimate for each asset class.
+ *
+ * Pure functions — no side effects, no I/O, fully testable.
+ * Reuses the same fee parsing logic as SwitchingCalculatorClient.tsx
+ * so the two tools stay in sync. The broker calc is the existing logic
+ * extracted into a named export; super and savings add new asset classes.
+ *
+ * AFSL note: these functions produce FACTUAL ESTIMATES based on user-
+ * supplied inputs. They do not recommend a specific product. The UI layer
+ * is responsible for surfacing the GENERAL_ADVICE_WARNING alongside any
+ * estimate output.
+ */
+
+// ─── Fee string parser (shared with switching-calculator) ─────────────────────
+
+/**
+ * Parses a fee string like "$19.95", "0.5%", "$0", "Free" into a
+ * {flat, pct} pair. Mirrors parseFee() in SwitchingCalculatorClient.tsx.
+ */
+export function parseFee(feeStr: string | null | undefined): {
+  flat: number;
+  pct: number;
+} {
+  if (!feeStr) return { flat: 0, pct: 0 };
+  const s = feeStr.replace(/,/g, "").trim();
+  const pctMatch = s.match(/([\d.]+)%/);
+  if (pctMatch) {
+    const pctRaw = pctMatch[1];
+    return { flat: 0, pct: parseFloat(pctRaw ?? "0") / 100 };
+  }
+  const flatMatch = s.match(/\$([\d.]+)/);
+  if (flatMatch) {
+    const flatRaw = flatMatch[1];
+    return { flat: parseFloat(flatRaw ?? "0"), pct: 0 };
+  }
+  // "$0", "free", "0" all collapse to zero
+  if (s === "0" || s.toLowerCase().includes("free") || s === "$0") {
+    return { flat: 0, pct: 0 };
+  }
+  return { flat: 0, pct: 0 };
+}
+
+// ─── Broker switching saving ──────────────────────────────────────────────────
+
+export interface BrokerFeeInputs {
+  /** ASX fee string for the current broker, e.g. "$19.95" or "0.5%" */
+  currentAsxFee: string | null | undefined;
+  /** ASX fee string for the target broker */
+  targetAsxFee: string | null | undefined;
+  /** US fee string for current broker */
+  currentUsFee?: string | null;
+  /** US fee string for target broker */
+  targetUsFee?: string | null;
+  /** FX rate in whole-number form (e.g. 0.70 means 0.70% = 0.007) */
+  currentFxRate?: number | null;
+  targetFxRate?: number | null;
+  /** Annual inactivity fee as a raw dollar string, e.g. "$50" */
+  currentInactivityFee?: string | null;
+  targetInactivityFee?: string | null;
+  /** Number of trades per year */
+  tradesPerYear: number;
+  /** Average trade size in AUD */
+  avgTradeSize: number;
+  /** Percentage of trades that are US shares (0–100) */
+  usAllocationPct: number;
+}
+
+export interface BrokerSavingResult {
+  currentAnnualCost: number;
+  targetAnnualCost: number;
+  /** Positive = saving by switching; negative = more expensive */
+  annualDifference: number;
+  /** Projection at [1, 2, 3, 5] years */
+  projectedSavings: { years: number; saving: number }[];
+}
+
+/**
+ * Estimates the annual cost difference between a current and target broker.
+ *
+ * Uses the same math as SwitchingCalculatorClient.tsx / calcAnnualCost().
+ * Both sides are calculated deterministically from the inputs — no randomness.
+ */
+export function calcBrokerSaving(inputs: BrokerFeeInputs): BrokerSavingResult {
+  const { tradesPerYear, avgTradeSize, usAllocationPct } = inputs;
+
+  const asxTrades = Math.round(tradesPerYear * (1 - usAllocationPct / 100));
+  const usTrades = tradesPerYear - asxTrades;
+
+  function annualCost(
+    asxFee: string | null | undefined,
+    usFee: string | null | undefined,
+    fxRate: number | null | undefined,
+    inactivityFee: string | null | undefined,
+  ): number {
+    const { flat: asxFlat, pct: asxPct } = parseFee(asxFee);
+    const { flat: usFlat, pct: usPct } = parseFee(usFee);
+    const fx = fxRate ? fxRate / 100 : 0.007;
+    const inactivity = inactivityFee
+      ? parseFloat(inactivityFee.replace(/[^0-9.]/g, "")) || 0
+      : 0;
+
+    const asxCost = asxTrades * Math.max(asxFlat, asxPct * avgTradeSize);
+    const usCost = usTrades * Math.max(usFlat, usPct * avgTradeSize);
+    const fxCost = usTrades * avgTradeSize * fx;
+
+    return asxCost + usCost + fxCost + inactivity;
+  }
+
+  const currentAnnualCost = annualCost(
+    inputs.currentAsxFee,
+    inputs.currentUsFee,
+    inputs.currentFxRate,
+    inputs.currentInactivityFee,
+  );
+  const targetAnnualCost = annualCost(
+    inputs.targetAsxFee,
+    inputs.targetUsFee,
+    inputs.targetFxRate,
+    inputs.targetInactivityFee,
+  );
+
+  const annualDifference = currentAnnualCost - targetAnnualCost;
+
+  const projectedSavings = [1, 2, 3, 5].map((years) => ({
+    years,
+    saving: Math.round(annualDifference * years),
+  }));
+
+  return {
+    currentAnnualCost: Math.round(currentAnnualCost * 100) / 100,
+    targetAnnualCost: Math.round(targetAnnualCost * 100) / 100,
+    annualDifference: Math.round(annualDifference * 100) / 100,
+    projectedSavings,
+  };
+}
+
+// ─── Super fund switching saving ──────────────────────────────────────────────
+
+export interface SuperFeeInputs {
+  /** Annual balance in AUD (used to estimate the $ impact of fee differences) */
+  balance: number;
+  /**
+   * Current fund's annual fee as a percentage of balance (admin + investment fee).
+   * Entered as percentage points (e.g. 1.5 for 1.5%).
+   */
+  currentFeeRatePct: number;
+  /**
+   * Target fund's annual fee as a percentage of balance.
+   */
+  targetFeeRatePct: number;
+  /**
+   * Current fund's fixed annual admin fee in AUD (flat $ component).
+   * Defaults to 0 if not applicable.
+   */
+  currentFixedFeeAud?: number;
+  /**
+   * Target fund's fixed annual admin fee in AUD.
+   */
+  targetFixedFeeAud?: number;
+}
+
+export interface SuperSavingResult {
+  currentAnnualFee: number;
+  targetAnnualFee: number;
+  /** Positive = saving by switching */
+  annualDifference: number;
+  projectedSavings: { years: number; saving: number }[];
+}
+
+/**
+ * Estimates the annual fee saving from switching super funds.
+ *
+ * Calculates total fees as: (balance × rate%) + fixed fee.
+ * Does NOT model investment returns or compound growth — the estimate is
+ * a flat fee comparison only, surfaced as "potential annual fee saving".
+ * This is intentionally conservative and factual.
+ */
+export function calcSuperSaving(inputs: SuperFeeInputs): SuperSavingResult {
+  const {
+    balance,
+    currentFeeRatePct,
+    targetFeeRatePct,
+    currentFixedFeeAud = 0,
+    targetFixedFeeAud = 0,
+  } = inputs;
+
+  const currentAnnualFee =
+    balance * (currentFeeRatePct / 100) + currentFixedFeeAud;
+  const targetAnnualFee =
+    balance * (targetFeeRatePct / 100) + targetFixedFeeAud;
+
+  const annualDifference = currentAnnualFee - targetAnnualFee;
+
+  const projectedSavings = [1, 2, 3, 5].map((years) => ({
+    years,
+    saving: Math.round(annualDifference * years),
+  }));
+
+  return {
+    currentAnnualFee: Math.round(currentAnnualFee * 100) / 100,
+    targetAnnualFee: Math.round(targetAnnualFee * 100) / 100,
+    annualDifference: Math.round(annualDifference * 100) / 100,
+    projectedSavings,
+  };
+}
+
+// ─── Savings account switching saving ────────────────────────────────────────
+
+export interface SavingsFeeInputs {
+  /** Cash balance in AUD */
+  balance: number;
+  /**
+   * Current account's interest rate (% p.a.) — use the ongoing rate,
+   * not the introductory/honeymoon rate.
+   */
+  currentRatePct: number;
+  /**
+   * Target account's interest rate (% p.a.).
+   * Use the ongoing rate for a fair comparison.
+   */
+  targetRatePct: number;
+  /**
+   * Current account's monthly fee in AUD (0 if fee-free).
+   */
+  currentMonthlyFeeAud?: number;
+  /**
+   * Target account's monthly fee in AUD.
+   */
+  targetMonthlyFeeAud?: number;
+}
+
+export interface SavingsSavingResult {
+  currentAnnualInterest: number;
+  targetAnnualInterest: number;
+  currentAnnualFees: number;
+  targetAnnualFees: number;
+  /** Net annual gain (interest gain minus any fee difference) */
+  annualDifference: number;
+  projectedSavings: { years: number; saving: number }[];
+}
+
+/**
+ * Estimates the annual gain from switching savings accounts.
+ *
+ * Calculates net difference as:
+ *   (target interest - current interest) - (target fees - current fees)
+ *
+ * Uses simple (non-compounding) interest for transparency.
+ * Does NOT account for introductory rates — use the ongoing rate.
+ */
+export function calcSavingsSaving(
+  inputs: SavingsFeeInputs,
+): SavingsSavingResult {
+  const {
+    balance,
+    currentRatePct,
+    targetRatePct,
+    currentMonthlyFeeAud = 0,
+    targetMonthlyFeeAud = 0,
+  } = inputs;
+
+  const currentAnnualInterest = balance * (currentRatePct / 100);
+  const targetAnnualInterest = balance * (targetRatePct / 100);
+  const currentAnnualFees = currentMonthlyFeeAud * 12;
+  const targetAnnualFees = targetMonthlyFeeAud * 12;
+
+  const currentNet = currentAnnualInterest - currentAnnualFees;
+  const targetNet = targetAnnualInterest - targetAnnualFees;
+  const annualDifference = targetNet - currentNet;
+
+  const projectedSavings = [1, 2, 3, 5].map((years) => ({
+    years,
+    saving: Math.round(annualDifference * years),
+  }));
+
+  return {
+    currentAnnualInterest: Math.round(currentAnnualInterest * 100) / 100,
+    targetAnnualInterest: Math.round(targetAnnualInterest * 100) / 100,
+    currentAnnualFees: Math.round(currentAnnualFees * 100) / 100,
+    targetAnnualFees: Math.round(targetAnnualFees * 100) / 100,
+    annualDifference: Math.round(annualDifference * 100) / 100,
+    projectedSavings,
+  };
+}


### PR DESCRIPTION
Round-4 deepening (6 of 10). A guided **switching-as-a-service** tool (broker / super / savings) — newly unblocked now that concierge ships. Factual step-by-step process + a "cost of staying vs switching" estimate + a referral CTA. AFSL-safe: process guidance + the user's own numbers; **no** "switch to X because it's best for you" (verified by tests).

- `lib/switching/*` — pure, tested: per-type **checklists** (broker: CHESS/HIN transfer vs sell-down, cost-base records; super: insurance-check-first with an ASIC RG 183 warning, lost-super search, myGov rollover, beneficiary; savings: intro-rate expiry, direct-debit/payroll migration, one-cycle buffer), each step carrying ATO/ASIC/ASX **source citations**; plus switching-saving calcs that **reuse** the existing fee/rate logic.
- `/switch/[type]` (SSG) + the `/switch` hub gains type cards above the existing broker planner. `HowTo` + `FAQPage` + breadcrumb JSON-LD via the **existing** builders (`schema-markup.ts` untouched); `SUPER_WARNING` prominent; `GENERAL_ADVICE_WARNING`; referral CTAs to `/compare`, `/super`, `/savings`, `/find-advisor`.

**Fix on verification:** escaped apostrophes in the estimate copy.

**Verified:** `tsc` clean · **62 tests** (per-type checklist integrity, AFSL-forbidden-phrase assertions, required regulatory steps, all 3 saving calcs + edges) pass · eslint clean · jsonld gate green. Tier A (page UI + tests; no schema/auth/migration).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUfSRE2Teb6VhEXFP6RpS9)_