### PR TITLE
feat: scenario → Pro dashboard previews + resume deep-links (deepen)

### DIFF
--- a/__tests__/lib/scenario-deep-link.test.ts
+++ b/__tests__/lib/scenario-deep-link.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Tests for lib/scenario-deep-link.ts
+ *
+ * Two concerns:
+ *   1. resolveScenarioParam — parses `?scenario=` values into saved-scenario indices.
+ *   2. assembleSavedScenarioPreviews — builds dashboard preview objects from the
+ *      persisted snapshot (pure, no I/O).
+ *
+ * Both functions are pure so no mocking is needed.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  resolveScenarioParam,
+  assembleSavedScenarioPreviews,
+  type ScenarioPreview,
+} from "@/lib/scenario-deep-link";
+import type { ScenarioPlannerSnapshot } from "@/lib/scenario-engine";
+
+// ─── Shared fixture helpers ───────────────────────────────────────────────────
+
+type SnapshotScenario = ScenarioPlannerSnapshot["scenarios"][number];
+
+function makeScenario(
+  label: string,
+  overrides: Partial<SnapshotScenario["summary"]> = {},
+): SnapshotScenario {
+  return {
+    id: Math.random().toString(36).slice(2),
+    label,
+    savedAt: new Date().toISOString(),
+    inputs: {
+      currentAge: 35,
+      retirementAge: 67,
+      annualSalary: 100_000,
+      employerSgRate: 0.115,
+      currentSuperBalance: 150_000,
+      extraConcessionalContribs: 0,
+      nonConcessionalContribs: 0,
+      unusedCarryForwardCap: 0,
+      expectedReturnPct: 7,
+      inflationRatePct: 3,
+      desiredRetirementIncome: 60_000,
+      annualInterestIncome: 0,
+      annualUnfrankedDividends: 0,
+      annualFrankedDividends: 0,
+      frankingPct: 100,
+      annualCapitalGain: 0,
+      capitalGainDiscountEligible: false,
+      propertyPurchasePrice: 0,
+      propertyGrowthRatePct: 0,
+      propertyRentalYieldPct: 3,
+      propertyHoldingCostsPct: 1.5,
+      propertyHeld12Months: true,
+    },
+    summary: {
+      projectedSuperAtRetirement: 1_200_000,
+      gapToTarget: -200_000, // surplus = on track
+      isOnTrack: true,
+      drawdownYears: 32,
+      taxSavingOnExtraContribs: 0,
+      taxOnInvestmentIncome: 0,
+      ...overrides,
+    },
+  };
+}
+
+// ─── resolveScenarioParam ─────────────────────────────────────────────────────
+
+describe("resolveScenarioParam", () => {
+  const scenarios: readonly SnapshotScenario[] = [
+    makeScenario("Conservative"),
+    makeScenario("Moderate"),
+    makeScenario("Aggressive"),
+  ];
+
+  it("returns -1 when param is null", () => {
+    expect(resolveScenarioParam(null, scenarios)).toBe(-1);
+  });
+
+  it("returns -1 when param is undefined", () => {
+    expect(resolveScenarioParam(undefined, scenarios)).toBe(-1);
+  });
+
+  it("returns -1 when param is empty string", () => {
+    expect(resolveScenarioParam("", scenarios)).toBe(-1);
+  });
+
+  it("returns -1 when scenarios array is empty", () => {
+    expect(resolveScenarioParam("0", [])).toBe(-1);
+  });
+
+  it("resolves a numeric '0' to index 0", () => {
+    expect(resolveScenarioParam("0", scenarios)).toBe(0);
+  });
+
+  it("resolves a numeric '1' to index 1", () => {
+    expect(resolveScenarioParam("1", scenarios)).toBe(1);
+  });
+
+  it("resolves a numeric '2' to index 2", () => {
+    expect(resolveScenarioParam("2", scenarios)).toBe(2);
+  });
+
+  it("returns -1 for a numeric index that is out of range", () => {
+    expect(resolveScenarioParam("5", scenarios)).toBe(-1);
+  });
+
+  it("resolves an exact label match (case-sensitive exact)", () => {
+    expect(resolveScenarioParam("Moderate", scenarios)).toBe(1);
+  });
+
+  it("resolves a case-insensitive label match", () => {
+    expect(resolveScenarioParam("aggressive", scenarios)).toBe(2);
+    expect(resolveScenarioParam("CONSERVATIVE", scenarios)).toBe(0);
+  });
+
+  it("returns -1 for a label that does not match any scenario", () => {
+    expect(resolveScenarioParam("NotExist", scenarios)).toBe(-1);
+  });
+
+  it("trims whitespace from both param and label for matching", () => {
+    const padded: readonly SnapshotScenario[] = [makeScenario("  My Plan  ")];
+    expect(resolveScenarioParam("  My Plan  ", padded)).toBe(0);
+    expect(resolveScenarioParam("my plan", padded)).toBe(0);
+  });
+
+  it("prefers numeric match over label match when param is all digits", () => {
+    // Scenario at index 1 is "Moderate"; a scenario named "1" would be label-matched
+    // but "1" as numeric selects index 1 directly.
+    expect(resolveScenarioParam("1", scenarios)).toBe(1);
+  });
+
+  it("handles a single-scenario array with numeric '0'", () => {
+    const one: readonly SnapshotScenario[] = [makeScenario("Solo")];
+    expect(resolveScenarioParam("0", one)).toBe(0);
+  });
+});
+
+// ─── assembleSavedScenarioPreviews ────────────────────────────────────────────
+
+describe("assembleSavedScenarioPreviews", () => {
+  it("returns an empty array for undefined input", () => {
+    expect(assembleSavedScenarioPreviews(undefined)).toEqual([]);
+  });
+
+  it("returns an empty array for null input", () => {
+    expect(assembleSavedScenarioPreviews(null)).toEqual([]);
+  });
+
+  it("returns an empty array for an empty scenarios array", () => {
+    expect(assembleSavedScenarioPreviews([])).toEqual([]);
+  });
+
+  it("maps one scenario to one ScenarioPreview", () => {
+    const s = makeScenario("My Plan", {
+      projectedSuperAtRetirement: 900_000,
+      isOnTrack: false,
+      gapToTarget: 600_000,
+      drawdownYears: 15,
+    });
+    const [preview] = assembleSavedScenarioPreviews([s]);
+    expect(preview).toBeDefined();
+    expect(preview!.label).toBe("My Plan");
+    expect(preview!.projectedSuper).toBe(900_000);
+    expect(preview!.isOnTrack).toBe(false);
+    expect(preview!.gapToTarget).toBe(600_000);
+    expect(preview!.drawdownYears).toBe(15);
+  });
+
+  it("generates a numeric deep-link resumeHref for each scenario", () => {
+    const scenarios = [
+      makeScenario("Alpha"),
+      makeScenario("Beta"),
+      makeScenario("Gamma"),
+    ];
+    const previews = assembleSavedScenarioPreviews(scenarios);
+    expect(previews[0]!.resumeHref).toBe("/scenarios/plan?scenario=0");
+    expect(previews[1]!.resumeHref).toBe("/scenarios/plan?scenario=1");
+    expect(previews[2]!.resumeHref).toBe("/scenarios/plan?scenario=2");
+  });
+
+  it("round-trips: resolveScenarioParam can resolve hrefs produced by assembly", () => {
+    const scenarios = [
+      makeScenario("A"),
+      makeScenario("B"),
+    ];
+    const previews = assembleSavedScenarioPreviews(scenarios);
+    for (const [i, preview] of previews.entries()) {
+      // Extract the `?scenario=<N>` value from the href.
+      const param = new URLSearchParams(preview!.resumeHref.split("?")[1]).get("scenario");
+      expect(resolveScenarioParam(param, scenarios)).toBe(i);
+    }
+  });
+
+  it("maps three scenarios preserving order", () => {
+    const scenarios = [
+      makeScenario("One"),
+      makeScenario("Two"),
+      makeScenario("Three"),
+    ];
+    const previews: ScenarioPreview[] = assembleSavedScenarioPreviews(scenarios);
+    expect(previews.map((p) => p.label)).toEqual(["One", "Two", "Three"]);
+  });
+
+  it("correctly marks an on-track scenario", () => {
+    const s = makeScenario("On Track", { isOnTrack: true, gapToTarget: -100_000 });
+    const [preview] = assembleSavedScenarioPreviews([s]);
+    expect(preview!.isOnTrack).toBe(true);
+  });
+
+  it("correctly marks an off-track scenario", () => {
+    const s = makeScenario("Behind", { isOnTrack: false, gapToTarget: 500_000 });
+    const [preview] = assembleSavedScenarioPreviews([s]);
+    expect(preview!.isOnTrack).toBe(false);
+    expect(preview!.gapToTarget).toBe(500_000);
+  });
+});

--- a/app/pro/dashboard/page.tsx
+++ b/app/pro/dashboard/page.tsx
@@ -10,6 +10,12 @@ import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
 import { getCurrentPricesBatch } from "@/lib/holdings/value";
 import { listBookmarks } from "@/lib/bookmarks";
 import { metricKindLabel, metricKindPath } from "@/lib/alert-thresholds";
+import { SCENARIO_PLANNER_CALC_KEY, type ScenarioPlannerSnapshot } from "@/lib/scenario-engine";
+import {
+  assembleSavedScenarioPreviews,
+  type ScenarioPreview,
+} from "@/lib/scenario-deep-link";
+import { formatCurrency } from "@/lib/utils";
 
 export const dynamic = "force-dynamic";
 
@@ -132,6 +138,112 @@ function BookmarksIcon() {
     <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
     </svg>
+  );
+}
+
+// ─── Re-export for tests ───────────────────────────────────────────────────
+// assembleSavedScenarioPreviews is pure and lives in lib/scenario-deep-link —
+// re-exported here so test files can follow the same import pattern as the
+// existing assembleDashboardSummary tests.
+export { assembleSavedScenarioPreviews } from "@/lib/scenario-deep-link";
+export type { ScenarioPreview } from "@/lib/scenario-deep-link";
+
+// ─── Saved scenarios inline card ───────────────────────────────────────────
+
+/**
+ * Renders the saved scenario planner card with inline previews and Resume links.
+ *
+ * When `previews` is empty, falls back to the same summary-card style as the
+ * other dashboard tiles (count + CTA link) so the layout is consistent.
+ *
+ * Note: anonymous-only scenarios live in sessionStorage and cannot be read
+ * server-side — users who haven't signed in when saving will see an empty
+ * state with a prompt to open the planner and re-save while signed in.
+ */
+function SavedScenariosCard({ previews }: { previews: ScenarioPreview[] }) {
+  if (previews.length === 0) {
+    // Empty-state: mirror SummaryCard appearance.
+    return (
+      <Link
+        href="/scenarios/plan"
+        className="group flex flex-col gap-3 rounded-xl border border-slate-200 bg-white p-5 hover:border-violet-300 hover:shadow-sm transition-all"
+      >
+        <div className="flex items-center justify-between gap-2">
+          <div className="w-9 h-9 bg-violet-50 text-violet-600 rounded-xl flex items-center justify-center shrink-0 group-hover:bg-violet-100 transition-colors">
+            <ScenariosIcon />
+          </div>
+          <span className="text-xs font-semibold text-violet-700 group-hover:text-violet-900 transition-colors">
+            Open planner &rarr;
+          </span>
+        </div>
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wider text-slate-500 mb-0.5">
+            Saved scenarios
+          </p>
+          <p className="text-2xl font-extrabold text-slate-900 tabular-nums leading-tight">
+            None saved
+          </p>
+          <p className="mt-0.5 text-xs text-slate-500 leading-relaxed">
+            Save up to 3 scenarios in the planner to resume them here
+          </p>
+        </div>
+      </Link>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3 rounded-xl border border-slate-200 bg-white p-5">
+      {/* Card header */}
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <div className="w-9 h-9 bg-violet-50 text-violet-600 rounded-xl flex items-center justify-center shrink-0">
+            <ScenariosIcon />
+          </div>
+          <p className="text-xs font-semibold uppercase tracking-wider text-slate-500">
+            Saved scenarios
+          </p>
+        </div>
+        <Link
+          href="/scenarios/plan"
+          className="text-xs font-semibold text-violet-700 hover:text-violet-900 transition-colors shrink-0"
+        >
+          Planner &rarr;
+        </Link>
+      </div>
+
+      {/* Scenario rows */}
+      <div className="space-y-2">
+        {previews.map((preview, idx) => (
+          <div
+            key={idx}
+            className="flex items-center justify-between gap-3 bg-slate-50 rounded-xl px-3 py-2.5"
+          >
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-bold text-slate-900 truncate">
+                {preview.label}
+              </p>
+              <p className="text-xs text-slate-500 leading-snug">
+                {formatCurrency(preview.projectedSuper)} projected &middot;{" "}
+                {preview.isOnTrack ? (
+                  <span className="text-emerald-600 font-semibold">On track</span>
+                ) : (
+                  <span className="text-amber-600 font-semibold">
+                    {formatCurrency(Math.abs(preview.gapToTarget))} gap
+                  </span>
+                )}
+                {" "}&middot; {preview.drawdownYears} yrs drawdown
+              </p>
+            </div>
+            <Link
+              href={preview.resumeHref}
+              className="shrink-0 text-xs font-bold px-3 py-1.5 bg-violet-100 text-violet-700 rounded-lg hover:bg-violet-200 transition-colors"
+            >
+              Resume
+            </Link>
+          </div>
+        ))}
+      </div>
+    </div>
   );
 }
 
@@ -289,6 +401,7 @@ export default async function ProDashboardPage() {
     watchlistRes,
     savedScenariosRes,
     activeDealsRes,
+    calcStateRes,
   ] = await Promise.all([
     supabase
       .from("investor_holdings")
@@ -313,6 +426,14 @@ export default async function ProDashboardPage() {
       .from("pro_deals")
       .select("id", { count: "exact", head: true })
       .eq("status", "active"),
+    // Fetch the signed-in user's calculator state to render scenario previews.
+    // user_calculator_state has RLS scoped to auth.uid()=user_id, so the
+    // regular server client is correct here (not admin).
+    supabase
+      .from("user_calculator_state")
+      .select("state")
+      .eq("user_id", userId)
+      .maybeSingle(),
   ]);
 
   // rate_alert_subscriptions — fetch full rows for the alert feed section.
@@ -351,6 +472,23 @@ export default async function ProDashboardPage() {
   const priceMap = await getCurrentPricesBatch(pricePairs);
 
   const alertRows = (alertsRes.data ?? []) as AlertFeedRow[];
+
+  // Parse saved scenario previews from the user_calculator_state DB row.
+  // The DB row holds a JSON blob under `state[SCENARIO_PLANNER_CALC_KEY].data`
+  // matching the `ScenarioPlannerSnapshot` shape. If the user has no saved
+  // scenarios (or never opened the planner), `scenarioPreviews` will be empty.
+  // Anonymous-only saves live in sessionStorage and cannot be read server-side
+  // — that is expected and noted in the card's empty-state copy.
+  const calcStateData = (
+    (calcStateRes.data as { state?: unknown } | null)?.state as
+      | Record<string, { data?: unknown }>
+      | null
+      | undefined
+  )?.[SCENARIO_PLANNER_CALC_KEY]?.data as
+    | ScenarioPlannerSnapshot
+    | null
+    | undefined;
+  const scenarioPreviews = assembleSavedScenarioPreviews(calcStateData?.scenarios);
 
   const summary = assembleDashboardSummary({
     holdings,
@@ -464,19 +602,8 @@ export default async function ProDashboardPage() {
           ctaLabel="View watchlist"
         />
 
-        {/* Saved comparisons */}
-        <SummaryCard
-          href="/account/saved"
-          icon={<ScenariosIcon />}
-          title="Saved comparisons"
-          value={
-            summary.savedScenariosCount === 0
-              ? "None saved"
-              : `${summary.savedScenariosCount} scenario${summary.savedScenariosCount === 1 ? "" : "s"}`
-          }
-          sub="Broker comparisons and calculator snapshots"
-          ctaLabel="View saved"
-        />
+        {/* Saved scenarios — inline previews with Resume deep-links */}
+        <SavedScenariosCard previews={scenarioPreviews} />
 
         {/* Pro deals */}
         <SummaryCard

--- a/app/scenarios/plan/ScenarioPlannerClient.tsx
+++ b/app/scenarios/plan/ScenarioPlannerClient.tsx
@@ -12,9 +12,14 @@
  * AFSL compliance: all outputs are factual projections with
  * GENERAL_ADVICE_WARNING displayed prominently. No personalised
  * recommendations are produced.
+ *
+ * Deep-link: when `initialScenarioParam` is provided (e.g. from
+ * `/scenarios/plan?scenario=0` or `?scenario=My+Scenario`) the component
+ * resolves the matching saved scenario and loads it into the form on mount,
+ * immediately after the persistence layer has hydrated.
  */
 
-import { useState, useMemo, useCallback } from "react";
+import React, { useState, useMemo, useCallback, useEffect } from "react";
 import Link from "next/link";
 import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
 import { formatCurrency } from "@/lib/utils";
@@ -28,6 +33,7 @@ import {
   type ScenarioPlannerSnapshot,
 } from "@/lib/scenario-engine";
 import { computeScenarioDelta, type DeltaRow } from "@/lib/scenario-delta";
+import { resolveScenarioParam } from "@/lib/scenario-deep-link";
 
 // ─── nanoid-lite (no dependency needed) ──────────────────────────────────────
 function nanoid(): string {
@@ -573,7 +579,17 @@ function ComparePanel({
 
 // ─── Main component ───────────────────────────────────────────────────────────
 
-export default function ScenarioPlannerClient() {
+export default function ScenarioPlannerClient({
+  initialScenarioParam,
+}: {
+  /**
+   * Raw value of the `?scenario=` query param (e.g. "0", "1", "My Scenario").
+   * Passed from the server page component so the client can resolve it after
+   * hydration without reading `window.location` directly.
+   * Undefined / null → no deep-link load.
+   */
+  initialScenarioParam?: string | null;
+}) {
   // ── Inputs ──────────────────────────────────────────────────────────────────
   const [currentAge, setCurrentAge] = useState(DEFAULT_INPUTS.currentAge);
   const [retirementAge, setRetirementAge] = useState(
@@ -628,6 +644,7 @@ export default function ScenarioPlannerClient() {
   const {
     value: persisted,
     setValue: setPersisted,
+    isHydrated,
   } = useCalculatorState<{ scenarios: ScenarioPlannerSnapshot["scenarios"] }>(
     SCENARIO_PLANNER_CALC_KEY,
     { scenarios: [] },
@@ -740,6 +757,26 @@ export default function ScenarioPlannerClient() {
     },
     [persisted.scenarios, setPersisted],
   );
+
+  // ── Deep-link: auto-load a scenario from the ?scenario= param ───────────────
+  //
+  // We wait for `isHydrated` so the saved scenarios are available. We only
+  // fire once (the effect is idempotent once `hasDeepLinkedRef.current` is set)
+  // to avoid fighting the user if they subsequently switch scenarios manually.
+  const hasDeepLinkedRef = React.useRef(false);
+  useEffect(() => {
+    if (
+      !initialScenarioParam ||
+      !isHydrated ||
+      hasDeepLinkedRef.current
+    ) return;
+
+    const idx = resolveScenarioParam(initialScenarioParam, persisted.scenarios);
+    if (idx !== -1) {
+      hasDeepLinkedRef.current = true;
+      handleLoad(idx);
+    }
+  }, [initialScenarioParam, isHydrated, persisted.scenarios, handleLoad]);
 
   // ── Compute saved-scenario results for compare ───────────────────────────────
   const savedResults = useMemo(

--- a/app/scenarios/plan/ScenarioPlannerClient.tsx
+++ b/app/scenarios/plan/ScenarioPlannerClient.tsx
@@ -774,6 +774,7 @@ export default function ScenarioPlannerClient({
     const idx = resolveScenarioParam(initialScenarioParam, persisted.scenarios);
     if (idx !== -1) {
       hasDeepLinkedRef.current = true;
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- one-shot deep-link load after hydration (guarded by hasDeepLinkedRef); depends on hydrated saved state, so it cannot run during render
       handleLoad(idx);
     }
   }, [initialScenarioParam, isHydrated, persisted.scenarios, handleLoad]);

--- a/app/scenarios/plan/page.tsx
+++ b/app/scenarios/plan/page.tsx
@@ -22,12 +22,24 @@ export const metadata: Metadata = {
   robots: "index, follow",
 };
 
-export default async function ScenarioPlannerPage() {
+export default async function ScenarioPlannerPage({
+  searchParams,
+}: {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+}) {
   const bcLd = breadcrumbJsonLd([
     { name: "Home", url: absoluteUrl("/") },
     { name: "Scenarios", url: absoluteUrl("/scenarios") },
     { name: "Scenario Planner" },
   ]);
+
+  // Resolve the `?scenario=` param so the client component can deep-link
+  // into a saved scenario after hydration. We accept both numeric index and
+  // human-readable label (matching is done client-side in resolveScenarioParam).
+  const resolved = searchParams ? await searchParams : {};
+  const scenarioParam = typeof resolved["scenario"] === "string"
+    ? resolved["scenario"]
+    : null;
 
   return (
     <>
@@ -35,7 +47,7 @@ export default async function ScenarioPlannerPage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(bcLd) }}
       />
-      <ScenarioPlannerClient />
+      <ScenarioPlannerClient initialScenarioParam={scenarioParam} />
     </>
   );
 }

--- a/lib/scenario-deep-link.ts
+++ b/lib/scenario-deep-link.ts
@@ -1,0 +1,92 @@
+/**
+ * Scenario deep-link helpers — pure utilities for the ?scenario= URL param
+ * that lets the Pro dashboard link directly into a saved scenario.
+ *
+ * Keeping these separate from ScenarioPlannerClient gives us:
+ *   - Pure functions that are trivially unit-testable without React.
+ *   - A single import point for dashboard preview assembly.
+ *
+ * No I/O, no React, no Next.js — intentionally portable.
+ */
+
+import type { ScenarioPlannerSnapshot } from "@/lib/scenario-engine";
+
+export type SavedScenarioRow = ScenarioPlannerSnapshot["scenarios"][number];
+
+// ─── Deep-link param parsing ───────────────────────────────────────────────────
+
+/**
+ * Given the raw `?scenario=` query-param value and the list of saved scenarios,
+ * return the 0-based index of the matching scenario, or -1 if none matches.
+ *
+ * Matching strategy (in priority order):
+ *   1. Numeric string → treat as 0-based index (e.g. "0", "1", "2").
+ *   2. Non-numeric string → case-insensitive match against `scenario.label`.
+ *
+ * The numeric-first approach means callers may encode either the positional
+ * index (stable for the current session) or the human label (stable across
+ * reorders). Both work.
+ */
+export function resolveScenarioParam(
+  param: string | null | undefined,
+  scenarios: readonly SavedScenarioRow[],
+): number {
+  if (!param || scenarios.length === 0) return -1;
+
+  const trimmed = param.trim();
+
+  // Numeric index path
+  if (/^\d+$/.test(trimmed)) {
+    const idx = parseInt(trimmed, 10);
+    return idx >= 0 && idx < scenarios.length ? idx : -1;
+  }
+
+  // Label match (case-insensitive, trim)
+  const lower = trimmed.toLowerCase();
+  const found = scenarios.findIndex((s) => s.label.trim().toLowerCase() === lower);
+  return found;
+}
+
+// ─── Dashboard preview assembly ───────────────────────────────────────────────
+
+export interface ScenarioPreview {
+  /** Scenario label (user-given name). */
+  label: string;
+  /** Projected super at retirement, formatted for display. */
+  projectedSuper: number;
+  /** Whether the scenario is on track per the 4% rule. */
+  isOnTrack: boolean;
+  /** Gap to the 4% rule target (positive = deficit, negative = surplus). */
+  gapToTarget: number;
+  /** Number of drawdown years projected. */
+  drawdownYears: number;
+  /**
+   * Deep-link href. Uses numeric index so it is stable regardless of label
+   * changes (label is mutable; position in the array is stable for the session).
+   */
+  resumeHref: string;
+}
+
+/**
+ * Build an array of `ScenarioPreview` objects for the dashboard card.
+ *
+ * Pure function — takes the raw `scenarios` array from the persisted snapshot
+ * and returns typed preview objects with pre-formatted metrics + deep-link hrefs.
+ *
+ * Returns an empty array when `scenarios` is undefined/null so the dashboard
+ * can handle the empty state without extra null guards.
+ */
+export function assembleSavedScenarioPreviews(
+  scenarios: readonly SavedScenarioRow[] | undefined | null,
+): ScenarioPreview[] {
+  if (!scenarios || scenarios.length === 0) return [];
+
+  return scenarios.map((s, idx): ScenarioPreview => ({
+    label: s.label,
+    projectedSuper: s.summary.projectedSuperAtRetirement,
+    isOnTrack: s.summary.isOnTrack,
+    gapToTarget: s.summary.gapToTarget,
+    drawdownYears: s.summary.drawdownYears,
+    resumeHref: `/scenarios/plan?scenario=${idx}`,
+  }));
+}


### PR DESCRIPTION
Round-4 deepening (9 of 10). Connects saved scenarios to the Investor Pro dashboard so members can **preview + resume** them — retention for the most-trafficked planning tool. Factual (the user's own data; AFSL-safe).

- `lib/scenario-deep-link.ts` — pure, tested: `resolveScenarioParam(param, scenarios)` (maps `?scenario=<index-or-label>` → array index; numeric-by-index, else case-insensitive label match) + `assembleSavedScenarioPreviews(scenarios)` (label + key metrics + resume href).
- `/scenarios/plan` reads `?scenario=` and loads that saved scenario on mount (once, after `useCalculatorState` hydration, guarded by a ref so it never fights manual selection).
- `/pro/dashboard` saved-scenarios card now shows **inline previews** (name + projected super / on-track / drawdown years) with **"Resume"** deep-links; graceful empty state. Reuses the existing `user_calculator_state` persistence — no new store.

**Fix on verification:** scoped the `set-state-in-effect` lint on the one-shot deep-link loader (it must run post-hydration; ref-guarded).

**Verified:** `tsc` clean · **23 tests** (param resolution: index/label/whitespace/out-of-range/null + preview assembly incl. round-trip) pass · eslint clean. Tier A (page UI + tests; no schema/auth). Note: anon-only (sessionStorage) scenarios can't render server-side — expected; empty-state copy notes it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUfSRE2Teb6VhEXFP6RpS9)_